### PR TITLE
Graph: add neutral seeded corpus

### DIFF
--- a/packages/effect/runtimeperf/suites/graph/fixtures/corpus.ts
+++ b/packages/effect/runtimeperf/suites/graph/fixtures/corpus.ts
@@ -1,0 +1,264 @@
+import { createHash } from "node:crypto"
+
+export type GraphSpec = {
+  readonly name: string
+  readonly seed: number
+  readonly kind: "directed" | "undirected"
+  readonly nodeCount: number
+  readonly edges: ReadonlyArray<readonly [source: number, target: number, weight: number, id: number]>
+}
+
+export type GraphShape =
+  | "chain"
+  | "starIn"
+  | "starOut"
+  | "grid"
+  | "layeredDag"
+  | "dense"
+  | "loopHeavy"
+  | "parallelChain"
+  | "disconnected"
+  | "churnedSparse"
+
+export type GraphFixtureFamily = "oracleSimple" | "effectRich"
+
+export type GraphSize = keyof typeof graphSizes
+
+export type AdapterRecipe = {
+  readonly nodeIndexHoles: ReadonlyArray<number>
+  readonly edgeIndexHoles: ReadonlyArray<number>
+}
+
+export type GraphFixture = {
+  readonly family: GraphFixtureFamily
+  readonly shape: GraphShape
+  readonly size: GraphSize
+  readonly spec: GraphSpec
+  readonly fingerprint: string
+  readonly adapterRecipe: AdapterRecipe
+}
+
+export const graphSizes = {
+  tiny: 8,
+  small: 24,
+  unit: 64
+} as const
+
+export const smokeSeeds = [3, 7, 13, 21, 34, 55, 89, 144] as const
+
+export const emptyAdapterRecipe: AdapterRecipe = {
+  nodeIndexHoles: [],
+  edgeIndexHoles: []
+}
+
+export const makePrng = (seed: number): () => number => {
+  let state = seed >>> 0
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0
+    let value = state
+    value = Math.imul(value ^ value >>> 15, value | 1)
+    value ^= value + Math.imul(value ^ value >>> 7, value | 61)
+    return (value ^ value >>> 14) >>> 0
+  }
+}
+
+const assertNonNegativeInteger = (value: number, name: string): void => {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new RangeError(`${name} must be a non-negative safe integer`)
+  }
+}
+
+export const validateGraphSpec = (spec: GraphSpec): void => {
+  assertNonNegativeInteger(spec.seed, "seed")
+  assertNonNegativeInteger(spec.nodeCount, "nodeCount")
+  const ids = new Set<number>()
+  for (const [source, target, weight, id] of spec.edges) {
+    if (!Number.isSafeInteger(source) || source < 0 || source >= spec.nodeCount) {
+      throw new RangeError(`edge ${id} has an invalid source`)
+    }
+    if (!Number.isSafeInteger(target) || target < 0 || target >= spec.nodeCount) {
+      throw new RangeError(`edge ${id} has an invalid target`)
+    }
+    if (!Number.isSafeInteger(weight)) {
+      throw new RangeError(`edge ${id} has an invalid weight`)
+    }
+    assertNonNegativeInteger(id, "edge id")
+    if (ids.has(id)) {
+      throw new RangeError(`duplicate edge id ${id}`)
+    }
+    ids.add(id)
+  }
+}
+
+const canonicalSpec = (spec: GraphSpec): string =>
+  JSON.stringify([spec.name, spec.seed, spec.kind, spec.nodeCount, spec.edges])
+
+export const fingerprintGraphSpec = (spec: GraphSpec): string =>
+  createHash("sha256").update(canonicalSpec(spec)).digest("hex")
+
+const richShapes = new Set<GraphShape>(["loopHeavy", "parallelChain", "churnedSparse"])
+
+const makeSparseChurnRecipe = (nodeCount: number, edgeCount: number, seed: number): AdapterRecipe => {
+  const random = makePrng(seed ^ 0xa511e9b3)
+  const holes = (activeCount: number, requested: number): ReadonlyArray<number> => {
+    const total = activeCount + requested
+    const positions = new Set<number>()
+    while (positions.size < requested) {
+      positions.add(random() % total)
+    }
+    return Array.from(positions).sort((left, right) => left - right)
+  }
+  return {
+    nodeIndexHoles: holes(nodeCount, Math.max(1, Math.floor(nodeCount / 4))),
+    edgeIndexHoles: holes(edgeCount, Math.max(1, Math.floor(edgeCount / 4)))
+  }
+}
+
+export const makeGraphSpec = (options: {
+  readonly shape: GraphShape
+  readonly nodeCount: number
+  readonly seed: number
+  readonly kind: GraphSpec["kind"]
+  readonly name?: string
+}): GraphSpec => {
+  const { kind, nodeCount, seed, shape } = options
+  assertNonNegativeInteger(seed, "seed")
+  assertNonNegativeInteger(nodeCount, "nodeCount")
+  const random = makePrng(seed)
+  const edges: Array<readonly [number, number, number, number]> = []
+  const keys = new Set<string>()
+  const weight = (): number => random() % 9 + 1
+  const add = (source: number, target: number, edgeWeight?: number, simple: boolean = false): void => {
+    const key = kind === "undirected" && source > target ? `${target}:${source}` : `${source}:${target}`
+    if (simple && keys.has(key)) {
+      return
+    }
+    keys.add(key)
+    edges.push([source, target, edgeWeight ?? weight(), edges.length])
+  }
+
+  switch (shape) {
+    case "chain":
+      for (let node = 1; node < nodeCount; node++) add(node - 1, node)
+      break
+    case "starIn":
+      for (let node = 1; node < nodeCount; node++) add(node, 0)
+      break
+    case "starOut":
+      for (let node = 1; node < nodeCount; node++) add(0, node)
+      break
+    case "grid": {
+      const width = Math.max(1, Math.ceil(Math.sqrt(nodeCount)))
+      for (let node = 0; node < nodeCount; node++) {
+        if (node % width + 1 < width && node + 1 < nodeCount) add(node, node + 1)
+        if (node + width < nodeCount) add(node, node + width)
+      }
+      break
+    }
+    case "layeredDag": {
+      const width = Math.max(2, Math.ceil(Math.sqrt(nodeCount)))
+      for (let source = 0; source < nodeCount; source++) {
+        const nextLayer = Math.floor(source / width) + 1
+        for (let offset = 0; offset < 2; offset++) {
+          const target = nextLayer * width + (source + offset) % width
+          if (target < nodeCount) add(source, target, undefined, true)
+        }
+        const skipTarget = (nextLayer + 1) * width + random() % width
+        if (skipTarget < nodeCount) add(source, skipTarget, undefined, true)
+      }
+      break
+    }
+    case "dense":
+      for (let source = 0; source < nodeCount; source++) {
+        const firstTarget = kind === "undirected" ? source + 1 : 0
+        for (let target = firstTarget; target < nodeCount; target++) {
+          if (source !== target) add(source, target)
+        }
+      }
+      break
+    case "loopHeavy":
+      for (let node = 1; node < nodeCount; node++) add(node - 1, node)
+      for (let node = 0; node < nodeCount; node += 2) add(node, node)
+      break
+    case "parallelChain":
+      for (let node = 1; node < nodeCount; node++) {
+        const repeatedWeight = weight()
+        add(node - 1, node, repeatedWeight)
+        add(node - 1, node, repeatedWeight)
+        add(node - 1, node)
+      }
+      break
+    case "disconnected":
+      for (let node = 1; node < nodeCount; node++) {
+        if (node % 4 !== 0 && node % 4 !== 3) add(node - 1, node)
+      }
+      break
+    case "churnedSparse": {
+      for (let node = 1; node < nodeCount; node++) add(node - 1, node, undefined, true)
+      const possibleEdges = nodeCount * Math.max(0, nodeCount - 1) / (kind === "undirected" ? 2 : 1)
+      const targetCount = Math.min(nodeCount * 2, possibleEdges)
+      if (nodeCount > 1) {
+        while (edges.length < targetCount) {
+          const source = random() % nodeCount
+          const target = random() % nodeCount
+          if (source !== target) add(source, target, undefined, true)
+        }
+      }
+      break
+    }
+  }
+
+  const spec: GraphSpec = {
+    name: options.name ?? `${shape}/${nodeCount}/${kind}/${seed}`,
+    seed,
+    kind,
+    nodeCount,
+    edges
+  }
+  validateGraphSpec(spec)
+  return spec
+}
+
+export const makeGraphFixture = (options: {
+  readonly shape: GraphShape
+  readonly size: GraphSize
+  readonly seed: number
+  readonly kind: GraphSpec["kind"]
+}): GraphFixture => {
+  const family = richShapes.has(options.shape) ? "effectRich" : "oracleSimple"
+  const spec = makeGraphSpec({
+    ...options,
+    nodeCount: graphSizes[options.size],
+    name: `${family}/${options.shape}/${options.size}/${options.kind}/${options.seed}`
+  })
+  const adapterRecipe = options.shape === "churnedSparse"
+    ? makeSparseChurnRecipe(spec.nodeCount, spec.edges.length, spec.seed)
+    : emptyAdapterRecipe
+  return {
+    family,
+    shape: options.shape,
+    size: options.size,
+    spec,
+    fingerprint: fingerprintGraphSpec(spec),
+    adapterRecipe
+  }
+}
+
+const corpusShapes: ReadonlyArray<GraphShape> = [
+  "chain",
+  "starIn",
+  "starOut",
+  "grid",
+  "layeredDag",
+  "dense",
+  "loopHeavy",
+  "parallelChain",
+  "disconnected",
+  "churnedSparse"
+]
+
+export const graphCorpus: ReadonlyArray<GraphFixture> = corpusShapes.flatMap((shape, index) =>
+  (["directed", "undirected"] as const).map((kind) =>
+    makeGraphFixture({ shape, size: "tiny", seed: smokeSeeds[index % smokeSeeds.length], kind })
+  )
+)

