### PR TITLE
Fix scoped lock finalizers release under the wrong fiber owner

### DIFF
--- a/.changeset/cozy-geese-remain.md
+++ b/.changeset/cozy-geese-remain.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix scoped reentrant lock finalizers releasing under the wrong fiber owner.

--- a/packages/effect/src/TxReentrantLock.ts
+++ b/packages/effect/src/TxReentrantLock.ts
@@ -266,24 +266,24 @@ export const acquireWrite = (self: TxReentrantLock): Effect.Effect<number> =>
  * @category mutations
  * @since 2.0.0
  */
+const releaseReadFor = (self: TxReentrantLock, fiberId: number): Effect.Effect<number> =>
+  Effect.gen(function*() {
+    const state = yield* TxRef.get(self.stateRef)
+    const currentCount = Option.getOrElse(HashMap.get(state.readers, fiberId), () => 0)
+
+    if (currentCount <= 0) return 0
+
+    const newCount = currentCount - 1
+    const newReaders = newCount === 0
+      ? HashMap.remove(state.readers, fiberId)
+      : HashMap.set(state.readers, fiberId, newCount)
+
+    yield* TxRef.set(self.stateRef, { ...state, readers: newReaders })
+    return newCount
+  }).pipe(Effect.tx)
+
 export const releaseRead = (self: TxReentrantLock): Effect.Effect<number> =>
-  Effect.withFiber((fiber) =>
-    Effect.gen(function*() {
-      const state = yield* TxRef.get(self.stateRef)
-      const fiberId = fiber.id
-      const currentCount = Option.getOrElse(HashMap.get(state.readers, fiberId), () => 0)
-
-      if (currentCount <= 0) return 0
-
-      const newCount = currentCount - 1
-      const newReaders = newCount === 0
-        ? HashMap.remove(state.readers, fiberId)
-        : HashMap.set(state.readers, fiberId, newCount)
-
-      yield* TxRef.set(self.stateRef, { ...state, readers: newReaders })
-      return newCount
-    }).pipe(Effect.tx)
-  )
+  Effect.withFiber((fiber) => releaseReadFor(self, fiber.id))
 
 /**
  * Releases one write lock held by the current fiber.
@@ -313,23 +313,23 @@ export const releaseRead = (self: TxReentrantLock): Effect.Effect<number> =>
  * @category mutations
  * @since 2.0.0
  */
+const releaseWriteFor = (self: TxReentrantLock, fiberId: number): Effect.Effect<number> =>
+  Effect.gen(function*() {
+    const state = yield* TxRef.get(self.stateRef)
+
+    if (Option.isNone(state.writer) || state.writer.value[0] !== fiberId) return 0
+
+    const newCount = state.writer.value[1] - 1
+    const newWriter = newCount <= 0
+      ? Option.none<readonly [number, number]>()
+      : Option.some([fiberId, newCount] as const)
+
+    yield* TxRef.set(self.stateRef, { ...state, writer: newWriter })
+    return newCount
+  }).pipe(Effect.tx)
+
 export const releaseWrite = (self: TxReentrantLock): Effect.Effect<number> =>
-  Effect.withFiber((fiber) =>
-    Effect.gen(function*() {
-      const state = yield* TxRef.get(self.stateRef)
-      const fiberId = fiber.id
-
-      if (Option.isNone(state.writer) || state.writer.value[0] !== fiberId) return 0
-
-      const newCount = state.writer.value[1] - 1
-      const newWriter = newCount <= 0
-        ? Option.none<readonly [number, number]>()
-        : Option.some([fiberId, newCount] as const)
-
-      yield* TxRef.set(self.stateRef, { ...state, writer: newWriter })
-      return newCount
-    }).pipe(Effect.tx)
-  )
+  Effect.withFiber((fiber) => releaseWriteFor(self, fiber.id))
 
 /**
  * Acquires a read lock for the duration of the scope.
@@ -361,9 +361,11 @@ export const releaseWrite = (self: TxReentrantLock): Effect.Effect<number> =>
  * @since 2.0.0
  */
 export const readLock = (self: TxReentrantLock): Effect.Effect<number, never, Scope.Scope> =>
