### PR TITLE
Scope Atom runtime memoization to registries

### DIFF
--- a/.changeset/pre/eff-523-registry-scoped-atom-runtime.md
+++ b/.changeset/pre/eff-523-registry-scoped-atom-runtime.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Scope `Atom.runtime` layer memoization to each `AtomRegistry` by default. Process-wide sharing is still available by passing a concrete `Layer.MemoMap` to `Atom.context`; the `Atom.defaultMemoMap` export has been removed.

--- a/packages/effect/src/unstable/reactivity/Atom.ts
+++ b/packages/effect/src/unstable/reactivity/Atom.ts
@@ -802,9 +802,7 @@ export function context(options?: {
         get.subscribe(atom, (value) => get.setSelf(value))
         return get.once(atom)
       }, { initialValueTarget: atom }) as any as A
-  return isAtom(memoMap)
-    ? factory as RegistryRuntimeFactory
-    : factory as SharedRuntimeFactory
+  return factory as any
 }
 
 /**

--- a/packages/effect/src/unstable/reactivity/Atom.ts
+++ b/packages/effect/src/unstable/reactivity/Atom.ts
@@ -694,7 +694,7 @@ export interface AtomRuntime<R, ER = never> extends Atom<AsyncResult.AsyncResult
 }
 
 /**
- * Factory for `AtomRuntime` values that share a `Layer.MemoMap` and a set of global layers.
+ * Factory for `AtomRuntime` values that share a set of global layers.
  *
  * @category models
  * @since 4.0.0
@@ -705,7 +705,6 @@ export interface RuntimeFactory {
       | Layer.Layer<R, E, AtomRegistry | Reactivity.Reactivity>
       | ((get: AtomContext) => Layer.Layer<R, E, AtomRegistry | Reactivity.Reactivity>)
   ): AtomRuntime<R, E>
-  readonly memoMap: Layer.MemoMap
   readonly addGlobalLayer: <A, E>(layer: Layer.Layer<A, E, AtomRegistry | Reactivity.Reactivity>) => void
 
   /**
@@ -718,14 +717,40 @@ export interface RuntimeFactory {
 }
 
 /**
- * Creates a `RuntimeFactory` backed by the supplied `Layer.MemoMap`.
+ * A `RuntimeFactory` backed by an atom whose memo map is scoped to each registry.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface RegistryRuntimeFactory extends RuntimeFactory {
+  readonly memoMap: Atom<Layer.MemoMap>
+}
+
+/**
+ * A `RuntimeFactory` backed by a concrete memo map shared across registries.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface SharedRuntimeFactory extends RuntimeFactory {
+  readonly memoMap: Layer.MemoMap
+}
+
+/**
+ * Creates a `RuntimeFactory` backed by a registry-scoped memo map by default,
+ * or by the supplied atom or concrete `Layer.MemoMap`.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const context: (options: {
-  readonly memoMap: Layer.MemoMap
-}) => RuntimeFactory = (options) => {
+export function context(): RegistryRuntimeFactory
+export function context(options: { readonly memoMap: Atom<Layer.MemoMap> }): RegistryRuntimeFactory
+export function context(options: { readonly memoMap: Layer.MemoMap }): SharedRuntimeFactory
+export function context(options?: {
+  readonly memoMap: Atom<Layer.MemoMap> | Layer.MemoMap
+}): RegistryRuntimeFactory | SharedRuntimeFactory {
+  const memoMap = options?.memoMap ?? removeTtl(make(() => Layer.makeMemoMapUnsafe()))
+  const resolveMemoMap = (get: AtomContext): Layer.MemoMap => isAtom(memoMap) ? get(memoMap) : memoMap
   let globalLayer: Layer.Layer<any, any, AtomRegistry> = Reactivity.layer
   function factory<E, R>(
     create:
@@ -747,23 +772,25 @@ export const context: (options: {
 
     self.read = function read(get: AtomContext) {
       const layer = get(layerAtom)
-      const build = Effect.flatMap(Effect.scope, (scope) => Layer.buildWithMemoMap(layer, options.memoMap, scope))
+      const build = Effect.flatMap(Effect.scope, (scope) => Layer.buildWithMemoMap(layer, resolveMemoMap(get), scope))
       return effect(get, build, { uninterruptible: true })
     }
 
     return self
   }
-  factory.memoMap = options.memoMap
+  factory.memoMap = memoMap
   factory.addGlobalLayer = (layer: Layer.Layer<any, any, AtomRegistry | Reactivity.Reactivity>) => {
     globalLayer = Layer.provideMerge(globalLayer, Layer.provide(layer, Reactivity.layer))
   }
-  const reactivityAtom = removeTtl(make(
-    Effect.contextWith((services: Context.Context<Scope.Scope>) =>
-      Layer.buildWithMemoMap(Reactivity.layer, options.memoMap, Context.get(services, Scope.Scope))
-    ).pipe(
-      Effect.map(Context.get(Reactivity.Reactivity))
+  const reactivityAtom = removeTtl(
+    make((get) =>
+      Effect.contextWith((services: Context.Context<Scope.Scope>) =>
+        Layer.buildWithMemoMap(Reactivity.layer, resolveMemoMap(get), Context.get(services, Scope.Scope))
+      ).pipe(
+        Effect.map(Context.get(Reactivity.Reactivity))
+      )
     )
-  ))
+  )
   factory.withReactivity =
     (keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>) =>
     <A extends Atom<any>>(atom: A): A =>
@@ -775,24 +802,18 @@ export const context: (options: {
         get.subscribe(atom, (value) => get.setSelf(value))
         return get.once(atom)
       }, { initialValueTarget: atom }) as any as A
-  return factory
+  return isAtom(memoMap)
+    ? factory as RegistryRuntimeFactory
+    : factory as SharedRuntimeFactory
 }
 
 /**
- * Default `Layer.MemoMap` used by the module-level `runtime` factory.
+ * Default registry-scoped `RuntimeFactory`.
  *
  * @category context
  * @since 4.0.0
  */
