### PR TITLE
Serialize concurrent nested SQL transactions

### DIFF
--- a/.changeset/quiet-savepoints-wait.md
+++ b/.changeset/quiet-savepoints-wait.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Serialize concurrent nested SQL transactions to prevent savepoint collisions.

--- a/.changeset/quiet-savepoints-wait.md
+++ b/.changeset/quiet-savepoints-wait.md
@@ -2,4 +2,5 @@
 "effect": patch
 ---
 
-Serialize concurrent nested SQL transactions to prevent savepoint collisions.
+Serialize concurrent nested SQL transactions to prevent savepoint collisions. Cross-dependent sibling nested
+transactions now deadlock instead of interleaving and risking silent data corruption.

--- a/packages/effect/src/unstable/sql/SqlClient.ts
+++ b/packages/effect/src/unstable/sql/SqlClient.ts
@@ -16,6 +16,7 @@ import * as Option from "../../Option.ts"
 import type * as Queue from "../../Queue.ts"
 import type { ReadonlyRecord } from "../../Record.ts"
 import * as Scope from "../../Scope.ts"
+import * as Semaphore from "../../Semaphore.ts"
 import * as Stream from "../../Stream.ts"
 import * as Tracer from "../../Tracer.ts"
 import type { NoInfer } from "../../Types.ts"
@@ -126,6 +127,7 @@ export declare namespace SqlClient {
 }
 
 let clientIdCounter = 0
