### PR TITLE
Remove the uuid dependency

### DIFF
--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -117,7 +117,6 @@
     "@standard-schema/spec": "^1.1.0",
     "fast-check": "^4.9.0",
     "kubernetes-types": "^1.30.0",
-    "msgpackr": "^2.0.4",
-    "uuid": "^14.0.1"
+    "msgpackr": "^2.0.4"
   }
 }

--- a/packages/effect/src/Crypto.ts
+++ b/packages/effect/src/Crypto.ts
@@ -11,6 +11,7 @@
  */
 import * as Context from "./Context.ts"
 import * as Effect from "./Effect.ts"
+import * as Uuid from "./internal/uuid.ts"
 import * as PlatformError from "./PlatformError.ts"
 
 const TypeId = "~effect/platform/Crypto"
@@ -270,9 +271,9 @@ export const make = (
         }
         return buffer
       }),
-    randomUUIDv4: Effect.sync(() => formatUUIDv4(randomBytesUnsafe(16))),
+    randomUUIDv4: Effect.sync(() => Uuid.v4String(randomBytesUnsafe(16))),
     randomUUIDv7: Effect.clockWith((clock) =>
-      Effect.succeed(formatUUIDv7(clock.currentTimeMillisUnsafe(), randomBytesUnsafe(16)))
+      Effect.succeed(Uuid.v7String(clock.currentTimeMillisUnsafe(), randomBytesUnsafe(16)))
     )
   })
 }
@@ -285,41 +286,3 @@ const validateSize = (method: string, size: number): Effect.Effect<number, Platf
       method,
       description: "size must be a non-negative safe integer"
     }))
-
-const hex = (byte: number): string => byte.toString(16).padStart(2, "0")
-
-const formatUUID = (bytes: Uint8Array): string => {
-  const segments = [
-    bytes.subarray(0, 4),
-    bytes.subarray(4, 6),
-    bytes.subarray(6, 8),
-    bytes.subarray(8, 10),
-    bytes.subarray(10, 16)
-  ]
-
-  return segments.map((segment) => Array.from(segment, hex).join("")).join("-")
-}
-
-const formatUUIDv4 = (bytes: Uint8Array): string => {
-  bytes[6] = (bytes[6] & 0x0f) | 0x40
-  bytes[8] = (bytes[8] & 0x3f) | 0x80
-
-  return formatUUID(bytes)
-}
-
-const maxUUIDv7Timestamp = 2 ** 48 - 1
-
-const formatUUIDv7 = (timestampMillis: number, bytes: Uint8Array): string => {
-  const timestamp = Math.min(Math.max(0, Math.trunc(timestampMillis)), maxUUIDv7Timestamp)
-
-  bytes[0] = Math.floor(timestamp / 2 ** 40)
-  bytes[1] = Math.floor(timestamp / 2 ** 32) & 0xff
-  bytes[2] = Math.floor(timestamp / 2 ** 24) & 0xff
-  bytes[3] = Math.floor(timestamp / 2 ** 16) & 0xff
-  bytes[4] = Math.floor(timestamp / 2 ** 8) & 0xff
-  bytes[5] = timestamp & 0xff
-  bytes[6] = (bytes[6] & 0x0f) | 0x70
-  bytes[8] = (bytes[8] & 0x3f) | 0x80
-
-  return formatUUID(bytes)
-}

--- a/packages/effect/src/internal/uuid.ts
+++ b/packages/effect/src/internal/uuid.ts
@@ -1,0 +1,51 @@
+const hex = (byte: number): string => byte.toString(16).padStart(2, "0")
+
+/** @internal */
+export const stringify = (bytes: Uint8Array): string => {
+  const segments = [
+    bytes.subarray(0, 4),
+    bytes.subarray(4, 6),
+    bytes.subarray(6, 8),
+    bytes.subarray(8, 10),
+    bytes.subarray(10, 16)
+  ]
+
+  return segments.map((segment) => Array.from(segment, hex).join("")).join("-")
+}
+
+const randomBytes = (): Uint8Array<ArrayBuffer> => globalThis.crypto.getRandomValues(new Uint8Array(16))
+
+/** @internal */
+export function v4Bytes(): Uint8Array<ArrayBuffer>
+export function v4Bytes<A extends ArrayBufferLike>(bytes: Uint8Array<A>): Uint8Array<A>
+export function v4Bytes(bytes: Uint8Array = randomBytes()): Uint8Array {
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  return bytes
+}
+
+/** @internal */
+export const v4String = (bytes?: Uint8Array): string => stringify(bytes === undefined ? v4Bytes() : v4Bytes(bytes))
+
+const maxV7Timestamp = 2 ** 48 - 1
+
+/** @internal */
+export function v7Bytes(timestampMillis: number): Uint8Array<ArrayBuffer>
+export function v7Bytes<A extends ArrayBufferLike>(timestampMillis: number, bytes: Uint8Array<A>): Uint8Array<A>
+export function v7Bytes(timestampMillis: number, bytes: Uint8Array = randomBytes()): Uint8Array {
+  const timestamp = Math.min(Math.max(0, Math.trunc(timestampMillis)), maxV7Timestamp)
+
+  bytes[0] = Math.floor(timestamp / 2 ** 40)
+  bytes[1] = Math.floor(timestamp / 2 ** 32) & 0xff
+  bytes[2] = Math.floor(timestamp / 2 ** 24) & 0xff
+  bytes[3] = Math.floor(timestamp / 2 ** 16) & 0xff
+  bytes[4] = Math.floor(timestamp / 2 ** 8) & 0xff
+  bytes[5] = timestamp & 0xff
+  bytes[6] = (bytes[6] & 0x0f) | 0x70
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  return bytes
+}
+
+/** @internal */
+export const v7String = (timestampMillis: number, bytes?: Uint8Array): string =>
+  stringify(bytes === undefined ? v7Bytes(timestampMillis) : v7Bytes(timestampMillis, bytes))

