### PR TITLE
Correct the UnknownSubcommand runtime tag spelling

### DIFF
--- a/.changeset/calm-dragons-command.md
+++ b/.changeset/calm-dragons-command.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Correct the runtime tag spelling for `CliError.UnknownSubcommand`.

--- a/packages/effect/src/unstable/cli/CliError.ts
+++ b/packages/effect/src/unstable/cli/CliError.ts
@@ -425,7 +425,7 @@ export class InvalidValue extends Schema.TaggedErrorClass<InvalidValue>(
  *   suggestions: ["deploy", "destroy"]
  * })
  *
- * unknownSubcommandError._tag // => "UnknownSubcomand"
+ * unknownSubcommandError._tag // => "UnknownSubcommand"
  * unknownSubcommandError.subcommand // => "deplyo"
  * unknownSubcommandError.parent // => ["myapp"]
  *
@@ -440,7 +440,7 @@ export class InvalidValue extends Schema.TaggedErrorClass<InvalidValue>(
  *   })
  *
  * const parseError = await Effect.runPromise(Effect.flip(parseSubcommand("deplyo")))
- * parseError._tag // => "UnknownSubcomand"
+ * parseError._tag // => "UnknownSubcommand"
  * ```
  *
  * @category models
@@ -448,7 +448,7 @@ export class InvalidValue extends Schema.TaggedErrorClass<InvalidValue>(
  */
 export class UnknownSubcommand extends Schema.TaggedErrorClass<UnknownSubcommand>(
   `${TypeId}/UnknownSubcommand`
-)("UnknownSubcomand", {
+)("UnknownSubcommand", {
   subcommand: Schema.String,
   parent: Schema.optional(Schema.Array(Schema.String)),
   suggestions: Schema.Array(Schema.String)

--- a/packages/effect/test/unstable/cli/Errors.test.ts
+++ b/packages/effect/test/unstable/cli/Errors.test.ts
@@ -25,6 +25,15 @@ const TestLayer = Layer.mergeAll(
 )
 
 describe("Command errors", () => {
+  it("uses the UnknownSubcommand class name as its runtime tag", () => {
+    const error = new CliError.UnknownSubcommand({
+      subcommand: "deplyo",
+      suggestions: ["deploy"]
+    })
+
+    assert.strictEqual(error._tag as string, "UnknownSubcommand")
+  })
+
   describe("parse", () => {
     it.effect("fails with MissingOption when a required flag is absent", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Summary

- Correct the runtime `_tag` for `CliError.UnknownSubcommand`.
- Update the corresponding JSDoc examples.
- Keep the regression coverage in the main unstable CLI error test suite.
- Add a patch changeset for `effect`.

## Validation

- `pnpm test --run packages/effect/test/unstable/cli/Errors.test.ts`
- `pnpm doctest --run packages/effect/src/unstable/cli/CliError.ts`
- `pnpm test --run packages/effect/test/unstable/cli`
- `pnpm lint`
- `pnpm check`

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Finding: `unstable-ai-cli-clierror-unknown-subcommand-tag`

Closes EFF-411