### PR TITLE
fix(ai-openai): decode nested Responses API error stream events

### DIFF
--- a/.changeset/openai-tolerant-error-stream-event.md
+++ b/.changeset/openai-tolerant-error-stream-event.md
@@ -1,0 +1,9 @@
+---
+"@effect/ai-openai": patch
+---
+
+Decode OpenAI Responses API `error` stream events whose payload is nested under `error`.
+
+The Responses API documents the `error` stream event with `code`, `message`, and `param` at the top level, but mid-stream errors (for example quota exhaustion) instead emit the standard error envelope nested under `error` — `{ "type": "error", "error": { "code", "message", "param", ... }, "sequence_number" }`. The strict schema only matched the flat shape, so a nested error event failed to decode and aborted the whole stream with an opaque schema error (`Expected UnknownResponseStreamEvent … Missing key at ["data"]["code"]`) instead of surfacing the actual error.
+
+`ResponseErrorEvent` now accepts both wire shapes and normalizes them to the documented shape, so the error's `code` and `message` always surface and the decoded type is unchanged.

--- a/.changeset/openai-tolerant-error-stream-event.md
+++ b/.changeset/openai-tolerant-error-stream-event.md
@@ -2,8 +2,4 @@
 "@effect/ai-openai": patch
 ---
 
-Decode OpenAI Responses API `error` stream events whose payload is nested under `error`.
-
-The Responses API documents the `error` stream event with `code`, `message`, and `param` at the top level, but mid-stream errors (for example quota exhaustion) instead emit the standard error envelope nested under `error` — `{ "type": "error", "error": { "code", "message", "param", ... }, "sequence_number" }`. The strict schema only matched the flat shape, so a nested error event failed to decode and aborted the whole stream with an opaque schema error (`Expected UnknownResponseStreamEvent … Missing key at ["data"]["code"]`) instead of surfacing the actual error.
-
-`ResponseErrorEvent` now accepts both wire shapes and normalizes them to the documented shape, so the error's `code` and `message` always surface and the decoded type is unchanged.
+Decode nested OpenAI Responses API error events without changing their decoded type.

--- a/packages/ai/openai/src/OpenAiSchema.ts
+++ b/packages/ai/openai/src/OpenAiSchema.ts
@@ -9,6 +9,7 @@
 import * as Effect from "effect/Effect"
 import * as Predicate from "effect/Predicate"
 import * as Schema from "effect/Schema"
+import * as SchemaTransformation from "effect/SchemaTransformation"
 
 const UnknownRecord = Schema.Record(Schema.String, Schema.Unknown)
 
@@ -1032,7 +1033,7 @@ const ResponseImageGenerationCallPartialImageEvent = Schema.Struct({
   partial_image_b64: Schema.String
 })
 
