### PR TITLE
Encode empty-data SSE events as dispatchable events

### DIFF
--- a/.changeset/empty-geckos-dispatch.md
+++ b/.changeset/empty-geckos-dispatch.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Encode SSE events with empty data as dispatchable events.

--- a/packages/effect/src/unstable/encoding/Sse.ts
+++ b/packages/effect/src/unstable/encoding/Sse.ts
@@ -660,9 +660,7 @@ export const encoder: Encoder = {
         if (event.event !== "message") {
           data += `event: ${event.event}\n`
         }
-        if (event.data !== "") {
-          data += `data: ${event.data.replace(/\n/g, "\ndata: ")}\n`
-        }
+        data += `data: ${event.data.replace(/\n/g, "\ndata: ")}\n`
         return data + "\n"
       }
       case "Retry": {

--- a/packages/effect/test/unstable/encoding/Sse.test.ts
+++ b/packages/effect/test/unstable/encoding/Sse.test.ts
@@ -41,6 +41,16 @@ describe("Sse", () => {
     ])
   })
 
+  it("roundtrips an SSE event with empty data", () => {
+    const input: Sse.Event = { _tag: "Event", event: "message", id: undefined, data: "" }
+    const events: Array<Sse.AnyEvent> = []
+    const parser = Sse.makeParser((event) => events.push(event))
+
+    parser.feed(Sse.encoder.write(input))
+
+    assert.deepStrictEqual(events, [input])
+  })
+
   it("Event preserves string payloads", () => {
     const decode = Schema.decodeUnknownSync(Sse.Event)
     const encode = Schema.encodeSync(Sse.Event)


### PR DESCRIPTION
## Summary

Encoding and reparsing an accepted event whose data is the empty string produces no event.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## SSE encoder drops empty-data events

**Module:** `encoding/Sse`  
**Audit ID:** `unstable-ai-cli-sse-empty-data-event-dropped`  
**Severity / confidence:** medium / high

### What happens

Encoding and reparsing an accepted event whose data is the empty string produces no event.

### Why it happens

The encoder omits data: for empty data and writes only a blank terminator, which the parser ignores while its data buffer is empty.

### Expected behavior

Every accepted Event, including data equal to the empty string, renders as an SSE event that can be dispatched.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/encoding/Sse.ts:654-669`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/encoding/Sse.ts#L654-L669)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/encoding/Sse.ts:654-669</code></summary>

```ts
export const encoder: Encoder = {
  write(event: AnyEvent): string {
    switch (event._tag) {
      case "Event": {
        let data = ""
        if (event.id !== undefined) {
          data += `id: ${event.id}\n`
        }
        if (event.event !== "message") {
          data += `event: ${event.event}\n`
        }
        if (event.data !== "") {
          data += `data: ${event.data.replace(/\n/g, "\ndata: ")}\n`
        }
        return data + "\n"
      }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/encoding/Sse.ts#L654-L669)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/encoding/Sse.test.ts
```

**Observed failure:** FAIL: the round-trip produced no event.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/encoding/Sse.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-ai-cli-sse-empty-data-event-dropped`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-416