### PR TITLE
Use local server for NodeHttpClient redirect test

### DIFF
--- a/packages/platform-node/test/NodeHttpClient.test.ts
+++ b/packages/platform-node/test/NodeHttpClient.test.ts
@@ -63,6 +63,8 @@ const LocalServerRoutes = HttpRouter.serve(HttpRouter.addAll([
       return HttpServerResponse.jsonUnsafe({ ...todo, id: 201 })
     })
   ),
+  HttpRouter.route("GET", "/redirect", Effect.succeed(HttpServerResponse.redirect("/redirected"))),
+  HttpRouter.route("GET", "/redirected", Effect.succeed(HttpServerResponse.text("redirected"))),
   HttpRouter.route("HEAD", "/todos", Effect.succeed(HttpServerResponse.empty({ status: 200 })))
 ]))
 ;[
@@ -96,18 +98,16 @@ const LocalServerRoutes = HttpRouter.serve(HttpRouter.addAll([
         expect(response).toContain("Google")
       }).pipe(Effect.provide(layer), flaky))
 
-    it.effect("google followRedirects", () =>
-      flaky(
-        Effect.gen(function*() {
-          const client = (yield* HttpClient.HttpClient).pipe(
-            HttpClient.followRedirects()
-          )
-          const response = yield* client.get("http://google.com/").pipe(
-            Effect.flatMap((_) => _.text)
-          )
-          expect(response).toContain("Google")
-        }).pipe(Effect.provide(layer))
-      ))
+    it.effect("local server followRedirects", () =>
+      Effect.gen(function*() {
+        const client = (yield* HttpClient.HttpClient).pipe(
+          HttpClient.followRedirects()
+        )
+        const response = yield* client.get("/redirect").pipe(
+          Effect.flatMap((_) => _.text)
+        )
+        expect(response).toBe("redirected")
+      }).pipe(Effect.provide(localServerTestLayer)))
 
     it.effect("google stream", () =>
       flaky(


### PR DESCRIPTION
## Summary

- replace the `google followRedirects` request with a local redirect route
- exercise redirects end-to-end for the fetch, `node:http`, and undici clients
- remove the flaky timeout guard from this redirect test

## Root cause

The test depended on a live HTTP request to Google, so external connection resets could fail CI before redirect behavior was verified. The existing local test server now provides a deterministic redirect target instead.

## Validation

- `nix develop -c pnpm vitest run packages/platform-node/test/NodeHttpClient.test.ts`
- `nix develop -c pnpm --filter @effect/platform-node check`
- `nix develop -c pnpm dprint check packages/platform-node/test/NodeHttpClient.test.ts`
- `nix develop -c pnpm oxlint -f unix packages/platform-node/test/NodeHttpClient.test.ts`

Closes EFF-381