### PR TITLE
Fix fromEpochSeconds constructs unusable out-of-range values

### DIFF
--- a/.changeset/valid-dates-arrive.md
+++ b/.changeset/valid-dates-arrive.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Reject epoch seconds outside the JavaScript `Date` range in `DateTime.fromEpochSeconds`.

--- a/packages/effect/src/internal/dateTime.ts
+++ b/packages/effect/src/internal/dateTime.ts
@@ -604,7 +604,7 @@ export const toEpochMillis = (self: DateTime.DateTime): number => self.epochMill
 export const toEpochSeconds = (self: DateTime.DateTime): number => Math.floor(self.epochMilliseconds / 1000)
 
 /** @internal */
-export const fromEpochSeconds = (seconds: number): DateTime.Utc => makeUtc(seconds * 1000)
+export const fromEpochSeconds = (seconds: number): DateTime.Utc => fromDateUnsafe(new Date(seconds * 1000))
 
 /** @internal */
 export const removeTime = (self: DateTime.DateTime): DateTime.Utc =>

--- a/packages/effect/test/DateTime.test.ts
+++ b/packages/effect/test/DateTime.test.ts
@@ -394,6 +394,10 @@ describe("DateTime", () => {
   })
 
   describe("fromEpochSeconds", () => {
+    it("rejects finite epoch seconds outside the Date range", () => {
+      throws(() => DateTime.fromEpochSeconds(8_640_000_000_001))
+    })
+
     it("creates DateTime from epoch seconds", () => {
       const dt = DateTime.fromEpochSeconds(1704067200)
       strictEqual(dt.toJSON(), "2024-01-01T00:00:00.000Z")


### PR DESCRIPTION
## Summary

- Validate epoch seconds through JavaScript's `Date` before constructing `DateTime.Utc` values.
- Reject non-finite and out-of-range inputs instead of returning values that later fail to format.
- Keep the regression test in the main `DateTime` test file and add a patch changeset.

## Testing

- `pnpm test --run packages/effect/test/DateTime.test.ts`
- `pnpm test --run --project effect`
- `pnpm lint`
- `pnpm check`

Closes EFF-498
