### PR TITLE
Fix killing a pipeline leaves its root process running

### DIFF
--- a/.changeset/fix-node-pipeline-kill.md
+++ b/.changeset/fix-node-pipeline-kill.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+Kill every process in a Node child process pipeline when killing its aggregate handle.

--- a/packages/platform-node-shared/src/NodeChildProcessSpawner.ts
+++ b/packages/platform-node-shared/src/NodeChildProcessSpawner.ts
@@ -619,6 +619,8 @@ const make = Effect.gen(function*() {
         }
 
         const handle = handles[handles.length - 1]
+        const kill = (options?: ChildProcess.KillOptions | undefined) =>
+          Effect.forEach([...handles].reverse(), (handle) => Effect.ignore(handle.kill(options)), { discard: true })
         const unref = Effect.gen(function*() {
           const rerefs: Array<Effect.Effect<void, PlatformError.PlatformError>> = []
           for (const handle of handles) {
@@ -631,7 +633,7 @@ const make = Effect.gen(function*() {
           pid: handle.pid,
           exitCode: handle.exitCode,
           isRunning: handle.isRunning,
-          kill: handle.kill,
+          kill,
           stdin: handle.stdin,
           stdout: handle.stdout,
           stderr: handle.stderr,

--- a/packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts
+++ b/packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts
@@ -34,7 +34,12 @@ it.live("kills every process in a pipeline", () =>
     )))
     yield* Effect.sleep("100 millis")
     yield* handle.kill({ killSignal: "SIGKILL" })
-    const rootSize = (yield* fs.stat(rootHeartbeat)).size
+    const rootSizeAfterKill = (yield* fs.stat(rootHeartbeat)).size
+    const childSizeAfterKill = (yield* fs.stat(childHeartbeat)).size
     yield* Effect.sleep("100 millis")
-    assert.strictEqual((yield* fs.stat(rootHeartbeat)).size, rootSize)
+    const rootFinalSize = (yield* fs.stat(rootHeartbeat)).size
+    const childFinalSize = (yield* fs.stat(childHeartbeat)).size
+
+    assert.strictEqual(rootFinalSize, rootSizeAfterKill)
+    assert.strictEqual(childFinalSize, childSizeAfterKill)
   }).pipe(Effect.scoped, Effect.provide(NodeServices)))

--- a/packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts
+++ b/packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts
@@ -1,8 +1,12 @@
 import * as NodeChildProcessSpawner from "@effect/platform-node-shared/NodeChildProcessSpawner"
 import * as NodeFileSystem from "@effect/platform-node-shared/NodeFileSystem"
 import * as NodePath from "@effect/platform-node-shared/NodePath"
+import { assert, it } from "@effect/vitest"
 import * as ChildProcessSpawnerTest from "effect-test/unstable/process/ChildProcessSpawnerTest"
+import * as Effect from "effect/Effect"
+import * as FileSystem from "effect/FileSystem"
 import * as Layer from "effect/Layer"
+import * as ChildProcess from "effect/unstable/process/ChildProcess"
 
 const NodeServices = NodeChildProcessSpawner.layer.pipe(
   Layer.provideMerge(Layer.mergeAll(
@@ -14,3 +18,23 @@ const NodeServices = NodeChildProcessSpawner.layer.pipe(
 ChildProcessSpawnerTest.suite("NodeChildProcessSpawner", NodeServices, {
   processGroups: true
 })
+
+it.live("kills every process in a pipeline", () =>
+  Effect.gen(function*() {
+    const fs = yield* FileSystem.FileSystem
+    const directory = yield* fs.makeTempDirectoryScoped()
+    const rootHeartbeat = `${directory}/root-heartbeat`
+    const childHeartbeat = `${directory}/child-heartbeat`
+    const handle = yield* ChildProcess.make(
+      "sh",
+      ["-c", "while :; do printf x >> \"$1\"; sleep 0.01; done", "pipeline-root", rootHeartbeat]
+    ).pipe(ChildProcess.pipeTo(ChildProcess.make(
+      "sh",
+      ["-c", "while :; do printf x >> \"$1\"; sleep 0.01; done", "pipeline-child", childHeartbeat]
+    )))
+    yield* Effect.sleep("100 millis")
+    yield* handle.kill({ killSignal: "SIGKILL" })
+    const rootSize = (yield* fs.stat(rootHeartbeat)).size
+    yield* Effect.sleep("100 millis")
+    assert.strictEqual((yield* fs.stat(rootHeartbeat)).size, rootSize)
+  }).pipe(Effect.scoped, Effect.provide(NodeServices)))


### PR DESCRIPTION
## Summary

Calling `kill` on a shared Node handle for a piped command terminates only the tail process and can leave earlier pipeline stages running.

> [!IMPORTANT]
> This PR includes the focused regression test and the implementation fix.

## Killing a pipeline leaves its root process running

**Module:** `platform-node-shared/NodeChildProcessSpawner`  
**Audit ID:** `effect-4bd8d5ecaeff09f4`  
**Severity / confidence:** medium / high

### What happens

Calling `kill` on a shared Node handle for a piped command terminates only the tail process and can leave earlier pipeline stages running.

### Why it happens

The shared Node spawner stores every stage in `handles` and applies `unref` across all of them, but builds the returned pipeline handle with `kill: handle.kill`, where `handle` is only the final stage. The independent Deno adapter applies `kill` to all handles in reverse order, confirming the platform contract is implemented at pipeline scope there.

### Expected behavior

A spawned `PipedCommand` yields one `ChildProcessHandle`, whose `kill` operation controls the child process represented by that handle. As with the pipeline's all-handle `unref`, killing that aggregate command must terminate every process started for it.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/platform-node-shared/src/NodeChildProcessSpawner.ts:567-642`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/platform-node-shared/src/NodeChildProcessSpawner.ts#L567-L642)

<details>
<summary>View problematic code at <code>packages/platform-node-shared/src/NodeChildProcessSpawner.ts:567-616</code></summary>

```ts
      case "PipedCommand": {
        const { commands, pipeOptions } = flattenCommand(cmd)
        const [root, ...pipeline] = commands

        const handles = [yield* spawnCommand(root)]

        for (let i = 0; i < pipeline.length; i++) {
          const command = pipeline[i]
          const options = pipeOptions[i] ?? {}
          const stdinConfig = resolveStdinOption(command.options)

          // Get the appropriate stream from the source based on `from` option
          const sourceStream = Stream.unwrap(
            Effect.succeed(getSourceStream(handles[handles.length - 1], options.from))
          )

          // Determine where to pipe: stdin or custom fd
          const toOption = options.to ?? "stdin"

          if (toOption === "stdin") {
            // Pipe to stdin (default behavior)
            handles.push(
              yield* spawnCommand(ChildProcess.make(command.command, command.args, {
                ...command.options,
                stdin: { ...stdinConfig, stream: sourceStream }
              }))
            )
          } else {
            // Pipe to custom fd (fd3, fd4, etc.)
            const fd = ChildProcess.parseFdName(toOption)
            if (Predicate.isNotUndefined(fd)) {
              const fdName = ChildProcess.fdName(fd) as `fd${number}`
              const existingFds = command.options.additionalFds ?? {}
              handles.push(
                yield* spawnCommand(ChildProcess.make(command.command, command.args, {
                  ...command.options,
                  additionalFds: {
                    ...existingFds,
                    [fdName]: { type: "input" as const, stream: sourceStream }
                  }
                }))
              )
            } else {
              // Invalid fd name, fall back to stdin
              handles.push(
                yield* spawnCommand(ChildProcess.make(command.command, command.args, {
                  ...command.options,
                  stdin: { ...stdinConfig, stream: sourceStream }
                }))
              )
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/platform-node-shared/src/NodeChildProcessSpawner.ts#L567-L642)

_Excerpt truncated. [Open the complete packages/platform-node-shared/src/NodeChildProcessSpawner.ts:567-642 range.](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/platform-node-shared/src/NodeChildProcessSpawner.ts#L567-L642)_

</details>

### Reproduction

```sh
pnpm test --run packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: Killing a pipeline leaves its root process running.

## Implementation

The Node spawner now kills every pipeline handle in reverse order, matching the Deno adapter. The regression verifies that both the root and tail processes stop.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-4bd8d5ecaeff09f4`
- Fix: aggregate pipeline kills with coverage for root and tail processes

Closes EFF-480