### PR TITLE
Decouple core runtime equality protocols

### DIFF
--- a/.changeset/quiet-dodos-compare.md
+++ b/.changeset/quiet-dodos-compare.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Reduce the core Effect runtime bundle by removing eager Equal and Hash protocol implementations from Cause, Exit, and Context.

--- a/.changeset/quiet-dodos-compare.md
+++ b/.changeset/quiet-dodos-compare.md
@@ -4,4 +4,4 @@
 
 Reduce the core Effect runtime bundle by removing eager Equal and Hash protocol implementations from Cause, Exit, and Context.
 
-`Cause.combine` now deduplicates `Fail` and `Die` reasons by `error` or `defect` identity. Other reasons use wrapper identity or an explicitly implemented Equal protocol.
+`Cause.combine` now deduplicates `Fail` and `Die` reasons by `error` or `defect` identity when their annotation maps are also identical. Other reasons use wrapper identity or an explicitly implemented Equal protocol.

--- a/.changeset/quiet-dodos-compare.md
+++ b/.changeset/quiet-dodos-compare.md
@@ -3,3 +3,5 @@
 ---
 
 Reduce the core Effect runtime bundle by removing eager Equal and Hash protocol implementations from Cause, Exit, and Context.
+
+`Cause.combine` now deduplicates `Fail` and `Die` reasons by `error` or `defect` identity. Other reasons use wrapper identity or an explicitly implemented Equal protocol.

--- a/packages/effect/src/Cause.ts
+++ b/packages/effect/src/Cause.ts
@@ -11,7 +11,6 @@
  */
 import * as Context from "./Context.ts"
 import type * as Effect from "./Effect.ts"
-import type { Equal } from "./Equal.ts"
 import type { Fiber } from "./Fiber.ts"
 import type { Inspectable } from "./Inspectable.ts"
 import * as core from "./internal/core.ts"
@@ -58,8 +57,7 @@ export const ReasonTypeId: "~effect/Cause/Reason" = core.CauseReasonTypeId
  *   of a given kind.
  * - Use {@link combine} to merge two causes.
  *
- * `Cause` implements `Equal` — two causes with the same reasons (by value)
- * compare as equal.
+ * Causes can be compared by value with `Equal.equals`.
  *
  * **Example** (Creating and inspecting a cause)
  *
@@ -72,7 +70,7 @@ export const ReasonTypeId: "~effect/Cause/Reason" = core.CauseReasonTypeId
  * @category models
  * @since 2.0.0
  */
