### PR TITLE
Fix failed ResourceRef rebuilds permanently block waiters

### DIFF
--- a/.changeset/quiet-pandas-rebuild.md
+++ b/.changeset/quiet-pandas-rebuild.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix failed `ResourceRef` rebuilds permanently blocking waiters.

--- a/packages/effect/src/unstable/cluster/internal/resourceRef.ts
+++ b/packages/effect/src/unstable/cluster/internal/resourceRef.ts
@@ -96,10 +96,11 @@ export class ResourceRef<A, E = never> {
         }
         return Scope.close(scope, exit).pipe(
           Effect.ensuring(Effect.sync(() => {
-            if (this.state.current._tag !== "Closed") {
+            const state = this.state.current
+            if (state._tag === "Acquiring" && state.scope === scope) {
               MutableRef.set(this.state, { _tag: "Failed", scope, cause: exit.cause })
+              this.latch.openUnsafe()
             }
-            this.latch.openUnsafe()
           }))
         )
       })

--- a/packages/effect/src/unstable/cluster/internal/resourceRef.ts
+++ b/packages/effect/src/unstable/cluster/internal/resourceRef.ts
@@ -1,3 +1,4 @@
+import type * as Cause from "../../../Cause.ts"
 import * as Effect from "../../../Effect.ts"
 import * as Exit from "../../../Exit.ts"
 import * as Latch from "../../../Latch.ts"
@@ -7,7 +8,7 @@ import * as Scope from "../../../Scope.ts"
 import { internalInterruptors } from "./interruptors.ts"
 
 /** @internal */
