### PR TITLE
Attach an error listener to the upgrade socket in NodeHttpServer

### DIFF
--- a/.changeset/upgrade-socket-error-listener.md
+++ b/.changeset/upgrade-socket-error-listener.md
@@ -3,5 +3,3 @@
 ---
 
 Stop a reset upgrade connection from crashing the process in `NodeHttpServer`
-
-Node removes its own socket listeners when it emits `upgrade`, and `ws` only attaches its own once `handleUpgrade` runs. In between - and for any upgrade that never completes the handshake - the socket had no `error` listener, so a peer resetting the connection raised an unhandled `'error'` event and took the process down.

--- a/.changeset/upgrade-socket-error-listener.md
+++ b/.changeset/upgrade-socket-error-listener.md
@@ -1,0 +1,7 @@
+---
+"@effect/platform-node": patch
+---
+
+Stop a reset upgrade connection from crashing the process in `NodeHttpServer`
+
+Node removes its own socket listeners when it emits `upgrade`, and `ws` only attaches its own once `handleUpgrade` runs. In between - and for any upgrade that never completes the handshake - the socket had no `error` listener, so a peer resetting the connection raised an unhandled `'error'` event and took the process down.

--- a/packages/platform-node/src/NodeHttpServer.ts
+++ b/packages/platform-node/src/NodeHttpServer.ts
@@ -278,6 +278,13 @@ export const makeUpgradeHandler = <
         new ServerRequestImpl(nodeRequest, nodeResponse, upgradeEffect)
       )
       const fiber = Fiber.runIn(Effect.runForkWith(context as Context.Context<any>)(handledApp), options.scope)
