### PR TITLE
Run boolean flag fallbacks when the flag is absent

### DIFF
--- a/.changeset/cli-boolean-flag-fallbacks.md
+++ b/.changeset/cli-boolean-flag-fallbacks.md
@@ -1,0 +1,15 @@
+---
+"effect": patch
+---
+
+Run `withFallbackConfig` and `withFallbackPrompt` for boolean flags that are absent from the command line.
+
+Both fallbacks were driven by the `MissingOption` error, which a boolean flag never produces because it parses as `false` when absent. Applying either combinator to a `Flag.boolean` therefore did nothing, including in the documented example:
+
+```ts
+const verbose = Flag.boolean("verbose").pipe(
+  Flag.withFallbackConfig(Config.boolean("VERBOSE"))
+)
+```
+
+The fallback now runs whenever the flag is absent, so `VERBOSE=true` is honored. An explicit `--verbose` or `--no-verbose` still wins, and `optional`/`withDefault` still supply the value before any fallback is consulted. When the config is missing the flag falls back to `false` as before; a cancelled prompt fails with `MissingOption`, matching the existing behavior for other flags.

--- a/packages/effect/src/unstable/cli/Param.ts
+++ b/packages/effect/src/unstable/cli/Param.ts
@@ -1357,6 +1357,37 @@ export const withDefault: {
 })
 
 /**
+ * Returns the name of the boolean flag a param reads, if it reads exactly one
+ * and always parses it.
+ *
+ * An absent boolean flag parses as `false` instead of failing with
+ * `MissingOption`, so fallbacks that react to that error never run for one.
+ * Fallback combinators use this to detect the absent case themselves. Params
+ * wrapped by `optional` or `withDefault` already supply their own value, and
+ * alternatives introduced by `orElse` may provide the value instead, so neither
+ * takes part in a fallback.
+ */
+const booleanFlagName = <Kind extends ParamKind, A>(self: Param<Kind, A>): string | undefined =>
+  matchParam(self, {
+    Single: (single) => single.kind === "flag" && Primitive.isBoolean(single.primitiveType) ? single.name : undefined,
+    Map: (mapped) => booleanFlagName(mapped.param),
+    Transform: (transformed) => transformed.alternatives.length === 0 ? booleanFlagName(transformed.param) : undefined,
+    Optional: () => undefined,
+    Variadic: () => undefined
+  })
+
+/**
+ * Checks whether a flag was provided on the command line.
+ *
+ * The parser records aliases and `--no-` negations under the canonical flag
+ * name, so an explicitly negated boolean flag counts as provided.
+ */
+const isFlagProvided = (args: ParsedArgs, name: string): boolean => {
+  const values = args.flags[name]
+  return values !== undefined && values.length > 0
+}
+
+/**
  * Adds a fallback config that is loaded when a required parameter is missing.
  *
  * **When to use**
@@ -1367,12 +1398,14 @@ export const withDefault: {
  * **Details**
  *
  * Provided CLI values win. Config is loaded only after a missing option or
- * missing argument error.
+ * missing argument error. A boolean flag is never missing because it parses as
+ * `false` when absent, so config is loaded whenever the flag is absent from the
+ * command line, and `--flag` or `--no-flag` still wins.
  *
  * **Gotchas**
  *
- * Missing config preserves the original missing-parameter error. Config parse
- * failure becomes `CliError.InvalidValue`.
+ * Missing config preserves the original missing-parameter error, or `false` for
+ * a boolean flag. Config parse failure becomes `CliError.InvalidValue`.
  *
  * @see {@link withDefault} for a pure default value
  * @see {@link withFallbackPrompt} for prompting interactively when input is missing
@@ -1397,20 +1430,36 @@ export const withFallbackConfig: {
       expected: configError.message,
       kind: error._tag === "MissingOption" ? "flag" : "argument"
     })
-  const runConfig = (error: CliError.MissingOption | CliError.MissingArgument, args: ParsedArgs) =>
+  const runConfig = (
+    error: CliError.MissingOption | CliError.MissingArgument,
+    args: ParsedArgs,
+    onMissing: LazyArg<
+      Effect.Effect<readonly [leftover: ReadonlyArray<string>, value: A | B], CliError.CliError, Environment>
+    >
+  ) =>
     Config.option(config).pipe(
       Effect.mapError((configError) => toInvalidValue(error, configError)),
       Effect.flatMap(Option.match({
-        onNone: () => Effect.fail(error),
+        onNone: onMissing,
         onSome: (value) => Effect.succeed([args.arguments, value as A | B] as const)
       }))
     )
+  const flagName = booleanFlagName(self)
   return transform(
     self,
-    (parse) => (args) =>
-      parse(args).pipe(
-        Effect.catchTag(["MissingOption", "MissingArgument"], (error) => runConfig(error, args))
+    (parse) => (args) => {
+      // A boolean flag parses as `false` when absent instead of failing, so the
+      // config has to be loaded before parsing rather than after it fails.
+      if (flagName !== undefined && !isFlagProvided(args, flagName)) {
+        return runConfig(new CliError.MissingOption({ option: flagName }), args, () => parse(args))
+      }
+      return parse(args).pipe(
+        Effect.catchTag(
+          ["MissingOption", "MissingArgument"],
+          (error) => runConfig(error, args, () => Effect.fail(error))
+        )
       )
+    }
   )
 })
 
@@ -1426,6 +1475,9 @@ export const withFallbackConfig: {
  *
  * `FallbackPrompt` accepts either a `Prompt` or an effect that builds one.
  * Effectful prompt creation is lazy and runs only when the fallback is needed.
+ * A boolean flag is never missing because it parses as `false` when absent, so
+ * the prompt runs whenever the flag is absent from the command line, and
+ * `--flag` or `--no-flag` still wins.
  *
  * **Gotchas**
  *
@@ -1451,12 +1503,19 @@ export const withFallbackPrompt: {
       Effect.map((value) => [args.arguments, value as A | B] as const),
       Effect.catchTag("QuitError", () => Effect.fail(error))
     )
+  const flagName = booleanFlagName(self)
   return transform(
     self,
-    (parse) => (args) =>
-      parse(args).pipe(
+    (parse) => (args) => {
+      // A boolean flag parses as `false` when absent instead of failing, so the
+      // prompt has to run before parsing rather than after it fails.
+      if (flagName !== undefined && !isFlagProvided(args, flagName)) {
+        return runPrompt(new CliError.MissingOption({ option: flagName }), args)
+      }
+      return parse(args).pipe(
         Effect.catchTag(["MissingOption", "MissingArgument"], (error) => runPrompt(error, args))
       )
+    }
   )
 })
 

--- a/packages/effect/test/unstable/cli/Param.test.ts
+++ b/packages/effect/test/unstable/cli/Param.test.ts
@@ -271,17 +271,67 @@ describe("Param", () => {
         assert.instanceOf(error, CliError.InvalidValue)
       }).pipe(Effect.provide(TestLayer)))
 
-    it.effect("does not prompt for missing boolean flags", () =>
+    it.effect("prompts for boolean flags that are absent", () =>
       Effect.gen(function*() {
-        const prompt = Prompt.text({ message: "Verbose" })
+        const prompt = Prompt.confirm({ message: "Verbose" })
         const flag = Flag.boolean("verbose").pipe(Flag.withFallbackPrompt(prompt))
+
+        yield* MockTerminal.inputText("y")
+
+        const [remaining, value] = yield* flag.parse({
+          flags: {},
+          arguments: ["tail"]
+        })
+
+        assert.strictEqual(value, true)
+        assert.deepStrictEqual(remaining, ["tail"])
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("does not prompt for negated boolean flags", () =>
+      Effect.gen(function*() {
+        const prompt = Prompt.confirm({ message: "Verbose" })
+        const flag = Flag.boolean("verbose").pipe(Flag.withFallbackPrompt(prompt))
+
+        // `--no-verbose` is recorded under the canonical flag name
+        const [, value] = yield* flag.parse({
+          flags: { verbose: ["false"] },
+          arguments: []
+        })
+
+        assert.strictEqual(value, false)
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("prefers defaults over fallback prompts for boolean flags", () =>
+      Effect.gen(function*() {
+        const prompt = Prompt.confirm({ message: "Verbose" })
+        const flag = Flag.boolean("verbose").pipe(
+          Flag.withDefault(true),
+          Flag.withFallbackPrompt(prompt)
+        )
 
         const [, value] = yield* flag.parse({
           flags: {},
           arguments: []
         })
 
-        assert.strictEqual(value, false)
+        assert.strictEqual(value, true)
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("returns MissingOption when a boolean flag prompt is cancelled", () =>
+      Effect.gen(function*() {
+        const prompt = Prompt.confirm({ message: "Verbose" })
+        const flag = Flag.boolean("verbose").pipe(Flag.withFallbackPrompt(prompt))
+
+        yield* MockTerminal.inputKey("c", { ctrl: true })
+
+        const error = yield* Effect.flip(
+          flag.parse({
+            flags: {},
+            arguments: []
+          })
+        )
+
+        assert.instanceOf(error, CliError.MissingOption)
       }).pipe(Effect.provide(TestLayer)))
 
     it.effect("returns MissingOption when prompt is cancelled", () =>
@@ -424,6 +474,126 @@ describe("Param", () => {
       return Effect.gen(function*() {
         const flag = Flag.integer("count").pipe(
           Flag.withFallbackConfig(Config.int("COUNT"))
+        )
+
+        const error = yield* Effect.flip(
+          flag.parse({
+            flags: {},
+            arguments: []
+          })
+        )
+
+        assert.instanceOf(error, CliError.InvalidValue)
+      }).pipe(
+        Effect.provideService(ConfigProvider.ConfigProvider, provider),
+        Effect.provide(TestLayer)
+      )
+    })
+
+    it.effect("uses ConfigProvider when a boolean flag is absent", () => {
+      const provider = ConfigProvider.fromEnv({
+        env: {
+          VERBOSE: "true"
+        }
+      })
+
+      return Effect.gen(function*() {
+        const flag = Flag.boolean("verbose").pipe(
+          Flag.withFallbackConfig(Config.boolean("VERBOSE"))
+        )
+
+        const [, value] = yield* flag.parse({
+          flags: {},
+          arguments: []
+        })
+
+        assert.strictEqual(value, true)
+      }).pipe(
+        Effect.provideService(ConfigProvider.ConfigProvider, provider),
+        Effect.provide(TestLayer)
+      )
+    })
+
+    it.effect("uses negated boolean flags before reading config fallbacks", () => {
+      const provider = ConfigProvider.fromEnv({
+        env: {
+          VERBOSE: "true"
+        }
+      })
+
+      return Effect.gen(function*() {
+        const flag = Flag.boolean("verbose").pipe(
+          Flag.withFallbackConfig(Config.boolean("VERBOSE"))
+        )
+
+        // `--no-verbose` is recorded under the canonical flag name
+        const [, value] = yield* flag.parse({
+          flags: { verbose: ["false"] },
+          arguments: []
+        })
+
+        assert.strictEqual(value, false)
+      }).pipe(
+        Effect.provideService(ConfigProvider.ConfigProvider, provider),
+        Effect.provide(TestLayer)
+      )
+    })
+
+    it.effect("returns false when a boolean flag is absent and config is missing", () => {
+      const provider = ConfigProvider.fromEnv({ env: {} })
+
+      return Effect.gen(function*() {
+        const flag = Flag.boolean("verbose").pipe(
+          Flag.withFallbackConfig(Config.boolean("VERBOSE"))
+        )
+
+        const [, value] = yield* flag.parse({
+          flags: {},
+          arguments: []
+        })
+
+        assert.strictEqual(value, false)
+      }).pipe(
+        Effect.provideService(ConfigProvider.ConfigProvider, provider),
+        Effect.provide(TestLayer)
+      )
+    })
+
+    it.effect("prefers defaults over config fallbacks for boolean flags", () => {
+      const provider = ConfigProvider.fromEnv({
+        env: {
+          VERBOSE: "false"
+        }
+      })
+
+      return Effect.gen(function*() {
+        const flag = Flag.boolean("verbose").pipe(
+          Flag.withDefault(true),
+          Flag.withFallbackConfig(Config.boolean("VERBOSE"))
+        )
+
+        const [, value] = yield* flag.parse({
+          flags: {},
+          arguments: []
+        })
+
+        assert.strictEqual(value, true)
+      }).pipe(
+        Effect.provideService(ConfigProvider.ConfigProvider, provider),
+        Effect.provide(TestLayer)
+      )
+    })
+
+    it.effect("returns InvalidValue when boolean config fails to parse", () => {
+      const provider = ConfigProvider.fromEnv({
+        env: {
+          VERBOSE: "nope"
+        }
+      })
+
+      return Effect.gen(function*() {
+        const flag = Flag.boolean("verbose").pipe(
+          Flag.withFallbackConfig(Config.boolean("VERBOSE"))
         )
 
         const error = yield* Effect.flip(


### PR DESCRIPTION
Quick second PR of the day, this one has more tests and does contradict with an earlier commit although I think this is for the better. Feel free to close/adjust if you don't agree.

The following is from the clanker again.

---

`Flag.withFallbackConfig` and `Flag.withFallbackPrompt` are silent no-ops when applied to a boolean flag. Both fallbacks are driven by the `MissingOption` / `MissingArgument` errors, and an absent boolean flag never produces one — the parser resolves it to `false`, which is correct CLI behaviour on its own. The consequence is that the fallback simply never runs.

The JSDoc on `Flag.withFallbackConfig` uses a boolean flag as its only example, so this is the shape people copy:

```ts
const verbose = Flag.boolean("verbose").pipe(
  Flag.withFallbackConfig(Config.boolean("VERBOSE"))
)
```

Nothing fails — a config value is just ignored, which is easy to ship and hard to notice.

## Reproduction

```ts
Command.make("probe", {
  bool: Flag.boolean("bool").pipe(Flag.withFallbackConfig(Config.boolean("PROBE_VALUE"))),
  str: Flag.string("str").pipe(Flag.withFallbackConfig(Config.string("PROBE_VALUE")))
}, Effect.fn(function*({ bool, str }) {
  yield* Console.log(`bool=${bool} str=${str}`)
}))
```

```
$ PROBE_VALUE=true probe
bool=false str=true
```

One environment variable, one combinator, two outcomes depending only on the flag's primitive type.

## The fix

Both combinators now detect the boolean flag a param reads and consult the fallback when that flag is absent from the parsed flags, before parsing resolves it to `false`.

No parser change was needed. The parser already canonicalizes aliases and records `--no-flag` as `"false"` under the canonical flag name, so "no entry in `ParsedArgs.flags`" is exactly "absent from the command line" — the same check `parseFlag` already makes before defaulting to `false`.

Precedence is unchanged everywhere else:

- `--flag` and `--no-flag` both win over the fallback.
- `optional` and `withDefault` supply their own value first, so the fallback is not consulted — matching how they already shadow the fallback for non-boolean flags.
- A param with `orElse` alternatives is left alone, since the alternative may supply the value.
- Missing config still yields `false`; a cancelled prompt still fails with `MissingOption`.

## Open question for maintainers: should `withFallbackPrompt` change too?

The `withFallbackConfig` half is an unambiguous bug fix. The `withFallbackPrompt` half is not, and I'd like your call on it.

It reverses a deliberate decision from `2e3e4b246` ("Add Flag.withFallbackPrompt"), whose spec said:

> Boolean flags that are absent still default to `false` and do not trigger the fallback prompt (consistent with existing parsing rules).

There was a passing test asserting exactly that, which this PR inverts.

The case for changing it: it is the identical no-op, for the identical reason. If `withFallbackConfig` on a boolean flag should do something, it is hard to argue `withFallbackPrompt` should not.

The case against: a boolean flag is inherently optional, so "absent" is not really a missing value the way it is for a required string flag. Prompting on every invocation where `--flag` was omitted is a much more visible behaviour change than reading an environment variable.

Happy to drop that half and keep this to `withFallbackConfig` (the commit is easy to split), or to keep both. If they stay split, the alternative for the prompt side is to document the limitation instead — the JSDoc examples currently promise behaviour that does not happen.

## Testing

`packages/effect/test/unstable/cli/Param.test.ts` — 9 new cases across both combinators: the fallback fires when the flag is absent, `--no-flag` beats the fallback, missing config yields `false`, `withDefault` beats the fallback, an unparseable config value becomes `InvalidValue`, and a cancelled prompt fails with `MissingOption`.

With the source change reverted, 4 of them fail and 26 pass. The other 5 pass either way by design — they pin the precedence rules the fix must not disturb.

```
pnpm vitest run --project effect packages/effect/test/unstable/cli/Param.test.ts
```

`pnpm lint` and `pnpm check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
