### PR TITLE
Pin fixed next release action on v3

### DIFF
--- a/.github/workflows/release-queue.yml
+++ b/.github/workflows/release-queue.yml
@@ -35,7 +35,7 @@ jobs:
         if: github.event.pull_request
         env:
           GITHUB_TOKEN: ${{ secrets.EFFECT_BOT_GH }}
-      - uses: Effect-TS/next-release-action@main
+      - uses: Effect-TS/next-release-action@0901387026995718742a42e0f6bf7743d0d83c2f
         with:
           github_token: ${{ secrets.EFFECT_BOT_GH }}
           packages: effect,@effect/platform


### PR DESCRIPTION
## Purpose

Pin the v3 release queue workflow to the merged `next-release-action` config-provider fix. This allows the action to read the configured `v3/next-minor` branch instead of using its fallback branch names.

Action fix: https://github.com/Effect-TS/next-release-action/pull/3

## Verification

- Not run at request
- `pnpm lint-fix` could not start because `eslint` is unavailable in the current install