### PR TITLE
Cache original response bytes before decoding text

### DIFF
--- a/.changeset/warm-rivers-cache.md
+++ b/.changeset/warm-rivers-cache.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve original HTTP response bytes when reading response text first.

--- a/packages/effect/src/unstable/http/HttpClientResponse.ts
+++ b/packages/effect/src/unstable/http/HttpClientResponse.ts
@@ -333,22 +333,7 @@ class WebHttpClientResponse extends Inspectable.Class implements HttpClientRespo
 
   private textBody?: Effect.Effect<string, Error.HttpClientError>
   get text(): Effect.Effect<string, Error.HttpClientError> {
-    if (this.textBody) {
-      return this.textBody
-    }
-    this.textBody = Effect.tryPromise({
-      try: () => this.source.text(),
-      catch: (cause) =>
-        new Error.HttpClientError({
-          reason: new Error.DecodeError({
-            request: this.request,
-            response: this,
-            cause
-          })
-        })
-    }).pipe(Effect.cached, Effect.runSync)
-    this.arrayBufferBody = Effect.map(this.textBody, (_) => new TextEncoder().encode(_).buffer)
-    return this.textBody
+    return this.textBody ??= Effect.map(this.arrayBuffer, (_) => new TextDecoder().decode(_))
   }
 
   get urlParamsBody(): Effect.Effect<UrlParams.UrlParams, Error.HttpClientError> {
@@ -397,7 +382,6 @@ class WebHttpClientResponse extends Inspectable.Class implements HttpClientRespo
           })
         })
     }).pipe(Effect.cached, Effect.runSync)
-    this.textBody = Effect.map(this.arrayBufferBody, (_) => new TextDecoder().decode(_))
     return this.arrayBufferBody
   }
 

--- a/packages/effect/test/unstable/http/HttpClient.test.ts
+++ b/packages/effect/test/unstable/http/HttpClient.test.ts
@@ -38,6 +38,17 @@ const makeRedirectClient = Effect.fnUntraced(function*(status: number, location:
 const RateLimiterTestLayer = RateLimiter.layer.pipe(Layer.provide(RateLimiter.layerStoreMemory))
 
 describe("HttpClient", () => {
+  it.effect("preserves source bytes after reading response text", () =>
+    Effect.gen(function*() {
+      const response = HttpClientResponse.fromWeb(
+        HttpClientRequest.get("https://example.com"),
+        new Response(new Uint8Array([0xef, 0xbb, 0xbf, 0x61]))
+      )
+      yield* response.text
+      const bytes = new Uint8Array(yield* response.arrayBuffer)
+      assert.deepStrictEqual(Array.from(bytes), [0xef, 0xbb, 0xbf, 0x61])
+    }))
+
   describe("tracer", () => {
     it.effect("includes request and response headers by default", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Summary

Reading text before arrayBuffer returns UTF-8 re-encoded text rather than the response's original bytes; the focused Web response loses its UTF-8 BOM and returns [97] instead of [239, 187, 191, 97].

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Text-first response caching loses source bytes

**Module:** `HttpClientResponse`  
**Audit ID:** `unstable-http-httpclientresponse-lossy-cache`  
**Severity / confidence:** medium / high

### What happens

Reading text before arrayBuffer returns UTF-8 re-encoded text rather than the response's original bytes; the focused Web response loses its UTF-8 BOM and returns [97] instead of [239, 187, 191, 97].

### Why it happens

The text-first path defines arrayBufferBody by UTF-8 re-encoding decoded text instead of caching source bytes. Decoding strips a UTF-8 BOM and can replace invalid sequences, while the inverse path correctly derives text from cached bytes.

### Expected behavior

arrayBuffer exposes the response's original bytes, independent of whether the cached text accessor was read first.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/http/HttpClientResponse.ts:334-351`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/http/HttpClientResponse.ts#L334-L351)
- [`packages/effect/src/unstable/http/HttpClientResponse.ts:384-401`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/http/HttpClientResponse.ts#L384-L401)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/http/HttpClientResponse.ts:334-351</code></summary>

```ts
  private textBody?: Effect.Effect<string, Error.HttpClientError>
  get text(): Effect.Effect<string, Error.HttpClientError> {
    if (this.textBody) {
      return this.textBody
    }
    this.textBody = Effect.tryPromise({
      try: () => this.source.text(),
      catch: (cause) =>
        new Error.HttpClientError({
          reason: new Error.DecodeError({
            request: this.request,
            response: this,
            cause
          })
        })
    }).pipe(Effect.cached, Effect.runSync)
    this.arrayBufferBody = Effect.map(this.textBody, (_) => new TextEncoder().encode(_).buffer)
    return this.textBody
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/http/HttpClientResponse.ts#L334-L351)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/http/HttpClientResponse.ts:384-401</code></summary>

```ts
  private arrayBufferBody?: Effect.Effect<ArrayBuffer, Error.HttpClientError>
  get arrayBuffer(): Effect.Effect<ArrayBuffer, Error.HttpClientError> {
    if (this.arrayBufferBody) {
      return this.arrayBufferBody
    }
    this.arrayBufferBody = Effect.tryPromise({
      try: () => this.source.arrayBuffer(),
      catch: (cause) =>
        new Error.HttpClientError({
          reason: new Error.DecodeError({
            request: this.request,
            response: this,
            cause
          })
        })
    }).pipe(Effect.cached, Effect.runSync)
    this.textBody = Effect.map(this.arrayBufferBody, (_) => new TextDecoder().decode(_))
    return this.arrayBufferBody
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/http/HttpClientResponse.ts#L384-L401)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/http/HttpClient.test.ts
```

**Observed failure:** Failed as intended: source bytes [239, 187, 191, 97] became [97] after reading text first.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/http/HttpClient.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-http-httpclientresponse-lossy-cache`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-422