### PR TITLE
Fix fiber.joinAll erases input fiber error types

### DIFF
--- a/.changeset/fiber-join-all-errors.md
+++ b/.changeset/fiber-join-all-errors.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve input fiber error types in `Fiber.joinAll`.

--- a/packages/effect/src/Fiber.ts
+++ b/packages/effect/src/Fiber.ts
@@ -309,7 +309,7 @@ export const joinAll: <A extends Iterable<Fiber<any, any>>>(
     A,
     A extends Iterable<Fiber<infer _A, infer _E>> ? _A : never
   >,
-  A extends Fiber<infer _A, infer _E> ? _E : never
+  A extends Iterable<Fiber<infer _A, infer _E>> ? _E : never
 > = effect.fiberJoinAll
 
 /**

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -822,7 +822,7 @@ export const fiberJoin = <A, E>(self: Fiber.Fiber<A, E>): Effect.Effect<A, E> =>
 /** @internal */
 export const fiberJoinAll = <A extends Iterable<Fiber.Fiber<any, any>>>(self: A): Effect.Effect<
   Arr.ReadonlyArray.With<A, A extends Iterable<Fiber.Fiber<infer _A, infer _E>> ? _A : never>,
-  A extends Fiber.Fiber<infer _A, infer _E> ? _E : never
+  A extends Iterable<Fiber.Fiber<infer _A, infer _E>> ? _E : never
 > =>
   callback((resume) => {
     const fibers = Array.from(self)

--- a/packages/effect/typetest/Fiber.tst.ts
+++ b/packages/effect/typetest/Fiber.tst.ts
@@ -1,0 +1,12 @@
+import { Effect, Fiber } from "effect"
+import { expect, it } from "tstyche"
+
+it("joinAll preserves input fiber errors", () => {
+  const fibers = null as unknown as readonly [
+    Fiber.Fiber<string, "err-1">,
+    Fiber.Fiber<number, "err-2">
+  ]
+  const result = Fiber.joinAll(fibers)
+
+  expect<Effect.Error<typeof result>>().type.toBe<"err-1" | "err-2">()
+})

--- a/packages/effect/typetest/Fiber.tst.ts
+++ b/packages/effect/typetest/Fiber.tst.ts
@@ -1,4 +1,5 @@
-import { Effect, Fiber } from "effect"
+import type { Effect } from "effect"
+import { Fiber } from "effect"
 import { expect, it } from "tstyche"
 
 it("joinAll preserves input fiber errors", () => {


### PR DESCRIPTION
## Summary

- Preserve input fiber error types in both the public `Fiber.joinAll` signature and its internal implementation signature.
- Keep the focused type regression test in `packages/effect/typetest/Fiber.tst.ts`.
- Add a patch changeset for `effect`.

## Root cause

The error conditional tested the iterable type itself against `Fiber<...>`, so it always reduced to `never`. It now extracts the error type from `Iterable<Fiber<...>>`, matching the success-type extraction and the runtime behavior.

## Validation

- `pnpm test-types packages/effect/typetest/Fiber.tst.ts` (TypeScript 5.9.3 and 6.0.3)
- `pnpm test --run packages/effect/test/Fiber.test.ts`
- `pnpm lint`
- `pnpm check`

## Audit provenance

- Audit base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Finding: `relsem-fiber-join-all-error-type`

Closes EFF-546