### PR TITLE
Fix tuple.pick types reorder and deduplicate requested indexes

### DIFF
--- a/.changeset/calm-tuples-pick.md
+++ b/.changeset/calm-tuples-pick.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Tuple.pick` return types to preserve the requested index order and duplicate indices.

--- a/packages/effect/src/Tuple.ts
+++ b/packages/effect/src/Tuple.ts
@@ -90,7 +90,9 @@ type _BuildTuple<
     [...I, unknown]
   >
 
-type PickTuple<T extends ReadonlyArray<unknown>, K> = _BuildTuple<T, K>
+type PickTuple<T extends ReadonlyArray<unknown>, I extends ReadonlyArray<Indices<T>>> = {
+  -readonly [K in keyof I]: T[I[K] & keyof T]
+}
 
 /**
  * Creates a new tuple containing only the elements at the specified indices.
@@ -119,11 +121,11 @@ type PickTuple<T extends ReadonlyArray<unknown>, K> = _BuildTuple<T, K>
 export const pick: {
   <const T extends ReadonlyArray<unknown>, const I extends ReadonlyArray<Indices<T>>>(
     indices: I
-  ): (self: T) => PickTuple<T, I[number]>
+  ): (self: T) => PickTuple<T, I>
   <const T extends ReadonlyArray<unknown>, const I extends ReadonlyArray<Indices<T>>>(
     self: T,
     indices: I
-  ): PickTuple<T, I[number]>
+  ): PickTuple<T, I>
 } = dual(
   2,
   <const T extends ReadonlyArray<unknown>>(

--- a/packages/effect/typetest/Tuple.tst.ts
+++ b/packages/effect/typetest/Tuple.tst.ts
@@ -54,6 +54,10 @@ describe("Tuple", () => {
     it("data-last", () => {
       expect(pipe(tuple, Tuple.pick([0, 2]))).type.toBe<[string, boolean]>()
     })
+
+    it("preserves index order and duplicates", () => {
+      expect(Tuple.pick(tuple, [2, 0, 2])).type.toBe<[boolean, string, boolean]>()
+    })
   })
 
   describe("omit", () => {


### PR DESCRIPTION
## Summary

`Tuple.pick(tuple, [2, 0, 2])` returns positions in that exact order at runtime but is typed in source-tuple order with duplicates removed. The static result shape does not describe either reordered selections or repeated indices.

> [!IMPORTANT]
> This PR includes focused regression tests and the implementation fix.

## Tuple.pick types reorder and deduplicate requested indexes

**Module:** `effect/Tuple`  
**Audit ID:** `effect-156f13a1f711bdf1`  
**Severity / confidence:** medium / high

### What happens

`Tuple.pick(tuple, [2, 0, 2])` returns positions in that exact order at runtime but is typed in source-tuple order with duplicates removed. The static result shape does not describe either reordered selections or repeated indices.

### Why it happens

Runtime code executes `indices.map((i) => self[i])`. The `PickTuple` type instead reduces over `T` from index zero upward and tests membership in the union `I[number]`, which erases order and duplicate occurrences before constructing the output tuple.

### Expected behavior

`Tuple.pick<T, I>` must map every index in tuple `I` to `T[I[K]]`, preserving the index tuple's order and multiplicity in the result type.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/Tuple.ts:79-134`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Tuple.ts#L79-L134)

<details>
<summary>View problematic code at <code>packages/effect/src/Tuple.ts:79-128</code></summary>

````ts
type _BuildTuple<
  T extends ReadonlyArray<unknown>,
  K,
  Acc extends ReadonlyArray<unknown> = [],
  I extends ReadonlyArray<unknown> = [] // current index counter
> = I["length"] extends T["length"] ? Acc
  : _BuildTuple<
    T,
    K,
    // If current index is in K, keep the element; otherwise skip it
    I["length"] extends K ? [...Acc, T[I["length"]]] : Acc,
    [...I, unknown]
  >

type PickTuple<T extends ReadonlyArray<unknown>, K> = _BuildTuple<T, K>

/**
 * Creates a new tuple containing only the elements at the specified indices.
 *
 * **When to use**
 *
 * Use to select a subset of elements from a tuple by position.
 *
 * **Details**
 *
 * The result order matches the order of the provided indices.
 *
 * **Example** (Selecting elements by index)
 *
 * ```ts import.meta.vitest
 * import { Tuple } from "effect"
 *
 * Tuple.pick(["a", "b", "c", "d"], [0, 2, 3]) // => ["a", "c", "d"]
 * ```
 *
 * @see {@link omit} – the inverse (exclude indices instead)
 * @see {@link get} – extract a single element
 * @category filtering
 * @since 4.0.0
 */
export const pick: {
  <const T extends ReadonlyArray<unknown>, const I extends ReadonlyArray<Indices<T>>>(
    indices: I
  ): (self: T) => PickTuple<T, I[number]>
  <const T extends ReadonlyArray<unknown>, const I extends ReadonlyArray<Indices<T>>>(
    self: T,
    indices: I
  ): PickTuple<T, I[number]>
} = dual(
  2,
````

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Tuple.ts#L79-L134)

_Excerpt truncated. [Open the complete packages/effect/src/Tuple.ts:79-134 range.](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Tuple.ts#L79-L134)_

</details>

### Reproduction

```sh
pnpm test-types packages/effect/typetest/Tuple.tst.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: Tuple.pick types reorder and deduplicate requested indexes.

## Implementation handoff

The focused reproduction tests on this branch are the regression specification for the implementation fix included in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test-types packages/effect/typetest/Tuple.tst.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-156f13a1f711bdf1`
- Initial patch: focused reproduction tests; implementation fix included

Closes EFF-503