### PR TITLE
Fix failed OTLP exports consume delta checkpoints

### DIFF
--- a/.changeset/failed-otlp-checkpoints.md
+++ b/.changeset/failed-otlp-checkpoints.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve OTLP metric delta checkpoints when an export fails.

--- a/packages/effect/src/unstable/observability/OtlpExporter.ts
+++ b/packages/effect/src/unstable/observability/OtlpExporter.ts
@@ -167,7 +167,7 @@ export const make: (
     readonly label: string
     readonly exportInterval: Duration.Input
     readonly maxBatchSize: number | "disabled"
-    readonly body: (data: Array<any>) => HttpBody
+    readonly body: (data: Array<any>) => readonly [body: HttpBody, onSuccess: Effect.Effect<void>]
     readonly shutdownTimeout: Duration.Input
   }
 ) => Effect.Effect<
@@ -208,9 +208,11 @@ export const make: (
       }
       buffer = []
     }
+    const [body, onSuccess] = options.body(items)
     return client.execute(
-      HttpClientRequest.setBody(request, options.body(items))
+      HttpClientRequest.setBody(request, body)
     ).pipe(
+      Effect.andThen(onSuccess),
       Effect.asVoid,
       Effect.withTracerEnabled(false)
     )

--- a/packages/effect/src/unstable/observability/OtlpLogger.ts
+++ b/packages/effect/src/unstable/observability/OtlpLogger.ts
@@ -71,7 +71,7 @@ export const make: (
     headers: options.headers,
     maxBatchSize: options.maxBatchSize ?? 1000,
     exportInterval: options.exportInterval ?? Duration.seconds(1),
-    body: (data) =>
+    body: (data) => [
       serialization.logs({
         resourceLogs: [{
           resource: otelResource,
@@ -81,6 +81,8 @@ export const make: (
           }]
         }]
       }),
+      Effect.void
+    ],
     shutdownTimeout: options.shutdownTimeout ?? Duration.seconds(3)
   })
 

