### PR TITLE
Add Cron.format for cron expression conversion

### DIFF
--- a/.changeset/warm-clocks-format.md
+++ b/.changeset/warm-clocks-format.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Cron.format` for converting a `Cron` instance to a cron expression.

--- a/.changeset/warm-clocks-format.md
+++ b/.changeset/warm-clocks-format.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Add `Cron.format` for converting a `Cron` instance to a cron expression.
+Add `Cron.format` for converting a `Cron` instance to a cron expression, with an option to include the seconds field.

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -641,7 +641,7 @@ export const parseUnsafe = (cron: string, tz?: DateTime.TimeZone | string): Cron
  * @since 4.0.0
  */
 export const format = (cron: Cron, options?: {
-  readonly includeSeconds?: boolean
+  readonly includeSeconds?: boolean | undefined
 }): string => {
   const segments = [cron.seconds, cron.minutes, cron.hours, cron.days, cron.months, cron.weekdays]
     .map(formatSegment)

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -613,7 +613,7 @@ export const parse = (cron: string, tz?: DateTime.TimeZone | string): Result.Res
 export const parseUnsafe = (cron: string, tz?: DateTime.TimeZone | string): Cron => Result.getOrThrow(parse(cron, tz))
 
 /**
- * Formats a `Cron` instance as a six-field cron expression.
+ * Formats a `Cron` instance as a cron expression.
  *
  * **Warning**
  *
@@ -626,16 +626,42 @@ export const parseUnsafe = (cron: string, tz?: DateTime.TimeZone | string): Cron
  *
  * const cron = Cron.parseUnsafe("23 0-20/2 * * 0", "UTC")
  *
- * Cron.format(cron) // => "0 23 0,2,4,6,8,10,12,14,16,18,20 * * 0"
+ * Cron.format(cron) // => "23 0-20/2 * * 0"
  * ```
  *
  * @category getters
  * @since 4.0.0
  */
-export const format = (cron: Cron): string =>
-  [cron.seconds, cron.minutes, cron.hours, cron.days, cron.months, cron.weekdays]
-    .map((values) => values.size === 0 ? "*" : Array.from(values).join(","))
-    .join(" ")
+export const format = (cron: Cron): string => {
+  const segments = [cron.seconds, cron.minutes, cron.hours, cron.days, cron.months, cron.weekdays]
+    .map(formatSegment)
+  return (cron.seconds.size === 1 && cron.seconds.has(0) ? segments.slice(1) : segments).join(" ")
+}
+
+const formatSegment = (values: ReadonlySet<number>): string => {
+  if (values.size === 0) {
+    return "*"
+  }
+  const array = Array.from(values)
+  const segments: Array<string> = []
+  let index = 0
+  while (index < array.length) {
+    const start = array[index]!
+    const step = array[index + 1]! - start
+    if (index + 2 < array.length && array[index + 2]! - array[index + 1]! === step) {
+      let end = index + 2
+      while (end + 1 < array.length && array[end + 1]! - array[end]! === step) {
+        end++
+      }
+      segments.push(`${start}-${array[end]}${step === 1 ? "" : `/${step}`}`)
+      index = end + 1
+    } else {
+      segments.push(`${start}`)
+      index++
+    }
+  }
+  return segments.join(",")
+}
 
 /**
  * Returns `true` when a date/time matches a `Cron` schedule.

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -12,7 +12,7 @@ import * as Data from "./Data.ts"
 import type * as DateTime from "./DateTime.ts"
 import * as Equal from "./Equal.ts"
 import * as Equ from "./Equivalence.ts"
-import { format } from "./Formatter.ts"
+import { format as formatValue } from "./Formatter.ts"
 import { constVoid, dual, pipe } from "./Function.ts"
 import * as Hash from "./Hash.ts"
 import { type Inspectable, NodeInspectSymbol } from "./Inspectable.ts"
@@ -152,7 +152,7 @@ const CronProto = {
     return toPojo(this)
   },
   toString(this: Cron) {
-    return `Cron(${format(toPojo(this))})`
+    return `Cron(${formatValue(toPojo(this))})`
   },
   toJSON(this: Cron) {
     const out = toPojo(this)
@@ -611,6 +611,31 @@ export const parse = (cron: string, tz?: DateTime.TimeZone | string): Result.Res
  * @since 4.0.0
  */
 export const parseUnsafe = (cron: string, tz?: DateTime.TimeZone | string): Cron => Result.getOrThrow(parse(cron, tz))
+
+/**
+ * Formats a `Cron` instance as a six-field cron expression.
+ *
+ * **Warning**
+ *
+ * Formatting drops the timezone information stored by the `Cron` instance.
+ *
+ * **Example** (Formatting a cron expression)
+ *
+ * ```ts import.meta.vitest
+ * import { Cron } from "effect"
+ *
+ * const cron = Cron.parseUnsafe("23 0-20/2 * * 0", "UTC")
+ *
+ * Cron.format(cron) // => "0 23 0,2,4,6,8,10,12,14,16,18,20 * * 0"
+ * ```
+ *
+ * @category getters
+ * @since 4.0.0
+ */
+export const format = (cron: Cron): string =>
+  [cron.seconds, cron.minutes, cron.hours, cron.days, cron.months, cron.weekdays]
+    .map((values) => values.size === 0 ? "*" : Array.from(values).join(","))
+    .join(" ")
 
 /**
  * Returns `true` when a date/time matches a `Cron` schedule.

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -615,6 +615,11 @@ export const parseUnsafe = (cron: string, tz?: DateTime.TimeZone | string): Cron
 /**
  * Formats a `Cron` instance as a cron expression.
  *
+ * **Details**
+ *
+ * The default seconds field (`0`) is omitted unless `includeSeconds` is `true`.
+ * Other seconds configurations are always included.
+ *
  * **Gotchas**
  *
  * Formatting drops the timezone information and the `and` restriction between
@@ -629,15 +634,20 @@ export const parseUnsafe = (cron: string, tz?: DateTime.TimeZone | string): Cron
  * const cron = Cron.parseUnsafe("23 0-20/2 * * 0", "UTC")
  *
  * Cron.format(cron) // => "23 0-20/2 * * 0"
+ * Cron.format(cron, { includeSeconds: true }) // => "0 23 0-20/2 * * 0"
  * ```
  *
  * @category getters
  * @since 4.0.0
  */
