### PR TITLE
Match Fish completions against the full command path

### DIFF
--- a/.changeset/fix-fish-command-path.md
+++ b/.changeset/fix-fish-command-path.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Match Fish completions against the full nested command path.

--- a/packages/effect/src/unstable/cli/internal/completions/fish.ts
+++ b/packages/effect/src/unstable/cli/internal/completions/fish.ts
@@ -18,7 +18,7 @@ const escapeFishString = (s: string): string => s.replace(/'/g, "\\'")
  * Build a Fish condition that checks the current subcommand context.
  *
  * For root-level completions with subcommands: `__fish_use_subcommand`
- * For nested commands: verify the parent subcommand is active AND none of its
+ * For nested commands: verify the full parent path is active AND none of its
  * child subcommands have been entered yet.
  */
 const subcommandCondition = (
@@ -31,14 +31,12 @@ const subcommandCondition = (
     }
     return ``
   }
-  const parent = parentPath[parentPath.length - 1]
+  const parentCondition = parentPath.map((parent) => `__fish_seen_subcommand_from ${parent}`).join("; and ")
   if (childSubcommandNames.length > 0) {
-    // Show only when parent is active but no child subcommand has been entered
-    return `__fish_seen_subcommand_from ${parent}; and not __fish_seen_subcommand_from ${
-      childSubcommandNames.join(" ")
-    }`
+    // Show only when the parent path is active but no child subcommand has been entered
+    return `${parentCondition}; and not __fish_seen_subcommand_from ${childSubcommandNames.join(" ")}`
   }
-  return `__fish_seen_subcommand_from ${parent}`
+  return parentCondition
 }
 
 /**

--- a/packages/effect/test/unstable/cli/completions/completions.test.ts
+++ b/packages/effect/test/unstable/cli/completions/completions.test.ts
@@ -1,4 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
+import { execFileSync } from "node:child_process"
 import { Argument, Command, Flag } from "effect/unstable/cli"
 import * as Completions from "effect/unstable/cli/Completions"
 import * as Bash from "effect/unstable/cli/internal/completions/bash"
@@ -339,6 +340,33 @@ describe("Zsh completions", () => {
 // ---------------------------------------------------------------------------
 
 describe("Fish completions", () => {
+  it("scopes nested completions by the full command path", () => {
+    const leaf = (name: string, flag: string): Completions.CommandDescriptor => ({
+      name,
+      description: undefined,
+      flags: [{ name: flag, aliases: [], description: undefined, type: { _tag: "Boolean" } }],
+      arguments: [],
+      subcommands: []
+    })
+    const descriptor: Completions.CommandDescriptor = {
+      name: "tool",
+      description: undefined,
+      flags: [],
+      arguments: [],
+      subcommands: [
+        { name: "alpha", description: undefined, flags: [], arguments: [], subcommands: [leaf("common", "alpha-only")] },
+        { name: "beta", description: undefined, flags: [], arguments: [], subcommands: [leaf("common", "beta-only")] }
+      ]
+    }
+    const script = Fish.generate("tool", descriptor)
+    const output = execFileSync("fish", ["-c", `${script}\ncomplete -C 'tool alpha common --'`], {
+      encoding: "utf8"
+    })
+
+    assert.include(output, "--alpha-only")
+    assert.notInclude(output, "--beta-only")
+  })
+
   it("generates complete commands for root subcommands", () => {
     const desc = fromCommand(withSubcommands)
     const script = Fish.generate("server", desc)

--- a/packages/effect/test/unstable/cli/completions/completions.test.ts
+++ b/packages/effect/test/unstable/cli/completions/completions.test.ts
@@ -1,5 +1,4 @@
 import { assert, describe, it } from "@effect/vitest"
-import { execFileSync } from "node:child_process"
 import { Argument, Command, Flag } from "effect/unstable/cli"
 import * as Completions from "effect/unstable/cli/Completions"
 import * as Bash from "effect/unstable/cli/internal/completions/bash"
@@ -354,17 +353,22 @@ describe("Fish completions", () => {
       flags: [],
       arguments: [],
       subcommands: [
-        { name: "alpha", description: undefined, flags: [], arguments: [], subcommands: [leaf("common", "alpha-only")] },
+        {
+          name: "alpha",
+          description: undefined,
+          flags: [],
+          arguments: [],
+          subcommands: [leaf("common", "alpha-only")]
+        },
         { name: "beta", description: undefined, flags: [], arguments: [], subcommands: [leaf("common", "beta-only")] }
       ]
     }
-    const script = Fish.generate("tool", descriptor)
-    const output = execFileSync("fish", ["-c", `${script}\ncomplete -C 'tool alpha common --'`], {
-      encoding: "utf8"
-    })
+    const lines = Fish.generate("tool", descriptor).split("\n")
+    const alphaOnly = lines.find((line) => line.includes("-l alpha-only"))!
+    const betaOnly = lines.find((line) => line.includes("-l beta-only"))!
 
-    assert.include(output, "--alpha-only")
-    assert.notInclude(output, "--beta-only")
+    assert.include(alphaOnly, "__fish_seen_subcommand_from alpha; and __fish_seen_subcommand_from common")
+    assert.include(betaOnly, "__fish_seen_subcommand_from beta; and __fish_seen_subcommand_from common")
   })
 
   it("generates complete commands for root subcommands", () => {


### PR DESCRIPTION
## Summary

Match nested Fish completion rules against every command in the active parent path. This prevents commands that reuse a nested subcommand name under different parents from activating completions from unrelated branches.

The regression test remains in the main completion test file and asserts the generated Fish predicates directly, so it does not require the `fish` binary in CI.

Closes EFF-405

## Validation

```sh
pnpm test --run packages/effect/test/unstable/cli/completions/completions.test.ts
pnpm lint-fix
pnpm check
```

## Audit provenance

- Audit ID: `unstable-ai-cli-fish-nested-command-path`
- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Severity / confidence: medium / high
