### PR TITLE
Fix jSON Schema additionalProperties is applied to declared fields

### DIFF
--- a/.changeset/clever-wolves-exclude.md
+++ b/.changeset/clever-wolves-exclude.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix imported JSON Schemas so `additionalProperties` ignores declared and pattern-matched properties.

--- a/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts
+++ b/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts
@@ -33,6 +33,40 @@ const never: ImportedJsonSchemaRepresentation = { _tag: "Never", checks: [] }
 const unknown: ImportedJsonSchemaRepresentation = { _tag: "Unknown", checks: [] }
 const string: ImportedJsonSchemaRepresentation = { _tag: "String", checks: [] }
 
+const additionalPropertyKeyFilterId = "effect/schema/isAdditionalPropertyKey"
+
+interface AdditionalPropertyKeyFilterPayload extends Schema.JsonObject {
+  readonly properties: ReadonlyArray<string>
+  readonly patterns: ReadonlyArray<string>
+}
+
+function additionalPropertyKeyFilter(
+  payload: AdditionalPropertyKeyFilterPayload,
+  annotations?: Schema.Annotations.Filter
+): SchemaAST.Filter<string> {
+  const properties = new Set(payload.properties)
+  const patterns = payload.patterns.map((pattern) => new globalThis.RegExp(pattern))
+  return Schema.makeFilter(
+    (key: string) => !properties.has(key) && patterns.every((pattern) => !pattern.test(key)),
+    {
+      representation: {
+        id: additionalPropertyKeyFilterId,
+        payload
+      },
+      ...annotations
+    }
+  )
+}
+
+const additionalPropertyKeyFilterReviver: SchemaRepresentation.FilterReviver<AdditionalPropertyKeyFilterPayload> = {
+  id: additionalPropertyKeyFilterId,
+  payloadSchema: Schema.Struct({
+    properties: Schema.Array(Schema.String),
+    patterns: Schema.Array(Schema.String)
+  }),
+  revive: ({ annotations, payload }) => additionalPropertyKeyFilter(payload, annotations)
+}
+
 function makeLiteral(literal: string | number | boolean): SchemaRepresentation.Literal {
   return { _tag: "Literal", literal, checks: [] }
 }
@@ -866,8 +900,23 @@ function translateJsonSchemaMultiDocument(
         type: unknown
       })
     } else if (typeof schema.additionalProperties === "object" && schema.additionalProperties !== null) {
+      const properties = typeof schema.properties === "object" &&
+          schema.properties !== null &&
+          !Array.isArray(schema.properties)
+        ? Object.keys(schema.properties)
+        : []
+      const patterns = typeof schema.patternProperties === "object" &&
+          schema.patternProperties !== null &&
+          !Array.isArray(schema.patternProperties)
+        ? Object.keys(schema.patternProperties)
+        : []
       signatures.push({
-        parameter: string,
+        parameter: properties.length === 0 && patterns.length === 0
+          ? string
+          : {
+            _tag: "String",
+            checks: [jsonSchemaFilter(additionalPropertyKeyFilterId, { properties, patterns })]
+          },
         type: recur(schema.additionalProperties, [...path, "additionalProperties"])
       })
     }
