### PR TITLE
Fix Changesets v3 release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,11 @@ jobs:
         run: |
           sed -i 's/"stripInternal": false/"stripInternal": true/' tsconfig.base.json
       - name: Create Release Pull Request or Publish
-        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
+        uses: changesets/action@d0ee272882939fa35f22d979828acb7e61e0bd47 # v2.0.0-next.4
         with:
-          version: pnpm changeset-version
-          publish: pnpm changeset-publish
-        env:
+          version-script: pnpm changeset-version
+          publish-script: pnpm changeset-publish
           # Use a personal access token instead of the one that GitHub generates
           # automatically to ensure workflows get triggered on the changesets
           # release branch.
-          GITHUB_TOKEN: ${{ secrets.CHANGESET_GITHUB_TOKEN }}
+          github-token: ${{ secrets.CHANGESET_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- upgrade the release workflow to `changesets/action@v2.0.0-next.4`
- migrate the renamed v2 script and token inputs
- retain the Changesets v3 prerelease layout under `.changeset/pre/`

## Context

The v1 action treated `.changeset/pre` as a legacy directory changeset and attempted to read `.changeset/pre/changes.md`, causing the release workflow to fail with `ENOENT`. The v2 action ignores non-Markdown entries while the repository CLI handles the archived prerelease changesets.

Failed run: https://github.com/Effect-TS/effect/actions/runs/30904274325/job/91975565666

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm changeset status`
- `pnpm lint-fix`
- `pnpm check`
- `git diff --check`