### PR TITLE
Keep NodeTerminal readline alive briefly between prompts

### DIFF
--- a/.changeset/node-terminal-idle-ttl.md
+++ b/.changeset/node-terminal-idle-ttl.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+Keep NodeTerminal's readline interface alive briefly between adjacent prompts to avoid a Windows TTY raw-mode hang.

--- a/packages/effect/test/RcRef.test.ts
+++ b/packages/effect/test/RcRef.test.ts
@@ -6,6 +6,7 @@ import * as Fiber from "effect/Fiber"
 import * as RcRef from "effect/RcRef"
 import * as Ref from "effect/Ref"
 import * as Scope from "effect/Scope"
+import { TestClock } from "effect/testing"
 
 describe("RcRef", () => {
   it.effect("deallocation", () =>
@@ -147,5 +148,49 @@ describe("RcRef", () => {
           released: 1
         }
       )
+    }))
+
+  it.effect("idleTimeToLive reuses and releases resources", () =>
+    Effect.gen(function*() {
+      let acquired = 0
+      let released = 0
+      const refScope = yield* Scope.make()
+      const ref = yield* RcRef.make({
+        acquire: Effect.acquireRelease(
+          Effect.sync(() => {
+            acquired++
+            return "foo"
+          }),
+          () =>
+            Effect.sync(() => {
+              released++
+            })
+        ),
+        idleTimeToLive: "10 millis"
+      }).pipe(Scope.provide(refScope))
+
+      assert.strictEqual(acquired, 0)
+      assert.strictEqual(yield* Effect.scoped(RcRef.get(ref)), "foo")
+      assert.strictEqual(acquired, 1)
+      assert.strictEqual(released, 0)
+
+      yield* TestClock.adjust("5 millis")
+      assert.strictEqual(yield* Effect.scoped(RcRef.get(ref)), "foo")
+      assert.strictEqual(acquired, 1)
+      assert.strictEqual(released, 0)
+
+      yield* TestClock.adjust("9 millis")
+      assert.strictEqual(released, 0)
+      yield* TestClock.adjust("1 millis")
+      assert.strictEqual(released, 1)
+
+      assert.strictEqual(yield* Effect.scoped(RcRef.get(ref)), "foo")
+      assert.strictEqual(acquired, 2)
+      assert.strictEqual(released, 1)
+
+      yield* TestClock.adjust("10 millis")
+      assert.strictEqual(released, 2)
+
+      yield* Scope.close(refScope, Exit.void)
     }))
 })

--- a/packages/effect/test/RcRef.test.ts
+++ b/packages/effect/test/RcRef.test.ts
@@ -154,7 +154,6 @@ describe("RcRef", () => {
     Effect.gen(function*() {
       let acquired = 0
       let released = 0
-      const refScope = yield* Scope.make()
       const ref = yield* RcRef.make({
         acquire: Effect.acquireRelease(
           Effect.sync(() => {
@@ -167,7 +166,7 @@ describe("RcRef", () => {
             })
         ),
         idleTimeToLive: "10 millis"
-      }).pipe(Scope.provide(refScope))
+      })
 
       assert.strictEqual(acquired, 0)
       assert.strictEqual(yield* Effect.scoped(RcRef.get(ref)), "foo")
@@ -190,7 +189,5 @@ describe("RcRef", () => {
 
       yield* TestClock.adjust("10 millis")
       assert.strictEqual(released, 2)
-
-      yield* Scope.close(refScope, Exit.void)
     }))
 })

--- a/packages/platform-deno/test/DenoTerminal.test.ts
+++ b/packages/platform-deno/test/DenoTerminal.test.ts
@@ -89,8 +89,12 @@ describe("DenoTerminal", () => {
     assertResult("read-line-after-end", "", "\"QuitError\"")
   })
 
-  it.effect("disposes readline after readLine completes", () =>
-    assertOpenResult("read-line-disposed", "line\n", "{\"line\":\"line\",\"dataListeners\":0}"))
+  it.effect("disposes readline after its idle TTL", () =>
+    assertOpenResult(
+      "read-line-disposed",
+      "line\n",
+      "{\"line\":\"line\",\"duringTtl\":1,\"dataListeners\":0}"
+    ))
 
   it.effect("interoperates with DenoStdio on stdin", () => assertInteropResult)
 })

