### PR TITLE
Stabilize blackholed query recovery test

### DIFF
--- a/packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts
+++ b/packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts
@@ -110,7 +110,7 @@ describe("SqlRunnerStorage", () => {
       yield* storage.acquire(runnerAddress1, shards)
       partitioned.current = true
       yield* storage.refresh(runnerAddress1, shards).pipe(Effect.exit, TestClock.withLive)
-      yield* Effect.sleep(150).pipe(TestClock.withLive)
+      yield* waitUntil(() => partitioned.activeQueries === 0)
 
       partitioned.current = false
       expect(


### PR DESCRIPTION
## Summary

- replace the fixed recovery delay with a wait for the timed-out blackholed query to actually exit
- keep the strict single-active-query assertion intact
- avoid starting the recovery query while detached interruption is still pending on a busy runner

## Root cause

The lock-operation deadline intentionally returns before waiting for detached interruption to finish. The test used a 150 ms sleep as a proxy for that cleanup, so a sufficiently delayed CI runner could start the recovery query while the original query was still counted as active.

## Verification

- focused blackholed-query recovery test: 8 consecutive post-fix runs
- complete SqlRunnerStorage integration file: 22 tests passed
- dprint check on the changed file
- oxlint on the changed file
- @effect/platform-node typecheck

Closes EFF-377