### PR TITLE
Rename Command.withHidden to Command.unlisted

### DIFF
--- a/.changeset/spicy-doors-unlist.md
+++ b/.changeset/spicy-doors-unlist.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Rename `Command.withHidden` to `Command.unlisted`, along with the `hidden` command property which is now `unlisted`.

--- a/packages/effect/src/unstable/cli/Command.ts
+++ b/packages/effect/src/unstable/cli/Command.ts
@@ -165,11 +165,11 @@ export interface Command<in out Name extends string, in Input, out ContextInput 
   readonly annotations: Context.Context<never>
 
   /**
-   * Whether this command is hidden from parent help output, shell
-   * completions, and unknown-subcommand suggestions. Hidden commands still
+   * Whether this command is omitted from parent help output, shell
+   * completions, and unknown-subcommand suggestions. Unlisted commands still
    * parse and execute normally when invoked by exact name.
    */
-  readonly hidden: boolean
+  readonly unlisted: boolean
 }
 
 /**
@@ -352,7 +352,7 @@ export declare namespace Command {
       readonly commands: NonEmptyReadonlyArray<Command.Any>
     }>
     readonly annotations: Context.Context<never>
-    readonly hidden: boolean
+    readonly unlisted: boolean
   }
 
   /**
@@ -925,7 +925,7 @@ export const withSubcommands: {
     description: impl.description,
     shortDescription: impl.shortDescription,
     alias: impl.alias,
-    hidden: impl.hidden,
+    unlisted: impl.unlisted,
     annotations: impl.annotations,
     globalFlags: impl.globalFlags,
     examples: impl.examples,
@@ -1025,7 +1025,7 @@ export const withSharedFlags: {
       description: impl.description,
       shortDescription: impl.shortDescription,
       alias: impl.alias,
-      hidden: impl.hidden,
+      unlisted: impl.unlisted,
       annotations: impl.annotations,
       globalFlags: impl.globalFlags,
       examples: impl.examples,
@@ -1210,7 +1210,7 @@ export const withAlias: {
 ) => makeCommand({ ...toImpl(self), alias }))
 
 /**
- * Hides a subcommand from parent help output, shell completions, and
+ * Omits a subcommand from parent help output, shell completions, and
  * "did you mean?" suggestions while keeping it fully invocable by exact name.
  *
  * **When to use**
@@ -1218,7 +1218,7 @@ export const withAlias: {
  * Use when experimental or internal subcommands should be accepted but not advertised on
  * the public CLI surface.
  *
- * **Example** (Hiding a subcommand)
+ * **Example** (Unlisting a subcommand)
  *
  * ```ts import.meta.vitest
  * import { Command } from "effect/unstable/cli"
@@ -1226,23 +1226,23 @@ export const withAlias: {
  * // `experimental` still runs when invoked as `mycli experimental`,
  * // but it does not appear under SUBCOMMANDS in `mycli --help`.
  * const experimental = Command.make("experimental").pipe(
- *   Command.withHidden
+ *   Command.unlisted
  * )
  *
  * const root = Command.make("mycli").pipe(
  *   Command.withSubcommands([experimental])
  * )
  *
- * root.subcommands[0].commands[0].hidden // => true
+ * root.subcommands[0].commands[0].unlisted // => true
  * ```
  *
  * @category combinators
  * @since 4.0.0
  */
