### PR TITLE
feat: add v2025-11-25 protocol adapter

### DIFF
--- a/.changeset/add-mcp-2025-11-25-protocol.md
+++ b/.changeset/add-mcp-2025-11-25-protocol.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+MCP servers can now use the 2025-11-25 protocol, including sampling with tools and both form- and URL-based elicitation.
+
+Enable it by adding `McpProtocol.v2025_11_25` to the server's `protocols` option.

--- a/.changeset/add-mcp-icons.md
+++ b/.changeset/add-mcp-icons.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+MCP servers can now provide icons for server information, resources, resource templates, prompts, and tools using `McpSchema.Icon`.
+
+Each icon can specify its source URI, MIME type, supported sizes, and light or dark theme.

--- a/packages/effect/src/unstable/ai/McpProtocol.ts
+++ b/packages/effect/src/unstable/ai/McpProtocol.ts
@@ -12,6 +12,7 @@ import type * as RpcGroup from "../rpc/RpcGroup.ts"
 import { protocol as protocol2024_11_05 } from "./internal/mcpProtocol/v2024_11_05.ts"
 import { protocol as protocol2025_03_26 } from "./internal/mcpProtocol/v2025_03_26.ts"
 import { protocol as protocol2025_06_18 } from "./internal/mcpProtocol/v2025_06_18.ts"
+import { protocol as protocol2025_11_25 } from "./internal/mcpProtocol/v2025_11_25.ts"
 import type * as McpSchema from "./McpSchema.ts"
 
 /**
@@ -20,7 +21,7 @@ import type * as McpSchema from "./McpSchema.ts"
  * @category models
  * @since 4.0.0
  */
-export type ProtocolVersion = "2024-11-05" | "2025-03-26" | "2025-06-18"
+export type ProtocolVersion = "2024-11-05" | "2025-03-26" | "2025-06-18" | "2025-11-25"
 
 /**
  * Payload codecs used by a protocol adapter.
@@ -104,6 +105,14 @@ export interface AnyProtocolAdapter<out Version extends string = string, Handler
 export interface ProtocolAdapter<out Version extends ProtocolVersion = ProtocolVersion>
   extends AnyProtocolAdapter<Version>
 {}
+
+/**
+ * The MCP 2025-11-25 protocol implementation.
+ *
+ * @category protocols
+ * @since 4.0.0
+ */
+export const v2025_11_25: ProtocolAdapter<"2025-11-25"> = protocol2025_11_25
 
 /**
  * The MCP 2025-06-18 protocol implementation.

--- a/packages/effect/src/unstable/ai/McpSchema.ts
+++ b/packages/effect/src/unstable/ai/McpSchema.ts
@@ -301,8 +301,38 @@ export class Annotations extends Schema.Opaque<Annotations>()(Schema.Struct({
    * effectively required, while 0 means "least important," and indicates that
    * the data is entirely optional.
    */
-  priority: optional(Schema.Finite.check(Schema.isBetween({ minimum: 0, maximum: 1 })))
+  priority: optional(Schema.Finite.check(Schema.isBetween({ minimum: 0, maximum: 1 }))),
+  /**
+   * The last time the annotated object was modified, formatted as an ISO 8601
+   * timestamp.
+   */
+  lastModified: optional(Schema.String)
 })) {}
+
+/**
+ * Schema for an icon that an MCP client can display.
+ *
+ * @category schemas
+ * @since 4.0.0
+ */
+export class Icon extends Schema.Class<Icon>("@effect/ai/McpSchema/Icon")({
+  /**
+   * URI containing the icon image.
+   */
+  src: Schema.String,
+  /**
+   * MIME type of the icon, when known.
+   */
+  mimeType: optional(Schema.String),
+  /**
+   * Sizes supported by the icon, such as `"48x48"` or `"any"`.
+   */
+  sizes: optional(Schema.Array(Schema.String)),
+  /**
+   * Color theme for which the icon was designed.
+   */
+  theme: optional(Schema.Literals(["light", "dark"]))
+}) {}
 
 /**
  * Describes the name and version of an MCP implementation.
@@ -313,7 +343,10 @@ export class Annotations extends Schema.Opaque<Annotations>()(Schema.Struct({
 export class Implementation extends Schema.Opaque<Implementation>()(Schema.Struct({
   name: Schema.String,
   title: optional(Schema.String),
-  version: Schema.String
+  version: Schema.String,
+  icons: optional(Schema.Array(Icon)),
+  description: optional(Schema.String),
+  websiteUrl: optional(Schema.String)
 })) {}
 
 /**
@@ -356,11 +389,29 @@ export class ClientCapabilities extends Schema.Class<ClientCapabilities>(
   /**
    * Present if the client supports sampling from an LLM.
    */
-  sampling: optional(Schema.Struct({})),
+  sampling: optional(Schema.Struct({
+    /**
+     * Present if the client supports context inclusion during sampling.
+     */
+    context: optional(Schema.Struct({})),
+    /**
+     * Present if the client supports tool use during sampling.
+     */
+    tools: optional(Schema.Struct({}))
+  })),
   /**
    * Present if the client supports elicitation from the server.
    */
-  elicitation: optional(Schema.Struct({}))
+  elicitation: optional(Schema.Struct({
+    /**
+     * Present if the client supports form-mode elicitation.
+     */
+    form: optional(Schema.Struct({})),
+    /**
+     * Present if the client supports URL-mode elicitation.
+     */
+    url: optional(Schema.Struct({}))
+  }))
 }) {}
 
 /**
@@ -851,6 +902,10 @@ export class Resource extends Schema.Class<Resource>(
    */
   annotations: optional(Annotations),
   /**
+   * Icons that clients can display for this resource.
+   */
+  icons: optional(Schema.Array(Icon)),
+  /**
    * The size of the raw resource content, in bytes (i.e., before base64
    * encoding or any tokenization), if known.
    *
@@ -906,6 +961,10 @@ export class ResourceTemplate extends Schema.Class<ResourceTemplate>(
    * Optional annotations for the client.
    */
   annotations: optional(Annotations),
+  /**
+   * Icons that clients can display for this resource template.
+   */
+  icons: optional(Schema.Array(Icon)),
 
   /**
    * Optional additional metadata for the client.
@@ -1172,6 +1231,10 @@ export class Prompt extends Schema.Class<Prompt>(
    * A list of arguments to use for templating the prompt.
    */
   arguments: optional(Schema.Array(PromptArgument)),
+  /**
+   * Icons that clients can display for this prompt.
+   */
+  icons: optional(Schema.Array(Icon)),
   _meta: optional(Schema.Record(Schema.String, Schema.Json))
 }) {}
 
@@ -1520,6 +1583,10 @@ export class Tool extends Schema.Class<Tool>(
    */
   annotations: optional(ToolAnnotations),
   /**
+   * Icons that clients can display for this tool.
+   */
+  icons: optional(Schema.Array(Icon)),
+  /**
    * Optional additional metadata for the client.
    *
    * This parameter name is reserved by MCP to allow clients and servers to
@@ -1728,6 +1795,70 @@ export class LoggingMessageNotification extends Rpc.make("notifications/message"
 // =============================================================================
 
 /**
+ * Schema for a tool-use request produced during MCP sampling.
+ *
+ * @category sampling
+ * @since 4.0.0
+ */
+export class ToolUseContent extends Schema.Class<ToolUseContent>("@effect/ai/McpSchema/ToolUseContent")({
+  type: Schema.tag("tool_use"),
+  /**
+   * Identifier used to associate a later tool result with this request.
+   */
+  id: Schema.String,
+  /**
+   * Name of the tool to invoke.
+   */
+  name: Schema.String,
+  /**
+   * Arguments supplied to the tool.
+   */
+  input: Schema.Record(Schema.String, Schema.Unknown),
+  _meta: optional(Schema.Record(Schema.String, Schema.Json))
+}) {}
+
+/**
+ * Schema for the result of a tool use supplied in a sampling message.
+ *
+ * @category sampling
+ * @since 4.0.0
+ */
+export class ToolResultContent extends Schema.Class<ToolResultContent>("@effect/ai/McpSchema/ToolResultContent")({
+  type: Schema.tag("tool_result"),
+  /**
+   * Identifier of the tool-use request that produced this result.
+   */
+  toolUseId: Schema.String,
+  /**
+   * Content returned by the tool.
+   */
+  content: Schema.Array(ContentBlock),
+  /**
+   * Optional structured result returned by the tool.
+   */
+  structuredContent: optional(Schema.Record(Schema.String, Schema.Unknown)),
+  /**
+   * Whether tool execution ended in an error.
+   */
+  isError: optional(Schema.Boolean),
+  _meta: optional(Schema.Record(Schema.String, Schema.Json))
+}) {}
+
+/**
+ * Schema for content blocks accepted in MCP sampling messages.
+ *
+ * @category sampling
+ * @since 4.0.0
+ */
+export const SamplingMessageContentBlock = Schema.Union([
+  TextContent,
+  ImageContent,
+  AudioContent,
+  ToolUseContent,
+  ToolResultContent
+])
+
+/**
  * Describes a message issued to or received from an LLM API.
  *
  * @category schemas
@@ -1735,8 +1866,22 @@ export class LoggingMessageNotification extends Rpc.make("notifications/message"
  */
 export class SamplingMessage extends Schema.Opaque<SamplingMessage>()(Schema.Struct({
   role: Role,
-  content: Schema.Union([TextContent, ImageContent, AudioContent])
+  content: Schema.Union([SamplingMessageContentBlock, Schema.Array(SamplingMessageContentBlock)]),
+  _meta: optional(Schema.Record(Schema.String, Schema.Json))
 })) {}
+
+/**
+ * Schema for controlling tool selection during MCP sampling.
+ *
+ * @category sampling
+ * @since 4.0.0
+ */
+export class ToolChoice extends Schema.Class<ToolChoice>("@effect/ai/McpSchema/ToolChoice")({
+  /**
+   * Tool-selection mode requested from the client.
+   */
+  mode: optional(Schema.Literals(["auto", "required", "none"]))
+}) {}
 
 /**
  * Schema for model selection hints.
@@ -1838,7 +1983,8 @@ export class CreateMessageResult extends Schema.Class<CreateMessageResult>(
   "@effect/ai/McpSchema/CreateMessageResult"
 )({
   role: Role,
-  content: Schema.Union([TextContent, ImageContent, AudioContent]),
+  content: Schema.Union([SamplingMessageContentBlock, Schema.Array(SamplingMessageContentBlock)]),
+  _meta: optional(Schema.Record(Schema.String, Schema.Json)),
   /**
    * The name of the model that generated the message.
    */
@@ -1896,7 +2042,15 @@ export class CreateMessage extends Rpc.make("sampling/createMessage", {
      * Optional metadata to pass through to the LLM provider. The format of
      * this metadata is provider-specific.
      */
-    metadata: optional(Schema.Record(Schema.String, Schema.Unknown))
+    metadata: optional(Schema.Record(Schema.String, Schema.Unknown)),
+    /**
+     * Tools that the model may call while producing the response.
+     */
+    tools: optional(Schema.Array(Tool)),
+    /**
+     * Controls whether the model may or must call a tool.
+     */
+    toolChoice: optional(ToolChoice)
   }
 }) {}
 
@@ -2038,7 +2192,11 @@ export class Root extends Schema.Class<Root>(
    * identifier for the root, which may be useful for display purposes or for
    * referencing the root in other parts of the application.
    */
-  name: optional(Schema.String)
+  name: optional(Schema.String),
+  /**
+   * Optional additional metadata associated with the root.
+   */
+  _meta: optional(Schema.Record(Schema.String, Schema.Json))
 }) {}
 
 /**
@@ -2101,6 +2259,243 @@ export class RootsListChangedNotification extends Rpc.make("notifications/roots/
 // =============================================================================
 
 /**
+ * Schema for a string field in an MCP elicitation form.
+ *
+ * @category elicitation
+ * @since 4.0.0
+ */
+export class StringSchema extends Schema.Class<StringSchema>("@effect/ai/McpSchema/StringSchema")({
+  type: Schema.tag("string"),
+  title: optional(Schema.String),
+  description: optional(Schema.String),
+  minLength: optional(Schema.Int),
+  maxLength: optional(Schema.Int),
+  format: optional(Schema.Literals(["email", "uri", "date", "date-time"])),
+  default: optional(Schema.String)
+}) {}
+
+/**
+ * Schema for a numeric field in an MCP elicitation form.
+ *
+ * @category elicitation
+ * @since 4.0.0
+ */
+export class NumberSchema extends Schema.Class<NumberSchema>("@effect/ai/McpSchema/NumberSchema")({
+  type: Schema.Literals(["number", "integer"]),
+  title: optional(Schema.String),
+  description: optional(Schema.String),
+  minimum: optional(Schema.Finite),
+  maximum: optional(Schema.Finite),
+  default: optional(Schema.Finite)
+}) {}
+
+/**
+ * Schema for a boolean field in an MCP elicitation form.
+ *
+ * @category elicitation
+ * @since 4.0.0
+ */
+export class BooleanSchema extends Schema.Class<BooleanSchema>("@effect/ai/McpSchema/BooleanSchema")({
+  type: Schema.tag("boolean"),
+  title: optional(Schema.String),
+  description: optional(Schema.String),
+  default: optional(Schema.Boolean)
+}) {}
+
+/**
+ * Schema for an untitled single-select field in an MCP elicitation form.
+ *
+ * @category elicitation
+ * @since 4.0.0
+ */
+export class UntitledSingleSelectEnumSchema extends Schema.Class<UntitledSingleSelectEnumSchema>(
+  "@effect/ai/McpSchema/UntitledSingleSelectEnumSchema"
+)({
+  type: Schema.tag("string"),
+  title: optional(Schema.String),
+  description: optional(Schema.String),
+  enum: Schema.Array(Schema.String),
+  default: optional(Schema.String)
+}) {}
+
+/**
+ * Schema for a titled single-select field in an MCP elicitation form.
+ *
+ * @category elicitation
+ * @since 4.0.0
+ */
+export class TitledSingleSelectEnumSchema extends Schema.Class<TitledSingleSelectEnumSchema>(
+  "@effect/ai/McpSchema/TitledSingleSelectEnumSchema"
+)({
+  type: Schema.tag("string"),
+  title: optional(Schema.String),
+  description: optional(Schema.String),
+  oneOf: Schema.Array(Schema.Struct({
+    const: Schema.String,
+    title: Schema.String
+  })),
+  default: optional(Schema.String)
+}) {}
+
+/**
+ * Schema for every single-select field in an MCP elicitation form.
+ *
+ * @category elicitation
+ * @since 4.0.0
+ */
+export const SingleSelectEnumSchema = Schema.Union([
+  UntitledSingleSelectEnumSchema,
+  TitledSingleSelectEnumSchema
+])
+
+/**
+ * Schema for an untitled multi-select field in an MCP elicitation form.
+ *
+ * @category elicitation
+ * @since 4.0.0
+ */
+export class UntitledMultiSelectEnumSchema extends Schema.Class<UntitledMultiSelectEnumSchema>(
+  "@effect/ai/McpSchema/UntitledMultiSelectEnumSchema"
+)({
+  type: Schema.tag("array"),
+  title: optional(Schema.String),
+  description: optional(Schema.String),
+  minItems: optional(Schema.Int),
+  maxItems: optional(Schema.Int),
+  items: Schema.Struct({
+    type: Schema.tag("string"),
+    enum: Schema.Array(Schema.String)
+  }),
+  default: optional(Schema.Array(Schema.String))
+}) {}
+
+/**
+ * Schema for a titled multi-select field in an MCP elicitation form.
+ *
+ * @category elicitation
+ * @since 4.0.0
+ */
+export class TitledMultiSelectEnumSchema extends Schema.Class<TitledMultiSelectEnumSchema>(
+  "@effect/ai/McpSchema/TitledMultiSelectEnumSchema"
+)({
+  type: Schema.tag("array"),
+  title: optional(Schema.String),
+  description: optional(Schema.String),
+  minItems: optional(Schema.Int),
+  maxItems: optional(Schema.Int),
+  items: Schema.Struct({
+    anyOf: Schema.Array(Schema.Struct({
+      const: Schema.String,
+      title: Schema.String
+    }))
+  }),
+  default: optional(Schema.Array(Schema.String))
+}) {}
+
+/**
+ * Schema for every multi-select field in an MCP elicitation form.
+ *
+ * @category elicitation
+ * @since 4.0.0
+ */
+export const MultiSelectEnumSchema = Schema.Union([
+  UntitledMultiSelectEnumSchema,
+  TitledMultiSelectEnumSchema
+])
+
+/**
+ * Schema for the legacy titled single-select elicitation field.
+ *
+ * @deprecated Use {@link TitledSingleSelectEnumSchema} instead.
+ * @category elicitation
+ * @since 4.0.0
+ */
+export class LegacyTitledEnumSchema extends Schema.Class<LegacyTitledEnumSchema>(
+  "@effect/ai/McpSchema/LegacyTitledEnumSchema"
+)({
+  type: Schema.tag("string"),
+  title: optional(Schema.String),
+  description: optional(Schema.String),
+  enum: Schema.Array(Schema.String),
+  enumNames: optional(Schema.Array(Schema.String)),
+  default: optional(Schema.String)
+}) {}
+
+/**
+ * Schema for every enumeration field in an MCP elicitation form.
+ *
+ * @category elicitation
+ * @since 4.0.0
+ */
+export const EnumSchema = Schema.Union([
+  SingleSelectEnumSchema,
+  MultiSelectEnumSchema,
+  LegacyTitledEnumSchema
+])
+
+/**
+ * Schema for primitive field definitions accepted by MCP elicitation forms.
+ *
+ * @category elicitation
+ * @since 4.0.0
+ */
+export const PrimitiveSchemaDefinition = Schema.Union([
+  StringSchema,
+  NumberSchema,
+  BooleanSchema,
+  EnumSchema
+])
+
+const ElicitationFormSchema = Schema.Struct({
+  $schema: optional(Schema.String),
+  type: Schema.tag("object"),
+  properties: Schema.Record(Schema.String, PrimitiveSchemaDefinition),
+  required: optional(Schema.Array(Schema.String))
+})
+
+/**
+ * Schema for form-mode MCP elicitation requests.
+ *
+ * @category elicitation
+ * @since 4.0.0
+ */
+export class ElicitRequestFormParams extends Schema.Class<ElicitRequestFormParams>(
+  "@effect/ai/McpSchema/ElicitRequestFormParams"
+)({
+  ...RequestMeta.fields,
+  mode: optional(Schema.Literal("form")),
+  message: Schema.String,
+  requestedSchema: ElicitationFormSchema
+}) {}
+
+/**
+ * Schema for URL-mode MCP elicitation requests.
+ *
+ * @category elicitation
+ * @since 4.0.0
+ */
+export class ElicitRequestURLParams extends Schema.Class<ElicitRequestURLParams>(
+  "@effect/ai/McpSchema/ElicitRequestURLParams"
+)({
+  ...RequestMeta.fields,
+  mode: Schema.Literal("url"),
+  message: Schema.String,
+  elicitationId: Schema.String,
+  url: Schema.String
+}) {}
+
+/**
+ * Schema for every MCP elicitation request mode.
+ *
+ * @category elicitation
+ * @since 4.0.0
+ */
+export const ElicitRequestParams = Schema.Union([
+  ElicitRequestFormParams,
+  ElicitRequestURLParams
+])
+
+/**
  * Schema for an accepted client response to an elicitation request.
  *
  * @category schemas
@@ -2121,7 +2516,10 @@ export class ElicitAcceptResult extends Schema.Class<ElicitAcceptResult>(
    * The submitted form data, only present when action is "accept".
    * Contains values matching the requested schema.
    */
