### PR TITLE
Hold persisted messages during entity registration

### DIFF
--- a/.changeset/slow-entities-register.md
+++ b/.changeset/slow-entities-register.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Hold persisted cluster messages while entity layers are still registering.

--- a/.changeset/slow-entities-register.md
+++ b/.changeset/slow-entities-register.md
@@ -2,4 +2,5 @@
 "effect": patch
 ---
 
-Hold persisted cluster messages while entity layers are still registering.
+Hold persisted cluster messages while entity layers are still registering, while retaining a bounded failure when
+registration never begins.

--- a/packages/effect/src/unstable/cluster/Sharding.ts
+++ b/packages/effect/src/unstable/cluster/Sharding.ts
@@ -240,6 +240,7 @@ const make = Effect.gen(function*() {
   const runnerStorage = yield* RunnerStorage
 
   const entityManagers = new Map<string, EntityManagerState>()
+  let entityRegistrationStartMillis: number | undefined
 
   const shardAssignments = MutableHashMap.empty<ShardId, RunnerAddress>()
   const selfShards = MutableHashSet.empty<ShardId>()
@@ -591,7 +592,6 @@ const make = Effect.gen(function*() {
     const entityRegistrationTimeoutMillis = Duration.toMillis(
       Duration.fromInputUnsafe(config.entityRegistrationTimeout)
     )
-    const storageStartMillis = clock.currentTimeMillisUnsafe()
 
     yield* Effect.gen(function*() {
       yield* Effect.logDebug("Starting")
@@ -617,7 +617,10 @@ const make = Effect.gen(function*() {
           }
           const state = entityManagers.get(address.entityType)
           if (!state) {
-            const sinceStart = clock.currentTimeMillisUnsafe() - storageStartMillis
+            if (entityRegistrationStartMillis === undefined) {
+              return Effect.void
+            }
+            const sinceStart = clock.currentTimeMillisUnsafe() - entityRegistrationStartMillis
             if (sinceStart < entityRegistrationTimeoutMillis) {
               // reset address in the case that the entity is slow to register
               MutableHashSet.add(resetAddresses, address)
@@ -1461,6 +1464,7 @@ const make = Effect.gen(function*() {
       // register entities while storage is idle
       // this ensures message order is preserved
       yield* withStorageReadLock(Effect.sync(() => {
+        entityRegistrationStartMillis ??= clock.currentTimeMillisUnsafe()
         entityManagers.set(entity.type, state)
         if (entityManagerLatches.has(entity.type)) {
           entityManagerLatches.get(entity.type)!.openUnsafe()

--- a/packages/effect/src/unstable/cluster/Sharding.ts
+++ b/packages/effect/src/unstable/cluster/Sharding.ts
@@ -622,8 +622,7 @@ const make = Effect.gen(function*() {
             const registrationStarted = entityRegistrationStartMillis !== undefined
             const timeoutStartMillis = entityRegistrationStartMillis ??
               (entityRegistrationFallbackStartMillis ??= now)
-            // If registration never starts, hold and warn for one interval,
-            // then use a second interval as the hard fallback.
+            // If registration never starts, allow two intervals from the first missing read before failing.
             const timeoutMillis = registrationStarted
               ? entityRegistrationTimeoutMillis
               : entityRegistrationTimeoutMillis * 2

--- a/packages/effect/src/unstable/cluster/Sharding.ts
+++ b/packages/effect/src/unstable/cluster/Sharding.ts
@@ -241,6 +241,7 @@ const make = Effect.gen(function*() {
 
   const entityManagers = new Map<string, EntityManagerState>()
   let entityRegistrationStartMillis: number | undefined
+  let entityRegistrationFallbackStartMillis: number | undefined
 
   const shardAssignments = MutableHashMap.empty<ShardId, RunnerAddress>()
   const selfShards = MutableHashSet.empty<ShardId>()
@@ -617,11 +618,16 @@ const make = Effect.gen(function*() {
           }
           const state = entityManagers.get(address.entityType)
           if (!state) {
-            if (entityRegistrationStartMillis === undefined) {
-              return Effect.void
-            }
-            const sinceStart = clock.currentTimeMillisUnsafe() - entityRegistrationStartMillis
-            if (sinceStart < entityRegistrationTimeoutMillis) {
+            const now = clock.currentTimeMillisUnsafe()
+            const registrationStarted = entityRegistrationStartMillis !== undefined
+            const timeoutStartMillis = entityRegistrationStartMillis ??
+              (entityRegistrationFallbackStartMillis ??= now)
+            // If registration never starts, hold and warn for one interval,
+            // then use a second interval as the hard fallback.
+            const timeoutMillis = registrationStarted
+              ? entityRegistrationTimeoutMillis
+              : entityRegistrationTimeoutMillis * 2
+            if (now - timeoutStartMillis < timeoutMillis) {
               // reset address in the case that the entity is slow to register
               MutableHashSet.add(resetAddresses, address)
               return Effect.void

--- a/packages/effect/test/cluster/Sharding.test.ts
+++ b/packages/effect/test/cluster/Sharding.test.ts
@@ -433,6 +433,71 @@ describe.concurrent("Sharding", () => {
       Layer.merge(TestEntityState.layer)
     ))))
 
+  it.effect("holds durable messages while entity layers are still building", () =>
+    Effect.gen(function*() {
+      const config = ShardingConfig.layer({
+        entityMailboxCapacity: 10,
+        entityRegistrationTimeout: 1000,
+        entityTerminationTimeout: 0,
+        entityMessagePollInterval: 100,
+        sendRetryInterval: 100,
+        refreshAssignmentsInterval: 0
+      })
+      const env = TestEntityNoState.pipe(
+        Layer.provideMerge(Sharding.layer),
+        Layer.provide(RunnerStorage.layerMemory),
+        Layer.provide(RunnerHealth.layerNoop),
+        Layer.provide(Runners.layerNoop),
+        Layer.provide(config)
+      )
+      const delayedEnv = TestEntityNoState.pipe(
+        Layer.provide(Layer.effectDiscard(Effect.sleep(10_000))),
+        Layer.provideMerge(Sharding.layer),
+        Layer.provide(RunnerStorage.layerMemory),
+        Layer.provide(RunnerHealth.layerNoop),
+        Layer.provide(Runners.layerNoop),
+        Layer.provide(config)
+      )
+      const driver = yield* MessageStorage.MemoryDriver
+      const state = yield* TestEntityState
+
+      yield* Effect.gen(function*() {
+        yield* TestClock.adjust(1)
+        const makeClient = yield* TestEntity.client
+        const client = makeClient("1")
+        yield* client.RequestWithKey({ key: "slow-registration" }).pipe(Effect.forkChild)
+        yield* TestClock.adjust(1)
+      }).pipe(
+        Effect.provide(env),
+        Effect.scoped
+      )
+
+      assert.strictEqual(driver.journal.length, 1)
+      assert.strictEqual(driver.replyIds.size, 0)
+      assert.strictEqual(driver.unprocessed.size, 1)
+
+      const fiber = yield* Effect.never.pipe(
+        Effect.provide(delayedEnv),
+        Effect.scoped,
+        Effect.forkChild({ startImmediately: true })
+      )
+
+      yield* TestClock.adjust(7500)
+      assert.strictEqual(driver.replyIds.size, 0)
+      assert.strictEqual(driver.unprocessed.size, 1)
+
+      yield* TestClock.adjust(2500)
+      yield* Queue.offer(state.messages, void 0)
+      yield* TestClock.adjust(100)
+
+      assert.strictEqual(driver.replyIds.size, 1)
+      assert.strictEqual(driver.unprocessed.size, 0)
+      yield* Fiber.interrupt(fiber)
+    }).pipe(Effect.provide(MessageStorage.layerMemory.pipe(
+      Layer.provide(ShardingConfig.layer({})),
+      Layer.merge(TestEntityState.layer)
+    ))))
+
   it.effect("durable streams are resumed on restart", () =>
     Effect.gen(function*() {
       const EnvLayer = TestShardingWithoutState.pipe(

--- a/packages/effect/test/cluster/Sharding.test.ts
+++ b/packages/effect/test/cluster/Sharding.test.ts
@@ -1,5 +1,19 @@
 import { assert, describe, expect, it } from "@effect/vitest"
-import { Array, Cause, Clock, Context, Effect, Exit, Fiber, Layer, MutableRef, Option, Queue, Stream } from "effect"
+import {
+  Array,
+  Cause,
+  Clock,
+  Context,
+  Effect,
+  Exit,
+  Fiber,
+  Layer,
+  Logger,
+  MutableRef,
+  Option,
+  Queue,
+  Stream
+} from "effect"
 import { TestClock } from "effect/testing"
 import {
   ClusterMetrics,
@@ -437,7 +451,7 @@ describe.concurrent("Sharding", () => {
     Effect.gen(function*() {
       const config = ShardingConfig.layer({
         entityMailboxCapacity: 10,
-        entityRegistrationTimeout: 1000,
+        entityRegistrationTimeout: 6000,
         entityTerminationTimeout: 0,
         entityMessagePollInterval: 100,
         sendRetryInterval: 100,
@@ -490,6 +504,67 @@ describe.concurrent("Sharding", () => {
       yield* Queue.offer(state.messages, void 0)
       yield* TestClock.adjust(100)
 
+      assert.strictEqual(driver.replyIds.size, 1)
+      assert.strictEqual(driver.unprocessed.size, 0)
+      yield* Fiber.interrupt(fiber)
+    }).pipe(Effect.provide(MessageStorage.layerMemory.pipe(
+      Layer.provide(ShardingConfig.layer({})),
+      Layer.merge(TestEntityState.layer)
+    ))))
+
+  it.effect("defects durable messages when no entity ever registers", () =>
+    Effect.gen(function*() {
+      const config = ShardingConfig.layer({
+        entityMailboxCapacity: 10,
+        entityRegistrationTimeout: 1000,
+        entityTerminationTimeout: 0,
+        entityMessagePollInterval: 100,
+        sendRetryInterval: 100,
+        refreshAssignmentsInterval: 0
+      })
+      const registeredEnv = TestEntityNoState.pipe(
+        Layer.provideMerge(Sharding.layer),
+        Layer.provide(RunnerStorage.layerMemory),
+        Layer.provide(RunnerHealth.layerNoop),
+        Layer.provide(Runners.layerNoop),
+        Layer.provide(config)
+      )
+      const noEntitiesEnv = Sharding.layer.pipe(
+        Layer.provide(RunnerStorage.layerMemory),
+        Layer.provide(RunnerHealth.layerNoop),
+        Layer.provide(Runners.layerNoop),
+        Layer.provide(config)
+      )
+      const driver = yield* MessageStorage.MemoryDriver
+      const warnings: Array<unknown> = []
+      const logger = Logger.make<unknown, void>((options) => {
+        if (options.logLevel === "Warn") {
+          warnings.push(options.message)
+        }
+      })
+
+      yield* Effect.gen(function*() {
+        yield* TestClock.adjust(1)
+        const makeClient = yield* TestEntity.client
+        const client = makeClient("1")
+        yield* client.RequestWithKey({ key: "missing-registration" }).pipe(Effect.forkChild)
+        yield* TestClock.adjust(1)
+      }).pipe(
+        Effect.provide(registeredEnv),
+        Effect.scoped
+      )
+
+      const fiber = yield* Effect.never.pipe(
+        Effect.provide(noEntitiesEnv),
+        Effect.scoped,
+        Effect.withLogger(logger),
+        Effect.forkChild({ startImmediately: true })
+      )
+
+      yield* TestClock.adjust(8000)
+      assert.isTrue(warnings.some((message) =>
+        globalThis.Array.isArray(message) && message.includes("Could not find entity manager for address, retrying")
+      ))
       assert.strictEqual(driver.replyIds.size, 1)
       assert.strictEqual(driver.unprocessed.size, 0)
       yield* Fiber.interrupt(fiber)

--- a/packages/platform-node/test/cluster/SqlMessageStorage.integration.test.ts
+++ b/packages/platform-node/test/cluster/SqlMessageStorage.integration.test.ts
@@ -4,9 +4,14 @@ import { assert, describe, expect, it } from "@effect/vitest"
 import { Effect, Fiber, FileSystem, Latch, Layer, Option } from "effect"
 import { TestClock } from "effect/testing"
 import {
+  Entity,
   Envelope,
   Message,
   MessageStorage,
+  RunnerHealth,
+  Runners,
+  RunnerStorage,
+  Sharding,
   ShardingConfig,
   Snowflake,
   SqlMessageStorage
@@ -15,6 +20,7 @@ import { SqlClient } from "effect/unstable/sql"
 import { MysqlContainer } from "../fixtures/mysql2-utils.ts"
 import { PgContainer } from "../fixtures/pg-utils.ts"
 import {
+  GetUserRpc,
   LongKeyRpc,
   makeAckChunk,
   makeChunkReply,
@@ -23,6 +29,11 @@ import {
   PrimaryKeyTest,
   StreamRpc
 } from "./MessageStorageTest.ts"
+
+const TestEntity = Entity.make("test", [GetUserRpc])
+const TestEntityLayer = TestEntity.toLayer({
+  GetUser: () => Effect.void
+})
 
 const StorageLive = SqlMessageStorage.layer.pipe(
   Layer.provideMerge(Snowflake.layerGenerator),
@@ -331,6 +342,43 @@ describe("SqlMessageStorage", () => {
         }))
     })
   })
+
+  it.effect("keeps held messages readable while entity layers build", () =>
+    Effect.gen(function*() {
+      const config = ShardingConfig.layer({
+        entityRegistrationTimeout: 6000,
+        entityTerminationTimeout: 0,
+        entityMessagePollInterval: 100,
+        refreshAssignmentsInterval: 0
+      })
+      const delayedEnv = TestEntityLayer.pipe(
+        Layer.provide(Layer.effectDiscard(Effect.sleep(10_000))),
+        Layer.provideMerge(Sharding.layer),
+        Layer.provide(RunnerStorage.layerMemory),
+        Layer.provide(RunnerHealth.layerNoop),
+        Layer.provide(Runners.layerNoop),
+        Layer.provide(config)
+      )
+      const storage = yield* MessageStorage.MessageStorage
+      const request = yield* makeRequest()
+      yield* storage.saveRequest(request)
+
+      const fiber = yield* Effect.never.pipe(
+        Effect.provide(delayedEnv),
+        Effect.scoped,
+        Effect.forkChild({ startImmediately: true })
+      )
+
+      yield* TestClock.adjust(7500)
+      expect(yield* storage.repliesFor([request])).toHaveLength(0)
+
+      yield* TestClock.adjust(2500)
+      yield* TestClock.adjust(100)
+      expect(yield* storage.repliesFor([request])).toHaveLength(1)
+      yield* Fiber.interrupt(fiber)
+    }).pipe(Effect.provide(StorageLive.pipe(
+      Layer.provideMerge(SqliteLayer)
+    ))))
 })
 
 const SqliteLayer = Effect.gen(function*() {


### PR DESCRIPTION
## Summary

- start the normal entity registration timeout at the first successful entity registration instead of Sharding layer construction
- keep held SQL rows readable by resetting their address while registration is pending
- if registration never begins, warn while holding and use two configured registration intervals from the first missing-message read as a hard fallback before persisting the existing defect reply
- add memory-backed coverage for slow and absent registration plus SQLite-backed coverage for the `last_read` hold path

## Root cause

The storage inbox captured its timeout origin while the Sharding layer was built. Shard acquisition and message polling could therefore consume the entire registration budget while dependent entity-definition layers were still building, causing valid persisted messages to be saved as defect replies.

SQL storage also stamps `last_read` when polling. Held rows must continue through `resetAddress` so they remain visible on subsequent polls and can be delivered immediately after entity registration.

## Validation

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/cluster/Sharding.test.ts` (27 tests)
- `EFFECT_INTEGRATION_TESTS=1 pnpm test --run packages/platform-node/test/cluster/SqlMessageStorage.integration.test.ts -t "keeps held messages readable while entity layers build"`
- `pnpm check`

Closes EFF-462
Closes #6980