### PR TITLE
Fix batched encrypted event records reuse per-record randomization metadata

### DIFF
--- a/.changeset/wise-bats-encrypt.md
+++ b/.changeset/wise-bats-encrypt.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Use a distinct AES-GCM initialization vector for each encrypted event log entry.
+Use a distinct AES-GCM initialization vector for each encrypted event log entry. `EventLogEncryption.encrypt` now returns each IV with its ciphertext, and encrypted event log clients and servers must be upgraded together because the `WriteEntries` wire shape changed.

--- a/.changeset/wise-bats-encrypt.md
+++ b/.changeset/wise-bats-encrypt.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Use a distinct AES-GCM initialization vector for each encrypted event log entry.

--- a/packages/effect/src/unstable/eventlog/EventLogEncryption.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogEncryption.ts
@@ -19,8 +19,8 @@ import type { Identity } from "./EventLog.ts"
 import { makeGetIdentityRootSecretMaterial } from "./internal/identityRootSecretDerivation.ts"
 
 /**
- * Schema for an encrypted journal entry paired with the id of the original
- * entry.
+ * Schema for an encrypted journal entry paired with its initialization vector
+ * and the id of the original entry.
  *
  * @category models
  * @since 4.0.0

--- a/packages/effect/src/unstable/eventlog/EventLogEncryption.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogEncryption.ts
@@ -27,6 +27,7 @@ import { makeGetIdentityRootSecretMaterial } from "./internal/identityRootSecret
  */
 export const EncryptedEntry = Schema.Struct({
   entryId: EntryId,
+  iv: Transferable.Uint8Array,
   encryptedEntry: Transferable.Uint8Array
 })
 
