### PR TITLE
Fix flaky workflow suspension race test

### DIFF
--- a/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
+++ b/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
@@ -462,10 +462,11 @@ describe.concurrent("ClusterWorkflowEngine", () => {
           Effect.forkChild({ startImmediately: true })
         )
 
-        // both branches park, the suspension commits, and the ensuring sleep
-        // keeps the run from settling
-        yield* TestClock.adjust(1)
-        yield* TestClock.adjust(1)
+        // Wait until both branches have parked and the ensuring sleep has
+        // started, so the completion deterministically lands during unwind.
+        while (flags.get("slow-unwind-started") !== true) {
+          yield* Effect.yieldNow
+        }
 
         const token = DurableDeferred.tokenFromExecutionId(SlowUnwindGateB, {
           workflow: SlowUnwindWorkflow,
@@ -1274,7 +1275,11 @@ const SlowUnwindWorkflowLayer = SlowUnwindWorkflow.toLayer(Effect.fnUntraced(fun
     ]
   }).pipe(
     // slows the unwind so completions can land while a suspension commits
-    Effect.ensuring(Effect.sleep("10 seconds"))
+    Effect.ensuring(
+      Effect.sync(() => flags.set("slow-unwind-started", true)).pipe(
+        Effect.andThen(Effect.sleep("10 seconds"))
+      )
+    )
   )
 }))
 


### PR DESCRIPTION
Closes EFF-619

## Summary

- replace fixed `TestClock` advances with an explicit barrier that observes the slow unwind starting
- deliver the deferred completion only after the race branches have parked, making the suspension-commit scenario deterministic

## Root cause

Under load, the test could complete `SlowUnwindGateB` before the initial workflow run reached its `ensuring` unwind. The workflow then correctly read the completion on its first run, so `slow-unwind-runs` was `1` even though the workflow returned the expected value.

## Validation

- targeted regression test passed 30 consecutive isolated runs
- `ClusterWorkflowEngine.test.ts`: 26/26 passed
- `pnpm check`
- `pnpm lint`