### PR TITLE
Allow MCP tool calls to omit optional arguments

### DIFF
--- a/.changeset/fix-mcp-call-tool-arguments.md
+++ b/.changeset/fix-mcp-call-tool-arguments.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Allow MCP tool calls to omit optional arguments.

--- a/packages/effect/src/unstable/ai/McpSchema.ts
+++ b/packages/effect/src/unstable/ai/McpSchema.ts
@@ -1562,9 +1562,12 @@ export class CallTool extends Rpc.make("tools/call", {
   payload: {
     ...RequestMeta.fields,
     name: Schema.String,
-    arguments: Schema.Record(
-      Schema.String,
-      Schema.Any
+    arguments: optionalWithDefault(
+      Schema.Record(
+        Schema.String,
+        Schema.Any
+      ),
+      () => ({})
     )
   }
 }) {}

--- a/packages/effect/test/unstable/ai/McpServer/v2025_06_18.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/v2025_06_18.test.ts
@@ -20,6 +20,9 @@ import * as UtilitiesTest from "./McpConformance/UtilitiesTest.ts"
 it("accepts tools/call without optional arguments", () => {
   const decoded = Schema.decodeUnknownExit(McpSchema.CallTool.payloadSchema)({ name: "ping" })
   assert.strictEqual(decoded._tag, "Success")
+  if (decoded._tag === "Success") {
+    assert.deepStrictEqual(decoded.value.arguments, {})
+  }
 })
 
 const protocol = McpProtocol.v2025_06_18

--- a/packages/effect/test/unstable/ai/McpServer/v2025_06_18.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/v2025_06_18.test.ts
@@ -1,6 +1,8 @@
 import { assert, describe, it } from "@effect/vitest"
 import * as Effect from "effect/Effect"
+import * as Schema from "effect/Schema"
 import * as McpProtocol from "effect/unstable/ai/McpProtocol"
+import * as McpSchema from "effect/unstable/ai/McpSchema"
 import * as BaseProtocolTest from "./McpConformance/BaseProtocolTest.ts"
 import * as CompletionTest from "./McpConformance/CompletionTest.ts"
 import * as ElicitationTest from "./McpConformance/ElicitationTest.ts"
@@ -14,6 +16,11 @@ import * as SamplingTest from "./McpConformance/SamplingTest.ts"
 import * as ToolsTest from "./McpConformance/ToolsTest.ts"
 import * as TransportsTest from "./McpConformance/TransportsTest.ts"
 import * as UtilitiesTest from "./McpConformance/UtilitiesTest.ts"
+
+it("accepts tools/call without optional arguments", () => {
+  const decoded = Schema.decodeUnknownExit(McpSchema.CallTool.payloadSchema)({ name: "ping" })
+  assert.strictEqual(decoded._tag, "Success")
+})
 
 const protocol = McpProtocol.v2025_06_18
 const testLayer = makeMcpConformanceLayer(protocol)


### PR DESCRIPTION
## Summary

Decoding a valid tools/call payload that contains a tool name but omits optional arguments fails before a no-parameter tool can run.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## No-argument MCP tool calls are rejected

**Module:** `ai/McpSchema`  
**Audit ID:** `unstable-ai-cli-mcp-call-tool-optional-arguments`  
**Severity / confidence:** medium / high

### What happens

Decoding a valid tools/call payload that contains a tool name but omits optional arguments fails before a no-parameter tool can run.

### Why it happens

The CallTool payload declares arguments as a required record instead of an optional field.

### Expected behavior

MCP tools/call makes arguments optional, so a no-parameter tool may be invoked with only its name.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/ai/McpSchema.ts:1559-1569`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/ai/McpSchema.ts#L1559-L1569)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/ai/McpSchema.ts:1559-1569</code></summary>

```ts
export class CallTool extends Rpc.make("tools/call", {
  success: CallToolResult,
  error: McpError,
  payload: {
    ...RequestMeta.fields,
    name: Schema.String,
    arguments: Schema.Record(
      Schema.String,
      Schema.Any
    )
  }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/ai/McpSchema.ts#L1559-L1569)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/ai/McpServer/v2025_06_18.test.ts
```

**Observed failure:** Decoding a call-tool request without arguments failed instead of succeeding.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/ai/McpServer/v2025_06_18.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `8f9499f562729f5f7b08d8bcc4db86b4aeff8a21`
- Findings: `unstable-ai-cli-mcp-call-tool-optional-arguments`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-413
