### PR TITLE
Fix replacing a trie key mutates the original and increments size

### DIFF
--- a/.changeset/fix-trie-key-replacement.md
+++ b/.changeset/fix-trie-key-replacement.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Trie.insert` to replace existing values without mutating the original trie or increasing its size.

--- a/packages/effect/src/internal/trie.ts
+++ b/packages/effect/src/internal/trie.ts
@@ -172,7 +172,7 @@ export const insert = dual<
     key: key[0],
     count: 0
   }
-  const count = n.count + 1
+  let count = n.count + 1
   let cIndex = 0
 
   while (cIndex < key.length) {
@@ -194,7 +194,17 @@ export const insert = dual<
       }
     } else {
       if (cIndex === key.length - 1) {
-        n.value = { value }
+        if (n.value !== undefined) {
+          count -= 1
+        }
+        nStack[nStack.length - 1] = {
+          key: n.key,
+          count,
+          value: { value },
+          left: n.left,
+          mid: n.mid,
+          right: n.right
+        }
       } else if (n.mid === undefined) {
         dStack.push(0)
         n = { key: key[cIndex + 1], count }

--- a/packages/effect/test/Trie.test.ts
+++ b/packages/effect/test/Trie.test.ts
@@ -80,6 +80,17 @@ describe("Trie", () => {
     deepStrictEqual(Array.from(trie4), [["call", 0], ["me", 1], ["mid", 3], ["mind", 2]])
   })
 
+  it("insert replaces a key without mutating or growing the original", () => {
+    const before = Trie.make(["a", 1])
+    const after = Trie.insert(before, "a", 2)
+
+    deepStrictEqual(
+      [Array.from(before), Trie.size(before), Array.from(after), Trie.size(after)],
+      [[["a", 1]], 1, [["a", 2]], 1],
+      "replacement must be immutable and preserve size"
+    )
+  })
+
   it("fromIterable preserves an empty iterable", () => {
     const iterable: Array<[string, number]> = []
     const trie = Trie.fromIterable(iterable)


### PR DESCRIPTION
## Summary

Inserting an existing key mutates the value visible through the original `Trie` and increments the replacement trie's size. Persistent snapshots are corrupted and cardinality reports a new entry where only a value replacement occurred.

> [!NOTE]
> This PR includes both the focused regression test and the implementation fix.

## Replacing a trie key mutates the original and increments size

**Module:** `effect/Trie`  
**Audit ID:** `effect-7bd661243f3c2d73`  
**Severity / confidence:** high / high

### What happens

Inserting an existing key mutates the value visible through the original `Trie` and increments the replacement trie's size. Persistent snapshots are corrupted and cardinality reports a new entry where only a value replacement occurred.

### Why it happens

The insertion traversal assigns `n.value = { value }` directly on the existing terminal node before path copying and computes `count` as `root.count + 1` unconditionally. The rebuilt path therefore shares the already-mutated leaf with the input and carries an inflated count for replacements.

### Expected behavior

`Trie.insert(self, key, value)` must return a persistent trie, leave `self` unchanged, and preserve `Trie.size` when `key` was already present.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/Trie.ts:130-414`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Trie.ts#L130-L414)

<details>
<summary>View problematic code at <code>packages/effect/src/Trie.ts:130-179</code></summary>

````ts
/**
 * Inserts a new entry in the `Trie`.
 *
 * **Example** (Inserting entries)
 *
 * ```ts import.meta.vitest
 * import { Trie } from "effect"
 *
 * const trie1 = Trie.empty<number>().pipe(
 *   Trie.insert("call", 0)
 * )
 * const trie2 = trie1.pipe(Trie.insert("me", 1))
 * const trie3 = trie2.pipe(Trie.insert("mind", 2))
 * const trie4 = trie3.pipe(Trie.insert("mid", 3))
 *
 * Array.from(trie1) // => [["call", 0]]
 * Array.from(trie2) // => [["call", 0], ["me", 1]]
 * Array.from(trie3) // => [["call", 0], ["me", 1], ["mind", 2]]
 * Array.from(trie4) // => [["call", 0], ["me", 1], ["mid", 3], ["mind", 2]]
 * ```
 *
 * @category mutations
 * @since 2.0.0
 */
export const insert: {
  <V>(key: string, value: V): (self: Trie<V>) => Trie<V>
  <V>(self: Trie<V>, key: string, value: V): Trie<V>
} = TR.insert

/**
 * Returns an `IterableIterator` of the keys within the `Trie`.
 *
 * **Details**
 *
 * The keys are returned in alphabetical order, regardless of insertion order.
 *
 * **Example** (Reading keys in alphabetical order)
 *
 * ```ts import.meta.vitest
 * import { Trie } from "effect"
 *
 * const trie = Trie.empty<number>().pipe(
 *   Trie.insert("cab", 0),
 *   Trie.insert("abc", 1),
 *   Trie.insert("bca", 2)
 * )
 *
 * Array.from(Trie.keys(trie)) // => ["abc", "bca", "cab"]
 * ```
 *
````

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Trie.ts#L130-L414)

_Excerpt truncated. [Open the complete packages/effect/src/Trie.ts:130-414 range.](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Trie.ts#L130-L414)_

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/Trie.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: Replacing a trie key mutates the original and increments size.

## Implementation

`Trie.insert` now copies the terminal node instead of mutating it in place, and only increments the trie count when the key did not already have a value.

Validated locally with:

```sh
pnpm test --run packages/effect/test/Trie.test.ts
pnpm lint-fix
pnpm check
```


## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-7bd661243f3c2d73`
- Initial patch: focused reproduction tests; implementation fix included in `a195aa044`

Closes EFF-468