### PR TITLE
Update MCP and cluster migration guidance

### DIFF
--- a/migration/annotations/effect__ai__McpSchema.yaml
+++ b/migration/annotations/effect__ai__McpSchema.yaml
@@ -1,6 +1,9 @@
 "@effect/ai/McpSchema#ContentBlock":
   replacement: "McpSchema.ContentBlock"
-  note: "Moved to effect/unstable/ai/McpSchema. It remains the MCP content-block union, but v4 exports it as a const schema rather than a Schema.Union subclass."
+  note: "Moved to effect/unstable/ai/McpSchema. It remains the MCP content-block union, but v4 exports it as a const schema rather than a Schema.Union subclass. Binary image, audio, and blob data still use Uint8Array values with base64 wire encoding."
+"@effect/ai/McpSchema#ElicitResult":
+  replacement: "McpSchema.ElicitResult"
+  note: "Moved to effect/unstable/ai/McpSchema. It remains the discriminated union of accepted responses with content and declined or canceled responses without content."
 "@effect/ai/McpSchema#FailureEncoded":
   replacement: "McpSchema.FailureEncoded"
   note: "Moved to effect/unstable/ai/McpSchema and still derives an encoded JSON-RPC failure union from an RpcGroup."

--- a/migration/annotations/effect__cluster__MessageStorage.yaml
+++ b/migration/annotations/effect__cluster__MessageStorage.yaml
@@ -6,7 +6,10 @@
   note: "Moved into core Effect with the same dependency-free no-op implementation."
 "@effect/cluster/MessageStorage#make":
   replacement: "effect/unstable/cluster/MessageStorage#make"
-  note: "Moved into core Effect. Context service projections now use the Service property instead of Type."
+  note: "Moved into core Effect. Context service projections now use the Service property instead of Type. Custom service implementations must also provide resetAddresses for batched mailbox resets."
+"@effect/cluster/MessageStorage#makeEncoded":
+  replacement: "effect/unstable/cluster/MessageStorage#makeEncoded"
+  note: "Moved into core Effect. Custom encoded drivers must replace resetAddress with resetAddresses and may use the new limit and addresses options passed to unprocessedMessages."
 "@effect/cluster/MessageStorage#Encoded":
   replacement: "effect/unstable/cluster/MessageStorage#Encoded"
-  note: "Moved into core Effect; use the v4 Envelope.Encoded and Reply.Encoded aliases in custom encoded storage implementations."
+  note: "Moved into core Effect; use the v4 Envelope.Encoded and Reply.Encoded aliases. Custom drivers now implement batched resetAddresses, and unprocessedMessages receives optional limit and address filters."

--- a/migration/annotations/effect__cluster__ShardingConfig.yaml
+++ b/migration/annotations/effect__cluster__ShardingConfig.yaml
@@ -3,7 +3,7 @@
   note: "Moved into core Effect; its Context service value type now uses the Service property instead of Type."
 "@effect/cluster/ShardingConfig#defaults":
   replacement: "effect/unstable/cluster/ShardingConfig#defaults"
-  note: "Moved into core Effect with the same complete defaults; service type projections now use Service instead of Type."
+  note: "Moved into core Effect; service type projections now use Service instead of Type. V4 also defaults maxResidentEntities to 10,000 and unprocessedMessageBatchSize to 1,024."
 "@effect/cluster/ShardingConfig#layer":
   replacement: "effect/unstable/cluster/ShardingConfig#layer"
   note: "Moved into core Effect with the same shallow default merge; service type projections now use Service instead of Type."

--- a/migration/v3-to-v4.md
+++ b/migration/v3-to-v4.md
@@ -4,7 +4,7 @@
 
 Base: `3d390f232bdbc3f0d3d6a2ae3c775084f494b547` (`3d390f232bdbc3f0d3d6a2ae3c775084f494b547`)
 
-Head: `origin/main` (`03031395d3ddee197217f826e7d9ef68b0674823`)
+Head: `origin/main` (`f4ba735bc450e5120800a4140f4f262a0cab2cae`)
 
 This file is generated from the API diff and `migration/annotations/*.yaml`.
 
