### PR TITLE
Stabilize held-message storage timing test

### DIFF
--- a/packages/platform/node/test/cluster/SqlMessageStorage.integration.test.ts
+++ b/packages/platform/node/test/cluster/SqlMessageStorage.integration.test.ts
@@ -518,7 +518,7 @@ describe("SqlMessageStorage", () => {
       yield* Fiber.interrupt(fiber)
     }).pipe(Effect.provide(StorageLayer.pipe(
       Layer.provideMerge(SqliteLayer)
-    ))))
+    ))), { timeout: 15_000 })
 })
 
 const SqliteLayer = Effect.gen(function*() {


### PR DESCRIPTION
Raise the wall-clock timeout for the held-message layer-build integration test from Vitest's 5-second default to 15 seconds.

The test advances a virtual clock and normally completes in under 2 seconds, but full-shard CI contention has pushed its real runtime just over 5 seconds. This keeps the behavioral assertions unchanged while allowing sufficient layer-startup scheduling headroom.

Validation:

- Focused held-message test passes
- Complete `SqlMessageStorage.integration.test.ts` passes (56 tests)
- `pnpm lint` passes

Closes EFF-651
