### PR TITLE
Refresh v3 to v4 migration guidance

### DIFF
--- a/migration/annotations/effect__FastCheck.yaml
+++ b/migration/annotations/effect__FastCheck.yaml
@@ -38,6 +38,9 @@
 "effect/FastCheck#constant":
   replacement: "FastCheck.constant"
   note: "Import FastCheck from effect/testing. The API remains; v4 infers literal types by default."
+"effect/FastCheck#context":
+  replacement: "FastCheck.context"
+  note: "Import FastCheck from effect/testing. The API is otherwise unchanged."
 "effect/FastCheck#fullUnicode":
   replacement: "FastCheck.string"
   note: "Import FastCheck from effect/testing. Use a one-unit binary Unicode string."

--- a/migration/annotations/effect__ParseResult.yaml
+++ b/migration/annotations/effect__ParseResult.yaml
@@ -1,6 +1,6 @@
 "effect/ParseResult#Forbidden":
   replacement: "SchemaIssue.Forbidden"
-  note: "Forbidden failures use the v4 SchemaIssue class; its constructor takes issue annotations only and no longer stores the schema AST or actual input value."
+  note: "Forbidden failures use the v4 SchemaIssue class; its constructor takes issue annotations plus optional input and parse options, retaining input only when reportInput is true."
 "effect/ParseResult#ArrayFormatter":
   replacement: "SchemaIssue.makeFormatterStandardSchemaV1"
   note: "Format error.issue with the Standard Schema formatter."

--- a/migration/annotations/effect__Schema.yaml
+++ b/migration/annotations/effect__Schema.yaml
@@ -1133,11 +1133,11 @@ effect/Schema#TaggedClass:
   replacement: Schema.TaggedClass
   note: The API remains public in v4, but its type/value declaration was consolidated; use the v4 declaration and update inferred types/signature as needed.
 effect/Schema#TaggedError:
-  replacement: Schema.TaggedErrorClass
-  note: Rename the tagged error class constructor.
+  replacement: Schema.TaggedError
+  note: The constructor name is retained; update to the v4 fields-or-Struct signature and infer the resulting class types.
 effect/Schema#TaggedErrorClass:
-  replacement: Schema.TaggedErrorClass
-  note: The API remains public in v4, but its type/value declaration was consolidated; use the v4 declaration and update inferred types/signature as needed.
+  replacement: Schema.TaggedError
+  note: The exported helper interface was removed; use the class returned by Schema.TaggedError and infer its types.
 effect/Schema#TaggedRequest:
   replacement: effect/unstable/rpc/Rpc.make
   note: The Schema request/serialization protocol was removed; migrate RPC requests to the v4 Rpc APIs.

--- a/migration/annotations/effect__experimental__RateLimiter.yaml
+++ b/migration/annotations/effect__experimental__RateLimiter.yaml
@@ -4,6 +4,9 @@
 "@effect/experimental/RateLimiter#make":
   replacement: effect/unstable/persistence/RateLimiter#make
   note: Import make from the v4 unstable RateLimiter module.
+"@effect/experimental/RateLimiter#makeSleep":
+  replacement: effect/unstable/persistence/RateLimiter#sleep
+  note: The accessor Effect was replaced by sleep; obtain the RateLimiter service and pass it to sleep directly or with its curried overload.
 "@effect/experimental/RateLimiter#RateLimiterError":
   replacement: effect/unstable/persistence/RateLimiter#RateLimiterError
   note: The retained name is now a wrapper error class whose reason is RateLimitExceeded or RateLimitStoreError.

--- a/migration/annotations/effect__platform__Error.yaml
+++ b/migration/annotations/effect__platform__Error.yaml
@@ -14,5 +14,5 @@
   replacement: "none"
   note: "The PlatformError runtime marker is internal in v4; use the PlatformError class/tag."
 "@effect/platform/Error#TypeIdError":
-  replacement: "Data.TaggedError or Schema.ErrorClass"
+  replacement: "Data.TaggedError or Schema.Error"
   note: "The platform-specific error-class factory was removed; define tagged data errors or schema-backed error classes directly."

--- a/migration/annotations/effect__platform__Headers.yaml
+++ b/migration/annotations/effect__platform__Headers.yaml
@@ -13,6 +13,9 @@
 "@effect/platform/Headers#has":
   replacement: "Headers.has"
   note: "Retained with the same dual, case-insensitive signature."
