### PR TITLE
Normalize Bellman-Ford negative cycles

### DIFF
--- a/.changeset/neat-graphs-induced.md
+++ b/.changeset/neat-graphs-induced.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add index-preserving `Graph.inducedSubgraph`.

--- a/.changeset/tidy-graphs-cycle.md
+++ b/.changeset/tidy-graphs-cycle.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Throw `GraphError` when a negative cycle affects a Bellman-Ford target, reserving `Option.none()` for unreachable paths.

--- a/.changeset/warm-graphs-degree.md
+++ b/.changeset/warm-graphs-degree.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add incident-edge, edges-between, and directed and undirected degree queries to `Graph`.

--- a/.changeset/wise-graphs-connect.md
+++ b/.changeset/wise-graphs-connect.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add unweighted reachability, explicit weak and strong connectivity predicates, weak components, and tree detection to `Graph`.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -1375,6 +1375,51 @@ export const neighborhood: {
 })
 
 /**
+ * Returns the subgraph induced by a collection of node indices.
+ *
+ * Node and edge indices are preserved. Duplicate input indices are ignored,
+ * output ordering follows the original graph, and every edge whose endpoints
+ * are both selected is retained. Throws a `GraphError` when a selected node
+ * does not exist.
+ *
+ * @category set operations
+ * @since 4.0.0
+ */
+export const inducedSubgraph: {
+  (nodeIndices: Iterable<NodeIndex>): <N, E, T extends Kind = "directed">(self: Graph<N, E, T>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed">(
+    self: Graph<N, E, T>,
+    nodeIndices: Iterable<NodeIndex>
+  ): Graph<N, E, T>
+} = dual(2, <N, E, T extends Kind>(
+  self: Graph<N, E, T>,
+  nodeIndices: Iterable<NodeIndex>
+): Graph<N, E, T> => {
+  const impl = internal.toImpl(self)
+  const selected = new Set<NodeIndex>()
+  for (const nodeIndex of nodeIndices) {
+    if (!impl.nodes.has(nodeIndex)) {
+      throw missingNode(nodeIndex)
+    }
+    selected.add(nodeIndex)
+  }
+
+  const nodes: Array<IndexedNode<N>> = []
+  for (const [index, data] of impl.nodes) {
+    if (selected.has(index)) {
+      nodes.push({ index, data })
+    }
+  }
+  const edges: Array<IndexedEdge<E>> = []
+  for (const [index, edge] of impl.edges) {
+    if (selected.has(edge.source) && selected.has(edge.target)) {
+      edges.push({ index, source: edge.source, target: edge.target, data: edge.data })
+    }
+  }
+  return fromSnapshot({ type: self.type, nodes, edges })
+})
+
+/**
  * Returns the disjoint union of two graphs.
  *
  * **Details**
@@ -2578,6 +2623,211 @@ export const hasEdge: {
 export const edgeCount = <N, E, T extends Kind = "directed">(
   graph: Graph<N, E, T> | MutableGraph<N, E, T>
 ): number => internal.toImpl(graph).edges.size
+
+/**
+ * Returns the indices of all edges incident to a node.
+ *
+ * Each edge is returned once in graph edge order, including self-loops.
+ * Throws a `GraphError` when the node does not exist.
+ *
+ * @category getters
+ * @since 4.0.0
+ */
+export const incidentEdges: {
+  (
+    nodeIndex: NodeIndex
+  ): <N, E, T extends Kind = "directed">(graph: Graph<N, E, T> | MutableGraph<N, E, T>) => Array<EdgeIndex>
+  <N, E, T extends Kind = "directed">(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+    nodeIndex: NodeIndex
+  ): Array<EdgeIndex>
+} = dual(2, <N, E, T extends Kind = "directed">(
+  graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+  nodeIndex: NodeIndex
+): Array<EdgeIndex> => {
+  const impl = internal.toImpl(graph)
+  if (!impl.nodes.has(nodeIndex)) {
+    throw missingNode(nodeIndex)
+  }
+  const result: Array<EdgeIndex> = []
+  for (const [edgeIndex, edge] of impl.edges) {
+    if (edge.source === nodeIndex || edge.target === nodeIndex) {
+      result.push(edgeIndex)
+    }
+  }
+  return result
+})
+
+/**
+ * Returns the indices of outgoing edges for a node in a directed graph.
+ *
+ * Parallel edges and self-loops are returned separately in adjacency order.
+ * Throws a `GraphError` for an undirected graph or missing node.
+ *
+ * @category getters
+ * @since 4.0.0
+ */
+export const outgoingEdges: {
+  (nodeIndex: NodeIndex): <N, E>(
+    graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">
+  ) => Array<EdgeIndex>
+  <N, E>(
+    graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">,
+    nodeIndex: NodeIndex
+  ): Array<EdgeIndex>
+} = dual(2, <N, E, T extends Kind = "directed">(
+  graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+  nodeIndex: NodeIndex
+): Array<EdgeIndex> => {
+  if (graph.type === "undirected") {
+    throw new GraphError({ message: "Cannot get outgoing edges of undirected graph" })
+  }
+  const impl = internal.toImpl(graph)
+  if (!impl.nodes.has(nodeIndex)) {
+    throw missingNode(nodeIndex)
+  }
+  return Array.from(impl.adjacency.get(nodeIndex)!)
+})
+
+/**
+ * Returns the indices of incoming edges for a node in a directed graph.
+ *
+ * Parallel edges and self-loops are returned separately in reverse-adjacency
+ * order. Throws a `GraphError` for an undirected graph or missing node.
+ *
+ * @category getters
+ * @since 4.0.0
+ */
+export const incomingEdges: {
+  (nodeIndex: NodeIndex): <N, E>(
+    graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">
+  ) => Array<EdgeIndex>
+  <N, E>(
+    graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">,
+    nodeIndex: NodeIndex
+  ): Array<EdgeIndex>
+} = dual(2, <N, E, T extends Kind = "directed">(
+  graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+  nodeIndex: NodeIndex
+): Array<EdgeIndex> => {
+  if (graph.type === "undirected") {
+    throw new GraphError({ message: "Cannot get incoming edges of undirected graph" })
+  }
+  const impl = internal.toImpl(graph)
+  if (!impl.nodes.has(nodeIndex)) {
+    throw missingNode(nodeIndex)
+  }
+  return Array.from(impl.reverseAdjacency.get(nodeIndex)!)
+})
+
+/**
+ * Returns all edge indices connecting the supplied nodes.
+ *
+ * Directed graphs only include edges from `source` to `target`; undirected
+ * graphs include either stored orientation. Parallel edges are retained.
+ * Throws a `GraphError` when either node does not exist.
+ *
+ * @category getters
+ * @since 4.0.0
+ */
+export const edgesBetween: {
+  (source: NodeIndex, target: NodeIndex): <N, E, T extends Kind = "directed">(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>
+  ) => Array<EdgeIndex>
+  <N, E, T extends Kind = "directed">(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+    source: NodeIndex,
+    target: NodeIndex
+  ): Array<EdgeIndex>
+} = dual(3, <N, E, T extends Kind = "directed">(
+  graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+  source: NodeIndex,
+  target: NodeIndex
+): Array<EdgeIndex> => {
+  const impl = internal.toImpl(graph)
+  if (!impl.nodes.has(source)) {
+    throw missingNode(source)
+  }
+  if (!impl.nodes.has(target)) {
+    throw missingNode(target)
+  }
+  const result: Array<EdgeIndex> = []
+  for (const [edgeIndex, edge] of impl.edges) {
+    if (
+      (edge.source === source && edge.target === target) ||
+      (graph.type === "undirected" && edge.source === target && edge.target === source)
+    ) {
+      result.push(edgeIndex)
+    }
+  }
+  return result
+})
+
+/**
+ * Returns the degree of a node in an undirected graph.
+ *
+ * Parallel edges count separately and a self-loop contributes two. Throws a
+ * `GraphError` for a directed graph or missing node.
+ *
+ * @category getters
+ * @since 4.0.0
+ */
+export const degree: {
+  (nodeIndex: NodeIndex): <N, E>(
+    graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
+  ) => number
+  <N, E>(graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">, nodeIndex: NodeIndex): number
+} = dual(2, <N, E, T extends Kind = "directed">(
+  graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+  nodeIndex: NodeIndex
+): number => {
+  if (graph.type === "directed") {
+    throw new GraphError({ message: "Cannot get degree of directed graph" })
+  }
+  const impl = internal.toImpl(graph)
+  if (!impl.nodes.has(nodeIndex)) {
+    throw missingNode(nodeIndex)
+  }
+  return impl.adjacency.get(nodeIndex)!.length
+})
+
+/**
+ * Returns the out-degree of a node in a directed graph.
+ *
+ * Parallel edges count separately and a self-loop contributes one. Throws a
+ * `GraphError` for an undirected graph or missing node.
+ *
+ * @category getters
+ * @since 4.0.0
+ */
+export const outDegree: {
+  (nodeIndex: NodeIndex): <N, E>(
+    graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">
+  ) => number
+  <N, E>(graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">, nodeIndex: NodeIndex): number
+} = dual(2, <N, E, T extends Kind = "directed">(
+  graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+  nodeIndex: NodeIndex
+): number => outgoingEdges(graph as any, nodeIndex).length)
+
+/**
+ * Returns the in-degree of a node in a directed graph.
+ *
+ * Parallel edges count separately and a self-loop contributes one. Throws a
+ * `GraphError` for an undirected graph or missing node.
+ *
+ * @category getters
+ * @since 4.0.0
+ */
+export const inDegree: {
+  (nodeIndex: NodeIndex): <N, E>(
+    graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">
+  ) => number
+  <N, E>(graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">, nodeIndex: NodeIndex): number
+} = dual(2, <N, E, T extends Kind = "directed">(
+  graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+  nodeIndex: NodeIndex
+): number => incomingEdges(graph as any, nodeIndex).length)
 
 const getDirectedNeighbors = <N, E>(
   graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">,
@@ -3896,6 +4146,123 @@ const getTraversableNeighbor = <N, E, T extends Kind>(
 ): NodeIndex => graph.type === "undirected" && edge.target === current ? edge.source : edge.target
 
 /**
+ * Configuration for unweighted reachability queries.
+ *
+ * `direction` defaults to `"outgoing"` and is ignored for undirected graphs.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ReachabilityConfig {
+  readonly direction?: TraversalDirection
+}
+
+const getUnweightedDistances = <N, E, T extends Kind>(
+  graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+  source: NodeIndex,
+  direction: TraversalDirection,
+  target?: NodeIndex
+): Map<NodeIndex, number> => {
+  const impl = internal.toImpl(graph)
+  if (!impl.nodes.has(source)) {
+    throw missingNode(source)
+  }
+  if (target !== undefined && !impl.nodes.has(target)) {
+    throw missingNode(target)
+  }
+
+  const cache = csr.get(graph)
+  const sourceNode = csr.getNodeIndex(cache, source)!
+  const targetNode = target === undefined ? undefined : csr.getNodeIndex(cache, target)!
+  const adjacencies = csr.getAdjacencies(cache, graph.type === "undirected" ? "outgoing" : direction)
+  const compactDistances = new Int32Array(cache.nodeIds.length)
+  compactDistances.fill(-1)
+  compactDistances[sourceNode] = 0
+  const queue = new Uint32Array(cache.nodeIds.length)
+  let head = 0
+  let tail = 0
+  queue[tail++] = sourceNode
+
+  while (head < tail) {
+    const current = queue[head++]
+    if (current === targetNode) {
+      break
+    }
+    const visit = (adjacency: csr.Adjacency) => {
+      for (let i = adjacency.rowOffsets[current]; i < adjacency.rowOffsets[current + 1]; i++) {
+        const neighbor = adjacency.columnIndices[i]
+        if (compactDistances[neighbor] === -1) {
+          compactDistances[neighbor] = compactDistances[current] + 1
+          queue[tail++] = neighbor
+        }
+      }
+    }
+    visit(adjacencies.primary)
+    if (adjacencies.secondary !== undefined) {
+      visit(adjacencies.secondary)
+    }
+  }
+
+  const result = new Map<NodeIndex, number>()
+  for (let i = 0; i < cache.nodeIds.length; i++) {
+    if (compactDistances[i] !== -1) {
+      result.set(cache.nodeIds[i], compactDistances[i])
+    }
+  }
+  return result
+}
+
+/**
+ * Returns minimum unweighted distances from a source to every reachable node.
+ *
+ * Throws a `GraphError` when the source does not exist. Directed traversal is
+ * outgoing by default and can be changed with `direction`.
+ *
+ * @category algorithms
+ * @since 4.0.0
+ */
+export const unweightedDistances: {
+  (source: NodeIndex, options?: ReachabilityConfig): <N, E, T extends Kind = "directed">(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>
+  ) => Map<NodeIndex, number>
+  <N, E, T extends Kind = "directed">(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+    source: NodeIndex,
+    options?: ReachabilityConfig
+  ): Map<NodeIndex, number>
+} = dual((args) => isGraph(args[0]), <N, E, T extends Kind = "directed">(
+  graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+  source: NodeIndex,
+  options?: ReachabilityConfig
+): Map<NodeIndex, number> => getUnweightedDistances(graph, source, options?.direction ?? "outgoing"))
+
+/**
+ * Tests whether a target is reachable from a source.
+ *
+ * Throws a `GraphError` when either endpoint does not exist. Directed traversal
+ * is outgoing by default and can be changed with `direction`.
+ *
+ * @category predicates
+ * @since 4.0.0
+ */
+export const hasPath: {
+  (source: NodeIndex, target: NodeIndex, options?: ReachabilityConfig): <N, E, T extends Kind = "directed">(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>
+  ) => boolean
+  <N, E, T extends Kind = "directed">(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+    source: NodeIndex,
+    target: NodeIndex,
+    options?: ReachabilityConfig
+  ): boolean
+} = dual((args) => isGraph(args[0]), <N, E, T extends Kind = "directed">(
+  graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+  source: NodeIndex,
+  target: NodeIndex,
+  options?: ReachabilityConfig
+): boolean => getUnweightedDistances(graph, source, options?.direction ?? "outgoing", target).has(target))
+
+/**
  * Finds connected components in an undirected graph.
  * Each component is represented as an array of node indices.
  *
@@ -3922,6 +4289,9 @@ const getTraversableNeighbor = <N, E, T extends Kind>(
 export const connectedComponents = <N, E>(
   graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
 ): Array<Array<NodeIndex>> => {
+  if ((graph as Graph<N, E, Kind> | MutableGraph<N, E, Kind>).type === "directed") {
+    throw new GraphError({ message: "Cannot find connected components of directed graph" })
+  }
   const impl = internal.toImpl(graph)
   if (!graph.mutable) {
     const cache = csr.get(graph)
@@ -3998,6 +4368,54 @@ export const connectedComponents = <N, E>(
     }
   }
 
+  return components
+}
+
+/**
+ * Finds weakly connected components in a directed graph.
+ *
+ * Edge direction is ignored while partitioning nodes. Throws a `GraphError`
+ * when used with an undirected graph.
+ *
+ * @category algorithms
+ * @since 4.0.0
+ */
+export const weaklyConnectedComponents = <N, E>(
+  graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">
+): Array<Array<NodeIndex>> => {
+  if ((graph as Graph<N, E, Kind> | MutableGraph<N, E, Kind>).type === "undirected") {
+    throw new GraphError({ message: "Cannot find weakly connected components of undirected graph" })
+  }
+  const cache = csr.get(graph)
+  const { primary, secondary } = csr.getAdjacencies(cache, "undirected")
+  const visited = new Uint8Array(cache.nodeIds.length)
+  const components: Array<Array<NodeIndex>> = []
+  for (let start = 0; start < cache.nodeIds.length; start++) {
+    if (visited[start] !== 0) {
+      continue
+    }
+    const component: Array<NodeIndex> = []
+    const stack = [start]
+    while (stack.length > 0) {
+      const current = stack.pop()!
+      if (visited[current] !== 0) {
+        continue
+      }
+      visited[current] = 1
+      component.push(cache.nodeIds[current])
+      const push = (adjacency: csr.Adjacency) => {
+        for (let i = adjacency.rowOffsets[current]; i < adjacency.rowOffsets[current + 1]; i++) {
+          const neighbor = adjacency.columnIndices[i]
+          if (visited[neighbor] === 0) {
+            stack.push(neighbor)
+          }
+        }
+      }
+      push(primary)
+      push(secondary!)
+    }
+    components.push(component)
+  }
   return components
 }
 
@@ -4196,6 +4614,64 @@ export const stronglyConnectedComponents = <N, E>(
   }
 
   return sccs
+}
+
+/**
+ * Tests whether an undirected graph has at most one connected component.
+ *
+ * The empty graph is considered connected. Throws a `GraphError` when used
+ * with a directed graph.
+ *
+ * @category predicates
+ * @since 4.0.0
+ */
+export const isConnected = <N, E>(
+  graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
+): boolean => connectedComponents(graph).length <= 1
+
+/**
+ * Tests whether a directed graph has at most one weakly connected component.
+ *
+ * The empty graph is considered weakly connected. Throws a `GraphError` when
+ * used with an undirected graph.
+ *
+ * @category predicates
+ * @since 4.0.0
+ */
+export const isWeaklyConnected = <N, E>(
+  graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">
+): boolean => weaklyConnectedComponents(graph).length <= 1
+
+/**
+ * Tests whether a directed graph has at most one strongly connected component.
+ *
+ * The empty graph is considered strongly connected. Throws a `GraphError` when
+ * used with an undirected graph.
+ *
+ * @category predicates
+ * @since 4.0.0
+ */
+export const isStronglyConnected = <N, E>(
+  graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">
+): boolean => stronglyConnectedComponents(graph).length <= 1
+
+/**
+ * Tests whether a non-empty undirected graph is a tree.
+ *
+ * Parallel edges and self-loops prevent a graph from being a tree. Throws a
+ * `GraphError` when used with a directed graph.
+ *
+ * @category predicates
+ * @since 4.0.0
+ */
+export const isTree = <N, E>(
+  graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
+): boolean => {
+  if ((graph as Graph<N, E, Kind> | MutableGraph<N, E, Kind>).type === "directed") {
+    throw new GraphError({ message: "Cannot determine tree status of directed graph" })
+  }
+  const nodes = nodeCount(graph)
+  return nodes > 0 && edgeCount(graph) === nodes - 1 && isConnected(graph)
 }
 
 // =============================================================================

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -5340,9 +5340,9 @@ export interface BellmanFordConfig<E> {
  * **Details**
  *
  * Negative edge weights are allowed, and `Infinity` behaves like an impassable
- * edge. Returns `Option.none()` when the target is unreachable or when a
- * negative cycle affects the path to the target. Throws a `GraphError` when
- * either endpoint is missing or an edge weight is `NaN` or `-Infinity`.
+ * edge. Returns `Option.none()` when the target is unreachable. Throws a
+ * `GraphError` when a reachable negative cycle can affect the target, either
+ * endpoint is missing, or an edge weight is `NaN` or `-Infinity`.
  *
  * **Example** (Finding shortest paths with Bellman-Ford)
  *
@@ -5480,7 +5480,7 @@ export const bellmanFord: {
       }
     }
     if (affected[target] !== 0) {
-      return Option.none()
+      throw new GraphError({ message: `Negative cycle affects path to node ${config.target}` })
     }
     if (distances[target] === Infinity) {
       return Option.none()
@@ -5592,7 +5592,7 @@ export const bellmanFord: {
 
       // If target is affected by a negative cycle, no shortest path exists.
       if (affectedNodes.has(config.target)) {
-        return Option.none()
+        throw new GraphError({ message: `Negative cycle affects path to node ${config.target}` })
       }
     }
   }

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -810,6 +810,50 @@ describe("Graph", () => {
       }
     })
 
+    it("inducedSubgraph preserves sparse node and edge indexes", () => {
+      const graph = Graph.fromSnapshot({
+        type: "directed",
+        nodes: [
+          { index: 2, data: "A" },
+          { index: 5, data: "B" },
+          { index: 9, data: "C" }
+        ],
+        edges: [
+          { index: 3, source: 2, target: 5, data: "A-B" },
+          { index: 7, source: 5, target: 9, data: "B-C" },
+          { index: 11, source: 5, target: 5, data: "B-B" }
+        ]
+      })
+
+      const result = Graph.inducedSubgraph(graph, [9, 5, 5])
+
+      assert.deepStrictEqual(Array.from(Graph.nodes(result)), [[5, "B"], [9, "C"]])
+      assert.deepStrictEqual(Array.from(Graph.edges(result)), [
+        [7, { source: 5, target: 9, data: "B-C" }],
+        [11, { source: 5, target: 5, data: "B-B" }]
+      ])
+    })
+
+    it("inducedSubgraph preserves graph kind and handles empty selections", () => {
+      const graph = Graph.undirected<string, number>((mutable) => {
+        Graph.addNode(mutable, "A")
+      })
+
+      const result = Graph.inducedSubgraph([])(graph)
+
+      assert.strictEqual(result.type, "undirected")
+      assert.strictEqual(Graph.nodeCount(result), 0)
+      assert.strictEqual(Graph.edgeCount(result), 0)
+    })
+
+    it("inducedSubgraph rejects missing nodes", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        Graph.addNode(mutable, "A")
+      })
+
+      expect(() => Graph.inducedSubgraph(graph, [0, 1])).toThrow("Node 1 does not exist")
+    })
+
     it("sum keeps equal nodes disjoint", () => {
       const left = Graph.directed<string, string>((mutable) => {
         const a = Graph.addNode(mutable, "A")
@@ -2383,6 +2427,76 @@ describe("Graph", () => {
       })
     })
 
+    describe("edge and degree queries", () => {
+      it("should preserve directed parallel edges and self-loops", () => {
+        const graph = Graph.directed<string, number>((mutable) => {
+          Graph.addNode(mutable, "A")
+          Graph.addNode(mutable, "B")
+          Graph.addEdge(mutable, 0, 1, 1)
+          Graph.addEdge(mutable, 0, 1, 2)
+          Graph.addEdge(mutable, 1, 0, 3)
+          Graph.addEdge(mutable, 0, 0, 4)
+        })
+
+        assert.deepStrictEqual(Graph.incidentEdges(graph, 0), [0, 1, 2, 3])
+        assert.deepStrictEqual(Graph.outgoingEdges(graph, 0), [0, 1, 3])
+        assert.deepStrictEqual(Graph.incomingEdges(graph, 0), [2, 3])
+        assert.deepStrictEqual(Graph.edgesBetween(graph, 0, 1), [0, 1])
+        assert.deepStrictEqual(Graph.edgesBetween(graph, 1, 0), [2])
+        assert.strictEqual(Graph.outDegree(graph, 0), 3)
+        assert.strictEqual(Graph.inDegree(graph, 0), 2)
+      })
+
+      it("should count undirected self-loops twice only for degree", () => {
+        const graph = Graph.undirected<string, number>((mutable) => {
+          Graph.addNode(mutable, "A")
+          Graph.addNode(mutable, "B")
+          Graph.addEdge(mutable, 0, 1, 1)
+          Graph.addEdge(mutable, 1, 0, 2)
+          Graph.addEdge(mutable, 0, 0, 3)
+        })
+
+        assert.deepStrictEqual(Graph.incidentEdges(graph, 0), [0, 1, 2])
+        assert.deepStrictEqual(Graph.edgesBetween(graph, 0, 1), [0, 1])
+        assert.deepStrictEqual(Graph.edgesBetween(graph, 0, 0), [2])
+        assert.strictEqual(Graph.degree(graph, 0), 4)
+      })
+
+      it("should support data-last calls and mutable graphs", () => {
+        const mutable = Graph.beginMutation(Graph.directed<string, number>((graph) => {
+          Graph.addNode(graph, "A")
+          Graph.addNode(graph, "B")
+          Graph.addEdge(graph, 0, 1, 1)
+        }))
+
+        assert.deepStrictEqual(Graph.incidentEdges(0)(mutable), [0])
+        assert.deepStrictEqual(Graph.outgoingEdges(0)(mutable), [0])
+        assert.deepStrictEqual(Graph.incomingEdges(1)(mutable), [0])
+        assert.deepStrictEqual(Graph.edgesBetween(0, 1)(mutable), [0])
+        assert.strictEqual(Graph.outDegree(0)(mutable), 1)
+        assert.strictEqual(Graph.inDegree(1)(mutable), 1)
+      })
+
+      it("should reject invalid kinds and missing nodes", () => {
+        const directed = Graph.directed<string, number>((mutable) => {
+          Graph.addNode(mutable, "A")
+        })
+        const undirected = Graph.undirected<string, number>((mutable) => {
+          Graph.addNode(mutable, "A")
+        })
+
+        expect(() => Graph.degree(directed as any, 0)).toThrow("Cannot get degree of directed graph")
+        expect(() => Graph.outgoingEdges(undirected as any, 0)).toThrow(
+          "Cannot get outgoing edges of undirected graph"
+        )
+        expect(() => Graph.incomingEdges(undirected as any, 0)).toThrow(
+          "Cannot get incoming edges of undirected graph"
+        )
+        expect(() => Graph.incidentEdges(directed, 1)).toThrow("Node 1 does not exist")
+        expect(() => Graph.edgesBetween(directed, 0, 1)).toThrow("Node 1 does not exist")
+      })
+    })
+
     describe("neighbors", () => {
       it("should return correct neighbors for directed graph", () => {
         const graph = Graph.directed<string, number>((mutable) => {
@@ -3439,6 +3553,116 @@ describe("Graph", () => {
 
       expect(() => Graph.stronglyConnectedComponents(graph as any))
         .toThrow("Cannot find strongly connected components of undirected graph")
+    })
+  })
+
+  describe("reachability and connectivity", () => {
+    it("should compute unweighted distances in each directed traversal mode", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        for (let i = 0; i < 4; i++) {
+          Graph.addNode(mutable, String(i))
+        }
+        Graph.addEdge(mutable, 0, 1, 1)
+        Graph.addEdge(mutable, 1, 2, 1)
+        Graph.addEdge(mutable, 3, 1, 1)
+      })
+
+      assert.deepStrictEqual(Array.from(Graph.unweightedDistances(graph, 0)), [[0, 0], [1, 1], [2, 2]])
+      assert.deepStrictEqual(Array.from(Graph.unweightedDistances(graph, 2, { direction: "incoming" })), [
+        [0, 2],
+        [1, 1],
+        [2, 0],
+        [3, 2]
+      ])
+      assert.deepStrictEqual(Array.from(Graph.unweightedDistances(graph, 0, { direction: "undirected" })), [
+        [0, 0],
+        [1, 1],
+        [2, 2],
+        [3, 2]
+      ])
+      assert.strictEqual(Graph.hasPath(graph, 0, 2), true)
+      assert.strictEqual(Graph.hasPath(graph, 2, 0), false)
+      assert.strictEqual(Graph.hasPath(graph, 2, 0, { direction: "incoming" }), true)
+      assert.strictEqual(Graph.hasPath(3, 2, { direction: "undirected" })(Graph.beginMutation(graph)), true)
+    })
+
+    it("should find weak components and connectivity for immutable and mutable graphs", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        for (let i = 0; i < 4; i++) {
+          Graph.addNode(mutable, String(i))
+        }
+        Graph.addEdge(mutable, 0, 1, 1)
+        Graph.addEdge(mutable, 2, 1, 1)
+      })
+
+      for (const candidate of [graph, Graph.beginMutation(graph)]) {
+        const components = Graph.weaklyConnectedComponents(candidate).map((component) => component.sort())
+        components.sort((a, b) => a[0] - b[0])
+        assert.deepStrictEqual(components, [[0, 1, 2], [3]])
+        assert.strictEqual(Graph.isWeaklyConnected(candidate), false)
+        assert.strictEqual(Graph.isStronglyConnected(candidate), false)
+      }
+    })
+
+    it("should rebuild CSR after graph mutation", () => {
+      const mutable = Graph.beginMutation(Graph.directed<string, number>((graph) => {
+        Graph.addNode(graph, "A")
+        Graph.addNode(graph, "B")
+        Graph.addNode(graph, "C")
+        Graph.addEdge(graph, 0, 1, 1)
+      }))
+
+      assert.strictEqual(Graph.weaklyConnectedComponents(mutable).length, 2)
+      assert.deepStrictEqual(Array.from(Graph.unweightedDistances(mutable, 0)), [[0, 0], [1, 1]])
+
+      Graph.addEdge(mutable, 1, 2, 1)
+
+      assert.strictEqual(Graph.weaklyConnectedComponents(mutable).length, 1)
+      assert.deepStrictEqual(Array.from(Graph.unweightedDistances(mutable, 0)), [[0, 0], [1, 1], [2, 2]])
+    })
+
+    it("should identify undirected trees and connected graphs", () => {
+      const tree = Graph.undirected<string, number>((mutable) => {
+        for (let i = 0; i < 3; i++) {
+          Graph.addNode(mutable, String(i))
+        }
+        Graph.addEdge(mutable, 0, 1, 1)
+        Graph.addEdge(mutable, 1, 2, 1)
+      })
+      const cycle = Graph.mutate(tree, (mutable) => {
+        Graph.addEdge(mutable, 2, 0, 1)
+      })
+
+      assert.strictEqual(Graph.isConnected(tree), true)
+      assert.strictEqual(Graph.isTree(tree), true)
+      assert.strictEqual(Graph.isTree(cycle), false)
+      assert.strictEqual(Graph.isConnected(Graph.undirected()), true)
+      assert.strictEqual(Graph.isTree(Graph.undirected()), false)
+      assert.strictEqual(Graph.isWeaklyConnected(Graph.directed()), true)
+      assert.strictEqual(Graph.isStronglyConnected(Graph.directed()), true)
+    })
+
+    it("should reject directed graphs when testing trees before short-circuiting", () => {
+      assertGraphError(() => Graph.isTree(Graph.directed() as any), "Cannot determine tree status of directed graph")
+      const directed = Graph.directed<string, number>((mutable) => {
+        Graph.addNode(mutable, "A")
+        Graph.addNode(mutable, "B")
+      })
+      assertGraphError(() => Graph.isTree(directed as any), "Cannot determine tree status of directed graph")
+    })
+
+    it("should reject missing nodes and mismatched connectivity kinds", () => {
+      const directed = Graph.directed<string, number>()
+      const undirected = Graph.undirected<string, number>()
+
+      expect(() => Graph.unweightedDistances(directed, 0)).toThrow("Node 0 does not exist")
+      expect(() => Graph.hasPath(directed, 0, 1)).toThrow("Node 0 does not exist")
+      expect(() => Graph.connectedComponents(directed as any)).toThrow(
+        "Cannot find connected components of directed graph"
+      )
+      expect(() => Graph.weaklyConnectedComponents(undirected as any)).toThrow(
+        "Cannot find weakly connected components of undirected graph"
+      )
     })
   })
 

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -4028,13 +4028,9 @@ describe("Graph", () => {
         Graph.addEdge(mutable, node, node, -1)
       })
 
