### PR TITLE
Improve Union candidate selection for nested unions and contradicted sentinels

### DIFF
--- a/.changeset/nested-union-sentinels.md
+++ b/.changeset/nested-union-sentinels.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Improve Union candidate selection: a nested union member is dispatched by the sentinels common to all its members, and candidates whose sentinel the input contradicts are excluded.

--- a/packages/effect/runtimeperf/config.json
+++ b/packages/effect/runtimeperf/config.json
@@ -160,6 +160,34 @@
               ],
               "path": "invalid",
               "size": 100
+            },
+            {
+              "name": "multi-sentinel-100-valid-first-effect",
+              "export": "effectMultiSentinel100ValidFirst",
+              "scenario": "multi-sentinel-100-valid-first",
+              "implementation": "effect",
+              "family": "union",
+              "astTags": [
+                "Union",
+                "Objects",
+                "Literal"
+              ],
+              "path": "valid",
+              "size": 100
+            },
+            {
+              "name": "multi-sentinel-100-invalid-variant-effect",
+              "export": "effectMultiSentinel100InvalidVariant",
+              "scenario": "multi-sentinel-100-invalid-variant",
+              "implementation": "effect",
+              "family": "union",
+              "astTags": [
+                "Union",
+                "Objects",
+                "Literal"
+              ],
+              "path": "invalid",
+              "size": 100
             }
           ]
         },

--- a/packages/effect/runtimeperf/suites/schema/fixtures/comparison.ts
+++ b/packages/effect/runtimeperf/suites/schema/fixtures/comparison.ts
@@ -69,3 +69,23 @@ const effectTagged100 = Schema.Union(
 export const effectTagged100ValidLast = effectCase(effectTagged100, taggedInput, true)
 export const effectTagged100InvalidSelected = effectCase(effectTagged100, taggedInvalidSelected, false)
 export const effectTagged100InvalidTag = effectCase(effectTagged100, taggedInvalidTag, false)
+
+const makeEffectMultiSentinelMember = (index) =>
+  Schema.Struct({
+    kind: Schema.Literal("shared"),
+    variant: Schema.Literal(`variant${index}`),
+    value: Schema.String
+  })
+
+const effectMultiSentinel100 = Schema.Union(
+  Array.from({ length: 100 }, (_, index) => makeEffectMultiSentinelMember(index))
+)
+const multiSentinelValidFirst = { kind: "shared", variant: "variant0", value: "value" }
+const multiSentinelInvalidVariant = { kind: "shared", variant: "missing", value: "value" }
+
+export const effectMultiSentinel100ValidFirst = effectCase(effectMultiSentinel100, multiSentinelValidFirst, true)
+export const effectMultiSentinel100InvalidVariant = effectCase(
+  effectMultiSentinel100,
+  multiSentinelInvalidVariant,
+  false
+)

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -2614,6 +2614,13 @@ export function collectSentinels(ast: AST): ReadonlyArray<Sentinel> {
         }
         return []
       })
+    case "Union": {
+      if (ast.types.length === 0) return []
+      const members = ast.types.map((type) => collectSentinels(toCandidate(type)))
+      return members[0].filter((s) =>
+        members.every((sentinels) => sentinels.some((o) => o.key === s.key && o.literal === s.literal))
+      )
+    }
     case "Suspend":
       return collectSentinels(ast.thunk())
   }
