### PR TITLE
Honor numeric zero TTL values in ScopedCache.make

### DIFF
--- a/.changeset/fuzzy-caches-expire.md
+++ b/.changeset/fuzzy-caches-expire.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Honor numeric zero time-to-live values in `Cache.make` and `ScopedCache.make`.

--- a/packages/effect/src/Cache.ts
+++ b/packages/effect/src/Cache.ts
@@ -305,7 +305,7 @@ export const make = <
 > =>
   makeWith<Key, A, E, R, ServiceMode>(options.lookup, {
     ...options,
-    timeToLive: options.timeToLive ? () => options.timeToLive! : defaultTimeToLive
+    timeToLive: options.timeToLive !== undefined ? () => options.timeToLive! : defaultTimeToLive
   })
 
 const Proto = {

--- a/packages/effect/src/ScopedCache.ts
+++ b/packages/effect/src/ScopedCache.ts
@@ -211,7 +211,7 @@ export const make = <
 > =>
   makeWith<Key, A, E, R, ServiceMode>({
     ...options,
-    timeToLive: options.timeToLive ? () => options.timeToLive! : defaultTimeToLive
+    timeToLive: options.timeToLive !== undefined ? () => options.timeToLive! : defaultTimeToLive
   })
 
 const Proto = {

--- a/packages/effect/test/Cache.test.ts
+++ b/packages/effect/test/Cache.test.ts
@@ -43,6 +43,19 @@ describe("Cache", () => {
         assert.isFalse(yield* Cache.has(cache, "test"))
       }))
 
+    it.effect("make - uses a numeric zero TTL", () =>
+      Effect.gen(function*() {
+        const cache = yield* Cache.make<string, number>({
+          capacity: 10,
+          lookup: (key) => Effect.succeed(key.length),
+          timeToLive: 0
+        })
+
+        yield* Cache.get(cache, "test")
+
+        assert.isFalse(yield* Cache.has(cache, "test"))
+      }))
+
     it.effect("make - lookup function context is preserved", () =>
       Effect.gen(function*() {
         class TestService extends Context.Service<TestService, { value: number }>()("TestService") {}

--- a/packages/effect/test/ScopedCache.test.ts
+++ b/packages/effect/test/ScopedCache.test.ts
@@ -44,6 +44,19 @@ describe("ScopedCache", () => {
           assert.isFalse(yield* ScopedCache.has(cache, "test"))
         }))
 
+      it.effect("uses a numeric zero TTL", () =>
+        Effect.gen(function*() {
+          const cache = yield* ScopedCache.make({
+            capacity: 10,
+            lookup: (key: string) => Effect.succeed(key.length),
+            timeToLive: 0
+          })
+
+          yield* ScopedCache.get(cache, "test")
+
+          assert.isFalse(yield* ScopedCache.has(cache, "test"))
+        }))
+
       it.effect("lookup function context is preserved", () =>
         Effect.gen(function*() {
           class TestService extends Context.Service<TestService, { value: number }>()("TestService") {}


### PR DESCRIPTION
## Summary

ScopedCache.make retains entries indefinitely when its fixed timeToLive is the valid numeric value zero.

> [!IMPORTANT]
> This PR includes focused regression tests and the implementation fix.

## Numeric zero TTL becomes infinity

**Module:** `ScopedCache`  
**Audit ID:** `core-s-z-testing-scoped-cache-zero-ttl`  
**Severity / confidence:** medium / high

### What happens

ScopedCache.make retains entries indefinitely when its fixed timeToLive is the valid numeric value zero.

### Why it happens

options.timeToLive ? ... : defaultTimeToLive treats numeric zero as absent and silently installs an infinite TTL, unlike makeWith, which honors Duration.zero.

### Expected behavior

The fixed timeToLive accepted by make is a Duration.Input, for which numeric 0 means immediate expiry.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/ScopedCache.ts:212-215`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/ScopedCache.ts#L212-L215)

<details>
<summary>View problematic code at <code>packages/effect/src/ScopedCache.ts:212-215</code></summary>

```ts
  makeWith<Key, A, E, R, ServiceMode>({
    ...options,
    timeToLive: options.timeToLive ? () => options.timeToLive! : defaultTimeToLive
  })
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/ScopedCache.ts#L212-L215)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/ScopedCache.test.ts -t "uses a numeric zero TTL"
```

**Observed failure:** has is true instead of false

## Implementation

The fixed-TTL constructors now distinguish an omitted TTL from numeric `0`, so zero expires immediately in both `ScopedCache.make` and `Cache.make`. The scoped reproduction remains unchanged, and matching regression coverage was added for `Cache.make`.

## Validation

- `pnpm test --run packages/effect/test/Cache.test.ts packages/effect/test/ScopedCache.test.ts`
- `pnpm lint-fix`
- `pnpm check`

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `core-s-z-testing-scoped-cache-zero-ttl`
- Initial patch: focused reproduction tests; implementation fix completed in this PR

Closes EFF-394