### PR TITLE
Cancel in-flight Tedious requests when their Effects are interrupted

### DIFF
--- a/.changeset/cancel-tedious-requests.md
+++ b/.changeset/cancel-tedious-requests.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-mssql": patch
+---
+
+Cancel in-flight Tedious requests when their Effects are interrupted.

--- a/packages/sql/mssql/src/MssqlClient.ts
+++ b/packages/sql/mssql/src/MssqlClient.ts
@@ -373,6 +373,7 @@ export const make = (
 
           conn.cancel()
           conn.execSql(req)
+          return Effect.sync(() => conn.cancel())
         })
 
       const runProcedure = (
@@ -421,6 +422,7 @@ export const make = (
 
           conn.cancel()
           conn.callProcedure(req)
+          return Effect.sync(() => conn.cancel())
         })
 
       const connection = identity<MssqlConnection>({

--- a/packages/sql/mssql/test/Client.test.ts
+++ b/packages/sql/mssql/test/Client.test.ts
@@ -1,24 +1,22 @@
 import { MssqlClient, Procedure } from "@effect/sql-mssql"
 import { assert, describe, expect, it } from "@effect/vitest"
-import { Effect } from "effect"
+import { Effect, Fiber } from "effect"
 import * as Reactivity from "effect/unstable/reactivity/Reactivity"
 import * as Statement from "effect/unstable/sql/Statement"
 import type * as Tedious from "tedious"
 import { vi } from "vitest"
 
-const state = vi.hoisted(() => ({ type: {} }))
+const state = vi.hoisted(() => ({ cancelCalls: 0, completeRequests: true, type: {} }))
 
 vi.mock("tedious", async (importOriginal) => {
   const original = await importOriginal<typeof Tedious>()
 
   class MockRequest {
     readonly listeners: Record<string, (...args: Array<any>) => void> = {}
-
     constructor(
       readonly sql: string,
       readonly callback: (cause: unknown, rowCount: number, rows: ReadonlyArray<any>) => void
     ) {}
-
     addParameter() {}
     addOutputParameter() {}
     on(event: string, listener: (...args: Array<any>) => void) {
@@ -32,9 +30,13 @@ vi.mock("tedious", async (importOriginal) => {
     }
     close() {}
     on() {}
-    cancel() {}
+    cancel() {
+      state.cancelCalls++
+    }
     execSql(request: MockRequest) {
-      request.callback(null, 0, [])
+      if (state.completeRequests) {
+        request.callback(null, 0, [])
+      }
     }
     callProcedure(request: MockRequest) {
       request.listeners.returnValue("answer", 42)
@@ -166,6 +168,23 @@ describe("mssql", () => {
       const result = yield* client.call(Procedure.compile(definition)({}))
 
       assert.deepStrictEqual(result, { output: { answer: 42 }, rows: [] })
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(Reactivity.layer)
+    ))
+
+  it.effect("cancels an in-flight Tedious request when interrupted", () =>
+    Effect.gen(function*() {
+      state.cancelCalls = 0
+      state.completeRequests = true
+      const client = yield* MssqlClient.make({ server: "localhost" })
+      state.completeRequests = false
+      const fiber = yield* Effect.forkChild(client`WAITFOR DELAY '00:01:00'`)
+      yield* Effect.yieldNow
+      const callsBeforeInterrupt = state.cancelCalls
+      yield* Fiber.interrupt(fiber)
+
+      assert.strictEqual(state.cancelCalls, callsBeforeInterrupt + 1)
     }).pipe(
       Effect.scoped,
       Effect.provide(Reactivity.layer)

--- a/packages/sql/mssql/test/Client.test.ts
+++ b/packages/sql/mssql/test/Client.test.ts
@@ -13,10 +13,12 @@ vi.mock("tedious", async (importOriginal) => {
 
   class MockRequest {
     readonly listeners: Record<string, (...args: Array<any>) => void> = {}
+
     constructor(
       readonly sql: string,
       readonly callback: (cause: unknown, rowCount: number, rows: ReadonlyArray<any>) => void
     ) {}
+
     addParameter() {}
     addOutputParameter() {}
     on(event: string, listener: (...args: Array<any>) => void) {


### PR DESCRIPTION
## Summary

Interrupting a query can return its connection to the pool while Tedious is still executing on that connection.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Request interruption does not cancel Tedious

**Module:** `mssql/MssqlClient`  
**Audit ID:** `sql-adapters-ms-3`  
**Severity / confidence:** high / high

### What happens

Interrupting a query can return its connection to the pool while Tedious is still executing on that connection.

### Why it happens

The Effect.callback bridges return no interruption canceler; conn.cancel() is called only before request execution, not when the fiber is interrupted.

### Expected behavior

Interruption must stop or quarantine an in-flight request before its scoped pool lease can be reused.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/sql/mssql/src/MssqlClient.ts:336-376`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/sql/mssql/src/MssqlClient.ts#L336-L376)
- [`packages/sql/mssql/src/MssqlClient.ts:378-424`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/sql/mssql/src/MssqlClient.ts#L378-L424)

<details>
<summary>View problematic code at <code>packages/sql/mssql/src/MssqlClient.ts:336-376</code></summary>

```ts
      const run = (
        sql: string,
        values?: ReadonlyArray<any>,
        rowsAsArray = false
      ) =>
        Effect.callback<any, SqlError>((resume) => {
          const req = new Tedious.Request(sql, (cause, _rowCount, result) => {
            if (cause) {
              resume(
                Effect.fail(new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") }))
              )
              return
            }

            if (rowsAsArray) {
              result = result.map((row: any) => row.map((_: any) => _.value))
            } else {
              result = rowsToObjects(result)
            }

            resume(Effect.succeed(result))
          })

          if (values) {
            for (let i = 0, len = values.length; i < len; i++) {
              const value = values[i]
              const name = numberToParamName(i)

              if (isMssqlParam(value)) {
                req.addParameter(name, value.paramA, value.paramB, value.paramC)
              } else {
                const kind = Statement.primitiveKind(value)
                const type = parameterTypes[kind]
                req.addParameter(name, type, value)
              }
            }
          }

          conn.cancel()
          conn.execSql(req)
        })
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/sql/mssql/src/MssqlClient.ts#L336-L376)

</details>
<details>
<summary>View problematic code at <code>packages/sql/mssql/src/MssqlClient.ts:378-424</code></summary>

```ts
      const runProcedure = (
        procedure: Procedure.ProcedureWithValues<any, any, any>,
        transformRows: ((rows: ReadonlyArray<any>) => ReadonlyArray<any>) | undefined
      ) =>
        Effect.callback<any, SqlError>((resume) => {
          const result: Record<string, any> = {}

          const req = new Tedious.Request(
            escape(procedure.name),
            (cause, _, rows) => {
              if (cause) {
                resume(
                  Effect.fail(new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") }))
                )
              } else {
                rows = rowsToObjects(rows)
                if (transformRows) {
                  rows = transformRows(rows) as any
                }
                resume(
                  Effect.succeed({
                    params: result,
                    rows
                  })
                )
              }
            }
          )

          for (const name in procedure.params) {
            const param = procedure.params[name]
            const value = procedure.values[name]
            req.addParameter(name, param.type, value, param.options)
          }

          for (const name in procedure.outputParams) {
            const param = procedure.outputParams[name]
            req.addOutputParameter(name, param.type, undefined, param.options)
          }

          req.on("returnValue", (name, value) => {
            Rec.assignProperty(result, name, value)
          })

          conn.cancel()
          conn.callProcedure(req)
        })
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/sql/mssql/src/MssqlClient.ts#L378-L424)

</details>

### Reproduction

```sh
pnpm test --run packages/sql/mssql/test/Client.test.ts
```

**Observed failure:** FAIL: interruption made no additional Tedious cancel call.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/sql/mssql/test/Client.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `sql-adapters-ms-3`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-436