### PR TITLE
Fix SQL resolvers executing empty batches

### DIFF
--- a/.changeset/fuzzy-lions-study.md
+++ b/.changeset/fuzzy-lions-study.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Prevent SQL resolvers from executing empty batches when all requests fail encoding.

--- a/.changeset/fuzzy-lions-study.md
+++ b/.changeset/fuzzy-lions-study.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Prevent SQL resolvers from executing empty batches when all requests fail encoding.
+Fix `SqlResolver.findById` failing to complete duplicate requests when id encoding fails, which surfaced as a `RequestResolver did not complete request` defect instead of the underlying `SchemaError`.

--- a/packages/effect/src/unstable/sql/SqlResolver.ts
+++ b/packages/effect/src/unstable/sql/SqlResolver.ts
@@ -376,19 +376,19 @@ const partitionRequestsById = function*<In, A, E, R, InE>(
     }
   }
 
-  let entry!: Request.Entry<SqlRequest<In, A, E, R>>
   const encode = Schema.encodeEffect(schema)
-  const handle = Effect.matchCauseEager({
-    onFailure(cause: Cause.Cause<Schema.SchemaError>) {
-      entry.completeUnsafe(Exit.failCause(cause))
-    },
-    onSuccess(value: InE) {
-      inputs.push(value)
-    }
-  })
-  for (const [, deduplicated] of Array.from(byIdMap)) {
-    entry = deduplicated
-    yield (Effect.provideContext(handle(encode(entry.request.payload)), entry.context) as Effect.Effect<void>)
+  for (const [, entry] of byIdMap) {
+    yield* Effect.provideContext(
+      Effect.matchCauseEager(encode(entry.request.payload), {
+        onFailure(cause) {
+          entry.completeUnsafe(Exit.failCause(cause))
+        },
+        onSuccess(value) {
+          inputs.push(value)
+        }
+      }),
+      entry.context
+    )
   }
 
   return [inputs, byIdMap] as const

--- a/packages/effect/src/unstable/sql/SqlResolver.ts
+++ b/packages/effect/src/unstable/sql/SqlResolver.ts
@@ -122,8 +122,8 @@ export const ordered = <Req extends Schema.Constraint, Res extends Schema.Constr
     key: transactionKey,
     resolver: Effect.fnUntraced(function*(entries) {
       const [inputs, encodedEntries] = yield* partitionRequests(entries, options.Request)
-      if (inputs.length === 0) return
-      const results = yield* options.execute(inputs as any).pipe(
+      if (!Arr.isArrayNonEmpty(inputs)) return
+      const results = yield* options.execute(inputs).pipe(
         Effect.provideContext(entries[0].context)
       )
       if (results.length !== inputs.length) {
@@ -179,9 +179,9 @@ export const grouped = <Req extends Schema.Constraint, Res extends Schema.Constr
     key: transactionKey,
     resolver: Effect.fnUntraced(function*(entries) {
       const [inputs] = yield* partitionRequests(entries, options.Request)
-      if (inputs.length === 0) return
+      if (!Arr.isArrayNonEmpty(inputs)) return
       const resultMap = MutableHashMap.empty<K, Arr.NonEmptyArray<Res["Type"]>>()
-      const results = yield* options.execute(inputs as any).pipe(
+      const results = yield* options.execute(inputs).pipe(
         Effect.provideContext(entries[0].context)
       )
       const decodedResults = yield* decodeResults(results).pipe(
@@ -248,8 +248,8 @@ export const findById = <Id extends Schema.Constraint, Res extends Schema.Constr
     key: transactionKey,
     resolver: Effect.fnUntraced(function*(entries) {
       const [inputs, idMap] = yield* partitionRequestsById(entries, options.Id)
-      if (inputs.length === 0) return
-      const results = yield* options.execute(inputs as any).pipe(
+      if (!Arr.isArrayNonEmpty(inputs)) return
+      const results = yield* options.execute(inputs).pipe(
         Effect.provideContext(entries[0].context)
       )
       const decodedResults = yield* decodeResults(results).pipe(
@@ -302,8 +302,8 @@ const void_ = <Req extends Schema.Constraint, _, E, R>(
     key: transactionKey,
     resolver: Effect.fnUntraced(function*(entries) {
       const [inputs] = yield* partitionRequests(entries, options.Request)
-      if (inputs.length === 0) return
-      yield* options.execute(inputs as any).pipe(
+      if (!Arr.isArrayNonEmpty(inputs)) return
+      yield* options.execute(inputs).pipe(
         Effect.provideContext(entries[0].context)
       )
       for (let i = 0; i < entries.length; i++) {

--- a/packages/effect/src/unstable/sql/SqlResolver.ts
+++ b/packages/effect/src/unstable/sql/SqlResolver.ts
@@ -358,6 +358,24 @@ const partitionRequestsById = function*<In, A, E, R, InE>(
   const len = requests.length
   const inputs = Arr.empty<InE>()
   const byIdMap = MutableHashMap.empty<In, Request.Entry<SqlRequest<In, A, E, R>>>()
+
+  for (let i = 0; i < len; i++) {
+    const entry = requests[i]
+    const existing = MutableHashMap.get(byIdMap, entry.request.payload)
+    if (Option.isSome(existing)) {
+      const previous = existing.value
+      MutableHashMap.set(byIdMap, entry.request.payload, {
+        ...previous,
+        completeUnsafe(exit) {
+          previous.completeUnsafe(exit)
+          entry.completeUnsafe(exit)
+        }
+      })
+    } else {
+      MutableHashMap.set(byIdMap, entry.request.payload, entry)
+    }
+  }
+
   let entry!: Request.Entry<SqlRequest<In, A, E, R>>
   const encode = Schema.encodeEffect(schema)
   const handle = Effect.matchCauseEager({
@@ -368,23 +386,9 @@ const partitionRequestsById = function*<In, A, E, R, InE>(
       inputs.push(value)
     }
   })
-
-  for (let i = 0; i < len; i++) {
-    entry = requests[i]
-    const existing = MutableHashMap.get(byIdMap, entry.request.payload)
-    if (Option.isSome(existing)) {
-      const duplicate = entry
-      MutableHashMap.set(byIdMap, entry.request.payload, {
-        ...existing.value,
-        completeUnsafe(exit) {
-          existing.value.completeUnsafe(exit)
-          duplicate.completeUnsafe(exit)
-        }
-      })
-    } else {
-      yield (Effect.provideContext(handle(encode(entry.request.payload)), entry.context) as Effect.Effect<void>)
-      MutableHashMap.set(byIdMap, entry.request.payload, entry)
-    }
+  for (const [, deduplicated] of Array.from(byIdMap)) {
+    entry = deduplicated
+    yield (Effect.provideContext(handle(encode(entry.request.payload)), entry.context) as Effect.Effect<void>)
   }
 
   return [inputs, byIdMap] as const

--- a/packages/effect/test/unstable/sql/SqlResolver.test.ts
+++ b/packages/effect/test/unstable/sql/SqlResolver.test.ts
@@ -19,10 +19,9 @@ describe("SqlResolver", () => {
           }
         })
 
-        const exit = yield* Effect.exit(SqlResolver.request(-1, resolver))
-        yield* Effect.yieldNow
+        const error = yield* Effect.flip(SqlResolver.request(-1, resolver))
 
-        assert(Exit.isFailure(exit))
+        assert.strictEqual(error._tag, "SchemaError")
         assert.strictEqual(executions, 0)
       }))
   })
@@ -41,11 +40,28 @@ describe("SqlResolver", () => {
           }
         })
 
-        const exit = yield* Effect.exit(SqlResolver.request(-1, resolver))
-        yield* Effect.yieldNow
+        const error = yield* Effect.flip(SqlResolver.request(-1, resolver))
 
-        assert(Exit.isFailure(exit))
+        assert.strictEqual(error._tag, "SchemaError")
         assert.strictEqual(executions, 0)
+      }))
+
+    it.effect("completes duplicate requests when id encoding fails", () =>
+      Effect.gen(function*() {
+        const resolver = SqlResolver.findById({
+          Id: Schema.Number.check(Schema.isGreaterThan(0)),
+          Result: Schema.Struct({ id: Schema.Number }),
+          ResultId: (result) => result.id,
+          execute: (inputs) => Effect.succeed(inputs.map((id) => ({ id })))
+        })
+        const execute = SqlResolver.request(resolver)
+
+        const errors = yield* Effect.all([
+          Effect.flip(execute(-1)),
+          Effect.flip(execute(-1))
+        ], { concurrency: "unbounded" })
+
+        assert.deepStrictEqual(errors.map((error) => error._tag), ["SchemaError", "SchemaError"])
       }))
 
     it.effect("deduplicates requests by id", () =>
@@ -91,10 +107,9 @@ describe("SqlResolver", () => {
           }
         })
 
-        const exit = yield* Effect.exit(SqlResolver.request(-1, resolver))
-        yield* Effect.yieldNow
+        const error = yield* Effect.flip(SqlResolver.request(-1, resolver))
 
-        assert(Exit.isFailure(exit))
+        assert.strictEqual(error._tag, "SchemaError")
         assert.strictEqual(executions, 0)
       }))
 
@@ -129,10 +144,9 @@ describe("SqlResolver", () => {
           }
         })
 
-        const exit = yield* Effect.exit(SqlResolver.request(-1, resolver))
-        yield* Effect.yieldNow
+        const error = yield* Effect.flip(SqlResolver.request(-1, resolver))
 
-        assert(Exit.isFailure(exit))
+        assert.strictEqual(error._tag, "SchemaError")
         assert.strictEqual(executions, 0)
       }))
   })

--- a/packages/effect/test/unstable/sql/SqlResolver.test.ts
+++ b/packages/effect/test/unstable/sql/SqlResolver.test.ts
@@ -4,17 +4,40 @@ import * as Schema from "effect/Schema"
 import { SqlResolver } from "effect/unstable/sql"
 
 describe("SqlResolver", () => {
+  describe("grouped", () => {
+    it.effect("does not execute a batch when every request fails encoding", () =>
+      Effect.gen(function*() {
+        let executions = 0
+        const resolver = SqlResolver.grouped({
+          Request: Schema.Number.check(Schema.isGreaterThan(0)),
+          RequestGroupKey: (request) => request,
+          Result: Schema.Number,
+          ResultGroupKey: (result) => result,
+          execute: (inputs) => {
+            executions++
+            return Effect.succeed(inputs)
+          }
+        })
+
+        const exit = yield* Effect.exit(SqlResolver.request(-1, resolver))
+        yield* Effect.yieldNow
+
+        assert(Exit.isFailure(exit))
+        assert.strictEqual(executions, 0)
+      }))
+  })
+
   describe("findById", () => {
-    it.effect("does not execute a batch when every id fails encoding", () =>
+    it.effect("does not execute a batch when every request fails encoding", () =>
       Effect.gen(function*() {
         let executions = 0
         const resolver = SqlResolver.findById({
           Id: Schema.Number.check(Schema.isGreaterThan(0)),
           Result: Schema.Struct({ id: Schema.Number }),
           ResultId: (result) => result.id,
-          execute: (ids) => {
+          execute: (inputs) => {
             executions++
-            return Effect.succeed(ids.map((id) => ({ id })))
+            return Effect.succeed(inputs.map((id) => ({ id })))
           }
         })
 
@@ -91,6 +114,26 @@ describe("SqlResolver", () => {
         assert(Exit.isFailure(invalid))
         assert(Exit.isSuccess(valid))
         assert.strictEqual(valid.value, "value-2")
+      }))
+  })
+
+  describe("void", () => {
+    it.effect("does not execute a batch when every request fails encoding", () =>
+      Effect.gen(function*() {
+        let executions = 0
+        const resolver = SqlResolver.void({
+          Request: Schema.Number.check(Schema.isGreaterThan(0)),
+          execute: (inputs) => {
+            executions++
+            return Effect.succeed(inputs)
+          }
+        })
+
+        const exit = yield* Effect.exit(SqlResolver.request(-1, resolver))
+        yield* Effect.yieldNow
+
+        assert(Exit.isFailure(exit))
+        assert.strictEqual(executions, 0)
       }))
   })
 })


### PR DESCRIPTION
## Summary

SQL resolver constructors invoked `options.execute(inputs)` after request encoding even when every request failed encoding and `inputs` was empty. This violated the public `Arr.NonEmptyArray` callback contract.

This PR now guards the `ordered`, `grouped`, `findById`, and `void` resolvers against empty encoded batches and adds focused regression coverage for every path.

## SQL resolvers invoke NonEmpty callbacks with an empty batch

**Module:** `packages/effect/src/unstable/sql/SqlResolver.ts`  
**Audit ID:** `relsem-sql-empty-encoded-batch`  
**Severity / confidence:** medium / high

### What happens

Each resolver partitions requests by whether encoding succeeds. Previously, `execute` was invoked unconditionally after partitioning, so an all-invalid batch reached a callback typed to accept only `Arr.NonEmptyArray`.

### Expected behavior

The resolver `execute` callbacks receive only non-empty encoded input batches. Per-request encoding failures complete those requests with `SchemaError` and do not trigger an impossible empty execution.

### Implementation

Each resolver now narrows the encoded inputs with `Arr.isArrayNonEmpty` before invoking `execute`. The existing `SqlResolver.test.ts` covers all-invalid batches for `ordered`, `grouped`, `findById`, and `void`.

### Validation

```sh
pnpm test --run packages/effect/test/unstable/sql/SqlResolver.test.ts
pnpm test --run --project effect
pnpm lint
pnpm check
```

## Audit provenance

- Audit base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Reproduction base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Finding: `relsem-sql-empty-encoded-batch`

Closes EFF-555