### PR TITLE
Fix unknown MCP cancellation suppresses a later reused request ID

### DIFF
--- a/.changeset/fuzzy-rabbits-cancel.md
+++ b/.changeset/fuzzy-rabbits-cancel.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Ignore MCP cancellation notifications for unknown request identifiers.

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -489,6 +489,7 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
   const isHttp = Option.isSome(yield* Effect.serviceOption(HttpRouter.HttpRouter))
   const sessions = protocolState.sessions
   const clientProtocols = new Map<number, McpProtocol.ProtocolAdapter>()
+  const activeRequests = new Map<number, Set<string>>()
   const cancelledRequests = new Map<number, Set<string>>()
   const handlers = yield* Layer.build(layerHandlers(options, {
     sessions,
@@ -577,6 +578,10 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
     ...protocol,
     send: (clientId, response) => {
       if (response._tag === "Exit") {
+        const active = activeRequests.get(clientId)
+        if (active?.delete(requestKey(response.requestId)) === true && active.size === 0) {
+          activeRequests.delete(clientId)
+        }
         const requests = cancelledRequests.get(clientId)
         if (requests?.delete(requestKey(response.requestId)) === true) {
           if (requests.size === 0) {
@@ -670,8 +675,12 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
               if (request.tag === "notifications/cancelled") {
                 return decodeCancelledNotification(request.payload).pipe(
                   Effect.flatMap(({ requestId }) => {
+                    const key = requestKey(requestId)
+                    if (activeRequests.get(clientId)?.has(key) !== true) {
+                      return Effect.void
+                    }
                     const requests = cancelledRequests.get(clientId) ?? new Set<string>()
-                    requests.add(requestKey(requestId))
+                    requests.add(key)
                     cancelledRequests.set(clientId, requests)
                     return f(clientId, {
                       _tag: "Interrupt",
@@ -732,7 +741,14 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
             }
             return selectedProtocol.payloadCodecs(rpc).decode(request.payload).pipe(
               Effect.matchEffect({
-                onSuccess: () => f(clientId, routedRequest),
+                onSuccess: () => {
+                  if (request.isNotification !== true) {
+                    const requests = activeRequests.get(clientId) ?? new Set<string>()
+                    requests.add(requestKey(request.id))
+                    activeRequests.set(clientId, requests)
+                  }
+                  return f(clientId, routedRequest)
+                },
                 onFailure: () =>
                   request.isNotification
                     ? Effect.void
@@ -752,6 +768,7 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
           case "Interrupt":
             return f(clientId, request)
           case "Eof":
+            activeRequests.delete(clientId)
             cancelledRequests.delete(clientId)
             return f(clientId, request)
           case "Pong":

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -489,8 +489,7 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
   const isHttp = Option.isSome(yield* Effect.serviceOption(HttpRouter.HttpRouter))
   const sessions = protocolState.sessions
   const clientProtocols = new Map<number, McpProtocol.ProtocolAdapter>()
-  const activeRequests = new Map<number, Set<string>>()
-  const cancelledRequests = new Map<number, Set<string>>()
+  const activeRequests = new Map<number, Map<string, boolean>>()
   const handlers = yield* Layer.build(layerHandlers(options, {
     sessions,
     protocolRegistry
@@ -578,15 +577,13 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
     ...protocol,
     send: (clientId, response) => {
       if (response._tag === "Exit") {
-        const active = activeRequests.get(clientId)
-        if (active?.delete(requestKey(response.requestId)) === true && active.size === 0) {
+        const requests = activeRequests.get(clientId)
+        const key = requestKey(response.requestId)
+        const cancelled = requests?.get(key)
+        if (requests !== undefined && requests.delete(key) && requests.size === 0) {
           activeRequests.delete(clientId)
         }
-        const requests = cancelledRequests.get(clientId)
-        if (requests?.delete(requestKey(response.requestId)) === true) {
-          if (requests.size === 0) {
-            cancelledRequests.delete(clientId)
-          }
+        if (cancelled === true) {
           return Effect.void
         }
       }
@@ -676,12 +673,11 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
                 return decodeCancelledNotification(request.payload).pipe(
                   Effect.flatMap(({ requestId }) => {
                     const key = requestKey(requestId)
-                    if (activeRequests.get(clientId)?.has(key) !== true) {
+                    const requests = activeRequests.get(clientId)
+                    if (requests?.has(key) !== true) {
                       return Effect.void
                     }
-                    const requests = cancelledRequests.get(clientId) ?? new Set<string>()
-                    requests.add(key)
-                    cancelledRequests.set(clientId, requests)
+                    requests.set(key, true)
                     return f(clientId, {
                       _tag: "Interrupt",
                       requestId: RpcMessage.RequestId(requestId)
@@ -743,8 +739,8 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
               Effect.matchEffect({
                 onSuccess: () => {
                   if (request.isNotification !== true) {
-                    const requests = activeRequests.get(clientId) ?? new Set<string>()
-                    requests.add(requestKey(request.id))
+                    const requests = activeRequests.get(clientId) ?? new Map<string, boolean>()
+                    requests.set(requestKey(request.id), false)
                     activeRequests.set(clientId, requests)
                   }
                   return f(clientId, routedRequest)
@@ -769,7 +765,6 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
             return f(clientId, request)
           case "Eof":
             activeRequests.delete(clientId)
-            cancelledRequests.delete(clientId)
             return f(clientId, request)
           case "Pong":
           case "Exit":

--- a/packages/effect/test/unstable/ai/McpServer/McpConformance/UtilitiesTest.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpConformance/UtilitiesTest.ts
@@ -134,13 +134,8 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
             yield* Effect.yieldNow
 
             const reusedExit = reused.pollUnsafe()
-            assert.isDefined(reusedExit)
-            if (reusedExit !== undefined) {
-              assert(Exit.isSuccess(reusedExit))
-              if (Exit.isSuccess(reusedExit)) {
-                assert.deepStrictEqual(reusedExit.value.result, {})
-              }
-            }
+            assert(reusedExit !== undefined && Exit.isSuccess(reusedExit))
+            assert.deepStrictEqual(reusedExit.value.result, {})
           }))
         it.effect("SHOULD ignore cancellation for an already completed request identifier", () =>
           Effect.gen(function*() {

--- a/packages/effect/test/unstable/ai/McpServer/McpConformance/UtilitiesTest.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpConformance/UtilitiesTest.ts
@@ -2,6 +2,7 @@ import { assert, describe, it } from "@effect/vitest"
 import * as Context from "effect/Context"
 import * as Deferred from "effect/Deferred"
 import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
 import type * as McpProtocol from "effect/unstable/ai/McpProtocol"
 import * as McpSchema from "effect/unstable/ai/McpSchema"
 import { makeMcpStdioHarness } from "../TestUtils/McpStdioHarness.ts"
@@ -117,6 +118,29 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
 
             assert.strictEqual(response.status, 202)
             assert.strictEqual(yield* Effect.promise(() => response.text()), "")
+          }))
+        it.effect("SHOULD allow a later request to reuse an unknown cancelled identifier", () =>
+          Effect.gen(function*() {
+            const fixture = yield* makeMcpStdioHarness(protocol)
+            yield* fixture.initialize()
+            yield* fixture.sendNotification("notifications/cancelled", {
+              requestId: "reused-id"
+            })
+
+            const reused = yield* fixture.sendRequest("ping", undefined, "reused-id").pipe(Effect.forkChild)
+            yield* Effect.yieldNow
+            const control = yield* fixture.sendRequest("ping", undefined, "control-id")
+            assert.deepStrictEqual(control.result, {})
+            yield* Effect.yieldNow
+
+            const reusedExit = reused.pollUnsafe()
+            assert.isDefined(reusedExit)
+            if (reusedExit !== undefined) {
+              assert(Exit.isSuccess(reusedExit))
+              if (Exit.isSuccess(reusedExit)) {
+                assert.deepStrictEqual(reusedExit.value.result, {})
+              }
+            }
           }))
         it.effect("SHOULD ignore cancellation for an already completed request identifier", () =>
           Effect.gen(function*() {


### PR DESCRIPTION
## Summary

Every valid cancellation ID is inserted into cancelledRequests before active-request existence is known. The next Exit for the same client and typed ID is deleted from that set and discarded, including a later unrelated request that reuses X.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Unknown MCP cancellation suppresses a later reused request ID

**Module:** `packages/effect/src/unstable/ai/McpServer.ts`  
**Audit ID:** `relsem-mcp-stale-cancel-id`  
**Severity / confidence:** medium / high

### What happens

Every valid cancellation ID is inserted into cancelledRequests before active-request existence is known. The next Exit for the same client and typed ID is deleted from that set and discarded, including a later unrelated request that reuses X.

### Why it happens

The owning implementation diverges from relation unstable-services-004.

### Expected behavior

MCP cancellation for an unknown request identifier is ignored; suppression applies only to the response of the matching active cancelled request.

### Relevant implementation

These links and excerpts are pinned to audit base `b206fa5d7655c1634c9993410a9203f6616a5ca2`.

- [`packages/effect/src/unstable/ai/McpServer.ts:670`](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/effect/src/unstable/ai/McpServer.ts#L670)

<details>
<summary>View problematic code at <code>packages/effect/src/unstable/ai/McpServer.ts:670</code></summary>

```ts
              if (request.tag === "notifications/cancelled") {
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/effect/src/unstable/ai/McpServer.ts#L670)

</details>

### Reproduction

```sh
pnpm --filter effect test --run test/unstable/ai/McpServer/v2025_06_18.test.ts -t "SHOULD allow a later request to reuse an unknown cancelled identifier"
```

**Observed failure:** Independently rerun; failed at the intended semantic assertion.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm --filter effect test --run test/unstable/ai/McpServer/v2025_06_18.test.ts -t "SHOULD allow a later request to reuse an unknown cancelled identifier"
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Reproduction base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Findings: `relsem-mcp-stale-cancel-id`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-563