### PR TITLE
Fix memory runner storage has no shard ownership model

### DIFF
--- a/.changeset/fair-shards-own.md
+++ b/.changeset/fair-shards-own.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Track in-memory cluster shard ownership per runner.

--- a/packages/effect/src/unstable/cluster/RunnerStorage.ts
+++ b/packages/effect/src/unstable/cluster/RunnerStorage.ts
@@ -12,6 +12,7 @@
 import { isArrayNonEmpty, type NonEmptyArray } from "../../Array.ts"
 import * as Context from "../../Context.ts"
 import * as Effect from "../../Effect.ts"
+import * as Equal from "../../Equal.ts"
 import * as Layer from "../../Layer.ts"
 import * as MutableHashMap from "../../MutableHashMap.ts"
 import type { PersistenceError } from "./ClusterError.ts"
@@ -203,8 +204,15 @@ export const makeEncoded = (encoded: Encoded) =>
  */
 export const makeMemory = Effect.gen(function*() {
   const runners = MutableHashMap.empty<RunnerAddress, Runner>()
-  let acquired: Array<ShardId.ShardId> = []
+  const acquired = MutableHashMap.empty<ShardId.ShardId, RunnerAddress>()
   let id = 0
+  const releaseAllShards = (address: RunnerAddress) => {
+    for (const [shardId, owner] of acquired) {
+      if (Equal.equals(owner, address)) {
+        MutableHashMap.remove(acquired, shardId)
+      }
+    }
+  }
 
   return RunnerStorage.of({
     getRunners: Effect.sync(() => Array.from(MutableHashMap.values(runners), (runner) => [runner, true])),
@@ -216,15 +224,38 @@ export const makeMemory = Effect.gen(function*() {
     unregister: (address) =>
       Effect.sync(() => {
         MutableHashMap.remove(runners, address)
+        releaseAllShards(address)
       }),
     setRunnerHealth: () => Effect.void,
-    acquire: (_address, shardIds) => {
-      acquired = Array.from(shardIds)
-      return Effect.succeed(acquired)
-    },
-    refresh: () => Effect.sync(() => acquired),
-    release: () => Effect.void,
-    releaseAll: () => Effect.void
+    acquire: (address, shardIds) =>
+      Effect.sync(() => {
+        const result: Array<ShardId.ShardId> = []
+        for (const shardId of shardIds) {
+          const owner = MutableHashMap.get(acquired, shardId).valueOrUndefined
+          if (owner !== undefined && !Equal.equals(owner, address)) continue
+          MutableHashMap.set(acquired, shardId, address)
+          result.push(shardId)
+        }
+        return result
+      }),
+    refresh: (address) =>
+      Effect.sync(() => {
+        const result: Array<ShardId.ShardId> = []
+        for (const [shardId, owner] of acquired) {
+          if (Equal.equals(owner, address)) {
+            result.push(shardId)
+          }
+        }
+        return result
+      }),
+    release: (address, shardId) =>
+      Effect.sync(() => {
+        const owner = MutableHashMap.get(acquired, shardId).valueOrUndefined
+        if (owner !== undefined && Equal.equals(owner, address)) {
+          MutableHashMap.remove(acquired, shardId)
+        }
+      }),
+    releaseAll: (address) => Effect.sync(() => releaseAllShards(address))
   })
 })
 

--- a/packages/effect/test/cluster/RunnerStorage.test.ts
+++ b/packages/effect/test/cluster/RunnerStorage.test.ts
@@ -10,7 +10,22 @@ describe("RunnerStorage", () => {
       const second = RunnerAddress.make("localhost", 41002)
       const shard = ShardId.make("default", 1)
       assert.deepStrictEqual(yield* storage.acquire(first, [shard]), [shard])
+      assert.deepStrictEqual(yield* storage.acquire(first, [shard]), [shard])
       assert.deepStrictEqual(yield* storage.acquire(second, [shard]), [])
+      assert.deepStrictEqual(yield* storage.refresh(first, []), [shard])
+      assert.deepStrictEqual(yield* storage.refresh(second, []), [])
+
+      yield* storage.release(second, shard)
+      assert.deepStrictEqual(yield* storage.acquire(second, [shard]), [])
+
+      yield* storage.release(first, shard)
+      assert.deepStrictEqual(yield* storage.acquire(second, [shard]), [shard])
+
+      yield* storage.releaseAll(second)
+      assert.deepStrictEqual(yield* storage.acquire(first, [shard]), [shard])
+
+      yield* storage.unregister(first)
+      assert.deepStrictEqual(yield* storage.acquire(second, [shard]), [shard])
     }))
 
   it.effect("memory acquire accepts a one-shot iterable", () =>

--- a/packages/effect/test/cluster/RunnerStorage.test.ts
+++ b/packages/effect/test/cluster/RunnerStorage.test.ts
@@ -3,6 +3,16 @@ import { Effect } from "effect"
 import { RunnerAddress, RunnerStorage, ShardId } from "effect/unstable/cluster"
 
 describe("RunnerStorage", () => {
+  it.effect("does not grant an owned shard to a second runner", () =>
+    Effect.gen(function*() {
+      const storage = yield* RunnerStorage.makeMemory
+      const first = RunnerAddress.make("localhost", 41001)
+      const second = RunnerAddress.make("localhost", 41002)
+      const shard = ShardId.make("default", 1)
+      assert.deepStrictEqual(yield* storage.acquire(first, [shard]), [shard])
+      assert.deepStrictEqual(yield* storage.acquire(second, [shard]), [])
+    }))
+
   it.effect("memory acquire accepts a one-shot iterable", () =>
     Effect.gen(function*() {
       const storage = yield* RunnerStorage.makeMemory


### PR DESCRIPTION
## Summary

The memory runner store grants every requested shard to every caller. A second runner can acquire a shard already returned to the first runner, and refresh reports one global list unrelated to caller ownership.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Memory runner storage has no shard ownership model

**Module:** `effect/unstable/cluster/RunnerStorage`  
**Audit ID:** `effect-453e8d9d8ea37346`  
**Severity / confidence:** high / high

### What happens

The memory runner store grants every requested shard to every caller. A second runner can acquire a shard already returned to the first runner, and refresh reports one global list unrelated to caller ownership.

### Why it happens

The implementation has one global `acquired` array rather than a shard-to-address ownership map. Each `acquire` overwrites that array and returns all input shards without consulting the address; `refresh` returns the same array for any address, while `release` and `releaseAll` do nothing.

### Expected behavior

Shard locks must be exclusive per shard and attributed to a runner address: acquire returns only unowned or caller-owned shards, refresh returns only shards owned by that caller, and release operations remove the corresponding ownership.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/unstable/cluster/RunnerStorage.ts:204-228`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/cluster/RunnerStorage.ts#L204-L228)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/cluster/RunnerStorage.ts:204-228</code></summary>

```ts
export const makeMemory = Effect.gen(function*() {
  const runners = MutableHashMap.empty<RunnerAddress, Runner>()
  let acquired: Array<ShardId.ShardId> = []
  let id = 0

  return RunnerStorage.of({
    getRunners: Effect.sync(() => Array.from(MutableHashMap.values(runners), (runner) => [runner, true])),
    register: (runner) =>
      Effect.sync(() => {
        MutableHashMap.set(runners, runner.address, runner)
        return MachineId.make(id++)
      }),
    unregister: (address) =>
      Effect.sync(() => {
        MutableHashMap.remove(runners, address)
      }),
    setRunnerHealth: () => Effect.void,
    acquire: (_address, shardIds) => {
      acquired = Array.from(shardIds)
      return Effect.succeed(acquired)
    },
    refresh: () => Effect.sync(() => acquired),
    release: () => Effect.void,
    releaseAll: () => Effect.void
  })
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/cluster/RunnerStorage.ts#L204-L228)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/cluster/MemoryRunnerStorageShardOwnership.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: Memory runner storage has no shard ownership model.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/cluster/MemoryRunnerStorageShardOwnership.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-453e8d9d8ea37346`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-515