### PR TITLE
Fix a failing request-body stream leaves the Node client hanging

### DIFF
--- a/.changeset/fix-node-http-stream-failure.md
+++ b/.changeset/fix-node-http-stream-failure.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node": patch
+---
+
+Fix Node HTTP client requests hanging when a streamed request body fails.

--- a/packages/platform-node/src/NodeHttpClient.ts
+++ b/packages/platform-node/src/NodeHttpClient.ts
@@ -455,8 +455,11 @@ export const makeNodeHttp = Effect.gen(function*() {
         headers: request.headers,
         signal
       })
-    return Effect.forkChild(sendBody(nodeRequest, request, request.body)).pipe(
-      Effect.flatMap(() => waitForResponse(nodeRequest, request)),
+    return Effect.raceFirst(
+      waitForResponse(nodeRequest, request),
+      sendBody(nodeRequest, request, request.body).pipe(Effect.andThen(Effect.never))
+    ).pipe(
+      Effect.onError(() => Effect.sync(() => nodeRequest.destroy())),
       Effect.map((_) => new NodeHttpResponse(request, _))
     )
   })

--- a/packages/platform-node/test/NodeHttpClient.test.ts
+++ b/packages/platform-node/test/NodeHttpClient.test.ts
@@ -1,6 +1,6 @@
 import { NodeHttpServer } from "@effect/platform-node"
 import * as NodeClient from "@effect/platform-node/NodeHttpClient"
-import { describe, expect, it } from "@effect/vitest"
+import { assert, describe, expect, it } from "@effect/vitest"
 import { Struct } from "effect"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
@@ -186,9 +186,12 @@ it.live("returns a stream body encoding failure", () =>
       yield* request.text
       return HttpServerResponse.empty()
     }).pipe(HttpServer.serveEffect())
-    yield* HttpClient.post("/", {
+    const error = yield* HttpClient.post("/", {
       body: HttpBody.stream(Stream.fail("encode failure"))
-    }).pipe(Effect.timeout("100 millis"))
+    }).pipe(Effect.timeout("1 second"), Effect.flip)
+    assert(error._tag === "HttpClientError")
+    assert.strictEqual(error.reason._tag, "EncodeError")
+    assert.strictEqual(error.reason.cause, "encode failure")
   }).pipe(Effect.provide(HttpServer.layerTestClient.pipe(
     Layer.provide(NodeClient.layerNodeHttp),
     Layer.provideMerge(NodeHttpServer.layer(Http.createServer, { port: 0 }))

--- a/packages/platform-node/test/NodeHttpClient.test.ts
+++ b/packages/platform-node/test/NodeHttpClient.test.ts
@@ -8,6 +8,7 @@ import * as Layer from "effect/Layer"
 import * as Schema from "effect/Schema"
 import * as Stream from "effect/Stream"
 import {
+  HttpBody,
   HttpClient,
   HttpClientRequest,
   HttpClientResponse,
@@ -177,6 +178,21 @@ const LocalServerRoutes = HttpRouter.serve(HttpRouter.addAll([
       }).pipe(Effect.provide(layer), flaky))
   })
 })
+
+it.live("returns a stream body encoding failure", () =>
+  Effect.gen(function*() {
+    yield* Effect.gen(function*() {
+      const request = yield* HttpServerRequest.HttpServerRequest
+      yield* request.text
+      return HttpServerResponse.empty()
+    }).pipe(HttpServer.serveEffect())
+    yield* HttpClient.post("/", {
+      body: HttpBody.stream(Stream.fail("encode failure"))
+    }).pipe(Effect.timeout("100 millis"))
+  }).pipe(Effect.provide(HttpServer.layerTestClient.pipe(
+    Layer.provide(NodeClient.layerNodeHttp),
+    Layer.provideMerge(NodeHttpServer.layer(Http.createServer, { port: 0 }))
+  ))))
 
 const flaky = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   effect.pipe(


### PR DESCRIPTION
## Summary

The `node:http` client can wait indefinitely for a response after its streaming request body has failed to encode.

> [!IMPORTANT]
> This PR includes focused regression coverage and the implementation fix.

## A failing request-body stream leaves the Node client hanging

**Module:** `platform-node/NodeHttpClient`  
**Audit ID:** `effect-2391e2d062db03e2`  
**Severity / confidence:** medium / high

### What happens

The `node:http` client can wait indefinitely for a response after its streaming request body has failed to encode.

### Why it happens

`makeNodeHttp` starts `sendBody(...)` with `Effect.forkChild`, discards the returned fiber, and immediately waits in `waitForResponse`. If `body.stream` fails, the child fiber gets the mapped `EncodeError`, but the parent neither joins that exit nor ends the `ClientRequest`; a server waiting for the request body sends no response, so the parent remains suspended.

### Expected behavior

The stream branch of `sendBody` maps upstream body failures to `HttpClientError.EncodeError`, and `HttpClient.execute` must complete with that declared error rather than lose progress when request transmission fails.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/platform-node/src/NodeHttpClient.ts:458-518`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/platform-node/src/NodeHttpClient.ts#L458-L518)

<details>
<summary>View problematic code at <code>packages/platform-node/src/NodeHttpClient.ts:458-507</code></summary>

```ts
    return Effect.forkChild(sendBody(nodeRequest, request, request.body)).pipe(
      Effect.flatMap(() => waitForResponse(nodeRequest, request)),
      Effect.map((_) => new NodeHttpResponse(request, _))
    )
  })
})

const sendBody = (
  nodeRequest: Http.ClientRequest,
  request: HttpClientRequest,
  body: Body.HttpBody
): Effect.Effect<void, Error.HttpClientError> =>
  Effect.suspend((): Effect.Effect<void, Error.HttpClientError> => {
    switch (body._tag) {
      case "Empty": {
        nodeRequest.end()
        return waitForFinish(nodeRequest, request)
      }
      case "Uint8Array":
      case "Raw": {
        nodeRequest.end(body.body)
        return waitForFinish(nodeRequest, request)
      }
      case "FormData": {
        const response = new globalThis.Response(body.formData)

        response.headers.forEach((value, key) => {
          nodeRequest.setHeader(key, value)
        })

        return Effect.tryPromise({
          try: () => pipeline(Readable.fromWeb(response.body! as any), nodeRequest),
          catch: (cause) =>
            new Error.HttpClientError({
              reason: new Error.TransportError({
                request,
                cause
              })
            })
        })
      }
      case "Stream": {
        return Stream.run(
          Stream.mapError(body.stream, (cause) =>
            new Error.HttpClientError({
              reason: new Error.EncodeError({
                request,
                cause
              })
            })),
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/platform-node/src/NodeHttpClient.ts#L458-L518)

_Excerpt truncated. [Open the complete packages/platform-node/src/NodeHttpClient.ts:458-518 range.](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/platform-node/src/NodeHttpClient.ts#L458-L518)_

</details>

### Reproduction

```sh
pnpm test --run packages/platform-node/test/NodeHttpClient.test.ts -t "returns a stream body encoding failure"
```

**Pre-fix result:** The focused contract assertion timed out against 17f0b91a, demonstrating the hanging request.

## Implementation

The Node client now races response arrival against request-body transmission. Successful body transmission continues waiting for the response, while a body failure terminates the request with the mapped encoding error and closes the underlying Node request.

## Validation

```sh
pnpm test --run packages/platform-node/test/NodeHttpClient.test.ts
pnpm lint-fix
pnpm check
```

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-2391e2d062db03e2`
- Initial patch: focused reproduction test; implementation fix included in this PR

Closes EFF-501