### PR TITLE
Rename Live layer conventions

### DIFF
--- a/packages/effect/HTTPAPI.md
+++ b/packages/effect/HTTPAPI.md
@@ -61,7 +61,7 @@ const Api = HttpApi.make("MyApi").add(
 )
 
 // Implementation
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Greetings", // The name of the group to handle
   (handlers) =>
@@ -72,14 +72,14 @@ const GroupLive = HttpApiBuilder.group(
 )
 
 // Server
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
 // Launch
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 After running the code, open a browser and navigate to http://localhost:3000. The server will respond with:
@@ -97,9 +97,9 @@ Adding a documentation layer gives you an interactive page where you (and your A
 To include Scalar in your server setup, provide the `HttpApiScalar.layer` when configuring the server.
 
 ```ts
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
   // Provide the Scalar layer so clients can access auto-generated docs
-  Layer.provide(GroupLive),
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
@@ -115,8 +115,8 @@ This URL will display the Scalar documentation, allowing you to explore the API'
 To include Swagger in your server setup, provide the `HttpApiSwagger.layer` when configuring the server.
 
 ```ts
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   // Provide the Swagger layer so clients can access auto-generated docs
   Layer.provide(HttpApiSwagger.layer(Api)), // "/docs" is the default path.
   // or Layer.provide(HttpApiScalar.layer(Api)),
@@ -167,19 +167,19 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Greetings",
   (handlers) => handlers.handle("hello", () => Effect.succeed("Hello, World!"))
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 
 // Create a program that derives and uses the client
 const program = Effect.gen(function*() {
@@ -356,7 +356,7 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
@@ -366,14 +366,14 @@ const GroupLive = HttpApiBuilder.group(
       ))
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 ## POST
@@ -417,7 +417,7 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
@@ -438,14 +438,14 @@ const GroupLive = HttpApiBuilder.group(
       })
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 ## DELETE
@@ -493,7 +493,7 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
@@ -516,14 +516,14 @@ const GroupLive = HttpApiBuilder.group(
       })
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 ## PATCH
@@ -582,7 +582,7 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
@@ -609,14 +609,14 @@ const GroupLive = HttpApiBuilder.group(
       })
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 ## Parameters
@@ -656,7 +656,7 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
@@ -673,14 +673,14 @@ const GroupLive = HttpApiBuilder.group(
       })
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 ## Catch-All Endpoints
@@ -741,7 +741,7 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
@@ -771,14 +771,14 @@ const GroupLive = HttpApiBuilder.group(
       })
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 > [!IMPORTANT]
@@ -819,7 +819,7 @@ const Api = HttpApi.make("MyApi")
   // Prefix for the entire API
   .prefix("/apiPrefix")
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "group",
   (handlers) =>
@@ -828,14 +828,14 @@ const GroupLive = HttpApiBuilder.group(
       .handle("endpointB", () => Effect.succeed("Endpoint B"))
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 You can test this endpoint using a GET request. For example:
@@ -884,7 +884,7 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
@@ -898,14 +898,14 @@ const GroupLive = HttpApiBuilder.group(
       })
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 #### Defining an Array of Values for a Query Parameter
@@ -939,7 +939,7 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
@@ -952,14 +952,14 @@ const GroupLive = HttpApiBuilder.group(
       })
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 You can test this endpoint by passing an array of values in the query string. For example:
@@ -1013,7 +1013,7 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
@@ -1023,14 +1023,14 @@ const GroupLive = HttpApiBuilder.group(
       ))
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 You can test the endpoint by sending the headers:
@@ -1078,7 +1078,7 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
@@ -1092,14 +1092,14 @@ const GroupLive = HttpApiBuilder.group(
       })
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 You can test this endpoint by sending a multipart request with a file upload. For example:
@@ -1150,7 +1150,7 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
@@ -1161,14 +1161,14 @@ const GroupLive = HttpApiBuilder.group(
       })
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 You can test this endpoint using a URL-encoded request body. For example:
@@ -1203,7 +1203,7 @@ const Api = HttpApi.make("MyApi").add(
   )
 )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Greetings",
   (handlers) =>
@@ -1220,13 +1220,13 @@ const GroupLive = HttpApiBuilder.group(
     )
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 ## Validating Request Cookies
@@ -1278,7 +1278,7 @@ const Api = HttpApi.make("api").add(
     .middleware(Auth)
 )
 
-const AuthLive = Layer.succeed(
+const AuthLayer = Layer.succeed(
   Auth,
   {
     session: (effect, opts) =>
@@ -1296,7 +1296,7 @@ const AuthLive = Layer.succeed(
   }
 )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "group",
   (handlers) =>
@@ -1305,16 +1305,16 @@ const GroupLive = HttpApiBuilder.group(
         const user = yield* CurrentUser
         return { id: user.id }
       }))
-).pipe(Layer.provide(AuthLive))
+).pipe(Layer.provide(AuthLayer))
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 
 // Valid session:
 // curl "http://localhost:3000/me" --cookie "session=valid-session"
@@ -1344,7 +1344,7 @@ const Api = HttpApi.make("api").add(
   )
 )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "group",
   (handlers) =>
@@ -1354,13 +1354,13 @@ const GroupLive = HttpApiBuilder.group(
     })
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 
 // curl "http://localhost:3000/me" --cookie "lang=it"
 // "Language: it"
@@ -1393,7 +1393,7 @@ const Api = HttpApi.make("myApi").add(
   )
 )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "group",
   (handlers) =>
@@ -1410,13 +1410,13 @@ const GroupLive = HttpApiBuilder.group(
       ))
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 You can test the streaming request using `curl` or any tool that supports sending binary data. For example:
@@ -1464,7 +1464,7 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
@@ -1476,14 +1476,14 @@ const GroupLive = HttpApiBuilder.group(
       })
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 ## Changing the Response Encoding
@@ -1522,7 +1522,7 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
@@ -1532,14 +1532,14 @@ const GroupLive = HttpApiBuilder.group(
       })
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 You can test this endpoint using a GET request. For example:
@@ -1594,7 +1594,7 @@ const Api = HttpApi.make("MyApi").add(
   )
 )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
@@ -1606,13 +1606,13 @@ const GroupLive = HttpApiBuilder.group(
       })))
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 
 // curl -v "http://localhost:3000/users" 2>&1 | grep -i "x-total-count"
 // < x-total-count: 1
@@ -1687,7 +1687,7 @@ const Api = HttpApi.make("MyApi").add(
   )
 )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
@@ -1701,13 +1701,13 @@ const GroupLive = HttpApiBuilder.group(
     })
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 
 // curl -v "http://localhost:3000/user/1" 2>&1 | grep -i "x-user-id"
 // < x-user-id: 1
@@ -1738,7 +1738,7 @@ const Api = HttpApi.make("api").add(
   )
 )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "group",
   (handlers) =>
@@ -1751,13 +1751,13 @@ const GroupLive = HttpApiBuilder.group(
       }))
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 
 // curl -v "http://localhost:3000/hello" 2>&1 | grep -i "x-custom"
 // < x-custom: hello
@@ -1784,7 +1784,7 @@ const Api = HttpApi.make("api").add(
   )
 )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "group",
   (handlers) =>
@@ -1801,13 +1801,13 @@ const GroupLive = HttpApiBuilder.group(
       }))
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 
 // curl -v "http://localhost:3000/hello" 2>&1 | grep -i "set-cookie"
 // < set-cookie: my-cookie=my-value; Path=/; HttpOnly; Secure
@@ -1835,7 +1835,7 @@ const Api = HttpApi.make("MyApi").add(
   )
 )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "group",
   (handlers) =>
@@ -1847,14 +1847,14 @@ const GroupLive = HttpApiBuilder.group(
         ))
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 
 // curl "http://localhost:3000/old" -L
 ```
@@ -1897,7 +1897,7 @@ const stream = Stream.make("a", "b", "c").pipe(
   Stream.map((s) => new TextEncoder().encode(s))
 )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "group",
   (handlers) =>
@@ -1908,13 +1908,13 @@ const GroupLive = HttpApiBuilder.group(
     )
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 You can test the streaming response using `curl` or any similar HTTP client that supports streaming:
@@ -1952,7 +1952,7 @@ const Api = HttpApi.make("myApi").add(
   )
 )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "group",
   (handlers) =>
@@ -1964,13 +1964,13 @@ const GroupLive = HttpApiBuilder.group(
       ))
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 
 // curl 'http://localhost:3000/events' --no-buffer
 // data: {"text":"one"}
@@ -2080,7 +2080,7 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
@@ -2101,14 +2101,14 @@ const GroupLive = HttpApiBuilder.group(
       })
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 You can test these endpoints. For example:
@@ -2164,7 +2164,7 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
@@ -2178,14 +2178,14 @@ const GroupLive = HttpApiBuilder.group(
       })
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 | Name                  | Status | Description                                                                                        |
@@ -2248,7 +2248,7 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
@@ -2262,14 +2262,14 @@ const GroupLive = HttpApiBuilder.group(
       })
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 ## Customizing Schema Error Responses
@@ -2314,7 +2314,7 @@ class SchemaErrorHandler extends HttpApiMiddleware.Service<SchemaErrorHandler>()
 ) {}
 
 // Implement the middleware layer
-const SchemaErrorHandlerLive = HttpApiMiddleware.layerSchemaErrorTransform(
+const SchemaErrorHandlerLayer = HttpApiMiddleware.layerSchemaErrorTransform(
   SchemaErrorHandler,
   (schemaError) =>
     Effect.fail(
@@ -2342,21 +2342,21 @@ const Api = HttpApi.make("MyApi").add(
   )
 )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) => handlers.handle("getUser", (ctx) => Effect.succeed({ id: ctx.query.id, name: `User ${ctx.query.id}` }))
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
-  Layer.provide(SchemaErrorHandlerLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
+  Layer.provide(SchemaErrorHandlerLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 
 // Test:
 // curl "http://localhost:3000/user?id=1"    # 200 OK
@@ -2418,7 +2418,7 @@ const Api = HttpApi.make("api").add(
     // Or apply the middleware to the entire group
     .middleware(Logger)
 )
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "group",
   (handlers) =>
@@ -2428,7 +2428,7 @@ const GroupLive = HttpApiBuilder.group(
     })
 )
 
-const LoggerLive = Layer.effect(
+const LoggerLayer = Layer.effect(
   Logger,
   Effect.gen(function*() {
     yield* Effect.log("creating Logger middleware")
@@ -2442,15 +2442,15 @@ const LoggerLive = Layer.effect(
   })
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
-  Layer.provide(LoggerLive),
+  Layer.provide(LoggerLayer),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 
 // Test this with this curl command:
 // curl "http://localhost:3000/user/1"
@@ -2492,7 +2492,7 @@ const Api = HttpApi.make("api").add(
   )
 )
 
-const LoadAuthLive = Layer.effect(
+const LoadAuthLayer = Layer.effect(
   LoadAuth,
   Effect.succeed((effect) =>
     Effect.provideService(effect, AuthInfo, {
@@ -2501,7 +2501,7 @@ const LoadAuthLive = Layer.effect(
   )
 )
 
-const RequireAuthLive = Layer.effect(
+const RequireAuthLayer = Layer.effect(
   RequireAuth,
   Effect.succeed(
     Effect.fnUntraced(function*(effect) {
@@ -2617,7 +2617,7 @@ class Authorization extends HttpApiMiddleware.Service<Authorization, {
   }
 ) {}
 
-const AuthorizationLive = Layer.succeed(
+const AuthorizationLayer = Layer.succeed(
   Authorization,
   // Return the security handlers for the middleware
   {
@@ -2707,7 +2707,7 @@ const security = HttpApiSecurity.apiKey({
   key: "token"
 })
 
-const UsersApiLive = HttpApiBuilder.group(Api, "Users", (handlers) =>
+const UsersApiLayer = HttpApiBuilder.group(Api, "Users", (handlers) =>
   handlers.handle("login", () =>
     // Set the security cookie with a redacted value
     HttpApiBuilder.securitySetCookie(security, Redacted.make("keep me secret"))))
@@ -2749,7 +2749,7 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
@@ -2764,8 +2764,8 @@ const GroupLive = HttpApiBuilder.group(
       })
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   Layer.provide(
     Layer.succeed(UsersRepository, {
@@ -2776,7 +2776,7 @@ const ApiLive = HttpApiBuilder.layer(Api).pipe(
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 # OpenAPI Documentation
@@ -2835,7 +2835,7 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
@@ -2862,14 +2862,14 @@ const GroupLive = HttpApiBuilder.group(
       })
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)), // "/docs" is the default path.
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 ```
 
 After running the server, open your browser and navigate to http://localhost:3000/docs.
@@ -3395,19 +3395,19 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Greetings",
   (handlers) => handlers.handle("hello", () => Effect.succeed("Hello, World!"))
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 
 // Create a program that derives and uses the client
 const program = Effect.gen(function*() {
@@ -3454,19 +3454,19 @@ const Api = HttpApi.make("MyApi")
       )
   )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "Greetings",
   (handlers) => handlers.handle("hello", () => Effect.succeed("Hello, World!"))
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   HttpRouter.serve,
   Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 }))
 )
 
-Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
+Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 
 const program = Effect.gen(function*() {
   const client = yield* HttpApiClient.make(Api, {
@@ -3500,21 +3500,21 @@ const Api = HttpApi.make("myApi").add(
   )
 )
 
-const GroupLive = HttpApiBuilder.group(
+const GroupLayer = HttpApiBuilder.group(
   Api,
   "group",
   (handlers) => handlers.handle("get", () => Effect.succeed("Hello, world!"))
 )
 
-const ApiLive = HttpApiBuilder.layer(Api).pipe(
-  Layer.provide(GroupLive),
+const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+  Layer.provide(GroupLayer),
   Layer.provide(HttpApiScalar.layer(Api)),
   Layer.provide(HttpServer.layerServices)
 )
 
 // Convert the API to a web handler
 const { dispose, handler } = HttpRouter.toWebHandler(
-  Layer.mergeAll(ApiLive)
+  Layer.mergeAll(ApiLayer)
 )
 
 // Serving the handler using a custom HTTP server

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -5813,7 +5813,7 @@ export const contextWith: <R, A, E, R2>(
  *
  * const Database = Context.Service<Database>("Database")
  *
- * const DatabaseLive = Layer.succeed(Database)({
+ * const DatabaseLayer = Layer.succeed(Database)({
  *   query: Effect.fn("Database.query")((sql: string) => Effect.succeed(`Result for: ${sql}`))
  * })
  *
@@ -5822,7 +5822,7 @@ export const contextWith: <R, A, E, R2>(
  *   return yield* db.query("SELECT * FROM users")
  * })
  *
- * const provided = Effect.provide(program, DatabaseLive)
+ * const provided = Effect.provide(program, DatabaseLayer)
  *
  * await Effect.runPromise(provided) // => "Result for: SELECT * FROM users"
  * ```

--- a/packages/effect/src/ErrorReporter.ts
+++ b/packages/effect/src/ErrorReporter.ts
@@ -204,7 +204,7 @@ export const CurrentErrorReporters: Context.Reference<ReadonlySet<ErrorReporter>
  * })
  *
  * // Replace all existing reporters
- * const ReporterLive = ErrorReporter.layer([
+ * const ReporterLayer = ErrorReporter.layer([
  *   firstReporter,
  *   secondReporter
  * ])
@@ -217,7 +217,7 @@ export const CurrentErrorReporters: Context.Reference<ReadonlySet<ErrorReporter>
  *
  * const program = Effect.fail("boom").pipe(
  *   Effect.withErrorReporting,
- *   Effect.provide(ReporterLive),
+ *   Effect.provide(ReporterLayer),
  *   Effect.exit
  * )
  *

--- a/packages/effect/src/Layer.ts
+++ b/packages/effect/src/Layer.ts
@@ -792,11 +792,11 @@ export const buildWithScope: {
  *   readonly query: (sql: string) => Effect.Effect<string>
  * }>()("Database") {}
  *
- * const DatabaseLive = Layer.succeed(Database, {
+ * const DatabaseLayer = Layer.succeed(Database, {
  *   query: Effect.fn("Database.query")((sql: string) => Effect.succeed(`Query result: ${sql}`))
  * })
  * const program = Database.use((database) => database.query("SELECT 1"))
- * Effect.runSync(Effect.provide(program, DatabaseLive)) // => "Query result: SELECT 1"
+ * Effect.runSync(Effect.provide(program, DatabaseLayer)) // => "Query result: SELECT 1"
  * ```
  *
  * @see {@link sync} for constructing layers from lazy values

--- a/packages/effect/src/Logger.ts
+++ b/packages/effect/src/Logger.ts
@@ -899,10 +899,10 @@ export const tracerLogger: Logger<unknown, void> = effect.tracerLogger
  * const customLogger = Logger.make((options) => {
  *   messages.push(options.message)
  * })
- * const CustomLoggerLive = Logger.layer([customLogger])
+ * const CustomLoggerLayer = Logger.layer([customLogger])
  *
  * const program = Effect.log("Application started").pipe(
- *   Effect.provide(CustomLoggerLive)
+ *   Effect.provide(CustomLoggerLayer)
  * )
  * Effect.runSync(program)
  * messages // => [["Application started"]]

--- a/packages/effect/test/HttpClient.test.ts
+++ b/packages/effect/test/HttpClient.test.ts
@@ -37,7 +37,7 @@ const makeJsonPlaceholder = Effect.gen(function*() {
 })
 interface JsonPlaceholder extends Effect.Success<typeof makeJsonPlaceholder> {}
 const JsonPlaceholder = Context.Service<JsonPlaceholder>("test/JsonPlaceholder")
-const JsonPlaceholderLive = Layer.effect(JsonPlaceholder)(makeJsonPlaceholder)
+const JsonPlaceholderLayer = Layer.effect(JsonPlaceholder)(makeJsonPlaceholder)
 const TestRoutes = HttpRouter.serve(HttpRouter.use(Effect.fnUntraced(function*(router) {
   yield* router.addAll([
     HttpRouter.route("GET", "/", Effect.succeed(HttpServerResponse.text("test"))),
@@ -76,7 +76,7 @@ const TestRoutes = HttpRouter.serve(HttpRouter.use(Effect.fnUntraced(function*(r
   ])
 })))
 const DenoHttpServerUrl = new URL("../../platform/deno/src/DenoHttpServer.ts", import.meta.url).href
-const TestServerLive = Layer.unwrap(Effect.promise(() =>
+const TestServerLayer = Layer.unwrap(Effect.promise(() =>
   "Deno" in globalThis
     ? (import(DenoHttpServerUrl) as Promise<{
       readonly layerServer: (options: {
@@ -98,9 +98,9 @@ const TestServerLive = Layer.unwrap(Effect.promise(() =>
 ].forEach(({ layer, name }) => {
   const layerTest = HttpServer.layerTestClient.pipe(
     Layer.provide(layer),
-    Layer.provideMerge(TestServerLive)
+    Layer.provideMerge(TestServerLayer)
   )
-  const testLayer = Layer.merge(JsonPlaceholderLive, TestRoutes).pipe(
+  const testLayer = Layer.merge(JsonPlaceholderLayer, TestRoutes).pipe(
     Layer.provideMerge(layerTest)
   )
 

--- a/packages/effect/test/cluster/MessageStorage.test.ts
+++ b/packages/effect/test/cluster/MessageStorage.test.ts
@@ -16,7 +16,7 @@ import {
 import { Headers } from "effect/unstable/http"
 import { Rpc, RpcSchema } from "effect/unstable/rpc"
 
-const MemoryLive = MessageStorage.layerMemory.pipe(
+const MemoryLayer = MessageStorage.layerMemory.pipe(
   Layer.provideMerge(Snowflake.layerGenerator),
   Layer.provide(ShardingConfig.layerDefaults)
 )
@@ -57,7 +57,7 @@ describe("MessageStorage", () => {
         expect(result._tag).toEqual("Success")
         const messages = yield* storage.unprocessedMessages([request.envelope.address.shardId])
         expect(messages).toHaveLength(1)
-      }).pipe(Effect.provide(MemoryLive)))
+      }).pipe(Effect.provide(MemoryLayer)))
 
     it.effect("detects duplicates", () =>
       Effect.gen(function*() {
@@ -75,7 +75,7 @@ describe("MessageStorage", () => {
           })
         )
         expect(result._tag).toEqual("Duplicate")
-      }).pipe(Effect.provide(MemoryLive)))
+      }).pipe(Effect.provide(MemoryLayer)))
 
     it.effect("unprocessedMessages excludes complete requests", () =>
       Effect.gen(function*() {
@@ -85,7 +85,7 @@ describe("MessageStorage", () => {
         yield* storage.saveReply(yield* makeReply(request))
         const messages = yield* storage.unprocessedMessages([request.envelope.address.shardId])
         expect(messages).toHaveLength(0)
-      }).pipe(Effect.provide(MemoryLive)))
+      }).pipe(Effect.provide(MemoryLayer)))
 
     it.effect("repliesFor", () =>
       Effect.gen(function*() {
@@ -98,7 +98,7 @@ describe("MessageStorage", () => {
         replies = yield* storage.repliesFor([request])
         expect(replies).toHaveLength(1)
         expect(replies[0].requestId).toEqual(request.envelope.requestId)
-      }).pipe(Effect.provide(MemoryLive)))
+      }).pipe(Effect.provide(MemoryLayer)))
 
     it.effect("registerReplyHandler", () =>
       Effect.gen(function*() {
@@ -116,7 +116,7 @@ describe("MessageStorage", () => {
         yield* storage.saveReply(yield* makeReply(request))
         yield* latch.await
         yield* Fiber.await(fiber)
-      }).pipe(Effect.provide(MemoryLive)))
+      }).pipe(Effect.provide(MemoryLayer)))
   })
 })
 

--- a/packages/effect/test/reactivity/Atom.test.ts
+++ b/packages/effect/test/reactivity/Atom.test.ts
@@ -2784,7 +2784,7 @@ interface BuildCounter {
   readonly inc: Effect.Effect<void>
 }
 const BuildCounter = Context.Service<BuildCounter>("BuildCounter")
-const BuildCounterLive = Layer.sync(BuildCounter, () => {
+const BuildCounterLayer = Layer.sync(BuildCounter, () => {
   let count = 0
   return BuildCounter.of({
     get: Effect.sync(() => count),
@@ -2799,7 +2799,7 @@ interface Counter {
   readonly inc: Effect.Effect<void>
 }
 const Counter = Context.Service<Counter>("Counter")
-const CounterLive = Layer.effect(
+const CounterLayer = Layer.effect(
   Counter,
   Effect.gen(function*() {
     const buildCounter = yield* BuildCounter
@@ -2813,7 +2813,7 @@ const CounterLive = Layer.effect(
     })
   })
 ).pipe(
-  Layer.provide(BuildCounterLive)
+  Layer.provide(BuildCounterLayer)
 )
 
 const CounterTest = Layer.effect(
@@ -2830,14 +2830,14 @@ const CounterTest = Layer.effect(
     })
   })
 ).pipe(
-  Layer.provide(BuildCounterLive)
+  Layer.provide(BuildCounterLayer)
 )
 
 interface Multiplier {
   readonly times: (n: number) => Effect.Effect<number>
 }
 const Multiplier = Context.Service<Multiplier>("Multiplier")
-const MultiplierLive = Layer.effect(
+const MultiplierLayer = Layer.effect(
   Multiplier,
   Effect.gen(function*() {
     const counter = yield* Counter
@@ -2847,9 +2847,9 @@ const MultiplierLive = Layer.effect(
     })
   })
 ).pipe(
-  Layer.provideMerge(CounterLive)
+  Layer.provideMerge(CounterLayer)
 )
 
-const buildCounterRuntime = Atom.runtime(BuildCounterLive)
-const counterRuntime = Atom.runtime(CounterLive)
-const multiplierRuntime = Atom.runtime(MultiplierLive)
+const buildCounterRuntime = Atom.runtime(BuildCounterLayer)
+const counterRuntime = Atom.runtime(CounterLayer)
+const multiplierRuntime = Atom.runtime(MultiplierLayer)

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -44,13 +44,13 @@ it.layer(TestServices)("HttpApiBuilder query parameters", (it) => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) => handlers.handle("list", ({ query }) => Effect.succeed(query))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const multiple = yield* client.test.list({ query: { ids: ["a", "b"] } })
       const single = yield* client.test.list({ query: { ids: ["a"] } })
 
@@ -68,7 +68,7 @@ it.effect("reuses response schema transformations by source AST", () => {
       .add(HttpApiEndpoint.get("second", "/second", { success: SharedSuccess }))
       .add(HttpApiEndpoint.get("distinct", "/distinct", { success: DistinctSuccess }))
   )
-  const GroupLive = HttpApiBuilder.group(
+  const GroupLayer = HttpApiBuilder.group(
     Api,
     "test",
     (handlers) =>
@@ -82,7 +82,7 @@ it.effect("reuses response schema transformations by source AST", () => {
     Effect.sync(() => vi.spyOn(Schema, "decodeTo")),
     (decodeTo) =>
       Effect.gen(function*() {
-        yield* Effect.scoped(Layer.build(GroupLive))
+        yield* Effect.scoped(Layer.build(GroupLayer))
         const responseSchemaCalls = decodeTo.mock.calls.filter(
           ([schema]) => schema === SharedSuccess || schema === DistinctSuccess
         )
@@ -111,13 +111,13 @@ it.layer(TestServices)("HttpApiBuilder payload content types", (it) => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) => handlers.handle("create", ({ payload }) => Effect.succeed(payload))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const declared = yield* client.test.create({
         headers: {},
         payload: { name: "Ada" }
@@ -146,13 +146,13 @@ it.layer(TestServices)("HttpApiBuilder payload content types", (it) => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) => handlers.handle("create", ({ payload }) => Effect.succeed(payload))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const result = yield* client.test.create({ payload: { name: "Ada" } })
 
       assert.deepStrictEqual(result, { name: "Ada" })
@@ -185,7 +185,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
           HttpApiEndpoint.get("result", "/test", { success: [Ok, Created] })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) =>
@@ -196,7 +196,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
             })))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const response = yield* client.test.result({ responseMode: "response-only" })
 
       assert.strictEqual(response.status, 201)
@@ -218,7 +218,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) =>
@@ -229,7 +229,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
             })))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const response = yield* client.test.result({ responseMode: "response-only" })
 
       assert.strictEqual(response.status, 200)
@@ -251,7 +251,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) =>
@@ -262,7 +262,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
             }) as any))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const exit = yield* Effect.exit(client.test.result({ responseMode: "response-only" }))
 
       assert.strictEqual(exit._tag, "Failure")
@@ -286,7 +286,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) =>
@@ -297,7 +297,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
             })))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const result = yield* client.test.result({})
 
       assert.deepStrictEqual(
@@ -329,7 +329,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
             })
           )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) =>
@@ -346,7 +346,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
               })))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const [success, successResponse] = yield* client.test.success({ responseMode: "decoded-and-response" })
       const error = yield* Effect.flip(client.test.error({}))
       const errorResponse = yield* client.test.error({ responseMode: "response-only" })
@@ -372,7 +372,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) =>
@@ -383,7 +383,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
             })))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const [value, response] = yield* client.test.created({ responseMode: "decoded-and-response" })
 
       assert.strictEqual(response.headers["x-count"], "2")
@@ -405,7 +405,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) =>
@@ -416,7 +416,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
             })))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const value = yield* client.test.created({})
 
       assert.strictEqual(value.body.toISOString(), "2024-01-02T03:04:05.000Z")
@@ -435,7 +435,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
           .add(HttpApiEndpoint.get("forwarded", "/forwarded", { success: Success }))
       )
       let forwarded: typeof Success.Type | undefined
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) =>
@@ -448,7 +448,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
             .handle("forwarded", () => Effect.succeed(forwarded!))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const [value, response] = yield* client.test.created({ responseMode: "decoded-and-response" })
       forwarded = value
       const result = yield* client.test.forwarded({})
@@ -472,7 +472,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) =>
@@ -483,7 +483,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
             })))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const response = yield* client.test.created({ responseMode: "response-only" })
 
       assert.strictEqual(response.status, 201)
@@ -508,13 +508,13 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) => handlers.handle("mixed", () => Effect.succeed({ body: "plain", headers: { "x-source": "body" } }))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const response = yield* client.test.mixed({ responseMode: "response-only" })
 
       assert.strictEqual(response.headers["content-type"], "application/vnd.plain+json")
@@ -536,13 +536,13 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
           HttpApiEndpoint.get("mixed", "/test", { success: [Wrapped, Plain] })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) => handlers.handle("mixed", () => Effect.succeed({ _tag: "Plain" as const, value: "plain" }))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const value = yield* client.test.mixed({})
 
       assert.deepStrictEqual(value, { _tag: "Plain", value: "plain" })
@@ -560,7 +560,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) =>
@@ -571,7 +571,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
             })))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const response = yield* client.test.override({ responseMode: "response-only" })
 
       assert.strictEqual(response.headers["content-type"], "application/custom")
