### PR TITLE
Enforce read-only mode when opening Bun SQLite databases

### DIFF
--- a/.changeset/read-only-bun-sqlite.md
+++ b/.changeset/read-only-bun-sqlite.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-sqlite-bun": patch
+---
+
+Enforce read-only mode when opening Bun SQLite databases.

--- a/packages/sql/sqlite-bun/src/SqliteClient.ts
+++ b/packages/sql/sqlite-bun/src/SqliteClient.ts
@@ -115,14 +115,15 @@ export const make = (
       undefined
 
     const makeConnection = Effect.gen(function*() {
+      const readonly = options.readonly === true
       const db = new Database(options.filename, {
-        readonly: options.readonly,
-        readwrite: options.readwrite ?? true,
-        create: options.create ?? true
+        readonly,
+        readwrite: readonly ? false : options.readwrite ?? true,
+        create: readonly ? false : options.create ?? true
       } as any)
       yield* Effect.addFinalizer(() => Effect.sync(() => db.close()))
 
-      if (options.disableWAL !== true) {
+      if (options.disableWAL !== true && !readonly) {
         db.run("PRAGMA journal_mode = WAL;")
       }
 

--- a/packages/sql/sqlite-bun/test/Client.test.ts
+++ b/packages/sql/sqlite-bun/test/Client.test.ts
@@ -1,6 +1,28 @@
-import { describe, it } from "@effect/vitest"
+import { Database } from "bun:sqlite"
+import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
+import { Reactivity } from "effect/unstable/reactivity"
+import * as SqliteClient from "../src/SqliteClient.ts"
 
 describe("Client", () => {
-  it.effect("should work", () => Effect.void)
+  test("should work", () => Effect.runPromise(Effect.void))
+
+  test("readonly clients reject writes", async () => {
+    const filename = `/tmp/effect-sqlite-bun-readonly-${crypto.randomUUID()}.db`
+    const db = new Database(filename, { create: true })
+    db.run("CREATE TABLE test (id INTEGER PRIMARY KEY)")
+    db.close()
+
+    try {
+      const write = Effect.scoped(
+        Effect.gen(function*() {
+          const sql = yield* SqliteClient.make({ filename, readonly: true })
+          yield* sql`INSERT INTO test DEFAULT VALUES`
+        })
+      ).pipe(Effect.provide(Reactivity.layer), Effect.runPromise)
+      await expect(write).rejects.toBeDefined()
+    } finally {
+      await Bun.file(filename).delete()
+    }
+  })
 })

--- a/packages/sql/sqlite-bun/test/Client.test.ts
+++ b/packages/sql/sqlite-bun/test/Client.test.ts
@@ -1,28 +1,35 @@
-import { Database } from "bun:sqlite"
-import { describe, expect, test } from "bun:test"
+import { assert, describe, it } from "@effect/vitest"
 import { Effect } from "effect"
 import { Reactivity } from "effect/unstable/reactivity"
-import * as SqliteClient from "../src/SqliteClient.ts"
+import { rm } from "node:fs/promises"
+
+const isBun = "bun" in process.versions
 
 describe("Client", () => {
-  test("should work", () => Effect.runPromise(Effect.void))
+  it.effect("should work", () => Effect.void)
 
-  test("readonly clients reject writes", async () => {
-    const filename = `/tmp/effect-sqlite-bun-readonly-${crypto.randomUUID()}.db`
-    const db = new Database(filename, { create: true })
-    db.run("CREATE TABLE test (id INTEGER PRIMARY KEY)")
-    db.close()
+  it.effect.skipIf(!isBun)("readonly clients reject writes", () =>
+    Effect.gen(function*() {
+      const { SqliteClient } = yield* Effect.promise(() => import("@effect/sql-sqlite-bun"))
+      const filename = `/tmp/effect-sqlite-bun-readonly-${crypto.randomUUID()}.db`
+      yield* Effect.acquireRelease(
+        Effect.void,
+        () => Effect.promise(() => rm(filename, { force: true }))
+      )
 
-    try {
-      const write = Effect.scoped(
+      yield* Effect.scoped(
         Effect.gen(function*() {
-          const sql = yield* SqliteClient.make({ filename, readonly: true })
-          yield* sql`INSERT INTO test DEFAULT VALUES`
+          const sql = yield* SqliteClient.make({ filename })
+          yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY)`
         })
-      ).pipe(Effect.provide(Reactivity.layer), Effect.runPromise)
-      await expect(write).rejects.toBeDefined()
-    } finally {
-      await Bun.file(filename).delete()
-    }
-  })
+      )
+
+      const sql = yield* SqliteClient.make({ filename, readonly: true })
+      assert.deepStrictEqual(yield* sql`SELECT * FROM test`, [])
+
+      const error = yield* Effect.flip(sql`INSERT INTO test DEFAULT VALUES`)
+      assert.strictEqual(error._tag, "SqlError")
+      assert(error.reason.cause instanceof Error)
+      assert.match(error.reason.cause.message, /attempt to write a readonly database/i)
+    }).pipe(Effect.provide(Reactivity.layer)))
 })


### PR DESCRIPTION
## Summary

A client created with readonly: true permits writes under the default configuration.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## readonly mode still opens a writable database

**Module:** `sqlite-bun/SqliteClient`  
**Audit ID:** `sql-adapters-sb-1`  
**Severity / confidence:** high / high

### What happens

A client created with readonly: true permits writes under the default configuration.

### Why it happens

Construction passes readonly: true while independently defaulting readwrite to true, and Bun's read/write flag wins.

### Expected behavior

SqliteClientConfig.readonly must enforce the public read-only open mode.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/sql/sqlite-bun/src/SqliteClient.ts:117-127`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/sql/sqlite-bun/src/SqliteClient.ts#L117-L127)

<details>
<summary>View problematic code at <code>packages/sql/sqlite-bun/src/SqliteClient.ts:117-127</code></summary>

```ts
    const makeConnection = Effect.gen(function*() {
      const db = new Database(options.filename, {
        readonly: options.readonly,
        readwrite: options.readwrite ?? true,
        create: options.create ?? true
      } as any)
      yield* Effect.addFinalizer(() => Effect.sync(() => db.close()))

      if (options.disableWAL !== true) {
        db.run("PRAGMA journal_mode = WAL;")
      }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/sql/sqlite-bun/src/SqliteClient.ts#L117-L127)

</details>

### Reproduction

```sh
bun test packages/sql/sqlite-bun/test/Client.test.ts
```

**Observed failure:** A write through the readonly client completed successfully.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
bun test packages/sql/sqlite-bun/test/Client.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `8f9499f562729f5f7b08d8bcc4db86b4aeff8a21`
- Findings: `sql-adapters-sb-1`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-430