### PR TITLE
Stop child process spawns and kills from flashing console windows on Windows

### DIFF
--- a/.changeset/windows-hide-child-process-console.md
+++ b/.changeset/windows-hide-child-process-console.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+Stop spawned child processes and Windows process-group kills from flashing console windows.

--- a/.changeset/windows-hide-child-process-console.md
+++ b/.changeset/windows-hide-child-process-console.md
@@ -2,4 +2,6 @@
 "@effect/platform-node-shared": patch
 ---
 
-Stop spawned child processes and Windows process-group kills from flashing console windows.
+Pass Node's `windowsHide` flag for spawned Windows children by default (except detached processes), with an independent
+`windowsHide` option for callers that need visible GUI windows. Process-group cleanup now invokes `taskkill` without a
+`cmd.exe` wrapper and hides its window.

--- a/packages/effect/src/unstable/process/ChildProcess.ts
+++ b/packages/effect/src/unstable/process/ChildProcess.ts
@@ -433,6 +433,14 @@ export interface CommandOptions extends KillOptions {
    */
   readonly detached?: boolean | undefined
   /**
+   * If set to `true`, prevents the child process's console or GUI window from
+   * becoming visible on Windows.
+   *
+   * Defaults to `true` unless `detached` is set to `true`. This option has no
+   * effect on non-Windows platforms.
+   */
+  readonly windowsHide?: boolean | undefined
+  /**
    * Configuration options for the standard input stream for the child process.
    */
   readonly stdin?: CommandInput | StdinConfig | undefined

--- a/packages/platform-node-shared/src/NodeChildProcessSpawner.ts
+++ b/packages/platform-node-shared/src/NodeChildProcessSpawner.ts
@@ -40,6 +40,7 @@ import {
 } from "effect/unstable/process/ChildProcessSpawner"
 import * as NodeChildProcess from "node:child_process"
 import { PassThrough } from "node:stream"
+import { buildSpawnOptions } from "./internal/nodeChildProcessSpawner.ts"
 import { handleErrnoException } from "./internal/utils.ts"
 import * as NodeSink from "./NodeSink.ts"
 import * as NodeStream from "./NodeStream.ts"
@@ -668,26 +669,6 @@ export const layer: Layer.Layer<
 // =============================================================================
 // Internal Helpers
 // =============================================================================
-
-/**
- * Builds the Node.js spawn options for a child process command.
- *
- * @category constructors
- * @since 4.0.0
- */
-export const buildSpawnOptions = (
-  options: ChildProcess.CommandOptions,
-  base: Pick<NodeChildProcess.SpawnOptions, "cwd" | "env" | "stdio">,
-  platform: NodeJS.Platform
-): NodeChildProcess.SpawnOptions => {
-  const detached = options.detached ?? platform !== "win32"
-  return {
-    ...base,
-    detached,
-    shell: options.shell,
-    windowsHide: options.windowsHide ?? !detached
-  }
-}
 
 /**
  * Result of flattening a pipeline of commands.

--- a/packages/platform-node-shared/src/NodeChildProcessSpawner.ts
+++ b/packages/platform-node-shared/src/NodeChildProcessSpawner.ts
@@ -354,13 +354,18 @@ const make = Effect.gen(function*() {
   ) => {
     if (globalThis.process.platform === "win32") {
       return Effect.callback<void, PlatformError.PlatformError>((resume) => {
-        NodeChildProcess.exec(`taskkill /pid ${childProcess.pid} /T /F`, (error) => {
-          if (error) {
-            resume(Effect.fail(toPlatformError("kill", toError(error), command)))
-          } else {
-            resume(Effect.void)
+        NodeChildProcess.execFile(
+          "taskkill",
+          ["/pid", String(childProcess.pid), "/T", "/F"],
+          { windowsHide: true },
+          (error) => {
+            if (error) {
+              resume(Effect.fail(toPlatformError("kill", toError(error), command)))
+            } else {
+              resume(Effect.void)
+            }
           }
-        })
+        )
       })
     }
     return Effect.try({
@@ -376,9 +381,14 @@ const make = Effect.gen(function*() {
     signal: NodeJS.Signals
   ): void => {
     if (globalThis.process.platform === "win32") {
-      NodeChildProcess.exec(`taskkill /pid ${childProcess.pid} /T /F`, () => {
-        // ignore errors during best-effort cleanup
-      })
+      NodeChildProcess.execFile(
+        "taskkill",
+        ["/pid", String(childProcess.pid), "/T", "/F"],
+        { windowsHide: true },
+        () => {
+          // ignore errors during best-effort cleanup
+        }
+      )
       return
     }
     try {
@@ -476,7 +486,10 @@ const make = Effect.gen(function*() {
             env,
             stdio,
             detached: cmd.options.detached ?? process.platform !== "win32",
-            shell: cmd.options.shell
+            shell: cmd.options.shell,
+            // Windows gives detached children their own console, so only hide it
+            // when the caller did not explicitly ask to detach
+            windowsHide: cmd.options.detached !== true
           }),
           Effect.fnUntraced(function*([childProcess, exitSignal]) {
             const exited = yield* Deferred.isDone(exitSignal)

--- a/packages/platform-node-shared/src/NodeChildProcessSpawner.ts
+++ b/packages/platform-node-shared/src/NodeChildProcessSpawner.ts
@@ -65,6 +65,17 @@ const toPlatformError = (
 type ExitCodeWithSignal = readonly [code: number | null, signal: NodeJS.Signals | null]
 type ExitSignal = Deferred.Deferred<ExitCodeWithSignal>
 
+const taskkill = (
+  childProcess: NodeChildProcess.ChildProcess,
+  onExit: (error: NodeChildProcess.ExecException | null) => void = () => {}
+) =>
+  NodeChildProcess.execFile(
+    "taskkill",
+    ["/pid", String(childProcess.pid!), "/T", "/F"],
+    { windowsHide: true },
+    onExit
+  )
+
 const make = Effect.gen(function*() {
   const fs = yield* FileSystem.FileSystem
   const path = yield* Path.Path
@@ -354,18 +365,13 @@ const make = Effect.gen(function*() {
   ) => {
     if (globalThis.process.platform === "win32") {
       return Effect.callback<void, PlatformError.PlatformError>((resume) => {
-        NodeChildProcess.execFile(
-          "taskkill",
-          ["/pid", String(childProcess.pid), "/T", "/F"],
-          { windowsHide: true },
-          (error) => {
-            if (error) {
-              resume(Effect.fail(toPlatformError("kill", toError(error), command)))
-            } else {
-              resume(Effect.void)
-            }
+        taskkill(childProcess, (error) => {
+          if (error) {
+            resume(Effect.fail(toPlatformError("kill", toError(error), command)))
+          } else {
+            resume(Effect.void)
           }
-        )
+        })
       })
     }
     return Effect.try({
@@ -381,14 +387,8 @@ const make = Effect.gen(function*() {
     signal: NodeJS.Signals
   ): void => {
     if (globalThis.process.platform === "win32") {
-      NodeChildProcess.execFile(
-        "taskkill",
-        ["/pid", String(childProcess.pid), "/T", "/F"],
-        { windowsHide: true },
-        () => {
-          // ignore errors during best-effort cleanup
-        }
-      )
+      // ignore errors during best-effort cleanup
+      taskkill(childProcess)
       return
     }
     try {
@@ -481,16 +481,7 @@ const make = Effect.gen(function*() {
         const stdio = buildStdioArray(stdinConfig, stdoutConfig, stderrConfig, resolvedAdditionalFds)
 
         const [childProcess, exitSignal] = yield* Effect.acquireRelease(
-          spawn(cmd, {
-            cwd,
-            env,
-            stdio,
-            detached: cmd.options.detached ?? process.platform !== "win32",
-            shell: cmd.options.shell,
-            // Windows gives detached children their own console, so only hide it
-            // when the caller did not explicitly ask to detach
-            windowsHide: cmd.options.detached !== true
-          }),
+          spawn(cmd, buildSpawnOptions(cmd.options, { cwd, env, stdio }, process.platform)),
           Effect.fnUntraced(function*([childProcess, exitSignal]) {
             const exited = yield* Deferred.isDone(exitSignal)
             const killWithTimeout = withTimeout(childProcess, cmd, cmd.options)
@@ -677,6 +668,26 @@ export const layer: Layer.Layer<
 // =============================================================================
 // Internal Helpers
 // =============================================================================
+
+/**
+ * Builds the Node.js spawn options for a child process command.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const buildSpawnOptions = (
+  options: ChildProcess.CommandOptions,
+  base: Pick<NodeChildProcess.SpawnOptions, "cwd" | "env" | "stdio">,
+  platform: NodeJS.Platform
+): NodeChildProcess.SpawnOptions => {
+  const detached = options.detached ?? platform !== "win32"
+  return {
+    ...base,
+    detached,
+    shell: options.shell,
+    windowsHide: options.windowsHide ?? !detached
+  }
+}
 
 /**
  * Result of flattening a pipeline of commands.

--- a/packages/platform-node-shared/src/internal/nodeChildProcessSpawner.ts
+++ b/packages/platform-node-shared/src/internal/nodeChildProcessSpawner.ts
@@ -1,0 +1,16 @@
+import type * as ChildProcess from "effect/unstable/process/ChildProcess"
+import type * as NodeChildProcess from "node:child_process"
+
+export const buildSpawnOptions = (
+  options: ChildProcess.CommandOptions,
+  base: Pick<NodeChildProcess.SpawnOptions, "cwd" | "env" | "stdio">,
+  platform: NodeJS.Platform
+): NodeChildProcess.SpawnOptions => {
+  const detached = options.detached ?? platform !== "win32"
+  return {
+    ...base,
+    detached,
+    shell: options.shell,
+    windowsHide: options.windowsHide ?? !detached
+  }
+}

--- a/packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts
+++ b/packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts
@@ -1,3 +1,4 @@
+import { buildSpawnOptions } from "@effect/platform-node-shared/internal/nodeChildProcessSpawner"
 import * as NodeChildProcessSpawner from "@effect/platform-node-shared/NodeChildProcessSpawner"
 import * as NodeFileSystem from "@effect/platform-node-shared/NodeFileSystem"
 import * as NodePath from "@effect/platform-node-shared/NodePath"
@@ -23,19 +24,19 @@ describe("buildSpawnOptions", () => {
   const base = { stdio: "pipe" } as const
 
   it("defaults to hiding non-detached Windows children", () => {
-    assert.deepStrictEqual(NodeChildProcessSpawner.buildSpawnOptions({}, base, "win32"), {
+    assert.deepStrictEqual(buildSpawnOptions({}, base, "win32"), {
       stdio: "pipe",
       detached: false,
       shell: undefined,
       windowsHide: true
     })
-    assert.deepStrictEqual(NodeChildProcessSpawner.buildSpawnOptions({ detached: true }, base, "win32"), {
+    assert.deepStrictEqual(buildSpawnOptions({ detached: true }, base, "win32"), {
       stdio: "pipe",
       detached: true,
       shell: undefined,
       windowsHide: false
     })
-    assert.deepStrictEqual(NodeChildProcessSpawner.buildSpawnOptions({ detached: false }, base, "win32"), {
+    assert.deepStrictEqual(buildSpawnOptions({ detached: false }, base, "win32"), {
       stdio: "pipe",
       detached: false,
       shell: undefined,
@@ -45,7 +46,7 @@ describe("buildSpawnOptions", () => {
 
   it("allows windowsHide to be configured independently of detached", () => {
     assert.deepStrictEqual(
-      NodeChildProcessSpawner.buildSpawnOptions({ detached: false, windowsHide: false }, base, "win32"),
+      buildSpawnOptions({ detached: false, windowsHide: false }, base, "win32"),
       {
         stdio: "pipe",
         detached: false,
@@ -54,7 +55,7 @@ describe("buildSpawnOptions", () => {
       }
     )
     assert.deepStrictEqual(
-      NodeChildProcessSpawner.buildSpawnOptions({ detached: true, windowsHide: true }, base, "win32"),
+      buildSpawnOptions({ detached: true, windowsHide: true }, base, "win32"),
       {
         stdio: "pipe",
         detached: true,

--- a/packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts
+++ b/packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts
@@ -1,7 +1,7 @@
 import * as NodeChildProcessSpawner from "@effect/platform-node-shared/NodeChildProcessSpawner"
 import * as NodeFileSystem from "@effect/platform-node-shared/NodeFileSystem"
 import * as NodePath from "@effect/platform-node-shared/NodePath"
-import { assert, it } from "@effect/vitest"
+import { assert, describe, it } from "@effect/vitest"
 import * as ChildProcessSpawnerTest from "effect-test/unstable/process/ChildProcessSpawnerTest"
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
@@ -17,6 +17,52 @@ const NodeServices = NodeChildProcessSpawner.layer.pipe(
 
 ChildProcessSpawnerTest.suite("NodeChildProcessSpawner", NodeServices, {
   processGroups: true
+})
+
+describe("buildSpawnOptions", () => {
+  const base = { stdio: "pipe" } as const
+
+  it("defaults to hiding non-detached Windows children", () => {
+    assert.deepStrictEqual(NodeChildProcessSpawner.buildSpawnOptions({}, base, "win32"), {
+      stdio: "pipe",
+      detached: false,
+      shell: undefined,
+      windowsHide: true
+    })
+    assert.deepStrictEqual(NodeChildProcessSpawner.buildSpawnOptions({ detached: true }, base, "win32"), {
+      stdio: "pipe",
+      detached: true,
+      shell: undefined,
+      windowsHide: false
+    })
+    assert.deepStrictEqual(NodeChildProcessSpawner.buildSpawnOptions({ detached: false }, base, "win32"), {
+      stdio: "pipe",
+      detached: false,
+      shell: undefined,
+      windowsHide: true
+    })
+  })
+
+  it("allows windowsHide to be configured independently of detached", () => {
+    assert.deepStrictEqual(
+      NodeChildProcessSpawner.buildSpawnOptions({ detached: false, windowsHide: false }, base, "win32"),
+      {
+        stdio: "pipe",
+        detached: false,
+        shell: undefined,
+        windowsHide: false
+      }
+    )
+    assert.deepStrictEqual(
+      NodeChildProcessSpawner.buildSpawnOptions({ detached: true, windowsHide: true }, base, "win32"),
+      {
+        stdio: "pipe",
+        detached: true,
+        shell: undefined,
+        windowsHide: true
+      }
+    )
+  })
 })
 
 it.live("kills every process in a pipeline", () =>


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

On Windows, spawning a child process or killing a process group can create a console window. In an app that polls providers and shells out to `git`, this shows up as bursts of black windows flashing on screen.

Two causes in `NodeChildProcessSpawner`:

- `spawn` never passed `windowsHide`, which Node defaults to `false`, so spawning a console executable such as `git` or `gh` creates a `conhost` window.
- `killProcessGroup` and `killProcessGroupOnExit` run `taskkill` through `NodeChildProcess.exec`, and `exec` always wraps its argument in `%ComSpec% /d /s /c`. Every process group kill therefore spawns a `cmd.exe`.

The `exec` wrapper is easy to confirm:

```
taskkill via exec()      -> spawnfile: C:\WINDOWS\system32\cmd.exe
taskkill via execFile()  -> spawnfile: taskkill
```

`detached: true` is left alone. Windows gives a detached child its own console on purpose, so hiding it would break callers that want a visible console process. `detached` already defaults to `false` on Windows, so the noisy paths are still covered.

## Validation

- `pnpm check`
- `pnpm lint`
- `pnpm vitest run --project @effect/platform-node-shared`: this package already fails 66 of 114 on Windows. The same run on an unmodified `main` fails identically, so none of those come from this change.

I did not add a test. The package has no seam for asserting the options handed to `NodeChildProcess.spawn`, and mocking the module looked out of keeping with the surrounding tests. Happy to add one if you would rather have it.

Interactive verification in a real Windows console remains external.

## Related

Reported downstream in pingdotgg/t3code#2537, where a 5 minute provider refresh and per-command git cleanup produce a repeating burst of flashes.
