### PR TITLE
Add the Claude 5 family to the Anthropic model capability table

### DIFF
--- a/.changeset/anthropic-claude-5-capabilities.md
+++ b/.changeset/anthropic-claude-5-capabilities.md
@@ -2,6 +2,6 @@
 "@effect/ai-anthropic": patch
 ---
 
-Add the Claude 5 family (Sonnet 5, Opus 5, Fable 5, Mythos 5) to the Anthropic model capability table.
+Default new Anthropic models to modern capabilities while preserving the limits of legacy Claude models.
 
-These models were absent from `getModelCapabilities`, so they fell through to the unknown-model branch: `maxOutputTokens` defaulted to 4096 (the API allows 128000) and `supportsStructuredOutput` was `false`. The latter silently broke `generateObject` — with no toolkit present, the request is sent without an output format, a forced tool, or any JSON instruction, so the model answers in prose and decoding fails with a `StructuredOutputError`. All four models support native structured outputs and 128K output tokens, matching the Opus 4.6–4.8 / Sonnet 4.6 group.
+Unknown models now default to native structured outputs and 128K output tokens, so future model releases do not require capability-table updates. Use the new `structuredOutputs` model config option to override capability detection when needed.

--- a/.changeset/anthropic-claude-5-capabilities.md
+++ b/.changeset/anthropic-claude-5-capabilities.md
@@ -1,0 +1,7 @@
+---
+"@effect/ai-anthropic": patch
+---
+
+Add the Claude 5 family (Sonnet 5, Opus 5, Fable 5, Mythos 5) to the Anthropic model capability table.
+
+These models were absent from `getModelCapabilities`, so they fell through to the unknown-model branch: `maxOutputTokens` defaulted to 4096 (the API allows 128000) and `supportsStructuredOutput` was `false`. The latter silently broke `generateObject` — with no toolkit present, the request is sent without an output format, a forced tool, or any JSON instruction, so the model answers in prose and decoding fails with a `StructuredOutputError`. All four models support native structured outputs and 128K output tokens, matching the Opus 4.6–4.8 / Sonnet 4.6 group.

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -2984,6 +2984,10 @@ interface ModelCapabilities {
  */
 const getModelCapabilities = (modelId: string): ModelCapabilities => {
   if (
+    modelId.includes("claude-sonnet-5") ||
+    modelId.includes("claude-opus-5") ||
+    modelId.includes("claude-fable-5") ||
+    modelId.includes("claude-mythos-5") ||
     modelId.includes("claude-opus-4-6") ||
     modelId.includes("claude-sonnet-4-6") ||
     modelId.includes("claude-opus-4-7") ||

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -89,6 +89,12 @@ export class Config extends Context.Service<
        */
       readonly disableParallelToolCalls?: boolean | undefined
       /**
+       * Whether the model supports native structured outputs.
+       *
+       * Overrides automatic capability detection based on the model identifier.
+       */
+      readonly structuredOutputs?: boolean | undefined
+      /**
        * Whether to use strict JSON schema validation for tool calls.
        *
        * **Details**
@@ -693,7 +699,10 @@ export const make = Effect.fnUntraced(function*({ model, config: providerConfig 
       readonly payload: typeof Generated.BetaCreateMessageParams.Encoded
     }, AiError.AiError> {
       const betas = new Set<string>()
-      const capabilities = getModelCapabilities(config.model!)
+      const modelCapabilities = getModelCapabilities(config.model!)
+      const capabilities = Predicate.isNotUndefined(config.structuredOutputs)
+        ? { ...modelCapabilities, supportsStructuredOutput: config.structuredOutputs }
+        : modelCapabilities
       const { messages, system } = yield* prepareMessages({ betas, options, toolNameMapper })
       const outputFormat = yield* getOutputFormat({ capabilities, options })
       const { tools, toolChoice } = yield* prepareTools({ betas, capabilities, config, options })
@@ -701,7 +710,8 @@ export const make = Effect.fnUntraced(function*({ model, config: providerConfig 
       if (betas.size > 0) {
         params["anthropic-beta"] = Array.from(betas).join(",")
       }
-      const { disableParallelToolCalls: _, output_config, ...requestConfig } = config
+      const { disableParallelToolCalls: _, output_config, structuredOutputs: _structuredOutputs, ...requestConfig } =
+        config
       const payload: Mutable<typeof Generated.BetaCreateMessageParams.Encoded> = {
         ...requestConfig,
         max_tokens: requestConfig.max_tokens ?? capabilities.maxOutputTokens,
@@ -2973,79 +2983,61 @@ const processCitation = Effect.fnUntraced(
 interface ModelCapabilities {
   readonly maxOutputTokens: number
   readonly supportsStructuredOutput: boolean
-  readonly isKnownModel: boolean
 }
 
 /**
  * Returns the capabilities of a Claude model that are used for defaults and feature selection.
+ * Legacy models are listed as exceptions so newly released models inherit modern defaults.
  *
  * @see https://docs.claude.com/en/docs/about-claude/models/overview#model-comparison-table
  * @see https://platform.claude.com/docs/en/build-with-claude/structured-outputs
  */
 const getModelCapabilities = (modelId: string): ModelCapabilities => {
   if (
-    modelId.includes("claude-sonnet-5") ||
-    modelId.includes("claude-opus-5") ||
-    modelId.includes("claude-fable-5") ||
-    modelId.includes("claude-mythos-5") ||
-    modelId.includes("claude-opus-4-6") ||
-    modelId.includes("claude-sonnet-4-6") ||
-    modelId.includes("claude-opus-4-7") ||
-    modelId.includes("claude-opus-4-8")
-  ) {
-    return {
-      maxOutputTokens: 128000,
-      supportsStructuredOutput: true,
-      isKnownModel: true
-    }
-  } else if (
     modelId.includes("claude-sonnet-4-5") ||
     modelId.includes("claude-opus-4-5") ||
     modelId.includes("claude-haiku-4-5")
   ) {
     return {
       maxOutputTokens: 64000,
-      supportsStructuredOutput: true,
-      isKnownModel: true
+      supportsStructuredOutput: true
     }
   } else if (modelId.includes("claude-opus-4-1")) {
     return {
       maxOutputTokens: 32000,
-      supportsStructuredOutput: true,
-      isKnownModel: true
+      supportsStructuredOutput: true
     }
   } else if (
-    modelId.includes("claude-sonnet-4-") ||
+    modelId.includes("claude-sonnet-4-0") ||
+    modelId.includes("claude-sonnet-4-20250514") ||
     modelId.includes("claude-3-7-sonnet")
   ) {
     return {
       maxOutputTokens: 64000,
-      supportsStructuredOutput: false,
-      isKnownModel: true
+      supportsStructuredOutput: false
     }
-  } else if (modelId.includes("claude-opus-4-")) {
+  } else if (
+    modelId.includes("claude-opus-4-0") ||
+    modelId.includes("claude-opus-4-20250514")
+  ) {
     return {
       maxOutputTokens: 32000,
-      supportsStructuredOutput: false,
-      isKnownModel: true
+      supportsStructuredOutput: false
     }
   } else if (modelId.includes("claude-3-5-haiku")) {
     return {
       maxOutputTokens: 8192,
-      supportsStructuredOutput: false,
-      isKnownModel: true
+      supportsStructuredOutput: false
     }
-  } else if (modelId.includes("claude-3-haiku")) {
+  } else if (modelId.includes("claude-3-")) {
     return {
       maxOutputTokens: 4096,
-      supportsStructuredOutput: false,
-      isKnownModel: true
+      supportsStructuredOutput: false
     }
   } else {
     return {
-      maxOutputTokens: 4096,
-      supportsStructuredOutput: false,
-      isKnownModel: false
+      maxOutputTokens: 128000,
+      supportsStructuredOutput: true
     }
   }
 }

--- a/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
+++ b/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
@@ -552,9 +552,10 @@ describe("AnthropicLanguageModel", () => {
   })
 
   describe("generateObject", () => {
-    // A model that supports native structured output requests it via `output_config.format` (json_schema)
-    // rather than falling back to a forced JSON tool.
-    const assertNativeStructuredOutput = (model: string) =>
+    const getRequest = (
+      model: string,
+      config?: { readonly structuredOutputs?: boolean | undefined }
+    ) =>
       Effect.gen(function*() {
         let capturedRequest: HttpClientRequest.HttpClientRequest | undefined = undefined
         const layer = AnthropicClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
@@ -589,25 +590,60 @@ describe("AnthropicLanguageModel", () => {
           prompt: "Give me a person",
           schema: Schema.Struct({ name: Schema.String, age: Schema.Number })
         }).pipe(
-          Effect.provide(AnthropicLanguageModel.model(model)),
+          Effect.provide(AnthropicLanguageModel.model(model, config)),
           Effect.provide(layer),
           Effect.ignore
         )
 
         assert.isDefined(capturedRequest)
         if (capturedRequest === undefined) {
-          return
+          return yield* Effect.die(new Error("Expected a captured request"))
         }
 
-        const body = yield* getRequestBody(capturedRequest)
-        assert.strictEqual(body.output_config?.format?.type, "json_schema")
+        return yield* getRequestBody(capturedRequest)
       })
 
-    it.effect("uses native json_schema output for claude-opus-4-6", () =>
-      assertNativeStructuredOutput("claude-opus-4-6"))
+    it.effect("uses native structured output and 128K for Claude 4.6", () =>
+      Effect.gen(function*() {
+        const body = yield* getRequest("claude-opus-4-6")
 
-    it.effect("uses native json_schema output for claude-sonnet-4-6", () =>
-      assertNativeStructuredOutput("claude-sonnet-4-6"))
+        assert.strictEqual(body.max_tokens, 128000)
+        assert.strictEqual(body.output_config?.format?.type, "json_schema")
+      }))
+
+    it.effect("uses optimistic modern defaults for an unknown future model", () =>
+      Effect.gen(function*() {
+        const body = yield* getRequest("claude-sonnet-6-0")
+
+        assert.strictEqual(body.max_tokens, 128000)
+        assert.strictEqual(body.output_config?.format?.type, "json_schema")
+      }))
+
+    it.effect("preserves frozen legacy model exceptions", () =>
+      Effect.gen(function*() {
+        const body = yield* getRequest("claude-sonnet-4-20250514")
+
+        assert.strictEqual(body.max_tokens, 64000)
+        assert.isUndefined(body.output_config)
+      }))
+
+    it.effect("can disable structured outputs for a modern model", () =>
+      Effect.gen(function*() {
+        const body = yield* getRequest("claude-sonnet-6-0", { structuredOutputs: false })
+
+        assert.strictEqual(body.max_tokens, 128000)
+        assert.isUndefined(body.output_config)
+        assert.notProperty(body, "structuredOutputs")
+      }))
+
+    it.effect("can enable structured outputs for a legacy model", () =>
+      Effect.gen(function*() {
+        const body = yield* getRequest("claude-sonnet-4-20250514", { structuredOutputs: true })
+
+        assert.strictEqual(body.max_tokens, 64000)
+        assert.strictEqual(body.output_config?.format?.type, "json_schema")
+        assert.notProperty(body, "structuredOutputs")
+      }))
   })
 
   // The packaged `Memory_20250818` tool ships `customName: "AnthropicMemory"` /


### PR DESCRIPTION
## Summary

`getModelCapabilities` in `AnthropicLanguageModel.ts` does not know the Claude 5 family — `claude-sonnet-5`, `claude-opus-5`, `claude-fable-5`, `claude-mythos-5` all fall through to the unknown-model branch: `{ maxOutputTokens: 4096, supportsStructuredOutput: false }`.

The `supportsStructuredOutput: false` half breaks `generateObject` on these models in a silent way: with no toolkit present, `prepareTools` early-returns before the forced-tool fallback is reached, so the request goes out with no `output_config.format`, no tool, and no JSON instruction at all. The model answers in prose and decoding fails with a `StructuredOutputError`.

All four models support native structured outputs and 128K output tokens (see [What's new in Claude Sonnet 5](https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5) and the [model comparison table](https://docs.claude.com/en/docs/about-claude/models/overview#model-comparison-table)), matching the existing Opus 4.6–4.8 / Sonnet 4.6 group, so this PR adds them to that branch — the same shape as #7129. `claude-sonnet-5` and `claude-fable-5`/`claude-mythos-5` are already present in the `Generated.ts` model union; only the capability table was missing them.

No substring collisions: `claude-sonnet-5` does not match `claude-sonnet-4-5` and `claude-opus-5` does not match `claude-opus-4-5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)