### PR TITLE
Support empty records and iterables in Prompt.all

### DIFF
--- a/.changeset/fix-prompt-all-iterables.md
+++ b/.changeset/fix-prompt-all-iterables.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Support empty records and non-array iterables in `Prompt.all`.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -693,10 +693,13 @@ export const all: <
   if (arguments.length === 1) {
     if (isPrompt(arguments[0])) {
       return map(arguments[0], (x) => [x]) as any
-    } else if (Array.isArray(arguments[0])) {
-      return allTupled(arguments[0]) as any
+    } else if (Predicate.isIterable(arguments[0])) {
+      return allTupled(Arr.fromIterable(arguments[0] as Iterable<Prompt<any>>)) as any
     } else {
       const entries = Object.entries(arguments[0] as Readonly<{ [K: string]: Prompt<any> }>)
+      if (entries.length === 0) {
+        return succeed({}) as any
+      }
       let result = map(entries[0][1], (value) => ({ [entries[0][0]]: value }))
       if (entries.length === 1) {
         return result as any

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -62,6 +62,16 @@ describe("Prompt.date", () => {
     }).pipe(Effect.provide(TestLayer)))
 })
 
+describe("Prompt.all", () => {
+  it("constructs a prompt for an empty record", () => {
+    assert.isTrue(Prompt.isPrompt(Prompt.all({})))
+  })
+
+  it("constructs a prompt for a non-array iterable", () => {
+    assert.isTrue(Prompt.isPrompt(Prompt.all(new Set([Prompt.succeed(1)]))))
+  })
+})
+
 describe("Prompt.integer", () => {
   it.effect("submits the default value", () =>
     Effect.gen(function*() {

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -63,13 +63,17 @@ describe("Prompt.date", () => {
 })
 
 describe("Prompt.all", () => {
-  it("constructs a prompt for an empty record", () => {
-    assert.isTrue(Prompt.isPrompt(Prompt.all({})))
-  })
+  it.effect("supports an empty record", () =>
+    Effect.gen(function*() {
+      const result = yield* Prompt.all({})
+      assert.deepStrictEqual(result, {})
+    }).pipe(Effect.provide(TestLayer)))
 
-  it("constructs a prompt for a non-array iterable", () => {
-    assert.isTrue(Prompt.isPrompt(Prompt.all(new Set([Prompt.succeed(1)]))))
-  })
+  it.effect("supports a non-array iterable", () =>
+    Effect.gen(function*() {
+      const result = yield* Prompt.all(new Set([Prompt.succeed(1)]))
+      assert.deepStrictEqual(result, [1])
+    }).pipe(Effect.provide(TestLayer)))
 })
 
 describe("Prompt.integer", () => {


### PR DESCRIPTION
## Summary

Constructing Prompt.all with an empty record or a supported non-array iterable throws synchronously instead of returning a prompt.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Prompt.all crashes on supported input shapes

**Module:** `cli/Prompt`  
**Audit ID:** `unstable-ai-cli-prompt-all-supported-input-crash`  
**Severity / confidence:** medium / high

### What happens

Constructing Prompt.all with an empty record or a supported non-array iterable throws synchronously instead of returning a prompt.

### Why it happens

Only arrays use iterable handling; other values go through Object.entries, followed by an unconditional entries[0] access.

### Expected behavior

Prompt.all supports either an iterable of prompts or a record of prompts, including empty collections.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/cli/Prompt.ts:648-719`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/Prompt.ts#L648-L719)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/cli/Prompt.ts:648-697</code></summary>

````ts
/**
 * Runs all the provided prompts in sequence respecting the structure provided
 * in input.
 *
 * **Details**
 *
 * Supports either a tuple / iterable of prompts or a record / struct of prompts
 * as an argument.
 *
 * **Example** (Collecting prompt results)
 *
 * ```ts import.meta.vitest
 * import { Effect, FileSystem, Layer, Path, Terminal } from "effect"
 * import { Prompt } from "effect/unstable/cli"
 *
 * const terminal = Terminal.make({
 *   columns: Effect.succeed(80),
 *   rows: Effect.succeed(24),
 *   readInput: Effect.succeed({} as never),
 *   readLine: Effect.die("unused"),
 *   display: () => Effect.void
 * })
 * const services = Layer.mergeAll(
 *   FileSystem.layerNoop({}),
 *   Path.layer,
 *   Layer.succeed(Terminal.Terminal, terminal)
 * )
 *
 * const username = Prompt.succeed("alice")
 * const password = Prompt.succeed("secret")
 *
 * const allWithTuple = Prompt.all([username, password])
 *
 * const allWithRecord = Prompt.all({ username, password })
 *
 * await Effect.runPromise(Effect.provide(allWithTuple, services)) // => ["alice", "secret"]
 * await Effect.runPromise(Effect.provide(allWithRecord, services)) // => { username: "alice", password: "secret" }
 * ```
 *
 * @category collecting & elements
 * @since 4.0.0
 */
export const all: <
  const Arg extends Iterable<Prompt<any>> | Record<string, Prompt<any>>
>(arg: Arg) => All.Return<Arg> = function() {
  if (arguments.length === 1) {
    if (isPrompt(arguments[0])) {
      return map(arguments[0], (x) => [x]) as any
    } else if (Array.isArray(arguments[0])) {
      return allTupled(arguments[0]) as any
````

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/Prompt.ts#L648-L719)

_Excerpt truncated. [Open the complete packages/effect/src/unstable/cli/Prompt.ts:648-719 range.](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/Prompt.ts#L648-L719)_

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/cli/PromptAll.audit.test.ts
```

**Observed failure:** FAIL: both supported cases threw while reading entries[0].

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/cli/PromptAll.audit.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-ai-cli-prompt-all-supported-input-crash`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-408