-export const defaultMemoMap: Layer.MemoMap = Layer.makeMemoMapUnsafe()
-
-/**
- * Default `RuntimeFactory` created with `defaultMemoMap`.
- *
- * @category context
- * @since 4.0.0
- */
-export const runtime: RuntimeFactory = context({ memoMap: defaultMemoMap })
+export const runtime: RegistryRuntimeFactory = context()
 
 /**
  * Returns `Rx.runtime.withReactivity` for refreshing an atom whenever the

--- a/packages/effect/test/reactivity/Atom.test.ts
+++ b/packages/effect/test/reactivity/Atom.test.ts
@@ -200,6 +200,106 @@ describe.sequential("Atom", () => {
     expect(result.value).toEqual(1)
   })
 
+  it("runtime layers are disposed with their registry", () => {
+    interface Service {
+      readonly id: number
+      readonly isAlive: () => boolean
+      readonly finalize: () => void
+    }
+    const Service = Context.Service<Service>("Atom.test/RegistryScopedService")
+    const finalized: Array<number> = []
+    let builds = 0
+    const layer = Layer.effect(
+      Service,
+      Effect.acquireRelease(
+        Effect.sync(() => {
+          const id = ++builds
+          let alive = true
+          return Service.of({ id, isAlive: () => alive, finalize: () => alive = false })
+        }),
+        (service) =>
+          Effect.sync(() => {
+            service.finalize()
+            finalized.push(service.id)
+          })
+      )
+    )
+    const runtime = Atom.runtime(layer)
+    const service = runtime.atom(Service)
+    const registryA = AtomRegistry.make()
+    const registryB = AtomRegistry.make()
+
+    const resultA = registryA.get(service)
+    const resultB = registryB.get(service)
+    assert(AsyncResult.isSuccess(resultA))
+    assert(AsyncResult.isSuccess(resultB))
+    expect(resultA.value.id).not.toEqual(resultB.value.id)
+
+    registryA.dispose()
+
+    expect(finalized).toEqual([resultA.value.id])
+    expect(resultA.value.isAlive()).toEqual(false)
+    expect(resultB.value.isAlive()).toEqual(true)
+    assert(AsyncResult.isSuccess(registryB.get(service)))
+
+    registryB.dispose()
+  })
+
+  it("default runtime factories build layers once per registry", () => {
+    const Service = Context.Service<number>("Atom.test/DefaultRegistryScopedService")
+    let builds = 0
+    const runtime = Atom.runtime(Layer.sync(Service, () => ++builds))
+    const service = runtime.atom(Service)
+    const registryA = AtomRegistry.make()
+    const registryB = AtomRegistry.make()
+
+    expect(registryA.get(service)).toEqual(AsyncResult.success(1))
+    expect(registryB.get(service)).toEqual(AsyncResult.success(2))
+    expect(builds).toEqual(2)
+
+    registryA.dispose()
+    registryB.dispose()
+  })
+
+  it("concrete runtime memo maps share layers across registries", () => {
+    const Service = Context.Service<number>("Atom.test/SharedRuntimeService")
+    let builds = 0
+    const factory = Atom.context({ memoMap: Layer.makeMemoMapUnsafe() })
+    const runtime = factory(Layer.sync(Service, () => ++builds))
+    const service = runtime.atom(Service)
+    const registryA = AtomRegistry.make()
+    const registryB = AtomRegistry.make()
+
+    expect(registryA.get(service)).toEqual(AsyncResult.success(1))
+    expect(registryB.get(service)).toEqual(AsyncResult.success(1))
+    expect(builds).toEqual(1)
+
+    registryA.dispose()
+    registryB.dispose()
+  })
+
+  it("shared memo map atoms share within a registry and isolate across registries", () => {
+    const Service = Context.Service<number>("Atom.test/SharedRegistryScopedService")
+    let builds = 0
+    const layer = Layer.sync(Service, () => ++builds)
+    const memoMap = Atom.make(() => Layer.makeMemoMapUnsafe())
+    const factoryA = Atom.context({ memoMap })
+    const factoryB = Atom.context({ memoMap })
+    const serviceA = factoryA(layer).atom(Service)
+    const serviceB = factoryB(layer).atom(Service)
+    const registryA = AtomRegistry.make()
+    const registryB = AtomRegistry.make()
+
+    expect(registryA.get(serviceA)).toEqual(AsyncResult.success(1))
+    expect(registryA.get(serviceB)).toEqual(AsyncResult.success(1))
+    expect(registryB.get(serviceA)).toEqual(AsyncResult.success(2))
+    expect(registryB.get(serviceB)).toEqual(AsyncResult.success(2))
+    expect(builds).toEqual(2)
+
+    registryA.dispose()
+    registryB.dispose()
+  })
+
   it("runtime replacement", async () => {
     const count = counterRuntime.atom(Counter.use((_) => _.get))
     const r = AtomRegistry.make({
@@ -2303,6 +2403,34 @@ describe.sequential("Atom", () => {
   })
 
   describe("Reactivity", () => {
+    it("does not broadcast mutations across registries", () => {
+      let reads = 0
+      const query = Atom.make(() => ++reads).pipe(
+        Atom.withReactivity(["counter"]),
+        Atom.keepAlive
+      )
+      const runtime = Atom.runtime(Layer.empty)
+      const mutation = runtime.fn(
+        Effect.fn(function*() {
+        }),
+        { reactivityKeys: ["counter"] }
+      )
+      const registryA = AtomRegistry.make()
+      const registryB = AtomRegistry.make()
+
+      expect(registryA.get(query)).toEqual(1)
+      expect(registryB.get(query)).toEqual(2)
+
+      registryA.set(mutation, void 0)
+
+      expect(reads).toEqual(3)
+      expect(registryA.get(query)).toEqual(3)
+      expect(registryB.get(query)).toEqual(2)
+
+      registryA.dispose()
+      registryB.dispose()
+    })
+
     it("rebuilds on mutation", async () => {
       const r = AtomRegistry.make()
       let rebuilds = 0

--- a/packages/effect/typetest/unstable/reactivity/Atom.tst.ts
+++ b/packages/effect/typetest/unstable/reactivity/Atom.tst.ts
@@ -1,0 +1,23 @@
+import { Layer } from "effect"
+import { Atom } from "effect/unstable/reactivity"
+import { describe, expect, it } from "tstyche"
+
+describe("Atom", () => {
+  describe("context", () => {
+    it("returns a registry runtime factory by default", () => {
+      expect(Atom.context()).type.toBe<Atom.RegistryRuntimeFactory>()
+    })
+
+    it("returns a registry runtime factory for an atom-backed memo map", () => {
+      const memoMap = Atom.make(() => Layer.makeMemoMapUnsafe())
+
+      expect(Atom.context({ memoMap })).type.toBe<Atom.RegistryRuntimeFactory>()
+    })
+
+    it("returns a shared runtime factory for a concrete memo map", () => {
+      const memoMap = Layer.makeMemoMapUnsafe()
+
+      expect(Atom.context({ memoMap })).type.toBe<Atom.SharedRuntimeFactory>()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- scope the default `Atom.runtime` memo map to each `AtomRegistry`
- add `Atom.context` overloads for registry-scoped map atoms and explicitly shared concrete maps
- isolate `Reactivity` broadcasts between registries and release registry-owned layers on disposal
- remove `Atom.defaultMemoMap` and document the behavior change in a patch changeset

## Root cause

The module-level runtime factory used one process-wide `Layer.MemoMap`, so independent registries shared layer instances and the same `Reactivity` service. Per-request registries therefore could not independently release their layers, and mutations in one registry refreshed queries in another.

## Validation

- `pnpm vitest packages/effect/test/reactivity/Atom.test.ts --run` (107 tests)
- `pnpm check`
- `pnpm lint`

Closes EFF-523
Closes #6887