### PR TITLE
Fix sSE accepts malformed retry directives

### DIFF
--- a/.changeset/fix-sse-retry-directives.md
+++ b/.changeset/fix-sse-retry-directives.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Ignore malformed retry directives when parsing server-sent event streams.

--- a/packages/effect/src/unstable/encoding/Sse.ts
+++ b/packages/effect/src/unstable/encoding/Sse.ts
@@ -396,11 +396,9 @@ export function makeParser(onParse: (event: AnyEvent) => void, options?: DecodeO
       eventName = value
     } else if (field === "id" && !value.includes("\u0000")) {
       lastEventId = value
-    } else if (field === "retry") {
+    } else if (field === "retry" && /^\d+$/.test(value)) {
       const retry = parseInt(value, 10)
-      if (!Number.isNaN(retry)) {
-        onParse(new Retry({ duration: Duration.millis(retry), lastEventId }))
-      }
+      onParse(new Retry({ duration: Duration.millis(retry), lastEventId }))
     }
   }
 }

--- a/packages/effect/test/unstable/encoding/Sse.test.ts
+++ b/packages/effect/test/unstable/encoding/Sse.test.ts
@@ -75,6 +75,15 @@ describe("Sse", () => {
     assert.strictEqual((events[0] as Sse.Event).event, "message")
   })
 
+  it("ignores retry values that are not ASCII digits", () => {
+    const events: Array<Sse.AnyEvent> = []
+    for (const value of ["123x", "+123", "-123", "1.5"]) {
+      Sse.makeParser((event) => events.push(event)).feed(`retry: ${value}\n`)
+    }
+
+    assert.deepStrictEqual(events, [])
+  })
+
   it("Event preserves string payloads", () => {
     const decode = Schema.decodeUnknownSync(Sse.Event)
     const encode = Schema.encodeSync(Sse.Event)


### PR DESCRIPTION
## Summary

The SSE parser accepts retry values `123x`, `+123`, `-123`, and `1.5` and emits Retry values of 123, 123, -123, and 1 milliseconds respectively.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## SSE accepts malformed retry directives

**Module:** `effect/unstable/encoding/Sse`  
**Audit ID:** `effect-1b834578333e2c6c`  
**Severity / confidence:** medium / high

### What happens

The SSE parser accepts retry values `123x`, `+123`, `-123`, and `1.5` and emits Retry values of 123, 123, -123, and 1 milliseconds respectively.

### Why it happens

The retry branch uses `parseInt(value, 10)` and checks only for NaN, so signs and numeric prefixes are accepted and trailing non-digits or fractional text are discarded.

### Expected behavior

The HTML Server-Sent Events algorithm applies a retry field only when its value consists entirely of ASCII digits; every other retry value must be ignored.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/unstable/encoding/Sse.ts:399-403`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/encoding/Sse.ts#L399-L403)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/encoding/Sse.ts:399-403</code></summary>

```ts
    } else if (field === "retry") {
      const retry = parseInt(value, 10)
      if (!Number.isNaN(retry)) {
        onParse(new Retry({ duration: Duration.millis(retry), lastEventId }))
      }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/encoding/Sse.ts#L399-L403)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/encoding/Sse.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: SSE accepts malformed retry directives.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/encoding/Sse.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-1b834578333e2c6c`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-502