### PR TITLE
Fix openRouter reasoning-end metadata uses an undeclared casing

### DIFF
--- a/.changeset/fuzzy-ravens-reason.md
+++ b/.changeset/fuzzy-ravens-reason.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openrouter": patch
+---
+
+Fix the casing of OpenRouter reasoning-end metadata.

--- a/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
+++ b/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
@@ -1320,7 +1320,7 @@ const makeStreamResponse = Effect.fnUntraced(
                 // The signature typically arrives in the last reasoning delta,
                 // but reasoning-start only carries the first delta's metadata.
                 metadata: accumulatedReasoningDetails.length > 0
-                  ? { openRouter: { reasoningDetails: accumulatedReasoningDetails } }
+                  ? { openrouter: { reasoningDetails: accumulatedReasoningDetails } }
                   : undefined
               })
               reasoningStarted = false

--- a/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
+++ b/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
@@ -276,13 +276,8 @@ describe("OpenRouterLanguageModel", () => {
           ]))
         )
 
-        const reasoningEnd = globalThis.Array.from(parts).find((part) => part.type === "reasoning-end")
-        assert.isDefined(reasoningEnd)
-        if (reasoningEnd?.type === "reasoning-end") {
-          assert.deepStrictEqual(reasoningEnd.metadata, {
-            openrouter: { reasoningDetails }
-          })
-        }
+        const reasoningEnd = parts.find((part) => part.type === "reasoning-end")
+        deepStrictEqual(reasoningEnd?.metadata, { openrouter: { reasoningDetails } })
       }))
   })
 })
@@ -377,7 +372,7 @@ const getRequestBody = (request: HttpClientRequest.HttpClientRequest) =>
     return yield* Effect.die(new Error("Expected Uint8Array body"))
   })
 
-const makeStreamTestLayer = (events: ReadonlyArray<unknown>) => {
+const makeStreamTestLayer = (events: ReadonlyArray<typeof Generated.ChatStreamChunk.Encoded>) => {
   const body = events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("") + "data: [DONE]\n\n"
   const httpClient = HttpClient.makeWith(
     Effect.fnUntraced(function*(requestEffect) {

--- a/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
+++ b/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
@@ -246,6 +246,44 @@ describe("OpenRouterLanguageModel", () => {
           })
         }
       }))
+
+    it.effect("uses lowercase openrouter reasoning-end metadata", () =>
+      Effect.gen(function*() {
+        const reasoningDetails = [{
+          type: "reasoning.text",
+          text: "thinking",
+          signature: "signature-final",
+          format: "unknown"
+        }] as const
+        const parts = yield* LanguageModel.streamText({ prompt: "reason then answer" }).pipe(
+          Stream.runCollect,
+          Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini")),
+          Effect.provide(makeStreamTestLayer([
+            {
+              id: "response-1",
+              object: "chat.completion.chunk",
+              model: "openai/gpt-4o-mini",
+              created: 1,
+              choices: [{ index: 0, delta: { reasoning_details: reasoningDetails } }]
+            },
+            {
+              id: "response-1",
+              object: "chat.completion.chunk",
+              model: "openai/gpt-4o-mini",
+              created: 1,
+              choices: [{ index: 0, finish_reason: "stop", delta: { content: "answer" } }]
+            }
+          ]))
+        )
+
+        const reasoningEnd = globalThis.Array.from(parts).find((part) => part.type === "reasoning-end")
+        assert.isDefined(reasoningEnd)
+        if (reasoningEnd?.type === "reasoning-end") {
+          assert.deepStrictEqual(reasoningEnd.metadata, {
+            openrouter: { reasoningDetails }
+          })
+        }
+      }))
   })
 })
 


### PR DESCRIPTION
## Summary

The transition branch emits metadata.openRouter, while start, delta, terminal-flush, and exported metadata all use openrouter.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## OpenRouter reasoning-end metadata uses an undeclared casing

**Module:** `packages/ai/openrouter/src/OpenRouterLanguageModel.ts`  
**Audit ID:** `relsem-openrouter-reasoning-metadata-case`  
**Severity / confidence:** medium / high

### What happens

The transition branch emits metadata.openRouter, while start, delta, terminal-flush, and exported metadata all use openrouter.

### Why it happens

A single branch spells the provider metadata key openRouter rather than openrouter.

### Expected behavior

Accumulated reasoning details on reasoning-end remain under the exported metadata.openrouter namespace.

### Relevant implementation

These links and excerpts are pinned to audit base `b206fa5d7655c1634c9993410a9203f6616a5ca2`.

- [`packages/ai/openrouter/src/OpenRouterLanguageModel.ts:1`](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/ai/openrouter/src/OpenRouterLanguageModel.ts#L1)

<details>
<summary>View problematic code at <code>packages/ai/openrouter/src/OpenRouterLanguageModel.ts:1</code></summary>

```ts
/**
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/b206fa5d7655c1634c9993410a9203f6616a5ca2/packages/ai/openrouter/src/OpenRouterLanguageModel.ts#L1)

</details>

### Reproduction

```sh
pnpm test --run packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts -t "uses lowercase openrouter reasoning-end metadata"
```

**Observed failure:** Independently rerun; failed at the intended semantic assertion.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts -t "uses lowercase openrouter reasoning-end metadata"
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Reproduction base: `b206fa5d7655c1634c9993410a9203f6616a5ca2`
- Findings: `relsem-openrouter-reasoning-metadata-case`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-565