### PR TITLE
Fix bun fileWebResponse ignores range options

### DIFF
--- a/.changeset/fuzzy-files-slice.md
+++ b/.changeset/fuzzy-files-slice.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-bun": patch
+---
+
+Honor offset and byte-count options in Bun Web File responses.

--- a/packages/platform-bun/src/BunHttpPlatform.ts
+++ b/packages/platform-bun/src/BunHttpPlatform.ts
@@ -43,8 +43,13 @@ const make: Effect.Effect<
     }
     return Response.raw(file, { headers, status, statusText })
   },
-  fileWebResponse(file, status, statusText, headers, _options) {
-    return Response.raw(file, { headers, status, statusText })
+  fileWebResponse(file, status, statusText, headers, options) {
+    const start = Number(options?.offset ?? 0)
+    const end = options?.bytesToRead !== undefined ? start + Number(options.bytesToRead) : undefined
+    const body = start > 0 || end !== undefined
+      ? (file as File).slice(start, end, file.type)
+      : file
+    return Response.raw(body, { headers, status, statusText })
   }
 })
 

--- a/packages/platform-bun/test/BunHttpPlatform.test.ts
+++ b/packages/platform-bun/test/BunHttpPlatform.test.ts
@@ -1,0 +1,25 @@
+import * as BunHttpPlatform from "@effect/platform-bun/BunHttpPlatform"
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import type * as HttpBody from "effect/unstable/http/HttpBody"
+import * as HttpPlatform from "effect/unstable/http/HttpPlatform"
+
+const readBody = (body: HttpBody.HttpBody) => {
+  assert.strictEqual(body._tag, "Raw")
+  return Effect.promise(() => new Response((body as HttpBody.Raw).body as BodyInit).text())
+}
+
+describe("BunHttpPlatform", () => {
+  it.effect("fileWebResponse honors offset and bytesToRead including zero", () =>
+    Effect.gen(function*() {
+      const platform = yield* HttpPlatform.HttpPlatform
+      const file = new File(["abcd"], "file.txt", { type: "text/plain", lastModified: 0 })
+      const sliced = yield* platform.fileWebResponse(file, { offset: 1, bytesToRead: 2 })
+      const empty = yield* platform.fileWebResponse(file, { offset: 1, bytesToRead: 0 })
+
+      assert.deepStrictEqual(
+        { sliced: yield* readBody(sliced.body), empty: yield* readBody(empty.body) },
+        { sliced: "bc", empty: "" }
+      )
+    }).pipe(Effect.provide(BunHttpPlatform.layer)))
+})


### PR DESCRIPTION
## Summary

- Make `BunHttpPlatform.fileWebResponse` honor `offset` and `bytesToRead` by slicing the Web `File` before creating the raw response.
- Preserve the file media type when creating a sliced body.
- Add focused regression coverage for partial and zero-byte ranges.
- Add a patch changeset for `@effect/platform-bun`.

Closes EFF-557

## Testing

```sh
bun ./node_modules/vitest/vitest.mjs --run packages/platform-bun/test/BunHttpPlatform.test.ts -t "fileWebResponse honors offset and bytesToRead including zero"
bun ./node_modules/vitest/vitest.mjs --run packages/platform-bun/test
pnpm lint
pnpm check
```

## Audit provenance

- Audit base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Reproduction base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Finding: `relsem-bun-fileweb-range`
