### PR TITLE
Fix catchCause does not deliver interrupt causes when fiber is interruptible

### DIFF
--- a/.changeset/catch-cause-interrupts.md
+++ b/.changeset/catch-cause-interrupts.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Effect.catchCause` to receive interruption causes from interrupted fibers.

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -538,6 +538,7 @@ export const exitFailCause: <E>(cause: Cause.Cause<E>) => Exit.Exit<never, E> = 
     }
     let cont = fiber.getCont(contE)
     while (fiber.interruptible && fiber._interruptedCause && cont) {
+      cont[contE](cause, fiber, annotated ? undefined : this)
       cont = fiber.getCont(contE)
     }
     return cont

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -2947,6 +2947,19 @@ describe("Effect", () => {
         )
         assert.deepStrictEqual(result, "e2")
       }))
+    it.effect("receives interrupt causes on interruption", () =>
+      Effect.gen(function*() {
+        let caught = false
+        const fiber = yield* Effect.never.pipe(
+          Effect.catchCause(() => Effect.sync(() => {
+            caught = true
+          })),
+          Effect.forkChild({ startImmediately: true })
+        )
+
+        yield* Fiber.interrupt(fiber)
+        assert.isTrue(caught)
+      }))
   })
 
   describe("transaction (composable transactions)", () => {

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -2947,18 +2947,20 @@ describe("Effect", () => {
         )
         assert.deepStrictEqual(result, "e2")
       }))
-    it.effect("receives interrupt causes on interruption", () =>
+    it.effect("receives interrupt causes from fiber interruption", () =>
       Effect.gen(function*() {
-        let caught = false
+        let caught: Cause.Cause<never> | undefined
         const fiber = yield* Effect.never.pipe(
-          Effect.catchCause(() => Effect.sync(() => {
-            caught = true
-          })),
+          Effect.catchCause((cause) => {
+            caught = cause
+            return Effect.void
+          }),
           Effect.forkChild({ startImmediately: true })
         )
 
         yield* Fiber.interrupt(fiber)
-        assert.isTrue(caught)
+        assert.isDefined(caught)
+        assert.isTrue(Cause.hasInterruptsOnly(caught))
       }))
   })
 

--- a/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
+++ b/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
@@ -47,7 +47,8 @@ describe.concurrent("ClusterWorkflowEngine", () => {
       expect(flags.get("compensation")).toBeFalsy()
       // ensuring will run
       expect(flags.get("ensuring")).toBeTruthy()
-      expect(flags.get("catchCause")).toBeFalsy()
+      // catchCause receives the suspension interrupt
+      expect(flags.get("catchCause")).toBeTruthy()
 
       // --- resume the workflow using DurableDeferred.done
 
@@ -71,7 +72,7 @@ describe.concurrent("ClusterWorkflowEngine", () => {
 
       // ensuring will run
       expect(flags.get("ensuring")).toBeTruthy()
-      expect(flags.get("catchCause")).toBeFalsy()
+      expect(flags.get("catchCause")).toBeTruthy()
 
       // test deduplication
       yield* EmailWorkflow.execute({


### PR DESCRIPTION
## Summary

- deliver external interruption causes to failure continuations such as `Effect.catchCause`
- continue unwinding after invoking skipped continuations so handler effects cannot recover from external interruption
- replace the audit reproduction with a focused cause assertion and update workflow suspension expectations
- add a patch changeset for `effect`

## Testing

- `pnpm test --run --project effect --silent=passed-only --reporter=dot`
- `pnpm --filter effect check`
- `pnpm dprint check packages/effect/src/internal/core.ts packages/effect/test/Effect.test.ts packages/effect/test/cluster/ClusterWorkflowEngine.test.ts .changeset/catch-cause-interrupts.md`
- `pnpm oxlint packages/effect/src/internal/core.ts packages/effect/test/Effect.test.ts packages/effect/test/cluster/ClusterWorkflowEngine.test.ts`

Closes EFF-571