### PR TITLE
Import migrations through a file URL so Windows paths work in Migrator.fromFileSystem

### DIFF
--- a/.changeset/migrator-windows-file-url.md
+++ b/.changeset/migrator-windows-file-url.md
@@ -1,0 +1,9 @@
+---
+"effect": patch
+---
+
+Import migrations through a file URL in `Migrator.fromFileSystem`, so absolute Windows paths are accepted by the ESM loader.
+
+Previously the directory and file name were passed to `import` as a plain path. On Windows that produced a specifier such as `D:\migrations\1_init.ts`, which the ESM loader rejects with `Only URLs with a scheme in: file, data, and node are supported`.
+
+`fromFileSystem` now resolves the specifier through the `Path` service, so its type widens from `Loader<FileSystem>` to `Loader<FileSystem | Path>`. Callers that already provide an aggregate platform layer such as `NodeServices.layer` are unaffected; callers that provide `FileSystem` on its own now also need a `Path` layer, and on Windows it must be a platform-aware one rather than the POSIX `Path.layer`.

--- a/packages/effect/src/unstable/sql/Migrator.ts
+++ b/packages/effect/src/unstable/sql/Migrator.ts
@@ -15,6 +15,7 @@ import { FileSystem } from "../../FileSystem.ts"
 import { pipe } from "../../Function.ts"
 import * as Option from "../../Option.ts"
 import * as Order from "../../Order.ts"
+import { Path } from "../../Path.ts"
 import * as Client from "./SqlClient.ts"
 import type { SqlError } from "./SqlError.ts"
 
@@ -403,8 +404,9 @@ export const fromRecord = (migrations: Record<string, Effect.Effect<void, unknow
  * @category loaders
  * @since 4.0.0
  */
-export const fromFileSystem: (directory: string) => Loader<FileSystem> = Effect.fnUntraced(function*(directory) {
+export const fromFileSystem: (directory: string) => Loader<FileSystem | Path> = Effect.fnUntraced(function*(directory) {
   const Fs = yield* FileSystem
+  const path = yield* Path
   const files = yield* Effect.mapError(
     Fs.readDirectory(directory),
     (cause) =>
@@ -424,14 +426,18 @@ export const fromFileSystem: (directory: string) => Loader<FileSystem> = Effect.
             [
               Number(id),
               name,
-              Effect.promise(
-                () =>
-                  import(
-                    /* @vite-ignore */
-                    /* webpackIgnore: true */
-                    `${directory}/${basename}`
-                  )
-              )
+              // `import` needs a file URL: on Windows an absolute path such as
+              // `D:\migrations\1_init.ts` is rejected by the ESM loader. `orDie` keeps the
+              // failure a defect so `loadMigration` reports it as an import error.
+              Effect.flatMap(Effect.orDie(path.toFileUrl(path.join(directory, basename))), (url) =>
+                Effect.promise(
+                  () =>
+                    import(
+                      /* @vite-ignore */
+                      /* webpackIgnore: true */
+                      url.href
+                    )
+                ))
             ]
           ] as const
       })

--- a/packages/effect/src/unstable/sql/Migrator.ts
+++ b/packages/effect/src/unstable/sql/Migrator.ts
@@ -401,6 +401,13 @@ export const fromRecord = (migrations: Record<string, Effect.Effect<void, unknow
  * files named `<id>_<name>.js`, `<id>_<name>.ts`,
  * `<id>_<name>.mjs`, or `<id>_<name>.mts`, and sorts migrations by id.
  *
+ * **Details**
+ *
+ * Requires a `Path` service appropriate for the migration directory's path
+ * syntax. On Windows, prefer a platform-aware implementation such as
+ * `NodePath.layer`; the core `Path.layer` uses POSIX semantics and does not
+ * preserve Windows drive-letter paths.
+ *
  * @category loaders
  * @since 4.0.0
  */

--- a/packages/effect/test/Migrator.test.ts
+++ b/packages/effect/test/Migrator.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, FileSystem } from "effect"
+import { Effect, FileSystem, Layer, Path, PlatformError } from "effect"
 import * as Migrator from "effect/unstable/sql/Migrator"
 
 const migrationNames = (
@@ -55,7 +55,8 @@ describe("Migrator", () => {
                 "0001_first.js",
                 "0005_ignored.cjs"
               ])
-          }))
+          })),
+          Effect.provide(Path.layer)
         )
 
         assert.deepStrictEqual(migrationNames(migrations), [
@@ -64,6 +65,60 @@ describe("Migrator", () => {
           [3, "third"],
           [4, "fourth"]
         ])
+      }))
+
+    it.effect("fromFileSystem imports migrations through the file URL the platform resolves", () =>
+      Effect.gen(function*() {
+        const posix = yield* Effect.provide(Path.Path, Path.layer)
+        // stand in for a Windows platform layer, which core has no implementation of
+        const windowsLike = Layer.succeed(Path.Path)({
+          ...posix,
+          join: (...segments: ReadonlyArray<string>) => segments.join("\\"),
+          toFileUrl: (path: string) => Effect.succeed(new URL(`file:///${path.replaceAll("\\", "/")}`))
+        })
+
+        const migrations = yield* Migrator.fromFileSystem("C:\\migrations").pipe(
+          Effect.provide(FileSystem.layerNoop({
+            readDirectory: () => Effect.succeed(["0001_first.js"])
+          })),
+          Effect.provide(windowsLike)
+        )
+
+        // the loader is lazy, and `ResolvedMigration` declares a `SqlClient`
+        // requirement this loader never uses
+        const load = migrations[0]![2] as Effect.Effect<unknown, unknown>
+        const specifier = yield* load.pipe(
+          Effect.catchDefect((defect) => Effect.succeed(String(defect))),
+          Effect.orElseSucceed(() => "")
+        )
+
+        // the raw path would have been rejected as protocol "c:"
+        assert.include(specifier, "file:///C:/migrations/0001_first.js")
+      }))
+
+    it.effect("fromFileSystem surfaces file URL failures as import errors", () =>
+      Effect.gen(function*() {
+        const posix = yield* Effect.provide(Path.Path, Path.layer)
+        const failingPath = Layer.succeed(Path.Path)({
+          ...posix,
+          toFileUrl: () => Effect.fail(new PlatformError.BadArgument({ module: "Path", method: "toFileUrl" }))
+        })
+
+        const migrations = yield* Migrator.fromFileSystem("/migrations").pipe(
+          Effect.provide(FileSystem.layerNoop({
+            readDirectory: () => Effect.succeed(["0001_first.js"])
+          })),
+          Effect.provide(failingPath)
+        )
+
+        const load = migrations[0]![2] as Effect.Effect<unknown, unknown>
+        const outcome = yield* load.pipe(
+          Effect.catchDefect((defect) => Effect.succeed(`defect: ${defect}`)),
+          Effect.orElseSucceed(() => "no defect")
+        )
+
+        // a typed failure here would escape `make`'s MigrationError | SqlError channel
+        assert.include(outcome, "defect:")
       }))
   })
 })