@@ -598,13 +598,13 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
           HttpApiEndpoint.get("limited", "/test", { error: RateLimitedResponse })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) => handlers.handle("limited", () => Effect.fail(new RateLimited({ retryAfter: 30 })))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const response = yield* client.test.limited({ responseMode: "response-only" })
 
       assert.strictEqual(response.status, 429)
@@ -633,13 +633,13 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
         )
       )
       const expiresAt = DateTime.makeUnsafe("2026-08-05T02:00:00.000Z").pipe(DateTime.toDate)
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) => handlers.handle("limited", () => Effect.fail(new RateLimited({ expiresAt })))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const response = yield* client.test.limited({ responseMode: "response-only" })
       const error = yield* Effect.flip(client.test.limited({}))
 
@@ -662,13 +662,13 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
         body: { _tag: "RateLimited" as const, message: "slow down" },
         headers: { "retry-after": 30 }
       })
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) => handlers.handle("limited", () => Effect.fail(expected))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const response = yield* client.test.limited({ responseMode: "response-only" })
 
       assert.strictEqual(response.status, 429)
@@ -699,13 +699,13 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) => handlers.handle("limited", () => Effect.fail(new RateLimited({ retryAfter: "30" })))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const response = yield* client.test.limited({ responseMode: "response-only" })
 
       assert.strictEqual(response.status, 429)
@@ -744,14 +744,14 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
           HttpApiEndpoint.get("limited", "/test", { error: RateLimitedResponse })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) =>
           handlers.handle("limited", () => Effect.fail(new RateLimited({ message: "slow down", retryAfter: 30 })))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const error = yield* Effect.flip(client.test.limited({}))
 
       assert.deepStrictEqual(error, new RateLimited({ message: "slow down", retryAfter: 30 }))
@@ -766,7 +766,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) =>
@@ -777,7 +777,7 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
             })))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const exit = yield* Effect.exit(client.test.invalid({ responseMode: "response-only" }))
 
       assert.strictEqual(exit._tag, "Failure")
@@ -802,7 +802,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
         )
       )
 
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) =>
@@ -812,7 +812,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
             ))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const response = yield* client.test.download({ responseMode: "response-only" })
       const chunks = yield* response.stream.pipe(Stream.runCollect)
 
@@ -835,7 +835,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) =>
@@ -846,7 +846,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
             })))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const response = yield* client.test.download({ responseMode: "response-only" })
       const chunks = yield* response.stream.pipe(Stream.runCollect)
 
@@ -876,7 +876,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) =>
@@ -887,7 +887,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
             )))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const response = yield* client.test.events({ responseMode: "response-only" })
       const chunks = yield* response.stream.pipe(Stream.runCollect)
 
@@ -921,7 +921,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) =>
@@ -932,7 +932,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
             })))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const response = yield* client.test.events({ responseMode: "response-only" })
       const chunks = yield* response.stream.pipe(Stream.runCollect)
 
@@ -956,7 +956,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) =>
@@ -967,7 +967,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
             })))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const exit = yield* Effect.exit(client.test.download({ responseMode: "response-only" }))
 
       assert.strictEqual(exit._tag, "Failure")
@@ -993,7 +993,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
         )
       )
 
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) =>
@@ -1003,7 +1003,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
             ))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const response = yield* client.test.events({ responseMode: "response-only" })
       const chunks = yield* response.stream.pipe(Stream.runCollect)
       const rendered = Array.from(chunks, (chunk) => textDecoder.decode(chunk))
@@ -1040,7 +1040,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
         )
       )
 
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) =>
@@ -1052,7 +1052,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
             ))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const bufferedResponse = yield* client.test.chat({ query: { stream: "false" }, responseMode: "response-only" })
       assert.strictEqual(bufferedResponse.status, 200)
       assert.strictEqual(bufferedResponse.headers["content-type"], "application/json")
@@ -1083,13 +1083,13 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) => handlers.handle("result", () => Effect.succeed({ message: "done" }))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const response = yield* client.test.result({ responseMode: "response-only" })
 
       assert.strictEqual(response.headers["content-type"], "application/json")
@@ -1109,7 +1109,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) =>
@@ -1120,7 +1120,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
             })))
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const response = yield* client.test.result({ responseMode: "response-only" })
 
       assert.strictEqual(response.headers["content-type"], "application/json")
@@ -1153,7 +1153,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
         )
       )
 
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "users",
         (handlers) =>
@@ -1174,7 +1174,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
           })
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["users"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["users"]).pipe(Effect.provide(GroupLayer))
       const getUser = yield* client.users.getUser({ params: { id: "user-1" } })
       const createUser = yield* client.users.createUser({ payload: { name: "Grace" } })
 
@@ -1191,12 +1191,12 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
       )
 
       for (const identifier of ["missing", "toString"] as const) {
-        const GroupLive = HttpApiBuilder.group(
+        const GroupLayer = HttpApiBuilder.group(
           Api,
           "users",
           (handlers) => handlers.handle(identifier as "getUser", () => Effect.succeed("missing"))
         )
-        const exit = yield* Effect.exit(Effect.scoped(Layer.build(GroupLive)))
+        const exit = yield* Effect.exit(Effect.scoped(Layer.build(GroupLayer)))
 
         assert.strictEqual(exit._tag, "Failure")
         if (exit._tag === "Failure") {
@@ -1217,7 +1217,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
           HttpApiEndpoint.get("getUser", "/users", { success: Schema.String })
         )
       )
-      const HandleLive = HttpApiBuilder.group(
+      const HandleLayer = HttpApiBuilder.group(
         Api,
         "users",
         (handlers) => {
@@ -1225,7 +1225,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
           return handlers.handle("getUser", () => Effect.succeed("second"))
         }
       )
-      const HandleAllLive = HttpApiBuilder.group(
+      const HandleAllLayer = HttpApiBuilder.group(
         Api,
         "users",
         (handlers) => {
@@ -1234,8 +1234,8 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
         }
       )
 
-      for (const GroupLive of [HandleLive, HandleAllLive]) {
-        const exit = yield* Effect.exit(Effect.scoped(Layer.build(GroupLive)))
+      for (const GroupLayer of [HandleLayer, HandleAllLayer]) {
+        const exit = yield* Effect.exit(Effect.scoped(Layer.build(GroupLayer)))
         assert.strictEqual(exit._tag, "Failure")
         if (exit._tag === "Failure") {
           const error = Cause.squash(exit.cause)
@@ -1267,13 +1267,13 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
           getUser: () => Effect.succeed("own")
         }
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "users",
         (handlers) => handlers.handleAll(implementations)
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["users"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["users"]).pipe(Effect.provide(GroupLayer))
 
       assert.strictEqual(yield* client.users.getUser(), "own")
     }))
@@ -1296,7 +1296,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
         )
       )
 
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "users",
         (handlers) =>
@@ -1309,7 +1309,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
           )
       )
 
-      const client = yield* HttpApiTest.groups(Api, ["users"]).pipe(Effect.provide(GroupLive))
+      const client = yield* HttpApiTest.groups(Api, ["users"]).pipe(Effect.provide(GroupLayer))
       const getUser = yield* client.users.getUser({ params: { id: "user-1" } })
 
       assert.deepStrictEqual(getUser, { id: "user-1", name: "Ada" })
@@ -1350,12 +1350,12 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
           }).middleware(M)
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "test",
         (handlers) => handlers.handle("protected", () => Effect.fail(new HandlerFailure({ message: "handler failed" })))
       )
