### PR TITLE
Fix Queue.await Done completion

### DIFF
--- a/.changeset/calm-queues-await.md
+++ b/.changeset/calm-queues-await.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Queue.await` failing with `Cause.Done` when registered before the queue ends.

--- a/packages/effect/src/Queue.ts
+++ b/packages/effect/src/Queue.ts
@@ -1993,7 +1993,7 @@ const finalize = <A, E>(self: Enqueue<A, E> | Dequeue<A, E>, exit: Failure<never
   }
   openState.takers.clear()
   for (const awaiter of openState.awaiters) {
-    awaiter(exit)
+    awaiter(Pull.isDoneCause(exit.cause) ? internalEffect.exitVoid : exit)
   }
   openState.awaiters.clear()
 }

--- a/packages/effect/src/Queue.ts
+++ b/packages/effect/src/Queue.ts
@@ -1570,16 +1570,14 @@ export const takeUnsafe = <A, E>(self: Dequeue<A, E>): Exit<A, E> | undefined =>
 
 const await_ = <A, E>(self: Dequeue<A, E>): Effect<void, Exclude<E, Done>> =>
   internalEffect.callback<void, Exclude<E, Done>>((resume) => {
+    const awaiter = (effect: Effect<void, E>) => resume(Pull.catchDone(effect, () => internalEffect.exitVoid))
     if (self.state._tag === "Done") {
-      if (Pull.isDoneCause(self.state.exit.cause)) {
-        return resume(internalEffect.exitVoid)
-      }
-      return resume(self.state.exit)
+      return awaiter(self.state.exit)
     }
-    self.state.awaiters.add(resume)
+    self.state.awaiters.add(awaiter)
     return internalEffect.sync(() => {
       if (self.state._tag !== "Done") {
-        self.state.awaiters.delete(resume)
+        self.state.awaiters.delete(awaiter)
       }
     })
   })
@@ -1993,7 +1991,7 @@ const finalize = <A, E>(self: Enqueue<A, E> | Dequeue<A, E>, exit: Failure<never
   }
   openState.takers.clear()
   for (const awaiter of openState.awaiters) {
-    awaiter(Pull.isDoneCause(exit.cause) ? internalEffect.exitVoid : exit)
+    awaiter(exit)
   }
   openState.awaiters.clear()
 }

--- a/packages/effect/test/Queue.test.ts
+++ b/packages/effect/test/Queue.test.ts
@@ -319,24 +319,16 @@ describe("Queue", () => {
       assert.isNotNull(fiber.pollUnsafe())
     }))
 
-  it.effect("await succeeds when registered before end", () =>
+  it.effect("end preserves Done for take and excludes it from await", () =>
     Effect.gen(function*() {
       const queue = yield* Queue.unbounded<never, Cause.Done>()
-      const fiber = yield* Queue.await(queue).pipe(Effect.forkChild)
+      const takeFiber = yield* Queue.take(queue).pipe(Effect.forkChild)
+      const awaitFiber = yield* Queue.await(queue).pipe(Effect.forkChild)
       yield* Effect.yieldNow
       yield* Queue.end(queue)
 
-      assert.strictEqual(yield* Fiber.join(fiber), void 0)
-    }))
-
-  it.effect("await preserves errors when registered before failure", () =>
-    Effect.gen(function*() {
-      const queue = yield* Queue.unbounded<never, string>()
-      const fiber = yield* Queue.await(queue).pipe(Effect.forkChild)
-      yield* Effect.yieldNow
-      yield* Queue.fail(queue, "boom")
-
-      assert.strictEqual(yield* Fiber.join(fiber).pipe(Effect.flip), "boom")
+      assert.deepStrictEqual(yield* Fiber.await(takeFiber), Exit.fail(Cause.Done()))
+      assert.strictEqual(yield* Fiber.join(awaitFiber), void 0)
     }))
 
   it.effect("bounded 0 capacity", () =>

--- a/packages/effect/test/Queue.test.ts
+++ b/packages/effect/test/Queue.test.ts
@@ -331,6 +331,16 @@ describe("Queue", () => {
       assert.strictEqual(yield* Fiber.join(awaitFiber), void 0)
     }))
 
+  it.effect("await preserves non-Done failures", () =>
+    Effect.gen(function*() {
+      const queue = yield* Queue.unbounded<number, string>()
+      const fiber = yield* Queue.await(queue).pipe(Effect.exit, Effect.forkChild)
+      yield* Effect.yieldNow
+      yield* Queue.fail(queue, "boom")
+
+      assert.deepStrictEqual(yield* Fiber.join(fiber), Exit.fail("boom"))
+    }))
+
   it.effect("bounded 0 capacity", () =>
     Effect.gen(function*() {
       const queue = yield* Queue.bounded<number>(0)

--- a/packages/effect/test/Queue.test.ts
+++ b/packages/effect/test/Queue.test.ts
@@ -329,6 +329,16 @@ describe("Queue", () => {
       assert.strictEqual(yield* Fiber.join(fiber), void 0)
     }))
 
+  it.effect("await preserves errors when registered before failure", () =>
+    Effect.gen(function*() {
+      const queue = yield* Queue.unbounded<never, string>()
+      const fiber = yield* Queue.await(queue).pipe(Effect.forkChild)
+      yield* Effect.yieldNow
+      yield* Queue.fail(queue, "boom")
+
+      assert.strictEqual(yield* Fiber.join(fiber).pipe(Effect.flip), "boom")
+    }))
+
   it.effect("bounded 0 capacity", () =>
     Effect.gen(function*() {
       const queue = yield* Queue.bounded<number>(0)

--- a/packages/effect/test/Queue.test.ts
+++ b/packages/effect/test/Queue.test.ts
@@ -319,6 +319,16 @@ describe("Queue", () => {
       assert.isNotNull(fiber.pollUnsafe())
     }))
 
+  it.effect("await succeeds when registered before end", () =>
+    Effect.gen(function*() {
+      const queue = yield* Queue.unbounded<never, Cause.Done>()
+      const fiber = yield* Queue.await(queue).pipe(Effect.forkChild)
+      yield* Effect.yieldNow
+      yield* Queue.end(queue)
+
+      assert.strictEqual(yield* Fiber.join(fiber), void 0)
+    }))
+
   it.effect("bounded 0 capacity", () =>
     Effect.gen(function*() {
       const queue = yield* Queue.bounded<number>(0)


### PR DESCRIPTION
## Summary

- normalize `Cause.Done` to successful `void` completion for awaiters registered before queue termination
- add a regression test covering `Queue.await` started before `Queue.end`
- add a patch changeset for `effect`

## Root cause

`Queue.await` normalized `Cause.Done` only when the queue was already in the `Done` state. Awaiters registered while the queue was open were resumed by `finalize` with the raw terminal exit instead.

## Validation

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/Queue.test.ts` (23 tests passed)
- `pnpm check`

Closes EFF-585
Closes #7171