--- a/packages/effect/runtimeperf/suites/graph/fixtures/effect.ts
+++ b/packages/effect/runtimeperf/suites/graph/fixtures/effect.ts
@@ -1,0 +1,82 @@
+import * as Graph from "effect/Graph"
+import type { AdapterRecipe, GraphSpec } from "./corpus.ts"
+import { emptyAdapterRecipe, validateGraphSpec } from "./corpus.ts"
+
+export type GraphEdgeData = {
+  readonly id: number
+  readonly weight: number
+}
+
+export type AdaptedGraph<T extends Graph.Kind> = {
+  readonly graph: Graph.Graph<number, GraphEdgeData, T>
+  readonly nodeIndices: ReadonlyArray<Graph.NodeIndex>
+  readonly edgeIndices: ReadonlyArray<Graph.EdgeIndex>
+}
+
+const validateHoles = (holes: ReadonlyArray<number>, activeCount: number, name: string): Set<number> => {
+  const total = activeCount + holes.length
+  const positions = new Set<number>()
+  for (const position of holes) {
+    if (!Number.isSafeInteger(position) || position < 0 || position >= total || positions.has(position)) {
+      throw new RangeError(`${name} must contain unique allocation positions`)
+    }
+    positions.add(position)
+  }
+  return positions
+}
+
+const populate = <T extends Graph.Kind>(
+  mutable: Graph.MutableGraph<number, GraphEdgeData, T>,
+  spec: GraphSpec,
+  recipe: AdapterRecipe,
+  nodeIndices: Array<Graph.NodeIndex>,
+  edgeIndices: Array<Graph.EdgeIndex>
+): void => {
+  const nodeHoles = validateHoles(recipe.nodeIndexHoles, spec.nodeCount, "nodeIndexHoles")
+  for (let position = 0; position < spec.nodeCount + nodeHoles.size; position++) {
+    if (nodeHoles.has(position)) {
+      const hole = Graph.addNode(mutable, -1)
+      Graph.removeNode(mutable, hole)
+    } else {
+      nodeIndices.push(Graph.addNode(mutable, nodeIndices.length))
+    }
+  }
+
+  const edgeHoles = validateHoles(recipe.edgeIndexHoles, spec.edges.length, "edgeIndexHoles")
+  if (edgeHoles.size > 0 && nodeIndices.length === 0) {
+    throw new RangeError("edgeIndexHoles require at least one node")
+  }
+  for (let position = 0; position < spec.edges.length + edgeHoles.size; position++) {
+    if (edgeHoles.has(position)) {
+      const node = nodeIndices[0]!
+      const hole = Graph.addEdge(mutable, node, node, { id: -1, weight: 0 })
+      Graph.removeEdge(mutable, hole)
+    } else {
+      const [source, target, weight, id] = spec.edges[edgeIndices.length]!
+      edgeIndices.push(Graph.addEdge(mutable, nodeIndices[source]!, nodeIndices[target]!, { id, weight }))
+    }
+  }
+}
+
+export const adaptGraphSpec = <T extends Graph.Kind>(
+  spec: GraphSpec & { readonly kind: T },
+  recipe: AdapterRecipe = emptyAdapterRecipe
+): AdaptedGraph<T> => {
+  validateGraphSpec(spec)
+  const nodeIndices: Array<Graph.NodeIndex> = []
+  const edgeIndices: Array<Graph.EdgeIndex> = []
+  const graph = spec.kind === "directed"
+    ? Graph.directed<number, GraphEdgeData>((mutable) => {
+      populate(mutable, spec, recipe, nodeIndices, edgeIndices)
+      return undefined
+    })
+    : Graph.undirected<number, GraphEdgeData>((mutable) => {
+      populate(mutable, spec, recipe, nodeIndices, edgeIndices)
+      return undefined
+    })
+  return {
+    graph: graph as Graph.Graph<number, GraphEdgeData, T>,
+    nodeIndices,
+    edgeIndices
+  }
+}

