### PR TITLE
Fix client-server-client FormData conversion loses multipart representation

### DIFF
--- a/.changeset/fresh-forms-travel.md
+++ b/.changeset/fresh-forms-travel.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve FormData bodies when converting client requests through HttpServerRequest.

--- a/packages/effect/src/unstable/http/HttpServerRequest.ts
+++ b/packages/effect/src/unstable/http/HttpServerRequest.ts
@@ -436,14 +436,19 @@ export const toClientRequest = (request: HttpServerRequest): HttpClientRequest.H
     Option.getOrElse(toURL(request), () => request.url)
   )
 
-const toClientBody = (request: HttpServerRequest): HttpBody.HttpBody =>
-  hasBody(request.method)
+const toClientBody = (request: HttpServerRequest): HttpBody.HttpBody => {
+  if (!hasBody(request.method)) {
+    return HttpBody.empty
+  }
+  const formData = getFormDataBody(request)
+  return formData === undefined
     ? HttpBody.stream(
       request.stream,
       request.headers["content-type"],
       parseContentLength(request.headers["content-length"])
     )
-    : HttpBody.empty
+    : HttpBody.formData(formData)
+}
 
 const parseContentLength = (contentLength: string | undefined): number | undefined => {
   if (contentLength === undefined) {

--- a/packages/effect/test/unstable/http/HttpServerRequest.test.ts
+++ b/packages/effect/test/unstable/http/HttpServerRequest.test.ts
@@ -20,7 +20,7 @@ describe("HttpServerRequest", () => {
         catch: () => undefined
       }).pipe(Effect.option)
 
-      assert.deepStrictEqual(
+      deepStrictEqual(
         {
           multipartMime: webRequest.headers.get("content-type")?.startsWith("multipart/form-data; boundary=") ?? false,
           name: Option.isSome(parsed) ? parsed.value.get("name") : undefined

--- a/packages/effect/test/unstable/http/HttpServerRequest.test.ts
+++ b/packages/effect/test/unstable/http/HttpServerRequest.test.ts
@@ -5,6 +5,30 @@ import * as Option from "effect/Option"
 import { HttpBody, HttpClientRequest, HttpServerRequest } from "effect/unstable/http"
 
 describe("HttpServerRequest", () => {
+  it.effect("preserves FormData through client-server-client conversion", () =>
+    Effect.gen(function*() {
+      const formData = new FormData()
+      formData.set("name", "alice")
+      const clientRequest = HttpClientRequest.post("https://example.com/upload").pipe(
+        HttpClientRequest.bodyFormData(formData)
+      )
+
+      const roundTrip = HttpServerRequest.toClientRequest(HttpServerRequest.fromClientRequest(clientRequest))
+      const webRequest = yield* HttpClientRequest.toWeb(roundTrip)
+      const parsed = yield* Effect.tryPromise({
+        try: () => webRequest.formData(),
+        catch: () => undefined
+      }).pipe(Effect.option)
+
+      assert.deepStrictEqual(
+        {
+          multipartMime: webRequest.headers.get("content-type")?.startsWith("multipart/form-data; boundary=") ?? false,
+          name: Option.isSome(parsed) ? parsed.value.get("name") : undefined
+        },
+        { multipartMime: true, name: "alice" }
+      )
+    }))
+
   it("toClientRequest", async () => {
     const serverRequest = HttpServerRequest.fromWeb(
       new Request("http://localhost:3000/todos/1?a=1&a=2#top", {


### PR DESCRIPTION
## Summary

A valid FormData HttpClientRequest becomes a generic Stream with no multipart Content-Type after conversion through HttpServerRequest, making the reconstructed request undecodable as form data.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Client-server-client FormData conversion loses multipart representation

**Module:** `packages/effect/src/unstable/http/HttpServerRequest.ts`  
**Audit ID:** `relsem-http-formdata-roundtrip`  
**Severity / confidence:** high / high

### What happens

A valid FormData HttpClientRequest becomes a generic Stream with no multipart Content-Type after conversion through HttpServerRequest, making the reconstructed request undecodable as form data.

### Why it happens

The owning implementation diverges from relation http-platform-007.

### Expected behavior

fromClientRequest and toClientRequest document preservation of request headers and body stream; required valid composition must retain enough metadata for the reconstructed body to have the same HTTP semantics.

### Relevant implementation

These links and excerpts are pinned to audit base `b206fa5d7655c1634c9993410a9203f6616a5ca2`.

- [`packages/effect/src/unstable/http/HttpServerRequest.ts:1`](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/effect/src/unstable/http/HttpServerRequest.ts#L1)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/http/HttpServerRequest.ts:1</code></summary>

```ts
/**
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/effect/src/unstable/http/HttpServerRequest.ts#L1)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/http/HttpServerRequest.test.ts -t "preserves FormData through client-server-client conversion"
```

**Observed failure:** Independently rerun; failed at the intended semantic assertion.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/http/HttpServerRequest.test.ts -t "preserves FormData through client-server-client conversion"
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Reproduction base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Findings: `relsem-http-formdata-roundtrip`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-543