### PR TITLE
Fix arbitrary migration annotations

### DIFF
--- a/migration/annotations/effect__Arbitrary.yaml
+++ b/migration/annotations/effect__Arbitrary.yaml
@@ -5,13 +5,13 @@
   replacement: "Schema.Annotations.ToArbitrary.Context"
   note: "Use the v4 arbitrary-derivation context type from Schema.Annotations."
 "effect/Arbitrary#LazyArbitrary":
-  replacement: "Schema.LazyArbitrary"
-  note: "The lazy arbitrary type moved onto Schema."
+  replacement: "Schema.Arbitrary"
+  note: "The arbitrary factory type moved onto Schema."
 "effect/Arbitrary#make":
   replacement: "Schema.toArbitrary"
   note: "Arbitrary derivation is now exposed directly by Schema."
-  example: "Schema.toArbitrary(schema)"
+  example: "Schema.toArbitrary(schema)(FastCheck)"
 "effect/Arbitrary#makeLazy":
-  replacement: "Schema.toArbitraryLazy"
+  replacement: "Schema.toArbitrary"
   note: "Lazy arbitrary derivation is now exposed directly by Schema."
-  example: "Schema.toArbitraryLazy(schema)"
+  example: "Schema.toArbitrary(schema)"


### PR DESCRIPTION
## Summary

- align the v3 `Arbitrary.LazyArbitrary` replacement with `Schema.Arbitrary`
- update `Arbitrary.make` and `Arbitrary.makeLazy` examples for the simplified `Schema.toArbitrary` factory API
- keep the generated migration reference stable when its annotations are regenerated

The upstream Schema arbitrary simplification updated `migration/v3-to-v4.md` but left its annotation source stale, so a later generator run would restore removed v4 APIs.

## Validation

- filtered the pinned API snapshots for the affected `effect/Arbitrary` and `effect/Schema` IDs
- `pnpm api-diff --base-ref 3d390f232bdbc3f0d3d6a2ae3c775084f494b547 --head-ref main --write-doc migration/v3-to-v4.md --check` against the document's prior pinned head
- `pnpm test --run packages/tools/api-diff/test/Annotations.test.ts`
- `pnpm lint-fix`
- `git diff --check`

The full current-head check also reports the unrelated pre-existing `effect/Inspectable#format` guidance gap; no commit in this maintenance range changed `Inspectable` or `Formatter`, so it is intentionally outside this focused update.

Closes EFF-584
