### PR TITLE
Fix map and Set equality permits many-to-one matches

### DIFF
--- a/.changeset/lucky-dingos-smile.md
+++ b/.changeset/lucky-dingos-smile.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix Map and Set equality allowing a right-side entry to match multiple left-side entries.

--- a/packages/effect/src/Equal.ts
+++ b/packages/effect/src/Equal.ts
@@ -366,7 +366,8 @@ export function makeCompareMap<K, V>(keyEquivalence: Equivalence<K>, valueEquiva
       for (let i = 0; i < thatEntries.length; i++) {
         const [thatKey, thatValue] = thatEntries[i]
         if (keyEquivalence(selfKey, thatKey) && valueEquivalence(selfValue, thatValue)) {
-          thatEntries.splice(i, 1)
+          thatEntries[i] = thatEntries[thatEntries.length - 1]
+          thatEntries.pop()
           found = true
           break
         }
@@ -391,7 +392,8 @@ export function makeCompareSet<A>(equivalence: Equivalence<A>) {
       for (let i = 0; i < thatValues.length; i++) {
         const thatValue = thatValues[i]
         if (equivalence(selfValue, thatValue)) {
-          thatValues.splice(i, 1)
+          thatValues[i] = thatValues[thatValues.length - 1]
+          thatValues.pop()
           found = true
           break
         }

--- a/packages/effect/src/Equal.ts
+++ b/packages/effect/src/Equal.ts
@@ -360,10 +360,13 @@ function compareRecords(
 /** @internal */
 export function makeCompareMap<K, V>(keyEquivalence: Equivalence<K>, valueEquivalence: Equivalence<V>) {
   return function compareMaps(self: Iterable<[K, V]>, that: Iterable<[K, V]>): boolean {
+    const thatEntries = Array.from(that)
     for (const [selfKey, selfValue] of self) {
       let found = false
-      for (const [thatKey, thatValue] of that) {
+      for (let i = 0; i < thatEntries.length; i++) {
+        const [thatKey, thatValue] = thatEntries[i]
         if (keyEquivalence(selfKey, thatKey) && valueEquivalence(selfValue, thatValue)) {
+          thatEntries.splice(i, 1)
           found = true
           break
         }
@@ -382,10 +385,13 @@ const compareMaps = makeCompareMap(compareBoth, compareBoth)
 /** @internal */
 export function makeCompareSet<A>(equivalence: Equivalence<A>) {
   return function compareSets(self: Iterable<A>, that: Iterable<A>): boolean {
+    const thatValues = Array.from(that)
     for (const selfValue of self) {
       let found = false
-      for (const thatValue of that) {
+      for (let i = 0; i < thatValues.length; i++) {
+        const thatValue = thatValues[i]
         if (equivalence(selfValue, thatValue)) {
+          thatValues.splice(i, 1)
           found = true
           break
         }

--- a/packages/effect/test/Equal.test.ts
+++ b/packages/effect/test/Equal.test.ts
@@ -1,8 +1,21 @@
+import { assert } from "@effect/vitest"
 import * as Equal from "effect/Equal"
 import * as Hash from "effect/Hash"
 import * as HashMap from "effect/HashMap"
 import * as Option from "effect/Option"
 import { describe, expect, it } from "vitest"
+
+class Key implements Equal.Equal, Hash.Hash {
+  constructor(readonly group: string) {}
+
+  [Equal.symbol](that: unknown) {
+    return that instanceof Key && this.group === that.group
+  }
+
+  [Hash.symbol]() {
+    return 0
+  }
+}
 
 describe("Equal.equals", () => {
   describe("plain objects", () => {
@@ -684,6 +697,19 @@ describe("Equal.equals", () => {
   })
 
   describe("Map and Set mixed", () => {
+    it("matches Map and Set entries one-to-one", () => {
+      const setResult = Equal.equals(
+        new Set([new Key("x"), new Key("x")]),
+        new Set([new Key("x"), new Key("y")])
+      )
+      const mapResult = Equal.equals(
+        new Map([[new Key("x"), 1], [new Key("x"), 1]]),
+        new Map([[new Key("x"), 1], [new Key("y"), 1]])
+      )
+
+      assert.deepStrictEqual([setResult, mapResult], [false, false])
+    })
+
     it("should handle objects containing maps and sets", () => {
       const obj1 = {
         map: new Map([["a", 1], ["b", 2]]),


### PR DESCRIPTION
## Summary

Equal.equals returns true for same-sized Sets containing two distinct Equal-equivalent x values versus one x and one y, and likewise for Maps, because both left x values reuse the single right x; distinct collections are conflated.

> [!IMPORTANT]
> This PR includes focused regression tests and updates Map and Set comparison to consume each right-side match at most once.

## Map and Set equality permits many-to-one matches

**Module:** `effect/Equal`  
**Audit ID:** `effect-c2ccacce11d583fb`  
**Severity / confidence:** medium / high

### What happens

Equal.equals returns true for same-sized Sets containing two distinct Equal-equivalent x values versus one x and one y, and likewise for Maps, because both left x values reuse the single right x; distinct collections are conflated.

### Why it happens

makeCompareMap and makeCompareSet independently scan the entire right iterable for each left item and stop at the first equivalent value, but never mark or remove a matched right item, so the size check does not prevent many-to-one reuse.

### Expected behavior

Structural equality for same-sized Map and Set values must establish a one-to-one correspondence under key/value or element equivalence; no right-side entry may satisfy more than one left-side entry.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/Equal.ts:275-399`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Equal.ts#L275-L399)

<details>
<summary>View problematic code at <code>packages/effect/src/Equal.ts:275-324</code></summary>

```ts
    } else if (self instanceof Map) {
      if (!(that instanceof Map) || self.size !== that.size) {
        return false
      }
      return compareMaps(self, that)
    } else if (self instanceof Set) {
      if (!(that instanceof Set) || self.size !== that.size) {
        return false
      }
      return compareSets(self, that)
    }
    return compareRecords(self as any, that as any)
  })
}

function withCache(self: object, that: object, f: (a: any, b: any) => boolean): boolean {
  // Check cache first
  let selfMap = equalityCache.get(self)
  if (!selfMap) {
    selfMap = new WeakMap()
    equalityCache.set(self, selfMap)
  } else if (selfMap.has(that)) {
    return selfMap.get(that)!
  }

  // Perform the comparison
  const result = f(self, that)

  // Cache the result bidirectionally
  selfMap.set(that, result)

  let thatMap = equalityCache.get(that)
  if (!thatMap) {
    thatMap = new WeakMap()
    equalityCache.set(that, thatMap)
  }
  thatMap.set(self, result)

  return result
}

const equalityCache = new WeakMap<object, WeakMap<object, boolean>>()

function compareArrays(self: Array<unknown>, that: Array<unknown>): boolean {
  for (let i = 0; i < self.length; i++) {
    if (!compareBoth(self[i], that[i])) {
      return false
    }
  }

```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Equal.ts#L275-L399)

_Excerpt truncated. [Open the complete packages/effect/src/Equal.ts:275-399 range.](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Equal.ts#L275-L399)_

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/Equal.test.ts -t "matches Map and Set entries one-to-one"
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: Map and Set equality permits many-to-one matches.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/Equal.test.ts -t "matches Map and Set entries one-to-one"
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-c2ccacce11d583fb`
- Initial patch: focused reproduction tests; implementation fix added in this PR

Closes EFF-494