### PR TITLE
Fix cluster shutdown hang from abandoned request

### DIFF
--- a/.changeset/fix-cluster-strand-request-shutdown.md
+++ b/.changeset/fix-cluster-strand-request-shutdown.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `@effect/cluster` shutdown hang by failing a non-discard `Sharding.sendOutgoing` request (with `EntityNotAssignedToRunner`) when it is abandoned during teardown, instead of resolving as sent.

--- a/.changeset/fix-cluster-strand-request-shutdown.md
+++ b/.changeset/fix-cluster-strand-request-shutdown.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix `@effect/cluster` shutdown hang by failing a non-discard `Sharding.sendOutgoing` request (with `EntityNotAssignedToRunner`) when it is abandoned during teardown, instead of resolving as sent.
+Fix cluster shutdown hangs by failing abandoned non-discard requests and stream chunk acknowledgements with `EntityNotAssignedToRunner`, including persisted requests sent after runner unregistration. This adds `EntityNotAssignedToRunner` to the typed error channel of entity clients and request-only `EntityProxy` RPC/HTTP endpoints; discard endpoints remain unchanged.

--- a/packages/effect/src/unstable/cluster/Entity.ts
+++ b/packages/effect/src/unstable/cluster/Entity.ts
@@ -34,7 +34,12 @@ import * as RpcClient from "../rpc/RpcClient.ts"
 import * as RpcGroup from "../rpc/RpcGroup.ts"
 import * as RpcSchema from "../rpc/RpcSchema.ts"
 import * as RpcServer from "../rpc/RpcServer.ts"
-import type { AlreadyProcessingMessage, MailboxFull, PersistenceError } from "./ClusterError.ts"
+import type {
+  AlreadyProcessingMessage,
+  EntityNotAssignedToRunner,
+  MailboxFull,
+  PersistenceError
+} from "./ClusterError.ts"
 import { Persisted, ShardGroup, Uninterruptible } from "./ClusterSchema.ts"
 import { EntityAddress } from "./EntityAddress.ts"
 import type { EntityId } from "./EntityId.ts"
@@ -117,7 +122,7 @@ export interface Entity<
       entityId: string
     ) => RpcClient.RpcClient.From<
       Rpcs,
-      MailboxFull | AlreadyProcessingMessage | PersistenceError
+      MailboxFull | AlreadyProcessingMessage | PersistenceError | EntityNotAssignedToRunner
     >,
     never,
     Sharding

--- a/packages/effect/src/unstable/cluster/EntityProxy.ts
+++ b/packages/effect/src/unstable/cluster/EntityProxy.ts
@@ -14,7 +14,7 @@ import * as HttpApiEndpoint from "../httpapi/HttpApiEndpoint.ts"
 import * as HttpApiGroup from "../httpapi/HttpApiGroup.ts"
 import * as Rpc from "../rpc/Rpc.ts"
 import * as RpcGroup from "../rpc/RpcGroup.ts"
-import { AlreadyProcessingMessage, MailboxFull, PersistenceError } from "./ClusterError.ts"
+import { AlreadyProcessingMessage, EntityNotAssignedToRunner, MailboxFull, PersistenceError } from "./ClusterError.ts"
 import type * as Entity from "./Entity.ts"
 import type { EntityId } from "./EntityId.ts"
 