-  content: Schema.Any
+  content: optional(Schema.Record(
+    Schema.String,
+    Schema.Union([Schema.String, Schema.Finite, Schema.Boolean, Schema.Array(Schema.String)])
+  ))
 }) {}
 
 /**
@@ -2169,17 +2567,18 @@ export const ElicitResult = Schema.Union([
 export class Elicit extends Rpc.make("elicitation/create", {
   success: ElicitResult,
   error: McpError,
+  payload: ElicitRequestParams
+}) {}
+
+/**
+ * Notifies a client that a URL-mode elicitation completed.
+ *
+ * @category elicitation
+ * @since 4.0.0
+ */
+export class ElicitationCompleteNotification extends Rpc.make("notifications/elicitation/complete", {
   payload: {
-    /**
-     * A message to display to the user, explaining what they are being
-     * elicited for.
-     */
-    message: Schema.String,
-    /**
-     * A restricted subset of JSON Schema.
-     * Only top-level properties are allowed, without nesting.
-     */
-    requestedSchema: Schema.Any
+    elicitationId: Schema.String
   }
 }) {}
 
@@ -2499,7 +2898,8 @@ export class ServerNotificationRpcs extends RpcGroup.make(
   ResourceUpdatedNotification,
   ResourceListChangedNotification,
   ToolListChangedNotification,
-  PromptListChangedNotification
+  PromptListChangedNotification,
+  ElicitationCompleteNotification
 ) {}
 
 /**

--- a/packages/effect/src/unstable/ai/McpSchema.ts
+++ b/packages/effect/src/unstable/ai/McpSchema.ts
@@ -2046,11 +2046,11 @@ export class CreateMessage extends Rpc.make("sampling/createMessage", {
     /**
      * Tools that the model may call while producing the response.
      */
-    tools: optional(Schema.Array(Tool)),
+    tools: optional(Schema.Array(Schema.Struct(Tool.fields))),
     /**
      * Controls whether the model may or must call a tool.
      */
-    toolChoice: optional(ToolChoice)
+    toolChoice: optional(Schema.Struct(ToolChoice.fields))
   }
 }) {}
 

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -2053,10 +2053,10 @@ export const elicit: <S extends Schema.ConstraintEncoder<Record<string, unknown>
   const { getClient } = yield* McpServerClient
   const client = yield* getClient
   const schema = options.schema