--- a/packages/effect/src/unstable/eventlog/EventJournal.ts
+++ b/packages/effect/src/unstable/eventlog/EventJournal.ts
@@ -11,12 +11,12 @@
  *
  * @since 4.0.0
  */
-import * as Uuid from "uuid"
 import type { Brand } from "../../Brand.ts"
 import * as Context from "../../Context.ts"
 import * as Data from "../../Data.ts"
 import * as DateTime from "../../DateTime.ts"
 import * as Effect from "../../Effect.ts"
+import * as Uuid from "../../internal/uuid.ts"
 import * as Layer from "../../Layer.ts"
 import * as Order from "../../Order.ts"
 import * as PubSub from "../../PubSub.ts"
@@ -178,7 +178,7 @@ export const RemoteId = Schema.Uint8Array.pipe(Schema.brand(RemoteIdTypeId))
  * @category unsafe
  * @since 4.0.0
  */
-export const makeRemoteIdUnsafe = (): RemoteId => Uuid.v4({}, new globalThis.Uint8Array(16)) as RemoteId
+export const makeRemoteIdUnsafe = (): RemoteId => Uuid.v4Bytes() as RemoteId
 
 /**
  * Runtime brand identifier used for `EntryId` values.
@@ -247,7 +247,7 @@ export const EntryIdOrder = Order.make<EntryId>((a, b) => {
  * @since 4.0.0
  */
 export const makeEntryIdUnsafe = (options: { msecs?: number } = {}): EntryId =>
-  Uuid.v7(options, new globalThis.Uint8Array(16)) as EntryId
+  Uuid.v7Bytes(options.msecs ?? DateTime.nowUnsafe().epochMilliseconds) as EntryId
 
 /**
  * Extracts the millisecond timestamp encoded in a UUID v7 `EntryId`.

--- a/packages/effect/src/unstable/eventlog/EventLogServerEncrypted.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogServerEncrypted.ts
@@ -10,10 +10,10 @@
  *
  * @since 4.0.0
  */
-import * as Uuid from "uuid"
 import * as Arr from "../../Array.ts"
 import * as Context from "../../Context.ts"
 import * as Effect from "../../Effect.ts"
+import * as Uuid from "../../internal/uuid.ts"
 import * as Layer from "../../Layer.ts"
 import * as PubSub from "../../PubSub.ts"
 import * as RcMap from "../../RcMap.ts"

--- a/packages/effect/src/unstable/eventlog/SqlEventJournal.ts
+++ b/packages/effect/src/unstable/eventlog/SqlEventJournal.ts
@@ -8,8 +8,8 @@
  *
  * @since 4.0.0
  */
-import * as Uuid from "uuid"
 import * as Effect from "../../Effect.ts"
+import * as Uuid from "../../internal/uuid.ts"
 import * as Layer from "../../Layer.ts"
 import * as PubSub from "../../PubSub.ts"
 import * as Schema from "../../Schema.ts"

--- a/packages/effect/src/unstable/schema/Model.ts
+++ b/packages/effect/src/unstable/schema/Model.ts
@@ -11,10 +11,10 @@
  *
  * @since 4.0.0
  */
-import * as Uuid from "uuid"
 import type { Brand } from "../../Brand.ts"
 import * as DateTime from "../../DateTime.ts"
 import * as Effect from "../../Effect.ts"
+import * as Uuid from "../../internal/uuid.ts"
 import * as Option from "../../Option.ts"
 import * as Predicate from "../../Predicate.ts"
 import * as Schema from "../../Schema.ts"
