### PR TITLE
Add explicit ConfigProvider environment record constructor

### DIFF
--- a/.changeset/explicit-env-record.md
+++ b/.changeset/explicit-env-record.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `ConfigProvider.fromEnvRecord` for building a provider from an explicit environment record.

--- a/packages/effect/src/ConfigProvider.ts
+++ b/packages/effect/src/ConfigProvider.ts
@@ -846,6 +846,12 @@ function emptyStringAsMissing(value: string | undefined, preserveEmptyStrings: b
  * `undefined` values are ignored. Path lookup and child discovery otherwise
  * use the same environment-variable semantics as {@link fromEnv}.
  *
+ * Environment variable names are captured at construction time to establish
+ * record keys and array lengths. The supplied record remains live for value
+ * lookups, so updates to known paths are observed by later loads. Keys added
+ * after construction can be loaded directly, but do not appear in captured
+ * parent record keys or array lengths.
+ *
  * Literal empty strings are treated as missing values by default. Pass
  * `{ preserveEmptyStrings: true }` to keep empty strings as explicit values.
  *

--- a/packages/effect/src/ConfigProvider.ts
+++ b/packages/effect/src/ConfigProvider.ts
@@ -833,13 +833,43 @@ function emptyStringAsMissing(value: string | undefined, preserveEmptyStrings: b
 }
 
 /**
+ * Creates a `ConfigProvider` backed by an explicit environment record.
+ *
+ * **When to use**
+ *
+ * Use when a restricted runtime cannot evaluate the automatic environment
+ * detection performed by {@link fromEnv}, or whenever the environment record
+ * must be supplied explicitly.
+ *
+ * **Details**
+ *
+ * `undefined` values are ignored. Path lookup and child discovery otherwise
+ * use the same environment-variable semantics as {@link fromEnv}.
+ *
+ * Literal empty strings are treated as missing values by default. Pass
+ * `{ preserveEmptyStrings: true }` to keep empty strings as explicit values.
+ *
+ * @see {@link fromEnv} – automatically reads the runtime environment
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export function fromEnvRecord(
+  env: Record<string, string | undefined>,
+  options?: { readonly preserveEmptyStrings?: boolean | undefined }
+): ConfigProvider {
+  const preserveEmptyStrings = options?.preserveEmptyStrings === true
+  const trie = buildEnvTrie(env)
+  return make((path) => Effect.succeed(nodeAtEnv(trie, env, path, preserveEmptyStrings)))
+}
+
+/**
  * Creates a `ConfigProvider` backed by environment variables.
  *
  * **When to use**
  *
  * Use to read configuration from `process.env`, which is the default when no
- * provider is explicitly set, or pass a custom env record for testing or
- * non-Node runtimes.
+ * provider is explicitly set, or pass a custom env record for testing.
  *
  * **Details**
  *
@@ -880,6 +910,7 @@ function emptyStringAsMissing(value: string | undefined, preserveEmptyStrings: b
  * ```
  *
  * @see {@link fromUnknown} – for JSON objects
+ * @see {@link fromEnvRecord} – for explicit records in restricted runtimes
  * @see {@link constantCase} – bridge camelCase keys to SCREAMING_SNAKE_CASE
  *
  * @category constructors
@@ -895,10 +926,7 @@ export function fromEnv(options?: {
     }).process?.env,
     ...(import.meta as any)?.env
   }
-  const preserveEmptyStrings = options?.preserveEmptyStrings === true
-  const trie = buildEnvTrie(env)
-
-  return make((path) => Effect.succeed(nodeAtEnv(trie, env, path, preserveEmptyStrings)))
+  return fromEnvRecord(env, { preserveEmptyStrings: options?.preserveEmptyStrings })
 }
 
 type EnvTrieNode = {
@@ -984,7 +1012,7 @@ function trieNodeAt(root: EnvTrieNode, path: Path): EnvTrieNode | undefined {
  *
  * Parsing is based on the `dotenv` / `dotenv-expand` algorithm.
  *
- * Internally delegates to {@link fromEnv} with the parsed key-value pairs.
+ * Internally delegates to {@link fromEnvRecord} with the parsed key-value pairs.
  *
  * **Example** (Parsing .env contents)
  *
@@ -1003,6 +1031,7 @@ function trieNodeAt(root: EnvTrieNode, path: Path): EnvTrieNode | undefined {
  * ```
  *
  * @see {@link fromDotEnv} – loads a `.env` file from disk
+ * @see {@link fromEnvRecord} – for explicit environment records
  * @see {@link fromEnv} – for raw environment variable access
  *
  * @category constructors
@@ -1016,7 +1045,7 @@ export function fromDotEnvContents(lines: string, options?: {
   if (options?.expandVariables) {
     env = dotEnvExpand(env)
   }
-  return fromEnv({ env, preserveEmptyStrings: options?.preserveEmptyStrings })
+  return fromEnvRecord(env, { preserveEmptyStrings: options?.preserveEmptyStrings })
 }
 
 const DOT_ENV_LINE =

--- a/packages/effect/test/ConfigProvider.test.ts
+++ b/packages/effect/test/ConfigProvider.test.ts
@@ -301,6 +301,10 @@ describe("ConfigProvider", () => {
       await assertSuccess(provider, [], ConfigProvider.makeRecord(new Set(["DEFINED"])))
     })
 
+    it("treats empty strings as missing by default", async () => {
+      await assertMissing(ConfigProvider.fromEnvRecord({ EMPTY: "" }), ["EMPTY"])
+    })
+
     it("preserves empty strings when requested", async () => {
       const provider = ConfigProvider.fromEnvRecord(
         { EMPTY: "" },

--- a/packages/effect/test/ConfigProvider.test.ts
+++ b/packages/effect/test/ConfigProvider.test.ts
@@ -288,6 +288,29 @@ describe("ConfigProvider", () => {
     })
   })
 
+  describe("fromEnvRecord", () => {
+    it("reads defined values and skips undefined values", async () => {
+      const env: Record<string, string | undefined> = {
+        DEFINED: "value",
+        UNDEFINED: undefined
+      }
+      const provider = ConfigProvider.fromEnvRecord(env)
+
+      await assertSuccess(provider, ["DEFINED"], ConfigProvider.makeValue("value"))
+      await assertMissing(provider, ["UNDEFINED"])
+      await assertSuccess(provider, [], ConfigProvider.makeRecord(new Set(["DEFINED"])))
+    })
+
+    it("preserves empty strings when requested", async () => {
+      const provider = ConfigProvider.fromEnvRecord(
+        { EMPTY: "" },
+        { preserveEmptyStrings: true }
+      )
+
+      await assertSuccess(provider, ["EMPTY"], ConfigProvider.makeValue(""))
+    })
+  })
+
   describe("fromEnv", () => {
     it("env without an underscore", async () => {
       const env = { A: "value1" }

--- a/packages/effect/typetest/ConfigProvider.tst.ts
+++ b/packages/effect/typetest/ConfigProvider.tst.ts
@@ -1,6 +1,8 @@
 import { ConfigProvider, Effect } from "effect"
 import { describe, expect, it } from "tstyche"
 
+declare const process: { readonly env: Record<string, string | undefined> }
+
 describe("ConfigProvider", () => {
   it("exposes lookup absence and input transformation", () => {
     const provider = ConfigProvider.make((_path) => Effect.succeed(ConfigProvider.makeValue("value")))
@@ -8,6 +10,11 @@ describe("ConfigProvider", () => {
     expect(provider.load([]))
       .type.toBe<Effect.Effect<ConfigProvider.Node | undefined, ConfigProvider.SourceError>>()
     expect(provider.mapInput((path) => path))
+      .type.toBe<ConfigProvider.ConfigProvider>()
+  })
+
+  it("accepts process.env as an explicit environment record", () => {
+    expect(ConfigProvider.fromEnvRecord(process.env))
       .type.toBe<ConfigProvider.ConfigProvider>()
   })
 })


### PR DESCRIPTION
Adds `ConfigProvider.fromEnvRecord` as a first-class explicit-record API alongside the unchanged `fromEnv` automatic environment path.

- accepts `Record<string, string | undefined>` and skips undefined entries
- preserves existing empty-string behavior and mixed liveness semantics
- documents that key/collection topology is captured at construction while values remain live
- delegates `fromEnv` and `fromDotEnvContents` through the new constructor
- keeps the default provider on `fromEnv()`
- adds runtime and type-level coverage plus an `effect` patch changeset

Scope: the existing `import.meta` auto-detection token remains in this module, so this change does not address analyzers that reject the token at parse time.

Validation:
- `pnpm vitest packages/effect/test/ConfigProvider.test.ts --run`
- `pnpm exec tstyche --target '>=5.9' packages/effect/typetest/ConfigProvider.tst.ts`
- `pnpm --filter effect check`
- focused oxlint and dprint checks
- `pnpm jsdocs` (no `ConfigProvider` findings)
- `pnpm exec changeset status --since origin/main --verbose`

Closes EFF-541