### PR TITLE
httpapi: WithHeaders response header schemas

### DIFF
--- a/.changeset/add-httpapi-with-headers.md
+++ b/.changeset/add-httpapi-with-headers.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+httpapi: add `HttpApiSchema.WithHeaders` for wrapping success schemas with a response headers schema, and `HttpApiSchema.encodeToWithHeaders` for folding response headers into domain types such as error classes.

--- a/.changeset/add-httpapi-with-headers.md
+++ b/.changeset/add-httpapi-with-headers.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-httpapi: add `HttpApiSchema.WithHeaders` for wrapping success schemas with a response headers schema, and `HttpApiSchema.encodeToWithHeaders` for folding response headers into domain types such as error classes.
+httpapi: add typed response headers across handlers, generated clients (including `HttpApiTest`), streaming responses, and OpenAPI with `HttpApiSchema.WithHeaders`. Add `HttpApiSchema.encodeToWithHeaders` for folding response headers into domain types such as error classes. Explicit `content-type` and `content-length` values applied with `HttpServerResponse.setHeader` or `setHeaders` now override body-derived values.

--- a/packages/effect/HTTPAPI.md
+++ b/packages/effect/HTTPAPI.md
@@ -1550,7 +1550,168 @@ The following encodings are supported:
 
 ## Setting Response Headers
 
-To add custom headers to the outgoing response, call `HttpEffect.appendPreResponseHandler` inside your handler. The callback receives the request and response objects and must return the updated response.
+Response headers can be declared in the endpoint's schemas, so they are type-checked on the server, rendered in the OpenAPI documentation, and decoded by the derived client. Two mechanisms are available:
+
+- `HttpApiSchema.WithHeaders(schema, headers)` wraps a response schema together with a headers schema. Handlers return the body and headers as a pair. Recommended for success responses, including streams.
+- `HttpApiSchema.encodeToWithHeaders` folds headers into an opaque domain type such as an error class, so handlers keep working with plain domain values.
+
+For headers that are not part of the API contract, `HttpEffect.appendPreResponseHandler` remains available as an untyped escape hatch.
+
+### Declaring Response Headers with WithHeaders
+
+Wrap the success schema with `HttpApiSchema.WithHeaders(schema, headers)`. The headers argument accepts a fields shorthand (as below) or any schema, mirroring the request-side `headers` option. The handler then returns a value built with `HttpApiSchema.withHeaders({ body, headers })`.
+
+**Example** (Declaring a Response Header on a Success Schema)
+
+```ts
+import { NodeHttpServer, NodeRuntime } from "@effect/platform-node"
+import { Effect, Layer, Schema } from "effect"
+import { HttpRouter } from "effect/unstable/http"
+import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup, HttpApiSchema } from "effect/unstable/httpapi"
+import { createServer } from "node:http"
+
+const User = Schema.Struct({
+  id: Schema.Int,
+  name: Schema.String
+})
+
+const Api = HttpApi.make("MyApi").add(
+  HttpApiGroup.make("Users").add(
+    HttpApiEndpoint.get("getUsers", "/users", {
+      // Wrap the success schema with a response headers schema
+      success: HttpApiSchema.WithHeaders(Schema.Array(User), {
+        "x-total-count": Schema.Int
+      })
+    })
+  )
+)
+
+const GroupLive = HttpApiBuilder.group(
+  Api,
+  "Users",
+  (handlers) =>
+    handlers.handle("getUsers", () =>
+      // Return the body together with the declared headers
+      Effect.succeed(HttpApiSchema.withHeaders({
+        body: [{ id: 1, name: "John" }],
+        headers: { "x-total-count": 1 }
+      })))
+)
+
+const ApiLive = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLive),
+  HttpRouter.serve,
+  Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
+)
+
+Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+
+// curl -v "http://localhost:3000/users" 2>&1 | grep -i "x-total-count"
+// < x-total-count: 1
+```
+
+The derived client detects the wrapper and returns the same shape, with the headers decoded through the headers schema:
+
+```ts
+const users = yield * client.Users.getUsers()
+users.body // => [{ id: 1, name: "John" }]
+users.headers // => { "x-total-count": 1 }
+```
+
+Things to know:
+
+- Header values are converted to strings at the HTTP boundary, the same way as request headers, params, and query. `Schema.Int` goes out as `"1"` and decodes back to `1` on the client. `undefined` values are omitted from the response.
+- Status and encoding annotations resolve from the wrapper first, then fall through to the inner schema, so `HttpApiSchema.WithHeaders(User.pipe(HttpApiSchema.status(201)), ...)` responds with `201`.
+- Declared headers are applied after the body is encoded and override headers set by the encoding on collision, including `content-type`.
+- Stream success schemas (`HttpApiSchema.StreamSse`, `HttpApiSchema.StreamUint8Array`) can be wrapped too. Headers are encoded before the response starts streaming, and the client resolves to a value whose `body` is the stream.
+- `WithHeaders` is also allowed on error schemas, in which case the handler fails with the wrapped value. For errors, `encodeToWithHeaders` (below) is usually more convenient because handlers can fail with the domain error directly.
+
+### Folding Headers into Domain Types with encodeToWithHeaders
+
+`HttpApiSchema.encodeToWithHeaders` encodes a schema as a `{ body, headers }` pair while its Type stays unchanged. This lets an error class carry data that travels in a response header: handlers fail with plain error instances, and the client receives the same class with the header folded back in.
+
+The body schema is authoritative for everything wire-level: status, content type, and response encoding resolve from the body schema's annotations. A status annotation on the source schema stops mattering once wrapped, so spell the status on the body — `HttpApiSchema.Empty(404)` declares an empty body with status 404.
+
+**Example** (Returning an Error With a Response Header)
+
+```ts
+import { NodeHttpServer, NodeRuntime } from "@effect/platform-node"
+import { Effect, Layer, Schema } from "effect"
+import { HttpRouter } from "effect/unstable/http"
+import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup, HttpApiSchema } from "effect/unstable/httpapi"
+import { createServer } from "node:http"
+
+class UserNotFound extends Schema.TaggedError<UserNotFound>()("UserNotFound", {
+  userId: Schema.Int
+}) {}
+
+const UserNotFoundWithHeaders = UserNotFound.pipe(
+  HttpApiSchema.encodeToWithHeaders({
+    // The body schema is authoritative for status and content type
+    body: HttpApiSchema.Empty(404),
+    headers: {
+      "x-user-id": Schema.Int
+    }
+  }, {
+    // Pure mappings between the domain type and the { body, headers } pair
+    decode: ({ headers }) => new UserNotFound({ userId: headers["x-user-id"] }),
+    encode: (error) => ({
+      headers: { "x-user-id": error.userId },
+      body: undefined
+    })
+  })
+)
+
+const User = Schema.Struct({
+  id: Schema.Int,
+  name: Schema.String
+})
+
+const Api = HttpApi.make("MyApi").add(
+  HttpApiGroup.make("Users").add(
+    HttpApiEndpoint.get("getUser", "/user/:id", {
+      params: {
+        id: Schema.Int
+      },
+      success: User,
+      error: UserNotFoundWithHeaders
+    })
+  )
+)
+
+const GroupLive = HttpApiBuilder.group(
+  Api,
+  "Users",
+  (handlers) =>
+    handlers.handle("getUser", (ctx) => {
+      const id = ctx.params.id
+      if (id === 1) {
+        // Fail with the plain error instance
+        return Effect.fail(new UserNotFound({ userId: id }))
+      }
+      return Effect.succeed({ id, name: `User ${id}` })
+    })
+)
+
+const ApiLive = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLive),
+  HttpRouter.serve,
+  Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
+)
+
+Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+
+// curl -v "http://localhost:3000/user/1" 2>&1 | grep -i "x-user-id"
+// < x-user-id: 1
+```
+
+The `decode`/`encode` mappings are pure total functions: validation lives in the body and headers schemas, the mappings only reshape valid data. The error channel is unchanged — a client calling this endpoint fails with a `UserNotFound` instance whose `userId` was decoded from the header.
+
+`encodeToWithHeaders` also works on custom success types, but avoid burying stream schemas in it; wrap streams with `WithHeaders` instead so the generated client keeps the stream's error channel.
+
+### Untyped Response Headers
+
+For headers that should not appear in the API contract, call `HttpEffect.appendPreResponseHandler` inside your handler. The callback receives the request and response objects and must return the updated response. These headers bypass the schemas, the OpenAPI documentation, and the derived client.
 
 **Example** (Adding a Custom Response Header)
 

--- a/packages/effect/HTTPAPI.md
+++ b/packages/effect/HTTPAPI.md
@@ -1555,6 +1555,8 @@ Response headers can be declared in the endpoint's schemas, so they are type-che
 - `HttpApiSchema.WithHeaders(schema, headers)` wraps a response schema together with a headers schema. Handlers return the body and headers as a pair. Recommended for success responses, including streams.
 - `HttpApiSchema.encodeToWithHeaders` folds headers into an opaque domain type such as an error class, so handlers keep working with plain domain values.
 
+Only one response schema carrying headers may be declared for each status, though plain responses with different content types may share that status.
+
 For headers that are not part of the API contract, `HttpEffect.appendPreResponseHandler` remains available as an untyped escape hatch.
 
 ### Declaring Response Headers with WithHeaders