-export interface Cause<out E> extends Pipeable, Inspectable, Equal {
+export interface Cause<out E> extends Pipeable, Inspectable {
   readonly [TypeId]: typeof TypeId
   readonly reasons: ReadonlyArray<Reason<E>>
 }
@@ -257,7 +255,7 @@ export declare namespace Cause {
    * @category models
    * @since 4.0.0
    */
-  export interface ReasonProto<Tag extends string> extends Inspectable, Equal {
+  export interface ReasonProto<Tag extends string> extends Inspectable {
     readonly [ReasonTypeId]: typeof ReasonTypeId
     readonly _tag: Tag
     readonly annotations: ReadonlyMap<string, unknown>

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -12,9 +12,7 @@
  */
 import type { Effect, EffectIterator } from "./Effect.ts"
 import * as Effectable from "./Effectable.ts"
-import * as Equal from "./Equal.ts"
 import { dual, type LazyArg } from "./Function.ts"
-import * as Hash from "./Hash.ts"
 import type { Inspectable } from "./Inspectable.ts"
 import { exitSucceed, PipeInspectableProto, withFiber } from "./internal/core.ts"
 import * as Option from "./Option.ts"
@@ -464,7 +462,7 @@ const TypeId = "~effect/Context" as const
  * @category models
  * @since 2.0.0
  */
-export interface Context<in Services> extends Equal.Equal, Pipeable, Inspectable {
+export interface Context<in Services> extends Pipeable, Inspectable {
   readonly [TypeId]: {
     readonly _Services: Types.Contravariant<Services>
   }
@@ -596,19 +594,6 @@ const Proto: Omit<
       _id: "Context",
       services: Array.from(this.mapUnsafe).map(([key, value]) => ({ key, value }))
     }
-  },
-  [Equal.symbol]<A>(this: Context<A>, that: unknown): boolean {
-    if (!isContext(that)) return false
-    const self = this.mapUnsafe
-    const other = that.mapUnsafe
-    if (self.size !== other.size) return false
-    for (const [key, value] of self) {
-      if (!other.has(key) || !Equal.equals(value, other.get(key))) return false
-    }
-    return true
-  },
-  [Hash.symbol]<A>(this: Context<A>): number {
-    return Hash.number(this.mapUnsafe.size)
   }
 }
 

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -163,16 +163,6 @@ export class CauseImpl<E> implements Cause.Cause<E> {
   [NodeInspectSymbol]() {
     return this.toJSON()
   }
-  [Equal.symbol](that: any): boolean {
-    return (
-      isCause(that) &&
-      this.reasons.length === that.reasons.length &&
-      this.reasons.every((e, i) => Equal.equals(e, that.reasons[i]))
-    )
-  }
-  [Hash.symbol](): number {
-    return Hash.array(this.reasons)
-  }
 }
 
 const annotationsMap = new WeakMap<object, ReadonlyMap<string, unknown>>()
@@ -226,8 +216,6 @@ export abstract class ReasonBase<Tag extends string> implements Cause.Cause.Reas
   }
 
   abstract toJSON(): unknown
-  abstract [Equal.symbol](that: any): boolean
-  abstract [Hash.symbol](): number
 
   toString() {
     return format(this)
@@ -260,18 +248,6 @@ export class Fail<E> extends ReasonBase<"Fail"> implements Cause.Fail<E> {
       error: this.error
     }
   }
-  [Equal.symbol](that: any): boolean {
-    return (
-      isFailReason(that) &&
-      Equal.equals(this.error, that.error) &&
-      Equal.equals(this.annotations, that.annotations)
-    )
-  }
-  [Hash.symbol](): number {
-    return Hash.combine(Hash.string(this._tag))(
-      Hash.combine(Hash.hash(this.error))(Hash.hash(this.annotations))
-    )
-  }
 }
 
 /** @internal */
@@ -303,18 +279,6 @@ export class Die extends ReasonBase<"Die"> implements Cause.Die {
       _tag: "Die",
       defect: this.defect
     }
-  }
-  [Equal.symbol](that: any): boolean {
-    return (
-      isDieReason(that) &&
-      Equal.equals(this.defect, that.defect) &&
-      Equal.equals(this.annotations, that.annotations)
-    )
-  }
-  [Hash.symbol](): number {
-    return Hash.combine(Hash.string(this._tag))(
-      Hash.combine(Hash.hash(this.defect))(Hash.hash(this.annotations))
-    )
   }
 }
 
@@ -486,16 +450,6 @@ export const makeExit = <
         _tag: options.op,
         [options.prop]: this[args]
       }
-    },
-    [Equal.symbol](this: any, that: any): boolean {
-      return (
-        isExit(that) &&
-        that._tag === this._tag &&
-        Equal.equals(this[args], (that as any)[args])
-      )
-    },
-    [Hash.symbol](this: any): number {
-      return Hash.combine(Hash.string(options.op), Hash.hash(this[args]))
     }
   }
   return function(value: unknown) {

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -5,14 +5,12 @@ import type * as Console from "../Console.ts"
 import * as Context from "../Context.ts"
 import * as Duration from "../Duration.ts"
 import type * as Effect from "../Effect.ts"
-import * as Equal from "../Equal.ts"
 import type * as Exit from "../Exit.ts"
 import type * as Fiber from "../Fiber.ts"
 import * as Filter from "../Filter.ts"
 import { formatJson } from "../Formatter.ts"
 import type { LazyArg } from "../Function.ts"
 import { constant, constFalse, constTrue, constUndefined, constVoid, dual, identity } from "../Function.ts"
-import * as Hash from "../Hash.ts"
 import { toJson, toStringUnknown } from "../Inspectable.ts"
 import * as Iterable from "../Iterable.ts"
 import type * as _Latch from "../Latch.ts"
@@ -121,18 +119,6 @@ export class Interrupt extends ReasonBase<"Interrupt"> implements Cause.Interrup
       _tag: "Interrupt",
       fiberId: this.fiberId
     }
