### PR TITLE
Expose the encoded type from TestSchema.Encoding.encodeUnknownEffect

### DIFF
--- a/.changeset/calm-schemas-encode.md
+++ b/.changeset/calm-schemas-encode.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix the encoded output type of `TestSchema.Encoding.encodeUnknownEffect`.

--- a/packages/effect/src/testing/TestSchema.ts
+++ b/packages/effect/src/testing/TestSchema.ts
@@ -459,7 +459,7 @@ export class Encoding<S extends Schema.Constraint> {
   readonly encodeUnknownEffect: (
     input: unknown,
     options?: SchemaAST.ParseOptions
-  ) => Effect.Effect<S["Type"], SchemaIssue.Issue, S["EncodingServices"]>
+  ) => Effect.Effect<S["Encoded"], SchemaIssue.Issue, S["EncodingServices"]>
   readonly options?: {
     readonly parseOptions?: SchemaAST.ParseOptions | undefined
   } | undefined

--- a/packages/effect/typetest/TestSchema.tst.ts
+++ b/packages/effect/typetest/TestSchema.tst.ts
@@ -1,0 +1,12 @@
+import type { Effect, SchemaIssue } from "effect"
+import { Schema } from "effect"
+import { TestSchema } from "effect/testing"
+import { describe, expect, it } from "tstyche"
+
+describe("TestSchema", () => {
+  it("types Encoding.encodeUnknownEffect with the encoded output", () => {
+    const encoding = new TestSchema.Asserts(Schema.NumberFromString).encoding()
+
+    expect(encoding.encodeUnknownEffect(1)).type.toBe<Effect.Effect<string, SchemaIssue.Issue>>()
+  })
+})


### PR DESCRIPTION
## Summary

TestSchema.Encoding.encodeUnknownEffect is typed as succeeding with the decoded Type even though it returns the Encoded value.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Encoding.encodeUnknownEffect exposes the decoded type

**Module:** `TestSchema`  
**Audit ID:** `core-s-z-testing-test-schema-encoded-type`  
**Severity / confidence:** medium / high

### What happens

TestSchema.Encoding.encodeUnknownEffect is typed as succeeding with the decoded Type even though it returns the Encoded value.

### Why it happens

The public property is annotated as Effect.Effect<S["Type"], ...> even though SchemaParser.encodeUnknownEffect returns Effect.Effect<S["Encoded"], ...>, breaking type-safe composition for transformed schemas.

### Expected behavior

An encoding operation succeeds with the schema's Encoded type.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/testing/TestSchema.ts:457-470`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/testing/TestSchema.ts#L457-L470)
- [`packages/effect/src/SchemaParser.ts:600-610`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/SchemaParser.ts#L600-L610)

<details>
<summary>View problematic code at <code>packages/effect/src/testing/TestSchema.ts:457-470</code></summary>

```ts
export class Encoding<S extends Schema.Constraint> {
  readonly schema: S
  readonly encodeUnknownEffect: (
    input: unknown,
    options?: SchemaAST.ParseOptions
  ) => Effect.Effect<S["Type"], SchemaIssue.Issue, S["EncodingServices"]>
  readonly options?: {
    readonly parseOptions?: SchemaAST.ParseOptions | undefined
  } | undefined
  constructor(schema: S, options?: {
    readonly parseOptions?: SchemaAST.ParseOptions | undefined
  }) {
    this.schema = schema
    this.encodeUnknownEffect = SchemaParser.encodeUnknownEffect(schema)
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/testing/TestSchema.ts#L457-L470)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/SchemaParser.ts:600-610</code></summary>

```ts
export function encodeUnknownEffect<S extends Schema.Constraint>(
  schema: S,
  options?: SchemaAST.ParseOptions
): (
  input: unknown,
  options?: SchemaAST.ParseOptions
) => Effect.Effect<S["Encoded"], SchemaIssue.Issue, S["EncodingServices"]> {
  const parser = run<S["Encoded"], S["EncodingServices"]>(SchemaAST.flip(schema.ast))
  return options === undefined
    ? parser
    : (input, overrideOptions) => parser(input, mergeParseOptions(options, overrideOptions))
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/SchemaParser.ts#L600-L610)

</details>

### Reproduction

```sh
pnpm test-types packages/effect/typetest/TestSchema.tst.ts
```

**Observed failure:** TypeScript 5.9.3 and 6.0.3 report Effect<number, Issue> is not Effect<string, Issue>

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test-types packages/effect/typetest/TestSchema.tst.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `core-s-z-testing-test-schema-encoded-type`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-383