### PR TITLE
Add Inspectable.format migration guidance

### DIFF
--- a/migration/annotations/effect__Inspectable.yaml
+++ b/migration/annotations/effect__Inspectable.yaml
@@ -1,3 +1,6 @@
+"effect/Inspectable#format":
+  replacement: "Formatter.formatJson"
+  note: "Use Formatter.formatJson(input, { space: 2 }) to preserve the v3 helper's pretty-printed JSON output."
 "effect/Inspectable#redact":
   replacement: "Redactable.redact"
   note: "The redaction protocol moved to Redactable and now receives the current fiber Context."

--- a/migration/v3-to-v4.md
+++ b/migration/v3-to-v4.md
@@ -4,7 +4,7 @@
 
 Base: `3d390f232bdbc3f0d3d6a2ae3c775084f494b547` (`3d390f232bdbc3f0d3d6a2ae3c775084f494b547`)
 
-Head: `main` (`b938c8ad2823bd88493187922f7d9090eff037b6`)
+Head: `origin/main` (`03031395d3ddee197217f826e7d9ef68b0674823`)
 
 This file is generated from the API diff and `migration/annotations/*.yaml`.
 
@@ -10774,6 +10774,8 @@ stream.pipe(
 - `HashSet.values` -> `none`: The HashSet itself is iterable; iterate it directly or call self[Symbol.iterator]() when an iterator object is required.
 
 ### `effect/Inspectable`
+
+- `Inspectable.format` -> `Formatter.formatJson`: Use Formatter.formatJson(input, { space: 2 }) to preserve the v3 helper's pretty-printed JSON output.
 
 - `Inspectable.redact` -> `Redactable.redact`: The redaction protocol moved to Redactable and now receives the current fiber Context.
 


### PR DESCRIPTION
## Summary

- document `Formatter.formatJson(input, { space: 2 })` as the v4 replacement for `Inspectable.format`
- regenerate the v3-to-v4 reference against main at `03031395d3ddee197217f826e7d9ef68b0674823`

## Why

The recent formatter refactor exposed `effect/Inspectable#format` as the only migration API without guidance. The replacement preserves the v3 helper's pretty-printed JSON behavior.

## Validation

- `pnpm api-diff --base-ref 3d390f232bdbc3f0d3d6a2ae3c775084f494b547 --head-ref origin/main --check`
- `pnpm lint-fix`
- `git diff --check`

Closes EFF-618