-      const MLive = Layer.succeed(M)({
+      const MLayer = Layer.succeed(M)({
         first: (effect, { credential }) =>
           Redacted.value(credential) === "ok" ? effect : Effect.fail("first unauthorized"),
         second: (effect, { credential }) =>
@@ -1363,8 +1363,8 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
       })
 
       const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(
-        Effect.provide(GroupLive),
-        Effect.provide(MLive)
+        Effect.provide(GroupLayer),
+        Effect.provide(MLayer)
       )
       const error = yield* Effect.flip(client.test.protected({ headers: { "x-first": "ok" } }))
 

--- a/packages/opentelemetry/src/NodeSdk.ts
+++ b/packages/opentelemetry/src/NodeSdk.ts
@@ -118,9 +118,9 @@ export const layer: {
         ? evaluate as Effect.Effect<Configuration>
         : Effect.sync(evaluate)
 
-      const ResourceLive = Resource.layerFromEnv(config.resource && Resource.configToAttributes(config.resource))
+      const ResourceLayer = Resource.layerFromEnv(config.resource && Resource.configToAttributes(config.resource))
 
-      const TracerLive = isNonEmpty(config.spanProcessor)
+      const TracerLayer = isNonEmpty(config.spanProcessor)
         ? Layer.provide(
           Tracer.layer,
           layerTracerProvider(config.spanProcessor, {
@@ -130,14 +130,14 @@ export const layer: {
         )
         : Layer.empty
 
-      const MetricsLive = isNonEmpty(config.metricReader)
+      const MetricsLayer = isNonEmpty(config.metricReader)
         ? Metrics.layer(constant(config.metricReader), {
           shutdownTimeout: config.shutdownTimeout,
           temporality: config.metricTemporality
         })
         : Layer.empty
 
-      const LoggerLive = isNonEmpty(config.logRecordProcessor)
+      const LoggerLayer = isNonEmpty(config.logRecordProcessor)
         ? Layer.provide(
           Logger.layer({ mergeWithExisting: config.loggerMergeWithExisting }),
           Logger.layerLoggerProvider(config.logRecordProcessor, {
@@ -147,8 +147,8 @@ export const layer: {
         )
         : Layer.empty
 
-      return Layer.mergeAll(TracerLive, MetricsLive, LoggerLive).pipe(
-        Layer.provideMerge(ResourceLive)
+      return Layer.mergeAll(TracerLayer, MetricsLayer, LoggerLayer).pipe(
+        Layer.provideMerge(ResourceLayer)
       )
     })
   )

--- a/packages/opentelemetry/src/WebSdk.ts
+++ b/packages/opentelemetry/src/WebSdk.ts
@@ -112,30 +112,30 @@ export const layer: {
         ? evaluate as Effect.Effect<Configuration>
         : Effect.sync(evaluate)
 
-      const ResourceLive = Resource.layer(config.resource)
+      const ResourceLayer = Resource.layer(config.resource)
 
-      const TracerLive = isNonEmpty(config.spanProcessor)
+      const TracerLayer = isNonEmpty(config.spanProcessor)
         ? Layer.provide(
           Tracer.layer,
           layerTracerProvider(config.spanProcessor, config.tracerConfig)
         )
         : Layer.empty
 
-      const LoggerLive = isNonEmpty(config.logRecordProcessor)
+      const LoggerLayer = isNonEmpty(config.logRecordProcessor)
         ? Layer.provide(
           Logger.layer({ mergeWithExisting: config.loggerMergeWithExisting }),
           Logger.layerLoggerProvider(config.logRecordProcessor, config.loggerProviderConfig)
         )
         : Layer.empty
 
-      const MetricsLive = isNonEmpty(config.metricReader)
+      const MetricsLayer = isNonEmpty(config.metricReader)
         ? Metrics.layer(constant(config.metricReader), {
           temporality: config.metricTemporality
         })
         : Layer.empty
 
-      return Layer.mergeAll(TracerLive, MetricsLive, LoggerLive).pipe(
-        Layer.provideMerge(ResourceLive)
+      return Layer.mergeAll(TracerLayer, MetricsLayer, LoggerLayer).pipe(
+        Layer.provideMerge(ResourceLayer)
       )
     })
   )

--- a/packages/opentelemetry/test/OtelLogger.test.ts
+++ b/packages/opentelemetry/test/OtelLogger.test.ts
@@ -31,7 +31,7 @@ describe("Logger", () => {
   describe("provided", () => {
     const exporter = new InMemoryLogRecordExporter()
 
-    const TracingLive = NodeSdk.layer(Effect.sync(() => ({
+    const TracingLayer = NodeSdk.layer(Effect.sync(() => ({
       resource: {
         serviceName: "test"
       },
@@ -44,7 +44,7 @@ describe("Logger", () => {
           Effect.repeat({ times: 9 })
         )
         assert.lengthOf(exporter.getFinishedLogRecords(), 10)
-      }).pipe(Effect.provide(TracingLive)))
+      }).pipe(Effect.provide(TracingLayer)))
 
     it.effect("maps Effect LogLevel to OTel SeverityNumber spec values", () => {
       const severityExporter = new InMemoryLogRecordExporter()
@@ -94,7 +94,7 @@ describe("Logger", () => {
         sleep: () => Effect.void
       }
 
-      const TracingLive = NodeSdk.layer(Effect.sync(() => ({
+      const TracingLayer = NodeSdk.layer(Effect.sync(() => ({
         resource: {
           serviceName: "test"
         },
@@ -120,7 +120,7 @@ describe("Logger", () => {
         assert.strictEqual(log.attributes.spanId, span.spanContext().spanId)
         assert.strictEqual(log.attributes.traceId, span.spanContext().traceId)
       }).pipe(
-        Effect.provide(TracingLive),
+        Effect.provide(TracingLayer),
         Effect.provideService(Clock.Clock, skewedClock)
       )
     })
@@ -128,7 +128,7 @@ describe("Logger", () => {
     it.effect("does not let annotations overwrite active span correlation", () => {
       const logExporter = new InMemoryLogRecordExporter()
       const spanExporter = new InMemorySpanExporter()
-      const TracingLive = NodeSdk.layer(Effect.sync(() => ({
+      const TracingLayer = NodeSdk.layer(Effect.sync(() => ({
         resource: { serviceName: "test" },
         spanProcessor: [new SimpleSpanProcessor(spanExporter)],
         logRecordProcessor: [new SimpleLogRecordProcessor({ exporter: logExporter })]
@@ -144,14 +144,14 @@ describe("Logger", () => {
         const span = spanExporter.getFinishedSpans()[0]!
         assert.strictEqual(log.attributes.traceId, span.spanContext().traceId)
         assert.strictEqual(log.attributes.spanId, span.spanContext().spanId)
-      }).pipe(Effect.provide(TracingLive))
+      }).pipe(Effect.provide(TracingLayer))
     })
   })
 
   describe("not provided", () => {
     const exporter = new InMemoryLogRecordExporter()
 
-    const TracingLive = NodeSdk.layer(Effect.sync(() => ({
+    const TracingLayer = NodeSdk.layer(Effect.sync(() => ({
       resource: {
         serviceName: "test"
       }
@@ -161,6 +161,6 @@ describe("Logger", () => {
       Effect.gen(function*() {
         yield* Effect.log("test")
         assert.lengthOf(exporter.getFinishedLogRecords(), 0)
-      }).pipe(Effect.provide(TracingLive)))
+      }).pipe(Effect.provide(TracingLayer)))
   })
 })

--- a/packages/opentelemetry/test/OtelTracer.test.ts
+++ b/packages/opentelemetry/test/OtelTracer.test.ts
@@ -10,7 +10,7 @@ import * as Effect from "effect/Effect"
 import * as Option from "effect/Option"
 import * as EffectTracer from "effect/Tracer"
 
-const TracingLive = NodeSdk.layer(Effect.sync(() => ({
+const TracingLayer = NodeSdk.layer(Effect.sync(() => ({
   resource: {
     serviceName: "test"
   },
@@ -29,7 +29,7 @@ describe("Tracer", () => {
         assert.instanceOf(span, OtelTracer.OtelSpan)
       }).pipe(
         Effect.withSpan("ok"),
-        Effect.provide(TracingLive)
+        Effect.provide(TracingLayer)
       ))
 
     it.effect("withSpan links", () =>
@@ -42,7 +42,7 @@ describe("Tracer", () => {
         assert.instanceOf(span, OtelTracer.OtelSpan)
         assert.lengthOf(span.links, 1)
       }).pipe(
-        Effect.provide(TracingLive)
+        Effect.provide(TracingLayer)
       ))
 
     it.effect("nested withSpan sets correct parent chain", () =>
@@ -56,7 +56,7 @@ describe("Tracer", () => {
         assert.isDefined(child.parent)
         assert.strictEqual((child.parent.valueOrUndefined! as OtelTracer.OtelSpan).name, "parent")
       }).pipe(
-        Effect.provide(TracingLive)
+        Effect.provide(TracingLayer)
       ))
 
     it.effect("supervisor sets context", () =>
@@ -65,7 +65,7 @@ describe("Tracer", () => {
         assert.isDefined(OtelApi.trace.getSpan(context))
       }).pipe(
         Effect.withSpan("ok"),
-        Effect.provide(TracingLive)
+        Effect.provide(TracingLayer)
       ))
 
     it.effect("supervisor sets context generator", () =>
@@ -75,7 +75,7 @@ describe("Tracer", () => {
         assert.isDefined(OtelApi.trace.getSpan(context))
       }).pipe(
         Effect.withSpan("ok"),
-        Effect.provide(TracingLive)
+        Effect.provide(TracingLayer)
       ))
 
     it.effect("currentOtelSpan", () =>
@@ -85,7 +85,7 @@ describe("Tracer", () => {
         assert.strictEqual((span as OtelTracer.OtelSpan).span, otelSpan)
       }).pipe(
         Effect.withSpan("ok"),
-        Effect.provide(TracingLive)
+        Effect.provide(TracingLayer)
       ))
 
     it.effect.each([OtelApi.SpanStatusCode.UNSET, OtelApi.SpanStatusCode.OK])(
@@ -127,7 +127,7 @@ describe("Tracer", () => {
           spanId: "2".repeat(16),
           sampled: false
         })),
-        Effect.provide(TracingLive)
+        Effect.provide(TracingLayer)
       ))
 
     it("preserves trace state and locality on an active OpenTelemetry parent", () => {
@@ -269,7 +269,7 @@ describe("Tracer", () => {
           })
         })
       }).pipe(
-        Effect.provide(TracingLive)
+        Effect.provide(TracingLayer)
       ))
   })
 

--- a/packages/platform/browser/test/fixtures/rpc-e2e.ts
+++ b/packages/platform/browser/test/fixtures/rpc-e2e.ts
@@ -9,7 +9,7 @@ import type { RpcClientError } from "effect/unstable/rpc/RpcClientError"
 import type * as RpcGroup from "effect/unstable/rpc/RpcGroup"
 import * as RpcServer from "effect/unstable/rpc/RpcServer"
 import * as RpcTest from "effect/unstable/rpc/RpcTest"
-import { AuthClient, AuthLive, TimingLive, User, UserRpcs, UsersLive } from "./rpc-schemas.ts"
+import { AuthClient, AuthLayer, TimingLayer, User, UserRpcs, UsersLayer } from "./rpc-schemas.ts"
 
 export class UsersClient extends Context.Service<
   UsersClient,
@@ -19,7 +19,7 @@ export class UsersClient extends Context.Service<
     Layer.provide(AuthClient)
   )
   static layerTest = Layer.effect(UsersClient)(RpcTest.makeClient(UserRpcs)).pipe(
-    Layer.provide([UsersLive, AuthLive, TimingLive, AuthClient])
+    Layer.provide([UsersLayer, AuthLayer, TimingLayer, AuthClient])
   )
 }
 

--- a/packages/platform/browser/test/fixtures/rpc-schemas.ts
+++ b/packages/platform/browser/test/fixtures/rpc-schemas.ts
@@ -69,7 +69,7 @@ export const UserRpcs = RpcGroup.make(
   })
 ).middleware(AuthMiddleware)
 
-export const AuthLive = Layer.succeed(AuthMiddleware)(
+export const AuthLayer = Layer.succeed(AuthMiddleware)(
   AuthMiddleware.of((effect, options) =>
     Effect.provideService(
       effect,
@@ -82,7 +82,7 @@ export const AuthLive = Layer.succeed(AuthMiddleware)(
 const rpcSuccesses = Metric.counter("rpc_middleware_success")
 const rpcDefects = Metric.counter("rpc_middleware_defects")
 const rpcCount = Metric.counter("rpc_middleware_count")
-export const TimingLive = Layer.succeed(TimingMiddleware)(
+export const TimingLayer = Layer.succeed(TimingMiddleware)(
   TimingMiddleware.of((effect) =>
     effect.pipe(
       Effect.tap(Metric.update(rpcSuccesses, 1)),
@@ -92,7 +92,7 @@ export const TimingLive = Layer.succeed(TimingMiddleware)(
   )
 )
 
-export const UsersLive = UserRpcs.toLayer(Effect.gen(function*() {
+export const UsersLayer = UserRpcs.toLayer(Effect.gen(function*() {
   let interrupts = 0
   let emits = 0
   return UserRpcs.of({
@@ -140,13 +140,13 @@ export const UsersLive = UserRpcs.toLayer(Effect.gen(function*() {
   })
 }))
 
-export const RpcLive = RpcServer.layer(UserRpcs, {
+export const RpcLayer = RpcServer.layer(UserRpcs, {
   disableFatalDefects: true
 }).pipe(
   Layer.provide([
-    UsersLive,
-    AuthLive,
-    TimingLive
+    UsersLayer,
+    AuthLayer,
+    TimingLayer
   ])
 )
 

--- a/packages/platform/browser/test/fixtures/rpc-worker.ts
+++ b/packages/platform/browser/test/fixtures/rpc-worker.ts
@@ -2,11 +2,11 @@ import * as BrowserWorkerRunner from "@effect/platform-browser/BrowserWorkerRunn
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import * as RpcServer from "effect/unstable/rpc/RpcServer"
-import { RpcLive } from "./rpc-schemas.ts"
+import { RpcLayer } from "./rpc-schemas.ts"
 
-const MainLive = RpcLive.pipe(
+const MainLayer = RpcLayer.pipe(
   Layer.provide(RpcServer.layerProtocolWorkerRunner),
   Layer.provide(BrowserWorkerRunner.layer)
 )
 
-Effect.runFork(Layer.launch(MainLive))
+Effect.runFork(Layer.launch(MainLayer))

--- a/packages/platform/deno/test/fixtures/rpc-e2e.ts
+++ b/packages/platform/deno/test/fixtures/rpc-e2e.ts
@@ -6,7 +6,7 @@ import type { RpcClientError } from "effect/unstable/rpc/RpcClientError"
 import type * as RpcGroup from "effect/unstable/rpc/RpcGroup"
 import * as RpcServer from "effect/unstable/rpc/RpcServer"
 import * as RpcTest from "effect/unstable/rpc/RpcTest"
-import { AuthClient, AuthLive, TimingLive, User, UserRpcs, UsersLive } from "./rpc-schemas.ts"
+import { AuthClient, AuthLayer, TimingLayer, User, UserRpcs, UsersLayer } from "./rpc-schemas.ts"
 
 export class UsersClient extends Context.Service<
   UsersClient,
@@ -16,7 +16,7 @@ export class UsersClient extends Context.Service<
     Layer.provide(AuthClient)
   )
   static layerTest = Layer.effect(UsersClient)(RpcTest.makeClient(UserRpcs)).pipe(
-    Layer.provide([UsersLive, AuthLive, TimingLive, AuthClient])
+    Layer.provide([UsersLayer, AuthLayer, TimingLayer, AuthClient])
   )
 }
 

--- a/packages/platform/deno/test/fixtures/rpc-schemas.ts
+++ b/packages/platform/deno/test/fixtures/rpc-schemas.ts
@@ -69,7 +69,7 @@ export const UserRpcs = RpcGroup.make(
   })
 ).middleware(AuthMiddleware)
 
-export const AuthLive = Layer.succeed(AuthMiddleware)(
+export const AuthLayer = Layer.succeed(AuthMiddleware)(
   AuthMiddleware.of((effect, options) =>
     Effect.provideService(
       effect,
@@ -82,7 +82,7 @@ export const AuthLive = Layer.succeed(AuthMiddleware)(
 const rpcSuccesses = Metric.counter("rpc_middleware_success")
 const rpcDefects = Metric.counter("rpc_middleware_defects")
 const rpcCount = Metric.counter("rpc_middleware_count")
-export const TimingLive = Layer.succeed(TimingMiddleware)(
+export const TimingLayer = Layer.succeed(TimingMiddleware)(
   TimingMiddleware.of((effect) =>
     effect.pipe(
       Effect.tap(Metric.update(rpcSuccesses, 1)),
@@ -92,7 +92,7 @@ export const TimingLive = Layer.succeed(TimingMiddleware)(
   )
 )
 
-export const UsersLive = UserRpcs.toLayer(Effect.gen(function*() {
+export const UsersLayer = UserRpcs.toLayer(Effect.gen(function*() {
   let interrupts = 0
   let emits = 0
   return UserRpcs.of({
@@ -140,13 +140,13 @@ export const UsersLive = UserRpcs.toLayer(Effect.gen(function*() {
   })
 }))
 
-export const RpcLive = RpcServer.layer(UserRpcs, {
+export const RpcLayer = RpcServer.layer(UserRpcs, {
   disableFatalDefects: true
 }).pipe(
   Layer.provide([
-    UsersLive,
-    AuthLive,
-    TimingLive
+    UsersLayer,
+    AuthLayer,
+    TimingLayer
   ])
 )
 

--- a/packages/platform/deno/test/fixtures/rpc-worker.ts
+++ b/packages/platform/deno/test/fixtures/rpc-worker.ts
@@ -2,11 +2,11 @@ import * as DenoWorkerRunner from "@effect/platform-deno/DenoWorkerRunner"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import * as RpcServer from "effect/unstable/rpc/RpcServer"
-import { RpcLive } from "./rpc-schemas.ts"
+import { RpcLayer } from "./rpc-schemas.ts"
 
-const MainLive = RpcLive.pipe(
+const MainLayer = RpcLayer.pipe(
   Layer.provide(RpcServer.layerProtocolWorkerRunner),
   Layer.provide(DenoWorkerRunner.layer)
 )
 
-Effect.runFork(Layer.launch(MainLive))
+Effect.runFork(Layer.launch(MainLayer))

--- a/packages/platform/node/test/HttpApi.test.ts
+++ b/packages/platform/node/test/HttpApi.test.ts
@@ -76,13 +76,13 @@ describe("HttpApi", () => {
             })
           )
       )
-    const GroupLive = HttpApiBuilder.group(
+    const GroupLayer = HttpApiBuilder.group(
       Api,
       "group",
       (handlers) => handlers.handle("catchAll", (ctx) => Effect.succeed(ctx.request.url))
     )
-    const ApiLive = HttpRouter.serve(
-      HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLive)),
+    const ApiLayer = HttpRouter.serve(
+      HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer)),
       { disableListenLog: true, disableLogger: true }
     ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
@@ -95,7 +95,7 @@ describe("HttpApi", () => {
       // client side
       const client = yield* HttpApiClient.make(Api)
       yield* assertClientText(client.group.catchAll(), "/*")
-    }).pipe(Effect.provide(ApiLive))
+    }).pipe(Effect.provide(ApiLayer))
   })
 
   describe("middleware", () => {
@@ -117,18 +117,18 @@ describe("HttpApi", () => {
               })
             ).middleware(M)
         )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "group",
         (handlers) => handlers.handle("a", () => Effect.succeed(1))
       )
-      const MLive = Layer.succeed(
+      const MLayer = Layer.succeed(
         M,
         () => Effect.fail("error")
       )
 
-      const ApiLive = HttpRouter.serve(
-        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLive), Layer.provide(MLive)),
+      const ApiLayer = HttpRouter.serve(
+        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer), Layer.provide(MLayer)),
         { disableListenLog: true, disableLogger: true }
       ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
@@ -139,7 +139,7 @@ describe("HttpApi", () => {
         // client side
         const client = yield* HttpApiClient.make(Api)
         yield* assertClientError(client.group.a(), "error")
-      }).pipe(Effect.provide(ApiLive))
+      }).pipe(Effect.provide(ApiLayer))
     })
 
     it.effect("error array", () => {
@@ -159,7 +159,7 @@ describe("HttpApi", () => {
           )
           .middleware(M)
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "group",
         (handlers) =>
@@ -167,7 +167,7 @@ describe("HttpApi", () => {
             .handle("unauthorized", () => Effect.succeed("ok"))
             .handle("forbidden", () => Effect.succeed("ok"))
       )
-      const MLive = Layer.succeed(
+      const MLayer = Layer.succeed(
         M,
         (_, { endpoint }) =>
           endpoint.identifier === "unauthorized"
@@ -175,8 +175,8 @@ describe("HttpApi", () => {
             : Effect.fail(new HttpApiError.Forbidden({}))
       )
 
-      const ApiLive = HttpRouter.serve(
-        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLive), Layer.provide(MLive)),
+      const ApiLayer = HttpRouter.serve(
+        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer), Layer.provide(MLayer)),
         { disableListenLog: true, disableLogger: true }
       ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
@@ -187,7 +187,7 @@ describe("HttpApi", () => {
         const client = yield* HttpApiClient.make(Api)
         yield* assertClientError(client.group.unauthorized(), new HttpApiError.Unauthorized({}))
         yield* assertClientError(client.group.forbidden(), new HttpApiError.Forbidden({}))
-      }).pipe(Effect.provide(ApiLive))
+      }).pipe(Effect.provide(ApiLayer))
     })
 
     it.effect("client middleware modifies request and receives metadata", () => {
@@ -204,15 +204,15 @@ describe("HttpApi", () => {
           )
           .middleware(M)
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "group",
         (handlers) => handlers.handle("a", (ctx) => Effect.succeed(ctx.request.headers["x-client"] ?? "missing"))
       )
-      const MLive = Layer.succeed(M, (effect) => effect)
+      const MLayer = Layer.succeed(M, (effect) => effect)
 
-      const ApiLive = HttpRouter.serve(
-        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLive), Layer.provide(MLive)),
+      const ApiLayer = HttpRouter.serve(
+        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer), Layer.provide(MLayer)),
         { disableListenLog: true, disableLogger: true }
       ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
@@ -235,7 +235,7 @@ describe("HttpApi", () => {
           group: "group",
           endpoint: "a"
         })
-      }).pipe(Effect.provide(ApiLive))
+      }).pipe(Effect.provide(ApiLayer))
     })
 
     it.effect("client middleware chain order is LIFO", () => {
@@ -257,7 +257,7 @@ describe("HttpApi", () => {
               .middleware(M2)
           )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "group",
         (handlers) =>
@@ -266,11 +266,11 @@ describe("HttpApi", () => {
             (ctx) => Effect.succeed(`${ctx.request.headers["x-m1"] ?? "0"}${ctx.request.headers["x-m2"] ?? "0"}`)
           )
       )
-      const M1Live = Layer.succeed(M1, (effect) => effect)
-      const M2Live = Layer.succeed(M2, (effect) => effect)
+      const M1Layer = Layer.succeed(M1, (effect) => effect)
+      const M2Layer = Layer.succeed(M2, (effect) => effect)
 
-      const ApiLive = HttpRouter.serve(
-        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLive), Layer.provide(M1Live), Layer.provide(M2Live)),
+      const ApiLayer = HttpRouter.serve(
+        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer), Layer.provide(M1Layer), Layer.provide(M2Layer)),
         { disableListenLog: true, disableLogger: true }
       ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
@@ -303,7 +303,7 @@ describe("HttpApi", () => {
 
         assert.strictEqual(yield* client.group.a(), "11")
         assert.deepStrictEqual(order, ["m2-before", "m1-before", "m1-after", "m2-after"])
-      }).pipe(Effect.provide(ApiLive))
+      }).pipe(Effect.provide(ApiLayer))
     })
 
     it.effect("required client middleware can fail with typed clientError", () => {
@@ -327,7 +327,7 @@ describe("HttpApi", () => {
           .middleware(M)
       )
       let handled = false
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "group",
         (handlers) =>
@@ -337,10 +337,10 @@ describe("HttpApi", () => {
               return "ok"
             }))
       )
-      const MLive = Layer.succeed(M, (effect) => effect)
+      const MLayer = Layer.succeed(M, (effect) => effect)
 
-      const ApiLive = HttpRouter.serve(
-        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLive), Layer.provide(MLive)),
+      const ApiLayer = HttpRouter.serve(
+        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer), Layer.provide(MLayer)),
         { disableListenLog: true, disableLogger: true }
       ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
@@ -356,7 +356,7 @@ describe("HttpApi", () => {
 
         yield* assertClientError(client.group.a(), new ClientFailure({}))
         assert.isFalse(handled)
-      }).pipe(Effect.provide(ApiLive))
+      }).pipe(Effect.provide(ApiLayer))
     })
 
     it.effect("optional client middleware is skipped when not provided", () => {
@@ -371,22 +371,22 @@ describe("HttpApi", () => {
           )
           .middleware(M)
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "group",
         (handlers) => handlers.handle("a", (ctx) => Effect.succeed(ctx.request.headers["x-optional"] ?? "missing"))
       )
-      const MLive = Layer.succeed(M, (effect) => effect)
+      const MLayer = Layer.succeed(M, (effect) => effect)
 
-      const ApiLive = HttpRouter.serve(
-        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLive), Layer.provide(MLive)),
+      const ApiLayer = HttpRouter.serve(
+        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer), Layer.provide(MLayer)),
         { disableListenLog: true, disableLogger: true }
       ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
       return Effect.gen(function*() {
         const client = yield* HttpApiClient.make(Api)
         assert.strictEqual(yield* client.group.a(), "missing")
-      }).pipe(Effect.provide(ApiLive))
+      }).pipe(Effect.provide(ApiLayer))
     })
 
     it.effect("layerClient supports effectful construction", () => {
@@ -405,15 +405,15 @@ describe("HttpApi", () => {
           )
           .middleware(M)
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "group",
         (handlers) => handlers.handle("a", (ctx) => Effect.succeed(ctx.request.headers["x-effect"] ?? "missing"))
       )
-      const MLive = Layer.succeed(M, (effect) => effect)
+      const MLayer = Layer.succeed(M, (effect) => effect)
 
-      const ApiLive = HttpRouter.serve(
-        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLive), Layer.provide(MLive)),
+      const ApiLayer = HttpRouter.serve(
+        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer), Layer.provide(MLayer)),
         { disableListenLog: true, disableLogger: true }
       ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
@@ -432,7 +432,7 @@ describe("HttpApi", () => {
         )
 
         assert.strictEqual(yield* client.group.a(), "from-effect")
-      }).pipe(Effect.provide(ApiLive))
+      }).pipe(Effect.provide(ApiLayer))
     })
 
     it.effect("security middleware can be implemented with layerClient", () => {
@@ -456,17 +456,17 @@ describe("HttpApi", () => {
           }))
           .middleware(M)
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "group",
         (handlers) => handlers.handle("a", () => CurrentToken)
       )
-      const MLive = Layer.succeed(M)({
+      const MLayer = Layer.succeed(M)({
         apiKey: (effect, options) => Effect.provideService(effect, CurrentToken, Redacted.value(options.credential))
       })
 
-      const ApiLive = HttpRouter.serve(
-        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLive), Layer.provide(MLive)),
+      const ApiLayer = HttpRouter.serve(
+        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer), Layer.provide(MLayer)),
         { disableListenLog: true, disableLogger: true }
       ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
@@ -481,7 +481,7 @@ describe("HttpApi", () => {
         const authedClient = yield* HttpApiClient.make(Api).pipe(Effect.provide(MClient))
 
         assert.strictEqual(yield* authedClient.group.a(), "token")
-      }).pipe(Effect.provide(ApiLive))
+      }).pipe(Effect.provide(ApiLayer))
     })
 
     it("security middleware cache does not reuse the first service impl", async () => {
@@ -509,20 +509,20 @@ describe("HttpApi", () => {
       )
 
       const makeWebHandler = (marker: string) => {
-        const GroupLive = HttpApiBuilder.group(
+        const GroupLayer = HttpApiBuilder.group(
           Api,
           "group",
           (handlers) => handlers.handle("a", () => Effect.map(CurrentMarker, (marker) => ({ marker })))
         )
-        const MLive = Layer.succeed(M)({
+        const MLayer = Layer.succeed(M)({
           apiKey: (effect) => Effect.provideService(effect, CurrentMarker, marker)
         })
 
         return HttpRouter.toWebHandler(
           Layer.mergeAll(
             HttpApiBuilder.layer(Api).pipe(
-              Layer.provide(GroupLive),
-              Layer.provide(MLive),
+              Layer.provide(GroupLayer),
+              Layer.provide(MLayer),
               Layer.provide(HttpServer.layerServices)
             )
           ),
@@ -584,24 +584,24 @@ describe("HttpApi", () => {
         .middleware(M1)
         .middleware(M2)
 
-      const HealthLive = HttpApiBuilder.group(
+      const HealthLayer = HttpApiBuilder.group(
         Api,
         "health",
         (handlers) => handlers.handle("health", () => Effect.succeed("ok"))
       )
-      const UsersLive = HttpApiBuilder.group(
+      const UsersLayer = HttpApiBuilder.group(
         Api,
         "users",
         (handlers) => handlers.handle("list", () => Effect.succeed("ok"))
       )
-      const M1Live = Layer.succeed(
+      const M1Layer = Layer.succeed(
         M1,
         (effect, { endpoint, group }) =>
           Effect.sync(() => calls.push(`m1:${group.identifier}.${endpoint.identifier}`)).pipe(
             Effect.flatMap(() => effect)
           )
       )
-      const M2Live = Layer.succeed(
+      const M2Layer = Layer.succeed(
         M2,
         (effect, { endpoint, group }) =>
           Effect.sync(() => calls.push(`m2:${group.identifier}.${endpoint.identifier}`)).pipe(
@@ -609,12 +609,12 @@ describe("HttpApi", () => {
           )
       )
 
-      const ApiLive = HttpRouter.serve(
+      const ApiLayer = HttpRouter.serve(
         HttpApiBuilder.layer(Api).pipe(
-          Layer.provide(HealthLive),
-          Layer.provide(UsersLive),
-          Layer.provide(M1Live),
-          Layer.provide(M2Live)
+          Layer.provide(HealthLayer),
+          Layer.provide(UsersLayer),
+          Layer.provide(M1Layer),
+          Layer.provide(M2Layer)
         ),
         { disableListenLog: true, disableLogger: true }
       ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
@@ -628,7 +628,7 @@ describe("HttpApi", () => {
           "m2:users.list",
           "m1:users.list"
         ])
-      }).pipe(Effect.provide(ApiLive))
+      }).pipe(Effect.provide(ApiLayer))
     })
 
     it.effect("missing middleware layer fails with service not found error", () => {
@@ -643,18 +643,18 @@ describe("HttpApi", () => {
           )
           .middleware(M)
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "group",
         (handlers) => handlers.handle("a", () => Effect.succeed("ok"))
       )
-      const ApiLive = HttpRouter.serve(
-        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLive)),
+      const ApiLayer = HttpRouter.serve(
+        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer)),
         { disableListenLog: true, disableLogger: true }
       ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
       return HttpClient.get("/a").pipe(
-        Effect.provide(ApiLive),
+        Effect.provide(ApiLayer),
         Effect.sandbox,
         Effect.flip,
         Effect.flatMap((cause) =>
@@ -686,18 +686,18 @@ describe("HttpApi", () => {
       .add(HealthApi)
       .addHttpApi(V0)
 
-    const UsersLive = HttpApiBuilder.group(
+    const UsersLayer = HttpApiBuilder.group(
       Api,
       "users",
       (handlers) => handlers.handle("list", () => Effect.succeed("ok"))
     )
-    const ApiLive = HttpRouter.serve(
-      HttpApiBuilder.layer(Api).pipe(Layer.provide(UsersLive)),
+    const ApiLayer = HttpRouter.serve(
+      HttpApiBuilder.layer(Api).pipe(Layer.provide(UsersLayer)),
       { disableListenLog: true, disableLogger: true }
     ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
     return HttpClient.get("/users").pipe(
-      Effect.provide(ApiLive),
+      Effect.provide(ApiLayer),
       Effect.sandbox,
       Effect.flip,
       Effect.flatMap((cause) =>
@@ -729,13 +729,13 @@ describe("HttpApi", () => {
                 })
               )
           )
-        const GroupLive = HttpApiBuilder.group(
+        const GroupLayer = HttpApiBuilder.group(
           Api,
           "group",
           (handlers) => handlers.handle("a", (ctx) => Effect.succeed(ctx.payload))
         )
-        const ApiLive = HttpRouter.serve(
-          HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLive)),
+        const ApiLayer = HttpRouter.serve(
+          HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer)),
           { disableListenLog: true, disableLogger: true }
         ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
@@ -764,7 +764,7 @@ describe("HttpApi", () => {
             optional: 1
           })
           yield* assertClientJson(client.group.a({ payload: { required: 1, optional: undefined } }), { required: 1 })
-        }).pipe(Effect.provide(ApiLive))
+        }).pipe(Effect.provide(ApiLayer))
       })
     })
 
@@ -781,14 +781,14 @@ describe("HttpApi", () => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "group",
         (handlers) => handlers.handle("a", (ctx) => Effect.succeed(ctx.payload))
       )
 
-      const ApiLive = HttpRouter.serve(
-        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLive)),
+      const ApiLayer = HttpRouter.serve(
+        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer)),
         { disableListenLog: true, disableLogger: true }
       ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
@@ -810,7 +810,7 @@ describe("HttpApi", () => {
         yield* assertClientJson(client.group.a({ payload: { a: "text" } }), { a: "text" })
         yield* assertClientJson(client.group.a({ payload: "text" }), "text")
         yield* assertClientJson(client.group.a({ payload: new Uint8Array([1, 2, 3]) }), { 0: 1, 1: 2, 2: 3 })
-      }).pipe(Effect.provide(ApiLive))
+      }).pipe(Effect.provide(ApiLayer))
     })
   })
 
@@ -826,14 +826,14 @@ describe("HttpApi", () => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "group",
         (handlers) => handlers.handle("get", (ctx) => Effect.succeed(`User ${ctx.params.id}`))
       )
 
-      const ApiLive = HttpRouter.serve(
-        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLive)),
+      const ApiLayer = HttpRouter.serve(
+        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer)),
         { disableListenLog: true, disableLogger: true }
       ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
@@ -844,7 +844,7 @@ describe("HttpApi", () => {
         // client side
         const client = yield* HttpApiClient.make(Api)
         yield* assertClientJson(client.group.get({ params: { id: 1 } }), "User 1")
-      }).pipe(Effect.provide(ApiLive))
+      }).pipe(Effect.provide(ApiLayer))
     })
   })
 
@@ -860,14 +860,14 @@ describe("HttpApi", () => {
           })
         )
       )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "group",
         (handlers) => handlers.handle("get", (ctx) => Effect.succeed(`User ${ctx.query.id}`))
       )
 
-      const ApiLive = HttpRouter.serve(
-        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLive)),
+      const ApiLayer = HttpRouter.serve(
+        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer)),
         { disableListenLog: true, disableLogger: true }
       ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
@@ -878,7 +878,7 @@ describe("HttpApi", () => {
         // client side
         const client = yield* HttpApiClient.make(Api)
         yield* assertClientJson(client.group.get({ query: { id: 1 } }), "User 1")
-      }).pipe(Effect.provide(ApiLive))
+      }).pipe(Effect.provide(ApiLayer))
     })
   })
 
@@ -899,7 +899,7 @@ describe("HttpApi", () => {
               })
             )
         )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "group",
         (handlers) =>
