### PR TITLE
Fix memory journal skips the first conflict candidate

### DIFF
--- a/.changeset/fix-memory-journal-conflicts.md
+++ b/.changeset/fix-memory-journal-conflicts.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix memory journal conflict detection skipping the first newer entry.

--- a/packages/effect/src/unstable/eventlog/EventJournal.ts
+++ b/packages/effect/src/unstable/eventlog/EventJournal.ts
@@ -438,7 +438,7 @@ export const makeMemory: Effect.Effect<EventJournal["Service"]> = Effect.gen(fun
           if (entry !== undefined && entry.createdAtMillis > entryMillis) {
             continue
           }
-          for (let j = i + 2; j < journal.length; j++) {
+          for (let j = i + 1; j < journal.length; j++) {
             const scannedEntry = journal[j]!
             if (scannedEntry.event === originEntry.event && scannedEntry.primaryKey === originEntry.primaryKey) {
               conflicts.push(scannedEntry)

--- a/packages/effect/test/unstable/eventlog/EventJournal.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventJournal.test.ts
@@ -2,6 +2,14 @@ import { assert, describe, it } from "@effect/vitest"
 import { Effect } from "effect"
 import * as EventJournal from "effect/unstable/eventlog/EventJournal"
 
+const entry = (msecs: number) =>
+  new EventJournal.Entry({
+    id: EventJournal.makeEntryIdUnsafe({ msecs }),
+    event: "Repro",
+    primaryKey: "key",
+    payload: new Uint8Array()
+  }, { disableChecks: true })
+
 describe("EventJournal", () => {
   it.effect("relays an imported entry to another remote", () =>
     Effect.gen(function*() {
@@ -50,6 +58,24 @@ describe("EventJournal", () => {
         effect: () => Effect.void
       })
       assert.strictEqual(yield* journal.nextRemoteSequence(remoteId), 6)
+    }))
+
+  it.effect("reports the first newer conflicting entry", () =>
+    Effect.gen(function*() {
+      const journal = yield* EventJournal.makeMemory
+      const newer = entry(2_000)
+      yield* journal.writeFromRemote({
+        remoteId: EventJournal.makeRemoteIdUnsafe(),
+        entries: [new EventJournal.RemoteEntry({ remoteSequence: 0, entry: newer })],
+        effect: () => Effect.void
+      })
+      let conflicts: ReadonlyArray<EventJournal.Entry> = []
+      yield* journal.writeFromRemote({
+        remoteId: EventJournal.makeRemoteIdUnsafe(),
+        entries: [new EventJournal.RemoteEntry({ remoteSequence: 0, entry: entry(1_000) })],
+        effect: (options) => Effect.sync(() => conflicts = options.conflicts)
+      })
+      assert.deepStrictEqual(conflicts.map((item) => item.idString), [newer.idString])
     }))
 
   it.effect("records entries in memory and publishes local changes", () =>


### PR DESCRIPTION
## Summary

Fix memory journal conflict detection so an imported entry receives every newer journal entry with the same event tag and primary key, including the first candidate after the insertion boundary.

The regression test is included in the module's main test file at `packages/effect/test/unstable/eventlog/EventJournal.test.ts`, and the fix changes the forward scan to begin at `i + 1`.

Closes EFF-517

## Validation

- `pnpm test --run packages/effect/test/unstable/eventlog/EventJournal.test.ts`
- `pnpm test --run packages/effect/test/unstable/eventlog`
- `pnpm lint`
- `pnpm check`

## Audit provenance

- Audit ID: `effect-00b143e067108348`
- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
