### PR TITLE
Honor writeFile flags in Deno

### DIFF
--- a/.changeset/quiet-files-write.md
+++ b/.changeset/quiet-files-write.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-deno": patch
+---
+
+Honor `FileSystem.writeFile` open flags in the Deno implementation.

--- a/packages/effect/test/FileSystem.test-utils.ts
+++ b/packages/effect/test/FileSystem.test-utils.ts
@@ -107,6 +107,50 @@ export const testLayer = <E>(layer: Layer.Layer<Fs.FileSystem, E>, options: Test
       expect(after).toEqual("")
     })))
 
+  it("writeFile with r+ overwrites without truncating", () =>
+    runPromise(Effect.gen(function*() {
+      const fs = yield* Fs.FileSystem
+      const path = yield* fs.makeTempFile()
+
+      yield* fs.writeFileString(path, "abcdef")
+      yield* fs.writeFile(path, new TextEncoder().encode("xy"), { flag: "r+" })
+
+      assert.strictEqual(yield* fs.readFileString(path), "xycdef")
+    })))
+
+  it("writeFile with r rejects writes", () =>
+    runPromise(Effect.gen(function*() {
+      const fs = yield* Fs.FileSystem
+      const path = yield* fs.makeTempFile()
+
+      yield* fs.writeFile(path, new TextEncoder().encode("data"), { flag: "r" }).pipe(Effect.flip)
+
+      assert.strictEqual(yield* fs.readFileString(path), "")
+    })))
+
+  it("writeFile with a appends", () =>
+    runPromise(Effect.gen(function*() {
+      const fs = yield* Fs.FileSystem
+      const path = yield* fs.makeTempFile()
+
+      yield* fs.writeFileString(path, "abc")
+      yield* fs.writeFile(path, new TextEncoder().encode("def"), { flag: "a" })
+
+      assert.strictEqual(yield* fs.readFileString(path), "abcdef")
+    })))
+
+  it("writeFile with wx exclusively creates", () =>
+    runPromise(Effect.gen(function*() {
+      const fs = yield* Fs.FileSystem
+      const root = yield* fs.makeTempDirectory()
+      const path = `${root}/file.txt`
+
+      yield* fs.writeFile(path, new TextEncoder().encode("first"), { flag: "wx" })
+      yield* fs.writeFile(path, new TextEncoder().encode("second"), { flag: "wx" }).pipe(Effect.flip)
+
+      assert.strictEqual(yield* fs.readFileString(path), "first")
+    })))
+
   it("should track the cursor position when reading", () =>
     runPromise(Effect.gen(function*() {
       const fs = yield* Fs.FileSystem

--- a/packages/effect/test/FileSystem.test-utils.ts
+++ b/packages/effect/test/FileSystem.test-utils.ts
@@ -113,9 +113,23 @@ export const testLayer = <E>(layer: Layer.Layer<Fs.FileSystem, E>, options: Test
       const path = yield* fs.makeTempFile()
 
       yield* fs.writeFileString(path, "abcdef")
-      yield* fs.writeFile(path, new TextEncoder().encode("xy"), { flag: "r+" })
+      yield* fs.writeFileString(path, "xy", { flag: "r+" })
 
       assert.strictEqual(yield* fs.readFileString(path), "xycdef")
+    })))
+
+  it("writeFile with empty data honors the flag", () =>
+    runPromise(Effect.gen(function*() {
+      const fs = yield* Fs.FileSystem
+      const path = yield* fs.makeTempFile()
+
+      yield* fs.writeFileString(path, "abc")
+      yield* fs.writeFileString(path, "")
+      assert.strictEqual(yield* fs.readFileString(path), "")
+
+      yield* fs.writeFileString(path, "abc")
+      yield* fs.writeFileString(path, "", { flag: "r+" })
+      assert.strictEqual(yield* fs.readFileString(path), "abc")
     })))
 
   it("writeFile with r rejects writes", () =>
@@ -123,7 +137,7 @@ export const testLayer = <E>(layer: Layer.Layer<Fs.FileSystem, E>, options: Test
       const fs = yield* Fs.FileSystem
       const path = yield* fs.makeTempFile()
 
-      yield* fs.writeFile(path, new TextEncoder().encode("data"), { flag: "r" }).pipe(Effect.flip)
+      yield* fs.writeFileString(path, "data", { flag: "r" }).pipe(Effect.flip)
 
       assert.strictEqual(yield* fs.readFileString(path), "")
     })))
@@ -134,7 +148,7 @@ export const testLayer = <E>(layer: Layer.Layer<Fs.FileSystem, E>, options: Test
       const path = yield* fs.makeTempFile()
 
       yield* fs.writeFileString(path, "abc")
-      yield* fs.writeFile(path, new TextEncoder().encode("def"), { flag: "a" })
+      yield* fs.writeFileString(path, "def", { flag: "a" })
 
       assert.strictEqual(yield* fs.readFileString(path), "abcdef")
     })))
