### PR TITLE
Fix schedule omits the schedule error from its return type

### DIFF
--- a/.changeset/fix-effect-schedule-errors.md
+++ b/.changeset/fix-effect-schedule-errors.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Include schedule errors in the error channel of `Effect.schedule` and `Effect.scheduleFrom`.

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -7717,15 +7717,15 @@ export const replicateEffect: {
 export const schedule: {
   <Output, Error, Env>(
     schedule: Schedule<Output, unknown, Error, Env>
-  ): <A, E, R>(self: Effect<A, E, R>) => Effect<Output, E, R | Env>
+  ): <A, E, R>(self: Effect<A, E, R>) => Effect<Output, E | Error, R | Env>
   <A, E, R, Output, Error, Env>(
     self: Effect<A, E, R>,
     schedule: Schedule<Output, unknown, Error, Env>
-  ): Effect<Output, E, R | Env>
+  ): Effect<Output, E | Error, R | Env>
 } = dual(2, <A, E, R, Output, Error, Env>(
   self: Effect<A, E, R>,
   schedule: Schedule<Output, unknown, Error, Env>
-): Effect<Output, E, R | Env> => scheduleFrom(self, undefined, schedule))
+): Effect<Output, E | Error, R | Env> => scheduleFrom(self, undefined, schedule))
 
 /**
  * Runs an effect repeatedly according to a schedule that is initialized with a
@@ -7769,12 +7769,12 @@ export const scheduleFrom: {
   <Input, Output, Error, Env>(
     initial: Input,
     schedule: Schedule<Output, Input, Error, Env>
-  ): <E, R>(self: Effect<Input, E, R>) => Effect<Output, E, R | Env>
+  ): <E, R>(self: Effect<Input, E, R>) => Effect<Output, E | Error, R | Env>
   <Input, E, R, Output, Error, Env>(
     self: Effect<Input, E, R>,
     initial: Input,
     schedule: Schedule<Output, Input, Error, Env>
-  ): Effect<Output, E, R | Env>
+  ): Effect<Output, E | Error, R | Env>
 } = internalSchedule.scheduleFrom
 
 // -----------------------------------------------------------------------------

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -184,17 +184,17 @@ export const scheduleFrom = dual<
     schedule: Schedule.Schedule<Output, Input, Error, Env>
   ) => <E, R>(
     self: Effect<Input, E, R>
-  ) => Effect<Output, E, R | Env>,
+  ) => Effect<Output, E | Error, R | Env>,
   <Input, E, R, Output, Error, Env>(
     self: Effect<Input, E, R>,
     initial: Input,
     schedule: Schedule.Schedule<Output, Input, Error, Env>
-  ) => Effect<Output, E, R | Env>
+  ) => Effect<Output, E | Error, R | Env>
 >(3, <Input, E, R, Output, Error, Env>(
   self: Effect<Input, E, R>,
   initial: Input,
   schedule: Schedule.Schedule<Output, Input, Error, Env>
-): Effect<Output, E, R | Env> =>
+): Effect<Output, E | Error, R | Env> =>
   effect.flatMap(Schedule.toStepWithMetadata(schedule), (step) => {
     let meta = Schedule.CurrentMetadata.defaultValue()
     const selfWithMeta = effect.suspend(() => effect.provideService(self, Schedule.CurrentMetadata, meta))
@@ -213,7 +213,7 @@ export const scheduleFrom = dual<
           }) as Effect<never, E, R | Env>
         }
       ),
-      (error) => core.isDone(error) ? effect.succeed(error.value as Output) : effect.fail(error as E)
+      (error) => core.isDone(error) ? effect.succeed(error.value as Output) : effect.fail(error as E | Error)
     )
   }))
 

--- a/packages/effect/typetest/Effect.tst.ts
+++ b/packages/effect/typetest/Effect.tst.ts
@@ -10,6 +10,7 @@ import {
   type Option,
   pipe,
   Result,
+  type Schedule,
   type Scope,
   type Sink,
   type Stream,
@@ -1097,5 +1098,13 @@ describe("Effect.retry", () => {
       })
     )
     expect(result).type.toBe<Effect.Effect<string, AiError | OtherError>>()
+  })
+})
+
+describe("Effect.schedule", () => {
+  it("includes schedule errors", () => {
+    const schedule = null as unknown as Schedule.Schedule<number, unknown, "schedule-error">
+    expect(Effect.schedule(Effect.fail("effect-error" as const), schedule))
+      .type.toBe<Effect.Effect<number, "effect-error" | "schedule-error">>()
   })
 })

--- a/packages/effect/typetest/Effect.tst.ts
+++ b/packages/effect/typetest/Effect.tst.ts
@@ -1102,9 +1102,29 @@ describe("Effect.retry", () => {
 })
 
 describe("Effect.schedule", () => {
-  it("includes schedule errors", () => {
+  it("includes schedule errors in data-first usage", () => {
     const schedule = null as unknown as Schedule.Schedule<number, unknown, "schedule-error">
     expect(Effect.schedule(Effect.fail("effect-error" as const), schedule))
+      .type.toBe<Effect.Effect<number, "effect-error" | "schedule-error">>()
+  })
+
+  it("includes schedule errors in data-last usage", () => {
+    const schedule = null as unknown as Schedule.Schedule<number, unknown, "schedule-error">
+    expect(Effect.fail("effect-error" as const).pipe(Effect.schedule(schedule)))
+      .type.toBe<Effect.Effect<number, "effect-error" | "schedule-error">>()
+  })
+})
+
+describe("Effect.scheduleFrom", () => {
+  it("includes schedule errors in data-first usage", () => {
+    const schedule = null as unknown as Schedule.Schedule<number, string, "schedule-error">
+    expect(Effect.scheduleFrom(Effect.fail("effect-error" as const), "initial", schedule))
+      .type.toBe<Effect.Effect<number, "effect-error" | "schedule-error">>()
+  })
+
+  it("includes schedule errors in data-last usage", () => {
+    const schedule = null as unknown as Schedule.Schedule<number, string, "schedule-error">
+    expect(Effect.fail("effect-error" as const).pipe(Effect.scheduleFrom("initial", schedule)))
       .type.toBe<Effect.Effect<number, "effect-error" | "schedule-error">>()
   })
 })


### PR DESCRIPTION
## Summary

`Effect.schedule` omits the schedule's error type from its declared error channel even though that error is propagated at runtime. Callers therefore receive an effect type that claims a schedule failure cannot occur.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## schedule omits the schedule error from its return type

**Module:** `effect/Effect`  
**Audit ID:** `effect-34b809e8b7c8fe74`  
**Severity / confidence:** medium / high

### What happens

`Effect.schedule` omits the schedule's error type from its declared error channel even though that error is propagated at runtime. Callers therefore receive an effect type that claims a schedule failure cannot occur.

### Why it happens

`Effect.schedule` delegates to `scheduleFrom`, which executes both the initial `step` and subsequent `step` calls inside `effect.catch_`; non-`Done` failures are re-raised with `effect.fail`. The public overloads nevertheless declare only `E`, discarding the `Error` parameter that those calls can fail with.

### Expected behavior

Both overloads of `Effect.schedule` must return `Effect<Output, E | Error, R | Env>` for an input `Effect<A, E, R>` and `Schedule<Output, unknown, Error, Env>`.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/Effect.ts:7677-7778`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Effect.ts#L7677-L7778)

<details>
<summary>View problematic code at <code>packages/effect/src/Effect.ts:7677-7726</code></summary>

````ts
/**
 * Runs an effect repeatedly according to a schedule and returns the schedule's
 * final output.
 *
 * **When to use**
 *
 * Use to rerun a successful effect according to a `Schedule` when the schedule
 * does not need a custom initial input.
 *
 * **Details**
 *
 * The schedule is first stepped with `undefined`. After each successful
 * execution, the effect's success value is fed to the schedule to decide
 * whether to run again. The returned effect fails if the effect or schedule
 * fails, and otherwise succeeds with the schedule output when the schedule
 * completes.
 *
 * **Example** (Scheduling repeated execution)
 *
 * ```ts import.meta.vitest
 * import { Effect, Schedule } from "effect"
 * const output: Array<unknown> = []
 *
 * const task = Effect.gen(function*() {
 *   yield* Effect.sync(() => { output.push("Task executing...") })
 *   return 1
 * })
 *
 * const program = Effect.schedule(task, Schedule.recurs(2))
 *
 * void output.push(Effect.runSync(program))
 * output // => ["Task executing...", "Task executing...", 2]
 * ```
 *
 * @see {@link scheduleFrom} for a variant that allows the schedule's decision
 * to depend on the result of this effect.
 *
 * @category repetition
 * @since 2.0.0
 */
export const schedule: {
  <Output, Error, Env>(
    schedule: Schedule<Output, unknown, Error, Env>
  ): <A, E, R>(self: Effect<A, E, R>) => Effect<Output, E, R | Env>
  <A, E, R, Output, Error, Env>(
    self: Effect<A, E, R>,
    schedule: Schedule<Output, unknown, Error, Env>
  ): Effect<Output, E, R | Env>
} = dual(2, <A, E, R, Output, Error, Env>(
  self: Effect<A, E, R>,
````

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Effect.ts#L7677-L7778)

_Excerpt truncated. [Open the complete packages/effect/src/Effect.ts:7677-7778 range.](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Effect.ts#L7677-L7778)_

</details>

### Reproduction

```sh
pnpm test-types packages/effect/typetest/Effect.tst.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: schedule omits the schedule error from its return type.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test-types packages/effect/typetest/Effect.tst.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-34b809e8b7c8fe74`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-500