-      const result = Graph.bellmanFord(graph, {
-        source: 0,
-        target: 0,
-        cost: (edge) => edge
-      })
-
-      assertNone(result)
+      expect(() => Graph.bellmanFord(graph, { source: 0, target: 0, cost: (edge) => edge })).toThrow(
+        "Negative cycle affects path to node 0"
+      )
     })
 
     it("should detect an undirected negative self-loop when source equals target", () => {
@@ -4043,13 +4039,9 @@ describe("Graph", () => {
         Graph.addEdge(mutable, node, node, -1)
       })
 
-      const result = Graph.bellmanFord(graph, {
-        source: 0,
-        target: 0,
-        cost: (edge) => edge
-      })
-
-      assertNone(result)
+      expect(() => Graph.bellmanFord(graph, { source: 0, target: 0, cost: (edge) => edge })).toThrow(
+        "Negative cycle affects path to node 0"
+      )
     })
 
     it("should detect negative cycles", () => {
@@ -4062,13 +4054,9 @@ describe("Graph", () => {
         Graph.addEdge(mutable, c, a, 1)
       })
 
-      const result = Graph.bellmanFord(graph, {
-        source: 0,
-        target: 2,
-        cost: (edge) => edge
-      })
-
-      expect(result).toEqual(Option.none())
+      expect(() => Graph.bellmanFord(graph, { source: 0, target: 2, cost: (edge) => edge })).toThrow(
+        "Negative cycle affects path to node 2"
+      )
     })
 
     it("should traverse undirected edges in reverse storage direction", () => {
@@ -4090,13 +4078,28 @@ describe("Graph", () => {
         Graph.addEdge(mutable, a, b, -1)
       })
 
-      const result = Graph.bellmanFord(graph, {
-        source: 0,
-        target: 1,
-        cost: (edge) => edge
-      })
+      expect(() => Graph.bellmanFord(graph, { source: 0, target: 1, cost: (edge) => edge })).toThrow(
+        "Negative cycle affects path to node 1"
+      )
+    })
 
