### PR TITLE
Fix disabled tracer timing still records span end times

### DIFF
--- a/.changeset/tracer-disabled-timing.md
+++ b/.changeset/tracer-disabled-timing.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Keep span end times at zero when tracer timing is disabled.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -5862,11 +5862,8 @@ export const useSpan: {
   return withFiber((fiber) => {
     const span = makeSpanUnsafe(fiber, name, options)
     const clock = fiber.getRef(ClockRef)
-    return onExit(internalCall(() => evaluate(span)), (exit) =>
-      sync(() => {
-        if (span.status._tag === "Ended") return
-        span.end(clock.currentTimeNanosUnsafe(), exit)
-      }))
+    const timingEnabled = fiber.getRef(TracerTimingEnabled)
+    return onExit(internalCall(() => evaluate(span)), (exit) => endSpan(span, exit, clock, timingEnabled))
   })
 }
 

--- a/packages/effect/test/Tracer.test.ts
+++ b/packages/effect/test/Tracer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@effect/vitest"
 import { assertInclude, assertNone, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
-import { Cause, Context, Duration, Effect, Fiber, Layer, Tracer } from "effect"
+import { Cause, Context, Duration, Effect, Fiber, Layer, References, Tracer } from "effect"
 import { TestClock } from "effect/testing"
 import type { Span } from "effect/Tracer"
 import { HttpClient, HttpClientResponse } from "effect/unstable/http"
@@ -287,6 +287,23 @@ describe("Tracer", () => {
 
         strictEqual(span.status.startTime, 0n)
       }))
+
+    it.effect("should set start and end times to zero when timing is disabled", () =>
+      Effect.gen(function*() {
+        yield* TestClock.adjust("1 millis")
+
+        const useSpan = yield* Effect.useSpan("useSpan", (span) => Effect.succeed(span))
+        const withSpan = yield* Effect.currentSpan.pipe(Effect.withSpan("withSpan"))
+
+        deepStrictEqual(
+          [useSpan.status, withSpan.status].map((status) => {
+            strictEqual(status._tag, "Ended")
+            return status._tag === "Ended" ? [status.startTime, status.endTime] : undefined
+          }),
+          [[0n, 0n], [0n, 0n]],
+          "disabled span timing"
+        )
+      }).pipe(Effect.provideService(References.TracerTimingEnabled, false)))
   })
 
   describe("Effect.linkSpans", () => {

--- a/packages/effect/test/Tracer.test.ts
+++ b/packages/effect/test/Tracer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@effect/vitest"
 import { assertInclude, assertNone, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
-import { Cause, Context, Duration, Effect, Fiber, Layer, References, Tracer } from "effect"
+import { Cause, Context, Duration, Effect, Fiber, Layer, Tracer } from "effect"
 import { TestClock } from "effect/testing"
 import type { Span } from "effect/Tracer"
 import { HttpClient, HttpClientResponse } from "effect/unstable/http"
@@ -303,7 +303,7 @@ describe("Tracer", () => {
           [[0n, 0n], [0n, 0n]],
           "disabled span timing"
         )
-      }).pipe(Effect.provideService(References.TracerTimingEnabled, false)))
+      }).pipe(Effect.withTracerTiming(false)))
   })
 
   describe("Effect.linkSpans", () => {


### PR DESCRIPTION
## Summary

The probe returned Ended with startTime=0n and endTime=1786089303652000000n.

> [!IMPORTANT]
> This PR includes the focused regression test, the implementation fix, and a patch changeset.

## Disabled tracer timing still records span end times

**Module:** `packages/effect/src/internal/effect.ts`  
**Audit ID:** `relsem-tracer-disabled-timing-end`  
**Severity / confidence:** low / high

### What happens

The probe returned Ended with startTime=0n and endTime=1786089303652000000n.

### Why it happens

makeSpanUnsafe consults TracerTimingEnabled for startTime, but useSpan captures only Clock and always uses its current time for endTime. The scoped path correctly captures timingEnabled and calls endSpan.

### Expected behavior

When tracer timing is disabled, span timing fields must remain zero for the complete span lifetime, including endTime.

### Relevant implementation

These links and excerpts are pinned to audit base `b206fa5d7655c1634c9993410a9203f6616a5ca2`.

- [`packages/effect/src/internal/effect.ts:5833`](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/effect/src/internal/effect.ts#L5833)

<details>
<summary>View problematic code at <code>packages/effect/src/internal/effect.ts:5833</code></summary>

```ts
/** @internal */
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/effect/src/internal/effect.ts#L5833)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/Tracer.test.ts -t "should set start and end times to zero when timing is disabled"
```

**Observed failure:** Independently rerun; failed at the intended semantic assertion.

## Validation

- Focused disabled-timing regression: passed
- Full `packages/effect/test` suite: 7,988 passed, 3 skipped
- Repository lint and type checks: passed

## Audit provenance

- Audit base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Reproduction base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Findings: `relsem-tracer-disabled-timing-end`
- Implementation: route `useSpan` completion through the timing-aware `endSpan` helper

Closes EFF-551