### PR TITLE
Close suspended workflow scopes after resumed completion

### DIFF
--- a/.changeset/frank-apes-vanish.md
+++ b/.changeset/frank-apes-vanish.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Close suspended workflow scopes after resumed completion.

--- a/packages/effect/src/unstable/workflow/WorkflowEngine.ts
+++ b/packages/effect/src/unstable/workflow/WorkflowEngine.ts
@@ -269,12 +269,13 @@ export class WorkflowInstance extends Context.Service<
 >()("effect/workflow/WorkflowEngine/WorkflowInstance") {
   static initial(
     workflow: Workflow.Any,
-    executionId: string
+    executionId: string,
+    scope = Scope.makeUnsafe()
   ): WorkflowInstance["Service"] {
     return WorkflowInstance.of({
       executionId,
       workflow,
-      scope: Scope.makeUnsafe(),
+      scope,
       suspended: false,
       interrupted: false,
       cause: undefined,
@@ -614,7 +615,11 @@ export const layerMemory: Layer.Layer<WorkflowEngine> = Layer.effect(WorkflowEng
       }
 
       const entry = workflows.get(state.instance.workflow._tag)!
-      const instance = WorkflowInstance.initial(state.instance.workflow, state.instance.executionId)
+      const instance = WorkflowInstance.initial(
+        state.instance.workflow,
+        state.instance.executionId,
+        state.instance.scope
+      )
       instance.interrupted = state.instance.interrupted
       state.instance = instance
       state.fiber = yield* state.execute(state.payload, state.instance.executionId).pipe(

--- a/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
+++ b/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
@@ -1,6 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Effect, Exit, Layer, Option, Schema } from "effect"
-import { Workflow, WorkflowEngine } from "effect/unstable/workflow"
+import { DurableDeferred, Workflow, WorkflowEngine } from "effect/unstable/workflow"
 
 describe("WorkflowEngine", () => {
   const IncrementWorkflow = Workflow.make("WorkflowEngine/IncrementWorkflow", {
@@ -57,4 +57,38 @@ describe("WorkflowEngine", () => {
         Layer.provideMerge(WorkflowEngine.layerMemory)
       ))
     ))
+
+  it.effect("layerMemory closes finalizers registered before suspension", () =>
+    Effect.gen(function*() {
+      const gate = DurableDeferred.make("WorkflowEngine/SuspendedScope/Gate")
+      const finalized: Array<number> = []
+      let runs = 0
+      const Suspends = Workflow.make("WorkflowEngine/SuspendedScope", {
+        payload: { id: Schema.String },
+        idempotencyKey: ({ id }) => id
+      })
+      const layer = Suspends.toLayer(() =>
+        Effect.gen(function*() {
+          const run = ++runs
+          yield* Workflow.addFinalizer(() => Effect.sync(() => finalized.push(run)))
+          yield* DurableDeferred.await(gate)
+        })
+      ).pipe(Layer.provideMerge(WorkflowEngine.layerMemory))
+
+      yield* Effect.gen(function*() {
+        const payload = { id: "one" }
+        const executionId = yield* Suspends.execute(payload, { discard: true })
+        let result = yield* Suspends.poll(executionId)
+        while (Option.isNone(result) || result.value._tag !== "Suspended") {
+          yield* Effect.yieldNow
+          result = yield* Suspends.poll(executionId)
+        }
+
+        const token = DurableDeferred.tokenFromExecutionId(gate, { workflow: Suspends, executionId })
+        yield* DurableDeferred.succeed(gate, { token, value: void 0 })
+        yield* Suspends.execute(payload)
+
+        assert.strictEqual(finalized.includes(1), true)
+      }).pipe(Effect.provide(layer))
+    }))
 })

--- a/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
+++ b/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
@@ -88,7 +88,7 @@ describe("WorkflowEngine", () => {
         yield* DurableDeferred.succeed(gate, { token, value: void 0 })
         yield* Suspends.execute(payload)
 
-        assert.strictEqual(finalized.includes(1), true)
+        assert.deepStrictEqual(finalized, [2, 1])
       }).pipe(Effect.provide(layer))
     }))
 })


### PR DESCRIPTION
## Summary

After a suspended in-memory workflow resumes and completes, finalizers registered before suspension remain open because the original workflow scope is abandoned.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Resuming a suspended workflow leaks its original scope

**Module:** `WorkflowEngine`  
**Audit ID:** `unstable-services-workflow-suspended-scope`  
**Severity / confidence:** high / high

### What happens

After a suspended in-memory workflow resumes and completes, finalizers registered before suspension remain open because the original workflow scope is abandoned.

### Why it happens

Resume replaces state.instance with WorkflowInstance.initial and its new scope; the prior suspended result deliberately left the old scope open, but replacement removes the last reference that could close it.

### Expected behavior

WorkflowInstance.scope represents the entire workflow lifetime and must close when the workflow fully completes, including finalizers registered before suspension.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/workflow/WorkflowEngine.ts:616-620`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/workflow/WorkflowEngine.ts#L616-L620)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/workflow/WorkflowEngine.ts:616-620</code></summary>

```ts
      const entry = workflows.get(state.instance.workflow._tag)!
      const instance = WorkflowInstance.initial(state.instance.workflow, state.instance.executionId)
      instance.interrupted = state.instance.interrupted
      state.instance = instance
      state.fiber = yield* state.execute(state.payload, state.instance.executionId).pipe(
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/workflow/WorkflowEngine.ts#L616-L620)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
```

**Observed failure:** FAIL: the first-run workflow finalizer remained open after resumed completion.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-services-workflow-suspended-scope`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-437