### PR TITLE
Prevent Effect.updateService and Effect.updateServiceScoped supertype widening

### DIFF
--- a/.changeset/funny-ears-beam.md
+++ b/.changeset/funny-ears-beam.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Prevent Effect.updateService and Effect.updateServiceScoped supertype widening

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6099,12 +6099,12 @@ export const updateContext: {
 export const updateService: {
   <I, A>(
     service: Context.Key<I, A>,
-    f: (value: A) => A
+    f: (value: A) => NoInfer<A>
   ): <XA, E, R>(self: Effect<XA, E, R>) => Effect<XA, E, R | I>
   <XA, E, R, I, A>(
     self: Effect<XA, E, R>,
     service: Context.Key<I, A>,
-    f: (value: A) => A
+    f: (value: A) => NoInfer<A>
   ): Effect<XA, E, R | I>
 } = internal.updateService
 
@@ -6169,7 +6169,7 @@ export const updateService: {
  */
 export const updateServiceScoped: <I, A>(
   service: Context.Key<I, A>,
-  f: (value: A) => A,
+  f: (value: A) => NoInfer<A>,
   options?: {
     readonly reset?: ((original: A, updated: A, current: A) => A) | undefined
   } | undefined

--- a/packages/effect/typetest/Effect.tst.ts
+++ b/packages/effect/typetest/Effect.tst.ts
@@ -1126,3 +1126,32 @@ describe("Effect.provideServiceEffect", () => {
     )
   })
 })
+
+describe("Effect.updateService", () => {
+  it("data-first disallows supertype return", () => {
+    Effect.updateService(
+      Effect.void,
+      ProvideServiceEffectServiceLiteral,
+      // @ts-expect-error Type 'string' is not assignable to type '"LITERAL"'
+      () => "test"
+    )
+  })
+
+  it("data-last disallows supertype return", () => {
+    Effect.updateService(
+      ProvideServiceEffectServiceLiteral,
+      // @ts-expect-error Type 'string' is not assignable to type '"LITERAL"'
+      () => "test"
+    )
+  })
+})
+
+describe("Effect.updateServiceScoped", () => {
+  it("disallows supertype return", () => {
+    Effect.updateServiceScoped(
+      ProvideServiceEffectServiceLiteral,
+      // @ts-expect-error Type 'string' is not assignable to type '"LITERAL"'
+      () => "test"
+    )
+  })
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Analogous to #7025 - some additional methods related to services that I've spotted.

Added tests failing without these changes:

<img width="990" height="548" alt="2026-08-05_15-38" src="https://github.com/user-attachments/assets/630c49b1-33ee-4deb-87c9-9fe039d7f61d" />

## Related

#7025 