### PR TITLE
Scope custom queue ID deduplication to each named queue

### DIFF
--- a/.changeset/scope-persisted-queue-ids.md
+++ b/.changeset/scope-persisted-queue-ids.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Scope custom persisted queue ID deduplication to each named queue.

--- a/packages/effect/src/unstable/persistence/PersistedQueue.ts
+++ b/packages/effect/src/unstable/persistence/PersistedQueue.ts
@@ -294,9 +294,9 @@ export const layerStoreMemory: Layer.Layer<
     attempts: number
     readonly element: unknown
   }
-  const ids = new Set<string>()
   const queues = new Map<string, {
     latch: Latch.Latch
+    ids: Set<string>
     items: Set<Entry>
   }>()
   const getOrCreateQueue = (name: string) => {
@@ -304,6 +304,7 @@ export const layerStoreMemory: Layer.Layer<
     if (!queue) {
       queue = {
         latch: Latch.makeUnsafe(false),
+        ids: new Set(),
         items: new Set()
       }
       queues.set(name, queue)
@@ -314,9 +315,9 @@ export const layerStoreMemory: Layer.Layer<
   return PersistedQueueStore.of({
     offer: (options) =>
       Effect.sync(() => {
-        if (ids.has(options.id)) return
-        ids.add(options.id)
         const queue = getOrCreateQueue(options.name)
+        if (queue.ids.has(options.id)) return
+        queue.ids.add(options.id)
         queue.items.add({ id: options.id, attempts: 0, element: options.element })
         queue.latch.openUnsafe()
       }),
@@ -857,9 +858,11 @@ export const makeStoreSql: (
   yield* sql.onDialectOrElse({
     mssql: () =>
       sql`IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = N'idx_${tableName}_id')
-        CREATE UNIQUE INDEX idx_${tableNameSql}_id ON ${tableNameSql} (id)`,
-    mysql: () => sql`CREATE UNIQUE INDEX ${sql(`idx_${tableName}_id`)} ON ${tableNameSql} (id)`.pipe(Effect.ignore),
-    orElse: () => sql`CREATE UNIQUE INDEX IF NOT EXISTS ${sql(`idx_${tableName}_id`)} ON ${tableNameSql} (id)`
+        CREATE UNIQUE INDEX idx_${tableNameSql}_id ON ${tableNameSql} (id, queue_name)`,
+    mysql: () =>
+      sql`CREATE UNIQUE INDEX ${sql(`idx_${tableName}_id`)} ON ${tableNameSql} (id, queue_name)`.pipe(Effect.ignore),
+    orElse: () =>
+      sql`CREATE UNIQUE INDEX IF NOT EXISTS ${sql(`idx_${tableName}_id`)} ON ${tableNameSql} (id, queue_name)`
   })
 
   yield* sql.onDialectOrElse({
@@ -894,7 +897,7 @@ export const makeStoreSql: (
       sql`
         INSERT INTO ${tableNameSql} (id, queue_name, element, completed, attempts, created_at, updated_at)
         VALUES (${id}, ${name}, ${element}, FALSE, 0, ${sqlNow}, ${sqlNow})
-        ON CONFLICT (id) DO NOTHING
+        ON CONFLICT (id, queue_name) DO NOTHING
       `,
     mysql: () => (id: string, name: string, element: string) =>
       sql`
@@ -903,7 +906,7 @@ export const makeStoreSql: (
       `,
     mssql: () => (id: string, name: string, element: string) =>
       sql`
-        IF NOT EXISTS (SELECT 1 FROM ${tableNameSql} WHERE id = ${id})
+        IF NOT EXISTS (SELECT 1 FROM ${tableNameSql} WHERE id = ${id} AND queue_name = ${name})
         BEGIN
           INSERT INTO ${tableNameSql} (id, queue_name, element, completed, attempts, created_at, updated_at)
           VALUES (${id}, ${name}, ${element}, 0, 0, ${sqlNow}, ${sqlNow})

--- a/packages/effect/test/unstable/persistence/PersistedQueue.test.ts
+++ b/packages/effect/test/unstable/persistence/PersistedQueue.test.ts
@@ -1,4 +1,25 @@
+import { assert, it } from "@effect/vitest"
+import { Effect, Layer, Schema } from "effect"
+import { TestClock } from "effect/testing"
 import { PersistedQueue } from "effect/unstable/persistence"
 import * as PersistedQueueTest from "./PersistedQueueTest.ts"
 
 PersistedQueueTest.suite("memory", PersistedQueue.layerStoreMemory)
+
+const Item = Schema.Struct({ value: Schema.Number })
+
+it.effect("custom ids are deduplicated independently in each queue", () =>
+  Effect.gen(function*() {
+    const first = yield* PersistedQueue.make({ name: "first", schema: Item })
+    const second = yield* PersistedQueue.make({ name: "second", schema: Item })
+    yield* first.offer({ value: 1 }, { id: "shared" })
+    yield* second.offer({ value: 2 }, { id: "shared" })
+
+    const fiber = yield* second.take(Effect.succeed).pipe(Effect.forkScoped)
+    yield* TestClock.adjust("10 millis")
+
+    assert.isDefined(fiber.pollUnsafe())
+  }).pipe(
+    Effect.scoped,
+    Effect.provide(PersistedQueue.layer.pipe(Layer.provide(PersistedQueue.layerStoreMemory)))
+  ))

--- a/packages/effect/test/unstable/persistence/PersistedQueue.test.ts
+++ b/packages/effect/test/unstable/persistence/PersistedQueue.test.ts
@@ -1,25 +1,4 @@
-import { assert, it } from "@effect/vitest"
-import { Effect, Layer, Schema } from "effect"
-import { TestClock } from "effect/testing"
 import { PersistedQueue } from "effect/unstable/persistence"
 import * as PersistedQueueTest from "./PersistedQueueTest.ts"
 
 PersistedQueueTest.suite("memory", PersistedQueue.layerStoreMemory)
-
-const Item = Schema.Struct({ value: Schema.Number })
-
-it.effect("custom ids are deduplicated independently in each queue", () =>
-  Effect.gen(function*() {
-    const first = yield* PersistedQueue.make({ name: "first", schema: Item })
-    const second = yield* PersistedQueue.make({ name: "second", schema: Item })
-    yield* first.offer({ value: 1 }, { id: "shared" })
-    yield* second.offer({ value: 2 }, { id: "shared" })
-
-    const fiber = yield* second.take(Effect.succeed).pipe(Effect.forkScoped)
-    yield* TestClock.adjust("10 millis")
-
-    assert.isDefined(fiber.pollUnsafe())
-  }).pipe(
-    Effect.scoped,
-    Effect.provide(PersistedQueue.layer.pipe(Layer.provide(PersistedQueue.layerStoreMemory)))
-  ))

--- a/packages/effect/test/unstable/persistence/PersistedQueueTest.ts
+++ b/packages/effect/test/unstable/persistence/PersistedQueueTest.ts
@@ -100,6 +100,22 @@ export const suite = (name: string, layer: Layer.Layer<PersistedQueue.PersistedQ
         assert.isUndefined(fiber.pollUnsafe())
       }))
 
+    it.effect("deduplicates custom ids independently in each queue", () =>
+      Effect.gen(function*() {
+        const first = yield* PersistedQueue.make({ name: "custom-id-first", schema: Item })
+        const second = yield* PersistedQueue.make({ name: "custom-id-second", schema: Item })
+
+        yield* first.offer({ n: 1n }, { id: "shared-custom-id" })
+        yield* second.offer({ n: 2n }, { id: "shared-custom-id" })
+
+        const fiber = yield* second.take(Effect.succeed).pipe(Effect.forkScoped)
+        yield* TestClock.adjust(1000)
+        yield* Effect.sleep(1000).pipe(TestClock.withLive)
+
+        assert.isDefined(fiber.pollUnsafe())
+        assert.deepStrictEqual(yield* Fiber.join(fiber), { n: 2n })
+      }))
+
     it.effect("does not redeliver in-flight elements", () =>
       Effect.gen(function*() {
         const queue = yield* PersistedQueue.make({


### PR DESCRIPTION
## Summary

Offering the same custom ID to two independently named memory or SQL queues silently drops the second queue's item, so that queue's consumer remains blocked.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Custom ID deduplication crosses named queues

**Module:** `PersistedQueue`  
**Audit ID:** `unstable-state-pq-1`  
**Severity / confidence:** high / high

### What happens

Offering the same custom ID to two independently named memory or SQL queues silently drops the second queue's item, so that queue's consumer remains blocked.

### Why it happens

The memory layer uses one factory-wide Set<string> for every queue name, while the SQL table uniquely indexes id without queue_name. Redis correctly scopes its ID set by queue name.

### Expected behavior

Deduplication applies when an ID already exists in the same queue; queue names define independent queues.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/unstable/persistence/PersistedQueue.ts:70-72`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/persistence/PersistedQueue.ts#L70-L72)
- [`packages/effect/src/unstable/persistence/PersistedQueue.ts:297-320`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/persistence/PersistedQueue.ts#L297-L320)
- [`packages/effect/src/unstable/persistence/PersistedQueue.ts:800-801`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/persistence/PersistedQueue.ts#L800-L801)
- [`packages/effect/src/unstable/persistence/PersistedQueue.ts:814-815`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/persistence/PersistedQueue.ts#L814-L815)
- [`packages/effect/src/unstable/persistence/PersistedQueue.ts:857-863`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/persistence/PersistedQueue.ts#L857-L863)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/persistence/PersistedQueue.ts:70-72</code></summary>

```ts
   * If an element with the same id already exists in the queue, it will not be
   * added again.
   */
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/persistence/PersistedQueue.ts#L70-L72)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/persistence/PersistedQueue.ts:297-320</code></summary>

```ts
  const ids = new Set<string>()
  const queues = new Map<string, {
    latch: Latch.Latch
    items: Set<Entry>
  }>()
  const getOrCreateQueue = (name: string) => {
    let queue = queues.get(name)
    if (!queue) {
      queue = {
        latch: Latch.makeUnsafe(false),
        items: new Set()
      }
      queues.set(name, queue)
    }
    return queue
  }

  return PersistedQueueStore.of({
    offer: (options) =>
      Effect.sync(() => {
        if (ids.has(options.id)) return
        ids.add(options.id)
        const queue = getOrCreateQueue(options.name)
        queue.items.add({ id: options.id, attempts: 0, element: options.element })
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/persistence/PersistedQueue.ts#L297-L320)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/persistence/PersistedQueue.ts:800-801</code></summary>

```ts
        id VARCHAR(36) NOT NULL,
        queue_name VARCHAR(100) NOT NULL,
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/persistence/PersistedQueue.ts#L800-L801)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/persistence/PersistedQueue.ts:814-815</code></summary>

```ts
        id VARCHAR(36) NOT NULL,
        queue_name VARCHAR(100) NOT NULL,
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/persistence/PersistedQueue.ts#L814-L815)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/unstable/persistence/PersistedQueue.ts:857-863</code></summary>

```ts
  yield* sql.onDialectOrElse({
    mssql: () =>
      sql`IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = N'idx_${tableName}_id')
        CREATE UNIQUE INDEX idx_${tableNameSql}_id ON ${tableNameSql} (id)`,
    mysql: () => sql`CREATE UNIQUE INDEX ${sql(`idx_${tableName}_id`)} ON ${tableNameSql} (id)`.pipe(Effect.ignore),
    orElse: () => sql`CREATE UNIQUE INDEX IF NOT EXISTS ${sql(`idx_${tableName}_id`)} ON ${tableNameSql} (id)`
  })
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/unstable/persistence/PersistedQueue.ts#L857-L863)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/persistence/PersistedQueue.test.ts
```

**Observed failure:** The second queue's take fiber remained pending after the same custom ID was offered to both queues.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/persistence/PersistedQueue.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `unstable-state-pq-1`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-443