### PR TITLE
Return selected rows from React Native SQLite value queries

### DIFF
--- a/.changeset/fix-react-native-sqlite-values.md
+++ b/.changeset/fix-react-native-sqlite-values.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-sqlite-react-native": patch
+---
+
+Return selected rows from synchronous and asynchronous value queries.

--- a/packages/sql/sqlite-react-native/src/SqliteClient.ts
+++ b/packages/sql/sqlite-react-native/src/SqliteClient.ts
@@ -143,8 +143,7 @@ export const make = (
 
       const run = (
         sql: string,
-        params: ReadonlyArray<unknown> = [],
-        values = false
+        params: ReadonlyArray<unknown> = []
       ) =>
         Effect.withFiber<Array<any>, SqlError>((fiber) => {
           if (fiber.getRef(AsyncQuery)) {
@@ -154,14 +153,29 @@ export const make = (
                 catch: (cause) =>
                   new SqlError({ reason: classifyError(cause, "Failed to execute statement (async)", "execute") })
               }),
-              (result) => values ? result.rawRows ?? [] : result.rows
+              (result) => result.rows
             )
           }
           return Effect.try({
-            try: () => {
-              const result = db.executeSync(sql, params as Array<any>)
-              return values ? result.rawRows ?? [] : result.rows
-            },
+            try: () => db.executeSync(sql, params as Array<any>).rows,
+            catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
+          })
+        })
+
+      const runValues = (
+        sql: string,
+        params: ReadonlyArray<unknown> = []
+      ) =>
+        Effect.withFiber<Array<any>, SqlError>((fiber) => {
+          if (fiber.getRef(AsyncQuery)) {
+            return Effect.tryPromise({
+              try: () => db.executeRaw(sql, params as Array<any>),
+              catch: (cause) =>
+                new SqlError({ reason: classifyError(cause, "Failed to execute statement (async)", "execute") })
+            })
+          }
+          return Effect.try({
+            try: () => db.executeRawSync(sql, params as Array<any>),
             catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
           })
         })
