### PR TITLE
Fix optional tuple arbitrary generation shifts later elements into gaps

### DIFF
--- a/.changeset/calm-tuples-align.md
+++ b/.changeset/calm-tuples-align.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix arbitrary generation for tuples with multiple optional elements.

--- a/packages/effect/src/internal/schema/toArbitrary.ts
+++ b/packages/effect/src/internal/schema/toArbitrary.ts
@@ -717,7 +717,9 @@ function base(ast: SchemaAST.AST, path: ReadonlyArray<PropertyKey>): LazyArbitra
               : out.map(Option.some)
           }
         )
-        let out = fc.tuple(...elementArbitraries).map(Array.getSomes)
+        let out = fc.tuple(...elementArbitraries).map((elements) =>
+          Array.getSomes(Array.takeWhile(elements, Option.isSome))
+        )
         // ---------------------------------------------
         // handle rest element
         // ---------------------------------------------

--- a/packages/effect/test/schema/toArbitrary.test.ts
+++ b/packages/effect/test/schema/toArbitrary.test.ts
@@ -591,6 +591,18 @@ describe("Arbitrary generation", () => {
         Schema.Tuple([Schema.String, Schema.optional(Schema.Number)])
       )
     })
+
+    it("generates values valid for optional tuple positions", () => {
+      const schema = Schema.Tuple([
+        Schema.optionalKey(Schema.String),
+        Schema.optionalKey(Schema.Number)
+      ])
+
+      FastCheck.assert(FastCheck.property(Schema.toArbitrary(schema), Schema.is(schema)), {
+        numRuns: 100,
+        seed: 17
+      })
+    })
   })
 
   describe("Array", () => {


### PR DESCRIPTION
## Summary

`Schema.toArbitrary` can generate `[number]` for a tuple shaped as `[string?, number?]`, which fails that same schema. Property tests using the derived arbitrary can fail on generator output before testing the target property.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Optional tuple arbitrary generation shifts later elements into gaps

**Module:** `effect/internal/schema/toArbitrary`  
**Audit ID:** `effect-7a7e36cb9da69f32`  
**Severity / confidence:** medium / high

### What happens

`Schema.toArbitrary` can generate `[number]` for a tuple shaped as `[string?, number?]`, which fails that same schema. Property tests using the derived arbitrary can fail on generator output before testing the target property.

### Why it happens

The array arbitrary independently includes each optional element with `fc.boolean`, wraps omissions in `Option.none`, and then calls `Array.getSomes`. If the first element is omitted and the second included, compaction moves the number into index zero, where the tuple schema expects a string.

### Expected behavior

Every value emitted by `Schema.toArbitrary(schema)` must satisfy `Schema.is(schema)`, including the positional prefix rule for optional `Schema.Tuple` elements.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/internal/schema/toArbitrary.ts:629-720`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/internal/schema/toArbitrary.ts#L629-L720)

<details>
<summary>View problematic code at <code>packages/effect/src/internal/schema/toArbitrary.ts:629-678</code></summary>

```ts
    case "Arrays": {
      const elements = ast.elements.map((ast, i) => ({
        ast,
        arbitrary: recur(ast, [...path, i])
      }))
      const len = ast.elements.length
      const rest = ast.rest.map((ast, i) => ({
        ast,
        arbitrary: recur(ast, [...path, len + i])
      }))
      const terminal: LazyOption<any> = (fc, ctx, recursionStack) => {
        const reset = resetContext(ctx)
        const elementArbitraries: Array<FastCheck.Arbitrary<Option.Option<any>>> = []
        const optionals: Array<FastCheck.Arbitrary<any> | undefined> = []
        let length = 0
        for (const element of elements) {
          const out = element.arbitrary.terminal(fc, reset, recursionStack)
          if (SchemaAST.isOptional(element.ast)) {
            optionals.push(out)
            continue
          }
          if (out === undefined) {
            return undefined
          }
          length++
          elementArbitraries.push(out.map(Option.some))
        }
        const minLength = ctx.constraint?.minLength ?? 0
        const needsRest = Array.isReadonlyArrayNonEmpty(rest) && minLength > length + optionals.length
        const optionalTarget = needsRest ? optionals.length : Math.max(0, minLength - length)
        let includedOptionals = 0
        for (const out of optionals) {
          if (includedOptionals >= optionalTarget || out === undefined) {
            elementArbitraries.push(fc.constant(Option.none()))
            continue
          }
          includedOptionals++
          length++
          elementArbitraries.push(out.map(Option.some))
        }
        if (includedOptionals < optionalTarget) {
          return undefined
        }
        let out = fc.tuple(...elementArbitraries).map(Array.getSomes)
        if (Array.isReadonlyArrayNonEmpty(rest)) {
          const [head, ...tail] = rest
          const restCtx = ast.elements.length === 0 ? ctx : reset
          const minRestLength = Math.max(0, minLength - length - tail.length)
          const headArbitrary = minRestLength === 0
            ? undefined
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/internal/schema/toArbitrary.ts#L629-L720)

_Excerpt truncated. [Open the complete packages/effect/src/internal/schema/toArbitrary.ts:629-720 range.](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/internal/schema/toArbitrary.ts#L629-L720)_

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/schema/toArbitrary.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: Optional tuple arbitrary generation shifts later elements into gaps.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/schema/toArbitrary.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-7a7e36cb9da69f32`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-497