### PR TITLE
Fix byte-backed text attachments are base64-encoded as plaintext

### DIFF
--- a/.changeset/fix-anthropic-plaintext-bytes.md
+++ b/.changeset/fix-anthropic-plaintext-bytes.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-anthropic": patch
+---
+
+Decode byte-backed plain-text attachments as UTF-8 text in Anthropic requests.

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -889,7 +889,7 @@ const prepareMessages = Effect.fnUntraced(
                           : {
                             type: "text",
                             media_type: "text/plain",
-                            data: typeof part.data === "string" ? part.data : Encoding.encodeBase64(part.data)
+                            data: typeof part.data === "string" ? part.data : new TextDecoder().decode(part.data)
                           } as const
 
                         content.push({

--- a/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
+++ b/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
@@ -501,31 +501,40 @@ describe("AnthropicLanguageModel", () => {
       Effect.gen(function*() {
         let body: any
         const client = AnthropicClient.layer({ apiKey: Redacted.make("test") }).pipe(
-          Layer.provide(Layer.succeed(HttpClient.HttpClient, HttpClient.makeWith(
-            Effect.fnUntraced(function*(requestEffect) {
-              const request = yield* requestEffect
-              body = JSON.parse(new TextDecoder().decode((request.body as any).body))
-              return HttpClientResponse.fromWeb(request, new Response(JSON.stringify({
-                id: "msg_1",
-                type: "message",
-                role: "assistant",
-                model: "claude-sonnet-4-20250514",
-                content: [{ type: "text", text: "ok" }],
-                stop_reason: "end_turn",
-                stop_sequence: null,
-                usage: {
-                  cache_creation: null,
-                  cache_creation_input_tokens: null,
-                  cache_read_input_tokens: null,
-                  inference_geo: null,
-                  input_tokens: 1,
-                  output_tokens: 1,
-                  service_tier: null
-                }
-              }), { status: 200 }))
-            }),
-            Effect.succeed as HttpClient.HttpClient.Preprocess<HttpClientError.HttpClientError, never>
-          )))
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            HttpClient.makeWith(
+              Effect.fnUntraced(function*(requestEffect) {
+                const request = yield* requestEffect
+                body = JSON.parse(new TextDecoder().decode((request.body as any).body))
+                return HttpClientResponse.fromWeb(
+                  request,
+                  new Response(
+                    JSON.stringify({
+                      id: "msg_1",
+                      type: "message",
+                      role: "assistant",
+                      model: "claude-sonnet-4-20250514",
+                      content: [{ type: "text", text: "ok" }],
+                      stop_reason: "end_turn",
+                      stop_sequence: null,
+                      usage: {
+                        cache_creation: null,
+                        cache_creation_input_tokens: null,
+                        cache_read_input_tokens: null,
+                        inference_geo: null,
+                        input_tokens: 1,
+                        output_tokens: 1,
+                        service_tier: null
+                      }
+                    }),
+                    { status: 200 }
+                  )
+                )
+              }),
+              Effect.succeed as HttpClient.HttpClient.Preprocess<HttpClientError.HttpClientError, never>
+            )
+          ))
         )
 
         yield* LanguageModel.generateText({

--- a/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
+++ b/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
@@ -496,6 +496,50 @@ describe("AnthropicLanguageModel", () => {
         )
         assert.strictEqual(clientToolResults.length, 0)
       }))
+
+    it.effect("encodes plaintext bytes as UTF-8 text", () =>
+      Effect.gen(function*() {
+        let body: any
+        const client = AnthropicClient.layer({ apiKey: Redacted.make("test") }).pipe(
+          Layer.provide(Layer.succeed(HttpClient.HttpClient, HttpClient.makeWith(
+            Effect.fnUntraced(function*(requestEffect) {
+              const request = yield* requestEffect
+              body = JSON.parse(new TextDecoder().decode((request.body as any).body))
+              return HttpClientResponse.fromWeb(request, new Response(JSON.stringify({
+                id: "msg_1",
+                type: "message",
+                role: "assistant",
+                model: "claude-sonnet-4-20250514",
+                content: [{ type: "text", text: "ok" }],
+                stop_reason: "end_turn",
+                stop_sequence: null,
+                usage: {
+                  cache_creation: null,
+                  cache_creation_input_tokens: null,
+                  cache_read_input_tokens: null,
+                  inference_geo: null,
+                  input_tokens: 1,
+                  output_tokens: 1,
+                  service_tier: null
+                }
+              }), { status: 200 }))
+            }),
+            Effect.succeed as HttpClient.HttpClient.Preprocess<HttpClientError.HttpClientError, never>
+          )))
+        )
+
+        yield* LanguageModel.generateText({
+          prompt: Prompt.make([{
+            role: "user",
+            content: [Prompt.filePart({ mediaType: "text/plain", data: new TextEncoder().encode("hello") })]
+          }])
+        }).pipe(
+          Effect.provide(AnthropicLanguageModel.model("claude-sonnet-4-20250514")),
+          Effect.provide(client)
+        )
+
+        assert.strictEqual(body.messages[0].content[0].source.data, "hello")
+      }))
   })
 
   describe("generateObject", () => {


### PR DESCRIPTION
## Summary

A `text/plain` prompt file containing UTF-8 bytes for `hello` is sent to Anthropic with source data `aGVsbG8=` instead of `hello`, so the model receives base64 characters as the document text.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Byte-backed text attachments are base64-encoded as plaintext

**Module:** `ai/anthropic/AnthropicLanguageModel`  
**Audit ID:** `effect-3be5a8855144f022`  
**Severity / confidence:** medium / high

### What happens

A `text/plain` prompt file containing UTF-8 bytes for `hello` is sent to Anthropic with source data `aGVsbG8=` instead of `hello`, so the model receives base64 characters as the document text.

### Why it happens

In the `text/plain` branch, `prepareMessages` selects a text document source but applies `Encoding.encodeBase64(part.data)` whenever `data` is not already a string, converting the bytes as binary payload rather than decoding their text.

### Expected behavior

`Prompt.FilePart` accepts `Uint8Array` file data, while Anthropic's `BetaPlainTextSource` protocol identifies its string `data` as a `type: "text"`, `media_type: "text/plain"` source; byte-backed plain text must preserve the represented text content.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/ai/anthropic/src/AnthropicLanguageModel.ts:872-893`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/ai/anthropic/src/AnthropicLanguageModel.ts#L872-L893)

<details>
<summary>View problematic code at <code>packages/ai/anthropic/src/AnthropicLanguageModel.ts:872-893</code></summary>

```ts
                      } else if (part.mediaType === "application/pdf" || part.mediaType === "text/plain") {
                        betas.add("pdfs-2024-09-25")

                        const enableCitations = areCitationsEnabled(part)
                        const documentOptions = getDocumentMetadata(part)

                        const source = isUrlData(part.data)
                          ? {
                            type: "url",
                            url: getUrlString(part.data)
                          } as const
                          : part.mediaType === "application/pdf"
                          ? {
                            type: "base64",
                            media_type: "application/pdf",
                            data: typeof part.data === "string" ? part.data : Encoding.encodeBase64(part.data)
                          } as const
                          : {
                            type: "text",
                            media_type: "text/plain",
                            data: typeof part.data === "string" ? part.data : Encoding.encodeBase64(part.data)
                          } as const
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/ai/anthropic/src/AnthropicLanguageModel.ts#L872-L893)

</details>

### Reproduction

```sh
pnpm test --run packages/ai/anthropic/test/Repro.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: Byte-backed text attachments are base64-encoded as plaintext.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/ai/anthropic/test/Repro.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-3be5a8855144f022`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-483