### PR TITLE
Graph: add improvement delivery plans

### DIFF
--- a/docs/graph-plans/01-correctness-contracts.md
+++ b/docs/graph-plans/01-correctness-contracts.md
@@ -1,0 +1,430 @@
+# Correctness Contracts and Semantic Hardening
+
+## Status and scope
+
+This is the first dependency in the graph improvement sequence. It defines and tests the observable contracts that
+later query, traversal, path, optimization, serialization, and performance plans must preserve. It does not propose a
+new graph kind, change stable numeric indexes, remove parallel edges or self-loops, or make synchronous APIs effectful.
+
+Assumptions:
+
+- The shared semantics in [`README.md`](./README.md#shared-semantics) are normative where the current implementation or
+  tests disagree.
+- Existing public signatures and default ordering remain intact. A behavior change is allowed only when a regression
+  test demonstrates a violation of those shared semantics or a standard `Equal` / `Hash` law.
+- `Edge<E>` is a shallow value envelope. The graph owns `source` and `target`, but does not deep-clone or freeze user
+  payload `E`.
+- This plan owns contract decisions and focused regression fixes. Later plans own reusable arc/snapshot kernels and new
+  algorithm families.
+
+Implementation checkpoint after `a371754b1e` (Optimize graph traversal): traversal now uses an internal CSR snapshot per
+iterator, DFS/BFS use explicit stacks or typed FIFO storage, and active iterators are isolated from later mutations. Those
+behaviors are no longer open correctness questions. Invalid radius values, caller-owned `start` arrays, DFS multi-root
+priority, and directed neighbor duplication remain open.
+
+## Current gaps
+
+### Traversal radius
+
+`SearchConfig.radius` and `NeighborhoodConfig.radius` accept any `number`, with no stated domain beyond being an edge
+distance (`Graph.ts:1272-1281`, `Graph.ts:5785-5789`). DFS and BFS compare integer depths directly with the supplied
+value (`Graph.ts:5838-5969`, `Graph.ts:6018-6125`), so `NaN`, negative values, and fractions silently acquire accidental
+semantics. For example, a negative or `NaN` radius yields start nodes only, while `1.5` reaches depth two. Postorder and
+`neighborhood` inherit those semantics (`Graph.ts:1332-1336`, `Graph.ts:6339-6395`). Existing tests cover only valid
+integer boundaries (`Graph.test.ts:696-742`, `Graph.test.ts:4261-4342`, `Graph.test.ts:4561-4574`).
+
+The CSR traversal rewrite did not add radius validation. DFS, BFS, bounded postorder membership, and `neighborhood`
+still compare integer depths to the supplied number, so this gap remains after `a371754b1e`.
+
+### Traversal snapshots, configuration ownership, and root order
+
+Traversal construction is lazy. Each fresh iterator now captures a CSR snapshot of node identity, node data, and the
+required adjacency, so mutations after iteration starts do not affect that active iterator; a later iterator observes the
+new graph state. DFS and BFS advance incrementally. Finite-radius postorder intentionally computes its complete bounded
+membership set when the iterator is created before yielding postorder results. This exception is documented and is not a
+remaining correctness defect.
+
+Two contracts remain unresolved:
+
+- `config.start` is retained by reference but validated only when the walker is created. Later caller mutation can change
+  future iterations or insert an unvalidated missing node into compact-index lookup.
+- BFS and postorder prioritize multiple roots in supplied order, while DFS currently pushes roots onto a LIFO stack in
+  supplied order and therefore prioritizes the last root. Duplicate-root and exact multi-root DFS ordering are not pinned.
+
+The implementation and tests now establish snapshot isolation for active traversal. They do not need a blanket
+"mutation during active iteration is unsupported" rule for DFS, BFS, postorder, or topo.
+
+### Neighbor multiplicity and ordering
+
+The shared contract says neighbor-node queries are unique. Undirected neighbors already use a `Set` and preserve first
+incident-edge order (`Graph.ts:3800-3821`), including one occurrence for a self-loop. Directed neighbors append one node
+per edge in both canonical and CSR-backed paths (`Graph.ts:2570-2605`), so parallel directed edges duplicate `neighbors`, `successors`, `predecessors`, and the
+deprecated `neighborsDirected`. Tests demonstrate undirected deduplication but do not exercise directed parallel edges
+or directed self-loops (`Graph.test.ts:2238-2308`). Direction-ignored traversal unions outgoing then incoming neighbors
+(`Graph.ts:3823-3839`), but its ordering and deduplication are not pinned for reciprocal edges or self-loops.
+
+Changing directed neighbor output from one item per edge to one item per node is compatibility-sensitive for callers
+that accidentally use these arrays as degree counts. It is nevertheless a bug fix under the shared semantics. Degree
+and incident-edge APIs must preserve multiplicity independently; later implementations must not derive degree from a
+deduplicated neighbor list. `.repos/graph` makes the same separation by deduplicating node queries
+(`.repos/graph/src/queries.ts:177-280`) while retaining edge-list queries (`.repos/graph/src/queries.ts:48-175`).
+
+### Mutation lifecycle and error precedence
+
+`endMutation` marks its source handle immutable and rejects a second finalization through `assertMutable`.
+`mutateScoped` always calls `endMutation` in `finally` (`Graph.ts:623-634`). If a callback manually
+calls `endMutation`, finalization in `finally` throws. If that callback then throws its own error, the finalization error
+masks the callback error. Current tests cover ordinary callback failure and late mutation, but not manual finalization,
+double finalization, or error precedence (`Graph.test.ts:970-1047`).
+
+### Undirected self-loop storage and removal
+
+Adding an undirected self-loop pushes the same edge index twice into both adjacency maps because source and target are
+equal (`Graph.ts:2312-2334`). Removal happens to splice one entry in each of two passes over the same arrays
+(`Graph.ts:2463-2499`), and node removal can collect the same edge index four times (`Graph.ts:2380-2402`). Public
+neighbors hide the duplication with a `Set`, but the internal representation is fragile and can make later arc,
+incident-edge, degree, and snapshot work count a loop two or four times by accident. Existing tests check only that an
+undirected loop is a neighbor and a cycle (`Graph.test.ts:2186-2193`, `Graph.test.ts:2877-2887`); they do not verify
+removal or adjacency-derived invariants after removing a loop-bearing node.
+
+### Hash-law tests
+
+Graph equality currently includes kind, stable indexes, allocator state, node data, and edge identity by edge index;
+undirected edge endpoints are unordered. The approved contract removes allocator history from equality because it is not
+active graph structure and is intentionally absent from `Schema.Graph`. Tests correctly assert that equal values have
+equal hashes, but also assert that unequal allocator state or edge data must produce different hashes (`Graph.test.ts:170-220`,
+`Graph.test.ts:859-889`). That converse is not a hash law: collisions are valid. Those assertions can fail after a valid
+hash implementation change and should be replaced by equality assertions plus the one required implication,
+`Equal.equals(a, b) => Hash.hash(a) === Hash.hash(b)`.
+
+### Public edge copy semantics
+
+`getEdge` and `edges` currently return a fresh shallow `Edge` envelope (`Graph.ts:240-246`, `Graph.ts:2531-2545`,
+`Graph.ts:5729-5748`). The regression test mutates returned endpoint fields and proves graph structure is not exposed
+(`Graph.test.ts:2040-2053`), but it does not pin freshness between calls, behavior for mutable graphs, or the intentional
+sharing of `edge.data`. This behavior was introduced as a patch-level fix and must not drift into deep-copying payloads
+or returning internal envelopes.
+
+### Weight and A* heuristic contracts
+
+Dijkstra and A* eagerly invoke `cost` for every edge before source-equals-target and early-target exits, reject negative
+or `NaN` weights, and treat `+Infinity` as impassable (`Graph.ts:4136-4161`, `Graph.ts:4531-4556`). Tests pin global
+validation, including unreachable/late negative edges and same-node queries (`Graph.test.ts:3209-3290`,
+`Graph.test.ts:3429-3537`). This matches the lesson from `.repos/graph`: early-exit searches otherwise miss invalid
+weights, so validation must precede search (`.repos/graph/src/algorithms/paths.ts:513-548`).
+
+The remaining ambiguity is heuristic correctness. A* rejects non-finite estimates only when it evaluates them
+(`Graph.ts:4558-4569`, `Graph.ts:4585-4647`) and permanently closes visited nodes. Its documentation says a heuristic
+"should be consistent" (`Graph.ts:4474-4485`), while `.repos/graph` describes admissibility instead
+(`.repos/graph/src/types.ts:472-484`). These are not interchangeable for this implementation: closed-node A* needs a
+consistent heuristic for the stated shortest-path guarantee. Finite but inadmissible or inconsistent values are not
+detectable locally and can return a non-shortest path.
+
+### Parallel-edge path identity
+
+`PathResult` exposes node indexes, total numeric distance, and edge payloads, but no edge indexes (`Graph.ts:4182-4186`).
+After `a371754b1e`, immutable CSR implementations retain compact edge positions in predecessor state, but CSR lacks the
+reverse projection to stable public `EdgeIndex`; mutable implementations still retain edge data directly. Two parallel
+edges with equal payloads therefore remain indistinguishable in a returned path. `AllPairsResult.costs` has the same
+ambiguity and collapses parallel choices into endpoint-keyed matrices. `.repos/graph` demonstrates
+the required model: predecessor state retains edge identity and each path step exposes the selected edge
+(`.repos/graph/src/algorithms/paths.ts:581-586`, `.repos/graph/src/algorithms/paths.ts:623-657`,
+`.repos/graph/tests/algorithms.test.ts:257`).
+
+Adding a required field to `PathResult` would change existing runtime object equality and the exported type. Existing
+results must remain unchanged; edge identity requires additive APIs only.
+
+### Type-level coverage
+
+Current type tests cover constructors, mutation callback synchrony, opacity, variance, set operations, traversal kind
+preservation, and `topo` rejection (`Graph.tst.ts:30-270`). They do not pin:
+
+- data-first/data-last inference for `dijkstra`, `astar`, and `bellmanFord`;
+- callback parameter inference for `cost` and `heuristic`;
+- acceptance of immutable and mutable graphs while preserving graph kind;
+- `successors` / `predecessors` rejection of undirected and unknown-kind graphs;
+- directed-neighbor, traversal-radius, and edge-result configuration shapes;
+- covariance of immutable results and invariance of mutable inputs at mutation entry points;
+- the proposed edge-identified path overloads and the absence of edge indexes from legacy results.
+
+## Desired contracts
+
+### Radius
+
+1. An omitted traversal radius means unbounded traversal; explicit `Infinity` is also accepted.
+2. Every finite radius must be a non-negative integer. `-0` is equivalent to `0`.
+3. `NaN`, `-Infinity`, negative values, and fractions throw `GraphError` with one stable message before a walker or
+   neighborhood is returned. Empty `start` does not bypass radius validation.
+4. Radius is minimum unweighted edge distance from any valid start. Radius zero yields each distinct start once.
+5. `dfs`, `bfs`, `dfsPostOrder`, and `neighborhood` use exactly the same validator and boundary semantics.
+
+Rejecting previously accepted invalid radii is compatibility-sensitive, but converts accidental behavior into the
+repository-wide invalid-algorithm-input policy.
+
+### Traversal iteration and configuration
+
+1. Calling `dfs`, `bfs`, or `dfsPostOrder` validates and copies `start`; later mutation of the caller's array cannot
+   affect any iteration. Each fresh iterator revalidates those copied starts against its captured graph state, so removing
+   a start between walker creation and iteration produces the documented missing-node `GraphError` rather than an invalid
+   compact lookup.
+2. Creating a walker performs no graph traversal. Every call to `[Symbol.iterator]()` captures current graph structure
+   and node data, and active iteration uses only that captured traversal state.
+3. Mutations after iterator creation are not observed by that active iterator. A fresh iterator from the same walker
+   observes graph state at its own creation time.
+4. DFS and BFS perform bounded work as results are requested. Finite-radius postorder may compute the complete bounded
+   reachable-node set at iterator creation before producing postorder output; document this explicit exception.
+5. Distinct start nodes are prioritized in supplied order for BFS, DFS, and postorder. Duplicate starts do not duplicate
+   output or alter the first occurrence's priority.
+
+Copying `start` closes a validation hole and is the least surprising ownership contract. Changing DFS's current
+last-root-first behavior is compatibility-sensitive and requires an exact regression fixture and release note.
+
+### Neighbors and incidences
+
+1. `neighbors`, `successors`, `predecessors`, and `neighborsDirected` return each reachable adjacent `NodeIndex` at most
+   once, for both graph kinds.
+2. Ordering is first occurrence in edge index/insertion order. For direction-ignored directed traversal, outgoing first
+   occurrences precede new incoming first occurrences.
+3. A self-loop contributes the node once to a neighbor-node result.
+4. Parallel and reciprocal edges do not duplicate nodes. They remain distinct edge occurrences for algorithms, degree,
+   capacity, flow, cycle, and future incident-edge queries.
+5. Missing nodes continue to produce `[]` for neighbor queries, preserving current safe collection behavior.
+
+### Mutation lifecycle
+
+1. A mutable handle has one active lifetime. Public `endMutation` succeeds once; a second direct call throws
+   `GraphError("Graph is not mutable")` as today.
+2. Every public mutation checks lifetime before touching storage. A finalized handle can still be queried as the stale
+   snapshot it contains, but cannot affect the immutable graph returned by finalization.
+3. `directed`, `undirected`, `make`, and `mutate` finalize their callback handle exactly once on normal return or throw.
+4. If a callback error and cleanup/lifecycle misuse both occur, the callback error is primary and must not be replaced
+   by a cleanup `GraphError`. The handle must still be inactive when control returns.
+5. If a callback manually finalizes and then returns normally, the scoped operation throws the lifecycle `GraphError`;
+   it must not silently return an unknown immutable snapshot. Manual `beginMutation` / `endMutation` remains the API for
+   callers that need explicit finalization.
+
+The error-precedence and manual-finalization behavior is compatibility-sensitive only for callbacks already violating
+the scoped lifetime contract.
+
+### Undirected self-loops
+
+1. One stored `EdgeIndex` represents one logical self-loop.
+2. It contributes two endpoint incidences to graph-theoretic undirected degree, one edge to edge enumeration and edge
+   count, one node to neighbor queries, and one cycle of length one.
+3. Ordered traversal arcs may expose two loop incidences internally, but no internal combination of outgoing and
+   incoming maps may turn them into four logical incidences.
+4. `removeEdge` removes every internal incidence for exactly that edge and leaves parallel loops untouched.
+5. `removeNode` removes every incident edge exactly once logically, including any number of self-loops and parallel
+   non-loop edges. No stale edge index remains in another node's adjacency.
+
+The concrete adjacency layout is private. Correctness tests should assert public behavior and a test-only invariant
+checker, not freeze a particular map representation. The internal architecture plan owns the final ordered arc layout.
+
+### Equality and hashing
+
+1. Equality compares active indexed structure and payloads, not `nextNodeIndex`, `nextEdgeIndex`, or removed trailing
+   allocator history. Graphs with identical active indexed nodes and edges are equal even if their next allocations differ.
+2. For all graph values `a` and `b`, equality implies equal hashes. Unequal graphs may collide.
+3. Undirected endpoint reversal preserves equality and hash; directed reversal does not preserve equality.
+4. Parallel edges remain paired by stable `EdgeIndex`, not multiset-matched by payload.
+5. Mutable graphs retain reference equality and stable reference hash for their active lifetime. Final immutable copies
+   return to structural equality/hash behavior.
+
+### Edge copies
+
+1. Each successful `getEdge` call and each element emitted by a fresh or repeated `edges` iteration is a fresh `Edge`
+   envelope, for immutable and mutable graph inputs.
+2. Mutating a returned envelope through an unsafe cast cannot alter endpoints, adjacency, equality, hashing, or later
+   reads of the graph.
+3. `data` is copied by reference. Mutating a mutable payload is visible through later reads and can affect structural
+   equality/hash; no deep immutability is promised.
+4. `Option.none`, edge index ordering, and `Edge`'s own ordered endpoint equality remain unchanged.
+
+### Weights and heuristics
+
+1. Dijkstra and A* accept weights in `[0, +Infinity]`; `-0` is accepted as zero. They reject negative values, `NaN`, and
+   `-Infinity` with `GraphError`. `+Infinity` means an impassable edge.
+2. Their weight contract is graph-global: every stored edge is validated before same-node or early-target success, even
+   if unreachable from the source. Callback exceptions propagate unchanged.
+3. Bellman-Ford and Floyd-Warshall accept finite negative values and `+Infinity`, reject `NaN` and `-Infinity`, and keep
+   their existing negative-cycle contracts. A later optimization plan may share validation code but may not weaken it.
+4. A* accepts any finite heuristic value, including negative values. Every estimate that the algorithm evaluates must
+   be finite or produce `GraphError`; it does not promise eager evaluation for unreachable nodes or the trivial
+   source-equals-target result.
+5. Shortest-path optimality from A* is guaranteed only when the caller supplies a consistent heuristic with
+   `h(target) = 0`: for each traversable edge `(u, v)`, `h(u) <= weight(u, v) + h(v)`. Consistency implies admissibility
+   under these contracts. The library validates finiteness, not consistency.
+6. With `heuristic: () => 0`, A* must agree with Dijkstra on reachability and distance. Deterministic tie breaking follows
+   edge insertion/index order; a particular equal-cost path is stable but not part of mathematical optimality.
+
+Documenting consistency as a caller precondition is not a behavior break. Changing A* to reopen closed nodes and offer
+an admissible-only guarantee would be a separate compatibility-sensitive algorithm change and is out of scope here.
+
+### Edge-identified paths
+
+Plan 05 exclusively owns the additive `Path` / `WeightedPath` model and all public edge-identified path APIs. This plan
+owns only the compatibility contract: `PathResult<E>` remains exactly `{ path, distance, costs }` in type and runtime
+shape, and existing `dijkstra`, `astar`, and `bellmanFord` calls retain their signatures and result shapes. Do not add
+`EdgePathResult`, `includeEdges`, optional edge-index fields, or overloads to existing algorithms.
+
+The shared predecessor state owned by plan 03 retains `EdgeIndex` internally. Legacy results project selected edge data
+from that state; additive plan-05 APIs project `Path` / `WeightedPath`. Parallel equal-data edges must be distinguishable
+through the additive model without altering legacy deep equality. Edge-aware all-pairs output remains gated in plan 05.
+
+## Phased TDD plan
+
+### Phase 1: Freeze the contract fixtures
+
+1. Add small directed and undirected fixtures containing reciprocal edges, equal-data parallel edges, parallel
+   self-loops, sparse indexes, and mixed insertion directions.
+2. Add a test-only invariant checker that derives expected endpoint incidences from `Graph.edges`; if private storage
+   inspection is necessary, keep it local to `Graph.test.ts` and use it only to detect stale/over-counted indexes.
+3. Correct hash tests first: remove unequal-implies-different assertions and add a table/property-style equality-implies-
+   same-hash check over endpoint reversal, parallel edges, self-loops, and undefined payloads. Add equal graph pairs with
+   different allocator histories and assert equal hashes.
+
+Verify: tests fail only for the newly demonstrated semantic gaps, not for hash collisions.
+
+### Phase 2: Radius and neighbor semantics
+
+1. Add failing tests for every invalid radius against DFS, BFS, postorder, and neighborhood, including empty starts and
+   data-last forms.
+2. Add tests proving `start` is copied, a removed start is revalidated by each fresh iterator, fresh iterators snapshot
+   current mutable state, active iterators remain isolated, and all traversal families prioritize distinct roots in
+   supplied order. Retain the documented bounded-postorder membership pass rather than treating it as an
+   eager-traversal regression.
+3. Add directed parallel/self-loop and direction-ignored reciprocal-edge tests that pin unique stable ordering.
+4. Introduce one internal radius validator and separate unique-node lookup from multiplicity-preserving edge/arc
+   iteration. Do not reuse deduplicated neighbors in `topo`, degree, or weighted algorithms.
+5. Copy `start` after eager validation and reverse DFS's initial compact-root push so first occurrence has first priority.
+6. Update JSDoc to state the exact radius domain, snapshot timing, bounded-postorder exception, uniqueness, and ordering.
+
+Verify: radius matrix and neighbor matrix pass; existing traversal and topological tests remain unchanged.
+
+### Phase 3: Lifecycle and self-loop mutation invariants
+
+1. Add failing tests for direct double finalization, callback manual finalization on normal return, callback error after
+   manual finalization, and all mutators used through a finalized handle.
+2. Add undirected loop tests for removing one of multiple loops, removing a loop-bearing node, re-adding after removal,
+   and preserving unrelated/parallel edges.
+3. Make scoped cleanup preserve the primary callback error while still deactivating the handle. Keep public
+   `endMutation` single-use.
+4. Normalize or robustly consume loop incidences so removal is independent of duplicate collection. Coordinate any
+   representation change with the internal architecture owner.
+
+Verify: no callback error is masked; invariant checker reports no stale adjacency after every mutation sequence.
+
+### Phase 4: Edge copies and weighted search contracts
+
+1. Extend copy tests across repeated getters, repeated walkers, active mutable graphs, unsafe envelope mutation, and a
+   mutable object payload demonstrating intentional shallow sharing.
+2. Add a shared weight matrix for Dijkstra, A*, Bellman-Ford, and Floyd-Warshall: `-Infinity`, negative finite, `-0`,
+   zero, finite positive, `+Infinity`, and `NaN`; include unreachable invalid edges and source-equals-target.
+3. Add A* tests for invalid source estimate, invalid discovered estimate, zero-heuristic equivalence, negative finite
+   consistent estimates, and a documented inconsistent-heuristic counterexample that does not claim optimality.
+4. Align JSDoc for every weighted config/result. Avoid promising callback counts beyond graph-global validation where
+   that is part of correctness.
+
+Verify: weighted algorithms agree on their documented domains and A* never claims an unconditional shortest path.
+
+### Phase 5: Prepare edge-identified reconstruction
+
+1. Add regression tests proving the exact legacy `PathResult` runtime shape and ambiguity for equal-data parallel edges.
+2. Coordinate with plan 03 to retain `EdgeIndex` in predecessor records and derive legacy `costs` from selected edges.
+3. Leave all public edge-identified models, utilities, and enumeration APIs to plan 05.
+
+Verify: internal edge identity survives reconstruction and all old result deep-equality tests pass unchanged.
+
+## Test matrix
+
+| Area | Directed | Undirected | Parallel edges | Self-loop | Sparse/removal | Mutable | Data-last |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Radius validation/boundary | yes | yes | representative | yes | yes | yes | yes |
+| Traversal snapshot/config/order | all directions and multiple roots | all directions and multiple roots | representative | yes | start removed between iterations | primary subject | yes |
+| Neighbor uniqueness/order | outgoing/incoming/ignored | both authored orders | equal and unequal data | one result | missing node | yes | yes |
+| Mutation lifecycle | yes | yes | yes | yes | remove/re-add | primary subject | n/a |
+| Adjacency/removal invariant | yes | yes | multiple | multiple | node and edge removal | yes | n/a |
+| Equality/hash law | yes | endpoint reversal | paired by index | yes | allocator history ignored | reference law | n/a |
+| Edge copy semantics | yes | yes | yes | yes | missing edge | yes | getter yes |
+| Weight domain | all four algorithms | reverse traversal | lightest/tie | source=target | unreachable invalid edge | yes | yes |
+| A* heuristic | consistent/zero/inconsistent | representative | tie | source=target | unreachable node | yes | yes |
+| Legacy path compatibility | Dijkstra/A*/Bellman-Ford | reverse traversal | equal payload ambiguity pinned | trivial path | removed indexes absent | yes | yes |
+
+Use regular `it` and `assert` from `@effect/vitest` for these synchronous tests. Do not add `Effect.runSync`, timers, or
+random unseeded fixtures. Any property test introduced by the verification-foundation plan should consume the same
+seeded fixtures rather than duplicate generators.
+
+## Type-test additions
+
+Extend `packages/effect/typetest/Graph.tst.ts` with focused blocks for:
+
+1. `dijkstra`, `astar`, and `bellmanFord` data-first/data-last inference on directed, undirected, and mutable graphs.
+2. Exact `E` inference for `cost`, exact `N` inference for both A* heuristic parameters, and kind preservation.
+3. Compile-time rejection of `successors`, `predecessors`, `neighborsDirected`, and `topo` for undirected and
+   non-narrowed `Kind` graphs without `as any`.
+4. Existing weighted algorithms returning `Option.Option<PathResult<E>>`, with no edge-index field or edge-aware config.
+5. Mutation callbacks remaining synchronous and unable to return the result of `endMutation` where `undefined` is
+   required.
+6. Immutable graph covariance and mutable graph invariance at each changed overload, including data-last partial
+   application.
+
+## Validation commands
+
+Run the narrowest repository gates after each phase from the workspace root:
+
+```sh
+pnpm lint-fix
+pnpm --filter effect test --run test/Graph.test.ts
+pnpm test-types Graph.tst.ts
+pnpm check
+```
+
+When JSDoc examples in `Graph.ts` change, also run:
+
+```sh
+pnpm doctest --run packages/effect/src/Graph.ts
+```
+
+Never use bare `pnpm test` or bare `pnpm doctest`. The implementation PR should record any pre-existing failures
+separately from failures introduced by these phases.
+
+## Changesets and compatibility notes
+
+- Radius rejection, defensive `start` copying, DFS root-priority correction, directed neighbor deduplication, lifecycle
+  error precedence, and any self-loop removal correction
+  are runtime behavior fixes. Ship them with an `effect` patch changeset that explicitly calls out invalid-radius
+  rejection, DFS multi-root ordering, and directed parallel-neighbor deduplication as compatibility-sensitive.
+- Edge-copy documentation/tests need no new changeset if behavior remains unchanged. A runtime correction to copy
+  freshness does require a patch changeset.
+- Hash-test corrections alone require no changeset. Removing allocator history from equality/hash is an approved runtime
+  correction and requires a patch changeset that calls out the compatibility-sensitive semantic change.
+- Plan 05 owns changesets for additive edge-identified path APIs. Keep behavior-fix and additive-API changesets separate
+  so release notes distinguish corrected semantics from new capability.
+
+## Dependencies and ownership boundaries
+
+- **Requires:** no earlier graph plan. This plan establishes the contracts all later plans require.
+- **Verification and benchmark foundations:** owns seeded generators, property/differential harnesses, and reusable
+  oracle adapters. This plan owns only deterministic regression fixtures and the hash-law assertions needed now.
+- **Internal architecture and performance kernel:** owns the ordered arc iterator, dense snapshot, and final adjacency
+  representation. It must implement the self-loop incidence and stable-order contracts here; this plan must not create
+  a competing permanent representation.
+- **Core queries and transforms:** owns additive incident-edge/edges-between/degree APIs. Those APIs must preserve edge
+  multiplicity while neighbor-node APIs remain unique. This plan does not add degree solely to expose an internal fix.
+- **Traversal and path features:** exclusively owns the public `Path` / `WeightedPath` model, edge-aware path utilities,
+  all-pairs edge identity, and multi-path APIs. It consumes plan 03 reconstruction and may not alter `PathResult`.
+- **Connectivity and DAG algorithms:** owns cycle/component/topological feature expansion. It depends on correct
+  self-loop/parallel incidence and must not derive edge multiplicity from unique neighbors.
+- **Internal architecture and performance kernel:** owns the shared named weight/capacity policy implementation. Domain
+  algorithms consume it and cannot weaken graph-global Dijkstra/A* validation or redefine `+Infinity`.
+- **Schema serialization:** out of scope. Snapshot/hydration must preserve stable edge indexes and rebuild adjacency
+  according to these incidence contracts; it must not serialize mutable lifecycle state.
+- **Effect-native interruption:** out of scope until synchronous kernels stabilize. Additive interrupted variants must
+  report the same validation errors and path identities as synchronous variants.
+- **DOT, Mermaid, and consolidated docs:** may proceed independently after edge ordering and copy semantics are fixed;
+  they must continue to emit each logical self-loop and parallel edge once.
+
+Completion criterion: every contract above is represented by a deterministic runtime or type-level regression test,
+all compatibility-sensitive fixes are called out in changesets, legacy API signatures and legacy path-result object
+shapes remain intact, and later plans can consume one unambiguous definition of node uniqueness, edge multiplicity,
+self-loop incidence, traversal snapshot/configuration ownership, weight validity, and path edge identity.

--- a/docs/graph-plans/02-verification-benchmarks.md
+++ b/docs/graph-plans/02-verification-benchmarks.md
@@ -1,0 +1,565 @@
+# Verification and Benchmark Foundations
+
+## Objective
+
+Build one reproducible verification and performance foundation for all Graph work. The foundation must detect semantic
+regressions in directed and undirected multigraphs, distinguish algorithmic complexity regressions from machine noise,
+and produce reproducible performance artifacts without putting wall-clock thresholds in the normal test suite.
+
+This plan does not add Graph APIs or implement tests. It defines the fixtures, adapters, assertions, benchmark workloads,
+CI policy, and ownership boundaries that later Graph plans should use.
+
+## Assumptions and Constraints
+
+- Preserve the shared contracts in [`README.md`](./README.md#shared-semantics): stable monotonic indexes, deterministic
+  insertion order, unique neighbor-node queries, occurrence-preserving incident-edge queries, parallel edges, and
+  self-loops.
+- Verification infrastructure is development-only. Graphology and comparison libraries must be dev dependencies and
+  must not enter Effect's runtime exports or production dependency graph.
+- Pure Graph tests use regular `it` and `assert` from `@effect/vitest`; Effect-returning additions use `it.effect` and
+  never `Effect.runSync`, as required by [`.patterns/testing.md`](../../.patterns/testing.md#testing-framework-selection).
+- Property failures must print a replayable seed and, for fast-check tests, the replay path. Randomness without an
+  explicit seed is prohibited.
+- Correctness gates compare semantic results. They do not compare implementation-specific traversal orders from an
+  oracle library when Effect promises its own insertion/index order.
+- Timing benchmarks are evidence, not correctness tests. Deterministic operation counts are the primary complexity
+  regression gate whenever the operation can be counted.
+
+## Current Baseline
+
+The existing suite already has broad example coverage in
+[`packages/effect/test/Graph.test.ts`](../../packages/effect/test/Graph.test.ts): construction and stable allocation,
+set operations, mutation, parallel edges and self-loops, connectivity, shortest paths, traversals, and topological
+ordering. Pathfinding also has three larger terrain examples in
+[`packages/effect/test/Pathfinding.test.ts`](../../packages/effect/test/Pathfinding.test.ts#L26-L58). The missing layer is
+systematic seeded coverage, independent oracles, deterministic scaling checks, and a maintained benchmark corpus.
+
+The implementation currently exposes connectivity, shortest-path, traversal, and DAG algorithms from
+[`Graph.ts`](../../packages/effect/src/Graph.ts#L3445-L5808). Verification should be added beside the existing examples,
+not replace readable hand-checked cases.
+
+The package already has two performance mechanisms:
+
+- Ad hoc Tinybench scripts under `packages/effect/benchmark/`; the Optic benchmark demonstrates batching, an observable
+  sink, `hrtimeNow`, and normalized ns/op reporting
+  ([`Optic.ts`](../../packages/effect/benchmark/schema/Optic.ts#L4-L20),
+  [`Optic.ts`](../../packages/effect/benchmark/schema/Optic.ts#L75-L103)).
+- The maintained `runtimeperf` harness, which runs validated synchronous fixtures in fresh Node processes, calibrates
+  batches, rotates implementations, records raw results, and supports paired base/head comparisons
+  ([`runtimeperf/README.md`](../../packages/effect/runtimeperf/README.md#measurement-model),
+  [`run.mts`](../../packages/effect/runtimeperf/run.mts#L45-L98),
+  [`compare.mts`](../../packages/effect/runtimeperf/compare.mts#L144-L180)).
+
+Graph benchmarks should use `runtimeperf` as the authoritative harness. A small standalone Tinybench file is useful for
+local profiling only and must consume the same fixture definitions.
+
+## File Layout and Ownership
+
+Implement the foundation with the following development-only layout:
+
+| Path | Responsibility |
+| --- | --- |
+| `packages/effect/runtimeperf/suites/graph/fixtures/corpus.ts` | Neutral seeded graph specifications, PRNG, named corpus shapes, size tiers, and corpus fingerprints. No library imports. |
+| `packages/effect/runtimeperf/suites/graph/fixtures/effect.ts` | Convert a neutral specification to an Effect Graph and retain ordinal-to-`NodeIndex` / ordinal-to-`EdgeIndex` maps. |
+| `packages/effect/runtimeperf/suites/graph/fixtures/graphology.ts` | Graphology conversion for differential tests and benchmark scenarios. |
+| `packages/effect/runtimeperf/suites/graph/fixtures/competitors.ts` | Cross-library adapters only; no correctness normalization. Add ngraph or graphlib only for workloads with a comparable public API. |
+| `packages/effect/runtimeperf/suites/graph/fixtures/cases.ts` | `RuntimePerfCase` factories. Construction happens in the factory for steady-state cases and in `run` only for explicit cold/build cases. |
+| `packages/effect/test/GraphProperty.test.ts` | Algebraic, metamorphic, model-based mutation, and rich multigraph properties. |
+| `packages/effect/test/GraphDifferential.test.ts` | Hand-validated oracle adapters followed by seeded differential cases. |
+| `packages/effect/test/GraphComplexity.test.ts` | Deterministic operation-count and lazy-materialization guards; no elapsed-time assertions. |
+| `packages/effect/runtimeperf/config.json` | `graph` suite registry, scenario metadata, tiers, shapes, and implementations. |
+| `packages/effect/runtimeperf/README.md` | Commands, workload semantics, corpus description, and interpretation policy. |
+
+The corpus lives with the runtimeperf fixture directory because base/head materialization copies the complete fixture
+directory ([`materialize.mts`](../../packages/effect/runtimeperf/materialize.mts#L5-L13)). Tests may import these
+development-only modules directly. Do not place shared fixture code under `src/` or export it from `effect`.
+
+## Shared Seeded Fixtures
+
+### Neutral representation
+
+Define a readonly `GraphSpec` with only primitives:
+
+```ts
+type GraphSpec = {
+  readonly name: string
+  readonly seed: number
+  readonly kind: "directed" | "undirected"
+  readonly nodeCount: number
+  readonly edges: ReadonlyArray<readonly [source: number, target: number, weight: number, id: number]>
+}
+```
+
+Node data is its ordinal. Edge data is `{ readonly id: number; readonly weight: number }`. Explicit edge IDs preserve
+identity through normalization and distinguish equal-weight parallel edges. Keep generation separate from adaptation so
+every implementation receives the exact same edge list, following the reference harness's neutral-input rule
+([`.repos/graph/bench/compare/generate.ts`](../../.repos/graph/bench/compare/generate.ts#L1-L14)).
+
+Use a small, local 32-bit PRNG such as `mulberry32`, with its algorithm pinned by golden output for one seed. The reference
+generator is a suitable starting point ([`.repos/graph/tests/differential/generators.ts`](../../.repos/graph/tests/differential/generators.ts#L4-L13)),
+but add these safeguards:
+
+- Validate `nodeCount`, edge bounds, finite integer weights, and feasible simple-edge targets before generation.
+- Use tuple keys or strings for deduplication; do not encode `source * nodeCount + target` once sizes could exceed exact
+  integer arithmetic.
+- Return the requested node count exactly. Grid and layered generators must not silently round up.
+- Fingerprint the canonical neutral spec with SHA-256 and include the fingerprint in benchmark reports.
+- Generation is outside timed operations except explicit graph-construction scenarios.
+
+### Fixture families
+
+Maintain two disjoint families:
+
+1. `oracleSimple`: no self-loops or parallel edges, positive integer weights, directed and undirected variants. This is
+   the lowest common denominator for independent libraries.
+2. `effectRich`: self-loops, same-direction and reverse-direction parallel edges, disconnected nodes, sparse public
+   indexes created by deterministic removals, duplicate weights, and zero/negative weights where an algorithm permits
+   them. These fixtures verify Effect semantics through independent properties, not forced oracle equivalence.
+
+Use a fixed smoke seed set such as `[3, 7, 13, 21, 34, 55, 89, 144]`. Do not create one Vitest test per seed; run the
+seed matrix inside a named test so reporting remains readable, and include `kind`, shape, size, seed, and fingerprint in
+failure messages. Add one fast-check arbitrary over bounded neutral specs for shrinking. Configure its `seed`,
+`numRuns`, and `endOnFailure`; CI should print the fast-check replay path.
+
+### Corpus shapes and sizes
+
+| Shape | Construction | Semantic purpose |
+| --- | --- | --- |
+| `empty` / `singleton` | 0 or 1 node, optional loop | Boundary conditions and zero-sized allocations. |
+| `chain` | `i -> i + 1` | Deep traversal, path reconstruction, stack safety, and linear scaling. |
+| `starIn` / `starOut` | One hub with all incoming or outgoing arcs | Directionality, high degree, and adjacency hot paths. |
+| `cycle` | Ring, plus optional loop and parallel pair | SCC, acyclicity, and cycle semantics. |
+| `disconnected` | Several chains/cycles plus isolates | Components and unreachable paths. |
+| `grid` | Exact-size right/down lattice; undirected variant | Long alternative paths and A* heuristics. |
+| `layeredDag` | Fixed-width layers, local fanout, seeded skip edges | Topological order, workflow-like traversal, and many equal-cost paths. |
+| `uniformSparse` | Seeded random, spanning chain first, approximately 3 edges/node | General reachable sparse workload. |
+| `scaleFree` | Seeded preferential attachment | Hub-heavy degree distribution and asymmetric reachability. |
+| `dense` | Complete or fixed-density simple graph | Quadratic/cubic algorithms at deliberately small sizes. |
+| `parallelChain` | `k` edges per adjacent pair with repeated and distinct weights | Edge occurrence, tie-breaking, and multigraph hot paths. |
+| `loopHeavy` | Loop on a fixed fraction of nodes plus ordinary edges | Degree, cycle, and path loop semantics. |
+| `churnedSparse` | Build, remove deterministic nodes/edges, then add more | Sparse stable indexes and dense-snapshot translation. |
+
+Size tiers are workload-dependent rather than one global matrix:
+
+| Tier | Linear / `O((V+E) log V)` | Quadratic | Cubic / path-enumerating | Use |
+| --- | ---: | ---: | ---: | --- |
+| Unit | 0-64 nodes | 8-32 | 4-12 | Fast properties and oracle checks on every PR. |
+| Quick benchmark | 1,000 and 10,000 | 128 and 512 | 24 and 64 | Manual harness smoke and routine local comparison. |
+| Full benchmark | 100,000 | 1,000-2,000 | 128-256 | Dedicated-machine release investigation only. |
+
+Cap each workload based on its documented complexity. Never run Floyd-Warshall, all-path enumeration, or Brandes-like
+analytics at the same sizes as BFS. The reference benchmark's explicit betweenness cap is the precedent
+([`.repos/graph/bench/compare/run.ts`](../../.repos/graph/bench/compare/run.ts#L36-L44)).
+
+## Correctness Normalization
+
+All adapters return normalized semantic values before comparison:
+
+| Result | Normal form |
+| --- | --- |
+| Node set | Ascending neutral node ordinal. |
+| Ordered Effect traversal | Exact Effect `NodeIndex` sequence; compare only to a hand-written reference traversal using insertion order. |
+| Components / SCCs | Sort ordinals within each component, then sort components lexicographically. |
+| Path | `{ reachable, distance, nodes, edgeIds }`; verify endpoints, edge continuity, direction, and recomputed weight before any oracle comparison. |
+| Oracle shortest path | Compare reachability and minimum distance. Do not compare the chosen node/edge sequence when equal-cost alternatives exist. |
+| Topological result | Verify every node occurs once and every directed edge has `position(source) < position(target)`; test Effect's tie order separately. |
+| Cycles | Edge-ID sequence canonicalized by minimum rotation; for undirected cycles also choose the lexicographically smaller orientation. Keep loop and two-parallel-edge cycles distinct. |
+| Floating scores | Map by neutral ordinal, verify finite values and normalization invariant, then compare with documented absolute plus relative tolerance. |
+| Spanning tree / forest | Canonical edge-ID set plus component count, acyclicity, coverage, and total weight. Do not require the same edges under ties. |
+
+Never normalize away behavior that Effect promises. In particular, separate assertions must retain public index holes,
+edge occurrence counts, and insertion order. The reference differential suite correctly canonicalizes only unordered
+component results ([`.repos/graph/tests/differential/oracle.test.ts`](../../.repos/graph/tests/differential/oracle.test.ts#L50-L55))
+and compares shortest-path weights rather than selected paths
+([`.repos/graph/tests/differential/oracle.test.ts`](../../.repos/graph/tests/differential/oracle.test.ts#L102-L130)).
+
+## Algebraic and Property Tests
+
+### Core graph laws
+
+Run each applicable law for both kinds and over rich multigraph fixtures:
+
+- `reverse(reverse(g))` is structurally equal to `g`, including edge IDs/data, allocator state, loops, parallel-edge
+  order, and sparse indexes; `reverse(g)` is a no-op structurally for undirected graphs.
+- Empty mutation preserves structural equality, hash, allocator state, node order, and edge order.
+- Mutating a graph does not change the source graph; finalization prevents further writes to the mutable handle.
+- Add/update/remove command sequences agree with a small independent `Map`-based model. Removing a node removes exactly
+  its incident edge occurrences and never reuses indexes.
+- `mapNodes(identity)`, `mapEdges(identity)`, `filterNodes(always)`, and `filterEdges(always)` preserve structure.
+- Node filtering leaves exactly the induced edge multiset. Edge filtering preserves all nodes and selected edge IDs.
+- Directed reverse swaps predecessor/successor sets and preserves degree totals. Undirected endpoint reversal is
+  semantically equal.
+- `compose` is idempotent under its documented set identity; intersection/difference/symmetric-difference obey their
+  membership laws using occurrence-aware expected models. Do not assume bag laws where current set operations
+  deliberately deduplicate equal identities, as pinned by
+  [`Graph.test.ts`](../../packages/effect/test/Graph.test.ts#L459-L494).
+- Equal immutable graphs have equal hashes. Do not assert the invalid converse that unequal graphs must have unequal
+  hashes.
+
+### Query and algorithm laws
+
+- Neighbor queries are duplicate-free and ordered by first incident edge occurrence; incident-edge queries retain every
+  parallel edge occurrence.
+- Sum of directed in-degrees and out-degrees is `E` each. Sum of undirected graph-theoretic degrees is `2E`, including
+  loops contributing two. Validate these independently from adjacency storage.
+- A directed loop and undirected loop are cycles; two parallel undirected edges are a cycle; one undirected edge is not.
+- `isBipartite` is invariant under edge orientation for undirected input, rejects every loop, accepts even cycles, and
+  rejects odd cycles. Validate returned partitions when an additive API supplies them.
+- Connected components partition all nodes and every edge remains within one component. SCCs partition all directed
+  nodes, are mutually reachable internally, and the condensation graph is acyclic.
+- BFS depths are nondecreasing. DFS/BFS/DFS-postorder yield each reachable node once, obey radius bounds, and restart
+  deterministically on every iteration.
+- A topological order is a permutation satisfying all edges; one exists exactly when a directed graph is acyclic.
+- Every returned path is valid and its reported distance equals its edge sum. Dijkstra, Bellman-Ford, Floyd-Warshall,
+  and A* with a zero heuristic agree on nonnegative fixtures. Bellman-Ford and Floyd-Warshall agree on negative-edge,
+  no-negative-cycle DAGs.
+- Adding a dominated heavier parallel edge cannot improve a shortest distance. Adding a nonnegative self-loop cannot
+  improve one. Removing an unused edge from a uniquely shortest path fixture does not change that result.
+- A* with an admissible grid heuristic returns the Dijkstra distance. An inconsistent but admissible heuristic gets a
+  dedicated regression fixture if the implementation claims to support reopening.
+- Floyd-Warshall diagonal distances are zero without a negative cycle, its finite distances satisfy triangle
+  inequalities, and each reconstructed path matches the matrix distance.
+
+The richer property family is the authority for multigraph behavior. The reference repository uses the same split
+between simple oracle graphs and rich self-property graphs
+([`.repos/graph/tests/differential/generators.ts`](../../.repos/graph/tests/differential/generators.ts#L29-L37),
+[`properties.test.ts`](../../.repos/graph/tests/differential/properties.test.ts#L24-L27)).
+
+## Differential Oracle Matrix
+
+Every oracle group starts with one hand-computed fixture that proves both adapters implement the intended convention.
+Only then run the seeded matrix. This prevents two adapters from agreeing on the wrong interpretation, following
+[`oracle.test.ts`](../../.repos/graph/tests/differential/oracle.test.ts#L21-L28).
+
+| Effect behavior | Graphology oracle | Domain | Comparison and limits |
+| --- | --- | --- | --- |
+| Neighbor/predecessor/successor sets and degree | Graphology core | Simple directed/undirected; degree may additionally use rich multi graphs after pinned loop checks | Compare sets/counts only. Effect insertion order and occurrence-preserving edge APIs use independent properties. |
+| Connected components | `graphology-components` | Undirected simple and rich; directed only if Effect later exposes explicitly weak components | Canonical partitions. Current `connectedComponents` accepts undirected graphs, so do not silently broaden its contract. |
+| Strongly connected components | `graphology-components` SCC implementation | Directed simple; rich after loop/parallel hand checks | Canonical partitions, plus independent condensation law. |
+| Dijkstra | `graphology-shortest-path` | Positive-weight simple directed/undirected | Reachability and distance. Graphology node paths cannot oracle Effect edge identity or tie order. |
+| Bellman-Ford, Floyd-Warshall, A* | Graphology Dijkstra as a cross-algorithm oracle | Nonnegative simple graphs only | Compare distances. Negative edges/cycles and heuristic behavior require independent properties. |
+| BFS reachability | Graphology neighbor APIs with a minimal queue | Simple directed/undirected | Reachable set and depth only; Effect traversal order remains independently specified. |
+| PageRank, betweenness, eigenvector centrality when added | `graphology-metrics` | Start with simple graphs and exactly matched options/normalization | Numeric tolerance after hand checks. Parallel-edge path multiplicity, loops, convergence, and tie semantics remain independent until explicitly proven equivalent. The reference suite documents these tolerance and option hazards ([`oracle.test.ts`](../../.repos/graph/tests/differential/oracle.test.ts#L193-L203), [`oracle.test.ts`](../../.repos/graph/tests/differential/oracle.test.ts#L411-L445)). |
+
+Do not use Graphology as the authority for:
+
+- structural equality/hashing, stable numeric allocation, mutation scopes, set-operation identity, or deterministic
+  insertion order;
+- occurrence-preserving incident edges and selected edge identity through parallel-edge paths;
+- Effect's explicit cycle rule that two parallel undirected edges form a cycle;
+- negative-cycle validation, invalid weight/heuristic errors, or `Option`/`GraphError` behavior;
+- lazy/eager pairing, interruption checkpoints, or output formats;
+- any algorithm whose options or normalization cannot be made identical.
+
+Graphology itself supports multigraphs, but support is not semantic equivalence. Admit a rich oracle case only after a
+small loop and parallel-edge fixture demonstrates the same convention. Otherwise use algebraic laws or a deliberately
+simple independent implementation bounded to unit-size graphs.
+
+## Deterministic Complexity Guards
+
+Elapsed-time assertions such as those in the reference read-path regression suite
+([`perf-regression.test.ts`](../../.repos/graph/tests/perf-regression.test.ts#L20-L75)) are too machine-dependent for the
+normal Effect suite. Retain its stronger idea: count observable work, as its lazy-path checks count indexed reads rather
+than time ([`perf-regression.test.ts`](../../.repos/graph/tests/perf-regression.test.ts#L78-L145)).
+
+Define a non-public probe vocabulary owned jointly with the internal architecture plan:
+
+```ts
+type GraphAlgorithmProbe = {
+  nodeDiscovered(): void
+  nodeDequeued(): void
+  arcExamined(edge: Graph.EdgeIndex): void
+  relaxationAttempted(edge: Graph.EdgeIndex): void
+  queuePush(): void
+  pathEdgeMaterialized(edge: Graph.EdgeIndex): void
+  checkpoint(): void
+}
+```
+
+Public wrappers pass no probe. Tests import internal kernels or construct them through a test-only internal factory; do
+not add public options, ambient globals, proxies, or production branching solely for tests. The internal architecture
+plan owns probe plumbing through the shared ordered arc iterator and dense snapshot. This plan owns fixtures and bounds.
+
+Add deterministic guards for:
+
+- BFS, DFS, components, SCC, topological sort, and acyclicity: discovered nodes `<= V`, arc examinations bounded by the
+  documented directed/undirected arc expansion, and doubling `V + E` doubles work within a small additive constant.
+- Dijkstra/A*: weight validation and arc examinations are linear in the reachable graph; heap pushes are bounded by
+  successful relaxations plus initialization. Do not assert a particular heap implementation.
+- Bellman-Ford: at most `(V - 1)E` relaxation attempts plus one negative-cycle pass; early exit is asserted only on a
+  fixture designed for it.
+- Floyd-Warshall: exact or tightly bounded `V^3` transition count over dense positions; sparse public indexes must not
+  change the count.
+- Queries and transforms: predicate/mapper invocation counts equal the relevant node or edge occurrence count. Reverse
+  and filtering remain linear under size doubling.
+- Lazy APIs added by later plans: consuming zero, one, or `k` results materializes only those result paths/cycles plus
+  unavoidable search state. Full collection is a sanity check that all results are eventually materialized.
+- Checkpoint-enabled kernels: checkpoint counts scale at the documented cadence and are independent of wall time.
+
+Use exact counts where the contract is implementation-independent; otherwise assert asymptotic bounds and ratios on
+`n`, `2n`, and `4n`. Each guard must include a deliberately quadratic or eager local fake in its test development history
+to prove the bound would fail. Do not retain the fake.
+
+## Microbenchmarks
+
+Register Effect-only scenarios under the `graph` runtimeperf suite. Each factory returns `{ run, validate }`, matching
+the existing fixture contract ([`runtimeperf/README.md`](../../packages/effect/runtimeperf/README.md#fixture-contract)).
+Validation must run before and after measurement, as the worker already guarantees
+([`worker.mts`](../../packages/effect/runtimeperf/worker.mts#L33-L54),
+[`worker.mts`](../../packages/effect/runtimeperf/worker.mts#L124-L148)).
+
+Required scenario families:
+
+- `build`: cold construction from a neutral spec; validate counts and corpus fingerprint.
+- `lookup`: batched `getNode`, `getEdge`, `hasNode`, and `hasEdge` over a deterministic index schedule, including a
+  churned sparse graph.
+- `adjacency`: full neighbors/predecessors/successors sweeps on sparse, star, loop-heavy, and parallel-heavy shapes.
+- `mutation`: one scoped batch of adds, updates, edge removals, and node removals from a prebuilt source.
+- `transform`: reverse, node/edge map/filter, induced neighborhood, and set operations.
+- `traversal`: fully consume BFS, DFS, DFS-postorder, topo, components, SCC, acyclicity, and bipartite checks.
+- `shortest-path`: Dijkstra, zero-heuristic and grid-heuristic A*, Bellman-Ford, and Floyd-Warshall at complexity-appropriate
+  tiers. Separate reachable, unreachable, equal-weight, parallel-edge, and sparse-index scenarios.
+- `lazy`: first result, first 10 results, and full collection for future lazy APIs. Never benchmark creating an iterator
+  without consuming the intended amount.
+- Future algorithms add scenarios only after correctness/property coverage and validation are complete.
+
+Keep setup and result validation outside `run`; consume iterators and return a semantic scalar or compact checksum so
+dead work cannot disappear. Let runtimeperf calibrate batches instead of hard-coding iteration counts. Record graph
+`V`, `E`, kind, shape, seed, fingerprint, operation, cold/steady state, and expected complexity in registry metadata.
+
+Use `pnpm runtimeperf graph/<case>` for exploratory absolute numbers and
+`pnpm runtimeperf-compare graph/<case> --base main --head HEAD` for authoritative source-change comparisons. The harness
+already uses independent worker processes and treats those processes, not Tinybench's internal samples, as statistical
+observations ([`runtimeperf/README.md`](../../packages/effect/runtimeperf/README.md#measurement-model)).
+
+## Cross-Library Benchmark Harness
+
+Extend the runtimeperf `graph` suite with implementations grouped by a shared `scenario`, so existing rotating order and
+paired ratio reporting apply ([`run.mts`](../../packages/effect/runtimeperf/run.mts#L53-L98)). Initial competitors:
+
+- Graphology for build, adjacency/degree, BFS reachability, Dijkstra, components, and supported analytics.
+- ngraph for build, directed traversal, degree sweep, and idiomatic `ngraph.path` shortest path.
+- `@dagrejs/graphlib` for build, traversal, components, and its available all-target Dijkstra, clearly labeled as a
+  different API cost.
+
+Do not add Cytoscape initially: it is primarily a visualization toolkit and makes the matrix slower without improving
+coverage of Effect's graph-kernel decisions. Add another library only when it has an idiomatic equivalent operation and
+the maintenance cost is justified.
+
+Fairness requirements:
+
+- Every adapter builds from the same simple directed or simple undirected `GraphSpec`; cross-library cases never use
+  loops or parallel edges unless every compared adapter has demonstrated matching semantics.
+- Call each library's public, idiomatic API. A minimal traversal loop over a public neighbor API is allowed only when the
+  library has no traversal helper, and must be identical in purpose across adapters.
+- Mark unsupported operations as unavailable rather than implementing a competitor's missing algorithm in the harness.
+- Separate build from steady-state operations. Warm any lazy index consistently before steady-state timing and record
+  that policy in scenario metadata.
+- Validate every adapter's output against the normalized expected result before timing. A benchmark that computes a
+  different answer is invalid, not merely a slow or crashed cell.
+- Label non-equivalent APIs prominently. The reference adapter's graphlib Dijkstra caveat is a good example
+  ([`.repos/graph/bench/compare/adapters.ts`](../../.repos/graph/bench/compare/adapters.ts#L178-L205)).
+- Cross-library results are diagnostic; base/head Effect comparisons are authoritative, matching current runtimeperf
+  policy ([`runtimeperf/README.md`](../../packages/effect/runtimeperf/README.md#L10-L12)).
+
+## Memory and Allocation Measurement
+
+Do not infer memory from ordinary timing workers. Add a separate opt-in runtimeperf mode with fresh processes and
+`--expose-gc`:
+
+1. Build or run one validated warmup, release warmup results, and force GC.
+2. Record `process.memoryUsage()` and V8 heap statistics.
+3. Build/run `k` identical independent fixtures, retaining only the values named by the scenario.
+4. Force GC and record the post-state.
+5. Report `(post - pre) / k` retained heap, `heapTotal`, `external`, and `arrayBuffers`, with raw before/after values.
+6. Repeat in independent workers and report median and MAD. A negative delta is retained as raw noise, not clamped.
+
+Measure these separately:
+
+- retained bytes per node/edge after graph construction;
+- temporary retained bytes after traversal/shortest-path completion with results released;
+- retained result size for all-pairs and eager multi-result APIs;
+- lazy iterator retained size before consumption, after one result, and after full consumption;
+- dense-snapshot/cache retained size before and after first hot-algorithm use.
+
+Heap deltas do not measure total allocation churn. For allocation investigations, add an opt-in Node Inspector
+`HeapProfiler.startSampling` mode (or `--heap-prof` artifact) and report sampled allocated bytes by stack. Sampling
+profiles are diagnostic artifacts only: do not gate CI on them or compare them as exact counts. Prefer deterministic
+`pathEdgeMaterialized`, queue-push, snapshot-build, and array-capacity probe counts when those answer the regression
+question.
+
+Memory fixtures must run one scenario per process, record Node/V8 version and flags, and avoid sharing cached Graph
+instances across samples. Compare base/head on the same machine with alternating order; do not publish cross-machine
+byte deltas as regressions.
+
+## Result Reporting
+
+Retain runtimeperf's JSON as the source of truth and add Graph-specific metadata without creating a second timing
+harness. Each report must contain:
+
+- schema version, run ID, Git refs and dirty-state hash;
+- Node, V8, OS, architecture, CPU model, core count, and relevant Node flags;
+- exact package versions for all adapters;
+- fixture name, kind, shape, requested/actual `V` and `E`, seed, corpus fingerprint, and size tier;
+- operation, implementation, setup/warm-state policy, expected complexity, batch size, execution order, all worker
+  measurements, median, MAD, and statistical comparison;
+- validation checksum and status;
+- memory raw snapshots or allocation-profile artifact path when that mode is used;
+- explicit statuses for unsupported, invalid-adapter, timeout, crash, and skipped-by-size-cap.
+
+Generate a Markdown summary from JSON rather than editing result tables manually. Show Effect base/head first, then
+cross-library ratios. Flag sub-resolution and high-variance cells instead of ranking them. Include methodology and
+fairness notes beside every generated table. The reference reports capture environment and generate documentation from
+JSON ([`.repos/graph/docs/benchmarks.md`](../../.repos/graph/docs/benchmarks.md#L176-L209)); Effect should keep generated
+artifacts under `tmp/runtimeperf/results/` rather than committing machine-specific numbers.
+
+## CI Policy
+
+| Gate | Trigger | Contents | Failure policy |
+| --- | --- | --- | --- |
+| Graph unit/property | Every PR through normal targeted/package tests | Hand examples, fixed smoke seeds, bounded fast-check properties, deterministic complexity guards | Required. Fail on semantic mismatch, replayable property failure, or operation-count bound. |
+| Differential | Every PR when Graph tests run | Unit-size simple corpus against Graphology plus rich independent laws | Required. No network and no timing assertions. |
+| Runtimeperf harness tests | Changes under `runtimeperf` or Graph benchmark fixtures | Registry/materialization/worker/report tests with tiny fixtures | Required. Verify the harness, not speed. |
+| Quick benchmark smoke | Manual dispatch, optionally nightly | Unit/quick subset, one or two shapes per complexity class, all installed adapters | Fail only on harness error, invalid result, missing artifact, or crash in a required Effect case. Never fail on shared-runner timing. |
+| Base/head performance | Maintainer-invoked or dedicated runner | Selected affected Effect scenarios with paired rounds | Informational by default; `--fail-on-regression` only after maintainer review and existing statistical classification. |
+| Full cross-library and memory | Manual dedicated machine | Full size matrix, retained-memory workers, optional allocation profiles | Artifact only. Never a PR gate. |
+
+Shared CI runners are unsuitable for canonical timing. The reference repository's benchmark workflow is manual and
+uploads JSON solely to prove reproducibility ([`.repos/graph/.github/workflows/bench.yml`](../../.repos/graph/.github/workflows/bench.yml#L1-L11));
+use the same policy.
+
+When a deterministic guard and a timing result disagree, investigate both, but do not weaken the deterministic bound
+because a noisy timing run happened to pass. Timing regressions require reruns on the same quiet machine, inspection of
+raw rounds, and a correctness check before action.
+
+## Implementation Phases
+
+### Phase 1: Corpus and adapters
+
+1. Add the neutral PRNG/spec generator, shape builders, size tiers, fingerprints, and Effect adapter.
+2. Add unit tests for deterministic PRNG output, exact sizes, edge validity, simple/rich constraints, and adapter
+   preservation of node/edge identity.
+3. Add Graphology development dependencies and adapter, with hand-checked loop/parallel probes documenting admitted and
+   excluded domains.
+
+Success criteria:
+
+- The same `(shape, size, seed, kind)` yields byte-for-byte identical neutral specs and fingerprints across runs.
+- Effect adaptation preserves exact edge occurrence and insertion order and can represent sparse public indexes.
+- Oracle adapters reject unsupported semantics rather than silently coercing them.
+
+### Phase 2: Property and differential verification
+
+1. Add core/model laws and rich multigraph properties.
+2. Add hand-checked oracle fixtures, then the simple seeded differential matrix.
+3. Add normalization helpers and ensure every failure reports replay metadata.
+4. Migrate no existing readable example unless duplication becomes materially expensive.
+
+Success criteria:
+
+- Every current Graph algorithm has at least one algebraic/metamorphic law in addition to examples.
+- Every oracle comparison is preceded by a hand-computed convention check.
+- Loops, parallel edges, disconnected graphs, sparse indexes, equal weights, and invalid weights each occur in dedicated
+  rich properties.
+- Restoring a known prior bug or introducing an adapter direction error causes a focused property/differential failure.
+
+### Phase 3: Deterministic complexity instrumentation
+
+Depends on the internal architecture/performance-kernel plan for the ordered arc iterator, dense snapshot, and internal
+probe plumbing. The probe vocabulary and tests can be prepared earlier; production plumbing lands with that plan.
+
+1. Instrument internal kernels without changing public signatures or behavior.
+2. Add exact/asymptotic count guards and lazy-materialization checks.
+3. Verify each bound against `n`, `2n`, and `4n` fixtures and against sparse-index variants.
+
+Success criteria:
+
+- Normal test execution contains no wall-clock threshold for Graph complexity.
+- A linear-to-quadratic adjacency regression and eager path materialization both fail deterministically.
+- Probe-disabled production paths have no observable semantic difference; benchmark the probe-disabled path only.
+
+### Phase 4: Runtimeperf Graph suite
+
+1. Generalize registry coverage metadata where current schema-specific `astTags` assumptions require it
+   ([`utils.mts`](../../packages/effect/runtimeperf/utils.mts#L218-L228)); do not fake Graph AST tags.
+2. Register validated Effect microbenchmarks by complexity tier.
+3. Add targeted registry, worker, materialization, and report tests.
+4. Document commands and interpretation in `runtimeperf/README.md`.
+
+Success criteria:
+
+- Every registered case validates before and after timing and returns synchronously.
+- `runtimeperf-compare` can materialize Graph fixtures in base/head worktrees without importing the current worktree's
+  fixture code.
+- Quick and selected base/head runs emit complete reproducible JSON with corpus fingerprints.
+
+### Phase 5: Cross-library, memory, and CI reporting
+
+1. Add only semantically comparable competitor adapters and normalized preflight validation.
+2. Add opt-in retained-memory workers and allocation-profile artifacts.
+3. Add JSON-to-Markdown Graph summaries and the manual quick workflow.
+4. Run a clean-checkout rehearsal before treating the harness as maintained infrastructure.
+
+Success criteria:
+
+- Every cross-library cell uses identical neutral input and records unsupported operations honestly.
+- Shared-runner jobs never fail due to timing ratios.
+- Memory reports isolate scenarios in fresh `--expose-gc` workers and retain raw readings.
+- A result can be reproduced from its command, Git refs, seed, fingerprint, versions, and Node flags.
+
+## Dependencies and Coordination
+
+- Requires the correctness-contract plan and the shared semantics in [`README.md`](./README.md#shared-semantics).
+- May begin before algorithm expansion: corpus generation, current properties, current Graphology checks, and runtimeperf
+  registry work are independent.
+- Deterministic kernel probes require the internal architecture/performance plan. That plan owns the ordered arc iterator,
+  dense snapshot, and probe plumbing; this plan owns probe names, fixtures, and assertions.
+- Each later domain plan owns algorithm-specific examples and properties, but must register shared fixtures and
+  benchmarks here rather than create private generators or timing scripts.
+- Effect-native interruption tests depend on the later checkpoint implementation. This plan reserves deterministic
+  checkpoint counts but does not introduce asynchronous timing tests.
+- Graphology oracle dependencies should land with the first differential tests. ngraph/graphlib dependencies should land
+  only with cross-library scenarios that use them.
+- No changeset is needed for development-only tests, fixtures, benchmark infrastructure, or documentation.
+
+## Verification Commands for the Implementation
+
+Use targeted commands while phases land; never run the unbounded whole-suite/watch commands:
+
+```sh
+pnpm lint-fix
+pnpm --filter effect test --run test/Graph.test.ts
+pnpm --filter effect test --run test/GraphProperty.test.ts
+pnpm --filter effect test --run test/GraphDifferential.test.ts
+pnpm --filter effect test --run test/GraphComplexity.test.ts
+node --test packages/effect/runtimeperf/test/*.test.mts
+pnpm check
+```
+
+Performance verification is explicit and non-gating unless requested:
+
+```sh
+pnpm runtimeperf graph
+pnpm runtimeperf graph/<scenario>
+pnpm runtimeperf-compare graph/<scenario> --base main --head HEAD
+pnpm runtimeperf-compare graph --base main --head HEAD --fail-on-regression
+```
+
+The implementation should add documented selectors for quick cross-library and memory modes before advertising exact
+commands for those modes. Do not overload ordinary `pnpm test` with benchmarks or GC/profile workers.
+
+## Completion Criteria
+
+This foundation is complete when:
+
+- correctness, property, differential, deterministic-complexity, microbenchmark, and cross-library suites consume one
+  versioned neutral corpus;
+- every random failure is replayable and every unordered result has an explicit normal form;
+- Graphology is used only inside proven-equivalent domains, while Effect multigraph/self-loop/index/order semantics are
+  protected by independent laws;
+- operation-count guards cover the hot asymptotic contracts without brittle elapsed-time assertions;
+- runtimeperf produces validated, base/head-comparable Graph results with raw rounds, environment, versions, seed, and
+  corpus fingerprint;
+- retained-memory and allocation diagnostics are isolated, opt-in, and never presented as deterministic CI facts;
+- CI blocks semantic and complexity regressions, verifies the benchmark harness, and leaves noisy performance judgment
+  to paired runs on controlled hardware.

--- a/docs/graph-plans/03-internal-architecture-performance.md
+++ b/docs/graph-plans/03-internal-architecture-performance.md
@@ -1,0 +1,575 @@
+# Internal Architecture and Performance
+
+## Status and intent
+
+This plan owns non-breaking internal architecture and runtime performance work for `effect/Graph`. It follows the
+correctness-contract and verification/benchmark foundations in the dependency order from `README.md`; it does not add
+graph features or change public signatures.
+
+The default outcome is still one public module, `effect/Graph`. Storage, iteration, queues, snapshots, and algorithm
+kernels remain implementation details under `packages/effect/src/internal/graph/`. A public kernel is explicitly not part
+of this program.
+
+Implementation checkpoint after `a371754b1e`: `packages/effect/src/internal/graphCsr.ts` now provides lazy compact-node
+translation, outgoing/incoming CSR, compact edge positions, and mutation invalidation. Traversal, topology, immutable
+weighted paths, cycle/connectivity work, and several queues already consume it. The remaining plan must harden and measure
+that architecture rather than introduce a second dense representation.
+
+## Success criteria
+
+- Preserve directed and undirected behavior, stable monotonic `NodeIndex` and `EdgeIndex` allocation, insertion/index
+  ordering, parallel edges, self-loops, lazy walkers, errors, equality, hashing, and scoped mutation behavior.
+- Replace every hot FIFO `Array.shift()` with an amortized O(1) queue without changing traversal order.
+- Let algorithms consume ordered arcs without first allocating neighbor arrays or losing `EdgeIndex` identity or edge
+  multiplicity.
+- Remove the unconditional second full storage copy at mutation finalization; consider copy-on-write mutation startup
+  only after the simpler change is measured.
+- Share deterministic binary-heap machinery between weighted algorithms without making it public.
+- Use sparse-to-dense translation and CSR typed arrays only where benchmarked workloads recover their construction and
+  memory cost. The ordinary map/adjacency representation remains canonical.
+- Make every retained cache correct for immutable and mutable graph lifecycles, including leaked finalized mutable
+  handles and graphs with sparse public indexes.
+- Keep all unbounded graph algorithms stack-safe.
+- Require behavioral parity and paired benchmark evidence before and after each performance phase, with a local rollback
+  point for every optimization.
+
+## Non-goals
+
+- No public representation, kernel, priority queue, snapshot, CSR, invalidation, or cache API.
+- No change to `Graph`, `MutableGraph`, `Edge`, walker, path-result, constructor, or mutation signatures.
+- No index reuse, implicit sorting, adjacency deduplication, or conversion of public indexes into array offsets.
+- No freezing, proxies, property descriptors, or reliance on callers being unable to retain a mutable handle.
+- No mixed or bidirectional edge kind, worker/Wasm kernel, automatic parallelism, or speculative algorithm-result cache.
+- No Schema implementation. This plan only defines the internal snapshot/hydration seam shared with the Schema plan.
+- No timing assertions in ordinary unit tests. CI-safe complexity tests may count observable callback or iterator work;
+  throughput and memory gates belong in the benchmark harness.
+
+## Current baseline
+
+`packages/effect/src/Graph.ts` remains the public implementation module, with derived dense traversal state extracted to
+`packages/effect/src/internal/graphCsr.ts`.
+
+- Canonical state is `Map<NodeIndex, N>`, `Map<EdgeIndex, Edge<E>>`, and outgoing/incoming
+  `Map<NodeIndex, Array<EdgeIndex>>` adjacency.
+- Public indexes are stable monotonic identifiers and can be sparse after removals. Map iteration and adjacency-array
+  order currently provide deterministic node, edge, and traversal order.
+- CSR captures compact node IDs/data at iterator creation, builds directional adjacency lazily, preserves canonical row
+  order, and is cached by graph shell with invalidation on public mutation. Active traversal iterators retain their prior
+  snapshot while fresh iterators rebuild after mutation.
+- DFS, BFS, postorder, topo, cycle/connectivity, and immutable weighted algorithms have substantial CSR migrations. BFS,
+  bounded-postorder membership, topo, and immutable Bellman-Ford use head-index or typed FIFO queues.
+- Two `shift()` hot loops remain in mutable `isBipartite` and mutable Bellman-Ford negative-cycle reachability. Mutable
+  Bellman-Ford also retains repeated `unshift()` path reconstruction.
+- Public directed neighbor queries still collect one node per parallel edge. The CSR and canonical paths agree on that
+  current bug; plan 01 owns deduplication without changing multiplicity-preserving algorithm rows.
+- Dijkstra and A* already use a binary min-heap with insertion sequence as a deterministic tie-breaker. Entries are
+  objects and the heap helpers are embedded in `Graph.ts`.
+- `beginMutation` copies both maps and every adjacency array. `endMutation` then copies the maps and every adjacency
+  array again. The second copy protects the immutable result from a leaked mutable handle, while
+  `Equal.byReferenceUnsafe` irreversibly gives the mutable shell reference equality.
+- `acyclic` is cached in graph state and manually invalidated by structural mutations. CSR uses a separate private
+  `WeakMap` cache and explicit invalidation.
+
+The useful lessons from `.repos/graph` are its dense translation, CSR arc arrays, versioned cache tests, typed min-heap,
+and deterministic performance sentinels. Its public kernel and caller-visible invalidation API are not suitable here:
+Effect graph storage is opaque, and all supported structural mutation already passes through scoped APIs.
+
+## Required semantic inventory
+
+Before changing internals, add one table-driven parity fixture that records public results from the current
+implementation for both graph kinds. It must include:
+
+- empty, disconnected, chain, wide star, diamond, cycle, and deep-chain graphs;
+- removed nodes and edges producing large gaps in otherwise small stable indexes;
+- parallel edges with equal and unequal data;
+- directed and undirected self-loops;
+- an undirected edge inserted with either endpoint as `source`;
+- multiple starts, duplicate starts, all traversal directions, finite radii, and lazy early termination;
+- equal-priority shortest paths and equal-weight parallel edges;
+- mutation with no writes, node-data-only writes, edge-data-only writes, structural additions/removals, `reverse`, and a
+  callback that throws;
+- retained mutable handles queried and used in attempted mutations after finalization;
+- equality, hash, node/edge iteration, next-index allocation, and exact `GraphError` behavior.
+
+The fixture should assert exact arrays where order is public behavior, not set equality. Oracle and property suites from
+the verification plan remain authoritative for broader correctness.
+
+## Target internal architecture
+
+### Canonical storage
+
+Keep maps and ordered adjacency as the canonical, mutation-friendly storage. Introduce an internal `GraphStorage<N, E>`
+owned by graph shells, containing nodes, edges, both adjacency maps, next indexes, and structural metadata. Public graph
+objects remain opaque shells implementing the existing protocols.
+
+An immutable shell never mutates its storage. A mutable shell may mutate only through Graph mutation functions and has
+an explicit active/finalized lifecycle. Internal ownership flags are ordinary fields; they are not enforcement through
+freeze, proxy, or descriptors.
+
+### Ordered arc kernel
+
+Use one allocation-free callback or cursor primitive rather than generators in the hottest loops. Its conceptual record
+is:
+
+```ts
+type Arc<E> = {
+  readonly from: NodeIndex
+  readonly to: NodeIndex
+  readonly edgeIndex: EdgeIndex
+  readonly edge: Edge<E>
+}
+```
+
+The implementation should pass these fields as callback parameters or expose them through a reusable cursor to avoid
+allocating this record. The edge envelope is internal and read-only by convention; public APIs still return fresh copies.
+The cursor supports `"outgoing"`, `"incoming"`, and direction-ignored traversal.
+
+- Directed outgoing and incoming arcs follow the corresponding adjacency list in `EdgeIndex` insertion order.
+- Direction-ignored traversal over a directed graph emits outgoing arcs first, then incoming arcs, preserving
+  `EdgeIndex` order within each group. It suppresses only the second occurrence of the same directed self-loop;
+  reciprocal and parallel edges remain separate arcs. This preserves the ordering fixed by plan 01.
+- An undirected edge contributes one oriented traversal arc at each endpoint, sharing the same `EdgeIndex`. An
+  undirected self-loop emits one traversal arc. A separate incidence/degree operation counts that loop twice without
+  exposing duplicate traversal or incident-edge results.
+- Parallel edges remain separate arcs even when their neighbor is equal. Algorithms can therefore retain predecessor
+  edge identity and multiplicity.
+- Public neighbor-node queries continue to return unique node indexes. They collect from the arc kernel with first-seen
+  ordering; only these public collection APIs pay for an output array and deduplication set.
+- Incident-edge and algorithm kernels consume every required occurrence. No internal algorithm may call a unique-node
+  helper when parallel-edge multiplicity affects degree, cycle, capacity, flow, or weighted analysis.
+
+The callback must support early exit so `hasEdge`, point-to-point search, and lazy walkers do not scan or allocate more
+than necessary.
+
+### Dense snapshot and CSR
+
+This section is now a hardening specification for the landed `graphCsr.ts`, not a proposal to add CSR from scratch.
+
+Dense storage is derived and optional, never canonical. A `DenseIndex` translates stable sparse public indexes to dense
+positions:
+
+```ts
+type DenseIndex = {
+  readonly nodeIndexAt: ReadonlyArray<NodeIndex>
+  readonly nodePosition: Map<NodeIndex, number>
+  readonly edgeIndexAt: ReadonlyArray<EdgeIndex>
+}
+```
+
+CSR then stores dense neighbor positions and dense edge positions in `Uint32Array`s, plus outgoing/incoming offsets.
+Looking up `edgeIndexAt[denseEdge]` preserves the actual `EdgeIndex`; public indexes must never be truncated into an
+`Int32Array`. Fall back to the ordered map kernel if node, edge, or arc counts cannot be represented safely in 32-bit
+typed arrays.
+
+CSR construction uses a count/prefix/fill pass over canonical edges and preserves `EdgeIndex` order within every row.
+For undirected self-loops and parallel edges it must reproduce the ordered arc contract exactly. Incoming arrays are
+built only for algorithms that need them, unless benchmarks show a combined snapshot is cheaper overall.
+
+Use dense snapshots only for multi-pass or allocation-heavy algorithms after per-algorithm crossover measurements.
+Single neighbor queries, small traversals, and one-pass sparse operations should stay on canonical adjacency. Do not use
+a single magic node-count threshold: decisions must include arc count, required directions, number of expected passes,
+and whether a compatible immutable snapshot is already cached.
+
+### Memory model
+
+Treat typed arrays as additional retained storage, not as a free replacement for maps. For `V` dense nodes and `A`
+traversal arcs, outgoing CSR costs approximately `4 * (V + 1) + 8 * A` bytes for offsets, targets, and dense edge
+positions. Retaining incoming CSR adds approximately the same amount. This excludes the comparatively expensive
+`nodePosition` map, `nodeIndexAt`/`edgeIndexAt` JavaScript arrays, object headers, alignment, and construction scratch.
+Invocation-local weights add `8 * E` bytes in a `Float64Array`; a typed heap also retains capacity, key, value, and stable
+sequence arrays and can temporarily double those arrays while growing.
+
+- Build only outgoing or incoming CSR when one direction is sufficient.
+- Release count/cursor scratch after construction and do not retain callback-derived weights.
+- Avoid caching CSR for one-shot algorithms when build cost and duplicate memory outlive the operation.
+- Record canonical graph bytes and incremental snapshot bytes separately. Before each migration, state a predicted
+  byte formula; unexplained measured retained memory more than 25% above that prediction is a rollback trigger.
+- Prefer canonical arcs when CSR's warm speedup is small relative to its retained bytes. On memory-sensitive dense graphs,
+  an invocation-local snapshot that becomes collectible after the call may be safer than a warm cache.
+- COW mutation can temporarily retain source storage plus copied maps/lists; measure no-op, one-write, and bulk-write peak
+  and retained memory. Do not ship COW if bulk mutation retains more than eager copying after finalization.
+
+### Cache safety
+
+- Cache derived structural snapshots in a module-private `WeakMap` keyed by graph shell identity. Immutable entries may
+  be reused. Mutable entries are allowed only with exhaustive invalidation from every public mutation path.
+- An active iterator or algorithm may retain the CSR captured at its start. Mutation invalidates the shell's cache so a
+  subsequent lookup rebuilds; it must not mutate an already-issued CSR. Add direct tests for every structural and data
+  mutation family and for same-walker fresh iteration.
+- Finalization returns a new immutable shell, so it starts with no cache even when it adopts storage from a mutable
+  shell. The finalized mutable shell remains inactive and cannot mutate through any public operation.
+- `beginMutation` never mutates the source immutable storage. If copy-on-write is adopted, each map and touched
+  adjacency list must be owned before its first write; untouched storage may remain shared because neither shell can
+  subsequently write it.
+- Keep cheap monotonic facts in mutable state only when invalidation is proven for every mutation. Otherwise move
+  `acyclic` to the immutable derived-cache policy and recompute for mutable calls. Tests must cover add/remove,
+  `filterMap*`, `reverse`, callback failure, and finalization.
+- Do not cache weighted snapshots across calls because cost and heuristic callbacks are arbitrary and edge data may be
+  reference-mutable outside Graph. Structural CSR may retain edge identity, but callback-derived weights remain
+  invocation-local.
+- Do not cache public arrays, mutable maps/sets, walkers, or algorithm results. Returning a cached mutable result would
+  make one caller's writes observable by another.
+
+### Mutation ownership and safe finalization
+
+First remove only the second copy:
+
+1. `beginMutation` creates a fresh mutable shell and the current full private storage copy.
+2. `endMutation` creates a fresh immutable shell that adopts the mutable shell's storage without cloning it.
+3. Before returning, mark the mutable shell finalized. Every public mutation continues to call `assertMutable`.
+4. The immutable and finalized mutable shells may share storage, but neither permits further writes. Queries through the
+   retained mutable handle remain allowed and observe the finalized result, matching current behavior.
+5. Never return the mutable shell itself: `Equal.byReferenceUnsafe` marks that object irreversibly and would break
+   structural equality/hashing after finalization.
+
+Only after this lands and is measured should startup copy-on-write be considered. A minimal COW design copies node or
+edge maps on their first data write and copies adjacency maps plus only the touched lists on structural writes. Bulk
+operations may choose one full copy/rebuild when it is cheaper than many per-list copies. If ownership bookkeeping makes
+common large batch mutation slower or materially increases retained memory, retain eager copying at `beginMutation`.
+
+Exception safety remains unchanged: `mutateScoped` finalizes in `finally`, the source immutable graph is untouched, the
+callback error is rethrown, and a captured mutable handle is inactive afterward.
+
+### Queues and priority queues
+
+- Add a tiny internal FIFO with an array and read cursor, or use local arrays with `head < queue.length` where reuse is
+  unnecessary. Periodically compact only for a genuinely long-lived reusable queue; traversal-local queues are simply
+  discarded. Never use `shift()` in graph kernels.
+- Extract the current deterministic binary min-heap into internal graph code. Preserve insertion sequence as the
+  secondary key so equal-priority Dijkstra/A* results do not reorder.
+- Start with a generic array heap shared by Dijkstra, A*, and future optimization algorithms. Adopt parallel typed-array
+  keys/positions only when the weighted-search benchmark shows a repeatable improvement and dense positions are already
+  available. A typed heap must retain a sequence array or an equivalent stable tie rule.
+- Continue duplicate pushes with stale/visited-entry skipping unless decrease-key wins benchmarks and does not alter tie
+  behavior. Do not add a complex indexed heap speculatively.
+
+### Numeric policies and path reconstruction
+
+Own one internal edge-accessor evaluation facility with named policies for shortest-path weights, MST weights, and flow
+capacities. It evaluates in stable edge-index order, retains edge identity, and lets each domain specify its accepted
+number range without cloning validation loops. Also own edge-index predecessor records and shared append/reverse path
+reconstruction; legacy `PathResult` and plan-05 path values are projections over that private state.
+
+### Stack safety
+
+All traversals, cycle detection, SCC/connectivity, path reconstruction, and future algorithms must use explicit stacks,
+queues, or parent arrays. DFS frames should hold a node plus an adjacency cursor, not an allocated neighbor array.
+Path reconstruction should append while following parents and reverse once, replacing repeated `unshift()`.
+
+Parity tests must run deep directed and undirected chains of at least 100,000 nodes for representative DFS, BFS, cycle,
+SCC/connectivity, topological, and path-reconstruction paths without `RangeError`. Keep these tests targeted and avoid
+quadratic result materialization.
+
+### Probes and checkpoints
+
+Plan 02 owns the test probe vocabulary and count bounds; this plan owns zero-observable-behavior plumbing through the arc,
+queue, relaxation, reconstruction, and snapshot kernels. Production wrappers pass no probe, and the probe-disabled hot
+path must not branch per arc solely for testing. Prefer separate instrumented kernel entry points or a setup-time-selected
+callback shape, then benchmark the ordinary path.
+
+Also define the no-op synchronous checkpoint/step protocol required by `README.md` and plan 10. Synchronous adapters drain
+the kernel without yielding. The protocol must permit a later Effect adapter to pause only at invariant-safe work-count
+boundaries and resume the same private state without recomputation. Do not make every small current operation a state
+machine now: establish the shared protocol and apply it only to long-running kernels as their domain plans land. No
+checkpoint option is public, and hot-loop overhead above 5% is a rollback condition.
+
+## Module organization
+
+Split only after the internal contracts are stable; moving code and changing algorithms in the same patch obscures
+regressions. The intended dependency direction is:
+
+```text
+Graph.ts (public API and JSDoc)
+  -> internal/graph/model.ts       shells, protocols, storage access
+  -> internal/graph/mutation.ts    ownership, adjacency maintenance, lifecycle
+  -> internal/graph/arc.ts         ordered canonical arc cursor
+  -> internal/graph/dense.ts       dense translation and optional CSR
+  -> internal/graph/queue.ts       FIFO and deterministic min-heap
+  -> internal/graph/kernel.ts      probes and resumable checkpoint protocol
+  -> internal/graph/algorithms.ts  synchronous kernels, split further by domain only as needed
+```
+
+`Graph.ts` remains the sole public entry point and retains exported declarations and JSDoc. Internal modules are blocked
+by the existing `./internal/*` package export rule. Avoid an internal barrel and avoid a generic graph framework: each
+file should own a coherent implementation detail. If `algorithms.ts` remains large, split by traversal, connectivity,
+paths, and optimization while keeping dependencies one-way through model/arc/dense/queue.
+
+Do not hand-edit generated `packages/effect/src/index.ts`. Because no public module is added or removed, code generation
+should produce no public export change.
+
+## Benchmark foundation and gates
+
+### Harness
+
+Plan 02 owns the Effect-only `graph` suite in `packages/effect/runtimeperf/config.json`, its neutral corpus, and fixture
+factories under `packages/effect/runtimeperf/suites/graph/fixtures/`. This program requires that foundation before source
+optimization and adds cases to its shared `cases.ts`; it does not create another fixture or timing system. Runtimeperf is
+preferred over ad hoc Tinybench scripts because it runs fresh Node processes, alternates base/head order, calibrates
+batches independently, and uses paired bootstrap classification. Each fixture validates its result before and after
+measurement.
+
+Add cases for:
+
+- full and early-abandoned BFS/DFS on chain, wide, and sparse-index graphs;
+- direction-ignored traversal and public neighbors on directed/undirected multigraphs;
+- `isAcyclic`, SCC/connectivity, and `topo` on deep and wide graphs;
+- Dijkstra and A* on sparse and dense weighted graphs with equal-priority ties;
+- Bellman-Ford negative-cycle reachability;
+- no-op, one-write, and 10,000-write `mutate`, with separate construction and finalization cases where possible;
+- cold dense-snapshot construction, warm immutable CSR reuse, and mutable invocation-local construction;
+- canonical arc scans versus CSR scans at small, medium, and large node/edge densities.
+
+Use plan 02's fixed seeded fixtures. Keep setup outside `run`, except explicitly named cold/build cases.
+Return a checksum that includes visited node order, selected `EdgeIndex` values, and distances so dead-code elimination or
+semantic drift cannot masquerade as speedup.
+
+An optional `packages/effect/benchmark/graph/core.ts` may consume the same fixtures for local profiling only; it is not a
+merge gate. Use plan 02's opt-in fresh-process `--expose-gc` memory mode for canonical-only, cold CSR, warm CSR, mutation
+start, and mutation end. Record medians and MAD from at least five processes, including `heapUsed`, `external`, and
+`arrayBuffers`; do not assert machine-specific absolute bytes in Vitest or advertise a memory command until plan 02 has
+defined its selector.
+
+### Gate policy
+
+Land the fixtures before source optimization so every phase compares against a parent containing the same fixtures. For
+each phase:
+
+1. Run the targeted parity tests and graph benchmark against the unmodified phase parent and archive the JSON report.
+2. Make one architectural/performance change, rerun the same selected cases with the same settings, and inspect raw
+   process measurements as well as classification.
+3. Require no statistically classified regression over 5% in any affected or control case. A deliberate tradeoff may be
+   accepted only when the plan names it in advance, the target case improves at least 10%, and the aggregate workload and
+   memory evidence justify it.
+4. Require the phase's claimed hot case to improve at least 10% or remove the extra machinery. For queue replacement on
+   wide/deep BFS and elimination of repeated neighbor allocation, target at least 20% at the largest fixture.
+5. Reject a dense/CSR phase if its cold case regresses by more than 10%, if its measured crossover does not occur in the
+   supported fixture range, or if retained memory exceeds the documented budget without a compensating target win.
+6. Run a second comparison with more rounds for results whose confidence interval crosses either threshold. Never tune a
+   threshold to make one noisy run pass.
+
+Exact paired commands after the graph suite exists:
+
+```sh
+pnpm runtimeperf graph
+pnpm runtimeperf-compare graph --base HEAD --head worktree --rounds 9 --time 500 --warmup-time 150
+pnpm runtimeperf-compare graph --base HEAD --head worktree --rounds 9 --time 500 --warmup-time 150 --fail-on-regression
+```
+
+For a committed phase, replace `--base HEAD --head worktree` with the phase's parent and commit SHA. Save the generated
+report path from `tmp/runtimeperf/results/` in the PR notes. Run the memory command defined by the new diagnostic in five
+fresh processes and include its median table; the implementing PR must document the exact command in that script's
+README/output.
+
+## Phased implementation
+
+### Phase 0: contracts and measurements
+
+Depends on the correctness-contract and verification/benchmark foundation plans. It can proceed independently of new
+algorithms and Schema serialization.
+
+- Add exact-order parity fixtures, multigraph/self-loop cases, retained-handle lifecycle cases, and 100,000-node stack
+  tests through plan 02's shared corpus and test layout.
+- Ensure plan 02's runtimeperf graph suite and memory mode contain the cases described above.
+- Capture baseline reports before touching implementation.
+
+Gate: all existing Graph tests and new parity tests pass; every fixture validates; repeated baseline runs have stable
+enough variance to classify a 10% change. Roll back or resize a fixture if calibration is dominated by setup, GC, or
+sub-timer operations.
+
+### Phase 1: FIFO and reconstruction linearity
+
+Depends only on Phase 0.
+
+- Most traversal/topology and immutable-path replacements landed in `a371754b1e`. Replace the remaining mutable
+  `isBipartite` and mutable Bellman-Ford `shift()` queues while preserving enqueue order.
+- Replace the remaining mutable Bellman-Ford path `unshift()` loop with append-and-reverse.
+- Do not change adjacency access or storage in this phase.
+
+Gate: exact BFS/topological/path parity and lazy early-termination tests pass; largest BFS improves at least 20%; no
+control regresses over 5%. Roll back an individual replacement if ordering changes or the target does not improve.
+
+### Phase 2: ordered arc cursor and allocation removal
+
+Depends on Phase 1 and the shared ordered-arc concept in `README.md`.
+
+- Treat the landed CSR rows as the current dense arc kernel and add a canonical-storage cursor only where benchmarks show
+  CSR construction is not justified. Do not create another dense representation.
+- Complete migrations family by family and keep public neighbor collectors as compatibility adapters.
+- Add compact-edge-position to stable public `EdgeIndex` projection. Immutable weighted algorithms currently retain only
+  compact edge positions, while mutable paths still retain edge data; neither satisfies the shared edge-identity contract.
+- Delete old array-producing internal neighbor helpers only after every consumer is classified as unique-node or
+  occurrence-preserving.
+
+Gate after each algorithm family: exact output parity, directed/undirected self-loop and parallel-edge tests, differential
+tests, stack tests, and selected runtimeperf cases. Require the largest allocation-heavy traversal to improve at least
+20%. Roll back only that family to the compatibility adapter if ordering, multiplicity, or performance fails.
+
+### Phase 3: mutation finalization ownership
+
+Depends on Phase 0; it can be developed in parallel with Phases 1-2 but should land separately.
+
+- Introduce graph shells/storage if needed and let a new immutable shell adopt finalized mutable storage.
+- Preserve irreversible reference equality only on the mutable shell.
+- Test no-op, successful, throwing, and retained-handle cases, including equality/hash before and after finalization.
+- Measure constructor mutation and `mutate` separately from algorithm work.
+
+Gate: end-mutation time and peak allocation for a 10,000-node/30,000-edge graph improve materially, with a target of at
+least 30%; begin-mutation and batch-write controls do not regress over 5%. Roll back to copy-on-finalize if any public path
+can mutate adopted storage or if memory is retained unexpectedly.
+
+### Phase 4: optional mutation copy-on-write
+
+Depends on Phase 3 and is conditional, not presumed necessary.
+
+- Prototype map-level and touched-adjacency-list ownership only if no-op and small-write mutation startup remains a
+  measured bottleneck.
+- Add bulk-copy/rebuild escape paths for large removals, filtering, and reverse.
+- Keep eager begin-copy as the fallback implementation until all mutation shapes pass.
+
+Gate: no-op and one-write cases improve at least 20%, 10,000-write and bulk-transform cases regress no more than 5%, and
+retained memory does not exceed eager copy. Otherwise do not ship COW; Phase 3 alone is the safe simpler result.
+
+### Phase 5: shared deterministic priority queue
+
+Depends on Phase 2 so entries can retain dense/public node and edge identity cleanly.
+
+- Extract the current stable heap and share it across Dijkstra/A* and later weighted algorithms.
+- Defer object-entry versus parallel-typed-array comparison to Phase 6, when dense translation exists. Preserve
+  equal-priority sequence ordering and duplicate-entry semantics.
+
+Gate: equal-cost path parity and weighted oracle tests pass. Extraction alone may be performance-neutral. The Phase 6
+typed-heap experiment ships only with at least a 10% large-graph weighted-search win and no small-graph regression over
+5%; otherwise retain the generic internal heap.
+
+### Phase 6: dense translation and CSR
+
+Depends on Phases 2 and 5 plus actual consumers from later algorithm plans. It must not block simple query/traversal work.
+
+- Audit and benchmark the landed sparse-to-dense translation, ordered outgoing/incoming CSR, and lazy edge projections.
+- Compare the current cached implementation with canonical and invocation-local alternatives per algorithm.
+- Retain mutable caching only if invalidation tests and cold/warm/memory measurements justify it.
+- Compare the generic heap with a dense typed heap here; retain the generic heap unless the weighted-search gate passes.
+- Migrate only algorithms with repeated adjacency passes or proven map/set overhead. Keep the canonical kernel beside
+  each migration as a small-graph/unsupported-size fallback and differential reference.
+
+Gate: bit-for-bit public parity, sparse-index and max-safe-public-index tests, CSR order/multiplicity tests, mutable cache
+safety tests, and cold/warm/memory benchmarks. Roll back each algorithm independently if no useful crossover exists.
+Remove CSR entirely if no planned algorithm benefits enough to justify duplicate memory.
+
+### Phase 7: cache hardening and module split
+
+Depends on stable storage, arc, mutation, and dense contracts from prior phases.
+
+- Move `acyclic` and structural snapshots under the documented immutable/mutable cache policy.
+- Add tests that count snapshot builds internally in a test-only manner: immutable warm reuse, distinct graph isolation,
+  no mutable reuse, mutation finalization, removal gaps, and garbage-collectable ownership where practical.
+- Extract internal modules without behavior changes, then run circular-dependency and bundle checks.
+
+Gate: no public API or generated-index diff, no new import cycle, identical parity output, and no benchmark regression over
+5%. If extraction introduces a cycle or measurable module-load/bundle cost, keep the affected code in the nearest deeper
+module rather than adding a barrel or indirection.
+
+## Schema snapshot/hydration coordination
+
+The Schema plan owns the encoded shape, validation, public constructors/codecs, and error mapping. Its encoded shape is
+exactly `type`, ordered indexed node entries, and ordered indexed edge entries; it has no wire `version`,
+`nextNodeIndex`, or `nextEdgeIndex`. This plan owns only the internal trusted seam that avoids rebuilding adjacency
+through repeated public mutations after Schema has validated input.
+
+The shared internal snapshot uses that same minimal shape. Hydration must validate or receive proof of these invariants:
+
+- indexes are finite safe non-negative integers and unique;
+- every edge endpoint exists;
+- node and edge entry order is canonical index/insertion order required by Graph behavior;
+- graph kind is directed or undirected.
+
+Hydration derives `nextNodeIndex` and `nextEdgeIndex` as one greater than the highest active index, or zero for an empty
+collection. This intentionally does not preserve trailing removed indexes across serialization. Internal in-memory graph
+storage and selection snapshots may retain allocator counters where an operation must preserve future allocation exactly,
+but those counters are not part of the Schema snapshot or encoded form.
+
+Hydration builds canonical adjacency in one pass and returns a fresh immutable shell with empty derived caches. It must
+not accept or serialize adjacency, CSR arrays, cache state, ownership flags, mutable state, or `acyclic`; those are
+recomputed internals. The trusted hydrator remains internal and is called only after Schema validation. Public
+`Graph.Snapshot`, `Graph.fromSnapshot`, and `Schema.Graph` landed separately in `189b003a23`; this plan owns only derived
+storage and cache coordination.
+
+If the Schema plan lands first, it may temporarily hydrate through public mutation. It must not invent a second internal
+representation; switch to this shared seam once available and retain round-trip tests for sparse active indexes,
+parallel edges, self-loops, equality, and allocator high-water derivation from active indexes.
+
+## Public-kernel decision
+
+Default decision: expose no public kernel. Opaque storage lets Effect change queues, ownership, CSR layout, cache policy,
+and algorithm selection without a semver contract, and the public `Graph` functions already cover supported use cases.
+
+Reconsider only in a separate public API proposal when all of the following are true:
+
+- at least two concrete external algorithm packages need zero-allocation arc access and cannot meet requirements through
+  existing APIs;
+- the ordered arc and snapshot contracts have survived at least two internal algorithm families without revision;
+- maintainers are willing to support index/multiplicity/order and invalidation semantics as public compatibility;
+- benchmarks show a material benefit that cannot be delivered internally or through existing lazy walkers;
+- the API can avoid exposing storage, mutable cache invalidation, typed-array layout, or ownership details.
+
+Even then, prefer a narrow read-only arc visitor over exposing maps, CSR, hydration, or caches. Absence of these criteria
+closes the question; internal test convenience is not justification for public API.
+
+## Dependencies and ownership
+
+- Requires the correctness-contract plan for exact self-loop, multiplicity, ordering, errors, and safe-lookup semantics.
+- Requires the verification/benchmark foundation plan for seeded fixtures and oracle adapters; this plan extends the
+  runtimeperf registry with graph-specific cases.
+- Owns canonical storage shells, ordered arc iteration, queue/heap internals, dense translation/CSR, named numeric
+  policies, edge-index path reconstruction, structural cache policy, mutation copy strategy, and internal module
+  boundaries.
+- Core-query, traversal/path, connectivity/DAG, optimization, and analytics plans consume the ordered arc and optional
+  dense kernels. They must not create competing adjacency or dense representations.
+- Owns the no-op checkpoint/step protocol and synchronous driver seam. The Effect-native interruption plan owns
+  Effect-returning adapters and applies the seam only after synchronous loop and ordering contracts stabilize.
+- The Schema plan owns all serialization API and validation, coordinating only through the internal trusted
+  snapshot/hydration seam above.
+
+## Exact validation for implementing PRs
+
+Run the narrow commands after every phase, never the whole test suite:
+
+```sh
+pnpm lint-fix
+pnpm --filter effect test --run test/Graph.test.ts
+pnpm --filter effect test --run test/GraphProperty.test.ts
+pnpm --filter effect test --run test/GraphDifferential.test.ts
+pnpm --filter effect test --run test/GraphComplexity.test.ts
+node --test packages/effect/runtimeperf/test/*.test.mts
+pnpm check
+pnpm runtimeperf graph
+pnpm runtimeperf-compare graph --base HEAD --head worktree --rounds 9 --time 500 --warmup-time 150 --fail-on-regression
+```
+
+For the module-splitting phase also run `pnpm circular`. For a committed module-splitting phase use:
+
+```sh
+pnpm bundle-compare HEAD~1
+```
+
+Review `tmp/bundle-stats.txt` and require no unexpected public `effect/Graph` increase. Once plan 02 defines its exact
+memory selector, run it in at least five fresh `node --expose-gc` workers and report median/MAD `heapUsed`, `external`, and
+`arrayBuffers` deltas. Until then, memory evidence is required for CSR and mutation ownership but is not represented by a
+made-up command.
+
+If a phase adds or changes type-level API despite this plan's non-breaking constraint, stop and resolve the scope rather
+than silently adding a type test or changeset. Internal-only refactors need no changeset; any observable runtime behavior
+or exported API change requires reassessment under the relevant domain plan.
+
+## Completion checklist
+
+- No graph hot loop uses `Array.shift()` or recursive descent.
+- Internal algorithms do not allocate neighbor arrays unless producing a public array result.
+- Arc traversal retains stable `EdgeIndex`, parallel-edge multiplicity, self-loop semantics, and deterministic order.
+- Immutable caches are safe and weakly held; mutable calls cannot observe stale snapshots.
+- Mutation no longer performs an unconditional begin/end double copy; any COW complexity has benchmark justification.
+- Dense/CSR and typed heaps exist only where crossover, warm reuse, and memory measurements justify them.
+- `effect/Graph` remains the only public module and no kernel is exported.
+- Schema hydration shares canonical snapshot invariants without serializing implementation state.
+- Every landed phase has parity results, paired benchmark reports, memory evidence where relevant, and a documented local
+  rollback decision.

--- a/docs/graph-plans/04-core-queries-transforms.md
+++ b/docs/graph-plans/04-core-queries-transforms.md
@@ -1,0 +1,417 @@
+# Core Queries and Transforms
+
+## Goal
+
+Add the small, conventional structural queries and subgraph transforms that applications otherwise have to rebuild
+from `nodes`, `edges`, `neighbors`, and traversal APIs. The additions must preserve the current graph model: stable
+numeric indexes, directedness in the type, parallel edges, self-loops, deterministic index order, scoped mutation,
+and lazy `Walker` iteration.
+
+This is an additive plan. Existing APIs and behavior, including `neighbors`, `successors`, `predecessors`,
+`neighborsDirected`, `externals`, `neighborhood`, mutable transforms, and set operations, remain unchanged.
+
+## Scope
+
+### In scope
+
+- Lazy incident, incoming, and outgoing edge walkers.
+- Degree, in-degree, and out-degree.
+- All edge occurrences between two nodes.
+- Reachability, undirected connectivity, and undirected tree predicates.
+- General index-preserving induced-subgraph transforms.
+- Immutable and mutable graph reads for every query.
+- Shared internal reuse needed to make these APIs consistent and efficient.
+
+### Out of scope
+
+- Graph generators such as complete, grid, random, Watts-Strogatz, and Barabasi-Albert graphs. Those are analytics
+  and fixture-building features owned by plan 09. This plan only defines the query and transform primitives that
+  plan 09 may use in generator tests.
+- Directed arborescence, weak/strong directed connectivity predicates, spanning trees, transitive closure, path
+  enumeration, line graphs, graph flattening, and hierarchy-specific transforms.
+- Renaming or replacing current APIs to match `.repos/graph`'s `get*` convention.
+- Convenience aliases that do not add a distinct semantic or type-level guarantee.
+
+## Current State and Reference Lessons
+
+`Graph.ts` already stores ordered node and edge maps plus outgoing and reverse adjacency arrays. It exposes eager
+neighbor arrays, lazy whole-graph `NodeWalker` / `EdgeWalker` values, directed `successors` and `predecessors`, and
+the configurable `externals` walker. Queries generally accept both `Graph` and `MutableGraph`; missing safe lookups
+use `Option`, collection queries are empty when no result exists, and `hasEdge` returns `false` for missing nodes.
+
+The reference implementation in `.repos/graph/src/queries.ts` demonstrates the usefulness of incident/in/out edge
+queries, degree variants, `edgesBetween`, and explicit sources/sinks. `.repos/graph/src/transforms.ts` demonstrates
+an induced subgraph, and `.repos/graph/src/algorithms/traversal.ts` demonstrates the value of small `hasPath`,
+`isConnected`, and `isTree` predicates. We should adopt those capabilities, not its naming, JSON identity model,
+mixed edge modes, hierarchy behavior, or eager-array bias.
+
+The reference also contains generators in `.repos/graph/src/generators.ts`. They do not belong in core queries and
+transforms. Plan 09 should own their API, randomness policy, validation, fixtures, and changesets; this plan should
+not introduce generator names or helper types that constrain that work.
+
+## Semantic Decisions
+
+### Edge occurrence and ordering
+
+- `incidentEdges` yields each stored edge incident to the node exactly once. A directed or undirected self-loop is
+  one stored edge occurrence and is yielded once, even though internal adjacency may register it in more than one
+  endpoint/direction slot.
+- Parallel edges are never deduplicated. Every distinct `EdgeIndex` is yielded.
+- `inEdges` and `outEdges` use authored direction and are directed-only at the type level. A directed self-loop is
+  present once in each walker.
+- `edgesBetween(source, target)` yields every matching edge in edge-index/insertion order. Directed graphs match
+  exactly `source -> target`; undirected graphs match either stored endpoint orientation. A self query matches all
+  self-loops at that node once each.
+- All new edge walkers follow `EdgeWalker` conventions: repeatable, genuinely lazy, copy `Edge` values before
+  exposing them, skip entries removed before they are read, and create fresh iterator state for each iteration.
+- Ordering is global edge insertion/index order, not “outgoing first, then incoming”. The internal ordered arc/edge
+  kernel should merge or scan indexes without changing this observable order.
+
+### Degree
+
+- Directed `inDegree` is the count of incoming edge occurrences and `outDegree` is the count of outgoing edge
+  occurrences. A directed self-loop contributes one to each.
+- Directed `degree` is `inDegree + outDegree`; therefore a self-loop contributes two.
+- Undirected `degree` is graph-theoretic degree. Every parallel edge contributes independently and every self-loop
+  contributes two.
+- `inDegree` and `outDegree` are directed-only. Defining them for undirected graphs would create duplicate names for
+  `degree` without useful semantics.
+- A missing node has degree `0`, matching empty adjacency and the safe behavior of `hasEdge` and collection queries.
+- Complexity is `O(1)` using validated adjacency lengths. Do not implement degree by collecting a walker.
+
+### Reachability and structural predicates
+
+- `hasPath(source, target)` follows outgoing arcs in directed graphs and either endpoint direction in undirected
+  graphs. It is reflexive only for an existing node: `hasPath(graph, n, n)` is `true` when `n` exists and `false`
+  when it does not.
+- Missing source or target nodes return `false`; a boolean query should not require an `Option` wrapper or throw for
+  ordinary absence.
+- `isConnected` is restricted to undirected graphs. Naming a directed graph “connected” is ambiguous between weak
+  and strong connectivity; those explicit directed concepts belong to the connectivity plan.
+- Plan 06 must not add a directed overload or alias named `isConnected`. It owns only explicitly named
+  `isWeaklyConnected` and `isStronglyConnected`; the three predicates have distinct, non-overlapping graph-kind domains.
+- The empty undirected graph and a one-node undirected graph are connected. This preserves the useful vacuous
+  convention and matches the reference behavior.
+- `isTree` is restricted to undirected graphs and means connected and acyclic. Empty and singleton graphs are
+  trees. A self-loop prevents tree status, and two parallel edges between the same endpoints form a cycle and
+  prevent tree status.
+- `isTree` may use the `|E| = |V| - 1` fast rejection, but correctness must ultimately follow the shared multigraph
+  cycle and connectivity contracts. Do not infer acyclicity from edge count alone.
+
+### Sources, sinks, and `externals`
+
+- Do not add `sources` or `sinks`; `externals(config?)` already provides this capability and the plan rejects convenience
+  aliases without distinct semantics.
+- Do not add `initials`, `terminals`, `roots`, `leaves`, `boundaryNodes`, or eager source/sink array aliases.
+
+### Missing nodes and empty results
+
+- Edge walkers for a missing node, and `edgesBetween` with either endpoint missing, are empty.
+- Degree variants return `0` for a missing node.
+- `hasPath` returns `false` if either endpoint is missing.
+- These APIs do not need `Option`: none returns a single optional value. Existing single-value lookups continue to
+  use `getNode` / `getEdge` and `Option.none`.
+- Subgraph selectors are different: a requested missing index is invalid structural input and throws `GraphError`.
+  Empty selector iterables are valid and produce an empty graph.
+
+### Subgraph identity and directedness
+
+- Both transforms preserve `T extends Kind` exactly.
+- Surviving nodes and edges retain their original `NodeIndex` and `EdgeIndex`; transforms must not compact or
+  renumber public identifiers. The next node and edge allocators also remain monotonic relative to the input so a
+  later mutation cannot reuse removed identifiers.
+- Node and edge iteration order remains the input graph's index/insertion order, regardless of selector iterable
+  order. Duplicate selector indexes are ignored.
+- `inducedSubgraph(nodes)` keeps exactly the selected nodes and every original edge whose two endpoints are selected.
+- The internal selected-structure copier can keep exactly selected nodes and edge occurrences. Every selected edge must
+   exist and both endpoints must be selected; otherwise it throws `GraphError` rather than silently changing the
+   request. Parallel edges and self-loops are selected independently by `EdgeIndex`.
+- Both transforms accept immutable or mutable input as a read and always return a new immutable `Graph`. They take a
+  synchronous snapshot during the call; later mutation of the source does not affect the result.
+- Empty node selection produces an empty graph.
+- These are structural selection operations, not graph set operations: they select by stable indexes and do not use
+  `IdentityOptions`, coalesce equal data, or compare another graph.
+- `neighborhood` remains unchanged, including its current index-allocation behavior. It may only be rewritten to use
+  the new induced-subgraph kernel if regression tests prove all existing observable behavior remains identical.
+
+## Proposed API
+
+Signatures are illustrative; implementation should match the repository's overload formatting and `dual` style.
+
+```ts
+export const incidentEdges: {
+  (nodeIndex: NodeIndex): <N, E, T extends Kind>(
+    self: Graph<N, E, T> | MutableGraph<N, E, T>
+  ) => EdgeWalker<E>
+  <N, E, T extends Kind>(
+    self: Graph<N, E, T> | MutableGraph<N, E, T>,
+    nodeIndex: NodeIndex
+  ): EdgeWalker<E>
+}
+
+export const inEdges: {
+  (nodeIndex: NodeIndex): <N, E>(
+    self: DirectedGraph<N, E> | MutableDirectedGraph<N, E>
+  ) => EdgeWalker<E>
+  <N, E>(
+    self: DirectedGraph<N, E> | MutableDirectedGraph<N, E>,
+    nodeIndex: NodeIndex
+  ): EdgeWalker<E>
+}
+
+export const outEdges: typeof inEdges
+
+export const edgesBetween: {
+  (source: NodeIndex, target: NodeIndex): <N, E, T extends Kind>(
+    self: Graph<N, E, T> | MutableGraph<N, E, T>
+  ) => EdgeWalker<E>
+  <N, E, T extends Kind>(
+    self: Graph<N, E, T> | MutableGraph<N, E, T>,
+    source: NodeIndex,
+    target: NodeIndex
+  ): EdgeWalker<E>
+}
+
+export const degree: {
+  (nodeIndex: NodeIndex): <N, E, T extends Kind>(
+    self: Graph<N, E, T> | MutableGraph<N, E, T>
+  ) => number
+  <N, E, T extends Kind>(
+    self: Graph<N, E, T> | MutableGraph<N, E, T>,
+    nodeIndex: NodeIndex
+  ): number
+}
+
+export const inDegree: {
+  (nodeIndex: NodeIndex): <N, E>(
+    self: DirectedGraph<N, E> | MutableDirectedGraph<N, E>
+  ) => number
+  <N, E>(
+    self: DirectedGraph<N, E> | MutableDirectedGraph<N, E>,
+    nodeIndex: NodeIndex
+  ): number
+}
+
+export const outDegree: typeof inDegree
+
+export const hasPath: {
+  (source: NodeIndex, target: NodeIndex): <N, E, T extends Kind>(
+    self: Graph<N, E, T> | MutableGraph<N, E, T>
+  ) => boolean
+  <N, E, T extends Kind>(
+    self: Graph<N, E, T> | MutableGraph<N, E, T>,
+    source: NodeIndex,
+    target: NodeIndex
+  ): boolean
+}
+
+export const isConnected: <N, E>(
+  self: UndirectedGraph<N, E> | MutableUndirectedGraph<N, E>
+) => boolean
+
+export const isTree: <N, E>(
+  self: UndirectedGraph<N, E> | MutableUndirectedGraph<N, E>
+) => boolean
+
+export const inducedSubgraph: {
+  (nodes: Iterable<NodeIndex>): <N, E, T extends Kind>(
+    self: Graph<N, E, T> | MutableGraph<N, E, T>
+  ) => Graph<N, E, T>
+  <N, E, T extends Kind>(
+    self: Graph<N, E, T> | MutableGraph<N, E, T>,
+    nodes: Iterable<NodeIndex>
+  ): Graph<N, E, T>
+}
+```
+
+Use normal overloads rather than `typeof` aliases in the actual source if `typeof` degrades generated API docs or
+parameter names. All multi-argument functions use both data-first and data-last forms. Unary whole-graph queries
+(`isConnected`, `isTree`) need no artificial zero-argument dual form.
+
+## Complexity Targets
+
+Let `V` and `E` be graph sizes, `deg(v)` the incident edge occurrences at `v`, and `k` the number of selected items.
+
+| API | Time | Additional space | Notes |
+| --- | ---: | ---: | --- |
+| `inEdges`, `outEdges` | `O(deg(v))` consumed | `O(1)` iterator state | Lazy; early termination is proportional to consumed edges. |
+| `incidentEdges` | `O(deg(v))` consumed | `O(deg(v))` worst case | Dedupe self-loop registrations by edge index while preserving parallel edges. |
+| `edgesBetween` | `O(min(outDegree(source), inDegree(target)))` where supported, otherwise `O(deg(source))` | `O(1)` or dedupe state | Preserve edge-index order. |
+| `degree`, `inDegree`, `outDegree` | `O(1)` | `O(1)` | Depends on correct adjacency accounting. |
+| `hasPath` | `O(V + E)` worst case | `O(V)` | Stop immediately when target is found. |
+| `isConnected` | `O(V + E)` | `O(V)` | One direction-ignored traversal. |
+| `isTree` | `O(V + E)` | `O(V)` | Edge-count fast rejection plus connectivity/cycle contract. |
+| `inducedSubgraph` | `O(V + E + k)` | `O(V + E)` result | Scan source order after validating selection. |
+
+Do not sacrifice deterministic order for a nominally tighter bound. The internal kernel may improve
+`edgesBetween` with ordered adjacency intersections, but a source-order scan is acceptable initially if benchmark
+evidence does not justify more indexing.
+
+## Implementation Reuse
+
+The implementation should be thin wrappers over shared internals rather than another adjacency interpretation.
+
+1. Use the ordered arc iterator owned by the internal-kernel plan for outgoing, incoming, and direction-ignored
+   traversal. It must retain `EdgeIndex`, distinguish authored direction, normalize undirected endpoints, and handle
+   undirected self-loop double registration correctly.
+2. Build `inEdges`, `outEdges`, `incidentEdges`, `edgesBetween`, neighbor queries, and `hasPath` on that kernel.
+   Existing neighbor and traversal code should migrate only where tests prove no ordering or mutation regression.
+3. Implement degree from adjacency counts after the correctness plan establishes exact self-loop registration
+   invariants. Directed degree is the sum of the two lists; undirected degree uses graph-theoretic endpoint count.
+4. Add one internal “copy selected structure” helper that copies maps, adjacency, reverse adjacency, graph kind,
+   allocator counters, and safe acyclic-cache state while retaining public indexes. Coordinate this representation
+   with schema snapshot/hydration work; do not create a second serialized graph model.
+5. `inducedSubgraph` computes the edge selection then delegates to the private selected-structure copier. Keep explicit
+   edge-selected subgraphs internal until a separately approved public use appears.
+6. `hasPath` may use a small queue/stack directly over ordered arcs. Do not collect `bfs`, because current `bfs`
+   throws for missing starts and exposes node values that this boolean query does not need.
+7. `isConnected` should perform one undirected traversal from the first node and compare visited count. `isTree`
+   should reuse `isConnected` and the corrected multigraph-aware acyclicity kernel rather than duplicate DFS logic.
+
+Mutable reads must not call `endMutation`, clone the source, or invalidate the mutation scope. Lazy walkers read the
+graph when each iterator runs, consistent with current `Walker` behavior. Snapshot-returning transforms read the
+current mutable state once and return an independent immutable graph.
+
+## Dependency and Ownership
+
+### Required earlier work
+
+- **Plan 01, correctness contracts:** adjacency and reverse-adjacency invariants, undirected self-loop registration,
+  parallel-edge handling, stable iteration order, mutable walker behavior, and multigraph cycle semantics must be
+  locked by regression tests first.
+- **Plan 03, internal architecture/performance kernel:** provide the ordered arc iterator and a selection/snapshot
+  helper capable of preserving sparse stable indexes and allocator counters. This plan must not introduce competing
+  arc or dense-index representations.
+
+### Work that can proceed independently
+
+- Public signatures, JSDoc, type tests, missing/empty behavior tests, and source/sink delegation can be prepared once
+  correctness contracts are agreed.
+- Subgraph selector validation and API tests can proceed against a simple source-order implementation before any
+  dense snapshot optimization.
+- Generator work in plan 09 is independent and should only consume released APIs, not block them.
+
+### APIs owned here
+
+This plan owns the public APIs listed above and only their lightweight kernels. The traversal/path plan owns richer
+traversal configuration and path values. The connectivity plan owns weak/strong directed connectivity, bridges,
+articulation points, and component APIs. Plan 08 owns analytics and plan 09 owns generators. If those plans need the same arc or
+snapshot primitive, ownership stays with the internal-kernel plan.
+
+## Phased Delivery
+
+1. **Correctness and kernel prerequisites**
+   - Lock adjacency, self-loop, parallel-edge, sparse-index, ordering, and mutable-iteration behavior.
+   - Land the shared ordered arc iterator and selected-structure copy helper.
+   - Verify against seeded and hand-built multigraph fixtures before exposing APIs.
+2. **Local edge and degree queries**
+   - Add `inEdges`, `outEdges`, `incidentEdges`, `edgesBetween`, `degree`, `inDegree`, and `outDegree`.
+   - Reuse internals without changing existing neighbor APIs.
+   - Benchmark high-degree nodes and parallel/self-loop-heavy fixtures.
+3. **Subgraph transforms**
+   - Add the private selected-structure copier and public `inducedSubgraph` with stable-index/allocator preservation.
+   - Verify result independence and all directed/undirected multigraph cases.
+4. **Structural predicates**
+   - Add `hasPath`, undirected-only `isConnected`, and undirected-only `isTree` after the ordered traversal and cycle
+     kernels are stable.
+   - Differentially verify against simple test oracles.
+5. **Documentation and release completion**
+   - Finish JSDoc examples, API grouping, type tests, complexity notes, and changesets.
+   - Coordinate references from traversal, connectivity, analytics/generator, and consolidated graph docs.
+
+Each phase may ship independently; do not hold basic local queries for plan 09 generator work.
+
+## Verification Matrix
+
+### Runtime tests
+
+Add focused tests in `packages/effect/test/Graph.test.ts` or split a dedicated graph-query test file if the repository
+has done so by implementation time. Cover at least:
+
+- Empty, singleton, disconnected, path, cycle, and branching graphs for both kinds where accepted.
+- Sparse node and edge indexes after removals; returned walkers and subgraphs retain original indexes and order.
+- Directed incoming/outgoing distinction, reverse-direction `edgesBetween`, and data-first/data-last parity.
+- Missing node behavior for every local query and both missing endpoints for `hasPath` / `edgesBetween`.
+- Parallel edges with equal and unequal data remain separate and ordered in every edge walker and subgraph.
+- Directed self-loop: once in each directional walker, once in incident/between walkers, in/out degree one, total
+  degree two, reflexive path true, and not a relevant undirected tree case.
+- Undirected self-loop: once in incident/between walkers, degree two, cycle present, and `isTree` false.
+- Two parallel undirected edges form a cycle and make `isTree` false; one edge between two nodes is a tree.
+- `hasPath`: directionality, undirected symmetry, early success, reflexive existing node, reflexive missing node,
+  disconnected target, self-loop, and parallel-edge paths.
+- `isConnected`: empty and singleton true, isolated node in a larger graph false, disconnected components false.
+- `isTree`: empty/singleton true, path true, disconnected forest false, cycle false, loop false, parallel-edge cycle
+  false.
+- Induced subgraphs include all and only edges with both endpoints selected, including parallel edges and loops.
+- Induced subgraphs preserve kind, node/edge data, sparse indexes, allocator monotonicity, insertion order, and source
+  independence after subsequent mutation.
+- All read queries work on `MutableGraph` during construction and manual mutation scopes without ending the scope.
+- Walker repeatability, partial consumption, removal before read, additions before a fresh iteration, and copied edge
+  values follow existing `Walker` tests.
+
+Use seeded fixtures and oracle adapters from the verification foundation for randomized checks:
+
+- `degree(v)` equals endpoint incidence count, with undirected loops counted twice.
+- `edgesBetween(a, b)` equals filtering all edges under kind-specific endpoint rules.
+- `hasPath(a, b)` agrees with a simple reference BFS and, when available, path-result presence.
+- `isConnected` agrees with component count under the documented empty-graph convention.
+- `isTree` agrees with connected plus multigraph-aware acyclic.
+- Induced subgraphs contain exactly the selected node set and all valid endpoint-closed edges.
+
+### Type tests
+
+Extend `packages/effect/typetest/Graph.tst.ts` to prove:
+
+- Every multi-argument API infers node data, edge data, and kind in both dual forms and through `pipe`.
+- Edge queries return `EdgeWalker<E>` and transforms preserve exact `T`.
+- Every read query accepts the matching mutable graph type.
+- `inEdges`, `outEdges`, `inDegree`, and `outDegree` reject undirected and unknown-kind graphs
+  until narrowed to directed.
+- `isConnected` and `isTree` reject directed and unknown-kind graphs until narrowed to undirected.
+- `degree`, `incidentEdges`, `edgesBetween`, `hasPath`, and `inducedSubgraph` accept either known kind and a
+  narrowed `Kind` graph.
+- Selector iterables accept arrays, sets, and walker-derived `Iterable` values without widening result data types.
+
+### Documentation
+
+- Add full public JSDoc with `@since`, categories, complexity, missing-node behavior, directedness, ordering,
+  self-loop/parallel-edge semantics, mutable-read support, and runnable examples.
+- Cross-link directional pairs, `incidentEdges` to `edges`, and `inducedSubgraph` to `neighborhood`.
+- Document why `isConnected` / `isTree` are undirected-only and point directed users to explicit connectivity APIs.
+- Show `Array.from(Graph.indices(...))` / `Graph.values(...)` for walkers rather than presenting them as arrays.
+- Update consolidated graph documentation and API inventories when their owning plan lands.
+- Run `pnpm lint`, targeted doctests for `packages/effect/src/Graph.ts`, and documentation link checks.
+
+### Validation commands
+
+For each implementation phase, run the narrowest applicable checks:
+
+```sh
+pnpm lint-fix
+pnpm --filter effect test --run test/Graph.test.ts
+pnpm test-types Graph.tst.ts
+pnpm doctest --run packages/effect/src/Graph.ts
+pnpm check
+```
+
+Add focused benchmark commands from the verification plan for high-degree edge queries, repeated degree reads,
+reachability early exit, and large subgraph selection. Never use benchmark improvements to relax semantic tests.
+
+## Changesets
+
+Every phase that exports one or more APIs requires an `effect` minor changeset because it adds public API. If the
+work is released in multiple phases, use one changeset per independently released API group and describe semantics,
+not internal implementation. Internal-kernel-only preparation needs no changeset. Plan 09 must provide separate
+changesets for generators; no generator should be mentioned in this plan's release note except as explicitly out of
+scope.
+
+## Acceptance Criteria
+
+- All proposed APIs are additive, follow Effect naming/dual/Walker conventions, and preserve exact graph kind.
+- Query behavior is fully specified for missing nodes, empty graphs, mutable reads, ordering, self-loops, and
+  parallel edges.
+- Directedness-ambiguous APIs are prevented by types rather than assigned undocumented weak/strong semantics.
+- Subgraphs retain surviving public indexes and allocator monotonicity and never collapse edge occurrences.
+- Existing `externals`, neighbor, traversal, set-operation, neighborhood, and mutable-transform behavior is unchanged.
+- Runtime, property/differential, type, doctest, lint, and targeted performance verification pass.
+- Generator ownership is left to plan 09 with no duplicate API or helper surface introduced here.

--- a/docs/graph-plans/05-traversal-paths.md
+++ b/docs/graph-plans/05-traversal-paths.md
@@ -1,0 +1,500 @@
+# Plan 05: Traversal and Paths
+
+## Scope
+
+Add edge-aware traversal and path facilities without changing the signatures or result shapes of `dfs`, `bfs`,
+`dfsPostOrder`, `dijkstra`, `astar`, `bellmanFord`, `floydWarshall`, `Walker`, or `PathResult`.
+
+This plan owns:
+
+- an edge-identity-preserving path model and shared reconstruction;
+- path projections, validation, slicing, containment, and concatenation;
+- enumeration of all tied shortest paths;
+- bounded lazy simple paths and shortest simple alternatives;
+- simple-cycle enumeration;
+- optional edge-aware BFS/DFS visits;
+- an optional bidirectional Dijkstra kernel for single-pair non-negative searches.
+
+This plan does **not** own Eulerian paths/circuits (plan 07), connected/strongly connected/biconnected components,
+reachability, topological ordering, transitive reduction, or other connectivity/DAG algorithms (plan 06). Random walks,
+coverage planning, and mixed/bidirectional edge kinds from `.repos/graph` are also out of scope.
+
+## Findings and Assumptions
+
+- `PathResult<E>` currently exposes `path`, `distance`, and edge **data** in `costs`; it cannot distinguish parallel
+  edges with equal data. After `a371754b1e`, immutable CSR weighted algorithms retain compact edge positions internally,
+  but CSR has no compact-to-public `EdgeIndex` projection and mutable implementations still retain edge data. Public edge
+  identity therefore remains unimplemented.
+- `Walker` is repeatable and lazy. Each traversal iterator captures CSR graph state when iteration begins, active
+  iteration is isolated from later mutation, and a fresh iterator observes current state. Existing BFS/DFS yield unique
+  nodes in stable adjacency order, but node-only output cannot identify the discovery edge.
+- The graph stores stable, monotonic node and edge indexes and preserves adjacency insertion order. New algorithms must
+  use those indexes as identity and ordering keys.
+- `.repos/graph` demonstrates the useful shape `source + edge/node steps`, all-tie predecessor reconstruction,
+  loopless reconstruction in the presence of zero-weight predecessor cycles, lazy simple paths, Yen's algorithm,
+  edge-identity path utilities, cycle enumeration, and bidirectional Dijkstra. Its semantics must be adapted to this
+  repository's two graph kinds, numeric stable indexes, `GraphError`, and dual API conventions rather than copied.
+- A path is a walk with explicit edge identity. Unless an API says "simple", repeated nodes and edges are structurally
+  valid. A simple path has no repeated node. A simple cycle repeats only its first node at the end.
+- New lazy iterables read graph state when a fresh iterator is created, matching `Walker`. They should use the same
+  snapshot-isolation contract: mutation does not alter an already-issued iterator, while later iterators observe it.
+  No public snapshot option is needed.
+
+## Public Models
+
+Names are provisional until the API review in phase 1, but the shape and separation from `PathResult` are required.
+
+```ts
+export interface Path {
+  readonly nodes: ReadonlyArray<NodeIndex>
+  readonly edges: ReadonlyArray<EdgeIndex>
+}
+
+export interface WeightedPath<E> extends Path {
+  readonly distance: number
+  readonly costs: ReadonlyArray<E>
+}
+
+export interface TraversalVisit<N, E> {
+  readonly node: NodeIndex
+  readonly data: N
+  readonly depth: number
+  readonly root: NodeIndex
+  readonly via: Option.Option<readonly [EdgeIndex, Edge<E>]>
+}
+
+export interface EnumerationOptions {
+  /** Maximum number of results. Zero yields none. Omitted means no result-count limit. */
+  readonly limit?: number
+}
+```
+
+`Path` invariants are `nodes.length >= 1` and `edges.length === nodes.length - 1`. The edge at position `i` connects
+`nodes[i]` to `nodes[i + 1]` under the graph kind. The model intentionally stores no graph, node data, or edge objects,
+so identity survives equal edge data and callers cannot mistake copied data for an edge identifier.
+
+Do not add `edgeIndices` to `PathResult`, even as an optional field: that would make old and new results observably
+different and encourage two path representations in one interface. Existing algorithms instead reconstruct an internal
+`Path`, then project it to the exact current `PathResult<E>` shape. `costs` remains the historical name and continues to
+contain edge data, not numeric weights.
+
+## Path Utilities
+
+All graph-taking functions are dual. Invalid structure returns `false` from the predicate and `Option.none` from safe
+construction/slicing; programmer-invalid numeric bounds or incompatible concatenation use `GraphError`.
+
+```ts
+export const pathNodes: (path: Path) => ReadonlyArray<NodeIndex>
+export const pathEdges: (path: Path) => ReadonlyArray<EdgeIndex>
+
+export const pathNodeData: {
+  <N, E, T extends Kind>(graph: Graph<N, E, T> | MutableGraph<N, E, T>, path: Path): Option.Option<Array<N>>
+  (path: Path): <N, E, T extends Kind>(graph: Graph<N, E, T> | MutableGraph<N, E, T>) => Option.Option<Array<N>>
+}
+
+export const pathEdgeData: {
+  <N, E, T extends Kind>(graph: Graph<N, E, T> | MutableGraph<N, E, T>, path: Path): Option.Option<Array<E>>
+  (path: Path): <N, E, T extends Kind>(graph: Graph<N, E, T> | MutableGraph<N, E, T>) => Option.Option<Array<E>>
+}
+
+export const pathDistance: {
+  <N, E, T extends Kind>(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+    path: Path,
+    cost: (edgeData: E) => number
+  ): Option.Option<number>
+  <E>(path: Path, cost: (edgeData: E) => number):
+    <N, T extends Kind>(graph: Graph<N, E, T> | MutableGraph<N, E, T>) => Option.Option<number>
+}
+
+export const isValidPath: {
+  <N, E, T extends Kind>(graph: Graph<N, E, T> | MutableGraph<N, E, T>, path: Path): boolean
+  (path: Path): <N, E, T extends Kind>(graph: Graph<N, E, T> | MutableGraph<N, E, T>) => boolean
+}
+
+export const pathFromEdges: {
+  <N, E, T extends Kind>(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+    source: NodeIndex,
+    edges: Iterable<EdgeIndex>
+  ): Option.Option<Path>
+  (source: NodeIndex, edges: Iterable<EdgeIndex>):
+    <N, E, T extends Kind>(graph: Graph<N, E, T> | MutableGraph<N, E, T>) => Option.Option<Path>
+}
+
+export const pathSlice: (path: Path, options: {
+  readonly from: number
+  readonly to?: number
+}) => Option.Option<Path>
+
+export const pathContains: (path: Path, candidate: Path, options?: {
+  readonly containment?: "prefix" | "contiguous"
+}) => boolean
+
+export const concatPaths: (head: Path, tail: Path) => Path
+export const pathToResult: {
+  <N, E, T extends Kind>(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+    path: Path,
+    distance: number
+  ): Option.Option<PathResult<E>>
+  (path: Path, distance: number):
+    <N, E, T extends Kind>(graph: Graph<N, E, T> | MutableGraph<N, E, T>) => Option.Option<PathResult<E>>
+}
+```
+
+`pathSlice` indexes nodes and uses half-open node bounds `[from, to)`, like `Array.slice`; it returns the corresponding
+contiguous edge range. Empty node slices are rejected because `Path` always has a source. `pathContains` compares both
+node and edge indexes, so equal node sequences using different parallel edges are different subpaths. `concatPaths`
+requires the last head node to equal the first tail node. Projections preserve order and return fresh arrays.
+
+## Ordered Arc and Reconstruction Kernel
+
+Plan 03 should own an internal ordered arc iterator with records equivalent to:
+
+```ts
+interface Arc<E> {
+  readonly from: NodeIndex
+  readonly to: NodeIndex
+  readonly edgeIndex: EdgeIndex
+  readonly edge: Edge<E>
+}
+```
+
+- `"outgoing"` on directed graphs emits source-to-target arcs; `"incoming"` emits reversed arcs;
+  `"undirected"` emits both directions while emitting a self-loop once.
+- All directions on an undirected graph use incident edges in edge-index/insertion order and orient each arc from the
+  current node to the other endpoint. A self-loop is emitted once.
+- Parallel edges produce parallel arcs and are never collapsed by neighbor identity.
+- The iterator is the only adjacency primitive used by the new traversal/path/cycle kernels.
+
+The shared predecessor record is `{ node: NodeIndex, edge: EdgeIndex }`. Single-path reconstruction chooses one record;
+tie reconstruction stores all equal-distance records and lazily backtracks them. Backtracking tracks nodes on the
+current partial path, preventing infinite reconstruction through zero-weight predecessor cycles and yielding only
+loopless shortest paths. Existing `dijkstra`, `astar`, and `bellmanFord` migrate to this kernel only after regression
+tests prove their current selected path, ordering, errors, and `PathResult` projection are unchanged.
+
+## Edge-Aware Traversal
+
+Node-only APIs remain unchanged. Add edge-aware variants only if plan 03's arc iterator makes them small wrappers:
+
+```ts
+export const dfsVisits: {
+  (config?: SearchConfig): <N, E, T extends Kind>(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>
+  ) => Iterable<TraversalVisit<N, E>>
+  <N, E, T extends Kind>(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+    config?: SearchConfig
+  ): Iterable<TraversalVisit<N, E>>
+}
+
+export const bfsVisits: typeof dfsVisits
+export const collectDfsVisits: /* same arguments */ Array<TraversalVisit<N, E>>
+export const collectBfsVisits: /* same arguments */ Array<TraversalVisit<N, E>>
+```
+
+Each node is yielded once. Roots have `depth: 0`, `root` equal to themselves, and `via: Option.none`; every other visit
+contains the exact first-discovery edge and oriented reached node. Multiple starts are considered in supplied order,
+duplicates are ignored after their first occurrence, and adjacency ties follow edge-index order. `radius` keeps its
+current shortest-edge-distance meaning. These are discovery-tree visits, not an enumeration of every examined edge;
+that distinction must be explicit in naming and JSDoc. The eager functions are exactly `Array.from(dfsVisits(...))`
+and `Array.from(bfsVisits(...))`.
+
+If the API review finds insufficient demand, omit these four public functions while still using edge-aware arcs
+internally. Do not add an ambiguous `dfsEdges` that could mean discovery edges or all examined edges.
+
+## All Tied Shortest Paths
+
+```ts
+export interface ShortestPathsConfig<E> extends EnumerationOptions {
+  readonly source: NodeIndex
+  readonly target: NodeIndex
+  readonly cost: (edgeData: E) => number
+  readonly algorithm?: "dijkstra" | "bellmanFord"
+}
+
+export const shortestPaths: {
+  <E>(config: ShortestPathsConfig<E>): <N, T extends Kind>(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>
+  ) => Iterable<WeightedPath<E>>
+  <N, E, T extends Kind>(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+    config: ShortestPathsConfig<E>
+  ): Iterable<WeightedPath<E>>
+}
+
+export const collectShortestPaths: /* same arguments */ Array<WeightedPath<E>>
+```
+
+`shortestPaths` means all **simple** source-to-target paths with minimum total weight, including alternatives differing
+only by parallel-edge identity. `source === target` yields the empty path first and does not enumerate non-empty
+zero-weight cycles. Unreachable targets yield nothing. Dijkstra requires all graph edge weights to be non-negative;
+Bellman-Ford permits finite negative weights. Both reject `NaN` and `-Infinity`; `Infinity` is impassable. A reachable
+negative cycle that can reach the target makes a minimum undefined and throws `GraphError`. Existing Bellman-Ford's
+current `Option.none` behavior remains unchanged unless plan 01 independently classifies it as a bug.
+
+For Dijkstra, do not stop when the target is first popped. Settle all nodes with distance less than or equal to the
+target distance so equal paths ending in zero-weight edges are retained. Tie predecessors are appended in ordered arc
+discovery order. Enumerate the resulting shortest-path relation forward in edge-index order, with an on-path node set,
+so edge-index sequences are emitted lexicographically without collecting every result first. This ordering is stable
+across heap implementations. `limit` truncates that order and does not claim that omitted tied paths do not exist.
+
+Complexity before output is `O((V + E) log V)` for Dijkstra and `O(VE)` for Bellman-Ford, with `O(V + E_t)` predecessor
+space where `E_t` is the number of shortest-path predecessor arcs. Reconstruction is `O(sum of emitted path lengths)`
+plus ordering overhead. The number of tied paths can be exponential.
+
+## Bounded Simple Paths
+
+```ts
+export interface SimplePathsConfig<E> extends EnumerationOptions {
+  readonly source: NodeIndex
+  readonly target: NodeIndex
+  /** Maximum edge count; defaults to V - 1. */
+  readonly maxDepth?: number
+  /** Optional inclusive total-cost bound. Requires cost. */
+  readonly maxDistance?: number
+  readonly cost?: (edgeData: E) => number
+}
+
+export const simplePaths: /* dual */ Iterable<Path>
+export const collectSimplePaths: /* dual */ Array<Path>
+```
+
+Use iterative DFS/backtracking, not recursive calls, so long chains are stack-safe. The current-path node set enforces
+looplessness. The natural finite bound is `V - 1`; `maxDepth` may only reduce it. `limit`, `maxDepth`, and `maxDistance`
+are checked before expanding more arcs. `limit: 0` performs endpoint and option validation, then yields nothing.
+`maxDepth` must be a non-negative integer. `maxDistance` must not be `NaN`; negative values simply yield no paths unless
+`source === target` and zero is allowed.
+
+Cost pruning is sound only for non-negative weights, so providing `maxDistance` validates all weights as non-negative,
+not `NaN`, and not `-Infinity`; `Infinity` remains impassable. Without `maxDistance`, weights are irrelevant and negative edges are accepted. Self-loops
+cannot occur in a simple source-to-target path, while parallel edges create distinct paths. Directed edges follow their
+direction; undirected edges may be traversed either way but the same node cannot be revisited.
+
+Output is depth-first lexicographic edge-index order. A yielded path is materialized, but unexplored paths are not;
+abandoning the iterator must stop work immediately. Worst-case time/output is exponential, per-active-iterator working
+space is `O(V + E)` plus one materialized result, and eager collection adds output-sized memory.
+
+## Shortest Simple Alternatives
+
+```ts
+export interface ShortestSimplePathsConfig<E> extends EnumerationOptions {
+  readonly source: NodeIndex
+  readonly target: NodeIndex
+  readonly cost: (edgeData: E) => number
+}
+
+export const shortestSimplePaths: /* dual */ Iterable<WeightedPath<E>>
+export const collectShortestSimplePaths: /* dual */ Array<WeightedPath<E>>
+```
+
+Implement Yen's algorithm first. It fits the existing non-negative single-pair Dijkstra kernel, preserves edge identity,
+handles directed/undirected graphs and parallel edges, and is substantially simpler to verify than Eppstein's algorithm.
+Do not copy `.repos/graph`'s filtered graph objects; pass temporary banned-node and banned-edge-index sets into the
+internal shortest-path kernel so stable indexes, graph identity, and adjacency order remain intact.
+
+Weights must be non-negative and not `NaN`; `Infinity` is impassable. Negative-weight alternatives are deferred: Yen
+with a Bellman-Ford spur kernel is possible but complicates cycle and potential handling without a demonstrated need.
+The empty source-to-source path is the only result for equal endpoints. Candidates are deduplicated by complete
+edge-index sequence. Output is nondecreasing total distance, then lexicographic edge-index sequence. `limit` is the
+maximum `k`; omitted `limit` enumerates until the candidate heap is empty, which may enumerate every simple path.
+
+For `k` emitted paths, a conventional implementation is `O(k V (E + V) log V)` worst case with Dijkstra spur searches,
+plus candidate storage. Benchmark before considering Eppstein or replacement-path optimizations.
+
+## Cycle Enumeration
+
+```ts
+export interface CyclesConfig extends EnumerationOptions {
+  readonly maxLength?: number
+}
+
+export const cycles: /* dual */ Iterable<Path>
+export const collectCycles: /* dual */ Array<Path>
+```
+
+Enumerate elementary cycles. A returned cycle repeats its source node at the end, so a self-loop is `{ nodes: [v, v],
+edges: [e] }`. Directed rotations are one cycle; reverse orientation is distinct only when distinct directed edges make
+it traversable. For undirected graphs, rotations and reversal are the same cycle. Two parallel undirected edges form a
+valid length-two cycle; one undirected edge traversed out and immediately back is not a cycle because an edge cannot be
+used twice. Distinct edge-index sets/sequences can therefore identify cycles with the same node set.
+
+Use Johnson's blocked-set algorithm for directed graphs, restricted to SCCs supplied by plan 06 if available; otherwise
+use an internal SCC helper that is not exported. Adapt the search for undirected graphs with arrival-edge tracking and
+canonicalization. Canonical output rotates to the smallest node index; undirected output chooses the lexicographically
+smaller edge-index sequence across the two orientations. Output visits canonical start nodes in node-index order and
+explores their arcs depth-first in edge-index order; duplicate canonical identities are suppressed on discovery. This is
+deterministic but intentionally does not promise a global sort that would require eager collection. `maxLength` is an
+inclusive edge count and must be a positive integer; `limit: 0` yields none.
+
+Johnson's directed complexity is `O((V + E)(C + 1))` for `C` cycles, excluding output copies. Undirected adaptation
+should target the same output-sensitive class; document any weaker bound if implementation evidence requires a simpler
+algorithm. The lazy implementation must not first collect all cycles for one start node, a defect visible in the
+reference implementation. The eager API only collects the lazy API.
+
+## Optional Bidirectional Dijkstra
+
+After the shared kernel and differential tests are stable, prototype bidirectional Dijkstra for one non-negative
+source/target query. It may be:
+
+- an internal optimization under existing `dijkstra`, only if exact current path/tie selection remains unchanged; or
+- an additive `dijkstraBidirectional` returning `Option.Option<PathResult<E>>` (and optionally an edge-aware sibling)
+  if deterministic equivalence cannot be guaranteed.
+
+Forward search uses outgoing arcs and backward search uses incoming arcs. For undirected graphs both use incident arcs.
+Terminate only when the minimum forward key plus minimum backward key is at least the best complete-path distance.
+Validate every weight before an early return, including `source === target`, so a negative edge outside the explored
+frontier cannot evade Dijkstra's contract. Meeting-node and equal-cost ties use the complete edge-index sequence rule,
+not whichever frontier happened to run first.
+
+Expected complexity remains `O((V + E) log V)` time and `O(V + E)` space, with lower explored volume on suitable
+single-pair workloads. Do not ship the optimization unless benchmarks show a material win on sparse road/grid and
+random/small-world fixtures without a meaningful regression on chains, stars, dense graphs, or tiny graphs.
+
+## Cancellation and Effect-Native Follow-up
+
+Synchronous APIs remain synchronous. There is no public checkpoint, cancellation callback, `AbortSignal`, or progress
+option. Kernels use plan 03's internal no-op checkpoint protocol at boundaries such as:
+
+- once per settled/dequeued node in shortest-path and traversal kernels;
+- once per Bellman-Ford edge-relaxation pass and at bounded intervals within a pass;
+- once per DFS backtracking/expansion step for simple paths and cycles;
+- before each Yen spur search and candidate emission.
+
+Checkpoint cadence is an internal performance and interruption detail, not a public callback or result-ordering
+contract. Plan 10 alone owns Effect adapters that provide fiber interruption and cooperative yielding.
+
+After synchronous kernels stabilize, additive Effect variants may wrap the same kernels with the plan 03 checkpoint
+abstraction and return `Effect`/`Stream` forms with native interruption. Do not add Effect variants in the initial phases,
+and do not claim interruption for a synchronous `Iterable` that only checks between `next()` calls.
+
+## Cross-Cutting Semantics
+
+| Concern | Contract |
+| --- | --- |
+| Directed graph | Follow source-to-target arcs unless a traversal config explicitly says `incoming` or `undirected`. Path-finding configs do not ignore direction. |
+| Undirected graph | Every edge is traversable both ways; output retains the one stored `EdgeIndex`. Storage orientation does not affect validity. |
+| Self-loop | Valid path step and a length-one cycle; excluded from simple paths except cycle output; source-to-source shortest/simple-alternative output is the empty path only. |
+| Parallel edges | Independent arcs, predecessor choices, paths, and cycles. Equal data never deduplicates edge identities. |
+| Zero-weight cycle | Dijkstra accepts it. Tie reconstruction tracks on-path nodes and emits finite loopless shortest paths only. |
+| Negative weight | Rejected by Dijkstra, A*, Yen, and bounded cost pruning. Bellman-Ford tie APIs accept finite negatives and reject target-affecting negative cycles. |
+| `NaN` / infinities | `NaN` and `-Infinity` are invalid. `Infinity` means impassable. Heuristic validation remains the existing A* contract. |
+| Missing endpoint | Public path-finding/enumeration APIs throw the existing missing-node `GraphError`; utility predicates return `false` and safe constructors/projections return `Option.none`. |
+| Determinism | Default structural order is stable node/edge insertion index. Cost-ranked outputs use distance, then lexicographic edge-index sequence. |
+| Bounds | Counts and lengths are integers in their documented ranges or throw `GraphError`; all checks happen before expensive work. |
+| Laziness | Creating an iterable does no search. Each iterator has fresh state. Eager functions are literal collection of the lazy form and have identical ordering/errors. |
+
+## Implementation Phases
+
+1. **Contracts and fixtures**: resolve names with plans 01-04; retain the landed traversal snapshot/order fixtures, add
+   the remaining radius/start-ownership/DFS-root regressions, and define canonical path/cycle identity and weight
+   validation.
+2. **Internal foundation**: extend the landed CSR rather than replacing it: add stable public edge-ID projection, unify
+   mutable and immutable predecessor state, and consume plan 03's heap, checkpoint, and weight policy. Keep all new pieces
+   internal initially.
+3. **Path model and utilities**: publish `Path`, projections, validation, construction, slicing, containment,
+   concatenation, and type tests. Migrate existing reconstruction internally while preserving `PathResult` output.
+4. **All tied shortest paths**: add lazy/eager APIs with Dijkstra and Bellman-Ford, zero-weight-cycle guards, bounds,
+   deterministic ordering, and differential tests.
+5. **Bounded simple paths**: add stack-safe lazy DFS and exact eager collector; verify early abandonment does not explore
+   later branches.
+6. **Shortest alternatives**: add Yen over banned-view Dijkstra, candidate heap, identity deduplication, and exhaustive
+   small-graph oracle tests.
+7. **Cycle enumeration**: add directed and undirected elementary-cycle iterators, canonicalization, bounds, and eager
+   collection. Coordinate SCC reuse with plan 06 without exposing connectivity APIs here.
+8. **Optional traversal visits**: add edge-aware visits only if API review validates the use case and implementation is a
+   thin shared-kernel wrapper.
+9. **Bidirectional prototype**: benchmark and either adopt internally with exact compatibility, expose additively, or
+   discard with recorded results.
+10. **Effect-native follow-up**: after synchronous performance and semantics settle, separately propose interruptible
+    Effect/Stream wrappers.
+
+Each phase should be independently reviewable. Do not combine cycle enumeration, Yen, and bidirectional optimization in
+one change.
+
+## Tests and Oracles
+
+Add focused runtime tests under `packages/effect/test/Graph.test.ts` or a dedicated `GraphPaths.test.ts`, plus public
+type assertions in `packages/effect/typetest/Graph.tst.ts`.
+
+Required example tests:
+
+- valid/invalid directed and reverse-stored undirected paths; stale node/edge indexes; malformed lengths;
+- projection and slicing laws, concatenation identity, prefix versus contiguous containment, and no input-array aliasing;
+- parallel edges with identical data remain distinct through shortest paths, simple paths, Yen, and cycles;
+- self-loops, directed mutual pairs, undirected triangles, and two parallel undirected edges;
+- all diamond ties, weighted ties, ties ending in zero-weight edges, and zero-weight predecessor cycles;
+- unreachable/equal endpoints; sparse indexes after removals; multiple starts and radius behavior for traversal visits;
+- negative edges outside an early-exit frontier, negative cycles reachable/unreachable from source and able/unable to
+  reach target, `NaN`, `Infinity`, and `-Infinity`;
+- `limit` values `0`, `1`, and larger than output; `maxDepth` at `0`, exact path length, and below path length;
+- internal checkpoint-count and resumability tests for every long-running family, using plan 02's probe harness;
+- repeated iteration produces equal output and eager output equals `Array.from(lazyOutput)`;
+- iterator abandonment after the first result does not enumerate/materialize remaining exponential branches;
+- exact deterministic output after unrelated removals create sparse, non-contiguous indexes.
+
+Property and differential oracles:
+
+- enumerate all edge-index sequences up to `V - 1` on seeded graphs with at most 7 nodes and compare simple paths,
+  minimum tied paths, sorted `k` alternatives, and cycles after canonicalization;
+- compare Dijkstra and Bellman-Ford distances on non-negative graphs and compare optional bidirectional Dijkstra to the
+  unidirectional kernel on directed and undirected seeded multigraphs;
+- use Floyd-Warshall distances as a small-graph distance oracle only, not as an edge-identity/tie oracle;
+- validate every emitted result with `isValidPath`, recompute its distance from edge indexes, and assert simple/cycle
+  node uniqueness rules;
+- metamorphic checks: adding an unreachable component does not change pair results; consistently increasing all edge
+  indexes through fixture reconstruction changes only identity/order, not distances; reversing stored endpoints of every
+  undirected edge preserves path/cycle identities modulo orientation;
+- retain `.repos/graph` cases as inspiration, especially zero-weight cycles, all diamond ties, parallel-edge Yen, cycle
+  deduplication, lazy first-result behavior, and negative edges beyond the explored frontier, but express expected values
+  using Effect `Graph` indexes and `@effect/vitest` assertions.
+
+## Benchmarks
+
+Use plan 02's seeded fixture and benchmark harness. Record time, allocations where available, explored nodes/arcs, and
+first-result versus full-consumption latency for:
+
+- BFS/DFS node walkers using `a371754b1e` as the CSR baseline, including cold snapshot construction, warm reuse, sparse
+  indexes, and active/fresh mutable iteration;
+- single-pair Dijkstra on chain, grid/road-like, random sparse, small-world, star, dense, and disconnected graphs;
+- all-tie shortest paths on layered diamonds, measuring first result, first 10, and full bounded consumption;
+- simple paths on deep chains (stack safety) and diamond ladders (early abandonment);
+- Yen for `k = 1, 5, 10, 50` on sparse weighted multigraphs;
+- cycle enumeration for acyclic, one-cycle, sparse many-cycle, and dense bounded cases;
+- eager versus lazy peak memory on 10k-node fixtures and tie-heavy small fixtures.
+
+Acceptance gates: no material regression in existing BFS/DFS or unidirectional Dijkstra baselines; lazy first-result work
+must not scale with the number of unconsumed results; bidirectional Dijkstra ships only with a demonstrated representative
+win and no semantic drift. Benchmark thresholds should be based on plan 02 baselines rather than hard-coded wall times.
+
+## Changesets and Documentation
+
+- Internal kernel migrations with no public or runtime behavior change need no changeset.
+- Each shipped group of new public models/functions requires an `effect` **minor** changeset because it is additive API.
+- Any independently demonstrated correction to existing runtime behavior requires an `effect` **patch** changeset and a
+  regression test; do not silently fold such corrections into this additive plan.
+- Every public symbol needs dual data-first/data-last signatures where applicable, JSDoc with directed/undirected and
+  laziness caveats, `@since`, examples, and typetests. Runnable examples require doctests.
+- Generated barrels must be updated through `pnpm codegen`, never by hand.
+
+## Dependencies and Ownership
+
+- **Plan 01, correctness contracts**: required before API implementation. It owns final missing-node, numeric-weight,
+  negative-cycle, mutable-iteration, self-loop, parallel-edge, and deterministic-order contracts. This plan must not
+  redefine existing behavior unilaterally.
+- **Plan 02, verification and benchmarks**: required for seeded multigraph generators, brute-force/oracle adapters,
+  laziness instrumentation, and benchmark baselines.
+- **Plan 03, architecture and performance kernel**: required for the ordered arc iterator, optional dense snapshot,
+  heap, shared weight validation, edge-index predecessors/reconstruction, and no-op checkpoint abstraction. This plan
+  should not create competing helpers.
+- **Plan 04, core queries and transforms**: required for stable incident-edge queries and any internal filtered/banned
+  graph view used by Yen. Yen must not clone or renumber public graphs.
+- **Plan 06** may later supply SCC decomposition to accelerate Johnson cycle enumeration. Cycle correctness cannot depend
+  on plan 06 landing first; keep any temporary SCC helper internal and remove it when shared ownership is available.
+- **Plan 07** exclusively owns Eulerian algorithms. It may consume this plan's `Path` model and plan 03's arc iterator, but this
+  plan must not implement or expose Eulerian paths, circuits, or edge-covering walks.
+
+Work that can proceed before all dependencies land is limited to contract tests, API naming review, brute-force test
+oracles, and benchmark fixture design. Public implementation begins only after plans 01 and 03 settle the shared
+semantics and internal representations.

--- a/docs/graph-plans/06-connectivity-dag-algorithms.md
+++ b/docs/graph-plans/06-connectivity-dag-algorithms.md
@@ -1,0 +1,460 @@
+# Connectivity and DAG Algorithms
+
+## Scope
+
+This plan adds structural analyses that sit above the core queries and traversal kernels: undirected cut structure,
+directed weak components, SCC condensation, transitive reduction, and rooted dominance. It also hardens the ordering
+and stack-safety contracts of the existing component algorithms without changing their public signatures.
+
+This plan does not own:
+
+- `hasPath`, `isConnected`, `isTree`, or other basic boolean queries, which belong to plan 04.
+- Cycle enumeration or cycle result types, which belong to plan 05. This plan may call `isAcyclic` but must not add a
+  second cycle finder.
+- Cycle witnesses from failed DAG operations. This plan owns the existing `topo` API and its ordering/error hardening,
+  but cycle result types and enumeration remain in plan 05.
+- Bipartite analysis, spanning trees, flow, centrality, or community detection.
+- Effect-native interruption wrappers. The synchronous kernels should use the shared checkpoint abstraction so a
+  later plan can add wrappers without duplicating algorithms.
+
+The work is additive except for internal replacement of recursive or allocation-heavy kernels and regression tests
+that pin existing behavior. Existing signatures for `connectedComponents`, `stronglyConnectedComponents`,
+`isAcyclic`, and `topo` remain unchanged.
+
+## Current Baseline
+
+`Graph.ts` currently provides:
+
+- Stack-safe directed and undirected `isAcyclic`, including the established rules that a self-loop is a cycle and two
+  parallel undirected edges form a cycle.
+- Eager `connectedComponents` for undirected graphs.
+- Stack-safe Kosaraju `stronglyConnectedComponents` for directed graphs, with a runtime `GraphError` for an
+  undirected graph passed through an unsafe cast.
+- A dual, lazy Kahn `topo` walker for directed DAGs. It throws `GraphError` for undirected or cyclic inputs and
+  prioritizes valid configured initial nodes.
+
+The reference repository adds bridges, articulation points, node-only biconnected components, transitive reduction,
+and a Cooper-Harvey-Kennedy dominator tree. Its coverage establishes useful fixtures and edge cases, but its recursive
+low-link, SCC, and reachability implementations are not stack-safe, its biconnected result loses edge identity, and
+its connectivity implementation does not adequately specify multigraph and self-loop behavior. Those details must
+not be copied implicitly.
+
+## Applicability and Semantics
+
+| Analysis | Directed graph | Undirected graph | Cycles allowed |
+| --- | --- | --- | --- |
+| Existing `connectedComponents` | No | Yes | Yes |
+| `weaklyConnectedComponents` | Yes | No; use `connectedComponents` | Yes |
+| `isWeaklyConnected` | Yes | No; use `isConnected` | Yes |
+| Existing `stronglyConnectedComponents` | Yes | No | Yes |
+| `isStronglyConnected` | Yes | No | Yes |
+| `condensationGraph` | Yes | No | Yes |
+| `bridges` | No | Yes | Yes |
+| `articulationPoints` | No | Yes | Yes |
+| `biconnectedComponents` | No | Yes | Yes |
+| `transitiveReduction` | Yes | No | No, DAG only |
+| `dominatorTree` | Yes | No | Yes |
+
+Public types should reject the wrong graph kind. Every implementation must also check `graph.type` and throw a
+`GraphError` when an unsafe cast defeats the type restriction. There is no option that silently ignores direction:
+weak connectivity is named explicitly, while cut structure is defined only for an undirected graph.
+
+Shared edge-case rules:
+
+- Empty component analyses return `[]`; an edgeless graph has one singleton weak/connected component per node.
+- A self-loop is never a bridge and never makes its node an articulation point. It is retained as its own
+  edge-bearing biconnected block so every undirected edge belongs to exactly one block.
+- Parallel undirected edges are distinct by `EdgeIndex`. In particular, neither of two parallel edges is a bridge;
+  the non-parent parallel edge acts as a back edge in low-link analysis. Both belong to the same biconnected block.
+- Edge orientation as stored in an undirected graph has no effect. Reversing the stored endpoints produces the same
+  node and edge-index results.
+- Disconnected graphs are analyzed as forests of DFS roots. Bridges and articulation points are returned across all
+  components. Biconnected output includes singleton blocks for isolated nodes.
+- Directed self-loops remain inside one SCC, disappear as internal edges in condensation, make transitive reduction
+  fail the DAG precondition, and do not change a node's immediate dominator.
+- Parallel directed edges do not change weak components, SCCs, or dominance. Their transitive-reduction behavior is
+  specified separately below.
+- Dominance is rooted reachability. Nodes not reachable from the root are omitted rather than assigned a sentinel
+  dominator. Disconnected reachable structure is therefore not possible within one result.
+
+The existing `topo` contract remains directed-only and lazy/repeatable. Empty and disconnected DAGs are valid. Every
+parallel edge contributes independently to in-degree, a self-loop is a cycle, configured `initials` must exist and have
+zero in-degree, and valid initials are prioritized without omitting other zero-in-degree nodes. Preserve current
+`GraphError` messages and the current rule that each fresh iteration observes fresh mutable graph state.
+
+## Public API
+
+Names below follow the existing `Graph` module style. Multi-argument functions use `dual`, supporting both
+`operation(graph, ...)` and `graph.pipe(operation(...))`. Unary whole-graph analyses are already naturally pipeable and
+must not gain artificial zero-argument overloads. These are synchronous APIs; do not add fake Effect wrappers that
+merely defer a synchronous call.
+
+```ts
+export interface BiconnectedComponent {
+  readonly nodes: ReadonlyArray<NodeIndex>
+  readonly edges: ReadonlyArray<EdgeIndex>
+}
+
+export interface CondensationResult {
+  readonly graph: DirectedGraph<ReadonlyArray<NodeIndex>, ReadonlyArray<EdgeIndex>>
+  readonly componentOf: ReadonlyMap<NodeIndex, NodeIndex>
+}
+
+export interface DominatorTree {
+  readonly root: NodeIndex
+  readonly nodes: ReadonlyArray<NodeIndex>
+  readonly immediateDominators: ReadonlyMap<NodeIndex, Option.Option<NodeIndex>>
+}
+
+export const weaklyConnectedComponents: <N, E>(
+  graph: DirectedGraph<N, E> | MutableDirectedGraph<N, E>
+) => Array<Array<NodeIndex>>
+
+export const isWeaklyConnected: <N, E>(
+  graph: DirectedGraph<N, E> | MutableDirectedGraph<N, E>
+) => boolean
+
+export const isStronglyConnected: <N, E>(
+  graph: DirectedGraph<N, E> | MutableDirectedGraph<N, E>
+) => boolean
+
+export const bridges: <N, E>(
+  graph: UndirectedGraph<N, E> | MutableUndirectedGraph<N, E>
+) => Array<EdgeIndex>
+
+export const articulationPoints: <N, E>(
+  graph: UndirectedGraph<N, E> | MutableUndirectedGraph<N, E>
+) => Array<NodeIndex>
+
+export const biconnectedComponents: <N, E>(
+  graph: UndirectedGraph<N, E> | MutableUndirectedGraph<N, E>
+) => Array<BiconnectedComponent>
+
+export const condensationGraph: <N, E>(
+  graph: DirectedGraph<N, E> | MutableDirectedGraph<N, E>
+) => CondensationResult
+
+export const transitiveReduction: <N, E>(
+  graph: DirectedGraph<N, E> | MutableDirectedGraph<N, E>
+) => DirectedGraph<N, E>
+
+export const dominatorTree: {
+  <N, E>(
+    graph: DirectedGraph<N, E> | MutableDirectedGraph<N, E>,
+    root: NodeIndex
+  ): DominatorTree
+  (root: NodeIndex): <N, E>(
+    graph: DirectedGraph<N, E> | MutableDirectedGraph<N, E>
+  ) => DominatorTree
+}
+```
+
+The exact overload formatting should follow neighboring APIs. `Option.none()` represents the root's immediate
+dominator; absence from `immediateDominators` represents an unreachable node. `nodes` makes the result's reachable
+domain and iteration order explicit.
+
+Do not add `get*` aliases from the reference repository. Do not add generator forms for these APIs: all of them need
+global discovery, low-link, closure, or fixpoint state before their results are known, so a generator would be
+nominally lazy rather than genuinely lazy.
+
+`isWeaklyConnected` and `isStronglyConnected` are the explicit directed predicates intentionally left out of plan 04's
+ambiguous `isConnected` surface. Both return `true` for empty and singleton directed graphs. They may stop once their
+answer is known and need not materialize component arrays; `isStronglyConnected` can use one outgoing and one incoming
+rooted traversal rather than a full SCC partition.
+
+Do not add a directed `isConnected` overload or alias. Plan 04's `isConnected` is undirected-only; weak and strong
+connectivity remain separately named and typed so no two public predicates overlap semantically.
+
+### Biconnected Result
+
+Return vertex-biconnected blocks with their exact edge membership, not only arrays of nodes. Articulation points may
+occur in multiple blocks; every non-isolated node occurs in at least one block; every edge occurs in exactly one
+block. A bridge is a two-node, one-edge block. An isolated node is a one-node, zero-edge block. A self-loop is a
+one-node, one-edge block. This representation supports multigraph consumers and permits all three cut APIs to share
+one analysis kernel.
+
+### Condensation Result
+
+Condensation is justified as the bridge between SCC analysis and DAG-only algorithms. Each condensation node stores
+the source graph node indexes in its SCC. `componentOf` maps each source `NodeIndex` to the corresponding condensation
+graph `NodeIndex`.
+
+The condensation graph is simple even when the source is a multigraph: all source edges crossing the same ordered
+component pair become one condensation edge whose data is the source `EdgeIndex` values in stable order. Internal SCC
+edges, including self-loops, do not become condensation edges. Empty and disconnected directed graphs are valid; all
+SCCs appear, including isolated nodes, and the result is always a DAG.
+
+### Transitive Reduction
+
+The operation returns a new immutable graph and never mutates its input. It retains every node and the original node
+data. Surviving edges retain their original `EdgeIndex`, endpoints, and data; removed indexes remain holes and the
+next-index counters are preserved. Build this by cloning and removing edges, not by reconstructing a graph with
+renumbered indexes.
+
+For each ordered endpoint pair in a DAG:
+
+- If another path of length at least two connects the endpoints, remove every direct parallel edge.
+- Otherwise retain only the lowest/insertion-first `EdgeIndex` and remove later parallel edges, because multiplicity
+  does not add reachability.
+
+This is the canonical reachability-preserving reduction of the simple relation represented by a directed multigraph.
+It is intentionally not an edge-data-preserving optimization. Empty graphs and disconnected DAGs are valid. An
+undirected input throws `GraphError("Cannot perform transitive reduction on undirected graph")`; any directed cycle,
+including a self-loop, throws `GraphError("Cannot perform transitive reduction on cyclic graph")`. Validate before
+constructing the output so failures are atomic.
+
+### Dominator Tree
+
+`dominatorTree(graph, root)` computes immediate dominators in the directed graph rooted at an existing node. A node
+`d` dominates `n` when every directed path from `root` to `n` contains `d`. Cycles, back edges, self-loops, and parallel
+edges are valid. A missing root throws the existing missing-node `GraphError`; an unsafe undirected input throws a
+kind-specific `GraphError`. There is no inferred root: Effect graphs have no initial-node field, and choosing a unique
+zero-in-degree node would make disconnected and cyclic behavior surprising.
+
+## Stable Ordering
+
+All new result ordering is part of the contract and is based on stable public indexes, never node or edge data:
+
+- Members of a newly added component result are ascending `NodeIndex`.
+- Weak components are ordered by their smallest node index.
+- Bridges and articulation points are ascending index.
+- Nodes and edges inside each biconnected block are ascending index. Blocks are ordered by smallest node index, then
+  smallest edge index, with an edge-less singleton ordered after edge-bearing blocks with the same node.
+- Condensation nodes follow the stable order returned by the SCC partition used to construct them; source node lists
+  are ascending. Condensation edges follow the first source edge for each component pair, and each edge's source
+  index list is ascending.
+- `DominatorTree.nodes` and `immediateDominators` iterate reachable nodes in ascending `NodeIndex`.
+- Transitive reduction preserves source node and surviving edge iteration order and all sparse indexes.
+
+Before replacing the existing connected-component or SCC internals, add exact-order regression fixtures for their
+current outputs, including sparse indexes. Preserve those outputs; do not silently canonicalize an existing API in an
+additive plan. New APIs may canonicalize a private copy of an SCC partition where their contracts require it.
+
+Results from mutable graphs describe the graph at call time. They are ordinary snapshots and do not update after a
+later mutation.
+
+## Implementation Design
+
+### Shared Undirected Low-Link Kernel
+
+Run one iterative Tarjan-style DFS forest over the direction-ignored ordered arc iterator. Each explicit frame stores
+the node, parent `EdgeIndex`, next arc position, DFS child count, and the edge that entered the frame. Dense arrays hold
+discovery time, low-link value, parent edge, and flags; an edge stack identifies biconnected blocks.
+
+Parent suppression must compare `EdgeIndex`, not parent node. This is the key multigraph rule: a second parallel edge
+to the parent remains visible and lowers the child's low-link. Push each tree edge once and each ancestor back edge
+once. Handle a self-loop once by edge identity and emit it as a standalone block without changing low-link values.
+On frame completion:
+
+- `low[child] > discovery[parent]` marks the entering edge as a bridge.
+- `low[child] >= discovery[parent]` closes one biconnected block at the entering edge.
+- A non-root parent meeting that boundary is an articulation point.
+- A DFS root is an articulation point exactly when it has more than one DFS-tree child.
+
+Start roots in node-index order and continue across disconnected components. Emit an isolated singleton after
+finishing a root with no incident non-loop edge and no loop block. Normalize public output once after analysis rather
+than adding ordered-set costs to the hot loop. `bridges`, `articulationPoints`, and `biconnectedComponents` should all
+delegate to this one internal result.
+
+### Weak and Strong Components
+
+`weaklyConnectedComponents` performs iterative BFS/DFS across direction-ignored arcs. Mark nodes when enqueued so
+parallel edges and self-loops do not duplicate work. The existing undirected `connectedComponents` can share this
+kernel only if exact-order regression tests prove no public ordering change.
+
+Keep the existing directed-only SCC semantics. Its iterative Kosaraju implementation may move onto dense arrays and
+ordered incoming/outgoing arcs, or be replaced by an iterative Tarjan SCC kernel, only after exact-order tests pin the
+current API. Condensation must consume one computed SCC partition and must not rerun SCC discovery per edge.
+
+Implement `isWeaklyConnected` as one direction-ignored traversal with early count comparison. Implement
+`isStronglyConnected` as outgoing and incoming traversals from the first node; reaching every node in both directions
+is equivalent to strong connectivity and avoids materializing SCC arrays. Both use the vacuous empty-graph convention.
+
+### Topological Ordering
+
+Retain `topo` as the public lazy `NodeWalker`; do not add an eager alias because callers can collect `Graph.indices` or
+`Graph.values`. Move its Kahn state onto the shared FIFO and ordered outgoing arc kernel while preserving exact enqueue
+order, `initials` priority, validation timing, repeatability, and mutable-state behavior. Count every parallel edge when
+initializing and decrementing in-degree. DAG consumers in this plan may use a private eager node-index projection of the
+same kernel, but must not collect node data or create a second tie-order rule.
+
+### Condensation
+
+Allocate one condensation node per SCC and a dense `componentOf` table/map. Scan original edges once in edge-index
+order. Ignore edges whose endpoints map to the same component; for crossing edges, group by the ordered component
+pair and append the source edge index. Add grouped edges in the order their pair is first encountered. Assert in tests,
+not production hot code, that the result is acyclic.
+
+### Transitive Reduction
+
+Validate graph kind and acyclicity, then obtain one stable topological order. On a dense snapshot, compute a reverse-
+topological reachability bitset for each node by OR-ing successor bitsets and setting successor bits. For each source,
+consider distinct successor nodes in ascending topological rank. A successor already covered by an earlier
+successor's reachability is redundant; otherwise retain its first edge and union its closure into the covered set.
+This ordering is valid because a later topological successor cannot reach an earlier one. Remove all redundant edges
+from a cloned graph in one mutation scope.
+
+Use packed typed-array bitsets from the dense kernel rather than nested JavaScript `Set`s. If the dense plan defines a
+memory threshold, provide a stack-safe repeated-search fallback with identical output rather than allocating
+quadratic memory unconditionally.
+
+### Dominators
+
+Use the Cooper-Harvey-Kennedy iterative algorithm initially: it is compact, well understood, and fast for typical
+control-flow graphs. Build reverse postorder of the root-reachable subgraph with explicit DFS frames, build reachable
+predecessor lists from incoming arcs, and iterate immediate dominators to a fixpoint. `intersect` walks the current
+dominator chains by reverse-postorder number. No recursive DFS is permitted.
+
+Check the shared synchronous checkpoint once per DFS batch and once per fixpoint sweep. Do not adopt the substantially
+more complex Lengauer-Tarjan algorithm without benchmark evidence that CHK is a bottleneck. The public result is
+materialized in stable node-index order after the fixpoint, independent of internal reverse-postorder order.
+
+## Complexity
+
+Let `V` be nodes, `E` be edge occurrences including parallel edges and loops, `C` be SCCs, and `W` be the machine-word
+width used by packed bitsets.
+
+| Operation | Time | Additional space |
+| --- | --- | --- |
+| Weak/connected components | `O(V + E)` | `O(V)` |
+| Weak/strong connectivity predicates | `O(V + E)` | `O(V)` |
+| Strongly connected components | `O(V + E)` | `O(V)` plus DFS frames |
+| Topological ordering | `O(V + E)` | `O(V)` plus lazy walker state |
+| Bridges/articulation/biconnected blocks | `O(V + E)` before output normalization | `O(V + E)` |
+| Condensation | `O(V + E)` expected, plus stable normalization | `O(V + E)` including grouped source edges |
+| Transitive reduction, bitset path | `O((V + E) * ceil(V / W) + E log E)` | `O(V * ceil(V / W) + E)` |
+| Transitive reduction fallback | `O(VE)` worst case | `O(V + E)` |
+| Dominator tree (CHK) | `O(I * (V + E))`, worst-case `O(VE)` | `O(V + E)` |
+
+Document these bounds in public JSDoc, including the potentially quadratic transitive-closure storage and CHK's
+fixpoint behavior. Sorting terms are over stable index normalization and per-source successor ordering; they must not
+hide repeated graph scans.
+
+## Errors and Validation
+
+- Reuse `GraphError`; do not introduce one error class per algorithm.
+- Wrong-kind errors are synchronous and occur before traversal.
+- `topo` and `transitiveReduction` distinguish wrong kind from cyclic directed input. Reduction performs no partial
+  mutation; `topo` preserves its existing walker-time validation behavior.
+- `dominatorTree` validates kind before root existence, then uses the shared missing-node error for the root.
+- Component and cut analyses have no failure for empty, disconnected, loopy, or parallel-edge graphs of the correct
+  kind.
+- Condensation is defined for every directed graph and therefore has no DAG precondition.
+- Do not catch internal invariant violations and return partial results. Dense/arc snapshots should guarantee that
+  every retained edge endpoint maps to a retained node.
+
+## Tests
+
+Add focused unit tests in `packages/effect/test/Graph.test.ts` or a dedicated graph algorithm test file if plan 02 has
+split the suite. Use `assert` from `@effect/vitest` and shared seeded fixtures/oracle adapters.
+
+### Example Fixtures
+
+- Triangle joined by one bridge to another triangle: one bridge, two articulation points, and three biconnected
+  blocks including the bridge block.
+- DFS-root path fixture with node order chosen so the root has two children, preventing the common root-articulation
+  and block-merging bug.
+- Reversed-storage undirected path, disconnected cycles, isolated nodes, an isolated self-loop, two and three parallel
+  edges, and a parallel pair plus a true bridge.
+- Directed chain, diamond, nested diamond, separate cycles with a tail, isolated directed nodes, SCC-to-SCC parallel
+  edges, and sparse node/edge indexes after deletion.
+- Transitive-reduction chain, triangle shortcut, diamond shortcut, disconnected DAG, empty DAG, duplicate direct
+  edges, direct parallels plus a length-two alternative, self-loop, and multi-node cycle.
+- Dominator chain, diamond, nested diamond, loop back-edge, unreachable island, parallel edges, self-loop, missing
+  root, and the Cooper-Harvey-Kennedy paper fixture.
+
+Every new API needs direct and piped-call tests, mutable and immutable inputs, wrong-kind runtime tests through an
+unsafe cast, exact stable-order assertions, and empty/singleton coverage. The multi-argument `dominatorTree` additionally
+needs both dual forms; unary whole-graph analyses do not use a zero-argument overload.
+
+### Oracles
+
+- On small seeded undirected multigraphs, brute-force bridges by removing one `EdgeIndex` and comparing connected-
+  component counts; brute-force articulation points by removing one node and its incident edges.
+- Compare cut vertices, bridges, and normalized edge-bearing blocks on simple graphs with a trusted adapter such as
+  Graphology or NetworkX. Keep multigraph self-loop and parallel-edge semantics in local hand-checked oracles if the
+  external library differs.
+- For small directed graphs, derive SCC equivalence from mutual `hasPath`; derive weak components from a disjoint-set
+  union over all edge endpoints.
+- Compare DAG transitive reduction with a trusted oracle on simple DAGs. For multigraphs, compare against a local
+  endpoint-relation oracle because most libraries discard edge identity.
+- For small rooted directed graphs, enumerate bounded simple root-to-node paths and intersect their node sets to
+  establish dominance, then select the closest strict dominator. Pin the paper example independently.
+
+### Properties
+
+- Removing a reported bridge increases the graph's component count by one; removing a non-bridge does not.
+- Removing an articulation point increases component count relative to removing a non-cut vertex under the standard
+  disconnected-graph definition.
+- Every undirected edge belongs to exactly one biconnected block; block intersections larger than one node are
+  impossible; a node shared by multiple non-loop blocks is an articulation point.
+- Reversing every stored undirected edge endpoint leaves normalized cut results unchanged.
+- SCCs and weak components partition all nodes exactly once. Every SCC is internally mutually reachable.
+- `isWeaklyConnected` agrees with weak component count under the empty convention; `isStronglyConnected` agrees with SCC
+  count and is invariant under reversing every directed edge.
+- Condensation is acyclic, contains exactly one node per SCC, and represents every crossing source edge exactly once
+  in one grouped edge. Condensing a DAG yields singleton SCC nodes.
+- Transitive reduction preserves reachability for every node pair, is idempotent, and is minimal over endpoint pairs:
+  removing any surviving representative changes reachability.
+- Every immediate dominator dominates its node; repeatedly following immediate dominators reaches the root without a
+  cycle; unreachable nodes are absent; the root alone maps to `Option.none()`.
+- Results are invariant under node/edge payload changes and deterministic across repeated calls.
+
+### Stack Safety and Scale
+
+Add non-recursion regressions for a long undirected path, a long directed SCC/chain, a long DAG reduction fallback,
+and a long dominator chain. Sizes should exceed typical JavaScript recursion limits while remaining suitable for a
+targeted test. Benchmarks should cover sparse large graphs, dense DAGs near the bitset threshold, parallel-edge-heavy
+undirected graphs, and dominator graphs requiring multiple CHK sweeps.
+
+### Type Tests
+
+Extend `packages/effect/typetest/Graph.tst.ts` to prove that directed-only and undirected-only analyses reject the wrong
+kind and a non-narrowed `Kind`, matching mutable graphs are accepted, unary results remain pipeable, both
+`dominatorTree` dual forms infer `N` and `E`, and the three result models expose readonly node/edge/map members with the
+declared graph kind. Verify that `transitiveReduction` preserves `N` and `E` and returns a directed immutable graph.
+
+## Dependencies and Ownership
+
+This plan requires:
+
+- Plans 01 and 02 for corrected multigraph contracts, seeded fixtures, differential adapters, and benchmark gates.
+- Plan 03's ordered arc iterator retaining `EdgeIndex`. Cut analysis cannot be correct on parallel undirected edges
+  if it traverses only unique neighbor nodes.
+- Plan 03's optional dense snapshot and packed-bitset policy for low-allocation arrays and transitive reduction.
+- Plan 04's graph-clone/filter transform that preserves sparse node/edge indexes and counters. If it does not expose
+  one, add only the minimum internal helper needed by transitive reduction rather than rebuilding public indexes.
+- Plan 04's `hasPath` only as a test oracle; production component, reduction, and dominator kernels must not perform
+  repeated public path queries.
+- The established `isAcyclic` contract from plans 01 and 05 for DAG validation. This plan owns stable topological
+  ordering; cycle details and enumeration remain owned by plan 05.
+
+The shared predecessor/path reconstruction kernel is not needed for public results in this plan. Dominator
+predecessor lists are structural incoming arcs, not shortest-path predecessors, and should use the arc/dense kernels
+directly. The no-op checkpoint belongs to shared groundwork; this plan places checkpoints but does not expose
+Effect-returning variants.
+
+Work that can proceed independently after the arc kernel exists:
+
+- Weak components and iterative undirected low-link analysis.
+- Dominator-tree implementation and its brute-force oracle.
+- API models, ordering fixtures, and wrong-kind tests.
+
+Condensation waits for the SCC ordering baseline. Transitive reduction waits for this plan's stable topological kernel,
+dense bitsets, and an index-preserving clone/filter path.
+
+## Delivery Sequence
+
+1. Pin current component/SCC/topological ordering and errors, including sparse indexes, parallel in-degree, and mutable
+   walker snapshots.
+2. Add weak components and the shared iterative undirected low-link kernel; expose bridges, articulation points, and
+   edge-aware biconnected components.
+3. Add condensation on one SCC pass and verify its DAG and crossing-edge invariants.
+4. Add DAG validation and index-preserving transitive reduction with bitset and bounded-memory paths.
+5. Add iterative CHK dominance with stable materialization and checkpoint calls.
+6. Run targeted unit, property, oracle, stack-safety, lint, type, and benchmark checks; add the required `effect`
+   changeset for the exported APIs.
+
+The plan is complete when every API has an explicit kind/error contract, all multigraph and self-loop properties pass,
+no implementation relies on the JavaScript call stack, reductions preserve reachability and public indexes, and no
+function or test duplicates the plan 04 basic queries or plan 05 cycle enumeration.

--- a/docs/graph-plans/07-optimization-algorithms.md
+++ b/docs/graph-plans/07-optimization-algorithms.md
@@ -1,0 +1,453 @@
+# Optimization Algorithms
+
+## Scope
+
+Minimum spanning tree/forest is approved for active implementation. The other three families remain designed but parked
+until a concrete consumer and separate maintainer approval exist:
+
+1. Minimum spanning tree/forest.
+2. Eulerian path and circuit.
+3. Maximum-cardinality bipartite matching.
+4. Maximum flow and minimum cut.
+
+Only items 1 and 2's shared prerequisites may land without reopening scope, and only item 1 may add public exports now.
+Do not implement Eulerian traversal, matching, or flow/cut merely for parity with the reference library.
+
+This plan does not add shortest paths, simple-path enumeration, or k-shortest paths; those remain in plan 05. It does
+not add connected components, strongly connected components, bridges, articulation points, or a second public
+bipartite predicate; connectivity remains in plan 06 and existing `isBipartite` behavior remains non-breaking. Matching
+may refactor the existing coloring implementation into a plan-03 internal helper, but must not create a competing
+coloring kernel or assign it to plan 06.
+
+The work is additive. All algorithms accept immutable and scoped-mutable graphs, are synchronous initially, preserve
+stable public `NodeIndex` and `EdgeIndex` values in their results, and throw `GraphError` for invalid structural or
+numeric input. They must not rebuild a result graph with newly allocated indexes.
+
+## Lessons From The Reference Repository
+
+The implementations in `.repos/graph` establish useful starting points but should not be copied as contracts:
+
+- Its Prim implementation correctly restarts for disconnected components, making the nominal tree API return a
+  forest, and its tests catch the earlier one-component bug. Kruskal handles forests more naturally and is simpler to
+  make deterministic.
+- Its Euler implementation uses iterative Hierholzer traversal, checks degree conditions, permits either odd endpoint
+  for an undirected path, and verifies that every edge was consumed. Retaining edge identity is essential for parallel
+  edges.
+- Its Hopcroft-Karp implementation derives a partition by coloring every component, rejects self-loops/non-bipartite
+  inputs, and reports the realizing edge for parallel-edge pairs.
+- Its Edmonds-Karp implementation shares one residual solver between max flow and min cut and tests the
+  max-flow/min-cut equality, flow conservation, parallel capacity, unreachable sinks, and endpoint validation.
+- The reference permits mixed edge modes and models an undirected edge as two independent directed capacities. Effect
+  Graph has only uniformly directed or undirected kinds, so this plan chooses narrower, explicit applicability instead.
+- The reference numeric validation misses `NaN` and infinities in several places. This plan validates all accessor
+  results before algorithm-specific early returns.
+
+## Applicability Matrix
+
+| Family | Directed graph | Undirected graph | Empty graph |
+| --- | --- | --- | --- |
+| Minimum spanning forest | Rejected | Supported | Empty forest |
+| Eulerian path/circuit | Supported | Supported | Trivial empty trail |
+| Maximum bipartite matching | Rejected | Supported | Empty matching |
+| Maximum flow/minimum cut | Supported | Rejected | Endpoints cannot be supplied, so `GraphError` |
+
+Directed MST is deliberately rejected. A directed minimum arborescence is a different problem with a required root
+and different semantics; it should receive a separately named future API rather than silently ignoring direction.
+The public MST and matching signatures should require `"undirected"`; a value passed through `any` or an erased kind
+must still receive a runtime `GraphError`.
+
+Flow is initially directed-only. Treating an undirected edge as two independent capacities, a shared absolute
+capacity, or a pair with net-flow reporting produces observably different answers and cut semantics. Users can model
+their intended policy by adding explicit directed edges. A future undirected-flow API should be separately specified.
+
+## Shared Numeric Policy
+
+Consume plan 03's internal facility that evaluates a numeric edge accessor exactly once per edge in ascending
+`EdgeIndex` order and reports the first invalid edge through `GraphError`. It retains an `EdgeIndex -> number` mapping
+and supports named policies rather than one supposedly universal validator. Do not add a plan-07 or plan-05 copy.
+
+| Use | Allowed | Rejected |
+| --- | --- | --- |
+| MST weight | Any finite number, including negative values and zero | `NaN`, `Infinity`, `-Infinity` |
+| Flow capacity | Finite number greater than or equal to zero | Negative values, `NaN`, `Infinity`, `-Infinity` |
+
+Negative MST weights are valid: spanning-tree optimality does not require non-negative weights. Normalize `-0` to
+`0` in totals and flow output. Infinite MST weights are rejected rather than treated as absent edges; omitting an edge
+is the unambiguous way to make it unavailable. Infinite capacities are rejected because they can produce an infinite
+flow and non-progressing residual arithmetic.
+
+Validation occurs before empty/trivial-result shortcuts so malformed edge data is never hidden by an early return.
+Accessor exceptions propagate unchanged, matching existing cost-accessor behavior; only invalid returned numbers
+become `GraphError`.
+
+The existing shortest-path policies remain unchanged. Their acceptance of positive infinity as an impassable edge is
+algorithm-specific and should not force MST or capacity semantics.
+
+## Proposed Public Models
+
+Names are provisional until implementation review, but the result shape and information content are contractual.
+
+```ts
+export interface MinimumSpanningForestConfig<E> {
+  readonly weight: (edgeData: E) => number
+}
+
+export interface SpanningTreeResult {
+  readonly nodes: ReadonlyArray<NodeIndex>
+  readonly edges: ReadonlyArray<EdgeIndex>
+  readonly weight: number
+}
+
+export interface MinimumSpanningForestResult {
+  readonly trees: ReadonlyArray<SpanningTreeResult>
+  readonly edges: ReadonlyArray<EdgeIndex>
+  readonly weight: number
+}
+
+export interface EulerianConfig {
+  readonly start?: NodeIndex
+}
+
+export interface EulerianTrail {
+  readonly nodes: ReadonlyArray<NodeIndex>
+  readonly edges: ReadonlyArray<EdgeIndex>
+  readonly circuit: boolean
+}
+
+export interface BipartiteMatch {
+  readonly left: NodeIndex
+  readonly right: NodeIndex
+  readonly edge: EdgeIndex
+}
+
+export interface MaximumBipartiteMatchingResult {
+  readonly matching: ReadonlyArray<BipartiteMatch>
+  readonly left: ReadonlyArray<NodeIndex>
+  readonly right: ReadonlyArray<NodeIndex>
+  readonly unmatched: ReadonlyArray<NodeIndex>
+}
+
+export interface FlowConfig<E> {
+  readonly source: NodeIndex
+  readonly sink: NodeIndex
+  readonly capacity: (edgeData: E) => number
+}
+
+export interface MinimumCutResult {
+  readonly capacity: number
+  readonly edges: ReadonlyArray<EdgeIndex>
+  readonly source: ReadonlyArray<NodeIndex>
+  readonly sink: ReadonlyArray<NodeIndex>
+}
+
+export interface MaximumFlowResult {
+  readonly value: number
+  readonly flow: ReadonlyMap<EdgeIndex, number>
+  readonly cut: MinimumCutResult
+}
+```
+
+The candidate functions are:
+
+- `minimumSpanningForest(graph, config)` returning `MinimumSpanningForestResult`.
+- `minimumSpanningTree(graph, config)` returning `Option<SpanningTreeResult>` and delegating to the forest kernel.
+- `eulerianPath(graph, config)` returning `Option<EulerianTrail>`.
+- `eulerianCircuit(graph, config)` returning `Option<EulerianTrail>`.
+- `maximumBipartiteMatching(graph)` returning `MaximumBipartiteMatchingResult`.
+- `maximumFlow(graph, config)` returning `MaximumFlowResult`.
+- `minimumCut(graph, config)` returning `MinimumCutResult` and delegating to the same residual solver as
+  `maximumFlow`.
+
+Every configurable function must have standard `dual` data-first/data-last overloads. Euler configuration should be
+optional at the semantic level; if the repository's dual conventions make an omitted second argument ambiguous, use
+an explicit empty config in the dual API rather than adding a second non-dual calling convention. Matching has no
+configuration and remains a unary function.
+
+`Option.none` means that no Eulerian trail of the requested kind exists. Missing configured nodes, wrong graph kind,
+non-bipartite matching input, identical flow endpoints, and invalid numeric values are invalid inputs and throw
+`GraphError`; they are not ordinary negative results. The models are plain readonly interfaces, not new tagged error
+types. `GraphError` remains the shared invalid-input ADT.
+
+Do not return edge data in place of identity. Callers can resolve retained indexes with `getEdge`, including when
+parallel edges carry equal data. A read-only type annotation does not make a JavaScript `Map` immutable, so the flow
+map must be newly owned by the result and never retained internally or reused across calls.
+
+## Minimum Spanning Forest
+
+### Algorithm Decision
+
+Implement Kruskal with a disjoint-set union structure as the production kernel.
+
+- It produces a full minimum spanning forest without component restarts.
+- It handles sparse stable indexes through the dense snapshot or an index-to-position map.
+- Self-loops fall out naturally because both endpoints already have the same representative.
+- Parallel edges remain independent candidates.
+- Deterministic tie-breaking is direct: sort by `(weight, EdgeIndex)`.
+- Complexity is `O(E log E + V alpha(V))` time and `O(V + E)` working memory.
+
+Do not expose an algorithm selector in the first API. It expands the behavioral surface without changing the result
+contract. Maintain an internal Prim implementation only if useful as an independent differential oracle and benchmark
+candidate. If later benchmarks establish a material dense-graph benefit, Prim can replace the kernel without an API
+change.
+
+### Forest Contract
+
+- A disconnected graph returns one minimum tree per connected component, including a zero-edge tree for every
+  isolated node. The API is named `minimumSpanningForest` so this is not surprising.
+- A connected non-empty graph has one tree. An empty graph has no trees, no edges, and total weight zero.
+- `minimumSpanningTree` returns that one tree for a connected non-empty graph and `Option.none` for an empty or
+  disconnected graph. A one-node graph therefore has a zero-edge minimum spanning tree. Invalid kind/weights still
+  throw before this projection.
+- `trees` are ordered by their lowest `NodeIndex`; each tree's `nodes` and `edges` are ascending by public index.
+  Top-level `edges` is the selected edge set in ascending index order, not selection order.
+- The total edge count is `V - C`, where `C` includes isolated components.
+- Self-loops are never selected, including negative self-loops.
+- Parallel edges compete independently; lower weight wins and equal weight chooses lower `EdgeIndex` when either can
+  occupy the same forest position.
+- Negative and zero weights are accepted under the shared policy.
+- No input graph, edge, node, or edge data is copied or mutated.
+
+## Eulerian Paths And Circuits
+
+Use iterative Hierholzer traversal with an ordered arc view retaining `EdgeIndex`. Complexity is `O(V + E)` time and
+`O(V + E)` memory. Recursion is not acceptable because a valid trail may contain every edge in a large graph.
+
+### Existence Rules
+
+- Directed circuit: every non-isolated node has equal in-degree and out-degree, and all non-isolated nodes belong to
+  one weakly connected component; consuming all edges is the final authoritative check.
+- Directed open path: exactly one node has `out - in = 1`, exactly one has `in - out = 1`, and all others balance.
+  A circuit also satisfies `eulerianPath`.
+- Undirected circuit: every non-isolated node has even graph-theoretic degree and the non-isolated subgraph is
+  connected.
+- Undirected open path: exactly two odd-degree nodes; a circuit also satisfies `eulerianPath`.
+- Isolated nodes do not invalidate a trail over a non-empty edge component.
+
+If `start` is omitted, choose the required directed start, otherwise the lower-index odd endpoint, otherwise the
+lowest-index node incident to an edge. For an edgeless non-empty graph choose the lowest node. If `start` exists but is
+not a valid start for the requested trail, return `Option.none`; if it is not present in the graph, throw `GraphError`.
+
+The empty graph has one trivial path/circuit represented by `nodes: []`, `edges: []`, and `circuit: true`. An edgeless
+non-empty graph returns the one-node trivial circuit chosen by the start rule. This makes both APIs total over valid
+graphs and avoids inventing a missing node.
+
+### Multigraph Rules And Ordering
+
+- A self-loop is one consumed edge. It contributes one incoming and one outgoing incidence in a directed graph and
+  two to undirected degree.
+- Every parallel edge is consumed separately. Never identify usage by endpoint pair or edge data.
+- Outgoing/incident arcs are considered in ascending `EdgeIndex` order. Hierholzer backtracking then determines the
+  unique documented deterministic result; add exact fixtures so implementation refactors preserve it.
+- `nodes.length === edges.length + 1` for non-empty-node trails, adjacent node pairs are realized by the corresponding
+  edge index, every graph edge appears exactly once, and a circuit's first and last node agree.
+- This is edge-covering trail work, not simple/shortest path work from plan 05.
+
+These APIs return one result, so a generator adds no useful early-exit behavior: existence cannot be confirmed until
+all edges have been accounted for. Keep them eager.
+
+## Maximum Bipartite Matching
+
+Implement maximum-cardinality matching with iterative Hopcroft-Karp over the deterministic two-coloring supplied by
+plan 06. Target complexity is `O(E sqrt(V))` time and `O(V + E)` memory. Avoid recursive augmenting DFS if it can grow
+with graph size; use explicit frames or otherwise prove the implementation stack-safe.
+
+- Only undirected graphs are accepted. Direction-erased calls on directed graphs throw `GraphError`.
+- A self-loop makes the graph non-bipartite, so matching throws `GraphError` identifying the lowest-index conflict
+  edge reported by the coloring kernel.
+- Parallel edges do not increase cardinality between a fixed pair. If that pair is matched, retain the first/lower
+  `EdgeIndex` encountered by deterministic adjacency.
+- Disconnected components are matched independently by the same global run. Empty and edgeless graphs return an empty
+  matching.
+- Coloring starts each uncolored component at its lowest `NodeIndex` on the left (`0`) side. This fixes the otherwise
+  arbitrary left/right orientation, including isolated nodes.
+- BFS roots, adjacency, and augmenting choices use ascending node/edge index order. Return matches in ascending `left`
+  index order; partitions and unmatched nodes are ascending.
+- `unmatched` includes isolated nodes and is the ascending complement of all matched endpoints.
+
+The derived partitions are included because they make the orientation of each match explicit and reusable. Supplying
+custom partitions, weighted matching, minimum vertex cover, and assignment costs are separate future APIs.
+
+The output is bounded by `V / 2` and computing any item requires completing augmentations, so no lazy form is useful.
+
+## Maximum Flow And Minimum Cut
+
+Implement one internal residual-network solver and project both public results from it. Start with Dinic rather than
+the reference's Edmonds-Karp: Dinic has `O(V^2 E)` worst-case time on general directed networks and performs materially
+better on the larger sparse networks expected here; Edmonds-Karp's `O(V E^2)` is useful as a small-graph test oracle.
+The residual representation should use dense positions internally but retain the originating `EdgeIndex` on each
+forward arc.
+
+### Flow Contract
+
+- Validate that source and sink exist and differ, and validate every capacity before returning a zero/trivial result.
+- Directed self-loops have zero useful source-to-sink flow. Keep them in the returned flow map with value zero, but do
+  not add them to level-graph work or a cut.
+- Parallel edges are separate capacity-bearing arcs; their capacities add naturally and each receives its own flow
+  entry.
+- Zero-capacity edges remain in the flow map with zero and never enter an augmenting level graph.
+- `flow` contains every input `EdgeIndex` in ascending insertion/index order. Values satisfy `0 <= flow[e] <=
+  capacity[e]`; there is no signed reverse-edge convention for directed graphs.
+- Flow conservation holds at every node except source and sink, and source outflow minus inflow equals `value`.
+- Deterministic BFS and blocking-flow traversal follow ascending edge-index order. Alternative maximum flows are
+  possible, so deterministic ordering is part of the returned per-edge-flow contract.
+
+After maximum flow, residual reachability from source defines the minimum cut. `cut.source` and `cut.sink` partition
+every node exactly once in ascending `NodeIndex` order, with source and sink on their named sides. `cut.edges` contains
+all original forward edges crossing source-side to sink-side in ascending `EdgeIndex` order. Its summed capacity equals
+both `cut.capacity` and the maximum-flow value, within exact JavaScript arithmetic for the supplied numbers.
+
+`minimumCut` runs the same solver rather than duplicating logic. `maximumFlow` includes the cut because it is already
+available after the residual solve; the separate function is a convenience projection, not a second algorithm.
+
+Flow and cut are single optimized results and are eager. Do not expose a lazy stream of augmentations as public API.
+The inner BFS/blocking-flow loops should invoke the shared synchronous checkpoint abstraction at bounded intervals so
+an additive Effect-native interruptible form can be introduced later without changing the kernel.
+
+## Internal Architecture
+
+Reuse the groundwork coordinated in the README:
+
+- Ordered arc iteration for Euler traversal, matching adjacency, and residual construction.
+- Dense snapshots for disjoint-set arrays, degree arrays, coloring, matching, and residual networks while preserving
+  sparse public indexes at the boundary.
+- Shared edge numeric evaluation for weights and capacities.
+- A stable min-heap only if an internal Prim oracle is retained; do not create a second heap beside plan 05's heap.
+- The existing bipartite coloring semantics, factored into plan 03 internals if reuse is justified.
+- Synchronous checkpoints in potentially long matching and flow loops.
+
+Keep kernels internal to `Graph.ts` unless the internal architecture plan establishes a dedicated module seam. Do not
+export residual arcs, disjoint sets, dense positions, coloring arrays, or algorithm selectors.
+
+## Implementation Phases
+
+### Phase 1: Contracts And Shared Validation
+
+- Finalize names and readonly result interfaces.
+- Land/reuse ordered edge-aware arcs, dense index translation, numeric evaluation, and plan 06 coloring.
+- Add type-level tests for graph-kind restrictions and both dual call forms.
+- Add invalid numeric and missing-node tests before algorithm kernels.
+
+### Phase 2: Minimum Spanning Forest
+
+- Implement deterministic Kruskal and component/result assembly.
+- Cover disconnected graphs, isolated nodes, negative weights, self-loops, parallel edges, sparse indexes, and ties.
+- Add an internal Prim oracle for differential tests only if this does not duplicate shared heap work.
+
+### Phase 3: Eulerian Trail
+
+Status: parked; requires a separate demand/API approval.
+
+- Implement stack-safe Hierholzer traversal for both graph kinds.
+- Cover all degree/existence cases, disconnected edge components, explicit starts, empty graphs, loops, parallel edges,
+  and exact edge-index order.
+
+### Phase 4: Bipartite Matching
+
+Status: parked; requires a separate demand/API approval.
+
+- Implement stack-safe deterministic Hopcroft-Karp using plan 06 coloring.
+- Cover multiple components, isolated nodes, non-bipartite rejection, parallel edges, and known greedy counterexamples.
+
+### Phase 5: Flow And Cut
+
+Status: parked; requires a separate demand/API approval.
+
+- Implement residual construction and deterministic Dinic.
+- Project both result forms from the same solved state.
+- Add capacity, conservation, cut, loops, parallel edges, sparse indexes, and deterministic tie tests.
+
+### Phase 6: Documentation And Performance
+
+- Add public JSDoc, runnable bounded examples, cross-links, complexity, graph-kind restrictions, numeric policies, and
+  multigraph gotchas.
+- Run doctests for changed examples and add a package changeset describing the additive APIs.
+- Establish benchmark baselines and only then consider kernel-level tuning.
+
+Each phase should be independently reviewable. Do not combine this work with shortest-path or connectivity rewrites.
+
+## Verification Strategy
+
+### Example And Regression Tests
+
+- MST: textbook weighted graph, already-a-tree, disconnected forest, isolated nodes, empty graph, negative weights,
+  equal ties, negative self-loop exclusion, lighter parallel edge selection, and deleted-index sparsity.
+- Euler: directed/undirected open trails and circuits, wrong degree counts, disconnected non-isolated components,
+  optional starts, isolated nodes, loops, two parallel undirected edges forming a circuit, and exact once-only edge use.
+- Matching: even cycles, grids, disconnected components, empty graph, self-loop/odd-cycle rejection, parallel edges,
+  perfect and imperfect matchings, and an instance where greedy matching is suboptimal.
+- Flow: the CLRS value-23 network, unreachable sink, antiparallel and parallel directed edges, incoming source/outgoing
+  sink edges, zero capacities, self-loops, fractional capacities, malformed capacities, and deterministic alternate
+  optima.
+
+### Property And Differential Tests
+
+Use seeded small multigraph generators and shrinkable fixtures from the verification foundation.
+
+- MST forest is acyclic, spans every input node, has `V - C` edges, and selects only input edge indexes.
+- Production Kruskal and an independent Prim implementation agree on total forest weight and per-component edge count.
+  They need not select the same edges under ties unless both use the specified tie policy.
+- For very small graphs, compare MST weight with exhaustive subsets.
+- Every Euler result has valid endpoint continuity, consumes each edge index exactly once, and satisfies the appropriate
+  endpoint/circuit condition. For small graphs, compare existence with exhaustive edge-trail search.
+- Every matching uses existing edge indexes and no node twice. Compare cardinality with exhaustive matching and with a
+  unit-capacity max-flow reduction on generated bipartite graphs.
+- Every flow obeys capacity constraints and conservation. Compare value with an independent Edmonds-Karp oracle on
+  small integral networks.
+- Assert `maximumFlow.value === minimumCut.capacity`, cut-edge capacity equals that value, and removing/capping cut
+  edges disconnects residual source from sink.
+- Re-run each algorithm on the same graph and assert structurally equal, index-identical output.
+- Compare supported simple-graph cases with a maintained external oracle adapter where available; do not let an oracle
+  erase parallel edge identity before local invariants are checked.
+
+Avoid approximate assertions unless a property fixture uses fractional capacities that genuinely accumulates floating
+roundoff. If approximation is required, use a documented scale-aware tolerance and still enforce non-negative residual
+capacity within that tolerance.
+
+## Benchmarks
+
+Add seeded, non-CI-gating benchmark cases with sparse and dense shapes:
+
+- Kruskal on sparse forests, dense complete graphs, heavy parallel-edge graphs, and many disconnected components;
+  compare internal Prim where retained.
+- Euler traversal on long trails, loop-heavy multigraphs, and high-degree parallel-edge graphs.
+- Hopcroft-Karp on balanced random bipartite graphs, grids, and adversarial layered graphs; compare a simple augmenting
+  path oracle only at small sizes.
+- Dinic on sparse random networks, dense networks, layered worst-case-like networks, and parallel-edge networks;
+  compare Edmonds-Karp throughput and allocations.
+
+Record wall time and peak/allocation proxies already supported by the benchmark foundation. Include graphs with sparse
+public indexes to catch accidental allocation by maximum index. Benchmarks justify internal algorithm replacement but
+must not loosen deterministic or numeric contracts.
+
+## Documentation And Release Requirements
+
+Every exported interface and function needs repository-compliant JSDoc with `@since`, exactly one category, graph-kind
+applicability, complexity, failure behavior, deterministic ordering, and self-loop/parallel-edge semantics. Runnable
+examples must use stable semantic assertions and retain edge indexes in observations. Cross-link `isBipartite`, plan
+05 path APIs, plan 06 connectivity APIs, and the max-flow/min-cut pair where relevant.
+
+Each approved family is an additive exported API change and requires its own package changeset. Run `pnpm lint-fix`, targeted
+`packages/effect/test/Graph.test.ts` tests, relevant type tests, `pnpm check`, and `pnpm doctest --run
+packages/effect/src/Graph.ts`; never run the unbounded whole-suite commands.
+
+## Dependencies And Ownership
+
+Required earlier work:
+
+- Correctness and verification plans for seeded generators, oracle adapters, multigraph invariants, and benchmark
+  conventions.
+- Internal architecture/performance work for ordered edge-aware arcs, optional dense snapshots, and checkpoints.
+- Plan 05 for shared heap/path-era numeric-accessor conventions; this plan does not own shortest or simple paths.
+- Existing `isBipartite` semantics and plan 06 connectivity semantics; this plan does not own components or a new
+  bipartite public API.
+
+Work that can proceed independently once result names are agreed:
+
+- Kruskal and Euler kernels need only ordered edge iteration and dense translation.
+- Matching can begin after the coloring contract is stable.
+- Flow can begin after numeric evaluation and dense translation are stable and does not depend on plan 05 path
+  reconstruction.
+
+This plan owns the optimization result interfaces, the domain semantics of MST/cut/flow numeric policies, deterministic
+optimization tie rules, residual network, disjoint set, Hierholzer traversal, Hopcroft-Karp state, and Dinic state. Plan
+03 owns their shared numeric evaluation machinery. This plan should consume, not fork, helpers owned by earlier plans.

--- a/docs/graph-plans/08-analytics.md
+++ b/docs/graph-plans/08-analytics.md
@@ -1,0 +1,600 @@
+# 08. Analytics and Specialist Algorithms
+
+## Purpose
+
+Add a small, defensible analytics surface after the graph correctness, verification, dense-kernel, traversal, path,
+connectivity, and optimization plans have stabilized. This is not a request to port every algorithm in `.repos/graph`.
+The Effect package should adopt algorithms with common demand, precise multigraph semantics, and reasonable bundle cost;
+specialist or heuristic algorithms remain gated or out of scope.
+
+Graph generators are owned by plan 09 and are not part of this plan. Tests and benchmarks use plan 02's shared fixtures
+regardless of whether plan 09 has landed; this plan must not export generators or create private fixture helpers.
+
+## Dependencies and Ownership
+
+This plan requires:
+
+- Plan 01's degree, self-loop, parallel-edge, and deterministic-order contracts.
+- Plan 02's seeded fixtures, oracle adapters, property tests, and benchmark harness.
+- Plan 03's ordered arc iterator, dense snapshot, numeric validation helpers, and synchronous checkpoint abstraction.
+- Plan 05's unweighted and non-negative weighted shortest-path kernels for closeness and betweenness.
+- Plan 06's connected-component support for validation and test oracles.
+- Plan 07's minimum-spanning-tree and metric-closure decisions only if Steiner tree or approximate TSP are reconsidered
+  outside this plan.
+
+Plan 03 owns sparse `NodeIndex` to dense-position translation and arc storage. This plan may add analytics-specific
+scratch arrays, but must not add another graph snapshot or CSR representation. Plan 09 owns public graph generators.
+The later Effect-native interruption phase owns the execution wrapper; this plan identifies checkpoint boundaries and
+must keep synchronous kernels independent of `Effect`.
+
+## Assessment of `.repos/graph`
+
+The reference implementation is useful as an algorithm inventory and fixture source, not as code to copy unchanged:
+
+- Centrality already uses dense typed arrays and checks cancellation by source or power iteration. Degree, closeness,
+  unweighted Brandes betweenness, and PageRank are compact and align well with Effect Graph.
+- PageRank and HITS silently return the last iterate on non-convergence, while eigenvector and Katz throw plain
+  `Error`. Effect Graph needs one explicit convergence contract and `GraphError` for synchronous failures.
+- Weighted eigenvector and Katz accept unchecked negative, infinite, and `NaN` weights. Their convergence and sign
+  semantics are therefore not suitable as-is.
+- Core decomposition is a good linear-time bucket-peeling implementation. It treats direction as undirected, ignores
+  self-loops, and counts parallel edges. Effect Graph should instead expose the operation only for undirected graphs
+  so direction is never erased implicitly.
+- Coloring correctly documents that greedy results are not chromatic optima, but its producer ignores self-loops while
+  its validator rejects every coloring of a self-loop. A future API must reject a self-loop before producing a result.
+- Isomorphism is a basic factorial backtracker. Its repeated full-edge scans and greedy payload-edge matching are not
+  sufficient for a general public implementation, especially when an edge predicate is not transitive.
+- Label propagation can oscillate until its iteration cap and returns the last partition without reporting that fact.
+  Girvan-Newman repeatedly recomputes edge betweenness. The greedy modularity implementation evaluates every possible
+  merge by recomputing modularity. These are useful demonstrations but poor production defaults.
+- Louvain is the only community candidate with an acceptable direction, but the reference's deterministic local move
+  policy and aggregation logic require differential validation on weighted loops and parallel edges before adoption.
+- The LR planarity test has a suitable boolean-only scope and avoids recursion, but it is a large specialist kernel
+  ported from NetworkX. License provenance, differential tests, and bundle impact are release blockers.
+- Approximate TSP uses an all-pairs metric closure, silently falls back when `from` is missing, and symmetrizes directed
+  distances. Its nearest-neighbor plus bounded 2-opt method has no useful approximation guarantee.
+- Steiner tree is a metric-closure approximation built from shortest paths and two MSTs. It returns a reconstructed
+  graph with new identities and throws plain errors. It belongs with optimization, not analytics.
+
+## Portfolio Decision
+
+| Item | Decision | Reason |
+| --- | --- | --- |
+| Degree, in-degree, and out-degree centrality | **Adopt** | Cheap, exact, common, and directly grounded in the shared degree contract. |
+| Closeness centrality | **Adopt** | Common and exact; reuses shortest-path kernels. Disconnected semantics can be made explicit. |
+| Betweenness centrality | **Adopt** | Common and exact; Brandes has a clear dense implementation and oracle ecosystem. |
+| PageRank | **Adopt** | Widely used directed analysis with bounded state and well-defined convergence validation. |
+| Core decomposition / k-core membership | **Adopt** | Exact linear-time undirected analysis with small implementation and output. |
+| HITS | **Later** | Useful for link analysis but overlaps PageRank and adds another convergence/normalization contract. |
+| Eigenvector centrality | **Later** | Useful but sensitive to disconnected graphs, dominant-eigenvalue multiplicity, signs, and convergence. |
+| Katz centrality | **Later** | Requires a defensible attenuation bound or explicit non-convergence behavior; less common than PageRank. |
+| Greedy coloring | **Later** | Valid scheduling heuristic, but not analytics and easy to mistake for minimum coloring. |
+| Graph isomorphism | **Later** | Valuable structural query, but a correct multigraph matcher needs a stronger algorithm and cancellation. |
+| Community detection | **Later, Louvain only** | Demand exists, but quality is heuristic and order/seed semantics are part of the result. |
+| Label propagation | **Reject** | Unstable quality and termination; adds random-policy surface without a quality guarantee. |
+| Girvan-Newman | **Reject** | Repeated betweenness is too expensive for a core default; dendrogram output substantially expands scope. |
+| Naive greedy modularity | **Reject** | The reference implementation's repeated full modularity scoring is not scalable. |
+| Boolean planarity | **Later** | Exact and useful, but specialist and implementation-heavy. Embeddings and counterexamples are excluded. |
+| Approximate TSP | **Reject** | No meaningful guarantee in the proposed method, quadratic storage, and optimization rather than analytics. |
+| Steiner tree | **Reject** | Specialist approximation with substantial path/MST composition and graph-identity questions; plan 07 territory. |
+
+"Later" means no public API should be reserved until its acceptance gate below is met. "Reject" means do not add the
+item to `Graph.ts` under this initiative; reconsideration requires a separate proposal with demonstrated Effect user
+demand and package-size evidence.
+
+## Shared Public and Numeric Contracts
+
+All adopted functions are synchronous, accept immutable or mutable graphs, support data-first and data-last use with
+`dual`, and return results keyed by stable public `NodeIndex` values. Score collections use
+`ReadonlyMap<NodeIndex, number>` rather than records because indexes can be sparse and removed indexes are not dense
+array positions. Maps are populated in node insertion/index iteration order.
+
+The implementation snapshots graph structure at call entry. It must not expose dense positions, and callbacks must not
+be allowed to make an in-progress mutable graph produce a partly old and partly new result. Follow the plan 03 policy
+for mutation during callbacks.
+
+Common validation:
+
+- Every tolerance must be finite and greater than zero.
+- Every iteration/pass limit must be a positive safe integer.
+- A weighted algorithm evaluates the edge callback once per edge at snapshot construction and caches the result.
+- Algorithms based on distances require weights greater than or equal to zero; weighted betweenness requires strictly
+  positive finite weights because zero-weight shortest-path cycles invalidate the simple Brandes dependency count.
+- `Infinity` may mean an impassable edge only where plan 03's shared weight policy supports it. `NaN`, negative values,
+  and unexpected infinities throw `GraphError` before partial output is returned.
+- Spectral and modularity methods, if accepted later, require finite non-negative weights. Parallel-edge weights sum.
+- Invalid options, missing node indexes, unsupported graph kinds, invalid weights, and non-convergence throw
+  `GraphError`. Empty valid graphs return empty maps or empty collections.
+
+Synchronous cancellation is deliberately not exposed as `AbortSignal`. Kernels call plan 03's no-op checkpoint at the
+boundaries listed below. The additive Effect APIs introduced in the interruption phase run chunked versions of the
+same kernels and check fiber interruption at those checkpoints; they fail with `GraphError` for algorithm errors and
+remain interruptible through the Effect runtime. Do not add duplicate `AbortSignal` and Effect cancellation models.
+
+No adopted algorithm is random. Results must be byte-for-byte stable for the same graph, options, and JavaScript
+runtime. A later randomized algorithm must accept an explicit integer `seed`, use the repository-owned PRNG from plan
+02, and document the PRNG/version as observable behavior. It must never use `Math.random`, current time, or an implicit
+random seed. Community detection should default to deterministic node-index order; a seeded shuffled mode is a future
+additive option, not required for first release.
+
+## Adopted APIs
+
+Names below follow the existing Effect Graph style rather than the `get*` naming in `.repos/graph`. Final JSDoc must
+state normalization, graph-kind restrictions, multigraph behavior, complexity, and convergence.
+
+```ts
+export const degreeCentrality: <N, E>(
+  graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
+) => ReadonlyMap<NodeIndex, number>
+
+export const inDegreeCentrality: <N, E>(
+  graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">
+) => ReadonlyMap<NodeIndex, number>
+
+export const outDegreeCentrality: <N, E>(
+  graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">
+) => ReadonlyMap<NodeIndex, number>
+```
+
+Scores are degree divided by `n - 1`, or zero when `n <= 1`. Parallel edges contribute independently, so scores may
+exceed one. An undirected self-loop contributes two before normalization; a directed self-loop contributes once to
+each of in-degree and out-degree. Do not add a graph-kind-erasing "total degree centrality" for directed graphs.
+
+```ts
+export interface ClosenessCentralityOptions<E> {
+  readonly cost?: (edgeData: E) => number
+}
+
+export const closenessCentrality: {
+  <E>(options?: ClosenessCentralityOptions<E>): <N, T extends Kind>(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>
+  ) => ReadonlyMap<NodeIndex, number>
+  <N, E, T extends Kind>(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+    options?: ClosenessCentralityOptions<E>
+  ): ReadonlyMap<NodeIndex, number>
+}
+```
+
+Without `cost`, distance is hop count. With `cost`, use non-negative weighted shortest paths. Directed graphs measure
+outward closeness: distances from each node following outgoing arcs. For a source with `r` other reachable nodes and
+distance sum `d`, return `(r / d) * (r / (n - 1))`, with zero when `r` or `d` is zero. This is the Wasserman-Faust
+disconnected-graph correction and is not configurable in the first API. Parallel edges provide independent candidate
+arcs; shortest distance naturally chooses the minimum. Self-loops do not improve a valid non-negative distance.
+Checkpoint once per source and during long single-source queue scans at the shared work budget.
+
+```ts
+export interface BetweennessCentralityOptions<E> {
+  readonly cost?: (edgeData: E) => number
+}
+
+export const betweennessCentrality: {
+  <E>(options?: BetweennessCentralityOptions<E>): <N, T extends Kind>(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>
+  ) => ReadonlyMap<NodeIndex, number>
+  <N, E, T extends Kind>(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+    options?: BetweennessCentralityOptions<E>
+  ): ReadonlyMap<NodeIndex, number>
+}
+```
+
+Use Brandes: BFS without `cost`, Dijkstra with strictly positive `cost`. Scores exclude path endpoints and are always
+normalized to `[0, 1]` for simple graphs: divide directed totals by `(n - 1)(n - 2)` and undirected totals by
+`(n - 1)(n - 2) / 2`, returning zeros for `n <= 2`. Parallel edges are distinct shortest paths and therefore affect
+path multiplicity even when endpoints and weights match. Directed paths follow outgoing arcs. Ignore self-loops in
+predecessor/dependency accumulation. Checkpoint once per source and at the shared queue/heap work budget.
+
+```ts
+export interface PageRankOptions<E> {
+  readonly weight?: (edgeData: E) => number
+  readonly damping?: number
+  readonly tolerance?: number
+  readonly maxIterations?: number
+}
+
+export const pageRank: {
+  <E>(options?: PageRankOptions<E>): <N, T extends Kind>(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>
+  ) => ReadonlyMap<NodeIndex, number>
+  <N, E, T extends Kind>(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+    options?: PageRankOptions<E>
+  ): ReadonlyMap<NodeIndex, number>
+}
+```
+
+Defaults are damping `0.85`, tolerance `1e-6`, and `100` iterations. Damping must be finite in `[0, 1)`. Unweighted
+edges have weight one. Weighted PageRank requires finite non-negative weights; parallel weights sum and undirected
+edges contribute one arc in each direction. A node whose outgoing weight sum is zero is dangling, including a node
+with only zero-weight outgoing edges. Redistribute dangling mass uniformly and use a uniform teleport vector. A
+self-loop participates in its node's outgoing distribution. Start uniformly, compare successive vectors by L1 norm,
+and converge when the norm is at most `tolerance`. Normalize the final finite vector to sum to one. Throw `GraphError`
+if no convergence occurs; never silently return the last iterate. Checkpoint at least once per iteration and at the
+shared arc work budget.
+
+Personalized teleport vectors and initial vectors are intentionally deferred. They complicate sparse-index
+validation and can be added without changing this API when demand exists.
+
+```ts
+export const coreNumbers: <N, E>(
+  graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
+) => ReadonlyMap<NodeIndex, number>
+
+export const kCore: {
+  (k: number): <N, E>(
+    graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
+  ) => ReadonlyArray<NodeIndex>
+  <N, E>(
+    graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">,
+    k: number
+  ): ReadonlyArray<NodeIndex>
+}
+```
+
+Use Batagelj-Zaversnik bucket peeling. `k` must be a non-negative safe integer. Return node indexes in graph insertion
+order, not peel order. Parallel edges contribute independently. Self-loops are ignored for core decomposition: they
+cannot connect a node to the remaining subgraph and must not allow a node to sustain its own core membership. This is
+an explicit algorithm-specific exception to graph-theoretic degree. Weighted and directed cores are excluded; do not
+silently erase direction. Checkpoint during snapshot construction and after each bounded peel-work budget.
+
+## Later Candidates and Acceptance Gates
+
+### Spectral and Link Scores
+
+Only consider these after PageRank is shipped and real demand shows that PageRank is insufficient:
+
+```ts
+export interface IterativeScoreOptions<E> {
+  readonly weight?: (edgeData: E) => number
+  readonly tolerance?: number
+  readonly maxIterations?: number
+}
+
+export interface HitsResult {
+  readonly hubs: ReadonlyMap<NodeIndex, number>
+  readonly authorities: ReadonlyMap<NodeIndex, number>
+}
+
+export const hits: {
+  <E>(options?: IterativeScoreOptions<E>): <N, T extends Kind>(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>
+  ) => HitsResult
+  <N, E, T extends Kind>(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+    options?: IterativeScoreOptions<E>
+  ): HitsResult
+}
+
+export const eigenvectorCentrality: {
+  <E>(options?: IterativeScoreOptions<E>): <N, T extends Kind>(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>
+  ) => ReadonlyMap<NodeIndex, number>
+  <N, E, T extends Kind>(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+    options?: IterativeScoreOptions<E>
+  ): ReadonlyMap<NodeIndex, number>
+}
+
+export interface KatzCentralityOptions<E> extends IterativeScoreOptions<E> {
+  readonly attenuation: number
+  readonly bias?: number
+}
+
+export const katzCentrality: {
+  <E>(options: KatzCentralityOptions<E>): <N, T extends Kind>(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>
+  ) => ReadonlyMap<NodeIndex, number>
+  <N, E, T extends Kind>(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+    options: KatzCentralityOptions<E>
+  ): ReadonlyMap<NodeIndex, number>
+}
+```
+
+All three use finite non-negative edge weights, sum parallel arcs, include self-loops, and follow incoming arcs for
+authority/eigenvector/Katz influence; undirected edges contribute both directions. HITS returns separate L2-normalized
+hub and authority vectors. Eigenvector returns a non-negative L2-normalized dominant vector and must document behavior
+for disconnected graphs and repeated dominant eigenvalues. Katz iterates `x = attenuation * A^T x + bias`, requires
+finite positive bias, and must either validate a conservative spectral-radius bound before iteration or clearly fail
+with `GraphError` on non-convergence. Every method throws on the iteration cap and checkpoints per iteration/work
+budget. Empty graphs return empty maps.
+
+Acceptance requires independently derived fixtures for directed hubs/authorities, disconnected equal-radius
+components, bipartite oscillation, weighted parallel arcs, and non-convergence. Do not copy the reference's implicit
+`A + I` shift without naming it as part of the mathematical API. Bundle comparison must show that shared power-
+iteration machinery actually reduces added code; otherwise ship only the specifically requested score.
+
+### Greedy Coloring
+
+Potential API:
+
+```ts
+export interface ColoringOptions {
+  readonly strategy?: "largest-first" | "dsatur"
+}
+export interface Coloring {
+  readonly colors: ReadonlyMap<NodeIndex, number>
+  readonly colorCount: number
+}
+export const greedyColoring: {
+  (options?: ColoringOptions): <N, E>(
+    graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
+  ) => Coloring
+  <N, E>(
+    graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">,
+    options?: ColoringOptions
+  ): Coloring
+}
+export const isValidColoring: {
+  (colors: ReadonlyMap<NodeIndex, number>): <N, E>(
+    graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
+  ) => boolean
+  <N, E>(
+    graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">,
+    colors: ReadonlyMap<NodeIndex, number>
+  ): boolean
+}
+```
+
+The result is a proper heuristic coloring, not a minimum coloring. Collapse parallel edges to one adjacency and reject
+any self-loop with `GraphError`; returning a coloring that the validator rejects is forbidden. Largest-first sorts by
+descending unique-neighbor degree then node insertion order. DSATUR chooses highest saturation, then highest degree,
+then insertion order. Color numbers start at zero and are assigned deterministically. There are no weights, seeds, or
+directed semantics. Checkpoint once per selected node and within large neighbor scans.
+
+Acceptance requires a demonstrated scheduling/register-allocation use case, property tests that every output validates,
+complete graphs, even/odd cycles, bipartite graphs, loops, parallel edges, sparse indexes, and adversarial fixtures
+where greedy is non-optimal. Never test or claim that DSATUR always uses no more colors than largest-first; that is not
+a general guarantee. Keep exact chromatic number out of scope.
+
+### Isomorphism
+
+Potential APIs, with `findIsomorphism` gated on demonstrated need for the witness:
+
+```ts
+export interface IsomorphismOptions<N, E> {
+  readonly nodeEqual?: (left: N, right: N) => boolean
+  readonly edgeEqual?: (left: E, right: E) => boolean
+}
+
+export const isIsomorphic: {
+  <N, E, T extends Kind>(
+    right: Graph<N, E, T> | MutableGraph<N, E, T>,
+    options?: IsomorphismOptions<N, E>
+  ): (left: Graph<N, E, T> | MutableGraph<N, E, T>) => boolean
+  <N, E, T extends Kind>(
+    left: Graph<N, E, T> | MutableGraph<N, E, T>,
+    right: Graph<N, E, T> | MutableGraph<N, E, T>,
+    options?: IsomorphismOptions<N, E>
+  ): boolean
+}
+
+export const findIsomorphism: {
+  <N, E, T extends Kind>(
+    right: Graph<N, E, T> | MutableGraph<N, E, T>,
+    options?: IsomorphismOptions<N, E>
+  ): (left: Graph<N, E, T> | MutableGraph<N, E, T>) => Option.Option<ReadonlyMap<NodeIndex, NodeIndex>>
+  <N, E, T extends Kind>(
+    left: Graph<N, E, T> | MutableGraph<N, E, T>,
+    right: Graph<N, E, T> | MutableGraph<N, E, T>,
+    options?: IsomorphismOptions<N, E>
+  ): Option.Option<ReadonlyMap<NodeIndex, NodeIndex>>
+}
+```
+
+Require both graphs to have the same kind at the type level. Matching ignores public node and edge indexes unless
+predicates inspect payloads.
+
+Directed orientation, undirected endpoint symmetry, self-loops, and parallel-edge multiplicity are structural.
+Payload predicates must be matched as a true bipartite matching of parallel edge occurrences, not the reference's
+greedy first match. Use a VF2-class feasibility search with deterministic candidate order by node insertion index,
+degree signatures, loop count, and already-mapped frontier. No weights or seed are intrinsic. Checkpoint at every
+bounded backtracking budget; an Effect-native variant is required before exposing this potentially exponential API.
+
+Acceptance requires exhaustive comparison against a brute-force oracle for all small directed and undirected
+multigraphs, relabeling properties, negative near-isomorphs, predicate cases, and timeout/interruption tests. Benchmark
+high-symmetry cycles, cliques, regular graphs, and deliberately non-isomorphic pairs. Reject release if common
+20-50-node fixtures are dominated by avoidable full-edge scans.
+
+### Community Detection
+
+If adopted later, expose only deterministic Louvain plus a separately useful modularity scorer:
+
+```ts
+export interface LouvainOptions<E> {
+  readonly weight?: (edgeData: E) => number
+  readonly resolution?: number
+  readonly maxPasses?: number
+}
+export const louvainCommunities: {
+  <E>(options?: LouvainOptions<E>): <N>(
+    graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
+  ) => ReadonlyArray<ReadonlyArray<NodeIndex>>
+  <N, E>(
+    graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">,
+    options?: LouvainOptions<E>
+  ): ReadonlyArray<ReadonlyArray<NodeIndex>>
+}
+export interface ModularityOptions<E> {
+  readonly weight?: (edgeData: E) => number
+  readonly resolution?: number
+}
+export const modularity: {
+  <E>(
+    communities: ReadonlyArray<ReadonlyArray<NodeIndex>>,
+    options?: ModularityOptions<E>
+  ): <N>(graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">) => number
+  <N, E>(
+    graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">,
+    communities: ReadonlyArray<ReadonlyArray<NodeIndex>>,
+    options?: ModularityOptions<E>
+  ): number
+}
+```
+
+Weights must be finite and non-negative, parallel weights sum, and self-loop weights contribute consistently to
+internal weight and twice to weighted degree. Resolution must be finite and positive. Communities contain nodes in
+insertion order and are ordered by their first node index. Validate that a modularity input covers every graph node
+exactly once and contains no missing index; invalid partitions throw `GraphError`. Louvain stops when no move improves
+modularity beyond a documented numeric epsilon or at `maxPasses`; unlike a fixed-point score, reaching the pass cap is
+a valid bounded heuristic result and should be reported in an internal result during development. Decide before
+release whether public metadata such as pass count is needed.
+
+Initial release is deterministic and has no seed: visit nodes and candidate communities in stable insertion order and
+break equal gains by the lowest stable community representative. If randomized traversal is later proven materially
+better, add an explicit `seed` option with plan 02's PRNG; identical seeds must produce identical canonical partitions.
+Checkpoint per local-moving sweep, aggregation pass, and work budget. Provide an Effect-native interruptible variant
+before publishing because local moving has data-dependent duration.
+
+Acceptance requires a reviewed modularity formula, NetworkX or igraph differential fixtures, hand-computed weighted
+loop/parallel-edge cases, partition properties, resolution tests, deterministic repeats, and quality comparisons on
+planted partitions. Benchmarks must include sparse graphs at 1k, 10k, and 100k nodes and must rule out the reference
+greedy-modularity and Girvan-Newman complexity. Do not promise recovery of a ground-truth partition or global maximum.
+
+### Boolean Planarity
+
+Potential API:
+
+```ts
+export const isPlanar: <N, E>(
+  graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
+) => boolean
+```
+
+Use an iterative linear-time LR test over the underlying simple undirected graph. Self-loops and duplicate parallel
+edges do not affect the answer and are removed in stable edge order. No weights or seed apply. The first release must
+not return an embedding, faces, Kuratowski witness, or layout. Checkpoint during component discovery and bounded DFS
+orientation/testing work; publish an Effect-native variant together with the synchronous function if large-graph
+interruption cannot otherwise be practical.
+
+Acceptance requires confirmed BSD-compatible provenance for any port, K5, K3,3, subdivisions, Petersen, grids,
+disconnected mixtures, loops/parallel edges, exhaustive small simple graphs, and differential tests against NetworkX.
+Benchmark long paths and at least a 100k-edge sparse graph for stack safety and linear scaling. Run bundle comparison;
+the boolean kernel is rejected from the core module if its minified cost is disproportionate to measured demand.
+
+## Explicit Rejections
+
+Approximate TSP must not be added under an analytics name. If plan 07 revisits it, require an undirected graph, an
+existing start index (`GraphError` if missing), finite non-negative weights, deterministic tie-breaking by node/edge
+index, explicit metric-closure memory documentation, and a method with a stated guarantee on metric inputs. A returned
+tour over closure nodes must also distinguish closure cost from the expanded edge walk. Nearest-neighbor plus bounded
+2-opt alone does not meet that gate.
+
+Steiner tree must likewise remain outside this plan. Any future plan 07 proposal must define whether the result is an
+edge-index set or a newly indexed graph, preserve parallel-edge identity during path expansion, require an undirected
+graph and connected terminals, validate finite non-negative weights, state the approximation ratio and assumptions,
+checkpoint each terminal-pair shortest path/MST phase, and benchmark the quadratic terminal metric closure. The
+small reference tests are insufficient evidence for the package cost.
+
+## Staged Delivery
+
+### Stage A: Contracts and Kernel Readiness
+
+- Freeze the score map, normalization, loop, parallel-edge, and graph-kind semantics above.
+- Confirm plan 03 dense snapshots retain stable node order and edge identity in outgoing and incoming arcs.
+- Add shared finite-option and weight validation without exporting analytics APIs.
+- Add benchmark datasets through plan 02; coordinate any reusable public generators with plan 09 rather than adding
+  them here.
+
+Exit gate: sparse-index, loop, and parallel-edge kernel tests pass, and no duplicate CSR/snapshot exists.
+
+### Stage B: Degree and Core Decomposition
+
+- Add the three degree centralities, `coreNumbers`, and `kCore`.
+- Implement bucket peeling with typed arrays and canonical map/array conversion at the boundary.
+- Add JSDoc and type tests proving directed-only and undirected-only APIs reject the wrong graph kind.
+
+Exit gate: hand fixtures and small brute-force peeling oracle agree; scaling is linear; `pnpm lint-fix`, targeted Graph
+tests, targeted Graph type tests, and `pnpm check` pass.
+
+### Stage C: Path-Based Centrality
+
+- Add unweighted closeness and betweenness first.
+- Add weighted modes only after shared shortest-path validation and heap behavior are stable.
+- Reuse buffers per source and avoid predecessor object allocation where incoming arcs plus distance labels suffice.
+
+Exit gate: NetworkX differential tests pass within the numeric tolerances below; weighted/unweighted benchmark
+regressions are recorded and cancellation checkpoints are exercised by an instrumented internal checkpoint.
+
+### Stage D: PageRank
+
+- Add weighted/unweighted PageRank with explicit dangling handling and non-convergence errors.
+- Keep personalization out of the first release.
+- Add convergence metadata internally for tests even if the public result remains a map.
+
+Exit gate: stochastic-mass invariants, analytic fixtures, NetworkX comparisons, iteration-cap errors, and sparse
+100k-edge benchmarks pass.
+
+### Stage E: Effect-Native Interruption
+
+- Add `closenessCentralityEffect`, `betweennessCentralityEffect`, and `pageRankEffect` only after the synchronous
+  kernels stabilize; add `coreNumbersEffect` only if benchmarks show peeling can monopolize a fiber materially.
+- Return `Effect.Effect<Result, GraphError>` and preserve ordinary Effect interruption rather than translating it into
+  `GraphError`.
+- Verify cancellation latency against the shared work budget and verify identical successful output to sync APIs.
+
+Exit gate: interruption tests do not rely on wall-clock sleeps and synchronous bundle paths do not import Effect
+runtime machinery solely for checkpoints.
+
+### Stage F: Re-evaluate Later Candidates Individually
+
+Each later candidate gets a separate changeset and can be declined independently. Prioritize observed demand, oracle
+quality, interruption, and bundle impact, not parity with `.repos/graph`. Do not combine spectral scores, coloring,
+isomorphism, community detection, and planarity into one release.
+
+## Verification Strategy
+
+### Correctness and Oracles
+
+- Use exact hand calculations for paths, cycles, stars, cliques, disconnected graphs, directed chains, dangling-node
+  PageRank, layered cores, and weighted parallel edges.
+- Use brute-force shortest-path enumeration for betweenness on small multigraphs so parallel shortest paths are tested
+  as occurrences rather than collapsed neighbors.
+- Use iterative node deletion as an independent small-graph core-number oracle.
+- Differential-test centralities, PageRank, and any later Louvain/planarity implementation against pinned NetworkX
+  versions through plan 02's development-only adapter. Normalize conventions before comparing rather than weakening
+  assertions until numbers match.
+- Add relabeling properties: remapping stable indexes must remap score keys/partitions while preserving numeric values
+  within tolerance. Add edge-insertion permutation tests only where the algorithm promises insertion-order
+  independence; deterministic heuristic output may intentionally depend on insertion order.
+- Verify every returned key is a live `NodeIndex`, every live node appears exactly once, no result is `NaN` or infinite,
+  PageRank sums to one, and normalized betweenness is bounded for simple graphs.
+
+Use absolute and relative tolerance together for numeric comparisons, initially `1e-10 + 1e-8 * abs(expected)` for
+oracle fixtures. Do not use exact equality for iterative scores. Also validate residuals: PageRank's returned vector
+must satisfy its transition equation within the requested tolerance, and later eigenvector/Katz outputs must satisfy
+their defining equations after normalization. Comparing only rank order is insufficient.
+
+### Performance and Memory
+
+Benchmark separately:
+
+- Sparse path, star, grid, random sparse, and dense graphs.
+- Directed and undirected snapshots, with sparse stable indexes after removals.
+- Unweighted versus weighted closeness/betweenness.
+- PageRank iterations per second and allocation per iteration.
+- Core decomposition at increasing edge counts.
+
+Record asymptotic expectations: degree and core `O(V + E)`; unweighted closeness and betweenness `O(VE)` on sparse
+graphs; weighted variants `O(V(E + V log V))`; PageRank `O(iterations * (V + E))`. Benchmarks must detect accidental
+per-source snapshot construction, per-iteration `Map` rebuilding, queue `shift()`, and dense `V x V` allocation.
+
+### Package Size
+
+`Graph.ts` is already a broad public module, so every accepted algorithm must remain tree-shakeable and avoid runtime
+dependencies. Run `pnpm bundle-compare <base-ref>` for every stage and report non-zero changes. Share dense snapshots,
+heaps, validation, normalization, and checkpoint helpers only when already justified by multiple algorithms; do not
+create a generic linear-algebra framework. Large specialist kernels, especially planarity, isomorphism, community
+detection, TSP, and Steiner, require an explicit size budget and may belong in a future opt-in package rather than
+`effect/Graph`.
+
+## Release and Changesets
+
+Every stage that exports a function, option, or result type requires a patch changeset for `effect`, public JSDoc with
+`@since`, runtime tests in `packages/effect/test/Graph.test.ts`, and type tests in
+`packages/effect/typetest/Graph.tst.ts`. Internal groundwork and benchmark-only changes do not require a changeset.
+Use one focused changeset per shipped stage; do not announce later/rejected APIs. Run the narrow validation required by
+the repository instructions, including doctests when public examples are added. No implementation stage is complete
+until its bundle comparison, oracle version, numeric tolerances, convergence behavior, and benchmark baseline are
+recorded in the pull request.

--- a/docs/graph-plans/09-generators.md
+++ b/docs/graph-plans/09-generators.md
@@ -1,0 +1,383 @@
+# Plan 09: Graph Generators
+
+## Status and Goal
+
+Add a small set of predictable graph constructors for examples, simulations, and analytics, while giving the
+verification suites a separate deterministic fixture builder capable of producing structures that production
+generators intentionally exclude.
+
+This is additive work. Existing `Graph.directed`, `Graph.undirected`, scoped mutation, automatic monotonic numeric
+`NodeIndex` / `EdgeIndex` allocation, parallel-edge support, and self-loop support remain unchanged.
+
+Binding decision: deterministic and stochastic public generators live in the existing `Graph` module. Stochastic
+generators are Effect-returning and consume the existing `Random` service. The resulting Graph-module dependency and
+bundle impact are accepted subject to the normal bundle comparison; do not create a separate generator module.
+
+Success means:
+
+- users can construct standard directed or undirected graph families without manually managing indexes;
+- stochastic public generators compose with Effect's `Random` service and are reproducible with `Random.withSeed`;
+- tests, differential oracles, and benchmarks share deterministic fixture builders that can exercise multigraph and
+  sparse-index behavior;
+- every generator has explicit edge-count, ordering, validation, and complexity contracts.
+
+## Dependencies and Ownership
+
+- Requires plan 01's correctness contracts for loop, parallel-edge, degree, and ordering semantics.
+- Requires and consumes plan 02's shared seeded fixture model, oracle adapters, seed reporting, and benchmark fixture
+  catalog; it must not create a second fixture representation or PRNG.
+- Uses the existing `Graph.make(type)`, `Graph.addNode`, and `Graph.addEdge` mutation path. Generator code must not
+  write `GraphImpl`, adjacency maps, allocator counters, or the acyclic cache directly.
+- Can implement deterministic production generators before analytics algorithms land. Random production generators
+  should wait for the plan-02 random-source helper so tests and benchmarks consume random values identically.
+- Coordinate benchmark sizes and topology names with the analytics plan. Analytics owns algorithm benchmarks;
+  plan 02 owns fixture construction and caching; this plan owns public generator behavior.
+- No dependency on dense snapshots is required. Generated graphs start dense; only internal fixtures deliberately
+  make public indexes sparse.
+
+Plan 02 is the binding owner of the neutral `GraphSpec` corpus, seeded PRNG, adapters, fingerprints, and replay metadata.
+This plan consumes that foundation and does not define alternate fixture helper names or representations.
+
+## Design Decisions
+
+### Production and Verification Are Different Surfaces
+
+Public production generators create conventional simple graphs: no self-loops and no parallel edges unless the
+mathematical family explicitly requires otherwise. Their shape, insertion order, and edge count are documented and
+stable.
+
+Internal fixtures must not be implemented by adding pathological switches to every public generator. They need a
+single lower-level builder supporting loops, parallel edges, deleted indexes, arbitrary payloads, random weights,
+and exact replay from a seed. This keeps user APIs understandable and lets verification cover the full existing Graph
+model.
+
+### Random APIs Are Effectful, Not Pure Seeded Functions
+
+Deterministic families remain synchronous. Stochastic public generators return `Effect.Effect<Graph<...>>` and draw
+from the active `Random.Random` service. A caller obtains deterministic output with:
+
+```ts
+Graph.erdosRenyi("undirected", 100, 0.05).pipe(Random.withSeed("example"))
+```
+
+Do not add `seed` options to public graph generators and do not embed Mulberry32 or another graph-specific PRNG.
+Effect already provides replaceable pseudo-random generation and `Random.withSeed(string | number)`. This decision:
+
+- avoids `Math.random` in deterministic use;
+- supports reproducible tests and simulations without exposing a second PRNG contract;
+- permits applications to provide their own `Random` service;
+- preserves the README rule that existing synchronous APIs stay synchronous while Effect variants are additive.
+
+The default `Random` service currently uses `Math.random`; therefore an unseeded stochastic call is intentionally
+nondeterministic. The API itself never calls `Math.random`, and deterministic documentation/tests always provide a
+seed. Randomness is not cryptographically secure and the JSDoc must say so.
+
+Implementation should acquire the active random service once and run the synchronous construction kernel with its
+`nextDoubleUnsafe`, rather than constructing one Effect per candidate edge. Any reusable service-access helper belongs
+with plan 02 or `Random`, not as a second generator-only service.
+
+### IDs, Types, Payloads, and Ordering
+
+- Every graph is built in one `Graph.make(type)` mutation scope.
+- Nodes are added in semantic position order and receive automatic indexes `0..n-1`.
+- Edges are added in the documented enumeration order and receive automatic indexes `0..m-1`.
+- Payload factories receive semantic positions/indexes but cannot supply graph IDs. Returned factory values are node
+  or edge data only.
+- The `type` literal is generic and is preserved as `Graph<N, E, T>`; fixed directed-only generators return
+  `DirectedGraph<N, E>`.
+- Default node data is its zero-based position and default edge data is `undefined`, producing
+  `Graph<number, void, T>` without requiring callbacks.
+- Factories are called exactly once per emitted node or edge, after configuration validation. If a factory throws,
+  the exception is not wrapped.
+
+Use small exported context types rather than positional callback arguments where a family has coordinates or ranks:
+
+```ts
+export interface GeneratedEdge {
+  readonly index: number
+  readonly source: NodeIndex
+  readonly target: NodeIndex
+}
+
+export interface GeneratorOptions<N = number, E = void> {
+  readonly node?: (index: NodeIndex) => N
+  readonly edge?: (edge: GeneratedEdge) => E
+}
+
+export interface GridNode {
+  readonly index: NodeIndex
+  readonly row: number
+  readonly column: number
+}
+
+export interface GridGeneratorOptions<N = GridNode, E = void> {
+  readonly node?: (node: GridNode) => N
+  readonly edge?: (edge: GeneratedEdge) => E
+}
+```
+
+`GeneratedEdge.index` is the insertion ordinal and therefore equals the initial automatic `EdgeIndex`; it is not a
+facility for overriding the ID. Grid's default node payload should be `GridNode`, because flattening a cell to only a
+number discards useful public information.
+
+## Proposed Public API
+
+Exact naming should receive the normal API review, but prefer concise names in the existing `Graph` module rather
+than a new package or class.
+
+```ts
+export const complete: <T extends Kind, N = number, E = void>(
+  type: T,
+  nodeCount: number,
+  options?: GeneratorOptions<N, E>
+) => Graph<N, E, T>
+
+export const path: <T extends Kind, N = number, E = void>(
+  type: T,
+  nodeCount: number,
+  options?: GeneratorOptions<N, E>
+) => Graph<N, E, T>
+
+export const cycle: <T extends Kind, N = number, E = void>(
+  type: T,
+  nodeCount: number,
+  options?: GeneratorOptions<N, E>
+) => Graph<N, E, T>
+
+export const grid: <T extends Kind, N = GridNode, E = void>(
+  type: T,
+  rows: number,
+  columns: number,
+  options?: GridGeneratorOptions<N, E>
+) => Graph<N, E, T>
+
+export const tree: <T extends Kind, N = number, E = void>(
+  type: T,
+  nodeCount: number,
+  branchingFactor: number,
+  options?: GeneratorOptions<N, E>
+) => Graph<N, E, T>
+
+export const erdosRenyi: <T extends Kind, N = number, E = void>(
+  type: T,
+  nodeCount: number,
+  probability: number,
+  options?: GeneratorOptions<N, E>
+) => Effect.Effect<Graph<N, E, T>>
+
+export const connectedRandom: <T extends Kind, N = number, E = void>(
+  type: T,
+  nodeCount: number,
+  edgeCount: number,
+  options?: GeneratorOptions<N, E>
+) => Effect.Effect<Graph<N, E, T>>
+
+export const dag: <N = number, E = void>(
+  nodeCount: number,
+  probability: number,
+  options?: GeneratorOptions<N, E>
+) => Effect.Effect<DirectedGraph<N, E>>
+```
+
+These are constructors, not dual graph transforms, so data-first/data-last overloads do not apply.
+
+### Complete
+
+- Undirected: emit one edge `(i, j)` for each `i < j`; edge count `n(n - 1) / 2`.
+- Directed: emit every ordered edge `(i, j)` where `i !== j`; edge count `n(n - 1)`.
+- No loops or parallel edges.
+- Complexity: `Theta(n + m)` time and graph storage, which is `Theta(n^2)` for nontrivial complete graphs.
+
+### Path and Cycle
+
+- `path` emits `(i, i + 1)` for `i = 0..n-2`. Directed paths point from lower to higher index. Edge count is
+  `max(0, n - 1)`.
+- `cycle` emits the path edges followed by `(n - 1, 0)`. Require `n >= 3`; this avoids presenting a one-node loop or
+  two parallel undirected edges as the conventional simple cycle `C_n`. Edge count is exactly `n`.
+- Complexity: `Theta(n)` time and storage.
+
+### Grid
+
+- Add cells in row-major order.
+- For each cell in row-major order, emit its right edge first and down edge second when those neighbors exist.
+- Directed grids point right and down and are DAGs. Undirected grids have the same edge occurrences without direction.
+- Node count is `rows * columns`; edge count is `rows * max(0, columns - 1) + columns * max(0, rows - 1)`.
+- Zero in either dimension produces an empty graph. A `1 x n` or `n x 1` grid is a path.
+- Complexity: `Theta(rows * columns)` time and storage.
+
+### Tree
+
+`tree` means a deterministic breadth-first complete k-ary tree, not an arbitrary tree parser and not a random tree.
+For node `i > 0`, its parent is `floor((i - 1) / branchingFactor)`. Directed edges point parent-to-child; undirected
+graphs contain the same edge occurrences. Edge count is `max(0, n - 1)`. Complexity is `Theta(n)`.
+
+This definition gives examples and benchmarks a stable balanced-ish tree while leaving arbitrary parent relations to
+normal graph construction.
+
+### Erdős-Rényi `G(n, p)`
+
+- Undirected: independently test each unordered pair `i < j` in complete-graph order.
+- Directed: independently test each ordered pair `i !== j` in complete-graph order.
+- Emit the edge when `nextDouble < probability`; no loops or parallel edges.
+- Edge count is random, in `[0, M]`, with expectation `pM`, where `M` is the corresponding complete edge count.
+- `p = 0` consumes no random values and returns no edges; `p = 1` consumes no random values and delegates to the same
+  deterministic kernel as `complete`. This makes boundary behavior independent of PRNG quirks.
+- Complexity: `Theta(n^2 + m)` time and `Theta(n + m)` graph storage. The pair scan is inherent to `G(n, p)`.
+
+### Exact-Edge Connected Random Graph
+
+- The result is connected for undirected graphs and **weakly connected** for directed graphs. JSDoc and the function
+  name description must not imply strong connectivity.
+- For `n > 1`, first generate a random spanning tree using a seeded Fisher-Yates node permutation and one random
+  earlier parent per subsequent node. In directed mode independently orient each tree edge.
+- Sample remaining simple non-loop pairs without replacement until exactly `edgeCount` edges exist. Directed graphs
+  treat `(u, v)` and `(v, u)` as distinct; undirected graphs do not.
+- The distribution is a spanning-tree-plus-extra-edges model, **not** uniform over all connected graphs.
+- Valid range is `0` for `n = 0`; `0..0` for `n = 1`; otherwise `n - 1 <= edgeCount <= M`.
+- Use an adaptive integer-pair sampler: rejection sampling while sparse, and complement/enumeration when dense. Never
+  use a capped retry loop that can silently return fewer edges.
+- Expected complexity is `O(n + m)` for sparse outputs and `O(M)` for dense outputs, with `O(n + min(m, M - m))`
+  temporary sampling storage in addition to the graph.
+
+### Random DAG
+
+- Shuffle node indexes to obtain a hidden topological rank.
+- Independently test each forward rank pair and emit only rank-lower to rank-higher edges.
+- Edge count is random in `[0, n(n - 1) / 2]`, with expectation `p * n(n - 1) / 2`.
+- The insertion/index order remains `0..n-1`; topological order is deliberately not always index order, making the
+  generator useful for algorithm verification.
+- No loops or parallel edges. Complexity is `Theta(n^2 + m)` time and `Theta(n + m)` storage.
+
+## Deferred Network Models
+
+Do not initially export Watts-Strogatz or Barabási-Albert generators.
+
+Both are valuable topology classes for centrality, community, clustering, and path-length benchmarks, so plan 02
+should include stable internal fixtures for them. They do not yet justify permanent production APIs:
+
+- Watts-Strogatz variants disagree about the initial lattice, which endpoint is rewired, whether failed rewires keep
+  the old edge, and whether connectivity is guaranteed.
+- Barabási-Albert variants disagree about seed size/shape, zero-degree handling, and whether attachment samples are
+  simultaneous or degree-updating.
+- The reference implementation's Barabási-Albert `m`-node seed and claimed minimum degree are inconsistent for the
+  initial seed (`K_m` has degree `m - 1`), illustrating why its contract needs more review.
+
+Promote either model only after at least two analytics benchmarks or user-facing examples need it, its exact variant
+is documented, and deterministic cross-seed properties exist. Promotion would be additive and require its own API
+review and changeset. Internal benchmark names should include the variant, for example
+`wattsStrogatzRewireSource` and `barabasiAlbertCompleteSeed`.
+
+## Validation and Failure Behavior
+
+Validate the complete configuration before calling payload factories or consuming randomness. Invalid structural or
+algorithmic inputs throw `GraphError`, matching the Graph module's synchronous invalid-input convention; stochastic
+functions create an Effect that defects with that `GraphError` when run rather than adding a new typed error channel.
+
+- Counts and dimensions must be finite non-negative safe integers.
+- Products and complete edge counts must remain safe integers; reject configurations whose automatic indexes or loop
+  bounds would exceed `Number.MAX_SAFE_INTEGER` before allocation.
+- `branchingFactor` must be a positive safe integer when `nodeCount > 1`. Accept any positive value for zero/one-node
+  trees because it does not affect shape; rejecting zero remains simpler and consistent.
+- Probabilities must be finite numbers in `[0, 1]`; `NaN` is invalid.
+- `cycle` requires at least three nodes.
+- `connectedRandom` validates the exact edge-count range described above.
+
+Error messages name the generator, field, received value, and expected range. Do not clamp, round, silently truncate,
+or return a partial graph.
+
+## Internal Fixture Builder (Plan 02)
+
+All generator tests, differential checks, and benchmarks use plan 02's neutral `GraphSpec`, fixed seed corpus, PRNG,
+Effect adapter, and oracle adapters. Rich specs cover allocation/removal sequences needed for sparse active indexes,
+self-loops, parallel edges, and signed/zero weights; simple specs exclude unsupported semantics before oracle adaptation.
+Fast-check may shrink serializable neutral descriptions, but it must hydrate through the same adapters and report plan
+02 replay metadata. Do not add an Effect-`Random` fixture model beside this corpus. Public stochastic generators still
+use the `Random` service as specified above; tests record their realized topology as a neutral spec when sharing it with
+oracles or benchmarks.
+
+## Tests and Properties
+
+Add focused runtime tests in `packages/effect/test/Graph.test.ts` unless the file's size warrants a dedicated
+`GraphGenerators.test.ts`, plus type tests for kind preservation and callback inference.
+
+Deterministic generator tests:
+
+- zero, one, and representative sizes; invalid integers, unsafe counts, overflow, and cycle sizes;
+- exact node/edge formulas and documented insertion order;
+- directed versus undirected complete, path, grid, and tree endpoint semantics;
+- grid coordinates and tree parent formula;
+- payload factories called once in order and not called on invalid configuration;
+- returned IDs are automatic contiguous indexes with no caller-supplied ID path;
+- structural properties: path/tree connected and acyclic, cycle cyclic, directed grid acyclic, expected degrees.
+
+Stochastic generator tests, always under `Random.withSeed`:
+
+- same seed and options produce equal graphs and callback payloads; representative different seeds change topology;
+- `G(n, 0)` is empty and `G(n, 1)` equals `complete` without consuming random draws;
+- Erdős-Rényi output is simple, loop-free, kind-correct, and within bounds;
+- connected random output has exactly the requested edge count and is connected/weakly connected for sparse,
+  mid-density, and complete bounds;
+- DAG output is simple and acyclic, including seeds whose topological order differs from index order;
+- a custom `Random` service with a counted sequence verifies draw order and boundary draw counts;
+- invalid stochastic configurations consume no random values and do not invoke factories.
+
+Property and differential tests:
+
+- generated endpoints always exist and every edge occurrence has a unique automatic `EdgeIndex`;
+- complete edge counts and degree formulas hold over bounded random sizes;
+- connected exact-edge generation terminates and reaches the requested count near maximum density;
+- fixture options independently cover loops, parallel edges, zero/negative weights, and sparse node/edge indexes;
+- sparse fixtures preserve monotonic allocator behavior after subsequent public `addNode` / `addEdge` calls;
+- simple fixture normalization has identical nodes, endpoints, direction, and weights in each oracle;
+- failures report a directly replayable seed.
+
+Avoid statistical tests with flaky distribution thresholds. Test deterministic invariants and fixed random streams;
+distribution smoke tests, if any, use broad deterministic aggregate bounds over a fixed seed corpus.
+
+## Benchmarks
+
+Plan 02 should cache or construct outside the timed region a stable fixture matrix containing:
+
+- path, cycle, balanced tree, and grid for sparse/local algorithms;
+- complete and dense Erdős-Rényi for quadratic/dense behavior;
+- weakly connected sparse random directed and undirected graphs;
+- random DAGs for topological and dependency analytics;
+- internal Watts-Strogatz for clustering/community behavior;
+- internal Barabási-Albert for degree-skew and centrality behavior;
+- rich multigraph fixtures with loops/parallel edges and sparse indexes for correctness/performance regression checks.
+
+Each benchmark records generator name, normalized parameters, seed, live `V`/`E`, allocated slots, graph kind, and
+weight policy. Analytics benchmarks must not time random generation and must not substitute only friendly production
+generators for pathological fixtures. Public generator microbenchmarks should separately measure construction cost at
+sparse and dense scales.
+
+## Documentation and Release Work
+
+- Add public JSDoc under `@category constructors`, including formulas, kind semantics, ordering, failure behavior,
+  randomness/security caveats, complexity, and deterministic `Random.withSeed` examples.
+- Update Graph module documentation with a short "standard and random generators" section. Do not expose internal
+  fixture helpers in user documentation.
+- Mark runnable examples with `import.meta.vitest`; seed every stochastic example and assert semantic graph values.
+- Add one `effect` minor changeset for the new exported constructor APIs. Internal fixtures and benchmarks do not need
+  a changeset.
+- Run `pnpm codegen` only if module/barrel exports change; functions added to the existing `Graph.ts` namespace should
+  flow through the existing generated `effect` barrel without a new module.
+
+## Implementation Sequence
+
+1. Reconcile plan-02 fixture/random-source ownership and names; verify one seeded stream can drive Graph construction,
+   differential normalization, and benchmark metadata.
+2. Add shared validation and payload context types, then complete/path/cycle/grid/tree through public mutation APIs.
+3. Add exact terminating pair-sampling kernels and the three Effect/Random generators.
+4. Add runtime, type, deterministic-seed, boundary, property, and differential tests.
+5. Add internal Watts-Strogatz and Barabási-Albert benchmark fixtures only after their variant contracts are written.
+6. Add JSDoc, user documentation, targeted generator/analytics benchmarks, codegen if required, and the changeset.
+
+## Non-Goals
+
+- User-supplied node or edge IDs, index hydration, or allocator resets.
+- Public switches for loops, parallel edges, deleted indexes, mixed edge kinds, or arbitrary malformed graphs.
+- Cryptographic graph generation or a new public PRNG abstraction.
+- Uniform sampling from all connected graphs or all DAGs.
+- Layout coordinates beyond grid row/column payloads.
+- Immediate public APIs for every named network model.

--- a/docs/graph-plans/10-effect-native-interruption.md
+++ b/docs/graph-plans/10-effect-native-interruption.md
@@ -1,0 +1,290 @@
+# Plan 10: Effect-Native Interruption and Cooperative Scheduling
+
+## Status and intent
+
+Add Effect-returning variants for graph algorithms that can occupy a JavaScript thread for a meaningfully long time.
+The variants must cooperate with Effect fiber interruption and scheduling without adding `AbortSignal`, changing an existing
+synchronous signature, or changing deterministic results.
+
+This work starts only after the synchronous kernels from plans 03 and 05-09 are stable. It is not a request to put every
+graph operation inside `Effect.sync`: doing so makes an operation nominally effectful but does not make a running JavaScript
+loop interruptible.
+
+## Decisions
+
+### Public naming and shape
+
+- Name an Effect-returning counterpart by appending `Effect` to the existing synchronous name: for example,
+  `floydWarshallEffect`, `betweennessCentralityEffect`, and `maxFlowEffect`.
+- Keep the synchronous function as the canonical base name. Do not rename, deprecate, or change it.
+- Preserve the synchronous function's argument order, result type, graph-kind constraints, configuration, and dual
+  data-first/data-last overloads. The Effect counterpart has the same dual arity and returns
+  `Effect.Effect<Result, GraphError>`.
+- Do not add `signal`, `AbortSignal`, `AbortController`, cancellation callbacks, or an interruption error to public options.
+  Callers use normal Effect composition such as `Fiber.interrupt`, `Effect.timeout`, races, scopes, and parent-child
+  interruption.
+- Do not add a generic `runAlgorithmEffect(name, ...)` dispatcher. Named exports remain discoverable, tree-shakeable, and
+  strongly typed.
+- Do not add a public checkpoint frequency option initially. A user-facing knob would expose kernel mechanics, make latency
+  guarantees hard to document, and destabilize benchmark comparisons. Tune internal constants from measurements instead.
+
+The `Effect` suffix follows the repository convention for an effectful counterpart of an otherwise pure or synchronous
+operation. `Interruptible`, `Async`, and `Cooperative` are rejected: interruption is a property of Effect execution, no
+Promise or worker is introduced, and scheduling cooperation is an implementation detail.
+
+### Errors and interruption
+
+- Algorithm and input failures already represented by `GraphError` are failures in the Effect error channel. The
+  synchronous API continues to throw the same `GraphError` at the same logical point.
+- Fiber interruption is interruption in the Effect `Cause`; it is not `GraphError`, `Option.none`, a partial result, or a
+  bespoke `GraphInterruptedError`. Consequently `Effect.catch` does not accidentally turn cancellation into an algorithm
+  result.
+- Kernel validation should return an internal failure outcome instead of throwing where practical. The synchronous adapter
+  throws that `GraphError`; the Effect adapter fails with it. This keeps the two adapters over one decision path.
+- Exceptions thrown by user-supplied weight, capacity, heuristic, matching, or other callbacks retain the established
+  synchronous semantics. They become defects in an Effect variant unless the owning synchronous plan explicitly models
+  them as `GraphError`; do not catch every unknown throwable and mislabel it as an algorithm error.
+- Interruption discards private partial state. No partially constructed collection, flow, partition, or matrix is published.
+  Normal garbage collection is sufficient because these kernels acquire no scoped resources.
+
+### Why a resumable kernel is required
+
+`Effect.sync(() => synchronousAlgorithm(...))` only observes interruption before or after the callback. The fiber runtime
+cannot suspend or interrupt the callback while its loop owns the JavaScript thread. Likewise, invoking a callback named
+`checkpoint` from a synchronous stack cannot `yield* Effect.yieldNow`.
+
+For each admitted algorithm, separate its state from its driving loop:
+
+```ts
+interface AlgorithmCheckpoint {
+  readonly shouldPause: (work: number) => boolean
+}
+
+type KernelStep<A> =
+  | { readonly _tag: "Continue" }
+  | { readonly _tag: "Done"; readonly value: A }
+  | { readonly _tag: "Failure"; readonly error: GraphError }
+```
+
+The exact internal names are owned by plan 03 and may differ. The required semantics are:
+
+- Kernel state survives a `Continue` result and resumes without recomputation.
+- Kernels consult one shared, internal checkpoint hook only at invariants-safe boundaries.
+- The synchronous adapter supplies a no-op checkpoint and drains the kernel in one call path.
+- The Effect adapter supplies a budget checkpoint, runs one bounded synchronous slice, and on `Continue` executes
+  `Effect.yieldNow` before resuming. Implement Effect drivers with the repository's preferred untraced Effect function
+  pattern and stack-safe suspension, not `async` / `await` or Promises.
+- A slice must not mutate the public graph. It may mutate only private kernel state and newly allocated result structures.
+- Do not duplicate an algorithm into separate synchronous and Effect implementations. Deterministic parity depends on both
+  adapters advancing the same kernel state machine.
+
+Plan 03 owns the reusable checkpoint protocol and driver helpers. Domain plans own the resumable state for their kernels.
+If plan 03 instead lands a generator/stepper protocol with these properties and acceptable synchronous overhead, reuse it;
+do not introduce a competing abstraction in this plan.
+
+### Checkpoint granularity and yielding
+
+Checkpoints represent logical work, not wall-clock time. Do not use `Date.now`, `new Date`, timers, or `Clock` in hot loops.
+Logical budgets make output and tests deterministic and avoid a clock read for every edge.
+
+Initial checkpoint boundaries by kernel family:
+
+| Family | Safe checkpoint boundary | Work charged |
+| --- | --- | --- |
+| Floyd-Warshall / dense all-pairs | Completed row for a fixed intermediate node; split a row into fixed column blocks when dense benchmarks exceed the latency target | Relaxation attempts |
+| Repeated-source all-pairs, closeness, betweenness | Completed source traversal; allow queue/stack blocks inside one source for very large components | Examined arcs plus queue pops |
+| Simple paths, simple cycles, isomorphism, exact coloring/TSP | A fixed block of search-state expansions, after restoring the explicit DFS/backtracking invariant | Candidate expansions and examined arcs |
+| PageRank, HITS, eigenvector, Katz | Fixed node blocks within an iteration, with convergence checked only after the complete iteration | Node/arc updates |
+| Louvain, label propagation, greedy modularity | Fixed node blocks after a committed move, plus phase/pass boundaries | Candidate community evaluations |
+| Girvan-Newman | Source blocks while recomputing betweenness and completed edge-removal rounds | Traversal/relaxation work |
+| Max-flow / min-cut | Fixed blocks while searching the residual graph and after a complete augmentation | Residual arcs examined |
+| Bellman-Ford and similarly repeated relaxations | Fixed edge blocks, preserving pass state, and completed passes | Relaxation attempts |
+| Dominators | Completed DFS/search blocks or semidominator buckets, only where the implementation's invariants permit | Nodes/arcs examined |
+
+Start with a slice budget calibrated to keep interruption latency below 5 ms on supported CI benchmark hardware for the
+large seeded fixtures. Also enforce a logical upper bound so one high-degree node, one dense row, or one backtracking branch
+cannot create an unbounded slice. Calibration belongs in benchmarks, not a public API.
+
+Yield exactly once after an exhausted slice. Do not yield after every edge, node, emitted result, or callback; that would
+dominate useful work. Do not use `Effect.sleep(0)` or a fixed delay. `Effect.yieldNow` delegates fairness to the active
+scheduler and creates an interruptible boundary. Effect's ordinary runtime operation budget is not a substitute because a
+large synchronous slice is one Effect runtime operation.
+
+Run initial validation and trivial early returns before the first forced yield, while still allowing pre-start fiber
+interruption through normal Effect evaluation. A computation that completes within one slice should not pay an extra
+scheduler turn.
+
+### Progress reporting
+
+Do not add progress callbacks, a progress service, or progress events in the first release.
+
+- Several target algorithms have no honest total: backtracking search, convergence algorithms, Louvain phases, and
+  augmenting-path flow can revise the amount of remaining work.
+- Calling user code at checkpoints complicates error/environment types and can perturb scheduling and determinism.
+- Streaming multi-result algorithms already communicate useful progress by producing results lazily; aggregate algorithms
+  can be observed externally by fiber lifecycle, metrics around the whole Effect, and tracing.
+
+Reconsider a separate, algorithm-specific progress API only after a concrete use case defines stable semantic units. Do not
+encode internal checkpoint counts as a public progress contract.
+
+## Admission policy
+
+An algorithm receives an Effect variant when at least one of these is true:
+
+- its normal implementation is cubic, repeated-source, iterative-to-convergence, repeated augmentation, or exponential;
+- it has an unbounded search space or can spend substantial time before producing its next lazy result;
+- seeded benchmarks show a representative supported input can hold the thread for at least 8 ms.
+
+The benchmark criterion prevents complexity notation alone from creating wrappers around operations that are fast in
+practice. Reassess admission when plans 05-09 finalize names and implementations.
+
+### Initial variants
+
+- **All-pairs and repeated relaxation:** `floydWarshallEffect`, any Johnson/repeated-source all-pairs counterpart introduced
+  by plan 05, and `bellmanFordEffect`. Single-pair Dijkstra and A* are admitted only if the large sparse benchmark crosses
+  the runtime threshold; they are not automatic variants.
+- **Enumerative search:** Effect variants for eager simple-path, simple-cycle, and k-shortest-simple-path collection APIs
+  from plan 05. Their lazy API remains the preferred way to bound results. If plan 05 exposes an Effect-native `Stream`, use
+  that stream as the interruptible collection kernel rather than adding another eager implementation. Ensure interruption
+  can occur while searching for the next result, not only between emitted results.
+- **Centrality:** closeness and betweenness, plus PageRank, HITS, eigenvector, and Katz variants from plan 08. Degree,
+  in-degree, and out-degree centrality are linear aggregations and do not receive variants absent benchmark evidence.
+- **Community:** Louvain, label propagation, Girvan-Newman, and greedy modularity variants from plan 08. A direct modularity
+  score calculation does not receive one unless benchmarks justify it.
+- **Optimization:** max-flow and min-cut variants from plan 07, sharing one resumable residual-network kernel. Add variants
+  for exact TSP, exact coloring, or other exponential optimization only if those APIs are accepted by plans 07-08.
+- **Matching/isomorphism:** graph and subgraph isomorphism/backtracking variants from plan 07 or 08. Maximum bipartite
+  matching receives a variant only if its finalized kernel crosses the threshold on benchmark fixtures.
+- **DAG/connectivity:** dominator-tree variants from plan 06 only if the finalized implementation has measurable long
+  uninterrupted phases. Connected components, SCCs, bridges, articulation points, topological sorting, acyclicity,
+  bipartiteness, planarity, core numbers, and ordinary traversals stay synchronous and/or lazy by default.
+
+### Explicit non-targets
+
+Do not add Effect variants for node/edge lookup, degree queries, neighbors, mutation, graph construction, map/filter,
+composition, set-like transforms, serialization, DOT/Mermaid output, ordinary BFS/DFS iteration, or small single-path
+convenience calls merely for API symmetry. Users can place a fast synchronous call in `Effect.sync` when composition alone
+is useful; this plan is specifically for cooperative CPU work.
+
+## Phases
+
+### Phase 1: Inventory after synchronous kernels stabilize
+
+1. Read the final APIs, semantics, fixtures, and benchmarks from plans 03 and 05-09.
+2. Benchmark all candidates on seeded sparse, dense, parallel-edge, self-loop, disconnected, and adversarial fixtures.
+3. Record admitted exports and rejected candidates with measured rationale. Do not implement an Effect wrapper before its
+   synchronous kernel and deterministic contract are complete.
+4. Identify the invariant-safe checkpoint boundaries in each admitted kernel and any single inner operation that violates
+   the target slice latency.
+
+### Phase 2: Shared resumable driver
+
+1. Extend plan 03's no-op synchronous checkpoint abstraction into the minimal resumable kernel/driver protocol described
+   above.
+2. Prove it with one structurally simple repeated-work kernel, preferably Floyd-Warshall or Bellman-Ford, before migrating
+   backtracking or community algorithms.
+3. Keep the synchronous adapter allocation-free per checkpoint and verify that the Effect driver yields only when its
+   logical budget is exhausted.
+4. Establish benchmark and interruption-latency harnesses shared by all later migrations.
+
+### Phase 3: Paths and optimization
+
+1. Migrate admitted all-pairs/repeated-relaxation kernels owned by plan 05.
+2. Migrate simple-path/cycle search so explicit search state survives between slices and lazy result ordering is unchanged.
+3. Migrate flow/min-cut and admitted matching/isomorphism/optimization kernels owned by plan 07.
+4. Add parity, interruption, fairness, and overhead tests per family before moving to analytics.
+
+### Phase 4: Analytics and community
+
+1. Migrate centrality and iterative ranking kernels from plan 08, preserving convergence checks and floating-point update
+   order exactly.
+2. Migrate community kernels from plan 08, preserving seeded/default ordering and committing node moves atomically between
+   checkpoints.
+3. Add dominator or other plan 06/09 candidates only when Phase 1 measurements admitted them.
+4. Re-run the full candidate inventory; do not add variants solely to make naming tables symmetrical.
+
+### Phase 5: Public API, documentation, and release
+
+1. Add JSDoc for each new export explaining that it is cooperatively scheduled, fiber-interruptible, deterministic, and
+   semantically equivalent to its synchronous counterpart.
+2. Include examples using ordinary fiber interruption or `Effect.timeout`; never demonstrate `AbortController`.
+3. Add a guide choosing among synchronous, lazy/streaming, and Effect variants. State that interruption latency is bounded
+   by a slice, not an immediate preemption of JavaScript.
+4. Run code generation if generated barrels are affected, API/type tests, targeted doctests, lint, and package type checks.
+5. Add a patch changeset for `effect` describing the additive exports. If the variants land over multiple pull requests,
+   each public batch gets its own changeset; internal kernel preparation alone does not.
+
+## Verification
+
+### Deterministic parity
+
+For every variant, assert deep semantic equality with the synchronous result on the same seeded fixtures, including:
+
+- empty, singleton, disconnected, directed, and undirected graphs where supported;
+- sparse stable indexes, parallel edges, self-loops, ties, unreachable nodes, and negative weights where valid;
+- deterministic path/cycle/result ordering and edge identity;
+- identical convergence output and floating-point values, not merely approximate agreement caused by reordered updates;
+- identical `GraphError` reason/message for invalid endpoints, weights, capacities, heuristics, graph kinds, and negative
+  cycles;
+- more than one slice, so parity tests exercise resume boundaries rather than only the one-shot path.
+
+Use seeded fixtures and oracle adapters owned by plan 02, plus plan 03's internal checkpoint probes. Add type tests proving dual invocation and the exact
+`Effect.Effect<Result, GraphError>` shape.
+
+### Fiber interruption and scheduling
+
+- Use `it.effect`, fork the algorithm into a child fiber, wait until a deterministic test hook reports at least one
+  checkpoint/yield, interrupt the fiber, and assert an interrupted `Exit`/`Cause` rather than a typed failure.
+- Do not use graph size plus arbitrary real sleeps to guess whether work started. Expose the checkpoint observer only to
+  tests or use a deterministic test scheduler/harness; do not make it public API.
+- Use `TestClock` for timeout-based tests and advance it explicitly. Keep a direct `Fiber.interrupt` test as the primary
+  proof because cooperative yielding itself is scheduler-driven rather than time-driven.
+- Verify interruption before start, after several resumptions, and during each major multi-phase family. Verify no result is
+  published and no public graph mutation occurs.
+- Run a competing fiber that increments a counter between slices to prove fairness. Completion of both fibers alone is not
+  sufficient evidence that the algorithm yielded.
+- Verify a small computation that fits in one slice completes without an unnecessary yield.
+
+### Performance budgets
+
+Compare against the stabilized synchronous baseline using the benchmark harness from plan 03:
+
+- Existing synchronous APIs: median runtime regression at most 5% and no more than one additional allocation per whole
+  invocation attributable to resumable state; investigate noise with repeated benchmark runs.
+- Effect variants without contention: median CPU/runtime overhead at most 20% over the same resumable synchronous kernel on
+  large fixtures. Report scheduler-turn count with the timing.
+- Cooperative latency: no measured slice above 5 ms on the designated CI fixture/hardware, with a logical-work cap guarding
+  pathological high-degree/search cases.
+- Memory: peak retained state no more than 10% above the synchronous kernel excluding unavoidable Effect runtime/fiber
+  objects and the final result. Enumeration tests must remain bounded by explicit fixture/result limits.
+
+If the synchronous budget cannot be met, do not ship a duplicated slow kernel or silently loosen the budget. First move
+checkpoint checks outward, reduce allocations, or specialize the no-op driver. If that still fails, keep the synchronous
+kernel unchanged and defer that Effect variant until a resumable design meets both parity and overhead requirements.
+
+## Dependencies and ownership
+
+- **Plans 02 and 03 are required:** plan 02 owns benchmark foundations and seeded fixtures; plan 03 owns dense snapshots,
+  ordered arc iteration, and the shared no-op checkpoint/resumable driver. This plan must not create alternate graph
+  snapshots or fixture systems.
+- **Plan 05 is required:** it owns traversal/path semantics, lazy simple paths/cycles, all-pairs choices, and path
+  ordering. Plan 03 owns shared path reconstruction. Effect variants adapt those kernels after stabilization.
+- **Plan 06 is required for DAG/connectivity candidates:** it owns dominators and decides whether any finalized multi-phase
+  connectivity kernel is eligible. Most linear connectivity APIs remain outside this plan.
+- **Plan 07 is required:** it owns flow, min-cut, matching, isomorphism, and optimization semantics, validation, and kernels.
+- **Plan 08 is required:** it owns centrality, ranking, community, convergence, seeded behavior, and generator algorithms.
+- **Plan 09 is required:** consume any final expensive algorithm kernels and consolidated benchmark decisions it introduces;
+  interruption remains last in the dependency order and must not force premature API choices upstream.
+
+Work that can proceed independently is limited to the candidate inventory, naming/type design, generic driver prototype,
+test harness design, and performance thresholds. Public exports and domain kernel migrations wait for their owning plans.
+
+## Completion criteria
+
+- Every shipped Effect variant is genuinely interruptible during expensive work and yields cooperatively.
+- Existing synchronous signatures, results, errors, ordering, and performance budgets remain intact.
+- Both adapters use one deterministic kernel; no `AbortSignal` code or duplicate algorithm exists.
+- Typed `GraphError` failures and fiber interruption are observably distinct.
+- Tests prove multi-slice parity, deterministic interruption, scheduler fairness, and bounded checkpoint overhead.
+- Documentation explains when not to use an Effect variant, and all additive public APIs have JSDoc, type coverage, and an
+  `effect` changeset.

--- a/docs/graph-plans/11-dot-mermaid-documentation.md
+++ b/docs/graph-plans/11-dot-mermaid-documentation.md
@@ -1,0 +1,361 @@
+# DOT, Mermaid, and Graph Documentation Plan
+
+## Objective
+
+Harden the existing `Graph.toGraphViz` and `Graph.toMermaid` emitters without changing their default graph semantics,
+then add only the small amount of output control that the `Graph` model can represent faithfully. Consolidate the
+module's user documentation after the shared graph semantics and algorithm surface have stabilized.
+
+Success means:
+
+- existing calls and data-first/data-last signatures continue to work;
+- default output remains byte-for-byte stable except where a regression test proves that the current text is invalid,
+  ambiguous, or permits statement injection;
+- nodes and edges are emitted in stable public index/insertion order, including sparse indexes after deletion;
+- labels and optional identifiers cannot escape their DOT or Mermaid syntactic context;
+- self-loops and every parallel edge remain separate statements;
+- both emitters remain synchronous, dependency-free at runtime, and `O(V + E + output size)` apart from user callbacks;
+- the Graph guide states semantics, lifecycle, complexity, and algorithm-selection guidance in one maintained place.
+
+## Current Baseline
+
+`packages/effect/src/Graph.ts` currently provides:
+
+- `GraphVizOptions<N, E>` with `nodeLabel`, `edgeLabel`, and `graphName`;
+- `toGraphViz`, which always quotes numeric node indexes and the graph name, escapes backslashes, quotes, and line
+  breaks, and emits nodes followed by edges in `Map` iteration order;
+- `MermaidOptions<N, E>` with `nodeLabel`, `edgeLabel`, `diagramType`, `direction`, and `nodeShape`;
+- `toMermaid`, which uses numeric node indexes, supports eight legacy flowchart shapes, and entity-escapes a selected
+  set of label characters;
+- tests for empty, directed, undirected, custom-label, shape, direction, self-loop, parallel-edge, and basic escaping
+  cases.
+
+The baseline has useful properties that must not be lost: automatic numeric indexes are deterministic, the emitters
+do not inspect user data beyond calling configured functions, and parallel edges are not deduplicated. The tests rely
+too heavily on `toContain`, however, and do not establish complete ordering or injection safety. Mermaid escaping also
+needs an explicit conservative syntax contract rather than an expanding list of characters inferred from examples.
+
+Lessons to adopt from `.repos/graph` are limited to canonical ordering, DOT reserved-word and newline handling,
+Mermaid exact syntax fixtures, mutation-stable edge ordering, and explicit support limitations. Its parsers, format
+preservation bags, hierarchy, ports, layout adapters, visual fields, click handlers, directives, and non-flowchart
+Mermaid dialects do not fit Effect's graph model or this plan.
+
+## Compatibility Contracts
+
+### Ordering and snapshots
+
+- Emit the header first, nodes in ascending stable insertion/index order, then edges in ascending stable
+  insertion/index order, followed by the closing DOT brace. This is the current `Map` order and is intentionally not a
+  semantic sort by label, endpoint, or user-provided identifier.
+- Deletion leaves sparse indexes and does not renumber output. Adding after deletion uses the next monotonic index.
+- A mutable graph is observed synchronously at the instant `toGraphViz` or `toMermaid` is called. Callbacks must not
+  mutate it; document that such re-entrant mutation has unspecified results rather than copying the full graph.
+- Replace partial output assertions with exact multiline assertions or focused inline snapshots. Avoid external
+  snapshot files for these small strings so format changes are visible in review.
+- Attribute maps, when enabled, use a documented canonical key order independent of JavaScript object insertion order.
+
+### Labels and identifiers
+
+- Keep `nodeLabel` and `edgeLabel` as literal-text callbacks. They never opt into DOT HTML labels, Mermaid markdown
+  strings, directives, styles, links, or raw syntax.
+- Keep automatic node identifiers based on `NodeIndex`; labels never become identifiers. Edge statements continue to
+  reference the emitted identifier map, not labels.
+- Custom node identifiers are additive and must be unique. DOT can quote any supported identifier text. Mermaid custom
+  identifiers must either be encoded into a documented safe identifier or rejected; never interpolate an unchecked
+  identifier. Prefer deterministic encoding plus collision detection so arbitrary application IDs remain usable.
+- Empty labels retain current behavior: DOT emits `label=""`; Mermaid emits an unlabeled edge and an explicitly empty
+  quoted node label. Any change to this distinction requires a regression test because Mermaid currently uses label
+  emptiness to select edge syntax.
+
+### Parallel edges, self-loops, and strict DOT
+
+- Emit one edge statement per `EdgeIndex`, including identical endpoint/label pairs and self-loops.
+- Do not add a `strict` DOT option. `strict graph` and `strict digraph` collapse multiedges in Graphviz and therefore
+  contradict Effect Graph's first-class parallel-edge semantics.
+- Mermaid may visually overlap parallel edges, but the source must retain every statement in edge-index order. The
+  guide must distinguish source fidelity from renderer geometry.
+- Do not coalesce, reverse, canonicalize endpoints, or otherwise rewrite undirected parallel edges.
+
+### Subgraphs
+
+Effect Graph has no compound-node or parent relation. Consequently, this plan does not infer subgraphs from node data
+or topology and does not add nested subgraphs, subgraph endpoints, cluster edges, or hierarchy APIs.
+
+Even a one-level output group introduces hierarchy-like grouping semantics that are outside this initiative's
+no-hierarchy scope and differ across DOT and Mermaid. `GraphOutputGroup` and `nodeGroup` are deferred by default and are
+not part of any implementation phase. Reconsider them only in a separate proposal with a concrete use case and
+cross-format contract; emitter hardening and documentation must not reserve these names.
+
+## Additive API Shape
+
+Preserve both existing overloads of `toGraphViz` and `toMermaid`. Extend the option interfaces rather than adding new
+top-level emitters or a generic format abstraction.
+
+```ts
+export type GraphVizAttributeValue = string | number | boolean
+
+export type GraphVizAttributes = Readonly<Record<string, GraphVizAttributeValue>>
+
+export interface GraphVizOptions<N, E> {
+  readonly nodeLabel?: (data: N) => string
+  readonly edgeLabel?: (data: E) => string
+  readonly graphName?: string
+  readonly nodeId?: (data: N, index: NodeIndex) => string
+  readonly graphAttributes?: GraphVizAttributes
+  readonly nodeAttributes?: (data: N, index: NodeIndex) => GraphVizAttributes
+  readonly edgeAttributes?: (data: E, index: EdgeIndex, edge: Edge<E>) => GraphVizAttributes
+  readonly indent?: string
+  readonly lineSeparator?: "\n" | "\r\n"
+}
+
+export interface MermaidOptions<N, E> {
+  readonly nodeLabel?: (data: N) => string
+  readonly edgeLabel?: (data: E) => string
+  readonly diagramType?: MermaidDiagramType
+  readonly direction?: MermaidDirection
+  readonly nodeShape?: (data: N) => MermaidNodeShape
+  readonly nodeId?: (data: N, index: NodeIndex) => string
+  readonly indent?: string
+  readonly lineSeparator?: "\n" | "\r\n"
+}
+```
+
+Signature decisions:
+
+- Retain the existing one-argument label and shape callbacks to avoid subtly changing their public contract. New
+  callbacks receive indexes explicitly.
+- Default `indent` remains two spaces and default `lineSeparator` remains `"\n"`, preserving current output.
+- Attribute values are always emitted as escaped quoted DOT strings. Numbers and booleans are converted to their
+  canonical string forms; no raw/HTML value escape hatch is provided.
+- Quote/escape DOT attribute keys as DOT identifiers, sort them lexically, and reserve `label`. The generated label
+  wins over a conflicting callback attribute, with the conflict documented and preferably rejected for new options.
+- `graphAttributes` emits graph attributes only. Do not add node/edge default bags because defaults introduce ordering
+  and override semantics not represented by Effect Graph.
+- Mermaid does not receive arbitrary attributes. Its style, class, click, directive, and initialization syntaxes have
+  renderer and security semantics beyond literal graph emission.
+- Treat `diagramType` as an existing syntax override, not as a conversion of graph kind. Preserve it for compatibility
+  while documenting that overriding it can intentionally render a directed graph with line syntax or an undirected
+  graph with arrows.
+
+Mermaid v11 edge IDs are a conditional follow-up, not part of the initial signature. Add an `edgeId` callback and an
+explicit syntax-version option only if exact deterministic fixtures establish one stable syntax that preserves parallel
+edges. Do not expose a guessed version union or emit v11-only syntax under existing defaults.
+
+## Escaping and Security
+
+### DOT
+
+Create context-specific internal formatters rather than one general replacement function:
+
+- quoted identifier: graph names, custom node IDs, and attribute keys when not safely bare;
+- quoted literal string: labels and every attribute value;
+- statement assembly: fixed keywords, operators, delimiters, indentation, and line separators only.
+
+Escape backslash before quote, normalize CRLF/CR/LF to DOT `\n`, and cover other control characters according to the
+Graphviz DOT quoted-string grammar. Never accept HTML-like labels or raw attribute fragments. Validate custom-ID
+uniqueness before emitting edges. Regression fixtures must include DOT keywords, quotes, backslashes, all newline
+forms, NUL/C0 controls where Graphviz has defined behavior, Unicode, very long labels, and payloads containing `];`,
+`}`, `->`, `--`, comments, and new graph statements.
+
+### Mermaid
+
+Choose a documented conservative flowchart baseline from the syntax contract represented by exact fixtures. Centralize
+escaping for quoted node labels and pipe-delimited edge labels, accounting for replacement order so
+newly generated entities are not escaped again. Cover quotes, hashes, ampersands, semicolons, pipes, brackets, braces,
+parentheses, backslashes, CR/LF variants, Unicode, Mermaid comments (`%%`), directives (`%%{...}%%`), `end`, shape
+delimiters, arrows, and HTML-like text.
+
+The output is safe diagram source, not sanitized HTML. Document that consumers remain responsible for configuring
+their Mermaid renderer's security level and sanitizing the renderer's generated HTML/SVG. The emitter must not create
+click handlers, links, raw HTML, initialization directives, style directives, or JavaScript URLs.
+
+For both formats, test malicious strings in graph names, node labels, edge labels, IDs, and DOT attribute keys/values.
+Assertions must prove that payload text remains inside one syntactic value and cannot add a
+node, edge, attribute statement, directive, subgraph, or closing delimiter.
+
+## Mermaid Syntax Policy
+
+- Do not claim parser-version conformance because parser dependencies and parser-backed tests are out of scope.
+- Keep default output in the conservative flowchart subset represented by exact fixtures: `graph`/`flowchart` headers, the five
+  directions already exposed, current legacy node-shape delimiters, and `-->`/`---` edges with quoted labels.
+- Use exact deterministic strings and syntactic containment assertions for escaping and injection cases. Do not add DOT,
+  Graphviz, or Mermaid parser dependencies to tests or production.
+- Put newer syntax behind an explicit additive option only when it provides a concrete capability and has separately
+  reviewed fixtures.
+
+## Performance Plan
+
+- Keep a single pass to collect/validate optional custom node IDs, one pass over nodes, and one pass over edges.
+- Use an array of complete lines and one final `join`; do not repeatedly concatenate the complete output.
+- Do not build a dense graph snapshot, adjacency traversal, or semantic sort for emission.
+- Call each configured node callback once per node and each edge callback once per edge. Cache callback results needed
+  for both declarations and endpoints.
+- Bound additional memory to `O(V + output size)` when custom IDs are used and `O(output size)` otherwise.
+- Add focused emitter benchmarks for empty, sparse-index, long-label, and large sparse/dense graphs. Measure default
+  and fully configured output separately. The benchmark gate should catch superlinear growth but should not publish
+  machine-specific timing promises in JSDoc.
+
+## Consolidated Graph User Documentation
+
+Add a maintained Graph guide in the package documentation location selected by the documentation maintainers, with
+`packages/effect/GRAPH.md` as the preferred analogue to `SCHEMA.md`. Link it from the package's documentation index and
+keep API JSDoc focused on individual functions rather than duplicating the guide.
+
+The guide must include:
+
+- the directed/undirected model, opaque stable `NodeIndex`/`EdgeIndex` identifiers, insertion ordering, sparse indexes,
+  and lookup/error conventions;
+- unique-neighbor versus incident-edge semantics, directed and undirected degree rules, self-loops, and parallel-edge
+  behavior;
+- construction and the scoped mutation lifecycle: `directed`/`undirected`, `mutate`, manual
+  `beginMutation`/`endMutation`, structural copying, invalid finalized handles, and why callbacks are synchronous;
+- iteration, queries, transforms, and the distinction between node walkers and edge-preserving APIs;
+- an audited complexity table for construction, mutation, lookup, traversal, connectivity, path, optimization,
+  analytics, and DOT/Mermaid emission. State assumptions and use `V`, `E`, and result-size terms; do not infer
+  complexity from function names;
+- an algorithm-choice guide covering BFS versus DFS, Dijkstra versus Bellman-Ford versus Floyd-Warshall versus A*,
+  directed versus undirected connectivity, DAG/topological operations, and when parallel edges or negative weights
+  affect the choice;
+- DOT and Mermaid examples, option behavior, deterministic ordering, escaping/security boundaries, renderer-version
+  policy, and the fact that emission does not perform layout;
+- a persistence section that links to the separate Graph Schema/persistence plan rather than defining an ad hoc JSON
+  representation here;
+- a benchmark section that links to reproducible benchmark source and checked-in/public CI results. Publish fixture
+  sizes, graph density, runtime, hardware/CI runner, date, command, and commit. Clearly separate measurements from
+  asymptotic guarantees and refresh results when algorithm kernels change materially.
+
+AI documentation examples, if Graph is added to `ai-docs/src`, should be short real-world slices that link to this
+guide. Run `pnpm ai-docgen` rather than editing generated `LLMS.md` files.
+
+## Phases
+
+### Phase 1: Contract fixtures and compatibility probes
+
+1. Convert current DOT and Mermaid happy-path tests to exact deterministic output assertions.
+2. Add fixtures for sparse indexes, callback invocation order, self-loops, directed and undirected parallel edges,
+   empty labels, and mutable snapshots.
+3. Add adversarial escaping/injection tables for every interpolated context.
+4. Assert exact complete outputs and syntactic containment for every adversarial payload. Do not claim external parser
+   conformance from these fixtures.
+
+Verification: targeted `packages/effect/test/Graph.test.ts` tests fail for each demonstrated escaping defect and pass
+for the unchanged baseline snapshots.
+
+### Phase 2: Minimal emitter hardening
+
+1. Split DOT and Mermaid escaping by syntactic context.
+2. Fix only defects demonstrated in Phase 1 while retaining default headers, indentation, ordering, and delimiters.
+3. Preserve one statement per edge and ensure all endpoints use the validated node-ID table.
+4. Update emitter JSDoc to state literal-label, ordering, complexity, security, and renderer compatibility contracts.
+
+Verification: targeted exact-output unit tests, `pnpm lint-fix`, `pnpm check`, and
+`pnpm doctest --run packages/effect/src/Graph.ts`.
+
+### Phase 3: Focused additive options
+
+1. Add custom node IDs, indentation, and line-separator options to both emitters.
+2. Add canonical graph/node/edge DOT attributes with typed values and no raw fragments.
+3. Add type tests for both overload styles, callback inference, readonly attributes, and invalid option values.
+4. Keep output groups deferred under the no-hierarchy scope.
+5. Evaluate Mermaid v11 edge IDs separately. They must be opt-in and version-explicit if accepted.
+
+Verification: `pnpm test-types Graph`, targeted exact-output Graph unit tests, doctests, `pnpm lint-fix`, and
+`pnpm check`.
+
+### Phase 4: Performance and publication
+
+1. Add representative emitter benchmarks using shared seeded graph fixtures from the verification/benchmark plan.
+2. Confirm linear scaling and callback counts; optimize only measured regressions.
+3. Publish reproducible results in the location linked by the Graph guide, including environment metadata.
+
+Verification: benchmark command documented with its seed and fixture sizes; results reproducible in CI or the
+repository's standard benchmark environment.
+
+### Phase 5: Consolidated documentation
+
+1. Audit final semantics and actual implementations from all completed Graph plans.
+2. Write the guide, complexity table, algorithm-choice guide, mutation lifecycle, multiedge/self-loop discussion,
+   persistence link, emitter compatibility contract, and benchmark publication section.
+3. Replace repetitive emitter JSDoc examples with a small progression of deterministic runnable examples and links to
+   the guide.
+4. Regenerate documentation artifacts through their generators.
+
+Verification: `pnpm lint`, targeted doctests for changed source files, `pnpm ai-docgen` if applicable, link checking,
+and review of generated diffs.
+
+## Tests and Doctests
+
+Required unit coverage in `packages/effect/test/Graph.test.ts`:
+
+- exact empty and populated output for both graph kinds;
+- stable node/edge ordering before and after deletion/addition;
+- all supported Mermaid shapes and directions against the documented syntax fixtures;
+- custom labels, IDs, DOT attributes, indentation, and line separators in data-first and data-last use;
+- duplicate custom IDs;
+- empty, whitespace-only, multiline, Unicode, control-character, and long labels;
+- separate directed/undirected self-loop and parallel-edge fixtures;
+- table-driven structural injection payloads for every output context;
+- callback count and invocation order on immutable and mutable graphs;
+- large fixture sanity tests that assert size/line counts without storing huge snapshots.
+
+Required type coverage in `packages/effect/typetest/Graph.tst.ts`:
+
+- generic inference for new node/edge attribute callbacks;
+- preservation of graph kind and mutable/immutable acceptance in both overload styles;
+- readonly attribute maps and the closed `lineSeparator` union;
+- no accidental widening of existing label/shape callback parameters.
+
+Runnable JSDoc examples should demonstrate one default export and one additive customization per format, with exact
+semantic string/line assertions. Keep security matrices and large outputs in unit tests, not JSDoc.
+
+## Changesets
+
+- Escaping changes that alter emitted runtime text require an `effect` patch changeset describing the invalid-output or
+  injection bug and the affected characters.
+- New exported option fields/types are additive public API and require an `effect` minor changeset unless maintainers
+  choose the repository's patch policy for additive APIs.
+- Documentation-only consolidation, benchmark-result refreshes, and test-only exact-output infrastructure do not need a
+  changeset.
+- Keep hardening and additive options in separate changesets when they can ship independently.
+
+## Dependencies and Ownership
+
+Required before implementation:
+
+- the correctness-contract plan must fix shared ordering, self-loop, parallel-edge, and lookup semantics;
+- the verification/benchmark foundation must own seeded fixtures, benchmark harness conventions, and publication
+  metadata;
+- the Schema/persistence plan must own serialized snapshots, hydration, index preservation, and the guide's persistence
+  target.
+
+Can proceed independently after correctness contracts:
+
+- emitter escaping fixtures and hardening;
+- Mermaid syntax fixtures;
+- additive output-only options that use public node/edge iteration;
+- emitter microbenchmarks.
+
+Must wait for the wider Graph program:
+
+- the final complexity table and algorithm-choice guide, because they must describe implemented kernels rather than
+  planned APIs;
+- published benchmark comparisons across algorithms;
+- final cross-links to Schema persistence and Effect-native interruption documentation.
+
+This plan does not own shared dense snapshots, arc iterators, algorithm validation, path reconstruction, interruption,
+or persistence internals. The emitters should not depend on those facilities.
+
+## Explicit Non-Goals
+
+- DOT or Mermaid parsers, round-trip converters, or syntax-preservation bags.
+- Any output format other than existing DOT and Mermaid flowchart/graph syntax.
+- Layout engines, rendering, SVG/HTML generation, rank calculation, routing, or visual geometry such as coordinates,
+  dimensions, splines, colors derived from geometry, and label positions.
+- Ports, compass points, record endpoints, HTML labels, hierarchy, compound nodes, nested subgraphs, cluster-edge
+  semantics, or subgraph endpoints.
+- Mermaid sequence, state, class, ER, mindmap, block, Ishikawa, timeline, or other diagram dialects.
+- Raw statements, raw attributes, directives, click handlers, links, scripts, styles, themes, or renderer
+  initialization blocks.
+- Strict DOT, edge deduplication, multiedge coalescing, or endpoint canonicalization.
+- A generic formatter/plugin abstraction, streaming API, asynchronous emitter, or custom user-defined format.
+- Persistence or JSON serialization beyond linking to the separate Schema plan.

--- a/docs/graph-plans/12-master-roadmap.md
+++ b/docs/graph-plans/12-master-roadmap.md
@@ -1,0 +1,231 @@
+# Graph Master Roadmap
+
+## Authority and status
+
+This roadmap is the binding coordination document for plans 01-11. Domain plans remain the detailed implementation
+specifications; when wording conflicts, this roadmap wins. Public names and release levels marked for maintainer approval
+are not commitments until approved.
+
+### Implementation checkpoint: 2026-08-16
+
+The delivery-status column below records roadmap disposition, not implementation completion. Current source includes
+`Schema.Graph` / `Graph.fromSnapshot` (`189b003a23`) and a broad CSR traversal optimization (`a371754b1e`). The latter
+implemented iterator-time CSR snapshots, mutation invalidation, stack-safe DFS/BFS/postorder, typed/head-index queues in
+major traversal paths, and partial compact-edge predecessor state. Still open are radius validation, defensive `start`
+copying, DFS first-root priority, directed-neighbor deduplication, the last mutable `shift`/`unshift` loops, stable public
+`EdgeIndex` reconstruction, and all public plan-05 `Path` APIs.
+
+The operational PR order and current port inventory are maintained in the
+[current execution plan](./13-current-execution-plan.md). The concrete pull-request split and merge lanes are maintained
+in the [PR delivery plan](./14-pr-delivery-plan.md).
+
+The current baseline is `packages/effect/src/Graph.ts`: it owns automatic numeric identifiers, the legacy three-field
+`PathResult`, algorithms, walkers, and the `toGraphViz` / `toMermaid` emitters. Derived dense traversal state lives in
+`packages/effect/src/internal/graphCsr.ts`; Schema snapshot coordination lives in `packages/effect/src/Schema.ts` and
+`packages/effect/src/internal/graph.ts`.
+
+Detailed contracts live in [plan 01's Desired contracts](./01-correctness-contracts.md#desired-contracts),
+[plan 02's Shared Seeded Fixtures](./02-verification-benchmarks.md#shared-seeded-fixtures),
+[plan 03's Target internal architecture](./03-internal-architecture-performance.md#target-internal-architecture), and
+each domain plan's Dependencies and Ownership section. Reference code is evidence, not API authority: relevant starting
+points include `.repos/graph/src/queries.ts`, `.repos/graph/src/algorithms/paths.ts`,
+`.repos/graph/src/algorithms/traversal.ts`, `.repos/graph/src/generators.ts`, and `.repos/graph/bench/compare/`.
+
+## Binding scope and semantics
+
+- Preserve every existing public signature and valid runtime shape. Correct behavior only where plan 01 has a focused
+  regression test; all new capability is additive.
+- Support only uniformly `"directed"` and `"undirected"` graphs. Do not add mixed/bidirectional edge kinds.
+- Keep automatic monotonic numeric `NodeIndex` and `EdgeIndex`; no caller-supplied IDs, reuse, or public dense positions.
+- Equality and hashing compare active indexed structure and payloads, not allocator history. `MAX_SAFE_INTEGER` is a valid
+  final allocated index; subsequent allocation fails atomically with `GraphError`.
+- Preserve stable index/insertion order, sparse active indexes, parallel edges, self-loops, scoped mutation, and shallow
+  copied public edge envelopes. Do not use freeze, proxies, or property descriptors.
+- Neighbor-node queries are unique. Incident/algorithm arc queries preserve edge occurrences. Directed loops contribute
+  one in and one out incidence; undirected loops contribute degree two but one logical edge.
+- Existing synchronous APIs stay synchronous. Effect variants are additive, benchmark-admitted, and use internal
+  resumable checkpoints only. No public checkpoint, progress callback, or `AbortSignal` leaks kernel mechanics.
+- Weighted algorithms on mutable inputs use one structural snapshot for an in-flight call; callback mutation affects
+  later calls. Payloads remain shallow references.
+- `PathResult<E>` remains exactly `{ path, distance, costs }`. Plan 05 owns additive `Path` / `WeightedPath` values;
+  existing shortest-path overloads do not gain `includeEdges` or optional edge fields.
+- Plan 04's `isConnected` is undirected-only. Plan 06 owns directed-only `isWeaklyConnected` and
+  `isStronglyConnected`; no directed `isConnected` alias or overlapping overload is allowed.
+- Output is DOT and Mermaid only. No layout, rendering, hierarchy, custom formatter/plugin, parser, or plain JSON graph
+  API. Emitter tests use exact strings without parser dependencies. Output groups are deferred as hierarchy-like scope;
+  Mermaid edge IDs remain separately gated.
+- `Schema.Graph` is separate. Its encoded/internal Schema snapshot contains only `type`, indexed nodes, and indexed
+  edges. It has no wire `version`, `nextNodeIndex`, or `nextEdgeIndex`; decode derives each allocator high-water mark as
+  `max(active index) + 1`, zero, or an internal exhausted state after `MAX_SAFE_INTEGER`. In-memory operation snapshots
+  may retain allocators when exact future allocation must survive a transform, but that state never enters the Schema encoding.
+- Every plan consumes plan 02's neutral fixture corpus and adapters and plan 03's ordered-arc, dense snapshot, numeric
+  policy, predecessor/path reconstruction, and checkpoint kernels. No domain-local replacement is allowed.
+
+See also [plan 05's Public Models](./05-traversal-paths.md#public-models),
+[plan 10's Decisions](./10-effect-native-interruption.md#decisions), and
+[plan 11's Explicit Non-Goals](./11-dot-mermaid-documentation.md#explicit-non-goals).
+
+## Plan index
+
+| Plan | Owner | Roadmap disposition |
+| --- | --- | --- |
+| [01](./01-correctness-contracts.md) | Existing API contracts and regression fixes | Committed foundation |
+| [02](./02-verification-benchmarks.md) | Neutral fixtures, properties, oracles, probes, runtimeperf | Committed foundation |
+| [03](./03-internal-architecture-performance.md) | Shared private kernels and measured internal optimization | CSR substantially landed; hardening/measurement and remaining kernels committed; COW gated |
+| [04](./04-core-queries-transforms.md) | Core queries, undirected predicates, subgraphs | Committed additive core, names subject to API review |
+| [05](./05-traversal-paths.md) | Public edge-aware paths and enumeration | `Path` foundation approved but not implemented; enumeration/visits/bidirectional work gated |
+| [06](./06-connectivity-dag-algorithms.md) | Explicit connectivity, cuts, condensation, DAG analyses | Committed structural set; expensive reduction/dominance land separately |
+| [07](./07-optimization-algorithms.md) | MST, Euler, matching, flow/cut | MST/forest active after prerequisites; all other families parked |
+| [08](./08-analytics.md) | Centrality, PageRank, core decomposition | Adopted set committed after kernels; all “Later” entries remain gated |
+| [09](./09-generators.md) | Public standard/random constructors | Committed small set after plan 02; network models deferred |
+| [10](./10-effect-native-interruption.md) | Effect drivers and admitted Effect variants | Last, benchmark-gated |
+| [11](./11-dot-mermaid-documentation.md) | Emitter hardening and consolidated guide | Hardening/docs committed; additive options individually gated |
+
+## Public API ownership
+
+| Public surface | Sole owner | Binding disposition |
+| --- | --- | --- |
+| Existing constructors, mutation, walkers, neighbors, algorithms, `PathResult`, emitters | Plan 01 contracts; original implementation remains | Non-breaking; regression fixes only |
+| Incident/in/out edges, edges-between, degree variants, `hasPath`, undirected `isConnected`/`isTree`, induced subgraphs | Plan 04 | Additive committed set; explicit edge-selected subgraphs remain internal |
+| `Path`, `WeightedPath`, path utilities, tied/simple/alternative paths, cycles, optional visits | Plan 05 | Path model/utilities first; enumerators and visits require per-group API gate |
+| Directed weak/strong connectivity, cuts, biconnected blocks, condensation, transitive reduction, dominators | Plan 06 | Explicit names only; no plan-04 aliases |
+| Spanning forest/tree | Plan 07 | Active after shared edge identity, numeric policy, verification, and API review |
+| Euler trails, matching, flow/cut | Plan 07 | Parked; require a new demand decision and one review/changeset per family |
+| Degree/closeness/betweenness centrality, PageRank, core numbers/k-core | Plan 08 | Adopted analytics set; stage independently |
+| HITS/eigenvector/Katz, coloring, isomorphism, Louvain, planarity | Plan 08 | Deferred; reserve no exports |
+| Complete/path/cycle/grid/tree and Effect-random graph constructors | Plan 09 | Small committed constructor set; automatic IDs only |
+| Effect-suffixed variants | Plan 10 | Only for benchmark-admitted finalized sync APIs |
+| DOT/Mermaid option additions and Graph guide | Plan 11 | No new format; groups deferred |
+| `Schema.Graph` codec and `EncodedGraph` | Separate Schema work | Exact minimal encoded shape; not owned by this roadmap |
+
+## Internal helper ownership
+
+| Helper/kernel | Owner | Consumers |
+| --- | --- | --- |
+| Neutral `GraphSpec`, seeded PRNG, fixtures, fingerprints, oracle/runtimeperf adapters | Plan 02 | Every plan |
+| Probe vocabulary and deterministic bounds | Plan 02 | Plans 03-10 |
+| Canonical storage/lifecycle and ordered outgoing/incoming/direction-ignored arc cursor | Plan 03 | Plans 01 and 04-10 |
+| Sparse-to-dense translation, optional CSR/bitsets, queue, stable heap | Plan 03 | Plans 05-10 when measured |
+| Numeric accessor evaluation and named weight/capacity policies | Plan 03 | Plans 01, 05, 07, 08 |
+| Edge-index predecessor records and shared path reconstruction/projection | Plan 03 | Existing paths and plan 05; plan 01 tests compatibility |
+| No-op checkpoint, resumable step protocol, synchronous driver, test probe seam | Plan 03 | Domain kernels; plan 10 supplies Effect driver |
+| Selected-structure copier preserving active indexes and in-memory allocators | Plan 03 | Plans 04 and 06; distinct from Schema snapshot |
+| Internal Schema snapshot/hydrator registration | Separate Schema work with plan 03 seam | Schema only; derives allocators from active indexes |
+| Algorithm-specific state (low-link, flow residuals, analytics scratch, generators) | Owning domain plan | Must build on plan 03, not fork it |
+
+## Dependency DAG
+
+```text
+01 contracts
+  -> 02 fixtures/oracles/benchmarks
+      -> 03 shared kernels
+          -> 04 core queries/transforms
+          -> 05 path model and traversal/path kernels
+              -> 06 connectivity/DAG (also depends on 04)
+                  -> 07 optimization (also depends on 05)
+                  -> 08 analytics (also depends on 05)
+          -> 09 public generators (fixture ownership remains in 02)
+
+03 + finalized admitted domain kernels -> 10 Effect-native interruption
+01 + 02 -> 11 emitter hardening
+final implemented surface + separate Schema.Graph -> 11 consolidated guide
+```
+
+Plan 11 emitter hardening may run after plans 01-02 without waiting for algorithms. Schema work may land independently
+through the existing seam. Plan 06 cycle enumeration dependency points to plan 05; plan 05 may consume plan 06 SCC only
+as an optimization, never as a correctness cycle.
+
+## Implementation waves
+
+Each slice is one reviewable PR unless it is tests/docs-only and naturally smaller.
+
+| Wave | PR-sized slice | Exit |
+| --- | --- | --- |
+| 0 | Plan 01 contract regressions and exact legacy path/emitter baselines | Targeted runtime/type tests pin compatibility |
+| 1A | Plan 02 neutral corpus + Effect adapter + fingerprints | Identical seed/spec replay; rich/simple domains explicit |
+| 1B | Property/differential tests and deterministic complexity probes | Hand oracle checks precede seeded comparisons |
+| 1C | Runtimeperf Graph registry and validated baseline cases | Reproducible base/head artifact; no timing CI gate |
+| 2A | Finish Plan 03 FIFO/reconstruction linearity after the landed traversal rewrite | No remaining `shift`/`unshift` hot loops; exact output parity and stack tests |
+| 2B | Harden landed CSR/ordered arcs; complete stable predecessor edge identity and numeric policies | No duplicate arc/path/weight helper remains |
+| 2C | Mutation finalization ownership and module seams | Retained handles safe; no public diff |
+| 2D | Dense/CSR, typed heap, or COW one experiment at a time | Ship only at each plan-03 benchmark/memory crossover |
+| 3A | Plan 04 local edge/degree queries and boundary walkers | Multigraph/mutable/type contracts pass |
+| 3B | Plan 04 subgraphs and structural predicates | Active indexes and in-memory allocators preserved |
+| 4A | Plan 05 `Path`/`WeightedPath`, utilities, internal legacy projection | Existing `PathResult` objects remain exact |
+| 4B | One path enumeration family per PR | Laziness and bounded small-graph oracle pass |
+| 5A | Plan 06 explicit connectivity and low-link cuts | No overlap with plan 04; iterative/edge-aware |
+| 5B | Condensation, transitive reduction, and dominators separately | Reachability/order/stack and memory gates pass |
+| 6A | Plan 09 deterministic constructors | Formulas, ordering, automatic IDs, validation pass |
+| 6B | Plan 09 Effect-random constructors | Seeded `Random` tests and neutral-spec adaptation pass |
+| 7A | Plan 08 degree/core analytics | Linear scaling and oracle pass |
+| 7B | Closeness/betweenness, then PageRank in separate PRs | Numeric/convergence/oracle/bundle gates pass |
+| 8 | Each approved plan-07 optimization family independently | Demand, API, oracle, bundle, benchmark gate per family |
+| 9A | Plan 11 emitter exact fixtures and injection hardening | Default compatibility except demonstrated fixes |
+| 9B | Approved emitter options, then consolidated guide | DOT/Mermaid only; no hierarchy/layout/custom format |
+| 10 | Plan 10 driver, one pilot, then admitted Effect families | Multi-slice parity, interruption, fairness, overhead pass |
+
+## Gating and exit criteria
+
+- A wave cannot consume an unlanded helper by cloning it locally. It waits, or lands the minimal helper in the owning
+  plan first.
+- Additive APIs require approved names, complete JSDoc/type/runtime tests, and a focused changeset. “Optional,” “Later,”
+  and prototype sections are not implementation authorization.
+- Existing behavior changes require a plan-01 regression proving a contract bug and a compatibility note.
+- Dense/CSR, COW, typed heaps, bidirectional Dijkstra, specialist algorithms, and Effect variants ship only when their
+  plan's benchmark, memory, parity, and bundle gates pass. Failed experiments are removed, not retained dormant.
+- Lazy APIs must prove zero/one/`k` consumption does not materialize all results. Every unbounded kernel is stack-safe.
+- Cross-library oracles are admitted only after hand-checked semantic equivalence; Effect multigraph identity/order
+  remains locally asserted.
+- Completion means no competing fixture, arc, dense, numeric, reconstruction, checkpoint, connectivity alias, or wire
+  representation exists.
+
+## Changeset strategy
+
+- Tests, benchmarks, internal refactors, and docs-only changes need no changeset.
+- Contract bug fixes that alter runtime behavior use a focused `effect` patch changeset and call out compatibility.
+- Additive public API groups receive one changeset per independently releasable PR. Keep them separate from bug fixes.
+- Emitter escaping fixes and emitter options use separate changesets.
+- The exact patch/minor level for additive APIs during the current release line requires maintainer approval; domain-plan
+  references to patch or minor are provisional. Never combine deferred/rejected names into release notes.
+- `Schema.Graph` changesets belong to the separate Schema implementation, not these graph-domain PRs.
+
+## Validation matrix
+
+| Change | Required validation |
+| --- | --- |
+| Documentation plans only | `pnpm lint-fix`; `git diff --check` |
+| Graph runtime code | `pnpm lint-fix`; targeted `pnpm --filter effect test --run test/<file>`; `pnpm check` |
+| Public types/API | Runtime checks above; `pnpm test-types Graph.tst.ts` |
+| Graph JSDoc examples | `pnpm lint`; `pnpm doctest --run packages/effect/src/Graph.ts` |
+| Schema coordination code | Targeted `test/schema/Graph.test.ts`; Schema type tests as applicable; `pnpm check` |
+| Property/differential/complexity | Only the affected `GraphProperty`, `GraphDifferential`, or `GraphComplexity` file |
+| Runtimeperf infrastructure | Targeted runtimeperf node tests plus selected validated Graph scenarios |
+| Performance-sensitive kernel | Same seeded base/head runtimeperf cases; memory mode where required; no wall-clock unit gate |
+| Module split/bundle-sensitive API | `pnpm circular`; `pnpm bundle-compare <base-ref>` and inspect `tmp/bundle-stats.txt` |
+
+Never run bare `pnpm test` or bare `pnpm doctest`.
+
+## Deferred and rejected
+
+Deferred pending a separate gate: traversal visits, all-pairs edge-aware output, bidirectional Dijkstra, COW/CSR/typed
+heap experiments without measured crossover, plan-07 Euler/matching/flow families, Watts-Strogatz and Barabasi-Albert public
+generators, Mermaid edge IDs, and all plan-08 “Later” analytics (HITS, eigenvector, Katz, greedy coloring, isomorphism,
+Louvain, boolean planarity).
+
+Rejected for this initiative: mixed/bidirectional edge kinds, caller IDs, index reuse, freeze/proxy/descriptors, public
+kernel/CSR/cache APIs, public checkpoints/progress/AbortSignal, alternate fixture systems, Schema wire version/allocator
+state, plain JSON graph models, layouts/rendering, custom formats/plugins, hierarchy/output groups, DOT/Mermaid parsers,
+strict DOT, label propagation, Girvan-Newman, naive greedy modularity, approximate TSP, and Steiner tree. See plan 08's
+Portfolio Decision and Explicit Rejections, plan 09's Non-Goals, and plan 11's Explicit Non-Goals.
+
+## Maintainer approval required
+
+- Final names and grouping for every new public API, especially plan 04 queries, plan 05 path models/enumerators, and
+  plan 06 result models.
+- Whether additive exports use patch or minor changesets on the active release line.
+- Final MST/forest public names and bundle budget. Other plan-07 families require a new demand decision before API review.
+- Whether adopted plan-08 analytics should all live in `effect/Graph` or a future opt-in surface.
+- Which plan-10 candidates cross the admission threshold after final synchronous benchmarks.
+- Which plan-11 additive identifier/attribute options are worth their security and compatibility surface; output groups
+  are not included in this decision because they are deferred by binding scope.
+- The final Graph guide location and benchmark-publication policy.

--- a/docs/graph-plans/13-current-execution-plan.md
+++ b/docs/graph-plans/13-current-execution-plan.md
@@ -1,0 +1,370 @@
+# Current Graph Execution Plan
+
+## Purpose
+
+This document translates the domain plans into work that can be implemented from the current `main` baseline after:
+
+- `e811353e3b`: detached public edge envelopes and finite A* heuristics;
+- `189b003a23`: `Graph.Snapshot`, `Graph.fromSnapshot`, and `Schema.Graph`;
+- `a371754b1e`: CSR-backed traversal and algorithm optimization.
+
+The [master roadmap](./12-master-roadmap.md) remains authoritative for shared semantics and ownership. This document owns
+current implementation status and PR order. A domain plan saying that work is "committed" means approved roadmap scope,
+not that its API already exists.
+
+`MixedGraph` and a visual/interchange graph representation are separate design proposals. They are not hidden
+prerequisites for this execution plan.
+
+## Current State
+
+### Implemented foundations
+
+- Immutable and scoped-mutable directed/undirected graphs with stable numeric indexes.
+- Snapshot/Schema round-tripping of active indexed topology.
+- CSR compact-node translation with lazy outgoing/incoming adjacency and mutation invalidation.
+- Iterator-time traversal snapshots: active iterators are mutation-isolated and fresh iterators see current state.
+- Stack-safe CSR DFS, BFS, postorder, topo, cycle/component/SCC, and substantial immutable weighted-path machinery.
+- Head-index or typed FIFO queues in the main traversal paths.
+- Compact predecessor edge positions in immutable Dijkstra, A*, and Bellman-Ford.
+- DOT and Mermaid legacy emitters.
+
+### Not implemented by the traversal work
+
+- The Plan 02 fixture/property/differential/complexity/runtimeperf foundation.
+- Stable compact-position to public `EdgeIndex` projection and one edge-aware ordered-arc contract.
+- Any Plan 04 public query or subgraph export.
+- Any Plan 05 public `Path`, path utility, or path-enumeration export.
+- Any new Plan 06 connectivity/DAG export.
+- Plan 07 optimization families, Plan 08 analytics, or Plan 09 generators.
+- Effect-native algorithm variants, emitter hardening options, or the consolidated Graph guide.
+
+## Track A: Stabilize Existing APIs
+
+These PRs precede additive public APIs. Keep behavior fixes separate from internal performance changes so each changeset
+states exactly what became observable.
+
+### A0. Correct hash tests and settle equality semantics
+
+Classification: tests/docs plus an approved compatibility-sensitive runtime correction.
+
+- Remove tests asserting that unequal graphs must have different hashes. Require only equality implying equal hash.
+- Document Effect's immutability requirement after hashing transitively contained payloads.
+- Remove allocator history from structural `Equal` / `Hash`. Active indexed structure and payloads determine equality,
+  matching the information preserved by `Schema.Graph`.
+
+Exit: law-correct tests cover graph kind, sparse indexes, undirected endpoint reversal, loops, and parallel edges.
+
+Changeset: none unless runtime equality/hash changes.
+
+### A1. Traversal inputs and root ordering
+
+Classification: confirmed contract bugs.
+
+- Add one validator shared by `neighborhood`, `dfs`, `bfs`, and `dfsPostOrder`.
+- Accept omitted radius, `Infinity`, `-0`, and non-negative integers. Reject `NaN`, `-Infinity`, negatives, and fractions.
+- Validate and copy `start` when constructing a walker.
+- Revalidate copied starts against every fresh iterator's CSR snapshot. A removed start throws the documented
+  missing-node `GraphError`; it never enters compact storage as `undefined`.
+- Make DFS prioritize the first distinct supplied root, matching BFS and postorder. Ignore duplicate roots after their
+  first occurrence.
+- Preserve the documented finite-radius postorder membership pass.
+
+Tests: invalid-radius matrix, empty starts, data-first/data-last, caller mutation of `start`, start removal between walker
+and iterator creation, active iterator isolation, repeated fresh iteration, and disconnected multi-root order.
+
+Changeset: `effect` patch identifying invalid-radius rejection and DFS multi-root ordering as compatibility-sensitive.
+
+### A2. Unique directed neighbor queries
+
+Classification: confirmed bug under the binding unique-neighbor contract.
+
+- Deduplicate only public `neighbors`, `successors`, `predecessors`, and deprecated `neighborsDirected` collection.
+- Preserve first edge occurrence order in cold canonical and warm CSR paths.
+- Do not deduplicate algorithm arcs, topo in-degree, parallel edges, or future degree/incident-edge operations.
+
+Tests: outgoing/incoming parallel edges, loops, reciprocal edges, mutable/cold/warm inputs, and weighted/topo regression
+fixtures proving physical edge multiplicity remains intact.
+
+Changeset: `effect` patch.
+
+### A3. Allocator exhaustion
+
+Classification: confirmed bug with approved boundary contract.
+
+Contract: `Number.MAX_SAFE_INTEGER` is a valid existing or newly allocated index, but the next allocation
+throws a stable `GraphError` before changing maps or adjacency. Never expose an unsafe integer or overwrite an entry due
+to floating-point saturation.
+
+Tests: snapshots ending at `MAX_SAFE_INTEGER - 1` and `MAX_SAFE_INTEGER`, node and edge exhaustion, no partial writes,
+error precedence, ordinary sparse allocation, and Schema decoding.
+
+Changeset: `effect` patch.
+
+### A4. Scoped mutation error precedence
+
+Classification: confirmed bug for lifecycle misuse.
+
+- Preserve the callback's original error when cleanup also discovers manual finalization.
+- Manual finalization followed by normal callback return continues to produce a lifecycle `GraphError`.
+- Ordinary callback failure still finalizes an active handle, and retained handles reject later mutation.
+- Keep direct `endMutation` single-use.
+
+Tests: double finalization; manual finalization plus normal return; manual finalization plus sentinel throw; constructor and
+`mutate` forms; retained-handle query/mutation behavior.
+
+Changeset: `effect` patch.
+
+### A5. Undirected self-loop invariant hardening
+
+Classification: internal risk, not yet a demonstrated additional public bug.
+
+- Add a test-only invariant checker for canonical adjacency and CSR projections.
+- Cover parallel loops, loop-bearing node removal, hydration, remove/re-add, cycle, bipartite, traversal, and weighted
+  behavior.
+- Do not normalize the private duplicate-incidence layout merely for aesthetics. Change it only if a regression proves
+  stale or over-counted public behavior, or if the ordered-arc kernel requires a simpler representation.
+- Preserve one logical edge, one edge enumeration, one neighbor, one traversal step, and graph-theoretic degree two.
+
+Changeset: none for tests/internal parity; patch only for demonstrated runtime correction.
+
+### A6. Finish linear queues and reconstruction
+
+Classification: internal performance parity.
+
+- Replace remaining mutable `isBipartite` and mutable Bellman-Ford `shift()` loops with head cursors.
+- Replace mutable Bellman-Ford `unshift()` reconstruction with append-and-reverse.
+- Preserve exact immutable/mutable ordering, selected costs, and errors.
+
+Changeset: none if observable output is identical.
+
+### A7. Stable CSR edge identity
+
+Classification: internal prerequisite for Plans 04-07.
+
+- Add compact-position to public-`EdgeIndex` projection without storing sparse public IDs in typed arrays.
+- Add incoming adjacency with edge identity.
+- Define one internal ordered arc operation for outgoing, incoming, and direction-ignored traversal.
+- Unify mutable and immutable predecessor records around stable edge identity.
+- Continue projecting legacy `{ path, distance, costs }` exactly; do not add fields to `PathResult`.
+
+Tests: sparse edge IDs including values above 32-bit range, equal-data parallel edges, self-loops, undirected stored
+orientation, immutable/mutable parity, and exact legacy result shape.
+
+Changeset: none until an additive Plan 05 API exposes edge identity.
+
+### A8. Mutable weighted callback semantics
+
+Classification: approved contract correction.
+
+Contract: Dijkstra, A*, and Bellman-Ford on a mutable graph capture one structural snapshot before invoking
+user cost/heuristic callbacks. Reentrant structural mutation affects later calls, not the in-flight result. Payloads remain
+shallow references and callback exceptions propagate unchanged.
+
+Land only after A7 lets mutable and immutable algorithms share identity-preserving reconstruction. Benchmark the added
+snapshot cost separately.
+
+Changeset: `effect` patch if this contract is adopted.
+
+### A9. Emitter defect probes
+
+Classification: handoff to Plan 11.
+
+- Add exact output and adversarial context fixtures for DOT and Mermaid.
+- Use exact output and syntactic-containment assertions only. Do not add parser dependencies or claim external parser
+  conformance.
+- Change escaping only after a fixture demonstrates invalid output or statement injection.
+- Keep escaping fixes separate from additive emitter options.
+
+Changeset: one focused patch per demonstrated runtime-text correction.
+
+## Track B: Shared Verification And Kernel Foundation
+
+No remaining Stately-derived domain may create its own fixture generator, dense representation, edge projection, numeric
+policy, or checkpoint mechanism.
+
+### B1. Neutral graph corpus
+
+- Add deterministic `GraphSpec` fixtures for chains, grids, stars, layered DAGs, dense graphs, loops, parallel edges,
+  sparse indexes, and mutation churn.
+- Add the Effect adapter, stable fingerprints, fixed seeds, and exact validity/order tests.
+
+### B2. Properties and differential tests
+
+- Add bounded seeded algebraic/model tests for existing Graph behavior.
+- Add Graphology only with the first hand-checked differential suite; reject unsupported multigraph semantics rather than
+  coercing them.
+- Add deterministic operation-count probes for complexity regressions.
+
+### B3. Graph runtimeperf
+
+- Generalize Schema-specific runtimeperf metadata before registering Graph.
+- Establish validated Effect-only build, traversal, mutation, path, and emitter baselines.
+- Add competitor adapters, retained-memory modes, and publication only after the Effect suite is stable.
+
+### B4. Shared algorithm policies
+
+- Extract named weight/capacity validation policies and the deterministic heap where reuse is demonstrated.
+- Add the no-op synchronous checkpoint/resumable-step seam only for kernels that can later justify Effect-native variants.
+- Retain the landed CSR; do not introduce a competing dense snapshot.
+
+## Track C: Port The Adopted Core
+
+Each bullet is a separate reviewable public-API PR unless grouped explicitly.
+
+### C1. Local edge and degree queries
+
+Add:
+
+- `incidentEdges`, `inEdges`, `outEdges`, `edgesBetween`;
+- `degree`, `inDegree`, `outDegree`.
+
+Do not add `sources` or `sinks`; existing `externals` already provides that capability. This first public tranche proves
+the A7 ordered-arc and self-loop contracts before more complex algorithms depend on them.
+
+### C2. Basic structural predicates
+
+Add `hasPath`, undirected `isConnected`, and undirected `isTree`, reusing CSR reachability and existing acyclicity.
+
+### C3. Index-preserving subgraphs
+
+- Add an internal selected-structure copier preserving active indexes and in-memory allocator state.
+- Expose `inducedSubgraph`.
+- Expose explicit edge-selected `subgraph` only when Yen, transitive reduction, or another concrete consumer demonstrates
+  public demand; otherwise keep the copier private.
+
+### C4. Deterministic standard generators
+
+Add `complete`, `path`, `cycle`, `grid`, and `tree`. They require no random service and provide reusable examples and
+verification fixtures. Preserve automatic IDs and deterministic edge order.
+
+### C5. Directed connectivity
+
+Add `weaklyConnectedComponents`, `isWeaklyConnected`, and `isStronglyConnected`. Pin exact existing component/SCC order
+before sharing their kernels.
+
+### C6. Undirected cut structure
+
+Add one iterative edge-aware low-link kernel and expose `bridges`, `articulationPoints`, and
+`biconnectedComponents` with an edge-identifying result model.
+
+### C7. Condensation and DAG transforms
+
+- Add `condensationGraph` after SCC ordering is stable.
+- Add `transitiveReduction` separately, with explicit DAG validation and bounded-memory strategy.
+- Add `dominatorTree` in an independent PR; it is not a prerequisite for paths or reduction.
+
+## Track D: Edge-Aware Paths
+
+Keep the initial surface smaller than the original Plan 05 proposal.
+
+### D1. Minimal path model
+
+Add:
+
+- `Path` with node and stable edge-index sequences;
+- `isValidPath`;
+- `pathFromEdges`.
+
+Keep legacy `PathResult` unchanged. Keep `pathToResult` internal. Do not add trivial `pathNodes` / `pathEdges` accessors,
+generic sequence helpers, or eager `collect*` aliases.
+
+### D2. Path enumeration series
+
+Land separately, in this order:
+
+1. `shortestPaths` for all tied shortest paths;
+2. lazy bounded `simplePaths`;
+3. `shortestSimplePaths` using Yen or a justified alternative;
+4. elementary `cycles`.
+
+Every iterable must have fresh state, stable edge-identity ordering, bounded early-abandonment tests, and an exhaustive
+small-graph oracle. `Array.from(...)` is the eager form; do not export redundant collectors.
+
+Traversal visits and bidirectional Dijkstra remain benchmark/use-case gated.
+
+## Track E: Analytics, Random Generators, And Optimization
+
+### Adopted analytics order
+
+1. Degree centralities after C1.
+2. `coreNumbers` / `kCore`.
+3. PageRank after numeric and checkpoint contracts.
+4. Closeness after reusable single-source kernels.
+5. Betweenness after tied-predecessor infrastructure.
+
+Each family requires independent oracle, scaling, numeric, bundle, and API-placement review.
+
+### Adopted random generators
+
+After B1/B2 establish random ownership:
+
+1. `erdosRenyi` and random DAG generation;
+2. `connectedRandom` separately because exact terminating sampling is more complex.
+
+Run a bundle comparison before importing `Effect` / `Random` into `Graph.ts`. Watts-Strogatz and Barabasi-Albert remain
+internal benchmark fixtures unless concrete public uses justify an exact model contract.
+
+### Approval-gated optimization families
+
+These are not automatic Stately-parity work:
+
+1. Minimum spanning forest/tree;
+2. Eulerian path/circuit;
+3. Maximum flow/minimum cut;
+4. Maximum bipartite matching.
+
+Each requires maintainer demand, API approval, independent properties/oracles, and bundle/performance evidence. Do not
+combine families in one PR.
+
+### Parked specialist analytics
+
+Keep HITS, eigenvector, Katz, coloring, isomorphism, Louvain, and planarity outside active implementation waves until a
+consumer and bundle budget are approved. Continue rejecting label propagation, Girvan-Newman, naive greedy modularity,
+approximate TSP, and Steiner tree for this initiative.
+
+## Track F: Final Layers
+
+### Emitter hardening and options
+
+After A9, fix only demonstrated DOT/Mermaid defects. Indentation, line separators, custom IDs, attributes, and Mermaid
+edge IDs remain individually gated. Do not add formats, parsers, output hierarchy, or layout.
+
+### Effect-native variants
+
+Plan 10 remains last. Add a shared driver and one expensive pilot only after its synchronous kernel is finalized and
+benchmarks show meaningful interruption/fairness need. Do not add Effect wrappers for symmetry.
+
+### Consolidated Graph guide
+
+Write the guide against shipped APIs and measured behavior: topology semantics, mutation lifecycle, snapshots/Schema,
+parallel edges and loops, algorithm selection, complexity, output security, and benchmark methodology.
+
+## Recorded Decisions
+
+1. Equality/hash ignore allocator history and compare active indexed structure and payloads.
+2. `MAX_SAFE_INTEGER` is allocatable once; subsequent allocation fails atomically.
+3. Mutable weighted callbacks receive structural snapshot isolation.
+4. Emitter tests use exact strings only and add no parser dependencies.
+5. Only `inducedSubgraph` is initially public; explicit edge selection remains internal.
+6. MST/forest is active; Euler, flow/cut, and matching remain parked.
+7. Deterministic and random generators live in `Graph`; random generators are Effect-returning and use `Random`.
+
+## Validation Per PR
+
+Use only affected targets:
+
+```sh
+pnpm lint-fix
+pnpm --filter effect test --run test/Graph.test.ts
+pnpm test-types Graph.tst.ts
+pnpm check
+```
+
+Add `GraphProperty`, `GraphDifferential`, `GraphComplexity`, runtimeperf, doctest, circular, or bundle commands only when
+the corresponding PR changes those surfaces. Never run bare `pnpm test` or bare `pnpm doctest`.
+
+## Immediate Sequence
+
+Start with A0 through A4, which are small contract-focused PRs and do not depend on speculative APIs. Then land A5-A7
+and B1-B3 in parallel where ownership does not overlap. C1 is the first additive public port and should not begin until A7
+provides stable edge identity and B1 supplies shared multigraph fixtures.

--- a/docs/graph-plans/14-pr-delivery-plan.md
+++ b/docs/graph-plans/14-pr-delivery-plan.md
@@ -1,0 +1,648 @@
+# Graph PR Delivery Plan
+
+## Delivery Principles
+
+This plan turns the [current execution plan](./13-current-execution-plan.md) into independently reviewable pull
+requests. It covers approved work only. Parked algorithms and unapproved emitter options are listed as later gates, not
+hidden inside active PRs.
+
+Rules:
+
+1. One observable correction or one additive API family per PR. Never mix a bug fix with new exports.
+2. A PR may depend on at most one unmerged predecessor. Prefer landing the prerequisite and rebasing onto `main`.
+3. Shared helpers land through their owner before consumers; consumers wait rather than clone them.
+4. Parallel development is encouraged, but merges touching `Graph.ts`, `Graph.tst.ts`, or the same test section are
+   serialized through a merge queue.
+5. Every public PR includes runtime tests, type tests, JSDoc, a bounded doctest example, and one focused changeset.
+6. Every performance claim has a validated baseline before implementation. No wall-clock unit-test assertions.
+7. Failed experiments are removed. Do not retain dormant kernels, feature flags, or reserved exports.
+
+Current execution note: benchmark/runtimeperf work is deferred. Skip B01, B02, V04, K05, F01-F03, emitter benchmark
+work, and all benchmark commands for now. During this cycle K06 follows K04 directly. The PR definitions remain below so
+the deferred work is not lost, but delivery agents must use the scoped instructions in
+[`15-agent-execution-prompt.md`](./15-agent-execution-prompt.md).
+
+## Dependency Overview
+
+```text
+Wave 0: existing behavior
+  S01 -> S02 -> S03
+  S04 -> S05
+  S06 -> S07 -> S08
+
+Wave 1: shared foundations
+  V01 -> V02 -> V03
+  K01 -> K02 -> K03 -> K04 -> K05 -> K06
+  V01 + K02 -> V04
+  B01 -> B02
+  E01 -> E02/E03
+
+Foundation checkpoint R1: S01-S07 + V01 + K01-K03
+
+Wave 2: additive core lanes
+  Q01 -> Q02 -> Q03
+  Q04 -> C04
+  G01 -> G02 -> R01 -> R02
+  C01 -> C03
+  Q01 -> C02
+  C01 -> C05
+
+Wave 3: edge-aware and analytical lanes
+  K03 -> P01 -> P02 -> P03 -> P04 -> P05 -> P06
+  Q02 -> A01/A02
+  K04 -> A03
+  P01 -> A04a -> A04b
+  P02 + A04a -> A05
+  P01 + K04 -> M01
+
+Wave 4: optional final layers
+  B02 + finalized expensive kernel -> F01 -> F02 -> F03
+  shipped surface -> D01
+```
+
+The arrows express semantic dependencies. They do not require every lane to wait for unrelated work.
+
+## Wave 0: Stabilize Existing Behavior
+
+### S01. Correct Graph hash-law tests
+
+Scope: tests and narrowly related documentation only.
+
+- Remove assertions that unequal graphs must have different hashes.
+- Add table-driven equality-implies-equal-hash coverage for kinds, sparse indexes, undirected endpoint reversal,
+  self-loops, parallel edges, and undefined payloads.
+- Do not change runtime equality or hashing.
+
+Changeset: none.
+
+### S02. Ignore allocator history in equality and hashing
+
+Depends on S01.
+
+- Remove allocator counters from immutable structural equality/hash.
+- Preserve stable active indexes, payload equality, edge identity, undirected endpoint symmetry, and mutable reference
+  equality/hash.
+- Add equal pairs with identical active structure and different removed trailing allocation history.
+- Document Effect's immutability expectation after transitively contained values are hashed.
+
+Changeset: focused `effect` patch describing the compatibility-sensitive equality correction.
+
+### S03. Make index exhaustion atomic
+
+Depends on S02 because both alter allocator semantics and `internal/graph.ts`.
+
+- Permit `Number.MAX_SAFE_INTEGER` as the final allocated node or edge index.
+- Represent subsequent allocator state internally as exhausted.
+- Throw before changing maps, adjacency, caches, or cycle metadata.
+- Decode snapshots ending at the maximum into exhausted state.
+- Pin endpoint-validation versus edge-exhaustion error precedence.
+
+Tests cover `MAX_SAFE_INTEGER - 1`, the final successful allocation, repeated failure, no partial writes, and
+`Schema.Graph` hydration.
+
+Changeset: focused `effect` patch.
+
+### S04. Stabilize traversal configuration
+
+Can develop alongside S01-S03; serialize its merge because `Graph.ts` is a hotspot.
+
+- Share radius validation across `neighborhood`, DFS, BFS, and postorder.
+- Copy starts after eager validation and revalidate them for each fresh iterator snapshot.
+- Make DFS honor first distinct root priority.
+- Preserve active iterator snapshot isolation and bounded-postorder membership behavior.
+
+Tests cover the complete invalid-radius matrix, empty starts, data-first/data-last calls, caller array mutation, start
+removal between walker/iterator creation, active/fresh mutable iteration, duplicates, and disconnected root order.
+
+Changeset: one `effect` patch describing invalid-radius rejection and DFS ordering.
+
+### S05. Deduplicate directed neighbor-node queries
+
+Depends on S04 for a clean traversal/order baseline.
+
+- Deduplicate only `neighbors`, `successors`, `predecessors`, and deprecated `neighborsDirected`.
+- Preserve first edge occurrence order in canonical and warmed CSR paths.
+- Preserve every physical edge for topo, weighted algorithms, degree, and edge walkers.
+
+Changeset: focused `effect` patch.
+
+### S06. Fix scoped mutation error precedence
+
+- Preserve the callback's original error when cleanup also detects manual finalization.
+- Keep direct `endMutation` single-use.
+- Manual finalization followed by normal callback return still raises the lifecycle error.
+- Cover constructors, `mutate`, retained handles, and all post-finalization mutation entry points.
+
+Changeset: focused `effect` patch.
+
+### S07. Pin undirected self-loop invariants
+
+Depends on S06. Tests first; change production storage only for a demonstrated failure.
+
+- Add a test-local adjacency/CSR invariant checker.
+- Cover parallel loops, loop-bearing node removal, hydration, remove/re-add, traversal, cycles, bipartiteness, and
+  weighted paths.
+- Preserve one logical edge/enumeration/neighbor/traversal step and graph-theoretic degree two.
+
+Changeset: none unless tests demonstrate a runtime correction.
+
+### S08. Finish mutable FIFO and reconstruction linearity
+
+Depends on S07 for parity fixtures.
+
+- Replace the remaining mutable `isBipartite` and Bellman-Ford `shift()` queues with head cursors.
+- Replace mutable Bellman-Ford `unshift()` reconstruction with append-and-reverse.
+- Do not change predecessor representation or adjacency access.
+
+Changeset: none.
+
+## Wave 1: Shared Verification And Kernel Foundation
+
+These lanes intentionally separate test infrastructure, graph internals, performance infrastructure, and emitter
+fixtures.
+
+### Verification Lane
+
+#### V01. Add the neutral seeded Graph corpus
+
+Can begin immediately in parallel with Wave 0.
+
+- Add `GraphSpec`, fixed PRNG output, named shape/size fixtures, fingerprints, and the Effect adapter.
+- Include chains, stars, grids, layered DAGs, dense graphs, loops, parallel edges, disconnected graphs, and sparse-index
+  mutation churn.
+- Preserve exact insertion order and ordinal-to-public-index mappings.
+
+Changeset: none.
+
+#### V02. Add local algebraic and model properties
+
+Depends on V01 and the relevant Wave 0 fixes.
+
+- Add `GraphProperty.test.ts` for reverse/identity laws, source immutability, mutation-model equivalence, allocation,
+  unique neighbors, edge occurrence preservation, traversal, paths, loops, and parallel edges.
+- Use fixed replayable seeds and bounded shrinking.
+
+Changeset: none.
+
+#### V03. Add Graphology differential verification
+
+Depends on V02.
+
+- Add the dev-only oracle dependency and adapter in the same PR.
+- Hand-check every admitted semantic domain before seeded comparisons.
+- Compare semantic normal forms only; reject unsupported multigraph cases instead of coercing them.
+
+Changeset: none.
+
+#### V04. Add deterministic complexity probes
+
+Depends on V01 and K02.
+
+- Instrument separate test entry points for node discovery, arc examination, queue pushes, relaxations, path
+  materialization, and snapshot builds. Checkpoint counts join this suite only when F02 introduces the seam.
+- Add `GraphComplexity.test.ts` with `n`, `2n`, and `4n` deterministic bounds.
+- Keep ordinary production hot paths free of optional per-arc test branches.
+
+Changeset: none.
+
+### Kernel Lane
+
+#### K01. Add stable public edge-ID projection to CSR
+
+Depends on S07.
+
+- Add compact-position to public-`EdgeIndex` projection.
+- Add incoming CSR with edge identity.
+- Keep compact positions in typed arrays and sparse public IDs in JavaScript arrays.
+- Test IDs above 32-bit range, loops, parallel edges, cache reuse, and mutation invalidation.
+
+Changeset: none.
+
+#### K02. Add the ordered-arc kernel
+
+Depends on K01.
+
+- Support outgoing, incoming, and direction-ignored traversal with early exit.
+- Retain source, target, stable edge ID, authored direction, and multiplicity.
+- Emit an undirected self-loop once as a traversal arc; retain parallel and reciprocal edges.
+- Add direct internal contract tests before migrating consumers.
+
+Changeset: none.
+
+#### K03. Unify stable predecessor records and reconstruction
+
+Depends on K02 and S08.
+
+- Use stable edge identity in mutable and immutable Dijkstra, A*, and Bellman-Ford predecessor state.
+- Share append-and-reverse reconstruction.
+- Continue returning exactly legacy `{ path, distance, costs }` objects.
+- Cover sparse/large edge IDs and equal-data parallel edges.
+
+Changeset: none.
+
+#### K04. Extract shared numeric policies
+
+Depends on K03.
+
+- Extract only policies consumed by current shortest paths and the approved MST/PageRank work.
+- Preserve graph-global validation order and callback exception identity.
+
+Changeset: none if behavior is identical.
+
+#### K05. Extract the deterministic shared heap
+
+Depends on K04 and B02.
+
+- Share the current stable heap across Dijkstra/A* without changing insertion-sequence ties or stale-entry behavior.
+- Do not add decrease-key, typed heaps, or new public selectors.
+- Compare exact equal-priority paths and weighted runtimeperf before/after.
+
+Changeset: none.
+
+#### K06. Give mutable weighted algorithms snapshot isolation
+
+Depends on K05 by merge order, though it consumes K03/K04 semantics.
+
+- Capture complete topology and required projections before invoking cost/heuristic callbacks.
+- Callback structural mutation affects later calls only; payloads remain shallow references.
+- Cover add/remove/finalize mutations from callbacks, callback errors, ordinary parity, and snapshot overhead.
+
+Changeset: focused `effect` patch.
+
+### Runtimeperf Lane
+
+#### B01. Generalize runtimeperf for non-Schema suites
+
+Can develop alongside V01.
+
+- Remove Schema-specific registry/report assumptions.
+- Prove complete fixture-directory materialization into base/head worktrees.
+- Do not add Graph benchmark cases yet.
+
+Changeset: none.
+
+#### B02. Register validated Effect-only Graph baselines
+
+Depends on V01 and B01; merge after Wave 0 for meaningful baselines.
+
+- Add build, lookup, CSR cold/warm, traversal, mutation, weighted path, and emitter cases.
+- Validate before and after timing and return semantic checksums.
+- Keep competitor adapters, retained-memory workers, and publication out of this PR.
+
+Changeset: none.
+
+### Emitter Fixture Lane
+
+#### E01. Convert emitters to exact contract fixtures
+
+Can run alongside kernel work; merge after S07.
+
+- Replace partial substring tests with exact DOT/Mermaid outputs.
+- Cover sparse order, callbacks, mutable call-time state, labels, loops, parallel edges, and adversarial containment.
+- Add no parser dependencies and change no output.
+
+Changeset: none.
+
+#### E02. Fix demonstrated DOT defects
+
+Depends on E01. Include only failing DOT contexts and exact expected changes.
+
+Changeset: focused `effect` patch if output changes.
+
+#### E03. Fix demonstrated Mermaid defects
+
+Depends on E01. Keep separate from E02 and all additive options.
+
+Changeset: focused `effect` patch if output changes.
+
+## Release Checkpoint R1: Additive Core Ready
+
+Required before the first new public Graph API:
+
+- S01-S07 merged.
+- V01 shared corpus available.
+- K01-K03 stable edge identity, arcs, and reconstruction merged.
+- No competing fixture, dense, edge projection, arc, or path reconstruction helper exists.
+
+S08, V02/V03, B02, and emitter work continue independently and block only consumers that need them.
+
+## Wave 2: Additive Core APIs
+
+Use dedicated runtime files such as `GraphQueries.test.ts`, `GraphGenerators.test.ts`, and
+`GraphConnectivity.test.ts` to reduce conflicts. Public declarations remain in `Graph.ts`.
+
+### Query Lane
+
+#### Q01. Add edge walkers
+
+Add `incidentEdges`, `inEdges`, `outEdges`, and `edgesBetween` over K02.
+
+Changeset: one additive `effect` changeset.
+
+#### Q02. Add degree queries
+
+Depends on Q01 contracts. Add `degree`, `inDegree`, and `outDegree`, including loop/parallel semantics and missing-node
+zero behavior.
+
+Changeset: one additive changeset.
+
+#### Q03. Add structural predicates
+
+Depends on Q01. Add `hasPath`, undirected `isConnected`, and undirected `isTree`.
+
+Changeset: one additive changeset.
+
+#### Q04. Add index-preserving induced subgraphs
+
+Can run independently after R1.
+
+- Add the private selected-structure copier and public `inducedSubgraph`.
+- Preserve active indexes, kind, order, payloads, allocator state, and source independence.
+- Keep exact edge-selected subgraphs private.
+
+Changeset: one additive changeset.
+
+### Generator Lane
+
+#### G01. Add complete, path, and cycle generators
+
+Add shared callback/context types only when used by this tranche.
+
+Changeset: one additive changeset.
+
+#### G02. Add grid and tree generators
+
+Depends on G01 conventions. Keep coordinate/rank models in this PR rather than inflating G01.
+
+Changeset: one additive changeset.
+
+#### R01. Add Erdos-Renyi and random DAG generators
+
+Depends on G02 and V01/V02.
+
+- Keep APIs in `Graph` and return Effect values using the existing `Random` service.
+- Verify `Random.withSeed`, draw order/counts, invalid-input no-draw behavior, simple topology, and DAG acyclicity.
+- Run circular and bundle checks because `Graph.ts` gains Effect/Random dependencies.
+
+Changeset: one additive changeset.
+
+#### R02. Add exact-edge connected random generation
+
+Depends on R01 random utilities. Keep separate because terminating no-replacement sampling and dense-complement behavior
+need isolated review.
+
+Changeset: one additive changeset.
+
+### Connectivity Lane
+
+#### C01. Add directed connectivity predicates
+
+Add `weaklyConnectedComponents`, `isWeaklyConnected`, and `isStronglyConnected` after pinning existing component/SCC
+order.
+
+Changeset: one additive changeset.
+
+#### C02. Add bridges, articulation points, and biconnected components
+
+Depends on Q01 and K02. Keep the three exports together because one iterative low-link kernel computes the cohesive
+result and splitting would duplicate temporary machinery.
+
+Changeset: one additive changeset.
+
+#### C03. Add condensation graphs
+
+Depends on C01. Preserve component mapping and crossing edge identity in deterministic order.
+
+Changeset: one additive changeset.
+
+#### C04. Add transitive reduction
+
+Depends on Q04 and existing topo. Keep standalone due to DAG validation, parallel-edge policy, reachability proof, and
+bounded-memory strategy.
+
+Changeset: one additive changeset.
+
+#### C05. Add dominator trees
+
+Depends on C01 ordering contracts. Keep standalone; it is not a prerequisite for other active families.
+
+Changeset: one additive changeset.
+
+## Wave 3: Paths, Analytics, And MST
+
+### Path Lane
+
+This lane merges mostly serially because every PR touches predecessor/arc/path code.
+
+#### P01. Add the minimal `Path` model
+
+Add `Path`, `isValidPath`, and `pathFromEdges`. Keep `PathResult` unchanged and conversion internal.
+
+Changeset: one additive changeset.
+
+#### P02. Add internal tied-predecessor reconstruction
+
+Depends on P01. Add tie storage, zero-weight-cycle guards, deterministic edge-sequence order, laziness probes, and
+small-graph oracles without public exports.
+
+Changeset: none.
+
+#### P03. Add all tied shortest paths
+
+Depends on P02. Add `WeightedPath` and `shortestPaths` only. Do not add an eager collector.
+
+Changeset: one additive changeset.
+
+#### P04. Add bounded simple paths
+
+Depends on P03 by delivery order, though it reuses only P01/K02 technically. Add stack-safe lazy `simplePaths` with
+bounds and early-abandonment tests.
+
+Changeset: one additive changeset.
+
+#### P05. Add shortest simple alternatives
+
+Depends on P04. Add `shortestSimplePaths` using Yen or a separately justified algorithm, with candidate identity,
+banned-view reuse, deterministic ordering, and exhaustive small-graph `k` checks.
+
+Changeset: one additive changeset.
+
+#### P06. Add elementary cycle enumeration
+
+Depends on P01 and lands after P05 to serialize source churn. Add lazy `cycles` with directed rotation and undirected
+rotation/reversal canonicalization, loops, parallel two-cycles, bounds, and exhaustive oracles.
+
+Changeset: one additive changeset.
+
+### Analytics Lane
+
+#### A01. Add degree centrality
+
+Depends on Q02. Add degree, in-degree, and out-degree centrality together.
+
+Changeset: one additive changeset.
+
+#### A02. Add core decomposition
+
+Depends on Q01/Q02. Add `coreNumbers` and `kCore` with a peeling oracle and linear-work probe.
+
+Changeset: one additive changeset.
+
+#### A03. Add PageRank
+
+Depends on K04 and V04. Keep standalone due to numeric/convergence semantics, dangling nodes, weighted parallel edges,
+checkpoint boundaries, and bundle impact.
+
+Changeset: one additive changeset.
+
+#### A04a. Add the reusable all-source distance kernel
+
+Depends on P01/K04. Add no public exports. Prove unweighted/weighted parity, callback evaluation bounds, sparse-index
+behavior, and no per-source CSR rebuilding.
+
+Changeset: none.
+
+#### A04b. Add closeness centrality
+
+Depends on A04a. Add only the public options/result API, directed/disconnected normalization contracts, JSDoc, type tests,
+and oracle comparisons.
+
+Changeset: one additive changeset.
+
+#### A05. Add betweenness centrality
+
+Depends on P02 and A04a's reusable traversal machinery. Keep standalone because Brandes multiplicity, weighted positivity,
+normalization, and multigraph semantics require independent review.
+
+Changeset: one additive changeset.
+
+### Optimization Lane
+
+#### M01. Add minimum spanning forest/tree
+
+Depends on P01 edge identity, K04 numeric policy, and V02/V03.
+
+- Add deterministic Kruskal-based forest and tree APIs only.
+- Cover disconnected/isolated nodes, negative weights, loops, parallel competition, sparse IDs, ties, and exhaustive
+  small-graph optimality.
+- Do not include Eulerian traversal, matching, flow, or cut code.
+
+Changeset: one additive changeset.
+
+## Wave 4: Final And Optional Layers
+
+These tasks do not block synchronous core delivery.
+
+### F01. Measure Effect-native candidates
+
+Depends on B02 and finalized expensive kernels. Produce admission evidence and select one pilot; no source API.
+
+Changeset: none.
+
+### F02. Apply a resumable seam to one pilot kernel
+
+Depends on F01. Add only the minimum internal state/step protocol needed by the pilot and prove synchronous multi-slice
+parity and acceptable overhead.
+
+Changeset: none.
+
+### F03. Add one public Effect-native pilot
+
+Depends on F02. Add the shared Effect driver and exactly one admitted variant with interruption, fairness, parity,
+overhead, bundle, and circular-dependency evidence.
+
+Changeset: one additive changeset.
+
+Every later admitted family is a separate PR. A failed pilot is removed or deferred and does not block Graph delivery.
+
+### D01. Publish the consolidated Graph guide
+
+Depends on the selected release surface being frozen.
+
+- Document only shipped APIs and measured complexity.
+- Cover topology semantics, mutation, snapshots/Schema, loops/parallel edges, algorithm selection, output security,
+  Effect-native behavior where shipped, and reproducible benchmark methodology.
+- Keep API-specific JSDoc in the implementation PRs; this PR consolidates rather than backfills missing documentation.
+
+Changeset: none.
+
+## Gated Follow-Ups
+
+The following require new approval and do not appear in active PR branches:
+
+- Eulerian traversal, maximum flow/minimum cut, and bipartite matching.
+- HITS, eigenvector, Katz, coloring, isomorphism, Louvain, and planarity.
+- Traversal visits and public bidirectional Dijkstra.
+- Public Watts-Strogatz and Barabasi-Albert generators.
+- Emitter indentation, line separators, custom IDs, DOT attributes, and Mermaid edge IDs.
+- Competitor/runtime-memory benchmark extensions and published benchmark tables.
+- COW, typed heaps, or additional dense representations without measured crossover.
+
+Rejected scope remains rejected: mixed/bidirectional graph kinds in this initiative, alternate formats, parsers, layout,
+hierarchy/output groups, public kernels/caches/checkpoints, approximate TSP, and Steiner tree.
+
+## Merge Lanes And Conflict Control
+
+After R1, these lanes may develop concurrently:
+
+1. Queries: Q01 -> Q02/Q03; Q04 independently.
+2. Generators: G01 -> G02 -> R01 -> R02.
+3. Connectivity: C01; C02 after Q01; C03 after C01; C04 after Q04; C05 after C01.
+4. Paths: P01 -> P02 -> P03 -> P04 -> P05 -> P06, merged serially.
+5. Analytics: A01/A02 after queries; A03 after K04; A04a/A04b after P01; A05 after P02/A04a.
+6. Optimization: M01 after P01/K04.
+7. Emitters: E01 -> E02/E03, independent of algorithm expansion.
+
+Logical parallelism does not imply clean Git parallelism. `Graph.ts` and `Graph.tst.ts` remain serialization points. New
+runtime tests should use family files to reduce conflicts, while each public branch rebases after the preceding merged
+Graph API PR.
+
+## Per-PR Validation
+
+Every code PR runs:
+
+```sh
+pnpm lint-fix
+pnpm --filter effect test --run test/<affected-graph-test>.ts
+pnpm check
+```
+
+Add only when affected:
+
+```sh
+pnpm test-types Graph.tst.ts
+pnpm lint
+pnpm doctest --run packages/effect/src/Graph.ts
+pnpm --filter effect test --run test/GraphProperty.test.ts
+pnpm --filter effect test --run test/GraphDifferential.test.ts
+pnpm --filter effect test --run test/GraphComplexity.test.ts
+node --test packages/effect/runtimeperf/test/*.test.mts
+pnpm runtimeperf graph/<scenario>
+pnpm runtimeperf-compare graph/<scenario> --base main --head HEAD
+pnpm circular
+pnpm bundle-compare <base-ref>
+```
+
+Inspect `tmp/bundle-stats.txt` and report non-zero differences. Never run bare `pnpm test` or bare `pnpm doctest`.
+
+## Changeset Policy
+
+- Runtime behavior correction: one focused `effect` patch changeset.
+- Additive public API: one changeset per independently releasable PR; patch/minor follows maintainer release policy.
+- Internal refactor, tests, fixtures, benchmarks, and docs-only work: no changeset.
+- Emitter hardening and emitter options never share a changeset.
+- Schema release notes remain separate from Graph-domain changes.
+
+## Recommended Starting Queue
+
+Open only these branches initially:
+
+1. S01 hash-law tests.
+2. S04 traversal configuration.
+3. S06 mutation error precedence.
+4. V01 neutral corpus.
+5. B01 runtimeperf generalization.
+6. E01 exact emitter fixtures.
+
+They have low semantic overlap and establish six clean review lanes. After S01 merges, begin S02; after S06 merges, begin
+S07; after V01 merges, begin V02. Do not open public feature PRs before R1.

--- a/docs/graph-plans/15-agent-execution-prompt.md
+++ b/docs/graph-plans/15-agent-execution-prompt.md
@@ -1,0 +1,311 @@
+# Graph Delivery Agent Prompt
+
+Use the prompt below to execute one Graph task group and open its pull requests. Replace `<TASK_GROUP>` before starting.
+Recommended usage is one agent invocation per group rather than `all`.
+
+```text
+You are the delivery agent for Effect's Graph improvement program.
+
+Workspace: /Users/fubhy/Projects/effect/effect
+Base branch: main
+Task group: <TASK_GROUP>
+
+Your job is to implement every currently unblocked PR in the selected task group, validate it, commit it on its own
+branch, push it, and open a GitHub pull request. Do not merge PRs.
+
+Read before doing anything:
+
+1. `.agents/AGENTS.md`
+2. Relevant files in `.patterns/`, especially `.patterns/effect.md`, `.patterns/testing.md`, and `.patterns/jsdoc.md`
+3. `docs/graph-plans/README.md`
+4. `docs/graph-plans/12-master-roadmap.md`
+5. `docs/graph-plans/13-current-execution-plan.md`
+6. `docs/graph-plans/14-pr-delivery-plan.md`
+7. The detailed domain plan(s) owning the selected group
+
+Authority order:
+
+1. This execution prompt's temporary exclusions
+2. Plan 14 PR boundaries and dependencies
+3. Plan 13 recorded decisions/current status
+4. Plan 12 binding semantics/ownership
+5. Domain plans for implementation detail
+
+## Temporary exclusions
+
+Do not implement, add, or run benchmark/runtimeperf work in this execution cycle.
+
+Explicitly skip:
+
+- B01 and B02
+- V04 deterministic complexity probes
+- K05 shared-heap extraction, because its acceptance requires a benchmark baseline
+- F01, F02, and F03 Effect-native admission/pilot work
+- emitter benchmark/publication work
+- runtimeperf configuration, cases, reports, memory modes, competitors, or artifacts
+- benchmark scripts, benchmark dependencies, timing assertions, performance thresholds, and bundle-size comparisons
+
+Do not block correctness or public API work merely because its future benchmark follow-up is deferred. Make no
+performance claims. Preserve existing complexity and avoid knowingly introducing an asymptotic regression.
+
+For this cycle, K06 depends directly on K04 after K03; K05 is deferred.
+
+## Selectable task groups
+
+- `stabilization`: S01-S08
+- `verification`: V01-V03
+- `kernel`: K01-K04 and K06; skip K05
+- `emitters`: E01-E03, exact fixtures and demonstrated fixes only
+- `queries`: Q01-Q04
+- `generators`: G01-G02 and R01-R02
+- `connectivity`: C01-C05
+- `paths`: P01-P06
+- `analytics`: A01-A05, including A04a and A04b
+- `mst`: M01
+- `docs`: D01 only when the shipped surface is frozen
+- `all`: all groups above in dependency order; use only when explicitly requested
+
+Parked and rejected items are never implied by `all`. Do not implement Eulerian traversal, flow/cut, matching,
+specialist analytics, MixedGraph, visual/interchange graph models, additional formats, layouts, parser dependencies,
+or unapproved emitter options.
+
+## Recorded decisions
+
+- Equality/hash compare active indexed structure and payloads, not allocator history.
+- `Number.MAX_SAFE_INTEGER` may be allocated once; the next allocation fails atomically.
+- Mutable weighted algorithms use one structural snapshot for each in-flight call.
+- Emitter tests use exact strings and no parser dependencies.
+- Only `inducedSubgraph` is initially public; exact edge-selected subgraphs remain internal.
+- MST/forest is the only active optimization family.
+- Random generators live in `Graph`, return Effect values, and use the existing `Random` service.
+- Legacy `PathResult` remains exactly `{ path, distance, costs }`.
+- Only directed and undirected graph kinds are in scope.
+
+## Execution protocol
+
+### 1. Inspect and classify
+
+- Inspect current `main`, recent Graph commits, current source/tests, and existing open PRs before coding.
+- Use `gh pr list` to avoid duplicating already-open work.
+- Compare the selected PR IDs against current source. Mark each as implemented, partially implemented, unblocked,
+  blocked by an unmerged dependency, or obsolete.
+- Never ask the user for a fact available in source, git history, plans, or GitHub.
+- If a plan conflicts with current implementation, stop that PR and report the exact conflict rather than guessing.
+
+### 2. Preserve the user's worktree
+
+- The shared workspace may be dirty and contains the planning documents. Never reset, clean, stash, or modify unrelated
+  user changes.
+- Prefer a separate git worktree for each PR under the approved temporary directory:
+  `/private/var/folders/3z/2rhdvb1j52x4lrwqf68j3qyc0000gn/T/opencode/graph-prs/<PR_ID>`.
+- Read planning documents from the shared workspace if they are not yet present on the branch.
+- Create branches non-interactively with names such as `graph/s01-hash-laws` or `graph/q01-edge-walkers`.
+- Base an independent PR on `origin/main`.
+- If a PR has an unmerged predecessor and cannot be implemented independently, either stop at that merge gate or create
+  an explicitly stacked branch based on the predecessor branch. Never pretend a stacked PR targets `main` cleanly.
+- Do not amend commits and do not use destructive git commands.
+
+### 3. Implement one PR ID at a time
+
+- Follow Plan 14's exact PR boundary. Do not bundle adjacent IDs for convenience.
+- Start with failing focused tests for behavior fixes and algorithm contracts.
+- Make the smallest implementation that satisfies the approved contract.
+- Reuse current CSR, snapshot, mutation, and Walker machinery; do not create competing representations.
+- Keep shared helpers in the owner specified by Plans 12-14.
+- Add no compatibility layer unless a shipped external contract requires it.
+- Preserve automatic numeric IDs, sparse active indexes, loops, parallel edges, deterministic ordering, scoped mutation,
+  and shallow payload semantics.
+- New lazy iterables use iterator-time snapshot isolation and fresh state per iterator.
+- Do not expose internal dense positions, CSR, caches, checkpoints, or mutable JSON models.
+
+### 4. Public API requirements
+
+For every additive public PR:
+
+- Add runtime tests in a focused family file where practical instead of further enlarging `Graph.test.ts`.
+- Add type tests covering data-first/data-last inference, mutable acceptance, exact graph-kind preservation, and
+  wrong-kind rejection.
+- Add repository-compliant JSDoc with applicability, ordering, loops/parallels, failures, complexity, and mutable
+  snapshot behavior.
+- Add one bounded deterministic runnable example where useful.
+- Use `dual` conventions consistently with existing Graph APIs.
+- Add exactly one focused changeset for the public family. Follow the repository's active additive release-level policy;
+  if it is not inferable from current changesets, use the level approved by maintainers in the plans or stop and report.
+- Run `pnpm codegen` only if modules are added or removed. Never hand-edit generated barrels.
+
+For runtime behavior corrections, add one focused `effect` patch changeset. Tests/internal/docs-only PRs receive no
+changeset unless repository policy requires one.
+
+### 5. Validation
+
+Run the narrowest applicable validation from repository root:
+
+```sh
+pnpm lint-fix
+pnpm --filter effect test --run test/<affected-file>.ts
+pnpm check
+```
+
+Add when applicable:
+
+```sh
+pnpm test-types Graph.tst.ts
+pnpm lint
+pnpm doctest --run packages/effect/src/Graph.ts
+pnpm --filter effect test --run test/GraphProperty.test.ts
+pnpm --filter effect test --run test/GraphDifferential.test.ts
+pnpm circular
+git diff --check
+```
+
+Never run:
+
+- bare `pnpm test`
+- bare `pnpm doctest`
+- `pnpm runtimeperf*`
+- benchmark commands or benchmark test files
+- `pnpm bundle-compare`
+
+If root `pnpm check` is blocked by unrelated workspace diagnostics, run the narrowest package check, capture the exact
+unrelated failure, and report it in the PR. Do not alter unrelated files to make validation pass.
+
+### 6. Commit and open the PR
+
+- Review the final diff for generated files, accidental formatting churn, unrelated changes, and plan-scope drift.
+- Commit only files belonging to the PR ID.
+- Use a concise imperative commit subject.
+- Push the branch and open the PR with `gh pr create`.
+- Do not merge the PR.
+
+PR title format:
+
+`Graph: <concise capability or correction>`
+
+PR body must include:
+
+```md
+## Summary
+
+- <what changed>
+- <important semantic decision>
+
+## Plan
+
+- PR ID: <ID>
+- Depends on: <merged PR/branch or none>
+- Deferred: benchmark/runtimeperf validation is intentionally out of scope for this cycle
+
+## Validation
+
+- `<exact command>`
+- `<exact command>`
+
+## Changeset
+
+- <file and release level, or "Not required">
+```
+
+For stacked PRs, set the actual predecessor branch as the GitHub base and state how it will be retargeted after merge.
+
+### 7. Continue or stop at the merge gate
+
+- After opening a PR, record its URL, branch, base, commit, validation, and dependency status.
+- Continue to the next independent PR in the selected group.
+- Do not create a deep stack merely to finish the group. Stop when the next PR requires an unmerged semantic foundation
+  and report the exact next action after merge.
+- A maximum of two stacked PRs is allowed. Beyond that, stop at the merge gate.
+
+## Group-specific cautions
+
+### Stabilization
+
+- S01 must land before S02; S02 before S03.
+- S04 and S06 can proceed independently.
+- S05 follows S04; S07 follows S06; S08 follows S07.
+- Do not normalize self-loop storage in S07 unless a failing public/invariant test requires it.
+
+### Verification
+
+- V01 adds no production imports.
+- V02 uses only the shared corpus.
+- V03 adds Graphology only with the first hand-checked differential tests.
+- Skip V04 entirely.
+
+### Kernel
+
+- K01-K04 are internal and have no changesets if behavior remains identical.
+- Skip K05.
+- K06 follows K04 and is an observable patch correction.
+- Never leak compact edge positions into public APIs or typed arrays containing sparse public IDs.
+
+### Emitters
+
+- E01 changes tests only.
+- E02 and E03 change output only for defects demonstrated by E01.
+- No parser packages, output options, identifiers, attributes, strict DOT, hierarchy, or other formats.
+
+### Queries
+
+- Q01 proves edge-occurrence semantics before Q02.
+- Do not add `sources` or `sinks`; use existing `externals`.
+- Q04 exposes only `inducedSubgraph`.
+
+### Generators
+
+- G01/G02 stay synchronous.
+- R01/R02 return Effect values and use `Random`; do not add seed options or a private PRNG.
+- Run `pnpm circular` for R01/R02, but no bundle or benchmark commands.
+
+### Connectivity
+
+- Pin existing component/SCC ordering before adding consumers.
+- C02 keeps bridges/articulation/biconnected results together around one low-link kernel.
+- C03, C04, and C05 are separate PRs.
+
+### Paths
+
+- P01 keeps legacy `PathResult` unchanged.
+- P02 is internal tie-predecessor groundwork with no changeset.
+- Do not add eager `collect*` aliases or trivial path field accessors.
+- Keep P03-P06 separate.
+
+### Analytics
+
+- Keep each public family separate.
+- A04a is internal; A04b exposes closeness.
+- Do not implement parked specialist analytics.
+
+### MST
+
+- Implement only minimum spanning forest/tree with stable input edge IDs.
+- Do not add Euler, flow/cut, matching, or directed arborescence.
+
+## Completion report
+
+At the end of the invocation, report:
+
+1. PRs opened, with URLs and dependency bases.
+2. PR IDs completed, skipped as already implemented, or blocked.
+3. Exact validation commands and outcomes for each PR.
+4. Changesets created.
+5. The next merge gate and recommended next agent invocation.
+6. Any plan/source contradiction discovered.
+
+Do not claim the whole Graph program is complete unless every non-excluded active PR in Plan 14 has merged.
+```
+
+## Suggested Invocation Order
+
+Use separate agents in this order, allowing independent lanes to overlap after their prerequisites merge:
+
+1. `stabilization`
+2. `verification`
+3. `kernel`
+4. `emitters`
+5. `queries`
+6. `generators` and `connectivity` in parallel
+7. `paths`
+8. `analytics` and `mst` after their path/query prerequisites
+9. `docs` after the shipped surface is frozen
+
+Do not invoke benchmark/runtimeperf or Effect-native task groups in this cycle.

--- a/docs/graph-plans/README.md
+++ b/docs/graph-plans/README.md
@@ -1,0 +1,81 @@
+# Graph Improvement Plans
+
+This directory coordinates non-breaking improvements to `packages/effect/src/Graph.ts` based on lessons from
+`.repos/graph`.
+
+The binding cross-plan decisions, ownership tables, dependency DAG, delivery waves, and gates are in the
+[master roadmap](./12-master-roadmap.md). If a domain plan conflicts with that document, the master roadmap wins.
+
+## Plan Index
+
+| Plan | Topic |
+| --- | --- |
+| [01](./01-correctness-contracts.md) | Correctness contracts and semantic hardening |
+| [02](./02-verification-benchmarks.md) | Verification and benchmark foundations |
+| [03](./03-internal-architecture-performance.md) | Internal architecture and performance |
+| [04](./04-core-queries-transforms.md) | Core queries and transforms |
+| [05](./05-traversal-paths.md) | Traversal and paths |
+| [06](./06-connectivity-dag-algorithms.md) | Connectivity and DAG algorithms |
+| [07](./07-optimization-algorithms.md) | Optimization algorithms |
+| [08](./08-analytics.md) | Analytics and specialist algorithms |
+| [09](./09-generators.md) | Graph generators |
+| [10](./10-effect-native-interruption.md) | Effect-native interruption and cooperative scheduling |
+| [11](./11-dot-mermaid-documentation.md) | DOT, Mermaid, and consolidated documentation |
+| [12](./12-master-roadmap.md) | Binding master roadmap |
+| [13](./13-current-execution-plan.md) | Current implementation status and execution order |
+| [14](./14-pr-delivery-plan.md) | Pull-request split, dependencies, and merge waves |
+| [15](./15-agent-execution-prompt.md) | Reusable delivery-agent prompt with selectable task groups |
+
+## Scope
+
+- Preserve all existing public signatures and behavior unless a regression test demonstrates a bug.
+- Keep only directed and undirected graph kinds.
+- Preserve scoped mutation and automatic monotonic numeric node and edge indexes.
+- Preserve parallel edges, self-loops, stable index ordering, and deterministic traversal.
+- Keep synchronous APIs synchronous. Any Effect-returning variants must be additive.
+- Keep output support limited to DOT and Mermaid.
+- Do not add mixed or bidirectional edges, layout engines, custom formats, a plain mutable JSON model, freezing,
+  proxies, or property-descriptor tricks.
+- Schema serialization has a separate plan and is out of scope here, except for coordination around internal graph
+  snapshots and hydration.
+
+## Shared Semantics
+
+- Neighbor-node queries return unique node indexes. Incident-edge queries preserve every edge occurrence.
+- Directed self-loops contribute once to in-degree and once to out-degree. Undirected self-loops contribute two to
+  graph-theoretic degree.
+- Parallel edges contribute independently to degree, paths, capacity, flow, and weighted analysis.
+- A self-loop is a cycle. Two parallel undirected edges form a cycle.
+- Default ordering follows node and edge insertion/index order. No API implicitly sorts unless documented.
+- Missing safe lookups return `Option.none`; empty collection queries return empty collections; invalid structural or
+  algorithmic inputs use `GraphError`.
+- Expensive multi-result APIs should be genuinely lazy first, with eager forms collecting the lazy form.
+- New public functions follow Effect dual/data-first/data-last conventions and require JSDoc, tests, and a changeset.
+
+## Shared Internal Groundwork
+
+Plans should coordinate around these internal concepts rather than creating competing representations:
+
+1. An ordered arc iterator for outgoing, incoming, and direction-ignored traversal that retains both neighbor and
+   `EdgeIndex`.
+2. An optional dense snapshot translating sparse stable public indexes to dense positions for hot algorithms.
+3. Shared weight, capacity, and heuristic validation policies.
+4. Shared predecessor/path reconstruction that retains edge identity internally.
+5. A no-op synchronous checkpoint abstraction that can also support additive Effect-native interruption.
+6. Seeded graph fixtures and oracle adapters shared by correctness, property, differential, and benchmark suites.
+
+## Dependency Order
+
+1. Correctness contracts.
+2. Verification and benchmark foundations.
+3. Internal architecture and performance kernel.
+4. Core queries and transforms.
+5. Traversal and path features.
+6. Connectivity and DAG algorithms.
+7. Optimization algorithms.
+8. Analytics and graph generators.
+9. Effect-native interruption after synchronous kernels stabilize.
+10. DOT, Mermaid, and consolidated documentation can proceed after shared semantics are fixed.
+
+Each domain plan must state which earlier plans it requires, which work can proceed independently, and which APIs or
+internal helpers it expects another plan to own.


### PR DESCRIPTION
## Summary

- Add the approved Graph improvement domain plans, roadmap, current execution plan, and PR delivery protocol
- Record the authoritative scope, dependencies, semantic contracts, exclusions, and merge gates

## Plan

- PR ID: PLANS
- Depends on: none
- Deferred: benchmark/runtimeperf validation is intentionally out of scope

## Validation

- `pnpm lint-fix`
- `git diff --check`

## Changeset

- Not required
