### PR TITLE
Remove redundant Effect.scoped test wrappers

### DIFF
--- a/packages/effect/test/FiberSetRuntimePropagation.test.ts
+++ b/packages/effect/test/FiberSetRuntimePropagation.test.ts
@@ -4,7 +4,7 @@ import { Deferred, Effect, Fiber, FiberSet } from "effect"
 
 describe("FiberSet.runtime interruption propagation", () => {
   it.effect("records external interruption when enabled", () =>
-    Effect.scoped(Effect.gen(function*() {
+    Effect.gen(function*() {
       const set = yield* FiberSet.make()
       const run = yield* FiberSet.runtime(set)()
       const fiber = run(Effect.never, { propagateInterruption: true })
@@ -12,5 +12,5 @@ describe("FiberSet.runtime interruption propagation", () => {
       yield* Fiber.interrupt(fiber)
 
       assertTrue(yield* Deferred.isDone(set.deferred), "external interruption should be recorded")
-    })))
+    }))
 })

--- a/packages/effect/test/PubSub.test.ts
+++ b/packages/effect/test/PubSub.test.ts
@@ -518,59 +518,51 @@ describe("PubSub", () => {
       }))
 
     it.effect("sliding preserves publish order with a lagging subscriber", () =>
-      Effect.scoped(
-        Effect.gen(function*() {
-          const pubsub = yield* PubSub.sliding<number>({ capacity: 4, replay: 3 })
-          yield* PubSub.subscribe(pubsub)
-          yield* PubSub.publishAll(pubsub, [1, 2])
-          const subscription = yield* PubSub.subscribe(pubsub)
-          yield* PubSub.publishAll(pubsub, [3, 4, 5])
+      Effect.gen(function*() {
+        const pubsub = yield* PubSub.sliding<number>({ capacity: 4, replay: 3 })
+        yield* PubSub.subscribe(pubsub)
+        yield* PubSub.publishAll(pubsub, [1, 2])
+        const subscription = yield* PubSub.subscribe(pubsub)
+        yield* PubSub.publishAll(pubsub, [3, 4, 5])
 
-          const values = yield* PubSub.takeAll(subscription)
-          assert.isTrue(values.every((value, index) => index === 0 || values[index - 1] <= value))
-        })
-      ))
+        const values = yield* PubSub.takeAll(subscription)
+        assert.isTrue(values.every((value, index) => index === 0 || values[index - 1] <= value))
+      }))
   })
 
   it.effect("shutdown interrupts suspended subscribers", () =>
-    Effect.scoped(
-      Effect.gen(function*() {
-        const pubsub = yield* PubSub.unbounded<number>()
-        const subscription = yield* PubSub.subscribe(pubsub)
-        const fiber = yield* Effect.forkChild(PubSub.take(subscription), { startImmediately: true })
+    Effect.gen(function*() {
+      const pubsub = yield* PubSub.unbounded<number>()
+      const subscription = yield* PubSub.subscribe(pubsub)
+      const fiber = yield* Effect.forkChild(PubSub.take(subscription), { startImmediately: true })
 
-        yield* PubSub.shutdown(pubsub)
+      yield* PubSub.shutdown(pubsub)
 
-        const exit = yield* Fiber.await(fiber)
-        assert.isTrue(Exit.hasInterrupts(exit!))
-      })
-    ))
+      const exit = yield* Fiber.await(fiber)
+      assert.isTrue(Exit.hasInterrupts(exit!))
+    }))
 
   it.effect("publish succeeds after interrupting a suspended subscriber", () =>
-    Effect.scoped(
-      Effect.gen(function*() {
-        const pubsub = yield* PubSub.dropping<number>(1)
-        const subscription = yield* PubSub.subscribe(pubsub)
-        const fiber = yield* Effect.forkChild(PubSub.take(subscription), { startImmediately: true })
+    Effect.gen(function*() {
+      const pubsub = yield* PubSub.dropping<number>(1)
+      const subscription = yield* PubSub.subscribe(pubsub)
+      const fiber = yield* Effect.forkChild(PubSub.take(subscription), { startImmediately: true })
 
-        yield* Fiber.interrupt(fiber)
+      yield* Fiber.interrupt(fiber)
 
-        assert.isTrue(yield* PubSub.publish(pubsub, 42))
-        assert.strictEqual(yield* PubSub.take(subscription), 42)
-      })
-    ))
+      assert.isTrue(yield* PubSub.publish(pubsub, 42))
+      assert.strictEqual(yield* PubSub.take(subscription), 42)
+    }))
 
   it.effect("shutdown interrupts suspended takeAll subscribers", () =>
-    Effect.scoped(
-      Effect.gen(function*() {
-        const pubsub = yield* PubSub.unbounded<number>()
-        const subscription = yield* PubSub.subscribe(pubsub)
-        const fiber = yield* Effect.forkChild(PubSub.takeAll(subscription), { startImmediately: true })
-        yield* PubSub.shutdown(pubsub)
-        const exit = yield* Fiber.await(fiber)
-        assert.isTrue(Exit.hasInterrupts(exit))
-      })
-    ))
+    Effect.gen(function*() {
+      const pubsub = yield* PubSub.unbounded<number>()
+      const subscription = yield* PubSub.subscribe(pubsub)
+      const fiber = yield* Effect.forkChild(PubSub.takeAll(subscription), { startImmediately: true })
+      yield* PubSub.shutdown(pubsub)
+      const exit = yield* Fiber.await(fiber)
+      assert.isTrue(Exit.hasInterrupts(exit))
+    }))
 
   it.effect("Stream.fromPubSub completes after shutdown", () =>
     Effect.gen(function*() {
@@ -587,24 +579,20 @@ describe("PubSub", () => {
     }))
 
   it.effect("publish returns false after shutdown", () =>
-    Effect.scoped(
-      Effect.gen(function*() {
-        const pubsub = yield* PubSub.unbounded<number>()
-        yield* PubSub.shutdown(pubsub)
+    Effect.gen(function*() {
+      const pubsub = yield* PubSub.unbounded<number>()
+      yield* PubSub.shutdown(pubsub)
 
-        assert.strictEqual(yield* PubSub.publish(pubsub, 1), false)
-      })
-    ))
+      assert.strictEqual(yield* PubSub.publish(pubsub, 1), false)
+    }))
 
   it.effect("publishAll returns false after shutdown", () =>
-    Effect.scoped(
-      Effect.gen(function*() {
-        const pubsub = yield* PubSub.unbounded<number>()
-        yield* PubSub.shutdown(pubsub)
+    Effect.gen(function*() {
+      const pubsub = yield* PubSub.unbounded<number>()
+      yield* PubSub.shutdown(pubsub)
 
-        assert.strictEqual(yield* PubSub.publishAll(pubsub, [1, 2, 3]), false)
-      })
-    ))
+      assert.strictEqual(yield* PubSub.publishAll(pubsub, [1, 2, 3]), false)
+    }))
 })
 
 const retains = (root: object, target: object): boolean => {

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -5149,7 +5149,7 @@ describe("Stream", () => {
 
   describe("broadcastN", () => {
     it.effect("fans out to a fixed number of streams", () =>
-      Effect.scoped(Effect.gen(function*() {
+      Effect.gen(function*() {
         const [left, right] = yield* Stream.make(1, 2, 3).pipe(
           Stream.broadcastN({ n: 2, capacity: 4 })
         )
@@ -5160,10 +5160,10 @@ describe("Stream", () => {
         ], { concurrency: "unbounded" })
 
         assert.deepStrictEqual(result, [[1, 2, 3], [1, 2, 3]])
-      })))
+      }))
 
     it.effect("propagates failures to all downstream streams", () =>
-      Effect.scoped(Effect.gen(function*() {
+      Effect.gen(function*() {
         const [left, right] = yield* Stream.fail("boom").pipe(
           Stream.broadcastN({ n: 2, capacity: 4 })
         )
@@ -5174,7 +5174,7 @@ describe("Stream", () => {
         ], { concurrency: "unbounded" })
 
         assert.deepStrictEqual(result, [Exit.fail("boom"), Exit.fail("boom")])
-      })))
+      }))
   })
 })
 

