### PR TITLE
Fix runCount discards its numeric result in the public type

### DIFF
--- a/.changeset/swift-geese-count.md
+++ b/.changeset/swift-geese-count.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix the return type of `Channel.runCount` to expose its numeric result.

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -7850,7 +7850,7 @@ export const bindTo: {
  */
 export const runCount = <OutElem, OutErr, OutDone, Env>(
   self: Channel<OutElem, OutErr, OutDone, unknown, unknown, unknown, Env>
-): Effect.Effect<void, OutErr, Env> => runFold(self, () => 0, (acc) => acc + 1)
+): Effect.Effect<number, OutErr, Env> => runFold(self, () => 0, (acc) => acc + 1)
 
 /**
  * Runs a channel and discards all output elements, returning only the final result.

--- a/packages/effect/typetest/Channel.tst.ts
+++ b/packages/effect/typetest/Channel.tst.ts
@@ -1,4 +1,4 @@
-import { Channel, Data, pipe, Result } from "effect"
+import { Channel, Data, Effect, pipe, Result } from "effect"
 import { describe, expect, it } from "tstyche"
 
 class ErrorA extends Data.TaggedError("ErrorA")<{ readonly message: string }> {}
@@ -108,5 +108,11 @@ describe("Channel.catchReasons", () => {
       )
     )
     expect(result).type.toBe<Channel.Channel<number, ErrorA | ErrorB>>()
+  })
+})
+
+describe("Channel.runCount", () => {
+  it("returns the output count", () => {
+    expect(Channel.runCount(Channel.fromIterable([1, 2, 3]))).type.toBe<Effect.Effect<number>>()
   })
 })

--- a/packages/effect/typetest/Channel.tst.ts
+++ b/packages/effect/typetest/Channel.tst.ts
@@ -1,4 +1,4 @@
-import { Channel, Data, Effect, pipe, Result } from "effect"
+import { Channel, Data, type Effect, pipe, Result } from "effect"
 import { describe, expect, it } from "tstyche"
 
 class ErrorA extends Data.TaggedError("ErrorA")<{ readonly message: string }> {}


### PR DESCRIPTION
## Summary

Channel.runCount(Channel.fromIterable([1, 2, 3])) evaluates to 3, but its exported return type is Effect.Effect<void, ...>; callers cannot use the count as a number without an assertion or cast.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## runCount discards its numeric result in the public type

**Module:** `effect/Channel`  
**Audit ID:** `effect-aff9f49bb8493fb7`  
**Severity / confidence:** medium / high

### What happens

Channel.runCount(Channel.fromIterable([1, 2, 3])) evaluates to 3, but its exported return type is Effect.Effect<void, ...>; callers cannot use the count as a number without an assertion or cast.

### Why it happens

The implementation delegates to runFold with the numeric initial value 0 and an incrementing accumulator, so its runtime success value is a number, but the explicit return annotation declares that value as void in the public type.

### Expected behavior

Channel.runCount must expose the count it produces as Effect.Effect<number, OutErr, Env>, preserving the channel error and environment parameters.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/Channel.ts:7827-7853`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Channel.ts#L7827-L7853)

<details>
<summary>View problematic code at <code>packages/effect/src/Channel.ts:7827-7853</code></summary>

````ts
/**
 * Runs a channel and counts the number of elements it outputs.
 *
 * **Example** (Counting channel output)
 *
 * ```ts import.meta.vitest
 * import { Channel, Data, Effect } from "effect"
 *
 * class CountError extends Data.TaggedError("CountError")<{
 *   readonly reason: string
 * }> {}
 *
 * // Create a channel with multiple elements
 * const numbersChannel = Channel.fromIterable([1, 2, 3, 4, 5])
 *
 * // Count the elements
 * const countEffect = Channel.runCount(numbersChannel)
 *
 * Effect.runSync(countEffect) // => 5
 * ```
 *
 * @category running
 * @since 4.0.0
 */
export const runCount = <OutElem, OutErr, OutDone, Env>(
  self: Channel<OutElem, OutErr, OutDone, unknown, unknown, unknown, Env>
): Effect.Effect<void, OutErr, Env> => runFold(self, () => 0, (acc) => acc + 1)
````

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Channel.ts#L7827-L7853)

</details>

### Reproduction

```sh
pnpm test-types packages/effect/typetest/ChannelRunCount.tst.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: runCount discards its numeric result in the public type.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test-types packages/effect/typetest/ChannelRunCount.tst.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-aff9f49bb8493fb7`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-496
