### PR TITLE
Fix logger shutdown is skipped after flush failure

### DIFF
--- a/.changeset/fix-otel-logger-shutdown.md
+++ b/.changeset/fix-otel-logger-shutdown.md
@@ -1,0 +1,5 @@
+---
+"@effect/opentelemetry": patch
+---
+
+Ensure logger providers shut down when flushing fails.

--- a/packages/opentelemetry/src/OtelLogger.ts
+++ b/packages/opentelemetry/src/OtelLogger.ts
@@ -184,7 +184,7 @@ export const layerLoggerProvider = (
           })
         ),
         (provider) =>
-          Effect.promise(() => provider.forceFlush().then(() => provider.shutdown())).pipe(
+          Effect.promise(() => provider.forceFlush().finally(() => provider.shutdown())).pipe(
             Effect.ignore,
             Effect.interruptible,
             Effect.timeoutOption(config?.shutdownTimeout ?? 3000)

--- a/packages/opentelemetry/test/OtelLogger.test.ts
+++ b/packages/opentelemetry/test/OtelLogger.test.ts
@@ -1,7 +1,9 @@
 import * as NodeSdk from "@effect/opentelemetry/NodeSdk"
+import * as OtelLogger from "@effect/opentelemetry/OtelLogger"
+import * as Resource from "@effect/opentelemetry/Resource"
 import { assert, describe, it } from "@effect/vitest"
 import { SeverityNumber } from "@opentelemetry/api-logs"
-import { InMemoryLogRecordExporter, SimpleLogRecordProcessor } from "@opentelemetry/sdk-logs"
+import { InMemoryLogRecordExporter, LoggerProvider, SimpleLogRecordProcessor } from "@opentelemetry/sdk-logs"
 import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base"
 import * as Clock from "effect/Clock"
 import * as Effect from "effect/Effect"
@@ -9,6 +11,25 @@ import * as Layer from "effect/Layer"
 import * as References from "effect/References"
 
 describe("Logger", () => {
+  it.effect("shuts down the logger provider after forceFlush rejects", () =>
+    Effect.gen(function*() {
+      let shutdowns = 0
+      const originalFlush = LoggerProvider.prototype.forceFlush
+      const originalShutdown = LoggerProvider.prototype.shutdown
+      LoggerProvider.prototype.forceFlush = () => Promise.reject(new Error("flush failed"))
+      LoggerProvider.prototype.shutdown = () => {
+        shutdowns++
+        return Promise.resolve()
+      }
+      const processor = { onEmit() {}, shutdown: async () => {}, forceFlush: async () => {} } as any
+      yield* Effect.exit(
+        Effect.scoped(Layer.build(OtelLogger.layerLoggerProvider(processor)).pipe(Effect.provide(Resource.layerEmpty)))
+      )
+      LoggerProvider.prototype.forceFlush = originalFlush
+      LoggerProvider.prototype.shutdown = originalShutdown
+      assert.strictEqual(shutdowns, 1)
+    }))
+
   describe("provided", () => {
     const exporter = new InMemoryLogRecordExporter()
 

--- a/packages/opentelemetry/test/OtelLogger.test.ts
+++ b/packages/opentelemetry/test/OtelLogger.test.ts
@@ -3,7 +3,7 @@ import * as OtelLogger from "@effect/opentelemetry/OtelLogger"
 import * as Resource from "@effect/opentelemetry/Resource"
 import { assert, describe, it } from "@effect/vitest"
 import { SeverityNumber } from "@opentelemetry/api-logs"
-import { InMemoryLogRecordExporter, LoggerProvider, SimpleLogRecordProcessor } from "@opentelemetry/sdk-logs"
+import { InMemoryLogRecordExporter, type LogRecordProcessor, SimpleLogRecordProcessor } from "@opentelemetry/sdk-logs"
 import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base"
 import * as Clock from "effect/Clock"
 import * as Effect from "effect/Effect"
@@ -14,19 +14,17 @@ describe("Logger", () => {
   it.effect("shuts down the logger provider after forceFlush rejects", () =>
     Effect.gen(function*() {
       let shutdowns = 0
-      const originalFlush = LoggerProvider.prototype.forceFlush
-      const originalShutdown = LoggerProvider.prototype.shutdown
-      LoggerProvider.prototype.forceFlush = () => Promise.reject(new Error("flush failed"))
-      LoggerProvider.prototype.shutdown = () => {
-        shutdowns++
-        return Promise.resolve()
+      const processor: LogRecordProcessor = {
+        onEmit() {},
+        forceFlush: () => Promise.reject(new Error("flush failed")),
+        shutdown: () => {
+          shutdowns++
+          return Promise.resolve()
+        }
       }
-      const processor = { onEmit() {}, shutdown: async () => {}, forceFlush: async () => {} } as any
       yield* Effect.exit(
         Effect.scoped(Layer.build(OtelLogger.layerLoggerProvider(processor)).pipe(Effect.provide(Resource.layerEmpty)))
       )
-      LoggerProvider.prototype.forceFlush = originalFlush
-      LoggerProvider.prototype.shutdown = originalShutdown
       assert.strictEqual(shutdowns, 1)
     }))
 


### PR DESCRIPTION
## Summary

If the OpenTelemetry logger provider rejects `forceFlush()` during layer release, `shutdown()` is not invoked even though release proceeds without surfacing the flush error.

## Logger shutdown is skipped after flush failure

**Module:** `opentelemetry/OtelLogger`  
**Audit ID:** `effect-04538106c479b0d9`  
**Severity / confidence:** medium / high

### What happens

If the OpenTelemetry logger provider rejects `forceFlush()` during layer release, `shutdown()` is not invoked even though release proceeds without surfacing the flush error.

### Why it happens

The finalizer chains `provider.shutdown()` only through `provider.forceFlush().then(...)`, so rejection prevents shutdown, while the surrounding `Effect.ignore` merely discards the chain's failure.

### Expected behavior

`layerLoggerProvider` documents flushing and shutting down its scoped logger provider when the layer is released; `LoggerProvider.forceFlush()` and `shutdown()` are distinct lifecycle methods.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/opentelemetry/src/OtelLogger.ts:186-191`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/opentelemetry/src/OtelLogger.ts#L186-L191)

<details>
<summary>View problematic code at <code>packages/opentelemetry/src/OtelLogger.ts:186-191</code></summary>

```ts
        (provider) =>
          Effect.promise(() => provider.forceFlush().then(() => provider.shutdown())).pipe(
            Effect.ignore,
            Effect.interruptible,
            Effect.timeoutOption(config?.shutdownTimeout ?? 3000)
          )
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/opentelemetry/src/OtelLogger.ts#L186-L191)

</details>

### Reproduction

```sh
pnpm test --run packages/opentelemetry/test/OtelLogger.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: Logger shutdown is skipped after flush failure.

## Implementation

The logger provider finalizer now runs `shutdown()` from `Promise.finally()`, so shutdown occurs whether `forceFlush()` fulfills or rejects. The regression test exercises the injected log record processor directly and verifies its shutdown method is reached after a flush rejection.

### Validation

- `pnpm test --run packages/opentelemetry/test`
- `pnpm lint`
- `pnpm check`

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-04538106c479b0d9`
- Fix commit: `e71a762f00e58d26a5153c7f4203d626d9df4639`

Closes EFF-504