--- a/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
+++ b/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
@@ -294,7 +294,7 @@ describe.concurrent("ClusterWorkflowEngine", () => {
       )
       assert(envelope)
       assert.strictEqual(envelope.address.shardId.group, "workflow")
-    }).pipe(Effect.scoped, Effect.provide(TestWorkflowEngine)))
+    }).pipe(Effect.provide(TestWorkflowEngine)))
 
   it.effect("propagates trace context to persisted workflow requests", () => {
     let callerSpan: Tracer.NativeSpan | undefined
@@ -335,7 +335,6 @@ describe.concurrent("ClusterWorkflowEngine", () => {
       assert.strictEqual(envelope.sampled, callerSpan.sampled)
     }).pipe(
       Effect.provideService(Tracer.Tracer, tracer),
-      Effect.scoped,
       Effect.provide(TestWorkflowEngine)
     )
   })
@@ -373,7 +372,7 @@ describe.concurrent("ClusterWorkflowEngine", () => {
       )
       assert(envelope)
       assert.strictEqual(envelope.address.shardId.group, "workflow")
-    }).pipe(Effect.scoped, Effect.provide(TestWorkflowEngine)))
+    }).pipe(Effect.provide(TestWorkflowEngine)))
 
   it.effect("SuspendOnFailure", () =>
     Effect.gen(function*() {

--- a/packages/effect/test/rpc/RpcServer.test.ts
+++ b/packages/effect/test/rpc/RpcServer.test.ts
@@ -5,58 +5,56 @@ import { Socket, SocketServer } from "effect/unstable/socket"
 
 describe("RpcServer", () => {
   it.effect("closes a socket when the serialization buffer limit is exceeded", () =>
-    Effect.scoped(
-      Effect.gen(function*() {
-        const handledChunks: Array<string> = []
-        const writes: Array<Uint8Array | string | Socket.CloseEvent> = []
-        const completed = yield* Deferred.make<void>()
-        let closed = false
+    Effect.gen(function*() {
+      const handledChunks: Array<string> = []
+      const writes: Array<Uint8Array | string | Socket.CloseEvent> = []
+      const completed = yield* Deferred.make<void>()
+      let closed = false
 
-        const socket = Socket.make({
-          runRaw: (handler) =>
-            Effect.gen(function*() {
-              for (const chunk of ["12", "34", "5", "{\"_tag\":\"Ping\"}\n"]) {
-                if (closed) break
-                handledChunks.push(chunk)
-                const result = handler(chunk)
-                if (Effect.isEffect(result)) {
-                  yield* result
-                }
+      const socket = Socket.make({
+        runRaw: (handler) =>
+          Effect.gen(function*() {
+            for (const chunk of ["12", "34", "5", "{\"_tag\":\"Ping\"}\n"]) {
+              if (closed) break
+              handledChunks.push(chunk)
+              const result = handler(chunk)
+              if (Effect.isEffect(result)) {
+                yield* result
               }
-            }).pipe(Effect.ensuring(Deferred.succeed(completed, void 0))),
-          writer: Effect.succeed((chunk) =>
-            Effect.sync(() => {
-              writes.push(chunk)
-              if (Socket.isCloseEvent(chunk)) {
-                closed = true
-              }
-            })
-          )
-        })
-        const socketServer = SocketServer.SocketServer.of({
-          address: {
-            _tag: "TcpAddress",
-            hostname: "localhost",
-            port: 0
-          },
-          run: (handler) => handler(socket).pipe(Effect.orDie, Effect.andThen(Effect.never))
-        })
-
-        const protocol = yield* RpcServer.makeProtocolSocketServer.pipe(
-          Effect.provide(Layer.succeed(SocketServer.SocketServer, socketServer)),
-          Effect.provide(Layer.succeed(
-            RpcSerialization.RpcSerialization,
-            RpcSerialization.makeNdjson({ maxBufferSize: 4 })
-          ))
+            }
+          }).pipe(Effect.ensuring(Deferred.succeed(completed, void 0))),
+        writer: Effect.succeed((chunk) =>
+          Effect.sync(() => {
+            writes.push(chunk)
+            if (Socket.isCloseEvent(chunk)) {
+              closed = true
+            }
+          })
         )
-        yield* Effect.forkScoped(protocol.run(() => Effect.void))
-        yield* Deferred.await(completed)
-
-        assert.deepStrictEqual(handledChunks, ["12", "34", "5"])
-        assert.strictEqual(writes.length, 1)
-        const closeEvent = writes[0]
-        assert(Socket.isCloseEvent(closeEvent))
-        assert.strictEqual(closeEvent.code, 1009)
       })
-    ))
+      const socketServer = SocketServer.SocketServer.of({
+        address: {
+          _tag: "TcpAddress",
+          hostname: "localhost",
+          port: 0
+        },
+        run: (handler) => handler(socket).pipe(Effect.orDie, Effect.andThen(Effect.never))
+      })
+
+      const protocol = yield* RpcServer.makeProtocolSocketServer.pipe(
+        Effect.provide(Layer.succeed(SocketServer.SocketServer, socketServer)),
+        Effect.provide(Layer.succeed(
+          RpcSerialization.RpcSerialization,
+          RpcSerialization.makeNdjson({ maxBufferSize: 4 })
+        ))
+      )
+      yield* Effect.forkScoped(protocol.run(() => Effect.void))
+      yield* Deferred.await(completed)
+
+      assert.deepStrictEqual(handledChunks, ["12", "34", "5"])
+      assert.strictEqual(writes.length, 1)
+      const closeEvent = writes[0]
+      assert(Socket.isCloseEvent(closeEvent))
+      assert.strictEqual(closeEvent.code, 1009)
+    }))
 })

--- a/packages/effect/test/unstable/ai/McpServer/McpConformance/ElicitationTest.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpConformance/ElicitationTest.ts
@@ -87,7 +87,7 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
             yield* peer.client["elicitation/create"](request)
 
             assert.strictEqual((yield* peer.takeRequest).method, "elicitation/create")
-          }).pipe(Effect.scoped))
+          }))
       })
 
       describe("Form Mode", () => {
@@ -119,7 +119,7 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
                 subscribed: true
               })
             }
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("MUST decode accepted content against the requested schema", () =>
           Effect.gen(function*() {
@@ -145,7 +145,7 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
             )
 
             assert.deepStrictEqual(result, { name: "Ada", age: 37 })
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("SCENARIO returns a typed failure when the user declines", () =>
           Effect.gen(function*() {
@@ -164,7 +164,7 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
             ).pipe(Effect.flip)
 
             assert.instanceOf(error, McpSchema.ElicitationDeclined)
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("SCENARIO interrupts the operation when the user cancels", () =>
           Effect.gen(function*() {
@@ -186,7 +186,7 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
             if (Exit.isFailure(exit)) {
               assert.isTrue(Cause.hasInterrupts(exit.cause))
             }
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("MUST reject accepted content that does not match the requested schema", () =>
           Effect.gen(function*() {
@@ -212,7 +212,7 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
             if (Exit.isFailure(exit)) {
               assert.isTrue(Cause.hasDies(exit.cause))
             }
-          }).pipe(Effect.scoped))
+          }))
       })
     })
   })

