### PR TITLE
Update Effect.head migration guidance

### DIFF
--- a/migration/annotations/effect__Effect.yaml
+++ b/migration/annotations/effect__Effect.yaml
@@ -239,8 +239,8 @@ effect/Effect#getRuntimeFlags:
   replacement: "none"
   note: "RuntimeFlags are no longer a public Effect service; use supported high-level runtime options. No direct public replacement exists in v4; rewrite the call site around the stated v4 primitive."
 effect/Effect#head:
-  replacement: "Effect.flatMap + Array.head + Effect.fromOption"
-  note: "Inspect the produced iterable explicitly and fail when it is empty. Adapt arguments and imports to the v4 API."
+  replacement: "Effect.head"
+  note: "Still exported in v4 with the same signature; the empty-iterable failure is now Cause.NoSuchElementError instead of Cause.NoSuchElementException."
 effect/Effect#if:
   replacement: "Effect.suspend"
   note: "Select the branch lazily with a JavaScript conditional inside `Effect.suspend`. Adapt arguments and imports to the v4 API."

--- a/migration/v3-to-v4.md
+++ b/migration/v3-to-v4.md
@@ -5860,6 +5860,8 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `EventLogRemote.Hello` -> `effect/unstable/eventlog/EventLogMessage#HelloResponse`: HelloResponse replaces Hello and includes the v4 authentication challenge; HelloRpc defines the endpoint.
 
+- `EventLogRemote.Ping`: TODO: needs guidance
+
 - `EventLogRemote.Pong` -> `none`: The event-log Pong model was removed; heartbeats belong to the generic RPC socket protocol.
 
 - `EventLogRemote.ProtocolRequest` -> `effect/unstable/eventlog/EventLogMessage#EventLogRemoteRpcs`: EventLogRemoteRpcs and generic RPC serialization replace the old protocol request union.
@@ -8466,6 +8468,8 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `Workflow.CaptureDefects` -> `effect/unstable/workflow/Workflow#CaptureDefects`: Moved into core Effect and changed from a Context.Tag subclass to a Context.Reference value with the same true default.
 
+- `Workflow.Complete`: TODO: needs guidance
+
 - `Workflow.Execution` -> `effect/unstable/workflow/Workflow#Execution`: Moved into core Effect; its workflow discriminator changed from name to \_tag.
 
 - `Workflow.Requirements` -> `Workflow.RequirementsClient / Workflow.RequirementsHandler`: The schema Context union split by direction: client payload encoding and result decoding versus handler payload decoding and result encoding.
@@ -9702,7 +9706,7 @@ Schema.toArbitrary(schema)
 
 - `Effect.getRuntimeFlags` -> `none`: RuntimeFlags are no longer a public Effect service; use supported high-level runtime options. No direct public replacement exists in v4; rewrite the call site around the stated v4 primitive.
 
-- `Effect.head` -> `Effect.flatMap + Array.head + Effect.fromOption`: Inspect the produced iterable explicitly and fail when it is empty. Adapt arguments and imports to the v4 API.
+- `Effect.head` -> `Effect.head`: Still exported in v4 with the same signature; the empty-iterable failure is now Cause.NoSuchElementError instead of Cause.NoSuchElementException.
 
 - `Effect.if` -> `Effect.suspend`: Select the branch lazily with a JavaScript conditional inside `Effect.suspend`. Adapt arguments and imports to the v4 API.
 

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -620,6 +620,16 @@ describe("Effect", () => {
         assert.strictEqual(result, 1)
       }))
 
+    it.effect("reads only the first element of a lazy iterable", () =>
+      Effect.gen(function*() {
+        function* naturals() {
+          let n = 0
+          while (true) yield n++
+        }
+        const result = yield* Effect.head(Effect.succeed(naturals()))
+        assert.strictEqual(result, 0)
+      }))
+
     it.effect("fails with NoSuchElementError for an empty iterable", () =>
       Effect.gen(function*() {
         const error = yield* Effect.head(Effect.succeed([] as Array<number>)).pipe(Effect.flip)


### PR DESCRIPTION
## Summary

- update the v3-to-v4 annotation to identify `Effect.head` as retained, with the v4 `Cause.NoSuchElementError` rename
- regenerate `migration/v3-to-v4.md` from the annotations
- add a lazy infinite-iterable regression test proving `Effect.head` reads only the first element

## Context

Follow-up to #7246, which merged while these requested review changes were in progress.

The generator also surfaced existing TODO entries for `EventLogRemote.Ping` and `Workflow.Complete`; they are retained as generated output.

## Validation

- `pnpm --filter effect test --run test/Effect.test.ts -t head`
- `pnpm lint-fix`
- `pnpm check`
- `pnpm api-diff --write-doc migration/v3-to-v4.md` (using the migration document's pinned base/head revisions in this dedicated checkout)

Closes EFF-656