### PR TITLE
Support raw BodyInit values in converted server requests

### DIFF
--- a/.changeset/fix-http-server-request-raw-body.md
+++ b/.changeset/fix-http-server-request-raw-body.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Support standard `BodyInit` values when reading converted client request bodies through `HttpServerRequest`.

--- a/packages/effect/src/unstable/http/HttpServerRequest.ts
+++ b/packages/effect/src/unstable/http/HttpServerRequest.ts
@@ -863,24 +863,24 @@ const rawBodyStream = (request: HttpServerRequest, body: unknown): Stream.Stream
   if (body instanceof Request) {
     return streamFromReadable(request, body.body)
   }
-  if (isFormData(body)) {
-    return streamFromReadable(request, new Response(body).body)
-  }
   if (isReadableStream(body)) {
     return streamFromReadable(request, body)
+  }
+  if (isBodyInit(body)) {
+    return streamFromReadable(request, new Response(body).body)
   }
   return Stream.fail(requestParseError(request, "Unsupported body type"))
 }
 
 const rawBodyBytes = (request: HttpServerRequest, body: unknown): Effect.Effect<Uint8Array, HttpServerError> => {
-  if (body instanceof Blob) {
-    return bytesFromBodyInit(request, body)
-  }
   if (body instanceof Request) {
     return Effect.tryPromise({
       try: () => body.arrayBuffer().then((buffer) => new Uint8Array(buffer)),
       catch: (cause) => requestParseError(request, undefined, cause)
     })
+  }
+  if (isBodyInit(body)) {
+    return bytesFromBodyInit(request, body)
   }
   return Effect.fail(requestParseError(request, "Unsupported body type"))
 }
@@ -994,6 +994,14 @@ const isReadableStream = (u: unknown): u is ReadableStream<Uint8Array> =>
   typeof ReadableStream !== "undefined" && u instanceof ReadableStream
 
 const isFormData = (u: unknown): u is FormData => typeof FormData !== "undefined" && u instanceof FormData
+
+const isBodyInit = (u: unknown): u is BodyInit =>
+  typeof u === "string" ||
+  (typeof ArrayBuffer !== "undefined" && (u instanceof ArrayBuffer || ArrayBuffer.isView(u))) ||
+  (typeof Blob !== "undefined" && u instanceof Blob) ||
+  isFormData(u) ||
+  (typeof URLSearchParams !== "undefined" && u instanceof URLSearchParams) ||
+  isReadableStream(u)
 
 const textDecoder = new TextDecoder()
 

