### PR TITLE
Encode storage primary key components without collisions

### DIFF
--- a/.changeset/fix-cluster-primary-key-collisions.md
+++ b/.changeset/fix-cluster-primary-key-collisions.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Encode cluster message storage primary key components to prevent collisions.

--- a/packages/effect/src/unstable/cluster/Envelope.ts
+++ b/packages/effect/src/unstable/cluster/Envelope.ts
@@ -417,6 +417,8 @@ export const primaryKey = <R extends Rpc.Any>(envelope: Envelope<R>): string | n
   })
 }
 
+const encodePrimaryKeyComponent = (value: string): string => value.replaceAll("%", "%25").replaceAll("/", "%2F")
+
 /**
  * Builds a storage primary-key string from an entity address, RPC tag, and
  * payload primary-key ID.
@@ -431,4 +433,6 @@ export const primaryKeyByAddress = (options: {
 }): string =>
   // storage drivers with fixed-width key columns (e.g. SqlMessageStorage)
   // hash this composed key at their own boundary
-  `${options.address.entityType}/${options.address.entityId}/${options.tag}/${options.id}`
+  `${encodePrimaryKeyComponent(options.address.entityType)}/${encodePrimaryKeyComponent(options.address.entityId)}/${
+    encodePrimaryKeyComponent(options.tag)
+  }/${encodePrimaryKeyComponent(options.id)}`

--- a/packages/effect/test/cluster/MessageStorage.test.ts
+++ b/packages/effect/test/cluster/MessageStorage.test.ts
@@ -23,7 +23,7 @@ const MemoryLive = MessageStorage.layerMemory.pipe(
 
 describe("MessageStorage", () => {
   it("keeps distinct address and RPC key tuples distinct", () => {
-    const first = Envelope.primaryKeyByAddress({
+    const firstOptions = {
       address: EntityAddress.make({
         shardId: ShardId.make("default", 1),
         entityType: EntityType.make("a/b"),
@@ -31,7 +31,8 @@ describe("MessageStorage", () => {
       }),
       tag: "d",
       id: "e"
-    })
+    }
+    const first = Envelope.primaryKeyByAddress(firstOptions)
     const second = Envelope.primaryKeyByAddress({
       address: EntityAddress.make({
         shardId: ShardId.make("default", 1),
@@ -42,6 +43,7 @@ describe("MessageStorage", () => {
       id: "e"
     })
     assert.notStrictEqual(first, second)
+    assert.strictEqual(first, Envelope.primaryKeyByAddress(firstOptions))
   })
 
   describe("memory", () => {

--- a/packages/effect/test/cluster/MessageStorage.test.ts
+++ b/packages/effect/test/cluster/MessageStorage.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "@effect/vitest"
+import { assert, describe, expect, it } from "@effect/vitest"
 import { Context, Effect, Exit, Fiber, Latch, Layer, Option, Schema } from "effect"
 import { TestClock } from "effect/testing"
 import {
@@ -22,6 +22,28 @@ const MemoryLive = MessageStorage.layerMemory.pipe(
 )
 
 describe("MessageStorage", () => {
+  it("keeps distinct address and RPC key tuples distinct", () => {
+    const first = Envelope.primaryKeyByAddress({
+      address: EntityAddress.make({
+        shardId: ShardId.make("default", 1),
+        entityType: EntityType.make("a/b"),
+        entityId: EntityId.make("c")
+      }),
+      tag: "d",
+      id: "e"
+    })
+    const second = Envelope.primaryKeyByAddress({
+      address: EntityAddress.make({
+        shardId: ShardId.make("default", 1),
+        entityType: EntityType.make("a"),
+        entityId: EntityId.make("b/c")
+      }),
+      tag: "d",
+      id: "e"
+    })
+    assert.notStrictEqual(first, second)
+  })
+
   describe("memory", () => {
     it.effect("saves a request", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Summary

Distinct valid request identities can receive the same persisted primary key and be incorrectly deduplicated.

> [!IMPORTANT]
> This PR started with focused failing reproduction tests. The implementation fix and changeset are now included.

## Storage primary keys are not injective

**Module:** `Envelope`  
**Audit ID:** `unstable-distributed-envelope-primary-key-collision`  
**Severity / confidence:** high / high

### What happens

Distinct valid request identities can receive the same persisted primary key and be incorrectly deduplicated.

### Why it happens

Four unrestricted strings are joined with slash delimiters without escaping or length framing.

### Expected behavior

Distinct entity type, entity id, tag, and id tuples must not deduplicate as the same request.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/cluster/Envelope.ts:402-434`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cluster/Envelope.ts#L402-L434)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/cluster/Envelope.ts:402-434</code></summary>

```ts
/**
 * Returns the storage primary key for a request envelope whose payload has a
 * primary key, or `null` when the envelope is not a keyed request.
 *
 * @category primary key
 * @since 4.0.0
 */
export const primaryKey = <R extends Rpc.Any>(envelope: Envelope<R>): string | null => {
  if (envelope._tag !== "Request" || !PrimaryKey.isPrimaryKey(envelope.payload)) {
    return null
  }
  return primaryKeyByAddress({
    address: envelope.address,
    tag: envelope.tag,
    id: PrimaryKey.value(envelope.payload)
  })
}

/**
 * Builds a storage primary-key string from an entity address, RPC tag, and
 * payload primary-key ID.
 *
 * @category primary key
 * @since 4.0.0
 */
export const primaryKeyByAddress = (options: {
  readonly address: EntityAddress
  readonly tag: string
  readonly id: string
}): string =>
  // storage drivers with fixed-width key columns (e.g. SqlMessageStorage)
  // hash this composed key at their own boundary
  `${options.address.entityType}/${options.address.entityId}/${options.tag}/${options.id}`
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/cluster/Envelope.ts#L402-L434)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/cluster/MessageStorage.test.ts
```

**Observed before the fix:** FAIL  
**Observed after the fix:** PASS

## Implementation

Primary-key components now escape both the slash delimiter and the percent escape marker before composition. The regression test also verifies that identical tuples remain deterministic.

Validated with:

```sh
pnpm test --run packages/effect/test/cluster/MessageStorage.test.ts
pnpm lint-fix
pnpm check
```

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-distributed-envelope-primary-key-collision`
- Initial patch: focused reproduction tests; implementation fix added in a follow-up commit

Closes EFF-433