### PR TITLE
Keep release PR type checks unstripped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,6 @@ jobs:
         uses: ./.github/actions/setup
       - name: Upgrade npm for OIDC support
         run: npm install -g npm@11
-      - name: Set strip internals config
-        run: |
-          sed -i 's/"stripInternal": false/"stripInternal": true/' tsconfig.base.json
       - name: Create Release Pull Request or Publish
         uses: changesets/action@d0ee272882939fa35f22d979828acb7e61e0bd47 # v2.0.0-next.4
         with:

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "api-diff": "pnpm --dir packages/tools/api-diff exec node src/bin.ts",
     "test-types": "tstyche --target '>=5.9'",
     "changeset-version": "changeset version",
-    "changeset-publish": "pnpm codemod && pnpm build && changeset publish"
+    "changeset-publish": "node scripts/set-strip-internal.mjs && pnpm codemod && pnpm build && changeset publish"
   },
   "devDependencies": {
     "@babel/cli": "^8.0.4",

--- a/scripts/set-strip-internal.mjs
+++ b/scripts/set-strip-internal.mjs
@@ -1,0 +1,11 @@
+import * as Fs from "node:fs"
+
+const path = new URL("../tsconfig.base.json", import.meta.url)
+const contents = Fs.readFileSync(path, "utf8")
+const updated = contents.replace('"stripInternal": false', '"stripInternal": true')
+
+if (contents === updated) {
+  throw new Error("Could not enable stripInternal in tsconfig.base.json")
+}
+
+Fs.writeFileSync(path, updated)


### PR DESCRIPTION
The release workflow enabled `stripInternal` before invoking `changesets/action`. When the action generated the version-packages commit, that dirty `tsconfig.base.json` change was included in the release branch. TypeScript project references then checked tests against stripped declarations in `dist/`, hiding the internal exports used by the test suite and producing 472 errors.

This removes the pre-action mutation and enables `stripInternal` only inside `changeset-publish`, immediately before the release build. Version-package PRs therefore retain the normal test configuration, while published declarations remain stripped.

Validation:
- `pnpm lint-fix`
- clean `pnpm check`
- verified the publish helper changes only `stripInternal`
- reproduced all 472 errors with the unpatched upstream TypeScript binary, ruling out the Effect tsgo patch

Closes EFF-465