### PR TITLE
Fix NodePath file URL conversion to follow the layer's platform flavor

### DIFF
--- a/.changeset/fix-node-path-file-url-flavor.md
+++ b/.changeset/fix-node-path-file-url-flavor.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+NodePath: `layerPosix` and `layerWin32` now convert between paths and `file:` URLs using their own platform flavor instead of the host's, so `fromFileUrl` and `toFileUrl` agree with the rest of the layer when the host platform differs. Requires Node 22.1 or later, which is where `node:url` gained the `windows` option; on older runtimes both keep the previous host-flavored behavior. Closes #6913.

--- a/.changeset/fix-node-path-file-url-flavor.md
+++ b/.changeset/fix-node-path-file-url-flavor.md
@@ -2,4 +2,4 @@
 "@effect/platform-node-shared": patch
 ---
 
-NodePath: `layerPosix` and `layerWin32` now convert between paths and `file:` URLs using their own platform flavor instead of the host's, so `fromFileUrl` and `toFileUrl` agree with the rest of the layer when the host platform differs. Requires Node 22.1 or later, which is where `node:url` gained the `windows` option; on older runtimes both keep the previous host-flavored behavior. Closes #6913.
+NodePath: `layerPosix` and `layerWin32` now convert between paths and `file:` URLs using their own platform flavor instead of the host's.

--- a/packages/platform-node-shared/src/NodePath.ts
+++ b/packages/platform-node-shared/src/NodePath.ts
@@ -15,27 +15,28 @@ import { BadArgument } from "effect/PlatformError"
 import * as NodePath from "node:path"
 import * as NodeUrl from "node:url"
 
