### PR TITLE
Fix slidingSize depends on upstream chunk boundaries

### DIFF
--- a/.changeset/fix-sliding-size-chunks.md
+++ b/.changeset/fix-sliding-size-chunks.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Stream.slidingSize` to produce the same windows regardless of upstream chunk boundaries.

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -6924,12 +6924,18 @@ export const slidingSize: {
         let cause: Cause.Cause<E | Cause.Done> | null = null
         const list = MutableList.make<A>()
         let emitted = false
+        let skip = 0
         const pull: Pull.Pull<
           Arr.NonEmptyReadonlyArray<Arr.NonEmptyReadonlyArray<A>>,
           E | Cause.Done
         > = Effect.matchCauseEffect(upstream, {
           onSuccess(arr) {
             MutableList.appendAllUnsafe(list, arr)
+            if (skip > 0) {
+              const length = list.length
+              MutableList.takeNVoid(list, skip)
+              skip = Math.max(0, skip - length)
+            }
             if (list.length < chunkSize) return pull
             emitted = true
             const chunks = [] as any as Arr.NonEmptyArray<Arr.NonEmptyReadonlyArray<A>>
@@ -6938,10 +6944,12 @@ export const slidingSize: {
                 chunks.push(MutableList.takeN(list, chunkSize) as any)
               } else {
                 chunks.push(MutableList.toArrayN(list, chunkSize) as any)
-                if (chunkSize === 1) {
+                if (chunkSize === 1 && stepSize <= 0) {
                   MutableList.take(list)
                 } else {
+                  const length = list.length
                   MutableList.takeNVoid(list, stepSize)
+                  skip = Math.max(0, stepSize - length)
                 }
               }
             }

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -4768,16 +4768,19 @@ describe("Stream", () => {
 
     it.effect("slidingSize is independent of upstream chunk boundaries", () =>
       Effect.gen(function*() {
-        const contiguous = yield* Stream.make(1, 2, 3, 4, 5).pipe(
-          Stream.slidingSize(2, 3),
-          Stream.runCollect
-        )
-        const chunked = yield* Stream.fromArrays([1, 2], [3, 4, 5]).pipe(
-          Stream.slidingSize(2, 3),
-          Stream.runCollect
-        )
+        const result = yield* Effect.all([
+          Stream.make(1, 2, 3, 4, 5),
+          Stream.fromArrays([1, 2], [3, 4, 5]),
+          Stream.fromArrays([1], [2], [3], [4], [5]),
+          Stream.fromArrays([1], [2], [3], [4])
+        ].map((stream) => stream.pipe(Stream.slidingSize(2, 3), Stream.runCollect)))
 
-        deepStrictEqual(chunked, contiguous, "sliding windows must not depend on upstream chunks")
+        deepStrictEqual(result, [
+          [[1, 2], [4, 5]],
+          [[1, 2], [4, 5]],
+          [[1, 2], [4, 5]],
+          [[1, 2], [4]]
+        ])
       }))
 
     it.effect("sliding - fails if upstream produces an error", () =>

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -4766,6 +4766,20 @@ describe("Stream", () => {
         deepStrictEqual(result1, result2)
       }))
 
+    it.effect("slidingSize is independent of upstream chunk boundaries", () =>
+      Effect.gen(function*() {
+        const contiguous = yield* Stream.make(1, 2, 3, 4, 5).pipe(
+          Stream.slidingSize(2, 3),
+          Stream.runCollect
+        )
+        const chunked = yield* Stream.fromArrays([1, 2], [3, 4, 5]).pipe(
+          Stream.slidingSize(2, 3),
+          Stream.runCollect
+        )
+
+        deepStrictEqual(chunked, contiguous, "sliding windows must not depend on upstream chunks")
+      }))
+
     it.effect("sliding - fails if upstream produces an error", () =>
       Effect.gen(function*() {
         const result = yield* pipe(


### PR DESCRIPTION
## Summary

For `stepSize` greater than `chunkSize`, `Stream.slidingSize` emits different windows for the same elements when upstream chunk boundaries differ. A sequence chunked as `[1, 2]`, `[3, 4, 5]` advances differently from one contiguous chunk, so grouping depends on transport batching.

> [!NOTE]
> This PR includes the regression coverage, implementation fix, and patch changeset.

## slidingSize depends on upstream chunk boundaries

**Module:** `effect/Stream`  
**Audit ID:** `effect-b8bd0d2108358b5a`  
**Severity / confidence:** medium / high

### What happens

For `stepSize` greater than `chunkSize`, `Stream.slidingSize` emits different windows for the same elements when upstream chunk boundaries differ. A sequence chunked as `[1, 2]`, `[3, 4, 5]` advances differently from one contiguous chunk, so grouping depends on transport batching.

### Why it happens

After emitting a window, the pull loop calls `MutableList.takeNVoid(list, stepSize)` only against elements currently buffered. When the buffer contains fewer than `stepSize` elements, it discards what is present but records no remaining skip count, so elements arriving in the next upstream chunk are included too early.

### Expected behavior

`Stream.slidingSize(chunkSize, stepSize)` must define windows over the logical element sequence and produce results independent of upstream `Chunk` boundaries.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/Stream.ts:6916-6960`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Stream.ts#L6916-L6960)

