### PR TITLE
Map socket writer exceptions and rejections to SocketError

### DIFF
--- a/.changeset/soft-sockets-write.md
+++ b/.changeset/soft-sockets-write.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Map WebSocket send exceptions and transform stream write rejections to typed `SocketError` failures.

--- a/packages/effect/src/unstable/socket/Socket.ts
+++ b/packages/effect/src/unstable/socket/Socket.ts
@@ -737,16 +737,18 @@ export const fromWebSocket = <RO>(
 
     const write = (chunk: Uint8Array | string | CloseEvent) =>
       latch.whenOpen(
-        Effect.try({
-          try: () => {
+        Effect.suspend(() => {
+          try {
             const ws = currentWS!
             if (isCloseEvent(chunk)) {
               ws.close(chunk.code, chunk.reason)
             } else {
               ws.send(chunk as string | Uint8Array<ArrayBuffer>)
             }
-          },
-          catch: (cause) => new SocketError({ reason: new SocketWriteError({ cause }) })
+            return Effect.void
+          } catch (cause) {
+            return Effect.fail(new SocketError({ reason: new SocketWriteError({ cause }) }))
+          }
         })
       )
     const writer = Effect.succeed(write)

--- a/packages/effect/src/unstable/socket/Socket.ts
+++ b/packages/effect/src/unstable/socket/Socket.ts
@@ -736,14 +736,19 @@ export const fromWebSocket = <RO>(
       )
 
     const write = (chunk: Uint8Array | string | CloseEvent) =>
-      latch.whenOpen(Effect.sync(() => {
-        const ws = currentWS!
-        if (isCloseEvent(chunk)) {
-          ws.close(chunk.code, chunk.reason)
-        } else {
-          ws.send(chunk as string | Uint8Array<ArrayBuffer>)
-        }
-      }))
+      latch.whenOpen(
+        Effect.try({
+          try: () => {
+            const ws = currentWS!
+            if (isCloseEvent(chunk)) {
+              ws.close(chunk.code, chunk.reason)
+            } else {
+              ws.send(chunk as string | Uint8Array<ArrayBuffer>)
+            }
+          },
+          catch: (cause) => new SocketError({ reason: new SocketWriteError({ cause }) })
+        })
+      )
     const writer = Effect.succeed(write)
 
     return Effect.succeed(make({
@@ -906,7 +911,10 @@ export const fromTransformStream = <R>(acquire: Effect.Effect<InputTransformStre
             })
           )
         }
-        return Effect.promise(() => getWriter(stream).write(typeof chunk === "string" ? encoder.encode(chunk) : chunk))
+        return Effect.tryPromise({
+          try: () => getWriter(stream).write(typeof chunk === "string" ? encoder.encode(chunk) : chunk),
+          catch: (cause) => new SocketError({ reason: new SocketWriteError({ cause }) })
+        })
       }))
     const writer = Effect.acquireRelease(
       Effect.succeed(write),

--- a/packages/platform-node/test/NodeSocket.test.ts
+++ b/packages/platform-node/test/NodeSocket.test.ts
@@ -147,5 +147,28 @@ describe("Socket", () => {
         assert.deepStrictEqual(chunks, ["Hello", "World"])
         assert.deepStrictEqual(received, ["A", "B", "C"])
       }))
+
+    it.effect("reports writable stream rejection as SocketError", () =>
+      Effect.gen(function*() {
+        const socket = yield* Socket.fromTransformStream(Effect.succeed({
+          readable: new ReadableStream<Uint8Array>({}),
+          writable: new WritableStream<Uint8Array>({
+            write: () => Promise.reject(new Error("write failed"))
+          })
+        }))
+        const exit = yield* Effect.scoped(Effect.gen(function*() {
+          const run = yield* Effect.forkChild(socket.runRaw(() => {}))
+          const write = yield* socket.writer
+          const exit = yield* Effect.exit(write(new Uint8Array([1])))
+          yield* Fiber.interrupt(run)
+          return exit
+        }))
+        assert.strictEqual(exit._tag, "Failure")
+        if (exit._tag === "Failure") {
+          assert.strictEqual(exit.cause.reasons[0]?._tag, "Fail")
+          const reason = exit.cause.reasons[0]
+          if (reason?._tag === "Fail") assert.isTrue(Socket.SocketError.is(reason.error))
+        }
+      }))
   })
 })

--- a/packages/platform-node/test/NodeSocket.test.ts
+++ b/packages/platform-node/test/NodeSocket.test.ts
@@ -102,6 +102,43 @@ describe("Socket", () => {
       }).pipe(
         Effect.provideService(Socket.WebSocketConstructor, (url) => new globalThis.WebSocket(url))
       ))
