### PR TITLE
Update scoped test guidance for v4

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -123,6 +123,7 @@ Read `.patterns/testing.md` before writing or changing tests.
 - Test files are located in `packages/*/test/`.
 - Main Effect library tests are in `packages/effect/test/`.
 - Use `it.effect` for Effect-returning tests.
+- `it.effect` and `it.live` already provide and close a `Scope` for each test; do not wrap test bodies in `Effect.scoped`.
 - Use regular `it` for pure synchronous tests.
 - Do not use `Effect.runSync` in tests.
 - Do not use `expect` from Vitest; use `assert` from `@effect/vitest`.

--- a/.patterns/testing.md
+++ b/.patterns/testing.md
@@ -4,6 +4,9 @@
 
 Use `it.effect` for tests that return Effects.
 
+`it.effect` and `it.live` each provide and close a `Scope` for every test. Return scoped effects directly; do not wrap
+the test body in `Effect.scoped`.
+
 ```typescript
 import { assert, describe, it } from "@effect/vitest"
 import { Effect } from "effect"

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -6,7 +6,7 @@ In this guide, we'll walk you through setting up the necessary dependencies and 
 
 # Requirements
 
-First, ensure you have a supported [`vitest`](https://vitest.dev/guide/) version installed (`^3.0.0` or `^4.0.0`).
+First, ensure you have a supported [`vitest`](https://vitest.dev/guide/) version installed (`^4.1.0`).
 
 ```sh
 pnpm add -D vitest
@@ -28,13 +28,13 @@ import { it } from "@effect/vitest"
 
 This import enhances the standard `it` function from `vitest` with several powerful features, including:
 
-| Feature         | Description                                                                                            |
-| --------------- | ------------------------------------------------------------------------------------------------------ |
-| `it.effect`     | Automatically injects a `TestContext` (e.g., `TestClock`) when running a test.                         |
-| `it.live`       | Runs the test with the live Effect environment.                                                        |
-| `it.scoped`     | Allows running an Effect program that requires a `Scope`.                                              |
-| `it.scopedLive` | Combines the features of `scoped` and `live`, using a live Effect environment that requires a `Scope`. |
-| `it.flakyTest`  | Facilitates the execution of tests that might occasionally fail.                                       |
+| Feature        | Description                                                                                         |
+| -------------- | --------------------------------------------------------------------------------------------------- |
+| `it.effect`    | Runs a scoped test with test services such as `TestClock` and `TestConsole`.                        |
+| `it.live`      | Runs a scoped test with the live Effect environment.                                                |
+| `it.layer`     | Shares a `Layer` between multiple tests.                                                            |
+| `it.prop`      | Runs property tests using Effect `Schema` values or FastCheck arbitraries.                          |
+| `it.flakyTest` | Retries an Effect that might occasionally fail until it succeeds or reaches the configured timeout. |
 
 # Writing Tests with `it.effect`
 
@@ -48,7 +48,7 @@ import { it } from "@effect/vitest"
 it.effect("test name", () => EffectContainingAssertions, timeout: number | TestOptions = 5_000)
 ```
 
-`it.effect` automatically provides a `TestContext`, allowing access to services like [`TestClock`](#using-the-testclock).
+`it.effect` automatically provides the Effect test services, including [`TestClock`](#using-the-testclock), and a fresh `Scope` for each test. The scope is closed when the test finishes.
 
 ## Testing Successful Operations
 
@@ -110,7 +110,7 @@ it.effect("test failure as Exit", () =>
 
 ## Using the TestClock
 
-When writing tests with `it.effect`, a `TestContext` is automatically provided. This context gives access to various testing services, including the [`TestClock`](https://effect.website/docs/guides/testing/testclock), which allows you to simulate the passage of time in your tests.
+When writing tests with `it.effect`, Effect test services are automatically provided. These include the [`TestClock`](https://effect.website/docs/guides/testing/testclock), which allows you to simulate the passage of time in your tests.
 
 **Note**: If you want to use the real-time clock (instead of the simulated one), you can switch to `it.live`.
 
@@ -126,7 +126,8 @@ Here are examples that demonstrate how you can work with time in your tests usin
 
 ```ts
 import { it } from "@effect/vitest"
-import { Clock, Effect, TestClock } from "effect"
+import { Clock, Effect } from "effect"
+import { TestClock } from "effect/testing"
 
 // Effect to log the current time
 const logNow = Effect.gen(function*() {
@@ -212,7 +213,7 @@ When adding new failing tests, you might not be able to fix them right away. Ins
 import { it } from "@effect/vitest"
 import { Effect, Exit } from "effect"
 
-function divide(a: number, b: number): number {
+function divide(a: number, b: number) {
   if (b === 0) return Effect.fail("Cannot divide by zero")
   return Effect.succeed(a / b)
 }
@@ -246,7 +247,7 @@ it.effect("providing a logger displays a log", () =>
   Effect.gen(function*() {
     yield* Effect.log("it.effect with custom logger") // Log will be displayed
   }).pipe(
-    Effect.provide(Logger.pretty) // Providing a pretty logger for log output
+    Effect.provide(Logger.layer([Logger.consolePretty()])) // Providing a pretty logger for log output
   ))
 
 // This test runs using `it.live`, which enables logging by default
@@ -256,11 +257,11 @@ it.live("it.live displays a log", () =>
   }))
 ```
 
-# Writing Tests with `it.scoped`
+# Resource Safety and Scope
 
-The `it.scoped` method is used for tests that involve `Effect` programs needing a `Scope`. A `Scope` ensures that any resources your test acquires are managed properly, meaning they will be released when the test completes. This helps prevent resource leaks and guarantees test isolation.
+Both `it.effect` and `it.live` provide a fresh `Scope` and close it after each test. Test bodies can therefore use scoped resources directly. Do not wrap the test body in `Effect.scoped`, because the test runner already manages its scope.
 
-**Example** (Using `it.scoped` to Manage Resource Lifecycle)
+**Example** (Managing a Resource Lifecycle)
 
 ```ts
 import { it } from "@effect/vitest"
@@ -273,14 +274,7 @@ const release = Console.log("release resource")
 // Defining a resource that requires proper management
 const resource = Effect.acquireRelease(acquire, () => release)
 
-// Incorrect usage: This will result in a type error because it lacks a scope
 it.effect("run with scope", () =>
-  Effect.gen(function*() {
-    yield* resource
-  }))
-
-// Correct usage: Using 'it.scoped' to manage the scope correctly
-it.scoped("run with scope", () =>
   Effect.gen(function*() {
     yield* resource
   }))


### PR DESCRIPTION
## Summary

- document that `it.effect` and `it.live` provide a managed `Scope`
- remove the obsolete `it.scoped` and `it.scopedLive` guidance
- update other v3-era requirements, imports, and logger APIs in the vitest README
- reinforce the scoped-test rule in the repository's agent and testing-pattern guidance

## Why

The package README and agent guidance did not make v4's built-in test scopes clear, which led agents to add redundant `Effect.scoped` wrappers.

## Validation

- `pnpm lint-fix`
- `pnpm --filter @effect/vitest check`
- `pnpm test --run packages/vitest/test/index.test.ts` (29 passed, 1 expected failure, 5 skipped)

Closes EFF-519