### PR TITLE
Rename Schedule sequencing APIs to concat

### DIFF
--- a/.changeset/eff-477-schedule-concat.md
+++ b/.changeset/eff-477-schedule-concat.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Rename `Schedule.andThen` to `Schedule.concat`.
+Rename `Schedule.andThen` and `Schedule.andThenResult` to `Schedule.concat` and `Schedule.concatResult`.

--- a/.changeset/eff-477-schedule-concat.md
+++ b/.changeset/eff-477-schedule-concat.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Rename `Schedule.andThen` to `Schedule.concat`.

--- a/cookbooks/schedule.md
+++ b/cookbooks/schedule.md
@@ -32,7 +32,7 @@ This cookbook intentionally defines schedules only. It does not apply them with
 | Adapt delay from metadata                 | `Schedule.addDelay`                                                                                               |
 | Replace or cap selected delay             | `Schedule.modifyDelay`                                                                                            |
 | Run phases in sequence                    | `Schedule.concat`                                                                                                 |
-| Preserve phase in output                  | `Schedule.andThenResult`                                                                                          |
+| Preserve phase in output                  | `Schedule.concatResult`                                                                                           |
 | Continue while all policies continue      | `Schedule.max`                                                                                                    |
 | Continue while any policy continues       | `Schedule.min`                                                                                                    |
 | Shape output from metadata                | `Schedule.map`                                                                                                    |
