### PR TITLE
fix(Deferred): guard waiter cleanup against post-completion runs

### DIFF
--- a/.changeset/deferred-cleanup-after-completion.md
+++ b/.changeset/deferred-cleanup-after-completion.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Deferred.await` dying with a `TypeError` when a waiter is interrupted after the `Deferred` has been completed.

--- a/packages/effect/src/Deferred.ts
+++ b/packages/effect/src/Deferred.ts
@@ -176,8 +176,12 @@ const _await = <A, E>(self: Deferred<A, E>): Effect<A, E> =>
     self.resumes ??= []
     self.resumes.push(resume)
     return internalEffect.sync(() => {
-      const index = self.resumes!.indexOf(resume)
-      self.resumes!.splice(index, 1)
+      // Completion resumes all waiters and clears `resumes`, so a cleanup
+      // running after completion has nothing to unregister.
+      const resumes = self.resumes
+      if (resumes === undefined) return
+      const index = resumes.indexOf(resume)
+      if (index >= 0) resumes.splice(index, 1)
     })
   })
 

--- a/packages/effect/test/Deferred.test.ts
+++ b/packages/effect/test/Deferred.test.ts
@@ -116,6 +116,34 @@ describe("Deferred", () => {
         assert.isTrue(yield* Deferred.succeed(deferred, 42))
         assert.strictEqual(yield* Fiber.join(live), 42)
       }))
+
+    it.effect("await - interrupting a waiter after completion does not die", () =>
+      Effect.gen(function*() {
+        const deferred = yield* Deferred.make<number>()
+        const interrupted = yield* Deferred.await(deferred).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+        const live = yield* Deferred.await(deferred).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+        assert.strictEqual(deferred.resumes?.length, 2)
+
+        // Waiters resume by running the completion effect, so a suspension
+        // inside it leaves the await's cleanup on the waiter's stack after
+        // completion has already cleared `resumes`. Interrupting the waiter
+        // from the same tick then runs that cleanup post-completion.
+        yield* Effect.sync(() => {
+          Deferred.doneUnsafe(deferred, Effect.as(Effect.yieldNow, 42))
+          assert.isUndefined(deferred.resumes)
+          interrupted.interruptUnsafe()
+        })
+
+        const exit = yield* Fiber.await(interrupted)
+        assert.isTrue(Exit.hasInterrupts(exit))
+        assert.isFalse(Exit.hasDies(exit))
+
+        assert.strictEqual(yield* Fiber.join(live), 42)
+      }))
   })
 
   describe("polling", () => {


### PR DESCRIPTION
Closes #7194

## What

Interrupting a `Deferred.await` waiter after the `Deferred` has completed dies with `TypeError: undefined is not an object (evaluating 'self.resumes.indexOf')` — the defect replaces the interrupt cause, so the fiber exits `Die` instead of interrupted. Observed in production at `4.0.0-beta.101` (long-poll handler, request abort racing a concurrent completion → HTTP 500s); code unchanged at head.

## Before / After

**Before**: `_await`'s cleanup unconditionally dereferenced `self.resumes`, but `doneUnsafe` sets it to `undefined` after resuming waiters — so any cleanup running post-completion crashed.

**After**: the cleanup early-returns when `resumes` is already cleared (and splices only on a found index, so a stale cleanup can never remove another waiter's registration via `splice(-1, 1)`).

```mermaid
sequenceDiagram
    participant W as Waiter fiber
    participant D as Deferred
    participant I as Interruptor
    W->>D: await — push resume, get cleanup
    I->>D: complete (doneUnsafe)
    D->>W: resume(effect) — waiter suspends in completion effect
    D->>D: resumes = undefined
    I->>W: interruptUnsafe()
    W->>D: cleanup: resumes.indexOf ❌ TypeError → Die
    Note over W,D: after fix: cleanup sees resumes cleared, returns — waiter exits interrupted ✓
```

## Testing

New test: `await - interrupting a waiter after completion does not die`. Deterministic: the completion effect suspends (`yieldNow`), so the resumed waiter's async-finalizer frame is still on its stack when it is interrupted, which runs the cleanup post-completion. Fails on the unguarded code with exactly the production defect; passes with the guard (verified both ways).

- `pnpm vitest run --project effect` — 8104 passed; the one failure (`unstable/cli/Prompt.test.ts`, date formatting) is pre-existing on an unmodified tree
- `pnpm --dir packages/effect check`, `oxlint`, `dprint check` — clean
- Changeset: `effect` patch
