### PR TITLE
Normalize unbounded PubSub replay capacities

### DIFF
--- a/.changeset/normalize-unbounded-pubsub-replay.md
+++ b/.changeset/normalize-unbounded-pubsub-replay.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Normalize unbounded PubSub replay capacities to positive integers.

--- a/packages/effect/src/PubSub.ts
+++ b/packages/effect/src/PubSub.ts
@@ -540,7 +540,10 @@ export const makeAtomicBounded = <A>(
  */
 export const makeAtomicUnbounded = <A>(options?: {
   readonly replay?: number | undefined
-}): PubSub.Atomic<A> => new UnboundedPubSub(options?.replay ? new ReplayBuffer(options.replay) : undefined)
+}): PubSub.Atomic<A> =>
+  new UnboundedPubSub(
+    options?.replay && options.replay > 0 ? new ReplayBuffer(Math.ceil(options.replay)) : undefined
+  )
 
 /**
  *  Returns the number of elements the queue can hold.

--- a/packages/effect/src/PubSub.ts
+++ b/packages/effect/src/PubSub.ts
@@ -540,10 +540,12 @@ export const makeAtomicBounded = <A>(
  */
 export const makeAtomicUnbounded = <A>(options?: {
   readonly replay?: number | undefined
-}): PubSub.Atomic<A> =>
-  new UnboundedPubSub(
-    options?.replay && options.replay > 0 ? new ReplayBuffer(Math.ceil(options.replay)) : undefined
+}): PubSub.Atomic<A> => {
+  const replay = options?.replay
+  return new UnboundedPubSub(
+    replay && replay > 0 ? new ReplayBuffer<A>(Math.ceil(replay)) : undefined
   )
+}
 
 /**
  *  Returns the number of elements the queue can hold.

--- a/packages/effect/test/PubSub.test.ts
+++ b/packages/effect/test/PubSub.test.ts
@@ -450,6 +450,22 @@ describe("PubSub", () => {
         assert.deepStrictEqual(yield* PubSub.takeAll(sub), [3, 4, 5])
       }))
 
+    it.effect("unbounded rounds up fractional replay", () =>
+      Effect.gen(function*() {
+        const pubsub = yield* PubSub.unbounded<number>({ replay: 1.5 })
+        yield* PubSub.publishAll(pubsub, [1, 2, 3, 4])
+        const sub = yield* PubSub.subscribe(pubsub)
+        assert.deepStrictEqual(yield* PubSub.takeAll(sub), [3, 4])
+      }))
+
+    it.effect("unbounded disables non-positive replay", () =>
+      Effect.gen(function*() {
+        const pubsub = yield* PubSub.unbounded<number>({ replay: -1 })
+        yield* PubSub.publishAll(pubsub, [1, 2])
+        const sub = yield* PubSub.subscribe(pubsub)
+        assert.deepStrictEqual(yield* PubSub.takeUpTo(sub, 2), [])
+      }))
+
     it.effect("unbounded takeUpTo", () => {
       const messages = [1, 2, 3, 4, 5]
       return PubSub.unbounded<number>({ replay: 3 }).pipe(


### PR DESCRIPTION
## What

Unbounded PubSubs passed replay values directly to `ReplayBuffer`. Fractional capacities could never equal the buffer's integer size, so eviction never ran and late subscribers received the full publication history. Negative replay values also enabled an effectively unbounded replay buffer.

## Fix

Normalize unbounded replay settings the same way as bounded PubSubs: only positive values enable replay, and fractional capacities are rounded up.

## Tests

- Added coverage for fractional replay capacity rounding.
- Added coverage for disabling non-positive replay values.
- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/PubSub.test.ts`
- `pnpm check`