### PR TITLE
Update pnpm/action-setup and upload-artifact to their Node 24 releases

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -12,7 +12,7 @@ runs:
   using: composite
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
     - name: Install node
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -100,7 +100,7 @@ jobs:
         run: node ./packages/tools/bundle/src/bin.ts compare --base-dir base/packages/tools/bundle/fixtures
       - name: Upload stats artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bundle-stats
           path: stats.txt


### PR DESCRIPTION
Closes #6915.

Every workflow run currently carries `Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/upload-artifact@v4, pnpm/action-setup@v4`.

The annotation keys off the `runs.using` value each action declares in its own `action.yml`, not off the Node version the runner ends up using — the runner log alongside it already says "This workflow is running with Node 24 by default". So `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` does not help; that variable was the opt-in from before the runner default flipped. Bumping the two actions is what clears it.

- `pnpm/action-setup@v4` -> `v6`. v5.0.0 moved it to node24 and v6.0.0 added pnpm v11 support; neither changed the input surface. It is invoked here with no inputs and resolves the version from `packageManager` in the root `package.json`.
- `actions/upload-artifact@v4` -> `v6`. v6.0.0 is the first node24 release — v5 is still node20, so a bump to v5 would not have cleared the warning. The `name`, `path` and `if-no-files-found` inputs used here are unchanged. v6 requires Actions Runner >= 2.327.1; the deprecation notice cites hosted runners at v2.328.0 and every job here is `runs-on: ubuntu-latest`. The `actions/download-artifact@v8` consumer in `bundle-comment.yml` is unaffected.

Every other action in `.github/` already declares node24: `actions/checkout@v6`, `actions/setup-node@v6`, `actions/download-artifact@v8`, `changesets/action@v1`, `denoland/setup-deno@v2`, `oven-sh/setup-bun@v2`, the three `peter-evans/*` actions, and `pullfrog/pullfrog@v0`.

No changeset: this touches CI configuration only, with no runtime or exported API change.

The verification for this is CI itself — the annotation should be absent from this PR's run. I could not check the `upload-artifact` path locally, and it only executes on `pull_request` events, so this PR's Bundle job is the first real exercise of it.

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>
