### PR TITLE
Generate unique paths for duplicate multipart filenames

### DIFF
--- a/.changeset/tender-points-sleep.md
+++ b/.changeset/tender-points-sleep.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Generate unique persisted paths for multipart files with duplicate filenames.

--- a/packages/effect/src/unstable/http/Multipart.ts
+++ b/packages/effect/src/unstable/http/Multipart.ts
@@ -678,6 +678,7 @@ export const toPersisted = (
     const path_ = yield* Path.Path
     const dir = yield* fs.makeTempDirectoryScoped()
     const persisted: Record<string, Array<PersistedFile> | Array<string> | string> = Object.create(null)
+    let fileIndex = 0
     yield* Stream.runForEach(stream, (part) => {
       if (part._tag === "Field") {
         if (!(part.key in persisted)) {
@@ -692,7 +693,7 @@ export const toPersisted = (
         return Effect.void
       }
       const file = part
-      const path = path_.join(dir, path_.basename(file.name).slice(-128))
+      const path = path_.join(dir, `${fileIndex++}-${path_.basename(file.name).slice(-128)}`)
       const filePart = new PersistedFileImpl(
         file.key,
         file.name,

--- a/packages/effect/src/unstable/http/Multipart.ts
+++ b/packages/effect/src/unstable/http/Multipart.ts
@@ -678,6 +678,7 @@ export const toPersisted = (
     const path_ = yield* Path.Path
     const dir = yield* fs.makeTempDirectoryScoped()
     const persisted: Record<string, Array<PersistedFile> | Array<string> | string> = Object.create(null)
+    const usedPaths = new Set<string>()
     let fileIndex = 0
     yield* Stream.runForEach(stream, (part) => {
       if (part._tag === "Field") {
@@ -693,7 +694,12 @@ export const toPersisted = (
         return Effect.void
       }
       const file = part
-      const path = path_.join(dir, `${fileIndex++}-${path_.basename(file.name).slice(-128)}`)
+      const fileName = path_.basename(file.name).slice(-128)
+      let path = path_.join(dir, fileName)
+      while (usedPaths.has(path)) {
+        path = path_.join(dir, `${fileIndex++}-${fileName}`)
+      }
+      usedPaths.add(path)
       const filePart = new PersistedFileImpl(
         file.key,
         file.name,

--- a/packages/effect/test/unstable/http/Multipart.test.ts
+++ b/packages/effect/test/unstable/http/Multipart.test.ts
@@ -1,8 +1,8 @@
 import { describe, it } from "@effect/vitest"
-import { Effect, ErrorReporter, identity, Schema, Stream, Unify } from "effect"
-import { Multipart } from "effect/unstable/http"
+import { Effect, ErrorReporter, FileSystem, identity, Path, Schema, Stream, Unify } from "effect"
+import { HttpClientRequest, HttpServerRequest, Multipart } from "effect/unstable/http"
 import * as HttpServerRespondable from "effect/unstable/http/HttpServerRespondable"
-import { deepStrictEqual, strictEqual } from "node:assert"
+import { deepStrictEqual, notStrictEqual, strictEqual } from "node:assert"
 
 describe("Multipart", () => {
   it.effect("parses fields and streams file content", () =>
@@ -59,6 +59,27 @@ describe("Multipart", () => {
       strictEqual(error._tag, "MultipartError")
       strictEqual(error.reason._tag, "TooManyParts")
     }))
+
+  it.effect("uses distinct persisted paths for files with the same client filename", () =>
+    Effect.scoped(Effect.gen(function*() {
+      const formData = new FormData()
+      formData.append("first", new File(["one"], "same.txt"))
+      formData.append("second", new File(["two"], "same.txt"))
+      const request = HttpServerRequest.fromClientRequest(
+        HttpClientRequest.bodyFormData(HttpClientRequest.post("https://example.com"), formData)
+      )
+      const writes: Array<string> = []
+      yield* Multipart.toPersisted(
+        request.multipartStream,
+        (path) => Effect.sync(() => writes.push(path))
+      ).pipe(
+        Effect.provideService(FileSystem.FileSystem, {
+          makeTempDirectoryScoped: () => Effect.succeed("/tmp/audit")
+        } as any),
+        Effect.provide(Path.layer)
+      )
+      notStrictEqual(writes[0], writes[1])
+    })))
 
   it.effect("responds based on the reason and is ignored by the ErrorReporter", () =>
     Effect.gen(function*() {

--- a/packages/effect/test/unstable/http/Multipart.test.ts
+++ b/packages/effect/test/unstable/http/Multipart.test.ts
@@ -60,7 +60,7 @@ describe("Multipart", () => {
       strictEqual(error.reason._tag, "TooManyParts")
     }))
 
-  it.effect("uses distinct persisted paths for files with the same client filename", () =>
+  it.effect("returns distinct persisted file paths for files with the same client filename", () =>
     Effect.scoped(Effect.gen(function*() {
       const formData = new FormData()
       formData.append("first", new File(["one"], "same.txt"))
@@ -69,16 +69,22 @@ describe("Multipart", () => {
         HttpClientRequest.bodyFormData(HttpClientRequest.post("https://example.com"), formData)
       )
       const writes: Array<string> = []
-      yield* Multipart.toPersisted(
+      const persisted = yield* Multipart.toPersisted(
         request.multipartStream,
         (path) => Effect.sync(() => writes.push(path))
       ).pipe(
-        Effect.provideService(FileSystem.FileSystem, {
-          makeTempDirectoryScoped: () => Effect.succeed("/tmp/audit")
-        } as any),
+        Effect.provideService(
+          FileSystem.FileSystem,
+          FileSystem.makeNoop({
+            makeTempDirectoryScoped: () => Effect.succeed("/tmp/audit")
+          })
+        ),
         Effect.provide(Path.layer)
       )
-      notStrictEqual(writes[0], writes[1])
+      const first = (persisted.first as Array<Multipart.PersistedFile>)[0]
+      const second = (persisted.second as Array<Multipart.PersistedFile>)[0]
+      notStrictEqual(first.path, second.path)
+      deepStrictEqual(writes, [first.path, second.path])
     })))
 
   it.effect("responds based on the reason and is ignored by the ErrorReporter", () =>

--- a/packages/effect/test/unstable/http/Multipart.test.ts
+++ b/packages/effect/test/unstable/http/Multipart.test.ts
@@ -83,6 +83,7 @@ describe("Multipart", () => {
       )
       const first = (persisted.first as Array<Multipart.PersistedFile>)[0]
       const second = (persisted.second as Array<Multipart.PersistedFile>)[0]
+      strictEqual(first.path, "/tmp/audit/same.txt")
       notStrictEqual(first.path, second.path)
       deepStrictEqual(writes, [first.path, second.path])
     })))


### PR DESCRIPTION
## Summary

Two ordinary file parts named same.txt receive the same persisted path, so the later write replaces the bytes referenced by both returned PersistedFile values and silently loses one file.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Equal multipart filenames overwrite each other during persistence

**Module:** `Multipart`  
**Audit ID:** `unstable-http-multipart-filename-collision`  
**Severity / confidence:** medium / high

### What happens

Two ordinary file parts named same.txt receive the same persisted path, so the later write replaces the bytes referenced by both returned PersistedFile values and silently loses one file.

### Why it happens

Each file path is derived only as join(tempDir, basename(file.name).slice(-128)). Parts with equal filenames are written sequentially to one path, and both returned values point to the final write.

### Expected behavior

toPersisted must preserve every valid multipart file part and return a path containing that part's bytes for the scope lifetime.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/http/Multipart.ts:672-708`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/http/Multipart.ts#L672-L708)
- [`packages/effect/src/unstable/http/Multipart.ts:695`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/http/Multipart.ts#L695)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/http/Multipart.ts:672-708</code></summary>

```ts
export const toPersisted = (
  stream: Stream.Stream<Part, MultipartError>,
  writeFile = defaultWriteFile
): Effect.Effect<Persisted, MultipartError, FileSystem.FileSystem | Path.Path | Scope.Scope> =>
  Effect.gen(function*() {
    const fs = yield* FileSystem.FileSystem
    const path_ = yield* Path.Path
    const dir = yield* fs.makeTempDirectoryScoped()
    const persisted: Record<string, Array<PersistedFile> | Array<string> | string> = Object.create(null)
    yield* Stream.runForEach(stream, (part) => {
      if (part._tag === "Field") {
        if (!(part.key in persisted)) {
          persisted[part.key] = part.value
        } else if (typeof persisted[part.key] === "string") {
          persisted[part.key] = [persisted[part.key] as string, part.value]
        } else {
          ;(persisted[part.key] as Array<string>).push(part.value)
        }
        return Effect.void
      } else if (part.name === "") {
        return Effect.void
      }
      const file = part
      const path = path_.join(dir, path_.basename(file.name).slice(-128))
      const filePart = new PersistedFileImpl(
        file.key,
        file.name,
        file.contentType,
        path
      )
      if (Array.isArray(persisted[part.key])) {
        ;(persisted[part.key] as Array<PersistedFile>).push(filePart)
      } else {
        persisted[part.key] = [filePart]
      }
      return writeFile(path, file)
    })
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/http/Multipart.ts#L672-L708)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/http/Multipart.ts:695</code></summary>

```ts
      const path = path_.join(dir, path_.basename(file.name).slice(-128))
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/http/Multipart.ts#L695)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/http/Multipart.test.ts
```

**Observed failure:** Failed as intended because both writes used /tmp/audit/same.txt and the returned paths were equal.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/http/Multipart.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-http-multipart-filename-collision`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-427