### PR TITLE
Inline INI, YAML, and TOML parsers

### DIFF
--- a/.changeset/calm-tools-parse.md
+++ b/.changeset/calm-tools-parse.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add lightweight INI, YAML, and TOML parsers under `effect/unstable/encoding` and remove their runtime dependencies.

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -102,7 +102,6 @@
     "check": "tsc -b tsconfig.json"
   },
   "devDependencies": {
-    "@types/ini": "^4.1.1",
     "@types/node": "^26.1.2",
     "ajv": "^8.20.0",
     "ajv-draft-04": "^1.0.0",
@@ -115,12 +114,9 @@
     "@standard-schema/spec": "^1.1.0",
     "fast-check": "^4.9.0",
     "find-my-way-ts": "^0.1.6",
-    "ini": "^7.0.0",
     "kubernetes-types": "^1.30.0",
     "msgpackr": "^2.0.4",
     "multipasta": "^0.2.8",
-    "toml": "^4.1.2",
-    "uuid": "^14.0.1",
-    "yaml": "^2.9.0"
+    "uuid": "^14.0.1"
   }
 }

--- a/packages/effect/src/unstable/cli/Primitive.ts
+++ b/packages/effect/src/unstable/cli/Primitive.ts
@@ -10,9 +10,6 @@
  *
  * @since 4.0.0
  */
-import * as Ini from "ini"
-import * as Toml from "toml"
-import * as Yaml from "yaml"
 import * as Config from "../../Config.ts"
 import * as Effect from "../../Effect.ts"
 import * as FileSystem from "../../FileSystem.ts"
@@ -24,6 +21,9 @@ import * as Schema from "../../Schema.ts"
 import type { Formatter } from "../../SchemaIssue.ts"
 import type * as Struct from "../../Struct.ts"
 import type { Covariant } from "../../Types.ts"
+import * as Ini from "../encoding/Ini.ts"
+import * as Toml from "../encoding/Toml.ts"
+import * as Yaml from "../encoding/Yaml.ts"
 import type { Environment } from "./Command.ts"
 
 const TypeId = "~effect/cli/Primitive"

