### PR TITLE
Disable Changesets changelog formatting

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,6 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@4.0.0-next.8/schema.json",
   "changelog": ["@changesets/changelog-github", { "repo": "Effect-TS/effect" }],
   "commit": false,
+  "format": false,
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",


### PR DESCRIPTION
## Summary

- disable Changesets v3 automatic changelog formatting
- preserve the existing dprint policy that excludes `packages/**/CHANGELOG.md`

## Context

Changesets v3 auto-detects dprint and invokes it with generated changelog files. Those files are explicitly excluded by `dprint.json`, so dprint finds no eligible files and exits with status 14. Setting `format` to `false` prevents that incompatible formatter invocation.

Failed run: https://github.com/Effect-TS/effect/actions/runs/30905627333/job/91979914805

## Verification

- `pnpm changeset status`
- `pnpm lint-fix`
- `git diff --check`
- reproduced dprint exit code 14 against `packages/effect/CHANGELOG.md`