### PR TITLE
Wait for MySQL test container readiness

### DIFF
--- a/packages/platform-node/test/cluster-integration/globalSetup.ts
+++ b/packages/platform-node/test/cluster-integration/globalSetup.ts
@@ -13,10 +13,21 @@ declare module "vitest" {
   }
 }
 
+const makeMysqlContainer = () =>
+  new MySqlContainer("mysql:lts").withHealthCheck({
+    test: [
+      "CMD-SHELL",
+      "MYSQL_PWD=\"$MYSQL_ROOT_PASSWORD\" mysqladmin ping --protocol TCP --host 127.0.0.1 --user root --silent"
+    ],
+    interval: 250,
+    timeout: 1000,
+    retries: 1000
+  })
+
 export default function setup(project: TestProject) {
   return Promise.all([
     new PostgreSqlContainer("postgres:alpine").start(),
-    new MySqlContainer("mysql:lts").start()
+    makeMysqlContainer().start()
   ]).then(([pg, mysql]) => {
     project.provide("clusterDatabases", {
       mysql: mysql.getConnectionUri(),

--- a/packages/platform-node/test/fixtures/mysql2-utils.ts
+++ b/packages/platform-node/test/fixtures/mysql2-utils.ts
@@ -7,6 +7,17 @@ export class ContainerError extends Data.TaggedError("ContainerError")<{
   cause: unknown
 }> {}
 
+const makeMysqlContainer = () =>
+  new MySqlContainer("mysql:lts").withHealthCheck({
+    test: [
+      "CMD-SHELL",
+      "MYSQL_PWD=\"$MYSQL_ROOT_PASSWORD\" mysqladmin ping --protocol TCP --host 127.0.0.1 --user root --silent"
+    ],
+    interval: 250,
+    timeout: 1000,
+    retries: 1000
+  })
+
 export class MysqlContainer extends Context.Service<
   MysqlContainer,
   StartedMySqlContainer
@@ -14,7 +25,7 @@ export class MysqlContainer extends Context.Service<
   static readonly layer = Layer.effect(this)(
     Effect.acquireRelease(
       Effect.tryPromise({
-        try: () => new MySqlContainer("mysql:lts").start(),
+        try: () => makeMysqlContainer().start(),
         catch: (cause) => new ContainerError({ cause })
       }),
       (container) => Effect.promise(() => container.stop())

--- a/packages/sql/mysql2/test/utils.ts
+++ b/packages/sql/mysql2/test/utils.ts
@@ -7,6 +7,17 @@ export class ContainerError extends Data.TaggedError("ContainerError")<{
   cause: unknown
 }> {}
 
+const makeMysqlContainer = () =>
+  new MySqlContainer("mysql:lts").withHealthCheck({
+    test: [
+      "CMD-SHELL",
+      "MYSQL_PWD=\"$MYSQL_ROOT_PASSWORD\" mysqladmin ping --protocol TCP --host 127.0.0.1 --user root --silent"
+    ],
+    interval: 250,
+    timeout: 1000,
+    retries: 1000
+  })
+
 export class MysqlContainer extends Context.Service<
   MysqlContainer,
   StartedMySqlContainer
@@ -14,7 +25,7 @@ export class MysqlContainer extends Context.Service<
   static readonly layer = Layer.effect(this)(
     Effect.acquireRelease(
       Effect.tryPromise({
-        try: () => new MySqlContainer("mysql:lts").start(),
+        try: () => makeMysqlContainer().start(),
         catch: (cause) => new ContainerError({ cause })
       }),
       (container) => Effect.promise(() => container.stop())


### PR DESCRIPTION
## Summary

- add a TCP `mysqladmin ping` health check to every `mysql:lts` test container
- make Testcontainers wait for MySQL initialization before constructing clients or providing cluster database URLs
- leave the Vitess container paths unchanged

## Root cause

The MySQL fixtures inherited Testcontainers' generic port readiness, unlike the PostgreSQL fixture's database-aware health check. MySQL can expose port 3306 before initialization is complete, so setup raced the server and failed with `ECONNREFUSED` until the Vitest hook timed out.

## Validation

- `pnpm --filter @effect/sql-mysql2 check`
- `pnpm --filter @effect/platform-node check`
- `pnpm lint`
- Targeted Docker-backed integration tests cannot run in this workspace because it has no working container runtime; GitHub CI covers them.

Closes EFF-520
