### PR TITLE
Use the supplied hash for all HashMap.modifyHash writes

### DIFF
--- a/.changeset/fix-hashmap-modify-hash.md
+++ b/.changeset/fix-hashmap-modify-hash.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Use the supplied hash for `HashMap.modifyHash` insertions, updates, and removals.

--- a/packages/effect/src/internal/hashMap.ts
+++ b/packages/effect/src/internal/hashMap.ts
@@ -977,13 +977,8 @@ export const hasBy = dual<
   return false
 })
 
-/** @internal */
-export const set = dual<
-  <K, V>(key: K, value: V) => (self: HashMap<K, V>) => HashMap<K, V>,
-  <K, V>(self: HashMap<K, V>, key: K, value: V) => HashMap<K, V>
->(3, <K, V>(self: HashMap<K, V>, key: K, value: V): HashMap<K, V> => {
+const setHash = <K, V>(self: HashMap<K, V>, key: K, hash: number, value: V): HashMap<K, V> => {
   const impl = self as HashMapImpl<K, V>
-  const hash = Hash.hash(key)
   const added = { value: false }
 
   // Pass edit context: use current edit if editable, otherwise NaN (never matches any edit)
@@ -1005,6 +1000,14 @@ export const set = dual<
   }
 
   return new HashMapImpl(false, impl._edit, newRoot, impl._size + (added.value ? 1 : 0))
+}
+
+/** @internal */
+export const set = dual<
+  <K, V>(key: K, value: V) => (self: HashMap<K, V>) => HashMap<K, V>,
+  <K, V>(self: HashMap<K, V>, key: K, value: V) => HashMap<K, V>
+>(3, <K, V>(self: HashMap<K, V>, key: K, value: V): HashMap<K, V> => {
+  return setHash(self, key, Hash.hash(key), value)
 })
 
 /** @internal */
@@ -1104,10 +1107,10 @@ export const modifyHash = dual<
   const updated = f(current)
 
   if (Option.isNone(updated)) {
-    return hasHash(self, key, hash) ? remove(self, key) : self
+    return hasHash(self, key, hash) ? removeHash(self, key, hash) : self
   }
 
-  return set(self, key, updated.value)
+  return setHash(self, key, hash, updated.value)
 })
 
 /** @internal */
@@ -1130,13 +1133,8 @@ export const union = dual<
   return result
 })
 
