### PR TITLE
Fix JSON Schema prefixItems import semantics

### DIFF
--- a/.changeset/tidy-tuples-rest.md
+++ b/.changeset/tidy-tuples-rest.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve `maxItems` semantics when importing JSON Schema `prefixItems`.

--- a/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts
+++ b/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts
@@ -757,26 +757,23 @@ function translateJsonSchemaMultiDocument(
       case "boolean":
         return { _tag: "Boolean", checks: [] }
       case "array": {
+        const prefixItems = Array.isArray(schema.prefixItems) ? schema.prefixItems : undefined
         const minItems = typeof schema.minItems === "number" ? schema.minItems : 0
-        const elements = Array.isArray(schema.prefixItems)
-          ? schema.prefixItems.map((element, index) => ({
-            isOptional: index + 1 > minItems,
-            type: recur(element, [...path, "prefixItems", index])
-          }))
-          : []
-        const isMaxItemsRepresentedByTuple = schema.items === undefined &&
-          Array.isArray(schema.prefixItems) &&
-          schema.maxItems === schema.prefixItems.length
-        const rest = schema.items !== undefined
-          ? [recur(schema.items, [...path, "items"])]
-          : isMaxItemsRepresentedByTuple
-          ? []
-          : [unknown]
+        const elements = prefixItems?.map((element, index) => ({
+          isOptional: index + 1 > minItems,
+          type: recur(element, [...path, "prefixItems", index])
+        })) ?? []
+        const isTupleClosed = schema.items === false ||
+          (schema.items === undefined &&
+            prefixItems !== undefined &&
+            schema.maxItems === prefixItems.length)
         return {
           _tag: "Arrays",
           elements,
-          rest,
-          checks: collectArrayChecks(schema, isMaxItemsRepresentedByTuple)
+          rest: isTupleClosed
+            ? []
+            : [schema.items === undefined ? unknown : recur(schema.items, [...path, "items"])],
+          checks: collectArrayChecks(schema)
         }
       }
       case "object":
@@ -811,15 +808,18 @@ function translateJsonSchemaMultiDocument(
     return checks
   }
 
-  function collectArrayChecks(
-    schema: JsonSchema.JsonSchema,
-    isMaxItemsRepresentedByTuple: boolean
-  ): Array<Check> {
+  function collectArrayChecks(schema: JsonSchema.JsonSchema): Array<Check> {
     const checks: Array<Check> = []
     if (schema.prefixItems === undefined) {
       addNumberCheck(checks, schema.minItems, "effect/schema/isMinLength", "minLength")
     }
-    if (!isMaxItemsRepresentedByTuple) {
+    const maxItems = schema.maxItems
+    const prefixItemsLength = Array.isArray(schema.prefixItems) ? schema.prefixItems.length : undefined
+    const isMaxItemsRedundant = typeof maxItems === "number" &&
+      (schema.items === false
+        ? maxItems >= (prefixItemsLength ?? 0)
+        : schema.items === undefined && maxItems === prefixItemsLength)
+    if (!isMaxItemsRedundant) {
       addNumberCheck(checks, schema.maxItems, "effect/schema/isMaxLength", "maxLength")
     }
     if (schema.uniqueItems === true) {

--- a/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts
+++ b/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts
@@ -767,13 +767,16 @@ function translateJsonSchemaMultiDocument(
           (schema.items === undefined &&
             prefixItems !== undefined &&
             schema.maxItems === prefixItems.length)
+        const isMaxItemsRedundant = isTupleClosed &&
+          typeof schema.maxItems === "number" &&
+          schema.maxItems >= elements.length
         return {
           _tag: "Arrays",
           elements,
           rest: isTupleClosed
             ? []
             : [schema.items === undefined ? unknown : recur(schema.items, [...path, "items"])],
-          checks: collectArrayChecks(schema)
+          checks: collectArrayChecks(schema, isMaxItemsRedundant)
         }
       }
       case "object":
@@ -808,17 +811,11 @@ function translateJsonSchemaMultiDocument(
     return checks
   }
 
-  function collectArrayChecks(schema: JsonSchema.JsonSchema): Array<Check> {
+  function collectArrayChecks(schema: JsonSchema.JsonSchema, isMaxItemsRedundant: boolean): Array<Check> {
     const checks: Array<Check> = []
     if (schema.prefixItems === undefined) {
       addNumberCheck(checks, schema.minItems, "effect/schema/isMinLength", "minLength")
     }
-    const maxItems = schema.maxItems
-    const prefixItemsLength = Array.isArray(schema.prefixItems) ? schema.prefixItems.length : undefined
-    const isMaxItemsRedundant = typeof maxItems === "number" &&
-      (schema.items === false
-        ? maxItems >= (prefixItemsLength ?? 0)
-        : schema.items === undefined && maxItems === prefixItemsLength)
     if (!isMaxItemsRedundant) {
       addNumberCheck(checks, schema.maxItems, "effect/schema/isMaxLength", "maxLength")
     }

--- a/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts
+++ b/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts
@@ -764,16 +764,19 @@ function translateJsonSchemaMultiDocument(
             type: recur(element, [...path, "prefixItems", index])
           }))
           : []
+        const isMaxItemsRepresentedByTuple = schema.items === undefined &&
+          Array.isArray(schema.prefixItems) &&
+          schema.maxItems === schema.prefixItems.length
         const rest = schema.items !== undefined
           ? [recur(schema.items, [...path, "items"])]
-          : schema.prefixItems !== undefined && typeof schema.maxItems === "number"
+          : isMaxItemsRepresentedByTuple
           ? []
           : [unknown]
         return {
           _tag: "Arrays",
           elements,
           rest,
-          checks: collectArrayChecks(schema)
+          checks: collectArrayChecks(schema, isMaxItemsRepresentedByTuple)
         }
       }
       case "object":
@@ -808,10 +811,15 @@ function translateJsonSchemaMultiDocument(
     return checks
   }
 
-  function collectArrayChecks(schema: JsonSchema.JsonSchema): Array<Check> {
+  function collectArrayChecks(
+    schema: JsonSchema.JsonSchema,
+    isMaxItemsRepresentedByTuple: boolean
+  ): Array<Check> {
     const checks: Array<Check> = []
     if (schema.prefixItems === undefined) {
       addNumberCheck(checks, schema.minItems, "effect/schema/isMinLength", "minLength")
+    }
+    if (!isMaxItemsRepresentedByTuple) {
       addNumberCheck(checks, schema.maxItems, "effect/schema/isMaxLength", "maxLength")
     }
     if (schema.uniqueItems === true) {

--- a/packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts
+++ b/packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts
@@ -31,7 +31,7 @@ describe("fromJsonSchemaDocument", () => {
     return schema
   }
 
-  it("{}", () => {
+  it("unconstrained schema", () => {
     assertFromJsonSchema(
       { schema: {} },
       {
@@ -88,7 +88,7 @@ describe("fromJsonSchemaDocument", () => {
   })
 
   describe("const", () => {
-    it("const: literal (string)", () => {
+    it("string literal", () => {
       assertFromJsonSchema(
         { schema: { const: "a" } },
         {
@@ -156,7 +156,7 @@ describe("fromJsonSchemaDocument", () => {
       )
     })
 
-    it("const: null", () => {
+    it("null literal", () => {
       assertFromJsonSchema(
         { schema: { const: null } },
         {
@@ -205,7 +205,7 @@ describe("fromJsonSchemaDocument", () => {
   })
 
   describe("enum", () => {
-    it("single enum (string)", () => {
+    it("single string member", () => {
       assertFromJsonSchema(
         { schema: { enum: ["a"] } },
         {
@@ -273,7 +273,7 @@ describe("fromJsonSchemaDocument", () => {
       )
     })
 
-    it("multiple enum (literals)", () => {
+    it("multiple literal members", () => {
       assertFromJsonSchema(
         { schema: { enum: ["a", 1] } },
         {
@@ -844,7 +844,7 @@ describe("fromJsonSchemaDocument", () => {
         )
       })
 
-      it("pattern", () => {
+      it("pattern with an explicit string type", () => {
         assertFromJsonSchema(
           { schema: { type: "string", pattern: "a*" } },
           {
@@ -877,6 +877,9 @@ describe("fromJsonSchemaDocument", () => {
             "references": {}
           }
         )
+      })
+
+      it("pattern infers the string type", () => {
         assertFromJsonSchema(
           { schema: { pattern: "a*" } },
           {
@@ -1665,7 +1668,7 @@ describe("fromJsonSchemaDocument", () => {
       )
     })
 
-    it("prefixItems", () => {
+    it("prefixItems closes when maxItems equals the prefix length", () => {
       assertFromJsonSchema(
         {
           schema: {
@@ -1692,7 +1695,9 @@ describe("fromJsonSchemaDocument", () => {
           "references": {}
         }
       )
+    })
 
+    it("prefixItems marks elements required by minItems", () => {
       assertFromJsonSchema(
         {
           schema: {
@@ -1928,7 +1933,7 @@ describe("fromJsonSchemaDocument", () => {
   })
 
   describe("type: object", () => {
-    it("type only", () => {
+    it("allows additional properties by default", () => {
       assertFromJsonSchema(
         { schema: { type: "object" } },
         {
@@ -1960,6 +1965,9 @@ describe("fromJsonSchemaDocument", () => {
           "references": {}
         }
       )
+    })
+
+    it("closes an object when additionalProperties is false", () => {
       assertFromJsonSchema(
         {
           schema: {
@@ -2103,7 +2111,7 @@ describe("fromJsonSchemaDocument", () => {
       )
     })
 
-    it("patternProperties", () => {
+    it("imports a single pattern property", () => {
       assertFromJsonSchema(
         {
           schema: {
@@ -2157,6 +2165,9 @@ describe("fromJsonSchemaDocument", () => {
           "references": {}
         }
       )
+    })
+
+    it("imports multiple pattern properties", () => {
       assertFromJsonSchema(
         {
           schema: {
@@ -2634,7 +2645,7 @@ describe("fromJsonSchemaDocument", () => {
     })
   })
 
-  it("type: array of strings", () => {
+  it("array of types", () => {
     assertFromJsonSchema(
       {
         schema: { type: ["string", "null"] }
@@ -2689,7 +2700,7 @@ describe("fromJsonSchemaDocument", () => {
     )
   })
 
-  it("imports true schemas and structured enum members", () => {
+  it("ignores true schemas in allOf", () => {
     assertFromJsonSchema(
       { schema: { allOf: [true, { type: "string" }] } },
       {
@@ -2700,6 +2711,9 @@ describe("fromJsonSchemaDocument", () => {
         "references": {}
       }
     )
+  })
+
+  it("imports structured enum members as JSON", () => {
     assertFromJsonSchema(
       { schema: { enum: [[], {}] } },
       {
@@ -3105,71 +3119,118 @@ describe("fromJsonSchemaDocument", () => {
   })
 
   describe("allOf", () => {
-    it("resolves references on either side of an intersection", () => {
+    it("resolves a root reference before intersecting allOf", () => {
       const definition: JsonSchema.JsonSchema = { type: "string", minLength: 1 }
-      for (
-        const schema of [
-          {
-            $ref: "#/$defs/A",
-            allOf: [{ type: "string", maxLength: 2 }],
-            $defs: { A: definition }
-          },
-          {
-            allOf: [{ $ref: "#/$defs/A" }, { type: "string", maxLength: 2 }],
-            $defs: { A: definition }
-          }
-        ]
-      ) {
-        assertFromJsonSchema({ schema }, {
-          "representation": {
-            "_tag": "String",
-            "checks": [
-              {
-                "_tag": "Filter",
-                "representation": {
-                  "id": "effect/schema/isMinLength",
-                  "payload": {
+      assertFromJsonSchema({
+        schema: {
+          $ref: "#/$defs/A",
+          allOf: [{ type: "string", maxLength: 2 }],
+          $defs: { A: definition }
+        }
+      }, {
+        "representation": {
+          "_tag": "String",
+          "checks": [
+            {
+              "_tag": "Filter",
+              "representation": {
+                "id": "effect/schema/isMinLength",
+                "payload": {
+                  "minLength": 1
+                }
+              },
+              "annotations": {
+                "expected": "a value with a length of at least 1",
+                "~structural": true,
+                "arbitrary": {
+                  "constraint": {
                     "minLength": 1
                   }
-                },
-                "annotations": {
-                  "expected": "a value with a length of at least 1",
-                  "~structural": true,
-                  "arbitrary": {
-                    "constraint": {
-                      "minLength": 1
-                    }
-                  }
-                },
-                "aborted": false
+                }
               },
-              {
-                "_tag": "Filter",
-                "representation": {
-                  "id": "effect/schema/isMaxLength",
-                  "payload": {
+              "aborted": false
+            },
+            {
+              "_tag": "Filter",
+              "representation": {
+                "id": "effect/schema/isMaxLength",
+                "payload": {
+                  "maxLength": 2
+                }
+              },
+              "annotations": {
+                "expected": "a value with a length of at most 2",
+                "~structural": true,
+                "arbitrary": {
+                  "constraint": {
                     "maxLength": 2
                   }
-                },
-                "annotations": {
-                  "expected": "a value with a length of at most 2",
-                  "~structural": true,
-                  "arbitrary": {
-                    "constraint": {
-                      "maxLength": 2
-                    }
-                  }
-                },
-                "aborted": false
-              }
-            ]
-          },
-          "references": {}
-        })
-      }
+                }
+              },
+              "aborted": false
+            }
+          ]
+        },
+        "references": {}
+      })
     })
 
-    it("preserves annotations on array and object intersections", () => {
+    it("resolves a reference declared inside allOf", () => {
+      const definition: JsonSchema.JsonSchema = { type: "string", minLength: 1 }
+      assertFromJsonSchema({
+        schema: {
+          allOf: [{ $ref: "#/$defs/A" }, { type: "string", maxLength: 2 }],
+          $defs: { A: definition }
+        }
+      }, {
+        "representation": {
+          "_tag": "String",
+          "checks": [
+            {
+              "_tag": "Filter",
+              "representation": {
+                "id": "effect/schema/isMinLength",
+                "payload": {
+                  "minLength": 1
+                }
+              },
+              "annotations": {
+                "expected": "a value with a length of at least 1",
+                "~structural": true,
+                "arbitrary": {
+                  "constraint": {
+                    "minLength": 1
+                  }
+                }
+              },
+              "aborted": false
+            },
+            {
+              "_tag": "Filter",
+              "representation": {
+                "id": "effect/schema/isMaxLength",
+                "payload": {
+                  "maxLength": 2
+                }
+              },
+              "annotations": {
+                "expected": "a value with a length of at most 2",
+                "~structural": true,
+                "arbitrary": {
+                  "constraint": {
+                    "maxLength": 2
+                  }
+                }
+              },
+              "aborted": false
+            }
+          ]
+        },
+        "references": {}
+      })
+    })
+
+    it("preserves annotations on array intersections", () => {
       assertFromJsonSchema(
         {
           schema: {
@@ -3203,6 +3264,9 @@ describe("fromJsonSchemaDocument", () => {
           "references": {}
         }
       )
+    })
+
+    it("preserves annotations on object intersections", () => {
       assertFromJsonSchema(
         {
           schema: {
@@ -3321,35 +3385,52 @@ describe("fromJsonSchemaDocument", () => {
         )
       })
 
-      it("filters enum members", () => {
-        for (
-          const [schema, member] of [
-            [{ type: "string", minLength: 2 }, { enum: ["a", "ab"] }],
-            [{ enum: ["a", "ab"] }, { type: "string", minLength: 2 }]
-          ]
-        ) {
-          assertFromJsonSchema(
-            { schema: { ...schema, allOf: [member] } },
-            {
-              "representation": {
-                "_tag": "Union",
-                "checks": [],
-                "types": [
-                  {
-                    "_tag": "Literal",
-                    "checks": [],
-                    "literal": {
-                      "type": "string",
-                      "value": "ab"
-                    }
+      it("filters enum members when the refinement precedes the enum", () => {
+        assertFromJsonSchema(
+          { schema: { type: "string", minLength: 2, allOf: [{ enum: ["a", "ab"] }] } },
+          {
+            "representation": {
+              "_tag": "Union",
+              "checks": [],
+              "types": [
+                {
+                  "_tag": "Literal",
+                  "checks": [],
+                  "literal": {
+                    "type": "string",
+                    "value": "ab"
                   }
-                ],
-                "mode": "anyOf"
-              },
-              "references": {}
-            }
-          )
-        }
+                }
+              ],
+              "mode": "anyOf"
+            },
+            "references": {}
+          }
+        )
+      })
+
+      it("filters enum members when the enum precedes the refinement", () => {
+        assertFromJsonSchema(
+          { schema: { enum: ["a", "ab"], allOf: [{ type: "string", minLength: 2 }] } },
+          {
+            "representation": {
+              "_tag": "Union",
+              "checks": [],
+              "types": [
+                {
+                  "_tag": "Literal",
+                  "checks": [],
+                  "literal": {
+                    "type": "string",
+                    "value": "ab"
+                  }
+                }
+              ],
+              "mode": "anyOf"
+            },
+            "references": {}
+          }
+        )
       })
     })
 
@@ -4010,7 +4091,7 @@ describe("fromJsonSchemaDocument", () => {
         )
       })
 
-      it("& string enum", () => {
+      it("intersects with a single-member string enum", () => {
         assertFromJsonSchema(
           {
             schema: {
@@ -4057,6 +4138,9 @@ describe("fromJsonSchemaDocument", () => {
             "references": {}
           }
         )
+      })
+
+      it("intersects with a multi-member string enum", () => {
         assertFromJsonSchema(
           {
             schema: {
@@ -4518,7 +4602,7 @@ describe("fromJsonSchemaDocument", () => {
         )
       })
 
-      it("& number enum", () => {
+      it("intersects with a single-member number enum", () => {
         assertFromJsonSchema(
           {
             schema: {
@@ -4565,6 +4649,9 @@ describe("fromJsonSchemaDocument", () => {
             "references": {}
           }
         )
+      })
+
+      it("intersects with a multi-member number enum", () => {
         assertFromJsonSchema(
           {
             schema: {
@@ -4641,7 +4728,7 @@ describe("fromJsonSchemaDocument", () => {
         )
       })
 
-      it("& boolean enum", () => {
+      it("intersects with a single-member boolean enum", () => {
         assertFromJsonSchema(
           {
             schema: {
@@ -5063,25 +5150,72 @@ describe("fromJsonSchemaDocument", () => {
       })
     })
 
-    it("short-circuits Never and handles primitive intersections", () => {
-      for (
-        const schema of [
-          { allOf: [false, { type: "string" }] },
-          { allOf: [{ type: "array" }, { type: "string" }] },
-          { allOf: [{ type: "object" }, { type: "string" }] },
-          { allOf: [{ type: "null" }, { type: "string" }] },
-          { allOf: [{ const: 1 }, { const: 2 }] }
-        ]
-      ) {
-        assertFromJsonSchema({ schema }, {
+    it("short-circuits false intersections to Never", () => {
+      assertFromJsonSchema(
+        { schema: { allOf: [false, { type: "string" }] } },
+        {
           "representation": {
             "_tag": "Never",
             "checks": []
           },
           "references": {}
-        })
-      }
+        }
+      )
+    })
 
+    it("returns Never when intersecting array and string", () => {
+      assertFromJsonSchema(
+        { schema: { allOf: [{ type: "array" }, { type: "string" }] } },
+        {
+          "representation": {
+            "_tag": "Never",
+            "checks": []
+          },
+          "references": {}
+        }
+      )
+    })
+
+    it("returns Never when intersecting object and string", () => {
+      assertFromJsonSchema(
+        { schema: { allOf: [{ type: "object" }, { type: "string" }] } },
+        {
+          "representation": {
+            "_tag": "Never",
+            "checks": []
+          },
+          "references": {}
+        }
+      )
+    })
+
+    it("returns Never when intersecting null and string", () => {
+      assertFromJsonSchema(
+        { schema: { allOf: [{ type: "null" }, { type: "string" }] } },
+        {
+          "representation": {
+            "_tag": "Never",
+            "checks": []
+          },
+          "references": {}
+        }
+      )
+    })
+
+    it("returns Never when intersecting distinct literals", () => {
+      assertFromJsonSchema(
+        { schema: { allOf: [{ const: 1 }, { const: 2 }] } },
+        {
+          "representation": {
+            "_tag": "Never",
+            "checks": []
+          },
+          "references": {}
+        }
+      )
+    })
+
+    it("preserves null when intersecting null types", () => {
       assertFromJsonSchema(
         { schema: { allOf: [{ type: "null" }, { type: "null" }] } },
         {
@@ -5092,6 +5226,9 @@ describe("fromJsonSchemaDocument", () => {
           "references": {}
         }
       )
+    })
+
+    it("preserves a literal when intersecting identical literals", () => {
       assertFromJsonSchema(
         { schema: { allOf: [{ const: 1 }, { const: 1 }] } },
         {
@@ -5106,30 +5243,43 @@ describe("fromJsonSchemaDocument", () => {
           "references": {}
         }
       )
-      for (
-        const allOf of [
-          [{ type: "boolean" }, { const: true }],
-          [{ const: true }, { type: "boolean" }]
-        ]
-      ) {
-        assertFromJsonSchema(
-          { schema: { allOf } },
-          {
-            "representation": {
-              "_tag": "Literal",
-              "checks": [],
-              "literal": {
-                "type": "boolean",
-                "value": true
-              }
-            },
-            "references": {}
-          }
-        )
-      }
     })
 
-    it("combines references and annotated stable wrappers on either side", () => {
+    it("preserves a matching literal after a boolean type", () => {
+      assertFromJsonSchema(
+        { schema: { allOf: [{ type: "boolean" }, { const: true }] } },
+        {
+          "representation": {
+            "_tag": "Literal",
+            "checks": [],
+            "literal": {
+              "type": "boolean",
+              "value": true
+            }
+          },
+          "references": {}
+        }
+      )
+    })
+
+    it("preserves a matching literal before a boolean type", () => {
+      assertFromJsonSchema(
+        { schema: { allOf: [{ const: true }, { type: "boolean" }] } },
+        {
+          "representation": {
+            "_tag": "Literal",
+            "checks": [],
+            "literal": {
+              "type": "boolean",
+              "value": true
+            }
+          },
+          "references": {}
+        }
+      )
+    })
+
+    it("combines a string with a reference", () => {
       const definition: JsonSchema.JsonSchema = { type: "string", minLength: 1 }
       assertFromJsonSchema(
         {
@@ -5167,29 +5317,40 @@ describe("fromJsonSchemaDocument", () => {
           "references": {}
         }
       )
+    })
 
-      for (
-        const schema of [
-          {
-            type: "string",
-            allOf: [{ $ref: "#/$defs/A", description: "annotated" }],
-            $defs: { A: definition }
-          },
-          {
-            $ref: "#/$defs/A",
-            description: "annotated",
-            allOf: [{ type: "string" }],
-            $defs: { A: definition }
-          }
-        ]
-      ) {
-        const document = fromJsonSchemaRepresentation(JsonSchema.fromSchemaDraft2020_12(schema))
-        strictEqual(document.representation._tag, "String")
-        if (document.representation._tag === "String") {
-          strictEqual(document.representation.annotations?.description, "annotated")
-        }
+    it("preserves annotations on a reference inside allOf", () => {
+      const definition: JsonSchema.JsonSchema = { type: "string", minLength: 1 }
+      const document = fromJsonSchemaRepresentation(
+        JsonSchema.fromSchemaDraft2020_12({
+          type: "string",
+          allOf: [{ $ref: "#/$defs/A", description: "annotated" }],
+          $defs: { A: definition }
+        })
+      )
+      strictEqual(document.representation._tag, "String")
+      if (document.representation._tag === "String") {
+        strictEqual(document.representation.annotations?.description, "annotated")
       }
+    })
 
+    it("preserves annotations on a root reference intersected with allOf", () => {
+      const definition: JsonSchema.JsonSchema = { type: "string", minLength: 1 }
+      const document = fromJsonSchemaRepresentation(
+        JsonSchema.fromSchemaDraft2020_12({
+          $ref: "#/$defs/A",
+          description: "annotated",
+          allOf: [{ type: "string" }],
+          $defs: { A: definition }
+        })
+      )
+      strictEqual(document.representation._tag, "String")
+      if (document.representation._tag === "String") {
+        strictEqual(document.representation.annotations?.description, "annotated")
+      }
+    })
+
+    it("preserves annotations through reference aliases", () => {
       const aliases = fromJsonSchemaRepresentation(
         JsonSchema.fromSchemaDraft2020_12({
           type: "string",
@@ -5206,7 +5367,7 @@ describe("fromJsonSchemaDocument", () => {
       }
     })
 
-    it("merges string annotations, overlapping properties and index signatures", () => {
+    it("merges annotations on string intersections", () => {
       const string = fromJsonSchemaRepresentation(
         JsonSchema.fromSchemaDraft2020_12({
           allOf: [
@@ -5222,7 +5383,9 @@ describe("fromJsonSchemaDocument", () => {
           contentSchema: { type: "number" }
         })
       }
+    })
 
+    it("merges constraints on overlapping required properties", () => {
       const object = toSchemaFromJsonSchemaDocument(
         JsonSchema.fromSchemaDraft2020_12({
           type: "object",
@@ -5240,7 +5403,9 @@ describe("fromJsonSchemaDocument", () => {
       const isObject = Schema.is(object)
       assertTrue(isObject({ a: "ab" }))
       assertFalse(isObject({ a: "a" }))
+    })
 
+    it("preserves optional properties when intersecting object fields", () => {
       const optionalObject = fromJsonSchemaRepresentation(
         JsonSchema.fromSchemaDraft2020_12({
           type: "object",
@@ -5257,7 +5422,9 @@ describe("fromJsonSchemaDocument", () => {
       if (optionalObject.representation._tag === "Objects") {
         strictEqual(optionalObject.representation.propertySignatures[0].isOptional, true)
       }
+    })
 
+    it("merges object index signatures", () => {
       const indexes = fromJsonSchemaRepresentation(
         JsonSchema.fromSchemaDraft2020_12({
           type: "object",

--- a/packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts
+++ b/packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts
@@ -17,6 +17,22 @@ function fromJsonSchemaRepresentation(
 }
 
 describe("fromJsonSchemaDocument", () => {
+  it("preserves maxItems semantics with prefixItems", () => {
+    const bounded = toSchemaFromJsonSchemaDocument(JsonSchema.fromSchemaDraft2020_12({
+      type: "array",
+      prefixItems: [{ type: "string" }, { type: "number" }],
+      maxItems: 1
+    }))
+    const open = toSchemaFromJsonSchemaDocument(JsonSchema.fromSchemaDraft2020_12({
+      type: "array",
+      prefixItems: [{ type: "string" }],
+      maxItems: 2
+    }))
+
+    assertFalse(Schema.is(bounded)(["a", 1]))
+    assertTrue(Schema.is(open)(["a", 1]))
+  })
+
   function assertFromJsonSchema(
     input: {
       readonly schema: JsonSchema.JsonSchema

--- a/packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts
+++ b/packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts
@@ -17,22 +17,6 @@ function fromJsonSchemaRepresentation(
 }
 
 describe("fromJsonSchemaDocument", () => {
-  it("preserves maxItems semantics with prefixItems", () => {
-    const bounded = toSchemaFromJsonSchemaDocument(JsonSchema.fromSchemaDraft2020_12({
-      type: "array",
-      prefixItems: [{ type: "string" }, { type: "number" }],
-      maxItems: 1
-    }))
-    const open = toSchemaFromJsonSchemaDocument(JsonSchema.fromSchemaDraft2020_12({
-      type: "array",
-      prefixItems: [{ type: "string" }],
-      maxItems: 2
-    }))
-
-    assertFalse(Schema.is(bounded)(["a", 1]))
-    assertTrue(Schema.is(open)(["a", 1]))
-  })
-
   function assertFromJsonSchema(
     input: {
       readonly schema: JsonSchema.JsonSchema
@@ -1503,6 +1487,179 @@ describe("fromJsonSchemaDocument", () => {
     })
 
     it("prefixItems", () => {
+      assertFromJsonSchema(
+        {
+          schema: {
+            type: "array",
+            prefixItems: [{ type: "string" }, { type: "number" }],
+            maxItems: 1
+          }
+        },
+        {
+          "representation": {
+            "_tag": "Arrays",
+            "checks": [
+              {
+                "_tag": "Filter",
+                "representation": {
+                  "id": "effect/schema/isMaxLength",
+                  "payload": {
+                    "maxLength": 1
+                  }
+                },
+                "annotations": {
+                  "expected": "a value with a length of at most 1",
+                  "~structural": true,
+                  "arbitrary": {
+                    "constraint": {
+                      "maxLength": 1
+                    }
+                  }
+                },
+                "aborted": false
+              }
+            ],
+            "elements": [
+              {
+                "isOptional": true,
+                "type": {
+                  "_tag": "String",
+                  "checks": []
+                }
+              },
+              {
+                "isOptional": true,
+                "type": {
+                  "_tag": "Number",
+                  "checks": [
+                    {
+                      "_tag": "Filter",
+                      "representation": {
+                        "id": "effect/schema/isFinite",
+                        "payload": null
+                      },
+                      "annotations": {
+                        "expected": "a finite number",
+                        "arbitrary": {
+                          "constraint": {
+                            "noInfinity": true,
+                            "noNaN": true
+                          }
+                        }
+                      },
+                      "aborted": false
+                    }
+                  ]
+                }
+              }
+            ],
+            "rest": [
+              {
+                "_tag": "Declaration",
+                "representation": {
+                  "id": "effect/schema/Json",
+                  "payload": null
+                },
+                "annotations": {
+                  "expected": "JSON value"
+                },
+                "typeParameters": [],
+                "checks": []
+              }
+            ]
+          },
+          "references": {}
+        }
+      )
+
+      assertFromJsonSchema(
+        {
+          schema: {
+            type: "array",
+            prefixItems: [{ type: "string" }],
+            maxItems: 2
+          }
+        },
+        {
+          "representation": {
+            "_tag": "Arrays",
+            "checks": [
+              {
+                "_tag": "Filter",
+                "representation": {
+                  "id": "effect/schema/isMaxLength",
+                  "payload": {
+                    "maxLength": 2
+                  }
+                },
+                "annotations": {
+                  "expected": "a value with a length of at most 2",
+                  "~structural": true,
+                  "arbitrary": {
+                    "constraint": {
+                      "maxLength": 2
+                    }
+                  }
+                },
+                "aborted": false
+              }
+            ],
+            "elements": [
+              {
+                "isOptional": true,
+                "type": {
+                  "_tag": "String",
+                  "checks": []
+                }
+              }
+            ],
+            "rest": [
+              {
+                "_tag": "Declaration",
+                "representation": {
+                  "id": "effect/schema/Json",
+                  "payload": null
+                },
+                "annotations": {
+                  "expected": "JSON value"
+                },
+                "typeParameters": [],
+                "checks": []
+              }
+            ]
+          },
+          "references": {}
+        }
+      )
+
+      assertFromJsonSchema(
+        {
+          schema: {
+            type: "array",
+            prefixItems: [{ type: "string" }],
+            items: false,
+            maxItems: 2
+          }
+        },
+        {
+          "representation": {
+            "_tag": "Arrays",
+            "checks": [],
+            "elements": [
+              {
+                "isOptional": true,
+                "type": {
+                  "_tag": "String",
+                  "checks": []
+                }
+              }
+            ],
+            "rest": []
+          },
+          "references": {}
+        }
+      )
+
       assertFromJsonSchema(
         {
           schema: {

--- a/packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts
+++ b/packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts
@@ -1486,7 +1486,7 @@ describe("fromJsonSchemaDocument", () => {
       )
     })
 
-    it("prefixItems", () => {
+    it("prefixItems preserves maxItems below the prefix length", () => {
       assertFromJsonSchema(
         {
           schema: {
@@ -1571,7 +1571,9 @@ describe("fromJsonSchemaDocument", () => {
           "references": {}
         }
       )
+    })
 
+    it("prefixItems preserves maxItems above the prefix length", () => {
       assertFromJsonSchema(
         {
           schema: {
@@ -1631,7 +1633,9 @@ describe("fromJsonSchemaDocument", () => {
           "references": {}
         }
       )
+    })
 
+    it("prefixItems omits maxItems redundant with items: false", () => {
       assertFromJsonSchema(
         {
           schema: {
@@ -1659,7 +1663,9 @@ describe("fromJsonSchemaDocument", () => {
           "references": {}
         }
       )
+    })
 
+    it("prefixItems", () => {
       assertFromJsonSchema(
         {
           schema: {


### PR DESCRIPTION
## Summary

Importing `prefixItems` with `maxItems` can accept arrays longer than `maxItems` and reject permitted trailing items when the bound exceeds the prefix length. The resulting Effect schema therefore disagrees with both bounded and open Draft 2020-12 tuple forms.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## JSON Schema prefixItems loses maxItems semantics

**Module:** `effect/internal/schema/fromJsonSchemaDocument`  
**Audit ID:** `effect-ff1a063c2ab0dc92`  
**Severity / confidence:** medium / high

### What happens

Importing `prefixItems` with `maxItems` can accept arrays longer than `maxItems` and reject permitted trailing items when the bound exceeds the prefix length. The resulting Effect schema therefore disagrees with both bounded and open Draft 2020-12 tuple forms.

### Why it happens

The importer creates an element for every `prefixItems` entry, sets `rest` to empty whenever any numeric `maxItems` is present, and suppresses `maxLength` checks whenever `prefixItems` exists. Thus a bound shorter than the prefix is not enforced, while a bound longer than the prefix is converted into a closed tuple at the prefix length.

### Expected behavior

`SchemaRepresentation.fromJsonSchemaDocument` must treat `prefixItems` as positional constraints, `maxItems` as the total array-length bound, and absent or permissive `items` as allowing values after the prefix up to that bound.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/internal/schema/fromJsonSchemaDocument.ts:759-820`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts#L759-L820)

<details>
<summary>View problematic code at <code>packages/effect/src/internal/schema/fromJsonSchemaDocument.ts:759-808</code></summary>

```ts
      case "array": {
        const minItems = typeof schema.minItems === "number" ? schema.minItems : 0
        const elements = Array.isArray(schema.prefixItems)
          ? schema.prefixItems.map((element, index) => ({
            isOptional: index + 1 > minItems,
            type: recur(element, [...path, "prefixItems", index])
          }))
          : []
        const rest = schema.items !== undefined
          ? [recur(schema.items, [...path, "items"])]
          : schema.prefixItems !== undefined && typeof schema.maxItems === "number"
          ? []
          : [unknown]
        return {
          _tag: "Arrays",
          elements,
          rest,
          checks: collectArrayChecks(schema)
        }
      }
      case "object":
        return {
          _tag: "Objects",
          propertySignatures: collectProperties(schema, path),
          indexSignatures: collectIndexSignatures(schema, path),
          checks: collectObjectChecks(schema, path)
        }
      default:
        return unknown
    }
  }

  function collectStringChecks(schema: JsonSchema.JsonSchema): Array<Check> {
    const checks: Array<Check> = []
    addNumberCheck(checks, schema.minLength, "effect/schema/isMinLength", "minLength")
    addNumberCheck(checks, schema.maxLength, "effect/schema/isMaxLength", "maxLength")
    if (typeof schema.pattern === "string") {
      checks.push(jsonSchemaFilter("effect/schema/isPattern", { source: schema.pattern, flags: "" }))
    }
    return checks
  }

  function collectNumberChecks(schema: JsonSchema.JsonSchema): Array<Check> {
    const checks: Array<Check> = []
    addNumberCheck(checks, schema.minimum, "effect/schema/isGreaterThanOrEqualTo", "minimum")
    addNumberCheck(checks, schema.maximum, "effect/schema/isLessThanOrEqualTo", "maximum")
    addNumberCheck(checks, schema.exclusiveMinimum, "effect/schema/isGreaterThan", "exclusiveMinimum")
    addNumberCheck(checks, schema.exclusiveMaximum, "effect/schema/isLessThan", "exclusiveMaximum")
    addNumberCheck(checks, schema.multipleOf, "effect/schema/isMultipleOf", "divisor")
    return checks
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts#L759-L820)

_Excerpt truncated. [Open the complete packages/effect/src/internal/schema/fromJsonSchemaDocument.ts:759-820 range.](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts#L759-L820)_

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: JSON Schema prefixItems loses maxItems semantics.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-ff1a063c2ab0dc92`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-491