@@ -270,7 +270,7 @@ import { Result, Schedule } from "effect"
 
 const phasedRetryClassifier = Schedule.exponential("100 millis").pipe(
   Schedule.upTo({ times: 2 }),
-  Schedule.andThenResult(Schedule.fibonacci("500 millis").pipe(Schedule.upTo({ times: 3 }))),
+  Schedule.concatResult(Schedule.fibonacci("500 millis").pipe(Schedule.upTo({ times: 3 }))),
   Schedule.map(({ output: result }) =>
     Result.match(result, {
       onFailure: (delay) => ({ phase: "fast", delay }),
@@ -280,7 +280,7 @@ const phasedRetryClassifier = Schedule.exponential("100 millis").pipe(
 )
 ```
 
-Explanation: `Schedule.andThenResult` keeps phase information in the output.
+Explanation: `Schedule.concatResult` keeps phase information in the output.
 The first schedule is represented by the failure side, and the second schedule
 is represented by the success side.
 

--- a/cookbooks/schedule.md
+++ b/cookbooks/schedule.md
@@ -31,7 +31,7 @@ This cookbook intentionally defines schedules only. It does not apply them with
 | Poll latest status                        | `Schedule.spaced` or `Schedule.fixed`, then `Schedule.setInputType`, `Schedule.passthrough`, and `Schedule.while` |
 | Adapt delay from metadata                 | `Schedule.addDelay`                                                                                               |
 | Replace or cap selected delay             | `Schedule.modifyDelay`                                                                                            |
-| Run phases in sequence                    | `Schedule.andThen`                                                                                                |
+| Run phases in sequence                    | `Schedule.concat`                                                                                                 |
 | Preserve phase in output                  | `Schedule.andThenResult`                                                                                          |
 | Continue while all policies continue      | `Schedule.max`                                                                                                    |
 | Continue while any policy continues       | `Schedule.min`                                                                                                    |
@@ -256,7 +256,7 @@ import { Schedule } from "effect"
 
 const cacheInvalidationSequence = Schedule.spaced("100 millis").pipe(
   Schedule.upTo({ times: 2 }),
-  Schedule.andThen(Schedule.spaced("30 seconds").pipe(Schedule.upTo({ times: 3 })))
+  Schedule.concat(Schedule.spaced("30 seconds").pipe(Schedule.upTo({ times: 3 })))
 )
 ```
 
@@ -543,8 +543,8 @@ import { Schedule } from "effect"
 
 const incidentEscalationCadence = Schedule.spaced("1 minute").pipe(
   Schedule.upTo({ times: 3 }),
-  Schedule.andThen(Schedule.spaced("5 minutes").pipe(Schedule.upTo({ times: 3 }))),
-  Schedule.andThen(Schedule.fixed("15 minutes"))
+  Schedule.concat(Schedule.spaced("5 minutes").pipe(Schedule.upTo({ times: 3 }))),
+  Schedule.concat(Schedule.fixed("15 minutes"))
 )
 ```
 
@@ -558,6 +558,6 @@ about 30 seconds, then switches to a cron schedule that recurs every day at
 import { Schedule } from "effect"
 
 const maintenanceCronAfterWarmup = Schedule.duration("30 seconds").pipe(
-  Schedule.andThen(Schedule.cron("0 3 * * *"))
+  Schedule.concat(Schedule.cron("0 3 * * *"))
 )
 ```

--- a/migration/annotations/effect__Schedule.yaml
+++ b/migration/annotations/effect__Schedule.yaml
@@ -2,7 +2,7 @@
   replacement: "Schedule.addDelay"
   note: "The v4 function is effectful by default and its callback receives full Schedule.Metadata; read metadata.output when only the prior output is needed."
 "effect/Schedule#andThenEither":
-  replacement: "Schedule.andThenResult"
+  replacement: "Schedule.concatResult"
   note: "Sequential phase tagging now uses Result: self outputs are Result.fail and the following schedule outputs are Result.succeed."
 "effect/Schedule#as":
   replacement: "Schedule.map"

--- a/migration/annotations/effect__Schedule.yaml
+++ b/migration/annotations/effect__Schedule.yaml
@@ -1,6 +1,9 @@
 "effect/Schedule#addDelayEffect":
   replacement: "Schedule.addDelay"
   note: "The v4 function is effectful by default and its callback receives full Schedule.Metadata; read metadata.output when only the prior output is needed."
+"effect/Schedule#andThen":
+  replacement: "Schedule.concat"
+  note: "The sequencing combinator was renamed to Schedule.concat."
 "effect/Schedule#andThenEither":
   replacement: "Schedule.concatResult"
   note: "Sequential phase tagging now uses Result: self outputs are Result.fail and the following schedule outputs are Result.succeed."

--- a/migration/annotations/effect__Schedule.yaml
+++ b/migration/annotations/effect__Schedule.yaml
@@ -83,8 +83,8 @@
   replacement: "Schedule.duration"
   note: "The duration constructor recurs once after the supplied delay."
 "effect/Schedule#fromDelays":
-  replacement: "Schedule.duration + Schedule.andThen"
-  note: "Build one Schedule.duration per delay and sequence them with Schedule.andThen."
+  replacement: "Schedule.duration + Schedule.concat"
+  note: "Build one Schedule.duration per delay and sequence them with Schedule.concat."
 "effect/Schedule#fromFunction":
   replacement: "Schedule.identity + Schedule.map"
   note: "Start with Schedule.identity<A>() and map metadata.input through the function."

--- a/migration/v3-to-v4.md
+++ b/migration/v3-to-v4.md
@@ -13245,7 +13245,7 @@ Schema.toFormatter(schema)
 
 - `Schedule.fromDelay` -> `Schedule.duration`: The duration constructor recurs once after the supplied delay.
 
-- `Schedule.fromDelays` -> `Schedule.duration + Schedule.andThen`: Build one Schedule.duration per delay and sequence them with Schedule.andThen.
+- `Schedule.fromDelays` -> `Schedule.duration + Schedule.concat`: Build one Schedule.duration per delay and sequence them with Schedule.concat.
 
 - `Schedule.fromFunction` -> `Schedule.identity + Schedule.map`: Start with Schedule.identity\<A\>() and map metadata.input through the function.
 

--- a/migration/v3-to-v4.md
+++ b/migration/v3-to-v4.md
@@ -13193,6 +13193,8 @@ Schema.toFormatter(schema)
 
 - `Schedule.addDelayEffect` -> `Schedule.addDelay`: The v4 function is effectful by default and its callback receives full Schedule.Metadata; read metadata.output when only the prior output is needed.
 
+- `Schedule.andThen` -> `Schedule.concat`: The sequencing combinator was renamed to Schedule.concat.
+
 - `Schedule.andThenEither` -> `Schedule.concatResult`: Sequential phase tagging now uses Result: self outputs are Result.fail and the following schedule outputs are Result.succeed.
 
 - `Schedule.as` -> `Schedule.map`: Map the metadata to the constant output; Schedule.map accepts either a plain value or an Effect.

--- a/migration/v3-to-v4.md
+++ b/migration/v3-to-v4.md
@@ -13193,7 +13193,7 @@ Schema.toFormatter(schema)
 
 - `Schedule.addDelayEffect` -> `Schedule.addDelay`: The v4 function is effectful by default and its callback receives full Schedule.Metadata; read metadata.output when only the prior output is needed.
 
-- `Schedule.andThenEither` -> `Schedule.andThenResult`: Sequential phase tagging now uses Result: self outputs are Result.fail and the following schedule outputs are Result.succeed.
+- `Schedule.andThenEither` -> `Schedule.concatResult`: Sequential phase tagging now uses Result: self outputs are Result.fail and the following schedule outputs are Result.succeed.
 
 - `Schedule.as` -> `Schedule.map`: Map the metadata to the constant output; Schedule.map accepts either a plain value or an Effect.
 

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -490,14 +490,14 @@ export const addDelay: {
  * ```ts import.meta.vitest
  * import { Schedule } from "effect"
  *
- * const schedule = Schedule.andThen(Schedule.recurs(1), Schedule.recurs(2))
+ * const schedule = Schedule.concat(Schedule.recurs(1), Schedule.recurs(2))
  * Schedule.isSchedule(schedule) // => true
  * ```
  *
  * @category sequencing
  * @since 2.0.0
  */
-export const andThen: {
+export const concat: {
   <Output2, Input2, Error2, Env2>(
     other: Schedule<Output2, Input2, Error2, Env2>
   ): <Output, Input, Error, Env>(

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -511,7 +511,7 @@ export const concat: {
   self: Schedule<Output, Input, Error, Env>,
   other: Schedule<Output2, Input2, Error2, Env2>
 ): Schedule<Output | Output2, Input & Input2, Error | Error2, Env | Env2> =>
-  map(andThenResult(self, other), ({ output }) => effect.succeed(Result.merge(output))))
+  map(concatResult(self, other), ({ output }) => effect.succeed(Result.merge(output))))
 
 /**
  * Returns a schedule that runs `self` to completion, then runs `other`, and
@@ -528,14 +528,14 @@ export const concat: {
  * ```ts import.meta.vitest
  * import { Schedule } from "effect"
  *
- * const schedule = Schedule.andThenResult(Schedule.recurs(1), Schedule.recurs(2))
+ * const schedule = Schedule.concatResult(Schedule.recurs(1), Schedule.recurs(2))
  * Schedule.isSchedule(schedule) // => true
  * ```
  *
  * @category sequencing
  * @since 4.0.0
  */
-export const andThenResult: {
+export const concatResult: {
   <Output2, Input2, Error2, Env2>(
     other: Schedule<Output2, Input2, Error2, Env2>
   ): <Output, Input, Error, Env>(

--- a/packages/effect/src/unstable/cluster/internal/entityManager.ts
+++ b/packages/effect/src/unstable/cluster/internal/entityManager.ts
@@ -110,7 +110,7 @@ export const make = Effect.fnUntraced(function*<
   const clock = yield* Clock
   const context = yield* Effect.context<Rpc.Services<Rpcs> | Rpc.Middleware<Rpcs> | RX>()
   const defectRetryPolicy = options.defectRetryPolicy
-    ? Schedule.andThen(options.defectRetryPolicy, defaultRetryPolicy)
+    ? Schedule.concat(options.defectRetryPolicy, defaultRetryPolicy)
     : defaultRetryPolicy
   const retryDriver = yield* Schedule.toStepWithSleep(defectRetryPolicy)
   const entityRpcs = new Map(entity.protocol.requests)

--- a/packages/effect/test/Schedule.test.ts
+++ b/packages/effect/test/Schedule.test.ts
@@ -81,6 +81,28 @@ describe("Schedule", () => {
   })
 
   describe("sequencing", () => {
+    it.effect("concat - sequences self then other and merges their outputs", () =>
+      Effect.gen(function*() {
+        const left = Schedule.identity<string>().pipe(
+          Schedule.upTo({ times: 2 }),
+          Schedule.map(({ output }) => `left:${output}`)
+        )
+        const right = Schedule.identity<string>().pipe(
+          Schedule.map(({ output }) => `right:${output}`)
+        )
+        const step = yield* Schedule.toStep(Schedule.concat(left, right))
+
+        const first = yield* step(0, "a")
+        const second = yield* step(0, "b")
+        const third = yield* step(0, "c")
+
+        assert.deepStrictEqual([first, second, third], [
+          ["left:a", Duration.zero],
+          ["left:b", Duration.zero],
+          ["right:c", Duration.zero]
+        ])
+      }))
+
     it.effect("tap - provides full metadata", () =>
       Effect.gen(function*() {
         const observed: Array<Schedule.Metadata<number, string>> = []

--- a/packages/effect/test/Schedule.test.ts
+++ b/packages/effect/test/Schedule.test.ts
@@ -225,13 +225,13 @@ describe("Schedule", () => {
         ])
       }))
 
-    it.effect("andThenResult - sequences self then other when collecting delays", () =>
+    it.effect("concatResult - sequences self then other when collecting delays", () =>
       Effect.gen(function*() {
         const left = Schedule.fixed("500 millis").pipe(
           Schedule.while(({ attempt }) => Effect.succeed(attempt <= 3))
         )
         const right = Schedule.fixed("1 second")
-        const schedule = Schedule.andThenResult(left, right)
+        const schedule = Schedule.concatResult(left, right)
         const inputs = Array.makeBy(6, constUndefined)
         const outputs = yield* runDelays(schedule, inputs)
         expect(outputs).toEqual([
@@ -244,13 +244,13 @@ describe("Schedule", () => {
         ])
       }))
 
-    it.effect("andThenResult - includes finite other completion when collecting delays", () =>
+    it.effect("concatResult - includes finite other completion when collecting delays", () =>
       Effect.gen(function*() {
         const left = Schedule.fixed("500 millis").pipe(
           Schedule.while(({ attempt }) => Effect.succeed(attempt <= 2))
         )
         const right = Schedule.duration("1 second")
-        const schedule = Schedule.andThenResult(left, right)
+        const schedule = Schedule.concatResult(left, right)
         const inputs = Array.makeBy(5, constUndefined)
         const outputs = yield* runDelays(schedule, inputs)
         expect(outputs).toEqual([
@@ -261,11 +261,11 @@ describe("Schedule", () => {
         ])
       }))
 
-    it.effect("andThenResult - wraps self outputs as Failure and other outputs as Success", () =>
+    it.effect("concatResult - wraps self outputs as Failure and other outputs as Success", () =>
       Effect.gen(function*() {
         const left = Schedule.identity<string>().pipe(Schedule.upTo({ times: 2 }))
         const right = Schedule.identity<string>()
-        const step = yield* Schedule.toStep(Schedule.andThenResult(left, right))
+        const step = yield* Schedule.toStep(Schedule.concatResult(left, right))
 
         const first = yield* step(0, "left-1")
         const second = yield* step(0, "left-2")


### PR DESCRIPTION
## Summary

- rename `Schedule.andThen` to `Schedule.concat` and `Schedule.andThenResult` to `Schedule.concatResult`
- update internal call sites, JSDoc examples, cookbook guidance, and v3-to-v4 migration references
- add focused sequencing coverage and a patch changeset

## Validation

- `pnpm vitest run packages/effect/test/Schedule.test.ts`
- `pnpm doctest packages/effect/src/Schedule.ts`
- `pnpm check`
- `pnpm lint`
- `pnpm changeset status --since origin/main`

Closes EFF-477