### PR TITLE
Use handleAll in HttpApi examples

### DIFF
--- a/ai-docs/src/51_http-server/10_basics.ts
+++ b/ai-docs/src/51_http-server/10_basics.ts
@@ -24,7 +24,9 @@ const SystemApiHandlers = HttpApiBuilder.group(
   Api,
   "system",
   Effect.fn(function*(handlers) {
-    return handlers.handle("health", () => Effect.void)
+    return handlers.handleAll({
+      health: () => Effect.void
+    })
   })
 )
 

--- a/ai-docs/src/51_http-server/fixtures/server/Users/http.ts
+++ b/ai-docs/src/51_http-server/fixtures/server/Users/http.ts
@@ -13,43 +13,40 @@ export const UsersApiHandlersNoDeps = HttpApiBuilder.group(
   Effect.fn(function*(handlers) {
     const users = yield* Users
 
-    return handlers
-      .handle("list", ({ query }) =>
+    return handlers.handleAll({
+      list: ({ query }) =>
         users.list(query.search).pipe(
           // The list endpoint expects no errors, so we convert any potential
           // errors into a 500 Internal Server Error.
           Effect.orDie
-        ))
-      .handle(
-        "search",
-        Effect.fn(function*({ payload }) {
-          if (payload.search === "bad-request") {
-            // You can use the built in error types like any other
-            // Schema.TaggedError
-            return yield* new HttpApiError.RequestTimeout()
-          }
-          return yield* users.list(payload.search).pipe(
-            Effect.catchReason(
-              "UsersError",
-              "SearchQueryTooShort",
-              // Re-fail the "SearchQueryTooShort" reason
-              Effect.fail,
-              // All other reasons are unexpected, so we convert them into a 500
-              // Internal Server Error.
-              Effect.die
-            )
+        ),
+      search: Effect.fn(function*({ payload }) {
+        if (payload.search === "bad-request") {
+          // You can use the built in error types like any other
+          // Schema.TaggedError
+          return yield* new HttpApiError.RequestTimeout()
+        }
+        return yield* users.list(payload.search).pipe(
+          Effect.catchReason(
+            "UsersError",
+            "SearchQueryTooShort",
+            // Re-fail the "SearchQueryTooShort" reason
+            Effect.fail,
+            // All other reasons are unexpected, so we convert them into a 500
+            // Internal Server Error.
+            Effect.die
           )
-        })
-      )
-      .handle("getById", ({ params }) =>
+        )
+      }),
+      getById: ({ params }) =>
         users.getById(params.id).pipe(
           // You can also use Effect.catchReasons to handle multiple error
           // reasons at once
           Effect.catchReasons("UsersError", {
             UserNotFound: (e) => Effect.fail(e)
           }, Effect.die)
-        ))
-      .handle("create", ({ payload }) =>
+        ),
+      create: ({ payload }) =>
         users.create(payload).pipe(
           Effect.orDie
           // You could alse use Effect.unwrapReason to moves rror reasons up to
@@ -61,17 +58,18 @@ export const UsersApiHandlersNoDeps = HttpApiBuilder.group(
           //   UserNotFound: Effect.die,
           //   SearchQueryTooShort: Effect.die
           // })
-        ))
-      .handle("update", ({ params, payload }) =>
+        ),
+      update: ({ params, payload }) =>
         users.update(params.id, payload).pipe(
           Effect.catchReasons("UsersError", {
             UserNotFound: (e) => Effect.fail(e)
           }, Effect.die)
-        ))
-      .handle("me", () =>
+        ),
+      me: () =>
         // The Authorization middleware provides the CurrentUser service, so we
         // can access it here.
-        CurrentUser)
+        CurrentUser
+    })
   })
 )
 

--- a/packages/effect/HTTPAPI.md
+++ b/packages/effect/HTTPAPI.md
@@ -380,6 +380,8 @@ Layer.launch(ApiLayer).pipe(NodeRuntime.runMain)
 
 Use `HttpApiEndpoint.post` to create an endpoint that accepts data. The `payload` option describes the shape of the request body, and `success` describes what the endpoint returns.
 
