### PR TITLE
Apply byte-range options to default Web-file responses

### DIFF
--- a/.changeset/curly-files-range.md
+++ b/.changeset/curly-files-range.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Apply byte range and chunk size options to default Web file responses.

--- a/packages/effect/src/unstable/http/HttpPlatform.ts
+++ b/packages/effect/src/unstable/http/HttpPlatform.ts
@@ -156,13 +156,44 @@ export const layer = Layer.effect(HttpPlatform)(
           { contentLength, headers, status, statusText }
         )
       },
-      fileWebResponse(file, status, statusText, headers, _options) {
+      fileWebResponse(file, status, statusText, headers, options) {
+        const offset = Number(options?.offset ?? 0)
+        const bytesToRead = options?.bytesToRead !== undefined ? Number(options.bytesToRead) : undefined
+        const chunkSize = options?.chunkSize !== undefined ? Math.max(1, Number(options.chunkSize)) : Infinity
+        const contentLength = bytesToRead ?? file.size - offset
+        const source = Stream.fromReadableStream({
+          evaluate: () => file.stream() as ReadableStream<Uint8Array>,
+          onError: identity
+        })
+        const stream = bytesToRead !== undefined && bytesToRead <= 0
+          ? Stream.empty
+          : source.pipe(
+            Stream.mapAccum(
+              () => ({ offset, remaining: bytesToRead }),
+              (state, bytes) => {
+                const start = Math.min(state.offset, bytes.length)
+                const offset = state.offset - start
+                const length = state.remaining === undefined
+                  ? bytes.length - start
+                  : Math.min(state.remaining, bytes.length - start)
+                const end = start + length
+                const remaining = state.remaining === undefined ? undefined : state.remaining - length
+                const chunks: Array<{ readonly bytes: Uint8Array; readonly done: boolean }> = []
+                for (let index = start; index < end; index += chunkSize) {
+                  chunks.push({
+                    bytes: bytes.subarray(index, Math.min(index + chunkSize, end)),
+                    done: remaining === 0 && index + chunkSize >= end
+                  })
+                }
+                return [{ offset, remaining }, chunks] as const
+              }
+            ),
+            Stream.takeUntil((chunk) => chunk.done),
+            Stream.map((chunk) => chunk.bytes)
+          )
         return Response.stream(
-          Stream.fromReadableStream({
-            evaluate: () => file.stream() as ReadableStream<Uint8Array>,
-            onError: identity
-          }),
-          { headers, status, statusText }
+          stream,
+          { contentLength, headers, status, statusText }
         )
       }
     }))

--- a/packages/effect/src/unstable/http/HttpPlatform.ts
+++ b/packages/effect/src/unstable/http/HttpPlatform.ts
@@ -160,41 +160,38 @@ export const layer = Layer.effect(HttpPlatform)(
         const offset = Number(options?.offset ?? 0)
         const bytesToRead = options?.bytesToRead !== undefined ? Number(options.bytesToRead) : undefined
         const chunkSize = options?.chunkSize !== undefined ? Math.max(1, Number(options.chunkSize)) : Infinity
-        const contentLength = bytesToRead ?? file.size - offset
-        const source = Stream.fromReadableStream({
-          evaluate: () => file.stream() as ReadableStream<Uint8Array>,
-          onError: identity
-        })
-        const stream = bytesToRead !== undefined && bytesToRead <= 0
+        const end = offset + (bytesToRead ?? Infinity)
+        const stream = end <= offset
           ? Stream.empty
-          : source.pipe(
+          : Stream.fromReadableStream({
+            evaluate: () => file.stream() as ReadableStream<Uint8Array>,
+            onError: identity
+          }).pipe(
             Stream.mapAccum(
-              () => ({ offset, remaining: bytesToRead }),
-              (state, bytes) => {
-                const start = Math.min(state.offset, bytes.length)
-                const offset = state.offset - start
-                const length = state.remaining === undefined
-                  ? bytes.length - start
-                  : Math.min(state.remaining, bytes.length - start)
-                const end = start + length
-                const remaining = state.remaining === undefined ? undefined : state.remaining - length
+              () => 0,
+              (position, bytes) => {
+                const next = position + bytes.length
+                const start = Math.min(Math.max(offset - position, 0), bytes.length)
+                const stop = Math.min(Math.max(end - position, 0), bytes.length)
                 const chunks: Array<{ readonly bytes: Uint8Array; readonly done: boolean }> = []
-                for (let index = start; index < end; index += chunkSize) {
+                for (let index = start; index < stop; index += chunkSize) {
                   chunks.push({
-                    bytes: bytes.subarray(index, Math.min(index + chunkSize, end)),
-                    done: remaining === 0 && index + chunkSize >= end
+                    bytes: bytes.subarray(index, Math.min(index + chunkSize, stop)),
+                    done: next >= end && index + chunkSize >= stop
                   })
                 }
-                return [{ offset, remaining }, chunks] as const
+                return [next, chunks]
               }
             ),
             Stream.takeUntil((chunk) => chunk.done),
             Stream.map((chunk) => chunk.bytes)
           )
-        return Response.stream(
-          stream,
-          { contentLength, headers, status, statusText }
-        )
+        return Response.stream(stream, {
+          contentLength: bytesToRead ?? file.size - offset,
+          headers,
+          status,
+          statusText
+        })
       }
     }))
 ).pipe(Layer.provide(Etag.layerWeak))

