### PR TITLE
Add @effect/atom-livestore, LiveStore bindings for Atom

### DIFF
--- a/.changeset/atom-livestore-package.md
+++ b/.changeset/atom-livestore-package.md
@@ -1,0 +1,7 @@
+---
+"@effect/atom-livestore": patch
+---
+
+Add `@effect/atom-livestore`, porting the LiveStore bindings from `@effect-atom/atom-livestore` to Effect v4.
+
+`AtomLivestore.Tag` creates a `Context.Service` class for a LiveStore `Store` backed by an atom runtime, exposing atoms for accessing the store (`store`, `storeUnsafe`), reactive query helpers (`makeQuery`, `makeQueryUnsafe`), and a writable atom for committing events (`commit`).

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -19,6 +19,7 @@
       "@effect/ai-openai",
       "@effect/ai-openai-compat",
       "@effect/ai-openrouter",
+      "@effect/atom-livestore",
       "@effect/atom-react",
       "@effect/atom-solid",
       "@effect/atom-vue",

--- a/packages/atom/livestore/LICENSE
+++ b/packages/atom/livestore/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-present The Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/atom/livestore/README.md
+++ b/packages/atom/livestore/README.md
@@ -1,0 +1,14 @@
+# @effect/atom-livestore
+
+[LiveStore](https://livestore.dev) bindings for Atom, the reactive state management modules for Effect. Create a LiveStore-backed service with atoms for accessing the store, reactive query atoms, and committing events.
+
+## Installation
+
+```sh
+npm install effect@rc @effect/atom-livestore@rc
+```
+
+## Documentation
+
+- [Effect website](https://effect.website)
+- [API reference](https://effect.website/docs/v4/api/atom-livestore)

--- a/packages/atom/livestore/package.json
+++ b/packages/atom/livestore/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@effect/atom-livestore",
+  "version": "4.0.0-rc.109",
+  "type": "module",
+  "license": "MIT",
+  "description": "LiveStore bindings for the Effect Atom modules",
+  "homepage": "https://effect.website",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Effect-TS/effect.git",
+    "directory": "packages/atom/livestore"
+  },
+  "bugs": {
+    "url": "https://github.com/Effect-TS/effect/issues"
+  },
+  "tags": [
+    "typescript",
+    "livestore",
+    "database"
+  ],
+  "keywords": [
+    "typescript",
+    "livestore",
+    "database"
+  ],
+  "sideEffects": [],
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts",
+    "./internal/*": null,
+    "./index": null,
+    "./*/index": null
+  },
+  "files": [
+    "src/**/*.ts",
+    "dist/**/*.js",
+    "dist/**/*.js.map",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.ts.map",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "ai-docs/**/*"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "exports": {
+      "./package.json": "./package.json",
+      ".": "./dist/index.js",
+      "./*": "./dist/*.js",
+      "./internal/*": null,
+      "./index": null,
+      "./*/index": null
+    }
+  },
+  "scripts": {
+    "build": "tsc -b tsconfig.json && pnpm babel",
+    "babel": "babel dist --plugins annotate-pure-calls --out-dir dist --source-maps",
+    "check": "tsc -b tsconfig.json"
+  },
+  "peerDependencies": {
+    "@livestore/livestore": "*",
+    "effect": "workspace:^"
+  },
+  "devDependencies": {
+    "@effect/opentelemetry": "workspace:^",
+    "@livestore/livestore": "0.0.0-snapshot-31e8d71134c5f4d89c21f6b1e3b6b5b39eeacd4e",
+    "@opentelemetry/api": "^1.9.0",
+    "effect": "workspace:^"
+  }
+}

--- a/packages/atom/livestore/src/AtomLivestore.ts
+++ b/packages/atom/livestore/src/AtomLivestore.ts
@@ -1,0 +1,203 @@
+/**
+ * Connects [LiveStore](https://livestore.dev) stores to atoms.
+ *
+ * `Tag` creates a `Context.Service` class for a LiveStore `Store`, backed by
+ * an atom runtime. The service exposes atoms for accessing the store, helpers
+ * for creating reactive query atoms that update whenever the underlying data
+ * changes, and a writable atom for committing events to the store.
+ *
+ * @since 4.0.0
+ */
+import type {
+  CreateStoreOptions,
+  LiveStoreEvent,
+  LiveStoreSchema,
+  OtelOptions,
+  Queryable,
+  Store
+} from "@livestore/livestore"
+import { createStore, provideOtel } from "@livestore/livestore"
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import { constUndefined } from "effect/Function"
+import * as Layer from "effect/Layer"
+import type { Mutable } from "effect/Types"
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
+import * as Atom from "effect/unstable/reactivity/Atom"
+
+/**
+ * A `Context.Service` for a LiveStore `Store` integrated with atom
+ * reactivity.
+ *
+ * **Details**
+ *
+ * It exposes the atom runtime used to create the store, atoms for accessing
+ * the store as an `AsyncResult` or unsafely as a plain value, query helpers
+ * that return reactive atoms, and a writable atom for committing events.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface AtomLiveStore<Self, Id extends string, S extends LiveStoreSchema, TContext = {}>
+  extends Context.Service<Self, Store<S, TContext>>
+{
+  new(_: never): Context.ServiceClass.Shape<Id, Store<S, TContext>>
+
+  /**
+   * The atom `Layer` that creates the store.
+   */
+  readonly layer: Atom.Atom<Layer.Layer<Self>>
+
+  /**
+   * The `AtomRuntime` that builds the store `Layer`. It can be used to create
+   * atoms that have access to the store service.
+   */
+  readonly runtime: Atom.AtomRuntime<Self>
+
+  /**
+   * An atom that allows you to access the `Store`. It will emit an
+   * `AsyncResult` that contains the store, or an error if it could not be
+   * created.
+   */
+  readonly store: Atom.Atom<AsyncResult.AsyncResult<Store<S, TContext>>>
+
+  /**
+   * An atom that allows you to access the `Store`. It will emit the store, or
+   * `undefined` if it has not been created yet.
+   */
+  readonly storeUnsafe: Atom.Atom<Store<S, TContext> | undefined>
+
+  /**
+   * Creates an atom that resolves a query. It embeds the loading of the store
+   * and will emit an `AsyncResult` containing the query result, updating
+   * whenever the underlying data changes.
+   */
+  readonly makeQuery: <A>(
+    query: Queryable<A> | ((get: Atom.AtomContext) => Queryable<A>)
+  ) => Atom.Atom<AsyncResult.AsyncResult<A>>
+
+  /**
+   * Creates an atom that resolves a query, updating whenever the underlying
+   * data changes. If the store has not been created yet, it will emit
+   * `undefined`.
+   */
+  readonly makeQueryUnsafe: <A>(
+    query: Queryable<A> | ((get: Atom.AtomContext) => Queryable<A>)
+  ) => Atom.Atom<A | undefined>
+
+  /**
+   * An `Atom.Writable` that allows you to commit an event to the store.
+   *
+   * If the store has not been created yet, the event is discarded.
+   */
+  readonly commit: Atom.Writable<void, LiveStoreEvent.Input.ForSchema<S>>
+}
+
+/**
+ * Options for creating an `AtomLiveStore` service, extending LiveStore's
+ * `CreateStoreOptions`.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type Options<S extends LiveStoreSchema, TContext = {}> =
+  & CreateStoreOptions<S, TContext>
+  & {
+    readonly otelOptions?: Partial<OtelOptions> | undefined
+    /**
+     * The `RuntimeFactory` used to create the atom runtime for the store.
+     *
+     * Only used when `options` is not a function.
+     */
+    readonly runtime?: Atom.RuntimeFactory | undefined
+  }
+
+/**
+ * Creates a `Context.Service` class for a LiveStore `Store` backed by an atom
+ * runtime.
+ *
+ * **Example**
+ *
+ * ```ts
+ * import { AtomLivestore } from "@effect/atom-livestore"
+ * import { makeInMemoryAdapter } from "@livestore/adapter-web"
+ * import { schema } from "./schema.ts"
+ *
+ * class StoreTag extends AtomLivestore.Tag<StoreTag>()("StoreTag", {
+ *   schema,
+ *   storeId: "default",
+ *   adapter: makeInMemoryAdapter()
+ * }) {}
+ * ```
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const Tag = <Self>() =>
+<const Id extends string, S extends LiveStoreSchema, TContext = {}>(
+  id: Id,
+  options: Options<S, TContext> | ((get: Atom.AtomContext) => Options<S, TContext>)
+): AtomLiveStore<Self, Id, S, TContext> => {
+  const self: Mutable<AtomLiveStore<Self, Id, S, TContext>> = Context.Service<Self, Store<S, TContext>>()(id) as any
+
+  const layerFromOptions = (opts: Options<S, TContext>) => {
+    const otelOptions: Parameters<typeof provideOtel>[0] = {}
+    if (opts.otelOptions?.tracer !== undefined) {
+      otelOptions.otelTracer = opts.otelOptions.tracer
+    }
+    if (opts.otelOptions?.rootSpanContext !== undefined) {
+      otelOptions.parentSpanContext = opts.otelOptions.rootSpanContext
+    }
+    return Layer.effect(
+      self,
+      createStore(opts).pipe(
+        provideOtel(otelOptions),
+        Effect.orDie
+      )
+    )
+  }
+
+  const runtimeFactory = (typeof options === "function" ? undefined : options.runtime) ?? Atom.runtime
+  self.runtime = runtimeFactory(
+    typeof options === "function" ? (get) => layerFromOptions(options(get)) : layerFromOptions(options)
+  )
+  self.layer = self.runtime.layer as Atom.Atom<Layer.Layer<Self>>
+  self.store = self.runtime.atom(self.use(Effect.succeed))
+  self.storeUnsafe = Atom.readable((get) => {
+    const result = get(self.store)
+    return AsyncResult.getOrElse(result, constUndefined)
+  })
+  self.makeQuery = <A>(query: Queryable<A> | ((get: Atom.AtomContext) => Queryable<A>)) =>
+    Atom.readable((get) => {
+      const result = get(self.store)
+      return AsyncResult.map(result, (store) => {
+        const q = typeof query === "function" ? query(get) : query
+        get.addFinalizer(
+          store.subscribe(q, (value) => {
+            get.setSelf(AsyncResult.success(value))
+          })
+        )
+        return store.query(q)
+      })
+    })
+  self.makeQueryUnsafe = <A>(query: Queryable<A> | ((get: Atom.AtomContext) => Queryable<A>)) =>
+    Atom.readable((get) => {
+      const store = get(self.storeUnsafe)
+      if (store === undefined) {
+        return undefined
+      }
+      const q = typeof query === "function" ? query(get) : query
+      get.addFinalizer(
+        store.subscribe(q, (value) => {
+          get.setSelf(value)
+        })
+      )
+      return store.query(q)
+    })
+  self.commit = Atom.writable((get) => {
+    get(self.storeUnsafe)
+  }, (ctx, value: LiveStoreEvent.Input.ForSchema<S>) => {
+    ctx.get(self.storeUnsafe)?.commit(value)
+  })
+  return self as AtomLiveStore<Self, Id, S, TContext>
+}

--- a/packages/atom/livestore/src/index.ts
+++ b/packages/atom/livestore/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @since 4.0.0
+ */
+
+/**
+ * @since 4.0.0
+ */
+export * as AtomLivestore from "./AtomLivestore.ts"