--- a/packages/effect/src/unstable/encoding/Ini.ts
+++ b/packages/effect/src/unstable/encoding/Ini.ts
@@ -1,0 +1,174 @@
+/**
+ * Parses INI configuration files.
+ *
+ * This module contains the decoding surface used by Effect's CLI without
+ * pulling in the complete `ini` package.
+ *
+ * @since 4.0.0
+ */
+
+/*
+ * The parser is adapted from `ini` 7.0.0.
+ *
+ * Copyright (c) Isaac Z. Schlueter and Contributors
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+ * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+const hasOwn = Object.prototype.hasOwnProperty
+
+const splitSections = (value: string): Array<string> => {
+  const sections: Array<string> = []
+  let start = 0
+  let index = 0
+  while ((index = value.indexOf(".", index)) !== -1) {
+    if (index === 0 || value[index - 1] !== "\\") {
+      sections.push(value.slice(start, index))
+      start = index + 1
+    }
+    index++
+  }
+  sections.push(value.slice(start))
+  return sections
+}
+
+const isQuoted = (value: string): boolean =>
+  value.length >= 2 &&
+  ((value.startsWith("\"") && value.endsWith("\"")) ||
+    (value.startsWith("'") && value.endsWith("'")))
+
+const unquote = (input: string | undefined): string => {
+  let value = (input ?? "").trim()
+  if (isQuoted(value)) {
+    if (value[0] === "'") {
+      value = value.slice(1, -1)
+    }
+    try {
+      return JSON.parse(value)
+    } catch {
+      return value
+    }
+  }
+
+  let escaped = false
+  let output = ""
+  for (const character of value) {
+    if (escaped) {
+      output += character === ";" || character === "#" || character === "\\"
+        ? character
+        : `\\${character}`
+      escaped = false
+    } else if (character === ";" || character === "#") {
+      break
+    } else if (character === "\\") {
+      escaped = true
+    } else {
+      output += character
+    }
+  }
+  return output.trim()
+}
+
+/**
+ * Parses an INI document into a null-prototype record.
+ *
+ * Section names separated by dots become nested records, repeated keys ending
+ * in `[]` become arrays, and the scalar values `true`, `false`, and `null` are
+ * decoded. Other scalar values remain strings.
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const parse = (input: string): Record<string, unknown> => {
+  const output: Record<string, any> = Object.create(null)
+  let current = output
+  const sectionPattern = /^\[([^\]]*)\]\s*$/
+  const propertyPattern = /^([^=]+)(=(.*))?$/
+
+  for (const line of input.split(/[\r\n]+/g)) {
+    if (line.length === 0 || /^\s*(?:[;#]|$)/.test(line)) {
+      continue
+    }
+
+    const sectionMatch = sectionPattern.exec(line)
+    if (sectionMatch !== null) {
+      const section = unquote(sectionMatch[1])
+      if (section === "__proto__") {
+        current = Object.create(null)
+      } else {
+        current = output[section] ??= Object.create(null)
+      }
+      continue
+    }
+
+    const propertyMatch = propertyPattern.exec(line)
+    if (propertyMatch === null) {
+      continue
+    }
+
+    const rawKey = unquote(propertyMatch[1])
+    const array = rawKey.length > 2 && rawKey.endsWith("[]")
+    const key = array ? rawKey.slice(0, -2) : rawKey
+    if (key === "__proto__") {
+      continue
+    }
+
+    const rawValue = propertyMatch[2] === undefined ? true : unquote(propertyMatch[3])
+    const value = rawValue === "true" || rawValue === "false" || rawValue === "null"
+      ? JSON.parse(rawValue)
+      : rawValue
+
+    if (array) {
+      if (!hasOwn.call(current, key)) {
+        current[key] = []
+      } else if (!Array.isArray(current[key])) {
+        current[key] = [current[key]]
+      }
+    }
+    if (Array.isArray(current[key])) {
+      current[key].push(value)
+    } else {
+      current[key] = value
+    }
+  }
+
+  const remove: Array<string> = []
+  for (const section of Object.keys(output)) {
+    if (typeof output[section] !== "object" || output[section] === null || Array.isArray(output[section])) {
+      continue
+    }
+
+    const parts = splitSections(section)
+    const last = parts.pop()!
+    const key = last.replace(/\\\./g, ".")
+    current = output
+    for (const part of parts) {
+      if (part === "__proto__") {
+        continue
+      }
+      if (!hasOwn.call(current, part) || typeof current[part] !== "object" || current[part] === null) {
+        current[part] = Object.create(null)
+      }
+      current = current[part]
+    }
+    if (current === output && key === last) {
+      continue
+    }
+    current[key] = output[section]
+    remove.push(section)
+  }
+  for (const section of remove) {
+    delete output[section]
+  }
+  return output
+}

--- a/packages/effect/src/unstable/encoding/Toml.ts
+++ b/packages/effect/src/unstable/encoding/Toml.ts
@@ -1,0 +1,504 @@
+/**
+ * Parses TOML configuration files.
+ *
+ * The implementation covers the TOML values and table forms used by Effect's
+ * configuration-file CLI primitive while avoiding a generated parser runtime.
+ *
+ * @since 4.0.0
+ */
+
+/*
+ * The behavior is based on `toml` 4.1.2.
+ *
+ * Copyright (c) 2012 Michelle Tilley
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+type Table = Record<string, unknown>
+
+const hasOwn = Object.prototype.hasOwnProperty
+const makeTable = (): Table => Object.create(null)
+const isTable = (value: unknown): value is Table =>
+  typeof value === "object" && value !== null && !Array.isArray(value) && !(value instanceof Date)
+
+class TomlParser {
+  readonly root = makeTable()
+  private readonly input: string
+  private current = this.root
+  private index = 0
+  private line = 1
+  private column = 1
+  private readonly explicitTables = new Set<string>()
+
+  constructor(input: string) {
+    this.input = input
+  }
+
+  parse(): Table {
+    while (true) {
+      this.skipDocumentWhitespace()
+      if (this.done) {
+        return this.root
+      }
+      if (this.peek() === "[") {
+        this.parseHeader()
+      } else {
+        const keys = this.parseKeyPath("=")
+        this.skipInlineWhitespace()
+        this.expect("=")
+        this.skipInlineWhitespace()
+        this.assign(this.current, keys, this.parseValue())
+        this.finishStatement()
+      }
+    }
+  }
+
+  private parseHeader(): void {
+    this.expect("[")
+    const array = this.peek() === "["
+    if (array) {
+      this.advance()
+    }
+    this.skipInlineWhitespace()
+    const path = this.parseKeyPath("]")
+    this.skipInlineWhitespace()
+    this.expect("]")
+    if (array) {
+      this.expect("]")
+    }
+    this.finishStatement()
+
+    const pathKey = JSON.stringify(path)
+    if (!array && this.explicitTables.has(pathKey)) {
+      this.fail(`Cannot redefine table '${path.join(".")}'`)
+    }
+    if (!array) {
+      this.explicitTables.add(pathKey)
+    }
+    this.current = this.resolveTable(path, array)
+  }
+
+  private resolveTable(path: ReadonlyArray<string>, array: boolean): Table {
+    let table = this.root
+    for (let index = 0; index < path.length; index++) {
+      const key = path[index]
+      const last = index === path.length - 1
+      let value = table[key]
+
+      if (last && array) {
+        if (value === undefined) {
+          value = []
+          table[key] = value
+        }
+        if (!Array.isArray(value)) {
+          this.fail(`Cannot redefine existing key '${path.slice(0, index + 1).join(".")}'`)
+        }
+        const next = makeTable()
+        value.push(next)
+        return next
+      }
+
+      if (value === undefined) {
+        value = makeTable()
+        table[key] = value
+      }
+      if (Array.isArray(value)) {
+        value = value[value.length - 1]
+      }
+      if (!isTable(value)) {
+        this.fail(`Cannot redefine existing key '${path.slice(0, index + 1).join(".")}'`)
+      }
+      table = value
+    }
+    return table
+  }
+
+  private assign(target: Table, keys: ReadonlyArray<string>, value: unknown): void {
+    let table = target
+    for (let index = 0; index < keys.length - 1; index++) {
+      const key = keys[index]
+      const existing = table[key]
+      if (existing === undefined) {
+        const child = makeTable()
+        table[key] = child
+        table = child
+      } else if (isTable(existing)) {
+        table = existing
+      } else {
+        this.fail(`Cannot redefine existing key '${keys.slice(0, index + 1).join(".")}'`)
+      }
+    }
+    const key = keys[keys.length - 1]
+    if (hasOwn.call(table, key)) {
+      this.fail(`Cannot redefine existing key '${keys.join(".")}'`)
+    }
+    table[key] = value
+  }
+
+  private parseKeyPath(stop: "=" | "]"): Array<string> {
+    const keys: Array<string> = []
+    while (true) {
+      this.skipInlineWhitespace()
+      const character = this.peek()
+      let key: string
+      if (character === "\"") {
+        key = this.parseBasicString(false)
+      } else if (character === "'") {
+        key = this.parseLiteralString(false)
+      } else {
+        const start = this.index
+        while (/[A-Za-z0-9_-]/.test(this.peek())) {
+          this.advance()
+        }
+        key = this.input.slice(start, this.index)
+      }
+      if (key.length === 0) {
+        this.fail("Expected a key")
+      }
+      keys.push(key)
+      this.skipInlineWhitespace()
+      if (this.peek() === ".") {
+        this.advance()
+        continue
+      }
+      if (this.peek() !== stop) {
+        this.fail(`Expected '${stop}'`)
+      }
+      return keys
+    }
+  }
+
+  private parseValue(): unknown {
+    const character = this.peek()
+    if (character === "\"") {
+      return this.parseBasicString(this.input.startsWith("\"\"\"", this.index))
+    }
+    if (character === "'") {
+      return this.parseLiteralString(this.input.startsWith("'''", this.index))
+    }
+    if (character === "[") {
+      return this.parseArray()
+    }
+    if (character === "{") {
+      return this.parseInlineTable()
+    }
+
+    const spaceSeparatedDateTime = /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})?)/
+      .exec(this.input.slice(this.index))
+    if (spaceSeparatedDateTime !== null) {
+      this.advance(spaceSeparatedDateTime[0].length)
+      return this.parseDate(`${spaceSeparatedDateTime[1]}T${spaceSeparatedDateTime[2]}`)!
+    }
+
+    const start = this.index
+    while (!this.done && !/[\s,#\]}]/.test(this.peek())) {
+      this.advance()
+    }
+    const token = this.input.slice(start, this.index)
+    if (token === "true") return true
+    if (token === "false") return false
+    if (token.length === 0) this.fail("Expected a value")
+
+    const date = this.parseDate(token)
+    if (date !== undefined) {
+      return date
+    }
+
+    const number = this.parseNumber(token)
+    if (number !== undefined) {
+      return number
+    }
+    this.fail(`Invalid value '${token}'`)
+  }
+
+  private parseDate(token: string): Date | string | undefined {
+    const date = "\\d{4}-\\d{2}-\\d{2}"
+    const time = "\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?"
+    if (new RegExp(`^${date}[Tt]${time}(?:[Zz]|[+-]\\d{2}:\\d{2})$`).test(token)) {
+      const value = new Date(token.replace("t", "T").replace("z", "Z"))
+      if (Number.isNaN(value.getTime())) {
+        this.fail(`Invalid date-time '${token}'`)
+      }
+      return value
+    }
+    if (
+      new RegExp(`^${date}[Tt]${time}$`).test(token) ||
+      new RegExp(`^${date}$`).test(token) ||
+      new RegExp(`^${time}$`).test(token)
+    ) {
+      return token.replace("t", "T")
+    }
+    return undefined
+  }
+
+  private parseNumber(token: string): number | undefined {
+    const normalized = token.replace(/_/g, "")
+    if (/^[+-]?(?:inf|nan)$/.test(token)) {
+      if (normalized.endsWith("nan")) return Number.NaN
+      return normalized[0] === "-" ? Number.NEGATIVE_INFINITY : Number.POSITIVE_INFINITY
+    }
+    if (/^0x[0-9A-Fa-f](?:_?[0-9A-Fa-f])*$/.test(token)) {
+      return Number.parseInt(normalized.slice(2), 16)
+    }
+    if (/^0o[0-7](?:_?[0-7])*$/.test(token)) {
+      return Number.parseInt(normalized.slice(2), 8)
+    }
+    if (/^0b[01](?:_?[01])*$/.test(token)) {
+      return Number.parseInt(normalized.slice(2), 2)
+    }
+    if (/^[+-]?(?:0|[1-9](?:_?\d)*)$/.test(token)) {
+      return Number(normalized)
+    }
+    if (
+      /^[+-]?(?:(?:0|[1-9](?:_?\d)*)\.\d(?:_?\d)*(?:[eE][+-]?\d(?:_?\d)*)?|(?:0|[1-9](?:_?\d)*)[eE][+-]?\d(?:_?\d)*)$/
+        .test(
+          token
+        )
+    ) {
+      return Number(normalized)
+    }
+    return undefined
+  }
+
+  private parseBasicString(multiline: boolean): string {
+    this.expect("\"")
+    if (multiline) {
+      this.expect("\"")
+      this.expect("\"")
+      if (this.peek() === "\n") this.advance()
+    }
+    let output = ""
+    while (!this.done) {
+      if (multiline && this.input.startsWith("\"\"\"", this.index)) {
+        this.advance(3)
+        return output
+      }
+      const character = this.peek()
+      if (!multiline && character === "\"") {
+        this.advance()
+        return output
+      }
+      if (!multiline && (character === "\n" || character === "\r")) {
+        this.fail("Basic strings cannot contain newlines")
+      }
+      if (character !== "\\") {
+        output += character
+        this.advance()
+        continue
+      }
+
+      this.advance()
+      if (multiline && /[ \t\r\n]/.test(this.peek())) {
+        while (/[ \t]/.test(this.peek())) this.advance()
+        if (this.peek() !== "\n" && this.peek() !== "\r") {
+          this.fail("Invalid multiline string continuation")
+        }
+        while (/[ \t\r\n]/.test(this.peek())) this.advance()
+        continue
+      }
+      const escape = this.peek()
+      this.advance()
+      const escapes: Record<string, string> = {
+        b: "\b",
+        t: "\t",
+        n: "\n",
+        f: "\f",
+        r: "\r",
+        "\"": "\"",
+        "\\": "\\"
+      }
+      if (hasOwn.call(escapes, escape)) {
+        output += escapes[escape]
+      } else if (escape === "u" || escape === "U") {
+        const length = escape === "u" ? 4 : 8
+        const hex = this.input.slice(this.index, this.index + length)
+        if (!new RegExp(`^[0-9A-Fa-f]{${length}}$`).test(hex)) {
+          this.fail("Invalid unicode escape")
+        }
+        output += String.fromCodePoint(Number.parseInt(hex, 16))
+        this.advance(length)
+      } else {
+        this.fail(`Invalid escape '\\${escape}'`)
+      }
+    }
+    this.fail("Unterminated basic string")
+  }
+
+  private parseLiteralString(multiline: boolean): string {
+    this.expect("'")
+    if (multiline) {
+      this.expect("'")
+      this.expect("'")
+      if (this.peek() === "\n") this.advance()
+    }
+    const start = this.index
+    while (!this.done) {
+      if (multiline && this.input.startsWith("'''", this.index)) {
+        const output = this.input.slice(start, this.index)
+        this.advance(3)
+        return output
+      }
+      if (!multiline && this.peek() === "'") {
+        const output = this.input.slice(start, this.index)
+        this.advance()
+        return output
+      }
+      if (!multiline && (this.peek() === "\n" || this.peek() === "\r")) {
+        this.fail("Literal strings cannot contain newlines")
+      }
+      this.advance()
+    }
+    this.fail("Unterminated literal string")
+  }
+
+  private parseArray(): Array<unknown> {
+    this.expect("[")
+    const output: Array<unknown> = []
+    while (true) {
+      this.skipArrayWhitespace()
+      if (this.peek() === "]") {
+        this.advance()
+        return output
+      }
+      output.push(this.parseValue())
+      this.skipArrayWhitespace()
+      if (this.peek() === "]") {
+        this.advance()
+        return output
+      }
+      this.expect(",")
+    }
+  }
+
+  private parseInlineTable(): Table {
+    this.expect("{")
+    const output = makeTable()
+    this.skipInlineWhitespace()
+    if (this.peek() === "}") {
+      this.advance()
+      return output
+    }
+    while (true) {
+      const keys = this.parseKeyPath("=")
+      this.skipInlineWhitespace()
+      this.expect("=")
+      this.skipInlineWhitespace()
+      this.assign(output, keys, this.parseValue())
+      this.skipInlineWhitespace()
+      if (this.peek() === "}") {
+        this.advance()
+        return output
+      }
+      this.expect(",")
+      this.skipInlineWhitespace()
+      if (this.peek() === "}") {
+        this.fail("Inline tables cannot end with a trailing comma")
+      }
+    }
+  }
+
+  private skipDocumentWhitespace(): void {
+    while (!this.done) {
+      if (/[ \t\r\n]/.test(this.peek())) {
+        this.advance()
+      } else if (this.peek() === "#") {
+        this.skipComment()
+      } else {
+        return
+      }
+    }
+  }
+
+  private skipInlineWhitespace(): void {
+    while (this.peek() === " " || this.peek() === "\t") {
+      this.advance()
+    }
+  }
+
+  private skipArrayWhitespace(): void {
+    while (!this.done) {
+      if (/[ \t\r\n]/.test(this.peek())) {
+        this.advance()
+      } else if (this.peek() === "#") {
+        this.skipComment()
+      } else {
+        return
+      }
+    }
+  }
+
+  private finishStatement(): void {
+    this.skipInlineWhitespace()
+    if (this.peek() === "#") {
+      this.skipComment()
+    }
+    if (!this.done && this.peek() !== "\n" && this.peek() !== "\r") {
+      this.fail("Expected the end of the line")
+    }
+  }
+
+  private skipComment(): void {
+    while (!this.done && this.peek() !== "\n") {
+      this.advance()
+    }
+  }
+
+  private expect(character: string): void {
+    if (this.peek() !== character) {
+      this.fail(`Expected '${character}'`)
+    }
+    this.advance()
+  }
+
+  private advance(count = 1): void {
+    for (let offset = 0; offset < count; offset++) {
+      if (this.input[this.index] === "\n") {
+        this.line++
+        this.column = 1
+      } else {
+        this.column++
+      }
+      this.index++
+    }
+  }
+
+  private peek(): string {
+    return this.input[this.index] ?? ""
+  }
+
+  private get done(): boolean {
+    return this.index >= this.input.length
+  }
+
+  private fail(message: string): never {
+    throw new SyntaxError(`${message} at line ${this.line}, column ${this.column}`)
+  }
+}
+
+/**
+ * Parses a TOML document into a null-prototype record.
+ *
+ * Offset date-times are represented by `Date`, matching the package this
+ * parser replaces. Local dates and times remain strings.
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const parse = (input: string): Record<string, unknown> => new TomlParser(input.replace(/^\uFEFF/, "")).parse()

--- a/packages/effect/src/unstable/encoding/Yaml.ts
+++ b/packages/effect/src/unstable/encoding/Yaml.ts
@@ -1,0 +1,541 @@
+/**
+ * Parses YAML configuration files.
+ *
+ * This is a focused YAML 1.2 configuration parser. It supports block and flow
+ * collections, quoted and block scalars, anchors, and aliases.
+ *
+ * @since 4.0.0
+ */
+
+/*
+ * The behavior is based on `yaml` 2.9.0.
+ *
+ * Copyright Eemeli Aro <eemeli@gmail.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+ * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+type YamlRecord = Record<string, unknown>
+
+type Line = {
+  readonly raw: string
+  readonly text: string
+  readonly indent: number
+  readonly number: number
+}
+
+const hasOwn = Object.prototype.hasOwnProperty
+
+const setProperty = (record: YamlRecord, key: string, value: unknown): void => {
+  Object.defineProperty(record, key, {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value
+  })
+}
+
+const stripComment = (input: string): string => {
+  let quote: "'" | "\"" | undefined
+  let escaped = false
+  for (let index = 0; index < input.length; index++) {
+    const character = input[index]
+    if (quote === "\"") {
+      if (escaped) {
+        escaped = false
+      } else if (character === "\\") {
+        escaped = true
+      } else if (character === quote) {
+        quote = undefined
+      }
+    } else if (quote === "'") {
+      if (character === quote && input[index + 1] === quote) {
+        index++
+      } else if (character === quote) {
+        quote = undefined
+      }
+    } else if (character === "'" || character === "\"") {
+      quote = character
+    } else if (character === "#" && (index === 0 || /\s/.test(input[index - 1]))) {
+      return input.slice(0, index).trimEnd()
+    }
+  }
+  return input.trimEnd()
+}
+
+const mappingSeparator = (input: string): number => {
+  let quote: "'" | "\"" | undefined
+  let escaped = false
+  let depth = 0
+  for (let index = 0; index < input.length; index++) {
+    const character = input[index]
+    if (quote === "\"") {
+      if (escaped) escaped = false
+      else if (character === "\\") escaped = true
+      else if (character === quote) quote = undefined
+    } else if (quote === "'") {
+      if (character === quote && input[index + 1] === quote) index++
+      else if (character === quote) quote = undefined
+    } else if (character === "'" || character === "\"") {
+      quote = character
+    } else if (character === "[" || character === "{") {
+      depth++
+    } else if (character === "]" || character === "}") {
+      depth--
+    } else if (character === ":" && depth === 0 && (input[index + 1] === undefined || /\s/.test(input[index + 1]))) {
+      return index
+    }
+  }
+  return -1
+}
+
+const parseDoubleQuoted = (input: string): string => {
+  if (!input.endsWith("\"") || input.length < 2) {
+    throw new SyntaxError("Unterminated double-quoted YAML string")
+  }
+  let output = ""
+  for (let index = 1; index < input.length - 1; index++) {
+    const character = input[index]
+    if (character !== "\\") {
+      output += character
+      continue
+    }
+    const escape = input[++index]
+    const escapes: Record<string, string> = {
+      "0": "\0",
+      a: "\x07",
+      b: "\b",
+      t: "\t",
+      n: "\n",
+      v: "\v",
+      f: "\f",
+      r: "\r",
+      e: "\x1b",
+      " ": " ",
+      "\"": "\"",
+      "/": "/",
+      "\\": "\\",
+      N: "\u0085",
+      _: "\u00a0",
+      L: "\u2028",
+      P: "\u2029"
+    }
+    if (hasOwn.call(escapes, escape)) {
+      output += escapes[escape]
+      continue
+    }
+    if (escape === "x" || escape === "u" || escape === "U") {
+      const length = escape === "x" ? 2 : escape === "u" ? 4 : 8
+      const hex = input.slice(index + 1, index + 1 + length)
+      if (!new RegExp(`^[0-9A-Fa-f]{${length}}$`).test(hex)) {
+        throw new SyntaxError("Invalid unicode escape in YAML string")
+      }
+      output += String.fromCodePoint(Number.parseInt(hex, 16))
+      index += length
+      continue
+    }
+    throw new SyntaxError(`Invalid YAML escape '\\${escape}'`)
+  }
+  return output
+}
+
+const parseScalar = (input: string): unknown => {
+  const value = input.trim()
+  if (value.length === 0) return null
+  if (value.startsWith("\"") && value.endsWith("\"")) {
+    return parseDoubleQuoted(value)
+  }
+  if (value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1).replace(/''/g, "'")
+  }
+  if (/^(?:null|~)$/i.test(value)) return null
+  if (/^true$/i.test(value)) return true
+  if (/^false$/i.test(value)) return false
+  if (/^[+-]?\.inf$/i.test(value)) return value[0] === "-" ? Number.NEGATIVE_INFINITY : Number.POSITIVE_INFINITY
+  if (/^\.nan$/i.test(value)) return Number.NaN
+
+  const normalized = value.replace(/_/g, "")
+  if (/^[+-]?0x[0-9a-f]+$/i.test(normalized)) {
+    const sign = normalized[0] === "-" ? -1 : 1
+    return sign * Number.parseInt(normalized.replace(/^[+-]?0x/i, ""), 16)
+  }
+  if (/^[+-]?0o[0-7]+$/i.test(normalized)) {
+    const sign = normalized[0] === "-" ? -1 : 1
+    return sign * Number.parseInt(normalized.replace(/^[+-]?0o/i, ""), 8)
+  }
+  if (
+    /^[+-]?(?:0|[1-9]\d*)$/.test(normalized) ||
+    /^[+-]?(?:(?:0|[1-9]\d*)?\.\d+|(?:0|[1-9]\d*)\.?\d*[eE][+-]?\d+)$/.test(normalized)
+  ) {
+    return Number(normalized)
+  }
+  return value
+}
+
+const parseKey = (input: string): string => {
+  const value = parseScalar(input)
+  return value === null || value === undefined ? "" : String(value)
+}
+
+class FlowParser {
+  private readonly input: string
+  private readonly anchors: ReadonlyMap<string, unknown>
+  private index = 0
+
+  constructor(input: string, anchors: ReadonlyMap<string, unknown>) {
+    this.input = input
+    this.anchors = anchors
+  }
+
+  parse(): unknown {
+    const value = this.parseValue()
+    this.skipWhitespace()
+    if (this.index !== this.input.length) {
+      this.fail("Unexpected flow collection content")
+    }
+    return value
+  }
+
+  private parseValue(): unknown {
+    this.skipWhitespace()
+    const character = this.peek()
+    if (character === "[") return this.parseSequence()
+    if (character === "{") return this.parseMapping()
+    if (character === "\"" || character === "'") return parseScalar(this.readQuoted(character))
+    if (character === "*") {
+      this.index++
+      const name = this.readUntil(/[,\]}\s]/)
+      if (!this.anchors.has(name)) this.fail(`Unknown alias '*${name}'`)
+      return this.anchors.get(name)
+    }
+    return parseScalar(this.readUntil(/[,\]}]/).trim())
+  }
+
+  private parseSequence(): Array<unknown> {
+    this.expect("[")
+    const output: Array<unknown> = []
+    this.skipWhitespace()
+    if (this.peek() === "]") {
+      this.index++
+      return output
+    }
+    while (true) {
+      output.push(this.parseValue())
+      this.skipWhitespace()
+      if (this.peek() === "]") {
+        this.index++
+        return output
+      }
+      this.expect(",")
+      this.skipWhitespace()
+      if (this.peek() === "]") {
+        this.index++
+        return output
+      }
+    }
+  }
+
+  private parseMapping(): YamlRecord {
+    this.expect("{")
+    const output: YamlRecord = {}
+    this.skipWhitespace()
+    if (this.peek() === "}") {
+      this.index++
+      return output
+    }
+    while (true) {
+      const key = this.parseKey()
+      this.skipWhitespace()
+      this.expect(":")
+      if (hasOwn.call(output, key)) this.fail(`Duplicate key '${key}'`)
+      setProperty(output, key, this.parseValue())
+      this.skipWhitespace()
+      if (this.peek() === "}") {
+        this.index++
+        return output
+      }
+      this.expect(",")
+      this.skipWhitespace()
+      if (this.peek() === "}") {
+        this.index++
+        return output
+      }
+    }
+  }
+
+  private parseKey(): string {
+    this.skipWhitespace()
+    const character = this.peek()
+    if (character === "\"" || character === "'") {
+      return parseKey(this.readQuoted(character))
+    }
+    return this.readUntil(/:/).trim()
+  }
+
+  private readQuoted(quote: string): string {
+    const start = this.index++
+    let escaped = false
+    while (this.index < this.input.length) {
+      const character = this.input[this.index++]
+      if (quote === "\"" && escaped) escaped = false
+      else if (quote === "\"" && character === "\\") escaped = true
+      else if (quote === "'" && character === quote && this.input[this.index] === quote) this.index++
+      else if (character === quote) return this.input.slice(start, this.index)
+    }
+    this.fail("Unterminated quoted scalar")
+  }
+
+  private readUntil(stop: RegExp): string {
+    const start = this.index
+    while (this.index < this.input.length && !stop.test(this.peek())) this.index++
+    return this.input.slice(start, this.index)
+  }
+
+  private skipWhitespace(): void {
+    while (/\s/.test(this.peek())) this.index++
+  }
+
+  private expect(character: string): void {
+    if (this.peek() !== character) this.fail(`Expected '${character}'`)
+    this.index++
+  }
+
+  private peek(): string {
+    return this.input[this.index] ?? ""
+  }
+
+  private fail(message: string): never {
+    throw new SyntaxError(`${message} at flow offset ${this.index}`)
+  }
+}
+
+class YamlParser {
+  private readonly lines: ReadonlyArray<Line>
+  private index = 0
+  private readonly anchors = new Map<string, unknown>()
+
+  constructor(lines: ReadonlyArray<Line>) {
+    this.lines = lines
+  }
+
+  parse(): unknown {
+    this.skipIgnored()
+    if (this.index >= this.lines.length) return null
+    const value = this.parseNode(this.lines[this.index].indent)
+    this.skipIgnored()
+    if (this.index < this.lines.length) {
+      this.fail(this.lines[this.index], "Unexpected content")
+    }
+    return value
+  }
+
+  private parseNode(indent: number): unknown {
+    this.skipIgnored()
+    const line = this.lines[this.index]
+    if (line === undefined) return null
+    if (line.indent !== indent) this.fail(line, `Expected indentation of ${indent} spaces`)
+    if (line.text === "-" || line.text.startsWith("- ")) return this.parseSequence(indent)
+    if (mappingSeparator(line.text) !== -1) return this.parseMapping(indent)
+    this.index++
+    return this.parseInlineValue(line.text)
+  }
+
+  private parseMapping(indent: number): YamlRecord {
+    const output: YamlRecord = {}
+    while (true) {
+      this.skipIgnored()
+      const line = this.lines[this.index]
+      if (line === undefined || line.indent < indent) return output
+      if (line.indent > indent) this.fail(line, `Unexpected indentation of ${line.indent} spaces`)
+      const separator = mappingSeparator(line.text)
+      if (separator === -1) return output
+      this.index++
+      this.parseMappingEntry(output, line.text, separator, indent, line)
+    }
+  }
+
+  private parseMappingEntry(
+    output: YamlRecord,
+    text: string,
+    separator: number,
+    indent: number,
+    line: Line
+  ): void {
+    const key = parseKey(text.slice(0, separator).trim())
+    const rawValue = text.slice(separator + 1).trim()
+    const value = this.parseNodeValue(rawValue, indent)
+    if (hasOwn.call(output, key)) this.fail(line, `Duplicate key '${key}'`)
+    setProperty(output, key, value)
+  }
+
+  private parseSequence(indent: number): Array<unknown> {
+    const output: Array<unknown> = []
+    while (true) {
+      this.skipIgnored()
+      const line = this.lines[this.index]
+      if (line === undefined || line.indent < indent) return output
+      if (line.indent > indent) this.fail(line, `Unexpected indentation of ${line.indent} spaces`)
+      if (line.text !== "-" && !line.text.startsWith("- ")) return output
+      this.index++
+      const item = line.text.slice(1).trimStart()
+      const separator = mappingSeparator(item)
+      if (separator === -1) {
+        output.push(this.parseNodeValue(item, indent))
+        continue
+      }
+
+      const mapping: YamlRecord = {}
+      this.parseMappingEntry(mapping, item, separator, indent + 2, line)
+      while (true) {
+        this.skipIgnored()
+        const continuation = this.lines[this.index]
+        if (continuation === undefined || continuation.indent <= indent) break
+        if (continuation.indent !== indent + 2) {
+          this.fail(continuation, `Expected indentation of ${indent + 2} spaces`)
+        }
+        const nextSeparator = mappingSeparator(continuation.text)
+        if (nextSeparator === -1) this.fail(continuation, "Expected a mapping entry")
+        this.index++
+        this.parseMappingEntry(mapping, continuation.text, nextSeparator, indent + 2, continuation)
+      }
+      output.push(mapping)
+    }
+  }
+
+  private parseNodeValue(rawValue: string, parentIndent: number): unknown {
+    let value = rawValue
+    let anchor: string | undefined
+    const anchorMatch = /^&([^\s,[\]{}]+)(?:\s+(.*))?$/.exec(value)
+    if (anchorMatch !== null) {
+      anchor = anchorMatch[1]
+      value = anchorMatch[2] ?? ""
+    }
+
+    let parsed: unknown
+    if (value.length === 0) {
+      this.skipIgnored()
+      const next = this.lines[this.index]
+      parsed = next !== undefined && next.indent > parentIndent ? this.parseNode(next.indent) : null
+    } else if (/^[|>](?:[1-9]?[+-]?|[+-]?[1-9]?)$/.test(value)) {
+      parsed = this.parseBlockScalar(value, parentIndent)
+    } else {
+      parsed = this.parseInlineValue(value)
+    }
+    if (anchor !== undefined) this.anchors.set(anchor, parsed)
+    return parsed
+  }
+
+  private parseInlineValue(value: string): unknown {
+    if (value.startsWith("*")) {
+      const name = value.slice(1).trim()
+      if (!this.anchors.has(name)) throw new SyntaxError(`Unknown YAML alias '*${name}'`)
+      return this.anchors.get(name)
+    }
+    if (value.startsWith("[") || value.startsWith("{")) {
+      return new FlowParser(value, this.anchors).parse()
+    }
+    return parseScalar(value)
+  }
+
+  private parseBlockScalar(indicator: string, parentIndent: number): string {
+    const style = indicator[0]
+    const chomp = indicator.includes("-") ? "strip" : indicator.includes("+") ? "keep" : "clip"
+    const explicitIndent = Number.parseInt(indicator.replace(/[^1-9]/g, ""), 10)
+    const start = this.index
+    let end = start
+    let contentIndent = Number.isNaN(explicitIndent) ? Number.POSITIVE_INFINITY : parentIndent + explicitIndent
+
+    while (end < this.lines.length) {
+      const line = this.lines[end]
+      if (line.raw.trim().length !== 0 && line.indent <= parentIndent) break
+      if (line.raw.trim().length !== 0) contentIndent = Math.min(contentIndent, line.indent)
+      end++
+    }
+    if (contentIndent === Number.POSITIVE_INFINITY) contentIndent = parentIndent + 1
+
+    const content: Array<string> = []
+    for (let index = start; index < end; index++) {
+      const line = this.lines[index]
+      if (line.raw.trim().length === 0) {
+        content.push("")
+      } else if (line.indent < contentIndent) {
+        this.fail(line, `Expected block scalar indentation of ${contentIndent} spaces`)
+      } else {
+        content.push(line.raw.slice(contentIndent))
+      }
+    }
+    this.index = end
+
+    let output = ""
+    if (style === "|") {
+      output = content.join("\n")
+    } else {
+      for (let index = 0; index < content.length; index++) {
+        output += content[index]
+        if (index < content.length - 1) {
+          output += content[index].length === 0 || content[index + 1].length === 0 ? "\n" : " "
+        }
+      }
+    }
+    if (chomp === "keep") return `${output}\n`
+    output = output.replace(/\n+$/, "")
+    return chomp === "strip" ? output : `${output}\n`
+  }
+
+  private skipIgnored(): void {
+    while (this.index < this.lines.length) {
+      const line = this.lines[this.index]
+      if (line.text.length === 0 || line.text.startsWith("%") || line.text === "---") {
+        this.index++
+      } else if (line.text === "...") {
+        this.index++
+        while (this.index < this.lines.length && this.lines[this.index].text.length === 0) this.index++
+        if (this.index < this.lines.length) {
+          this.fail(this.lines[this.index], "Multiple YAML documents are not supported")
+        }
+      } else {
+        return
+      }
+    }
+  }
+
+  private fail(line: Line, message: string): never {
+    throw new SyntaxError(`${message} at line ${line.number}`)
+  }
+}
+
+/**
+ * Parses one YAML document into JavaScript values.
+ *
+ * The core YAML 1.2 scalar schema is used, so booleans, nulls, and numbers are
+ * decoded while date-like values remain strings.
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const parse = (input: string): unknown => {
+  const source = input.replace(/^\uFEFF/, "").replace(/\r\n?/g, "\n")
+  const lines = source.split("\n").map((raw, index): Line => {
+    const indentation = /^( *)/.exec(raw)![1].length
+    if (raw.slice(0, indentation + 1).includes("\t")) {
+      throw new SyntaxError(`Tabs cannot be used for YAML indentation at line ${index + 1}`)
+    }
+    return {
+      raw,
+      text: stripComment(raw.slice(indentation)),
+      indent: indentation,
+      number: index + 1
+    }
+  })
+  return new YamlParser(lines).parse()
+}

--- a/packages/effect/src/unstable/encoding/index.ts
+++ b/packages/effect/src/unstable/encoding/index.ts
@@ -7,6 +7,11 @@
 /**
  * @since 4.0.0
  */
