### PR TITLE
Check symbol-keyed properties in Match object patterns

### DIFF
--- a/.changeset/famous-loops-flow.md
+++ b/.changeset/famous-loops-flow.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Check symbol-keyed properties in Match object patterns.

--- a/packages/effect/src/internal/matcher.ts
+++ b/packages/effect/src/internal/matcher.ts
@@ -124,8 +124,8 @@ const makePredicate = (pattern: unknown): Predicate.Predicate<unknown> => {
       return true
     }
   } else if (pattern !== null && typeof pattern === "object") {
-    const keysAndPredicates = Object.entries(pattern).map(
-      ([k, p]) => [k, makePredicate(p)] as const
+    const keysAndPredicates = Reflect.ownKeys(pattern).map(
+      (key) => [key, makePredicate((pattern as any)[key])] as const
     )
     const len = keysAndPredicates.length
 

--- a/packages/effect/test/Match.test.ts
+++ b/packages/effect/test/Match.test.ts
@@ -24,4 +24,15 @@ describe("Match", () => {
     strictEqual(match({ _tag: "A.one" }), "hit")
     strictEqual(match(null), "miss")
   })
+
+  it("checks symbol-keyed object pattern properties", () => {
+    const key = Symbol("key")
+    const match = pipe(
+      Match.type<{ readonly [key]: "expected" | "other" }>(),
+      Match.when({ [key]: "expected" }, () => "hit"),
+      Match.orElse(() => "miss")
+    )
+
+    strictEqual(match({ [key]: "other" }), "miss")
+  })
 })

--- a/packages/effect/test/Match.test.ts
+++ b/packages/effect/test/Match.test.ts
@@ -33,6 +33,8 @@ describe("Match", () => {
       Match.orElse(() => "miss")
     )
 
+    strictEqual(match({ [key]: "expected" }), "hit")
     strictEqual(match({ [key]: "other" }), "miss")
+    strictEqual(match({} as any), "miss")
   })
 })


### PR DESCRIPTION
## Summary

A valid typed object pattern whose only key is a symbol compiles as an empty conjunction and matches non-null objects that do not satisfy the symbol property's constraint.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Symbol-keyed object patterns match without checking the symbol

**Module:** `Match`  
**Audit ID:** `core-g-r-match-symbol-key-pattern-omitted`  
**Severity / confidence:** medium / high

### What happens

A valid typed object pattern whose only key is a symbol compiles as an empty conjunction and matches non-null objects that do not satisfy the symbol property's constraint.

### Why it happens

The runtime compiler enumerates pattern properties with Object.entries, which omits symbols. A symbol-only pattern therefore has no compiled predicates and accepts the wrong value.

### Expected behavior

Types.PatternBase maps every key of a record-shaped value, including symbol keys, and a successful object-pattern match satisfies every supplied property constraint.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/Match.ts:2234-2238`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/Match.ts#L2234-L2238)
- [`packages/effect/src/internal/matcher.ts:126-145`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/internal/matcher.ts#L126-L145)

<details>
<summary>View problematic code at <code>packages/effect/src/Match.ts:2234-2238</code></summary>

```ts
  export type PatternBase<A> = A extends ReadonlyArray<infer _T> ? ReadonlyArray<any> | PatternPrimitive<A>
    : A extends Record<string, any> ? Partial<
        { [K in keyof A]: PatternPrimitive<A[K] & {}> | PatternBase<A[K] & {}> }
      >
    : never
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/Match.ts#L2234-L2238)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/internal/matcher.ts:126-145</code></summary>

```ts
  } else if (pattern !== null && typeof pattern === "object") {
    const keysAndPredicates = Object.entries(pattern).map(
      ([k, p]) => [k, makePredicate(p)] as const
    )
    const len = keysAndPredicates.length

    return (u: unknown) => {
      if (typeof u !== "object" || u === null) {
        return false
      }

      for (let i = 0; i < len; i++) {
        const [key, predicate] = keysAndPredicates[i]
        if (!(key in u) || predicate((u as any)[key]) === false) {
          return false
        }
      }

      return true
    }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/internal/matcher.ts#L126-L145)

</details>

### Reproduction

```sh
pnpm vitest run packages/effect/test/Match.test.ts -t "checks symbol-keyed object pattern properties"
```

**Observed failure:** The intended failure was reproduced: the matcher returned "hit" instead of "miss".

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm vitest run packages/effect/test/Match.test.ts -t "checks symbol-keyed object pattern properties"
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `core-g-r-match-symbol-key-pattern-omitted`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-393
