### PR TITLE
Include plain variant structs in the default union

### DIFF
--- a/.changeset/plain-variant-unions.md
+++ b/.changeset/plain-variant-unions.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Include plain variant structs in the default variant union.

--- a/packages/effect/src/unstable/schema/VariantSchema.ts
+++ b/packages/effect/src/unstable/schema/VariantSchema.ts
@@ -296,12 +296,13 @@ type MissingSelfGeneric<Params extends string = ""> =
  * @category models
  * @since 4.0.0
  */
-export interface Union<Members extends ReadonlyArray<Struct<any>>> extends
-  Schema.Union<
-    {
-      readonly [K in keyof Members]: [Members[K]] extends [Schema.Top] ? Members[K] : never
-    }
-  >
+export interface Union<Members extends ReadonlyArray<Struct<any>>, Default extends string = string>
+  extends
+    Schema.Union<
+      {
+        readonly [K in keyof Members]: Extract<Default, Members[K], true>
+      }
+    >
 {}
 
 /**
@@ -410,7 +411,7 @@ export const make = <
       }
   readonly Union: <const Members extends ReadonlyArray<Struct<any>>>(
     members: Members
-  ) => Union<Members> & Union.Variants<Members, Variants[number]>
+  ) => Union<Members, Default> & Union.Variants<Members, Variants[number]>
   readonly extract: {
     <V extends Variants[number]>(
       variant: V
@@ -469,7 +470,7 @@ export const make = <
     }
   }
   function UnionVariants(members: ReadonlyArray<Struct<any>>) {
-    return Union(members, options.variants)
+    return Union(members, options.defaultVariant, options.variants)
   }
   const fieldEvolve = dual(
     2,
@@ -582,11 +583,18 @@ const Field = <const A extends Field.Config>(schemas: A): Field<A> => {
   return self
 }
 
-const Union = <Members extends ReadonlyArray<Struct<any>>, Variants extends ReadonlyArray<string>>(
+const Union = <
+  Members extends ReadonlyArray<Struct<any>>,
+  Default extends string,
+  Variants extends ReadonlyArray<string>
+>(
   members: Members,
+  defaultVariant: Default,
   variants: Variants
 ) => {
-  const VariantUnion = Schema.Union(members.filter((member) => Schema.isSchema(member))) as any
+  const VariantUnion = Schema.Union(
+    members.map((member) => Schema.isSchema(member) ? member : extract(member, defaultVariant, { isDefault: true }))
+  ) as any
   for (const variant of variants) {
     Object.defineProperty(VariantUnion, variant, {
       value: Schema.Union(members.map((member) => extract(member, variant)))

--- a/packages/effect/test/unstable/schema/VariantSchema.test.ts
+++ b/packages/effect/test/unstable/schema/VariantSchema.test.ts
@@ -45,6 +45,8 @@ describe("VariantSchema", () => {
     const union = Test.Union([first, second])
 
     assert.strictEqual(union.members.length, 2)
+    assert.deepStrictEqual(Schema.decodeUnknownSync(union)({ value: "foo" }), { value: "foo" })
+    assert.deepStrictEqual(Schema.decodeUnknownSync(union)({ value: 42 }), { value: 42 })
   })
 })
 

--- a/packages/effect/test/unstable/schema/VariantSchema.test.ts
+++ b/packages/effect/test/unstable/schema/VariantSchema.test.ts
@@ -37,6 +37,15 @@ describe("VariantSchema", () => {
     assert.deepStrictEqual(Schema.decodeSync(User.b)({ name: "Alice" }), { name: "Alice" })
     assert.deepStrictEqual(Object.keys(User.fields), ["id", "name"])
   })
+
+  it("includes plain variant structs in the default union", () => {
+    const Test = VariantSchema.make({ variants: ["a", "b"], defaultVariant: "a" })
+    const first = Test.Struct({ value: Schema.String })
+    const second = Test.Struct({ value: Schema.Number })
+    const union = Test.Union([first, second])
+
+    assert.strictEqual(union.members.length, 2)
+  })
 })
 
 describe("Model", () => {

--- a/packages/effect/typetest/VariantSchema.tst.ts
+++ b/packages/effect/typetest/VariantSchema.tst.ts
@@ -26,9 +26,13 @@ describe("VariantSchema", () => {
     const second = Test.Struct({
       value: Test.FieldOnly(["a", "b"])(Schema.Number)
     })
+    const union = Test.Union([first, second])
 
     expect(Test.Union).type.toBeCallableWith([first, second])
     expect(Test.Union).type.not.toBeCallableWith(first, second)
+    expect<Schema.Schema.Type<typeof union>>().type.toBe<
+      { readonly value: string } | { readonly value: number }
+    >()
   })
 
   it("Class preserves constructor and variant schema types", () => {


### PR DESCRIPTION
## Summary

A Union built from documented plain Struct members creates an empty default union that accepts neither member shape.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Default union excludes plain variant structs

**Module:** `schema/VariantSchema`  
**Audit ID:** `unstable-ai-cli-variant-schema-default-union-empty`  
**Severity / confidence:** high / high

### What happens

A Union built from documented plain Struct members creates an empty default union that accepts neither member shape.

### Why it happens

Default construction filters members with Schema.isSchema instead of extracting their configured default variants, and Struct values are not schemas.

### Expected behavior

Union accepts Struct members and creates a default union over each member's default schema.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/schema/VariantSchema.ts:293-305`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/schema/VariantSchema.ts#L293-L305)
- [`packages/effect/src/unstable/schema/VariantSchema.ts:471-473`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/schema/VariantSchema.ts#L471-L473)
- [`packages/effect/src/unstable/schema/VariantSchema.ts:585-595`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/schema/VariantSchema.ts#L585-L595)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/schema/VariantSchema.ts:293-305</code></summary>

```ts
/**
 * Union schema over the default schemas of a list of variant schema structs.
 *
 * @category models
 * @since 4.0.0
 */
export interface Union<Members extends ReadonlyArray<Struct<any>>> extends
  Schema.Union<
    {
      readonly [K in keyof Members]: [Members[K]] extends [Schema.Top] ? Members[K] : never
    }
  >
{}
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/schema/VariantSchema.ts#L293-L305)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/schema/VariantSchema.ts:471-473</code></summary>

```ts
  function UnionVariants(members: ReadonlyArray<Struct<any>>) {
    return Union(members, options.variants)
  }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/schema/VariantSchema.ts#L471-L473)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/schema/VariantSchema.ts:585-595</code></summary>

```ts
const Union = <Members extends ReadonlyArray<Struct<any>>, Variants extends ReadonlyArray<string>>(
  members: Members,
  variants: Variants
) => {
  const VariantUnion = Schema.Union(members.filter((member) => Schema.isSchema(member))) as any
  for (const variant of variants) {
    Object.defineProperty(VariantUnion, variant, {
      value: Schema.Union(members.map((member) => extract(member, variant)))
    })
  }
  return VariantUnion
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/schema/VariantSchema.ts#L585-L595)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/schema/VariantSchemaDefaultUnionAudit.test.ts
```

**Observed failure:** FAIL: the default union contained zero members.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/schema/VariantSchemaDefaultUnionAudit.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-ai-cli-variant-schema-default-union-empty`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-401