### PR TITLE
Scope message storage address clearing to shard

### DIFF
--- a/.changeset/scope-message-storage-clear-address.md
+++ b/.changeset/scope-message-storage-clear-address.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Scope `MessageStorage.clearAddress` deletions to the addressed shard.

--- a/packages/effect/src/unstable/cluster/MessageStorage.ts
+++ b/packages/effect/src/unstable/cluster/MessageStorage.ts
@@ -991,21 +991,20 @@ export class MemoryDriver extends Context.Service<MemoryDriver>()("effect/cluste
       resetAddress: () => Effect.void,
       clearAddress: (address) =>
         Effect.sync(() => {
+          const sameAddress = (envelope: Envelope.Encoded) =>
+            address.shardId.group === envelope.address.shardId.group &&
+            address.shardId.id === envelope.address.shardId.id &&
+            address.entityType === envelope.address.entityType &&
+            address.entityId === envelope.address.entityId
           for (const [primaryKey, entry] of requestsByPrimaryKey) {
             const envelope = entry.envelope
-            const sameAddress = ShardId.toString(address.shardId) === ShardId.toString(envelope.address.shardId) &&
-              address.entityType === envelope.address.entityType &&
-              address.entityId === envelope.address.entityId
-            if (sameAddress) {
+            if (sameAddress(envelope)) {
               requestsByPrimaryKey.delete(primaryKey)
             }
           }
           for (let i = journal.length - 1; i >= 0; i--) {
             const envelope = journal[i]
-            const sameAddress = ShardId.toString(address.shardId) === ShardId.toString(envelope.address.shardId) &&
-              address.entityType === envelope.address.entityType &&
-              address.entityId === envelope.address.entityId
-            if (!sameAddress || envelope._tag !== "Request") {
+            if (!sameAddress(envelope) || envelope._tag !== "Request") {
               continue
             }
             unprocessed.delete(envelope)

--- a/packages/effect/src/unstable/cluster/MessageStorage.ts
+++ b/packages/effect/src/unstable/cluster/MessageStorage.ts
@@ -993,7 +993,8 @@ export class MemoryDriver extends Context.Service<MemoryDriver>()("effect/cluste
         Effect.sync(() => {
           for (const [primaryKey, entry] of requestsByPrimaryKey) {
             const envelope = entry.envelope
-            const sameAddress = address.entityType === envelope.address.entityType &&
+            const sameAddress = ShardId.toString(address.shardId) === ShardId.toString(envelope.address.shardId) &&
+              address.entityType === envelope.address.entityType &&
               address.entityId === envelope.address.entityId
             if (sameAddress) {
               requestsByPrimaryKey.delete(primaryKey)
@@ -1001,7 +1002,8 @@ export class MemoryDriver extends Context.Service<MemoryDriver>()("effect/cluste
           }
           for (let i = journal.length - 1; i >= 0; i--) {
             const envelope = journal[i]
-            const sameAddress = address.entityType === envelope.address.entityType &&
+            const sameAddress = ShardId.toString(address.shardId) === ShardId.toString(envelope.address.shardId) &&
+              address.entityType === envelope.address.entityType &&
               address.entityId === envelope.address.entityId
             if (!sameAddress || envelope._tag !== "Request") {
               continue

--- a/packages/effect/src/unstable/cluster/SqlMessageStorage.ts
+++ b/packages/effect/src/unstable/cluster/SqlMessageStorage.ts
@@ -642,14 +642,16 @@ export const make: (options?: {
         DELETE FROM ${repliesTableSql}
         WHERE request_id IN (
           SELECT id FROM ${messagesTableSql}
-          WHERE entity_type = ${address.entityType}
+          WHERE shard_id = ${address.shardId.toString()}
+          AND entity_type = ${address.entityType}
           AND entity_id = ${address.entityId}
         )
       `.pipe(
         Effect.andThen(
           sql`
             DELETE FROM ${messagesTableSql}
-            WHERE entity_type = ${address.entityType}
+            WHERE shard_id = ${address.shardId.toString()}
+            AND entity_type = ${address.entityType}
             AND entity_id = ${address.entityId}
           `
         ),

--- a/packages/effect/test/cluster/MessageStorage.test.ts
+++ b/packages/effect/test/cluster/MessageStorage.test.ts
@@ -49,6 +49,54 @@ describe("MessageStorage", () => {
         expect(result._tag).toEqual("Success")
       }).pipe(Effect.provide(MessageStorage.MemoryDriver.layer)))
 
+    it.effect("clears messages and replies only from the matching shard", () =>
+      Effect.gen(function*() {
+        const storage = yield* MessageStorage.MessageStorage
+        const entityType = EntityType.make("Repro")
+        const entityId = EntityId.make("one")
+        const targetAddress = EntityAddress.make({
+          shardId: ShardId.make("default", 1),
+          entityType,
+          entityId
+        })
+        const preservedAddress = EntityAddress.make({
+          shardId: ShardId.make("default", 2),
+          entityType,
+          entityId
+        })
+        const target = yield* makeRequest({
+          rpc: PrimaryKeyTest,
+          payload: PrimaryKeyTest.payloadSchema.make({ id: 1 }),
+          address: targetAddress
+        })
+        const preserved = yield* makeRequest({
+          rpc: PrimaryKeyTest,
+          payload: PrimaryKeyTest.payloadSchema.make({ id: 2 }),
+          address: preservedAddress
+        })
+        yield* storage.saveRequest(target)
+        yield* storage.saveRequest(preserved)
+        yield* storage.saveReply(yield* makeReply(target))
+        yield* storage.saveReply(yield* makeReply(preserved))
+
+        yield* storage.clearAddress(targetAddress)
+
+        const targetId = yield* storage.requestIdForPrimaryKey({
+          address: targetAddress,
+          tag: target.envelope.tag,
+          id: "1"
+        })
+        const preservedId = yield* storage.requestIdForPrimaryKey({
+          address: preservedAddress,
+          tag: preserved.envelope.tag,
+          id: "2"
+        })
+        expect(targetId).toEqual(Option.none())
+        expect(preservedId).toEqual(Option.some(preserved.envelope.requestId))
+        expect(yield* storage.repliesForUnfiltered([target.envelope.requestId])).toHaveLength(0)
+        expect(yield* storage.repliesForUnfiltered([preserved.envelope.requestId])).toHaveLength(1)
+      }).pipe(Effect.provide(MemoryLayer)))
+
     it.effect("saves a request", () =>
       Effect.gen(function*() {
         const storage = yield* MessageStorage.MessageStorage
@@ -127,17 +175,19 @@ export const GetUserRpc = Rpc.make("GetUser", {
 export const makeRequest = Effect.fnUntraced(function*(options?: {
   readonly rpc?: Rpc.AnyWithProps
   readonly payload?: any
+  readonly address?: EntityAddress.EntityAddress
 }) {
   const snowflake = yield* Snowflake.Generator
   const rpc = options?.rpc ?? GetUserRpc
   return new Message.OutgoingRequest({
     envelope: Envelope.makeRequest<any>({
       requestId: snowflake.nextUnsafe(),
-      address: EntityAddress.make({
-        shardId: ShardId.make("default", 1),
-        entityType: EntityType.make("test"),
-        entityId: EntityId.make("1")
-      }),
+      address: options?.address ??
+        EntityAddress.make({
+          shardId: ShardId.make("default", 1),
+          entityType: EntityType.make("test"),
+          entityId: EntityId.make("1")
+        }),
       tag: rpc._tag,
       payload: options?.payload ?? { id: 123 },
       traceId: "noop",

--- a/packages/platform/node/test/cluster/MessageStorageTest.ts
+++ b/packages/platform/node/test/cluster/MessageStorageTest.ts
@@ -101,17 +101,19 @@ export const GetUserRpc = Rpc.make("GetUser", {
 export const makeRequest = Effect.fnUntraced(function*(options?: {
   readonly rpc?: Rpc.AnyWithProps
   readonly payload?: any
+  readonly address?: EntityAddress.EntityAddress
 }) {
   const snowflake = yield* Snowflake.Generator
   const rpc = options?.rpc ?? GetUserRpc
   return new Message.OutgoingRequest({
     envelope: Envelope.makeRequest<any>({
       requestId: snowflake.nextUnsafe(),
-      address: EntityAddress.make({
-        shardId: ShardId.make("default", 1),
-        entityType: EntityType.make("test"),
-        entityId: EntityId.make("1")
-      }),
+      address: options?.address ??
+        EntityAddress.make({
+          shardId: ShardId.make("default", 1),
+          entityType: EntityType.make("test"),
+          entityId: EntityId.make("1")
+        }),
       tag: rpc._tag,
       payload: options?.payload ?? { id: 123 },
       traceId: "noop",

--- a/packages/platform/node/test/cluster/SqlMessageStorage.integration.test.ts
+++ b/packages/platform/node/test/cluster/SqlMessageStorage.integration.test.ts
@@ -5,12 +5,16 @@ import { Effect, Fiber, FileSystem, Latch, Layer, Option } from "effect"
 import { TestClock } from "effect/testing"
 import {
   Entity,
+  EntityAddress,
+  EntityId,
+  EntityType,
   Envelope,
   Message,
   MessageStorage,
   RunnerHealth,
   Runners,
   RunnerStorage,
+  ShardId,
   Sharding,
   ShardingConfig,
   Snowflake,
@@ -78,6 +82,56 @@ describe("SqlMessageStorage", () => {
           messages = yield* storage.unprocessedMessages([request.envelope.address.shardId])
           expect(messages).toHaveLength(5)
           expect(messages.map((m: any) => m.envelope.payload.id)).toEqual([6, 7, 8, 9, 10])
+        }))
+
+      it.effect("clearAddress scopes messages and replies to the matching shard", () =>
+        Effect.gen(function*() {
+          yield* truncate
+
+          const storage = yield* MessageStorage.MessageStorage
+          const entityType = EntityType.make("Repro")
+          const entityId = EntityId.make("one")
+          const targetAddress = EntityAddress.make({
+            shardId: ShardId.make("default", 1),
+            entityType,
+            entityId
+          })
+          const preservedAddress = EntityAddress.make({
+            shardId: ShardId.make("default", 2),
+            entityType,
+            entityId
+          })
+          const target = yield* makeRequest({
+            rpc: PrimaryKeyTest,
+            payload: PrimaryKeyTest.payloadSchema.make({ id: 1 }),
+            address: targetAddress
+          })
+          const preserved = yield* makeRequest({
+            rpc: PrimaryKeyTest,
+            payload: PrimaryKeyTest.payloadSchema.make({ id: 2 }),
+            address: preservedAddress
+          })
+          yield* storage.saveRequest(target)
+          yield* storage.saveRequest(preserved)
+          yield* storage.saveReply(yield* makeReply(target))
+          yield* storage.saveReply(yield* makeReply(preserved))
+
+          yield* storage.clearAddress(targetAddress)
+
+          const targetId = yield* storage.requestIdForPrimaryKey({
+            address: targetAddress,
+            tag: target.envelope.tag,
+            id: "1"
+          })
+          const preservedId = yield* storage.requestIdForPrimaryKey({
+            address: preservedAddress,
+            tag: preserved.envelope.tag,
+            id: "2"
+          })
+          expect(targetId).toEqual(Option.none())
+          expect(preservedId).toEqual(Option.some(preserved.envelope.requestId))
+          expect(yield* storage.repliesForUnfiltered([target.envelope.requestId])).toHaveLength(0)
+          expect(yield* storage.repliesForUnfiltered([preserved.envelope.requestId])).toHaveLength(1)
         }))
 
       it.effect("saveReply + saveRequest duplicate", () =>


### PR DESCRIPTION
## Summary

- include `shard_id` when clearing messages and replies from SQL storage
- include the encoded shard id when matching addresses in memory storage
- cover cross-shard preservation through the public `MessageStorage` interface in memory, PostgreSQL, MySQL, and SQLite

## Why

`clearAddress` previously matched only entity type and entity id. When the same entity address values existed on multiple acquired shards, clearing one shard could remove another shard's messages and replies.

## Validation

- `pnpm vitest packages/effect/test/cluster/MessageStorage.test.ts --run`
- `EFFECT_INTEGRATION_TESTS=1 pnpm vitest packages/platform/node/test/cluster/SqlMessageStorage.integration.test.ts --run --project @effect/platform-node`
- `pnpm lint`
- `pnpm check`

Closes EFF-616