### PR TITLE
Fix memory runner storage ignores health state

### DIFF
--- a/.changeset/fix-memory-runner-health.md
+++ b/.changeset/fix-memory-runner-health.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve and update runner health in the in-memory cluster runner storage.

--- a/packages/effect/src/unstable/cluster/RunnerStorage.ts
+++ b/packages/effect/src/unstable/cluster/RunnerStorage.ts
@@ -195,29 +195,31 @@ export const makeEncoded = (encoded: Encoded) =>
  *
  * **Details**
  *
- * Registered runners are treated as healthy and shard acquisition is kept only in
- * process memory.
+ * Runner health and shard acquisition are kept only in process memory.
  *
  * @category constructors
  * @since 4.0.0
  */
 export const makeMemory = Effect.gen(function*() {
-  const runners = MutableHashMap.empty<RunnerAddress, Runner>()
+  const runners = MutableHashMap.empty<RunnerAddress, readonly [runner: Runner, healthy: boolean]>()
   let acquired: Array<ShardId.ShardId> = []
   let id = 0
 
   return RunnerStorage.of({
-    getRunners: Effect.sync(() => Array.from(MutableHashMap.values(runners), (runner) => [runner, true])),
-    register: (runner) =>
+    getRunners: Effect.sync(() => Array.from(MutableHashMap.values(runners))),
+    register: (runner, healthy) =>
       Effect.sync(() => {
-        MutableHashMap.set(runners, runner.address, runner)
+        MutableHashMap.set(runners, runner.address, [runner, healthy])
         return MachineId.make(id++)
       }),
     unregister: (address) =>
       Effect.sync(() => {
         MutableHashMap.remove(runners, address)
       }),
-    setRunnerHealth: () => Effect.void,
+    setRunnerHealth: (address, healthy) =>
+      Effect.sync(() => {
+        MutableHashMap.modify(runners, address, ([runner]) => [runner, healthy] as const)
+      }),
     acquire: (_address, shardIds) => {
       acquired = Array.from(shardIds)
       return Effect.succeed(acquired)

--- a/packages/effect/test/cluster/RunnerStorage.test.ts
+++ b/packages/effect/test/cluster/RunnerStorage.test.ts
@@ -1,8 +1,16 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Effect } from "effect"
-import { RunnerAddress, RunnerStorage, ShardId } from "effect/unstable/cluster"
+import { Runner, RunnerAddress, RunnerStorage, ShardId } from "effect/unstable/cluster"
 
 describe("RunnerStorage", () => {
+  it.effect("preserves runner health in memory", () =>
+    Effect.gen(function*() {
+      const storage = yield* RunnerStorage.makeMemory
+      const address = RunnerAddress.make("localhost", 41001)
+      yield* storage.register(Runner.make({ address, groups: ["default"], weight: 1 }), false)
+      assert.strictEqual((yield* storage.getRunners)[0][1], false)
+    }))
+
   it.effect("memory acquire accepts a one-shot iterable", () =>
     Effect.gen(function*() {
       const storage = yield* RunnerStorage.makeMemory

--- a/packages/effect/test/cluster/RunnerStorage.test.ts
+++ b/packages/effect/test/cluster/RunnerStorage.test.ts
@@ -3,12 +3,14 @@ import { Effect } from "effect"
 import { Runner, RunnerAddress, RunnerStorage, ShardId } from "effect/unstable/cluster"
 
 describe("RunnerStorage", () => {
-  it.effect("preserves runner health in memory", () =>
+  it.effect("tracks runner health in memory", () =>
     Effect.gen(function*() {
       const storage = yield* RunnerStorage.makeMemory
       const address = RunnerAddress.make("localhost", 41001)
       yield* storage.register(Runner.make({ address, groups: ["default"], weight: 1 }), false)
       assert.strictEqual((yield* storage.getRunners)[0][1], false)
+      yield* storage.setRunnerHealth(address, true)
+      assert.strictEqual((yield* storage.getRunners)[0][1], true)
     }))
 
   it.effect("memory acquire accepts a one-shot iterable", () =>


### PR DESCRIPTION
## Summary

The memory runner store always reports every registered runner as healthy, regardless of the health supplied at registration or later health updates.

> [!IMPORTANT]
> This PR includes the focused regression test and the implementation fix.

## Memory runner storage ignores health state

**Module:** `effect/unstable/cluster/RunnerStorage`  
**Audit ID:** `effect-6b4bec2883cd0974`  
**Severity / confidence:** medium / high

### What happens

The memory runner store always reports every registered runner as healthy, regardless of the health supplied at registration or later health updates.

### Why it happens

The backing map contains only `Runner`, `register` ignores its `healthy` argument, `getRunners` constructs every tuple with literal `true`, and `setRunnerHealth` is a no-op. There is therefore no state location in the memory implementation capable of representing an unhealthy runner.

### Expected behavior

Runner health is stored state: `register(runner, healthy)` must preserve the supplied boolean, `setRunnerHealth` must update it for that address, and `getRunners` must return the current value.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/effect/src/unstable/cluster/RunnerStorage.ts:193-220`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/cluster/RunnerStorage.ts#L193-L220)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/cluster/RunnerStorage.ts:193-220</code></summary>

```ts
/**
 * Creates an in-memory `RunnerStorage` implementation for tests and local use.
 *
 * **Details**
 *
 * Registered runners are treated as healthy and shard acquisition is kept only in
 * process memory.
 *
 * @category constructors
 * @since 4.0.0
 */
export const makeMemory = Effect.gen(function*() {
  const runners = MutableHashMap.empty<RunnerAddress, Runner>()
  let acquired: Array<ShardId.ShardId> = []
  let id = 0

  return RunnerStorage.of({
    getRunners: Effect.sync(() => Array.from(MutableHashMap.values(runners), (runner) => [runner, true])),
    register: (runner) =>
      Effect.sync(() => {
        MutableHashMap.set(runners, runner.address, runner)
        return MachineId.make(id++)
      }),
    unregister: (address) =>
      Effect.sync(() => {
        MutableHashMap.remove(runners, address)
      }),
    setRunnerHealth: () => Effect.void,
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/effect/src/unstable/cluster/RunnerStorage.ts#L193-L220)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/cluster/RunnerStorage.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: Memory runner storage ignores health state.

## Implementation

The in-memory store now retains each runner together with its current health. Registration preserves the supplied health, `setRunnerHealth` updates existing entries, and `getRunners` returns the stored value. The regression test covers both registration and health updates.

Validated with:

```sh
pnpm test --run packages/effect/test/cluster/RunnerStorage.test.ts
pnpm lint-fix
pnpm check
```

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-6b4bec2883cd0974`
- Initial patch: focused reproduction tests; implementation fix added in `4e79398b0`

Closes EFF-479