### PR TITLE
Defer memoized Layer state installation until Effect execution

### DIFF
--- a/.changeset/early-jobs-bow.md
+++ b/.changeset/early-jobs-bow.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Defer memoized Layer state installation until Effect execution.

--- a/packages/effect/src/Layer.ts
+++ b/packages/effect/src/Layer.ts
@@ -447,11 +447,13 @@ class MemoMapImpl implements MemoMap {
     scope: Scope.Scope,
     build: (memoMap: MemoMap, scope: Scope.Scope) => Effect<Context.Context<ROut>, E, RIn>
   ): Effect<Context.Context<ROut>, E, RIn> {
-    const existing = this.get(layer, scope)
-    if (existing) {
-      return existing
-    }
-    return memoMapBuild(this, layer, scope, build)
+    return internalEffect.suspend(() => {
+      const existing = this.get(layer, scope)
+      if (existing) {
+        return existing
+      }
+      return memoMapBuild(this, layer, scope, build)
+    })
   }
 }
 

--- a/packages/effect/test/Layer.test.ts
+++ b/packages/effect/test/Layer.test.ts
@@ -457,6 +457,7 @@ describe("Layer", () => {
       const scope = Scope.makeUnsafe()
       const layer = Layer.effectDiscard(Effect.void)
 
+      // @effect-diagnostics-next-line floatingEffect:off
       Layer.buildWithMemoMap(layer, memoMap, scope)
 
       assert.strictEqual((memoMap as any).map.size, 0)

--- a/packages/effect/test/Layer.test.ts
+++ b/packages/effect/test/Layer.test.ts
@@ -452,6 +452,16 @@ describe("Layer", () => {
   })
 
   describe("MemoMap", () => {
+    it("does not memoize a build before its Effect executes", () => {
+      const memoMap = Layer.makeMemoMapUnsafe()
+      const scope = Scope.makeUnsafe()
+      const layer = Layer.effectDiscard(Effect.void)
+
+      Layer.buildWithMemoMap(layer, memoMap, scope)
+
+      assert.strictEqual((memoMap as any).map.size, 0)
+    })
+
     it.effect("memoizes suspend across builds", () =>
       Effect.gen(function*() {
         const arr: Array<string> = []


### PR DESCRIPTION
## Summary

- Defer memoized Layer lookup and state installation until the returned Effect executes.
- Preserve memoization when multiple Layer build Effects are constructed before execution.
- Add a focused regression test and patch changeset.

## Audit finding

Constructing a memoized Layer build Effect previously inserted an entry into the memo map immediately. If that Effect was abandoned, a later build could wait forever on its never-completed deferred while leaking the child scope and memo entry.

`MemoMapImpl.getOrElseMemoize` now suspends both the lookup and any new entry installation until Effect execution.

## Validation

- `pnpm vitest run packages/effect/test/Layer.test.ts`
- `pnpm lint-fix`
- `pnpm check`

Closes EFF-392
