### PR TITLE
Preserve lexical ordering in streaming template interpolation

### DIFF
--- a/.changeset/tidy-cats-stream.md
+++ b/.changeset/tidy-cats-stream.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve lexical ordering in streaming template interpolation.

--- a/packages/effect/src/unstable/http/Template.ts
+++ b/packages/effect/src/unstable/http/Template.ts
@@ -218,8 +218,7 @@ export function stream<A extends ReadonlyArray<InterpolatedWithStream>>(
   return Stream.flatMap(
     Stream.fromIterable(chunks),
     (chunk) =>
-      typeof chunk === "string" ? Stream.succeed(chunk) : Effect.isEffect(chunk) ? Stream.fromEffect(chunk) : chunk,
-    { concurrency: "unbounded" }
+      typeof chunk === "string" ? Stream.succeed(chunk) : Effect.isEffect(chunk) ? Stream.fromEffect(chunk) : chunk
   )
 }
 

--- a/packages/effect/src/unstable/http/Template.ts
+++ b/packages/effect/src/unstable/http/Template.ts
@@ -215,10 +215,12 @@ export function stream<A extends ReadonlyArray<InterpolatedWithStream>>(
     buffer = ""
   }
 
-  return Stream.flatMap(
-    Stream.fromIterable(chunks),
-    (chunk) =>
-      typeof chunk === "string" ? Stream.succeed(chunk) : Effect.isEffect(chunk) ? Stream.fromEffect(chunk) : chunk
+  return Stream.fromIterable(chunks).pipe(
+    Stream.mapEffect(
+      (chunk) => Effect.isEffect(chunk) ? chunk : Effect.succeed(chunk),
+      { concurrency: "unbounded" }
+    ),
+    Stream.flatMap((chunk) => typeof chunk === "string" ? Stream.succeed(chunk) : chunk)
   )
 }
 

--- a/packages/effect/test/unstable/http/Template.test.ts
+++ b/packages/effect/test/unstable/http/Template.test.ts
@@ -1,0 +1,17 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Fiber, Stream } from "effect"
+import { TestClock } from "effect/testing"
+import { Template } from "effect/unstable/http"
+
+describe("Template", () => {
+  it.effect("preserves template segment order", () =>
+    Effect.gen(function*() {
+      const fiber = yield* Stream.runCollect(
+        Template.stream`a${Effect.delay(Effect.succeed("slow"), "1 second")}b${"fast"}c`
+      ).pipe(Effect.forkChild)
+      yield* Effect.yieldNow
+      yield* TestClock.adjust("1 second")
+      const chunks = yield* Fiber.join(fiber)
+      assert.strictEqual(chunks.join(""), "aslowbfastc")
+    }))
+})

--- a/packages/effect/test/unstable/http/Template.test.ts
+++ b/packages/effect/test/unstable/http/Template.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Fiber, Stream } from "effect"
+import { Deferred, Effect, Fiber, Stream } from "effect"
 import { TestClock } from "effect/testing"
 import { Template } from "effect/unstable/http"
 
@@ -13,5 +13,26 @@ describe("Template", () => {
       yield* TestClock.adjust("1 second")
       const chunks = yield* Fiber.join(fiber)
       assert.strictEqual(chunks.join(""), "aslowbfastc")
+    }))
+
+  it.effect("evaluates effect interpolations concurrently", () =>
+    Effect.gen(function*() {
+      const firstStarted = yield* Deferred.make<void>()
+      const secondStarted = yield* Deferred.make<void>()
+      const releaseFirst = yield* Deferred.make<void>()
+      const fiber = yield* Template.stream`${
+        Deferred.succeed(firstStarted, void 0).pipe(
+          Effect.andThen(Deferred.await(releaseFirst)),
+          Effect.as("first")
+        )
+      }${Deferred.succeed(secondStarted, void 0).pipe(Effect.as("second"))}`.pipe(
+        Stream.runCollect,
+        Effect.forkChild
+      )
+      yield* Deferred.await(firstStarted)
+      yield* Effect.yieldNow
+      assert.isTrue(yield* Deferred.isDone(secondStarted))
+      yield* Deferred.succeed(releaseFirst, void 0)
+      assert.deepStrictEqual(yield* Fiber.join(fiber), ["first", "second"])
     }))
 })


### PR DESCRIPTION
## Summary

Template.stream allows later static and fast segments to overtake an earlier delayed interpolation, changing a${slow}b${fast}c into abfastcslow rather than aslowbfastc.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Streaming interpolation does not preserve template order

**Module:** `Template`  
**Audit ID:** `unstable-http-template-stream-order`  
**Severity / confidence:** medium / high

### What happens

Template.stream allows later static and fast segments to overtake an earlier delayed interpolation, changing a${slow}b${fast}c into abfastcslow rather than aslowbfastc.

### Why it happens

The lexical segment stream is flattened with concurrency set to unbounded, so later segments can emit before an earlier effect or stream interpolation completes.

### Expected behavior

A template stream must emit static and interpolated segments in lexical template order.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/http/Template.ts:218-223`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/http/Template.ts#L218-L223)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/http/Template.ts:218-223</code></summary>

```ts
  return Stream.flatMap(
    Stream.fromIterable(chunks),
    (chunk) =>
      typeof chunk === "string" ? Stream.succeed(chunk) : Effect.isEffect(chunk) ? Stream.fromEffect(chunk) : chunk,
    { concurrency: "unbounded" }
  )
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/http/Template.ts#L218-L223)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/http/Template.test.ts
```

**Observed failure:** Failed deterministically under TestClock with abfastcslow instead of aslowbfastc.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/http/Template.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-http-template-stream-order`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-425