### PR TITLE
Key statement constructor caches by their full configuration

### DIFF
--- a/.changeset/slow-apples-listen.md
+++ b/.changeset/slow-apples-listen.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix SQL statement constructor caching to include the compiler, span attributes, and row transformer.

--- a/packages/effect/src/unstable/sql/Statement.ts
+++ b/packages/effect/src/unstable/sql/Statement.ts
@@ -14,6 +14,7 @@ import { Clock } from "../../Clock.ts"
 import * as Context from "../../Context.ts"
 import * as Effect from "../../Effect.ts"
 import * as Effectable from "../../Effectable.ts"
+import * as Equal from "../../Equal.ts"
 import type * as Fiber from "../../Fiber.ts"
 import { constUndefined } from "../../Function.ts"
 import * as internalEffect from "../../internal/effect.ts"
@@ -535,9 +536,16 @@ export const make = (
   spanAttributes: ReadonlyArray<readonly [string, unknown]>,
   transformRows: (<A extends object>(row: ReadonlyArray<A>) => ReadonlyArray<A>) | undefined
 ): Constructor => {
-  const cache = transformRows === undefined ? constructorCache.noTransforms : constructorCache.transforms
-  if (cache.has(acquirer)) {
-    return cache.get(acquirer)!
+  const cache = constructorCache.get(acquirer)
+  if (cache !== undefined) {
+    const entry = cache.find((entry) =>
+      entry.compiler === compiler &&
+      Equal.equals(entry.spanAttributes, spanAttributes) &&
+      entry.transformRows === transformRows
+    )
+    if (entry !== undefined) {
+      return entry.constructor
+    }
   }
   const self = Object.assign(
     function sql(strings: unknown, ...args: Array<any>): any {
@@ -597,15 +605,29 @@ export const make = (
     }
   )
 
-  cache.set(acquirer, self)
+  const entry: ConstructorCacheEntry = {
+    compiler,
+    spanAttributes,
+    transformRows,
+    constructor: self
+  }
+  if (cache === undefined) {
+    constructorCache.set(acquirer, [entry])
+  } else {
+    cache.push(entry)
+  }
 
   return self
 }
 
-const constructorCache = {
-  transforms: new WeakMap<Acquirer, Constructor>(),
-  noTransforms: new WeakMap<Acquirer, Constructor>()
+interface ConstructorCacheEntry {
+  readonly compiler: Compiler
+  readonly spanAttributes: ReadonlyArray<readonly [string, unknown]>
+  readonly transformRows: (<A extends object>(row: ReadonlyArray<A>) => ReadonlyArray<A>) | undefined
+  readonly constructor: Constructor
 }
+
+const constructorCache = new WeakMap<Acquirer, Array<ConstructorCacheEntry>>()
 
 /**
  * Builds a `Statement` from template strings and arguments, preserving

--- a/packages/effect/test/unstable/sql/Statement.test.ts
+++ b/packages/effect/test/unstable/sql/Statement.test.ts
@@ -1,4 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
 import * as Statement from "effect/unstable/sql/Statement"
 
 describe("Statement", () => {
@@ -13,5 +14,21 @@ describe("Statement", () => {
     assert.deepStrictEqual(nested.array([row]), [{ OWN: 2 }])
     assert.deepStrictEqual(nested.array([[row]]), [[{ OWN: 2 }]])
     assert.deepStrictEqual(flat.array([row]), [{ OWN: 2 }])
+  })
+
+  it("keeps compiler configuration when an acquirer is reused", () => {
+    const acquirer = Effect.die("not executed")
+    const postgres = Statement.makeCompiler({
+      dialect: "pg",
+      placeholder: (index) => `$${index}`,
+      onIdentifier: Statement.defaultEscape("\""),
+      onRecordUpdate: () => ["", []],
+      onCustom: () => ["", []]
+    })
+    const pg = Statement.make(acquirer, postgres, [], undefined)
+    const sqlite = Statement.make(acquirer, Statement.makeCompilerSqlite(), [], undefined)
+
+    assert.deepStrictEqual(pg`select ${1}`.compile(), ["select $1", [1]])
+    assert.deepStrictEqual(sqlite`select ${1}`.compile(), ["select ?", [1]])
   })
 })

--- a/packages/effect/test/unstable/sql/Statement.test.ts
+++ b/packages/effect/test/unstable/sql/Statement.test.ts
@@ -16,7 +16,7 @@ describe("Statement", () => {
     assert.deepStrictEqual(flat.array([row]), [{ OWN: 2 }])
   })
 
-  it("keeps compiler configuration when an acquirer is reused", () => {
+  it("caches constructors by their full configuration", () => {
     const acquirer = Effect.die("not executed")
     const postgres = Statement.makeCompiler({
       dialect: "pg",
@@ -25,10 +25,25 @@ describe("Statement", () => {
       onRecordUpdate: () => ["", []],
       onCustom: () => ["", []]
     })
-    const pg = Statement.make(acquirer, postgres, [], undefined)
-    const sqlite = Statement.make(acquirer, Statement.makeCompilerSqlite(), [], undefined)
+    const transformRows = <A extends object>(rows: ReadonlyArray<A>) => rows
+    const otherTransformRows = <A extends object>(rows: ReadonlyArray<A>) => rows
+    const spanAttributes = [["db.system", "postgresql"]] as const
+    const pg = Statement.make(acquirer, postgres, spanAttributes, transformRows)
+    const sqlite = Statement.make(acquirer, Statement.makeCompilerSqlite(), spanAttributes, transformRows)
 
     assert.deepStrictEqual(pg`select ${1}`.compile(), ["select $1", [1]])
     assert.deepStrictEqual(sqlite`select ${1}`.compile(), ["select ?", [1]])
+    assert.strictEqual(
+      pg,
+      Statement.make(acquirer, postgres, [["db.system", "postgresql"]], transformRows)
+    )
+    assert.notStrictEqual(
+      pg,
+      Statement.make(acquirer, postgres, [["db.system", "sqlite"]], transformRows)
+    )
+    assert.notStrictEqual(
+      pg,
+      Statement.make(acquirer, postgres, spanAttributes, otherTransformRows)
+    )
   })
 })


### PR DESCRIPTION
## Summary

Reusing an acquirer can return a statement constructor configured with another compiler, transform function, or span attributes.

> [!NOTE]
> This PR includes focused regression coverage and the implementation fix.

## Statement constructor cache crosses configuration

**Module:** `Statement`  
**Audit ID:** `unstable-services-statement-constructor-cache`  
**Severity / confidence:** high / high

### What happens

Reusing an acquirer can return a statement constructor configured with another compiler, transform function, or span attributes.

### Why it happens

The constructor cache keys only on acquirer and whether transforms are present, ignoring the compiler and the remaining configuration values.

### Expected behavior

make must return a constructor configured by every supplied acquirer, compiler, spanAttributes, and transformRows argument.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/sql/Statement.ts:532-608`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/sql/Statement.ts#L532-L608)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/sql/Statement.ts:532-581</code></summary>

```ts
export const make = (
  acquirer: Acquirer,
  compiler: Compiler,
  spanAttributes: ReadonlyArray<readonly [string, unknown]>,
  transformRows: (<A extends object>(row: ReadonlyArray<A>) => ReadonlyArray<A>) | undefined
): Constructor => {
  const cache = transformRows === undefined ? constructorCache.noTransforms : constructorCache.transforms
  if (cache.has(acquirer)) {
    return cache.get(acquirer)!
  }
  const self = Object.assign(
    function sql(strings: unknown, ...args: Array<any>): any {
      if (typeof strings === "string") {
        return identifier(strings)
      } else if (Array.isArray(strings) && "raw" in strings) {
        return statement(
          acquirer,
          compiler,
          strings as TemplateStringsArray,
          args,
          spanAttributes,
          transformRows
        )
      }

      throw "absurd"
    },
    {
      unsafe<A extends object = Row>(
        sql: string,
        params?: ReadonlyArray<unknown>
      ) {
        return makeUnsafe<A>(
          [literal(sql, params)],
          acquirer,
          compiler,
          spanAttributes,
          transformRows
        )
      },
      literal(sql: string) {
        return fragment([literal(sql)])
      },
      in: in_,
      insert(value: any) {
        return recordInsertHelper(
          Array.isArray(value) ? value : [value]
        )
      },
      update(value: any, omit: any) {
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/sql/Statement.ts#L532-L608)

_Excerpt truncated. [Open the complete packages/effect/src/unstable/sql/Statement.ts:532-608 range.](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/sql/Statement.ts#L532-L608)_

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/sql/Statement.test.ts
```

**Observed failure:** FAIL: the SQLite constructor retained PostgreSQL compilation with a $1 placeholder.

## Verification

- `pnpm test --run packages/effect/test/unstable/sql/Statement.test.ts`
- `pnpm test --run --project effect`
- `pnpm lint`
- `pnpm check`

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-services-statement-constructor-cache`
- Initial patch: focused reproduction tests
- Follow-up: full-configuration cache fix, expanded regression coverage, and changeset

Closes EFF-439