### PR TITLE
Add minimum spanning forests

### DIFF
--- a/.changeset/calm-graphs-span.md
+++ b/.changeset/calm-graphs-span.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add deterministic, index-preserving `Graph.minimumSpanningForest`.

--- a/.changeset/clear-graphs-reduce.md
+++ b/.changeset/clear-graphs-reduce.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add index-preserving transitive reduction for directed acyclic graphs.

--- a/.changeset/quick-graphs-paths.md
+++ b/.changeset/quick-graphs-paths.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add bounded lazy enumeration of simple paths and all tied shortest paths.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -4757,6 +4757,100 @@ export const isTree = <N, E>(
   return nodes > 0 && edgeCount(graph) === nodes - 1 && isConnected(graph)
 }
 
+/**
+ * Returns a minimum spanning forest of an undirected graph using Kruskal's
+ * algorithm.
+ *
+ * All node indices and selected edge indices are preserved. Negative finite
+ * weights are allowed, `Infinity` marks an unavailable edge, and equal weights
+ * are resolved by original edge order. Throws a `GraphError` for a directed
+ * graph or when a weight is `NaN` or `-Infinity`.
+ *
+ * @category algorithms
+ * @since 4.0.0
+ */
+export const minimumSpanningForest: {
+  <E>(cost: (edgeData: E) => number): <N>(
+    graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
+  ) => Graph<N, E, "undirected">
+  <N, E>(
+    graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">,
+    cost: (edgeData: E) => number
+  ): Graph<N, E, "undirected">
+} = dual(2, <N, E>(
+  graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">,
+  cost: (edgeData: E) => number
+): Graph<N, E, "undirected"> => {
+  if ((graph as Graph<N, E, Kind> | MutableGraph<N, E, Kind>).type === "directed") {
+    throw new GraphError({ message: "Cannot find minimum spanning forest of directed graph" })
+  }
+  const impl = internal.toImpl(graph)
+  const nodes: Array<IndexedNode<N>> = []
+  const compactByNode = new Map<NodeIndex, number>()
+  for (const [index, data] of impl.nodes) {
+    compactByNode.set(index, nodes.length)
+    nodes.push({ index, data })
+  }
+  const weightedEdges: Array<{ readonly index: EdgeIndex; readonly weight: number; readonly order: number }> = []
+  let order = 0
+  for (const [index, edge] of impl.edges) {
+    const weight = cost(edge.data)
+    if (Number.isNaN(weight) || weight === -Infinity) {
+      throw new GraphError({ message: "Minimum spanning forest does not support NaN or -Infinity edge weights" })
+    }
+    if (weight !== Infinity) {
+      weightedEdges.push({ index, weight, order })
+    }
+    order++
+  }
+  weightedEdges.sort((self, that) => self.weight - that.weight || self.order - that.order)
+
+  const parents = new Uint32Array(nodes.length)
+  const ranks = new Uint8Array(nodes.length)
+  for (let i = 0; i < parents.length; i++) {
+    parents[i] = i
+  }
+  const find = (node: number): number => {
+    let root = node
+    while (parents[root] !== root) {
+      root = parents[root]
+    }
+    while (parents[node] !== node) {
+      const parent = parents[node]
+      parents[node] = root
+      node = parent
+    }
+    return root
+  }
+  const selected = new Set<EdgeIndex>()
+  for (const weighted of weightedEdges) {
+    const edge = impl.edges.get(weighted.index)!
+    let sourceRoot = find(compactByNode.get(edge.source)!)
+    let targetRoot = find(compactByNode.get(edge.target)!)
+    if (sourceRoot === targetRoot) {
+      continue
+    }
+    selected.add(weighted.index)
+    if (ranks[sourceRoot] < ranks[targetRoot]) {
+      const swap = sourceRoot
+      sourceRoot = targetRoot
+      targetRoot = swap
+    }
+    parents[targetRoot] = sourceRoot
+    if (ranks[sourceRoot] === ranks[targetRoot]) {
+      ranks[sourceRoot]++
+    }
+  }
+
+  const edges: Array<IndexedEdge<E>> = []
+  for (const [index, edge] of impl.edges) {
+    if (selected.has(index)) {
+      edges.push({ index, source: edge.source, target: edge.target, data: edge.data })
+    }
+  }
+  return fromSnapshot({ type: "undirected", nodes, edges })
+})
+
 // =============================================================================
 // Path Finding Algorithms
 // =============================================================================

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -4851,6 +4851,82 @@ export const minimumSpanningForest: {
   return fromSnapshot({ type: "undirected", nodes, edges })
 })
 
