### PR TITLE
Isolate compiled SQL fragment caches by compiler instance

### DIFF
--- a/.changeset/isolate-sql-compiler-cache.md
+++ b/.changeset/isolate-sql-compiler-cache.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Isolate compiled SQL fragment caches by compiler instance.

--- a/packages/effect/src/unstable/sql/Statement.ts
+++ b/packages/effect/src/unstable/sql/Statement.ts
@@ -799,21 +799,24 @@ export const makeCompiler = <C extends Custom<any, any, any, any> = any>(
   self.options = options
   self.dialect = options.dialect
   self.disableTransforms = false
+  self.statementCache = new WeakMap<Fragment, CompiledStatement>()
+  self.statementCacheNoTransform = new WeakMap<Fragment, CompiledStatement>()
   return self
 }
+
+type CompiledStatement = readonly [sql: string, binds: ReadonlyArray<unknown>]
 
 interface CompilerImpl extends Compiler {
   readonly options: CompilerOptions
   readonly disableTransforms: boolean
+  readonly statementCache: WeakMap<Fragment, CompiledStatement>
+  readonly statementCacheNoTransform: WeakMap<Fragment, CompiledStatement>
   compile(
     statement: Fragment,
     withoutTransform?: boolean,
     placeholderOverride?: (u: unknown) => string
-  ): readonly [sql: string, binds: ReadonlyArray<unknown>]
+  ): CompiledStatement
 }
-
-const statementCacheSymbol = Symbol.for("effect/unstable/sql/Statement/statementCache")
-const statementCacheNoTransformSymbol = Symbol.for("effect/unstable/sql/Statement/statementCacheNoTransform")
 
 const CompilerProto = {
   compile(
@@ -824,9 +827,10 @@ const CompilerProto = {
   ): readonly [sql: string, binds: ReadonlyArray<unknown>] {
     const opts = this.options
     withoutTransform = withoutTransform || this.disableTransforms
-    const cacheSymbol = withoutTransform ? statementCacheNoTransformSymbol : statementCacheSymbol
-    if (cacheSymbol in statement) {
-      return (statement as any)[cacheSymbol]
+    const cache = withoutTransform ? this.statementCacheNoTransform : this.statementCache
+    const cached = cache.get(statement)
+    if (cached !== undefined) {
+      return cached
     }
 
     const segments = statement.segments
@@ -1033,7 +1037,8 @@ const CompilerProto = {
     if (placeholderOverride !== undefined) {
       return result
     }
-    return (statement as any)[cacheSymbol] = result
+    cache.set(statement, result)
+    return result
   },
 
   get withoutTransform() {

--- a/packages/effect/test/unstable/sql/Statement.test.ts
+++ b/packages/effect/test/unstable/sql/Statement.test.ts
@@ -29,7 +29,7 @@ describe("Statement", () => {
       Statement.parameter(1)
     ])
 
-    assert.deepStrictEqual(postgres.compile(fragment), ["\"value\"$1", [1]])
-    assert.deepStrictEqual(sqlite.compile(fragment), ["\"value\"?", [1]])
+    assert.deepStrictEqual(postgres.compile(fragment, false), ["\"value\"$1", [1]])
+    assert.deepStrictEqual(sqlite.compile(fragment, false), ["\"value\"?", [1]])
   })
 })

--- a/packages/effect/test/unstable/sql/Statement.test.ts
+++ b/packages/effect/test/unstable/sql/Statement.test.ts
@@ -14,4 +14,22 @@ describe("Statement", () => {
     assert.deepStrictEqual(nested.array([[row]]), [[{ OWN: 2 }]])
     assert.deepStrictEqual(flat.array([row]), [{ OWN: 2 }])
   })
+
+  it("compiles one fragment independently for each compiler", () => {
+    const postgres = Statement.makeCompiler({
+      dialect: "pg",
+      placeholder: (index) => `$${index}`,
+      onIdentifier: Statement.defaultEscape("\""),
+      onRecordUpdate: () => ["", []],
+      onCustom: () => ["", []]
+    })
+    const sqlite = Statement.makeCompilerSqlite()
+    const fragment = Statement.fragment([
+      Statement.identifier("value"),
+      Statement.parameter(1)
+    ])
+
+    assert.deepStrictEqual(postgres.compile(fragment), ["\"value\"$1", [1]])
+    assert.deepStrictEqual(sqlite.compile(fragment), ["\"value\"?", [1]])
+  })
 })


### PR DESCRIPTION
## Summary

Compiling the same fragment with a second compiler can return SQL and placeholders generated by the first compiler's dialect.

Closes EFF-434

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Fragment compilation cache crosses SQL dialects

**Module:** `Statement`  
**Audit ID:** `unstable-services-statement-compiler-cache`  
**Severity / confidence:** high / high

### What happens

Compiling the same fragment with a second compiler can return SQL and placeholders generated by the first compiler's dialect.

### Why it happens

The compiled tuple is cached directly on the fragment under a global symbol per transform mode, without isolating entries by compiler instance.

### Expected behavior

Compiler.compile must use the receiving compiler's dialect, identifier transform, placeholders, and custom handlers.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/sql/Statement.ts:815-830`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/sql/Statement.ts#L815-L830)
- [`packages/effect/src/unstable/sql/Statement.ts:1032-1036`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/sql/Statement.ts#L1032-L1036)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/sql/Statement.ts:815-830</code></summary>

```ts
const statementCacheSymbol = Symbol.for("effect/unstable/sql/Statement/statementCache")
const statementCacheNoTransformSymbol = Symbol.for("effect/unstable/sql/Statement/statementCacheNoTransform")

const CompilerProto = {
  compile(
    this: CompilerImpl,
    statement: Fragment,
    withoutTransform = false,
    placeholderOverride?: (u: unknown) => string
  ): readonly [sql: string, binds: ReadonlyArray<unknown>] {
    const opts = this.options
    withoutTransform = withoutTransform || this.disableTransforms
    const cacheSymbol = withoutTransform ? statementCacheNoTransformSymbol : statementCacheSymbol
    if (cacheSymbol in statement) {
      return (statement as any)[cacheSymbol]
    }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/sql/Statement.ts#L815-L830)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/sql/Statement.ts:1032-1036</code></summary>

```ts
    const result = [sql, binds] as const
    if (placeholderOverride !== undefined) {
      return result
    }
    return (statement as any)[cacheSymbol] = result
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/sql/Statement.ts#L1032-L1036)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/sql/Statement.test.ts
```

**Observed failure:** FAIL: SQLite compilation returned PostgreSQL SQL with a $1 placeholder.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/sql/Statement.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-services-statement-compiler-cache`
- Initial patch: focused reproduction tests; implementation fix pending