@@ -909,8 +909,8 @@ describe("HttpApi", () => {
             .handle("c", () => Effect.succeed("-"))
       )
 
-      const ApiLive = HttpRouter.serve(
-        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLive)),
+      const ApiLayer = HttpRouter.serve(
+        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer)),
         { disableListenLog: true, disableLogger: true }
       ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
@@ -925,7 +925,7 @@ describe("HttpApi", () => {
         yield* assertClientJson(client.group.a(), undefined)
         yield* assertClientJson(client.group.b(), undefined)
         yield* assertClientJson(client.group.c(), "c")
-      }).pipe(Effect.provide(ApiLive))
+      }).pipe(Effect.provide(ApiLayer))
     })
 
     it("no content via toWebHandler", async () => {
@@ -934,17 +934,17 @@ describe("HttpApi", () => {
           HttpApiGroup.make("group")
             .add(HttpApiEndpoint.delete("remove", "/items/:id", { params: { id: Schema.String } }))
         )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "group",
         (handlers) => handlers.handle("remove", () => Effect.void)
       )
-      const ApiLive = HttpApiBuilder.layer(Api).pipe(
-        Layer.provide(GroupLive),
+      const ApiLayer = HttpApiBuilder.layer(Api).pipe(
+        Layer.provide(GroupLayer),
         Layer.provide(HttpServer.layerServices)
       )
       const { handler, dispose } = HttpRouter.toWebHandler(
-        Layer.mergeAll(ApiLive),
+        Layer.mergeAll(ApiLayer),
         { disableLogger: true }
       )
       try {
@@ -966,14 +966,14 @@ describe("HttpApi", () => {
               })
             )
           )
-          const GroupLive = HttpApiBuilder.group(
+          const GroupLayer = HttpApiBuilder.group(
             Api,
             "group",
             (handlers) => handlers.handle("a", () => Effect.succeed("a"))
           )
 
-          const ApiLive = HttpRouter.serve(
-            HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLive)),
+          const ApiLayer = HttpRouter.serve(
+            HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer)),
             { disableListenLog: true, disableLogger: true }
           ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
@@ -986,7 +986,7 @@ describe("HttpApi", () => {
             // client side
             const client = yield* HttpApiClient.make(Api)
             yield* assertClientJson(client.group.a(), "a")
-          }).pipe(Effect.provide(ApiLive))
+          }).pipe(Effect.provide(ApiLayer))
         })
       })
     })
