### PR TITLE
Fix txPubSub subscriber release interrupts after hub shutdown

### DIFF
--- a/.changeset/eff-552-txqueue-shutdown.md
+++ b/.changeset/eff-552-txqueue-shutdown.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Make `TxQueue.shutdown` safe to call after a queue has already been interrupted.

--- a/packages/effect/src/TxQueue.ts
+++ b/packages/effect/src/TxQueue.ts
@@ -1358,7 +1358,7 @@ export const clear = <A, E>(self: TxEnqueue<A, E>): Effect.Effect<Array<A>, Excl
  */
 export const shutdown = <A, E>(self: TxEnqueue<A, E>): Effect.Effect<boolean> =>
   Effect.gen(function*() {
-    yield* Effect.ignore(clear(self))
+    yield* Effect.ignoreCause(clear(self))
     return yield* interrupt(self)
   }).pipe(Effect.tx)
 

--- a/packages/effect/test/TxPubSub.test.ts
+++ b/packages/effect/test/TxPubSub.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Fiber, Option, TxPubSub, TxQueue } from "effect"
+import { Effect, Exit, Fiber, Option, Scope, TxPubSub, TxQueue } from "effect"
 
 describe("TxPubSub", () => {
   describe("constructors", () => {
@@ -331,6 +331,17 @@ describe("TxPubSub", () => {
   })
 
   describe("scope cleanup", () => {
+    it.effect("releases a subscriber after hub shutdown without interruption", () =>
+      Effect.gen(function*() {
+        const hub = yield* Effect.tx(TxPubSub.unbounded<number>())
+        const scope = yield* Scope.make()
+        yield* TxPubSub.subscribe(hub).pipe(Scope.provide(scope))
+        yield* Effect.tx(TxPubSub.shutdown(hub))
+
+        const release = yield* Effect.exit(Scope.close(scope, Exit.void))
+        assert(Exit.isSuccess(release))
+      }))
+
     it.effect("closing scope removes subscriber", () =>
       Effect.gen(function*() {
         const hub = yield* Effect.tx(TxPubSub.unbounded<number>())


### PR DESCRIPTION
## Summary

TxPubSub.shutdown first calls TxQueue.shutdown on the subscriber. Its scope finalizer later calls releaseSubscriber, which calls TxQueue.shutdown again. clear observes the queue's interrupt Done cause; Effect.ignore does not recover interruption, so the finalizer and Scope.close exit with interruption. The minimal public sequence TxQueue.shutdown(queue) twice likewise yields Success(true) then an interrupt Exit rather than a boolean result.

> [!IMPORTANT]
> This PR includes the focused regression test and the implementation fix in `TxQueue.shutdown`.

## TxPubSub subscriber release interrupts after hub shutdown

**Module:** `packages/effect/src/TxPubSub.ts`  
**Audit ID:** `relsem-txpubsub-release-after-shutdown`  
**Severity / confidence:** medium / high

### What happens

TxPubSub.shutdown first calls TxQueue.shutdown on the subscriber. Its scope finalizer later calls releaseSubscriber, which calls TxQueue.shutdown again. clear observes the queue's interrupt Done cause; Effect.ignore does not recover interruption, so the finalizer and Scope.close exit with interruption. The minimal public sequence TxQueue.shutdown(queue) twice likewise yields Success(true) then an interrupt Exit rather than a boolean result.

### Why it happens

TxQueue.shutdown attempts to tolerate clear failure with Effect.ignore, but clear can fail by interruption when the queue is already interrupt-completed. Effect.ignore handles the typed failure channel, not the full interruption cause, so repeated shutdown is not total and TxPubSub's release finalizer inherits that interruption.

### Expected behavior

A scoped TxPubSub subscription release must unregister and shut down its queue without turning ordinary scope closure into interruption, including when hub shutdown already terminated that queue.

### Relevant implementation

These links and excerpts are pinned to audit base `b206fa5d7655c1634c9993410a9203f6616a5ca2`.

- [`packages/effect/src/TxPubSub.ts:582`](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/effect/src/TxPubSub.ts#L582)

<details>
<summary>View problematic code at <code>packages/effect/src/TxPubSub.ts:582</code></summary>

```ts
export const releaseSubscriber: {
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/effect/src/TxPubSub.ts#L582)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/TxPubSub.test.ts -t "releases a subscriber after hub shutdown without interruption"
```

**Validation:** The reproduction failed before the implementation change and passes after it.

## Implementation

`TxQueue.shutdown` now ignores the full cause from `clear` before interrupting the queue, making repeated shutdown safe when the queue is already interrupted.

The focused regression, full `effect` test project, repository lint, and type checks all pass.

## Audit provenance

- Audit base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Reproduction base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Findings: `relsem-txpubsub-release-after-shutdown`
- Implementation: focused reproduction test plus interruption-tolerant `TxQueue.shutdown`

Closes EFF-552