### PR TITLE
fix(cluster): discard volatile messages eagerly

### DIFF
--- a/.changeset/tidy-tools-juggle.md
+++ b/.changeset/tidy-tools-juggle.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Ensure discarded non-persisted cluster messages complete without waiting for the entity reply.

--- a/packages/effect/src/unstable/cluster/RunnerServer.ts
+++ b/packages/effect/src/unstable/cluster/RunnerServer.ts
@@ -55,16 +55,16 @@ export const layerHandlers = Runners.Rpcs.toLayer(Effect.gen(function*() {
 
   return {
     Ping: () => Effect.void,
-    Notify: ({ envelope }) =>
-      sharding.notify(
-        envelope._tag === "Request"
-          ? new Message.IncomingRequest({
-            envelope,
-            respond: constVoid,
-            lastSentReply: Option.none()
-          })
-          : new Message.IncomingEnvelope({ envelope })
-      ),
+    Notify: ({ envelope, persisted }) => {
+      const message = envelope._tag === "Request"
+        ? new Message.IncomingRequest({
+          envelope,
+          respond: constVoid,
+          lastSentReply: Option.none()
+        })
+        : new Message.IncomingEnvelope({ envelope })
+      return persisted ? sharding.notify(message) : sharding.send(message)
+    },
     Effect: ({ persisted, request }) => {
       let replyEncoded: Option.Option<Effect.Effect<Reply.Encoded, ClusterError.EntityNotAssignedToRunner>> = Option
         .none()

--- a/packages/effect/src/unstable/cluster/Runners.ts
+++ b/packages/effect/src/unstable/cluster/Runners.ts
@@ -98,7 +98,14 @@ export class Runners extends Context.Service<Runners, {
       readonly message: Message.Outgoing<R>
       readonly discard: boolean
     }
-  ) => Effect.Effect<void, PersistenceError>
+  ) => Effect.Effect<
+    void,
+    | EntityNotAssignedToRunner
+    | RunnerUnavailable
+    | MailboxFull
+    | AlreadyProcessingMessage
+    | PersistenceError
+  >
 
   /**
    * Notify the current Runner that a message is available, then read replies from
@@ -143,11 +150,6 @@ export class Runners extends Context.Service<Runners, {
  * `MessageStorage`, duplicate requests are resumed from stored replies when
  * possible, and pending replies are polled according to
  * `ShardingConfig.entityReplyPollInterval`.
- *
- * **Gotchas**
- *
- * `notifyLocal` only supports RPCs annotated as persisted; calling it with a
- * non-persisted message dies instead of returning a typed error.
  *
  * @see {@link makeRpc} for the RPC-backed implementation built on top of this constructor
  * @see {@link makeNoop} for a no-op implementation when remote runner communication is not needed
@@ -660,20 +662,22 @@ export const makeRpc: Effect.Effect<
         return Effect.void
       }
       const rpc = message.rpc as any as Rpc.AnyWithProps
+      const isPersisted = Context.get(rpc.annotations, Persisted)
       const envelope = message.envelope
       const encode: Effect.Effect<Envelope.AckChunk | Envelope.Interrupt | Envelope.PartialRequest> =
         message._tag === "OutgoingRequest" ? Effect.orDie(Message.serializeRequest(message)) : Effect.succeed(envelope)
-      return Effect.flatMap(encode, (envelope) =>
+      const notify = Effect.flatMap(encode, (envelope) =>
         RcMap.get(clients, address.value).pipe(
           Effect.flatMap((client) =>
             client.Notify({
               envelope,
-              persisted: Context.get(rpc.annotations, Persisted)
+              persisted: isPersisted
             })
           ),
           Effect.scoped,
-          Effect.ignore
+          Effect.catchTag("RpcClientError", () => Effect.fail(new RunnerUnavailable({ address: address.value })))
         ))
+      return isPersisted ? Effect.ignore(notify) : notify
     },
     onRunnerUnavailable: (address) => RcMap.invalidate(clients, address)
   })

--- a/packages/effect/src/unstable/cluster/Runners.ts
+++ b/packages/effect/src/unstable/cluster/Runners.ts
@@ -146,9 +146,8 @@ export class Runners extends Context.Service<Runners, {
  *
  * **Gotchas**
  *
- * `notify` and `notifyLocal` only support RPCs annotated as persisted; calling
- * either path with a non-persisted message dies instead of returning a typed
- * error.
+ * `notifyLocal` only supports RPCs annotated as persisted; calling it with a
+ * non-persisted message dies instead of returning a typed error.
  *
  * @see {@link makeRpc} for the RPC-backed implementation built on top of this constructor
  * @see {@link makeNoop} for a no-op implementation when remote runner communication is not needed
@@ -175,7 +174,7 @@ export const make: (options: Omit<Runners["Service"], "sendLocal" | "notifyLocal
     const rpc = message.rpc as any as Rpc.AnyWithProps
     const persisted = Context.get(rpc.annotations, Persisted)
     if (!persisted) {
-      return Effect.die("Runners.notify only supports persisted messages")
+      return afterPersist(message, false)
     }
 
     if (message._tag === "OutgoingEnvelope") {
@@ -473,10 +472,11 @@ export class Rpcs extends RpcGroup.make(
   Rpc.make("Ping"),
   Rpc.make("Notify", {
     payload: {
-      envelope: Envelope.Partial
+      envelope: Envelope.Partial,
+      persisted: Schema.Boolean
     },
     success: Schema.Void,
-    error: Schema.Union([EntityNotAssignedToRunner, AlreadyProcessingMessage])
+    error: rpcErrors
   }),
   Rpc.make("Effect", {
     payload: {
@@ -659,12 +659,18 @@ export const makeRpc: Effect.Effect<
       if (Option.isNone(address)) {
         return Effect.void
       }
+      const rpc = message.rpc as any as Rpc.AnyWithProps
       const envelope = message.envelope
       const encode: Effect.Effect<Envelope.AckChunk | Envelope.Interrupt | Envelope.PartialRequest> =
         message._tag === "OutgoingRequest" ? Effect.orDie(Message.serializeRequest(message)) : Effect.succeed(envelope)
       return Effect.flatMap(encode, (envelope) =>
         RcMap.get(clients, address.value).pipe(
-          Effect.flatMap((client) => client.Notify({ envelope })),
+          Effect.flatMap((client) =>
+            client.Notify({
+              envelope,
+              persisted: Context.get(rpc.annotations, Persisted)
+            })
+          ),
           Effect.scoped,
           Effect.ignore
         ))

--- a/packages/effect/src/unstable/cluster/Runners.ts
+++ b/packages/effect/src/unstable/cluster/Runners.ts
@@ -90,7 +90,8 @@ export class Runners extends Context.Service<Runners, {
   >
 
   /**
-   * Notify a Runner that a message is available, then read replies from storage.
+   * Notify a Runner that a message is available. Persisted messages recover
+   * replies from storage, while volatile messages complete after delivery.
    */
   readonly notify: <R extends Rpc.Any>(
     options: {

--- a/packages/effect/src/unstable/cluster/Sharding.ts
+++ b/packages/effect/src/unstable/cluster/Sharding.ts
@@ -1012,6 +1012,8 @@ const make = Effect.gen(function*() {
         }
         return runnerIsLocal
           ? sendLocal(message)
+          : discard
+          ? runnersService.notify({ address: maybeRunner, message, discard })
           : runnersService.send({ address: maybeRunner.value, message })
       }),
       (error) =>

--- a/packages/effect/test/cluster/Runners.test.ts
+++ b/packages/effect/test/cluster/Runners.test.ts
@@ -220,6 +220,13 @@ describe.concurrent("Runners.makeRpc", () => {
   const respondWithDefect = (request: FromClientEncoded, write: (data: FromServerEncoded) => Effect.Effect<void>) =>
     request._tag === "Request" ? write({ _tag: "Defect", defect: "boom" }) : Effect.void
 
+  const failTransport = () =>
+    Effect.fail(
+      new RpcClientError({
+        reason: new Socket.SocketCloseError({ code: 1006 })
+      })
+    )
+
   it.effect("a server-delivered defect resolves the request instead of RunnerUnavailable", () =>
     Effect.gen(function*() {
       const runners = yield* Runners.Runners
@@ -255,13 +262,7 @@ describe.concurrent("Runners.makeRpc", () => {
         return assert.fail("send must fail for a transport failure")
       }
       assert.instanceOf(Cause.squash(exit.cause), ClusterError.RunnerUnavailable)
-    }).pipe(Effect.provide(layerRunners(layerFakeProtocol(() =>
-      Effect.fail(
-        new RpcClientError({
-          reason: new Socket.SocketCloseError({ code: 1006 })
-        })
-      )
-    )))))
+    }).pipe(Effect.provide(layerRunners(layerFakeProtocol(failTransport)))))
 
   it.effect("volatile notification transport failures map to RunnerUnavailable", () =>
     Effect.gen(function*() {
@@ -278,13 +279,7 @@ describe.concurrent("Runners.makeRpc", () => {
         return assert.fail("volatile notification must fail when delivery fails")
       }
       assert.instanceOf(Cause.squash(exit.cause), ClusterError.RunnerUnavailable)
-    }).pipe(Effect.provide(layerRunners(layerFakeProtocol(() =>
-      Effect.fail(
-        new RpcClientError({
-          reason: new Socket.SocketCloseError({ code: 1006 })
-        })
-      )
-    )))))
+    }).pipe(Effect.provide(layerRunners(layerFakeProtocol(failTransport)))))
 
   it.effect("persisted notification transport failures are ignored", () =>
     Effect.gen(function*() {
@@ -297,13 +292,7 @@ describe.concurrent("Runners.makeRpc", () => {
         message,
         discard: true
       })
-    }).pipe(Effect.provide(layerRunners(layerFakeProtocol(() =>
-      Effect.fail(
-        new RpcClientError({
-          reason: new Socket.SocketCloseError({ code: 1006 })
-        })
-      )
-    )))))
+    }).pipe(Effect.provide(layerRunners(layerFakeProtocol(failTransport)))))
 
   it.effect("a delivered defect for a persisted request maps to RunnerUnavailable for storage recovery", () =>
     Effect.gen(function*() {

--- a/packages/effect/test/cluster/Runners.test.ts
+++ b/packages/effect/test/cluster/Runners.test.ts
@@ -263,6 +263,48 @@ describe.concurrent("Runners.makeRpc", () => {
       )
     )))))
 