+"@effect/platform/Headers#Headers":
+  replacement: "Headers.Headers"
+  note: "Import Headers from effect/unstable/http; the immutable string-record interface is retained with its v4 TypeId brand."
 "@effect/platform/Headers#HeadersTypeId":
   replacement: "Headers.TypeId"
   note: "The public Headers type-id symbol was renamed from HeadersTypeId to TypeId."

--- a/migration/annotations/effect__platform__HttpApiSchema.yaml
+++ b/migration/annotations/effect__platform__HttpApiSchema.yaml
@@ -29,14 +29,14 @@
   replacement: "effect/unstable/httpapi/HttpApiSchema#Empty"
   note: "The API remains and returns Schema.Void annotated with the supplied status."
 "@effect/platform/HttpApiSchema#EmptyError":
-  replacement: "effect/Schema#ErrorClass"
+  replacement: "effect/Schema#Error"
   note: "Define a normal schema error with httpApiStatus, then derive its no-content wire schema with asNoContent."
 "@effect/platform/HttpApiSchema#EmptyErrorClass":
-  replacement: "effect/Schema#ErrorClass"
-  note: "The class and no-content codec are separate in v4; combine ErrorClass with HttpApiSchema.asNoContent."
+  replacement: "effect/Schema#Error"
+  note: "The class and no-content codec are separate in v4; combine Schema.Error with HttpApiSchema.asNoContent."
 "@effect/platform/HttpApiSchema#EmptyErrorUnify":
   replacement: "none"
-  note: "Removed with EmptyError; Schema.ErrorClass instances already support yieldable-error behavior."
+  note: "Removed with EmptyError; Schema.Error instances already support yieldable-error behavior."
 "@effect/platform/HttpApiSchema#EmptyErrorUnifyIgnore":
   replacement: "none"
   note: "Removed with EmptyError; do not recreate the old Unify marker."

--- a/migration/v3-to-v4.md
+++ b/migration/v3-to-v4.md
@@ -4,7 +4,7 @@
 
 Base: `3d390f232bdbc3f0d3d6a2ae3c775084f494b547` (`3d390f232bdbc3f0d3d6a2ae3c775084f494b547`)
 
-Head: `main` (`a94cbed84e9e49bea4bff925599c0f19c4e3deab`)
+Head: `main` (`b938c8ad2823bd88493187922f7d9090eff037b6`)
 
 This file is generated from the API diff and `migration/annotations/*.yaml`.
 
@@ -5966,6 +5966,8 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `RateLimiter.TypeId` -> `effect/unstable/persistence/RateLimiter#TypeId`: Import TypeId from the v4 unstable RateLimiter module; it is now a string brand.
 
+- `RateLimiter.makeSleep` -> `effect/unstable/persistence/RateLimiter#sleep`: The accessor Effect was replaced by sleep; obtain the RateLimiter service and pass it to sleep directly or with its curried overload.
+
 ### `@effect/experimental/RateLimiter/Redis`
 
 - `Redis.layerStore` -> `effect/unstable/persistence/RateLimiter#layerStoreRedis`: The Redis adapter was merged into RateLimiter and now requires the generic Redis.Redis service.
@@ -6440,7 +6442,7 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `Error.TypeId` -> `none`: The PlatformError runtime marker is internal in v4; use the PlatformError class/tag.
 
-- `Error.TypeIdError` -> `Data.TaggedError or Schema.ErrorClass`: The platform-specific error-class factory was removed; define tagged data errors or schema-backed error classes directly.
+- `Error.TypeIdError` -> `Data.TaggedError or Schema.Error`: The platform-specific error-class factory was removed; define tagged data errors or schema-backed error classes directly.
 
 - `Error.isPlatformError` -> `value instanceof PlatformError.PlatformError`: PlatformError is a class in v4; use an instanceof check or match its PlatformError tag.
 
@@ -6501,6 +6503,8 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 - `FileSystem.make` -> `FileSystem.make`: The constructor remains after moving the module to effect/FileSystem; adapt the implementation to the v4 service shape.
 
 ### `@effect/platform/Headers`
+
+- `Headers.Headers` -> `Headers.Headers`: Import Headers from effect/unstable/http; the immutable string-record interface is retained with its v4 TypeId brand.
 
 - `Headers.HeadersTypeId` -> `Headers.TypeId`: The public Headers type-id symbol was renamed from HeadersTypeId to TypeId.
 
@@ -6756,11 +6760,11 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `HttpApiSchema.Empty` -> `effect/unstable/httpapi/HttpApiSchema#Empty`: The API remains and returns Schema.Void annotated with the supplied status.
 
