### PR TITLE
Fix Graph cache and pathfinding edge cases

### DIFF
--- a/.changeset/curly-graphs-connect.md
+++ b/.changeset/curly-graphs-connect.md
@@ -2,5 +2,4 @@
 "effect": patch
 ---
 
-Add graph snapshots, low-link connectivity analysis, bipartite matching, maximum flow, and minimum cut APIs. Fix
-mutable graph cache consistency and guard weighted pathfinding against inconsistent snapshots and numeric overflow.
+Add graph snapshots, low-link connectivity analysis, bipartite matching, maximum flow, and minimum cut APIs.

--- a/.changeset/curly-graphs-connect.md
+++ b/.changeset/curly-graphs-connect.md
@@ -2,4 +2,5 @@
 "effect": patch
 ---
 
-Add graph snapshots, low-link connectivity analysis, bipartite matching, maximum flow, and minimum cut APIs.
+Add graph snapshots, low-link connectivity analysis, bipartite matching, maximum flow, and minimum cut APIs. Fix
+mutable graph cache consistency and guard weighted pathfinding against inconsistent snapshots and numeric overflow.

--- a/.changeset/tough-graphs-cache.md
+++ b/.changeset/tough-graphs-cache.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix mutable graph cache consistency and guard weighted pathfinding against inconsistent snapshots and numeric overflow.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -387,15 +387,6 @@ const getMutableImplForMutation = <N, E, T extends Kind>(
   return internal.toImpl(graph)
 }
 
-/** @internal */
-const withoutMutableCache = <N, E, T extends Kind, A>(
-  graph: MutableGraph<N, E, T>,
-  evaluate: (impl: internal.GraphImpl<N, E, T>) => A
-): A => {
-  assertMutable(graph)
-  return csr.withoutCache(graph, () => evaluate(internal.toImpl(graph)))
-}
-
 // =============================================================================
 // Constructors
 // =============================================================================
