### PR TITLE
Fix Effect.fromOption inline inference

### DIFF
--- a/.changeset/fix-from-option-inline-inference.md
+++ b/.changeset/fix-from-option-inline-inference.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Effect.fromOption` data-first inference for inline `Option` expressions.

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -1815,11 +1815,17 @@ export const fromResult: <A, E>(result: Result.Result<A, E>) => Effect<A, E> = i
  */
 export const fromOption: <
   Arg extends Option<unknown> | LazyArg<unknown>,
-  Rest extends [] | [onNone: LazyArg<unknown>] = []
+  Rest extends [] | [onNone: LazyArg<unknown> | undefined] = []
 >(
   arg: Arg & (Rest extends [] ? unknown : Option<unknown>),
   ...rest: Rest
-) => [Arg] extends [Option<infer A>] ? Effect<A, Rest extends [LazyArg<infer E>] ? E : Cause.NoSuchElementError>
+) => [Arg] extends [Option<infer A>] ? Effect<
+    A,
+    Rest extends [LazyArg<infer E>] ? E
+      : Rest extends [undefined] ? Cause.NoSuchElementError
+      : Rest extends [LazyArg<infer E> | undefined] ? E | Cause.NoSuchElementError
+      : Cause.NoSuchElementError
+  >
   : [Arg] extends [LazyArg<infer E>] ? <A>(option: Option<A>) => Effect<A, E>
   : never = internal.fromOption
 

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -1813,10 +1813,13 @@ export const fromResult: <A, E>(result: Result.Result<A, E>) => Effect<A, E> = i
  * @category converting
  * @since 4.0.0
  */
-export const fromOption: <Arg extends Option<unknown> | LazyArg<unknown>, E = Cause.NoSuchElementError>(
-  arg: Arg,
-  ...rest: [Arg] extends [Option<unknown>] ? [onNone?: LazyArg<E>] : []
-) => [Arg] extends [Option<infer A>] ? Effect<A, E>
+export const fromOption: <
+  Arg extends Option<unknown> | LazyArg<unknown>,
+  Rest extends [] | [onNone: LazyArg<unknown>] = []
+>(
+  arg: Arg & (Rest extends [] ? unknown : Option<unknown>),
+  ...rest: Rest
+) => [Arg] extends [Option<infer A>] ? Effect<A, Rest extends [LazyArg<infer E>] ? E : Cause.NoSuchElementError>
   : [Arg] extends [LazyArg<infer E>] ? <A>(option: Option<A>) => Effect<A, E>
   : never = internal.fromOption
 

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -945,10 +945,14 @@ export const suspend: <A, E, R>(
 })
 
 /** @internal */
-export const fromOption: <Arg extends Option.Option<unknown> | LazyArg<unknown>, E = Cause.NoSuchElementError>(
-  arg: Arg,
-  ...rest: [Arg] extends [Option.Option<unknown>] ? [onNone?: LazyArg<E>] : []
-) => [Arg] extends [Option.Option<infer A>] ? Effect.Effect<A, E>
+export const fromOption: <
+  Arg extends Option.Option<unknown> | LazyArg<unknown>,
+  Rest extends [] | [onNone: LazyArg<unknown>] = []
+>(
+  arg: Arg & (Rest extends [] ? unknown : Option.Option<unknown>),
+  ...rest: Rest
+) => [Arg] extends [Option.Option<infer A>]
+  ? Effect.Effect<A, Rest extends [LazyArg<infer E>] ? E : Cause.NoSuchElementError>
   : [Arg] extends [LazyArg<infer E>] ? <A>(option: Option.Option<A>) => Effect.Effect<A, E>
   : never = dual(
     (args) => args.length >= 2 || Option.isOption(args[0]),

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -947,12 +947,17 @@ export const suspend: <A, E, R>(
 /** @internal */
 export const fromOption: <
   Arg extends Option.Option<unknown> | LazyArg<unknown>,
-  Rest extends [] | [onNone: LazyArg<unknown>] = []
+  Rest extends [] | [onNone: LazyArg<unknown> | undefined] = []
 >(
   arg: Arg & (Rest extends [] ? unknown : Option.Option<unknown>),
   ...rest: Rest
-) => [Arg] extends [Option.Option<infer A>]
-  ? Effect.Effect<A, Rest extends [LazyArg<infer E>] ? E : Cause.NoSuchElementError>
+) => [Arg] extends [Option.Option<infer A>] ? Effect.Effect<
+    A,
+    Rest extends [LazyArg<infer E>] ? E
+      : Rest extends [undefined] ? Cause.NoSuchElementError
+      : Rest extends [LazyArg<infer E> | undefined] ? E | Cause.NoSuchElementError
+      : Cause.NoSuchElementError
+  >
   : [Arg] extends [LazyArg<infer E>] ? <A>(option: Option.Option<A>) => Effect.Effect<A, E>
   : never = dual(
     (args) => args.length >= 2 || Option.isOption(args[0]),

--- a/packages/effect/typetest/Effect.tst.ts
+++ b/packages/effect/typetest/Effect.tst.ts
@@ -240,9 +240,9 @@ describe("Effect.fromOption", () => {
   })
 
   it("supports an inline HashMap lookup in data-first form", () => {
-    const values = HashMap.make(["key", 1] as const)
+    const values = HashMap.make(["key", 1])
     const result = Effect.fromOption(HashMap.get(values, "key"), () => new SimpleError({ code: 1 }))
-    expect(result).type.toBeAssignableTo<Effect.Effect<number, SimpleError>>()
+    expect(result).type.toBe<Effect.Effect<number, SimpleError>>()
   })
 
   it("supports a custom error in data-last form", () => {
@@ -251,6 +251,26 @@ describe("Effect.fromOption", () => {
       Effect.fromOption(() => new SimpleError({ code: 1 }))
     )
     expect(result).type.toBe<Effect.Effect<string, SimpleError>>()
+  })
+
+  it("supports an inline HashMap lookup in data-last form", () => {
+    const values = HashMap.make(["key", 1])
+    const result = pipe(
+      HashMap.get(values, "key"),
+      Effect.fromOption(() => new SimpleError({ code: 1 }))
+    )
+    expect(result).type.toBe<Effect.Effect<number, SimpleError>>()
+  })
+
+  it("uses NoSuchElementError for an explicitly undefined onNone", () => {
+    const result = Effect.fromOption(optionString, undefined)
+    expect(result).type.toBe<Effect.Effect<string, Cause.NoSuchElementError>>()
+  })
+
+  it("includes NoSuchElementError for an optional onNone", () => {
+    const forward = <A, E>(option: Option.Option<A>, onNone?: () => E) => Effect.fromOption(option, onNone)
+    const result = forward(optionString, () => new SimpleError({ code: 1 }))
+    expect(result).type.toBe<Effect.Effect<string, SimpleError | Cause.NoSuchElementError>>()
   })
 
   it("rejects an error callback as the data-first value", () => {

--- a/packages/effect/typetest/Effect.tst.ts
+++ b/packages/effect/typetest/Effect.tst.ts
@@ -7,6 +7,7 @@ import {
   Effect,
   type ExecutionPlan,
   Fiber,
+  HashMap,
   type Layer,
   type Option,
   pipe,
@@ -238,12 +239,23 @@ describe("Effect.fromOption", () => {
     expect(result).type.toBe<Effect.Effect<string, SimpleError>>()
   })
 
+  it("supports an inline HashMap lookup in data-first form", () => {
+    const values = HashMap.make(["key", 1] as const)
+    const result = Effect.fromOption(HashMap.get(values, "key"), () => new SimpleError({ code: 1 }))
+    expect(result).type.toBeAssignableTo<Effect.Effect<number, SimpleError>>()
+  })
+
   it("supports a custom error in data-last form", () => {
     const result = pipe(
       optionString,
       Effect.fromOption(() => new SimpleError({ code: 1 }))
     )
     expect(result).type.toBe<Effect.Effect<string, SimpleError>>()
+  })
+
+  it("rejects an error callback as the data-first value", () => {
+    // @ts-expect-error is not assignable to parameter
+    Effect.fromOption(() => new SimpleError({ code: 1 }), () => new OtherError({ message: "missing" }))
   })
 
   it("supports callback usage with the default error", () => {


### PR DESCRIPTION
## Summary

- infer the optional `onNone` callback independently from the `Option` argument
- preserve data-last usage, default `NoSuchElementError` inference, and callback compatibility
- add regression coverage for inline `HashMap.get` expressions and invalid two-callback usage
- add a patch changeset

## Root cause

The conditional rest parameter depended on the same generic inferred from the first argument. For inline generic expressions such as `HashMap.get(...)`, inference widened that generic toward the data-last callback branch, collapsing the rest tuple to zero arguments.

## Validation

- `pnpm check`
- `pnpm --filter effect check`
- `pnpm test-types Effect.tst.ts`
- `pnpm test packages/effect/test/Effect.test.ts --run`
- `pnpm lint`

Closes EFF-655
Closes #7232