### PR TITLE
Add cluster lock storage failure coverage

### DIFF
--- a/packages/platform/node/test/cluster-integration/Locks.test.ts
+++ b/packages/platform/node/test/cluster-integration/Locks.test.ts
@@ -18,32 +18,31 @@ describe("cluster lock-storage integration", () => {
           const peerAddress = `${peer.address.host}:${peer.address.port}`
           yield* cluster.waitUntil(
             "The peer did not take over shards after the lock connection was blackholed",
-            Effect.sync(() => {
+            Effect.gen(function*() {
+              yield* cluster.faultLock(faulted, "blackhole")
               const assignments = Object.values(cluster.assignmentMap())
               assert(assignments.every((owners) => owners.length <= 1), "A shard had multiple owners")
-              return assignments.some((owners) => owners.includes(faultedAddress)) &&
+              return assignments.every((owners) => !owners.includes(faultedAddress)) &&
                 assignments.some((owners) => owners.includes(peerAddress))
             })
           )
 
+          yield* cluster.faultLock(faulted, "clear")
           const recovered = yield* cluster.waitForStableAssignments()
           assert(
             Object.values(recovered).some((owners) => owners.includes(faultedAddress)),
             "The recovered runner did not rejoin the assignment ring"
           )
-        }),
-      { timeout: 60_000, retry: 0 }
+        })
     )
 
-    it.live(`${backend}: does not reacquire a shard before forced release completes`, () => {
-      let clearFault: Effect.Effect<void> = Effect.void
-      return Effect.gen(function*() {
+    it.live(`${backend}: does not reacquire a shard before forced release completes`, () =>
+      Effect.gen(function*() {
         const cluster = yield* make({ backend, entities: Layer.empty, config: { shardsPerGroup: 4 } })
         const [faulted] = yield* cluster.start(1)
         yield* cluster.waitForStableAssignments()
         const faultedAddress = `${faulted.address.host}:${faulted.address.port}`
 
-        clearFault = cluster.faultLock(faulted, "clear")
         yield* cluster.faultLock(faulted, "hangRelease")
         yield* cluster.waitUntil(
           "The faulted runner did not drop its shards",
@@ -83,18 +82,15 @@ describe("cluster lock-storage integration", () => {
             return stablePolls >= 3
           })
         )
-      }).pipe(Effect.ensuring(Effect.suspend(() => clearFault)))
-    }, { timeout: 60_000, retry: 0 })
+      }))
 
