### PR TITLE
Mark omittable CLI inputs as optional in structured help

### DIFF
--- a/.changeset/kind-flags-help.md
+++ b/.changeset/kind-flags-help.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Mark omittable CLI flags and arguments as optional in structured help.

--- a/packages/effect/src/unstable/cli/internal/command.ts
+++ b/packages/effect/src/unstable/cli/internal/command.ts
@@ -139,7 +139,8 @@ export const makeCommand = <const Name extends string, Input, E, R, ContextInput
           name: single.name,
           type: single.typeName ?? Primitive.getTypeName(single.primitiveType),
           description: single.description,
-          required: !metadata.isOptional,
+          required: !metadata.isOptional &&
+            (!metadata.isVariadic || Option.exists(metadata.variadicMin, (min) => min > 0)),
           variadic: metadata.isVariadic
         })
       }
@@ -159,11 +160,12 @@ export const makeCommand = <const Name extends string, Input, E, R, ContextInput
 
     for (const option of config.flags) {
       const singles = Param.extractSingleParams(option)
+      const metadata = Param.getParamMetadata(option)
       for (const single of singles) {
         // Hidden flags still parse on the command line but are omitted from
         // generated --help output.
         if (single.hidden) continue
-        flags.push(toFlagDoc(single))
+        flags.push(toFlagDoc(single, metadata))
       }
     }
 
@@ -233,14 +235,17 @@ export const makeCommand = <const Name extends string, Input, E, R, ContextInput
 /**
  * Converts a single flag param into a FlagDoc for help display.
  */
