### PR TITLE
Use Promise microtasks in Scheduler

### DIFF
--- a/.changeset/quick-schedulers-promise.md
+++ b/.changeset/quick-schedulers-promise.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Use Promise microtasks for synchronous Scheduler dispatch.

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -94,7 +94,7 @@ const setImmediate = "setImmediate" in globalThis
 
 const setMicrotask = (f: () => void) => {
   let cancelled = false
-  queueMicrotask(() => {
+  Promise.resolve().then(() => {
     if (!cancelled) f()
   })
   return (): void => {

--- a/packages/effect/test/Scheduler.test.ts
+++ b/packages/effect/test/Scheduler.test.ts
@@ -39,27 +39,6 @@ describe("Scheduler", () => {
     }
   })
 
-  it("MixedScheduler does not use queueMicrotask", () => {
-    const queueMicrotask = vi.spyOn(globalThis, "queueMicrotask").mockImplementation(() => {
-      throw new Error("queueMicrotask is not supported")
-    })
-
-    try {
-      const scheduler = new Scheduler.MixedScheduler("sync").makeDispatcher()
-      let called = false
-
-      scheduler.scheduleTask(() => {
-        called = true
-      }, 0)
-      scheduler.flush()
-
-      assert.strictEqual(called, true)
-      assert.strictEqual(queueMicrotask.mock.calls.length, 0)
-    } finally {
-      queueMicrotask.mockRestore()
-    }
-  })
-
   it.effect("MixedScheduler orders by priority (sync)", () =>
     Effect.sync(() => {
       const scheduler = new Scheduler.MixedScheduler("sync").makeDispatcher()

--- a/packages/effect/test/Scheduler.test.ts
+++ b/packages/effect/test/Scheduler.test.ts
@@ -39,6 +39,27 @@ describe("Scheduler", () => {
     }
   })
 
+  it("MixedScheduler does not use queueMicrotask", () => {
+    const queueMicrotask = vi.spyOn(globalThis, "queueMicrotask").mockImplementation(() => {
+      throw new Error("queueMicrotask is not supported")
+    })
+
+    try {
+      const scheduler = new Scheduler.MixedScheduler("sync").makeDispatcher()
+      let called = false
+
+      scheduler.scheduleTask(() => {
+        called = true
+      }, 0)
+      scheduler.flush()
+
+      assert.strictEqual(called, true)
+      assert.strictEqual(queueMicrotask.mock.calls.length, 0)
+    } finally {
+      queueMicrotask.mockRestore()
+    }
+  })
+
   it.effect("MixedScheduler orders by priority (sync)", () =>
     Effect.sync(() => {
       const scheduler = new Scheduler.MixedScheduler("sync").makeDispatcher()


### PR DESCRIPTION
## Summary

- schedule synchronous Scheduler dispatch with `Promise.resolve().then`
- add an `effect` patch changeset

## Testing

- `nix develop -c pnpm --filter effect test --run test/Scheduler.test.ts`
- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`

Closes EFF-589
Closes #7177
