### PR TITLE
Fix node tracer shutdown is skipped after flush failure

### DIFF
--- a/.changeset/fix-opentelemetry-shutdown-after-flush.md
+++ b/.changeset/fix-opentelemetry-shutdown-after-flush.md
@@ -1,0 +1,5 @@
+---
+"@effect/opentelemetry": patch
+---
+
+Ensure OpenTelemetry providers shut down when flushing fails.

--- a/packages/opentelemetry/src/NodeSdk.ts
+++ b/packages/opentelemetry/src/NodeSdk.ts
@@ -74,7 +74,7 @@ export const layerTracerProvider = (
           return provider
         }),
         (provider) =>
-          Effect.promise(() => provider.forceFlush().then(() => provider.shutdown())).pipe(
+          Effect.promise(() => provider.forceFlush().finally(() => provider.shutdown())).pipe(
             Effect.ignore,
             Effect.interruptible,
             Effect.timeoutOption(config?.shutdownTimeout ?? 3000)

--- a/packages/opentelemetry/src/OtelLogger.ts
+++ b/packages/opentelemetry/src/OtelLogger.ts
@@ -184,7 +184,7 @@ export const layerLoggerProvider = (
           })
         ),
         (provider) =>
-          Effect.promise(() => provider.forceFlush().then(() => provider.shutdown())).pipe(
+          Effect.promise(() => provider.forceFlush().finally(() => provider.shutdown())).pipe(
             Effect.ignore,
             Effect.interruptible,
             Effect.timeoutOption(config?.shutdownTimeout ?? 3000)

--- a/packages/opentelemetry/src/WebSdk.ts
+++ b/packages/opentelemetry/src/WebSdk.ts
@@ -70,7 +70,7 @@ export const layerTracerProvider = (
         }),
         (provider) =>
           Effect.ignore(
-            Effect.promise(() => provider.forceFlush().then(() => provider.shutdown()))
+            Effect.promise(() => provider.forceFlush().finally(() => provider.shutdown()))
           )
       )
     })

--- a/packages/opentelemetry/test/NodeSdk.test.ts
+++ b/packages/opentelemetry/test/NodeSdk.test.ts
@@ -14,9 +14,19 @@ it.effect("shuts down the Node provider after forceFlush rejects", () =>
       shutdowns++
       return Promise.resolve()
     }
-    const processor = { onStart() {}, onEnd() {}, shutdown: async () => {}, forceFlush: async () => {} } as any
-    yield* Effect.exit(Effect.scoped(Layer.build(NodeSdk.layerTracerProvider(processor)).pipe(Effect.provide(Resource.layerEmpty))))
-    NodeTracerProvider.prototype.forceFlush = originalFlush
-    NodeTracerProvider.prototype.shutdown = originalShutdown
+    const processor = {
+      onStart() {},
+      onEnd() {},
+      shutdown: () => Promise.resolve(),
+      forceFlush: () => Promise.resolve()
+    } as any
+    yield* Effect.exit(
+      Effect.scoped(Layer.build(NodeSdk.layerTracerProvider(processor)).pipe(Effect.provide(Resource.layerEmpty)))
+    ).pipe(
+      Effect.ensuring(Effect.sync(() => {
+        NodeTracerProvider.prototype.forceFlush = originalFlush
+        NodeTracerProvider.prototype.shutdown = originalShutdown
+      }))
+    )
     assert.strictEqual(shutdowns, 1)
   }))

--- a/packages/opentelemetry/test/NodeSdk.test.ts
+++ b/packages/opentelemetry/test/NodeSdk.test.ts
@@ -1,0 +1,22 @@
+import * as NodeSdk from "@effect/opentelemetry/NodeSdk"
+import * as Resource from "@effect/opentelemetry/Resource"
+import { assert, it } from "@effect/vitest"
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node"
+import { Effect, Layer } from "effect"
+
+it.effect("shuts down the Node provider after forceFlush rejects", () =>
+  Effect.gen(function*() {
+    let shutdowns = 0
+    const originalFlush = NodeTracerProvider.prototype.forceFlush
+    const originalShutdown = NodeTracerProvider.prototype.shutdown
+    NodeTracerProvider.prototype.forceFlush = () => Promise.reject(new Error("flush failed"))
+    NodeTracerProvider.prototype.shutdown = () => {
+      shutdowns++
+      return Promise.resolve()
+    }
+    const processor = { onStart() {}, onEnd() {}, shutdown: async () => {}, forceFlush: async () => {} } as any
+    yield* Effect.exit(Effect.scoped(Layer.build(NodeSdk.layerTracerProvider(processor)).pipe(Effect.provide(Resource.layerEmpty))))
+    NodeTracerProvider.prototype.forceFlush = originalFlush
+    NodeTracerProvider.prototype.shutdown = originalShutdown
+    assert.strictEqual(shutdowns, 1)
+  }))


### PR DESCRIPTION
## Summary

When a Node tracer provider's `forceFlush()` rejects during layer release, its `shutdown()` method is never called even though the scoped layer completes its finalizer.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Node tracer shutdown is skipped after flush failure

**Module:** `opentelemetry/NodeSdk`  
**Audit ID:** `effect-0111ed64f66fad3e`  
**Severity / confidence:** medium / high

### What happens

When a Node tracer provider's `forceFlush()` rejects during layer release, its `shutdown()` method is never called even though the scoped layer completes its finalizer.

### Why it happens

The finalizer places `provider.shutdown()` in the fulfillment callback of `provider.forceFlush().then(...)`; a rejected flush skips that callback, and the later `Effect.ignore` only suppresses the rejection.

### Expected behavior

`layerTracerProvider` documents a scoped provider that is shut down when the layer is released; provider `forceFlush()` and `shutdown()` are separate lifecycle operations, so release-time shutdown remains required after a flush failure.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/opentelemetry/src/NodeSdk.ts:76-81`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/opentelemetry/src/NodeSdk.ts#L76-L81)

<details>
<summary>View problematic code at <code>packages/opentelemetry/src/NodeSdk.ts:76-81</code></summary>

```ts
        (provider) =>
          Effect.promise(() => provider.forceFlush().then(() => provider.shutdown())).pipe(
            Effect.ignore,
            Effect.interruptible,
            Effect.timeoutOption(config?.shutdownTimeout ?? 3000)
          )
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/opentelemetry/src/NodeSdk.ts#L76-L81)

</details>

### Reproduction

```sh
pnpm test --run packages/opentelemetry/test/Repro.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: Node tracer shutdown is skipped after flush failure.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/opentelemetry/test/Repro.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-0111ed64f66fad3e`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-505