### PR TITLE
Support refinements in Schedule.while

### DIFF
--- a/.changeset/narrow-schedule-while.md
+++ b/.changeset/narrow-schedule-while.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Support narrowing schedule input and output types with type guard predicates passed to `Schedule.while`.

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -1321,6 +1321,13 @@ export const upTo: {
 })
 
 const while_: {
+  <Input, Output, Meta extends Metadata<Output, Input>>(
+    predicate: (
+      metadata: Metadata<Output, Input>
+    ) => metadata is Meta
+  ): <Error, Env>(
+    self: Schedule<Output, Input, Error, Env>
+  ) => Schedule<Meta["output"], Meta["input"], Error, Env>
   <Input, Output, Error2 = never, Env2 = never>(
     predicate: (
       metadata: Metadata<Output, Input>
@@ -1328,6 +1335,12 @@ const while_: {
   ): <Error, Env>(
     self: Schedule<Output, Input, Error, Env>
   ) => Schedule<Output, Input, Error | Error2, Env | Env2>
+  <Output, Input, Error, Env, Meta extends Metadata<Output, Input>>(
+    self: Schedule<Output, Input, Error, Env>,
+    predicate: (
+      metadata: Metadata<Output, Input>
+    ) => metadata is Meta
+  ): Schedule<Meta["output"], Meta["input"], Error, Env>
   <Output, Input, Error, Env, Error2 = never, Env2 = never>(
     self: Schedule<Output, Input, Error, Env>,
     predicate: (

--- a/packages/effect/typetest/Schedule.tst.ts
+++ b/packages/effect/typetest/Schedule.tst.ts
@@ -73,4 +73,14 @@ describe("Schedule", () => {
     >()
     expect(Schedule.upTo({})(self)).type.toBe<Schedule.Schedule<number, string, "error", "service">>()
   })
+
+  it("while", () => {
+    const self = hole<Schedule.Schedule<number | string, boolean | Date, "error", "service">>()
+    const refinement = (
+      metadata: Schedule.Metadata<number | string, boolean | Date>
+    ): metadata is Schedule.Metadata<number, Date> => true
+
+    expect(Schedule.while(refinement)(self)).type.toBe<Schedule.Schedule<number, Date, "error", "service">>()
+    expect(Schedule.while(self, refinement)).type.toBe<Schedule.Schedule<number, Date, "error", "service">>()
+  })
 })


### PR DESCRIPTION
## Summary
- add type guard overloads to `Schedule.while`
- narrow schedule input and output types for pipeable and data-first usage
- add type-level coverage and a patch changeset

## Testing
- `pnpm test-types packages/effect/typetest/Schedule.tst.ts`
- `pnpm check`
- `pnpm exec dprint check packages/effect/src/Schedule.ts packages/effect/typetest/Schedule.tst.ts .changeset/narrow-schedule-while.md`
- `NODE_OPTIONS=--experimental-strip-types pnpm exec oxlint packages/effect/src/Schedule.ts packages/effect/typetest/Schedule.tst.ts`