### PR TITLE
Rename RateLimiter makeSleep to sleep

### DIFF
--- a/.changeset/fix-rate-limiter-sleep.md
+++ b/.changeset/fix-rate-limiter-sleep.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Rename `RateLimiter.makeSleep` to `RateLimiter.sleep` and support data-first and data-last usage.

--- a/.changeset/fix-rate-limiter-sleep.md
+++ b/.changeset/fix-rate-limiter-sleep.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Rename `RateLimiter.makeSleep` to `RateLimiter.sleep` and support data-first and data-last usage.
+Rename `RateLimiter.makeSleep` to `RateLimiter.sleep` and support self-first partially applied and uncurried usage.

--- a/packages/effect/src/unstable/persistence/RateLimiter.ts
+++ b/packages/effect/src/unstable/persistence/RateLimiter.ts
@@ -14,7 +14,7 @@ import * as Config from "../../Config.ts"
 import * as Context from "../../Context.ts"
 import * as Duration from "../../Duration.ts"
 import * as Effect from "../../Effect.ts"
-import { flow, identity } from "../../Function.ts"
+import { dual, flow, identity } from "../../Function.ts"
 import * as Layer from "../../Layer.ts"
 import * as Schema from "../../Schema.ts"
 import * as Redis from "./Redis.ts"
@@ -285,7 +285,7 @@ export const makeWithRateLimiter: Effect.Effect<
 )
 
 /**
- * Accesses a function that sleeps when the rate limit is exceeded.
+ * Sleeps when the rate limit is exceeded.
  *
  * **Example** (Sleeping until rate limit permits)
  *
@@ -294,52 +294,62 @@ export const makeWithRateLimiter: Effect.Effect<
  * import { RateLimiter } from "effect/unstable/persistence"
  *
  * const program = Effect.gen(function*() {
- *   // Access the `sleep` function from the RateLimiter module
- *   const sleep = yield* RateLimiter.makeSleep
- *
- *   // Use the `sleep` function with specific rate limiting parameters.
- *   // This will only sleep if the rate limit has been exceeded.
- *   const result = yield* sleep({
- *     key: "some-key",
+ *   const limiter = yield* RateLimiter.RateLimiter
+ *   const dataFirst = yield* RateLimiter.sleep(limiter, {
+ *     key: "data-first",
  *     limit: 10,
  *     window: "5 seconds",
  *     algorithm: "fixed-window"
  *   })
- *   return result.remaining
+ *   const dataLast = yield* RateLimiter.sleep({
+ *     key: "data-last",
+ *     limit: 10,
+ *     window: "5 seconds",
+ *     algorithm: "fixed-window"
+ *   })(limiter)
+ *   return [dataFirst.remaining, dataLast.remaining]
  * }).pipe(
  *   Effect.provide(RateLimiter.layer.pipe(Layer.provide(RateLimiter.layerStoreMemory)))
  * )
  *
- * await Effect.runPromise(program) // => 9
+ * await Effect.runPromise(program) // => [9, 9]
  * ```
  *
  * @category accessors
  * @since 4.0.0
  */
