### PR TITLE
Report transient RPC socket open failures

### DIFF
--- a/.changeset/report-transient-rpc-socket-errors.md
+++ b/.changeset/report-transient-rpc-socket-errors.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Report retried RPC socket open failures through the `onTransientError` protocol hook.
+Report retried RPC socket open failures through the `onTransientError` protocol hook and fail in-flight requests when the retry policy is exhausted.

--- a/.changeset/report-transient-rpc-socket-errors.md
+++ b/.changeset/report-transient-rpc-socket-errors.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Report retried RPC socket open failures through the `onTransientError` protocol hook.

--- a/packages/effect/src/unstable/rpc/RpcClient.ts
+++ b/packages/effect/src/unstable/rpc/RpcClient.ts
@@ -1008,6 +1008,12 @@ export const layerProtocolHttp = (options: {
 export const makeProtocolSocket = (options?: {
   readonly retryTransientErrors?: boolean | undefined
   readonly retryPolicy?: Schedule.Schedule<any, Socket.SocketError> | undefined
+  /**
+   * Runs for each retried `SocketOpenError` when `retryTransientErrors` is enabled.
+   * Ping timeouts are also reported because the protocol classifies them as
+   * `SocketOpenError`. The returned `Effect<void>` cannot fail with a typed error
+   * or require services; defects are logged and ignored so retries can continue.
+   */
   readonly onTransientError?: ((error: RpcClientError) => Effect.Effect<void>) | undefined
 }): Effect.Effect<
   Protocol["Service"],
@@ -1033,6 +1039,13 @@ export const makeProtocolSocket = (options?: {
 
     const broadcast = (response: FromServerEncoded) =>
       Effect.forEach(clientIds, (clientId) => writeResponse(clientId, response))
+    const broadcastError = (error: RpcClientError) => {
+      currentError = error
+      return broadcast({
+        _tag: "ClientProtocolError",
+        error
+      })
+    }
 
     yield* Effect.suspend(() => {
       parser = serialization.makeUnsafe()
@@ -1107,15 +1120,19 @@ export const makeProtocolSocket = (options?: {
           options?.retryTransientErrors && hasError &&
           error.success.reason._tag === "SocketOpenError"
         ) {
-          return options.onTransientError?.(rpcError) ?? Effect.void
+          return (options.onTransientError?.(rpcError) ?? Effect.void).pipe(
+            Effect.ignoreCause({
+              log: true,
+              message: "RpcClient onTransientError hook failed"
+            })
+          )
         }
-        currentError = rpcError
-        return broadcast({
-          _tag: "ClientProtocolError",
-          error: currentError
-        })
+        return broadcastError(rpcError)
       }),
-      Effect.retry(options?.retryPolicy ?? defaultRetryPolicy),
+      Effect.retryOrElse(
+        options?.retryPolicy ?? defaultRetryPolicy,
+        (error) => broadcastError(new RpcClientError({ reason: error.reason }))
+      ),
       Effect.annotateLogs({
         module: "RpcClient",
         method: "makeProtocolSocket"
@@ -1178,6 +1195,12 @@ const makePinger = Effect.fnUntraced(function*<A, E, R>(writePing: Effect.Effect
  */
 export const layerProtocolSocket = (options?: {
   readonly retryTransientErrors?: boolean | undefined
+  /**
+   * Runs for each retried `SocketOpenError` when `retryTransientErrors` is enabled.
+   * Ping timeouts are also reported because the protocol classifies them as
+   * `SocketOpenError`. The returned `Effect<void>` cannot fail with a typed error
+   * or require services; defects are logged and ignored so retries can continue.
+   */
   readonly onTransientError?: ((error: RpcClientError) => Effect.Effect<void>) | undefined
 }): Layer.Layer<
   Protocol,

--- a/packages/effect/src/unstable/rpc/RpcClient.ts
+++ b/packages/effect/src/unstable/rpc/RpcClient.ts
@@ -1008,6 +1008,7 @@ export const layerProtocolHttp = (options: {
 export const makeProtocolSocket = (options?: {
   readonly retryTransientErrors?: boolean | undefined
   readonly retryPolicy?: Schedule.Schedule<any, Socket.SocketError> | undefined
+  readonly onTransientError?: ((error: RpcClientError) => Effect.Effect<void>) | undefined
 }): Effect.Effect<
   Protocol["Service"],
   never,
@@ -1096,18 +1097,19 @@ export const makeProtocolSocket = (options?: {
       Effect.tapCause((cause) => {
         const error = Cause.findError(cause)
         const hasError = Result.isSuccess(error)
-        if (
-          options?.retryTransientErrors && hasError &&
-          error.success.reason._tag === "SocketOpenError"
-        ) {
-          return Effect.void
-        }
-        currentError = new RpcClientError({
+        const rpcError = new RpcClientError({
           reason: hasError ? error.success.reason : new RpcClientDefect({
             message: "Unknown socket error",
             cause: Cause.squash(cause)
           })
         })
+        if (
+          options?.retryTransientErrors && hasError &&
+          error.success.reason._tag === "SocketOpenError"
+        ) {
+          return options.onTransientError?.(rpcError) ?? Effect.void
+        }
+        currentError = rpcError
         return broadcast({
           _tag: "ClientProtocolError",
           error: currentError
@@ -1176,6 +1178,7 @@ const makePinger = Effect.fnUntraced(function*<A, E, R>(writePing: Effect.Effect
  */
 export const layerProtocolSocket = (options?: {
   readonly retryTransientErrors?: boolean | undefined
+  readonly onTransientError?: ((error: RpcClientError) => Effect.Effect<void>) | undefined
 }): Layer.Layer<
   Protocol,
   never,

--- a/packages/effect/test/rpc/RpcClient.test.ts
+++ b/packages/effect/test/rpc/RpcClient.test.ts
@@ -84,7 +84,7 @@ describe("RpcClient", () => {
     }))
 
   it.effect("reports transient socket open errors without failing in-flight streams", () =>
-    Effect.scoped(Effect.gen(function*() {
+    Effect.gen(function*() {
       const requestSent = yield* Deferred.make<void>()
       const threeErrors = yield* Deferred.make<void>()
       const errors: Array<RpcClientError> = []
@@ -123,10 +123,10 @@ describe("RpcClient", () => {
         assert.strictEqual(error.reason._tag, "SocketOpenError")
       }
       assert.isUndefined(streamFiber.pollUnsafe())
-    })))
+    }))
 
   it.effect("fails in-flight streams when transient retries are exhausted", () =>
-    Effect.scoped(Effect.gen(function*() {
+    Effect.gen(function*() {
       const requestSent = yield* Deferred.make<void>()
       const socketError = new Socket.SocketError({
         reason: new Socket.SocketOpenError({
@@ -160,10 +160,10 @@ describe("RpcClient", () => {
 
       assert.instanceOf(error, RpcClientError)
       assert.strictEqual(error.reason._tag, "SocketOpenError")
-    })))
+    }))
 
   it.effect("continues retrying when the transient error hook defects", () =>
-    Effect.scoped(Effect.gen(function*() {
+    Effect.gen(function*() {
       const requestSent = yield* Deferred.make<void>()
       let attempts = 0
       const socketError = new Socket.SocketError({
@@ -204,5 +204,5 @@ describe("RpcClient", () => {
       assert.strictEqual(attempts, 3)
       assert.instanceOf(error, RpcClientError)
       assert.strictEqual(error.reason._tag, "SocketOpenError")
-    })))
+    }))
 })

--- a/packages/effect/test/rpc/RpcClient.test.ts
+++ b/packages/effect/test/rpc/RpcClient.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Cause, Deferred, Effect, Layer, Schedule, Schema, Stream } from "effect"
+import { Cause, Deferred, Effect, Fiber, Layer, Schedule, Schema, Stream } from "effect"
+import { TestClock } from "effect/testing"
 import * as HttpClient from "effect/unstable/http/HttpClient"
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse"
 import { Rpc, RpcClient, RpcGroup, RpcMessage, RpcSchema, RpcSerialization } from "effect/unstable/rpc"
@@ -99,7 +100,7 @@ describe("RpcClient", () => {
       })
       const protocol = yield* RpcClient.makeProtocolSocket({
         retryTransientErrors: true,
-        retryPolicy: Schedule.recurs(2),
+        retryPolicy: Schedule.spaced("1 millis"),
         onTransientError: (error) =>
           Effect.suspend(() => {
             errors.push(error)
@@ -114,6 +115,7 @@ describe("RpcClient", () => {
       )
       const streamFiber = yield* client.Events().pipe(Stream.runDrain, Effect.forkChild)
 
+      yield* TestClock.adjust("2 millis")
       yield* Deferred.await(threeErrors).pipe(Effect.timeout("1 second"))
 
       assert.lengthOf(errors, 3)
@@ -121,5 +123,86 @@ describe("RpcClient", () => {
         assert.strictEqual(error.reason._tag, "SocketOpenError")
       }
       assert.isUndefined(streamFiber.pollUnsafe())
+    })))
+
+  it.effect("fails in-flight streams when transient retries are exhausted", () =>
+    Effect.scoped(Effect.gen(function*() {
+      const requestSent = yield* Deferred.make<void>()
+      const socketError = new Socket.SocketError({
+        reason: new Socket.SocketOpenError({
+          kind: "Unknown",
+          cause: new Error("connection refused")
+        })
+      })
+      const socket = Socket.make({
+        runRaw: () => Deferred.await(requestSent).pipe(Effect.andThen(Effect.fail(socketError))),
+        writer: Effect.succeed(() => Deferred.succeed(requestSent, void 0))
+      })
+      const protocol = yield* RpcClient.makeProtocolSocket({
+        retryTransientErrors: true,
+        retryPolicy: Schedule.recurs(2)
+      }).pipe(
+        Effect.provideService(Socket.Socket, socket),
+        Effect.provide(RpcSerialization.layerNdjson)
+      )
+      const client = yield* RpcClient.make(TestGroup).pipe(
+        Effect.provideService(RpcClient.Protocol, protocol)
+      )
+      const streamFiber = yield* client.Events().pipe(
+        Stream.runDrain,
+        Effect.timeout("1 second"),
+        Effect.flip,
+        Effect.forkChild
+      )
+
+      yield* TestClock.adjust("1 second")
+      const error = yield* Fiber.join(streamFiber)
+
+      assert.instanceOf(error, RpcClientError)
+      assert.strictEqual(error.reason._tag, "SocketOpenError")
+    })))
+
+  it.effect("continues retrying when the transient error hook defects", () =>
+    Effect.scoped(Effect.gen(function*() {
+      const requestSent = yield* Deferred.make<void>()
+      let attempts = 0
+      const socketError = new Socket.SocketError({
+        reason: new Socket.SocketOpenError({
+          kind: "Unknown",
+          cause: new Error("connection refused")
+        })
+      })
+      const socket = Socket.make({
+        runRaw: () =>
+          Deferred.await(requestSent).pipe(
+            Effect.tap(() => Effect.sync(() => attempts++)),
+            Effect.andThen(Effect.fail(socketError))
+          ),
+        writer: Effect.succeed(() => Deferred.succeed(requestSent, void 0))
+      })
+      const protocol = yield* RpcClient.makeProtocolSocket({
+        retryTransientErrors: true,
+        retryPolicy: Schedule.recurs(2),
+        onTransientError: () => Effect.die("hook defect")
+      }).pipe(
+        Effect.provideService(Socket.Socket, socket),
+        Effect.provide(RpcSerialization.layerNdjson)
+      )
+      const client = yield* RpcClient.make(TestGroup).pipe(
+        Effect.provideService(RpcClient.Protocol, protocol)
+      )
+      const streamFiber = yield* client.Events().pipe(
+        Stream.runDrain,
+        Effect.timeout("1 second"),
+        Effect.flip,
+        Effect.forkChild
+      )
+
+      yield* TestClock.adjust("1 second")
+      const error = yield* Fiber.join(streamFiber)
+
+      assert.strictEqual(attempts, 3)
+      assert.instanceOf(error, RpcClientError)
+      assert.strictEqual(error.reason._tag, "SocketOpenError")
     })))
 })

--- a/packages/effect/test/rpc/RpcClient.test.ts
+++ b/packages/effect/test/rpc/RpcClient.test.ts
@@ -1,9 +1,10 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Cause, Effect, Layer, Schema, Stream } from "effect"
+import { Cause, Deferred, Effect, Layer, Schedule, Schema, Stream } from "effect"
 import * as HttpClient from "effect/unstable/http/HttpClient"
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse"
 import { Rpc, RpcClient, RpcGroup, RpcMessage, RpcSchema, RpcSerialization } from "effect/unstable/rpc"
 import { RpcClientError } from "effect/unstable/rpc/RpcClientError"
+import * as Socket from "effect/unstable/socket/Socket"
 
 const TestGroup = RpcGroup.make(
   Rpc.make("Ping", { success: Schema.String }),
@@ -80,4 +81,45 @@ describe("RpcClient", () => {
       assert.strictEqual(error.reason._tag, "RpcClientDefect")
       assert.strictEqual(error.reason.message, "HTTP response ended before RPC request completed")
     }))
+
+  it.effect("reports transient socket open errors without failing in-flight streams", () =>
+    Effect.scoped(Effect.gen(function*() {
+      const requestSent = yield* Deferred.make<void>()
+      const threeErrors = yield* Deferred.make<void>()
+      const errors: Array<RpcClientError> = []
+      const socketError = new Socket.SocketError({
+        reason: new Socket.SocketOpenError({
+          kind: "Unknown",
+          cause: new Error("connection refused")
+        })
+      })
+      const socket = Socket.make({
+        runRaw: () => Deferred.await(requestSent).pipe(Effect.andThen(Effect.fail(socketError))),
+        writer: Effect.succeed(() => Deferred.succeed(requestSent, void 0))
+      })
+      const protocol = yield* RpcClient.makeProtocolSocket({
+        retryTransientErrors: true,
+        retryPolicy: Schedule.recurs(2),
+        onTransientError: (error) =>
+          Effect.suspend(() => {
+            errors.push(error)
+            return errors.length === 3 ? Deferred.succeed(threeErrors, void 0) : Effect.void
+          })
+      }).pipe(
+        Effect.provideService(Socket.Socket, socket),
+        Effect.provide(RpcSerialization.layerNdjson)
+      )
+      const client = yield* RpcClient.make(TestGroup).pipe(
+        Effect.provideService(RpcClient.Protocol, protocol)
+      )
+      const streamFiber = yield* client.Events().pipe(Stream.runDrain, Effect.forkChild)
+
+      yield* Deferred.await(threeErrors).pipe(Effect.timeout("1 second"))
+
+      assert.lengthOf(errors, 3)
+      for (const error of errors) {
+        assert.strictEqual(error.reason._tag, "SocketOpenError")
+      }
+      assert.isUndefined(streamFiber.pollUnsafe())
+    })))
 })


### PR DESCRIPTION
## Summary

- add an `onTransientError` hook to socket protocol options and the socket protocol layer
- report every retried pre-open `SocketOpenError` as a structured `RpcClientError`
- fall back to a terminal `ClientProtocolError` broadcast when a finite retry policy is exhausted
- contain and log hook defects so observational code cannot stop reconnection
- cover continuing retries, finite exhaustion, and hook defects with socket RPC regression tests
- add a patch changeset

## Why

With `retryTransientErrors: true`, the socket protocol intentionally suppresses terminal `ClientProtocolError` broadcasts for pre-open failures so registered requests survive reconnection. That same branch previously emitted no observable signal, leaving applications unable to distinguish reconnection from a silently parked stream.

The hook is the smallest signal that preserves the retry contract. Reusing the existing broadcast for every attempt would fail all registered entries and effectively defeat `retryTransientErrors`. Once a finite retry policy is exhausted, however, there will be no reconnection, so the final error is stored and broadcast to fail registered entries cleanly.

Hook defects are logged and ignored. The hook is observational, and allowing its defect to kill the protocol fiber would recreate the silent-stop failure mode it exists to expose.

Issue #5988 is separable and already addressed by the current v4 shape: `RpcClientError.reason` retains the typed socket reason (including close codes, close reasons, and open causes). This change reuses that structured error for both hook and terminal paths without altering the error model.

## Validation

- `nix develop -c pnpm check`
- targeted dprint and oxlint checks
- focused `RpcClient.test.ts` suite: 6/6 passed

Closes EFF-473
Closes #7030
