### PR TITLE
Fix curried catch overloads expose the handled error type

### DIFF
--- a/.changeset/fair-sinks-catch.md
+++ b/.changeset/fair-sinks-catch.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix the error type exposed by the curried `Sink.catch` overload.

--- a/packages/effect/src/Sink.ts
+++ b/packages/effect/src/Sink.ts
@@ -2104,7 +2104,7 @@ export const catchCause: {
 const catch_: {
   <E, A2, E2, R2>(
     f: (error: Types.NoInfer<E>) => Effect.Effect<A2, E2, R2>
-  ): <A, In, L, R>(self: Sink<A, In, L, E, R>) => Sink<A2 | A, In, L, E, R2 | R>
+  ): <A, In, L, R>(self: Sink<A, In, L, E, R>) => Sink<A2 | A, In, L, E2, R2 | R>
   <A, In, L, E, R, A2, E2, R2>(
     self: Sink<A, In, L, E, R>,
     f: (error: E) => Effect.Effect<A2, E2, R2>

--- a/packages/effect/typetest/Sink.tst.ts
+++ b/packages/effect/typetest/Sink.tst.ts
@@ -1,0 +1,13 @@
+import { Effect, Sink } from "effect"
+import { describe, expect, it } from "tstyche"
+
+describe("Sink", () => {
+  it("curried catch replaces the handled error type", () => {
+    const sink = null as unknown as Sink.Sink<number, string, never, "old-error">
+    const recovered = Sink.catch<"old-error", never, "new-error", never>(
+      (_) => Effect.fail("new-error" as const)
+    )(sink)
+
+    expect(recovered).type.toBe<Sink.Sink<number, string, never, "new-error">>()
+  })
+})


### PR DESCRIPTION
## Summary

The curried `Sink.catch` overload retains the handled error type and omits the fallback effect's error type, despite runtime recovery replacing the former with the latter. Data-last calls therefore expose an error channel inconsistent with both data-first calls and execution.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Curried catch overloads expose the handled error type

**Module:** `effect/Sink`  
**Audit ID:** `effect-682f972b1b7ccb47`  
**Severity / confidence:** medium / high

### What happens

The curried `Sink.catch` overload retains the handled error type and omits the fallback effect's error type, despite runtime recovery replacing the former with the latter. Data-last calls therefore expose an error channel inconsistent with both data-first calls and execution.

### Why it happens

The implementation applies `Effect.catch`, maps a successful fallback into the sink result, and consequently removes `E` while allowing `E2`. The curried signature returns `Sink<..., E, ...>`, whereas the data-first signature correctly returns `Sink<..., E2, ...>`.

### Expected behavior

For both invocation forms, `Sink.catch` must transform `Sink<A, In, L, E, R>` with a handler returning `Effect<A2, E2, R2>` into `Sink<A | A2, In, L, E2, R | R2>`.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/Sink.ts:2104-2119`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Sink.ts#L2104-L2119)

<details>
<summary>View problematic code at <code>packages/effect/src/Sink.ts:2104-2119</code></summary>

```ts
const catch_: {
  <E, A2, E2, R2>(
    f: (error: Types.NoInfer<E>) => Effect.Effect<A2, E2, R2>
  ): <A, In, L, R>(self: Sink<A, In, L, E, R>) => Sink<A2 | A, In, L, E, R2 | R>
  <A, In, L, E, R, A2, E2, R2>(
    self: Sink<A, In, L, E, R>,
    f: (error: E) => Effect.Effect<A2, E2, R2>
  ): Sink<A | A2, In, L, E2, R | R2>
} = dual(2, <A, In, L, E, R, A2, E2, R2>(
  self: Sink<A, In, L, E, R>,
  f: (error: E) => Effect.Effect<A2, E2, R2>
): Sink<A | A2, In, L, E2, R | R2> =>
  transformEffect(
    self,
    Effect.catch((error) => Effect.map(f(error), (a2) => [a2 as A | A2] as const))
  ))
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Sink.ts#L2104-L2119)

</details>

### Reproduction

```sh
pnpm test-types packages/effect/typetest/Sink.tst.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: Curried catch overloads expose the handled error type.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test-types packages/effect/typetest/Sink.tst.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-682f972b1b7ccb47`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-493