@@ -145,8 +159,8 @@ export const testLayer = <E>(layer: Layer.Layer<Fs.FileSystem, E>, options: Test
       const root = yield* fs.makeTempDirectory()
       const path = `${root}/file.txt`
 
-      yield* fs.writeFile(path, new TextEncoder().encode("first"), { flag: "wx" })
-      yield* fs.writeFile(path, new TextEncoder().encode("second"), { flag: "wx" }).pipe(Effect.flip)
+      yield* fs.writeFileString(path, "first", { flag: "wx" })
+      yield* fs.writeFileString(path, "second", { flag: "wx" }).pipe(Effect.flip)
 
       assert.strictEqual(yield* fs.readFileString(path), "first")
     })))

--- a/packages/platform-deno/src/DenoFileSystem.ts
+++ b/packages/platform-deno/src/DenoFileSystem.ts
@@ -321,7 +321,7 @@ class FileImpl implements FileSystem.File {
   }
 
   writeAll(buffer: Uint8Array) {
-    return this.writeAllChunk(buffer)
+    return buffer.length === 0 ? Effect.void : this.writeAllChunk(buffer)
   }
 }
 
@@ -439,12 +439,23 @@ const watch = (
     Stream.unwrap
   )
 
-const writeFile: FileSystem.FileSystem["writeFile"] = (path, data, options) =>
-  Effect.acquireUseRelease(
-    tryPromise("writeFile", path, () => Deno.open(path, openOptions(options?.flag ?? "w", options?.mode))),
-    (file) => new FileImpl(file, options?.flag?.startsWith("a") ?? false).writeAll(data),
+const writeFile: FileSystem.FileSystem["writeFile"] = (path, data, options) => {
+  const flag = options?.flag ?? "w"
+  if (flag === "w" || flag === "wx" || flag === "a" || flag === "ax") {
+    return tryPromise("writeFile", path, (signal) =>
+      Deno.writeFile(path, data, {
+        append: flag.startsWith("a"),
+        createNew: flag.includes("x"),
+        ...(options?.mode === undefined ? {} : { mode: options.mode }),
+        signal
+      }))
+  }
+  return Effect.acquireUseRelease(
+    tryPromise("writeFile", path, () => Deno.open(path, openOptions(flag, options?.mode))),
+    (file) => new FileImpl(file, flag.startsWith("a")).writeAll(data),
     (file) => close(file, "writeFile", path)
   )
+}
 
 const makeFileSystem = Effect.map(Effect.serviceOption(FileSystem.WatchBackend), (backend) =>
   FileSystem.make({

--- a/packages/platform-deno/src/DenoFileSystem.ts
+++ b/packages/platform-deno/src/DenoFileSystem.ts
@@ -439,17 +439,12 @@ const watch = (
     Stream.unwrap
   )
 
-const writeFile: FileSystem.FileSystem["writeFile"] = (path, data, options) => {
-  const flag = options?.flag
-  return tryPromise("writeFile", path, (signal) =>
-    Deno.writeFile(path, data, {
-      append: flag?.startsWith("a") ?? false,
-      create: flag !== "r" && flag !== "r+",
-      createNew: flag?.includes("x") ?? false,
-      ...(options?.mode === undefined ? {} : { mode: options.mode }),
-      signal
-    }))
-}
+const writeFile: FileSystem.FileSystem["writeFile"] = (path, data, options) =>
+  Effect.acquireUseRelease(
+    tryPromise("writeFile", path, () => Deno.open(path, openOptions(options?.flag ?? "w", options?.mode))),
+    (file) => new FileImpl(file, options?.flag?.startsWith("a") ?? false).writeAll(data),
+    (file) => close(file, "writeFile", path)
+  )
 
 const makeFileSystem = Effect.map(Effect.serviceOption(FileSystem.WatchBackend), (backend) =>
   FileSystem.make({


### PR DESCRIPTION
## Summary

- honor every `FileSystem.writeFile` open flag in the Deno adapter
- preserve native `AbortSignal` cancellation for `w`, `wx`, `a`, and `ax` writes
- use `Deno.open` for read and `+` modes that `Deno.writeFile` cannot faithfully represent
- handle empty writes without raising `WriteZero`
- add shared filesystem coverage for read-only, read/write, append, exclusive-create, and empty-write behavior
- add a patch changeset for `@effect/platform-deno`

## Root cause

`Deno.writeFile` exposes only append/create/createNew booleans, so it cannot represent every Node-style open flag. In particular, `r` was writable and `r+` truncated the file. Routing every mode through `Deno.open` fixed those semantics but regressed empty writes and cancellation. The hybrid implementation keeps the native, cancellable path where its semantics are sufficient and uses the complete `Deno.open` mapping for the remaining flags.

## Validation

- `deno task test --run packages/platform-deno/test/DenoFileSystem.test.ts` (19 passed, 1 skipped)
- `pnpm test --run packages/platform-node-shared/test/NodeFileSystem.test.ts` (23 passed)
- `pnpm lint-fix`
- `pnpm check`

Closes EFF-522