### PR TITLE
Migrate NodeRedis from ioredis to redis (node-redis)

### DIFF
--- a/.changeset/node-redis-client.md
+++ b/.changeset/node-redis-client.md
@@ -2,34 +2,8 @@
 "@effect/platform-node": patch
 ---
 
-Migrate `NodeRedis` from `ioredis` to the `redis` (node-redis) client.
+Migrate `NodeRedis` from `ioredis` to `redis` (node-redis), replacing the peer dependency with `redis: >=5.0.0 <7.0.0`.
 
-`ioredis` is deprecated in favour of [`node-redis`](https://redis.io/docs/latest/develop/clients/nodejs/), so `NodeRedis` now builds on it. Replace the `ioredis` peer dependency with `redis`:
+`layer` and `layerConfig` now accept `RedisClientOptions`: socket settings move under `socket`, `db` becomes `database`, command methods are camelCase, and arbitrary commands use `sendCommand`. Clients use RESP2 by default.
 
-```sh
-npm uninstall ioredis && npm install redis
-```
-
-**Connection options**
-
-`NodeRedis.layer` and `NodeRedis.layerConfig` now take node-redis' `RedisClientOptions` instead of ioredis' `RedisOptions`. Socket settings move under `socket`, and `db` is renamed to `database`:
-
-```ts
-// before
-NodeRedis.layer({ host: "localhost", port: 6379, db: 1 })
-
-// after
-NodeRedis.layer({ socket: { host: "localhost", port: 6379 }, database: 1 })
-```
-
-A `url` can be used instead: `NodeRedis.layer({ url: "redis://localhost:6379/1" })`.
-
-**Layer construction can now fail**
-
-`node-redis` connects explicitly, so both layers connect while being built and now carry `RedisError` in their error channel. By default the initial connection fails on its first connection error. A caller-supplied `socket.reconnectStrategy` overrides this behavior; after the client is ready, the default reconnect strategy uses node-redis' exponential backoff and stops on socket timeouts.
-
-Scope finalization calls `close()`, which waits for in-flight commands, including blocking commands, and can therefore delay scope closure.
-
-**Direct client access**
-
-`NodeRedis.NodeRedis` exposes a RESP2 `RedisClientType` rather than an `ioredis` client. Command methods are camelCase (`client.lRange` instead of `client.lrange`), and arbitrary commands use `client.sendCommand([...])` instead of `client.call(...)`. RESP2 is pinned for stable reply shapes; opting into RESP3 requires an untyped options escape hatch. See the [migration guide](https://redis.io/docs/latest/develop/clients/nodejs/migration/) for the full API comparison.
+Layers connect while being built and can fail with `RedisError`. Initial connections fail fast unless a `socket.reconnectStrategy` is provided; after `ready`, the default reconnect behavior applies. Scope finalization uses `close()`, so in-flight or blocking commands can delay closure.

--- a/.changeset/node-redis-client.md
+++ b/.changeset/node-redis-client.md
@@ -4,6 +4,6 @@
 
 Migrate `NodeRedis` from `ioredis` to `redis` (node-redis), replacing the peer dependency with `redis: >=5.0.0 <7.0.0`.
 
-`layer` and `layerConfig` now accept `RedisClientOptions`: socket settings move under `socket`, `db` becomes `database`, command methods are camelCase, and arbitrary commands use `sendCommand`. Clients use RESP2 by default.
+`layer` and `layerConfig` now accept `RedisClientOptions`: socket settings move under `socket`, `db` becomes `database`, command methods are camelCase, and arbitrary commands use `sendCommand`. Protocol selection follows the installed node-redis version's default.
 
 Layers connect while being built and can fail with `RedisError`. Initial connections fail fast unless a `socket.reconnectStrategy` is provided; after `ready`, the default reconnect behavior applies. Scope finalization uses `close()`, so in-flight or blocking commands can delay closure.

--- a/.changeset/node-redis-client.md
+++ b/.changeset/node-redis-client.md
@@ -1,0 +1,33 @@
+---
+"@effect/platform-node": patch
+---
+
+Migrate `NodeRedis` from `ioredis` to the `redis` (node-redis) client.
+
+`ioredis` is deprecated in favour of [`node-redis`](https://redis.io/docs/latest/develop/clients/nodejs/), so `NodeRedis` now builds on it. Replace the `ioredis` peer dependency with `redis`:
+
+```sh
+npm uninstall ioredis && npm install redis
+```
+
+**Connection options**
+
+`NodeRedis.layer` and `NodeRedis.layerConfig` now take node-redis' `RedisClientOptions` instead of ioredis' `RedisOptions`. Socket settings move under `socket`, and `db` is renamed to `database`:
+
+```ts
+// before
+NodeRedis.layer({ host: "localhost", port: 6379, db: 1 })
+
+// after
+NodeRedis.layer({ socket: { host: "localhost", port: 6379 }, database: 1 })
+```
+
+A `url` can be used instead: `NodeRedis.layer({ url: "redis://localhost:6379/1" })`.
+
+**Layer construction can now fail**
+
+`node-redis` connects explicitly, so both layers connect while being built and now carry `RedisError` in their error channel. By default `node-redis` retries the initial connection indefinitely; pass `socket: { reconnectStrategy: false }` to fail on the first connection error instead.
+
+**Direct client access**
+
+`NodeRedis.NodeRedis` exposes a `RedisClientType` rather than an `ioredis` client. Command methods are camelCase (`client.lRange` instead of `client.lrange`), arbitrary commands use `client.sendCommand([...])` instead of `client.call(...)`, and node-redis 6 speaks RESP3 by default — pass `RESP: 2` to keep RESP2 reply shapes. See the [migration guide](https://redis.io/docs/latest/develop/clients/nodejs/migration/) for the full API comparison.

--- a/.changeset/node-redis-client.md
+++ b/.changeset/node-redis-client.md
@@ -26,8 +26,10 @@ A `url` can be used instead: `NodeRedis.layer({ url: "redis://localhost:6379/1" 
 
 **Layer construction can now fail**
 
-`node-redis` connects explicitly, so both layers connect while being built and now carry `RedisError` in their error channel. By default `node-redis` retries the initial connection indefinitely; pass `socket: { reconnectStrategy: false }` to fail on the first connection error instead.
+`node-redis` connects explicitly, so both layers connect while being built and now carry `RedisError` in their error channel. By default the initial connection fails on its first connection error. A caller-supplied `socket.reconnectStrategy` overrides this behavior; after the client is ready, the default reconnect strategy uses node-redis' exponential backoff and stops on socket timeouts.
+
+Scope finalization calls `close()`, which waits for in-flight commands, including blocking commands, and can therefore delay scope closure.
 
 **Direct client access**
 
-`NodeRedis.NodeRedis` exposes a `RedisClientType` rather than an `ioredis` client. Command methods are camelCase (`client.lRange` instead of `client.lrange`), arbitrary commands use `client.sendCommand([...])` instead of `client.call(...)`, and node-redis 6 speaks RESP3 by default — pass `RESP: 2` to keep RESP2 reply shapes. See the [migration guide](https://redis.io/docs/latest/develop/clients/nodejs/migration/) for the full API comparison.
+`NodeRedis.NodeRedis` exposes a RESP2 `RedisClientType` rather than an `ioredis` client. Command methods are camelCase (`client.lRange` instead of `client.lrange`), and arbitrary commands use `client.sendCommand([...])` instead of `client.call(...)`. RESP2 is pinned for stable reply shapes; opting into RESP3 requires an untyped options escape hatch. See the [migration guide](https://redis.io/docs/latest/develop/clients/nodejs/migration/) for the full API comparison.

--- a/packages/platform/node/package.json
+++ b/packages/platform/node/package.json
@@ -72,13 +72,14 @@
   },
   "peerDependencies": {
     "effect": "workspace:^",
-    "ioredis": ">=5.7.0 <6.0.0"
+    "redis": ">=5.0.0 <7.0.0"
   },
   "devDependencies": {
     "@testcontainers/mysql": "^12.0.4",
     "@testcontainers/postgresql": "^12.0.4",
     "@testcontainers/redis": "^12.0.4",
     "@types/node": "^26.1.2",
-    "effect": "workspace:^"
+    "effect": "workspace:^",
+    "redis": "^6.2.1"
   }
 }

--- a/packages/platform/node/src/NodeRedis.ts
+++ b/packages/platform/node/src/NodeRedis.ts
@@ -16,7 +16,10 @@ import * as Effect from "effect/Effect"
 import * as Fn from "effect/Function"
 import * as Layer from "effect/Layer"
 import * as Redis from "effect/unstable/persistence/Redis"
-import { createClient, type RedisClientOptions, type RedisClientType } from "redis"
+import { createClient, type RedisClientOptions, type RedisClientType, SocketTimeoutError } from "redis"
+
+type NodeRedisClientOptions = RedisClientOptions<{}, {}, {}, 2>
+type NodeRedisClient = RedisClientType<{}, {}, {}, 2>
 
 /**
  * Service tag for the Node Redis integration, exposing the underlying
@@ -27,24 +30,46 @@ import { createClient, type RedisClientOptions, type RedisClientType } from "red
  * @since 4.0.0
  */
 export class NodeRedis extends Context.Service<NodeRedis, {
-  readonly client: RedisClientType
-  readonly use: <A>(f: (client: RedisClientType) => Promise<A>) => Effect.Effect<A, Redis.RedisError>
+  readonly client: NodeRedisClient
+  readonly use: <A>(f: (client: NodeRedisClient) => Promise<A>) => Effect.Effect<A, Redis.RedisError>
 }>()("@effect/platform-node/NodeRedis") {}
 
 const make = Effect.fnUntraced(function*(
-  options?: RedisClientOptions
+  options?: NodeRedisClientOptions
 ) {
+  let ready = false
+  const socket = options?.socket
   const client = yield* Effect.acquireRelease(
-    Effect.sync((): RedisClientType => createClient(options)),
+    Effect.sync((): NodeRedisClient =>
+      createClient({
+        RESP: 2,
+        ...options,
+        socket: socket?.reconnectStrategy === undefined
+          ? {
+            ...socket,
+            reconnectStrategy: (retries, cause) => {
+              if (!ready) return cause
+              if (cause instanceof SocketTimeoutError) return false
+              const jitter = Math.floor(Math.random() * 200)
+              const delay = Math.min(2 ** retries * 50, 2000)
+              return delay + jitter
+            }
+          }
+          : socket
+      })
+    ),
     (client) => Effect.ignore(Effect.tryPromise(() => client.close()))
   )
+  client.once("ready", () => {
+    ready = true
+  })
 
   // node-redis rethrows `error` events that have no listener, which would crash
   // the process on a transient socket failure. Command failures are still
-  // reported as `RedisError`, so these are only logged at debug level.
-  const runFork = Effect.runForkWith(yield* Effect.context<never>())
+  // reported as `RedisError`.
+  const runSync = Effect.runSyncWith(yield* Effect.context<never>())
   client.on("error", (cause) => {
-    runFork(Effect.logDebug("NodeRedis client error", cause))
+    runSync(Effect.logWarning("NodeRedis client error", cause))
   })
 
   yield* Effect.tryPromise({
@@ -52,7 +77,7 @@ const make = Effect.fnUntraced(function*(
     catch: (cause) => new Redis.RedisError({ cause })
   })
 
-  const use = <A>(f: (client: RedisClientType) => Promise<A>) =>
+  const use = <A>(f: (client: NodeRedisClient) => Promise<A>) =>
     Effect.tryPromise({
       try: () => f(client),
       catch: (cause) => new Redis.RedisError({ cause })
@@ -83,16 +108,19 @@ const make = Effect.fnUntraced(function*(
  *
  * **Details**
  *
- * `node-redis` retries the initial connection using `socket.reconnectStrategy`,
- * which by default backs off and retries indefinitely. Pass
- * `socket: { reconnectStrategy: false }` to fail the layer on the first
- * connection error instead.
+ * By default, the initial connection fails on its first connection error. A
+ * caller-supplied `socket.reconnectStrategy` is used instead when present. Once
+ * the client has emitted `ready`, the default reconnect strategy uses
+ * node-redis' exponential backoff and stops on socket timeouts.
+ *
+ * Scope finalization calls `close()`, which waits for in-flight commands,
+ * including blocking commands, and can therefore delay scope closure.
  *
  * @category layers
  * @since 4.0.0
  */
 export const layer = (
-  options?: RedisClientOptions | undefined
+  options?: NodeRedisClientOptions | undefined
 ): Layer.Layer<Redis.Redis | NodeRedis, Redis.RedisError> => Layer.effectContext(make(options))
 
 /**
@@ -100,13 +128,23 @@ export const layer = (
  * client options, connecting the client when the layer is built and closing it
  * when the layer scope ends.
  *
+ * **Details**
+ *
+ * By default, the initial connection fails on its first connection error. A
+ * caller-supplied `socket.reconnectStrategy` is used instead when present. Once
+ * the client has emitted `ready`, the default reconnect strategy uses
+ * node-redis' exponential backoff and stops on socket timeouts.
+ *
+ * Scope finalization calls `close()`, which waits for in-flight commands,
+ * including blocking commands, and can therefore delay scope closure.
+ *
  * @category layers
  * @since 4.0.0
  */
 export const layerConfig: (
-  options: Config.Wrap<RedisClientOptions>
+  options: Config.Wrap<NodeRedisClientOptions>
 ) => Layer.Layer<Redis.Redis | NodeRedis, Redis.RedisError | Config.ConfigError> = (
-  options: Config.Wrap<RedisClientOptions>
+  options: Config.Wrap<NodeRedisClientOptions>
 ): Layer.Layer<Redis.Redis | NodeRedis, Redis.RedisError | Config.ConfigError> =>
   Layer.effectContext(
     Config.unwrap(options).pipe(

--- a/packages/platform/node/src/NodeRedis.ts
+++ b/packages/platform/node/src/NodeRedis.ts
@@ -57,7 +57,7 @@ const make = Effect.fnUntraced(function*(
           : socket
       })
     ),
-    (client) => Effect.ignore(Effect.tryPromise(() => client.close()))
+    (client) => Effect.ignoreCause(Effect.promise(() => client.close()))
   )
   client.once("ready", () => {
     ready = true

--- a/packages/platform/node/src/NodeRedis.ts
+++ b/packages/platform/node/src/NodeRedis.ts
@@ -1,11 +1,12 @@
 /**
- * Node.js Redis integration backed by `ioredis`.
+ * Node.js Redis integration backed by `redis` (node-redis).
  *
- * This module creates a scoped `ioredis` client and exposes it in two forms:
+ * This module creates a scoped `node-redis` client and exposes it in two forms:
  * the generic `Redis` service and the {@link NodeRedis} service for direct
- * access to the underlying client. `layer` accepts ioredis options directly,
- * while `layerConfig` reads them from Effect config. Both layers close the
- * client when the layer scope ends.
+ * access to the underlying client. `layer` accepts node-redis client options
+ * directly, while `layerConfig` reads them from Effect config. `node-redis`
+ * connects explicitly, so layer construction can fail with a `RedisError`.
+ * Both layers close the client when the layer scope ends.
  *
  * @since 4.0.0
  */
@@ -14,31 +15,44 @@ import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Fn from "effect/Function"
 import * as Layer from "effect/Layer"
-import * as Scope from "effect/Scope"
 import * as Redis from "effect/unstable/persistence/Redis"
-import * as IoRedis from "ioredis"
+import { createClient, type RedisClientOptions, type RedisClientType } from "redis"
 
 /**
  * Service tag for the Node Redis integration, exposing the underlying
- * `ioredis` client and a `use` helper that maps client failures to
+ * `node-redis` client and a `use` helper that maps client failures to
  * `RedisError`.
  *
  * @category services
  * @since 4.0.0
  */
 export class NodeRedis extends Context.Service<NodeRedis, {
-  readonly client: IoRedis.Redis
-  readonly use: <A>(f: (client: IoRedis.Redis) => Promise<A>) => Effect.Effect<A, Redis.RedisError>
+  readonly client: RedisClientType
+  readonly use: <A>(f: (client: RedisClientType) => Promise<A>) => Effect.Effect<A, Redis.RedisError>
 }>()("@effect/platform-node/NodeRedis") {}
 
 const make = Effect.fnUntraced(function*(
-  options?: IoRedis.RedisOptions
+  options?: RedisClientOptions
 ) {
-  const scope = yield* Effect.scope
-  yield* Scope.addFinalizer(scope, Effect.promise(() => client.quit()))
-  const client = new IoRedis.Redis(options ?? {})
+  const client = yield* Effect.acquireRelease(
+    Effect.sync((): RedisClientType => createClient(options)),
+    (client) => Effect.ignore(Effect.tryPromise(() => client.close()))
+  )
 
-  const use = <A>(f: (client: IoRedis.Redis) => Promise<A>) =>
+  // node-redis rethrows `error` events that have no listener, which would crash
+  // the process on a transient socket failure. Command failures are still
+  // reported as `RedisError`, so these are only logged at debug level.
+  const runFork = Effect.runForkWith(yield* Effect.context<never>())
+  client.on("error", (cause) => {
+    runFork(Effect.logDebug("NodeRedis client error", cause))
+  })
+
+  yield* Effect.tryPromise({
+    try: () => client.connect(),
+    catch: (cause) => new Redis.RedisError({ cause })
+  })
+
+  const use = <A>(f: (client: RedisClientType) => Promise<A>) =>
     Effect.tryPromise({
       try: () => f(client),
       catch: (cause) => new Redis.RedisError({ cause })
@@ -47,7 +61,7 @@ const make = Effect.fnUntraced(function*(
   const redis = yield* Redis.make({
     send: <A = unknown>(command: string, ...args: ReadonlyArray<string>) =>
       Effect.tryPromise({
-        try: () => client.call(command, ...args) as Promise<A>,
+        try: () => client.sendCommand([command, ...args]) as Promise<A>,
         catch: (cause) => new Redis.RedisError({ cause })
       })
   })
@@ -63,28 +77,37 @@ const make = Effect.fnUntraced(function*(
 })
 
 /**
- * Provides `Redis` and `NodeRedis` services backed by an `ioredis` client
- * created with the supplied options and closed when the layer scope ends.
+ * Provides `Redis` and `NodeRedis` services backed by a `node-redis` client
+ * created with the supplied options, connected when the layer is built and
+ * closed when the layer scope ends.
+ *
+ * **Details**
+ *
+ * `node-redis` retries the initial connection using `socket.reconnectStrategy`,
+ * which by default backs off and retries indefinitely. Pass
+ * `socket: { reconnectStrategy: false }` to fail the layer on the first
+ * connection error instead.
  *
  * @category layers
  * @since 4.0.0
  */
 export const layer = (
-  options?: IoRedis.RedisOptions | undefined
-): Layer.Layer<Redis.Redis | NodeRedis> => Layer.effectContext(make(options))
+  options?: RedisClientOptions | undefined
+): Layer.Layer<Redis.Redis | NodeRedis, Redis.RedisError> => Layer.effectContext(make(options))
 
 /**
- * Provides `Redis` and `NodeRedis` services from `Config`-backed ioredis
- * options, closing the client when the layer scope ends.
+ * Provides `Redis` and `NodeRedis` services from `Config`-backed node-redis
+ * client options, connecting the client when the layer is built and closing it
+ * when the layer scope ends.
  *
  * @category layers
  * @since 4.0.0
  */
 export const layerConfig: (
-  options: Config.Wrap<IoRedis.RedisOptions>
-) => Layer.Layer<Redis.Redis | NodeRedis, Config.ConfigError> = (
-  options: Config.Wrap<IoRedis.RedisOptions>
-): Layer.Layer<Redis.Redis | NodeRedis, Config.ConfigError> =>
+  options: Config.Wrap<RedisClientOptions>
+) => Layer.Layer<Redis.Redis | NodeRedis, Redis.RedisError | Config.ConfigError> = (
+  options: Config.Wrap<RedisClientOptions>
+): Layer.Layer<Redis.Redis | NodeRedis, Redis.RedisError | Config.ConfigError> =>
   Layer.effectContext(
     Config.unwrap(options).pipe(
       Effect.flatMap(make)

--- a/packages/platform/node/src/NodeRedis.ts
+++ b/packages/platform/node/src/NodeRedis.ts
@@ -16,10 +16,10 @@ import * as Effect from "effect/Effect"
 import * as Fn from "effect/Function"
 import * as Layer from "effect/Layer"
 import * as Redis from "effect/unstable/persistence/Redis"
-import { createClient, type RedisClientOptions, type RedisClientType, SocketTimeoutError } from "redis"
+import { createClient, SocketTimeoutError } from "redis"
 
-type NodeRedisClientOptions = RedisClientOptions<{}, {}, {}, 2>
-type NodeRedisClient = RedisClientType<{}, {}, {}, 2>
+type NodeRedisClient = ReturnType<typeof createClient>
+type NodeRedisClientOptions = NonNullable<Parameters<typeof createClient>[0]>
 
 /**
  * Service tag for the Node Redis integration, exposing the underlying
@@ -42,7 +42,6 @@ const make = Effect.fnUntraced(function*(
   const client = yield* Effect.acquireRelease(
     Effect.sync((): NodeRedisClient =>
       createClient({
-        RESP: 2,
         ...options,
         socket: socket?.reconnectStrategy === undefined
           ? {

--- a/packages/platform/node/test/NodeRedis.integration.test.ts
+++ b/packages/platform/node/test/NodeRedis.integration.test.ts
@@ -13,8 +13,10 @@ const RedisLayer = Layer.unwrap(
       (container) => Effect.promise(() => container.stop())
     )
     return NodeRedis.layer({
-      host: container.getHost(),
-      port: container.getMappedPort(6379)
+      socket: {
+        host: container.getHost(),
+        port: container.getMappedPort(6379)
+      }
     })
   }).pipe(
     Effect.catchCause(() => Effect.fail(new PersistedCacheTest.TransientError()))
@@ -66,14 +68,14 @@ it.layer(PersistedQueueRedisLayer, { timeout: "30 seconds" })(
         const error = yield* queue.take(() => Effect.fail("boom"), { maxAttempts: 1 }).pipe(Effect.flip)
         assert.strictEqual(error, "boom")
 
-        const failed = yield* redis.use((client) => client.lrange(`effectq:${queueName}:failed`, 0, -1))
+        const failed = yield* redis.use((client) => client.lRange(`effectq:${queueName}:failed`, 0, -1))
         assert.strictEqual(failed.length, 1)
         const failedItem = JSON.parse(failed[0])
         assert.strictEqual(failedItem.id, id)
         assert.deepStrictEqual(failedItem.element, { n: 42 })
         assert.strictEqual(failedItem.attempts, 1)
 
-        const pending = yield* redis.use((client) => client.hlen(`effectq:${queueName}:pending`))
+        const pending = yield* redis.use((client) => client.hLen(`effectq:${queueName}:pending`))
         assert.strictEqual(pending, 0)
       }))
   }

--- a/packages/platform/node/test/NodeRedis.integration.test.ts
+++ b/packages/platform/node/test/NodeRedis.integration.test.ts
@@ -4,7 +4,8 @@ import { RedisContainer } from "@testcontainers/redis"
 import { Effect, Layer, Schema } from "effect"
 import * as PersistedCacheTest from "effect-test/unstable/persistence/PersistedCacheTest"
 import * as PersistedQueueTest from "effect-test/unstable/persistence/PersistedQueueTest"
-import { PersistedQueue, Persistence } from "effect/unstable/persistence"
+import { PersistedQueue, Persistence, Redis } from "effect/unstable/persistence"
+import { createServer } from "node:net"
 
 const RedisLayer = Layer.unwrap(
   Effect.gen(function*() {
@@ -47,6 +48,19 @@ const PersistedQueueRedisLayer = Layer.mergeAll(
   )
 )
 
+it.effect("fails the initial connection by default", () =>
+  Effect.gen(function*() {
+    const port = yield* closedPort
+    const error = yield* Layer.build(NodeRedis.layer({
+      socket: {
+        host: "127.0.0.1",
+        port
+      }
+    })).pipe(Effect.flip)
+
+    assert.instanceOf(error, Redis.RedisError)
+  }))
+
 it.layer(PersistedQueueRedisLayer, { timeout: "30 seconds" })(
   "PersistedQueue (NodeRedis)",
   (it) => {
@@ -84,3 +98,26 @@ it.layer(PersistedQueueRedisLayer, { timeout: "30 seconds" })(
 const RedisItem = Schema.Struct({
   n: Schema.Number
 })
+
+const closedPort = Effect.promise(
+  () =>
+    new Promise<number>((resolve, reject) => {
+      const server = createServer()
+      server.once("error", reject)
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address()
+        if (address === null || typeof address === "string") {
+          server.close()
+          reject(new Error("Could not allocate a TCP port"))
+          return
+        }
+        server.close((error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(address.port)
+          }
+        })
+      })
+    })
+)

--- a/packages/platform/node/test/NodeRedis.integration.test.ts
+++ b/packages/platform/node/test/NodeRedis.integration.test.ts
@@ -64,6 +64,12 @@ it.effect("fails the initial connection by default", () =>
 it.layer(PersistedQueueRedisLayer, { timeout: "30 seconds" })(
   "PersistedQueue (NodeRedis)",
   (it) => {
+    it.effect("uses the node-redis protocol default", () =>
+      Effect.gen(function*() {
+        const redis = yield* NodeRedis.NodeRedis
+        assert.strictEqual(redis.client.options.RESP, undefined)
+      }))
+
     // The shared PersistedQueue suite can only assert that exhausted elements
     // are no longer delivered, which is also true if they are silently
     // dropped. There is no public API for reading failed elements, so

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -480,9 +480,6 @@ importers:
       '@effect/platform-node-shared':
         specifier: workspace:^
         version: link:../node-shared
-      ioredis:
-        specifier: '>=5.7.0 <6.0.0'
-        version: 5.8.2
       mime:
         specifier: ^4.1.0
         version: 4.1.0
@@ -505,6 +502,9 @@ importers:
       effect:
         specifier: workspace:^
         version: link:../../effect
+      redis:
+        specifier: ^6.2.1
+        version: 6.2.1(@opentelemetry/api@1.9.1)
 
   packages/platform/node-shared:
     dependencies:
@@ -2173,9 +2173,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@ioredis/commands@1.4.0':
-    resolution: {integrity: sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==}
-
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -2732,6 +2729,42 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@redis/bloom@6.2.1':
+    resolution: {integrity: sha512-huQgNLaCIZfQ9SeLn4q9124uOUd8HbZDYHwwUzNcRgHqCHiHKl2dDxMqJCeWh8cMqZAoWuHR8XnWbDMIf+o7ag==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.2.1
+
+  '@redis/client@6.2.1':
+    resolution: {integrity: sha512-LzxBY7SIBvvJiyCgcaJZZakE3fJrZZ++i24+EDW9fKpCl68D35uJcKFpZZwCfOoG9WZTbyZlMzMeM0gtOAMU9Q==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@node-rs/xxhash': ^1.1.0
+      '@opentelemetry/api': '>=1 <2'
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@redis/json@6.2.1':
+    resolution: {integrity: sha512-AFIUJ8Gj0DaaSBHYuSt8+O0oYWM+50OK1c0OmodB7XERIA8+BbyV3O4v76f9iccWasd1/7qjfZTpuzexUaZtrQ==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.2.1
+
+  '@redis/search@6.2.1':
+    resolution: {integrity: sha512-2vfOAOyYFE7UUw3sBBlkqqruBtOUS4HRY5MtW4hp83llrwvtrTE4r22CEqXddlV+54zkLxBE4nmsIJ/dpezQrQ==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.2.1
+
+  '@redis/time-series@6.2.1':
+    resolution: {integrity: sha512-kiYniph04dJOole+L359B6C9E+jYS2uDP7hca6Onj0xF38ZIpyxARO0Iq0W4ZRn1e8Q6vqW00QFZVSMRA/2Ijw==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.2.1
 
   '@redocly/ajv@8.11.2':
     resolution: {integrity: sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==}
@@ -4413,6 +4446,7 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@13.0.6:
@@ -4437,6 +4471,7 @@ packages:
 
   gulp-header@1.8.12:
     resolution: {integrity: sha512-lh9HLdb53sC7XIZOYzTXM4lFuXElv3EVkSDhsd7DoJBj7hm+Ni7D3qYbb+Rr8DuM8nRanBvkVO9d7askreXGnQ==}
+    deprecated: Removed event-stream from gulp-header
 
   happy-dom@20.11.1:
     resolution: {integrity: sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==}
@@ -4541,10 +4576,6 @@ packages:
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
-
-  ioredis@5.8.2:
-    resolution: {integrity: sha512-C6uC+kleiIMmjViJINWk80sOQw5lEzse1ZmvD+S/s8p8CWapftSaC+kocGTx6xrbrJ4WmYQGC08ffHLr6ToR6Q==}
-    engines: {node: '>=12.22.0'}
 
   is-buffer@1.1.6:
     resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
@@ -4922,14 +4953,8 @@ packages:
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
-  lodash.defaults@4.2.0:
-    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
-
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
-
-  lodash.isarguments@3.1.0:
-    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
@@ -4951,6 +4976,7 @@ packages:
 
   lodash.template@4.18.1:
     resolution: {integrity: sha512-5urZrLnV/VD6zHK5KsVtZgt7H19v51mIzoS0aBNH8yp3I8tbswrEjOABOPY8m8uB7NuibubLrMX+Y0PXsU9X+w==}
+    deprecated: This package is deprecated. Use https://socket.dev/npm/package/eta instead.
 
   lodash.templatesettings@4.2.0:
     resolution: {integrity: sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==}
@@ -5729,13 +5755,9 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
-  redis-errors@1.2.0:
-    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
-    engines: {node: '>=4'}
-
-  redis-parser@3.0.0:
-    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
-    engines: {node: '>=4'}
+  redis@6.2.1:
+    resolution: {integrity: sha512-Z9VHtgYs48PiQC77X9O2Er8Hj4T+5BtFjT91/vi5Is1D04N72cA946ZslM1ImJw8ZctFBZWAVjM7S5wJNeHMpg==}
+    engines: {node: '>= 20.0.0'}
 
   reftools@1.1.9:
     resolution: {integrity: sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==}
@@ -6078,9 +6100,6 @@ packages:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
 
-  standard-as-callback@2.1.0:
-    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
-
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
@@ -6340,6 +6359,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -7901,8 +7921,6 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@ioredis/commands@1.4.0': {}
-
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -8450,6 +8468,28 @@ snapshots:
       react-native: 0.83.0(@babel/core@8.0.1)(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
+
+  '@redis/bloom@6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 6.2.1(@opentelemetry/api@1.9.1)
+
+  '@redis/client@6.2.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      cluster-key-slot: 1.1.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@redis/json@6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 6.2.1(@opentelemetry/api@1.9.1)
+
+  '@redis/search@6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 6.2.1(@opentelemetry/api@1.9.1)
+
+  '@redis/time-series@6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 6.2.1(@opentelemetry/api@1.9.1)
 
   '@redocly/ajv@8.11.2':
     dependencies:
@@ -10254,20 +10294,6 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  ioredis@5.8.2:
-    dependencies:
-      '@ioredis/commands': 1.4.0
-      cluster-key-slot: 1.1.2
-      debug: 4.4.3(supports-color@10.2.2)
-      denque: 2.1.0
-      lodash.defaults: 4.2.0
-      lodash.isarguments: 3.1.0
-      redis-errors: 1.2.0
-      redis-parser: 3.0.0
-      standard-as-callback: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
   is-buffer@1.1.6: {}
 
   is-core-module@2.16.2:
@@ -10679,11 +10705,7 @@ snapshots:
 
   lodash.camelcase@4.3.0: {}
 
-  lodash.defaults@4.2.0: {}
-
   lodash.includes@4.3.0: {}
-
-  lodash.isarguments@3.1.0: {}
 
   lodash.isboolean@3.0.3: {}
 
@@ -11655,11 +11677,16 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
-  redis-errors@1.2.0: {}
-
-  redis-parser@3.0.0:
+  redis@6.2.1(@opentelemetry/api@1.9.1):
     dependencies:
-      redis-errors: 1.2.0
+      '@redis/bloom': 6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))
+      '@redis/client': 6.2.1(@opentelemetry/api@1.9.1)
+      '@redis/json': 6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))
+      '@redis/search': 6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))
+      '@redis/time-series': 6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))
+    transitivePeerDependencies:
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
 
   reftools@1.1.9: {}
 
@@ -12021,8 +12048,6 @@ snapshots:
   stacktrace-parser@0.1.11:
     dependencies:
       type-fest: 0.7.1
-
-  standard-as-callback@2.1.0: {}
 
   statuses@1.5.0: {}
 


### PR DESCRIPTION
Redis has deprecated `ioredis` in favour of `node-redis`, so `@effect/platform-node`'s `NodeRedis` module now builds on the `redis` client. This follows the official migration guide and keeps the peer range compatible with both redis 5 and 6.

## Breaking changes

**Peer dependency** — replace `ioredis` with `redis: >=5.0.0 <7.0.0`. The package continues to support Node >=18; redis 5 remains available for Node 18 users, while redis 6 requires a newer Node release.

**Connection options** — `layer` and `layerConfig` take node-redis' `RedisClientOptions` instead of ioredis' `RedisOptions`. Socket settings move under `socket`, and `db` becomes `database`:

```ts
// before
NodeRedis.layer({ host: "localhost", port: 6379, db: 1 })

// after
NodeRedis.layer({ socket: { host: "localhost", port: 6379 }, database: 1 })
```

A connection string works too: `NodeRedis.layer({ url: "redis://localhost:6379/1" })`.

**Layers can now fail** — node-redis connects explicitly, so both layers connect while being built and carry `RedisError` in their error channel.

**Direct client access** — `NodeRedis.NodeRedis` exposes node-redis's client type. Command methods are camelCase (`client.lRange` rather than `client.lrange`), and arbitrary commands use `client.sendCommand([...])` rather than `client.call(...)`. Protocol selection follows the installed node-redis version's default; callers can explicitly select a protocol through `RESP`, and the exposed types account for protocol-dependent replies.

## Connection lifecycle

- By default, an initial connection error fails layer construction immediately.
- A caller-supplied `socket.reconnectStrategy` is preserved. After the client first emits `ready`, the default strategy uses node-redis' exponential backoff and stops on `SocketTimeoutError`.
- Client `error` events are logged synchronously at warning level; they do not fork a fiber per event.
- Scope finalization uses `close()`. It waits for in-flight commands, including blocking commands, so scope closure can be delayed.

## Testing

- `EFFECT_INTEGRATION_TESTS=1 pnpm vitest run --project @effect/platform-node test/NodeRedis.integration.test.ts` — 13 tests passed, including fail-fast initial connection and protocol-default coverage.
- `pnpm check` — passed.
- `pnpm lint` — passed.
- `pnpm --filter @effect/platform-node check` with redis 5.12.1 — passed in an isolated worktree.

Closes EFF-650