--- a/packages/effect/test/unstable/ai/McpServer/McpConformance/RootsTest.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpConformance/RootsTest.ts
@@ -26,7 +26,7 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
             yield* peer.client["roots/list"](undefined)
 
             assert.strictEqual((yield* peer.takeRequest).method, "roots/list")
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("MUST accept roots requests when the client advertises list changes", () =>
           Effect.gen(function*() {
@@ -41,7 +41,7 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
             yield* peer.client["roots/list"](undefined)
 
             assert.strictEqual((yield* peer.takeRequest).method, "roots/list")
-          }).pipe(Effect.scoped))
+          }))
       })
 
       describe("Listing Roots", () => {
@@ -70,7 +70,7 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
                 { uri: "file:///unnamed", name: undefined }
               ]
             )
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("MAY accept an empty roots list", () =>
           Effect.gen(function*() {
@@ -85,7 +85,7 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
             const result = yield* peer.client["roots/list"](undefined)
 
             assert.deepStrictEqual(result.roots, [])
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("MUST surface client errors returned by roots/list", () =>
           Effect.gen(function*() {
@@ -106,7 +106,7 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
 
             assert.instanceOf(error, McpSchema.InternalError)
             assert.strictEqual(error.message, "Roots unavailable")
-          }).pipe(Effect.scoped))
+          }))
       })
 
       describe("Root List Changes", () => {

--- a/packages/effect/test/unstable/ai/McpServer/McpConformance/SamplingTest.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpConformance/SamplingTest.ts
@@ -87,7 +87,7 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
             yield* peer.client["sampling/createMessage"](samplingRequest)
 
             assert.strictEqual((yield* peer.takeRequest).method, "sampling/createMessage")
-          }).pipe(Effect.scoped))
+          }))
       })
 
       describe("Creating Messages", () => {
@@ -126,7 +126,7 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
             assert.deepStrictEqual(payload.stopSequences, ["STOP"])
             assert.deepStrictEqual(payload.metadata, { request: "metadata" })
             assert.strictEqual(payload.includeContext, "thisServer")
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("MUST accept and decode text sampling content", () =>
           Effect.gen(function*() {
@@ -149,7 +149,7 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
               type: "text",
               text: "sampled"
             })
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("MUST accept image sampling content", () =>
           Effect.gen(function*() {
@@ -179,7 +179,7 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
               data: new Uint8Array([1, 2, 3]),
               mimeType: "image/png"
             })
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("MUST accept audio sampling content", () =>
           Effect.gen(function*() {
@@ -209,7 +209,7 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
               data: new Uint8Array([4, 5, 6]),
               mimeType: "audio/wav"
             })
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("MUST surface sampling errors returned by the client", () =>
           Effect.gen(function*() {
@@ -230,7 +230,7 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
 
             assert.instanceOf(error, McpSchema.InternalError)
             assert.strictEqual(error.message, "Sampling failed")
-          }).pipe(Effect.scoped))
+          }))
       })
     })
   })

