### PR TITLE
Preserve CRLF state across SSE input chunk boundaries

### DIFF
--- a/.changeset/polite-dingos-unite.md
+++ b/.changeset/polite-dingos-unite.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve CRLF state across SSE input chunk boundaries.

--- a/packages/effect/src/unstable/encoding/Sse.ts
+++ b/packages/effect/src/unstable/encoding/Sse.ts
@@ -255,6 +255,7 @@ export function makeParser(onParse: (event: AnyEvent) => void, options?: DecodeO
   let buffer: string
   let startingPosition: number
   let startingFieldLength: number
+  let discardTrailingNewline: boolean
 
   // Event state
   let eventId: string | undefined
@@ -270,6 +271,7 @@ export function makeParser(onParse: (event: AnyEvent) => void, options?: DecodeO
     buffer = ""
     startingPosition = 0
     startingFieldLength = -1
+    discardTrailingNewline = false
 
     eventId = undefined
     eventName = undefined
@@ -291,7 +293,6 @@ export function makeParser(onParse: (event: AnyEvent) => void, options?: DecodeO
     // Set up chunk-specific processing state
     const length = buffer.length
     let position = 0
-    let discardTrailingNewline = false
 
     // Read the current buffer byte by byte
     while (position < length) {

--- a/packages/effect/test/unstable/encoding/Sse.test.ts
+++ b/packages/effect/test/unstable/encoding/Sse.test.ts
@@ -4,6 +4,21 @@ import * as Schema from "effect/Schema"
 import * as Sse from "effect/unstable/encoding/Sse"
 
 describe("Sse", () => {
+  it("treats CRLF split across chunks as one line ending", () => {
+    const events: Array<Sse.AnyEvent> = []
+    const parser = Sse.makeParser((event) => events.push(event))
+
+    parser.feed("data: first\r")
+    parser.feed("\ndata: second\n\n")
+
+    assert.deepStrictEqual(events, [{
+      _tag: "Event",
+      event: "message",
+      id: undefined,
+      data: "first\nsecond"
+    }])
+  })
+
   it("Event preserves string payloads", () => {
     const decode = Schema.decodeUnknownSync(Sse.Event)
     const encode = Schema.encodeSync(Sse.Event)


### PR DESCRIPTION
## Summary

When CR and LF arrive in separate chunks, the LF is treated as another blank line and prematurely dispatches the pending event.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Split CRLF dispatches a spurious SSE event

**Module:** `encoding/Sse`  
**Audit ID:** `unstable-ai-cli-sse-crlf-chunk-boundary`  
**Severity / confidence:** high / high

### What happens

When CR and LF arrive in separate chunks, the LF is treated as another blank line and prematurely dispatches the pending event.

### Why it happens

The discardTrailingNewline state is local to one feed call and forgets a trailing CR before the next chunk arrives.

### Expected behavior

CRLF is one SSE line terminator regardless of transport chunk boundaries.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/encoding/Sse.ts:291-338`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/encoding/Sse.ts#L291-L338)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/encoding/Sse.ts:291-338</code></summary>

```ts
    // Set up chunk-specific processing state
    const length = buffer.length
    let position = 0
    let discardTrailingNewline = false

    // Read the current buffer byte by byte
    while (position < length) {
      // EventSource allows for carriage return + line feed, which means we
      // need to ignore a linefeed character if the previous character was a
      // carriage return
      // @todo refactor to reduce nesting, consider checking previous byte?
      // @todo but consider multiple chunks etc
      if (discardTrailingNewline) {
        if (buffer[position] === "\n") {
          ++position
        }
        discardTrailingNewline = false
      }

      let lineLength = -1
      let fieldLength = startingFieldLength
      let character: string

      for (let index = startingPosition; lineLength < 0 && index < length; ++index) {
        character = buffer[index]
        if (character === ":" && fieldLength < 0) {
          fieldLength = index - position
        } else if (character === "\r") {
          discardTrailingNewline = true
          lineLength = index - position
        } else if (character === "\n") {
          lineLength = index - position
        }
      }

      if (lineLength < 0) {
        startingPosition = length - position
        startingFieldLength = fieldLength
        break
      } else {
        startingPosition = 0
        startingFieldLength = -1
      }

      parseEventStreamLine(buffer, position, fieldLength, lineLength)

      position += lineLength + 1
    }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/encoding/Sse.ts#L291-L338)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/encoding/SseCrlfChunkBoundaryAudit.test.ts
```

**Observed failure:** FAIL: one event was split into two events.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/encoding/SseCrlfChunkBoundaryAudit.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-ai-cli-sse-crlf-chunk-boundary`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-400