### PR TITLE
Skip cleared poller slots in PubSub publish

### DIFF
--- a/.changeset/tidy-pandas-listen.md
+++ b/.changeset/tidy-pandas-listen.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Skip cleared poller slots when a PubSub publish completes subscribers, instead of dying with `TypeError: Cannot read properties of undefined (reading 'effect')` after a waiting subscriber was interrupted

--- a/packages/effect/src/PubSub.ts
+++ b/packages/effect/src/PubSub.ts
@@ -2643,7 +2643,15 @@ const strategyCompletePollersUnsafe = <A>(
 ): void => {
   let keepPolling = true
   while (keepPolling && !subscription.isEmpty()) {
-    const poller = MutableList.take(pollers)
+    // `take` can observe a cleared slot (interruption clears a waiting
+    // poller's slot out of band), so `undefined` is a real possibility the
+    // signature does not admit; completing it would dereference undefined.
+    const poller: Deferred.Deferred<A> | typeof MutableList.Empty | undefined = MutableList.take(
+      pollers
+    )
+    if (poller === undefined) {
+      continue
+    }
     if (poller === MutableList.Empty) {
       removeSubscribers(subscribers, subscription, pollers)
       if (pollers.length === 0) {


### PR DESCRIPTION
Fixes #7184.

`MutableList.take` can observe a cleared slot: `take` nulls consumed slots for GC, and interrupting a waiting poller clears its slot out of band. `strategyCompletePollersUnsafe` only guarded against the `Empty` sentinel before handing the taken value to `Deferred.doneUnsafe`, which immediately reads `.effect` on it:

```
TypeError: Cannot read properties of undefined (reading 'effect')
    at Module.doneUnsafe (effect/dist/Deferred.js:653:12)
    at strategyCompletePollersUnsafe (effect/dist/PubSub.js:2064:18)
```

This reproduced on 100% of abrupt websocket disconnects in our production server (Threadlines): an `Effect.raceFirst` loser holding a `PubSub.subscribe` + `Stream.fromSubscription(...).pipe(Stream.take(1), Stream.runDrain)` is interrupted by the socket closing while the connection's release finalizer publishes to the same PubSub.

The fix skips cleared slots and keeps draining, with a type annotation admitting the `undefined` case the signature otherwise hides (`take` itself writes `undefined as any`). We have been running this exact guard as a package patch in production; the disconnect scenario publishes cleanly and `packages/effect/test/PubSub.test.ts` passes (34/34), `tsc -b` clean.