-const ResponseErrorEvent = Schema.Struct({
+const ResponseErrorEventDecoded = Schema.Struct({
   type: Schema.Literal("error"),
   code: Schema.NullOr(Schema.String),
   message: Schema.String,
@@ -1040,6 +1041,43 @@ const ResponseErrorEvent = Schema.Struct({
   sequence_number: Schema.Int,
   status: Schema.optionalKey(Schema.Int)
 })
+
+// The Responses API documents the `error` stream event with `code`, `message`,
+// and `param` at the top level, but mid-stream errors (for example quota
+// exhaustion) instead emit the standard error envelope nested under `error`
+// (`{ type: "error", error: { code, message, param, ... }, sequence_number }`).
+// Accept both wire shapes and normalize them to the documented shape, so an
+// error event — the one event that most needs to surface — never fails to
+// decode and abort the whole stream with an opaque schema error.
+const ResponseErrorEvent = Schema.Struct({
+  type: Schema.Literal("error"),
+  code: Schema.optionalKey(Schema.NullOr(Schema.String)),
+  message: Schema.optionalKey(Schema.String),
+  param: Schema.optionalKey(Schema.NullOr(Schema.String)),
+  sequence_number: Schema.optionalKey(Schema.Int),
+  status: Schema.optionalKey(Schema.Int),
+  error: Schema.optionalKey(Schema.Struct({
+    type: Schema.optionalKey(Schema.NullOr(Schema.String)),
+    code: Schema.optionalKey(Schema.NullOr(Schema.String)),
+    message: Schema.optionalKey(Schema.String),
+    param: Schema.optionalKey(Schema.NullOr(Schema.String))
+  }))
+}).pipe(
+  Schema.decodeTo(
+    ResponseErrorEventDecoded,
+    SchemaTransformation.transform({
+      decode: (input) => ({
+        type: "error" as const,
+        code: input.code ?? input.error?.code ?? null,
+        message: input.message ?? input.error?.message ?? "An unknown error occurred",
+        param: input.param ?? input.error?.param ?? null,
+        sequence_number: input.sequence_number ?? 0,
+        ...(input.status !== undefined ? { status: input.status } : {})
+      }),
+      encode: (value) => value
+    })
+  )
+)
 
 const knownResponseStreamEventTypes = new Set([
   "response.created",

--- a/packages/ai/openai/src/OpenAiSchema.ts
+++ b/packages/ai/openai/src/OpenAiSchema.ts
@@ -1033,7 +1033,7 @@ const ResponseImageGenerationCallPartialImageEvent = Schema.Struct({
   partial_image_b64: Schema.String
 })
 
-const ResponseErrorEventDecoded = Schema.Struct({
+const ResponseErrorEvent = Schema.Struct({
   type: Schema.Literal("error"),
   code: Schema.NullOr(Schema.String),
   message: Schema.String,
@@ -1042,39 +1042,22 @@ const ResponseErrorEventDecoded = Schema.Struct({
   status: Schema.optionalKey(Schema.Int)
 })
 
-// The Responses API documents the `error` stream event with `code`, `message`,
-// and `param` at the top level, but mid-stream errors (for example quota
-// exhaustion) instead emit the standard error envelope nested under `error`
-// (`{ type: "error", error: { code, message, param, ... }, sequence_number }`).
-// Accept both wire shapes and normalize them to the documented shape, so an
-// error event — the one event that most needs to surface — never fails to
-// decode and abort the whole stream with an opaque schema error.
-const ResponseErrorEvent = Schema.Struct({
+// OpenAI can nest stream error details under `error`.
+const NestedResponseErrorEvent = Schema.Struct({
   type: Schema.Literal("error"),
-  code: Schema.optionalKey(Schema.NullOr(Schema.String)),
-  message: Schema.optionalKey(Schema.String),
-  param: Schema.optionalKey(Schema.NullOr(Schema.String)),
-  sequence_number: Schema.optionalKey(Schema.Int),
-  status: Schema.optionalKey(Schema.Int),
-  error: Schema.optionalKey(Schema.Struct({
-    type: Schema.optionalKey(Schema.NullOr(Schema.String)),
-    code: Schema.optionalKey(Schema.NullOr(Schema.String)),
-    message: Schema.optionalKey(Schema.String),
-    param: Schema.optionalKey(Schema.NullOr(Schema.String))
-  }))
+  error: Schema.Struct({
+    code: Schema.NullOr(Schema.String),
+    message: Schema.String,
+    param: Schema.NullOr(Schema.String)
+  }),
+  sequence_number: Schema.Int,
+  status: Schema.optionalKey(Schema.Int)
 }).pipe(
   Schema.decodeTo(
-    ResponseErrorEventDecoded,
+    ResponseErrorEvent,
     SchemaTransformation.transform({
-      decode: (input) => ({
-        type: "error" as const,
-        code: input.code ?? input.error?.code ?? null,
-        message: input.message ?? input.error?.message ?? "An unknown error occurred",
-        param: input.param ?? input.error?.param ?? null,
-        sequence_number: input.sequence_number ?? 0,
-        ...(input.status !== undefined ? { status: input.status } : {})
-      }),
-      encode: (value) => value
+      decode: ({ error, ...rest }) => ({ ...rest, ...error }),
+      encode: ({ code, message, param, ...rest }) => ({ ...rest, error: { code, message, param } })
     })
   )
 )
@@ -1167,6 +1150,7 @@ export const ResponseStreamEvent = Schema.Union([
   ResponseApplyPatchCallOperationDiffDoneEvent,
   ResponseImageGenerationCallPartialImageEvent,
   ResponseErrorEvent,
+  NestedResponseErrorEvent,
   UnknownResponseStreamEvent
 ])
 

--- a/packages/ai/openai/test/OpenAiSchema.test.ts
+++ b/packages/ai/openai/test/OpenAiSchema.test.ts
@@ -283,6 +283,45 @@ describe("OpenAiSchema", () => {
       assert.isDefined(malformed)
     }))
 
+  it("decodes the error event whether the payload is flat or nested under `error`", () => {
+    // The documented shape carries `code`/`message`/`param` at the top level.
+    const flat = Schema.decodeUnknownSync(OpenAiSchema.ResponseStreamEvent)({
+      type: "error",
+      code: "ERR",
+      message: "boom",
+      param: null,
+      sequence_number: 1
+    })
+    assert.deepStrictEqual(flat, {
+      type: "error",
+      code: "ERR",
+      message: "boom",
+      param: null,
+      sequence_number: 1
+    })
+
+    // Mid-stream errors (e.g. quota exhaustion) instead nest the standard error
+    // envelope under `error`. This must decode too — not abort the stream — and
+    // normalize to the documented shape so the message and code still surface.
+    const nested = Schema.decodeUnknownSync(OpenAiSchema.ResponseStreamEvent)({
+      type: "error",
+      error: {
+        type: "insufficient_quota",
+        code: "credit_balance_exhausted",
+        message: "You have no credits remaining.",
+        param: null
+      },
+      sequence_number: 2
+    })
+    assert.deepStrictEqual(nested, {
+      type: "error",
+      code: "credit_balance_exhausted",
+      message: "You have no credits remaining.",
+      param: null,
+      sequence_number: 2
+    })
+  })
+
   it("decodes embedding response variants (numeric + string/base64)", () => {
     const numeric = Schema.decodeUnknownSync(OpenAiSchema.CreateEmbeddingResponse)({
       object: "list",

--- a/packages/ai/openai/test/OpenAiSchema.test.ts
+++ b/packages/ai/openai/test/OpenAiSchema.test.ts
@@ -284,7 +284,6 @@ describe("OpenAiSchema", () => {
     }))
 
   it("decodes the error event whether the payload is flat or nested under `error`", () => {
-    // The documented shape carries `code`/`message`/`param` at the top level.
     const flat = Schema.decodeUnknownSync(OpenAiSchema.ResponseStreamEvent)({
       type: "error",
       code: "ERR",
@@ -300,9 +299,6 @@ describe("OpenAiSchema", () => {
       sequence_number: 1
     })
 
-    // Mid-stream errors (e.g. quota exhaustion) instead nest the standard error
-    // envelope under `error`. This must decode too — not abort the stream — and
-    // normalize to the documented shape so the message and code still surface.
     const nested = Schema.decodeUnknownSync(OpenAiSchema.ResponseStreamEvent)({
       type: "error",
       error: {
@@ -320,7 +316,76 @@ describe("OpenAiSchema", () => {
       param: null,
       sequence_number: 2
     })
+
+    const nestedWithStatus = Schema.decodeUnknownSync(OpenAiSchema.ResponseStreamEvent)({
+      type: "error",
+      error: {
+        code: "rate_limited",
+        message: "Too many requests.",
+        param: null
+      },
+      sequence_number: 3,
+      status: 429
+    })
+    assert.deepStrictEqual(nestedWithStatus, {
+      type: "error",
+      code: "rate_limited",
+      message: "Too many requests.",
+      param: null,
+      sequence_number: 3,
+      status: 429
+    })
   })
+
+  it.effect("rejects error events missing spec-required fields", () =>
+    Effect.gen(function*() {
+      const malformed = [
+        { type: "error" },
+        { type: "error", error: {}, sequence_number: 3 },
+        { type: "error", error: { code: "x" }, sequence_number: 3 }
+      ]
+      for (const event of malformed) {
+        const failure = yield* Schema.decodeUnknownEffect(OpenAiSchema.ResponseStreamEvent)(event).pipe(Effect.flip)
+        assert.isDefined(failure)
+      }
+    }))
+
+  it.effect("surfaces nested error events in SSE decoding instead of aborting the stream", () =>
+    Effect.gen(function*() {
+      const sseBody = [
+        {
+          type: "response.created",
+          sequence_number: 1,
+          response: makeResponse({ status: "in_progress" })
+        },
+        {
+          type: "error",
+          error: {
+            type: "insufficient_quota",
+            code: "credit_balance_exhausted",
+            message: "You have no credits remaining.",
+            param: null
+          },
+          sequence_number: 2
+        }
+      ].map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")
+
+      const events = yield* Stream.fromIterable([sseBody]).pipe(
+        Stream.pipeThroughChannel(Sse.decodeDataSchema(OpenAiSchema.ResponseStreamEvent)),
+        Stream.map((event) => event.data),
+        Stream.runCollect
+      )
+
+      const decoded = globalThis.Array.from(events)
+      assert.strictEqual(decoded.length, 2)
+      assert.deepStrictEqual(decoded[1], {
+        type: "error",
+        code: "credit_balance_exhausted",
+        message: "You have no credits remaining.",
+        param: null,
+        sequence_number: 2
+      })
+    }))
 
   it("decodes embedding response variants (numeric + string/base64)", () => {
     const numeric = Schema.decodeUnknownSync(OpenAiSchema.CreateEmbeddingResponse)({


### PR DESCRIPTION
## What

The OpenAI Responses API documents the `error` stream event with `code`, `message`, and `param` at the **top level**, and `OpenAiSchema.ResponseErrorEvent` matches exactly that:

```ts
Schema.Struct({
  type: Schema.Literal("error"),
  code: Schema.NullOr(Schema.String),
  message: Schema.String,
  param: Schema.NullOr(Schema.String),
  sequence_number: Schema.Int,
  status: Schema.optionalKey(Schema.Int)
})
```

But mid-stream errors are emitted with the standard error envelope **nested under `error`**. Here is the `data` payload of a real `event: error` frame captured from `POST /v1/responses` (`stream: true`) when the account is out of credits:

```jsonc
{
  "type": "error",
  "error": {
    "type": "insufficient_quota",
    "code": "credit_balance_exhausted",
    "message": "You have no credits remaining. Add credits to continue using the API…",
    "param": null
  },
  "sequence_number": 2
}
```

`code`, `message`, and `param` are absent at the top level here, so the event fails to decode. Because `ResponseStreamEvent` is decoded with `Sse.decodeDataSchema`, that single failing event **aborts the entire stream** with an opaque schema error instead of surfacing the real problem:

```
OpenAiClient.createResponseStream: Invalid output: Missing key
  at ["data"]["code"]
Expected UnknownResponseStreamEvent
  at ["data"]
```

The `UnknownResponseStreamEvent` fallback deliberately excludes known event types (including `"error"`), so a nested-shape error event can't fall through it either — the caller just sees the message above instead of "no credits". The error event is the one event that most needs to surface, so hard-failing on it is especially unfortunate.

## Fix

`ResponseErrorEvent` now accepts **both** wire shapes and normalizes them to the documented shape via `Schema.decodeTo`:

- flat/spec payloads decode unchanged;
- nested payloads have `code` / `message` / `param` lifted from the `error` envelope;
- the **decoded `Type` is unchanged** — only the accepted `Encoded` shape widens — so there is no downstream type change (the union member's `.Type` stays `{ type, code, message, param, sequence_number, status? }`).

This keeps the existing strictness for other events (the "does not silently decode malformed known events as unknown" test still holds); it only teaches the `error` event about OpenAI's actual second shape.

## Test

Adds a case to `packages/ai/openai/test/OpenAiSchema.test.ts` that decodes `ResponseStreamEvent` for both the flat and the nested error payloads, asserting the nested one normalizes to the documented shape.

## Note

I validated the schema and transform in isolation — both shapes, and as a union member alongside a known sibling and the unknown fallback — typechecking clean under `strict` + `exactOptionalPropertyTypes`. I was not able to run the full monorepo build locally, so please let CI confirm formatting / lint.