--- a/packages/effect/src/unstable/http/HttpServerResponse.ts
+++ b/packages/effect/src/unstable/http/HttpServerResponse.ts
@@ -534,7 +534,7 @@ export const setHeader: {
     makeResponse({
       ...self,
       headers: Headers.set(self.headers, key, value)
-    })
+    }, true)
 )
 
 /**

--- a/packages/effect/src/unstable/http/HttpServerResponse.ts
+++ b/packages/effect/src/unstable/http/HttpServerResponse.ts
@@ -570,7 +570,7 @@ export const setHeaders: {
     makeResponse({
       ...self,
       headers: Headers.setAll(self.headers, input)
-    })
+    }, true)
 )
 
 /**
@@ -1339,7 +1339,7 @@ const makeResponse = (options: {
   readonly headers?: Headers.Headers | undefined
   readonly cookies?: Cookies.Cookies | undefined
   readonly body?: Body.HttpBody | undefined
-}) => {
+}, preferHeaders = false) => {
   const self = Object.create(Proto) as Mutable<HttpServerResponse>
   self.status = options.status
   self.statusText = options.statusText
@@ -1350,10 +1350,10 @@ const makeResponse = (options: {
     (self.body.contentType || self.body.contentLength !== undefined)
   ) {
     const newHeaders = Headers.fromRecordUnsafe({ ...options.headers }) as any
-    if (self.body.contentType) {
+    if (self.body.contentType && (!preferHeaders || newHeaders["content-type"] === undefined)) {
       newHeaders["content-type"] = self.body.contentType
     }
-    if (self.body.contentLength !== undefined) {
+    if (self.body.contentLength !== undefined && (!preferHeaders || newHeaders["content-length"] === undefined)) {
       newHeaders["content-length"] = self.body.contentLength.toString()
     }
     self.headers = newHeaders

--- a/packages/effect/src/unstable/httpapi/HttpApi.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApi.ts
@@ -313,7 +313,8 @@ const extractResponseContent = (
   return map
 
   function add(schema: Schema.Top) {
-    if (HttpApiSchema.isStreamSchema(schema)) return
+    const body = HttpApiSchema.isWithHeaders(schema) ? schema.schema : schema
+    if (HttpApiSchema.isStreamSchema(body)) return
     const status = getStatus(schema)
     const schemas = map.get(status)
     if (schemas === undefined) {

--- a/packages/effect/src/unstable/httpapi/HttpApi.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApi.ts
@@ -15,7 +15,6 @@ import { type Pipeable, pipeArguments } from "../../Pipeable.ts"
 import * as Predicate from "../../Predicate.ts"
 import * as Record from "../../Record.ts"
 import type * as Schema from "../../Schema.ts"
-import type * as SchemaAST from "../../SchemaAST.ts"
 import type { PathInput } from "../http/HttpRouter.ts"
 import * as HttpApiEndpoint from "./HttpApiEndpoint.ts"
 import type * as HttpApiGroup from "./HttpApiGroup.ts"
@@ -290,11 +289,11 @@ export const reflect = <Id extends string, Groups extends HttpApiGroup.Constrain
         mergedAnnotations: Context.merge(groupAnnotations, endpoint.annotations),
         successes: extractResponseContent(
           HttpApiEndpoint.getSuccessSchemas(endpoint),
-          HttpApiSchema.getStatusSuccess
+          HttpApiSchema.getStatusSuccessSchema
         ),
         errors: extractResponseContent(
           HttpApiEndpoint.getErrorSchemas(endpoint),
-          HttpApiSchema.getStatusError
+          HttpApiSchema.getStatusErrorSchema
         )
       })
     }
@@ -305,7 +304,7 @@ export const reflect = <Id extends string, Groups extends HttpApiGroup.Constrain
 
 const extractResponseContent = (
   schemas: Array<Schema.Top>,
-  getStatus: (ast: SchemaAST.AST) => number
+  getStatus: (schema: Schema.Constraint) => number
 ): ReadonlyMap<number, [Schema.Top, ...Array<Schema.Top>]> => {
   const map = new Map<number, [Schema.Top, ...Array<Schema.Top>]>()
 
@@ -315,8 +314,7 @@ const extractResponseContent = (
 
   function add(schema: Schema.Top) {
     if (HttpApiSchema.isStreamSchema(schema)) return
-    const ast = schema.ast
-    const status = getStatus(ast)
+    const status = getStatus(schema)
     const schemas = map.get(status)
     if (schemas === undefined) {
       map.set(status, [schema])

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -804,14 +804,19 @@ function handlerToHttpEffect(
       }
       let responseHeaders: unknown | undefined
       if (encodeWithHeaders !== undefined && HttpApiSchema.isWithHeadersValue(response)) {
-        responseHeaders = yield* HttpApiSchemaError.wrap("ResponseHeaders", encodeWithHeaders(response.headers))
+        responseHeaders = response.headers
         response = response.body
       }
       const encoded = yield* HttpApiSchemaError.wrap(
         "Body",
         encodeStream?.(response, context) ?? encodeSuccess(response)
       )
-      return responseHeaders === undefined ? encoded : Response.setHeaders(encoded, responseHeaders as any)
+      if (responseHeaders === undefined) return encoded
+      const encodedHeaders = yield* HttpApiSchemaError.wrap(
+        "ResponseHeaders",
+        encodeWithHeaders!.get(encoded.status)!(responseHeaders)
+      )
+      return Response.setHeaders(encoded, encodedHeaders as any)
     })
   ).pipe(
     Effect.withErrorReporting,
@@ -926,15 +931,25 @@ type StreamEncoder = (response: unknown, context: Context.Context<never>) =>
 
 type WithHeadersEncoder = (headers: unknown) => Effect.Effect<unknown, Schema.SchemaError, unknown>
 
-function makeWithHeadersEncoder(endpoint: HttpApiEndpoint.Top): WithHeadersEncoder | undefined {
-  const schemas: Array<Schema.Top> = []
+function makeWithHeadersEncoder(endpoint: HttpApiEndpoint.Top): Map<number, WithHeadersEncoder> | undefined {
+  const schemasByStatus = new Map<number, Array<Schema.Top>>()
   for (const schema of endpoint.success) {
     if (HttpApiSchema.isWithHeaders(schema)) {
-      schemas.push(Schema.toCodecStringTree(schema.headers))
+      const status = HttpApiSchema.getStatusSuccessSchema(schema)
+      const schemas = schemasByStatus.get(status)
+      if (schemas === undefined) {
+        schemasByStatus.set(status, [Schema.toCodecStringTree(schema.headers)])
+      } else {
+        schemas.push(Schema.toCodecStringTree(schema.headers))
+      }
     }
   }
-  if (schemas.length === 0) return undefined
-  return Schema.encodeUnknownEffect(schemas.length === 1 ? schemas[0] : Schema.Union(schemas))
+  if (schemasByStatus.size === 0) return undefined
+  const encoders = new Map<number, WithHeadersEncoder>()
+  for (const [status, schemas] of schemasByStatus) {
+    encoders.set(status, Schema.encodeUnknownEffect(schemas.length === 1 ? schemas[0] : Schema.Union(schemas)))
+  }
+  return encoders
 }
 
 function makeStreamEncoder(endpoint: HttpApiEndpoint.Top): StreamEncoder | undefined {

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -936,7 +936,7 @@ function makeWithHeadersEncoder(endpoint: HttpApiEndpoint.Top): Map<number, With
   for (const schema of endpoint.success) {
     if (HttpApiSchema.isWithHeaders(schema)) {
       const status = HttpApiSchema.getStatusSuccessSchema(schema)
-      const headersSchema = Schema.toCodecStringTree(schema.headers)
+      const headersSchema = schema.headers
       const schemas = schemasByStatus.get(status)
       if (schemas === undefined) {
         schemasByStatus.set(status, [headersSchema])
@@ -1086,7 +1086,7 @@ function toResponseErrorSchema(
   if (!HttpApiSchema.isWithHeaders(schema)) return toResponseErrorSchemaPlain(schema)
 
   const encodeBody = Schema.encodeUnknownEffect(schema.schema)
-  const encodeHeaders = Schema.encodeUnknownEffect(Schema.toCodecStringTree(schema.headers))
+  const encodeHeaders = Schema.encodeUnknownEffect(schema.headers)
   const encodeResponse = getResponseEncode(
     HttpApiSchema.getStatusErrorSchema(schema),
     HttpApiSchema.getResponseEncodingSchema(schema),
@@ -1151,13 +1151,9 @@ function getResponseTransformation(
     const headersCodec = withHeaders.headersCodec
     let encodeHeaders: (headers: unknown) => Effect.Effect<unknown, Schema.SchemaError, unknown>
     if (headersCodec === undefined) {
-      // The annotation transform has already encoded the declared headers schema,
-      // so disableCodecs only skips its automatic codec and not HTTP stringification.
-      encodeHeaders = Schema.encodeUnknownEffect(Schema.toCodecStringTree(Schema.toEncoded(withHeaders.headers)))
+      encodeHeaders = Schema.encodeUnknownEffect(Schema.toEncoded(withHeaders.headers))
     } else {
-      const decodeHeaders = Schema.decodeUnknownEffect(withHeaders.headers)
-      const encodeCodec = Schema.encodeUnknownEffect(headersCodec)
-      encodeHeaders = (headers) => Effect.flatMap(decodeHeaders(headers), encodeCodec)
+      encodeHeaders = Schema.encodeUnknownEffect(headersCodec)
     }
     return withHeadersTransformation(encodeBody, encodeHeaders)
   }

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -1116,26 +1116,25 @@ function getResponseTransformation(
       HttpApiSchema.isNoContent(withHeaders.body.ast)
     )
     const headersCodec = withHeaders.headersCodec
-    const encodeHeaders = headersCodec === undefined ? undefined : (
+    const encodeHeaders = (
       headers: unknown
     ): Effect.Effect<unknown, SchemaIssue.Issue, unknown> =>
-      Schema.decodeUnknownEffect(withHeaders.headers)(headers).pipe(
-        Effect.flatMap(Schema.encodeUnknownEffect(headersCodec)),
-        Effect.mapError((error) => error.issue)
-      )
+      (headersCodec === undefined
+        ? Schema.encodeUnknownEffect(Schema.toCodecStringTree(Schema.toEncoded(withHeaders.headers)))(headers)
+        : Schema.decodeUnknownEffect(withHeaders.headers)(headers).pipe(
+          Effect.flatMap(Schema.encodeUnknownEffect(headersCodec))
+        )).pipe(
+          Effect.mapError((error) => error.issue)
+        )
     return SchemaTransformation.transformOrFail<unknown, Response.HttpServerResponse, never, unknown>({
       decode: () => Effect.fail(new SchemaIssue.Forbidden({ message: "Encode only schema" })),
       encode: (value) => {
         const withHeaders = value as { readonly body: unknown; readonly headers: unknown }
-        return Effect.flatMap(encodeBody(withHeaders.body), (response) => {
-          if (encodeHeaders === undefined) {
-            return Effect.succeed(Response.setHeaders(response, withHeaders.headers as any))
-          }
-          return Effect.map(
+        return Effect.flatMap(encodeBody(withHeaders.body), (response) =>
+          Effect.map(
             encodeHeaders(withHeaders.headers),
             (headers) => Response.setHeaders(response, headers as any)
-          )
-        })
+          ))
       }
     })
   }

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -1100,7 +1100,7 @@ function toResponseErrorSchema(
     HttpApiSchema.getResponseEncodingSchema(schema),
     HttpApiSchema.isNoContent(schema.schema.ast)
   )
-  const transformation = withHeadersTransformation<HttpApiSchema.WithHeaders.Value<unknown, Schema.StringTree>>(
+  const transformation = withHeadersTransformation<HttpApiSchema.withHeaders<unknown, Schema.StringTree>>(
     (body) =>
       encodeBody(body).pipe(
         Effect.mapError((error) => error.issue),

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -812,9 +812,18 @@ function handlerToHttpEffect(
         encodeStream?.(response, context) ?? encodeSuccess(response)
       )
       if (encodeWithHeaders === undefined || responseHeaders === undefined) return encoded
+      const encodeHeaders = encodeWithHeaders.get(encoded.status)
       const encodedHeaders = yield* HttpApiSchemaError.wrap(
         "ResponseHeaders",
-        encodeWithHeaders.get(encoded.status)!(responseHeaders)
+        encodeHeaders === undefined
+          ? Effect.fail(
+            new Schema.SchemaError(
+              new SchemaIssue.InvalidValue({
+                message: `Endpoint declares no header-carrying response for encoded status: ${encoded.status}`
+              })
+            )
+          )
+          : encodeHeaders(responseHeaders)
       )
       return Response.setHeaders(encoded, encodedHeaders as any)
     })

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -809,21 +809,13 @@ function handlerToHttpEffect(
       }
       const encoded = yield* HttpApiSchemaError.wrap(
         "Body",
-        encodeStream?.(response, context) ?? encodeSuccess(response)
+        encodeStream?.(response, context) ??
+          (responseHeaders !== undefined ? encodeWithHeaders!.encodeBody(response) : encodeSuccess(response))
       )
       if (encodeWithHeaders === undefined || responseHeaders === undefined) return encoded
-      const encodeHeaders = encodeWithHeaders.get(encoded.status)
       const encodedHeaders = yield* HttpApiSchemaError.wrap(
         "ResponseHeaders",
-        encodeHeaders === undefined
-          ? Effect.fail(
-            new Schema.SchemaError(
-              new SchemaIssue.InvalidValue({
-                message: `Endpoint declares no header-carrying response for encoded status: ${encoded.status}`
-              })
-            )
-          )
-          : encodeHeaders(responseHeaders)
+        encodeWithHeaders.encodeHeaders.get(encoded.status)!(responseHeaders)
       )
       return Response.setHeaders(encoded, encodedHeaders as any)
     })
@@ -940,15 +932,33 @@ type StreamEncoder = (response: unknown, context: Context.Context<never>) =>
 
 type WithHeadersEncoder = (headers: unknown) => Effect.Effect<unknown, Schema.SchemaError, unknown>
 
-function makeWithHeadersEncoder(endpoint: HttpApiEndpoint.Top): Map<number, WithHeadersEncoder> | undefined {
-  const encoders = new Map<number, WithHeadersEncoder>()
+interface WithHeadersEncoders {
+  readonly encodeBody: (body: unknown) => Effect.Effect<HttpServerResponse, Schema.SchemaError, unknown>
+  readonly encodeHeaders: ReadonlyMap<number, WithHeadersEncoder>
+}
+
+function makeWithHeadersEncoder(endpoint: HttpApiEndpoint.Top): WithHeadersEncoders | undefined {
+  const encodeHeaders = new Map<number, WithHeadersEncoder>()
+  const bodySchemas: Array<Schema.ConstraintEncoder<HttpServerResponse, unknown>> = []
   for (const schema of endpoint.success) {
-    if (HttpApiSchema.isWithHeaders(schema)) {
-      const status = HttpApiSchema.getStatusSuccessSchema(schema)
-      encoders.set(status, Schema.encodeUnknownEffect(schema.headers))
+    if (!HttpApiSchema.isWithHeaders(schema)) continue
+    encodeHeaders.set(HttpApiSchema.getStatusSuccessSchema(schema), Schema.encodeUnknownEffect(schema.headers))
+    if (!HttpApiSchema.isStreamSchema(schema.schema)) {
+      bodySchemas.push(toResponseSuccessSchema(schema))
     }
   }
-  return encoders.size === 0 ? undefined : encoders
+  if (encodeHeaders.size === 0) return undefined
+  // Branded response bodies encode against the header-carrying members only, so
+  // the encoded status always has a matching header schema.
+  const bodySchema: Schema.ConstraintEncoder<HttpServerResponse, unknown> = bodySchemas.length === 0
+    ? Schema.Never
+    : bodySchemas.length === 1
+    ? bodySchemas[0]
+    : Schema.Union(bodySchemas)
+  return {
+    encodeBody: Schema.encodeUnknownEffect(bodySchema),
+    encodeHeaders
+  }
 }
 
 function makeStreamEncoder(endpoint: HttpApiEndpoint.Top): StreamEncoder | undefined {

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -807,12 +807,10 @@ function handlerToHttpEffect(
         responseHeaders = yield* HttpApiSchemaError.wrap("ResponseHeaders", encodeWithHeaders(response.headers))
         response = response.body
       }
-      const streamResponse = encodeStream?.(response, context)
-      if (streamResponse !== undefined) {
-        const encoded = yield* HttpApiSchemaError.wrap("Body", streamResponse)
-        return responseHeaders === undefined ? encoded : Response.setHeaders(encoded, responseHeaders as any)
-      }
-      const encoded = yield* HttpApiSchemaError.wrap("Body", encodeSuccess(response))
+      const encoded = yield* HttpApiSchemaError.wrap(
+        "Body",
+        encodeStream?.(response, context) ?? encodeSuccess(response)
+      )
       return responseHeaders === undefined ? encoded : Response.setHeaders(encoded, responseHeaders as any)
     })
   ).pipe(
@@ -1063,8 +1061,8 @@ function renderSseEvent(event: Sse.EventEncoded) {
   })
 }
 
-const toResponseSuccessSchema = toResponseSchema(HttpApiSchema.getStatusSuccess)
-const toResponseErrorSchemaPlain = toResponseSchema(HttpApiSchema.getStatusError)
+const toResponseSuccessSchema = toResponseSchema(HttpApiSchema.getStatusSuccessSchema)
+const toResponseErrorSchemaPlain = toResponseSchema(HttpApiSchema.getStatusErrorSchema)
 
 function toResponseErrorSchema(
   schema: Schema.Constraint
@@ -1078,25 +1076,14 @@ function toResponseErrorSchema(
     HttpApiSchema.getResponseEncodingSchema(schema),
     HttpApiSchema.isNoContent(schema.schema.ast)
   )
-  const transformation = SchemaTransformation.transformOrFail<
-    HttpApiSchema.WithHeaders.Value<unknown, Schema.StringTree>,
-    Response.HttpServerResponse,
-    never,
-    unknown
-  >({
-    decode: () => Effect.fail(new SchemaIssue.Forbidden({ message: "Encode only schema" })),
-    encode: (value) => {
-      return Effect.flatMap(
-        encodeBody(value.body).pipe(Effect.mapError((error) => error.issue)),
-        (body) =>
-          Effect.flatMap(encodeResponse(body), (response) =>
-            Effect.map(
-              encodeHeaders(value.headers).pipe(Effect.mapError((error) => error.issue)),
-              (headers) => Response.setHeaders(response, headers as any)
-            ))
-      )
-    }
-  })
+  const transformation = withHeadersTransformation<HttpApiSchema.WithHeaders.Value<unknown, Schema.StringTree>>(
+    (body) =>
+      encodeBody(body).pipe(
+        Effect.mapError((error) => error.issue),
+        Effect.flatMap(encodeResponse)
+      ),
+    encodeHeaders
+  )
   return $HttpServerResponse.pipe(Schema.decodeTo(schema, transformation))
 }
 
@@ -1115,74 +1102,77 @@ function makeErrorSchema(
   return schemas.length === 1 ? schemas[0] : Schema.Union(schemas)
 }
 
-function toResponseSchema(getStatus: (ast: SchemaAST.AST) => number) {
-  const cache = new WeakMap<SchemaAST.AST, Schema.Top>()
+function toResponseSchema(getStatus: (schema: Schema.Constraint) => number) {
+  // WithHeaders wrappers share a single declaration AST, so they are cached by instance
+  const cache = new WeakMap<object, Schema.Top>()
 
   return (schema: Schema.Constraint): Schema.ConstraintEncoder<HttpServerResponse, unknown> => {
-    const isWithHeaders = HttpApiSchema.isWithHeaders(schema)
-    if (!isWithHeaders) {
-      const cached = cache.get(schema.ast)
-      if (cached !== undefined) {
-        return cached as any
-      }
+    const key = HttpApiSchema.isWithHeaders(schema) ? schema : schema.ast
+    const cached = cache.get(key)
+    if (cached !== undefined) {
+      return cached as any
     }
-    const bodySchema = isWithHeaders ? schema.schema : schema
+    const bodySchema = HttpApiSchema.isWithHeaders(schema) ? schema.schema : schema
     const responseSchema = $HttpServerResponse.pipe(
       Schema.decodeTo(bodySchema, getResponseTransformation(getStatus, schema))
     )
-    if (!isWithHeaders) {
-      cache.set(schema.ast, responseSchema)
-    }
+    cache.set(key, responseSchema)
     return responseSchema
   }
 }
 
 function getResponseTransformation(
-  getStatus: (ast: SchemaAST.AST) => number,
+  getStatus: (schema: Schema.Constraint) => number,
   schema: Schema.Constraint
 ): SchemaTransformation.Transformation<unknown, Response.HttpServerResponse, never, unknown> {
   const withHeaders = HttpApiSchema.getWithHeadersAnnotation(schema.ast)
   if (withHeaders !== undefined) {
     const encodeBody = getResponseEncode(
-      getStatus(withHeaders.body.ast),
+      getStatus(withHeaders.body),
       HttpApiSchema.getResponseEncoding(withHeaders.body.ast),
       HttpApiSchema.isNoContent(withHeaders.body.ast)
     )
     const headersCodec = withHeaders.headersCodec
-    const encodeHeaders = headersCodec === undefined
+    let encodeHeaders: (headers: unknown) => Effect.Effect<unknown, Schema.SchemaError, unknown>
+    if (headersCodec === undefined) {
       // The annotation transform has already encoded the declared headers schema,
       // so disableCodecs only skips its automatic codec and not HTTP stringification.
-      ? Schema.encodeUnknownEffect(Schema.toCodecStringTree(Schema.toEncoded(withHeaders.headers)))
-      : (headers: unknown) =>
-        Schema.decodeUnknownEffect(withHeaders.headers)(headers).pipe(
-          Effect.flatMap(Schema.encodeUnknownEffect(headersCodec))
-        )
-    return SchemaTransformation.transformOrFail<unknown, Response.HttpServerResponse, never, unknown>({
-      decode: () => Effect.fail(new SchemaIssue.Forbidden({ message: "Encode only schema" })),
-      encode: (value) => {
-        const withHeaders = value as { readonly body: unknown; readonly headers: unknown }
-        return Effect.flatMap(encodeBody(withHeaders.body), (response) =>
-          Effect.map(
-            encodeHeaders(withHeaders.headers).pipe(Effect.mapError((error) => error.issue)),
-            (headers) => Response.setHeaders(response, headers as any)
-          ))
-      }
-    })
+      encodeHeaders = Schema.encodeUnknownEffect(Schema.toCodecStringTree(Schema.toEncoded(withHeaders.headers)))
+    } else {
+      const decodeHeaders = Schema.decodeUnknownEffect(withHeaders.headers)
+      const encodeCodec = Schema.encodeUnknownEffect(headersCodec)
+      encodeHeaders = (headers) => Effect.flatMap(decodeHeaders(headers), encodeCodec)
+    }
+    return withHeadersTransformation(encodeBody, encodeHeaders)
   }
 
-  const responseSchema = HttpApiSchema.isWithHeaders(schema) ? schema.schema : schema
-  const ast = schema.ast
+  const bodySchema = HttpApiSchema.isWithHeaders(schema) ? schema.schema : schema
   const encode = getResponseEncode(
-    HttpApiSchema.isWithHeaders(schema) ? HttpApiSchema.getStatusSuccessSchema(schema) : getStatus(ast),
-    HttpApiSchema.isWithHeaders(schema)
-      ? HttpApiSchema.getResponseEncodingSchema(schema)
-      : HttpApiSchema.getResponseEncoding(ast),
-    HttpApiSchema.isNoContent(responseSchema.ast)
+    getStatus(schema),
+    HttpApiSchema.getResponseEncodingSchema(schema),
+    HttpApiSchema.isNoContent(bodySchema.ast)
   )
 
   return SchemaTransformation.transformOrFail({
     decode: () => Effect.fail(new SchemaIssue.Forbidden({ message: "Encode only schema" })),
     encode
+  })
+}
+
+function withHeadersTransformation<T = unknown>(
+  encodeBody: (body: unknown) => Effect.Effect<Response.HttpServerResponse, SchemaIssue.Issue, unknown>,
+  encodeHeaders: (headers: unknown) => Effect.Effect<unknown, Schema.SchemaError, unknown>
+): SchemaTransformation.Transformation<T, Response.HttpServerResponse, never, unknown> {
+  return SchemaTransformation.transformOrFail<T, Response.HttpServerResponse, never, unknown>({
+    decode: () => Effect.fail(new SchemaIssue.Forbidden({ message: "Encode only schema" })),
+    encode: (value) => {
+      const pair = value as { readonly body: unknown; readonly headers: unknown }
+      return Effect.flatMap(encodeBody(pair.body), (response) =>
+        Effect.map(
+          encodeHeaders(pair.headers).pipe(Effect.mapError((error) => error.issue)),
+          (headers) => Response.setHeaders(response, headers as any)
+        ))
+    }
   })
 }
 

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -811,10 +811,10 @@ function handlerToHttpEffect(
         "Body",
         encodeStream?.(response, context) ?? encodeSuccess(response)
       )
-      if (responseHeaders === undefined) return encoded
+      if (encodeWithHeaders === undefined || responseHeaders === undefined) return encoded
       const encodedHeaders = yield* HttpApiSchemaError.wrap(
         "ResponseHeaders",
-        encodeWithHeaders!.get(encoded.status)!(responseHeaders)
+        encodeWithHeaders.get(encoded.status)!(responseHeaders)
       )
       return Response.setHeaders(encoded, encodedHeaders as any)
     })
@@ -936,11 +936,12 @@ function makeWithHeadersEncoder(endpoint: HttpApiEndpoint.Top): Map<number, With
   for (const schema of endpoint.success) {
     if (HttpApiSchema.isWithHeaders(schema)) {
       const status = HttpApiSchema.getStatusSuccessSchema(schema)
+      const headersSchema = Schema.toCodecStringTree(schema.headers)
       const schemas = schemasByStatus.get(status)
       if (schemas === undefined) {
-        schemasByStatus.set(status, [Schema.toCodecStringTree(schema.headers)])
+        schemasByStatus.set(status, [headersSchema])
       } else {
-        schemas.push(Schema.toCodecStringTree(schema.headers))
+        schemas.push(headersSchema)
       }
     }
   }

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -932,25 +932,14 @@ type StreamEncoder = (response: unknown, context: Context.Context<never>) =>
 type WithHeadersEncoder = (headers: unknown) => Effect.Effect<unknown, Schema.SchemaError, unknown>
 
 function makeWithHeadersEncoder(endpoint: HttpApiEndpoint.Top): Map<number, WithHeadersEncoder> | undefined {
-  const schemasByStatus = new Map<number, Array<Schema.Top>>()
+  const encoders = new Map<number, WithHeadersEncoder>()
   for (const schema of endpoint.success) {
     if (HttpApiSchema.isWithHeaders(schema)) {
       const status = HttpApiSchema.getStatusSuccessSchema(schema)
-      const headersSchema = schema.headers
-      const schemas = schemasByStatus.get(status)
-      if (schemas === undefined) {
-        schemasByStatus.set(status, [headersSchema])
-      } else {
-        schemas.push(headersSchema)
-      }
+      encoders.set(status, Schema.encodeUnknownEffect(schema.headers))
     }
   }
-  if (schemasByStatus.size === 0) return undefined
-  const encoders = new Map<number, WithHeadersEncoder>()
-  for (const [status, schemas] of schemasByStatus) {
-    encoders.set(status, Schema.encodeUnknownEffect(schemas.length === 1 ? schemas[0] : Schema.Union(schemas)))
-  }
-  return encoders
+  return encoders.size === 0 ? undefined : encoders
 }
 
 function makeStreamEncoder(endpoint: HttpApiEndpoint.Top): StreamEncoder | undefined {

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -930,7 +930,7 @@ function makeWithHeadersEncoder(endpoint: HttpApiEndpoint.Top): WithHeadersEncod
   const schemas: Array<Schema.Top> = []
   for (const schema of endpoint.success) {
     if (HttpApiSchema.isWithHeaders(schema)) {
-      schemas.push(schema.headers)
+      schemas.push(Schema.toCodecStringTree(schema.headers))
     }
   }
   if (schemas.length === 0) return undefined
@@ -1070,7 +1070,7 @@ function toResponseErrorSchema(
   if (!HttpApiSchema.isWithHeaders(schema)) return toResponseErrorSchemaPlain(schema)
 
   const encodeBody = Schema.encodeUnknownEffect(schema.schema)
-  const encodeHeaders = Schema.encodeUnknownEffect(schema.headers)
+  const encodeHeaders = Schema.encodeUnknownEffect(Schema.toCodecStringTree(schema.headers))
   const encodeResponse = getResponseEncode(
     HttpApiSchema.getStatusErrorSchema(schema),
     HttpApiSchema.getResponseEncodingSchema(schema),

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -803,10 +803,9 @@ function handlerToHttpEffect(
         return response
       }
       let responseHeaders: unknown | undefined
-      if (encodeWithHeaders !== undefined && hasProperty(response, HttpApiSchema.WithHeadersValueTypeId)) {
-        const withHeaders = response as unknown as HttpApiSchema.WithHeaders.Value<unknown, unknown>
-        responseHeaders = yield* HttpApiSchemaError.wrap("ResponseHeaders", encodeWithHeaders(withHeaders.headers))
-        response = withHeaders.body
+      if (encodeWithHeaders !== undefined && HttpApiSchema.isWithHeadersValue(response)) {
+        responseHeaders = yield* HttpApiSchemaError.wrap("ResponseHeaders", encodeWithHeaders(response.headers))
+        response = response.body
       }
       const streamResponse = encodeStream?.(response, context)
       if (streamResponse !== undefined) {
@@ -1065,7 +1064,41 @@ function renderSseEvent(event: Sse.EventEncoded) {
 }
 
 const toResponseSuccessSchema = toResponseSchema(HttpApiSchema.getStatusSuccess)
-const toResponseErrorSchema = toResponseSchema(HttpApiSchema.getStatusError)
+const toResponseErrorSchemaPlain = toResponseSchema(HttpApiSchema.getStatusError)
+
+function toResponseErrorSchema(
+  schema: Schema.Constraint
+): Schema.ConstraintEncoder<HttpServerResponse, unknown> {
+  if (!HttpApiSchema.isWithHeaders(schema)) return toResponseErrorSchemaPlain(schema)
+
+  const encodeBody = Schema.encodeUnknownEffect(schema.schema)
+  const encodeHeaders = Schema.encodeUnknownEffect(schema.headers)
+  const encodeResponse = getResponseEncode(
+    HttpApiSchema.getStatusErrorSchema(schema),
+    HttpApiSchema.getResponseEncodingSchema(schema),
+    HttpApiSchema.isNoContent(schema.schema.ast)
+  )
+  const transformation = SchemaTransformation.transformOrFail<
+    HttpApiSchema.WithHeaders.Value<unknown, Schema.StringTree>,
+    Response.HttpServerResponse,
+    never,
+    unknown
+  >({
+    decode: () => Effect.fail(new SchemaIssue.Forbidden({ message: "Encode only schema" })),
+    encode: (value) => {
+      return Effect.flatMap(
+        encodeBody(value.body).pipe(Effect.mapError((error) => error.issue)),
+        (body) =>
+          Effect.flatMap(encodeResponse(body), (response) =>
+            Effect.map(
+              encodeHeaders(value.headers).pipe(Effect.mapError((error) => error.issue)),
+              (headers) => Response.setHeaders(response, headers as any)
+            ))
+      )
+    }
+  })
+  return $HttpServerResponse.pipe(Schema.decodeTo(schema, transformation))
+}
 
 function makeSuccessSchema(
   endpoint: HttpApiEndpoint.Top

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -1116,15 +1116,13 @@ function getResponseTransformation(
       HttpApiSchema.isNoContent(withHeaders.body.ast)
     )
     const headersCodec = withHeaders.headersCodec
-    const encodeHeaders = (
-      headers: unknown
-    ): Effect.Effect<unknown, SchemaIssue.Issue, unknown> =>
-      (headersCodec === undefined
-        ? Schema.encodeUnknownEffect(Schema.toCodecStringTree(Schema.toEncoded(withHeaders.headers)))(headers)
-        : Schema.decodeUnknownEffect(withHeaders.headers)(headers).pipe(
+    const encodeHeaders = headersCodec === undefined
+      // The annotation transform has already encoded the declared headers schema,
+      // so disableCodecs only skips its automatic codec and not HTTP stringification.
+      ? Schema.encodeUnknownEffect(Schema.toCodecStringTree(Schema.toEncoded(withHeaders.headers)))
+      : (headers: unknown) =>
+        Schema.decodeUnknownEffect(withHeaders.headers)(headers).pipe(
           Effect.flatMap(Schema.encodeUnknownEffect(headersCodec))
-        )).pipe(
-          Effect.mapError((error) => error.issue)
         )
     return SchemaTransformation.transformOrFail<unknown, Response.HttpServerResponse, never, unknown>({
       decode: () => Effect.fail(new SchemaIssue.Forbidden({ message: "Encode only schema" })),
@@ -1132,7 +1130,7 @@ function getResponseTransformation(
         const withHeaders = value as { readonly body: unknown; readonly headers: unknown }
         return Effect.flatMap(encodeBody(withHeaders.body), (response) =>
           Effect.map(
-            encodeHeaders(withHeaders.headers),
+            encodeHeaders(withHeaders.headers).pipe(Effect.mapError((error) => error.issue)),
             (headers) => Response.setHeaders(response, headers as any)
           ))
       }

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -760,6 +760,7 @@ function handlerToHttpEffect(
   const decodeHeaders = UndefinedOr.map(endpoint.headers, Schema.decodeUnknownEffect)
   const decodeQuery = UndefinedOr.map(endpoint.query, Schema.decodeUnknownEffect)
   const encodeStream = makeStreamEncoder(endpoint)
+  const encodeWithHeaders = makeWithHeadersEncoder(endpoint)
 
   const shouldParsePayload = endpoint.payload.size > 0 && !isRaw
   const payloadBy = shouldParsePayload ? buildPayloadDecoders(endpoint.payload) : undefined
@@ -797,15 +798,23 @@ function handlerToHttpEffect(
           request.payload = yield* HttpApiSchemaError.wrap("Payload", result)
         }
       }
-      const response = yield* handler(request)
+      let response = yield* handler(request)
       if (Response.isHttpServerResponse(response)) {
         return response
       }
+      let responseHeaders: unknown | undefined
+      if (encodeWithHeaders !== undefined && hasProperty(response, HttpApiSchema.WithHeadersValueTypeId)) {
+        const withHeaders = response as unknown as HttpApiSchema.WithHeaders.Value<unknown, unknown>
+        responseHeaders = yield* HttpApiSchemaError.wrap("ResponseHeaders", encodeWithHeaders(withHeaders.headers))
+        response = withHeaders.body
+      }
       const streamResponse = encodeStream?.(response, context)
       if (streamResponse !== undefined) {
-        return yield* HttpApiSchemaError.wrap("Body", streamResponse)
+        const encoded = yield* HttpApiSchemaError.wrap("Body", streamResponse)
+        return responseHeaders === undefined ? encoded : Response.setHeaders(encoded, responseHeaders as any)
       }
-      return yield* HttpApiSchemaError.wrap("Body", encodeSuccess(response))
+      const encoded = yield* HttpApiSchemaError.wrap("Body", encodeSuccess(response))
+      return responseHeaders === undefined ? encoded : Response.setHeaders(encoded, responseHeaders as any)
     })
   ).pipe(
     Effect.withErrorReporting,
@@ -918,6 +927,19 @@ type StreamEncoder = (response: unknown, context: Context.Context<never>) =>
   | Effect.Effect<HttpServerResponse, Schema.SchemaError, unknown>
   | undefined
 
+type WithHeadersEncoder = (headers: unknown) => Effect.Effect<unknown, Schema.SchemaError, unknown>
+
+function makeWithHeadersEncoder(endpoint: HttpApiEndpoint.Top): WithHeadersEncoder | undefined {
+  const schemas: Array<Schema.Top> = []
+  for (const schema of endpoint.success) {
+    if (HttpApiSchema.isWithHeaders(schema)) {
+      schemas.push(schema.headers)
+    }
+  }
+  if (schemas.length === 0) return undefined
+  return Schema.encodeUnknownEffect(schemas.length === 1 ? schemas[0] : Schema.Union(schemas))
+}
+
 function makeStreamEncoder(endpoint: HttpApiEndpoint.Top): StreamEncoder | undefined {
   const streamSchema = getStreamSuccessSchema(endpoint)
   if (streamSchema === undefined) {
@@ -967,15 +989,17 @@ function makeStreamEncoder(endpoint: HttpApiEndpoint.Top): StreamEncoder | undef
 
 function getStreamSuccessSchema(endpoint: HttpApiEndpoint.Top) {
   for (const schema of endpoint.success) {
-    if (HttpApiSchema.isStreamSchema(schema)) {
-      return schema
+    const body = HttpApiSchema.isWithHeaders(schema) ? schema.schema : schema
+    if (HttpApiSchema.isStreamSchema(body)) {
+      return body
     }
   }
 }
 
 function hasBufferedSuccess(endpoint: HttpApiEndpoint.Top): boolean {
   for (const schema of endpoint.success) {
-    if (Schema.isSchema(schema) && !HttpApiSchema.isStreamSchema(schema)) return true
+    const body = HttpApiSchema.isWithHeaders(schema) ? schema.schema : schema
+    if (Schema.isSchema(body) && !HttpApiSchema.isStreamSchema(body)) return true
   }
   return endpoint.success.size === 0
 }
@@ -1062,14 +1086,20 @@ function toResponseSchema(getStatus: (ast: SchemaAST.AST) => number) {
   const cache = new WeakMap<SchemaAST.AST, Schema.Top>()
 
   return (schema: Schema.Constraint): Schema.ConstraintEncoder<HttpServerResponse, unknown> => {
-    const cached = cache.get(schema.ast)
-    if (cached !== undefined) {
-      return cached as any
+    const isWithHeaders = HttpApiSchema.isWithHeaders(schema)
+    if (!isWithHeaders) {
+      const cached = cache.get(schema.ast)
+      if (cached !== undefined) {
+        return cached as any
+      }
     }
+    const bodySchema = isWithHeaders ? schema.schema : schema
     const responseSchema = $HttpServerResponse.pipe(
-      Schema.decodeTo(schema, getResponseTransformation(getStatus, schema))
+      Schema.decodeTo(bodySchema, getResponseTransformation(getStatus, schema))
     )
-    cache.set(schema.ast, responseSchema)
+    if (!isWithHeaders) {
+      cache.set(schema.ast, responseSchema)
+    }
     return responseSchema
   }
 }
@@ -1077,12 +1107,47 @@ function toResponseSchema(getStatus: (ast: SchemaAST.AST) => number) {
 function getResponseTransformation(
   getStatus: (ast: SchemaAST.AST) => number,
   schema: Schema.Constraint
-): SchemaTransformation.Transformation<unknown, Response.HttpServerResponse> {
+): SchemaTransformation.Transformation<unknown, Response.HttpServerResponse, never, unknown> {
+  const withHeaders = HttpApiSchema.getWithHeadersAnnotation(schema.ast)
+  if (withHeaders !== undefined) {
+    const encodeBody = getResponseEncode(
+      getStatus(withHeaders.body.ast),
+      HttpApiSchema.getResponseEncoding(withHeaders.body.ast),
+      HttpApiSchema.isNoContent(withHeaders.body.ast)
+    )
+    const headersCodec = withHeaders.headersCodec
+    const encodeHeaders = headersCodec === undefined ? undefined : (
+      headers: unknown
+    ): Effect.Effect<unknown, SchemaIssue.Issue, unknown> =>
+      Schema.decodeUnknownEffect(withHeaders.headers)(headers).pipe(
+        Effect.flatMap(Schema.encodeUnknownEffect(headersCodec)),
+        Effect.mapError((error) => error.issue)
+      )
+    return SchemaTransformation.transformOrFail<unknown, Response.HttpServerResponse, never, unknown>({
+      decode: () => Effect.fail(new SchemaIssue.Forbidden({ message: "Encode only schema" })),
+      encode: (value) => {
+        const withHeaders = value as { readonly body: unknown; readonly headers: unknown }
+        return Effect.flatMap(encodeBody(withHeaders.body), (response) => {
+          if (encodeHeaders === undefined) {
+            return Effect.succeed(Response.setHeaders(response, withHeaders.headers as any))
+          }
+          return Effect.map(
+            encodeHeaders(withHeaders.headers),
+            (headers) => Response.setHeaders(response, headers as any)
+          )
+        })
+      }
+    })
+  }
+
+  const responseSchema = HttpApiSchema.isWithHeaders(schema) ? schema.schema : schema
   const ast = schema.ast
   const encode = getResponseEncode(
-    getStatus(ast),
-    HttpApiSchema.getResponseEncoding(ast),
-    HttpApiSchema.isNoContent(ast)
+    HttpApiSchema.isWithHeaders(schema) ? HttpApiSchema.getStatusSuccessSchema(schema) : getStatus(ast),
+    HttpApiSchema.isWithHeaders(schema)
+      ? HttpApiSchema.getResponseEncodingSchema(schema)
+      : HttpApiSchema.getResponseEncoding(ast),
+    HttpApiSchema.isNoContent(responseSchema.ast)
   )
 
   return SchemaTransformation.transformOrFail({

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -1137,14 +1137,7 @@ function getResponseTransformation(
       HttpApiSchema.getResponseEncoding(withHeaders.body.ast),
       HttpApiSchema.isNoContent(withHeaders.body.ast)
     )
-    const headersCodec = withHeaders.headersCodec
-    let encodeHeaders: (headers: unknown) => Effect.Effect<unknown, Schema.SchemaError, unknown>
-    if (headersCodec === undefined) {
-      encodeHeaders = Schema.encodeUnknownEffect(Schema.toEncoded(withHeaders.headers))
-    } else {
-      encodeHeaders = Schema.encodeUnknownEffect(headersCodec)
-    }
-    return withHeadersTransformation(encodeBody, encodeHeaders)
+    return withHeadersTransformation(encodeBody, Schema.encodeUnknownEffect(withHeaders.headersCodec))
   }
 
   const bodySchema = HttpApiSchema.isWithHeaders(schema) ? schema.schema : schema

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -71,7 +71,7 @@ export type ForApi<Api extends HttpApi.Constraint, E = never, R = never> = Api e
 type SuccessType<S> = S extends HttpApiSchema.WithHeaders<
   infer _Inner,
   infer _Headers
-> ? HttpApiSchema.WithHeaders.Value<SuccessType<_Inner>, _Headers["Type"]>
+> ? HttpApiSchema.withHeaders<SuccessType<_Inner>, _Headers["Type"]>
   : S extends HttpApiSchema.StreamSse<
     infer _Events,
     infer _Error,

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -359,7 +359,21 @@ export const makeClient = <ApiId extends string, Groups extends HttpApiGroup.Con
         }
 
         const successAlternatives = new Map<number, Array<ResponseAlternative>>()
+        const successSchemasByStatus = new Map<number, [Schema.Top, ...Array<Schema.Top>]>()
         for (const [status, schemas] of successes.entries()) {
+          for (const schema of schemas) {
+            const schemaStatus = HttpApiSchema.isWithHeaders(schema)
+              ? HttpApiSchema.getStatusSuccessSchema(schema)
+              : status
+            const existing = successSchemasByStatus.get(schemaStatus)
+            if (existing === undefined) {
+              successSchemasByStatus.set(schemaStatus, [schema])
+            } else {
+              existing.push(schema)
+            }
+          }
+        }
+        for (const [status, schemas] of successSchemasByStatus.entries()) {
           const grouped = groupSchemasByContentType(schemas)
           for (const [contentType, schemas] of grouped.entries()) {
             addResponseAlternative(successAlternatives, status, contentType, schemasToResponse(schemas))
@@ -722,9 +736,43 @@ const compilePath = (path: string) => {
 }
 
 function schemasToResponse(schemas: readonly [Schema.Constraint, ...Array<Schema.Constraint>]) {
-  const codec = toCodecArrayBuffer(schemas)
+  const hasWithHeaders = schemas.some((schema) =>
+    HttpApiSchema.isWithHeaders(schema) || HttpApiSchema.getWithHeadersAnnotation(schema.ast) !== undefined
+  )
+  const codec = hasWithHeaders
+    ? Schema.Union(schemas.map(toCodecArrayBufferWithHeaders))
+    : toCodecArrayBuffer(schemas)
   const decode = Schema.decodeEffect(codec)
-  return (response: HttpClientResponse.HttpClientResponse) => Effect.flatMap(response.arrayBuffer, decode)
+  return (response: HttpClientResponse.HttpClientResponse) =>
+    Effect.flatMap(
+      response.arrayBuffer,
+      hasWithHeaders
+        ? (body) => decode({ body, headers: response.headers })
+        : decode
+    )
+}
+
+function toCodecArrayBufferWithHeaders(schema: Schema.Constraint): Schema.Top {
+  const isWithHeaders = HttpApiSchema.isWithHeaders(schema)
+  const annotation = HttpApiSchema.getWithHeadersAnnotation(schema.ast)
+  if (annotation !== undefined) {
+    return Schema.Struct({
+      body: fromArrayBuffer(annotation.body),
+      headers: Schema.toCodecStringTree(Schema.toEncoded(annotation.headers))
+    }).pipe(Schema.decodeTo(schema))
+  }
+  return Schema.Struct({
+    body: toCodecArrayBuffer([isWithHeaders ? schema.schema : schema]),
+    headers: isWithHeaders ? schema.headers : Schema.Unknown
+  }).pipe(
+    Schema.decodeTo(
+      isWithHeaders ? schema : Schema.toType(schema),
+      SchemaTransformation.transform({
+        decode: (value) => isWithHeaders ? HttpApiSchema.withHeaders(value) : value.body,
+        encode: (value: any) => isWithHeaders ? value : { body: value, headers: undefined }
+      }) as any
+    )
+  )
 }
 
 type ResponseDecoder = (response: HttpClientResponse.HttpClientResponse) => Effect.Effect<unknown, unknown, unknown>
@@ -768,9 +816,10 @@ function groupSchemasByContentType(
 ): Map<string, Arr.NonEmptyReadonlyArray<Schema.Top>> {
   const grouped = new Map<string, [Schema.Top, ...Array<Schema.Top>]>()
   for (const schema of schemas) {
-    const contentType = HttpApiSchema.isNoContent(schema.ast)
+    const body = HttpApiSchema.isWithHeaders(schema) ? schema.schema : schema
+    const contentType = HttpApiSchema.isNoContent(body.ast)
       ? ""
-      : MediaType.normalize(HttpApiSchema.getResponseEncoding(schema.ast).contentType)
+      : MediaType.normalize(HttpApiSchema.getResponseEncodingSchema(schema).contentType)
     const existing = grouped.get(contentType)
     if (existing === undefined) {
       grouped.set(contentType, [schema])
@@ -940,31 +989,34 @@ function toCodecArrayBuffer(schemas: readonly [Schema.Constraint, ...Array<Schem
   return Schema.Union(schemas.map(onSchema))
 
   function onSchema(schema: Schema.Constraint) {
-    const encoding = HttpApiSchema.getResponseEncoding(schema.ast)
-    switch (encoding._tag) {
-      case "Json": {
-        // handle json codecs that transform void schemas to null
-        const encodedIsNull = SchemaAST.isNull(SchemaAST.toEncoded(schema.ast))
-        return UnknownFromArrayBuffer.pipe(Schema.decodeTo(
-          schema,
-          encodedIsNull ?
+    return fromArrayBuffer(schema).pipe(Schema.decodeTo(schema))
+  }
+}
+
+function fromArrayBuffer(schema: Schema.Constraint): Schema.Top {
+  const encoding = HttpApiSchema.getResponseEncoding(schema.ast)
+  switch (encoding._tag) {
+    case "Json": {
+      // handle json codecs that transform void schemas to null
+      const encodedIsNull = SchemaAST.isNull(SchemaAST.toEncoded(schema.ast))
+      return encodedIsNull
+        ? UnknownFromArrayBuffer.pipe(
+          Schema.decodeTo(
+            Schema.Unknown,
             SchemaTransformation.transform({
               decode: (a) => a === undefined ? null : a,
               encode: (a) => a === null ? undefined : a
-            }) as any :
-            undefined
-        ))
-      }
-      case "FormUrlEncoded":
-        return StringFromArrayBuffer.pipe(
-          Schema.decodeTo(UrlParams.schemaRecord),
-          Schema.decodeTo(schema)
+            }) as any
+          )
         )
-      case "Uint8Array":
-        return Uint8ArrayFromArrayBuffer.pipe(Schema.decodeTo(schema))
-      case "Text":
-        return StringFromArrayBuffer.pipe(Schema.decodeTo(schema))
+        : UnknownFromArrayBuffer
     }
+    case "FormUrlEncoded":
+      return StringFromArrayBuffer.pipe(Schema.decodeTo(UrlParams.schemaRecord))
+    case "Uint8Array":
+      return Uint8ArrayFromArrayBuffer
+    case "Text":
+      return StringFromArrayBuffer
   }
 }
 

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -363,37 +363,17 @@ export const makeClient = <ApiId extends string, Groups extends HttpApiGroup.Con
         }
 
         const successAlternatives = new Map<number, Array<ResponseAlternative>>()
-        const successSchemasByStatus = new Map<number, [Schema.Top, ...Array<Schema.Top>]>()
         for (const [status, schemas] of successes.entries()) {
-          for (const schema of schemas) {
-            if (HttpApiSchema.isWithHeaders(schema) && HttpApiSchema.isStreamSchema(schema.schema)) {
-              continue
-            }
-            const schemaStatus = HttpApiSchema.isWithHeaders(schema)
-              ? HttpApiSchema.getStatusSuccessSchema(schema)
-              : status
-            const existing = successSchemasByStatus.get(schemaStatus)
-            if (existing === undefined) {
-              successSchemasByStatus.set(schemaStatus, [schema])
-            } else {
-              existing.push(schema)
-            }
-          }
-        }
-        for (const [status, schemas] of successSchemasByStatus.entries()) {
           const grouped = groupSchemasByContentType(schemas)
           for (const [contentType, schemas] of grouped.entries()) {
             addResponseAlternative(successAlternatives, status, contentType, schemasToResponse(schemas))
           }
         }
         for (const streamSuccess of getStreamSuccessSchemas(endpoint)) {
-          const isWithHeaders = isWithHeadersStreamSuccess(streamSuccess)
-          const streamSchema = isWithHeaders ? streamSuccess.schema : streamSuccess
+          const streamSchema = isWithHeadersStreamSuccess(streamSuccess) ? streamSuccess.schema : streamSuccess
           addResponseAlternative(
             successAlternatives,
-            isWithHeaders
-              ? HttpApiSchema.getStatusSuccessSchema(streamSuccess)
-              : HttpApiSchema.getStatusStream(streamSuccess),
+            HttpApiSchema.getStatusSuccessSchema(streamSuccess),
             streamSchema.contentType,
             streamToResponse(streamSuccess)
           )
@@ -772,8 +752,9 @@ function toCodecArrayBufferWithHeaders(schema: Schema.Constraint): Schema.Top {
       headers: Schema.toCodecStringTree(Schema.toEncoded(annotation.headers))
     }).pipe(Schema.decodeTo(schema))
   }
+  const body = isWithHeaders ? schema.schema : schema
   return Schema.Struct({
-    body: toCodecArrayBuffer([isWithHeaders ? schema.schema : schema]),
+    body: fromArrayBuffer(body).pipe(Schema.decodeTo(body)),
     headers: isWithHeaders ? schema.headers : Schema.Unknown
   }).pipe(
     Schema.decodeTo(

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -68,15 +68,19 @@ export type ForApi<Api extends HttpApi.Constraint, E = never, R = never> = Api e
   HttpApi.HttpApi<infer _Id, infer Groups> ? Client<Groups, E, R> :
   never
 
-type SuccessType<S> = S extends HttpApiSchema.StreamSse<
-  infer _Events,
-  infer _Error,
-  infer _Value
-> ? Stream.Stream<
-    _Value,
-    _Error["Type"] | HttpClientError.HttpClientError | Schema.SchemaError | Sse.Retry | Sse.SseError,
-    never
-  >
+type SuccessType<S> = S extends HttpApiSchema.WithHeaders<
+  infer _Inner,
+  infer _Headers
+> ? HttpApiSchema.WithHeaders.Value<SuccessType<_Inner>, _Headers["Type"]>
+  : S extends HttpApiSchema.StreamSse<
+    infer _Events,
+    infer _Error,
+    infer _Value
+  > ? Stream.Stream<
+      _Value,
+      _Error["Type"] | HttpClientError.HttpClientError | Schema.SchemaError | Sse.Retry | Sse.SseError,
+      never
+    >
   : S extends HttpApiSchema.StreamUint8Array ? Stream.Stream<Uint8Array, HttpClientError.HttpClientError, never>
   : S extends Schema.Constraint ? S["Type"]
   : never
@@ -362,6 +366,9 @@ export const makeClient = <ApiId extends string, Groups extends HttpApiGroup.Con
         const successSchemasByStatus = new Map<number, [Schema.Top, ...Array<Schema.Top>]>()
         for (const [status, schemas] of successes.entries()) {
           for (const schema of schemas) {
+            if (HttpApiSchema.isWithHeaders(schema) && HttpApiSchema.isStreamSchema(schema.schema)) {
+              continue
+            }
             const schemaStatus = HttpApiSchema.isWithHeaders(schema)
               ? HttpApiSchema.getStatusSuccessSchema(schema)
               : status
@@ -380,10 +387,14 @@ export const makeClient = <ApiId extends string, Groups extends HttpApiGroup.Con
           }
         }
         for (const streamSuccess of getStreamSuccessSchemas(endpoint)) {
+          const isWithHeaders = isWithHeadersStreamSuccess(streamSuccess)
+          const streamSchema = isWithHeaders ? streamSuccess.schema : streamSuccess
           addResponseAlternative(
             successAlternatives,
-            HttpApiSchema.getStatusStream(streamSuccess),
-            streamSuccess.contentType,
+            isWithHeaders
+              ? HttpApiSchema.getStatusSuccessSchema(streamSuccess)
+              : HttpApiSchema.getStatusStream(streamSuccess),
+            streamSchema.contentType,
             streamToResponse(streamSuccess)
           )
         }
@@ -851,24 +862,35 @@ function failUnsupportedContentType(
 
 const reservedStreamFailureEvent = "effect/httpapi/stream/failure"
 
-function getStreamSuccessSchemas(endpoint: HttpApiEndpoint.Top): Array<HttpApiSchema.StreamSchema> {
-  const schemas: Array<HttpApiSchema.StreamSchema> = []
+type StreamSuccessSchema =
+  | HttpApiSchema.StreamSchema
+  | HttpApiSchema.WithHeaders<HttpApiSchema.StreamSchema, Schema.Top>
+
+const isWithHeadersStreamSuccess = (
+  schema: StreamSuccessSchema
+): schema is HttpApiSchema.WithHeaders<HttpApiSchema.StreamSchema, Schema.Top> => HttpApiSchema.isWithHeaders(schema)
+
+function getStreamSuccessSchemas(endpoint: HttpApiEndpoint.Top): Array<StreamSuccessSchema> {
+  const schemas: Array<StreamSuccessSchema> = []
   for (const schema of endpoint.success) {
-    if (HttpApiSchema.isStreamSchema(schema)) {
-      schemas.push(schema)
+    const body = HttpApiSchema.isWithHeaders(schema) ? schema.schema : schema
+    if (HttpApiSchema.isStreamSchema(body)) {
+      schemas.push(schema as StreamSuccessSchema)
     }
   }
   return schemas
 }
 
-function streamToResponse(streamSchema: HttpApiSchema.StreamSchema) {
+function streamToResponse(successSchema: StreamSuccessSchema) {
+  const isWithHeaders = isWithHeadersStreamSuccess(successSchema)
+  const streamSchema = isWithHeaders ? successSchema.schema : successSchema
   const sse = HttpApiSchema.isStreamUint8Array(streamSchema)
     ? undefined
     : {
       declaration: streamSchema,
       decoder: makeSseDecoder(streamSchema)
     }
-  return (response: HttpClientResponse.HttpClientResponse) =>
+  const toStream = (response: HttpClientResponse.HttpClientResponse) =>
     Effect.map(Effect.context<never>(), (context) =>
       Stream.provideContext(
         sse === undefined ?
@@ -876,6 +898,14 @@ function streamToResponse(streamSchema: HttpApiSchema.StreamSchema) {
           decodeSseStream(response.stream, sse.declaration, sse.decoder),
         context as Context.Context<unknown>
       ))
+  if (!isWithHeaders) return toStream
+
+  const decodeHeaders = Schema.decodeUnknownEffect(successSchema.headers)
+  return (response: HttpClientResponse.HttpClientResponse) =>
+    Effect.flatMap(
+      decodeHeaders(response.headers),
+      (headers) => Effect.map(toStream(response), (body) => HttpApiSchema.withHeaders({ body, headers }))
+    )
 }
 
 function makeSseDecoder(

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -749,7 +749,7 @@ function toCodecArrayBufferWithHeaders(schema: Schema.Constraint): Schema.Top {
   if (annotation !== undefined) {
     return Schema.Struct({
       body: fromArrayBuffer(annotation.body),
-      headers: annotation.headersCodec ?? Schema.toEncoded(annotation.headers)
+      headers: annotation.headersCodec
     }).pipe(Schema.decodeTo(schema))
   }
   const body = isWithHeaders ? schema.schema : schema

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -749,7 +749,7 @@ function toCodecArrayBufferWithHeaders(schema: Schema.Constraint): Schema.Top {
   if (annotation !== undefined) {
     return Schema.Struct({
       body: fromArrayBuffer(annotation.body),
-      headers: Schema.toCodecStringTree(Schema.toEncoded(annotation.headers))
+      headers: annotation.headersCodec ?? Schema.toEncoded(annotation.headers)
     }).pipe(Schema.decodeTo(schema))
   }
   const body = isWithHeaders ? schema.schema : schema

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -1180,6 +1180,7 @@ function getErrorResponse(
       throw new Error("Streaming schemas are not supported in error responses")
     }
   }
+  validateResponseExclusivity(schemas, HttpApiSchema.getStatusErrorSchema)
   return new Set(disableCodecs ? schemas : schemas.map(transformResponseSchema))
 }
 
@@ -1232,6 +1233,8 @@ function validateSuccessResponse(schemas: ReadonlyArray<Schema.Constraint>, meth
       entry.noContent = entry.noContent || noContent
     }
   }
+
+  validateResponseExclusivity(schemas, HttpApiSchema.getStatusSuccessSchema)
 }
 
 function getStatusEntry(
@@ -1248,6 +1251,39 @@ function getStatusEntry(
     statuses.set(status, entry)
   }
   return entry
+}
+
+function validateResponseExclusivity(
+  schemas: ReadonlyArray<Schema.Constraint>,
+  getStatus: (schema: Schema.Constraint) => number
+) {
+  const occupied = new Map<string, boolean>()
+  for (const schema of schemas) {
+    const status = getStatus(schema)
+    const withHeadersAnnotation = HttpApiSchema.getWithHeadersAnnotation(schema.ast)
+    const body = HttpApiSchema.isWithHeaders(schema) ? schema.schema : withHeadersAnnotation?.body ?? schema
+    const contentType = HttpApiSchema.isNoContent(body.ast)
+      ? ""
+      : MediaType.normalize(
+        HttpApiSchema.isStreamSchema(body)
+          ? body.contentType
+          : HttpApiSchema.getResponseEncodingSchema(schema).contentType
+      )
+    const key = `${status} ${contentType}`
+    const withHeaders = HttpApiSchema.isWithHeaders(schema) || withHeadersAnnotation !== undefined
+    const existing = occupied.get(key)
+    if (existing !== undefined) {
+      if (withHeaders || existing) {
+        throw new Error(
+          `Cannot combine a response with headers with another response for status ${status} and content-type: ${
+            contentType || "<no content>"
+          }`
+        )
+      }
+    } else {
+      occupied.set(key, withHeaders)
+    }
+  }
 }
 
 function validateStreamSuccess(schema: HttpApiSchema.StreamSchema, method: HttpMethod) {

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -47,7 +47,7 @@ export const isHttpApiEndpoint = (u: unknown): u is Top => Predicate.hasProperty
 type SuccessType<S> = S extends HttpApiSchema.WithHeaders<
   infer _Inner,
   infer _Headers
-> ? HttpApiSchema.WithHeaders.Value<SuccessType<_Inner>, _Headers["Type"]>
+> ? HttpApiSchema.withHeaders<SuccessType<_Inner>, _Headers["Type"]>
   : S extends HttpApiSchema.StreamSse<
     infer _Events,
     infer _Error,

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -1272,17 +1272,14 @@ function validateResponseExclusivity(
     const key = `${status} ${contentType}`
     const withHeaders = HttpApiSchema.isWithHeaders(schema) || withHeadersAnnotation !== undefined
     const existing = occupied.get(key)
-    if (existing !== undefined) {
-      if (withHeaders || existing) {
-        throw new Error(
-          `Cannot combine a response with headers with another response for status ${status} and content-type: ${
-            contentType || "<no content>"
-          }`
-        )
-      }
-    } else {
-      occupied.set(key, withHeaders)
+    if (existing !== undefined && (existing || withHeaders)) {
+      throw new Error(
+        `Cannot combine a response with headers with another response for status ${status} and content-type: ${
+          contentType || "<no content>"
+        }`
+      )
     }
+    occupied.set(key, withHeaders)
   }
 }
 

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -1185,6 +1185,7 @@ function getErrorResponse(
 }
 
 function validateSuccessResponse(schemas: ReadonlyArray<Schema.Constraint>, method: HttpMethod) {
+  let hasStream = false
   const statuses = new Map<number, {
     readonly stream?: HttpApiSchema.StreamSchema | undefined
     bufferedContentTypes: Set<string>
@@ -1196,10 +1197,11 @@ function validateSuccessResponse(schemas: ReadonlyArray<Schema.Constraint>, meth
     const status = HttpApiSchema.getStatusSuccessSchema(schema)
     if (HttpApiSchema.isStreamSchema(inner)) {
       validateStreamSuccess(inner, method)
-      const entry = getStatusEntry(statuses, status)
-      if (entry.stream !== undefined) {
-        throw new Error(`Multiple streaming success responses for status: ${status}`)
+      if (hasStream) {
+        throw new Error("Multiple streaming success responses are not supported")
       }
+      hasStream = true
+      const entry = getStatusEntry(statuses, status)
       if (entry.noContent) {
         throw new Error(`Cannot combine no-content and streaming success responses for status: ${status}`)
       }

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -44,11 +44,15 @@ const TypeId = "~effect/httpapi/HttpApiEndpoint"
  */
 export const isHttpApiEndpoint = (u: unknown): u is Top => Predicate.hasProperty(u, TypeId)
 