@@ -22,6 +22,11 @@ const clientErrors = [
   MailboxFull,
   AlreadyProcessingMessage,
   PersistenceError
+] as const
+
+const requestErrors = [
+  ...clientErrors,
+  EntityNotAssignedToRunner
 ] as const
 
 /**
@@ -75,7 +80,7 @@ export const toRpcGroup = <Type extends string, Rpcs extends Rpc.Any>(
     }
     const rpc = Rpc.make(`${entity.type}.${parentRpc._tag}`, {
       payload: payloadSchema,
-      error: Schema.Union([parentRpc.errorSchema, ...clientErrors]),
+      error: Schema.Union([parentRpc.errorSchema, ...requestErrors]),
       success: parentRpc.successSchema
     }).annotateMerge(parentRpc.annotations)
     const rpcDiscard = Rpc.make(`${entity.type}.${parentRpc._tag}Discard`, {
@@ -115,11 +120,12 @@ export type ConvertRpcs<Rpcs extends Rpc.Any, Prefix extends string> = Rpcs exte
       }>,
       _Success,
       Schema.Codec<
-        _Error["Type"] | MailboxFull | AlreadyProcessingMessage | PersistenceError,
+        _Error["Type"] | MailboxFull | AlreadyProcessingMessage | PersistenceError | EntityNotAssignedToRunner,
         | _Error["Encoded"]
         | typeof MailboxFull["Encoded"]
         | typeof AlreadyProcessingMessage["Encoded"]
-        | typeof PersistenceError["Encoded"],
+        | typeof PersistenceError["Encoded"]
+        | typeof EntityNotAssignedToRunner["Encoded"],
         _Error["DecodingServices"],
         _Error["EncodingServices"]
       >
@@ -193,7 +199,7 @@ export const toHttpApiGroup = <const Name extends string, Type extends string, R
       params: entityIdPath,
       payload: parentRpc.payloadSchema,
       success: parentRpc.successSchema,
-      error: [parentRpc.errorSchema, ...clientErrors]
+      error: [parentRpc.errorSchema, ...requestErrors]
     }).annotateMerge(parentRpc.annotations)
     const endpointDiscard = HttpApiEndpoint.post(
       `${parentRpc._tag}Discard`,
@@ -250,6 +256,7 @@ export type ConvertHttpApi<Rpcs extends Rpc.Any> = Rpcs extends Rpc.Rpc<
       | typeof MailboxFull
       | typeof AlreadyProcessingMessage
       | typeof PersistenceError
+      | typeof EntityNotAssignedToRunner
     >
     | HttpApiEndpoint.HttpApiEndpoint<
       `${_Tag}Discard`,

--- a/packages/effect/src/unstable/cluster/Sharding.ts
+++ b/packages/effect/src/unstable/cluster/Sharding.ts
@@ -973,11 +973,36 @@ const make = Effect.gen(function*() {
       message._tag === "OutgoingRequest" ? message.annotations : message.rpc.annotations,
       Persisted
     )
+    const abandon = (error: EntityNotAssignedToRunner) => {
+      const shouldFail = !discard &&
+        (message._tag === "OutgoingRequest" || message.envelope._tag === "AckChunk")
+      if (!isPersisted) {
+        return shouldFail
+          ? Effect.fail(error)
+          : Effect.logDebug("Abandoning outgoing message during shutdown", message.envelope.address)
+      }
+      const persist = message._tag === "OutgoingRequest"
+        ? storage.saveRequest(message)
+        : storage.saveEnvelope(message)
+      return Effect.catchTag(persist, "MalformedMessage", Effect.die).pipe(
+        Effect.andThen(
+          shouldFail
+            ? Effect.fail(error)
+            : Effect.logWarning("Persisting outgoing message abandoned during shutdown", message.envelope.address)
+        )
+      )
+    }
     return Effect.catchFilter(
       Effect.suspend(() => {
         const address = message.envelope.address
         if (isPersisted && !storageEnabled) {
           return Effect.die("Sharding.sendOutgoing: Persisted messages require MessageStorage")
+        }
+        if (
+          MutableRef.get(isShutdown) &&
+          (message._tag === "OutgoingRequest" || message.envelope._tag === "AckChunk")
+        ) {
+          return abandon(new EntityNotAssignedToRunner({ address }))
         }
         const maybeRunner = MutableHashMap.get(shardAssignments, address.shardId)
         const runnerIsLocal = Option.isSome(maybeRunner) && isLocalRunner(maybeRunner.value)
@@ -1003,22 +1028,7 @@ const make = Effect.gen(function*() {
           const cannotRecover = MutableRef.get(isShutdown) ||
             (targetManager !== undefined && targetManager.status !== "alive")
           if (cannotRecover) {
-            const awaitingReply = message._tag === "OutgoingRequest" && !discard
-            if (!isPersisted) {
-              return awaitingReply
-                ? Effect.fail(error)
-                : Effect.logDebug("Abandoning outgoing message during shutdown", message.envelope.address)
-            }
-            const persist = message._tag === "OutgoingRequest"
-              ? storage.saveRequest(message)
-              : storage.saveEnvelope(message)
-            return Effect.catchTag(persist, "MalformedMessage", Effect.die).pipe(
-              Effect.andThen(
-                awaitingReply
-                  ? Effect.fail(error)
-                  : Effect.logWarning("Persisting outgoing message abandoned during shutdown", message.envelope.address)
-              )
-            )
+            return abandon(error)
           }
         }
         if (retries === 0) {

--- a/packages/effect/src/unstable/cluster/Sharding.ts
+++ b/packages/effect/src/unstable/cluster/Sharding.ts
@@ -124,7 +124,7 @@ export class Sharding extends Context.Service<Sharding, {
       entityId: string
     ) => RpcClient.RpcClient.From<
       Rpcs,
-      MailboxFull | AlreadyProcessingMessage | PersistenceError
+      MailboxFull | AlreadyProcessingMessage | PersistenceError | EntityNotAssignedToRunner
     >
   >
 
@@ -178,7 +178,7 @@ export class Sharding extends Context.Service<Sharding, {
     discard: boolean
   ) => Effect.Effect<
     void,
-    MailboxFull | AlreadyProcessingMessage | PersistenceError
+    MailboxFull | AlreadyProcessingMessage | PersistenceError | EntityNotAssignedToRunner
   >
 
   /**
@@ -967,7 +967,7 @@ const make = Effect.gen(function*() {
     retries?: number
   ): Effect.Effect<
     void,
-    MailboxFull | AlreadyProcessingMessage | PersistenceError
+    MailboxFull | AlreadyProcessingMessage | PersistenceError | EntityNotAssignedToRunner
   > {
     const isPersisted = Context.get(
       message._tag === "OutgoingRequest" ? message.annotations : message.rpc.annotations,
@@ -1003,15 +1003,20 @@ const make = Effect.gen(function*() {
           const cannotRecover = MutableRef.get(isShutdown) ||
             (targetManager !== undefined && targetManager.status !== "alive")
           if (cannotRecover) {
+            const awaitingReply = message._tag === "OutgoingRequest" && !discard
             if (!isPersisted) {
-              return Effect.logDebug("Abandoning outgoing message during shutdown", message.envelope.address)
+              return awaitingReply
+                ? Effect.fail(error)
+                : Effect.logDebug("Abandoning outgoing message during shutdown", message.envelope.address)
             }
             const persist = message._tag === "OutgoingRequest"
               ? storage.saveRequest(message)
               : storage.saveEnvelope(message)
             return Effect.catchTag(persist, "MalformedMessage", Effect.die).pipe(
               Effect.andThen(
-                Effect.logWarning("Persisting outgoing message abandoned during shutdown", message.envelope.address)
+                awaitingReply
+                  ? Effect.fail(error)
+                  : Effect.logWarning("Persisting outgoing message abandoned during shutdown", message.envelope.address)
               )
             )
           }
@@ -1183,7 +1188,7 @@ const make = Effect.gen(function*() {
     Entity<any, any>,
     (entityId: string) => RpcClient.RpcClient<
       any,
-      MailboxFull | AlreadyProcessingMessage
+      MailboxFull | AlreadyProcessingMessage | EntityNotAssignedToRunner
     >,
     never
   > = yield* ResourceMap.make(
@@ -1196,7 +1201,7 @@ const make = Effect.gen(function*() {
         flatten: true,
         onFromClient(options): Effect.Effect<
           void,
-          MailboxFull | AlreadyProcessingMessage | PersistenceError
+          MailboxFull | AlreadyProcessingMessage | PersistenceError | EntityNotAssignedToRunner
         > {
           const address = Context.getUnsafe(options.context, ClientAddressTag)
           switch (options.message._tag) {
@@ -1337,7 +1342,7 @@ const make = Effect.gen(function*() {
   const makeClient = <Type extends string, Rpcs extends Rpc.Any>(entity: Entity<Type, Rpcs>): Effect.Effect<
     (
       entityId: string
-    ) => RpcClient.RpcClient.From<Rpcs, MailboxFull | AlreadyProcessingMessage>
+    ) => RpcClient.RpcClient.From<Rpcs, MailboxFull | AlreadyProcessingMessage | EntityNotAssignedToRunner>
   > => clients.get(entity) as any
 
   const clientRespondDiscard = (_reply: Reply.Reply<any>) => Effect.void

--- a/packages/effect/src/unstable/cluster/Sharding.ts
+++ b/packages/effect/src/unstable/cluster/Sharding.ts
@@ -973,9 +973,9 @@ const make = Effect.gen(function*() {
       message._tag === "OutgoingRequest" ? message.annotations : message.rpc.annotations,
       Persisted
     )
+    const shouldFail = !discard &&
+      (message._tag === "OutgoingRequest" || message.envelope._tag === "AckChunk")
     const abandon = (error: EntityNotAssignedToRunner) => {
-      const shouldFail = !discard &&
-        (message._tag === "OutgoingRequest" || message.envelope._tag === "AckChunk")
       if (!isPersisted) {
         return shouldFail
           ? Effect.fail(error)
@@ -998,11 +998,8 @@ const make = Effect.gen(function*() {
         if (isPersisted && !storageEnabled) {
           return Effect.die("Sharding.sendOutgoing: Persisted messages require MessageStorage")
         }
-        if (
-          MutableRef.get(isShutdown) &&
-          (message._tag === "OutgoingRequest" || message.envelope._tag === "AckChunk")
-        ) {
-          return abandon(new EntityNotAssignedToRunner({ address }))
+        if (shouldFail && MutableRef.get(isShutdown)) {
+          return Effect.fail(new EntityNotAssignedToRunner({ address }))
         }
         const maybeRunner = MutableHashMap.get(shardAssignments, address.shardId)
         const runnerIsLocal = Option.isSome(maybeRunner) && isLocalRunner(maybeRunner.value)

--- a/packages/effect/test/cluster/Sharding.test.ts
+++ b/packages/effect/test/cluster/Sharding.test.ts
@@ -310,7 +310,7 @@ describe.concurrent("Sharding", () => {
       const streamExit = yield* Deferred.make<Exit.Exit<void, unknown>>()
 
       const Receiver = Entity.make("ShutdownStreamReceiver", [
-        Rpc.make("Values", { success: Schema.Number, stream: true }).annotate(ClusterSchema.Persisted, false)
+        Rpc.make("Values", { success: Schema.Number, stream: true }).annotate(ClusterSchema.Persisted, true)
       ])
       const ReceiverLayer = Receiver.toLayer({
         Values: () => Stream.fromQueue(chunks).pipe(Stream.onStart(Deferred.succeed(streamStarted, void 0)))
@@ -356,7 +356,9 @@ describe.concurrent("Sharding", () => {
 
       const shardAcquired = Latch.makeUnsafe()
       const armed = Latch.makeUnsafe()
+      let driver!: MessageStorage.MemoryDriver["Service"]
       const runFiber = yield* Effect.gen(function*() {
+        driver = yield* MessageStorage.MemoryDriver
         const sharding = yield* Sharding.Sharding
         const shardId = sharding.getShardId(EntityId.make("1"), "default")
         while (!sharding.hasShardId(shardId)) {
@@ -384,6 +386,7 @@ describe.concurrent("Sharding", () => {
       const failure = Cause.findErrorOption(exit.cause)
       assert(Option.isSome(failure), "stream did not fail with a typed error")
       assert(failure.value instanceof ClusterError.EntityNotAssignedToRunner)
+      assert.strictEqual(driver.journal.filter((envelope) => envelope._tag === "AckChunk").length, 1)
     }), 20_000)
 
   it.effect("interrupts are sent for volatile messages on shutdown", () =>

--- a/packages/effect/test/cluster/Sharding.test.ts
+++ b/packages/effect/test/cluster/Sharding.test.ts
@@ -4,6 +4,7 @@ import {
   Cause,
   Clock,
   Context,
+  Deferred,
   Effect,
   Exit,
   Fiber,
@@ -13,10 +14,12 @@ import {
   MutableRef,
   Option,
   Queue,
+  Schema,
   Stream
 } from "effect"
 import { TestClock } from "effect/testing"
 import {
+  ClusterError,
   ClusterMetrics,
   ClusterSchema,
   Entity,
@@ -140,6 +143,7 @@ describe.concurrent("Sharding", () => {
         `shutdown completes when a finalizing entity sends an outgoing message (persisted=${persisted}, preemptiveShutdown=${preemptiveShutdown})`,
         () =>
           Effect.gen(function*() {
+            const discardExit = yield* Deferred.make<Exit.Exit<void, unknown>>()
             const Receiver = Entity.make("ShutdownDeadlockReceiver", [
               Rpc.make("Ping").annotate(ClusterSchema.Persisted, persisted)
             ])
@@ -151,7 +155,15 @@ describe.concurrent("Sharding", () => {
             const SenderLayer = Sender.toLayer(Effect.gen(function*() {
               const receiver = yield* Receiver.client
               // finalizer sends an outgoing message during entity teardown
-              yield* Effect.addFinalizer(() => receiver("peer").Ping(void 0, { discard: true }).pipe(Effect.ignore))
+              yield* Effect.addFinalizer(() =>
+                Effect.uninterruptible(
+                  Effect.sleep(300).pipe(
+                    Effect.andThen(receiver("peer").Ping(void 0, { discard: true })),
+                    Effect.exit,
+                    Effect.flatMap((exit) => Deferred.succeed(discardExit, exit))
+                  )
+                )
+              )
               return { Arm: () => Effect.void }
             }))
 
@@ -201,6 +213,7 @@ describe.concurrent("Sharding", () => {
             runFiber.interruptUnsafe()
             const completed = yield* Fiber.await(runFiber).pipe(Effect.timeoutOption("4 seconds"))
             assert(Option.isSome(completed), "Sharding scope-close hung during shutdown (deadlock)")
+            assert(Exit.isSuccess(yield* Deferred.await(discardExit)), "discard send failed during shutdown")
             assert.strictEqual(driver.journal.length, persisted ? 1 : 0)
           }),
         20_000
@@ -211,6 +224,7 @@ describe.concurrent("Sharding", () => {
       `shutdown completes when a finalizing entity awaits a reply from an unroutable entity (persisted=${persisted})`,
       () =>
         Effect.gen(function*() {
+          const requestExit = yield* Deferred.make<Exit.Exit<void, unknown>>()
           const Receiver = Entity.make("StrandReceiver", [
             Rpc.make("Ping").annotate(ClusterSchema.Persisted, persisted)
           ])
@@ -222,7 +236,15 @@ describe.concurrent("Sharding", () => {
           const SenderLayer = Sender.toLayer(Effect.gen(function*() {
             const receiver = yield* Receiver.client
             // uninterruptible finalizer that awaits a reply from another entity
-            yield* Effect.addFinalizer(() => Effect.uninterruptible(receiver("peer").Ping().pipe(Effect.ignore)))
+            yield* Effect.addFinalizer(() =>
+              Effect.uninterruptible(
+                Effect.sleep(300).pipe(
+                  Effect.andThen(receiver("peer").Ping()),
+                  Effect.exit,
+                  Effect.flatMap((exit) => Deferred.succeed(requestExit, exit))
+                )
+              )
+            )
             return { Arm: () => Effect.void }
           }))
 
@@ -270,11 +292,99 @@ describe.concurrent("Sharding", () => {
           const completed = yield* Fiber.await(runFiber).pipe(Effect.timeoutOption("4 seconds"))
           assert(Option.isSome(completed), "Sharding scope-close hung during shutdown (stranded caller)")
           assert(!Exit.hasDies(completed.value), "finalizer defected instead of failing cleanly")
+          const exit = yield* Deferred.await(requestExit)
+          assert(Exit.isFailure(exit), "request succeeded instead of failing during shutdown")
+          const failure = Cause.findErrorOption(exit.cause)
+          assert(Option.isSome(failure), "request did not fail with a typed error")
+          assert(failure.value instanceof ClusterError.EntityNotAssignedToRunner)
           assert.strictEqual(driver.journal.length, persisted ? 1 : 0)
         }),
       20_000
     )
   }
+
+  it.live("fails a stream when its chunk acknowledgement is abandoned during shutdown", () =>
+    Effect.gen(function*() {
+      const chunks = yield* Queue.unbounded<number>()
+      const streamStarted = yield* Deferred.make<void>()
+      const streamExit = yield* Deferred.make<Exit.Exit<void, unknown>>()
+
+      const Receiver = Entity.make("ShutdownStreamReceiver", [
+        Rpc.make("Values", { success: Schema.Number, stream: true }).annotate(ClusterSchema.Persisted, false)
+      ])
+      const ReceiverLayer = Receiver.toLayer({
+        Values: () => Stream.fromQueue(chunks).pipe(Stream.onStart(Deferred.succeed(streamStarted, void 0)))
+      })
+
+      const Sender = Entity.make("ShutdownStreamSender", [
+        Rpc.make("Arm").annotate(ClusterSchema.Persisted, false)
+      ])
+      const SenderLayer = Sender.toLayer(Effect.gen(function*() {
+        const receiver = yield* Receiver.client
+        const streamFiber = yield* receiver("peer").Values().pipe(
+          Stream.runDrain,
+          Effect.uninterruptible,
+          Effect.forkScoped({ startImmediately: true })
+        )
+        yield* Deferred.await(streamStarted)
+        yield* Effect.addFinalizer(() =>
+          Effect.uninterruptible(
+            Queue.offer(chunks, 1).pipe(
+              Effect.andThen(Fiber.await(streamFiber)),
+              Effect.flatMap((exit) => Deferred.succeed(streamExit, exit))
+            )
+          )
+        )
+        return { Arm: () => Effect.void }
+      }))
+
+      const env = Layer.mergeAll(SenderLayer, ReceiverLayer).pipe(
+        Layer.provideMerge(Sharding.layer),
+        Layer.provide(RunnerStorage.layerMemory),
+        Layer.provide(RunnerHealth.layerNoop),
+        Layer.provide(Runners.layerNoop),
+        Layer.provideMerge(MessageStorage.layerMemory),
+        Layer.provide(ShardingConfig.layer({
+          runnerAddress: Option.some(RunnerAddress.make("localhost", 1234)),
+          shardsPerGroup: 8,
+          entityTerminationTimeout: 1000,
+          entityMessagePollInterval: 50,
+          refreshAssignmentsInterval: 20,
+          sendRetryInterval: 10
+        }))
+      )
+
+      const shardAcquired = Latch.makeUnsafe()
+      const armed = Latch.makeUnsafe()
+      const runFiber = yield* Effect.gen(function*() {
+        const sharding = yield* Sharding.Sharding
+        const shardId = sharding.getShardId(EntityId.make("1"), "default")
+        while (!sharding.hasShardId(shardId)) {
+          yield* Effect.sleep(5)
+        }
+        yield* shardAcquired.open
+        yield* (yield* Sender.client)("1").Arm()
+        yield* armed.open
+        return yield* Effect.never
+      }).pipe(Effect.provide(env), Effect.scoped, Effect.forkDetach)
+
+      const acquired = yield* shardAcquired.await.pipe(Effect.timeoutOption("8 seconds"))
+      if (Option.isNone(acquired)) {
+        runFiber.interruptUnsafe()
+        yield* Fiber.await(runFiber)
+      }
+      assert(Option.isSome(acquired), "Timed out waiting for sender shard acquisition")
+      yield* armed.await
+
+      runFiber.interruptUnsafe()
+      const completed = yield* Fiber.await(runFiber).pipe(Effect.timeoutOption("4 seconds"))
+      assert(Option.isSome(completed), "Sharding scope-close hung after abandoning a stream chunk acknowledgement")
+      const exit = yield* Deferred.await(streamExit)
+      assert(Exit.isFailure(exit), "stream succeeded instead of failing during shutdown")
+      const failure = Cause.findErrorOption(exit.cause)
+      assert(Option.isSome(failure), "stream did not fail with a typed error")
+      assert(failure.value instanceof ClusterError.EntityNotAssignedToRunner)
+    }), 20_000)
 
   it.effect("interrupts are sent for volatile messages on shutdown", () =>
     Effect.gen(function*() {

--- a/packages/effect/test/cluster/Sharding.test.ts
+++ b/packages/effect/test/cluster/Sharding.test.ts
@@ -206,6 +206,74 @@ describe.concurrent("Sharding", () => {
         20_000
       )
     }
+
+    it.live(
+      `shutdown completes when a finalizing entity awaits a reply from an unroutable entity (persisted=${persisted})`,
+      () =>
+        Effect.gen(function*() {
+          const Receiver = Entity.make("StrandReceiver", [
+            Rpc.make("Ping").annotate(ClusterSchema.Persisted, persisted)
+          ])
+          const ReceiverLayer = Receiver.toLayer({ Ping: () => Effect.void })
+
+          const Sender = Entity.make("StrandSender", [
+            Rpc.make("Arm").annotate(ClusterSchema.Persisted, false)
+          ])
+          const SenderLayer = Sender.toLayer(Effect.gen(function*() {
+            const receiver = yield* Receiver.client
+            // uninterruptible finalizer that awaits a reply from another entity
+            yield* Effect.addFinalizer(() => Effect.uninterruptible(receiver("peer").Ping().pipe(Effect.ignore)))
+            return { Arm: () => Effect.void }
+          }))
+
+          const env = Layer.mergeAll(SenderLayer, ReceiverLayer).pipe(
+            Layer.provideMerge(Sharding.layer),
+            Layer.provide(RunnerStorage.layerMemory),
+            Layer.provide(RunnerHealth.layerNoop),
+            Layer.provide(Runners.layerNoop),
+            Layer.provideMerge(MessageStorage.layerMemory),
+            Layer.provide(ShardingConfig.layer({
+              runnerAddress: Option.some(RunnerAddress.make("localhost", 1234)),
+              shardsPerGroup: 8,
+              entityTerminationTimeout: 0,
+              entityMessagePollInterval: 50,
+              refreshAssignmentsInterval: 20,
+              sendRetryInterval: 10
+            }))
+          )
+
+          const shardAcquired = Latch.makeUnsafe()
+          const armed = Latch.makeUnsafe()
+          let driver!: MessageStorage.MemoryDriver["Service"]
+          const runFiber = yield* Effect.gen(function*() {
+            driver = yield* MessageStorage.MemoryDriver
+            const sharding = yield* Sharding.Sharding
+            const shardId = sharding.getShardId(EntityId.make("1"), "default")
+            while (!sharding.hasShardId(shardId)) {
+              yield* Effect.sleep(5)
+            }
+            yield* shardAcquired.open
+            yield* (yield* Sender.client)("1").Arm()
+            yield* armed.open
+            return yield* Effect.never
+          }).pipe(Effect.provide(env), Effect.scoped, Effect.forkDetach)
+
+          const acquired = yield* shardAcquired.await.pipe(Effect.timeoutOption("8 seconds"))
+          if (Option.isNone(acquired)) {
+            runFiber.interruptUnsafe()
+            yield* Fiber.await(runFiber)
+          }
+          assert(Option.isSome(acquired), "Timed out waiting for sender shard acquisition")
+          yield* armed.await
+
+          runFiber.interruptUnsafe()
+          const completed = yield* Fiber.await(runFiber).pipe(Effect.timeoutOption("4 seconds"))
+          assert(Option.isSome(completed), "Sharding scope-close hung during shutdown (stranded caller)")
+          assert(!Exit.hasDies(completed.value), "finalizer defected instead of failing cleanly")
+          assert.strictEqual(driver.journal.length, persisted ? 1 : 0)
+        }),
+      20_000
+    )
   }
 
   it.effect("interrupts are sent for volatile messages on shutdown", () =>


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Follow-up to #7032. That PR abandons undeliverable outgoing messages during shutdown — but it abandons them by succeeding. This is fine for fire-and-forget but wrong for a request whose caller is awaiting a reply. Basically the caller just hangs forever on a reply that never comes, and if it's an uninterruptible teardown finalizer (which I think is a normal pattern?) then the whole shutdown deadlocks.

Fix: when abandoning a non-discard request during teardown, fail it with `EntityNotAssignedToRunner` instead of resolving as sent, so the caller unblocks. Discards and persisted saves are unchanged. 

Notable: as a result `EntityNotAssignedToRunner` is now in the error channel of `Entity.client` / `Sharding.sendOutgoing` / `Sharding.makeClient`. The alternative was to die the request but `EntityNotAssignedToRunner` felt a tiny bit more appropriate.

Regression test arms an uninterruptible finalizer to await a reply during teardown and asserts shutdown completes (persisted + non-persisted).

## Related

- Related Issue #7032