+When a group has more than one endpoint, use `.handleAll` to register all the handlers in a single call, keyed by endpoint name. Single endpoints can still be registered one at a time with `.handle`.
+
 **Example** (Defining a POST Endpoint with Payload and Success Schemas)
 
 ```ts
@@ -421,21 +423,22 @@ const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
-    handlers
-      .handle("getUsers", () =>
+    handlers.handleAll({
+      getUsers: () =>
         Effect.succeed(
           [{ id: 1, name: "User 1" }, { id: 2, name: "User 2" }]
-        ))
-      .handle("getUser", (ctx) => {
+        ),
+      getUser: (ctx) => {
         const id = ctx.params.id
         return Effect.succeed({ id, name: `User ${id}` })
-      })
-      .handle("createUser", (ctx) => {
+      },
+      createUser: (ctx) => {
         //    ┌─── User
         //    ▼
         const user = ctx.payload
         return Effect.succeed(user)
-      })
+      }
+    })
 )
 
 const ApiLayer = HttpApiBuilder.layer(Api).pipe(
@@ -497,23 +500,24 @@ const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
-    handlers
-      .handle("getUsers", () =>
+    handlers.handleAll({
+      getUsers: () =>
         Effect.succeed(
           [{ id: 1, name: "User 1" }, { id: 2, name: "User 2" }]
-        ))
-      .handle("getUser", (ctx) => {
+        ),
+      getUser: (ctx) => {
         const id = ctx.params.id
         return Effect.succeed({ id, name: `User ${id}` })
-      })
-      .handle("createUser", (ctx) => {
+      },
+      createUser: (ctx) => {
         const user = ctx.payload
         return Effect.succeed(user)
-      })
-      .handle("deleteUser", (ctx) => {
+      },
+      deleteUser: (ctx) => {
         const id = ctx.params.id
         return Effect.log(`Deleting user ${id}`)
-      })
+      }
+    })
 )
 
 const ApiLayer = HttpApiBuilder.layer(Api).pipe(
@@ -586,27 +590,28 @@ const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
-    handlers
-      .handle("getUsers", () =>
+    handlers.handleAll({
+      getUsers: () =>
         Effect.succeed(
           [{ id: 1, name: "User 1" }, { id: 2, name: "User 2" }]
-        ))
-      .handle("getUser", (ctx) => {
+        ),
+      getUser: (ctx) => {
         const id = ctx.params.id
         return Effect.succeed({ id, name: `User ${id}` })
-      })
-      .handle("createUser", (ctx) => {
+      },
+      createUser: (ctx) => {
         const user = ctx.payload
         return Effect.succeed(user)
-      })
-      .handle("deleteUser", (ctx) => {
+      },
+      deleteUser: (ctx) => {
         const id = ctx.params.id
         return Effect.log(`Deleting user ${id}`)
-      })
-      .handle("updateUser", (ctx) => {
+      },
+      updateUser: (ctx) => {
         const id = ctx.params.id
         return Effect.succeed({ id, name: `User ${id}` })
-      })
+      }
+    })
 )
 
 const ApiLayer = HttpApiBuilder.layer(Api).pipe(
@@ -660,17 +665,18 @@ const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
-    handlers
-      .handle("getUsers", () =>
+    handlers.handleAll({
+      getUsers: () =>
         Effect.succeed(
           [{ id: 1, name: "User 1" }, { id: 2, name: "User 2" }]
-        ))
-      .handle("getUser", (ctx) => {
+        ),
+      getUser: (ctx) => {
         //    ┌─── number
         //    ▼
         const id = ctx.params.id
         return Effect.succeed({ id, name: `User ${id}` })
-      })
+      }
+    })
 )
 
 const ApiLayer = HttpApiBuilder.layer(Api).pipe(
@@ -745,30 +751,31 @@ const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
-    handlers
-      .handle("getUsers", () =>
+    handlers.handleAll({
+      getUsers: () =>
         Effect.succeed(
           [{ id: 1, name: "User 1" }, { id: 2, name: "User 2" }]
-        ))
-      .handle("getUser", (ctx) => {
+        ),
+      getUser: (ctx) => {
         const id = ctx.params.id
         return Effect.succeed({ id, name: `User ${id}` })
-      })
-      .handle("createUser", (ctx) => {
+      },
+      createUser: (ctx) => {
         const user = ctx.payload
         return Effect.succeed(user)
-      })
-      .handle("deleteUser", (ctx) => {
+      },
+      deleteUser: (ctx) => {
         const id = ctx.params.id
         return Effect.log(`Deleting user ${id}`)
-      })
-      .handle("updateUser", (ctx) => {
+      },
+      updateUser: (ctx) => {
         const id = ctx.params.id
         return Effect.succeed({ id, name: `User ${id}` })
-      })
-      .handle("catchAll", () => {
+      },
+      catchAll: () => {
         return Effect.succeed("Not found")
-      })
+      }
+    })
 )
 
 const ApiLayer = HttpApiBuilder.layer(Api).pipe(
@@ -823,9 +830,10 @@ const GroupLayer = HttpApiBuilder.group(
   Api,
   "group",
   (handlers) =>
-    handlers
-      .handle("endpointA", () => Effect.succeed("Endpoint A"))
-      .handle("endpointB", () => Effect.succeed("Endpoint B"))
+    handlers.handleAll({
+      endpointA: () => Effect.succeed("Endpoint A"),
+      endpointB: () => Effect.succeed("Endpoint B")
+    })
 )
 
 const ApiLayer = HttpApiBuilder.layer(Api).pipe(
@@ -1839,12 +1847,13 @@ const GroupLayer = HttpApiBuilder.group(
   Api,
   "group",
   (handlers) =>
-    handlers
-      .handle("newPage", () => Effect.succeed("You are on /new"))
-      .handle("oldPage", () =>
+    handlers.handleAll({
+      newPage: () => Effect.succeed("You are on /new"),
+      oldPage: () =>
         Effect.succeed(
           HttpServerResponse.redirect("/new", { status: 302 })
-        ))
+        )
+    })
 )
 
 const ApiLayer = HttpApiBuilder.layer(Api).pipe(
@@ -2084,21 +2093,22 @@ const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
-    handlers
-      .handle("getUser", (ctx) => {
+    handlers.handleAll({
+      getUser: (ctx) => {
         const id = ctx.params.id
         if (id === 1) {
           return Effect.fail(UserNotFound.make({ message: "User not found" }))
         }
         return Effect.succeed({ id, name: `User ${id}` })
-      })
-      .handle("deleteUser", (ctx) => {
+      },
+      deleteUser: (ctx) => {
         const id = ctx.params.id
         if (id === 1) {
           return Effect.fail(UserNotFound.make({ message: "User not found" }))
         }
         return Effect.succeed(void 0)
-      })
+      }
+    })
 )
 
 const ApiLayer = HttpApiBuilder.layer(Api).pipe(
@@ -2839,27 +2849,28 @@ const GroupLayer = HttpApiBuilder.group(
   Api,
   "Users",
   (handlers) =>
-    handlers
-      .handle("getUsers", () =>
+    handlers.handleAll({
+      getUsers: () =>
         Effect.succeed(
           [{ id: 1, name: "User 1" }, { id: 2, name: "User 2" }]
-        ))
-      .handle("getUser", (ctx) => {
+        ),
+      getUser: (ctx) => {
         const id = ctx.params.id
         return Effect.succeed({ id, name: `User ${id}` })
-      })
-      .handle("createUser", (ctx) => {
+      },
+      createUser: (ctx) => {
         const user = ctx.payload
         return Effect.succeed(user)
-      })
-      .handle("deleteUser", (ctx) => {
+      },
+      deleteUser: (ctx) => {
         const id = ctx.params.id
         return Effect.log(`Deleting user ${id}`)
-      })
-      .handle("updateUser", (ctx) => {
+      },
+      updateUser: (ctx) => {
         const id = ctx.params.id
         return Effect.succeed({ id, name: `User ${id}` })
-      })
+      }
+    })
 )
 
 const ApiLayer = HttpApiBuilder.layer(Api).pipe(


### PR DESCRIPTION
## Summary

- rewrite the HttpApi system example to register its handler with `handleAll`
- consolidate the users example handlers into a single typed `handleAll` map
- preserve the existing handler behavior and dependency wiring

## Validation

- `pnpm lint-fix`
- `pnpm ai-docgen`
- `pnpm check`

Closes EFF-647