--- a/packages/atom/livestore/tsconfig.json
+++ b/packages/atom/livestore/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src"],
+  "references": [
+    { "path": "../../effect" },
+    { "path": "../../opentelemetry" }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,12 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@changesets/get-github-info@1.0.0-next.4':
-    hash: a5b1907668397f36aab989954aa78993792f578b83e41a164ab7ecd573ac9166
-    path: patches/@changesets__get-github-info@1.0.0-next.4.patch
-  '@changesets/read@1.0.0-next.10':
-    hash: 00298a7e3295e97aab2f89a36af496eef21b576642bd2eac88ae13ceca78cccb
-    path: patches/@changesets__read@1.0.0-next.10.patch
+  '@changesets/get-github-info@1.0.0-next.4': a5b1907668397f36aab989954aa78993792f578b83e41a164ab7ecd573ac9166
+  '@changesets/read@1.0.0-next.10': 00298a7e3295e97aab2f89a36af496eef21b576642bd2eac88ae13ceca78cccb
 
 importers:
 
@@ -108,13 +104,13 @@ importers:
         version: 20.11.1
       jscodeshift:
         specifier: ^17.4.0
-        version: 17.4.0
+        version: 17.4.0(supports-color@10.2.2)
       lalph:
         specifier: ^0.3.139
         version: 0.3.139
       madge:
         specifier: ^8.0.0
-        version: 8.0.0(typescript@7.0.2)
+        version: 8.0.0(supports-color@10.2.2)(typescript@7.0.2)
       oxlint:
         specifier: ^1.76.0
         version: 1.76.0
@@ -132,7 +128,7 @@ importers:
         version: 4.22.2(core-js@3.47.0)(rolldown@1.1.5)(rollup@4.62.3)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       rollup-plugin-esbuild:
         specifier: ^6.2.1
-        version: 6.2.1(esbuild@0.28.1)(rollup@4.62.3)
+        version: 6.2.1(esbuild@0.28.1)(rollup@4.62.3)(supports-color@10.2.2)
       rollup-plugin-visualizer:
         specifier: ^7.0.1
         version: 7.0.1(rolldown@1.1.5)(rollup@4.62.3)
@@ -260,6 +256,21 @@ importers:
 
   packages/ai/openrouter:
     devDependencies:
+      effect:
+        specifier: workspace:^
+        version: link:../../effect
+
+  packages/atom/livestore:
+    devDependencies:
+      '@effect/opentelemetry':
+        specifier: workspace:^
+        version: link:../../opentelemetry
+      '@livestore/livestore':
+        specifier: 0.0.0-snapshot-31e8d71134c5f4d89c21f6b1e3b6b5b39eeacd4e
+        version: 0.0.0-snapshot-31e8d71134c5f4d89c21f6b1e3b6b5b39eeacd4e(@effect/opentelemetry@packages+opentelemetry)(@effect/platform-browser@4.0.0-rc.108(effect@packages+effect))(@effect/platform-bun@4.0.0-rc.109(effect@packages+effect))(@effect/platform-node-shared@4.0.0-rc.109(effect@packages+effect))(@effect/platform-node@4.0.0-rc.109(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1)))(@effect/vitest@packages+vitest)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.9.0(@opentelemetry/api@1.9.1))(@standard-schema/spec@1.1.0)(effect@packages+effect)
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
       effect:
         specifier: workspace:^
         version: link:../../effect
@@ -467,7 +478,7 @@ importers:
         version: '@jsr/std__assert@1.0.19'
       '@testcontainers/redis':
         specifier: ^12.0.4
-        version: 12.0.4
+        version: 12.0.4(supports-color@10.2.2)
       '@types/deno':
         specifier: ^2.7.0
         version: 2.7.0
@@ -489,13 +500,13 @@ importers:
     devDependencies:
       '@testcontainers/mysql':
         specifier: ^12.0.4
-        version: 12.0.4
+        version: 12.0.4(supports-color@10.2.2)
       '@testcontainers/postgresql':
         specifier: ^12.0.4
-        version: 12.0.4
+        version: 12.0.4(supports-color@10.2.2)
       '@testcontainers/redis':
         specifier: ^12.0.4
-        version: 12.0.4
+        version: 12.0.4(supports-color@10.2.2)
       '@types/node':
         specifier: ^26.1.2
         version: 26.1.2
@@ -562,17 +573,17 @@ importers:
         version: link:../../effect
       testcontainers:
         specifier: ^12.0.4
-        version: 12.0.4
+        version: 12.0.4(supports-color@10.2.2)
 
   packages/sql/mssql:
     dependencies:
       tedious:
         specifier: ^19.2.1
-        version: 19.2.1(@azure/core-client@1.10.1)
+        version: 19.2.1(@azure/core-client@1.10.1(supports-color@10.2.2))(supports-color@10.2.2)
     devDependencies:
       '@testcontainers/mssqlserver':
         specifier: ^12.0.4
-        version: 12.0.4
+        version: 12.0.4(supports-color@10.2.2)
       effect:
         specifier: workspace:^
         version: link:../../effect
@@ -585,7 +596,7 @@ importers:
     devDependencies:
       '@testcontainers/mysql':
         specifier: ^12.0.4
-        version: 12.0.4
+        version: 12.0.4(supports-color@10.2.2)
       effect:
         specifier: workspace:^
         version: link:../../effect
@@ -610,7 +621,7 @@ importers:
     devDependencies:
       '@testcontainers/postgresql':
         specifier: ^12.0.4
-        version: 12.0.4
+        version: 12.0.4(supports-color@10.2.2)
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
@@ -668,7 +679,7 @@ importers:
     devDependencies:
       '@op-engineering/op-sqlite':
         specifier: ^17.1.2