-export const toFlagDoc = (single: Param.Single<typeof Param.flagKind, unknown>): FlagDoc => {
+export const toFlagDoc = (
+  single: Param.Single<typeof Param.flagKind, unknown>,
+  metadata: ReturnType<typeof Param.getParamMetadata>
+): FlagDoc => {
   const formattedAliases = single.aliases.map((alias) => alias.length === 1 ? `-${alias}` : `--${alias}`)
   return {
     name: single.name,
     aliases: formattedAliases,
     type: single.typeName ?? Primitive.getTypeName(single.primitiveType),
     description: appendChoiceKeys(single.description, Primitive.getChoiceKeys(single.primitiveType)),
-    required: single.primitiveType._tag !== "Boolean"
+    required: single.primitiveType._tag !== "Boolean" && !metadata.isOptional
   }
 }
 

--- a/packages/effect/src/unstable/cli/internal/help.ts
+++ b/packages/effect/src/unstable/cli/internal/help.ts
@@ -111,6 +111,7 @@ const getSharedFlagsForCommandPath = (
     const ancestorImpl = toImpl(ancestor)
     for (const flag of ancestorImpl.contextConfig.flags) {
       const singles = Param.extractSingleParams(flag)
+      const metadata = Param.getParamMetadata(flag)
       for (const single of singles) {
         if (seen.has(single.name)) {
           continue
@@ -122,7 +123,7 @@ const getSharedFlagsForCommandPath = (
           continue
         }
         seen.add(single.name)
-        sharedFlags.push(toFlagDoc(single))
+        sharedFlags.push(toFlagDoc(single, metadata))
       }
     }
   }
@@ -165,13 +166,14 @@ export const getHelpForCommandPath = <Name extends string, Input, E, R, ContextI
     const globalFlagDocs: Array<FlagDoc> = []
     for (const flag of flags) {
       const singles = Param.extractSingleParams(flag.flag)
+      const metadata = Param.getParamMetadata(flag.flag)
       for (const single of singles) {
         // Same rule as command-local flags: hidden globals are still parsed
         // and still trigger their handlers, they just don't appear under
         // "GLOBAL FLAGS" in --help.
         if (single.hidden) continue
         globalFlagDocs.push({
-          ...toFlagDoc(single),
+          ...toFlagDoc(single, metadata),
           required: false
         })
       }

--- a/packages/effect/test/unstable/cli/Help.test.ts
+++ b/packages/effect/test/unstable/cli/Help.test.ts
@@ -39,22 +39,36 @@ const runCommand = Effect.fnUntraced(
 )
 
 describe("Command help output", () => {
-  it("marks optional flags as not required in structured help", () => {
+  it("marks omittable flags as not required in structured help", () => {
     const command = Command.make("app", {
-      output: Flag.string("output").pipe(Flag.optional)
+      required: Flag.string("required"),
+      optional: Flag.string("optional").pipe(Flag.optional),
+      defaulted: Flag.string("defaulted").pipe(Flag.withDefault("output.txt"))
     })
     const help = toImpl(command).buildHelpDoc(["app"])
 
-    assert.isFalse(help.flags[0].required)
+    assert.deepStrictEqual(help.flags.map((flag) => flag.required), [true, false, false])
   })
 
-  it("marks zero-minimum variadic arguments as not required in structured help", () => {
-    const command = Command.make("app", {
+  it("marks omittable arguments as not required in structured help", () => {
+    const requiredVariadic = Command.make("app", {
+      files: Argument.string("files").pipe(Argument.variadic({ min: 1 }))
+    })
+    const optionalVariadic = Command.make("app", {
       files: Argument.string("files").pipe(Argument.variadic())
     })
-    const help = toImpl(command).buildHelpDoc(["app"])
+    const defaulted = Command.make("app", {
+      output: Argument.string("output").pipe(Argument.withDefault("output.txt"))
+    })
 
-    assert.isFalse(help.args![0].required)
+    assert.deepStrictEqual(
+      [
+        toImpl(requiredVariadic).buildHelpDoc(["app"]).args![0].required,
+        toImpl(optionalVariadic).buildHelpDoc(["app"]).args![0].required,
+        toImpl(defaulted).buildHelpDoc(["app"]).args![0].required
+      ],
+      [true, false, false]
+    )
   })
 
   it.effect("renders root command help", () =>

--- a/packages/effect/test/unstable/cli/Help.test.ts
+++ b/packages/effect/test/unstable/cli/Help.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "@effect/vitest"
+import { assert, describe, expect, it } from "@effect/vitest"
 import { Effect, FileSystem, Layer, Path, Stdio } from "effect"
 import { TestConsole } from "effect/testing"
-import { CliOutput, Command, Flag } from "effect/unstable/cli"
+import { Argument, CliOutput, Command, Flag } from "effect/unstable/cli"
+import { toImpl } from "effect/unstable/cli/internal/command"
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner"
 import * as Cli from "./fixtures/ComprehensiveCli.ts"
 import * as MockTerminal from "./services/MockTerminal.ts"
@@ -38,6 +39,24 @@ const runCommand = Effect.fnUntraced(
 )
 
 describe("Command help output", () => {
+  it("marks optional flags as not required in structured help", () => {
+    const command = Command.make("app", {
+      output: Flag.string("output").pipe(Flag.optional)
+    })
+    const help = toImpl(command).buildHelpDoc(["app"])
+
+    assert.isFalse(help.flags[0].required)
+  })
+
+  it("marks zero-minimum variadic arguments as not required in structured help", () => {
+    const command = Command.make("app", {
+      files: Argument.string("files").pipe(Argument.variadic())
+    })
+    const help = toImpl(command).buildHelpDoc(["app"])
+
+    assert.isFalse(help.args![0].required)
+  })
+
   it.effect("renders root command help", () =>
     Effect.gen(function*() {
       const helpText = yield* runCommand(["--help"])


### PR DESCRIPTION
## Summary

Structured help reports optional non-boolean flags and zero-minimum variadic arguments as required.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Structured help marks omittable inputs required

**Module:** `cli/internal/command`  
**Audit ID:** `unstable-ai-cli-help-omittable-inputs-required`  
**Severity / confidence:** medium / high

### What happens

Structured help reports optional non-boolean flags and zero-minimum variadic arguments as required.

### Why it happens

Flag requiredness checks only primitive type, and argument requiredness checks only isOptional while ignoring defaults and repetition minima.

### Expected behavior

FlagDoc.required and ArgDoc.required indicate whether the corresponding input must be provided.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/cli/internal/command.ts:134-167`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/internal/command.ts#L134-L167)
- [`packages/effect/src/unstable/cli/internal/command.ts:236-244`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/internal/command.ts#L236-L244)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/cli/internal/command.ts:134-167</code></summary>

```ts
    for (const arg of config.arguments) {
      const singles = Param.extractSingleParams(arg)
      const metadata = Param.getParamMetadata(arg)
      for (const single of singles) {
        args.push({
          name: single.name,
          type: single.typeName ?? Primitive.getTypeName(single.primitiveType),
          description: single.description,
          required: !metadata.isOptional,
          variadic: metadata.isVariadic
        })
      }
    }

    let usage = commandPath.length > 0 ? commandPath.join(" ") : options.name
    // Only render `<subcommand>` in usage when at least one visible subcommand
    // exists; an all-hidden subcommand tree should look like a leaf command.
    if (subcommands.some((group) => group.commands.some((c) => !c.hidden))) {
      usage += " <subcommand>"
    }
    usage += " [flags]"
    for (const arg of args) {
      const argName = arg.variadic ? `<${arg.name}...>` : `<${arg.name}>`
      usage += ` ${arg.required ? argName : `[${argName}]`}`
    }

    for (const option of config.flags) {
      const singles = Param.extractSingleParams(option)
      for (const single of singles) {
        // Hidden flags still parse on the command line but are omitted from
        // generated --help output.
        if (single.hidden) continue
        flags.push(toFlagDoc(single))
      }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/internal/command.ts#L134-L167)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/cli/internal/command.ts:236-244</code></summary>

```ts
export const toFlagDoc = (single: Param.Single<typeof Param.flagKind, unknown>): FlagDoc => {
  const formattedAliases = single.aliases.map((alias) => alias.length === 1 ? `-${alias}` : `--${alias}`)
  return {
    name: single.name,
    aliases: formattedAliases,
    type: single.typeName ?? Primitive.getTypeName(single.primitiveType),
    description: appendChoiceKeys(single.description, Primitive.getChoiceKeys(single.primitiveType)),
    required: single.primitiveType._tag !== "Boolean"
  }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/internal/command.ts#L236-L244)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/cli/HelpRequired.audit.test.ts
```

**Observed failure:** FAIL: both omittable inputs reported required true.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/cli/HelpRequired.audit.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-ai-cli-help-omittable-inputs-required`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-406