### PR TITLE
Fix NodeStream.toString registers duplicate error event listener

### DIFF
--- a/.changeset/sweet-lizards-sing.md
+++ b/.changeset/sweet-lizards-sing.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+Fix `NodeStream.toString` registering a duplicate `error` event listener.

--- a/packages/platform-node-shared/src/NodeStream.ts
+++ b/packages/platform-node-shared/src/NodeStream.ts
@@ -235,9 +235,6 @@ export const toString = <E = Cause.UnknownError>(
       }
       resume(Effect.fail(onError(err) as E))
     })
-    stream.once("error", (err) => {
-      resume(Effect.fail(onError(err) as E))
-    })
 
     let string = ""
     let bytes = 0

--- a/packages/platform-node-shared/test/NodeStream.test.ts
+++ b/packages/platform-node-shared/test/NodeStream.test.ts
@@ -174,19 +174,10 @@ describe("Stream", () => {
   it.effect("toString registers one error listener", () =>
     Effect.gen(function*() {
       const stream = new Readable({
-        read() {
-          this.destroy(new Error("boom"))
-        }
+        read() {}
       })
-      const once = stream.once.bind(stream)
-      let errorListeners = 0
-      stream.once = ((event: string, ...args: Array<any>) => {
-        if (event === "error") errorListeners++
-        return (once as any)(event, ...args)
-      }) as typeof stream.once
-
-      yield* NodeStream.toString(() => stream).pipe(Effect.exit)
-
-      assert.strictEqual(errorListeners, 1)
+      yield* NodeStream.toString(() => stream).pipe(Effect.forkChild)
+      yield* Effect.yieldNow
+      assert.strictEqual(stream.listenerCount("error"), 1)
     }))
 })

--- a/packages/platform-node-shared/test/NodeStream.test.ts
+++ b/packages/platform-node-shared/test/NodeStream.test.ts
@@ -170,4 +170,23 @@ describe("Stream", () => {
       )
       assert.deepEqual(error.cause, "error")
     }))
+
+  it.effect("toString registers one error listener", () =>
+    Effect.gen(function*() {
+      const stream = new Readable({
+        read() {
+          this.destroy(new Error("boom"))
+        }
+      })
+      const once = stream.once.bind(stream)
+      let errorListeners = 0
+      stream.once = ((event: string, ...args: Array<any>) => {
+        if (event === "error") errorListeners++
+        return (once as any)(event, ...args)
+      }) as typeof stream.once
+
+      yield* NodeStream.toString(() => stream).pipe(Effect.exit)
+
+      assert.strictEqual(errorListeners, 1)
+    }))
 })


### PR DESCRIPTION
## Summary

- remove the duplicate one-shot `error` listener from `NodeStream.toString`
- rewrite the regression test to assert the supplied stream's public listener count without monkey-patching
- add a patch changeset for `@effect/platform-node-shared`

## Validation

- `pnpm test --run packages/platform-node-shared/test/NodeStream.test.ts`
- `pnpm --filter @effect/platform-node-shared check`
- targeted `oxlint` and `dprint check`

Closes EFF-569