### PR TITLE
Fix fractional durable clock wake-ups

### DIFF
--- a/.changeset/fix-durable-clock-fractional-wakeup.md
+++ b/.changeset/fix-durable-clock-fractional-wakeup.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Normalize cluster durable clock wake-up timestamps to whole milliseconds.

--- a/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
+++ b/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
@@ -618,7 +618,10 @@ export const make = Effect.gen(function*() {
             payload: {
               name: options.clock.name,
               workflowName: workflow._tag,
-              wakeUp: DateTime.addDuration(now, options.clock.duration)
+              wakeUp: DateTime.mapEpochMillis(
+                DateTime.addDuration(now, options.clock.duration),
+                Math.ceil
+              )
             }
           })
         ),

--- a/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
+++ b/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
@@ -231,10 +231,11 @@ describe.concurrent("ClusterWorkflowEngine", () => {
       assert.isTrue(flags.get("child-end"))
     }).pipe(Effect.provide(TestWorkflowLayer)))
 
-  it.effect("routes durable clock wakeups to the workflow shard group", () =>
+  it.effect("routes fractional millisecond durable clock wakeups to the workflow shard group", () =>
     Effect.gen(function*() {
       const driver = yield* MessageStorage.MemoryDriver
       const sharding = yield* Sharding.Sharding
+      const startedAt = yield* DateTime.now
 
       const fiber = yield* ShardedClockWorkflow.execute({
         id: "sharded-clock"
@@ -247,8 +248,11 @@ describe.concurrent("ClusterWorkflowEngine", () => {
       )
       assert(envelope)
       assert.strictEqual(envelope.address.shardId.group, "workflow")
+      const deliverAt = driver.requests.get(envelope.requestId)?.deliverAt
+      assert.isNumber(deliverAt)
+      assert.strictEqual(deliverAt, DateTime.toEpochMillis(startedAt) + 10001)
 
-      yield* TestClock.adjust("10 seconds")
+      yield* TestClock.adjust(10001)
       yield* sharding.pollStorage
       yield* TestClock.adjust(5000)
       yield* Fiber.join(fiber)
@@ -687,7 +691,7 @@ const ShardedClockWorkflow = Workflow.make("ShardedClockWorkflow", {
 const ShardedClockWorkflowLayer = ShardedClockWorkflow.toLayer(Effect.fnUntraced(function*() {
   yield* DurableClock.sleep({
     name: "ShardedClock",
-    duration: "10 seconds",
+    duration: 10000.5,
     inMemoryThreshold: Duration.zero
   })
 }))


### PR DESCRIPTION
## RFC status

**Implementation complete, locally validated, and independently reviewed with no findings.** This is ready for review. RFC feedback is specifically requested on using ceiling semantics at the cluster persistence boundary.

## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Cluster durable clocks currently accept fractional-millisecond `Duration` values but compute a fractional `wakeUp` timestamp that cannot be encoded by the integer-backed `Schema.DateTimeUtcFromMillis` payload.

This can happen naturally when a workflow uses jittered exponential retry delays. Multiplying a base duration by a floating-point jitter factor produces fractional milliseconds; forcing that delay through `DurableClock.sleep` then defects before the retry can be scheduled.

This change normalizes the final absolute `wakeUp` timestamp with `Math.ceil` inside `ClusterWorkflowEngine.scheduleClock`. The normalization is deliberately limited to the cluster persistence boundary:

- `Duration` and `DateTime` retain sub-millisecond arithmetic.
- The integer-backed RPC and SQL delivery timestamp receive a representable value.
- Ceiling semantics ensure a durable timer cannot wake earlier than requested, adding at most one millisecond.

The existing sharded durable-clock test now uses a `10000.5ms` duration and asserts the persisted deadline is exactly `startedAt + 10001ms`. The regression test fails against the original implementation because no clock request can be encoded.

### Focused RFC question

Is normalizing the final absolute timestamp with `Math.ceil` in `ClusterWorkflowEngine.scheduleClock` the preferred boundary and timer semantic?

## Validation

- Regression test against the original implementation: failed as expected because the durable-clock request was absent after schema encoding failed
- `pnpm lint-fix` - passed
- `pnpm test --run packages/effect/test/cluster/ClusterWorkflowEngine.test.ts` - 13 tests passed
- `pnpm check` - passed
- `git diff --check` - passed
- Independent review loop - clean after strengthening the test to distinguish ceiling from floor/truncation

## Related

- Closes #7015

---

This investigation and implementation were prepared with assistance from OpenAI GPT-5.6 Sol (medium reasoning) and human-verified against Effect `main`, targeted tests, and production evidence.