-/** @internal */
-export const remove = dual<
-  <K>(key: K) => <V>(self: HashMap<K, V>) => HashMap<K, V>,
-  <K, V>(self: HashMap<K, V>, key: K) => HashMap<K, V>
->(2, <K, V>(self: HashMap<K, V>, key: K): HashMap<K, V> => {
+const removeHash = <K, V>(self: HashMap<K, V>, key: K, hash: number): HashMap<K, V> => {
   const impl = self as HashMapImpl<K, V>
-  const hash = Hash.hash(key)
   const removed = { value: false }
 
   const edit = impl._editable ? impl._edit : NaN
@@ -1157,6 +1155,14 @@ export const remove = dual<
   }
 
   return new HashMapImpl(false, impl._edit, newRoot, impl._size - 1)
+}
+
+/** @internal */
+export const remove = dual<
+  <K>(key: K) => <V>(self: HashMap<K, V>) => HashMap<K, V>,
+  <K, V>(self: HashMap<K, V>, key: K) => HashMap<K, V>
+>(2, <K, V>(self: HashMap<K, V>, key: K): HashMap<K, V> => {
+  return removeHash(self, key, Hash.hash(key))
 })
 
 /** @internal */

--- a/packages/effect/test/HashMap.test.ts
+++ b/packages/effect/test/HashMap.test.ts
@@ -29,6 +29,14 @@ describe("HashMap", () => {
   })
 
   describe("basic operations", () => {
+    it("modifyHash stores a new key under the supplied hash", () => {
+      const key = {}
+      const hash = 12345
+      const map = HashMap.modifyHash(HashMap.empty<object, string>(), key, hash, () => Option.some("value"))
+
+      expect(HashMap.getHash(map, key, hash)).toEqual(Option.some("value"))
+    })
+
     it("get - existing key", () => {
       const map = HashMap.make(["a", 1], ["b", 2])
       expect(HashMap.get(map, "a")).toEqual(Option.some(1))

--- a/packages/effect/test/HashMap.test.ts
+++ b/packages/effect/test/HashMap.test.ts
@@ -37,6 +37,15 @@ describe("HashMap", () => {
       expect(HashMap.getHash(map, key, hash)).toEqual(Option.some("value"))
     })
 
+    it("modifyHash removes a key using the supplied hash", () => {
+      const key = {}
+      const hash = 12345
+      const map = HashMap.modifyHash(HashMap.empty<object, string>(), key, hash, () => Option.some("value"))
+      const removed = HashMap.modifyHash(map, key, hash, () => Option.none())
+
+      expect(HashMap.getHash(removed, key, hash)).toEqual(Option.none())
+    })
+
     it("get - existing key", () => {
       const map = HashMap.make(["a", 1], ["b", 2])
       expect(HashMap.get(map, "a")).toEqual(Option.some(1))


### PR DESCRIPTION
## Summary

modifyHash looks up a key with the caller-supplied hash but inserts or removes it using a recomputed hash. A newly inserted value can therefore be unreachable through getHash with the supplied hash, and the explicit-hash API does not avoid recomputation.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## modifyHash recomputes the supplied hash on writes

**Module:** `HashMap`  
**Audit ID:** `core-g-r-hashmap-modifyhash-recomputes-hash`  
**Severity / confidence:** low / high

### What happens

modifyHash looks up a key with the caller-supplied hash but inserts or removes it using a recomputed hash. A newly inserted value can therefore be unreachable through getHash with the supplied hash, and the explicit-hash API does not avoid recomputation.

### Why it happens

The lookup path uses getHash and hasHash, but insertion delegates to set and removal delegates to remove. Both ordinary write paths recompute Hash.hash(key), so storage and removal can occur under a different hash from the one supplied to modifyHash.

### Expected behavior

modifyHash sets or removes a key using the caller-supplied precomputed hash, complementing getHash and hasHash.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/HashMap.ts:783-836`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/HashMap.ts#L783-L836)
- [`packages/effect/src/internal/hashMap.ts:981-1011`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/internal/hashMap.ts#L981-L1011)
- [`packages/effect/src/internal/hashMap.ts:1099-1111`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/internal/hashMap.ts#L1099-L1111)
- [`packages/effect/src/internal/hashMap.ts:1134-1167`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/internal/hashMap.ts#L1134-L1167)

<details>
<summary>View problematic code at <code>packages/effect/src/HashMap.ts:783-832</code></summary>

````ts
/**
 * Sets or removes the specified key using a precomputed hash and an update
 * function.
 *
 * **Details**
 *
 * The update function receives `Some(value)` when the key exists or `None`
 * when it does not. Returning `Some(newValue)` stores the value, and returning
 * `None` removes the key or leaves it absent.
 *
 * **Example** (Updating values with a hash)
 *
 * ```ts import.meta.vitest
 * import { Hash, HashMap, Option } from "effect"
 *
 * // Useful when working with precomputed hashes for performance
 * const counters = HashMap.make(["downloads", 100], ["views", 250])
 *
 * // Cache hash computation for frequently accessed keys
 * const metricKey = "downloads"
 * const cachedHash = Hash.string(metricKey)
 *
 * // Update function that increments counter or initializes to 1
 * const incrementCounter = (current: Option.Option<number>) =>
 *   Option.isSome(current) ? Option.some(current.value + 1) : Option.some(1)
 *
 * // Use cached hash for efficient updates in loops
 * const updated = HashMap.modifyHash(
 *   counters,
 *   metricKey,
 *   cachedHash,
 *   incrementCounter
 * )
 * HashMap.get(updated, "downloads") // => Option.some(101)
 *
 * // Add new metric with precomputed hash
 * const newMetric = "clicks"
 * const clicksHash = Hash.string(newMetric)
 * const withClicks = HashMap.modifyHash(
 *   updated,
 *   newMetric,
 *   clicksHash,
 *   incrementCounter
 * )
 * HashMap.get(withClicks, "clicks") // => Option.some(1)
 * ```
 *
 * @category transforming
 * @since 2.0.0
 */
````

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/HashMap.ts#L783-L836)

_Excerpt truncated. [Open the complete packages/effect/src/HashMap.ts:783-836 range.](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/HashMap.ts#L783-L836)_

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/internal/hashMap.ts:981-1011</code></summary>

```ts
export const set = dual<
  <K, V>(key: K, value: V) => (self: HashMap<K, V>) => HashMap<K, V>,
  <K, V>(self: HashMap<K, V>, key: K, value: V) => HashMap<K, V>
>(3, <K, V>(self: HashMap<K, V>, key: K, value: V): HashMap<K, V> => {
  const impl = self as HashMapImpl<K, V>
  const hash = Hash.hash(key)
  const added = { value: false }

  // Pass edit context: use current edit if editable, otherwise NaN (never matches any edit)
  const edit = impl._editable ? impl._edit : NaN
  const newRoot = impl._root.set(edit, 0, hash, key, value, added)

  if (impl._editable) {
    // In-place mutation
    impl._root = newRoot
    if (added.value) {
      impl._size++
    }
    return self
  }

  // Immutable: create new instance if changed
  if (impl._root === newRoot) {
    return self
  }

  return new HashMapImpl(false, impl._edit, newRoot, impl._size + (added.value ? 1 : 0))
})

/** @internal */
export const keys = <K, V>(self: HashMap<K, V>): IterableIterator<K> => {
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/internal/hashMap.ts#L981-L1011)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/internal/hashMap.ts:1099-1111</code></summary>

```ts
export const modifyHash = dual<
  <K, V>(key: K, hash: number, f: HashMap.UpdateFn<V>) => (self: HashMap<K, V>) => HashMap<K, V>,
  <K, V>(self: HashMap<K, V>, key: K, hash: number, f: HashMap.UpdateFn<V>) => HashMap<K, V>
>(4, <K, V>(self: HashMap<K, V>, key: K, hash: number, f: HashMap.UpdateFn<V>): HashMap<K, V> => {
  const current = getHash(self, key, hash)
  const updated = f(current)

  if (Option.isNone(updated)) {
    return hasHash(self, key, hash) ? remove(self, key) : self
  }

  return set(self, key, updated.value)
})
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/internal/hashMap.ts#L1099-L1111)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/internal/hashMap.ts:1134-1167</code></summary>

```ts
export const remove = dual<
  <K>(key: K) => <V>(self: HashMap<K, V>) => HashMap<K, V>,
  <K, V>(self: HashMap<K, V>, key: K) => HashMap<K, V>
>(2, <K, V>(self: HashMap<K, V>, key: K): HashMap<K, V> => {
  const impl = self as HashMapImpl<K, V>
  const hash = Hash.hash(key)
  const removed = { value: false }

  const edit = impl._editable ? impl._edit : NaN
  const newRoot = impl._root.remove(edit, 0, hash, key, removed)

  if (!removed.value) {
    return self
  }

  if (impl._editable) {
    impl._root = newRoot ?? emptyNode
    impl._size--
    return self
  }

  if (newRoot === undefined) {
    return empty()
  }

  return new HashMapImpl(false, impl._edit, newRoot, impl._size - 1)
})

/** @internal */
export const removeMany = dual<
  <K>(keys: Iterable<K>) => <V>(self: HashMap<K, V>) => HashMap<K, V>,
  <K, V>(self: HashMap<K, V>, keys: Iterable<K>) => HashMap<K, V>
>(2, <K, V>(self: HashMap<K, V>, keys: Iterable<K>): HashMap<K, V> => {
  let result = self
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/internal/hashMap.ts#L1134-L1167)

</details>

### Reproduction

```sh
pnpm vitest run packages/effect/test/HashMap.test.ts -t "modifyHash stores a new key under the supplied hash"
```

**Observed failure:** The intended failure was reproduced: getHash returned None instead of Some("value").

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm vitest run packages/effect/test/HashMap.test.ts -t "modifyHash stores a new key under the supplied hash"
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `core-g-r-hashmap-modifyhash-recomputes-hash`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-397