--- a/packages/effect/src/unstable/observability/OtlpMetrics.ts
+++ b/packages/effect/src/unstable/observability/OtlpMetrics.ts
@@ -112,9 +112,12 @@ export const make: (options: {
   let previousHistogramState = new Map<string, PreviousHistogramState>()
   let previousFrequencyState = new Map<string, Map<string, number>>()
   let previousSummaryState = new Map<string, PreviousSummaryState>()
+  let snapshotSequence = 0
+  let committedSnapshotSequence = -1
 
   const snapshot = (): readonly [body: HttpBody, onSuccess: Effect.Effect<void>] => {
     const snapshot = Metric.snapshotUnsafe(services)
+    const currentSnapshotSequence = snapshotSequence++
     const nowNanos = clock.currentTimeNanosUnsafe()
     const nowTime = String(nowNanos)
     const nextCounterState = new Map(previousCounterState)
@@ -441,11 +444,13 @@ export const make: (options: {
     })
     const onSuccess = isDelta
       ? Effect.sync(() => {
+        if (currentSnapshotSequence < committedSnapshotSequence) return
         previousCounterState = nextCounterState
         previousHistogramState = nextHistogramState
         previousFrequencyState = nextFrequencyState
         previousSummaryState = nextSummaryState
         previousExportTimeNanos = nowNanos
+        committedSnapshotSequence = currentSnapshotSequence
       })
       : Effect.void
     return [body, onSuccess]

--- a/packages/effect/src/unstable/observability/OtlpMetrics.ts
+++ b/packages/effect/src/unstable/observability/OtlpMetrics.ts
@@ -71,8 +71,8 @@ export type AggregationTemporality = "cumulative" | "delta"
  *
  * The exporter snapshots registered Effect metrics on the configured interval, serializes them with the selected aggregation temporality, and flushes during scope finalization up to `shutdownTimeout`.
  * Manual flushing also triggers a snapshot. With delta temporality, each
- * snapshot advances the previous-export state, so frequent flushes narrow the
- * delta aggregation windows.
+ * successful export advances the previous-export state, so frequent successful
+ * flushes narrow the delta aggregation windows.
  *
  * @category constructors
  * @since 4.0.0
@@ -108,15 +108,19 @@ export const make: (options: {
 
   // State for delta temporality tracking
   let previousExportTimeNanos: bigint = startTimeNanos
-  const previousCounterState = new Map<string, number | bigint>()
-  const previousHistogramState = new Map<string, PreviousHistogramState>()
-  const previousFrequencyState = new Map<string, Map<string, number>>()
-  const previousSummaryState = new Map<string, PreviousSummaryState>()
+  let previousCounterState = new Map<string, number | bigint>()
+  let previousHistogramState = new Map<string, PreviousHistogramState>()
+  let previousFrequencyState = new Map<string, Map<string, number>>()
+  let previousSummaryState = new Map<string, PreviousSummaryState>()
 
-  const snapshot = (): HttpBody => {
+  const snapshot = (): readonly [body: HttpBody, onSuccess: Effect.Effect<void>] => {
     const snapshot = Metric.snapshotUnsafe(services)
     const nowNanos = clock.currentTimeNanosUnsafe()
     const nowTime = String(nowNanos)
+    const nextCounterState = new Map(previousCounterState)
+    const nextHistogramState = new Map(previousHistogramState)
+    const nextFrequencyState = new Map(previousFrequencyState)
+    const nextSummaryState = new Map(previousSummaryState)
     const metricData: Array<IMetric> = []
     const metricDataByName = new Map<string, IMetric>()
     const addMetricData = (data: IMetric) => {
@@ -162,7 +166,7 @@ export const make: (options: {
                 }
               }
             }
-            previousCounterState.set(metricKey, currentCount)
+            nextCounterState.set(metricKey, currentCount)
           }
 
           const dataPoint: INumberDataPoint = {
@@ -253,7 +257,7 @@ export const make: (options: {
               // Note: This is a limitation - true delta min/max would require tracking
               // observations within each interval
             }
-            previousHistogramState.set(metricKey, {
+            nextHistogramState.set(metricKey, {
               count: state.state.count,
               sum: state.state.sum,
               bucketCounts: currentBuckets.counts.slice(),
@@ -314,7 +318,7 @@ export const make: (options: {
           }
 
           if (isDelta) {
-            previousFrequencyState.set(metricKey, currentOccurrences)
+            nextFrequencyState.set(metricKey, currentOccurrences)
           }
 
           if (metricDataByName.has(state.id)) {
@@ -366,7 +370,7 @@ export const make: (options: {
               reportCount = state.state.count - previousState.count
               reportSum = state.state.sum - previousState.sum
             }
-            previousSummaryState.set(metricKey, {
+            nextSummaryState.set(metricKey, {
               count: state.state.count,
               sum: state.state.sum
             })
@@ -426,12 +430,7 @@ export const make: (options: {
       }
     }
 
-    // Update the previous export time for delta calculations
-    if (isDelta) {
-      previousExportTimeNanos = nowNanos
-    }
-
-    return serialization.metrics({
+    const body = serialization.metrics({
       resourceMetrics: [{
         resource,
         scopeMetrics: [{
@@ -440,6 +439,16 @@ export const make: (options: {
         }]
       }]
     })
+    const onSuccess = isDelta
+      ? Effect.sync(() => {
+        previousCounterState = nextCounterState
+        previousHistogramState = nextHistogramState
+        previousFrequencyState = nextFrequencyState
+        previousSummaryState = nextSummaryState
+        previousExportTimeNanos = nowNanos
+      })
+      : Effect.void
+    return [body, onSuccess]
   }
 
   yield* Exporter.make({

--- a/packages/effect/src/unstable/observability/OtlpTracer.ts
+++ b/packages/effect/src/unstable/observability/OtlpTracer.ts
@@ -83,7 +83,7 @@ export const make: (
           }]
         }]
       }
-      return serialization.traces(data)
+      return [serialization.traces(data), Effect.void]
     },
     shutdownTimeout: options.shutdownTimeout ?? Duration.seconds(3)
   })

--- a/packages/effect/test/unstable/observability/OtlpExporter.test.ts
+++ b/packages/effect/test/unstable/observability/OtlpExporter.test.ts
@@ -43,7 +43,7 @@ const makeExporter = (
     headers: undefined,
     exportInterval: options?.exportInterval ?? "1 hour",
     maxBatchSize: options?.maxBatchSize ?? 1,
-    body: options?.body ?? (() => HttpBody.empty),
+    body: (data) => [options?.body?.(data) ?? HttpBody.empty, Effect.void],
     shutdownTimeout: options?.shutdownTimeout ?? "1 second"
   }).pipe(
     Effect.provideService(HttpClient.HttpClient, httpClient),
@@ -57,7 +57,7 @@ const makeExporterRaw = (maxBatchSize: number | "disabled" = 1) =>
     headers: undefined,
     exportInterval: "1 hour",
     maxBatchSize,
-    body: () => HttpBody.empty,
+    body: () => [HttpBody.empty, Effect.void],
     shutdownTimeout: "1 second"
   })
 

--- a/packages/effect/test/unstable/observability/OtlpMetrics.test.ts
+++ b/packages/effect/test/unstable/observability/OtlpMetrics.test.ts
@@ -5,15 +5,16 @@ import { HttpClient, type HttpClientError, HttpClientResponse } from "effect/uns
 import { OtlpExporter, OtlpMetrics, OtlpSerialization } from "effect/unstable/observability"
 
 describe("OtlpMetrics", () => {
-  it.effect("retains a delta after a failed export", () =>
+  it.effect("retains delta checkpoints after a failed export", () =>
     Effect.scoped(Effect.gen(function*() {
-      const bodies = yield* Ref.make<Array<any>>([])
+      const bodies = yield* Ref.make<ReadonlyArray<OtlpExportRequest>>([])
       const attempts = yield* Ref.make(0)
       const client = HttpClient.makeWith(
         Effect.fnUntraced(function*(requestEffect) {
           const request = yield* requestEffect
           if (request.body._tag === "Uint8Array") {
-            yield* Ref.update(bodies, (all) => [...all, JSON.parse(new TextDecoder().decode(request.body.body))])
+            const body = JSON.parse(new TextDecoder().decode(request.body.body)) as OtlpExportRequest
+            yield* Ref.update(bodies, Array.append(body))
           }
           const attempt = yield* Ref.updateAndGet(attempts, (n) => n + 1)
           return HttpClientResponse.fromWeb(request, new Response(null, { status: attempt === 1 ? 400 : 200 }))
@@ -30,15 +31,46 @@ describe("OtlpMetrics", () => {
         Layer.provideMerge(Layer.succeed(HttpClient.HttpClient, client))
       )
       yield* Effect.gen(function*() {
-        yield* Metric.update(Metric.counter("repro_delta"), 5)
+        yield* Metric.update(Metric.counter("repro_counter"), 5)
+        const histogram = Metric.histogram("repro_histogram", { boundaries: [10, 50, 100] })
+        yield* Metric.update(histogram, 25)
+        yield* Metric.update(histogram, 75)
+        const frequency = Metric.frequency("repro_frequency")
+        yield* Metric.update(frequency, "a")
+        yield* Metric.update(frequency, "a")
+        yield* Metric.update(frequency, "b")
+        const summary = Metric.summary("repro_summary", {
+          maxAge: "1 minute",
+          maxSize: 100,
+          quantiles: [0.5]
+        })
+        yield* Metric.update(summary, 10)
+        yield* Metric.update(summary, 20)
+        yield* Metric.update(summary, 30)
         const flusher = yield* OtlpExporter.Flusher
         yield* flusher.flush
         yield* TestClock.adjust("60 seconds")
         yield* flusher.flush
       }).pipe(Effect.provide(layer), Effect.provideService(Metric.MetricRegistry, new Map()))
-      const values = (yield* Ref.get(bodies)).map((body) => body.resourceMetrics[0].scopeMetrics[0].metrics
-        .find((metric: any) => metric.name === "repro_delta").sum.dataPoints[0].asDouble)
-      assert.deepStrictEqual(values.slice(0, 2), [5, 5])
+      const [first, second] = yield* Ref.get(bodies)
+      assert.strictEqual(findMetric(first, "repro_counter")?.sum?.dataPoints[0].asDouble, 5)
+      assert.strictEqual(findMetric(second, "repro_counter")?.sum?.dataPoints[0].asDouble, 5)
+      assert.strictEqual(findMetric(first, "repro_histogram")?.histogram?.dataPoints[0].count, 2)
+      assert.strictEqual(findMetric(second, "repro_histogram")?.histogram?.dataPoints[0].count, 2)
+      assert.strictEqual(findMetric(first, "repro_histogram")?.histogram?.dataPoints[0].sum, 100)
+      assert.strictEqual(findMetric(second, "repro_histogram")?.histogram?.dataPoints[0].sum, 100)
+      assert.strictEqual(findFrequencyValue(first, "repro_frequency", "a"), 2)
+      assert.strictEqual(findFrequencyValue(second, "repro_frequency", "a"), 2)
+      assert.strictEqual(findFrequencyValue(first, "repro_frequency", "b"), 1)
+      assert.strictEqual(findFrequencyValue(second, "repro_frequency", "b"), 1)
+      assert.strictEqual(findMetric(first, "repro_summary_count")?.sum?.dataPoints[0].asInt, 3)
+      assert.strictEqual(findMetric(second, "repro_summary_count")?.sum?.dataPoints[0].asInt, 3)
+      assert.strictEqual(findMetric(first, "repro_summary_sum")?.sum?.dataPoints[0].asDouble, 60)
+      assert.strictEqual(findMetric(second, "repro_summary_sum")?.sum?.dataPoints[0].asDouble, 60)
+      assert.strictEqual(
+        findMetric(second, "repro_counter")?.sum?.dataPoints[0].startTimeUnixNano,
+        findMetric(first, "repro_counter")?.sum?.dataPoints[0].startTimeUnixNano
+      )
     })))
 
   describe("cumulative temporality", () => {
@@ -552,3 +584,12 @@ const findMetric = (request: OtlpExportRequest, name: string): OtlpMetric | unde
   }
   return undefined
 }
+
+const findFrequencyValue = (request: OtlpExportRequest, name: string, key: string): number | undefined =>
+  findMetric(request, name)?.sum?.dataPoints.find((dataPoint) =>
+    dataPoint.attributes.some((attribute) =>
+      attribute.key === "key" &&
+      Predicate.hasProperty(attribute.value, "stringValue") &&
+      attribute.value.stringValue === key
+    )
+  )?.asInt

--- a/packages/effect/test/unstable/observability/OtlpMetrics.test.ts
+++ b/packages/effect/test/unstable/observability/OtlpMetrics.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Array, Context, Effect, Layer, Metric, Predicate, Ref } from "effect"
+import { Array, Context, Deferred, Effect, Fiber, Layer, Metric, Predicate, Ref } from "effect"
 import { TestClock } from "effect/testing"
 import { HttpClient, type HttpClientError, HttpClientResponse } from "effect/unstable/http"
 import { OtlpExporter, OtlpMetrics, OtlpSerialization } from "effect/unstable/observability"
@@ -71,6 +71,62 @@ describe("OtlpMetrics", () => {
         findMetric(second, "repro_counter")?.sum?.dataPoints[0].startTimeUnixNano,
         findMetric(first, "repro_counter")?.sum?.dataPoints[0].startTimeUnixNano
       )
+    })))
+
+  it.effect("does not regress delta checkpoints when exports complete out of order", () =>
+    Effect.scoped(Effect.gen(function*() {
+      const bodies = yield* Ref.make<ReadonlyArray<OtlpExportRequest>>([])
+      const started = yield* Effect.forEach([0, 1], () => Deferred.make<void>())
+      const releases = yield* Effect.forEach([0, 1], () => Deferred.make<void>())
+      let requestIndex = 0
+      const client = HttpClient.makeWith(
+        Effect.fnUntraced(function*(requestEffect) {
+          const request = yield* requestEffect
+          if (request.body._tag === "Uint8Array") {
+            const body = JSON.parse(new TextDecoder().decode(request.body.body)) as OtlpExportRequest
+            yield* Ref.update(bodies, Array.append(body))
+          }
+          const index = requestIndex++
+          if (index < 2) {
+            yield* Deferred.succeed(started[index], undefined)
+            yield* Deferred.await(releases[index])
+          }
+          return HttpClientResponse.fromWeb(request, new Response())
+        }),
+        Effect.succeed as HttpClient.HttpClient.Preprocess<HttpClientError.HttpClientError, never>
+      )
+      const layer = OtlpMetrics.layer({
+        url: "http://localhost:4318/v1/metrics",
+        resource: { serviceName: "repro" },
+        temporality: "delta",
+        exportInterval: "1 hour"
+      }).pipe(
+        Layer.provide(OtlpSerialization.layerJson),
+        Layer.provideMerge(Layer.succeed(HttpClient.HttpClient, client))
+      )
+      yield* Effect.gen(function*() {
+        const counter = Metric.counter("concurrent_delta")
+        const flusher = yield* OtlpExporter.Flusher
+        yield* Metric.update(counter, 1)
+        const first = yield* Effect.forkChild(flusher.flush)
+        yield* Deferred.await(started[0])
+
+        yield* TestClock.adjust("1 second")
+        yield* Metric.update(counter, 1)
+        const second = yield* Effect.forkChild(flusher.flush)
+        yield* Deferred.await(started[1])
+
+        yield* Deferred.succeed(releases[1], undefined)
+        yield* Fiber.join(second)
+        yield* Deferred.succeed(releases[0], undefined)
+        yield* Fiber.join(first)
+
+        yield* TestClock.adjust("1 second")
+        yield* flusher.flush
+      }).pipe(Effect.provide(layer), Effect.provideService(Metric.MetricRegistry, new Map()))
+
+      const requests = yield* Ref.get(bodies)
+      assert.strictEqual(findMetric(requests[2], "concurrent_delta")?.sum?.dataPoints[0].asDouble, 0)
     })))
 
   describe("cumulative temporality", () => {

--- a/packages/effect/test/unstable/observability/OtlpMetrics.test.ts
+++ b/packages/effect/test/unstable/observability/OtlpMetrics.test.ts
@@ -6,7 +6,7 @@ import { OtlpExporter, OtlpMetrics, OtlpSerialization } from "effect/unstable/ob
 
 describe("OtlpMetrics", () => {
   it.effect("retains delta checkpoints after a failed export", () =>
-    Effect.scoped(Effect.gen(function*() {
+    Effect.gen(function*() {
       const bodies = yield* Ref.make<ReadonlyArray<OtlpExportRequest>>([])
       const attempts = yield* Ref.make(0)
       const client = HttpClient.makeWith(
@@ -71,7 +71,7 @@ describe("OtlpMetrics", () => {
         findMetric(second, "repro_counter")?.sum?.dataPoints[0].startTimeUnixNano,
         findMetric(first, "repro_counter")?.sum?.dataPoints[0].startTimeUnixNano
       )
-    })))
+    }))
 
   it.effect("does not regress delta checkpoints when exports complete out of order", () =>
     Effect.scoped(Effect.gen(function*() {

--- a/packages/effect/test/unstable/observability/OtlpMetrics.test.ts
+++ b/packages/effect/test/unstable/observability/OtlpMetrics.test.ts
@@ -2,9 +2,45 @@ import { assert, describe, it } from "@effect/vitest"
 import { Array, Context, Effect, Layer, Metric, Predicate, Ref } from "effect"
 import { TestClock } from "effect/testing"
 import { HttpClient, type HttpClientError, HttpClientResponse } from "effect/unstable/http"
-import { OtlpMetrics, OtlpSerialization } from "effect/unstable/observability"
+import { OtlpExporter, OtlpMetrics, OtlpSerialization } from "effect/unstable/observability"
 
 describe("OtlpMetrics", () => {
+  it.effect("retains a delta after a failed export", () =>
+    Effect.scoped(Effect.gen(function*() {
+      const bodies = yield* Ref.make<Array<any>>([])
+      const attempts = yield* Ref.make(0)
+      const client = HttpClient.makeWith(
+        Effect.fnUntraced(function*(requestEffect) {
+          const request = yield* requestEffect
+          if (request.body._tag === "Uint8Array") {
+            yield* Ref.update(bodies, (all) => [...all, JSON.parse(new TextDecoder().decode(request.body.body))])
+          }
+          const attempt = yield* Ref.updateAndGet(attempts, (n) => n + 1)
+          return HttpClientResponse.fromWeb(request, new Response(null, { status: attempt === 1 ? 400 : 200 }))
+        }),
+        Effect.succeed as HttpClient.HttpClient.Preprocess<HttpClientError.HttpClientError, never>
+      )
+      const layer = OtlpMetrics.layer({
+        url: "http://localhost:4318/v1/metrics",
+        resource: { serviceName: "repro" },
+        temporality: "delta",
+        exportInterval: "1 hour"
+      }).pipe(
+        Layer.provide(OtlpSerialization.layerJson),
+        Layer.provideMerge(Layer.succeed(HttpClient.HttpClient, client))
+      )
+      yield* Effect.gen(function*() {
+        yield* Metric.update(Metric.counter("repro_delta"), 5)
+        const flusher = yield* OtlpExporter.Flusher
+        yield* flusher.flush
+        yield* TestClock.adjust("60 seconds")
+        yield* flusher.flush
+      }).pipe(Effect.provide(layer), Effect.provideService(Metric.MetricRegistry, new Map()))
+      const values = (yield* Ref.get(bodies)).map((body) => body.resourceMetrics[0].scopeMetrics[0].metrics
+        .find((metric: any) => metric.name === "repro_delta").sum.dataPoints[0].asDouble)
+      assert.deepStrictEqual(values.slice(0, 2), [5, 5])
+    })))
+
   describe("cumulative temporality", () => {
     it.effect("reports counter totals across export intervals", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Summary

A delta snapshot advances its baselines while constructing the request body, so an HTTP rejection still consumes the counter, histogram, frequency, and summary values in that request. The next successful export reports only changes after the rejected attempt and starts its interval at the rejected attempt's timestamp.

> [!NOTE]
> This PR includes focused regression coverage and the implementation fix.

## Failed OTLP exports consume delta checkpoints

**Module:** `effect/unstable/observability/OtlpMetrics`  
**Audit ID:** `effect-f60831606fc1abf3`  
**Severity / confidence:** high / high

### What happens

A delta snapshot advances its baselines while constructing the request body, so an HTTP rejection still consumes the counter, histogram, frequency, and summary values in that request. The next successful export reports only changes after the rejected attempt and starts its interval at the rejected attempt's timestamp.

### Why it happens

The exporter calls `snapshot` from `setBody` before `client.execute` determines the response status. During that call, `previousCounterState`, `previousHistogramState`, `previousFrequencyState`, `previousSummaryState`, and `previousExportTimeNanos` are mutated to the current snapshot; the exporter's failure branch only sets `disabledUntil` and clears its buffer, with no rollback of those metric baselines.

### Expected behavior

For delta temporality, the previous-value maps and previous export time must identify the last successfully exported checkpoint; a failed export must leave that checkpoint unchanged so every observation is included in a later successful export.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/unstable/observability/OtlpMetrics.ts:146-442`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/observability/OtlpMetrics.ts#L146-L442)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/observability/OtlpMetrics.ts:146-195</code></summary>

```ts
          if (isDelta) {
            const previousCount = previousCounterState.get(metricKey)
            if (previousCount !== undefined) {
              if (typeof currentCount === "bigint" && typeof previousCount === "bigint") {
                reportValue = currentCount - previousCount
                // Handle reset: if current < previous, report current value
                if (reportValue < BigInt(0)) {
                  reportValue = currentCount
                }
              } else {
                const curr = Number(currentCount)
                const prev = Number(previousCount)
                reportValue = curr - prev
                // Handle reset
                if (reportValue < 0) {
                  reportValue = curr
                }
              }
            }
            previousCounterState.set(metricKey, currentCount)
          }

          const dataPoint: INumberDataPoint = {
            attributes,
            startTimeUnixNano: intervalStartTime,
            timeUnixNano: nowTime
          }
          if (typeof reportValue === "bigint") {
            dataPoint.asInt = Number(reportValue)
          } else {
            dataPoint.asDouble = reportValue
          }
          if (metricDataByName.has(state.id)) {
            metricDataByName.get(state.id)!.sum!.dataPoints.push(dataPoint)
          } else {
            addMetricData({
              name: state.id,
              description: state.description!,
              unit,
              sum: {
                aggregationTemporality: aggregationTemporalityEnum,
                isMonotonic: state.state.incremental,
                dataPoints: [dataPoint]
              }
            })
          }
          break
        }
        case "Gauge": {
          // Gauges don't have temporality - they always report current value
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/observability/OtlpMetrics.ts#L146-L442)

_Excerpt truncated. [Open the complete packages/effect/src/unstable/observability/OtlpMetrics.ts:146-442 range.](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/observability/OtlpMetrics.ts#L146-L442)_

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/observability/OtlpMetrics.test.ts
```

**Regression:** The focused contract assertion fails against 17f0b91a and passes with this fix.

## Implementation

The shared exporter now pairs each encoded request with an action that runs only after the filtered, retried HTTP request succeeds. Metrics build candidate delta state while serializing and commit the counter, histogram, frequency, summary, and interval checkpoints in that success action. Log and trace exporters use a no-op success action.

The regression test remains in the module's main test file and covers every affected metric type.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-f60831606fc1abf3`
- Initial patch: focused reproduction tests; implementation completed in `13a4ee2c0`

Closes EFF-513