@@ -683,6 +674,9 @@ export const endMutation = <N, E, T extends Kind = "directed">(
   mutable: MutableGraph<N, E, T>
 ): Graph<N, E, T> => {
   assertMutable(mutable)
+  if (csr.isTransforming(mutable)) {
+    throw new GraphError({ message: "Cannot finalize graph during a transformation" })
+  }
   const source = internal.toImpl(mutable)
   csr.invalidate(mutable)
   const graph = internal.finalize(source)
@@ -1869,14 +1863,15 @@ export const updateNode = <N, E, T extends Kind = "directed">(
   index: NodeIndex,
   f: (data: N) => N
 ): void => {
-  withoutMutableCache(mutable, (impl) => {
+  assertMutable(mutable)
+  const impl = internal.toImpl(mutable)
+  csr.withTransformation(mutable, () => {
     if (!impl.nodes.has(index)) {
       return
     }
 
     const currentData = impl.nodes.get(index)!
     const newData = f(currentData)
-    assertMutable(mutable)
     impl.nodes.set(index, newData)
   })
 }
@@ -1907,14 +1902,15 @@ export const updateEdge = <N, E, T extends Kind = "directed">(
   edgeIndex: EdgeIndex,
   f: (data: E) => E
 ): void => {
-  withoutMutableCache(mutable, (impl) => {
+  assertMutable(mutable)
+  const impl = internal.toImpl(mutable)
+  csr.withTransformation(mutable, () => {
     if (!impl.edges.has(edgeIndex)) {
       return
     }
 
     const currentEdge = impl.edges.get(edgeIndex)!
     const newData = f(currentEdge.data)
-    assertMutable(mutable)
     impl.edges.set(edgeIndex, {
       source: currentEdge.source,
       target: currentEdge.target,
@@ -1953,11 +1949,12 @@ export const mapNodes = <N, E, T extends Kind = "directed">(
   mutable: MutableGraph<N, E, T>,
   f: (data: N) => N
 ): void => {
-  withoutMutableCache(mutable, (impl) => {
+  assertMutable(mutable)
+  const impl = internal.toImpl(mutable)
+  csr.withTransformation(mutable, () => {
     // Transform existing node data in place
     for (const [index, data] of impl.nodes) {
       const newData = f(data)
-      assertMutable(mutable)
       impl.nodes.set(index, newData)
     }
   })
@@ -1990,11 +1987,12 @@ export const mapEdges = <N, E, T extends Kind = "directed">(
   mutable: MutableGraph<N, E, T>,
   f: (data: E) => E
 ): void => {
-  withoutMutableCache(mutable, (impl) => {
+  assertMutable(mutable)
+  const impl = internal.toImpl(mutable)
+  csr.withTransformation(mutable, () => {
     // Transform existing edge data in place
     for (const [index, edgeData] of impl.edges) {
       const newData = f(edgeData.data)
-      assertMutable(mutable)
       impl.edges.set(index, {
         source: edgeData.source,
         target: edgeData.target,
@@ -2109,13 +2107,14 @@ export const filterMapNodes = <N, E, T extends Kind = "directed">(
   mutable: MutableGraph<N, E, T>,
   f: (data: N) => Option.Option<N>
 ): void => {
-  withoutMutableCache(mutable, (impl) => {
+  assertMutable(mutable)
+  const impl = internal.toImpl(mutable)
+  csr.withTransformation(mutable, () => {
     const nodesToRemove: Array<NodeIndex> = []
 
     // First pass: identify nodes to remove and transform data for nodes to keep
     for (const [index, data] of impl.nodes) {
       const result = f(data)
-      assertMutable(mutable)
       if (Option.isSome(result)) {
         // Transform node data
         impl.nodes.set(index, result.value)
@@ -2166,13 +2165,14 @@ export const filterMapEdges = <N, E, T extends Kind = "directed">(
   mutable: MutableGraph<N, E, T>,
   f: (data: E) => Option.Option<E>
 ): void => {
-  withoutMutableCache(mutable, (impl) => {
+  assertMutable(mutable)
+  const impl = internal.toImpl(mutable)
+  csr.withTransformation(mutable, () => {
     const edgesToRemove: Array<EdgeIndex> = []
 
     // First pass: identify edges to remove and transform data for edges to keep
     for (const [index, edgeData] of impl.edges) {
       const result = f(edgeData.data)
-      assertMutable(mutable)
       if (Option.isSome(result)) {
         // Transform edge data
         impl.edges.set(index, {

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -674,7 +674,7 @@ export const endMutation = <N, E, T extends Kind = "directed">(
   mutable: MutableGraph<N, E, T>
 ): Graph<N, E, T> => {
   assertMutable(mutable)
-  if (csr.isTransforming(mutable)) {
+  if (internal.isTransforming(mutable)) {
     throw new GraphError({ message: "Cannot finalize graph during a transformation" })
   }
   const source = internal.toImpl(mutable)
@@ -1863,9 +1863,8 @@ export const updateNode = <N, E, T extends Kind = "directed">(
   index: NodeIndex,
   f: (data: N) => N
 ): void => {
-  assertMutable(mutable)
-  const impl = internal.toImpl(mutable)
-  csr.withTransformation(mutable, () => {
+  const impl = getMutableImplForMutation(mutable)
+  internal.withTransformation(mutable, () => {
     if (!impl.nodes.has(index)) {
       return
     }
@@ -1902,9 +1901,8 @@ export const updateEdge = <N, E, T extends Kind = "directed">(
   edgeIndex: EdgeIndex,
   f: (data: E) => E
 ): void => {
-  assertMutable(mutable)
-  const impl = internal.toImpl(mutable)
-  csr.withTransformation(mutable, () => {
+  const impl = getMutableImplForMutation(mutable)
+  internal.withTransformation(mutable, () => {
     if (!impl.edges.has(edgeIndex)) {
       return
     }
@@ -1949,9 +1947,8 @@ export const mapNodes = <N, E, T extends Kind = "directed">(
   mutable: MutableGraph<N, E, T>,
   f: (data: N) => N
 ): void => {
-  assertMutable(mutable)
-  const impl = internal.toImpl(mutable)
-  csr.withTransformation(mutable, () => {
+  const impl = getMutableImplForMutation(mutable)
+  internal.withTransformation(mutable, () => {
     // Transform existing node data in place
     for (const [index, data] of impl.nodes) {
       const newData = f(data)
@@ -1987,9 +1984,8 @@ export const mapEdges = <N, E, T extends Kind = "directed">(
   mutable: MutableGraph<N, E, T>,
   f: (data: E) => E
 ): void => {
-  assertMutable(mutable)
-  const impl = internal.toImpl(mutable)
-  csr.withTransformation(mutable, () => {
+  const impl = getMutableImplForMutation(mutable)
+  internal.withTransformation(mutable, () => {
     // Transform existing edge data in place
     for (const [index, edgeData] of impl.edges) {
       const newData = f(edgeData.data)
@@ -2107,9 +2103,8 @@ export const filterMapNodes = <N, E, T extends Kind = "directed">(
   mutable: MutableGraph<N, E, T>,
   f: (data: N) => Option.Option<N>
 ): void => {
-  assertMutable(mutable)
-  const impl = internal.toImpl(mutable)
-  csr.withTransformation(mutable, () => {
+  const impl = getMutableImplForMutation(mutable)
+  internal.withTransformation(mutable, () => {
     const nodesToRemove: Array<NodeIndex> = []
 
     // First pass: identify nodes to remove and transform data for nodes to keep
@@ -2165,9 +2160,8 @@ export const filterMapEdges = <N, E, T extends Kind = "directed">(
   mutable: MutableGraph<N, E, T>,
   f: (data: E) => Option.Option<E>
 ): void => {
-  assertMutable(mutable)
-  const impl = internal.toImpl(mutable)
-  csr.withTransformation(mutable, () => {
+  const impl = getMutableImplForMutation(mutable)
+  internal.withTransformation(mutable, () => {
     const edgesToRemove: Array<EdgeIndex> = []
 
     // First pass: identify edges to remove and transform data for edges to keep

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -383,7 +383,9 @@ const getMutableImplForMutation = <N, E, T extends Kind>(
   graph: MutableGraph<N, E, T>
 ): internal.GraphImpl<N, E, T> => {
   assertMutable(graph)
-  csr.invalidate(graph)
+  if (!internal.isTransforming(graph)) {
+    csr.invalidate(graph)
+  }
   return internal.toImpl(graph)
 }
 

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -387,6 +387,15 @@ const getMutableImplForMutation = <N, E, T extends Kind>(
   return internal.toImpl(graph)
 }
 
+/** @internal */
+const withoutMutableCache = <N, E, T extends Kind, A>(
+  graph: MutableGraph<N, E, T>,
+  evaluate: (impl: internal.GraphImpl<N, E, T>) => A
+): A => {
+  assertMutable(graph)
+  return csr.withoutCache(graph, () => evaluate(internal.toImpl(graph)))
+}
+
 // =============================================================================
 // Constructors
 // =============================================================================
@@ -1860,14 +1869,16 @@ export const updateNode = <N, E, T extends Kind = "directed">(
   index: NodeIndex,
   f: (data: N) => N
 ): void => {
-  const impl = getMutableImplForMutation(mutable)
-  if (!impl.nodes.has(index)) {
-    return
-  }
+  withoutMutableCache(mutable, (impl) => {
+    if (!impl.nodes.has(index)) {
+      return
+    }
 
-  const currentData = impl.nodes.get(index)!
-  const newData = f(currentData)
-  impl.nodes.set(index, newData)
+    const currentData = impl.nodes.get(index)!
+    const newData = f(currentData)
+    assertMutable(mutable)
+    impl.nodes.set(index, newData)
+  })
 }
 
 /**
@@ -1896,17 +1907,19 @@ export const updateEdge = <N, E, T extends Kind = "directed">(
   edgeIndex: EdgeIndex,
   f: (data: E) => E
 ): void => {
-  const impl = getMutableImplForMutation(mutable)
-  if (!impl.edges.has(edgeIndex)) {
-    return
-  }
+  withoutMutableCache(mutable, (impl) => {
+    if (!impl.edges.has(edgeIndex)) {
+      return
+    }
 
-  const currentEdge = impl.edges.get(edgeIndex)!
-  const newData = f(currentEdge.data)
-  impl.edges.set(edgeIndex, {
-    source: currentEdge.source,
-    target: currentEdge.target,
-    data: newData
+    const currentEdge = impl.edges.get(edgeIndex)!
+    const newData = f(currentEdge.data)
+    assertMutable(mutable)
+    impl.edges.set(edgeIndex, {
+      source: currentEdge.source,
+      target: currentEdge.target,
+      data: newData
+    })
   })
 }
 
@@ -1940,13 +1953,14 @@ export const mapNodes = <N, E, T extends Kind = "directed">(
   mutable: MutableGraph<N, E, T>,
   f: (data: N) => N
 ): void => {
-  const impl = getMutableImplForMutation(mutable)
-
-  // Transform existing node data in place
-  for (const [index, data] of impl.nodes) {
-    const newData = f(data)
-    impl.nodes.set(index, newData)
-  }
+  withoutMutableCache(mutable, (impl) => {
+    // Transform existing node data in place
+    for (const [index, data] of impl.nodes) {
+      const newData = f(data)
+      assertMutable(mutable)
+      impl.nodes.set(index, newData)
+    }
+  })
 }
 
 /**
@@ -1976,17 +1990,18 @@ export const mapEdges = <N, E, T extends Kind = "directed">(
   mutable: MutableGraph<N, E, T>,
   f: (data: E) => E
 ): void => {
-  const impl = getMutableImplForMutation(mutable)
-
-  // Transform existing edge data in place
-  for (const [index, edgeData] of impl.edges) {
-    const newData = f(edgeData.data)
-    impl.edges.set(index, {
-      source: edgeData.source,
-      target: edgeData.target,
-      data: newData
-    })
-  }
+  withoutMutableCache(mutable, (impl) => {
+    // Transform existing edge data in place
+    for (const [index, edgeData] of impl.edges) {
+      const newData = f(edgeData.data)
+      assertMutable(mutable)
+      impl.edges.set(index, {
+        source: edgeData.source,
+        target: edgeData.target,
+        data: newData
+      })
+    }
+  })
 }
 
 /**
@@ -2094,25 +2109,27 @@ export const filterMapNodes = <N, E, T extends Kind = "directed">(
   mutable: MutableGraph<N, E, T>,
   f: (data: N) => Option.Option<N>
 ): void => {
-  const impl = getMutableImplForMutation(mutable)
-  const nodesToRemove: Array<NodeIndex> = []
+  withoutMutableCache(mutable, (impl) => {
+    const nodesToRemove: Array<NodeIndex> = []
 
-  // First pass: identify nodes to remove and transform data for nodes to keep
-  for (const [index, data] of impl.nodes) {
-    const result = f(data)
-    if (Option.isSome(result)) {
-      // Transform node data
-      impl.nodes.set(index, result.value)
-    } else {
-      // Mark for removal
-      nodesToRemove.push(index)
+    // First pass: identify nodes to remove and transform data for nodes to keep
+    for (const [index, data] of impl.nodes) {
+      const result = f(data)
+      assertMutable(mutable)
+      if (Option.isSome(result)) {
+        // Transform node data
+        impl.nodes.set(index, result.value)
+      } else {
+        // Mark for removal
+        nodesToRemove.push(index)
+      }
     }
-  }
 
-  // Second pass: remove filtered out nodes and their edges
-  for (const nodeIndex of nodesToRemove) {
-    removeNode(mutable, nodeIndex)
-  }
+    // Second pass: remove filtered out nodes and their edges
+    for (const nodeIndex of nodesToRemove) {
+      removeNode(mutable, nodeIndex)
+    }
+  })
 }
 
 /**
@@ -2149,29 +2166,31 @@ export const filterMapEdges = <N, E, T extends Kind = "directed">(
   mutable: MutableGraph<N, E, T>,
   f: (data: E) => Option.Option<E>
 ): void => {
-  const impl = getMutableImplForMutation(mutable)
-  const edgesToRemove: Array<EdgeIndex> = []
+  withoutMutableCache(mutable, (impl) => {
+    const edgesToRemove: Array<EdgeIndex> = []
 
-  // First pass: identify edges to remove and transform data for edges to keep
-  for (const [index, edgeData] of impl.edges) {
-    const result = f(edgeData.data)
-    if (Option.isSome(result)) {
-      // Transform edge data
-      impl.edges.set(index, {
-        source: edgeData.source,
-        target: edgeData.target,
-        data: result.value
-      })
-    } else {
-      // Mark for removal
-      edgesToRemove.push(index)
+    // First pass: identify edges to remove and transform data for edges to keep
+    for (const [index, edgeData] of impl.edges) {
+      const result = f(edgeData.data)
+      assertMutable(mutable)
+      if (Option.isSome(result)) {
+        // Transform edge data
+        impl.edges.set(index, {
+          source: edgeData.source,
+          target: edgeData.target,
+          data: result.value
+        })
+      } else {
+        // Mark for removal
+        edgesToRemove.push(index)
+      }
     }
-  }
 
-  // Second pass: remove filtered out edges
-  for (const edgeIndex of edgesToRemove) {
-    removeEdge(mutable, edgeIndex)
-  }
+    // Second pass: remove filtered out edges
+    for (const edgeIndex of edgesToRemove) {
+      removeEdge(mutable, edgeIndex)
+    }
+  })
 }
 
 /**
@@ -5990,6 +6009,9 @@ export const dijkstra: {
   const cache = csr.get(graph)
   const cachedEdges = csr.getEdges(cache)
   const cachedEdgeIds = csr.getEdgeIds(cache)
+  const outgoing = csr.getOutgoingWithEdges(cache)
+  const source = csr.getNodeIndex(cache, config.source)!
+  const target = csr.getNodeIndex(cache, config.target)!
   const edgeWeights = new Float64Array(cachedEdges.length)
   for (let i = 0; i < cachedEdges.length; i++) {
     const weight = config.cost(cachedEdges[i].data)
@@ -6009,9 +6031,6 @@ export const dijkstra: {
     })
   }
 
-  const outgoing = csr.getOutgoingWithEdges(cache)
-  const source = csr.getNodeIndex(cache, config.source)!
-  const target = csr.getNodeIndex(cache, config.target)!
   const distances = new Float64Array(cache.nodeIds.length)
   distances.fill(Infinity)
   distances[source] = 0
@@ -6365,6 +6384,11 @@ export const astar: {
   const cache = csr.get(graph)
   const cachedEdges = csr.getEdges(cache)
   const cachedEdgeIds = csr.getEdgeIds(cache)
+  const outgoing = csr.getOutgoingWithEdges(cache)
+  const source = csr.getNodeIndex(cache, config.source)!
+  const target = csr.getNodeIndex(cache, config.target)!
+  const sourceNodeData = cache.nodeData[source] as N
+  const targetNodeData = cache.nodeData[target] as N
   const edgeWeights = new Float64Array(cachedEdges.length)
   for (let i = 0; i < cachedEdges.length; i++) {
     const weight = config.cost(cachedEdges[i].data)
@@ -6376,7 +6400,7 @@ export const astar: {
 
   // Early return if source equals target
   if (config.source === config.target) {
-    if (!Number.isFinite(config.heuristic(impl.nodes.get(config.source)!, impl.nodes.get(config.target)!))) {
+    if (!Number.isFinite(config.heuristic(sourceNodeData, targetNodeData))) {
       throw new GraphError({ message: "A* algorithm requires finite heuristic values" })
     }
     return Option.some({
@@ -6387,8 +6411,6 @@ export const astar: {
     })
   }
 
-  // Get target node data for heuristic calculations
-  const targetNodeData = impl.nodes.get(config.target)!
   const getHeuristic = (nodeData: N): number => {
     const value = config.heuristic(nodeData, targetNodeData)
     if (!Number.isFinite(value)) {
@@ -6397,9 +6419,6 @@ export const astar: {
     return value
   }
 
-  const outgoing = csr.getOutgoingWithEdges(cache)
-  const source = csr.getNodeIndex(cache, config.source)!
-  const target = csr.getNodeIndex(cache, config.target)!
   const scores = new Float64Array(cache.nodeIds.length)
   scores.fill(Infinity)
   scores[source] = 0
@@ -6411,7 +6430,7 @@ export const astar: {
   const visited = new Uint8Array(cache.nodeIds.length)
   const openSet = denseMinHeapMake(cache.nodeIds.length)
   let sequence = 0
-  denseMinHeapPush(openSet, source, getHeuristic(cache.nodeData[source] as N), sequence++)
+  denseMinHeapPush(openSet, source, getHeuristic(sourceNodeData), sequence++)
 
   while (openSet.size > 0) {
     denseMinHeapPop(openSet)
@@ -6500,7 +6519,8 @@ export interface BellmanFordConfig<E> {
  * Negative edge weights are allowed, and `Infinity` behaves like an impassable
  * edge. Returns `Option.none()` when the target is unreachable. Throws a
  * `GraphError` when a reachable negative cycle can affect the target, either
- * endpoint is missing, or an edge weight is `NaN` or `-Infinity`.
+ * endpoint is missing, an edge weight is `NaN` or `-Infinity`, or finite
+ * distance arithmetic exceeds the finite number range.
  *
  * **Example** (Finding shortest paths with Bellman-Ford)
  *
@@ -6553,6 +6573,7 @@ export const bellmanFord: {
   const edges = csr.getEdges(cache)
   const edgeIds = csr.getEdgeIds(cache)
   const edgeCache = csr.getEdgeEndpoints(cache)
+  const outgoing = csr.getOutgoing(cache)
   const source = csr.getNodeIndex(cache, config.source)!
   const target = csr.getNodeIndex(cache, config.target)!
   const weights = new Float64Array(edges.length)
@@ -6562,6 +6583,17 @@ export const bellmanFord: {
       throw new GraphError({ message: "Bellman-Ford algorithm does not support NaN or -Infinity edge weights" })
     }
     weights[i] = weight
+  }
+
+  const addWeight = (distance: number, weight: number): number => {
+    if (distance === Infinity || weight === Infinity) {
+      return Infinity
+    }
+    const candidate = distance + weight
+    if (!Number.isFinite(candidate)) {
+      throw new GraphError({ message: "Bellman-Ford distance calculation exceeded the finite number range" })
+    }
+    return candidate
   }
 
   const distances = new Float64Array(cache.nodeIds.length)
@@ -6579,16 +6611,18 @@ export const bellmanFord: {
       const edgeTarget = edgeCache.targets[edge]
       const weight = weights[edge]
       const sourceDistance = distances[edgeSource]
-      if (sourceDistance !== Infinity && sourceDistance + weight < distances[edgeTarget]) {
-        distances[edgeTarget] = sourceDistance + weight
+      const candidate = addWeight(sourceDistance, weight)
+      if (candidate < distances[edgeTarget]) {
+        distances[edgeTarget] = candidate
         previousNode[edgeTarget] = edgeSource
         previousEdge[edgeTarget] = edge
         hasUpdate = true
       }
       if (graph.type === "undirected" && edgeSource !== edgeTarget) {
         const targetDistance = distances[edgeTarget]
-        if (targetDistance !== Infinity && targetDistance + weight < distances[edgeSource]) {
-          distances[edgeSource] = targetDistance + weight
+        const reverseCandidate = addWeight(targetDistance, weight)
+        if (reverseCandidate < distances[edgeSource]) {
+          distances[edgeSource] = reverseCandidate
           previousNode[edgeSource] = edgeTarget
           previousEdge[edgeSource] = edge
           hasUpdate = true
@@ -6615,20 +6649,18 @@ export const bellmanFord: {
     const edgeSource = edgeCache.sources[edge]
     const edgeTarget = edgeCache.targets[edge]
     const weight = weights[edge]
-    if (distances[edgeSource] !== Infinity && distances[edgeSource] + weight < distances[edgeTarget]) {
+    if (addWeight(distances[edgeSource], weight) < distances[edgeTarget]) {
       markAffected(edgeTarget)
     }
     if (
       graph.type === "undirected" &&
       edgeSource !== edgeTarget &&
-      distances[edgeTarget] !== Infinity &&
-      distances[edgeTarget] + weight < distances[edgeSource]
+      addWeight(distances[edgeTarget], weight) < distances[edgeSource]
     ) {
       markAffected(edgeSource)
     }
   }
   if (tail > 0) {
-    const outgoing = csr.getOutgoing(cache)
     while (head < tail) {
       const node = queue[head++]
       for (let i = outgoing.rowOffsets[node]; i < outgoing.rowOffsets[node + 1]; i++) {
@@ -6647,7 +6679,11 @@ export const bellmanFord: {
   const pathEdges: Array<EdgeIndex> = []
   const costs: Array<E> = []
   let current = target
+  let remaining = cache.nodeIds.length
   while (current !== -1) {
+    if (remaining-- === 0) {
+      throw new GraphError({ message: `Negative cycle affects path to node ${config.target}` })
+    }
     path.push(cache.nodeIds[current])
     const edge = previousEdge[current]
     if (edge !== -1) {

--- a/packages/effect/src/internal/graph.ts
+++ b/packages/effect/src/internal/graph.ts
@@ -31,6 +31,32 @@ export const toImpl = <N, E, T extends Graph.Kind = "directed">(
   graph: Graph.Graph<N, E, T> | Graph.MutableGraph<N, E, T>
 ): GraphImpl<N, E, T> => graph as unknown as GraphImpl<N, E, T>
 
+const transformationDepth = new WeakMap<GraphImpl<any, any, any>, number>()
+
+/** @internal */
+export const isTransforming = <N, E, T extends Graph.Kind>(
+  graph: Graph.Graph<N, E, T> | Graph.MutableGraph<N, E, T>
+): boolean => transformationDepth.has(toImpl(graph))
+
+/** @internal */
+export const withTransformation = <N, E, T extends Graph.Kind, A>(
+  graph: Graph.MutableGraph<N, E, T>,
+  evaluate: () => A
+): A => {
+  const impl = toImpl(graph)
+  const depth = transformationDepth.get(impl) ?? 0
+  transformationDepth.set(impl, depth + 1)
+  try {
+    return evaluate()
+  } finally {
+    if (depth === 0) {
+      transformationDepth.delete(impl)
+    } else {
+      transformationDepth.set(impl, depth)
+    }
+  }
+}
+
 const edgeEquals = (type: Graph.Kind, self: Graph.Edge<any>, that: Graph.Edge<any>): boolean =>
   (type === "directed"
     ? self.source === that.source && self.target === that.target

--- a/packages/effect/src/internal/graph.ts
+++ b/packages/effect/src/internal/graph.ts
@@ -16,6 +16,7 @@ export interface GraphImpl<in out N, in out E, T extends Graph.Kind = "directed"
   readonly [TypeId]: unknown
   type: T
   mutable: boolean
+  transformationDepth: number
   nodes: Map<Graph.NodeIndex, N>
   edges: Map<Graph.EdgeIndex, Graph.Edge<E>>
   adjacency: Map<Graph.NodeIndex, Array<Graph.EdgeIndex>>
@@ -31,12 +32,10 @@ export const toImpl = <N, E, T extends Graph.Kind = "directed">(
   graph: Graph.Graph<N, E, T> | Graph.MutableGraph<N, E, T>
 ): GraphImpl<N, E, T> => graph as unknown as GraphImpl<N, E, T>
 
-const transformationDepth = new WeakMap<GraphImpl<any, any, any>, number>()
-
 /** @internal */
 export const isTransforming = <N, E, T extends Graph.Kind>(
   graph: Graph.Graph<N, E, T> | Graph.MutableGraph<N, E, T>
-): boolean => transformationDepth.has(toImpl(graph))
+): boolean => toImpl(graph).transformationDepth > 0
 
 /** @internal */
 export const withTransformation = <N, E, T extends Graph.Kind, A>(
@@ -44,16 +43,11 @@ export const withTransformation = <N, E, T extends Graph.Kind, A>(
   evaluate: () => A
 ): A => {
   const impl = toImpl(graph)
-  const depth = transformationDepth.get(impl) ?? 0
-  transformationDepth.set(impl, depth + 1)
+  impl.transformationDepth++
   try {
     return evaluate()
   } finally {
-    if (depth === 0) {
-      transformationDepth.delete(impl)
-    } else {
-      transformationDepth.set(impl, depth)
-    }
+    impl.transformationDepth--
   }
 }
 
@@ -139,6 +133,7 @@ export const make = <N, E, T extends Graph.Kind>(type: T, mutable: boolean): Gra
   const graph: GraphImpl<N, E, T> = Object.create(ProtoGraph)
   graph.type = type
   graph.mutable = mutable
+  graph.transformationDepth = 0
   graph.nodes = new Map()
   graph.edges = new Map()
   graph.adjacency = new Map()
@@ -180,6 +175,7 @@ export const finalize = <N, E, T extends Graph.Kind>(source: GraphImpl<N, E, T>)
   const graph: GraphImpl<N, E, T> = Object.create(ProtoGraph)
   graph.type = source.type
   graph.mutable = false
+  graph.transformationDepth = 0
   graph.nodes = source.nodes
   graph.edges = source.edges
   graph.adjacency = source.adjacency

--- a/packages/effect/src/internal/graph.ts
+++ b/packages/effect/src/internal/graph.ts
@@ -16,7 +16,7 @@ export interface GraphImpl<in out N, in out E, T extends Graph.Kind = "directed"
   readonly [TypeId]: unknown
   type: T
   mutable: boolean
-  transformationDepth: number
+  transformations: number
   nodes: Map<Graph.NodeIndex, N>
   edges: Map<Graph.EdgeIndex, Graph.Edge<E>>
   adjacency: Map<Graph.NodeIndex, Array<Graph.EdgeIndex>>
@@ -35,7 +35,7 @@ export const toImpl = <N, E, T extends Graph.Kind = "directed">(
 /** @internal */
 export const isTransforming = <N, E, T extends Graph.Kind>(
   graph: Graph.Graph<N, E, T> | Graph.MutableGraph<N, E, T>
-): boolean => toImpl(graph).transformationDepth > 0
+): boolean => toImpl(graph).transformations > 0
 
 /** @internal */
 export const withTransformation = <N, E, T extends Graph.Kind, A>(
@@ -43,11 +43,11 @@ export const withTransformation = <N, E, T extends Graph.Kind, A>(
   evaluate: () => A
 ): A => {
   const impl = toImpl(graph)
-  impl.transformationDepth++
+  impl.transformations++
   try {
     return evaluate()
   } finally {
-    impl.transformationDepth--
+    impl.transformations--
   }
 }
 
@@ -133,7 +133,7 @@ export const make = <N, E, T extends Graph.Kind>(type: T, mutable: boolean): Gra
   const graph: GraphImpl<N, E, T> = Object.create(ProtoGraph)
   graph.type = type
   graph.mutable = mutable
-  graph.transformationDepth = 0
+  graph.transformations = 0
   graph.nodes = new Map()
   graph.edges = new Map()
   graph.adjacency = new Map()
@@ -175,7 +175,7 @@ export const finalize = <N, E, T extends Graph.Kind>(source: GraphImpl<N, E, T>)
   const graph: GraphImpl<N, E, T> = Object.create(ProtoGraph)
   graph.type = source.type
   graph.mutable = false
-  graph.transformationDepth = 0
+  graph.transformations = 0
   graph.nodes = source.nodes
   graph.edges = source.edges
   graph.adjacency = source.adjacency

--- a/packages/effect/src/internal/graphCsr.ts
+++ b/packages/effect/src/internal/graphCsr.ts
@@ -1,5 +1,5 @@
 import type * as Graph from "../Graph.ts"
-import { type GraphImpl, toImpl } from "./graph.ts"
+import { type GraphImpl, isTransforming, toImpl } from "./graph.ts"
 
 /** @internal */
 export interface Adjacency {
@@ -52,7 +52,6 @@ export interface Csr {
 }
 
 const cache = new WeakMap<GraphImpl<any, any, any>, Csr>()
-const transformationDepth = new WeakMap<GraphImpl<any, any, any>, number>()
 
 /** @internal */
 export const getNodeIndex = (csr: Csr, nodeId: Graph.NodeIndex): number | undefined =>
@@ -224,36 +223,11 @@ export const invalidate = <N, E, T extends Graph.Kind>(
 }
 
 /** @internal */
-export const isTransforming = <N, E, T extends Graph.Kind>(
-  graph: Graph.Graph<N, E, T> | Graph.MutableGraph<N, E, T>
-): boolean => transformationDepth.has(toImpl(graph))
-
-/** @internal */
-export const withTransformation = <N, E, T extends Graph.Kind, A>(
-  graph: Graph.MutableGraph<N, E, T>,
-  evaluate: () => A
-): A => {
-  const impl = toImpl(graph)
-  const depth = transformationDepth.get(impl) ?? 0
-  cache.delete(impl)
-  transformationDepth.set(impl, depth + 1)
-  try {
-    return evaluate()
-  } finally {
-    if (depth === 0) {
-      transformationDepth.delete(impl)
-    } else {
-      transformationDepth.set(impl, depth)
-    }
-  }
-}
-
-/** @internal */
 export const get = <N, E, T extends Graph.Kind>(
   graph: Graph.Graph<N, E, T> | Graph.MutableGraph<N, E, T>
 ): Csr => {
   const impl = toImpl(graph)
-  const cacheEnabled = !transformationDepth.has(impl)
+  const cacheEnabled = !isTransforming(graph)
   if (cacheEnabled) {
     const cached = cache.get(impl)
     if (cached !== undefined) {

--- a/packages/effect/src/internal/graphCsr.ts
+++ b/packages/effect/src/internal/graphCsr.ts
@@ -52,7 +52,7 @@ export interface Csr {
 }
 
 const cache = new WeakMap<GraphImpl<any, any, any>, Csr>()
-const cacheSuspensions = new WeakMap<GraphImpl<any, any, any>, number>()
+const transformationDepth = new WeakMap<GraphImpl<any, any, any>, number>()
 
 /** @internal */
 export const getNodeIndex = (csr: Csr, nodeId: Graph.NodeIndex): number | undefined =>
@@ -224,21 +224,26 @@ export const invalidate = <N, E, T extends Graph.Kind>(
 }
 
 /** @internal */
-export const withoutCache = <N, E, T extends Graph.Kind, A>(
+export const isTransforming = <N, E, T extends Graph.Kind>(
+  graph: Graph.Graph<N, E, T> | Graph.MutableGraph<N, E, T>
+): boolean => transformationDepth.has(toImpl(graph))
+
+/** @internal */
+export const withTransformation = <N, E, T extends Graph.Kind, A>(
   graph: Graph.MutableGraph<N, E, T>,
   evaluate: () => A
 ): A => {
   const impl = toImpl(graph)
-  const depth = cacheSuspensions.get(impl) ?? 0
+  const depth = transformationDepth.get(impl) ?? 0
   cache.delete(impl)
-  cacheSuspensions.set(impl, depth + 1)
+  transformationDepth.set(impl, depth + 1)
   try {
     return evaluate()
   } finally {
     if (depth === 0) {
-      cacheSuspensions.delete(impl)
+      transformationDepth.delete(impl)
     } else {
-      cacheSuspensions.set(impl, depth)
+      transformationDepth.set(impl, depth)
     }
   }
 }
@@ -248,7 +253,7 @@ export const get = <N, E, T extends Graph.Kind>(
   graph: Graph.Graph<N, E, T> | Graph.MutableGraph<N, E, T>
 ): Csr => {
   const impl = toImpl(graph)
-  const cacheEnabled = !cacheSuspensions.has(impl)
+  const cacheEnabled = !transformationDepth.has(impl)
   if (cacheEnabled) {
     const cached = cache.get(impl)
     if (cached !== undefined) {

--- a/packages/effect/src/internal/graphCsr.ts
+++ b/packages/effect/src/internal/graphCsr.ts
@@ -52,6 +52,7 @@ export interface Csr {
 }
 
 const cache = new WeakMap<GraphImpl<any, any, any>, Csr>()
+const cacheSuspensions = new WeakMap<GraphImpl<any, any, any>, number>()
 
 /** @internal */
 export const getNodeIndex = (csr: Csr, nodeId: Graph.NodeIndex): number | undefined =>
@@ -223,13 +224,36 @@ export const invalidate = <N, E, T extends Graph.Kind>(
 }
 
 /** @internal */
+export const withoutCache = <N, E, T extends Graph.Kind, A>(
+  graph: Graph.MutableGraph<N, E, T>,
+  evaluate: () => A
+): A => {
+  const impl = toImpl(graph)
+  const depth = cacheSuspensions.get(impl) ?? 0
+  cache.delete(impl)
+  cacheSuspensions.set(impl, depth + 1)
+  try {
+    return evaluate()
+  } finally {
+    if (depth === 0) {
+      cacheSuspensions.delete(impl)
+    } else {
+      cacheSuspensions.set(impl, depth)
+    }
+  }
+}
+
+/** @internal */
 export const get = <N, E, T extends Graph.Kind>(
   graph: Graph.Graph<N, E, T> | Graph.MutableGraph<N, E, T>
 ): Csr => {
   const impl = toImpl(graph)
-  const cached = cache.get(impl)
-  if (cached !== undefined) {
-    return cached
+  const cacheEnabled = !cacheSuspensions.has(impl)
+  if (cacheEnabled) {
+    const cached = cache.get(impl)
+    if (cached !== undefined) {
+      return cached
+    }
   }
 
   // Node ids and data are captured together so an iterator never consults mutable maps after it starts.
@@ -268,6 +292,8 @@ export const get = <N, E, T extends Graph.Kind>(
     indexByEdgeId: undefined
   }
 
-  cache.set(impl, result)
+  if (cacheEnabled) {
+    cache.set(impl, result)
+  }
   return result
 }

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -1802,7 +1802,7 @@ describe("Graph", () => {
   })
 
   describe("callback-driven transform caching", () => {
-    it("should reject writes after a transform callback finalizes the graph", () => {
+    it("should reject finalization from a transform callback", () => {
       const mutable = Graph.beginMutation(Graph.directed<string, never>((graph) => {
         Graph.addNode(graph, "old")
       }))
@@ -1815,10 +1815,10 @@ describe("Graph", () => {
             Array.from(Graph.bfs(finalized, { start: [0] }))
             return "new"
           }),
-        "Graph is not mutable"
+        "Cannot finalize graph during a transformation"
       )
-      assertSome(Graph.getNode(finalized!, 0), "old")
-      assert.deepStrictEqual(Array.from(Graph.values(Graph.bfs(finalized!, { start: [0] }))), ["old"])
+      assert.strictEqual(finalized, undefined)
+      assertSome(Graph.getNode(mutable, 0), "old")
     })
 
     it("should not retain node data cached by updateNode callbacks", () => {

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -26,6 +26,16 @@ const makeSingleEdgeGraph = (weight: number) =>
     Graph.addEdge(mutable, source, target, weight)
   })
 
+const makeMutableWeightedPath = () =>
+  Graph.beginMutation(Graph.directed<string, number>((mutable) => {
+    Graph.addNode(mutable, "source")
+    Graph.addNode(mutable, "middle")
+    Graph.addNode(mutable, "target")
+    Graph.addEdge(mutable, 0, 1, 1)
+    Graph.addEdge(mutable, 1, 2, 1)
+    Graph.addEdge(mutable, 0, 2, 3)
+  }))
+
 const unsupportedEdgeWeights = [NaN, -Infinity] as const
 
 const assertGraphError = (thunk: () => void, message: string) => {
@@ -1788,6 +1798,136 @@ describe("Graph", () => {
       // After transformation
       const afterData = Graph.getEdge(graph, edgeAB!)
       expect(assertSomeEdge(afterData).data).toBe(50)
+    })
+  })
+
+  describe("callback-driven transform caching", () => {
+    it("should reject writes after a transform callback finalizes the graph", () => {
+      const mutable = Graph.beginMutation(Graph.directed<string, never>((graph) => {
+        Graph.addNode(graph, "old")
+      }))
+      let finalized: Graph.DirectedGraph<string, never> | undefined
+
+      assertGraphError(
+        () =>
+          Graph.updateNode(mutable, 0, () => {
+            finalized = Graph.endMutation(mutable)
+            Array.from(Graph.bfs(finalized, { start: [0] }))
+            return "new"
+          }),
+        "Graph is not mutable"
+      )
+      assertSome(Graph.getNode(finalized!, 0), "old")
+      assert.deepStrictEqual(Array.from(Graph.values(Graph.bfs(finalized!, { start: [0] }))), ["old"])
+    })
+
+    it("should not retain node data cached by updateNode callbacks", () => {
+      const mutable = Graph.beginMutation(Graph.directed<string, never>((graph) => {
+        Graph.addNode(graph, "old")
+      }))
+
+      Graph.updateNode(mutable, 0, () => {
+        assert.deepStrictEqual(Array.from(Graph.values(Graph.bfs(mutable, { start: [0] }))), ["old"])
+        return "new"
+      })
+
+      assert.deepStrictEqual(Array.from(Graph.values(Graph.bfs(mutable, { start: [0] }))), ["new"])
+    })
+
+    it("should not retain edge data cached by updateEdge callbacks", () => {
+      const mutable = Graph.beginMutation(Graph.directed<string, number>((graph) => {
+        Graph.addNode(graph, "source")
+        Graph.addNode(graph, "target")
+        Graph.addEdge(graph, 0, 1, 1)
+      }))
+
+      Graph.updateEdge(mutable, 0, () => {
+        assert.deepStrictEqual(Array.from(Graph.simplePaths(mutable, { source: 0, target: 1 }))[0].costs, [1])
+        return 2
+      })
+
+      assert.deepStrictEqual(Array.from(Graph.simplePaths(mutable, { source: 0, target: 1 }))[0].costs, [2])
+    })
+
+    it("should expose earlier node writes to later bulk transform callbacks", () => {
+      const run = (transform: (mutable: Graph.MutableDirectedGraph<string, never>) => void) => {
+        const mutable = Graph.beginMutation(Graph.directed<string, never>((graph) => {
+          Graph.addNode(graph, "a")
+          Graph.addNode(graph, "b")
+        }))
+        transform(mutable)
+        return Array.from(Graph.values(Graph.bfs(mutable, { start: [0, 1] })))
+      }
+
+      assert.deepStrictEqual(
+        run((mutable) => {
+          const seen: Array<Array<string>> = []
+          Graph.mapNodes(mutable, (data) => {
+            seen.push(Array.from(Graph.values(Graph.bfs(mutable, { start: [0, 1] }))))
+            return data.toUpperCase()
+          })
+          assert.deepStrictEqual(seen, [["a", "b"], ["A", "b"]])
+        }),
+        ["A", "B"]
+      )
+
+      assert.deepStrictEqual(
+        run((mutable) => {
+          const seen: Array<Array<string>> = []
+          Graph.filterMapNodes(mutable, (data) => {
+            seen.push(Array.from(Graph.values(Graph.bfs(mutable, { start: [0, 1] }))))
+            return Option.some(data.toUpperCase())
+          })
+          assert.deepStrictEqual(seen, [["a", "b"], ["A", "b"]])
+        }),
+        ["A", "B"]
+      )
+    })
+
+    it("should expose earlier edge writes to later bulk transform callbacks", () => {
+      const run = (transform: (mutable: Graph.MutableDirectedGraph<string, number>) => void) => {
+        const mutable = Graph.beginMutation(Graph.directed<string, number>((graph) => {
+          Graph.addNode(graph, "source")
+          Graph.addNode(graph, "middle")
+          Graph.addNode(graph, "target")
+          Graph.addEdge(graph, 0, 1, 1)
+          Graph.addEdge(graph, 1, 2, 2)
+        }))
+        transform(mutable)
+        return Option.getOrThrow(Graph.dijkstra(mutable, { source: 0, target: 2, cost: (edge) => edge })).distance
+      }
+      const assertTransform = (
+        transform: (
+          mutable: Graph.MutableDirectedGraph<string, number>,
+          inspect: () => number
+        ) => void
+      ) => {
+        const seen: Array<number> = []
+        const distance = run((mutable) =>
+          transform(mutable, () => {
+            const current = Option.getOrThrow(
+              Graph.dijkstra(mutable, { source: 0, target: 2, cost: (edge) => edge })
+            ).distance
+            seen.push(current)
+            return current
+          })
+        )
+        assert.deepStrictEqual(seen, [3, 4])
+        assert.strictEqual(distance, 6)
+      }
+
+      assertTransform((mutable, inspect) =>
+        Graph.mapEdges(mutable, (data) => {
+          inspect()
+          return data * 2
+        })
+      )
+      assertTransform((mutable, inspect) =>
+        Graph.filterMapEdges(mutable, (data) => {
+          inspect()
+          return Option.some(data * 2)
+        })
+      )
     })
   })
 
@@ -4437,6 +4577,25 @@ describe("Graph", () => {
       assert.deepStrictEqual(Graph.dijkstra(Graph.beginMutation(graph), config), expected)
     })
 
+    it("should snapshot mutable adjacency before evaluating costs", () => {
+      const mutable = makeMutableWeightedPath()
+      let mutated = false
+      const result = Graph.dijkstra(mutable, {
+        source: 0,
+        target: 2,
+        cost: (edge) => {
+          if (!mutated) {
+            mutated = true
+            Graph.removeEdge(mutable, 1)
+          }
+          return edge
+        }
+      })
+
+      assertSome(result, { path: [0, 1, 2], edges: [0, 1], distance: 2, costs: [1, 1] })
+      assert.strictEqual(Graph.edgeCount(mutable), 2)
+    })
+
     it("should return None for unreachable nodes", () => {
       let nodeA: Graph.NodeIndex
       let nodeB: Graph.NodeIndex
@@ -4702,6 +4861,26 @@ describe("Graph", () => {
       assert.deepStrictEqual(Graph.astar(Graph.beginMutation(graph), config), expected)
     })
 
+    it("should snapshot mutable adjacency before evaluating costs", () => {
+      const mutable = makeMutableWeightedPath()
+      let mutated = false
+      const result = Graph.astar(mutable, {
+        source: 0,
+        target: 2,
+        cost: (edge) => {
+          if (!mutated) {
+            mutated = true
+            Graph.removeEdge(mutable, 1)
+          }
+          return edge
+        },
+        heuristic: () => 0
+      })
+
+      assertSome(result, { path: [0, 1, 2], edges: [0, 1], distance: 2, costs: [1, 1] })
+      assert.strictEqual(Graph.edgeCount(mutable), 2)
+    })
+
     it("should return None for unreachable nodes", () => {
       const graph = Graph.directed<{ x: number; y: number }, number>((mutable) => {
         const a = Graph.addNode(mutable, { x: 0, y: 0 })
@@ -4962,6 +5141,30 @@ describe("Graph", () => {
       })
 
       assertNone(result)
+    })
+
+    it("should reject finite distance arithmetic outside the number range", () => {
+      const underflow = Graph.directed<string, number>((mutable) => {
+        Graph.addNode(mutable, "A")
+        Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, 0, 1, -Number.MAX_VALUE)
+        Graph.addEdge(mutable, 1, 0, -Number.MAX_VALUE)
+      })
+      const overflow = Graph.directed<string, number>((mutable) => {
+        Graph.addNode(mutable, "A")
+        Graph.addNode(mutable, "B")
+        Graph.addNode(mutable, "C")
+        Graph.addEdge(mutable, 0, 1, Number.MAX_VALUE)
+        Graph.addEdge(mutable, 1, 2, Number.MAX_VALUE)
+      })
+      const error = "Bellman-Ford distance calculation exceeded the finite number range"
+
+      for (const graph of [underflow, Graph.beginMutation(underflow)]) {
+        assertGraphError(() => Graph.bellmanFord(graph, { source: 0, target: 0, cost: (edge) => edge }), error)
+      }
+      for (const graph of [overflow, Graph.beginMutation(overflow)]) {
+        assertGraphError(() => Graph.bellmanFord(graph, { source: 0, target: 2, cost: (edge) => edge }), error)
+      }
     })
 
     it("should detect a directed negative self-loop when source equals target", () => {


### PR DESCRIPTION
## Summary

- track nested callback-driven graph transformations as graph lifecycle state and reject finalization while one is active
- invalidate CSR once at the outer transformation boundary, then build fresh uncached projections for reentrant reads without redundant nested invalidation
- materialize consistent graph snapshots before Dijkstra, A*, and Bellman-Ford invoke user cost callbacks
- reject Bellman-Ford distance overflow and bound predecessor reconstruction to prevent hangs

## Validation

- `pnpm lint-fix`
- `pnpm --filter effect test --run test/Graph.test.ts`
- `pnpm check` (passes with existing duplicate-package warnings from `tmp/bundle-base`)