+export * as Ini from "./Ini.ts"
+
+/**
+ * @since 4.0.0
+ */
 export * as Msgpack from "./Msgpack.ts"
 
 /**
@@ -18,3 +23,13 @@ export * as Ndjson from "./Ndjson.ts"
  * @since 4.0.0
  */
 export * as Sse from "./Sse.ts"
+
+/**
+ * @since 4.0.0
+ */
+export * as Toml from "./Toml.ts"
+
+/**
+ * @since 4.0.0
+ */
+export * as Yaml from "./Yaml.ts"

--- a/packages/effect/test/unstable/encoding/Ini.test.ts
+++ b/packages/effect/test/unstable/encoding/Ini.test.ts
@@ -1,0 +1,48 @@
+import { assert, describe, it } from "@effect/vitest"
+import * as Ini from "effect/unstable/encoding/Ini"
+
+describe("Ini", () => {
+  it("parses sections, arrays, and scalar values", () => {
+    assert.deepStrictEqual(
+      Ini.parse(`
+enabled=true
+missing=null
+name=effect
+tag[]=one
+tag[]=two
+
+[database.pool]
+size=10
+`),
+      {
+        enabled: true,
+        missing: null,
+        name: "effect",
+        tag: ["one", "two"],
+        database: {
+          pool: {
+            size: "10"
+          }
+        }
+      }
+    )
+  })
+
+  it("supports quoted values, comments, and escaped section dots", () => {
+    assert.deepStrictEqual(
+      Ini.parse(`
+plain=value ; comment
+quoted="value # retained"
+[a\\.b]
+key=yes
+`),
+      {
+        plain: "value",
+        quoted: "value # retained",
+        "a.b": {
+          key: "yes"
+        }
+      }
+    )
+  })
+})

