### PR TITLE
Retain the last SSE event ID across dispatched events

### DIFF
--- a/.changeset/fix-sse-last-event-id.md
+++ b/.changeset/fix-sse-last-event-id.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Retain the last SSE event ID across dispatched events.

--- a/packages/effect/src/unstable/encoding/Sse.ts
+++ b/packages/effect/src/unstable/encoding/Sse.ts
@@ -258,7 +258,6 @@ export function makeParser(onParse: (event: AnyEvent) => void, options?: DecodeO
   let discardTrailingNewline: boolean
 
   // Event state
-  let eventId: string | undefined
   let lastEventId: string | undefined
   let eventName: string | undefined
   let data: string
@@ -273,7 +272,7 @@ export function makeParser(onParse: (event: AnyEvent) => void, options?: DecodeO
     startingFieldLength = -1
     discardTrailingNewline = false
 
-    eventId = undefined
+    lastEventId = undefined
     eventName = undefined
     data = ""
   }
@@ -365,12 +364,11 @@ export function makeParser(onParse: (event: AnyEvent) => void, options?: DecodeO
       if (data.length > 0) {
         onParse({
           _tag: "Event",
-          id: eventId,
+          id: lastEventId,
           event: eventName ?? "message",
           data: data.slice(0, -1) // remove trailing newline
         })
         data = ""
-        eventId = undefined
       }
       eventName = undefined
       return
@@ -397,7 +395,6 @@ export function makeParser(onParse: (event: AnyEvent) => void, options?: DecodeO
     } else if (field === "event") {
       eventName = value
     } else if (field === "id" && !value.includes("\u0000")) {
-      eventId = value
       lastEventId = value
     } else if (field === "retry") {
       const retry = parseInt(value, 10)

--- a/packages/effect/test/unstable/encoding/Sse.test.ts
+++ b/packages/effect/test/unstable/encoding/Sse.test.ts
@@ -19,6 +19,15 @@ describe("Sse", () => {
     }])
   })
 
+  it("retains the last event ID for later events", () => {
+    const events: Array<Sse.AnyEvent> = []
+    const parser = Sse.makeParser((event) => events.push(event))
+
+    parser.feed("id: 1\ndata: first\n\ndata: second\n\n")
+
+    assert.strictEqual((events[1] as Sse.Event).id, "1")
+  })
+
   it("Event preserves string payloads", () => {
     const decode = Schema.decodeUnknownSync(Sse.Event)
     const encode = Schema.encodeSync(Sse.Event)

--- a/packages/effect/test/unstable/encoding/Sse.test.ts
+++ b/packages/effect/test/unstable/encoding/Sse.test.ts
@@ -25,7 +25,20 @@ describe("Sse", () => {
 
     parser.feed("id: 1\ndata: first\n\ndata: second\n\n")
 
-    assert.strictEqual((events[1] as Sse.Event).id, "1")
+    assert.deepStrictEqual(events, [
+      {
+        _tag: "Event",
+        id: "1",
+        event: "message",
+        data: "first"
+      },
+      {
+        _tag: "Event",
+        id: "1",
+        event: "message",
+        data: "second"
+      }
+    ])
   })
 
   it("Event preserves string payloads", () => {


### PR DESCRIPTION
## Summary

Events after an id field are emitted without that ID unless they repeat the field themselves.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## SSE last event ID is not retained

**Module:** `encoding/Sse`  
**Audit ID:** `unstable-ai-cli-sse-last-event-id-not-retained`  
**Severity / confidence:** medium / high

### What happens

Events after an id field are emitted without that ID unless they repeat the field themselves.

### Why it happens

Dispatch reads and resets a per-event eventId instead of using the persistent lastEventId already retained for retry output.

### Expected behavior

An SSE id field updates a persistent last-event-ID buffer used by later dispatched events until changed.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/encoding/Sse.ts:259-276`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/encoding/Sse.ts#L259-L276)
- [`packages/effect/src/unstable/encoding/Sse.ts:362-373`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/encoding/Sse.ts#L362-L373)
- [`packages/effect/src/unstable/encoding/Sse.ts:398-405`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/encoding/Sse.ts#L398-L405)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/encoding/Sse.ts:259-276</code></summary>

```ts
  // Event state
  let eventId: string | undefined
  let lastEventId: string | undefined
  let eventName: string | undefined
  let data: string

  reset()
  return { feed, reset }

  function reset(): void {
    isFirstChunk = true
    buffer = ""
    startingPosition = 0
    startingFieldLength = -1

    eventId = undefined
    eventName = undefined
    data = ""
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/encoding/Sse.ts#L259-L276)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/encoding/Sse.ts:362-373</code></summary>

```ts
    if (lineLength === 0) {
      // We reached the last line of this event
      if (data.length > 0) {
        onParse({
          _tag: "Event",
          id: eventId,
          event: eventName ?? "message",
          data: data.slice(0, -1) // remove trailing newline
        })
        data = ""
        eventId = undefined
      }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/encoding/Sse.ts#L362-L373)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/encoding/Sse.ts:398-405</code></summary>

```ts
    } else if (field === "id" && !value.includes("\u0000")) {
      eventId = value
      lastEventId = value
    } else if (field === "retry") {
      const retry = parseInt(value, 10)
      if (!Number.isNaN(retry)) {
        onParse(new Retry({ duration: Duration.millis(retry), lastEventId }))
      }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/encoding/Sse.ts#L398-L405)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/encoding/Sse.test.ts
```

**Observed failure:** FAIL: the later event ID was undefined.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/encoding/Sse.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-ai-cli-sse-last-event-id-not-retained`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-419