### PR TITLE
Fix zero maxBytes handling in NodeStream

### DIFF
--- a/.changeset/fix-zero-max-bytes.md
+++ b/.changeset/fix-zero-max-bytes.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+Enforce zero-byte limits when consuming Node readable streams.

--- a/packages/platform/node-shared/src/NodeStream.ts
+++ b/packages/platform/node-shared/src/NodeStream.ts
@@ -245,6 +245,9 @@ export const toString = <E = Cause.UnknownError>(
       string += chunk
       bytes += Buffer.byteLength(chunk)
       if (maxBytesNumber !== undefined && bytes > maxBytesNumber) {
+        if ("closed" in stream && !stream.closed) {
+          stream.destroy()
+        }
         resume(Effect.fail(onError(new Error("maxBytes exceeded")) as E))
       }
     })
@@ -296,6 +299,9 @@ export const toArrayBuffer = <E = Cause.UnknownError>(
       buffers.push(chunk)
       bytes += chunk.length
       if (maxBytesNumber !== undefined && bytes > maxBytesNumber) {
+        if ("closed" in stream && !stream.closed) {
+          stream.destroy()
+        }
         resume(Effect.fail(onError(new Error("maxBytes exceeded")) as E))
       }
     })

--- a/packages/platform/node-shared/src/NodeStream.ts
+++ b/packages/platform/node-shared/src/NodeStream.ts
@@ -222,7 +222,7 @@ export const toString = <E = Cause.UnknownError>(
     readonly maxBytes?: SizeInput | undefined
   }
 ): Effect.Effect<string, E> => {
-  const maxBytesNumber = options?.maxBytes ? Number(options.maxBytes) : undefined
+  const maxBytesNumber = options?.maxBytes !== undefined ? Number(options.maxBytes) : undefined
   const onError = options?.onError ?? defaultOnError
   const encoding = options?.encoding ?? "utf8"
   return Effect.callback((resume) => {
@@ -244,7 +244,7 @@ export const toString = <E = Cause.UnknownError>(
     stream.on("data", (chunk) => {
       string += chunk
       bytes += Buffer.byteLength(chunk)
-      if (maxBytesNumber && bytes > maxBytesNumber) {
+      if (maxBytesNumber !== undefined && bytes > maxBytesNumber) {
         resume(Effect.fail(onError(new Error("maxBytes exceeded")) as E))
       }
     })
@@ -271,7 +271,7 @@ export const toArrayBuffer = <E = Cause.UnknownError>(
     readonly maxBytes?: SizeInput | undefined
   }
 ): Effect.Effect<ArrayBuffer, E> => {
-  const maxBytesNumber = options?.maxBytes ? Number(options.maxBytes) : undefined
+  const maxBytesNumber = options?.maxBytes !== undefined ? Number(options.maxBytes) : undefined
   const onError = options?.onError ?? defaultOnError
   return Effect.callback((resume) => {
     const stream = readable() as Readable
@@ -295,7 +295,7 @@ export const toArrayBuffer = <E = Cause.UnknownError>(
     stream.on("data", (chunk) => {
       buffers.push(chunk)
       bytes += chunk.length
-      if (maxBytesNumber && bytes > maxBytesNumber) {
+      if (maxBytesNumber !== undefined && bytes > maxBytesNumber) {
         resume(Effect.fail(onError(new Error("maxBytes exceeded")) as E))
       }
     })

--- a/packages/platform/node-shared/test/NodeStream.test.ts
+++ b/packages/platform/node-shared/test/NodeStream.test.ts
@@ -180,4 +180,24 @@ describe("Stream", () => {
       yield* Effect.yieldNow
       assert.strictEqual(stream.listenerCount("error"), 1)
     }))
+
+  it.effect("toString enforces a zero maxBytes limit", () =>
+    Effect.gen(function*() {
+      const error = yield* NodeStream.toString(() => Readable.from(["a"]), {
+        maxBytes: 0,
+        onError: () => "maxBytes exceeded" as const
+      }).pipe(Effect.flip)
+
+      assert.strictEqual(error, "maxBytes exceeded")
+    }))
+
+  it.effect("toArrayBuffer enforces a zero maxBytes limit", () =>
+    Effect.gen(function*() {
+      const error = yield* NodeStream.toArrayBuffer(() => Readable.from([Buffer.from("a")]), {
+        maxBytes: 0,
+        onError: () => "maxBytes exceeded" as const
+      }).pipe(Effect.flip)
+
+      assert.strictEqual(error, "maxBytes exceeded")
+    }))
 })

--- a/packages/platform/node-shared/test/NodeStream.test.ts
+++ b/packages/platform/node-shared/test/NodeStream.test.ts
@@ -183,21 +183,39 @@ describe("Stream", () => {
 
   it.effect("toString enforces a zero maxBytes limit", () =>
     Effect.gen(function*() {
-      const error = yield* NodeStream.toString(() => Readable.from(["a"]), {
+      let emitted = false
+      const stream = new Readable({
+        read() {
+          if (emitted) return
+          emitted = true
+          this.push("a")
+        }
+      })
+      const error = yield* NodeStream.toString(() => stream, {
         maxBytes: 0,
         onError: () => "maxBytes exceeded" as const
       }).pipe(Effect.flip)
 
       assert.strictEqual(error, "maxBytes exceeded")
+      assert.isTrue(stream.destroyed)
     }))
 
   it.effect("toArrayBuffer enforces a zero maxBytes limit", () =>
     Effect.gen(function*() {
-      const error = yield* NodeStream.toArrayBuffer(() => Readable.from([Buffer.from("a")]), {
+      let emitted = false
+      const stream = new Readable({
+        read() {
+          if (emitted) return
+          emitted = true
+          this.push(Buffer.from("a"))
+        }
+      })
+      const error = yield* NodeStream.toArrayBuffer(() => stream, {
         maxBytes: 0,
         onError: () => "maxBytes exceeded" as const
       }).pipe(Effect.flip)
 
       assert.strictEqual(error, "maxBytes exceeded")
+      assert.isTrue(stream.destroyed)
     }))
 })


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`NodeStream.toString` and `NodeStream.toArrayBuffer` accepted `maxBytes: 0`, but truthiness checks treated the value as if no limit had been supplied. Both functions therefore consumed non-empty streams even though the configured maximum was zero.

This replaces the truthiness checks with explicit `undefined` checks in both sibling implementations, preserving zero as a valid limit. Focused regression tests cover both the string and binary consumers.

Validation:

- New tests failed on the unmodified implementation by returning one byte.
- `vitest run packages/platform/node-shared/test/NodeStream.test.ts` (12 tests passed)
- `tsc -b tsconfig.json`
- `oxlint -f unix`
- `dprint check`

## Related

- Related Issue #
- Closes #