@@ -1022,7 +1022,7 @@ describe("HttpApi", () => {
               })
             )
         )
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "group",
         (handlers) =>
@@ -1035,8 +1035,8 @@ describe("HttpApi", () => {
             .handle("f", () => Effect.fail(new HttpApiError.BadRequest({})))
       )
 
-      const ApiLive = HttpRouter.serve(
-        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLive)),
+      const ApiLayer = HttpRouter.serve(
+        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer)),
         { disableListenLog: true, disableLogger: true }
       ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
@@ -1057,7 +1057,7 @@ describe("HttpApi", () => {
         yield* assertClientError(client.group.d(), undefined)
         yield* assertClientError(client.group.e(), new HttpApiError.Unauthorized({}))
         yield* assertClientError(client.group.f(), new HttpApiError.BadRequest({}))
-      }).pipe(Effect.provide(ApiLive))
+      }).pipe(Effect.provide(ApiLayer))
     })
   })
 
@@ -1105,7 +1105,7 @@ describe("HttpApi", () => {
             endpointClientUser,
             expected
           )
-        }).pipe(Effect.provide(HttpLive)))
+        }).pipe(Effect.provide(HttpLayer)))
 
       it.live("multipart", () =>
         Effect.gen(function*() {
@@ -1117,7 +1117,7 @@ describe("HttpApi", () => {
             contentType: "text/plain",
             length: 5
           })
-        }).pipe(Effect.provide(HttpLive)))
+        }).pipe(Effect.provide(HttpLayer)))
 
       it.live("multipart stream", () =>
         Effect.gen(function*() {
@@ -1129,7 +1129,7 @@ describe("HttpApi", () => {
             contentType: "text/plain",
             length: 5
           })
-        }).pipe(Effect.provide(HttpLive)))
+        }).pipe(Effect.provide(HttpLayer)))
     })
 
     describe("headers", () => {
@@ -1144,14 +1144,14 @@ describe("HttpApi", () => {
             })
           )
         )
-        const GroupLive = HttpApiBuilder.group(
+        const GroupLayer = HttpApiBuilder.group(
           Api,
           "group",
           (handlers) => handlers.handle("get", (ctx) => Effect.succeed(`User ${ctx.headers.id}`))
         )
 
-        const ApiLive = HttpRouter.serve(
-          HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLive)),
+        const ApiLayer = HttpRouter.serve(
+          HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer)),
           { disableListenLog: true, disableLogger: true }
         ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
@@ -1159,7 +1159,7 @@ describe("HttpApi", () => {
           const client = yield* HttpApiClient.make(Api)
           const result = yield* client.group.get({ headers: { id: 1 } })
           assert.strictEqual(result, "User 1")
-        }).pipe(Effect.provide(ApiLive))
+        }).pipe(Effect.provide(ApiLayer))
       })
 
       it.effect("is decoded / encoded", () =>
@@ -1178,7 +1178,7 @@ describe("HttpApi", () => {
               createdAt: DateTime.makeUnsafe(0)
             })
           )
-        }).pipe(Effect.provide(HttpLive)))
+        }).pipe(Effect.provide(HttpLayer)))
     })
 
     describe("errors", () => {
@@ -1188,7 +1188,7 @@ describe("HttpApi", () => {
           assert.strictEqual(response.status, 418)
           const text = yield* response.text
           assert.strictEqual(text, "")
-        }).pipe(Effect.provide(HttpLive)))
+        }).pipe(Effect.provide(HttpLayer)))
 
       it.effect("empty errors decode", () =>
         Effect.gen(function*() {
@@ -1197,7 +1197,7 @@ describe("HttpApi", () => {
             Effect.flip
           )
           assert.deepStrictEqual(error, new GroupError({}))
-        }).pipe(Effect.provide(HttpLive)))
+        }).pipe(Effect.provide(HttpLayer)))
 
       it.effect("default to 500 status code", () =>
         Effect.gen(function*() {
@@ -1210,7 +1210,7 @@ describe("HttpApi", () => {
           assert.deepStrictEqual(body, {
             _tag: "NoStatusError"
           })
-        }).pipe(Effect.provide(HttpLive)))
+        }).pipe(Effect.provide(HttpLayer)))
 
       it.effect("class level annotations", () =>
         Effect.gen(function*() {
@@ -1220,7 +1220,7 @@ describe("HttpApi", () => {
             HttpClient.execute
           )
           assert.strictEqual(response.status, 400)
-        }).pipe(Effect.provide(HttpLive)))
+        }).pipe(Effect.provide(HttpLayer)))
 
       it.effect("BadRequest", () =>
         Effect.gen(function*() {
@@ -1230,7 +1230,7 @@ describe("HttpApi", () => {
           )
           assert(error._tag === "HttpClientError" && error.reason._tag === "DecodeError")
           assert.strictEqual(error.reason.response.status, 400)
-        }).pipe(Effect.provide(HttpLive)))
+        }).pipe(Effect.provide(HttpLayer)))
     })
 
     it.effect("handler level context", () =>
@@ -1240,7 +1240,7 @@ describe("HttpApi", () => {
         const user = users[0]
         assert.strictEqual(user.name, "page 1")
         assert.deepStrictEqual(user.createdAt, DateTime.makeUnsafe(0))
-      }).pipe(Effect.provide(HttpLive)))
+      }).pipe(Effect.provide(HttpLayer)))
 
     it.effect("custom client context", () =>
       Effect.gen(function*() {
@@ -1266,7 +1266,7 @@ describe("HttpApi", () => {
         const user = users[0]
         assert.strictEqual(user.name, "page 1")
         assert.isTrue(tapped)
-      }).pipe(Effect.provide(HttpLive)))
+      }).pipe(Effect.provide(HttpLayer)))
 
     describe("security", () => {
       it.effect("security middleware sets current user", () =>
@@ -1279,7 +1279,7 @@ describe("HttpApi", () => {
           })
           const user = yield* client.users.findById({ params: { id: -1 } })
           assert.strictEqual(user.name, "foo")
-        }).pipe(Effect.provide(HttpLive)))
+        }).pipe(Effect.provide(HttpLayer)))
 
       it.effect("apiKey header security", () =>
         Effect.gen(function*() {
@@ -1298,7 +1298,7 @@ describe("HttpApi", () => {
           )
           const redacted = yield* decode
           assert.strictEqual(Redacted.value(redacted), "foo")
-        }).pipe(Effect.provide(HttpLive)))
+        }).pipe(Effect.provide(HttpLayer)))
 
       it.effect("apiKey query security", () =>
         Effect.gen(function*() {
@@ -1312,7 +1312,7 @@ describe("HttpApi", () => {
             })
           )
           assert.strictEqual(Redacted.value(redacted), "foo")
-        }).pipe(Effect.provide(HttpLive)))
+        }).pipe(Effect.provide(HttpLayer)))
     })
 
     it.effect("client responseMode decoded-and-response", () =>
@@ -1325,7 +1325,7 @@ describe("HttpApi", () => {
         })
         assert.strictEqual(users[0].name, "page 1")
         assert.strictEqual(response.status, 200)
-      }).pipe(Effect.provide(HttpLive)))
+      }).pipe(Effect.provide(HttpLayer)))
 
     it.effect("client responseMode response-only skips decoding", () => {
       const Api = HttpApi.make("api").add(
@@ -1338,14 +1338,14 @@ describe("HttpApi", () => {
         )
       )
 
-      const GroupLive = HttpApiBuilder.group(
+      const GroupLayer = HttpApiBuilder.group(
         Api,
         "group",
         (handlers) => handlers.handleRaw("bad", () => Effect.succeed(HttpServerResponse.text("not-json")))
       )
 
-      const ApiLive = HttpRouter.serve(
-        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLive)),
+      const ApiLayer = HttpRouter.serve(
+        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer)),
         { disableListenLog: true, disableLogger: true }
       ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
@@ -1359,7 +1359,7 @@ describe("HttpApi", () => {
         })
         assert.strictEqual(response.status, 200)
         assert.strictEqual(yield* response.text, "not-json")
-      }).pipe(Effect.provide(ApiLive))
+      }).pipe(Effect.provide(ApiLayer))
     })
 
     it.effect("multiple payload types", () =>
@@ -1385,7 +1385,7 @@ describe("HttpApi", () => {
           payload: { foo: "Some group" }
         })
         assert.deepStrictEqual(group, new Group({ id: 1, name: "Some group" }))
-      }).pipe(Effect.provide(HttpLive)))
+      }).pipe(Effect.provide(HttpLayer)))
 
     it.effect(".handle can return HttpServerResponse", () =>
       Effect.gen(function*() {
@@ -1398,7 +1398,7 @@ describe("HttpApi", () => {
           id: 1,
           name: "Some group"
         })
-      }).pipe(Effect.provide(HttpLive)))
+      }).pipe(Effect.provide(HttpLayer)))
 
     it.effect(".handleRaw can manually process body", () =>
       Effect.gen(function*() {
@@ -1411,7 +1411,7 @@ describe("HttpApi", () => {
           id: 1,
           name: "Some group"
         })
-      }).pipe(Effect.provide(HttpLive)))
+      }).pipe(Effect.provide(HttpLayer)))
 
     describe("OpenAPI spec", () => {
       it("fixture", () => {
@@ -1445,7 +1445,7 @@ describe("HttpApi", () => {
           })
         )
       )
-      const ApiLive = HttpApiBuilder.layer(Api).pipe(
+      const ApiLayer = HttpApiBuilder.layer(Api).pipe(
         Layer.provide(
           HttpApiBuilder.group(
             Api,
@@ -1460,7 +1460,7 @@ describe("HttpApi", () => {
         const client = yield* HttpApiClient.make(Api)
         const response = yield* client.group.error().pipe(Effect.flip)
         assert.deepStrictEqual(response, new RateLimitError({ message: "Rate limit exceeded" }))
-      }).pipe(Effect.provide(ApiLive))
+      }).pipe(Effect.provide(ApiLayer))
     })
   })
 
