### PR TITLE
Fix openRouter streamed citation end offsets overwrite start offsets

### DIFF
--- a/.changeset/fair-citations-stream.md
+++ b/.changeset/fair-citations-stream.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openrouter": patch
+---
+
+Preserve start and end offsets for streamed OpenRouter citations.

--- a/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
+++ b/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
@@ -1361,7 +1361,7 @@ const makeStreamResponse = Effect.fnUntraced(
                         ? { startIndex: annotation.url_citation.start_index }
                         : undefined),
                       ...(Predicate.isNotUndefined(annotation.url_citation.end_index)
-                        ? { startIndex: annotation.url_citation.end_index }
+                        ? { endIndex: annotation.url_citation.end_index }
                         : undefined)
                     }
                   }

--- a/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
+++ b/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
@@ -344,10 +344,13 @@ const makeStreamTestLayer = (events: ReadonlyArray<unknown>) => {
   const httpClient = HttpClient.makeWith(
     Effect.fnUntraced(function*(requestEffect) {
       const request = yield* requestEffect
-      return HttpClientResponse.fromWeb(request, new Response(body, {
-        status: 200,
-        headers: { "content-type": "text/event-stream" }
-      }))
+      return HttpClientResponse.fromWeb(
+        request,
+        new Response(body, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" }
+        })
+      )
     }),
     Effect.succeed as HttpClient.HttpClient.Preprocess<HttpClientError.HttpClientError, never>
   )

--- a/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
+++ b/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
@@ -1,7 +1,7 @@
 import { Generated, OpenRouterClient, OpenRouterLanguageModel } from "@effect/ai-openrouter"
 import { assert, describe, it } from "@effect/vitest"
 import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
-import { Array, Context, Effect, Layer, Redacted, Ref, Schema } from "effect"
+import { Array, Context, Effect, Layer, Redacted, Ref, Schema, Stream } from "effect"
 import { LanguageModel, Prompt, Tool, Toolkit } from "effect/unstable/ai"
 import { HttpClient, type HttpClientError, type HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
@@ -209,6 +209,44 @@ describe("OpenRouterLanguageModel", () => {
         }).pipe(Effect.provide(makeTestLayer())))
     })
   })
+
+  describe("streamText", () => {
+    it.effect("preserves streamed citation start and end indexes", () =>
+      Effect.gen(function*() {
+        const parts = yield* LanguageModel.streamText({ prompt: "cite a source" }).pipe(
+          Stream.runCollect,
+          Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini")),
+          Effect.provide(makeStreamTestLayer([{
+            id: "response-1",
+            object: "chat.completion.chunk",
+            model: "openai/gpt-4o-mini",
+            created: 1,
+            choices: [{
+              index: 0,
+              delta: {
+                annotations: [{
+                  type: "url_citation",
+                  url_citation: {
+                    url: "https://example.com/source",
+                    title: "source",
+                    start_index: 2,
+                    end_index: 9
+                  }
+                }]
+              }
+            }]
+          }]))
+        )
+
+        const source = globalThis.Array.from(parts).find((part) => part.type === "source")
+        assert.isDefined(source)
+        if (source?.type === "source") {
+          assert.deepStrictEqual(source.metadata, {
+            openrouter: { startIndex: 2, endIndex: 9 }
+          })
+        }
+      }))
+  })
 })
 
 // =============================================================================
@@ -300,3 +338,20 @@ const getRequestBody = (request: HttpClientRequest.HttpClientRequest) =>
     }
     return yield* Effect.die(new Error("Expected Uint8Array body"))
   })
+
+const makeStreamTestLayer = (events: ReadonlyArray<unknown>) => {
+  const body = events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("") + "data: [DONE]\n\n"
+  const httpClient = HttpClient.makeWith(
+    Effect.fnUntraced(function*(requestEffect) {
+      const request = yield* requestEffect
+      return HttpClientResponse.fromWeb(request, new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" }
+      }))
+    }),
+    Effect.succeed as HttpClient.HttpClient.Preprocess<HttpClientError.HttpClientError, never>
+  )
+  return OpenRouterClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+    Layer.provide(Layer.succeed(HttpClient.HttpClient, httpClient))
+  )
+}


### PR DESCRIPTION
## Summary

The stream output contains metadata.openrouter.startIndex = 9 and no endIndex; non-stream conversion correctly emits startIndex = 2 and endIndex = 9.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## OpenRouter streamed citation end offsets overwrite start offsets

**Module:** `packages/ai/openrouter/src/OpenRouterLanguageModel.ts`  
**Audit ID:** `relsem-openrouter-citation-end-index`  
**Severity / confidence:** medium / high

### What happens

The stream output contains metadata.openrouter.startIndex = 9 and no endIndex; non-stream conversion correctly emits startIndex = 2 and endIndex = 9.

### Why it happens

The end_index conditional creates another startIndex property instead of endIndex; object spread order overwrites the real start value.

### Expected behavior

Equivalent citations preserve distinct startIndex and endIndex fields under metadata.openrouter in both modes.

### Relevant implementation

These links and excerpts are pinned to audit base `b206fa5d7655c1634c9993410a9203f6616a5ca2`.

- [`packages/ai/openrouter/src/OpenRouterLanguageModel.ts:1`](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/ai/openrouter/src/OpenRouterLanguageModel.ts#L1)

<details>
<summary>View problematic code at <code>packages/ai/openrouter/src/OpenRouterLanguageModel.ts:1</code></summary>

```ts
/**
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/ai/openrouter/src/OpenRouterLanguageModel.ts#L1)

</details>

### Reproduction

```sh
pnpm test --run packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts -t "preserves streamed citation start and end indexes"
```

**Observed failure:** Independently rerun; failed at the intended semantic assertion.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts -t "preserves streamed citation start and end indexes"
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Reproduction base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Findings: `relsem-openrouter-citation-end-index`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-562