### PR TITLE
Fix wrapped spans treat every OpenTelemetry status as an error

### DIFF
--- a/.changeset/tidy-spans-rest.md
+++ b/.changeset/tidy-spans-rest.md
@@ -1,0 +1,5 @@
+---
+"@effect/opentelemetry": patch
+---
+
+Fix wrapped spans treating non-error OpenTelemetry statuses as errors.

--- a/packages/opentelemetry/src/OtelTracer.ts
+++ b/packages/opentelemetry/src/OtelTracer.ts
@@ -310,7 +310,7 @@ const makeOtelSpan = (span: Tracer.Span, clock: Clock.Clock): Otel.Span => {
       return self
     },
     setStatus(status) {
-      exit = Otel.SpanStatusCode.ERROR
+      exit = status.code === Otel.SpanStatusCode.ERROR
         ? Exit.die(status.message ?? "Unknown error")
         : Exit.void
       return self

--- a/packages/opentelemetry/test/OtelTracer.test.ts
+++ b/packages/opentelemetry/test/OtelTracer.test.ts
@@ -89,6 +89,18 @@ describe("Tracer", () => {
         Effect.provide(TracingLive)
       ))
 
+    it.effect("honors a non-error wrapper status", () =>
+      Effect.gen(function*() {
+        const span = yield* Effect.currentSpan
+        const wrapper = yield* OtelTracer.currentOtelSpan
+        wrapper.setStatus({ code: OtelApi.SpanStatusCode.OK })
+        wrapper.end()
+        assert.strictEqual(span.status._tag, "Ended")
+        if (span.status._tag === "Ended") {
+          assert.strictEqual(span.status.exit._tag, "Success")
+        }
+      }).pipe(Effect.withSpan("repro")))
+
     it.effect("preserves the sampling decision of generic external spans", () =>
       Effect.gen(function*() {
         const span = yield* Effect.currentSpan

--- a/packages/opentelemetry/test/OtelTracer.test.ts
+++ b/packages/opentelemetry/test/OtelTracer.test.ts
@@ -89,15 +89,30 @@ describe("Tracer", () => {
         Effect.provide(TracingLive)
       ))
 
-    it.effect("honors a non-error wrapper status", () =>
+    it.effect.each([OtelApi.SpanStatusCode.UNSET, OtelApi.SpanStatusCode.OK])(
+      "honors non-error wrapper status %s",
+      (status) =>
+        Effect.gen(function*() {
+          const span = yield* Effect.currentSpan
+          const wrapper = yield* OtelTracer.currentOtelSpan
+          wrapper.setStatus({ code: status })
+          wrapper.end()
+          assert.strictEqual(span.status._tag, "Ended")
+          if (span.status._tag === "Ended") {
+            assert.strictEqual(span.status.exit._tag, "Success")
+          }
+        }).pipe(Effect.withSpan("repro"))
+    )
+
+    it.effect("honors an error wrapper status", () =>
       Effect.gen(function*() {
         const span = yield* Effect.currentSpan
         const wrapper = yield* OtelTracer.currentOtelSpan
-        wrapper.setStatus({ code: OtelApi.SpanStatusCode.OK })
+        wrapper.setStatus({ code: OtelApi.SpanStatusCode.ERROR })
         wrapper.end()
         assert.strictEqual(span.status._tag, "Ended")
         if (span.status._tag === "Ended") {
-          assert.strictEqual(span.status.exit._tag, "Success")
+          assert.strictEqual(span.status.exit._tag, "Failure")
         }
       }).pipe(Effect.withSpan("repro")))
 


### PR DESCRIPTION
## Summary

- Fix wrapped spans so only `SpanStatusCode.ERROR` ends the underlying Effect span with a failed `Exit`.
- Cover `UNSET`, `OK`, and `ERROR` in the existing `OtelTracer.test.ts`.
- Add a patch changeset for `@effect/opentelemetry`.

## Validation

- `pnpm test --run packages/opentelemetry/test/OtelTracer.test.ts`
- `pnpm lint-fix`
- `pnpm check`

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Finding: `effect-0e3df1d1fe3adbe5`

Closes EFF-484