### PR TITLE
Support max reasoning and compatible provider quota errors

### DIFF
--- a/.changeset/openai-compatible-quota-errors.md
+++ b/.changeset/openai-compatible-quota-errors.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai": patch
+---
+
+Support max reasoning effort and quota errors returned by OpenAI-compatible providers.

--- a/packages/ai/openai/src/OpenAiSchema.ts
+++ b/packages/ai/openai/src/OpenAiSchema.ts
@@ -662,7 +662,7 @@ export const CreateResponse = Schema.Struct({
   previous_response_id: Schema.optional(Schema.String),
   model: Schema.optional(Schema.String),
   reasoning: Schema.optional(Schema.Struct({
-    effort: Schema.optional(Schema.Literals(["none", "minimal", "low", "medium", "high", "xhigh"])),
+    effort: Schema.optional(Schema.Literals(["none", "minimal", "low", "medium", "high", "xhigh", "max"])),
 
     summary: Schema.optional(Schema.Literals(["auto", "concise", "detailed"])),
     generate_summary: Schema.optional(Schema.Literals(["auto", "concise", "detailed"]))

--- a/packages/ai/openai/src/internal/errors.ts
+++ b/packages/ai/openai/src/internal/errors.ts
@@ -28,6 +28,11 @@ export const OpenAiErrorBody = Schema.Struct({
   })
 })
 
+const OpenAiCompatibleErrorBody = Schema.Struct({
+  error: Schema.String,
+  code: Schema.optional(Schema.String)
+})
+
 // =============================================================================
 // Error Mappers
 // =============================================================================
@@ -147,14 +152,25 @@ const mapStatusCodeError = Effect.fnUntraced(function*(
     json = undefined
   }
   const decoded = Schema.decodeUnknownOption(OpenAiErrorBody)(json)
+  const compatibleDecoded = Schema.decodeUnknownOption(OpenAiCompatibleErrorBody)(json)
+  const message = Option.isSome(decoded)
+    ? decoded.value.error.message
+    : Option.isSome(compatibleDecoded)
+    ? compatibleDecoded.value.error
+    : undefined
+  const errorCode = Option.isSome(decoded)
+    ? decoded.value.error.code ?? null
+    : Option.isSome(compatibleDecoded)
+    ? compatibleDecoded.value.code ?? null
+    : null
 
   const reason = mapStatusCodeToReason({
     status,
     headers,
-    message: Option.isSome(decoded) ? decoded.value.error.message : undefined,
+    message,
     http: buildHttpContext({ request, response, body }),
     metadata: {
-      errorCode: Option.isSome(decoded) ? decoded.value.error.code ?? null : null,
+      errorCode,
       errorType: Option.isSome(decoded) ? decoded.value.error.type ?? null : null,
       requestId: requestId ?? null
     }
@@ -321,11 +337,18 @@ export const mapStatusCodeToReason = ({ status, headers, message, metadata, http
         metadata: { openai: metadata },
         http
       })
+    case 402:
+      return new AiError.QuotaExhaustedError({
+        metadata: { openai: metadata },
+        http
+      })
     case 429: {
       // Best-effort detection: OpenAI returns insufficient_quota for billing/quota issues
       if (
         metadata.errorCode === "insufficient_quota" ||
-        metadata.errorType === "insufficient_quota"
+        metadata.errorType === "insufficient_quota" ||
+        metadata.errorCode === "billing_insufficient_balance" ||
+        metadata.errorType === "billing_insufficient_balance"
       ) {
         return new AiError.QuotaExhaustedError({
           metadata: { openai: metadata },

--- a/packages/ai/openai/test/OpenAiClient.test.ts
+++ b/packages/ai/openai/test/OpenAiClient.test.ts
@@ -348,6 +348,34 @@ describe("OpenAiClient", () => {
         }
       }))))
 
+    it.effect("maps OpenAI-compatible 402 errors to QuotaExhaustedError", () =>
+      Effect.gen(function*() {
+        const client = yield* OpenAiClient.OpenAiClient
+        const result = yield* client.createResponse({ model: "grok-4", input: "test" }).pipe(Effect.flip)
+
+        assert.strictEqual(result._tag, "AiError")
+        assert.strictEqual(result.reason._tag, "QuotaExhaustedError")
+        assert.isFalse(result.isRetryable)
+      }).pipe(Effect.provide(makeTestLayer(undefined, {
+        _tag: "Json",
+        status: 402,
+        body: { error: "Your balance is too low", code: "billing_insufficient_balance" }
+      }))))
+
+    it.effect("maps OpenAI-compatible insufficient balance errors to QuotaExhaustedError", () =>
+      Effect.gen(function*() {
+        const client = yield* OpenAiClient.OpenAiClient
+        const result = yield* client.createResponse({ model: "grok-4", input: "test" }).pipe(Effect.flip)
+
+        assert.strictEqual(result._tag, "AiError")
+        assert.strictEqual(result.reason._tag, "QuotaExhaustedError")
+        assert.isFalse(result.isRetryable)
+      }).pipe(Effect.provide(makeTestLayer(undefined, {
+        _tag: "Json",
+        status: 429,
+        body: { error: "Your balance is too low", code: "billing_insufficient_balance" }
+      }))))
+
     it("mapStatusCodeToReason detects insufficient_quota as QuotaExhaustedError", () => {
       const http = {
         request: {
@@ -585,6 +613,9 @@ type MockResponse =
         readonly type?: string
         readonly code?: string | null
       }
+    } | {
+      readonly error: string
+      readonly code?: string
     }
     readonly status?: number | undefined
     readonly headers?: Record<string, string> | undefined

--- a/packages/ai/openai/test/OpenAiSchema.test.ts
+++ b/packages/ai/openai/test/OpenAiSchema.test.ts
@@ -17,6 +17,14 @@ const makeResponse = (overrides: Record<string, unknown> = {}) => ({
 })
 
 describe("OpenAiSchema", () => {
+  it("accepts max reasoning effort", () => {
+    const decoded = Schema.decodeUnknownSync(OpenAiSchema.CreateResponse)({
+      reasoning: { effort: "max" }
+    })
+
+    assert.strictEqual(decoded.reasoning?.effort, "max")
+  })
+
   it("decodes a representative response payload", () => {
     const decoded = Schema.decodeUnknownSync(OpenAiSchema.Response)({
       ...makeResponse(),


### PR DESCRIPTION
## Summary
- accept `max` as a Responses API reasoning effort
- decode the flat `{ error, code }` error payload used by OpenAI-compatible providers such as xAI
- classify HTTP 402 and `billing_insufficient_balance` responses as non-retryable quota exhaustion
- add focused request-schema and client error-mapping coverage

## Context
`@effect/ai-openai` is also used with OpenAI-compatible endpoints. xAI can return billing errors as HTTP 402 with a flat `{ error: string, code?: string }` body, or use the `billing_insufficient_balance` code. Without decoding that shape, the useful provider message and code are lost and the error is classified incorrectly.

I searched existing and merged PRs in the Effect repositories before opening this and did not find a proposal covering these cases.

## Verification
- `pnpm lint-fix`
- `pnpm test packages/ai/openai/test/OpenAiClient.test.ts packages/ai/openai/test/OpenAiSchema.test.ts`
- `pnpm check`