### PR TITLE
Reject NDJSON values without a JSON representation

### DIFF
--- a/.changeset/tough-rooms-camp.md
+++ b/.changeset/tough-rooms-camp.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Reject NDJSON values without a JSON representation.

--- a/packages/effect/src/unstable/encoding/Ndjson.ts
+++ b/packages/effect/src/unstable/encoding/Ndjson.ts
@@ -73,7 +73,15 @@ export const encodeString = <IE = never, Done = unknown>(): Channel.Channel<
   Channel.fromTransform((upstream, _scope) =>
     Effect.succeed(Effect.flatMap(upstream, (input) => {
       try {
-        return Effect.succeed(Arr.of(input.map((item) => JSON.stringify(item)).join("\n") + "\n"))
+        return Effect.succeed(Arr.of(
+          input.map((item) => {
+            const output = JSON.stringify(item)
+            if (output === undefined) {
+              throw new TypeError("Value cannot be represented as JSON")
+            }
+            return output
+          }).join("\n") + "\n"
+        ))
       } catch (cause) {
         return Effect.fail(new NdjsonError({ kind: "Pack", cause }))
       }

--- a/packages/effect/test/unstable/encoding/Ndjson.test.ts
+++ b/packages/effect/test/unstable/encoding/Ndjson.test.ts
@@ -1,18 +1,23 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Exit, Stream } from "effect"
+import { Effect, Stream } from "effect"
 import * as Schema from "effect/Schema"
 import * as Ndjson from "effect/unstable/encoding/Ndjson"
 
 describe("Ndjson", () => {
-  it.effect("fails instead of emitting invalid NDJSON for undefined", () =>
+  it.effect("fails for values without a JSON representation", () =>
     Effect.gen(function*() {
-      const exit = yield* Stream.make(undefined).pipe(
-        Stream.pipeThroughChannel(Ndjson.encodeString()),
-        Stream.runCollect,
-        Effect.exit
-      )
+      const inputs = [undefined, () => {}, Symbol("x")]
 
-      assert.isTrue(Exit.isFailure(exit))
+      for (const input of inputs) {
+        const error = yield* Stream.make(input).pipe(
+          Stream.pipeThroughChannel(Ndjson.encodeString()),
+          Stream.runCollect,
+          Effect.flip
+        )
+
+        assert.instanceOf(error, Ndjson.NdjsonError)
+        assert.strictEqual(error.kind, "Pack")
+      }
     }))
 
   it.effect("decodeSchema decodes records split across Uint8Array chunks", () =>

--- a/packages/effect/test/unstable/encoding/Ndjson.test.ts
+++ b/packages/effect/test/unstable/encoding/Ndjson.test.ts
@@ -1,9 +1,20 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Stream } from "effect"
+import { Effect, Exit, Stream } from "effect"
 import * as Schema from "effect/Schema"
 import * as Ndjson from "effect/unstable/encoding/Ndjson"
 
 describe("Ndjson", () => {
+  it.effect("fails instead of emitting invalid NDJSON for undefined", () =>
+    Effect.gen(function*() {
+      const exit = yield* Stream.make(undefined).pipe(
+        Stream.pipeThroughChannel(Ndjson.encodeString()),
+        Stream.runCollect,
+        Effect.exit
+      )
+
+      assert.isTrue(Exit.isFailure(exit))
+    }))
+
   it.effect("decodeSchema decodes records split across Uint8Array chunks", () =>
     Effect.gen(function*() {
       const messages = yield* Stream.make(


### PR DESCRIPTION
## Summary

encodeString reports success for undefined and emits a blank line that the module's own decoder rejects.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Undefined encodes as an invalid blank NDJSON record

**Module:** `encoding/Ndjson`  
**Audit ID:** `unstable-ai-cli-ndjson-undefined-blank-record`  
**Severity / confidence:** medium / high

### What happens

encodeString reports success for undefined and emits a blank line that the module's own decoder rejects.

### Why it happens

JSON.stringify(undefined) returns undefined, which Array.join coerces to an empty field before the newline is appended.

### Expected behavior

Every accepted input becomes a complete JSON value on one line, or encoding fails with NdjsonError when no JSON representation exists.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/encoding/Ndjson.ts:65-81`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/encoding/Ndjson.ts#L65-L81)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/encoding/Ndjson.ts:65-81</code></summary>

```ts
export const encodeString = <IE = never, Done = unknown>(): Channel.Channel<
  Arr.NonEmptyReadonlyArray<string>,
  IE | NdjsonError,
  Done,
  Arr.NonEmptyReadonlyArray<unknown>,
  IE,
  Done
> =>
  Channel.fromTransform((upstream, _scope) =>
    Effect.succeed(Effect.flatMap(upstream, (input) => {
      try {
        return Effect.succeed(Arr.of(input.map((item) => JSON.stringify(item)).join("\n") + "\n"))
      } catch (cause) {
        return Effect.fail(new NdjsonError({ kind: "Pack", cause }))
      }
    }))
  )
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/encoding/Ndjson.ts#L65-L81)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/encoding/Ndjson.test.ts
```

**Observed failure:** FAIL: the encoder succeeded and emitted a blank line.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/encoding/Ndjson.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-ai-cli-ndjson-undefined-blank-record`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-420