### PR TITLE
Preserve TestClock nanosecond precision

### DIFF
--- a/.changeset/precise-test-clock-nanos.md
+++ b/.changeset/precise-test-clock-nanos.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve nanosecond precision when adjusting `TestClock` with large durations.

--- a/packages/effect/src/testing/TestClock.ts
+++ b/packages/effect/src/testing/TestClock.ts
@@ -340,8 +340,13 @@ export const make = Effect.fnUntraced(function*(
   })
 
   const runSemaphore = yield* Semaphore.make(1)
-  const run = Effect.fnUntraced(function*(step: (currentTimestamp: number) => number) {
+  const run = Effect.fnUntraced(function*(
+    step: (currentTimestamp: number) => number,
+    adjustmentNanos?: bigint
+  ) {
     yield* Fiber.await(yield* Effect.forkChild(Effect.yieldNow))
+    const initialWallNanos = currentWallNanos
+    const initialMonotonicNanos = currentMonotonicNanos
     const endTimestamp = step(currentTimestamp)
     const advanceTo = (timestamp: number) => {
       const deltaMillis = timestamp - currentTimestamp
@@ -361,11 +366,19 @@ export const make = Effect.fnUntraced(function*(
       yield* Effect.yieldNow
     }
     advanceTo(endTimestamp)
+    if (adjustmentNanos !== undefined && Number.isFinite(endTimestamp)) {
+      currentWallNanos = initialWallNanos + adjustmentNanos
+      if (adjustmentNanos > BigInt(0)) {
+        currentMonotonicNanos = initialMonotonicNanos + adjustmentNanos
+      }
+    }
   }, runSemaphore.withPermits(1))
 
-  function adjust(duration: Duration.Input) {
-    const millis = Duration.toMillis(Duration.fromInputUnsafe(duration))
-    return warningDone.pipe(Effect.andThen(run((timestamp) => timestamp + millis)))
+  function adjust(input: Duration.Input) {
+    const duration = Duration.fromInputUnsafe(input)
+    const millis = Duration.toMillis(duration)
+    const nanos = Number.isFinite(millis) ? Duration.toNanosUnsafe(duration) : undefined
+    return warningDone.pipe(Effect.andThen(run((timestamp) => timestamp + millis, nanos)))
   }
 
   function setTime(timestamp: number) {

--- a/packages/effect/test/TestClock.test.ts
+++ b/packages/effect/test/TestClock.test.ts
@@ -78,6 +78,15 @@ describe("TestClock", () => {
       assert.strictEqual(yield* testClock.monotonicTimeNanos, 1_000_000_000n)
     }))
 
+  it.effect("adjust - preserves precision for nanosecond durations beyond Number.MAX_SAFE_INTEGER", () =>
+    Effect.gen(function*() {
+      const testClock = yield* TestClock.make()
+      const nanos = 999_999_999_999_999_000n
+      yield* testClock.adjust(Duration.nanos(nanos))
+      assert.strictEqual(testClock.monotonicTimeNanosUnsafe(), nanos)
+      assert.strictEqual(testClock.currentTimeNanosUnsafe(), nanos)
+    }))
+
   it.effect("adjust - keeps nanosecond access total after infinite durations", () =>
     Effect.gen(function*() {
       for (const duration of [Duration.infinity, Duration.negativeInfinity]) {


### PR DESCRIPTION
## Summary

- preserve exact bigint nanosecond endpoints when `TestClock.adjust` receives a large finite duration
- retain millisecond timestamps for sleeper scheduling without reconstructing final nanosecond clock state from a lossy `number`
- add a regression test and patch changeset

## Root cause

`TestClock.adjust` converted every duration to numeric milliseconds, and `run` rebuilt wall and monotonic nanoseconds from that value. Large epoch-nanosecond durations therefore lost precision beyond `Number.MAX_SAFE_INTEGER`.

## Validation

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm --filter effect test --run test/TestClock.test.ts`
- `nix develop -c pnpm check`

Closes EFF-607