### PR TITLE
Keep ordered SQL resolver results aligned after encoding failures

### DIFF
--- a/.changeset/calm-results-align.md
+++ b/.changeset/calm-results-align.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Keep ordered SQL resolver results aligned when batched request encoding fails.

--- a/packages/effect/src/unstable/sql/SqlResolver.ts
+++ b/packages/effect/src/unstable/sql/SqlResolver.ts
@@ -121,7 +121,7 @@ export const ordered = <Req extends Schema.Constraint, Res extends Schema.Constr
   >({
     key: transactionKey,
     resolver: Effect.fnUntraced(function*(entries) {
-      const inputs = yield* partitionRequests(entries, options.Request)
+      const [inputs, encodedEntries] = yield* partitionRequests(entries, options.Request)
       const results = yield* options.execute(inputs as any).pipe(
         Effect.provideContext(entries[0].context)
       )
@@ -131,8 +131,8 @@ export const ordered = <Req extends Schema.Constraint, Res extends Schema.Constr
       const decodedResults = yield* decodeArray(results).pipe(
         Effect.provideContext(entries[0].context)
       )
-      for (let i = 0; i < entries.length; i++) {
-        entries[i].completeUnsafe(Exit.succeed(decodedResults[i]))
+      for (let i = 0; i < encodedEntries.length; i++) {
+        encodedEntries[i].completeUnsafe(Exit.succeed(decodedResults[i]))
       }
     })
   })
@@ -177,7 +177,7 @@ export const grouped = <Req extends Schema.Constraint, Res extends Schema.Constr
   >({
     key: transactionKey,
     resolver: Effect.fnUntraced(function*(entries) {
-      const inputs = yield* partitionRequests(entries, options.Request)
+      const [inputs] = yield* partitionRequests(entries, options.Request)
       const resultMap = MutableHashMap.empty<K, Arr.NonEmptyArray<Res["Type"]>>()
       const results = yield* options.execute(inputs as any).pipe(
         Effect.provideContext(entries[0].context)
@@ -298,7 +298,7 @@ const void_ = <Req extends Schema.Constraint, _, E, R>(
   >({
     key: transactionKey,
     resolver: Effect.fnUntraced(function*(entries) {
-      const inputs = yield* partitionRequests(entries, options.Request)
+      const [inputs] = yield* partitionRequests(entries, options.Request)
       yield* options.execute(inputs as any).pipe(
         Effect.provideContext(entries[0].context)
       )
@@ -326,6 +326,7 @@ const partitionRequests = function*<In, A, E, R, InE>(
 ) {
   const len = requests.length
   const inputs = Arr.empty<InE>()
+  const encodedEntries = Arr.empty<Request.Entry<SqlRequest<In, A, E, R>>>()
   let entry!: Request.Entry<SqlRequest<In, A, E, R>>
   const encode = Schema.encodeEffect(schema)
   const handle = Effect.matchCauseEager({
@@ -334,6 +335,7 @@ const partitionRequests = function*<In, A, E, R, InE>(
     },
     onSuccess(value: InE) {
       inputs.push(value)
+      encodedEntries.push(entry)
     }
   })
 
@@ -342,7 +344,7 @@ const partitionRequests = function*<In, A, E, R, InE>(
     yield (Effect.provideContext(handle(encode(entry.request.payload)), entry.context) as Effect.Effect<void>)
   }
 
-  return inputs
+  return [inputs, encodedEntries] as const
 }
 
 const partitionRequestsById = function*<In, A, E, R, InE>(

--- a/packages/effect/test/unstable/sql/SqlResolver.test.ts
+++ b/packages/effect/test/unstable/sql/SqlResolver.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect } from "effect"
+import { Effect, Exit } from "effect"
 import * as Schema from "effect/Schema"
 import { SqlResolver } from "effect/unstable/sql"
 
@@ -32,6 +32,26 @@ describe("SqlResolver", () => {
           }
         )
         assert.deepStrictEqual(batches, [[1, 2]])
+      }))
+  })
+
+  describe("ordered", () => {
+    it.effect("keeps valid results aligned when another request fails encoding", () =>
+      Effect.gen(function*() {
+        const resolver = SqlResolver.ordered({
+          Request: Schema.Number.check(Schema.isGreaterThan(0)),
+          Result: Schema.String,
+          execute: (inputs) => Effect.succeed(inputs.map((input) => `value-${input}`))
+        })
+        const execute = SqlResolver.request(resolver)
+        const [invalid, valid] = yield* Effect.all([
+          Effect.exit(execute(-1)),
+          Effect.exit(execute(2))
+        ], { concurrency: "unbounded" })
+
+        assert(Exit.isFailure(invalid))
+        assert(Exit.isSuccess(valid))
+        assert.strictEqual(valid.value, "value-2")
       }))
   })
 })


### PR DESCRIPTION
## Summary

When one batched request fails schema encoding, a later valid request can be completed with the wrong positional result or undefined.

> [!IMPORTANT]
> This PR includes the focused regression test, implementation fix, and patch changeset.

## Ordered results misalign after input encoding failure

**Module:** `SqlResolver`  
**Audit ID:** `unstable-services-sql-resolver-ordered-alignment`  
**Severity / confidence:** high / high

### What happens

When one batched request fails schema encoding, a later valid request can be completed with the wrong positional result or undefined.

### Why it happens

partitionRequests removes failed inputs without returning the surviving entries; ordered then indexes shortened decoded results using original entry indexes.

### Expected behavior

Each successfully encoded request must receive its corresponding result, while a request that fails encoding must fail independently.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/sql/SqlResolver.ts:123-136`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/sql/SqlResolver.ts#L123-L136)
- [`packages/effect/src/unstable/sql/SqlResolver.ts:323-345`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/sql/SqlResolver.ts#L323-L345)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/sql/SqlResolver.ts:123-136</code></summary>

```ts
    resolver: Effect.fnUntraced(function*(entries) {
      const inputs = yield* partitionRequests(entries, options.Request)
      const results = yield* options.execute(inputs as any).pipe(
        Effect.provideContext(entries[0].context)
      )
      if (results.length !== inputs.length) {
        return yield* new ResultLengthMismatch({ expected: inputs.length, actual: results.length })
      }
      const decodedResults = yield* decodeArray(results).pipe(
        Effect.provideContext(entries[0].context)
      )
      for (let i = 0; i < entries.length; i++) {
        entries[i].completeUnsafe(Exit.succeed(decodedResults[i]))
      }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/sql/SqlResolver.ts#L123-L136)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/sql/SqlResolver.ts:323-345</code></summary>

```ts
const partitionRequests = function*<In, A, E, R, InE>(
  requests: Arr.NonEmptyArray<Request.Entry<SqlRequest<In, A, E, R>>>,
  schema: Schema.ConstraintCodec<In, InE, R, R>
) {
  const len = requests.length
  const inputs = Arr.empty<InE>()
  let entry!: Request.Entry<SqlRequest<In, A, E, R>>
  const encode = Schema.encodeEffect(schema)
  const handle = Effect.matchCauseEager({
    onFailure(cause: Cause.Cause<Schema.SchemaError>) {
      entry.completeUnsafe(Exit.failCause(cause))
    },
    onSuccess(value: InE) {
      inputs.push(value)
    }
  })

  for (let i = 0; i < len; i++) {
    entry = requests[i]
    yield (Effect.provideContext(handle(encode(entry.request.payload)), entry.context) as Effect.Effect<void>)
  }

  return inputs
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/sql/SqlResolver.ts#L323-L345)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/sql/SqlResolver.test.ts
```

**Observed failure:** FAIL: the valid request succeeded with undefined instead of value-2.

## Validation

- `pnpm test --run packages/effect/test/unstable/sql/SqlResolver.test.ts`
- `pnpm test --run --project effect`
- `pnpm lint`
- `pnpm check`

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-services-sql-resolver-ordered-alignment`
- Final patch: focused reproduction test, implementation fix, and changeset

Closes EFF-438
