### PR TITLE
Fix OpenAI tool result test fixtures

### DIFF
--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -427,7 +427,8 @@ describe("OpenAiLanguageModel", () => {
                     id: "call_apply_patch",
                     name: "OpenAiApplyPatch",
                     isFailure: false,
-                    result: { status: "completed", output: "deleted" }
+                    result: { status: "completed", output: "deleted" },
+                    providerExecuted: false
                   })]
                 }
               ]),
@@ -477,7 +478,8 @@ describe("OpenAiLanguageModel", () => {
                         stderr: "",
                         outcome: { type: "exit", exit_code: 0 }
                       }]
-                    }
+                    },
+                    providerExecuted: false
                   })]
                 }
               ]),
@@ -521,7 +523,8 @@ describe("OpenAiLanguageModel", () => {
                     id: "call_local_shell",
                     name: "OpenAiLocalShell",
                     isFailure: false,
-                    result: { output: "hello\n" }
+                    result: { output: "hello\n" },
+                    providerExecuted: false
                   })]
                 }
               ]),


### PR DESCRIPTION
## Summary

- mark the apply-patch, shell, and local-shell result fixtures as locally executed
- restore compatibility with the required `ToolResultPart.providerExecuted` field

## Root cause

`providerExecuted` became required on `ToolResultPart`, but three OpenAI language-model test fixtures were not updated. This caused the main-branch type check to fail before the affected Node test shard could complete successfully.

## Validation

- `pnpm check`
- `pnpm test --shard 1/2` (176 files passed; 4,739 tests passed; 2 skipped)

Closes EFF-368