### PR TITLE
Fix DevTools span request snapshots

### DIFF
--- a/.changeset/fix-devtools-span-snapshot.md
+++ b/.changeset/fix-devtools-span-snapshot.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix DevTools span requests to preserve their state when queued for sending.

--- a/packages/effect/src/unstable/devtools/DevToolsClient.ts
+++ b/packages/effect/src/unstable/devtools/DevToolsClient.ts
@@ -25,9 +25,7 @@ import * as Socket from "../socket/Socket.ts"
 import * as DevToolsSchema from "./DevToolsSchema.ts"
 
 const RequestSchema = Schema.toCodecJson(DevToolsSchema.Request)
-const EncodedRequestSchema = Schema.toEncoded(RequestSchema)
 const ResponseSchema = Schema.toCodecJson(DevToolsSchema.Response)
-const encodeRequest = Schema.encodeSync(RequestSchema)
 
 /**
  * Service for sending span and span-event telemetry to the Effect devtools
@@ -48,11 +46,11 @@ export class DevToolsClient extends Context.Service<
 const makeEffect = Effect.gen(function*() {
   const socket = yield* Socket.Socket
   const services = yield* Effect.context<never>()
-  const requests = yield* Queue.unbounded<(typeof RequestSchema)["Encoded"]>()
+  const requests = yield* Queue.unbounded<DevToolsSchema.Request>()
   const connected = yield* Deferred.make<void>()
 
   const offerMetricsSnapshot = Effect.sync(() => {
-    Queue.offerUnsafe(requests, encodeRequest(toMetricsSnapshot(services)))
+    Queue.offerUnsafe(requests, toMetricsSnapshot(services))
   })
 
   const handleResponse = (
@@ -71,7 +69,7 @@ const makeEffect = Effect.gen(function*() {
   const fiber = yield* Stream.fromQueue(requests).pipe(
     Stream.pipeThroughChannel(
       Ndjson.duplexSchemaString(Socket.toChannelString(socket), {
-        inputSchema: EncodedRequestSchema,
+        inputSchema: RequestSchema,
         outputSchema: ResponseSchema
       })
     ),
@@ -89,7 +87,7 @@ const makeEffect = Effect.gen(function*() {
     )
   )
 
-  yield* Effect.suspend(() => Queue.offer(requests, encodeRequest({ _tag: "Ping" }))).pipe(
+  yield* Effect.suspend(() => Queue.offer(requests, { _tag: "Ping" })).pipe(
     Effect.delay("3 seconds"),
     Effect.forever,
     Effect.forkScoped
@@ -102,7 +100,7 @@ const makeEffect = Effect.gen(function*() {
 
   return DevToolsClient.of({
     sendUnsafe(request: DevToolsSchema.Span | DevToolsSchema.SpanEvent) {
-      Queue.offerUnsafe(requests, encodeRequest(request))
+      Queue.offerUnsafe(requests, request)
     }
   })
 })
@@ -186,7 +184,8 @@ const makeTracerEffect = Effect.gen(function*() {
   return Tracer.make({
     span(options) {
       const span = currentTracer.span(options)
-      client.sendUnsafe(span)
+      // the span is mutated in place, so send a snapshot of its current state
+      client.sendUnsafe({ ...span })
       const oldEvent = span.event
       span.event = function(this: Tracer.Span, name, startTime, attributes) {
         client.sendUnsafe({
@@ -203,7 +202,7 @@ const makeTracerEffect = Effect.gen(function*() {
       const oldEnd = span.end
       span.end = function(this: Tracer.Span, endTime, exit) {
         oldEnd.call(this, endTime, exit)
-        client.sendUnsafe(span)
+        client.sendUnsafe({ ...span })
       }
 
       return span

--- a/packages/effect/src/unstable/devtools/DevToolsClient.ts
+++ b/packages/effect/src/unstable/devtools/DevToolsClient.ts
@@ -25,7 +25,9 @@ import * as Socket from "../socket/Socket.ts"
 import * as DevToolsSchema from "./DevToolsSchema.ts"
 
 const RequestSchema = Schema.toCodecJson(DevToolsSchema.Request)
+const EncodedRequestSchema = Schema.toEncoded(RequestSchema)
 const ResponseSchema = Schema.toCodecJson(DevToolsSchema.Response)
+const encodeRequest = Schema.encodeSync(RequestSchema)
 
 /**
  * Service for sending span and span-event telemetry to the Effect devtools
@@ -46,11 +48,11 @@ export class DevToolsClient extends Context.Service<
 const makeEffect = Effect.gen(function*() {
   const socket = yield* Socket.Socket
   const services = yield* Effect.context<never>()
-  const requests = yield* Queue.unbounded<DevToolsSchema.Request>()
+  const requests = yield* Queue.unbounded<(typeof RequestSchema)["Encoded"]>()
   const connected = yield* Deferred.make<void>()
 
   const offerMetricsSnapshot = Effect.sync(() => {
-    Queue.offerUnsafe(requests, toMetricsSnapshot(services))
+    Queue.offerUnsafe(requests, encodeRequest(toMetricsSnapshot(services)))
   })
 
   const handleResponse = (
@@ -69,7 +71,7 @@ const makeEffect = Effect.gen(function*() {
   const fiber = yield* Stream.fromQueue(requests).pipe(
     Stream.pipeThroughChannel(
       Ndjson.duplexSchemaString(Socket.toChannelString(socket), {
-        inputSchema: RequestSchema,
+        inputSchema: EncodedRequestSchema,
         outputSchema: ResponseSchema
       })
     ),
@@ -87,7 +89,7 @@ const makeEffect = Effect.gen(function*() {
     )
   )
 
-  yield* Effect.suspend(() => Queue.offer(requests, { _tag: "Ping" })).pipe(
+  yield* Effect.suspend(() => Queue.offer(requests, encodeRequest({ _tag: "Ping" }))).pipe(
     Effect.delay("3 seconds"),
     Effect.forever,
     Effect.forkScoped
@@ -100,7 +102,7 @@ const makeEffect = Effect.gen(function*() {
 
   return DevToolsClient.of({
     sendUnsafe(request: DevToolsSchema.Span | DevToolsSchema.SpanEvent) {
-      Queue.offerUnsafe(requests, request)
+      Queue.offerUnsafe(requests, encodeRequest(request))
     }
   })
 })

--- a/packages/effect/test/unstable/devtools/DevToolsClient.test.ts
+++ b/packages/effect/test/unstable/devtools/DevToolsClient.test.ts
@@ -1,0 +1,47 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Deferred, Effect, Layer } from "effect"
+import { DevToolsClient } from "effect/unstable/devtools"
+import { Socket } from "effect/unstable/socket"
+
+describe("DevToolsClient", () => {
+  it.effect("sends a short-lived span once in each state", () =>
+    Effect.gen(function*() {
+      const spans: Array<any> = []
+      const received = yield* Deferred.make<void>()
+      const socket = Socket.make({
+        runRaw: (handler) =>
+          Effect.suspend(() => {
+            const result = handler("{\"_tag\":\"Pong\"}\n")
+            return Effect.isEffect(result) ? result : Effect.void
+          }).pipe(Effect.andThen(Effect.never)),
+        writer: Effect.succeed((chunk) =>
+          Effect.sync(() => {
+            if (Socket.isCloseEvent(chunk)) return false
+            const text = typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk)
+            for (const line of text.trim().split("\n")) {
+              if (line.length === 0) continue
+              const message = JSON.parse(line)
+              if (message._tag === "Span") spans.push(message)
+            }
+            return spans.length >= 2
+          }).pipe(
+            Effect.flatMap((done) => done ? Deferred.succeed(received, void 0) : Effect.void),
+            Effect.asVoid
+          )
+        )
+      })
+
+      yield* Effect.gen(function*() {
+        yield* Effect.void.pipe(Effect.withSpan("child"))
+        yield* Deferred.await(received)
+      }).pipe(
+        Effect.provide(
+          DevToolsClient.layerTracer.pipe(
+            Layer.provide(Layer.succeed(Socket.Socket, socket))
+          )
+        )
+      )
+
+      assert.deepStrictEqual(spans.map((span) => span.status._tag), ["Started", "Ended"])
+    }))
+})


### PR DESCRIPTION
## Summary

- encode DevTools requests when they are enqueued so mutable spans retain their send-time state
- add a wire-level regression test covering a sub-millisecond span's started and ended frames
- add a patch changeset

## Testing

- `nix develop -c pnpm vitest run packages/effect/test/unstable/devtools/DevToolsClient.test.ts`
- `nix develop -c pnpm --filter effect check`
- `nix develop -c pnpm lint`

Closes EFF-472
Closes #7031