--- a/packages/effect/test/unstable/http/Multipart.test.ts
+++ b/packages/effect/test/unstable/http/Multipart.test.ts
@@ -116,7 +116,7 @@ describe("Multipart", () => {
   })
 
   it.effect("returns distinct persisted file paths for files with the same client filename", () =>
-    Effect.scoped(Effect.gen(function*() {
+    Effect.gen(function*() {
       const formData = new FormData()
       formData.append("first", new File(["one"], "same.txt"))
       formData.append("second", new File(["two"], "same.txt"))
@@ -141,7 +141,7 @@ describe("Multipart", () => {
       strictEqual(first.path, "/tmp/audit/same.txt")
       notStrictEqual(first.path, second.path)
       deepStrictEqual(writes, [first.path, second.path])
-    })))
+    }))
 
   it.effect("responds based on the reason and is ignored by the ErrorReporter", () =>
     Effect.gen(function*() {

--- a/packages/effect/test/unstable/observability/OtlpExporter.test.ts
+++ b/packages/effect/test/unstable/observability/OtlpExporter.test.ts
@@ -250,88 +250,80 @@ describe("OtlpExporter", () => {
     }))
 
   it.effect("retries status 429 with numeric retry-after delay", () =>
-    Effect.scoped(
-      Effect.gen(function*() {
-        const { attempts, httpClient } = yield* makeHttpClient("2")
-        const exporter = yield* makeExporter(httpClient)
+    Effect.gen(function*() {
+      const { attempts, httpClient } = yield* makeHttpClient("2")
+      const exporter = yield* makeExporter(httpClient)
 
-        exporter.push({ value: 1 })
-        yield* yieldNowN(3)
+      exporter.push({ value: 1 })
+      yield* yieldNowN(3)
 
-        assert.strictEqual(yield* Ref.get(attempts), 1)
+      assert.strictEqual(yield* Ref.get(attempts), 1)
 
-        yield* TestClock.adjust("1 second")
-        yield* yieldNowN(2)
-        assert.strictEqual(yield* Ref.get(attempts), 1)
+      yield* TestClock.adjust("1 second")
+      yield* yieldNowN(2)
+      assert.strictEqual(yield* Ref.get(attempts), 1)
 
-        yield* TestClock.adjust("1 second")
-        yield* yieldNowN(2)
-        assert.strictEqual(yield* Ref.get(attempts), 2)
-      })
-    ))
+      yield* TestClock.adjust("1 second")
+      yield* yieldNowN(2)
+      assert.strictEqual(yield* Ref.get(attempts), 2)
+    }))
 
   it.effect("retries status 429 with HTTP-date retry-after delay", () =>
-    Effect.scoped(
-      Effect.gen(function*() {
-        const { attempts, httpClient } = yield* makeHttpClient("Thu, 01 Jan 1970 00:01:00 GMT")
-        const exporter = yield* makeExporter(httpClient)
+    Effect.gen(function*() {
+      const { attempts, httpClient } = yield* makeHttpClient("Thu, 01 Jan 1970 00:01:00 GMT")
+      const exporter = yield* makeExporter(httpClient)
 
-        exporter.push({ value: 1 })
-        yield* yieldNowN(3)
+      exporter.push({ value: 1 })
+      yield* yieldNowN(3)
 
-        assert.strictEqual(yield* Ref.get(attempts), 1)
+      assert.strictEqual(yield* Ref.get(attempts), 1)
 
-        yield* TestClock.adjust("5 seconds")
-        yield* yieldNowN(2)
-        assert.strictEqual(yield* Ref.get(attempts), 1)
+      yield* TestClock.adjust("5 seconds")
+      yield* yieldNowN(2)
+      assert.strictEqual(yield* Ref.get(attempts), 1)
 
-        yield* TestClock.adjust("55 seconds")
-        yield* yieldNowN(2)
-        assert.strictEqual(yield* Ref.get(attempts), 2)
-      })
-    ))
+      yield* TestClock.adjust("55 seconds")
+      yield* yieldNowN(2)
+      assert.strictEqual(yield* Ref.get(attempts), 2)
+    }))
 
   it.effect("uses fallback retry-after delay when header is non-numeric", () =>
-    Effect.scoped(
-      Effect.gen(function*() {
-        const { attempts, httpClient } = yield* makeHttpClient("soon")
-        const exporter = yield* makeExporter(httpClient)
+    Effect.gen(function*() {
+      const { attempts, httpClient } = yield* makeHttpClient("soon")
+      const exporter = yield* makeExporter(httpClient)
 
-        exporter.push({ value: 1 })
-        yield* yieldNowN(3)
+      exporter.push({ value: 1 })
+      yield* yieldNowN(3)
 
-        assert.strictEqual(yield* Ref.get(attempts), 1)
+      assert.strictEqual(yield* Ref.get(attempts), 1)
 
-        yield* TestClock.adjust("4 seconds")
-        yield* yieldNowN(2)
-        assert.strictEqual(yield* Ref.get(attempts), 1)
+      yield* TestClock.adjust("4 seconds")
+      yield* yieldNowN(2)
+      assert.strictEqual(yield* Ref.get(attempts), 1)
 
-        yield* TestClock.adjust("1 second")
-        yield* yieldNowN(2)
-        assert.strictEqual(yield* Ref.get(attempts), 2)
-      })
-    ))
+      yield* TestClock.adjust("1 second")
+      yield* yieldNowN(2)
+      assert.strictEqual(yield* Ref.get(attempts), 2)
+    }))
 
   it.effect("uses fallback retry-after delay when header is missing", () =>
-    Effect.scoped(
-      Effect.gen(function*() {
-        const { attempts, httpClient } = yield* makeHttpClient(undefined)
-        const exporter = yield* makeExporter(httpClient)
+    Effect.gen(function*() {
+      const { attempts, httpClient } = yield* makeHttpClient(undefined)
+      const exporter = yield* makeExporter(httpClient)
 
-        exporter.push({ value: 1 })
-        yield* yieldNowN(3)
+      exporter.push({ value: 1 })
+      yield* yieldNowN(3)
 
-        assert.strictEqual(yield* Ref.get(attempts), 1)
+      assert.strictEqual(yield* Ref.get(attempts), 1)
 
-        yield* TestClock.adjust("4 seconds")
-        yield* yieldNowN(2)
-        assert.strictEqual(yield* Ref.get(attempts), 1)
+      yield* TestClock.adjust("4 seconds")
+      yield* yieldNowN(2)
+      assert.strictEqual(yield* Ref.get(attempts), 1)
 
-        yield* TestClock.adjust("1 second")
-        yield* yieldNowN(2)
-        assert.strictEqual(yield* Ref.get(attempts), 2)
-      })
-    ))
+      yield* TestClock.adjust("1 second")
+      yield* yieldNowN(2)
+      assert.strictEqual(yield* Ref.get(attempts), 2)
+    }))
 
   describe("flush", () => {
     it.effect("exports buffered items without advancing to the export interval", () =>
@@ -424,24 +416,22 @@ describe("OtlpExporter", () => {
       }))
 
     it.effect("deregisters an exporter when its scope closes", () =>
-      Effect.scoped(
-        Effect.gen(function*() {
-          const { attempts, httpClient } = yield* makeStatusHttpClient(200)
-          const flusher = yield* OtlpExporter.Flusher
-          const scope = yield* Scope.make()
+      Effect.gen(function*() {
+        const { attempts, httpClient } = yield* makeStatusHttpClient(200)
+        const flusher = yield* OtlpExporter.Flusher
+        const scope = yield* Scope.make()
 
-          yield* makeExporterRaw("disabled").pipe(
-            Effect.provideService(HttpClient.HttpClient, httpClient),
-            Effect.provideService(Scope.Scope, scope)
-          )
+        yield* makeExporterRaw("disabled").pipe(
+          Effect.provideService(HttpClient.HttpClient, httpClient),
+          Effect.provideService(Scope.Scope, scope)
+        )
 
-          yield* Scope.close(scope, Exit.void)
-          assert.strictEqual(yield* Ref.get(attempts), 1)
+        yield* Scope.close(scope, Exit.void)
+        assert.strictEqual(yield* Ref.get(attempts), 1)
 
-          yield* flusher.flush
-          assert.strictEqual(yield* Ref.get(attempts), 1)
-        }).pipe(Effect.provide(OtlpExporter.layerFlusher))
-      ))
+        yield* flusher.flush
+        assert.strictEqual(yield* Ref.get(attempts), 1)
+      }).pipe(Effect.provide(OtlpExporter.layerFlusher)))
 
     it.effect("succeeds with no registered exporters", () =>
       Effect.gen(function*() {

--- a/packages/effect/test/unstable/persistence/Redis.test.ts
+++ b/packages/effect/test/unstable/persistence/Redis.test.ts
@@ -31,7 +31,6 @@ describe("Redis", () => {
       const store = yield* backing.make("empty")
       yield* store.clear
     }).pipe(
-      Effect.scoped,
       Effect.provide(Persistence.layerBackingRedis.pipe(Layer.provide(Layer.succeed(Redis.Redis, redis))))
     )
   })
@@ -68,7 +67,6 @@ describe("Redis", () => {
         expires: new Map([["ttl:batch", 2]])
       }])
     }).pipe(
-      Effect.scoped,
       Effect.provide(Persistence.layerBackingRedis.pipe(Layer.provide(Layer.succeed(Redis.Redis, redis))))
     )
   })

--- a/packages/effect/test/unstable/process/ChildProcess.test.ts
+++ b/packages/effect/test/unstable/process/ChildProcess.test.ts
@@ -83,21 +83,21 @@ describe("ChildProcess", () => {
         const cmd = ChildProcess.make`echo hello`
         const handle = yield* cmd
         assert.strictEqual(handle.pid, ChildProcessSpawner.ProcessId(12345))
-      }).pipe(Effect.scoped, Effect.provide(MockExecutorLayer)))
+      }).pipe(Effect.provide(MockExecutorLayer)))
 
     it.effect("should spawn a standard command", () =>
       Effect.gen(function*() {
         const cmd = ChildProcess.make("node", ["--version"])
         const handle = yield* cmd
         assert.strictEqual(handle.pid, ChildProcessSpawner.ProcessId(12345))
-      }).pipe(Effect.scoped, Effect.provide(MockExecutorLayer)))
+      }).pipe(Effect.provide(MockExecutorLayer)))
 
     it.effect("should return a process handle", () =>
       Effect.gen(function*() {
         const cmd = ChildProcess.make`long-running-process`
         const handle = yield* cmd
         assert.strictEqual(handle.pid, ChildProcessSpawner.ProcessId(12345))
-      }).pipe(Effect.scoped, Effect.provide(MockExecutorLayer)))
+      }).pipe(Effect.provide(MockExecutorLayer)))
 
     it.effect("collects stdout through Stream APIs", () =>
       Effect.gen(function*() {
@@ -105,7 +105,7 @@ describe("ChildProcess", () => {
         const handle = yield* cmd
         const chunks = yield* Stream.runCollect(handle.stdout)
         assert.isTrue(chunks.length > 0)
-      }).pipe(Effect.scoped, Effect.provide(MockExecutorLayer)))
+      }).pipe(Effect.provide(MockExecutorLayer)))
 
     it.effect("should allow waiting for exit code", () =>
       Effect.gen(function*() {
@@ -113,7 +113,7 @@ describe("ChildProcess", () => {
         const handle = yield* cmd
         const exitCode = yield* handle.exitCode
         assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
-      }).pipe(Effect.scoped, Effect.provide(MockExecutorLayer)))
+      }).pipe(Effect.provide(MockExecutorLayer)))
 
     it.effect("should unref a process and return a reref effect", () =>
       Effect.gen(function*() {
@@ -122,7 +122,7 @@ describe("ChildProcess", () => {
         const reref = yield* handle.unref
         assert.isDefined(reref)
         yield* reref
-      }).pipe(Effect.scoped, Effect.provide(MockExecutorLayer)))
+      }).pipe(Effect.provide(MockExecutorLayer)))
 
     it.effect("should allow restoring the reference within acquireRelease", () =>
       Effect.gen(function*() {
@@ -148,7 +148,7 @@ describe("ChildProcess", () => {
         )
         const handle = yield* pipeline
         assert.strictEqual(handle.pid, ChildProcessSpawner.ProcessId(12345))
-      }).pipe(Effect.scoped, Effect.provide(MockExecutorLayer)))
+      }).pipe(Effect.provide(MockExecutorLayer)))
   })
 
   describe("setCwd", () => {
@@ -346,7 +346,7 @@ describe("ChildProcess", () => {
           const handle = yield* cmd
           assert.isDefined(handle.getInputFd)
           assert.isDefined(handle.getOutputFd)
-        }).pipe(Effect.scoped, Effect.provide(MockExecutorLayer)))
+        }).pipe(Effect.provide(MockExecutorLayer)))
     })
   })
 })