-- `HttpApiSchema.EmptyError` -> `effect/Schema#ErrorClass`: Define a normal schema error with httpApiStatus, then derive its no-content wire schema with asNoContent.
+- `HttpApiSchema.EmptyError` -> `effect/Schema#Error`: Define a normal schema error with httpApiStatus, then derive its no-content wire schema with asNoContent.
 
-- `HttpApiSchema.EmptyErrorClass` -> `effect/Schema#ErrorClass`: The class and no-content codec are separate in v4; combine ErrorClass with HttpApiSchema.asNoContent.
+- `HttpApiSchema.EmptyErrorClass` -> `effect/Schema#Error`: The class and no-content codec are separate in v4; combine Schema.Error with HttpApiSchema.asNoContent.
 
-- `HttpApiSchema.EmptyErrorUnify` -> `none`: Removed with EmptyError; Schema.ErrorClass instances already support yieldable-error behavior.
+- `HttpApiSchema.EmptyErrorUnify` -> `none`: Removed with EmptyError; Schema.Error instances already support yieldable-error behavior.
 
 - `HttpApiSchema.EmptyErrorUnifyIgnore` -> `none`: Removed with EmptyError; do not recreate the old Unify marker.
 
@@ -10246,6 +10250,8 @@ FastCheck.nat({ max: 0xffff }).map(String.fromCharCode)
 
 - `FastCheck.constant` -> `FastCheck.constant`: Import FastCheck from effect/testing. The API remains; v4 infers literal types by default.
 
+- `FastCheck.context` -> `FastCheck.context`: Import FastCheck from effect/testing. The API is otherwise unchanged.
+
 #### `FastCheck.fullUnicode`
 
 **Replacement:** `FastCheck.string`
@@ -12197,7 +12203,7 @@ SchemaIssue.makeFormatterStandardSchemaV1()(error.issue).issues
 
 - `ParseResult.DecodeUnknown` -> `Schema.decodeUnknownEffect`: Use the function type returned by Schema.decodeUnknownEffect.
 
-- `ParseResult.Forbidden` -> `SchemaIssue.Forbidden`: Forbidden failures use the v4 SchemaIssue class; its constructor takes issue annotations only and no longer stores the schema AST or actual input value.
+- `ParseResult.Forbidden` -> `SchemaIssue.Forbidden`: Forbidden failures use the v4 SchemaIssue class; its constructor takes issue annotations plus optional input and parse options, retaining input only when reportInput is true.
 
 - `ParseResult.Missing` -> `SchemaIssue.MissingKey`: Missing-key failures use the v4 SchemaIssue class.
 
@@ -13891,9 +13897,7 @@ Schema.toFormatter(schema)
 
 - `Schema.TaggedClass` -> `Schema.TaggedClass`: The API remains public in v4, but its type/value declaration was consolidated; use the v4 declaration and update inferred types/signature as needed.
 
-- `Schema.TaggedError` -> `Schema.TaggedErrorClass`: Rename the tagged error class constructor.
-
-- `Schema.TaggedErrorClass` -> `Schema.TaggedErrorClass`: The API remains public in v4, but its type/value declaration was consolidated; use the v4 declaration and update inferred types/signature as needed.
+- `Schema.TaggedErrorClass` -> `Schema.TaggedError`: The exported helper interface was removed; use the class returned by Schema.TaggedError and infer its types.
 
 - `Schema.TaggedRequest` -> `effect/unstable/rpc/Rpc.make`: The Schema request/serialization protocol was removed; migrate RPC requests to the v4 Rpc APIs.
 


### PR DESCRIPTION
## Summary

- document the `RateLimiter.makeSleep` to `RateLimiter.sleep` migration and explicitly guide moved `Headers.Headers` and `FastCheck.context` APIs
- update guidance for the `Schema.Error` / `Schema.TaggedError` constructor renames and opt-in schema issue input reporting
- regenerate the v3-to-v4 reference at main `b938c8ad2823bd88493187922f7d9090eff037b6`

## Why

Recent public API renames changed existing replacements and altered fuzzy API matching, exposing previously implicit module moves. Explicit annotations keep the generated migration reference accurate and stable.

## Validation

- `pnpm api-diff --base-ref 3d390f232bdbc3f0d3d6a2ae3c775084f494b547 --head-ref main --write-doc migration/v3-to-v4.md --check`
- `pnpm lint-fix`
- `git diff --check`

Closes EFF-533