### PR TITLE
Round Redis persistence TTLs

### DIFF
--- a/.changeset/tidy-apples-rest.md
+++ b/.changeset/tidy-apples-rest.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Round Redis persistence TTLs up to whole milliseconds before passing them to integer-only expiration commands.

--- a/packages/effect/src/unstable/persistence/Persistence.ts
+++ b/packages/effect/src/unstable/persistence/Persistence.ts
@@ -943,7 +943,13 @@ export const layerBackingRedis: Layer.Layer<
             Effect.mapError(
               ttl === undefined
                 ? redis.send("SET", prefixed(key), JSON.stringify(value))
-                : redis.send("SET", prefixed(key), JSON.stringify(value), "PX", String(Duration.toMillis(ttl))),
+                : redis.send(
+                  "SET",
+                  prefixed(key),
+                  JSON.stringify(value),
+                  "PX",
+                  String(Math.ceil(Duration.toMillis(ttl)))
+                ),
               ({ cause }) =>
                 new PersistenceError({
                   message: `Failed to set key ${key} in Redis`,
@@ -958,7 +964,7 @@ export const layerBackingRedis: Layer.Layer<
                 const pkey = prefixed(key)
                 sets.set(pkey, JSON.stringify(value))
                 if (ttl) {
-                  expires.set(pkey, Duration.toMillis(ttl))
+                  expires.set(pkey, Math.ceil(Duration.toMillis(ttl)))
                 }
               }
               return Effect.mapError(

--- a/packages/effect/test/unstable/persistence/Redis.test.ts
+++ b/packages/effect/test/unstable/persistence/Redis.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Layer } from "effect"
+import { Duration, Effect, Layer } from "effect"
 import { Persistence, Redis } from "effect/unstable/persistence"
 
 describe("Redis", () => {
@@ -30,6 +30,43 @@ describe("Redis", () => {
       const backing = yield* Persistence.BackingPersistence
       const store = yield* backing.make("empty")
       yield* store.clear
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(Persistence.layerBackingRedis.pipe(Layer.provide(Layer.succeed(Redis.Redis, redis))))
+    )
+  })
+
+  it.effect("rounds fractional persistence TTLs up to whole milliseconds", () => {
+    const commands: Array<readonly [command: string, args: ReadonlyArray<string>]> = []
+    const scripts: Array<unknown> = []
+    const redis = Redis.Redis.of({
+      send: <A>(command: string, ...args: ReadonlyArray<string>) => {
+        commands.push([command, args])
+        return Effect.succeed(undefined as unknown as A)
+      },
+      eval:
+        <Config extends { readonly params: ReadonlyArray<unknown>; readonly result: unknown }>() =>
+        (...params: Config["params"]) => {
+          scripts.push(params[0])
+          return Effect.succeed(undefined as Config["result"])
+        }
+    })
+    return Effect.gen(function*() {
+      const backing = yield* Persistence.BackingPersistence
+      const store = yield* backing.make("ttl")
+      const ttl = Duration.nanos(1_500_000n)
+
+      yield* store.set("single", {}, ttl)
+      yield* store.setMany([["batch", {}, ttl]])
+
+      assert.deepStrictEqual(
+        commands.filter(([command]) => command === "SET"),
+        [["SET", ["ttl:single", "{}", "PX", "2"]]]
+      )
+      assert.deepStrictEqual(scripts, [{
+        sets: new Map([["ttl:batch", "{}"]]),
+        expires: new Map([["ttl:batch", 2]])
+      }])
     }).pipe(
       Effect.scoped,
       Effect.provide(Persistence.layerBackingRedis.pipe(Layer.provide(Layer.succeed(Redis.Redis, redis))))


### PR DESCRIPTION
## Summary

- round fractional Redis persistence TTLs up to whole milliseconds
- apply the normalization to both single-entry `SET ... PX` and batch `PEXPIRE` writes
- add regression coverage for both paths and a patch changeset

## Why

`Duration.toMillis` can return fractional values, but Redis requires integer millisecond arguments for `PX` and `PEXPIRE`. Redis 8.8.1 reproduces the failure with `ERR value is not an integer or out of range` for `PX 1.5`.

Rounding upward preserves the requested TTL without expiring entries early.

## Validation

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/unstable/persistence/Redis.test.ts`
- `pnpm check`

Closes EFF-464