### PR TITLE
Fix defecting execution-plan observers replace outcomes and leave events unpaired

### DIFF
--- a/.changeset/quiet-observers-report.md
+++ b/.changeset/quiet-observers-report.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Prevent execution-plan event observer defects from changing attempt outcomes or leaving attempt events unpaired.

--- a/packages/effect/src/internal/executionPlan.ts
+++ b/packages/effect/src/internal/executionPlan.ts
@@ -31,6 +31,7 @@ export const makeEventEmitter = (
 ): EventEmitter => {
   let lastStepIndex = -1
   let stepAttempt = 0
+  const emit = (event: Api.Event<any>) => effect.ignoreCause(onEvent(event))
   return {
     begin: effect.clockWith((clock) =>
       effect.suspend(() => {
@@ -47,7 +48,7 @@ export const makeEventEmitter = (
           startNanos: clock.monotonicTimeNanosUnsafe()
         }
         return effect.as(
-          onEvent({
+          emit({
             _tag: "AttemptStart",
             attempt: state.attempt,
             stepAttempt: state.stepAttempt,
@@ -60,7 +61,7 @@ export const makeEventEmitter = (
     end: (state, exit) =>
       effect.clockWith((clock) => {
         const duration = Duration.nanos(clock.monotonicTimeNanosUnsafe() - state.startNanos)
-        return onEvent(
+        return emit(
           exit._tag === "Success"
             ? {
               _tag: "AttemptSuccess",

--- a/packages/effect/test/ExecutionPlan.test.ts
+++ b/packages/effect/test/ExecutionPlan.test.ts
@@ -240,6 +240,25 @@ describe("ExecutionPlan", () => {
           assertTrue(events[1]._tag === "AttemptSuccess" && Duration.isDuration(events[1].duration))
         }))
 
+      it.effect("observer defects do not change the outcome or leave attempts unpaired", () =>
+        Effect.gen(function*() {
+          const events = Array.empty<string>()
+          const exit = yield* Effect.succeed("source-success").pipe(
+            Effect.withExecutionPlan(ExecutionPlan.make({ provide: Context.empty() }), {
+              onEvent: (event) =>
+                Effect.sync(() => events.push(event._tag)).pipe(
+                  Effect.andThen(event._tag === "AttemptStart" ? Effect.die("observer-defect") : Effect.void)
+                )
+            }),
+            Effect.exit
+          )
+
+          assert.deepStrictEqual(
+            { exit, events },
+            { exit: Exit.succeed("source-success"), events: ["AttemptStart", "AttemptSuccess"] }
+          )
+        }))
+
       it.effect("emits an event pair per attempt within a step", () =>
         Effect.gen(function*() {
           const { events, onEvent } = makeCollector()

--- a/packages/effect/test/ExecutionPlan.test.ts
+++ b/packages/effect/test/ExecutionPlan.test.ts
@@ -247,15 +247,16 @@ describe("ExecutionPlan", () => {
             Effect.withExecutionPlan(ExecutionPlan.make({ provide: Context.empty() }), {
               onEvent: (event) =>
                 Effect.sync(() => events.push(event._tag)).pipe(
-                  Effect.andThen(event._tag === "AttemptStart" ? Effect.die("observer-defect") : Effect.void)
+                  Effect.andThen(Effect.die("observer-defect"))
                 )
             }),
             Effect.exit
           )
 
-          assert.deepStrictEqual(
+          deepStrictEqual(
             { exit, events },
-            { exit: Exit.succeed("source-success"), events: ["AttemptStart", "AttemptSuccess"] }
+            { exit: Exit.succeed("source-success"), events: ["AttemptStart", "AttemptSuccess"] },
+            "observer defects must not affect the source outcome"
           )
         }))
 
@@ -399,6 +400,27 @@ describe("ExecutionPlan", () => {
     })
 
     describe("Stream.withExecutionPlan", () => {
+      it.effect("observer defects do not change the outcome or leave attempts unpaired", () =>
+        Effect.gen(function*() {
+          const events = Array.empty<string>()
+          const exit = yield* Stream.succeed("source-success").pipe(
+            Stream.withExecutionPlan(ExecutionPlan.make({ provide: Context.empty() }), {
+              onEvent: (event) =>
+                Effect.sync(() => events.push(event._tag)).pipe(
+                  Effect.andThen(Effect.die("observer-defect"))
+                )
+            }),
+            Stream.runCollect,
+            Effect.exit
+          )
+
+          deepStrictEqual(
+            { exit, events },
+            { exit: Exit.succeed(["source-success"]), events: ["AttemptStart", "AttemptSuccess"] },
+            "observer defects must not affect the source outcome"
+          )
+        }))
+
       it.effect("emits events for each step attempt", () =>
         Effect.gen(function*() {
           const { events, onEvent } = makeCollector()


### PR DESCRIPTION
Closes EFF-556

## Summary

- Treat execution-plan event observers as best-effort so their defects cannot replace an attempt's source outcome.
- Preserve paired `AttemptStart` and terminal events for both `Effect.withExecutionPlan` and `Stream.withExecutionPlan`.
- Add the matching Stream regression test and a patch changeset for `effect`.

## Validation

```sh
pnpm test --run packages/effect/test/ExecutionPlan.test.ts
pnpm lint
pnpm check
```

## Audit provenance

- Audit ID: `relsem-execution-plan-event-pairing`
- Audit base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