-      assertNone(result)
+    it("should ignore negative cycles that cannot affect the target", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        for (let i = 0; i < 4; i++) {
+          Graph.addNode(mutable, String(i))
+        }
+        Graph.addEdge(mutable, 0, 1, 1)
+        Graph.addEdge(mutable, 1, 2, -2)
+        Graph.addEdge(mutable, 2, 1, 1)
+        Graph.addEdge(mutable, 0, 3, 5)
+      })
+      const expected = { path: [0, 3], edges: [3], distance: 5, costs: [5] }
+
+      assertSome(Graph.bellmanFord(graph, { source: 0, target: 3, cost: (edge) => edge }), expected)
+      assertSome(
+        Graph.bellmanFord(Graph.beginMutation(graph), { source: 0, target: 3, cost: (edge) => edge }),
+        expected
+      )
     })
   })
 

--- a/packages/effect/typetest/Graph.tst.ts
+++ b/packages/effect/typetest/Graph.tst.ts
@@ -246,6 +246,13 @@ describe("Graph", () => {
     >()
   })
 
+  it("inducedSubgraph", () => {
+    expect(Graph.inducedSubgraph(directed, [0, 1])).type.toBe<Graph.DirectedGraph<string, number>>()
+    expect(pipe(undirected, Graph.inducedSubgraph(new Set([0, 1])))).type.toBe<
+      Graph.UndirectedGraph<string, number>
+    >()
+  })
+
   it("undirected traversal", () => {
     expect(Graph.dfs(directed, { direction: "undirected", radius: 1 })).type.toBe<Graph.NodeWalker<string>>()
     expect(Graph.bfs(directed, { direction: "undirected", radius: 1 })).type.toBe<Graph.NodeWalker<string>>()
@@ -258,6 +265,46 @@ describe("Graph", () => {
 
     expect(path.edges).type.toBe<Array<Graph.EdgeIndex>>()
     expect(allPairs.edges).type.toBe<Map<Graph.NodeIndex, Map<Graph.NodeIndex, Array<Graph.EdgeIndex>>>>()
+  })
+
+  it("edge and degree queries", () => {
+    expect(Graph.incidentEdges(directed, 0)).type.toBe<Array<Graph.EdgeIndex>>()
+    expect(pipe(undirected, Graph.incidentEdges(0))).type.toBe<Array<Graph.EdgeIndex>>()
+    expect(Graph.edgesBetween(directed, 0, 1)).type.toBe<Array<Graph.EdgeIndex>>()
+    expect(pipe(undirected, Graph.edgesBetween(0, 1))).type.toBe<Array<Graph.EdgeIndex>>()
+    expect(Graph.outgoingEdges(directed, 0)).type.toBe<Array<Graph.EdgeIndex>>()
+    expect(Graph.incomingEdges(mutableDirected, 0)).type.toBe<Array<Graph.EdgeIndex>>()
+    expect(Graph.degree(undirected, 0)).type.toBe<number>()
+    expect(Graph.outDegree(directed, 0)).type.toBe<number>()
+    expect(Graph.inDegree(mutableDirected, 0)).type.toBe<number>()
+
+    // @ts-expect-error! Directed edge queries require a directed graph
+    Graph.outgoingEdges(undirected, 0)
+    // @ts-expect-error! Directed edge queries require a directed graph
+    Graph.incomingEdges(mutableUndirected, 0)
+    // @ts-expect-error! Degree requires an undirected graph
+    Graph.degree(directed, 0)
+  })
+
+  it("reachability and connectivity", () => {
+    expect(Graph.unweightedDistances(directed, 0)).type.toBe<Map<Graph.NodeIndex, number>>()
+    expect(pipe(directed, Graph.unweightedDistances(0, { direction: "incoming" }))).type.toBe<
+      Map<Graph.NodeIndex, number>
+    >()
+    expect(Graph.hasPath(directed, 0, 1)).type.toBe<boolean>()
+    expect(pipe(undirected, Graph.hasPath(0, 1))).type.toBe<boolean>()
+    expect(Graph.weaklyConnectedComponents(directed)).type.toBe<Array<Array<Graph.NodeIndex>>>()
+    expect(Graph.isConnected(undirected)).type.toBe<boolean>()
+    expect(Graph.isWeaklyConnected(directed)).type.toBe<boolean>()
+    expect(Graph.isStronglyConnected(mutableDirected)).type.toBe<boolean>()
+    expect(Graph.isTree(mutableUndirected)).type.toBe<boolean>()
+
+    // @ts-expect-error! Weak connectivity requires a directed graph
+    Graph.weaklyConnectedComponents(undirected)
+    // @ts-expect-error! Undirected connectivity requires an undirected graph
+    Graph.isConnected(directed)
+    // @ts-expect-error! Trees require an undirected graph
+    Graph.isTree(directed)
   })
 
   it("topo", () => {


### PR DESCRIPTION
Stack: #7291 → **#7285** → #7289 → #7284 → #7286 → #7290 → #7283 → #7287 → #7288

Depends on #7291.

Reserves Option.none() for unreachable Bellman-Ford targets and throws GraphError when a reachable negative cycle can affect the requested target. Includes immutable and mutable parity coverage.