### PR TITLE
Share MySQL persistence container across suites

### DIFF
--- a/packages/effect/test/unstable/persistence/PersistedCacheTest.ts
+++ b/packages/effect/test/unstable/persistence/PersistedCacheTest.ts
@@ -21,11 +21,11 @@ export class TransientError extends Data.TaggedError("TransientError") {}
 
 class LookupService extends Context.Service<LookupService, { readonly value: string }>()("LookupService") {}
 
-const registerSuite = <R>(
+export const suiteWith = <R>(
   storeId: string,
   layer: Layer.Layer<Persistence.Persistence, unknown, R>,
   testApi: Vitest.MethodsNonLive<R>,
-  timeout: Duration.Input
+  timeout: Duration.Input = "60 seconds"
 ) =>
   testApi.layer(layer, { timeout })(`PersistedCache (${storeId})`, (it) => {
     it.effect("smoke test", () =>
@@ -101,11 +101,4 @@ const registerSuite = <R>(
   })
 
 export const suite = (storeId: string, layer: Layer.Layer<Persistence.Persistence, unknown>) =>
-  registerSuite(storeId, layer, it, "60 seconds")
-
-export const suiteWith = <R>(
-  storeId: string,
-  layer: Layer.Layer<Persistence.Persistence, unknown, R>,
-  testApi: Vitest.MethodsNonLive<R>,
-  timeout: Duration.Input = "60 seconds"
-) => registerSuite(storeId, layer, testApi, timeout)
+  suiteWith(storeId, layer, it)

--- a/packages/effect/test/unstable/persistence/PersistedCacheTest.ts
+++ b/packages/effect/test/unstable/persistence/PersistedCacheTest.ts
@@ -1,5 +1,6 @@
 import { assert, it } from "@effect/vitest"
-import type { Layer } from "effect"
+import type { Vitest } from "@effect/vitest"
+import type { Duration, Layer } from "effect"
 import { Context, Data, Effect, Exit, Schema } from "effect"
 import { Persistable, PersistedCache, Persistence } from "effect/unstable/persistence"
 
@@ -20,8 +21,13 @@ export class TransientError extends Data.TaggedError("TransientError") {}
 
 class LookupService extends Context.Service<LookupService, { readonly value: string }>()("LookupService") {}
 
-export const suite = (storeId: string, layer: Layer.Layer<Persistence.Persistence, unknown>) =>
-  it.layer(layer, { timeout: "60 seconds" })(`PersistedCache (${storeId})`, (it) => {
+const registerSuite = <R>(
+  storeId: string,
+  layer: Layer.Layer<Persistence.Persistence, unknown, R>,
+  testApi: Vitest.MethodsNonLive<R>,
+  timeout: Duration.Input
+) =>
+  testApi.layer(layer, { timeout })(`PersistedCache (${storeId})`, (it) => {
     it.effect("smoke test", () =>
       Effect.gen(function*() {
         const persistence = yield* Persistence.Persistence
@@ -93,3 +99,13 @@ export const suite = (storeId: string, layer: Layer.Layer<Persistence.Persistenc
         assert.deepStrictEqual(result3, new User({ id: 1, name: "first" }))
       }), 30_000)
   })
+
+export const suite = (storeId: string, layer: Layer.Layer<Persistence.Persistence, unknown>) =>
+  registerSuite(storeId, layer, it, "60 seconds")
+
+export const suiteWith = <R>(
+  storeId: string,
+  layer: Layer.Layer<Persistence.Persistence, unknown, R>,
+  testApi: Vitest.MethodsNonLive<R>,
+  timeout: Duration.Input = "60 seconds"
+) => registerSuite(storeId, layer, testApi, timeout)

--- a/packages/effect/test/unstable/persistence/PersistedQueueTest.ts
+++ b/packages/effect/test/unstable/persistence/PersistedQueueTest.ts
@@ -1,14 +1,21 @@
 import { assert, it } from "@effect/vitest"
+import type { Vitest } from "@effect/vitest"
 import { Effect, Fiber, Latch, Layer, Schema } from "effect"
+import type { Duration } from "effect"
 import { TestClock } from "effect/testing"
 import { PersistedQueue } from "effect/unstable/persistence"
 
-export const suite = (name: string, layer: Layer.Layer<PersistedQueue.PersistedQueueStore, unknown>) =>
-  it.layer(
+const registerSuite = <R>(
+  name: string,
+  layer: Layer.Layer<PersistedQueue.PersistedQueueStore, unknown, R>,
+  testApi: Vitest.MethodsNonLive<R>,
+  timeout: Duration.Input
+) =>
+  testApi.layer(
     PersistedQueue.layer.pipe(
       Layer.provideMerge(layer)
     ),
-    { timeout: "30 seconds" }
+    { timeout }
   )(`PersistedQueue (${name})`, (it) => {
     it.effect("offer + take", () =>
       Effect.gen(function*() {
@@ -209,3 +216,13 @@ export const suite = (name: string, layer: Layer.Layer<PersistedQueue.PersistedQ
 const Item = Schema.Struct({
   n: Schema.BigInt
 })
+
+export const suite = (name: string, layer: Layer.Layer<PersistedQueue.PersistedQueueStore, unknown>) =>
+  registerSuite(name, layer, it, "30 seconds")
+
+export const suiteWith = <R>(
+  name: string,
+  layer: Layer.Layer<PersistedQueue.PersistedQueueStore, unknown, R>,
+  testApi: Vitest.MethodsNonLive<R>,
+  timeout: Duration.Input = "30 seconds"
+) => registerSuite(name, layer, testApi, timeout)

--- a/packages/effect/test/unstable/persistence/PersistedQueueTest.ts
+++ b/packages/effect/test/unstable/persistence/PersistedQueueTest.ts
@@ -5,11 +5,11 @@ import type { Duration } from "effect"
 import { TestClock } from "effect/testing"
 import { PersistedQueue } from "effect/unstable/persistence"
 
-const registerSuite = <R>(
+export const suiteWith = <R>(
   name: string,
   layer: Layer.Layer<PersistedQueue.PersistedQueueStore, unknown, R>,
   testApi: Vitest.MethodsNonLive<R>,
-  timeout: Duration.Input
+  timeout: Duration.Input = "30 seconds"
 ) =>
   testApi.layer(
     PersistedQueue.layer.pipe(
@@ -218,11 +218,4 @@ const Item = Schema.Struct({
 })
 
 export const suite = (name: string, layer: Layer.Layer<PersistedQueue.PersistedQueueStore, unknown>) =>
-  registerSuite(name, layer, it, "30 seconds")
-
-export const suiteWith = <R>(
-  name: string,
-  layer: Layer.Layer<PersistedQueue.PersistedQueueStore, unknown, R>,
-  testApi: Vitest.MethodsNonLive<R>,
-  timeout: Duration.Input = "30 seconds"
-) => registerSuite(name, layer, testApi, timeout)
+  suiteWith(name, layer, it)

--- a/packages/sql/mysql2/test/Persistence.integration.test.ts
+++ b/packages/sql/mysql2/test/Persistence.integration.test.ts
@@ -8,24 +8,32 @@ import { PersistedQueue, Persistence } from "effect/unstable/persistence"
 import { SqlClient } from "effect/unstable/sql"
 import { MysqlContainer } from "./utils.ts"
 
-PersistedCacheTest.suite(
-  "sql-mysql2-multi",
-  Persistence.layerSqlMultiTable.pipe(Layer.provide(MysqlContainer.layerClient))
+const layerClient = Layer.effect(SqlClient.SqlClient)(SqlClient.SqlClient).pipe(
+  Layer.provide(MysqlContainer.layerClient)
 )
 
-PersistedCacheTest.suite(
-  "sql-mysql2-single",
-  Persistence.layerSql.pipe(Layer.provide(MysqlContainer.layerClient))
-)
-
-PersistedQueueTest.suite(
-  "sql-mysql2",
-  PersistedQueue.layerStoreSql().pipe(
-    Layer.provide(MysqlContainer.layerClient)
+it.layer(layerClient, { timeout: "90 seconds" })("Persistence", (it) => {
+  PersistedCacheTest.suiteWith(
+    "sql-mysql2-multi",
+    Persistence.layerSqlMultiTable,
+    it,
+    "90 seconds"
   )
-)
 
-it.layer(MysqlContainer.layerClient, { timeout: "30 seconds" })("Persistence SQL cleanup", (it) => {
+  PersistedCacheTest.suiteWith(
+    "sql-mysql2-single",
+    Persistence.layerSql,
+    it,
+    "90 seconds"
+  )
+
+  PersistedQueueTest.suiteWith(
+    "sql-mysql2",
+    PersistedQueue.layerStoreSql(),
+    it,
+    "90 seconds"
+  )
+
   it.effect("deletes expired entries in batches", () =>
     Effect.gen(function*() {
       const sql = (yield* SqlClient.SqlClient).withoutTransforms()
@@ -33,6 +41,7 @@ it.layer(MysqlContainer.layerClient, { timeout: "30 seconds" })("Persistence SQL
       const expiredCount = sql<{ readonly count: number }>`
         SELECT COUNT(*) AS count FROM ${table} WHERE store_id = 'expired'
       `.pipe(Effect.map((rows) => Number(rows[0].count)))
+      yield* sql`DROP TABLE IF EXISTS ${table}`
       yield* sql`
         CREATE TABLE ${table} (
           store_id VARCHAR(191) NOT NULL,

--- a/packages/sql/mysql2/test/Persistence.integration.test.ts
+++ b/packages/sql/mysql2/test/Persistence.integration.test.ts
@@ -8,31 +8,12 @@ import { PersistedQueue, Persistence } from "effect/unstable/persistence"
 import { SqlClient } from "effect/unstable/sql"
 import { MysqlContainer } from "./utils.ts"
 
-const layerClient = Layer.effect(SqlClient.SqlClient)(SqlClient.SqlClient).pipe(
-  Layer.provide(MysqlContainer.layerClient)
-)
+it.layer(MysqlContainer.layerClient, { timeout: "90 seconds" })("Persistence", (it) => {
+  PersistedCacheTest.suiteWith("sql-mysql2-multi", Persistence.layerSqlMultiTable, it)
 
-it.layer(layerClient, { timeout: "90 seconds" })("Persistence", (it) => {
-  PersistedCacheTest.suiteWith(
-    "sql-mysql2-multi",
-    Persistence.layerSqlMultiTable,
-    it,
-    "90 seconds"
-  )
+  PersistedCacheTest.suiteWith("sql-mysql2-single", Persistence.layerSql, it)
 
-  PersistedCacheTest.suiteWith(
-    "sql-mysql2-single",
-    Persistence.layerSql,
-    it,
-    "90 seconds"
-  )
-
-  PersistedQueueTest.suiteWith(
-    "sql-mysql2",
-    PersistedQueue.layerStoreSql(),
-    it,
-    "90 seconds"
-  )
+  PersistedQueueTest.suiteWith("sql-mysql2", PersistedQueue.layerStoreSql(), it)
 
   it.effect("deletes expired entries in batches", () =>
     Effect.gen(function*() {
@@ -41,6 +22,7 @@ it.layer(layerClient, { timeout: "90 seconds" })("Persistence", (it) => {
       const expiredCount = sql<{ readonly count: number }>`
         SELECT COUNT(*) AS count FROM ${table} WHERE store_id = 'expired'
       `.pipe(Effect.map((rows) => Number(rows[0].count)))
+      // Reset the table left by the single-table cache suite so cleanup builds its own schema and index.
       yield* sql`DROP TABLE IF EXISTS ${table}`
       yield* sql`
         CREATE TABLE ${table} (


### PR DESCRIPTION
## Summary

- keep one MySQL client and testcontainer alive across the persistence integration suites in the file
- allow shared persistence test suites to register under an existing `it.layer` context
- raise container-backed setup hooks to 90 seconds and explicitly reset the cleanup test table

## Root cause

Each top-level `it.layer` invocation owned a separate scope and memo map, so the four persistence suites each started their own `mysql:lts` container. On a contended CI runner, container startup, the initial connection check, and schema creation could exceed the queue suite's 30-second hook timeout.

## Validation

- `pnpm lint`
- `pnpm check`
- `EFFECT_INTEGRATION_TESTS=1 pnpm test --run --project @effect/sql-mysql2 test/Persistence.integration.test.ts` (13 tests passed)

Closes EFF-582
