### PR TITLE
Optimize Graph queries and traversals

### DIFF
--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -2808,7 +2808,16 @@ export const outDegree: {
 } = dual(2, <N, E, T extends Kind = "directed">(
   graph: Graph<N, E, T> | MutableGraph<N, E, T>,
   nodeIndex: NodeIndex
-): number => outgoingEdges(graph as any, nodeIndex).length)
+): number => {
+  if (graph.type === "undirected") {
+    throw new GraphError({ message: "Cannot get outgoing edges of undirected graph" })
+  }
+  const impl = internal.toImpl(graph)
+  if (!impl.nodes.has(nodeIndex)) {
+    throw missingNode(nodeIndex)
+  }
+  return impl.adjacency.get(nodeIndex)!.length
+})
 
 /**
  * Returns the in-degree of a node in a directed graph.
@@ -2827,7 +2836,16 @@ export const inDegree: {
 } = dual(2, <N, E, T extends Kind = "directed">(
   graph: Graph<N, E, T> | MutableGraph<N, E, T>,
   nodeIndex: NodeIndex
-): number => incomingEdges(graph as any, nodeIndex).length)
+): number => {
+  if (graph.type === "undirected") {
+    throw new GraphError({ message: "Cannot get incoming edges of undirected graph" })
+  }
+  const impl = internal.toImpl(graph)
+  if (!impl.nodes.has(nodeIndex)) {
+    throw missingNode(nodeIndex)
+  }
+  return impl.reverseAdjacency.get(nodeIndex)!.length
+})
 
 const getDirectedNeighbors = <N, E>(
   graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">,
@@ -4343,7 +4361,61 @@ export const hasPath: {
   source: NodeIndex,
   target: NodeIndex,
   options?: ReachabilityConfig
-): boolean => getUnweightedDistances(graph, source, options?.direction ?? "outgoing", target).has(target))
+): boolean => {
+  const impl = internal.toImpl(graph)
+  if (!impl.nodes.has(source)) {
+    throw missingNode(source)
+  }
+  if (!impl.nodes.has(target)) {
+    throw missingNode(target)
+  }
+  if (source === target) {
+    return true
+  }
+
+  const cache = csr.get(graph)
+  const sourceNode = csr.getNodeIndex(cache, source)!
+  const targetNode = csr.getNodeIndex(cache, target)!
+  const adjacencies = csr.getAdjacencies(
+    cache,
+    graph.type === "undirected" ? "outgoing" : options?.direction ?? "outgoing"
+  )
+  const visited = new Uint8Array(cache.nodeIds.length)
+  const queue = new Uint32Array(cache.nodeIds.length)
+  let head = 0
+  let tail = 1
+  visited[sourceNode] = 1
+  queue[0] = sourceNode
+
+  while (head < tail) {
+    const current = queue[head++]
+    const primary = adjacencies.primary
+    for (let i = primary.rowOffsets[current]; i < primary.rowOffsets[current + 1]; i++) {
+      const neighbor = primary.columnIndices[i]
+      if (neighbor === targetNode) {
+        return true
+      }
+      if (visited[neighbor] === 0) {
+        visited[neighbor] = 1
+        queue[tail++] = neighbor
+      }
+    }
+    const secondary = adjacencies.secondary
+    if (secondary !== undefined) {
+      for (let i = secondary.rowOffsets[current]; i < secondary.rowOffsets[current + 1]; i++) {
+        const neighbor = secondary.columnIndices[i]
+        if (neighbor === targetNode) {
+          return true
+        }
+        if (visited[neighbor] === 0) {
+          visited[neighbor] = 1
+          queue[tail++] = neighbor
+        }
+      }
+    }
+  }
+  return false
+})
 
 /**
  * Finds connected components in an undirected graph.
@@ -4381,7 +4453,6 @@ export const connectedComponents = <N, E>(
     const outgoing = csr.getOutgoing(cache)
     const visited = new Uint8Array(cache.nodeIds.length)
     const neighborMarks = new Uint32Array(cache.nodeIds.length)
-    const neighbors: Array<number> = []
     const components: Array<Array<NodeIndex>> = []
     let neighborGeneration = 0
 
@@ -4401,18 +4472,14 @@ export const connectedComponents = <N, E>(
         component.push(cache.nodeIds[current])
 
         // Generation marks deduplicate parallel-edge neighbors without clearing a full-sized array per node.
-        neighbors.length = 0
         neighborGeneration++
         for (let i = outgoing.rowOffsets[current]; i < outgoing.rowOffsets[current + 1]; i++) {
           const neighbor = outgoing.columnIndices[i]
           if (neighborMarks[neighbor] !== neighborGeneration) {
             neighborMarks[neighbor] = neighborGeneration
-            neighbors.push(neighbor)
-          }
-        }
-        for (const neighbor of neighbors) {
-          if (visited[neighbor] === 0) {
-            stack.push(neighbor)
+            if (visited[neighbor] === 0) {
+              stack.push(neighbor)
+            }
           }
         }
       }
@@ -4424,6 +4491,7 @@ export const connectedComponents = <N, E>(
   }
 
   const visited = new Set<NodeIndex>()
+  const neighbors = new Set<NodeIndex>()
   const components: Array<Array<NodeIndex>> = []
   for (const startNode of impl.nodes.keys()) {
     if (!visited.has(startNode)) {
@@ -4437,11 +4505,16 @@ export const connectedComponents = <N, E>(
           visited.add(current)
           component.push(current)
 
-          // Add all unvisited neighbors to stack
-          const nodeNeighbors = getUndirectedNeighbors(graph, current)
-          for (const neighbor of nodeNeighbors) {
-            if (!visited.has(neighbor)) {
-              stack.push(neighbor)
+          neighbors.clear()
+          const adjacency = impl.adjacency.get(current)!
+          for (const edgeIndex of adjacency) {
+            const edge = impl.edges.get(edgeIndex)!
+            const neighbor = edge.source === current ? edge.target : edge.source
+            if (!neighbors.has(neighbor)) {
+              neighbors.add(neighbor)
+              if (!visited.has(neighbor)) {
+                stack.push(neighbor)
+              }
             }
           }
         }
@@ -4471,31 +4544,37 @@ export const weaklyConnectedComponents = <N, E>(
   }
   const cache = csr.get(graph)
   const { primary, secondary } = csr.getAdjacencies(cache, "undirected")
-  const visited = new Uint8Array(cache.nodeIds.length)
+  const nodeCount = cache.nodeIds.length
+  const visited = new Uint8Array(nodeCount)
+  const stack = new Uint32Array(primary.columnIndices.length + secondary!.columnIndices.length + 1)
   const components: Array<Array<NodeIndex>> = []
-  for (let start = 0; start < cache.nodeIds.length; start++) {
+  for (let start = 0; start < nodeCount; start++) {
     if (visited[start] !== 0) {
       continue
     }
     const component: Array<NodeIndex> = []
-    const stack = [start]
-    while (stack.length > 0) {
-      const current = stack.pop()!
+    let stackSize = 1
+    stack[0] = start
+    while (stackSize > 0) {
+      const current = stack[--stackSize]
       if (visited[current] !== 0) {
         continue
       }
       visited[current] = 1
       component.push(cache.nodeIds[current])
-      const push = (adjacency: csr.Adjacency) => {
-        for (let i = adjacency.rowOffsets[current]; i < adjacency.rowOffsets[current + 1]; i++) {
-          const neighbor = adjacency.columnIndices[i]
-          if (visited[neighbor] === 0) {
-            stack.push(neighbor)
-          }
+
+      for (let i = primary.rowOffsets[current]; i < primary.rowOffsets[current + 1]; i++) {
+        const neighbor = primary.columnIndices[i]
+        if (visited[neighbor] === 0) {
+          stack[stackSize++] = neighbor
         }
       }
-      push(primary)
-      push(secondary!)
+      for (let i = secondary!.rowOffsets[current]; i < secondary!.rowOffsets[current + 1]; i++) {
+        const neighbor = secondary!.columnIndices[i]
+        if (visited[neighbor] === 0) {
+          stack[stackSize++] = neighbor
+        }
+      }
     }
     components.push(component)
   }
@@ -4699,6 +4778,44 @@ export const stronglyConnectedComponents = <N, E>(
   return sccs
 }
 
+/** @internal */
+const csrReachesAll = (
+  nodeCount: number,
+  primary: csr.Adjacency,
+  secondary?: csr.Adjacency
+): boolean => {
+  if (nodeCount === 0) {
+    return true
+  }
+  const visited = new Uint8Array(nodeCount)
+  const queue = new Uint32Array(nodeCount)
+  let head = 0
+  let tail = 1
+  visited[0] = 1
+  queue[0] = 0
+
+  while (head < tail) {
+    const current = queue[head++]
+    for (let i = primary.rowOffsets[current]; i < primary.rowOffsets[current + 1]; i++) {
+      const neighbor = primary.columnIndices[i]
+      if (visited[neighbor] === 0) {
+        visited[neighbor] = 1
+        queue[tail++] = neighbor
+      }
+    }
+    if (secondary !== undefined) {
+      for (let i = secondary.rowOffsets[current]; i < secondary.rowOffsets[current + 1]; i++) {
+        const neighbor = secondary.columnIndices[i]
+        if (visited[neighbor] === 0) {
+          visited[neighbor] = 1
+          queue[tail++] = neighbor
+        }
+      }
+    }
+  }
+  return tail === nodeCount
+}
+
 /**
  * Tests whether an undirected graph has at most one connected component.
  *
@@ -4710,7 +4827,13 @@ export const stronglyConnectedComponents = <N, E>(
  */
 export const isConnected = <N, E>(
   graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
-): boolean => connectedComponents(graph).length <= 1
+): boolean => {
+  if ((graph as Graph<N, E, Kind> | MutableGraph<N, E, Kind>).type === "directed") {
+    throw new GraphError({ message: "Cannot find connected components of directed graph" })
+  }
+  const cache = csr.get(graph)
+  return csrReachesAll(cache.nodeIds.length, csr.getOutgoing(cache))
+}
 
 /**
  * Tests whether a directed graph has at most one weakly connected component.
@@ -4723,7 +4846,14 @@ export const isConnected = <N, E>(
  */
 export const isWeaklyConnected = <N, E>(
   graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">
-): boolean => weaklyConnectedComponents(graph).length <= 1
+): boolean => {
+  if ((graph as Graph<N, E, Kind> | MutableGraph<N, E, Kind>).type === "undirected") {
+    throw new GraphError({ message: "Cannot find weakly connected components of undirected graph" })
+  }
+  const cache = csr.get(graph)
+  const { primary, secondary } = csr.getAdjacencies(cache, "undirected")
+  return csrReachesAll(cache.nodeIds.length, primary, secondary)
+}
 
 /**
  * Tests whether a directed graph has at most one strongly connected component.
@@ -4736,7 +4866,14 @@ export const isWeaklyConnected = <N, E>(
  */
 export const isStronglyConnected = <N, E>(
   graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">
-): boolean => stronglyConnectedComponents(graph).length <= 1
+): boolean => {
+  if ((graph as Graph<N, E, Kind> | MutableGraph<N, E, Kind>).type === "undirected") {
+    throw new GraphError({ message: "Cannot find strongly connected components of undirected graph" })
+  }
+  const cache = csr.get(graph)
+  return csrReachesAll(cache.nodeIds.length, csr.getOutgoing(cache)) &&
+    csrReachesAll(cache.nodeIds.length, csr.getIncoming(cache))
+}
 
 /**
  * Tests whether a non-empty undirected graph is a tree.
@@ -5016,19 +5153,25 @@ interface DenseMinHeap {
   nodes: Uint32Array
   priorities: Float64Array
   sequences: Float64Array
+  positions: Int32Array | undefined
   size: number
   poppedNode: number
   poppedPriority: number
 }
 
-const denseMinHeapMake = (capacity: number): DenseMinHeap => ({
-  nodes: new Uint32Array(Math.max(4, capacity)),
-  priorities: new Float64Array(Math.max(4, capacity)),
-  sequences: new Float64Array(Math.max(4, capacity)),
-  size: 0,
-  poppedNode: 0,
-  poppedPriority: 0
-})
+const denseMinHeapMake = (capacity: number, indexed = false): DenseMinHeap => {
+  const positions = indexed ? new Int32Array(capacity) : undefined
+  positions?.fill(-1)
+  return {
+    nodes: new Uint32Array(Math.max(4, capacity)),
+    priorities: new Float64Array(Math.max(4, capacity)),
+    sequences: new Float64Array(Math.max(4, capacity)),
+    positions,
+    size: 0,
+    poppedNode: 0,
+    poppedPriority: 0
+  }
+}
 
 const denseMinHeapPush = (
   heap: DenseMinHeap,
@@ -5036,20 +5179,23 @@ const denseMinHeapPush = (
   priority: number,
   sequence: number
 ): void => {
-  if (heap.size === heap.nodes.length) {
-    const capacity = heap.size * 2
-    const nodes = new Uint32Array(capacity)
-    const priorities = new Float64Array(capacity)
-    const sequences = new Float64Array(capacity)
-    nodes.set(heap.nodes)
-    priorities.set(heap.priorities)
-    sequences.set(heap.sequences)
-    heap.nodes = nodes
-    heap.priorities = priorities
-    heap.sequences = sequences
+  let index = heap.positions?.[node] ?? -1
+  if (index === -1) {
+    if (heap.size === heap.nodes.length) {
+      const capacity = heap.size * 2
+      const nodes = new Uint32Array(capacity)
+      const priorities = new Float64Array(capacity)
+      const sequences = new Float64Array(capacity)
+      nodes.set(heap.nodes)
+      priorities.set(heap.priorities)
+      sequences.set(heap.sequences)
+      heap.nodes = nodes
+      heap.priorities = priorities
+      heap.sequences = sequences
+    }
+    index = heap.size++
   }
 
-  let index = heap.size++
   while (index > 0) {
     const parent = (index - 1) >>> 1
     if (
@@ -5061,11 +5207,17 @@ const denseMinHeapPush = (
     heap.nodes[index] = heap.nodes[parent]
     heap.priorities[index] = heap.priorities[parent]
     heap.sequences[index] = heap.sequences[parent]
+    if (heap.positions !== undefined) {
+      heap.positions[heap.nodes[index]] = index
+    }
     index = parent
   }
   heap.nodes[index] = node
   heap.priorities[index] = priority
   heap.sequences[index] = sequence
+  if (heap.positions !== undefined) {
+    heap.positions[node] = index
+  }
 }
 
 const denseMinHeapPop = (heap: DenseMinHeap): boolean => {
@@ -5075,6 +5227,9 @@ const denseMinHeapPop = (heap: DenseMinHeap): boolean => {
 
   heap.poppedNode = heap.nodes[0]
   heap.poppedPriority = heap.priorities[0]
+  if (heap.positions !== undefined) {
+    heap.positions[heap.poppedNode] = -1
+  }
   const last = --heap.size
   if (last === 0) {
     return true
@@ -5107,11 +5262,17 @@ const denseMinHeapPop = (heap: DenseMinHeap): boolean => {
     heap.nodes[index] = heap.nodes[child]
     heap.priorities[index] = heap.priorities[child]
     heap.sequences[index] = heap.sequences[child]
+    if (heap.positions !== undefined) {
+      heap.positions[heap.nodes[index]] = index
+    }
     index = child
   }
   heap.nodes[index] = node
   heap.priorities[index] = priority
   heap.sequences[index] = sequence
+  if (heap.positions !== undefined) {
+    heap.positions[node] = index
+  }
   return true
 }
 
@@ -5252,7 +5413,7 @@ export const dijkstra: {
     previousNode.fill(-1)
     previousEdge.fill(-1)
     const visited = new Uint8Array(cache.nodeIds.length)
-    const priorityQueue = denseMinHeapMake(cache.nodeIds.length)
+    const priorityQueue = denseMinHeapMake(cache.nodeIds.length, true)
     let sequence = 0
     denseMinHeapPush(priorityQueue, source, 0, sequence++)
 

--- a/packages/effect/src/internal/graphCsr.ts
+++ b/packages/effect/src/internal/graphCsr.ts
@@ -64,12 +64,13 @@ const materializeEdges = (csr: Csr): void => {
   if (csr.edgesByIndex !== undefined) {
     return
   }
-  const entries = Array.from(toImpl(csr.graph).edges)
-  const edgeIds = new Array<Graph.EdgeIndex>(entries.length)
-  const edges = new Array<Graph.Edge<any>>(entries.length)
-  for (let i = 0; i < entries.length; i++) {
-    edgeIds[i] = entries[i][0]
-    edges[i] = entries[i][1]
+  const graphEdges = toImpl(csr.graph).edges
+  const edgeIds = new Array<Graph.EdgeIndex>(graphEdges.size)
+  const edges = new Array<Graph.Edge<any>>(graphEdges.size)
+  let index = 0
+  for (const [edgeId, edge] of graphEdges) {
+    edgeIds[index] = edgeId
+    edges[index++] = edge
   }
   csr.edgeIdsByIndex = edgeIds
   csr.edgesByIndex = edges
@@ -232,13 +233,17 @@ export const get = <N, E, T extends Graph.Kind>(
   }
 
   // Node ids and data are captured together so an iterator never consults mutable maps after it starts.
-  const nodeIds = Array.from(impl.nodes.keys())
+  const nodeIds = new Array<Graph.NodeIndex>(impl.nodes.size)
+  const nodeData = new Array<any>(impl.nodes.size)
   let compactNodeIds = true
-  for (let i = 0; i < nodeIds.length; i++) {
-    if (nodeIds[i] !== i) {
+  let nodePosition = 0
+  for (const [nodeId, data] of impl.nodes) {
+    nodeIds[nodePosition] = nodeId
+    nodeData[nodePosition] = data
+    if (nodeId !== nodePosition) {
       compactNodeIds = false
-      break
     }
+    nodePosition++
   }
 
   const indexByNodeId = compactNodeIds ? undefined : new Map<Graph.NodeIndex, number>()
@@ -252,7 +257,7 @@ export const get = <N, E, T extends Graph.Kind>(
     type: impl.type,
     graph,
     nodeIds,
-    nodeData: Array.from(impl.nodes.values()),
+    nodeData,
     indexByNodeId,
     outgoingCsr: undefined,
     incomingCsr: undefined,

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -2494,8 +2494,12 @@ describe("Graph", () => {
           () => Graph.incomingEdges(undirected as any, 0),
           "Cannot get incoming edges of undirected graph"
         )
+        assertGraphError(() => Graph.outDegree(undirected as any, 0), "Cannot get outgoing edges of undirected graph")
+        assertGraphError(() => Graph.inDegree(undirected as any, 0), "Cannot get incoming edges of undirected graph")
         assertGraphError(() => Graph.incidentEdges(directed, 1), "Node 1 does not exist")
         assertGraphError(() => Graph.edgesBetween(directed, 0, 1), "Node 1 does not exist")
+        assertGraphError(() => Graph.outDegree(directed, 1), "Node 1 does not exist")
+        assertGraphError(() => Graph.inDegree(directed, 1), "Node 1 does not exist")
       })
     })
 
@@ -3504,6 +3508,7 @@ describe("Graph", () => {
       })
 
       assert.deepStrictEqual(Graph.connectedComponents(graph), [[0, 2, 1]])
+      assert.deepStrictEqual(Graph.connectedComponents(Graph.beginMutation(graph)), [[0, 2, 1]])
     })
   })
 
@@ -3624,6 +3629,8 @@ describe("Graph", () => {
       assert.strictEqual(Graph.hasPath(graph, 2, 0), false)
       assert.strictEqual(Graph.hasPath(graph, 2, 0, { direction: "incoming" }), true)
       assert.strictEqual(Graph.hasPath(3, 2, { direction: "undirected" })(Graph.beginMutation(graph)), true)
+      assert.strictEqual(Graph.hasPath(graph, 0, 0), true)
+      assertGraphError(() => Graph.hasPath(graph, 0, 4), "Node 4 does not exist")
     })
 
     it("should find weak components and connectivity for immutable and mutable graphs", () => {
@@ -3644,6 +3651,19 @@ describe("Graph", () => {
       }
     })
 
+    it("should preserve weak component traversal order", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        Graph.addNode(mutable, "root")
+        Graph.addNode(mutable, "first")
+        Graph.addNode(mutable, "second")
+        Graph.addEdge(mutable, 0, 1, 1)
+        Graph.addEdge(mutable, 0, 2, 2)
+      })
+
+      assert.deepStrictEqual(Graph.weaklyConnectedComponents(graph), [[0, 2, 1]])
+      assert.deepStrictEqual(Graph.weaklyConnectedComponents(Graph.beginMutation(graph)), [[0, 2, 1]])
+    })
+
     it("should rebuild CSR after graph mutation", () => {
       const mutable = Graph.beginMutation(Graph.directed<string, number>((graph) => {
         Graph.addNode(graph, "A")
@@ -3659,6 +3679,12 @@ describe("Graph", () => {
 
       assert.strictEqual(Graph.weaklyConnectedComponents(mutable).length, 1)
       assert.deepStrictEqual(Array.from(Graph.unweightedDistances(mutable, 0)), [[0, 0], [1, 1], [2, 2]])
+
+      Graph.addNode(mutable, "D")
+      assert.strictEqual(Graph.hasPath(mutable, 0, 3), false)
+
+      Graph.addEdge(mutable, 2, 3, 1)
+      assert.strictEqual(Graph.hasPath(mutable, 0, 3), true)
     })
 
     it("should identify undirected trees and connected graphs", () => {
@@ -3680,6 +3706,42 @@ describe("Graph", () => {
       assert.strictEqual(Graph.isTree(Graph.undirected()), false)
       assert.strictEqual(Graph.isWeaklyConnected(Graph.directed()), true)
       assert.strictEqual(Graph.isStronglyConnected(Graph.directed()), true)
+    })
+
+    it("should test connectivity without constructing components", () => {
+      const connected = Graph.undirected<void, void>((mutable) => {
+        Graph.addNode(mutable, undefined)
+        Graph.addNode(mutable, undefined)
+        Graph.addEdge(mutable, 0, 1, undefined)
+      })
+      const disconnected = Graph.mutate(connected, (mutable) => {
+        Graph.addNode(mutable, undefined)
+      })
+      const weak = Graph.directed<void, void>((mutable) => {
+        Graph.addNode(mutable, undefined)
+        Graph.addNode(mutable, undefined)
+        Graph.addNode(mutable, undefined)
+        Graph.addEdge(mutable, 0, 1, undefined)
+        Graph.addEdge(mutable, 1, 2, undefined)
+      })
+      const strong = Graph.mutate(weak, (mutable) => {
+        Graph.addEdge(mutable, 2, 0, undefined)
+      })
+
+      for (const candidate of [connected, Graph.beginMutation(connected)]) {
+        assert.strictEqual(Graph.isConnected(candidate), true)
+      }
+      for (const candidate of [disconnected, Graph.beginMutation(disconnected)]) {
+        assert.strictEqual(Graph.isConnected(candidate), false)
+      }
+      for (const candidate of [weak, Graph.beginMutation(weak)]) {
+        assert.strictEqual(Graph.isWeaklyConnected(candidate), true)
+        assert.strictEqual(Graph.isStronglyConnected(candidate), false)
+      }
+      for (const candidate of [strong, Graph.beginMutation(strong)]) {
+        assert.strictEqual(Graph.isWeaklyConnected(candidate), true)
+        assert.strictEqual(Graph.isStronglyConnected(candidate), true)
+      }
     })
 
     it("should reject directed graphs when testing trees before short-circuiting", () => {
@@ -3704,6 +3766,18 @@ describe("Graph", () => {
       assertGraphError(
         () => Graph.weaklyConnectedComponents(undirected as any),
         "Cannot find weakly connected components of undirected graph"
+      )
+      assertGraphError(
+        () => Graph.isConnected(directed as any),
+        "Cannot find connected components of directed graph"
+      )
+      assertGraphError(
+        () => Graph.isWeaklyConnected(undirected as any),
+        "Cannot find weakly connected components of undirected graph"
+      )
+      assertGraphError(
+        () => Graph.isStronglyConnected(undirected as any),
+        "Cannot find strongly connected components of undirected graph"
       )
     })
   })
@@ -3913,6 +3987,27 @@ describe("Graph", () => {
         distance: 42,
         costs: [1, 1, 20, 20]
       })
+    })
+
+    it("should assign a fresh insertion order when decreasing a priority", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        const source = Graph.addNode(mutable, "source")
+        const improved = Graph.addNode(mutable, "improved")
+        const shortcut = Graph.addNode(mutable, "shortcut")
+        const direct = Graph.addNode(mutable, "direct")
+        const target = Graph.addNode(mutable, "target")
+        Graph.addEdge(mutable, source, improved, 10)
+        Graph.addEdge(mutable, source, shortcut, 1)
+        Graph.addEdge(mutable, source, direct, 2)
+        Graph.addEdge(mutable, shortcut, improved, 1)
+        Graph.addEdge(mutable, improved, target, 1)
+        Graph.addEdge(mutable, direct, target, 1)
+      })
+      const config = { source: 0, target: 4, cost: (edge: number) => edge }
+      const expected = Option.some({ path: [0, 3, 4], edges: [2, 5], distance: 3, costs: [2, 1] })
+
+      assert.deepStrictEqual(Graph.dijkstra(graph, config), expected)
+      assert.deepStrictEqual(Graph.dijkstra(Graph.beginMutation(graph), config), expected)
     })
 
     it("should return None for unreachable nodes", () => {


### PR DESCRIPTION
## Summary

- make directed degree reads allocation-free
- optimize connected and weak component traversal while preserving established DFS ordering
- implement direct CSR traversals for reachability and connectivity predicates
- bound immutable Dijkstra heaps to one entry per node with indexed decrease-key
- reduce cold CSR projection allocations

## Performance

Benchmarked against `@statelyai/graph` on an Apple M2 Max with Node v26.7.0.

- weak components: 5.5x to 17.6x faster than the previous implementation at roughly 100k nodes
- degree sweeps: 2.3x to 3.1x faster at roughly 100k nodes, now at parity or faster than Stately
- connected components: 3.6x faster in the focused benchmark, now within approximately 15% of Stately
- early-target `hasPath`: approximately 450x faster than constructing an unweighted distance map
- connectivity predicates: approximately 2x to 10x faster by avoiding component materialization

Effect remains substantially faster in the focused SCC, bipartite, topological sort, Bellman-Ford, and Floyd-Warshall workloads.

Bidirectional Dijkstra was evaluated but intentionally not included because randomized differential testing showed that it changes canonical equal-cost path selection. Construction cache-state tracking was also intentionally excluded.

## Validation

- `pnpm lint-fix`
- `pnpm --filter effect test --run test/Graph.test.ts test/Pathfinding.test.ts`
- `pnpm check`
- `git diff --check`
- randomized immutable/mutable Dijkstra parity checks
- Effect-vs-Stately focused and 1k/10k/100k benchmark suites