### PR TITLE
Update README installation guidance for V4 RC

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Effect is a library for building robust, maintainable, type-safe, and production
 
 > **Effect V4 is currently a release candidate.** The `main` branch contains v4 development.
 
+## Requirements
+
+- **TypeScript 5.9 or newer.** TypeScript 7 is recommended for the best performance and compatibility with [Effect's TypeScript tooling](https://github.com/Effect-TS/tsgo#installation).
+- **Node.js 18 or newer** when running Effect on Node.js.
+- **Strict type-checking:** the `strict` flag must be enabled in your `tsconfig.json`.
+
 ## Install V4 RC
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -6,27 +6,23 @@
 
 Effect is a library for building robust, maintainable, type-safe, and production grade applications in TypeScript. It helps you handle the hard problems at scale: typed errors, dependency injection, structured concurrency, scheduling, tracing, and unified schema validation.
 
-> **Effect V4 is currently in beta.** The `main` branch contains v4 development.
+> **Effect V4 is currently a release candidate.** The `main` branch contains v4 development.
 
-## Install V4 Beta
+## Install V4 RC
 
 ```sh
-npm install effect@beta
+npm install effect@rc
 ```
 
 ## Effect v3
 
 The Effect v3 source code is available on the [`v3`](https://github.com/Effect-TS/effect/tree/v3) branch.
 
-```sh
-npm install effect@latest
-```
-
 Issues and pull requests meant for Effect v3 should target the [`v3`](https://github.com/Effect-TS/effect/tree/v3) branch.
 
 ## Packages
 
-This monorepo contains the core `effect` package alongside integration packages that extend it. All v4 packages are published under the `beta` tag on npm.
+This monorepo contains the core `effect` package alongside integration packages that extend it. All v4 packages are published under the `rc` tag on npm.
 
 | Package                                                               | Description                                              | API Reference                                                      |
 | --------------------------------------------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ Effect is a library for building robust, maintainable, type-safe, and production
 
 > **Effect V4 is currently a release candidate.** The `main` branch contains v4 development.
 
-## Requirements
-
-- **TypeScript 5.9 or newer.** TypeScript 7 is recommended for the best performance and compatibility with [Effect's TypeScript tooling](https://github.com/Effect-TS/tsgo#installation).
-- **Node.js 18 or newer** is the general minimum for running Effect on Node.js. Some integration packages require newer runtimes; for example, `@effect/sql-sqlite-node` requires Node.js 22.16 or newer.
-- **Strict type-checking:** the `strict` flag must be enabled in your `tsconfig.json`.
-
 ## Install V4 RC
 
 ```sh
 npm install effect@rc
 ```
+
+## Requirements
+
+- **TypeScript 5.9 or newer.** TypeScript 7 is recommended for the best performance and compatibility with [Effect's TypeScript tooling](https://github.com/Effect-TS/tsgo#installation).
+- **Node.js 18 or newer** is the general minimum for running Effect on Node.js. Some integration packages require newer runtimes; for example, `@effect/sql-sqlite-node` requires Node.js 22.16 or newer.
+- **Strict type-checking:** the `strict` flag must be enabled in your `tsconfig.json`.
 
 ## Effect v3
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Effect is a library for building robust, maintainable, type-safe, and production
 ## Requirements
 
 - **TypeScript 5.9 or newer.** TypeScript 7 is recommended for the best performance and compatibility with [Effect's TypeScript tooling](https://github.com/Effect-TS/tsgo#installation).
-- **Node.js 18 or newer** when running Effect on Node.js.
+- **Node.js 18 or newer** is the general minimum for running Effect on Node.js. Some integration packages require newer runtimes; for example, `@effect/sql-sqlite-node` requires Node.js 22.16 or newer.
 - **Strict type-checking:** the `strict` flag must be enabled in your `tsconfig.json`.
 
 ## Install V4 RC

--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ npm install effect@rc
 
 ## Effect v3
 
-The Effect v3 source code is available on the [`v3`](https://github.com/Effect-TS/effect/tree/v3) branch.
-
-Issues and pull requests meant for Effect v3 should target the [`v3`](https://github.com/Effect-TS/effect/tree/v3) branch.
+The Effect v3 source code is available on the [`v3`](https://github.com/Effect-TS/effect/tree/v3) branch, which is also where issues and pull requests meant for Effect v3 should be targeted.
 
 ## Packages
 

--- a/packages/ai/anthropic/README.md
+++ b/packages/ai/anthropic/README.md
@@ -5,7 +5,7 @@ An [Anthropic](https://www.anthropic.com) provider for the Effect AI modules. In
 ## Installation
 
 ```sh
-npm install effect@beta @effect/ai-anthropic@beta
+npm install effect@rc @effect/ai-anthropic@rc
 ```
 
 ## Documentation

--- a/packages/ai/openai-compat/README.md
+++ b/packages/ai/openai-compat/README.md
@@ -5,7 +5,7 @@ Connects the Effect AI modules to any OpenAI-compatible API, with support for ch
 ## Installation
 
 ```sh
-npm install effect@beta @effect/ai-openai-compat@beta
+npm install effect@rc @effect/ai-openai-compat@rc
 ```
 
 ## Documentation

--- a/packages/ai/openai/README.md
+++ b/packages/ai/openai/README.md
@@ -5,7 +5,7 @@ An [OpenAI](https://openai.com) provider for the Effect AI modules. Includes a t
 ## Installation
 
 ```sh
-npm install effect@beta @effect/ai-openai@beta
+npm install effect@rc @effect/ai-openai@rc
 ```
 
 ## Documentation

--- a/packages/ai/openrouter/README.md
+++ b/packages/ai/openrouter/README.md
@@ -5,7 +5,7 @@ An [OpenRouter](https://openrouter.ai) provider for the Effect AI modules. Inclu
 ## Installation
 
 ```sh
-npm install effect@beta @effect/ai-openrouter@beta
+npm install effect@rc @effect/ai-openrouter@rc
 ```
 
 ## Documentation

--- a/packages/atom/react/README.md
+++ b/packages/atom/react/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```sh
-npm install effect@beta @effect/atom-react@beta
+npm install effect@rc @effect/atom-react@rc
 ```
 
 ## Documentation

--- a/packages/atom/solid/README.md
+++ b/packages/atom/solid/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```sh
-npm install effect@beta @effect/atom-solid@beta
+npm install effect@rc @effect/atom-solid@rc
 ```
 
 ## Documentation

--- a/packages/atom/vue/README.md
+++ b/packages/atom/vue/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```sh
-npm install effect@beta @effect/atom-vue@beta
+npm install effect@rc @effect/atom-vue@rc
 ```
 
 ## Documentation

--- a/packages/effect/README.md
+++ b/packages/effect/README.md
@@ -6,7 +6,8 @@ The `effect` package is the core of the framework. It provides primitives for ma
 
 ## Requirements
 
-- **TypeScript 5.9 or newer**
+- **TypeScript 5.9 or newer.** TypeScript 7 is recommended for the best performance and compatibility with [Effect's TypeScript tooling](https://github.com/Effect-TS/tsgo#installation).
+- **Node.js 18 or newer** when running Effect on Node.js.
 - **Strict type-checking:** the `strict` flag must be enabled in your `tsconfig.json`:
 
   ```json

--- a/packages/effect/README.md
+++ b/packages/effect/README.md
@@ -20,7 +20,7 @@ The `effect` package is the core of the framework. It provides primitives for ma
 ## Installation
 
 ```sh
-npm install effect@beta
+npm install effect@rc
 ```
 
 ## Documentation

--- a/packages/effect/README.md
+++ b/packages/effect/README.md
@@ -4,6 +4,12 @@ Effect is a library for building robust, maintainable, type-safe, and production
 
 The `effect` package is the core of the framework. It provides primitives for managing side effects, errors, concurrency, resources, and structured data, alongside a rich standard library.
 
+## Installation
+
+```sh
+npm install effect@rc
+```
+
 ## Requirements
 
 - **TypeScript 5.9 or newer.** TypeScript 7 is recommended for the best performance and compatibility with [Effect's TypeScript tooling](https://github.com/Effect-TS/tsgo#installation).
@@ -17,12 +23,6 @@ The `effect` package is the core of the framework. It provides primitives for ma
     }
   }
   ```
-
-## Installation
-
-```sh
-npm install effect@rc
-```
 
 ## Documentation
 

--- a/packages/effect/runtimeperf/README.md
+++ b/packages/effect/runtimeperf/README.md
@@ -18,7 +18,7 @@ Run the complete registry:
 pnpm runtimeperf
 ```
 
-Run the cases extracted from the `effect@beta`, Valibot and Zod adapters in
+Run the cases extracted from the `effect@rc`, Valibot and Zod adapters in
 [`open-circle/schema-benchmarks`](https://github.com/open-circle/schema-benchmarks):
 
 ```sh

--- a/packages/effect/runtimeperf/README.md
+++ b/packages/effect/runtimeperf/README.md
@@ -18,7 +18,7 @@ Run the complete registry:
 pnpm runtimeperf
 ```
 
-Run the cases extracted from the `effect@rc`, Valibot and Zod adapters in
+Run the cases extracted from the `effect@beta`, Valibot and Zod adapters in
 [`open-circle/schema-benchmarks`](https://github.com/open-circle/schema-benchmarks):
 
 ```sh

--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -5,7 +5,7 @@ An [OpenTelemetry](https://opentelemetry.io) integration for Effect. Exports Eff
 ## Installation
 
 ```sh
-npm install effect@beta @effect/opentelemetry@beta
+npm install effect@rc @effect/opentelemetry@rc
 ```
 
 The relevant `@opentelemetry/*` SDK packages are required as peer dependencies, depending on which features you use.

--- a/packages/platform/browser/README.md
+++ b/packages/platform/browser/README.md
@@ -5,7 +5,7 @@ Browser implementations of the Effect platform services, including the HTTP clie
 ## Installation
 
 ```sh
-npm install effect@beta @effect/platform-browser@beta
+npm install effect@rc @effect/platform-browser@rc
 ```
 
 ## Documentation

--- a/packages/platform/bun/README.md
+++ b/packages/platform/bun/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```sh
-npm install effect@beta @effect/platform-bun@beta
+npm install effect@rc @effect/platform-bun@rc
 ```
 
 ## Documentation

--- a/packages/platform/deno/README.md
+++ b/packages/platform/deno/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```sh
-npm install effect@beta @effect/platform-deno@beta
+npm install effect@rc @effect/platform-deno@rc
 ```
 
 ## Documentation

--- a/packages/platform/node-shared/README.md
+++ b/packages/platform/node-shared/README.md
@@ -5,7 +5,7 @@ Effect platform services shared between Node.js-compatible runtimes. Used intern
 ## Installation
 
 ```sh
-npm install effect@beta @effect/platform-node-shared@beta
+npm install effect@rc @effect/platform-node-shared@rc
 ```
 
 ## Documentation

--- a/packages/platform/node/README.md
+++ b/packages/platform/node/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```sh
-npm install effect@beta @effect/platform-node@beta
+npm install effect@rc @effect/platform-node@rc
 ```
 
 ## Documentation

--- a/packages/sql/clickhouse/README.md
+++ b/packages/sql/clickhouse/README.md
@@ -5,7 +5,7 @@ An Effect SQL client for [ClickHouse](https://clickhouse.com), built on the [`@c
 ## Installation
 
 ```sh
-npm install effect@beta @effect/sql-clickhouse@beta
+npm install effect@rc @effect/sql-clickhouse@rc
 ```
 
 ## Documentation

--- a/packages/sql/d1/README.md
+++ b/packages/sql/d1/README.md
@@ -5,7 +5,7 @@ An Effect SQL client for [Cloudflare D1](https://developers.cloudflare.com/d1/),
 ## Installation
 
 ```sh
-npm install effect@beta @effect/sql-d1@beta
+npm install effect@rc @effect/sql-d1@rc
 ```
 
 ## Documentation

--- a/packages/sql/libsql/README.md
+++ b/packages/sql/libsql/README.md
@@ -5,7 +5,7 @@ An Effect SQL client for [libSQL](https://turso.tech/libsql), built on the [`@li
 ## Installation
 
 ```sh
-npm install effect@beta @effect/sql-libsql@beta
+npm install effect@rc @effect/sql-libsql@rc
 ```
 
 ## Documentation

--- a/packages/sql/mssql/README.md
+++ b/packages/sql/mssql/README.md
@@ -5,7 +5,7 @@ An Effect SQL client for Microsoft SQL Server, built on the [`tedious`](https://
 ## Installation
 
 ```sh
-npm install effect@beta @effect/sql-mssql@beta
+npm install effect@rc @effect/sql-mssql@rc
 ```
 
 ## Documentation

--- a/packages/sql/mysql2/README.md
+++ b/packages/sql/mysql2/README.md
@@ -5,7 +5,7 @@ An Effect SQL client for MySQL, built on the [`mysql2`](https://sidorares.github
 ## Installation
 
 ```sh
-npm install effect@beta @effect/sql-mysql2@beta
+npm install effect@rc @effect/sql-mysql2@rc
 ```
 
 ## Documentation

--- a/packages/sql/pg/README.md
+++ b/packages/sql/pg/README.md
@@ -5,7 +5,7 @@ An Effect SQL client for PostgreSQL, built on the [`pg`](https://node-postgres.c
 ## Installation
 
 ```sh
-npm install effect@beta @effect/sql-pg@beta
+npm install effect@rc @effect/sql-pg@rc
 ```
 
 ## Documentation

--- a/packages/sql/pglite/README.md
+++ b/packages/sql/pglite/README.md
@@ -5,7 +5,7 @@ An Effect SQL client for [PGlite](https://pglite.dev), a WASM build of PostgreSQ
 ## Installation
 
 ```sh
-npm install effect@beta @effect/sql-pglite@beta
+npm install effect@rc @effect/sql-pglite@rc
 ```
 
 ## Documentation

--- a/packages/sql/sqlite-bun/README.md
+++ b/packages/sql/sqlite-bun/README.md
@@ -5,7 +5,7 @@ An Effect SQL client for SQLite on the [Bun](https://bun.sh) runtime, built on `
 ## Installation
 
 ```sh
-npm install effect@beta @effect/sql-sqlite-bun@beta
+npm install effect@rc @effect/sql-sqlite-bun@rc
 ```
 
 ## Documentation

--- a/packages/sql/sqlite-do/README.md
+++ b/packages/sql/sqlite-do/README.md
@@ -5,7 +5,7 @@ An Effect SQL client for the SQLite storage in [Cloudflare Durable Objects](http
 ## Installation
 
 ```sh
-npm install effect@beta @effect/sql-sqlite-do@beta
+npm install effect@rc @effect/sql-sqlite-do@rc
 ```
 
 ## Documentation

--- a/packages/sql/sqlite-node/README.md
+++ b/packages/sql/sqlite-node/README.md
@@ -2,6 +2,10 @@
 
 An Effect SQL client for SQLite on Node.js, built on the built-in `node:sqlite` module.
 
+## Requirements
+
+- **Node.js 22.16 or newer**, which introduced the [`sqlite.backup()`](https://nodejs.org/docs/latest-v22.x/api/sqlite.html#sqlitebackup-sourcedb-destination-options) API imported by this package.
+
 ## Installation
 
 ```sh

--- a/packages/sql/sqlite-node/README.md
+++ b/packages/sql/sqlite-node/README.md
@@ -2,15 +2,15 @@
 
 An Effect SQL client for SQLite on Node.js, built on the built-in `node:sqlite` module.
 
-## Requirements
-
-- **Node.js 22.16 or newer**, which introduced the [`sqlite.backup()`](https://nodejs.org/docs/latest-v22.x/api/sqlite.html#sqlitebackupsourcedb-destination-options) API imported by this package.
-
 ## Installation
 
 ```sh
 npm install effect@rc @effect/sql-sqlite-node@rc
 ```
+
+## Requirements
+
+- **Node.js 22.16 or newer**, which introduced the [`sqlite.backup()`](https://nodejs.org/docs/latest-v22.x/api/sqlite.html#sqlitebackupsourcedb-destination-options) API imported by this package.
 
 ## Documentation
 

--- a/packages/sql/sqlite-node/README.md
+++ b/packages/sql/sqlite-node/README.md
@@ -4,7 +4,7 @@ An Effect SQL client for SQLite on Node.js, built on the built-in `node:sqlite` 
 
 ## Requirements
 
-- **Node.js 22.16 or newer**, which introduced the [`sqlite.backup()`](https://nodejs.org/docs/latest-v22.x/api/sqlite.html#sqlitebackup-sourcedb-destination-options) API imported by this package.
+- **Node.js 22.16 or newer**, which introduced the [`sqlite.backup()`](https://nodejs.org/docs/latest-v22.x/api/sqlite.html#sqlitebackupsourcedb-destination-options) API imported by this package.
 
 ## Installation
 

--- a/packages/sql/sqlite-node/README.md
+++ b/packages/sql/sqlite-node/README.md
@@ -5,7 +5,7 @@ An Effect SQL client for SQLite on Node.js, built on the built-in `node:sqlite` 
 ## Installation
 
 ```sh
-npm install effect@beta @effect/sql-sqlite-node@beta
+npm install effect@rc @effect/sql-sqlite-node@rc
 ```
 
 ## Documentation

--- a/packages/sql/sqlite-react-native/README.md
+++ b/packages/sql/sqlite-react-native/README.md
@@ -5,7 +5,7 @@ An Effect SQL client for SQLite in React Native applications, built on the [`@op
 ## Installation
 
 ```sh
-npm install effect@beta @effect/sql-sqlite-react-native@beta
+npm install effect@rc @effect/sql-sqlite-react-native@rc
 ```
 
 ## Documentation

--- a/packages/sql/sqlite-wasm/README.md
+++ b/packages/sql/sqlite-wasm/README.md
@@ -5,7 +5,7 @@ An Effect SQL client for SQLite compiled to WebAssembly, built on the [`@effect/
 ## Installation
 
 ```sh
-npm install effect@beta @effect/sql-sqlite-wasm@beta
+npm install effect@rc @effect/sql-sqlite-wasm@rc
 ```
 
 ## Documentation

--- a/packages/tools/docgen/README.md
+++ b/packages/tools/docgen/README.md
@@ -5,7 +5,7 @@ An opinionated documentation generator for Effect projects.
 ## Installation
 
 ```sh
-npm install -D @effect/docgen@beta
+npm install -D @effect/docgen@rc
 ```
 
 ## Documentation

--- a/packages/tools/doctest/README.md
+++ b/packages/tools/doctest/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```sh
-npm install -D @effect/doctest@beta
+npm install -D @effect/doctest@rc
 ```
 
 ## Documentation

--- a/packages/tools/openapi-generator/README.md
+++ b/packages/tools/openapi-generator/README.md
@@ -5,7 +5,7 @@ Generates Effect `Schema` types, HTTP clients, and `HttpApi` modules from OpenAP
 ## Installation
 
 ```sh
-npm install effect@beta @effect/openapi-generator@beta
+npm install effect@rc @effect/openapi-generator@rc
 ```
 
 ## Documentation

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -7,7 +7,7 @@ Helpers for testing Effect-based code with [Vitest](https://vitest.dev). Provide
 Ensure a supported `vitest` version is installed (`^4.1.0`), then add the package as a dev dependency:
 
 ```sh
-npm install -D vitest @effect/vitest@beta
+npm install -D vitest @effect/vitest@rc
 ```
 
 ## Documentation


### PR DESCRIPTION
## Summary

- update V4 README installation commands from the `beta` tag to `rc`
- describe V4 as a release candidate and replace the V3 installation example with a concise link to the `v3` branch
- document TypeScript 5.9 as the minimum and recommend TypeScript 7 with a link to the Effect tooling setup
- document Node.js 18 as the general/core floor and the higher Node.js 22.16 requirement for `@effect/sql-sqlite-node`

## Requirement basis

- the repository's type tests target TypeScript `>=5.9` and pass with TypeScript 5.9.3
- the repository uses TypeScript 7 and `@effect/tsgo`; the linked tooling setup requires TypeScript 7
- the Node platform, shared Node platform, OpenTelemetry, and docgen package manifests declare Node.js `>=18.0.0`
- `@effect/sql-sqlite-node` statically imports the top-level `node:sqlite` `backup()` export: it is absent in Node.js 22.15 and was added in Node.js 22.16

## Merge order

This PR must merge only after or alongside the release pre-tag switch from `beta` to `rc`; until that switch lands, the documented `rc` package tag is not available.

## Impact

Readers get consistent V4 RC installation guidance and explicit compiler, tooling, general Node.js, and integration-specific runtime requirements.

## Validation

- `nix develop -c pnpm lint`
- `nix develop -c pnpm test-types`
- `nix develop -c pnpm vitest run packages/sql/sqlite-node/test/Client.test.ts`
- verified `import { backup } from "node:sqlite"` fails on Node.js 22.15.0 and succeeds on Node.js 22.16.0
- `git diff --check`
- verified the only remaining `effect@beta` README reference is the intentional runtimeperf benchmark adapter label
- verified `.changeset/pre.json` is unchanged

Closes EFF-598