-type SuccessType<S> = S extends HttpApiSchema.StreamSse<
-  infer _Events,
-  infer _Error,
-  infer _Value
-> ? Stream.Stream<_Value, _Error["Type"], never>
+type SuccessType<S> = S extends HttpApiSchema.WithHeaders<
+  infer _Inner,
+  infer _Headers
+> ? HttpApiSchema.WithHeaders.Value<SuccessType<_Inner>, _Headers["Type"]>
+  : S extends HttpApiSchema.StreamSse<
+    infer _Events,
+    infer _Error,
+    infer _Value
+  > ? Stream.Stream<_Value, _Error["Type"], never>
   : S extends HttpApiSchema.StreamUint8Array ? Stream.Stream<Uint8Array, unknown, never>
   : S extends Schema.Constraint ? S["Type"]
   : never
@@ -75,15 +79,24 @@ type UnwrapReadonlyArray<S> = S extends ReadonlyArray<infer A> ? A : S
 
 type ExtractBufferedSuccess<S extends SuccessConstraint> = Exclude<
   Extract<UnwrapReadonlyArray<S>, Schema.Top>,
-  HttpApiSchema.StreamSchema
+  HttpApiSchema.StreamSchema | HttpApiSchema.WithHeaders<Schema.Top, Schema.Top>
 >
 
 type ExtractStreamSuccess<S extends SuccessConstraint> = UnwrapReadonlyArray<S> extends infer Success ?
   Success extends HttpApiSchema.StreamSchema ? Success : never
   : never
 
-type ToSuccessCodec<S extends SuccessConstraint> = [ExtractBufferedSuccess<S>] extends [never] ? ExtractStreamSuccess<S>
-  : Schema.toCodecJson<ExtractBufferedSuccess<S>> | ExtractStreamSuccess<S>
+type ExtractWithHeadersSuccess<S extends SuccessConstraint> = UnwrapReadonlyArray<S> extends infer Success ?
+  Success extends HttpApiSchema.WithHeaders<infer _Inner, infer _Headers> ? HttpApiSchema.WithHeaders<
+      _Inner extends HttpApiSchema.StreamSchema ? _Inner : Schema.toCodecJson<_Inner>,
+      Schema.toCodecStringTree<_Headers>
+    > :
+  never
+  : never
+
+type ToSuccessCodec<S extends SuccessConstraint> = [ExtractBufferedSuccess<S>] extends [never] ?
+  ExtractStreamSuccess<S> | ExtractWithHeadersSuccess<S>
+  : Schema.toCodecJson<ExtractBufferedSuccess<S>> | ExtractStreamSuccess<S> | ExtractWithHeadersSuccess<S>
 
 type ToJsonCodec<S> = [S] extends [never] ? never
   : [S] extends [Schema.Constraint] ? Schema.toCodecJson<S>
