### PR TITLE
Fix void MCP tools are reported as internal failures

### DIFF
--- a/.changeset/fix-void-mcp-tool-results.md
+++ b/.changeset/fix-void-mcp-tool-results.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Keep MCP tool calls that return void successful.

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -1299,7 +1299,7 @@ export const registerToolkit: <Tools extends Record<string, Tool.Any>>(
             new CallToolResult({
               isError: false,
               structuredContent: typeof result.encodedResult === "object" ? result.encodedResult : undefined,
-              content: [{
+              content: result.encodedResult === undefined ? [] : [{
                 type: "text",
                 text: JSON.stringify(result.encodedResult)
               }]

--- a/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
@@ -292,7 +292,13 @@ describe("McpServer", () => {
           arguments: {}
         })
 
-        assert.notStrictEqual(result.isError, true)
+        assert.deepStrictEqual(
+          result,
+          new McpSchema.CallToolResult({
+            isError: false,
+            content: []
+          })
+        )
       }))
 
     it.effect("returns schema-validated messages for declared handler failures", () =>

--- a/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
@@ -283,6 +283,18 @@ describe("McpServer", () => {
         )
       }))
 
+    it.effect("keeps void tool results successful", () =>
+      Effect.gen(function*() {
+        const client = yield* makeToolkitTestClient()
+
+        const result = yield* client["tools/call"]({
+          name: "UntypedTool",
+          arguments: {}
+        })
+
+        assert.notStrictEqual(result.isError, true)
+      }))
+
     it.effect("returns schema-validated messages for declared handler failures", () =>
       Effect.gen(function*() {
         const client = yield* makeToolkitTestClient()


### PR DESCRIPTION
## Summary

Calling a registered tool whose successful handler returns void produces `content: [{"type":"text","text":"Tool execution failed due to an internal server error."}]` with `isError: true`.

> [!IMPORTANT]
> This PR includes focused regression coverage and the implementation fix.

## Void MCP tools are reported as internal failures

**Module:** `effect/unstable/ai/McpServer`  
**Audit ID:** `effect-c9c84023834a0007`  
**Severity / confidence:** medium / high

### What happens

Calling a registered tool whose successful handler returns void produces `content: [{"type":"text","text":"Tool execution failed due to an internal server error."}]` with `isError: true`.

### Why it happens

The toolkit result path applies `JSON.stringify` to the encoded void value, producing undefined for the required TextContent `text` string; the resulting defect is converted into the generic error CallToolResult.

### Expected behavior

MCP 2025-06-18 CallToolResult treats omitted or false `isError` as success and reserves `isError: true` for tool execution errors; a successful no-output call can return an empty content array.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/unstable/ai/McpServer.ts:1298-1325`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/ai/McpServer.ts#L1298-L1325)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/ai/McpServer.ts:1298-1325</code></summary>

```ts
          Effect.map((result) =>
            new CallToolResult({
              isError: false,
              structuredContent: typeof result.encodedResult === "object" ? result.encodedResult : undefined,
              content: [{
                type: "text",
                text: JSON.stringify(result.encodedResult)
              }]
            })
          ),
          Effect.tapCause(Effect.logError),
          Effect.catch((error) => {
            if (AiError.isAiError(error)) {
              const reason = (error as AiError.AiError).reason
              return reason._tag === "ToolParameterValidationError"
                ? Effect.fail(new InvalidParams({ message: reason.message }))
                : Effect.succeed(toolErrorResult(INTERNAL_TOOL_ERROR_MESSAGE))
            }
            if (isDeclaredFailure(error)) {
              const message = error instanceof Error
                ? error.message
                : INTERNAL_TOOL_ERROR_MESSAGE
              return Effect.succeed(toolErrorResult(message))
            }
            return Effect.succeed(toolErrorResult(INTERNAL_TOOL_ERROR_MESSAGE))
          }),
          Effect.catchDefect(() => Effect.succeed(toolErrorResult(INTERNAL_TOOL_ERROR_MESSAGE)))
        )
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/ai/McpServer.ts#L1298-L1325)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: Void MCP tools are reported as internal failures.

## Implementation

Void encoded results now produce an empty `content` array while remaining successful. The regression test asserts the complete result shape.

Run the focused regression command:

```sh
pnpm test --run packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
```


## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-c9c84023834a0007`
- Fix: void encoded results return an empty successful content array

Closes EFF-481