### PR TITLE
Fix deno fileWebResponse ignores range options

### DIFF
--- a/.changeset/eff-558-deno-file-web-range.md
+++ b/.changeset/eff-558-deno-file-web-range.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-deno": patch
+---
+
+Honor `offset` and `bytesToRead` when creating Deno Web file responses.

--- a/packages/platform-deno/src/DenoHttpPlatform.ts
+++ b/packages/platform-deno/src/DenoHttpPlatform.ts
@@ -67,12 +67,29 @@ export const make = Platform.make({
       statusText
     })
   },
-  fileWebResponse(file, status, statusText, headers, _options) {
-    return Response.raw(file, {
+  fileWebResponse(file, status, statusText, headers, options) {
+    const offset = Number(options?.offset ?? 0)
+    const available = Math.max(0, file.size - offset)
+    const contentLength = options?.bytesToRead === undefined
+      ? available
+      : Math.min(available, Math.max(0, Number(options.bytesToRead)))
+    let body: typeof file | ReadableStream<Uint8Array> = file
+    if (contentLength === 0) {
+      body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.close()
+        }
+      })
+    } else if (offset > 0 || options?.bytesToRead !== undefined) {
+      body = (file.stream() as ReadableStream<Uint8Array>).pipeThrough(
+        new ByteSliceStream(offset, offset + contentLength - 1)
+      )
+    }
+    return Response.raw(body, {
       headers: {
         ...headers,
         "content-type": file.type,
-        "content-length": file.size.toString()
+        "content-length": contentLength.toString()
       },
       status,
       statusText

--- a/packages/platform-deno/test/DenoHttpPlatform.test.ts
+++ b/packages/platform-deno/test/DenoHttpPlatform.test.ts
@@ -8,7 +8,30 @@ const fixture = `${import.meta.dirname}/fixtures/text.txt`
 
 const readStream = (stream: ReadableStream<Uint8Array>) => Effect.promise(() => new globalThis.Response(stream).text())
 
+const readBody = (body: HttpBody.HttpBody) => {
+  assert.strictEqual(body._tag, "Raw")
+  return Effect.promise(() => new Response((body as HttpBody.Raw).body as BodyInit).text())
+}
+
 describe("DenoHttpPlatform", () => {
+  it.effect("fileWebResponse honors offset and bytesToRead including zero", () =>
+    Effect.gen(function*() {
+      const platform = yield* HttpPlatform.HttpPlatform
+      const file = new File(["abcd"], "file.txt", { type: "text/plain", lastModified: 0 })
+      const sliced = yield* platform.fileWebResponse(file, { offset: 1, bytesToRead: 2 })
+      const empty = yield* platform.fileWebResponse(file, { offset: 1, bytesToRead: 0 })
+
+      assert.deepStrictEqual(
+        {
+          slicedLength: sliced.headers["content-length"],
+          slicedBody: yield* readBody(sliced.body),
+          emptyLength: empty.headers["content-length"],
+          emptyBody: yield* readBody(empty.body)
+        },
+        { slicedLength: "2", slicedBody: "bc", emptyLength: "0", emptyBody: "" }
+      )
+    }).pipe(Effect.provide(DenoHttpPlatform.layer)))
+
   it.effect("fileResponse reads exact bytesToRead", () =>
     Effect.gen(function*() {
       const platform = yield* HttpPlatform.HttpPlatform


### PR DESCRIPTION
## Summary

Deno's `HttpPlatform` backend returns the full Web File even when `offset` and `bytesToRead` request a slice.

This PR is intentionally scoped to the Deno backend; Bun and Node require separate fixes.

> [!IMPORTANT]
> This PR includes both the focused regression test and the Deno implementation fix.

## Deno fileWebResponse ignores range options

**Module:** `packages/platform-deno/src/DenoHttpPlatform.ts`  
**Audit ID:** `relsem-deno-fileweb-range`  
**Severity / confidence:** high / high

### What happens

Every concrete non-portable HttpPlatform backend returns the full Web File even when offset and bytesToRead request a slice.

### Why it happens

The owning implementation diverges from relation http-platform-011.

### Expected behavior

HttpPlatform.fileWebResponse publicly accepts offset, bytesToRead, and chunkSize, and the portable implementation documents and implements byte-range selection.

### Relevant implementation

These links and excerpts are pinned to audit base `b206fa5d7655c1634c9993410a9203f6616a5ca2`.

- [`packages/platform-deno/src/DenoHttpPlatform.ts:1`](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/platform-deno/src/DenoHttpPlatform.ts#L1)

<details>
<summary>View problematic code at <code>packages/platform-deno/src/DenoHttpPlatform.ts:1</code></summary>

```ts
/**
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/platform-deno/src/DenoHttpPlatform.ts#L1)

</details>

### Reproduction

```sh
deno run -A npm:vitest --run packages/platform-deno/test/DenoHttpPlatform.test.ts -t "fileWebResponse honors offset and bytesToRead including zero"
```

**Validation:** The regression failed against the original implementation, returning the full `abcd` body and length `4`; it passes with this fix.

## Validation

- Focused Deno regression: passed
- Full `@effect/platform-deno` suite: 207 passed, 11 skipped
- Deno package type check: passed
- Repository lint and TypeScript check: passed

## Audit provenance

- Audit base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Reproduction base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Findings: `relsem-deno-fileweb-range`
- Initial patch: focused reproduction tests; implementation fix added in `446fc728ac`

Closes EFF-558