### PR TITLE
Reduce Equal module bundle size

### DIFF
--- a/.changeset/tall-emus-invent.md
+++ b/.changeset/tall-emus-invent.md
@@ -1,0 +1,16 @@
+---
+"effect": patch
+---
+
+Reduce the bundle size of the `Equal` module.
+
+`Equal.equals` no longer computes `Hash.hash` as a fast-path rejection before
+comparing objects, making the `Hash` module import type-only. Structural
+comparison already short-circuits on the first mismatch, and inside
+hash-bucketed collections the hashes are always equal by the time `Equal.equals`
+runs, so the pre-check mostly added overhead. `Equal.isEqual` also checks the
+symbol directly instead of going through `Predicate.hasProperty`, removing the
+`Predicate` and `Function` modules from the dependency graph.
+
+A bundle containing only `Equal.equals` shrinks from 4752 to 2651 bytes
+minified (1886 to 1058 bytes gzipped).

--- a/packages/effect/src/Equal.ts
+++ b/packages/effect/src/Equal.ts
@@ -10,9 +10,8 @@
  * @since 2.0.0
  */
 import type { Equivalence } from "./Equivalence.ts"
-import * as Hash from "./Hash.ts"
+import type * as Hash from "./Hash.ts"
 import { byReferenceInstances, getAllObjectKeys } from "./internal/equal.ts"
-import { hasProperty } from "./Predicate.ts"
 
 /**
  * Defines the unique string identifier for the `Equal` interface.
@@ -130,9 +129,8 @@ export interface Equal extends Hash.Hash {
  * Functions without an `Equal` implementation compare by reference. Circular
  * references are handled when both structures are circular at the same depth.
  *
- * Hash values are checked first as a fast-path rejection. The function also
- * supports dual data-last usage: call it with one argument to get a curried
- * predicate.
+ * The function also supports dual data-last usage: call it with one argument
+ * to get a curried predicate.
  *
  * **Gotchas**
  *
@@ -229,9 +227,7 @@ const visitedRight = new WeakSet<object>()
 
 /** Helper to perform cached object comparison */
 function compareObjects(self: object, that: object): boolean {
-  if (Hash.hash(self) !== Hash.hash(that)) {
-    return false
-  } else if (self instanceof Date) {
+  if (self instanceof Date) {
     if (!(that instanceof Date)) return false
     const selfTime = self.getTime()
     const thatTime = that.getTime()
@@ -441,7 +437,8 @@ const compareSets = makeCompareSet(compareBoth)
  * @category guards
  * @since 2.0.0
  */
-export const isEqual = (u: unknown): u is Equal => hasProperty(u, symbol)
+export const isEqual = (u: unknown): u is Equal =>
+  ((typeof u === "object" && u !== null) || typeof u === "function") && symbol in u
 
 /**
  * Wraps {@link equals} as an `Equivalence<A>`.


### PR DESCRIPTION
Closes EFF-378

## Summary

Reduces the bundle size of the `Equal` module by removing its runtime dependencies on the `Hash`, `Predicate`, and `Function` modules.

A bundle containing only `Equal.equals` (rollup + esbuild + terser + gzip, same pipeline as the bundle tooling) shrinks by **44%**:

|  | minified | gzipped |
|---|---:|---:|
| before | 4752 B | 1886 B |
| after | 2651 B | 1058 B |

The bundle now contains only `Equal.ts` and `internal/equal.ts`.

## Changes

- `compareObjects` no longer computes `Hash.hash` for both operands as a fast-path rejection, making the `Hash` import type-only. The pre-check was soundness-neutral (it only rejects early under the Equal/Hash contract) and mostly redundant:
  - Structural comparison already short-circuits on the first mismatch, while the hash pre-check walks both structures completely.
  - Inside hash-bucketed collections (`HashMap`, `HashSet`, ...) the hashes are already equal by the time `Equal.equals` runs, so the pre-check was pure overhead there.
  - Repeated comparisons of the same pair are already served by the existing `WeakMap` result cache.
- `isEqual` checks the `Equal` symbol directly instead of going through `Predicate.hasProperty`, which dropped `Predicate` and `Function` (via `dual`) from the dependency graph.

## Notes

The fixture comparison (`pnpm bundle-compare`) shows ±0.05 KB shifts on the full-app fixtures. That is gzip noise from module reordering: with the runtime `Hash` import gone, rollup emits `Hash`/`Function` at a different position in the chunk. The actual minified content delta on `basic.ts` is +8 bytes (the inlined `isEqual` predicate).

## Validation

- `pnpm vitest run` for `Equal`, `Predicate`, `Data`, `HashMap`, `HashSet`, `MutableHashMap`, `MutableHashSet` (313 tests pass)
- `pnpm doctest --run packages/effect/src/Equal.ts`
- `pnpm check`
- `pnpm lint-fix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
