### PR TITLE
Fix single-value array query decoding

### DIFF
--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -747,6 +747,44 @@ function decodePayload(
   }
 }
 
+function acceptsSingleUrlParam(ast: SchemaAST.AST, key?: string): boolean {
+  ast = SchemaAST.toEncoded(ast)
+  switch (ast._tag) {
+    case "String":
+    case "TemplateLiteral":
+      return true
+    case "Literal":
+      return typeof ast.literal === "string"
+    case "Objects": {
+      if (key === undefined) return false
+      const property = ast.propertySignatures.find((property) => property.name === key)
+      if (property !== undefined) return acceptsSingleUrlParam(property.type)
+      const input = { [key]: undefined }
+      return ast.indexSignatures.some((index) =>
+        SchemaAST.getIndexSignatureKeys(input, index.parameter).length > 0 && acceptsSingleUrlParam(index.type)
+      )
+    }
+    case "Union":
+      return ast.types.some((ast) => acceptsSingleUrlParam(ast, key))
+    case "Suspend":
+      return acceptsSingleUrlParam(ast.thunk(), key)
+    default:
+      return false
+  }
+}
+
+function normalizeUrlParams(
+  params: Record<string, string | Array<string>>,
+  ast: SchemaAST.AST
+): Record<string, string | Array<string>> {
+  const normalized: Record<string, string | Array<string>> = {}
+  for (const key in params) {
+    const value = params[key]
+    normalized[key] = Array.isArray(value) || acceptsSingleUrlParam(ast, key) ? value : [value]
+  }
+  return normalized
+}
+
 function handlerToHttpEffect(
   group: HttpApiGroup.Top,
   endpoint: HttpApiEndpoint.Top,
@@ -786,8 +824,11 @@ function handlerToHttpEffect(
       if (decodeHeaders) {
         request.headers = yield* HttpApiSchemaError.wrap("Headers", decodeHeaders(httpRequest.headers))
       }
-      if (decodeQuery) {
-        request.query = yield* HttpApiSchemaError.wrap("Query", decodeQuery(query))
+      if (decodeQuery && endpoint.query) {
+        request.query = yield* HttpApiSchemaError.wrap(
+          "Query",
+          decodeQuery(normalizeUrlParams(query, endpoint.query.ast))
+        )
       }
       if (payloadBy) {
         const result = decodePayload(payloadBy, httpRequest, query)

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -33,6 +33,40 @@ const TestServices = Layer.mergeAll(
   HttpPlatform.layer
 ).pipe(Layer.provideMerge(FileSystem.layerNoop({})))
 
+it.layer(TestServices)("HttpApiBuilder query parameters", (it) => {
+  const Api = HttpApi.make("Api").add(
+    HttpApiGroup.make("test").add(
+      HttpApiEndpoint.get("search", "/search", {
+        query: {
+          ids: Schema.Array(Schema.String)
+        },
+        success: Schema.Array(Schema.String)
+      })
+    )
+  )
+  const GroupLive = HttpApiBuilder.group(
+    Api,
+    "test",
+    (handlers) => handlers.handle("search", ({ query }) => Effect.succeed(query.ids))
+  )
+
+  it.effect("decodes a single array query parameter", () =>
+    Effect.gen(function*() {
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const result = yield* client.test.search({ query: { ids: ["a"] } })
+
+      assert.deepStrictEqual(result, ["a"])
+    }))
+
+  it.effect("decodes repeated array query parameters", () =>
+    Effect.gen(function*() {
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const result = yield* client.test.search({ query: { ids: ["a", "b"] } })
+
+      assert.deepStrictEqual(result, ["a", "b"])
+    }))
+})
+
 it.effect("reuses response schema transformations by source AST", () => {
   const SharedSuccess = Schema.String.pipe(HttpApiSchema.asText())
   const DistinctSuccess = Schema.String.pipe(HttpApiSchema.asText({ contentType: "text/custom" }))


### PR DESCRIPTION
## Summary

- normalize bare query parameter values to arrays when the endpoint's encoded query schema requires an array
- preserve scalar string fields and already-repeated query parameters
- cover both one-element and repeated array query parameter round trips through the generated client and server

## Root cause

`ParsedSearchParams` represents one occurrence as a string and only promotes a key to an array after a second occurrence. The derived client encodes a one-element array as one occurrence, so `HttpApiBuilder` passed a bare string to an array schema.

## Validation

- `pnpm test --run packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts`
- `pnpm check`
- `pnpm lint`

Closes EFF-590
Closes #7186