-        version: 17.1.2(react-native@0.83.0(@babel/core@8.0.1)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
+        version: 17.1.2(react-native@0.83.0(@babel/core@8.0.1)(@types/react@19.2.17)(react@19.2.7)(supports-color@10.2.2))(react@19.2.7)
       effect:
         specifier: workspace:^
         version: link:../../effect
@@ -776,7 +787,7 @@ importers:
         version: 4.62.3
       rollup-plugin-esbuild:
         specifier: ^6.2.1
-        version: 6.2.1(esbuild@0.28.1)(rollup@4.62.3)
+        version: 6.2.1(esbuild@0.28.1)(rollup@4.62.3)(supports-color@10.2.2)
       rollup-plugin-visualizer:
         specifier: ^7.0.1
         version: 7.0.1(rolldown@1.1.5)(rollup@4.62.3)
@@ -1729,46 +1740,55 @@ packages:
     resolution: {integrity: sha512-2h5oe4tHGXJOTLU5BxVJLGPP1qQQxxECdjUaRkLxGn2rZIEf/7HwoJ+TjwMUaIVg4QxAFxfiMJJ3MRZjumJpsg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@dprint/linux-arm64-musl@0.55.2':
     resolution: {integrity: sha512-Z1X9mNLHWoSI7CHz888H2w27IV2UQ5lL/YbTwgguJM9ApLgvkMer5qr4pLlXF6vEY3+Rm0445eo3uojbjE7PTw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@dprint/linux-loong64-glibc@0.55.2':
     resolution: {integrity: sha512-qxk4Cg/SjO14DALoG1MFZL+n6pEvCyd7VDHg1cQIpp82mZ+wtRaWkJqSaItWj12x8jihA32wAoQ/8OHz+5FFsQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@dprint/linux-loong64-musl@0.55.2':
     resolution: {integrity: sha512-Mr+kRdZnxhUHBmhhADkYOo1g81PYvbh7eBo+lpMStgIvL/5Z93mGAcp/1NFcpeN02pilaI1N59awV08ApJ19cA==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@dprint/linux-ppc64-glibc@0.55.2':
     resolution: {integrity: sha512-C8XEL3f3yg+MWZD4qlot+ibJ0GDPvCT5jq9ErwPdKteyIPpe6IPSqiEApYSQ194Q7audL8rgS0WdJsW4HNVhmw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@dprint/linux-ppc64-musl@0.55.2':
     resolution: {integrity: sha512-tSGe4bTmL5/EhNH38baCKWBGxOXVB0M5Loxnpls7wsQjuLpzWnzDCw4wiO3C7PrKLbAe4sJUWhbgdDXa3TJ2eQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@dprint/linux-riscv64-glibc@0.55.2':
     resolution: {integrity: sha512-gSaoq9e3vGTfYm5jcEd86YysFsp8OJF/CGZgBzNNu3NSjLEs8VVgTObDxQI+U7ex2mA17lbpWyr3diejaaK+bg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@dprint/linux-x64-glibc@0.55.2':
     resolution: {integrity: sha512-GBLWjuqTT5OGbqh2gQENQihhfRn/AjdDu2SVwjmbZcOFR80HMppIfFrIIolBB3FLyrZk+M8rMk8EAo0tQ3PAXw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@dprint/linux-x64-musl@0.55.2':
     resolution: {integrity: sha512-GZEUpmtxCOiauRtqOqT/erAjy2ws8dOxx7oQJFf9g5bypisuapwymvr7fUVVb8nqccFqjx7E5kN4IxKDlzntHA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@dprint/win32-arm64@0.55.2':
     resolution: {integrity: sha512-dxDdxU4a6wQ4K0omdAxW7o0mUdOI03z0/Ah3N6O9Ja7wAMQI5sbfzq7DOJ739UVXtHSB4zBTtYuk1MrBOIyVQQ==}
@@ -1792,6 +1812,29 @@ packages:
     resolution: {integrity: sha512-IRfvvwqQLabVTIw9hhIj4scOGIYPfa13QuEFv+dBWE6p47R+RR0J8jQvfDINFf0Vn80XXVjNRtZxkZpkKXLx2A==}
     engines: {node: '>=0.10.0'}
     hasBin: true
+
+  '@effect/platform-browser@4.0.0-rc.108':
+    resolution: {integrity: sha512-u/q7G0e+KHvhvgf0leDTa2GGZ+NlUtghX1FwAtHQ8vfdyCB+ln61O7meNQBASDSsMLTfQ79qoTtSics6Ccj1zA==}
+    peerDependencies:
+      effect: ^4.0.0-rc.108
+
+  '@effect/platform-bun@4.0.0-rc.109':
+    resolution: {integrity: sha512-fOOGilEBTKOYjRrOcblSiX5GdQOmR46ETTyMmkQoqYhmx+iAMKImM5YoCm10QDMWtbzerT4oeDKUJivXvOC20w==}
+    peerDependencies:
+      effect: ^4.0.0-rc.109
+
+  '@effect/platform-node-shared@4.0.0-rc.109':
+    resolution: {integrity: sha512-jhZJnf81N7Z5+Z41Qr0cKT75WzGu6M1W05xrSdu/V8PK0kSFtU5hJMBxSGDWNlgWhBwK0WRZtnMHY8HLdONg1w==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      effect: ^4.0.0-rc.109
+
+  '@effect/platform-node@4.0.0-rc.109':
+    resolution: {integrity: sha512-LE/GTh6MCZ0uzbEFH9WmxQkC9snjWuFyh8vW04AAgbKKxSHXsepHSK9RcE/2oYKr6RhrOTD0C2wC0i+J9qoe2g==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      effect: ^4.0.0-rc.109
+      redis: '>=5.0.0 <7.0.0'
 
   '@effect/tsgo-darwin-arm64@0.21.0':
     resolution: {integrity: sha512-cTh8nsNwsxyCAwKEc8euvon2zMMBBA7ZlHmPKEX5hcX1iLCbAeOg0uOQKse3uGwg2dZG1C8YTMBdGN+JQIdPrA==}
@@ -2066,89 +2109,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2347,6 +2406,62 @@ packages:
     resolution: {integrity: sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg==}
     cpu: [x64]
     os: [win32]
+
+  '@livestore/common@0.0.0-snapshot-31e8d71134c5f4d89c21f6b1e3b6b5b39eeacd4e':
+    resolution: {integrity: sha512-VsMTJTEG0Ncd/JAA+UcmYy+5117pulAZB5WLHt7gMrUi0gz7Ggj9XSmzxAz5yCj0vcyFUc/oXTOK0y73gqfhPQ==}
+    peerDependencies:
+      '@effect/opentelemetry': ^4.0.0-beta.99
+      '@effect/platform-browser': ^4.0.0-beta.99
+      '@effect/platform-bun': ^4.0.0-beta.99
+      '@effect/platform-node': ^4.0.0-beta.99
+      '@effect/platform-node-shared': ^4.0.0-beta.99
+      '@effect/vitest': ^4.0.0-beta.99
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/resources': ^2.2.0
+      '@standard-schema/spec': ^1.1.0
+      effect: ^4.0.0-beta.99
+
+  '@livestore/livestore@0.0.0-snapshot-31e8d71134c5f4d89c21f6b1e3b6b5b39eeacd4e':
+    resolution: {integrity: sha512-xANmkJQ8tP1czU07g37WJQs27NVaJ0qmj+Yy+sy2VqAd7MZn87rubUsMMxmL72XJnjdTzFN3VCcrt2SKLIlW7g==}
+    peerDependencies:
+      '@effect/opentelemetry': ^4.0.0-beta.99
+      '@effect/platform-browser': ^4.0.0-beta.99
+      '@effect/platform-bun': ^4.0.0-beta.99
+      '@effect/platform-node': ^4.0.0-beta.99
+      '@effect/platform-node-shared': ^4.0.0-beta.99
+      '@effect/vitest': ^4.0.0-beta.99
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/resources': ^2.2.0
+      '@standard-schema/spec': ^1.1.0
+      effect: ^4.0.0-beta.99
+
+  '@livestore/utils@0.0.0-snapshot-31e8d71134c5f4d89c21f6b1e3b6b5b39eeacd4e':
+    resolution: {integrity: sha512-aHyEX8Ksuy1IM2SoVdxNcw1pjGo/l2nhdC8tEBn0FvPBR5O1qSSmgj3XT12qipymXn/GT+9mFHh7svO6eOY0fg==}
+    peerDependencies:
+      '@effect/opentelemetry': ^4.0.0-beta.99
+      '@effect/platform-browser': ^4.0.0-beta.99
+      '@effect/platform-bun': ^4.0.0-beta.99
+      '@effect/platform-node': ^4.0.0-beta.99
+      '@effect/platform-node-shared': ^4.0.0-beta.99
+      '@effect/vitest': ^4.0.0-beta.99
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/resources': ^2.2.0
+      '@standard-schema/spec': ^1.1.0
+      effect: ^4.0.0-beta.99
+
+  '@livestore/webmesh@0.0.0-snapshot-31e8d71134c5f4d89c21f6b1e3b6b5b39eeacd4e':
+    resolution: {integrity: sha512-CwpqkexBN7C7SllVHHnA/b7Noy99ogALMBT2kdpqknXL05FqqVadipKGGHLMyC2oZbmNte61OQAFUJDdMHSQ8A==}
+    peerDependencies:
+      '@effect/opentelemetry': ^4.0.0-beta.99
+      '@effect/platform-browser': ^4.0.0-beta.99
+      '@effect/platform-bun': ^4.0.0-beta.99
+      '@effect/platform-node': ^4.0.0-beta.99
+      '@effect/platform-node-shared': ^4.0.0-beta.99
+      '@effect/vitest': ^4.0.0-beta.99
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/resources': ^2.2.0
+      '@standard-schema/spec': ^1.1.0
+      effect: ^4.0.0-beta.99
 
   '@manypkg/find-root@3.1.0':
     resolution: {integrity: sha512-BcSqCyKhBVZ5YkSzOiheMCV41kqAFptW6xGqYSTjkVTl9XQpr+pqHhwgGCOHQtjDCv7Is6EFyA14Sm5GVbVABA==}
@@ -2556,48 +2671,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.76.0':
     resolution: {integrity: sha512-oPFkkKTgl0K/EIg9fQ8oA3IGcI05/Mq1en04iFa41mmNPT+6KEiByVazTOZZJiHMBBrbsns1YJ2e1Scqwzesjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.76.0':
     resolution: {integrity: sha512-gN7yZ0eqflA5Fhf1wvHxGUltIV3FsvmB1zhNMDEK9vSHhc7E6qg9CuPeBgPZab66Tjzq6w6kHAtNEvnTHf4cyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.76.0':
     resolution: {integrity: sha512-S/HqMbn22mQrjtErUxEoS/a55u8kIeXvreIxiJu5G7Le3UecEd6SQZxrDIpuhtgaFnsY/nVra3ytP+pRljDilA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.76.0':
     resolution: {integrity: sha512-ZIga3097VJZolGZk6SrIAUokIGfRkxRlhiHDUznZptGBfwrhD7pNfD1rzEzsCwvk/1DX0A1bLz+liuNh5QKIVQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.76.0':
     resolution: {integrity: sha512-ZGiiA7pFzMJSyMWYZTVlPgbTsx+Vl8ihLGMIujPwaslUF7kIPPWAbVmAlTc+9lWDV+DCiB8Ikixu+lSHeOIIWQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.76.0':
     resolution: {integrity: sha512-JLiy5WuvEBFTT6ErIFV35SLzi0R7Iri6MKU6dZbTxfIx8pndbbPs3Mj780nMipBFcPkti+okAPOJ9POKkHFEgg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.76.0':
     resolution: {integrity: sha512-z7lgKQtbo/I1NIe8G5NHLesxJDv0tRSUWTpXKb9Pm3E9nKFKfO4IOSDtFroKgXtOYb0jQbcdH+0wzTyMXVes+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.76.0':
     resolution: {integrity: sha512-JOjKymIpb9QcYfEhZsN6h4V9Ivd474W38cNIBRv6bg2TbIvogbMTH0Mg6YWW9TiRDqfcX+/Hyfsbo5vcSE5guQ==}
@@ -2811,36 +2934,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.5':
     resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.5':
     resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.5':
     resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.5':
     resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.5':
     resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
@@ -2938,66 +3067,79 @@ packages:
     resolution: {integrity: sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.3':
     resolution: {integrity: sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.3':
     resolution: {integrity: sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.3':
     resolution: {integrity: sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.3':
     resolution: {integrity: sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.3':
     resolution: {integrity: sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.3':
     resolution: {integrity: sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.3':
     resolution: {integrity: sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.3':
     resolution: {integrity: sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.3':
     resolution: {integrity: sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.3':
     resolution: {integrity: sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.3':
     resolution: {integrity: sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.3':
     resolution: {integrity: sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.3':
     resolution: {integrity: sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==}
@@ -4900,24 +5042,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -5253,6 +5399,11 @@ packages:
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.0.9:
+    resolution: {integrity: sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   native-duplexpair@1.0.0:
@@ -5627,6 +5778,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-bytes@7.0.1:
+    resolution: {integrity: sha512-285/jRCYIbMGDciDdrw0KPNC4LKEEwz/bwErcYNxSJOi4CpGUuLpb9gQpg3XJP0XYj9ldSRluXxih4lX2YN8Xw==}
+    engines: {node: '>=20'}
+
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -5672,6 +5827,9 @@ packages:
 
   pure-rand@8.4.1:
     resolution: {integrity: sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ==}
+
+  qrcode-generator@2.0.4:
+    resolution: {integrity: sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g==}
 
   queue@6.0.2:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
@@ -6466,6 +6624,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   valibot@1.4.2:
@@ -6787,13 +6946,13 @@ snapshots:
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.5.2
 
-  '@azure-rest/core-client@2.6.0':
+  '@azure-rest/core-client@2.6.0(supports-color@10.2.2)':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.1
-      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-auth': 1.10.1(supports-color@10.2.2)
+      '@azure/core-rest-pipeline': 1.23.0(supports-color@10.2.2)
       '@azure/core-tracing': 1.3.1
-      '@typespec/ts-http-runtime': 0.3.5
+      '@typespec/ts-http-runtime': 0.3.5(supports-color@10.2.2)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -6802,37 +6961,37 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@azure/core-auth@1.10.1':
+  '@azure/core-auth@1.10.1(supports-color@10.2.2)':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-util': 1.13.1
+      '@azure/core-util': 1.13.1(supports-color@10.2.2)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/core-client@1.10.1':
+  '@azure/core-client@1.10.1(supports-color@10.2.2)':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.1
-      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-auth': 1.10.1(supports-color@10.2.2)
+      '@azure/core-rest-pipeline': 1.23.0(supports-color@10.2.2)
       '@azure/core-tracing': 1.3.1
-      '@azure/core-util': 1.13.1
-      '@azure/logger': 1.3.0
+      '@azure/core-util': 1.13.1(supports-color@10.2.2)
+      '@azure/logger': 1.3.0(supports-color@10.2.2)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/core-http-compat@2.4.0(@azure/core-client@1.10.1)(@azure/core-rest-pipeline@1.23.0)':
+  '@azure/core-http-compat@2.4.0(@azure/core-client@1.10.1(supports-color@10.2.2))(@azure/core-rest-pipeline@1.23.0(supports-color@10.2.2))':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-client': 1.10.1
-      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-client': 1.10.1(supports-color@10.2.2)
+      '@azure/core-rest-pipeline': 1.23.0(supports-color@10.2.2)
 
-  '@azure/core-lro@2.7.2':
+  '@azure/core-lro@2.7.2(supports-color@10.2.2)':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-util': 1.13.1
-      '@azure/logger': 1.3.0
+      '@azure/core-util': 1.13.1(supports-color@10.2.2)
+      '@azure/logger': 1.3.0(supports-color@10.2.2)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -6841,14 +7000,14 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@azure/core-rest-pipeline@1.23.0':
+  '@azure/core-rest-pipeline@1.23.0(supports-color@10.2.2)':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.1
+      '@azure/core-auth': 1.10.1(supports-color@10.2.2)
       '@azure/core-tracing': 1.3.1
-      '@azure/core-util': 1.13.1
-      '@azure/logger': 1.3.0
-      '@typespec/ts-http-runtime': 0.3.5
+      '@azure/core-util': 1.13.1(supports-color@10.2.2)
+      '@azure/logger': 1.3.0(supports-color@10.2.2)
+      '@typespec/ts-http-runtime': 0.3.5(supports-color@10.2.2)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -6857,23 +7016,23 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@azure/core-util@1.13.1':
+  '@azure/core-util@1.13.1(supports-color@10.2.2)':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@typespec/ts-http-runtime': 0.3.5
+      '@typespec/ts-http-runtime': 0.3.5(supports-color@10.2.2)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/identity@4.13.1':
+  '@azure/identity@4.13.1(supports-color@10.2.2)':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.1
-      '@azure/core-client': 1.10.1
-      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-auth': 1.10.1(supports-color@10.2.2)
+      '@azure/core-client': 1.10.1(supports-color@10.2.2)
+      '@azure/core-rest-pipeline': 1.23.0(supports-color@10.2.2)
       '@azure/core-tracing': 1.3.1
-      '@azure/core-util': 1.13.1
-      '@azure/logger': 1.3.0
+      '@azure/core-util': 1.13.1(supports-color@10.2.2)
+      '@azure/logger': 1.3.0(supports-color@10.2.2)
       '@azure/msal-browser': 5.6.3
       '@azure/msal-node': 5.1.2
       open: 10.2.0
@@ -6881,40 +7040,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/keyvault-common@2.1.0':
+  '@azure/keyvault-common@2.1.0(supports-color@10.2.2)':
     dependencies:
-      '@azure-rest/core-client': 2.6.0
+      '@azure-rest/core-client': 2.6.0(supports-color@10.2.2)
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.1
-      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-auth': 1.10.1(supports-color@10.2.2)
+      '@azure/core-rest-pipeline': 1.23.0(supports-color@10.2.2)
       '@azure/core-tracing': 1.3.1
-      '@azure/core-util': 1.13.1
-      '@azure/logger': 1.3.0
+      '@azure/core-util': 1.13.1(supports-color@10.2.2)
+      '@azure/logger': 1.3.0(supports-color@10.2.2)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/keyvault-keys@4.10.0(@azure/core-client@1.10.1)':
+  '@azure/keyvault-keys@4.10.0(@azure/core-client@1.10.1(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@azure-rest/core-client': 2.6.0
+      '@azure-rest/core-client': 2.6.0(supports-color@10.2.2)
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.1
-      '@azure/core-http-compat': 2.4.0(@azure/core-client@1.10.1)(@azure/core-rest-pipeline@1.23.0)
-      '@azure/core-lro': 2.7.2
+      '@azure/core-auth': 1.10.1(supports-color@10.2.2)
+      '@azure/core-http-compat': 2.4.0(@azure/core-client@1.10.1(supports-color@10.2.2))(@azure/core-rest-pipeline@1.23.0(supports-color@10.2.2))
+      '@azure/core-lro': 2.7.2(supports-color@10.2.2)
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-rest-pipeline': 1.23.0(supports-color@10.2.2)
       '@azure/core-tracing': 1.3.1
-      '@azure/core-util': 1.13.1
-      '@azure/keyvault-common': 2.1.0
-      '@azure/logger': 1.3.0
+      '@azure/core-util': 1.13.1(supports-color@10.2.2)
+      '@azure/keyvault-common': 2.1.0(supports-color@10.2.2)
+      '@azure/logger': 1.3.0(supports-color@10.2.2)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@azure/core-client'
       - supports-color
 
-  '@azure/logger@1.3.0':
+  '@azure/logger@1.3.0(supports-color@10.2.2)':
     dependencies:
-      '@typespec/ts-http-runtime': 0.3.5
+      '@typespec/ts-http-runtime': 0.3.5(supports-color@10.2.2)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -6962,16 +7121,16 @@ snapshots:
 
   '@babel/compat-data@8.0.0': {}
 
-  '@babel/core@7.29.7':
+  '@babel/core@7.29.7(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
@@ -7038,15 +7197,15 @@ snapshots:
       lru-cache: 11.5.2
       semver: 7.8.5
 
-  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@10.2.2)
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@10.2.2)
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -7055,16 +7214,16 @@ snapshots:
 
   '@babel/helper-globals@8.0.0': {}
 
-  '@babel/helper-member-expression-to-functions@7.29.7':
+  '@babel/helper-member-expression-to-functions@7.29.7(supports-color@10.2.2)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.29.7':
+  '@babel/helper-module-imports@7.29.7(supports-color@10.2.2)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -7074,12 +7233,12 @@ snapshots:
       '@babel/traverse': 8.0.4
       '@babel/types': 8.0.4
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -7100,18 +7259,18 @@ snapshots:
     dependencies:
       '@babel/core': 8.0.1
 
-  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@10.2.2)
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7(supports-color@10.2.2)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -7166,9 +7325,9 @@ snapshots:
       '@babel/core': 8.0.1
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-flow@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-flow@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@8.0.1)':
@@ -7186,9 +7345,9 @@ snapshots:
       '@babel/core': 8.0.1
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@8.0.1)':
@@ -7231,15 +7390,15 @@ snapshots:
       '@babel/core': 8.0.1
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -7249,16 +7408,16 @@ snapshots:
       '@babel/core': 8.0.1
       '@babel/helper-plugin-utils': 8.0.1(@babel/core@8.0.1)
 
-  '@babel/plugin-transform-flow-strip-types@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-flow-strip-types@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
 
-  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -7269,59 +7428,59 @@ snapshots:
       '@babel/helper-module-transforms': 8.0.1(@babel/core@8.0.1)
       '@babel/helper-plugin-utils': 8.0.1(@babel/core@8.0.1)
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@10.2.2)
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-flow@7.29.7(@babel/core@7.29.7)':
+  '@babel/preset-flow@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
 
-  '@babel/preset-typescript@7.29.7(@babel/core@7.29.7)':
+  '@babel/preset-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/register@7.29.7(@babel/core@7.29.7)':
+  '@babel/register@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       clone-deep: 4.0.1
       find-cache-dir: 2.1.0
       make-dir: 2.1.0
@@ -7344,7 +7503,7 @@ snapshots:
       '@babel/parser': 8.0.4
       '@babel/types': 8.0.4
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -7666,6 +7825,38 @@ snapshots:
       repeat-string: 1.6.1
       strip-color: 0.1.0
 
+  '@effect/platform-browser@4.0.0-rc.108(effect@packages+effect)':
+    dependencies:
+      effect: link:packages/effect
+
+  '@effect/platform-bun@4.0.0-rc.109(effect@packages+effect)':
+    dependencies:
+      '@effect/platform-node-shared': 4.0.0-rc.109(effect@packages+effect)
+      effect: link:packages/effect
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@effect/platform-node-shared@4.0.0-rc.109(effect@packages+effect)':
+    dependencies:
+      '@types/ws': 8.18.1
+      effect: link:packages/effect
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@effect/platform-node@4.0.0-rc.109(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@effect/platform-node-shared': 4.0.0-rc.109(effect@packages+effect)
+      effect: link:packages/effect
+      mime: 4.1.0
+      redis: 6.2.1(@opentelemetry/api@1.9.1)
+      undici: 8.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@effect/tsgo-darwin-arm64@0.21.0':
     optional: true
 
@@ -7970,12 +8161,12 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.27.12
 
-  '@jest/transform@29.7.0':
+  '@jest/transform@29.7.0(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      babel-plugin-istanbul: 6.1.1
+      babel-plugin-istanbul: 6.1.1(supports-color@10.2.2)
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -8084,7 +8275,7 @@ snapshots:
     dependencies:
       '@jsr/std__bytes': 1.0.6
 
-  '@kwsites/file-exists@1.1.1':
+  '@kwsites/file-exists@1.1.1(supports-color@10.2.2)':
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -8148,6 +8339,66 @@ snapshots:
   '@libsql/win32-x64-msvc@0.5.29':
     optional: true
 
+  '@livestore/common@0.0.0-snapshot-31e8d71134c5f4d89c21f6b1e3b6b5b39eeacd4e(@effect/opentelemetry@packages+opentelemetry)(@effect/platform-browser@4.0.0-rc.108(effect@packages+effect))(@effect/platform-bun@4.0.0-rc.109(effect@packages+effect))(@effect/platform-node-shared@4.0.0-rc.109(effect@packages+effect))(@effect/platform-node@4.0.0-rc.109(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1)))(@effect/vitest@packages+vitest)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.9.0(@opentelemetry/api@1.9.1))(@standard-schema/spec@1.1.0)(effect@packages+effect)':
+    dependencies:
+      '@effect/opentelemetry': link:packages/opentelemetry
+      '@effect/platform-browser': 4.0.0-rc.108(effect@packages+effect)
+      '@effect/platform-bun': 4.0.0-rc.109(effect@packages+effect)
+      '@effect/platform-node': 4.0.0-rc.109(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1))
+      '@effect/platform-node-shared': 4.0.0-rc.109(effect@packages+effect)
+      '@effect/vitest': link:packages/vitest
+      '@livestore/utils': 0.0.0-snapshot-31e8d71134c5f4d89c21f6b1e3b6b5b39eeacd4e(@effect/opentelemetry@packages+opentelemetry)(@effect/platform-browser@4.0.0-rc.108(effect@packages+effect))(@effect/platform-bun@4.0.0-rc.109(effect@packages+effect))(@effect/platform-node-shared@4.0.0-rc.109(effect@packages+effect))(@effect/platform-node@4.0.0-rc.109(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1)))(@effect/vitest@packages+vitest)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.9.0(@opentelemetry/api@1.9.1))(@standard-schema/spec@1.1.0)(effect@packages+effect)
+      '@livestore/webmesh': 0.0.0-snapshot-31e8d71134c5f4d89c21f6b1e3b6b5b39eeacd4e(@effect/opentelemetry@packages+opentelemetry)(@effect/platform-browser@4.0.0-rc.108(effect@packages+effect))(@effect/platform-bun@4.0.0-rc.109(effect@packages+effect))(@effect/platform-node-shared@4.0.0-rc.109(effect@packages+effect))(@effect/platform-node@4.0.0-rc.109(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1)))(@effect/vitest@packages+vitest)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.9.0(@opentelemetry/api@1.9.1))(@standard-schema/spec@1.1.0)(effect@packages+effect)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@standard-schema/spec': 1.1.0
+      effect: link:packages/effect
+
+  '@livestore/livestore@0.0.0-snapshot-31e8d71134c5f4d89c21f6b1e3b6b5b39eeacd4e(@effect/opentelemetry@packages+opentelemetry)(@effect/platform-browser@4.0.0-rc.108(effect@packages+effect))(@effect/platform-bun@4.0.0-rc.109(effect@packages+effect))(@effect/platform-node-shared@4.0.0-rc.109(effect@packages+effect))(@effect/platform-node@4.0.0-rc.109(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1)))(@effect/vitest@packages+vitest)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.9.0(@opentelemetry/api@1.9.1))(@standard-schema/spec@1.1.0)(effect@packages+effect)':
+    dependencies:
+      '@effect/opentelemetry': link:packages/opentelemetry
+      '@effect/platform-browser': 4.0.0-rc.108(effect@packages+effect)
+      '@effect/platform-bun': 4.0.0-rc.109(effect@packages+effect)
+      '@effect/platform-node': 4.0.0-rc.109(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1))
+      '@effect/platform-node-shared': 4.0.0-rc.109(effect@packages+effect)
+      '@effect/vitest': link:packages/vitest
+      '@livestore/common': 0.0.0-snapshot-31e8d71134c5f4d89c21f6b1e3b6b5b39eeacd4e(@effect/opentelemetry@packages+opentelemetry)(@effect/platform-browser@4.0.0-rc.108(effect@packages+effect))(@effect/platform-bun@4.0.0-rc.109(effect@packages+effect))(@effect/platform-node-shared@4.0.0-rc.109(effect@packages+effect))(@effect/platform-node@4.0.0-rc.109(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1)))(@effect/vitest@packages+vitest)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.9.0(@opentelemetry/api@1.9.1))(@standard-schema/spec@1.1.0)(effect@packages+effect)
+      '@livestore/utils': 0.0.0-snapshot-31e8d71134c5f4d89c21f6b1e3b6b5b39eeacd4e(@effect/opentelemetry@packages+opentelemetry)(@effect/platform-browser@4.0.0-rc.108(effect@packages+effect))(@effect/platform-bun@4.0.0-rc.109(effect@packages+effect))(@effect/platform-node-shared@4.0.0-rc.109(effect@packages+effect))(@effect/platform-node@4.0.0-rc.109(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1)))(@effect/vitest@packages+vitest)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.9.0(@opentelemetry/api@1.9.1))(@standard-schema/spec@1.1.0)(effect@packages+effect)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@standard-schema/spec': 1.1.0
+      effect: link:packages/effect
+
+  '@livestore/utils@0.0.0-snapshot-31e8d71134c5f4d89c21f6b1e3b6b5b39eeacd4e(@effect/opentelemetry@packages+opentelemetry)(@effect/platform-browser@4.0.0-rc.108(effect@packages+effect))(@effect/platform-bun@4.0.0-rc.109(effect@packages+effect))(@effect/platform-node-shared@4.0.0-rc.109(effect@packages+effect))(@effect/platform-node@4.0.0-rc.109(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1)))(@effect/vitest@packages+vitest)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.9.0(@opentelemetry/api@1.9.1))(@standard-schema/spec@1.1.0)(effect@packages+effect)':
+    dependencies:
+      '@effect/opentelemetry': link:packages/opentelemetry
+      '@effect/platform-browser': 4.0.0-rc.108(effect@packages+effect)
+      '@effect/platform-bun': 4.0.0-rc.109(effect@packages+effect)
+      '@effect/platform-node': 4.0.0-rc.109(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1))
+      '@effect/platform-node-shared': 4.0.0-rc.109(effect@packages+effect)
+      '@effect/vitest': link:packages/vitest
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@standard-schema/spec': 1.1.0
+      effect: link:packages/effect
+      nanoid: 5.0.9
+      pretty-bytes: 7.0.1
+      qrcode-generator: 2.0.4
+
+  '@livestore/webmesh@0.0.0-snapshot-31e8d71134c5f4d89c21f6b1e3b6b5b39eeacd4e(@effect/opentelemetry@packages+opentelemetry)(@effect/platform-browser@4.0.0-rc.108(effect@packages+effect))(@effect/platform-bun@4.0.0-rc.109(effect@packages+effect))(@effect/platform-node-shared@4.0.0-rc.109(effect@packages+effect))(@effect/platform-node@4.0.0-rc.109(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1)))(@effect/vitest@packages+vitest)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.9.0(@opentelemetry/api@1.9.1))(@standard-schema/spec@1.1.0)(effect@packages+effect)':
+    dependencies:
+      '@effect/opentelemetry': link:packages/opentelemetry
+      '@effect/platform-browser': 4.0.0-rc.108(effect@packages+effect)
+      '@effect/platform-bun': 4.0.0-rc.109(effect@packages+effect)
+      '@effect/platform-node': 4.0.0-rc.109(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1))
+      '@effect/platform-node-shared': 4.0.0-rc.109(effect@packages+effect)
+      '@effect/vitest': link:packages/vitest
+      '@livestore/utils': 0.0.0-snapshot-31e8d71134c5f4d89c21f6b1e3b6b5b39eeacd4e(@effect/opentelemetry@packages+opentelemetry)(@effect/platform-browser@4.0.0-rc.108(effect@packages+effect))(@effect/platform-bun@4.0.0-rc.109(effect@packages+effect))(@effect/platform-node-shared@4.0.0-rc.109(effect@packages+effect))(@effect/platform-node@4.0.0-rc.109(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1)))(@effect/vitest@packages+vitest)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.9.0(@opentelemetry/api@1.9.1))(@standard-schema/spec@1.1.0)(effect@packages+effect)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@standard-schema/spec': 1.1.0
+      effect: link:packages/effect
+
   '@manypkg/find-root@3.1.0':
     dependencies:
       '@manypkg/tools': 2.1.2
@@ -8190,10 +8441,10 @@ snapshots:
 
   '@neon-rs/load@0.0.4': {}
 
-  '@op-engineering/op-sqlite@17.1.2(react-native@0.83.0(@babel/core@8.0.1)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)':
+  '@op-engineering/op-sqlite@17.1.2(react-native@0.83.0(@babel/core@8.0.1)(@types/react@19.2.17)(react@19.2.7)(supports-color@10.2.2))(react@19.2.7)':
     dependencies:
       react: 19.2.7
-      react-native: 0.83.0(@babel/core@8.0.1)(@types/react@19.2.17)(react@19.2.7)
+      react-native: 0.83.0(@babel/core@8.0.1)(@types/react@19.2.17)(react@19.2.7)(supports-color@10.2.2)
 
   '@opentelemetry/api-logs@0.220.0':
     dependencies:
@@ -8414,13 +8665,13 @@ snapshots:
       nullthrows: 1.1.1
       yargs: 17.7.3
 
-  '@react-native/community-cli-plugin@0.83.0':
+  '@react-native/community-cli-plugin@0.83.0(supports-color@10.2.2)':
     dependencies:
-      '@react-native/dev-middleware': 0.83.0
+      '@react-native/dev-middleware': 0.83.0(supports-color@10.2.2)
       debug: 4.4.3(supports-color@10.2.2)
       invariant: 2.2.4
-      metro: 0.83.7
-      metro-config: 0.83.7
+      metro: 0.83.7(supports-color@10.2.2)
+      metro-config: 0.83.7(supports-color@10.2.2)
       metro-core: 0.83.7
       semver: 7.8.5
     transitivePeerDependencies:
@@ -8435,19 +8686,19 @@ snapshots:
       cross-spawn: 7.0.6
       fb-dotslash: 0.5.8
 
-  '@react-native/dev-middleware@0.83.0':
+  '@react-native/dev-middleware@0.83.0(supports-color@10.2.2)':
     dependencies:
       '@isaacs/ttlcache': 1.4.1
       '@react-native/debugger-frontend': 0.83.0
       '@react-native/debugger-shell': 0.83.0
-      chrome-launcher: 0.15.2
-      chromium-edge-launcher: 0.2.0
-      connect: 3.7.0
+      chrome-launcher: 0.15.2(supports-color@10.2.2)
+      chromium-edge-launcher: 0.2.0(supports-color@10.2.2)
+      connect: 3.7.0(supports-color@10.2.2)
       debug: 4.4.3(supports-color@10.2.2)
       invariant: 2.2.4
       nullthrows: 1.1.1
       open: 7.4.2
-      serve-static: 1.16.3
+      serve-static: 1.16.3(supports-color@10.2.2)
       ws: 7.5.13
     transitivePeerDependencies:
       - bufferutil
@@ -8460,12 +8711,12 @@ snapshots:
 
   '@react-native/normalize-colors@0.83.0': {}
 
-  '@react-native/virtualized-lists@0.83.0(@types/react@19.2.17)(react-native@0.83.0(@babel/core@8.0.1)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)':
+  '@react-native/virtualized-lists@0.83.0(@types/react@19.2.17)(react-native@0.83.0(@babel/core@8.0.1)(@types/react@19.2.17)(react@19.2.7)(supports-color@10.2.2))(react@19.2.7)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.2.7
-      react-native: 0.83.0(@babel/core@8.0.1)(@types/react@19.2.17)(react@19.2.7)
+      react-native: 0.83.0(@babel/core@8.0.1)(@types/react@19.2.17)(react@19.2.7)(supports-color@10.2.2)
     optionalDependencies:
       '@types/react': 19.2.17
 
@@ -8715,36 +8966,36 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@testcontainers/mssqlserver@12.0.4':
+  '@testcontainers/mssqlserver@12.0.4(supports-color@10.2.2)':
     dependencies:
-      testcontainers: 12.1.0
+      testcontainers: 12.1.0(supports-color@10.2.2)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
       - supports-color
 
-  '@testcontainers/mysql@12.0.4':
+  '@testcontainers/mysql@12.0.4(supports-color@10.2.2)':
     dependencies:
-      testcontainers: 12.0.4
+      testcontainers: 12.0.4(supports-color@10.2.2)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
       - supports-color
 
-  '@testcontainers/postgresql@12.0.4':
+  '@testcontainers/postgresql@12.0.4(supports-color@10.2.2)':
     dependencies:
-      testcontainers: 12.0.4
+      testcontainers: 12.0.4(supports-color@10.2.2)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
       - supports-color
 
-  '@testcontainers/redis@12.0.4':
+  '@testcontainers/redis@12.0.4(supports-color@10.2.2)':
     dependencies:
-      testcontainers: 12.0.4
+      testcontainers: 12.0.4(supports-color@10.2.2)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -8955,7 +9206,7 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/project-service@8.65.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.65.0(supports-color@10.2.2)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.65.0
@@ -8970,9 +9221,9 @@ snapshots:
 
   '@typescript-eslint/types@8.65.0': {}
 
-  '@typescript-eslint/typescript-estree@8.65.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.65.0(supports-color@10.2.2)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.65.0(supports-color@10.2.2)(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
@@ -9050,9 +9301,9 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  '@typespec/ts-http-runtime@0.3.5':
+  '@typespec/ts-http-runtime@0.3.5(supports-color@10.2.2)':
     dependencies:
-      http-proxy-agent: 7.0.2
+      http-proxy-agent: 7.0.2(supports-color@10.2.2)
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -9344,12 +9595,12 @@ snapshots:
 
   b4a@1.8.1: {}
 
-  babel-jest@29.7.0(@babel/core@8.0.1):
+  babel-jest@29.7.0(@babel/core@8.0.1)(supports-color@10.2.2):
     dependencies:
       '@babel/core': 8.0.1
-      '@jest/transform': 29.7.0
+      '@jest/transform': 29.7.0(supports-color@10.2.2)
       '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 6.1.1
+      babel-plugin-istanbul: 6.1.1(supports-color@10.2.2)
       babel-preset-jest: 29.6.3(@babel/core@8.0.1)
       chalk: 4.1.2
       graceful-fs: 4.2.11
@@ -9361,12 +9612,12 @@ snapshots:
     dependencies:
       '@babel/core': 8.0.1
 
-  babel-plugin-istanbul@6.1.1:
+  babel-plugin-istanbul@6.1.1(supports-color@10.2.2):
     dependencies:
       '@babel/helper-plugin-utils': 7.29.7
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.6
-      istanbul-lib-instrument: 5.2.1
+      istanbul-lib-instrument: 5.2.1(supports-color@10.2.2)
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
@@ -9556,21 +9807,21 @@ snapshots:
 
   chownr@3.0.0: {}
 
-  chrome-launcher@0.15.2:
+  chrome-launcher@0.15.2(supports-color@10.2.2):
     dependencies:
       '@types/node': 26.1.2
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
-      lighthouse-logger: 1.4.2
+      lighthouse-logger: 1.4.2(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  chromium-edge-launcher@0.2.0:
+  chromium-edge-launcher@0.2.0(supports-color@10.2.2):
     dependencies:
       '@types/node': 26.1.2
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
-      lighthouse-logger: 1.4.2
+      lighthouse-logger: 1.4.2(supports-color@10.2.2)
       mkdirp: 1.0.4
       rimraf: 3.0.2
     transitivePeerDependencies:
@@ -9651,10 +9902,10 @@ snapshots:
     dependencies:
       source-map: 0.6.1
 
-  connect@3.7.0:
+  connect@3.7.0(supports-color@10.2.2):
     dependencies:
-      debug: 2.6.9
-      finalhandler: 1.1.2
+      debug: 2.6.9(supports-color@10.2.2)
+      finalhandler: 1.1.2(supports-color@10.2.2)
       parseurl: 1.3.3
       utils-merge: 1.0.1
     transitivePeerDependencies:
@@ -9705,9 +9956,11 @@ snapshots:
 
   dataloader@2.2.3: {}
 
-  debug@2.6.9:
+  debug@2.6.9(supports-color@10.2.2):
     dependencies:
       ms: 2.0.0
+    optionalDependencies:
+      supports-color: 10.2.2
 
   debug@4.4.3(supports-color@10.2.2):
     dependencies:
@@ -9738,12 +9991,12 @@ snapshots:
 
   depd@2.0.0: {}
 
-  dependency-tree@11.5.0:
+  dependency-tree@11.5.0(supports-color@10.2.2):
     dependencies:
       '@discoveryjs/json-ext': 1.1.0
       commander: 12.1.0
       filing-cabinet: 5.5.1
-      precinct: 12.3.2
+      precinct: 12.3.2(supports-color@10.2.2)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -9790,16 +10043,16 @@ snapshots:
 
   detective-stylus@5.0.1: {}
 
-  detective-typescript@14.1.2(typescript@5.9.3):
+  detective-typescript@14.1.2(supports-color@10.2.2)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(supports-color@10.2.2)(typescript@5.9.3)
       ast-module-types: 6.0.2
       node-source-walk: 7.0.2
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  detective-vue2@2.3.0(typescript@5.9.3):
+  detective-vue2@2.3.0(supports-color@10.2.2)(typescript@5.9.3):
     dependencies:
       '@dependents/detective-less': 5.0.3
       '@vue/compiler-sfc': 3.5.40
@@ -9807,7 +10060,7 @@ snapshots:
       detective-sass: 6.0.2
       detective-scss: 5.0.2
       detective-stylus: 5.0.1
-      detective-typescript: 14.1.2(typescript@5.9.3)
+      detective-typescript: 14.1.2(supports-color@10.2.2)(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -9818,7 +10071,7 @@ snapshots:
     dependencies:
       yaml: 2.9.0
 
-  docker-modem@5.0.7:
+  docker-modem@5.0.7(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       readable-stream: 3.6.2
@@ -9827,12 +10080,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  dockerode@5.0.1:
+  dockerode@5.0.1(supports-color@10.2.2):
     dependencies:
       '@balena/dockerignore': 1.0.2
       '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.7.15
-      docker-modem: 5.0.7
+      docker-modem: 5.0.7(supports-color@10.2.2)
       protobufjs: 7.6.5
       tar-fs: 2.1.5
     transitivePeerDependencies:
@@ -10058,9 +10311,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@1.1.2:
+  finalhandler@1.1.2(supports-color@10.2.2):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@10.2.2)
       encodeurl: 1.0.2
       escape-html: 1.0.3
       on-finished: 2.3.0
@@ -10239,7 +10492,7 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@10.2.2)
@@ -10368,9 +10621,9 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
-  istanbul-lib-instrument@5.2.1:
+  istanbul-lib-instrument@5.2.1(supports-color@10.2.2):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/parser': 7.29.7
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
@@ -10492,18 +10745,18 @@ snapshots:
 
   jsc-safe-url@0.2.4: {}
 
-  jscodeshift@17.4.0:
+  jscodeshift@17.4.0(supports-color@10.2.2):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/parser': 7.29.7
-      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7)
-      '@babel/preset-flow': 7.29.7(@babel/core@7.29.7)
-      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
-      '@babel/register': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/preset-flow': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/register': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
       flow-parser: 0.323.0
       graceful-fs: 4.2.11
       neo-async: 2.6.2
@@ -10629,9 +10882,9 @@ snapshots:
       '@libsql/linux-x64-musl': 0.5.29
       '@libsql/win32-x64-msvc': 0.5.29
 
-  lighthouse-logger@1.4.2:
+  lighthouse-logger@1.4.2(supports-color@10.2.2):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@10.2.2)
       marky: 1.3.0
     transitivePeerDependencies:
       - supports-color
@@ -10755,13 +11008,13 @@ snapshots:
 
   lz-string@1.5.0: {}
 
-  madge@8.0.0(typescript@7.0.2):
+  madge@8.0.0(supports-color@10.2.2)(typescript@7.0.2):
     dependencies:
       chalk: 4.1.2
       commander: 7.2.0
       commondir: 1.0.1
       debug: 4.4.3(supports-color@10.2.2)
-      dependency-tree: 11.5.0
+      dependency-tree: 11.5.0(supports-color@10.2.2)
       ora: 5.4.1
       pluralize: 8.0.0
       pretty-ms: 7.0.1
@@ -10813,9 +11066,9 @@ snapshots:
 
   merge-stream@2.0.0: {}
 
-  metro-babel-transformer@0.83.7:
+  metro-babel-transformer@0.83.7(supports-color@10.2.2):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       flow-enums-runtime: 0.0.6
       hermes-parser: 0.35.0
       metro-cache-key: 0.83.7
@@ -10827,7 +11080,7 @@ snapshots:
     dependencies:
       flow-enums-runtime: 0.0.6
 
-  metro-cache@0.83.7:
+  metro-cache@0.83.7(supports-color@10.2.2):
     dependencies:
       exponential-backoff: 3.1.3
       flow-enums-runtime: 0.0.6
@@ -10836,13 +11089,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-config@0.83.7:
+  metro-config@0.83.7(supports-color@10.2.2):
     dependencies:
-      connect: 3.7.0
+      connect: 3.7.0(supports-color@10.2.2)
       flow-enums-runtime: 0.0.6
       jest-validate: 29.7.0
-      metro: 0.83.7
-      metro-cache: 0.83.7
+      metro: 0.83.7(supports-color@10.2.2)
+      metro-cache: 0.83.7(supports-color@10.2.2)
       metro-core: 0.83.7
       metro-runtime: 0.83.7
       yaml: 2.9.0
@@ -10857,7 +11110,7 @@ snapshots:
       lodash.throttle: 4.1.1
       metro-resolver: 0.83.7
 
-  metro-file-map@0.83.7:
+  metro-file-map@0.83.7(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       fb-watchman: 2.0.2
@@ -10885,13 +11138,13 @@ snapshots:
       '@babel/runtime': 7.29.7
       flow-enums-runtime: 0.0.6
 
-  metro-source-map@0.83.7:
+  metro-source-map@0.83.7(supports-color@10.2.2):
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
-      metro-symbolicate: 0.83.7
+      metro-symbolicate: 0.83.7(supports-color@10.2.2)
       nullthrows: 1.1.1
       ob1: 0.83.7
       source-map: 0.5.7
@@ -10899,60 +11152,60 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-symbolicate@0.83.7:
+  metro-symbolicate@0.83.7(supports-color@10.2.2):
     dependencies:
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
-      metro-source-map: 0.83.7
+      metro-source-map: 0.83.7(supports-color@10.2.2)
       nullthrows: 1.1.1
       source-map: 0.5.7
       vlq: 1.0.1
     transitivePeerDependencies:
       - supports-color
 
-  metro-transform-plugins@0.83.7:
+  metro-transform-plugins@0.83.7(supports-color@10.2.2):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/generator': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       flow-enums-runtime: 0.0.6
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
 
-  metro-transform-worker@0.83.7:
+  metro-transform-worker@0.83.7(supports-color@10.2.2):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       flow-enums-runtime: 0.0.6
-      metro: 0.83.7
-      metro-babel-transformer: 0.83.7
-      metro-cache: 0.83.7
+      metro: 0.83.7(supports-color@10.2.2)
+      metro-babel-transformer: 0.83.7(supports-color@10.2.2)
+      metro-cache: 0.83.7(supports-color@10.2.2)
       metro-cache-key: 0.83.7
       metro-minify-terser: 0.83.7
-      metro-source-map: 0.83.7
-      metro-transform-plugins: 0.83.7
+      metro-source-map: 0.83.7(supports-color@10.2.2)
+      metro-transform-plugins: 0.83.7(supports-color@10.2.2)
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  metro@0.83.7:
+  metro@0.83.7(supports-color@10.2.2):
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
       accepts: 2.0.0
       ci-info: 2.0.0
-      connect: 3.7.0
+      connect: 3.7.0(supports-color@10.2.2)
       debug: 4.4.3(supports-color@10.2.2)
       error-stack-parser: 2.1.4
       flow-enums-runtime: 0.0.6
@@ -10963,18 +11216,18 @@ snapshots:
       jest-worker: 29.7.0
       jsc-safe-url: 0.2.4
       lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.7
-      metro-cache: 0.83.7
+      metro-babel-transformer: 0.83.7(supports-color@10.2.2)
+      metro-cache: 0.83.7(supports-color@10.2.2)
       metro-cache-key: 0.83.7
-      metro-config: 0.83.7
+      metro-config: 0.83.7(supports-color@10.2.2)
       metro-core: 0.83.7
-      metro-file-map: 0.83.7
+      metro-file-map: 0.83.7(supports-color@10.2.2)
       metro-resolver: 0.83.7
       metro-runtime: 0.83.7
-      metro-source-map: 0.83.7
-      metro-symbolicate: 0.83.7
-      metro-transform-plugins: 0.83.7
-      metro-transform-worker: 0.83.7
+      metro-source-map: 0.83.7(supports-color@10.2.2)
+      metro-symbolicate: 0.83.7(supports-color@10.2.2)
+      metro-transform-plugins: 0.83.7(supports-color@10.2.2)
+      metro-transform-worker: 0.83.7(supports-color@10.2.2)
       mime-types: 3.0.2
       nullthrows: 1.1.1
       serialize-error: 2.1.0
@@ -11110,6 +11363,8 @@ snapshots:
     optional: true
 
   nanoid@3.3.16: {}
+
+  nanoid@5.0.9: {}
 
   native-duplexpair@1.0.0: {}
 
@@ -11456,7 +11711,7 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
-  precinct@12.3.2:
+  precinct@12.3.2(supports-color@10.2.2):
     dependencies:
       '@dependents/detective-less': 5.0.3
       commander: 12.1.0
@@ -11467,8 +11722,8 @@ snapshots:
       detective-sass: 6.0.2
       detective-scss: 5.0.2
       detective-stylus: 5.0.1
-      detective-typescript: 14.1.2(typescript@5.9.3)
-      detective-vue2: 2.3.0(typescript@5.9.3)
+      detective-typescript: 14.1.2(supports-color@10.2.2)(typescript@5.9.3)
+      detective-vue2: 2.3.0(supports-color@10.2.2)(typescript@5.9.3)
       module-definition: 6.0.2
       node-source-walk: 7.0.2
       postcss: 8.5.24
@@ -11477,6 +11732,8 @@ snapshots:
       - supports-color
 
   prettier@3.9.6: {}
+
+  pretty-bytes@7.0.1: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -11510,9 +11767,9 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
-  properties-reader@3.0.1:
+  properties-reader@3.0.1(supports-color@10.2.2):
     dependencies:
-      '@kwsites/file-exists': 1.1.1
+      '@kwsites/file-exists': 1.1.1(supports-color@10.2.2)
       mkdirp: 3.0.1
     transitivePeerDependencies:
       - supports-color
@@ -11539,6 +11796,8 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@8.4.1: {}
+
+  qrcode-generator@2.0.4: {}
 
   queue@6.0.2:
     dependencies:
@@ -11582,20 +11841,20 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-native@0.83.0(@babel/core@8.0.1)(@types/react@19.2.17)(react@19.2.7):
+  react-native@0.83.0(@babel/core@8.0.1)(@types/react@19.2.17)(react@19.2.7)(supports-color@10.2.2):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.83.0
       '@react-native/codegen': 0.83.0(@babel/core@8.0.1)
-      '@react-native/community-cli-plugin': 0.83.0
+      '@react-native/community-cli-plugin': 0.83.0(supports-color@10.2.2)
       '@react-native/gradle-plugin': 0.83.0
       '@react-native/js-polyfills': 0.83.0
       '@react-native/normalize-colors': 0.83.0
-      '@react-native/virtualized-lists': 0.83.0(@types/react@19.2.17)(react-native@0.83.0(@babel/core@8.0.1)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
+      '@react-native/virtualized-lists': 0.83.0(@types/react@19.2.17)(react-native@0.83.0(@babel/core@8.0.1)(@types/react@19.2.17)(react@19.2.7)(supports-color@10.2.2))(react@19.2.7)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
-      babel-jest: 29.7.0(@babel/core@8.0.1)
+      babel-jest: 29.7.0(@babel/core@8.0.1)(supports-color@10.2.2)
       babel-plugin-syntax-hermes-parser: 0.32.0
       base64-js: 1.5.1
       commander: 12.1.0
@@ -11606,7 +11865,7 @@ snapshots:
       jest-environment-node: 29.7.0
       memoize-one: 5.2.1
       metro-runtime: 0.83.7
-      metro-source-map: 0.83.7
+      metro-source-map: 0.83.7(supports-color@10.2.2)
       nullthrows: 1.1.1
       pretty-format: 29.7.0
       promise: 8.3.0
@@ -11770,7 +12029,7 @@ snapshots:
     transitivePeerDependencies:
       - core-js
 
-  rollup-plugin-esbuild@6.2.1(esbuild@0.28.1)(rollup@4.62.3):
+  rollup-plugin-esbuild@6.2.1(esbuild@0.28.1)(rollup@4.62.3)(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       es-module-lexer: 1.7.0
@@ -11861,9 +12120,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@0.19.2:
+  send@0.19.2(supports-color@10.2.2):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@10.2.2)
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 2.0.0
@@ -11891,12 +12150,12 @@ snapshots:
 
   seroval@1.5.5: {}
 
-  serve-static@1.16.3:
+  serve-static@1.16.3(supports-color@10.2.2):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.2
+      send: 0.19.2(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -12212,11 +12471,11 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
-  tedious@19.2.1(@azure/core-client@1.10.1):
+  tedious@19.2.1(@azure/core-client@1.10.1(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:
-      '@azure/core-auth': 1.10.1
-      '@azure/identity': 4.13.1
-      '@azure/keyvault-keys': 4.10.0(@azure/core-client@1.10.1)
+      '@azure/core-auth': 1.10.1(supports-color@10.2.2)
+      '@azure/identity': 4.13.1(supports-color@10.2.2)
+      '@azure/keyvault-keys': 4.10.0(@azure/core-client@1.10.1(supports-color@10.2.2))(supports-color@10.2.2)
       '@js-joda/core': 5.7.0
       '@types/node': 26.1.2
       bl: 6.1.6
@@ -12248,7 +12507,7 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.5
 
-  testcontainers@12.0.4:
+  testcontainers@12.0.4(supports-color@10.2.2):
     dependencies:
       '@balena/dockerignore': 1.0.2
       '@types/dockerode': 4.0.1
@@ -12257,10 +12516,10 @@ snapshots:
       byline: 5.0.0
       debug: 4.4.3(supports-color@10.2.2)
       docker-compose: 1.4.2
-      dockerode: 5.0.1
+      dockerode: 5.0.1(supports-color@10.2.2)
       get-port: 5.1.1
       proper-lockfile: 4.1.2
-      properties-reader: 3.0.1
+      properties-reader: 3.0.1(supports-color@10.2.2)
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.3
       tmp: 0.2.7
@@ -12271,7 +12530,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  testcontainers@12.1.0:
+  testcontainers@12.1.0(supports-color@10.2.2):
     dependencies:
       '@balena/dockerignore': 1.0.2
       '@types/dockerode': 4.0.1
@@ -12280,10 +12539,10 @@ snapshots:
       byline: 5.0.0
       debug: 4.4.3(supports-color@10.2.2)
       docker-compose: 1.4.2
-      dockerode: 5.0.1
+      dockerode: 5.0.1(supports-color@10.2.2)
       get-port: 5.1.1
       proper-lockfile: 4.1.2
-      properties-reader: 3.0.1
+      properties-reader: 3.0.1(supports-color@10.2.2)
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.3
       tmp: 0.2.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,11 @@ allowBuilds:
   tree-sitter-typescript: false
   workerd: false
 
+minimumReleaseAgeExclude:
+  - '@effect/platform-bun@4.0.0-rc.109'
+  - '@effect/platform-node-shared@4.0.0-rc.109'
+  - '@effect/platform-node@4.0.0-rc.109'
+
 patchedDependencies:
   '@changesets/get-github-info@1.0.0-next.4': patches/@changesets__get-github-info@1.0.0-next.4.patch
   '@changesets/read@1.0.0-next.10': patches/@changesets__read@1.0.0-next.10.patch

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -9,6 +9,7 @@
     { "path": "packages/ai/openai-compat" },
     { "path": "packages/ai/openai" },
     { "path": "packages/ai/openrouter" },
+    { "path": "packages/atom/livestore" },
     { "path": "packages/atom/react" },
     { "path": "packages/atom/vue" },
     { "path": "packages/atom/solid" },


### PR DESCRIPTION
## Summary

Adds `@effect/atom-livestore` under `packages/atom/livestore`, porting [`@effect-atom/atom-livestore`](https://github.com/tim-smart/effect-atom/tree/main/packages/atom-livestore) to Effect v4 alongside the existing atom framework bindings (`atom-react`, `atom-solid`, `atom-vue`).

LiveStore's main branch has migrated to Effect v4 (`effect@^4.0.0-beta.99`, published as `0.0.0-snapshot-*` builds), but the atom bindings it documents ([LiveStore Effect docs](https://docs.livestore.dev/patterns/effect/)) only exist for Effect v3, leaving no working `AtomLivestore` integration on v4. This PR closes that gap.

## API

Same surface as the v3 package, adapted to v4 conventions:

- `AtomLivestore.Tag<Self>()(id, options)` creates a `Context.Service` class for a LiveStore `Store` (was `Context.Tag`/`TagClassShape`), built via `Layer.effect` + `createStore` + `provideOtel` on an `Atom.runtime`
- `store` emits `AsyncResult<Store<S, TContext>>` (v3 `Result` → v4 `AsyncResult`), `storeUnsafe` emits `Store | undefined`
- `makeQuery` / `makeQueryUnsafe` create reactive query atoms; they now accept LiveStore's v4 `Queryable<A>` (superset of `LiveQueryDef<A>`), and use the v4 `store.subscribe(query, onUpdate)` callback signature directly (the v3 `onUpdate.onUpdate` shim is gone)
- `commit` is now typed as `Atom.Writable<void, LiveStoreEvent.Input.ForSchema<S>>` instead of v3's `Writable<void, {}>`, so committing events from another schema is a type error
- New optional `runtime: Atom.RuntimeFactory` option, mirroring `AtomHttpApi.Service` / `AtomRpc`

Implementation notes:

- `otelOptions` are assembled conditionally to satisfy `exactOptionalPropertyTypes`
- `store` is derived via `self.use(Effect.succeed)` rather than passing the service class to `runtime.atom` (the class is a function, which `runtime.atom` would treat as a read callback)
- peer dep on `@livestore/livestore` is `*` since the v4-compatible builds are currently only published under `0.0.0-snapshot-*` versions (which no ordinary range matches); the dev dep pins the snapshot for `livestorejs/livestore@31e8d71`

## Testing

- `pnpm --filter @effect/atom-livestore run check` / `build` pass
- `tsc -b tsconfig.packages.json` passes with the new project reference
- Verified inference end-to-end against a real LiveStore schema (events + materializers + `queryDb`): query atoms infer row types (not `any`), and `commit` rejects foreign events — via a temporary type-level smoke test, not committed
- No runtime tests: exercising a real store needs a platform adapter (`@livestore/adapter-*`), which seemed too heavy a dev dependency for this PR — happy to add if wanted

## Notes for review

- `syncPayloadSchema` typing (third generic on `CreateStoreOptions`) is not threaded through `Options`, matching the v3 surface; can follow up if desired
- `pnpm-workspace.yaml` `minimumReleaseAgeExclude` entries and part of the lockfile churn come from pnpm auto-installing registry copies of `@effect/*` peers for the external `@livestore/*` packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)