-export const makeSleep: Effect.Effect<
-  ((options: {
+export const sleep: {
+  (options: {
     readonly algorithm?: "fixed-window" | "token-bucket" | undefined
     readonly window: Duration.Input
     readonly limit: number
     readonly key: string
     readonly tokens?: number | undefined
-  }) => Effect.Effect<ConsumeResult, RateLimiterError>),
-  never,
-  RateLimiter
-> = RateLimiter.use((limiter) =>
-  Effect.succeed((options) =>
-    Effect.flatMap(
-      limiter.consume({
-        ...options,
-        onExceeded: "delay"
-      }),
-      (result) => {
-        if (Duration.isZero(result.delay)) return Effect.succeed(result)
-        return Effect.as(Effect.sleep(result.delay), result)
-      }
-    )
-  )
-)
+  }): (self: RateLimiter) => Effect.Effect<ConsumeResult, RateLimiterError>
+  (self: RateLimiter, options: {
+    readonly algorithm?: "fixed-window" | "token-bucket" | undefined
+    readonly window: Duration.Input
+    readonly limit: number
+    readonly key: string
+    readonly tokens?: number | undefined
+  }): Effect.Effect<ConsumeResult, RateLimiterError>
+} = dual(2, (self: RateLimiter, options: {
+  readonly algorithm?: "fixed-window" | "token-bucket" | undefined
+  readonly window: Duration.Input
+  readonly limit: number
+  readonly key: string
+  readonly tokens?: number | undefined
+}): Effect.Effect<ConsumeResult, RateLimiterError> =>
+  Effect.flatMap(
+    self.consume({
+      ...options,
+      onExceeded: "delay"
+    }),
+    (result) => {
+      if (Duration.isZero(result.delay)) return Effect.succeed(result)
+      return Effect.as(Effect.sleep(result.delay), result)
+    }
+  ))
 
 /**
  * Runtime type identifier for `RateLimiterError`.

--- a/packages/effect/src/unstable/persistence/RateLimiter.ts
+++ b/packages/effect/src/unstable/persistence/RateLimiter.ts
@@ -14,7 +14,7 @@ import * as Config from "../../Config.ts"
 import * as Context from "../../Context.ts"
 import * as Duration from "../../Duration.ts"
 import * as Effect from "../../Effect.ts"
-import { dual, flow, identity } from "../../Function.ts"
+import { flow, identity } from "../../Function.ts"
 import * as Layer from "../../Layer.ts"
 import * as Schema from "../../Schema.ts"
 import * as Redis from "./Redis.ts"
@@ -295,19 +295,20 @@ export const makeWithRateLimiter: Effect.Effect<
  *
  * const program = Effect.gen(function*() {
  *   const limiter = yield* RateLimiter.RateLimiter
- *   const dataFirst = yield* RateLimiter.sleep(limiter, {
- *     key: "data-first",
+ *   const partiallyApplied = RateLimiter.sleep(limiter)
+ *   const partial = yield* partiallyApplied({
+ *     key: "partial",
  *     limit: 10,
  *     window: "5 seconds",
  *     algorithm: "fixed-window"
  *   })
- *   const dataLast = yield* RateLimiter.sleep({
- *     key: "data-last",
+ *   const direct = yield* RateLimiter.sleep(limiter, {
+ *     key: "direct",
  *     limit: 10,
  *     window: "5 seconds",
  *     algorithm: "fixed-window"
- *   })(limiter)
- *   return [dataFirst.remaining, dataLast.remaining]
+ *   })
+ *   return [partial.remaining, direct.remaining]
  * }).pipe(
  *   Effect.provide(RateLimiter.layer.pipe(Layer.provide(RateLimiter.layerStoreMemory)))
  * )
@@ -318,29 +319,40 @@ export const makeWithRateLimiter: Effect.Effect<
  * @category accessors
  * @since 4.0.0
  */