+let transactionSemaphoreIdCounter = 0
 
 /**
  * Constructs a `SqlClient` from connection acquirers, a compiler, transaction
@@ -227,66 +229,73 @@ export const makeWithTransaction = <I, S>(options: {
   readonly commit: (conn: NoInfer<S>) => Effect.Effect<void, SqlError>
   readonly rollback: (conn: NoInfer<S>) => Effect.Effect<void, SqlError>
   readonly rollbackSavepoint: (conn: NoInfer<S>, id: number) => Effect.Effect<void, SqlError>
-}) =>
-<R, E, A>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E | SqlError, R> => {
-  return Effect.uninterruptibleMask((restore) =>
-    Effect.useSpan(
-      "sql.transaction",
-      { kind: "client" },
-      (span) =>
-        Effect.withFiber<A, E | SqlError, R>((fiber) => {
-          for (const [key, value] of options.spanAttributes) {
-            span.attribute(key, value)
-          }
-          const services = fiber.context
-          const clock = fiber.getRef(Clock)
-          const connOption = Context.getOption(services, options.transactionService)
-          const conn = connOption._tag === "Some"
-            ? Effect.succeed([undefined, connOption.value[0]] as const)
-            : options.acquireConnection
-          const id = connOption._tag === "Some" ? connOption.value[1] + 1 : 0
-          return Effect.flatMap(
-            conn,
-            (
-              [scope, conn]
-            ) =>
-              (id === 0 ? options.begin(conn) : options.savepoint(conn, id)).pipe(
-                Effect.flatMap(() =>
-                  Effect.provideContext(
-                    restore(effect),
-                    services.pipe(
-                      Context.add(options.transactionService, [conn, id]),
-                      Context.add(Tracer.ParentSpan, span)
-                    )
-                  )
-                ),
-                Effect.exit,
-                Effect.flatMap((exit) => {
-                  let effect: Effect.Effect<void>
-                  if (Exit.isSuccess(exit)) {
-                    if (id === 0) {
-                      span.event("db.transaction.commit", clock.currentTimeNanosUnsafe())
-                      effect = Effect.orDie(options.commit(conn))
-                    } else {
-                      span.event("db.transaction.savepoint", clock.currentTimeNanosUnsafe())
-                      effect = Effect.void
-                    }
-                  } else {
-                    span.event("db.transaction.rollback", clock.currentTimeNanosUnsafe())
-                    effect = Effect.orDie(
-                      id > 0
-                        ? options.rollbackSavepoint(conn, id)
-                        : options.rollback(conn)
-                    )
-                  }
-                  const withScope = scope !== undefined ? Effect.ensuring(effect, Scope.close(scope, exit)) : effect
-                  return Effect.flatMap(withScope, () => exit)
-                })
-              )
-          )
-        })
-    )
+}) => {
+  const transactionSemaphore = Context.Service<Semaphore.Semaphore>(
+    `effect/sql/SqlClient/TransactionSemaphore/${transactionSemaphoreIdCounter++}`
   )
+  return <R, E, A>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E | SqlError, R> =>
+    Effect.uninterruptibleMask((restore) =>
+      Effect.useSpan(
+        "sql.transaction",
+        { kind: "client" },
+        (span) =>
+          Effect.withFiber<A, E | SqlError, R>((fiber) => {
+            for (const [key, value] of options.spanAttributes) {
+              span.attribute(key, value)
+            }
+            const services = fiber.context
+            const clock = fiber.getRef(Clock)
+            const connOption = Context.getOption(services, options.transactionService)
+            const conn = connOption._tag === "Some"
+              ? Effect.succeed([undefined, connOption.value[0]] as const)
+              : options.acquireConnection
+            const id = connOption._tag === "Some" ? connOption.value[1] + 1 : 0
+            const transaction = Effect.flatMap(
+              conn,
+              (
+                [scope, conn]
+              ) =>
+                (id === 0 ? options.begin(conn) : options.savepoint(conn, id)).pipe(
+                  Effect.flatMap(() =>
+                    Effect.provideContext(
+                      restore(effect),
+                      services.pipe(
+                        Context.add(options.transactionService, [conn, id]),
+                        Context.add(transactionSemaphore, Semaphore.makeUnsafe(1)),
+                        Context.add(Tracer.ParentSpan, span)
+                      )
+                    )
+                  ),
+                  Effect.exit,
+                  Effect.flatMap((exit) => {
+                    let effect: Effect.Effect<void>
+                    if (Exit.isSuccess(exit)) {
+                      if (id === 0) {
+                        span.event("db.transaction.commit", clock.currentTimeNanosUnsafe())
+                        effect = Effect.orDie(options.commit(conn))
+                      } else {
+                        span.event("db.transaction.savepoint", clock.currentTimeNanosUnsafe())
+                        effect = Effect.void
+                      }
+                    } else {
+                      span.event("db.transaction.rollback", clock.currentTimeNanosUnsafe())
+                      effect = Effect.orDie(
+                        id > 0
+                          ? options.rollbackSavepoint(conn, id)
+                          : options.rollback(conn)
+                      )
+                    }
+                    const withScope = scope !== undefined ? Effect.ensuring(effect, Scope.close(scope, exit)) : effect
+                    return Effect.flatMap(withScope, () => exit)
+                  })
+                )
+            )
+            return id === 0
+              ? transaction
+              : Context.getUnsafe(services, transactionSemaphore).withPermit(transaction)
+          })
+      )
+    )
 }
 
 /**

--- a/packages/sql/pg/test/Client.integration.test.ts
+++ b/packages/sql/pg/test/Client.integration.test.ts
@@ -1,6 +1,6 @@
 import { PgClient } from "@effect/sql-pg"
 import { assert, expect, it } from "@effect/vitest"
-import { Effect, Fiber, Redacted, Stream, String } from "effect"
+import { Deferred, Effect, Fiber, Redacted, Stream, String } from "effect"
 import { TestClock } from "effect/testing"
 import { SqlClient } from "effect/unstable/sql"
 import * as Statement from "effect/unstable/sql/Statement"
@@ -250,6 +250,39 @@ it.layer(PgContainer.layerClient, { timeout: "30 seconds" })("PgClient", (it) =>
         { "generate_series": 3 }
       ])
     }))
+
+  it.effect("preserves successful concurrent nested transactions", () =>
+    Effect.gen(function*() {
+      const sql = yield* PgClient.PgClient
+      const firstStarted = yield* Deferred.make<void>()
+      const firstInserted = yield* Deferred.make<void>()
+
+      const rows = yield* sql.withTransaction(
+        Effect.gen(function*() {
+          yield* sql`CREATE TEMP TABLE nested_transactions (value TEXT) ON COMMIT DROP`
+          yield* Effect.all([
+            sql.withTransaction(
+              Effect.gen(function*() {
+                yield* Deferred.succeed(firstStarted, undefined)
+                yield* Effect.sleep("100 millis")
+                yield* sql`INSERT INTO nested_transactions VALUES ('first')`
+                yield* Deferred.succeed(firstInserted, undefined)
+              })
+            ),
+            Deferred.await(firstStarted).pipe(
+              Effect.andThen(sql.withTransaction(
+                Deferred.await(firstInserted).pipe(
+                  Effect.andThen(Effect.fail("rollback"))
+                )
+              ))
+            )
+          ], { concurrency: "unbounded" }).pipe(Effect.catch(() => Effect.void))
+          return yield* sql<{ value: string }>`SELECT value FROM nested_transactions`
+        })
+      )
+
+      assert.deepStrictEqual(rows, [{ value: "first" }])
+    }).pipe(TestClock.withLive))
 })
 
 it.layer(PgContainer.layerMakeClient, { timeout: "30 seconds" })("PgClient.makeClient", (it) => {

--- a/packages/sql/pglite/test/Transaction.test.ts
+++ b/packages/sql/pglite/test/Transaction.test.ts
@@ -1,6 +1,7 @@
 import { PgliteClient } from "@effect/sql-pglite"
 import { assert, describe, layer } from "@effect/vitest"
-import { Effect } from "effect"
+import { Deferred, Effect } from "effect"
+import { TestClock } from "effect/testing"
 
 const ClientLayer = PgliteClient.layer({})
 
@@ -58,5 +59,35 @@ describe("PgliteClient transactions", () => {
         )
         assert.strictEqual(rows.at(0)?.total, 1)
       }))
+
+    it.effect("preserves successful concurrent nested transactions", () =>
+      Effect.gen(function*() {
+        const sql = yield* setup("tx_nested_concurrent")
+        const firstStarted = yield* Deferred.make<void>()
+        const firstInserted = yield* Deferred.make<void>()
+
+        yield* sql.withTransaction(
+          Effect.all([
+            sql.withTransaction(
+              Effect.gen(function*() {
+                yield* Deferred.succeed(firstStarted, undefined)
+                yield* Effect.sleep("100 millis")
+                yield* sql.unsafe(`INSERT INTO tx_nested_concurrent (name) VALUES ('first')`)
+                yield* Deferred.succeed(firstInserted, undefined)
+              })
+            ),
+            Deferred.await(firstStarted).pipe(
+              Effect.andThen(sql.withTransaction(
+                Deferred.await(firstInserted).pipe(
+                  Effect.andThen(Effect.fail("rollback"))
+                )
+              ))
+            )
+          ], { concurrency: "unbounded" }).pipe(Effect.catch(() => Effect.void))
+        )
+
+        const rows = yield* sql.unsafe<{ name: string }>(`SELECT name FROM tx_nested_concurrent`)
+        assert.deepStrictEqual(rows, [{ name: "first" }])
+      }).pipe(TestClock.withLive))
   })
 })


### PR DESCRIPTION
## Summary

- serialize sibling nested transactions at each transaction depth
- prevent same-name PostgreSQL savepoints from overlapping and rolling back successful sibling work
- add a deterministic SQL-PG integration regression test and a patch changeset

## Root cause

Concurrent nested transactions inherited the same connection and transaction depth, so sibling fibers emitted the same savepoint name. A failing sibling could then roll back writes performed by a sibling that had already succeeded.

## Validation

- `EFFECT_INTEGRATION_TESTS=1 nix develop -c pnpm test --run packages/sql/pg/test/Client.integration.test.ts` (25 passed)
- `nix develop -c pnpm test --run packages/sql/pglite/test/Transaction.test.ts` (4 passed)
- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`

Closes EFF-380
Closes #6935