### PR TITLE
Fix SQLite persisted queue delivery

### DIFF
--- a/.changeset/fix-sqlite-persisted-queue.md
+++ b/.changeset/fix-sqlite-persisted-queue.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix SQL persisted queue delivery on SQLite builds without `SQLITE_ENABLE_UPDATE_DELETE_LIMIT`.

--- a/packages/effect/src/unstable/persistence/PersistedQueue.ts
+++ b/packages/effect/src/unstable/persistence/PersistedQueue.ts
@@ -1031,6 +1031,7 @@ export const makeStoreSql: (
           yield* Effect.yieldNow
         }
       }).pipe(
+        Effect.tapCause(Effect.logWarning),
         Effect.sandbox,
         Effect.retry(Schedule.spaced(500)),
         Effect.forkScoped

--- a/packages/effect/src/unstable/persistence/PersistedQueue.ts
+++ b/packages/effect/src/unstable/persistence/PersistedQueue.ts
@@ -999,13 +999,16 @@ export const makeStoreSql: (
           sql<Element>`
             UPDATE ${tableNameSql}
             SET acquired_at = ${sqlNow}, acquired_by = ${workerIdSql}
-            WHERE queue_name = ${name}
-            AND completed = FALSE
-            AND attempts < ${maxAttempts}
-            AND (acquired_at IS NULL OR acquired_at < ${expiresAt})
+            WHERE sequence IN (
+              SELECT sequence FROM ${tableNameSql}
+              WHERE queue_name = ${name}
+              AND completed = FALSE
+              AND attempts < ${maxAttempts}
+              AND (acquired_at IS NULL OR acquired_at < ${expiresAt})
+              ORDER BY updated_at ASC, sequence ASC
+              LIMIT ${sql.literal(size.toString())}
+            )
             RETURNING sequence, id, queue_name, element, attempts
-            ORDER BY updated_at ASC, sequence ASC
-            LIMIT ${sql.literal(size.toString())}
           `
       })
 

--- a/packages/sql/sqlite-node/test/Persistence.test.ts
+++ b/packages/sql/sqlite-node/test/Persistence.test.ts
@@ -2,9 +2,10 @@ import { NodeFileSystem } from "@effect/platform-node"
 import { SqliteClient } from "@effect/sql-sqlite-node"
 import { assert, expect, it } from "@effect/vitest"
 import { Duration, Effect, FileSystem, Layer } from "effect"
+import * as PersistedQueueTest from "effect-test/unstable/persistence/PersistedQueueTest"
 import * as SqlCleanupTest from "effect-test/unstable/persistence/SqlCleanupTest"
 import { TestClock } from "effect/testing"
-import { Persistence } from "effect/unstable/persistence"
+import { PersistedQueue, Persistence } from "effect/unstable/persistence"
 import { Reactivity } from "effect/unstable/reactivity"
 import * as SqlClient from "effect/unstable/sql/SqlClient"
 
@@ -117,6 +118,11 @@ const suite = (name: string, layer: Layer.Layer<Persistence.BackingPersistence, 
 
 suite("table-per-store", Persistence.layerBackingSqlMultiTable)
 suite("single-table", Persistence.layerBackingSql)
+
+PersistedQueueTest.suite(
+  "sql-sqlite-node",
+  PersistedQueue.layerStoreSql().pipe(Layer.provide(ClientLayer))
+)
 
 it.layer(ClientLayer)("Persistence SQL cleanup", (it) => {
   it.effect("deletes expired entries in batches", () =>


### PR DESCRIPTION
## Summary

- make SQLite persisted queue acquisition portable across builds without `SQLITE_ENABLE_UPDATE_DELETE_LIMIT`
- log SQL poll failures before the polling loop retries
- add SQLite dialect and delivery coverage by running the shared persisted queue suite against `@effect/sql-sqlite-node`

## Root cause

The SQLite fallback appended `ORDER BY` and `LIMIT` directly to an `UPDATE ... RETURNING` statement. That syntax is only available when SQLite is compiled with the optional `SQLITE_ENABLE_UPDATE_DELETE_LIMIT` extension, so the polling query failed on affected Node SQLite builds and queue consumers waited indefinitely without an observable error.

The acquisition query now selects its ordered, limited batch in a subquery before updating those rows. Poll failures are logged before the existing retry schedule continues.

## Coverage

The shared persisted queue suite now runs against the real SQLite dialect in the default test run, covering queue delivery behavior through `@effect/sql-sqlite-node`.

## Verification

- `nix develop -c pnpm test --run packages/sql/sqlite-node/test/Persistence.test.ts`
- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`

Closes EFF-665
Closes #7264