### PR TITLE
Respect zero Node socket open timeouts

### DIFF
--- a/.changeset/zero-node-socket-timeout.md
+++ b/.changeset/zero-node-socket-timeout.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+Respect zero-duration open timeouts when opening Node sockets.

--- a/packages/platform/node-shared/src/NodeSocket.ts
+++ b/packages/platform/node-shared/src/NodeSocket.ts
@@ -135,7 +135,7 @@ export const fromDuplex = <RO>(
           })
         )
         conn = yield* Scope.provide(open, scope).pipe(
-          options?.openTimeout ?
+          options?.openTimeout !== undefined ?
             Effect.timeoutOrElse({
               duration: options.openTimeout,
               orElse: () =>

--- a/packages/platform/node/test/NodeSocket.test.ts
+++ b/packages/platform/node/test/NodeSocket.test.ts
@@ -79,6 +79,19 @@ describe("Socket", () => {
       assert.strictEqual(output, "HelloWorld")
     }))
 
+  it.live("respects a zero open timeout", () =>
+    Effect.gen(function*() {
+      const socket = yield* NodeSocket.fromDuplex(Effect.never, { openTimeout: 0 })
+      const error = yield* socket.runRaw(() => {}).pipe(
+        Effect.flip,
+        Effect.timeout("1 second")
+      )
+      assert.strictEqual(error.reason._tag, "SocketOpenError")
+      if (error.reason._tag === "SocketOpenError") {
+        assert.strictEqual(error.reason.kind, "Timeout")
+      }
+    }))
+
   describe("WebSocket", () => {
     const url = `ws://localhost:1234`
 


### PR DESCRIPTION
## What

`NodeSocket.fromDuplex` ignored `openTimeout: 0`, so an acquisition that never completed remained suspended instead of immediately failing with a socket open timeout.

## Fix

Treat the timeout as configured whenever it is not `undefined`. This preserves zero-duration inputs and matches the handling used by the sibling Deno socket implementation.

## Tests

- Added a regression test proving a zero open timeout produces a `SocketOpenError` with the `Timeout` kind.
- `pnpm lint-fix`
- `pnpm test --run packages/platform/node/test/NodeSocket.test.ts`
- `pnpm check`