@@ -176,10 +190,10 @@ export const make = (
           return run(sql, params)
         },
         executeValues(sql, params) {
-          return run(sql, params, true)
+          return runValues(sql, params)
         },
         executeValuesUnprepared(sql, params) {
-          return run(sql, params, true)
+          return runValues(sql, params)
         },
         executeUnprepared(sql, params, transformRows) {
           return this.execute(sql, params, transformRows)

--- a/packages/sql/sqlite-react-native/test/Client.test.ts
+++ b/packages/sql/sqlite-react-native/test/Client.test.ts
@@ -1,6 +1,29 @@
-import { describe, it } from "@effect/vitest"
+import { assert, describe, it } from "@effect/vitest"
 import { Effect } from "effect"
+import { Reactivity } from "effect/unstable/reactivity"
+import { vi } from "vitest"
+
+const state = vi.hoisted(() => ({
+  database: {
+    close() {},
+    execute: async () => ({ rowsAffected: 0, rows: [{ value: 1 }] }),
+    executeSync: () => ({ rowsAffected: 0, rows: [{ value: 1 }] })
+  }
+}))
+
+vi.mock("@op-engineering/op-sqlite", () => ({
+  open: () => state.database
+}))
+
+import { SqliteClient } from "@effect/sql-sqlite-react-native"
 
 describe("Client", () => {
   it.effect("should work", () => Effect.void)
+
+  it.effect("returns array rows from values queries", () =>
+    Effect.gen(function*() {
+      const sql = yield* SqliteClient.make({ filename: "test.db" })
+      const rows = yield* sql`SELECT 1 AS value`.values
+      assert.deepStrictEqual(rows, [[1]])
+    }).pipe(Effect.provide(Reactivity.layer)))
 })

--- a/packages/sql/sqlite-react-native/test/Client.test.ts
+++ b/packages/sql/sqlite-react-native/test/Client.test.ts
@@ -7,6 +7,8 @@ const state = vi.hoisted(() => ({
   database: {
     close() {},
     execute: async () => ({ rowsAffected: 0, rows: [{ value: 1 }] }),
+    executeRaw: async () => [[1]],
+    executeRawSync: () => [[1]],
     executeSync: () => ({ rowsAffected: 0, rows: [{ value: 1 }] })
   }
 }))
@@ -20,10 +22,21 @@ import { SqliteClient } from "@effect/sql-sqlite-react-native"
 describe("Client", () => {
   it.effect("should work", () => Effect.void)
 
-  it.effect("returns array rows from values queries", () =>
+  it.effect("returns array rows from synchronous values queries", () =>
     Effect.gen(function*() {
       const sql = yield* SqliteClient.make({ filename: "test.db" })
       const rows = yield* sql`SELECT 1 AS value`.values
+      const unpreparedRows = yield* sql`SELECT 1 AS value`.valuesUnprepared
       assert.deepStrictEqual(rows, [[1]])
+      assert.deepStrictEqual(unpreparedRows, [[1]])
+    }).pipe(Effect.provide(Reactivity.layer)))
+
+  it.effect("returns array rows from asynchronous values queries", () =>
+    Effect.gen(function*() {
+      const sql = yield* SqliteClient.make({ filename: "test.db" })
+      const rows = yield* SqliteClient.withAsyncQuery(sql`SELECT 1 AS value`.values)
+      const unpreparedRows = yield* SqliteClient.withAsyncQuery(sql`SELECT 1 AS value`.valuesUnprepared)
+      assert.deepStrictEqual(rows, [[1]])
+      assert.deepStrictEqual(unpreparedRows, [[1]])
     }).pipe(Effect.provide(Reactivity.layer)))
 })


### PR DESCRIPTION
## Summary

Successful synchronous and asynchronous value queries read a missing rawRows property and return an empty array instead of selected values.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Value queries discard selected rows

**Module:** `sqlite-react-native/SqliteClient`  
**Audit ID:** `sql-adapters-rn-1`  
**Severity / confidence:** high / high

### What happens

Successful synchronous and asynchronous value queries read a missing rawRows property and return an empty array instead of selected values.

### Why it happens

The implementation calls execute or executeSync, which return object rows, but then reads rawRows supplied only by executeRaw or executeRawSync.

### Expected behavior

values and valuesUnprepared must return selected rows as arrays.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/sql/sqlite-react-native/src/SqliteClient.ts:144-167`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/sql/sqlite-react-native/src/SqliteClient.ts#L144-L167)
- [`packages/sql/sqlite-react-native/src/SqliteClient.ts:178-183`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/sql/sqlite-react-native/src/SqliteClient.ts#L178-L183)

<details>
<summary>View problematic code at <code>packages/sql/sqlite-react-native/src/SqliteClient.ts:144-167</code></summary>

```ts
      const run = (
        sql: string,
        params: ReadonlyArray<unknown> = [],
        values = false
      ) =>
        Effect.withFiber<Array<any>, SqlError>((fiber) => {
          if (fiber.getRef(AsyncQuery)) {
            return Effect.map(
              Effect.tryPromise({
                try: () => db.execute(sql, params as Array<any>),
                catch: (cause) =>
                  new SqlError({ reason: classifyError(cause, "Failed to execute statement (async)", "execute") })
              }),
              (result) => values ? result.rawRows ?? [] : result.rows
            )
          }
          return Effect.try({
            try: () => {
              const result = db.executeSync(sql, params as Array<any>)
              return values ? result.rawRows ?? [] : result.rows
            },
            catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
          })
        })
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/sql/sqlite-react-native/src/SqliteClient.ts#L144-L167)

</details>
<details>
<summary>View problematic code at <code>packages/sql/sqlite-react-native/src/SqliteClient.ts:178-183</code></summary>

```ts
        executeValues(sql, params) {
          return run(sql, params, true)
        },
        executeValuesUnprepared(sql, params) {
          return run(sql, params, true)
        },
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/sql/sqlite-react-native/src/SqliteClient.ts#L178-L183)

</details>

### Reproduction

```sh
pnpm test --run packages/sql/sqlite-react-native/test/Client.test.ts
```

**Observed failure:** FAIL: the values query returned [] instead of [[1]].

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/sql/sqlite-react-native/test/Client.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `sql-adapters-rn-1`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-429