### PR TITLE
Fix tuple.make loses element literal types

### DIFF
--- a/.changeset/neat-tuples-remember.md
+++ b/.changeset/neat-tuples-remember.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve literal element types in `Tuple.make`.

--- a/packages/effect/src/Tuple.ts
+++ b/packages/effect/src/Tuple.ts
@@ -43,7 +43,7 @@ import type { Apply, Lambda } from "./Struct.ts"
  * @category constructors
  * @since 2.0.0
  */
-export const make = <Elements extends ReadonlyArray<unknown>>(...elements: Elements): Elements => elements
+export const make = <const Elements extends Array<unknown>>(...elements: Elements): Elements => elements
 
 type Indices<T extends ReadonlyArray<unknown>> = Exclude<Partial<T>["length"], T["length"]>
 

--- a/packages/effect/src/Tuple.ts
+++ b/packages/effect/src/Tuple.ts
@@ -43,7 +43,8 @@ import type { Apply, Lambda } from "./Struct.ts"
  * @category constructors
  * @since 2.0.0
  */
-export const make = <const Elements extends ReadonlyArray<unknown>>(...elements: Elements): Elements => elements
+export const make = <const Elements extends ReadonlyArray<unknown>>(...elements: [...Elements]): [...Elements] =>
+  elements
 
 type Indices<T extends ReadonlyArray<unknown>> = Exclude<Partial<T>["length"], T["length"]>
 

--- a/packages/effect/src/Tuple.ts
+++ b/packages/effect/src/Tuple.ts
@@ -43,7 +43,7 @@ import type { Apply, Lambda } from "./Struct.ts"
  * @category constructors
  * @since 2.0.0
  */
-export const make = <const Elements extends Array<unknown>>(...elements: Elements): Elements => elements
+export const make = <const Elements extends ReadonlyArray<unknown>>(...elements: Elements): Elements => elements
 
 type Indices<T extends ReadonlyArray<unknown>> = Exclude<Partial<T>["length"], T["length"]>
 

--- a/packages/effect/typetest/Tuple.tst.ts
+++ b/packages/effect/typetest/Tuple.tst.ts
@@ -7,6 +7,10 @@ const tuple = ["a", 2, true] as [string, number, boolean]
 const optionalTuple = ["a", 2, true] as [string?, number?, boolean?]
 
 describe("Tuple", () => {
+  it("make preserves argument literals", () => {
+    expect(Tuple.make("a", 1, true)).type.toBe<["a", 1, true]>()
+  })
+
   describe("get", () => {
     it("errors", () => {
       pipe(


### PR DESCRIPTION
## Summary

`Tuple.make("a", 1, true)` is inferred as `[string, number, boolean]` rather than `["a", 1, true]`. The constructor loses exact argument information, preventing its result from satisfying APIs that require those literal tuple positions.

## Tuple.make loses element literal types

**Module:** `effect/Tuple`  
**Audit ID:** `effect-de659caf5c519c20`  
**Severity / confidence:** low / high

### What happens

`Tuple.make("a", 1, true)` is inferred as `[string, number, boolean]` rather than `["a", 1, true]`. The constructor loses exact argument information, preventing its result from satisfying APIs that require those literal tuple positions.

### Why it happens

The rest parameter uses `Elements extends ReadonlyArray<unknown>` without a `const` type parameter. TypeScript therefore widens primitive arguments while inferring `Elements`, and the identity implementation returns that widened generic tuple type.

### Expected behavior

`Tuple.make` must preserve each argument's literal type in the returned tuple, as promised by its constructor contract.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/Tuple.ts:20-46`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Tuple.ts#L20-L46)

<details>
<summary>View problematic code at <code>packages/effect/src/Tuple.ts:20-46</code></summary>

````ts
/**
 * Creates a tuple from the provided arguments.
 *
 * **When to use**
 *
 * Use when you need a properly typed tuple without writing `[a, b, c] as const`
 * or another manual cast.
 *
 * **Details**
 *
 * The returned value has the exact tuple type, with each element's literal type
 * preserved.
 *
 * **Example** (Creating a tuple)
 *
 * ```ts import.meta.vitest
 * import { Tuple } from "effect"
 *
 * Tuple.make(10, 20, "red") // => [10, 20, "red"]
 * ```
 *
 * @see {@link get} – access a single element by index
 * @see {@link appendElement} – append an element to a tuple
 * @category constructors
 * @since 2.0.0
 */
export const make = <Elements extends ReadonlyArray<unknown>>(...elements: Elements): Elements => elements
````

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/Tuple.ts#L20-L46)

</details>

### Reproduction

```sh
pnpm test-types packages/effect/typetest/Tuple.tst.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: Tuple.make loses element literal types.

## Implementation

`Tuple.make` now uses a const type parameter constrained to a readonly array, with mutable tuple spreads for the rest parameter and return type. This preserves each argument's literal type while retaining a mutable tuple result.

## Validation

```sh
pnpm test-types packages/effect/typetest/Tuple.tst.ts
pnpm test packages/effect/test/Tuple.test.ts --run
pnpm lint
pnpm check
```

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-de659caf5c519c20`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-488