### PR TITLE
Emit valid terminal CSI sequences from cursorTo

### DIFF
--- a/.changeset/fix-ansi-cursor-to.md
+++ b/.changeset/fix-ansi-cursor-to.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Emit valid CSI sequences from the unstable CLI `cursorTo` helper.

--- a/packages/effect/src/unstable/cli/internal/ansi.ts
+++ b/packages/effect/src/unstable/cli/internal/ansi.ts
@@ -79,9 +79,9 @@ export const combine = (...styles: Array<string>): Array<string> => styles
 /** @internal */
 export const cursorTo = (column: number, row?: number): string => {
   if (row === undefined) {
-    return `\x1b${Math.max(column + 1, 0)} G`
+    return `${ESC}${Math.max(column + 1, 0)}G`
   }
-  return `\x1b${row + 1}${SEP}${Math.max(column + 1, 0)} H`
+  return `${ESC}${row + 1}${SEP}${Math.max(column + 1, 0)}H`
 }
 
 /** @internal */

--- a/packages/effect/test/unstable/cli/Ansi.test.ts
+++ b/packages/effect/test/unstable/cli/Ansi.test.ts
@@ -1,0 +1,10 @@
+import { assert, it } from "@effect/vitest"
+import * as Ansi from "effect/unstable/cli/internal/ansi"
+
+it("emits a standard CSI horizontal absolute sequence", () => {
+  assert.strictEqual(Ansi.cursorTo(0), "\x1b[1G")
+})
+
+it("emits a standard CSI cursor-position sequence", () => {
+  assert.strictEqual(Ansi.cursorTo(2, 3), "\x1b[4;3H")
+})


### PR DESCRIPTION
## Summary

Both horizontal and row-column cursorTo forms emit invalid terminal escape sequences.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## cursorTo emits malformed CSI sequences

**Module:** `cli/internal/ansi`  
**Audit ID:** `unstable-ai-cli-ansi-cursor-to-malformed`  
**Severity / confidence:** medium / high

### What happens

Both horizontal and row-column cursorTo forms emit invalid terminal escape sequences.

### Why it happens

Both branches omit the CSI opening bracket and insert an invalid space before the command byte.

### Expected behavior

Cursor helpers emit valid CSI sequences using one-based terminal coordinates.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/cli/internal/ansi.ts:79-85`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/internal/ansi.ts#L79-L85)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/cli/internal/ansi.ts:79-85</code></summary>

```ts
/** @internal */
export const cursorTo = (column: number, row?: number): string => {
  if (row === undefined) {
    return `\x1b${Math.max(column + 1, 0)} G`
  }
  return `\x1b${row + 1}${SEP}${Math.max(column + 1, 0)} H`
}
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/internal/ansi.ts#L79-L85)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/cli/AnsiCursorTo.audit.test.ts
```

**Observed failure:** FAIL: cursorTo emitted ESC 1 G and ESC 4;3 H.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/cli/AnsiCursorTo.audit.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-ai-cli-ansi-cursor-to-malformed`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-402