### PR TITLE
Fix effect.result and Effect.option erase non-typed reasons from mixed Causes

### DIFF
--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -255,6 +255,24 @@ describe("Effect", () => {
       ))
   })
 
+  it.effect("result and option preserve defects and interruptions in mixed causes", () =>
+    Effect.gen(function*() {
+      const causes = [
+        Cause.combine(Cause.fail("typed"), Cause.die("defect")),
+        Cause.combine(Cause.fail("typed"), Cause.interrupt(99))
+      ]
+      const observed = yield* Effect.forEach(causes, (cause) =>
+        Effect.all([
+          Effect.failCause(cause).pipe(Effect.result, Effect.exit),
+          Effect.failCause(cause).pipe(Effect.option, Effect.exit)
+        ]))
+
+      assert.deepStrictEqual<unknown>(
+        observed,
+        causes.map((cause) => [Exit.failCause(cause), Exit.failCause(cause)])
+      )
+    }))
+
   describe("try", () => {
     it.effect("succeeds with the returned value in direct-thunk form", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Summary

For Fail(typed)+Die(defect), result produced Exit.Success(Result.Failure(typed)) and option produced Exit.Success(Option.None). For Fail(typed)+Interrupt(99), the same successful projections occurred. In all four outcomes the Die or Interrupt reason was absent.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Effect.result and Effect.option erase non-typed reasons from mixed Causes

**Module:** `packages/effect/src/Effect.ts`  
**Audit ID:** `relsem-effect-result-mixed-cause`  
**Severity / confidence:** high / high

### What happens

For Fail(typed)+Die(defect), result produced Exit.Success(Result.Failure(typed)) and option produced Exit.Success(Option.None). For Fail(typed)+Interrupt(99), the same successful projections occurred. In all four outcomes the Die or Interrupt reason was absent.

### Why it happens

matchEffect treats the presence of any Fail reason as a wholly recoverable failure. It passes only fail.error to the handler and discards the original Cause, including sibling Die and Interrupt reasons.

### Expected behavior

result and option may capture typed recoverable failures as data, but coexisting defects and interruptions must remain effect failures; exit must retain the complete Cause.

### Relevant implementation

These links and excerpts are pinned to audit base `b206fa5d7655c1634c9993410a9203f6616a5ca2`.

- [`packages/effect/src/Effect.ts:1`](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/effect/src/Effect.ts#L1)

<details>
<summary>View problematic code at <code>packages/effect/src/Effect.ts:1</code></summary>

```ts
/**
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/effect/src/Effect.ts#L1)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/Effect.test.ts -t "result and option preserve defects and interruptions in mixed causes"
```

**Observed failure:** Independently rerun; failed at the intended semantic assertion.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/Effect.test.ts -t "result and option preserve defects and interruptions in mixed causes"
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Reproduction base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Findings: `relsem-effect-result-mixed-cause`
- Initial patch: focused reproduction tests; implementation fix pending