### PR TITLE
Add malformed cluster message coverage

### DIFF
--- a/packages/platform/node/test/cluster-integration/Persistence.test.ts
+++ b/packages/platform/node/test/cluster-integration/Persistence.test.ts
@@ -1,6 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Cause, Clock, DateTime, Effect, Exit, Fiber, Latch, Option, PrimaryKey, Schema, Stream } from "effect"
-import { ClusterSchema, DeliverAt, Entity } from "effect/unstable/cluster"
+import { ClusterSchema, DeliverAt, Entity, EntityId, ShardId } from "effect/unstable/cluster"
 import { Rpc, RpcSchema } from "effect/unstable/rpc"
 import { type Backend, make } from "./harness.ts"
 
@@ -521,6 +521,53 @@ describe("cluster message persistence integration", () => {
         )
         assert.deepStrictEqual(yield* cluster.messageCounts(), {
           failed: 2,
+          replied: 1,
+          unprocessed: 0
+        })
+      }))
+
+    it.live(`${backend}: defects a malformed persisted envelope without wedging the mailbox`, () =>
+      Effect.gen(function*() {
+        resetState()
+        const cluster = yield* make({ backend, entities: PersistenceEntityLayer })
+        const malformedId = `${backend}-malformed-stored`
+        const entityId = EntityId.make(malformedId)
+        const shardId = cluster.clientSharding.getShardId(entityId, PersistenceEntity.getShardGroup(entityId))
+        yield* cluster.insertMessage({
+          deliver_at: null,
+          entity_id: malformedId,
+          entity_type: PersistenceEntity.type,
+          headers: JSON.stringify({ invalid: 1 }),
+          id: "1",
+          kind: 0,
+          message_id: null,
+          payload: JSON.stringify({ id: malformedId }),
+          reply_id: null,
+          request_id: "1",
+          sampled: null,
+          shard_id: ShardId.toString(shardId),
+          span_id: null,
+          tag: "Healthy",
+          trace_id: null
+        })
+
+        yield* cluster.start(1)
+        yield* cluster.waitForStableAssignments()
+        yield* cluster.waitUntil(
+          "The malformed persisted envelope was not stored as a defect",
+          Effect.map(cluster.failedMessageCount, (value) => value === 1)
+        )
+        assert.strictEqual(count("Healthy", malformedId), 0)
+
+        const client = yield* cluster.getClient(PersistenceEntity)
+        const healthyId = `${backend}-malformed-stored-healthy`
+        assert.strictEqual(
+          yield* client("malformed-stored-healthy").Healthy(new KeyedPayload({ id: healthyId })),
+          `healthy:${healthyId}`
+        )
+        assert.strictEqual(count("Healthy", healthyId), 1)
+        assert.deepStrictEqual(yield* cluster.messageCounts(), {
+          failed: 1,
           replied: 1,
           unprocessed: 0
         })

--- a/packages/platform/node/test/cluster-integration/README.md
+++ b/packages/platform/node/test/cluster-integration/README.md
@@ -23,6 +23,7 @@ prefix, and every runner listens on an operating-system-assigned port.
 - `freeze(runner)` to suspend SQL heartbeats and lock refresh while leaving the runner's sockets and reserved SQL connection open.
 - `faultLock(runner, mode)` to blackhole, stick, fail, stick while blocking release of, or clear faults on a runner's reserved lock connection.
 - `cutSocket(runner, { peer, direction })` to close one inbound or outbound client/runner connection without stopping either endpoint.
+- `insertMessage(row)` to inject a raw row into this cluster's prefixed message table.
 - `waitUntil`, `waitForStableAssignments`, and `waitForEntityOwner` for deadline-based polling with cluster diagnostics on failure.
 - `clientSharding` and `ownersOfShard` for direct shard ownership assertions.
 - `messageCounts`, `unprocessedMessageCount`, `repliedMessageCount`, and `failedMessageCount` for storage assertions scoped to the cluster prefix.

--- a/packages/platform/node/test/cluster-integration/harness.ts
+++ b/packages/platform/node/test/cluster-integration/harness.ts
@@ -67,6 +67,24 @@ export interface CutSocketOptions {
   readonly peer: ClusterRunner | "client"
 }
 
+export interface InsertMessageRow {
+  readonly deliver_at: number | bigint | null
+  readonly entity_id: string
+  readonly entity_type: string
+  readonly headers: string | null
+  readonly id: string | bigint
+  readonly kind: 0 | 1 | 2
+  readonly message_id: string | null
+  readonly payload: string | null
+  readonly reply_id: string | bigint | null
+  readonly request_id: string | bigint
+  readonly sampled: boolean | number | null
+  readonly shard_id: string
+  readonly span_id: string | null
+  readonly tag: string | null
+  readonly trace_id: string | null
+}
+
 type HarnessConfig = Partial<ShardingConfig.ShardingConfig["Service"]> & {
   readonly shardLockDisableAdvisory: boolean
 }
@@ -525,6 +543,11 @@ export const make = Effect.fnUntraced(function*(options: MakeOptions) {
     return socketController.cut(source, target)
   }
 
+  const insertMessage = (row: InsertMessageRow) => {
+    const messages = sql(`${prefix}_messages`)
+    return sql`INSERT INTO ${messages} ${sql.insert({ ...row })}`.unprepared.pipe(Effect.asVoid)
+  }
+
   const assignmentMap = () => {
     const assignments: Record<string, ReadonlyArray<string>> = {}
     const groups = config.availableShardGroups ?? ShardingConfig.defaults.availableShardGroups
@@ -659,6 +682,7 @@ export const make = Effect.fnUntraced(function*(options: MakeOptions) {
     faultLock,
     freeze,
     getClient,
+    insertMessage,
     kill,
     lockMode: options.lockMode ?? "advisory",
     messageCounts,


### PR DESCRIPTION
## Summary

- add a typed `insertMessage(row)` cluster-integration harness API for prefixed message-table injection
- cover malformed persisted envelopes on PostgreSQL and MySQL
- verify the corrupt request is stored as a defect without invoking its handler or wedging subsequent mailbox work

## Validation

- `pnpm lint-fix`
- `EFFECT_CLUSTER_TESTS=1 pnpm test-cluster packages/platform/node/test/cluster-integration/Persistence.test.ts` (30 passed)
- `pnpm check`

Closes EFF-645