+/**
+ * Returns the transitive reduction of a directed acyclic graph.
+ *
+ * The result preserves reachability with the fewest structural source-target
+ * pairs. Node and retained edge indices are preserved; parallel edges are
+ * coalesced by retaining the first edge for each required pair. Throws a
+ * `GraphError` for an undirected graph or cyclic input.
+ *
+ * @category algorithms
+ * @since 4.0.0
+ */
+export const transitiveReduction = <N, E>(
+  graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">
+): Graph<N, E, "directed"> => {
+  if ((graph as Graph<N, E, Kind> | MutableGraph<N, E, Kind>).type === "undirected") {
+    throw new GraphError({ message: "Cannot transitively reduce undirected graph" })
+  }
+  if (!isAcyclic(graph)) {
+    throw new GraphError({ message: "Cannot transitively reduce cyclic graph" })
+  }
+
+  const impl = internal.toImpl(graph)
+  const nodes: Array<IndexedNode<N>> = []
+  for (const [index, data] of impl.nodes) {
+    nodes.push({ index, data })
+  }
+  const firstEdges = new Map<NodeIndex, Map<NodeIndex, EdgeIndex>>()
+  for (const [edgeIndex, edge] of impl.edges) {
+    let targets = firstEdges.get(edge.source)
+    if (targets === undefined) {
+      targets = new Map()
+      firstEdges.set(edge.source, targets)
+    }
+    if (!targets.has(edge.target)) {
+      targets.set(edge.target, edgeIndex)
+    }
+  }
+
+  const retained = new Set<EdgeIndex>()
+  for (const [source, targets] of firstEdges) {
+    for (const [target, edgeIndex] of targets) {
+      const visited = new Set<NodeIndex>([source])
+      const queue = [source]
+      let reachable = false
+      for (let head = 0; head < queue.length && !reachable; head++) {
+        const current = queue[head]
+        for (const candidateIndex of impl.adjacency.get(current)!) {
+          const candidate = impl.edges.get(candidateIndex)!
+          if (current === source && candidate.target === target) {
+            continue
+          }
+          if (candidate.target === target) {
+            reachable = true
+            break
+          }
+          if (!visited.has(candidate.target)) {
+            visited.add(candidate.target)
+            queue.push(candidate.target)
+          }
+        }
+      }
+      if (!reachable) {
+        retained.add(edgeIndex)
+      }
+    }
+  }
+
+  const edges: Array<IndexedEdge<E>> = []
+  for (const [index, edge] of impl.edges) {
+    if (retained.has(index)) {
+      edges.push({ index, source: edge.source, target: edge.target, data: edge.data })
+    }
+  }
+  return fromSnapshot({ type: "directed", nodes, edges })
+}
+
 // =============================================================================
 // Path Finding Algorithms
 // =============================================================================