@@ -2726,12 +2733,16 @@ export function getCandidates(
     const base = idx.otherwise?.[runtimeType] ?? emptyCandidates
     if (Predicate.isObjectKeyword(input)) {
       const selected = new Set(base)
+      const excluded = new Set<number>()
       for (const [k, m] of idx.bySentinel) {
         const value = Object.hasOwn(input, k) ? (input as any)[k] : undefined
         if (value !== undefined) {
-          const match = m.get(value)
-          if (match) {
-            for (const candidate of match) selected.add(candidate)
+          for (const [literal, indexes] of m) {
+            if (literal === value) {
+              for (const candidate of indexes) selected.add(candidate)
+            } else {
+              for (const candidate of indexes) excluded.add(candidate)
+            }
           }
         } else if (isConstructor) {
           for (const indexes of m.values()) {
@@ -2739,7 +2750,7 @@ export function getCandidates(
           }
         }
       }
-      return Array.from(selected).sort((a, b) => a - b).map((i) => types[i])
+      return Array.from(selected).filter((i) => !excluded.has(i)).sort((a, b) => a - b).map((i) => types[i])
     }
     return base.map((i) => types[i])
   }

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -2627,7 +2627,10 @@ export function collectSentinels(ast: AST): ReadonlyArray<Sentinel> {
 }
 
 type CandidateIndex = (input: any, isConstructor: boolean) => ReadonlyArray<AST>
-type SentinelEntry = readonly [Map<LiteralValue | symbol, Set<number>>, Set<number>]
+type SentinelEntry = readonly [
+  byValue: Map<LiteralValue | symbol, Set<number>>,
+  all: Set<number>
+]
 type SentinelIndex = Map<PropertyKey, SentinelEntry>
 
 const candidateIndexCache = new WeakMap<ReadonlyArray<AST>, CandidateIndex>()
@@ -2697,6 +2700,9 @@ function getIndex(types: ReadonlyArray<AST>): CandidateIndex {
       return emptyCandidates
     }
   } else if (bySentinel) {
+    // A key owned by every discriminated candidate is safe to use as the initial selector: no candidate can
+    // be excluded merely because it uses a different sentinel key. Prefer the key with the most distinct values
+    // to minimize the matching bucket.
     let commonSentinel: [PropertyKey, SentinelEntry] | undefined
     for (const entry of bySentinel) {
       if (
@@ -2712,8 +2718,11 @@ function getIndex(types: ReadonlyArray<AST>): CandidateIndex {
       const base = otherwise?.[runtimeType] ?? emptyCandidates
       if (!Predicate.isObjectKeyword(input)) return base.map((i) => types[i])
 
+      // Non-discriminated candidates are runtime-type fallbacks and are never removed by sentinel checks.
       const selected = new Set(base)
       let directKey: PropertyKey | undefined
+      // An observed common key can seed the selection directly; an unknown value rules out every
+      // discriminated candidate.
       if (commonSentinel) {
         const [key, [byValue]] = commonSentinel
         const hasKey = Object.hasOwn(input, key)
@@ -2726,6 +2735,8 @@ function getIndex(types: ReadonlyArray<AST>): CandidateIndex {
         }
       }
 
+      // Without an observed common key, collect positive matches from every sentinel. Constructor mode treats
+      // absent and undefined keys as unconstrained and therefore selects every candidate that owns the key.
       if (directKey === undefined) {
         for (const [key, [byValue, all]] of bySentinel) {
           const hasKey = Object.hasOwn(input, key)
@@ -2740,6 +2751,7 @@ function getIndex(types: ReadonlyArray<AST>): CandidateIndex {
           }
         }
       }
+      // Missing keys are neutral. An observed key rejects only selected candidates that own it and do not match.
       for (const [key, [byValue, all]] of bySentinel) {
         if (key === directKey) continue
         const hasKey = Object.hasOwn(input, key)

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -2630,6 +2630,8 @@ type CandidateIndex =
   | ((input: any, isConstructor: boolean) => ReadonlyArray<AST>)
   | {
     bySentinel?: Map<PropertyKey, Map<LiteralValue | symbol, Array<number>>>
+    completeSentinelCoverage?: boolean
+    sentinelsByCandidate?: Array<ReadonlyArray<Sentinel> | undefined>
     otherwise?: { [K in Type]?: Array<number> }
   }
 
@@ -2663,6 +2665,8 @@ function getIndex(types: ReadonlyArray<AST>): CandidateIndex {
 
     if (sentinels.length) { // discriminated variants
       idx.bySentinel ??= new Map()
+      const sentinelsByCandidate = idx.sentinelsByCandidate ??= []
+      sentinelsByCandidate[i] = sentinels
       for (const { key, literal } of sentinels) {
         let m = idx.bySentinel.get(key)
         if (!m) idx.bySentinel.set(key, m = new Map())
@@ -2675,6 +2679,13 @@ function getIndex(types: ReadonlyArray<AST>): CandidateIndex {
       const candidateTypes = getCandidateTypes(encoded)
       for (const t of candidateTypes) (idx.otherwise[t] ??= []).push(i)
     }
+  }
+
+  if (idx.bySentinel && idx.sentinelsByCandidate) {
+    const keys = Array.from(idx.bySentinel.keys())
+    idx.completeSentinelCoverage = idx.sentinelsByCandidate.every((sentinels) =>
+      sentinels === undefined || keys.every((key) => sentinels.some((sentinel) => sentinel.key === key))
+    )
   }
 
   if (literalCandidates) {
@@ -2712,6 +2723,14 @@ function filterLiterals(input: any) {
   }
 }
 
+function matchesSentinels(input: any, sentinels: ReadonlyArray<Sentinel>, isConstructor: boolean): boolean {
+  return sentinels.every(({ key, literal }) => {
+    if (!Object.hasOwn(input, key)) return true
+    const value = input[key]
+    return (isConstructor && value === undefined) || value === literal
+  })
+}
+
 /**
  * The goal is to reduce the number of a union members that will be checked.
  * This is useful to reduce the number of issues that will be returned.
@@ -2732,17 +2751,37 @@ export function getCandidates(
   if (idx.bySentinel) {
     const base = idx.otherwise?.[runtimeType] ?? emptyCandidates
     if (Predicate.isObjectKeyword(input)) {
+      if (idx.completeSentinelCoverage) {
+        // Every discriminated candidate is constrained by every sentinel key,
+        // so the smallest positive match is a safe and selective starting point.
+        let seed: ReadonlyArray<number> | undefined
+        for (const [key, byValue] of idx.bySentinel) {
+          const hasKey = Object.hasOwn(input, key)
+          const value = hasKey ? (input as any)[key] : undefined
+          if (hasKey && (!isConstructor || value !== undefined)) {
+            const match = byValue.get(value)
+            if (!match) return base.map((i) => types[i])
+            if (!seed || match.length < seed.length) seed = match
+          }
+        }
+        if (seed) {
+          const selected = new Set(base)
+          for (const i of seed) {
+            if (matchesSentinels(input, idx.sentinelsByCandidate![i]!, isConstructor)) selected.add(i)
+          }
+          return Array.from(selected).sort((a, b) => a - b).map((i) => types[i])
+        }
+        if (!isConstructor) return base.map((i) => types[i])
+      }
+
       const selected = new Set(base)
-      const excluded = new Set<number>()
       for (const [k, m] of idx.bySentinel) {
-        const value = Object.hasOwn(input, k) ? (input as any)[k] : undefined
-        if (value !== undefined) {
-          for (const [literal, indexes] of m) {
-            if (literal === value) {
-              for (const candidate of indexes) selected.add(candidate)
-            } else {
-              for (const candidate of indexes) excluded.add(candidate)
-            }
+        const hasKey = Object.hasOwn(input, k)
+        const value = hasKey ? (input as any)[k] : undefined
+        if (hasKey && (!isConstructor || value !== undefined)) {
+          const match = m.get(value)
+          if (match) {
+            for (const candidate of match) selected.add(candidate)
           }
         } else if (isConstructor) {
           for (const indexes of m.values()) {
@@ -2750,7 +2789,10 @@ export function getCandidates(
           }
         }
       }
-      return Array.from(selected).filter((i) => !excluded.has(i)).sort((a, b) => a - b).map((i) => types[i])
+      return Array.from(selected).filter((i) => {
+        const sentinels = idx.sentinelsByCandidate?.[i]
+        return !sentinels || matchesSentinels(input, sentinels, isConstructor)
+      }).sort((a, b) => a - b).map((i) => types[i])
     }
     return base.map((i) => types[i])
   }

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -2627,6 +2627,8 @@ export function collectSentinels(ast: AST): ReadonlyArray<Sentinel> {
 }
 
 type CandidateIndex = (input: any, isConstructor: boolean) => ReadonlyArray<AST>
+type SentinelEntry = readonly [Map<LiteralValue | symbol, Set<number>>, Set<number>]
+type SentinelIndex = Map<PropertyKey, SentinelEntry>
 
 const candidateIndexCache = new WeakMap<ReadonlyArray<AST>, CandidateIndex>()
 const emptyCandidates: ReadonlyArray<never> = Object.freeze([])
@@ -2635,9 +2637,8 @@ function getIndex(types: ReadonlyArray<AST>): CandidateIndex {
   let index = candidateIndexCache.get(types)
   if (index) return index
 
-  let bySentinel: Map<PropertyKey, Map<LiteralValue | symbol, Array<number>>> | undefined
-  const sentinelCandidates: Array<number> = []
-  const sentinelsByCandidate: Array<ReadonlyArray<Sentinel> | undefined> = []
+  let bySentinel: SentinelIndex | undefined
+  let sentinelCandidateCount = 0
   let otherwise: { [K in Type]?: Array<number> } | undefined
   let literalCandidates: Map<LiteralValue | symbol, Array<AST>> | undefined
   let onlyLiterals = true
@@ -2662,14 +2663,14 @@ function getIndex(types: ReadonlyArray<AST>): CandidateIndex {
 
     if (sentinels.length) { // discriminated variants
       bySentinel ??= new Map()
-      sentinelCandidates.push(i)
-      sentinelsByCandidate[i] = sentinels
+      sentinelCandidateCount++
       for (const { key, literal } of sentinels) {
-        let m = bySentinel.get(key)
-        if (!m) bySentinel.set(key, m = new Map())
-        let arr = m.get(literal)
-        if (!arr) m.set(literal, arr = [])
-        if (arr[arr.length - 1] !== i) arr.push(i)
+        let entry = bySentinel.get(key)
+        if (!entry) bySentinel.set(key, entry = [new Map(), new Set()])
+        entry[1].add(i)
+        let indexes = entry[0].get(literal)
+        if (!indexes) entry[0].set(literal, indexes = new Set())
+        indexes.add(i)
       }
     } else { // non-discriminated
       otherwise ??= {}
@@ -2682,10 +2683,10 @@ function getIndex(types: ReadonlyArray<AST>): CandidateIndex {
     literalCandidates.forEach(Object.freeze)
     index = (input) => literalCandidates.get(input) ?? emptyCandidates
   } else if (bySentinel?.size === 1 && !otherwise) {
-    const [key, byValue] = bySentinel.entries().next().value!
+    const [key, [byValue]] = bySentinel.entries().next().value!
     const candidates = byValue as unknown as Map<LiteralValue | symbol, ReadonlyArray<AST>>
     for (const [literal, indexes] of byValue) {
-      candidates.set(literal, Object.freeze(indexes.map((index) => types[index])))
+      candidates.set(literal, Object.freeze(Array.from(indexes, (index) => types[index])))
     }
     index = (input, isConstructor) => {
       if (Predicate.isObjectKeyword(input)) {
@@ -2696,62 +2697,61 @@ function getIndex(types: ReadonlyArray<AST>): CandidateIndex {
       return emptyCandidates
     }
   } else if (bySentinel) {
-    const keys = Array.from(bySentinel.keys())
-    const completeSentinelCoverage = sentinelCandidates.every((i) =>
-      keys.every((key) => sentinelsByCandidate[i]!.some((sentinel) => sentinel.key === key))
-    )
+    let commonSentinel: [PropertyKey, SentinelEntry] | undefined
+    for (const entry of bySentinel) {
+      if (
+        (!commonSentinel || entry[1][0].size > commonSentinel[1][0].size) &&
+        entry[1][1].size === sentinelCandidateCount
+      ) {
+        commonSentinel = entry
+      }
+    }
 
     index = (input, isConstructor) => {
       const runtimeType: Type = input === null ? "null" : Array.isArray(input) ? "array" : typeof input
       const base = otherwise?.[runtimeType] ?? emptyCandidates
       if (!Predicate.isObjectKeyword(input)) return base.map((i) => types[i])
 
-      if (completeSentinelCoverage) {
-        // Every discriminated candidate is constrained by every sentinel key,
-        // so the smallest positive match is a safe and selective starting point.
-        let seed: ReadonlyArray<number> | undefined
-        for (const [key, byValue] of bySentinel) {
-          const hasKey = Object.hasOwn(input, key)
-          const value = hasKey ? (input as any)[key] : undefined
-          if (hasKey && (!isConstructor || value !== undefined)) {
-            const match = byValue.get(value)
-            if (!match) return base.map((i) => types[i])
-            if (!seed || match.length < seed.length) seed = match
-          }
-        }
-        if (seed) {
-          const selected = new Set(base)
-          if (bySentinel.size === 1) {
-            for (const i of seed) selected.add(i)
-          } else {
-            for (const i of seed) {
-              if (matchesSentinels(input, sentinelsByCandidate[i]!, isConstructor)) selected.add(i)
-            }
-          }
-          return Array.from(selected).sort((a, b) => a - b).map((i) => types[i])
-        }
-        if (!isConstructor) return base.map((i) => types[i])
-      }
-
       const selected = new Set(base)
-      for (const [key, byValue] of bySentinel) {
+      let directKey: PropertyKey | undefined
+      if (commonSentinel) {
+        const [key, [byValue]] = commonSentinel
         const hasKey = Object.hasOwn(input, key)
         const value = hasKey ? (input as any)[key] : undefined
         if (hasKey && (!isConstructor || value !== undefined)) {
           const match = byValue.get(value)
-          if (match) {
-            for (const i of match) selected.add(i)
-          }
-        } else if (isConstructor) {
-          for (const indexes of byValue.values()) {
-            for (const i of indexes) selected.add(i)
+          if (!match) return base.map((i) => types[i])
+          for (const i of match) selected.add(i)
+          directKey = key
+        }
+      }
+
+      if (directKey === undefined) {
+        for (const [key, [byValue, all]] of bySentinel) {
+          const hasKey = Object.hasOwn(input, key)
+          const value = hasKey ? (input as any)[key] : undefined
+          if (hasKey && (!isConstructor || value !== undefined)) {
+            const match = byValue.get(value)
+            if (match) {
+              for (const i of match) selected.add(i)
+            }
+          } else if (isConstructor) {
+            for (const i of all) selected.add(i)
           }
         }
       }
-      return Array.from(selected).filter((i) => {
-        const sentinels = sentinelsByCandidate[i]
-        return !sentinels || matchesSentinels(input, sentinels, isConstructor)
-      }).sort((a, b) => a - b).map((i) => types[i])
+      for (const [key, [byValue, all]] of bySentinel) {
+        if (key === directKey) continue
+        const hasKey = Object.hasOwn(input, key)
+        const value = hasKey ? (input as any)[key] : undefined
+        if (hasKey && (!isConstructor || value !== undefined)) {
+          const match = byValue.get(value)
+          for (const i of selected) {
+            if (all.has(i) && !match?.has(i)) selected.delete(i)
+          }
+        }
+      }
+      return Array.from(selected).sort((a, b) => a - b).map((i) => types[i])
     }
   } else {
     index = (input) => {
@@ -2773,14 +2773,6 @@ function filterLiterals(input: any) {
       encoded.symbol === input
       : true
   }
-}
-
-function matchesSentinels(input: any, sentinels: ReadonlyArray<Sentinel>, isConstructor: boolean): boolean {
-  return sentinels.every(({ key, literal }) => {
-    if (!Object.hasOwn(input, key)) return true
-    const value = input[key]
-    return (isConstructor && value === undefined) || value === literal
-  })
 }
 
 /**

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -2766,8 +2766,12 @@ export function getCandidates(
         }
         if (seed) {
           const selected = new Set(base)
-          for (const i of seed) {
-            if (matchesSentinels(input, idx.sentinelsByCandidate![i]!, isConstructor)) selected.add(i)
+          if (idx.bySentinel.size === 1) {
+            for (const i of seed) selected.add(i)
+          } else {
+            for (const i of seed) {
+              if (matchesSentinels(input, idx.sentinelsByCandidate![i]!, isConstructor)) selected.add(i)
+            }
           }
           return Array.from(selected).sort((a, b) => a - b).map((i) => types[i])
         }

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -2626,30 +2626,27 @@ export function collectSentinels(ast: AST): ReadonlyArray<Sentinel> {
   }
 }
 
-type CandidateIndex =
-  | ((input: any, isConstructor: boolean) => ReadonlyArray<AST>)
-  | {
-    bySentinel?: Map<PropertyKey, Map<LiteralValue | symbol, Array<number>>>
-    completeSentinelCoverage?: boolean
-    sentinelsByCandidate?: Array<ReadonlyArray<Sentinel> | undefined>
-    otherwise?: { [K in Type]?: Array<number> }
-  }
+type CandidateIndex = (input: any, isConstructor: boolean) => ReadonlyArray<AST>
 
 const candidateIndexCache = new WeakMap<ReadonlyArray<AST>, CandidateIndex>()
 const emptyCandidates: ReadonlyArray<never> = Object.freeze([])
 
 function getIndex(types: ReadonlyArray<AST>): CandidateIndex {
-  let idx = candidateIndexCache.get(types)
-  if (idx) return idx
+  let index = candidateIndexCache.get(types)
+  if (index) return index
 
-  idx = {}
-  let literalCandidates: Map<LiteralValue | symbol, Array<AST>> | null | undefined
+  let bySentinel: Map<PropertyKey, Map<LiteralValue | symbol, Array<number>>> | undefined
+  const sentinelCandidates: Array<number> = []
+  const sentinelsByCandidate: Array<ReadonlyArray<Sentinel> | undefined> = []
+  let otherwise: { [K in Type]?: Array<number> } | undefined
+  let literalCandidates: Map<LiteralValue | symbol, Array<AST>> | undefined
+  let onlyLiterals = true
   for (let i = 0; i < types.length; i++) {
     const a = types[i]
     const encoded = toCandidate(a)
     if (isNever(encoded)) continue
 
-    if (literalCandidates !== null) {
+    if (onlyLiterals) {
       if (isLiteral(encoded) || isUniqueSymbol(encoded)) {
         literalCandidates ??= new Map()
         const literal = isLiteral(encoded) ? encoded.literal : encoded.symbol
@@ -2657,59 +2654,114 @@ function getIndex(types: ReadonlyArray<AST>): CandidateIndex {
         if (!arr) literalCandidates.set(literal, arr = [])
         arr.push(a)
       } else {
-        literalCandidates = null
+        onlyLiterals = false
       }
     }
 
     const sentinels = collectSentinels(encoded)
 
     if (sentinels.length) { // discriminated variants
-      idx.bySentinel ??= new Map()
-      const sentinelsByCandidate = idx.sentinelsByCandidate ??= []
+      bySentinel ??= new Map()
+      sentinelCandidates.push(i)
       sentinelsByCandidate[i] = sentinels
       for (const { key, literal } of sentinels) {
-        let m = idx.bySentinel.get(key)
-        if (!m) idx.bySentinel.set(key, m = new Map())
+        let m = bySentinel.get(key)
+        if (!m) bySentinel.set(key, m = new Map())
         let arr = m.get(literal)
         if (!arr) m.set(literal, arr = [])
         if (arr[arr.length - 1] !== i) arr.push(i)
       }
     } else { // non-discriminated
-      idx.otherwise ??= {}
+      otherwise ??= {}
       const candidateTypes = getCandidateTypes(encoded)
-      for (const t of candidateTypes) (idx.otherwise[t] ??= []).push(i)
+      for (const t of candidateTypes) (otherwise[t] ??= []).push(i)
     }
   }
 
-  if (idx.bySentinel && idx.sentinelsByCandidate) {
-    const keys = Array.from(idx.bySentinel.keys())
-    idx.completeSentinelCoverage = idx.sentinelsByCandidate.every((sentinels) =>
-      sentinels === undefined || keys.every((key) => sentinels.some((sentinel) => sentinel.key === key))
-    )
-  }
-
-  if (literalCandidates) {
+  if (onlyLiterals && literalCandidates) {
     literalCandidates.forEach(Object.freeze)
-    idx = (input) => literalCandidates.get(input) ?? emptyCandidates
-  } else if (idx.bySentinel?.size === 1 && !idx.otherwise) {
-    for (const [key, byValue] of idx.bySentinel) {
-      const candidates = byValue as unknown as Map<LiteralValue | symbol, ReadonlyArray<AST>>
-      for (const [literal, indexes] of byValue) {
-        candidates.set(literal, Object.freeze(indexes.map((index) => types[index])))
+    index = (input) => literalCandidates.get(input) ?? emptyCandidates
+  } else if (bySentinel?.size === 1 && !otherwise) {
+    const [key, byValue] = bySentinel.entries().next().value!
+    const candidates = byValue as unknown as Map<LiteralValue | symbol, ReadonlyArray<AST>>
+    for (const [literal, indexes] of byValue) {
+      candidates.set(literal, Object.freeze(indexes.map((index) => types[index])))
+    }
+    index = (input, isConstructor) => {
+      if (Predicate.isObjectKeyword(input)) {
+        const value = Object.hasOwn(input, key) ? (input as any)[key] : undefined
+        if (value !== undefined) return candidates.get(value) ?? emptyCandidates
+        if (isConstructor) return types
       }
-      idx = (input, isConstructor) => {
-        if (Predicate.isObjectKeyword(input)) {
-          const value = Object.hasOwn(input, key) ? (input as any)[key] : undefined
-          if (value !== undefined) return candidates.get(value) ?? emptyCandidates
-          if (isConstructor) return types
+      return emptyCandidates
+    }
+  } else if (bySentinel) {
+    const keys = Array.from(bySentinel.keys())
+    const completeSentinelCoverage = sentinelCandidates.every((i) =>
+      keys.every((key) => sentinelsByCandidate[i]!.some((sentinel) => sentinel.key === key))
+    )
+
+    index = (input, isConstructor) => {
+      const runtimeType: Type = input === null ? "null" : Array.isArray(input) ? "array" : typeof input
+      const base = otherwise?.[runtimeType] ?? emptyCandidates
+      if (!Predicate.isObjectKeyword(input)) return base.map((i) => types[i])
+
+      if (completeSentinelCoverage) {
+        // Every discriminated candidate is constrained by every sentinel key,
+        // so the smallest positive match is a safe and selective starting point.
+        let seed: ReadonlyArray<number> | undefined
+        for (const [key, byValue] of bySentinel) {
+          const hasKey = Object.hasOwn(input, key)
+          const value = hasKey ? (input as any)[key] : undefined
+          if (hasKey && (!isConstructor || value !== undefined)) {
+            const match = byValue.get(value)
+            if (!match) return base.map((i) => types[i])
+            if (!seed || match.length < seed.length) seed = match
+          }
         }
-        return emptyCandidates
+        if (seed) {
+          const selected = new Set(base)
+          if (bySentinel.size === 1) {
+            for (const i of seed) selected.add(i)
+          } else {
+            for (const i of seed) {
+              if (matchesSentinels(input, sentinelsByCandidate[i]!, isConstructor)) selected.add(i)
+            }
+          }
+          return Array.from(selected).sort((a, b) => a - b).map((i) => types[i])
+        }
+        if (!isConstructor) return base.map((i) => types[i])
       }
+
+      const selected = new Set(base)
+      for (const [key, byValue] of bySentinel) {
+        const hasKey = Object.hasOwn(input, key)
+        const value = hasKey ? (input as any)[key] : undefined
+        if (hasKey && (!isConstructor || value !== undefined)) {
+          const match = byValue.get(value)
+          if (match) {
+            for (const i of match) selected.add(i)
+          }
+        } else if (isConstructor) {
+          for (const indexes of byValue.values()) {
+            for (const i of indexes) selected.add(i)
+          }
+        }
+      }
+      return Array.from(selected).filter((i) => {
+        const sentinels = sentinelsByCandidate[i]
+        return !sentinels || matchesSentinels(input, sentinels, isConstructor)
+      }).sort((a, b) => a - b).map((i) => types[i])
+    }
+  } else {
+    index = (input) => {
+      const runtimeType: Type = input === null ? "null" : Array.isArray(input) ? "array" : typeof input
+      return (otherwise?.[runtimeType] ?? emptyCandidates).map((i) => types[i]).filter(filterLiterals(input))
     }
   }
 
-  candidateIndexCache.set(types, idx)
-  return idx
+  candidateIndexCache.set(types, index)
+  return index
 }
 
 function filterLiterals(input: any) {
@@ -2742,67 +2794,7 @@ export function getCandidates(
   types: ReadonlyArray<AST>,
   isConstructor = false
 ): ReadonlyArray<AST> {
-  const idx = getIndex(types)
-  if (typeof idx === "function") return idx(input, isConstructor)
-
-  const runtimeType: Type = input === null ? "null" : Array.isArray(input) ? "array" : typeof input
-
-  // 1. Try sentinel-based dispatch (most selective)
-  if (idx.bySentinel) {
-    const base = idx.otherwise?.[runtimeType] ?? emptyCandidates
-    if (Predicate.isObjectKeyword(input)) {
-      if (idx.completeSentinelCoverage) {
-        // Every discriminated candidate is constrained by every sentinel key,
-        // so the smallest positive match is a safe and selective starting point.
-        let seed: ReadonlyArray<number> | undefined
-        for (const [key, byValue] of idx.bySentinel) {
-          const hasKey = Object.hasOwn(input, key)
-          const value = hasKey ? (input as any)[key] : undefined
-          if (hasKey && (!isConstructor || value !== undefined)) {
-            const match = byValue.get(value)
-            if (!match) return base.map((i) => types[i])
-            if (!seed || match.length < seed.length) seed = match
-          }
-        }
-        if (seed) {
-          const selected = new Set(base)
-          if (idx.bySentinel.size === 1) {
-            for (const i of seed) selected.add(i)
-          } else {
-            for (const i of seed) {
-              if (matchesSentinels(input, idx.sentinelsByCandidate![i]!, isConstructor)) selected.add(i)
-            }
-          }
-          return Array.from(selected).sort((a, b) => a - b).map((i) => types[i])
-        }
-        if (!isConstructor) return base.map((i) => types[i])
-      }
-
-      const selected = new Set(base)
-      for (const [k, m] of idx.bySentinel) {
-        const hasKey = Object.hasOwn(input, k)
-        const value = hasKey ? (input as any)[k] : undefined
-        if (hasKey && (!isConstructor || value !== undefined)) {
-          const match = m.get(value)
-          if (match) {
-            for (const candidate of match) selected.add(candidate)
-          }
-        } else if (isConstructor) {
-          for (const indexes of m.values()) {
-            for (const candidate of indexes) selected.add(candidate)
-          }
-        }
-      }
-      return Array.from(selected).filter((i) => {
-        const sentinels = idx.sentinelsByCandidate?.[i]
-        return !sentinels || matchesSentinels(input, sentinels, isConstructor)
-      }).sort((a, b) => a - b).map((i) => types[i])
-    }
-    return base.map((i) => types[i])
-  }
-
-  // 2. Fallback: runtime-type dispatch only
-  return (idx.otherwise?.[runtimeType] ?? emptyCandidates).map((i) => types[i]).filter(filterLiterals(input))
+  return getIndex(types)(input, isConstructor)
 }
 
 /**

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -4132,6 +4132,32 @@ Expected a value between -2147483648 and 2147483647`
       )
     })
 
+    it(`mode: "oneOf" with nested and contradicted sentinels`, async () => {
+      const nested = Schema.Union([
+        Schema.Struct({ kind: Schema.Literal("a"), variant: Schema.Literal("x") }),
+        Schema.Struct({ kind: Schema.Literal("a"), variant: Schema.Literal("y") })
+      ])
+      const schema = Schema.Struct({
+        block: Schema.Union([
+          nested,
+          Schema.Struct({ kind: Schema.Literal("b") })
+        ], { mode: "oneOf" })
+      })
+      const decoding = new TestSchema.Asserts(schema).decoding()
+
+      await decoding.succeed({ block: { kind: "a", variant: "x" } })
+      await decoding.fail(
+        { block: { kind: "a", variant: "z" } },
+        `Expected { readonly "kind": "a", readonly "variant": "x", ... } | { readonly "kind": "a", readonly "variant": "y", ... }
+  at ["block"]`
+      )
+      await decoding.fail(
+        { block: { kind: "a", variant: undefined } },
+        `Expected { readonly "kind": "a", readonly "variant": "x", ... } | { readonly "kind": "a", readonly "variant": "y", ... }
+  at ["block"]`
+      )
+    })
+
     it(`mode: "oneOf" counts repeated member occurrences`, async () => {
       const member = Schema.Struct({ kind: Schema.Literal("a") })
       const schema = Schema.Union([member, member], { mode: "oneOf" })

--- a/packages/effect/test/schema/SchemaAST.test.ts
+++ b/packages/effect/test/schema/SchemaAST.test.ts
@@ -476,7 +476,7 @@ describe("SchemaAST", () => {
       deepStrictEqual(SchemaAST.getCandidates(input, ast.types), [ast.types[0]])
     })
 
-    it("should collect matches from different sentinel keys without duplicates", () => {
+    it("should handle candidates with different sentinel keys", () => {
       const schema = Schema.Union([
         Schema.Struct({
           kind: Schema.Literal("a"),
@@ -489,6 +489,14 @@ describe("SchemaAST", () => {
       deepStrictEqual(
         SchemaAST.getCandidates({ kind: "a", status: "ready", value: "value" }, ast.types),
         [ast.types[0], ast.types[1]]
+      )
+      deepStrictEqual(
+        SchemaAST.getCandidates({ kind: "b", status: "ready", value: "value" }, ast.types),
+        [ast.types[1]]
+      )
+      deepStrictEqual(
+        SchemaAST.getCandidates({ kind: undefined, status: "ready", value: "value" }, ast.types),
+        [ast.types[1]]
       )
     })
 
@@ -544,7 +552,6 @@ describe("SchemaAST", () => {
       const ast = Schema.Union([hosted, flat]).ast
       deepStrictEqual(SchemaAST.getCandidates({ kind: "a" }, ast.types), [ast.types[0]])
       deepStrictEqual(SchemaAST.getCandidates({ kind: "b" }, ast.types), [ast.types[1]])
-      deepStrictEqual(SchemaAST.getCandidates({ kind: "c" }, ast.types), [])
     })
 
     it("should exclude members whose sentinel the input contradicts", () => {
@@ -555,8 +562,10 @@ describe("SchemaAST", () => {
       const ast = schema.ast
       deepStrictEqual(SchemaAST.getCandidates({ kind: "a", variant: "x" }, ast.types), [ast.types[0]])
       deepStrictEqual(SchemaAST.getCandidates({ kind: "a", variant: "z" }, ast.types), [])
+      deepStrictEqual(SchemaAST.getCandidates({ kind: "a", variant: undefined }, ast.types), [])
       // A missing sentinel key does not exclude: the member still owes the error.
       deepStrictEqual(SchemaAST.getCandidates({ kind: "a" }, ast.types), [ast.types[0], ast.types[1]])
+      deepStrictEqual(SchemaAST.getCandidates({ kind: "a", variant: undefined }, ast.types, true), ast.types)
     })
   })
 

--- a/packages/effect/test/schema/SchemaAST.test.ts
+++ b/packages/effect/test/schema/SchemaAST.test.ts
@@ -316,6 +316,27 @@ describe("SchemaAST", () => {
       const ast = E.ast
       deepStrictEqual(SchemaAST.collectSentinels(ast), [{ key: "_tag", literal: "E" }])
     })
+
+    it("Union: the sentinels common to every member", () => {
+      const shared = Schema.Union([
+        Schema.Struct({ kind: Schema.Literal("a"), variant: Schema.Literal("x") }),
+        Schema.Struct({ kind: Schema.Literal("a"), variant: Schema.Literal("y") })
+      ])
+      deepStrictEqual(SchemaAST.collectSentinels(shared.ast), [{ key: "kind", literal: "a" }])
+
+      const disjoint = Schema.Union([
+        Schema.Struct({ kind: Schema.Literal("a") }),
+        Schema.Struct({ kind: Schema.Literal("b") })
+      ])
+      deepStrictEqual(SchemaAST.collectSentinels(disjoint.ast), [])
+
+      // A suspended member stays opaque, so the intersection is conservative.
+      const withSuspend = Schema.Union([
+        Schema.Struct({ kind: Schema.Literal("a") }),
+        Schema.suspend(() => Schema.Struct({ kind: Schema.Literal("a") }))
+      ])
+      deepStrictEqual(SchemaAST.collectSentinels(withSuspend.ast), [])
+    })
   })
 
   describe("getCandidates", () => {
@@ -512,6 +533,30 @@ describe("SchemaAST", () => {
       const schema = Schema.Union([member], { mode: "oneOf" })
       const input = { kind: "a" }
       strictEqual(Schema.decodeUnknownSync(schema)(input), input)
+    })
+
+    it("should dispatch a nested union member by its common sentinel", () => {
+      const hosted = Schema.Union([
+        Schema.Struct({ kind: Schema.Literal("a"), variant: Schema.Literal("x") }),
+        Schema.Struct({ kind: Schema.Literal("a"), variant: Schema.Literal("y") })
+      ])
+      const flat = Schema.Struct({ kind: Schema.Literal("b") })
+      const ast = Schema.Union([hosted, flat]).ast
+      deepStrictEqual(SchemaAST.getCandidates({ kind: "a" }, ast.types), [ast.types[0]])
+      deepStrictEqual(SchemaAST.getCandidates({ kind: "b" }, ast.types), [ast.types[1]])
+      deepStrictEqual(SchemaAST.getCandidates({ kind: "c" }, ast.types), [])
+    })
+
+    it("should exclude members whose sentinel the input contradicts", () => {
+      const schema = Schema.Union([
+        Schema.Struct({ kind: Schema.Literal("a"), variant: Schema.Literal("x"), value: Schema.String }),
+        Schema.Struct({ kind: Schema.Literal("a"), variant: Schema.Literal("y"), value: Schema.Number })
+      ])
+      const ast = schema.ast
+      deepStrictEqual(SchemaAST.getCandidates({ kind: "a", variant: "x" }, ast.types), [ast.types[0]])
+      deepStrictEqual(SchemaAST.getCandidates({ kind: "a", variant: "z" }, ast.types), [])
+      // A missing sentinel key does not exclude: the member still owes the error.
+      deepStrictEqual(SchemaAST.getCandidates({ kind: "a" }, ast.types), [ast.types[0], ast.types[1]])
     })
   })
 


### PR DESCRIPTION
> [!NOTE]
> This PR was authored autonomously by Claude Fable 5, manually reviewed only, and is currently in use as a local patch.

Two refinements to the union candidate index. Both are pure narrowings — a member is only dropped when it provably cannot parse the input — so successful parses are unchanged in both `anyOf` and `oneOf` modes. The goal is the one `getCandidates` already states: fewer members tried, fewer issues reported.

1. **`collectSentinels` learns a `Union` case**: the sentinels of a union are the sentinels common to every member. A union of structs that all fix `kind: "a"` (variants discriminated by a second key) is itself dispatchable by `kind` when it stands in a host union. Members are projected through `toCandidate` first, so a suspended member contributes no sentinels and the intersection collapses to empty — laziness is preserved exactly as #6704 established.

2. **`getCandidates` excludes candidates the input contradicts**: a member fixing `variant: "x"` cannot match input carrying `variant: "y"`, even when another sentinel key (a tag shared between sibling variants) selected it. Previously matches were unioned across sentinel keys, so one wrong discriminant re-ran every sibling and reported issues for members the input plainly did not mean. This makes the multi-key case consistent with the single-key case, where `getCandidates({ _tag: "c" }, ...)` already returns no candidates. A missing sentinel key still does not exclude — the member keeps owing its `MissingKey` error.

Motivation: a CMS blocks union where each block is a union of designs sharing a `blockType` literal and differing on `variant`. One wrong `variant` used to produce issues from every sibling design and every non-discriminated block; with both changes it produces a single issue at the failing block's path.