### PR TITLE
Decode split UTF-8 sequences correctly in NDJSON streams

### DIFF
--- a/.changeset/fix-ndjson-split-utf8.md
+++ b/.changeset/fix-ndjson-split-utf8.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Decode split UTF-8 sequences correctly in NDJSON streams.

--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -128,7 +128,7 @@ export const makeNdjson = (options?: StreamOptions): RpcSerialization["Service"]
       }
       return ({
         decode: (bytes) => {
-          buffer += typeof bytes === "string" ? bytes : decoder.decode(bytes)
+          buffer += typeof bytes === "string" ? bytes : decoder.decode(bytes, { stream: true })
           let position = 0
           let nlIndex = buffer.indexOf("\n", position)
           const items: Array<unknown> = []

--- a/packages/effect/test/rpc/RpcSerialization.test.ts
+++ b/packages/effect/test/rpc/RpcSerialization.test.ts
@@ -106,7 +106,9 @@ describe("RpcSerialization", () => {
   it("ndjson decodes a multibyte character split across byte chunks", () => {
     const parser = RpcSerialization.ndjson.makeUnsafe()
     const message = { value: "\u20ac" }
-    const bytes = new TextEncoder().encode(parser.encode(message)!)
+    const encoded = parser.encode(message)
+    assert(typeof encoded === "string")
+    const bytes = new TextEncoder().encode(encoded)
     const split = bytes.indexOf(0xe2) + 1
 
     assert.deepStrictEqual(parser.decode(bytes.slice(0, split)), [])

--- a/packages/effect/test/rpc/RpcSerialization.test.ts
+++ b/packages/effect/test/rpc/RpcSerialization.test.ts
@@ -103,6 +103,16 @@ describe("RpcSerialization", () => {
     assert.deepStrictEqual(parser.decode("x".repeat(1024)), [])
   })
 
+  it("ndjson decodes a multibyte character split across byte chunks", () => {
+    const parser = RpcSerialization.ndjson.makeUnsafe()
+    const message = { value: "\u20ac" }
+    const bytes = new TextEncoder().encode(parser.encode(message)!)
+    const split = bytes.indexOf(0xe2) + 1
+
+    assert.deepStrictEqual(parser.decode(bytes.slice(0, split)), [])
+    assert.deepStrictEqual(parser.decode(bytes.slice(split)), [message])
+  })
+
   it.effect("layerNdjsonWith forwards maxBufferSize to its decoder", () =>
     Effect.gen(function*() {
       const serialization = yield* RpcSerialization.RpcSerialization


### PR DESCRIPTION
## Summary

A valid multibyte UTF-8 character split across transport chunks is replaced by invalid replacement characters before NDJSON parsing.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## NDJSON decoding corrupts split UTF-8

**Module:** `RpcSerialization`  
**Audit ID:** `unstable-services-rpc-ndjson-utf8-chunk`  
**Severity / confidence:** high / high

### What happens

A valid multibyte UTF-8 character split across transport chunks is replaced by invalid replacement characters before NDJSON parsing.

### Why it happens

Each byte chunk is finalized with TextDecoder.decode(bytes) without streaming mode, so partial multibyte sequences are replaced instead of carried into the next chunk.

### Expected behavior

A framed streaming parser must decode valid UTF-8 independently of transport chunk boundaries.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/rpc/RpcSerialization.ts:123-147`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/rpc/RpcSerialization.ts#L123-L147)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/rpc/RpcSerialization.ts:123-147</code></summary>

```ts
      const decoder = new TextDecoder()
      let buffer = ""
      const failMaxBufferSize = (maxBufferSize: number): never => {
        buffer = ""
        throw new MaxBufferSizeExceeded({ maxBufferSize })
      }
      return ({
        decode: (bytes) => {
          buffer += typeof bytes === "string" ? bytes : decoder.decode(bytes)
          let position = 0
          let nlIndex = buffer.indexOf("\n", position)
          const items: Array<unknown> = []
          while (nlIndex !== -1) {
            if (isBufferSizeExceeded(nlIndex - position, maxBufferSize)) {
              failMaxBufferSize(maxBufferSize)
            }
            const item = JSON.parse(buffer.slice(position, nlIndex))
            items.push(item)
            position = nlIndex + 1
            nlIndex = buffer.indexOf("\n", position)
          }
          buffer = buffer.slice(position)
          if (isBufferSizeExceeded(buffer.length, maxBufferSize)) {
            failMaxBufferSize(maxBufferSize)
          }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/rpc/RpcSerialization.ts#L123-L147)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/rpc/RpcSerialization.test.ts
```

**Observed failure:** FAIL: U+20AC decoded as three U+FFFD replacement characters.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/rpc/RpcSerialization.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-services-rpc-ndjson-utf8-chunk`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-435