### PR TITLE
Register alternate flags used by Param.orElse

### DIFF
--- a/.changeset/register-param-alternate-flags.md
+++ b/.changeset/register-param-alternate-flags.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Register alternate flags used by `Param.orElse` and `Param.orElseResult`.

--- a/packages/effect/src/unstable/cli/Param.ts
+++ b/packages/effect/src/unstable/cli/Param.ts
@@ -12,7 +12,7 @@
  */
 import * as Config from "../../Config.ts"
 import * as Effect from "../../Effect.ts"
-import { dual, identity } from "../../Function.ts"
+import { dual, identity, type LazyArg } from "../../Function.ts"
 import * as Option from "../../Option.ts"
 import { type Pipeable, pipeArguments } from "../../Pipeable.ts"
 import * as Predicate from "../../Predicate.ts"
@@ -226,7 +226,11 @@ export interface Transform<Kind extends ParamKind, in out A, out B> extends Para
   readonly _tag: "Transform"
   readonly kind: Kind
   readonly param: Param<Kind, A>
-  readonly f: (parse: Parse<A>) => Parse<B>
+  readonly alternatives: ReadonlyArray<LazyArg<Param<Kind, unknown>>>
+  readonly f: (
+    parse: Parse<A>,
+    alternatives: ReadonlyArray<LazyArg<Parse<unknown>>>
+  ) => Parse<B>
 }
 
 /**
@@ -1061,15 +1065,22 @@ export const map: {
 
 const transform = <Kind extends ParamKind, A, B>(
   self: Param<Kind, A>,
-  f: (parse: Parse<A>) => Parse<B>
-) =>
-  Object.assign(Object.create(Proto), {
+  f: (
+    parse: Parse<A>,
+    alternatives: ReadonlyArray<LazyArg<Parse<unknown>>>
+  ) => Parse<B>,
+  alternatives: ReadonlyArray<LazyArg<Param<Kind, unknown>>> = []
+): Transform<Kind, A, B> => {
+  const alternativeParsers = alternatives.map((alternative) => () => alternative().parse)
+  return Object.assign(Object.create(Proto), {
     _tag: "Transform",
     kind: self.kind,
     param: self,
+    alternatives,
     f,
-    parse: f(self.parse)
+    parse: f(self.parse, alternativeParsers)
   })
+}
 
 /**
  * Transforms the parsed value of an option using an effectful mapping function.
@@ -1845,20 +1856,20 @@ export const withSchema: {
  * @since 4.0.0
  */
 export const orElse: {
-  <B, Kind extends ParamKind>(
-    orElse: (error: CliError.CliError) => Param<Kind, B>
-  ): <A>(self: Param<Kind, A>) => Param<Kind, A | B>
+  <B, Kind extends ParamKind>(orElse: LazyArg<Param<Kind, B>>): <A>(self: Param<Kind, A>) => Param<Kind, A | B>
   <Kind extends ParamKind, A, B>(
     self: Param<Kind, A>,
-    orElse: (error: CliError.CliError) => Param<Kind, B>
+    orElse: LazyArg<Param<Kind, B>>
   ): Param<Kind, A | B>
 } = dual(2, <Kind extends ParamKind, A, B>(
   self: Param<Kind, A>,
-  orElse: (error: CliError.CliError) => Param<Kind, B>
+  orElse: LazyArg<Param<Kind, B>>
 ) =>
   transform(
     self,
-    (parse: Parse<A>): Parse<A | B> => (args: ParsedArgs) => Effect.catch(parse(args), (err) => orElse(err).parse(args))
+    (parse: Parse<A>, alternatives): Parse<A | B> => (args: ParsedArgs) =>
+      Effect.catch(parse(args), () => (alternatives[0]!() as Parse<B>)(args)),
+    [orElse]
   ))
 
 /**
@@ -1887,27 +1898,28 @@ export const orElse: {
  */
 export const orElseResult: {
   <Kind extends ParamKind, B>(
-    orElse: (error: CliError.CliError) => Param<Kind, B>
+    orElse: LazyArg<Param<Kind, B>>
   ): <A>(self: Param<Kind, A>) => Param<Kind, Result.Result<A, B>>
   <Kind extends ParamKind, A, B>(
     self: Param<Kind, A>,
-    orElse: (error: CliError.CliError) => Param<Kind, B>
+    orElse: LazyArg<Param<Kind, B>>
   ): Param<Kind, Result.Result<A, B>>
 } = dual(2, <Kind extends ParamKind, A, B>(
   self: Param<Kind, A>,
-  orElse: (error: CliError.CliError) => Param<Kind, B>
+  orElse: LazyArg<Param<Kind, B>>
 ) => {
   return transform(
     self,
-    (parse: Parse<A>): Parse<Result.Result<A, B>> => (args: ParsedArgs) =>
+    (parse: Parse<A>, alternatives): Parse<Result.Result<A, B>> => (args: ParsedArgs) =>
       Effect.catch(
         Effect.map(parse(args), ([leftover, value]) => [leftover, Result.succeed(value)] as const),
-        (err) =>
+        () =>
           Effect.map(
-            orElse(err).parse(args),
+            (alternatives[0]!() as Parse<B>)(args),
             ([leftover, value]) => [leftover, Result.fail(value)] as const
           )
-      )
+      ),
+    [orElse]
   )
 })
 