--- a/packages/effect/test/unstable/process/ChildProcessSpawnerTest.ts
+++ b/packages/effect/test/unstable/process/ChildProcessSpawnerTest.ts
@@ -50,7 +50,7 @@ export const suite = (
 
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(output, "portable")
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should spawn echo command", () =>
             Effect.gen(function*() {
@@ -60,7 +60,7 @@ export const suite = (
 
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(output, "hello world")
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should spawn with template literal", () =>
             Effect.gen(function*() {
@@ -70,7 +70,7 @@ export const suite = (
 
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(output, "spawned")
-            }).pipe(Effect.scoped))
+            }))
         })
 
         describe("cwd option", () => {
@@ -83,7 +83,7 @@ export const suite = (
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               // On macOS, /tmp is a symlink to /private/tmp
               assert.isTrue(output.includes("tmp"))
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should use cwd with template literal form", () =>
             Effect.gen(function*() {
@@ -93,7 +93,7 @@ export const suite = (
 
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.isTrue(output.includes("tmp"))
-            }).pipe(Effect.scoped))
+            }))
         })
 
         describe("env option", () => {
@@ -108,7 +108,7 @@ export const suite = (
 
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(output, "test_value")
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should handle multiple environment variables", () =>
             Effect.gen(function*() {
@@ -121,7 +121,7 @@ export const suite = (
 
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(output, "one-two-three")
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should merge environment variables with setEnv", () =>
             Effect.gen(function*() {
@@ -135,7 +135,7 @@ export const suite = (
 
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(output, "one-override-three")
-            }).pipe(Effect.scoped))
+            }))
         })
 
         describe("shell option", () => {
@@ -151,7 +151,7 @@ export const suite = (
 
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(output, "expanded")
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should not expand variables without shell", () =>
             Effect.gen(function*() {
@@ -162,7 +162,7 @@ export const suite = (
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               // Without shell, $HOME should not be expanded
               assert.strictEqual(output, "$HOME")
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should allow piping with shell", () =>
             Effect.gen(function*() {
@@ -172,7 +172,7 @@ export const suite = (
 
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(output, "HELLO")
-            }).pipe(Effect.scoped))
+            }))
         })
 
         describe("template literal forms", () => {
@@ -184,7 +184,7 @@ export const suite = (
 
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(output, "hello")
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should handle string interpolation", () =>
             Effect.gen(function*() {
@@ -195,7 +195,7 @@ export const suite = (
 
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(output, "hello world")
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should handle number interpolation", () =>
             Effect.gen(function*() {
@@ -206,7 +206,7 @@ export const suite = (
 
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(output, "count is 42")
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should handle array interpolation", () =>
             Effect.gen(function*() {
@@ -223,7 +223,7 @@ export const suite = (
 
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.isTrue(output.includes("array-interpolation.txt"))
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should handle multiple interpolations", () =>
             Effect.gen(function*() {
@@ -235,7 +235,7 @@ export const suite = (
 
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(output, "hello world")
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should handle options with template literal", () =>
             Effect.gen(function*() {
@@ -246,7 +246,7 @@ export const suite = (
 
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(output, "test.txt")
-            }).pipe(Effect.scoped))
+            }))
         })
 
         describe("stderr streaming", () => {
@@ -258,7 +258,7 @@ export const suite = (
 
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(stderr, "error message")
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should capture both stdout and stderr", () =>
             Effect.gen(function*() {
@@ -272,7 +272,7 @@ export const suite = (
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(stdout, "stdout")
               assert.strictEqual(stderr, "stderr")
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should handle more stdout than stderr", () =>
             Effect.gen(function*() {
@@ -290,7 +290,7 @@ export const suite = (
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(stdout, ["line1", "line2", "line3", "line4", "line5"].join("\n"))
               assert.strictEqual(stderr, "error")
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should handle more stderr than stdout", () =>
             Effect.gen(function*() {
@@ -308,7 +308,7 @@ export const suite = (
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(stdout, "output")
               assert.strictEqual(stderr, ["err1", "err2", "err3", "err4", "err5"].join("\n"))
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should allow reading only stdout when stderr is empty", () =>
             Effect.gen(function*() {
@@ -323,7 +323,7 @@ export const suite = (
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(stdout, "only stdout")
               assert.strictEqual(stderr, "")
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should allow reading only stderr when stdout is empty", () =>
             Effect.gen(function*() {
@@ -338,7 +338,7 @@ export const suite = (
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(stdout, "")
               assert.strictEqual(stderr, "only stderr")
-            }).pipe(Effect.scoped))
+            }))
         })
 
         describe("combined output (all)", () => {
@@ -366,7 +366,7 @@ export const suite = (
               assert.strictEqual(lines.length, 4)
               assert.deepStrictEqual(lines.filter((line) => line.startsWith("stdout")), ["stdout1", "stdout2"])
               assert.deepStrictEqual(lines.filter((line) => line.startsWith("stderr")), ["stderr1", "stderr2"])
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should capture only stdout via .all when no stderr", () =>
             Effect.gen(function*() {
@@ -376,7 +376,7 @@ export const suite = (
 
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(all, "hello from stdout")
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should capture only stderr via .all when no stdout", () =>
             Effect.gen(function*() {
@@ -386,7 +386,7 @@ export const suite = (
 
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(all, "hello from stderr")
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should handle many lines of interspersed output via .all", () =>
             Effect.gen(function*() {
@@ -409,7 +409,7 @@ export const suite = (
                 lines.filter((line) => line.startsWith("stderr")),
                 ["stderr1", "stderr2", "stderr3", "stderr4", "stderr5"]
               )
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should allow reading .all independently", () =>
             Effect.gen(function*() {
@@ -422,7 +422,7 @@ export const suite = (
 
               assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
               assert.strictEqual(all, ["out", "err"].join("\n"))
-            }).pipe(Effect.scoped))
+            }))
         })
 
         describe("stdout streaming", () => {
@@ -432,7 +432,7 @@ export const suite = (
               const output = yield* decodeByteStream(handle.stdout)
 
               assert.strictEqual(output, "streaming output")
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should stream multiple lines", () =>
             Effect.gen(function*() {
@@ -440,7 +440,7 @@ export const suite = (
               const output = yield* decodeByteStream(handle.stdout)
 
               assert.strictEqual(output, ["line1", "line2", "line3"].join("\n"))
-            }).pipe(Effect.scoped))
+            }))
         })
 
         describe("process control", () => {
@@ -453,7 +453,7 @@ export const suite = (
               // After killing, exitCode should eventually resolve (with signal error)
               const exit = yield* Effect.exit(handle.exitCode)
               assert.isTrue(exit._tag === "Failure")
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should kill with specific signal", () =>
             Effect.gen(function*() {
@@ -463,7 +463,7 @@ export const suite = (
 
               const exit = yield* Effect.exit(handle.exitCode)
               assert.isTrue(exit._tag === "Failure")
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should force kill a process after the initial signal times out", () =>
             Effect.gen(function*() {
@@ -504,7 +504,7 @@ export const suite = (
               )
 
               assert.isTrue(completed)
-            }).pipe(Effect.scoped))
+            }))
 
           it.effect("should force kill a process when its scope closes", () =>
             Effect.gen(function*() {
@@ -542,7 +542,7 @@ export const suite = (
               )
 
               assert.isTrue(completed)
-            }).pipe(Effect.scoped))
+            }))
         })
       })
 
@@ -557,7 +557,7 @@ export const suite = (
 
             assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
             assert.strictEqual(output, "HELLO WORLD")
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("should spawn a three-stage pipeline", () =>
           Effect.gen(function*() {
@@ -570,7 +570,7 @@ export const suite = (
 
             assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
             assert.strictEqual(output, "HELLO-WORLD")
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("should pipe grep output", () =>
           Effect.gen(function*() {
@@ -582,7 +582,7 @@ export const suite = (
 
             assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
             assert.strictEqual(output, "line2")
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("should handle mixed command forms in pipeline", () =>
           Effect.gen(function*() {
@@ -594,7 +594,7 @@ export const suite = (
 
             assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
             assert.strictEqual(output, "HELLO")
-          }).pipe(Effect.scoped))
+          }))
       })
 
       describe("pipeline pipe options", () => {
@@ -609,7 +609,7 @@ export const suite = (
 
             assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
             assert.strictEqual(output, "error")
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("should pipe combined output with { from: 'all' }", () =>
           Effect.gen(function*() {
@@ -628,7 +628,7 @@ export const suite = (
             assert.strictEqual(lines.length, 3)
             assert.deepStrictEqual(lines.filter((line) => line.startsWith("out")), ["out1", "out2"])
             assert.deepStrictEqual(lines.filter((line) => line.startsWith("err")), ["err1"])
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("should default to stdout when no options provided", () =>
           Effect.gen(function*() {
@@ -642,7 +642,7 @@ export const suite = (
             assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
             // Only stdout should be piped (default behavior)
             assert.strictEqual(output, "stdout")
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("should work with empty options object", () =>
           Effect.gen(function*() {
@@ -654,7 +654,7 @@ export const suite = (
 
             assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
             assert.strictEqual(output, "HELLO")
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("should work with explicit { from: 'stdout' }", () =>
           Effect.gen(function*() {
@@ -666,7 +666,7 @@ export const suite = (
 
             assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
             assert.strictEqual(output, "HELLO")
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("should work with explicit { to: 'stdin' }", () =>
           Effect.gen(function*() {
@@ -678,7 +678,7 @@ export const suite = (
 
             assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
             assert.strictEqual(output, "HELLO")
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("should support chained pipes with different options", () =>
           Effect.gen(function*() {
@@ -693,7 +693,7 @@ export const suite = (
 
             assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
             assert.strictEqual(output, "error")
-          }).pipe(Effect.scoped))
+          }))
       })
 
       describe("error handling", () => {
@@ -703,7 +703,7 @@ export const suite = (
             const exitCode = yield* handle.exitCode
 
             assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(1))
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("should fail for invalid command", () =>
           Effect.gen(function*() {
@@ -712,7 +712,7 @@ export const suite = (
             )
 
             assert.isTrue(exit._tag === "Failure")
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("should handle spawn error with invalid cwd", () =>
           Effect.gen(function*() {
@@ -721,7 +721,7 @@ export const suite = (
             )
 
             assert.isTrue(exit._tag === "Failure")
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("should throw permission denied as a typed error", () =>
           Effect.gen(function*() {
@@ -734,7 +734,7 @@ export const suite = (
             assert.strictEqual(result.reason._tag, "PermissionDenied")
             assert.strictEqual(result.reason.module, "ChildProcess")
             assert.strictEqual(result.reason.method, "spawn")
-          }).pipe(Effect.scoped))
+          }))
       })
 
       describe("stdin", () => {
@@ -748,7 +748,7 @@ export const suite = (
 
             assert.deepStrictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
             assert.strictEqual(output, input)
-          }).pipe(Effect.scoped))
+          }))
       })
 
       describe.skipIf(options.additionalFds === false)("additionalFds", () => {
@@ -765,7 +765,7 @@ export const suite = (
 
             assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
             assert.strictEqual(fd3Output, "hello from fd3")
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("should write data to an input fd (fd3)", () =>
           Effect.gen(function*() {
@@ -785,7 +785,7 @@ export const suite = (
 
             assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
             assert.strictEqual(stdout, inputData)
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("should handle multiple additional fds", () =>
           Effect.gen(function*() {
@@ -808,7 +808,7 @@ export const suite = (
             assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
             assert.strictEqual(fd3Output, "output on fd3")
             assert.strictEqual(fd4Output, "output on fd4")
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("should handle fd gaps (e.g., fd3 and fd5 without fd4)", () =>
           Effect.gen(function*() {
@@ -831,7 +831,7 @@ export const suite = (
             assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
             assert.strictEqual(fd3Output, "on fd3")
             assert.strictEqual(fd5Output, "on fd5")
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("should return empty stream for unconfigured output fd", () =>
           Effect.gen(function*() {
@@ -843,7 +843,7 @@ export const suite = (
 
             assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
             assert.strictEqual(fd3Output, "")
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("should handle bidirectional communication via separate fds", () =>
           Effect.gen(function*() {
@@ -867,7 +867,7 @@ export const suite = (
 
             assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
             assert.strictEqual(fd4Output, "HELLO")
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect("should work alongside normal stdin/stdout/stderr", () =>
           Effect.gen(function*() {
@@ -889,7 +889,7 @@ export const suite = (
             assert.strictEqual(stdout, "stdout")
             assert.strictEqual(stderr, "stderr")
             assert.strictEqual(fd3Output, "fd3")
-          }).pipe(Effect.scoped))
+          }))
       })
 
       describe.sequential("process supervision", () => {
@@ -969,7 +969,7 @@ export const suite = (
               Effect.orElseSucceed(() => 0)
             )
             assert.strictEqual(afterKill, 0)
-          }).pipe(Effect.scoped))
+          }))
 
         it.effect.skipIf(!options.processGroups)(
           "should cleanup child processes when parent exits with non-zero code",
@@ -1010,7 +1010,7 @@ export const suite = (
               )
               // Child processes should be cleaned up after non-zero exit
               assert.strictEqual(afterExit, 0)
-            }).pipe(Effect.scoped)
+            })
         )
 
         it.effect("should not kill an unrefed process when scope closes", () =>
@@ -1155,7 +1155,7 @@ export const suite = (
           assert.strictEqual(lines.length, 100000)
           assert.strictEqual(lines[0], "1")
           assert.strictEqual(lines[99999], "100000")
-        }).pipe(Effect.scoped), { timeout: 10_000 })
+        }), { timeout: 10_000 })
 
       it.effect("ChildProcess.string should not deadlock on large output", () =>
         Effect.gen(function*() {

--- a/packages/opentelemetry/test/OtelMetrics.test.ts
+++ b/packages/opentelemetry/test/OtelMetrics.test.ts
@@ -340,7 +340,7 @@ describe("Metrics", () => {
     }))
 
   it.effect("reports the same delta to every registered reader", () =>
-    Effect.scoped(Effect.gen(function*() {
+    Effect.gen(function*() {
       class Reader extends MetricReader {
         protected onShutdown(): Promise<void> {
           return Promise.resolve()
@@ -362,5 +362,5 @@ describe("Metrics", () => {
       const firstValue = (firstResult.resourceMetrics.scopeMetrics[0]!.metrics[0] as any).dataPoints[0].value
       const secondValue = (secondResult.resourceMetrics.scopeMetrics[0]!.metrics[0] as any).dataPoints[0].value
       assert.deepStrictEqual([firstValue, secondValue], [1, 1])
-    })).pipe(Effect.provideService(Metric.MetricRegistry, new Map())))
+    }).pipe(Effect.provideService(Metric.MetricRegistry, new Map())))
 })

--- a/packages/opentelemetry/test/OtelTracer.test.ts
+++ b/packages/opentelemetry/test/OtelTracer.test.ts
@@ -42,7 +42,6 @@ describe("Tracer", () => {
         assert.instanceOf(span, OtelTracer.OtelSpan)
         assert.lengthOf(span.links, 1)
       }).pipe(
-        Effect.scoped,
         Effect.provide(TracingLive)
       ))
 
@@ -243,7 +242,6 @@ describe("Tracer", () => {
           })
         })
       }).pipe(
-        Effect.scoped,
         Effect.provide(TracingLive)
       ))
   })

--- a/packages/platform-deno/test/DenoChildProcessSpawner.test.ts
+++ b/packages/platform-deno/test/DenoChildProcessSpawner.test.ts
@@ -74,7 +74,7 @@ describe("DenoChildProcessSpawner options", () => {
           description: "The detached option is unsupported because Deno has no equivalent"
         })
       )
-    }).pipe(Effect.scoped, Effect.provide(layer)))
+    }).pipe(Effect.provide(layer)))
 
   it.effect("rejects additionalFds", () =>
     Effect.gen(function*() {
@@ -89,7 +89,7 @@ describe("DenoChildProcessSpawner options", () => {
           description: "The additionalFds option is unsupported because Deno has no equivalent"
         })
       )
-    }).pipe(Effect.scoped, Effect.provide(layer)))
+    }).pipe(Effect.provide(layer)))
 
   it.effect("rejects additional fd pipe sources", () =>
     Effect.gen(function*() {
@@ -105,7 +105,7 @@ describe("DenoChildProcessSpawner options", () => {
           description: "The additionalFds option is unsupported because Deno has no equivalent"
         })
       )
-    }).pipe(Effect.scoped, Effect.provide(layer)))
+    }).pipe(Effect.provide(layer)))
 
   it.effect("kills every process in a pipeline", () =>
     Effect.gen(function*() {
@@ -137,7 +137,7 @@ describe("DenoChildProcessSpawner options", () => {
 
       assert.strictEqual(rootFinalSize, rootSizeAfterKill)
       assert.strictEqual(childFinalSize, childSizeAfterKill)
-    }).pipe(Effect.scoped, Effect.provide(layer)))
+    }).pipe(Effect.provide(layer)))
 
   it.effect("emulates shell true without escaping joined arguments", () =>
     Effect.gen(function*() {

--- a/packages/platform-deno/test/DenoHttpCompression.test.ts
+++ b/packages/platform-deno/test/DenoHttpCompression.test.ts
@@ -154,5 +154,5 @@ describe("DenoHttpCompression", () => {
         const compressed = new Uint8Array(yield* zstd.arrayBuffer)
         assert.strictEqual(Zlib.zstdDecompressSync(compressed).toString(), bigJson)
       }
-    }).pipe(Effect.scoped, Effect.provide(DenoHttpServer.layerTest)))
+    }).pipe(Effect.provide(DenoHttpServer.layerTest)))
 })

--- a/packages/platform-deno/test/DenoHttpServer.test.ts
+++ b/packages/platform-deno/test/DenoHttpServer.test.ts
@@ -507,7 +507,7 @@ describe("DenoHttpServer", () => {
 
       const disposed = yield* Effect.promise(() => runtime.dispose()).pipe(Effect.timeoutOption("2 seconds"))
       assert.strictEqual(disposed._tag, "Some")
-    }).pipe(Effect.scoped))
+    }))
 
   describe("HttpServerRespondable", () => {
     it.effect("error/schema", () =>
@@ -683,7 +683,7 @@ describe("DenoHttpServer", () => {
 
       assert.deepStrictEqual(yield* Queue.take(received), new Uint8Array([1, 2, 3]))
       socket.close()
-    }).pipe(Effect.scoped, Effect.provide(DenoHttpServer.layerTest)))
+    }).pipe(Effect.provide(DenoHttpServer.layerTest)))
 })
 
 const serveWebSocket = (

--- a/packages/platform-deno/test/DenoRedis.integration.test.ts
+++ b/packages/platform-deno/test/DenoRedis.integration.test.ts
@@ -74,7 +74,7 @@ it.layer(PersistedQueueRedisLayer, { timeout: "30 seconds" })(
 )
 
 it.effect("closes the connection when interrupted during acquisition", () =>
-  Effect.scoped(Effect.gen(function*() {
+  Effect.gen(function*() {
     const listener = yield* makeListener
     const authReceived = yield* Deferred.make<void>()
     const sendAuthReply = yield* Deferred.make<void>()
@@ -100,10 +100,10 @@ it.effect("closes the connection when interrupted during acquisition", () =>
     yield* Fiber.join(interruptFiber)
 
     assert.isNull(yield* Fiber.join(server))
-  })))
+  }))
 
 it.effect("uses the URL username for two-argument AUTH", () =>
-  Effect.scoped(Effect.gen(function*() {
+  Effect.gen(function*() {
     const listener = yield* makeListener
     const server = yield* Effect.gen(function*() {
       const connection = yield* accept(listener)
@@ -122,10 +122,10 @@ it.effect("uses the URL username for two-argument AUTH", () =>
       yield* Fiber.join(server),
       "*3\r\n$4\r\nAUTH\r\n$5\r\nalice\r\n$6\r\nsecret\r\n"
     )
-  })))
+  }))
 
 it.effect("prefers explicit credentials over URL credentials", () =>
-  Effect.scoped(Effect.gen(function*() {
+  Effect.gen(function*() {
     const listener = yield* makeListener
     const server = yield* Effect.gen(function*() {
       const connection = yield* accept(listener)
@@ -145,7 +145,7 @@ it.effect("prefers explicit credentials over URL credentials", () =>
       yield* Fiber.join(server),
       "*3\r\n$4\r\nAUTH\r\n$3\r\nbob\r\n$5\r\nother\r\n"
     )
-  })))
+  }))
 
 const RedisItem = Schema.Struct({
   n: Schema.Number

--- a/packages/platform-node-shared/test/NodeFileSystem.test.ts
+++ b/packages/platform-node-shared/test/NodeFileSystem.test.ts
@@ -59,7 +59,6 @@ describe("FileSystem", () => {
       const event = yield* Fiber.join(fiber)
       assert.strictEqual(event.path, "direct.txt")
     }).pipe(
-      Effect.scoped,
       Effect.provide(NodeFileSystem.layer)
     ))
 
@@ -78,7 +77,6 @@ describe("FileSystem", () => {
       const event = yield* Fiber.join(fiber)
       assert.strictEqual(event.path, "direct.txt")
     }).pipe(
-      Effect.scoped,
       Effect.provide(NodeFileSystem.layer)
     ))
 
@@ -96,7 +94,6 @@ describe("FileSystem", () => {
       const event = yield* Fiber.join(fiber)
       assert(event.path.endsWith("nested.txt"))
     }).pipe(
-      Effect.scoped,
       Effect.provide(NodeFileSystem.layer)
     ))
 })

--- a/packages/platform-node/test/KeyValueStore.test.ts
+++ b/packages/platform-node/test/KeyValueStore.test.ts
@@ -45,7 +45,6 @@ describe("KeyValueStore / layerFileSystem", () => {
       assert.deepStrictEqual(yield* fs.readDirectory(directory), [])
       assert.strictEqual(yield* fs.readFileString(sibling), "sibling")
     }).pipe(
-      Effect.scoped,
       Effect.provide(NodeFileSystem.layer)
     ))
 })

--- a/packages/platform-node/test/NodeHttpCompression.test.ts
+++ b/packages/platform-node/test/NodeHttpCompression.test.ts
@@ -165,7 +165,7 @@ describe("NodeHttpCompression", () => {
       assert.strictEqual(head.status, 200)
       const result = yield* closed.await.pipe(Effect.timeoutOption("1 second"))
       assert.strictEqual(result._tag, "Some")
-    }).pipe(Effect.scoped, Effect.provide(NodeHttpServer.layerTest)))
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)))
 
   it.effect("flushes compressed chunks incrementally over the wire", () =>
     Effect.gen(function*() {
@@ -204,5 +204,5 @@ describe("NodeHttpCompression", () => {
         )
       )
       assert.strictEqual(received.join(""), "data: first\n\ndata: second\n\n")
-    }).pipe(Effect.scoped, Effect.provide(NodeHttpServer.layerTest)))
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)))
 })

--- a/packages/platform-node/test/NodeHttpServer.test.ts
+++ b/packages/platform-node/test/NodeHttpServer.test.ts
@@ -546,7 +546,7 @@ describe("HttpServer", () => {
       yield* completed.await
 
       assert.strictEqual(closeListenerRemovals, 1)
-    }).pipe(Effect.scoped))
+    }))
 
   it.effect("coalesces streaming chunks from the same pull", () =>
     Effect.gen(function*() {
@@ -582,7 +582,7 @@ describe("HttpServer", () => {
       yield* completed.await
 
       assert.deepStrictEqual(writes.map((chunk) => Buffer.Buffer.from(chunk).toString()), ["ab"])
-    }).pipe(Effect.scoped))
+    }))
 
   it.effect("waits for drain after a streaming write applies backpressure", () =>
     Effect.gen(function*() {
@@ -623,7 +623,7 @@ describe("HttpServer", () => {
       nodeResponse.emit("drain")
       yield* completed.await
       assert.strictEqual(writeCount, 1)
-    }).pipe(Effect.scoped))
+    }))
 
   it.live("disposes after a client aborts a handler awaiting an upstream request", () => {
     const upstreamStarted = Latch.makeUnsafe()
@@ -864,7 +864,7 @@ describe("HttpServer", () => {
       expect(uncaught).toEqual([])
       const response = yield* HttpClient.get("/")
       expect(response.status).toEqual(200)
-    }).pipe(Effect.scoped, Effect.provide(layerTestWebsocket)))
+    }).pipe(Effect.provide(layerTestWebsocket)))
 })
 
 const layerTestWebsocket = HttpServer.layerTestClient.pipe(

--- a/packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts
+++ b/packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts
@@ -229,7 +229,6 @@ describe("SqlRunnerStorage", () => {
       expect(yield* storageA.acquire(runnerAddress1, [shard])).toEqual([shard])
       expect(yield* storageB.acquire(runnerAddress2, [shard])).toEqual([shard])
     }).pipe(
-      Effect.scoped,
       Effect.provide(PgContainer.layerClient),
       Effect.provide(ShardingConfig.layer())
     ), 60_000)