<details>
<summary>View problematic code at <code>packages/effect/src/Stream.ts:6916-6960</code></summary>

```ts
export const slidingSize: {
  (chunkSize: number, stepSize: number): <A, E, R>(self: Stream<A, E, R>) => Stream<Arr.NonEmptyReadonlyArray<A>, E, R>
  <A, E, R>(self: Stream<A, E, R>, chunkSize: number, stepSize: number): Stream<Arr.NonEmptyReadonlyArray<A>, E, R>
} = dual(
  3,
  <A, E, R>(self: Stream<A, E, R>, chunkSize: number, stepSize: number): Stream<Arr.NonEmptyReadonlyArray<A>, E, R> =>
    transformPull(self, (upstream, _scope) =>
      Effect.sync(() => {
        let cause: Cause.Cause<E | Cause.Done> | null = null
        const list = MutableList.make<A>()
        let emitted = false
        const pull: Pull.Pull<
          Arr.NonEmptyReadonlyArray<Arr.NonEmptyReadonlyArray<A>>,
          E | Cause.Done
        > = Effect.matchCauseEffect(upstream, {
          onSuccess(arr) {
            MutableList.appendAllUnsafe(list, arr)
            if (list.length < chunkSize) return pull
            emitted = true
            const chunks = [] as any as Arr.NonEmptyArray<Arr.NonEmptyReadonlyArray<A>>
            while (list.length >= chunkSize) {
              if (chunkSize === stepSize) {
                chunks.push(MutableList.takeN(list, chunkSize) as any)
              } else {
                chunks.push(MutableList.toArrayN(list, chunkSize) as any)
                if (chunkSize === 1) {
                  MutableList.take(list)
                } else {
                  MutableList.takeNVoid(list, stepSize)
                }
              }
            }
            return Effect.succeed(chunks)
          },
          onFailure(cause_) {
            if (emitted) MutableList.takeNVoid(list, chunkSize - stepSize)
            if (list.length === 0) return Effect.failCause(cause_)
            cause = cause_
            return Effect.succeed(Arr.of(MutableList.takeAll(list) as any))
          }
        })

        return Effect.suspend(() => cause ? Effect.failCause(cause) : pull)
      }))
)
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Stream.ts#L6916-L6960)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/Stream.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: slidingSize depends on upstream chunk boundaries.

## Validation

- `pnpm test --run packages/effect/test/Stream.test.ts`
- `pnpm lint-fix`
- `pnpm check`

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-b8bd0d2108358b5a`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-495