### PR TITLE
Fix memory journal returns the last remote sequence instead of the next

### DIFF
--- a/.changeset/fix-memory-journal-next-sequence.md
+++ b/.changeset/fix-memory-journal-next-sequence.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Return the first unused remote sequence from the in-memory event journal.

--- a/packages/effect/src/unstable/eventlog/EventJournal.ts
+++ b/packages/effect/src/unstable/eventlog/EventJournal.ts
@@ -86,7 +86,7 @@ export class EventJournal extends Context.Service<EventJournal, {
   ) => Effect.Effect<A, EventJournalError | E, R>
 
   /**
-   * Retrieve the last known sequence number for a remote source.
+   * Retrieve the first unused sequence number for a remote source.
    */
   readonly nextRemoteSequence: (remoteId: RemoteId) => Effect.Effect<number, EventJournalError>
 
@@ -417,8 +417,8 @@ export const makeMemory: Effect.Effect<EventJournal["Service"]> = Effect.gen(fun
       for (const remoteEntry of options.entries) {
         if (byId.has(remoteEntry.entry.idString)) {
           duplicateEntries.push(remoteEntry.entry)
-          if (remoteEntry.remoteSequence > remote.sequence) {
-            remote.sequence = remoteEntry.remoteSequence
+          if (remoteEntry.remoteSequence >= remote.sequence) {
+            remote.sequence = remoteEntry.remoteSequence + 1
           }
           continue
         }
@@ -456,8 +456,8 @@ export const makeMemory: Effect.Effect<EventJournal["Service"]> = Effect.gen(fun
             target.missing.push(remoteEntry.entry)
           }
         })
-        if (remoteEntry.remoteSequence > remote.sequence) {
-          remote.sequence = remoteEntry.remoteSequence
+        if (remoteEntry.remoteSequence >= remote.sequence) {
+          remote.sequence = remoteEntry.remoteSequence + 1
         }
       }
       journal.sort((a, b) => a.createdAtMillis - b.createdAtMillis)

--- a/packages/effect/test/unstable/eventlog/EventJournal.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventJournal.test.ts
@@ -26,6 +26,24 @@ describe("EventJournal", () => {
       assert.deepStrictEqual(sourceMissing, [])
     }))
 
