### PR TITLE
Preserve fractional leading zeros while editing float prompts

### DIFF
--- a/.changeset/tidy-floats-edit.md
+++ b/.changeset/tidy-floats-edit.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve fractional leading zeros while editing float prompts.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -2875,7 +2875,11 @@ const defaultFloatProcessor = (input: string, state: NumberState) => {
     return Effect.succeed(Action.NextFrame({
       state: {
         ...state,
-        value: input === "." ? `${parsed}.` : `${parsed}`,
+        value: input === "."
+          ? `${parsed}.`
+          : state.value.includes(".") && /^\d$/.test(input)
+          ? state.value + input
+          : `${parsed}`,
         error: Option.none()
       }
     }))

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -85,6 +85,16 @@ describe("Prompt.integer", () => {
 })
 
 describe("Prompt.float", () => {
+  it.effect("preserves a leading zero in the fractional part", () =>
+    Effect.gen(function*() {
+      yield* MockTerminal.inputText("0.05")
+      yield* MockTerminal.inputKey("enter")
+
+      const value = yield* Prompt.run(Prompt.float({ message: "Rate" }))
+
+      assert.strictEqual(value, 0.05)
+    }).pipe(Effect.provide(TestLayer)))
+
   it.effect("renders appended input without literal parsed", () =>
     Effect.gen(function*() {
       const prompt = Prompt.float({ message: "Rate" })


### PR DESCRIPTION
## Summary

Typing a fractional value such as 0.05 mutates the edit buffer and submits 5 instead.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Float entry drops fractional leading zeros

**Module:** `cli/Prompt`  
**Audit ID:** `unstable-ai-cli-prompt-float-leading-zero`  
**Severity / confidence:** medium / high

### What happens

Typing a fractional value such as 0.05 mutates the edit buffer and submits 5 instead.

### Why it happens

Each keystroke is parsed and serialized; entering 0.0 is normalized back to 0 before the following digit is appended.

### Expected behavior

The float prompt accepts floating-point input before applying configured rounding and validation.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/cli/Prompt.ts:2861-2883`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/Prompt.ts#L2861-L2883)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/cli/Prompt.ts:2861-2883</code></summary>

```ts
const defaultFloatProcessor = (input: string, state: NumberState) => {
  if (input === "." && state.value.includes(".")) {
    return Effect.succeed(Action.Beep())
  }
  if (state.value.length === 0 && input === "-") {
    return Effect.succeed(Action.NextFrame({
      state: { ...state, value: "-", error: Option.none() }
    }))
  }

  const parsed = Number.parseFloat(state.value + input)
  if (Number.isNaN(parsed)) {
    return Effect.succeed(Action.Beep())
  } else {
    return Effect.succeed(Action.NextFrame({
      state: {
        ...state,
        value: input === "." ? `${parsed}.` : `${parsed}`,
        error: Option.none()
      }
    }))
  }
}
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cli/Prompt.ts#L2861-L2883)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/cli/PromptFloatZero.audit.test.ts
```

**Observed failure:** FAIL: 0.05 was submitted as 5.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/cli/PromptFloatZero.audit.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-ai-cli-prompt-float-leading-zero`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-412