### PR TITLE
Fix HttpRouter middleware handled errors

### DIFF
--- a/.changeset/twenty-garlics-marry.md
+++ b/.changeset/twenty-garlics-marry.md
@@ -2,4 +2,5 @@
 "effect": patch
 ---
 
-Fix `HttpRouter.Middleware.layer` to provide request error services for errors declared in `handles`.
+Fix `HttpRouter.Middleware.layer` to provide request error services for errors declared in `handles`, and expose global
+middleware errors from `HttpRouter.toHttpEffect`.

--- a/.changeset/twenty-garlics-marry.md
+++ b/.changeset/twenty-garlics-marry.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `HttpRouter.Middleware.layer` to provide request error services for errors declared in `handles`.

--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -582,7 +582,7 @@ export const toHttpEffect = <A, E, R>(
 ): Effect.Effect<
   Effect.Effect<
     HttpServerResponse.HttpServerResponse,
-    Request.Only<"Error", R> | Request.Only<"GlobalRequires", R> | HttpServerError.HttpServerError,
+    Request.Only<"Error", R> | Request.Only<"GlobalError", R> | HttpServerError.HttpServerError,
     Scope.Scope | HttpServerRequest.HttpServerRequest | Request.Only<"Requires", R> | Request.Only<"GlobalRequires", R>
   >,
   Request.Without<E>,

--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -845,7 +845,8 @@ export interface Middleware<
   readonly [MiddlewareTypeId]: Config
 
   readonly layer: [Config["requires"]] extends [never] ? Layer.Layer<
-      Request.From<"Requires", Config["provides"]>,
+      | Request.From<"Requires", Config["provides"]>
+      | Request.From<"Error", Config["handles"]>,
       Config["layerError"],
       | Config["layerRequires"]
       | Request.From<"Requires", Config["requires"]>

--- a/packages/effect/typetest/unstable/http/HttpRouter.tst.ts
+++ b/packages/effect/typetest/unstable/http/HttpRouter.tst.ts
@@ -1,5 +1,5 @@
 import { Context, Effect, Layer } from "effect"
-import { HttpRouter, HttpServerResponse } from "effect/unstable/http"
+import { HttpRouter, type HttpServerError, HttpServerResponse } from "effect/unstable/http"
 import { describe, expect, it } from "tstyche"
 
 describe("HttpRouter", () => {
@@ -15,6 +15,23 @@ describe("HttpRouter", () => {
 
       expect<Layer.Success<typeof middleware.layer>>().type
         .toBeAssignableFrom<HttpRouter.Request<"Error", MyError>>()
+    })
+  })
+
+  describe("toHttpEffect", () => {
+    it("includes errors from global middleware", () => {
+      class MyError {
+        readonly _tag = "MyError"
+      }
+
+      const globalMiddleware = HttpRouter.middleware(
+        (effect) => Effect.andThen(effect, Effect.fail(new MyError())),
+        { global: true }
+      )
+      const result = HttpRouter.toHttpEffect(globalMiddleware)
+
+      expect<Effect.Error<Effect.Success<typeof result>>>().type
+        .toBe<MyError | HttpServerError.HttpServerError>()
     })
   })
 

--- a/packages/effect/typetest/unstable/http/HttpRouter.tst.ts
+++ b/packages/effect/typetest/unstable/http/HttpRouter.tst.ts
@@ -3,6 +3,21 @@ import { HttpRouter, HttpServerResponse } from "effect/unstable/http"
 import { describe, expect, it } from "tstyche"
 
 describe("HttpRouter", () => {
+  describe("middleware", () => {
+    it("provides handled request errors", () => {
+      class MyError {
+        readonly _tag = "MyError"
+      }
+
+      const middleware = HttpRouter.middleware<{ handles: MyError }>()((effect) =>
+        effect.pipe(Effect.catchTag("MyError", Effect.die))
+      )
+
+      expect<Layer.Success<typeof middleware.layer>>().type
+        .toBeAssignableFrom<HttpRouter.Request<"Error", MyError>>()
+    })
+  })
+
   describe("toWebHandler", () => {
     it("excludes adapter services required by middleware from the request context", () => {
       class CurrentUser extends Context.Service<CurrentUser, { readonly id: string }>()("CurrentUser") {}


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I have noticed that `HttpRouter.Middleware.layer` currently provides request dependencies markers declared through `provides`, but does not provide the corresponding request error markers declared through `handles`.

This PR:
- changes the return type of `HttpRouter.Middleware.layer` to provide the error marker.
- adds a regression test verify that the returned layer includes the error marker.
