### PR TITLE
Fix concurrent first RcRef borrowers acquire different generations

### DIFF
--- a/.changeset/eff-542-rc-ref-generation.md
+++ b/.changeset/eff-542-rc-ref-generation.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Ensure concurrent first `RcRef` borrowers share the same resource generation.

--- a/packages/effect/src/internal/rcRef.ts
+++ b/packages/effect/src/internal/rcRef.ts
@@ -94,21 +94,21 @@ export const make = <A, E, R>(options: {
   })
 
 const getState = <A, E>(self: RcRefImpl<A, E>) =>
-  Effect.uninterruptibleMask((restore) => {
-    switch (self.state._tag) {
-      case "Closed": {
-        return Effect.interrupt
-      }
-      case "Acquired": {
-        self.state.refCount++
-        return self.state.fiber
-          ? Effect.as(Fiber.interrupt(self.state.fiber), self.state)
-          : Effect.succeed(self.state)
-      }
-      case "Empty": {
-        const scope = Scope.makeUnsafe()
-        return self.semaphore.withPermits(1)(
-          restore(Effect.provideContext(
+  self.semaphore.withPermits(1)(
+    Effect.uninterruptibleMask((restore) => {
+      switch (self.state._tag) {
+        case "Closed": {
+          return Effect.interrupt
+        }
+        case "Acquired": {
+          self.state.refCount++
+          return self.state.fiber
+            ? Effect.as(Fiber.interrupt(self.state.fiber), self.state)
+            : Effect.succeed(self.state)
+        }
+        case "Empty": {
+          const scope = Scope.makeUnsafe()
+          return restore(Effect.provideContext(
             self.acquire as Effect.Effect<A, E>,
             Context.add(self.context, Scope.Scope, scope)
           )).pipe(Effect.map((value) => {
@@ -123,10 +123,10 @@ const getState = <A, E>(self: RcRefImpl<A, E>) =>
             self.state = state
             return state
           }))
-        )
+        }
       }
-    }
-  })
+    })
+  )
 
 /** @internal */
 export const get = Effect.fnUntraced(function*<A, E>(

--- a/packages/effect/src/internal/rcRef.ts
+++ b/packages/effect/src/internal/rcRef.ts
@@ -94,39 +94,44 @@ export const make = <A, E, R>(options: {
   })
 
 const getState = <A, E>(self: RcRefImpl<A, E>) =>
-  self.semaphore.withPermits(1)(
-    Effect.uninterruptibleMask((restore) => {
-      switch (self.state._tag) {
-        case "Closed": {
-          return Effect.interrupt
-        }
-        case "Acquired": {
-          self.state.refCount++
-          return self.state.fiber
-            ? Effect.as(Fiber.interrupt(self.state.fiber), self.state)
-            : Effect.succeed(self.state)
-        }
-        case "Empty": {
-          const scope = Scope.makeUnsafe()
-          return restore(Effect.provideContext(
-            self.acquire as Effect.Effect<A, E>,
-            Context.add(self.context, Scope.Scope, scope)
-          )).pipe(Effect.map((value) => {
-            const state: State.Acquired<A> = {
-              _tag: "Acquired",
-              value,
-              scope,
-              fiber: undefined,
-              refCount: 1,
-              invalidated: false
-            }
-            self.state = state
-            return state
-          }))
-        }
+  Effect.uninterruptibleMask(function loop(restore): Effect.Effect<State.Acquired<A>, E> {
+    switch (self.state._tag) {
+      case "Closed": {
+        return Effect.interrupt
       }
-    })
-  )
+      case "Acquired": {
+        self.state.refCount++
+        return self.state.fiber
+          ? Effect.as(Fiber.interrupt(self.state.fiber), self.state)
+          : Effect.succeed(self.state)
+      }
+      case "Empty": {
+        const scope = Scope.makeUnsafe()
+        return self.semaphore.withPermit(
+          Effect.suspend(() => {
+            if (self.state._tag !== "Empty") {
+              return loop(restore)
+            }
+            return restore(Effect.provideContext(
+              self.acquire as Effect.Effect<A, E>,
+              Context.add(self.context, Scope.Scope, scope)
+            )).pipe(Effect.map((value) => {
+              const state: State.Acquired<A> = {
+                _tag: "Acquired",
+                value,
+                scope,
+                fiber: undefined,
+                refCount: 1,
+                invalidated: false
+              }
+              self.state = state
+              return state
+            }))
+          })
+        )
+      }
+    }
+  })
 
 /** @internal */
 export const get = Effect.fnUntraced(function*<A, E>(

--- a/packages/effect/test/RcRef.test.ts
+++ b/packages/effect/test/RcRef.test.ts
@@ -1,7 +1,10 @@
 import { assert, describe, it } from "@effect/vitest"
+import * as Deferred from "effect/Deferred"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
+import * as Fiber from "effect/Fiber"
 import * as RcRef from "effect/RcRef"
+import * as Ref from "effect/Ref"
 import * as Scope from "effect/Scope"
 
 describe("RcRef", () => {
@@ -54,6 +57,72 @@ describe("RcRef", () => {
 
       const exit = yield* RcRef.get(ref).pipe(Effect.scoped, Effect.exit)
       assert.isTrue(Exit.hasInterrupts(exit))
+    }))
+
+  it.effect("shares one generation between concurrent first borrowers", () =>
+    Effect.gen(function*() {
+      const acquired = yield* Ref.make(0)
+      const released = yield* Ref.make(0)
+      const firstStarted = yield* Deferred.make<void>()
+      const releaseFirst = yield* Deferred.make<void>()
+      const refScope = yield* Scope.make()
+      const scopeA = yield* Scope.make()
+      const scopeB = yield* Scope.make()
+      const ref = yield* RcRef.make({
+        acquire: Effect.acquireRelease(
+          Effect.gen(function*() {
+            const id = yield* Ref.updateAndGet(acquired, (n) => n + 1)
+            if (id === 1) {
+              yield* Deferred.succeed(firstStarted, undefined)
+              yield* Deferred.await(releaseFirst)
+            }
+            return { id }
+          }),
+          () => Ref.update(released, (n) => n + 1)
+        )
+      }).pipe(Scope.provide(refScope))
+
+      const fiberA = yield* RcRef.get(ref).pipe(
+        Scope.provide(scopeA),
+        Effect.forkChild({ startImmediately: true })
+      )
+      yield* Deferred.await(firstStarted)
+      const fiberB = yield* RcRef.get(ref).pipe(
+        Scope.provide(scopeB),
+        Effect.forkChild({ startImmediately: true })
+      )
+      yield* Deferred.succeed(releaseFirst, undefined)
+
+      const exitA = yield* Fiber.await(fiberA)
+      const exitB = yield* Fiber.await(fiberB)
+      const generationA = yield* Fiber.join(fiberA)
+      const generationB = yield* Fiber.join(fiberB)
+      const closeAExit = yield* Scope.close(scopeA, Exit.void).pipe(Effect.exit)
+      const closeBExit = yield* Scope.close(scopeB, Exit.void).pipe(Effect.exit)
+      const refCloseExit = yield* Scope.close(refScope, Exit.void).pipe(Effect.exit)
+
+      assert.deepStrictEqual(
+        {
+          exitA,
+          exitB,
+          closeAExit,
+          closeBExit,
+          refCloseExit,
+          sameGeneration: generationA === generationB,
+          acquired: yield* Ref.get(acquired),
+          released: yield* Ref.get(released)
+        },
+        {
+          exitA: Exit.succeed(generationA),
+          exitB: Exit.succeed(generationA),
+          closeAExit: Exit.void,
+          closeBExit: Exit.void,
+          refCloseExit: Exit.void,
+          sameGeneration: true,
+          acquired: 1,
+          released: 1
+        }
+      )
     }))
 
   // it.scoped("idleTimeToLive", () =>

--- a/packages/effect/test/RcRef.test.ts
+++ b/packages/effect/test/RcRef.test.ts
@@ -124,43 +124,4 @@ describe("RcRef", () => {
         }
       )
     }))
-
-  // it.scoped("idleTimeToLive", () =>
-  //   Effect.gen(function*() {
-  //     let acquired = 0
-  //     let released = 0
-  //     const ref = yield* RcRef.make({
-  //       acquire: Effect.acquireRelease(
-  //         Effect.sync(() => {
-  //           acquired++
-  //           return "foo"
-  //         }),
-  //         () =>
-  //           Effect.sync(() => {
-  //             released++
-  //           })
-  //       ),
-  //       idleTimeToLive: 1000
-  //     })
-  //
-  //     assert.strictEqual(acquired, 0)
-  //     assert.strictEqual(yield* Effect.scoped(RcRef.get(ref)), "foo")
-  //     assert.strictEqual(acquired, 1)
-  //     assert.strictEqual(released, 0)
-  //
-  //     yield* TestClock.adjust(1000)
-  //     assert.strictEqual(released, 1)
-  //
-  //     assert.strictEqual(yield* Effect.scoped(RcRef.get(ref)), "foo")
-  //     assert.strictEqual(acquired, 2)
-  //     assert.strictEqual(released, 1)
-  //
-  //     yield* TestClock.adjust(500)
-  //     assert.strictEqual(yield* Effect.scoped(RcRef.get(ref)), "foo")
-  //     assert.strictEqual(acquired, 2)
-  //     assert.strictEqual(released, 1)
-  //
-  //     yield* TestClock.adjust(1000)
-  //     assert.strictEqual(released, 2)
-  //   }))
 })


### PR DESCRIPTION
## Summary

The controlled probe returned resource IDs [1,2] with acquired=2 while both borrower scopes were simultaneously open.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Concurrent first RcRef borrowers acquire different generations

**Module:** `packages/effect/src/internal/rcRef.ts`  
**Audit ID:** `relsem-rc-ref-concurrent-first-borrow`  
**Severity / confidence:** high / high

### What happens

The controlled probe returned resource IDs [1,2] with acquired=2 while both borrower scopes were simultaneously open.

### Why it happens

The Empty/Open state decision occurs outside semaphore ownership. A second caller can observe Empty, wait, and then acquire again after the first caller has already stored State.Acquired.

### Expected behavior

Overlapping borrowers of one RcRef must share its single in-progress or acquired resource until their scopes release it.

### Relevant implementation

These links and excerpts are pinned to audit base `b206fa5d7655c1634c9993410a9203f6616a5ca2`.

- [`packages/effect/src/internal/rcRef.ts:96`](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/effect/src/internal/rcRef.ts#L96)

<details>
<summary>View problematic code at <code>packages/effect/src/internal/rcRef.ts:96</code></summary>

```ts
const getState = <A, E>(self: RcRefImpl<A, E>) =>
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/effect/src/internal/rcRef.ts#L96)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/RcRef.test.ts -t "shares one generation between concurrent first borrowers"
```

**Observed failure:** Independently rerun; failed at the intended semantic assertion.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/RcRef.test.ts -t "shares one generation between concurrent first borrowers"
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Reproduction base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Findings: `relsem-rc-ref-concurrent-first-borrow`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-542