### PR TITLE
Vendor find-my-way router

### DIFF
--- a/.changeset/fuzzy-routers-smile.md
+++ b/.changeset/fuzzy-routers-smile.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix several edge cases in the vendored FindMyWay router.

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -113,7 +113,6 @@
   "dependencies": {
     "@standard-schema/spec": "^1.1.0",
     "fast-check": "^4.9.0",
-    "find-my-way-ts": "^0.1.6",
     "kubernetes-types": "^1.30.0",
     "msgpackr": "^2.0.4",
     "multipasta": "^0.2.8",

--- a/packages/effect/src/unstable/http/FindMyWay.ts
+++ b/packages/effect/src/unstable/http/FindMyWay.ts
@@ -1,15 +1,74 @@
-/**
- * Re-exports the `find-my-way-ts` router package used by the unstable HTTP
- * routing modules.
+/*
+ * MIT License
  *
- * This module keeps the router types and helpers available from the Effect HTTP
- * namespace without wrapping or changing them.
+ * Copyright (c) 2017-2019 Tomas Della Vedova
  *
- * @since 4.0.0
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 
 /**
- * @category re-exports
+ * A radix-tree HTTP router used by the unstable HTTP routing modules.
+ *
  * @since 4.0.0
  */
-export * from "find-my-way-ts"
+import * as internal from "./FindMyWay/internal/router.ts"
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export interface RouterConfig {
+  readonly ignoreTrailingSlash: boolean
+  readonly ignoreDuplicateSlashes: boolean
+  readonly caseSensitive: boolean
+  readonly maxParamLength: number
+}
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type PathInput = `/${string}` | "*"
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export interface Router<A> {
+  readonly on: (method: string | Iterable<string>, path: PathInput, handler: A) => void
+  readonly all: (path: PathInput, handler: A) => void
+  readonly find: (method: string, url: string) => FindResult<A> | undefined
+  readonly has: (method: string, url: string) => boolean
+}
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export interface FindResult<A> {
+  readonly handler: A
+  readonly params: Record<string, string | undefined>
+  readonly searchParams: Record<string, string | Array<string>>
+}
+
+/**
+ * @since 4.0.0
+ * @category constructors
+ */
+export const make: <A>(options?: Partial<RouterConfig>) => Router<A> = internal.make

--- a/packages/effect/src/unstable/http/FindMyWay.ts
+++ b/packages/effect/src/unstable/http/FindMyWay.ts
@@ -1,3 +1,10 @@
+/**
+ * A radix-tree HTTP router used by the unstable HTTP routing modules.
+ *
+ * @since 4.0.0
+ */
+import * as internal from "./FindMyWay/internal/router.ts"
+
 /*
  * MIT License
  *
@@ -21,13 +28,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
-/**
- * A radix-tree HTTP router used by the unstable HTTP routing modules.
- *
- * @since 4.0.0
- */
-import * as internal from "./FindMyWay/internal/router.ts"
 
 /**
  * @since 4.0.0

--- a/packages/effect/src/unstable/http/FindMyWay/internal/queryString.ts
+++ b/packages/effect/src/unstable/http/FindMyWay/internal/queryString.ts
@@ -1,0 +1,420 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017-2019 Tomas Della Vedova
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @since 1.0.0
+ */
+// Taken from https://github.com/anonrig/fast-querystring under MIT License
+const plusRegex = /\+/g
+const Empty: new() => Record<string, any> = function() {} as any
+Empty.prototype = Object.create(null)
+
+/**
+ * @category parsing
+ * @since 1.0.0
+ */
+export function parse(input: string) {
+  // Optimization: Use new Empty() instead of Object.create(null) for performance
+  // v8 has a better optimization for initializing functions compared to Object
+  const result = new Empty()
+
+  if (typeof input !== "string") {
+    return result
+  }
+
+  const inputLength = input.length
+  let key = ""
+  let value = ""
+  let startingIndex = -1
+  let equalityIndex = -1
+  let shouldDecodeKey = false
+  let shouldDecodeValue = false
+  let keyHasPlus = false
+  let valueHasPlus = false
+  let hasBothKeyValuePair = false
+  let c = 0
+
+  // Have a boundary of input.length + 1 to access last pair inside the loop.
+  for (let i = 0; i < inputLength + 1; i++) {
+    c = i !== inputLength ? input.charCodeAt(i) : 38
+
+    // Handle '&' and end of line to pass the current values to result
+    if (c === 38) {
+      hasBothKeyValuePair = equalityIndex > startingIndex
+
+      // Optimization: Reuse equality index to store the end of key
+      if (!hasBothKeyValuePair) {
+        equalityIndex = i
+      }
+
+      key = input.slice(startingIndex + 1, equalityIndex)
+
+      // Add key/value pair only if the range size is greater than 1; a.k.a. contains at least "="
+      if (hasBothKeyValuePair || key.length > 0) {
+        // Optimization: Replace '+' with space
+        if (keyHasPlus) {
+          key = key.replace(plusRegex, " ")
+        }
+
+        // Optimization: Do not decode if it's not necessary.
+        if (shouldDecodeKey) {
+          try {
+            key = decodeURIComponent(key) || key
+          } catch {}
+        }
+
+        if (hasBothKeyValuePair) {
+          value = input.slice(equalityIndex + 1, i)
+
+          if (valueHasPlus) {
+            value = value.replace(plusRegex, " ")
+          }
+
+          if (shouldDecodeValue) {
+            try {
+              value = decodeURIComponent(value) || value
+            } catch {}
+          }
+        }
+        const currentValue = result[key]
+
+        if (currentValue === undefined) {
+          result[key] = value
+        } else {
+          // Optimization: value.pop is faster than Array.isArray(value)
+          if (currentValue.pop) {
+            currentValue.push(value)
+          } else {
+            result[key] = [currentValue, value]
+          }
+        }
+      }
+
+      // Reset reading key value pairs
+      value = ""
+      startingIndex = i
+      equalityIndex = i
+      shouldDecodeKey = false
+      shouldDecodeValue = false
+      keyHasPlus = false
+      valueHasPlus = false
+    } // Check '='
+    else if (c === 61) {
+      if (equalityIndex <= startingIndex) {
+        equalityIndex = i
+      } // If '=' character occurs again, we should decode the input.
+      else {
+        shouldDecodeValue = true
+      }
+    } // Check '+', and remember to replace it with empty space.
+    else if (c === 43) {
+      if (equalityIndex > startingIndex) {
+        valueHasPlus = true
+      } else {
+        keyHasPlus = true
+      }
+    } // Check '%' character for encoding
+    else if (c === 37) {
+      if (equalityIndex > startingIndex) {
+        shouldDecodeValue = true
+      } else {
+        shouldDecodeKey = true
+      }
+    }
+  }
+
+  return result
+}
+
+function getAsPrimitive(value: any) {
+  const type = typeof value
+
+  if (type === "string") {
+    // Length check is handled inside encodeString function
+    return encodeString(value)
+  } else if (type === "bigint" || type === "boolean") {
+    return "" + value
+  } else if (type === "number" && Number.isFinite(value)) {
+    return value < 1e21 ? "" + value : encodeString("" + value)
+  }
+
+  return ""
+}
+
+/**
+ * @category encoding
+ * @since 1.0.0
+ */
+export function stringify(input: Record<string, any>): string {
+  let result = ""
+
+  if (input === null || typeof input !== "object") {
+    return result
+  }
+
+  const separator = "&"
+  const keys = Object.keys(input)
+  const keyLength = keys.length
+  let valueLength = 0
+
+  for (let i = 0; i < keyLength; i++) {
+    const key = keys[i]
+    const value = input[key]
+    const encodedKey = encodeString(key) + "="
+
+    if (i) {
+      result += separator
+    }
+
+    if (Array.isArray(value)) {
+      valueLength = value.length
+      for (let j = 0; j < valueLength; j++) {
+        if (j) {
+          result += separator
+        }
+
+        // Optimization: Dividing into multiple lines improves the performance.
+        // Since v8 does not need to care about the '+' character if it was one-liner.
+        result += encodedKey
+        result += getAsPrimitive(value[j])
+      }
+    } else {
+      result += encodedKey
+      result += getAsPrimitive(value)
+    }
+  }
+
+  return result
+}
+
+// -----------------------------------------------------------------------------
+
+// This has been taken from Node.js project.
+// Full implementation can be found from https://github.com/nodejs/node/blob/main/lib/internal/querystring.js
+
+const hexTable = Array.from(
+  { length: 256 },
+  (_, i) => "%" + ((i < 16 ? "0" : "") + i.toString(16)).toUpperCase()
+)
+
+// These characters do not need escaping when generating query strings:
+// ! - . _ ~
+// ' ( ) *
+// digits
+// alpha (uppercase)
+// alpha (lowercase)
+// biome-ignore format: the array should not be formatted
+const noEscape = new Int8Array([
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0, // 0 - 15
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0, // 16 - 31
+  0,
+  1,
+  0,
+  0,
+  0,
+  0,
+  0,
+  1,
+  1,
+  1,
+  1,
+  0,
+  0,
+  1,
+  1,
+  0, // 32 - 47
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0, // 48 - 63
+  0,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1, // 64 - 79
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  0,
+  0,
+  0,
+  0,
+  1, // 80 - 95
+  0,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1, // 96 - 111
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  0,
+  0,
+  0,
+  1,
+  0 // 112 - 127
+])
+
+function encodeString(str: string) {
+  const len = str.length
+  if (len === 0) return ""
+
+  let out = ""
+  let lastPos = 0
+  let i = 0
+
+  outer: for (; i < len; i++) {
+    let c = str.charCodeAt(i)
+
+    // ASCII
+    while (c < 0x80) {
+      if (noEscape[c] !== 1) {
+        if (lastPos < i) out += str.slice(lastPos, i)
+        lastPos = i + 1
+        out += hexTable[c]
+      }
+
+      if (++i === len) break outer
+
+      c = str.charCodeAt(i)
+    }
+
+    if (lastPos < i) out += str.slice(lastPos, i)
+
+    // Multi-byte characters ...
+    if (c < 0x800) {
+      lastPos = i + 1
+      out += hexTable[0xc0 | (c >> 6)] + hexTable[0x80 | (c & 0x3f)]
+      continue
+    }
+    if (c < 0xd800 || c >= 0xe000) {
+      lastPos = i + 1
+      out += hexTable[0xe0 | (c >> 12)] +
+        hexTable[0x80 | ((c >> 6) & 0x3f)] +
+        hexTable[0x80 | (c & 0x3f)]
+      continue
+    }
+    // Surrogate pair
+    ++i
+
+    // This branch should never happen because all URLSearchParams entries
+    // should already be converted to USVString. But, included for
+    // completion's sake anyway.
+    if (i >= len) {
+      throw new Error("URI malformed")
+    }
+
+    const c2 = str.charCodeAt(i) & 0x3ff
+
+    lastPos = i + 1
+    c = 0x10000 + (((c & 0x3ff) << 10) | c2)
+    out += hexTable[0xf0 | (c >> 18)] +
+      hexTable[0x80 | ((c >> 12) & 0x3f)] +
+      hexTable[0x80 | ((c >> 6) & 0x3f)] +
+      hexTable[0x80 | (c & 0x3f)]
+  }
+  if (lastPos === 0) return str
+  if (lastPos < len) return out + str.slice(lastPos)
+  return out
+}

--- a/packages/effect/src/unstable/http/FindMyWay/internal/router.ts
+++ b/packages/effect/src/unstable/http/FindMyWay/internal/router.ts
@@ -506,7 +506,7 @@ abstract class NodeBase {
 }
 
 abstract class ParentNode extends NodeBase {
-  readonly staticChildren: Record<string, StaticNode> = {}
+  readonly staticChildren: Record<string, StaticNode> = Object.create(null)
 
   findStaticMatchingChild(
     path: string,
@@ -760,7 +760,7 @@ function compileCreateParams(
 ): (paramsArray: ReadonlyArray<string>) => Record<string, string> {
   const len = params.length
   return function(paramsArray) {
-    const paramsObject: Record<string, string> = {}
+    const paramsObject: Record<string, string> = Object.create(null)
     for (let i = 0; i < len; i++) {
       paramsObject[params[i]] = paramsArray[i]
     }
@@ -895,6 +895,8 @@ function safeDecodeURIComponent(uriComponent: string) {
 
   for (let i = startIndex; i < uriComponent.length; i++) {
     if (uriComponent.charCodeAt(i) === 37) {
+      if (i + 2 >= uriComponent.length) break
+
       const highCharCode = uriComponent.charCodeAt(i + 1)
       const lowCharCode = uriComponent.charCodeAt(i + 2)
 

--- a/packages/effect/src/unstable/http/FindMyWay/internal/router.ts
+++ b/packages/effect/src/unstable/http/FindMyWay/internal/router.ts
@@ -54,7 +54,7 @@ class RouterImpl<A> implements Router.Router<A> {
 
   readonly options: Router.RouterConfig
   routes: Array<Route> = []
-  trees: Record<string, StaticNode> = {}
+  trees: Record<string, StaticNode> = Object.create(null)
 
   on(
     method: string | Iterable<string>,
@@ -72,10 +72,10 @@ class RouterImpl<A> implements Router.Router<A> {
         OPTIONAL_PARAM_REGEXP,
         "$1$2"
       ) as Router.PathInput
-      const pathOptional = path.replace(
+      const pathOptional = (path.replace(
         OPTIONAL_PARAM_REGEXP,
         "$2"
-      ) as Router.PathInput
+      ) || "/") as Router.PathInput
 
       this.on(method, pathFull, handler)
       this.on(method, pathOptional, handler)
@@ -145,7 +145,10 @@ class RouterImpl<A> implements Router.Router<A> {
 
       if (isParametricNode) {
         let isRegexNode = false
+        let isParamSafe = true
+        let backtrack = ""
         const regexps = []
+        let nodePatternParts = ""
 
         let lastParamStartIndex = i + 1
         for (let j = lastParamStartIndex;; j++) {
@@ -168,8 +171,10 @@ class RouterImpl<A> implements Router.Router<A> {
               regexps.push(trimRegExpStartAndEnd(regexString))
 
               j = endOfRegexIndex + 1
+              isParamSafe = true
             } else {
-              regexps.push("(.*?)")
+              regexps.push(isParamSafe ? "(.*?)" : `(${backtrack}|(?:(?!${backtrack}).)*)`)
+              isParamSafe = false
             }
 
             const staticPartStartIndex = j
@@ -187,17 +192,18 @@ class RouterImpl<A> implements Router.Router<A> {
             if (staticPart) {
               staticPart = staticPart.split("::").join(":")
               staticPart = staticPart.split("%").join("%25")
-              regexps.push(escapeRegExp(staticPart))
+              regexps.push(backtrack = escapeRegExp(staticPart))
             }
 
             lastParamStartIndex = j + 1
+            nodePatternParts += "()" + staticPart
 
             if (
               isEndOfNode ||
               pattern.charCodeAt(j) === 47 ||
               j === pattern.length
             ) {
-              const nodePattern = isRegexNode ? "()" + staticPart : staticPart
+              const nodePattern = isRegexNode ? nodePatternParts : staticPart
               const nodePath = pattern.slice(i, j)
 
               pattern = pattern.slice(0, i + 1) + nodePattern + pattern.slice(j)
@@ -342,24 +348,23 @@ class RouterImpl<A> implements Router.Router<A> {
 
       currentNode = node
 
-      // static route
-      if (currentNode._tag === "StaticNode") {
-        pathIndex += currentNode.prefix.length
-        continue
-      }
-
-      if (currentNode._tag === "WildcardNode") {
-        let param = originPath.slice(pathIndex)
-        if (shouldDecodeParam) {
-          param = safeDecodeURIComponent(param)
+      while (true) {
+        if (currentNode._tag === "StaticNode") {
+          pathIndex += currentNode.prefix.length
+          break
         }
 
-        params.push(param)
-        pathIndex = pathLen
-        continue
-      }
+        if (currentNode._tag === "WildcardNode") {
+          let param = originPath.slice(pathIndex)
+          if (shouldDecodeParam) {
+            param = safeDecodeURIComponent(param)
+          }
 
-      if (currentNode._tag === "ParametricNode") {
+          params.push(param)
+          pathIndex = pathLen
+          break
+        }
+
         let paramEndIndex = originPath.indexOf("/", pathIndex)
         if (paramEndIndex === -1) {
           paramEndIndex = pathLen
@@ -372,23 +377,59 @@ class RouterImpl<A> implements Router.Router<A> {
 
         if (currentNode.regex !== undefined) {
           const matchedParameters: RegExpExecArray | null = currentNode.regex.exec(param)
-          if (matchedParameters === null) continue
-
-          for (let i = 1; i < matchedParameters.length; i++) {
-            const matchedParam: string = matchedParameters[i]
-            if (matchedParam.length > maxParamLength) {
+          if (matchedParameters === null) {
+            if (brothersNodesStack.length === 0) {
               return undefined
             }
-            params.push(matchedParam)
+
+            const brotherNodeState = brothersNodesStack.pop()!
+            pathIndex = brotherNodeState.brotherPathIndex
+            params.splice(brotherNodeState.paramsCount)
+            currentNode = brotherNodeState.brotherNode
+            continue
+          }
+
+          let maxParamLengthExceeded = false
+          for (let i = 1; i < matchedParameters.length; i++) {
+            const matchedParam = matchedParameters[i] ?? ""
+            if (matchedParam.length > maxParamLength) {
+              maxParamLengthExceeded = true
+              break
+            }
+          }
+
+          if (maxParamLengthExceeded) {
+            if (brothersNodesStack.length === 0) {
+              return undefined
+            }
+
+            const brotherNodeState = brothersNodesStack.pop()!
+            pathIndex = brotherNodeState.brotherPathIndex
+            params.splice(brotherNodeState.paramsCount)
+            currentNode = brotherNodeState.brotherNode
+            continue
+          }
+
+          for (let i = 1; i < matchedParameters.length; i++) {
+            params.push(matchedParameters[i] ?? "")
           }
         } else {
           if (param.length > maxParamLength) {
-            return undefined
+            if (brothersNodesStack.length === 0) {
+              return undefined
+            }
+
+            const brotherNodeState = brothersNodesStack.pop()!
+            pathIndex = brotherNodeState.brotherPathIndex
+            params.splice(brotherNodeState.paramsCount)
+            currentNode = brotherNodeState.brotherNode
+            continue
           }
           params.push(param)
         }
 
         pathIndex = paramEndIndex
+        break
       }
     }
   }
@@ -893,6 +934,7 @@ const httpMethods = [
   "PROPPATCH",
   "PURGE",
   "PUT",
+  "QUERY",
   "REBIND",
   "REPORT",
   "SEARCH",

--- a/packages/effect/src/unstable/http/FindMyWay/internal/router.ts
+++ b/packages/effect/src/unstable/http/FindMyWay/internal/router.ts
@@ -1,0 +1,906 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017-2019 Tomas Della Vedova
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import type * as Router from "../../FindMyWay.ts"
+import * as QS from "./queryString.ts"
+
+const FULL_PATH_REGEXP = /^https?:\/\/.*?\//
+const OPTIONAL_PARAM_REGEXP = /(\/:[^/()]*?)\?(\/?)/
+
+interface Route<A = unknown> {
+  readonly method: string
+  readonly path: Router.PathInput
+  readonly pattern: string
+  readonly handler: A
+  readonly params: ReadonlyArray<string>
+}
+
+/** @internal */
+export const make = <A>(
+  options: Partial<Router.RouterConfig> = {}
+): Router.Router<A> => new RouterImpl(options)
+
+class RouterImpl<A> implements Router.Router<A> {
+  constructor(options: Partial<Router.RouterConfig> = {}) {
+    this.options = {
+      ignoreTrailingSlash: true,
+      ignoreDuplicateSlashes: true,
+      caseSensitive: false,
+      maxParamLength: 100,
+      ...options
+    }
+  }
+
+  readonly options: Router.RouterConfig
+  routes: Array<Route> = []
+  trees: Record<string, StaticNode> = {}
+
+  on(
+    method: string | Iterable<string>,
+    path: Router.PathInput,
+    handler: A
+  ): void {
+    const optionalParamMatch = path.match(OPTIONAL_PARAM_REGEXP)
+    if (optionalParamMatch && optionalParamMatch.index !== undefined) {
+      assert(
+        path.length === optionalParamMatch.index + optionalParamMatch[0].length,
+        "Optional Parameter needs to be the last parameter of the path"
+      )
+
+      const pathFull = path.replace(
+        OPTIONAL_PARAM_REGEXP,
+        "$1$2"
+      ) as Router.PathInput
+      const pathOptional = path.replace(
+        OPTIONAL_PARAM_REGEXP,
+        "$2"
+      ) as Router.PathInput
+
+      this.on(method, pathFull, handler)
+      this.on(method, pathOptional, handler)
+      return
+    }
+
+    if (this.options.ignoreDuplicateSlashes) {
+      path = removeDuplicateSlashes(path)
+    }
+
+    if (this.options.ignoreTrailingSlash) {
+      path = trimLastSlash(path)
+    }
+
+    const methods = typeof method === "string" ? [method] : method
+    for (const method of methods) {
+      this._on(method, path, handler)
+    }
+  }
+
+  all(path: Router.PathInput, handler: A) {
+    this.on(httpMethods, path, handler)
+  }
+
+  private _on(method: string, path: Router.PathInput, handler: A): void {
+    if (this.trees[method] === undefined) {
+      this.trees[method] = new StaticNode("/")
+    }
+
+    let pattern = path
+    if (pattern === "*" && this.trees[method].prefix.length !== 0) {
+      const currentRoot = this.trees[method]
+      this.trees[method] = new StaticNode("")
+      this.trees[method].staticChildren["/"] = currentRoot
+    }
+
+    let parentNodePathIndex = this.trees[method].prefix.length
+    let currentNode: Node = this.trees[method]
+
+    const params = []
+    for (let i = 0; i <= pattern.length; i++) {
+      if (pattern.charCodeAt(i) === 58 && pattern.charCodeAt(i + 1) === 58) {
+        // It's a double colon
+        i++
+        continue
+      }
+
+      const isParametricNode = pattern.charCodeAt(i) === 58 && pattern.charCodeAt(i + 1) !== 58
+      const isWildcardNode = pattern.charCodeAt(i) === 42
+
+      if (
+        isParametricNode ||
+        isWildcardNode ||
+        (i === pattern.length && i !== parentNodePathIndex)
+      ) {
+        let staticNodePath = pattern.slice(parentNodePathIndex, i)
+        if (!this.options.caseSensitive) {
+          staticNodePath = staticNodePath.toLowerCase()
+        }
+        staticNodePath = staticNodePath.split("::").join(":")
+        staticNodePath = staticNodePath.split("%").join("%25")
+        // add the static part of the route to the tree
+        currentNode = (currentNode as StaticNode).createStaticChild(
+          staticNodePath
+        )
+      }
+
+      if (isParametricNode) {
+        let isRegexNode = false
+        const regexps = []
+
+        let lastParamStartIndex = i + 1
+        for (let j = lastParamStartIndex;; j++) {
+          const charCode = pattern.charCodeAt(j)
+
+          const isRegexParam = charCode === 40
+          const isStaticPart = charCode === 45 || charCode === 46
+          const isEndOfNode = charCode === 47 || j === pattern.length
+
+          if (isRegexParam || isStaticPart || isEndOfNode) {
+            const paramName = pattern.slice(lastParamStartIndex, j)
+            params.push(paramName)
+
+            isRegexNode = isRegexNode || isRegexParam || isStaticPart
+
+            if (isRegexParam) {
+              const endOfRegexIndex = getClosingParenthensePosition(pattern, j)
+              const regexString = pattern.slice(j, endOfRegexIndex + 1)
+
+              regexps.push(trimRegExpStartAndEnd(regexString))
+
+              j = endOfRegexIndex + 1
+            } else {
+              regexps.push("(.*?)")
+            }
+
+            const staticPartStartIndex = j
+            for (; j < pattern.length; j++) {
+              const charCode = pattern.charCodeAt(j)
+              if (charCode === 47) break
+              if (charCode === 58) {
+                const nextCharCode = pattern.charCodeAt(j + 1)
+                if (nextCharCode === 58) j++
+                else break
+              }
+            }
+
+            let staticPart = pattern.slice(staticPartStartIndex, j)
+            if (staticPart) {
+              staticPart = staticPart.split("::").join(":")
+              staticPart = staticPart.split("%").join("%25")
+              regexps.push(escapeRegExp(staticPart))
+            }
+
+            lastParamStartIndex = j + 1
+
+            if (
+              isEndOfNode ||
+              pattern.charCodeAt(j) === 47 ||
+              j === pattern.length
+            ) {
+              const nodePattern = isRegexNode ? "()" + staticPart : staticPart
+              const nodePath = pattern.slice(i, j)
+
+              pattern = pattern.slice(0, i + 1) + nodePattern + pattern.slice(j)
+              i += nodePattern.length
+
+              const regex = isRegexNode
+                ? new RegExp("^" + regexps.join("") + "$")
+                : undefined
+              currentNode = (currentNode as StaticNode).createParametricChild(
+                regex,
+                staticPart,
+                nodePath
+              )
+              parentNodePathIndex = i + 1
+              break
+            }
+          }
+        }
+      } else if (isWildcardNode) {
+        // add the wildcard parameter
+        params.push("*")
+        currentNode = (currentNode as StaticNode).createWildcardChild()
+        parentNodePathIndex = i + 1
+
+        if (i !== pattern.length - 1) {
+          throw new Error("Wildcard must be the last character in the route")
+        }
+      }
+    }
+
+    if (!this.options.caseSensitive) {
+      pattern = pattern.toLowerCase() as Router.PathInput
+    }
+
+    if (pattern === "*") {
+      pattern = "/*"
+    }
+
+    for (const existRoute of this.routes) {
+      if (existRoute.method === method && existRoute.pattern === pattern) {
+        throw new Error(
+          `Method '${method}' already declared for route '${pattern}'`
+        )
+      }
+    }
+
+    const route = { method, path, pattern, params, handler }
+    this.routes.push(route)
+    currentNode.addRoute(route)
+  }
+
+  has(method: string, path: string): boolean {
+    const node = this.trees[method]
+    if (node === undefined) {
+      return false
+    }
+
+    const staticNode = node.getStaticChild(path)
+    if (staticNode === undefined) {
+      return false
+    }
+
+    return staticNode.isLeafNode
+  }
+
+  find(method: string, path: string): Router.FindResult<A> | undefined {
+    let currentNode: Node | undefined = this.trees[method]
+    if (currentNode === undefined) return undefined
+
+    if (path.charCodeAt(0) !== 47) {
+      // 47 is '/'
+      path = path.replace(FULL_PATH_REGEXP, "/")
+    }
+
+    // This must be run before sanitizeUrl as the resulting function
+    // .sliceParameter must be constructed with same URL string used
+    // throughout the rest of this function.
+    if (this.options.ignoreDuplicateSlashes) {
+      path = removeDuplicateSlashes(path)
+    }
+
+    let sanitizedUrl
+    let querystring
+    let shouldDecodeParam
+
+    try {
+      sanitizedUrl = safeDecodeURI(path)
+      path = sanitizedUrl.path
+      querystring = sanitizedUrl.querystring
+      shouldDecodeParam = sanitizedUrl.shouldDecodeParam
+    } catch (error) {
+      return undefined
+    }
+
+    if (this.options.ignoreTrailingSlash) {
+      path = trimLastSlash(path)
+    }
+
+    const originPath = path
+
+    if (this.options.caseSensitive === false) {
+      path = path.toLowerCase()
+    }
+
+    const maxParamLength = this.options.maxParamLength
+
+    let pathIndex = (currentNode as StaticNode).prefix.length
+    const params = []
+    const pathLen = path.length
+
+    const brothersNodesStack: Array<BrotherNode> = []
+
+    while (true) {
+      if (pathIndex === pathLen && currentNode.isLeafNode) {
+        const handle = currentNode.handlerStorage?.find()
+        if (handle !== undefined) {
+          return {
+            handler: handle.handler as A,
+            params: handle.createParams(params),
+            searchParams: QS.parse(querystring)
+          } as const
+        }
+      }
+
+      let node: Node | undefined = currentNode.getNextNode(
+        path,
+        pathIndex,
+        brothersNodesStack,
+        params.length
+      )
+
+      if (node === undefined) {
+        if (brothersNodesStack.length === 0) {
+          return undefined
+        }
+
+        const brotherNodeState = brothersNodesStack.pop()!
+        pathIndex = brotherNodeState.brotherPathIndex
+        params.splice(brotherNodeState.paramsCount)
+        node = brotherNodeState.brotherNode
+      }
+
+      currentNode = node
+
+      // static route
+      if (currentNode._tag === "StaticNode") {
+        pathIndex += currentNode.prefix.length
+        continue
+      }
+
+      if (currentNode._tag === "WildcardNode") {
+        let param = originPath.slice(pathIndex)
+        if (shouldDecodeParam) {
+          param = safeDecodeURIComponent(param)
+        }
+
+        params.push(param)
+        pathIndex = pathLen
+        continue
+      }
+
+      if (currentNode._tag === "ParametricNode") {
+        let paramEndIndex = originPath.indexOf("/", pathIndex)
+        if (paramEndIndex === -1) {
+          paramEndIndex = pathLen
+        }
+
+        let param = originPath.slice(pathIndex, paramEndIndex)
+        if (shouldDecodeParam) {
+          param = safeDecodeURIComponent(param)
+        }
+
+        if (currentNode.regex !== undefined) {
+          const matchedParameters: RegExpExecArray | null = currentNode.regex.exec(param)
+          if (matchedParameters === null) continue
+
+          for (let i = 1; i < matchedParameters.length; i++) {
+            const matchedParam: string = matchedParameters[i]
+            if (matchedParam.length > maxParamLength) {
+              return undefined
+            }
+            params.push(matchedParam)
+          }
+        } else {
+          if (param.length > maxParamLength) {
+            return undefined
+          }
+          params.push(param)
+        }
+
+        pathIndex = paramEndIndex
+      }
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Handler storage
+// ----------------------------------------------------------------------------
+
+interface Handler {
+  readonly params: ReadonlyArray<string>
+  readonly handler: unknown
+  readonly createParams: (
+    paramsArray: ReadonlyArray<string>
+  ) => Record<string, string>
+}
+
+class HandlerStorage {
+  readonly handlers: Array<Handler> = []
+  unconstrainedHandler: Handler | undefined
+
+  find() {
+    return this.unconstrainedHandler
+  }
+
+  add(route: Route) {
+    const handler: Handler = {
+      params: route.params,
+      handler: route.handler,
+      createParams: compileCreateParams(route.params)
+    }
+    this.handlers.push(handler)
+    this.unconstrainedHandler = this.handlers[0]
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Nodes
+// ----------------------------------------------------------------------------
+
+interface BrotherNode {
+  readonly paramsCount: number
+  readonly brotherPathIndex: number
+  readonly brotherNode: Node
+}
+
+type Node = StaticNode | ParametricNode | WildcardNode
+
+abstract class NodeBase {
+  isLeafNode = false
+  routes: Array<Route> | undefined
+  handlerStorage: HandlerStorage | undefined
+
+  addRoute(route: Route) {
+    if (this.routes === undefined) {
+      this.routes = [route]
+    } else {
+      this.routes.push(route)
+    }
+
+    if (this.handlerStorage === undefined) {
+      this.handlerStorage = new HandlerStorage()
+    }
+    this.isLeafNode = true
+    this.handlerStorage.add(route)
+  }
+
+  abstract getNextNode(
+    path: string,
+    pathIndex: number,
+    nodeStack: any,
+    paramsCount: number
+  ): Node | undefined
+}
+
+abstract class ParentNode extends NodeBase {
+  readonly staticChildren: Record<string, StaticNode> = {}
+
+  findStaticMatchingChild(
+    path: string,
+    pathIndex: number
+  ): StaticNode | undefined {
+    const staticChild = this.staticChildren[path.charAt(pathIndex)]
+    if (
+      staticChild === undefined ||
+      !staticChild.matchPrefix(path, pathIndex)
+    ) {
+      return undefined
+    }
+    return staticChild
+  }
+
+  getStaticChild(path: string, pathIndex = 0): StaticNode | undefined {
+    if (path.length === pathIndex) {
+      return this as any
+    }
+
+    const staticChild = this.findStaticMatchingChild(path, pathIndex)
+    if (staticChild === undefined) {
+      return undefined
+    }
+
+    return staticChild.getStaticChild(
+      path,
+      pathIndex + staticChild.prefix.length
+    )
+  }
+
+  createStaticChild(path: string): StaticNode {
+    if (path.length === 0) {
+      return this as any
+    }
+
+    let staticChild = this.staticChildren[path.charAt(0)]
+    if (staticChild) {
+      let i = 1
+      for (; i < staticChild.prefix.length; i++) {
+        if (path.charCodeAt(i) !== staticChild.prefix.charCodeAt(i)) {
+          staticChild = staticChild.split(this, i)
+          break
+        }
+      }
+      return staticChild.createStaticChild(path.slice(i))
+    }
+
+    const label = path.charAt(0)
+    this.staticChildren[label] = new StaticNode(path)
+    return this.staticChildren[label]
+  }
+}
+
+class StaticNode extends ParentNode {
+  readonly _tag = "StaticNode"
+  constructor(prefix: string) {
+    super()
+    this.setPrefix(prefix)
+  }
+
+  prefix!: string
+  matchPrefix!: (path: string, pathIndex: number) => boolean
+  readonly parametricChildren: Array<ParametricNode> = []
+
+  wildcardChild: WildcardNode | undefined
+
+  private setPrefix(prefix: string) {
+    this.prefix = prefix
+
+    if (prefix.length === 1) {
+      this.matchPrefix = (_path, _pathIndex) => true
+    } else {
+      const len = prefix.length
+      this.matchPrefix = function(path, pathIndex) {
+        for (let i = 1; i < len; i++) {
+          if (path.charCodeAt(pathIndex + i) !== this.prefix.charCodeAt(i)) {
+            return false
+          }
+        }
+        return true
+      }
+    }
+  }
+
+  getParametricChild(regex: RegExp | undefined): ParametricNode | undefined {
+    if (regex === undefined) {
+      return this.parametricChildren.find((child) => child.isRegex === false)
+    }
+
+    const source = regex.source
+    return this.parametricChildren.find((child) => {
+      if (child.regex === undefined) {
+        return false
+      }
+      return child.regex.source === source
+    })
+  }
+
+  createParametricChild(
+    regex: RegExp | undefined,
+    staticSuffix: string | undefined,
+    nodePath: string
+  ) {
+    let child = this.getParametricChild(regex)
+    if (child !== undefined) {
+      child.nodePaths.add(nodePath)
+      return child
+    }
+
+    child = new ParametricNode(regex, staticSuffix, nodePath)
+    this.parametricChildren.push(child)
+    this.parametricChildren.sort((child1, child2) => {
+      if (!child1.isRegex) return 1
+      if (!child2.isRegex) return -1
+
+      if (child1.staticSuffix === undefined) return 1
+      if (child2.staticSuffix === undefined) return -1
+
+      if (child2.staticSuffix.endsWith(child1.staticSuffix)) return 1
+      if (child1.staticSuffix.endsWith(child2.staticSuffix)) return -1
+
+      return 0
+    })
+
+    return child
+  }
+
+  createWildcardChild() {
+    if (this.wildcardChild === undefined) {
+      this.wildcardChild = new WildcardNode()
+    }
+    return this.wildcardChild
+  }
+
+  split(parentNode: ParentNode, length: number) {
+    const parentPrefix = this.prefix.slice(0, length)
+    const childPrefix = this.prefix.slice(length)
+
+    this.setPrefix(childPrefix)
+
+    const staticNode = new StaticNode(parentPrefix)
+    staticNode.staticChildren[childPrefix.charAt(0)] = this
+    parentNode.staticChildren[parentPrefix.charAt(0)] = staticNode
+
+    return staticNode
+  }
+
+  getNextNode(
+    path: string,
+    pathIndex: number,
+    nodeStack: Array<BrotherNode>,
+    paramsCount: number
+  ): Node | undefined {
+    let node: Node | undefined = this.findStaticMatchingChild(path, pathIndex)
+    let parametricBrotherNodeIndex = 0
+
+    if (node === undefined) {
+      if (this.parametricChildren.length === 0) {
+        return this.wildcardChild
+      }
+
+      node = this.parametricChildren[0]
+      parametricBrotherNodeIndex = 1
+    }
+
+    if (this.wildcardChild !== undefined) {
+      nodeStack.push({
+        paramsCount,
+        brotherPathIndex: pathIndex,
+        brotherNode: this.wildcardChild
+      })
+    }
+
+    for (
+      let i = this.parametricChildren.length - 1;
+      i >= parametricBrotherNodeIndex;
+      i--
+    ) {
+      nodeStack.push({
+        paramsCount,
+        brotherPathIndex: pathIndex,
+        brotherNode: this.parametricChildren[i]
+      })
+    }
+
+    return node
+  }
+}
+
+class ParametricNode extends ParentNode {
+  readonly _tag = "ParametricNode"
+  readonly regex: RegExp | undefined
+  readonly staticSuffix: string | undefined
+  constructor(
+    regex: RegExp | undefined,
+    staticSuffix: string | undefined,
+    nodePath: string
+  ) {
+    super()
+    this.regex = regex
+    this.staticSuffix = staticSuffix
+    this.isRegex = !!regex
+    this.nodePaths = new Set([nodePath])
+  }
+
+  readonly isRegex: boolean
+  readonly nodePaths: Set<string>
+
+  getNextNode(path: string, pathIndex: number) {
+    return this.findStaticMatchingChild(path, pathIndex)
+  }
+}
+
+class WildcardNode extends NodeBase {
+  readonly _tag = "WildcardNode"
+  getNextNode(
+    _path: string,
+    _pathIndex: number,
+    _nodeStack: any,
+    _paramsCount: number
+  ): Node | undefined {
+    return undefined
+  }
+}
+
+// --
+
+interface Assert {
+  (condition: any, message?: string): asserts condition
+}
+const assert: Assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message)
+  }
+}
+
+function removeDuplicateSlashes(path: string): Router.PathInput {
+  return path.replace(/\/\/+/g, "/") as Router.PathInput
+}
+
+function trimLastSlash(path: string): Router.PathInput {
+  if (path.length > 1 && path.charCodeAt(path.length - 1) === 47) {
+    return path.slice(0, -1) as Router.PathInput
+  }
+  return path as Router.PathInput
+}
+
+function compileCreateParams(
+  params: ReadonlyArray<string>
+): (paramsArray: ReadonlyArray<string>) => Record<string, string> {
+  const len = params.length
+  return function(paramsArray) {
+    const paramsObject: Record<string, string> = {}
+    for (let i = 0; i < len; i++) {
+      paramsObject[params[i]] = paramsArray[i]
+    }
+    return paramsObject
+  }
+}
+
+function getClosingParenthensePosition(path: string, idx: number) {
+  // `path.indexOf()` will always return the first position of the closing parenthese,
+  // but it's inefficient for grouped or wrong regexp expressions.
+  // see issues #62 and #63 for more info
+
+  let parentheses = 1
+
+  while (idx < path.length) {
+    idx++
+
+    // ignore skipped chars
+    if (path[idx] === "\\") {
+      idx++
+      continue
+    }
+
+    if (path[idx] === ")") {
+      parentheses--
+    } else if (path[idx] === "(") {
+      parentheses++
+    }
+
+    if (!parentheses) return idx
+  }
+
+  throw new TypeError("Invalid regexp expression in \"" + path + "\"")
+}
+
+function trimRegExpStartAndEnd(regexString: string) {
+  // removes chars that marks start "^" and end "$" of regexp
+  if (regexString.charCodeAt(1) === 94) {
+    regexString = regexString.slice(0, 1) + regexString.slice(2)
+  }
+
+  if (regexString.charCodeAt(regexString.length - 2) === 36) {
+    regexString = regexString.slice(0, regexString.length - 2) +
+      regexString.slice(regexString.length - 1)
+  }
+
+  return regexString
+}
+
+function escapeRegExp(string: string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+// It must spot all the chars where decodeURIComponent(x) !== decodeURI(x)
+// The chars are: # $ & + , / : ; = ? @
+function decodeComponentChar(highCharCode: number, lowCharCode: number) {
+  if (highCharCode === 50) {
+    if (lowCharCode === 53) return "%"
+
+    if (lowCharCode === 51) return "#"
+    if (lowCharCode === 52) return "$"
+    if (lowCharCode === 54) return "&"
+    if (lowCharCode === 66) return "+"
+    if (lowCharCode === 98) return "+"
+    if (lowCharCode === 67) return ","
+    if (lowCharCode === 99) return ","
+    if (lowCharCode === 70) return "/"
+    if (lowCharCode === 102) return "/"
+    return undefined
+  }
+  if (highCharCode === 51) {
+    if (lowCharCode === 65) return ":"
+    if (lowCharCode === 97) return ":"
+    if (lowCharCode === 66) return ";"
+    if (lowCharCode === 98) return ";"
+    if (lowCharCode === 68) return "="
+    if (lowCharCode === 100) return "="
+    if (lowCharCode === 70) return "?"
+    if (lowCharCode === 102) return "?"
+    return undefined
+  }
+  if (highCharCode === 52 && lowCharCode === 48) {
+    return "@"
+  }
+  return undefined
+}
+
+function safeDecodeURI(path: string) {
+  let shouldDecode = false
+  let shouldDecodeParam = false
+
+  let querystring = ""
+
+  for (let i = 1; i < path.length; i++) {
+    const charCode = path.charCodeAt(i)
+
+    if (charCode === 37) {
+      const highCharCode = path.charCodeAt(i + 1)
+      const lowCharCode = path.charCodeAt(i + 2)
+
+      if (decodeComponentChar(highCharCode, lowCharCode) === undefined) {
+        shouldDecode = true
+      } else {
+        shouldDecodeParam = true
+        // %25 - encoded % char. We need to encode one more time to prevent double decoding
+        if (highCharCode === 50 && lowCharCode === 53) {
+          shouldDecode = true
+          path = path.slice(0, i + 1) + "25" + path.slice(i + 1)
+          i += 2
+        }
+        i += 2
+      }
+      // Some systems do not follow RFC and separate the path and query
+      // string with a `;` character (code 59), e.g. `/foo;jsessionid=123456`.
+      // Thus, we need to split on `;` as well as `?` and `#`.
+    } else if (charCode === 63 || charCode === 59 || charCode === 35) {
+      querystring = path.slice(i + 1)
+      path = path.slice(0, i)
+      break
+    }
+  }
+  const decodedPath = shouldDecode ? decodeURI(path) : path
+  return { path: decodedPath, querystring, shouldDecodeParam } as const
+}
+
+function safeDecodeURIComponent(uriComponent: string) {
+  const startIndex = uriComponent.indexOf("%")
+  if (startIndex === -1) return uriComponent
+
+  let decoded = ""
+  let lastIndex = startIndex
+
+  for (let i = startIndex; i < uriComponent.length; i++) {
+    if (uriComponent.charCodeAt(i) === 37) {
+      const highCharCode = uriComponent.charCodeAt(i + 1)
+      const lowCharCode = uriComponent.charCodeAt(i + 2)
+
+      const decodedChar = decodeComponentChar(highCharCode, lowCharCode)
+      decoded += uriComponent.slice(lastIndex, i) + decodedChar
+
+      lastIndex = i + 3
+    }
+  }
+  return (
+    uriComponent.slice(0, startIndex) + decoded + uriComponent.slice(lastIndex)
+  )
+}
+
+const httpMethods = [
+  "ACL",
+  "BIND",
+  "CHECKOUT",
+  "CONNECT",
+  "COPY",
+  "DELETE",
+  "GET",
+  "HEAD",
+  "LINK",
+  "LOCK",
+  "M-SEARCH",
+  "MERGE",
+  "MKACTIVITY",
+  "MKCALENDAR",
+  "MKCOL",
+  "MOVE",
+  "NOTIFY",
+  "OPTIONS",
+  "PATCH",
+  "POST",
+  "PROPFIND",
+  "PROPPATCH",
+  "PURGE",
+  "PUT",
+  "REBIND",
+  "REPORT",
+  "SEARCH",
+  "SOURCE",
+  "SUBSCRIBE",
+  "TRACE",
+  "UNBIND",
+  "UNLINK",
+  "UNLOCK",
+  "UNSUBSCRIBE"
+] as const

--- a/packages/effect/test/unstable/http/FindMyWay/case-insensitive.test.ts
+++ b/packages/effect/test/unstable/http/FindMyWay/case-insensitive.test.ts
@@ -1,0 +1,153 @@
+import { assert, it } from "@effect/vitest"
+import { FindMyWay as Router } from "effect/unstable/http"
+
+const make = () =>
+  Router.make<boolean>({
+    caseSensitive: false
+  })
+
+it("case insensitive static routes of level 1", () => {
+  const router = make()
+  router.on("GET", "/woo", true)
+  assert(router.find("GET", "/woo")?.handler)
+})
+
+it("case insensitive static routes of level 2", () => {
+  const router = make()
+  router.on("GET", "/foo/woo", true)
+  assert(router.find("GET", "/FoO/WOO")?.handler)
+})
+
+it("case insensitive static routes of level 3", () => {
+  const router = make()
+  router.on("GET", "/foo/bar/woo", true)
+  assert(router.find("GET", "/Foo/bAR/WoO")?.handler)
+})
+
+it("parametric case insensitive", () => {
+  const router = make()
+  router.on("GET", "/foo/:param", true)
+  const result = router.find("GET", "/Foo/bAR")
+  assert(result)
+  assert(result.handler)
+  assert(result.params.param === "bAR")
+})
+
+it("parametric case insensitive with a static part", () => {
+  const router = make()
+  router.on("GET", "/foo/my-:param", true)
+  const result = router.find("GET", "/Foo/MY-bAR")
+  assert(result)
+  assert(result.handler)
+  assert(result.params.param === "bAR")
+})
+
+it("parametric case insensitive with capital letter", () => {
+  const router = make()
+  router.on("GET", "/foo/:Param", true)
+  const result = router.find("GET", "/Foo/bAR")
+  assert(result)
+  assert(result.handler)
+  assert(result.params.Param === "bAR")
+})
+
+it("case insensitive with capital letter in static path with param", () => {
+  const router = make()
+  router.on("GET", "/Foo/bar/:param", true)
+  const result = router.find("GET", "/foo/bar/baZ")
+  assert(result)
+  assert(result.handler)
+  assert(result.params.param === "baZ")
+})
+
+it("case insensitive with multiple paths containing capital letter in static path with param", () => {
+  const router = make()
+  router.on("GET", "/Foo/bar/:param", true)
+  router.on("GET", "/Foo/baz/:param", true)
+
+  let result = router.find("GET", "/foo/bar/baZ")
+  assert(result)
+  assert(result.handler)
+  assert(result.params.param === "baZ")
+
+  result = router.find("GET", "/foo/bar/baR")
+  assert(result)
+  assert(result.handler)
+  assert(result.params.param === "baR")
+})
+
+it("case insensitive with multiple mixed-case params within same slash couple", () => {
+  const router = make()
+  router.on("GET", "/foo/:param1-:param2", true)
+
+  const result = router.find("GET", "/FOO/My-bAR")
+  assert(result)
+  assert(result.handler)
+  assert(result.params.param1 === "My")
+  assert(result.params.param2 === "bAR")
+})
+
+it("case insensitive with multiple mixed-case params", () => {
+  const router = make()
+  router.on("GET", "/foo/:param1/:param2", true)
+
+  const result = router.find("GET", "/FOO/My/bAR")
+  assert(result)
+  assert(result.handler)
+  assert(result.params.param1 === "My")
+  assert(result.params.param2 === "bAR")
+})
+
+it("case insensitive with wildcard", () => {
+  const router = make()
+  router.on("GET", "/foo/*", true)
+
+  const result = router.find("GET", "/FOO/bAR")
+  assert(result)
+  assert(result.handler)
+  assert(result.params["*"] === "bAR")
+})
+
+it("parametric case insensitive with multiple routes", () => {
+  const router = make()
+  const tests = [
+    [
+      "POST",
+      "/foo/:param/Static/:userId/Save",
+      "/foo/bAR/static/one/SAVE",
+      {
+        param: "bAR",
+        userId: "one"
+      }
+    ],
+    [
+      "POST",
+      "/foo/:param/Static/:userId/Update",
+      "/fOO/Bar/Static/two/update",
+      {
+        param: "Bar",
+        userId: "two"
+      }
+    ],
+    [
+      "POST",
+      "/foo/:param/Static/:userId/CANCEL",
+      "/Foo/bAR/STATIC/THREE/cAnCeL",
+      {
+        param: "bAR",
+        userId: "THREE"
+      }
+    ]
+  ] as const
+
+  tests.forEach(([method, path]) => {
+    router.on(method, path, true)
+  })
+
+  tests.forEach(([method, , url, params]) => {
+    const result = router.find(method, url)
+    assert(result)
+    assert(result.handler)
+    assert.deepStrictEqual(result.params, params)
+  })
+})

--- a/packages/effect/test/unstable/http/FindMyWay/matching-order.test.ts
+++ b/packages/effect/test/unstable/http/FindMyWay/matching-order.test.ts
@@ -1,0 +1,16 @@
+import { assert, it } from "@effect/vitest"
+import { FindMyWay as Router } from "effect/unstable/http"
+
+it("Matching order", () => {
+  const router = Router.make<boolean>()
+
+  router.on("GET", "/foo/bar/*", true)
+  router.on("GET", "/foo/:param/static", true)
+
+  assert.deepStrictEqual(router.find("GET", "/foo/bar/static")?.params, {
+    "*": "static"
+  })
+  assert.deepStrictEqual(router.find("GET", "/foo/value/static")?.params, {
+    param: "value"
+  })
+})

--- a/packages/effect/test/unstable/http/FindMyWay/methods.test.ts
+++ b/packages/effect/test/unstable/http/FindMyWay/methods.test.ts
@@ -1,0 +1,16 @@
+import { assert, it } from "@effect/vitest"
+import { FindMyWay as Router } from "effect/unstable/http"
+
+it("returns undefined for method names inherited from Object.prototype", () => {
+  const router = Router.make<boolean>()
+  router.on("GET", "/", true)
+
+  assert.isUndefined(router.find("constructor", "/"))
+})
+
+it("registers QUERY with all", () => {
+  const router = Router.make<boolean>()
+  router.all("/all", true)
+
+  assert.strictEqual(router.find("QUERY", "/all")?.handler, true)
+})

--- a/packages/effect/test/unstable/http/FindMyWay/optional-params.test.ts
+++ b/packages/effect/test/unstable/http/FindMyWay/optional-params.test.ts
@@ -1,0 +1,108 @@
+import { assert, it } from "@effect/vitest"
+import { FindMyWay as Router } from "effect/unstable/http"
+
+it("Test route with optional parameter", () => {
+  const router = Router.make<boolean>()
+
+  router.on("GET", "/a/:param/b/:optional?", true)
+
+  assert.deepStrictEqual(router.find("GET", "/a/foo-bar/b")?.params, {
+    param: "foo-bar"
+  })
+  assert.deepStrictEqual(router.find("GET", "/a/foo-bar/b/foo")?.params, {
+    param: "foo-bar",
+    optional: "foo"
+  })
+})
+
+it("Test for duplicate route with optional param", () => {
+  const router = Router.make<boolean>()
+  router.on("GET", "/foo/:bar?", true)
+  assert.throws(() => router.on("GET", "/foo", true))
+})
+
+it("Test for param with ? not at the end", () => {
+  const router = Router.make<boolean>()
+
+  assert.throws(() => router.on("GET", "/foo/:bar?/baz", true))
+})
+
+it("Multi parametric route with optional param", () => {
+  const router = Router.make<boolean>()
+
+  router.on("GET", "/a/:p1-:p2?", true)
+
+  assert.deepStrictEqual(router.find("GET", "/a/foo-bar-baz")?.params, {
+    p1: "foo",
+    p2: "bar-baz"
+  })
+  assert.deepStrictEqual(router.find("GET", "/a")?.params, {})
+})
+
+it("Optional Parameter with ignoreTrailingSlash = true", () => {
+  const router = Router.make<boolean>({
+    ignoreTrailingSlash: true,
+    ignoreDuplicateSlashes: false
+  })
+
+  router.on("GET", "/test/hello/:optional?", true)
+
+  assert.deepStrictEqual(router.find("GET", "/test/hello/")?.params, {})
+  assert.deepStrictEqual(router.find("GET", "/test/hello")?.params, {})
+  assert.deepStrictEqual(router.find("GET", "/test/hello/foo")?.params, {
+    optional: "foo"
+  })
+  assert.deepStrictEqual(router.find("GET", "/test/hello/foo/")?.params, {
+    optional: "foo"
+  })
+})
+
+it("Optional Parameter with ignoreTrailingSlash = false", () => {
+  const router = Router.make<boolean>({
+    ignoreTrailingSlash: false,
+    ignoreDuplicateSlashes: false
+  })
+
+  router.on("GET", "/test/hello/:optional?", true)
+
+  assert.deepStrictEqual(router.find("GET", "/test/hello/")?.params, {
+    optional: ""
+  })
+  assert.deepStrictEqual(router.find("GET", "/test/hello")?.params, {})
+  assert.deepStrictEqual(router.find("GET", "/test/hello/foo")?.params, {
+    optional: "foo"
+  })
+  assert.isUndefined(router.find("GET", "/test/hello/foo/"))
+})
+
+it("Optional Parameter with ignoreDuplicateSlashes = true", () => {
+  const router = Router.make<boolean>({
+    ignoreDuplicateSlashes: true
+  })
+
+  router.on("GET", "/test/hello/:optional?", true)
+
+  assert.deepStrictEqual(router.find("GET", "/test//hello")?.params, {})
+  assert.deepStrictEqual(router.find("GET", "/test/hello")?.params, {})
+  assert.deepStrictEqual(router.find("GET", "/test/hello/foo")?.params, {
+    optional: "foo"
+  })
+  assert.deepStrictEqual(router.find("GET", "/test//hello//foo")?.params, {
+    optional: "foo"
+  })
+})
+
+it("Optional Parameter with ignoreDuplicateSlashes = false", () => {
+  const router = Router.make<boolean>({
+    ignoreDuplicateSlashes: false
+  })
+
+  router.on("GET", "/test/hello/:optional?", true)
+
+  assert.isUndefined(router.find("GET", "/test//hello"))
+  assert.deepStrictEqual(router.find("GET", "/test/hello")?.params, {})
+  assert.deepStrictEqual(router.find("GET", "/test/hello/foo")?.params, {
+    optional: "foo"
+  })
+  assert.isUndefined(router.find("GET", "/test//hello//foo"))
+})

--- a/packages/effect/test/unstable/http/FindMyWay/optional-params.test.ts
+++ b/packages/effect/test/unstable/http/FindMyWay/optional-params.test.ts
@@ -33,10 +33,21 @@ it("Multi parametric route with optional param", () => {
   router.on("GET", "/a/:p1-:p2?", true)
 
   assert.deepStrictEqual(router.find("GET", "/a/foo-bar-baz")?.params, {
-    p1: "foo",
-    p2: "bar-baz"
+    p1: "foo-bar",
+    p2: "baz"
   })
   assert.deepStrictEqual(router.find("GET", "/a")?.params, {})
+})
+
+it("Optional parameter at root", () => {
+  const router = Router.make<boolean>()
+
+  router.on("GET", "/:optional?", true)
+
+  assert.deepStrictEqual(router.find("GET", "/")?.params, {})
+  assert.deepStrictEqual(router.find("GET", "/foo")?.params, {
+    optional: "foo"
+  })
 })
 
 it("Optional Parameter with ignoreTrailingSlash = true", () => {

--- a/packages/effect/test/unstable/http/FindMyWay/params-collisions.test.ts
+++ b/packages/effect/test/unstable/http/FindMyWay/params-collisions.test.ts
@@ -1,0 +1,84 @@
+import { assert, it } from "@effect/vitest"
+import { FindMyWay as Router } from "effect/unstable/http"
+
+it("should setup parametric and regexp node", () => {
+  const router = Router.make<number>()
+
+  router.on("GET", "/foo/:bar", 1)
+  router.on("GET", "/foo/:bar(123)", 2)
+
+  assert.strictEqual(router.find("GET", "/foo/value")?.handler, 1)
+  assert.strictEqual(router.find("GET", "/foo/123")?.handler, 2)
+})
+
+it("should setup parametric and multi-parametric node", () => {
+  const router = Router.make<number>()
+
+  router.on("GET", "/foo/:bar", 1)
+  router.on("GET", "/foo/:bar.png", 2)
+
+  assert.strictEqual(router.find("GET", "/foo/value")?.handler, 1)
+  assert.strictEqual(router.find("GET", "/foo/value.png")?.handler, 2)
+})
+
+it("should throw when set upping two parametric nodes", () => {
+  const router = Router.make<number>()
+  router.on("GET", "/foo/:bar", 1)
+  assert.throws(() => router.on("GET", "/foo/:baz", 2))
+})
+
+it("should throw when set upping two regexp nodes", () => {
+  const router = Router.make<number>()
+  router.on("GET", "/foo/:bar(123)", 1)
+  assert.throws(() => router.on("GET", "/foo/:bar(456)", 2))
+})
+
+it("should set up two parametric nodes with static ending", () => {
+  const router = Router.make<number>()
+
+  router.on("GET", "/foo/:bar.png", 1)
+  router.on("GET", "/foo/:bar.jpeg", 2)
+
+  assert.strictEqual(router.find("GET", "/foo/value.png")?.handler, 1)
+  assert.strictEqual(router.find("GET", "/foo/value.jpeg")?.handler, 2)
+})
+
+it("should set up two regexp nodes with static ending", () => {
+  const router = Router.make<number>()
+
+  router.on("GET", "/foo/:bar(123).png", 1)
+  router.on("GET", "/foo/:bar(456).jpeg", 2)
+
+  assert.strictEqual(router.find("GET", "/foo/123.png")?.handler, 1)
+  assert.strictEqual(router.find("GET", "/foo/456.jpeg")?.handler, 2)
+})
+
+it("node with longer static suffix should have higher priority", () => {
+  const router = Router.make<number>()
+
+  router.on("GET", "/foo/:bar.png", 1)
+  router.on("GET", "/foo/:bar.png.png", 2)
+
+  assert.strictEqual(router.find("GET", "/foo/value.png")?.handler, 1)
+  assert.strictEqual(router.find("GET", "/foo/value.png.png")?.handler, 2)
+})
+
+it("node with longer static suffix should have higher priority", () => {
+  const router = Router.make<number>()
+
+  router.on("GET", "/foo/:bar.png.png", 2)
+  router.on("GET", "/foo/:bar.png", 1)
+
+  assert.strictEqual(router.find("GET", "/foo/value.png")?.handler, 1)
+  assert.strictEqual(router.find("GET", "/foo/value.png.png")?.handler, 2)
+})
+
+it("should set up regexp node and node with static ending", () => {
+  const router = Router.make<number>()
+
+  router.on("GET", "/foo/:bar(123)", 1)
+  router.on("GET", "/foo/:bar(123).jpeg", 2)
+
+  assert.strictEqual(router.find("GET", "/foo/123")?.handler, 1)
+  assert.strictEqual(router.find("GET", "/foo/123.jpeg")?.handler, 2)
+})

--- a/packages/effect/test/unstable/http/FindMyWay/params-collisions.test.ts
+++ b/packages/effect/test/unstable/http/FindMyWay/params-collisions.test.ts
@@ -82,3 +82,13 @@ it("should set up regexp node and node with static ending", () => {
   assert.strictEqual(router.find("GET", "/foo/123")?.handler, 1)
   assert.strictEqual(router.find("GET", "/foo/123.jpeg")?.handler, 2)
 })
+
+it("distinguishes routes with different static parts between parameters", () => {
+  const router = Router.make<string>()
+
+  router.on("GET", "/foo/:a-:b", "dash")
+  router.on("GET", "/foo/:a.:b", "dot")
+
+  assert.strictEqual(router.find("GET", "/foo/x-y")?.handler, "dash")
+  assert.strictEqual(router.find("GET", "/foo/x.y")?.handler, "dot")
+})

--- a/packages/effect/test/unstable/http/FindMyWay/params-collisions.test.ts
+++ b/packages/effect/test/unstable/http/FindMyWay/params-collisions.test.ts
@@ -92,3 +92,10 @@ it("distinguishes routes with different static parts between parameters", () => 
   assert.strictEqual(router.find("GET", "/foo/x-y")?.handler, "dash")
   assert.strictEqual(router.find("GET", "/foo/x.y")?.handler, "dot")
 })
+
+it("preserves parameters named __proto__", () => {
+  const router = Router.make<boolean>()
+  router.on("GET", "/foo/:__proto__", true)
+
+  assert.strictEqual(router.find("GET", "/foo/value")?.params.__proto__, "value")
+})

--- a/packages/effect/test/unstable/http/FindMyWay/path-params-match.test.ts
+++ b/packages/effect/test/unstable/http/FindMyWay/path-params-match.test.ts
@@ -1,0 +1,43 @@
+import { assert, it } from "@effect/vitest"
+import { FindMyWay as Router } from "effect/unstable/http"
+
+it("path params match", () => {
+  const router = Router.make<1 | 2 | "c" | "param">()
+
+  router.on("GET", "/ab1", 1)
+  router.on("GET", "/ab2", 2)
+  router.on("GET", "/ac", "c")
+  router.on("GET", "/:pam", "param")
+
+  assert.strictEqual(router.find("GET", "/ab1")?.handler, 1)
+  assert.strictEqual(router.find("GET", "/ab1/")?.handler, 1)
+  assert.strictEqual(router.find("GET", "//ab1")?.handler, 1)
+  assert.strictEqual(router.find("GET", "//ab1//")?.handler, 1)
+  assert.strictEqual(router.find("GET", "/ab2")?.handler, 2)
+  assert.strictEqual(router.find("GET", "/ab2/")?.handler, 2)
+  assert.strictEqual(router.find("GET", "//ab2")?.handler, 2)
+  assert.strictEqual(router.find("GET", "//ab2//")?.handler, 2)
+  assert.strictEqual(router.find("GET", "/ac")?.handler, "c")
+  assert.strictEqual(router.find("GET", "/ac/")?.handler, "c")
+  assert.strictEqual(router.find("GET", "//ac")?.handler, "c")
+  assert.strictEqual(router.find("GET", "//ac//")?.handler, "c")
+  assert.strictEqual(router.find("GET", "/foo")?.handler, "param")
+  assert.strictEqual(router.find("GET", "/foo/")?.handler, "param")
+  assert.strictEqual(router.find("GET", "//foo")?.handler, "param")
+  assert.strictEqual(router.find("GET", "//foo//")?.handler, "param")
+  assert.deepStrictEqual(router.find("GET", "/abcdef"), {
+    handler: "param",
+    params: { pam: "abcdef" },
+    searchParams: {}
+  })
+  assert.deepStrictEqual(router.find("GET", "/abcdef/"), {
+    handler: "param",
+    params: { pam: "abcdef" },
+    searchParams: {}
+  })
+  assert.deepStrictEqual(router.find("GET", "//abcdef"), {
+    handler: "param",
+    params: { pam: "abcdef" },
+    searchParams: {}
+  })
+})

--- a/packages/effect/test/unstable/http/FindMyWay/path-params-match.test.ts
+++ b/packages/effect/test/unstable/http/FindMyWay/path-params-match.test.ts
@@ -41,3 +41,21 @@ it("path params match", () => {
     searchParams: {}
   })
 })
+
+it("does not read inherited static child entries", () => {
+  const label = "\uE000"
+  // oxlint-disable-next-line no-extend-native -- Reproduce an inherited entry without reaching into router internals.
+  Object.defineProperty(Object.prototype, label, {
+    configurable: true,
+    value: {}
+  })
+
+  try {
+    const router = Router.make<boolean>()
+    router.on("GET", `/${label}`, true)
+
+    assert.strictEqual(router.find("GET", `/${label}`)?.handler, true)
+  } finally {
+    Reflect.deleteProperty(Object.prototype, label)
+  }
+})

--- a/packages/effect/test/unstable/http/FindMyWay/querystring.test.ts
+++ b/packages/effect/test/unstable/http/FindMyWay/querystring.test.ts
@@ -1,0 +1,38 @@
+import { assert, it } from "@effect/vitest"
+import { FindMyWay as Router } from "effect/unstable/http"
+
+it("should sanitize the url - query", () => {
+  const router = Router.make<boolean>()
+  router.on("GET", "/test", true)
+  assert.deepStrictEqual(
+    router.find("GET", "/test?hello=world")?.searchParams,
+    { hello: "world" }
+  )
+})
+
+it("should sanitize the url - hash", () => {
+  const router = Router.make<boolean>()
+
+  router.on("GET", "/test", true)
+
+  assert.deepStrictEqual(router.find("GET", "/test#hello")?.searchParams, {
+    hello: ""
+  })
+})
+
+it("handles path and query separated by ;", () => {
+  const router = Router.make<boolean>()
+  router.on("GET", "/test", true)
+  assert.deepStrictEqual(
+    router.find("GET", "/test;jsessionid=123456")?.searchParams,
+    { jsessionid: "123456" }
+  )
+})
+
+it("handles %", () => {
+  const router = Router.make<boolean>()
+  router.on("GET", "/test", true)
+  assert.deepStrictEqual(router.find("GET", "/test?%")?.searchParams, {
+    "%": ""
+  })
+})

--- a/packages/effect/test/unstable/http/FindMyWay/regex.test.ts
+++ b/packages/effect/test/unstable/http/FindMyWay/regex.test.ts
@@ -71,6 +71,14 @@ it("safe decodeURIComponent", () => {
   assert.isUndefined(router.find("GET", "/test/hel%\"Flo"))
 })
 
+it("rejects truncated percent encodings", () => {
+  const router = Router.make<boolean>()
+  router.on("GET", "/test/:id", true)
+
+  assert.isUndefined(router.find("GET", "/test/a%"))
+  assert.isUndefined(router.find("GET", "/test/a%2"))
+})
+
 it("does not match an empty segment against a non-empty regex", () => {
   const router = Router.make<boolean>({
     ignoreTrailingSlash: false
@@ -106,4 +114,11 @@ it("avoids backtracking across static parameter separators", { timeout: 1_000 },
   router.on("GET", "/:foo-:bar-", true)
 
   router.find("GET", "/" + "-".repeat(16_000) + "a")
+})
+
+it("avoids backtracking across mixed static parameter separators", { timeout: 1_000 }, () => {
+  const router = Router.make<boolean>()
+  router.on("GET", "/:foo-:bar-", true)
+
+  router.find("GET", "/" + "a-".repeat(8_000) + "b")
 })

--- a/packages/effect/test/unstable/http/FindMyWay/regex.test.ts
+++ b/packages/effect/test/unstable/http/FindMyWay/regex.test.ts
@@ -1,0 +1,72 @@
+import { assert, it } from "@effect/vitest"
+import { FindMyWay as Router } from "effect/unstable/http"
+
+it("route with matching regex", () => {
+  const router = Router.make<boolean>()
+  router.on("GET", "/test/:id(^\\d+$)", true)
+  assert.deepStrictEqual(router.find("GET", "/test/12")?.handler, true)
+})
+
+it("route without matching regex", () => {
+  const router = Router.make<boolean>()
+  router.on("GET", "/test/:id(^\\d+$)", true)
+  assert.isUndefined(router.find("GET", "/test/test"))
+})
+
+it("route with an extension regex 2", () => {
+  const router = Router.make<number>()
+
+  router.on("GET", "/test/S/:file(^\\S+).png", 1)
+  router.on("GET", "/test/D/:file(^\\D+).png", 2)
+
+  assert.strictEqual(router.find("GET", "/test/S/foo.png")?.handler, 1)
+  assert.strictEqual(router.find("GET", "/test/D/foo.png")?.handler, 2)
+})
+
+it("nested route with matching regex", () => {
+  const router = Router.make<boolean>()
+  router.on("GET", "/test/:id(^\\d+$)/hello", true)
+  assert.deepStrictEqual(router.find("GET", "/test/12/hello")?.handler, true)
+})
+
+it("mixed nested route with matching regex", () => {
+  const router = Router.make<boolean>()
+  router.on("GET", "/test/:id(^\\d+$)/hello/:world", true)
+  assert.deepStrictEqual(router.find("GET", "/test/12/hello/world")?.params, {
+    id: "12",
+    world: "world"
+  })
+})
+
+it("mixed nested route with double matching regex", () => {
+  const router = Router.make<boolean>()
+  router.on("GET", "/test/:id(^\\d+$)/hello/:world(^\\d+$)", true)
+  assert.deepStrictEqual(router.find("GET", "/test/12/hello/15")?.params, {
+    id: "12",
+    world: "15"
+  })
+})
+
+it("mixed nested route without double matching regex", () => {
+  const router = Router.make<boolean>()
+  router.on("GET", "/test/:id(^\\d+$)/hello/:world(^\\d+$)", true)
+  assert.isUndefined(router.find("GET", "/test/12/hello/test"))
+})
+
+it("route with an extension regex", () => {
+  const router = Router.make<boolean>()
+  router.on("GET", "/test/:file(^\\d+).png", true)
+  assert.deepStrictEqual(router.find("GET", "/test/12.png")?.handler, true)
+})
+
+it("route with an extension regex - no match", () => {
+  const router = Router.make<boolean>()
+  router.on("GET", "/test/:file(^\\d+).png", true)
+  assert.isUndefined(router.find("GET", "/test/aa.png"))
+})
+
+it("safe decodeURIComponent", () => {
+  const router = Router.make<boolean>()
+  router.on("GET", "/test/:id(^\\d+$)", true)
+  assert.isUndefined(router.find("GET", "/test/hel%\"Flo"))
+})

--- a/packages/effect/test/unstable/http/FindMyWay/regex.test.ts
+++ b/packages/effect/test/unstable/http/FindMyWay/regex.test.ts
@@ -70,3 +70,40 @@ it("safe decodeURIComponent", () => {
   router.on("GET", "/test/:id(^\\d+$)", true)
   assert.isUndefined(router.find("GET", "/test/hel%\"Flo"))
 })
+
+it("does not match an empty segment against a non-empty regex", () => {
+  const router = Router.make<boolean>({
+    ignoreTrailingSlash: false
+  })
+  router.on("GET", "/users/:userId(^\\d+)", true)
+
+  assert.isUndefined(router.find("GET", "/users/"))
+})
+
+it("matches undefined regex captures as empty strings", () => {
+  const router = Router.make<boolean>({
+    ignoreTrailingSlash: false
+  })
+  router.on("GET", "/test/:id(^((?!abc).)*$)", true)
+
+  assert.deepStrictEqual(router.find("GET", "/test/")?.params, {
+    id: ""
+  })
+})
+
+it("falls back when a parameter exceeds maxParamLength", () => {
+  const router = Router.make<string>({
+    maxParamLength: 3
+  })
+  router.on("GET", "/users/:userId", "parameter")
+  router.on("GET", "/users/*", "wildcard")
+
+  assert.strictEqual(router.find("GET", "/users/long")?.handler, "wildcard")
+})
+
+it("avoids backtracking across static parameter separators", { timeout: 1_000 }, () => {
+  const router = Router.make<boolean>()
+  router.on("GET", "/:foo-:bar-", true)
+
+  router.find("GET", "/" + "-".repeat(16_000) + "a")
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,9 +341,6 @@ importers:
       fast-check:
         specifier: ^4.9.0
         version: 4.9.0
-      find-my-way-ts:
-        specifier: ^0.1.6
-        version: 0.1.6
       kubernetes-types:
         specifier: ^1.30.0
         version: 1.30.0
@@ -4343,9 +4340,6 @@ packages:
   find-cache-dir@3.3.2:
     resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
     engines: {node: '>=8'}
-
-  find-my-way-ts@0.1.6:
-    resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
 
   find-up@3.0.0:
     resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
@@ -10070,8 +10064,6 @@ snapshots:
       commondir: 1.0.1
       make-dir: 3.1.0
       pkg-dir: 4.2.0
-
-  find-my-way-ts@0.1.6: {}
 
   find-up@3.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- vendor the `find-my-way-ts` v0.1.6 radix router and query-string parser under Effect's `FindMyWay` module
- preserve the existing public API and Tomas Della Vedova's MIT attribution
- port all seven tests from the TypeScript package plus focused upstream regression coverage
- remove the external package from `effect` and the pnpm lockfile

## Upstream audit

The TypeScript rewrite forked from `delvedor/find-my-way` v7.7.0. Applicable fixes through current upstream were ported for:

- optional parameters at the root path
- safe multi-parameter separator matching and distinct route patterns
- prototype-safe method lookup and the `QUERY` HTTP method
- regex mismatch backtracking, empty captures, and `maxParamLength` fallback

Constraint routing, `off`/`findRoute`, and pretty-print fixes do not apply to this reduced API. The later semicolon-delimiter option was not included because it is an opt-in behavior/API change rather than a bug fix.

## Validation

- `pnpm lint-fix`
- all eight targeted `FindMyWay` test files (53 tests)
- `packages/effect/test/HttpClient.test.ts` and `packages/effect/test/unstable/ai/McpServer/McpServer.test.ts` (24 tests)
- `pnpm check`
- `pnpm install --frozen-lockfile`

Closes EFF-451