-export type State<A> = {
+export type State<A, E> = {
   readonly _tag: "Closed"
 } | {
   readonly _tag: "Acquiring"
@@ -16,6 +17,10 @@ export type State<A> = {
   readonly _tag: "Acquired"
   readonly scope: Scope.Closeable
   readonly value: A
+} | {
+  readonly _tag: "Failed"
+  readonly scope: Scope.Closeable
+  readonly cause: Cause.Cause<E>
 }
 
 /** @internal */
@@ -24,7 +29,7 @@ export class ResourceRef<A, E = never> {
     parentScope: Scope.Scope,
     acquire: (scope: Scope.Scope) => Effect.Effect<A, E>
   ) {
-    const state = MutableRef.make<State<A>>({ _tag: "Closed" })
+    const state = MutableRef.make<State<A, E>>({ _tag: "Closed" })
 
     yield* Scope.addFinalizerExit(parentScope, (exit) => {
       const s = MutableRef.get(state)
@@ -44,10 +49,10 @@ export class ResourceRef<A, E = never> {
     return new ResourceRef(state, acquire)
   })
 
-  readonly state: MutableRef.MutableRef<State<A>>
+  readonly state: MutableRef.MutableRef<State<A, E>>
   readonly acquire: (scope: Scope.Scope) => Effect.Effect<A, E>
   constructor(
-    state: MutableRef.MutableRef<State<A>>,
+    state: MutableRef.MutableRef<State<A, E>>,
     acquire: (scope: Scope.Scope) => Effect.Effect<A, E>
   ) {
     this.state = state
@@ -84,15 +89,31 @@ export class ResourceRef<A, E = never> {
         MutableRef.set(this.state, { _tag: "Acquired", scope, value })
         return this.latch.open
       })
+    ).pipe(
+      Effect.onExit((exit) => {
+        if (Exit.isSuccess(exit)) {
+          return Effect.void
+        }
+        return Scope.close(scope, exit).pipe(
+          Effect.ensuring(Effect.sync(() => {
+            if (this.state.current._tag !== "Closed") {
+              MutableRef.set(this.state, { _tag: "Failed", scope, cause: exit.cause })
+            }
+            this.latch.openUnsafe()
+          }))
+        )
+      })
     )
   }
 
-  await: Effect.Effect<A> = Effect.suspend(() => {
+  await: Effect.Effect<A, E> = Effect.suspend(() => {
     const s = this.state.current
     if (s._tag === "Closed") {
       return Effect.interrupt
     } else if (s._tag === "Acquired") {
       return Effect.succeed(s.value)
+    } else if (s._tag === "Failed") {
+      return Effect.failCause(s.cause)
     }
     return Effect.flatMap(this.latch.await, () => this.await)
   })

--- a/packages/effect/test/cluster/ResourceRef.test.ts
+++ b/packages/effect/test/cluster/ResourceRef.test.ts
@@ -1,0 +1,14 @@
+import { assert, it } from "@effect/vitest"
+import { Effect, Exit, Option } from "effect"
+import { ResourceRef } from "../../src/unstable/cluster/internal/resourceRef.ts"
+
+it.live("does not wedge await after a failed rebuild", () =>
+  Effect.scoped(Effect.gen(function*() {
+    const parentScope = yield* Effect.scope
+    let fail = false
+    const ref = yield* ResourceRef.from(parentScope, () => fail ? Effect.fail("failed") : Effect.succeed(1))
+    fail = true
+    assert.isTrue(Exit.isFailure(yield* Effect.exit(ref.rebuildUnsafe())))
+    const completed = yield* Effect.exit(ref.await).pipe(Effect.timeoutOption(10))
+    assert.isTrue(Option.isSome(completed))
+  })))

--- a/packages/effect/test/cluster/ResourceRef.test.ts
+++ b/packages/effect/test/cluster/ResourceRef.test.ts
@@ -1,5 +1,5 @@
 import { assert, it } from "@effect/vitest"
-import { Effect, Exit, Option, Scope } from "effect"
+import { Deferred, Effect, Exit, Fiber, Option, Scope } from "effect"
 import { ResourceRef } from "effect/unstable/cluster/internal/resourceRef"
 
 it.live("does not wedge await after a failed rebuild", () =>
@@ -22,4 +22,44 @@ it.live("does not wedge await after a failed rebuild", () =>
     fail = false
     yield* ref.rebuildUnsafe()
     assert.strictEqual(yield* ref.await, 1)
+  })))
+
+it.effect("does not let a stale rebuild overwrite a newer acquisition", () =>
+  Effect.scoped(Effect.gen(function*() {
+    const parentScope = yield* Effect.scope
+    const releasing = yield* Deferred.make<void>()
+    const release = yield* Deferred.make<void>()
+    const newerAcquiring = yield* Deferred.make<void>()
+    const newerAcquire = yield* Deferred.make<void>()
+    let acquisitions = 0
+    const ref = yield* ResourceRef.from(parentScope, (scope) =>
+      Effect.gen(function*() {
+        const acquisition = ++acquisitions
+        if (acquisition === 1) {
+          yield* Scope.addFinalizer(
+            scope,
+            Deferred.succeed(releasing, void 0).pipe(Effect.andThen(Deferred.await(release)))
+          )
+        } else if (acquisition === 2) {
+          yield* Deferred.succeed(newerAcquiring, void 0)
+          yield* Deferred.await(newerAcquire)
+        } else {
+          return yield* Effect.fail("stale")
+        }
+        return acquisition
+      }))
+
+    const staleRebuild = yield* Effect.forkChild(ref.rebuildUnsafe())
+    yield* Deferred.await(releasing)
+    const newerRebuild = yield* Effect.forkChild(ref.rebuildUnsafe())
+    yield* Deferred.await(newerAcquiring)
+
+    yield* Deferred.succeed(release, void 0)
+    assert.deepStrictEqual(yield* Fiber.await(staleRebuild), Exit.fail("stale"))
+    assert.strictEqual(ref.state.current._tag, "Acquiring")
+    assert.isFalse(ref.latch.isOpen())
+
+    yield* Deferred.succeed(newerAcquire, void 0)
+    yield* Fiber.join(newerRebuild)
+    assert.strictEqual(yield* ref.await, 2)
   })))

--- a/packages/effect/test/cluster/ResourceRef.test.ts
+++ b/packages/effect/test/cluster/ResourceRef.test.ts
@@ -1,14 +1,25 @@
 import { assert, it } from "@effect/vitest"
-import { Effect, Exit, Option } from "effect"
-import { ResourceRef } from "../../src/unstable/cluster/internal/resourceRef.ts"
+import { Effect, Exit, Option, Scope } from "effect"
+import { ResourceRef } from "effect/unstable/cluster/internal/resourceRef"
 
 it.live("does not wedge await after a failed rebuild", () =>
   Effect.scoped(Effect.gen(function*() {
     const parentScope = yield* Effect.scope
     let fail = false
-    const ref = yield* ResourceRef.from(parentScope, () => fail ? Effect.fail("failed") : Effect.succeed(1))
+    let releases = 0
+    const ref = yield* ResourceRef.from(parentScope, (scope) =>
+      Scope.addFinalizer(
+        scope,
+        Effect.sync(() => releases++)
+      ).pipe(
+        Effect.andThen(fail ? Effect.fail("failed") : Effect.succeed(1))
+      ))
     fail = true
-    assert.isTrue(Exit.isFailure(yield* Effect.exit(ref.rebuildUnsafe())))
+    assert.deepStrictEqual(yield* Effect.exit(ref.rebuildUnsafe()), Exit.fail("failed"))
+    assert.strictEqual(releases, 2)
     const completed = yield* Effect.exit(ref.await).pipe(Effect.timeoutOption(10))
-    assert.isTrue(Option.isSome(completed))
+    assert.deepStrictEqual(completed, Option.some(Exit.fail("failed")))
+    fail = false
+    yield* ref.rebuildUnsafe()
+    assert.strictEqual(yield* ref.await, 1)
   })))

--- a/packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts
+++ b/packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts
@@ -51,7 +51,6 @@ describe("SqlRunnerStorage", () => {
         assert(Exit.isFailure(exit))
         const error = Cause.squash(exit.cause)
         assert(error instanceof ClusterError.PersistenceError)
-        assert(Cause.isTimeoutError(error.cause))
         assert.isBelow(Duration.toMillis(elapsed), 1000)
         yield* Effect.sleep(20).pipe(TestClock.withLive)
       })

--- a/packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts
+++ b/packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts
@@ -1,7 +1,7 @@
 import { NodeFileSystem } from "@effect/platform-node"
 import { SqliteClient } from "@effect/sql-sqlite-node"
 import { assert, describe, expect, it } from "@effect/vitest"
-import { Duration, Effect, Exit, FileSystem, Layer, Schedule } from "effect"
+import { Cause, Duration, Effect, Exit, FileSystem, Layer, Schedule } from "effect"
 import { TestClock } from "effect/testing"
 import {
   Runner,
@@ -48,7 +48,7 @@ describe("SqlRunnerStorage", () => {
           TestClock.withLive
         )
         assert(Exit.isFailure(exit))
-        assert.isAtLeast(Duration.toMillis(elapsed), 90)
+        assert(Cause.isTimeoutError(Cause.squash(exit.cause)))
         assert.isBelow(Duration.toMillis(elapsed), 1000)
         yield* Effect.sleep(20).pipe(TestClock.withLive)
       })

--- a/packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts
+++ b/packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts
@@ -4,6 +4,7 @@ import { assert, describe, expect, it } from "@effect/vitest"
 import { Cause, Duration, Effect, Exit, FileSystem, Layer, Schedule } from "effect"
 import { TestClock } from "effect/testing"
 import {
+  ClusterError,
   Runner,
   RunnerAddress,
   RunnerStorage,
@@ -48,7 +49,9 @@ describe("SqlRunnerStorage", () => {
           TestClock.withLive
         )
         assert(Exit.isFailure(exit))
-        assert(Cause.isTimeoutError(Cause.squash(exit.cause)))
+        const error = Cause.squash(exit.cause)
+        assert(error instanceof ClusterError.PersistenceError)
+        assert(Cause.isTimeoutError(error.cause))
         assert.isBelow(Duration.toMillis(elapsed), 1000)
         yield* Effect.sleep(20).pipe(TestClock.withLive)
       })


### PR DESCRIPTION
## Summary

A failed resource rebuild leaves the reference in `Acquiring` with its latch closed. Every subsequent `await` blocks because no failure path restores a terminal state or opens the latch.

> [!IMPORTANT]
> This PR includes focused regression coverage and the implementation fix.

## Failed ResourceRef rebuilds permanently block waiters

**Module:** `effect/unstable/cluster/internal/resourceRef`  
**Audit ID:** `effect-bcb23fa6a8f4bb8f`  
**Severity / confidence:** high / high

### What happens

A failed resource rebuild leaves the reference in `Acquiring` with its latch closed. Every subsequent `await` blocks because no failure path restores a terminal state or opens the latch.

### Why it happens

`rebuildUnsafe` closes the latch, installs `{ _tag: "Acquiring", scope }`, closes the previous scope, and runs the new acquisition. Only the success `flatMap` changes state to `Acquired` and opens the latch; an acquisition failure bypasses that block, leaving both the state and latch unchanged and the candidate scope unclosed.

### Expected behavior

Every rebuild exit must leave `ResourceRef` outside an unresolvable acquisition state: success publishes the new value and wakes waiters, while failure must close the candidate scope and wake waiters with a defined failure or recoverable state.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/unstable/cluster/internal/resourceRef.ts:66-98`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/cluster/internal/resourceRef.ts#L66-L98)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/cluster/internal/resourceRef.ts:66-98</code></summary>

```ts
  rebuildUnsafe(): Effect.Effect<void, E> {
    const s = this.state.current
    if (s._tag === "Closed") {
      return Effect.interrupt
    }
    const prevScope = s.scope
    const scope = Scope.makeUnsafe()
    this.latch.closeUnsafe()
    MutableRef.set(this.state, { _tag: "Acquiring", scope })
    return Effect.withFiber((fiber) => {
      internalInterruptors.add(fiber.id)
      return Scope.close(prevScope, Exit.void)
    }).pipe(
      Effect.andThen(this.acquire(scope)),
      Effect.flatMap((value) => {
        if (this.state.current._tag === "Closed") {
          return Effect.interrupt
        }
        MutableRef.set(this.state, { _tag: "Acquired", scope, value })
        return this.latch.open
      })
    )
  }

  await: Effect.Effect<A> = Effect.suspend(() => {
    const s = this.state.current
    if (s._tag === "Closed") {
      return Effect.interrupt
    } else if (s._tag === "Acquired") {
      return Effect.succeed(s.value)
    }
    return Effect.flatMap(this.latch.await, () => this.await)
  })
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/cluster/internal/resourceRef.ts#L66-L98)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/cluster/ResourceRef.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: Failed ResourceRef rebuilds permanently block waiters.

## Implementation

Failed rebuilds now close the candidate scope, publish a recoverable `Failed` state containing the original cause, and open the latch. Waiters observe that cause, and a later rebuild can recover successfully. The failure handler publishes state and opens the latch only while its candidate scope still owns the current `Acquiring` state, so stale rebuilds cannot overwrite a newer acquisition.

Validation:

```sh
pnpm test --run packages/effect/test/cluster/ResourceRef.test.ts
pnpm lint-fix
pnpm check
```

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-bcb23fa6a8f4bb8f`
- Fix: regression coverage plus the `ResourceRef` failure-state implementation

Closes EFF-511