### PR TITLE
Preserve file and directory semantics in completion descriptors

### DIFF
--- a/.changeset/tender-files-complete.md
+++ b/.changeset/tender-files-complete.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve file and directory semantics in CLI completion descriptors.

--- a/packages/effect/src/unstable/cli/Primitive.ts
+++ b/packages/effect/src/unstable/cli/Primitive.ts
@@ -479,8 +479,8 @@ export type PathType = "file" | "directory" | "either"
 export const path = (
   pathType: PathType,
   mustExist?: boolean
-): Primitive<string> =>
-  makePrimitive(
+): Primitive<string> => {
+  const primitive = makePrimitive(
     "Path",
     Effect.fnUntraced(function*(value) {
       const fs = yield* FileSystem.FileSystem
@@ -518,6 +518,8 @@ export const path = (
       return absolutePath
     })
   )
+  return Object.assign(primitive, { pathType })
+}
 
 /**
  * Creates a primitive that wraps string input in `Redacted`.
@@ -984,3 +986,7 @@ export const getTypeName = <A>(primitive: Primitive<A>): string => {
 /** @internal */
 export const getChoiceKeys = (primitive: Primitive<unknown>): ReadonlyArray<string> | undefined =>
   primitive._tag === "Choice" ? (primitive as any).choiceKeys : undefined
+
+/** @internal */
+export const getPathType = (primitive: Primitive<unknown>): PathType | undefined =>
+  primitive._tag === "Path" ? (primitive as any).pathType : undefined

--- a/packages/effect/src/unstable/cli/internal/completions/descriptor.ts
+++ b/packages/effect/src/unstable/cli/internal/completions/descriptor.ts
@@ -30,15 +30,12 @@ const toFlagType = (single: Param.Single<"flag", unknown>): Completions.FlagType
       const keys = Primitive.getChoiceKeys(single.primitiveType)
       return { _tag: "Choice", values: keys ?? [] }
     }
-    case "Path": {
-      const typeName = single.typeName
-      const pathType: "file" | "directory" | "either" = typeName === "file"
-        ? "file"
-        : typeName === "directory"
-        ? "directory"
-        : "either"
-      return { _tag: "Path", pathType }
-    }
+    case "Path":
+      return { _tag: "Path", pathType: Primitive.getPathType(single.primitiveType) ?? "either" }
+    case "FileText":
+    case "FileParse":
+    case "FileSchema":
+      return { _tag: "Path", pathType: "file" }
     default:
       return { _tag: "String" }
   }
@@ -57,15 +54,12 @@ const toArgumentType = (single: Param.Single<"argument", unknown>): Completions.
       const keys = Primitive.getChoiceKeys(single.primitiveType)
       return { _tag: "Choice", values: keys ?? [] }
     }
-    case "Path": {
-      const typeName = single.typeName
-      const pathType: "file" | "directory" | "either" = typeName === "file"
-        ? "file"
-        : typeName === "directory"
-        ? "directory"
-        : "either"
-      return { _tag: "Path", pathType }
-    }
+    case "Path":
+      return { _tag: "Path", pathType: Primitive.getPathType(single.primitiveType) ?? "either" }
+    case "FileText":
+    case "FileParse":
+    case "FileSchema":
+      return { _tag: "Path", pathType: "file" }
     default:
       return { _tag: "String" }
   }

--- a/packages/effect/test/unstable/cli/completions/descriptor.test.ts
+++ b/packages/effect/test/unstable/cli/completions/descriptor.test.ts
@@ -1,4 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
+import { Schema } from "effect"
 import { Argument, Command, Flag } from "effect/unstable/cli"
 import { fromCommand } from "effect/unstable/cli/internal/completions/descriptor"
 
@@ -68,22 +69,31 @@ describe("CommandDescriptor", () => {
       assert.deepStrictEqual(configFlag.type, { _tag: "Path", pathType: "either" })
     })
 
