### PR TITLE
Fix multipart file parts hanging when parser limits are exceeded mid-file

### DIFF
--- a/.changeset/fix-multipart-total-size-mid-file.md
+++ b/.changeset/fix-multipart-total-size-mid-file.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fail in-progress multipart file part streams when a parser limit (such as `maxTotalSize`) is exceeded mid-file, instead of hanging indefinitely, and stop masking those parser errors as `InternalError` in `Multipart.toPersisted`.

--- a/packages/effect/src/unstable/http/Multipart.ts
+++ b/packages/effect/src/unstable/http/Multipart.ts
@@ -453,6 +453,7 @@ export const makeChannel = <IE>(headers: Record<string, string>): Channel.Channe
     Effect.map(makeConfig(headers), (config) => {
       let partsBuffer: Array<Part> = []
       let exit = Option.none<Exit.Exit<never, IE | MultipartError | Cause.Done>>()
+      let fileExit = Option.none<Exit.Exit<never, MultipartError>>()
 
       const parser = MP.make({
         ...config,
@@ -463,14 +464,19 @@ export const makeChannel = <IE>(headers: Record<string, string>): Channel.Channe
           let chunks: Array<Uint8Array> = []
           let finished = false
           const pullChunks = Channel.fromPull(
-            Effect.succeed(Effect.suspend(function loop(): Pull.Pull<Arr.NonEmptyReadonlyArray<Uint8Array>> {
-              if (!Arr.isReadonlyArrayNonEmpty(chunks)) {
-                return finished ? Cause.done() : Effect.flatMap(pump, loop)
-              }
-              const chunk = chunks
-              chunks = []
-              return Effect.succeed(chunk)
-            }))
+            Effect.succeed(
+              Effect.suspend(function loop(): Pull.Pull<Arr.NonEmptyReadonlyArray<Uint8Array>, MultipartError> {
+                if (!Arr.isReadonlyArrayNonEmpty(chunks)) {
+                  // a part completed before the parser errored still ends cleanly
+                  if (finished) return Cause.done()
+                  if (Option.isSome(fileExit)) return fileExit.value
+                  return Effect.flatMap(pump, loop)
+                }
+                const chunk = chunks
+                chunks = []
+                return Effect.succeed(chunk)
+              })
+            )
           )
           partsBuffer.push(new FileImpl(info, pullChunks))
           return function(chunk) {
@@ -482,7 +488,9 @@ export const makeChannel = <IE>(headers: Record<string, string>): Channel.Channe
           }
         },
         onError(error_) {
-          exit = Option.some(Exit.fail(convertError(error_)))
+          const error = convertError(error_)
+          fileExit = Option.some(Exit.fail(error))
+          exit = Option.some(Exit.fail(error))
         },
         onDone() {
           if (Option.isNone(exit)) {
@@ -502,6 +510,7 @@ export const makeChannel = <IE>(headers: Record<string, string>): Channel.Channe
           if (Pull.isDoneCause(cause)) {
             parser.end()
           } else {
+            fileExit = Option.some(Exit.failCause(cause)) as any
             exit = Option.some(Exit.failCause(cause)) as any
           }
           return Effect.void
@@ -594,17 +603,14 @@ class FileImpl extends PartBase implements File {
 
   constructor(
     info: MP.PartInfo,
-    channel: Channel.Channel<Arr.NonEmptyReadonlyArray<Uint8Array>>
+    channel: Channel.Channel<Arr.NonEmptyReadonlyArray<Uint8Array>, MultipartError>
   ) {
     super()
     this.key = info.name
     this.name = info.filename ?? info.name
     this.contentType = info.contentType
     this.content = Stream.fromChannel(channel)
-    this.contentEffect = channel.pipe(
-      collectUint8Array,
-      Effect.mapError((cause) => MultipartError.fromReason("InternalError", cause))
-    )
+    this.contentEffect = collectUint8Array(channel)
   }
 
   toJSON(): unknown {
@@ -622,9 +628,8 @@ const defaultWriteFile = (path: string, file: File) =>
   Effect.flatMap(
     FileSystem.FileSystem,
     (fs) =>
-      Effect.mapError(
-        Stream.run(file.content, fs.sink(path)),
-        (cause) => MultipartError.fromReason("InternalError", cause)
+      Stream.run(file.content, fs.sink(path)).pipe(
+        Effect.catchTag("PlatformError", (cause) => Effect.fail(MultipartError.fromReason("InternalError", cause)))
       )
   )
 

--- a/packages/effect/src/unstable/http/Multipart.ts
+++ b/packages/effect/src/unstable/http/Multipart.ts
@@ -510,7 +510,9 @@ export const makeChannel = <IE>(headers: Record<string, string>): Channel.Channe
           if (Pull.isDoneCause(cause)) {
             parser.end()
           } else {
-            fileExit = Option.some(Exit.failCause(cause)) as any
+            fileExit = Option.some(
+              Exit.failCause(Cause.map(cause, (error) => MultipartError.fromReason("InternalError", error)))
+            )
             exit = Option.some(Exit.failCause(cause)) as any
           }
           return Effect.void

--- a/packages/effect/test/unstable/http/Multipart.test.ts
+++ b/packages/effect/test/unstable/http/Multipart.test.ts
@@ -256,6 +256,34 @@ describe("Multipart", () => {
       strictEqual(error.reason._tag, "FileTooLarge")
     }))
 
+  it.effect("wraps upstream errors as InternalError in in-progress file content streams", () =>
+    Effect.gen(function*() {
+      const bytes = new TextEncoder().encode(`${filePart("file", 4096)}\r\n--${boundary}--\r\n`)
+      const stream = Stream.fromReadableStream({
+        evaluate: () =>
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(bytes.subarray(0, 256))
+              controller.enqueue(bytes.subarray(256, 512))
+            },
+            pull(controller) {
+              controller.error(new Error("boom"))
+            }
+          }),
+        onError: identity
+      }).pipe(
+        Stream.pipeThroughChannel(
+          Multipart.makeChannel({ "content-type": `multipart/form-data; boundary=${boundary}` })
+        )
+      )
+      const error = yield* Stream.runForEach(stream, (part) =>
+        part._tag === "File" ? Effect.asVoid(part.contentEffect) : Effect.void).pipe(Effect.flip)
+      if (!(error instanceof Multipart.MultipartError)) {
+        throw new Error(`expected MultipartError, got ${String(error)}`)
+      }
+      strictEqual(error.reason._tag, "InternalError")
+    }))
+
   it.effect("persists completed files before failing when maxTotalSize is exceeded in a later file", () =>
     Effect.gen(function*() {
       const first = filePart("first", 256)

--- a/packages/effect/test/unstable/http/Multipart.test.ts
+++ b/packages/effect/test/unstable/http/Multipart.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "@effect/vitest"
-import { Effect, ErrorReporter, FileSystem, identity, Path, Schema, Stream, Unify } from "effect"
+import { Effect, ErrorReporter, FileSystem, identity, Path, Schema, Sink, Stream, Unify } from "effect"
 import { HttpClientRequest, HttpServerRequest, Multipart, MultipartParser } from "effect/unstable/http"
 import * as HttpServerRespondable from "effect/unstable/http/HttpServerRespondable"
 import { deepStrictEqual, notStrictEqual, strictEqual } from "node:assert"
@@ -195,6 +195,84 @@ describe("Multipart", () => {
       strictEqual(first.path, "/tmp/audit/same.txt")
       notStrictEqual(first.path, second.path)
       deepStrictEqual(writes, [first.path, second.path])
+    }))
+
+  const boundary = "----effectboundary"
+
+  const multipartRequest = (parts: ReadonlyArray<string>) => {
+    const body = `${parts.join("\r\n")}\r\n--${boundary}--\r\n`
+    const bytes = new TextEncoder().encode(body)
+    return Stream.fromReadableStream({
+      evaluate: () =>
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            for (let i = 0; i < bytes.length; i += 256) {
+              controller.enqueue(bytes.subarray(i, i + 256))
+            }
+            controller.close()
+          }
+        }),
+      onError: (cause) => Multipart.MultipartError.fromReason("InternalError", cause)
+    }).pipe(
+      Stream.pipeThroughChannel(
+        Multipart.makeChannel({ "content-type": `multipart/form-data; boundary=${boundary}` })
+      )
+    )
+  }
+
+  const filePart = (name: string, size: number) =>
+    `--${boundary}\r\nContent-Disposition: form-data; name="${name}"; filename="${name}.txt"\r\n\r\n${"A".repeat(size)}`
+
+  const noopFileSystem = FileSystem.makeNoop({
+    makeTempDirectoryScoped: () => Effect.succeed("/tmp/audit"),
+    sink: () => Sink.drain
+  })
+
+  // no Effect.timeout guard: the regression mode is an event-loop-starving busy
+  // loop, which no in-process timer can preempt
+  it.effect("fails the file content stream when maxTotalSize is exceeded mid-file", () =>
+    Effect.gen(function*() {
+      const stream = multipartRequest([filePart("file", 4096)])
+      const error = yield* Multipart.toPersisted(stream).pipe(
+        Effect.provide(Multipart.limitsServices({ maxTotalSize: 512 })),
+        Effect.provideService(FileSystem.FileSystem, noopFileSystem),
+        Effect.provide(Path.layer),
+        Effect.flip
+      )
+      strictEqual(error._tag, "MultipartError")
+      strictEqual(error.reason._tag, "BodyTooLarge")
+    }))
+
+  it.effect("fails the file content stream when maxFileSize is exceeded mid-file", () =>
+    Effect.gen(function*() {
+      const stream = multipartRequest([filePart("file", 4096)])
+      const error = yield* Multipart.toPersisted(stream).pipe(
+        Effect.provide(Multipart.limitsServices({ maxFileSize: 512 })),
+        Effect.provideService(FileSystem.FileSystem, noopFileSystem),
+        Effect.provide(Path.layer),
+        Effect.flip
+      )
+      strictEqual(error._tag, "MultipartError")
+      strictEqual(error.reason._tag, "FileTooLarge")
+    }))
+
+  it.effect("persists completed files before failing when maxTotalSize is exceeded in a later file", () =>
+    Effect.gen(function*() {
+      const first = filePart("first", 256)
+      const stream = multipartRequest([first, filePart("second", 4096)])
+      const written: Array<readonly [string, number]> = []
+      const error = yield* Multipart.toPersisted(
+        stream,
+        (_, file) => Effect.map(file.contentEffect, (bytes) => void written.push([file.name, bytes.length]))
+      ).pipe(
+        Effect.provide(Multipart.limitsServices({ maxTotalSize: first.length + 256 })),
+        Effect.provideService(FileSystem.FileSystem, noopFileSystem),
+        Effect.provide(Path.layer),
+        Effect.flip
+      )
+      strictEqual(error._tag, "MultipartError")
+      strictEqual(error.reason._tag, "BodyTooLarge")
+      deepStrictEqual(written, [["first.txt", 256]])
     }))
 
   it.effect("responds based on the reason and is ignored by the ErrorReporter", () =>


### PR DESCRIPTION
## What & why

`Multipart.toPersisted` (and `Multipart.persisted` in `@effect/platform-bun`) hangs indefinitely when a multipart parser limit such as `maxTotalSize` is exceeded **mid-file** during an upload. The handler never completes and the request eventually times out without any response.

Root cause: when the parser reports a limit violation, it drops the offending chunk without forwarding it to the boundary scanner, so the in-progress file part's terminating boundary is never seen and its content stream never closes. The file part's pull loop in `Multipart.makeChannel` only terminated on that boundary (`finished`), so it kept pumping forever (a busy loop after upstream EOF) without ever observing the parser error. This is the same failure mode that was fixed upstream in multipasta (tim-smart/multipasta#40); the fix there landed in the web-stream wrapper, whose equivalent here is `makeChannel`.

Note: on `main` the external multipasta dependency is gone — the parser is vendored in `effect/unstable/http/MultipartParser` — so instead of a dependency bump this fixes the vendored wrapper. The issue is labeled `3.0`; happy to backport or adjust if a 3.x-line fix (multipasta bump) is wanted separately.

## Changes

- `Multipart.makeChannel`: propagate parser errors (and upstream stream failures) to in-progress file part streams via a `fileExit` exit, checked after buffered chunks drain. A part that **completed** before the parser errored still ends cleanly (`finished` wins), and only the in-progress part fails.
- `toPersisted`'s default file writer: only wrap `PlatformError` as `InternalError`; parser `MultipartError`s now keep their reason (e.g. `BodyTooLarge` → 413 instead of a masked `InternalError` → 500). Same for `File.contentEffect`, which previously wrapped every error as `InternalError`.
- Regression tests (3): `maxTotalSize` mid-file, `maxFileSize` mid-file, and a two-file case asserting a completed first file persists fully before the second file fails.
- Changeset: `effect` patch.

## Reproduction & verification

- New tests **hang** on current `main` (an event-loop-starving busy loop — verified by stashing the fix; no in-process timeout can preempt it) and **pass** with the fix.
- End-to-end under real Bun (1.3.14): `BunMultipart.persisted(request)` with `maxTotalSize: 1024` and a chunked 8 KB upload — **hangs pre-fix** (killed after 15 s), **fails fast with `MultipartError: BodyTooLarge` post-fix**.
- Checks run: `pnpm test --run test/unstable/http/Multipart.test.ts` (13/13), `HttpServerRequest.test.ts` + `HttpEffect.test.ts` (40/40), `@effect/platform-node` `MultipartParser.test.ts` (84/84), `bun node_modules/vitest/vitest.mjs run --project @effect/platform-bun` (13/13), `pnpm check` (tsc -b, clean), `pnpm lint-fix` (0 errors).

## Review & limitations

- Diff reviewed with kiro-cli (claude-opus-5); two rounds of findings addressed (default writeFile path now tested, upstream-halt passes the `Cause` through instead of squashing, multi-file ordering test added). Final pass: LGTM.
- The `@effect/platform-bun` test project has no multipart coverage; Bun verification was done with an ad-hoc script (deleted after use) rather than a committed test.
- No explicit timeout guard in the regression tests: the pre-fix failure mode starves the event loop, so no in-process timer (including vitest's own `testTimeout`) can fire — noted in a comment above the tests.

Closes #6284