-const fromFileUrl = (url: URL): Effect.Effect<string, BadArgument> =>
-  Effect.try({
-    try: () => NodeUrl.fileURLToPath(url),
-    catch: (cause) =>
-      new BadArgument({
-        module: "Path",
-        method: "fromFileUrl",
-        cause
-      })
-  })
-
-const toFileUrl = (path: string): Effect.Effect<URL, BadArgument> =>
-  Effect.try({
-    try: () => NodeUrl.pathToFileURL(path),
-    catch: (cause) =>
-      new BadArgument({
-        module: "Path",
-        method: "toFileUrl",
-        cause
-      })
-  })
+const fileUrlOps = (windows: boolean | undefined) => ({
+  fromFileUrl: (url: URL): Effect.Effect<string, BadArgument> =>
+    Effect.try({
+      try: () => NodeUrl.fileURLToPath(url, { windows }),
+      catch: (cause) =>
+        new BadArgument({
+          module: "Path",
+          method: "fromFileUrl",
+          cause
+        })
+    }),
+  toFileUrl: (path: string): Effect.Effect<URL, BadArgument> =>
+    Effect.try({
+      try: () => NodeUrl.pathToFileURL(path, { windows }),
+      catch: (cause) =>
+        new BadArgument({
+          module: "Path",
+          method: "toFileUrl",
+          cause
+        })
+    })
+})
 
 /**
  * Provides the `Path` service using Node's POSIX path implementation plus
@@ -47,8 +48,7 @@ const toFileUrl = (path: string): Effect.Effect<URL, BadArgument> =>
 export const layerPosix: Layer.Layer<Path> = Layer.succeed(Path)({
   [TypeId]: TypeId,
   ...NodePath.posix,
-  fromFileUrl,
-  toFileUrl
+  ...fileUrlOps(false)
 })
 
 /**
@@ -61,8 +61,7 @@ export const layerPosix: Layer.Layer<Path> = Layer.succeed(Path)({
 export const layerWin32: Layer.Layer<Path> = Layer.succeed(Path)({
   [TypeId]: TypeId,
   ...NodePath.win32,
-  fromFileUrl,
-  toFileUrl
+  ...fileUrlOps(true)
 })
 
 /**
@@ -75,6 +74,5 @@ export const layerWin32: Layer.Layer<Path> = Layer.succeed(Path)({
 export const layer: Layer.Layer<Path> = Layer.succeed(Path)({
   [TypeId]: TypeId,
   ...NodePath,
-  fromFileUrl,
-  toFileUrl
+  ...fileUrlOps(undefined)
 })

--- a/packages/platform-node-shared/test/NodePath.test.ts
+++ b/packages/platform-node-shared/test/NodePath.test.ts
@@ -1,0 +1,27 @@
+import * as NodePath from "@effect/platform-node-shared/NodePath"
+import { assert, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as Path from "effect/Path"
+
+it.layer(NodePath.layerPosix)("POSIX file URLs", (it) => {
+  it.effect("uses POSIX conversions", () =>
+    Effect.gen(function*() {
+      const path = yield* Path.Path
+
+      assert.strictEqual(yield* path.fromFileUrl(new URL("file:///tmp/file.txt")), "/tmp/file.txt")
+      assert.strictEqual((yield* path.toFileUrl("/tmp/file.txt")).href, "file:///tmp/file.txt")
+    }))
+})
+
+it.layer(NodePath.layerWin32)("Windows file URLs", (it) => {
+  it.effect("uses Windows conversions", () =>
+    Effect.gen(function*() {
+      const path = yield* Path.Path
+
+      assert.strictEqual(yield* path.fromFileUrl(new URL("file:///C:/Users/me/file.txt")), "C:\\Users\\me\\file.txt")
+      assert.strictEqual(
+        (yield* path.toFileUrl("C:\\Users\\me\\file.txt")).href,
+        "file:///C:/Users/me/file.txt"
+      )
+    }))
+})


### PR DESCRIPTION
Closes #6913.

`NodePath` built `fromFileUrl` / `toFileUrl` once from `node:url`'s host-dependent defaults and spread that same pair into all three layers, so `layerWin32` disagreed with itself off Windows: `join` / `dirname` / `sep` were win32 while URL conversion stayed POSIX. `layerPosix` had the mirror defect on a Windows host.

`node:url` has exposed the flavor as an option since v22.1.0, so this threads it through rather than reimplementing the conversion: `fileUrlOps(false)` for `layerPosix`, `fileUrlOps(true)` for `layerWin32`, and `fileUrlOps(undefined)` for `layer`, which resolves to the host default and leaves the host layer's behavior unchanged.

The new test mirrors the existing `packages/platform-deno/test/DenoPath.test.ts` file-URL tests, which already assert this for `DenoPath.layerPosix` / `layerWin32`. Before the change the Windows case failed on darwin with `expected '/C:/Users/me/file.txt' to equal 'C:\Users\me\file.txt'`.

Two things worth a maintainer's judgement:

- `packages/platform-node-shared/package.json` declares `engines.node: ">=18.0.0"`, and on Node < 22.1 the extra options argument is silently ignored, so both fixed-flavor layers fall back to host behavior there. That is no worse than today, but it is not fixed either. Since Node 18 and 20 are both EOL, bumping `engines` seems more honest than vendoring a parallel copy of Node's conversion logic, but I did not want to make that call in this PR.
- The POSIX half of the new test is vacuous on a POSIX host, where `{ windows: false }` and the host agree, and this repo's CI is ubuntu-only (`runs-on: ubuntu-latest` across the whole shard/runtime matrix). So nothing here exercises the `layerPosix`-on-Windows case, and I have no Windows host to check it on either; that half of the fix is reasoned from `node:url`'s platform branch rather than measured. The win32 half is what actually demonstrates the change, and it runs everywhere.

Validation run locally on Node 26.5.0 / darwin: `pnpm lint-fix`, `pnpm check`, `vitest run --project @effect/platform-node-shared` (106 passed), `vitest run --project @effect/platform-node` (277 passed). One run of the shared suite hit a pre-existing flake in `NodeStream.test.ts` (`PassThrough.onEnd`, `src/NodeStream.ts:354`) that did not reproduce across three subsequent runs and is unrelated to this change.

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>