@@ -2124,7 +2136,12 @@ const transformSingle = <Kind extends ParamKind, A>(
   return matchParam(param, {
     Single: (single) => f(single),
     Map: (mapped) => map(transformSingle(mapped.param, f), mapped.f),
-    Transform: (mapped) => transform(transformSingle(mapped.param, f), mapped.f),
+    Transform: (mapped) =>
+      transform(
+        transformSingle(mapped.param, f),
+        mapped.f,
+        mapped.alternatives.map((alternative) => () => transformSingle(alternative(), f))
+      ),
     Optional: (p) => optional(transformSingle(p.param, f)) as Param<Kind, A>,
     Variadic: (p) =>
       variadic(transformSingle(p.param, f), {
@@ -2146,7 +2163,10 @@ export const extractSingleParams = <Kind extends ParamKind, A>(
   return matchParam(param, {
     Single: (single) => [single as Single<Kind, unknown>],
     Map: (mapped) => extractSingleParams(mapped.param),
-    Transform: (mapped) => extractSingleParams(mapped.param),
+    Transform: (mapped) => [
+      ...extractSingleParams(mapped.param),
+      ...mapped.alternatives.flatMap((alternative) => extractSingleParams(alternative()))
+    ],
     Optional: (optional) => extractSingleParams(optional.param),
     Variadic: (variadic) => extractSingleParams(variadic.param)
   })

--- a/packages/effect/test/unstable/cli/Param.test.ts
+++ b/packages/effect/test/unstable/cli/Param.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Config, ConfigProvider, Effect, FileSystem, Layer, Option, Path, Ref, Stdio } from "effect"
+import { Config, ConfigProvider, Effect, FileSystem, Layer, Option, Path, Ref, Result, Stdio } from "effect"
 import { TestConsole } from "effect/testing"
 import { Argument, CliError, Command, Flag, Param, Primitive, Prompt } from "effect/unstable/cli"
 import * as Lexer from "effect/unstable/cli/internal/lexer"
@@ -39,6 +39,22 @@ describe("Param", () => {
 
       assert.isUndefined(parsed.errors)
       assert.deepStrictEqual(parsed.flags["config-url"], ["https://example.com"])
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("registers and parses the alternate flag declared by orElseResult", () =>
+    Effect.gen(function*() {
+      const flag = Flag.string("config").pipe(
+        Flag.orElseResult(() => Flag.string("config-url"))
+      )
+
+      assert.deepStrictEqual(Param.extractSingleParams(flag).map((param) => param.name), ["config", "config-url"])
+
+      const [, result] = yield* flag.parse({
+        flags: { "config-url": ["https://example.com"] },
+        arguments: []
+      })
+
+      assert.deepStrictEqual(result, Result.fail("https://example.com"))
     }).pipe(Effect.provide(TestLayer)))
 
   it("preserves __proto__ as an own makeSingle option", () => {

--- a/packages/effect/test/unstable/cli/Param.test.ts
+++ b/packages/effect/test/unstable/cli/Param.test.ts
@@ -1,7 +1,9 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Config, ConfigProvider, Effect, FileSystem, Layer, Option, Path, Ref, Stdio } from "effect"
 import { TestConsole } from "effect/testing"
-import { Argument, CliError, Flag, Param, Primitive, Prompt } from "effect/unstable/cli"
+import { Argument, CliError, Command, Flag, Param, Primitive, Prompt } from "effect/unstable/cli"
+import * as Lexer from "effect/unstable/cli/internal/lexer"
+import * as Parser from "effect/unstable/cli/internal/parser"
 import { ChildProcessSpawner } from "effect/unstable/process"
 import * as MockTerminal from "./services/MockTerminal.ts"
 
@@ -25,6 +27,20 @@ const TestLayer = Layer.mergeAll(
 )
 
 describe("Param", () => {
+  it.effect("recognizes the alternate flag declared by orElse", () =>
+    Effect.gen(function*() {
+      const command = Command.make("app", {
+        config: Flag.string("config").pipe(
+          Flag.orElse(() => Flag.string("config-url"))
+        )
+      })
+
+      const parsed = yield* Parser.parseArgs(Lexer.lex(["--config-url", "https://example.com"]), command)
+
+      assert.isUndefined(parsed.errors)
+      assert.deepStrictEqual(parsed.flags["config-url"], ["https://example.com"])
+    }).pipe(Effect.provide(TestLayer)))
+
   it("preserves __proto__ as an own makeSingle option", () => {
     const value = { polluted: true }
     const param = Param.makeSingle({


### PR DESCRIPTION
## Summary

A valid alternate flag supplied through Param.orElse is rejected as unrecognized before fallback parsing can run.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Param.orElse alternate flags are not registered

**Module:** `cli/Param`  
**Audit ID:** `unstable-ai-cli-param-orelse-flag-registration`  
**Severity / confidence:** high / high

### What happens

A valid alternate flag supplied through Param.orElse is rejected as unrecognized before fallback parsing can run.

### Why it happens

The fallback is retained only in a transform closure, while parameter extraction traverses only the primary parameter and omits the alternate name from the command registry.

### Expected behavior

Param.orElse accepts a fallback parameter, including one with a different flag name.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/cli/Param.ts:1847-1862`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/Param.ts#L1847-L1862)
- [`packages/effect/src/unstable/cli/Param.ts:2143-2152`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/Param.ts#L2143-L2152)
- [`packages/effect/src/unstable/cli/internal/parser.ts:59-61`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/internal/parser.ts#L59-L61)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/cli/Param.ts:1847-1862</code></summary>

```ts
export const orElse: {
  <B, Kind extends ParamKind>(
    orElse: (error: CliError.CliError) => Param<Kind, B>
  ): <A>(self: Param<Kind, A>) => Param<Kind, A | B>
  <Kind extends ParamKind, A, B>(
    self: Param<Kind, A>,
    orElse: (error: CliError.CliError) => Param<Kind, B>
  ): Param<Kind, A | B>
} = dual(2, <Kind extends ParamKind, A, B>(
  self: Param<Kind, A>,
  orElse: (error: CliError.CliError) => Param<Kind, B>
) =>
  transform(
    self,
    (parse: Parse<A>): Parse<A | B> => (args: ParsedArgs) => Effect.catch(parse(args), (err) => orElse(err).parse(args))
  ))
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/Param.ts#L1847-L1862)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/cli/Param.ts:2143-2152</code></summary>

```ts
export const extractSingleParams = <Kind extends ParamKind, A>(
  param: Param<Kind, A>
): Array<Single<Kind, unknown>> => {
  return matchParam(param, {
    Single: (single) => [single as Single<Kind, unknown>],
    Map: (mapped) => extractSingleParams(mapped.param),
    Transform: (mapped) => extractSingleParams(mapped.param),
    Optional: (optional) => extractSingleParams(optional.param),
    Variadic: (variadic) => extractSingleParams(variadic.param)
  })
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/Param.ts#L2143-L2152)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/cli/internal/parser.ts:59-61</code></summary>

```ts
    const singles = commandImpl.config.flags.flatMap(Param.extractSingleParams)
    const flagParams = singles.filter(Param.isFlagParam)
    const flagRegistry = createFlagRegistry(flagParams)
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/internal/parser.ts#L59-L61)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/cli/ParamOrElseFlag.audit.test.ts
```

**Observed failure:** FAIL: --config-url produced UnrecognizedOption.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/cli/ParamOrElseFlag.audit.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-ai-cli-param-orelse-flag-registration`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-398