### PR TITLE
Guard graph transformations and add bulk removals

### DIFF
--- a/.changeset/fuzzy-graphs-transform.md
+++ b/.changeset/fuzzy-graphs-transform.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Disallow graph mutations from transformation callbacks to preserve graph invariants.
+Add bulk node and edge removal operations, and disallow graph mutations from transformation callbacks to preserve graph invariants.

--- a/.changeset/fuzzy-graphs-transform.md
+++ b/.changeset/fuzzy-graphs-transform.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Disallow graph mutations from transformation callbacks to preserve graph invariants.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -383,9 +383,10 @@ const getMutableImplForMutation = <N, E, T extends Kind>(
   graph: MutableGraph<N, E, T>
 ): internal.GraphImpl<N, E, T> => {
   assertMutable(graph)
-  if (!internal.isTransforming(graph)) {
-    csr.invalidate(graph)
+  if (internal.isTransforming(graph)) {
+    throw new GraphError({ message: "Cannot mutate graph during a transformation" })
   }
+  csr.invalidate(graph)
   return internal.toImpl(graph)
 }
 
@@ -677,7 +678,7 @@ export const endMutation = <N, E, T extends Kind = "directed">(
 ): Graph<N, E, T> => {
   assertMutable(mutable)
   if (internal.isTransforming(mutable)) {
-    throw new GraphError({ message: "Cannot finalize graph during a transformation" })
+    throw new GraphError({ message: "Cannot mutate graph during a transformation" })
   }
   const source = internal.toImpl(mutable)
   csr.invalidate(mutable)
@@ -1842,6 +1843,8 @@ export const findEdges: {
 
 /**
  * Updates a single node's data by applying a transformation function.
+ * The transformation may query the graph, but cannot mutate or finalize the
+ * same graph while it runs.
  *
  * **Example** (Updating node data)
  *
@@ -1879,6 +1882,8 @@ export const updateNode = <N, E, T extends Kind = "directed">(
 
 /**
  * Updates a single edge's data by applying a transformation function.
+ * The transformation may query the graph, but cannot mutate or finalize the
+ * same graph while it runs.
  *
  * **Example** (Updating edge data)
  *
@@ -1926,6 +1931,8 @@ export const updateEdge = <N, E, T extends Kind = "directed">(
  * **Details**
  *
  * Node indices and edges are preserved; only the stored node data is replaced.
+ * The mapping function may query the graph, but cannot mutate or finalize the
+ * same graph while it runs.
  *
  * **Example** (Mapping node data)
  *
@@ -1961,6 +1968,8 @@ export const mapNodes = <N, E, T extends Kind = "directed">(
 
 /**
  * Transforms all edge data in a mutable graph using the provided mapping function.
+ * The mapping function may query the graph, but cannot mutate or finalize the
+ * same graph while it runs.
  *
  * **Example** (Mapping edge data)
  *
@@ -2074,6 +2083,8 @@ export const reverse = <N, E, T extends Kind = "directed">(
 /**
  * Filters and optionally transforms nodes in a mutable graph using a predicate function.
  * Nodes that return Option.none are removed along with all their connected edges.
+ * The function may query the graph, but cannot mutate or finalize the same
+ * graph while it runs.
  *
  * **Example** (Filtering and mapping nodes)
  *
@@ -2106,9 +2117,8 @@ export const filterMapNodes = <N, E, T extends Kind = "directed">(
   f: (data: N) => Option.Option<N>
 ): void => {
   const impl = getMutableImplForMutation(mutable)
+  const nodesToRemove: Array<NodeIndex> = []
   internal.withTransformation(mutable, () => {
-    const nodesToRemove: Array<NodeIndex> = []
-
     // First pass: identify nodes to remove and transform data for nodes to keep
     for (const [index, data] of impl.nodes) {
       const result = f(data)
@@ -2120,17 +2130,19 @@ export const filterMapNodes = <N, E, T extends Kind = "directed">(
         nodesToRemove.push(index)
       }
     }
-
-    // Second pass: remove filtered out nodes and their edges
-    for (const nodeIndex of nodesToRemove) {
-      removeNode(mutable, nodeIndex)
-    }
   })
+
+  // Second pass: remove filtered out nodes and their edges
+  for (const nodeIndex of nodesToRemove) {
+    removeNode(mutable, nodeIndex)
+  }
 }
 
 /**
  * Filters and optionally transforms edges in a mutable graph using a predicate function.
  * Edges that return Option.none are removed from the graph.
+ * The function may query the graph, but cannot mutate or finalize the same
+ * graph while it runs.
  *
  * **Example** (Filtering and mapping edges)
  *
@@ -2163,9 +2175,8 @@ export const filterMapEdges = <N, E, T extends Kind = "directed">(
   f: (data: E) => Option.Option<E>
 ): void => {
   const impl = getMutableImplForMutation(mutable)
+  const edgesToRemove: Array<EdgeIndex> = []
   internal.withTransformation(mutable, () => {
-    const edgesToRemove: Array<EdgeIndex> = []
-
     // First pass: identify edges to remove and transform data for edges to keep
     for (const [index, edgeData] of impl.edges) {
       const result = f(edgeData.data)
@@ -2181,17 +2192,19 @@ export const filterMapEdges = <N, E, T extends Kind = "directed">(
         edgesToRemove.push(index)
       }
     }
-
-    // Second pass: remove filtered out edges
-    for (const edgeIndex of edgesToRemove) {
-      removeEdge(mutable, edgeIndex)
-    }
   })
+
+  // Second pass: remove filtered out edges
+  for (const edgeIndex of edgesToRemove) {
+    removeEdge(mutable, edgeIndex)
+  }
 }
 
 /**
  * Filters nodes by removing those that don't match the predicate.
  * This function modifies the mutable graph in place.
+ * The predicate may query the graph, but cannot mutate or finalize the same
+ * graph while it runs.
  *
  * **Example** (Filtering nodes)
  *
@@ -2221,12 +2234,14 @@ export const filterNodes = <N, E, T extends Kind = "directed">(
   const impl = getMutableImplForMutation(mutable)
   const nodesToRemove: Array<NodeIndex> = []
 
-  // Identify nodes to remove
-  for (const [index, data] of impl.nodes) {
-    if (!predicate(data)) {
-      nodesToRemove.push(index)
+  internal.withTransformation(mutable, () => {
+    // Identify nodes to remove
+    for (const [index, data] of impl.nodes) {
+      if (!predicate(data)) {
+        nodesToRemove.push(index)
+      }
     }
-  }
+  })
 
   // Remove filtered out nodes (this also removes connected edges)
   for (const nodeIndex of nodesToRemove) {
@@ -2237,6 +2252,8 @@ export const filterNodes = <N, E, T extends Kind = "directed">(
 /**
  * Filters edges by removing those that don't match the predicate.
  * This function modifies the mutable graph in place.
+ * The predicate may query the graph, but cannot mutate or finalize the same
+ * graph while it runs.
  *
  * **Example** (Filtering edges)
  *
@@ -2269,12 +2286,14 @@ export const filterEdges = <N, E, T extends Kind = "directed">(
   const impl = getMutableImplForMutation(mutable)
   const edgesToRemove: Array<EdgeIndex> = []
 
-  // Identify edges to remove
-  for (const [index, edgeData] of impl.edges) {
-    if (!predicate(edgeData.data)) {
-      edgesToRemove.push(index)
+  internal.withTransformation(mutable, () => {
+    // Identify edges to remove
+    for (const [index, edgeData] of impl.edges) {
+      if (!predicate(edgeData.data)) {
+        edgesToRemove.push(index)
+      }
     }
-  }
+  })
 
   // Remove filtered out edges
   for (const edgeIndex of edgesToRemove) {

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -2117,7 +2117,7 @@ export const filterMapNodes = <N, E, T extends Kind = "directed">(
   f: (data: N) => Option.Option<N>
 ): void => {
   const impl = getMutableImplForMutation(mutable)
-  const nodesToRemove: Array<NodeIndex> = []
+  const remove: Array<NodeIndex> = []
   internal.withTransformation(mutable, () => {
     // First pass: identify nodes to remove and transform data for nodes to keep
     for (const [index, data] of impl.nodes) {
@@ -2127,15 +2127,13 @@ export const filterMapNodes = <N, E, T extends Kind = "directed">(
         impl.nodes.set(index, result.value)
       } else {
         // Mark for removal
-        nodesToRemove.push(index)
+        remove.push(index)
       }
     }
   })
 
   // Second pass: remove filtered out nodes and their edges
-  for (const nodeIndex of nodesToRemove) {
-    removeNode(mutable, nodeIndex)
-  }
+  removeNodes(mutable, remove)
 }
 
 /**
@@ -2175,7 +2173,7 @@ export const filterMapEdges = <N, E, T extends Kind = "directed">(
   f: (data: E) => Option.Option<E>
 ): void => {
   const impl = getMutableImplForMutation(mutable)
-  const edgesToRemove: Array<EdgeIndex> = []
+  const remove: Array<EdgeIndex> = []
   internal.withTransformation(mutable, () => {
     // First pass: identify edges to remove and transform data for edges to keep
     for (const [index, edgeData] of impl.edges) {
@@ -2189,15 +2187,13 @@ export const filterMapEdges = <N, E, T extends Kind = "directed">(
         })
       } else {
         // Mark for removal
-        edgesToRemove.push(index)
+        remove.push(index)
       }
     }
   })
 
   // Second pass: remove filtered out edges
-  for (const edgeIndex of edgesToRemove) {
-    removeEdge(mutable, edgeIndex)
-  }
+  removeEdges(mutable, remove)
 }
 
 /**
@@ -2232,21 +2228,19 @@ export const filterNodes = <N, E, T extends Kind = "directed">(
   predicate: (data: N) => boolean
 ): void => {
   const impl = getMutableImplForMutation(mutable)
-  const nodesToRemove: Array<NodeIndex> = []
+  const remove: Array<NodeIndex> = []
 
   internal.withTransformation(mutable, () => {
     // Identify nodes to remove
     for (const [index, data] of impl.nodes) {
       if (!predicate(data)) {
-        nodesToRemove.push(index)
+        remove.push(index)
       }
     }
   })
 
   // Remove filtered out nodes (this also removes connected edges)
-  for (const nodeIndex of nodesToRemove) {
-    removeNode(mutable, nodeIndex)
-  }
+  removeNodes(mutable, remove)
 }
 
 /**
@@ -2284,21 +2278,19 @@ export const filterEdges = <N, E, T extends Kind = "directed">(
   predicate: (data: E) => boolean
 ): void => {
   const impl = getMutableImplForMutation(mutable)
-  const edgesToRemove: Array<EdgeIndex> = []
+  const remove: Array<EdgeIndex> = []
 
   internal.withTransformation(mutable, () => {
     // Identify edges to remove
     for (const [index, edgeData] of impl.edges) {
       if (!predicate(edgeData.data)) {
-        edgesToRemove.push(index)
+        remove.push(index)
       }
     }
   })
 
   // Remove filtered out edges
-  for (const edgeIndex of edgesToRemove) {
-    removeEdge(mutable, edgeIndex)
-  }
+  removeEdges(mutable, remove)
 }
 
 // =============================================================================
@@ -2454,10 +2446,47 @@ export const removeNode = <N, E, T extends Kind = "directed">(
   nodeIndex: NodeIndex
 ): void => {
   const impl = getMutableImplForMutation(mutable)
+  if (removeNodeInternal(impl, nodeIndex)) {
+    invalidateCycleFlagOnRemoval(impl)
+  }
+}
 
+/**
+ * Removes multiple nodes and all their incident edges from a mutable graph.
+ *
+ * The input is collected before mutation, so it may be backed by an iterator
+ * over the same graph. Missing and duplicate node indices are ignored.
+ *
+ * @category mutations
+ * @since 4.0.0
+ */
+export const removeNodes = <N, E, T extends Kind = "directed">(
+  mutable: MutableGraph<N, E, T>,
+  nodeIndices: Iterable<NodeIndex>
+): void => {
+  const impl = getMutableImplForMutation(mutable)
+  const indices = Array.from(nodeIndices)
+
+  let removed = false
+  for (const nodeIndex of indices) {
+    if (removeNodeInternal(impl, nodeIndex)) {
+      removed = true
+    }
+  }
+
+  if (removed) {
+    invalidateCycleFlagOnRemoval(impl)
+  }
+}
+
+/** @internal */
+const removeNodeInternal = <N, E, T extends Kind = "directed">(
+  impl: internal.GraphImpl<N, E, T>,
+  nodeIndex: NodeIndex
+): boolean => {
   // Check if node exists
   if (!impl.nodes.has(nodeIndex)) {
-    return // Node doesn't exist, nothing to remove
+    return false // Node doesn't exist, nothing to remove
   }
 
   // Collect all incident edges for removal
@@ -2489,9 +2518,7 @@ export const removeNode = <N, E, T extends Kind = "directed">(
   impl.adjacency.delete(nodeIndex)
   impl.reverseAdjacency.delete(nodeIndex)
 
-  // Only invalidate cycle flag if the graph wasn't already known to be acyclic
-  // Removing nodes cannot introduce cycles in an acyclic graph
-  invalidateCycleFlagOnRemoval(impl)
+  return true
 }
 
 /**
@@ -2521,11 +2548,37 @@ export const removeEdge = <N, E, T extends Kind = "directed">(
   edgeIndex: EdgeIndex
 ): void => {
   const impl = getMutableImplForMutation(mutable)
-  const wasRemoved = removeEdgeInternal(impl, edgeIndex)
-
   // Only invalidate cycle flag if an edge was actually removed
   // and only if the graph wasn't already known to be acyclic
-  if (wasRemoved) {
+  if (removeEdgeInternal(impl, edgeIndex)) {
+    invalidateCycleFlagOnRemoval(impl)
+  }
+}
+
+/**
+ * Removes multiple edges from a mutable graph.
+ *
+ * The input is collected before mutation, so it may be backed by an iterator
+ * over the same graph. Missing and duplicate edge indices are ignored.
+ *
+ * @category mutations
+ * @since 4.0.0
+ */
+export const removeEdges = <N, E, T extends Kind = "directed">(
+  mutable: MutableGraph<N, E, T>,
+  edgeIndices: Iterable<EdgeIndex>
+): void => {
+  const impl = getMutableImplForMutation(mutable)
+  const indices = Array.from(edgeIndices)
+
+  let removed = false
+  for (const edgeIndex of indices) {
+    if (removeEdgeInternal(impl, edgeIndex)) {
+      removed = true
+    }
+  }
+
+  if (removed) {
     invalidateCycleFlagOnRemoval(impl)
   }
 }

--- a/packages/effect/src/internal/graph.ts
+++ b/packages/effect/src/internal/graph.ts
@@ -16,7 +16,7 @@ export interface GraphImpl<in out N, in out E, T extends Graph.Kind = "directed"
   readonly [TypeId]: unknown
   type: T
   mutable: boolean
-  transformations: number
+  transforming: boolean
   nodes: Map<Graph.NodeIndex, N>
   edges: Map<Graph.EdgeIndex, Graph.Edge<E>>
   adjacency: Map<Graph.NodeIndex, Array<Graph.EdgeIndex>>
@@ -35,7 +35,7 @@ export const toImpl = <N, E, T extends Graph.Kind = "directed">(
 /** @internal */
 export const isTransforming = <N, E, T extends Graph.Kind>(
   graph: Graph.Graph<N, E, T> | Graph.MutableGraph<N, E, T>
-): boolean => toImpl(graph).transformations > 0
+): boolean => toImpl(graph).transforming
 
 /** @internal */
 export const withTransformation = <N, E, T extends Graph.Kind, A>(
@@ -43,11 +43,11 @@ export const withTransformation = <N, E, T extends Graph.Kind, A>(
   evaluate: () => A
 ): A => {
   const impl = toImpl(graph)
-  impl.transformations++
+  impl.transforming = true
   try {
     return evaluate()
   } finally {
-    impl.transformations--
+    impl.transforming = false
   }
 }
 
@@ -133,7 +133,7 @@ export const make = <N, E, T extends Graph.Kind>(type: T, mutable: boolean): Gra
   const graph: GraphImpl<N, E, T> = Object.create(ProtoGraph)
   graph.type = type
   graph.mutable = mutable
-  graph.transformations = 0
+  graph.transforming = false
   graph.nodes = new Map()
   graph.edges = new Map()
   graph.adjacency = new Map()
@@ -175,7 +175,7 @@ export const finalize = <N, E, T extends Graph.Kind>(source: GraphImpl<N, E, T>)
   const graph: GraphImpl<N, E, T> = Object.create(ProtoGraph)
   graph.type = source.type
   graph.mutable = false
-  graph.transformations = 0
+  graph.transforming = false
   graph.nodes = source.nodes
   graph.edges = source.edges
   graph.adjacency = source.adjacency

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -1801,7 +1801,7 @@ describe("Graph", () => {
     })
   })
 
-  describe("callback-driven transform caching", () => {
+  describe("callback-driven transformations", () => {
     it("should reject finalization from a transform callback", () => {
       const mutable = Graph.beginMutation(Graph.directed<string, never>((graph) => {
         Graph.addNode(graph, "old")
@@ -1815,10 +1815,76 @@ describe("Graph", () => {
             Array.from(Graph.bfs(finalized, { start: [0] }))
             return "new"
           }),
-        "Cannot finalize graph during a transformation"
+        "Cannot mutate graph during a transformation"
       )
       assert.strictEqual(finalized, undefined)
       assertSome(Graph.getNode(mutable, 0), "old")
+    })
+
+    it("should reject every mutation from a transform callback", () => {
+      const mutable = Graph.beginMutation(Graph.directed<string, number>((graph) => {
+        Graph.addNode(graph, "source")
+        Graph.addNode(graph, "target")
+        Graph.addEdge(graph, 0, 1, 1)
+      }))
+      const mutations: ReadonlyArray<() => unknown> = [
+        () => Graph.addNode(mutable, "new"),
+        () => Graph.updateNode(mutable, 0, () => "updated"),
+        () => Graph.updateEdge(mutable, 0, () => 2),
+        () => Graph.mapNodes(mutable, () => "mapped"),
+        () => Graph.mapEdges(mutable, () => 3),
+        () => Graph.reverse(mutable),
+        () => Graph.filterMapNodes(mutable, () => Option.none()),
+        () => Graph.filterMapEdges(mutable, () => Option.none()),
+        () => Graph.filterNodes(mutable, () => false),
+        () => Graph.filterEdges(mutable, () => false),
+        () => Graph.addEdge(mutable, 1, 0, 4),
+        () => Graph.removeNode(mutable, 0),
+        () => Graph.removeEdge(mutable, 0),
+        () => Graph.endMutation(mutable)
+      ]
+
+      for (const mutation of mutations) {
+        assertGraphError(
+          () =>
+            Graph.updateNode(mutable, 0, (data) => {
+              mutation()
+              return data
+            }),
+          "Cannot mutate graph during a transformation"
+        )
+      }
+
+      assert.deepStrictEqual(Graph.toSnapshot(mutable), {
+        type: "directed",
+        nodes: [{ index: 0, data: "source" }, { index: 1, data: "target" }],
+        edges: [{ index: 0, source: 0, target: 1, data: 1 }]
+      })
+    })
+
+    it("should guard filter predicate callbacks", () => {
+      const mutable = Graph.beginMutation(Graph.directed<string, number>((graph) => {
+        Graph.addNode(graph, "source")
+        Graph.addNode(graph, "target")
+        Graph.addEdge(graph, 0, 1, 1)
+      }))
+
+      assertGraphError(
+        () =>
+          Graph.filterNodes(mutable, () => {
+            Graph.removeNode(mutable, 0)
+            return true
+          }),
+        "Cannot mutate graph during a transformation"
+      )
+      assertGraphError(
+        () =>
+          Graph.filterEdges(mutable, () => {
+            Graph.removeEdge(mutable, 0)
+            return true
+          }),
+        "Cannot mutate graph during a transformation"
+      )
     })
 
     it("should not retain node data cached by updateNode callbacks", () => {

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -1429,7 +1429,9 @@ describe("Graph", () => {
         () => Graph.filterEdges(retained!, () => false),
         () => Graph.addEdge(retained!, nodeB!, nodeA!, 4),
         () => Graph.removeNode(retained!, nodeA!),
-        () => Graph.removeEdge(retained!, edge!)
+        () => Graph.removeNodes(retained!, [nodeA!]),
+        () => Graph.removeEdge(retained!, edge!),
+        () => Graph.removeEdges(retained!, [edge!])
       ]
       for (const mutation of mutations) {
         assertGraphError(mutation, "Graph is not mutable")
@@ -1840,7 +1842,9 @@ describe("Graph", () => {
         () => Graph.filterEdges(mutable, () => false),
         () => Graph.addEdge(mutable, 1, 0, 4),
         () => Graph.removeNode(mutable, 0),
+        () => Graph.removeNodes(mutable, [0]),
         () => Graph.removeEdge(mutable, 0),
+        () => Graph.removeEdges(mutable, [0]),
         () => Graph.endMutation(mutable)
       ]
 
@@ -2544,6 +2548,38 @@ describe("Graph", () => {
     })
   })
 
+  describe("removeNodes", () => {
+    it("should remove nodes, incident edges, and ignore duplicate or missing indices", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        for (const node of ["A", "B", "C"]) {
+          Graph.addNode(mutable, node)
+        }
+        Graph.addEdge(mutable, 0, 1, 1)
+        Graph.addEdge(mutable, 1, 2, 2)
+        Graph.addEdge(mutable, 2, 0, 3)
+
+        Graph.removeNodes(mutable, [1, 1, 999])
+      })
+
+      assert.deepStrictEqual(Graph.toSnapshot(graph), {
+        type: "directed",
+        nodes: [{ index: 0, data: "A" }, { index: 2, data: "C" }],
+        edges: [{ index: 2, source: 2, target: 0, data: 3 }]
+      })
+    })
+
+    it("should collect graph-backed iterables before removing nodes", () => {
+      const graph = Graph.directed<string, never>((mutable) => {
+        Graph.addNode(mutable, "A")
+        Graph.addNode(mutable, "B")
+
+        Graph.removeNodes(mutable, Graph.indices(Graph.nodes(mutable)))
+      })
+
+      strictEqual(Graph.nodeCount(graph), 0)
+    })
+  })
+
   describe("removeEdge", () => {
     it("should remove an edge between two nodes", () => {
       let edgeIndex: Graph.EdgeIndex
@@ -2598,6 +2634,34 @@ describe("Graph", () => {
       })
 
       expect(Graph.edgeCount(result)).toBe(1)
+    })
+  })
+
+  describe("removeEdges", () => {
+    it("should remove edges and ignore duplicate or missing indices", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        Graph.addNode(mutable, "A")
+        Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, 0, 1, 1)
+        Graph.addEdge(mutable, 1, 0, 2)
+
+        Graph.removeEdges(mutable, [0, 0, 999])
+      })
+
+      assert.deepStrictEqual(Graph.toSnapshot(graph).edges, [{ index: 1, source: 1, target: 0, data: 2 }])
+    })
+
+    it("should collect graph-backed iterables before removing edges", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        Graph.addNode(mutable, "A")
+        Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, 0, 1, 1)
+        Graph.addEdge(mutable, 1, 0, 2)
+
+        Graph.removeEdges(mutable, Graph.indices(Graph.edges(mutable)))
+      })
+
+      strictEqual(Graph.edgeCount(graph), 0)
     })
   })
 


### PR DESCRIPTION
## Summary

- add public removeNodes and removeEdges operations with safe iterable materialization and batched invalidation
- reject all public mutations and finalization while a graph transformation callback is running
- replace transformation depth tracking with a boolean and keep reads available during callbacks
- perform filter removals through the new batch APIs and document the callback contract
- add regression coverage and a patch changeset

## Validation

- pnpm lint-fix
- pnpm --filter effect test --run test/Graph.test.ts
- pnpm check
- git diff --check

pnpm check passes with existing duplicate-package warnings caused by tmp/bundle-base.