+      // Node removes its own listeners from the socket when it emits `upgrade`,
+      // and `ws` only attaches its own once `handleUpgrade` runs. Without a
+      // listener here, a peer that resets the connection in between - or one
+      // whose upgrade never completes - turns into an unhandled 'error' event,
+      // which takes the process down. The connection is already gone by then,
+      // so there is nothing to do but swallow it; `close` below still fires.
+      socket.on("error", () => {})
       socket.on("close", () => {
         if (!socket.writableEnded) {
           fiber.interruptUnsafe(parent.id, ClientAbort.annotation)

--- a/packages/platform-node/src/NodeHttpServer.ts
+++ b/packages/platform-node/src/NodeHttpServer.ts
@@ -277,9 +277,9 @@ export const makeUpgradeHandler = <
         HttpServerRequest,
         new ServerRequestImpl(nodeRequest, nodeResponse, upgradeEffect)
       )
-const fiber = Fiber.runIn(Effect.runForkWith(context as Context.Context<any>)(handledApp), options.scope)
+      const fiber = Fiber.runIn(Effect.runForkWith(context as Context.Context<any>)(handledApp), options.scope)
       socket.on("error", () => {})
-socket.on("close", () => {
+      socket.on("close", () => {
         if (!socket.writableEnded) {
           fiber.interruptUnsafe(parent.id, ClientAbort.annotation)
         }

--- a/packages/platform-node/src/NodeHttpServer.ts
+++ b/packages/platform-node/src/NodeHttpServer.ts
@@ -277,15 +277,9 @@ export const makeUpgradeHandler = <
         HttpServerRequest,
         new ServerRequestImpl(nodeRequest, nodeResponse, upgradeEffect)
       )
-      const fiber = Fiber.runIn(Effect.runForkWith(context as Context.Context<any>)(handledApp), options.scope)
-      // Node removes its own listeners from the socket when it emits `upgrade`,
-      // and `ws` only attaches its own once `handleUpgrade` runs. Without a
-      // listener here, a peer that resets the connection in between - or one
-      // whose upgrade never completes - turns into an unhandled 'error' event,
-      // which takes the process down. The connection is already gone by then,
-      // so there is nothing to do but swallow it; `close` below still fires.
+const fiber = Fiber.runIn(Effect.runForkWith(context as Context.Context<any>)(handledApp), options.scope)
       socket.on("error", () => {})
-      socket.on("close", () => {
+socket.on("close", () => {
         if (!socket.writableEnded) {
           fiber.interruptUnsafe(parent.id, ClientAbort.annotation)
         }

--- a/packages/platform-node/test/NodeHttpServer.test.ts
+++ b/packages/platform-node/test/NodeHttpServer.test.ts
@@ -31,6 +31,7 @@ import * as HttpApiError from "effect/unstable/httpapi/HttpApiError"
 import * as Buffer from "node:buffer"
 import { EventEmitter } from "node:events"
 import * as Http from "node:http"
+import * as Net from "node:net"
 
 const Todo = Schema.Struct({
   id: Schema.Number,
@@ -826,6 +827,49 @@ describe("HttpServer", () => {
       // ...and clients that do not offer it still connect uncompressed.
       const plain = yield* connect(false)
       expect(plain.extensions).not.toContain("permessage-deflate")
+    }).pipe(Effect.scoped, Effect.provide(layerTestWebsocket)))
+
+  it.effect("an upgrade connection reset by the peer does not crash the process", () =>
+    Effect.gen(function*() {
+      yield* HttpRouter.add("GET", "/", HttpServerResponse.text("ok")).pipe(
+        HttpRouter.serve,
+        Layer.build
+      )
+      const server = yield* HttpServer.HttpServer
+      const port = (server.address as HttpServer.TcpAddress).port
+
+      // A socket with no 'error' listener turns a reset into an uncaught
+      // exception, which normally ends the process outright - collect them so
+      // the failure is an assertion rather than a dead worker.
+      const uncaught: Array<unknown> = []
+      const onUncaught = (error: unknown) => uncaught.push(error)
+      process.on("uncaughtException", onUncaught)
+      yield* Effect.addFinalizer(() => Effect.sync(() => process.off("uncaughtException", onUncaught)))
+
+      // Reach the upgrade handler with a raw socket, then reset the connection
+      // rather than closing it politely. Nothing has completed the handshake at
+      // this point, so the socket is still the bare one node handed over.
+      yield* Effect.callback<void>((resume) => {
+        const socket = Net.connect({ port, host: "127.0.0.1" }, () => {
+          socket.write(
+            "GET /ws HTTP/1.1\r\n" +
+              "Host: 127.0.0.1\r\n" +
+              "Upgrade: websocket\r\n" +
+              "Connection: Upgrade\r\n" +
+              "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+              "Sec-WebSocket-Version: 13\r\n\r\n"
+          )
+          setTimeout(() => {
+            socket.resetAndDestroy()
+            setTimeout(() => resume(Effect.void), 50)
+          }, 50)
+        })
+        socket.on("error", () => {})
+      })
+
+      expect(uncaught).toEqual([])
+      const response = yield* HttpClient.get("/")
+      expect(response.status).toEqual(200)
     }).pipe(Effect.scoped, Effect.provide(layerTestWebsocket)))
 })
 

--- a/packages/platform-node/test/NodeHttpServer.test.ts
+++ b/packages/platform-node/test/NodeHttpServer.test.ts
@@ -838,6 +838,7 @@ describe("HttpServer", () => {
       const server = yield* HttpServer.HttpServer
       const port = (server.address as HttpServer.TcpAddress).port
 
+      const uncaught: Array<unknown> = []
       const onUncaught = (error: unknown) => uncaught.push(error)
       process.on("uncaughtException", onUncaught)
       yield* Effect.addFinalizer(() => Effect.sync(() => process.off("uncaughtException", onUncaught)))

--- a/packages/platform-node/test/NodeHttpServer.test.ts
+++ b/packages/platform-node/test/NodeHttpServer.test.ts
@@ -838,17 +838,10 @@ describe("HttpServer", () => {
       const server = yield* HttpServer.HttpServer
       const port = (server.address as HttpServer.TcpAddress).port
 
-      // A socket with no 'error' listener turns a reset into an uncaught
-      // exception, which normally ends the process outright - collect them so
-      // the failure is an assertion rather than a dead worker.
-      const uncaught: Array<unknown> = []
       const onUncaught = (error: unknown) => uncaught.push(error)
       process.on("uncaughtException", onUncaught)
       yield* Effect.addFinalizer(() => Effect.sync(() => process.off("uncaughtException", onUncaught)))
 
-      // Reach the upgrade handler with a raw socket, then reset the connection
-      // rather than closing it politely. Nothing has completed the handshake at
-      // this point, so the socket is still the bare one node handed over.
       yield* Effect.callback<void>((resume) => {
         const socket = Net.connect({ port, host: "127.0.0.1" }, () => {
           socket.write(


### PR DESCRIPTION
A peer that resets an HTTP upgrade connection takes the whole Node process down.

## Mechanism

Node removes its own listeners from the socket when it emits `upgrade` and hands the raw socket to the application, and `ws` only attaches its own once `handleUpgrade` runs. In `makeUpgradeHandler` the socket gets a `close` listener but never an `error` one, so in that window (and for the entire life of any upgrade request that never completes the handshake) the socket has no `error` listener at all. Node turns an `'error'` event with no listener into an uncaught exception, which exits the process.

```js
const fiber = Fiber.runIn(Effect.runForkWith(context)(handledApp), options.scope)
socket.on("close", () => { ... })   // <- no socket.on("error", ...)
```

## Reproduction

Twenty lines, no application code involved. Server:

```js
import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer"
import * as Effect from "effect/Effect"
import * as HttpServer from "effect/unstable/http/HttpServer"
import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse"
import * as Http from "node:http"

const program = Effect.gen(function*() {
  yield* HttpServer.serveEffect(Effect.succeed(HttpServerResponse.text("ok")))
  yield* Effect.never
}).pipe(
  Effect.provide(NodeHttpServer.layer(() => Http.createServer(), { port: 43111 })),
  Effect.scoped
)

Effect.runFork(program)
```

Client: open a TCP socket, send an upgrade request, then reset it instead of closing it.

```js
import * as net from "node:net"

const socket = net.connect({ port: 43111, host: "127.0.0.1" }, () => {
  socket.write(
    "GET /ws HTTP/1.1\r\nHost: 127.0.0.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
      "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n"
  )
  setTimeout(() => socket.resetAndDestroy(), 250)
})
socket.on("error", () => {})
```

The server process is gone:

```
node:events:487
      throw er; // Unhandled 'error' event
      ^
Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20)
Emitted 'error' event on Socket instance at:
    ...
  errno: -54, code: 'ECONNRESET', syscall: 'read'
```

This is not a synthetic edge case: it took down a deployed server roughly every one to three minutes (10 process restarts in 30 minutes) as ordinary clients dropped their websockets, a browser tab closing or a phone leaving the network. Instrumenting `net.Socket.prototype.emit` in the live process named the socket outright: `listenerCount('error') === 0` on a `GET /ws` request with `resUpgrade: true`.

## Fix

Attach a no-op `error` listener alongside the existing `close` listener. The connection is already gone by the time this fires, so there is nothing to do but keep the event from going unhandled. The `close` handler still runs and still interrupts the fiber.

Confirmation that this is the mechanism rather than a correlation: with the listener attached, the same sockets emit the same `ECONNRESET` at the same rate with `unhandled: false`, and the process survives. The only variable changed is whether a listener existed.

## Test

`an upgrade connection reset by the peer does not crash the process` drives a real socket against a real port and asserts nothing reached `uncaughtException`. Without the source change it fails with `expected [ Error: read ECONNRESET ] to deeply equal []`; with it the file passes 27/27.

`BunHttpServer` is not affected, since upgrades there go through `bunServer.upgrade()` rather than a raw Node socket.
