### PR TITLE
Fix persisted cluster reply serialization hangs

### DIFF
--- a/.changeset/fix-persisted-cluster-reply-hang.md
+++ b/.changeset/fix-persisted-cluster-reply-hang.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Persist a serializable defect when a cluster reply cannot be encoded, preventing persisted entity callers from hanging.

--- a/packages/effect/src/unstable/cluster/MessageStorage.ts
+++ b/packages/effect/src/unstable/cluster/MessageStorage.ts
@@ -567,6 +567,18 @@ export const makeEncoded: (encoded: Encoded) => Effect.Effect<
   const snowflakeGen = yield* Snowflake.Generator
   const clock = yield* Clock
 
+  const serializeReply = <R extends Rpc.Any>(reply: Reply.ReplyWithContext<R>) =>
+    Effect.catchTag(
+      Reply.serialize(reply),
+      "MalformedMessage",
+      (error) =>
+        Effect.orDie(Reply.serialize(Reply.ReplyWithContext.fromDefect({
+          id: reply.reply.id,
+          requestId: reply.reply.requestId,
+          defect: error
+        })))
+    )
+
   const storage: MessageStorage["Service"] = yield* make({
     saveRequest: (message) =>
       Message.serializeEnvelope(message).pipe(
@@ -606,11 +618,7 @@ export const makeEncoded: (encoded: Encoded) => Effect.Effect<
         ),
         Effect.asVoid
       ),
-    saveReply: (reply) =>
-      Effect.flatMap(
-        Reply.serialize(reply),
-        encoded.saveReply
-      ),
+    saveReply: (reply) => Effect.flatMap(serializeReply(reply), encoded.saveReply),
     clearReplies: encoded.clearReplies,
     repliesFor: Effect.fnUntraced(function*(messages) {
       const requestIds = Arr.empty<string>()

--- a/packages/effect/src/unstable/cluster/MessageStorage.ts
+++ b/packages/effect/src/unstable/cluster/MessageStorage.ts
@@ -567,18 +567,6 @@ export const makeEncoded: (encoded: Encoded) => Effect.Effect<
   const snowflakeGen = yield* Snowflake.Generator
   const clock = yield* Clock
 
-  const serializeReply = <R extends Rpc.Any>(reply: Reply.ReplyWithContext<R>) =>
-    Effect.catchTag(
-      Reply.serialize(reply),
-      "MalformedMessage",
-      (error) =>
-        Effect.orDie(Reply.serialize(Reply.ReplyWithContext.fromDefect({
-          id: reply.reply.id,
-          requestId: reply.reply.requestId,
-          defect: error
-        })))
-    )
-
   const storage: MessageStorage["Service"] = yield* make({
     saveRequest: (message) =>
       Message.serializeEnvelope(message).pipe(
@@ -618,7 +606,7 @@ export const makeEncoded: (encoded: Encoded) => Effect.Effect<
         ),
         Effect.asVoid
       ),
-    saveReply: (reply) => Effect.flatMap(serializeReply(reply), encoded.saveReply),
+    saveReply: (reply) => Effect.flatMap(Reply.serializeOrDefect(reply), encoded.saveReply),
     clearReplies: encoded.clearReplies,
     repliesFor: Effect.fnUntraced(function*(messages) {
       const requestIds = Arr.empty<string>()

--- a/packages/effect/src/unstable/cluster/Reply.ts
+++ b/packages/effect/src/unstable/cluster/Reply.ts
@@ -434,6 +434,27 @@ export const serialize = <R extends Rpc.Any>(
 }
 
 /**
+ * Serializes a `ReplyWithContext`, falling back to a serializable defect reply
+ * when the original reply cannot be encoded.
+ *
+ * @category serialization
+ * @since 4.0.0
+ */
+export const serializeOrDefect = <R extends Rpc.Any>(
+  self: ReplyWithContext<R>
+): Effect.Effect<Encoded> =>
+  Effect.catchTag(
+    serialize(self),
+    "MalformedMessage",
+    (error) =>
+      Effect.orDie(serialize(ReplyWithContext.fromDefect({
+        id: self.reply.id,
+        requestId: self.reply.requestId,
+        defect: error
+      })))
+  )
+
+/**
  * Serializes an outgoing request's last received reply when one exists, returning
  * `None` when no reply has been received and refailing encoding errors as
  * `MalformedMessage`.

--- a/packages/effect/src/unstable/cluster/RunnerServer.ts
+++ b/packages/effect/src/unstable/cluster/RunnerServer.ts
@@ -42,15 +42,6 @@ const serializeDefectReply = <R extends Rpc.Any>(
     defect
   })))
 
-const serializeReply = <R extends Rpc.Any>(
-  reply: Reply.ReplyWithContext<R>
-): Effect.Effect<Reply.Encoded> =>
-  Effect.catchTag(
-    Reply.serialize(reply),
-    "MalformedMessage",
-    (error) => serializeDefectReply(reply, error)
-  )
-
 /**
  * Layer that handles runner protocol RPCs by forwarding requests to `Sharding`
  * and `MessageStorage`.
@@ -84,7 +75,7 @@ export const layerHandlers = Runners.Rpcs.toLayer(Effect.gen(function*() {
         envelope: request,
         lastSentReply: Option.none(),
         respond(reply) {
-          resume(serializeReply(reply))
+          resume(Reply.serializeOrDefect(reply))
           return Effect.void
         }
       })

--- a/packages/effect/test/cluster/Sharding.test.ts
+++ b/packages/effect/test/cluster/Sharding.test.ts
@@ -64,6 +64,22 @@ describe.concurrent("Sharding", () => {
       expect(driver.unprocessed.size).toEqual(0)
     }).pipe(Effect.provide(TestSharding)))
 
+  it.live("defects instead of hanging when persisted failures contain non-JSON Error values", () =>
+    Effect.gen(function*() {
+      const driver = yield* MessageStorage.MemoryDriver
+      const makeClient = yield* TestEntity.client
+      const client = makeClient("1")
+      const cause = yield* client.Fail().pipe(
+        Effect.timeout("2 seconds"),
+        Effect.sandbox,
+        Effect.flip
+      )
+      assert(Cause.hasDies(cause))
+      assert.include(Cause.pretty(cause), "MalformedMessage")
+      assert.strictEqual(driver.replyIds.size, 1)
+      assert.strictEqual(driver.unprocessed.size, 0)
+    }).pipe(Effect.provide(TestSharding)))
+
   it.effect("routes durable interrupts through storage", () =>
     Effect.gen(function*() {
       const driver = yield* MessageStorage.MemoryDriver

--- a/packages/effect/test/cluster/TestEntity.ts
+++ b/packages/effect/test/cluster/TestEntity.ts
@@ -10,6 +10,10 @@ export class User extends Schema.Class<User>("User")({
   name: Schema.String
 }) {}
 
+export class BoomError extends Schema.TaggedError<BoomError>()("BoomError", {
+  cause: Schema.Unknown
+}) {}
+
 export class StreamWithKey extends Rpc.make("StreamWithKey", {
   success: RpcSchema.Stream(Schema.Number, Schema.Never),
   payload: { key: Schema.String },
@@ -26,6 +30,7 @@ export const TestEntity = Entity.make("TestEntity", [
     payload: { id: Schema.Number }
   }).annotate(ClusterSchema.Persisted, false),
   Rpc.make("Never"),
+  Rpc.make("Fail", { error: BoomError }),
   Rpc.make("NeverFork"),
   Rpc.make("NeverVolatile").annotate(ClusterSchema.Persisted, false),
   Rpc.make("RequestWithKey", {
@@ -105,6 +110,7 @@ export const TestEntityNoState = TestEntity.toLayer(
           return new User({ id: envelope.payload.id, name: `User ${envelope.payload.id}` })
         }),
       Never: never,
+      Fail: () => Effect.fail(new BoomError({ cause: new Error("boom") })),
       NeverFork: (envelope) => Rpc.fork(never(envelope)),
       NeverVolatile: never,
       RequestWithKey: (envelope) => {


### PR DESCRIPTION
## Summary

- persist a serializable defect reply when a cluster reply cannot be encoded
- add an in-memory regression test through the real `Entity.client` → sharding → message-storage path
- verify the persisted request is completed and the caller receives `MalformedMessage` instead of hanging

## Root cause

`Reply.serialize` correctly rejects an `Error` stored inside `Schema.Unknown` because persisted replies use strict JSON encoding. The resulting `MalformedMessage` was retried and converted to a defect in the entity response fiber, but no terminal reply was stored, leaving the caller waiting indefinitely.

The reported `Effect.orDie` omission is not present on current `main`: the Exit response pipeline already ends with `Effect.orDie`, and the sibling Chunk, keep-alive, and malformed-input response sites are also guarded. The fix therefore follows the existing `RunnerServer` behavior for unserializable replies by persisting a serializable defect fallback at the encoded storage boundary.

## Validation

- `pnpm test --run packages/effect/test/cluster/Sharding.test.ts`
- `pnpm test --run packages/effect/test/cluster/MessageStorage.test.ts`
- `pnpm test --run packages/effect/test/cluster/Runners.test.ts`
- `pnpm lint-fix`
- `pnpm check`

Closes EFF-379
Closes #6932