--- a/packages/effect/test/unstable/http/HttpServerRequest.test.ts
+++ b/packages/effect/test/unstable/http/HttpServerRequest.test.ts
@@ -2,7 +2,7 @@ import { assert, describe, it } from "@effect/vitest"
 import { assertNone, assertSome, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import { Effect, Schema, Stream } from "effect"
 import * as Option from "effect/Option"
-import { HttpClientRequest, HttpServerRequest } from "effect/unstable/http"
+import { HttpBody, HttpClientRequest, HttpServerRequest } from "effect/unstable/http"
 
 describe("HttpServerRequest", () => {
   it("toClientRequest", async () => {
@@ -107,6 +107,13 @@ describe("HttpServerRequest", () => {
         assert.strictEqual(parts[1].contentType, "text/plain")
         assert.strictEqual(new TextDecoder().decode(yield* parts[1].contentEffect), "hello")
       }
+    }))
+
+  it.effect("reads a raw BodyInit after conversion from a client request", () =>
+    Effect.gen(function*() {
+      const client = HttpClientRequest.setBody(HttpClientRequest.post("https://example.com"), HttpBody.raw("abc"))
+      const server = HttpServerRequest.fromClientRequest(client)
+      assert.strictEqual(yield* server.text, "abc")
     }))
 
   it.effect("schemaBodyJson applies parse options", () =>

--- a/packages/effect/test/unstable/http/HttpServerRequest.test.ts
+++ b/packages/effect/test/unstable/http/HttpServerRequest.test.ts
@@ -116,6 +116,23 @@ describe("HttpServerRequest", () => {
       assert.strictEqual(yield* server.text, "abc")
     }))
 
+  it.effect("reads raw BodyInit bytes after conversion from a client request", () =>
+    Effect.gen(function*() {
+      const client = HttpClientRequest.setBody(HttpClientRequest.post("https://example.com"), HttpBody.raw("abc"))
+      const server = HttpServerRequest.fromClientRequest(client)
+      assert.deepStrictEqual(new Uint8Array(yield* server.arrayBuffer), new Uint8Array([97, 98, 99]))
+    }))
+
+  it.effect("streams a raw URLSearchParams after conversion from a client request", () =>
+    Effect.gen(function*() {
+      const client = HttpClientRequest.setBody(
+        HttpClientRequest.post("https://example.com"),
+        HttpBody.raw(new URLSearchParams({ a: "1", b: "two" }))
+      )
+      const server = HttpServerRequest.fromClientRequest(client)
+      assert.strictEqual(yield* server.stream.pipe(Stream.decodeText(), Stream.mkString), "a=1&b=two")
+    }))
+
   it.effect("schemaBodyJson applies parse options", () =>
     Effect.gen(function*() {
       const request = HttpServerRequest.fromWeb(


### PR DESCRIPTION
## Summary

fromClientRequest preserves a raw string body, but reading it through the server request body accessors fails with HttpServerError(RequestParseError) instead of returning its bytes or text.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Client request conversion rejects ordinary raw BodyInit values

**Module:** `HttpServerRequest`  
**Audit ID:** `unstable-http-httpserverrequest-raw-body`  
**Severity / confidence:** medium / high

### What happens

fromClientRequest preserves a raw string body, but reading it through the server request body accessors fails with HttpServerError(RequestParseError) instead of returning its bytes or text.

### Why it happens

HttpBody.raw accepts runtime body values, and strings are valid Fetch BodyInit values, but rawBodyStream only supports Request, FormData, and ReadableStream, while rawBodyBytes only supports Blob and Request. A raw string therefore fails as an unsupported body type.

### Expected behavior

fromClientRequest preserves a client's body and exposes it through the server request body accessors.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/http/HttpServerRequest.ts:733-784`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/http/HttpServerRequest.ts#L733-L784)
- [`packages/effect/src/unstable/http/HttpServerRequest.ts:862-886`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/http/HttpServerRequest.ts#L862-L886)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/http/HttpServerRequest.ts:733-782</code></summary>

```ts
  get stream(): Stream.Stream<Uint8Array, HttpServerError> {
    const body = this.source.body
    switch (body._tag) {
      case "Empty": {
        return Stream.empty
      }
      case "Uint8Array": {
        return Stream.succeed(body.body)
      }
      case "Stream": {
        return Stream.mapError(body.stream, (cause) => requestParseError(this, undefined, cause))
      }
      case "FormData": {
        return streamFromReadable(this, new Response(body.formData).body)
      }
      case "Raw": {
        return rawBodyStream(this, body.body)
      }
    }
  }

  private bytesEffect: Effect.Effect<Uint8Array, HttpServerError> | undefined
  private get bytes(): Effect.Effect<Uint8Array, HttpServerError> {
    if (this.bytesEffect) {
      return this.bytesEffect
    }
    const body = this.source.body
    let effect: Effect.Effect<Uint8Array, HttpServerError>
    switch (body._tag) {
      case "Empty": {
        effect = Effect.succeed(new Uint8Array(0))
        break
      }
      case "Uint8Array": {
        effect = Effect.succeed(body.body)
        break
      }
      case "FormData": {
        effect = bytesFromBodyInit(this, body.formData)
        break
      }
      case "Stream": {
        effect = Stream.mkUint8Array(this.stream)
        break
      }
      case "Raw": {
        effect = rawBodyBytes(this, body.body)
        break
      }
    }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/http/HttpServerRequest.ts#L733-L784)

_Excerpt truncated. [Open the complete packages/effect/src/unstable/http/HttpServerRequest.ts:733-784 range.](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/http/HttpServerRequest.ts#L733-L784)_

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/http/HttpServerRequest.ts:862-886</code></summary>

```ts
const rawBodyStream = (request: HttpServerRequest, body: unknown): Stream.Stream<Uint8Array, HttpServerError> => {
  if (body instanceof Request) {
    return streamFromReadable(request, body.body)
  }
  if (isFormData(body)) {
    return streamFromReadable(request, new Response(body).body)
  }
  if (isReadableStream(body)) {
    return streamFromReadable(request, body)
  }
  return Stream.fail(requestParseError(request, "Unsupported body type"))
}

const rawBodyBytes = (request: HttpServerRequest, body: unknown): Effect.Effect<Uint8Array, HttpServerError> => {
  if (body instanceof Blob) {
    return bytesFromBodyInit(request, body)
  }
  if (body instanceof Request) {
    return Effect.tryPromise({
      try: () => body.arrayBuffer().then((buffer) => new Uint8Array(buffer)),
      catch: (cause) => requestParseError(request, undefined, cause)
    })
  }
  return Effect.fail(requestParseError(request, "Unsupported body type"))
}
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/http/HttpServerRequest.ts#L862-L886)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/http/HttpServerRequest.test.ts
```

**Observed failure:** Failed as intended with HttpServerError(RequestParseError): Unsupported body type.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/http/HttpServerRequest.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-http-httpserverrequest-raw-body`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-426