@@ -6279,6 +6355,300 @@ export const bellmanFord: {
     edges: pathEdges,
     distance,
     costs
+  })
+})
+
+/**
+ * A repeatable lazy iterable of edge-aware graph paths.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface PathWalker<E> extends Iterable<PathResult<E>> {}
+
+/**
+ * Configuration for lazy simple-path enumeration.
+ *
+ * `limit` bounds the number of yielded paths and defaults to `Infinity`.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface SimplePathsConfig {
+  readonly source: NodeIndex
+  readonly target: NodeIndex
+  readonly limit?: number
+}
+
+/**
+ * Configuration for enumerating all tied shortest paths.
+ *
+ * Edge costs must be non-negative. `limit` bounds the number of yielded paths
+ * and defaults to `Infinity`.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface AllShortestPathsConfig<E> extends DijkstraConfig<E> {
+  readonly limit?: number
+}
+
+const pathEnumerationLimit = (limit: number | undefined): number => {
+  const value = limit ?? Infinity
+  if (value !== Infinity && (!Number.isInteger(value) || value < 0)) {
+    throw new GraphError({ message: "Path enumeration limit must be a non-negative integer or Infinity" })
+  }
+  return value
+}
+
+const pathWalker = <E>(iterator: () => Iterator<PathResult<E>>): PathWalker<E> => ({
+  [Symbol.iterator]: iterator
+})
+
+/**
+ * Lazily enumerates simple source-to-target paths in depth-first edge order.
+ *
+ * Nodes are never repeated within a path, so enumeration is finite even for
+ * cyclic graphs. Path distance is the number of traversed edges. Throws a
+ * `GraphError` for missing endpoints or an invalid `limit`.
+ * Mutable graphs are snapshotted when iteration begins.
+ *
+ * @category algorithms
+ * @since 4.0.0
+ */
+export const simplePaths: {
+  <E>(config: SimplePathsConfig): <N, T extends Kind = "directed">(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>
+  ) => PathWalker<E>
+  <N, E, T extends Kind = "directed">(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+    config: SimplePathsConfig
+  ): PathWalker<E>
+} = dual(2, <N, E, T extends Kind = "directed">(
+  graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+  config: SimplePathsConfig
+): PathWalker<E> => {
+  const impl = internal.toImpl(graph)
+  if (!impl.nodes.has(config.source)) {
+    throw missingNode(config.source)
+  }
+  if (!impl.nodes.has(config.target)) {
+    throw missingNode(config.target)
+  }
+  const limit = pathEnumerationLimit(config.limit)
+
+  return pathWalker(function*() {
+    const cache = csr.get(graph)
+    const source = csr.getNodeIndex(cache, config.source)
+    if (source === undefined) {
+      throw missingNode(config.source)
+    }
+    const target = csr.getNodeIndex(cache, config.target)
+    if (target === undefined) {
+      throw missingNode(config.target)
+    }
+    if (limit === 0) {
+      return
+    }
+    const outgoing = csr.getOutgoingWithEdges(cache)
+    const edgeIds = csr.getEdgeIds(cache)
+    const graphEdges = csr.getEdges(cache)
+    const path = [config.source]
+    const pathEdges: Array<EdgeIndex> = []
+    const costs: Array<E> = []
+    const visited = new Uint8Array(cache.nodeIds.length)
+    visited[source] = 1
+    const stack: Array<{ readonly node: number; position: number }> = [{
+      node: source,
+      position: outgoing.rowOffsets[source]
+    }]
+    let emitted = 0
+
+    const backtrack = () => {
+      const frame = stack.pop()!
+      if (stack.length > 0) {
+        visited[frame.node] = 0
+        path.pop()
+        pathEdges.pop()
+        costs.pop()
+      }
+    }
+
+    while (stack.length > 0 && emitted < limit) {
+      const frame = stack[stack.length - 1]
+      if (frame.node === target) {
+        emitted++
+        yield {
+          path: Array.from(path),
+          edges: Array.from(pathEdges),
+          distance: pathEdges.length,
+          costs: Array.from(costs)
+        }
+        backtrack()
+        continue
+      }
+      if (frame.position >= outgoing.rowOffsets[frame.node + 1]) {
+        backtrack()
+        continue
+      }
+      const position = frame.position++
+      const neighbor = outgoing.columnIndices[position]
+      if (visited[neighbor] !== 0) {
+        continue
+      }
+      const edge = outgoing.edgeIndices[position]
+      visited[neighbor] = 1
+      path.push(cache.nodeIds[neighbor])
+      pathEdges.push(edgeIds[edge])
+      costs.push(graphEdges[edge].data)
+      stack.push({ node: neighbor, position: outgoing.rowOffsets[neighbor] })
+    }
+  })
+})
+
+/**
+ * Lazily enumerates all simple paths tied for minimum total cost.
+ *
+ * Parallel edges produce distinct paths. Edge costs must be non-negative;
+ * `Infinity` behaves as unavailable. Throws a `GraphError` for missing
+ * endpoints, invalid costs, or an invalid `limit`.
+ * Mutable graphs are snapshotted when iteration begins.
+ *
+ * @category algorithms
+ * @since 4.0.0
+ */
+export const allShortestPaths: {
+  <E>(config: AllShortestPathsConfig<E>): <N, T extends Kind = "directed">(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>
+  ) => PathWalker<E>
+  <N, E, T extends Kind = "directed">(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+    config: AllShortestPathsConfig<E>
+  ): PathWalker<E>
+} = dual(2, <N, E, T extends Kind = "directed">(
+  graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+  config: AllShortestPathsConfig<E>
+): PathWalker<E> => {
+  const impl = internal.toImpl(graph)
+  if (!impl.nodes.has(config.source)) {
+    throw missingNode(config.source)
+  }
+  if (!impl.nodes.has(config.target)) {
+    throw missingNode(config.target)
+  }
+  const limit = pathEnumerationLimit(config.limit)
+
+  return pathWalker(function*() {
+    const cache = csr.get(graph)
+    const source = csr.getNodeIndex(cache, config.source)
+    if (source === undefined) {
+      throw missingNode(config.source)
+    }
+    const target = csr.getNodeIndex(cache, config.target)
+    if (target === undefined) {
+      throw missingNode(config.target)
+    }
+    const graphEdges = csr.getEdges(cache)
+    const edgeIds = csr.getEdgeIds(cache)
+    const outgoing = csr.getOutgoingWithEdges(cache)
+    const weights = new Float64Array(graphEdges.length)
+    for (let edge = 0; edge < graphEdges.length; edge++) {
+      const weight = config.cost(graphEdges[edge].data)
+      if (Number.isNaN(weight) || weight < 0) {
+        throw new GraphError({ message: "All shortest paths requires non-negative edge weights" })
+      }
+      weights[edge] = weight
+    }
+    if (limit === 0) {
+      return
+    }
+
+    const distances = new Float64Array(cache.nodeIds.length)
+    distances.fill(Infinity)
+    distances[source] = 0
+    const previous: Array<Array<{ readonly node: number; readonly edge: number }> | undefined> = new Array(
+      cache.nodeIds.length
+    )
+    const queue: Array<MinHeapEntry> = []
+    let sequence = 0
+    minHeapPush(queue, { node: source, priority: 0, sequence: sequence++ })
+    while (queue.length > 0) {
+      const current = minHeapPop(queue)!
+      if (current.priority !== distances[current.node]) {
+        continue
+      }
+      for (let i = outgoing.rowOffsets[current.node]; i < outgoing.rowOffsets[current.node + 1]; i++) {
+        const edge = outgoing.edgeIndices[i]
+        const neighbor = outgoing.columnIndices[i]
+        const nextDistance = current.priority + weights[edge]
+        const known = distances[neighbor]
+        const predecessor = { node: current.node, edge }
+        if (nextDistance < known) {
+          distances[neighbor] = nextDistance
+          previous[neighbor] = [predecessor]
+          minHeapPush(queue, { node: neighbor, priority: nextDistance, sequence: sequence++ })
+        } else if (nextDistance === known && nextDistance !== Infinity) {
+          const predecessors = previous[neighbor]
+          if (predecessors === undefined) {
+            previous[neighbor] = [predecessor]
+          } else {
+            predecessors.push(predecessor)
+          }
+        }
+      }
+    }
+
+    const distance = distances[target]
+    if (distance === Infinity) {
+      return
+    }
+    if (source === target) {
+      yield { path: [config.source], edges: [], distance: 0, costs: [] }
+      return
+    }
+    const reversePath = [target]
+    const reverseEdges: Array<number> = []
+    const visited = new Uint8Array(cache.nodeIds.length)
+    visited[target] = 1
+    const stack: Array<{ readonly node: number; position: number }> = [{ node: target, position: 0 }]
+    let emitted = 0
+
+    const backtrack = () => {
+      const frame = stack.pop()!
+      if (stack.length > 0) {
+        visited[frame.node] = 0
+        reversePath.pop()
+        reverseEdges.pop()
+      }
+    }
+
+    while (stack.length > 0 && emitted < limit) {
+      const frame = stack[stack.length - 1]
+      if (frame.node === source) {
+        emitted++
+        yield {
+          path: reversePath.map((node) => cache.nodeIds[node]).reverse(),
+          edges: reverseEdges.map((edge) => edgeIds[edge]).reverse(),
+          distance,
+          costs: reverseEdges.map((edge) => graphEdges[edge].data as E).reverse()
+        }
+        backtrack()
+        continue
+      }
+      const predecessors = previous[frame.node] ?? []
+      if (frame.position >= predecessors.length) {
+        backtrack()
+        continue
+      }
+      const predecessor = predecessors[frame.position++]
+      if (visited[predecessor.node] !== 0) {
+        continue
+      }
+      visited[predecessor.node] = 1
+      reversePath.push(predecessor.node)
+      reverseEdges.push(predecessor.edge)
+      stack.push({ node: predecessor.node, position: 0 })
+    }
   })
 })
 

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -3704,6 +3704,64 @@ describe("Graph", () => {
     })
   })
 
