### PR TITLE
fix(cli): generate Zsh completions for arguments and subcommands

### DIFF
--- a/.changeset/fix-zsh-mixed-command-completions.md
+++ b/.changeset/fix-zsh-mixed-command-completions.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix Zsh completions for CLI commands with both positional arguments and subcommands.

--- a/packages/effect/src/unstable/cli/internal/completions/zsh.ts
+++ b/packages/effect/src/unstable/cli/internal/completions/zsh.ts
@@ -133,8 +133,14 @@ const generateFunction = (
         lines.push(`    ${spec}`)
       }
     }
-    for (const arg of descriptor.arguments) {
-      lines.push(`    ${argSpec(arg)}`)
+    if (descriptor.arguments.length > 0) {
+      lines.push(`    -`)
+      lines.push(`    parent-arguments`)
+      for (const arg of descriptor.arguments) {
+        lines.push(`    ${argSpec(arg)}`)
+      }
+      lines.push(`    -`)
+      lines.push(`    subcommands`)
     }
     lines.push(`    '1:command:->command'`)
     lines.push(`    '*::arg:->args'`)

--- a/packages/effect/test/unstable/cli/completions/completions.test.ts
+++ b/packages/effect/test/unstable/cli/completions/completions.test.ts
@@ -69,6 +69,17 @@ const withPaths = Command.make("process", {
   )
 }).pipe(Command.withDescription("Process files"))
 
+const withOptionalDirectoryAndSubcommands = Command.make("example", {
+  directory: Argument.directory("directory").pipe(
+    Argument.withDescription("Directory to start in"),
+    Argument.optional
+  )
+}).pipe(
+  Command.withSubcommands([
+    Command.make("serve").pipe(Command.withDescription("Start the server"))
+  ])
+)
+
 const nested3Levels = (() => {
   const leaf = Command.make("action", {
     dryRun: Flag.boolean("dry-run").pipe(Flag.withDescription("Dry run mode"))
@@ -339,6 +350,27 @@ describe("Zsh completions", () => {
     const desc = fromCommand(withChoices)
     const script = Zsh.generate("deploy", desc)
     assert.include(script, "(us-east eu-west ap-south)")
+  })
+
+  it("uses alternative argument sets for positional arguments and subcommands", () => {
+    const desc = fromCommand(withOptionalDirectoryAndSubcommands)
+    const script = Zsh.generate("example", desc)
+
+    assert.include(
+      script,
+      `    -
+    parent-arguments
+    ':Directory to start in:_directories'
+    -
+    subcommands
+    '1:command:->command'
+    '*::arg:->args'`
+    )
+    assert.notInclude(
+      script,
+      `    ':Directory to start in:_directories'
+    '1:command:->command'`
+    )
   })
 
   it("starts with #compdef directive", () => {


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Effect CLI commands can define both parent positional arguments and subcommands. At the first non-flag word, the CLI has two valid interpretations:

```text
example [parent positional arguments...]
example <subcommand> [subcommand arguments...]
```

The Zsh generator previously emitted the parent positional descriptors and `1:command:->command` in one `_arguments` set. A positional descriptor implicitly claims the first positional slot, so Zsh 5.9 rejected the additional explicit position-1 command definition with:

```text
_arguments:comparguments: doubled argument definition: 1:command:->command
```

This change represents the two command forms as mutually exclusive named `_arguments` sets:

```zsh
- parent-arguments
  # all parent positional descriptors
- subcommands
  '1:command:->command'
  '*::arg:->args'
```

Flag specifications remain before the first named set, which makes them common to both forms. The subcommand set retains the existing state machine, so selecting a known subcommand still dispatches to its generated completion function. All positional descriptors are emitted into the parent set in order, so the implementation applies to optional, multiple, and variadic arguments rather than special-casing directories. Commands with only positional arguments or only subcommands keep their existing output.

The regression test covers a root command with an optional directory argument and a `serve` subcommand, and verifies that the positional and command definitions are placed in separate argument sets.

## Related

No linked issue.