-  }
-  [Equal.symbol](that: any): boolean {
-    return (
-      isInterruptReason(that) &&
-      this.fiberId === that.fiberId &&
-      this.annotations === that.annotations
-    )
-  }
-  [Hash.symbol](): number {
-    return Hash.combine(Hash.string(`${this._tag}:${this.fiberId}`))(
-      Hash.random(this.annotations)
-    )
   }
 }
 
@@ -250,12 +236,24 @@ export const causeCombine: {
     } else if (that.reasons.length === 0) {
       return self as Cause.Cause<E | E2>
     }
-    const newCause = new CauseImpl<E | E2>(
-      Arr.union(self.reasons, that.reasons)
-    )
-    return Equal.equals(self, newCause) ? self : newCause
+    const reasons = self.reasons.slice() as Array<Cause.Reason<E | E2>>
+    for (let i = 0; i < that.reasons.length; i++) {
+      const reason = that.reasons[i]
+      if (!reasons.some((current) => runtimeEquals(current, reason))) {
+        reasons.push(reason)
+      }
+    }
+    return reasons.length === self.reasons.length ? self : new CauseImpl(reasons)
   }
 )
+
+const EqualSymbol = "~effect/interfaces/Equal"
+
+const runtimeEquals = (self: unknown, that: unknown): boolean =>
+  self === that ||
+  (hasProperty(self, EqualSymbol) &&
+    hasProperty(that, EqualSymbol) &&
+    (self as any)[EqualSymbol](that))
 
 /** @internal */
 export const causeMap: {

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -250,8 +250,12 @@ export const causeCombine: {
 
 const causeReasonEquals = (self: Cause.Reason<unknown>, that: Cause.Reason<unknown>): boolean => {
   if (self === that) return true
-  if (self._tag === "Fail" && that._tag === "Fail") return self.error === that.error
-  if (self._tag === "Die" && that._tag === "Die") return self.defect === that.defect
+  if (self._tag === "Fail" && that._tag === "Fail") {
+    return self.error === that.error && self.annotations === that.annotations
+  }
+  if (self._tag === "Die" && that._tag === "Die") {
+    return self.defect === that.defect && self.annotations === that.annotations
+  }
   return hasProperty(self, Equal.symbol) &&
     hasProperty(that, Equal.symbol) &&
     (self as any)[Equal.symbol](that)

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -5,6 +5,7 @@ import type * as Console from "../Console.ts"
 import * as Context from "../Context.ts"
 import * as Duration from "../Duration.ts"
 import type * as Effect from "../Effect.ts"
+import * as Equal from "../Equal.ts"
 import type * as Exit from "../Exit.ts"
 import type * as Fiber from "../Fiber.ts"
 import * as Filter from "../Filter.ts"
@@ -247,13 +248,11 @@ export const causeCombine: {
   }
 )
 
-const EqualSymbol = "~effect/interfaces/Equal"
-
 const runtimeEquals = (self: unknown, that: unknown): boolean =>
   self === that ||
-  (hasProperty(self, EqualSymbol) &&
-    hasProperty(that, EqualSymbol) &&
-    (self as any)[EqualSymbol](that))
+  (hasProperty(self, Equal.symbol) &&
+    hasProperty(that, Equal.symbol) &&
+    (self as any)[Equal.symbol](that))
 
 /** @internal */
 export const causeMap: {

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -240,7 +240,7 @@ export const causeCombine: {
     const reasons = self.reasons.slice() as Array<Cause.Reason<E | E2>>
     for (let i = 0; i < that.reasons.length; i++) {
       const reason = that.reasons[i]
-      if (!reasons.some((current) => runtimeEquals(current, reason))) {
+      if (!reasons.some((current) => causeReasonEquals(current, reason))) {
         reasons.push(reason)
       }
     }
@@ -248,11 +248,14 @@ export const causeCombine: {
   }
 )
 
-const runtimeEquals = (self: unknown, that: unknown): boolean =>
-  self === that ||
-  (hasProperty(self, Equal.symbol) &&
+const causeReasonEquals = (self: Cause.Reason<unknown>, that: Cause.Reason<unknown>): boolean => {
+  if (self === that) return true
+  if (self._tag === "Fail" && that._tag === "Fail") return self.error === that.error
+  if (self._tag === "Die" && that._tag === "Die") return self.defect === that.defect
+  return hasProperty(self, Equal.symbol) &&
     hasProperty(that, Equal.symbol) &&
-    (self as any)[Equal.symbol](that))
+    (self as any)[Equal.symbol](that)
+}
 
 /** @internal */
 export const causeMap: {

--- a/packages/effect/test/Cause.test.ts
+++ b/packages/effect/test/Cause.test.ts
@@ -558,6 +558,38 @@ describe("Cause", () => {
       assert.strictEqual(Cause.combine(Cause.fail(defect), Cause.die(defect)).reasons.length, 2)
     })
 
+    it("preserves annotated Fail and Die reasons with shared payloads", () => {
+      const Annotation = Context.Service<string>("CauseTest/CombineAnnotation")
+      const error = { message: "error" }
+      const defect = { message: "defect" }
+      const failLeft = Cause.annotate(Cause.fail(error), Context.make(Annotation, "fail-left"))
+      const failRight = Cause.annotate(Cause.fail(error), Context.make(Annotation, "fail-right"))
+      const dieLeft = Cause.annotate(Cause.die(defect), Context.make(Annotation, "die-left"))
+      const dieRight = Cause.annotate(Cause.die(defect), Context.make(Annotation, "die-right"))
+
+      const failCombined = Cause.combine(failLeft, failRight)
+      const dieCombined = Cause.combine(dieLeft, dieRight)
+
+      assert.strictEqual(failCombined.reasons.length, 2)
+      assert.strictEqual(dieCombined.reasons.length, 2)
+      assert.strictEqual(
+        Context.getOrUndefined(Cause.reasonAnnotations(failCombined.reasons[0]), Annotation),
+        "fail-left"
+      )
+      assert.strictEqual(
+        Context.getOrUndefined(Cause.reasonAnnotations(failCombined.reasons[1]), Annotation),
+        "fail-right"
+      )
+      assert.strictEqual(
+        Context.getOrUndefined(Cause.reasonAnnotations(dieCombined.reasons[0]), Annotation),
+        "die-left"
+      )
+      assert.strictEqual(
+        Context.getOrUndefined(Cause.reasonAnnotations(dieCombined.reasons[1]), Annotation),
+        "die-right"
+      )
+    })
+
     it("delegates to reasons that explicitly implement Equal", () => {
       const left = Cause.makeInterruptReason(1) as any
       const right = Cause.makeInterruptReason(2) as any

--- a/packages/effect/test/Cause.test.ts
+++ b/packages/effect/test/Cause.test.ts
@@ -1,12 +1,26 @@
 import * as Cause from "effect/Cause"
 import * as Context from "effect/Context"
+import * as Equal from "effect/Equal"
 import { pipe } from "effect/Function"
+import * as Hash from "effect/Hash"
 import * as Option from "effect/Option"
 import * as Result from "effect/Result"
 import assert from "node:assert/strict"
 import { describe, it } from "vitest"
 
 describe("Cause", () => {
+  describe("equality", () => {
+    it("uses generic structural equality without implementing Equal or Hash", () => {
+      const left = Cause.fail({ message: "error" })
+      const right = Cause.fail({ message: "error" })
+
+      assert.strictEqual(Equal.isEqual(left), false)
+      assert.strictEqual(Hash.isHash(left), false)
+      assert.strictEqual(Equal.equals(left, right), true)
+      assert.strictEqual(Hash.hash(left), Hash.hash(right))
+    })
+  })
+
   describe("TypeId", () => {
     it("is a string constant", () => {
       assert.strictEqual(Cause.TypeId, "~effect/Cause")
@@ -510,6 +524,24 @@ describe("Cause", () => {
       const combined2 = Cause.combine(Cause.empty, cause)
       assert.strictEqual(combined1.reasons.length, 1)
       assert.strictEqual(combined2.reasons.length, 1)
+    })
+
+    it("deduplicates reasons by identity", () => {
+      const reason = Cause.makeFailReason("error")
+      const self = Cause.fromReasons([reason])
+
+      assert.strictEqual(Cause.combine(self, Cause.fromReasons([reason])), self)
+      assert.strictEqual(Cause.combine(Cause.fail("error"), Cause.fail("error")).reasons.length, 2)
+    })
+
+    it("delegates to reasons that explicitly implement Equal", () => {
+      const left = Cause.makeFailReason("left") as any
+      const right = Cause.makeFailReason("right") as any
+      left[Equal.symbol] = () => true
+      right[Equal.symbol] = () => true
+      const self = Cause.fromReasons([left])
+
+      assert.strictEqual(Cause.combine(self, Cause.fromReasons([right])), self)
     })
 
     it("combines mixed reason types", () => {

--- a/packages/effect/test/Cause.test.ts
+++ b/packages/effect/test/Cause.test.ts
@@ -527,16 +527,40 @@ describe("Cause", () => {
     })
 
     it("deduplicates reasons by identity", () => {
-      const reason = Cause.makeFailReason("error")
+      const reason = Cause.makeInterruptReason(1)
       const self = Cause.fromReasons([reason])
 
       assert.strictEqual(Cause.combine(self, Cause.fromReasons([reason])), self)
-      assert.strictEqual(Cause.combine(Cause.fail("error"), Cause.fail("error")).reasons.length, 2)
+      assert.strictEqual(Cause.combine(Cause.interrupt(1), Cause.interrupt(1)).reasons.length, 2)
+    })
+
+    it("deduplicates Fail reasons by error identity", () => {
+      const error = { message: "error" }
+      const self = Cause.fail(error)
+
+      assert.strictEqual(Cause.combine(self, Cause.fail(error)), self)
+      assert.strictEqual(Cause.combine(Cause.fail("error"), Cause.fail("error")).reasons.length, 1)
+      assert.strictEqual(
+        Cause.combine(Cause.fail({ message: "error" }), Cause.fail({ message: "error" })).reasons.length,
+        2
+      )
+    })
+
+    it("deduplicates Die reasons by defect identity", () => {
+      const defect = { message: "defect" }
+      const self = Cause.die(defect)
+
+      assert.strictEqual(Cause.combine(self, Cause.die(defect)), self)
+      assert.strictEqual(
+        Cause.combine(Cause.die({ message: "defect" }), Cause.die({ message: "defect" })).reasons.length,
+        2
+      )
+      assert.strictEqual(Cause.combine(Cause.fail(defect), Cause.die(defect)).reasons.length, 2)
     })
 
     it("delegates to reasons that explicitly implement Equal", () => {
-      const left = Cause.makeFailReason("left") as any
-      const right = Cause.makeFailReason("right") as any
+      const left = Cause.makeInterruptReason(1) as any
+      const right = Cause.makeInterruptReason(2) as any
       left[Equal.symbol] = () => true
       right[Equal.symbol] = () => true
       const self = Cause.fromReasons([left])

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -1,6 +1,7 @@
 import { assertFalse, assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import * as Context from "effect/Context"
 import * as Equal from "effect/Equal"
+import * as Hash from "effect/Hash"
 import * as Option from "effect/Option"
 import * as Redactable from "effect/Redactable"
 import { describe, it } from "vitest"
@@ -163,13 +164,22 @@ describe("Context", () => {
     deepStrictEqual(visited, [[A.key, 1], [B.key, 2]])
   })
 
-  it("supports equality and JSON materialization", () => {
+  it("uses generic structural equality without implementing Equal or Hash", () => {
     const left = Context.make(A, 1).pipe(Context.add(B, 2))
-    const right = Context.makeUnsafe(new Map([[A.key, 1], [B.key, 2]]))
+    const structurallyEqual = Context.make(A, 1).pipe(Context.add(B, 2))
+    const differentlyConstructed = Context.makeUnsafe(new Map([[A.key, 1], [B.key, 2]]))
 
-    assertTrue(Equal.equals(left, right))
+    assertFalse(Equal.isEqual(left))
+    assertFalse(Hash.isHash(left))
+    assertTrue(Equal.equals(left, structurallyEqual))
+    assertFalse(Equal.equals(left, differentlyConstructed))
     assertFalse(Equal.equals(left, Context.make(A, 2)))
-    deepStrictEqual(left.toJSON(), {
+  })
+
+  it("supports JSON materialization", () => {
+    const context = Context.make(A, 1).pipe(Context.add(B, 2))
+
+    deepStrictEqual(context.toJSON(), {
       _id: "Context",
       services: [{ key: A.key, value: 1 }, { key: B.key, value: 2 }]
     })

--- a/packages/effect/test/Exit.test.ts
+++ b/packages/effect/test/Exit.test.ts
@@ -1,7 +1,17 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Exit } from "effect"
+import { Equal, Exit, Hash } from "effect"
 
 describe("Exit", () => {
+  it("uses generic structural equality without implementing Equal or Hash", () => {
+    const left = Exit.succeed({ value: 1 })
+    const right = Exit.succeed({ value: 1 })
+
+    assert.isFalse(Equal.isEqual(left))
+    assert.isFalse(Hash.isHash(left))
+    assert.isTrue(Equal.equals(left, right))
+    assert.strictEqual(Hash.hash(left), Hash.hash(right))
+  })
+
   it("toString", () => {
     assert.strictEqual(Exit.succeed(1).toString(), "Success(1)")
     assert.strictEqual(Exit.fail("error").toString(), `Failure(Cause([Fail("error")]))`)


### PR DESCRIPTION
## Summary

- remove eager Equal / Hash protocol implementations from Cause, Exit, and Context runtime values
- replace `causeCombine`'s `Array.union` and generic `Equal.equals` paths with a small comparator that preserves payload-and-annotation-identity deduplication for Fail / Die reasons
- add focused equality / deduplication coverage and a patch changeset

## Equality semantics

Cause, Exit, and Context no longer advertise or implement the Equal / Hash protocols. Callers that explicitly import `Equal` or `Hash` can still compare or hash these values through the generic structural fallback.

For Context, generic structural equality reflects the stored representation: contexts built through the same operations compare structurally, while logically equivalent contexts built through different internal representations may not.

`Cause.combine` first preserves exact reason-wrapper identity. Distinct matching `Fail` wrappers deduplicate only when both their `.error` payloads and annotation-map references are `===`; matching `Die` wrappers use the same rule for `.defect`. This retains separately annotated reasons even when they share a payload. Remaining reason pairs may deduplicate through an explicitly implemented `[Equal.symbol]`; otherwise they remain distinct.

Types that still opt into Equal / Hash retain their existing protocol behavior.

## Bundle impact

Measured against the PR's rebased parent with:

```sh
pnpm bundle-compare-selected --base f0be8554d packages/tools/bundle/fixtures/basic.ts
```

| Fixture | Before | After | Difference |
|:--|--:|--:|--:|
| `basic.ts` | 6.92 KB | 5.11 KB | -1.81 KB (-26.15%) |

The post-change `pnpm bundle-analyze packages/tools/bundle/fixtures/basic.ts` output retains 42 rendered bytes from `Equal.js` for the `Equal.symbol` binding. `Hash.js`, `internal/equal.js`, `Array.js`, and the deep comparison implementation remain tree-shaken.

## Validation

- `pnpm lint-fix`
- `pnpm check`
- `pnpm test --run packages/effect/test/Cause.test.ts packages/effect/test/Exit.test.ts packages/effect/test/Context.test.ts` (146 tests)
- `pnpm bundle-analyze packages/tools/bundle/fixtures/basic.ts`
- `pnpm bundle-compare-selected --base f0be8554d packages/tools/bundle/fixtures/basic.ts`

Closes EFF-526