### PR TITLE
Add HttpStatus module with fromLiteral and centralize status mappings

### DIFF
--- a/.changeset/http-status-from-literal.md
+++ b/.changeset/http-status-from-literal.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add a `HttpStatus` module to `effect/unstable/http` that centralizes the mapping from HTTP status literal names to numeric codes and exports `HttpStatus.fromLiteral`. `HttpApiSchema.status` now consumes the new module.

--- a/packages/effect/src/unstable/http/HttpStatus.ts
+++ b/packages/effect/src/unstable/http/HttpStatus.ts
@@ -1,0 +1,100 @@
+/**
+ * Named HTTP status codes for the unstable HTTP modules.
+ *
+ * This module centralizes the mapping from literal names of the known HTTP
+ * status codes, such as `"OK"` and `"Conflict"`, to their numeric codes. Use
+ * {@link fromLiteral} to obtain a status code from a literal name instead of
+ * remembering raw numbers.
+ *
+ * @since 4.0.0
+ */
+
+const codeByLiteral = {
+  Continue: 100,
+  SwitchingProtocols: 101,
+  Processing: 102,
+  EarlyHints: 103,
+  OK: 200,
+  Ok: 200,
+  Created: 201,
+  Accepted: 202,
+  NonAuthoritativeInformation: 203,
+  NoContent: 204,
+  ResetContent: 205,
+  PartialContent: 206,
+  MultiStatus: 207,
+  AlreadyReported: 208,
+  ImUsed: 226,
+  MultipleChoices: 300,
+  MovedPermanently: 301,
+  Found: 302,
+  SeeOther: 303,
+  NotModified: 304,
+  TemporaryRedirect: 307,
+  PermanentRedirect: 308,
+  BadRequest: 400,
+  Unauthorized: 401,
+  PaymentRequired: 402,
+  Forbidden: 403,
+  NotFound: 404,
+  MethodNotAllowed: 405,
+  NotAcceptable: 406,
+  ProxyAuthenticationRequired: 407,
+  RequestTimeout: 408,
+  Conflict: 409,
+  Gone: 410,
+  LengthRequired: 411,
+  PreconditionFailed: 412,
+  PayloadTooLarge: 413,
+  UriTooLong: 414,
+  UnsupportedMediaType: 415,
+  RangeNotSatisfiable: 416,
+  ExpectationFailed: 417,
+  ImATeapot: 418,
+  MisdirectedRequest: 421,
+  UnprocessableEntity: 422,
+  Locked: 423,
+  FailedDependency: 424,
+  TooEarly: 425,
+  UpgradeRequired: 426,
+  PreconditionRequired: 428,
+  TooManyRequests: 429,
+  RequestHeaderFieldsTooLarge: 431,
+  UnavailableForLegalReasons: 451,
+  InternalServerError: 500,
+  NotImplemented: 501,
+  BadGateway: 502,
+  ServiceUnavailable: 503,
+  GatewayTimeout: 504,
+  HttpVersionNotSupported: 505,
+  VariantAlsoNegotiates: 506,
+  InsufficientStorage: 507,
+  LoopDetected: 508,
+  NotExtended: 510,
+  NetworkAuthenticationRequired: 511
+} as const
+
+/**
+ * Union of literal names for the known HTTP status codes.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type Literal = keyof typeof codeByLiteral
+
+/**
+ * Returns the numeric HTTP status code for a literal name.
+ *
+ * **Example** (Obtaining status codes from literal names)
+ *
+ * ```ts import.meta.vitest
+ * import { HttpStatus } from "effect/unstable/http"
+ *
+ * HttpStatus.fromLiteral("OK") // => 200
+ * HttpStatus.fromLiteral("Conflict") // => 409
+ * ```
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const fromLiteral = <L extends Literal>(literal: L): (typeof codeByLiteral)[L] => codeByLiteral[literal]

--- a/packages/effect/src/unstable/http/index.ts
+++ b/packages/effect/src/unstable/http/index.ts
@@ -117,6 +117,11 @@ export * as HttpStaticServer from "./HttpStaticServer.ts"
 /**
  * @since 4.0.0
  */