+  it.effect("volatile notification transport failures map to RunnerUnavailable", () =>
+    Effect.gen(function*() {
+      const runners = yield* Runners.Runners
+      const snowflakeGen = yield* Snowflake.Generator
+      const message = makeOutgoingRequest(TestRpc, snowflakeGen.nextUnsafe(), () => Effect.void)
+
+      const exit = yield* Effect.exit(runners.notify({
+        address: Option.some(runnerAddress),
+        message,
+        discard: true
+      }))
+      if (!Exit.isFailure(exit)) {
+        return assert.fail("volatile notification must fail when delivery fails")
+      }
+      assert.instanceOf(Cause.squash(exit.cause), ClusterError.RunnerUnavailable)
+    }).pipe(Effect.provide(layerRunners(layerFakeProtocol(() =>
+      Effect.fail(
+        new RpcClientError({
+          reason: new Socket.SocketCloseError({ code: 1006 })
+        })
+      )
+    )))))
+
+  it.effect("persisted notification transport failures are ignored", () =>
+    Effect.gen(function*() {
+      const runners = yield* Runners.Runners
+      const snowflakeGen = yield* Snowflake.Generator
+      const message = makeOutgoingRequest(TestRpcPersisted, snowflakeGen.nextUnsafe(), () => Effect.void)
+
+      yield* runners.notify({
+        address: Option.some(runnerAddress),
+        message,
+        discard: true
+      })
+    }).pipe(Effect.provide(layerRunners(layerFakeProtocol(() =>
+      Effect.fail(
+        new RpcClientError({
+          reason: new Socket.SocketCloseError({ code: 1006 })
+        })
+      )
+    )))))
+
   it.effect("a delivered defect for a persisted request maps to RunnerUnavailable for storage recovery", () =>
     Effect.gen(function*() {
       const runners = yield* Runners.Runners

--- a/packages/effect/test/cluster/Sharding.test.ts
+++ b/packages/effect/test/cluster/Sharding.test.ts
@@ -919,6 +919,75 @@ describe.concurrent("Sharding", () => {
       expect(driver.unprocessed.size).toEqual(1)
     }).pipe(Effect.provide(TestSharding)))
 
+  it.effect("client discard returns while the volatile request keeps processing", () =>
+    Effect.gen(function*() {
+      yield* TestClock.adjust(1)
+      const state = yield* TestEntityState
+      const makeClient = yield* TestEntity.client
+      const client = makeClient("1")
+
+      const result = yield* client.NeverVolatile(void 0, { discard: true })
+
+      assert.isUndefined(result)
+      yield* TestClock.adjust(1)
+      assert.strictEqual(Queue.sizeUnsafe(state.envelopes), 1)
+    }).pipe(Effect.provide(TestSharding)))
+
+  it.effect("client volatile discard retries a failed delivery", () =>
+    Effect.gen(function*() {
+      let attempts = 0
+      const config = ShardingConfig.layer({
+        entityMailboxCapacity: 10,
+        entityTerminationTimeout: 0,
+        entityMessagePollInterval: 5000,
+        sendRetryInterval: 100,
+        refreshAssignmentsInterval: 0
+      })
+      const runners = Layer.effect(Runners.Runners)(
+        Effect.gen(function*() {
+          const runners = yield* Runners.makeNoop
+          return {
+            ...runners,
+            notify(options) {
+              attempts++
+              return attempts === 1
+                ? Effect.fail(
+                  new ClusterError.RunnerUnavailable({
+                    address: Option.getOrThrow(options.address)
+                  })
+                )
+                : Effect.void
+            }
+          }
+        })
+      ).pipe(
+        Layer.provide([MessageStorage.layerMemory, Snowflake.layerGenerator]),
+        Layer.provide(config)
+      )
+      const layer = TestShardingWithoutRunners.pipe(
+        Layer.provide(runners),
+        Layer.provide([MessageStorage.layerMemory, Snowflake.layerGenerator]),
+        Layer.provideMerge(config)
+      )
+
+      yield* Effect.gen(function*() {
+        yield* TestClock.adjust(1)
+        const config = yield* ShardingConfig.ShardingConfig
+        ;(config as any).runnerAddress = Option.some(RunnerAddress.make("localhost", 1234))
+        const makeClient = yield* TestEntity.client
+        const client = makeClient("1")
+        const fiber = yield* client.NeverVolatile(void 0, { discard: true }).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+
+        assert.strictEqual(attempts, 1)
+        assert.isUndefined(fiber.pollUnsafe())
+        yield* TestClock.adjust(100)
+        yield* Fiber.join(fiber)
+        assert.strictEqual(attempts, 2)
+      }).pipe(Effect.provide(layer))
+    }))
+
   it.effect("defects when a durable request has no MessageStorage", () =>
     Effect.gen(function*() {
       const makeClient = yield* TestEntity.client

--- a/packages/effect/test/cluster/Sharding.test.ts
+++ b/packages/effect/test/cluster/Sharding.test.ts
@@ -936,39 +936,6 @@ describe.concurrent("Sharding", () => {
   it.effect("client volatile discard retries a failed delivery", () =>
     Effect.gen(function*() {
       let attempts = 0
-      const config = ShardingConfig.layer({
-        entityMailboxCapacity: 10,
-        entityTerminationTimeout: 0,
-        entityMessagePollInterval: 5000,
-        sendRetryInterval: 100,
-        refreshAssignmentsInterval: 0
-      })
-      const runners = Layer.effect(Runners.Runners)(
-        Effect.gen(function*() {
-          const runners = yield* Runners.makeNoop
-          return {
-            ...runners,
-            notify(options) {
-              attempts++
-              return attempts === 1
-                ? Effect.fail(
-                  new ClusterError.RunnerUnavailable({
-                    address: Option.getOrThrow(options.address)
-                  })
-                )
-                : Effect.void
-            }
-          }
-        })
-      ).pipe(
-        Layer.provide([MessageStorage.layerMemory, Snowflake.layerGenerator]),
-        Layer.provide(config)
-      )
-      const layer = TestShardingWithoutRunners.pipe(
-        Layer.provide(runners),
-        Layer.provide([MessageStorage.layerMemory, Snowflake.layerGenerator]),
-        Layer.provideMerge(config)
-      )
 
       yield* Effect.gen(function*() {
         yield* TestClock.adjust(1)
@@ -985,7 +952,38 @@ describe.concurrent("Sharding", () => {
         yield* TestClock.adjust(100)
         yield* Fiber.join(fiber)
         assert.strictEqual(attempts, 2)
-      }).pipe(Effect.provide(layer))
+      }).pipe(
+        Effect.provide(TestShardingWithoutRunners.pipe(
+          Layer.provide(
+            Layer.effect(Runners.Runners)(
+              Effect.gen(function*() {
+                const runners = yield* Runners.makeNoop
+                return {
+                  ...runners,
+                  notify(options) {
+                    attempts++
+                    return attempts === 1
+                      ? Effect.fail(
+                        new ClusterError.RunnerUnavailable({
+                          address: Option.getOrThrow(options.address)
+                        })
+                      )
+                      : Effect.void
+                  }
+                }
+              })
+            )
+          ),
+          Layer.provide([MessageStorage.layerMemory, Snowflake.layerGenerator]),
+          Layer.provideMerge(ShardingConfig.layer({
+            entityMailboxCapacity: 10,
+            entityTerminationTimeout: 0,
+            entityMessagePollInterval: 5000,
+            sendRetryInterval: 100,
+            refreshAssignmentsInterval: 0
+          }))
+        ))
+      )
     }))
 
   it.effect("defects when a durable request has no MessageStorage", () =>

--- a/packages/platform/deno/test/cluster/SocketRunner.test.ts
+++ b/packages/platform/deno/test/cluster/SocketRunner.test.ts
@@ -102,7 +102,7 @@ const ISOLATION_PORT = 50_126
 // host runner to finish handling it.
 describe("SocketRunner", () => {
   it.live(
-    "persisted and non-persisted entity calls with BigDecimal and discard should not stack overflow",
+    "discarded persisted requests serialize circular values and volatile requests do not wait for replies",
     () =>
       Effect.gen(function*() {
         const volatileStarted = yield* Deferred.make<void>()
@@ -138,7 +138,12 @@ describe("SocketRunner", () => {
           ).pipe(Effect.forkChild)
 
           yield* Deferred.await(volatileStarted)
-          yield* Fiber.join(volatileFiber).pipe(Effect.timeout("1 second"))
+          yield* Fiber.join(volatileFiber).pipe(
+            Effect.timeoutOrElse({
+              duration: "1 second",
+              orElse: () => Effect.die("volatile discard waited for the entity reply")
+            })
+          )
           yield* Deferred.succeed(releaseVolatile, void 0)
         }).pipe(
           Effect.provide(makeClientLayer(RUNNER_PORT)),

--- a/packages/platform/deno/test/cluster/SocketRunner.test.ts
+++ b/packages/platform/deno/test/cluster/SocketRunner.test.ts
@@ -28,14 +28,18 @@ const TestEntity = Entity
     Rpc.make("Process", {
       payload: TestPayload,
       success: Schema.Void
-    })
+    }).annotate(ClusterSchema.Persisted, true),
+    Rpc.make("ProcessVolatile", {
+      payload: TestPayload,
+      success: Schema.Void
+    }).annotate(ClusterSchema.Persisted, false)
   ])
-  .annotateRpcs(ClusterSchema.Persisted, true)
   .annotateRpcs(ClusterSchema.Uninterruptible, true)
 
 const TestEntityLayer = TestEntity.toLayer(
   Effect.succeed({
-    Process: () => Effect.void
+    Process: () => Effect.void,
+    ProcessVolatile: () => Effect.void
   })
 )
 
@@ -98,7 +102,7 @@ const ISOLATION_PORT = 50_126
 
 describe("SocketRunner", () => {
   it.live(
-    "entity call with BigDecimal and discard should not stack overflow",
+    "persisted and non-persisted entity calls with BigDecimal and discard should not stack overflow",
     () =>
       Effect.gen(function*() {
         yield* Layer.launch(makeRunnerLayer(RUNNER_PORT, TestEntityLayer)).pipe(Effect.forkScoped)
@@ -113,6 +117,10 @@ describe("SocketRunner", () => {
           const amount = BigDecimal.fromStringUnsafe("123.45")
           yield* client.Process(
             TestPayload.make({ id: "req-1", amount }),
+            { discard: true }
+          )
+          yield* client.ProcessVolatile(
+            TestPayload.make({ id: "req-2", amount }),
             { discard: true }
           )
         }).pipe(

--- a/packages/platform/deno/test/cluster/SocketRunner.test.ts
+++ b/packages/platform/deno/test/cluster/SocketRunner.test.ts
@@ -1,6 +1,6 @@
 import { DenoClusterSocket } from "@effect/platform-deno"
 import { assert, describe, it } from "@effect/vitest"
-import { BigDecimal, Cause, Effect, Exit, Fiber, Layer, Option, PrimaryKey, Schema } from "effect"
+import { BigDecimal, Cause, Deferred, Effect, Exit, Fiber, Layer, Option, PrimaryKey, Schema } from "effect"
 import type { Sharding } from "effect/unstable/cluster"
 import {
   ClusterSchema,
@@ -35,13 +35,6 @@ const TestEntity = Entity
     }).annotate(ClusterSchema.Persisted, false)
   ])
   .annotateRpcs(ClusterSchema.Uninterruptible, true)
-
-const TestEntityLayer = TestEntity.toLayer(
-  Effect.succeed({
-    Process: () => Effect.void,
-    ProcessVolatile: () => Effect.void
-  })
-)
 
 const RUNNER_PORT = 50_125
 const SharedStorage = Layer.mergeAll(
@@ -100,11 +93,30 @@ const IsolationEntityLayer = IsolationEntity.toLayer(
 
 const ISOLATION_PORT = 50_126
 
+// BigDecimal.normalize creates a circular `normalized` self-reference.
+// When a persisted message is sent with discard: true, the notify path in Runners.makeRpc
+// passes the raw envelope (with circular BigDecimal payload) to the runner via msgpack,
+// causing RangeError: Maximum call stack size exceeded.
+//
+// Volatile discard still goes through runners.send (Effect RPC), so the client must wait
+// until the host runner replies before the discarded call completes.
 describe("SocketRunner", () => {
   it.live(
     "persisted and non-persisted entity calls with BigDecimal and discard should not stack overflow",
     () =>
       Effect.gen(function*() {
+        const volatileStarted = yield* Deferred.make<void>()
+        const releaseVolatile = yield* Deferred.make<void>()
+        const TestEntityLayer = TestEntity.toLayer(
+          Effect.succeed({
+            Process: () => Effect.void,
+            ProcessVolatile: () =>
+              Deferred.succeed(volatileStarted, void 0).pipe(
+                Effect.andThen(Deferred.await(releaseVolatile))
+              )
+          })
+        )
+
         yield* Layer.launch(makeRunnerLayer(RUNNER_PORT, TestEntityLayer)).pipe(Effect.forkScoped)
 
         yield* Effect.sleep("2 seconds")
@@ -119,10 +131,20 @@ describe("SocketRunner", () => {
             TestPayload.make({ id: "req-1", amount }),
             { discard: true }
           )
-          yield* client.ProcessVolatile(
+
+          const volatileFiber = yield* client.ProcessVolatile(
             TestPayload.make({ id: "req-2", amount }),
             { discard: true }
+          ).pipe(Effect.forkChild)
+
+          yield* Deferred.await(volatileStarted)
+          // While the handler is still running, the discarded volatile call must not complete.
+          assert.isUndefined(
+            volatileFiber.pollUnsafe(),
+            "volatile discard must wait for the runner reply"
           )
+          yield* Deferred.succeed(releaseVolatile, void 0)
+          yield* Fiber.join(volatileFiber)
         }).pipe(
           Effect.provide(makeClientLayer(RUNNER_PORT)),
           Effect.scoped

--- a/packages/platform/deno/test/cluster/SocketRunner.test.ts
+++ b/packages/platform/deno/test/cluster/SocketRunner.test.ts
@@ -98,8 +98,8 @@ const ISOLATION_PORT = 50_126
 // passes the raw envelope (with circular BigDecimal payload) to the runner via msgpack,
 // causing RangeError: Maximum call stack size exceeded.
 //
-// Volatile discard still goes through runners.send (Effect RPC), so the client must wait
-// until the host runner replies before the discarded call completes.
+// Volatile discard should complete after the request is sent, without waiting for the
+// host runner to finish handling it.
 describe("SocketRunner", () => {
   it.live(
     "persisted and non-persisted entity calls with BigDecimal and discard should not stack overflow",
@@ -138,13 +138,8 @@ describe("SocketRunner", () => {
           ).pipe(Effect.forkChild)
 
           yield* Deferred.await(volatileStarted)
-          // While the handler is still running, the discarded volatile call must not complete.
-          assert.isUndefined(
-            volatileFiber.pollUnsafe(),
-            "volatile discard must wait for the runner reply"
-          )
+          yield* Fiber.join(volatileFiber).pipe(Effect.timeout("1 second"))
           yield* Deferred.succeed(releaseVolatile, void 0)
-          yield* Fiber.join(volatileFiber)
         }).pipe(
           Effect.provide(makeClientLayer(RUNNER_PORT)),
           Effect.scoped

--- a/packages/platform/node/test/cluster/SocketRunner.test.ts
+++ b/packages/platform/node/test/cluster/SocketRunner.test.ts
@@ -1,6 +1,6 @@
 import { NodeClusterSocket } from "@effect/platform-node"
 import { assert, describe, it } from "@effect/vitest"
-import { BigDecimal, Cause, Effect, Exit, Fiber, Layer, Option, PrimaryKey, Schema } from "effect"
+import { BigDecimal, Cause, Deferred, Effect, Exit, Fiber, Layer, Option, PrimaryKey, Schema } from "effect"
 import type { Sharding } from "effect/unstable/cluster"
 import {
   ClusterSchema,
@@ -35,13 +35,6 @@ const TestEntity = Entity
     }).annotate(ClusterSchema.Persisted, false)
   ])
   .annotateRpcs(ClusterSchema.Uninterruptible, true)
-
-const TestEntityLayer = TestEntity.toLayer(
-  Effect.succeed({
-    Process: () => Effect.void,
-    ProcessVolatile: () => Effect.void
-  })
-)
 
 const RUNNER_PORT = 50_123
 // Build shared storage instances once, so runner and client see the same state.
@@ -109,11 +102,26 @@ const ISOLATION_PORT = 50_124
 // When a persisted message is sent with discard: true, the notify path in Runners.makeRpc
 // passes the raw envelope (with circular BigDecimal payload) to the runner via msgpack,
 // causing RangeError: Maximum call stack size exceeded.
+//
+// Volatile discard still goes through runners.send (Effect RPC), so the client must wait
+// until the host runner replies before the discarded call completes.
 describe("SocketRunner", () => {
   it.live(
     "persisted and non-persisted entity calls with BigDecimal and discard should not stack overflow",
     () =>
       Effect.gen(function*() {
+        const volatileStarted = yield* Deferred.make<void>()
+        const releaseVolatile = yield* Deferred.make<void>()
+        const TestEntityLayer = TestEntity.toLayer(
+          Effect.succeed({
+            Process: () => Effect.void,
+            ProcessVolatile: () =>
+              Deferred.succeed(volatileStarted, void 0).pipe(
+                Effect.andThen(Deferred.await(releaseVolatile))
+              )
+          })
+        )
+
         // Start the runner (with socket server and entity handler)
         yield* Layer.launch(makeRunnerLayer(RUNNER_PORT, TestEntityLayer)).pipe(Effect.forkScoped)
 
@@ -137,10 +145,20 @@ describe("SocketRunner", () => {
             TestPayload.make({ id: "req-1", amount }),
             { discard: true }
           )
-          yield* client.ProcessVolatile(
+
+          const volatileFiber = yield* client.ProcessVolatile(
             TestPayload.make({ id: "req-2", amount }),
             { discard: true }
+          ).pipe(Effect.forkChild)
+
+          yield* Deferred.await(volatileStarted)
+          // While the handler is still running, the discarded volatile call must not complete.
+          assert.isUndefined(
+            volatileFiber.pollUnsafe(),
+            "volatile discard must wait for the runner reply"
           )
+          yield* Deferred.succeed(releaseVolatile, void 0)
+          yield* Fiber.join(volatileFiber)
         }).pipe(
           Effect.provide(makeClientLayer(RUNNER_PORT)),
           Effect.scoped

--- a/packages/platform/node/test/cluster/SocketRunner.test.ts
+++ b/packages/platform/node/test/cluster/SocketRunner.test.ts
@@ -107,7 +107,7 @@ const ISOLATION_PORT = 50_124
 // host runner to finish handling it.
 describe("SocketRunner", () => {
   it.live(
-    "persisted and non-persisted entity calls with BigDecimal and discard should not stack overflow",
+    "discarded persisted requests serialize circular values and volatile requests do not wait for replies",
     () =>
       Effect.gen(function*() {
         const volatileStarted = yield* Deferred.make<void>()
@@ -152,7 +152,12 @@ describe("SocketRunner", () => {
           ).pipe(Effect.forkChild)
 
           yield* Deferred.await(volatileStarted)
-          yield* Fiber.join(volatileFiber).pipe(Effect.timeout("1 second"))
+          yield* Fiber.join(volatileFiber).pipe(
+            Effect.timeoutOrElse({
+              duration: "1 second",
+              orElse: () => Effect.die("volatile discard waited for the entity reply")
+            })
+          )
           yield* Deferred.succeed(releaseVolatile, void 0)
         }).pipe(
           Effect.provide(makeClientLayer(RUNNER_PORT)),

--- a/packages/platform/node/test/cluster/SocketRunner.test.ts
+++ b/packages/platform/node/test/cluster/SocketRunner.test.ts
@@ -103,8 +103,8 @@ const ISOLATION_PORT = 50_124
 // passes the raw envelope (with circular BigDecimal payload) to the runner via msgpack,
 // causing RangeError: Maximum call stack size exceeded.
 //
-// Volatile discard still goes through runners.send (Effect RPC), so the client must wait
-// until the host runner replies before the discarded call completes.
+// Volatile discard should complete after the request is sent, without waiting for the
+// host runner to finish handling it.
 describe("SocketRunner", () => {
   it.live(
     "persisted and non-persisted entity calls with BigDecimal and discard should not stack overflow",
@@ -152,13 +152,8 @@ describe("SocketRunner", () => {
           ).pipe(Effect.forkChild)
 
           yield* Deferred.await(volatileStarted)
-          // While the handler is still running, the discarded volatile call must not complete.
-          assert.isUndefined(
-            volatileFiber.pollUnsafe(),
-            "volatile discard must wait for the runner reply"
-          )
+          yield* Fiber.join(volatileFiber).pipe(Effect.timeout("1 second"))
           yield* Deferred.succeed(releaseVolatile, void 0)
-          yield* Fiber.join(volatileFiber)
         }).pipe(
           Effect.provide(makeClientLayer(RUNNER_PORT)),
           Effect.scoped

--- a/packages/platform/node/test/cluster/SocketRunner.test.ts
+++ b/packages/platform/node/test/cluster/SocketRunner.test.ts
@@ -28,14 +28,18 @@ const TestEntity = Entity
     Rpc.make("Process", {
       payload: TestPayload,
       success: Schema.Void
-    })
+    }).annotate(ClusterSchema.Persisted, true),
+    Rpc.make("ProcessVolatile", {
+      payload: TestPayload,
+      success: Schema.Void
+    }).annotate(ClusterSchema.Persisted, false)
   ])
-  .annotateRpcs(ClusterSchema.Persisted, true)
   .annotateRpcs(ClusterSchema.Uninterruptible, true)
 
 const TestEntityLayer = TestEntity.toLayer(
   Effect.succeed({
-    Process: () => Effect.void
+    Process: () => Effect.void,
+    ProcessVolatile: () => Effect.void
   })
 )
 
@@ -107,7 +111,7 @@ const ISOLATION_PORT = 50_124
 // causing RangeError: Maximum call stack size exceeded.
 describe("SocketRunner", () => {
   it.live(
-    "entity call with BigDecimal and discard should not stack overflow",
+    "persisted and non-persisted entity calls with BigDecimal and discard should not stack overflow",
     () =>
       Effect.gen(function*() {
         // Start the runner (with socket server and entity handler)
@@ -131,6 +135,10 @@ describe("SocketRunner", () => {
 
           yield* client.Process(
             TestPayload.make({ id: "req-1", amount }),
+            { discard: true }
+          )
+          yield* client.ProcessVolatile(
+            TestPayload.make({ id: "req-2", amount }),
             { discard: true }
           )
         }).pipe(


### PR DESCRIPTION
## Summary

- route discarded non-persisted cluster requests through the fire-and-forget runner notification path
- return immediately after the remote runner accepts the request without waiting for the entity reply
- propagate volatile notification delivery failures so existing sharding retries remain active
- continue ignoring remote notification failures for persisted requests, which recover through storage
- cover immediate completion and failed-delivery retry behavior with fast cluster tests
- cover the socket behavior for Node and Deno and improve failure diagnostics

## Root cause

Remote volatile requests previously used the reply-bearing runner `Effect` RPC even when the caller selected `discard: true`, so callers waited for entity replies. Moving them to `Notify` fixed that wait but initially ignored every delivery error, allowing volatile messages to be lost without a signal. Volatile notifications now propagate runner and transport failures while persisted notifications retain their storage-backed error handling.

## Validation

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/cluster/Sharding.test.ts` (36 passed)
- `pnpm test --run packages/effect/test/cluster/Runners.test.ts packages/effect/test/cluster/RunnerServer.test.ts packages/platform/node/test/cluster/SocketRunner.test.ts` (10 passed)
- `pnpm check`
- `deno check packages/platform/deno/test/cluster/SocketRunner.test.ts`

Closes EFF-596
