### PR TITLE
Exclude disabled choices from multi-select prompts

### DIFF
--- a/.changeset/calm-pears-smile.md
+++ b/.changeset/calm-pears-smile.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Exclude disabled choices from multi-select prompt selection and submission.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -1216,7 +1216,7 @@ export const multiSelect = <const A>(
   const initialSelected = new Set<number>()
   for (let i = 0; i < opts.choices.length; i++) {
     const choice = opts.choices[i] as SelectChoice<A>
-    if (choice.selected === true) {
+    if (choice.selected === true && !choice.disabled) {
       initialSelected.add(i)
     }
   }
@@ -2649,16 +2649,22 @@ const processSpace = <A>(
 ) => {
   const selectedIndices = new Set(state.selectedIndices)
   if (state.index === 0) {
-    if (state.selectedIndices.size === options.choices.length) {
+    const selectableCount = options.choices.filter((choice) => !choice.disabled).length
+    const selectedCount = Array.from(state.selectedIndices).filter((index) => !options.choices[index].disabled).length
+    if (selectedCount === selectableCount) {
       selectedIndices.clear()
     } else {
       for (let i = 0; i < options.choices.length; i++) {
-        selectedIndices.add(i)
+        if (options.choices[i].disabled) {
+          selectedIndices.delete(i)
+        } else {
+          selectedIndices.add(i)
+        }
       }
     }
   } else if (state.index === 1) {
     for (let i = 0; i < options.choices.length; i++) {
-      if (state.selectedIndices.has(i)) {
+      if (options.choices[i].disabled || state.selectedIndices.has(i)) {
         selectedIndices.delete(i)
       } else {
         selectedIndices.add(i)
@@ -2666,7 +2672,9 @@ const processSpace = <A>(
     }
   } else {
     const choiceIndex = state.index - metaOptionsCount
-    if (selectedIndices.has(choiceIndex)) {
+    if (options.choices[choiceIndex].disabled) {
+      return Effect.succeed(Action.NextFrame({ state }))
+    } else if (selectedIndices.has(choiceIndex)) {
       selectedIndices.delete(choiceIndex)
     } else {
       selectedIndices.add(choiceIndex)
@@ -2706,7 +2714,8 @@ const handleMultiSelectProcess = <A>(options: SelectOptionsReq<A> & MultiSelectO
       }
       case "enter":
       case "return": {
-        const selectedCount = state.selectedIndices.size
+        const selectedIndices = Array.from(state.selectedIndices).filter((index) => !options.choices[index].disabled)
+        const selectedCount = selectedIndices.length
         if (options.min !== undefined && selectedCount < options.min) {
           return Effect.succeed(
             Action.NextFrame({ state: { ...state, error: Option.some(`At least ${options.min} are required`) } })
@@ -2717,9 +2726,7 @@ const handleMultiSelectProcess = <A>(options: SelectOptionsReq<A> & MultiSelectO
             Action.NextFrame({ state: { ...state, error: Option.some(`At most ${options.max} choices are allowed`) } })
           )
         }
-        const selectedValues = Array.from(state.selectedIndices).sort(EffectNumber.Order).map((index) =>
-          options.choices[index].value
-        )
+        const selectedValues = selectedIndices.sort(EffectNumber.Order).map((index) => options.choices[index].value)
         return Effect.succeed(Action.Submit({ value: selectedValues }))
       }
       default: {

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -2561,9 +2561,9 @@ const renderMultiSelectChoices = <A>(
   renderOptions?: RenderOptions | undefined
 ) => {
   const choices = options.choices
-  const totalChoices = choices.length
-  const selectedCount = state.selectedIndices.size
-  const allSelected = selectedCount === totalChoices
+  const selectableCount = choices.filter((choice) => !choice.disabled).length
+  const selectedCount = Array.from(state.selectedIndices).filter((index) => !choices[index].disabled).length
+  const allSelected = selectedCount === selectableCount
 
   const selectAllText = allSelected
     ? options?.selectNone ?? "Select None"
@@ -2599,8 +2599,9 @@ const renderMultiSelectChoices = <A>(
       const annotatedCheckbox = isHighlighted && renderOptions?.plain !== true
         ? Ansi.annotate(checkbox, Ansi.cyanBright)
         : checkbox
-      const title = renderMultiSelectTitle(choice.title, isHighlighted, renderOptions)
-      const description = renderChoiceDescription(choice as SelectChoice<A>, isHighlighted, renderOptions)
+      const selectChoice = choice as SelectChoice<A>
+      const title = renderChoiceTitle(selectChoice, isHighlighted, renderOptions)
+      const description = renderChoiceDescription(selectChoice, isHighlighted, renderOptions)
       documents.push(prefix + " " + annotatedCheckbox + " " + title + " " + description)
     }
   }
@@ -2655,9 +2656,7 @@ const processSpace = <A>(
       selectedIndices.clear()
     } else {
       for (let i = 0; i < options.choices.length; i++) {
-        if (options.choices[i].disabled) {
-          selectedIndices.delete(i)
-        } else {
+        if (!options.choices[i].disabled) {
           selectedIndices.add(i)
         }
       }
@@ -2673,7 +2672,7 @@ const processSpace = <A>(
   } else {
     const choiceIndex = state.index - metaOptionsCount
     if (options.choices[choiceIndex].disabled) {
-      return Effect.succeed(Action.NextFrame({ state }))
+      return Effect.succeed(Action.Beep())
     } else if (selectedIndices.has(choiceIndex)) {
       selectedIndices.delete(choiceIndex)
     } else {

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -497,6 +497,8 @@ describe("Prompt.multiSelect", () => {
       const value = yield* Prompt.run(prompt)
 
       assert.deepStrictEqual(value, [])
+      const output = yield* MockTerminal.displayLines
+      assert.isTrue(output.some((line) => String(line).includes("\x07")))
     }).pipe(Effect.provide(TestLayer)))
 
   it.effect("does not select disabled choices when selecting all", () =>
@@ -514,6 +516,8 @@ describe("Prompt.multiSelect", () => {
       const value = yield* Prompt.run(prompt)
 
       assert.deepStrictEqual(value, ["available"])
+      const output = yield* MockTerminal.displayLines
+      assert.isTrue(findFrame(toFrames(output), "Select None") !== undefined)
     }).pipe(Effect.provide(TestLayer)))
 
   it.effect("does not select disabled choices when inverting the selection", () =>
@@ -552,6 +556,8 @@ describe("Prompt.multiSelect", () => {
       const output = yield* MockTerminal.displayLines
       const initialFrame = findFrame(toFrames(output), "Unavailable")
       assert.isTrue(initialFrame?.includes("☐ Unavailable"))
+      const rawInitialFrame = findFrame(toRawFrames(output), "Unavailable")
+      assert.isTrue(rawInitialFrame?.includes(`${escape}[9m${escape}[90mUnavailable`))
     }).pipe(Effect.provide(TestLayer)))
 
   it.effect("underlines the active label", () =>

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -483,6 +483,22 @@ describe("Prompt.file", () => {
 })
 
 describe("Prompt.multiSelect", () => {
+  it.effect("does not allow a disabled multi-select choice to be selected", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.multiSelect({
+        message: "Pick items",
+        choices: [{ title: "Unavailable", value: "unavailable", disabled: true }]
+      })
+      yield* MockTerminal.inputKey("down")
+      yield* MockTerminal.inputKey("down")
+      yield* MockTerminal.inputKey("space")
+      yield* MockTerminal.inputKey("enter")
+
+      const value = yield* Prompt.run(prompt)
+
+      assert.deepStrictEqual(value, [])
+    }).pipe(Effect.provide(TestLayer)))
+
   it.effect("underlines the active label", () =>
     Effect.gen(function*() {
       const prompt = Prompt.multiSelect({

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -499,6 +499,61 @@ describe("Prompt.multiSelect", () => {
       assert.deepStrictEqual(value, [])
     }).pipe(Effect.provide(TestLayer)))
 
+  it.effect("does not select disabled choices when selecting all", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.multiSelect({
+        message: "Pick items",
+        choices: [
+          { title: "Available", value: "available" },
+          { title: "Unavailable", value: "unavailable", disabled: true }
+        ]
+      })
+      yield* MockTerminal.inputKey("space")
+      yield* MockTerminal.inputKey("enter")
+
+      const value = yield* Prompt.run(prompt)
+
+      assert.deepStrictEqual(value, ["available"])
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("does not select disabled choices when inverting the selection", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.multiSelect({
+        message: "Pick items",
+        choices: [
+          { title: "Available", value: "available" },
+          { title: "Unavailable", value: "unavailable", disabled: true }
+        ]
+      })
+      yield* MockTerminal.inputKey("down")
+      yield* MockTerminal.inputKey("space")
+      yield* MockTerminal.inputKey("enter")
+
+      const value = yield* Prompt.run(prompt)
+
+      assert.deepStrictEqual(value, ["available"])
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("ignores disabled preselected choices when validating and submitting", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.multiSelect({
+        message: "Pick items",
+        choices: [
+          { title: "Available", value: "available", selected: true },
+          { title: "Unavailable", value: "unavailable", disabled: true, selected: true }
+        ],
+        max: 1
+      })
+      yield* MockTerminal.inputKey("enter")
+
+      const value = yield* Prompt.run(prompt)
+
+      assert.deepStrictEqual(value, ["available"])
+      const output = yield* MockTerminal.displayLines
+      const initialFrame = findFrame(toFrames(output), "Unavailable")
+      assert.isTrue(initialFrame?.includes("☐ Unavailable"))
+    }).pipe(Effect.provide(TestLayer)))
+
   it.effect("underlines the active label", () =>
     Effect.gen(function*() {
       const prompt = Prompt.multiSelect({


### PR DESCRIPTION
## Summary

Exclude disabled choices from multi-select initialization, toggles, bulk operations, validation, and submission.

> [!IMPORTANT]
> This PR includes focused regression tests and the implementation fix.

## Multi-select submits disabled choices

**Module:** `cli/Prompt`  
**Audit ID:** `unstable-ai-cli-prompt-disabled-multiselect`  
**Severity / confidence:** medium / high

### What happens

Disabled choices can be toggled, bulk-selected, and returned by the multi-select prompt.

### Why it happens

Multi-select toggle, select-all, inverse, and submission paths never inspect the disabled property.

### Expected behavior

SelectChoice.disabled makes a choice unavailable throughout the select-family prompts.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/cli/Prompt.ts:2646-2676`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/Prompt.ts#L2646-L2676)
- [`packages/effect/src/unstable/cli/Prompt.ts:2691-2723`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/Prompt.ts#L2691-L2723)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/cli/Prompt.ts:2646-2676</code></summary>

```ts
const processSpace = <A>(
  state: MultiSelectState,
  options: SelectOptionsReq<A>
) => {
  const selectedIndices = new Set(state.selectedIndices)
  if (state.index === 0) {
    if (state.selectedIndices.size === options.choices.length) {
      selectedIndices.clear()
    } else {
      for (let i = 0; i < options.choices.length; i++) {
        selectedIndices.add(i)
      }
    }
  } else if (state.index === 1) {
    for (let i = 0; i < options.choices.length; i++) {
      if (state.selectedIndices.has(i)) {
        selectedIndices.delete(i)
      } else {
        selectedIndices.add(i)
      }
    }
  } else {
    const choiceIndex = state.index - metaOptionsCount
    if (selectedIndices.has(choiceIndex)) {
      selectedIndices.delete(choiceIndex)
    } else {
      selectedIndices.add(choiceIndex)
    }
  }
  return Effect.succeed(Action.NextFrame({ state: { ...state, selectedIndices } }))
}
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/Prompt.ts#L2646-L2676)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/cli/Prompt.ts:2691-2723</code></summary>

```ts
const handleMultiSelectProcess = <A>(options: SelectOptionsReq<A> & MultiSelectOptionsReq) => {
  return (input: Terminal.UserInput, state: MultiSelectState) => {
    const totalChoices = options.choices.length + metaOptionsCount
    switch (input.key.name) {
      case "k":
      case "up": {
        return processMultiSelectCursorUp({ ...state, error: Option.none() }, totalChoices)
      }
      case "j":
      case "down":
      case "tab": {
        return processMultiSelectCursorDown({ ...state, error: Option.none() }, totalChoices)
      }
      case "space": {
        return processSpace(state, options)
      }
      case "enter":
      case "return": {
        const selectedCount = state.selectedIndices.size
        if (options.min !== undefined && selectedCount < options.min) {
          return Effect.succeed(
            Action.NextFrame({ state: { ...state, error: Option.some(`At least ${options.min} are required`) } })
          )
        }
        if (options.max !== undefined && selectedCount > options.max) {
          return Effect.succeed(
            Action.NextFrame({ state: { ...state, error: Option.some(`At most ${options.max} choices are allowed`) } })
          )
        }
        const selectedValues = Array.from(state.selectedIndices).sort(EffectNumber.Order).map((index) =>
          options.choices[index].value
        )
        return Effect.succeed(Action.Submit({ value: selectedValues }))
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/Prompt.ts#L2691-L2723)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/cli/Prompt.test.ts
```

**Before the fix:** the prompt returned the disabled unavailable choice.

## Implementation

Disabled choices are omitted from initial selection, individual and bulk selection operations, validation counts, and submitted values.

## Validation

```sh
pnpm test --run --project effect
pnpm lint
pnpm check
```

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-ai-cli-prompt-disabled-multiselect`
- Initial patch: focused reproduction tests; implementation fix added in this PR

Closes EFF-409