### PR TITLE
Fix ClickHouse KILL QUERY parameterization

### DIFF
--- a/.changeset/calm-hounds-smile.md
+++ b/.changeset/calm-hounds-smile.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-clickhouse": patch
+---
+
+Parameterize ClickHouse query IDs when cancelling queries and inserts.

--- a/packages/sql/clickhouse/src/ClickhouseClient.ts
+++ b/packages/sql/clickhouse/src/ClickhouseClient.ts
@@ -253,7 +253,12 @@ export const make = (
             }
             return Effect.suspend(() => {
               controller.abort()
-              return Effect.promise(() => this.conn.command({ query: `KILL QUERY WHERE query_id = '${queryId}'` }))
+              return Effect.promise(() =>
+                this.conn.command({
+                  query: "KILL QUERY WHERE query_id = {queryId:String}",
+                  query_params: { queryId }
+                })
+              )
             })
           })
         })
@@ -375,7 +380,12 @@ export const make = (
             )
             return Effect.suspend(() => {
               controller.abort()
-              return Effect.promise(() => client.command({ query: `KILL QUERY WHERE query_id = '${queryId}'` }))
+              return Effect.promise(() =>
+                client.command({
+                  query: "KILL QUERY WHERE query_id = {queryId:String}",
+                  query_params: { queryId }
+                })
+              )
             })
           })
         },

--- a/packages/sql/clickhouse/test/Client.test.ts
+++ b/packages/sql/clickhouse/test/Client.test.ts
@@ -1,16 +1,23 @@
 import { ClickhouseClient } from "@effect/sql-clickhouse"
 import { assert, describe, it } from "@effect/vitest"
-import { Effect } from "effect"
+import { Effect, Fiber } from "effect"
 import { TestClock } from "effect/testing"
 import * as Reactivity from "effect/unstable/reactivity/Reactivity"
 import * as Statement from "effect/unstable/sql/Statement"
 import { vi } from "vitest"
 
 let closeCalls = 0
+let connectImmediately = false
+const commandCalls: Array<Record<string, unknown>> = []
 
 vi.mock("@clickhouse/client", () => ({
   createClient: () => ({
-    exec: () => new Promise(() => {}),
+    exec: () => connectImmediately ? Promise.resolve({}) : new Promise(() => {}),
+    query: () => new Promise(() => {}),
+    command: (options: Record<string, unknown>) => {
+      commandCalls.push(options)
+      return Promise.resolve({})
+    },
     close: () => {
       closeCalls++
       return Promise.resolve()
@@ -28,6 +35,7 @@ describe("ClickhouseClient", () => {
 
   it.effect("closes the client when the connection check times out", () =>
     Effect.gen(function*() {
+      connectImmediately = false
       closeCalls = 0
       const fiber = yield* Effect.forkDetach(
         ClickhouseClient.make({ url: "http://localhost:8123" }).pipe(Effect.scoped)
@@ -39,4 +47,24 @@ describe("ClickhouseClient", () => {
       assert.isDefined(result)
       assert.strictEqual(closeCalls, 1)
     }).pipe(Effect.provide(Reactivity.layer)))
+
+  it.effect("parameterizes the query id when cancelling", () =>
+    Effect.gen(function*() {
+      connectImmediately = true
+      commandCalls.length = 0
+      const queryId = "id' OR 1 = 1 --"
+      const client = yield* ClickhouseClient.make({ url: "http://localhost:8123" })
+      const fiber = yield* client.withQueryId(client.unsafe("SELECT 1"), queryId).pipe(Effect.forkScoped)
+      yield* Effect.yieldNow
+
+      yield* Fiber.interrupt(fiber)
+
+      assert.deepStrictEqual(commandCalls, [{
+        query: "KILL QUERY WHERE query_id = {queryId:String}",
+        query_params: { queryId }
+      }])
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(Reactivity.layer)
+    ))
 })

--- a/packages/sql/clickhouse/test/Client.test.ts
+++ b/packages/sql/clickhouse/test/Client.test.ts
@@ -14,6 +14,7 @@ vi.mock("@clickhouse/client", () => ({
   createClient: () => ({
     exec: () => connectImmediately ? Promise.resolve({}) : new Promise(() => {}),
     query: () => new Promise(() => {}),
+    insert: () => new Promise(() => {}),
     command: (options: Record<string, unknown>) => {
       commandCalls.push(options)
       return Promise.resolve({})
@@ -48,13 +49,36 @@ describe("ClickhouseClient", () => {
       assert.strictEqual(closeCalls, 1)
     }).pipe(Effect.provide(Reactivity.layer)))
 
-  it.effect("parameterizes the query id when cancelling", () =>
+  it.effect("parameterizes the query id when cancelling a query", () =>
     Effect.gen(function*() {
       connectImmediately = true
       commandCalls.length = 0
       const queryId = "id' OR 1 = 1 --"
       const client = yield* ClickhouseClient.make({ url: "http://localhost:8123" })
       const fiber = yield* client.withQueryId(client.unsafe("SELECT 1"), queryId).pipe(Effect.forkScoped)
+      yield* Effect.yieldNow
+
+      yield* Fiber.interrupt(fiber)
+
+      assert.deepStrictEqual(commandCalls, [{
+        query: "KILL QUERY WHERE query_id = {queryId:String}",
+        query_params: { queryId }
+      }])
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(Reactivity.layer)
+    ))
+
+  it.effect("parameterizes the query id when cancelling an insert", () =>
+    Effect.gen(function*() {
+      connectImmediately = true
+      commandCalls.length = 0
+      const queryId = "id' OR 1 = 1 --"
+      const client = yield* ClickhouseClient.make({ url: "http://localhost:8123" })
+      const fiber = yield* client.withQueryId(
+        client.insertQuery({ table: "test", values: [] }),
+        queryId
+      ).pipe(Effect.forkScoped)
       yield* Effect.yieldNow
 
       yield* Fiber.interrupt(fiber)


### PR DESCRIPTION
## Summary

- Parameterize caller-provided query IDs in ClickHouse `KILL QUERY` commands.
- Cover cancellation for both regular queries and inserts with focused regression tests.
- Add a patch changeset for `@effect/sql-clickhouse`.

## Validation

```sh
pnpm vitest run packages/sql/clickhouse/test/Client.test.ts
pnpm --filter @effect/sql-clickhouse check
pnpm exec dprint check packages/sql/clickhouse/src/ClickhouseClient.ts packages/sql/clickhouse/test/Client.test.ts .changeset/calm-hounds-smile.md
pnpm exec oxlint packages/sql/clickhouse/src/ClickhouseClient.ts packages/sql/clickhouse/test/Client.test.ts
```

Closes EFF-572