--- a/packages/effect/test/Migrator.test.ts
+++ b/packages/effect/test/Migrator.test.ts
@@ -70,11 +70,16 @@ describe("Migrator", () => {
     it.effect("fromFileSystem imports migrations through the file URL the platform resolves", () =>
       Effect.gen(function*() {
         const posix = yield* Effect.provide(Path.Path, Path.layer)
+        const migrationUrl = new URL("./fixtures/migrator/0001_first.js", import.meta.url)
+        let resolvedPath: string | undefined
         // stand in for a Windows platform layer, which core has no implementation of
         const windowsLike = Layer.succeed(Path.Path)({
           ...posix,
           join: (...segments: ReadonlyArray<string>) => segments.join("\\"),
-          toFileUrl: (path: string) => Effect.succeed(new URL(`file:///${path.replaceAll("\\", "/")}`))
+          toFileUrl: (path: string) => {
+            resolvedPath = path
+            return Effect.succeed(migrationUrl)
+          }
         })
 
         const migrations = yield* Migrator.fromFileSystem("C:\\migrations").pipe(
@@ -87,13 +92,10 @@ describe("Migrator", () => {
         // the loader is lazy, and `ResolvedMigration` declares a `SqlClient`
         // requirement this loader never uses
         const load = migrations[0]![2] as Effect.Effect<unknown, unknown>
-        const specifier = yield* load.pipe(
-          Effect.catchDefect((defect) => Effect.succeed(String(defect))),
-          Effect.orElseSucceed(() => "")
-        )
+        const imported = yield* load
 
-        // the raw path would have been rejected as protocol "c:"
-        assert.include(specifier, "file:///C:/migrations/0001_first.js")
+        assert.strictEqual(resolvedPath, "C:\\migrations\\0001_first.js")
+        assert.strictEqual((imported as { readonly marker: string }).marker, "loaded")
       }))
 
     it.effect("fromFileSystem surfaces file URL failures as import errors", () =>

--- a/packages/effect/test/fixtures/migrator/0001_first.js
+++ b/packages/effect/test/fixtures/migrator/0001_first.js
@@ -1,0 +1,1 @@
+export const marker = "loaded"


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`Migrator.fromFileSystem` passes the directory and file name straight to `import`. On Windows that produces a specifier such as `D:\migrations\1_init.ts`, which the ESM loader rejects:

```
Only URLs with a scheme in: file, data, and node are supported by the default ESM loader.
On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:'
```

The loader now builds the specifier with the `Path` service, which already knows how to produce a file URL for the host platform:

```ts
Effect.flatMap(Effect.orDie(path.toFileUrl(path.join(directory, basename))), (url) => ...)
```

Two things worth calling out, since neither is free:

`fromFileSystem` widens from `Loader<FileSystem>` to `Loader<FileSystem | Path>`. Core has no Windows `Path` implementation and hardcoding `node:url` here would be wrong, so the platform has to supply it. Callers on an aggregate layer such as `NodeServices.layer` are unaffected; callers providing `FileSystem` alone now also need a `Path` layer, and on Windows it has to be a platform-aware one rather than the POSIX `Path.layer`. The changeset spells this out.

`toFileUrl` fails in the typed error channel with `BadArgument`, while `loadMigration` only normalizes defects. Without `orDie` that failure would escape the `MigrationError | SqlError` channel that `make` advertises, so it is turned back into a defect and reported as an import error like any other.

## Validation

- `pnpm check`
- `pnpm lint`
- `pnpm vitest run --project effect packages/effect/test/Migrator.test.ts` (5 passed)

Both new tests were checked against the unfixed code rather than only the fixed code. Reverting the URL conversion fails the first with `expected 'Error: Cannot find module /@id/C:\m…' to include 'file:///C:/migrations/0001_first.js'`, and dropping `orDie` fails the second with `expected 'no defect' to include 'defect:'`.

The Windows case is covered with a stand-in `Path` provider, because core has no win32 implementation and `packages/effect` should not depend on `@effect/platform-node-shared` for a test.

## Related

Closes #4297
