### PR TITLE
Recognize and ignore a leading UTF-8 BOM in SSE streams

### DIFF
--- a/.changeset/fix-sse-leading-bom.md
+++ b/.changeset/fix-sse-leading-bom.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Recognize and ignore a leading UTF-8 byte order mark in server-sent event streams.

--- a/packages/effect/src/unstable/encoding/Sse.ts
+++ b/packages/effect/src/unstable/encoding/Sse.ts
@@ -280,10 +280,10 @@ export function makeParser(onParse: (event: AnyEvent) => void, options?: DecodeO
   function feed(chunk: string): SseError | undefined {
     buffer = buffer ? buffer + chunk : chunk
 
-    // Strip any UTF8 byte order mark (BOM) at the start of the stream.
+    // Strip any UTF-8 byte order mark (BOM) at the start of the stream.
     // Note that we do not strip any non - UTF8 BOM, as eventsource streams are
     // always decoded as UTF8 as per the specification.
-    if (isFirstChunk && hasBom(buffer)) {
+    if (isFirstChunk && buffer.startsWith(BOM)) {
       buffer = buffer.slice(BOM.length)
     }
 
@@ -405,11 +405,7 @@ export function makeParser(onParse: (event: AnyEvent) => void, options?: DecodeO
   }
 }
 
-const BOM = [239, 187, 191]
-
-function hasBom(buffer: string) {
-  return BOM.every((charCode: number, index: number) => buffer.charCodeAt(index) === charCode)
-}
+const BOM = "\uFEFF"
 
 /**
  * Stateful Server-Sent Events parser returned by `makeParser`.

--- a/packages/effect/test/unstable/encoding/Sse.test.ts
+++ b/packages/effect/test/unstable/encoding/Sse.test.ts
@@ -51,6 +51,20 @@ describe("Sse", () => {
     assert.deepStrictEqual(events, [input])
   })
 
+  it("strips a UTF-8 BOM from the start of an SSE stream", () => {
+    const events: Array<Sse.AnyEvent> = []
+    const parser = Sse.makeParser((event) => events.push(event))
+
+    parser.feed("\uFEFFdata: ok\n\n")
+
+    assert.deepStrictEqual(events, [{
+      _tag: "Event",
+      event: "message",
+      id: undefined,
+      data: "ok"
+    }])
+  })
+
   it("Event preserves string payloads", () => {
     const decode = Schema.decodeUnknownSync(Sse.Event)
     const encode = Schema.encodeSync(Sse.Event)


### PR DESCRIPTION
## Summary

- Recognize and ignore a decoded `U+FEFF` byte-order mark at the beginning of an SSE stream.
- Preserve BOM characters in non-leading positions by retaining the parser's first-chunk guard.
- Add focused regression coverage and an `effect` patch changeset.

## Validation

- `pnpm test --run packages/effect/test/unstable/encoding/Sse.test.ts`
- `pnpm lint-fix`
- `pnpm check`

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Finding: `unstable-ai-cli-sse-leading-bom`

Closes EFF-417