-export const withHidden = <const Name extends string, Input, E, R, ContextInput>(
+export const unlisted = <const Name extends string, Input, E, R, ContextInput>(
   self: Command<Name, Input, ContextInput, E, R>
 ): Command<Name, Input, ContextInput, E, R> =>
-  makeCommand({ ...toImpl(self), hidden: true }) as Command<Name, Input, ContextInput, E, R>
+  makeCommand({ ...toImpl(self), unlisted: true }) as Command<Name, Input, ContextInput, E, R>
 
 /**
  * Adds a custom annotation to a command.

--- a/packages/effect/src/unstable/cli/internal/command.ts
+++ b/packages/effect/src/unstable/cli/internal/command.ts
@@ -98,7 +98,7 @@ export const makeCommand = <const Name extends string, Input, E, R, ContextInput
   readonly description?: string | undefined
   readonly shortDescription?: string | undefined
   readonly alias?: string | undefined
-  readonly hidden?: boolean | undefined
+  readonly unlisted?: boolean | undefined
   readonly examples?: ReadonlyArray<Command.Example> | undefined
   readonly subcommands?: ReadonlyArray<SubcommandGroup> | undefined
   readonly parse?: ((input: ParsedTokens) => Effect.Effect<Input, CliError.CliError, Environment>) | undefined
@@ -148,8 +148,8 @@ export const makeCommand = <const Name extends string, Input, E, R, ContextInput
 
     let usage = commandPath.length > 0 ? commandPath.join(" ") : options.name
     // Only render `<subcommand>` in usage when at least one visible subcommand
-    // exists; an all-hidden subcommand tree should look like a leaf command.
-    if (subcommands.some((group) => group.commands.some((c) => !c.hidden))) {
+    // exists; an all-unlisted subcommand tree should look like a leaf command.
+    if (subcommands.some((group) => group.commands.some((c) => !c.unlisted))) {
       usage += " <subcommand>"
     }
     usage += " [flags]"
@@ -172,10 +172,10 @@ export const makeCommand = <const Name extends string, Input, E, R, ContextInput
     const subcommandDocs: Array<SubcommandGroupDoc> = []
 
     for (const group of subcommands) {
-      // Hidden subcommands still parse on the command line but are omitted
+      // Unlisted subcommands still parse on the command line but are omitted
       // from --help. Drop the whole group when nothing visible remains so we
       // don't render an empty heading.
-      const visible = group.commands.filter((c) => !c.hidden)
+      const visible = group.commands.filter((c) => !c.unlisted)
       if (visible.length === 0) continue
       subcommandDocs.push({
         group: group.group,
@@ -208,7 +208,7 @@ export const makeCommand = <const Name extends string, Input, E, R, ContextInput
     annotations,
     globalFlags,
     subcommands,
-    hidden: options.hidden ?? false,
+    unlisted: options.unlisted ?? false,
     config,
     contextConfig,
     service,

--- a/packages/effect/src/unstable/cli/internal/completions/descriptor.ts
+++ b/packages/effect/src/unstable/cli/internal/completions/descriptor.ts
@@ -110,9 +110,9 @@ export const fromCommand = (cmd: Command.Any): Completions.CommandDescriptor => 
   const subcommands: Array<Completions.CommandDescriptor> = []
   for (const group of cmd.subcommands) {
     for (const subcommand of group.commands) {
-      // Omit hidden subcommands from completion scripts so tab-completion in
+      // Omit unlisted subcommands from completion scripts so tab-completion in
       // the shell does not advertise commands that are absent from --help.
-      if (subcommand.hidden) continue
+      if (subcommand.unlisted) continue
       subcommands.push(fromCommand(subcommand))
     }
   }

--- a/packages/effect/src/unstable/cli/internal/parser.ts
+++ b/packages/effect/src/unstable/cli/internal/parser.ts
@@ -826,12 +826,12 @@ const resolveFirstValue = (
   // Not a subcommand. Check if this looks like a typo.
   const expectsArgs = toImpl(command).config.arguments.length > 0
   if (!expectsArgs && subIndex.size > 0) {
-    // Exclude hidden subcommands so a typo cannot reveal a subcommand name
-    // that was intentionally kept out of --help. Hidden commands still
+    // Exclude unlisted subcommands so a typo cannot reveal a subcommand name
+    // that was intentionally kept out of --help. Unlisted commands still
     // resolve via subIndex when invoked by exact name.
     const visibleKeys: Array<string> = []
     for (const [key, sub] of subIndex) {
-      if (!sub.hidden) visibleKeys.push(key)
+      if (!sub.unlisted) visibleKeys.push(key)
     }
     const suggestions = suggest(value, visibleKeys)
     state.errors.push(

--- a/packages/effect/src/unstable/cli/internal/wizard.ts
+++ b/packages/effect/src/unstable/cli/internal/wizard.ts
@@ -54,7 +54,7 @@ const promptCommand: (
 ) => Effect.Effect<void, CliError.CliError | Terminal.QuitError, Command.Environment> = Effect.fnUntraced(
   function*(command, commandLine, sectionName) {
     const impl = toImpl(command)
-    const visibleSubcommands = command.subcommands.flatMap((group) => group.commands.filter((child) => !child.hidden))
+    const visibleSubcommands = command.subcommands.flatMap((group) => group.commands.filter((child) => !child.unlisted))
     const config = visibleSubcommands.length === 0 ? impl.config : impl.contextConfig
 
     if (config.flags.length > 0) {
@@ -103,7 +103,7 @@ const promptCommand: (
 )
 
 const hasWizardSteps = (command: Command.Command.Any): boolean => {
-  const hasVisibleSubcommands = command.subcommands.some((group) => group.commands.some((child) => !child.hidden))
+  const hasVisibleSubcommands = command.subcommands.some((group) => group.commands.some((child) => !child.unlisted))
   return hasVisibleSubcommands || toImpl(command).config.orderedParams.length > 0
 }
 

--- a/packages/effect/test/unstable/cli/Command.test.ts
+++ b/packages/effect/test/unstable/cli/Command.test.ts
@@ -725,22 +725,22 @@ describe("Command", () => {
   })
 
   describe("withSubcommands", () => {
-    it("preserves hidden metadata when adding subcommands", () => {
+    it("preserves unlisted metadata when adding subcommands", () => {
       const withChild = Command.make("internal").pipe(
-        Command.withHidden,
+        Command.unlisted,
         Command.withSubcommands([Command.make("child")])
       )
 
-      assert.isTrue(withChild.hidden)
+      assert.isTrue(withChild.unlisted)
     })
 
-    it("preserves hidden metadata when adding shared flags", () => {
+    it("preserves unlisted metadata when adding shared flags", () => {
       const withShared = Command.make("internal").pipe(
-        Command.withHidden,
+        Command.unlisted,
         Command.withSharedFlags({ verbose: Flag.boolean("verbose") })
       )
 
-      assert.isTrue(withShared.hidden)
+      assert.isTrue(withShared.unlisted)
     })
 
     it.effect("should execute parent handler when no subcommand provided", () =>

--- a/packages/effect/test/unstable/cli/Help.test.ts
+++ b/packages/effect/test/unstable/cli/Help.test.ts
@@ -181,14 +181,14 @@ describe("Command help output", () => {
       expect(errorText + helpText).not.toContain("experimental-foo")
     }).pipe(Effect.provide(TestLayer)))
 
-  it.effect("hides subcommands marked with withHidden from help output", () =>
+  it.effect("hides unlisted subcommands from help output", () =>
     Effect.gen(function*() {
       const visible = Command.make("visible").pipe(
         Command.withDescription("A visible subcommand")
       )
       const secret = Command.make("experimental-foo").pipe(
         Command.withDescription("Should not appear"),
-        Command.withHidden
+        Command.unlisted
       )
       const root = Command.make("tool").pipe(
         Command.withSubcommands([visible, secret])
@@ -203,11 +203,11 @@ describe("Command help output", () => {
       expect(helpText).not.toContain("Should not appear")
     }).pipe(Effect.provide(TestLayer)))
 
-  it.effect("hidden subcommand still parses on the command line", () =>
+  it.effect("unlisted subcommand still parses on the command line", () =>
     Effect.gen(function*() {
       let invoked = false
       const secret = Command.make("experimental-foo").pipe(
-        Command.withHidden,
+        Command.unlisted,
         Command.withHandler(() =>
           Effect.sync(() => {
             invoked = true
@@ -224,9 +224,9 @@ describe("Command help output", () => {
       expect(invoked).toBe(true)
     }).pipe(Effect.provide(TestLayer)))
 
-  it.effect("hidden subcommand name does not leak through unknown-subcommand suggestions", () =>
+  it.effect("unlisted subcommand name does not leak through unknown-subcommand suggestions", () =>
     Effect.gen(function*() {
-      const secret = Command.make("experimental-foo").pipe(Command.withHidden)
+      const secret = Command.make("experimental-foo").pipe(Command.unlisted)
       const root = Command.make("tool").pipe(
         Command.withSubcommands([secret])
       )
@@ -241,9 +241,9 @@ describe("Command help output", () => {
       expect(errorText + helpText).not.toContain("experimental-foo")
     }).pipe(Effect.provide(TestLayer)))
 
-  it.effect("subcommand group with only hidden commands disappears entirely", () =>
+  it.effect("subcommand group with only unlisted commands disappears entirely", () =>
     Effect.gen(function*() {
-      const secret = Command.make("experimental-foo").pipe(Command.withHidden)
+      const secret = Command.make("experimental-foo").pipe(Command.unlisted)
       const root = Command.make("tool").pipe(
         Command.withSubcommands([secret])
       )


### PR DESCRIPTION
Renames the `Command.withHidden` combinator in `effect/unstable/cli` to `Command.unlisted`, and renames the backing `hidden` command state to `unlisted`.

Rationale: `with*` combinators normally take an argument (`withDescription("...")`), so the argument-less `withHidden` broke the convention's shape, and "hidden" could suggest the command is disabled rather than just omitted from help output.

Changes:

- `Command.withHidden` renamed to `Command.unlisted`
- `Command` and `Command.Any` property `hidden` renamed to `unlisted`, including the internal constructor option and all internal reads (help, wizard, parser suggestions, shell completions)
- Tests, doc comments, and doctest example updated
- `Flag.withHidden` / `Param.withHidden` untouched (flag-level concept, out of scope)

All `unstable/cli` tests (326) and Command doctests pass; `pnpm check` is clean.

Closes EFF-446

🤖 Generated with [Claude Code](https://claude.com/claude-code)
