### PR TITLE
Make CLI boolean flags required when omitted

### DIFF
--- a/.changeset/required-boolean-flags.md
+++ b/.changeset/required-boolean-flags.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Make unstable CLI boolean flags required when omitted, allowing optional, default, config, and prompt fallbacks to handle absence consistently.

--- a/ai-docs/src/70_cli/10_basics.ts
+++ b/ai-docs/src/70_cli/10_basics.ts
@@ -23,7 +23,8 @@ const tasks = Command.make("tasks").pipe(
     workspace,
     verbose: Flag.boolean("verbose").pipe(
       Flag.withAlias("v"),
-      Flag.withDescription("Print diagnostic output")
+      Flag.withDescription("Print diagnostic output"),
+      Flag.withDefault(false)
     )
   }),
   Command.withDescription("Track and manage tasks")
@@ -92,7 +93,8 @@ const list = Command.make(
       Flag.withDefault("open")
     ),
     json: Flag.boolean("json").pipe(
-      Flag.withDescription("Print machine-readable output")
+      Flag.withDescription("Print machine-readable output"),
+      Flag.withDefault(false)
     )
   },
   Effect.fn(function*({ status, json }) {

--- a/packages/effect/src/unstable/cli/Command.ts
+++ b/packages/effect/src/unstable/cli/Command.ts
@@ -98,7 +98,7 @@ import * as Prompt from "./Prompt.ts"
  *   never
  * > = Command.make("deploy", {
  *   env: Flag.string("env"),
- *   force: Flag.boolean("force"),
+ *   force: Flag.boolean("force").pipe(Flag.withDefault(false)),
  *   files: Argument.string("files").pipe(Argument.variadic())
  * })
  *
@@ -456,7 +456,7 @@ export type Services<C> = C extends Command<
  *
  * const parent = Command.make("app").pipe(
  *   Command.withSharedFlags({
- *     verbose: Flag.boolean("verbose"),
+ *     verbose: Flag.boolean("verbose").pipe(Flag.withDefault(false)),
  *     config: Flag.string("config")
  *   })
  * )
@@ -582,14 +582,17 @@ export const isCommand = (u: unknown): u is Command.Any => Predicate.hasProperty
  *     port: Flag.integer("port").pipe(Flag.withDefault(3000))
  *   },
  *   files: Argument.string("files").pipe(Argument.variadic),
- *   force: Flag.boolean("force").pipe(Flag.withDescription("Force deployment"))
+ *   force: Flag.boolean("force").pipe(
+ *     Flag.withDescription("Force deployment"),
+ *     Flag.withDefault(false)
+ *   )
  * })
  *
  * // Command with handler
  * const output: Array<string> = []
  * const deployWithHandler = Command.make("deploy", {
  *   environment: Flag.string("env"),
- *   force: Flag.boolean("force")
+ *   force: Flag.boolean("force").pipe(Flag.withDefault(false))
  * }, (config) =>
  *   Effect.gen(function*() {
  *     yield* Effect.sync(() => output.push(`Starting deployment to ${config.environment}`))
@@ -798,7 +801,7 @@ const normalizeSubcommandEntries = (
  * // Parent command with shared flags
  * const git = Command.make("git").pipe(
  *   Command.withSharedFlags({
- *     verbose: Flag.boolean("verbose")
+ *     verbose: Flag.boolean("verbose").pipe(Flag.withDefault(false))
  *   })
  * )
  *

--- a/packages/effect/src/unstable/cli/Flag.ts
+++ b/packages/effect/src/unstable/cli/Flag.ts
@@ -66,6 +66,7 @@ export const string = (name: string): Flag<string> => Param.string(Param.flagKin
  *
  * const verboseFlag = Flag.boolean("verbose")
  * // Usage: --verbose (true) or --no-verbose (false)
+ * // Omission fails unless the flag is made optional or given a fallback.
  * verboseFlag.kind // => "flag"
  * ```
  *

--- a/packages/effect/src/unstable/cli/GlobalFlag.ts
+++ b/packages/effect/src/unstable/cli/GlobalFlag.ts
@@ -155,7 +155,8 @@ let settingIdCounter = 0
 export const Help: Action<boolean> = action({
   flag: Flag.boolean("help").pipe(
     Flag.withAlias("h"),
-    Flag.withDescription("Show help information")
+    Flag.withDescription("Show help information"),
+    Flag.withDefault(false)
   ),
   run: Effect.fnUntraced(function*(_, { builtIns, command, commandPath }) {
     const formatter = yield* CliOutput.Formatter
@@ -177,7 +178,8 @@ export const Help: Action<boolean> = action({
 export const Version: Action<boolean> = action({
   flag: Flag.boolean("version").pipe(
     Flag.withAlias("v"),
-    Flag.withDescription("Show version information")
+    Flag.withDescription("Show version information"),
+    Flag.withDefault(false)
   ),
   run: Effect.fnUntraced(function*(_, { command, version }) {
     const formatter = yield* CliOutput.Formatter
@@ -198,7 +200,8 @@ export const Version: Action<boolean> = action({
  */
 export const Wizard: Action<boolean> = action({
   flag: Flag.boolean("wizard").pipe(
-    Flag.withDescription("Start wizard mode for a command")
+    Flag.withDescription("Start wizard mode for a command"),
+    Flag.withDefault(false)
   ),
   run: () => Effect.void
 })

--- a/packages/effect/src/unstable/cli/Param.ts
+++ b/packages/effect/src/unstable/cli/Param.ts
@@ -400,8 +400,9 @@ export const string = <const Kind extends ParamKind>(
  * // Create a boolean argument
  * const enableArg = Param.boolean(Param.argumentKind, "enable")
  *
- * // Usage in CLI: --verbose (defaults to true when present, false when absent)
- * // or as positional: true/false
+ * // Usage in CLI: --verbose (true) or --no-verbose (false).
+ * // The flag is required unless made optional or given a fallback.
+ * // Boolean positional arguments accept true/false.
  * const kinds = [verboseFlag.kind, enableArg.kind] // => ["flag", "argument"]
  * ```
  *
@@ -1272,18 +1273,7 @@ export const optional = <Kind extends ParamKind, A>(
   param: Param<Kind, A>
 ): Param<Kind, Option.Option<A>> => {
   const parse: Parse<Option.Option<A>> = Effect.fnUntraced(function*(args) {
-    const single = getUnderlyingSingleOrThrow(param)
-
-    // Handle boolean params that are explicitly marked as optional (i.e. the
-    // end user wants to return `Option.none()` instead of `false` when the
-    // flag (or its negated variant) are not present on the command line
-    if (
-      isFlagParam(single) &&
-      Primitive.isBoolean(single.primitiveType) &&
-      ![single.name, ...single.aliases].some((name) => (args.flags[name] ?? []).length > 0)
-    ) {
-      return [args.arguments, Option.none()] as const
-    }
+    getUnderlyingSingleOrThrow(param)
 
     return yield* param.parse(args).pipe(
       Effect.map(([leftover, value]) => [leftover, Option.some(value)] as const),
@@ -1967,13 +1957,7 @@ const parseFlag: <A>(
   const providedValues = args.flags[name]
 
   if (providedValues === undefined || providedValues.length === 0) {
-    // Option not provided (empty array due to initialization)
-    if (Primitive.isBoolean(primitiveType)) {
-      // Boolean params default to false when not present
-      return [args.arguments, false as any] as const
-    } else {
-      return yield* new CliError.MissingOption({ option: name })
-    }
+    return yield* new CliError.MissingOption({ option: name })
   }
 
   // Parse the first value (later we can handle multiple)

--- a/packages/effect/src/unstable/cli/internal/config.ts
+++ b/packages/effect/src/unstable/cli/internal/config.ts
@@ -15,7 +15,7 @@
  * ```ts
  * // User declares:
  * const config = {
- *   verbose: Flag.boolean("verbose"),
+ *   verbose: Flag.boolean("verbose").pipe(Flag.withDefault(false)),
  *   server: {
  *     host: Flag.string("host"),
  *     port: Flag.integer("port")

--- a/packages/effect/test/unstable/cli/Command.test.ts
+++ b/packages/effect/test/unstable/cli/Command.test.ts
@@ -1521,6 +1521,22 @@ describe("Command", () => {
         assert.deepStrictEqual(captured, [false, false])
       }).pipe(Effect.provide(TestLayer)))
 
+    it.effect("should parse required boolean flags when explicitly enabled or disabled", () =>
+      Effect.gen(function*() {
+        const captured: Array<boolean> = []
+
+        const cmd = Command.make("tool", {
+          verbose: Flag.boolean("verbose")
+        }, (config) => Effect.sync(() => captured.push(config.verbose)))
+
+        const runCmd = Command.runWith(cmd, { version: "1.0.0" })
+
+        yield* runCmd(["--verbose"])
+        yield* runCmd(["--no-verbose"])
+
+        assert.deepStrictEqual(captured, [true, false])
+      }).pipe(Effect.provide(TestLayer)))
+
     it.effect("should support optional boolean flags and --no-<flag> negation", () =>
       Effect.gen(function*() {
         const captured: Array<Option.Option<boolean>> = []
@@ -1548,7 +1564,10 @@ describe("Command", () => {
 
         const cmd = Command.make("tool", {
           prompt: Flag.boolean("prompt"),
-          force: Flag.boolean("force").pipe(Flag.withAlias("no-prompt"))
+          force: Flag.boolean("force").pipe(
+            Flag.withAlias("no-prompt"),
+            Flag.withDefault(false)
+          )
         }, (config) => Effect.sync(() => captured.push([config.prompt, config.force] as const)))
 
         const runCmd = Command.runWith(cmd, { version: "1.0.0" })

--- a/packages/effect/test/unstable/cli/Param.test.ts
+++ b/packages/effect/test/unstable/cli/Param.test.ts
@@ -27,6 +27,44 @@ const TestLayer = Layer.mergeAll(
 )
 
 describe("Param", () => {
+  describe("boolean", () => {
+    it.effect("returns MissingOption when a boolean flag is omitted", () =>
+      Effect.gen(function*() {
+        const error = yield* Effect.flip(
+          Flag.boolean("verbose").parse({
+            flags: {},
+            arguments: []
+          })
+        )
+
+        assert.instanceOf(error, CliError.MissingOption)
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("uses the requested default when a boolean flag is omitted", () =>
+      Effect.gen(function*() {
+        const flag = Flag.boolean("verbose").pipe(Flag.withDefault(true))
+
+        const [, value] = yield* flag.parse({
+          flags: {},
+          arguments: []
+        })
+
+        assert.isTrue(value)
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("restores switch behavior with a false default", () =>
+      Effect.gen(function*() {
+        const flag = Flag.boolean("verbose").pipe(Flag.withDefault(false))
+
+        const [, value] = yield* flag.parse({
+          flags: {},
+          arguments: []
+        })
+
+        assert.isFalse(value)
+      }).pipe(Effect.provide(TestLayer)))
+  })
+
   it.effect("recognizes the alternate flag declared by orElse", () =>
     Effect.gen(function*() {
       const command = Command.make("app", {
@@ -84,7 +122,7 @@ describe("Param", () => {
         assert.deepStrictEqual(value, Option.none())
       }).pipe(Effect.provide(TestLayer)))
 
-    it.effect("returns some when an optional boolean flag is provided", () =>
+    it.effect("returns some false when an optional boolean flag is explicitly disabled", () =>
       Effect.gen(function*() {
         const flag = Flag.boolean("verbose").pipe(Flag.optional)
 
@@ -271,17 +309,32 @@ describe("Param", () => {
         assert.instanceOf(error, CliError.InvalidValue)
       }).pipe(Effect.provide(TestLayer)))
 
-    it.effect("does not prompt for missing boolean flags", () =>
+    it.effect("prompts for missing boolean flags", () =>
       Effect.gen(function*() {
-        const prompt = Prompt.text({ message: "Verbose" })
+        const prompt = Prompt.confirm({ message: "Verbose" })
         const flag = Flag.boolean("verbose").pipe(Flag.withFallbackPrompt(prompt))
+
+        yield* MockTerminal.inputKey("y")
 
         const [, value] = yield* flag.parse({
           flags: {},
           arguments: []
         })
 
-        assert.strictEqual(value, false)
+        assert.isTrue(value)
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("uses an explicitly disabled boolean before prompting", () =>
+      Effect.gen(function*() {
+        const prompt = Prompt.confirm({ message: "Verbose" })
+        const flag = Flag.boolean("verbose").pipe(Flag.withFallbackPrompt(prompt))
+
+        const [, value] = yield* flag.parse({
+          flags: { verbose: ["false"] },
+          arguments: []
+        })
+
+        assert.isFalse(value)
       }).pipe(Effect.provide(TestLayer)))
 
     it.effect("returns MissingOption when prompt is cancelled", () =>
@@ -320,6 +373,54 @@ describe("Param", () => {
   })
 
   describe("withFallbackConfig", () => {
+    it.effect("uses ConfigProvider when a boolean flag is missing", () => {
+      const provider = ConfigProvider.fromEnv({
+        env: {
+          VERBOSE: "true"
+        }
+      })
+
+      return Effect.gen(function*() {
+        const flag = Flag.boolean("verbose").pipe(
+          Flag.withFallbackConfig(Config.boolean("VERBOSE"))
+        )
+
+        const [, value] = yield* flag.parse({
+          flags: {},
+          arguments: []
+        })
+
+        assert.isTrue(value)
+      }).pipe(
+        Effect.provideService(ConfigProvider.ConfigProvider, provider),
+        Effect.provide(TestLayer)
+      )
+    })
+
+    it.effect("uses an explicitly disabled boolean before reading config fallbacks", () => {
+      const provider = ConfigProvider.fromEnv({
+        env: {
+          VERBOSE: "true"
+        }
+      })
+
+      return Effect.gen(function*() {
+        const flag = Flag.boolean("verbose").pipe(
+          Flag.withFallbackConfig(Config.boolean("VERBOSE"))
+        )
+
+        const [, value] = yield* flag.parse({
+          flags: { verbose: ["false"] },
+          arguments: []
+        })
+
+        assert.isFalse(value)
+      }).pipe(
+        Effect.provideService(ConfigProvider.ConfigProvider, provider),
+        Effect.provide(TestLayer)
+      )
+    })
+
     it.effect("uses ConfigProvider when a flag is missing", () => {
       const provider = ConfigProvider.fromEnv({
         env: {

--- a/packages/effect/test/unstable/cli/fixtures/ComprehensiveCli.ts
+++ b/packages/effect/test/unstable/cli/fixtures/ComprehensiveCli.ts
@@ -12,12 +12,14 @@ const usersList = Command.make("list", {
   ),
   // Boolean flag
   active: Flag.boolean("active").pipe(
-    Flag.withDescription("Show only active users")
+    Flag.withDescription("Show only active users"),
+    Flag.withDefault(false)
   ),
   // Option with both short and long aliases
   verbose: Flag.boolean("verbose").pipe(
     Flag.withAlias("v"),
-    Flag.withDescription("Show detailed information")
+    Flag.withDescription("Show detailed information"),
+    Flag.withDefault(false)
   )
 }, (config) =>
   logAction("users list", {
@@ -45,7 +47,8 @@ const usersCreate = Command.make("create", {
   // Boolean with explicit value support
   notify: Flag.boolean("notify").pipe(
     Flag.withAlias("n"),
-    Flag.withDescription("Send notification email")
+    Flag.withDescription("Send notification email"),
+    Flag.withDefault(false)
   )
 }, (config) =>
   logAction("users create", {
@@ -117,7 +120,8 @@ const admin = Command.make("admin").pipe(
   Command.withSharedFlags({
     // Boolean that can be set to false explicitly
     sudo: Flag.boolean("sudo").pipe(
-      Flag.withDescription("Run with elevated privileges")
+      Flag.withDescription("Run with elevated privileges"),
+      Flag.withDefault(false)
     )
   }),
   Command.withDescription("Administrative commands"),
@@ -136,11 +140,13 @@ const copy = Command.make("copy", {
   // Boolean flags with short aliases
   recursive: Flag.boolean("recursive").pipe(
     Flag.withAlias("r"),
-    Flag.withDescription("Copy directories recursively")
+    Flag.withDescription("Copy directories recursively"),
+    Flag.withDefault(false)
   ),
   force: Flag.boolean("force").pipe(
     Flag.withAlias("f"),
-    Flag.withDescription("Overwrite existing files")
+    Flag.withDescription("Overwrite existing files"),
+    Flag.withDefault(false)
   ),
   // Integer option
   buffer: Flag.integer("buffer-size").pipe(
@@ -167,7 +173,8 @@ const move = Command.make("move", {
   // Options
   interactive: Flag.boolean("interactive").pipe(
     Flag.withAlias("i"),
-    Flag.withDescription("Prompt before overwrite")
+    Flag.withDescription("Prompt before overwrite"),
+    Flag.withDefault(false)
   )
 }, (config) =>
   logAction("move", {
@@ -186,15 +193,18 @@ const remove = Command.make("remove", {
   // Multiple boolean options
   recursive: Flag.boolean("recursive").pipe(
     Flag.withAlias("r"),
-    Flag.withDescription("Remove directories and contents")
+    Flag.withDescription("Remove directories and contents"),
+    Flag.withDefault(false)
   ),
   force: Flag.boolean("force").pipe(
     Flag.withAlias("f"),
-    Flag.withDescription("Force removal without prompts")
+    Flag.withDescription("Force removal without prompts"),
+    Flag.withDefault(false)
   ),
   verbose: Flag.boolean("verbose").pipe(
     Flag.withAlias("v"),
-    Flag.withDescription("Explain what is being done")
+    Flag.withDescription("Explain what is being done"),
+    Flag.withDefault(false)
   )
 }, (config) =>
   logAction("remove", {
@@ -214,7 +224,8 @@ const build = Command.make("build", {
   ),
   verbose: Flag.boolean("verbose").pipe(
     Flag.withAlias("v"),
-    Flag.withDescription("Enable verbose output")
+    Flag.withDescription("Enable verbose output"),
+    Flag.withDefault(false)
   ),
   configFile: Flag.string("config-file").pipe(
     Flag.withAlias("f"),
@@ -252,7 +263,8 @@ const gitAdd = Command.make("add", {
     Argument.withDescription("Files to add")
   ),
   update: Flag.boolean("update").pipe(
-    Flag.withDescription("Update tracked files")
+    Flag.withDescription("Update tracked files"),
+    Flag.withDefault(false)
   )
 }, (config) =>
   logAction("git add", {
@@ -264,7 +276,8 @@ const gitAdd = Command.make("add", {
 
 const gitStatus = Command.make("status", {
   short: Flag.boolean("short").pipe(
-    Flag.withDescription("Show short format")
+    Flag.withDescription("Show short format"),
+    Flag.withDefault(false)
   )
 }, (config) =>
   logAction("git status", {
@@ -276,7 +289,8 @@ const gitStatus = Command.make("status", {
 const git = Command.make("git").pipe(
   Command.withSharedFlags({
     verbose: Flag.boolean("verbose").pipe(
-      Flag.withDescription("Enable verbose output")
+      Flag.withDescription("Enable verbose output"),
+      Flag.withDefault(false)
     )
   }),
   Command.withHandler((config) =>
@@ -335,7 +349,8 @@ const deployCommand = Command.make("deploy", {
     )
   },
   dryRun: Flag.boolean("dry-run").pipe(
-    Flag.withDescription("Perform a dry run")
+    Flag.withDescription("Perform a dry run"),
+    Flag.withDefault(false)
   )
 }, (config) =>
   logAction("deploy", {
@@ -401,7 +416,8 @@ export const ComprehensiveCli = Command.make("mycli").pipe(
     // Global options available to all subcommands
     debug: Flag.boolean("debug").pipe(
       Flag.withAlias("d"),
-      Flag.withDescription("Enable debug logging")
+      Flag.withDescription("Enable debug logging"),
+      Flag.withDefault(false)
     ),
     config: Flag.file("config").pipe(
       Flag.withAlias("c"),
@@ -410,7 +426,8 @@ export const ComprehensiveCli = Command.make("mycli").pipe(
     ),
     quiet: Flag.boolean("quiet").pipe(
       Flag.withAlias("q"),
-      Flag.withDescription("Suppress non-error output")
+      Flag.withDescription("Suppress non-error output"),
+      Flag.withDefault(false)
     )
   }),
   Command.withDescription("A comprehensive CLI tool demonstrating all features"),

--- a/packages/tools/ai-codegen/src/main.ts
+++ b/packages/tools/ai-codegen/src/main.ts
@@ -28,11 +28,13 @@ const providerFlag = Flag.string("provider").pipe(
 )
 
 const skipLintFlag = Flag.boolean("skip-lint").pipe(
-  Flag.withDescription("Skip Oxlint step")
+  Flag.withDescription("Skip Oxlint step"),
+  Flag.withDefault(false)
 )
 
 const skipFormatFlag = Flag.boolean("skip-format").pipe(
-  Flag.withDescription("Skip Dprint step")
+  Flag.withDescription("Skip Dprint step"),
+  Flag.withDefault(false)
 )
 
 // =============================================================================

--- a/packages/tools/ai-docgen/src/main.ts
+++ b/packages/tools/ai-docgen/src/main.ts
@@ -25,7 +25,8 @@ const output = Flag.path("output").pipe(
 
 const watch = Flag.boolean("watch").pipe(
   Flag.withAlias("w"),
-  Flag.withDescription("Watch for file changes and regenerate documentation")
+  Flag.withDescription("Watch for file changes and regenerate documentation"),
+  Flag.withDefault(false)
 )
 
 Command.make("effect-ai-docgen", { directory, output, watch }).pipe(

--- a/packages/tools/api-diff/src/Cli.ts
+++ b/packages/tools/api-diff/src/Cli.ts
@@ -27,7 +27,8 @@ const writeDoc = Flag.string("write-doc").pipe(
 )
 
 const check = Flag.boolean("check").pipe(
-  Flag.withDescription("List APIs without migration annotations and fail if any remain")
+  Flag.withDescription("List APIs without migration annotations and fail if any remain"),
+  Flag.withDefault(false)
 )
 
 const runApiDiff = Effect.fnUntraced(function*(options: {


### PR DESCRIPTION
## Summary

- make absent boolean flags fail with `MissingOption`, matching other flag types
- route boolean defaults, optionality, config fallbacks, and prompt fallbacks through the shared missing-value behavior
- preserve switch-style behavior for built-ins, tools, fixtures, and examples with explicit `withDefault(false)`
- cover required/default/fallback/optional behavior and explicit `--flag` / `--no-flag` parsing

## Root cause

`parseFlag` special-cased booleans by returning `false` on absence, preventing the normal missing-option fallback chain from running.

## Validation

- `nix develop -c pnpm vitest run` (10,080 passed, 1 expected failure, 55 skipped)
- `nix develop -c pnpm vitest run packages/effect/test/unstable/cli` (354 passed)
- `nix develop -c pnpm check`
- `nix develop -c pnpm lint`

Closes EFF-677