### PR TITLE
Restore Effect.head

### DIFF
--- a/.changeset/restore-effect-head.md
+++ b/.changeset/restore-effect-head.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Restore `Effect.head` for retrieving the first element of an iterable produced by an effect.
+Add `Effect.head` for retrieving the first element of an iterable produced by an effect.

--- a/.changeset/restore-effect-head.md
+++ b/.changeset/restore-effect-head.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Restore `Effect.head` for retrieving the first element of an iterable produced by an effect.

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -789,6 +789,34 @@ export const forEach: {
 } = internal.forEach
 
 /**
+ * Returns the first element of the iterable produced by an effect, or fails
+ * with `NoSuchElementError` if the iterable is empty.
+ *
+ * **When to use**
+ *
+ * Use when an effect produces a collection that must contain at least one
+ * element and absence should be represented in the typed error channel.
+ *
+ * **Example** (Getting the first element)
+ *
+ * ```ts import.meta.vitest
+ * import { Effect, Option } from "effect"
+ *
+ * const first = await Effect.runPromise(Effect.head(Effect.succeed([1, 2, 3])))
+ * first // => 1
+ *
+ * const empty = Effect.head(Effect.succeed([] as Array<number>)).pipe(Effect.catchNoSuchElement)
+ * await Effect.runPromise(empty) // => Option.none()
+ * ```
+ *
+ * @category getters
+ * @since 2.0.0
+ */
+export const head: <A, E, R>(
+  self: Effect<Iterable<A>, E, R>
+) => Effect<A, E | Cause.NoSuchElementError, R> = internal.head
+
+/**
  * Executes a body effect repeatedly while a condition holds true.
  *
  * **Example** (Repeating an effectful loop)

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -4658,6 +4658,15 @@ export const forEach: {
     return eff ? as(eff, out as any) : succeed(out as any)
   }))
 
+/** @internal */
+export const head = <A, E, R>(
+  self: Effect.Effect<Iterable<A>, E, R>
+): Effect.Effect<A, E | Cause.NoSuchElementError, R> =>
+  flatMap(self, (elements) => {
+    const result = elements[Symbol.iterator]().next()
+    return result.done ? fail(new NoSuchElementError()) : succeed(result.value)
+  })
+
 const forEachSequential = <A, B, E, R>(
   iterable: Iterable<A>,
   f: (a: A, index: number) => Effect.Effect<B, E, R>,

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -613,6 +613,27 @@ describe("Effect", () => {
       }))
   })
 
+  describe("head", () => {
+    it.effect("returns the first element", () =>
+      Effect.gen(function*() {
+        const result = yield* Effect.head(Effect.succeed([1, 2, 3]))
+        assert.strictEqual(result, 1)
+      }))
+
+    it.effect("fails with NoSuchElementError for an empty iterable", () =>
+      Effect.gen(function*() {
+        const error = yield* Effect.head(Effect.succeed([] as Array<number>)).pipe(Effect.flip)
+        assert.isTrue(Cause.isNoSuchElementError(error))
+      }))
+
+    it.effect("preserves the source failure", () =>
+      Effect.gen(function*() {
+        const source: Effect.Effect<Iterable<number>, "failure"> = Effect.fail("failure")
+        const error = yield* Effect.head(source).pipe(Effect.flip)
+        assert.strictEqual(error, "failure")
+      }))
+  })
+
   describe("all", () => {
     it.effect("tuple", () =>
       Effect.gen(function*() {

--- a/packages/effect/typetest/Effect.tst.ts
+++ b/packages/effect/typetest/Effect.tst.ts
@@ -72,6 +72,7 @@ declare const fiberStringOrNumber: Fiber.Fiber<string, "err-1"> | Fiber.Fiber<nu
 declare const stringArray: Array<Effect.Effect<string, "err-3", "dep-3">>
 declare const numberRecord: Record<string, Effect.Effect<number, "err-4", "dep-4">>
 declare const optionalEffect: Option.Option<Effect.Effect<string, "err-1", "dep-1">>
+declare const iterableString: Effect.Effect<Iterable<string>, "err-1", "dep-1">
 
 class AcquireReleaseDependency extends Context.Service<AcquireReleaseDependency, string>()(
   "AcquireReleaseDependency"
@@ -292,6 +293,13 @@ describe("Effect.firstSuccessOf", () => {
     ])
 
     expect(result).type.toBe<Effect.Effect<string | number, "err-1" | "err-2", "dep-1" | "dep-2">>()
+  })
+})
+
+describe("Effect.head", () => {
+  it("infers the element and preserves the source error and requirements", () => {
+    const result = Effect.head(iterableString)
+    expect(result).type.toBe<Effect.Effect<string, "err-1" | Cause.NoSuchElementError, "dep-1">>()
   })
 })
 


### PR DESCRIPTION
## Summary

- restore `Effect.head` with v3-compatible first-element and empty-iterable behavior
- preserve the source error and service types while adding `Cause.NoSuchElementError` for empty iterables
- add focused runtime/type tests, API documentation, and a patch changeset

## Validation

- `pnpm --filter effect test --run test/Effect.test.ts -t head`
- `pnpm test-types Effect.tst.ts`
- `pnpm doctest --run packages/effect/src/Effect.ts`
- `pnpm lint-fix`
- `pnpm check`

Closes EFF-656