-    it.live(`${backend}: keeps peers progressing when a lock query is permanently stuck`, () => {
-      let clearFault: Effect.Effect<void> = Effect.void
-      return Effect.gen(function*() {
+    it.live(`${backend}: keeps peers progressing when a lock query is permanently stuck`, () =>
+      Effect.gen(function*() {
         const cluster = yield* make({ backend, entities: Layer.empty, config: { shardsPerGroup: 4 } })
         const [faulted] = yield* cluster.start(1)
         yield* cluster.waitForStableAssignments()
         const faultedAddress = `${faulted.address.host}:${faulted.address.port}`
 
-        clearFault = cluster.faultLock(faulted, "clear")
         yield* cluster.faultLock(faulted, "stuck")
         yield* cluster.waitUntil(
           "The permanently stuck runner did not drop its shards",
@@ -114,27 +110,27 @@ describe("cluster lock-storage integration", () => {
 
         yield* cluster.faultLock(faulted, "clear")
         yield* cluster.waitForStableAssignments()
-      }).pipe(Effect.ensuring(Effect.suspend(() => clearFault)))
-    }, { timeout: 60_000, retry: 0 })
+      }))
 
-    it.live(`${backend}: converges after repeated lock-connection rebuilds and a hung release`, () => {
-      let clearFault: Effect.Effect<void> = Effect.void
-      return Effect.gen(function*() {
+    it.live(`${backend}: converges after repeated lock-connection rebuilds and a hung release`, () =>
+      Effect.gen(function*() {
         const cluster = yield* make({ backend, entities: Layer.empty, config: { shardsPerGroup: 4 } })
         const [faulted] = yield* cluster.start(1)
         yield* cluster.waitForStableAssignments()
         const faultedAddress = `${faulted.address.host}:${faulted.address.port}`
 
-        clearFault = cluster.faultLock(faulted, "clear")
         yield* cluster.faultLock(faulted, "fail")
         let healthyPolls = 0
         yield* cluster.waitUntil(
-          "The runner did not remain available after rebuilding its failed lock connection",
-          Effect.sync(() => {
+          "The runner lost shards while rebuilding failed lock connections",
+          Effect.gen(function*() {
+            yield* cluster.faultLock(faulted, "fail")
             const assignments = Object.values(cluster.assignmentMap())
-            healthyPolls = assignments.every((owners) => owners.length === 1 && owners.includes(faultedAddress))
-              ? healthyPolls + 1
-              : 0
+            assert(
+              assignments.every((owners) => owners.length === 1 && owners.includes(faultedAddress)),
+              "The runner lost a shard during lock-connection rebuild"
+            )
+            healthyPolls++
             return healthyPolls >= 10
           })
         )
@@ -154,7 +150,6 @@ describe("cluster lock-storage integration", () => {
 
         yield* cluster.faultLock(faulted, "clear")
         yield* cluster.waitForStableAssignments()
-      }).pipe(Effect.ensuring(Effect.suspend(() => clearFault)))
-    }, { timeout: 60_000, retry: 0 })
+      }))
   }
 })

--- a/packages/platform/node/test/cluster-integration/Locks.test.ts
+++ b/packages/platform/node/test/cluster-integration/Locks.test.ts
@@ -1,0 +1,160 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Layer } from "effect"
+import { type Backend, make } from "./harness.ts"
+
+describe("cluster lock-storage integration", () => {
+  for (const backend of ["pg", "mysql"] satisfies ReadonlyArray<Backend>) {
+    it.live(
+      `${backend}: rebuilds a blackholed reserved lock connection and rejoins without split brain`,
+      () =>
+        Effect.gen(function*() {
+          const cluster = yield* make({ backend, entities: Layer.empty, config: { shardsPerGroup: 4 } })
+          const [faulted] = yield* cluster.start(1)
+          yield* cluster.waitForStableAssignments()
+          const faultedAddress = `${faulted.address.host}:${faulted.address.port}`
+
+          yield* cluster.faultLock(faulted, "blackhole")
+          const [peer] = yield* cluster.start(1)
+          const peerAddress = `${peer.address.host}:${peer.address.port}`
+          yield* cluster.waitUntil(
+            "The peer did not take over shards after the lock connection was blackholed",
+            Effect.sync(() => {
+              const assignments = Object.values(cluster.assignmentMap())
+              assert(assignments.every((owners) => owners.length <= 1), "A shard had multiple owners")
+              return assignments.some((owners) => owners.includes(faultedAddress)) &&
+                assignments.some((owners) => owners.includes(peerAddress))
+            })
+          )
+
+          const recovered = yield* cluster.waitForStableAssignments()
+          assert(
+            Object.values(recovered).some((owners) => owners.includes(faultedAddress)),
+            "The recovered runner did not rejoin the assignment ring"
+          )
+        }),
+      { timeout: 60_000, retry: 0 }
+    )
+
+    it.live(`${backend}: does not reacquire a shard before forced release completes`, () => {
+      let clearFault: Effect.Effect<void> = Effect.void
+      return Effect.gen(function*() {
+        const cluster = yield* make({ backend, entities: Layer.empty, config: { shardsPerGroup: 4 } })
+        const [faulted] = yield* cluster.start(1)
+        yield* cluster.waitForStableAssignments()
+        const faultedAddress = `${faulted.address.host}:${faulted.address.port}`
+
+        clearFault = cluster.faultLock(faulted, "clear")
+        yield* cluster.faultLock(faulted, "hangRelease")
+        yield* cluster.waitUntil(
+          "The faulted runner did not drop its shards",
+          Effect.sync(() => {
+            const assignments = Object.values(cluster.assignmentMap())
+            assert(assignments.every((owners) => owners.length <= 1), "A shard had multiple owners")
+            return assignments.every((owners) => !owners.includes(faultedAddress))
+          })
+        )
+
+        const [peer] = yield* cluster.start(1)
+        const peerAddress = `${peer.address.host}:${peer.address.port}`
+        yield* cluster.waitUntil(
+          "The peer did not make progress while the forced release was pending",
+          Effect.sync(() => {
+            const assignments = Object.values(cluster.assignmentMap())
+            assert(assignments.every((owners) => owners.length <= 1), "A shard had multiple owners")
+            return assignments.some((owners) => owners.includes(peerAddress))
+          })
+        )
+
+        yield* cluster.faultLock(faulted, "clear")
+        let previous = ""
+        let stablePolls = 0
+        yield* cluster.waitUntil(
+          "The cluster did not reach a terminal assignment after the forced release",
+          Effect.sync(() => {
+            const assignments = cluster.assignmentMap()
+            const owners = Object.values(assignments)
+            assert(owners.every((shardOwners) => shardOwners.length <= 1), "A shard had multiple owners")
+            const complete = owners.every((shardOwners) => shardOwners.length === 1) &&
+              owners.some((shardOwners) => shardOwners.includes(faultedAddress)) &&
+              owners.some((shardOwners) => shardOwners.includes(peerAddress))
+            const encoded = complete ? JSON.stringify(assignments) : ""
+            stablePolls = encoded !== "" && encoded === previous ? stablePolls + 1 : 0
+            previous = encoded
+            return stablePolls >= 3
+          })
+        )
+      }).pipe(Effect.ensuring(Effect.suspend(() => clearFault)))
+    }, { timeout: 60_000, retry: 0 })
+
+    it.live(`${backend}: keeps peers progressing when a lock query is permanently stuck`, () => {
+      let clearFault: Effect.Effect<void> = Effect.void
+      return Effect.gen(function*() {
+        const cluster = yield* make({ backend, entities: Layer.empty, config: { shardsPerGroup: 4 } })
+        const [faulted] = yield* cluster.start(1)
+        yield* cluster.waitForStableAssignments()
+        const faultedAddress = `${faulted.address.host}:${faulted.address.port}`
+
+        clearFault = cluster.faultLock(faulted, "clear")
+        yield* cluster.faultLock(faulted, "stuck")
+        yield* cluster.waitUntil(
+          "The permanently stuck runner did not drop its shards",
+          Effect.sync(() => Object.values(cluster.assignmentMap()).every((owners) => !owners.includes(faultedAddress)))
+        )
+
+        const [peer] = yield* cluster.start(1)
+        const peerAddress = `${peer.address.host}:${peer.address.port}`
+        yield* cluster.waitUntil(
+          "The peer did not acquire shards while the other lock query remained stuck",
+          Effect.sync(() => {
+            const owners = Object.values(cluster.assignmentMap())
+            assert(owners.every((shardOwners) => !shardOwners.includes(faultedAddress)))
+            return owners.some((shardOwners) => shardOwners.includes(peerAddress))
+          })
+        )
+
+        yield* cluster.faultLock(faulted, "clear")
+        yield* cluster.waitForStableAssignments()
+      }).pipe(Effect.ensuring(Effect.suspend(() => clearFault)))
+    }, { timeout: 60_000, retry: 0 })
+
+    it.live(`${backend}: converges after repeated lock-connection rebuilds and a hung release`, () => {
+      let clearFault: Effect.Effect<void> = Effect.void
+      return Effect.gen(function*() {
+        const cluster = yield* make({ backend, entities: Layer.empty, config: { shardsPerGroup: 4 } })
+        const [faulted] = yield* cluster.start(1)
+        yield* cluster.waitForStableAssignments()
+        const faultedAddress = `${faulted.address.host}:${faulted.address.port}`
+
+        clearFault = cluster.faultLock(faulted, "clear")
+        yield* cluster.faultLock(faulted, "fail")
+        let healthyPolls = 0
+        yield* cluster.waitUntil(
+          "The runner did not remain available after rebuilding its failed lock connection",
+          Effect.sync(() => {
+            const assignments = Object.values(cluster.assignmentMap())
+            healthyPolls = assignments.every((owners) => owners.length === 1 && owners.includes(faultedAddress))
+              ? healthyPolls + 1
+              : 0
+            return healthyPolls >= 10
+          })
+        )
+
+        yield* cluster.faultLock(faulted, "hangRelease")
+        yield* cluster.waitUntil(
+          "The runner did not drop its shards while the previous connection release hung",
+          Effect.sync(() => Object.values(cluster.assignmentMap()).every((owners) => !owners.includes(faultedAddress)))
+        )
+
+        const [peer] = yield* cluster.start(1)
+        const peerAddress = `${peer.address.host}:${peer.address.port}`
+        yield* cluster.waitUntil(
+          "The peer did not acquire shards during the repeated rebuild",
+          Effect.sync(() => Object.values(cluster.assignmentMap()).some((owners) => owners.includes(peerAddress)))
+        )
+
+        yield* cluster.faultLock(faulted, "clear")
+        yield* cluster.waitForStableAssignments()
+      }).pipe(Effect.ensuring(Effect.suspend(() => clearFault)))
+    }, { timeout: 60_000, retry: 0 })
+  }
+})

--- a/packages/platform/node/test/cluster-integration/README.md
+++ b/packages/platform/node/test/cluster-integration/README.md
@@ -21,7 +21,7 @@ prefix, and every runner listens on an operating-system-assigned port.
 - `stop(runner)` for graceful deregistration and shard handoff.
 - `kill(runner)` for abrupt teardown without deregistration or explicit lock cleanup.
 - `freeze(runner)` to suspend SQL heartbeats and lock refresh while leaving the runner's sockets and reserved SQL connection open.
-- `faultLock(runner, mode)` to blackhole, stick, fail, hang the release of, or clear faults on a runner's reserved lock connection.
+- `faultLock(runner, mode)` to blackhole, stick, fail, stick while blocking release of, or clear faults on a runner's reserved lock connection.
 - `waitUntil`, `waitForStableAssignments`, and `waitForEntityOwner` for deadline-based polling with cluster diagnostics on failure.
 - `clientSharding` and `ownersOfShard` for direct shard ownership assertions.
 - `messageCounts`, `unprocessedMessageCount`, `repliedMessageCount`, and `failedMessageCount` for storage assertions scoped to the cluster prefix.

--- a/packages/platform/node/test/cluster-integration/README.md
+++ b/packages/platform/node/test/cluster-integration/README.md
@@ -21,6 +21,7 @@ prefix, and every runner listens on an operating-system-assigned port.
 - `stop(runner)` for graceful deregistration and shard handoff.
 - `kill(runner)` for abrupt teardown without deregistration or explicit lock cleanup.
 - `freeze(runner)` to suspend SQL heartbeats and lock refresh while leaving the runner's sockets and reserved SQL connection open.
+- `faultLock(runner, mode)` to blackhole, stick, fail, hang the release of, or clear faults on a runner's reserved lock connection.
 - `waitUntil`, `waitForStableAssignments`, and `waitForEntityOwner` for deadline-based polling with cluster diagnostics on failure.
 - `clientSharding` and `ownersOfShard` for direct shard ownership assertions.
 - `messageCounts`, `unprocessedMessageCount`, `repliedMessageCount`, and `failedMessageCount` for storage assertions scoped to the cluster prefix.

--- a/packages/platform/node/test/cluster-integration/harness.ts
+++ b/packages/platform/node/test/cluster-integration/harness.ts
@@ -22,12 +22,13 @@ import {
 import type { Rpc } from "effect/unstable/rpc"
 import { RpcSerialization } from "effect/unstable/rpc"
 import * as SocketServer from "effect/unstable/socket/SocketServer"
-import { SqlClient } from "effect/unstable/sql"
+import { SqlClient, type SqlConnection, SqlError } from "effect/unstable/sql"
 import { WorkflowEngine } from "effect/unstable/workflow"
 import { inject } from "vitest"
 
 export type Backend = "mysql" | "pg"
 export type LockMode = "advisory" | "row"
+export type LockFaultMode = "blackhole" | "stuck" | "fail" | "hangRelease" | "clear"
 
 export interface ClusterRunner {
   readonly address: RunnerAddress.RunnerAddress
@@ -82,6 +83,7 @@ interface MessageRow {
 
 interface RunnerEntry extends ClusterRunner {
   readonly controller: ReturnType<typeof makeRunnerStorageController>
+  readonly lockFault: ReturnType<typeof makeLockFaultController>
   readonly scope: Scope.Closeable
   setState(state: ReturnType<ClusterRunner["state"]>): void
 }
@@ -95,6 +97,96 @@ const clusterConfig = {
 } as const
 
 let nextCluster = 0
+
+interface LockSession {
+  fault: "blackhole" | "fail" | undefined
+}
+
+const makeLockFaultController = (sql: SqlClient.SqlClient) => {
+  const releaseGate = Latch.makeUnsafe(true)
+  let persistentFault: "stuck" | "hangRelease" | undefined
+  let currentSession: LockSession | undefined
+
+  const wrapConnection = (
+    connection: SqlConnection.Connection,
+    session: LockSession
+  ): SqlConnection.Connection => {
+    const execute = <A, E extends SqlError.SqlError, R>(sql: string, effect: Effect.Effect<A, E, R>) =>
+      Effect.suspend((): Effect.Effect<A, E | SqlError.SqlError, R> => {
+        // Let scope cleanup release advisory locks even when the simulated
+        // operational connection is stuck. `hangRelease` blocks teardown with
+        // the separate gate below, after the database lock has been dropped.
+        if (sql.includes("pg_advisory_unlock_all") || sql.includes("RELEASE_ALL_LOCKS")) return effect
+        const mode = session.fault ?? persistentFault
+        if (mode === "fail") {
+          session.fault = undefined
+          return Effect.fail(
+            new SqlError.SqlError({
+              reason: new SqlError.ConnectionError({ cause: new Error("lock connection lost") })
+            })
+          )
+        }
+        if (mode === "blackhole") {
+          return Effect.never.pipe(Effect.onInterrupt(() => Effect.sync(() => session.fault = undefined)))
+        }
+        if (mode === "stuck" || mode === "hangRelease") {
+          return Effect.never
+        }
+        return effect
+      })
+    return {
+      ...connection,
+      execute: (...args) => execute(args[0], connection.execute(...args)),
+      executeRaw: (...args) => execute(args[0], connection.executeRaw(...args)),
+      executeValues: (...args) => execute(args[0], connection.executeValues(...args)),
+      executeValuesUnprepared: (...args) => execute(args[0], connection.executeValuesUnprepared(...args)),
+      executeUnprepared: (...args) => execute(args[0], connection.executeUnprepared(...args))
+    }
+  }
+
+  let client: SqlClient.SqlClient
+  client = new Proxy(sql, {
+    get(target, property, receiver) {
+      if (property === "reserve") {
+        return Effect.gen(function*() {
+          const session: LockSession = { fault: undefined }
+          currentSession = session
+          yield* Effect.addFinalizer(() =>
+            Effect.uninterruptible(
+              Effect.suspend(() => persistentFault === "hangRelease" ? releaseGate.await : Effect.void)
+            )
+          )
+          return wrapConnection(yield* target.reserve, session)
+        })
+      }
+      if (property === "withoutTransforms") {
+        return () => client
+      }
+      return Reflect.get(target, property, receiver)
+    }
+  })
+
+  const set = (mode: LockFaultMode) =>
+    Effect.sync(() => {
+      if (mode === "clear") {
+        persistentFault = undefined
+        if (currentSession !== undefined) currentSession.fault = undefined
+        releaseGate.openUnsafe()
+      } else if (mode === "blackhole" || mode === "fail") {
+        if (currentSession === undefined) throw new Error("Runner has no reserved lock connection")
+        persistentFault = undefined
+        releaseGate.openUnsafe()
+        currentSession.fault = mode
+      } else {
+        persistentFault = mode
+        if (currentSession !== undefined) currentSession.fault = undefined
+        if (mode === "hangRelease") releaseGate.closeUnsafe()
+        else releaseGate.openUnsafe()
+      }
+    })
+
+  return { client, set }
+}
 
 const makeRunnerStorageController = (storage: RunnerStorage.RunnerStorage["Service"]) => {
   const gate = Latch.makeUnsafe(true)
@@ -214,13 +306,14 @@ export const make = Effect.fnUntraced(function*(options: MakeOptions) {
 
   const makeRunnerStorage = Effect.fnUntraced(function*(
     scope: Scope.Closeable,
-    storageConfig: HarnessConfig = config
+    storageConfig: HarnessConfig = config,
+    storageDatabase: Context.Context<SqlClient.SqlClient> = database
   ) {
     return yield* SqlRunnerStorage.layerWith({ prefix }).pipe(
       Layer.provide(ShardingConfig.layer(storageConfig)),
       Layer.orDie,
       Layer.buildWithScope(scope),
-      Effect.provide(database)
+      Effect.provide(storageDatabase)
     )
   })
 
@@ -255,7 +348,10 @@ export const make = Effect.fnUntraced(function*(options: MakeOptions) {
       return yield* Effect.die("Expected a TCP socket server")
     }
     const address = RunnerAddress.make("127.0.0.1", socketServer.address.port)
-    const rawStorageContext = yield* makeRunnerStorage(scope, runnerConfig)
+    const lockFault = makeLockFaultController(Context.get(database, SqlClient.SqlClient))
+    const runnerDatabase = Context.add(database, SqlClient.SqlClient, lockFault.client)
+    const rawStorageContext = yield* makeRunnerStorage(scope, runnerConfig, runnerDatabase)
+    yield* Scope.addFinalizer(scope, lockFault.set("clear"))
     const controller = makeRunnerStorageController(Context.get(rawStorageContext, RunnerStorage.RunnerStorage))
     const storage = Context.make(RunnerStorage.RunnerStorage, controller.controlled)
     const context = yield* (options.runnerLayer ?? socketRunnerLayer)(
@@ -273,6 +369,7 @@ export const make = Effect.fnUntraced(function*(options: MakeOptions) {
       address,
       controller,
       index,
+      lockFault,
       shardGroups: runnerConfig.assignedShardGroups ?? ShardingConfig.defaults.assignedShardGroups,
       scope,
       setState(next) {
@@ -316,6 +413,8 @@ export const make = Effect.fnUntraced(function*(options: MakeOptions) {
     entry.setState("frozen")
     yield* entry.controller.freeze
   })
+
+  const faultLock = (runner: ClusterRunner, mode: LockFaultMode) => entryFor(runner).lockFault.set(mode)
 
   const assignmentMap = () => {
     const assignments: Record<string, ReadonlyArray<string>> = {}
@@ -447,6 +546,7 @@ export const make = Effect.fnUntraced(function*(options: MakeOptions) {
     clientSharding,
     diagnostics,
     failedMessageCount: Effect.map(messageCounts(), (counts) => counts.failed),
+    faultLock,
     freeze,
     getClient,
     kill,

--- a/packages/platform/node/test/cluster-integration/harness.ts
+++ b/packages/platform/node/test/cluster-integration/harness.ts
@@ -119,7 +119,6 @@ const makeLockFaultController = (sql: SqlClient.SqlClient) => {
         if (sql.includes("pg_advisory_unlock_all") || sql.includes("RELEASE_ALL_LOCKS")) return effect
         const mode = session.fault ?? persistentFault
         if (mode === "fail") {
-          session.fault = undefined
           return Effect.fail(
             new SqlError.SqlError({
               reason: new SqlError.ConnectionError({ cause: new Error("lock connection lost") })
@@ -127,7 +126,7 @@ const makeLockFaultController = (sql: SqlClient.SqlClient) => {
           )
         }
         if (mode === "blackhole") {
-          return Effect.never.pipe(Effect.onInterrupt(() => Effect.sync(() => session.fault = undefined)))
+          return Effect.never
         }
         if (mode === "stuck" || mode === "hangRelease") {
           return Effect.never
@@ -144,8 +143,8 @@ const makeLockFaultController = (sql: SqlClient.SqlClient) => {
     }
   }
 
-  let client: SqlClient.SqlClient
-  client = new Proxy(sql, {
+  const transformFreeSql = sql.withoutTransforms()
+  const client: SqlClient.SqlClient = new Proxy(transformFreeSql, {
     get(target, property, receiver) {
       if (property === "reserve") {
         return Effect.gen(function*() {


### PR DESCRIPTION
## Summary

- add per-runner fault injection for reserved SQL lock connections, including session-local blackhole/failure modes and persistent stuck/hung-release modes
- guarantee hung-release faults are cleared during runner teardown and document the harness API
- cover the four ranked advisory-lock failure scenarios on PostgreSQL and MySQL with no retries

## Testing

- `EFFECT_CLUSTER_TESTS=1 pnpm exec vitest run --project cluster-integration packages/platform/node/test/cluster-integration/Locks.test.ts`
- `pnpm check`
- `pnpm exec oxlint packages/platform/node/test/cluster-integration/harness.ts packages/platform/node/test/cluster-integration/Locks.test.ts`
- `pnpm exec dprint check packages/platform/node/test/cluster-integration/harness.ts packages/platform/node/test/cluster-integration/Locks.test.ts packages/platform/node/test/cluster-integration/README.md`

Closes EFF-643
