### PR TITLE
Fix Deno filesystem error context

### DIFF
--- a/.changeset/deno-write-copy-errors.md
+++ b/.changeset/deno-write-copy-errors.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-deno": patch
+---
+
+Preserve high-level filesystem error context for `writeFile` and normalize Deno `AlreadyExists` errors from `copy`.

--- a/packages/effect/test/FileSystem.test-utils.ts
+++ b/packages/effect/test/FileSystem.test-utils.ts
@@ -1,8 +1,9 @@
 import { assert, expect, it } from "@effect/vitest"
-import { Array } from "effect"
+import { Array, Result } from "effect"
 import * as Effect from "effect/Effect"
 import * as Fs from "effect/FileSystem"
 import type * as Layer from "effect/Layer"
+import * as PlatformError from "effect/PlatformError"
 import * as Stream from "effect/Stream"
 
 export interface TestLayerOptions {
@@ -137,8 +138,11 @@ export const testLayer = <E>(layer: Layer.Layer<Fs.FileSystem, E>, options: Test
       const fs = yield* Fs.FileSystem
       const path = yield* fs.makeTempFile()
 
-      yield* fs.writeFileString(path, "data", { flag: "r" }).pipe(Effect.flip)
+      const error = yield* fs.writeFileString(path, "data", { flag: "r" }).pipe(Effect.flip)
 
+      assert(error.reason instanceof PlatformError.SystemError)
+      assert.strictEqual(error.reason.method, "writeFile")
+      assert.strictEqual(error.reason.pathOrDescriptor, path)
       assert.strictEqual(yield* fs.readFileString(path), "")
     })))
 
