### PR TITLE
Fix closing an older Bun serve scope restores an obsolete handler

### DIFF
--- a/.changeset/eff-548-bun-serve-scope.md
+++ b/.changeset/eff-548-bun-serve-scope.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-bun": patch
+---
+
+Fix Bun HTTP server handler restoration when serve scopes close out of order.

--- a/.changeset/eff-548-bun-serve-scope.md
+++ b/.changeset/eff-548-bun-serve-scope.md
@@ -2,4 +2,4 @@
 "@effect/platform-bun": patch
 ---
 
-Fix Bun HTTP server handler restoration when serve scopes close out of order.
+Fix Bun HTTP server handler restoration and defer shutdown while serve scopes remain active.

--- a/packages/effect/test/unstable/ai/McpServer/TestUtils/McpHttpHarness.ts
+++ b/packages/effect/test/unstable/ai/McpServer/TestUtils/McpHttpHarness.ts
@@ -17,20 +17,26 @@ export const makeHttpHarness = Effect.fnUntraced(function*<A, E>(
   let sessionId: string | null = null
   let protocolVersion: string | null = null
 
-  const fetch: typeof globalThis.fetch = async (input, init) => {
-    const request = input instanceof Request ? input : new Request(input, init)
-    if (sessionId !== null) {
-      request.headers.set("Mcp-Session-Id", sessionId)
-    }
-    if (protocolVersion !== null && !request.headers.has("Mcp-Protocol-Version")) {
-      request.headers.set("Mcp-Protocol-Version", protocolVersion)
-    }
-    const response = await handler(request)
-    sessionId = response.headers.get("Mcp-Session-Id") ?? sessionId
-    protocolVersion = response.headers.get("Mcp-Protocol-Version") ?? protocolVersion
-    responses.push(response.clone())
-    return response
-  }
+  const fetch = Object.assign(
+    async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init?: Parameters<typeof globalThis.fetch>[1]
+    ): Promise<Response> => {
+      const request = input instanceof Request ? input : new Request(input, init)
+      if (sessionId !== null) {
+        request.headers.set("Mcp-Session-Id", sessionId)
+      }
+      if (protocolVersion !== null && !request.headers.has("Mcp-Protocol-Version")) {
+        request.headers.set("Mcp-Protocol-Version", protocolVersion)
+      }
+      const response = await handler(request)
+      sessionId = response.headers.get("Mcp-Session-Id") ?? sessionId
+      protocolVersion = response.headers.get("Mcp-Protocol-Version") ?? protocolVersion
+      responses.push(response.clone())
+      return response
+    },
+    { preconnect() {} }
+  )
 
   const postText = (body: string, headers?: HeadersInit) =>
     Effect.promise(() =>

--- a/packages/effect/test/unstable/ai/McpServer/TestUtils/McpHttpHarness.ts
+++ b/packages/effect/test/unstable/ai/McpServer/TestUtils/McpHttpHarness.ts
@@ -17,26 +17,21 @@ export const makeHttpHarness = Effect.fnUntraced(function*<A, E>(
   let sessionId: string | null = null
   let protocolVersion: string | null = null
 
-  const fetch = Object.assign(
-    async (
-      input: Parameters<typeof globalThis.fetch>[0],
-      init?: Parameters<typeof globalThis.fetch>[1]
-    ): Promise<Response> => {
-      const request = input instanceof Request ? input : new Request(input, init)
-      if (sessionId !== null) {
-        request.headers.set("Mcp-Session-Id", sessionId)
-      }
-      if (protocolVersion !== null && !request.headers.has("Mcp-Protocol-Version")) {
-        request.headers.set("Mcp-Protocol-Version", protocolVersion)
-      }
-      const response = await handler(request)
-      sessionId = response.headers.get("Mcp-Session-Id") ?? sessionId
-      protocolVersion = response.headers.get("Mcp-Protocol-Version") ?? protocolVersion
-      responses.push(response.clone())
-      return response
-    },
-    { preconnect() {} }
-  )
+  const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const request = input instanceof Request ? input : new Request(input, init)
+    if (sessionId !== null) {
+      request.headers.set("Mcp-Session-Id", sessionId)
+    }
+    if (protocolVersion !== null && !request.headers.has("Mcp-Protocol-Version")) {
+      request.headers.set("Mcp-Protocol-Version", protocolVersion)
+    }
+    const response = await handler(request)
+    sessionId = response.headers.get("Mcp-Session-Id") ?? sessionId
+    protocolVersion = response.headers.get("Mcp-Protocol-Version") ?? protocolVersion
+    responses.push(response.clone())
+    return response
+  }
+  const fetch: typeof globalThis.fetch = Object.assign(fetchImpl, { preconnect() {} })
 
   const postText = (body: string, headers?: HeadersInit) =>
     Effect.promise(() =>

--- a/packages/platform-browser/test/BrowserCrypto.test.ts
+++ b/packages/platform-browser/test/BrowserCrypto.test.ts
@@ -33,7 +33,7 @@ describe("BrowserCrypto", () => {
     }).pipe(Effect.provide(BrowserCrypto.layer.pipe(
       Layer.provide(Layer.succeed(BrowserCrypto.WebCrypto, {
         ...crypto,
-        getRandomValues(array) {
+        getRandomValues<T extends ArrayBufferView | null>(array: T): T {
           if (array !== null) {
             assert.ok(array.byteLength <= 65_536)
             chunks.push(array.byteLength)
@@ -53,7 +53,7 @@ describe("BrowserCrypto", () => {
     }).pipe(Effect.provide(BrowserCrypto.layer.pipe(
       Layer.provide(Layer.succeed(BrowserCrypto.WebCrypto, {
         ...crypto,
-        getRandomValues(array) {
+        getRandomValues<T extends ArrayBufferView | null>(array: T): T {
           return getRandomValues(array)
         }
       }))
@@ -69,7 +69,7 @@ describe("BrowserCrypto", () => {
     }).pipe(Effect.provide(BrowserCrypto.layer.pipe(
       Layer.provide(Layer.succeed(BrowserCrypto.WebCrypto, {
         ...crypto,
-        getRandomValues(array) {
+        getRandomValues<T extends ArrayBufferView | null>(array: T): T {
           return getRandomValues(array)
         }
       }))

--- a/packages/platform-browser/test/BrowserCrypto.test.ts
+++ b/packages/platform-browser/test/BrowserCrypto.test.ts
@@ -53,9 +53,7 @@ describe("BrowserCrypto", () => {
     }).pipe(Effect.provide(BrowserCrypto.layer.pipe(
       Layer.provide(Layer.succeed(BrowserCrypto.WebCrypto, {
         ...crypto,
-        getRandomValues<T extends ArrayBufferView | null>(array: T): T {
-          return getRandomValues(array)
-        }
+        getRandomValues
       }))
     ))))
 
@@ -69,9 +67,7 @@ describe("BrowserCrypto", () => {
     }).pipe(Effect.provide(BrowserCrypto.layer.pipe(
       Layer.provide(Layer.succeed(BrowserCrypto.WebCrypto, {
         ...crypto,
-        getRandomValues<T extends ArrayBufferView | null>(array: T): T {
-          return getRandomValues(array)
-        }
+        getRandomValues
       }))
     ))))
 

--- a/packages/platform-bun/src/BunHttpServer.ts
+++ b/packages/platform-bun/src/BunHttpServer.ts
@@ -171,10 +171,10 @@ export const make = Effect.fnUntraced(
         }
 
         yield* Scope.addFinalizerExit(serveScope, () => {
-          const index = handlerStack.lastIndexOf(handler)
+          const index = handlerStack.indexOf(handler)
           if (index !== -1) handlerStack.splice(index, 1)
           server.reload({ fetch: handlerStack[handlerStack.length - 1] })
-          return preemptiveShutdown
+          return handlerStack.length === 1 ? preemptiveShutdown : Effect.void
         })
         handlerStack.push(handler)
         server.reload({ fetch: handler })

--- a/packages/platform-bun/src/BunHttpServer.ts
+++ b/packages/platform-bun/src/BunHttpServer.ts
@@ -171,7 +171,8 @@ export const make = Effect.fnUntraced(
         }
 
         yield* Scope.addFinalizerExit(serveScope, () => {
-          handlerStack.pop()
+          const index = handlerStack.lastIndexOf(handler)
+          if (index !== -1) handlerStack.splice(index, 1)
           server.reload({ fetch: handlerStack[handlerStack.length - 1] })
           return preemptiveShutdown
         })

--- a/packages/platform-bun/test/BunHttpServer.test.ts
+++ b/packages/platform-bun/test/BunHttpServer.test.ts
@@ -6,14 +6,16 @@ import * as Scope from "effect/Scope"
 import * as HttpServer from "effect/unstable/http/HttpServer"
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse"
 
+const fetchText = (url: string) =>
+  Effect.promise(() => fetch(url, { headers: { connection: "close" } }).then((response) => response.text()))
+
 describe("BunHttpServer", () => {
   it.effect("closing an older serve scope keeps the newer handler active", () =>
     Effect.gen(function*() {
       const ownerScope = yield* Effect.scope
       const server = yield* BunHttpServer.make({
         hostname: "127.0.0.1",
-        port: 0,
-        disablePreemptiveShutdown: true
+        port: 0
       })
       const firstScope = yield* Scope.fork(ownerScope)
       const secondScope = yield* Scope.fork(ownerScope)
@@ -22,9 +24,9 @@ describe("BunHttpServer", () => {
       yield* server.serve(Effect.succeed(HttpServerResponse.text("second"))).pipe(Scope.provide(secondScope))
       const url = HttpServer.formatAddress(server.address)
 
-      assert.strictEqual(yield* Effect.promise(() => fetch(url).then((response) => response.text())), "second")
+      assert.strictEqual(yield* fetchText(url), "second")
       yield* Scope.close(firstScope, Exit.void)
-      assert.strictEqual(yield* Effect.promise(() => fetch(url).then((response) => response.text())), "second")
+      assert.strictEqual(yield* fetchText(url), "second")
     }))
 
   it.effect("closing the newer serve scope restores the older handler", () =>
@@ -32,8 +34,7 @@ describe("BunHttpServer", () => {
       const ownerScope = yield* Effect.scope
       const server = yield* BunHttpServer.make({
         hostname: "127.0.0.1",
-        port: 0,
-        disablePreemptiveShutdown: true
+        port: 0
       })
       const firstScope = yield* Scope.fork(ownerScope)
       const secondScope = yield* Scope.fork(ownerScope)
@@ -42,8 +43,8 @@ describe("BunHttpServer", () => {
       yield* server.serve(Effect.succeed(HttpServerResponse.text("second"))).pipe(Scope.provide(secondScope))
       const url = HttpServer.formatAddress(server.address)
 
-      assert.strictEqual(yield* Effect.promise(() => fetch(url).then((response) => response.text())), "second")
+      assert.strictEqual(yield* fetchText(url), "second")
       yield* Scope.close(secondScope, Exit.void)
-      assert.strictEqual(yield* Effect.promise(() => fetch(url).then((response) => response.text())), "first")
+      assert.strictEqual(yield* fetchText(url), "first")
     }))
 })

--- a/packages/platform-bun/test/BunHttpServer.test.ts
+++ b/packages/platform-bun/test/BunHttpServer.test.ts
@@ -26,4 +26,24 @@ describe("BunHttpServer", () => {
       yield* Scope.close(firstScope, Exit.void)
       assert.strictEqual(yield* Effect.promise(() => fetch(url).then((response) => response.text())), "second")
     }))
+
+  it.effect("closing the newer serve scope restores the older handler", () =>
+    Effect.gen(function*() {
+      const ownerScope = yield* Effect.scope
+      const server = yield* BunHttpServer.make({
+        hostname: "127.0.0.1",
+        port: 0,
+        disablePreemptiveShutdown: true
+      })
+      const firstScope = yield* Scope.fork(ownerScope)
+      const secondScope = yield* Scope.fork(ownerScope)
+
+      yield* server.serve(Effect.succeed(HttpServerResponse.text("first"))).pipe(Scope.provide(firstScope))
+      yield* server.serve(Effect.succeed(HttpServerResponse.text("second"))).pipe(Scope.provide(secondScope))
+      const url = HttpServer.formatAddress(server.address)
+
+      assert.strictEqual(yield* Effect.promise(() => fetch(url).then((response) => response.text())), "second")
+      yield* Scope.close(secondScope, Exit.void)
+      assert.strictEqual(yield* Effect.promise(() => fetch(url).then((response) => response.text())), "first")
+    }))
 })

--- a/packages/platform-bun/test/BunHttpServer.test.ts
+++ b/packages/platform-bun/test/BunHttpServer.test.ts
@@ -1,0 +1,29 @@
+import * as BunHttpServer from "@effect/platform-bun/BunHttpServer"
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
+import * as Scope from "effect/Scope"
+import * as HttpServer from "effect/unstable/http/HttpServer"
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse"
+
+describe("BunHttpServer", () => {
+  it.effect("closing an older serve scope keeps the newer handler active", () =>
+    Effect.gen(function*() {
+      const ownerScope = yield* Effect.scope
+      const server = yield* BunHttpServer.make({
+        hostname: "127.0.0.1",
+        port: 0,
+        disablePreemptiveShutdown: true
+      })
+      const firstScope = yield* Scope.fork(ownerScope)
+      const secondScope = yield* Scope.fork(ownerScope)
+
+      yield* server.serve(Effect.succeed(HttpServerResponse.text("first"))).pipe(Scope.provide(firstScope))
+      yield* server.serve(Effect.succeed(HttpServerResponse.text("second"))).pipe(Scope.provide(secondScope))
+      const url = HttpServer.formatAddress(server.address)
+
+      assert.strictEqual(yield* Effect.promise(() => fetch(url).then((response) => response.text())), "second")
+      yield* Scope.close(firstScope, Exit.void)
+      assert.strictEqual(yield* Effect.promise(() => fetch(url).then((response) => response.text())), "second")
+    }))
+})


### PR DESCRIPTION
## Summary

- Unregister the exact Bun HTTP handler owned by each `HttpServer.serve` scope, so out-of-order finalization preserves the newest live handler.
- Defer preemptive server shutdown until the final serve registration is removed.
- Cover both scope-closure orders under the default server configuration with fresh HTTP connections.
- Keep the shared TypeScript test program compatible with Bun's global `fetch` and Web Crypto augmentations.

## Validation

- `pnpm check`
- `pnpm lint`
- Full `@effect/platform-bun` suite: 12/12 tests
- MCP server and BrowserCrypto suites: 192/192 tests
- Confirmed the default-config, fresh-connection regression fails before the shutdown fix and passes afterward

## Audit provenance

- Audit ID: `relsem-bun-serve-scope-handler`
- Audit base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Reproduction base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`

Closes EFF-548