@@ -243,7 +242,6 @@ describe("SqlRunnerStorage", () => {
       expect(yield* storageA.acquire(runnerAddress1, [shard])).toEqual([shard])
       expect(yield* storageB.acquire(runnerAddress2, [shard])).toEqual([])
     }).pipe(
-      Effect.scoped,
       Effect.provide(PgContainer.layerClient),
       Effect.provide(ShardingConfig.layer())
     ), 60_000)

--- a/packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts
+++ b/packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts
@@ -229,6 +229,8 @@ describe("SqlRunnerStorage", () => {
       expect(yield* storageA.acquire(runnerAddress1, [shard])).toEqual([shard])
       expect(yield* storageB.acquire(runnerAddress2, [shard])).toEqual([shard])
     }).pipe(
+      // Release the advisory-lock connections before the PostgreSQL layer.
+      Effect.scoped,
       Effect.provide(PgContainer.layerClient),
       Effect.provide(ShardingConfig.layer())
     ), 60_000)
@@ -242,6 +244,8 @@ describe("SqlRunnerStorage", () => {
       expect(yield* storageA.acquire(runnerAddress1, [shard])).toEqual([shard])
       expect(yield* storageB.acquire(runnerAddress2, [shard])).toEqual([])
     }).pipe(
+      // Release the advisory-lock connections before the PostgreSQL layer.
+      Effect.scoped,
       Effect.provide(PgContainer.layerClient),
       Effect.provide(ShardingConfig.layer())
     ), 60_000)


### PR DESCRIPTION
## Summary

- remove redundant `Effect.scoped` wrappers from `it.effect` and `it.live` callbacks across the test suite
- rely on the `Scope` supplied by `@effect/vitest`
- preserve nested scopes with distinct lifetimes, including the advisory-lock tests and the WebSocket scope whose nesting relative to its provided layer is behaviorally required

## Advisory-lock fix

The two `SqlRunnerStorage` advisory-lock tests still need an inner scope. `Effect.provide(PgContainer.layerClient)` owns a private layer scope, while the storages otherwise register their reserved connections in Vitest's outer scope. That lets PostgreSQL tear down before the advisory-lock finalizers run, causing cleanup to hang until the 60-second test timeout.

## Validation

- `pnpm lint`
- `pnpm check`
- targeted Node/Vitest entrypoints: 17 files, 722 tests passed
- targeted Deno entrypoints: 4 files, 102 tests passed
- PostgreSQL advisory-lock selection reproduced both timeouts twice before the fix, then passed both tests twice after the fix

Closes EFF-471
Closes EFF-476