--- a/packages/effect/test/unstable/encoding/Toml.test.ts
+++ b/packages/effect/test/unstable/encoding/Toml.test.ts
@@ -1,0 +1,71 @@
+import { assert, describe, it } from "@effect/vitest"
+import * as Toml from "effect/unstable/encoding/Toml"
+
+describe("Toml", () => {
+  it("parses tables, dotted keys, arrays, and inline tables", () => {
+    assert.deepStrictEqual(
+      Toml.parse(`
+title = "Effect"
+ports = [8000, 8001]
+database.connection.timeout = 30
+
+[database]
+enabled = true
+credentials = { user = "root", roles = ["admin", "writer"] }
+`),
+      {
+        title: "Effect",
+        ports: [8000, 8001],
+        database: {
+          connection: { timeout: 30 },
+          enabled: true,
+          credentials: { user: "root", roles: ["admin", "writer"] }
+        }
+      }
+    )
+  })
+
+  it("parses arrays of tables and date-time values", () => {
+    assert.deepStrictEqual(
+      Toml.parse(`
+[[servers]]
+name = "alpha"
+started = 2026-08-05T01:02:03Z
+
+[[servers]]
+name = "beta"
+started = 2026-08-05
+`),
+      {
+        servers: [
+          { name: "alpha", started: new Date("2026-08-05T01:02:03Z") },
+          { name: "beta", started: "2026-08-05" }
+        ]
+      }
+    )
+  })
+
+  it("parses multiline strings and numeric formats", () => {
+    assert.deepStrictEqual(
+      Toml.parse(`
+message = """
+hello \\
+  world"""
+hex = 0xDEAD_BEEF
+fraction = 1_000.5
+local = 2026-08-05 01:02:03
+`),
+      {
+        message: "hello world",
+        hex: 0xdeadbeef,
+        fraction: 1000.5,
+        local: "2026-08-05T01:02:03"
+      }
+    )
+  })
+
+  it("rejects duplicate keys", () => {
+    assert.throws(() => Toml.parse("key = 1\nkey = 2\n"))
+    assert.throws(() => Toml.parse("key = 1__000\n"))
+  })
+})