--- a/packages/effect/test/unstable/http/HttpPlatform.test.ts
+++ b/packages/effect/test/unstable/http/HttpPlatform.test.ts
@@ -3,16 +3,18 @@ import { Effect, FileSystem, Stream } from "effect"
 import { HttpPlatform } from "effect/unstable/http"
 
 describe("HttpPlatform", () => {
+  const file = {
+    name: "file.bin",
+    lastModified: 0,
+    size: 4,
+    type: "application/octet-stream",
+    stream: () => new Blob([new Uint8Array([1, 2, 3, 4])]).stream()
+  }
+
   it.effect("honors Web file offset and byte count", () =>
     Effect.gen(function*() {
       const platform = yield* HttpPlatform.HttpPlatform
-      const response = yield* platform.fileWebResponse({
-        name: "file.bin",
-        lastModified: 0,
-        size: 4,
-        type: "application/octet-stream",
-        stream: () => new Blob([new Uint8Array([1, 2, 3, 4])]).stream()
-      }, { offset: 1, bytesToRead: 2 })
+      const response = yield* platform.fileWebResponse(file, { offset: 1, bytesToRead: 2 })
       assert.strictEqual(response.body._tag, "Stream")
       if (response.body._tag === "Stream") {
         assert.strictEqual(response.body.contentLength, 2)
@@ -27,13 +29,7 @@ describe("HttpPlatform", () => {
   it.effect("honors Web file chunk size", () =>
     Effect.gen(function*() {
       const platform = yield* HttpPlatform.HttpPlatform
-      const response = yield* platform.fileWebResponse({
-        name: "file.bin",
-        lastModified: 0,
-        size: 4,
-        type: "application/octet-stream",
-        stream: () => new Blob([new Uint8Array([1, 2, 3, 4])]).stream()
-      }, { offset: 0, bytesToRead: 4, chunkSize: 2 })
+      const response = yield* platform.fileWebResponse(file, { offset: 0, bytesToRead: 4, chunkSize: 2 })
       assert.strictEqual(response.body._tag, "Stream")
       if (response.body._tag === "Stream") {
         assert.strictEqual(response.body.contentLength, 4)

--- a/packages/effect/test/unstable/http/HttpPlatform.test.ts
+++ b/packages/effect/test/unstable/http/HttpPlatform.test.ts
@@ -1,0 +1,25 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, FileSystem, Stream } from "effect"
+import { HttpPlatform } from "effect/unstable/http"
+
+describe("HttpPlatform", () => {
+  it.effect("honors Web file offset and byte count", () =>
+    Effect.gen(function*() {
+      const platform = yield* HttpPlatform.HttpPlatform
+      const response = yield* platform.fileWebResponse({
+        name: "file.bin",
+        lastModified: 0,
+        size: 4,
+        type: "application/octet-stream",
+        stream: () => new Blob([new Uint8Array([1, 2, 3, 4])]).stream()
+      }, { offset: 1, bytesToRead: 2 })
+      assert.strictEqual(response.body._tag, "Stream")
+      if (response.body._tag === "Stream") {
+        const bytes = yield* Stream.mkUint8Array(response.body.stream)
+        assert.deepStrictEqual(Array.from(bytes), [2, 3])
+      }
+    }).pipe(
+      Effect.provide(HttpPlatform.layer),
+      Effect.provideService(FileSystem.FileSystem, {} as any)
+    ))
+})

--- a/packages/effect/test/unstable/http/HttpPlatform.test.ts
+++ b/packages/effect/test/unstable/http/HttpPlatform.test.ts
@@ -15,8 +15,30 @@ describe("HttpPlatform", () => {
       }, { offset: 1, bytesToRead: 2 })
       assert.strictEqual(response.body._tag, "Stream")
       if (response.body._tag === "Stream") {
+        assert.strictEqual(response.body.contentLength, 2)
         const bytes = yield* Stream.mkUint8Array(response.body.stream)
         assert.deepStrictEqual(Array.from(bytes), [2, 3])
+      }
+    }).pipe(
+      Effect.provide(HttpPlatform.layer),
+      Effect.provideService(FileSystem.FileSystem, {} as any)
+    ))
+
+  it.effect("honors Web file chunk size", () =>
+    Effect.gen(function*() {
+      const platform = yield* HttpPlatform.HttpPlatform
+      const response = yield* platform.fileWebResponse({
+        name: "file.bin",
+        lastModified: 0,
+        size: 4,
+        type: "application/octet-stream",
+        stream: () => new Blob([new Uint8Array([1, 2, 3, 4])]).stream()
+      }, { offset: 0, bytesToRead: 4, chunkSize: 2 })
+      assert.strictEqual(response.body._tag, "Stream")
+      if (response.body._tag === "Stream") {
+        assert.strictEqual(response.body.contentLength, 4)
+        const chunks = yield* Stream.runCollect(response.body.stream)
+        assert.deepStrictEqual(chunks.map((chunk) => Array.from(chunk)), [[1, 2], [3, 4]])
       }
     }).pipe(
       Effect.provide(HttpPlatform.layer),


### PR DESCRIPTION
## Summary

The default Web-file layer ignores offset, bytesToRead, and chunkSize and streams the complete File-like value; a request for bytes two and three returns all four source bytes.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Default Web-file responses ignore byte-range options

**Module:** `HttpPlatform`  
**Audit ID:** `unstable-http-httpplatform-fileweb-range`  
**Severity / confidence:** medium / high

### What happens

The default Web-file layer ignores offset, bytesToRead, and chunkSize and streams the complete File-like value; a request for bytes two and three returns all four source bytes.

### Why it happens

The default layer names the argument _options and always streams file.stream() in full, making HttpServerResponse.fileWeb range options ineffective.

### Expected behavior

fileWebResponse accepts offset, bytesToRead, and chunkSize options and must serve the selected file region.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/http/HttpPlatform.ts:159-166`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/http/HttpPlatform.ts#L159-L166)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/http/HttpPlatform.ts:159-166</code></summary>

```ts
      fileWebResponse(file, status, statusText, headers, _options) {
        return Response.stream(
          Stream.fromReadableStream({
            evaluate: () => file.stream() as ReadableStream<Uint8Array>,
            onError: identity
          }),
          { headers, status, statusText }
        )
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/http/HttpPlatform.ts#L159-L166)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/http/HttpPlatform.test.ts
```

**Observed failure:** Failed as intended with [1, 2, 3, 4] instead of [2, 3].

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/http/HttpPlatform.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-http-httpplatform-fileweb-range`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-421