### PR TITLE
Expose terminal state through Stdio

### DIFF
--- a/.changeset/eff-532-stdio-terminal.md
+++ b/.changeset/eff-532-stdio-terminal.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+"@effect/platform-node-shared": patch
+"@effect/platform-deno": patch
+---
+
+Expose `stdinIsTerminal` and `stdoutIsTerminal` effects through the `Stdio` service.

--- a/packages/effect/src/Stdio.ts
+++ b/packages/effect/src/Stdio.ts
@@ -63,6 +63,18 @@ export const TypeId: TypeId = "~effect/Stdio"
 export interface Stdio {
   readonly [TypeId]: TypeId
   readonly args: Effect.Effect<ReadonlyArray<string>>
+  /**
+   * Whether standard input is attached to a terminal.
+   *
+   * @since 4.0.0
+   */
+  readonly stdinIsTerminal: Effect.Effect<boolean>
+  /**
+   * Whether standard output is attached to a terminal.
+   *
+   * @since 4.0.0
+   */
+  readonly stdoutIsTerminal: Effect.Effect<boolean>
   stdout(options?: {
     readonly endOnDone?: boolean | undefined
   }): Sink.Sink<void, string | Uint8Array, never, PlatformError>
@@ -98,16 +110,23 @@ export const Stdio: Context.Service<Stdio, Stdio> = Context.Service<Stdio>(TypeI
  *
  * **Details**
  *
- * The returned service reuses the supplied fields unchanged and only adds the
- * `Stdio` type identifier; it does not create a `Layer` or provide defaults.
+ * The returned service reuses the supplied fields unchanged and adds the
+ * `Stdio` type identifier. Omitted terminal-detection fields default to
+ * effects that succeed with `false`.
  *
  * @see {@link layerTest} for a test layer with default fields that can be overridden
  *
  * @category constructors
  * @since 4.0.0
  */
-export const make = (options: Omit<Stdio, TypeId>): Stdio => ({
+export const make = (
+  options:
+    & Omit<Stdio, TypeId | "stdinIsTerminal" | "stdoutIsTerminal">
+    & Partial<Pick<Stdio, "stdinIsTerminal" | "stdoutIsTerminal">>
+): Stdio => ({
   [TypeId]: TypeId,
+  stdinIsTerminal: Effect.succeed(false),
+  stdoutIsTerminal: Effect.succeed(false),
   ...options
 })
 
@@ -123,7 +142,7 @@ export const make = (options: Omit<Stdio, TypeId>): Stdio => ({
  *
  * Any provided fields override defaults. By default, arguments are empty,
  * standard output and error are draining sinks, and standard input is an empty
- * stream.
+ * stream, and terminal-detection effects succeed with `false`.
  *
  * @see {@link make} for constructing a `Stdio` service directly without a `Layer` or defaults
  *

--- a/packages/effect/test/Stdio.test.ts
+++ b/packages/effect/test/Stdio.test.ts
@@ -1,0 +1,22 @@
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as Stdio from "effect/Stdio"
+
+describe("Stdio", () => {
+  it.effect("layerTest defaults terminal state to false", () =>
+    Effect.gen(function*() {
+      const stdio = yield* Stdio.Stdio
+      assert.isFalse(yield* stdio.stdinIsTerminal)
+      assert.isFalse(yield* stdio.stdoutIsTerminal)
+    }).pipe(Effect.provide(Stdio.layerTest({}))))
+
+  it.effect("layerTest allows terminal state overrides", () =>
+    Effect.gen(function*() {
+      const stdio = yield* Stdio.Stdio
+      assert.isTrue(yield* stdio.stdinIsTerminal)
+      assert.isTrue(yield* stdio.stdoutIsTerminal)
+    }).pipe(Effect.provide(Stdio.layerTest({
+      stdinIsTerminal: Effect.succeed(true),
+      stdoutIsTerminal: Effect.succeed(true)
+    }))))
+})

--- a/packages/platform-deno/src/DenoStdio.ts
+++ b/packages/platform-deno/src/DenoStdio.ts
@@ -40,6 +40,8 @@ export const layer: Layer.Layer<Stdio.Stdio> = Layer.succeed(
   Stdio.Stdio,
   Stdio.make({
     args: Effect.sync(() => Deno.args),
+    stdinIsTerminal: Effect.sync(() => Deno.stdin.isTerminal()),
+    stdoutIsTerminal: Effect.sync(() => Deno.stdout.isTerminal()),
     stdout: (options) => output(() => Deno.stdout.writable, "stdout", options),
     stderr: (options) => output(() => Deno.stderr.writable, "stderr", options),
     stdin: Stream.fromReadableStream({

--- a/packages/platform-deno/test/DenoStdio.test.ts
+++ b/packages/platform-deno/test/DenoStdio.test.ts
@@ -1,0 +1,50 @@
+import * as DenoStdio from "@effect/platform-deno/DenoStdio"
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as Stdio from "effect/Stdio"
+
+const streams = [Deno.stdin, Deno.stdout] as const
+
+const setIsTerminal = (stdin: boolean, stdout: boolean) =>
+  Effect.sync(() => {
+    Object.defineProperty(streams[0], "isTerminal", { configurable: true, value: () => stdin })
+    Object.defineProperty(streams[1], "isTerminal", { configurable: true, value: () => stdout })
+  })
+
+const withRestoredIsTerminal = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => streams.map((stream) => Object.getOwnPropertyDescriptor(stream, "isTerminal"))),
+    () => effect,
+    (descriptors) =>
+      Effect.sync(() => {
+        streams.forEach((stream, index) => {
+          const descriptor = descriptors[index]
+          if (descriptor === undefined) {
+            Reflect.deleteProperty(stream, "isTerminal")
+          } else {
+            Object.defineProperty(stream, "isTerminal", descriptor)
+          }
+        })
+      })
+  )
+
+describe("DenoStdio", () => {
+  it.effect("reads terminal state when the effects run", () =>
+    withRestoredIsTerminal(
+      Effect.gen(function*() {
+        const stdio = yield* Stdio.Stdio
+
+        yield* setIsTerminal(true, false)
+        assert.deepStrictEqual(
+          yield* Effect.all([stdio.stdinIsTerminal, stdio.stdoutIsTerminal]),
+          [true, false]
+        )
+
+        yield* setIsTerminal(false, true)
+        assert.deepStrictEqual(
+          yield* Effect.all([stdio.stdinIsTerminal, stdio.stdoutIsTerminal]),
+          [false, true]
+        )
+      }).pipe(Effect.provide(DenoStdio.layer))
+    ))
+})

--- a/packages/platform-node-shared/src/NodeStdio.ts
+++ b/packages/platform-node-shared/src/NodeStdio.ts
@@ -28,6 +28,8 @@ export const layer: Layer.Layer<Stdio.Stdio> = Layer.succeed(
   Stdio.Stdio,
   Stdio.make({
     args: Effect.sync(() => process.argv.slice(2)),
+    stdinIsTerminal: Effect.sync(() => process.stdin.isTTY === true),
+    stdoutIsTerminal: Effect.sync(() => process.stdout.isTTY === true),
     stdout: (options) =>
       fromWritable({
         evaluate: () => process.stdout,

--- a/packages/platform-node-shared/test/NodeStdio.test.ts
+++ b/packages/platform-node-shared/test/NodeStdio.test.ts
@@ -1,0 +1,50 @@
+import * as NodeStdio from "@effect/platform-node-shared/NodeStdio"
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as Stdio from "effect/Stdio"
+
+const streams = [process.stdin, process.stdout] as const
+
+const setIsTTY = (stdin: boolean, stdout: boolean) =>
+  Effect.sync(() => {
+    Object.defineProperty(streams[0], "isTTY", { configurable: true, value: stdin })
+    Object.defineProperty(streams[1], "isTTY", { configurable: true, value: stdout })
+  })
+
+const withRestoredIsTTY = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => streams.map((stream) => Object.getOwnPropertyDescriptor(stream, "isTTY"))),
+    () => effect,
+    (descriptors) =>
+      Effect.sync(() => {
+        streams.forEach((stream, index) => {
+          const descriptor = descriptors[index]
+          if (descriptor === undefined) {
+            Reflect.deleteProperty(stream, "isTTY")
+          } else {
+            Object.defineProperty(stream, "isTTY", descriptor)
+          }
+        })
+      })
+  )
+
+describe("NodeStdio", () => {
+  it.effect("reads terminal state when the effects run", () =>
+    withRestoredIsTTY(
+      Effect.gen(function*() {
+        const stdio = yield* Stdio.Stdio
+
+        yield* setIsTTY(true, false)
+        assert.deepStrictEqual(
+          yield* Effect.all([stdio.stdinIsTerminal, stdio.stdoutIsTerminal]),
+          [true, false]
+        )
+
+        yield* setIsTTY(false, true)
+        assert.deepStrictEqual(
+          yield* Effect.all([stdio.stdinIsTerminal, stdio.stdoutIsTerminal]),
+          [false, true]
+        )
+      }).pipe(Effect.provide(NodeStdio.layer))
+    ))
+})


### PR DESCRIPTION
## Summary

- add lazy stdin/stdout terminal-state effects to the public `Stdio` service
- implement Node/Bun and Deno runtime detection without leaking runtime globals across the abstraction
- provide backwards-compatible `Stdio.make` defaults and deterministic `layerTest` overrides
- cover defaults, overrides, and lazy runtime evaluation

## Validation

- `pnpm check`
- `pnpm lint`
- `pnpm vitest run --project effect packages/effect/test/Stdio.test.ts`
- `pnpm vitest run --project @effect/platform-node-shared`
- `deno task test run --project @effect/platform-deno`

Closes EFF-532