--- a/packages/effect/test/unstable/encoding/Yaml.test.ts
+++ b/packages/effect/test/unstable/encoding/Yaml.test.ts
@@ -1,0 +1,72 @@
+import { assert, describe, it } from "@effect/vitest"
+import * as Yaml from "effect/unstable/encoding/Yaml"
+
+describe("Yaml", () => {
+  it("parses nested block and flow collections", () => {
+    assert.deepStrictEqual(
+      Yaml.parse(`
+name: effect
+enabled: true
+ports: [3000, 3001]
+database:
+  host: localhost
+  credentials:
+    - user: root
+      roles: [admin, writer]
+    - user: guest
+      roles: []
+`),
+      {
+        name: "effect",
+        enabled: true,
+        ports: [3000, 3001],
+        database: {
+          host: "localhost",
+          credentials: [
+            { user: "root", roles: ["admin", "writer"] },
+            { user: "guest", roles: [] }
+          ]
+        }
+      }
+    )
+  })
+
+  it("parses quoted and block scalars", () => {
+    assert.deepStrictEqual(
+      Yaml.parse(`
+quoted: "line\\nvalue"
+literal: |
+  first
+  second
+folded: >-
+  first
+  second
+`),
+      {
+        quoted: "line\nvalue",
+        literal: "first\nsecond\n",
+        folded: "first second"
+      }
+    )
+  })
+
+  it("resolves aliases", () => {
+    assert.deepStrictEqual(
+      Yaml.parse(`
+defaults: &defaults
+  host: localhost
+  port: 5432
+development:
+  settings: *defaults
+`),
+      {
+        defaults: { host: "localhost", port: 5432 },
+        development: { settings: { host: "localhost", port: 5432 } }
+      }
+    )
+  })
+
+  it("rejects invalid indentation", () => {
+    assert.throws(() => Yaml.parse("root:\n   child: true\n  sibling: false\n"))
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,9 +344,6 @@ importers:
       find-my-way-ts:
         specifier: ^0.1.6
         version: 0.1.6
-      ini:
-        specifier: ^7.0.0
-        version: 7.0.0
       kubernetes-types:
         specifier: ^1.30.0
         version: 1.30.0
@@ -356,19 +353,10 @@ importers:
       multipasta:
         specifier: ^0.2.8
         version: 0.2.8
-      toml:
-        specifier: ^4.1.2
-        version: 4.1.2
       uuid:
         specifier: ^14.0.1
         version: 14.0.1
-      yaml:
-        specifier: ^2.9.0
-        version: 2.9.0
     devDependencies:
-      '@types/ini':
-        specifier: ^4.1.1
-        version: 4.1.1
       '@types/node':
         specifier: ^26.1.2
         version: 26.1.2
@@ -3202,9 +3190,6 @@ packages:
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
 
-  '@types/ini@4.1.1':
-    resolution: {integrity: sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg==}
-
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
 
@@ -4572,10 +4557,6 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
-
-  ini@7.0.0:
-    resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
-    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -6333,10 +6314,6 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
-
-  toml@4.1.2:
-    resolution: {integrity: sha512-m0vXfHODcw3gk+KONAOlVQ5yNHc3yS3B1ybM3HS1vqDoS0RWTDDVBVVTYi8hH0k+2OM1vmo9fb1WX9EVqjqfHA==}
-    engines: {node: '>=20'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -8879,8 +8856,6 @@ snapshots:
     dependencies:
       '@types/node': 26.1.2
 
-  '@types/ini@4.1.1': {}
-
   '@types/istanbul-lib-coverage@2.0.6': {}
 
   '@types/istanbul-lib-report@3.0.3':
@@ -10305,8 +10280,6 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
-
-  ini@7.0.0: {}
 
   invariant@2.2.4:
     dependencies:
@@ -12378,8 +12351,6 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
-
-  toml@4.1.2: {}
 
   totalist@3.0.1: {}
 


### PR DESCRIPTION
## Summary

- add focused `Ini`, `Yaml`, and `Toml` parsers under `effect/unstable/encoding`
- update the CLI configuration-file primitive to use the in-tree parsers
- remove the `ini`, `yaml`, `toml`, and `@types/ini` dependencies
- add parser coverage and preserve upstream license attribution

## Validation

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/unstable/encoding/Ini.test.ts packages/effect/test/unstable/encoding/Yaml.test.ts packages/effect/test/unstable/encoding/Toml.test.ts packages/effect/test/unstable/cli/Primitive.test.ts`
- `pnpm check`

Closes EFF-452