### PR TITLE
Return the new offset from File.seek

### DIFF
--- a/.changeset/fresh-files-seek.md
+++ b/.changeset/fresh-files-seek.md
@@ -1,0 +1,7 @@
+---
+"effect": minor
+"@effect/platform-node-shared": minor
+"@effect/platform-deno": minor
+---
+
+Return the new file offset as a `Size` from `File.seek`.

--- a/packages/effect/src/FileSystem.ts
+++ b/packages/effect/src/FileSystem.ts
@@ -1010,7 +1010,7 @@ export const isFile = (u: unknown): u is File => hasProperty(u, FileTypeId)
  * const file: FileSystem.File = {
  *   [FileSystem.FileTypeId]: FileSystem.FileTypeId,
  *   stat: Effect.succeed({ size: FileSystem.Size(5) } as FileSystem.File.Info),
- *   seek: () => Effect.void,
+ *   seek: () => Effect.succeed(FileSystem.Size(0)),
  *   sync: Effect.void,
  *   read: (buffer) => Effect.sync(() => {
  *     buffer.set([1, 2, 3, 4, 5])
@@ -1040,7 +1040,7 @@ export const isFile = (u: unknown): u is File => hasProperty(u, FileTypeId)
 export interface File {
   readonly [FileTypeId]: typeof FileTypeId
   readonly stat: Effect.Effect<File.Info, PlatformError>
-  readonly seek: (offset: SizeInput, from: SeekMode) => Effect.Effect<void>
+  readonly seek: (offset: SizeInput, from: SeekMode) => Effect.Effect<Size>
   readonly sync: Effect.Effect<void, PlatformError>
   readonly read: (buffer: Uint8Array) => Effect.Effect<Size, PlatformError>
   readonly readAlloc: (size: SizeInput) => Effect.Effect<Option.Option<Uint8Array>, PlatformError>

--- a/packages/platform-deno/src/DenoFileSystem.ts
+++ b/packages/platform-deno/src/DenoFileSystem.ts
@@ -215,7 +215,7 @@ class FileImpl implements FileSystem.File {
       } else {
         this.position += size
       }
-      return this.position
+      return FileSystem.Size(this.position)
     })
   }
 

--- a/packages/platform-node-shared/src/NodeFileSystem.ts
+++ b/packages/platform-node-shared/src/NodeFileSystem.ts
@@ -283,7 +283,7 @@ const makeFile = (() => {
           this.position = this.position + offsetSize
         }
 
-        return this.position
+        return FileSystem.Size(this.position)
       })
     }
 


### PR DESCRIPTION
## Summary

- change `File.seek` to return the new offset as a branded `Size`
- keep the Node/Bun and Deno implementations aligned with the public contract
- update the `File` example implementation for the new return type

Node and Bun use the shared Node file-system implementation. The browser package does not provide a file-system implementation.

## Validation

- `pnpm check`
- `pnpm lint`
- `pnpm vitest run --project @effect/platform-node-shared` (106 tests)
- `deno task test --run --project @effect/platform-deno` (197 passed, 11 skipped)
- `pnpm doctest packages/effect/src/FileSystem.ts` (16 tests)

Closes EFF-475