+  describe("minimumSpanningForest", () => {
+    it("should preserve sparse indexes and include isolated nodes", () => {
+      const graph = Graph.fromSnapshot({
+        type: "undirected",
+        nodes: [
+          { index: 2, data: "A" },
+          { index: 5, data: "B" },
+          { index: 9, data: "C" },
+          { index: 20, data: "isolated" }
+        ],
+        edges: [
+          { index: 3, source: 2, target: 5, data: 4 },
+          { index: 7, source: 2, target: 5, data: 1 },
+          { index: 11, source: 5, target: 9, data: -2 },
+          { index: 13, source: 2, target: 9, data: 2 },
+          { index: 17, source: 9, target: 20, data: Infinity }
+        ]
+      })
+
+      for (const candidate of [graph, Graph.beginMutation(graph)]) {
+        const result = Graph.minimumSpanningForest(candidate, (edge) => edge)
+        assert.deepStrictEqual(Array.from(Graph.indices(Graph.nodes(result))), [2, 5, 9, 20])
+        assert.deepStrictEqual(Array.from(Graph.indices(Graph.edges(result))), [7, 11])
+      }
+    })
+
+    it("should break equal-weight ties by edge order", () => {
+      const graph = Graph.undirected<string, number>((mutable) => {
+        for (let i = 0; i < 3; i++) {
+          Graph.addNode(mutable, String(i))
+        }
+        Graph.addEdge(mutable, 0, 1, 1)
+        Graph.addEdge(mutable, 1, 2, 1)
+        Graph.addEdge(mutable, 0, 2, 1)
+      })
+
+      const result = Graph.minimumSpanningForest(graph, (edge) => edge)
+
+      assert.deepStrictEqual(Array.from(Graph.indices(Graph.edges(result))), [0, 1])
+    })
+
+    it("should reject directed graphs and unsupported weights", () => {
+      expect(() => Graph.minimumSpanningForest(Graph.directed() as any, () => 1)).toThrow(
+        "Cannot find minimum spanning forest of directed graph"
+      )
+      for (const weight of [NaN, -Infinity]) {
+        const graph = Graph.undirected<string, number>((mutable) => {
+          Graph.addNode(mutable, "A")
+          Graph.addNode(mutable, "B")
+          Graph.addEdge(mutable, 0, 1, weight)
+        })
+        expect(() => Graph.minimumSpanningForest(graph, (edge) => edge)).toThrow(
+          "Minimum spanning forest does not support NaN or -Infinity edge weights"
+        )
+      }
+    })
+  })
+
   describe("dijkstra", () => {
     it("should find shortest path in simple graph", () => {
       let nodeA: Graph.NodeIndex

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -851,7 +851,7 @@ describe("Graph", () => {
         Graph.addNode(mutable, "A")
       })
 
-      expect(() => Graph.inducedSubgraph(graph, [0, 1])).toThrow("Node 1 does not exist")
+      assertGraphError(() => Graph.inducedSubgraph(graph, [0, 1]), "Node 1 does not exist")
     })
 
     it("sum keeps equal nodes disjoint", () => {
@@ -2485,15 +2485,17 @@ describe("Graph", () => {
           Graph.addNode(mutable, "A")
         })
 
-        expect(() => Graph.degree(directed as any, 0)).toThrow("Cannot get degree of directed graph")
-        expect(() => Graph.outgoingEdges(undirected as any, 0)).toThrow(
+        assertGraphError(() => Graph.degree(directed as any, 0), "Cannot get degree of directed graph")
+        assertGraphError(
+          () => Graph.outgoingEdges(undirected as any, 0),
           "Cannot get outgoing edges of undirected graph"
         )
-        expect(() => Graph.incomingEdges(undirected as any, 0)).toThrow(
+        assertGraphError(
+          () => Graph.incomingEdges(undirected as any, 0),
           "Cannot get incoming edges of undirected graph"
         )
-        expect(() => Graph.incidentEdges(directed, 1)).toThrow("Node 1 does not exist")
-        expect(() => Graph.edgesBetween(directed, 0, 1)).toThrow("Node 1 does not exist")
+        assertGraphError(() => Graph.incidentEdges(directed, 1), "Node 1 does not exist")
+        assertGraphError(() => Graph.edgesBetween(directed, 0, 1), "Node 1 does not exist")
       })
     })
 
@@ -3693,12 +3695,14 @@ describe("Graph", () => {
       const directed = Graph.directed<string, number>()
       const undirected = Graph.undirected<string, number>()
 
-      expect(() => Graph.unweightedDistances(directed, 0)).toThrow("Node 0 does not exist")
-      expect(() => Graph.hasPath(directed, 0, 1)).toThrow("Node 0 does not exist")
-      expect(() => Graph.connectedComponents(directed as any)).toThrow(
+      assertGraphError(() => Graph.unweightedDistances(directed, 0), "Node 0 does not exist")
+      assertGraphError(() => Graph.hasPath(directed, 0, 1), "Node 0 does not exist")
+      assertGraphError(
+        () => Graph.connectedComponents(directed as any),
         "Cannot find connected components of directed graph"
       )
-      expect(() => Graph.weaklyConnectedComponents(undirected as any)).toThrow(
+      assertGraphError(
+        () => Graph.weaklyConnectedComponents(undirected as any),
         "Cannot find weakly connected components of undirected graph"
       )
     })
@@ -3746,7 +3750,8 @@ describe("Graph", () => {
     })
 
     it("should reject directed graphs and unsupported weights", () => {
-      expect(() => Graph.minimumSpanningForest(Graph.directed() as any, () => 1)).toThrow(
+      assertGraphError(
+        () => Graph.minimumSpanningForest(Graph.directed() as any, () => 1),
         "Cannot find minimum spanning forest of directed graph"
       )
       for (const weight of [NaN, -Infinity]) {
@@ -3755,10 +3760,64 @@ describe("Graph", () => {
           Graph.addNode(mutable, "B")
           Graph.addEdge(mutable, 0, 1, weight)
         })
-        expect(() => Graph.minimumSpanningForest(graph, (edge) => edge)).toThrow(
+        assertGraphError(
+          () => Graph.minimumSpanningForest(graph, (edge) => edge),
           "Minimum spanning forest does not support NaN or -Infinity edge weights"
         )
       }
+    })
+  })
+
+  describe("transitiveReduction", () => {
+    it("should preserve sparse indexes and coalesce parallel edges", () => {
+      const graph = Graph.fromSnapshot({
+        type: "directed",
+        nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }, { index: 9, data: "C" }],
+        edges: [
+          { index: 3, source: 2, target: 5, data: "first" },
+          { index: 4, source: 2, target: 5, data: "parallel" },
+          { index: 7, source: 5, target: 9, data: "next" },
+          { index: 11, source: 2, target: 9, data: "redundant" }
+        ]
+      })
+
+      for (const candidate of [graph, Graph.beginMutation(graph)]) {
+        const result = Graph.transitiveReduction(candidate)
+        assert.deepStrictEqual(Array.from(Graph.indices(Graph.nodes(result))), [2, 5, 9])
+        assert.deepStrictEqual(Array.from(Graph.indices(Graph.edges(result))), [3, 7])
+        assert.strictEqual(Graph.hasPath(result, 2, 9), true)
+      }
+    })
+
+    it("should retain both branches of a diamond", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        for (let i = 0; i < 4; i++) {
+          Graph.addNode(mutable, String(i))
+        }
+        Graph.addEdge(mutable, 0, 1, 1)
+        Graph.addEdge(mutable, 0, 2, 1)
+        Graph.addEdge(mutable, 1, 3, 1)
+        Graph.addEdge(mutable, 2, 3, 1)
+      })
+
+      assert.deepStrictEqual(
+        Array.from(Graph.indices(Graph.edges(Graph.transitiveReduction(graph)))),
+        [0, 1, 2, 3]
+      )
+    })
+
+    it("should reject undirected and cyclic graphs", () => {
+      assertGraphError(
+        () => Graph.transitiveReduction(Graph.undirected() as any),
+        "Cannot transitively reduce undirected graph"
+      )
+      const cyclic = Graph.directed<string, number>((mutable) => {
+        Graph.addNode(mutable, "A")
+        Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, 0, 1, 1)
+        Graph.addEdge(mutable, 1, 0, 1)
+      })
+      assertGraphError(() => Graph.transitiveReduction(cyclic), "Cannot transitively reduce cyclic graph")
     })
   })
 