-    it("retains path semantics when a path flag has a custom metavar", () => {
+    it("retains path semantics when a path has a custom metavar", () => {
       const command = Command.make("app", {
-        directory: Flag.path("directory", { pathType: "directory", typeName: "DIR" })
+        directory: Flag.path("directory", { pathType: "directory", typeName: "DIR" }),
+        file: Argument.path("file", { pathType: "file" }).pipe(Argument.withMetavar("INPUT"))
       })
       const descriptor = fromCommand(command)
 
       assert.deepStrictEqual(descriptor.flags[0].type, { _tag: "Path", pathType: "directory" })
+      assert.deepStrictEqual(descriptor.arguments[0].type, { _tag: "Path", pathType: "file" })
     })
 
-    it("classifies file-backed flags as file paths", () => {
+    it("classifies file-backed flags and arguments as file paths", () => {
       const command = Command.make("app", {
-        config: Flag.fileText("config")
+        flagText: Flag.fileText("flag-text"),
+        flagParse: Flag.fileParse("flag-parse"),
+        flagSchema: Flag.fileSchema("flag-schema", Schema.Unknown),
+        argumentText: Argument.fileText("argument-text"),
+        argumentParse: Argument.fileParse("argument-parse"),
+        argumentSchema: Argument.fileSchema("argument-schema", Schema.Unknown)
       })
       const descriptor = fromCommand(command)
+      const fileType = { _tag: "Path", pathType: "file" } as const
 
-      assert.deepStrictEqual(descriptor.flags[0].type, { _tag: "Path", pathType: "file" })
+      assert.deepStrictEqual(descriptor.flags.map((flag) => flag.type), [fileType, fileType, fileType])
+      assert.deepStrictEqual(descriptor.arguments.map((argument) => argument.type), [fileType, fileType, fileType])
     })
 
     it("extracts choice flags with values", () => {

--- a/packages/effect/test/unstable/cli/completions/descriptor.test.ts
+++ b/packages/effect/test/unstable/cli/completions/descriptor.test.ts
@@ -68,6 +68,24 @@ describe("CommandDescriptor", () => {
       assert.deepStrictEqual(configFlag.type, { _tag: "Path", pathType: "either" })
     })
 
+    it("retains path semantics when a path flag has a custom metavar", () => {
+      const command = Command.make("app", {
+        directory: Flag.path("directory", { pathType: "directory", typeName: "DIR" })
+      })
+      const descriptor = fromCommand(command)
+
+      assert.deepStrictEqual(descriptor.flags[0].type, { _tag: "Path", pathType: "directory" })
+    })
+
+    it("classifies file-backed flags as file paths", () => {
+      const command = Command.make("app", {
+        config: Flag.fileText("config")
+      })
+      const descriptor = fromCommand(command)
+
+      assert.deepStrictEqual(descriptor.flags[0].type, { _tag: "Path", pathType: "file" })
+    })
+
     it("extracts choice flags with values", () => {
       const cmd = Command.make("test", {
         color: Flag.choice("color", ["red", "green", "blue"])


### PR DESCRIPTION
## Summary

Custom display metadata changes directory completion to generic path completion, while file-backed primitives lose file completion entirely.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Completion descriptors lose path semantics

**Module:** `cli/internal/completions/descriptor`  
**Audit ID:** `unstable-ai-cli-completion-path-semantics`  
**Severity / confidence:** medium / high

### What happens

Custom display metadata changes directory completion to generic path completion, while file-backed primitives lose file completion entirely.

### Why it happens

Path type is inferred from typeName, and FileText, FileParse, and FileSchema fall through to String instead of Path/file.

### Expected behavior

Completion descriptors preserve whether CLI inputs consume files or directories independently of display metadata.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/cli/internal/completions/descriptor.ts:18-71`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/internal/completions/descriptor.ts#L18-L71)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/cli/internal/completions/descriptor.ts:18-67</code></summary>

```ts
const toFlagType = (single: Param.Single<"flag", unknown>): Completions.FlagType => {
  const tag = single.primitiveType._tag
  switch (tag) {
    case "Boolean":
      return { _tag: "Boolean" }
    case "Integer":
      return { _tag: "Integer" }
    case "Float":
      return { _tag: "Float" }
    case "Date":
      return { _tag: "Date" }
    case "Choice": {
      const keys = Primitive.getChoiceKeys(single.primitiveType)
      return { _tag: "Choice", values: keys ?? [] }
    }
    case "Path": {
      const typeName = single.typeName
      const pathType: "file" | "directory" | "either" = typeName === "file"
        ? "file"
        : typeName === "directory"
        ? "directory"
        : "either"
      return { _tag: "Path", pathType }
    }
    default:
      return { _tag: "String" }
  }
}

const toArgumentType = (single: Param.Single<"argument", unknown>): Completions.ArgumentType => {
  const tag = single.primitiveType._tag
  switch (tag) {
    case "Integer":
      return { _tag: "Integer" }
    case "Float":
      return { _tag: "Float" }
    case "Date":
      return { _tag: "Date" }
    case "Choice": {
      const keys = Primitive.getChoiceKeys(single.primitiveType)
      return { _tag: "Choice", values: keys ?? [] }
    }
    case "Path": {
      const typeName = single.typeName
      const pathType: "file" | "directory" | "either" = typeName === "file"
        ? "file"
        : typeName === "directory"
        ? "directory"
        : "either"
      return { _tag: "Path", pathType }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/internal/completions/descriptor.ts#L18-L71)

_Excerpt truncated. [Open the complete packages/effect/src/unstable/cli/internal/completions/descriptor.ts:18-71 range.](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/internal/completions/descriptor.ts#L18-L71)_

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/cli/CompletionPathTypes.audit.test.ts
```

**Observed failure:** FAIL: a directory became either and a file-backed flag became String.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/cli/CompletionPathTypes.audit.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-ai-cli-completion-path-semantics`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-407