-  const request = Elicit.payloadSchema.make({
+  const request = yield* Schema.decodeUnknownEffect(Elicit.payloadSchema)({
     message: options.message,
     requestedSchema: Tool.getJsonSchemaFromSchema(schema)
-  })
+  }).pipe(Effect.orDie)
   const res = yield* client.elicit(request).pipe(
     Effect.catchCause((cause) => Effect.fail(new ElicitationDeclined({ cause: Cause.squash(cause), request })))
   )

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -50,7 +50,6 @@ import type * as McpProtocol from "./McpProtocol.ts"
 import * as McpSchema from "./McpSchema.ts"
 import {
   CallToolResult,
-  Elicit,
   ElicitationDeclined,
   EnabledWhen,
   GetPromptResult,
@@ -646,6 +645,9 @@ const layerMcpProtocolState = (
 export const run: (options: {
   readonly name: string
   readonly version: string
+  readonly description?: string | undefined
+  readonly websiteUrl?: string | undefined
+  readonly icons?: ReadonlyArray<McpSchema.Icon> | undefined
   readonly protocols: Arr.NonEmptyReadonlyArray<McpProtocol.ProtocolAdapter>
   readonly extensions?: ServerExtensions | undefined
 }) => Effect.Effect<
@@ -655,6 +657,9 @@ export const run: (options: {
 > = Effect.fnUntraced(function*(options: {
   readonly name: string
   readonly version: string
+  readonly description?: string | undefined
+  readonly websiteUrl?: string | undefined
+  readonly icons?: ReadonlyArray<McpSchema.Icon> | undefined
   readonly protocols: Arr.NonEmptyReadonlyArray<McpProtocol.ProtocolAdapter>
   readonly extensions?: ServerExtensions | undefined
 }) {
@@ -668,6 +673,9 @@ export const run: (options: {
 const runWithProtocolState = Effect.fnUntraced(function*(options: {
   readonly name: string
   readonly version: string
+  readonly description?: string | undefined
+  readonly websiteUrl?: string | undefined
+  readonly icons?: ReadonlyArray<McpSchema.Icon> | undefined
   readonly extensions?: ServerExtensions | undefined
 }, protocolState: McpProtocolState["Service"]) {
   const protocolRegistry = protocolState.protocolRegistry
@@ -1119,6 +1127,9 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
 export const layer = (options: {
   readonly name: string
   readonly version: string
+  readonly description?: string | undefined
+  readonly websiteUrl?: string | undefined
+  readonly icons?: ReadonlyArray<McpSchema.Icon> | undefined
   readonly protocols: Arr.NonEmptyReadonlyArray<McpProtocol.ProtocolAdapter>
   readonly extensions?: ServerExtensions | undefined
 }): Layer.Layer<McpServer | McpServerClient, Cause.IllegalArgumentError, RpcServer.Protocol> =>
@@ -1129,6 +1140,9 @@ export const layer = (options: {
 const layerWithProtocolState = (options: {
   readonly name: string
   readonly version: string
+  readonly description?: string | undefined
+  readonly websiteUrl?: string | undefined
+  readonly icons?: ReadonlyArray<McpSchema.Icon> | undefined
   readonly extensions?: ServerExtensions | undefined
 }): Layer.Layer<McpServer | McpServerClient, never, RpcServer.Protocol | McpProtocolState> =>
   Layer.effectDiscard(
@@ -1163,6 +1177,9 @@ const layerWithProtocolState = (options: {
 export const layerStdio = (options: {
   readonly name: string
   readonly version: string
+  readonly description?: string | undefined
+  readonly websiteUrl?: string | undefined
+  readonly icons?: ReadonlyArray<McpSchema.Icon> | undefined
   readonly protocols: Arr.NonEmptyReadonlyArray<McpProtocol.ProtocolAdapter>
   readonly extensions?: ServerExtensions | undefined
 }): Layer.Layer<McpServer | McpServerClient, Cause.IllegalArgumentError, Stdio> =>
@@ -1269,6 +1286,9 @@ const mcpStdioSerialization = (
 export const layerHttp = (options: {
   readonly name: string
   readonly version: string
+  readonly description?: string | undefined
+  readonly websiteUrl?: string | undefined
+  readonly icons?: ReadonlyArray<McpSchema.Icon> | undefined
   readonly path: HttpRouter.PathInput
   readonly protocols: Arr.NonEmptyReadonlyArray<McpProtocol.ProtocolAdapter>
   readonly extensions?: ServerExtensions | undefined
@@ -2053,7 +2073,8 @@ export const elicit: <S extends Schema.ConstraintEncoder<Record<string, unknown>
   const { getClient } = yield* McpServerClient
   const client = yield* getClient
   const schema = options.schema
-  const request = yield* Schema.decodeUnknownEffect(Elicit.payloadSchema)({
+  const request = yield* Schema.decodeUnknownEffect(McpSchema.ElicitRequestFormParams)({
+    mode: "form",
     message: options.message,
     requestedSchema: Tool.getJsonSchemaFromSchema(schema)
   }).pipe(Effect.orDie)
@@ -2132,6 +2153,9 @@ const PingRpcs = RpcGroup.make(Ping).middleware(McpServerClientMiddleware)
 const layerHandlers = (serverInfo: {
   readonly name: string
   readonly version: string
+  readonly description?: string | undefined
+  readonly websiteUrl?: string | undefined
+  readonly icons?: ReadonlyArray<McpSchema.Icon> | undefined
   readonly extensions?: ServerExtensions | undefined
 }, options: {
   readonly sessions: Sessions
@@ -2216,10 +2240,13 @@ const layerHandlers = (serverInfo: {
                 }
                 return Effect.succeed({
                   capabilities,
-                  serverInfo: {
+                  serverInfo: McpSchema.Implementation.make({
                     name: serverInfo.name,
-                    version: serverInfo.version
-                  }
+                    version: serverInfo.version,
+                    description: serverInfo.description,
+                    websiteUrl: serverInfo.websiteUrl,
+                    icons: serverInfo.icons
+                  })
                 })
               })
             }

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -88,14 +88,21 @@ import type * as Toolkit from "./Toolkit.ts"
 
 type CompletionContext = typeof Complete.payloadSchema.Type["context"]
 
+interface QueuedServerNotification {
+  readonly notification: McpCore.ServerNotification
+  readonly targetClientId?: number | undefined
+}
+
 const internalState = new WeakMap<object, {
   readonly core: McpCore.McpCore
-  readonly notifications: Queue.Dequeue<McpCore.ServerNotification>
+  readonly notifications: Queue.Dequeue<QueuedServerNotification>
 }>()
 type ServerExtensions = NonNullable<typeof ServerCapabilities.Type["extensions"]>
 type ServerNotificationRequest<
-  R extends Rpc.Any = RpcGroup.Rpcs<typeof ServerNotificationRpcs>
+  R extends Rpc.Any = RpcGroup.Rpcs<typeof BroadcastServerNotificationRpcs>
 > = R extends Rpc.Any ? RpcMessage.Request<R> : never
+
+const BroadcastServerNotificationRpcs = ServerNotificationRpcs.omit("notifications/elicitation/complete")
 
 const validateStructuredContent = (
   toolName: string,
@@ -164,7 +171,11 @@ const toInternalServerNotification = (
  * @since 4.0.0
  */
 export class McpServer extends Context.Service<McpServer, {
-  readonly notifications: RpcClient.RpcClient<RpcGroup.Rpcs<typeof ServerNotificationRpcs>>
+  readonly notifications: RpcClient.RpcClient<RpcGroup.Rpcs<typeof BroadcastServerNotificationRpcs>>
+  readonly notifyElicitationComplete: (options: {
+    readonly clientId: number
+    readonly elicitationId: string
+  }) => Effect.Effect<void>
   readonly initializedClients: Set<number>
   readonly tools: ReadonlyArray<{
     readonly tool: McpTool
@@ -269,9 +280,9 @@ export class McpServer extends Context.Service<McpServer, {
       readonly prompt: Prompt
       readonly annotations: Context.Context<never>
     }> = []
-    const notificationsQueue = yield* Queue.make<McpCore.ServerNotification>()
+    const notificationsQueue = yield* Queue.make<QueuedServerNotification>()
     const listChangedHandles = new Map<string, any>()
-    const notifications = yield* RpcClient.makeNoSerialization(ServerNotificationRpcs, {
+    const notifications = yield* RpcClient.makeNoSerialization(BroadcastServerNotificationRpcs, {
       spanPrefix: "McpServer/Notifications",
       onFromClient: (options) =>
         Effect.suspend((): Effect.Effect<void> => {
@@ -288,13 +299,13 @@ export class McpServer extends Context.Service<McpServer, {
               listChangedHandles.set(
                 message.tag,
                 setTimeout(() => {
-                  Queue.offerUnsafe(notificationsQueue, notification)
+                  Queue.offerUnsafe(notificationsQueue, { notification })
                   listChangedHandles.delete(message.tag)
                 }, 0)
               )
             }
           } else {
-            Queue.offerUnsafe(notificationsQueue, notification)
+            Queue.offerUnsafe(notificationsQueue, { notification })
           }
           return notifications.write({
             clientId: 0,
@@ -307,6 +318,11 @@ export class McpServer extends Context.Service<McpServer, {
 
     const service = McpServer.of({
       notifications: notifications.client,
+      notifyElicitationComplete: ({ clientId, elicitationId }) =>
+        Queue.offer(notificationsQueue, {
+          notification: McpCore.ServerNotification.ElicitationComplete({ elicitationId }),
+          targetClientId: clientId
+        }),
       initializedClients: new Set(),
       get tools() {
         return tools
@@ -1025,7 +1041,7 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
   })
 
   yield* Queue.take(internalState.get(server)!.notifications).pipe(
-    Effect.flatMap(Effect.fnUntraced(function*(notification) {
+    Effect.flatMap(Effect.fnUntraced(function*({ notification, targetClientId }) {
       const clientIds = yield* patchedProtocol.clientIds
       for (const clientId of clientProtocols.keys()) {
         if (!clientIds.has(clientId)) {
@@ -1038,6 +1054,9 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
         }
       }
       for (const clientId of server.initializedClients.keys()) {
+        if (targetClientId !== undefined && clientId !== targetClientId) {
+          continue
+        }
         if (!clientIds.has(clientId)) {
           server.initializedClients.delete(clientId)
           continue

--- a/packages/effect/src/unstable/ai/internal/mcpCore.ts
+++ b/packages/effect/src/unstable/ai/internal/mcpCore.ts
@@ -293,6 +293,7 @@ export type ServerNotification = Data.TaggedEnum<{
   ResourcesChanged: { readonly metadata?: Schema.JsonObject | undefined }
   ToolsChanged: { readonly metadata?: Schema.JsonObject | undefined }
   PromptsChanged: { readonly metadata?: Schema.JsonObject | undefined }
+  ElicitationComplete: { readonly elicitationId: string }
 }>
 
 /** @internal */

--- a/packages/effect/src/unstable/ai/internal/mcpCore.ts
+++ b/packages/effect/src/unstable/ai/internal/mcpCore.ts
@@ -48,10 +48,7 @@ export interface CanonicalServerCapabilities {
 /** @internal */
 export interface CanonicalInitializeResult {
   readonly capabilities: CanonicalServerCapabilities
-  readonly serverInfo: Readonly<{
-    readonly name: string
-    readonly version: string
-  }>
+  readonly serverInfo: McpSchema.Implementation
   readonly instructions?: string | undefined
 }
 

--- a/packages/effect/src/unstable/ai/internal/mcpProtocol.ts
+++ b/packages/effect/src/unstable/ai/internal/mcpProtocol.ts
@@ -127,6 +127,19 @@ export const transcode = <
   )
 
 /** @internal */
+export const transcodeStrict = <
+  From extends Schema.Constraint,
+  To extends Schema.Constraint
+>(
+  from: From,
+  to: To,
+  input: Schema.Schema.Type<From>
+) =>
+  Schema.encodeEffect(from)(input).pipe(
+    Effect.flatMap(Schema.decodeUnknownEffect(to, { onExcessProperty: "error" }))
+  )
+
+/** @internal */
 export const makeNotificationProjector = Effect.fn(function*(
   options: {
     readonly supportsProgressMessage: boolean

--- a/packages/effect/src/unstable/ai/internal/mcpProtocol.ts
+++ b/packages/effect/src/unstable/ai/internal/mcpProtocol.ts
@@ -198,7 +198,8 @@ export const makeNotificationProjector = Effect.fn(function*(
       payload: PublicMcpSchema.PromptListChangedNotification.payloadSchema.make({
         _meta: notification.metadata
       })
-    })
+    }),
+    ElicitationComplete: () => undefined
   })
 })
 

--- a/packages/effect/src/unstable/ai/internal/mcpProtocol/v2024_11_05.ts
+++ b/packages/effect/src/unstable/ai/internal/mcpProtocol/v2024_11_05.ts
@@ -283,7 +283,7 @@ export const protocol = McpProtocol.make({
     }),
     createMessage: Effect.fnUntraced(function*(request) {
       yield* requireCapability(profile, "sampling/createMessage", "sampling")
-      const wireRequest = yield* McpProtocol.transcode(
+      const wireRequest = yield* McpProtocol.transcodeStrict(
         PublicMcpSchema.CreateMessage.payloadSchema,
         McpSchema.CreateMessage.payloadSchema,
         request

--- a/packages/effect/src/unstable/ai/internal/mcpProtocol/v2025_03_26.ts
+++ b/packages/effect/src/unstable/ai/internal/mcpProtocol/v2025_03_26.ts
@@ -309,7 +309,7 @@ export const protocol = McpProtocol.make({
     }),
     createMessage: Effect.fnUntraced(function*(request) {
       yield* requireCapability(profile, "sampling/createMessage", "sampling")
-      const wireRequest = yield* McpProtocol.transcode(
+      const wireRequest = yield* McpProtocol.transcodeStrict(
         PublicMcpSchema.CreateMessage.payloadSchema,
         McpSchema.CreateMessage.payloadSchema,
         request

--- a/packages/effect/src/unstable/ai/internal/mcpProtocol/v2025_06_18.ts
+++ b/packages/effect/src/unstable/ai/internal/mcpProtocol/v2025_06_18.ts
@@ -2,6 +2,7 @@ import * as Effect from "../../../../Effect.ts"
 import * as Encoding from "../../../../Encoding.ts"
 import * as Match from "../../../../Match.ts"
 import * as Schema from "../../../../Schema.ts"
+import * as Struct from "../../../../Struct.ts"
 import * as PublicMcpSchema from "../../McpSchema.ts"
 import * as McpCore from "../mcpCore.ts"
 import * as McpProtocol from "../mcpProtocol.ts"
@@ -305,7 +306,7 @@ export const protocol = McpProtocol.make({
     }),
     createMessage: Effect.fnUntraced(function*(request) {
       yield* requireCapability(profile, "sampling/createMessage", "sampling")
-      const wireRequest = yield* McpProtocol.transcode(
+      const wireRequest = yield* McpProtocol.transcodeStrict(
         PublicMcpSchema.CreateMessage.payloadSchema,
         McpSchema.CreateMessage.payloadSchema,
         request
@@ -327,11 +328,13 @@ export const protocol = McpProtocol.make({
     }),
     elicit: Effect.fnUntraced(function*(request) {
       yield* requireCapability(profile, "elicitation/create", "elicitation")
-      const wireRequest = yield* McpProtocol.transcode(
-        PublicMcpSchema.Elicit.payloadSchema,
+      const projected = request.mode === "form"
+        ? Struct.omit(request, ["mode"])
+        : request
+      const wireRequest = yield* Schema.decodeUnknownEffect(
         McpSchema.Elicit.payloadSchema,
-        request
-      ).pipe(
+        { onExcessProperty: "error" }
+      )(projected).pipe(
         Effect.mapError(() => unsupported("elicitation/create", "Request is not representable by this protocol"))
       )
       const result = yield* client["elicitation/create"](wireRequest).pipe(

--- a/packages/effect/src/unstable/ai/internal/mcpProtocol/v2025_11_25.ts
+++ b/packages/effect/src/unstable/ai/internal/mcpProtocol/v2025_11_25.ts
@@ -35,13 +35,31 @@ const requireCapability = (
     ? Effect.void
     : Effect.fail(unsupported(operation, `Client did not advertise the ${capability} capability`))
 
-const supportsElicitationSchema = (request: typeof PublicMcpSchema.Elicit.payloadSchema.Type): boolean => {
-  if (request.mode === "url") return false
-  if (request.requestedSchema.$schema !== undefined) return false
-  return Object.values(request.requestedSchema.properties).every((property) => {
-    if (Array.isArray(property.type) || "oneOf" in property || "items" in property) return false
-    return property.type === "boolean" || !("default" in property)
+const requiresSamplingTools = (request: typeof PublicMcpSchema.CreateMessage.payloadSchema.Type): boolean =>
+  request.tools !== undefined ||
+  request.toolChoice !== undefined ||
+  request.messages.some((message) => {
+    const content = message.content
+    return "type" in content
+      ? content.type === "tool_use" || content.type === "tool_result"
+      : content.some((block) => block.type === "tool_use" || block.type === "tool_result")
   })
+
+const resultRequiresSamplingTools = (result: typeof McpSchema.CreateMessage.successSchema.Type): boolean =>
+  result.stopReason === "toolUse" ||
+  ("type" in result.content
+    ? result.content.type === "tool_use" || result.content.type === "tool_result"
+    : result.content.some((block) => block.type === "tool_use" || block.type === "tool_result"))
+
+const hasElicitationModeCapability = (
+  profile: McpCore.NegotiatedProtocolProfile,
+  mode: "form" | "url"
+): boolean => {
+  const elicitation = profile.clientCapabilities.elicitation
+  if (elicitation === undefined) return false
+  return mode === "form"
+    ? elicitation.form !== undefined || elicitation.url === undefined
+    : elicitation.url !== undefined
 }
 
 const projectContent = Effect.fnUntraced(function*(content: typeof PublicMcpSchema.ContentBlock.Type) {
@@ -209,175 +227,185 @@ export const protocol = McpProtocol.make({
               })
             )
           ),
-      "prompts/get": ({ arguments: args, name }) =>
-        Effect.gen(function*() {
-          const request = yield* PublicMcpSchema.McpServerClient
-          const result = yield* core.prompts.get(name, args ?? {}, McpProtocol.invocationFromClient(request)).pipe(
-            Effect.mapError(McpProtocol.ProtocolError.fromFeature)
-          )
-          const messages = yield* Effect.forEach(result.messages, (message) =>
-            projectContent(message.content).pipe(
-              Effect.map((content) => ({ role: message.role, content })),
-              Effect.mapError(McpProtocol.ProtocolError.fromTool)
-            ))
-          return McpSchema.GetPromptResult.make({
-            description: result.description,
-            messages,
-            _meta: result._meta
-          })
-        }),
-      "completion/complete": (completeRequest) =>
-        Effect.gen(function*() {
-          const request = yield* PublicMcpSchema.McpServerClient
-          const result = yield* core.completions.complete({
-            reference: completeRequest.ref.type === "ref/prompt"
-              ? {
-                type: "prompt",
-                name: completeRequest.ref.name,
-                title: completeRequest.ref.title
-              }
-              : { type: "resourceTemplate", uriTemplate: completeRequest.ref.uri },
-            argument: completeRequest.argument,
-            context: completeRequest.context?.arguments === undefined
-              ? undefined
-              : { arguments: completeRequest.context.arguments },
-            metadata: completeRequest._meta
-          }, McpProtocol.invocationFromClient(request)).pipe(Effect.mapError(McpProtocol.ProtocolError.fromFeature))
-          return McpSchema.CompleteResult.make({
-            completion: {
-              values: Array.from(result.values),
-              total: result.total,
-              hasMore: result.hasMore
-            },
-            _meta: result.metadata
-          })
-        }),
-      "tools/list": () =>
-        Effect.gen(function*() {
-          const request = yield* PublicMcpSchema.McpServerClient
-          const tools = yield* core.tools.list(McpProtocol.profileFromClient(request))
-          return McpSchema.ListToolsResult.make({
-            tools: tools.map((tool) =>
-              McpSchema.Tool.make({
-                name: tool.name,
-                title: tool.title,
-                description: tool.description,
-                inputSchema: tool.inputSchema,
-                outputSchema: tool.outputSchema,
-                icons: tool.icons,
-                annotations: tool.annotations === undefined
-                  ? undefined
-                  : McpSchema.ToolAnnotations.make({
-                    readOnlyHint: tool.annotations.readOnlyHint,
-                    destructiveHint: tool.annotations.destructiveHint,
-                    idempotentHint: tool.annotations.idempotentHint,
-                    openWorldHint: tool.annotations.openWorldHint
-                  }),
-                _meta: tool._meta
-              })
-            )
-          })
-        }),
-      "tools/call": (call) =>
-        Effect.gen(function*() {
-          const request = yield* PublicMcpSchema.McpServerClient
-          const result = yield* core.tools.call(
-            { ...call, arguments: call.arguments ?? {} },
-            McpProtocol.invocationFromClient(request)
-          ).pipe(
-            Effect.catchTag("InvalidToolInput", (error) =>
-              Effect.succeed(PublicMcpSchema.CallToolResult.make({
-                content: [PublicMcpSchema.TextContent.make({
-                  type: "text",
-                  text: error.message
-                })],
-                isError: true
-              }))),
+      "prompts/get": Effect.fnUntraced(function*({ arguments: args, name }) {
+        const request = yield* PublicMcpSchema.McpServerClient
+        const result = yield* core.prompts.get(name, args ?? {}, McpProtocol.invocationFromClient(request)).pipe(
+          Effect.mapError(McpProtocol.ProtocolError.fromFeature)
+        )
+        const messages = yield* Effect.forEach(result.messages, (message) =>
+          projectContent(message.content).pipe(
+            Effect.map((content) => ({ role: message.role, content })),
             Effect.mapError(McpProtocol.ProtocolError.fromTool)
-          )
-          const content = yield* Effect.forEach(result.content, projectContent).pipe(
-            Effect.mapError(McpProtocol.ProtocolError.fromTool)
-          )
-          const structuredContent = yield* projectStructuredContent(result.structuredContent).pipe(
-            Effect.mapError(McpProtocol.ProtocolError.fromTool)
-          )
-          return McpSchema.CallToolResult.make({
-            content,
-            structuredContent,
-            isError: result.isError,
-            _meta: result._meta
-          })
+          ))
+        return McpSchema.GetPromptResult.make({
+          description: result.description,
+          messages,
+          _meta: result._meta
         })
+      }),
+      "completion/complete": Effect.fnUntraced(function*(completeRequest) {
+        const request = yield* PublicMcpSchema.McpServerClient
+        const result = yield* core.completions.complete({
+          reference: completeRequest.ref.type === "ref/prompt"
+            ? {
+              type: "prompt",
+              name: completeRequest.ref.name,
+              title: completeRequest.ref.title
+            }
+            : { type: "resourceTemplate", uriTemplate: completeRequest.ref.uri },
+          argument: completeRequest.argument,
+          context: completeRequest.context?.arguments === undefined
+            ? undefined
+            : { arguments: completeRequest.context.arguments },
+          metadata: completeRequest._meta
+        }, McpProtocol.invocationFromClient(request)).pipe(Effect.mapError(McpProtocol.ProtocolError.fromFeature))
+        return McpSchema.CompleteResult.make({
+          completion: {
+            values: Array.from(result.values),
+            total: result.total,
+            hasMore: result.hasMore
+          },
+          _meta: result.metadata
+        })
+      }),
+      "tools/list": Effect.fnUntraced(function*() {
+        const request = yield* PublicMcpSchema.McpServerClient
+        const tools = yield* core.tools.list(McpProtocol.profileFromClient(request))
+        return McpSchema.ListToolsResult.make({
+          tools: tools.map((tool) =>
+            McpSchema.Tool.make({
+              name: tool.name,
+              title: tool.title,
+              description: tool.description,
+              inputSchema: tool.inputSchema,
+              outputSchema: tool.outputSchema,
+              icons: tool.icons,
+              annotations: tool.annotations === undefined
+                ? undefined
+                : McpSchema.ToolAnnotations.make({
+                  readOnlyHint: tool.annotations.readOnlyHint,
+                  destructiveHint: tool.annotations.destructiveHint,
+                  idempotentHint: tool.annotations.idempotentHint,
+                  openWorldHint: tool.annotations.openWorldHint
+                }),
+              _meta: tool._meta
+            })
+          )
+        })
+      }),
+      "tools/call": Effect.fnUntraced(function*(call) {
+        const request = yield* PublicMcpSchema.McpServerClient
+        const result = yield* core.tools.call(
+          { ...call, arguments: call.arguments ?? {} },
+          McpProtocol.invocationFromClient(request)
+        ).pipe(
+          Effect.catchTag("InvalidToolInput", (error) =>
+            Effect.succeed(PublicMcpSchema.CallToolResult.make({
+              content: [PublicMcpSchema.TextContent.make({
+                type: "text",
+                text: error.message
+              })],
+              isError: true
+            }))),
+          Effect.mapError(McpProtocol.ProtocolError.fromTool)
+        )
+        const content = yield* Effect.forEach(result.content, projectContent).pipe(
+          Effect.mapError(McpProtocol.ProtocolError.fromTool)
+        )
+        const structuredContent = yield* projectStructuredContent(result.structuredContent).pipe(
+          Effect.mapError(McpProtocol.ProtocolError.fromTool)
+        )
+        return McpSchema.CallToolResult.make({
+          content,
+          structuredContent,
+          isError: result.isError,
+          _meta: result._meta
+        })
+      })
     }),
   toReverseClient: (profile, client) => ({
-    listRoots: (request) =>
-      Effect.gen(function*() {
-        yield* requireCapability(profile, "roots/list", "roots")
-        const wireRequest = yield* McpProtocol.transcode(
-          PublicMcpSchema.ListRoots.payloadSchema,
-          McpSchema.ListRoots.payloadSchema,
-          request
-        ).pipe(
-          Effect.mapError(() => unsupported("roots/list", "Request is not representable by this protocol"))
+    listRoots: Effect.fnUntraced(function*(request) {
+      yield* requireCapability(profile, "roots/list", "roots")
+      const wireRequest = yield* McpProtocol.transcode(
+        PublicMcpSchema.ListRoots.payloadSchema,
+        McpSchema.ListRoots.payloadSchema,
+        request
+      ).pipe(
+        Effect.mapError(() => unsupported("roots/list", "Request is not representable by this protocol"))
+      )
+      const { roots } = yield* client["roots/list"](wireRequest).pipe(
+        Effect.mapError(McpProtocol.reverseError("roots/list"))
+      )
+      return new PublicMcpSchema.ListRootsResult({ roots })
+    }),
+    createMessage: Effect.fnUntraced(function*(request) {
+      yield* requireCapability(profile, "sampling/createMessage", "sampling")
+      if (requiresSamplingTools(request) && profile.clientCapabilities.sampling?.tools == undefined) {
+        return yield* unsupported("sampling/createMessage", "Client did not advertise the sampling.tools capability")
+      }
+      if (
+        (request.includeContext === "thisServer" || request.includeContext === "allServers") &&
+        profile.clientCapabilities.sampling?.context == undefined
+      ) {
+        return yield* unsupported("sampling/createMessage", "Client did not advertise the sampling.context capability")
+      }
+      const wireRequest = yield* McpProtocol.transcode(
+        PublicMcpSchema.CreateMessage.payloadSchema,
+        McpSchema.CreateMessage.payloadSchema,
+        request
+      ).pipe(
+        Effect.mapError(() => unsupported("sampling/createMessage", "Request is not representable by this protocol"))
+      )
+      const result = yield* client["sampling/createMessage"](wireRequest).pipe(
+        Effect.mapError(McpProtocol.reverseError("sampling/createMessage"))
+      )
+      if (resultRequiresSamplingTools(result) && profile.clientCapabilities.sampling?.tools == undefined) {
+        return yield* unsupported("sampling/createMessage", "Client did not advertise the sampling.tools capability")
+      }
+      return yield* McpProtocol.transcode(
+        McpSchema.CreateMessage.successSchema,
+        PublicMcpSchema.CreateMessage.successSchema,
+        result
+      ).pipe(
+        Effect.mapError(() =>
+          unsupported("sampling/createMessage", "Response is not representable by the canonical model")
         )
-        const result = yield* client["roots/list"](wireRequest)
-        return new PublicMcpSchema.ListRootsResult({ roots: result.roots })
-      }).pipe(Effect.mapError(McpProtocol.reverseError("roots/list"))),
-    createMessage: (request) =>
-      Effect.gen(function*() {
-        yield* requireCapability(profile, "sampling/createMessage", "sampling")
-        if (!McpProtocol.isLegacySamplingRequest(request)) {
-          return yield* Effect.fail(
-            unsupported("sampling/createMessage", "Request is not representable by this protocol")
-          )
-        }
-        const wireRequest = yield* McpProtocol.transcode(
-          PublicMcpSchema.CreateMessage.payloadSchema,
-          McpSchema.CreateMessage.payloadSchema,
-          request
-        ).pipe(
-          Effect.mapError(() => unsupported("sampling/createMessage", "Request is not representable by this protocol"))
-        )
-        const result = yield* client["sampling/createMessage"](wireRequest)
-        return yield* McpProtocol.transcode(
-          McpSchema.CreateMessage.successSchema,
-          PublicMcpSchema.CreateMessage.successSchema,
-          result
-        ).pipe(
-          Effect.mapError(() =>
-            unsupported("sampling/createMessage", "Response is not representable by the canonical model")
-          )
-        )
-      }).pipe(Effect.mapError(McpProtocol.reverseError("sampling/createMessage"))),
-    elicit: (request) =>
-      Effect.gen(function*() {
-        yield* requireCapability(profile, "elicitation/create", "elicitation")
-        if (!supportsElicitationSchema(request)) {
-          return yield* Effect.fail(unsupported("elicitation/create", "Request is not representable by this protocol"))
-        }
-        const wireRequest = yield* McpProtocol.transcode(
-          PublicMcpSchema.Elicit.payloadSchema,
-          McpSchema.Elicit.payloadSchema,
-          request
-        ).pipe(
-          Effect.mapError(() => unsupported("elicitation/create", "Request is not representable by this protocol"))
-        )
-        const result = yield* client["elicitation/create"](wireRequest)
-        return yield* McpProtocol.transcode(
-          McpSchema.Elicit.successSchema,
-          PublicMcpSchema.Elicit.successSchema,
-          result
-        ).pipe(
-          Effect.mapError(() =>
-            unsupported("elicitation/create", "Response is not representable by the canonical model")
-          )
-        )
-      }).pipe(Effect.mapError(McpProtocol.reverseError("elicitation/create")))
+      )
+    }),
+    elicit: Effect.fnUntraced(function*(request) {
+      yield* requireCapability(profile, "elicitation/create", "elicitation")
+      const mode = request.mode === "url" ? "url" : "form"
+      if (!hasElicitationModeCapability(profile, mode)) {
+        return yield* unsupported("elicitation/create", `Client did not advertise the elicitation.${mode} capability`)
+      }
+      const wireRequest = yield* McpProtocol.transcode(
+        PublicMcpSchema.Elicit.payloadSchema,
+        McpSchema.Elicit.payloadSchema,
+        request
+      ).pipe(
+        Effect.mapError(() => unsupported("elicitation/create", "Request is not representable by this protocol"))
+      )
+      const result = yield* client["elicitation/create"](wireRequest).pipe(
+        Effect.mapError(McpProtocol.reverseError("elicitation/create"))
+      )
+      return yield* McpProtocol.transcode(
+        McpSchema.Elicit.successSchema,
+        PublicMcpSchema.Elicit.successSchema,
+        result
+      ).pipe(
+        Effect.mapError(() => unsupported("elicitation/create", "Response is not representable by the canonical model"))
+      )
+    })
   }),
   projectNotification: (notification) =>
-    McpProtocol.makeNotificationProjector({
-      supportsProgressMessage: true
-    }, notification),
+    notification._tag === "ElicitationComplete"
+      ? Effect.succeed({
+        tag: "notifications/elicitation/complete",
+        payload: { elicitationId: notification.elicitationId }
+      })
+      : McpProtocol.makeNotificationProjector({
+        supportsProgressMessage: true
+      }, notification),
   normalizeCancellation: (payload) =>
     Schema.decodeUnknownEffect(McpSchema.CancelledNotification.payloadSchema)(payload).pipe(
       Effect.map((request) => ({

--- a/packages/effect/src/unstable/ai/internal/mcpProtocol/v2025_11_25.ts
+++ b/packages/effect/src/unstable/ai/internal/mcpProtocol/v2025_11_25.ts
@@ -1,0 +1,389 @@
+import * as Effect from "../../../../Effect.ts"
+import * as Encoding from "../../../../Encoding.ts"
+import * as Match from "../../../../Match.ts"
+import * as Schema from "../../../../Schema.ts"
+import * as PublicMcpSchema from "../../McpSchema.ts"
+import * as McpCore from "../mcpCore.ts"
+import * as McpProtocol from "../mcpProtocol.ts"
+import * as McpSchema from "../mcpSchema/v2025_11_25.ts"
+
+const ClientRequestRpcs = McpSchema.ClientRequestRpcs.middleware(
+  PublicMcpSchema.McpServerClientMiddleware
+)
+
+const ClientRpcs = ClientRequestRpcs.merge(McpSchema.ClientNotificationRpcs)
+
+const AdapterRpcs = ClientRpcs.omit("ping")
+
+const unsupported = (
+  operation: PublicMcpSchema.McpReverseOperationUnsupported["operation"],
+  reason: string
+) =>
+  new PublicMcpSchema.McpReverseOperationUnsupported({
+    operation,
+    protocolVersion: McpSchema.protocolVersion,
+    reason
+  })
+
+const requireCapability = (
+  profile: McpCore.NegotiatedProtocolProfile,
+  operation: PublicMcpSchema.McpReverseOperationUnsupported["operation"],
+  capability: "roots" | "sampling" | "elicitation"
+) =>
+  Object.hasOwn(profile.clientCapabilities, capability) &&
+    profile.clientCapabilities[capability] !== undefined
+    ? Effect.void
+    : Effect.fail(unsupported(operation, `Client did not advertise the ${capability} capability`))
+
+const supportsElicitationSchema = (request: typeof PublicMcpSchema.Elicit.payloadSchema.Type): boolean => {
+  if (request.mode === "url") return false
+  if (request.requestedSchema.$schema !== undefined) return false
+  return Object.values(request.requestedSchema.properties).every((property) => {
+    if (Array.isArray(property.type) || "oneOf" in property || "items" in property) return false
+    return property.type === "boolean" || !("default" in property)
+  })
+}
+
+const projectContent = Effect.fnUntraced(function*(content: typeof PublicMcpSchema.ContentBlock.Type) {
+  return Match.value(content).pipe(
+    Match.when({ type: Match.is("text", "resource_link") }, (content) => content),
+    Match.when({ type: Match.is("image", "audio") }, (content) => ({
+      type: content.type,
+      mimeType: content.mimeType,
+      data: Encoding.encodeBase64(content.data),
+      annotations: content.annotations,
+      _meta: content._meta
+    })),
+    Match.when({ type: "resource" }, (content) => {
+      const resource = content.resource
+      if ("text" in resource) {
+        return McpSchema.EmbeddedResource.make({
+          type: "resource",
+          resource: {
+            uri: resource.uri,
+            mimeType: resource.mimeType,
+            _meta: resource._meta,
+            text: resource.text
+          },
+          annotations: content.annotations,
+          _meta: content._meta
+        })
+      }
+      return McpSchema.EmbeddedResource.make({
+        type: "resource",
+        resource: {
+          uri: resource.uri,
+          mimeType: resource.mimeType,
+          _meta: resource._meta,
+          blob: Encoding.encodeBase64(resource.blob)
+        },
+        annotations: content.annotations,
+        _meta: content._meta
+      })
+    }),
+    Match.exhaustive
+  )
+})
+
+const projectStructuredContent = Effect.fnUntraced(function*(content: Schema.Json | undefined) {
+  if (content === undefined || Schema.is(Schema.Record(Schema.String, Schema.Json))(content)) {
+    return content
+  }
+  return yield* new McpCore.UnsupportedByProtocol({
+    protocolVersion: McpSchema.protocolVersion,
+    feature: "non-object structured tool content"
+  })
+})
+
+/** @internal */
+export const protocol = McpProtocol.make({
+  protocolVersion: McpSchema.protocolVersion,
+  transport: {
+    acceptsJsonRpcBatches: false,
+    requiresVersionHeader: true
+  },
+  clientRpcs: ClientRpcs,
+  clientNotificationRpcs: McpSchema.ClientNotificationRpcs,
+  serverRequestRpcs: McpSchema.ServerRequestRpcs,
+  serverNotificationRpcs: McpSchema.ServerNotificationRpcs,
+  handlerRpcs: AdapterRpcs,
+  makeHandlers: (core, lifecycle) =>
+    AdapterRpcs.of({
+      initialize: (request, { client }) =>
+        lifecycle.initialize(McpSchema.protocolVersion, {
+          protocolVersion: McpSchema.protocolVersion,
+          clientCapabilities: PublicMcpSchema.ClientCapabilities.make(request.capabilities),
+          clientInfo: PublicMcpSchema.Implementation.make(request.clientInfo),
+          requestMetadata: request._meta
+        }, client.id).pipe(
+          Effect.map((result) =>
+            McpSchema.InitializeResult.make({
+              protocolVersion: McpSchema.protocolVersion,
+              capabilities: ({
+                experimental: result.capabilities.experimental,
+                logging: result.capabilities.logging ? {} : undefined,
+                completions: result.capabilities.completions ? {} : undefined,
+                prompts: result.capabilities.prompts,
+                resources: result.capabilities.resources,
+                tools: result.capabilities.tools
+              }),
+              serverInfo: result.serverInfo,
+              instructions: result.instructions
+            })
+          )
+        ),
+      "logging/setLevel": ({ level }, { client, headers }) =>
+        lifecycle.setLogLevel(level, client.id, headers).pipe(Effect.as({})),
+      "notifications/cancelled": () => Effect.void,
+      "notifications/initialized": (_, { client, headers }) =>
+        lifecycle.clientNotification(McpCore.ClientNotification.Initialized(), client.id, headers),
+      "notifications/progress": (progress, { client, headers }) =>
+        lifecycle.clientNotification(
+          McpCore.ClientNotification.Progress({
+            progressToken: progress.progressToken,
+            progress: progress.progress,
+            total: progress.total,
+            message: progress.message,
+            metadata: progress._meta
+          }),
+          client.id,
+          headers
+        ),
+      "notifications/roots/list_changed": (_, { client, headers }) =>
+        lifecycle.clientNotification(McpCore.ClientNotification.RootsChanged(), client.id, headers),
+      "resources/list": () =>
+        PublicMcpSchema.McpServerClient.use((request) => core.resources.list(McpProtocol.profileFromClient(request)))
+          .pipe(
+            Effect.map((resources) =>
+              McpSchema.ListResourcesResult.make({
+                resources: resources.map((resource) => McpSchema.Resource.make(resource))
+              })
+            )
+          ),
+      "resources/templates/list": () =>
+        PublicMcpSchema.McpServerClient.use((request) =>
+          core.resources.listTemplates(McpProtocol.profileFromClient(request))
+        ).pipe(
+          Effect.map((resourceTemplates) =>
+            McpSchema.ListResourceTemplatesResult.make({
+              resourceTemplates: resourceTemplates.map((resourceTemplate) =>
+                McpSchema.ResourceTemplate.make(resourceTemplate)
+              )
+            })
+          )
+        ),
+      "resources/read": Effect.fnUntraced(function*({ uri }) {
+        const request = yield* PublicMcpSchema.McpServerClient
+        const result = yield* core.resources.read(uri, McpProtocol.invocationFromClient(request)).pipe(
+          Effect.mapError(McpProtocol.ProtocolError.fromFeature)
+        )
+        return McpSchema.ReadResourceResult.make({
+          contents: result.contents.map((content) =>
+            "text" in content
+              ? {
+                uri: content.uri,
+                mimeType: content.mimeType,
+                _meta: content._meta,
+                text: content.text
+              }
+              : {
+                uri: content.uri,
+                mimeType: content.mimeType,
+                _meta: content._meta,
+                blob: Encoding.encodeBase64(content.blob)
+              }
+          ),
+          _meta: result._meta
+        })
+      }),
+      "resources/subscribe": ({ uri }, { client, headers }) =>
+        lifecycle.subscribe(uri, client.id, headers).pipe(Effect.as({})),
+      "resources/unsubscribe": ({ uri }, { client, headers }) =>
+        lifecycle.unsubscribe(uri, client.id, headers).pipe(Effect.as({})),
+      "prompts/list": () =>
+        PublicMcpSchema.McpServerClient.use((request) => core.prompts.list(McpProtocol.profileFromClient(request)))
+          .pipe(
+            Effect.map((prompts) =>
+              McpSchema.ListPromptsResult.make({
+                prompts: prompts.map((prompt) => McpSchema.Prompt.make(prompt))
+              })
+            )
+          ),
+      "prompts/get": ({ arguments: args, name }) =>
+        Effect.gen(function*() {
+          const request = yield* PublicMcpSchema.McpServerClient
+          const result = yield* core.prompts.get(name, args ?? {}, McpProtocol.invocationFromClient(request)).pipe(
+            Effect.mapError(McpProtocol.ProtocolError.fromFeature)
+          )
+          const messages = yield* Effect.forEach(result.messages, (message) =>
+            projectContent(message.content).pipe(
+              Effect.map((content) => ({ role: message.role, content })),
+              Effect.mapError(McpProtocol.ProtocolError.fromTool)
+            ))
+          return McpSchema.GetPromptResult.make({
+            description: result.description,
+            messages,
+            _meta: result._meta
+          })
+        }),
+      "completion/complete": (completeRequest) =>
+        Effect.gen(function*() {
+          const request = yield* PublicMcpSchema.McpServerClient
+          const result = yield* core.completions.complete({
+            reference: completeRequest.ref.type === "ref/prompt"
+              ? {
+                type: "prompt",
+                name: completeRequest.ref.name,
+                title: completeRequest.ref.title
+              }
+              : { type: "resourceTemplate", uriTemplate: completeRequest.ref.uri },
+            argument: completeRequest.argument,
+            context: completeRequest.context?.arguments === undefined
+              ? undefined
+              : { arguments: completeRequest.context.arguments },
+            metadata: completeRequest._meta
+          }, McpProtocol.invocationFromClient(request)).pipe(Effect.mapError(McpProtocol.ProtocolError.fromFeature))
+          return McpSchema.CompleteResult.make({
+            completion: {
+              values: Array.from(result.values),
+              total: result.total,
+              hasMore: result.hasMore
+            },
+            _meta: result.metadata
+          })
+        }),
+      "tools/list": () =>
+        Effect.gen(function*() {
+          const request = yield* PublicMcpSchema.McpServerClient
+          const tools = yield* core.tools.list(McpProtocol.profileFromClient(request))
+          return McpSchema.ListToolsResult.make({
+            tools: tools.map((tool) =>
+              McpSchema.Tool.make({
+                name: tool.name,
+                title: tool.title,
+                description: tool.description,
+                inputSchema: tool.inputSchema,
+                outputSchema: tool.outputSchema,
+                icons: tool.icons,
+                annotations: tool.annotations === undefined
+                  ? undefined
+                  : McpSchema.ToolAnnotations.make({
+                    readOnlyHint: tool.annotations.readOnlyHint,
+                    destructiveHint: tool.annotations.destructiveHint,
+                    idempotentHint: tool.annotations.idempotentHint,
+                    openWorldHint: tool.annotations.openWorldHint
+                  }),
+                _meta: tool._meta
+              })
+            )
+          })
+        }),
+      "tools/call": (call) =>
+        Effect.gen(function*() {
+          const request = yield* PublicMcpSchema.McpServerClient
+          const result = yield* core.tools.call(
+            { ...call, arguments: call.arguments ?? {} },
+            McpProtocol.invocationFromClient(request)
+          ).pipe(
+            Effect.catchTag("InvalidToolInput", (error) =>
+              Effect.succeed(PublicMcpSchema.CallToolResult.make({
+                content: [PublicMcpSchema.TextContent.make({
+                  type: "text",
+                  text: error.message
+                })],
+                isError: true
+              }))),
+            Effect.mapError(McpProtocol.ProtocolError.fromTool)
+          )
+          const content = yield* Effect.forEach(result.content, projectContent).pipe(
+            Effect.mapError(McpProtocol.ProtocolError.fromTool)
+          )
+          const structuredContent = yield* projectStructuredContent(result.structuredContent).pipe(
+            Effect.mapError(McpProtocol.ProtocolError.fromTool)
+          )
+          return McpSchema.CallToolResult.make({
+            content,
+            structuredContent,
+            isError: result.isError,
+            _meta: result._meta
+          })
+        })
+    }),
+  toReverseClient: (profile, client) => ({
+    listRoots: (request) =>
+      Effect.gen(function*() {
+        yield* requireCapability(profile, "roots/list", "roots")
+        const wireRequest = yield* McpProtocol.transcode(
+          PublicMcpSchema.ListRoots.payloadSchema,
+          McpSchema.ListRoots.payloadSchema,
+          request
+        ).pipe(
+          Effect.mapError(() => unsupported("roots/list", "Request is not representable by this protocol"))
+        )
+        const result = yield* client["roots/list"](wireRequest)
+        return new PublicMcpSchema.ListRootsResult({ roots: result.roots })
+      }).pipe(Effect.mapError(McpProtocol.reverseError("roots/list"))),
+    createMessage: (request) =>
+      Effect.gen(function*() {
+        yield* requireCapability(profile, "sampling/createMessage", "sampling")
+        if (!McpProtocol.isLegacySamplingRequest(request)) {
+          return yield* Effect.fail(
+            unsupported("sampling/createMessage", "Request is not representable by this protocol")
+          )
+        }
+        const wireRequest = yield* McpProtocol.transcode(
+          PublicMcpSchema.CreateMessage.payloadSchema,
+          McpSchema.CreateMessage.payloadSchema,
+          request
+        ).pipe(
+          Effect.mapError(() => unsupported("sampling/createMessage", "Request is not representable by this protocol"))
+        )
+        const result = yield* client["sampling/createMessage"](wireRequest)
+        return yield* McpProtocol.transcode(
+          McpSchema.CreateMessage.successSchema,
+          PublicMcpSchema.CreateMessage.successSchema,
+          result
+        ).pipe(
+          Effect.mapError(() =>
+            unsupported("sampling/createMessage", "Response is not representable by the canonical model")
+          )
+        )
+      }).pipe(Effect.mapError(McpProtocol.reverseError("sampling/createMessage"))),
+    elicit: (request) =>
+      Effect.gen(function*() {
+        yield* requireCapability(profile, "elicitation/create", "elicitation")
+        if (!supportsElicitationSchema(request)) {
+          return yield* Effect.fail(unsupported("elicitation/create", "Request is not representable by this protocol"))
+        }
+        const wireRequest = yield* McpProtocol.transcode(
+          PublicMcpSchema.Elicit.payloadSchema,
+          McpSchema.Elicit.payloadSchema,
+          request
+        ).pipe(
+          Effect.mapError(() => unsupported("elicitation/create", "Request is not representable by this protocol"))
+        )
+        const result = yield* client["elicitation/create"](wireRequest)
+        return yield* McpProtocol.transcode(
+          McpSchema.Elicit.successSchema,
+          PublicMcpSchema.Elicit.successSchema,
+          result
+        ).pipe(
+          Effect.mapError(() =>
+            unsupported("elicitation/create", "Response is not representable by the canonical model")
+          )
+        )
+      }).pipe(Effect.mapError(McpProtocol.reverseError("elicitation/create")))
+  }),
+  projectNotification: (notification) =>
+    McpProtocol.makeNotificationProjector({
+      supportsProgressMessage: true
+    }, notification),
+  normalizeCancellation: (payload) =>
+    Schema.decodeUnknownEffect(McpSchema.CancelledNotification.payloadSchema)(payload).pipe(
+      Effect.map((request) => ({
+        requestId: request.requestId,
+        reason: request.reason,
+        metadata: request._meta
+      }))
+    )
+})

--- a/packages/effect/src/unstable/ai/internal/mcpSchema/v2025_11_25.ts
+++ b/packages/effect/src/unstable/ai/internal/mcpSchema/v2025_11_25.ts
@@ -1,0 +1,481 @@
+/**
+ * Supported non-Task MCP v2025-11-25 wire schemas.
+ *
+ * This module is a dated delta from v2025-06-18. Experimental Tasks are not
+ * part of the supported vocabulary for this adapter.
+ *
+ * @internal
+ */
+import * as Schema from "../../../../Schema.ts"
+import * as Rpc from "../../../rpc/Rpc.ts"
+import * as RpcGroup from "../../../rpc/RpcGroup.ts"
+import * as Previous from "./v2025_06_18.ts"
+
+export * from "./v2025_06_18.ts"
+
+export const protocolVersion = "2025-11-25"
+
+const optional = Previous.optional
+const JsonObject = Schema.Record(Schema.String, Schema.Json)
+const Meta = optional(JsonObject)
+
+export const Icon = Schema.Struct({
+  src: Schema.String,
+  mimeType: optional(Schema.String),
+  sizes: optional(Schema.Array(Schema.String)),
+  theme: optional(Schema.Literals(["light", "dark"]))
+})
+
+export const Implementation = Schema.Struct({
+  ...Previous.Implementation.fields,
+  description: optional(Schema.String),
+  websiteUrl: optional(Schema.String),
+  icons: optional(Schema.Array(Icon))
+})
+
+export const ClientCapabilities = Schema.Struct({
+  ...Previous.ClientCapabilities.fields,
+  sampling: optional(Schema.Struct({
+    context: optional(JsonObject),
+    tools: optional(JsonObject)
+  })),
+  elicitation: optional(Schema.Struct({
+    form: optional(JsonObject),
+    url: optional(JsonObject)
+  }))
+})
+
+export const Annotations = Schema.Struct({
+  ...Previous.Annotations.fields,
+  lastModified: optional(Schema.String)
+})
+
+export const Resource = Schema.Struct({
+  ...Previous.Resource.fields,
+  annotations: optional(Annotations),
+  icons: optional(Schema.Array(Icon))
+})
+
+export const ResourceTemplate = Schema.Struct({
+  ...Previous.ResourceTemplate.fields,
+  annotations: optional(Annotations),
+  icons: optional(Schema.Array(Icon))
+})
+
+export const Prompt = Schema.Struct({
+  ...Previous.Prompt.fields,
+  icons: optional(Schema.Array(Icon))
+})
+
+export const TextContent = Schema.Struct({
+  ...Previous.TextContent.fields,
+  annotations: optional(Annotations)
+})
+
+export const ImageContent = Schema.Struct({
+  ...Previous.ImageContent.fields,
+  annotations: optional(Annotations)
+})
+
+export const AudioContent = Schema.Struct({
+  ...Previous.AudioContent.fields,
+  annotations: optional(Annotations)
+})
+
+export const EmbeddedResource = Schema.Struct({
+  ...Previous.EmbeddedResource.fields,
+  annotations: optional(Annotations)
+})
+
+export const ResourceLink = Schema.Struct({
+  ...Resource.fields,
+  type: Schema.Literal("resource_link")
+})
+
+export const ContentBlock = Schema.Union([
+  TextContent,
+  ImageContent,
+  AudioContent,
+  ResourceLink,
+  EmbeddedResource
+])
+
+export const PromptMessage = Schema.Struct({
+  role: Previous.Role,
+  content: ContentBlock
+})
+
+export const Tool = Schema.Struct({
+  ...Previous.Tool.fields,
+  icons: optional(Schema.Array(Icon))
+})
+
+export const CallToolResult = Schema.Struct({
+  ...Previous.CallToolResult.fields,
+  content: Schema.Array(ContentBlock)
+})
+
+export class CallTool extends Rpc.make("tools/call", {
+  success: CallToolResult,
+  error: Previous.McpError,
+  payload: Previous.CallTool.payloadSchema
+}) {}
+
+export const ToolUseContent = Schema.Struct({
+  type: Schema.Literal("tool_use"),
+  id: Schema.String,
+  name: Schema.String,
+  input: JsonObject,
+  _meta: Meta
+})
+
+export const ToolResultContent = Schema.Struct({
+  type: Schema.Literal("tool_result"),
+  toolUseId: Schema.String,
+  content: Schema.Array(ContentBlock),
+  structuredContent: optional(JsonObject),
+  isError: optional(Schema.Boolean),
+  _meta: Meta
+})
+
+export const SamplingMessageContentBlock = Schema.Union([
+  TextContent,
+  ImageContent,
+  AudioContent,
+  ToolUseContent,
+  ToolResultContent
+])
+
+export const SamplingMessage = Schema.Struct({
+  role: Previous.Role,
+  content: Schema.Union([
+    SamplingMessageContentBlock,
+    Schema.Array(SamplingMessageContentBlock)
+  ]),
+  _meta: Meta
+})
+
+export const ToolChoice = Schema.Struct({
+  mode: optional(Schema.Literals(["auto", "required", "none"]))
+})
+
+export const CreateMessageResult = Schema.Struct({
+  ...Previous.ResultMeta.fields,
+  ...SamplingMessage.fields,
+  model: Schema.String,
+  stopReason: optional(Schema.String)
+})
+
+export class CreateMessage extends Rpc.make("sampling/createMessage", {
+  success: CreateMessageResult,
+  error: Previous.McpError,
+  payload: {
+    ...Previous.CreateMessage.payloadSchema.fields,
+    messages: Schema.Array(SamplingMessage),
+    maxTokens: Schema.Int,
+    tools: optional(Schema.Array(Tool)),
+    toolChoice: optional(ToolChoice)
+  }
+}) {}
+
+export const Root = Schema.Struct({
+  ...Previous.Root.fields,
+  _meta: Meta
+})
+
+export const ListRootsResult = Schema.Struct({
+  ...Previous.ResultMeta.fields,
+  roots: Schema.Array(Root)
+})
+
+export class ListRoots extends Rpc.make("roots/list", {
+  success: ListRootsResult,
+  error: Previous.McpError,
+  payload: Schema.UndefinedOr(Previous.RequestMeta)
+}) {}
+
+export const StringSchema = Schema.Struct({
+  type: Schema.Literal("string"),
+  title: optional(Schema.String),
+  description: optional(Schema.String),
+  minLength: optional(Schema.Int),
+  maxLength: optional(Schema.Int),
+  format: optional(Schema.Literals(["email", "uri", "date", "date-time"])),
+  default: optional(Schema.String)
+})
+
+export const NumberSchema = Schema.Struct({
+  type: Schema.Literals(["number", "integer"]),
+  title: optional(Schema.String),
+  description: optional(Schema.String),
+  minimum: optional(Schema.Finite),
+  maximum: optional(Schema.Finite),
+  default: optional(Schema.Finite)
+})
+
+export const BooleanSchema = Schema.Struct({
+  type: Schema.Literal("boolean"),
+  title: optional(Schema.String),
+  description: optional(Schema.String),
+  default: optional(Schema.Boolean)
+})
+
+const EnumOption = Schema.Struct({
+  const: Schema.String,
+  title: Schema.String
+})
+
+export const UntitledSingleSelectEnumSchema = Schema.Struct({
+  type: Schema.Literal("string"),
+  title: optional(Schema.String),
+  description: optional(Schema.String),
+  enum: Schema.Array(Schema.String),
+  default: optional(Schema.String)
+})
+
+export const TitledSingleSelectEnumSchema = Schema.Struct({
+  type: Schema.Literal("string"),
+  title: optional(Schema.String),
+  description: optional(Schema.String),
+  oneOf: Schema.Array(EnumOption),
+  default: optional(Schema.String)
+})
+
+export const SingleSelectEnumSchema = Schema.Union([
+  UntitledSingleSelectEnumSchema,
+  TitledSingleSelectEnumSchema
+])
+
+export const UntitledMultiSelectEnumSchema = Schema.Struct({
+  type: Schema.Literal("array"),
+  title: optional(Schema.String),
+  description: optional(Schema.String),
+  minItems: optional(Schema.Int),
+  maxItems: optional(Schema.Int),
+  items: Schema.Struct({
+    type: Schema.Literal("string"),
+    enum: Schema.Array(Schema.String)
+  }),
+  default: optional(Schema.Array(Schema.String))
+})
+
+export const TitledMultiSelectEnumSchema = Schema.Struct({
+  type: Schema.Literal("array"),
+  title: optional(Schema.String),
+  description: optional(Schema.String),
+  minItems: optional(Schema.Int),
+  maxItems: optional(Schema.Int),
+  items: Schema.Struct({
+    anyOf: Schema.Array(EnumOption)
+  }),
+  default: optional(Schema.Array(Schema.String))
+})
+
+export const MultiSelectEnumSchema = Schema.Union([
+  UntitledMultiSelectEnumSchema,
+  TitledMultiSelectEnumSchema
+])
+
+export const LegacyTitledEnumSchema = Schema.Struct({
+  type: Schema.Literal("string"),
+  title: optional(Schema.String),
+  description: optional(Schema.String),
+  enum: Schema.Array(Schema.String),
+  enumNames: optional(Schema.Array(Schema.String)),
+  default: optional(Schema.String)
+})
+
+export const EnumSchema = Schema.Union([
+  SingleSelectEnumSchema,
+  MultiSelectEnumSchema,
+  LegacyTitledEnumSchema
+])
+
+export const PrimitiveSchemaDefinition = Schema.Union([
+  StringSchema,
+  NumberSchema,
+  BooleanSchema,
+  EnumSchema
+])
+
+export const RequestedSchema = Schema.Struct({
+  $schema: optional(Schema.String),
+  type: Schema.Literal("object"),
+  properties: Schema.Record(Schema.String, PrimitiveSchemaDefinition),
+  required: optional(Schema.Array(Schema.String))
+})
+
+export const ElicitRequestFormParams = Schema.Struct({
+  ...Previous.RequestMeta.fields,
+  mode: optional(Schema.Literal("form")),
+  message: Schema.String,
+  requestedSchema: RequestedSchema
+})
+
+export const ElicitRequestURLParams = Schema.Struct({
+  ...Previous.RequestMeta.fields,
+  mode: Schema.Literal("url"),
+  message: Schema.String,
+  elicitationId: Schema.String,
+  url: Schema.String
+})
+
+export const ElicitRequestParams = Schema.Union([
+  ElicitRequestFormParams,
+  ElicitRequestURLParams
+])
+
+export const URL_ELICITATION_REQUIRED = -32042
+
+export const URLElicitationRequiredError = Schema.Struct({
+  jsonrpc: Schema.Literal("2.0"),
+  id: optional(Previous.RequestId),
+  error: Schema.Struct({
+    code: Schema.Literal(URL_ELICITATION_REQUIRED),
+    message: Schema.String,
+    data: Schema.StructWithRest(
+      Schema.Struct({
+        elicitations: Schema.Array(ElicitRequestURLParams)
+      }),
+      [Schema.Record(Schema.String, Schema.Json)]
+    )
+  })
+})
+
+export const ElicitResult = Schema.Struct({
+  ...Previous.ResultMeta.fields,
+  action: Schema.Literals(["accept", "decline", "cancel"]),
+  content: optional(Schema.Record(
+    Schema.String,
+    Schema.Union([Schema.String, Schema.Finite, Schema.Boolean, Schema.Array(Schema.String)])
+  ))
+})
+
+export class Elicit extends Rpc.make("elicitation/create", {
+  success: ElicitResult,
+  error: Previous.McpError,
+  payload: ElicitRequestParams
+}) {}
+
+export class ElicitationCompleteNotification extends Rpc.make("notifications/elicitation/complete", {
+  payload: {
+    elicitationId: Schema.String
+  }
+}) {}
+
+export const InitializeResult = Schema.Struct({
+  ...Previous.InitializeResult.fields,
+  serverInfo: Implementation
+})
+
+export class Initialize extends Rpc.make("initialize", {
+  success: InitializeResult,
+  error: Previous.McpError,
+  payload: {
+    ...Previous.Initialize.payloadSchema.fields,
+    capabilities: ClientCapabilities,
+    clientInfo: Implementation
+  }
+}) {}
+
+export const ListResourcesResult = Schema.Struct({
+  ...Previous.PaginatedResult.fields,
+  resources: Schema.Array(Resource)
+})
+
+export const ListResourceTemplatesResult = Schema.Struct({
+  ...Previous.PaginatedResult.fields,
+  resourceTemplates: Schema.Array(ResourceTemplate)
+})
+
+export const ListPromptsResult = Schema.Struct({
+  ...Previous.PaginatedResult.fields,
+  prompts: Schema.Array(Prompt)
+})
+
+export const GetPromptResult = Schema.Struct({
+  ...Previous.GetPromptResult.fields,
+  messages: Schema.Array(PromptMessage)
+})
+
+export const ListToolsResult = Schema.Struct({
+  ...Previous.PaginatedResult.fields,
+  tools: Schema.Array(Tool)
+})
+
+export class ListResources extends Rpc.make("resources/list", {
+  success: ListResourcesResult,
+  error: Previous.McpError,
+  payload: Schema.UndefinedOr(Previous.PaginatedRequest)
+}) {}
+
+export class ListResourceTemplates extends Rpc.make("resources/templates/list", {
+  success: ListResourceTemplatesResult,
+  error: Previous.McpError,
+  payload: Schema.UndefinedOr(Previous.PaginatedRequest)
+}) {}
+
+export class ListPrompts extends Rpc.make("prompts/list", {
+  success: ListPromptsResult,
+  error: Previous.McpError,
+  payload: Schema.UndefinedOr(Previous.PaginatedRequest)
+}) {}
+
+export class GetPrompt extends Rpc.make("prompts/get", {
+  success: GetPromptResult,
+  error: Previous.McpError,
+  payload: {
+    ...Previous.RequestMeta.fields,
+    name: Schema.String,
+    arguments: optional(Schema.Record(Schema.String, Schema.String))
+  }
+}) {}
+
+export class ListTools extends Rpc.make("tools/list", {
+  success: ListToolsResult,
+  error: Previous.McpError,
+  payload: Schema.UndefinedOr(Previous.PaginatedRequest)
+}) {}
+
+export class ClientRequestRpcs extends RpcGroup.make(
+  Previous.Ping,
+  Initialize,
+  Previous.Complete,
+  Previous.SetLevel,
+  GetPrompt,
+  ListPrompts,
+  ListResources,
+  ListResourceTemplates,
+  Previous.ReadResource,
+  Previous.Subscribe,
+  Previous.Unsubscribe,
+  CallTool,
+  ListTools
+) {}
+
+export class ClientNotificationRpcs extends RpcGroup.make(
+  Previous.CancelledNotification,
+  Previous.ProgressNotification,
+  Previous.InitializedNotification,
+  Previous.RootsListChangedNotification
+) {}
+
+export class ClientRpcs extends ClientRequestRpcs.merge(ClientNotificationRpcs) {}
+
+export class ServerRequestRpcs extends RpcGroup.make(
+  Previous.Ping,
+  CreateMessage,
+  ListRoots,
+  Elicit
+) {}
+
+export class ServerNotificationRpcs extends RpcGroup.make(
+  Previous.CancelledNotification,
+  Previous.ProgressNotification,
+  Previous.LoggingMessageNotification,
+  Previous.ResourceUpdatedNotification,
+  Previous.ResourceListChangedNotification,
+  Previous.ToolListChangedNotification,
+  Previous.PromptListChangedNotification,
+  ElicitationCompleteNotification
+) {}

--- a/packages/effect/test/unstable/ai/McpServer/McpConformance/ElicitationTest.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpConformance/ElicitationTest.ts
@@ -75,6 +75,24 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
     describe("Elicitation", () => {
       // https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation
       describe("Capabilities", () => {
+        it.effect.skipIf(protocol.protocolVersion !== "2025-11-25")(
+          "MUST treat an empty elicitation capability as form support",
+          () =>
+            Effect.gen(function*() {
+              const test = yield* McpConformance
+              const peer = yield* test.makePeer({
+                capabilities: { elicitation: {} },
+                handlers: {
+                  "elicitation/create": () => Effect.succeed({ action: "accept", content: { name: "Ada" } })
+                }
+              })
+
+              yield* peer.reverseClient.elicit(Schema.decodeUnknownSync(McpSchema.Elicit.payloadSchema)(request))
+
+              assert.deepStrictEqual((yield* peer.takeRequest).payload, request)
+            }).pipe(Effect.scoped)
+        )
+
         it.effect("MUST send elicitation requests when the client advertises elicitation", () =>
           Effect.gen(function*() {
             const test = yield* McpConformance
@@ -93,6 +111,29 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
 
             assert.strictEqual((yield* peer.takeRequest).method, "elicitation/create")
           }))
+
+        it.effect.skipIf(protocol.protocolVersion !== "2025-11-25")(
+          "MUST gate form and URL modes on their independent nested capabilities",
+          () =>
+            Effect.gen(function*() {
+              const test = yield* McpConformance
+              const formOnly = yield* test.makePeer({ capabilities: { elicitation: { form: {} } } })
+              const urlOnly = yield* test.makePeer({ capabilities: { elicitation: { url: {} } } })
+
+              const formOnUrlOnly = yield* Effect.exit(urlOnly.reverseClient.elicit(request))
+              const urlOnFormOnly = yield* Effect.exit(formOnly.reverseClient.elicit({
+                mode: "url",
+                message: "Authorize access",
+                url: "https://example.com/authorize",
+                elicitationId: "authorization-1"
+              }))
+
+              assert.strictEqual(formOnUrlOnly._tag, "Failure")
+              assert.strictEqual(urlOnFormOnly._tag, "Failure")
+              assert.deepStrictEqual(yield* formOnly.requests, [])
+              assert.deepStrictEqual(yield* urlOnly.requests, [])
+            })
+        )
       })
 
       describe("Form Mode", () => {
@@ -126,6 +167,28 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
             }
           }))
 
+        it.effect.skipIf(protocol.protocolVersion !== "2025-11-25")(
+          "MUST preserve omitted and explicit form modes",
+          () =>
+            Effect.gen(function*() {
+              const test = yield* McpConformance
+              const peer = yield* test.makePeer({
+                capabilities: { elicitation: { form: {} } },
+                handlers: {
+                  "elicitation/create": () => Effect.succeed({ action: "accept", content: { name: "Ada" } })
+                }
+              })
+
+              yield* peer.reverseClient.elicit(Schema.decodeUnknownSync(McpSchema.Elicit.payloadSchema)(request))
+              yield* peer.reverseClient.elicit(
+                Schema.decodeUnknownSync(McpSchema.Elicit.payloadSchema)({ ...request, mode: "form" })
+              )
+
+              const requests = yield* peer.requests
+              assert.deepStrictEqual(requests.map((_) => _.payload), [request, { ...request, mode: "form" }])
+            }).pipe(Effect.scoped)
+        )
+
         it.effect("MUST decode accepted content against the requested schema", () =>
           Effect.gen(function*() {
             const test = yield* McpConformance
@@ -151,6 +214,24 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
 
             assert.deepStrictEqual(result, { name: "Ada", age: 37 })
           }))
+
+        it.effect("MUST reject schemas outside the elicitation subset before sending", () =>
+          Effect.gen(function*() {
+            const test = yield* McpConformance
+            const peer = yield* test.makePeer({ capabilities: { elicitation: {} } })
+
+            const exit = yield* Effect.exit(runElicitation(
+              peer.reverseClient,
+              protocol.protocolVersion,
+              Schema.Struct({ nested: Schema.Struct({ value: Schema.String }) })
+            ))
+
+            assert.isTrue(Exit.isFailure(exit))
+            if (Exit.isFailure(exit)) {
+              assert.isTrue(Cause.hasDies(exit.cause))
+            }
+            assert.deepStrictEqual(yield* peer.requests, [])
+          }).pipe(Effect.scoped))
 
         it.effect("SCENARIO returns a typed failure when the user declines", () =>
           Effect.gen(function*() {
@@ -218,6 +299,33 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
               assert.isTrue(Cause.hasDies(exit.cause))
             }
           }))
+      })
+
+      describe("URL Mode", () => {
+        it.effect.skipIf(protocol.protocolVersion !== "2025-11-25")(
+          "MUST round-trip URL elicitation",
+          () =>
+            Effect.gen(function*() {
+              const test = yield* McpConformance
+              const request = {
+                mode: "url" as const,
+                message: "Authorize access",
+                url: "https://example.com/authorize",
+                elicitationId: "authorization-1"
+              }
+              const peer = yield* test.makePeer({
+                capabilities: { elicitation: { url: {} } },
+                handlers: { "elicitation/create": () => Effect.succeed({ action: "accept" }) }
+              })
+
+              const result = yield* peer.reverseClient.elicit(
+                Schema.decodeUnknownSync(McpSchema.Elicit.payloadSchema)(request)
+              )
+
+              assert.deepStrictEqual((yield* peer.takeRequest).payload, request)
+              assert.strictEqual(result.action, "accept")
+            }).pipe(Effect.scoped)
+        )
       })
     })
   })

--- a/packages/effect/test/unstable/ai/McpServer/McpConformance/SamplingTest.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpConformance/SamplingTest.ts
@@ -88,6 +88,143 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
 
             assert.strictEqual((yield* peer.takeRequest).method, "sampling/createMessage")
           }))
+
+        it.effect.skipIf(protocol.protocolVersion !== "2025-11-25")(
+          "SHOULD reject context-enabled requests before sending without sampling.context",
+          () =>
+            Effect.gen(function*() {
+              const test = yield* McpConformance
+              const peer = yield* test.makePeer({ capabilities: { sampling: {} } })
+              const request = McpSchema.CreateMessage.payloadSchema.make({
+                ...samplingRequest,
+                includeContext: "thisServer"
+              })
+
+              const exit = yield* Effect.exit(peer.reverseClient.createMessage(request))
+
+              assert.strictEqual(exit._tag, "Failure")
+              assert.deepStrictEqual(yield* peer.requests, [])
+            })
+        )
+
+        it.effect.skipIf(protocol.protocolVersion !== "2025-11-25")(
+          "MUST reject every tool-enabled request shape before sending without sampling.tools",
+          () =>
+            Effect.gen(function*() {
+              const test = yield* McpConformance
+              const requests = [
+                {
+                  name: "tools",
+                  request: {
+                    messages: [{ role: "user", content: { type: "text", text: "Weather?" } }],
+                    tools: [{ name: "weather", inputSchema: { type: "object" } }],
+                    maxTokens: 64
+                  }
+                },
+                {
+                  name: "toolChoice",
+                  request: {
+                    messages: [{ role: "user", content: { type: "text", text: "Weather?" } }],
+                    toolChoice: { mode: "required" },
+                    maxTokens: 64
+                  }
+                },
+                {
+                  name: "tool_use content",
+                  request: {
+                    messages: [{
+                      role: "assistant",
+                      content: { type: "tool_use", id: "call-1", name: "weather", input: { city: "Zurich" } }
+                    }],
+                    maxTokens: 64
+                  }
+                },
+                {
+                  name: "tool_result content",
+                  request: {
+                    messages: [{
+                      role: "user",
+                      content: {
+                        type: "tool_result",
+                        toolUseId: "call-1",
+                        content: [{ type: "text", text: "Sunny" }]
+                      }
+                    }],
+                    maxTokens: 64
+                  }
+                }
+              ] as const
+
+              for (const testCase of requests) {
+                const peer = yield* test.makePeer({ capabilities: { sampling: {} } })
+                const request = Schema.decodeUnknownSync(McpSchema.CreateMessage.payloadSchema)(testCase.request)
+                const exit = yield* Effect.exit(peer.reverseClient.createMessage(request))
+
+                assert.strictEqual(exit._tag, "Failure", testCase.name)
+                assert.deepStrictEqual(yield* peer.requests, [], testCase.name)
+              }
+            }).pipe(Effect.scoped)
+        )
+
+        it.effect.skipIf(protocol.protocolVersion !== "2025-11-25")(
+          "MUST allow text-only content arrays without sampling.tools",
+          () =>
+            Effect.gen(function*() {
+              const test = yield* McpConformance
+              const peer = yield* test.makePeer({
+                capabilities: { sampling: {} },
+                handlers: {
+                  "sampling/createMessage": () =>
+                    Effect.succeed({
+                      role: "assistant",
+                      content: [{ type: "text", text: "First" }, { type: "text", text: "Second" }],
+                      model: "text-model"
+                    })
+                }
+              })
+
+              const result = yield* peer.reverseClient.createMessage(
+                Schema.decodeUnknownSync(McpSchema.CreateMessage.payloadSchema)({
+                  messages: [{
+                    role: "user",
+                    content: [{ type: "text", text: "First" }, { type: "text", text: "Second" }]
+                  }],
+                  maxTokens: 64
+                })
+              )
+
+              assert.strictEqual((yield* peer.requests).length, 1)
+              assert.deepStrictEqual(JSON.parse(JSON.stringify(result.content)), [
+                { type: "text", text: "First" },
+                { type: "text", text: "Second" }
+              ])
+            })
+        )
+
+        it.effect.skipIf(protocol.protocolVersion !== "2025-11-25")(
+          "SCENARIO rejects unexpected tool-enabled responses when sampling.tools was not advertised",
+          () =>
+            Effect.gen(function*() {
+              const test = yield* McpConformance
+              const peer = yield* test.makePeer({
+                capabilities: { sampling: {} },
+                handlers: {
+                  "sampling/createMessage": () =>
+                    Effect.succeed({
+                      role: "assistant",
+                      content: { type: "tool_use", id: "call-1", name: "weather", input: {} },
+                      model: "tool-model",
+                      stopReason: "toolUse"
+                    })
+                }
+              })
+
+              const exit = yield* Effect.exit(peer.reverseClient.createMessage(samplingRequest))
+
+              assert.strictEqual(exit._tag, "Failure")
+              assert.strictEqual((yield* peer.requests).length, 1)
+            })
+        )
       })
 
       describe("Creating Messages", () => {
@@ -95,7 +232,9 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
           Effect.gen(function*() {
             const test = yield* McpConformance
             const peer = yield* test.makePeer({
-              capabilities: { sampling: {} },
+              capabilities: {
+                sampling: protocol.protocolVersion === "2025-11-25" ? { context: {} } : {}
+              },
               handlers: {
                 "sampling/createMessage": () => Effect.succeed(textResponse)
               }
@@ -235,6 +374,94 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
             if ("code" in error) assert.strictEqual(error.code, McpSchema.INTERNAL_ERROR_CODE)
             assert.strictEqual(error.message, "Sampling failed")
           }))
+
+        it.effect.skipIf(protocol.protocolVersion !== "2025-11-25")(
+          "MUST round-trip tool-enabled sampling requests and results",
+          () =>
+            Effect.gen(function*() {
+              const test = yield* McpConformance
+              const response = {
+                role: "assistant",
+                content: [{
+                  type: "tool_use",
+                  id: "call-2",
+                  name: "weather",
+                  input: { city: "Geneva" }
+                }],
+                model: "tool-model",
+                stopReason: "toolUse"
+              } as const
+              const peer = yield* test.makePeer({
+                capabilities: { sampling: { tools: {} } },
+                handlers: { "sampling/createMessage": () => Effect.succeed(response) }
+              })
+              const request = McpSchema.CreateMessage.payloadSchema.make({
+                messages: [
+                  McpSchema.SamplingMessage.make({
+                    role: "assistant",
+                    content: McpSchema.ToolUseContent.make({
+                      id: "call-1",
+                      name: "weather",
+                      input: { city: "Zurich" }
+                    })
+                  }),
+                  McpSchema.SamplingMessage.make({
+                    role: "user",
+                    content: McpSchema.ToolResultContent.make({
+                      toolUseId: "call-1",
+                      content: [McpSchema.TextContent.make({ text: "Sunny" })],
+                      structuredContent: { temperature: 24 }
+                    })
+                  })
+                ],
+                tools: [{
+                  name: "weather",
+                  description: "Get weather",
+                  inputSchema: {
+                    type: "object",
+                    properties: { city: { type: "string" } },
+                    required: ["city"]
+                  }
+                }],
+                toolChoice: new McpSchema.ToolChoice({ mode: "required" }),
+                maxTokens: 64
+              })
+
+              const result = yield* peer.reverseClient.createMessage(request)
+              const recorded = yield* peer.takeRequest
+
+              assert.strictEqual(recorded.method, "sampling/createMessage")
+              assert.deepStrictEqual(recorded.payload, {
+                messages: [
+                  {
+                    role: "assistant",
+                    content: { type: "tool_use", id: "call-1", name: "weather", input: { city: "Zurich" } }
+                  },
+                  {
+                    role: "user",
+                    content: {
+                      type: "tool_result",
+                      toolUseId: "call-1",
+                      content: [{ type: "text", text: "Sunny" }],
+                      structuredContent: { temperature: 24 }
+                    }
+                  }
+                ],
+                tools: [{
+                  name: "weather",
+                  description: "Get weather",
+                  inputSchema: {
+                    type: "object",
+                    properties: { city: { type: "string" } },
+                    required: ["city"]
+                  }
+                }],
+                toolChoice: { mode: "required" },
+                maxTokens: 64
+              })
+              assert.deepStrictEqual(JSON.parse(JSON.stringify(result)), response)
+            })
+        )
       })
     })
   })

--- a/packages/effect/test/unstable/ai/McpServer/McpConformance/ToolsTest.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpConformance/ToolsTest.ts
@@ -193,6 +193,7 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
         it.effect("MUST reject an unknown tool name with a protocol error", () =>
           Effect.gen(function*() {
             const test = yield* McpConformance
+            const before = (yield* test.observations).toolInvocations
             const initialized = yield* test.initialize({ server: "features" })
             yield* test.notifyInitialized(initialized)
             const response = yield* test.send(initialized, {
@@ -207,9 +208,28 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
             const error = yield* test.decodeError(response)
 
             assert.strictEqual(error.error.code, McpSchema.INVALID_PARAMS_ERROR_CODE)
+            assert.strictEqual((yield* test.observations).toolInvocations, before)
           }))
 
-        it.effect("MUST reject arguments that do not match the input schema with a protocol error", () =>
+        it.effect("MUST reject malformed tool params without invoking a handler", () =>
+          Effect.gen(function*() {
+            const test = yield* McpConformance
+            const initialized = yield* test.initialize({ server: "features" })
+            yield* test.notifyInitialized(initialized)
+            const before = (yield* test.observations).toolInvocations
+            const response = yield* test.send(initialized, {
+              jsonrpc: "2.0",
+              id: 2,
+              method: "tools/call",
+              params: { arguments: { value: "called" } }
+            })
+            const error = yield* test.decodeError(response)
+
+            assert.strictEqual(error.error.code, McpSchema.INVALID_PARAMS_ERROR_CODE)
+            assert.strictEqual((yield* test.observations).toolInvocations, before)
+          }))
+
+        it.effect("MUST handle arguments that do not match the input schema for the revision", () =>
           Effect.gen(function*() {
             const test = yield* McpConformance
             const initialized = yield* test.initialize({ server: "features" })
@@ -223,9 +243,16 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
                 arguments: { value: 123 }
               }
             })
-            const error = yield* test.decodeError(response)
-
-            assert.strictEqual(error.error.code, McpSchema.INVALID_PARAMS_ERROR_CODE)
+            if (protocol.protocolVersion === "2025-11-25") {
+              const result = yield* test.decodeResult(response).pipe(
+                Effect.flatMap((message) => decodeCallTool(message.result))
+              )
+              assert.strictEqual(result.isError, true)
+              assert.strictEqual(result.content[0]?.type, "text")
+            } else {
+              const error = yield* test.decodeError(response)
+              assert.strictEqual(error.error.code, McpSchema.INVALID_PARAMS_ERROR_CODE)
+            }
           }))
         it.effect("MUST not invoke a tool handler when argument validation fails", () =>
           Effect.gen(function*() {

--- a/packages/effect/test/unstable/ai/McpServer/McpConformance/TransportsTest.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpConformance/TransportsTest.ts
@@ -155,6 +155,17 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
 
       describe(httpTransportSuiteName(protocol), () => {
         describe("Sending Messages to the Server", () => {
+          it.effect.skipIf(["2024-11-05", "2025-03-26"].includes(protocol.protocolVersion))(
+            "MUST reject JSON-RPC batches",
+            () =>
+              Effect.gen(function*() {
+                const test = yield* McpConformance
+                const response = yield* test.post([test.initializeRequest()])
+
+                assert.isAtLeast(response.status, 400)
+              })
+          )
+
           it.effect("MUST accept JSON-RPC requests through POST on the MCP endpoint", () =>
             Effect.gen(function*() {
               const test = yield* McpConformance
@@ -186,6 +197,25 @@ export const suite = (protocol: McpProtocol.ProtocolAdapter, layer: McpConforman
               assert.strictEqual(response.status, 202)
               assert.strictEqual(yield* Effect.promise(() => response.text()), "")
             }))
+
+          it.effect.skipIf(["2024-11-05", "2025-03-26"].includes(protocol.protocolVersion))(
+            "MUST require the negotiated protocol-version header after initialization",
+            () =>
+              Effect.gen(function*() {
+                const test = yield* McpConformance
+                const initialized = yield* test.initialize()
+                assert.isNotNull(initialized.sessionId)
+
+                const missing = yield* test.ping(initialized, { includeProtocolVersion: false })
+                const mismatched = yield* test.ping(initialized, {
+                  id: 3,
+                  protocolVersion: protocol.protocolVersion === "2025-11-25" ? "2025-06-18" : "2025-03-26"
+                })
+
+                assert.isAtLeast(missing.status, 400)
+                assert.isAtLeast(mismatched.status, 400)
+              })
+          )
 
           it.effect("MUST require the application/json content type for POST requests", () =>
             Effect.gen(function*() {

--- a/packages/effect/test/unstable/ai/McpServer/ProtocolAdapters.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/ProtocolAdapters.test.ts
@@ -13,6 +13,16 @@ import * as Toolkit from "effect/unstable/ai/Toolkit"
 import * as RpcClient from "effect/unstable/rpc/RpcClient"
 import { makeHttpHarness } from "./TestUtils/McpHttpHarness.ts"
 
+const ServerIcon = McpSchema.Icon.make({
+  src: "https://example.com/server.svg",
+  mimeType: "image/svg+xml",
+  sizes: ["48x48", "any"],
+  theme: "dark"
+})
+const ResourceIcon = McpSchema.Icon.make({ src: "https://example.com/resource.svg" })
+const PromptIcon = McpSchema.Icon.make({ src: "https://example.com/prompt.svg" })
+const ToolIcon = McpSchema.Icon.make({ src: "https://example.com/tool.svg" })
+
 const SharedTool = Tool.make("shared", {
   parameters: Tool.EmptyParams,
   success: Schema.String
@@ -163,8 +173,16 @@ const makeFixture = Effect.fnUntraced(function*() {
     Layer.provide(McpServer.layerHttp({
       name: "ProtocolAdapterServer",
       version: "1.0.0",
+      description: "Protocol adapter fixture",
+      websiteUrl: "https://example.com/mcp",
+      icons: [McpSchema.Icon.make({
+        src: "https://example.com/server.svg",
+        mimeType: "image/svg+xml",
+        sizes: ["any"]
+      })],
       path: "/mcp",
       protocols: [
+        McpProtocol.v2025_11_25,
         McpProtocol.v2025_06_18,
         McpProtocol.v2025_03_26,
         McpProtocol.v2024_11_05
@@ -210,6 +228,7 @@ const makeLowLevelFixture = Effect.fnUntraced(function*() {
         resource: new McpSchema.Resource({
           uri: "file:///metadata.txt",
           name: "metadata-resource",
+          icons: [ResourceIcon],
           _meta: { descriptor: "fixture" }
         }),
         annotations: Context.empty(),
@@ -223,6 +242,7 @@ const makeLowLevelFixture = Effect.fnUntraced(function*() {
       yield* server.addPrompt({
         prompt: new McpSchema.Prompt({
           name: "metadata-prompt",
+          icons: [PromptIcon],
           _meta: { descriptor: "fixture" }
         }),
         annotations: Context.empty(),
@@ -251,6 +271,7 @@ const makeLowLevelFixture = Effect.fnUntraced(function*() {
         tool: new McpSchema.Tool({
           name: "title-precedence",
           title: "Canonical title",
+          icons: [ToolIcon],
           inputSchema: {
             type: "object",
             properties: {}
@@ -463,8 +484,12 @@ const makeLowLevelFixture = Effect.fnUntraced(function*() {
     Layer.provide(McpServer.layerHttp({
       name: "LowLevelProtocolAdapterServer",
       version: "1.0.0",
+      description: "Low-level protocol adapter fixture",
+      websiteUrl: "https://example.com/low-level-mcp",
+      icons: [ServerIcon],
       path: "/mcp",
       protocols: [
+        McpProtocol.v2025_11_25,
         McpProtocol.v2025_06_18,
         McpProtocol.v2025_03_26,
         McpProtocol.v2024_11_05
@@ -496,7 +521,7 @@ const decodeJsonRpcResponse = Schema.decodeUnknownEffect(JsonRpcResponse)
 
 const initialize = Effect.fnUntraced(function*(
   post: Effect.Success<ReturnType<typeof makeFixture>>["post"],
-  protocolVersion: "2025-06-18" | "2025-03-26" | "2024-11-05",
+  protocolVersion: "2025-11-25" | "2025-06-18" | "2025-03-26" | "2024-11-05",
   options?: {
     readonly capabilities?: Record<string, unknown>
     readonly clientInfo?: {

--- a/packages/effect/test/unstable/ai/McpServer/ProtocolAdapters.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/ProtocolAdapters.test.ts
@@ -362,7 +362,8 @@ const makeLowLevelFixture = Effect.fnUntraced(function*() {
                 },
                 annotations: {
                   audience: ["assistant"],
-                  priority: 0.75
+                  priority: 0.75,
+                  lastModified: "2026-08-13T00:00:00Z"
                 },
                 _meta: { content: "fixture" }
               }],
@@ -717,6 +718,21 @@ describe("McpServer protocol adapters", () => {
           assert.deepStrictEqual(yield* protocol.projectNotification(notification), expected)
         }
       }
+
+      const elicitationComplete = McpCore.ServerNotification.ElicitationComplete({ elicitationId: "elicitation-1" })
+      assert.deepStrictEqual(yield* McpProtocol.v2025_11_25.projectNotification(elicitationComplete), {
+        tag: "notifications/elicitation/complete",
+        payload: { elicitationId: "elicitation-1" }
+      })
+      for (
+        const protocol of [
+          McpProtocol.v2024_11_05,
+          McpProtocol.v2025_03_26,
+          McpProtocol.v2025_06_18
+        ]
+      ) {
+        assert.isUndefined(yield* protocol.projectNotification(elicitationComplete))
+      }
     }))
   it.effect("should omit elicitation when the negotiated protocol predates v2025-06-18", () =>
     Effect.gen(function*() {
@@ -1022,7 +1038,7 @@ describe("McpServer protocol adapters", () => {
     Effect.gen(function*() {
       const fixture = yield* makeLowLevelFixture()
 
-      for (const protocolVersion of ["2025-06-18", "2025-03-26", "2024-11-05"] as const) {
+      for (const protocolVersion of ["2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"] as const) {
         const client = yield* initialize(fixture.post, protocolVersion)
         const result = resultOf(
           yield* client.request("tools/call", { name: "annotated-resource" })
@@ -1034,14 +1050,23 @@ describe("McpServer protocol adapters", () => {
         const resource = Schema.decodeUnknownSync(
           Schema.Record(Schema.String, Schema.Unknown)
         )(content.resource)
-        assert.deepStrictEqual(content.annotations, {
-          audience: ["assistant"],
-          priority: 0.75
-        })
+        assert.deepStrictEqual(
+          content.annotations,
+          protocolVersion === "2025-11-25"
+            ? {
+              audience: ["assistant"],
+              priority: 0.75,
+              lastModified: "2026-08-13T00:00:00Z"
+            }
+            : {
+              audience: ["assistant"],
+              priority: 0.75
+            }
+        )
         assert.strictEqual(resource.uri, "file:///annotated.txt")
         assert.strictEqual(resource.mimeType, "text/plain")
         assert.strictEqual(resource.text, "annotated")
-        if (protocolVersion === "2025-06-18") {
+        if (protocolVersion === "2025-11-25" || protocolVersion === "2025-06-18") {
           assert.deepStrictEqual(resource._meta, { source: "fixture" })
           assert.deepStrictEqual(content._meta, { content: "fixture" })
         } else {
@@ -1091,6 +1116,46 @@ describe("McpServer protocol adapters", () => {
           assert.notProperty(content, "_meta")
         }
       }
+    }))
+
+  it.effect("should expose implementation metadata and descriptor icons when supported by the protocol", () =>
+    Effect.gen(function*() {
+      const fixture = yield* makeLowLevelFixture()
+      const november = yield* initialize(fixture.post, "2025-11-25")
+      const june = yield* initialize(fixture.post, "2025-06-18")
+
+      assert.deepStrictEqual(november.initializeResult.serverInfo, {
+        name: "LowLevelProtocolAdapterServer",
+        version: "1.0.0",
+        description: "Low-level protocol adapter fixture",
+        websiteUrl: "https://example.com/low-level-mcp",
+        icons: [{
+          src: "https://example.com/server.svg",
+          mimeType: "image/svg+xml",
+          sizes: ["48x48", "any"],
+          theme: "dark"
+        }]
+      })
+      assert.deepStrictEqual(june.initializeResult.serverInfo, {
+        name: "LowLevelProtocolAdapterServer",
+        version: "1.0.0"
+      })
+
+      const resources = resultOf(yield* november.request("resources/list"))
+      const resource = (resources.resources as Array<Record<string, unknown>>).find(
+        (_) => _.uri === "file:///metadata.txt"
+      )
+      assert.isDefined(resource)
+      assert.deepStrictEqual(resource.icons, [{ src: "https://example.com/resource.svg" }])
+
+      const prompts = resultOf(yield* november.request("prompts/list"))
+      const prompt = (prompts.prompts as Array<Record<string, unknown>>).find((_) => _.name === "metadata-prompt")
+      assert.isDefined(prompt)
+      assert.deepStrictEqual(prompt.icons, [{ src: "https://example.com/prompt.svg" }])
+
+      const tool = listedTools(yield* november.request("tools/list")).find((_) => _.name === "title-precedence")
+      assert.isDefined(tool)
+      assert.deepStrictEqual(tool.icons, [{ src: "https://example.com/tool.svg" }])
     }))
 
   it.effect("should hide and reject a tool when its declaration is incompatible with the revision", () =>

--- a/packages/effect/test/unstable/ai/McpServer/v2025_06_18.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/v2025_06_18.test.ts
@@ -1,14 +1,10 @@
-import { assert, describe, it } from "@effect/vitest"
-import * as Effect from "effect/Effect"
-import * as Schema from "effect/Schema"
 import * as McpProtocol from "effect/unstable/ai/McpProtocol"
-import * as McpSchema from "effect/unstable/ai/McpSchema"
 import * as BaseProtocolTest from "./McpConformance/BaseProtocolTest.ts"
 import * as CompletionTest from "./McpConformance/CompletionTest.ts"
 import * as ElicitationTest from "./McpConformance/ElicitationTest.ts"
 import * as LifecycleTest from "./McpConformance/LifecycleTest.ts"
 import * as LoggingTest from "./McpConformance/LoggingTest.ts"
-import { layer as makeMcpConformanceLayer, McpConformance } from "./McpConformance/McpConformance.ts"
+import { layer as makeMcpConformanceLayer } from "./McpConformance/McpConformance.ts"
 import * as PromptsTest from "./McpConformance/PromptsTest.ts"
 import * as ResourcesTest from "./McpConformance/ResourcesTest.ts"
 import * as RootsTest from "./McpConformance/RootsTest.ts"
@@ -16,14 +12,6 @@ import * as SamplingTest from "./McpConformance/SamplingTest.ts"
 import * as ToolsTest from "./McpConformance/ToolsTest.ts"
 import * as TransportsTest from "./McpConformance/TransportsTest.ts"
 import * as UtilitiesTest from "./McpConformance/UtilitiesTest.ts"
-
-it("accepts tools/call without optional arguments", () => {
-  const decoded = Schema.decodeUnknownExit(McpSchema.CallTool.payloadSchema)({ name: "ping" })
-  assert.strictEqual(decoded._tag, "Success")
-  if (decoded._tag === "Success") {
-    assert.deepStrictEqual(decoded.value.arguments, {})
-  }
-})
 
 const protocol = McpProtocol.v2025_06_18
 const testLayer = makeMcpConformanceLayer(protocol)
@@ -40,34 +28,3 @@ LoggingTest.suite(protocol, testLayer)
 RootsTest.suite(protocol, testLayer)
 SamplingTest.suite(protocol, testLayer)
 ElicitationTest.suite(protocol, testLayer)
-
-it.layer(testLayer)(`Mcp Conformance (${protocol.protocolVersion})`, (it) => {
-  describe("Transport-specific behavior", () => {
-    it.effect("MUST reject JSON-RPC batches", () =>
-      Effect.gen(function*() {
-        const test = yield* McpConformance
-        const response = yield* test.post([test.initializeRequest()])
-
-        assert.isAtLeast(response.status, 400)
-      }))
-
-    it.effect("MUST require the negotiated protocol-version header after initialization", () =>
-      Effect.gen(function*() {
-        const test = yield* McpConformance
-        const initialized = yield* test.initialize()
-        assert.isNotNull(initialized.sessionId)
-
-        const missing = yield* test.ping(initialized, {
-          includeProtocolVersion: false
-        })
-        const mismatched = yield* test.ping(initialized, {
-          id: 3,
-          protocolVersion: "2025-03-26"
-        })
-
-        assert.strictEqual(initialized.message.result.protocolVersion, protocol.protocolVersion)
-        assert.isAtLeast(missing.status, 400)
-        assert.isAtLeast(mismatched.status, 400)
-      }))
-  })
-})

--- a/packages/effect/test/unstable/ai/McpServer/v2025_11_25.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/v2025_11_25.test.ts
@@ -4,11 +4,13 @@ import * as McpProtocol from "effect/unstable/ai/McpProtocol"
 import * as McpSchema from "effect/unstable/ai/McpSchema"
 import * as BaseProtocolTest from "./McpConformance/BaseProtocolTest.ts"
 import * as CompletionTest from "./McpConformance/CompletionTest.ts"
+import * as ElicitationTest from "./McpConformance/ElicitationTest.ts"
 import * as LifecycleTest from "./McpConformance/LifecycleTest.ts"
 import * as LoggingTest from "./McpConformance/LoggingTest.ts"
 import { layer as makeMcpConformanceLayer, McpConformance } from "./McpConformance/McpConformance.ts"
 import * as PromptsTest from "./McpConformance/PromptsTest.ts"
 import * as ResourcesTest from "./McpConformance/ResourcesTest.ts"
+import * as SamplingTest from "./McpConformance/SamplingTest.ts"
 import * as ToolsTest from "./McpConformance/ToolsTest.ts"
 import * as TransportsTest from "./McpConformance/TransportsTest.ts"
 import * as UtilitiesTest from "./McpConformance/UtilitiesTest.ts"
@@ -25,6 +27,8 @@ ResourcesTest.suite(protocol, testLayer)
 PromptsTest.suite(protocol, testLayer)
 CompletionTest.suite(protocol, testLayer)
 LoggingTest.suite(protocol, testLayer)
+SamplingTest.suite(protocol, testLayer)
+ElicitationTest.suite(protocol, testLayer)
 
 it.layer(testLayer)(`Mcp Conformance (${protocol.protocolVersion})`, (it) => {
   describe("Tools", () => {

--- a/packages/effect/test/unstable/ai/McpServer/v2025_11_25.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/v2025_11_25.test.ts
@@ -1,0 +1,49 @@
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as McpProtocol from "effect/unstable/ai/McpProtocol"
+import * as McpSchema from "effect/unstable/ai/McpSchema"
+import * as BaseProtocolTest from "./McpConformance/BaseProtocolTest.ts"
+import * as CompletionTest from "./McpConformance/CompletionTest.ts"
+import * as LifecycleTest from "./McpConformance/LifecycleTest.ts"
+import * as LoggingTest from "./McpConformance/LoggingTest.ts"
+import { layer as makeMcpConformanceLayer, McpConformance } from "./McpConformance/McpConformance.ts"
+import * as PromptsTest from "./McpConformance/PromptsTest.ts"
+import * as ResourcesTest from "./McpConformance/ResourcesTest.ts"
+import * as ToolsTest from "./McpConformance/ToolsTest.ts"
+import * as TransportsTest from "./McpConformance/TransportsTest.ts"
+import * as UtilitiesTest from "./McpConformance/UtilitiesTest.ts"
+
+const protocol = McpProtocol.v2025_11_25
+const testLayer = makeMcpConformanceLayer(protocol)
+
+LifecycleTest.suite(protocol, testLayer)
+BaseProtocolTest.suite(protocol, testLayer)
+TransportsTest.suite(protocol, testLayer)
+UtilitiesTest.suite(protocol, testLayer)
+ToolsTest.suite(protocol, testLayer)
+ResourcesTest.suite(protocol, testLayer)
+PromptsTest.suite(protocol, testLayer)
+CompletionTest.suite(protocol, testLayer)
+LoggingTest.suite(protocol, testLayer)
+
+it.layer(testLayer)(`Mcp Conformance (${protocol.protocolVersion})`, (it) => {
+  describe("Tools", () => {
+    it.effect("does not expose experimental Tasks without an extension", () =>
+      Effect.gen(function*() {
+        const test = yield* McpConformance
+        const initialized = yield* test.initialize({ server: "features" })
+        yield* test.notifyInitialized(initialized)
+        const before = (yield* test.observations).toolInvocations
+        const response = yield* test.send(initialized, {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tasks/get",
+          params: { taskId: "task-1" }
+        })
+        const error = yield* test.decodeError(response)
+
+        assert.strictEqual(error.error.code, McpSchema.METHOD_NOT_FOUND_ERROR_CODE)
+        assert.strictEqual((yield* test.observations).toolInvocations, before)
+      }))
+  })
+})

--- a/packages/effect/typetest/unstable/ai/McpServer.tst.ts
+++ b/packages/effect/typetest/unstable/ai/McpServer.tst.ts
@@ -12,7 +12,7 @@ import { describe, expect, it } from "tstyche"
 const serverOptions = {
   name: "TestServer",
   version: "1.0.0",
-  protocols: [McpProtocol.v2025_06_18]
+  protocols: [McpProtocol.v2025_11_25]
 } as const
 
 describe("McpServer", () => {
@@ -72,20 +72,24 @@ describe("McpServer", () => {
 
     it("should expose every historical protocol adapter", () => {
       expect<keyof typeof McpProtocol>().type.toBe<
-        "v2024_11_05" | "v2025_03_26" | "v2025_06_18"
+        "v2024_11_05" | "v2025_03_26" | "v2025_06_18" | "v2025_11_25"
       >()
-      expect<McpProtocol.ProtocolVersion>().type.toBe<"2024-11-05" | "2025-03-26" | "2025-06-18">()
+      expect<McpProtocol.ProtocolVersion>().type.toBe<
+        "2024-11-05" | "2025-03-26" | "2025-06-18" | "2025-11-25"
+      >()
     })
 
     it("should expose each historical protocol through the structural adapter interface", () => {
       expect(McpProtocol.v2024_11_05).type.toBeAssignableTo<McpProtocol.ProtocolAdapter<"2024-11-05">>()
       expect(McpProtocol.v2025_03_26).type.toBeAssignableTo<McpProtocol.ProtocolAdapter<"2025-03-26">>()
       expect(McpProtocol.v2025_06_18).type.toBeAssignableTo<McpProtocol.ProtocolAdapter<"2025-06-18">>()
+      expect(McpProtocol.v2025_11_25).type.toBeAssignableTo<McpProtocol.ProtocolAdapter<"2025-11-25">>()
 
       const protocols: readonly [McpProtocol.ProtocolAdapter, ...Array<McpProtocol.ProtocolAdapter>] = [
         McpProtocol.v2024_11_05,
         McpProtocol.v2025_03_26,
-        McpProtocol.v2025_06_18
+        McpProtocol.v2025_06_18,
+        McpProtocol.v2025_11_25
       ]
 
       expect(protocols[0].protocolVersion).type.toBe<McpProtocol.ProtocolVersion>()


### PR DESCRIPTION
## Type
- [x] Feature

## Description

Hot on the heels of adding the `McpCore`, I was ready with the  next important step: `v2025-11-25`.  The issue goes over the main criteria but the big changes in this protocol version are:

- **Icons** for tools, resources, resource templates, and prompts (SEP-973)
- **Input validation** errors as tool execution errors (SEP-1303)
- **Tool calling in sampling** via tools and toolChoice (SEP-1577)
- **Elicitation enhancements** -> default values (SEP-1034), titled/multi-select enums (SEP-1330), URL mode (SEP-1036)

What's been left out is the experimental Tasks (SEP-1686) as there is a separate issue to address this with the task extension. Clients should still be able negotiate this is a v2025-11-28 server just without the Task capabilities.

What more interesting now if that we're starting to update the `McpSchema` (what user-land will be using) with some new functionality like `Icons` and `Tools` with Sampling which are negotiated as part of the ProtocolAdaptors they wish to support.  So they can add it as part of their `McpServer`, but the client will not need to know about it unless the protocol versions allows.

<details><summary>A toy example of some of these changes:</summary>

```ts
// New in 2025-11-25: server, resource, prompt, and tool descriptors can expose icons. Clients may choose the best entry for their size and color theme.
const ServerIcon = McpSchema.Icon.make({
  src: "https://example.com/icons/weather-server.svg",
  mimeType: "image/svg+xml",
  sizes: ["48x48", "any"],
  theme: "dark"
})

const AskWeatherModel = Tool.make("ask_weather_model", {
  description: "Ask the connected client's model to plan a weather lookup",
  parameters: Schema.Struct({
    city: Schema.String
  }),
  // CreateMessageResult is both the decoded response type and its Schema, so the tool preserves the structured sampling result without stringifying it.
  success: McpSchema.CreateMessageResult,
  failure: Schema.Never,
  dependencies: [McpSchema.McpServerClient]
})

const WeatherToolkit = Toolkit.make(AskWeatherModel)

const WeatherHandlers = WeatherToolkit.toLayer(WeatherToolkit.of({
  ask_weather_model: Effect.fnUntraced(
    function*({ city }) {
      // Every handler can inspect the protocol and capabilities negotiated with the client, then obtain the version-neutral reverse-operation facade.
      const currentClient = yield* McpSchema.McpServerClient
      const client = yield* currentClient.getClient

      const result = yield* client.createMessage(
        McpSchema.CreateMessage.payloadSchema.make({
          messages: [
            McpSchema.SamplingMessage.make({
              role: "user",
              content: McpSchema.TextContent.make({
                text: `Plan how to find the current weather in ${city}.`
              })
            })
          ],
          // New in 2025-11-25: sampling requests can declare tools and control whether the client's model may or must call one.
          tools: [{
            name: "get_weather",
            description: "Get current weather for a city",
            inputSchema: {
              type: "object",
              properties: {
                city: { type: "string" }
              },
              required: ["city"]
            }
          }],
          toolChoice: new McpSchema.ToolChoice({ mode: "required" }),
          maxTokens: 200
        })
      )

      // A November client may return ToolUseContent. A real server would run the requested tool and continue with matching ToolResultContent.
      return result
    },
    (effect) =>
      effect.pipe(
        Effect.scoped,
        Effect.orDie
      )
  )
}))

const McpLive = McpServer.toolkit(WeatherToolkit).pipe(
  Layer.provide(WeatherHandlers),
  Layer.provide(McpServer.layerStdio({
    name: "weather-demo",
    version: "1.0.0",
    description: "Demonstrates MCP 2025-11-25 metadata and sampling tools",
    // New in 2025-11-25: richer implementation metadata is projected during initialization and omitted automatically for older negotiated versions.
    websiteUrl: "https://example.com/weather-demo",
    icons: [ServerIcon],
    protocols: [
      // June remains a fallback for clients that do not yet offer the newer revision.
      McpProtocol.v2025_06_18,
      // New dated adapter with tool sampling, URL elicitation, icons
      McpProtocol.v2025_11_25
    ]
  })),
  Layer.provide(NodeServices.layer)
)

// The November adapter rejects the tool-enabled sampling request before it is sent when the connected client has not advertised `sampling.tools`.
NodeRuntime.runMain(Layer.launch(McpLive))
```
</details>

## How to Review

If you're familiar with the other `ProtocolAdaptor` version then you will notice a lot of similarities and duplication.  This is mostly intentional for now as we went to make sure each version owns as much of tis own schema and behaviours. 

Probably the best places to review would be:

```txt
effect/unstable/ai/
├── internal
│   ├── mcpProtocol
│   │   ├── .
│   │   ╰── v2025_11_25.ts <- wire implementation for protocol
│   ├── mcpSchema
│   │   ├── .
│   │   ╰── v2025_11_25.ts <- new McpSchema for protocol
│   ╰── .
├── McpSchema.ts <- added Icons
├── McpServer.ts <- changes sampling and clicitation
.
```

The tests are interesting but mostly I think to see how the conformance suite is being used to cover the most recent version and skip tests that don't apply to older verions:
```
 ✓  effect  test/unstable/ai/McpServer/v2024_11_05.test.ts (161 tests | 19 skipped) 251ms
 ✓  effect  test/unstable/ai/McpServer/v2025_03_26.test.ts (166 tests | 16 skipped) 261ms
 ✓  effect  test/unstable/ai/McpServer/v2025_06_18.test.ts (171 tests | 9 skipped) 279ms
 ✓  effect  test/unstable/ai/McpServer/v2025_11_25.test.ts (166 tests) 279ms
```

Any questions or comments, feel free to ask here or reach out on discord!

## Related

- Related PRs #6625, #6829 
- Related Issues #6834
- Closes #6706
