### PR TITLE
Fix synchronous iterator channels omit early-close cleanup

### DIFF
--- a/.changeset/calm-pugs-clean.md
+++ b/.changeset/calm-pugs-clean.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Close synchronous iterators when their channels terminate early.

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -656,15 +656,16 @@ export const acquireRelease: {
  * @since 4.0.0
  */
 export const fromIterator = <A, L>(iterator: LazyArg<Iterator<A, L>>): Channel<A, never, L> =>
-  fromPull(
-    Effect.sync(() => {
-      const iter = iterator()
-      return Effect.suspend(() => {
-        const state = iter.next()
-        return state.done ? Cause.done(state.value) : Effect.succeed(state.value)
-      })
+  fromTransform(Effect.fnUntraced(function*(_, scope) {
+    const iter = iterator()
+    if (iter.return) {
+      yield* Scope.addFinalizer(scope, Effect.sync(() => iter.return!()))
+    }
+    return Effect.suspend(() => {
+      const state = iter.next()
+      return state.done ? Cause.done(state.value) : Effect.succeed(state.value)
     })
-  )
+  }))
 
 /**
  * Creates a `Channel` that emits all elements from an array.
@@ -755,28 +756,29 @@ export const fromIteratorArray = <A, L>(
   iterator: LazyArg<Iterator<A, L>>,
   chunkSize = DefaultChunkSize
 ): Channel<Arr.NonEmptyReadonlyArray<A>, never, L> =>
-  fromPull(
-    Effect.sync(() => {
-      const iter = iterator()
-      let done = Option.none<L>()
-      return Effect.suspend(() => {
-        if (done._tag === "Some") return Cause.done(done.value)
-        const buffer: Array<A> = []
-        while (buffer.length < chunkSize) {
-          const state = iter.next()
-          if (state.done) {
-            if (buffer.length === 0) {
-              return Cause.done(state.value)
-            }
-            done = Option.some(state.value)
-            break
+  fromTransform(Effect.fnUntraced(function*(_, scope) {
+    const iter = iterator()
+    if (iter.return) {
+      yield* Scope.addFinalizer(scope, Effect.sync(() => iter.return!()))
+    }
+    let done = Option.none<L>()
+    return Effect.suspend(() => {
+      if (done._tag === "Some") return Cause.done(done.value)
+      const buffer: Array<A> = []
+      while (buffer.length < chunkSize) {
+        const state = iter.next()
+        if (state.done) {
+          if (buffer.length === 0) {
+            return Cause.done(state.value)
           }
-          buffer.push(state.value)
+          done = Option.some(state.value)
+          break
         }
-        return Effect.succeed(buffer as any as Arr.NonEmptyReadonlyArray<A>)
-      })
+        buffer.push(state.value)
+      }
+      return Effect.succeed(buffer as any as Arr.NonEmptyReadonlyArray<A>)
     })
-  )
+  }))
 
 /**
  * Creates a `Channel` that emits all elements from an iterable.

--- a/packages/effect/test/Channel.test.ts
+++ b/packages/effect/test/Channel.test.ts
@@ -103,29 +103,29 @@ describe("Channel", () => {
         assert.deepStrictEqual(result, [[0, 1, 1], [2, 3]])
       }))
 
-    it.effect("closes synchronous iterators on early termination", () =>
+    it.effect.each(
+      [
+        ["fromIterator", false],
+        ["fromIteratorArray", true]
+      ] as const
+    )("%s closes synchronous iterators on early termination", ([_, array]) =>
       Effect.gen(function*() {
-        const check = Effect.fnUntraced(function*(array: boolean) {
-          let closed = false
-          function* values() {
-            try {
-              yield 1
-              yield 2
-            } finally {
-              closed = true
-            }
+        let closed = false
+        function* values() {
+          try {
+            yield 1
+            yield 2
+          } finally {
+            closed = true
           }
-          const channel = array
-            ? Channel.fromIteratorArray(() => values(), 1)
-            : Channel.fromIterator(() => values())
-          yield* Channel.runHead(channel)
-          return closed
-        })
+        }
+        if (array) {
+          yield* Channel.runHead(Channel.fromIteratorArray(() => values(), 1))
+        } else {
+          yield* Channel.runHead(Channel.fromIterator(() => values()))
+        }
 
-        assert.deepStrictEqual(
-          [yield* check(false), yield* check(true)],
-          [true, true]
-        )
+        assert.isTrue(closed)
       }))
 
     it.effect("fromIterable", () =>

--- a/packages/effect/test/Channel.test.ts
+++ b/packages/effect/test/Channel.test.ts
@@ -103,6 +103,31 @@ describe("Channel", () => {
         assert.deepStrictEqual(result, [[0, 1, 1], [2, 3]])
       }))
 
+    it.effect("closes synchronous iterators on early termination", () =>
+      Effect.gen(function*() {
+        const check = Effect.fnUntraced(function*(array: boolean) {
+          let closed = false
+          function* values() {
+            try {
+              yield 1
+              yield 2
+            } finally {
+              closed = true
+            }
+          }
+          const channel = array
+            ? Channel.fromIteratorArray(() => values(), 1)
+            : Channel.fromIterator(() => values())
+          yield* Channel.runHead(channel)
+          return closed
+        })
+
+        assert.deepStrictEqual(
+          [yield* check(false), yield* check(true)],
+          [true, true]
+        )
+      }))
+
     it.effect("fromIterable", () =>
       Effect.gen(function*() {
         const set = new Set([1, 1, 2, 3])


### PR DESCRIPTION
## Summary

After Channel.runHead consumes one value from a generator-backed fromIterator or fromIteratorArray channel, the generator's finally block is not run; early consumers can leave iterator-owned resources open.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Synchronous iterator channels omit early-close cleanup

**Module:** `effect/Channel`  
**Audit ID:** `effect-35a16c321f831be0`  
**Severity / confidence:** medium / high

### What happens

After Channel.runHead consumes one value from a generator-backed fromIterator or fromIteratorArray channel, the generator's finally block is not run; early consumers can leave iterator-owned resources open.

### Why it happens

Both constructors allocate the iterator inside a plain fromPull effect and only call iter.next(); unlike fromAsyncIterable, they register no scope finalizer and never call iter.return(), so runHead ends the channel through Cause.done() without closing the iterator.

### Expected behavior

fromIterator and fromIteratorArray must invoke an acquired iterator's return method when the channel scope terminates before next() reports done, while preserving the natural done value on full exhaustion.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/Channel.ts:658-779`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Channel.ts#L658-L779)

<details>
<summary>View problematic code at <code>packages/effect/src/Channel.ts:658-707</code></summary>

````ts
export const fromIterator = <A, L>(iterator: LazyArg<Iterator<A, L>>): Channel<A, never, L> =>
  fromPull(
    Effect.sync(() => {
      const iter = iterator()
      return Effect.suspend(() => {
        const state = iter.next()
        return state.done ? Cause.done(state.value) : Effect.succeed(state.value)
      })
    })
  )

/**
 * Creates a `Channel` that emits all elements from an array.
 *
 * **Example** (Creating channels from arrays)
 *
 * ```ts import.meta.vitest
 * import { Channel, Effect } from "effect"
 *
 * const channel = Channel.fromArray([1, 2, 3, 4, 5])
 * Effect.runSync(Channel.runCollect(channel)) // => [1, 2, 3, 4, 5]
 * ```
 *
 * @category constructors
 * @since 4.0.0
 */
export const fromArray = <A>(array: ReadonlyArray<A>): Channel<A> =>
  fromPull(Effect.sync(() => {
    let index = 0
    return Effect.suspend(() => index >= array.length ? Cause.done() : Effect.succeed(array[index++]))
  }))

/**
 * Creates a `Channel` that emits all elements from a chunk.
 *
 * **Example** (Creating channels from chunks)
 *
 * ```ts import.meta.vitest
 * import { Channel, Chunk, Effect } from "effect"
 *
 * const chunk = Chunk.make(1, 2, 3)
 * const channel = Channel.fromChunk(chunk)
 * Effect.runSync(Channel.runCollect(channel)) // => [1, 2, 3]
 * ```
 *
 * @category constructors
 * @since 4.0.0
 */
export const fromChunk = <A>(chunk: Chunk.Chunk<A>): Channel<A> => fromArray(Chunk.toReadonlyArray(chunk))

````

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Channel.ts#L658-L779)

_Excerpt truncated. [Open the complete packages/effect/src/Channel.ts:658-779 range.](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Channel.ts#L658-L779)_

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/ChannelIteratorClose.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: Synchronous iterator channels omit early-close cleanup.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/ChannelIteratorClose.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-35a16c321f831be0`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-499