### PR TITLE
Reduce Atom bundle size by making context stream helpers standalone

### DIFF
--- a/.changeset/atom-context-stream-bundle-size.md
+++ b/.changeset/atom-context-stream-bundle-size.md
@@ -1,0 +1,20 @@
+---
+"effect": patch
+---
+
+Reduce Atom bundle size by moving the atom context `stream` and `streamResult`
+methods to standalone `Atom.stream` and `Atom.streamResult` functions.
+
+The context methods lived on the shared context prototype, so every atom user
+paid for the `Stream` and `Queue` machinery even when no streams were used.
+As standalone functions they are only included in a bundle when actually
+imported, shrinking a minimal atom bundle by around 23%.
+
+```ts
+// before
+Atom.make((get) => get.stream(count))
+// after
+Atom.make((get) => Atom.stream(get, count))
+```
+
+The atom context also exposes a readonly `disposed` flag.

--- a/packages/effect/src/unstable/reactivity/Atom.ts
+++ b/packages/effect/src/unstable/reactivity/Atom.ts
@@ -28,6 +28,7 @@ import * as Option from "../../Option.ts"
 import type { Pipeable } from "../../Pipeable.ts"
 import { hasProperty } from "../../Predicate.ts"
 import * as Pull from "../../Pull.ts"
+import * as Queue from "../../Queue.ts"
 import type { ReadonlyRecord } from "../../Record.ts"
 import * as Scheduler from "../../Scheduler.ts"
 import * as Schema from "../../Schema.ts"
@@ -177,17 +178,10 @@ export interface AtomContext {
   setResult<A, E, W>(this: AtomContext, atom: Writable<AsyncResult.AsyncResult<A, E>, W>, value: W): Effect.Effect<A, E>
   some<A>(this: AtomContext, atom: Atom<Option.Option<A>>): Effect.Effect<A>
   someOnce<A>(this: AtomContext, atom: Atom<Option.Option<A>>): Effect.Effect<A>
-  stream<A>(this: AtomContext, atom: Atom<A>, options?: {
-    readonly withoutInitialValue?: boolean
-    readonly bufferSize?: number
-  }): Stream.Stream<A>
-  streamResult<A, E>(this: AtomContext, atom: Atom<AsyncResult.AsyncResult<A, E>>, options?: {
-    readonly withoutInitialValue?: boolean
-    readonly bufferSize?: number
-  }): Stream.Stream<A, E>
   subscribe<A>(this: AtomContext, atom: Atom<A>, f: (_: A) => void, options?: {
     readonly immediate?: boolean
   }): void
+  readonly disposed: boolean
   readonly registry: Registry.AtomRegistry
 }
 
@@ -487,7 +481,7 @@ const makeRead: {
           else if (EffectTypeId in value) {
             return effect(get, value as any, options, providedServices)
           } else if (StreamTypeId in value) {
-            return stream(get, value as any, options, providedServices)
+            return streamRead(get, value as any, options, providedServices)
           }
           return value
         }
@@ -501,7 +495,7 @@ const makeRead: {
     }
   } else if (Stream.isStream(arg)) {
     return function(get: AtomContext, providedServices?: Context.Context<any>) {
-      return stream(get, arg as any, options, providedServices)
+      return streamRead(get, arg as any, options, providedServices)
     }
   }
 
