### PR TITLE
Preserve provider metadata in Prompt.fromResponseParts

### DIFF
--- a/.changeset/pre/eff-537-preserve-response-metadata.md
+++ b/.changeset/pre/eff-537-preserve-response-metadata.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve provider metadata when converting AI response parts into prompts.

--- a/.changeset/pre/eff-537-preserve-response-metadata.md
+++ b/.changeset/pre/eff-537-preserve-response-metadata.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Preserve provider metadata when converting AI response parts into prompts.
+Preserve provider metadata when converting AI response parts into prompts. OpenAI chats using `store: true` now reuse restored item IDs as item references, while conversation-mode chats omit items already present in the conversation instead of inlining them.

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -316,13 +316,23 @@ declare module "effect/unstable/ai/Prompt" {
    *
    * **Details**
    *
-   * Controls Anthropic prompt caching for tool result content.
+   * Carries Anthropic MCP metadata and controls prompt caching for tool result
+   * content.
    *
    * @category models
    * @since 4.0.0
    */
   export interface ToolResultPartOptions extends ProviderOptions {
     readonly anthropic?: {
+      /**
+       * Contains details about the MCP tool that produced the result.
+       */
+      readonly mcp_tool?: {
+        /**
+         * The name of the MCP server
+         */
+        readonly server: string
+      } | null
       /**
        * A breakpoint which marks the end of reusable content eligible for caching.
        */

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -2,7 +2,7 @@ import { type Generated, OpenAiClient, OpenAiLanguageModel, OpenAiSchema, OpenAi
 import { assert, describe, it } from "@effect/vitest"
 import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import { Array, Context, Effect, Layer, Redacted, Ref, Schema, Stream } from "effect"
-import { LanguageModel, Prompt, Tool, Toolkit } from "effect/unstable/ai"
+import { LanguageModel, Prompt, Response as AiResponse, Tool, Toolkit } from "effect/unstable/ai"
 import { HttpClient, type HttpClientError, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
 describe("OpenAiLanguageModel", () => {
@@ -317,6 +317,45 @@ describe("OpenAiLanguageModel", () => {
             const reasoningItem = body.input.find((m: any) => m.type === "reasoning")
             assert.isDefined(reasoningItem)
             strictEqual(reasoningItem.id, "reasoning_123")
+          }).pipe(Effect.provide(makeTestLayer({ body: { model: "o1" } }))))
+
+        it.effect("replays encrypted reasoning from response parts", () =>
+          Effect.gen(function*() {
+            const history = Prompt.fromResponseParts([
+              AiResponse.makePart("reasoning-start", {
+                id: "reasoning_123:0",
+                metadata: { openai: { itemId: "reasoning_123" } }
+              }),
+              AiResponse.makePart("reasoning-delta", {
+                id: "reasoning_123:0",
+                delta: "Let me think..."
+              }),
+              AiResponse.makePart("reasoning-end", {
+                id: "reasoning_123:0",
+                metadata: {
+                  openai: {
+                    itemId: "reasoning_123",
+                    encryptedContent: "encrypted-reasoning"
+                  }
+                }
+              })
+            ])
+
+            yield* LanguageModel.generateText({
+              prompt: Prompt.concat(history, Prompt.make("Continue"))
+            }).pipe(Effect.provide(OpenAiLanguageModel.model("o1")))
+
+            const requests = yield* MockHttpClient.requests
+            const body = yield* getRequestBody(requests[0])
+            const reasoningItem = body.input.find((item: any) => item.type === "reasoning")
+
+            assert.isDefined(reasoningItem)
+            deepStrictEqual(reasoningItem, {
+              type: "reasoning",
+              id: "reasoning_123",
+              summary: [{ type: "summary_text", text: "Let me think..." }],
+              encrypted_content: "encrypted-reasoning"
+            })
           }).pipe(Effect.provide(makeTestLayer({ body: { model: "o1" } }))))
 
         it.effect("converts tool call parts to function_call", () =>

--- a/packages/effect/src/unstable/ai/Prompt.ts
+++ b/packages/effect/src/unstable/ai/Prompt.ts
@@ -2004,6 +2004,17 @@ export const make = (input: RawInput): Prompt => {
  */
 export const fromMessages = (messages: ReadonlyArray<Message>): Prompt => makePrompt(messages)
 
+const mergeOptions = (left: ProviderOptions, right: ProviderOptions): ProviderOptions => {
+  const result: Record<string, ProviderOptions[string]> = { ...left }
+  for (const [provider, metadata] of Object.entries(right)) {
+    const previous = result[provider]
+    result[provider] = Predicate.isObject(previous) && Predicate.isObject(metadata)
+      ? Object.assign({}, previous, metadata)
+      : metadata
+  }
+  return result
+}
+
 /**
  * Creates a `Prompt` from response parts by folding completed text and
  * reasoning streams into assistant parts, preserving provider metadata as
@@ -2055,19 +2066,6 @@ export const fromResponseParts = (parts: ReadonlyArray<Response.AnyPart>): Promp
 
   const activeTextDeltas = new Map<string, { text: string; options: ProviderOptions }>()
   const activeReasoningDeltas = new Map<string, { text: string; options: ProviderOptions }>()
-
-  const mergeOptions = (left: ProviderOptions, right: ProviderOptions): ProviderOptions =>
-    Object.fromEntries(
-      Object.entries({ ...left, ...right }).map(([provider, metadata]) => {
-        const previous = left[provider]
-        return [
-          provider,
-          Predicate.isObject(previous) && Predicate.isObject(metadata)
-            ? Object.assign({}, previous, metadata)
-            : metadata
-        ]
-      })
-    )
 
   for (const part of parts) {
     switch (part.type) {
@@ -2149,7 +2147,7 @@ export const fromResponseParts = (parts: ReadonlyArray<Response.AnyPart>): Promp
             isFailure: part.isFailure,
             result: part.encodedResult,
             providerExecuted: part.providerExecuted ?? false,
-            options: part.metadata as ToolResultPartOptions
+            options: part.metadata
           }))
         }
         break

--- a/packages/effect/src/unstable/ai/Prompt.ts
+++ b/packages/effect/src/unstable/ai/Prompt.ts
@@ -2006,9 +2006,10 @@ export const fromMessages = (messages: ReadonlyArray<Message>): Prompt => makePr
 
 /**
  * Creates a `Prompt` from response parts by folding completed text and
- * reasoning streams into assistant parts, placing tool calls and approval
- * requests in an assistant message, and placing non-preliminary tool results
- * in a tool message using their encoded results.
+ * reasoning streams into assistant parts, preserving provider metadata as
+ * prompt options, placing tool calls and approval requests in an assistant
+ * message, and placing non-preliminary tool results in a tool message using
+ * their encoded results.
  *
  * **Example** (Creating prompts from response parts)
  *
@@ -2052,55 +2053,76 @@ export const fromResponseParts = (parts: ReadonlyArray<Response.AnyPart>): Promp
   const assistantParts: Array<AssistantMessagePart> = []
   const toolParts: Array<ToolMessagePart> = []
 
-  const activeTextDeltas = new Map<string, { text: string }>()
-  const activeReasoningDeltas = new Map<string, { text: string }>()
+  const activeTextDeltas = new Map<string, { text: string; options: ProviderOptions }>()
+  const activeReasoningDeltas = new Map<string, { text: string; options: ProviderOptions }>()
+
+  const mergeOptions = (left: ProviderOptions, right: ProviderOptions): ProviderOptions =>
+    Object.fromEntries(
+      Object.entries({ ...left, ...right }).map(([provider, metadata]) => {
+        const previous = left[provider]
+        return [
+          provider,
+          Predicate.isObject(previous) && Predicate.isObject(metadata)
+            ? Object.assign({}, previous, metadata)
+            : metadata
+        ]
+      })
+    )
 
   for (const part of parts) {
     switch (part.type) {
       // Text Parts
       case "text": {
-        assistantParts.push(makePart("text", { text: part.text }))
+        assistantParts.push(makePart("text", { text: part.text, options: part.metadata }))
         break
       }
 
       // Text Parts (streaming)
       case "text-start": {
-        activeTextDeltas.set(part.id, { text: "" })
+        activeTextDeltas.set(part.id, { text: "", options: part.metadata })
         break
       }
       case "text-delta": {
         if (activeTextDeltas.has(part.id)) {
-          activeTextDeltas.get(part.id)!.text += part.delta
+          const active = activeTextDeltas.get(part.id)!
+          active.text += part.delta
+          active.options = mergeOptions(active.options, part.metadata)
         }
         break
       }
       case "text-end": {
         if (activeTextDeltas.has(part.id)) {
-          assistantParts.push(makePart("text", activeTextDeltas.get(part.id)!))
+          const active = activeTextDeltas.get(part.id)!
+          active.options = mergeOptions(active.options, part.metadata)
+          assistantParts.push(makePart("text", active))
         }
         break
       }
 
       // Reasoning Parts
       case "reasoning": {
-        assistantParts.push(makePart("reasoning", { text: part.text }))
+        assistantParts.push(makePart("reasoning", { text: part.text, options: part.metadata }))
         break
       }
 
       // Reasoning Parts (streaming)
       case "reasoning-start": {
-        activeReasoningDeltas.set(part.id, { text: "" })
+        activeReasoningDeltas.set(part.id, { text: "", options: part.metadata })
         break
       }
       case "reasoning-delta": {
         if (activeReasoningDeltas.has(part.id)) {
-          activeReasoningDeltas.get(part.id)!.text += part.delta
+          const active = activeReasoningDeltas.get(part.id)!
+          active.text += part.delta
+          active.options = mergeOptions(active.options, part.metadata)
         }
         break
       }
       case "reasoning-end": {
         if (activeReasoningDeltas.has(part.id)) {
-          assistantParts.push(makePart("reasoning", activeReasoningDeltas.get(part.id)!))
+          const active = activeReasoningDeltas.get(part.id)!
+          active.options = mergeOptions(active.options, part.metadata)
+          assistantParts.push(makePart("reasoning", active))
         }
         break
       }
@@ -2111,7 +2133,8 @@ export const fromResponseParts = (parts: ReadonlyArray<Response.AnyPart>): Promp
           id: part.id,
           name: part.name,
           params: part.params,
-          providerExecuted: part.providerExecuted ?? false
+          providerExecuted: part.providerExecuted ?? false,
+          options: part.metadata
         }))
         break
       }
@@ -2125,7 +2148,8 @@ export const fromResponseParts = (parts: ReadonlyArray<Response.AnyPart>): Promp
             name: part.name,
             isFailure: part.isFailure,
             result: part.encodedResult,
-            providerExecuted: part.providerExecuted ?? false
+            providerExecuted: part.providerExecuted ?? false,
+            options: part.metadata as ToolResultPartOptions
           }))
         }
         break

--- a/packages/effect/test/unstable/ai/Prompt.test.ts
+++ b/packages/effect/test/unstable/ai/Prompt.test.ts
@@ -81,6 +81,145 @@ describe("Prompt", () => {
       assert.deepStrictEqual(prompt, expected)
     })
 
+    it("preserves metadata on non-streaming response parts", () => {
+      const parts = [
+        Response.makePart("text", {
+          text: "Hello",
+          metadata: { test: { value: "text" } }
+        }),
+        Response.makePart("reasoning", {
+          text: "Thinking",
+          metadata: { openai: { encryptedContent: "encrypted-reasoning" } }
+        }),
+        Response.makePart("tool-call", {
+          id: "call-1",
+          name: "get_weather",
+          params: { city: "London" },
+          providerExecuted: false,
+          metadata: { google: { thoughtSignature: "signed-call" } }
+        }),
+        Response.makePart("tool-result", {
+          id: "call-1",
+          name: "get_weather",
+          isFailure: false,
+          result: { temp: 20 },
+          encodedResult: { temp: 20 },
+          preliminary: false,
+          providerExecuted: false,
+          metadata: { test: { value: "tool-result" } }
+        })
+      ]
+
+      const prompt = Prompt.fromResponseParts(parts)
+
+      assert.deepStrictEqual(
+        prompt,
+        Prompt.make([
+          {
+            role: "assistant",
+            content: [
+              { type: "text", text: "Hello", options: { test: { value: "text" } } },
+              {
+                type: "reasoning",
+                text: "Thinking",
+                options: { openai: { encryptedContent: "encrypted-reasoning" } }
+              },
+              {
+                type: "tool-call",
+                id: "call-1",
+                name: "get_weather",
+                params: { city: "London" },
+                providerExecuted: false,
+                options: { google: { thoughtSignature: "signed-call" } }
+              }
+            ]
+          },
+          {
+            role: "tool",
+            content: [{
+              type: "tool-result",
+              id: "call-1",
+              name: "get_weather",
+              isFailure: false,
+              result: { temp: 20 },
+              providerExecuted: false,
+              options: { test: { value: "tool-result" } }
+            }]
+          }
+        ])
+      )
+    })
+
+    it("accumulates metadata across streamed text and reasoning parts", () => {
+      const parts = [
+        Response.makePart("text-start", {
+          id: "text-1",
+          metadata: { testStart: { value: "text-start" } }
+        }),
+        Response.makePart("text-delta", {
+          id: "text-1",
+          delta: "Hello",
+          metadata: { testDelta: { value: "text-delta" } }
+        }),
+        Response.makePart("text-end", {
+          id: "text-1",
+          metadata: { testEnd: { value: "text-end" } }
+        }),
+        Response.makePart("reasoning-start", {
+          id: "reasoning-1",
+          metadata: { openai: { itemId: "reasoning-item" } }
+        }),
+        Response.makePart("reasoning-delta", {
+          id: "reasoning-1",
+          delta: "Thinking"
+        }),
+        Response.makePart("reasoning-delta", {
+          id: "reasoning-1",
+          delta: "",
+          metadata: { testDelta: { value: "reasoning-delta" } }
+        }),
+        Response.makePart("reasoning-end", {
+          id: "reasoning-1",
+          metadata: {
+            openai: { encryptedContent: "encrypted-reasoning" },
+            testEnd: { value: "reasoning-end" }
+          }
+        })
+      ]
+
+      const prompt = Prompt.fromResponseParts(parts)
+
+      assert.deepStrictEqual(
+        prompt,
+        Prompt.make([{
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "Hello",
+              options: {
+                testStart: { value: "text-start" },
+                testDelta: { value: "text-delta" },
+                testEnd: { value: "text-end" }
+              }
+            },
+            {
+              type: "reasoning",
+              text: "Thinking",
+              options: {
+                openai: {
+                  itemId: "reasoning-item",
+                  encryptedContent: "encrypted-reasoning"
+                },
+                testDelta: { value: "reasoning-delta" },
+                testEnd: { value: "reasoning-end" }
+              }
+            }
+          ]
+        }])
+      )
+    })
+
     it("places tool calls in assistant messages and tool results in tool messages", () => {
       const parts = [
         Response.makePart("tool-call", {


### PR DESCRIPTION
## Summary

- preserve response-part metadata as prompt provider options for text, reasoning, tool-call, and tool-result parts
- accumulate provider metadata across streamed text and reasoning start/delta/end parts
- retain OpenAI reasoning `itemId` and `encryptedContent` together for multi-turn continuity
- verify the full response-parts-to-OpenAI-request round trip emits `encrypted_content`
- add regression coverage and a patch changeset for `effect`

## Root cause

`Prompt.fromResponseParts` rebuilt prompt parts without copying response `metadata` into prompt `options`. Follow-up requests therefore silently omitted provider continuity data, including OpenAI encrypted reasoning content.

This is the Effect v4 equivalent of draft PR #6442, which targets the legacy `v3` branch.

## Validation

- `pnpm test run packages/effect/test/unstable/ai/Prompt.test.ts packages/ai/openai/test/OpenAiLanguageModel.test.ts packages/ai/anthropic/test/AnthropicLanguageModel.test.ts` (98 tests)
- `pnpm lint`
- `pnpm check`
- `pnpm build`

Closes EFF-537
Closes #7099