### PR TITLE
Fix openRouter emits cumulative tool-parameter prefixes as deltas

### DIFF
--- a/.changeset/openrouter-tool-parameter-deltas.md
+++ b/.changeset/openrouter-tool-parameter-deltas.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openrouter": patch
+---
+
+Emit incremental tool parameter fragments from OpenRouter streaming responses.

--- a/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
+++ b/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
@@ -1441,7 +1441,7 @@ const makeStreamResponse = Effect.fnUntraced(
                 parts.push({
                   type: "tool-params-delta",
                   id: activeToolCall.id,
-                  delta: activeToolCall.params
+                  delta: toolCall.function?.arguments ?? ""
                 })
               }
 

--- a/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
+++ b/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
@@ -1377,6 +1377,7 @@ const makeStreamResponse = Effect.fnUntraced(
             for (const toolCall of toolCalls) {
               const index = toolCall.index ?? toolCalls.length - 1
               let activeToolCall = activeToolCalls[index]
+              const argumentsDelta = toolCall.function?.arguments ?? ""
 
               // Tool call start - OpenRouter returns all information except the
               // tool call parameters in the first chunk
@@ -1415,7 +1416,7 @@ const makeStreamResponse = Effect.fnUntraced(
                   id: toolCall.id,
                   type: "function",
                   name: toolCall.function.name,
-                  params: toolCall.function.arguments ?? ""
+                  params: argumentsDelta
                 }
 
                 activeToolCalls[index] = activeToolCall
@@ -1425,23 +1426,16 @@ const makeStreamResponse = Effect.fnUntraced(
                   id: activeToolCall.id,
                   name: activeToolCall.name
                 })
-
-                // Emit a tool call delta part if parameters were also sent
-                if (activeToolCall.params.length > 0) {
-                  parts.push({
-                    type: "tool-params-delta",
-                    id: activeToolCall.id,
-                    delta: activeToolCall.params
-                  })
-                }
               } else {
-                // If an active tool call was found, update and emit the delta for
-                // the tool call's parameters
-                activeToolCall.params += toolCall.function?.arguments ?? ""
+                activeToolCall.params += argumentsDelta
+              }
+
+              // Emit a tool call delta part if parameters were also sent
+              if (argumentsDelta.length > 0) {
                 parts.push({
                   type: "tool-params-delta",
                   id: activeToolCall.id,
-                  delta: toolCall.function?.arguments ?? ""
+                  delta: argumentsDelta
                 })
               }
 

--- a/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
+++ b/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
@@ -320,6 +320,16 @@ describe("OpenRouterLanguageModel", () => {
               created: 1,
               choices: [{
                 index: 0,
+                delta: { tool_calls: [{ index: 0 }] }
+              }]
+            },
+            {
+              id: "response-1",
+              object: "chat.completion.chunk",
+              model: "openai/gpt-4o-mini",
+              created: 1,
+              choices: [{
+                index: 0,
                 finish_reason: "tool_calls",
                 delta: { tool_calls: [{ index: 0, function: { arguments: "1}" } }] }
               }]
@@ -327,7 +337,7 @@ describe("OpenRouterLanguageModel", () => {
           ]))
         )
 
-        assert.deepStrictEqual(
+        deepStrictEqual(
           globalThis.Array.from(parts)
             .filter((part) => part.type === "tool-params-delta")
             .map((part) => part.delta),

--- a/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
+++ b/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
@@ -279,6 +279,61 @@ describe("OpenRouterLanguageModel", () => {
         const reasoningEnd = parts.find((part) => part.type === "reasoning-end")
         deepStrictEqual(reasoningEnd?.metadata, { openrouter: { reasoningDetails } })
       }))
+
+    it.effect("emits incremental tool parameter fragments", () =>
+      Effect.gen(function*() {
+        const ProbeTool = Tool.make("ProbeTool", {
+          parameters: Schema.Struct({ a: Schema.Number }),
+          success: Schema.String
+        })
+        const toolkit = Toolkit.make(ProbeTool)
+        const parts = yield* LanguageModel.streamText({
+          prompt: "call the tool",
+          toolkit,
+          disableToolCallResolution: true
+        }).pipe(
+          Stream.runCollect,
+          Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini")),
+          Effect.provide(toolkit.toLayer({ ProbeTool: () => Effect.succeed("ok") })),
+          Effect.provide(makeStreamTestLayer([
+            {
+              id: "response-1",
+              object: "chat.completion.chunk",
+              model: "openai/gpt-4o-mini",
+              created: 1,
+              choices: [{
+                index: 0,
+                delta: {
+                  tool_calls: [{
+                    index: 0,
+                    id: "call-1",
+                    type: "function",
+                    function: { name: "ProbeTool", arguments: "{\"a\":" }
+                  }]
+                }
+              }]
+            },
+            {
+              id: "response-1",
+              object: "chat.completion.chunk",
+              model: "openai/gpt-4o-mini",
+              created: 1,
+              choices: [{
+                index: 0,
+                finish_reason: "tool_calls",
+                delta: { tool_calls: [{ index: 0, function: { arguments: "1}" } }] }
+              }]
+            }
+          ]))
+        )
+
+        assert.deepStrictEqual(
+          globalThis.Array.from(parts)
+            .filter((part) => part.type === "tool-params-delta")
+            .map((part) => part.delta),
+          ["{\"a\":", "1}"]
+        )
+      }))
   })
 })
 


### PR DESCRIPTION
## Summary

- Emit each OpenRouter tool-call argument fragment as received while separately accumulating the complete JSON for final tool-call decoding.
- Suppress empty `tool-params-delta` parts when a continuation chunk carries no arguments.
- Add regression coverage for multi-chunk tool arguments, including an argument-less continuation chunk.
- Add a patch changeset for `@effect/ai-openrouter`.

## Validation

- `pnpm test --run packages/ai/openrouter/test`
- `pnpm lint`
- `pnpm check`

Closes EFF-564