@@ -4348,7 +4407,8 @@ describe("Graph", () => {
         Graph.addEdge(mutable, node, node, -1)
       })
 
-      expect(() => Graph.bellmanFord(graph, { source: 0, target: 0, cost: (edge) => edge })).toThrow(
+      assertGraphError(
+        () => Graph.bellmanFord(graph, { source: 0, target: 0, cost: (edge) => edge }),
         "Negative cycle affects path to node 0"
       )
     })
@@ -4359,7 +4419,8 @@ describe("Graph", () => {
         Graph.addEdge(mutable, node, node, -1)
       })
 
-      expect(() => Graph.bellmanFord(graph, { source: 0, target: 0, cost: (edge) => edge })).toThrow(
+      assertGraphError(
+        () => Graph.bellmanFord(graph, { source: 0, target: 0, cost: (edge) => edge }),
         "Negative cycle affects path to node 0"
       )
     })
@@ -4374,7 +4435,8 @@ describe("Graph", () => {
         Graph.addEdge(mutable, c, a, 1)
       })
 
-      expect(() => Graph.bellmanFord(graph, { source: 0, target: 2, cost: (edge) => edge })).toThrow(
+      assertGraphError(
+        () => Graph.bellmanFord(graph, { source: 0, target: 2, cost: (edge) => edge }),
         "Negative cycle affects path to node 2"
       )
     })
