### PR TITLE
Make Iterable.flatten stack safe across empty iterables

### DIFF
--- a/.changeset/fix-iterable-flatten-stack-safety.md
+++ b/.changeset/fix-iterable-flatten-stack-safety.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Make `Iterable.flatten` stack safe across empty iterables.

--- a/packages/effect/src/Iterable.ts
+++ b/packages/effect/src/Iterable.ts
@@ -1543,19 +1543,20 @@ export const flatten = <A>(self: Iterable<Iterable<A>>): Iterable<A> => ({
     const outerIterator = self[Symbol.iterator]()
     let innerIterator: Iterator<A> | undefined
     function next() {
-      if (innerIterator === undefined) {
-        const next = outerIterator.next()
-        if (next.done) {
-          return next
+      while (true) {
+        if (innerIterator === undefined) {
+          const next = outerIterator.next()
+          if (next.done) {
+            return next
+          }
+          innerIterator = next.value[Symbol.iterator]()
         }
-        innerIterator = next.value[Symbol.iterator]()
-      }
-      const result = innerIterator.next()
-      if (result.done) {
+        const result = innerIterator.next()
+        if (!result.done) {
+          return result
+        }
         innerIterator = undefined
-        return next()
       }
-      return result
     }
     return { next }
   }

--- a/packages/effect/test/Iterable.test.ts
+++ b/packages/effect/test/Iterable.test.ts
@@ -396,6 +396,13 @@ describe("Iterable", () => {
     deepStrictEqual(toArray(Iter.flatten([[1], [2], [3]])), [1, 2, 3])
   })
 
+  it("flatten is stack safe across empty iterables", () => {
+    const input: Array<Iterable<number>> = Array.from({ length: 20_000 }, () => [])
+    input.push([1])
+
+    deepStrictEqual(toArray(Iter.flatten(input)), [1])
+  })
+
   it("cartesianWith", () => {
     const right = (function*() {
       yield* [1, 2, 3]


### PR DESCRIPTION
## Summary

A finite iterable containing many consecutive empty inner iterables can throw RangeError before yielding a later value or completing.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## flatten overflows on a long run of empty iterables

**Module:** `Iterable`  
**Audit ID:** `core-g-r-iterable-flatten-empty-run-stack-overflow`  
**Severity / confidence:** medium / high

### What happens

A finite iterable containing many consecutive empty inner iterables can throw RangeError before yielding a later value or completing.

### Why it happens

When an inner iterator is exhausted, next clears it and recursively calls itself. Every consecutive empty iterable consumes another JavaScript stack frame, so 20,000 empty iterables overflow before the recursion reaches a later value.

### Expected behavior

flatten lazily flattens arbitrary iterable inputs, including empty inner iterables, without iteration depth growing with the number of consecutive empty inputs.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/Iterable.ts:1498-1506`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/Iterable.ts#L1498-L1506)
- [`packages/effect/src/Iterable.ts:1541-1562`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/Iterable.ts#L1541-L1562)

<details>
<summary>View problematic code at <code>packages/effect/src/Iterable.ts:1498-1506</code></summary>

```ts
export const flatMap: {
  <A, B>(
    f: (a: NoInfer<A>, i: number) => Iterable<B>
  ): (self: Iterable<A>) => Iterable<B>
  <A, B>(self: Iterable<A>, f: (a: NoInfer<A>, i: number) => Iterable<B>): Iterable<B>
} = dual(
  2,
  <A, B>(self: Iterable<A>, f: (a: A, i: number) => Iterable<B>): Iterable<B> => flatten(map(self, f))
)
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/Iterable.ts#L1498-L1506)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/Iterable.ts:1541-1562</code></summary>

```ts
export const flatten = <A>(self: Iterable<Iterable<A>>): Iterable<A> => ({
  [Symbol.iterator]() {
    const outerIterator = self[Symbol.iterator]()
    let innerIterator: Iterator<A> | undefined
    function next() {
      if (innerIterator === undefined) {
        const next = outerIterator.next()
        if (next.done) {
          return next
        }
        innerIterator = next.value[Symbol.iterator]()
      }
      const result = innerIterator.next()
      if (result.done) {
        innerIterator = undefined
        return next()
      }
      return result
    }
    return { next }
  }
})
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/Iterable.ts#L1541-L1562)

</details>

### Reproduction

```sh
pnpm vitest run packages/effect/test/Iterable.test.ts -t "flatten is stack safe across empty iterables"
```

**Observed failure:** The intended failure was reproduced with RangeError: Maximum call stack size exceeded.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm vitest run packages/effect/test/Iterable.test.ts -t "flatten is stack safe across empty iterables"
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `core-g-r-iterable-flatten-empty-run-stack-overflow`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-390