### PR TITLE
Fix scopedRef.set orphans a replacement when old cleanup defects

### DIFF
--- a/.changeset/tidy-scoped-refs-close.md
+++ b/.changeset/tidy-scoped-refs-close.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Ensure `ScopedRef.set` releases a replacement when the previous value's finalizer defects.

--- a/packages/effect/src/ScopedRef.ts
+++ b/packages/effect/src/ScopedRef.ts
@@ -183,7 +183,9 @@ export const set: {
         Scope.provide(scope),
         Effect.tapCause((cause) => Scope.close(scope, Exit.failCause(cause)))
       )
-      yield* Scope.close(self.backing.backing.ref.current[0], Exit.void)
+      yield* Scope.close(self.backing.backing.ref.current[0], Exit.void).pipe(
+        Effect.tapCause((cause) => Scope.close(scope, Exit.failCause(cause)))
+      )
       self.backing.backing.ref.current = [scope, value]
     },
     Effect.uninterruptible,

--- a/packages/effect/test/ScopedRef.test.ts
+++ b/packages/effect/test/ScopedRef.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from "@effect/vitest"
+import { assert, describe, it } from "@effect/vitest"
 import { strictEqual } from "@effect/vitest/utils"
-import { Effect, identity, pipe, ScopedRef } from "effect"
+import { Effect, Exit, identity, pipe, Ref, Scope, ScopedRef } from "effect"
 import * as Counter from "./utils/counter.ts"
 
 describe("ScopedRef", () => {
@@ -86,6 +86,37 @@ describe("ScopedRef", () => {
 
       strictEqual(released, false, "failed replacement must not release the current resource")
       strictEqual(yield* ScopedRef.get(ref), 1)
+    }))
+  it.effect("releases a replacement when the old finalizer defects", () =>
+    Effect.gen(function*() {
+      const oldReleased = yield* Ref.make(0)
+      const replacementAcquired = yield* Ref.make(0)
+      const replacementReleased = yield* Ref.make(0)
+      const ownerScope = yield* Scope.make()
+      const ref = yield* ScopedRef.fromAcquire(
+        Effect.acquireRelease(
+          Effect.succeed(0),
+          () =>
+            Ref.update(oldReleased, (n) => n + 1).pipe(
+              Effect.andThen(Effect.die("old-release-defect"))
+            )
+        )
+      ).pipe(Scope.provide(ownerScope))
+
+      const setExit = yield* ScopedRef.set(
+        ref,
+        Effect.acquireRelease(
+          Ref.updateAndGet(replacementAcquired, (n) => n + 1),
+          () => Ref.update(replacementReleased, (n) => n + 1)
+        )
+      ).pipe(Effect.exit)
+      const ownerCloseExit = yield* Scope.close(ownerScope, Exit.void).pipe(Effect.exit)
+
+      assert.deepStrictEqual(setExit, Exit.die("old-release-defect"))
+      assert.deepStrictEqual(ownerCloseExit, Exit.void)
+      strictEqual(yield* Ref.get(oldReleased), 1)
+      strictEqual(yield* Ref.get(replacementAcquired), 1)
+      strictEqual(yield* Ref.get(replacementReleased), 1)
     }))
   it.effect("fromAcquire tracks the initial resource through replacement and scope close", () =>
     Effect.gen(function*() {

--- a/packages/effect/test/ScopedRef.test.ts
+++ b/packages/effect/test/ScopedRef.test.ts
@@ -110,6 +110,7 @@ describe("ScopedRef", () => {
           () => Ref.update(replacementReleased, (n) => n + 1)
         )
       ).pipe(Effect.exit)
+      strictEqual(yield* ScopedRef.get(ref), 0)
       const ownerCloseExit = yield* Scope.close(ownerScope, Exit.void).pipe(Effect.exit)
 
       assert.deepStrictEqual(setExit, Exit.die("old-release-defect"))


### PR DESCRIPTION
## Summary

set failed with defect old-release-defect, retained current='old', and recorded replacementAcquired=1 but replacementReleased=0 after outer closure.

> [!NOTE]
> This PR includes the focused regression test, implementation fix, and patch changeset.

## ScopedRef.set orphans a replacement when old cleanup defects

**Module:** `packages/effect/src/ScopedRef.ts`  
**Audit ID:** `relsem-scoped-ref-old-finalizer-failure`  
**Severity / confidence:** medium / high

### What happens

set failed with defect old-release-defect, retained current='old', and recorded replacementAcquired=1 but replacementReleased=0 after outer closure.

### Why it happens

There is no ensuring/onExit cleanup around the interval after replacement acquisition and before backing assignment. Scope.close(old) can defect and short-circuit the generator.

### Expected behavior

Once replacement acquisition succeeds, every later exit from ScopedRef.set must either install that replacement under outer ownership or close its temporary scope; no acquired replacement may be orphaned.

### Relevant implementation

These links and excerpts are pinned to audit base `b206fa5d7655c1634c9993410a9203f6616a5ca2`.

- [`packages/effect/src/ScopedRef.ts:181`](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/effect/src/ScopedRef.ts#L181)

<details>
<summary>View problematic code at <code>packages/effect/src/ScopedRef.ts:181</code></summary>

```ts
      const scope = Scope.makeUnsafe()
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/effect/src/ScopedRef.ts#L181)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/ScopedRef.test.ts -t "releases a replacement when the old finalizer defects"
```

**Observed failure:** Independently rerun; failed at the intended semantic assertion.

## Implementation

`ScopedRef.set` now closes the newly acquired replacement scope if closing the previous value's scope fails. The failed set retains the previous value and propagates the original cleanup defect without orphaning the replacement.

The focused regression, full `ScopedRef` test file, repository lint, and TypeScript checks pass locally.

## Audit provenance

- Audit base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Reproduction base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Findings: `relsem-scoped-ref-old-finalizer-failure`
- Initial patch: focused reproduction tests; implementation fix added in this PR

Closes EFF-550