### PR TITLE
Ignore `uniqueItems` when set to `false` while importing JSON Schema documents

### DIFF
--- a/.changeset/fix-json-schema-unique-items-false.md
+++ b/.changeset/fix-json-schema-unique-items-false.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Ignore `uniqueItems` when set to `false` while importing JSON Schema documents.

--- a/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts
+++ b/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts
@@ -814,7 +814,7 @@ function translateJsonSchemaMultiDocument(
       addNumberCheck(checks, schema.minItems, "effect/schema/isMinLength", "minLength")
       addNumberCheck(checks, schema.maxItems, "effect/schema/isMaxLength", "maxLength")
     }
-    if (typeof schema.uniqueItems === "boolean") {
+    if (schema.uniqueItems === true) {
       checks.push(jsonSchemaFilter("effect/schema/isUnique", null))
     }
     return checks

--- a/packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts
+++ b/packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts
@@ -1737,6 +1737,14 @@ describe("fromJsonSchemaDocument", () => {
           }
         )
       })
+
+      it("does not require uniqueness when uniqueItems is false", () => {
+        const schema = toSchemaFromJsonSchemaDocument(
+          JsonSchema.fromSchemaDraft2020_12({ type: "array", uniqueItems: false })
+        )
+
+        assertTrue(Schema.is(schema)(["a", "a"]))
+      })
     })
   })
 


### PR DESCRIPTION
## Summary

Importing a JSON Schema array with uniqueItems set to false rejects duplicate elements.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## uniqueItems false enables uniqueness

**Module:** `SchemaRepresentation`  
**Audit ID:** `core-s-z-testing-schema-representation-unique-items-false`  
**Severity / confidence:** medium / high

### What happens

Importing a JSON Schema array with uniqueItems set to false rejects duplicate elements.

### Why it happens

collectArrayChecks adds the effect/schema/isUnique filter for either boolean value, so the importer strengthens a valid external schema and rejects values it must accept.

### Expected behavior

JSON Schema Draft 2020-12 uniqueItems: false imposes no uniqueness constraint.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/internal/schema/fromJsonSchemaDocument.ts:811-820`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts#L811-L820)

<details>
<summary>View problematic code at <code>packages/effect/src/internal/schema/fromJsonSchemaDocument.ts:811-820</code></summary>

```ts
  function collectArrayChecks(schema: JsonSchema.JsonSchema): Array<Check> {
    const checks: Array<Check> = []
    if (schema.prefixItems === undefined) {
      addNumberCheck(checks, schema.minItems, "effect/schema/isMinLength", "minLength")
      addNumberCheck(checks, schema.maxItems, "effect/schema/isMaxLength", "maxLength")
    }
    if (typeof schema.uniqueItems === "boolean") {
      checks.push(jsonSchemaFilter("effect/schema/isUnique", null))
    }
    return checks
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts#L811-L820)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts -t "does not require uniqueness when uniqueItems is false"
```

**Observed failure:** validity false instead of true

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts -t "does not require uniqueness when uniqueItems is false"
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `core-s-z-testing-schema-representation-unique-items-false`
- Initial patch: focused reproduction tests; implementation fix pending