### PR TITLE
Fix xHR formData decoding always defects

### DIFF
--- a/.changeset/fix-xhr-form-data.md
+++ b/.changeset/fix-xhr-form-data.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-browser": patch
+---
+
+Fix form data decoding for XMLHttpRequest client responses.

--- a/packages/platform-browser/src/BrowserHttpClient.ts
+++ b/packages/platform-browser/src/BrowserHttpClient.ts
@@ -399,7 +399,11 @@ class ClientResponseImpl extends IncomingMessageImpl<HttpClientError.HttpClientE
   }
 
   get formData(): Effect.Effect<FormData, HttpClientError.HttpClientError> {
-    return Effect.die("Not implemented")
+    return Effect.flatMap(this.arrayBuffer, (body) =>
+      Effect.tryPromise({
+        try: () => new globalThis.Response(body, { headers: this.headers }).formData(),
+        catch: this.onError
+      }))
   }
 
   override toString(): string {

--- a/packages/platform-browser/test/BrowserHttpClient.test.ts
+++ b/packages/platform-browser/test/BrowserHttpClient.test.ts
@@ -88,4 +88,15 @@ describe("BrowserHttpClient", () => {
         body: "{ \"message\": \"Success!\" }"
       }]
     }))))
+
+  it.effect("decodes an XHR response as FormData", () =>
+    HttpClient.get("http://localhost/form").pipe(
+      Effect.flatMap((response) => response.formData),
+      Effect.provide(layer({
+        get: ["http://localhost/form", {
+          headers: { "content-type": "multipart/form-data; boundary=x" },
+          body: "--x\r\nContent-Disposition: form-data; name=\"value\"\r\n\r\ntest\r\n--x--\r\n"
+        }]
+      }))
+    ))
 })

--- a/packages/platform-browser/test/BrowserHttpClient.test.ts
+++ b/packages/platform-browser/test/BrowserHttpClient.test.ts
@@ -90,13 +90,15 @@ describe("BrowserHttpClient", () => {
     }))))
 
   it.effect("decodes an XHR response as FormData", () =>
-    HttpClient.get("http://localhost/form").pipe(
-      Effect.flatMap((response) => response.formData),
-      Effect.provide(layer({
-        get: ["http://localhost/form", {
-          headers: { "content-type": "multipart/form-data; boundary=x" },
-          body: "--x\r\nContent-Disposition: form-data; name=\"value\"\r\n\r\ntest\r\n--x--\r\n"
-        }]
-      }))
-    ))
+    Effect.gen(function*() {
+      const formData = yield* HttpClient.get("http://localhost/form").pipe(
+        Effect.flatMap((response) => response.formData)
+      )
+      assert.strictEqual(formData.get("value"), "test")
+    }).pipe(Effect.provide(layer({
+      get: ["http://localhost/form", {
+        headers: { "content-type": "multipart/form-data; boundary=x" },
+        body: "--x\r\nContent-Disposition: form-data; name=\"value\"\r\n\r\ntest\r\n--x--\r\n"
+      }]
+    }))))
 })


### PR DESCRIPTION
## Summary

Evaluating `formData` on an XMLHttpRequest-backed client response terminates the fiber with a defect instead of producing form data or a typed decode failure.

> [!IMPORTANT]
> This PR includes the focused regression test and the XMLHttpRequest form-data decoding fix.

## XHR formData decoding always defects

**Module:** `platform-browser/BrowserHttpClient`  
**Audit ID:** `effect-a46eb759b072a705`  
**Severity / confidence:** medium / high

### What happens

Evaluating `formData` on an XMLHttpRequest-backed client response terminates the fiber with a defect instead of producing form data or a typed decode failure.

### Why it happens

`BrowserHttpClient.ClientResponseImpl.formData` returns `Effect.die("Not implemented")` without inspecting the response body or content type. This applies to every response produced by `layerXMLHttpRequest`; nearby XHR tests cover JSON, streams, cookies, and array buffers but never exercise the required `formData` member.

### Expected behavior

`HttpClientResponse.formData` is declared as `Effect<FormData, HttpClientError>`, so an XHR response must expose form-data decoding through that success/error channel. Invalid multipart input may fail with `HttpClientError`; the accessor must not unconditionally leave the declared channel.

### Relevant implementation

These links and excerpts are pinned to audit base `17f0b91a243ccfe4a38d27debdc983adf434e738`.

- [`packages/platform-browser/src/BrowserHttpClient.ts:401-403`](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/platform-browser/src/BrowserHttpClient.ts#L401-L403)

<details>
<summary>View problematic code at <code>packages/platform-browser/src/BrowserHttpClient.ts:401-403</code></summary>

```ts
  get formData(): Effect.Effect<FormData, HttpClientError.HttpClientError> {
    return Effect.die("Not implemented")
  }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/17f0b91a243ccfe4a38d27debdc983adf434e738/packages/platform-browser/src/BrowserHttpClient.ts#L401-L403)

</details>

### Reproduction

```sh
pnpm test --run packages/platform-browser/test/BrowserHttpClient.test.ts
```

**Observed failure:** Focused contract assertion failed against 17f0b91a, demonstrating: XHR formData decoding always defects.

## Implementation

`ClientResponseImpl.formData` now waits for the XHR response body, delegates multipart parsing to `Response.formData()`, and maps parsing failures to `HttpClientError.DecodeError`. The regression test asserts the decoded field value.

## Audit provenance

- Audit base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Reproduction base: `17f0b91a243ccfe4a38d27debdc983adf434e738`
- Findings: `effect-a46eb759b072a705`
- Initial patch: focused reproduction test; implementation fix added in `98b7e988d`

Closes EFF-478