### PR TITLE
Fix fiberSet serializes itself as FiberMap

### DIFF
--- a/.changeset/fix-fiberset-json-id.md
+++ b/.changeset/fix-fiberset-json-id.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix the inspectable JSON identity of `FiberSet`.

--- a/packages/effect/src/FiberSet.ts
+++ b/packages/effect/src/FiberSet.ts
@@ -100,7 +100,7 @@ const Proto = {
   ...PipeInspectableProto,
   toJSON(this: FiberSet<unknown, unknown>) {
     return {
-      _id: "FiberMap",
+      _id: "FiberSet",
       state: this.state
     }
   }

--- a/packages/effect/test/FiberSet.test.ts
+++ b/packages/effect/test/FiberSet.test.ts
@@ -4,6 +4,12 @@ import { Array, Deferred, Effect, Exit, Fiber, FiberSet, pipe, Ref, Scope } from
 import { TestClock } from "effect/testing"
 
 describe("FiberSet", () => {
+  it.effect("identifies FiberSet in JSON", () =>
+    Effect.gen(function*() {
+      const set = yield* FiberSet.make()
+      strictEqual((set.toJSON() as { readonly _id: string })._id, "FiberSet")
+    }))
+
   it.effect("interrupts running fibers when the scope closes", () =>
     Effect.gen(function*() {
       const ref = yield* Ref.make(0)


### PR DESCRIPTION
## Summary

- Fix `FiberSet.toJSON()` to identify the abstraction as `FiberSet` instead of `FiberMap`.
- Keep the regression assertion in the existing `packages/effect/test/FiberSet.test.ts` suite.
- Add a patch changeset for the user-visible inspection behavior correction.

## Validation

- `pnpm test --run packages/effect/test/FiberSet.test.ts`
- `pnpm test --run packages/effect/test`
- `pnpm lint`
- `pnpm check`

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Finding: `effect-5bde654107f0fb71`

Closes EFF-489