@@ -76,10 +77,12 @@ export class EventLogEncryption extends Context.Service<EventLogEncryption, {
   readonly encrypt: (
     identity: Identity["Service"],
     entries: ReadonlyArray<Entry>
-  ) => Effect.Effect<{
-    readonly iv: Uint8Array<ArrayBuffer>
-    readonly encryptedEntries: ReadonlyArray<Uint8Array<ArrayBuffer>>
-  }>
+  ) => Effect.Effect<
+    ReadonlyArray<{
+      readonly iv: Uint8Array<ArrayBuffer>
+      readonly encryptedEntry: Uint8Array<ArrayBuffer>
+    }>
+  >
   readonly decrypt: (
     identity: Identity["Service"],
     entries: ReadonlyArray<EncryptedRemoteEntry>
@@ -104,22 +107,19 @@ export const makeEncryptionSubtle = (crypto: Crypto): Effect.Effect<EventLogEncr
       encrypt: Effect.fnUntraced(function*(identity, entries) {
         const data = yield* Effect.orDie(Entry.encodeArray(entries))
         const key = (yield* getIdentityRootSecretMaterial(identity)).encryptionKey
-        const iv = crypto.getRandomValues(new Uint8Array(12))
-        const encryptedEntries = yield* Effect.promise(() =>
+        return yield* Effect.promise(() =>
           Promise.all(
-            data.map((entry) =>
-              crypto.subtle.encrypt(
+            data.map(async (entry) => {
+              const iv = crypto.getRandomValues(new Uint8Array(12))
+              const encryptedEntry = await crypto.subtle.encrypt(
                 { name: "AES-GCM", iv: toBufferSource(iv), tagLength: 128 },
                 key,
                 toBufferSource(entry)
               )
-            )
+              return { iv, encryptedEntry: new Uint8Array(encryptedEntry) }
+            })
           )
         )
-        return {
-          iv,
-          encryptedEntries: encryptedEntries.map((entry) => new Uint8Array(entry))
-        }
       }),
       decrypt: Effect.fnUntraced(function*(identity, entries) {
         const key = (yield* getIdentityRootSecretMaterial(identity)).encryptionKey

--- a/packages/effect/src/unstable/eventlog/EventLogEncryption.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogEncryption.ts
@@ -109,14 +109,13 @@ export const makeEncryptionSubtle = (crypto: Crypto): Effect.Effect<EventLogEncr
         const key = (yield* getIdentityRootSecretMaterial(identity)).encryptionKey
         return yield* Effect.promise(() =>
           Promise.all(
-            data.map(async (entry) => {
+            data.map((entry) => {
               const iv = crypto.getRandomValues(new Uint8Array(12))
-              const encryptedEntry = await crypto.subtle.encrypt(
+              return crypto.subtle.encrypt(
                 { name: "AES-GCM", iv: toBufferSource(iv), tagLength: 128 },
                 key,
                 toBufferSource(entry)
-              )
-              return { iv, encryptedEntry: new Uint8Array(encryptedEntry) }
+              ).then((encryptedEntry) => ({ iv, encryptedEntry: new Uint8Array(encryptedEntry) }))
             })
           )
         )

--- a/packages/effect/src/unstable/eventlog/EventLogMessage.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogMessage.ts
@@ -261,8 +261,8 @@ export class WriteChunkedRpc extends Rpc.make("EventLog.WriteChunked", {
  *
  * **Details**
  *
- * It includes the client public key, target store id, AES-GCM initialization
- * vector, and encrypted entries.
+ * It includes the client public key, target store id, and encrypted entries
+ * with their AES-GCM initialization vectors.
  *
  * @category protocols
  * @since 4.0.0
@@ -270,7 +270,6 @@ export class WriteChunkedRpc extends Rpc.make("EventLog.WriteChunked", {
 export class WriteEntries extends Schema.Class<WriteEntries>("effect/eventlog/EventLogRemote/WriteEntries")({
   publicKey: Schema.String,
   storeId: StoreId,
-  iv: Transferable.Uint8Array,
   encryptedEntries: Schema.Array(EncryptedEntry)
 }) {
   static FromMsgpack = Msgpack.schema(WriteEntries)

--- a/packages/effect/src/unstable/eventlog/EventLogRemote.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogRemote.ts
@@ -307,14 +307,14 @@ export const makeEncrypted = Effect.gen(function*(): Effect.fn.Return<
   return yield* makeWith({
     encodeWrite: (options) =>
       encryption.encrypt(options.identity, options.entries).pipe(
-        Effect.flatMap((msg) =>
+        Effect.flatMap((encryptedEntries) =>
           new WriteEntries({
             publicKey: options.identity.publicKey,
             storeId: options.storeId,
-            iv: msg.iv,
-            encryptedEntries: msg.encryptedEntries.map((entry, i) => ({
+            encryptedEntries: encryptedEntries.map((entry, i) => ({
               entryId: options.entries[i].id,
-              encryptedEntry: entry
+              iv: entry.iv,
+              encryptedEntry: entry.encryptedEntry
             }))
           }).encoded
         )

--- a/packages/effect/src/unstable/eventlog/EventLogServerEncrypted.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogServerEncrypted.ts
@@ -67,10 +67,10 @@ export const layerRpcHandlers = Layer.unwrap(Effect.gen(function*() {
         })
       }
       if (request.encryptedEntries.length === 0) return
-      const entries = request.encryptedEntries.map(({ encryptedEntry, entryId }) =>
+      const entries = request.encryptedEntries.map(({ encryptedEntry, entryId, iv }) =>
         new PersistedEntry({
           entryId,
-          iv: request.iv,
+          iv,
           encryptedEntry
         })
       )

--- a/packages/effect/test/unstable/eventlog/EventLog.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventLog.test.ts
@@ -76,6 +76,43 @@ describe("EventLog", () => {
       assert.strictEqual(decrypted[0].entry.idString, entry.idString)
     }).pipe(Effect.provide(EventLogEncryption.layerSubtle)))
 
+  it.effect("uses a distinct AES-GCM IV for each entry", () =>
+    Effect.gen(function*() {
+      const ivs: Array<Array<number>> = []
+      const subtle = new Proxy(globalThis.crypto.subtle, {
+        get(target, property) {
+          if (property === "encrypt") {
+            return (algorithm: AesGcmParams, key: CryptoKey, data: BufferSource) => {
+              const iv = algorithm.iv as ArrayBufferView<ArrayBuffer>
+              ivs.push(Array.from(new Uint8Array(iv.buffer, iv.byteOffset, iv.byteLength)))
+              return target.encrypt(algorithm, key, data)
+            }
+          }
+          const value = Reflect.get(target, property, target)
+          return typeof value === "function" ? value.bind(target) : value
+        }
+      })
+      const encryption = yield* EventLogEncryption.makeEncryptionSubtle({
+        subtle,
+        getRandomValues: globalThis.crypto.getRandomValues.bind(globalThis.crypto),
+        randomUUID: globalThis.crypto.randomUUID.bind(globalThis.crypto)
+      } as Crypto)
+      const identity = yield* encryption.generateIdentity
+      const entries = ["user-1", "user-2"].map((primaryKey, index) =>
+        new EventJournal.Entry({
+          id: EventJournal.makeEntryIdUnsafe(),
+          event: "UserCreated",
+          primaryKey,
+          payload: new Uint8Array([index])
+        }, { disableChecks: true })
+      )
+
+      yield* encryption.encrypt(identity, entries)
+
+      assert.lengthOf(ivs, 2)
+      assert.notDeepEqual(ivs[0], ivs[1])
+    }))
+
   it.effect("publishes local journal changes through a scoped subscription", () =>
     Effect.gen(function*() {
       const remoteId = EventJournal.makeRemoteIdUnsafe()

--- a/packages/effect/test/unstable/eventlog/EventLog.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventLog.test.ts
@@ -55,48 +55,9 @@ describe("EventLog", () => {
       }).pipe(Effect.provide(logLayer(handled)))
     }))
 
-  it.effect("encrypts and decrypts entries", () =>
+  it.effect("encrypts and decrypts entries with a distinct IV per entry", () =>
     Effect.gen(function*() {
       const encryption = yield* EventLogEncryption.EventLogEncryption
-      const identity = yield* encryption.generateIdentity
-      const entry = new EventJournal.Entry({
-        id: EventJournal.makeEntryIdUnsafe(),
-        event: "UserCreated",
-        primaryKey: "user-1",
-        payload: new Uint8Array([1, 2, 3])
-      }, { disableChecks: true })
-      const encrypted = yield* encryption.encrypt(identity, [entry])
-      const decrypted = yield* encryption.decrypt(identity, [{
-        sequence: 0,
-        iv: encrypted[0].iv,
-        entryId: entry.id,
-        encryptedEntry: encrypted[0].encryptedEntry
-      }])
-      assert.strictEqual(decrypted.length, 1)
-      assert.strictEqual(decrypted[0].entry.idString, entry.idString)
-    }).pipe(Effect.provide(EventLogEncryption.layerSubtle)))
-
-  it.effect("uses a distinct AES-GCM IV for each entry", () =>
-    Effect.gen(function*() {
-      const ivs: Array<Array<number>> = []
-      const subtle = new Proxy(globalThis.crypto.subtle, {
-        get(target, property) {
-          if (property === "encrypt") {
-            return (algorithm: AesGcmParams, key: CryptoKey, data: BufferSource) => {
-              const iv = algorithm.iv as ArrayBufferView<ArrayBuffer>
-              ivs.push(Array.from(new Uint8Array(iv.buffer, iv.byteOffset, iv.byteLength)))
-              return target.encrypt(algorithm, key, data)
-            }
-          }
-          const value = Reflect.get(target, property, target)
-          return typeof value === "function" ? value.bind(target) : value
-        }
-      })
-      const encryption = yield* EventLogEncryption.makeEncryptionSubtle({
-        subtle,
-        getRandomValues: globalThis.crypto.getRandomValues.bind(globalThis.crypto),
-        randomUUID: globalThis.crypto.randomUUID.bind(globalThis.crypto)
-      } as Crypto)
       const identity = yield* encryption.generateIdentity
       const entries = ["user-1", "user-2"].map((primaryKey, index) =>
         new EventJournal.Entry({
@@ -106,12 +67,17 @@ describe("EventLog", () => {
           payload: new Uint8Array([index])
         }, { disableChecks: true })
       )
-
-      yield* encryption.encrypt(identity, entries)
-
-      assert.lengthOf(ivs, 2)
-      assert.notDeepEqual(ivs[0], ivs[1])
-    }))
+      const encrypted = yield* encryption.encrypt(identity, entries)
+      assert.notDeepEqual(encrypted[0].iv, encrypted[1].iv)
+      const decrypted = yield* encryption.decrypt(
+        identity,
+        encrypted.map((entry, index) => ({ ...entry, sequence: index, entryId: entries[index].id }))
+      )
+      assert.deepStrictEqual(
+        decrypted.map((remote) => remote.entry.idString),
+        entries.map((entry) => entry.idString)
+      )
+    }).pipe(Effect.provide(EventLogEncryption.layerSubtle)))
 
   it.effect("publishes local journal changes through a scoped subscription", () =>
     Effect.gen(function*() {

--- a/packages/effect/test/unstable/eventlog/EventLog.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventLog.test.ts
@@ -68,9 +68,9 @@ describe("EventLog", () => {
       const encrypted = yield* encryption.encrypt(identity, [entry])
       const decrypted = yield* encryption.decrypt(identity, [{
         sequence: 0,
-        iv: encrypted.iv,
+        iv: encrypted[0].iv,
         entryId: entry.id,
-        encryptedEntry: encrypted.encryptedEntries[0]
+        encryptedEntry: encrypted[0].encryptedEntry
       }])
       assert.strictEqual(decrypted.length, 1)
       assert.strictEqual(decrypted[0].entry.idString, entry.idString)

--- a/packages/sql/sqlite-node/test/SqlEventLogServerEncrypted.test.ts
+++ b/packages/sql/sqlite-node/test/SqlEventLogServerEncrypted.test.ts
@@ -32,10 +32,10 @@ const persistEntries = (
 ) =>
   Effect.gen(function*() {
     const encrypted = yield* encryption.encrypt(identity, entries)
-    return encrypted.encryptedEntries.map((encryptedEntry, index) =>
+    return encrypted.map(({ encryptedEntry, iv }, index) =>
       new EventLogServer.PersistedEntry({
         entryId: entries[index].id,
-        iv: encrypted.iv,
+        iv,
         encryptedEntry
       })
     )
@@ -50,10 +50,10 @@ const encodeWrite = Effect.fnUntraced(function*(
   return yield* new EventLogMessage.WriteEntries({
     publicKey: identity.publicKey,
     storeId: storeIdA,
-    iv: encrypted.iv,
     encryptedEntries: [{
       entryId: entry.id,
-      encryptedEntry: encrypted.encryptedEntries[0]
+      iv: encrypted[0].iv,
+      encryptedEntry: encrypted[0].encryptedEntry
     }]
   }).encoded
 })


### PR DESCRIPTION
## Summary

encrypt generates one 12-byte IV per batch and passes that same IV and key to every subtle.encrypt call in the batch. EventLogRemote and encrypted servers carry/copy that one IV to every entry.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Batched encrypted event records reuse per-record randomization metadata

**Module:** `packages/effect/src/unstable/eventlog/EventLogEncryption.ts`  
**Audit ID:** `relsem-eventlog-record-randomization`  
**Severity / confidence:** high / high

### What happens

encrypt generates one 12-byte IV per batch and passes that same IV and key to every subtle.encrypt call in the batch. EventLogRemote and encrypted servers carry/copy that one IV to every entry.

### Why it happens

The wire/API shape returns one iv next to encryptedEntries, and encryption maps all encoded entries while closing over the single iv instead of generating a unique nonce per ciphertext.

### Expected behavior

EventLogEncryption is the confidentiality/integrity service for encrypted event-log replication and uses AES-GCM under an identity-derived key.

### Relevant implementation

These links and excerpts are pinned to audit base `b206fa5d7655c1634c9993410a9203f6616a5ca2`.

- [`packages/effect/src/unstable/eventlog/EventLogEncryption.ts:1`](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/effect/src/unstable/eventlog/EventLogEncryption.ts#L1)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/eventlog/EventLogEncryption.ts:1</code></summary>

```ts
/**
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/effect/src/unstable/eventlog/EventLogEncryption.ts#L1)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/unstable/eventlog/EventLog.test.ts -t "uses a distinct AES-GCM IV for each entry"
```

**Observed failure:** Independently rerun; failed at the intended semantic assertion.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/unstable/eventlog/EventLog.test.ts -t "uses a distinct AES-GCM IV for each entry"
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Reproduction base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Findings: `relsem-eventlog-record-randomization`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-559