@@ -163,6 +167,27 @@ export const testLayer = <E>(layer: Layer.Layer<Fs.FileSystem, E>, options: Test
       yield* fs.writeFileString(path, "second", { flag: "wx" }).pipe(Effect.flip)
 
       assert.strictEqual(yield* fs.readFileString(path), "first")
+    })))
+
+  it("copy with overwrite false preserves an existing destination", () =>
+    runPromise(Effect.gen(function*() {
+      const fs = yield* Fs.FileSystem
+      const root = yield* fs.makeTempDirectory()
+      const source = `${root}/source.txt`
+      const destination = `${root}/destination.txt`
+      yield* fs.writeFileString(source, "source")
+      yield* fs.writeFileString(destination, "destination")
+
+      const result = yield* Effect.result(fs.copy(source, destination, { overwrite: false }))
+
+      if (Result.isFailure(result)) {
+        assert(result.failure.reason instanceof PlatformError.SystemError)
+        assert.strictEqual(result.failure.reason._tag, "AlreadyExists")
+        assert.strictEqual(result.failure.reason.method, "copy")
+        assert.strictEqual(result.failure.reason.pathOrDescriptor, source)
+      }
+      assert.strictEqual(yield* fs.readFileString(source), "source")
+      assert.strictEqual(yield* fs.readFileString(destination), "destination")
     })))
 
   it("should track the cursor position when reading", () =>

--- a/packages/effect/test/FileSystem.test-utils.ts
+++ b/packages/effect/test/FileSystem.test-utils.ts
@@ -3,7 +3,6 @@ import { Array, Result } from "effect"
 import * as Effect from "effect/Effect"
 import * as Fs from "effect/FileSystem"
 import type * as Layer from "effect/Layer"
-import * as PlatformError from "effect/PlatformError"
 import * as Stream from "effect/Stream"
 
 export interface TestLayerOptions {
@@ -140,7 +139,7 @@ export const testLayer = <E>(layer: Layer.Layer<Fs.FileSystem, E>, options: Test
 
       const error = yield* fs.writeFileString(path, "data", { flag: "r" }).pipe(Effect.flip)
 
-      assert(error.reason instanceof PlatformError.SystemError)
+      assert(error.reason._tag !== "BadArgument")
       assert.strictEqual(error.reason.method, "writeFile")
       assert.strictEqual(error.reason.pathOrDescriptor, path)
       assert.strictEqual(yield* fs.readFileString(path), "")
@@ -181,8 +180,7 @@ export const testLayer = <E>(layer: Layer.Layer<Fs.FileSystem, E>, options: Test
       const result = yield* Effect.result(fs.copy(source, destination, { overwrite: false }))
 
       if (Result.isFailure(result)) {
-        assert(result.failure.reason instanceof PlatformError.SystemError)
-        assert.strictEqual(result.failure.reason._tag, "AlreadyExists")
+        assert(result.failure.reason._tag === "AlreadyExists")
         assert.strictEqual(result.failure.reason.method, "copy")
         assert.strictEqual(result.failure.reason.pathOrDescriptor, source)
       }

--- a/packages/platform-deno/src/DenoFileSystem.ts
+++ b/packages/platform-deno/src/DenoFileSystem.ts
@@ -272,17 +272,13 @@ class FileImpl implements FileSystem.File {
     )
   }
 
-  private writeChunk(
-    method: string,
-    buffer: Uint8Array,
-    pathOrDescriptor?: string | number
-  ) {
+  private writeChunk(method: string, buffer: Uint8Array) {
     return Effect.suspend(() => {
       const position = this.position
       return Effect.map(
         tryPromise(
           method,
-          pathOrDescriptor,
+          undefined,
           async () => {
             if (!this.append && this.nativePosition !== position) {
               this.file.seekSync(position, Deno.SeekMode.Start)
@@ -308,33 +304,24 @@ class FileImpl implements FileSystem.File {
     return this.writeChunk("write", buffer)
   }
 
-  private writeAllChunk(
-    buffer: Uint8Array,
-    method: string,
-    pathOrDescriptor?: string | number
-  ): Effect.Effect<void, PlatformError.PlatformError> {
-    return Effect.flatMap(this.writeChunk(method, buffer, pathOrDescriptor), (bytesWritten) => {
+  private writeAllChunk(buffer: Uint8Array): Effect.Effect<void, PlatformError.PlatformError> {
+    return Effect.flatMap(this.writeChunk("writeAll", buffer), (bytesWritten) => {
       if (bytesWritten === BigInt(0)) {
         return Effect.fail(PlatformError.systemError({
           module: "FileSystem",
-          method,
-          pathOrDescriptor,
+          method: "writeAll",
           _tag: "WriteZero",
           description: "write returned 0 bytes written"
         }))
       }
       return bytesWritten < buffer.length
-        ? this.writeAllChunk(buffer.subarray(Number(bytesWritten)), method, pathOrDescriptor)
+        ? this.writeAllChunk(buffer.subarray(Number(bytesWritten)))
         : Effect.void
     })
   }
 
-  writeAll(
-    buffer: Uint8Array,
-    method = "writeAll",
-    pathOrDescriptor?: string | number
-  ) {
-    return buffer.length === 0 ? Effect.void : this.writeAllChunk(buffer, method, pathOrDescriptor)
+  writeAll(buffer: Uint8Array) {
+    return buffer.length === 0 ? Effect.void : this.writeAllChunk(buffer)
   }
 }
 
@@ -465,7 +452,14 @@ const writeFile: FileSystem.FileSystem["writeFile"] = (path, data, options) => {
   }
   return Effect.acquireUseRelease(
     tryPromise("writeFile", path, () => Deno.open(path, openOptions(flag, options?.mode))),
-    (file) => new FileImpl(file, flag.startsWith("a")).writeAll(data, "writeFile", path),
+    (file) =>
+      new FileImpl(file, flag.startsWith("a")).writeAll(data).pipe(
+        Effect.mapError((error) =>
+          error.reason instanceof PlatformError.SystemError
+            ? PlatformError.systemError({ ...error.reason, method: "writeFile", pathOrDescriptor: path })
+            : error
+        )
+      ),
     (file) => close(file, "writeFile", path)
   )
 }

--- a/packages/platform-deno/src/DenoFileSystem.ts
+++ b/packages/platform-deno/src/DenoFileSystem.ts
@@ -455,7 +455,7 @@ const writeFile: FileSystem.FileSystem["writeFile"] = (path, data, options) => {
     (file) =>
       new FileImpl(file, flag.startsWith("a")).writeAll(data).pipe(
         Effect.mapError((error) =>
-          error.reason instanceof PlatformError.SystemError
+          error.reason._tag !== "BadArgument"
             ? PlatformError.systemError({ ...error.reason, method: "writeFile", pathOrDescriptor: path })
             : error
         )

--- a/packages/platform-deno/src/DenoFileSystem.ts
+++ b/packages/platform-deno/src/DenoFileSystem.ts
@@ -272,13 +272,17 @@ class FileImpl implements FileSystem.File {
     )
   }
 
-  private writeChunk(method: string, buffer: Uint8Array) {
+  private writeChunk(
+    method: string,
+    buffer: Uint8Array,
+    pathOrDescriptor?: string | number
+  ) {
     return Effect.suspend(() => {
       const position = this.position
       return Effect.map(
         tryPromise(
           method,
-          undefined,
+          pathOrDescriptor,
           async () => {
             if (!this.append && this.nativePosition !== position) {
               this.file.seekSync(position, Deno.SeekMode.Start)
@@ -304,24 +308,33 @@ class FileImpl implements FileSystem.File {
     return this.writeChunk("write", buffer)
   }
 
-  private writeAllChunk(buffer: Uint8Array): Effect.Effect<void, PlatformError.PlatformError> {
-    return Effect.flatMap(this.writeChunk("writeAll", buffer), (bytesWritten) => {
+  private writeAllChunk(
+    buffer: Uint8Array,
+    method: string,
+    pathOrDescriptor?: string | number
+  ): Effect.Effect<void, PlatformError.PlatformError> {
+    return Effect.flatMap(this.writeChunk(method, buffer, pathOrDescriptor), (bytesWritten) => {
       if (bytesWritten === BigInt(0)) {
         return Effect.fail(PlatformError.systemError({
           module: "FileSystem",
-          method: "writeAll",
+          method,
+          pathOrDescriptor,
           _tag: "WriteZero",
           description: "write returned 0 bytes written"
         }))
       }
       return bytesWritten < buffer.length
-        ? this.writeAllChunk(buffer.subarray(Number(bytesWritten)))
+        ? this.writeAllChunk(buffer.subarray(Number(bytesWritten)), method, pathOrDescriptor)
         : Effect.void
     })
   }
 
-  writeAll(buffer: Uint8Array) {
-    return buffer.length === 0 ? Effect.void : this.writeAllChunk(buffer)
+  writeAll(
+    buffer: Uint8Array,
+    method = "writeAll",
+    pathOrDescriptor?: string | number
+  ) {
+    return buffer.length === 0 ? Effect.void : this.writeAllChunk(buffer, method, pathOrDescriptor)
   }
 }
 
@@ -452,7 +465,7 @@ const writeFile: FileSystem.FileSystem["writeFile"] = (path, data, options) => {
   }
   return Effect.acquireUseRelease(
     tryPromise("writeFile", path, () => Deno.open(path, openOptions(flag, options?.mode))),
-    (file) => new FileImpl(file, flag.startsWith("a")).writeAll(data),
+    (file) => new FileImpl(file, flag.startsWith("a")).writeAll(data, "writeFile", path),
     (file) => close(file, "writeFile", path)
   )
 }

--- a/packages/platform-deno/src/internal/error.ts
+++ b/packages/platform-deno/src/internal/error.ts
@@ -16,6 +16,9 @@ export const handleError = (
   let tag: SystemErrorTag = "Unknown"
 
   switch (denoError?.name) {
+    case "AlreadyExists":
+      tag = "AlreadyExists"
+      break
     case "NotCapable":
       tag = "PermissionDenied"
       break

--- a/packages/platform-deno/test/DenoFileSystem.test.ts
+++ b/packages/platform-deno/test/DenoFileSystem.test.ts
@@ -1,9 +1,45 @@
 import * as DenoFileSystem from "@effect/platform-deno/DenoFileSystem"
-import { describe } from "@effect/vitest"
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as FileSystem from "effect/FileSystem"
+import { SystemError } from "effect/PlatformError"
 import { testLayer } from "../../effect/test/FileSystem.test-utils.ts"
 
-describe("FileSystem", () =>
+describe("FileSystem", () => {
   testLayer(DenoFileSystem.layer, {
     accessOnDirectory: false,
     tempFileScopedRemovesDirectory: false
-  }))
+  })
+
+  it.effect("reports delegated write errors as writeFile errors", () =>
+    Effect.gen(function*() {
+      const fs = yield* FileSystem.FileSystem
+      const root = yield* fs.makeTempDirectoryScoped()
+      const path = `${root}/file.txt`
+      yield* fs.writeFileString(path, "seed")
+
+      const error = yield* Effect.flip(fs.writeFileString(path, "data", { flag: "r" }))
+
+      assert(error.reason instanceof SystemError)
+      assert.strictEqual(error.reason.method, "writeFile")
+      assert.strictEqual(error.reason.pathOrDescriptor, path)
+    }).pipe(Effect.provide(DenoFileSystem.layer)))
+
+  it.effect("maps an existing copy destination to AlreadyExists", () =>
+    Effect.gen(function*() {
+      const fs = yield* FileSystem.FileSystem
+      const root = yield* fs.makeTempDirectoryScoped()
+      const source = `${root}/source.txt`
+      const destination = `${root}/destination.txt`
+      yield* fs.writeFileString(source, "source")
+      yield* fs.writeFileString(destination, "destination")
+
+      const error = yield* Effect.flip(fs.copy(source, destination, { overwrite: false }))
+
+      assert(error.reason instanceof SystemError)
+      assert.strictEqual(error.reason._tag, "AlreadyExists")
+      assert.strictEqual(error.reason.method, "copy")
+      assert.strictEqual(error.reason.pathOrDescriptor, source)
+      assert.strictEqual(yield* fs.readFileString(destination), "destination")
+    }).pipe(Effect.provide(DenoFileSystem.layer)))
+})

--- a/packages/platform-deno/test/DenoFileSystem.test.ts
+++ b/packages/platform-deno/test/DenoFileSystem.test.ts
@@ -1,45 +1,9 @@
 import * as DenoFileSystem from "@effect/platform-deno/DenoFileSystem"
-import { assert, describe, it } from "@effect/vitest"
-import * as Effect from "effect/Effect"
-import * as FileSystem from "effect/FileSystem"
-import { SystemError } from "effect/PlatformError"
+import { describe } from "@effect/vitest"
 import { testLayer } from "../../effect/test/FileSystem.test-utils.ts"
 
-describe("FileSystem", () => {
+describe("FileSystem", () =>
   testLayer(DenoFileSystem.layer, {
     accessOnDirectory: false,
     tempFileScopedRemovesDirectory: false
-  })
-
-  it.effect("reports delegated write errors as writeFile errors", () =>
-    Effect.gen(function*() {
-      const fs = yield* FileSystem.FileSystem
-      const root = yield* fs.makeTempDirectoryScoped()
-      const path = `${root}/file.txt`
-      yield* fs.writeFileString(path, "seed")
-
-      const error = yield* Effect.flip(fs.writeFileString(path, "data", { flag: "r" }))
-
-      assert(error.reason instanceof SystemError)
-      assert.strictEqual(error.reason.method, "writeFile")
-      assert.strictEqual(error.reason.pathOrDescriptor, path)
-    }).pipe(Effect.provide(DenoFileSystem.layer)))
-
-  it.effect("maps an existing copy destination to AlreadyExists", () =>
-    Effect.gen(function*() {
-      const fs = yield* FileSystem.FileSystem
-      const root = yield* fs.makeTempDirectoryScoped()
-      const source = `${root}/source.txt`
-      const destination = `${root}/destination.txt`
-      yield* fs.writeFileString(source, "source")
-      yield* fs.writeFileString(destination, "destination")
-
-      const error = yield* Effect.flip(fs.copy(source, destination, { overwrite: false }))
-
-      assert(error.reason instanceof SystemError)
-      assert.strictEqual(error.reason._tag, "AlreadyExists")
-      assert.strictEqual(error.reason.method, "copy")
-      assert.strictEqual(error.reason.pathOrDescriptor, source)
-      assert.strictEqual(yield* fs.readFileString(destination), "destination")
-    }).pipe(Effect.provide(DenoFileSystem.layer)))
-})
+  }))

--- a/packages/platform-deno/test/internal/error.test.ts
+++ b/packages/platform-deno/test/internal/error.test.ts
@@ -10,6 +10,7 @@ describe("handleError", () => {
     [withCode(new Deno.errors.NotFound(), "ENOENT"), "NotFound"],
     [withCode(new Deno.errors.NotADirectory(), "ENOTDIR"), "BadResource"],
     [new Deno.errors.AlreadyExists(), "AlreadyExists"],
+    [withCode(new Deno.errors.AlreadyExists(), "EEXIST"), "AlreadyExists"],
     [withCode(new Deno.errors.IsADirectory(), "EISDIR"), "BadResource"],
     [withCode(new Deno.errors.PermissionDenied(), "EACCES"), "PermissionDenied"],
     [new Deno.errors.NotCapable(), "PermissionDenied"],

--- a/packages/platform-deno/test/internal/error.test.ts
+++ b/packages/platform-deno/test/internal/error.test.ts
@@ -9,7 +9,7 @@ describe("handleError", () => {
   const cases: ReadonlyArray<readonly [error: Error, tag: SystemErrorTag]> = [
     [withCode(new Deno.errors.NotFound(), "ENOENT"), "NotFound"],
     [withCode(new Deno.errors.NotADirectory(), "ENOTDIR"), "BadResource"],
-    [withCode(new Deno.errors.AlreadyExists(), "EEXIST"), "AlreadyExists"],
+    [new Deno.errors.AlreadyExists(), "AlreadyExists"],
     [withCode(new Deno.errors.IsADirectory(), "EISDIR"), "BadResource"],
     [withCode(new Deno.errors.PermissionDenied(), "EACCES"), "PermissionDenied"],
     [new Deno.errors.NotCapable(), "PermissionDenied"],


### PR DESCRIPTION
## Summary

- preserve `writeFile` method and path context when high-level Deno writes delegate to `FileImpl`
- normalize name-only `Deno.errors.AlreadyExists` failures produced by `@std/fs` copy
- add focused filesystem and internal error-mapping regressions
- add a patch changeset for `@effect/platform-deno`

## Root cause

Non-native `writeFile` flag handling reused `FileImpl.writeAll`, which labeled failures as `writeAll` without the original path. Separately, the copy helper constructs `Deno.errors.AlreadyExists` without an errno-style `code`, while the adapter only recognized `EEXIST`.

## Validation

- `deno task test --run --project @effect/platform-deno` (205 passed, 11 skipped)
- `pnpm --filter @effect/platform-deno check`
- focused `dprint` and `oxlint` checks on the changed files

Closes EFF-527