+  it.effect("returns the next unused remote sequence", () =>
+    Effect.gen(function*() {
+      const journal = yield* EventJournal.makeMemory
+      const remoteId = EventJournal.makeRemoteIdUnsafe()
+      const entry = new EventJournal.Entry({
+        id: EventJournal.makeEntryIdUnsafe(),
+        event: "Repro",
+        primaryKey: "key",
+        payload: new Uint8Array()
+      }, { disableChecks: true })
+      yield* journal.writeFromRemote({
+        remoteId,
+        entries: [new EventJournal.RemoteEntry({ remoteSequence: 0, entry })],
+        effect: () => Effect.void
+      })
+      assert.strictEqual(yield* journal.nextRemoteSequence(remoteId), 1)
+    }))
+
   it.effect("records entries in memory and publishes local changes", () =>
     Effect.gen(function*() {
       const journal = yield* EventJournal.EventJournal

--- a/packages/effect/test/unstable/eventlog/EventJournal.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventJournal.test.ts
@@ -36,12 +36,20 @@ describe("EventJournal", () => {
         primaryKey: "key",
         payload: new Uint8Array()
       }, { disableChecks: true })
+
+      assert.strictEqual(yield* journal.nextRemoteSequence(remoteId), 0)
       yield* journal.writeFromRemote({
         remoteId,
         entries: [new EventJournal.RemoteEntry({ remoteSequence: 0, entry })],
         effect: () => Effect.void
       })
       assert.strictEqual(yield* journal.nextRemoteSequence(remoteId), 1)
+      yield* journal.writeFromRemote({
+        remoteId,
+        entries: [new EventJournal.RemoteEntry({ remoteSequence: 5, entry })],
+        effect: () => Effect.void
+      })
+      assert.strictEqual(yield* journal.nextRemoteSequence(remoteId), 6)
     }))
 
   it.effect("records entries in memory and publishes local changes", () =>


### PR DESCRIPTION
## Summary

After importing remote sequence `n`, the memory journal returns `n` as the next synchronization start instead of `n + 1`. Sequence zero is especially indistinguishable from the initial empty state.

> [!IMPORTANT]
> This PR includes focused regression coverage and the memory-journal implementation fix.

## Memory journal returns the last remote sequence instead of the next

**Module:** `effect/unstable/eventlog/EventJournal`  
**Audit ID:** `effect-2f6a0458baf5d1fe`  
**Severity / confidence:** high / high

### What happens

After importing remote sequence `n`, the memory journal returns `n` as the next synchronization start instead of `n + 1`. Sequence zero is especially indistinguishable from the initial empty state.

### Why it happens

Each memory remote stores a `sequence` initialized to zero; imports update it to the greatest observed `remoteSequence`, and `nextRemoteSequence` returns that field unchanged. The SQL implementation computes `MAX(sequence) + 1` and the IndexedDB implementation reads the greatest sequence and adds one, confirming that this state is a cursor for the next request rather than the last value itself.

### Expected behavior

`nextRemoteSequence(remoteId)` must return the first unused sequence for that remote: zero when no remote entries are recorded, otherwise one greater than the maximum recorded sequence.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/unstable/eventlog/EventJournal.ts:417-481`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/eventlog/EventJournal.ts#L417-L481)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/eventlog/EventJournal.ts:417-466</code></summary>

```ts
      for (const remoteEntry of options.entries) {
        if (byId.has(remoteEntry.entry.idString)) {
          duplicateEntries.push(remoteEntry.entry)
          if (remoteEntry.remoteSequence > remote.sequence) {
            remote.sequence = remoteEntry.remoteSequence
          }
          continue
        }
        uncommittedRemotes.push(remoteEntry)
        uncommitted.push(remoteEntry.entry)
      }

      const compacted = options.compact
        ? yield* options.compact(uncommittedRemotes)
        : uncommitted

      for (const originEntry of compacted) {
        const entryMillis = entryIdMillis(originEntry.id)
        const conflicts: Array<Entry> = []
        for (let i = journal.length - 1; i >= -1; i--) {
          const entry = journal[i]
          if (entry !== undefined && entry.createdAtMillis > entryMillis) {
            continue
          }
          for (let j = i + 2; j < journal.length; j++) {
            const scannedEntry = journal[j]!
            if (scannedEntry.event === originEntry.event && scannedEntry.primaryKey === originEntry.primaryKey) {
              conflicts.push(scannedEntry)
            }
          }
          yield* options.effect({ entry: originEntry, conflicts })
          break
        }
      }
      for (const remoteEntry of uncommittedRemotes) {
        journal.push(remoteEntry.entry)
        byId.set(remoteEntry.entry.idString, remoteEntry.entry)
        if (remoteEntry.remoteSequence > remote.sequence) {
          remote.sequence = remoteEntry.remoteSequence
        }
      }
      journal.sort((a, b) => a.createdAtMillis - b.createdAtMillis)
      return {
        duplicateEntries
      }
    }),
    withRemoteUncommited: (remoteId, f) =>
      Effect.acquireUseRelease(
        Effect.sync(() => ensureRemote(remoteId).missing.slice()),
        f,
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/eventlog/EventJournal.ts#L417-L481)

_Excerpt truncated. [Open the complete packages/effect/src/unstable/eventlog/EventJournal.ts:417-481 range.](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/eventlog/EventJournal.ts#L417-L481)_

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/eventlog/EventJournal.test.ts
```

**Validation:** The focused contract assertion fails against 17f0b91a and passes with this fix.

## Implementation

The memory journal now stores the first unused remote sequence after both new and duplicate remote imports. The regression test covers the empty state, sequence zero, and a non-zero duplicate sequence.

Validated with:

```sh
pnpm test --run packages/effect/test/unstable/eventlog/EventJournal.test.ts
```

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-2f6a0458baf5d1fe`
- Initial patch: focused reproduction tests
- Final patch: implementation fix, expanded coverage, and changeset

Closes EFF-516