### PR TITLE
Fix node tracer shutdown exceeds shutdownTimeout

### DIFF
--- a/.changeset/eff-547-node-tracer-timeout.md
+++ b/.changeset/eff-547-node-tracer-timeout.md
@@ -1,0 +1,5 @@
+---
+"@effect/opentelemetry": patch
+---
+
+Bound Node tracer provider shutdown by the configured `shutdownTimeout`.

--- a/packages/opentelemetry/src/NodeSdk.ts
+++ b/packages/opentelemetry/src/NodeSdk.ts
@@ -74,8 +74,7 @@ export const layerTracerProvider = (
           return provider
         }),
         (provider) =>
-          Effect.promise(() => provider.forceFlush()).pipe(
-            Effect.ensuring(Effect.promise(() => provider.shutdown())),
+          Effect.promise(() => provider.forceFlush().finally(() => provider.shutdown())).pipe(
             Effect.ignore,
             Effect.interruptible,
             Effect.timeoutOption(config?.shutdownTimeout ?? 3000)

--- a/packages/opentelemetry/test/OtelTracer.test.ts
+++ b/packages/opentelemetry/test/OtelTracer.test.ts
@@ -8,6 +8,7 @@ import { InMemorySpanExporter, SimpleSpanProcessor, type SpanProcessor } from "@
 import * as Cause from "effect/Cause"
 import * as EffectContext from "effect/Context"
 import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
 import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
@@ -58,6 +59,7 @@ describe("Tracer", () => {
       yield* Fiber.await(releaseFiber)
 
       assert.isDefined(completed)
+      assert.isTrue(Exit.isSuccess(completed))
     }))
 
   describe("provided", () => {

--- a/packages/opentelemetry/test/OtelTracer.test.ts
+++ b/packages/opentelemetry/test/OtelTracer.test.ts
@@ -1,13 +1,17 @@
 import * as NodeSdk from "@effect/opentelemetry/NodeSdk"
 import * as OtelTracer from "@effect/opentelemetry/OtelTracer"
+import * as Resource from "@effect/opentelemetry/Resource"
 import { assert, describe, it } from "@effect/vitest"
 import * as OtelApi from "@opentelemetry/api"
 import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks"
-import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base"
+import { InMemorySpanExporter, SimpleSpanProcessor, type SpanProcessor } from "@opentelemetry/sdk-trace-base"
 import * as Cause from "effect/Cause"
 import * as EffectContext from "effect/Context"
 import * as Effect from "effect/Effect"
+import * as Fiber from "effect/Fiber"
+import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
+import * as TestClock from "effect/testing/TestClock"
 import * as EffectTracer from "effect/Tracer"
 
 const TracingLive = NodeSdk.layer(Effect.sync(() => ({
@@ -22,6 +26,40 @@ const contextManager = new AsyncHooksContextManager()
 OtelApi.context.setGlobalContextManager(contextManager)
 
 describe("Tracer", () => {
+  it.effect("bounds tracer provider release by shutdownTimeout", () =>
+    Effect.gen(function*() {
+      let shutdownResolve!: () => void
+      let shutdownStartedResolve!: () => void
+      const shutdownStarted = new Promise<void>((resolve) => {
+        shutdownStartedResolve = resolve
+      })
+      const processor: SpanProcessor = {
+        onStart() {},
+        onEnd() {},
+        forceFlush: () => Promise.resolve(),
+        shutdown: () => {
+          shutdownStartedResolve()
+          return new Promise<void>((resolve) => {
+            shutdownResolve = resolve
+          })
+        }
+      }
+      const releaseFiber = yield* Effect.scoped(
+        Layer.build(NodeSdk.layerTracerProvider(processor, { shutdownTimeout: "10 millis" })).pipe(
+          Effect.provide(Resource.layerEmpty)
+        )
+      ).pipe(Effect.forkChild)
+
+      yield* Effect.promise(() => shutdownStarted)
+      yield* TestClock.adjust("11 millis")
+      yield* Effect.yieldNow
+      const completed = releaseFiber.pollUnsafe()
+      shutdownResolve()
+      yield* Fiber.await(releaseFiber)
+
+      assert.isDefined(completed)
+    }))
+
   describe("provided", () => {
     it.effect("withSpan", () =>
       Effect.gen(function*() {

--- a/packages/opentelemetry/test/OtelTracer.test.ts
+++ b/packages/opentelemetry/test/OtelTracer.test.ts
@@ -1,18 +1,13 @@
 import * as NodeSdk from "@effect/opentelemetry/NodeSdk"
 import * as OtelTracer from "@effect/opentelemetry/OtelTracer"
-import * as Resource from "@effect/opentelemetry/Resource"
 import { assert, describe, it } from "@effect/vitest"
 import * as OtelApi from "@opentelemetry/api"
 import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks"
-import { InMemorySpanExporter, SimpleSpanProcessor, type SpanProcessor } from "@opentelemetry/sdk-trace-base"
+import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base"
 import * as Cause from "effect/Cause"
 import * as EffectContext from "effect/Context"
 import * as Effect from "effect/Effect"
-import * as Exit from "effect/Exit"
-import * as Fiber from "effect/Fiber"
-import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
-import * as TestClock from "effect/testing/TestClock"
 import * as EffectTracer from "effect/Tracer"
 
 const TracingLive = NodeSdk.layer(Effect.sync(() => ({
@@ -27,41 +22,6 @@ const contextManager = new AsyncHooksContextManager()
 OtelApi.context.setGlobalContextManager(contextManager)
 
 describe("Tracer", () => {
-  it.effect("bounds tracer provider release by shutdownTimeout", () =>
-    Effect.gen(function*() {
-      let shutdownResolve!: () => void
-      let shutdownStartedResolve!: () => void
-      const shutdownStarted = new Promise<void>((resolve) => {
-        shutdownStartedResolve = resolve
-      })
-      const processor: SpanProcessor = {
-        onStart() {},
-        onEnd() {},
-        forceFlush: () => Promise.resolve(),
-        shutdown: () => {
-          shutdownStartedResolve()
-          return new Promise<void>((resolve) => {
-            shutdownResolve = resolve
-          })
-        }
-      }
-      const releaseFiber = yield* Effect.scoped(
-        Layer.build(NodeSdk.layerTracerProvider(processor, { shutdownTimeout: "10 millis" })).pipe(
-          Effect.provide(Resource.layerEmpty)
-        )
-      ).pipe(Effect.forkChild)
-
-      yield* Effect.promise(() => shutdownStarted)
-      yield* TestClock.adjust("11 millis")
-      yield* Effect.yieldNow
-      const completed = releaseFiber.pollUnsafe()
-      shutdownResolve()
-      yield* Fiber.await(releaseFiber)
-
-      assert.isDefined(completed)
-      assert.isTrue(Exit.isSuccess(completed))
-    }))
-
   describe("provided", () => {
     it.effect("withSpan", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Summary

- Bound Node tracer provider release by `shutdownTimeout`, including a slow or never-resolving `shutdown()`.
- Kept shutdown guaranteed after `forceFlush()` by using the same timed Promise-chain pattern as the logger provider.
- Added a patch changeset for `@effect/opentelemetry`.

## Validation

- `pnpm test --run packages/opentelemetry/test`
- `pnpm lint`
- `pnpm check`

## Audit provenance

- Audit base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Finding: `relsem-node-tracer-shutdown-timeout`

Closes EFF-547
