### PR TITLE
fix(openapi): preserve JSON.rawJSON in cached specs

### DIFF
--- a/.changeset/preserve-openapi-raw-json.md
+++ b/.changeset/preserve-openapi-raw-json.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve `JSON.rawJSON` values when cloning cached OpenAPI specs.

--- a/packages/effect/src/unstable/httpapi/OpenApi.ts
+++ b/packages/effect/src/unstable/httpapi/OpenApi.ts
@@ -227,11 +227,15 @@ const compileSchemas: CompileSchemas = (asts) =>
     )
   )
 
+const jsonWithRawJSON = JSON as unknown as { isRawJSON?: (value: unknown) => boolean }
+
+const isJsonRawJSON = (value: unknown): boolean => jsonWithRawJSON.isRawJSON?.(value) === true
+
 const cloneOpenAPISpec = <A>(value: A): A => {
   if (Array.isArray(value)) {
     return value.map(cloneOpenAPISpec) as A
   }
-  if (value !== null && typeof value === "object") {
+  if (value !== null && typeof value === "object" && !isJsonRawJSON(value)) {
     const out: Record<string, unknown> = {}
     for (const key of Object.keys(value)) {
       InternalRecord.assignProperty(out, key, cloneOpenAPISpec((value as Record<string, unknown>)[key]))

--- a/packages/effect/src/unstable/httpapi/OpenApi.ts
+++ b/packages/effect/src/unstable/httpapi/OpenApi.ts
@@ -227,15 +227,11 @@ const compileSchemas: CompileSchemas = (asts) =>
     )
   )
 
-const jsonWithRawJSON = JSON as unknown as { isRawJSON?: (value: unknown) => boolean }
-
-const isJsonRawJSON = (value: unknown): boolean => jsonWithRawJSON.isRawJSON?.(value) === true
-
 const cloneOpenAPISpec = <A>(value: A): A => {
   if (Array.isArray(value)) {
     return value.map(cloneOpenAPISpec) as A
   }
-  if (value !== null && typeof value === "object" && !isJsonRawJSON(value)) {
+  if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
     const out: Record<string, unknown> = {}
     for (const key of Object.keys(value)) {
       InternalRecord.assignProperty(out, key, cloneOpenAPISpec((value as Record<string, unknown>)[key]))

--- a/packages/effect/test/unstable/httpapi/OpenApi.test.ts
+++ b/packages/effect/test/unstable/httpapi/OpenApi.test.ts
@@ -97,6 +97,22 @@ describe("OpenApi", () => {
     assert.isUndefined(third.paths["/resource"]!.get!.summary)
   })
 
+  it("preserves JSON.rawJSON values when cloning cached specs", () => {
+    const rawJson = (JSON as { rawJSON: (value: string) => unknown }).rawJSON("9223372036854775807")
+    const Api = HttpApi.make("Api").annotate(OpenApi.Transform, (spec) => ({
+      ...spec,
+      info: {
+        ...spec.info,
+        "x-raw": rawJson
+      }
+    }))
+
+    const expected = `{"title":"Api","version":"0.0.1","x-raw":9223372036854775807}`
+
+    assert.strictEqual(JSON.stringify(OpenApi.fromApi(Api).info), expected)
+    assert.strictEqual(JSON.stringify(OpenApi.fromApi(Api).info), expected)
+  })
+
   it("isolates the cached spec from external override mutations", () => {
     const info = { title: "Api", version: "1.0.0" }
     const Api = HttpApi.make("Api").annotate(OpenApi.Override, { info })

--- a/packages/effect/test/unstable/httpapi/OpenApi.test.ts
+++ b/packages/effect/test/unstable/httpapi/OpenApi.test.ts
@@ -98,7 +98,7 @@ describe("OpenApi", () => {
   })
 
   it("preserves JSON.rawJSON values when cloning cached specs", () => {
-    const rawJson = (JSON as { rawJSON: (value: string) => unknown }).rawJSON("9223372036854775807")
+    const rawJson = (JSON as unknown as { rawJSON: (value: string) => unknown }).rawJSON("9223372036854775807")
     const Api = HttpApi.make("Api").annotate(OpenApi.Transform, (spec) => ({
       ...spec,
       info: {


### PR DESCRIPTION
## Summary

- preserve `JSON.rawJSON` values when cloning cached OpenAPI specs
- skip frozen objects so values with internal slots remain intact
- keep the regression test for repeated `OpenApi.fromApi` calls and the patch changeset

## Details

`JSON.rawJSON` objects are frozen and carry internal JSON serialization behavior. The cached spec clone added in #6550 recursively copied enumerable object keys, which turned a raw JSON object into a plain `{ rawJSON: ... }` object on cache hits. The clone now returns frozen objects unchanged, preserving their serialization behavior without a raw-JSON-specific helper.

## Tests

- `nix develop -c pnpm test --run packages/effect/test/unstable/httpapi/OpenApi.test.ts`
- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`
- `git diff --check`

Fixes #7239

Closes EFF-734