--- a/packages/effect/test/GraphCorpus.test.ts
+++ b/packages/effect/test/GraphCorpus.test.ts
@@ -1,0 +1,140 @@
+import { assert, describe, it } from "@effect/vitest"
+import * as Graph from "effect/Graph"
+import {
+  fingerprintGraphSpec,
+  graphCorpus,
+  graphSizes,
+  makeGraphFixture,
+  makeGraphSpec,
+  makePrng,
+  validateGraphSpec
+} from "../runtimeperf/suites/graph/fixtures/corpus.ts"
+import { adaptGraphSpec } from "../runtimeperf/suites/graph/fixtures/effect.ts"
+
+describe("Graph corpus", () => {
+  it("pins the local PRNG output", () => {
+    const random = makePrng(0x12345678)
+    assert.deepStrictEqual(Array.from({ length: 6 }, () => random()), [
+      455919406,
+      4042750857,
+      4036713555,
+      1004527575,
+      3885174651,
+      3342903291
+    ])
+  })
+
+  it("generates exact-size valid deterministic shapes", () => {
+    assert.deepStrictEqual(
+      Array.from(new Set(graphCorpus.map((fixture) => fixture.shape))).sort(),
+      [
+        "chain",
+        "churnedSparse",
+        "dense",
+        "disconnected",
+        "grid",
+        "layeredDag",
+        "loopHeavy",
+        "parallelChain",
+        "starIn",
+        "starOut"
+      ]
+    )
+    for (const fixture of graphCorpus) {
+      validateGraphSpec(fixture.spec)
+      assert.strictEqual(fixture.spec.nodeCount, graphSizes.tiny, fixture.spec.name)
+      const replay = makeGraphFixture({
+        shape: fixture.shape,
+        size: fixture.size,
+        seed: fixture.spec.seed,
+        kind: fixture.spec.kind
+      })
+      assert.deepStrictEqual(replay, fixture, fixture.spec.name)
+    }
+
+    for (const nodeCount of [0, 1, 2, 7, 10]) {
+      const grid = makeGraphSpec({ shape: "grid", nodeCount, seed: 7, kind: "directed" })
+      assert.strictEqual(grid.nodeCount, nodeCount)
+      assert.ok(grid.edges.every(([source, target]) => source < nodeCount && target < nodeCount))
+    }
+  })
+
+  it("keeps simple and rich fixture domains explicit", () => {
+    for (const fixture of graphCorpus) {
+      const pairs = new Set<string>()
+      for (const [source, target] of fixture.spec.edges) {
+        const pair = fixture.spec.kind === "undirected" && source > target
+          ? `${target}:${source}`
+          : `${source}:${target}`
+        if (fixture.family === "oracleSimple") {
+          assert.notStrictEqual(source, target, fixture.spec.name)
+          assert.ok(!pairs.has(pair), fixture.spec.name)
+        }
+        pairs.add(pair)
+      }
+      if (fixture.family === "effectRich") {
+        assert.ok(
+          fixture.shape === "churnedSparse" || fixture.spec.edges.some(([source, target]) => source === target) ||
+            pairs.size < fixture.spec.edges.length,
+          fixture.spec.name
+        )
+      }
+    }
+  })
+
+  it("pins canonical fingerprints", () => {
+    const spec = makeGraphSpec({
+      shape: "layeredDag",
+      nodeCount: 10,
+      seed: 13,
+      kind: "directed",
+      name: "fingerprint-golden"
+    })
+    assert.strictEqual(
+      fingerprintGraphSpec(spec),
+      "1d446ec801850c2694b94ae971989b6311b4955440dbf77ad3624fff8735d2c2"
+    )
+    assert.notStrictEqual(fingerprintGraphSpec({ ...spec, seed: 14 }), fingerprintGraphSpec(spec))
+  })
+
+  it("preserves insertion order and ordinal mappings", () => {
+    const fixture = makeGraphFixture({ shape: "parallelChain", size: "tiny", seed: 21, kind: "directed" })
+    const adapted = adaptGraphSpec(fixture.spec, fixture.adapterRecipe)
+    assert.deepStrictEqual(adapted.nodeIndices, Array.from({ length: fixture.spec.nodeCount }, (_, index) => index))
+    assert.deepStrictEqual(adapted.edgeIndices, fixture.spec.edges.map((edge) => edge[3]))
+    assert.deepStrictEqual(
+      Array.from(adapted.graph),
+      adapted.nodeIndices.map((index, ordinal) => [index, ordinal] as const)
+    )
+    assert.deepStrictEqual(
+      Array.from(Graph.edges(adapted.graph)),
+      fixture.spec.edges.map(([source, target, weight, id], ordinal) => [
+        adapted.edgeIndices[ordinal],
+        {
+          source: adapted.nodeIndices[source],
+          target: adapted.nodeIndices[target],
+          data: { id, weight }
+        }
+      ])
+    )
+  })
+
+  it("applies sparse churn through an explicit adapter recipe", () => {
+    const fixture = makeGraphFixture({ shape: "churnedSparse", size: "tiny", seed: 34, kind: "undirected" })
+    const adapted = adaptGraphSpec(fixture.spec, fixture.adapterRecipe)
+    assert.ok(fixture.adapterRecipe.nodeIndexHoles.length > 0)
+    assert.ok(fixture.adapterRecipe.edgeIndexHoles.length > 0)
+    const activeIndices = (activeCount: number, holes: ReadonlyArray<number>): ReadonlyArray<number> =>
+      Array.from({ length: activeCount + holes.length }, (_, index) => index).filter((index) => !holes.includes(index))
+    assert.deepStrictEqual(
+      adapted.nodeIndices,
+      activeIndices(fixture.spec.nodeCount, fixture.adapterRecipe.nodeIndexHoles)
+    )
+    assert.deepStrictEqual(
+      adapted.edgeIndices,
+      activeIndices(fixture.spec.edges.length, fixture.adapterRecipe.edgeIndexHoles)
+    )
+    assert.deepStrictEqual(Array.from(Graph.indices(Graph.nodes(adapted.graph))), adapted.nodeIndices)
+    assert.deepStrictEqual(Array.from(Graph.indices(Graph.edges(adapted.graph))), adapted.edgeIndices)
+  })
+})

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -9,6 +9,7 @@
     "./packages/*/test/**/*.json",
     "./packages/*/typetest/**/*.ts",
     "./packages/*/benchmark/**/*.ts",
+    "./packages/effect/runtimeperf/suites/graph/fixtures/**/*.ts",
     "./packages/**/test/**/*.ts",
     "./packages/**/test/**/*.json",
     "./packages/**/typetest/**/*.ts",


### PR DESCRIPTION
## Summary

- add a deterministic primitive-only GraphSpec corpus with fixed PRNG output, named shape and size fixtures, and SHA-256 fingerprints
- add an Effect adapter that preserves insertion order and ordinal-to-public-index mappings, including explicit sparse mutation recipes
- cover deterministic replay, exact grid sizes, fixture validity, fingerprints, rich/simple domains, ordering, and sparse adaptation

## Plan

- PR ID: V01
- Depends on: none
- Deferred: benchmark/runtimeperf validation is intentionally out of scope for this cycle

## Validation

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/GraphCorpus.test.ts`
- `pnpm check`
- `git diff --check`

## Changeset

- Not required
