### PR TITLE
Separate the default variant cache key from named variants

### DIFF
--- a/.changeset/fix-variant-schema-default-cache.md
+++ b/.changeset/fix-variant-schema-default-cache.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Separate the default `VariantSchema` cache from named variant entries.

--- a/packages/effect/src/unstable/schema/VariantSchema.ts
+++ b/packages/effect/src/unstable/schema/VariantSchema.ts
@@ -26,6 +26,7 @@ import * as Struct_ from "../../Struct.ts"
 export const TypeId = "~effect/schema/VariantSchema"
 
 const cacheSymbol = Symbol.for(`${TypeId}/cache`)
+const defaultCacheSymbol = Symbol.for(`${TypeId}/defaultCache`)
 
 /**
  * Pipeable container of schema fields that can be extracted into per-variant
@@ -38,6 +39,8 @@ export interface Struct<in out A extends Field.Fields> extends Pipeable {
   readonly [TypeId]: A
   /** @internal */
   [cacheSymbol]?: Record<string, Schema.Top>
+  /** @internal */
+  [defaultCacheSymbol]?: Record<string, Schema.Top>
 }
 
 /**
@@ -214,10 +217,11 @@ const extract: {
       readonly isDefault?: boolean | undefined
     }
   ): Extract<V, A> => {
-    const cache = self[cacheSymbol] ?? (self[cacheSymbol] = Object.create(null))
-    const cacheKey = options?.isDefault === true ? "__default" : variant
-    if (Object.hasOwn(cache, cacheKey)) {
-      return cache[cacheKey] as any
+    const cache = options?.isDefault === true
+      ? self[defaultCacheSymbol] ?? (self[defaultCacheSymbol] = Object.create(null))
+      : self[cacheSymbol] ?? (self[cacheSymbol] = Object.create(null))
+    if (Object.hasOwn(cache, variant)) {
+      return cache[variant] as any
     }
     const fields: Record<string, any> = {}
     for (const key of Object.keys(self[TypeId])) {
@@ -243,7 +247,7 @@ const extract: {
       }
     }
     const schema = Schema.Struct(fields)
-    cache[cacheKey] = schema
+    cache[variant] = schema
     return schema as any
   }
 )

--- a/packages/effect/test/unstable/schema/VariantSchema.test.ts
+++ b/packages/effect/test/unstable/schema/VariantSchema.test.ts
@@ -65,13 +65,21 @@ describe("VariantSchema", () => {
 
   it("does not collide the __default variant with the default-schema cache entry", () => {
     const Test = VariantSchema.make({ variants: ["a", "__default"], defaultVariant: "a" })
-    const struct = Test.Struct({
+    const defaultFirst = Test.Struct({
       value: Test.Field({ a: Schema.String, __default: Schema.Number })
     })
 
-    Test.extract(struct, "a")
+    Test.extract(defaultFirst, "a")
 
-    assert.strictEqual(Test.extract(struct, "__default").fields.value, Schema.Number)
+    assert.strictEqual(Test.extract(defaultFirst, "__default").fields.value, Schema.Number)
+
+    const namedFirst = Test.Struct({
+      value: Test.Field({ a: Schema.String, __default: Schema.Number })
+    })
+
+    Test.extract(namedFirst, "__default")
+
+    assert.strictEqual(Test.extract(namedFirst, "a").fields.value, Schema.String)
   })
 })
 

--- a/packages/effect/test/unstable/schema/VariantSchema.test.ts
+++ b/packages/effect/test/unstable/schema/VariantSchema.test.ts
@@ -62,6 +62,17 @@ describe("VariantSchema", () => {
 
     assert.deepStrictEqual(Object.keys(Test.extract(struct, "a").fields), ["value"])
   })
+
+  it("does not collide the __default variant with the default-schema cache entry", () => {
+    const Test = VariantSchema.make({ variants: ["a", "__default"], defaultVariant: "a" })
+    const struct = Test.Struct({
+      value: Test.Field({ a: Schema.String, __default: Schema.Number })
+    })
+
+    Test.extract(struct, "a")
+
+    assert.strictEqual(Test.extract(struct, "__default").fields.value, Schema.Number)
+  })
 })
 
 describe("Model", () => {


### PR DESCRIPTION
## Summary

A configured variant literally named __default can return the selected default variant's schema instead of its own.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Variant __default collides with the default cache key

**Module:** `schema/VariantSchema`  
**Audit ID:** `unstable-ai-cli-variant-schema-default-cache-collision`  
**Severity / confidence:** medium / high

### What happens

A configured variant literally named __default can return the selected default variant's schema instead of its own.

### Why it happens

Default extraction and the ordinary __default variant share the same string cache key, so whichever is extracted first populates the other's entry.

### Expected behavior

Every accepted string in options.variants extracts its configured schema independently of the selected default variant.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/schema/VariantSchema.ts:28`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/schema/VariantSchema.ts#L28)
- [`packages/effect/src/unstable/schema/VariantSchema.ts:198-220`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/schema/VariantSchema.ts#L198-L220)
- [`packages/effect/src/unstable/schema/VariantSchema.ts:486-491`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/schema/VariantSchema.ts#L486-L491)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/schema/VariantSchema.ts:28</code></summary>

```ts
const cacheSymbol = Symbol.for(`${TypeId}/cache`)
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/schema/VariantSchema.ts#L28)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/schema/VariantSchema.ts:198-220</code></summary>

```ts
const extract: {
  <V extends string, const IsDefault extends boolean = false>(
    variant: V,
    options?: {
      readonly isDefault?: IsDefault | undefined
    }
  ): <A extends Struct<any>>(self: A) => Extract<V, A, IsDefault>
  <V extends string, A extends Struct<any>, const IsDefault extends boolean = false>(self: A, variant: V, options?: {
    readonly isDefault?: IsDefault | undefined
  }): Extract<V, A, IsDefault>
} = dual(
  (args) => isStruct(args[0]),
  <V extends string, A extends Struct<any>>(
    self: A,
    variant: V,
    options?: {
      readonly isDefault?: boolean | undefined
    }
  ): Extract<V, A> => {
    const cache = self[cacheSymbol] ?? (self[cacheSymbol] = Object.create(null))
    const cacheKey = options?.isDefault === true ? "__default" : variant
    if (Object.hasOwn(cache, cacheKey)) {
      return cache[cacheKey] as any
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/schema/VariantSchema.ts#L198-L220)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/schema/VariantSchema.ts:486-491</code></summary>

```ts
  const extractVariants = dual(
    2,
    (self: Struct<any>, variant: string): any =>
      extract(self, variant, {
        isDefault: variant === options.defaultVariant
      })
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/schema/VariantSchema.ts#L486-L491)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/schema/VariantSchema.test.ts
```

**Observed failure:** FAIL: the named variant was replaced by the cached default schema.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/schema/VariantSchema.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-ai-cli-variant-schema-default-cache-collision`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-414