### PR TITLE
Allow customizing CLI prompt prefixes

### DIFF
--- a/.changeset/custom-cli-prompt-prefix.md
+++ b/.changeset/custom-cli-prompt-prefix.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Allow customizing the prefix displayed by CLI prompts.

--- a/.changeset/custom-cli-prompt-symbol.md
+++ b/.changeset/custom-cli-prompt-symbol.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Allow customizing the symbol displayed by CLI prompts.

--- a/.changeset/custom-cli-prompt-symbol.md
+++ b/.changeset/custom-cli-prompt-symbol.md
@@ -1,5 +1,0 @@
----
-"effect": patch
----
-
-Allow customizing the symbol displayed by CLI prompts.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -160,6 +160,10 @@ export interface ConfirmOptions {
    */
   readonly message: string
   /**
+   * The symbol to display at the start of the prompt (defaults to `"?"`).
+   */
+  readonly symbol?: string
+  /**
    * The initial value of the confirm prompt (defaults to `false`).
    */
   readonly initial?: boolean
@@ -205,6 +209,10 @@ export interface DateOptions {
    * The message to display in the prompt.
    */
   readonly message: string
+  /**
+   * The symbol to display at the start of the prompt (defaults to `"?"`).
+   */
+  readonly symbol?: string
   /**
    * The initial date value to display in the prompt (defaults to the current
    * date).
@@ -280,6 +288,10 @@ export interface IntegerOptions {
    * The message to display in the prompt.
    */
   readonly message: string
+  /**
+   * The symbol to display at the start of the prompt (defaults to `"?"`).
+   */
+  readonly symbol?: string
   /**
    * The default value of the integer prompt.
    */
@@ -362,6 +374,10 @@ export interface FileOptions {
    */
   readonly message?: string
   /**
+   * The symbol to display at the start of the prompt (defaults to `"?"`).
+   */
+  readonly symbol?: string
+  /**
    * Where the user will initially be prompted to select files from, defaulting
    * to the current working directory.
    */
@@ -393,6 +409,10 @@ export interface SelectOptions<A> {
    * The message to display in the prompt.
    */
   readonly message: string
+  /**
+   * The symbol to display at the start of the prompt (defaults to `"?"`).
+   */
+  readonly symbol?: string
   /**
    * The choices to display to the user.
    */
@@ -499,6 +519,10 @@ export interface TextOptions {
    */
   readonly message: string
   /**
+   * The symbol to display at the start of the prompt (defaults to `"?"`).
+   */
+  readonly symbol?: string
+  /**
    * The default value of the text option.
    */
   readonly default?: string
@@ -521,6 +545,10 @@ export interface ToggleOptions {
    * The message to display in the prompt.
    */
   readonly message: string
+  /**
+   * The symbol to display at the start of the prompt (defaults to `"?"`).
+   */
+  readonly symbol?: string
   /**
    * The intitial value of the toggle prompt (defaults to `false`).
    */
@@ -745,6 +773,7 @@ const annotateErrorLine = (line: string): string => Ansi.annotate(line, Ansi.com
 export const confirm = (options: ConfirmOptions): Prompt<boolean> => {
   const opts: Required<ConfirmOptions> = {
     initial: false,
+    symbol: "?",
     ...options,
     label: {
       confirm: "yes",
@@ -841,6 +870,7 @@ export const date = (options: DateOptions): Prompt<Date> => {
   const opts: Required<DateOptions> = {
     initial: new Date(),
     dateMask: "YYYY-MM-DD HH:mm:ss",
+    symbol: "?",
     validate: Effect.succeed,
     ...options,
     locales: {
@@ -879,6 +909,7 @@ export const file = (options: FileOptions = {}): Prompt<string> => {
   const opts: FileOptionsReq = {
     type: options.type ?? "file",
     message: options.message ?? `Choose a file`,
+    symbol: options.symbol ?? "?",
     startingPath: Option.fromUndefinedOr(options.startingPath),
     default: Option.fromUndefinedOr(options.default),
     maxPerPage: options.maxPerPage ?? 10,
@@ -953,6 +984,7 @@ export const flatMap: {
 export const float = (options: FloatOptions): Prompt<number> => {
   const opts: FloatOptionsReq = {
     default: 0,
+    symbol: "?",
     min: Number.NEGATIVE_INFINITY,
     max: Number.POSITIVE_INFINITY,
     incrementBy: 1,
@@ -1006,6 +1038,7 @@ export const hidden = (
 export const integer = (options: IntegerOptions): Prompt<number> => {
   const opts: IntegerOptionsReq = {
     default: 0,
+    symbol: "?",
     min: Number.NEGATIVE_INFINITY,
     max: Number.POSITIVE_INFINITY,
     incrementBy: 1,
@@ -1136,6 +1169,7 @@ const getSelectInitialIndex = <A>(choices: ReadonlyArray<SelectChoice<A>>): numb
 export const select = <const A>(options: SelectOptions<A>): Prompt<A> => {
   const opts: SelectOptionsReq<A> = {
     maxPerPage: 10,
+    symbol: "?",
     ...options
   }
   const initialIndex = getSelectInitialIndex(opts.choices)
@@ -1172,6 +1206,7 @@ export const select = <const A>(options: SelectOptions<A>): Prompt<A> => {
 export const autoComplete = <const A>(options: AutoCompleteOptions<A>): Prompt<A> => {
   const opts: AutoCompleteOptionsReq<A> = {
     maxPerPage: 10,
+    symbol: "?",
     filterLabel: "filter",
     filterPlaceholder: "type to filter",
     emptyMessage: "No matches",
@@ -1213,6 +1248,7 @@ export const multiSelect = <const A>(
 ): Prompt<Array<A>> => {
   const opts: SelectOptionsReq<A> & MultiSelectOptionsReq = {
     maxPerPage: 10,
+    symbol: "?",
     ...options
   }
   // Seed initial selection from choices marked as selected: true
@@ -1270,6 +1306,7 @@ export const text = (
 export const toggle = (options: ToggleOptions): Prompt<boolean> => {
   const opts: ToggleOptionsReq = {
     initial: false,
+    symbol: "?",
     active: "on",
     inactive: "off",
     ...options
@@ -1468,7 +1505,7 @@ const handleConfirmClear = (options: ConfirmOptionsReq) => {
       : options.placeholder.defaultDeny!
     const promptText = renderConfirmOutput(
       confirmMessage,
-      "?",
+      options.symbol,
       figures.pointerSmall,
       options,
       { plain: true }
@@ -1489,7 +1526,7 @@ const renderConfirmOutput = (
 
 const renderConfirmNextFrame = Effect.fnUntraced(function*(state: ConfirmState, options: ConfirmOptionsReq) {
   const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate("?", Ansi.cyanBright)
+  const leadingSymbol = Ansi.annotate(options.symbol, Ansi.cyanBright)
   const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
   // Marking these explicitly as present with `!` because they always will be
   // and there is really no value in adding a `DeepRequired` type helper just
@@ -1555,7 +1592,7 @@ const handleDateClear = (options: DateOptionsReq) => {
     const figures = yield* platformFigures
     const resetCurrentLine = Ansi.eraseLine + Ansi.cursorLeft
     const parts = Arr.reduce(state.dateParts, "", (doc, part) => doc + part.toString())
-    const promptText = renderDateOutput("?", figures.pointerSmall, parts, options, { plain: true })
+    const promptText = renderDateOutput(options.symbol, figures.pointerSmall, parts, options, { plain: true })
     const errorText = Option.isSome(state.error)
       ? Arr.match(state.error.value.split(NEWLINE_REGEXP), {
         onEmpty: () => "",
@@ -1604,7 +1641,7 @@ const renderDateOutput = (
 
 const renderDateNextFrame = Effect.fnUntraced(function*(state: DateState, options: DateOptionsReq) {
   const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate("?", Ansi.cyanBright)
+  const leadingSymbol = Ansi.annotate(options.symbol, Ansi.cyanBright)
   const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
   const parts = renderParts(state)
   const promptMsg = renderDateOutput(leadingSymbol, trailingSymbol, parts, options)
@@ -2205,7 +2242,7 @@ const handleFileClear = (options: FileOptionsReq) => {
     const resolvedPathText = `${figures.pointerSmall} ${resolvedPath}`
     const isConfirming = showConfirmation(state.confirm)
     const promptText = isConfirming
-      ? renderPrompt("(Y/n)", CONFIRM_MESSAGE, "?", figures.pointerSmall, { plain: true })
+      ? renderPrompt("(Y/n)", CONFIRM_MESSAGE, options.symbol, figures.pointerSmall, { plain: true })
       : renderPrompt(renderFileFilter(state, { plain: true }), options.message, figures.tick, figures.ellipsis, {
         plain: true
       })
@@ -2320,7 +2357,7 @@ const renderFileNextFrame = Effect.fnUntraced(function*(state: FileState, option
   const resolvedPathMsg = Ansi.annotate(figures.pointerSmall + " " + resolvedPath, Ansi.blackBright)
 
   if (showConfirmation(state.confirm)) {
-    const leadingSymbol = Ansi.annotate("?", Ansi.cyanBright)
+    const leadingSymbol = Ansi.annotate(options.symbol, Ansi.cyanBright)
     const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
     const confirm = Ansi.annotate("(Y/n)", Ansi.blackBright)
     const promptMsg = renderPrompt(confirm, CONFIRM_MESSAGE, leadingSymbol, trailingSymbol)
@@ -2618,7 +2655,7 @@ const renderMultiSelectNextFrame = Effect.fnUntraced(
   function*<A>(state: MultiSelectState, options: SelectOptionsReq<A>) {
     const figures = yield* platformFigures
     const choices = renderMultiSelectChoices(state, options, figures)
-    const leadingSymbol = Ansi.annotate("?", Ansi.cyanBright)
+    const leadingSymbol = Ansi.annotate(options.symbol, Ansi.cyanBright)
     const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
     const promptMsg = renderSelectOutput(leadingSymbol, trailingSymbol, options)
     const error = renderMultiSelectError(state, figures.pointer)
@@ -2694,7 +2731,7 @@ const handleMultiSelectClear = <A>(options: SelectOptionsReq<A>) =>
     const columns = yield* terminal.columns
     const figures = yield* platformFigures
     const clearPrompt = Ansi.eraseLine + Ansi.cursorLeft
-    const promptText = renderSelectOutput("?", figures.pointerSmall, options, { plain: true })
+    const promptText = renderSelectOutput(options.symbol, figures.pointerSmall, options, { plain: true })
     const choicesText = renderMultiSelectChoices(state, options, figures, { plain: true })
     const errorText = renderMultiSelectError(state, figures.pointer, { plain: true })
     const clearOutput = clearOutputWithError(`${promptText}\n${choicesText}`, columns, errorText)
@@ -2767,7 +2804,7 @@ const handleNumberClear = (options: IntegerOptionsReq) => {
     const figures = yield* platformFigures
     const resetCurrentLine = Ansi.eraseLine + Ansi.cursorLeft
     const errorText = renderNumberError(state, figures.pointerSmall, { plain: true })
-    const promptText = renderNumberOutput(state, "?", figures.pointerSmall, options, { plain: true })
+    const promptText = renderNumberOutput(state, options.symbol, figures.pointerSmall, options, { plain: true })
     const clearOutput = clearOutputWithError(promptText, columns, errorText)
     return clearOutput + resetCurrentLine
   })
@@ -2823,7 +2860,7 @@ const renderNumberOutput = (
 
 const renderNumberNextFrame = Effect.fnUntraced(function*(state: NumberState, options: IntegerOptionsReq) {
   const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate("?", Ansi.cyanBright)
+  const leadingSymbol = Ansi.annotate(options.symbol, Ansi.cyanBright)
   const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
   const errorMsg = renderNumberError(state, figures.pointerSmall)
   const promptMsg = renderNumberOutput(state, leadingSymbol, trailingSymbol, options)
@@ -3251,7 +3288,7 @@ const renderAutoCompleteChoices = <A>(
 const renderSelectNextFrame = Effect.fnUntraced(function*<A>(state: SelectState, options: SelectOptionsReq<A>) {
   const figures = yield* platformFigures
   const choices = renderSelectChoices(state, options, figures)
-  const leadingSymbol = Ansi.annotate("?", Ansi.cyanBright)
+  const leadingSymbol = Ansi.annotate(options.symbol, Ansi.cyanBright)
   const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
   const promptMsg = renderSelectOutput(leadingSymbol, trailingSymbol, options)
   return Ansi.cursorHide + promptMsg + "\n" + choices
@@ -3263,7 +3300,7 @@ const renderAutoCompleteNextFrame = Effect.fnUntraced(function*<A>(
 ) {
   const figures = yield* platformFigures
   const choices = renderAutoCompleteChoices(state, options, figures)
-  const leadingSymbol = Ansi.annotate("?", Ansi.cyanBright)
+  const leadingSymbol = Ansi.annotate(options.symbol, Ansi.cyanBright)
   const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
   const promptMsg = renderAutoCompleteOutput(state, leadingSymbol, trailingSymbol, options)
   return Ansi.cursorHide + promptMsg + "\n" + choices
@@ -3373,7 +3410,7 @@ const handleSelectClear = <A>(options: SelectOptionsReq<A>) =>
     const columns = yield* terminal.columns
     const figures = yield* platformFigures
     const clearPrompt = Ansi.eraseLine + Ansi.cursorLeft
-    const promptText = renderSelectOutput("?", figures.pointerSmall, options, { plain: true })
+    const promptText = renderSelectOutput(options.symbol, figures.pointerSmall, options, { plain: true })
     const choicesText = renderSelectChoices(state, options, figures, { plain: true })
     const clearOutput = eraseText(`${promptText}\n${choicesText}`, columns)
     return clearOutput + clearPrompt
@@ -3385,7 +3422,7 @@ const handleAutoCompleteClear = <A>(options: AutoCompleteOptionsReq<A>) =>
     const columns = yield* terminal.columns
     const figures = yield* platformFigures
     const clearPrompt = Ansi.eraseLine + Ansi.cursorLeft
-    const promptText = renderAutoCompleteOutput(state, "?", figures.pointerSmall, options, { plain: true })
+    const promptText = renderAutoCompleteOutput(state, options.symbol, figures.pointerSmall, options, { plain: true })
     const choicesText = renderAutoCompleteChoices(state, options, figures, { plain: true })
     const clearOutput = eraseText(`${promptText}\n${choicesText}`, columns)
     return clearOutput + clearPrompt
@@ -3481,7 +3518,7 @@ const renderClearScreen = Effect.fnUntraced(function*(state: TextState, options:
   const resetCurrentLine = Ansi.eraseLine + Ansi.cursorLeft
   const errorText = renderTextError(state, figures.pointerSmall, { plain: true })
   const clearOutput = clearOutputWithError(
-    renderTextOutput(state, "?", figures.pointerSmall, options, { plain: true }),
+    renderTextOutput(state, options.symbol, figures.pointerSmall, options, { plain: true }),
     columns,
     errorText
   )
@@ -3565,7 +3602,7 @@ const renderTextOutput = (
 
 const renderTextNextFrame = Effect.fnUntraced(function*(state: TextState, options: TextOptionsReq) {
   const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate("?", Ansi.cyanBright)
+  const leadingSymbol = Ansi.annotate(options.symbol, Ansi.cyanBright)
   const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
   const promptMsg = renderTextOutput(state, leadingSymbol, trailingSymbol, options)
   const errorMsg = renderTextError(state, figures.pointerSmall)
@@ -3742,6 +3779,7 @@ const basePrompt = (
 ): Prompt<string> => {
   const opts: TextOptionsReq = {
     default: "",
+    symbol: "?",
     type,
     validate: Effect.succeed,
     ...options
@@ -3769,7 +3807,7 @@ const handleToggleClear = Effect.fnUntraced(function*(options: ToggleOptionsReq)
   const figures = yield* platformFigures
   const clearPrompt = Ansi.eraseLine + Ansi.cursorLeft
   const toggleText = `${options.active} / ${options.inactive}`
-  const promptText = renderPrompt(toggleText, options.message, "?", figures.pointerSmall, { plain: true })
+  const promptText = renderPrompt(toggleText, options.message, options.symbol, figures.pointerSmall, { plain: true })
   const clearOutput = eraseText(promptText, columns)
   return clearOutput + clearPrompt
 })
@@ -3807,7 +3845,7 @@ const renderToggleOutput = (
 
 const renderToggleNextFrame = Effect.fnUntraced(function*(state: ToggleState, options: ToggleOptionsReq) {
   const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate("?", Ansi.cyanBright)
+  const leadingSymbol = Ansi.annotate(options.symbol, Ansi.cyanBright)
   const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
   const toggle = renderToggle(state, options)
   const promptMsg = renderToggleOutput(toggle, leadingSymbol, trailingSymbol, options)

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -160,9 +160,9 @@ export interface ConfirmOptions {
    */
   readonly message: string
   /**
-   * The single-column symbol to display at the start of the prompt (defaults to `"?"`).
+   * The single-column prefix to display at the start of the prompt (defaults to `"?"`).
    */
-  readonly symbol?: string
+  readonly prefix?: string
   /**
    * The initial value of the confirm prompt (defaults to `false`).
    */
@@ -210,9 +210,9 @@ export interface DateOptions {
    */
   readonly message: string
   /**
-   * The single-column symbol to display at the start of the prompt (defaults to `"?"`).
+   * The single-column prefix to display at the start of the prompt (defaults to `"?"`).
    */
-  readonly symbol?: string
+  readonly prefix?: string
   /**
    * The initial date value to display in the prompt (defaults to the current
    * date).
@@ -289,9 +289,9 @@ export interface IntegerOptions {
    */
   readonly message: string
   /**
-   * The single-column symbol to display at the start of the prompt (defaults to `"?"`).
+   * The single-column prefix to display at the start of the prompt (defaults to `"?"`).
    */
-  readonly symbol?: string
+  readonly prefix?: string
   /**
    * The default value of the integer prompt.
    */
@@ -374,10 +374,10 @@ export interface FileOptions {
    */
   readonly message?: string
   /**
-   * The single-column symbol to display at the start of the directory traversal
+   * The single-column prefix to display at the start of the directory traversal
    * confirmation prompt (defaults to `"?"`).
    */
-  readonly symbol?: string
+  readonly prefix?: string
   /**
    * Where the user will initially be prompted to select files from, defaulting
    * to the current working directory.
@@ -411,9 +411,9 @@ export interface SelectOptions<A> {
    */
   readonly message: string
   /**
-   * The single-column symbol to display at the start of the prompt (defaults to `"?"`).
+   * The single-column prefix to display at the start of the prompt (defaults to `"?"`).
    */
-  readonly symbol?: string
+  readonly prefix?: string
   /**
    * The choices to display to the user.
    */
@@ -520,9 +520,9 @@ export interface TextOptions {
    */
   readonly message: string
   /**
-   * The single-column symbol to display at the start of the prompt (defaults to `"?"`).
+   * The single-column prefix to display at the start of the prompt (defaults to `"?"`).
    */
-  readonly symbol?: string
+  readonly prefix?: string
   /**
    * The default value of the text option.
    */
@@ -547,9 +547,9 @@ export interface ToggleOptions {
    */
   readonly message: string
   /**
-   * The single-column symbol to display at the start of the prompt (defaults to `"?"`).
+   * The single-column prefix to display at the start of the prompt (defaults to `"?"`).
    */
-  readonly symbol?: string
+  readonly prefix?: string
   /**
    * The intitial value of the toggle prompt (defaults to `false`).
    */
@@ -583,7 +583,7 @@ const defaultFigures = {
   pointer: "❯"
 }
 
-const DEFAULT_SYMBOL = "?"
+const DEFAULT_PREFIX = "?"
 
 const windowsFigures = {
   arrowUp: defaultFigures.arrowUp,
@@ -777,7 +777,7 @@ export const confirm = (options: ConfirmOptions): Prompt<boolean> => {
   const opts: Required<ConfirmOptions> = {
     initial: false,
     ...options,
-    symbol: options.symbol ?? DEFAULT_SYMBOL,
+    prefix: options.prefix ?? DEFAULT_PREFIX,
     label: {
       confirm: "yes",
       deny: "no",
@@ -875,7 +875,7 @@ export const date = (options: DateOptions): Prompt<Date> => {
     dateMask: "YYYY-MM-DD HH:mm:ss",
     validate: Effect.succeed,
     ...options,
-    symbol: options.symbol ?? DEFAULT_SYMBOL,
+    prefix: options.prefix ?? DEFAULT_PREFIX,
     locales: {
       ...defaultLocales,
       ...options.locales
@@ -912,7 +912,7 @@ export const file = (options: FileOptions = {}): Prompt<string> => {
   const opts: FileOptionsReq = {
     type: options.type ?? "file",
     message: options.message ?? `Choose a file`,
-    symbol: options.symbol ?? DEFAULT_SYMBOL,
+    prefix: options.prefix ?? DEFAULT_PREFIX,
     startingPath: Option.fromUndefinedOr(options.startingPath),
     default: Option.fromUndefinedOr(options.default),
     maxPerPage: options.maxPerPage ?? 10,
@@ -1002,7 +1002,7 @@ export const float = (options: FloatOptions): Prompt<number> => {
       return Effect.succeed(n)
     },
     ...options,
-    symbol: options.symbol ?? DEFAULT_SYMBOL
+    prefix: options.prefix ?? DEFAULT_PREFIX
   }
   const initialValue = options.default === undefined ? "" : `${opts.default}`
   const initialState: NumberState = {
@@ -1055,7 +1055,7 @@ export const integer = (options: IntegerOptions): Prompt<number> => {
       return Effect.succeed(n)
     },
     ...options,
-    symbol: options.symbol ?? DEFAULT_SYMBOL
+    prefix: options.prefix ?? DEFAULT_PREFIX
   }
   const initialValue = options.default === undefined ? "" : `${opts.default}`
   const initialState: NumberState = {
@@ -1173,7 +1173,7 @@ export const select = <const A>(options: SelectOptions<A>): Prompt<A> => {
   const opts: SelectOptionsReq<A> = {
     maxPerPage: 10,
     ...options,
-    symbol: options.symbol ?? DEFAULT_SYMBOL
+    prefix: options.prefix ?? DEFAULT_PREFIX
   }
   const initialIndex = getSelectInitialIndex(opts.choices)
   return custom(initialIndex, {
@@ -1213,7 +1213,7 @@ export const autoComplete = <const A>(options: AutoCompleteOptions<A>): Prompt<A
     filterPlaceholder: "type to filter",
     emptyMessage: "No matches",
     ...options,
-    symbol: options.symbol ?? DEFAULT_SYMBOL
+    prefix: options.prefix ?? DEFAULT_PREFIX
   }
   const initialIndex = getSelectInitialIndex(opts.choices)
   const filtered = filterAutoCompleteChoices(opts.choices, "")
@@ -1252,7 +1252,7 @@ export const multiSelect = <const A>(
   const opts: SelectOptionsReq<A> & MultiSelectOptionsReq = {
     maxPerPage: 10,
     ...options,
-    symbol: options.symbol ?? DEFAULT_SYMBOL
+    prefix: options.prefix ?? DEFAULT_PREFIX
   }
   // Seed initial selection from choices marked as selected: true
   const initialSelected = new Set<number>()
@@ -1312,7 +1312,7 @@ export const toggle = (options: ToggleOptions): Prompt<boolean> => {
     active: "on",
     inactive: "off",
     ...options,
-    symbol: options.symbol ?? DEFAULT_SYMBOL
+    prefix: options.prefix ?? DEFAULT_PREFIX
   }
   return custom(opts.initial, {
     render: handleToggleRender(opts),
@@ -1508,7 +1508,7 @@ const handleConfirmClear = (options: ConfirmOptionsReq) => {
       : options.placeholder.defaultDeny!
     const promptText = renderConfirmOutput(
       confirmMessage,
-      options.symbol,
+      options.prefix,
       figures.pointerSmall,
       options,
       { plain: true }
@@ -1529,7 +1529,7 @@ const renderConfirmOutput = (
 
 const renderConfirmNextFrame = Effect.fnUntraced(function*(state: ConfirmState, options: ConfirmOptionsReq) {
   const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate(options.symbol, Ansi.cyanBright)
+  const leadingSymbol = Ansi.annotate(options.prefix, Ansi.cyanBright)
   const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
   // Marking these explicitly as present with `!` because they always will be
   // and there is really no value in adding a `DeepRequired` type helper just
@@ -1595,7 +1595,7 @@ const handleDateClear = (options: DateOptionsReq) => {
     const figures = yield* platformFigures
     const resetCurrentLine = Ansi.eraseLine + Ansi.cursorLeft
     const parts = Arr.reduce(state.dateParts, "", (doc, part) => doc + part.toString())
-    const promptText = renderDateOutput(options.symbol, figures.pointerSmall, parts, options, { plain: true })
+    const promptText = renderDateOutput(options.prefix, figures.pointerSmall, parts, options, { plain: true })
     const errorText = Option.isSome(state.error)
       ? Arr.match(state.error.value.split(NEWLINE_REGEXP), {
         onEmpty: () => "",
@@ -1644,7 +1644,7 @@ const renderDateOutput = (
 
 const renderDateNextFrame = Effect.fnUntraced(function*(state: DateState, options: DateOptionsReq) {
   const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate(options.symbol, Ansi.cyanBright)
+  const leadingSymbol = Ansi.annotate(options.prefix, Ansi.cyanBright)
   const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
   const parts = renderParts(state)
   const promptMsg = renderDateOutput(leadingSymbol, trailingSymbol, parts, options)
@@ -2245,7 +2245,7 @@ const handleFileClear = (options: FileOptionsReq) => {
     const resolvedPathText = `${figures.pointerSmall} ${resolvedPath}`
     const isConfirming = showConfirmation(state.confirm)
     const promptText = isConfirming
-      ? renderPrompt("(Y/n)", CONFIRM_MESSAGE, options.symbol, figures.pointerSmall, { plain: true })
+      ? renderPrompt("(Y/n)", CONFIRM_MESSAGE, options.prefix, figures.pointerSmall, { plain: true })
       : renderPrompt(renderFileFilter(state, { plain: true }), options.message, figures.tick, figures.ellipsis, {
         plain: true
       })
@@ -2360,7 +2360,7 @@ const renderFileNextFrame = Effect.fnUntraced(function*(state: FileState, option
   const resolvedPathMsg = Ansi.annotate(figures.pointerSmall + " " + resolvedPath, Ansi.blackBright)
 
   if (showConfirmation(state.confirm)) {
-    const leadingSymbol = Ansi.annotate(options.symbol, Ansi.cyanBright)
+    const leadingSymbol = Ansi.annotate(options.prefix, Ansi.cyanBright)
     const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
     const confirm = Ansi.annotate("(Y/n)", Ansi.blackBright)
     const promptMsg = renderPrompt(confirm, CONFIRM_MESSAGE, leadingSymbol, trailingSymbol)
@@ -2658,7 +2658,7 @@ const renderMultiSelectNextFrame = Effect.fnUntraced(
   function*<A>(state: MultiSelectState, options: SelectOptionsReq<A>) {
     const figures = yield* platformFigures
     const choices = renderMultiSelectChoices(state, options, figures)
-    const leadingSymbol = Ansi.annotate(options.symbol, Ansi.cyanBright)
+    const leadingSymbol = Ansi.annotate(options.prefix, Ansi.cyanBright)
     const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
     const promptMsg = renderSelectOutput(leadingSymbol, trailingSymbol, options)
     const error = renderMultiSelectError(state, figures.pointer)
@@ -2734,7 +2734,7 @@ const handleMultiSelectClear = <A>(options: SelectOptionsReq<A>) =>
     const columns = yield* terminal.columns
     const figures = yield* platformFigures
     const clearPrompt = Ansi.eraseLine + Ansi.cursorLeft
-    const promptText = renderSelectOutput(options.symbol, figures.pointerSmall, options, { plain: true })
+    const promptText = renderSelectOutput(options.prefix, figures.pointerSmall, options, { plain: true })
     const choicesText = renderMultiSelectChoices(state, options, figures, { plain: true })
     const errorText = renderMultiSelectError(state, figures.pointer, { plain: true })
     const clearOutput = clearOutputWithError(`${promptText}\n${choicesText}`, columns, errorText)
@@ -2807,7 +2807,7 @@ const handleNumberClear = (options: IntegerOptionsReq) => {
     const figures = yield* platformFigures
     const resetCurrentLine = Ansi.eraseLine + Ansi.cursorLeft
     const errorText = renderNumberError(state, figures.pointerSmall, { plain: true })
-    const promptText = renderNumberOutput(state, options.symbol, figures.pointerSmall, options, { plain: true })
+    const promptText = renderNumberOutput(state, options.prefix, figures.pointerSmall, options, { plain: true })
     const clearOutput = clearOutputWithError(promptText, columns, errorText)
     return clearOutput + resetCurrentLine
   })
@@ -2863,7 +2863,7 @@ const renderNumberOutput = (
 
 const renderNumberNextFrame = Effect.fnUntraced(function*(state: NumberState, options: IntegerOptionsReq) {
   const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate(options.symbol, Ansi.cyanBright)
+  const leadingSymbol = Ansi.annotate(options.prefix, Ansi.cyanBright)
   const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
   const errorMsg = renderNumberError(state, figures.pointerSmall)
   const promptMsg = renderNumberOutput(state, leadingSymbol, trailingSymbol, options)
@@ -3291,7 +3291,7 @@ const renderAutoCompleteChoices = <A>(
 const renderSelectNextFrame = Effect.fnUntraced(function*<A>(state: SelectState, options: SelectOptionsReq<A>) {
   const figures = yield* platformFigures
   const choices = renderSelectChoices(state, options, figures)
-  const leadingSymbol = Ansi.annotate(options.symbol, Ansi.cyanBright)
+  const leadingSymbol = Ansi.annotate(options.prefix, Ansi.cyanBright)
   const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
   const promptMsg = renderSelectOutput(leadingSymbol, trailingSymbol, options)
   return Ansi.cursorHide + promptMsg + "\n" + choices
@@ -3303,7 +3303,7 @@ const renderAutoCompleteNextFrame = Effect.fnUntraced(function*<A>(
 ) {
   const figures = yield* platformFigures
   const choices = renderAutoCompleteChoices(state, options, figures)
-  const leadingSymbol = Ansi.annotate(options.symbol, Ansi.cyanBright)
+  const leadingSymbol = Ansi.annotate(options.prefix, Ansi.cyanBright)
   const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
   const promptMsg = renderAutoCompleteOutput(state, leadingSymbol, trailingSymbol, options)
   return Ansi.cursorHide + promptMsg + "\n" + choices
@@ -3413,7 +3413,7 @@ const handleSelectClear = <A>(options: SelectOptionsReq<A>) =>
     const columns = yield* terminal.columns
     const figures = yield* platformFigures
     const clearPrompt = Ansi.eraseLine + Ansi.cursorLeft
-    const promptText = renderSelectOutput(options.symbol, figures.pointerSmall, options, { plain: true })
+    const promptText = renderSelectOutput(options.prefix, figures.pointerSmall, options, { plain: true })
     const choicesText = renderSelectChoices(state, options, figures, { plain: true })
     const clearOutput = eraseText(`${promptText}\n${choicesText}`, columns)
     return clearOutput + clearPrompt
@@ -3425,7 +3425,7 @@ const handleAutoCompleteClear = <A>(options: AutoCompleteOptionsReq<A>) =>
     const columns = yield* terminal.columns
     const figures = yield* platformFigures
     const clearPrompt = Ansi.eraseLine + Ansi.cursorLeft
-    const promptText = renderAutoCompleteOutput(state, options.symbol, figures.pointerSmall, options, { plain: true })
+    const promptText = renderAutoCompleteOutput(state, options.prefix, figures.pointerSmall, options, { plain: true })
     const choicesText = renderAutoCompleteChoices(state, options, figures, { plain: true })
     const clearOutput = eraseText(`${promptText}\n${choicesText}`, columns)
     return clearOutput + clearPrompt
@@ -3521,7 +3521,7 @@ const renderClearScreen = Effect.fnUntraced(function*(state: TextState, options:
   const resetCurrentLine = Ansi.eraseLine + Ansi.cursorLeft
   const errorText = renderTextError(state, figures.pointerSmall, { plain: true })
   const clearOutput = clearOutputWithError(
-    renderTextOutput(state, options.symbol, figures.pointerSmall, options, { plain: true }),
+    renderTextOutput(state, options.prefix, figures.pointerSmall, options, { plain: true }),
     columns,
     errorText
   )
@@ -3605,7 +3605,7 @@ const renderTextOutput = (
 
 const renderTextNextFrame = Effect.fnUntraced(function*(state: TextState, options: TextOptionsReq) {
   const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate(options.symbol, Ansi.cyanBright)
+  const leadingSymbol = Ansi.annotate(options.prefix, Ansi.cyanBright)
   const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
   const promptMsg = renderTextOutput(state, leadingSymbol, trailingSymbol, options)
   const errorMsg = renderTextError(state, figures.pointerSmall)
@@ -3785,7 +3785,7 @@ const basePrompt = (
     type,
     validate: Effect.succeed,
     ...options,
-    symbol: options.symbol ?? DEFAULT_SYMBOL
+    prefix: options.prefix ?? DEFAULT_PREFIX
   }
 
   const initialState: TextState = {
@@ -3810,7 +3810,7 @@ const handleToggleClear = Effect.fnUntraced(function*(options: ToggleOptionsReq)
   const figures = yield* platformFigures
   const clearPrompt = Ansi.eraseLine + Ansi.cursorLeft
   const toggleText = `${options.active} / ${options.inactive}`
-  const promptText = renderPrompt(toggleText, options.message, options.symbol, figures.pointerSmall, { plain: true })
+  const promptText = renderPrompt(toggleText, options.message, options.prefix, figures.pointerSmall, { plain: true })
   const clearOutput = eraseText(promptText, columns)
   return clearOutput + clearPrompt
 })
@@ -3848,7 +3848,7 @@ const renderToggleOutput = (
 
 const renderToggleNextFrame = Effect.fnUntraced(function*(state: ToggleState, options: ToggleOptionsReq) {
   const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate(options.symbol, Ansi.cyanBright)
+  const leadingSymbol = Ansi.annotate(options.prefix, Ansi.cyanBright)
   const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
   const toggle = renderToggle(state, options)
   const promptMsg = renderToggleOutput(toggle, leadingSymbol, trailingSymbol, options)

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -160,7 +160,7 @@ export interface ConfirmOptions {
    */
   readonly message: string
   /**
-   * The symbol to display at the start of the prompt (defaults to `"?"`).
+   * The single-column symbol to display at the start of the prompt (defaults to `"?"`).
    */
   readonly symbol?: string
   /**
@@ -210,7 +210,7 @@ export interface DateOptions {
    */
   readonly message: string
   /**
-   * The symbol to display at the start of the prompt (defaults to `"?"`).
+   * The single-column symbol to display at the start of the prompt (defaults to `"?"`).
    */
   readonly symbol?: string
   /**
@@ -289,7 +289,7 @@ export interface IntegerOptions {
    */
   readonly message: string
   /**
-   * The symbol to display at the start of the prompt (defaults to `"?"`).
+   * The single-column symbol to display at the start of the prompt (defaults to `"?"`).
    */
   readonly symbol?: string
   /**
@@ -374,7 +374,8 @@ export interface FileOptions {
    */
   readonly message?: string
   /**
-   * The symbol to display at the start of the prompt (defaults to `"?"`).
+   * The single-column symbol to display at the start of the directory traversal
+   * confirmation prompt (defaults to `"?"`).
    */
   readonly symbol?: string
   /**
@@ -410,7 +411,7 @@ export interface SelectOptions<A> {
    */
   readonly message: string
   /**
-   * The symbol to display at the start of the prompt (defaults to `"?"`).
+   * The single-column symbol to display at the start of the prompt (defaults to `"?"`).
    */
   readonly symbol?: string
   /**
@@ -519,7 +520,7 @@ export interface TextOptions {
    */
   readonly message: string
   /**
-   * The symbol to display at the start of the prompt (defaults to `"?"`).
+   * The single-column symbol to display at the start of the prompt (defaults to `"?"`).
    */
   readonly symbol?: string
   /**
@@ -546,7 +547,7 @@ export interface ToggleOptions {
    */
   readonly message: string
   /**
-   * The symbol to display at the start of the prompt (defaults to `"?"`).
+   * The single-column symbol to display at the start of the prompt (defaults to `"?"`).
    */
   readonly symbol?: string
   /**
@@ -581,6 +582,8 @@ const defaultFigures = {
   line: "─",
   pointer: "❯"
 }
+
+const DEFAULT_SYMBOL = "?"
 
 const windowsFigures = {
   arrowUp: defaultFigures.arrowUp,
@@ -773,8 +776,8 @@ const annotateErrorLine = (line: string): string => Ansi.annotate(line, Ansi.com
 export const confirm = (options: ConfirmOptions): Prompt<boolean> => {
   const opts: Required<ConfirmOptions> = {
     initial: false,
-    symbol: "?",
     ...options,
+    symbol: options.symbol ?? DEFAULT_SYMBOL,
     label: {
       confirm: "yes",
       deny: "no",
@@ -870,9 +873,9 @@ export const date = (options: DateOptions): Prompt<Date> => {
   const opts: Required<DateOptions> = {
     initial: new Date(),
     dateMask: "YYYY-MM-DD HH:mm:ss",
-    symbol: "?",
     validate: Effect.succeed,
     ...options,
+    symbol: options.symbol ?? DEFAULT_SYMBOL,
     locales: {
       ...defaultLocales,
       ...options.locales
@@ -909,7 +912,7 @@ export const file = (options: FileOptions = {}): Prompt<string> => {
   const opts: FileOptionsReq = {
     type: options.type ?? "file",
     message: options.message ?? `Choose a file`,
-    symbol: options.symbol ?? "?",
+    symbol: options.symbol ?? DEFAULT_SYMBOL,
     startingPath: Option.fromUndefinedOr(options.startingPath),
     default: Option.fromUndefinedOr(options.default),
     maxPerPage: options.maxPerPage ?? 10,
@@ -984,7 +987,6 @@ export const flatMap: {
 export const float = (options: FloatOptions): Prompt<number> => {
   const opts: FloatOptionsReq = {
     default: 0,
-    symbol: "?",
     min: Number.NEGATIVE_INFINITY,
     max: Number.POSITIVE_INFINITY,
     incrementBy: 1,
@@ -999,7 +1001,8 @@ export const float = (options: FloatOptions): Prompt<number> => {
       }
       return Effect.succeed(n)
     },
-    ...options
+    ...options,
+    symbol: options.symbol ?? DEFAULT_SYMBOL
   }
   const initialValue = options.default === undefined ? "" : `${opts.default}`
   const initialState: NumberState = {
@@ -1038,7 +1041,6 @@ export const hidden = (
 export const integer = (options: IntegerOptions): Prompt<number> => {
   const opts: IntegerOptionsReq = {
     default: 0,
-    symbol: "?",
     min: Number.NEGATIVE_INFINITY,
     max: Number.POSITIVE_INFINITY,
     incrementBy: 1,
@@ -1052,7 +1054,8 @@ export const integer = (options: IntegerOptions): Prompt<number> => {
       }
       return Effect.succeed(n)
     },
-    ...options
+    ...options,
+    symbol: options.symbol ?? DEFAULT_SYMBOL
   }
   const initialValue = options.default === undefined ? "" : `${opts.default}`
   const initialState: NumberState = {
@@ -1169,8 +1172,8 @@ const getSelectInitialIndex = <A>(choices: ReadonlyArray<SelectChoice<A>>): numb
 export const select = <const A>(options: SelectOptions<A>): Prompt<A> => {
   const opts: SelectOptionsReq<A> = {
     maxPerPage: 10,
-    symbol: "?",
-    ...options
+    ...options,
+    symbol: options.symbol ?? DEFAULT_SYMBOL
   }
   const initialIndex = getSelectInitialIndex(opts.choices)
   return custom(initialIndex, {
@@ -1206,11 +1209,11 @@ export const select = <const A>(options: SelectOptions<A>): Prompt<A> => {
 export const autoComplete = <const A>(options: AutoCompleteOptions<A>): Prompt<A> => {
   const opts: AutoCompleteOptionsReq<A> = {
     maxPerPage: 10,
-    symbol: "?",
     filterLabel: "filter",
     filterPlaceholder: "type to filter",
     emptyMessage: "No matches",
-    ...options
+    ...options,
+    symbol: options.symbol ?? DEFAULT_SYMBOL
   }
   const initialIndex = getSelectInitialIndex(opts.choices)
   const filtered = filterAutoCompleteChoices(opts.choices, "")
@@ -1248,8 +1251,8 @@ export const multiSelect = <const A>(
 ): Prompt<Array<A>> => {
   const opts: SelectOptionsReq<A> & MultiSelectOptionsReq = {
     maxPerPage: 10,
-    symbol: "?",
-    ...options
+    ...options,
+    symbol: options.symbol ?? DEFAULT_SYMBOL
   }
   // Seed initial selection from choices marked as selected: true
   const initialSelected = new Set<number>()
@@ -1306,10 +1309,10 @@ export const text = (
 export const toggle = (options: ToggleOptions): Prompt<boolean> => {
   const opts: ToggleOptionsReq = {
     initial: false,
-    symbol: "?",
     active: "on",
     inactive: "off",
-    ...options
+    ...options,
+    symbol: options.symbol ?? DEFAULT_SYMBOL
   }
   return custom(opts.initial, {
     render: handleToggleRender(opts),
@@ -3779,10 +3782,10 @@ const basePrompt = (
 ): Prompt<string> => {
   const opts: TextOptionsReq = {
     default: "",
-    symbol: "?",
     type,
     validate: Effect.succeed,
-    ...options
+    ...options,
+    symbol: options.symbol ?? DEFAULT_SYMBOL
   }
 
   const initialState: TextState = {

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -158,6 +158,26 @@ describe("Prompt.float", () => {
 })
 
 describe("Prompt.text", () => {
+  it.effect("renders the default prompt symbol", () =>
+    Effect.gen(function*() {
+      yield* MockTerminal.inputKey("enter")
+
+      yield* Prompt.run(Prompt.text({ message: "Name" }))
+
+      const frames = toFrames(yield* MockTerminal.displayLines)
+      assert.include(frames[0] ?? "", "? Name")
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("renders a custom prompt symbol", () =>
+    Effect.gen(function*() {
+      yield* MockTerminal.inputKey("enter")
+
+      yield* Prompt.run(Prompt.text({ message: "Name", symbol: "!" }))
+
+      const frames = toFrames(yield* MockTerminal.displayLines)
+      assert.include(frames[0] ?? "", "! Name")
+    }).pipe(Effect.provide(TestLayer)))
+
   it.effect("starts from the default value so it can be edited", () =>
     Effect.gen(function*() {
       const prompt = Prompt.text({

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -158,14 +158,16 @@ describe("Prompt.float", () => {
 })
 
 describe("Prompt.text", () => {
-  it.effect("renders the default prompt symbol", () =>
+  it.effect("uses the default prompt symbol when symbol is explicitly undefined", () =>
     Effect.gen(function*() {
       yield* MockTerminal.inputKey("enter")
 
-      yield* Prompt.run(Prompt.text({ message: "Name" }))
+      const options = { message: "Name", symbol: undefined } as unknown as Prompt.TextOptions
+      yield* Prompt.run(Prompt.text(options))
 
       const frames = toFrames(yield* MockTerminal.displayLines)
       assert.include(frames[0] ?? "", "? Name")
+      assert.notInclude(frames[0] ?? "", "undefined")
     }).pipe(Effect.provide(TestLayer)))
 
   it.effect("renders a custom prompt symbol", () =>
@@ -275,6 +277,27 @@ describe("Prompt.text", () => {
 
       assert.isTrue(lastFrame !== undefined)
       assert.isFalse(lastFrame?.includes("Jane"))
+    }).pipe(Effect.provide(TestLayer)))
+})
+
+describe("Prompt.select", () => {
+  it.effect("preserves a custom prompt symbol across redraws", () =>
+    Effect.gen(function*() {
+      yield* MockTerminal.inputKey("down")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(Prompt.select({
+        message: "Pick item",
+        symbol: "!",
+        choices: [
+          { title: "First", value: "first" },
+          { title: "Second", value: "second" }
+        ]
+      }))
+
+      assert.strictEqual(result, "second")
+      const frames = toFrames(yield* MockTerminal.displayLines)
+      assert.strictEqual(frames.filter((frame) => frame.includes("! Pick item")).length, 2)
     }).pipe(Effect.provide(TestLayer)))
 })
 

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -158,11 +158,11 @@ describe("Prompt.float", () => {
 })
 
 describe("Prompt.text", () => {
-  it.effect("uses the default prompt symbol when symbol is explicitly undefined", () =>
+  it.effect("uses the default prompt prefix when prefix is explicitly undefined", () =>
     Effect.gen(function*() {
       yield* MockTerminal.inputKey("enter")
 
-      const options = { message: "Name", symbol: undefined } as unknown as Prompt.TextOptions
+      const options = { message: "Name", prefix: undefined } as unknown as Prompt.TextOptions
       yield* Prompt.run(Prompt.text(options))
 
       const frames = toFrames(yield* MockTerminal.displayLines)
@@ -170,11 +170,11 @@ describe("Prompt.text", () => {
       assert.notInclude(frames[0] ?? "", "undefined")
     }).pipe(Effect.provide(TestLayer)))
 
-  it.effect("renders a custom prompt symbol", () =>
+  it.effect("renders a custom prompt prefix", () =>
     Effect.gen(function*() {
       yield* MockTerminal.inputKey("enter")
 
-      yield* Prompt.run(Prompt.text({ message: "Name", symbol: "!" }))
+      yield* Prompt.run(Prompt.text({ message: "Name", prefix: "!" }))
 
       const frames = toFrames(yield* MockTerminal.displayLines)
       assert.include(frames[0] ?? "", "! Name")
@@ -281,14 +281,14 @@ describe("Prompt.text", () => {
 })
 
 describe("Prompt.select", () => {
-  it.effect("preserves a custom prompt symbol across redraws", () =>
+  it.effect("preserves a custom prompt prefix across redraws", () =>
     Effect.gen(function*() {
       yield* MockTerminal.inputKey("down")
       yield* MockTerminal.inputKey("enter")
 
       const result = yield* Prompt.run(Prompt.select({
         message: "Pick item",
-        symbol: "!",
+        prefix: "!",
         choices: [
           { title: "First", value: "first" },
           { title: "Second", value: "second" }


### PR DESCRIPTION
## Summary

- add an optional `prefix` setting to every built-in CLI prompt option
- preserve `?` as the default, including when callers explicitly pass `undefined`
- use custom prefixes consistently in active rendering and clear calculations
- document the single-column constraint and the file prompt's confirmation-only behavior
- add a patch changeset and regression coverage for undefined prefixes and redraws

## Validation

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/effect/test/unstable/cli/Prompt.test.ts` (37 tests)
- `nix develop -c pnpm test-types packages/effect/typetest/unstable/cli/Prompt.tst.ts` (TypeScript 5.9 and 6.0)
- `nix develop -c pnpm check`
- `nix develop -c pnpm changeset status --since origin/main`

Closes EFF-666