+export * as HttpStatus from "./HttpStatus.ts"
+
+/**
+ * @since 4.0.0
+ */
 export * as HttpTraceContext from "./HttpTraceContext.ts"
 
 /**

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -17,6 +17,7 @@ import * as SchemaTransformation from "../../SchemaTransformation.ts"
 import * as Stream from "../../Stream.ts"
 import type * as Sse from "../encoding/Sse.ts"
 import { hasBody, type HttpMethod } from "../http/HttpMethod.ts"
+import * as HttpStatus from "../http/HttpStatus.ts"
 import type * as Multipart_ from "../http/Multipart.ts"
 
 declare module "../../Schema.ts" {
@@ -87,71 +88,6 @@ export type ResponseEncoding = {
   readonly contentType: string
 }
 
-const statusCodeByLiteral = {
-  Continue: 100,
-  SwitchingProtocols: 101,
-  Processing: 102,
-  EarlyHints: 103,
-  OK: 200,
-  Ok: 200,
-  Created: 201,
-  Accepted: 202,
-  NonAuthoritativeInformation: 203,
-  NoContent: 204,
-  ResetContent: 205,
-  PartialContent: 206,
-  MultiStatus: 207,
-  AlreadyReported: 208,
-  ImUsed: 226,
-  MultipleChoices: 300,
-  MovedPermanently: 301,
-  Found: 302,
-  SeeOther: 303,
-  NotModified: 304,
-  TemporaryRedirect: 307,
-  PermanentRedirect: 308,
-  BadRequest: 400,
-  Unauthorized: 401,
-  PaymentRequired: 402,
-  Forbidden: 403,
-  NotFound: 404,
-  MethodNotAllowed: 405,
-  NotAcceptable: 406,
-  ProxyAuthenticationRequired: 407,
-  RequestTimeout: 408,
-  Conflict: 409,
-  Gone: 410,
-  LengthRequired: 411,
-  PreconditionFailed: 412,
-  PayloadTooLarge: 413,
-  UriTooLong: 414,
-  UnsupportedMediaType: 415,
-  RangeNotSatisfiable: 416,
-  ExpectationFailed: 417,
-  ImATeapot: 418,
-  MisdirectedRequest: 421,
-  UnprocessableEntity: 422,
-  Locked: 423,
-  FailedDependency: 424,
-  TooEarly: 425,
-  UpgradeRequired: 426,
-  PreconditionRequired: 428,
-  TooManyRequests: 429,
-  RequestHeaderFieldsTooLarge: 431,
-  UnavailableForLegalReasons: 451,
-  InternalServerError: 500,
-  NotImplemented: 501,
-  BadGateway: 502,
-  ServiceUnavailable: 503,
-  GatewayTimeout: 504,
-  HttpVersionNotSupported: 505,
-  VariantAlsoNegotiates: 506,
-  InsufficientStorage: 507,
-  LoopDetected: 508,
-  NotExtended: 510,
-  NetworkAuthenticationRequired: 511
-} as const
-
 const StreamSchemaTypeId = "~effect/httpapi/HttpApiSchema/Stream"
 
 /**
@@ -160,7 +96,7 @@ const StreamSchemaTypeId = "~effect/httpapi/HttpApiSchema/Stream"
  * @category models
  * @since 4.0.0
  */
-export type StatusLiteral = keyof typeof statusCodeByLiteral
+export type StatusLiteral = HttpStatus.Literal
 
 /**
  * Sets the HTTP status code of a schema.
@@ -181,7 +117,7 @@ export function status(code: StatusLiteral): {
   <S extends Schema.Top>(self: S): S["Rebuild"]
 }
 export function status(code: number | StatusLiteral) {
-  const statusCode = typeof code === "string" ? statusCodeByLiteral[code] : code
+  const statusCode = typeof code === "string" ? HttpStatus.fromLiteral(code) : code
   return <S extends Schema.Top>(self: S): S["Rebuild"] => self.annotate({ httpApiStatus: statusCode })
 }
 

--- a/packages/effect/test/unstable/http/HttpStatus.test.ts
+++ b/packages/effect/test/unstable/http/HttpStatus.test.ts
@@ -1,0 +1,16 @@
+import { describe, it } from "@effect/vitest"
+import { strictEqual } from "@effect/vitest/utils"
+import { HttpStatus } from "effect/unstable/http"
+
+describe("HttpStatus", () => {
+  it("fromLiteral returns the numeric status code", () => {
+    strictEqual(HttpStatus.fromLiteral("Continue"), 100)
+    strictEqual(HttpStatus.fromLiteral("OK"), 200)
+    strictEqual(HttpStatus.fromLiteral("Ok"), 200)
+    strictEqual(HttpStatus.fromLiteral("Created"), 201)
+    strictEqual(HttpStatus.fromLiteral("MovedPermanently"), 301)
+    strictEqual(HttpStatus.fromLiteral("Conflict"), 409)
+    strictEqual(HttpStatus.fromLiteral("InternalServerError"), 500)
+    strictEqual(HttpStatus.fromLiteral("NetworkAuthenticationRequired"), 511)
+  })
+})

--- a/packages/effect/test/unstable/httpapi/HttpApiSchema.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiSchema.test.ts
@@ -274,4 +274,11 @@ describe("HttpApiSchema", () => {
     assert.isFalse(HttpApiSchema.isStreamSchema(Schema.String))
     assert.isFalse(HttpApiSchema.isStreamSchema(Schema.Uint8Array.pipe(HttpApiSchema.asUint8Array())))
   })
+
+  describe("status", () => {
+    it("accepts status literals", () => {
+      assert.strictEqual(HttpApiSchema.getStatusSuccess(Schema.String.pipe(HttpApiSchema.status("Created")).ast), 201)
+      assert.strictEqual(HttpApiSchema.getStatusError(Schema.String.pipe(HttpApiSchema.status("Conflict")).ast), 409)
+    })
+  })
 })


### PR DESCRIPTION
Adds a new `HttpStatus` module to `effect/unstable/http`, alongside `HttpMethod`, that centralizes the mapping from HTTP status literal names to numeric codes.

- `HttpStatus.Literal` is the union of known status literal names.
- `HttpStatus.fromLiteral` returns the numeric code for a literal, with the exact literal code preserved in the return type (`fromLiteral("OK")` is typed `200`).
- `HttpApiSchema` now consumes the new module: the local `statusCodeByLiteral` map is removed, `StatusLiteral` is an alias of `HttpStatus.Literal`, and `status()` resolves literals via `HttpStatus.fromLiteral`.

Includes tests for `HttpStatus.fromLiteral` and literal handling in `HttpApiSchema.status`, plus a runnable JSDoc example and a changeset.

Validation: `pnpm lint-fix`, targeted `pnpm vitest --run --project effect` on the two test files (23 passed), `pnpm doctest --run` on the new module, and `pnpm check`.

Closes EFF-621
Closes #6884

🤖 Generated with [Claude Code](https://claude.com/claude-code)
