### PR TITLE
Add connectivity, matching, and flow algorithms to Graph

### DIFF
--- a/.changeset/curly-graphs-connect.md
+++ b/.changeset/curly-graphs-connect.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add graph snapshots, low-link connectivity analysis, bipartite matching, maximum flow, and minimum cut APIs.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -490,6 +490,47 @@ export const fromSnapshot = <N, E, T extends Kind>(snapshot: Snapshot<N, E, T>):
 }
 
 /**
+ * Returns the active indexed structure of a graph.
+ *
+ * Nodes and edges are returned in graph order with their current indexes.
+ * Undirected edges retain their stored endpoint orientation, and each returned
+ * node and edge record is newly allocated. The operation runs in `O(V + E)`.
+ *
+ * **Example** (Round-tripping a graph snapshot)
+ *
+ * ```ts import.meta.vitest
+ * import { Equal, Graph } from "effect"
+ *
+ * const graph = Graph.fromSnapshot({
+ *   type: "undirected",
+ *   nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }],
+ *   edges: [{ index: 3, source: 5, target: 2, data: "A-B" }]
+ * })
+ *
+ * Equal.equals(Graph.fromSnapshot(Graph.toSnapshot(graph)), graph) // => true
+ * ```
+ *
+ * @see {@link fromSnapshot} for reconstructing an immutable graph
+ * @category converting
+ * @since 4.0.0
+ */
+export const toSnapshot = <N, E, T extends Kind = "directed">(
+  graph: Graph<N, E, T> | MutableGraph<N, E, T>
+): Snapshot<N, E, T> => {
+  const impl = internal.toImpl(graph)
+  return {
+    type: graph.type,
+    nodes: Array.from(impl.nodes, ([index, data]) => ({ index, data })),
+    edges: Array.from(impl.edges, ([index, edge]) => ({
+      index,
+      source: edge.source,
+      target: edge.target,
+      data: edge.data
+    }))
+  }
+}
+
+/**
  * Creates a graph constructor for the specified graph kind.
  *
  * **When to use**
@@ -4208,6 +4249,214 @@ export const isBipartite = <N, E>(
 }
 
 /**
+ * A pair of matched nodes and the edge that realizes the match.
+ *
+ * `left` and `right` refer to the bipartition derived by
+ * `maximumBipartiteMatching`, not to the stored edge orientation.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface BipartiteMatch {
+  readonly left: NodeIndex
+  readonly right: NodeIndex
+  readonly edge: EdgeIndex
+}
+
+/** @internal */
+const bipartiteColors = <N, E>(
+  graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
+): { readonly cache: csr.Csr; readonly colors: Int8Array } => {
+  if ((graph as Graph<N, E, Kind> | MutableGraph<N, E, Kind>).type === "directed") {
+    throw new GraphError({ message: "Cannot find bipartite matching of directed graph" })
+  }
+  const cache = csr.get(graph)
+  const outgoing = csr.getOutgoing(cache)
+  const colors = new Int8Array(cache.nodeIds.length)
+  const queue = new Uint32Array(cache.nodeIds.length)
+  colors.fill(-1)
+
+  for (let start = 0; start < cache.nodeIds.length; start++) {
+    if (colors[start] !== -1) {
+      continue
+    }
+    let head = 0
+    let tail = 1
+    colors[start] = 0
+    queue[0] = start
+    while (head < tail) {
+      const node = queue[head++]
+      const color = colors[node] === 0 ? 1 : 0
+      for (let i = outgoing.rowOffsets[node]; i < outgoing.rowOffsets[node + 1]; i++) {
+        const neighbor = outgoing.columnIndices[i]
+        if (colors[neighbor] === -1) {
+          colors[neighbor] = color
+          queue[tail++] = neighbor
+        } else if (colors[neighbor] === colors[node]) {
+          throw new GraphError({ message: "Cannot find bipartite matching of non-bipartite graph" })
+        }
+      }
+    }
+  }
+  return { cache, colors }
+}
+
+/**
+ * Returns a maximum-cardinality matching of an undirected bipartite graph.
+ *
+ * The bipartition is derived internally. Self-loops and odd cycles throw a
+ * `GraphError`. Isolated nodes are allowed. Parallel edges do not change the
+ * matching cardinality, and the first edge in graph order between each matched
+ * pair is reported. Results follow left-partition graph order. Hopcroft-Karp
+ * runs in `O(E * sqrt(V))` time.
+ *
+ * **Example** (Matching a bipartite graph)
+ *
+ * ```ts import.meta.vitest
+ * import { Graph } from "effect"
+ *
+ * const graph = Graph.undirected<string, string>((mutable) => {
+ *   for (const node of ["A", "B", "X", "Y"]) Graph.addNode(mutable, node)
+ *   Graph.addEdge(mutable, 0, 2, "A-X")
+ *   Graph.addEdge(mutable, 0, 3, "A-Y")
+ *   Graph.addEdge(mutable, 1, 2, "B-X")
+ * })
+ *
+ * Graph.maximumBipartiteMatching(graph) // => [{ left: 0, right: 3, edge: 1 }, { left: 1, right: 2, edge: 2 }]
+ * ```
+ *
+ * @category algorithms
+ * @since 4.0.0
+ */
+export const maximumBipartiteMatching = <N, E>(
+  graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
+): Array<BipartiteMatch> => {
+  const { cache, colors } = bipartiteColors(graph)
+  const endpoints = csr.getEdgeEndpoints(cache)
+  const edgeIds = csr.getEdgeIds(cache)
+  const adjacency: Array<Array<{ readonly right: number; readonly edge: number }>> = Array.from({
+    length: cache.nodeIds.length
+  }, () => [])
+  const seen = Array.from({ length: cache.nodeIds.length }, () => new Set<number>())
+
+  for (let edge = 0; edge < edgeIds.length; edge++) {
+    const source = endpoints.sources[edge]
+    const target = endpoints.targets[edge]
+    const left = colors[source] === 0 ? source : target
+    const right = colors[source] === 0 ? target : source
+    if (!seen[left].has(right)) {
+      seen[left].add(right)
+      adjacency[left].push({ right, edge })
+    }
+  }
+
+  const unmatched = -1
+  const infinity = 0x7fffffff
+  const matchLeft = new Int32Array(cache.nodeIds.length)
+  const matchRight = new Int32Array(cache.nodeIds.length)
+  const matchEdge = new Int32Array(cache.nodeIds.length)
+  const distance = new Int32Array(cache.nodeIds.length)
+  const queue = new Uint32Array(cache.nodeIds.length)
+  matchLeft.fill(unmatched)
+  matchRight.fill(unmatched)
+  matchEdge.fill(unmatched)
+  let shortestDistance = infinity
+
+  const hasLayer = (): boolean => {
+    let head = 0
+    let tail = 0
+    shortestDistance = infinity
+    for (let left = 0; left < colors.length; left++) {
+      if (colors[left] !== 0) {
+        continue
+      }
+      if (matchLeft[left] === unmatched) {
+        distance[left] = 0
+        queue[tail++] = left
+      } else {
+        distance[left] = infinity
+      }
+    }
+    while (head < tail) {
+      const left = queue[head++]
+      if (distance[left] >= shortestDistance) {
+        continue
+      }
+      for (const arc of adjacency[left]) {
+        const next = matchRight[arc.right]
+        if (next === unmatched) {
+          shortestDistance = distance[left] + 1
+        } else if (distance[next] === infinity) {
+          distance[next] = distance[left] + 1
+          queue[tail++] = next
+        }
+      }
+    }
+    return shortestDistance !== infinity
+  }
+
+  const augment = (start: number): boolean => {
+    const stack: Array<{
+      readonly left: number
+      position: number
+      readonly viaRight: number
+      readonly viaEdge: number
+    }> = [{ left: start, position: 0, viaRight: unmatched, viaEdge: unmatched }]
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1]
+      const arcs = adjacency[frame.left]
+      if (frame.position >= arcs.length) {
+        distance[frame.left] = infinity
+        stack.pop()
+        continue
+      }
+      const arc = arcs[frame.position++]
+      const next = matchRight[arc.right]
+      if (next === unmatched && distance[frame.left] + 1 === shortestDistance) {
+        matchLeft[frame.left] = arc.right
+        matchRight[arc.right] = frame.left
+        matchEdge[frame.left] = arc.edge
+        for (let i = stack.length - 1; i > 0; i--) {
+          const child = stack[i]
+          const parent = stack[i - 1]
+          matchLeft[parent.left] = child.viaRight
+          matchRight[child.viaRight] = parent.left
+          matchEdge[parent.left] = child.viaEdge
+        }
+        return true
+      }
+      if (next === unmatched) {
+        continue
+      }
+      if (distance[next] === distance[frame.left] + 1) {
+        stack.push({ left: next, position: 0, viaRight: arc.right, viaEdge: arc.edge })
+      }
+    }
+    return false
+  }
+
+  while (hasLayer()) {
+    for (let left = 0; left < colors.length; left++) {
+      if (colors[left] === 0 && matchLeft[left] === unmatched) {
+        augment(left)
+      }
+    }
+  }
+
+  const matches: Array<BipartiteMatch> = []
+  for (let left = 0; left < colors.length; left++) {
+    if (matchLeft[left] !== unmatched) {
+      matches.push({
+        left: cache.nodeIds[left],
+        right: cache.nodeIds[matchLeft[left]],
+        edge: edgeIds[matchEdge[left]]
+      })
+    }
+  }
+  return matches
+}
+
+/**
  * Get neighbors for undirected graphs by checking both adjacency and reverse adjacency.
  * For undirected graphs, we need to find the other endpoint of each edge incident to the node.
  */