@@ -4398,7 +4460,8 @@ describe("Graph", () => {
         Graph.addEdge(mutable, a, b, -1)
       })
 
-      expect(() => Graph.bellmanFord(graph, { source: 0, target: 1, cost: (edge) => edge })).toThrow(
+      assertGraphError(
+        () => Graph.bellmanFord(graph, { source: 0, target: 1, cost: (edge) => edge }),
         "Negative cycle affects path to node 1"
       )
     })
@@ -4439,7 +4502,7 @@ describe("Graph", () => {
       // Check distance A to C (should be 5 via B, not 7 direct)
       expect(result.distances.get(0)?.get(2)).toBe(5)
       expect(result.paths.get(0)?.get(2)).toEqual([0, 1, 2])
-      expect(result.edges.get(0)?.get(2)).toEqual([0, 1])
+      assert.deepStrictEqual(result.edges.get(0)?.get(2), [0, 1])
       expect(result.costs.get(0)?.get(2)).toEqual([3, 2])
 
       // Check distance A to B
@@ -4464,7 +4527,7 @@ describe("Graph", () => {
 
       expect(result.distances.get(0)?.get(2)).toBe(Infinity)
       expect(result.paths.get(0)?.get(2)).toBeNull()
-      expect(result.edges.get(0)?.get(2)).toEqual([])
+      assert.deepStrictEqual(result.edges.get(0)?.get(2), [])
     })
 
     it("should handle same source and target", () => {
@@ -4476,7 +4539,7 @@ describe("Graph", () => {
 
       expect(result.distances.get(0)?.get(0)).toBe(0)
       expect(result.paths.get(0)?.get(0)).toEqual([0])
-      expect(result.edges.get(0)?.get(0)).toEqual([])
+      assert.deepStrictEqual(result.edges.get(0)?.get(0), [])
       expect(result.costs.get(0)?.get(0)).toEqual([])
     })
 
@@ -4498,7 +4561,7 @@ describe("Graph", () => {
 
       expect(result.distances.get(0)?.get(1)).toBe(Infinity)
       expect(result.paths.get(0)?.get(1)).toBeNull()
-      expect(result.edges.get(0)?.get(1)).toEqual([])
+      assert.deepStrictEqual(result.edges.get(0)?.get(1), [])
       expect(result.costs.get(0)?.get(1)).toEqual([])
     })
 
@@ -4557,7 +4620,7 @@ describe("Graph", () => {
 
       expect(result.distances.get(0)?.get(2)).toBe(2)
       expect(result.paths.get(0)?.get(2)).toEqual([0, 1, 2])
-      expect(result.edges.get(0)?.get(2)).toEqual([0, 1])
+      assert.deepStrictEqual(result.edges.get(0)?.get(2), [0, 1])
       expect(result.costs.get(0)?.get(2)).toEqual([1, 1])
     })
 
@@ -4569,6 +4632,185 @@ describe("Graph", () => {
       })
 
       expect(() => Graph.floydWarshall(graph, (edge) => edge)).toThrow("Negative cycle detected")
+    })
+  })
+
+  describe("lazy path enumeration", () => {
+    it("should lazily enumerate repeatable simple paths with exact edges", () => {
+      const graph = Graph.directed<string, string>((mutable) => {
+        for (let i = 0; i < 4; i++) {
+          Graph.addNode(mutable, String(i))
+        }
+        Graph.addEdge(mutable, 0, 1, "0-1")
+        Graph.addEdge(mutable, 0, 2, "0-2")
+        Graph.addEdge(mutable, 1, 2, "1-2")
+        Graph.addEdge(mutable, 1, 3, "1-3")
+        Graph.addEdge(mutable, 2, 3, "2-3")
+        Graph.addEdge(mutable, 2, 1, "2-1")
+      })
+      const paths = Graph.simplePaths(graph, { source: 0, target: 3, limit: 3 })
+      const expected = [
+        { path: [0, 1, 2, 3], edges: [0, 2, 4], distance: 3, costs: ["0-1", "1-2", "2-3"] },
+        { path: [0, 1, 3], edges: [0, 3], distance: 2, costs: ["0-1", "1-3"] },
+        { path: [0, 2, 3], edges: [1, 4], distance: 2, costs: ["0-2", "2-3"] }
+      ]
+
+      assert.deepStrictEqual(Array.from(paths), expected)
+      assert.deepStrictEqual(Array.from(paths), expected)
+    })
+
+    it("should enumerate parallel and structurally tied shortest paths", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        for (let i = 0; i < 4; i++) {
+          Graph.addNode(mutable, String(i))
+        }
+        Graph.addEdge(mutable, 0, 1, 1)
+        Graph.addEdge(mutable, 0, 2, 1)
+        Graph.addEdge(mutable, 1, 3, 1)
+        Graph.addEdge(mutable, 2, 3, 1)
+        Graph.addEdge(mutable, 0, 1, 1)
+      })
+
+      const result = Array.from(Graph.allShortestPaths(graph, { source: 0, target: 3, cost: (edge) => edge }))
+
+      assert.deepStrictEqual(result, [
+        { path: [0, 1, 3], edges: [0, 2], distance: 2, costs: [1, 1] },
+        { path: [0, 1, 3], edges: [4, 2], distance: 2, costs: [1, 1] },
+        { path: [0, 2, 3], edges: [1, 3], distance: 2, costs: [1, 1] }
+      ])
+      assert.deepStrictEqual(
+        Array.from(Graph.allShortestPaths(Graph.beginMutation(graph), {
+          source: 0,
+          target: 3,
+          cost: (edge) => edge,
+          limit: 2
+        })),
+        result.slice(0, 2)
+      )
+    })
+
+    it("should handle empty path enumerations", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        Graph.addNode(mutable, "A")
+        Graph.addNode(mutable, "B")
+      })
+
+      assert.deepStrictEqual(Array.from(Graph.simplePaths(graph, { source: 0, target: 0 })), [
+        { path: [0], edges: [], distance: 0, costs: [] }
+      ])
+      assert.deepStrictEqual(
+        Array.from(Graph.allShortestPaths(graph, { source: 0, target: 1, cost: (edge) => edge })),
+        []
+      )
+      assert.deepStrictEqual(Array.from(Graph.simplePaths(graph, { source: 0, target: 1, limit: 0 })), [])
+    })
+
+    it("should defer shortest-path computation until iteration", () => {
+      const graph = makeSingleEdgeGraph(1)
+      let costCalls = 0
+      const paths = Graph.allShortestPaths(graph, {
+        source: 0,
+        target: 1,
+        cost: (edge) => {
+          costCalls++
+          return edge
+        }
+      })
+
+      assert.strictEqual(costCalls, 0)
+      assert.deepStrictEqual(Array.from(paths), [{ path: [0, 1], edges: [0], distance: 1, costs: [1] }])
+      assert.strictEqual(costCalls, 1)
+    })
+
+    it("should revalidate mutable path endpoints when iteration starts", () => {
+      const makeMutable = () =>
+        Graph.beginMutation(Graph.directed<string, number>((graph) => {
+          Graph.addNode(graph, "A")
+          Graph.addNode(graph, "B")
+          Graph.addEdge(graph, 0, 1, 1)
+        }))
+      const simpleGraph = makeMutable()
+      const simple = Graph.simplePaths(simpleGraph, { source: 0, target: 1 })
+      Graph.removeNode(simpleGraph, 0)
+      assertGraphError(() => Array.from(simple), "Node 0 does not exist")
+
+      const shortestGraph = makeMutable()
+      const shortest = Graph.allShortestPaths(shortestGraph, { source: 0, target: 1, cost: (edge) => edge })
+      Graph.removeNode(shortestGraph, 1)
+      assertGraphError(() => Array.from(shortest), "Node 1 does not exist")
+    })
+
+    it("should isolate active mutable path iterations from later mutations", () => {
+      const makeMutable = () =>
+        Graph.beginMutation(Graph.directed<string, number>((graph) => {
+          for (let i = 0; i < 4; i++) {
+            Graph.addNode(graph, String(i))
+          }
+          Graph.addEdge(graph, 0, 1, 1)
+          Graph.addEdge(graph, 0, 2, 1)
+          Graph.addEdge(graph, 1, 3, 1)
+          Graph.addEdge(graph, 2, 3, 1)
+        }))
+      const assertSnapshot = (paths: Graph.PathWalker<number>, mutable: Graph.MutableDirectedGraph<string, number>) => {
+        const iterator = paths[Symbol.iterator]()
+        assert.deepStrictEqual(iterator.next().value?.edges, [0, 2])
+        Graph.removeEdge(mutable, 1)
+        assert.deepStrictEqual(iterator.next().value?.edges, [1, 3])
+      }
+
+      const simpleGraph = makeMutable()
+      assertSnapshot(Graph.simplePaths(simpleGraph, { source: 0, target: 3 }), simpleGraph)
+
+      const shortestGraph = makeMutable()
+      assertSnapshot(
+        Graph.allShortestPaths(shortestGraph, { source: 0, target: 3, cost: (edge) => edge }),
+        shortestGraph
+      )
+    })
+
+    it("should snapshot mutable adjacency before evaluating shortest-path costs", () => {
+      const mutable = Graph.beginMutation(Graph.directed<string, number>((graph) => {
+        Graph.addNode(graph, "A")
+        Graph.addNode(graph, "B")
+        Graph.addNode(graph, "C")
+        Graph.addEdge(graph, 0, 1, 1)
+        Graph.addEdge(graph, 1, 2, 1)
+        Graph.addEdge(graph, 0, 2, 3)
+      }))
+      let mutated = false
+      const paths = Graph.allShortestPaths(mutable, {
+        source: 0,
+        target: 2,
+        cost: (edge) => {
+          if (!mutated) {
+            mutated = true
+            Graph.removeEdge(mutable, 1)
+          }
+          return edge
+        }
+      })
+
+      assert.deepStrictEqual(Array.from(paths), [
+        { path: [0, 1, 2], edges: [0, 1], distance: 2, costs: [1, 1] }
+      ])
+    })
+
+    it("should validate path enumeration options", () => {
+      const graph = makeSingleEdgeGraph(-1)
+
+      assertGraphError(
+        () => Array.from(Graph.allShortestPaths(graph, { source: 0, target: 1, cost: (edge) => edge })),
+        "All shortest paths requires non-negative edge weights"
+      )
+      assertGraphError(
+        () => Array.from(Graph.allShortestPaths(graph, { source: 0, target: 1, cost: (edge) => edge, limit: 0 })),
+        "All shortest paths requires non-negative edge weights"
+      )
+      assertGraphError(
+        () => Graph.simplePaths(graph, { source: 0, target: 1, limit: -1 }),
+        "Path enumeration limit must be a non-negative integer or Infinity"
+      )
+      assertGraphError(() => Graph.simplePaths(graph, { source: 0, target: 2 }), "Node 2 does not exist")
     })
   })
 