-export const format = (cron: Cron): string => {
+export const format = (cron: Cron, options?: {
+  readonly includeSeconds?: boolean
+}): string => {
   const segments = [cron.seconds, cron.minutes, cron.hours, cron.days, cron.months, cron.weekdays]
     .map(formatSegment)
-  return (cron.seconds.size === 1 && cron.seconds.has(0) ? segments.slice(1) : segments).join(" ")
+  return (
+    options?.includeSeconds !== true && cron.seconds.size === 1 && cron.seconds.has(0) ? segments.slice(1) : segments
+  ).join(" ")
 }
 
 const formatSegment = (values: ReadonlySet<number>): string => {

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -615,9 +615,11 @@ export const parseUnsafe = (cron: string, tz?: DateTime.TimeZone | string): Cron
 /**
  * Formats a `Cron` instance as a cron expression.
  *
- * **Warning**
+ * **Gotchas**
  *
- * Formatting drops the timezone information stored by the `Cron` instance.
+ * Formatting drops the timezone information and the `and` restriction between
+ * days and weekdays. Parsing the result is therefore not guaranteed to produce
+ * an equivalent schedule.
  *
  * **Example** (Formatting a cron expression)
  *

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -238,6 +238,35 @@ describe("Cron", () => {
     )
   })
 
+  it("format preserves non-uniform values", () => {
+    strictEqual(
+      Cron.format(Cron.make({
+        minutes: [1, 5, 11],
+        hours: [],
+        days: [],
+        months: [],
+        weekdays: []
+      })),
+      "1,5,11 * * * *"
+    )
+  })
+
+  it("format handles default, non-default, and unrestricted seconds", () => {
+    const format = (seconds?: Iterable<number>) =>
+      Cron.format(Cron.make({
+        seconds,
+        minutes: [],
+        hours: [],
+        days: [],
+        months: [],
+        weekdays: []
+      }))
+
+    strictEqual(format(), "* * * * *")
+    strictEqual(format([15, 30]), "15,30 * * * * *")
+    strictEqual(format([]), "* * * * * *")
+  })
+
   it("make supports requiring both days and weekdays", () => {
     const utc = DateTime.zoneMakeNamedUnsafe("UTC")
     const values = {

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -225,6 +225,13 @@ describe("Cron", () => {
     )
   })
 
+  it("format can include the default seconds field", () => {
+    strictEqual(
+      Cron.format(Cron.parseUnsafe("23 0-20/2 * * 0"), { includeSeconds: true }),
+      "0 23 0-20/2 * * 0"
+    )
+  })
+
   it("format compacts multiple runs within a field", () => {
     strictEqual(
       Cron.format(Cron.make({

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -218,10 +218,23 @@ describe("Cron", () => {
     )
   })
 
-  it("format", () => {
+  it("format preserves compact cron syntax", () => {
     strictEqual(
       Cron.format(Cron.parseUnsafe("23 0-20/2 * * 0", "Europe/Berlin")),
-      "0 23 0,2,4,6,8,10,12,14,16,18,20 * * 0"
+      "23 0-20/2 * * 0"
+    )
+  })
+
+  it("format compacts multiple runs within a field", () => {
+    strictEqual(
+      Cron.format(Cron.make({
+        minutes: [0, 1, 2, 10, 20, 30],
+        hours: [],
+        days: [],
+        months: [],
+        weekdays: []
+      })),
+      "0-2,10-30/10 * * * *"
     )
   })
 

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -218,6 +218,13 @@ describe("Cron", () => {
     )
   })
 
+  it("format", () => {
+    strictEqual(
+      Cron.format(Cron.parseUnsafe("23 0-20/2 * * 0", "Europe/Berlin")),
+      "0 23 0,2,4,6,8,10,12,14,16,18,20 * * 0"
+    )
+  })
+
   it("make supports requiring both days and weekdays", () => {
     const utc = DateTime.zoneMakeNamedUnsafe("UTC")
     const values = {


### PR DESCRIPTION
## Summary

- add `Cron.format` with compact range and step syntax
- omit the default zero-seconds field while retaining six fields for non-default seconds
- support `{ includeSeconds: true }` to force a six-field expression without changing default output
- document that formatting drops timezone information and the days/weekdays `and` restriction
- add focused coverage for compact arithmetic runs, unrestricted fields, and seconds handling
- add an `effect` patch changeset

## Testing

- `nix develop -c pnpm vitest run packages/effect/test/Cron.test.ts`
- `nix develop -c pnpm --filter effect check`
- `nix develop -c pnpm lint`
- `nix develop -c pnpm doctest packages/effect/src/Cron.ts --run`
- `nix develop -c pnpm changeset status --since origin/main`

Closes EFF-534
