### PR TITLE
Default empty SSE event types to the message type

### DIFF
--- a/.changeset/sour-bees-sleep.md
+++ b/.changeset/sour-bees-sleep.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Default empty Server-Sent Event types to `message`.

--- a/packages/effect/src/unstable/encoding/Sse.ts
+++ b/packages/effect/src/unstable/encoding/Sse.ts
@@ -365,7 +365,7 @@ export function makeParser(onParse: (event: AnyEvent) => void, options?: DecodeO
         onParse({
           _tag: "Event",
           id: lastEventId,
-          event: eventName ?? "message",
+          event: eventName || "message",
           data: data.slice(0, -1) // remove trailing newline
         })
         data = ""

--- a/packages/effect/test/unstable/encoding/Sse.test.ts
+++ b/packages/effect/test/unstable/encoding/Sse.test.ts
@@ -51,6 +51,15 @@ describe("Sse", () => {
     assert.deepStrictEqual(events, [input])
   })
 
+  it("uses message for an empty SSE event type", () => {
+    const events: Array<Sse.AnyEvent> = []
+    const parser = Sse.makeParser((event) => events.push(event))
+
+    parser.feed("event:\ndata: ok\n\n")
+
+    assert.strictEqual((events[0] as Sse.Event).event, "message")
+  })
+
   it("Event preserves string payloads", () => {
     const decode = Schema.decodeUnknownSync(Sse.Event)
     const encode = Schema.encodeSync(Sse.Event)

--- a/packages/effect/test/unstable/encoding/Sse.test.ts
+++ b/packages/effect/test/unstable/encoding/Sse.test.ts
@@ -57,6 +57,7 @@ describe("Sse", () => {
 
     parser.feed("event:\ndata: ok\n\n")
 
+    assert.strictEqual(events.length, 1)
     assert.strictEqual((events[0] as Sse.Event).event, "message")
   })
 


### PR DESCRIPTION
## Summary

Parsing an empty event field emits an event whose type is the empty string instead of message.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Empty SSE event type does not default to message

**Module:** `encoding/Sse`  
**Audit ID:** `unstable-ai-cli-sse-empty-event-type`  
**Severity / confidence:** medium / high

### What happens

Parsing an empty event field emits an event whose type is the empty string instead of message.

### Why it happens

Dispatch uses nullish coalescing, so an empty string survives instead of selecting the message default.

### Expected behavior

An empty event-type buffer defaults to message when the SSE event is dispatched.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/encoding/Sse.ts:362-375`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/encoding/Sse.ts#L362-L375)
- [`packages/effect/src/unstable/encoding/Sse.ts:396-397`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/encoding/Sse.ts#L396-L397)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/encoding/Sse.ts:362-375</code></summary>

```ts
    if (lineLength === 0) {
      // We reached the last line of this event
      if (data.length > 0) {
        onParse({
          _tag: "Event",
          id: eventId,
          event: eventName ?? "message",
          data: data.slice(0, -1) // remove trailing newline
        })
        data = ""
        eventId = undefined
      }
      eventName = undefined
      return
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/encoding/Sse.ts#L362-L375)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/encoding/Sse.ts:396-397</code></summary>

```ts
    } else if (field === "event") {
      eventName = value
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/encoding/Sse.ts#L396-L397)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/encoding/Sse.test.ts
```

**Observed failure:** FAIL: the event type remained empty.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/encoding/Sse.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-ai-cli-sse-empty-event-type`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-418