### PR TITLE
Stabilize DurableDeferred race replay test

### DIFF
--- a/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
+++ b/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
@@ -266,7 +266,7 @@ describe.concurrent("ClusterWorkflowEngine", () => {
         yield* TestClock.adjust(1)
         yield* TestClock.adjust("1 second")
         while (flags.get("losing-deferred-tail-runs") !== 1) {
-          yield* Effect.yieldNow
+          yield* TestClock.adjust("1 second")
         }
 
         const token = DurableDeferred.tokenFromExecutionId(LosingDeferredGate, {


### PR DESCRIPTION
## Summary

Advance the test clock while waiting for the losing-deferred workflow to enter its tail activity.

## Root cause

The test advanced virtual time by a fixed amount and then only yielded. Under load, the workflow could install its one-second activity timer after that advance, leaving virtual time frozen and the readiness loop spinning until the 20-second timeout.

## Validation

- reproduced the timeout under a forced late-start schedule
- verified the adverse schedule passes with the fix
- 20 repeated targeted runs
- full `ClusterWorkflowEngine.test.ts` suite (26 tests)
- `pnpm lint`

Closes EFF-628