@@ -833,7 +827,7 @@ export const withReactivity: (
 // constructors - stream
 // -----------------------------------------------------------------------------
 
-const stream = <A, E>(
+const streamRead = <A, E>(
   get: AtomContext,
   stream: Stream.Stream<A, E, AtomRegistry>,
   options?: {
@@ -1022,17 +1016,10 @@ export interface FnContext {
   set<R, W>(this: FnContext, atom: Writable<R, W>, value: W): void
   setResult<A, E, W>(this: FnContext, atom: Writable<AsyncResult.AsyncResult<A, E>, W>, value: W): Effect.Effect<A, E>
   some<A>(this: FnContext, atom: Atom<Option.Option<A>>): Effect.Effect<A>
-  stream<A>(this: FnContext, atom: Atom<A>, options?: {
-    readonly withoutInitialValue?: boolean
-    readonly bufferSize?: number
-  }): Stream.Stream<A>
-  streamResult<A, E>(this: FnContext, atom: Atom<AsyncResult.AsyncResult<A, E>>, options?: {
-    readonly withoutInitialValue?: boolean
-    readonly bufferSize?: number
-  }): Stream.Stream<A, E>
   subscribe<A>(this: FnContext, atom: Atom<A>, f: (_: A) => void, options?: {
     readonly immediate?: boolean
   }): void
+  readonly disposed: boolean
   readonly registry: Registry.AtomRegistry
 }
 
@@ -2309,6 +2296,62 @@ function updateSearchParams() {
 // -----------------------------------------------------------------------------
 // conversions
 // -----------------------------------------------------------------------------
+
+/**
+ * Converts an atom into a stream of its values using an atom context.
+ *
+ * **Details**
+ *
+ * The stream emits the atom's current value immediately unless
+ * `withoutInitialValue` is set, and then emits subsequent changes. The
+ * subscription is released when the context is disposed.
+ *
+ * @category converting
+ * @since 4.0.0
+ */
+export const stream = <A>(
+  get: AtomContext | FnContext,
+  atom: Atom<A>,
+  options?: {
+    readonly withoutInitialValue?: boolean
+  }
+): Stream.Stream<A> => {
+  const ctx = get as AtomContext
+  if (ctx.disposed) return Stream.empty
+  return Stream.callback<A>((queue) =>
+    Effect.sync(() => {
+      ctx.subscribe(atom, (value) => Queue.offerUnsafe(queue, value), {
+        immediate: !options?.withoutInitialValue
+      })
+    })
+  )
+}
+
+/**
+ * Converts an `AsyncResult` atom into a stream of its success values using an
+ * atom context.
+ *
+ * **Details**
+ *
+ * Initial results are skipped, successes are emitted as stream values, and
+ * failures fail the stream with the result cause.
+ *
+ * @category converting
+ * @since 4.0.0
+ */
+export const streamResult = <A, E>(
+  get: AtomContext | FnContext,
+  atom: Atom<AsyncResult.AsyncResult<A, E>>,
+  options?: {
+    readonly withoutInitialValue?: boolean
+  }
+): Stream.Stream<A, E> =>
+  stream(get, atom, options).pipe(
+    Stream.filter(AsyncResult.isNotInitial),
+    Stream.mapEffect((result) =>
+      result._tag === "Success" ? Effect.succeed(result.value) : Effect.failCause(result.cause)
+    )
+  )
 
 /**
  * Converts an atom into a stream using the `AtomRegistry` service.

--- a/packages/effect/src/unstable/reactivity/AtomRegistry.ts
+++ b/packages/effect/src/unstable/reactivity/AtomRegistry.ts
@@ -986,31 +986,6 @@ const LifetimeProto: Omit<Lifetime<any>, "node" | "finalizers" | "disposed" | "i
     this.node.registry.set(atom, value)
   },
 
-  stream<A>(this: Lifetime<any>, atom: Atom.Atom<A>, options?: {
-    readonly withoutInitialValue?: boolean
-  }) {
-    if (this.disposed) return Stream.empty
-    return Stream.callback<A>((queue) =>
-      Effect.sync(() => {
-        this.subscribe(atom, (value) => Queue.offerUnsafe(queue, value), {
-          immediate: !options?.withoutInitialValue
-        })
-      })
-    )
-  },
-
-  streamResult<A, E>(this: Lifetime<any>, atom: Atom.Atom<Result.AsyncResult<A, E>>, options?: {
-    readonly withoutInitialValue?: boolean
-    readonly bufferSize?: number
-  }): Stream.Stream<A, E> {
-    return this.stream(atom, options).pipe(
-      Stream.filter(Result.isNotInitial),
-      Stream.mapEffect((result) =>
-        result._tag === "Success" ? Effect.succeed(result.value) : Effect.failCause(result.cause)
-      )
-    )
-  },
-
   dispose(this: Lifetime<any>): void {
     this.disposed = true
     if (this.finalizers === undefined) {

--- a/packages/effect/test/reactivity/Atom.test.ts
+++ b/packages/effect/test/reactivity/Atom.test.ts
@@ -623,8 +623,8 @@ describe.sequential("Atom", () => {
     expect(() => disposed.setSelf(1)).not.toThrow()
     expect(() => disposed.set(state, 1)).not.toThrow()
     expect(registry.get(state)).toEqual(0)
-    expect(() => disposed.stream(state)).not.toThrow()
-    expect(() => disposed.streamResult(result)).not.toThrow()
+    expect(() => Atom.stream(disposed, state)).not.toThrow()
+    expect(() => Atom.streamResult(disposed, result)).not.toThrow()
   })
 
   it("disposed lifetime ignores async updates", async () => {
@@ -1251,9 +1251,9 @@ describe.sequential("Atom", () => {
     assert.strictEqual(r.get(bool), true)
   })
 
-  it("get.stream", async () => {
+  it("Atom.stream", async () => {
     const count = Atom.make(0)
-    const multiplied = Atom.make((get) => get.stream(count).pipe(Stream.map((_) => _ * 2)))
+    const multiplied = Atom.make((get) => Atom.stream(get, count).pipe(Stream.map((_) => _ * 2)))
 
     const r = AtomRegistry.make()
     const cancel = r.mount(multiplied)
@@ -1268,10 +1268,10 @@ describe.sequential("Atom", () => {
     cancel()
   })
 
-  it("get.streamResult", async () => {
+  it("Atom.streamResult", async () => {
     const count = Atom.make(0)
-    const multiplied = Atom.make((get) => get.stream(count).pipe(Stream.map((_) => _ * 2)))
-    const plusOne = Atom.make((get) => get.streamResult(multiplied).pipe(Stream.map((_) => _ + 1)))
+    const multiplied = Atom.make((get) => Atom.stream(get, count).pipe(Stream.map((_) => _ * 2)))
+    const plusOne = Atom.make((get) => Atom.streamResult(get, multiplied).pipe(Stream.map((_) => _ + 1)))
 
     const r = AtomRegistry.make()
     const cancel = r.mount(plusOne)

--- a/packages/tools/bundle/fixtures/atom-runtime.ts
+++ b/packages/tools/bundle/fixtures/atom-runtime.ts
@@ -1,0 +1,17 @@
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import * as Atom from "effect/unstable/reactivity/Atom"
+import * as AtomRegistry from "effect/unstable/reactivity/AtomRegistry"
+
+interface Users {
+  readonly list: Effect.Effect<ReadonlyArray<number>>
+}
+const Users = Context.Service<Users>("Users")
+const UsersLayer = Layer.succeed(Users, { list: Effect.succeed([1, 2, 3]) })
+
+const runtime = Atom.runtime(UsersLayer)
+const users = runtime.atom(Users.use((u) => u.list))
+
+const registry = AtomRegistry.make()
+registry.get(users)

--- a/packages/tools/bundle/fixtures/atom.ts
+++ b/packages/tools/bundle/fixtures/atom.ts
@@ -1,0 +1,12 @@
+import * as Effect from "effect/Effect"
+import * as Atom from "effect/unstable/reactivity/Atom"
+import * as AtomRegistry from "effect/unstable/reactivity/AtomRegistry"
+
+const count = Atom.make(0)
+const double = Atom.make((get) => get(count) * 2)
+const effectful = Atom.make(Effect.succeed(123))
+
+const registry = AtomRegistry.make()
+registry.set(count, 1)
+registry.get(double)
+registry.get(effectful)


### PR DESCRIPTION
## Summary

Optimizes the Atom modules for bundle size. The atom context `stream` / `streamResult` methods lived on the shared `Lifetime` prototype in `AtomRegistry.ts`, so **every** atom user retained the `Stream`, `Queue`, and `Channel` machinery, even for a plain synchronous state atom.

This PR moves them to standalone, tree-shakeable functions:

```ts
// before
Atom.make((get) => get.stream(count))
Atom.make((get) => get.streamResult(result))

// after
Atom.make((get) => Atom.stream(get, count))
Atom.make((get) => Atom.streamResult(get, result))
```

The atom context now also exposes a readonly `disposed` flag (used by `Atom.stream` to preserve the previous disposed-context behavior of returning `Stream.empty`).

## Bundle size impact (minified + gzip, via the repo bundle tooling)

| Fixture | Before | After |
|:--|:--|:--|
| state atom + registry | 16.71 KB | 12.79 KB (−23%) |
| effect atom | 16.79 KB | 12.87 KB (−23%) |
| `Atom.runtime` + service atom | 24.01 KB | 22.85 KB (−5%) |

Also adds `atom.ts` and `atom-runtime.ts` bundle fixtures so CI tracks these sizes going forward.

## Possible follow-up

`RuntimeProto.pull` and `RuntimeProto.subscriptionRef` have the same structural issue: every `Atom.runtime` user retains the stream-pull and `SubscriptionRef` machinery. Removing them from the prototype (measured by patching dist) takes the runtime fixture from 22.85 KB to 20.09 KB (−12%). Left out of this PR since it reshapes the `AtomRuntime` API surface; happy to do it as a follow-up if wanted.

## Validation

- `pnpm check` clean
- `pnpm vitest --run packages/effect/test/reactivity/` — 112 tests pass
- `pnpm lint-fix` on changed files

Closes EFF-663

🤖 Generated with [Claude Code](https://claude.com/claude-code)