-  Effect.acquireRelease(
-    acquireRead(self),
-    () => releaseRead(self)
+  Effect.withFiber((fiber) =>
+    Effect.acquireRelease(
+      acquireRead(self),
+      () => releaseReadFor(self, fiber.id)
+    )
   )
 
 /**
@@ -396,9 +398,11 @@ export const readLock = (self: TxReentrantLock): Effect.Effect<number, never, Sc
  * @since 2.0.0
  */
 export const writeLock = (self: TxReentrantLock): Effect.Effect<number, never, Scope.Scope> =>
-  Effect.acquireRelease(
-    acquireWrite(self),
-    () => releaseWrite(self)
+  Effect.withFiber((fiber) =>
+    Effect.acquireRelease(
+      acquireWrite(self),
+      () => releaseWriteFor(self, fiber.id)
+    )
   )
 
 /**

--- a/packages/effect/test/TxReentrantLock.test.ts
+++ b/packages/effect/test/TxReentrantLock.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Exit, Fiber, TxReentrantLock } from "effect"
+import { Effect, Exit, Fiber, Scope, TxReentrantLock } from "effect"
 
 describe("TxReentrantLock", () => {
   describe("constructors", () => {
@@ -410,4 +410,17 @@ describe("TxReentrantLock", () => {
         assert.strictEqual(result, 0)
       })))
   })
+
+  it.effect("releases a scoped read lock when another fiber closes the scope", () =>
+    Effect.gen(function*() {
+      const lock = yield* TxReentrantLock.make()
+      const scope = yield* Scope.make()
+      const fiber = yield* TxReentrantLock.readLock(lock).pipe(
+        Effect.provideService(Scope.Scope, scope),
+        Effect.forkChild
+      )
+      yield* Fiber.join(fiber)
+      yield* Scope.close(scope, Exit.void)
+      assert.isFalse(yield* TxReentrantLock.readLocked(lock))
+    }))
 })

--- a/packages/effect/test/TxReentrantLock.test.ts
+++ b/packages/effect/test/TxReentrantLock.test.ts
@@ -423,4 +423,17 @@ describe("TxReentrantLock", () => {
       yield* Scope.close(scope, Exit.void)
       assert.isFalse(yield* TxReentrantLock.readLocked(lock))
     }))
+
+  it.effect("releases a scoped write lock when another fiber closes the scope", () =>
+    Effect.gen(function*() {
+      const lock = yield* TxReentrantLock.make()
+      const scope = yield* Scope.make()
+      const fiber = yield* TxReentrantLock.writeLock(lock).pipe(
+        Effect.provideService(Scope.Scope, scope),
+        Effect.forkChild
+      )
+      yield* Fiber.join(fiber)
+      yield* Scope.close(scope, Exit.void)
+      assert.isFalse(yield* TxReentrantLock.writeLocked(lock))
+    }))
 })


### PR DESCRIPTION
## Summary

A scoped read or write lock remains held when its `Scope` is closed by a fiber other than the acquiring fiber. The finalizer runs but releases against the closer's identity, leaving the acquiring fiber's ownership entry in lock state.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Scoped lock finalizers release under the wrong fiber owner

**Module:** `effect/TxReentrantLock`  
**Audit ID:** `effect-bb62d93fdba2fa9c`  
**Severity / confidence:** high / high

### What happens

A scoped read or write lock remains held when its `Scope` is closed by a fiber other than the acquiring fiber. The finalizer runs but releases against the closer's identity, leaving the acquiring fiber's ownership entry in lock state.

### Why it happens

`Effect.acquireRelease` acquires through `acquireRead` or `acquireWrite`, which records the current `fiber.id`, but its finalizer later calls `releaseRead(self)` or `releaseWrite(self)`. Those release functions query the finalizer fiber's current id rather than the recorded owner, find no matching ownership, and return without changing `stateRef`.

### Expected behavior

`TxReentrantLock.readLock` and `writeLock` must release exactly the acquisition they register when the supplied `Scope` closes, regardless of which fiber performs `Scope.close`.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/TxReentrantLock.ts:269-402`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/TxReentrantLock.ts#L269-L402)

<details>
<summary>View problematic code at <code>packages/effect/src/TxReentrantLock.ts:269-318</code></summary>

````ts
export const releaseRead = (self: TxReentrantLock): Effect.Effect<number> =>
  Effect.withFiber((fiber) =>
    Effect.gen(function*() {
      const state = yield* TxRef.get(self.stateRef)
      const fiberId = fiber.id
      const currentCount = Option.getOrElse(HashMap.get(state.readers, fiberId), () => 0)

      if (currentCount <= 0) return 0

      const newCount = currentCount - 1
      const newReaders = newCount === 0
        ? HashMap.remove(state.readers, fiberId)
        : HashMap.set(state.readers, fiberId, newCount)

      yield* TxRef.set(self.stateRef, { ...state, readers: newReaders })
      return newCount
    }).pipe(Effect.tx)
  )

/**
 * Releases one write lock held by the current fiber.
 *
 * **When to use**
 *
 * Use to leave a manually acquired write lock.
 *
 * **Details**
 *
 * Returns the remaining number of write locks held by this fiber.
 *
 * **Example** (Releasing a write lock)
 *
 * ```ts import.meta.vitest
 * import { Effect, TxReentrantLock } from "effect"
 *
 * const program = Effect.gen(function*() {
 *   const lock = yield* TxReentrantLock.make()
 *   yield* TxReentrantLock.acquireWrite(lock)
 *   return yield* TxReentrantLock.releaseWrite(lock)
 * })
 *
 * await Effect.runPromise(program) // => 0
 * ```
 *
 * @category mutations
 * @since 2.0.0
 */
export const releaseWrite = (self: TxReentrantLock): Effect.Effect<number> =>
  Effect.withFiber((fiber) =>
    Effect.gen(function*() {
````

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/TxReentrantLock.ts#L269-L402)

_Excerpt truncated. [Open the complete packages/effect/src/TxReentrantLock.ts:269-402 range.](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/TxReentrantLock.ts#L269-L402)_

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/TxReentrantLock.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: Scoped lock finalizers release under the wrong fiber owner.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/TxReentrantLock.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-bb62d93fdba2fa9c`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-514