### PR TITLE
Correct max output tokens for Claude Opus 4.6, 4.7, 4.8 and Sonnet 4.6

### DIFF
--- a/.changeset/anthropic-stale-max-output-tokens.md
+++ b/.changeset/anthropic-stale-max-output-tokens.md
@@ -1,0 +1,7 @@
+---
+"@effect/ai-anthropic": patch
+---
+
+Correct the maximum output tokens for Claude Opus 4.6, 4.7, 4.8 and Sonnet 4.6.
+
+These models were grouped with the 4.5 family at 64000 output tokens, half of the 128000 the API actually allows, so requests defaulted to a cap far below the model's real limit. The 4.5 models keep 64000, which is correct for them.

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -2984,13 +2984,20 @@ interface ModelCapabilities {
  */
 const getModelCapabilities = (modelId: string): ModelCapabilities => {
   if (
-    modelId.includes("claude-sonnet-4-5") ||
-    modelId.includes("claude-opus-4-5") ||
-    modelId.includes("claude-haiku-4-5") ||
     modelId.includes("claude-opus-4-6") ||
     modelId.includes("claude-sonnet-4-6") ||
     modelId.includes("claude-opus-4-7") ||
     modelId.includes("claude-opus-4-8")
+  ) {
+    return {
+      maxOutputTokens: 128000,
+      supportsStructuredOutput: true,
+      isKnownModel: true
+    }
+  } else if (
+    modelId.includes("claude-sonnet-4-5") ||
+    modelId.includes("claude-opus-4-5") ||
+    modelId.includes("claude-haiku-4-5")
   ) {
     return {
       maxOutputTokens: 64000,


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

These models share the 4.5 family's 64000 token entry in `getModelCapabilities`, but each allows 128000, so requests default to half the model's real limit.

Anthropic's [models overview](https://platform.claude.com/docs/en/about-claude/models/overview) lists "Max output: 128k tokens" for Opus 4.6, 4.7, 4.8 and Sonnet 4.6, against 64k for Sonnet 4.5 and Opus 4.5. The API says the same when a request exceeds it:

```
max_tokens: 9999999 > 128000, which is the maximum allowed number of output tokens for claude-opus-4-8
```

The 4.5 models keep their existing 64000 entry, which is correct for them.

## Related

- Related Issue #
- Closes #