### PR TITLE
Use local server in NodeHttpClient tests

### DIFF
--- a/packages/platform-node/test/NodeHttpClient.test.ts
+++ b/packages/platform-node/test/NodeHttpClient.test.ts
@@ -28,7 +28,7 @@ const TodoWithoutId = Schema.Struct({
   ...Struct.omit(Todo.fields, ["id"])
 })
 
-const makeJsonPlaceholder = Effect.gen(function*() {
+const makeLocalServerClient = Effect.gen(function*() {
   const client = yield* HttpClient.HttpClient
   const createTodo = (todo: typeof TodoWithoutId.Type) =>
     HttpClientRequest.post("/todos").pipe(
@@ -41,32 +41,30 @@ const makeJsonPlaceholder = Effect.gen(function*() {
     createTodo
   } as const
 })
-interface JsonPlaceholder extends Effect.Success<typeof makeJsonPlaceholder> {}
-const JsonPlaceholder = Context.Service<JsonPlaceholder>("test/JsonPlaceholder")
-const JsonPlaceholderLive = Layer.effect(JsonPlaceholder)(makeJsonPlaceholder)
-const JsonPlaceholderRoutes = HttpRouter.serve(HttpRouter.use(Effect.fnUntraced(function*(router) {
-  yield* router.addAll([
-    HttpRouter.route(
-      "GET",
-      "/todos/1",
-      Effect.succeed(HttpServerResponse.jsonUnsafe({
-        userId: 1,
-        id: 1,
-        title: "test",
-        completed: false
-      }))
-    ),
-    HttpRouter.route(
-      "POST",
-      "/todos",
-      Effect.gen(function*() {
-        const todo = yield* HttpServerRequest.schemaBodyJson(TodoWithoutId)
-        return HttpServerResponse.jsonUnsafe({ ...todo, id: 201 })
-      })
-    ),
-    HttpRouter.route("HEAD", "/todos", Effect.succeed(HttpServerResponse.empty({ status: 200 })))
-  ])
-})))
+interface LocalServerClient extends Effect.Success<typeof makeLocalServerClient> {}
+const LocalServerClient = Context.Service<LocalServerClient>("test/LocalServerClient")
+const LocalServerClientLive = Layer.effect(LocalServerClient)(makeLocalServerClient)
+const LocalServerRoutes = HttpRouter.serve(HttpRouter.addAll([
+  HttpRouter.route(
+    "GET",
+    "/todos/1",
+    Effect.succeed(HttpServerResponse.jsonUnsafe({
+      userId: 1,
+      id: 1,
+      title: "test",
+      completed: false
+    }))
+  ),
+  HttpRouter.route(
+    "POST",
+    "/todos",
+    Effect.gen(function*() {
+      const todo = yield* HttpServerRequest.schemaBodyJson(TodoWithoutId)
+      return HttpServerResponse.jsonUnsafe({ ...todo, id: 201 })
+    })
+  ),
+  HttpRouter.route("HEAD", "/todos", Effect.succeed(HttpServerResponse.empty({ status: 200 })))
+]))
 ;[
   {
     name: "fetch",
@@ -85,7 +83,7 @@ const JsonPlaceholderRoutes = HttpRouter.serve(HttpRouter.use(Effect.fnUntraced(
     Layer.provide(layer),
     Layer.provideMerge(NodeHttpServer.layer(Http.createServer, { port: 0 }))
   )
-  const jsonPlaceholderTestLayer = Layer.merge(JsonPlaceholderLive, JsonPlaceholderRoutes).pipe(
+  const localServerTestLayer = Layer.merge(LocalServerClientLive, LocalServerRoutes).pipe(
     Layer.provideMerge(layerTest)
   )
 
@@ -125,28 +123,28 @@ const JsonPlaceholderRoutes = HttpRouter.serve(HttpRouter.use(Effect.fnUntraced(
         }).pipe(Effect.provide(layer))
       ))
 
-    it.effect("jsonplaceholder", () =>
+    it.effect("local server", () =>
       Effect.gen(function*() {
-        const jp = yield* JsonPlaceholder
-        const response = yield* jp.client.get("/todos/1").pipe(
+        const local = yield* LocalServerClient
+        const response = yield* local.client.get("/todos/1").pipe(
           Effect.flatMap(HttpClientResponse.schemaBodyJson(Todo))
         )
         expect(response.id).toBe(1)
       }).pipe(
-        Effect.provide(jsonPlaceholderTestLayer)
+        Effect.provide(localServerTestLayer)
       ))
 
-    it.effect("jsonplaceholder schemaBodyJson", () =>
+    it.effect("local server schemaBodyJson", () =>
       Effect.gen(function*() {
-        const jp = yield* JsonPlaceholder
-        const response = yield* jp.createTodo({
+        const local = yield* LocalServerClient
+        const response = yield* local.createTodo({
           userId: 1,
           title: "test",
           completed: false
         })
         expect(response.title).toBe("test")
       }).pipe(
-        Effect.provide(jsonPlaceholderTestLayer)
+        Effect.provide(localServerTestLayer)
       ))
 
     it.effect("head request with schemaJson", () =>
@@ -158,7 +156,7 @@ const JsonPlaceholderRoutes = HttpRouter.serve(HttpRouter.use(Effect.fnUntraced(
           )
         )
         expect(response).toEqual({ status: 200 })
-      }).pipe(Effect.provide(jsonPlaceholderTestLayer)))
+      }).pipe(Effect.provide(localServerTestLayer)))
 
     it.live("interrupt", () =>
       Effect.gen(function*() {

--- a/packages/platform-node/test/NodeHttpClient.test.ts
+++ b/packages/platform-node/test/NodeHttpClient.test.ts
@@ -1,3 +1,4 @@
+import { NodeHttpServer } from "@effect/platform-node"
 import * as NodeClient from "@effect/platform-node/NodeHttpClient"
 import { describe, expect, it } from "@effect/vitest"
 import { Struct } from "effect"
@@ -6,7 +7,16 @@ import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import * as Schema from "effect/Schema"
 import * as Stream from "effect/Stream"
-import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
+import {
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+  HttpRouter,
+  HttpServer,
+  HttpServerRequest,
+  HttpServerResponse
+} from "effect/unstable/http"
+import * as Http from "node:http"
 
 const Todo = Schema.Struct({
   userId: Schema.Number,
@@ -19,10 +29,7 @@ const TodoWithoutId = Schema.Struct({
 })
 
 const makeJsonPlaceholder = Effect.gen(function*() {
-  const defaultClient = yield* HttpClient.HttpClient
-  const client = defaultClient.pipe(
-    HttpClient.mapRequest(HttpClientRequest.prependUrl("https://jsonplaceholder.typicode.com"))
-  )
+  const client = yield* HttpClient.HttpClient
   const createTodo = (todo: typeof TodoWithoutId.Type) =>
     HttpClientRequest.post("/todos").pipe(
       HttpClientRequest.schemaBodyJson(TodoWithoutId)(todo),
@@ -37,6 +44,29 @@ const makeJsonPlaceholder = Effect.gen(function*() {
 interface JsonPlaceholder extends Effect.Success<typeof makeJsonPlaceholder> {}
 const JsonPlaceholder = Context.Service<JsonPlaceholder>("test/JsonPlaceholder")
 const JsonPlaceholderLive = Layer.effect(JsonPlaceholder)(makeJsonPlaceholder)
+const JsonPlaceholderRoutes = HttpRouter.serve(HttpRouter.use(Effect.fnUntraced(function*(router) {
+  yield* router.addAll([
+    HttpRouter.route(
+      "GET",
+      "/todos/1",
+      Effect.succeed(HttpServerResponse.jsonUnsafe({
+        userId: 1,
+        id: 1,
+        title: "test",
+        completed: false
+      }))
+    ),
+    HttpRouter.route(
+      "POST",
+      "/todos",
+      Effect.gen(function*() {
+        const todo = yield* HttpServerRequest.schemaBodyJson(TodoWithoutId)
+        return HttpServerResponse.jsonUnsafe({ ...todo, id: 201 })
+      })
+    ),
+    HttpRouter.route("HEAD", "/todos", Effect.succeed(HttpServerResponse.empty({ status: 200 })))
+  ])
+})))
 ;[
   {
     name: "fetch",
@@ -51,6 +81,14 @@ const JsonPlaceholderLive = Layer.effect(JsonPlaceholder)(makeJsonPlaceholder)
     layer: NodeClient.layerUndici
   }
 ].forEach(({ layer, name }) => {
+  const layerTest = HttpServer.layerTestClient.pipe(
+    Layer.provide(layer),
+    Layer.provideMerge(NodeHttpServer.layer(Http.createServer, { port: 0 }))
+  )
+  const jsonPlaceholderTestLayer = Layer.merge(JsonPlaceholderLive, JsonPlaceholderRoutes).pipe(
+    Layer.provideMerge(layerTest)
+  )
+
   describe(`NodeHttpClient - ${name}`, () => {
     it.effect("google", () =>
       Effect.gen(function*() {
@@ -95,10 +133,7 @@ const JsonPlaceholderLive = Layer.effect(JsonPlaceholder)(makeJsonPlaceholder)
         )
         expect(response.id).toBe(1)
       }).pipe(
-        Effect.provide(JsonPlaceholderLive.pipe(
-          Layer.provide(layer)
-        )),
-        flaky
+        Effect.provide(jsonPlaceholderTestLayer)
       ))
 
     it.effect("jsonplaceholder schemaBodyJson", () =>
@@ -111,22 +146,19 @@ const JsonPlaceholderLive = Layer.effect(JsonPlaceholder)(makeJsonPlaceholder)
         })
         expect(response.title).toBe("test")
       }).pipe(
-        Effect.provide(JsonPlaceholderLive.pipe(
-          Layer.provide(layer)
-        )),
-        flaky
+        Effect.provide(jsonPlaceholderTestLayer)
       ))
 
     it.effect("head request with schemaJson", () =>
       Effect.gen(function*() {
         const client = yield* HttpClient.HttpClient
-        const response = yield* client.head("https://jsonplaceholder.typicode.com/todos").pipe(
+        const response = yield* client.head("/todos").pipe(
           Effect.flatMap(
             HttpClientResponse.schemaJson(Schema.Struct({ status: Schema.Literal(200) }))
           )
         )
         expect(response).toEqual({ status: 200 })
-      }).pipe(Effect.provide(layer), flaky))
+      }).pipe(Effect.provide(jsonPlaceholderTestLayer)))
 
     it.live("interrupt", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Summary

- replace jsonplaceholder network calls with an ephemeral local Node HTTP server
- exercise the same GET, POST body-schema, and HEAD response paths across fetch, node:http, and undici
- remove flaky wrappers from the now-deterministic cases

## Root cause

The tests depended on jsonplaceholder.typicode.com, whose intermittent Cloudflare 5xx responses caused unrelated CI failures.

## Validation

- `pnpm test packages/platform-node/test/NodeHttpClient.test.ts --run` (24 passed)
- `pnpm --filter @effect/platform-node check`
- dprint and oxlint on the changed test file

Closes EFF-357