@@ -4926,7 +4926,9 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 ### `@effect/ai/McpSchema`
 
-- `McpSchema.ContentBlock` -> `McpSchema.ContentBlock`: Moved to effect/unstable/ai/McpSchema. It remains the MCP content-block union, but v4 exports it as a const schema rather than a Schema.Union subclass.
+- `McpSchema.ContentBlock` -> `McpSchema.ContentBlock`: Moved to effect/unstable/ai/McpSchema. It remains the MCP content-block union, but v4 exports it as a const schema rather than a Schema.Union subclass. Binary image, audio, and blob data still use Uint8Array values with base64 wire encoding.
+
+- `McpSchema.ElicitResult` -> `McpSchema.ElicitResult`: Moved to effect/unstable/ai/McpSchema. It remains the discriminated union of accepted responses with content and declined or canceled responses without content.
 
 - `McpSchema.McpError` -> `McpSchema.McpError`: Moved, but changed from a constructable base class to a union schema of standard tagged protocol errors plus McpErrorBase. Use McpErrorBase to construct a generic MCP error.
 
@@ -5676,9 +5678,11 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 ### `@effect/cluster/MessageStorage`
 
-- `MessageStorage.Encoded` -> `effect/unstable/cluster/MessageStorage#Encoded`: Moved into core Effect; use the v4 Envelope.Encoded and Reply.Encoded aliases in custom encoded storage implementations.
+- `MessageStorage.Encoded` -> `effect/unstable/cluster/MessageStorage#Encoded`: Moved into core Effect; use the v4 Envelope.Encoded and Reply.Encoded aliases. Custom drivers now implement batched resetAddresses, and unprocessedMessages receives optional limit and address filters.
 
-- `MessageStorage.make` -> `effect/unstable/cluster/MessageStorage#make`: Moved into core Effect. Context service projections now use the Service property instead of Type.
+- `MessageStorage.make` -> `effect/unstable/cluster/MessageStorage#make`: Moved into core Effect. Context service projections now use the Service property instead of Type. Custom service implementations must also provide resetAddresses for batched mailbox resets.
+
+- `MessageStorage.makeEncoded` -> `effect/unstable/cluster/MessageStorage#makeEncoded`: Moved into core Effect. Custom encoded drivers must replace resetAddress with resetAddresses and may use the new limit and addresses options passed to unprocessedMessages.
 
 ### `@effect/cluster/Reply`
 
@@ -5716,7 +5720,7 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `ShardingConfig.config` -> `effect/unstable/cluster/ShardingConfig#config`: Moved into core Effect; its Context service value type now uses the Service property instead of Type.
 
-- `ShardingConfig.defaults` -> `effect/unstable/cluster/ShardingConfig#defaults`: Moved into core Effect with the same complete defaults; service type projections now use Service instead of Type.
+- `ShardingConfig.defaults` -> `effect/unstable/cluster/ShardingConfig#defaults`: Moved into core Effect; service type projections now use Service instead of Type. V4 also defaults maxResidentEntities to 10,000 and unprocessedMessageBatchSize to 1,024.
 
 - `ShardingConfig.layer` -> `effect/unstable/cluster/ShardingConfig#layer`: Moved into core Effect with the same shallow default merge; service type projections now use Service instead of Type.
 


### PR DESCRIPTION
## Summary

- document the current MCP `ContentBlock` and `ElicitResult` migration behavior
- document batched cluster message-storage resets and unprocessed-message filters
- record the new sharding residency and polling defaults
- regenerate the v3-to-v4 reference against main at `f4ba735bc450e5120800a4140f4f262a0cab2cae`

## Why

Recent main-branch changes updated MCP protocol schemas and the cluster storage driver contract. The migration reference now explains the affected v3 API IDs without pulling unrelated full-diff gaps into this maintenance run.

## Validation

- `pnpm lint-fix`
- `git diff --check`
- `pnpm api-diff --base-ref 3d390f232bdbc3f0d3d6a2ae3c775084f494b547 --head-ref origin/main --check` (the scoped MCP and MessageStorage gaps are resolved; the command still reports unrelated pre-existing `EventLogRemote.Ping` and `Workflow.Complete` gaps)

Closes EFF-654