### PR TITLE
docs(sql-pg): correct README driver claim (postgres.js → pg)

### DIFF
--- a/.changeset/sql-pg-readme-driver-fix.md
+++ b/.changeset/sql-pg-readme-driver-fix.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-pg": patch
+---
+
+Fix README: `@effect/sql-pg` uses the `pg` (node-postgres) library, not `postgres.js`. The backend was switched in #5606.

--- a/packages/sql-pg/README.md
+++ b/packages/sql-pg/README.md
@@ -1,6 +1,6 @@
 # `@effect/sql-pg`
 
-An `@effect/sql` implementation using the `postgres.js` library.
+An `@effect/sql` implementation using the `pg` (node-postgres) library.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

`packages/sql-pg/README.md` on the `v3` branch still says the package is "An `@effect/sql` implementation using the `postgres.js` library." That has been stale since #5606 switched the `@effect/sql-pg` backend from `postgres.js` to node-postgres (`pg`), released in `@effect/sql-pg` 0.48.0 (changelog: "Use \"pg\" npm library for @effect/sql-pg backend").

This PR updates the sentence to: "An `@effect/sql` implementation using the `pg` (node-postgres) library."

It targets `v3` because that is the Effect 3.x maintenance line; on `main` (v4) this README no longer lives at this path.

## Verification

Checked `packages/sql-pg/package.json` on `v3`: it depends on `"pg": "^8.16.3"` and not on `postgres.js`, so the corrected sentence matches the actual dependency.

No code changes and no tests — this is a one-sentence documentation fix. A patch changeset for `@effect/sql-pg` is included at `.changeset/sql-pg-readme-driver-fix.md`, per this repo's AGENTS.md requirement that all PRs include a changeset.

Co-authored by: Claude Fable 5