### PR TITLE
Fix dropped text for nullable streamed tool calls

### DIFF
--- a/.changeset/openai-compat-null-tool-calls.md
+++ b/.changeset/openai-compat-null-tool-calls.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai-compat": patch
+---
+
+Preserve streamed text from OpenAI-compatible providers that send `tool_calls: null` on text-only chunks.

--- a/packages/ai/openai-compat/src/OpenAiClient.ts
+++ b/packages/ai/openai-compat/src/OpenAiClient.ts
@@ -1123,7 +1123,10 @@ const ChatCompletionDelta = Schema.Struct({
   content: Schema.optionalKey(Schema.NullOr(Schema.String)),
   reasoning: Schema.optionalKey(Schema.NullOr(Schema.String)),
   reasoning_content: Schema.optionalKey(Schema.NullOr(Schema.String)),
-  tool_calls: Schema.optionalKey(Schema.Array(ChatCompletionToolCallDelta))
+  // Some OpenAI-compatible providers send `tool_calls: null` when a streamed
+  // chunk contains only text. Accepting null keeps the text-bearing chunk from
+  // being classified as an unknown event.
+  tool_calls: Schema.optionalKey(Schema.NullOr(Schema.Array(ChatCompletionToolCallDelta)))
 })
 
 const ChatCompletionChoice = Schema.Struct({

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -1287,7 +1287,7 @@ const makeStreamResponse = Effect.fnUntraced(
           parts.push({ type: "text-delta", id: textId, delta: choice.delta.content })
         }
 
-        if (choice.delta?.tool_calls !== undefined) {
+        if (Predicate.isNotNullish(choice.delta?.tool_calls)) {
           hasToolCalls = hasToolCalls || choice.delta.tool_calls.length > 0
           choice.delta.tool_calls.forEach((deltaTool, indexInChunk) => {
             const toolIndex = deltaTool.index ?? indexInChunk

--- a/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
@@ -901,6 +901,48 @@ describe("OpenAiLanguageModel", () => {
         }
       }))
 
+    it.effect("emits text when streamed tool_calls is null", () =>
+      Effect.gen(function*() {
+        const layer = OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) =>
+              Effect.succeed(sseResponse(request, [
+                {
+                  id: "chatcmpl_nullable_tool_calls",
+                  object: "chat.completion.chunk",
+                  model: "inception/mercury-2",
+                  created: 1,
+                  choices: [{
+                    index: 0,
+                    delta: {
+                      content: "Hello",
+                      role: "assistant",
+                      tool_calls: null
+                    },
+                    finish_reason: null
+                  }]
+                },
+                "[DONE]"
+              ]))
+            )
+          ))
+        )
+
+        const partsChunk = yield* LanguageModel.streamText({ prompt: "test" }).pipe(
+          Stream.runCollect,
+          Effect.provide(OpenAiLanguageModel.model("inception/mercury-2")),
+          Effect.provide(layer)
+        )
+
+        const text = Array.from(partsChunk)
+          .filter((part) => part.type === "text-delta")
+          .map((part) => part.delta)
+          .join("")
+
+        assert.strictEqual(text, "Hello")
+      }))
+
     it.effect("decodes streamed tool call params with the OpenAI codec", () =>
       Effect.gen(function*() {
         const layer = OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(


### PR DESCRIPTION
## Summary

- accept OpenAI-compatible streaming chunks that encode `delta.tool_calls` as `null`
- treat nullable tool calls as absent while preserving text deltas
- add regression coverage through `OpenAiLanguageModel.streamText`
- include a patch changeset for `@effect/ai-openai-compat`

## Root cause

The streaming chunk schema required `delta.tool_calls` to be an array whenever present. Providers such as Inception Mercury 2 send `null` on text-only chunks, causing the entire chunk to become an `UnknownChatCompletionEvent` and its valid `delta.content` to be skipped.

## Validation

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/ai/openai-compat/test` (43 tests)
- `nix develop -c pnpm check`
- `nix develop -c pnpm changeset status --since origin/main`

Closes EFF-668
Closes #7268