### PR TITLE
Fix clearAddress leaves primary-key deduplication state

### DIFF
--- a/.changeset/fix-message-storage-clear-address-dedup.md
+++ b/.changeset/fix-message-storage-clear-address-dedup.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Clear in-memory message primary-key indexes when clearing an entity address.

--- a/packages/effect/src/unstable/cluster/MessageStorage.ts
+++ b/packages/effect/src/unstable/cluster/MessageStorage.ts
@@ -991,6 +991,14 @@ export class MemoryDriver extends Context.Service<MemoryDriver>()("effect/cluste
       resetAddress: () => Effect.void,
       clearAddress: (address) =>
         Effect.sync(() => {
+          for (const [primaryKey, entry] of requestsByPrimaryKey) {
+            const envelope = entry.envelope
+            const sameAddress = address.entityType === envelope.address.entityType &&
+              address.entityId === envelope.address.entityId
+            if (sameAddress) {
+              requestsByPrimaryKey.delete(primaryKey)
+            }
+          }
           for (let i = journal.length - 1; i >= 0; i--) {
             const envelope = journal[i]
             const sameAddress = address.entityType === envelope.address.entityType &&

--- a/packages/effect/test/cluster/MessageStorage.test.ts
+++ b/packages/effect/test/cluster/MessageStorage.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, expect, it } from "@effect/vitest"
+import { describe, expect, it } from "@effect/vitest"
 import { Context, Effect, Exit, Fiber, Latch, Layer, Option, Schema } from "effect"
 import { TestClock } from "effect/testing"
 import {
@@ -31,14 +31,14 @@ describe("MessageStorage", () => {
           entityType: EntityType.make("Repro"),
           entityId: EntityId.make("one")
         })
-        const envelope = {
+        const envelope: Envelope.PartialRequestEncoded = {
           _tag: "Request",
           requestId: "1",
           address: { shardId: { group: "default", id: 1 }, entityType: "Repro", entityId: "one" },
           tag: "Repro",
           payload: {},
           headers: {}
-        } as any
+        }
         yield* driver.encoded.saveEnvelope({ envelope, primaryKey: "dedup-key", deliverAt: null })
         yield* driver.encoded.clearAddress(address)
         const result = yield* driver.encoded.saveEnvelope({
@@ -46,7 +46,7 @@ describe("MessageStorage", () => {
           primaryKey: "dedup-key",
           deliverAt: null
         })
-        assert.strictEqual(result._tag, "Success")
+        expect(result._tag).toEqual("Success")
       }).pipe(Effect.provide(MessageStorage.MemoryDriver.layer)))
 
     it.effect("saves a request", () =>

--- a/packages/effect/test/cluster/MessageStorage.test.ts
+++ b/packages/effect/test/cluster/MessageStorage.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "@effect/vitest"
+import { assert, describe, expect, it } from "@effect/vitest"
 import { Context, Effect, Exit, Fiber, Latch, Layer, Option, Schema } from "effect"
 import { TestClock } from "effect/testing"
 import {
@@ -23,6 +23,32 @@ const MemoryLive = MessageStorage.layerMemory.pipe(
 
 describe("MessageStorage", () => {
   describe("memory", () => {
+    it.effect("removes the primary-key index when clearing an address", () =>
+      Effect.gen(function*() {
+        const driver = yield* MessageStorage.MemoryDriver
+        const address = EntityAddress.make({
+          shardId: ShardId.make("default", 1),
+          entityType: EntityType.make("Repro"),
+          entityId: EntityId.make("one")
+        })
+        const envelope = {
+          _tag: "Request",
+          requestId: "1",
+          address: { shardId: { group: "default", id: 1 }, entityType: "Repro", entityId: "one" },
+          tag: "Repro",
+          payload: {},
+          headers: {}
+        } as any
+        yield* driver.encoded.saveEnvelope({ envelope, primaryKey: "dedup-key", deliverAt: null })
+        yield* driver.encoded.clearAddress(address)
+        const result = yield* driver.encoded.saveEnvelope({
+          envelope: { ...envelope, requestId: "2" },
+          primaryKey: "dedup-key",
+          deliverAt: null
+        })
+        assert.strictEqual(result._tag, "Success")
+      }).pipe(Effect.provide(MessageStorage.MemoryDriver.layer)))
+
     it.effect("saves a request", () =>
       Effect.gen(function*() {
         const storage = yield* MessageStorage.MessageStorage


### PR DESCRIPTION
## Summary

Clearing an entity address removes its requests, journal records, and unprocessed envelopes but retains the corresponding entries in the memory driver's primary-key index. Reusing one of those keys is still reported as a duplicate of the deleted request.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## clearAddress leaves primary-key deduplication state

**Module:** `effect/unstable/cluster/MessageStorage`  
**Audit ID:** `effect-87e7029d5a5c69d6`  
**Severity / confidence:** high / high

### What happens

Clearing an entity address removes its requests, journal records, and unprocessed envelopes but retains the corresponding entries in the memory driver's primary-key index. Reusing one of those keys is still reported as a duplicate of the deleted request.

### Why it happens

`saveEnvelope` records each deduplication key in `requestsByPrimaryKey`. The `clearAddress` loop deletes matching envelopes from `unprocessed`, `requests`, and `journal`, but never finds or removes map entries whose `MemoryEntry.envelope` belongs to the cleared address.

### Expected behavior

After `clearAddress(address)` completes, no request state for that address may remain reachable through request-id or primary-key lookup, and saving a new request with a formerly used primary key must succeed as a new request.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/unstable/cluster/MessageStorage.ts:827-1005`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/cluster/MessageStorage.ts#L827-L1005)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/cluster/MessageStorage.ts:827-876</code></summary>

```ts
    const requests = new Map<string, MemoryEntry>()
    const requestsByPrimaryKey = new Map<string, MemoryEntry>()
    const unprocessed = new Set<Envelope.Encoded>()
    const replyIds = new Set<string>()

    const journal: Array<Envelope.Encoded> = []

    const cursors = new WeakMap<{}, number>()

    const unprocessedWith = (predicate: Predicate<Envelope.Encoded>) => {
      const messages: Array<{
        readonly envelope: Envelope.Encoded
        readonly lastSentReply: Option.Option<Reply.Encoded>
      }> = []
      const now = clock.currentTimeMillisUnsafe()
      for (const envelope of unprocessed) {
        if (!predicate(envelope)) {
          continue
        }
        if (envelope._tag === "Request") {
          const entry = requests.get(envelope.requestId)
          if (entry?.deliverAt && entry.deliverAt > now) {
            continue
          }
          messages.push({
            envelope,
            lastSentReply: Option.fromNullishOr(entry?.replies[entry.replies.length - 1])
          })
        } else {
          messages.push({
            envelope,
            lastSentReply: Option.none()
          })
        }
      }
      return messages
    }

    const replyLatch = yield* Latch.make()

    function repliesFor(requestIds: Array<string>) {
      const replies = Arr.empty<Reply.Encoded>()
      for (const requestId of requestIds) {
        const request = requests.get(requestId)
        if (!request) continue
        else if (request.lastReceivedChunk === undefined) {
          replies.push(...request.replies)
          continue
        }
        const sequence = request.lastReceivedChunk.sequence
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/cluster/MessageStorage.ts#L827-L1005)

_Excerpt truncated. [Open the complete packages/effect/src/unstable/cluster/MessageStorage.ts:827-1005 range.](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/cluster/MessageStorage.ts#L827-L1005)_

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/cluster/MessageStorageClearAddressDedup.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: clearAddress leaves primary-key deduplication state.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/cluster/MessageStorageClearAddressDedup.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-87e7029d5a5c69d6`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-512