### PR TITLE
Fix getAndUpdateSome targets the wrapper instead of its backing ref

### DIFF
--- a/.changeset/silly-dodos-update.md
+++ b/.changeset/silly-dodos-update.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `SynchronizedRef.getAndUpdateSome` to update its backing ref.

--- a/packages/effect/src/SynchronizedRef.ts
+++ b/packages/effect/src/SynchronizedRef.ts
@@ -226,7 +226,7 @@ export const getAndUpdateSome: {
 } = dual(
   2,
   <A>(self: SynchronizedRef<A>, pf: (a: A) => Option.Option<A>): Effect.Effect<A> =>
-    self.semaphore.withPermit(Ref.getAndUpdateSome(self, pf))
+    self.semaphore.withPermit(Ref.getAndUpdateSome(self.backing, pf))
 )
 
 /**

--- a/packages/effect/test/SynchronizedRef.test.ts
+++ b/packages/effect/test/SynchronizedRef.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@effect/vitest"
 import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
-import { Deferred, Effect, Exit, Fiber, pipe, SynchronizedRef } from "effect"
+import { Deferred, Effect, Exit, Fiber, Option, pipe, SynchronizedRef } from "effect"
 
 const current = "value"
 const update = "new value"
@@ -101,5 +101,12 @@ describe("SynchronizedRef", () => {
       yield* Fiber.interrupt(fiber)
       const result = yield* SynchronizedRef.updateAndGetEffect(ref, (_) => Effect.succeed(Closed))
       deepStrictEqual(result, Closed)
+    }))
+  it.effect("getAndUpdateSome updates the backing ref", () =>
+    Effect.gen(function*() {
+      const ref = yield* SynchronizedRef.make(1)
+      const previous = yield* SynchronizedRef.getAndUpdateSome(ref, (n) => Option.some(n + 1))
+      strictEqual(previous, 1)
+      strictEqual(yield* SynchronizedRef.get(ref), 2)
     }))
 })


### PR DESCRIPTION
## Summary

`SynchronizedRef.getAndUpdateSome` defects instead of applying a matching update because it reads `self.ref` from an object that stores its state in `self.backing`. The previous value is not returned and the backing ref remains unchanged.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## getAndUpdateSome targets the wrapper instead of its backing ref

**Module:** `effect/SynchronizedRef`  
**Audit ID:** `effect-c3d7ca100fa23bcf`  
**Severity / confidence:** high / high

### What happens

`SynchronizedRef.getAndUpdateSome` defects instead of applying a matching update because it reads `self.ref` from an object that stores its state in `self.backing`. The previous value is not returned and the backing ref remains unchanged.

### Why it happens

The method acquires `self.semaphore` and delegates to `Ref.getAndUpdateSome(self, pf)`. That helper dereferences `self.ref.current`, but `makeUnsafe` initializes only `self.backing` and `self.semaphore`, so the delegated operation accesses `current` through an undefined `ref` field.

### Expected behavior

`SynchronizedRef.getAndUpdateSome` must atomically return the previous `A` and write the `Option.some` value to `SynchronizedRef.backing` while holding its semaphore; `Option.none` must leave that backing value unchanged.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/SynchronizedRef.ts:223-230`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/SynchronizedRef.ts#L223-L230)

<details>
<summary>View problematic code at <code>packages/effect/src/SynchronizedRef.ts:223-230</code></summary>

```ts
export const getAndUpdateSome: {
  <A>(pf: (a: A) => Option.Option<A>): (self: SynchronizedRef<A>) => Effect.Effect<A>
  <A>(self: SynchronizedRef<A>, pf: (a: A) => Option.Option<A>): Effect.Effect<A>
} = dual(
  2,
  <A>(self: SynchronizedRef<A>, pf: (a: A) => Option.Option<A>): Effect.Effect<A> =>
    self.semaphore.withPermit(Ref.getAndUpdateSome(self, pf))
)
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/SynchronizedRef.ts#L223-L230)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/SynchronizedRef.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: getAndUpdateSome targets the wrapper instead of its backing ref.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/SynchronizedRef.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-c3d7ca100fa23bcf`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-510
