### PR TITLE
Correct year, ordinal, and meridiem date-mask formatting

### DIFF
--- a/.changeset/tidy-dates-smile.md
+++ b/.changeset/tidy-dates-smile.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Correct year, ordinal, and meridiem date-mask formatting.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -1999,6 +1999,9 @@ class Day extends DatePart {
   }
 
   private ordinalIndicator(day: number): string {
+    if (day >= 11 && day <= 13) {
+      return "th"
+    }
     switch (day % 10) {
       case 1:
         return "st"
@@ -2057,7 +2060,7 @@ class Year extends DatePart {
   override toString() {
     const year = `${this.date.getFullYear()}`.padStart(4, "0")
     return this.token.length === 2
-      ? year.substring(-2)
+      ? year.slice(-2)
       : year
   }
 }
@@ -2074,7 +2077,7 @@ class Meridiem extends DatePart {
   setValue(_value: string): void {}
 
   override toString() {
-    const meridiem = this.date.getHours() > 12 ? "pm" : "am"
+    const meridiem = this.date.getHours() >= 12 ? "pm" : "am"
     return /A/.test(this.token)
       ? meridiem.toUpperCase()
       : meridiem

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Data, Effect, Fiber, FileSystem, Layer, Match, Path, Queue, Redacted } from "effect"
+import { Data, DateTime, Effect, Fiber, FileSystem, Layer, Match, Path, Queue, Redacted } from "effect"
 import { Prompt } from "effect/unstable/cli"
 import * as MockTerminal from "./services/MockTerminal.ts"
 
@@ -52,7 +52,7 @@ const findFrame = (frames: ReadonlyArray<string>, text: string) => frames.find((
 describe("Prompt.date", () => {
   it.effect("renders two-digit years, teen ordinals, and noon meridiem correctly", () =>
     Effect.gen(function*() {
-      const initial = new Date(2024, 0, 11, 12, 0, 0)
+      const initial = DateTime.toDateUtc(DateTime.makeUnsafe({ year: 2024, month: 1, day: 11, hour: 12 }))
       yield* MockTerminal.inputKey("enter")
 
       yield* Prompt.run(Prompt.date({ message: "When", initial, dateMask: "YY Do A" }))

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -49,6 +49,19 @@ const toRawFrames = (lines: ReadonlyArray<unknown>) =>
 
 const findFrame = (frames: ReadonlyArray<string>, text: string) => frames.find((frame) => frame.includes(text))
 
+describe("Prompt.date", () => {
+  it.effect("renders two-digit years, teen ordinals, and noon meridiem correctly", () =>
+    Effect.gen(function*() {
+      const initial = new Date(2024, 0, 11, 12, 0, 0)
+      yield* MockTerminal.inputKey("enter")
+
+      yield* Prompt.run(Prompt.date({ message: "When", initial, dateMask: "YY Do A" }))
+      const output = (yield* MockTerminal.displayLines).map(String).join("\n")
+
+      assert.include(output, "24 11th PM")
+    }).pipe(Effect.provide(TestLayer)))
+})
+
 describe("Prompt.integer", () => {
   it.effect("submits the default value", () =>
     Effect.gen(function*() {


### PR DESCRIPTION
## Summary

- render `YY` date-mask tokens as two-digit years
- use `th` for the 11th, 12th, and 13th
- label noon and later hours as PM
- keep the regression coverage in the existing `Prompt.test.ts` file
- add a patch changeset for `effect`

## Validation

- `pnpm test --run packages/effect/test/unstable/cli/Prompt.test.ts`
- `pnpm lint-fix`
- `pnpm check`

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Finding: `unstable-ai-cli-prompt-date-mask-rendering`

Closes EFF-410