@@ -4481,6 +4730,515 @@ export const connectedComponents = <N, E>(
 
   return components
 }
+
+/** @internal */
+interface LowLinkResult {
+  readonly bridges: Array<EdgeIndex>
+  readonly articulationPoints: Array<NodeIndex>
+  readonly biconnectedComponents: Array<Array<NodeIndex>>
+}
+
+/** @internal */
+const analyzeLowLinks = <N, E>(
+  graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
+): LowLinkResult => {
+  if ((graph as Graph<N, E, Kind> | MutableGraph<N, E, Kind>).type === "directed") {
+    throw new GraphError({ message: "Cannot analyze undirected connectivity of directed graph" })
+  }
+  const cache = csr.get(graph)
+  const outgoing = csr.getOutgoingWithEdges(cache)
+  const edgeIds = csr.getEdgeIds(cache)
+  const endpoints = csr.getEdgeEndpoints(cache)
+  const discovered = new Int32Array(cache.nodeIds.length)
+  const low = new Int32Array(cache.nodeIds.length)
+  const parentNode = new Int32Array(cache.nodeIds.length)
+  const parentEdge = new Int32Array(cache.nodeIds.length)
+  const childCount = new Uint32Array(cache.nodeIds.length)
+  const bridgeMarks = new Uint8Array(edgeIds.length)
+  const articulationMarks = new Uint8Array(cache.nodeIds.length)
+  const edgeStack: Array<number> = []
+  const components: Array<Array<number>> = []
+  const loopNodes = new Set<number>()
+  discovered.fill(-1)
+  parentNode.fill(-1)
+  parentEdge.fill(-1)
+  let time = 0
+
+  const popComponent = (stopEdge: number): void => {
+    const nodes = new Set<number>()
+    while (edgeStack.length > 0) {
+      const edge = edgeStack.pop()!
+      nodes.add(endpoints.sources[edge])
+      nodes.add(endpoints.targets[edge])
+      if (edge === stopEdge) {
+        break
+      }
+    }
+    if (nodes.size > 0) {
+      components.push(Array.from(nodes).sort((a, b) => a - b))
+    }
+  }
+
+  for (let start = 0; start < cache.nodeIds.length; start++) {
+    if (discovered[start] !== -1) {
+      continue
+    }
+    discovered[start] = low[start] = time++
+    const stack: Array<{ readonly node: number; position: number }> = [{
+      node: start,
+      position: outgoing.rowOffsets[start]
+    }]
+
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1]
+      const end = outgoing.rowOffsets[frame.node + 1]
+      if (frame.position < end) {
+        const position = frame.position++
+        const edge = outgoing.edgeIndices[position]
+        const neighbor = outgoing.columnIndices[position]
+        if (neighbor === frame.node) {
+          loopNodes.add(frame.node)
+          continue
+        }
+        if (edge === parentEdge[frame.node]) {
+          continue
+        }
+        if (discovered[neighbor] === -1) {
+          childCount[frame.node]++
+          parentNode[neighbor] = frame.node
+          parentEdge[neighbor] = edge
+          discovered[neighbor] = low[neighbor] = time++
+          edgeStack.push(edge)
+          stack.push({ node: neighbor, position: outgoing.rowOffsets[neighbor] })
+        } else if (discovered[neighbor] < discovered[frame.node]) {
+          low[frame.node] = Math.min(low[frame.node], discovered[neighbor])
+          edgeStack.push(edge)
+        }
+        continue
+      }
+
+      stack.pop()
+      const parent = parentNode[frame.node]
+      if (parent === -1) {
+        if (childCount[frame.node] > 1) {
+          articulationMarks[frame.node] = 1
+        }
+      } else {
+        low[parent] = Math.min(low[parent], low[frame.node])
+        if (low[frame.node] > discovered[parent]) {
+          bridgeMarks[parentEdge[frame.node]] = 1
+        }
+        if (low[frame.node] >= discovered[parent]) {
+          if (parentNode[parent] !== -1) {
+            articulationMarks[parent] = 1
+          }
+          popComponent(parentEdge[frame.node])
+        }
+      }
+    }
+  }
+
+  for (const node of loopNodes) {
+    components.push([node])
+  }
+  components.sort((left, right) => {
+    const length = Math.min(left.length, right.length)
+    for (let i = 0; i < length; i++) {
+      if (left[i] !== right[i]) {
+        return left[i] - right[i]
+      }
+    }
+    return left.length - right.length
+  })
+
+  const resultBridges: Array<EdgeIndex> = []
+  for (let edge = 0; edge < edgeIds.length; edge++) {
+    if (bridgeMarks[edge] !== 0) {
+      resultBridges.push(edgeIds[edge])
+    }
+  }
+  const resultArticulationPoints: Array<NodeIndex> = []
+  for (let node = 0; node < cache.nodeIds.length; node++) {
+    if (articulationMarks[node] !== 0) {
+      resultArticulationPoints.push(cache.nodeIds[node])
+    }
+  }
+  return {
+    bridges: resultBridges,
+    articulationPoints: resultArticulationPoints,
+    biconnectedComponents: components.map((component) => component.map((node) => cache.nodeIds[node]))
+  }
+}
+
+/**
+ * Returns the edges whose removal increases the number of connected components.
+ *
+ * The graph must be undirected. Parent edges are tracked by edge index, so a
+ * parallel edge prevents either edge from being a bridge. Self-loops are never
+ * bridges. Results follow graph edge order. The iterative low-link traversal is
+ * stack-safe and runs in `O(V + E)` time.
+ *
+ * **Example** (Finding bridge edges)
+ *
+ * ```ts import.meta.vitest
+ * import { Graph } from "effect"
+ *
+ * const graph = Graph.undirected<void, void>((mutable) => {
+ *   for (let i = 0; i < 3; i++) Graph.addNode(mutable, undefined)
+ *   Graph.addEdge(mutable, 0, 1, undefined)
+ *   Graph.addEdge(mutable, 1, 2, undefined)
+ * })
+ *
+ * Graph.bridges(graph) // => [0, 1]
+ * ```
+ *
+ * @category algorithms
+ * @since 4.0.0
+ */
+export const bridges = <N, E>(
+  graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
+): Array<EdgeIndex> => analyzeLowLinks(graph).bridges
+
+/**
+ * Returns the nodes whose removal increases the number of connected components.
+ *
+ * The graph must be undirected. Disconnected components, parallel edges, and
+ * self-loops are handled by an iterative, stack-safe low-link traversal in
+ * `O(V + E)` time. Results follow graph node order.
+ *
+ * **Example** (Finding articulation points)
+ *
+ * ```ts import.meta.vitest
+ * import { Graph } from "effect"
+ *
+ * const graph = Graph.undirected<void, void>((mutable) => {
+ *   for (let i = 0; i < 3; i++) Graph.addNode(mutable, undefined)
+ *   Graph.addEdge(mutable, 0, 1, undefined)
+ *   Graph.addEdge(mutable, 1, 2, undefined)
+ * })
+ *
+ * Graph.articulationPoints(graph) // => [1]
+ * ```
+ *
+ * @category algorithms
+ * @since 4.0.0
+ */
+export const articulationPoints = <N, E>(
+  graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
+): Array<NodeIndex> => analyzeLowLinks(graph).articulationPoints
+
+/**
+ * Returns the maximal biconnected node components of an undirected graph.
+ *
+ * Articulation points can occur in more than one component. Isolated vertices
+ * are excluded, while a vertex with a self-loop forms a singleton component.
+ * Nodes within components and the components themselves follow graph order.
+ * Parallel edges are treated independently. The iterative low-link traversal
+ * is stack-safe and runs in `O(V + E)` time.
+ *
+ * **Example** (Finding biconnected components)
+ *
+ * ```ts import.meta.vitest
+ * import { Graph } from "effect"
+ *
+ * const graph = Graph.undirected<void, void>((mutable) => {
+ *   for (let i = 0; i < 5; i++) Graph.addNode(mutable, undefined)
+ *   Graph.addEdge(mutable, 0, 1, undefined)
+ *   Graph.addEdge(mutable, 1, 2, undefined)
+ *   Graph.addEdge(mutable, 2, 0, undefined)
+ *   Graph.addEdge(mutable, 2, 3, undefined)
+ *   Graph.addEdge(mutable, 3, 4, undefined)
+ *   Graph.addEdge(mutable, 4, 2, undefined)
+ * })
+ *
+ * Graph.biconnectedComponents(graph) // => [[0, 1, 2], [2, 3, 4]]
+ * ```
+ *
+ * @category algorithms
+ * @since 4.0.0
+ */
+export const biconnectedComponents = <N, E>(
+  graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
+): Array<Array<NodeIndex>> => analyzeLowLinks(graph).biconnectedComponents
+
+/**
+ * Configuration for source-to-target flow algorithms.
+ *
+ * `capacity` receives stored edge data and must return a finite,
+ * non-negative number.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface MaximumFlowConfig<E> {
+  readonly source: NodeIndex
+  readonly target: NodeIndex
+  readonly capacity: (edge: E) => number
+}
+
+/**
+ * Maximum flow value, per-edge flows, and a corresponding minimum cut.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface MaximumFlowResult {
+  readonly value: number
+  readonly flows: Map<EdgeIndex, number>
+  readonly cut: Array<EdgeIndex>
+}
+
+/**
+ * Minimum cut value, crossing edges, and residual-reachability partitions.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface MinimumCutResult {
+  readonly value: number
+  readonly edges: Array<EdgeIndex>
+  readonly source: Array<NodeIndex>
+  readonly target: Array<NodeIndex>
+}
+
+/** @internal */
+interface FlowSolution extends MaximumFlowResult {
+  readonly sourceSide: Uint8Array
+  readonly nodeIds: Array<NodeIndex>
+}
+
+/** @internal */
+interface ResidualArc {
+  readonly from: number
+  readonly to: number
+  readonly capacity: number
+  readonly edge: number
+  flow: number
+}
+
+/** @internal */
+const solveMaximumFlow = <N, E>(
+  graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">,
+  config: MaximumFlowConfig<E>
+): FlowSolution => {
+  if ((graph as Graph<N, E, Kind> | MutableGraph<N, E, Kind>).type === "undirected") {
+    throw new GraphError({ message: "Cannot compute flow of undirected graph" })
+  }
+  const cache = csr.get(graph)
+  const source = csr.getNodeIndex(cache, config.source)
+  if (source === undefined) {
+    throw missingNode(config.source)
+  }
+  const target = csr.getNodeIndex(cache, config.target)
+  if (target === undefined) {
+    throw missingNode(config.target)
+  }
+  if (source === target) {
+    throw new GraphError({ message: "Flow source and target must be different nodes" })
+  }
+
+  const edges = csr.getEdges(cache) as Array<Edge<E>>
+  const edgeIds = csr.getEdgeIds(cache)
+  const endpoints = csr.getEdgeEndpoints(cache)
+  const capacities = new Float64Array(edges.length)
+  const arcs: Array<ResidualArc> = []
+  const adjacency: Array<Array<number>> = Array.from({ length: cache.nodeIds.length }, () => [])
+  const forwardArc = new Int32Array(edges.length)
+  forwardArc.fill(-1)
+
+  for (let edge = 0; edge < edges.length; edge++) {
+    const capacity = config.capacity(edges[edge].data)
+    if (!Number.isFinite(capacity) || capacity < 0) {
+      throw new GraphError({ message: `Edge ${edgeIds[edge]} capacity must be a finite non-negative number` })
+    }
+    capacities[edge] = capacity
+    const from = endpoints.sources[edge]
+    const to = endpoints.targets[edge]
+    if (from === to) {
+      continue
+    }
+    const index = arcs.length
+    forwardArc[edge] = index
+    adjacency[from].push(index)
+    arcs.push({ from, to, capacity, edge, flow: 0 })
+    adjacency[to].push(index + 1)
+    arcs.push({ from: to, to: from, capacity: 0, edge: -1, flow: 0 })
+  }
+
+  const parentArc = new Int32Array(cache.nodeIds.length)
+  const visited = new Uint8Array(cache.nodeIds.length)
+  const queue = new Uint32Array(cache.nodeIds.length)
+  let value = 0
+  while (true) {
+    parentArc.fill(-1)
+    visited.fill(0)
+    let head = 0
+    let tail = 1
+    queue[0] = source
+    visited[source] = 1
+    while (head < tail && visited[target] === 0) {
+      const node = queue[head++]
+      for (const arcIndex of adjacency[node]) {
+        const arc = arcs[arcIndex]
+        if (arc.capacity - arc.flow > 0 && visited[arc.to] === 0) {
+          visited[arc.to] = 1
+          parentArc[arc.to] = arcIndex
+          queue[tail++] = arc.to
+          if (arc.to === target) {
+            break
+          }
+        }
+      }
+    }
+    if (visited[target] === 0) {
+      break
+    }
+
+    let amount = Infinity
+    for (let node = target; node !== source;) {
+      const arc = arcs[parentArc[node]]
+      amount = Math.min(amount, arc.capacity - arc.flow)
+      node = arc.from
+    }
+    if (!Number.isFinite(value + amount)) {
+      throw new GraphError({ message: "Maximum flow exceeds the finite number range" })
+    }
+    for (let node = target; node !== source;) {
+      const arcIndex = parentArc[node]
+      const arc = arcs[arcIndex]
+      arc.flow += amount
+      arcs[arcIndex ^ 1].flow -= amount
+      node = arc.from
+    }
+    value += amount
+  }
+
+  const flows = new Map<EdgeIndex, number>()
+  for (let edge = 0; edge < edgeIds.length; edge++) {
+    const arcIndex = forwardArc[edge]
+    flows.set(edgeIds[edge], arcIndex === -1 ? 0 : arcs[arcIndex].flow)
+  }
+
+  visited.fill(0)
+  let head = 0
+  let tail = 1
+  queue[0] = source
+  visited[source] = 1
+  while (head < tail) {
+    const node = queue[head++]
+    for (const arcIndex of adjacency[node]) {
+      const arc = arcs[arcIndex]
+      if (arc.capacity - arc.flow > 0 && visited[arc.to] === 0) {
+        visited[arc.to] = 1
+        queue[tail++] = arc.to
+      }
+    }
+  }
+
+  const cut: Array<EdgeIndex> = []
+  for (let edge = 0; edge < edgeIds.length; edge++) {
+    if (
+      endpoints.sources[edge] !== endpoints.targets[edge] &&
+      visited[endpoints.sources[edge]] !== 0 &&
+      visited[endpoints.targets[edge]] === 0
+    ) {
+      cut.push(edgeIds[edge])
+    }
+  }
+  return { value, flows, cut, sourceSide: visited, nodeIds: cache.nodeIds }
+}
+
+/**
+ * Returns a maximum flow and corresponding minimum cut for a directed graph.
+ *
+ * Capacities must be finite and non-negative. Missing or equal endpoints and a
+ * total flow outside the finite number range throw a `GraphError`. Parallel
+ * edges retain independent capacities, self-loops carry no source-to-target
+ * flow, and the flow map includes every original edge in graph order, including
+ * zero-flow edges. Edmonds-Karp runs in `O(V * E^2)` time.
+ *
+ * **Example** (Computing maximum flow)
+ *
+ * ```ts import.meta.vitest
+ * import { Graph } from "effect"
+ *
+ * const graph = Graph.directed<string, number>((mutable) => {
+ *   for (const node of ["source", "a", "target"]) Graph.addNode(mutable, node)
+ *   Graph.addEdge(mutable, 0, 1, 3)
+ *   Graph.addEdge(mutable, 1, 2, 2)
+ *   Graph.addEdge(mutable, 0, 2, 1)
+ * })
+ *
+ * Graph.maximumFlow(graph, { source: 0, target: 2, capacity: (edge) => edge }).value // => 3
+ * ```
+ *
+ * @see {@link minimumCut} for the residual-reachability partition
+ * @category algorithms
+ * @since 4.0.0
+ */
+export const maximumFlow: {
+  <E>(config: MaximumFlowConfig<E>): <N>(
+    graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">
+  ) => MaximumFlowResult
+  <N, E>(
+    graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">,
+    config: MaximumFlowConfig<E>
+  ): MaximumFlowResult
+} = dual(2, <N, E>(
+  graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">,
+  config: MaximumFlowConfig<E>
+): MaximumFlowResult => {
+  const { cut, flows, value } = solveMaximumFlow(graph, config)
+  return { value, flows, cut }
+})
+
+/**
+ * Returns a minimum cut and its node partitions for a directed graph.
+ *
+ * The source partition contains nodes reachable from the source in the final
+ * residual network; the target partition contains its complement. Both follow
+ * graph node order. Cut edges follow graph edge order, and their total capacity
+ * equals the returned maximum-flow value. Validation, parallel-edge,
+ * self-loop, and `O(V * E^2)` complexity behavior match `maximumFlow`.
+ *
+ * **Example** (Partitioning a minimum cut)
+ *
+ * ```ts import.meta.vitest
+ * import { Graph } from "effect"
+ *
+ * const graph = Graph.directed<string, number>((mutable) => {
+ *   for (const node of ["source", "a", "target"]) Graph.addNode(mutable, node)
+ *   Graph.addEdge(mutable, 0, 1, 2)
+ *   Graph.addEdge(mutable, 1, 2, 1)
+ * })
+ *
+ * Graph.minimumCut(graph, { source: 0, target: 2, capacity: (edge) => edge }).source // => [0, 1]
+ * ```
+ *
+ * @see {@link maximumFlow} for per-edge flow values
+ * @category algorithms
+ * @since 4.0.0
+ */
+export const minimumCut: {
+  <E>(config: MaximumFlowConfig<E>): <N>(
+    graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">
+  ) => MinimumCutResult
+  <N, E>(
+    graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">,
+    config: MaximumFlowConfig<E>
+  ): MinimumCutResult
+} = dual(2, <N, E>(
+  graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">,
+  config: MaximumFlowConfig<E>
+): MinimumCutResult => {
+  const solution = solveMaximumFlow(graph, config)
+  const source: Array<NodeIndex> = []
+  const target: Array<NodeIndex> = []
+  for (let node = 0; node < solution.nodeIds.length; node++) {
+    ;(solution.sourceSide[node] === 0 ? target : source).push(solution.nodeIds[node])
+  }
+  return { value: solution.value, edges: solution.cut, source, target }
+})
 
 /**
  * Finds weakly connected components in a directed graph.

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -249,6 +249,53 @@ describe("Graph", () => {
         "Edge target 2 does not reference a node"
       )
     })
+
+    describe("toSnapshot", () => {
+      it("preserves empty graphs and supports mutable graphs", () => {
+        assert.deepStrictEqual(Graph.toSnapshot(Graph.directed()), { type: "directed", nodes: [], edges: [] })
+        const mutable = Graph.beginMutation(Graph.undirected<string, number>())
+        Graph.addNode(mutable, "A")
+        assert.deepStrictEqual(Graph.toSnapshot(mutable), {
+          type: "undirected",
+          nodes: [{ index: 0, data: "A" }],
+          edges: []
+        })
+      })
+
+      it("preserves sparse indexes, parallel edges, self-loops, and stored orientation", () => {
+        const graph = Graph.fromSnapshot({
+          type: "undirected",
+          nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }],
+          edges: [
+            { index: 3, source: 5, target: 2, data: "first" },
+            { index: 7, source: 5, target: 2, data: "parallel" },
+            { index: 11, source: 5, target: 5, data: "loop" }
+          ]
+        })
+        const snapshot = Graph.toSnapshot(graph)
+
+        assert.deepStrictEqual(snapshot, {
+          type: "undirected",
+          nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }],
+          edges: [
+            { index: 3, source: 5, target: 2, data: "first" },
+            { index: 7, source: 5, target: 2, data: "parallel" },
+            { index: 11, source: 5, target: 5, data: "loop" }
+          ]
+        })
+        assert.strictEqual(Equal.equals(Graph.fromSnapshot(snapshot), graph), true)
+      })
+
+      it("does not expose stored edge records", () => {
+        const graph = makeSingleEdgeGraph(1)
+        const snapshot = Graph.toSnapshot(graph)
+        const edge = snapshot.edges[0] as { source: number; target: number; data: number }
+        edge.source = 1
+        edge.data = 2
+
+        assert.deepStrictEqual(Option.getOrThrow(Graph.getEdge(graph, 0)), { source: 0, target: 1, data: 1 })
+      })
+    })
   })
 
   describe("equality and hashing", () => {
@@ -3489,6 +3536,121 @@ describe("Graph", () => {
     })
   })
 
+  describe("maximumBipartiteMatching", () => {
+    it("handles empty graphs and isolated nodes", () => {
+      assert.deepStrictEqual(Graph.maximumBipartiteMatching(Graph.undirected()), [])
+      const graph = Graph.undirected<void, void>((mutable) => {
+        Graph.addNode(mutable, undefined)
+        Graph.addNode(mutable, undefined)
+      })
+      assert.deepStrictEqual(Graph.maximumBipartiteMatching(graph), [])
+    })
+
+    it("finds single, perfect, and non-perfect maximum matchings", () => {
+      const single = Graph.undirected<void, void>((mutable) => {
+        Graph.addNode(mutable, undefined)
+        Graph.addNode(mutable, undefined)
+        Graph.addEdge(mutable, 0, 1, undefined)
+      })
+      assert.deepStrictEqual(Graph.maximumBipartiteMatching(single), [{ left: 0, right: 1, edge: 0 }])
+
+      const graph = Graph.undirected<void, void>((mutable) => {
+        for (let i = 0; i < 5; i++) Graph.addNode(mutable, undefined)
+        Graph.addEdge(mutable, 0, 2, undefined)
+        Graph.addEdge(mutable, 0, 3, undefined)
+        Graph.addEdge(mutable, 1, 2, undefined)
+        Graph.addEdge(mutable, 1, 4, undefined)
+      })
+      assert.deepStrictEqual(Graph.maximumBipartiteMatching(graph), [
+        { left: 0, right: 3, edge: 1 },
+        { left: 1, right: 2, edge: 2 }
+      ])
+      assert.strictEqual(Graph.maximumBipartiteMatching(graph).length, 2)
+    })
+
+    it("is deterministic across disconnected components and possible matchings", () => {
+      const graph = Graph.undirected<void, void>((mutable) => {
+        for (let i = 0; i < 8; i++) Graph.addNode(mutable, undefined)
+        for (const [source, target] of [[0, 2], [0, 3], [1, 2], [1, 3], [4, 6], [5, 7]] as const) {
+          Graph.addEdge(mutable, source, target, undefined)
+        }
+      })
+
+      assert.deepStrictEqual(Graph.maximumBipartiteMatching(graph), [
+        { left: 0, right: 2, edge: 0 },
+        { left: 1, right: 3, edge: 3 },
+        { left: 4, right: 6, edge: 4 },
+        { left: 5, right: 7, edge: 5 }
+      ])
+    })
+
+    it("uses the first parallel edge without changing cardinality", () => {
+      const graph = Graph.undirected<void, string>((mutable) => {
+        Graph.addNode(mutable, undefined)
+        Graph.addNode(mutable, undefined)
+        Graph.addEdge(mutable, 1, 0, "first")
+        Graph.addEdge(mutable, 0, 1, "second")
+      })
+
+      assert.deepStrictEqual(Graph.maximumBipartiteMatching(graph), [{ left: 0, right: 1, edge: 0 }])
+    })
+
+    it("matches a brute-force oracle for all three-by-three bipartite graphs", () => {
+      const oracle = (adjacency: ReadonlyArray<ReadonlyArray<number>>, left = 0, used = 0): number => {
+        if (left === adjacency.length) return 0
+        let best = oracle(adjacency, left + 1, used)
+        for (const right of adjacency[left]) {
+          if ((used & (1 << right)) === 0) {
+            best = Math.max(best, 1 + oracle(adjacency, left + 1, used | (1 << right)))
+          }
+        }
+        return best
+      }
+
+      for (let mask = 0; mask < 1 << 9; mask++) {
+        const adjacency: Array<Array<number>> = [[], [], []]
+        const graph = Graph.undirected<void, void>((mutable) => {
+          for (let i = 0; i < 6; i++) Graph.addNode(mutable, undefined)
+          for (let left = 0; left < 3; left++) {
+            for (let right = 0; right < 3; right++) {
+              if ((mask & (1 << (left * 3 + right))) !== 0) {
+                adjacency[left].push(right)
+                Graph.addEdge(mutable, left, right + 3, undefined)
+              }
+            }
+          }
+        })
+        assert.strictEqual(Graph.maximumBipartiteMatching(graph).length, oracle(adjacency))
+      }
+    })
+
+    it("rejects self-loops, odd cycles, and directed graphs", () => {
+      const loop = Graph.undirected<void, void>((mutable) => {
+        Graph.addNode(mutable, undefined)
+        Graph.addEdge(mutable, 0, 0, undefined)
+      })
+      const triangle = Graph.undirected<void, void>((mutable) => {
+        for (let i = 0; i < 3; i++) Graph.addNode(mutable, undefined)
+        Graph.addEdge(mutable, 0, 1, undefined)
+        Graph.addEdge(mutable, 1, 2, undefined)
+        Graph.addEdge(mutable, 2, 0, undefined)
+      })
+
+      assertGraphError(
+        () => Graph.maximumBipartiteMatching(loop),
+        "Cannot find bipartite matching of non-bipartite graph"
+      )
+      assertGraphError(
+        () => Graph.maximumBipartiteMatching(triangle),
+        "Cannot find bipartite matching of non-bipartite graph"
+      )
+      assertGraphError(
+        () => Graph.maximumBipartiteMatching(Graph.directed() as any),
+        "Cannot find bipartite matching of directed graph"
+      )
+    })
+  })
+
   describe("connectedComponents", () => {
     it("should find connected components in disconnected undirected graph", () => {
       const graph = Graph.undirected<string, string>((mutable) => {
@@ -3540,6 +3702,104 @@ describe("Graph", () => {
 
       assert.deepStrictEqual(Graph.connectedComponents(graph), [[0, 2, 1]])
       assert.deepStrictEqual(Graph.connectedComponents(Graph.beginMutation(graph)), [[0, 2, 1]])
+    })
+  })
+
+  describe("low-link connectivity", () => {
+    const analyze = <N, E>(graph: Graph.UndirectedGraph<N, E>) => ({
+      bridges: Graph.bridges(graph),
+      articulationPoints: Graph.articulationPoints(graph),
+      biconnectedComponents: Graph.biconnectedComponents(graph)
+    })
+
+    it("handles empty graphs and isolated nodes", () => {
+      assert.deepStrictEqual(analyze(Graph.undirected()), {
+        bridges: [],
+        articulationPoints: [],
+        biconnectedComponents: []
+      })
+      const isolated = Graph.undirected<void, void>((mutable) => {
+        Graph.addNode(mutable, undefined)
+      })
+      assert.deepStrictEqual(analyze(isolated), {
+        bridges: [],
+        articulationPoints: [],
+        biconnectedComponents: []
+      })
+    })
+
+    it("handles a single edge, paths, and cycles", () => {
+      const single = Graph.undirected<void, void>((mutable) => {
+        Graph.addNode(mutable, undefined)
+        Graph.addNode(mutable, undefined)
+        Graph.addEdge(mutable, 0, 1, undefined)
+      })
+      assert.deepStrictEqual(analyze(single), {
+        bridges: [0],
+        articulationPoints: [],
+        biconnectedComponents: [[0, 1]]
+      })
+
+      const path = Graph.undirected<void, void>((mutable) => {
+        for (let i = 0; i < 3; i++) Graph.addNode(mutable, undefined)
+        Graph.addEdge(mutable, 0, 1, undefined)
+        Graph.addEdge(mutable, 1, 2, undefined)
+      })
+      assert.deepStrictEqual(analyze(path), {
+        bridges: [0, 1],
+        articulationPoints: [1],
+        biconnectedComponents: [[0, 1], [1, 2]]
+      })
+
+      const cycle = Graph.mutate(path, (mutable) => {
+        Graph.addEdge(mutable, 2, 0, undefined)
+      })
+      assert.deepStrictEqual(analyze(cycle), {
+        bridges: [],
+        articulationPoints: [],
+        biconnectedComponents: [[0, 1, 2]]
+      })
+    })
+
+    it("handles shared articulation points and disconnected components", () => {
+      const graph = Graph.undirected<void, void>((mutable) => {
+        for (let i = 0; i < 8; i++) Graph.addNode(mutable, undefined)
+        for (const [source, target] of [[0, 1], [1, 2], [2, 0], [2, 3], [3, 4], [4, 2], [5, 6]] as const) {
+          Graph.addEdge(mutable, source, target, undefined)
+        }
+      })
+
+      assert.deepStrictEqual(analyze(graph), {
+        bridges: [6],
+        articulationPoints: [2],
+        biconnectedComponents: [[0, 1, 2], [2, 3, 4], [5, 6]]
+      })
+    })
+
+    it("handles parallel edges, self-loops, and sparse indexes", () => {
+      const graph = Graph.fromSnapshot({
+        type: "undirected",
+        nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }, { index: 9, data: "C" }],
+        edges: [
+          { index: 3, source: 5, target: 2, data: "first" },
+          { index: 7, source: 2, target: 5, data: "parallel" },
+          { index: 11, source: 5, target: 9, data: "bridge" },
+          { index: 13, source: 9, target: 9, data: "loop" }
+        ]
+      })
+
+      assert.deepStrictEqual(analyze(graph), {
+        bridges: [11],
+        articulationPoints: [5],
+        biconnectedComponents: [[2, 5], [5, 9], [9]]
+      })
+    })
+
+    it("rejects directed graphs at runtime", () => {
+      const graph = Graph.directed() as any
+      for (const operation of [Graph.bridges, Graph.articulationPoints, Graph.biconnectedComponents]) {
+        assertGraphError(() => operation(graph), "Cannot analyze undirected connectivity of directed graph")
+      }
     })
   })
 
@@ -3810,6 +4070,142 @@ describe("Graph", () => {
         () => Graph.isStronglyConnected(undirected as any),
         "Cannot find strongly connected components of undirected graph"
       )
+    })
+  })
+
+  describe("maximumFlow and minimumCut", () => {
+    const config = { source: 0, target: 2, capacity: (edge: number) => edge }
+
+    it("rejects missing or equal endpoints and undirected graphs", () => {
+      const graph = Graph.directed<void, number>((mutable) => {
+        Graph.addNode(mutable, undefined)
+        Graph.addNode(mutable, undefined)
+      })
+      assertGraphError(() => Graph.maximumFlow(graph, config), "Node 2 does not exist")
+      assertGraphError(
+        () => Graph.minimumCut(graph, { ...config, source: 2 }),
+        "Node 2 does not exist"
+      )
+      assertGraphError(
+        () => Graph.maximumFlow(graph, { ...config, source: 0, target: 0 }),
+        "Flow source and target must be different nodes"
+      )
+      assertGraphError(
+        () => Graph.maximumFlow(Graph.undirected() as any, config),
+        "Cannot compute flow of undirected graph"
+      )
+    })
+
+    it("computes a single-edge flow in data-first and data-last forms", () => {
+      const graph = makeSingleEdgeGraph(3)
+      const expected = { value: 3, flows: new Map([[0, 3]]), cut: [0] }
+
+      assert.deepStrictEqual(Graph.maximumFlow(graph, { ...config, target: 1 }), expected)
+      assert.deepStrictEqual(Graph.maximumFlow({ ...config, target: 1 })(graph), expected)
+      assert.deepStrictEqual(Graph.minimumCut(graph, { ...config, target: 1 }), {
+        value: 3,
+        edges: [0],
+        source: [0],
+        target: [1]
+      })
+    })
+
+    it("handles multiple paths, bottlenecks, and parallel edges", () => {
+      const graph = Graph.directed<void, number>((mutable) => {
+        for (let i = 0; i < 4; i++) Graph.addNode(mutable, undefined)
+        Graph.addEdge(mutable, 0, 1, 3)
+        Graph.addEdge(mutable, 0, 1, 2)
+        Graph.addEdge(mutable, 0, 2, 2)
+        Graph.addEdge(mutable, 1, 2, 1)
+        Graph.addEdge(mutable, 1, 3, 3)
+        Graph.addEdge(mutable, 2, 3, 3)
+      })
+      const result = Graph.maximumFlow(graph, { source: 0, target: 3, capacity: (edge) => edge })
+
+      assert.strictEqual(result.value, 6)
+      assert.deepStrictEqual(Array.from(result.flows.keys()), [0, 1, 2, 3, 4, 5])
+      assert.strictEqual((result.flows.get(0) ?? 0) + (result.flows.get(1) ?? 0), 4)
+    })
+
+    it("uses reverse residual edges to reroute flow", () => {
+      const graph = Graph.directed<void, number>((mutable) => {
+        for (let i = 0; i < 6; i++) Graph.addNode(mutable, undefined)
+        for (const [source, target] of [[0, 1], [0, 2], [1, 3], [2, 3], [3, 5], [1, 4], [4, 5]] as const) {
+          Graph.addEdge(mutable, source, target, 1)
+        }
+      })
+
+      assert.strictEqual(Graph.maximumFlow(graph, { source: 0, target: 5, capacity: (edge) => edge }).value, 2)
+    })
+
+    it("handles zero capacity, disconnected targets, self-loops, and fractions", () => {
+      const graph = Graph.directed<void, number>((mutable) => {
+        for (let i = 0; i < 4; i++) Graph.addNode(mutable, undefined)
+        Graph.addEdge(mutable, 0, 0, 100)
+        Graph.addEdge(mutable, 0, 1, 0)
+        Graph.addEdge(mutable, 0, 2, 0.75)
+        Graph.addEdge(mutable, 2, 1, 0.5)
+      })
+      const result = Graph.maximumFlow(graph, { source: 0, target: 1, capacity: (edge) => edge })
+
+      assert.strictEqual(result.value, 0.5)
+      assert.deepStrictEqual(result.flows, new Map([[0, 0], [1, 0], [2, 0.5], [3, 0.5]]))
+      assert.strictEqual(Graph.maximumFlow(graph, { source: 0, target: 3, capacity: (edge) => edge }).value, 0)
+    })
+
+    it("rejects negative, NaN, and infinite capacities, including self-loops", () => {
+      for (const capacity of [-1, NaN, Infinity, -Infinity]) {
+        const graph = Graph.directed<void, number>((mutable) => {
+          Graph.addNode(mutable, undefined)
+          Graph.addNode(mutable, undefined)
+          Graph.addEdge(mutable, 0, 0, capacity)
+        })
+        assertGraphError(
+          () => Graph.maximumFlow(graph, { source: 0, target: 1, capacity: (edge) => edge }),
+          "Edge 0 capacity must be a finite non-negative number"
+        )
+      }
+    })
+
+    it("rejects a total flow outside the finite number range", () => {
+      const graph = Graph.directed<void, number>((mutable) => {
+        Graph.addNode(mutable, undefined)
+        Graph.addNode(mutable, undefined)
+        Graph.addEdge(mutable, 0, 1, Number.MAX_VALUE)
+        Graph.addEdge(mutable, 0, 1, Number.MAX_VALUE)
+      })
+
+      assertGraphError(
+        () => Graph.maximumFlow(graph, { source: 0, target: 1, capacity: (edge) => edge }),
+        "Maximum flow exceeds the finite number range"
+      )
+    })
+
+    it("enforces capacity bounds, conservation, and max-flow/min-cut equality", () => {
+      const capacities = [16, 13, 10, 4, 12, 9, 14, 7, 20, 4]
+      const endpoints = [[0, 1], [0, 2], [1, 2], [2, 1], [1, 3], [3, 2], [2, 4], [4, 3], [3, 5], [4, 5]] as const
+      const graph = Graph.directed<void, number>((mutable) => {
+        for (let i = 0; i < 6; i++) Graph.addNode(mutable, undefined)
+        for (let i = 0; i < endpoints.length; i++) {
+          Graph.addEdge(mutable, endpoints[i][0], endpoints[i][1], capacities[i])
+        }
+      })
+      const flowConfig = { source: 0, target: 5, capacity: (edge: number) => edge }
+      const flow = Graph.maximumFlow(graph, flowConfig)
+      const cut = Graph.minimumCut(graph, flowConfig)
+      const balance = new Float64Array(6)
+
+      for (let edge = 0; edge < endpoints.length; edge++) {
+        const value = flow.flows.get(edge)!
+        assert.strictEqual(value >= 0 && value <= capacities[edge], true)
+        balance[endpoints[edge][0]] -= value
+        balance[endpoints[edge][1]] += value
+      }
+      assert.strictEqual(flow.value, 23)
+      assert.strictEqual(cut.value, flow.value)
+      assert.strictEqual(cut.edges.reduce((sum, edge) => sum + capacities[edge], 0), flow.value)
+      assert.deepStrictEqual(Array.from(balance), [-23, 0, 0, 0, 0, 23])
+      assert.deepStrictEqual([...cut.source, ...cut.target].sort((a, b) => a - b), [0, 1, 2, 3, 4, 5])
     })
   })
 

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -3562,8 +3562,8 @@ describe("Graph", () => {
         Graph.addEdge(mutable, 1, 4, undefined)
       })
       assert.deepStrictEqual(Graph.maximumBipartiteMatching(graph), [
-        { left: 0, right: 3, edge: 1 },
-        { left: 1, right: 2, edge: 2 }
+        { left: 0, right: 2, edge: 0 },
+        { left: 1, right: 4, edge: 3 }
       ])
       assert.strictEqual(Graph.maximumBipartiteMatching(graph).length, 2)
     })


### PR DESCRIPTION
## Summary

- add index-preserving `Graph.toSnapshot` conversion for immutable and mutable graphs
- add stack-safe low-link bridge, articulation-point, and biconnected-component analysis
- add deterministic Hopcroft-Karp bipartite matching
- add shared Edmonds-Karp maximum-flow and minimum-cut operations
- document public models, ordering, parallel-edge, self-loop, validation, and complexity semantics
- add focused coverage and a patch changeset

## Validation

- `pnpm lint-fix`
- `pnpm --filter effect test --run test/Graph.test.ts`
- `pnpm doctest --run packages/effect/src/Graph.ts`
- `pnpm check`
- `git diff --check`

`pnpm check` completed successfully with existing duplicate-package warnings from `tmp/bundle-base`.