### PR TITLE
Remove Context service definition stack capture

### DIFF
--- a/.changeset/calm-services-rest.md
+++ b/.changeset/calm-services-rest.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Stop capturing definition-location stack frames in `Context.Service`.

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -17,7 +17,6 @@ import { dual, type LazyArg } from "./Function.ts"
 import * as Hash from "./Hash.ts"
 import type { Inspectable } from "./Inspectable.ts"
 import { exitSucceed, PipeInspectableProto, withFiber } from "./internal/core.ts"
-import { getStackTraceLimit, setStackTraceLimit } from "./internal/stackTraceLimit.ts"
 import * as Option from "./Option.ts"
 import type { Pipeable } from "./Pipeable.ts"
 import { hasProperty } from "./Predicate.ts"
@@ -67,7 +66,6 @@ export interface Key<out Identifier, out Shape> extends Effect<Shape, never, Ide
   readonly Service: Shape
   readonly Identifier: Identifier
   readonly key: string
-  readonly stack?: string | undefined
 }
 
 /**
@@ -244,19 +242,9 @@ export const Service: {
     >
     & { readonly make: Make }
 } = function() {
-  const prevLimit = getStackTraceLimit()
-  setStackTraceLimit(2)
-  const err = new Error()
-  setStackTraceLimit(prevLimit)
   function KeyClass() {}
   const self = KeyClass as any as Types.Mutable<Reference<any>>
   Object.setPrototypeOf(self, ServiceProto)
-  // @effect-diagnostics-next-line floatingEffect:off
-  Object.defineProperty(self, "stack", {
-    get() {
-      return err.stack
-    }
-  })
   const init = (key: string, options?: {
     readonly defaultValue?: any
     readonly make?: any
@@ -289,8 +277,7 @@ const ServiceProto: any = {
   toJSON<I, A>(this: Service<I, A>) {
     return {
       _id: "Service",
-      key: this.key,
-      stack: this.stack
+      key: this.key
     }
   },
   of<Service>(this: void, self: Service): Service {
@@ -1049,15 +1036,6 @@ const serviceNotFoundError = (service: Key<any, any>) => {
   const error = new Error(
     `Service not found${service.key ? `: ${String(service.key)}` : ""}`
   )
-  if (service.stack) {
-    const lines = service.stack.split("\n")
-    if (lines.length > 2) {
-      const afterAt = lines[2].match(/at (.*)/)
-      if (afterAt) {
-        error.message = error.message + ` (defined at ${afterAt[1]})`
-      }
-    }
-  }
   if (error.stack) {
     const lines = error.stack.split("\n")
     lines.splice(1, 3)

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -10,6 +10,16 @@ describe("Context", () => {
   const B = Context.Service<number>("ContextTest/B")
   const C = Context.Service<number>("ContextTest/C")
 
+  it("does not capture the service definition location", () => {
+    const Service = Context.Service<number>("ContextTest/NoDefinitionStack")
+
+    assertFalse("stack" in Service)
+    deepStrictEqual(Service.toJSON(), {
+      _id: "Service",
+      key: "ContextTest/NoDefinitionStack"
+    })
+  })
+
   it("keeps the source immutable across additions", () => {
     const source = Context.make(A, 1)
     const result = Context.add(source, B, 2)

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -10,16 +10,6 @@ describe("Context", () => {
   const B = Context.Service<number>("ContextTest/B")
   const C = Context.Service<number>("ContextTest/C")
 
-  it("does not capture the service definition location", () => {
-    const Service = Context.Service<number>("ContextTest/NoDefinitionStack")
-
-    assertFalse("stack" in Service)
-    deepStrictEqual(Service.toJSON(), {
-      _id: "Service",
-      key: "ContextTest/NoDefinitionStack"
-    })
-  })
-
   it("keeps the source immutable across additions", () => {
     const source = Context.make(A, 1)
     const result = Context.add(source, B, 2)


### PR DESCRIPTION
## Summary

- stop `Context.Service` from capturing definition-location stack frames
- remove definition stack data from service keys, JSON, and missing-service errors

## Testing

- `nix develop -c pnpm --dir packages/effect check`
- `nix develop -c pnpm lint`

Closes EFF-525