@@ -1139,11 +1152,18 @@ function getSuccessResponse(
   if (success === undefined) return new Set()
   const schemas = Arr.ensure(success)
   validateSuccessResponse(schemas, method)
-  return new Set(
-    disableCodecs ?
-      schemas :
-      schemas.map((schema) => HttpApiSchema.isStreamSchema(schema) ? schema : transformResponse(schema))
-  )
+  return new Set(disableCodecs ? schemas : schemas.map(transformSuccess))
+}
+
+function transformSuccess(schema: Schema.Top): Schema.Top {
+  if (HttpApiSchema.isStreamSchema(schema)) return schema
+  if (HttpApiSchema.isWithHeaders(schema)) {
+    const inner = HttpApiSchema.isStreamSchema(schema.schema)
+      ? schema.schema
+      : applyResponseEncoding(schema.schema, HttpApiSchema.getResponseEncodingSchema(schema))
+    return HttpApiSchema.rebuildWithHeaders(schema, inner, Schema.toCodecStringTree(schema.headers))
+  }
+  return transformResponse(schema)
 }
 
 function getErrorResponse(
@@ -1155,6 +1175,9 @@ function getErrorResponse(
   for (const schema of schemas) {
     if (HttpApiSchema.isStreamSchema(schema)) {
       throw new Error("Streaming schemas are not supported in error responses")
+    }
+    if (HttpApiSchema.isWithHeaders(schema)) {
+      throw new Error("WithHeaders is not supported in error responses, use encodeToWithHeaders instead")
     }
   }
   return new Set(disableCodecs ? schemas : schemas.map(transformResponse))
@@ -1168,9 +1191,10 @@ function validateSuccessResponse(schemas: ReadonlyArray<Schema.Constraint>, meth
   }>()
 
   for (const schema of schemas) {
-    if (HttpApiSchema.isStreamSchema(schema)) {
-      validateStreamSuccess(schema, method)
-      const status = HttpApiSchema.getStatusStream(schema)
+    const inner = HttpApiSchema.isWithHeaders(schema) ? schema.schema : schema
+    const status = HttpApiSchema.getStatusSuccessSchema(schema)
+    if (HttpApiSchema.isStreamSchema(inner)) {
+      validateStreamSuccess(inner, method)
       const entry = getStatusEntry(statuses, status)
       if (entry.stream !== undefined) {
         throw new Error(`Multiple streaming success responses for status: ${status}`)
@@ -1178,21 +1202,20 @@ function validateSuccessResponse(schemas: ReadonlyArray<Schema.Constraint>, meth
       if (entry.noContent) {
         throw new Error(`Cannot combine no-content and streaming success responses for status: ${status}`)
       }
-      if (entry.bufferedContentTypes.has(MediaType.normalize(schema.contentType))) {
+      if (entry.bufferedContentTypes.has(MediaType.normalize(inner.contentType))) {
         throw new Error(
-          `Cannot combine buffered and streaming success responses for status ${status} and content-type: ${schema.contentType}`
+          `Cannot combine buffered and streaming success responses for status ${status} and content-type: ${inner.contentType}`
         )
       }
-      statuses.set(status, { ...entry, stream: schema })
+      statuses.set(status, { ...entry, stream: inner })
     } else {
-      const status = HttpApiSchema.getStatusSuccess(schema.ast)
       const entry = getStatusEntry(statuses, status)
-      const noContent = HttpApiSchema.isNoContent(schema.ast)
+      const noContent = HttpApiSchema.isNoContent(inner.ast)
       if (entry.stream !== undefined) {
         if (noContent) {
           throw new Error(`Cannot combine no-content and streaming success responses for status: ${status}`)
         }
-        const encoding = HttpApiSchema.getResponseEncoding(schema.ast)
+        const encoding = HttpApiSchema.getResponseEncodingSchema(schema)
         if (
           MediaType.normalize(encoding.contentType) === MediaType.normalize(entry.stream.contentType)
         ) {
@@ -1203,7 +1226,7 @@ function validateSuccessResponse(schemas: ReadonlyArray<Schema.Constraint>, meth
       }
       if (!noContent) {
         entry.bufferedContentTypes.add(
-          MediaType.normalize(HttpApiSchema.getResponseEncoding(schema.ast).contentType)
+          MediaType.normalize(HttpApiSchema.getResponseEncodingSchema(schema).contentType)
         )
       }
       entry.noContent = entry.noContent || noContent
@@ -1274,7 +1297,10 @@ function hasReservedEventLiteral(ast: AST.AST, seen: Set<AST.AST>): boolean {
 }
 
 function transformResponse(schema: Schema.Top): Schema.Top {
-  const encoding = HttpApiSchema.getResponseEncoding(schema.ast)
+  return applyResponseEncoding(schema, HttpApiSchema.getResponseEncoding(schema.ast))
+}
+
+function applyResponseEncoding(schema: Schema.Top, encoding: HttpApiSchema.ResponseEncoding): Schema.Top {
   switch (encoding._tag) {
     case "Json":
       return Schema.toCodecJson(schema)

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -1335,7 +1335,7 @@ function transformResponse(schema: Schema.Top): Schema.Top {
   return withHeaders === undefined ? transformed : transformed.annotate({
     "~httpApiWithHeaders": {
       ...withHeaders,
-      headersCodec: Schema.toCodecStringTree(withHeaders.headers)
+      headersCodec: Schema.toCodecStringTree(Schema.toEncoded(withHeaders.headers))
     }
   })
 }

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -1258,6 +1258,7 @@ function validateResponseExclusivity(
   getStatus: (schema: Schema.Constraint) => number
 ) {
   const occupied = new Map<string, boolean>()
+  const withHeadersStatuses = new Set<number>()
   for (const schema of schemas) {
     const status = getStatus(schema)
     const withHeadersAnnotation = HttpApiSchema.getWithHeadersAnnotation(schema.ast)
@@ -1271,6 +1272,12 @@ function validateResponseExclusivity(
       )
     const key = `${status} ${contentType}`
     const withHeaders = HttpApiSchema.isWithHeaders(schema) || withHeadersAnnotation !== undefined
+    if (withHeaders) {
+      if (withHeadersStatuses.has(status)) {
+        throw new Error(`Cannot declare multiple responses with headers for status ${status}`)
+      }
+      withHeadersStatuses.add(status)
+    }
     const existing = occupied.get(key)
     if (existing !== undefined && (existing || withHeaders)) {
       throw new Error(

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -958,9 +958,11 @@ export type SuccessConstraint = Schema.Top | ReadonlyArray<Schema.Top>
  */
 export type ErrorConstraint = Schema.Top | ReadonlyArray<Schema.Top>
 
+type ErrorSchema<S> = S extends HttpApiSchema.WithHeaders<infer Inner, Schema.Top> ? Inner : S
+
 type ErrorNoStream<S extends ErrorConstraint> = [
   Extract<
-    S extends ReadonlyArray<Schema.Constraint> ? S[number] : S,
+    ErrorSchema<S extends ReadonlyArray<Schema.Constraint> ? S[number] : S>,
     HttpApiSchema.StreamSchema
   >
 ] extends [never] ? S : never
@@ -1173,14 +1175,18 @@ function getErrorResponse(
   if (error === undefined) return new Set()
   const schemas = Arr.ensure(error)
   for (const schema of schemas) {
-    if (HttpApiSchema.isStreamSchema(schema)) {
+    const body = HttpApiSchema.isWithHeaders(schema) ? schema.schema : schema
+    if (HttpApiSchema.isStreamSchema(body)) {
       throw new Error("Streaming schemas are not supported in error responses")
     }
-    if (HttpApiSchema.isWithHeaders(schema)) {
-      throw new Error("WithHeaders is not supported in error responses, use encodeToWithHeaders instead")
-    }
   }
-  return new Set(disableCodecs ? schemas : schemas.map(transformResponse))
+  return new Set(disableCodecs ? schemas : schemas.map(transformError))
+}
+
+function transformError(schema: Schema.Top): Schema.Top {
+  if (!HttpApiSchema.isWithHeaders(schema)) return transformResponse(schema)
+  const inner = applyResponseEncoding(schema.schema, HttpApiSchema.getResponseEncodingSchema(schema))
+  return HttpApiSchema.rebuildWithHeaders(schema, inner, Schema.toCodecStringTree(schema.headers))
 }
 
 function validateSuccessResponse(schemas: ReadonlyArray<Schema.Constraint>, method: HttpMethod) {

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -1154,10 +1154,10 @@ function getSuccessResponse(
   if (success === undefined) return new Set()
   const schemas = Arr.ensure(success)
   validateSuccessResponse(schemas, method)
-  return new Set(disableCodecs ? schemas : schemas.map(transformSuccess))
+  return new Set(disableCodecs ? schemas : schemas.map(transformResponseSchema))
 }
 
-function transformSuccess(schema: Schema.Top): Schema.Top {
+function transformResponseSchema(schema: Schema.Top): Schema.Top {
   if (HttpApiSchema.isStreamSchema(schema)) return schema
   if (HttpApiSchema.isWithHeaders(schema)) {
     const inner = HttpApiSchema.isStreamSchema(schema.schema)
@@ -1180,13 +1180,7 @@ function getErrorResponse(
       throw new Error("Streaming schemas are not supported in error responses")
     }
   }
-  return new Set(disableCodecs ? schemas : schemas.map(transformError))
-}
-
-function transformError(schema: Schema.Top): Schema.Top {
-  if (!HttpApiSchema.isWithHeaders(schema)) return transformResponse(schema)
-  const inner = applyResponseEncoding(schema.schema, HttpApiSchema.getResponseEncodingSchema(schema))
-  return HttpApiSchema.rebuildWithHeaders(schema, inner, Schema.toCodecStringTree(schema.headers))
+  return new Set(disableCodecs ? schemas : schemas.map(transformResponseSchema))
 }
 
 function validateSuccessResponse(schemas: ReadonlyArray<Schema.Constraint>, method: HttpMethod) {

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -1330,9 +1330,19 @@ function hasReservedEventLiteral(ast: AST.AST, seen: Set<AST.AST>): boolean {
 }
 
 function transformResponse(schema: Schema.Top): Schema.Top {
-  const transformed = applyResponseEncoding(schema, HttpApiSchema.getResponseEncoding(schema.ast))
   const withHeaders = HttpApiSchema.getWithHeadersAnnotation(schema.ast)
-  return withHeaders === undefined ? transformed : transformed.annotate({
+  if (withHeaders === undefined) {
+    return applyResponseEncoding(schema, HttpApiSchema.getResponseEncoding(schema.ast))
+  }
+  const body = applyResponseEncoding(
+    Schema.toEncoded(withHeaders.body),
+    HttpApiSchema.getResponseEncoding(schema.ast)
+  )
+  const transformed = Schema.Struct({
+    body,
+    headers: Schema.toEncoded(withHeaders.headers)
+  }).pipe(Schema.decodeTo(schema))
+  return transformed.annotate({
     "~httpApiWithHeaders": {
       ...withHeaders,
       headersCodec: Schema.toCodecStringTree(Schema.toEncoded(withHeaders.headers))

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -1297,7 +1297,14 @@ function hasReservedEventLiteral(ast: AST.AST, seen: Set<AST.AST>): boolean {
 }
 
 function transformResponse(schema: Schema.Top): Schema.Top {
-  return applyResponseEncoding(schema, HttpApiSchema.getResponseEncoding(schema.ast))
+  const transformed = applyResponseEncoding(schema, HttpApiSchema.getResponseEncoding(schema.ast))
+  const withHeaders = HttpApiSchema.getWithHeadersAnnotation(schema.ast)
+  return withHeaders === undefined ? transformed : transformed.annotate({
+    "~httpApiWithHeaders": {
+      ...withHeaders,
+      headersCodec: Schema.toCodecStringTree(withHeaders.headers)
+    }
+  })
 }
 
 function applyResponseEncoding(schema: Schema.Top, encoding: HttpApiSchema.ResponseEncoding): Schema.Top {

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -1257,8 +1257,10 @@ function validateResponseExclusivity(
   schemas: ReadonlyArray<Schema.Constraint>,
   getStatus: (schema: Schema.Constraint) => number
 ) {
-  const occupied = new Map<string, boolean>()
-  const withHeadersStatuses = new Set<number>()
+  const statuses = new Map<number, {
+    headerContentType: string | undefined
+    readonly plainContentTypes: Set<string>
+  }>()
   for (const schema of schemas) {
     const status = getStatus(schema)
     const withHeadersAnnotation = HttpApiSchema.getWithHeadersAnnotation(schema.ast)
@@ -1270,23 +1272,27 @@ function validateResponseExclusivity(
           ? body.contentType
           : HttpApiSchema.getResponseEncodingSchema(schema).contentType
       )
-    const key = `${status} ${contentType}`
-    const withHeaders = HttpApiSchema.isWithHeaders(schema) || withHeadersAnnotation !== undefined
-    if (withHeaders) {
-      if (withHeadersStatuses.has(status)) {
-        throw new Error(`Cannot declare multiple responses with headers for status ${status}`)
-      }
-      withHeadersStatuses.add(status)
+    let entry = statuses.get(status)
+    if (entry === undefined) {
+      entry = { headerContentType: undefined, plainContentTypes: new Set() }
+      statuses.set(status, entry)
     }
-    const existing = occupied.get(key)
-    if (existing !== undefined && (existing || withHeaders)) {
-      throw new Error(
+    const combineError = () =>
+      new Error(
         `Cannot combine a response with headers with another response for status ${status} and content-type: ${
           contentType || "<no content>"
         }`
       )
+    if (HttpApiSchema.isWithHeaders(schema) || withHeadersAnnotation !== undefined) {
+      if (entry.headerContentType !== undefined) {
+        throw new Error(`Cannot declare multiple responses with headers for status ${status}`)
+      }
+      if (entry.plainContentTypes.has(contentType)) throw combineError()
+      entry.headerContentType = contentType
+    } else {
+      if (entry.headerContentType === contentType) throw combineError()
+      entry.plainContentTypes.add(contentType)
     }
-    occupied.set(key, withHeaders)
   }
 }
 
@@ -1337,22 +1343,19 @@ function hasReservedEventLiteral(ast: AST.AST, seen: Set<AST.AST>): boolean {
 }
 
 function transformResponse(schema: Schema.Top): Schema.Top {
+  const encoding = HttpApiSchema.getResponseEncoding(schema.ast)
   const withHeaders = HttpApiSchema.getWithHeadersAnnotation(schema.ast)
   if (withHeaders === undefined) {
-    return applyResponseEncoding(schema, HttpApiSchema.getResponseEncoding(schema.ast))
+    return applyResponseEncoding(schema, encoding)
   }
-  const body = applyResponseEncoding(
-    Schema.toEncoded(withHeaders.body),
-    HttpApiSchema.getResponseEncoding(schema.ast)
-  )
-  const transformed = Schema.Struct({
-    body,
-    headers: Schema.toEncoded(withHeaders.headers)
-  }).pipe(Schema.decodeTo(schema))
-  return transformed.annotate({
+  const headers = Schema.toEncoded(withHeaders.headers)
+  return Schema.Struct({
+    body: applyResponseEncoding(Schema.toEncoded(withHeaders.body), encoding),
+    headers
+  }).pipe(Schema.decodeTo(schema)).annotate({
     "~httpApiWithHeaders": {
       ...withHeaders,
-      headersCodec: Schema.toCodecStringTree(Schema.toEncoded(withHeaders.headers))
+      headersCodec: Schema.toCodecStringTree(headers)
     }
   })
 }

--- a/packages/effect/src/unstable/httpapi/HttpApiError.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiError.ts
@@ -437,15 +437,15 @@ export type HttpApiSchemaErrorTypeId = "~effect/httpapi/HttpApiError/HttpApiSche
 export const HttpApiSchemaErrorTypeId: HttpApiSchemaErrorTypeId = "~effect/httpapi/HttpApiError/HttpApiSchemaError"
 
 /**
- * Error raised when an HTTP API request component fails schema decoding. It records
- * which component failed and responds as an empty `400 Bad Request` when rendered
- * as a server response.
+ * Error raised when an HTTP API request or response component fails schema
+ * decoding or encoding. It records which component failed and responds as an
+ * empty `400 Bad Request` when rendered as a server response.
  *
  * @category errors
  * @since 4.0.0
  */
 export class HttpApiSchemaError extends Data.TaggedClass("HttpApiSchemaError")<{
-  readonly kind: "Params" | "Headers" | "Query" | "Body" | "Payload"
+  readonly kind: "Params" | "Headers" | "Query" | "Body" | "Payload" | "ResponseHeaders"
   readonly cause: Schema.SchemaError
 }> {
   readonly [HttpApiSchemaErrorTypeId]: HttpApiSchemaErrorTypeId = HttpApiSchemaErrorTypeId

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -536,9 +536,10 @@ export type WithHeadersValueTypeId = typeof WithHeadersValueTypeId
  *   wire and `undefined` leaves are omitted from the response.
  * - Status and response-encoding annotations are resolved from the wrapper
  *   first, falling through to the inner schema.
- * - When a success union has multiple `WithHeaders` members, header encoding
- *   uses the first matching union member. Keep their header shapes disjoint so
- *   a value cannot encode against the wrong member.
+ * - A header-carrying response cannot share its status and content type with
+ *   another response in the same success or error union. Endpoint construction
+ *   rejects ambiguous declarations, including those made with
+ *   {@link encodeToWithHeaders}.
  * - `Rebuild` preserves the brand and both parts, so `.annotate` keeps the
  *   wrapper intact.
  *

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -548,8 +548,8 @@ export type WithHeadersValueTypeId = typeof WithHeadersValueTypeId
  */
 export interface WithHeaders<S extends Schema.Top, H extends Schema.Top> extends
   Schema.Bottom<
-    WithHeaders.Value<S["Type"], H["Type"]>,
-    WithHeaders.Value<S["Encoded"], Schema.StringTree>,
+    withHeaders<S["Type"], H["Type"]>,
+    withHeaders<S["Encoded"], Schema.StringTree>,
     S["DecodingServices"] | H["DecodingServices"],
     S["EncodingServices"] | H["EncodingServices"],
     SchemaAST.Declaration,
@@ -563,31 +563,23 @@ export interface WithHeaders<S extends Schema.Top, H extends Schema.Top> extends
 }
 
 /**
- * Namespace for `WithHeaders` types.
+ * The Type of a `WithHeaders` schema: what handlers return and what the
+ * client resolves to, constructed via {@link withHeaders}.
+ *
+ * `body` is the inner success value. For stream success schemas it is the
+ * `Stream` itself, so headers are decided before the body starts streaming.
  *
  * @category models
  * @since 4.0.0
  */
-export declare namespace WithHeaders {
-  /**
-   * The Type of a `WithHeaders` schema: what handlers return and what the
-   * client resolves to, constructed via {@link withHeaders}.
-   *
-   * `body` is the inner success value. For stream success schemas it is the
-   * `Stream` itself, so headers are decided before the body starts streaming.
-   *
-   * @category models
-   * @since 4.0.0
-   */
-  export interface Value<A, H> {
-    readonly [WithHeadersValueTypeId]: WithHeadersValueTypeId
-    readonly body: A
-    readonly headers: H
-  }
+export interface withHeaders<A, H> {
+  readonly [WithHeadersValueTypeId]: WithHeadersValueTypeId
+  readonly body: A
+  readonly headers: H
 }
 
 /** @internal */
-export const isWithHeadersValue = (u: unknown): u is WithHeaders.Value<unknown, unknown> =>
+export const isWithHeadersValue = (u: unknown): u is withHeaders<unknown, unknown> =>
   Predicate.hasProperty(u, WithHeadersValueTypeId)
 
 const withHeadersValueSchema = Schema.declare(isWithHeadersValue)
@@ -656,7 +648,7 @@ export function WithHeaders(
 export const withHeaders = <A, H>(options: {
   readonly body: A
   readonly headers: H
-}): WithHeaders.Value<A, H> => ({
+}): withHeaders<A, H> => ({
   [WithHeadersValueTypeId]: WithHeadersValueTypeId,
   body: options.body,
   headers: options.headers

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -517,18 +517,20 @@ export const WithHeadersValueTypeId = "~effect/httpapi/HttpApiSchema/WithHeaders
 export type WithHeadersValueTypeId = typeof WithHeadersValueTypeId
 
 /**
- * A success response schema wrapping a body schema together with a response
- * headers schema.
+ * A response schema wrapping a body schema together with a response headers
+ * schema.
  *
  * **Details**
  *
  * `WithHeaders` is a branded declaration schema: it carries the inner success
  * schema and the headers schema as properties, and server, client, and OpenAPI
- * integrations detect the brand and handle body and headers separately.
+ * integrations detect the brand and handle body and headers separately. It is
+ * supported for error responses, though {@link encodeToWithHeaders} is usually
+ * more convenient there because handlers can fail with the domain error value.
  *
- * - `schema` is the inner success schema. Anything valid as a success schema is
- *   valid here, including `StreamSse` and `StreamUint8Array`. Nesting
- *   `WithHeaders` is rejected at construction.
+ * - `schema` is the inner response schema. Success responses may wrap
+ *   `StreamSse` and `StreamUint8Array`; error responses remain non-streaming.
+ *   Nesting `WithHeaders` is rejected at construction.
  * - `headers` is any schema; integrations encode and decode it via
  *   `Schema.toCodecStringTree`, so leaves become `string | undefined` on the
  *   wire and `undefined` leaves are omitted from the response.
@@ -583,7 +585,8 @@ export declare namespace WithHeaders {
   }
 }
 
-const isWithHeadersValue = (u: unknown): u is WithHeaders.Value<unknown, unknown> =>
+/** @internal */
+export const isWithHeadersValue = (u: unknown): u is WithHeaders.Value<unknown, unknown> =>
   Predicate.hasProperty(u, WithHeadersValueTypeId)
 
 const withHeadersValueSchema = Schema.declare(isWithHeadersValue)
@@ -1067,4 +1070,12 @@ export function getStatusStream(self: StreamSchema): number {
 /** @internal */
 export function getStatusError(self: SchemaAST.AST): number {
   return resolveHttpApiStatus(self) ?? 500
+}
+
+/** @internal */
+export function getStatusErrorSchema(schema: Schema.Constraint): number {
+  if (isWithHeaders(schema)) {
+    return resolveHttpApiStatus(schema.ast) ?? getStatusError(schema.schema.ast)
+  }
+  return getStatusError(schema.ast)
 }

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -534,6 +534,9 @@ export type WithHeadersValueTypeId = typeof WithHeadersValueTypeId
  *   wire and `undefined` leaves are omitted from the response.
  * - Status and response-encoding annotations are resolved from the wrapper
  *   first, falling through to the inner schema.
+ * - When a success union has multiple `WithHeaders` members, header encoding
+ *   uses the first matching union member. Keep their header shapes disjoint so
+ *   a value cannot encode against the wrong member.
  * - `Rebuild` preserves the brand and both parts, so `.annotate` keeps the
  *   wrapper intact.
  *
@@ -591,13 +594,21 @@ const withHeadersValueSchema = Schema.declare(isWithHeadersValue)
  * Headers accept either a schema or a fields shorthand, mirroring the
  * request-side headers option.
  *
- * ```ts
+ * ```ts import.meta.vitest
  * import { Schema } from "effect"
  * import { HttpApiSchema } from "effect/unstable/httpapi"
  *
  * const schema = HttpApiSchema.WithHeaders(Schema.String, {
  *   "x-total-count": Schema.FiniteFromString
  * })
+ * const response: typeof schema.Type = HttpApiSchema.withHeaders({
+ *   body: "created",
+ *   headers: { "x-total-count": 1 }
+ * })
+ *
+ * HttpApiSchema.isWithHeaders(schema) // => true
+ * response.body // => "created"
+ * response.headers // => { "x-total-count": 1 }
  * ```
  *
  * @category constructors
@@ -632,6 +643,9 @@ export function WithHeaders(
  * including in mixed success unions. The same shape is used on both sides: a
  * value received from a client can be returned from another handler unchanged.
  *
+ * See {@link WithHeaders} for an example that constructs a schema and its
+ * corresponding response value.
+ *
  * @category constructors
  * @since 4.0.0
  */
@@ -646,6 +660,18 @@ export const withHeaders = <A, H>(options: {
 
 /**
  * Returns `true` when a schema is a `WithHeaders` response schema.
+ *
+ * ```ts import.meta.vitest
+ * import { Schema } from "effect"
+ * import { HttpApiSchema } from "effect/unstable/httpapi"
+ *
+ * const schema = HttpApiSchema.WithHeaders(Schema.String, {
+ *   "x-request-id": Schema.String
+ * })
+ *
+ * HttpApiSchema.isWithHeaders(schema) // => true
+ * HttpApiSchema.isWithHeaders(Schema.String) // => false
+ * ```
  *
  * @category predicates
  * @since 4.0.0
@@ -705,7 +731,7 @@ export interface encodeToWithHeaders<
  * defects on the client. Stream responses should use {@link WithHeaders},
  * which preserves the body stream's error channel in the generated client.
  *
- * ```ts
+ * ```ts import.meta.vitest
  * import { Schema } from "effect"
  * import { HttpApiSchema } from "effect/unstable/httpapi"
  *
@@ -727,6 +753,9 @@ export interface encodeToWithHeaders<
  *     })
  *   })
  * )
+ *
+ * const encoded = Schema.encodeSync(UserNotFoundWithHeaders)(new UserNotFound({ userId: 123 }))
+ * encoded // => { body: undefined, headers: { "x-user-id": 123 } }
  * ```
  *
  * @see {@link WithHeaders} for the structural wrapper recommended for success

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -47,6 +47,7 @@ declare module "../../Schema.ts" {
 export interface WithHeadersAnnotation {
   readonly body: Schema.Top
   readonly headers: Schema.Top
+  readonly headersCodec?: Schema.Top | undefined
 }
 
 /**
@@ -962,6 +963,9 @@ export const isNoContent = (ast: SchemaAST.AST): boolean => {
 }
 
 const resolveHttpApiEncoding = SchemaAST.resolveAt<Encoding>("~httpApiEncoding")
+
+/** @internal */
+export const getWithHeadersAnnotation = SchemaAST.resolveAt<WithHeadersAnnotation>("~httpApiWithHeaders")
 
 const resolveHttpApiStatus = SchemaAST.resolveAt<number>("httpApiStatus")
 

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -701,6 +701,10 @@ export interface encodeToWithHeaders<
  * The mappings are pure total functions: validation lives in the body and
  * header schemas, the mappings only reshape valid data.
  *
+ * Streams used as the body schema turn mid-stream transport errors into
+ * defects on the client. Stream responses should use {@link WithHeaders},
+ * which preserves the body stream's error channel in the generated client.
+ *
  * ```ts
  * import { Schema } from "effect"
  * import { HttpApiSchema } from "effect/unstable/httpapi"

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -1049,14 +1049,7 @@ export function getStatusSuccessSchema(schema: Schema.Constraint): number {
 
 /** @internal */
 export function getResponseEncodingSchema(schema: Schema.Constraint): ResponseEncoding {
-  if (isWithHeaders(schema)) {
-    const encoding = resolveHttpApiEncoding(schema.ast)
-    if (encoding !== undefined) {
-      if (encoding._tag === "Multipart") {
-        throw new Error("Multipart is not supported in response")
-      }
-      return encoding
-    }
+  if (isWithHeaders(schema) && resolveHttpApiEncoding(schema.ast) === undefined) {
     return getResponseEncoding(schema.schema.ast)
   }
   return getResponseEncoding(schema.ast)

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -29,8 +29,24 @@ declare module "../../Schema.ts" {
        * @internal
        */
       readonly "~httpApiEncoding"?: Encoding | undefined
+      /**
+       * Marks schemas produced by `encodeToWithHeaders`, carrying the body and
+       * headers schemas so integrations can split the encoded pair.
+       * @internal
+       */
+      readonly "~httpApiWithHeaders"?: WithHeadersAnnotation | undefined
     }
   }
+}
+
+/**
+ * Annotation payload attached by `encodeToWithHeaders`.
+ *
+ * @internal
+ */
+export interface WithHeadersAnnotation {
+  readonly body: Schema.Top
+  readonly headers: Schema.Top
 }
 
 /**
@@ -468,6 +484,286 @@ function defaultStreamContentType(mode: StreamMode): string {
 }
 
 /**
+ * Runtime brand key used to mark `WithHeaders` response schemas.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export const WithHeadersTypeId = "~effect/httpapi/HttpApiSchema/WithHeaders"
+
+/**
+ * Type-level brand identifier used by `WithHeaders`.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export type WithHeadersTypeId = typeof WithHeadersTypeId
+
+/**
+ * Runtime brand key used to mark `WithHeaders` response values.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export const WithHeadersValueTypeId = "~effect/httpapi/HttpApiSchema/WithHeadersValue"
+
+/**
+ * Type-level brand identifier used by `WithHeaders` response values.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export type WithHeadersValueTypeId = typeof WithHeadersValueTypeId
+
+/**
+ * A success response schema wrapping a body schema together with a response
+ * headers schema.
+ *
+ * **Details**
+ *
+ * `WithHeaders` is a branded declaration schema: it carries the inner success
+ * schema and the headers schema as properties, and server, client, and OpenAPI
+ * integrations detect the brand and handle body and headers separately.
+ *
+ * - `schema` is the inner success schema. Anything valid as a success schema is
+ *   valid here, including `StreamSse` and `StreamUint8Array`. Nesting
+ *   `WithHeaders` is rejected at construction.
+ * - `headers` is any schema; integrations encode and decode it via
+ *   `Schema.toCodecStringTree`, so leaves become `string | undefined` on the
+ *   wire and `undefined` leaves are omitted from the response.
+ * - Status and response-encoding annotations are resolved from the wrapper
+ *   first, falling through to the inner schema.
+ * - `Rebuild` preserves the brand and both parts, so `.annotate` keeps the
+ *   wrapper intact.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface WithHeaders<S extends Schema.Top, H extends Schema.Top> extends
+  Schema.Bottom<
+    WithHeaders.Value<S["Type"], H["Type"]>,
+    WithHeaders.Value<S["Encoded"], Schema.StringTree>,
+    S["DecodingServices"] | H["DecodingServices"],
+    S["EncodingServices"] | H["EncodingServices"],
+    SchemaAST.Declaration,
+    WithHeaders<S, H>
+  >
+{
+  readonly "Rebuild": WithHeaders<S, H>
+  readonly [WithHeadersTypeId]: typeof WithHeadersTypeId
+  readonly schema: S
+  readonly headers: H
+}
+
+/**
+ * Namespace for `WithHeaders` types.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export declare namespace WithHeaders {
+  /**
+   * The Type of a `WithHeaders` schema: what handlers return and what the
+   * client resolves to, constructed via {@link withHeaders}.
+   *
+   * `body` is the inner success value. For stream success schemas it is the
+   * `Stream` itself, so headers are decided before the body starts streaming.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Value<A, H> {
+    readonly [WithHeadersValueTypeId]: WithHeadersValueTypeId
+    readonly body: A
+    readonly headers: H
+  }
+}
+
+const isWithHeadersValue = (u: unknown): u is WithHeaders.Value<unknown, unknown> =>
+  Predicate.hasProperty(u, WithHeadersValueTypeId)
+
+const withHeadersValueSchema = Schema.declare(isWithHeadersValue)
+
+/**
+ * Wraps a success schema with a response headers schema.
+ *
+ * Headers accept either a schema or a fields shorthand, mirroring the
+ * request-side headers option.
+ *
+ * ```ts
+ * import { Schema } from "effect"
+ * import { HttpApiSchema } from "effect/unstable/httpapi"
+ *
+ * const schema = HttpApiSchema.WithHeaders(Schema.String, {
+ *   "x-total-count": Schema.FiniteFromString
+ * })
+ * ```
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export function WithHeaders<S extends Schema.Top, H extends Schema.Struct.Fields>(
+  schema: S,
+  headers: H
+): WithHeaders<S, Schema.Struct<H>>
+export function WithHeaders<S extends Schema.Top, H extends Schema.Top>(
+  schema: S,
+  headers: H
+): WithHeaders<S, H>
+export function WithHeaders(
+  schema: Schema.Top,
+  headers: Schema.Top | Schema.Struct.Fields
+): WithHeaders<Schema.Top, Schema.Top> {
+  if (isWithHeaders(schema)) {
+    throw new Error("WithHeaders schemas cannot be nested")
+  }
+  return Schema.make<WithHeaders<Schema.Top, Schema.Top>>(withHeadersValueSchema.ast, {
+    [WithHeadersTypeId]: WithHeadersTypeId,
+    schema,
+    headers: Schema.isSchema(headers) ? headers : Schema.Struct(headers)
+  })
+}
+
+/**
+ * Constructs a `WithHeaders` response value from a body and headers.
+ *
+ * The returned value is branded so servers and clients can detect it exactly,
+ * including in mixed success unions. The same shape is used on both sides: a
+ * value received from a client can be returned from another handler unchanged.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const withHeaders = <A, H>(options: {
+  readonly body: A
+  readonly headers: H
+}): WithHeaders.Value<A, H> => ({
+  [WithHeadersValueTypeId]: WithHeadersValueTypeId,
+  body: options.body,
+  headers: options.headers
+})
+
+/**
+ * Returns `true` when a schema is a `WithHeaders` response schema.
+ *
+ * @category predicates
+ * @since 4.0.0
+ */
+export const isWithHeaders = (u: unknown): u is WithHeaders<Schema.Top, Schema.Top> =>
+  Schema.isSchema(u) && Predicate.hasProperty(u, WithHeadersTypeId)
+
+/** @internal */
+export function rebuildWithHeaders(
+  self: WithHeaders<Schema.Top, Schema.Top>,
+  schema: Schema.Top,
+  headers: Schema.Top
+): WithHeaders<Schema.Top, Schema.Top> {
+  return Schema.make<WithHeaders<Schema.Top, Schema.Top>>(self.ast, {
+    [WithHeadersTypeId]: WithHeadersTypeId,
+    schema,
+    headers
+  })
+}
+
+/**
+ * Schema type returned by `encodeToWithHeaders`, encoding as a `{ body, headers }`
+ * pair while decoding to the source schema type.
+ *
+ * @category schemas
+ * @since 4.0.0
+ */
+export interface encodeToWithHeaders<
+  S extends Schema.Top,
+  Body extends Schema.Top,
+  Headers extends Schema.Struct.Fields
+> extends
+  Schema.decodeTo<
+    Schema.toType<S>,
+    Schema.Struct<{
+      readonly body: Body
+      readonly headers: Schema.Struct<Headers>
+    }>
+  >
+{}
+
+/**
+ * Encodes a schema as a `{ body, headers }` pair, folding response headers into
+ * an opaque domain type such as an error class.
+ *
+ * **Details**
+ *
+ * The encoded side is the pair of the body schema and the headers fields; the
+ * Type stays the source schema's Type. The body schema is authoritative for
+ * everything wire-level: status, content type, and response encoding resolve
+ * from the body schema's annotations.
+ *
+ * The mappings are pure total functions: validation lives in the body and
+ * header schemas, the mappings only reshape valid data.
+ *
+ * ```ts
+ * import { Schema } from "effect"
+ * import { HttpApiSchema } from "effect/unstable/httpapi"
+ *
+ * class UserNotFound extends Schema.TaggedError<UserNotFound>()("UserNotFound", {
+ *   userId: Schema.Int
+ * }) {}
+ *
+ * const UserNotFoundWithHeaders = UserNotFound.pipe(
+ *   HttpApiSchema.encodeToWithHeaders({
+ *     body: HttpApiSchema.Empty(404),
+ *     headers: {
+ *       "x-user-id": Schema.Int
+ *     }
+ *   }, {
+ *     decode: ({ headers }) => new UserNotFound({ userId: headers["x-user-id"] }),
+ *     encode: (error) => ({
+ *       headers: { "x-user-id": error.userId },
+ *       body: undefined
+ *     })
+ *   })
+ * )
+ * ```
+ *
+ * @see {@link WithHeaders} for the structural wrapper recommended for success
+ * responses, including streams.
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export function encodeToWithHeaders<
+  S extends Schema.Top,
+  Body extends Schema.Top,
+  Headers extends Schema.Struct.Fields
+>(options: {
+  readonly body: Body
+  readonly headers: Headers
+}, transformation: {
+  readonly decode: (
+    value: Schema.Struct.Type<{ readonly body: Body; readonly headers: Schema.Struct<Headers> }>
+  ) => S["Type"]
+  readonly encode: (
+    value: S["Type"]
+  ) => Schema.Struct.Type<{ readonly body: Body; readonly headers: Schema.Struct<Headers> }>
+}) {
+  return (self: S): encodeToWithHeaders<S, Body, Headers> => {
+    const body = options.body
+    const headers = Schema.Struct(options.headers)
+    const status = resolveHttpApiStatus(body.ast)
+    const encoding = resolveHttpApiEncoding(body.ast)
+    return Schema.Struct({ body, headers }).pipe(
+      Schema.decodeTo(
+        Schema.toType(self),
+        SchemaTransformation.transform(transformation)
+      )
+    ).annotate({
+      "~httpApiWithHeaders": { body, headers },
+      ...(status !== undefined ? { httpApiStatus: status } : undefined),
+      ...(encoding !== undefined ? { "~httpApiEncoding": encoding } : undefined)
+    })
+  }
+}
+
+/**
  * Runtime brand key used to mark schemas as buffered multipart payloads.
  *
  * @category type IDs
@@ -701,6 +997,29 @@ export function getResponseEncoding(ast: SchemaAST.AST): ResponseEncoding {
 /** @internal */
 export function getStatusSuccess(self: SchemaAST.AST): number {
   return resolveHttpApiStatus(self) ?? 200
+}
+
+/** @internal */
+export function getStatusSuccessSchema(schema: Schema.Constraint): number {
+  if (isWithHeaders(schema)) {
+    return resolveHttpApiStatus(schema.ast) ?? getStatusSuccess(schema.schema.ast)
+  }
+  return getStatusSuccess(schema.ast)
+}
+
+/** @internal */
+export function getResponseEncodingSchema(schema: Schema.Constraint): ResponseEncoding {
+  if (isWithHeaders(schema)) {
+    const encoding = resolveHttpApiEncoding(schema.ast)
+    if (encoding !== undefined) {
+      if (encoding._tag === "Multipart") {
+        throw new Error("Multipart is not supported in response")
+      }
+      return encoding
+    }
+    return getResponseEncoding(schema.schema.ast)
+  }
+  return getResponseEncoding(schema.ast)
 }
 
 /** @internal */

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -531,9 +531,9 @@ export type WithHeadersValueTypeId = typeof WithHeadersValueTypeId
  * - `schema` is the inner response schema. Success responses may wrap
  *   `StreamSse` and `StreamUint8Array`; error responses remain non-streaming.
  *   Nesting `WithHeaders` is rejected at construction.
- * - `headers` is any schema; integrations encode and decode it via
- *   `Schema.toCodecStringTree`, so leaves become `string | undefined` on the
- *   wire and `undefined` leaves are omitted from the response.
+ * - `headers` is any schema; endpoint construction applies
+ *   `Schema.toCodecStringTree` unless codecs are disabled, so leaves become
+ *   `string | undefined` on the wire and `undefined` leaves are omitted from the response.
  * - Status and response-encoding annotations are resolved from the wrapper
  *   first, falling through to the inner schema.
  * - A header-carrying response cannot share its status and content type with

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -47,7 +47,7 @@ declare module "../../Schema.ts" {
 export interface WithHeadersAnnotation {
   readonly body: Schema.Top
   readonly headers: Schema.Top
-  readonly headersCodec?: Schema.Top | undefined
+  readonly headersCodec: Schema.Top
 }
 
 /**
@@ -794,7 +794,7 @@ export function encodeToWithHeaders<
         SchemaTransformation.transform(transformation)
       )
     ).annotate({
-      "~httpApiWithHeaders": { body, headers },
+      "~httpApiWithHeaders": { body, headers, headersCodec: Schema.toEncoded(headers) },
       ...(status !== undefined ? { httpApiStatus: status } : undefined),
       ...(encoding !== undefined ? { "~httpApiEncoding": encoding } : undefined)
     })

--- a/packages/effect/src/unstable/httpapi/OpenApi.ts
+++ b/packages/effect/src/unstable/httpapi/OpenApi.ts
@@ -728,39 +728,36 @@ function extractResponseBodies(
     const body = HttpApiSchema.isWithHeaders(schema) ? schema.schema : annotation?.body ?? schema
     const headers = HttpApiSchema.isWithHeaders(schema) ? schema.headers : annotation?.headers
     const status = getStatus(schema)
-    if (HttpApiSchema.isStreamSchema(body)) {
-      addStreamContent(body, status, headers)
-      return
-    }
     const ast = body.ast
-    if (HttpApiSchema.isNoContent(ast)) {
-      addNoContent(status, getDescription(schema.ast) ?? getDescription(ast) ?? "<No Content>", headers)
+    if (HttpApiSchema.isStreamSchema(body)) {
+      addStreamContent(body, status)
+    } else if (HttpApiSchema.isNoContent(ast)) {
+      addNoContent(status, getDescription(schema.ast) ?? getDescription(ast) ?? "<No Content>")
     } else {
       addContent(
         body,
         status,
         HttpApiSchema.getResponseEncodingSchema(schema),
-        getDescription(schema.ast) ?? getDescription(ast),
-        headers
+        getDescription(schema.ast) ?? getDescription(ast)
       )
+    }
+    if (headers !== undefined) {
+      map.get(status)!.headers.push(headers)
     }
   }
 
-  function addNoContent(status: number, description: string, headers: Schema.Constraint | undefined) {
+  function addNoContent(status: number, description: string) {
     const statusMap = map.get(status)
     if (statusMap === undefined) {
       map.set(status, {
         descriptions: new Set([description]),
         content: undefined,
-        headers: headers === undefined ? [] : [headers],
+        headers: [],
         streamContent: undefined
       })
     } else {
       if (description !== undefined) {
         statusMap.descriptions.add(description)
-      }
-      if (headers !== undefined) {
-        statusMap.headers.push(headers)
       }
     }
   }
@@ -769,8 +766,7 @@ function extractResponseBodies(
     schema: Schema.Constraint,
     status: number,
     encoding: HttpApiSchema.Encoding,
-    description: string | undefined,
-    headers: Schema.Constraint | undefined
+    description: string | undefined
   ) {
     const statusMap = map.get(status)
     const { _tag, contentType } = encoding
@@ -778,16 +774,13 @@ function extractResponseBodies(
       map.set(status, {
         descriptions: new Set(description !== undefined ? [description] : []),
         content: new Map([[_tag, new Map([[contentType, new Set([schema])]])]]),
-        headers: headers === undefined ? [] : [headers],
+        headers: [],
         streamContent: undefined
       })
     } else {
       // concat descriptions
       if (description !== undefined) {
         statusMap.descriptions.add(description)
-      }
-      if (headers !== undefined) {
-        statusMap.headers.push(headers)
       }
 
       if (statusMap.content === undefined) {
@@ -810,21 +803,17 @@ function extractResponseBodies(
 
   function addStreamContent(
     stream: HttpApiSchema.StreamSchema,
-    status: number,
-    headers: Schema.Constraint | undefined
+    status: number
   ) {
     const statusMap = map.get(status)
     if (statusMap === undefined) {
       map.set(status, {
         descriptions: new Set(),
         content: undefined,
-        headers: headers === undefined ? [] : [headers],
+        headers: [],
         streamContent: new Map([[stream.contentType, stream]])
       })
     } else {
-      if (headers !== undefined) {
-        statusMap.headers.push(headers)
-      }
       if (statusMap.streamContent === undefined) {
         statusMap.streamContent = new Map([[stream.contentType, stream]])
       } else {

--- a/packages/effect/src/unstable/httpapi/OpenApi.ts
+++ b/packages/effect/src/unstable/httpapi/OpenApi.ts
@@ -587,7 +587,7 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
       processResponseBodies(
         extractResponseBodies(
           HttpApiEndpoint.getErrorSchemas(endpoint),
-          (schema) => HttpApiSchema.getStatusError(schema.ast),
+          HttpApiSchema.getStatusErrorSchema,
           resolveDescriptionOrIdentifier
         ),
         () => "Error"

--- a/packages/effect/src/unstable/httpapi/OpenApi.ts
+++ b/packages/effect/src/unstable/httpapi/OpenApi.ts
@@ -369,11 +369,30 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
       const method = endpoint.method.toLowerCase() as OpenAPISpecMethodName
 
       function processResponseBodies(bodies: ResponseBodies, defaultDescription: () => string) {
-        for (const [status, { content, descriptions, streamContent }] of bodies) {
+        for (const [status, { content, descriptions, headers, streamContent }] of bodies) {
           const description = descriptions.size > 0 ? Array.from(descriptions).join(" | ") : defaultDescription()
           InternalRecord.assignProperty(op.responses, status, {
             description
           })
+          for (const schema of headers) {
+            const ast = SchemaAST.getLastEncoding(schema.ast)
+            if (SchemaAST.isObjects(ast)) {
+              for (const ps of ast.propertySignatures) {
+                const name = String(ps.name).toLowerCase()
+                if (name === "content-type") continue
+                op.responses[status].headers ??= {}
+                InternalRecord.assignProperty(op.responses[status].headers, name, {
+                  schema: {},
+                  required: !SchemaAST.isOptional(ps.type)
+                })
+                pathOps.push({
+                  _tag: "parameter",
+                  ast: ps.type,
+                  path: ["paths", path, method, "responses", String(status), "headers", name, "schema"]
+                })
+              }
+            }
+          }
           if (content !== undefined) {
             content.forEach((map, encoding) => {
               map.forEach((schemas, contentType) => {
@@ -568,7 +587,7 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
       processResponseBodies(
         extractResponseBodies(
           HttpApiEndpoint.getErrorSchemas(endpoint),
-          HttpApiSchema.getStatusError,
+          (schema) => HttpApiSchema.getStatusError(schema.ast),
           resolveDescriptionOrIdentifier
         ),
         () => "Error"
@@ -673,6 +692,7 @@ type ResponseBodies = Map<
   {
     descriptions: Set<string>
     content: Content | undefined // undefined means no content
+    headers: Array<Schema.Constraint>
     streamContent: StreamContent | undefined
   }
 >
@@ -682,19 +702,20 @@ const reservedStreamFailureEvent = "effect/httpapi/stream/failure"
 function extractSuccessResponseBodies(endpoint: HttpApiEndpoint.Top): ResponseBodies {
   return extractResponseBodies(
     HttpApiEndpoint.getSuccessSchemas(endpoint),
-    HttpApiSchema.getStatusSuccess,
+    HttpApiSchema.getStatusSuccessSchema,
     resolveDescriptionOrIdentifier
   )
 }
 
 function extractResponseBodies(
   schemas: Array<Schema.Constraint>,
-  getStatus: (ast: SchemaAST.AST) => number,
+  getStatus: (schema: Schema.Constraint) => number,
   getDescription: (ast: SchemaAST.AST) => string | undefined
 ): ResponseBodies {
   const map = new Map<number, {
     descriptions: Set<string>
     content: Content | undefined
+    headers: Array<Schema.Constraint>
     streamContent: StreamContent | undefined
   }>()
 
@@ -703,48 +724,70 @@ function extractResponseBodies(
   return map
 
   function process(schema: Schema.Constraint) {
-    if (HttpApiSchema.isStreamSchema(schema)) {
-      addStreamContent(schema)
+    const annotation = HttpApiSchema.getWithHeadersAnnotation(schema.ast)
+    const body = HttpApiSchema.isWithHeaders(schema) ? schema.schema : annotation?.body ?? schema
+    const headers = HttpApiSchema.isWithHeaders(schema) ? schema.headers : annotation?.headers
+    const status = getStatus(schema)
+    if (HttpApiSchema.isStreamSchema(body)) {
+      addStreamContent(body, status, headers)
       return
     }
-    const ast = schema.ast
-    const status = getStatus(ast)
+    const ast = body.ast
     if (HttpApiSchema.isNoContent(ast)) {
-      addNoContent(status, getDescription(schema.ast) ?? "<No Content>")
+      addNoContent(status, getDescription(schema.ast) ?? getDescription(ast) ?? "<No Content>", headers)
     } else {
-      addContent(schema, status, HttpApiSchema.getResponseEncoding(ast))
+      addContent(
+        body,
+        status,
+        HttpApiSchema.getResponseEncodingSchema(schema),
+        getDescription(schema.ast) ?? getDescription(ast),
+        headers
+      )
     }
   }
 
-  function addNoContent(status: number, description: string) {
+  function addNoContent(status: number, description: string, headers: Schema.Constraint | undefined) {
     const statusMap = map.get(status)
     if (statusMap === undefined) {
       map.set(status, {
         descriptions: new Set([description]),
         content: undefined,
+        headers: headers === undefined ? [] : [headers],
         streamContent: undefined
       })
     } else {
       if (description !== undefined) {
         statusMap.descriptions.add(description)
       }
+      if (headers !== undefined) {
+        statusMap.headers.push(headers)
+      }
     }
   }
 
-  function addContent(schema: Schema.Constraint, status: number, encoding: HttpApiSchema.Encoding) {
-    const description = getDescription(schema.ast)
+  function addContent(
+    schema: Schema.Constraint,
+    status: number,
+    encoding: HttpApiSchema.Encoding,
+    description: string | undefined,
+    headers: Schema.Constraint | undefined
+  ) {
     const statusMap = map.get(status)
     const { _tag, contentType } = encoding
     if (statusMap === undefined) {
       map.set(status, {
         descriptions: new Set(description !== undefined ? [description] : []),
         content: new Map([[_tag, new Map([[contentType, new Set([schema])]])]]),
+        headers: headers === undefined ? [] : [headers],
         streamContent: undefined
       })
     } else {
       // concat descriptions
       if (description !== undefined) {
         statusMap.descriptions.add(description)
+      }
+      if (headers !== undefined) {
+        statusMap.headers.push(headers)
       }
 
       if (statusMap.content === undefined) {
@@ -765,19 +808,28 @@ function extractResponseBodies(
     }
   }
 
-  function addStreamContent(stream: HttpApiSchema.StreamSchema) {
-    const status = HttpApiSchema.getStatusStream(stream)
+  function addStreamContent(
+    stream: HttpApiSchema.StreamSchema,
+    status: number,
+    headers: Schema.Constraint | undefined
+  ) {
     const statusMap = map.get(status)
     if (statusMap === undefined) {
       map.set(status, {
         descriptions: new Set(),
         content: undefined,
+        headers: headers === undefined ? [] : [headers],
         streamContent: new Map([[stream.contentType, stream]])
       })
-    } else if (statusMap.streamContent === undefined) {
-      statusMap.streamContent = new Map([[stream.contentType, stream]])
     } else {
-      statusMap.streamContent.set(stream.contentType, stream)
+      if (headers !== undefined) {
+        statusMap.headers.push(headers)
+      }
+      if (statusMap.streamContent === undefined) {
+        statusMap.streamContent = new Map([[stream.contentType, stream]])
+      } else {
+        statusMap.streamContent.set(stream.contentType, stream)
+      }
     }
   }
 }
@@ -1042,7 +1094,16 @@ export type OpenApiSpecContent = {
 export interface OpenApiSpecResponse {
   description: string
   content?: OpenApiSpecContent
+  headers?: Record<string, OpenAPISpecHeader>
 }
+
+/**
+ * Generated OpenAPI response header object.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type OpenAPISpecHeader = Omit<OpenAPISpecParameter, "name" | "in">
 
 /**
  * Generated OpenAPI media type object containing the JSON Schema for a request or response body.

--- a/packages/effect/src/unstable/httpapi/OpenApi.ts
+++ b/packages/effect/src/unstable/httpapi/OpenApi.ts
@@ -726,7 +726,7 @@ function extractResponseBodies(
   function process(schema: Schema.Constraint) {
     const annotation = HttpApiSchema.getWithHeadersAnnotation(schema.ast)
     const body = HttpApiSchema.isWithHeaders(schema) ? schema.schema : annotation?.body ?? schema
-    const headers = HttpApiSchema.isWithHeaders(schema) ? schema.headers : annotation?.headers
+    const headers = HttpApiSchema.isWithHeaders(schema) ? schema.headers : annotation?.headersCodec
     const status = getStatus(schema)
     const ast = body.ast
     if (HttpApiSchema.isStreamSchema(body)) {

--- a/packages/effect/test/unstable/http/HttpServerResponse.test.ts
+++ b/packages/effect/test/unstable/http/HttpServerResponse.test.ts
@@ -5,6 +5,16 @@ import { HttpBody, HttpClientRequest, HttpClientResponse, HttpServerResponse } f
 const TestValue = Context.Reference<number>("test/TestValue", { defaultValue: () => 0 })
 
 describe("HttpServerResponse", () => {
+  it("setHeader overrides body-derived content headers", () => {
+    const response = HttpServerResponse.text("body").pipe(
+      HttpServerResponse.setHeader("content-type", "text/custom"),
+      HttpServerResponse.setHeader("content-length", "1")
+    )
+
+    assert.strictEqual(response.headers["content-type"], "text/custom")
+    assert.strictEqual(response.headers["content-length"], "1")
+  })
+
   it.effect("fromClientResponse preserves status, headers, cookies, and json", () =>
     Effect.gen(function*() {
       const request = HttpClientRequest.get("http://localhost:3000/todos/1")

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -406,6 +406,39 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
       assert.strictEqual(yield* response.text, "slow down")
     }))
 
+  it.effect("encodes and decodes an error wrapped in WithHeaders", () =>
+    Effect.gen(function*() {
+      const RateLimited = HttpApiSchema.WithHeaders(
+        Schema.Struct({
+          _tag: Schema.Literal("RateLimited"),
+          message: Schema.String
+        }).pipe(HttpApiSchema.status(429)),
+        { "retry-after": Schema.Int }
+      )
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("limited", "/test", { error: RateLimited })
+        )
+      )
+      const expected = HttpApiSchema.withHeaders({
+        body: { _tag: "RateLimited" as const, message: "slow down" },
+        headers: { "retry-after": 30 }
+      })
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) => handlers.handle("limited", () => Effect.fail(expected))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const response = yield* client.test.limited({ responseMode: "response-only" })
+
+      assert.strictEqual(response.status, 429)
+      assert.strictEqual(response.headers["retry-after"], "30")
+      assert.deepStrictEqual(yield* response.json, expected.body)
+      assert.deepStrictEqual(yield* Effect.flip(client.test.limited({})), expected)
+    }))
+
   it.effect("stringifies encodeToWithHeaders values when endpoint codecs are disabled", () =>
     Effect.gen(function*() {
       class RateLimited extends Schema.TaggedError<RateLimited>()("RateLimited", {

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -210,7 +210,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
       )
     }))
 
-  it.effect("stringifies WithHeaders values when endpoint codecs are disabled", () =>
+  it.effect("passes through string-shaped WithHeaders when endpoint codecs are disabled", () =>
     Effect.gen(function*() {
       const Api = HttpApi.make("Api").add(
         HttpApiGroup.make("test")
@@ -219,7 +219,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
               disableCodecs: true,
               success: HttpApiSchema.WithHeaders(
                 Schema.String.pipe(HttpApiSchema.asText()),
-                { "x-count": Schema.Int }
+                { "x-count": Schema.String }
               )
             })
           )
@@ -228,7 +228,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
               disableCodecs: true,
               error: HttpApiSchema.WithHeaders(
                 Schema.String.pipe(HttpApiSchema.status(429), HttpApiSchema.asText()),
-                { "retry-after": Schema.Int }
+                { "retry-after": Schema.String }
               )
             })
           )
@@ -241,24 +241,30 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
             .handle("success", () =>
               Effect.succeed(HttpApiSchema.withHeaders({
                 body: "ok",
-                headers: { "x-count": 2 }
+                headers: { "x-count": "2" }
               })))
             .handle("error", () =>
               Effect.fail(HttpApiSchema.withHeaders({
                 body: "slow down",
-                headers: { "retry-after": 30 }
+                headers: { "retry-after": "30" }
               })))
       )
 
       const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
-      const success = yield* client.test.success({ responseMode: "response-only" })
-      const error = yield* client.test.error({ responseMode: "response-only" })
+      const [success, successResponse] = yield* client.test.success({ responseMode: "decoded-and-response" })
+      const error = yield* Effect.flip(client.test.error({}))
+      const errorResponse = yield* client.test.error({ responseMode: "response-only" })
+      if (!HttpApiSchema.isWithHeadersValue(error)) {
+        throw new Error("Expected WithHeaders error")
+      }
 
-      assert.strictEqual(success.headers["x-count"], "2")
-      assert.strictEqual(error.headers["retry-after"], "30")
+      assert.strictEqual(successResponse.headers["x-count"], "2")
+      assert.deepStrictEqual(success.headers, { "x-count": "2" })
+      assert.strictEqual(errorResponse.headers["retry-after"], "30")
+      assert.deepStrictEqual(error.headers, { "retry-after": "30" })
     }))
 
-  it.effect("decodes a buffered success body and its declared headers", () =>
+  it.effect("encodes and decodes response headers with codecs enabled", () =>
     Effect.gen(function*() {
       const Api = HttpApi.make("Api").add(
         HttpApiGroup.make("test").add(
@@ -282,8 +288,9 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
       )
 
       const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
-      const value = yield* client.test.created({})
+      const [value, response] = yield* client.test.created({ responseMode: "decoded-and-response" })
 
+      assert.strictEqual(response.headers["x-count"], "2")
       assert.deepStrictEqual(
         value,
         HttpApiSchema.withHeaders({
@@ -543,15 +550,15 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
       assert.deepStrictEqual(yield* Effect.flip(client.test.limited({})), expected)
     }))
 
-  it.effect("stringifies encodeToWithHeaders values when endpoint codecs are disabled", () =>
+  it.effect("passes through string-shaped encodeToWithHeaders values when endpoint codecs are disabled", () =>
     Effect.gen(function*() {
       class RateLimited extends Schema.TaggedError<RateLimited>()("RateLimited", {
-        retryAfter: Schema.Int
+        retryAfter: Schema.String
       }) {}
       const RateLimitedResponse = RateLimited.pipe(
         HttpApiSchema.encodeToWithHeaders({
           body: Schema.String.pipe(HttpApiSchema.status(429), HttpApiSchema.asText()),
-          headers: { "retry-after": Schema.Int }
+          headers: { "retry-after": Schema.String }
         }, {
           decode: ({ headers }) => new RateLimited({ retryAfter: headers["retry-after"] }),
           encode: (error) => ({ body: "slow down", headers: { "retry-after": error.retryAfter } })
@@ -568,7 +575,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
       const GroupLive = HttpApiBuilder.group(
         Api,
         "test",
-        (handlers) => handlers.handle("limited", () => Effect.fail(new RateLimited({ retryAfter: 30 })))
+        (handlers) => handlers.handle("limited", () => Effect.fail(new RateLimited({ retryAfter: "30" })))
       )
 
       const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
@@ -577,6 +584,10 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
       assert.strictEqual(response.status, 429)
       assert.strictEqual(response.headers["retry-after"], "30")
       assert.strictEqual(yield* response.text, "slow down")
+      assert.deepStrictEqual(
+        yield* Effect.flip(client.test.limited({})),
+        new RateLimited({ retryAfter: "30" })
+      )
     }))
 
   it.effect("decodes an error body and headers through encodeToWithHeaders", () =>

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -122,6 +122,169 @@ it.layer(TestServices)("HttpApiBuilder payload content types", (it) => {
     }))
 })
 
+it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
+  it.effect("encodes a buffered success body and its declared headers", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("created", "/test", {
+            success: HttpApiSchema.WithHeaders(
+              Schema.Struct({ id: Schema.Int }).pipe(HttpApiSchema.status(201)),
+              {
+                "x-count": Schema.Int,
+                "x-optional": Schema.optional(Schema.String)
+              }
+            )
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers.handle("created", () =>
+            Effect.succeed(HttpApiSchema.withHeaders({
+              body: { id: 1 },
+              headers: { "x-count": 2, "x-optional": undefined }
+            })))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const response = yield* client.test.created({ responseMode: "response-only" })
+
+      assert.strictEqual(response.status, 201)
+      assert.strictEqual(response.headers["x-count"], "2")
+      assert.isFalse("x-optional" in response.headers)
+      assert.deepStrictEqual(yield* response.json, { id: 1 })
+    }))
+
+  it.effect("does not unwrap an unbranded value in a mixed success union", () =>
+    Effect.gen(function*() {
+      const Plain = Schema.Struct({
+        body: Schema.String,
+        headers: Schema.Struct({ "x-source": Schema.String })
+      }).pipe(HttpApiSchema.asJson({ contentType: "application/vnd.plain+json" }))
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("mixed", "/test", {
+            success: [
+              HttpApiSchema.WithHeaders(Schema.String, { "x-source": Schema.String }),
+              Plain
+            ]
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) => handlers.handle("mixed", () => Effect.succeed({ body: "plain", headers: { "x-source": "body" } }))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const response = yield* client.test.mixed({ responseMode: "response-only" })
+
+      assert.strictEqual(response.headers["content-type"], "application/vnd.plain+json")
+      assert.isFalse("x-source" in response.headers)
+      assert.deepStrictEqual(yield* response.json, { body: "plain", headers: { "x-source": "body" } })
+    }))
+
+  it.effect("applies declared headers after body encoding", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("override", "/test", {
+            success: HttpApiSchema.WithHeaders(
+              Schema.String.pipe(HttpApiSchema.asText({ contentType: "text/plain" })),
+              { "content-type": Schema.String, "x-source": Schema.String }
+            )
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers.handle("override", () =>
+            Effect.succeed(HttpApiSchema.withHeaders({
+              body: "ok",
+              headers: { "content-type": "application/custom", "x-source": "schema" }
+            })))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const response = yield* client.test.override({ responseMode: "response-only" })
+
+      assert.strictEqual(response.headers["content-type"], "application/custom")
+      assert.strictEqual(response.headers["x-source"], "schema")
+      assert.strictEqual(yield* response.text, "ok")
+    }))
+
+  it.effect("encodes error headers through encodeToWithHeaders", () =>
+    Effect.gen(function*() {
+      class RateLimited extends Schema.TaggedError<RateLimited>()("RateLimited", {
+        retryAfter: Schema.Int
+      }) {}
+      const RateLimitedResponse = RateLimited.pipe(
+        HttpApiSchema.encodeToWithHeaders({
+          body: Schema.String.pipe(HttpApiSchema.status(429), HttpApiSchema.asText()),
+          headers: { "retry-after": Schema.Int }
+        }, {
+          decode: ({ headers }) => new RateLimited({ retryAfter: headers["retry-after"] }),
+          encode: (error) => ({ body: "slow down", headers: { "retry-after": error.retryAfter } })
+        })
+      )
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("limited", "/test", { error: RateLimitedResponse })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) => handlers.handle("limited", () => Effect.fail(new RateLimited({ retryAfter: 30 })))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const response = yield* client.test.limited({ responseMode: "response-only" })
+
+      assert.strictEqual(response.status, 429)
+      assert.strictEqual(response.headers["content-type"], "text/plain")
+      assert.strictEqual(response.headers["retry-after"], "30")
+      assert.strictEqual(yield* response.text, "slow down")
+    }))
+
+  it.effect("defects with ResponseHeaders when success header encoding fails", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("invalid", "/test", {
+            success: HttpApiSchema.WithHeaders(Schema.String, { "x-count": Schema.Int })
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers.handle("invalid", () =>
+            Effect.succeed(HttpApiSchema.withHeaders({
+              body: "ok",
+              headers: { "x-count": "invalid" as any }
+            })))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const exit = yield* Effect.exit(client.test.invalid({ responseMode: "response-only" }))
+
+      assert.strictEqual(exit._tag, "Failure")
+      if (exit._tag === "Failure") {
+        const error = Cause.squash(exit.cause) as any
+        assert.strictEqual(error._tag, "HttpApiSchemaError")
+        assert.strictEqual(error.kind, "ResponseHeaders")
+      }
+    }))
+})
+
 it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
   it.effect("emits StreamUint8Array handler responses as streamed bytes with the declared content type", () =>
     Effect.gen(function*() {

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -517,6 +517,40 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
       assert.strictEqual(yield* response.text, "slow down")
     }))
 
+  it.effect("encodes annotation headers from their declared encoded shape", () =>
+    Effect.gen(function*() {
+      class RateLimited extends Schema.TaggedError<RateLimited>()("RateLimited", {
+        expiresAt: Schema.Date
+      }) {}
+      const RateLimitedResponse = RateLimited.pipe(
+        HttpApiSchema.encodeToWithHeaders({
+          body: Schema.String.pipe(HttpApiSchema.status(429)),
+          headers: { "expires-at": Schema.Date }
+        }, {
+          decode: ({ headers }) => new RateLimited({ expiresAt: headers["expires-at"] }),
+          encode: (error) => ({ body: "slow down", headers: { "expires-at": error.expiresAt } })
+        })
+      )
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("limited", "/test", { error: RateLimitedResponse })
+        )
+      )
+      const expiresAt = DateTime.makeUnsafe("2026-08-05T02:00:00.000Z").pipe(DateTime.toDate)
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) => handlers.handle("limited", () => Effect.fail(new RateLimited({ expiresAt })))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const response = yield* client.test.limited({ responseMode: "response-only" })
+      const error = yield* Effect.flip(client.test.limited({}))
+
+      assert.strictEqual(response.headers["expires-at"], "2026-08-05T02:00:00.000Z")
+      assert.deepStrictEqual(error, new RateLimited({ expiresAt }))
+    }))
+
   it.effect("encodes and decodes an error wrapped in WithHeaders", () =>
     Effect.gen(function*() {
       const RateLimited = HttpApiSchema.WithHeaders(

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -177,7 +177,40 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
       assert.strictEqual(response.headers["x-source"], "created:value")
     }))
 
-  it.effect("defects with ResponseHeaders when a branded response encodes to a plain status", () =>
+  it.effect("encodes a branded response against the header-carrying member when body shapes overlap", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("result", "/test", {
+            success: [
+              Schema.Struct({ value: Schema.String }).pipe(HttpApiSchema.status(201)),
+              HttpApiSchema.WithHeaders(
+                Schema.Struct({ value: Schema.String }),
+                { "x-source": Schema.String }
+              )
+            ]
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers.handle("result", () =>
+            Effect.succeed(HttpApiSchema.withHeaders({
+              body: { value: "wrapped" },
+              headers: { "x-source": "value" }
+            })))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const response = yield* client.test.result({ responseMode: "response-only" })
+
+      assert.strictEqual(response.status, 200)
+      assert.strictEqual(response.headers["x-source"], "value")
+    }))
+
+  it.effect("fails with a Body schema error when a branded response body matches no header-carrying member", () =>
     Effect.gen(function*() {
       const Api = HttpApi.make("Api").add(
         HttpApiGroup.make("test").add(
@@ -210,11 +243,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
       if (exit._tag === "Failure") {
         const error = Cause.squash(exit.cause) as any
         assert.strictEqual(error._tag, "HttpApiSchemaError")
-        assert.strictEqual(error.kind, "ResponseHeaders")
-        assert.strictEqual(
-          error.cause.message,
-          "Endpoint declares no header-carrying response for encoded status: 201"
-        )
+        assert.strictEqual(error.kind, "Body")
       }
     }))
 

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -177,6 +177,47 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
       assert.strictEqual(response.headers["x-source"], "created:value")
     }))
 
+  it.effect("defects with ResponseHeaders when a branded response encodes to a plain status", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("result", "/test", {
+            success: [
+              HttpApiSchema.WithHeaders(
+                Schema.Struct({ _tag: Schema.Literal("A") }),
+                { "x-source": Schema.String }
+              ),
+              Schema.Struct({ _tag: Schema.Literal("B") }).pipe(HttpApiSchema.status(201))
+            ]
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers.handle("result", () =>
+            Effect.succeed(HttpApiSchema.withHeaders({
+              body: { _tag: "B" as const },
+              headers: { "x-source": "value" }
+            }) as any))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const exit = yield* Effect.exit(client.test.result({ responseMode: "response-only" }))
+
+      assert.strictEqual(exit._tag, "Failure")
+      if (exit._tag === "Failure") {
+        const error = Cause.squash(exit.cause) as any
+        assert.strictEqual(error._tag, "HttpApiSchemaError")
+        assert.strictEqual(error.kind, "ResponseHeaders")
+        assert.strictEqual(
+          error.cause.message,
+          "Endpoint declares no header-carrying response for encoded status: 201"
+        )
+      }
+    }))
+
   it.effect("round trips user-managed header codecs through HttpApiTest", () =>
     Effect.gen(function*() {
       const Api = HttpApi.make("Api").add(

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -123,6 +123,75 @@ it.layer(TestServices)("HttpApiBuilder payload content types", (it) => {
 })
 
 it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
+  it.effect("decodes a buffered success body and its declared headers", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("created", "/test", {
+            success: HttpApiSchema.WithHeaders(
+              Schema.Struct({ id: Schema.Int }).pipe(HttpApiSchema.status(201)),
+              { "x-count": Schema.Int }
+            )
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers.handle("created", () =>
+            Effect.succeed(HttpApiSchema.withHeaders({
+              body: { id: 1 },
+              headers: { "x-count": 2 }
+            })))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const value = yield* client.test.created({})
+
+      assert.deepStrictEqual(
+        value,
+        HttpApiSchema.withHeaders({
+          body: { id: 1 },
+          headers: { "x-count": 2 }
+        })
+      )
+    }))
+
+  it.effect("round trips a client-received branded value through another handler", () =>
+    Effect.gen(function*() {
+      const Success = HttpApiSchema.WithHeaders(
+        Schema.Struct({ id: Schema.Int }).pipe(HttpApiSchema.status(201)),
+        { "x-count": Schema.Int }
+      )
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test")
+          .add(HttpApiEndpoint.get("created", "/created", { success: Success }))
+          .add(HttpApiEndpoint.get("forwarded", "/forwarded", { success: Success }))
+      )
+      let forwarded: typeof Success.Type | undefined
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers
+            .handle("created", () =>
+              Effect.succeed(HttpApiSchema.withHeaders({
+                body: { id: 1 },
+                headers: { "x-count": 2 }
+              })))
+            .handle("forwarded", () => Effect.succeed(forwarded!))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const [value, response] = yield* client.test.created({ responseMode: "decoded-and-response" })
+      forwarded = value
+      const result = yield* client.test.forwarded({})
+
+      assert.strictEqual(response.status, 201)
+      assert.deepStrictEqual(result, value)
+    }))
+
   it.effect("encodes a buffered success body and its declared headers", () =>
     Effect.gen(function*() {
       const Api = HttpApi.make("Api").add(
@@ -251,6 +320,46 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
       assert.strictEqual(response.headers["content-type"], "text/plain")
       assert.strictEqual(response.headers["retry-after"], "30")
       assert.strictEqual(yield* response.text, "slow down")
+    }))
+
+  it.effect("decodes an error body and headers through encodeToWithHeaders", () =>
+    Effect.gen(function*() {
+      class RateLimited extends Schema.TaggedError<RateLimited>()("RateLimited", {
+        message: Schema.String,
+        retryAfter: Schema.Int
+      }) {}
+      const RateLimitedResponse = RateLimited.pipe(
+        HttpApiSchema.encodeToWithHeaders({
+          body: Schema.String.pipe(HttpApiSchema.status(429), HttpApiSchema.asText()),
+          headers: { "retry-after": Schema.Int }
+        }, {
+          decode: ({ body, headers }) =>
+            new RateLimited({
+              message: body,
+              retryAfter: headers["retry-after"]
+            }),
+          encode: (error) => ({
+            body: error.message,
+            headers: { "retry-after": error.retryAfter }
+          })
+        })
+      )
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("limited", "/test", { error: RateLimitedResponse })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers.handle("limited", () => Effect.fail(new RateLimited({ message: "slow down", retryAfter: 30 })))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const error = yield* Effect.flip(client.test.limited({}))
+
+      assert.deepStrictEqual(error, new RateLimited({ message: "slow down", retryAfter: 30 }))
     }))
 
   it.effect("defects with ResponseHeaders when success header encoding fails", () =>

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -156,6 +156,54 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
       )
     }))
 
+  it.effect("stringifies WithHeaders values when endpoint codecs are disabled", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test")
+          .add(
+            HttpApiEndpoint.get("success", "/success", {
+              disableCodecs: true,
+              success: HttpApiSchema.WithHeaders(
+                Schema.String.pipe(HttpApiSchema.asText()),
+                { "x-count": Schema.Int }
+              )
+            })
+          )
+          .add(
+            HttpApiEndpoint.get("error", "/error", {
+              disableCodecs: true,
+              error: HttpApiSchema.WithHeaders(
+                Schema.String.pipe(HttpApiSchema.status(429), HttpApiSchema.asText()),
+                { "retry-after": Schema.Int }
+              )
+            })
+          )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers
+            .handle("success", () =>
+              Effect.succeed(HttpApiSchema.withHeaders({
+                body: "ok",
+                headers: { "x-count": 2 }
+              })))
+            .handle("error", () =>
+              Effect.fail(HttpApiSchema.withHeaders({
+                body: "slow down",
+                headers: { "retry-after": 30 }
+              })))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const success = yield* client.test.success({ responseMode: "response-only" })
+      const error = yield* client.test.error({ responseMode: "response-only" })
+
+      assert.strictEqual(success.headers["x-count"], "2")
+      assert.strictEqual(error.headers["retry-after"], "30")
+    }))
+
   it.effect("decodes a buffered success body and its declared headers", () =>
     Effect.gen(function*() {
       const Api = HttpApi.make("Api").add(

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -123,6 +123,39 @@ it.layer(TestServices)("HttpApiBuilder payload content types", (it) => {
 })
 
 it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
+  it.effect("round trips user-managed header codecs through HttpApiTest", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("result", "/test", {
+            disableCodecs: true,
+            success: HttpApiSchema.WithHeaders(
+              Schema.String.pipe(HttpApiSchema.asText()),
+              { "x-count": Schema.FiniteFromString }
+            )
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers.handle("result", () =>
+            Effect.succeed(HttpApiSchema.withHeaders({
+              body: "ok",
+              headers: { "x-count": 2 }
+            })))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const result = yield* client.test.result({})
+
+      assert.deepStrictEqual(
+        result,
+        HttpApiSchema.withHeaders({ body: "ok", headers: { "x-count": 2 } })
+      )
+    }))
+
   it.effect("decodes a buffered success body and its declared headers", () =>
     Effect.gen(function*() {
       const Api = HttpApi.make("Api").add(

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -373,6 +373,42 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
       assert.strictEqual(yield* response.text, "slow down")
     }))
 
+  it.effect("stringifies encodeToWithHeaders values when endpoint codecs are disabled", () =>
+    Effect.gen(function*() {
+      class RateLimited extends Schema.TaggedError<RateLimited>()("RateLimited", {
+        retryAfter: Schema.Int
+      }) {}
+      const RateLimitedResponse = RateLimited.pipe(
+        HttpApiSchema.encodeToWithHeaders({
+          body: Schema.String.pipe(HttpApiSchema.status(429), HttpApiSchema.asText()),
+          headers: { "retry-after": Schema.Int }
+        }, {
+          decode: ({ headers }) => new RateLimited({ retryAfter: headers["retry-after"] }),
+          encode: (error) => ({ body: "slow down", headers: { "retry-after": error.retryAfter } })
+        })
+      )
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("limited", "/test", {
+            disableCodecs: true,
+            error: RateLimitedResponse
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) => handlers.handle("limited", () => Effect.fail(new RateLimited({ retryAfter: 30 })))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const response = yield* client.test.limited({ responseMode: "response-only" })
+
+      assert.strictEqual(response.status, 429)
+      assert.strictEqual(response.headers["retry-after"], "30")
+      assert.strictEqual(yield* response.text, "slow down")
+    }))
+
   it.effect("decodes an error body and headers through encodeToWithHeaders", () =>
     Effect.gen(function*() {
       class RateLimited extends Schema.TaggedError<RateLimited>()("RateLimited", {
@@ -477,6 +513,41 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
       assert.deepStrictEqual(Array.from(chunks, (chunk) => Array.from(chunk)), [[1, 2], [3]])
     }))
 
+  it.effect("unwraps WithHeaders StreamUint8Array responses before stream dispatch", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("download", "/test", {
+            success: HttpApiSchema.WithHeaders(
+              HttpApiSchema.status(206)(
+                HttpApiSchema.StreamUint8Array({ contentType: "application/custom-bytes" })
+              ),
+              { "content-type": Schema.String, "x-count": Schema.Int }
+            )
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers.handle("download", () =>
+            Effect.succeed(HttpApiSchema.withHeaders({
+              body: Stream.make(new Uint8Array([1, 2]), new Uint8Array([3])),
+              headers: { "content-type": "application/overridden", "x-count": 2 }
+            })))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const response = yield* client.test.download({ responseMode: "response-only" })
+      const chunks = yield* response.stream.pipe(Stream.runCollect)
+
+      assert.strictEqual(response.status, 206)
+      assert.strictEqual(response.headers["content-type"], "application/overridden")
+      assert.strictEqual(response.headers["x-count"], "2")
+      assert.deepStrictEqual(Array.from(chunks, (chunk) => Array.from(chunk)), [[1, 2], [3]])
+    }))
+
   it.effect("renders successful StreamSse events incrementally with the declared content type", () =>
     Effect.gen(function*() {
       const Events = Schema.Struct({
@@ -518,6 +589,85 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
         Array.from(chunks, (chunk) => textDecoder.decode(chunk)),
         ["event: first\ndata: one\n\n", "event: second\ndata: two\n\n"]
       )
+    }))
+
+  it.effect("unwraps WithHeaders StreamSse responses before SSE encoding", () =>
+    Effect.gen(function*() {
+      const Events = Schema.Struct({
+        event: Schema.String,
+        data: Schema.String
+      })
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("events", "/test", {
+            success: HttpApiSchema.WithHeaders(
+              HttpApiSchema.status(202)(
+                HttpApiSchema.StreamSse({
+                  contentType: "text/event-stream; charset=utf-8",
+                  events: Events,
+                  error: StreamError
+                })
+              ),
+              { "x-count": Schema.Int }
+            )
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers.handle("events", () =>
+            Effect.succeed(HttpApiSchema.withHeaders({
+              body: Stream.make({ event: "first", data: "one" }),
+              headers: { "x-count": 1 }
+            })))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const response = yield* client.test.events({ responseMode: "response-only" })
+      const chunks = yield* response.stream.pipe(Stream.runCollect)
+
+      assert.strictEqual(response.status, 202)
+      assert.strictEqual(response.headers["content-type"], "text/event-stream; charset=utf-8")
+      assert.strictEqual(response.headers["x-count"], "1")
+      assert.deepStrictEqual(Array.from(chunks, (chunk) => textDecoder.decode(chunk)), [
+        "event: first\ndata: one\n\n"
+      ])
+    }))
+
+  it.effect("fails WithHeaders stream header encoding before returning a response", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("download", "/test", {
+            success: HttpApiSchema.WithHeaders(
+              HttpApiSchema.StreamUint8Array(),
+              { "x-count": Schema.Int }
+            )
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers.handle("download", () =>
+            Effect.succeed(HttpApiSchema.withHeaders({
+              body: Stream.make(new Uint8Array([1])),
+              headers: { "x-count": "invalid" as any }
+            })))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const exit = yield* Effect.exit(client.test.download({ responseMode: "response-only" }))
+
+      assert.strictEqual(exit._tag, "Failure")
+      if (exit._tag === "Failure") {
+        const error = Cause.squash(exit.cause) as any
+        assert.strictEqual(error._tag, "HttpApiSchemaError")
+        assert.strictEqual(error.kind, "ResponseHeaders")
+      }
     }))
 
   it.effect("renders StreamSse failures as one reserved event containing an encoded full cause", () =>
@@ -607,6 +757,67 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
       assert.deepStrictEqual(Array.from(chunks, (chunk) => textDecoder.decode(chunk)), [
         `data: {"text":"hello"}\n\n`
       ])
+    }))
+
+  it.effect("keeps a plain buffered alternative when the stream is wrapped", () =>
+    Effect.gen(function*() {
+      const Buffered = Schema.Struct({ message: Schema.String })
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("result", "/test", {
+            success: [
+              HttpApiSchema.WithHeaders(
+                HttpApiSchema.StreamUint8Array(),
+                { "x-source": Schema.String }
+              ),
+              Buffered
+            ]
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) => handlers.handle("result", () => Effect.succeed({ message: "done" }))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const response = yield* client.test.result({ responseMode: "response-only" })
+
+      assert.strictEqual(response.headers["content-type"], "application/json")
+      assert.deepStrictEqual(yield* response.json, { message: "done" })
+    }))
+
+  it.effect("detects a wrapped buffered alternative alongside a plain stream", () =>
+    Effect.gen(function*() {
+      const Buffered = Schema.Struct({ message: Schema.String })
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("result", "/test", {
+            success: [
+              HttpApiSchema.StreamUint8Array(),
+              HttpApiSchema.WithHeaders(Buffered, { "x-source": Schema.String })
+            ]
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers.handle("result", () =>
+            Effect.succeed(HttpApiSchema.withHeaders({
+              body: { message: "done" },
+              headers: { "x-source": "buffered" }
+            })))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const response = yield* client.test.result({ responseMode: "response-only" })
+
+      assert.strictEqual(response.headers["content-type"], "application/json")
+      assert.strictEqual(response.headers["x-source"], "buffered")
+      assert.deepStrictEqual(yield* response.json, { message: "done" })
     }))
 
   it.effect("registers handleAll handlers at runtime", () =>

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -1,5 +1,16 @@
 import { assert, it, vi } from "@effect/vitest"
-import { Cause, DateTime, Effect, FileSystem, Layer, Path, Redacted, Schema, Stream } from "effect"
+import {
+  Cause,
+  DateTime,
+  Effect,
+  FileSystem,
+  Layer,
+  Path,
+  Redacted,
+  Schema,
+  SchemaTransformation,
+  Stream
+} from "effect"
 import { Etag, HttpPlatform } from "effect/unstable/http"
 import {
   HttpApi,
@@ -123,6 +134,49 @@ it.layer(TestServices)("HttpApiBuilder payload content types", (it) => {
 })
 
 it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
+  it.effect("encodes WithHeaders using the schema for the response status", () =>
+    Effect.gen(function*() {
+      const encodedHeader = (prefix: string) =>
+        Schema.String.pipe(
+          Schema.decodeTo(
+            Schema.String,
+            SchemaTransformation.transform({
+              decode: (value) => value,
+              encode: (value) => `${prefix}:${value}`
+            })
+          )
+        )
+      const Ok = HttpApiSchema.WithHeaders(
+        Schema.Struct({ _tag: Schema.Literal("Ok") }),
+        { "x-source": encodedHeader("ok") }
+      )
+      const Created = HttpApiSchema.WithHeaders(
+        Schema.Struct({ _tag: Schema.Literal("Created") }).pipe(HttpApiSchema.status(201)),
+        { "x-source": encodedHeader("created") }
+      )
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("result", "/test", { success: [Ok, Created] })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers.handle("result", () =>
+            Effect.succeed(HttpApiSchema.withHeaders({
+              body: { _tag: "Created" as const },
+              headers: { "x-source": "value" }
+            })))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const response = yield* client.test.result({ responseMode: "response-only" })
+
+      assert.strictEqual(response.status, 201)
+      assert.strictEqual(response.headers["x-source"], "created:value")
+    }))
+
   it.effect("round trips user-managed header codecs through HttpApiTest", () =>
     Effect.gen(function*() {
       const Api = HttpApi.make("Api").add(
@@ -371,7 +425,9 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
         Schema.Struct({ _tag: Schema.Literal("Wrapped"), value: Schema.String }),
         { "x-source": Schema.String }
       )
-      const Plain = Schema.Struct({ _tag: Schema.Literal("Plain"), value: Schema.String })
+      const Plain = Schema.Struct({ _tag: Schema.Literal("Plain"), value: Schema.String }).pipe(
+        HttpApiSchema.asJson({ contentType: "application/vnd.plain+json" })
+      )
       const Api = HttpApi.make("Api").add(
         HttpApiGroup.make("test").add(
           HttpApiEndpoint.get("mixed", "/test", { success: [Wrapped, Plain] })

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -1,5 +1,5 @@
 import { assert, it, vi } from "@effect/vitest"
-import { Cause, Effect, FileSystem, Layer, Path, Redacted, Schema, Stream } from "effect"
+import { Cause, DateTime, Effect, FileSystem, Layer, Path, Redacted, Schema, Stream } from "effect"
 import { Etag, HttpPlatform } from "effect/unstable/http"
 import {
   HttpApi,
@@ -158,6 +158,33 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
       )
     }))
 
+  it.effect("decodes a transforming buffered success body and its declared headers", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("created", "/test", {
+            success: HttpApiSchema.WithHeaders(Schema.Date, { "x-source": Schema.String })
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers.handle("created", () =>
+            Effect.succeed(HttpApiSchema.withHeaders({
+              body: DateTime.makeUnsafe("2024-01-02T03:04:05.000Z").pipe(DateTime.toDate),
+              headers: { "x-source": "schema" }
+            })))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const value = yield* client.test.created({})
+
+      assert.strictEqual(value.body.toISOString(), "2024-01-02T03:04:05.000Z")
+      assert.deepStrictEqual(value.headers, { "x-source": "schema" })
+    }))
+
   it.effect("round trips a client-received branded value through another handler", () =>
     Effect.gen(function*() {
       const Success = HttpApiSchema.WithHeaders(
@@ -255,6 +282,30 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
       assert.strictEqual(response.headers["content-type"], "application/vnd.plain+json")
       assert.isFalse("x-source" in response.headers)
       assert.deepStrictEqual(yield* response.json, { body: "plain", headers: { "x-source": "body" } })
+    }))
+
+  it.effect("decodes a plain value in a mixed WithHeaders success union", () =>
+    Effect.gen(function*() {
+      const Wrapped = HttpApiSchema.WithHeaders(
+        Schema.Struct({ _tag: Schema.Literal("Wrapped"), value: Schema.String }),
+        { "x-source": Schema.String }
+      )
+      const Plain = Schema.Struct({ _tag: Schema.Literal("Plain"), value: Schema.String })
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("mixed", "/test", { success: [Wrapped, Plain] })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) => handlers.handle("mixed", () => Effect.succeed({ _tag: "Plain" as const, value: "plain" }))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const value = yield* client.test.mixed({})
+
+      assert.deepStrictEqual(value, { _tag: "Plain", value: "plain" })
     }))
 
   it.effect("applies declared headers after body encoding", () =>

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -147,11 +147,11 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
           )
         )
       const Ok = HttpApiSchema.WithHeaders(
-        Schema.Struct({ _tag: Schema.Literal("Ok") }),
+        Schema.TaggedStruct("Ok", {}),
         { "x-source": encodedHeader("ok") }
       )
       const Created = HttpApiSchema.WithHeaders(
-        Schema.Struct({ _tag: Schema.Literal("Created") }).pipe(HttpApiSchema.status(201)),
+        Schema.TaggedStruct("Created", {}).pipe(HttpApiSchema.status(201)),
         { "x-source": encodedHeader("created") }
       )
       const Api = HttpApi.make("Api").add(
@@ -217,10 +217,10 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
           HttpApiEndpoint.get("result", "/test", {
             success: [
               HttpApiSchema.WithHeaders(
-                Schema.Struct({ _tag: Schema.Literal("A") }),
+                Schema.TaggedStruct("A", {}),
                 { "x-source": Schema.String }
               ),
-              Schema.Struct({ _tag: Schema.Literal("B") }).pipe(HttpApiSchema.status(201))
+              Schema.TaggedStruct("B", {}).pipe(HttpApiSchema.status(201))
             ]
           })
         )
@@ -499,10 +499,10 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
   it.effect("decodes a plain value in a mixed WithHeaders success union", () =>
     Effect.gen(function*() {
       const Wrapped = HttpApiSchema.WithHeaders(
-        Schema.Struct({ _tag: Schema.Literal("Wrapped"), value: Schema.String }),
+        Schema.TaggedStruct("Wrapped", { value: Schema.String }),
         { "x-source": Schema.String }
       )
-      const Plain = Schema.Struct({ _tag: Schema.Literal("Plain"), value: Schema.String }).pipe(
+      const Plain = Schema.TaggedStruct("Plain", { value: Schema.String }).pipe(
         HttpApiSchema.asJson({ contentType: "application/vnd.plain+json" })
       )
       const Api = HttpApi.make("Api").add(
@@ -624,10 +624,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
   it.effect("encodes and decodes an error wrapped in WithHeaders", () =>
     Effect.gen(function*() {
       const RateLimited = HttpApiSchema.WithHeaders(
-        Schema.Struct({
-          _tag: Schema.Literal("RateLimited"),
-          message: Schema.String
-        }).pipe(HttpApiSchema.status(429)),
+        Schema.TaggedStruct("RateLimited", { message: Schema.String }).pipe(HttpApiSchema.status(429)),
         { "retry-after": Schema.Int }
       )
       const Api = HttpApi.make("Api").add(
@@ -1298,6 +1295,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
         message: Schema.String
       }, { httpApiStatus: 418 }) {}
 
+      // @effect-diagnostics-next-line leakingRequirements:off
       class M extends HttpApiMiddleware.Service<M>()("Security/HandlerFailure", {
         error: Schema.String.pipe(
           HttpApiSchema.status(401),

--- a/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
@@ -291,6 +291,48 @@ describe("HttpApiClient", () => {
       }))
   })
 
+  describe("response headers", () => {
+    it.effect("fails response decoding when a declared header is invalid", () =>
+      Effect.gen(function*() {
+        const Api = HttpApi.make("Api").add(
+          HttpApiGroup.make("test").add(
+            HttpApiEndpoint.get("created", "/created", {
+              success: HttpApiSchema.WithHeaders(
+                Schema.Struct({ id: Schema.Int }),
+                { "x-count": Schema.Int }
+              )
+            })
+          )
+        )
+        const decodeFailure = Effect.fnUntraced(function*(body: unknown, count: string) {
+          const client = yield* HttpApiClient.makeWith(Api, {
+            baseUrl: "http://test",
+            httpClient: clientFromResponse(() =>
+              new Response(JSON.stringify(body), {
+                status: 200,
+                headers: {
+                  "content-type": "application/json",
+                  "x-count": count
+                }
+              })
+            )
+          })
+          const exit = yield* Effect.exit(client.test.created({}))
+          assert.strictEqual(exit._tag, "Failure")
+          if (exit._tag === "Success") {
+            throw new Error("Expected response decoding to fail")
+          }
+          return Cause.squash(exit.cause) as { readonly _tag?: string }
+        })
+
+        const bodyError = yield* decodeFailure({ id: "invalid" }, "1")
+        const headerError = yield* decodeFailure({ id: 1 }, "invalid")
+
+        assert.strictEqual(bodyError._tag, "SchemaError")
+        assert.strictEqual(headerError._tag, bodyError._tag)
+      }))
+  })
+
   describe("urlBuilder", () => {
     const Api = HttpApi.make("Api")
       .add(

--- a/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
@@ -110,6 +110,138 @@ describe("HttpApiClient", () => {
         assert.deepStrictEqual(first.map((chunk) => Array.from(chunk)), [[1, 2]])
       }))
 
+    it.effect("decodes WithHeaders StreamUint8Array bodies and headers", () =>
+      Effect.gen(function*() {
+        const Api = HttpApi.make("Api").add(
+          HttpApiGroup.make("test").add(
+            HttpApiEndpoint.get("download", "/download", {
+              success: HttpApiSchema.WithHeaders(
+                HttpApiSchema.StreamUint8Array(),
+                { "x-count": Schema.Int }
+              )
+            })
+          )
+        )
+        const client = yield* HttpApiClient.makeWith(Api, {
+          baseUrl: "http://test",
+          httpClient: clientFromResponse(() =>
+            new Response(byteStream([new Uint8Array([1, 2]), new Uint8Array([3])]), {
+              status: 200,
+              headers: { "x-count": "2" }
+            })
+          )
+        })
+
+        const value = yield* client.test.download({})
+        const first = yield* value.body.pipe(Stream.take(1), Stream.runCollect)
+
+        assert.deepStrictEqual(value.headers, { "x-count": 2 })
+        assert.deepStrictEqual(first.map((chunk) => Array.from(chunk)), [[1, 2]])
+      }))
+
+    it.effect("decodes WithHeaders StreamSse bodies and headers", () =>
+      Effect.gen(function*() {
+        const Api = HttpApi.make("Api").add(
+          HttpApiGroup.make("test").add(
+            HttpApiEndpoint.get("events", "/events", {
+              success: HttpApiSchema.WithHeaders(
+                HttpApiSchema.StreamSse({
+                  data: Schema.Struct({ text: Schema.String }),
+                  error: StreamError
+                }),
+                { "x-count": Schema.Int }
+              )
+            })
+          )
+        )
+        const client = yield* HttpApiClient.makeWith(Api, {
+          baseUrl: "http://test",
+          httpClient: clientFromResponse(() =>
+            new Response(textStream([`data: {"text":"hello"}\n\n`]), {
+              status: 200,
+              headers: {
+                "content-type": "text/event-stream",
+                "x-count": "1"
+              }
+            })
+          )
+        })
+
+        const value = yield* client.test.events({})
+        const events = yield* Stream.runCollect(value.body)
+
+        assert.deepStrictEqual(value.headers, { "x-count": 1 })
+        assert.deepStrictEqual(events, [{ text: "hello" }])
+      }))
+
+    it.effect("fails invalid WithHeaders stream headers before returning the body", () =>
+      Effect.gen(function*() {
+        const Api = HttpApi.make("Api").add(
+          HttpApiGroup.make("test").add(
+            HttpApiEndpoint.get("download", "/download", {
+              success: HttpApiSchema.WithHeaders(
+                HttpApiSchema.StreamUint8Array(),
+                { "x-count": Schema.Int }
+              )
+            })
+          )
+        )
+        const client = yield* HttpApiClient.makeWith(Api, {
+          baseUrl: "http://test",
+          httpClient: clientFromResponse(() =>
+            new Response(byteStream([new Uint8Array([1])]), {
+              status: 200,
+              headers: { "x-count": "invalid" }
+            })
+          )
+        })
+
+        const exit = yield* Effect.exit(client.test.download({}))
+
+        assert.strictEqual(exit._tag, "Failure")
+        if (exit._tag === "Failure") {
+          assert.strictEqual((Cause.squash(exit.cause) as { readonly _tag?: string })._tag, "SchemaError")
+        }
+      }))
+
+    it.effect("selects a WithHeaders stream from a mixed buffered success by content type", () =>
+      Effect.gen(function*() {
+        const Api = HttpApi.make("Api").add(
+          HttpApiGroup.make("test").add(
+            HttpApiEndpoint.get("chat", "/chat", {
+              success: [
+                Schema.Struct({ message: Schema.String }),
+                HttpApiSchema.WithHeaders(
+                  HttpApiSchema.StreamSse({ data: Schema.Struct({ text: Schema.String }) }),
+                  { "x-count": Schema.Int }
+                )
+              ]
+            })
+          )
+        )
+        const client = yield* HttpApiClient.makeWith(Api, {
+          baseUrl: "http://test",
+          httpClient: clientFromResponse(() =>
+            new Response(textStream([`data: {"text":"hello"}\n\n`]), {
+              status: 200,
+              headers: {
+                "content-type": "text/event-stream; charset=utf-8",
+                "x-count": "1"
+              }
+            })
+          )
+        })
+
+        const value = yield* client.test.chat({})
+        if (!(HttpApiSchema.WithHeadersValueTypeId in value)) {
+          throw new Error("Expected WithHeaders response")
+        }
+        const events = yield* Stream.runCollect(value.body)
+
+        assert.deepStrictEqual(value.headers, { "x-count": 1 })
+        assert.deepStrictEqual(events, [{ text: "hello" }])
+      }))
+
     it.effect("decodes StreamSse successes at the annotated status", () =>
       Effect.gen(function*() {
         const client = yield* HttpApiClient.makeWith(AnnotatedStreamingApi, {

--- a/packages/effect/test/unstable/httpapi/HttpApiEndpoint.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiEndpoint.test.ts
@@ -208,7 +208,7 @@ describe("HttpApiEndpoint streaming success schemas", () => {
   })
 })
 
-describe("HttpApiEndpoint WithHeaders success schemas", () => {
+describe("HttpApiEndpoint WithHeaders schemas", () => {
   it("keeps the wrapper in the success set with codec-transformed parts", () => {
     const endpoint = HttpApiEndpoint.get("list", "/users", {
       success: HttpApiSchema.WithHeaders(Schema.Struct({ a: Schema.String }), {
@@ -297,11 +297,22 @@ describe("HttpApiEndpoint WithHeaders success schemas", () => {
     )
   })
 
-  it("WithHeaders in error throws during endpoint construction", () => {
-    assert.throws(() =>
-      HttpApiEndpoint.get("list", "/users", {
-        error: HttpApiSchema.WithHeaders(Schema.String, { "x-count": Schema.Int }) as any
-      })
-    )
+  it("keeps WithHeaders in the error set with codec-transformed parts", () => {
+    const endpoint = HttpApiEndpoint.get("list", "/users", {
+      error: HttpApiSchema.WithHeaders(
+        Schema.Struct({ message: Schema.String }).pipe(HttpApiSchema.status(429)),
+        { "retry-after": Schema.Int }
+      )
+    })
+
+    const [schema] = Array.from(endpoint.error)
+    assert.isTrue(HttpApiSchema.isWithHeaders(schema))
+    assert.strictEqual(HttpApiSchema.getStatusErrorSchema(schema), 429)
+    if (HttpApiSchema.isWithHeaders(schema)) {
+      assert.deepStrictEqual(
+        Schema.encodeSync(schema.headers as any)({ "retry-after": 30 }),
+        { "retry-after": "30" }
+      )
+    }
   })
 })

--- a/packages/effect/test/unstable/httpapi/HttpApiEndpoint.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiEndpoint.test.ts
@@ -248,6 +248,108 @@ describe("HttpApiEndpoint WithHeaders schemas", () => {
     )
   })
 
+  it("rejects two WithHeaders successes sharing a status across content types", () => {
+    assert.throws(
+      () =>
+        HttpApiEndpoint.get("get", "/", {
+          success: [
+            HttpApiSchema.WithHeaders(
+              Schema.Struct({ value: Schema.String }),
+              { "x-json": Schema.String }
+            ),
+            HttpApiSchema.WithHeaders(
+              Schema.String.pipe(HttpApiSchema.asText()),
+              { "x-text": Schema.String }
+            )
+          ]
+        }),
+      "Cannot declare multiple responses with headers for status 200"
+    )
+  })
+
+  it("rejects two encodeToWithHeaders errors sharing a status", () => {
+    const JsonError = Schema.String.pipe(
+      HttpApiSchema.encodeToWithHeaders({
+        body: Schema.Struct({ message: Schema.String }),
+        headers: { "x-json": Schema.String }
+      }, {
+        decode: ({ body }) => body.message,
+        encode: (message) => ({ body: { message }, headers: { "x-json": "json" } })
+      })
+    )
+    const TextError = Schema.String.pipe(
+      HttpApiSchema.encodeToWithHeaders({
+        body: Schema.String.pipe(HttpApiSchema.asText()),
+        headers: { "x-text": Schema.String }
+      }, {
+        decode: ({ body }) => body,
+        encode: (message) => ({ body: message, headers: { "x-text": "text" } })
+      })
+    )
+
+    assert.throws(
+      () => HttpApiEndpoint.get("get", "/", { error: [JsonError, TextError] }),
+      "Cannot declare multiple responses with headers for status 500"
+    )
+  })
+
+  it("rejects mixed WithHeaders and encodeToWithHeaders responses sharing a status", () => {
+    const AnnotatedError = Schema.String.pipe(
+      HttpApiSchema.encodeToWithHeaders({
+        body: Schema.String.pipe(HttpApiSchema.status(429), HttpApiSchema.asText()),
+        headers: { "retry-after": Schema.String }
+      }, {
+        decode: ({ body }) => body,
+        encode: (message) => ({ body: message, headers: { "retry-after": "30" } })
+      })
+    )
+
+    assert.throws(
+      () =>
+        HttpApiEndpoint.get("get", "/", {
+          error: [
+            HttpApiSchema.WithHeaders(
+              Schema.Struct({ message: Schema.String }).pipe(HttpApiSchema.status(429)),
+              { "x-trace-id": Schema.String }
+            ),
+            AnnotatedError
+          ]
+        }),
+      "Cannot declare multiple responses with headers for status 429"
+    )
+  })
+
+  it("allows one response with headers and a plain response for the same status across content types", () => {
+    const endpoint = HttpApiEndpoint.get("get", "/", {
+      success: [
+        HttpApiSchema.WithHeaders(
+          Schema.Struct({ value: Schema.String }),
+          { "x-trace-id": Schema.String }
+        ),
+        Schema.String.pipe(HttpApiSchema.asText())
+      ]
+    })
+
+    assert.strictEqual(endpoint.success.size, 2)
+  })
+
+  it("allows responses with headers on distinct statuses", () => {
+    const endpoint = HttpApiEndpoint.get("get", "/", {
+      success: [
+        HttpApiSchema.WithHeaders(
+          Schema.Struct({ value: Schema.String }),
+          { "x-trace-id": Schema.String }
+        ),
+        HttpApiSchema.WithHeaders(
+          Schema.Struct({ created: Schema.Boolean }).pipe(HttpApiSchema.status(201)),
+          { location: Schema.String }
+        )
+      ]
+    })
+
+    assert.strictEqual(endpoint.success.size, 2)
+  })
+
   it("keeps the wrapper in the success set with codec-transformed parts", () => {
     const endpoint = HttpApiEndpoint.get("list", "/users", {
       success: HttpApiSchema.WithHeaders(Schema.Struct({ a: Schema.String }), {

--- a/packages/effect/test/unstable/httpapi/HttpApiEndpoint.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiEndpoint.test.ts
@@ -209,6 +209,45 @@ describe("HttpApiEndpoint streaming success schemas", () => {
 })
 
 describe("HttpApiEndpoint WithHeaders schemas", () => {
+  it("rejects a WithHeaders success sharing its status and content type", () => {
+    assert.throws(
+      () =>
+        HttpApiEndpoint.get("get", "/", {
+          success: [
+            Schema.Struct({ plain: Schema.String }),
+            HttpApiSchema.WithHeaders(
+              Schema.Struct({ wrapped: Schema.String }),
+              { "x-trace-id": Schema.String }
+            )
+          ]
+        }),
+      "Cannot combine a response with headers with another response for status 200 and content-type: application/json"
+    )
+  })
+
+  it("rejects an encodeToWithHeaders error sharing its status and content type", () => {
+    const ErrorWithHeaders = Schema.String.pipe(
+      HttpApiSchema.encodeToWithHeaders({
+        body: Schema.Struct({ wrapped: Schema.String }),
+        headers: { "x-trace-id": Schema.String }
+      }, {
+        decode: ({ body }) => body.wrapped,
+        encode: (message) => ({ body: { wrapped: message }, headers: { "x-trace-id": "trace" } })
+      })
+    )
+
+    assert.throws(
+      () =>
+        HttpApiEndpoint.get("get", "/", {
+          error: [
+            Schema.Struct({ plain: Schema.String }),
+            ErrorWithHeaders
+          ]
+        }),
+      "Cannot combine a response with headers with another response for status 500 and content-type: application/json"
+    )
+  })
+
   it("keeps the wrapper in the success set with codec-transformed parts", () => {
     const endpoint = HttpApiEndpoint.get("list", "/users", {
       success: HttpApiSchema.WithHeaders(Schema.Struct({ a: Schema.String }), {

--- a/packages/effect/test/unstable/httpapi/HttpApiEndpoint.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiEndpoint.test.ts
@@ -207,3 +207,101 @@ describe("HttpApiEndpoint streaming success schemas", () => {
     )
   })
 })
+
+describe("HttpApiEndpoint WithHeaders success schemas", () => {
+  it("keeps the wrapper in the success set with codec-transformed parts", () => {
+    const endpoint = HttpApiEndpoint.get("list", "/users", {
+      success: HttpApiSchema.WithHeaders(Schema.Struct({ a: Schema.String }), {
+        "x-count": Schema.Int
+      })
+    })
+
+    const [schema] = Array.from(endpoint.success)
+    assert.isTrue(HttpApiSchema.isWithHeaders(schema))
+    if (HttpApiSchema.isWithHeaders(schema)) {
+      assert.deepStrictEqual(
+        Schema.encodeSync(schema.headers as any)({ "x-count": 3 }),
+        { "x-count": "3" }
+      )
+    }
+  })
+
+  it("leaves the wrapper untouched when codecs are disabled", () => {
+    const wrapped = HttpApiSchema.WithHeaders(Schema.Struct({ a: Schema.String }), {
+      "x-count": Schema.Int
+    })
+    const endpoint = HttpApiEndpoint.get("list", "/users", {
+      disableCodecs: true,
+      success: wrapped
+    })
+
+    assert.isTrue(endpoint.success.has(wrapped))
+  })
+
+  it("keeps a wrapped stream schema as the inner schema", () => {
+    const stream = sse()
+    const endpoint = HttpApiEndpoint.get("events", "/events", {
+      success: HttpApiSchema.WithHeaders(stream, { "x-count": Schema.Int })
+    })
+
+    const [schema] = Array.from(endpoint.success)
+    assert.isTrue(HttpApiSchema.isWithHeaders(schema))
+    if (HttpApiSchema.isWithHeaders(schema)) {
+      assert.strictEqual(schema.schema, stream)
+    }
+  })
+
+  it("preserves wrapper annotations through endpoint construction", () => {
+    const endpoint = HttpApiEndpoint.get("list", "/users", {
+      success: HttpApiSchema.WithHeaders(Schema.Struct({ a: Schema.String }), {
+        "x-count": Schema.Int
+      }).pipe(HttpApiSchema.status(201))
+    })
+
+    const [schema] = Array.from(endpoint.success)
+    assert.strictEqual(HttpApiSchema.getStatusSuccessSchema(schema), 201)
+  })
+
+  it("validates a wrapped stream like a bare stream", () => {
+    assert.throws(() =>
+      HttpApiEndpoint.get("events", "/events", {
+        success: [
+          HttpApiSchema.WithHeaders(sse(), { "x-count": Schema.Int }),
+          HttpApiSchema.StreamUint8Array({ contentType: "application/custom-stream" })
+        ]
+      })
+    )
+    assert.throws(() =>
+      HttpApiEndpoint.head("events", "/events", {
+        success: HttpApiSchema.WithHeaders(sse(), { "x-count": Schema.Int }) as any
+      })
+    )
+  })
+
+  it("resolves the status from the wrapper when validating per-status combinations", () => {
+    const wrapped = HttpApiSchema.WithHeaders(sse(), { "x-count": Schema.Int })
+      .pipe(HttpApiSchema.status(206))
+    const endpoint = HttpApiEndpoint.get("events", "/events", {
+      success: [wrapped, sse()]
+    })
+
+    assert.strictEqual(endpoint.success.size, 2)
+
+    assert.throws(() =>
+      HttpApiEndpoint.get("events", "/events", {
+        success: [
+          HttpApiSchema.WithHeaders(sse(), { "x-count": Schema.Int }),
+          sse()
+        ]
+      })
+    )
+  })
+
+  it("WithHeaders in error throws during endpoint construction", () => {
+    assert.throws(() =>
+      HttpApiEndpoint.get("list", "/users", {
+        error: HttpApiSchema.WithHeaders(Schema.String, { "x-count": Schema.Int }) as any
+      })
+    )
+  })
+})

--- a/packages/effect/test/unstable/httpapi/HttpApiEndpoint.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiEndpoint.test.ts
@@ -178,17 +178,16 @@ describe("HttpApiEndpoint streaming success schemas", () => {
     )
   })
 
-  it("two streaming successes for distinct statuses are allowed", () => {
+  it("two streaming successes for distinct statuses throw", () => {
     const stream = HttpApiSchema.status(206)(sse())
     const bytes = HttpApiSchema.status(200)(
       HttpApiSchema.StreamUint8Array({ contentType: "application/custom-stream" })
     )
-    const endpoint = HttpApiEndpoint.get("events", "/events", {
-      success: [stream, bytes]
-    })
 
-    assert.isTrue(endpoint.success.has(stream))
-    assert.isTrue(endpoint.success.has(bytes))
+    assert.throws(
+      () => HttpApiEndpoint.get("events", "/events", { success: [stream, bytes] }),
+      "Multiple streaming success responses are not supported"
+    )
   })
 
   it("statically detectable SSE reserved failure event name throws", () => {
@@ -419,22 +418,34 @@ describe("HttpApiEndpoint WithHeaders schemas", () => {
     )
   })
 
-  it("resolves the status from the wrapper when validating per-status combinations", () => {
-    const wrapped = HttpApiSchema.WithHeaders(sse(), { "x-count": Schema.Int })
-      .pipe(HttpApiSchema.status(206))
-    const endpoint = HttpApiEndpoint.get("events", "/events", {
-      success: [wrapped, sse()]
-    })
+  it("rejects wrapped and bare streams at distinct statuses", () => {
+    assert.throws(
+      () =>
+        HttpApiEndpoint.get("events", "/events", {
+          success: [
+            HttpApiSchema.status(206)(
+              HttpApiSchema.StreamUint8Array({ contentType: "application/custom-bytes" })
+            ),
+            HttpApiSchema.WithHeaders(
+              HttpApiSchema.status(201)(
+                HttpApiSchema.StreamUint8Array({ contentType: "application/other-bytes" })
+              ),
+              { "x-source": Schema.String }
+            )
+          ]
+        }),
+      "Multiple streaming success responses are not supported"
+    )
 
-    assert.strictEqual(endpoint.success.size, 2)
-
-    assert.throws(() =>
-      HttpApiEndpoint.get("events", "/events", {
-        success: [
-          HttpApiSchema.WithHeaders(sse(), { "x-count": Schema.Int }),
-          sse()
-        ]
-      })
+    assert.throws(
+      () =>
+        HttpApiEndpoint.get("events", "/events", {
+          success: [
+            HttpApiSchema.WithHeaders(sse(), { "x-count": Schema.Int }),
+            sse()
+          ]
+        }),
+      "Multiple streaming success responses are not supported"
     )
   })
 

--- a/packages/effect/test/unstable/httpapi/HttpApiSchema.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiSchema.test.ts
@@ -115,6 +115,161 @@ describe("HttpApiSchema", () => {
     })
   })
 
+  describe("WithHeaders", () => {
+    it("stores the inner schema and headers schema", () => {
+      const headers = Schema.Struct({ "x-total-count": Schema.FiniteFromString })
+      const schema = HttpApiSchema.WithHeaders(Schema.String, headers)
+
+      assert.isTrue(Schema.isSchema(schema))
+      assert.isTrue(HttpApiSchema.isWithHeaders(schema))
+      assert.strictEqual(schema.schema, Schema.String)
+      assert.strictEqual(schema.headers, headers)
+    })
+
+    it("does not identify other schemas as WithHeaders", () => {
+      assert.isFalse(HttpApiSchema.isWithHeaders(Schema.String))
+      assert.isFalse(HttpApiSchema.isWithHeaders(HttpApiSchema.StreamUint8Array()))
+    })
+
+    it("supports a fields shorthand for headers", () => {
+      const schema = HttpApiSchema.WithHeaders(Schema.String, {
+        "x-total-count": Schema.FiniteFromString
+      })
+
+      assert.isTrue(Schema.isSchema(schema.headers))
+      assert.deepStrictEqual(Object.keys(schema.headers.fields), ["x-total-count"])
+    })
+
+    it("rejects nested WithHeaders schemas", () => {
+      const inner = HttpApiSchema.WithHeaders(Schema.String, { "x-a": Schema.String })
+
+      assert.throws(
+        () => HttpApiSchema.WithHeaders(inner, { "x-b": Schema.String }),
+        "WithHeaders schemas cannot be nested"
+      )
+    })
+
+    it("accepts only branded values when decoding", () => {
+      const schema = HttpApiSchema.WithHeaders(Schema.String, { "x-a": Schema.String })
+      const value = HttpApiSchema.withHeaders({ body: "a", headers: { "x-a": "1" } })
+
+      assert.strictEqual(Schema.decodeUnknownSync(schema)(value), value)
+      assert.throws(() => Schema.decodeUnknownSync(schema)({ body: "a", headers: { "x-a": "1" } }))
+    })
+
+    it("keeps the wrapper intact through annotate", () => {
+      const headers = Schema.Struct({ "x-a": Schema.String })
+      const schema = HttpApiSchema.WithHeaders(Schema.String, headers).annotate({ description: "described" })
+
+      assert.isTrue(HttpApiSchema.isWithHeaders(schema))
+      assert.strictEqual(schema.schema, Schema.String)
+      assert.strictEqual(schema.headers, headers)
+    })
+
+    it("resolves the status from the wrapper first, falling through to the inner schema", () => {
+      const headers = Schema.Struct({ "x-a": Schema.String })
+
+      const onInner = HttpApiSchema.WithHeaders(Schema.String.pipe(HttpApiSchema.status(201)), headers)
+      assert.strictEqual(HttpApiSchema.getStatusSuccessSchema(onInner), 201)
+
+      const onWrapper = HttpApiSchema.WithHeaders(Schema.String, headers).pipe(HttpApiSchema.status(202))
+      assert.isTrue(HttpApiSchema.isWithHeaders(onWrapper))
+      assert.strictEqual(HttpApiSchema.getStatusSuccessSchema(onWrapper), 202)
+
+      const onBoth = HttpApiSchema.WithHeaders(Schema.String.pipe(HttpApiSchema.status(201)), headers)
+        .pipe(HttpApiSchema.status(202))
+      assert.strictEqual(HttpApiSchema.getStatusSuccessSchema(onBoth), 202)
+
+      const onNeither = HttpApiSchema.WithHeaders(Schema.String, headers)
+      assert.strictEqual(HttpApiSchema.getStatusSuccessSchema(onNeither), 200)
+
+      assert.strictEqual(HttpApiSchema.getStatusSuccessSchema(Schema.String.pipe(HttpApiSchema.status(201))), 201)
+    })
+
+    it("resolves the response encoding from the wrapper first, falling through to the inner schema", () => {
+      const headers = Schema.Struct({ "x-a": Schema.String })
+
+      const onInner = HttpApiSchema.WithHeaders(Schema.String.pipe(HttpApiSchema.asText()), headers)
+      assert.strictEqual(HttpApiSchema.getResponseEncodingSchema(onInner)._tag, "Text")
+
+      const onWrapper = HttpApiSchema.WithHeaders(Schema.String, headers).pipe(
+        HttpApiSchema.asJson({ contentType: "application/vnd.custom+json" })
+      )
+      assert.isTrue(HttpApiSchema.isWithHeaders(onWrapper))
+      assert.strictEqual(
+        HttpApiSchema.getResponseEncodingSchema(onWrapper).contentType,
+        "application/vnd.custom+json"
+      )
+
+      const onNeither = HttpApiSchema.WithHeaders(Schema.String, headers)
+      assert.strictEqual(HttpApiSchema.getResponseEncodingSchema(onNeither)._tag, "Json")
+    })
+  })
+
+  describe("withHeaders", () => {
+    it("constructs a branded response value", () => {
+      const value = HttpApiSchema.withHeaders({ body: "a", headers: { "x-a": "1" } })
+
+      assert.strictEqual(value.body, "a")
+      assert.deepStrictEqual(value.headers, { "x-a": "1" })
+    })
+  })
+
+  describe("encodeToWithHeaders", () => {
+    class UserNotFound extends Schema.TaggedError<UserNotFound>()("UserNotFound", {
+      userId: Schema.Int
+    }) {}
+
+    const WrappedUserNotFound = UserNotFound.pipe(
+      HttpApiSchema.encodeToWithHeaders({
+        body: HttpApiSchema.Empty(404),
+        headers: { "x-user-id": Schema.Int }
+      }, {
+        decode: ({ headers }) => new UserNotFound({ userId: headers["x-user-id"] }),
+        encode: (error) => ({
+          headers: { "x-user-id": error.userId },
+          body: undefined
+        })
+      })
+    )
+
+    it("encodes to a body and headers pair", () => {
+      assert.deepStrictEqual(
+        Schema.encodeSync(WrappedUserNotFound)(new UserNotFound({ userId: 1 })),
+        { body: undefined, headers: { "x-user-id": 1 } }
+      )
+    })
+
+    it("decodes a pair back to the source type", () => {
+      assert.deepStrictEqual(
+        Schema.decodeUnknownSync(WrappedUserNotFound)({ body: undefined, headers: { "x-user-id": 1 } }),
+        new UserNotFound({ userId: 1 })
+      )
+    })
+
+    it("resolves the status from the body schema", () => {
+      assert.strictEqual(HttpApiSchema.getStatusError(WrappedUserNotFound.ast), 404)
+    })
+
+    it("resolves the response encoding from the body schema", () => {
+      const schema = Schema.String.pipe(
+        HttpApiSchema.encodeToWithHeaders({
+          body: Schema.String.pipe(HttpApiSchema.asText()),
+          headers: { "x-a": Schema.String }
+        }, {
+          decode: ({ body }) => body,
+          encode: (value) => ({ body: value, headers: { "x-a": "1" } })
+        })
+      )
+
+      assert.strictEqual(HttpApiSchema.getResponseEncoding(schema.ast)._tag, "Text")
+    })
+
+    it("defaults the response encoding to Json", () => {
+      assert.strictEqual(HttpApiSchema.getResponseEncoding(WrappedUserNotFound.ast)._tag, "Json")
+    })
+  })
+
   it("does not identify buffered schemas as stream schemas", () => {
     assert.isFalse(HttpApiSchema.isStreamSchema(Schema.String))
     assert.isFalse(HttpApiSchema.isStreamSchema(Schema.Uint8Array.pipe(HttpApiSchema.asUint8Array())))

--- a/packages/effect/test/unstable/httpapi/OpenApi.test.ts
+++ b/packages/effect/test/unstable/httpapi/OpenApi.test.ts
@@ -196,6 +196,46 @@ describe("OpenApi", () => {
     })
   })
 
+  it("emits encodeToWithHeaders wire schemas according to codec mode", () => {
+    const ErrorWithHeaders = Schema.Number.pipe(
+      HttpApiSchema.encodeToWithHeaders({
+        body: HttpApiSchema.Empty(404),
+        headers: { "X-Error-Id": Schema.Int }
+      }, {
+        decode: ({ headers }) => headers["X-Error-Id"],
+        encode: (id) => ({ body: undefined, headers: { "X-Error-Id": id } })
+      })
+    )
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("test")
+        .add(
+          HttpApiEndpoint.get("encoded", "/encoded", {
+            error: ErrorWithHeaders
+          })
+        )
+        .add(
+          HttpApiEndpoint.get("unencoded", "/unencoded", {
+            disableCodecs: true,
+            error: ErrorWithHeaders
+          })
+        )
+    )
+
+    const spec = OpenApi.fromApi(Api)
+
+    assert.deepStrictEqual(
+      spec.paths["/encoded"]?.get?.responses[404]?.headers?.["x-error-id"]?.schema,
+      {
+        type: "string",
+        allOf: [{ pattern: "^[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?$" }]
+      }
+    )
+    assert.deepStrictEqual(
+      spec.paths["/unencoded"]?.get?.responses[404]?.headers?.["x-error-id"]?.schema,
+      { type: "integer" }
+    )
+  })
+
   it("emits headers for an error wrapped in WithHeaders", () => {
     const Api = HttpApi.make("Api").add(
       HttpApiGroup.make("test").add(

--- a/packages/effect/test/unstable/httpapi/OpenApi.test.ts
+++ b/packages/effect/test/unstable/httpapi/OpenApi.test.ts
@@ -138,6 +138,88 @@ describe("OpenApi", () => {
     assert.property(streamExtension, "errorSchema")
   })
 
+  it("emits encoded success response headers", () => {
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("test").add(
+        HttpApiEndpoint.get("success", "/success", {
+          success: HttpApiSchema.WithHeaders(Schema.String, {
+            "X-Count": Schema.FiniteFromString,
+            "X-Optional": Schema.optionalKey(Schema.FiniteFromString),
+            "Content-Type": Schema.String
+          })
+        })
+      )
+    )
+
+    const spec = OpenApi.fromApi(Api)
+
+    assert.deepStrictEqual(spec.paths["/success"]?.get?.responses[200]?.headers, {
+      "x-count": {
+        schema: { type: "string" },
+        required: true
+      },
+      "x-optional": {
+        schema: { type: "string" },
+        required: false
+      }
+    })
+  })
+
+  it("emits encoded error response headers", () => {
+    class NotFound extends Schema.TaggedError<NotFound>()("NotFound", {
+      id: Schema.Number
+    }) {}
+    const NotFoundWithHeaders = NotFound.pipe(
+      HttpApiSchema.encodeToWithHeaders({
+        body: HttpApiSchema.Empty(404),
+        headers: { "X-Error-Id": Schema.FiniteFromString }
+      }, {
+        decode: ({ headers }) => new NotFound({ id: headers["X-Error-Id"] }),
+        encode: (error) => ({ body: undefined, headers: { "X-Error-Id": error.id } })
+      })
+    )
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("test").add(
+        HttpApiEndpoint.get("error", "/error", {
+          error: NotFoundWithHeaders
+        })
+      )
+    )
+
+    const spec = OpenApi.fromApi(Api)
+
+    assert.deepStrictEqual(spec.paths["/error"]?.get?.responses[404]?.headers, {
+      "x-error-id": {
+        schema: { type: "string" },
+        required: true
+      }
+    })
+  })
+
+  it("emits stream response headers", () => {
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("test").add(
+        HttpApiEndpoint.get("stream", "/stream", {
+          success: HttpApiSchema.WithHeaders(HttpApiSchema.StreamUint8Array(), {
+            "X-Stream-Id": Schema.Int
+          })
+        })
+      )
+    )
+
+    const spec = OpenApi.fromApi(Api)
+
+    assert.deepStrictEqual(spec.paths["/stream"]?.get?.responses[200]?.headers, {
+      "x-stream-id": {
+        schema: {
+          type: "string",
+          allOf: [{ pattern: "^[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?$" }]
+        },
+        required: true
+      }
+    })
+  })
+
   it("rejects duplicate method and path pairs", () => {
     const Api = HttpApi.make("Api").add(
       HttpApiGroup.make("test").add(

--- a/packages/effect/test/unstable/httpapi/OpenApi.test.ts
+++ b/packages/effect/test/unstable/httpapi/OpenApi.test.ts
@@ -196,6 +196,31 @@ describe("OpenApi", () => {
     })
   })
 
+  it("emits headers for an error wrapped in WithHeaders", () => {
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("test").add(
+        HttpApiEndpoint.get("error", "/error", {
+          error: HttpApiSchema.WithHeaders(
+            Schema.Struct({ message: Schema.String }).pipe(HttpApiSchema.status(429)),
+            { "X-Retry-After": Schema.Int }
+          )
+        })
+      )
+    )
+
+    const spec = OpenApi.fromApi(Api)
+
+    assert.deepStrictEqual(spec.paths["/error"]?.get?.responses[429]?.headers, {
+      "x-retry-after": {
+        schema: {
+          type: "string",
+          allOf: [{ pattern: "^[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?$" }]
+        },
+        required: true
+      }
+    })
+  })
+
   it("emits stream response headers", () => {
     const Api = HttpApi.make("Api").add(
       HttpApiGroup.make("test").add(

--- a/packages/effect/typetest/unstable/httpapi/HttpApiClient.tst.ts
+++ b/packages/effect/typetest/unstable/httpapi/HttpApiClient.tst.ts
@@ -641,6 +641,76 @@ describe("HttpApiClient", () => {
       >()
     })
 
+    it("widens only the body stream errors for WithHeaders StreamSse successes", () => {
+      const Api = HttpApi.make("Api")
+        .add(
+          HttpApiGroup.make("group")
+            .add(
+              HttpApiEndpoint.get("a", "/a", {
+                success: HttpApiSchema.WithHeaders(
+                  HttpApiSchema.StreamSse({
+                    data: Schema.Struct({ id: Schema.String }),
+                    error: Schema.Struct({ reason: Schema.String })
+                  }),
+                  { "x-count": Schema.Int }
+                )
+              })
+            )
+        )
+      const client = Effect.runSync(
+        HttpApiClient.make(Api).pipe(Effect.provide(FetchHttpClient.layer))
+      )
+      const f = client.group.a
+
+      type ClientStream = Stream.Stream<
+        { readonly id: string },
+        | { readonly reason: string }
+        | HttpClientError.HttpClientError
+        | Schema.SchemaError
+        | Sse.Retry
+        | Sse.SseError
+      >
+      type Success = HttpApiSchema.WithHeaders.Value<ClientStream, { readonly "x-count": number }>
+
+      expect(f()).type.toBe<
+        Effect.Effect<Success, HttpClientError.HttpClientError | Schema.SchemaError>
+      >()
+      expect(f({ responseMode: "decoded-and-response" })).type.toBe<
+        Effect.Effect<
+          [Success, HttpClientResponse.HttpClientResponse],
+          HttpClientError.HttpClientError | Schema.SchemaError
+        >
+      >()
+    })
+
+    it("widens the body transport error for WithHeaders StreamUint8Array successes", () => {
+      const Api = HttpApi.make("Api")
+        .add(
+          HttpApiGroup.make("group")
+            .add(
+              HttpApiEndpoint.get("a", "/a", {
+                success: HttpApiSchema.WithHeaders(
+                  HttpApiSchema.StreamUint8Array(),
+                  { "x-count": Schema.Int }
+                )
+              })
+            )
+        )
+      const client = Effect.runSync(
+        HttpApiClient.make(Api).pipe(Effect.provide(FetchHttpClient.layer))
+      )
+      const f = client.group.a
+
+      type Success = HttpApiSchema.WithHeaders.Value<
+        Stream.Stream<Uint8Array, HttpClientError.HttpClientError>,
+        { readonly "x-count": number }
+      >
+
+      expect(f()).type.toBe<
+        Effect.Effect<Success, HttpClientError.HttpClientError | Schema.SchemaError>
+      >()
+    })
+
     it("returns decoded data streams for StreamSse data successes", () => {
       const Api = HttpApi.make("Api")
         .add(

--- a/packages/effect/typetest/unstable/httpapi/HttpApiClient.tst.ts
+++ b/packages/effect/typetest/unstable/httpapi/HttpApiClient.tst.ts
@@ -670,7 +670,7 @@ describe("HttpApiClient", () => {
         | Sse.Retry
         | Sse.SseError
       >
-      type Success = HttpApiSchema.WithHeaders.Value<ClientStream, { readonly "x-count": number }>
+      type Success = HttpApiSchema.withHeaders<ClientStream, { readonly "x-count": number }>
 
       expect(f()).type.toBe<
         Effect.Effect<Success, HttpClientError.HttpClientError | Schema.SchemaError>
@@ -701,7 +701,7 @@ describe("HttpApiClient", () => {
       )
       const f = client.group.a
 
-      type Success = HttpApiSchema.WithHeaders.Value<
+      type Success = HttpApiSchema.withHeaders<
         Stream.Stream<Uint8Array, HttpClientError.HttpClientError>,
         { readonly "x-count": number }
       >

--- a/packages/effect/typetest/unstable/httpapi/HttpApiEndpoint.tst.ts
+++ b/packages/effect/typetest/unstable/httpapi/HttpApiEndpoint.tst.ts
@@ -468,6 +468,75 @@ describe("HttpApiEndpoint", () => {
       expect(endpoint["~Success"]).type.toBe<typeof stream>()
     })
 
+    it("applies the JSON and string-tree codecs to WithHeaders parts", () => {
+      const Body = Schema.Struct({ a: Schema.String })
+      const Headers = Schema.Struct({ "x-count": Schema.Int })
+      const endpoint = HttpApiEndpoint.get("a", "/a", {
+        success: HttpApiSchema.WithHeaders(Body, Headers)
+      })
+
+      expect(endpoint["~Success"]).type.toBe<
+        HttpApiSchema.WithHeaders<Schema.toCodecJson<typeof Body>, Schema.toCodecStringTree<typeof Headers>>
+      >()
+    })
+
+    it("maps WithHeaders to branded value success and handler types", () => {
+      const endpoint = HttpApiEndpoint.get("a", "/a", {
+        success: HttpApiSchema.WithHeaders(Schema.Struct({ a: Schema.String }), {
+          "x-count": Schema.Int
+        })
+      })
+
+      type Success = HttpApiSchema.WithHeaders.Value<
+        { readonly a: string },
+        { readonly "x-count": number }
+      >
+
+      expect<HttpApiEndpoint.SuccessWithIdentifier<typeof endpoint, "a">>().type.toBe<Success>()
+      expect<ReturnType<HttpApiEndpoint.Handler<typeof endpoint, never, never>>>().type.toBe<
+        Effect.Effect<Success | HttpServerResponse, never>
+      >()
+    })
+
+    it("keeps the stream handler type for a wrapped stream schema", () => {
+      const endpoint = HttpApiEndpoint.get("a", "/a", {
+        success: HttpApiSchema.WithHeaders(
+          HttpApiSchema.StreamSse({
+            data: Schema.Struct({ id: Schema.String }),
+            error: Schema.Struct({ reason: Schema.String })
+          }),
+          { "x-count": Schema.Int }
+        )
+      })
+
+      type Success = HttpApiSchema.WithHeaders.Value<
+        Stream.Stream<{ readonly id: string }, { readonly reason: string }>,
+        { readonly "x-count": number }
+      >
+
+      expect<HttpApiEndpoint.SuccessWithIdentifier<typeof endpoint, "a">>().type.toBe<Success>()
+      expect<ReturnType<HttpApiEndpoint.Handler<typeof endpoint, never, never>>>().type.toBe<
+        Effect.Effect<Success | HttpServerResponse, never>
+      >()
+    })
+
+    it("preserves mixed WithHeaders and plain schemas", () => {
+      const endpoint = HttpApiEndpoint.get("a", "/a", {
+        success: [
+          HttpApiSchema.WithHeaders(Schema.Struct({ a: Schema.String }), {
+            "x-count": Schema.Int
+          }),
+          Schema.String.pipe(HttpApiSchema.status(201), HttpApiSchema.asText())
+        ]
+      })
+
+      type Success =
+        | HttpApiSchema.WithHeaders.Value<{ readonly a: string }, { readonly "x-count": number }>
+        | string
+
+      expect<HttpApiEndpoint.SuccessWithIdentifier<typeof endpoint, "a">>().type.toBe<Success>()
+    })
+
     it("maps StreamUint8Array to stream success and handler types", () => {
       const endpoint = HttpApiEndpoint.get("a", "/a", {
         success: HttpApiSchema.StreamUint8Array()

--- a/packages/effect/typetest/unstable/httpapi/HttpApiEndpoint.tst.ts
+++ b/packages/effect/typetest/unstable/httpapi/HttpApiEndpoint.tst.ts
@@ -487,7 +487,7 @@ describe("HttpApiEndpoint", () => {
         })
       })
 
-      type Success = HttpApiSchema.WithHeaders.Value<
+      type Success = HttpApiSchema.withHeaders<
         { readonly a: string },
         { readonly "x-count": number }
       >
@@ -509,7 +509,7 @@ describe("HttpApiEndpoint", () => {
         )
       })
 
-      type Success = HttpApiSchema.WithHeaders.Value<
+      type Success = HttpApiSchema.withHeaders<
         Stream.Stream<{ readonly id: string }, { readonly reason: string }>,
         { readonly "x-count": number }
       >
@@ -531,7 +531,7 @@ describe("HttpApiEndpoint", () => {
       })
 
       type Success =
-        | HttpApiSchema.WithHeaders.Value<{ readonly a: string }, { readonly "x-count": number }>
+        | HttpApiSchema.withHeaders<{ readonly a: string }, { readonly "x-count": number }>
         | string
 
       expect<HttpApiEndpoint.SuccessWithIdentifier<typeof endpoint, "a">>().type.toBe<Success>()

--- a/packages/effect/typetest/unstable/httpapi/HttpApiSchema.tst.ts
+++ b/packages/effect/typetest/unstable/httpapi/HttpApiSchema.tst.ts
@@ -126,7 +126,7 @@ describe("HttpApiSchema", () => {
       expect(schema.schema).type.toBe<Schema.String>()
       expect(schema.headers).type.toBe<typeof Headers>()
       expect<typeof schema["Type"]>().type.toBe<
-        HttpApiSchema.WithHeaders.Value<string, { readonly "x-total-count": number }>
+        HttpApiSchema.withHeaders<string, { readonly "x-total-count": number }>
       >()
     })
 
@@ -160,7 +160,7 @@ describe("HttpApiSchema", () => {
     it("constructs a branded value", () => {
       const value = HttpApiSchema.withHeaders({ body: "a", headers: { "x-a": "1" } })
 
-      expect(value).type.toBe<HttpApiSchema.WithHeaders.Value<string, { "x-a": string }>>()
+      expect(value).type.toBe<HttpApiSchema.withHeaders<string, { "x-a": string }>>()
       expect(value.body).type.toBe<string>()
     })
   })

--- a/packages/effect/typetest/unstable/httpapi/HttpApiSchema.tst.ts
+++ b/packages/effect/typetest/unstable/httpapi/HttpApiSchema.tst.ts
@@ -117,6 +117,81 @@ describe("HttpApiSchema", () => {
     })
   })
 
+  describe("WithHeaders", () => {
+    it("preserves the inner schema and headers schema types", () => {
+      const Headers = Schema.Struct({ "x-total-count": Schema.FiniteFromString })
+      const schema = HttpApiSchema.WithHeaders(Schema.String, Headers)
+
+      expect(schema).type.toBe<HttpApiSchema.WithHeaders<Schema.String, typeof Headers>>()
+      expect(schema.schema).type.toBe<Schema.String>()
+      expect(schema.headers).type.toBe<typeof Headers>()
+      expect<typeof schema["Type"]>().type.toBe<
+        HttpApiSchema.WithHeaders.Value<string, { readonly "x-total-count": number }>
+      >()
+    })
+
+    it("supports a fields shorthand for headers", () => {
+      const schema = HttpApiSchema.WithHeaders(Schema.String, {
+        "x-total-count": Schema.FiniteFromString
+      })
+
+      expect(schema).type.toBe<
+        HttpApiSchema.WithHeaders<Schema.String, Schema.Struct<{ "x-total-count": Schema.FiniteFromString }>>
+      >()
+    })
+
+    it("preserves the wrapper type when annotated with status", () => {
+      const Headers = Schema.Struct({ "x-total-count": Schema.FiniteFromString })
+      const schema = HttpApiSchema.WithHeaders(Schema.String, Headers).pipe(HttpApiSchema.status(201))
+
+      expect(schema).type.toBe<HttpApiSchema.WithHeaders<Schema.String, typeof Headers>>()
+    })
+
+    it("preserves schema services", () => {
+      const Headers = Schema.Struct({ "x-total-count": Schema.FiniteFromString })
+      const schema = HttpApiSchema.WithHeaders(Schema.String, Headers)
+
+      expect<typeof schema["DecodingServices"]>().type.toBe<never>()
+      expect<typeof schema["EncodingServices"]>().type.toBe<never>()
+    })
+  })
+
+  describe("withHeaders", () => {
+    it("constructs a branded value", () => {
+      const value = HttpApiSchema.withHeaders({ body: "a", headers: { "x-a": "1" } })
+
+      expect(value).type.toBe<HttpApiSchema.WithHeaders.Value<string, { "x-a": string }>>()
+      expect(value.body).type.toBe<string>()
+    })
+  })
+
+  describe("encodeToWithHeaders", () => {
+    it("keeps the source Type and encodes to a body and headers pair", () => {
+      class UserNotFound extends Schema.TaggedError<UserNotFound>()("UserNotFound", {
+        userId: Schema.Int
+      }) {}
+
+      const schema = UserNotFound.pipe(
+        HttpApiSchema.encodeToWithHeaders({
+          body: HttpApiSchema.Empty(404),
+          headers: { "x-user-id": Schema.Int }
+        }, {
+          decode: ({ headers }) => new UserNotFound({ userId: headers["x-user-id"] }),
+          encode: (error) => ({
+            headers: { "x-user-id": error.userId },
+            body: undefined
+          })
+        })
+      )
+
+      expect<typeof schema["Type"]>().type.toBe<UserNotFound>()
+      expect<typeof schema["Encoded"]>().type.toBeAssignableTo<{
+        readonly body: void
+        readonly headers: { readonly "x-user-id": number }
+      }>()
+    })
+  })
+
   describe("StreamUint8Array", () => {
     it("constructs the stream schema", () => {
       const stream = HttpApiSchema.StreamUint8Array()


### PR DESCRIPTION
## Summary

- Add `HttpApiSchema.WithHeaders` and branded `withHeaders` response values for typed success headers across handlers and generated clients.
- Add `HttpApiSchema.encodeToWithHeaders` for folding response headers into domain types such as error classes.
- Encode and decode buffered and streaming response headers in `HttpApiBuilder`, `HttpApiClient`, and `HttpApiTest`, including mixed-success dispatch and user-managed codecs.
- Render declared response headers in OpenAPI and document the public API, stream behavior, and overlapping-union constraint.
- Make explicit `content-type` and `content-length` values applied through `HttpServerResponse.setHeader` or `setHeaders` override body-derived values.

Closes EFF-369
Closes EFF-448

## Validation

- `pnpm check`
- `pnpm lint`
- `pnpm vitest --run --project effect test/unstable/httpapi/` (150 passed)
- `pnpm doctest --run packages/effect/src/unstable/httpapi/HttpApiSchema.ts` (3 passed)
- Root `pnpm docgen` reaches only the pre-existing `HttpStaticServer` example error for the missing `HttpPlatform.compression` field; the new examples typecheck and execute successfully.
