### PR TITLE
Fix runner streams do not terminate after terminal replies

### DIFF
--- a/.changeset/fix-runner-stream-completion.md
+++ b/.changeset/fix-runner-stream-completion.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+End runner streams after emitting their terminal replies.

--- a/packages/effect/src/unstable/cluster/RunnerServer.ts
+++ b/packages/effect/src/unstable/cluster/RunnerServer.ts
@@ -129,6 +129,9 @@ export const layerHandlers = Runners.Rpcs.toLayer(Effect.gen(function*() {
               return Reply.serialize(reply).pipe(
                 Effect.flatMap((reply) => {
                   Queue.offerUnsafe(queue, reply)
+                  if (reply._tag === "WithExit") {
+                    Queue.endUnsafe(queue)
+                  }
                   return Effect.void
                 }),
                 Effect.catchTag("MalformedMessage", (error) =>

--- a/packages/effect/test/cluster/RunnerServer.test.ts
+++ b/packages/effect/test/cluster/RunnerServer.test.ts
@@ -1,0 +1,72 @@
+import { assert, it } from "@effect/vitest"
+import { Effect, Fiber, Layer, Option, Queue, Schema, Stream } from "effect"
+import { TestClock } from "effect/testing"
+import {
+  ClusterSchema,
+  Entity,
+  EntityAddress,
+  EntityId,
+  EntityType,
+  type Envelope,
+  MessageStorage,
+  RunnerHealth,
+  Runners,
+  RunnerServer,
+  RunnerStorage,
+  Sharding,
+  ShardingConfig,
+  Snowflake
+} from "effect/unstable/cluster"
+import { Headers } from "effect/unstable/http"
+import { Rpc, RpcTest } from "effect/unstable/rpc"
+
+const ReproEntity = Entity.make("ReproRunnerServer", [
+  Rpc.make("ReproStream", { success: Schema.Int, payload: { id: Schema.Number }, stream: true })
+]).annotateRpcs(ClusterSchema.Persisted, false)
+
+const handlers = RunnerServer.layerHandlers.pipe(
+  Layer.provideMerge(ReproEntity.toLayer({ ReproStream: () => Stream.make(1) })),
+  Layer.provideMerge(Sharding.layer),
+  Layer.provideMerge(Snowflake.layerGenerator),
+  Layer.provide(RunnerStorage.layerMemory),
+  Layer.provide(RunnerHealth.layerNoop),
+  Layer.provide(Runners.layerNoop),
+  Layer.provideMerge(MessageStorage.layerMemory),
+  Layer.provide(ShardingConfig.layer({
+    entityMailboxCapacity: 10,
+    entityTerminationTimeout: 0,
+    entityMessagePollInterval: 5000,
+    sendRetryInterval: 100,
+    refreshAssignmentsInterval: 0
+  }))
+)
+
+it.effect("completes a successful runner stream", () =>
+  Effect.gen(function*() {
+    yield* TestClock.adjust(1)
+    const sharding = yield* Sharding.Sharding
+    const snowflake = yield* Snowflake.Generator
+    const entityId = EntityId.make("one")
+    const request = {
+      _tag: "Request",
+      requestId: snowflake.nextUnsafe(),
+      address: EntityAddress.make({
+        shardId: sharding.getShardId(entityId, ReproEntity.getShardGroup(entityId)),
+        entityType: EntityType.make("ReproRunnerServer"),
+        entityId
+      }),
+      tag: "ReproStream",
+      payload: { id: 1 },
+      headers: Headers.empty
+    } as Envelope.PartialRequest
+    const client = yield* RpcTest.makeClient(Runners.Rpcs)
+    const queue = yield* client.Stream({ request, persisted: false }, { asQueue: true })
+    const completion = yield* Queue.take(queue).pipe(
+      Effect.forever,
+      Effect.catchTag("Done", () => Effect.void),
+      Effect.timeoutOption(10),
+      Effect.forkChild
+    )
+    yield* TestClock.adjust(10)
+    assert.deepStrictEqual(yield* Fiber.join(completion), Option.some(undefined))
+  }).pipe(Effect.provide(handlers)))

--- a/packages/effect/test/cluster/RunnerServer.test.ts
+++ b/packages/effect/test/cluster/RunnerServer.test.ts
@@ -1,5 +1,5 @@
 import { assert, it } from "@effect/vitest"
-import { Effect, Fiber, Layer, Option, Queue, Schema, Stream } from "effect"
+import { Effect, Layer, Option, Queue, Schema, Stream } from "effect"
 import { TestClock } from "effect/testing"
 import {
   ClusterSchema,
@@ -7,7 +7,7 @@ import {
   EntityAddress,
   EntityId,
   EntityType,
-  type Envelope,
+  Envelope,
   MessageStorage,
   RunnerHealth,
   Runners,
@@ -61,12 +61,35 @@ it.effect("completes a successful runner stream", () =>
     } as Envelope.PartialRequest
     const client = yield* RpcTest.makeClient(Runners.Rpcs)
     const queue = yield* client.Stream({ request, persisted: false }, { asQueue: true })
-    const completion = yield* Queue.take(queue).pipe(
-      Effect.forever,
-      Effect.catchTag("Done", () => Effect.void),
-      Effect.timeoutOption(10),
-      Effect.forkChild
+    const first = yield* Queue.take(queue).pipe(
+      Effect.timeout("1 second"),
+      TestClock.withLive
     )
-    yield* TestClock.adjust(10)
-    assert.deepStrictEqual(yield* Fiber.join(completion), Option.some(undefined))
+    if (first._tag !== "Chunk") {
+      return assert.fail("expected the stream value before the terminal reply")
+    }
+    assert.deepStrictEqual(first.values, [1])
+
+    yield* client.Envelope({
+      envelope: new Envelope.AckChunk({
+        id: snowflake.nextUnsafe(),
+        address: request.address,
+        requestId: request.requestId,
+        replyId: Snowflake.Snowflake(first.id)
+      }),
+      persisted: false
+    })
+
+    const completion = yield* Effect.gen(function*() {
+      const last = yield* Queue.take(queue)
+      yield* Queue.take(queue).pipe(Effect.catchTag("Done", () => Effect.void))
+      return last
+    }).pipe(
+      Effect.timeoutOption("1 second"),
+      TestClock.withLive
+    )
+    if (Option.isNone(completion)) {
+      return assert.fail("expected the runner stream to complete")
+    }
+    assert.strictEqual(completion.value._tag, "WithExit")
   }).pipe(Effect.provide(handlers)))


### PR DESCRIPTION
## Summary

A successful streaming entity sends a terminal `WithExit` reply into the runner stream queue, but the queue remains open. Consumers receive the terminal reply and then wait indefinitely for another element.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Runner streams do not terminate after terminal replies

**Module:** `effect/unstable/cluster/RunnerServer`  
**Audit ID:** `effect-e9eb781f32ffb957`  
**Severity / confidence:** high / high

### What happens

A successful streaming entity sends a terminal `WithExit` reply into the runner stream queue, but the queue remains open. Consumers receive the terminal reply and then wait indefinitely for another element.

### Why it happens

The stream handler's `respond` callback serializes every reply and calls `Queue.offerUnsafe`. It calls `Queue.endUnsafe` only when serialization itself fails and a fallback defect reply is emitted; the normal `WithExit` branch has no terminal control flow even though `Reply` defines `WithExit` as final.

### Expected behavior

`WithExit` is the final reply for a clustered RPC request; after enqueuing it, the runner's streaming RPC queue must transition to its done state so remote stream consumers terminate normally.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/unstable/cluster/RunnerServer.ts:121-159`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/cluster/RunnerServer.ts#L121-L159)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/cluster/RunnerServer.ts:121-159</code></summary>

```ts
    Stream: ({ persisted, request }) =>
      Effect.flatMap(
        Queue.make<Reply.Encoded, ClusterError.EntityNotAssignedToRunner | Cause.Done>(),
        (queue) => {
          const message = new Message.IncomingRequest({
            envelope: request,
            lastSentReply: Option.none(),
            respond(reply) {
              return Reply.serialize(reply).pipe(
                Effect.flatMap((reply) => {
                  Queue.offerUnsafe(queue, reply)
                  return Effect.void
                }),
                Effect.catchTag("MalformedMessage", (error) =>
                  Effect.flatMap(serializeDefectReply(reply, error), (reply) => {
                    // the fallback defect reply is terminal, so end the stream
                    Queue.offerUnsafe(queue, reply)
                    Queue.endUnsafe(queue)
                    return Effect.void
                  }))
              )
            }
          })
          return Effect.as(
            persisted ?
              Effect.andThen(
                storage.registerReplyHandler(message).pipe(
                  Effect.onError((cause) =>
                    Queue.failCause(queue, cause)
                  ),
                  Effect.forkScoped
                ),
                sharding.notify(message, constWaitUntilRead)
              ) :
              sharding.send(message),
            queue
          )
        }
      ),
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/cluster/RunnerServer.ts#L121-L159)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/cluster/RunnerServerStreamCompletion.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: Runner streams do not terminate after terminal replies.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/cluster/RunnerServerStreamCompletion.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-e9eb781f32ffb957`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-509