### PR TITLE
Make Node HTTP client tests deterministic

### DIFF
--- a/packages/platform-node/test/NodeHttpClient.test.ts
+++ b/packages/platform-node/test/NodeHttpClient.test.ts
@@ -64,6 +64,8 @@ const LocalServerRoutes = HttpRouter.serve(HttpRouter.addAll([
       return HttpServerResponse.jsonUnsafe({ ...todo, id: 201 })
     })
   ),
+  HttpRouter.route("GET", "/text", Effect.succeed(HttpServerResponse.text("test"))),
+  HttpRouter.route("GET", "/hang", Effect.never),
   HttpRouter.route("GET", "/redirect", Effect.succeed(HttpServerResponse.redirect("/redirected"))),
   HttpRouter.route("GET", "/redirected", Effect.succeed(HttpServerResponse.text("redirected"))),
   HttpRouter.route("HEAD", "/todos", Effect.succeed(HttpServerResponse.empty({ status: 200 })))
@@ -91,13 +93,13 @@ const LocalServerRoutes = HttpRouter.serve(HttpRouter.addAll([
   )
 
   describe(`NodeHttpClient - ${name}`, () => {
-    it.effect("google", () =>
+    it.effect("text", () =>
       Effect.gen(function*() {
-        const response = yield* HttpClient.get("https://www.google.com/").pipe(
+        const response = yield* HttpClient.get("/text").pipe(
           Effect.flatMap((_) => _.text)
         )
-        expect(response).toContain("Google")
-      }).pipe(Effect.provide(layer), flaky))
+        expect(response).toBe("test")
+      }).pipe(Effect.provide(localServerTestLayer)))
 
     it.effect("local server followRedirects", () =>
       Effect.gen(function*() {
@@ -110,19 +112,17 @@ const LocalServerRoutes = HttpRouter.serve(HttpRouter.addAll([
         expect(response).toBe("redirected")
       }).pipe(Effect.provide(localServerTestLayer)))
 
-    it.effect("google stream", () =>
-      flaky(
-        Effect.gen(function*() {
-          const client = yield* HttpClient.HttpClient
-          const response = yield* client.get("https://www.google.com/").pipe(
-            Effect.map((_) => _.stream),
-            Stream.unwrap,
-            Stream.decodeText(),
-            Stream.mkString
-          )
-          expect(response).toContain("Google")
-        }).pipe(Effect.provide(layer))
-      ))
+    it.effect("text stream", () =>
+      Effect.gen(function*() {
+        const client = yield* HttpClient.HttpClient
+        const response = yield* client.get("/text").pipe(
+          Effect.map((_) => _.stream),
+          Stream.unwrap,
+          Stream.decodeText(),
+          Stream.mkString
+        )
+        expect(response).toBe("test")
+      }).pipe(Effect.provide(localServerTestLayer)))
 
     it.effect("local server", () =>
       Effect.gen(function*() {
@@ -162,20 +162,20 @@ const LocalServerRoutes = HttpRouter.serve(HttpRouter.addAll([
     it.live("interrupt", () =>
       Effect.gen(function*() {
         const client = yield* HttpClient.HttpClient
-        const response = yield* client.get("https://www.google.com/").pipe(
+        const response = yield* client.get("/hang").pipe(
           Effect.flatMap((_) => _.text),
           Effect.timeout(1),
           Effect.asSome,
           Effect.catchTag("TimeoutError", () => Effect.succeedNone)
         )
         expect(response._tag).toEqual("None")
-      }).pipe(Effect.provide(layer), flaky))
+      }).pipe(Effect.provide(localServerTestLayer)))
 
     it.effect("close early", () =>
       Effect.gen(function*() {
-        const response = yield* HttpClient.get("https://www.google.com/")
+        const response = yield* HttpClient.get("/text")
         expect(response.status).toBe(200)
-      }).pipe(Effect.provide(layer), flaky))
+      }).pipe(Effect.provide(localServerTestLayer)))
   })
 })
 
@@ -196,11 +196,3 @@ it.live("returns a stream body encoding failure", () =>
     Layer.provide(NodeClient.layerNodeHttp),
     Layer.provideMerge(NodeHttpServer.layer(Http.createServer, { port: 0 }))
   ))))
-
-const flaky = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-  effect.pipe(
-    Effect.timeoutOrElse({
-      duration: "10 seconds",
-      orElse: () => Effect.void
-    })
-  )


### PR DESCRIPTION
## Summary

- replace Google-dependent Node HTTP client tests with deterministic routes on the existing ephemeral test server
- add a hanging local route for the interruption test
- remove the timeout-only flaky wrapper, which did not handle anti-bot responses

## Root cause

GitHub-hosted runners share outbound IPs, and Google intermittently returned 302 anti-bot challenges or HTTP 429 responses. Those valid HTTP responses bypassed the timeout fallback and caused assertions across the fetch, node:http, and undici clients to fail.

## Validation

- `pnpm vitest run --project @effect/platform-node packages/platform-node/test/NodeHttpClient.test.ts` repeated 20 times (500 tests total)
- `pnpm vitest run --project @effect/platform-node` (377 tests)
- `pnpm --filter @effect/platform-node check`
- dprint and oxlint on the changed test file

Closes EFF-576