@@ -755,7 +755,7 @@ export const Uint8Array: Schema.instanceOf<Uint8Array<ArrayBuffer>> = Schema.Uin
 export const UuidV4BytesWithGenerate = <B extends string>(
   schema: Schema.brand<Schema.instanceOf<Uint8Array<ArrayBuffer>>, B>
 ): Schema.withConstructorDefault<Schema.brand<Schema.instanceOf<Uint8Array<ArrayBuffer>>, B>> =>
-  schema.pipe(Schema.withConstructorDefault(Effect.sync(() => Uuid.v4({}, new globalThis.Uint8Array(16)))))
+  schema.pipe(Schema.withConstructorDefault(Effect.sync(() => Uuid.v4Bytes())))
 
 /**
  * A field that represents a binary UUID v4 that is generated on inserts.
@@ -798,7 +798,7 @@ export interface UuidV4Insert<B extends string> extends
 export const UuidV4WithGenerate = <B extends string>(
   schema: Schema.brand<Schema.String, B>
 ): Schema.withConstructorDefault<Schema.brand<Schema.String, B>> =>
-  schema.pipe(Schema.withConstructorDefault(Effect.sync(() => Uuid.v4())))
+  schema.pipe(Schema.withConstructorDefault(Effect.sync(Uuid.v4String)))
 
 /**
  * A field that represents a string UUID v4 that is generated on inserts.
@@ -841,11 +841,11 @@ export interface UuidV7Insert<B extends string> extends
 export const UuidV7WithGenerate = <B extends string>(
   schema: Schema.brand<Schema.String, B>
 ): Schema.withConstructorDefault<Schema.brand<Schema.String, B>> =>
-  schema.pipe(Schema.withConstructorDefault(Effect.clockWith((clock) =>
-    Effect.succeed(Uuid.v7({
-      msecs: clock.currentTimeMillisUnsafe()
-    }))
-  )))
+  schema.pipe(
+    Schema.withConstructorDefault(
+      Effect.clockWith((clock) => Effect.succeed(Uuid.v7String(clock.currentTimeMillisUnsafe())))
+    )
+  )
 
 /**
  * A field that represents a string UUID v7 that is generated on inserts.

--- a/packages/effect/test/internal/Uuid.test.ts
+++ b/packages/effect/test/internal/Uuid.test.ts
@@ -1,0 +1,26 @@
+import { assert, describe, it } from "@effect/vitest"
+import * as Uuid from "effect/internal/uuid"
+
+const bytes = () => Uint8Array.from({ length: 16 }, (_, i) => i)
+
+describe("Uuid", () => {
+  it("stringifies UUID bytes", () => {
+    assert.strictEqual(Uuid.stringify(bytes()), "00010203-0405-0607-0809-0a0b0c0d0e0f")
+  })
+
+  it("generates UUID v4 bytes and strings", () => {
+    assert.deepStrictEqual(
+      Uuid.v4Bytes(bytes()),
+      Uint8Array.of(0, 1, 2, 3, 4, 5, 0x46, 7, 0x88, 9, 10, 11, 12, 13, 14, 15)
+    )
+    assert.strictEqual(Uuid.v4String(bytes()), "00010203-0405-4607-8809-0a0b0c0d0e0f")
+  })
+
+  it("generates UUID v7 bytes and strings", () => {
+    assert.deepStrictEqual(
+      Uuid.v7Bytes(0x0123456789ab, bytes()),
+      Uint8Array.of(1, 0x23, 0x45, 0x67, 0x89, 0xab, 0x76, 7, 0x88, 9, 10, 11, 12, 13, 14, 15)
+    )
+    assert.strictEqual(Uuid.v7String(0x0123456789ab, bytes()), "01234567-89ab-7607-8809-0a0b0c0d0e0f")
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,9 +347,6 @@ importers:
       msgpackr:
         specifier: ^2.0.4
         version: 2.0.4
-      uuid:
-        specifier: ^14.0.1
-        version: 14.0.1
     devDependencies:
       '@types/node':
         specifier: ^26.1.2
@@ -6453,10 +6450,6 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@14.0.1:
-    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
-    hasBin: true
-
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
@@ -12467,8 +12460,6 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
-
-  uuid@14.0.1: {}
 
   uuid@8.3.2: {}
 


### PR DESCRIPTION
## Summary

- add a private UUID helper for stringification and v4/v7 generation
- migrate Crypto, schema model defaults, and event-log call sites to the helper
- remove the direct `uuid` dependency from the Effect package
- add focused tests for UUID byte layout and string formatting

## Validation

- `pnpm test --run packages/effect/test/internal/Uuid.test.ts packages/effect/test/Crypto.test.ts packages/effect/test/unstable/eventlog/EventJournal.test.ts`
- `pnpm check`
- `pnpm lint`

Closes EFF-604