@@ -926,6 +975,7 @@ function toRepresentation(
 
 const jsonSchemaRevivers: ReadonlyArray<SchemaRepresentation.AnyReviver> = [
   Schema.JsonReviver,
+  additionalPropertyKeyFilterReviver,
   Schema.isPatternReviver,
   Schema.isFiniteReviver,
   Schema.isGreaterThanReviver,

--- a/packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts
+++ b/packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts
@@ -26,6 +26,17 @@ describe("fromJsonSchemaDocument", () => {
     }))
 
     assertTrue(Schema.is(schema)({ a: "ok", extra: true }))
+    assertFalse(Schema.is(schema)({ a: "ok", extra: "not a boolean" }))
+  })
+
+  it("applies additionalProperties only to properties not matched by patternProperties", () => {
+    const schema = toSchemaFromJsonSchemaDocument(JsonSchema.fromSchemaDraft2020_12({
+      type: "object",
+      patternProperties: { "^x": { type: "string" } },
+      additionalProperties: { type: "boolean" }
+    }))
+
+    assertTrue(Schema.is(schema)({ xName: "ok", extra: true }))
   })
 
   function assertFromJsonSchema(
@@ -1921,7 +1932,19 @@ describe("fromJsonSchemaDocument", () => {
               {
                 "parameter": {
                   "_tag": "String",
-                  "checks": []
+                  "checks": [
+                    {
+                      "_tag": "Filter",
+                      "aborted": false,
+                      "representation": {
+                        "id": "effect/schema/isAdditionalPropertyKey",
+                        "payload": {
+                          "patterns": [],
+                          "properties": ["a"]
+                        }
+                      }
+                    }
+                  ]
                 },
                 "type": {
                   "_tag": "Boolean",

--- a/packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts
+++ b/packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts
@@ -17,6 +17,17 @@ function fromJsonSchemaRepresentation(
 }
 
 describe("fromJsonSchemaDocument", () => {
+  it("applies additionalProperties only to undeclared properties", () => {
+    const schema = toSchemaFromJsonSchemaDocument(JsonSchema.fromSchemaDraft2020_12({
+      type: "object",
+      properties: { a: { type: "string" } },
+      required: ["a"],
+      additionalProperties: { type: "boolean" }
+    }))
+
+    assertTrue(Schema.is(schema)({ a: "ok", extra: true }))
+  })
+
   function assertFromJsonSchema(
     input: {
       readonly schema: JsonSchema.JsonSchema


### PR DESCRIPTION
## Summary

Importing an object with a declared string property and boolean `additionalProperties` rejects `{ a: "ok", extra: true }`. The declared property is incorrectly subjected to the additional-property schema, so a JSON Schema-valid object fails Effect validation.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## JSON Schema additionalProperties is applied to declared fields

**Module:** `effect/internal/schema/fromJsonSchemaDocument`  
**Audit ID:** `effect-8486ba58a19a6ce5`  
**Severity / confidence:** medium / high

### What happens

Importing an object with a declared string property and boolean `additionalProperties` rejects `{ a: "ok", extra: true }`. The declared property is incorrectly subjected to the additional-property schema, so a JSON Schema-valid object fails Effect validation.

### Why it happens

The importer creates a property signature for `a` and also creates an unrestricted string index signature for `additionalProperties`. Effect's object representation applies that index signature to every string key, intersecting the boolean constraint with the declared string constraint on `a` instead of excluding declared names.

### Expected behavior

`SchemaRepresentation.fromJsonSchemaDocument` must preserve Draft 2020-12 object semantics: `additionalProperties` applies only to property names not covered by `properties` or `patternProperties`.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/internal/schema/fromJsonSchemaDocument.ts:823-875`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts#L823-L875)

<details>
<summary>View problematic code at <code>packages/effect/src/internal/schema/fromJsonSchemaDocument.ts:823-872</code></summary>

```ts
  function collectProperties(
    schema: JsonSchema.JsonSchema,
    path: Path
  ): Array<SchemaRepresentation.PropertySignature> {
    const properties =
      typeof schema.properties === "object" && schema.properties !== null && !Array.isArray(schema.properties)
        ? schema.properties as Record<string, unknown>
        : {}
    const required = Array.isArray(schema.required)
      ? schema.required.filter((key): key is string => typeof key === "string")
      : []
    const keys = new Set([...Object.keys(properties), ...required])
    return Array.from(keys, (name) => ({
      name,
      type: recur(properties[name], [...path, "properties", name]),
      isOptional: !required.includes(name),
      isMutable: false
    }))
  }

  function collectIndexSignatures(
    schema: JsonSchema.JsonSchema,
    path: Path
  ): Array<SchemaRepresentation.IndexSignature> {
    const signatures: Array<SchemaRepresentation.IndexSignature> = []
    if (
      typeof schema.patternProperties === "object" &&
      schema.patternProperties !== null &&
      !Array.isArray(schema.patternProperties)
    ) {
      for (const [pattern, value] of Object.entries(schema.patternProperties)) {
        signatures.push({
          parameter: {
            _tag: "String",
            checks: [jsonSchemaFilter("effect/schema/isPattern", { source: pattern, flags: "" })]
          },
          type: recur(value, [...path, "patternProperties", pattern])
        })
      }
    }
    if (schema.additionalProperties === undefined || schema.additionalProperties === true) {
      signatures.push({
        parameter: string,
        type: unknown
      })
    } else if (typeof schema.additionalProperties === "object" && schema.additionalProperties !== null) {
      signatures.push({
        parameter: string,
        type: recur(schema.additionalProperties, [...path, "additionalProperties"])
      })
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts#L823-L875)

_Excerpt truncated. [Open the complete packages/effect/src/internal/schema/fromJsonSchemaDocument.ts:823-875 range.](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts#L823-L875)_

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: JSON Schema additionalProperties is applied to declared fields.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-8486ba58a19a6ce5`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-490

