### PR TITLE
Fix use of Schema.NonEmptyArrayEnsure with strings

### DIFF
--- a/.changeset/slimy-swans-repeat.md
+++ b/.changeset/slimy-swans-repeat.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix use of Schema.NonEmptyArrayEnsure with strings

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -1664,7 +1664,7 @@ export interface NonEmptyArrayEnsure<Value extends Schema.Any>
 export function NonEmptyArrayEnsure<Value extends Schema.Any>(value: Value): NonEmptyArrayEnsure<Value> {
   return transform(Union(value, NonEmptyArray(value)), NonEmptyArray(typeSchema(asSchema(value))), {
     strict: true,
-    decode: (i) => array_.ensure(i) as never,
+    decode: (i) => Array.isArray(i) && array_.isNonEmptyReadonlyArray(i) ? i : (array_.of(i) as never),
     encode: (a) => a.length === 1 ? a[0] : a
   })
 }

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -1664,7 +1664,7 @@ export interface NonEmptyArrayEnsure<Value extends Schema.Any>
 export function NonEmptyArrayEnsure<Value extends Schema.Any>(value: Value): NonEmptyArrayEnsure<Value> {
   return transform(Union(value, NonEmptyArray(value)), NonEmptyArray(typeSchema(asSchema(value))), {
     strict: true,
-    decode: (i) => array_.isNonEmptyReadonlyArray(i) ? i : array_.of(i),
+    decode: (i) => array_.ensure(i) as never,
     encode: (a) => a.length === 1 ? a[0] : a
   })
 }

--- a/packages/effect/test/Schema/Schema/NonEmptyArrayEnsure.test.ts
+++ b/packages/effect/test/Schema/Schema/NonEmptyArrayEnsure.test.ts
@@ -5,7 +5,9 @@ import * as Util from "../TestUtils.js"
 describe("NonEmptyArrayEnsure", () => {
   it("decode non-array", async () => {
     const schema = S.NonEmptyArrayEnsure(S.NumberFromString)
+    const schema2 = S.NonEmptyArrayEnsure(S.String)
     await Util.assertions.decoding.succeed(schema, "123", [123])
+    await Util.assertions.decoding.succeed(schema2, "foo", ["foo"])
     await Util.assertions.decoding.fail(
       schema,
       null,

--- a/packages/effect/test/Schema/Schema/NonEmptyArrayEnsure.test.ts
+++ b/packages/effect/test/Schema/Schema/NonEmptyArrayEnsure.test.ts
@@ -58,6 +58,11 @@ describe("NonEmptyArrayEnsure", () => {
     )
   })
 
+  it("decode array value", async () => {
+    const schema = S.NonEmptyArrayEnsure(S.Array(S.String))
+    await Util.assertions.decoding.succeed(schema, [], [[]])
+  })
+
   it("encode", async () => {
     const schema = S.NonEmptyArrayEnsure(S.NumberFromString)
     await Util.assertions.encoding.succeed(schema, [123], "123")


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`Schema.NonEmptyArrayEnsure` doesn't work with strings. The compiler doesn't recognise that the value being passed to `Array.isNonEmptyReadonlyArray` might not be an array, and the function only checks the `length` property which also exists on strings.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
