### PR TITLE
fix(sql): propagate a failed transaction begin as a typed error

### DIFF
--- a/.changeset/sql-begin-failure-typed.md
+++ b/.changeset/sql-begin-failure-typed.md
@@ -1,0 +1,16 @@
+---
+"effect": patch
+---
+
+Propagate a failed `BEGIN` or `SAVEPOINT` from `SqlClient.withTransaction` as a typed `SqlError`.
+
+`makeWithTransaction` wrapped the `begin` step together with the transaction body, so a
+failed `BEGIN` took the rollback branch. No transaction was active at that point, the
+`ROLLBACK` failed, and its `Effect.orDie` wrapper replaced the original typed error with a
+defect (`cannot rollback - no transaction is active`). Callers could no longer classify the
+failure as retryable. The path became reachable when the sqlite client started using
+`BEGIN IMMEDIATE`, which acquires a write lock and can fail with `SQLITE_BUSY`.
+
+Commit and rollback now run only after `begin` or `savepoint` succeeds. A failed `begin` or
+`savepoint` fails with its original `SqlError`, leaves the wrapped effect unexecuted, and
+still closes the acquired connection scope.

--- a/packages/effect/src/unstable/sql/SqlClient.ts
+++ b/packages/effect/src/unstable/sql/SqlClient.ts
@@ -254,41 +254,48 @@ export const makeWithTransaction = <I, S>(options: {
               conn,
               (
                 [scope, conn]
-              ) =>
-                (id === 0 ? options.begin(conn) : options.savepoint(conn, id)).pipe(
-                  Effect.flatMap(() =>
-                    Effect.provideContext(
-                      restore(effect),
-                      services.pipe(
-                        Context.add(options.transactionService, [conn, id]),
-                        Context.add(transactionSemaphore, Semaphore.makeUnsafe(1)),
-                        Context.add(Tracer.ParentSpan, span)
-                      )
+              ) => {
+                // A failed begin/savepoint never opened a transaction, so it must
+                // propagate as its original typed error without any rollback.
+                const begin = id === 0 ? options.begin(conn) : options.savepoint(conn, id)
+                const beginWithScope = scope !== undefined
+                  ? Effect.onError(begin, (cause) => Scope.close(scope, Exit.failCause(cause)))
+                  : begin
+                return Effect.flatMap(beginWithScope, () =>
+                  Effect.provideContext(
+                    restore(effect),
+                    services.pipe(
+                      Context.add(options.transactionService, [conn, id]),
+                      Context.add(transactionSemaphore, Semaphore.makeUnsafe(1)),
+                      Context.add(Tracer.ParentSpan, span)
                     )
-                  ),
-                  Effect.exit,
-                  Effect.flatMap((exit) => {
-                    let effect: Effect.Effect<void>
-                    if (Exit.isSuccess(exit)) {
-                      if (id === 0) {
-                        span.event("db.transaction.commit", clock.currentTimeNanosUnsafe())
-                        effect = Effect.orDie(options.commit(conn))
+                  ).pipe(
+                    Effect.exit,
+                    Effect.flatMap((exit) => {
+                      let effect: Effect.Effect<void>
+                      if (Exit.isSuccess(exit)) {
+                        if (id === 0) {
+                          span.event("db.transaction.commit", clock.currentTimeNanosUnsafe())
+                          effect = Effect.orDie(options.commit(conn))
+                        } else {
+                          span.event("db.transaction.savepoint", clock.currentTimeNanosUnsafe())
+                          effect = Effect.void
+                        }
                       } else {
-                        span.event("db.transaction.savepoint", clock.currentTimeNanosUnsafe())
-                        effect = Effect.void
+                        span.event("db.transaction.rollback", clock.currentTimeNanosUnsafe())
+                        effect = Effect.orDie(
+                          id > 0
+                            ? options.rollbackSavepoint(conn, id)
+                            : options.rollback(conn)
+                        )
                       }
-                    } else {
-                      span.event("db.transaction.rollback", clock.currentTimeNanosUnsafe())
-                      effect = Effect.orDie(
-                        id > 0
-                          ? options.rollbackSavepoint(conn, id)
-                          : options.rollback(conn)
-                      )
-                    }
-                    const withScope = scope !== undefined ? Effect.ensuring(effect, Scope.close(scope, exit)) : effect
-                    return Effect.flatMap(withScope, () => exit)
-                  })
-                )
+                      const withScope = scope !== undefined
+                        ? Effect.ensuring(effect, Scope.close(scope, exit))
+                        : effect
+                      return Effect.flatMap(withScope, () => exit)
+                    })
+                  ))
+              }
             )
             return id === 0
               ? transaction

--- a/packages/effect/src/unstable/sql/SqlClient.ts
+++ b/packages/effect/src/unstable/sql/SqlClient.ts
@@ -12,6 +12,7 @@ import { Clock } from "../../Clock.ts"
 import * as Context from "../../Context.ts"
 import * as Effect from "../../Effect.ts"
 import * as Exit from "../../Exit.ts"
+import { identity } from "../../Function.ts"
 import * as Option from "../../Option.ts"
 import type * as Queue from "../../Queue.ts"
 import type { ReadonlyRecord } from "../../Record.ts"
@@ -254,48 +255,43 @@ export const makeWithTransaction = <I, S>(options: {
               conn,
               (
                 [scope, conn]
-              ) => {
-                // A failed begin/savepoint never opened a transaction, so it must
-                // propagate as its original typed error without any rollback.
-                const begin = id === 0 ? options.begin(conn) : options.savepoint(conn, id)
-                const beginWithScope = scope !== undefined
-                  ? Effect.onError(begin, (cause) => Scope.close(scope, Exit.failCause(cause)))
-                  : begin
-                return Effect.flatMap(beginWithScope, () =>
-                  Effect.provideContext(
-                    restore(effect),
-                    services.pipe(
-                      Context.add(options.transactionService, [conn, id]),
-                      Context.add(transactionSemaphore, Semaphore.makeUnsafe(1)),
-                      Context.add(Tracer.ParentSpan, span)
-                    )
-                  ).pipe(
-                    Effect.exit,
-                    Effect.flatMap((exit) => {
-                      let effect: Effect.Effect<void>
-                      if (Exit.isSuccess(exit)) {
-                        if (id === 0) {
-                          span.event("db.transaction.commit", clock.currentTimeNanosUnsafe())
-                          effect = Effect.orDie(options.commit(conn))
-                        } else {
-                          span.event("db.transaction.savepoint", clock.currentTimeNanosUnsafe())
-                          effect = Effect.void
-                        }
-                      } else {
-                        span.event("db.transaction.rollback", clock.currentTimeNanosUnsafe())
-                        effect = Effect.orDie(
-                          id > 0
-                            ? options.rollbackSavepoint(conn, id)
-                            : options.rollback(conn)
+              ) =>
+                (id === 0 ? options.begin(conn) : options.savepoint(conn, id)).pipe(
+                  Effect.flatMap(() =>
+                    Effect.onExitPrimitive(
+                      Effect.provideContext(
+                        restore(effect),
+                        services.pipe(
+                          Context.add(options.transactionService, [conn, id]),
+                          Context.add(transactionSemaphore, Semaphore.makeUnsafe(1)),
+                          Context.add(Tracer.ParentSpan, span)
                         )
-                      }
-                      const withScope = scope !== undefined
-                        ? Effect.ensuring(effect, Scope.close(scope, exit))
-                        : effect
-                      return Effect.flatMap(withScope, () => exit)
-                    })
-                  ))
-              }
+                      ),
+                      (exit) => {
+                        let effect: Effect.Effect<void>
+                        if (Exit.isSuccess(exit)) {
+                          if (id === 0) {
+                            span.event("db.transaction.commit", clock.currentTimeNanosUnsafe())
+                            effect = Effect.orDie(options.commit(conn))
+                          } else {
+                            span.event("db.transaction.savepoint", clock.currentTimeNanosUnsafe())
+                            effect = Effect.void
+                          }
+                        } else {
+                          span.event("db.transaction.rollback", clock.currentTimeNanosUnsafe())
+                          effect = Effect.orDie(
+                            id > 0
+                              ? options.rollbackSavepoint(conn, id)
+                              : options.rollback(conn)
+                          )
+                        }
+                        return Effect.flatMap(effect, () => exit)
+                      },
+                      true
+                    )
+                  ),
+                  scope ? (eff) => Effect.onExitPrimitive(eff, (exit) => Scope.close(scope, exit), true) : identity
+                )
             )
             return id === 0
               ? transaction

--- a/packages/effect/test/unstable/sql/SqlClient.test.ts
+++ b/packages/effect/test/unstable/sql/SqlClient.test.ts
@@ -1,0 +1,178 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Cause, Context, Effect, Exit, Option, Scope } from "effect"
+import { SqlClient, SqlError } from "effect/unstable/sql"
+
+interface StubConnection {
+  readonly id: string
+}
+
+interface StubTransactionConnection {
+  readonly _: unique symbol
+}
+
+const sqlError = (message: string) =>
+  new SqlError.SqlError({
+    reason: new SqlError.UnknownError({ cause: new Error(message), message })
+  })
+
+let harnessIdCounter = 0
+
+/**
+ * Builds a `makeWithTransaction` wrapper over stub transaction commands, so the
+ * transaction control flow can be driven without a database driver.
+ *
+ * The stubs mirror the driver contract: `rollback` and `rollbackSavepoint` fail
+ * when no transaction or savepoint is active, which is what a real database
+ * reports when a rollback is issued after a failed `BEGIN`.
+ */
+const makeHarness = (failures: {
+  readonly begin?: SqlError.SqlError | undefined
+  readonly savepoint?: SqlError.SqlError | undefined
+} = {}) => {
+  const calls: Array<string> = []
+  const conn: StubConnection = { id: "stub" }
+  const transactionService = Context.Service<
+    StubTransactionConnection,
+    readonly [conn: StubConnection, counter: number]
+  >(`test/SqlClient/TransactionConnection/${harnessIdCounter++}`)
+
+  let transactionActive = false
+  const savepoints: Array<number> = []
+
+  const record = (name: string) => Effect.sync(() => calls.push(name))
+
+  const withTransaction = SqlClient.makeWithTransaction({
+    transactionService,
+    spanAttributes: [],
+    acquireConnection: Effect.flatMap(Scope.make(), (scope) =>
+      Effect.as(
+        Effect.flatMap(
+          record("acquireConnection"),
+          () => Scope.addFinalizer(scope, record("closeConnection"))
+        ),
+        [scope, conn] as const
+      )),
+    begin: () =>
+      Effect.flatMap(record("begin"), () => {
+        if (failures.begin !== undefined) {
+          return Effect.fail(failures.begin)
+        }
+        transactionActive = true
+        return Effect.void
+      }),
+    savepoint: (_conn, id) =>
+      Effect.flatMap(record(`savepoint(${id})`), () => {
+        if (failures.savepoint !== undefined) {
+          return Effect.fail(failures.savepoint)
+        }
+        savepoints.push(id)
+        return Effect.void
+      }),
+    commit: () =>
+      Effect.flatMap(record("commit"), () =>
+        transactionActive
+          ? Effect.sync(() => {
+            transactionActive = false
+          })
+          : Effect.fail(sqlError("cannot commit - no transaction is active"))),
+    rollback: () =>
+      Effect.flatMap(record("rollback"), () =>
+        transactionActive
+          ? Effect.sync(() => {
+            transactionActive = false
+          })
+          : Effect.fail(sqlError("cannot rollback - no transaction is active"))),
+    rollbackSavepoint: (_conn, id) =>
+      Effect.flatMap(record(`rollbackSavepoint(${id})`), () =>
+        savepoints.includes(id)
+          ? Effect.sync(() => {
+            savepoints.splice(savepoints.indexOf(id), 1)
+          })
+          : Effect.fail(sqlError(`cannot rollback to savepoint ${id} - it does not exist`)))
+  })
+
+  return { calls, withTransaction } as const
+}
+
+const assertTypedFailure = <A, E>(exit: Exit.Exit<A, E>, error: E) => {
+  assert.isTrue(Exit.isFailure(exit))
+  if (!Exit.isFailure(exit)) {
+    return
+  }
+  assert.isFalse(
+    Cause.hasDies(exit.cause),
+    `expected a typed failure but the cause contains a defect:\n${Cause.pretty(exit.cause)}`
+  )
+  assert.deepStrictEqual(Cause.findErrorOption(exit.cause), Option.some(error))
+}
+
+describe("SqlClient", () => {
+  describe("makeWithTransaction", () => {
+    it.effect("propagates a failed begin as a typed error without rolling back", () =>
+      Effect.gen(function*() {
+        const beginError = sqlError("database is locked")
+        const harness = makeHarness({ begin: beginError })
+        let executed = false
+
+        const exit = yield* Effect.exit(harness.withTransaction(Effect.sync(() => {
+          executed = true
+        })))
+
+        assertTypedFailure(exit, beginError)
+        assert.isFalse(executed)
+        assert.deepStrictEqual(harness.calls, ["acquireConnection", "begin", "closeConnection"])
+      }))
+
+    it.effect("rolls back when the wrapped effect fails after a successful begin", () =>
+      Effect.gen(function*() {
+        const harness = makeHarness()
+
+        const exit = yield* Effect.exit(harness.withTransaction(Effect.fail("boom" as const)))
+
+        assertTypedFailure(exit, "boom" as const)
+        assert.deepStrictEqual(harness.calls, ["acquireConnection", "begin", "rollback", "closeConnection"])
+      }))
+
+    it.effect("propagates a failed savepoint as a typed error without rolling back", () =>
+      Effect.gen(function*() {
+        const savepointError = sqlError("cannot create savepoint")
+        const harness = makeHarness({ savepoint: savepointError })
+        let executed = false
+
+        const exit = yield* Effect.exit(harness.withTransaction(
+          harness.withTransaction(Effect.sync(() => {
+            executed = true
+          }))
+        ))
+
+        assertTypedFailure(exit, savepointError)
+        assert.isFalse(executed)
+        assert.deepStrictEqual(harness.calls, [
+          "acquireConnection",
+          "begin",
+          "savepoint(1)",
+          "rollback",
+          "closeConnection"
+        ])
+      }))
+
+    it.effect("closes the connection scope when begin fails", () =>
+      Effect.gen(function*() {
+        const harness = makeHarness({ begin: sqlError("database is locked") })
+
+        yield* Effect.exit(harness.withTransaction(Effect.void))
+
+        assert.include(harness.calls, "closeConnection")
+      }))
+
+    it.effect("commits and returns the value when the wrapped effect succeeds", () =>
+      Effect.gen(function*() {
+        const harness = makeHarness()
+
+        const result = yield* harness.withTransaction(Effect.succeed(1))
+
+        assert.strictEqual(result, 1)
+        assert.deepStrictEqual(harness.calls, ["acquireConnection", "begin", "commit", "closeConnection"])
+      }))
+  })
+})

--- a/packages/sql/sqlite-node/test/Client.test.ts
+++ b/packages/sql/sqlite-node/test/Client.test.ts
@@ -1,7 +1,7 @@
 import { NodeFileSystem } from "@effect/platform-node"
 import { SqliteClient } from "@effect/sql-sqlite-node"
 import { assert, describe, it } from "@effect/vitest"
-import { Duration, Effect, FileSystem } from "effect"
+import { Cause, Duration, Effect, Exit, FileSystem, Option } from "effect"
 import { Reactivity } from "effect/unstable/reactivity"
 
 const makeClient = Effect.gen(function*() {
@@ -114,6 +114,32 @@ describe("Client", () => {
           assert.match(error.reason.cause.message, /database is locked/i)
         })
       )
+    }))
+
+  it.effect("fails a contended transaction with a typed error", () =>
+    Effect.gen(function*() {
+      const { client, contender } = yield* makeClients
+      yield* contender`PRAGMA busy_timeout = 1`
+
+      const exit = yield* client.withTransaction(
+        Effect.exit(contender.withTransaction(Effect.void))
+      )
+
+      assert.isTrue(Exit.isFailure(exit))
+      if (!Exit.isFailure(exit)) {
+        return
+      }
+      // `BEGIN IMMEDIATE` cannot take the write lock, so it fails before a
+      // transaction exists. The failure has to stay a typed, retryable
+      // `SqlError` instead of being replaced by a rollback defect.
+      assert.isFalse(
+        Cause.hasDies(exit.cause),
+        `expected a typed failure but the cause contains a defect:\n${Cause.pretty(exit.cause)}`
+      )
+      const error = Option.getOrThrow(Cause.findErrorOption(exit.cause))
+      assert.strictEqual(error._tag, "SqlError")
+      assert(error.reason.cause instanceof Error)
+      assert.match(error.reason.cause.message, /database is locked/i)
     }))
 
   it.effect("supports transactions on readonly clients", () =>


### PR DESCRIPTION
fixes #7235

## What was broken

`makeWithTransaction` in `packages/effect/src/unstable/sql/SqlClient.ts` wrapped the `begin`/`savepoint` step together with the transaction body in `Effect.exit`. A failed `BEGIN` therefore landed in the failure branch, which issues a `ROLLBACK`. No transaction was active at that point, so the `ROLLBACK` failed too, and its `Effect.orDie` wrapper discarded the original typed `SqlError` and replaced it with a defect:

```
DEFECT (untyped, not retryable):
  effect/sql/SqlError: Failed to execute statement
    effect/sql/SqlError/UnknownError: Failed to execute statement
      Error: cannot rollback - no transaction is active
```

Callers can no longer classify the failure as busy/locked, so busy-retry logic never sees it.

## Why it surfaced now

The `makeWithTransaction` code is unchanged from the betas, but the branch was unreachable: the older sqlite client set neither `beginTransaction` nor `busy_timeout`, so a plain deferred `BEGIN` took no lock and could not fail. The current sqlite client sets `beginTransaction: "BEGIN IMMEDIATE"` plus `PRAGMA busy_timeout` for writable connections, so `BEGIN` itself can fail with `SQLITE_BUSY` and reach the latent branch.

## The fix

`begin`/`savepoint` now runs outside the `Effect.exit` region. Commit and rollback handling applies only after it succeeds. A failed `begin`/`savepoint` propagates as its original typed `SqlError`, and the acquired connection scope is still closed via `Effect.onError`. Everything else is unchanged: `uninterruptibleMask`/`restore` behaviour, span events, `Effect.orDie` on the commit/rollback that follow a successful begin, and scope closure on every other path.

## Tests

New `packages/effect/test/unstable/sql/SqlClient.test.ts` drives `makeWithTransaction` with stub transaction commands (no driver needed). The stubs mirror the driver contract: `rollback`/`rollbackSavepoint` fail when nothing is active.

- a failed `begin` propagates typed, the wrapped effect never runs, and `rollback` is not called
- a failed wrapped effect after a successful `begin` still rolls back and propagates its typed error
- a failed `savepoint` in a nested transaction propagates typed without `rollbackSavepoint`
- the connection scope is closed when `begin` fails
- the success path still commits and returns the value

All five fail-first: before the fix the begin and savepoint cases fail with the `cannot rollback - no transaction is active` defect.

Verified end-to-end against `@effect/sql-sqlite-node` with the reproduction from the issue (two connections, `busyTimeout: 0`). Before: `hasDies: true`, `UnknownError: cannot rollback - no transaction is active`. After: a typed `SqlError` whose reason is `LockTimeoutError` with `isRetryable: true`.

Added in follow-up: `packages/sql/sqlite-node/test/Client.test.ts` now carries the driver-level counterpart, so the reported scenario is guarded in CI rather than only checked by hand. A contending client with `PRAGMA busy_timeout = 1` runs `withTransaction` while another client holds the write lock; the test asserts the cause carries no defect and that the typed error is a `SqlError` reporting `database is locked`. It fails on `main` with `expected a typed failure but the cause contains a defect` and passes with this change.