--- a/packages/effect/typetest/Graph.tst.ts
+++ b/packages/effect/typetest/Graph.tst.ts
@@ -312,6 +312,18 @@ describe("Graph", () => {
     expect(Graph.findCycle(mutableUndirected)).type.toBe<Option.Option<Graph.CycleResult>>()
   })
 
+  it("minimumSpanningForest", () => {
+    expect(Graph.minimumSpanningForest(undirected, (edge) => edge)).type.toBe<
+      Graph.UndirectedGraph<string, number>
+    >()
+    expect(pipe(mutableUndirected, Graph.minimumSpanningForest((edge) => edge))).type.toBe<
+      Graph.UndirectedGraph<string, number>
+    >()
+
+    // @ts-expect-error! Minimum spanning forests require an undirected graph
+    Graph.minimumSpanningForest(directed, (edge) => edge)
+  })
+
   it("topo", () => {
     expect(Graph.topo(directed)).type.toBe<Graph.NodeWalker<string>>()
     expect(Graph.topo(directed, { initials: [0] })).type.toBe<Graph.NodeWalker<string>>()

--- a/packages/effect/typetest/Graph.tst.ts
+++ b/packages/effect/typetest/Graph.tst.ts
@@ -324,6 +324,32 @@ describe("Graph", () => {
     Graph.minimumSpanningForest(directed, (edge) => edge)
   })
 
+  it("transitiveReduction", () => {
+    expect(Graph.transitiveReduction(directed)).type.toBe<Graph.DirectedGraph<string, number>>()
+    expect(Graph.transitiveReduction(mutableDirected)).type.toBe<Graph.DirectedGraph<string, number>>()
+
+    // @ts-expect-error! Transitive reduction requires a directed graph
+    Graph.transitiveReduction(undirected)
+  })
+
+  it("lazy path enumeration", () => {
+    expect(Graph.simplePaths(directed, { source: 0, target: 1 })).type.toBe<Graph.PathWalker<number>>()
+    expect(pipe(undirected, Graph.simplePaths({ source: 0, target: 1, limit: 10 }))).type.toBe<
+      Graph.PathWalker<number>
+    >()
+    expect(Graph.allShortestPaths(directed, { source: 0, target: 1, cost: (edge) => edge })).type.toBe<
+      Graph.PathWalker<number>
+    >()
+    expect(pipe(
+      mutableDirected,
+      Graph.allShortestPaths({
+        source: 0,
+        target: 1,
+        cost: (edge) => edge
+      })
+    )).type.toBe<Graph.PathWalker<number>>()
+  })
+
   it("topo", () => {
     expect(Graph.topo(directed)).type.toBe<Graph.NodeWalker<string>>()
     expect(Graph.topo(directed, { initials: [0] })).type.toBe<Graph.NodeWalker<string>>()


### PR DESCRIPTION
Stack: #7291 → #7285 → #7289 → #7284 → #7286 → #7290 → **#7283** → #7287 → #7288

Depends on #7290.

Adds deterministic Kruskal minimumSpanningForest for undirected graphs. Preserves node and selected edge indexes, includes isolated nodes, supports negative finite weights, skips Infinity, and rejects invalid weights.