-export const sleep: {
-  (options: {
-    readonly algorithm?: "fixed-window" | "token-bucket" | undefined
-    readonly window: Duration.Input
-    readonly limit: number
-    readonly key: string
-    readonly tokens?: number | undefined
-  }): (self: RateLimiter) => Effect.Effect<ConsumeResult, RateLimiterError>
-  (self: RateLimiter, options: {
-    readonly algorithm?: "fixed-window" | "token-bucket" | undefined
-    readonly window: Duration.Input
-    readonly limit: number
-    readonly key: string
-    readonly tokens?: number | undefined
-  }): Effect.Effect<ConsumeResult, RateLimiterError>
-} = dual(2, (self: RateLimiter, options: {
+export function sleep(self: RateLimiter): (options: {
   readonly algorithm?: "fixed-window" | "token-bucket" | undefined
   readonly window: Duration.Input
   readonly limit: number
   readonly key: string
   readonly tokens?: number | undefined
-}): Effect.Effect<ConsumeResult, RateLimiterError> =>
-  Effect.flatMap(
+}) => Effect.Effect<ConsumeResult, RateLimiterError>
+export function sleep(self: RateLimiter, options: {
+  readonly algorithm?: "fixed-window" | "token-bucket" | undefined
+  readonly window: Duration.Input
+  readonly limit: number
+  readonly key: string
+  readonly tokens?: number | undefined
+}): Effect.Effect<ConsumeResult, RateLimiterError>
+export function sleep(self: RateLimiter, options?: {
+  readonly algorithm?: "fixed-window" | "token-bucket" | undefined
+  readonly window: Duration.Input
+  readonly limit: number
+  readonly key: string
+  readonly tokens?: number | undefined
+}):
+  | Effect.Effect<ConsumeResult, RateLimiterError>
+  | ((options: {
+    readonly algorithm?: "fixed-window" | "token-bucket" | undefined
+    readonly window: Duration.Input
+    readonly limit: number
+    readonly key: string
+    readonly tokens?: number | undefined
+  }) => Effect.Effect<ConsumeResult, RateLimiterError>)
+{
+  if (options === undefined) {
+    return (options) => sleep(self, options)
+  }
+  return Effect.flatMap(
     self.consume({
       ...options,
       onExceeded: "delay"
@@ -349,7 +361,8 @@ export const sleep: {
       if (Duration.isZero(result.delay)) return Effect.succeed(result)
       return Effect.as(Effect.sleep(result.delay), result)
     }
-  ))
+  )
+}
 
 /**
  * Runtime type identifier for `RateLimiterError`.

--- a/packages/effect/test/unstable/persistence/RateLimiter.test.ts
+++ b/packages/effect/test/unstable/persistence/RateLimiter.test.ts
@@ -4,6 +4,28 @@ import { TestClock } from "effect/testing"
 import { RateLimiter } from "effect/unstable/persistence"
 
 describe(`RateLimiter`, () => {
+  it.effect("supports data-first and data-last sleep", () =>
+    Effect.gen(function*() {
+      const limiter = yield* RateLimiter.make
+      const dataFirst = yield* RateLimiter.sleep(limiter, {
+        algorithm: "fixed-window",
+        window: "1 minute",
+        limit: 5,
+        key: "data-first"
+      })
+      const dataLast = yield* RateLimiter.sleep({
+        algorithm: "fixed-window",
+        window: "1 minute",
+        limit: 5,
+        key: "data-last"
+      })(limiter)
+
+      assert.strictEqual(dataFirst.remaining, 4)
+      assert.strictEqual(dataLast.remaining, 4)
+    }).pipe(
+      Effect.provide(RateLimiter.layerStoreMemory)
+    ))
+
   describe("fixed-window", () => {
     it.effect("returns accumulated delays after the fixed window is exceeded", () =>
       Effect.gen(function*() {

--- a/packages/effect/test/unstable/persistence/RateLimiter.test.ts
+++ b/packages/effect/test/unstable/persistence/RateLimiter.test.ts
@@ -4,24 +4,33 @@ import { TestClock } from "effect/testing"
 import { RateLimiter } from "effect/unstable/persistence"
 
 describe(`RateLimiter`, () => {
-  it.effect("supports data-first and data-last sleep", () =>
+  it.effect("supports partially applied sleep", () =>
     Effect.gen(function*() {
       const limiter = yield* RateLimiter.make
-      const dataFirst = yield* RateLimiter.sleep(limiter, {
+      const sleep = RateLimiter.sleep(limiter)
+      const result = yield* sleep({
         algorithm: "fixed-window",
         window: "1 minute",
         limit: 5,
-        key: "data-first"
+        key: "partial"
       })
-      const dataLast = yield* RateLimiter.sleep({
+
+      assert.strictEqual(result.remaining, 4)
+    }).pipe(
+      Effect.provide(RateLimiter.layerStoreMemory)
+    ))
+
+  it.effect("supports uncurried sleep", () =>
+    Effect.gen(function*() {
+      const limiter = yield* RateLimiter.make
+      const result = yield* RateLimiter.sleep(limiter, {
         algorithm: "fixed-window",
         window: "1 minute",
         limit: 5,
-        key: "data-last"
-      })(limiter)
+        key: "direct"
+      })
 
-      assert.strictEqual(dataFirst.remaining, 4)
-      assert.strictEqual(dataLast.remaining, 4)
+      assert.strictEqual(result.remaining, 4)
     }).pipe(
       Effect.provide(RateLimiter.layerStoreMemory)
     ))


### PR DESCRIPTION
## Summary

- rename `RateLimiter.makeSleep` to `RateLimiter.sleep`
- support self-first partial application with `sleep(self)(options)` and direct calls with `sleep(self, options)`
- update the runnable JSDoc example, add separate coverage for both signatures, and add a patch changeset

## Validation

- `pnpm lint-fix`
- `pnpm --filter effect test --run test/unstable/persistence/RateLimiter.test.ts`
- `pnpm check`
- `pnpm doctest --run packages/effect/src/unstable/persistence/RateLimiter.ts`
- package-local `pnpm docgen` reached example typechecking but is currently blocked by an unrelated existing `HttpStaticServer` example missing the required `compression` field

Closes EFF-466