--- a/packages/platform-deno/test/fixtures/deno-terminal.ts
+++ b/packages/platform-deno/test/fixtures/deno-terminal.ts
@@ -78,7 +78,9 @@ const readLineAfterEnd = Effect.gen(function*() {
 const readLineDisposed = Effect.gen(function*() {
   const terminal = yield* Terminal.Terminal
   const line = yield* terminal.readLine
-  return { line, dataListeners: process.stdin.listenerCount("data") }
+  const duringTtl = process.stdin.listenerCount("data")
+  yield* Effect.sleep("20 millis")
+  return { line, duringTtl, dataListeners: process.stdin.listenerCount("data") }
 })
 
 const interop = Effect.gen(function*() {

--- a/packages/platform-node-shared/src/NodeTerminal.ts
+++ b/packages/platform-node-shared/src/NodeTerminal.ts
@@ -82,7 +82,8 @@ export const make: (
               Queue.endUnsafe(lines)
             }
           })
-      )
+      ),
+      idleTimeToLive: "10 millis"
     })
 
     const columns = Effect.sync(() => stdout.columns ?? 0)

--- a/packages/platform-node-shared/test/NodeTerminal.test.ts
+++ b/packages/platform-node-shared/test/NodeTerminal.test.ts
@@ -67,5 +67,9 @@ describe("NodeTerminal", () => {
   })
 
   it.effect("disposes readline after its idle TTL", () =>
-    assertOpenResult("read-line-disposed", "line\n", "{\"line\":\"line\",\"dataListeners\":0}"))
+    assertOpenResult(
+      "read-line-disposed",
+      "line\n",
+      "{\"line\":\"line\",\"duringTtl\":1,\"dataListeners\":0}"
+    ))
 })

--- a/packages/platform-node-shared/test/NodeTerminal.test.ts
+++ b/packages/platform-node-shared/test/NodeTerminal.test.ts
@@ -66,6 +66,6 @@ describe("NodeTerminal", () => {
     assertResult("read-line-after-end", "", "\"QuitError\"")
   })
 
-  it.effect("disposes readline after readLine completes", () =>
+  it.effect("disposes readline after its idle TTL", () =>
     assertOpenResult("read-line-disposed", "line\n", "{\"line\":\"line\",\"dataListeners\":0}"))
 })

--- a/packages/platform-node-shared/test/fixtures/node-terminal.ts
+++ b/packages/platform-node-shared/test/fixtures/node-terminal.ts
@@ -74,8 +74,9 @@ const readLineAfterEnd = Effect.gen(function*() {
 const readLineDisposed = Effect.gen(function*() {
   const terminal = yield* Terminal.Terminal
   const line = yield* terminal.readLine
+  const duringTtl = process.stdin.listenerCount("data")
   yield* Effect.sleep("20 millis")
-  return { line, dataListeners: process.stdin.listenerCount("data") }
+  return { line, duringTtl, dataListeners: process.stdin.listenerCount("data") }
 })
 
 const mode = process.argv[2]

--- a/packages/platform-node-shared/test/fixtures/node-terminal.ts
+++ b/packages/platform-node-shared/test/fixtures/node-terminal.ts
@@ -74,6 +74,7 @@ const readLineAfterEnd = Effect.gen(function*() {
 const readLineDisposed = Effect.gen(function*() {
   const terminal = yield* Terminal.Terminal
   const line = yield* terminal.readLine
+  yield* Effect.sleep("20 millis")
   return { line, dataListeners: process.stdin.listenerCount("data") }
 })
 


### PR DESCRIPTION
## Summary

- keep `NodeTerminal`'s readline `RcRef` alive for 10ms between uses
- verify `RcRef` reacquisition inside the idle TTL reuses the resource
- verify the resource is released after the TTL and readline is eventually disposed

## Why

On Windows, immediately releasing and reacquiring the terminal resource can bounce TTY raw mode and trigger the libuv cancellation-state bug observed with Bun. A short idle TTL lets adjacent prompts reuse the same readline resource while preserving eventual cleanup.

## Validation

- `pnpm test --run packages/effect/test/RcRef.test.ts packages/platform-node-shared/test/NodeTerminal.test.ts`
- `pnpm --filter effect check`
- `pnpm --filter @effect/platform-node-shared check`
- focused dprint and oxlint checks

Interactive verification in a real Windows console remains external.

Closes EFF-539
Closes #7101