@@ -1473,7 +1473,7 @@ describe("HttpApi", () => {
       }).pipe(
         Effect.provide([
           NodeHttpServer.layerHttpServices,
-          AuthorizationLive,
+          AuthorizationLayer,
           HttpApiBuilder.group(Api, "groups", (handlers) =>
             handlers
               .handle("findById", () => Effect.succeed(new Group({ id: 1, name: "foo" })))
@@ -1691,12 +1691,12 @@ class Api extends HttpApi.make("api")
 class UserRepo extends Context.Service<UserRepo, {
   readonly findById: (id: number) => Effect.Effect<User>
 }>()("UserRepo") {
-  static Live = Layer.succeed(this)({
+  static layer = Layer.succeed(this)({
     findById: (id) => Effect.map(DateTime.now, (now) => ({ id, name: "foo", createdAt: now }))
   })
 }
 
-const AuthorizationLive = Layer.succeed(
+const AuthorizationLayer = Layer.succeed(
   Authorization
 )({
   cookie: (effect, opts) =>
@@ -1711,7 +1711,7 @@ const AuthorizationLive = Layer.succeed(
     )
 })
 
-const HttpUsersLive = HttpApiBuilder.group(
+const HttpUsersLayer = HttpApiBuilder.group(
   Api,
   "users",
   Effect.fnUntraced(function*(handlers) {
@@ -1768,12 +1768,12 @@ const HttpUsersLive = HttpApiBuilder.group(
   })
 ).pipe(
   Layer.provide([
-    UserRepo.Live,
-    AuthorizationLive
+    UserRepo.layer,
+    AuthorizationLayer
   ])
 )
 
-const HttpGroupsLive = HttpApiBuilder.group(
+const HttpGroupsLayer = HttpApiBuilder.group(
   Api,
   "groups",
   (handlers) =>
@@ -1810,19 +1810,19 @@ const HttpGroupsLive = HttpApiBuilder.group(
       )
 )
 
-const TopLevelLive = HttpApiBuilder.group(
+const TopLevelLayer = HttpApiBuilder.group(
   Api,
   "root",
   (handlers) => handlers.handle("healthz", (_) => Effect.void)
 )
 
-const HttpApiLive = Layer.provide(HttpApiBuilder.layer(Api), [
-  HttpGroupsLive,
-  HttpUsersLive,
-  TopLevelLive
+const HttpApiLayer = Layer.provide(HttpApiBuilder.layer(Api), [
+  HttpGroupsLayer,
+  HttpUsersLayer,
+  TopLevelLayer
 ])
 
-const HttpLive = HttpRouter.serve(HttpApiLive, {
+const HttpLayer = HttpRouter.serve(HttpApiLayer, {
   disableListenLog: true,
   disableLogger: true
 }).pipe(

--- a/packages/platform/node/test/NodeHttpClient.test.ts
+++ b/packages/platform/node/test/NodeHttpClient.test.ts
@@ -45,7 +45,7 @@ const makeLocalServerClient = Effect.gen(function*() {
 })
 interface LocalServerClient extends Effect.Success<typeof makeLocalServerClient> {}
 const LocalServerClient = Context.Service<LocalServerClient>("test/LocalServerClient")
-const LocalServerClientLive = Layer.effect(LocalServerClient)(makeLocalServerClient)
+const LocalServerClientLayer = Layer.effect(LocalServerClient)(makeLocalServerClient)
 const LocalServerRoutes = HttpRouter.serve(HttpRouter.addAll([
   HttpRouter.route(
     "GET",
@@ -90,7 +90,7 @@ const LocalServerRoutes = HttpRouter.serve(HttpRouter.addAll([
     Layer.provide(layer),
     Layer.provideMerge(NodeHttpServer.layer(Http.createServer, { port: 0 }))
   )
-  const localServerTestLayer = Layer.merge(LocalServerClientLive, LocalServerRoutes).pipe(
+  const localServerTestLayer = Layer.merge(LocalServerClientLayer, LocalServerRoutes).pipe(
     Layer.provideMerge(layerTest)
   )
 

--- a/packages/platform/node/test/RpcServer.test.ts
+++ b/packages/platform/node/test/RpcServer.test.ts
@@ -6,14 +6,14 @@ import { HttpClient, HttpClientRequest, HttpRouter, HttpServer } from "effect/un
 import { Rpc, RpcClient, RpcGroup, RpcSerialization, RpcServer, RpcTest } from "effect/unstable/rpc"
 import { SocketServer } from "effect/unstable/socket"
 import { e2eSuite, UsersClient } from "./fixtures/rpc-e2e.ts"
-import { RpcLive, User } from "./fixtures/rpc-schemas.ts"
+import { RpcLayer, User } from "./fixtures/rpc-schemas.ts"
 
 describe("RpcServer", () => {
   // http ndjson
   const HttpProtocol = RpcServer.layerProtocolHttp({ path: "/rpc" }).pipe(
     Layer.provide(HttpRouter.layer)
   )
-  const HttpNdjsonServer = RpcLive.pipe(
+  const HttpNdjsonServer = RpcLayer.pipe(
     Layer.provideMerge(HttpProtocol),
     Layer.provide(HttpRouter.serve(HttpProtocol, { disableListenLog: true, disableLogger: true }))
   )
@@ -55,7 +55,7 @@ describe("RpcServer", () => {
   const WsProtocol = RpcServer.layerProtocolWebsocket({ path: "/rpc" }).pipe(
     Layer.provide(HttpRouter.layer)
   )
-  const HttpWsServer = RpcLive.pipe(
+  const HttpWsServer = RpcLayer.pipe(
     Layer.provideMerge(WsProtocol),
     Layer.provide(HttpRouter.serve(WsProtocol, { disableListenLog: true, disableLogger: true }))
   )
@@ -99,7 +99,7 @@ describe("RpcServer", () => {
   )
 
   // tcp
-  const TcpServer = RpcLive.pipe(
+  const TcpServer = RpcLayer.pipe(
     Layer.provideMerge(RpcServer.layerProtocolSocketServer),
     Layer.provideMerge(NodeSocketServer.layer({ port: 0 }))
   )

--- a/packages/platform/node/test/cluster-integration/harness.ts
+++ b/packages/platform/node/test/cluster-integration/harness.ts
@@ -151,7 +151,7 @@ const makeRunnerStorageController = (storage: RunnerStorage.RunnerStorage["Servi
   }
 }
 
-const RunnerHealthLive = RunnerHealth.layerPing.pipe(
+const RunnerHealthLayer = RunnerHealth.layerPing.pipe(
   Layer.provide(Runners.layerRpc),
   Layer.provide(NodeClusterSocket.layerClientProtocol)
 )
@@ -164,7 +164,7 @@ export const socketRunnerLayer = (
 ) =>
   entities.pipe(
     Layer.provideMerge(SocketRunner.layer),
-    Layer.provide(RunnerHealthLive),
+    Layer.provide(RunnerHealthLayer),
     Layer.provide(Layer.succeed(SocketServer.SocketServer, socketServer)),
     Layer.provide(NodeClusterSocket.layerClientProtocol),
     Layer.provide(ShardingConfig.layer({

--- a/packages/platform/node/test/cluster/MessageStorageTest.ts
+++ b/packages/platform/node/test/cluster/MessageStorageTest.ts
@@ -16,7 +16,7 @@ import {
 import { Headers } from "effect/unstable/http"
 import { Rpc, RpcSchema } from "effect/unstable/rpc"
 
-const MemoryLive = MessageStorage.layerMemory.pipe(
+const MemoryLayer = MessageStorage.layerMemory.pipe(
   Layer.provideMerge(Snowflake.layerGenerator),
   Layer.provide(ShardingConfig.layerDefaults)
 )
@@ -31,7 +31,7 @@ describe("MessageStorage", () => {
         expect(result._tag).toEqual("Success")
         const messages = yield* storage.unprocessedMessages([request.envelope.address.shardId])
         expect(messages).toHaveLength(1)
-      }).pipe(Effect.provide(MemoryLive)))
+      }).pipe(Effect.provide(MemoryLayer)))
 
     it.effect("detects duplicates", () =>
       Effect.gen(function*() {
@@ -49,7 +49,7 @@ describe("MessageStorage", () => {
           })
         )
         expect(result._tag).toEqual("Duplicate")
-      }).pipe(Effect.provide(MemoryLive)))
+      }).pipe(Effect.provide(MemoryLayer)))
 
     it.effect("unprocessedMessages excludes complete requests", () =>
       Effect.gen(function*() {
@@ -59,7 +59,7 @@ describe("MessageStorage", () => {
         yield* storage.saveReply(yield* makeReply(request))
         const messages = yield* storage.unprocessedMessages([request.envelope.address.shardId])
         expect(messages).toHaveLength(0)
-      }).pipe(Effect.provide(MemoryLive)))
+      }).pipe(Effect.provide(MemoryLayer)))
 
     it.effect("repliesFor", () =>
       Effect.gen(function*() {
@@ -72,7 +72,7 @@ describe("MessageStorage", () => {
         replies = yield* storage.repliesFor([request])
         expect(replies).toHaveLength(1)
         expect(replies[0].requestId).toEqual(request.envelope.requestId)
-      }).pipe(Effect.provide(MemoryLive)))
+      }).pipe(Effect.provide(MemoryLayer)))
 
     it.effect("registerReplyHandler", () =>
       Effect.gen(function*() {
@@ -90,7 +90,7 @@ describe("MessageStorage", () => {
         yield* storage.saveReply(yield* makeReply(request))
         yield* latch.await
         yield* Fiber.await(fiber)
-      }).pipe(Effect.provide(MemoryLive)))
+      }).pipe(Effect.provide(MemoryLayer)))
   })
 })
 

--- a/packages/platform/node/test/cluster/SqlMessageStorage.integration.test.ts
+++ b/packages/platform/node/test/cluster/SqlMessageStorage.integration.test.ts
@@ -35,7 +35,7 @@ const TestEntityLayer = TestEntity.toLayer({
   GetUser: () => Effect.void
 })
 
-const StorageLive = SqlMessageStorage.layer.pipe(
+const StorageLayer = SqlMessageStorage.layer.pipe(
   Layer.provideMerge(Snowflake.layerGenerator),
   Layer.provide([ShardingConfig.layerDefaults, NodeCrypto.layer])
 )
@@ -52,7 +52,7 @@ describe("SqlMessageStorage", () => {
     ["mysql", Layer.orDie(MysqlContainer.layerClient)],
     ["sqlite", Layer.orDie(SqliteLayer)]
   ] as const).forEach(([label, layer]) => {
-    it.layer(StorageLive.pipe(Layer.provideMerge(layer)), {
+    it.layer(StorageLayer.pipe(Layer.provideMerge(layer)), {
       timeout: 120000
     })(label, (it) => {
       it.effect("saveRequest", () =>
@@ -376,7 +376,7 @@ describe("SqlMessageStorage", () => {
       yield* TestClock.adjust(100)
       expect(yield* storage.repliesFor([request])).toHaveLength(1)
       yield* Fiber.interrupt(fiber)
-    }).pipe(Effect.provide(StorageLive.pipe(
+    }).pipe(Effect.provide(StorageLayer.pipe(
       Layer.provideMerge(SqliteLayer)
     ))))
 })

--- a/packages/platform/node/test/cluster/SqlRunnerStorage.integration.test.ts
+++ b/packages/platform/node/test/cluster/SqlRunnerStorage.integration.test.ts
@@ -16,12 +16,12 @@ import { SqlClient, type SqlConnection, SqlError } from "effect/unstable/sql"
 import { MysqlContainer } from "../fixtures/mysql2-utils.ts"
 import { PgContainer } from "../fixtures/pg-utils.ts"
 
-const StorageLive = SqlRunnerStorage.layer
+const StorageLayer = SqlRunnerStorage.layer
 
 describe("SqlRunnerStorage", () => {
   it.effect("bounds shard lock operations and rebuilds an unresponsive reserved connection", () => {
     const partitioned = makePartitionState()
-    const layer = StorageLive.pipe(
+    const layer = StorageLayer.pipe(
       Layer.provideMerge(blackholeReservedConnection(partitioned, true)),
       Layer.provide(ShardingConfig.layer({
         shardLockExpiration: 1000,
@@ -96,7 +96,7 @@ describe("SqlRunnerStorage", () => {
 
   it.effect("recovers when a blackholed query cannot resume after the partition clears", () => {
     const partitioned = makePartitionState()
-    const layer = StorageLive.pipe(
+    const layer = StorageLayer.pipe(
       Layer.provideMerge(blackholeReservedConnection(partitioned, false)),
       Layer.provide(ShardingConfig.layer({
         shardLockDisableAdvisory: true,
@@ -134,7 +134,7 @@ describe("SqlRunnerStorage", () => {
 
   it.effect("rebuilds the reserved connection again when a rebuilt connection stops responding", () => {
     const partitioned = makePartitionState()
-    const layer = StorageLive.pipe(
+    const layer = StorageLayer.pipe(
       Layer.provideMerge(blackholeReservedConnection(partitioned, false)),
       Layer.provide(ShardingConfig.layer({
         shardLockExpiration: 1000,
@@ -179,7 +179,7 @@ describe("SqlRunnerStorage", () => {
 
   it.effect("rebuilds the reserved connection when releasing the previous one hangs", () => {
     const partitioned = makePartitionState()
-    const layer = StorageLive.pipe(
+    const layer = StorageLayer.pipe(
       Layer.provideMerge(blackholeReservedConnection(partitioned, false)),
       Layer.provide(ShardingConfig.layer({
         shardLockDisableAdvisory: true,
@@ -264,10 +264,10 @@ describe("SqlRunnerStorage", () => {
     ["sqlite", Layer.orDie(SqliteLayer)]
   ] as const).flatMap(([label, layer]) =>
     [
-      [label, StorageLive.pipe(Layer.provideMerge(layer), Layer.provide(ShardingConfig.layer()))],
+      [label, StorageLayer.pipe(Layer.provideMerge(layer), Layer.provide(ShardingConfig.layer()))],
       [
         label + " (no advisory)",
-        StorageLive.pipe(
+        StorageLayer.pipe(
           Layer.provideMerge(layer),
           Layer.provide(ShardingConfig.layer({
             shardLockDisableAdvisory: true

--- a/packages/platform/node/test/fixtures/rpc-e2e.ts
+++ b/packages/platform/node/test/fixtures/rpc-e2e.ts
@@ -9,7 +9,7 @@ import type { RpcClientError } from "effect/unstable/rpc/RpcClientError"
 import type * as RpcGroup from "effect/unstable/rpc/RpcGroup"
 import * as RpcServer from "effect/unstable/rpc/RpcServer"
 import * as RpcTest from "effect/unstable/rpc/RpcTest"
-import { AuthClient, AuthLive, TimingLive, User, UserRpcs, UsersLive } from "./rpc-schemas.ts"
+import { AuthClient, AuthLayer, TimingLayer, User, UserRpcs, UsersLayer } from "./rpc-schemas.ts"
 
 export class UsersClient extends Context.Service<
   UsersClient,
@@ -19,7 +19,7 @@ export class UsersClient extends Context.Service<
     Layer.provide(AuthClient)
   )
   static layerTest = Layer.effect(UsersClient)(RpcTest.makeClient(UserRpcs)).pipe(
-    Layer.provide([UsersLive, AuthLive, TimingLive, AuthClient])
+    Layer.provide([UsersLayer, AuthLayer, TimingLayer, AuthClient])
   )
 }
 

--- a/packages/platform/node/test/fixtures/rpc-schemas.ts
+++ b/packages/platform/node/test/fixtures/rpc-schemas.ts
@@ -76,7 +76,7 @@ export const UserRpcs = RpcGroup.make(
   })
 ).middleware(AuthMiddleware)
 
-export const AuthLive = Layer.succeed(AuthMiddleware)(
+export const AuthLayer = Layer.succeed(AuthMiddleware)(
   AuthMiddleware.of((effect, options) =>
     Effect.provideService(
       effect,
@@ -89,7 +89,7 @@ export const AuthLive = Layer.succeed(AuthMiddleware)(
 const rpcSuccesses = Metric.counter("rpc_middleware_success")
 const rpcDefects = Metric.counter("rpc_middleware_defects")
 const rpcCount = Metric.counter("rpc_middleware_count")
-export const TimingLive = Layer.succeed(TimingMiddleware)(
+export const TimingLayer = Layer.succeed(TimingMiddleware)(
   TimingMiddleware.of((effect) =>
     effect.pipe(
       Effect.tap(Metric.update(rpcSuccesses, 1)),
@@ -99,7 +99,7 @@ export const TimingLive = Layer.succeed(TimingMiddleware)(
   )
 )
 
-export const UsersLive = UserRpcs.toLayer(Effect.gen(function*() {
+export const UsersLayer = UserRpcs.toLayer(Effect.gen(function*() {
   let interrupts = 0
   let emits = 0
   return UserRpcs.of({
@@ -158,13 +158,13 @@ export const UsersLive = UserRpcs.toLayer(Effect.gen(function*() {
   })
 }))
 
-export const RpcLive = RpcServer.layer(UserRpcs, {
+export const RpcLayer = RpcServer.layer(UserRpcs, {
   disableFatalDefects: true
 }).pipe(
   Layer.provide([
-    UsersLive,
-    AuthLive,
-    TimingLive
+    UsersLayer,
+    AuthLayer,
+    TimingLayer
   ])
 )
 

--- a/packages/tools/docgen/src/bin.ts
+++ b/packages/tools/docgen/src/bin.ts
@@ -11,12 +11,12 @@ import { cli } from "./CLI.ts"
 import * as Configuration from "./Configuration.ts"
 import * as Domain from "./Domain.ts"
 
-const MainLive = Configuration.configProviderLayer.pipe(
+const MainLayer = Configuration.configProviderLayer.pipe(
   Layer.provideMerge(Layer.mergeAll(Domain.Process.layer, NodeServices.layer))
 )
 
 Effect.sync(() => process.argv.slice(2)).pipe(
   Effect.flatMap(cli),
-  Effect.provide(MainLive),
+  Effect.provide(MainLayer),
   NodeRuntime.runMain
 )

--- a/packages/tools/docgen/test/Configuration.test.ts
+++ b/packages/tools/docgen/test/Configuration.test.ts
@@ -79,7 +79,7 @@ const makeProcess = (env: Record<string, string> = {}) =>
     env: Effect.succeed(env)
   })
 
-const makeTestLive = (env: Record<string, string> = {}) =>
+const makeTestLayer = (env: Record<string, string> = {}) =>
   Configuration.configProviderLayer.pipe(
     Layer.fresh,
     Layer.provideMerge(Layer.mergeAll(
@@ -124,7 +124,7 @@ describe("Configuration", () => {
         examplesCompilerOptions: Configuration.defaultCompilerOptions
       })
     })
-    return testCliFor(program)([]).pipe(Effect.provide(makeTestLive()))
+    return testCliFor(program)([]).pipe(Effect.provide(makeTestLayer()))
   })
 
   it.effect("should use the configuration contained in docgen.json if it exists", () => {
@@ -159,7 +159,7 @@ describe("Configuration", () => {
     })
     return testCliFor(program)([]).pipe(
       Effect.provide(
-        makeTestLive().pipe(Layer.provide(makeDocgenJson({
+        makeTestLayer().pipe(Layer.provide(makeDocgenJson({
           projectHomepage: "myproject",
           srcLink: "mygithub",
           parseCompilerOptions
@@ -172,7 +172,7 @@ describe("Configuration", () => {
     Effect.gen(function*() {
       const result = yield* Effect.exit(
         testCliFor(Effect.void)([]).pipe(
-          Effect.provide(makeTestLive().pipe(Layer.provide(makeDocgenJson({ projectHomepage: 1 } as any))))
+          Effect.provide(makeTestLayer().pipe(Layer.provide(makeDocgenJson({ projectHomepage: 1 } as any))))
         )
       )
       if (Exit.isSuccess(result)) {
@@ -190,7 +190,7 @@ describe("Configuration", () => {
     })
     return testCliFor(program)(["--enable-search", "--enforce-version"]).pipe(
       Effect.provide(
-        makeTestLive().pipe(Layer.provide(makeDocgenJson({
+        makeTestLayer().pipe(Layer.provide(makeDocgenJson({
           enableSearch: false,
           enforceVersion: false
         })))
@@ -206,7 +206,7 @@ describe("Configuration", () => {
     })
     return testCliFor(program)([]).pipe(
       Effect.provide(
-        makeTestLive().pipe(Layer.provide(makeDocgenJson({
+        makeTestLayer().pipe(Layer.provide(makeDocgenJson({
           enableSearch: false,
           enforceVersion: false
         })))
@@ -221,7 +221,7 @@ describe("Configuration", () => {
       assert.isFalse(config.enforceVersion)
     })
     return testCliFor(program)(["--disable-search", "--no-enforce-version"]).pipe(
-      Effect.provide(makeTestLive())
+      Effect.provide(makeTestLayer())
     )
   })
 
@@ -236,7 +236,7 @@ describe("Configuration", () => {
       "--no-enforce-descriptions",
       "--no-enforce-examples",
       "--no-run-examples"
-    ]).pipe(Effect.provide(makeTestLive({
+    ]).pipe(Effect.provide(makeTestLayer({
       DOCGEN_ENFORCE_DESCRIPTIONS: "true",
       DOCGEN_ENFORCE_EXAMPLES: "true",
       DOCGEN_RUN_EXAMPLES: "true"
@@ -250,7 +250,7 @@ describe("Configuration", () => {
     })
     return testCliFor(program)(["--no-run-examples"]).pipe(
       Effect.provide(
-        makeTestLive({ DOCGEN_RUN_EXAMPLES: "true" }).pipe(
+        makeTestLayer({ DOCGEN_RUN_EXAMPLES: "true" }).pipe(
           Layer.provide(makeDocgenJson({ runExamples: true }))
         )
       )
@@ -266,7 +266,7 @@ describe("Configuration", () => {
     })
     return testCliFor(program)([]).pipe(
       Effect.provide(
-        makeTestLive({ DOCGEN_EXCLUDE: "a,b" }).pipe(
+        makeTestLayer({ DOCGEN_EXCLUDE: "a,b" }).pipe(
           Layer.provide(makeDocgenJson({ exclude: ["from-docgen"] }))
         )
       )
@@ -284,7 +284,7 @@ describe("Configuration", () => {
       "{\"strict\":false}",
       "--examples-compiler-options",
       "{\"module\":\"ESNext\"}"
-    ]).pipe(Effect.provide(makeTestLive()))
+    ]).pipe(Effect.provide(makeTestLayer()))
   })
 
   it.effect("rejects both compiler option forms for the same category", () =>
@@ -296,7 +296,7 @@ describe("Configuration", () => {
       for (const [fileFlag, inlineFlag] of cases) {
         const result = yield* Effect.result(
           testCliFor(Effect.void)([fileFlag, existingFile, inlineFlag, "{}"]).pipe(
-            Effect.provide(makeTestLive())
+            Effect.provide(makeTestLayer())
           )
         )
         if (Result.isSuccess(result)) {
@@ -314,7 +314,7 @@ describe("Configuration", () => {
       for (const flag of ["--parse-compiler-options", "--examples-compiler-options"]) {
         for (const value of ["null", "[]", "1", "\"text\""]) {
           const result = yield* Effect.result(
-            testCliFor(Effect.void)([flag, value]).pipe(Effect.provide(makeTestLive()))
+            testCliFor(Effect.void)([flag, value]).pipe(Effect.provide(makeTestLayer()))
           )
           if (Result.isSuccess(result)) {
             return assert.fail(`${flag} should reject ${value}`)

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -184,24 +184,24 @@ export const live: Vitest.Tester<Scope.Scope> = internal.live
  * import { Effect, Layer, Context } from "effect"
  *
  * class Foo extends Context.Service<Foo, "foo">()("Foo") {
- *   static Live = Layer.succeed(Foo, "foo")
+ *   static layer = Layer.succeed(Foo, "foo")
  * }
  *
  * class Bar extends Context.Service<Bar, "bar">()("Bar") {
- *   static Live = Layer.effect(
+ *   static layer = Layer.effect(
  *     Bar,
  *     Effect.map(Foo, () => "bar" as const)
  *   )
  * }
  *
- * layer(Foo.Live)("layer", (it) => {
+ * layer(Foo.layer)("layer", (it) => {
  *   it.effect("adds context", () =>
  *     Effect.gen(function*() {
  *       const foo = yield* Foo
  *       assert.strictEqual(foo, "foo")
  *     }))
  *
- *   it.layer(Bar.Live)("nested", (it) => {
+ *   it.layer(Bar.layer)("nested", (it) => {
  *     it.effect("adds context", () =>
  *       Effect.gen(function*() {
  *         const foo = yield* Foo

--- a/packages/vitest/test/index.test.ts
+++ b/packages/vitest/test/index.test.ts
@@ -84,11 +84,11 @@ it.live.fails("interrupts on timeout", (ctx) =>
   }), 1)
 
 class Foo extends Context.Service<Foo, "foo">()("Foo") {
-  static Live = Layer.succeed(Foo)("foo")
+  static layer = Layer.succeed(Foo)("foo")
 }
 
 class Bar extends Context.Service<Bar, "bar">()("Bar") {
-  static Live = Layer.effect(Bar)(Effect.map(Foo, () => "bar" as const))
+  static layer = Layer.effect(Bar)(Effect.map(Foo, () => "bar" as const))
 }
 
 class Sleeper extends Context.Service<Sleeper, {
@@ -106,14 +106,14 @@ class Sleeper extends Context.Service<Sleeper, {
 }
 
 describe("layer", () => {
-  layer(Foo.Live)((it) => {
+  layer(Foo.layer)((it) => {
     it.effect("adds context", () =>
       Effect.gen(function*() {
         const foo = yield* Foo
         expect(foo).toEqual("foo")
       }))
 
-    it.layer(Bar.Live)("nested", (it) => {
+    it.layer(Bar.layer)("nested", (it) => {
       it.effect("adds context", () =>
         Effect.gen(function*() {
           const foo = yield* Foo
@@ -123,7 +123,7 @@ describe("layer", () => {
         }))
     })
 
-    it.layer(Bar.Live)((it) => {
+    it.layer(Bar.layer)((it) => {
       it.effect("without name", () =>
         Effect.gen(function*() {
           const foo = yield* Foo
@@ -140,7 +140,7 @@ describe("layer", () => {
       })
 
       class Scoped extends Context.Service<Scoped, "scoped">()("Scoped") {
-        static Live = Layer.effect(Scoped)(
+        static layer = Layer.effect(Scoped)(
           Effect.acquireRelease(
             Effect.succeed("scoped" as const),
             () => Effect.sync(() => released = true)
@@ -148,7 +148,7 @@ describe("layer", () => {
         )
       }
 
-      it.layer(Scoped.Live)((it) => {
+      it.layer(Scoped.layer)((it) => {
         it.effect("adds context", () =>
           Effect.gen(function*() {
             const foo = yield* Foo
@@ -183,7 +183,7 @@ describe("layer", () => {
       }))
   })
 
-  layer(Foo.Live)("with a name", (it) => {
+  layer(Foo.layer)("with a name", (it) => {
     describe("with a nested describe", () => {
       it.effect("adds context", () =>
         Effect.gen(function*() {

--- a/packages/vitest/test/nested-isolation.test.ts
+++ b/packages/vitest/test/nested-isolation.test.ts
@@ -8,11 +8,11 @@ describe("nested sibling layers", () => {
   const releasedChildIds: Array<number> = []
 
   class Parent extends Context.Service<Parent, "parent">()("Parent") {
-    static readonly Live = Layer.succeed(Parent)("parent")
+    static readonly layer = Layer.succeed(Parent)("parent")
   }
 
   class Child extends Context.Service<Child, { readonly id: number }>()("Child") {
-    static readonly Live = Layer.effect(Child)(
+    static readonly layer = Layer.effect(Child)(
       Effect.flatMap(Parent, () => {
         const id = ++nextChildId
         return Effect.acquireRelease(
@@ -26,8 +26,8 @@ describe("nested sibling layers", () => {
     )
   }
 
-  layer(Parent.Live)("parent", (it) => {
-    it.layer(Child.Live)("first sibling", (it) => {
+  layer(Parent.layer)("parent", (it) => {
+    it.layer(Child.layer)("first sibling", (it) => {
       it.effect("allocates child", () =>
         Effect.gen(function*() {
           const child = yield* Child
@@ -38,7 +38,7 @@ describe("nested sibling layers", () => {
         }))
     })
 
-    it.layer(Child.Live)("second sibling", (it) => {
+    it.layer(Child.layer)("second sibling", (it) => {
       beforeAll(() => {
         expect(releasedChildIds).toEqual([firstChildId])
       })
@@ -69,11 +69,11 @@ describe.concurrent("nested sibling layers in concurrent suites", () => {
   const releasedSharedIds: Array<number> = []
 
   class Parent extends Context.Service<Parent, "parent">()("ConcurrentParent") {
-    static readonly Live = Layer.succeed(Parent)("parent")
+    static readonly layer = Layer.succeed(Parent)("parent")
   }
 
   class SharedChild extends Context.Service<SharedChild, { readonly id: number }>()("SharedChild") {
-    static readonly Live = Layer.effect(SharedChild)(
+    static readonly layer = Layer.effect(SharedChild)(
       Effect.flatMap(Parent, () =>
         Effect.gen(function*() {
           yield* Effect.promise(() => new Promise<void>((resolve) => setTimeout(resolve, 50)))
@@ -90,9 +90,9 @@ describe.concurrent("nested sibling layers in concurrent suites", () => {
     )
   }
 
-  layer(Parent.Live)("parent", (it) => {
+  layer(Parent.layer)("parent", (it) => {
     describe.concurrent("concurrent siblings", () => {
-      it.layer(SharedChild.Live)("first sibling", (it) => {
+      it.layer(SharedChild.layer)("first sibling", (it) => {
         it.effect("captures shared child", () =>
           Effect.gen(function*() {
             const child = yield* SharedChild
@@ -101,7 +101,7 @@ describe.concurrent("nested sibling layers in concurrent suites", () => {
           }))
       })
 
-      it.layer(SharedChild.Live)("second sibling", (it) => {
+      it.layer(SharedChild.layer)("second sibling", (it) => {
         it.effect("allocates an isolated child", () =>
           Effect.gen(function*() {
             const child = yield* SharedChild
@@ -127,7 +127,7 @@ describe("nested sibling isolation with provided state graph", () => {
   }
 
   class Parent extends Context.Service<Parent, "parent">()("ProvidedParent") {
-    static readonly Live = Layer.succeed(Parent)("parent")
+    static readonly layer = Layer.succeed(Parent)("parent")
   }
 
   class State extends Context.Service<State, StateShape>()("ProvidedState") {}
@@ -176,7 +176,7 @@ describe("nested sibling isolation with provided state graph", () => {
     })
   ).pipe(Layer.provide(migratedLayer))
 
-  layer(Parent.Live)("parent", (it) => {
+  layer(Parent.layer)("parent", (it) => {
     it.layer(inMemoryLayer)("first sibling", (it) => {
       it.effect("mutates isolated provided state", () =>
         Effect.gen(function*() {


### PR DESCRIPTION
## Summary

- rename genuine layer identifiers from the `Live` suffix to `Layer`
- rename static class layer properties and references from `.Live` to lower-camel `.layer`
- update shipped code, public examples, internal tooling, fixtures, and tests while preserving incidental/config uses of “live”

## Validation

- `pnpm exec dprint fmt`
- `pnpm check`
- `pnpm lint`
- affected Vitest suite: 390 passed, 1 expected failure, 5 skipped
- docgen configuration suite: 12 passed

Closes EFF-613