### PR TITLE
Expose SQL runner recovery test failures

### DIFF
--- a/packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts
+++ b/packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts
@@ -86,8 +86,7 @@ describe("SqlRunnerStorage", () => {
 
       assert.strictEqual(partitioned.activeQueries, 0)
     }).pipe(
-      // Let reserved-connection finalizers finish if an assertion fails while
-      // the simulated connection is partitioned.
+      // Ensure layer teardown cannot mask a body failure with Vitest's timeout.
       Effect.ensuring(Effect.sync(() => {
         partitioned.current = false
       })),

--- a/packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts
+++ b/packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts
@@ -85,7 +85,14 @@ describe("SqlRunnerStorage", () => {
       yield* storage.release(runnerAddress1, shards[0]).pipe(TestClock.withLive)
 
       assert.strictEqual(partitioned.activeQueries, 0)
-    }).pipe(Effect.provide(layer))
+    }).pipe(
+      // Let reserved-connection finalizers finish if an assertion fails while
+      // the simulated connection is partitioned.
+      Effect.ensuring(Effect.sync(() => {
+        partitioned.current = false
+      })),
+      Effect.provide(layer)
+    )
   }, 60_000)
 
   it.effect("recovers when a blackholed query cannot resume after the partition clears", () => {


### PR DESCRIPTION
## Summary

- always clear the simulated partition before the `resumePending: true` test layer tears down
- prevent reserved-connection cleanup from masking a body failure as Vitest's outer 60-second timeout
- leave the existing deadline, concurrency, and recovery assertions unchanged

## Scope

This is a diagnosability fix, not a proven fix for the underlying assertion flake. The original Actions job recorded only the masked outer timeout, while its rerun, PR CI, and repeated focused runs passed. If the failure recurs, this cleanup will preserve the actual assertion or wait diagnostic.

The similar `resumePending: false` test does not need the same guard: it disables advisory locks and its blocked query is interruptible. A forced failure surfaced in 1.5 seconds, and a forced `waitUntil` timeout surfaced its intended diagnostic in 12.6 seconds rather than becoming the 60-second outer timeout.

## Validation

- both partition recovery tests passed together
- the first test's forced body failure surfaced in 1.5 seconds
- the second test's forced `waitUntil` failure surfaced in 12.6 seconds
- focused first test passed in 8 consecutive fresh Vitest/container runs
- `pnpm --dir packages/platform-node check`
- `pnpm exec dprint check packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts`

Closes EFF-580