### PR TITLE
Fix conflict scanning indexes the wrong history array

### DIFF
--- a/.changeset/tidy-cats-smile.md
+++ b/.changeset/tidy-cats-smile.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix unencrypted event log conflict scanning to inspect the newer history suffix.

--- a/packages/effect/src/unstable/eventlog/EventLogServerUnencrypted.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogServerUnencrypted.ts
@@ -411,7 +411,7 @@ const toConflicts = (
     const newHistory = history.slice(i)
     let conflicts: Array<Entry> = []
     for (let j = 0; j < newHistory.length; j++) {
-      const scannedEntry = history[j]!
+      const scannedEntry = newHistory[j]!
       if (scannedEntry.event === originEntry.event && scannedEntry.primaryKey === originEntry.primaryKey) {
         conflicts.push(scannedEntry)
       }

--- a/packages/effect/test/unstable/eventlog/EventLogServerUnencrypted.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventLogServerUnencrypted.test.ts
@@ -41,79 +41,77 @@ const authenticate = Effect.fnUntraced(function*(options: {
 })
 
 it.effect("indexes conflicts from the sliced history", () =>
-  Effect.scoped(
-    Effect.gen(function*() {
-      const encode = Schema.encodeUnknownEffect(event.payloadMsgPack)
-      const makeEntry = Effect.fnUntraced(function*(msecs: number, key: string, value: number) {
-        return new EventJournal.Entry({
-          id: EventJournal.makeEntryIdUnsafe({ msecs }),
-          event: "ReproEvent",
-          primaryKey: key,
-          payload: yield* encode({ key, value })
-        }, { disableChecks: true })
-      })
-      const originA = yield* makeEntry(1_000, "other-origin", 10)
-      const oldSameKey = yield* makeEntry(2_000, "key", 20)
-      const originB = yield* makeEntry(3_000, "key", 30)
-      const newerOtherKey = yield* makeEntry(4_000, "other", 40)
-      const newerSameKey = yield* makeEntry(5_000, "key", 50)
+  Effect.gen(function*() {
+    const encode = Schema.encodeUnknownEffect(event.payloadMsgPack)
+    const makeEntry = Effect.fnUntraced(function*(msecs: number, key: string, value: number) {
+      return new EventJournal.Entry({
+        id: EventJournal.makeEntryIdUnsafe({ msecs }),
+        event: "ReproEvent",
+        primaryKey: key,
+        payload: yield* encode({ key, value })
+      }, { disableChecks: true })
+    })
+    const originA = yield* makeEntry(1_000, "other-origin", 10)
+    const oldSameKey = yield* makeEntry(2_000, "key", 20)
+    const originB = yield* makeEntry(3_000, "key", 30)
+    const newerOtherKey = yield* makeEntry(4_000, "other", 40)
+    const newerSameKey = yield* makeEntry(5_000, "key", 50)
 
-      const storage = yield* EventLogServerUnencrypted.makeStorageMemory
-      yield* storage.write(storeId, [oldSameKey, newerOtherKey, newerSameKey])
-      const registry = yield* EventLog.Registry.pipe(Effect.provide(EventLog.layerRegistry))
-      const seenOriginA = yield* Ref.make<ReadonlyArray<EventJournal.Entry> | undefined>(undefined)
-      const seenOriginB = yield* Ref.make<ReadonlyArray<EventJournal.Entry> | undefined>(undefined)
-      registry.registerHandlerUnsafe({
-        event: event.tag,
-        handler: {
-          event,
-          context: Context.empty() as Context.Context<any>,
-          handler: ({ payload, conflicts }) => {
-            const value = (payload as { value: number }).value
-            return value === 10
-              ? Ref.set(seenOriginA, conflicts.map((conflict) => conflict.entry))
-              : value === 30
-              ? Ref.set(seenOriginB, conflicts.map((conflict) => conflict.entry))
-              : Effect.void
-          }
+    const storage = yield* EventLogServerUnencrypted.makeStorageMemory
+    yield* storage.write(storeId, [oldSameKey, newerOtherKey, newerSameKey])
+    const registry = yield* EventLog.Registry.pipe(Effect.provide(EventLog.layerRegistry))
+    const seenOriginA = yield* Ref.make<ReadonlyArray<EventJournal.Entry> | undefined>(undefined)
+    const seenOriginB = yield* Ref.make<ReadonlyArray<EventJournal.Entry> | undefined>(undefined)
+    registry.registerHandlerUnsafe({
+      event: event.tag,
+      handler: {
+        event,
+        context: Context.empty() as Context.Context<any>,
+        handler: ({ payload, conflicts }) => {
+          const value = (payload as { value: number }).value
+          return value === 10
+            ? Ref.set(seenOriginA, conflicts.map((conflict) => conflict.entry))
+            : value === 30
+            ? Ref.set(seenOriginB, conflicts.map((conflict) => conflict.entry))
+            : Effect.void
         }
-      })
+      }
+    })
 
-      const client = yield* RpcTest.makeClient(EventLogMessage.EventLogRemoteRpcs).pipe(
-        Effect.provide(EventLogServerUnencrypted.layerRpcHandlers.pipe(
-          Layer.provide(Layer.succeed(EventLogServerUnencrypted.Storage, storage)),
-          Layer.provide(Layer.succeed(EventLog.Registry, registry)),
-          Layer.provide(Layer.succeed(EventLogServerUnencrypted.StoreMapping, {
-            resolve: ({ storeId }) => Effect.succeed(storeId),
-            hasStore: () => Effect.succeed(true)
-          })),
-          Layer.provide(Layer.succeed(EventLogServerUnencrypted.EventLogServerAuthorization, {
-            authorizeWrite: () => Effect.void,
-            authorizeRead: () => Effect.void,
-            authorizeIdentity: () => Effect.void
-          }))
-        ))
-      )
-      const identity = yield* EventLog.makeIdentity
-      const hello = yield* client["EventLog.Hello"]()
-      yield* client["EventLog.Authenticate"](
-        yield* authenticate({
-          identity,
-          challenge: hello.challenge,
-          remoteId: hello.remoteId
-        })
-      )
-      const data = yield* new EventLogMessage.WriteEntriesUnencrypted({
-        publicKey: identity.publicKey,
-        storeId,
-        entries: [originA, originB]
-      }).encoded
-      yield* client["EventLog.WriteSingle"]({ data })
-      const originAConflicts = yield* Ref.get(seenOriginA)
-      assert.isDefined(originAConflicts)
-      assert.deepStrictEqual(originAConflicts.map((entry) => entry.idString), [])
-      const originBConflicts = yield* Ref.get(seenOriginB)
-      assert.isDefined(originBConflicts)
-      assert.deepStrictEqual(originBConflicts.map((entry) => entry.idString), [newerSameKey.idString])
-    }).pipe(Effect.provide(EventLogEncryption.layerSubtle))
-  ))
+    const client = yield* RpcTest.makeClient(EventLogMessage.EventLogRemoteRpcs).pipe(
+      Effect.provide(EventLogServerUnencrypted.layerRpcHandlers.pipe(
+        Layer.provide(Layer.succeed(EventLogServerUnencrypted.Storage, storage)),
+        Layer.provide(Layer.succeed(EventLog.Registry, registry)),
+        Layer.provide(Layer.succeed(EventLogServerUnencrypted.StoreMapping, {
+          resolve: ({ storeId }) => Effect.succeed(storeId),
+          hasStore: () => Effect.succeed(true)
+        })),
+        Layer.provide(Layer.succeed(EventLogServerUnencrypted.EventLogServerAuthorization, {
+          authorizeWrite: () => Effect.void,
+          authorizeRead: () => Effect.void,
+          authorizeIdentity: () => Effect.void
+        }))
+      ))
+    )
+    const identity = yield* EventLog.makeIdentity
+    const hello = yield* client["EventLog.Hello"]()
+    yield* client["EventLog.Authenticate"](
+      yield* authenticate({
+        identity,
+        challenge: hello.challenge,
+        remoteId: hello.remoteId
+      })
+    )
+    const data = yield* new EventLogMessage.WriteEntriesUnencrypted({
+      publicKey: identity.publicKey,
+      storeId,
+      entries: [originA, originB]
+    }).encoded
+    yield* client["EventLog.WriteSingle"]({ data })
+    const originAConflicts = yield* Ref.get(seenOriginA)
+    assert.isDefined(originAConflicts)
+    assert.deepStrictEqual(originAConflicts.map((entry) => entry.idString), [])
+    const originBConflicts = yield* Ref.get(seenOriginB)
+    assert.isDefined(originBConflicts)
+    assert.deepStrictEqual(originBConflicts.map((entry) => entry.idString), [newerSameKey.idString])
+  }).pipe(Effect.provide(EventLogEncryption.layerSubtle)))

--- a/packages/effect/test/unstable/eventlog/EventLogServerUnencrypted.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventLogServerUnencrypted.test.ts
@@ -62,12 +62,15 @@ it.effect("indexes conflicts from the sliced history", () =>
     const registry = yield* EventLog.Registry.pipe(Effect.provide(EventLog.layerRegistry))
     const seen = yield* Ref.make<ReadonlyArray<EventJournal.Entry> | undefined>(undefined)
     registry.registerHandlerUnsafe({
-      event,
-      context: Context.empty(),
-      handler: ({ payload, conflicts }) =>
-        (payload as { value: number }).value === 30
-          ? Ref.set(seen, conflicts.map((conflict) => conflict.entry))
-          : Effect.void
+      event: event.tag,
+      handler: {
+        event,
+        context: Context.empty() as Context.Context<any>,
+        handler: ({ payload, conflicts }) =>
+          (payload as { value: number }).value === 30
+            ? Ref.set(seen, conflicts.map((conflict) => conflict.entry))
+            : Effect.void
+      }
     })
 
     const client = yield* RpcTest.makeClient(EventLogMessage.EventLogRemoteRpcs).pipe(

--- a/packages/effect/test/unstable/eventlog/EventLogServerUnencrypted.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventLogServerUnencrypted.test.ts
@@ -41,67 +41,71 @@ const authenticate = Effect.fnUntraced(function*(options: {
 })
 
 it.effect("indexes conflicts from the sliced history", () =>
-  Effect.scoped(Effect.gen(function*() {
-    const encode = Schema.encodeUnknownEffect(event.payloadMsgPack)
-    const makeEntry = Effect.fnUntraced(function*(msecs: number, key: string, value: number) {
-      return new EventJournal.Entry({
-        id: EventJournal.makeEntryIdUnsafe({ msecs }),
-        event: "ReproEvent",
-        primaryKey: key,
-        payload: yield* encode({ key, value })
-      }, { disableChecks: true })
-    })
-    const originA = yield* makeEntry(1_000, "other-origin", 10)
-    const oldSameKey = yield* makeEntry(2_000, "key", 20)
-    const originB = yield* makeEntry(3_000, "key", 30)
-    const newerOtherKey = yield* makeEntry(4_000, "other", 40)
-    const newerSameKey = yield* makeEntry(5_000, "key", 50)
+  Effect.scoped(
+    Effect.gen(function*() {
+      const encode = Schema.encodeUnknownEffect(event.payloadMsgPack)
+      const makeEntry = Effect.fnUntraced(function*(msecs: number, key: string, value: number) {
+        return new EventJournal.Entry({
+          id: EventJournal.makeEntryIdUnsafe({ msecs }),
+          event: "ReproEvent",
+          primaryKey: key,
+          payload: yield* encode({ key, value })
+        }, { disableChecks: true })
+      })
+      const originA = yield* makeEntry(1_000, "other-origin", 10)
+      const oldSameKey = yield* makeEntry(2_000, "key", 20)
+      const originB = yield* makeEntry(3_000, "key", 30)
+      const newerOtherKey = yield* makeEntry(4_000, "other", 40)
+      const newerSameKey = yield* makeEntry(5_000, "key", 50)
 
-    const storage = yield* EventLogServerUnencrypted.makeStorageMemory
-    yield* storage.write(storeId, [oldSameKey, newerOtherKey, newerSameKey])
-    const registry = yield* EventLog.Registry.pipe(Effect.provide(EventLog.layerRegistry))
-    const seen = yield* Ref.make<ReadonlyArray<EventJournal.Entry> | undefined>(undefined)
-    registry.registerHandlerUnsafe({
-      event: event.tag,
-      handler: {
-        event,
-        context: Context.empty() as Context.Context<any>,
-        handler: ({ payload, conflicts }) =>
-          (payload as { value: number }).value === 30
-            ? Ref.set(seen, conflicts.map((conflict) => conflict.entry))
-            : Effect.void
-      }
-    })
+      const storage = yield* EventLogServerUnencrypted.makeStorageMemory
+      yield* storage.write(storeId, [oldSameKey, newerOtherKey, newerSameKey])
+      const registry = yield* EventLog.Registry.pipe(Effect.provide(EventLog.layerRegistry))
+      const seen = yield* Ref.make<ReadonlyArray<EventJournal.Entry> | undefined>(undefined)
+      registry.registerHandlerUnsafe({
+        event: event.tag,
+        handler: {
+          event,
+          context: Context.empty() as Context.Context<any>,
+          handler: ({ payload, conflicts }) =>
+            (payload as { value: number }).value === 30
+              ? Ref.set(seen, conflicts.map((conflict) => conflict.entry))
+              : Effect.void
+        }
+      })
 
-    const client = yield* RpcTest.makeClient(EventLogMessage.EventLogRemoteRpcs).pipe(
-      Effect.provide(EventLogServerUnencrypted.layerRpcHandlers.pipe(
-        Layer.provide(Layer.succeed(EventLogServerUnencrypted.Storage, storage)),
-        Layer.provide(Layer.succeed(EventLog.Registry, registry)),
-        Layer.provide(Layer.succeed(EventLogServerUnencrypted.StoreMapping, {
-          resolve: ({ storeId }) => Effect.succeed(storeId),
-          hasStore: () => Effect.succeed(true)
-        })),
-        Layer.provide(Layer.succeed(EventLogServerUnencrypted.EventLogServerAuthorization, {
-          authorizeWrite: () => Effect.void,
-          authorizeRead: () => Effect.void,
-          authorizeIdentity: () => Effect.void
-        }))
-      ))
-    )
-    const identity = yield* EventLog.makeIdentity
-    const hello = yield* client["EventLog.Hello"]()
-    yield* client["EventLog.Authenticate"](yield* authenticate({
-      identity,
-      challenge: hello.challenge,
-      remoteId: hello.remoteId
-    }))
-    const data = yield* new EventLogMessage.WriteEntriesUnencrypted({
-      publicKey: identity.publicKey,
-      storeId,
-      entries: [originA, originB]
-    }).encoded
-    yield* client["EventLog.WriteSingle"]({ data })
-    const conflicts = yield* Ref.get(seen)
-    assert.isDefined(conflicts)
-    assert.deepStrictEqual(conflicts.map((entry) => entry.idString), [newerSameKey.idString])
-  }).pipe(Effect.provide(EventLogEncryption.layerSubtle))))
+      const client = yield* RpcTest.makeClient(EventLogMessage.EventLogRemoteRpcs).pipe(
+        Effect.provide(EventLogServerUnencrypted.layerRpcHandlers.pipe(
+          Layer.provide(Layer.succeed(EventLogServerUnencrypted.Storage, storage)),
+          Layer.provide(Layer.succeed(EventLog.Registry, registry)),
+          Layer.provide(Layer.succeed(EventLogServerUnencrypted.StoreMapping, {
+            resolve: ({ storeId }) => Effect.succeed(storeId),
+            hasStore: () => Effect.succeed(true)
+          })),
+          Layer.provide(Layer.succeed(EventLogServerUnencrypted.EventLogServerAuthorization, {
+            authorizeWrite: () => Effect.void,
+            authorizeRead: () => Effect.void,
+            authorizeIdentity: () => Effect.void
+          }))
+        ))
+      )
+      const identity = yield* EventLog.makeIdentity
+      const hello = yield* client["EventLog.Hello"]()
+      yield* client["EventLog.Authenticate"](
+        yield* authenticate({
+          identity,
+          challenge: hello.challenge,
+          remoteId: hello.remoteId
+        })
+      )
+      const data = yield* new EventLogMessage.WriteEntriesUnencrypted({
+        publicKey: identity.publicKey,
+        storeId,
+        entries: [originA, originB]
+      }).encoded
+      yield* client["EventLog.WriteSingle"]({ data })
+      const conflicts = yield* Ref.get(seen)
+      assert.isDefined(conflicts)
+      assert.deepStrictEqual(conflicts.map((entry) => entry.idString), [newerSameKey.idString])
+    }).pipe(Effect.provide(EventLogEncryption.layerSubtle))
+  ))

--- a/packages/effect/test/unstable/eventlog/EventLogServerUnencrypted.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventLogServerUnencrypted.test.ts
@@ -61,16 +61,21 @@ it.effect("indexes conflicts from the sliced history", () =>
       const storage = yield* EventLogServerUnencrypted.makeStorageMemory
       yield* storage.write(storeId, [oldSameKey, newerOtherKey, newerSameKey])
       const registry = yield* EventLog.Registry.pipe(Effect.provide(EventLog.layerRegistry))
-      const seen = yield* Ref.make<ReadonlyArray<EventJournal.Entry> | undefined>(undefined)
+      const seenOriginA = yield* Ref.make<ReadonlyArray<EventJournal.Entry> | undefined>(undefined)
+      const seenOriginB = yield* Ref.make<ReadonlyArray<EventJournal.Entry> | undefined>(undefined)
       registry.registerHandlerUnsafe({
         event: event.tag,
         handler: {
           event,
           context: Context.empty() as Context.Context<any>,
-          handler: ({ payload, conflicts }) =>
-            (payload as { value: number }).value === 30
-              ? Ref.set(seen, conflicts.map((conflict) => conflict.entry))
+          handler: ({ payload, conflicts }) => {
+            const value = (payload as { value: number }).value
+            return value === 10
+              ? Ref.set(seenOriginA, conflicts.map((conflict) => conflict.entry))
+              : value === 30
+              ? Ref.set(seenOriginB, conflicts.map((conflict) => conflict.entry))
               : Effect.void
+          }
         }
       })
 
@@ -104,8 +109,11 @@ it.effect("indexes conflicts from the sliced history", () =>
         entries: [originA, originB]
       }).encoded
       yield* client["EventLog.WriteSingle"]({ data })
-      const conflicts = yield* Ref.get(seen)
-      assert.isDefined(conflicts)
-      assert.deepStrictEqual(conflicts.map((entry) => entry.idString), [newerSameKey.idString])
+      const originAConflicts = yield* Ref.get(seenOriginA)
+      assert.isDefined(originAConflicts)
+      assert.deepStrictEqual(originAConflicts.map((entry) => entry.idString), [])
+      const originBConflicts = yield* Ref.get(seenOriginB)
+      assert.isDefined(originBConflicts)
+      assert.deepStrictEqual(originBConflicts.map((entry) => entry.idString), [newerSameKey.idString])
     }).pipe(Effect.provide(EventLogEncryption.layerSubtle))
   ))

--- a/packages/effect/test/unstable/eventlog/UnencryptedEventLogConflictIndex.test.ts
+++ b/packages/effect/test/unstable/eventlog/UnencryptedEventLogConflictIndex.test.ts
@@ -1,0 +1,104 @@
+import { assert, it } from "@effect/vitest"
+import { Context, Effect, Layer, Redacted, Ref, Schema } from "effect"
+import * as EventGroup from "effect/unstable/eventlog/EventGroup"
+import * as EventJournal from "effect/unstable/eventlog/EventJournal"
+import * as EventLog from "effect/unstable/eventlog/EventLog"
+import * as EventLogEncryption from "effect/unstable/eventlog/EventLogEncryption"
+import * as EventLogMessage from "effect/unstable/eventlog/EventLogMessage"
+import * as EventLogServerUnencrypted from "effect/unstable/eventlog/EventLogServerUnencrypted"
+import * as EventLogSessionAuth from "effect/unstable/eventlog/EventLogSessionAuth"
+import { makeGetIdentityRootSecretMaterial } from "effect/unstable/eventlog/internal/identityRootSecretDerivation"
+import * as RpcTest from "effect/unstable/rpc/RpcTest"
+
+const ReproGroup = EventGroup.empty.add({
+  tag: "ReproEvent",
+  primaryKey: (payload) => payload.key,
+  payload: Schema.Struct({ key: Schema.String, value: Schema.Number })
+})
+const event = ReproGroup.events.ReproEvent
+const storeId = EventLogMessage.StoreId.make("repro-store")
+const getIdentityRootSecretMaterial = makeGetIdentityRootSecretMaterial(globalThis.crypto)
+
+const authenticate = Effect.fnUntraced(function*(options: {
+  readonly identity: EventLog.Identity["Service"]
+  readonly challenge: Uint8Array
+  readonly remoteId: EventJournal.RemoteId
+}) {
+  const material = yield* getIdentityRootSecretMaterial(options.identity)
+  const signature = yield* EventLogSessionAuth.signSessionAuthPayload({
+    remoteId: options.remoteId,
+    challenge: options.challenge,
+    publicKey: options.identity.publicKey,
+    signingPublicKey: material.signingPublicKey,
+    signingPrivateKey: Redacted.value(material.signingPrivateKey)
+  })
+  return new EventLogMessage.Authenticate({
+    publicKey: options.identity.publicKey,
+    signingPublicKey: material.signingPublicKey,
+    signature,
+    algorithm: "Ed25519"
+  })
+})
+
+it.effect("indexes conflicts from the sliced history", () =>
+  Effect.scoped(Effect.gen(function*() {
+    const encode = Schema.encodeUnknownEffect(event.payloadMsgPack)
+    const makeEntry = Effect.fnUntraced(function*(msecs: number, key: string, value: number) {
+      return new EventJournal.Entry({
+        id: EventJournal.makeEntryIdUnsafe({ msecs }),
+        event: "ReproEvent",
+        primaryKey: key,
+        payload: yield* encode({ key, value })
+      }, { disableChecks: true })
+    })
+    const originA = yield* makeEntry(1_000, "other-origin", 10)
+    const oldSameKey = yield* makeEntry(2_000, "key", 20)
+    const originB = yield* makeEntry(3_000, "key", 30)
+    const newerOtherKey = yield* makeEntry(4_000, "other", 40)
+    const newerSameKey = yield* makeEntry(5_000, "key", 50)
+
+    const storage = yield* EventLogServerUnencrypted.makeStorageMemory
+    yield* storage.write(storeId, [oldSameKey, newerOtherKey, newerSameKey])
+    const registry = yield* EventLog.Registry.pipe(Effect.provide(EventLog.layerRegistry))
+    const seen = yield* Ref.make<ReadonlyArray<EventJournal.Entry> | undefined>(undefined)
+    registry.registerHandlerUnsafe({
+      event,
+      context: Context.empty(),
+      handler: ({ payload, conflicts }) =>
+        (payload as { value: number }).value === 30
+          ? Ref.set(seen, conflicts.map((conflict) => conflict.entry))
+          : Effect.void
+    })
+
+    const client = yield* RpcTest.makeClient(EventLogMessage.EventLogRemoteRpcs).pipe(
+      Effect.provide(EventLogServerUnencrypted.layerRpcHandlers.pipe(
+        Layer.provide(Layer.succeed(EventLogServerUnencrypted.Storage, storage)),
+        Layer.provide(Layer.succeed(EventLog.Registry, registry)),
+        Layer.provide(Layer.succeed(EventLogServerUnencrypted.StoreMapping, {
+          resolve: ({ storeId }) => Effect.succeed(storeId),
+          hasStore: () => Effect.succeed(true)
+        })),
+        Layer.provide(Layer.succeed(EventLogServerUnencrypted.EventLogServerAuthorization, {
+          authorizeWrite: () => Effect.void,
+          authorizeRead: () => Effect.void,
+          authorizeIdentity: () => Effect.void
+        }))
+      ))
+    )
+    const identity = yield* EventLog.makeIdentity
+    const hello = yield* client["EventLog.Hello"]()
+    yield* client["EventLog.Authenticate"](yield* authenticate({
+      identity,
+      challenge: hello.challenge,
+      remoteId: hello.remoteId
+    }))
+    const data = yield* new EventLogMessage.WriteEntriesUnencrypted({
+      publicKey: identity.publicKey,
+      storeId,
+      entries: [originA, originB]
+    }).encoded
+    yield* client["EventLog.WriteSingle"]({ data })
+    const conflicts = yield* Ref.get(seen)
+    assert.isDefined(conflicts)
+    assert.deepStrictEqual(conflicts.map((entry) => entry.idString), [newerSameKey.idString])
+  }).pipe(Effect.provide(EventLogEncryption.layerSubtle))))


### PR DESCRIPTION
## Summary

The unencrypted server identifies the correct newer suffix of stored entries but scans an equally sized prefix when building conflicts. It can report entries older than the incoming event while omitting newer same-key entries from the end of storage.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Conflict scanning indexes the wrong history array

**Module:** `effect/unstable/eventlog/EventLogServerUnencrypted`  
**Audit ID:** `effect-64c8be87a9a44e92`  
**Severity / confidence:** high / high

### What happens

The unencrypted server identifies the correct newer suffix of stored entries but scans an equally sized prefix when building conflicts. It can report entries older than the incoming event while omitting newer same-key entries from the end of storage.

### Why it happens

At insertion index `i`, `toConflicts` assigns `newHistory = history.slice(i)`. The loop is bounded by `newHistory.length` but reads `history[j]` instead of `newHistory[j]`, so whenever `i > 0` it examines prefix indices `0..newHistory.length - 1` rather than suffix indices `i..history.length - 1`.

### Expected behavior

For each incoming entry, conflicts must contain all and only non-duplicate stored entries at or after its chronological insertion point whose event tag and primary key match the incoming entry.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/unstable/eventlog/EventLogServerUnencrypted.ts:396-423`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/eventlog/EventLogServerUnencrypted.ts#L396-L423)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/eventlog/EventLogServerUnencrypted.ts:396-423</code></summary>

```ts
const toConflicts = (
  history: ReadonlyArray<Entry>,
  originEntry: Entry
): [duplicate: boolean, conflicts: Array<Entry>, newHistory: Array<Entry>] => {
  let duplicate = false

  for (let i = 0; i < history.length; i++) {
    const entry = history[i]
    if (entry.createdAtMillis < originEntry.createdAtMillis) {
      continue
    } else if (entry.idString === originEntry.idString) {
      duplicate = true
      continue
    }

    const newHistory = history.slice(i)
    let conflicts: Array<Entry> = []
    for (let j = 0; j < newHistory.length; j++) {
      const scannedEntry = history[j]!
      if (scannedEntry.event === originEntry.event && scannedEntry.primaryKey === originEntry.primaryKey) {
        conflicts.push(scannedEntry)
      }
    }
    return [duplicate, conflicts, newHistory]
  }

  return [duplicate, [], []]
}
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/eventlog/EventLogServerUnencrypted.ts#L396-L423)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/eventlog/UnencryptedEventLogConflictIndex.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: Conflict scanning indexes the wrong history array.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/eventlog/UnencryptedEventLogConflictIndex.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-64c8be87a9a44e92`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-469