### PR TITLE
Persist permanent entries in KVS setMany operations

### DIFF
--- a/.changeset/quick-kiwis-remember.md
+++ b/.changeset/quick-kiwis-remember.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Persist permanent entries in KVS `setMany` operations.

--- a/packages/effect/src/unstable/persistence/Persistence.ts
+++ b/packages/effect/src/unstable/persistence/Persistence.ts
@@ -1094,7 +1094,6 @@ export const layerBackingKvs: Layer.Layer<
           setMany: (entries) =>
             Effect.forEach(entries, ([key, value, ttl]) => {
               const expires = unsafeTtlToExpires(clock, ttl)
-              if (expires === null) return Effect.void
               const encoded = JSON.stringify([value, expires])
               return store.set(key, encoded)
             }, { concurrency: "unbounded", discard: true }).pipe(

--- a/packages/effect/test/unstable/persistence/KeyValueStore.test.ts
+++ b/packages/effect/test/unstable/persistence/KeyValueStore.test.ts
@@ -1,6 +1,7 @@
-import { afterEach, assert, describe, it } from "@effect/vitest"
+import { afterEach, describe, it } from "@effect/vitest"
 import { assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
-import { Effect, Layer, Option, Schema } from "effect"
+import type { Layer } from "effect"
+import { Effect, Option, Schema } from "effect"
 import * as KeyValueStore from "effect/unstable/persistence/KeyValueStore"
 import * as Persistence from "effect/unstable/persistence/Persistence"
 
@@ -84,24 +85,24 @@ export const testLayer = <E>(layer: Layer.Layer<KeyValueStore.KeyValueStore, E>)
       strictEqual(value, undefined)
       strictEqual(length, 0)
     })))
+
+  it("setMany stores entries without a TTL", () =>
+    run(
+      Effect.gen(function*() {
+        const backing = yield* Persistence.BackingPersistence
+        const store = yield* backing.make("store")
+
+        yield* store.setMany([["key", { value: 1 }, undefined]])
+
+        deepStrictEqual(yield* store.get("key"), { value: 1 })
+      }).pipe(
+        Effect.scoped,
+        Effect.provide(Persistence.layerBackingKvs)
+      )
+    ))
 }
 
 describe("KeyValueStore / layerMemory", () => testLayer(KeyValueStore.layerMemory))
-
-describe("Persistence / layerBackingKvs", () => {
-  it.effect("stores entries without a TTL", () =>
-    Effect.gen(function*() {
-      const backing = yield* Persistence.BackingPersistence
-      const store = yield* backing.make("store")
-
-      yield* store.setMany([["key", { value: 1 }, undefined]])
-
-      assert.deepStrictEqual(yield* store.get("key"), { value: 1 })
-    }).pipe(
-      Effect.scoped,
-      Effect.provide(Persistence.layerBackingKvs.pipe(Layer.provide(KeyValueStore.layerMemory)))
-    ))
-})
 
 describe("KeyValueStore / prefix", () => {
   it.effect("prefixes the keys", () =>

--- a/packages/effect/test/unstable/persistence/KeyValueStore.test.ts
+++ b/packages/effect/test/unstable/persistence/KeyValueStore.test.ts
@@ -1,8 +1,8 @@
-import { afterEach, describe, it } from "@effect/vitest"
+import { afterEach, assert, describe, it } from "@effect/vitest"
 import { assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
-import type { Layer } from "effect"
-import { Effect, Option, Schema } from "effect"
+import { Effect, Layer, Option, Schema } from "effect"
 import * as KeyValueStore from "effect/unstable/persistence/KeyValueStore"
+import * as Persistence from "effect/unstable/persistence/Persistence"
 
 export const testLayer = <E>(layer: Layer.Layer<KeyValueStore.KeyValueStore, E>) => {
   const run = <E, A>(effect: Effect.Effect<A, E, KeyValueStore.KeyValueStore>) =>
@@ -87,6 +87,21 @@ export const testLayer = <E>(layer: Layer.Layer<KeyValueStore.KeyValueStore, E>)
 }
 
 describe("KeyValueStore / layerMemory", () => testLayer(KeyValueStore.layerMemory))
+
+describe("Persistence / layerBackingKvs", () => {
+  it.effect("stores entries without a TTL", () =>
+    Effect.gen(function*() {
+      const backing = yield* Persistence.BackingPersistence
+      const store = yield* backing.make("store")
+
+      yield* store.setMany([["key", { value: 1 }, undefined]])
+
+      assert.deepStrictEqual(yield* store.get("key"), { value: 1 })
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(Persistence.layerBackingKvs.pipe(Layer.provide(KeyValueStore.layerMemory)))
+    ))
+})
 
 describe("KeyValueStore / prefix", () => {
   it.effect("prefixes the keys", () =>


### PR DESCRIPTION
## Summary

KVS setMany silently skips every entry without a finite TTL, so values requested as permanent are absent immediately after the operation succeeds.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## KVS setMany skips permanent entries

**Module:** `Persistence`  
**Audit ID:** `unstable-state-p-1`  
**Severity / confidence:** high / high

### What happens

KVS setMany silently skips every entry without a finite TTL, so values requested as permanent are absent immediately after the operation succeeds.

### Why it happens

unsafeTtlToExpires returns null for an undefined TTL, but the setMany loop treats null as a reason to return Effect.void instead of writing the permanent entry.

### Expected behavior

BackingPersistenceStore.setMany has the same persistence semantics as repeated set calls, and an undefined TTL means no expiration.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/persistence/Persistence.ts:1094-1100`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/persistence/Persistence.ts#L1094-L1100)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/persistence/Persistence.ts:1094-1100</code></summary>

```ts
          setMany: (entries) =>
            Effect.forEach(entries, ([key, value, ttl]) => {
              const expires = unsafeTtlToExpires(clock, ttl)
              if (expires === null) return Effect.void
              const encoded = JSON.stringify([value, expires])
              return store.set(key, encoded)
            }, { concurrency: "unbounded", discard: true }).pipe(
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/persistence/Persistence.ts#L1094-L1100)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/persistence/KeyValueStore.test.ts
```

**Observed failure:** get("key") returned undefined after permanent setMany completed.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/persistence/KeyValueStore.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-state-p-1`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-440