### PR TITLE
Fix response.failed loses its provider error

### DIFF
--- a/.changeset/fix-openai-response-failure.md
+++ b/.changeset/fix-openai-response-failure.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai": patch
+---
+
+Preserve OpenAI provider errors from failed response stream events.

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -1759,14 +1759,27 @@ const makeStreamResponse = Effect.fnUntraced(
           }
 
           case "response.completed":
-          case "response.incomplete":
-          case "response.failed": {
+          case "response.incomplete": {
             parts.push({
               type: "finish",
               reason: InternalUtilities.resolveFinishReason(
                 event.response.incomplete_details?.reason,
                 hasToolCalls
               ),
+              usage: getUsage(event.response.usage),
+              response: buildHttpResponseDetails(response),
+              ...toServiceTier(event.response.service_tier)
+            })
+            break
+          }
+
+          case "response.failed": {
+            if (event.response.error) {
+              parts.push({ type: "error", error: event.response.error })
+            }
+            parts.push({
+              type: "finish",
+              reason: "error",
               usage: getUsage(event.response.usage),
               response: buildHttpResponseDetails(response),
               ...toServiceTier(event.response.service_tier)

--- a/packages/ai/openai/src/OpenAiSchema.ts
+++ b/packages/ai/openai/src/OpenAiSchema.ts
@@ -830,6 +830,11 @@ const OutputItem = Schema.Union([
   WebSearchCall
 ])
 
+const ResponseError = Schema.Struct({
+  code: Schema.String,
+  message: Schema.String
+})
+
 /**
  * Schema for an OpenAI Responses API response object.
  *
@@ -858,6 +863,7 @@ export const Response = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed([]))
   ),
   usage: Schema.optionalKey(Schema.NullOr(ResponseUsage)),
+  error: Schema.optionalKey(Schema.NullOr(ResponseError)),
   incomplete_details: Schema.optionalKey(
     Schema.NullOr(
       Schema.Struct({

--- a/packages/ai/openai/test/OpenAiSchema.test.ts
+++ b/packages/ai/openai/test/OpenAiSchema.test.ts
@@ -1,5 +1,5 @@
+import { OpenAiClient, OpenAiLanguageModel } from "@effect/ai-openai"
 import * as OpenAiSchema from "@effect/ai-openai/OpenAiSchema"
-import { type Generated, OpenAiClient, OpenAiLanguageModel } from "@effect/ai-openai"
 import { assert, describe, it } from "@effect/vitest"
 import { Effect, Layer, Schema, Stream } from "effect"
 import { LanguageModel } from "effect/unstable/ai"
@@ -294,30 +294,49 @@ describe("OpenAiSchema", () => {
   })
 
   it.effect("exposes the response.failed error payload", () => {
-    const response = HttpClientResponse.fromWeb(HttpClientRequest.get("https://api.openai.com/v1/responses"), new Response())
-    const failed = {
-      id: "resp_1",
-      object: "response",
-      created_at: 1,
-      model: "gpt-4o-mini",
-      status: "failed",
-      output: [],
-      error: { code: "server_error", message: "provider exploded" }
-    }
-    const client = Layer.succeed(OpenAiClient.OpenAiClient, OpenAiClient.OpenAiClient.of({
-      client: undefined as any,
-      createResponse: () => Effect.die("unexpected"),
-      createResponseStream: () => Effect.succeed([
-        response,
-        Stream.make({ type: "response.failed", sequence_number: 1, response: failed } as any as Generated.ResponseStreamEvent)
-      ]),
-      createEmbedding: () => Effect.die("unexpected")
-    }))
+    const response = HttpClientResponse.fromWeb(
+      HttpClientRequest.get("https://api.openai.com/v1/responses"),
+      new Response()
+    )
+    const failed = Schema.decodeUnknownSync(OpenAiSchema.ResponseStreamEvent)({
+      type: "response.failed",
+      sequence_number: 1,
+      response: {
+        id: "resp_1",
+        object: "response",
+        created_at: 1,
+        model: "gpt-4o-mini",
+        status: "failed",
+        output: [],
+        error: { code: "server_error", message: "provider exploded" }
+      }
+    })
+    const client = Layer.succeed(
+      OpenAiClient.OpenAiClient,
+      OpenAiClient.OpenAiClient.of({
+        client: undefined as any,
+        createResponse: () => Effect.die("unexpected"),
+        createResponseStream: () =>
+          Effect.succeed([
+            response,
+            Stream.make(failed)
+          ]),
+        createEmbedding: () => Effect.die("unexpected")
+      })
+    )
 
     return LanguageModel.streamText({ prompt: "test" }).pipe(
       Stream.runCollect,
-      Effect.map((parts) => Array.from(parts).find((part) => part.type === "error")),
-      Effect.tap((error) => Effect.sync(() => assert.isDefined(error))),
+      Effect.tap((parts) =>
+        Effect.sync(() => {
+          const error = Array.from(parts).find((part) => part.type === "error")
+          const finish = Array.from(parts).find((part) => part.type === "finish")
+          assert.isDefined(error)
+          assert.deepStrictEqual(error.error, { code: "server_error", message: "provider exploded" })
+          assert.isDefined(finish)
+          assert.strictEqual(finish.reason, "error")
+        })
+      ),
       Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
       Effect.provide(client)
     )

--- a/packages/ai/openai/test/OpenAiSchema.test.ts
+++ b/packages/ai/openai/test/OpenAiSchema.test.ts
@@ -1,7 +1,10 @@
 import * as OpenAiSchema from "@effect/ai-openai/OpenAiSchema"
+import { type Generated, OpenAiClient, OpenAiLanguageModel } from "@effect/ai-openai"
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Schema, Stream } from "effect"
+import { Effect, Layer, Schema, Stream } from "effect"
+import { LanguageModel } from "effect/unstable/ai"
 import * as Sse from "effect/unstable/encoding/Sse"
+import { HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
 const makeResponse = (overrides: Record<string, unknown> = {}) => ({
   id: "resp_123",
@@ -288,5 +291,35 @@ describe("OpenAiSchema", () => {
 
     assert.strictEqual(numeric.data[0].embedding[0], 0.1)
     assert.strictEqual(base64.data[0].embedding, "AQID")
+  })
+
+  it.effect("exposes the response.failed error payload", () => {
+    const response = HttpClientResponse.fromWeb(HttpClientRequest.get("https://api.openai.com/v1/responses"), new Response())
+    const failed = {
+      id: "resp_1",
+      object: "response",
+      created_at: 1,
+      model: "gpt-4o-mini",
+      status: "failed",
+      output: [],
+      error: { code: "server_error", message: "provider exploded" }
+    }
+    const client = Layer.succeed(OpenAiClient.OpenAiClient, OpenAiClient.OpenAiClient.of({
+      client: undefined as any,
+      createResponse: () => Effect.die("unexpected"),
+      createResponseStream: () => Effect.succeed([
+        response,
+        Stream.make({ type: "response.failed", sequence_number: 1, response: failed } as any as Generated.ResponseStreamEvent)
+      ]),
+      createEmbedding: () => Effect.die("unexpected")
+    }))
+
+    return LanguageModel.streamText({ prompt: "test" }).pipe(
+      Stream.runCollect,
+      Effect.map((parts) => Array.from(parts).find((part) => part.type === "error")),
+      Effect.tap((error) => Effect.sync(() => assert.isDefined(error))),
+      Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+      Effect.provide(client)
+    )
   })
 })


### PR DESCRIPTION
## Summary

A valid `response.failed` stream event carrying `{ code, message }` is decoded and emitted as a normal `finish` part, so the stream can end with reason `stop` and no error part.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## response.failed loses its provider error

**Module:** `ai/openai/OpenAiSchema`  
**Audit ID:** `effect-0e3b1f668ed8bac7`  
**Severity / confidence:** high / high

### What happens

A valid `response.failed` stream event carrying `{ code, message }` is decoded and emitted as a normal `finish` part, so the stream can end with reason `stop` and no error part.

### Why it happens

The local `Response` schema used by `ResponseFailedEvent` omits `error`, so decoding drops it, and `makeStreamResponse` then shares one finish-only switch branch for `response.completed`, `response.incomplete`, and `response.failed`.

### Expected behavior

The OpenAI Responses streaming protocol's `ResponseFailedEvent` requires `response.error: ResponseError`; terminal failure handling must preserve that required provider payload for the language-model stream consumer.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/ai/openai/src/OpenAiSchema.ts:852-910`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/ai/openai/src/OpenAiSchema.ts#L852-L910)

<details>
<summary>View problematic code at <code>packages/ai/openai/src/OpenAiSchema.ts:852-901</code></summary>

```ts
export const Response = Schema.Struct({
  id: Schema.String,
  object: Schema.optionalKey(Schema.Literal("response")),
  model: Schema.String,
  created_at: Schema.Int,
  output: Schema.Array(OutputItem).pipe(
    Schema.withDecodingDefault(Effect.succeed([]))
  ),
  usage: Schema.optionalKey(Schema.NullOr(ResponseUsage)),
  incomplete_details: Schema.optionalKey(
    Schema.NullOr(
      Schema.Struct({
        reason: Schema.optionalKey(Schema.Literals(["max_output_tokens", "content_filter"]))
      })
    )
  ),
  service_tier: Schema.optionalKey(Schema.String)
})

/**
 * OpenAI Responses API response object.
 *
 * **When to use**
 *
 * Use when typing non-streaming OpenAI Responses API responses.
 *
 * **Details**
 *
 * Response objects include metadata, output items, optional token usage, and
 * optional incomplete details.
 *
 * @category models
 * @since 4.0.0
 */
export type Response = typeof Response.Type

const ResponseCreatedEvent = Schema.Struct({
  type: Schema.Literal("response.created"),
  response: Response,
  sequence_number: Schema.Int
})

const ResponseCompletedEvent = Schema.Struct({
  type: Schema.Literal("response.completed"),
  response: Response,
  sequence_number: Schema.Int
})

const ResponseIncompleteEvent = Schema.Struct({
  type: Schema.Literal("response.incomplete"),
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/ai/openai/src/OpenAiSchema.ts#L852-L910)

_Excerpt truncated. [Open the complete packages/ai/openai/src/OpenAiSchema.ts:852-910 range.](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/ai/openai/src/OpenAiSchema.ts#L852-L910)_

</details>

### Reproduction

```sh
pnpm test --run packages/ai/openai/test/Repro.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: response.failed loses its provider error.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/ai/openai/test/Repro.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-0e3b1f668ed8bac7`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-507