### PR TITLE
Fix multipart parser continuing after maxParts

### DIFF
--- a/.changeset/multipart-parser-limits.md
+++ b/.changeset/multipart-parser-limits.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Stop multipart parsing after part count, part size, or field size limits are exceeded.

--- a/packages/effect/src/unstable/http/MultipartParser/internal/multipart.ts
+++ b/packages/effect/src/unstable/http/MultipartParser/internal/multipart.ts
@@ -74,7 +74,8 @@ export function make({
     isFile: false,
     fieldChunks: [] as Array<Uint8Array>,
     fieldSize: 0,
-    done: false
+    done: false,
+    stopped: false
   }
 
   function skipBody() {
@@ -88,6 +89,10 @@ export function make({
   const split = Search.make(
     `\r\n--${boundary}`,
     function(index, chunk) {
+      if (state.stopped) {
+        return
+      }
+
       if (index === 0) {
         // data before the first boundary
         skipBody()
@@ -127,12 +132,14 @@ export function make({
 
         state.parts++
         if (state.parts > maxParts) {
-          onError(errMaxParts)
+          state.stopped = true
+          return onError(errMaxParts)
         }
       }
 
       if ((state.partSize += chunk.length) > maxPartSize) {
-        onError(errMaxPartSize)
+        state.stopped = true
+        return onError(errMaxPartSize)
       }
 
       if (state.state === State.headers) {
@@ -199,7 +206,8 @@ export function make({
           } else {
             const buf = chunk.subarray(result.endPosition)
             if ((state.fieldSize += buf.length) > maxFieldSize) {
-              onError(errMaxFieldSize)
+              state.stopped = true
+              return onError(errMaxFieldSize)
             }
             state.fieldChunks.push(buf)
           }
@@ -208,7 +216,8 @@ export function make({
         state.onChunk(chunk)
       } else {
         if ((state.fieldSize += chunk.length) > maxFieldSize) {
-          onError(errMaxFieldSize)
+          state.stopped = true
+          return onError(errMaxFieldSize)
         }
         state.fieldChunks.push(chunk)
       }
@@ -219,6 +228,9 @@ export function make({
 
   return {
     write(chunk: Uint8Array) {
+      if (state.stopped) {
+        return
+      }
       if ((state.totalSize += chunk.length) > maxTotalSize) {
         return onError(errMaxTotalSize)
       }
@@ -226,7 +238,7 @@ export function make({
     },
     end() {
       split.end()
-      if (!state.done) {
+      if (!state.done && !state.stopped) {
         onError(errEndNotReached)
       }
 
@@ -240,6 +252,7 @@ export function make({
       state.fieldChunks = []
       state.fieldSize = 0
       state.done = false
+      state.stopped = false
     }
   } as const
 }

--- a/packages/effect/test/unstable/http/Multipart.test.ts
+++ b/packages/effect/test/unstable/http/Multipart.test.ts
@@ -84,14 +84,42 @@ describe("Multipart", () => {
       strictEqual(error.reason._tag, "TooManyParts")
     }))
 
-  it("stops delivering fields when maxParts is exceeded", () => {
+  it.each<{
+    description: string
+    options: {
+      readonly maxParts?: number
+      readonly maxFieldSize?: number
+      readonly maxPartSize?: number
+    }
+    limit: "MaxParts" | "MaxFieldSize" | "MaxPartSize"
+    expectedFields: Array<string>
+  }>([
+    {
+      description: "maxParts",
+      options: { maxParts: 2 },
+      limit: "MaxParts",
+      expectedFields: ["a", "b"]
+    },
+    {
+      description: "maxFieldSize",
+      options: { maxFieldSize: 1 },
+      limit: "MaxFieldSize",
+      expectedFields: []
+    },
+    {
+      description: "maxPartSize",
+      options: { maxPartSize: 1 },
+      limit: "MaxPartSize",
+      expectedFields: []
+    }
+  ])("stops delivering fields when $description is exceeded", ({ expectedFields, limit, options }) => {
     const boundary = "----testboundary"
     const encoder = new TextEncoder()
     const fields: Array<string> = []
     const errors: Array<MultipartParser.MultipartError> = []
     const parser = MultipartParser.make({
       headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
-      maxParts: 2,
+      ...options,
       onField(info) {
         fields.push(info.name)
       },
@@ -101,13 +129,13 @@ describe("Multipart", () => {
       },
       onDone() {}
     })
-    const part = (name: string) =>
-      `--${boundary}\r\nContent-Disposition: form-data; name="${name}"\r\n\r\n${name}\r\n`
+    const part = (name: string) => `--${boundary}\r\nContent-Disposition: form-data; name="${name}"\r\n\r\nvalue\r\n`
 
     parser.write(encoder.encode(part("a") + part("b") + part("c") + part("d") + `--${boundary}--\r\n`))
+    parser.end()
 
-    deepStrictEqual(errors[0], { _tag: "ReachedLimit", limit: "MaxParts" })
-    deepStrictEqual(fields, ["a", "b"])
+    deepStrictEqual(errors, [{ _tag: "ReachedLimit", limit }])
+    deepStrictEqual(fields, expectedFields)
   })
 
   it("handles the final boundary delimiter split between the trailing hyphens", () => {

--- a/packages/effect/test/unstable/http/Multipart.test.ts
+++ b/packages/effect/test/unstable/http/Multipart.test.ts
@@ -84,6 +84,32 @@ describe("Multipart", () => {
       strictEqual(error.reason._tag, "TooManyParts")
     }))
 
+  it("stops delivering fields when maxParts is exceeded", () => {
+    const boundary = "----testboundary"
+    const encoder = new TextEncoder()
+    const fields: Array<string> = []
+    const errors: Array<MultipartParser.MultipartError> = []
+    const parser = MultipartParser.make({
+      headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+      maxParts: 2,
+      onField(info) {
+        fields.push(info.name)
+      },
+      onFile: () => () => {},
+      onError(error) {
+        errors.push(error)
+      },
+      onDone() {}
+    })
+    const part = (name: string) =>
+      `--${boundary}\r\nContent-Disposition: form-data; name="${name}"\r\n\r\n${name}\r\n`
+
+    parser.write(encoder.encode(part("a") + part("b") + part("c") + part("d") + `--${boundary}--\r\n`))
+
+    deepStrictEqual(errors[0], { _tag: "ReachedLimit", limit: "MaxParts" })
+    deepStrictEqual(fields, ["a", "b"])
+  })
+
   it("handles the final boundary delimiter split between the trailing hyphens", () => {
     const boundary = "----testboundary"
     const encoder = new TextEncoder()

--- a/packages/platform-node/test/MultipartParser.test.ts
+++ b/packages/platform-node/test/MultipartParser.test.ts
@@ -209,14 +209,11 @@ const cases: ReadonlyArray<MultipartCase> = [
     ],
     boundary: "---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k",
     config: {
-      maxPartSize: 13,
       maxFieldSize: 5
     },
-    expected: [
-      ["field", "file_name_0", "super alpha file", "text/plain"],
-      ["file", "upload_file_0", 26, "1k_a.dat", "application/octet-stream"]
-    ],
-    name: "Fields and files (limits)"
+    expected: [],
+    errors: ["ReachedLimit"],
+    name: "stops after maxFieldSize is exceeded"
   },
   {
     source: [
@@ -231,12 +228,11 @@ const cases: ReadonlyArray<MultipartCase> = [
     ],
     boundary: "---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k",
     config: {
-      maxParts: 0
+      maxPartSize: 13
     },
-    expected: [
-      ["file", "upload_file_0", 26, "1k_a.dat", "application/octet-stream"]
-    ],
-    name: "should not emit fieldsLimit if no field was sent"
+    expected: [],
+    errors: ["ReachedLimit"],
+    name: "stops after maxPartSize is exceeded"
   },
   {
     source: [
@@ -257,12 +253,9 @@ const cases: ReadonlyArray<MultipartCase> = [
     config: {
       maxParts: 0
     },
-    expected: [
-      ["field", "file_name_0", "super alpha file", "text/plain"],
-      ["file", "upload_file_0", 26, "1k_a.dat", "application/octet-stream"]
-    ],
-    errors: ["ReachedLimit", "ReachedLimit"],
-    name: "should respect parts limit of 0"
+    expected: [],
+    errors: ["ReachedLimit"],
+    name: "stops before the first part when maxParts is 0"
   },
   {
     source: [
@@ -287,13 +280,9 @@ const cases: ReadonlyArray<MultipartCase> = [
     config: {
       maxParts: 1
     },
-    errors: ["ReachedLimit", "ReachedLimit"],
-    expected: [
-      ["field", "file_name_0", "super alpha file", "text/plain"],
-      ["field", "file_name_1", "super beta file", "text/plain"],
-      ["file", "upload_file_0", 26, "1k_a.dat", "application/octet-stream"]
-    ],
-    name: "should respect parts limit of 1"
+    errors: ["ReachedLimit"],
+    expected: [["field", "file_name_0", "super alpha file", "text/plain"]],
+    name: "stops after maxParts is exceeded"
   },
   {
     source: [


### PR DESCRIPTION
## Summary

Stop the low-level multipart parser after `maxParts`, `maxPartSize`, or `maxFieldSize` is exceeded so later fields are not delivered and the limit error is reported only once.

## Changes

- Add a parser stop state for part-count, part-size, and field-size violations.
- Avoid reporting `EndNotReached` after parsing has intentionally stopped on a limit.
- Consolidate focused regression coverage in `Multipart.test.ts` for all three limits.
- Add an `effect` patch changeset.

## Validation

- `pnpm vitest packages/effect/test/unstable/http/Multipart.test.ts --run`
- `pnpm check`
- `pnpm lint`

Closes EFF-568