### PR TITLE
Share persistence layers across cache tests

### DIFF
--- a/packages/effect/test/unstable/persistence/PersistedCacheTest.ts
+++ b/packages/effect/test/unstable/persistence/PersistedCacheTest.ts
@@ -1,6 +1,6 @@
-import { assert, describe, it } from "@effect/vitest"
+import { assert, it } from "@effect/vitest"
 import type { Layer } from "effect"
-import { Context, Data, Effect, Exit, Result, Schema } from "effect"
+import { Context, Data, Effect, Exit, Schema } from "effect"
 import { Persistable, PersistedCache, Persistence } from "effect/unstable/persistence"
 
 class User extends Schema.Class<User>("User")({
@@ -21,7 +21,7 @@ export class TransientError extends Data.TaggedError("TransientError") {}
 class LookupService extends Context.Service<LookupService, { readonly value: string }>()("LookupService") {}
 
 export const suite = (storeId: string, layer: Layer.Layer<Persistence.Persistence, unknown>) =>
-  describe(`PersistedCache (${storeId})`, { timeout: 30_000 }, () => {
+  it.layer(layer, { timeout: "60 seconds" })(`PersistedCache (${storeId})`, (it) => {
     it.effect("smoke test", () =>
       Effect.gen(function*() {
         const persistence = yield* Persistence.Persistence
@@ -65,11 +65,7 @@ export const suite = (storeId: string, layer: Layer.Layer<Persistence.Persistenc
           Exit.fail("Not found"),
           Exit.succeed(new User({ id: 2, name: "Jane" }))
         ])
-      }).pipe(
-        Effect.provide(layer),
-        Effect.catchFilter((e) => e instanceof TransientError ? Result.succeed(e) : Result.fail(e), () => Effect.void),
-        flakyTest
-      ))
+      }), 30_000)
 
     it.effect("requireServicesAt: 'lookup' requires lookup services at get-time", () =>
       Effect.gen(function*() {
@@ -95,17 +91,5 @@ export const suite = (storeId: string, layer: Layer.Layer<Persistence.Persistenc
         assert.deepStrictEqual(result1, new User({ id: 1, name: "first" }))
         assert.deepStrictEqual(result2, new User({ id: 2, name: "second" }))
         assert.deepStrictEqual(result3, new User({ id: 1, name: "first" }))
-      }).pipe(
-        Effect.provide(layer),
-        Effect.catchFilter((e) => e instanceof TransientError ? Result.succeed(e) : Result.fail(e), () => Effect.void),
-        flakyTest
-      ))
+      }), 30_000)
   })
-
-const flakyTest = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-  effect.pipe(
-    Effect.timeoutOrElse({
-      duration: "10 seconds",
-      orElse: () => Effect.void
-    })
-  )

--- a/packages/platform-browser/test/BrowserPersistencePersistedCache.test.ts
+++ b/packages/platform-browser/test/BrowserPersistencePersistedCache.test.ts
@@ -1,5 +1,5 @@
 import * as BrowserPersistence from "@effect/platform-browser/BrowserPersistence"
-import { afterEach, beforeEach, describe } from "@effect/vitest"
+import { afterAll, beforeAll, describe } from "@effect/vitest"
 import * as PersistedCacheTest from "effect-test/unstable/persistence/PersistedCacheTest"
 import { indexedDB as fakeIndexedDb } from "fake-indexeddb"
 
@@ -7,12 +7,12 @@ const database = "effect_persistence_integration"
 
 let previousIndexedDb: unknown
 
-beforeEach(() => {
+beforeAll(() => {
   previousIndexedDb = Reflect.get(globalThis, "indexedDB")
   Reflect.set(globalThis, "indexedDB", fakeIndexedDb)
 })
 
-afterEach(() => {
+afterAll(() => {
   fakeIndexedDb.deleteDatabase(database)
   if (previousIndexedDb === undefined) {
     Reflect.deleteProperty(globalThis, "indexedDB")

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -160,7 +160,7 @@ export default defineConfig({
       ...project("@effect/sql-d1", "packages/sql/d1", !isDeno),
       ...project("@effect/sql-libsql", "packages/sql/libsql"),
       ...project("@effect/sql-mssql", "packages/sql/mssql"),
-      // MySQL starts a fresh container per integration test, so avoid competing
+      // MySQL starts a fresh container per integration test suite, so avoid competing
       // with the other container-backed projects on Deno CI runners.
       ...project(
         "@effect/sql-mysql2",


### PR DESCRIPTION
## Summary

- acquire each persistence layer once per PersistedCache suite instead of once per test
- keep container setup and teardown outside the individual 30-second test budget
- remove the timeout wrapper that could turn an unexecuted test body into a passing test
- align the IndexedDB fixture lifetime with the shared suite layer

## Root cause

The failing MySQL test was not blocked by a PersistedCache race. Under CI load, each test independently started and stopped a `mysql:lts` container, with individual cases taking 24–30 seconds. The 10-second timeout wrapper then interrupted the test and returned success while container cleanup continued, so the outer 30-second Vitest timeout could still fire—and nominal passes could skip the assertions entirely.

## Validation

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/unstable/persistence/PersistedCache.test.ts --reporter=verbose`
- `pnpm test --run packages/platform-browser/test/BrowserPersistencePersistedCache.test.ts --reporter=verbose`
- `pnpm check`

The MySQL integration test could not run locally because this environment has no container runtime; the original Actions log was used to confirm the resource-lifecycle timing pattern.

Closes EFF-445