### PR TITLE
Fix failed ResourceMap lookups leak acquisition scopes

### DIFF
--- a/.changeset/close-failed-resource-map-scopes.md
+++ b/.changeset/close-failed-resource-map-scopes.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Close `ResourceMap` acquisition scopes when a lookup fails.

--- a/packages/effect/src/unstable/cluster/internal/resourceMap.ts
+++ b/packages/effect/src/unstable/cluster/internal/resourceMap.ts
@@ -73,7 +73,10 @@ export class ResourceMap<K, A, E> {
           return Deferred.done(deferred, exit)
         }
         backingDelete(this.entries, key)
-        return Deferred.done(deferred, exit)
+        return Effect.andThen(
+          Deferred.done(deferred, exit),
+          Scope.close(scope, exit)
+        )
       })
     })
   }

--- a/packages/effect/src/unstable/cluster/internal/resourceMap.ts
+++ b/packages/effect/src/unstable/cluster/internal/resourceMap.ts
@@ -65,7 +65,7 @@ export class ResourceMap<K, A, E> {
       if (existing) {
         return Deferred.await(existing.deferred)
       }
-      const scope = Effect.runSync(Scope.make())
+      const scope = Scope.makeUnsafe()
       const deferred = Deferred.makeUnsafe<A, E>()
       backingSet(this.entries, key, { scope, deferred })
       return Effect.onExit(this.lookup(key, scope), (exit) => {

--- a/packages/effect/test/cluster/ResourceMap.test.ts
+++ b/packages/effect/test/cluster/ResourceMap.test.ts
@@ -1,15 +1,18 @@
-import { assert, it } from "@effect/vitest"
+import { assert, describe, it } from "@effect/vitest"
 import { Effect } from "effect"
-import { ResourceMap } from "../../src/unstable/cluster/internal/resourceMap.ts"
+import { ResourceMap } from "effect/unstable/cluster/internal/resourceMap"
 
-it.effect("closes a failed lookup scope", () =>
-  Effect.scoped(Effect.gen(function*() {
-    let finalized = 0
-    const map = yield* ResourceMap.make((_key: string) =>
-      Effect.gen(function*() {
-        yield* Effect.addFinalizer(() => Effect.sync(() => finalized++))
-        return yield* Effect.fail("failed")
-      }))
-    yield* Effect.exit(map.get("key"))
-    assert.strictEqual(finalized, 1)
-  })))
+describe("ResourceMap", () => {
+  it.effect("closes a failed lookup scope", () =>
+    Effect.scoped(Effect.gen(function*() {
+      let finalized = 0
+      const map = yield* ResourceMap.make((_key: string) =>
+        Effect.gen(function*() {
+          yield* Effect.addFinalizer(() => Effect.sync(() => finalized++))
+          return yield* Effect.fail("failed")
+        })
+      )
+      yield* Effect.exit(map.get("key"))
+      assert.strictEqual(finalized, 1)
+    })))
+})

--- a/packages/effect/test/cluster/ResourceMap.test.ts
+++ b/packages/effect/test/cluster/ResourceMap.test.ts
@@ -1,0 +1,15 @@
+import { assert, it } from "@effect/vitest"
+import { Effect } from "effect"
+import { ResourceMap } from "../../src/unstable/cluster/internal/resourceMap.ts"
+
+it.effect("closes a failed lookup scope", () =>
+  Effect.scoped(Effect.gen(function*() {
+    let finalized = 0
+    const map = yield* ResourceMap.make((_key: string) =>
+      Effect.gen(function*() {
+        yield* Effect.addFinalizer(() => Effect.sync(() => finalized++))
+        return yield* Effect.fail("failed")
+      }))
+    yield* Effect.exit(map.get("key"))
+    assert.strictEqual(finalized, 1)
+  })))


### PR DESCRIPTION
## Summary

Close each keyed resource's private acquisition scope when its lookup fails, so finalizers registered before the failure run immediately. Includes a focused regression test and patch changeset.

## Failed ResourceMap lookups leak acquisition scopes

**Module:** `effect/unstable/cluster/internal/resourceMap`  
**Audit ID:** `effect-fb55d74159c877b4`  
**Severity / confidence:** medium / high

### What happens

When a new keyed resource acquisition fails, its entry is removed from the map but its private acquisition scope is left open. Finalizers registered before the failure do not run.

### Why it happens

For a missing key, `get` creates a closeable scope and stores it with a deferred. Its failure `onExit` branch deletes the entry and completes the deferred but never calls `Scope.close`. Because the parent finalizer closes only scopes still present in the backing map, deleting the failed entry also removes the only later cleanup path.

### Expected behavior

Every per-key scope created by `ResourceMap.get` must be closed exactly once: by removal or map shutdown after a successful acquisition, or immediately when acquisition fails before the entry becomes usable.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/unstable/cluster/internal/resourceMap.ts:68-77`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/cluster/internal/resourceMap.ts#L68-L77)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/cluster/internal/resourceMap.ts:68-77</code></summary>

```ts
      const scope = Effect.runSync(Scope.make())
      const deferred = Deferred.makeUnsafe<A, E>()
      backingSet(this.entries, key, { scope, deferred })
      return Effect.onExit(this.lookup(key, scope), (exit) => {
        if (exit._tag === "Success") {
          return Deferred.done(deferred, exit)
        }
        backingDelete(this.entries, key)
        return Deferred.done(deferred, exit)
      })
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/cluster/internal/resourceMap.ts#L68-L77)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/cluster/ResourceMap.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: Failed ResourceMap lookups leak acquisition scopes.

## Implementation

The failure branch now completes the shared deferred and closes the per-key scope with the acquisition exit. The regression test verifies that finalizers registered before a failed acquisition run immediately.

## Validation

```sh
pnpm test --run packages/effect/test/cluster/ResourceMap.test.ts
pnpm test --run packages/effect/test/cluster
pnpm lint
pnpm check
```

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-fb55d74159c877b4`
- Initial patch: focused reproduction test; implementation fix included in this PR

Closes EFF-486