### PR TITLE
Fix cluster single-runner shutdown deadlock

### DIFF
--- a/.changeset/fix-cluster-shutdown-deadlock.md
+++ b/.changeset/fix-cluster-shutdown-deadlock.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix a `@effect/cluster` shutdown deadlock on single-runner topologies (e.g. single-node deployments and `TestRunner`), where `Sharding.sendOutgoing` retried `EntityNotAssignedToRunner` forever during teardown.

--- a/packages/effect/src/unstable/cluster/Sharding.ts
+++ b/packages/effect/src/unstable/cluster/Sharding.ts
@@ -969,13 +969,13 @@ const make = Effect.gen(function*() {
     void,
     MailboxFull | AlreadyProcessingMessage | PersistenceError
   > {
+    const isPersisted = Context.get(
+      message._tag === "OutgoingRequest" ? message.annotations : message.rpc.annotations,
+      Persisted
+    )
     return Effect.catchFilter(
       Effect.suspend(() => {
         const address = message.envelope.address
-        const isPersisted = Context.get(
-          message._tag === "OutgoingRequest" ? message.annotations : message.rpc.annotations,
-          Persisted
-        )
         if (isPersisted && !storageEnabled) {
           return Effect.die("Sharding.sendOutgoing: Persisted messages require MessageStorage")
         }
@@ -1003,7 +1003,17 @@ const make = Effect.gen(function*() {
           const cannotRecover = MutableRef.get(isShutdown) ||
             (targetManager !== undefined && targetManager.status !== "alive")
           if (cannotRecover) {
-            return Effect.logDebug("Abandoning outgoing message during shutdown", message.envelope.address)
+            if (!isPersisted) {
+              return Effect.logDebug("Abandoning outgoing message during shutdown", message.envelope.address)
+            }
+            const persist = message._tag === "OutgoingRequest"
+              ? storage.saveRequest(message)
+              : storage.saveEnvelope(message)
+            return Effect.catchTag(persist, "MalformedMessage", Effect.die).pipe(
+              Effect.andThen(
+                Effect.logWarning("Persisting outgoing message abandoned during shutdown", message.envelope.address)
+              )
+            )
           }
         }
         if (retries === 0) {

--- a/packages/effect/src/unstable/cluster/Sharding.ts
+++ b/packages/effect/src/unstable/cluster/Sharding.ts
@@ -997,6 +997,15 @@ const make = Effect.gen(function*() {
           ? Result.succeed(error)
           : Result.fail(error),
       (error) => {
+        // Abandon the message during teardown: retrying would loop forever once the runner is shutting down
+        if (error._tag === "EntityNotAssignedToRunner") {
+          const targetManager = entityManagers.get(message.envelope.address.entityType)
+          const cannotRecover = MutableRef.get(isShutdown) ||
+            (targetManager !== undefined && targetManager.status !== "alive")
+          if (cannotRecover) {
+            return Effect.logDebug("Abandoning outgoing message during shutdown", message.envelope.address)
+          }
+        }
         if (retries === 0) {
           return Effect.die(error)
         }

--- a/packages/effect/test/cluster/Sharding.test.ts
+++ b/packages/effect/test/cluster/Sharding.test.ts
@@ -7,6 +7,7 @@ import {
   Effect,
   Exit,
   Fiber,
+  Latch,
   Layer,
   Logger,
   MutableRef,
@@ -17,6 +18,8 @@ import {
 import { TestClock } from "effect/testing"
 import {
   ClusterMetrics,
+  ClusterSchema,
+  Entity,
   EntityId,
   MachineId,
   MessageStorage,
@@ -30,6 +33,7 @@ import {
   ShardingConfig,
   Snowflake
 } from "effect/unstable/cluster"
+import { Rpc } from "effect/unstable/rpc"
 import {
   CallerId,
   ContextBleedEntity,
@@ -129,6 +133,62 @@ describe.concurrent("Sharding", () => {
       // server interrupt is not sent
       expect(driver.replyIds.size).toEqual(0)
     }))
+
+  for (const preemptiveShutdown of [true, false]) {
+    it.live(`shutdown completes when a finalizing entity sends an outgoing message (preemptiveShutdown=${preemptiveShutdown})`, () =>
+      Effect.gen(function*() {
+        const Receiver = Entity.make("ShutdownDeadlockReceiver", [
+          Rpc.make("Ping").annotate(ClusterSchema.Persisted, false)
+        ])
+        const ReceiverLayer = Receiver.toLayer({ Ping: () => Effect.void })
+
+        const Sender = Entity.make("ShutdownDeadlockSender", [
+          Rpc.make("Arm").annotate(ClusterSchema.Persisted, false)
+        ])
+        const SenderLayer = Sender.toLayer(Effect.gen(function*() {
+          const receiver = yield* Receiver.client
+          // finalizer sends an outgoing message during entity teardown
+          yield* Effect.addFinalizer(() => receiver("peer").Ping(void 0, { discard: true }).pipe(Effect.ignore))
+          return { Arm: () => Effect.void }
+        }))
+
+        const env = Layer.mergeAll(SenderLayer, ReceiverLayer).pipe(
+          Layer.provideMerge(Sharding.layer),
+          Layer.provide(RunnerStorage.layerMemory),
+          Layer.provide(RunnerHealth.layerNoop),
+          Layer.provide(Runners.layerNoop),
+          Layer.provide(MessageStorage.layerMemory),
+          Layer.provide(ShardingConfig.layer({
+            runnerAddress: Option.some(RunnerAddress.make("localhost", 1234)),
+            shardsPerGroup: 8,
+            entityTerminationTimeout: 0,
+            entityMessagePollInterval: 50,
+            refreshAssignmentsInterval: 20,
+            sendRetryInterval: 10,
+            preemptiveShutdown
+          }))
+        )
+
+        const armed = Latch.makeUnsafe()
+        const runFiber = yield* Effect.gen(function*() {
+          const sharding = yield* Sharding.Sharding
+          const shardId = sharding.getShardId(EntityId.make("1"), "default")
+          for (let i = 0; i < 500 && !sharding.hasShardId(shardId); i++) {
+            yield* Effect.sleep(5)
+          }
+          yield* (yield* Sender.client)("1").Arm()
+          yield* armed.open
+          return yield* Effect.never
+        }).pipe(Effect.provide(env), Effect.scoped, Effect.forkChild)
+
+        yield* armed.await
+
+        // Interrupting the fiber closes the Sharding scope, running the entity
+        // finalizer (and its outgoing send) as part of teardown
+        const completed = yield* Fiber.interrupt(runFiber).pipe(Effect.timeoutOption("10 seconds"))
+        assert(Option.isSome(completed), "Sharding scope-close hung during shutdown (deadlock)")
+      }))
+  }
 
   it.effect("interrupts are sent for volatile messages on shutdown", () =>
     Effect.gen(function*() {

--- a/packages/effect/test/cluster/Sharding.test.ts
+++ b/packages/effect/test/cluster/Sharding.test.ts
@@ -134,60 +134,78 @@ describe.concurrent("Sharding", () => {
       expect(driver.replyIds.size).toEqual(0)
     }))
 
-  for (const preemptiveShutdown of [true, false]) {
-    it.live(`shutdown completes when a finalizing entity sends an outgoing message (preemptiveShutdown=${preemptiveShutdown})`, () =>
-      Effect.gen(function*() {
-        const Receiver = Entity.make("ShutdownDeadlockReceiver", [
-          Rpc.make("Ping").annotate(ClusterSchema.Persisted, false)
-        ])
-        const ReceiverLayer = Receiver.toLayer({ Ping: () => Effect.void })
+  for (const persisted of [false, true] as const) {
+    for (const preemptiveShutdown of [true, false]) {
+      it.live(
+        `shutdown completes when a finalizing entity sends an outgoing message (persisted=${persisted}, preemptiveShutdown=${preemptiveShutdown})`,
+        () =>
+          Effect.gen(function*() {
+            const Receiver = Entity.make("ShutdownDeadlockReceiver", [
+              Rpc.make("Ping").annotate(ClusterSchema.Persisted, persisted)
+            ])
+            const ReceiverLayer = Receiver.toLayer({ Ping: () => Effect.void })
 
-        const Sender = Entity.make("ShutdownDeadlockSender", [
-          Rpc.make("Arm").annotate(ClusterSchema.Persisted, false)
-        ])
-        const SenderLayer = Sender.toLayer(Effect.gen(function*() {
-          const receiver = yield* Receiver.client
-          // finalizer sends an outgoing message during entity teardown
-          yield* Effect.addFinalizer(() => receiver("peer").Ping(void 0, { discard: true }).pipe(Effect.ignore))
-          return { Arm: () => Effect.void }
-        }))
+            const Sender = Entity.make("ShutdownDeadlockSender", [
+              Rpc.make("Arm").annotate(ClusterSchema.Persisted, false)
+            ])
+            const SenderLayer = Sender.toLayer(Effect.gen(function*() {
+              const receiver = yield* Receiver.client
+              // finalizer sends an outgoing message during entity teardown
+              yield* Effect.addFinalizer(() => receiver("peer").Ping(void 0, { discard: true }).pipe(Effect.ignore))
+              return { Arm: () => Effect.void }
+            }))
 
-        const env = Layer.mergeAll(SenderLayer, ReceiverLayer).pipe(
-          Layer.provideMerge(Sharding.layer),
-          Layer.provide(RunnerStorage.layerMemory),
-          Layer.provide(RunnerHealth.layerNoop),
-          Layer.provide(Runners.layerNoop),
-          Layer.provide(MessageStorage.layerMemory),
-          Layer.provide(ShardingConfig.layer({
-            runnerAddress: Option.some(RunnerAddress.make("localhost", 1234)),
-            shardsPerGroup: 8,
-            entityTerminationTimeout: 0,
-            entityMessagePollInterval: 50,
-            refreshAssignmentsInterval: 20,
-            sendRetryInterval: 10,
-            preemptiveShutdown
-          }))
-        )
+            const env = Layer.mergeAll(SenderLayer, ReceiverLayer).pipe(
+              Layer.provideMerge(Sharding.layer),
+              Layer.provide(RunnerStorage.layerMemory),
+              Layer.provide(RunnerHealth.layerNoop),
+              Layer.provide(Runners.layerNoop),
+              Layer.provideMerge(MessageStorage.layerMemory),
+              Layer.provide(ShardingConfig.layer({
+                runnerAddress: Option.some(RunnerAddress.make("localhost", 1234)),
+                shardsPerGroup: 8,
+                entityTerminationTimeout: 0,
+                entityMessagePollInterval: 50,
+                refreshAssignmentsInterval: 20,
+                sendRetryInterval: 10,
+                preemptiveShutdown
+              }))
+            )
 
-        const armed = Latch.makeUnsafe()
-        const runFiber = yield* Effect.gen(function*() {
-          const sharding = yield* Sharding.Sharding
-          const shardId = sharding.getShardId(EntityId.make("1"), "default")
-          for (let i = 0; i < 500 && !sharding.hasShardId(shardId); i++) {
-            yield* Effect.sleep(5)
-          }
-          yield* (yield* Sender.client)("1").Arm()
-          yield* armed.open
-          return yield* Effect.never
-        }).pipe(Effect.provide(env), Effect.scoped, Effect.forkChild)
+            const shardAcquired = Latch.makeUnsafe()
+            const armed = Latch.makeUnsafe()
+            let driver!: MessageStorage.MemoryDriver["Service"]
+            const runFiber = yield* Effect.gen(function*() {
+              driver = yield* MessageStorage.MemoryDriver
+              const sharding = yield* Sharding.Sharding
+              const shardId = sharding.getShardId(EntityId.make("1"), "default")
+              while (!sharding.hasShardId(shardId)) {
+                yield* Effect.sleep(5)
+              }
+              yield* shardAcquired.open
+              yield* (yield* Sender.client)("1").Arm()
+              yield* armed.open
+              return yield* Effect.never
+            }).pipe(Effect.provide(env), Effect.scoped, Effect.forkDetach)
 
-        yield* armed.await
+            const acquired = yield* shardAcquired.await.pipe(Effect.timeoutOption("8 seconds"))
+            if (Option.isNone(acquired)) {
+              runFiber.interruptUnsafe()
+              yield* Fiber.await(runFiber)
+            }
+            assert(Option.isSome(acquired), "Timed out waiting for sender shard acquisition")
+            yield* armed.await
 
-        // Interrupting the fiber closes the Sharding scope, running the entity
-        // finalizer (and its outgoing send) as part of teardown
-        const completed = yield* Fiber.interrupt(runFiber).pipe(Effect.timeoutOption("10 seconds"))
-        assert(Option.isSome(completed), "Sharding scope-close hung during shutdown (deadlock)")
-      }))
+            // Interrupting the fiber closes the Sharding scope, running the entity
+            // finalizer (and its outgoing send) as part of teardown
+            runFiber.interruptUnsafe()
+            const completed = yield* Fiber.await(runFiber).pipe(Effect.timeoutOption("4 seconds"))
+            assert(Option.isSome(completed), "Sharding scope-close hung during shutdown (deadlock)")
+            assert.strictEqual(driver.journal.length, persisted ? 1 : 0)
+          }),
+        20_000
+      )
+    }
   }
 
   it.effect("interrupts are sent for volatile messages on shutdown", () =>


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Hit this running a single-node cluster locally: shutdown would just hang forever, spamming `WARN No healthy runners available`.

If an entity fires an outgoing message while it's finalizing (e.g. a reactor pushing an update to another entity) and the target shard is no longer routable, `sendOutgoing` retries `EntityNotAssignedToRunner` forever. On a single runner the shard never gets reassigned, so the finalizer never completes and the Sharding scope never closes. Multi-runner masks it since the shard just moves to a peer.

Fix: bail out of the retry when it provably can't succeed — the runner is shutting down, or the target's local entity manager is already closing/closed. `RunnerUnavailable` still retries so rolling deploys are unaffected, and persisted messages stay durable in storage.

Added a regression test that arms an entity finalizer to send during teardown and asserts the scope actually closes (both preemptive and non-preemptive shutdown).