### PR TITLE
Handle accepted undefined fields during variant extraction

### DIFF
--- a/.changeset/fuzzy-hornets-wish.md
+++ b/.changeset/fuzzy-hornets-wish.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Handle accepted undefined fields during variant extraction.

--- a/packages/effect/src/unstable/schema/VariantSchema.ts
+++ b/packages/effect/src/unstable/schema/VariantSchema.ts
@@ -87,7 +87,7 @@ export declare namespace Struct {
   export type Validate<A, Variant extends string> = {
     readonly [K in keyof A]: A[K] extends { readonly [TypeId]: infer _ } ? Validate<A[K], Variant> :
       A[K] extends Field<infer Config> ? [keyof Config] extends [Variant] ? {} : "field must have valid variants"
-      : {}
+      : unknown
   }
 }
 
@@ -144,7 +144,7 @@ export declare namespace Field {
    * @since 4.0.0
    */
   export type ConfigWithKeys<K extends string> = {
-    readonly [P in K]?: Schema.Top
+    readonly [P in K]?: Schema.Top | undefined
   }
 
   /**
@@ -222,6 +222,9 @@ const extract: {
     const fields: Record<string, any> = {}
     for (const key of Object.keys(self[TypeId])) {
       const value = self[TypeId][key]
+      if (value === undefined) {
+        continue
+      }
       if (TypeId in value) {
         if (options?.isDefault === true && Schema.isSchema(value)) {
           InternalRecord.assignProperty(fields, key, value)
@@ -230,7 +233,10 @@ const extract: {
         }
       } else if (FieldTypeId in value) {
         if (Object.hasOwn(value.schemas, variant)) {
-          InternalRecord.assignProperty(fields, key, value.schemas[variant])
+          const schema = value.schemas[variant]
+          if (schema !== undefined) {
+            InternalRecord.assignProperty(fields, key, schema)
+          }
         }
       } else {
         InternalRecord.assignProperty(fields, key, value)

--- a/packages/effect/test/unstable/schema/VariantSchema.test.ts
+++ b/packages/effect/test/unstable/schema/VariantSchema.test.ts
@@ -48,6 +48,13 @@ describe("VariantSchema", () => {
     assert.deepStrictEqual(Schema.decodeUnknownSync(union)({ value: "foo" }), { value: "foo" })
     assert.deepStrictEqual(Schema.decodeUnknownSync(union)({ value: 42 }), { value: 42 })
   })
+
+  it("omits undefined fields accepted by VariantSchema.Struct", () => {
+    const Test = VariantSchema.make({ variants: ["a"], defaultVariant: "a" })
+    const struct = Test.Struct({ value: Schema.String, skipped: undefined })
+
+    assert.deepStrictEqual(Object.keys(Test.extract(struct, "a").fields), ["value"])
+  })
 })
 
 describe("Model", () => {

--- a/packages/effect/test/unstable/schema/VariantSchema.test.ts
+++ b/packages/effect/test/unstable/schema/VariantSchema.test.ts
@@ -55,6 +55,13 @@ describe("VariantSchema", () => {
 
     assert.deepStrictEqual(Object.keys(Test.extract(struct, "a").fields), ["value"])
   })
+
+  it("omits undefined fields selected by VariantSchema.Field", () => {
+    const Test = VariantSchema.make({ variants: ["a"], defaultVariant: "a" })
+    const struct = Test.Struct({ value: Schema.String, skipped: Test.Field({ a: undefined }) })
+
+    assert.deepStrictEqual(Object.keys(Test.extract(struct, "a").fields), ["value"])
+  })
 })
 
 describe("Model", () => {


### PR DESCRIPTION
## Summary

Variant extraction throws a native TypeError for direct or wrapped undefined fields that the public field types explicitly accept.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Accepted undefined fields crash variant extraction

**Module:** `schema/VariantSchema`  
**Audit ID:** `unstable-ai-cli-variant-schema-undefined-field-crash`  
**Severity / confidence:** medium / high

### What happens

Variant extraction throws a native TypeError for direct or wrapped undefined fields that the public field types explicitly accept.

### Why it happens

Extraction evaluates TypeId in value before checking value and can also pass an undefined wrapped schema to Schema.Struct.

### Expected behavior

Struct.Fields and Field.Fields accept undefined so conditionally omitted fields can be represented without crashing extraction.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/schema/VariantSchema.ts:66-78`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/schema/VariantSchema.ts#L66-L78)
- [`packages/effect/src/unstable/schema/VariantSchema.ts:150-163`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/schema/VariantSchema.ts#L150-L163)
- [`packages/effect/src/unstable/schema/VariantSchema.ts:222-239`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/schema/VariantSchema.ts#L222-L239)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/schema/VariantSchema.ts:66-78</code></summary>

```ts
   * Field map accepted by a variant struct, where each property may be a schema, a
   * variant field, a nested struct, or `undefined`.
   *
   * @category models
   * @since 4.0.0
   */
  export type Fields = {
    readonly [key: string]:
      | Schema.Top
      | Field<any>
      | Struct<any>
      | undefined
  }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/schema/VariantSchema.ts#L66-L78)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/schema/VariantSchema.ts:150-163</code></summary>

```ts
  /**
   * Field map whose properties may be schemas, variant fields, nested structs, or
   * `undefined`.
   *
   * @category models
   * @since 4.0.0
   */
  export type Fields = {
    readonly [key: string]:
      | Schema.Top
      | Field<any>
      | Struct<any>
      | undefined
  }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/schema/VariantSchema.ts#L150-L163)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/schema/VariantSchema.ts:222-239</code></summary>

```ts
    const fields: Record<string, any> = {}
    for (const key of Object.keys(self[TypeId])) {
      const value = self[TypeId][key]
      if (TypeId in value) {
        if (options?.isDefault === true && Schema.isSchema(value)) {
          InternalRecord.assignProperty(fields, key, value)
        } else {
          InternalRecord.assignProperty(fields, key, extract(value, variant))
        }
      } else if (FieldTypeId in value) {
        if (Object.hasOwn(value.schemas, variant)) {
          InternalRecord.assignProperty(fields, key, value.schemas[variant])
        }
      } else {
        InternalRecord.assignProperty(fields, key, value)
      }
    }
    const schema = Schema.Struct(fields)
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/schema/VariantSchema.ts#L222-L239)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/schema/VariantSchema.test.ts
```

**Observed failure:** FAIL: extraction threw a native TypeError.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/schema/VariantSchema.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-ai-cli-variant-schema-undefined-field-crash`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-415