### PR TITLE
Fix mCP sampling metadata has the wrong optionality and shape

### DIFF
--- a/.changeset/curvy-melons-stare.md
+++ b/.changeset/curvy-melons-stare.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix MCP sampling metadata optionality and validate it as an object.

--- a/packages/effect/src/unstable/ai/McpSchema.ts
+++ b/packages/effect/src/unstable/ai/McpSchema.ts
@@ -1854,7 +1854,7 @@ export class CreateMessage extends Rpc.make("sampling/createMessage", {
      * Optional metadata to pass through to the LLM provider. The format of
      * this metadata is provider-specific.
      */
-    metadata: Schema.Any
+    metadata: optional(Schema.Record(Schema.String, Schema.Unknown))
   }
 }) {}
 

--- a/packages/effect/test/unstable/ai/McpSchema.test.ts
+++ b/packages/effect/test/unstable/ai/McpSchema.test.ts
@@ -1,0 +1,15 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Schema } from "effect"
+import * as McpSchema from "effect/unstable/ai/McpSchema"
+
+describe("McpSchema", () => {
+  const decodeCreateMessage = Schema.decodeUnknownSync(McpSchema.CreateMessage.payloadSchema)
+
+  it("allows create-message metadata to be omitted", () => {
+    assert.doesNotThrow(() => decodeCreateMessage({ messages: [], maxTokens: 1 }))
+  })
+
+  it("requires create-message metadata to be an object", () => {
+    assert.throws(() => decodeCreateMessage({ messages: [], maxTokens: 1, metadata: "invalid" }))
+  })
+})


### PR DESCRIPTION
## Summary

CreateMessage payload decoding rejects `{"messages":[],"maxTokens":1}` with `Missing key` at `metadata`, but accepts `{"messages":[],"maxTokens":1,"metadata":"invalid"}`.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## MCP sampling metadata has the wrong optionality and shape

**Module:** `effect/unstable/ai/McpSchema`  
**Audit ID:** `effect-0b445959c4e36e55`  
**Severity / confidence:** medium / high

### What happens

CreateMessage payload decoding rejects `{"messages":[],"maxTokens":1}` with `Missing key` at `metadata`, but accepts `{"messages":[],"maxTokens":1,"metadata":"invalid"}`.

### Why it happens

The payload declares `metadata: Schema.Any`, which makes the key required while placing no constraint on its value.

### Expected behavior

The MCP 2025-06-18 CreateMessageRequest schema defines `metadata?: object`: the field may be absent, and when present its value must be an object.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/unstable/ai/McpSchema.ts:1826-1858`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/ai/McpSchema.ts#L1826-L1858)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/ai/McpSchema.ts:1826-1858</code></summary>

```ts
export class CreateMessage extends Rpc.make("sampling/createMessage", {
  success: CreateMessageResult,
  error: McpError,
  payload: {
    messages: Schema.Array(SamplingMessage),
    /**
     * The server's preferences for which model to select. The client MAY ignore
     * these preferences.
     */
    modelPreferences: optional(Schema.Struct(ModelPreferences.fields)),
    /**
     * An optional system prompt the server wants to use for sampling. The
     * client MAY modify or omit this prompt.
     */
    systemPrompt: optional(Schema.String),
    /**
     * A request to include context from one or more MCP servers (including the
     * caller), to be attached to the prompt. The client MAY ignore this request.
     */
    includeContext: optional(Schema.Literals(["none", "thisServer", "allServers"])),
    temperature: optional(Schema.Finite),
    /**
     * The maximum number of tokens to sample, as requested by the server. The
     * client MAY choose to sample fewer tokens than requested.
     */
    maxTokens: Schema.Int,
    stopSequences: optional(Schema.Array(Schema.String)),
    /**
     * Optional metadata to pass through to the LLM provider. The format of
     * this metadata is provider-specific.
     */
    metadata: Schema.Any
  }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/ai/McpSchema.ts#L1826-L1858)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/ai/McpSchema.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: MCP sampling metadata has the wrong optionality and shape.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/ai/McpSchema.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-0b445959c4e36e55`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-482