### PR TITLE
Fix memory journal does not relay imported entries

### DIFF
--- a/.changeset/fix-memory-journal-relay.md
+++ b/.changeset/fix-memory-journal-relay.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Relay entries imported into an in-memory event journal to other remotes.

--- a/packages/effect/src/unstable/eventlog/EventJournal.ts
+++ b/packages/effect/src/unstable/eventlog/EventJournal.ts
@@ -451,11 +451,19 @@ export const makeMemory: Effect.Effect<EventJournal["Service"]> = Effect.gen(fun
       for (const remoteEntry of uncommittedRemotes) {
         journal.push(remoteEntry.entry)
         byId.set(remoteEntry.entry.idString, remoteEntry.entry)
+        remotes.forEach((target) => {
+          if (target !== remote) {
+            target.missing.push(remoteEntry.entry)
+          }
+        })
         if (remoteEntry.remoteSequence > remote.sequence) {
           remote.sequence = remoteEntry.remoteSequence
         }
       }
       journal.sort((a, b) => a.createdAtMillis - b.createdAtMillis)
+      remotes.forEach((remote) => {
+        remote.missing.sort((a, b) => a.createdAtMillis - b.createdAtMillis)
+      })
       return {
         duplicateEntries
       }

--- a/packages/effect/test/unstable/eventlog/EventJournal.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventJournal.test.ts
@@ -3,6 +3,27 @@ import { Effect } from "effect"
 import * as EventJournal from "effect/unstable/eventlog/EventJournal"
 
 describe("EventJournal", () => {
+  it.effect("relays an imported entry to another remote", () =>
+    Effect.gen(function*() {
+      const journal = yield* EventJournal.makeMemory
+      const source = EventJournal.makeRemoteIdUnsafe()
+      const target = EventJournal.makeRemoteIdUnsafe()
+      yield* journal.nextRemoteSequence(target)
+      const entry = new EventJournal.Entry({
+        id: EventJournal.makeEntryIdUnsafe(),
+        event: "Repro",
+        primaryKey: "key",
+        payload: new Uint8Array()
+      }, { disableChecks: true })
+      yield* journal.writeFromRemote({
+        remoteId: source,
+        entries: [new EventJournal.RemoteEntry({ remoteSequence: 0, entry })],
+        effect: () => Effect.void
+      })
+      const missing = yield* journal.withRemoteUncommited(target, Effect.succeed)
+      assert.deepStrictEqual(missing.map((item) => item.idString), [entry.idString])
+    }))
+
   it.effect("records entries in memory and publishes local changes", () =>
     Effect.gen(function*() {
       const journal = yield* EventJournal.EventJournal

--- a/packages/effect/test/unstable/eventlog/EventJournal.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventJournal.test.ts
@@ -22,6 +22,8 @@ describe("EventJournal", () => {
       })
       const missing = yield* journal.withRemoteUncommited(target, Effect.succeed)
       assert.deepStrictEqual(missing.map((item) => item.idString), [entry.idString])
+      const sourceMissing = yield* journal.withRemoteUncommited(source, Effect.succeed)
+      assert.deepStrictEqual(sourceMissing, [])
     }))
 
   it.effect("records entries in memory and publishes local changes", () =>


### PR DESCRIPTION
## Summary

The in-memory event journal now relays entries imported from one remote to every other registered remote. The source remote remains excluded, and each remote's pending entries stay ordered by journal timestamp.

The focused regression was reproduced before the implementation change and now passes. This PR also includes a patch changeset for `effect`.

## Testing

- `pnpm test --run packages/effect/test/unstable/eventlog/EventJournal.test.ts`
- `pnpm test --run packages/effect/test/unstable/eventlog`
- `pnpm lint`
- `pnpm check`

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Finding: `effect-f61b3cab494601d1`

Closes EFF-508