### PR TITLE
Fix bounded Graph DFS ordering and A* validation

### DIFF
--- a/.changeset/fix-graph-dfs-astar-edge-cases.md
+++ b/.changeset/fix-graph-dfs-astar-edge-cases.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve depth-first traversal order with finite radii and validate A* heuristics for trivial paths.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -6018,6 +6018,9 @@ export const astar: {
 
   // Early return if source equals target
   if (config.source === config.target) {
+    if (!Number.isFinite(config.heuristic(impl.nodes.get(config.source)!, impl.nodes.get(config.target)!))) {
+      throw new GraphError({ message: "A* algorithm requires finite heuristic values" })
+    }
     return Option.some({
       path: [config.source],
       edges: [],
@@ -7218,52 +7221,51 @@ export const dfs: {
       }
     }
 
-    const stackDepths: Array<number> = []
-    // DFS may first discover a node by a longer route, so bounded traversal retries it when a shorter depth appears.
-    const bestDepths = new Int32Array(cache.nodeIds.length)
-    const starts = new Uint8Array(cache.nodeIds.length)
-    const neighborMarks = new Uint32Array(cache.nodeIds.length)
-    const neighbors: Array<number> = []
-    let neighborGeneration = 0
-    bestDepths.fill(-1)
-    const distinctStarts: Array<number> = []
-    for (const node of startPositions) {
-      if (starts[node] === 0) {
-        starts[node] = 1
-        bestDepths[node] = 0
-        distinctStarts.push(node)
+    // Radius is shortest edge distance, so determine membership with BFS before imposing DFS order.
+    const reached = new Uint8Array(cache.nodeIds.length)
+    const queue = new Uint32Array(cache.nodeIds.length)
+    const depths = new Uint32Array(cache.nodeIds.length)
+    let head = 0
+    let tail = 0
+
+    for (const position of startPositions) {
+      if (reached[position] === 0) {
+        reached[position] = 1
+        queue[tail++] = position
       }
     }
-    for (let i = distinctStarts.length - 1; i >= 0; i--) {
-      stack.push(distinctStarts[i])
-      stackDepths.push(0)
-    }
 
-    const collectNeighbors = (targets: Uint32Array, offsets: Uint32Array, current: number) => {
+    const enqueue = (targets: Uint32Array, offsets: Uint32Array, current: number, depth: number) => {
       for (let i = offsets[current]; i < offsets[current + 1]; i++) {
         const neighbor = targets[i]
-        if (neighborMarks[neighbor] !== neighborGeneration) {
-          neighborMarks[neighbor] = neighborGeneration
-          neighbors.push(neighbor)
+        if (reached[neighbor] === 0) {
+          reached[neighbor] = 1
+          queue[tail] = neighbor
+          depths[tail++] = depth + 1
         }
       }
     }
 
-    const pushNeighbors = (current: number, depth: number) => {
-      neighbors.length = 0
-      neighborGeneration++
-      collectNeighbors(view.primary.columnIndices, view.primary.rowOffsets, current)
-      if (view.secondary !== undefined) {
-        collectNeighbors(view.secondary.columnIndices, view.secondary.rowOffsets, current)
+    while (head < tail) {
+      const current = queue[head]
+      const depth = depths[head++]
+      if (depth < radius) {
+        enqueue(view.primary.columnIndices, view.primary.rowOffsets, current, depth)
+        if (view.secondary !== undefined) {
+          enqueue(view.secondary.columnIndices, view.secondary.rowOffsets, current, depth)
+        }
       }
-      const nextDepth = depth + 1
-      for (let i = neighbors.length - 1; i >= 0; i--) {
-        const neighbor = neighbors[i]
-        const neighborDepth = bestDepths[neighbor]
-        if (neighborDepth === -1 || nextDepth < neighborDepth) {
-          bestDepths[neighbor] = nextDepth
+    }
+
+    for (let i = startPositions.length - 1; i >= 0; i--) {
+      stack.push(startPositions[i])
+    }
+
+    const pushNeighbors = (targets: Uint32Array, offsets: Uint32Array, current: number) => {
+      for (let i = offsets[current + 1] - 1; i >= offsets[current]; i--) {
+        const neighbor = targets[i]
+        if (reached[neighbor] !== 0 && yielded[neighbor] === 0) {
           stack.push(neighbor)
-          stackDepths.push(nextDepth)
         }
       }
     }
@@ -7272,18 +7274,14 @@ export const dfs: {
       next() {
         while (stack.length > 0) {
           const current = stack.pop()!
-          const depth = stackDepths.pop()!
-          if (bestDepths[current] !== depth) {
-            continue
-          }
-
-          if (depth < radius) {
-            pushNeighbors(current, depth)
-          }
-
           if (yielded[current] !== 0) {
             continue
           }
+
+          if (view.secondary !== undefined) {
+            pushNeighbors(view.secondary.columnIndices, view.secondary.rowOffsets, current)
+          }
+          pushNeighbors(view.primary.columnIndices, view.primary.rowOffsets, current)
           yielded[current] = 1
 
           return { done: false, value: f(cache.nodeIds[current], cache.nodeData[current] as N) }

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -4406,6 +4406,25 @@ describe("Graph", () => {
       }
     })
 
+    it("should validate the heuristic when source equals target", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        Graph.addNode(mutable, "source")
+      })
+
+      for (const candidate of [graph, Graph.beginMutation(graph)]) {
+        assertGraphError(
+          () =>
+            Graph.astar(candidate, {
+              source: 0,
+              target: 0,
+              cost: (edge) => edge,
+              heuristic: () => NaN
+            }),
+          "A* algorithm requires finite heuristic values"
+        )
+      }
+    })
+
     it("should treat infinity weights as unreachable", () => {
       const graph = makeSingleEdgeGraph(Infinity)
 
@@ -5369,6 +5388,24 @@ describe("Graph", () => {
       const dfsIterator = Graph.dfs(graph, { start: [0], radius: 2 })
 
       assert.deepStrictEqual(Array.from(Graph.indices(dfsIterator)), [0, 1, 2, 3])
+    })
+
+    it("should preserve DFS order when a finite radius includes every reachable node", () => {
+      const graph = Graph.directed<number, void>((mutable) => {
+        for (let i = 0; i < 4; i++) {
+          Graph.addNode(mutable, i)
+        }
+        Graph.addEdge(mutable, 2, 1, undefined)
+        Graph.addEdge(mutable, 2, 3, undefined)
+        Graph.addEdge(mutable, 2, 0, undefined)
+        Graph.addEdge(mutable, 1, 0, undefined)
+      })
+
+      for (const candidate of [graph, Graph.beginMutation(graph)]) {
+        const unbounded = Array.from(Graph.indices(Graph.dfs(candidate, { start: [2] })))
+        const bounded = Array.from(Graph.indices(Graph.dfs(candidate, { start: [2], radius: 4 })))
+        assert.deepStrictEqual(bounded, unbounded)
+      }
     })
 
     it("should limit BFS traversal by radius", () => {


### PR DESCRIPTION
## Summary
- preserve canonical depth-first ordering when a finite radius includes all reachable nodes
- compute bounded DFS membership by shortest edge distance before traversal
- validate A* heuristic values when source and target are the same node
- add immutable and mutable graph regression coverage

## Validation
- `pnpm --filter effect test --run test/Graph.test.ts`
- `pnpm check` (passes with existing duplicate-package warnings from `tmp/bundle-base`)
- `pnpm exec oxlint packages/effect/src/Graph.ts packages/effect/test/Graph.test.ts`
- `git diff --check`