### PR TITLE
Fix sQL findById resolvers invoke NonEmpty callbacks with an empty batch

### DIFF
--- a/.changeset/eff-554-sql-resolver.md
+++ b/.changeset/eff-554-sql-resolver.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Prevent SQL resolvers from invoking non-empty batch callbacks when every request fails encoding.

--- a/packages/effect/src/unstable/sql/SqlResolver.ts
+++ b/packages/effect/src/unstable/sql/SqlResolver.ts
@@ -122,6 +122,7 @@ export const ordered = <Req extends Schema.Constraint, Res extends Schema.Constr
     key: transactionKey,
     resolver: Effect.fnUntraced(function*(entries) {
       const [inputs, encodedEntries] = yield* partitionRequests(entries, options.Request)
+      if (inputs.length === 0) return
       const results = yield* options.execute(inputs as any).pipe(
         Effect.provideContext(entries[0].context)
       )
@@ -178,6 +179,7 @@ export const grouped = <Req extends Schema.Constraint, Res extends Schema.Constr
     key: transactionKey,
     resolver: Effect.fnUntraced(function*(entries) {
       const [inputs] = yield* partitionRequests(entries, options.Request)
+      if (inputs.length === 0) return
       const resultMap = MutableHashMap.empty<K, Arr.NonEmptyArray<Res["Type"]>>()
       const results = yield* options.execute(inputs as any).pipe(
         Effect.provideContext(entries[0].context)
@@ -246,6 +248,7 @@ export const findById = <Id extends Schema.Constraint, Res extends Schema.Constr
     key: transactionKey,
     resolver: Effect.fnUntraced(function*(entries) {
       const [inputs, idMap] = yield* partitionRequestsById(entries, options.Id)
+      if (inputs.length === 0) return
       const results = yield* options.execute(inputs as any).pipe(
         Effect.provideContext(entries[0].context)
       )
@@ -299,6 +302,7 @@ const void_ = <Req extends Schema.Constraint, _, E, R>(
     key: transactionKey,
     resolver: Effect.fnUntraced(function*(entries) {
       const [inputs] = yield* partitionRequests(entries, options.Request)
+      if (inputs.length === 0) return
       yield* options.execute(inputs as any).pipe(
         Effect.provideContext(entries[0].context)
       )

--- a/packages/effect/test/unstable/sql/SqlResolver.test.ts
+++ b/packages/effect/test/unstable/sql/SqlResolver.test.ts
@@ -56,6 +56,25 @@ describe("SqlResolver", () => {
   })
 
   describe("ordered", () => {
+    it.effect("does not execute a batch when every request fails encoding", () =>
+      Effect.gen(function*() {
+        let executions = 0
+        const resolver = SqlResolver.ordered({
+          Request: Schema.Number.check(Schema.isGreaterThan(0)),
+          Result: Schema.String,
+          execute: (inputs) => {
+            executions++
+            return Effect.succeed(inputs.map(String))
+          }
+        })
+
+        const exit = yield* Effect.exit(SqlResolver.request(-1, resolver))
+        yield* Effect.yieldNow
+
+        assert(Exit.isFailure(exit))
+        assert.strictEqual(executions, 0)
+      }))
+
     it.effect("keeps valid results aligned when another request fails encoding", () =>
       Effect.gen(function*() {
         const resolver = SqlResolver.ordered({

--- a/packages/effect/test/unstable/sql/SqlResolver.test.ts
+++ b/packages/effect/test/unstable/sql/SqlResolver.test.ts
@@ -5,6 +5,26 @@ import { SqlResolver } from "effect/unstable/sql"
 
 describe("SqlResolver", () => {
   describe("findById", () => {
+    it.effect("does not execute a batch when every id fails encoding", () =>
+      Effect.gen(function*() {
+        let executions = 0
+        const resolver = SqlResolver.findById({
+          Id: Schema.Number.check(Schema.isGreaterThan(0)),
+          Result: Schema.Struct({ id: Schema.Number }),
+          ResultId: (result) => result.id,
+          execute: (ids) => {
+            executions++
+            return Effect.succeed(ids.map((id) => ({ id })))
+          }
+        })
+
+        const exit = yield* Effect.exit(SqlResolver.request(-1, resolver))
+        yield* Effect.yieldNow
+
+        assert(Exit.isFailure(exit))
+        assert.strictEqual(executions, 0)
+      }))
+
     it.effect("deduplicates requests by id", () =>
       Effect.gen(function*() {
         const batches: Array<Array<number>> = []


### PR DESCRIPTION
## Summary

Both resolvers invoke options.execute(inputs) unconditionally after partitioning. When all requests fail encoding, inputs is [], despite the public callback type being NonEmptyArray.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## SQL findById resolvers invoke NonEmpty callbacks with an empty batch

**Module:** `packages/effect/src/unstable/sql/SqlResolver.ts`  
**Audit ID:** `relsem-sql-empty-id-batch`  
**Severity / confidence:** medium / high

### What happens

Both resolvers invoke options.execute(inputs) unconditionally after partitioning. When all requests fail encoding, inputs is [], despite the public callback type being NonEmptyArray.

### Why it happens

The owning implementation diverges from relation unstable-services-018.

### Expected behavior

ordered.execute and findById.execute receive Arr.NonEmptyArray encoded inputs. Per-request encoding failures complete those requests with SchemaError and must not create an impossible empty execute batch.

### Relevant implementation

These links and excerpts are pinned to audit base `b206fa5d7655c1634c9993410a9203f6616a5ca2`.

- [`packages/effect/src/unstable/sql/SqlResolver.ts:101`](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/effect/src/unstable/sql/SqlResolver.ts#L101)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/sql/SqlResolver.ts:101</code></summary>

```ts
export const ordered = <Req extends Schema.Constraint, Res extends Schema.Constraint, _, E, R>(
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/effect/src/unstable/sql/SqlResolver.ts#L101)

</details>

### Reproduction

```sh
pnpm --filter effect test --run test/unstable/sql/SqlResolver.test.ts -t "does not execute a batch when every id fails encoding"
```

**Observed failure:** Independently rerun; failed at the intended semantic assertion.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm --filter effect test --run test/unstable/sql/SqlResolver.test.ts -t "does not execute a batch when every id fails encoding"
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Reproduction base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Findings: `relsem-sql-empty-id-batch`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-554