+
+    it.effect("reports send errors as SocketError", () =>
+      Effect.gen(function*() {
+        class ThrowingWebSocket extends EventTarget {
+          readonly readyState = globalThis.WebSocket.OPEN
+
+          close(): void {}
+
+          send(): void {
+            throw new Error("send failed")
+          }
+        }
+        const webSocket = new ThrowingWebSocket()
+        const socket = yield* Socket.makeWebSocket(Effect.succeed(url), { closeCodeIsError: () => false }).pipe(
+          Effect.provideService(
+            Socket.WebSocketConstructor,
+            () => webSocket as unknown as globalThis.WebSocket
+          )
+        )
+        const exit = yield* Effect.scoped(Effect.gen(function*() {
+          const run = yield* Effect.forkChild(socket.runRaw(() => {}))
+          const write = yield* socket.writer
+          const exit = yield* Effect.exit(write(new Uint8Array([1])))
+          webSocket.dispatchEvent(new CloseEvent("close", { code: 1000 }))
+          yield* Fiber.join(run)
+          return exit
+        }))
+        assert.strictEqual(exit._tag, "Failure")
+        if (exit._tag === "Failure") {
+          assert.strictEqual(exit.cause.reasons[0]?._tag, "Fail")
+          const reason = exit.cause.reasons[0]
+          if (reason?._tag === "Fail") {
+            assert.isTrue(Socket.SocketError.is(reason.error))
+            assert.strictEqual(reason.error.reason._tag, "SocketWriteError")
+          }
+        }
+      }))
   })
 
   describe("TransformStream", () => {
@@ -167,7 +204,10 @@ describe("Socket", () => {
         if (exit._tag === "Failure") {
           assert.strictEqual(exit.cause.reasons[0]?._tag, "Fail")
           const reason = exit.cause.reasons[0]
-          if (reason?._tag === "Fail") assert.isTrue(Socket.SocketError.is(reason.error))
+          if (reason?._tag === "Fail") {
+            assert.isTrue(Socket.SocketError.is(reason.error))
+            assert.strictEqual(reason.error.reason._tag, "SocketWriteError")
+          }
         }
       }))
   })


### PR DESCRIPTION
## Summary

Transform-stream write rejection and synchronous WebSocket send errors become defects rather than typed SocketError failures, bypassing the recovery promised by Socket.writer.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Socket writer failures escape as defects

**Module:** `Socket`  
**Audit ID:** `unstable-http-socket-writer-defects`  
**Severity / confidence:** medium / high

### What happens

Transform-stream write rejection and synchronous WebSocket send errors become defects rather than typed SocketError failures, bypassing the recovery promised by Socket.writer.

### Why it happens

The WebSocket writer wraps send in Effect.sync, making synchronous exceptions defects, and the transform-stream writer uses Effect.promise, making rejected WritableStream.write promises defects.

### Expected behavior

Socket.writer returns effects whose declared failure channel is SocketError.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/socket/Socket.ts:738-746`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/socket/Socket.ts#L738-L746)
- [`packages/effect/src/unstable/socket/Socket.ts:898-910`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/socket/Socket.ts#L898-L910)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/socket/Socket.ts:738-746</code></summary>

```ts
    const write = (chunk: Uint8Array | string | CloseEvent) =>
      latch.whenOpen(Effect.sync(() => {
        const ws = currentWS!
        if (isCloseEvent(chunk)) {
          ws.close(chunk.code, chunk.reason)
        } else {
          ws.send(chunk as string | Uint8Array<ArrayBuffer>)
        }
      }))
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/socket/Socket.ts#L738-L746)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/socket/Socket.ts:898-910</code></summary>

```ts
    const write = (chunk: Uint8Array | string | CloseEvent) =>
      latch.whenOpen(Effect.suspend(() => {
        const { fiberSet, stream } = currentStream!
        if (isCloseEvent(chunk)) {
          return Deferred.fail(
            fiberSet.deferred,
            new SocketError({
              reason: new SocketCloseError({ code: chunk.code, closeReason: chunk.reason })
            })
          )
        }
        return Effect.promise(() => getWriter(stream).write(typeof chunk === "string" ? encoder.encode(chunk) : chunk))
      }))
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/socket/Socket.ts#L898-L910)

</details>

### Reproduction

```sh
pnpm test --run packages/platform-node/test/NodeSocket.test.ts
```

**Observed failure:** Failed as intended because the transform-stream write rejection produced Die(Error: write failed), not Fail(SocketError).

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/platform-node/test/NodeSocket.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-http-socket-writer-defects`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-424