### PR TITLE
Return MSSQL procedure values through the output property

### DIFF
--- a/.changeset/good-cups-reply.md
+++ b/.changeset/good-cups-reply.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-mssql": patch
+---
+
+Return MSSQL procedure values through the output property.

--- a/packages/sql/mssql/src/MssqlClient.ts
+++ b/packages/sql/mssql/src/MssqlClient.ts
@@ -396,7 +396,7 @@ export const make = (
                 }
                 resume(
                   Effect.succeed({
-                    params: result,
+                    output: result,
                     rows
                   })
                 )

--- a/packages/sql/mssql/test/Client.test.ts
+++ b/packages/sql/mssql/test/Client.test.ts
@@ -3,11 +3,14 @@ import { assert, describe, expect, it } from "@effect/vitest"
 import { Effect } from "effect"
 import * as Reactivity from "effect/unstable/reactivity/Reactivity"
 import * as Statement from "effect/unstable/sql/Statement"
+import type * as Tedious from "tedious"
 import { vi } from "vitest"
 
 const state = vi.hoisted(() => ({ type: {} }))
 
-vi.mock("tedious", () => {
+vi.mock("tedious", async (importOriginal) => {
+  const original = await importOriginal<typeof Tedious>()
+
   class MockRequest {
     readonly listeners: Record<string, (...args: Array<any>) => void> = {}
 
@@ -52,16 +55,9 @@ vi.mock("tedious", () => {
   }
 
   return {
+    ...original,
     Connection: MockConnection,
-    Request: MockRequest,
-    TYPES: {
-      VarChar: state.type,
-      Int: state.type,
-      BigInt: state.type,
-      Bit: state.type,
-      DateTime: state.type,
-      VarBinary: state.type
-    }
+    Request: MockRequest
   }
 })
 

--- a/packages/sql/mssql/test/Client.test.ts
+++ b/packages/sql/mssql/test/Client.test.ts
@@ -1,7 +1,57 @@
-import { MssqlClient } from "@effect/sql-mssql"
-import { describe, expect, it } from "@effect/vitest"
+import { MssqlClient, Procedure } from "@effect/sql-mssql"
+import { assert, describe, expect, it } from "@effect/vitest"
 import { Effect } from "effect"
+import * as Reactivity from "effect/unstable/reactivity/Reactivity"
 import * as Statement from "effect/unstable/sql/Statement"
+import { vi } from "vitest"
+
+const state = vi.hoisted(() => ({ type: {} }))
+
+vi.mock("tedious", () => {
+  class MockRequest {
+    readonly listeners: Record<string, (...args: Array<any>) => void> = {}
+
+    constructor(
+      readonly sql: string,
+      readonly callback: (cause: unknown, rowCount: number, rows: ReadonlyArray<any>) => void
+    ) {}
+
+    addParameter() {}
+    addOutputParameter() {}
+    on(event: string, listener: (...args: Array<any>) => void) {
+      this.listeners[event] = listener
+    }
+  }
+
+  class MockConnection {
+    connect(callback: (cause: unknown) => void) { callback(null) }
+    close() {}
+    on() {}
+    cancel() {}
+    execSql(request: MockRequest) { request.callback(null, 0, []) }
+    callProcedure(request: MockRequest) {
+      request.listeners.returnValue("answer", 42)
+      request.callback(null, 0, [])
+    }
+    beginTransaction(callback: (cause: unknown) => void) { callback(null) }
+    commitTransaction(callback: (cause: unknown) => void) { callback(null) }
+    saveTransaction(callback: (cause: unknown) => void) { callback(null) }
+    rollbackTransaction(callback: (cause: unknown) => void) { callback(null) }
+  }
+
+  return {
+    Connection: MockConnection,
+    Request: MockRequest,
+    TYPES: {
+      VarChar: state.type,
+      Int: state.type,
+      BigInt: state.type,
+      Bit: state.type,
+      DateTime: state.type,
+      VarBinary: state.type
+    }
+  }
+})
 
 const sql = Statement.make(Effect.void as any, MssqlClient.makeCompiler(), [], undefined)
 
@@ -88,4 +138,16 @@ describe("mssql", () => {
     const [query] = sql`SELECT * FROM ${sql("peo[]ple.te[st]ing")}`.compile()
     expect(query).toEqual(`SELECT * FROM [peo[]]ple].[te[st]]ing]`)
   })
+
+  it.effect("returns stored procedure output parameters under output", () =>
+    Effect.gen(function*() {
+      const client = yield* MssqlClient.make({ server: "localhost" })
+      const definition = Procedure.outputParam<number>()("answer", state.type as any)(Procedure.make("get_answer"))
+      const result = yield* client.call(Procedure.compile(definition)({}))
+
+      assert.deepStrictEqual(result, { output: { answer: 42 }, rows: [] })
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(Reactivity.layer)
+    ))
 })

--- a/packages/sql/mssql/test/Client.test.ts
+++ b/packages/sql/mssql/test/Client.test.ts
@@ -24,19 +24,31 @@ vi.mock("tedious", () => {
   }
 
   class MockConnection {
-    connect(callback: (cause: unknown) => void) { callback(null) }
+    connect(callback: (cause: unknown) => void) {
+      callback(null)
+    }
     close() {}
     on() {}
     cancel() {}
-    execSql(request: MockRequest) { request.callback(null, 0, []) }
+    execSql(request: MockRequest) {
+      request.callback(null, 0, [])
+    }
     callProcedure(request: MockRequest) {
       request.listeners.returnValue("answer", 42)
       request.callback(null, 0, [])
     }
-    beginTransaction(callback: (cause: unknown) => void) { callback(null) }
-    commitTransaction(callback: (cause: unknown) => void) { callback(null) }
-    saveTransaction(callback: (cause: unknown) => void) { callback(null) }
-    rollbackTransaction(callback: (cause: unknown) => void) { callback(null) }
+    beginTransaction(callback: (cause: unknown) => void) {
+      callback(null)
+    }
+    commitTransaction(callback: (cause: unknown) => void) {
+      callback(null)
+    }
+    saveTransaction(callback: (cause: unknown) => void) {
+      callback(null)
+    }
+    rollbackTransaction(callback: (cause: unknown) => void) {
+      callback(null)
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary

Successful stored procedure output values are returned under params, leaving the exported and documented result.output property undefined.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Procedure output uses the wrong result property

**Module:** `mssql/MssqlClient`  
**Audit ID:** `sql-adapters-ms-2`  
**Severity / confidence:** high / high

### What happens

Successful stored procedure output values are returned under params, leaving the exported and documented result.output property undefined.

### Why it happens

The implementation accumulates returnValue events correctly but resolves the enclosing object as { params: result, rows }.

### Expected behavior

MssqlClient.call must return stored procedure results as { output, rows }.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/sql/mssql/src/MssqlClient.ts:378-424`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/sql/mssql/src/MssqlClient.ts#L378-L424)
- [`packages/sql/mssql/src/Procedure.ts:92-104`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/sql/mssql/src/Procedure.ts#L92-L104)

<details>
<summary>View problematic code at <code>packages/sql/mssql/src/MssqlClient.ts:378-424</code></summary>

```ts
      const runProcedure = (
        procedure: Procedure.ProcedureWithValues<any, any, any>,
        transformRows: ((rows: ReadonlyArray<any>) => ReadonlyArray<any>) | undefined
      ) =>
        Effect.callback<any, SqlError>((resume) => {
          const result: Record<string, any> = {}

          const req = new Tedious.Request(
            escape(procedure.name),
            (cause, _, rows) => {
              if (cause) {
                resume(
                  Effect.fail(new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") }))
                )
              } else {
                rows = rowsToObjects(rows)
                if (transformRows) {
                  rows = transformRows(rows) as any
                }
                resume(
                  Effect.succeed({
                    params: result,
                    rows
                  })
                )
              }
            }
          )

          for (const name in procedure.params) {
            const param = procedure.params[name]
            const value = procedure.values[name]
            req.addParameter(name, param.type, value, param.options)
          }

          for (const name in procedure.outputParams) {
            const param = procedure.outputParams[name]
            req.addOutputParameter(name, param.type, undefined, param.options)
          }

          req.on("returnValue", (name, value) => {
            Rec.assignProperty(result, name, value)
          })

          conn.cancel()
          conn.callProcedure(req)
        })
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/sql/mssql/src/MssqlClient.ts#L378-L424)

</details>
<details>
<summary>View problematic code at <code>packages/sql/mssql/src/Procedure.ts:92-104</code></summary>

```ts
  /**
   * Result of a SQL Server stored procedure call, containing typed output parameter values and returned rows.
   *
   * @category models
   * @since 4.0.0
   */
  export interface Result<
    O extends Record<string, Parameter.Parameter<any>>,
    A
  > {
    readonly output: ParametersRecord<O>
    readonly rows: ReadonlyArray<A>
  }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/sql/mssql/src/Procedure.ts#L92-L104)

</details>

### Reproduction

```sh
pnpm test --run packages/sql/mssql/test/Client.test.ts
```

**Observed failure:** FAIL: the result was { params: { answer: 42 }, rows: [] }.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/sql/mssql/test/Client.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `sql-adapters-ms-2`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-432
