### PR TITLE
Keep TestClock nanosecond access total after infinite adjustments

### DIFF
--- a/.changeset/fuzzy-timers-smile.md
+++ b/.changeset/fuzzy-timers-smile.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Keep TestClock nanosecond access total after infinite adjustments.

--- a/packages/effect/src/testing/TestClock.ts
+++ b/packages/effect/src/testing/TestClock.ts
@@ -247,6 +247,7 @@ export const make = Effect.fnUntraced(function*(
   const warningSemaphore = yield* Semaphore.make(1)
 
   let currentTimestamp: number = new Date(0).getTime()
+  let currentWallNanos = BigInt(0)
   let currentMonotonicNanos = BigInt(0)
   let warningState: WarningState = WarningState.Start()
 
@@ -255,7 +256,7 @@ export const make = Effect.fnUntraced(function*(
   }
 
   function currentTimeNanosUnsafe(): bigint {
-    return BigInt(Math.floor(currentTimestamp * 1000000))
+    return currentWallNanos
   }
 
   function monotonicTimeNanosUnsafe(): bigint {
@@ -338,6 +339,9 @@ export const make = Effect.fnUntraced(function*(
       const deltaMillis = timestamp - currentTimestamp
       if (deltaMillis > 0 && Number.isFinite(deltaMillis)) {
         currentMonotonicNanos += BigInt(Math.round(deltaMillis * 1_000_000))
+      }
+      if (Number.isFinite(timestamp)) {
+        currentWallNanos = BigInt(Math.floor(timestamp * 1_000_000))
       }
       currentTimestamp = timestamp
     }

--- a/packages/effect/test/TestClock.test.ts
+++ b/packages/effect/test/TestClock.test.ts
@@ -70,11 +70,13 @@ describe("TestClock", () => {
       assert.strictEqual(yield* testClock.monotonicTimeNanos, 1_000_000_000n)
     }))
 
-  it.effect("adjust - keeps nanosecond access total after an infinite duration", () =>
+  it.effect("adjust - keeps nanosecond access total after infinite durations", () =>
     Effect.gen(function*() {
-      const testClock = yield* TestClock.make()
-      yield* testClock.adjust(Duration.infinity)
-      assert.strictEqual(typeof (yield* testClock.currentTimeNanos), "bigint")
+      for (const duration of [Duration.infinity, Duration.negativeInfinity]) {
+        const testClock = yield* TestClock.make()
+        yield* testClock.adjust(duration)
+        assert.strictEqual(typeof (yield* testClock.currentTimeNanos), "bigint")
+      }
     }))
 
   it.effect("setTime - advances monotonic time only when moving forward", () =>

--- a/packages/effect/test/TestClock.test.ts
+++ b/packages/effect/test/TestClock.test.ts
@@ -70,6 +70,13 @@ describe("TestClock", () => {
       assert.strictEqual(yield* testClock.monotonicTimeNanos, 1_000_000_000n)
     }))
 
+  it.effect("adjust - keeps nanosecond access total after an infinite duration", () =>
+    Effect.gen(function*() {
+      const testClock = yield* TestClock.make()
+      yield* testClock.adjust(Duration.infinity)
+      assert.strictEqual(typeof (yield* testClock.currentTimeNanos), "bigint")
+    }))
+
   it.effect("setTime - advances monotonic time only when moving forward", () =>
     Effect.gen(function*() {
       const testClock = yield* TestClock.make()


### PR DESCRIPTION
## Summary

After an accepted infinite TestClock adjustment, currentTimeNanos defects with RangeError.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Infinite adjustment defects an infallible clock accessor

**Module:** `TestClock`  
**Audit ID:** `core-s-z-testing-test-clock-infinite-nanoseconds`  
**Severity / confidence:** medium / high

### What happens

After an accepted infinite TestClock adjustment, currentTimeNanos defects with RangeError.

### Why it happens

adjust(Duration.infinity) stores Infinity as currentTimestamp, and the next nanosecond read evaluates BigInt(Infinity); negative infinity fails analogously.

### Expected behavior

adjust accepts any Duration.Input, including infinities, while currentTimeNanos is an infallible Effect<bigint> accessor.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/testing/TestClock.ts:257-258`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/testing/TestClock.ts#L257-L258)
- [`packages/effect/src/testing/TestClock.ts:354-357`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/testing/TestClock.ts#L354-L357)
- [`packages/effect/src/Duration.ts:134-166`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/Duration.ts#L134-L166)

<details>
<summary>View problematic code at <code>packages/effect/src/testing/TestClock.ts:257-258</code></summary>

```ts
  function currentTimeNanosUnsafe(): bigint {
    return BigInt(Math.floor(currentTimestamp * 1000000))
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/testing/TestClock.ts#L257-L258)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/testing/TestClock.ts:354-357</code></summary>

```ts
  function adjust(duration: Duration.Input) {
    const millis = Duration.toMillis(Duration.fromInputUnsafe(duration))
    return warningDone.pipe(Effect.andThen(run((timestamp) => timestamp + millis)))
  }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/testing/TestClock.ts#L354-L357)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/Duration.ts:134-166</code></summary>

```ts
 * Valid input types that can be converted to a Duration.
 *
 * **When to use**
 *
 * Use when an API should accept any value that Effect can convert into a
 * `Duration`, including existing durations, millisecond numbers, nanosecond
 * bigints, high-resolution tuples, duration strings, infinity strings, or
 * duration objects.
 *
 * **Details**
 *
 * String inputs accept values like `"10 seconds"`, `"500 millis"`,
 * `"Infinity"`, and `"-Infinity"`. Finite fractional values that are
 * normalized to nanoseconds are rounded to the nearest nanosecond, with ties
 * away from zero.
 *
 * @see {@link fromInput} for safe conversion to `Option`
 * @see {@link fromInputUnsafe} for throwing conversion
 * @see {@link DurationObject} for object-shaped duration input
 * @see {@link Unit} for supported string units
 *
 * @category models
 * @since 4.0.0
 */
export type Input =
  | Duration
  | number // millis
  | bigint // nanos
  | readonly [seconds: number, nanos: number]
  | `${number} ${Unit}`
  | "Infinity"
  | "-Infinity"
  | DurationObject
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/Duration.ts#L134-L166)

</details>

### Reproduction

```sh
NODE_OPTIONS=--preserve-symlinks pnpm test --run packages/effect/test/TestClock.test.ts -t "nanosecond access total"
```

**Observed failure:** RangeError from BigInt(Infinity)

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
NODE_OPTIONS=--preserve-symlinks pnpm test --run packages/effect/test/TestClock.test.ts -t "nanosecond access total"
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `core-s-z-testing-test-clock-infinite-nanoseconds`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-395