### PR TITLE
Fix log annotations overwrite active span correlation identifiers

### DIFF
--- a/.changeset/fair-logs-correlate.md
+++ b/.changeset/fair-logs-correlate.md
@@ -1,0 +1,5 @@
+---
+"@effect/opentelemetry": patch
+---
+
+Prevent log annotations from overwriting active span correlation identifiers.

--- a/packages/opentelemetry/src/OtelLogger.ts
+++ b/packages/opentelemetry/src/OtelLogger.ts
@@ -91,6 +91,10 @@ export const make: Effect.Effect<
       fiberId: options.fiber.id
     }
 
+    for (const [key, value] of Object.entries(options.fiber.getRef(References.CurrentLogAnnotations))) {
+      Rec.assignProperty(attributes, key, unknownToAttributeValue(value))
+    }
+
     const span = Context.getOrUndefined(options.fiber.context, Tracer.ParentSpan)
 
     if (Predicate.isNotUndefined(span)) {
@@ -98,9 +102,6 @@ export const make: Effect.Effect<
       attributes.traceId = span.traceId
     }
 
-    for (const [key, value] of Object.entries(options.fiber.getRef(References.CurrentLogAnnotations))) {
-      Rec.assignProperty(attributes, key, unknownToAttributeValue(value))
-    }
     const now = options.date.getTime()
     for (const [label, startTime] of options.fiber.getRef(References.CurrentLogSpans)) {
       attributes[`logSpan.${label}`] = `${now - startTime}ms`

--- a/packages/opentelemetry/test/OtelLogger.test.ts
+++ b/packages/opentelemetry/test/OtelLogger.test.ts
@@ -124,6 +124,28 @@ describe("Logger", () => {
         Effect.provideService(Clock.Clock, skewedClock)
       )
     })
+
+    it.effect("does not let annotations overwrite active span correlation", () => {
+      const logExporter = new InMemoryLogRecordExporter()
+      const spanExporter = new InMemorySpanExporter()
+      const TracingLive = NodeSdk.layer(Effect.sync(() => ({
+        resource: { serviceName: "test" },
+        spanProcessor: [new SimpleSpanProcessor(spanExporter)],
+        logRecordProcessor: [new SimpleLogRecordProcessor({ exporter: logExporter })]
+      })))
+
+      return Effect.gen(function*() {
+        yield* Effect.log("test").pipe(
+          Effect.annotateLogs({ traceId: "spoof-trace", spanId: "spoof-span" }),
+          Effect.withSpan("parent")
+        )
+
+        const log = logExporter.getFinishedLogRecords()[0]!
+        const span = spanExporter.getFinishedSpans()[0]!
+        assert.strictEqual(log.attributes.traceId, span.spanContext().traceId)
+        assert.strictEqual(log.attributes.spanId, span.spanContext().spanId)
+      }).pipe(Effect.provide(TracingLive))
+    })
   })
 
   describe("not provided", () => {


### PR DESCRIPTION
## Summary

The logger writes real correlation ids first, then assigns CurrentLogAnnotations into the same attributes object. Annotations named traceId or spanId replace the reserved correlation values.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Log annotations overwrite active span correlation identifiers

**Module:** `packages/opentelemetry/src/OtelLogger.ts`  
**Audit ID:** `relsem-otel-logger-correlation-annotation`  
**Severity / confidence:** medium / high

### What happens

The logger writes real correlation ids first, then assigns CurrentLogAnnotations into the same attributes object. Annotations named traceId or spanId replace the reserved correlation values.

### Why it happens

Reserved fields and user annotations share one flat namespace, and user annotations are copied after reserved trace fields with unconditional assignment.

### Expected behavior

OtelLogger correlates a log with its active Effect parent by emitting that exact parent traceId and spanId.

### Relevant implementation

These links and excerpts are pinned to audit base `b206fa5d7655c1634c9993410a9203f6616a5ca2`.

- [`packages/opentelemetry/src/OtelLogger.ts:1`](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/opentelemetry/src/OtelLogger.ts#L1)

<details>
<summary>View problematic code at <code>packages/opentelemetry/src/OtelLogger.ts:1</code></summary>

```ts
/**
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/opentelemetry/src/OtelLogger.ts#L1)

</details>

### Reproduction

```sh
pnpm test --run packages/opentelemetry/test/OtelLogger.test.ts -t "does not let annotations overwrite active span correlation"
```

**Observed failure:** Independently rerun; failed at the intended semantic assertion.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/opentelemetry/test/OtelLogger.test.ts -t "does not let annotations overwrite active span correlation"
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Reproduction base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Findings: `relsem-otel-logger-correlation-annotation`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-553