### PR TITLE
Fix sQL journal commits entries before callback success

### DIFF
--- a/.changeset/bright-journals-commit.md
+++ b/.changeset/bright-journals-commit.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Commit SQL event journal entries only after their write callback succeeds.

--- a/packages/effect/src/unstable/eventlog/SqlEventJournal.ts
+++ b/packages/effect/src/unstable/eventlog/SqlEventJournal.ts
@@ -220,10 +220,12 @@ export const make = (options?: {
             primaryKey,
             payload
           }, { disableChecks: true })
-          yield* insertEntry(toEntryRow(entry))
-          const value = yield* effect(entry)
-          yield* PubSub.publish(pubsub, entry)
-          return value
+          return yield* Effect.uninterruptibleMask((restore) =>
+            restore(effect(entry)).pipe(
+              Effect.tap(insertEntry(toEntryRow(entry))),
+              Effect.tap(PubSub.publish(pubsub, entry))
+            )
+          )
         },
         withTracerDisabled,
         Effect.mapError((cause) => new EventJournal.EventJournalError({ cause, method: "write" }))

--- a/packages/sql/sqlite-node/test/SqlEventJournal.test.ts
+++ b/packages/sql/sqlite-node/test/SqlEventJournal.test.ts
@@ -14,6 +14,19 @@ const makeJournal = Effect.gen(function*() {
 }).pipe(Effect.provide(Reactivity.layer))
 
 describe("SqlEventJournal", () => {
+  it.effect("commits only after the write callback succeeds", () =>
+    Effect.gen(function*() {
+      const sql = yield* SqliteClient.make({ filename: ":memory:" })
+      const journal = yield* SqlEventJournal.make().pipe(Effect.provideService(SqlClient.SqlClient, sql))
+      yield* Effect.exit(journal.write({
+        event: "Repro",
+        primaryKey: "key",
+        payload: new Uint8Array([1]),
+        effect: () => Effect.fail("callback failed")
+      }))
+      assert.deepStrictEqual(yield* journal.entries, [])
+    }).pipe(Effect.provide(Reactivity.layer)))
+
   it.effect("writes and reads entries", () =>
     Effect.gen(function*() {
       const journal = yield* makeJournal


### PR DESCRIPTION
## Summary

The SQL-backed local write inserts the new journal row before running its supplied effect. If that effect fails, the call fails but the row remains queryable as a committed event.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## SQL journal commits entries before callback success

**Module:** `effect/unstable/eventlog/SqlEventJournal`  
**Audit ID:** `effect-fbf492476d81f7ef`  
**Severity / confidence:** high / high

### What happens

The SQL-backed local write inserts the new journal row before running its supplied effect. If that effect fails, the call fails but the row remains queryable as a committed event.

### Why it happens

The SQL implementation executes `insertEntry(toEntryRow(entry))` and only then yields `effect(entry)`. `write` does not open a transaction of its own, so a direct call has no rollback boundary when the later effect fails; publication is skipped, but the earlier insert is already durable.

### Expected behavior

`EventJournal.write` must run its effect before committing the entry: only a successful effect may make the entry visible through `entries`, replay, or replication, and any effect failure must leave no committed row.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/unstable/eventlog/SqlEventJournal.ts:173-225`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/eventlog/SqlEventJournal.ts#L173-L225)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/eventlog/SqlEventJournal.ts:173-222</code></summary>

```ts
      if (entries.length > 0) {
        yield* insertEntries(entries.map(toEntryRow))
      }
      if (remoteRows.length > 0) {
        yield* insertRemotes(remoteRows)
      }

      const uncommitted = options.entries.filter((entry) => !existingIds.has(entry.entry.idString))
      const duplicateEntries = options.entries
        .filter((entry) => existingIds.has(entry.entry.idString))
        .map((entry) => entry.entry)
      const compacted = options.compact
        ? yield* options.compact(uncommitted)
        : uncommitted.map((remoteEntry) => remoteEntry.entry)

      for (const entry of compacted) {
        const conflicts = yield* sql`
            SELECT *
            FROM ${entryTableSql}
            WHERE event = ${entry.event} AND
                  primary_key = ${entry.primaryKey} AND
                  timestamp >= ${entry.createdAtMillis}
            ORDER BY timestamp ASC
          `.pipe(
          Effect.flatMap(decodeEntryRows),
          Effect.map(toEntries)
        )
        yield* options.effect({ entry, conflicts })
      }

      return {
        duplicateEntries
      }
    })

    return EventJournal.EventJournal.of({
      entries: sql`SELECT * FROM ${entryTableSql} ORDER BY timestamp ASC`.pipe(
        withTracerDisabled,
        Effect.flatMap(decodeEntryRows),
        Effect.map(toEntries),
        Effect.mapError((cause) => new EventJournal.EventJournalError({ cause, method: "entries" }))
      ),
      write: Effect.fnUntraced(
        function*({ effect, event, payload, primaryKey }) {
          const entry = new EventJournal.Entry({
            id: EventJournal.makeEntryIdUnsafe(),
            event,
            primaryKey,
            payload
          }, { disableChecks: true })
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/eventlog/SqlEventJournal.ts#L173-L225)

_Excerpt truncated. [Open the complete packages/effect/src/unstable/eventlog/SqlEventJournal.ts:173-225 range.](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/eventlog/SqlEventJournal.ts#L173-L225)_

</details>

### Reproduction

```sh
pnpm test --run packages/sql/sqlite-node/test/SqlJournalCallbackOrder.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: SQL journal commits entries before callback success.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/sql/sqlite-node/test/SqlJournalCallbackOrder.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-fbf492476d81f7ef`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-506