### PR TITLE
Graph: ignore allocator history in equality

### DIFF
--- a/.changeset/flat-graphs-agree.md
+++ b/.changeset/flat-graphs-agree.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Ignore removed allocator history when comparing and hashing immutable Graph values with the same active indexed structure.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -170,6 +170,11 @@ export interface Proto<out N, out E> extends Iterable<readonly [NodeIndex, N]>, 
  * Use as the immutable graph model for code that queries, traverses,
  * transforms, or analyzes graph structure without mutating it.
  *
+ * **Gotchas**
+ *
+ * After a graph is hashed, its transitively contained node and edge payloads
+ * used by hashing must remain immutable, as with other Effect values.
+ *
  * @see {@link MutableGraph} for the mutable counterpart used inside mutation scopes
  * @see {@link DirectedGraph} for a `Graph` fixed to directed edges
  * @see {@link UndirectedGraph} for a `Graph` fixed to undirected edges

--- a/packages/effect/src/internal/graph.ts
+++ b/packages/effect/src/internal/graph.ts
@@ -60,8 +60,6 @@ const ProtoGraph = {
       if (
         this.nodes.size !== thatImpl.nodes.size ||
         this.edges.size !== thatImpl.edges.size ||
-        this.nextNodeIndex !== thatImpl.nextNodeIndex ||
-        this.nextEdgeIndex !== thatImpl.nextEdgeIndex ||
         this.type !== thatImpl.type
       ) {
         return false
@@ -86,8 +84,6 @@ const ProtoGraph = {
     hash = hash ^ Hash.string(this.type)
     hash = hash ^ Hash.number(this.nodes.size)
     hash = hash ^ Hash.number(this.edges.size)
-    hash = hash ^ Hash.number(this.nextNodeIndex)
-    hash = hash ^ Hash.number(this.nextEdgeIndex)
     for (const [nodeIndex, nodeData] of this.nodes) {
       hash = hash ^ (Hash.hash(nodeIndex) + Hash.hash(nodeData))
     }

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -331,16 +331,20 @@ describe("Graph", () => {
       strictEqual(Equal.equals(left, right), false)
     })
 
-    it("compares future node allocation", () => {
-      const left = Graph.directed<string, string>()
+    it("ignores removed trailing node allocation history", () => {
+      const left = makeGraph("directed", [[0, 1, "edge"]])
       const right = Graph.directed<string, string>((mutable) => {
+        const source = Graph.addNode(mutable, "A")
+        const target = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, source, target, "edge")
         const node = Graph.addNode(mutable, "removed")
         Graph.removeNode(mutable, node)
       })
 
-      strictEqual(Graph.nodeCount(left), Graph.nodeCount(right))
-      strictEqual(Graph.edgeCount(left), Graph.edgeCount(right))
-      strictEqual(Equal.equals(left, right), false)
+      assert.deepStrictEqual(Array.from(left), Array.from(right))
+      assert.deepStrictEqual(Array.from(Graph.edges(left)), Array.from(Graph.edges(right)))
+      strictEqual(Equal.equals(left, right), true)
+      strictEqual(Hash.hash(left), Hash.hash(right))
 
       let leftNode: Graph.NodeIndex | undefined
       let rightNode: Graph.NodeIndex | undefined
@@ -351,22 +355,24 @@ describe("Graph", () => {
         rightNode = Graph.addNode(mutable, "next")
       })
 
-      strictEqual(leftNode, 0)
-      strictEqual(rightNode, 1)
+      strictEqual(leftNode, 2)
+      strictEqual(rightNode, 3)
     })
 
-    it("compares future edge allocation", () => {
-      const left = makeGraph("directed", [])
+    it("ignores removed trailing edge allocation history", () => {
+      const left = makeGraph("directed", [[0, 1, "edge"]])
       const right = Graph.directed<string, string>((mutable) => {
         const source = Graph.addNode(mutable, "A")
         const target = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, source, target, "edge")
         const edge = Graph.addEdge(mutable, source, target, "removed")
         Graph.removeEdge(mutable, edge)
       })
 
       assert.deepStrictEqual(Array.from(left), Array.from(right))
       assert.deepStrictEqual(Array.from(Graph.edges(left)), Array.from(Graph.edges(right)))
-      strictEqual(Equal.equals(left, right), false)
+      strictEqual(Equal.equals(left, right), true)
+      strictEqual(Hash.hash(left), Hash.hash(right))
 
       let leftEdge: Graph.EdgeIndex | undefined
       let rightEdge: Graph.EdgeIndex | undefined
@@ -377,8 +383,8 @@ describe("Graph", () => {
         rightEdge = Graph.addEdge(mutable, 0, 1, "next")
       })
 
-      strictEqual(leftEdge, 0)
-      strictEqual(rightEdge, 1)
+      strictEqual(leftEdge, 1)
+      strictEqual(rightEdge, 2)
     })
 
     it("preserves allocator equality and hashing through an empty mutation", () => {


### PR DESCRIPTION
## Summary

- Remove allocator counters from immutable Graph structural equality and hashing.
- Preserve equality over graph kind, active stable indexes, payloads, edge identity, and undirected endpoint symmetry while mutable graphs retain reference equality and hashing.
- Cover equal active graphs with different removed trailing allocation history and document the immutability expectation for transitively hashed payloads.

## Plan

- PR ID: S02
- Depends on: merged PR #7271
- Deferred: benchmark/runtimeperf validation is intentionally out of scope for this cycle

## Validation

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/Graph.test.ts` (299 passed after rebasing onto current `main`)
- `pnpm lint`
- `pnpm check`
- `git diff --check`

No doctest was run because only public JSDoc prose changed; no runnable example changed.

## Changeset

- `.changeset/flat-graphs-agree.md`: `effect` patch
