### PR TITLE
Fix Bash subcommand dispatch for flag values

### DIFF
--- a/.changeset/fix-bash-subcommand-dispatch.md
+++ b/.changeset/fix-bash-subcommand-dispatch.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Prevent Bash completions from treating flag values as subcommands.

--- a/packages/effect/src/unstable/cli/internal/completions/bash.ts
+++ b/packages/effect/src/unstable/cli/internal/completions/bash.ts
@@ -130,9 +130,19 @@ const generateFunction = (
   // Subcommand dispatch
   if (descriptor.subcommands.length > 0) {
     lines.push(`  # Subcommand dispatch`)
-    lines.push(`  local cmd`)
-    lines.push(`  for ((i = 1; i < cword; i++)); do`)
+    lines.push(`  local cmd _skip_next=0`)
+    lines.push(`  for ((i = _command_index + 1; i < cword; i++)); do`)
+    lines.push(`    if (( _skip_next )); then`)
+    lines.push(`      _skip_next=0`)
+    lines.push(`      continue`)
+    lines.push(`    fi`)
     lines.push(`    case "\${words[i]}" in`)
+    for (const flag of descriptor.flags) {
+      if (flag.type._tag === "Boolean") continue
+      const forms = flagNamesForWordlist(flag)
+      lines.push(`      ${forms.join("|")}) _skip_next=1 ;;`)
+      lines.push(`      ${forms.map((form) => `${form}=*`).join("|")}) ;;`)
+    }
     for (const sub of descriptor.subcommands) {
       const subFuncName = `_${[...currentPath, sub.name].map(sanitizeFunctionName).join("_")}`
       lines.push(`      ${sub.name})`)

--- a/packages/effect/test/unstable/cli/completions/completions.test.ts
+++ b/packages/effect/test/unstable/cli/completions/completions.test.ts
@@ -44,7 +44,8 @@ const withSubcommands = (() => {
   }).pipe(Command.withDescription("Stop the server"))
 
   return Command.make("server", {
-    verbose: Flag.boolean("verbose").pipe(Flag.withAlias("v"))
+    verbose: Flag.boolean("verbose").pipe(Flag.withAlias("v")),
+    config: Flag.string("config")
   }).pipe(
     Command.withDescription("Server management"),
     Command.withSubcommands([start, stop])
@@ -150,6 +151,23 @@ describe("Bash completions", () => {
     const script = Bash.generate("server", desc)
     assert.include(script, "start)")
     assert.include(script, "stop)")
+  })
+
+  it("does not dispatch subcommands from flag values", () => {
+    const desc = fromCommand(withSubcommands)
+    const script = Bash.generate("server", desc)
+    assert.include(
+      script,
+      `for ((i = _command_index + 1; i < cword; i++)); do
+    if (( _skip_next )); then
+      _skip_next=0
+      continue
+    fi
+    case "\${words[i]}" in
+      --config) _skip_next=1 ;;
+      --config=*) ;;
+      start)`
+    )
   })
 
   it("includes long flag names with -- prefix", () => {


### PR DESCRIPTION
## Summary

- skip separate-form flag values while scanning generated Bash completions for subcommands
- recognize inline `--flag=value` forms and scope nested scans to the active command
- add focused regression coverage and a patch changeset

## Root cause

The generated subcommand dispatch loop matched every prior word directly against subcommand names, so a value such as `run` in `--config run` could incorrectly select the `run` subcommand.

## Validation

- `pnpm test --run packages/effect/test/unstable/cli/completions/completions.test.ts`
- `pnpm lint-fix`
- `pnpm check`

Closes EFF-444