### PR TITLE
feat: add support for `mdx` in `@effect/doctest`

### DIFF
--- a/.changeset/big-masks-care.md
+++ b/.changeset/big-masks-care.md
@@ -1,0 +1,5 @@
+---
+"@effect/doctest": patch
+---
+
+Support `.mdx` files

--- a/packages/tools/doctest/README.md
+++ b/packages/tools/doctest/README.md
@@ -1,6 +1,6 @@
 # `@effect/doctest`
 
-`@effect/doctest` extracts marked TypeScript examples from JSDoc comments and Markdown files, then runs each example as an isolated Vitest module.
+`@effect/doctest` extracts marked TypeScript examples from JSDoc comments, Markdown, and MDX files, then runs each example as an isolated Vitest module.
 
 Mark runnable fences with `import.meta.vitest`:
 
@@ -51,7 +51,7 @@ export const value = 1
 
 Markers must trail a complete expression statement or supported `const` declaration on the same line. Standalone markers, destructuring declarations, multiple declarations, and `let` or `var` declarations are not supported. The transform does not implicitly await promises, run Effects, or consume iterators; write those operations explicitly. Ordinary comments are ignored. Await asynchronous work so all assertions and cleanup occur before the snippet module finishes evaluating.
 
-Regular tests can use `include` in the same project. Documentation sources use `includeSource`, which lets Vitest discard files without the marker before collection. The plugin resolves imports relative to each example's original TypeScript or Markdown file:
+Regular tests can use `include` in the same project. Documentation sources use `includeSource`, which lets Vitest discard files without the marker before collection. The plugin resolves imports relative to each example's original TypeScript, Markdown, or MDX file:
 
 ```ts
 import * as Doctest from "@effect/doctest/Plugin"
@@ -61,7 +61,7 @@ export default defineConfig({
   plugins: [Doctest.plugin()],
   test: {
     include: ["test/**/*.test.ts"],
-    includeSource: ["src/**/*.ts", "docs/**/*.md"]
+    includeSource: ["src/**/*.ts", "docs/**/*.{md,mdx}"]
   }
 })
 ```

--- a/packages/tools/doctest/src/Source.ts
+++ b/packages/tools/doctest/src/Source.ts
@@ -98,4 +98,6 @@ export const extract = (source: string, format: SourceFormat = "jsdoc"): Readonl
  * @since 4.0.0
  */
 export const extractFile = (file: string): Promise<ReadonlyArray<Snippet>> =>
-  readFile(file, "utf8").then((source) => extract(source, file.endsWith(".md") ? "markdown" : "jsdoc"))
+  readFile(file, "utf8").then((source) =>
+    extract(source, file.endsWith(".md") || file.endsWith(".mdx") ? "markdown" : "jsdoc")
+  )

--- a/packages/tools/doctest/test/Source.test.ts
+++ b/packages/tools/doctest/test/Source.test.ts
@@ -116,4 +116,24 @@ describe("Source", () => {
       ])
     })
   })
+
+  describe("MDX", () => {
+    it("extracts marked TypeScript fences from mdx content", () => {
+      const source = [
+        "import { SomeComponent } from './component'",
+        "",
+        "## Example",
+        "",
+        "<SomeComponent />",
+        "",
+        "```ts import.meta.vitest",
+        "const result = 42",
+        "```"
+      ].join("\n")
+
+      assert.deepStrictEqual(Source.extract(source, "markdown"), [
+        { source: "const result = 42", line: 7, name: undefined }
+      ])
+    })
+  })
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Add support for `mdx` files

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
