### PR TITLE
Fix node fileWebResponse ignores range options

### DIFF
--- a/.changeset/fix-node-file-web-range.md
+++ b/.changeset/fix-node-file-web-range.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node": patch
+---
+
+Honor range options when creating Node responses from Web files.

--- a/packages/platform-node/src/NodeHttpPlatform.ts
+++ b/packages/platform-node/src/NodeHttpPlatform.ts
@@ -90,13 +90,36 @@ export const make = Platform.make({
       statusText
     })
   },
-  fileWebResponse(file, status, statusText, headers, _options) {
-    return ServerResponse.raw(Readable.fromWeb(file.stream() as any), {
+  fileWebResponse(file, status, statusText, headers, options) {
+    const offset = Number(options?.offset ?? 0)
+    const bytesToRead = options?.bytesToRead !== undefined ? Number(options.bytesToRead) : undefined
+    const chunkSize = options?.chunkSize !== undefined ? Math.max(1, Number(options.chunkSize)) : Infinity
+    const end = offset + (bytesToRead ?? Infinity)
+    const contentLength = Math.min(
+      Math.max(0, file.size - offset),
+      bytesToRead !== undefined ? Math.max(0, bytesToRead) : Infinity
+    )
+    const stream = end <= offset
+      ? Readable.from([])
+      : Readable.from(async function*() {
+        let position = 0
+        for await (const bytes of Readable.fromWeb(file.stream() as any)) {
+          const next = position + bytes.length
+          const start = Math.min(Math.max(offset - position, 0), bytes.length)
+          const stop = Math.min(Math.max(end - position, 0), bytes.length)
+          for (let index = start; index < stop; index += chunkSize) {
+            yield bytes.subarray(index, Math.min(index + chunkSize, stop))
+          }
+          if (next >= end) return
+          position = next
+        }
+      }())
+    return ServerResponse.raw(stream, {
       headers: Headers.merge(
         headers,
         Headers.fromRecordUnsafe({
           "content-type": headers["content-type"] ?? Mime.getType(file.name) ?? "application/octet-stream",
-          "content-length": file.size.toString()
+          "content-length": contentLength.toString()
         })
       ),
       status,

--- a/packages/platform-node/test/NodeHttpPlatform.test.ts
+++ b/packages/platform-node/test/NodeHttpPlatform.test.ts
@@ -3,6 +3,7 @@ import { assert, describe, it } from "@effect/vitest"
 import * as Effect from "effect/Effect"
 import type * as HttpBody from "effect/unstable/http/HttpBody"
 import * as HttpPlatform from "effect/unstable/http/HttpPlatform"
+import { File } from "node:buffer"
 import { Readable } from "node:stream"
 
 const readStream = (stream: Readable) =>
@@ -15,6 +16,28 @@ const readStream = (stream: Readable) =>
   })
 
 describe("NodeHttpPlatform", () => {
+  it.effect("fileWebResponse honors offset and bytesToRead including zero", () =>
+    Effect.gen(function*() {
+      const platform = yield* HttpPlatform.HttpPlatform
+      const file = new File(["abcd"], "file.txt", { type: "text/plain", lastModified: 0 })
+      const sliced = yield* platform.fileWebResponse(file, { offset: 1, bytesToRead: 2 })
+      const empty = yield* platform.fileWebResponse(file, { offset: 1, bytesToRead: 0 })
+
+      assert.strictEqual(sliced.body._tag, "Raw")
+      assert((sliced.body as HttpBody.Raw).body instanceof Readable)
+      assert.strictEqual(empty.body._tag, "Raw")
+      assert((empty.body as HttpBody.Raw).body instanceof Readable)
+      assert.deepStrictEqual(
+        {
+          slicedLength: sliced.headers["content-length"],
+          slicedBody: yield* readStream((sliced.body as HttpBody.Raw).body as Readable),
+          emptyLength: empty.headers["content-length"],
+          emptyBody: yield* readStream((empty.body as HttpBody.Raw).body as Readable)
+        },
+        { slicedLength: "2", slicedBody: "bc", emptyLength: "0", emptyBody: "" }
+      )
+    }).pipe(Effect.provide(NodeHttpPlatform.layer)))
+
   it.effect("fileResponse reads exact bytesToRead", () =>
     Effect.gen(function*() {
       const platform = yield* HttpPlatform.HttpPlatform


### PR DESCRIPTION
## Summary

Every concrete non-portable HttpPlatform backend returns the full Web File even when offset and bytesToRead request a slice.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Node fileWebResponse ignores range options

**Module:** `packages/platform-node/src/NodeHttpPlatform.ts`  
**Audit ID:** `relsem-node-fileweb-range`  
**Severity / confidence:** high / high

### What happens

Every concrete non-portable HttpPlatform backend returns the full Web File even when offset and bytesToRead request a slice.

### Why it happens

The owning implementation diverges from relation http-platform-011.

### Expected behavior

HttpPlatform.fileWebResponse publicly accepts offset, bytesToRead, and chunkSize, and the portable implementation documents and implements byte-range selection.

### Relevant implementation

These links and excerpts are pinned to audit base `b206fa5d7655c1634c9993410a9203f6616a5ca2`.

- [`packages/platform-node/src/NodeHttpPlatform.ts:1`](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/platform-node/src/NodeHttpPlatform.ts#L1)

<details>
<summary>View problematic code at <code>packages/platform-node/src/NodeHttpPlatform.ts:1</code></summary>

```ts
/**
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/platform-node/src/NodeHttpPlatform.ts#L1)

</details>

### Reproduction

```sh
pnpm test --run packages/platform-node/test/NodeHttpPlatform.test.ts -t "fileWebResponse honors offset and bytesToRead including zero"
```

**Observed failure:** Independently rerun; failed at the intended semantic assertion.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/platform-node/test/NodeHttpPlatform.test.ts -t "fileWebResponse honors offset and bytesToRead including zero"
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Reproduction base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Findings: `relsem-node-fileweb-range`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-544