### PR TITLE
Improve Graph API documentation

### DIFF
--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -42,7 +42,6 @@ const TypeId = internal.TypeId
  * are not reused.
  *
  * @see {@link EdgeIndex} for edge identifiers instead of node identifiers
- * @see {@link addNode} for creating node identifiers
  *
  * @category models
  * @since 3.18.0
@@ -63,9 +62,6 @@ export type NodeIndex = number
  * identifiers are not reused.
  *
  * @see {@link NodeIndex} for node identifiers instead of edge identifiers
- * @see {@link Edge} for the edge value addressed by this identifier
- * @see {@link addEdge} for creating edge identifiers
- * @see {@link getEdge} for reading edges by identifier
  *
  * @category models
  * @since 3.18.0
@@ -79,10 +75,6 @@ export type EdgeIndex = number
  *
  * Use as the graph edge value that carries source node, target node, and stored
  * edge data together.
- *
- * @see {@link getEdge} for reading a single edge by identifier
- * @see {@link addEdge} for adding edges to a graph
- * @see {@link edges} for iterating graph edges
  *
  * @category models
  * @since 3.18.0
@@ -100,9 +92,6 @@ export interface Edge<out E> {
  *
  * Use when writing graph-polymorphic types or helpers that need to preserve
  * whether a graph is directed or undirected.
- *
- * @see {@link Graph} for immutable graphs parameterized by kind
- * @see {@link MutableGraph} for mutable graphs parameterized by kind
  *
  * @category models
  * @since 3.18.0
@@ -133,8 +122,20 @@ export interface IndexedEdge<out E> extends Edge<E> {
 /**
  * Active indexed structure used to reconstruct an immutable graph.
  *
+ * **When to use**
+ *
+ * Use when serializing or importing graph structure while preserving active
+ * node and edge identifiers.
+ *
+ * **Details**
+ *
  * Node and edge indexes must be non-negative safe integers in strictly
  * increasing order. Every edge endpoint must reference an indexed node.
+ *
+ * **Gotchas**
+ *
+ * A snapshot records only active identifiers, not allocator history. After
+ * reconstruction, new identifiers continue after the greatest active index.
  *
  * @see {@link fromSnapshot} for reconstructing a graph
  * @category models
@@ -155,7 +156,7 @@ export interface Snapshot<out N, out E, out T extends Kind> {
  * internal; use module functions such as `nodes`, `edges`, `getNode`, and
  * `getEdge` to inspect graph contents.
  *
- * @category models
+ * @category protocols
  * @since 3.18.0
  */
 export interface Proto<out N, out E> extends Iterable<readonly [NodeIndex, N]>, Equal.Equal, Pipeable, Inspectable {
@@ -176,8 +177,6 @@ export interface Proto<out N, out E> extends Iterable<readonly [NodeIndex, N]>, 
  * used by hashing must remain immutable, as with other Effect values.
  *
  * @see {@link MutableGraph} for the mutable counterpart used inside mutation scopes
- * @see {@link DirectedGraph} for a `Graph` fixed to directed edges
- * @see {@link UndirectedGraph} for a `Graph` fixed to undirected edges
  *
  * @category models
  * @since 3.18.0
@@ -197,7 +196,7 @@ export declare namespace Graph {
   /**
    * Type-level variance marker for immutable graphs.
    *
-   * @category models
+   * @category utility types
    * @since 4.0.0
    */
   export interface Variance<out N, out E> {
@@ -216,8 +215,6 @@ export declare namespace Graph {
  *
  * @see {@link Graph} for the immutable graph interface
  * @see {@link mutate} for scoped mutation of an immutable graph
- * @see {@link beginMutation} for opening a mutable graph manually
- * @see {@link endMutation} for returning to an immutable graph
  *
  * @category models
  * @since 3.18.0
@@ -240,7 +237,7 @@ export declare namespace MutableGraph {
   /**
    * Type-level variance marker for scoped mutable graphs.
    *
-   * @category models
+   * @category utility types
    * @since 4.0.0
    */
   export interface Variance<in out N, in out E> {
@@ -270,9 +267,7 @@ const copyEdge = <E>(edge: Edge<E>): Edge<E> => ({
  * `N` and edge data of type `E`.
  *
  * @see {@link directed} for constructing directed graphs
- * @see {@link Graph} for the generic immutable graph type
  * @see {@link UndirectedGraph} for graphs whose edges connect both endpoints
- * @see {@link MutableDirectedGraph} for the mutable directed graph type
  *
  * @category models
  * @since 3.18.0
@@ -293,7 +288,6 @@ export type DirectedGraph<N, E> = Graph<N, E, "directed">
  *
  * @see {@link undirected} for constructing undirected graphs
  * @see {@link DirectedGraph} for graphs whose edges have source-to-target direction
- * @see {@link MutableUndirectedGraph} for the mutable undirected graph type
  *
  * @category models
  * @since 3.18.0
@@ -309,7 +303,6 @@ export type UndirectedGraph<N, E> = Graph<N, E, "undirected">
  * whose edges have source-to-target direction.
  *
  * @see {@link MutableGraph} for the generic mutable graph type
- * @see {@link DirectedGraph} for the immutable directed graph type
  * @see {@link MutableUndirectedGraph} for mutable graphs without edge direction
  *
  * @category models
@@ -326,7 +319,6 @@ export type MutableDirectedGraph<N, E> = MutableGraph<N, E, "directed">
  * whose edges connect both endpoints without direction.
  *
  * @see {@link MutableDirectedGraph} for mutable graphs with directed edges
- * @see {@link UndirectedGraph} for the immutable undirected graph type
  * @see {@link MutableGraph} for the generic mutable graph type
  *
  * @category models
@@ -418,9 +410,18 @@ export const isGraph = <N = unknown, E = unknown, T extends Kind = Kind, U = nev
 /**
  * Reconstructs an immutable graph from its indexed active structure.
  *
+ * **When to use**
+ *
+ * Use when importing a snapshot or other externally indexed graph structure.
+ * Prefer `directed` or `undirected` when creating a new graph without existing
+ * identifiers.
+ *
+ * **Gotchas**
+ *
  * The node and edge arrays must be ordered by strictly increasing,
  * non-negative safe integer indexes, and every edge endpoint must reference a
- * node in the snapshot. Invalid snapshots throw a {@link GraphError}.
+ * node in the snapshot. Invalid snapshots throw a `GraphError`. Historical
+ * removed identifiers after the greatest active index are not retained.
  *
  * **Example** (Preserving graph indexes)
  *
@@ -433,9 +434,10 @@ export const isGraph = <N = unknown, E = unknown, T extends Kind = Kind, U = nev
  *   edges: [{ index: 3, source: 2, target: 5, data: 1 }]
  * })
  *
- * Array.from(graph) // => [[2, "A"], [5, "B"]]
+ * Graph.toSnapshot(graph).edges[0].index // => 3
  * ```
  *
+ * @see {@link toSnapshot} for capturing a graph snapshot
  * @category constructors
  * @since 4.0.0
  */
@@ -495,9 +497,21 @@ export const fromSnapshot = <N, E, T extends Kind>(snapshot: Snapshot<N, E, T>):
 /**
  * Returns the active indexed structure of a graph.
  *
+ * **When to use**
+ *
+ * Use when serializing a graph or passing its active structure across a
+ * boundary where node and edge identifiers must be preserved.
+ *
+ * **Details**
+ *
  * Nodes and edges are returned in graph order with their current indexes.
  * Undirected edges retain their stored endpoint orientation, and each returned
  * node and edge record is newly allocated. The operation runs in `O(V + E)`.
+ *
+ * **Gotchas**
+ *
+ * Node and edge payloads are not cloned. The snapshot also omits allocator
+ * history for identifiers that are no longer active.
  *
  * **Example** (Round-tripping a graph snapshot)
  *
@@ -573,6 +587,16 @@ export const make =
 /**
  * Creates a directed graph, optionally with initial mutations.
  *
+ * **When to use**
+ *
+ * Use when relationships have a source-to-target direction, such as
+ * dependencies, workflows, or routing links.
+ *
+ * **Gotchas**
+ *
+ * The mutable callback handle is finalized when the callback returns and must
+ * not be retained for later mutation.
+ *
  * **Example** (Creating a directed graph)
  *
  * ```ts import.meta.vitest
@@ -598,6 +622,16 @@ export const directed: <N, E>(
 
 /**
  * Creates an undirected graph, optionally with initial mutations.
+ *
+ * **When to use**
+ *
+ * Use when relationships connect both endpoints symmetrically, such as social
+ * connections or physical links.
+ *
+ * **Gotchas**
+ *
+ * The mutable callback handle is finalized when the callback returns and must
+ * not be retained for later mutation.
  *
  * **Example** (Creating an undirected graph)
  *
@@ -627,7 +661,18 @@ export const undirected: <N, E>(
 // =============================================================================
 
 /**
- * Creates a mutable scope for safe graph mutations by copying the data structure.
+ * Creates a mutable copy of an immutable graph for a manual mutation scope.
+ *
+ * **When to use**
+ *
+ * Use when a mutation scope must span code that cannot be expressed as one
+ * `mutate` callback.
+ *
+ * **Gotchas**
+ *
+ * The graph structure is copied, but node and edge payload objects remain
+ * shared by reference. Always finish the scope with `endMutation`; prefer
+ * `mutate` when a callback is sufficient.
  *
  * **Example** (Beginning a mutation scope)
  *
@@ -640,6 +685,8 @@ export const undirected: <N, E>(
  * Array.of(Graph.nodeCount(mutable), Graph.nodeCount(graph)) // => [0, 0]
  * ```
  *
+ * @see {@link endMutation} for finalizing the mutable graph
+ * @see {@link mutate} for automatically scoped mutation
  * @category mutations
  * @since 3.18.0
  */
@@ -654,10 +701,14 @@ export const beginMutation = <N, E, T extends Kind = "directed">(
 /**
  * Converts a mutable graph back to an immutable graph, ending the mutation scope.
  *
- * **Details**
+ * **When to use**
  *
- * Finalizes the mutable handle. Later public mutation operations on that handle
- * fail with a `GraphError`.
+ * Use to finish a mutation scope opened with `beginMutation`.
+ *
+ * **Gotchas**
+ *
+ * Finalization is terminal. Later public mutation operations on the same
+ * mutable handle fail with a `GraphError`.
  *
  * **Example** (Ending a mutation scope)
  *
@@ -670,6 +721,8 @@ export const beginMutation = <N, E, T extends Kind = "directed">(
  * Graph.nodeCount(Graph.endMutation(mutable)) // => 0
  * ```
  *
+ * @see {@link beginMutation} for opening a manual mutation scope
+ * @see {@link mutate} for automatically scoped mutation
  * @category mutations
  * @since 3.18.0
  */
@@ -705,7 +758,23 @@ const mutateScoped = <N, E, T extends Kind>(
 }
 
 /**
- * Performs scoped mutations on a graph, automatically managing the mutation lifecycle.
+ * Returns an immutable graph after applying scoped mutations to a structural copy.
+ *
+ * **When to use**
+ *
+ * Use for the usual immutable update workflow when several node or edge
+ * mutations should be applied together.
+ *
+ * **Details**
+ *
+ * The original graph remains structurally unchanged. The mutable callback
+ * handle is finalized whether the callback returns or throws.
+ *
+ * **Gotchas**
+ *
+ * Payload objects are shared unless the callback replaces them. A callback
+ * failure is rethrown after the mutable handle is finalized, and the handle
+ * must not escape for later mutation.
  *
  * **Example** (Applying scoped mutations)
  *
@@ -723,6 +792,8 @@ const mutateScoped = <N, E, T extends Kind>(
  * Graph.edgeCount(newGraph) // => 1
  * ```
  *
+ * @see {@link beginMutation} for opening a manual mutation scope
+ * @see {@link endMutation} for finalizing a manual mutation scope
  * @category mutations
  * @since 3.18.0
  */
@@ -797,10 +868,16 @@ class EdgeIdentity<NI, EI> implements Equal.Equal {
 /**
  * Configures node and edge identity for graph set operations.
  *
+ * **When to use**
+ *
+ * Use when logical graph membership should be based on a stable key rather
+ * than the complete node or edge payload.
+ *
  * **Details**
  *
  * Both functions default to using the complete node or edge data. Edge identity
  * also includes the identities of its endpoint nodes and the graph kind.
+ * Projected identities use Effect equality and hashing semantics.
  *
  * **Gotchas**
  *
@@ -808,7 +885,7 @@ class EdgeIdentity<NI, EI> implements Equal.Equal {
  * with the same endpoint identities and projected edge identity are treated as
  * the same member by graph set operations.
  *
- * @category models
+ * @category configuration
  * @since 4.0.0
  */
 export interface IdentityOptions<N, E, NI = N, EI = E> {
@@ -893,6 +970,11 @@ const assertSameKind = <N, E>(self: Graph<N, E, Kind>, that: Graph<N, E, Kind>):
 /**
  * Composes two graphs, merging nodes by identity.
  *
+ * **When to use**
+ *
+ * Use when combining graphs that describe overlapping logical entities and
+ * should merge those entities by payload or a projected identity.
+ *
  * **Details**
  *
  * Nodes and edges present in both graphs use data from `that`. The result has
@@ -907,7 +989,7 @@ const assertSameKind = <N, E>(self: Graph<N, E, Kind>, that: Graph<N, E, Kind>):
  * Nodes with equal identities in one input graph are coalesced. The last node
  * supplies the data, and redirected edges can collapse or become self-loops.
  * Parallel edges with equal identities are also coalesced, with the last edge
- * supplying the data.
+ * supplying the data. The result allocates new node and edge identifiers.
  *
  * **Example** (Combining graphs)
  *
@@ -934,6 +1016,7 @@ const assertSameKind = <N, E>(self: Graph<N, E, Kind>, that: Graph<N, E, Kind>):
  * Graph.edgeCount(result) // => 2
  * ```
  *
+ * @see {@link sum} for combining graphs without merging equal nodes
  * @category set operations
  * @since 4.0.0
  */
@@ -986,6 +1069,11 @@ export const compose: {
 /**
  * Returns the intersection of two graphs, matching nodes by identity.
  *
+ * **When to use**
+ *
+ * Use when extracting nodes and edges that represent the same logical
+ * structure in both graphs.
+ *
  * **Details**
  *
  * Node data comes from `self`, and edge data comes from `that`. The result has
@@ -999,7 +1087,8 @@ export const compose: {
  *
  * Nodes with equal identities in one input graph are coalesced. The last node
  * supplies the data, and redirected edges can collapse or become self-loops.
- * The result contains at most one edge for each shared edge identity.
+ * The result contains at most one edge for each shared edge identity and
+ * allocates new node and edge identifiers.
  *
  * **Example** (Finding shared structure)
  *
@@ -1024,6 +1113,7 @@ export const compose: {
  * Graph.edgeCount(result) // => 1
  * ```
  *
+ * @see {@link compose} for identity-based graph union
  * @category set operations
  * @since 4.0.0
  */
@@ -1081,6 +1171,11 @@ export const intersection: {
 /**
  * Returns `self` without edges also present in `that`.
  *
+ * **When to use**
+ *
+ * Use when retaining all logical nodes from one graph while removing edge
+ * relationships also represented by another graph.
+ *
  * **Details**
  *
  * All nodes from `self` are preserved. Edges are matched by endpoint and edge
@@ -1095,7 +1190,7 @@ export const intersection: {
  * Nodes with equal identities in one input graph are coalesced. The last node
  * supplies the data, and redirected edges can collapse or become self-loops.
  * If `that` contains an edge identity, every parallel edge with that identity
- * is removed from `self`.
+ * is removed from `self`. The result allocates new node and edge identifiers.
  *
  * **Example** (Removing shared edges)
  *
@@ -1122,6 +1217,7 @@ export const intersection: {
  * Graph.edgeCount(result) // => 1
  * ```
  *
+ * @see {@link symmetricDifference} for retaining edges unique to either graph
  * @category set operations
  * @since 4.0.0
  */
@@ -1165,6 +1261,10 @@ export const difference: {
 /**
  * Returns edges present in exactly one of two graphs.
  *
+ * **When to use**
+ *
+ * Use when comparing graphs and retaining relationships unique to either one.
+ *
  * **Details**
  *
  * Keeps nodes from both graphs. Overlapping nodes use data from `that`. The
@@ -1181,7 +1281,7 @@ export const difference: {
  * Nodes with equal identities in one input graph are coalesced. The last node
  * supplies the data, and redirected edges can collapse or become self-loops.
  * Parallel edges with equal identities are coalesced before the graphs are
- * compared.
+ * compared. The result allocates new node and edge identifiers.
  *
  * **Example** (Finding differing edges)
  *
@@ -1210,6 +1310,7 @@ export const difference: {
  * Graph.edgeCount(result) // => 2
  * ```
  *
+ * @see {@link difference} for removing only the edges found in another graph
  * @category set operations
  * @since 4.0.0
  */
@@ -1265,13 +1366,24 @@ export const symmetricDifference: {
 /**
  * Returns the complement over the existing node set.
  *
+ * **When to use**
+ *
+ * Use when materializing every relationship that is currently absent between
+ * distinct nodes.
+ *
  * **Details**
  *
- * Adds every missing edge between distinct nodes. The `createEdge` function
- * receives the source and target node data for each added edge. The result has
- * the same graph kind as `self`.
+ * Directed graphs add each missing ordered pair. Undirected graphs add each
+ * missing unordered pair once. The `createEdge` function receives the source
+ * and target node data for each added edge. The result has the same graph kind
+ * as `self`.
  *
- * `G' = {V, (V x V) \ E}`
+ * `G' = {V, ((V x V) without self-pairs) \ E}`
+ *
+ * **Gotchas**
+ *
+ * Self-loops are never created. If any edge already connects a pair, parallel
+ * complement edges are not added. The result allocates new identifiers.
  *
  * **Example** (Finding missing relationships)
  *
@@ -1289,6 +1401,7 @@ export const symmetricDifference: {
  * Graph.edgeCount(result) // => 1
  * ```
  *
+ * @see {@link hasEdge} for testing one relationship
  * @category set operations
  * @since 4.0.0
  */
@@ -1344,7 +1457,7 @@ export const complement: {
  * `direction` controls how directed edges are traversed and defaults to
  * `"outgoing"`.
  *
- * @category models
+ * @category configuration
  * @since 4.0.0
  */
 export interface NeighborhoodConfig {
@@ -1355,6 +1468,10 @@ export interface NeighborhoodConfig {
 /**
  * Returns the induced subgraph containing nodes within a radius of a node.
  *
+ * **When to use**
+ *
+ * Use when extracting a local reachable region around one node.
+ *
  * **Details**
  *
  * The `radius` option is the maximum edge distance from `nodeIndex`, accepts
@@ -1363,6 +1480,12 @@ export interface NeighborhoodConfig {
  * traversal and defaults to `"outgoing"`. The result has the same graph kind
  * as `self` and keeps all original edges whose endpoints are both reached.
  * `"undirected"` ignores edge direction while finding reachable nodes.
+ *
+ * **Gotchas**
+ *
+ * Traversal chooses the nodes, then all original edges between reached nodes
+ * are retained. The result is not merely a traversal tree, and it allocates new
+ * node and edge identifiers.
  *
  * **Example** (Getting a local neighborhood)
  *
@@ -1382,6 +1505,7 @@ export interface NeighborhoodConfig {
  * Graph.nodeCount(result) // => 2
  * ```
  *
+ * @see {@link inducedSubgraph} for selecting nodes while preserving identifiers
  * @category set operations
  * @since 4.0.0
  */
@@ -1431,10 +1555,22 @@ export const neighborhood: {
 /**
  * Returns the subgraph induced by a collection of node indices.
  *
+ * **When to use**
+ *
+ * Use when selecting an exact node set while preserving its active node and
+ * edge identifiers.
+ *
+ * **Details**
+ *
  * Node and edge indices are preserved. Duplicate input indices are ignored,
  * output ordering follows the original graph, and every edge whose endpoints
- * are both selected is retained. Throws a `GraphError` when a selected node
- * does not exist.
+ * are both selected is retained.
+ *
+ * **Gotchas**
+ *
+ * Throws a `GraphError` when a selected node does not exist.
+ *
+ * @see {@link neighborhood} for selecting nodes by traversal distance
  *
  * @category set operations
  * @since 4.0.0
@@ -1476,6 +1612,11 @@ export const inducedSubgraph: {
 /**
  * Returns the disjoint union of two graphs.
  *
+ * **When to use**
+ *
+ * Use when combining graphs while keeping every node distinct, even when node
+ * payloads are equal.
+ *
  * **Details**
  *
  * Copies all nodes and edges from both graphs without merging equal node data.
@@ -1483,6 +1624,12 @@ export const inducedSubgraph: {
  * graph kinds do not match.
  *
  * `G1 + G2 = {disjoint V1 + V2, disjoint E1 + E2}`
+ *
+ * **Gotchas**
+ *
+ * All node and edge identifiers are newly allocated.
+ *
+ * @see {@link compose} for merging overlapping logical nodes by identity
  *
  * @category set operations
  * @since 4.0.0
@@ -1550,7 +1697,6 @@ export const sum: {
  *
  * @see {@link mutate} for obtaining a mutable graph from an immutable graph
  * @see {@link addEdge} for connecting existing nodes
- * @see {@link removeNode} for removing nodes from a mutable graph
  *
  * @category mutations
  * @since 3.18.0
@@ -1628,7 +1774,7 @@ export const getNode: {
  * Graph.hasNode(graph, 999) // => false
  * ```
  *
- * @category getters
+ * @category predicates
  * @since 3.18.0
  */
 export const hasNode: {
@@ -1843,8 +1989,16 @@ export const findEdges: {
 
 /**
  * Updates a single node's data by applying a transformation function.
- * The transformation may query the graph, but cannot mutate or finalize the
- * same graph while it runs.
+ *
+ * **When to use**
+ *
+ * Use when replacing one node payload while preserving its identifier and
+ * incident edges.
+ *
+ * **Gotchas**
+ *
+ * A missing node index is ignored. The transformation may query the graph, but
+ * cannot mutate or finalize the same graph while it runs.
  *
  * **Example** (Updating node data)
  *
@@ -1882,8 +2036,16 @@ export const updateNode = <N, E, T extends Kind = "directed">(
 
 /**
  * Updates a single edge's data by applying a transformation function.
- * The transformation may query the graph, but cannot mutate or finalize the
- * same graph while it runs.
+ *
+ * **When to use**
+ *
+ * Use when replacing one edge payload while preserving its identifier and
+ * endpoints.
+ *
+ * **Gotchas**
+ *
+ * A missing edge index is ignored. The transformation may query the graph, but
+ * cannot mutate or finalize the same graph while it runs.
  *
  * **Example** (Updating edge data)
  *
@@ -1900,7 +2062,7 @@ export const updateNode = <N, E, T extends Kind = "directed">(
  * Option.map(Graph.getEdge(result, 0), (edge) => edge.data) // => Option.some(20)
  * ```
  *
- * @category mutations
+ * @category transforming
  * @since 3.18.0
  */
 export const updateEdge = <N, E, T extends Kind = "directed">(
@@ -1928,11 +2090,19 @@ export const updateEdge = <N, E, T extends Kind = "directed">(
  * Transforms every node's data in a mutable graph in place using the provided
  * mapping function.
  *
+ * **When to use**
+ *
+ * Use when updating every node payload without changing graph structure.
+ *
  * **Details**
  *
  * Node indices and edges are preserved; only the stored node data is replaced.
- * The mapping function may query the graph, but cannot mutate or finalize the
- * same graph while it runs.
+ *
+ * **Gotchas**
+ *
+ * This function mutates in place, returns `void`, and cannot change the node
+ * payload type. The mapping function may query the graph, but cannot mutate or
+ * finalize the same graph while it runs.
  *
  * **Example** (Mapping node data)
  *
@@ -1949,7 +2119,9 @@ export const updateEdge = <N, E, T extends Kind = "directed">(
  * Graph.getNode(graph, 0) // => Option.some("NODE A")
  * ```
  *
- * @category transforming
+ * @see {@link updateNode} for updating one node
+ * @see {@link filterMapNodes} for mapping while removing nodes
+ * @category mapping
  * @since 3.18.0
  */
 export const mapNodes = <N, E, T extends Kind = "directed">(
@@ -1967,9 +2139,21 @@ export const mapNodes = <N, E, T extends Kind = "directed">(
 }
 
 /**
- * Transforms all edge data in a mutable graph using the provided mapping function.
- * The mapping function may query the graph, but cannot mutate or finalize the
- * same graph while it runs.
+ * Transforms every edge payload in a mutable graph in place.
+ *
+ * **When to use**
+ *
+ * Use when updating every edge payload without changing graph structure.
+ *
+ * **Details**
+ *
+ * Edge identifiers and endpoints are preserved.
+ *
+ * **Gotchas**
+ *
+ * This function mutates in place, returns `void`, and cannot change the edge
+ * payload type. The mapping function may query the graph, but cannot mutate or
+ * finalize the same graph while it runs.
  *
  * **Example** (Mapping edge data)
  *
@@ -1988,7 +2172,9 @@ export const mapNodes = <N, E, T extends Kind = "directed">(
  * Option.map(Graph.getEdge(graph, 0), (edge) => edge.data) // => Option.some(20)
  * ```
  *
- * @category transforming
+ * @see {@link updateEdge} for updating one edge
+ * @see {@link filterMapEdges} for mapping while removing edges
+ * @category mapping
  * @since 3.18.0
  */
 export const mapEdges = <N, E, T extends Kind = "directed">(
@@ -2037,6 +2223,19 @@ const rebuildAdjacency = <N, E, T extends Kind = "directed">(
 /**
  * Swaps source and target nodes for every edge in a mutable graph.
  *
+ * **When to use**
+ *
+ * Use when reversing every relationship in a directed graph, such as creating
+ * a dependency transpose.
+ *
+ * **Details**
+ *
+ * Edge identifiers and payloads are preserved.
+ *
+ * **Gotchas**
+ *
+ * This operation is a no-op for undirected graphs.
+ *
  * **Example** (Reversing edge directions)
  *
  * ```ts import.meta.vitest
@@ -2083,8 +2282,11 @@ export const reverse = <N, E, T extends Kind = "directed">(
 /**
  * Filters and optionally transforms nodes in a mutable graph using a predicate function.
  * Nodes that return Option.none are removed along with all their connected edges.
+ *
+ * **Gotchas**
+ *
  * The function may query the graph, but cannot mutate or finalize the same
- * graph while it runs.
+ * graph while it runs. Retained payloads must remain the same node type.
  *
  * **Example** (Filtering and mapping nodes)
  *
@@ -2109,7 +2311,7 @@ export const reverse = <N, E, T extends Kind = "directed">(
  * Graph.nodeCount(graph) // => 2
  * ```
  *
- * @category transforming
+ * @category filtering
  * @since 3.18.0
  */
 export const filterMapNodes = <N, E, T extends Kind = "directed">(
@@ -2139,8 +2341,11 @@ export const filterMapNodes = <N, E, T extends Kind = "directed">(
 /**
  * Filters and optionally transforms edges in a mutable graph using a predicate function.
  * Edges that return Option.none are removed from the graph.
+ *
+ * **Gotchas**
+ *
  * The function may query the graph, but cannot mutate or finalize the same
- * graph while it runs.
+ * graph while it runs. Retained payloads must remain the same edge type.
  *
  * **Example** (Filtering and mapping edges)
  *
@@ -2165,7 +2370,7 @@ export const filterMapNodes = <N, E, T extends Kind = "directed">(
  * Graph.edgeCount(graph) // => 2
  * ```
  *
- * @category transforming
+ * @category filtering
  * @since 3.18.0
  */
 export const filterMapEdges = <N, E, T extends Kind = "directed">(
@@ -2199,6 +2404,11 @@ export const filterMapEdges = <N, E, T extends Kind = "directed">(
 /**
  * Filters nodes by removing those that don't match the predicate.
  * This function modifies the mutable graph in place.
+ * Removed nodes also remove all incident edges; retained node identifiers are
+ * preserved.
+ *
+ * **Gotchas**
+ *
  * The predicate may query the graph, but cannot mutate or finalize the same
  * graph while it runs.
  *
@@ -2220,7 +2430,7 @@ export const filterMapEdges = <N, E, T extends Kind = "directed">(
  * Graph.nodeCount(graph) // => 2
  * ```
  *
- * @category transforming
+ * @category filtering
  * @since 3.18.0
  */
 export const filterNodes = <N, E, T extends Kind = "directed">(
@@ -2246,6 +2456,10 @@ export const filterNodes = <N, E, T extends Kind = "directed">(
 /**
  * Filters edges by removing those that don't match the predicate.
  * This function modifies the mutable graph in place.
+ * Nodes are retained even when removing edges leaves them isolated.
+ *
+ * **Gotchas**
+ *
  * The predicate may query the graph, but cannot mutate or finalize the same
  * graph while it runs.
  *
@@ -2270,7 +2484,7 @@ export const filterNodes = <N, E, T extends Kind = "directed">(
  * Graph.edgeCount(graph) // => 2
  * ```
  *
- * @category transforming
+ * @category filtering
  * @since 3.18.0
  */
 export const filterEdges = <N, E, T extends Kind = "directed">(
@@ -2331,9 +2545,9 @@ const invalidateCycleFlagOnAddition = <N, E, T extends Kind = "directed">(
  *
  * **Details**
  *
- * Creates an `Edge` with the source, target, and data at the next edge index,
- * updates adjacency indexes, and increments the graph's next edge index.
- * Undirected graphs register the same edge for both endpoints.
+ * Self-loops and parallel edges are allowed. Undirected graphs retain the
+ * supplied source and target orientation in the stored `Edge`, while traversal
+ * and neighbor queries treat the connection as bidirectional.
  *
  * **Gotchas**
  *
@@ -2354,8 +2568,6 @@ const invalidateCycleFlagOnAddition = <N, E, T extends Kind = "directed">(
  *
  * @see {@link mutate} for obtaining a mutable graph from an immutable graph
  * @see {@link addNode} for creating node indexes before connecting them
- * @see {@link getEdge} for reading the returned edge
- * @see {@link removeEdge} for removing an edge from a mutable graph
  *
  * @category mutations
  * @since 3.18.0
@@ -2422,6 +2634,10 @@ export const addEdge = <N, E, T extends Kind = "directed">(
 /**
  * Removes a node and all its incident edges from a mutable graph.
  *
+ * **Gotchas**
+ *
+ * A missing node index is ignored.
+ *
  * **Example** (Removing a node)
  *
  * ```ts import.meta.vitest
@@ -2454,8 +2670,21 @@ export const removeNode = <N, E, T extends Kind = "directed">(
 /**
  * Removes multiple nodes and all their incident edges from a mutable graph.
  *
+ * **When to use**
+ *
+ * Use when deleting a collection of nodes in one mutation pass.
+ *
+ * **Details**
+ *
  * The input is collected before mutation, so it may be backed by an iterator
- * over the same graph. Missing and duplicate node indices are ignored.
+ * over the same graph.
+ *
+ * **Gotchas**
+ *
+ * Missing and duplicate node indices are ignored. Removing a node also removes
+ * all of its incident edges.
+ *
+ * @see {@link removeNode} for removing one node
  *
  * @category mutations
  * @since 4.0.0
@@ -2524,6 +2753,10 @@ const removeNodeInternal = <N, E, T extends Kind = "directed">(
 /**
  * Removes an edge from a mutable graph.
  *
+ * **Gotchas**
+ *
+ * A missing edge index is ignored.
+ *
  * **Example** (Removing an edge)
  *
  * ```ts import.meta.vitest
@@ -2558,8 +2791,20 @@ export const removeEdge = <N, E, T extends Kind = "directed">(
 /**
  * Removes multiple edges from a mutable graph.
  *
+ * **When to use**
+ *
+ * Use when deleting a collection of edges in one mutation pass.
+ *
+ * **Details**
+ *
  * The input is collected before mutation, so it may be backed by an iterator
- * over the same graph. Missing and duplicate edge indices are ignored.
+ * over the same graph.
+ *
+ * **Gotchas**
+ *
+ * Missing and duplicate edge indices are ignored. Nodes are never removed.
+ *
+ * @see {@link removeEdge} for removing one edge
  *
  * @category mutations
  * @since 4.0.0
@@ -2681,6 +2926,15 @@ export const getEdge: {
 /**
  * Checks whether an edge exists between two nodes in the graph.
  *
+ * **Details**
+ *
+ * Directed graphs test only `source` to `target`; undirected graphs accept
+ * either stored orientation. Parallel edges still produce one boolean result.
+ *
+ * **Gotchas**
+ *
+ * Returns `false` when either node does not exist.
+ *
  * **Example** (Checking edge existence)
  *
  * ```ts import.meta.vitest
@@ -2697,7 +2951,8 @@ export const getEdge: {
  * Graph.hasEdge(graph, 0, 2) // => false
  * ```
  *
- * @category getters
+ * @see {@link edgesBetween} for all matching edge identifiers
+ * @category predicates
  * @since 3.18.0
  */
 export const hasEdge: {
@@ -3048,6 +3303,11 @@ const getUniqueDirectedNeighbors = <N, E>(
  * Each neighbor appears once in first edge occurrence order, including the
  * queried node when it has a self-loop.
  *
+ * **Gotchas**
+ *
+ * Returns an empty array when the node does not exist. For directed graphs,
+ * use `predecessors` when incoming neighbors are required.
+ *
  * **Example** (Getting outgoing neighbors)
  *
  * ```ts import.meta.vitest
@@ -3105,7 +3365,8 @@ export const neighbors: {
  *
  * **Gotchas**
  *
- * Throws a `GraphError` when used with an undirected graph.
+ * Throws a `GraphError` when used with an undirected graph. A missing node
+ * returns an empty array.
  *
  * @see {@link predecessors} for incoming neighbors in a directed graph
  * @see {@link neighbors} for generic neighbor lookup across graph kinds
@@ -3148,7 +3409,8 @@ export const successors: {
  *
  * **Gotchas**
  *
- * Throws a `GraphError` when used with an undirected graph.
+ * Throws a `GraphError` when used with an undirected graph. A missing node
+ * returns an empty array.
  *
  * @see {@link successors} for outgoing neighbors in a directed graph
  * @see {@link neighbors} for generic neighbor lookup across graph kinds
@@ -3252,6 +3514,10 @@ export const neighborsDirected: {
 /**
  * Configuration options for GraphViz DOT format generation from graphs.
  *
+ * **When to use**
+ *
+ * Use when customizing labels or the graph name produced by `toGraphViz`.
+ *
  * **Details**
  *
  * These options customize node labels, edge labels, and graph naming in DOT
@@ -3277,7 +3543,8 @@ export const neighborsDirected: {
  * Array.of(basicOptions.nodeLabel?.("A"), namedOptions.graphName) // => ["Node: A", "MyDependencyGraph"]
  * ```
  *
- * @category options
+ * @see {@link toGraphViz} for generating DOT output
+ * @category configuration
  * @since 3.18.0
  */
 export interface GraphVizOptions<N, E> {
@@ -3306,6 +3573,11 @@ const escapeGraphVizString = (value: string): string =>
 /**
  * Exports a graph to GraphViz DOT format for visualization.
  *
+ * **When to use**
+ *
+ * Use when sending graph structure to GraphViz-compatible visualization or
+ * documentation tools.
+ *
  * **Example** (Exporting GraphViz DOT)
  *
  * ```ts import.meta.vitest
@@ -3323,6 +3595,7 @@ const escapeGraphVizString = (value: string): string =>
  * Graph.toGraphViz(graph).split("\n") // => ['digraph "G" {', '  "0" [label="Node A"];', '  "1" [label="Node B"];', '  "2" [label="Node C"];', '  "0" -> "1" [label="1"];', '  "1" -> "2" [label="2"];', '  "2" -> "0" [label="3"];', "}"]
  * ```
  *
+ * @see {@link toMermaid} for Mermaid diagram output
  * @category converting
  * @since 3.18.0
  */
@@ -3504,18 +3777,17 @@ export type MermaidDiagramType =
   | "graph" // For undirected graphs
 
 /**
- * Configuration options for Mermaid diagram generation, following GraphViz pattern.
- *
- * @category models
- * @since 4.0.0
- */
-/**
  * Configuration options for Mermaid diagram generation from graphs.
+ *
+ * **When to use**
+ *
+ * Use when customizing labels, layout, node shapes, or syntax emitted by
+ * `toMermaid`.
  *
  * **Details**
  *
  * These options customize node labels, edge labels, diagram type, layout
- * direction, node shapes, and graph naming in Mermaid format.
+ * direction and node shapes in Mermaid format.
  *
  * **Example** (Configuring Mermaid output)
  *
@@ -3539,7 +3811,8 @@ export type MermaidDiagramType =
  * Array.of(basicOptions.nodeLabel?.("A"), advancedOptions.nodeShape?.("start")) // => ["Node: A", "circle"]
  * ```
  *
- * @category options
+ * @see {@link toMermaid} for generating Mermaid output
+ * @category configuration
  * @since 3.18.0
  */
 export interface MermaidOptions<N, E> {
@@ -3631,150 +3904,32 @@ const formatMermaidNode = (
 /**
  * Exports a graph to Mermaid diagram format for visualization.
  *
+ * **When to use**
+ *
+ * Use when embedding graph diagrams in Markdown, documentation sites, or other
+ * Mermaid-compatible tools.
+ *
  * **Details**
  *
- * Mermaid is a popular diagram-as-code tool that generates flowcharts and other
- * visualizations from text-based definitions. This function converts Effect Graph
- * structures to valid Mermaid syntax for use in documentation, web applications,
- * and visualization tools.
+ * Directed graphs default to `flowchart` with arrow edges, while undirected
+ * graphs default to `graph` with line edges. Labels and node shapes can be
+ * customized with `MermaidOptions`.
  *
- * **Example** (Exporting a directed Mermaid diagram)
+ * **Example** (Exporting a Mermaid diagram)
  *
  * ```ts import.meta.vitest
  * import { Graph } from "effect"
  *
- * // Basic directed graph export
- * const graph = Graph.directed<string, number>((mutable) => {
+ * const graph = Graph.directed<string, string>((mutable) => {
  *   const app = Graph.addNode(mutable, "App")
- *   const db = Graph.addNode(mutable, "Database")
- *   const cache = Graph.addNode(mutable, "Cache")
- *   Graph.addEdge(mutable, app, db, 1)
- *   Graph.addEdge(mutable, app, cache, 2)
+ *   const database = Graph.addNode(mutable, "Database")
+ *   Graph.addEdge(mutable, app, database, "queries")
  * })
  *
- * Graph.toMermaid(graph).split("\n") // => ["flowchart TD", '  0["App"]', '  1["Database"]', '  2["Cache"]', '  0 -->|"1"| 1', '  0 -->|"2"| 2']
+ * Graph.toMermaid(graph).split("\n") // => ["flowchart TD", '  0["App"]', '  1["Database"]', '  0 -->|"queries"| 1']
  * ```
  *
- * **Example** (Exporting an undirected Mermaid diagram)
- *
- * ```ts import.meta.vitest
- * import { Graph } from "effect"
- *
- * // Undirected graph with custom labels and direction
- * const socialGraph = Graph.undirected<{ name: string }, string>((mutable) => {
- *   const alice = Graph.addNode(mutable, { name: "Alice" })
- *   const bob = Graph.addNode(mutable, { name: "Bob" })
- *   const charlie = Graph.addNode(mutable, { name: "Charlie" })
- *   Graph.addEdge(mutable, alice, bob, "friends")
- *   Graph.addEdge(mutable, bob, charlie, "colleagues")
- * })
- *
- * const mermaid = Graph.toMermaid(socialGraph, {
- *   nodeLabel: (person) => person.name,
- *   edgeLabel: (relationship) => relationship,
- *   direction: "LR"
- * })
- * mermaid.split("\n") // => ["graph LR", '  0["Alice"]', '  1["Bob"]', '  2["Charlie"]', '  0 ---|"friends"| 1', '  1 ---|"colleagues"| 2']
- * ```
- *
- * **Example** (Customizing Mermaid node shapes)
- *
- * ```ts import.meta.vitest
- * import { Graph } from "effect"
- *
- * // Advanced styling with node shapes for flowchart
- * const workflow = Graph.directed<{ type: string; name: string }, string>(
- *   (mutable) => {
- *     const start = Graph.addNode(mutable, { type: "start", name: "Begin" })
- *     const process = Graph.addNode(mutable, {
- *       type: "process",
- *       name: "Process Data"
- *     })
- *     const decision = Graph.addNode(mutable, {
- *       type: "decision",
- *       name: "Valid?"
- *     })
- *     const end = Graph.addNode(mutable, { type: "end", name: "Complete" })
- *     Graph.addEdge(mutable, start, process, "")
- *     Graph.addEdge(mutable, process, decision, "")
- *     Graph.addEdge(mutable, decision, end, "yes")
- *   }
- * )
- *
- * const mermaid = Graph.toMermaid(workflow, {
- *   nodeLabel: (node) => node.name,
- *   nodeShape: (node) => {
- *     switch (node.type) {
- *       case "start":
- *         return "stadium"
- *       case "process":
- *         return "rectangle"
- *       case "decision":
- *         return "diamond"
- *       case "end":
- *         return "stadium"
- *       default:
- *         return "rectangle"
- *     }
- *   }
- * })
- * mermaid.split("\n") // => ["flowchart TD", '  0(["Begin"])', '  1["Process Data"]', '  2{"Valid?"}', '  3(["Complete"])', "  0 --> 1", "  1 --> 2", '  2 -->|"yes"| 3']
- * ```
- *
- * **Example** (Visualizing dependency graphs)
- *
- * ```ts import.meta.vitest
- * import { Graph } from "effect"
- *
- * // Real-world example: Software dependency graph
- * interface Dependency {
- *   name: string
- *   version: string
- *   type: "library" | "framework" | "tool"
- * }
- *
- * const dependencyGraph = Graph.directed<Dependency, string>((mutable) => {
- *   const app = Graph.addNode(mutable, {
- *     name: "MyApp",
- *     version: "1.0.0",
- *     type: "library"
- *   } satisfies Dependency)
- *   const react = Graph.addNode(mutable, {
- *     name: "React",
- *     version: "18.0.0",
- *     type: "framework"
- *   } satisfies Dependency)
- *   const lodash = Graph.addNode(mutable, {
- *     name: "Lodash",
- *     version: "4.17.0",
- *     type: "library"
- *   } satisfies Dependency)
- *   const webpack = Graph.addNode(mutable, {
- *     name: "Webpack",
- *     version: "5.0.0",
- *     type: "tool"
- *   } satisfies Dependency)
- *
- *   Graph.addEdge(mutable, app, react, "depends on")
- *   Graph.addEdge(mutable, app, lodash, "depends on")
- *   Graph.addEdge(mutable, app, webpack, "builds with")
- * })
- *
- * const dependencyDiagram = Graph.toMermaid(dependencyGraph, {
- *   nodeLabel: (dep) => `${dep.name}\\nv${dep.version}`,
- *   edgeLabel: (edge) => edge,
- *   nodeShape: (dep) =>
- *     dep.type === "framework" ?
- *       "hexagon" :
- *       dep.type === "tool"
- *       ? "diamond"
- *       : "rectangle",
- *   direction: "TB"
- * })
- *
- * dependencyDiagram.split("\n") // => ["flowchart TB", '  0["MyApp#92;nv1.0.0"]', '  1{{"React#92;nv18.0.0"}}', '  2["Lodash#92;nv4.17.0"]', '  3{"Webpack#92;nv5.0.0"}', '  0 -->|"depends on"| 1', '  0 -->|"depends on"| 2', '  0 -->|"builds with"| 3']
- * ```
- *
+ * @see {@link toGraphViz} for GraphViz DOT output
  * @category converting
  * @since 3.18.0
  */
@@ -3890,6 +4045,8 @@ export type TraversalDirection = Direction | "undirected"
 /**
  * A cycle witness containing a closed node path and its traversed edges.
  *
+ * **Details**
+ *
  * `path` repeats its first node at the end, so `edges.length` is always
  * `path.length - 1`.
  *
@@ -3904,9 +4061,17 @@ export interface CycleResult {
 /**
  * Returns one cycle in a graph, if present.
  *
+ * **When to use**
+ *
+ * Use when you need the nodes and edges of a concrete cycle for diagnostics or
+ * reporting.
+ *
+ * **Details**
+ *
  * Directed cycles respect edge orientation. A self-loop is represented as a
  * one-edge cycle, and two parallel undirected edges form a two-edge cycle.
  *
+ * @see {@link isAcyclic} when only a boolean cycle check is needed
  * @category algorithms
  * @since 4.0.0
  */
@@ -3973,12 +4138,15 @@ export const findCycle = <N, E, T extends Kind = "directed">(
 /**
  * Checks whether the graph is acyclic (contains no cycles).
  *
+ * **When to use**
+ *
+ * Use when validating that a graph contains no cycle and a cycle witness is
+ * not needed.
+ *
  * **Details**
  *
- * Uses depth-first search to detect back edges, which indicate cycles.
- * For directed graphs, any back edge creates a cycle. For undirected graphs,
- * a back edge that doesn't use the same edge used to enter the current node
- * creates a cycle.
+ * Directed cycles respect edge orientation. Self-loops are cycles, and two
+ * parallel edges form a cycle in an undirected graph.
  *
  * **Example** (Checking cycles)
  *
@@ -4005,6 +4173,8 @@ export const findCycle = <N, E, T extends Kind = "directed">(
  * Graph.isAcyclic(cyclic) // => false
  * ```
  *
+ * @see {@link findCycle} for retrieving one cycle witness
+ * @see {@link topo} for ordering a directed acyclic graph
  * @category algorithms
  * @since 3.18.0
  */
@@ -4213,11 +4383,15 @@ export const isAcyclic = <N, E, T extends Kind = "directed">(
 /**
  * Checks whether an undirected graph is bipartite.
  *
+ * **When to use**
+ *
+ * Use when validating that nodes can be divided into two groups with every
+ * edge crossing between the groups.
+ *
  * **Details**
  *
  * A bipartite graph is one whose vertices can be divided into two disjoint sets
- * such that no two vertices within the same set are adjacent. Uses BFS coloring
- * to determine bipartiteness.
+ * such that no two vertices within the same set are adjacent.
  *
  * **Example** (Checking bipartite graphs)
  *
@@ -4248,6 +4422,7 @@ export const isAcyclic = <N, E, T extends Kind = "directed">(
  * Graph.isBipartite(triangle) // => false
  * ```
  *
+ * @see {@link maximumBipartiteMatching} for matching nodes after validation
  * @category algorithms
  * @since 3.18.0
  */
@@ -4338,6 +4513,8 @@ export const isBipartite = <N, E>(
 /**
  * A pair of matched nodes and the edge that realizes the match.
  *
+ * **Details**
+ *
  * `left` and `right` refer to the bipartition derived by
  * `maximumBipartiteMatching`, not to the stored edge orientation.
  *
@@ -4391,11 +4568,23 @@ const bipartiteColors = <N, E>(
 /**
  * Returns a maximum-cardinality matching of an undirected bipartite graph.
  *
+ * **When to use**
+ *
+ * Use when assigning as many disjoint pairs as possible between the two sides
+ * of a bipartite graph, such as workers to jobs or users to resources.
+ *
+ * **Details**
+ *
  * The bipartition is derived internally. Self-loops and odd cycles throw a
  * `GraphError`. Isolated nodes are allowed. Parallel edges do not change the
  * matching cardinality, and the first edge in graph order between each matched
  * pair is reported. Results follow left-partition graph order. Hopcroft-Karp
  * runs in `O(E * sqrt(V))` time.
+ *
+ * **Gotchas**
+ *
+ * The graph must be undirected and bipartite. The derived left and right sides
+ * are not based on stored edge orientation.
  *
  * **Example** (Matching a bipartite graph)
  *
@@ -4412,6 +4601,7 @@ const bipartiteColors = <N, E>(
  * Graph.maximumBipartiteMatching(graph) // => [{ left: 0, right: 3, edge: 1 }, { left: 1, right: 2, edge: 2 }]
  * ```
  *
+ * @see {@link isBipartite} for validating the graph without computing a matching
  * @category algorithms
  * @since 4.0.0
  */
@@ -4579,9 +4769,16 @@ const getTraversableNeighbor = <N, E, T extends Kind>(
 /**
  * Configuration for unweighted reachability queries.
  *
+ * **When to use**
+ *
+ * Use when controlling whether reachability follows outgoing edges, incoming
+ * edges, or either direction.
+ *
+ * **Details**
+ *
  * `direction` defaults to `"outgoing"` and is ignored for undirected graphs.
  *
- * @category models
+ * @category configuration
  * @since 4.0.0
  */
 export interface ReachabilityConfig {
@@ -4646,8 +4843,23 @@ const getUnweightedDistances = <N, E, T extends Kind>(
 /**
  * Returns minimum unweighted distances from a source to every reachable node.
  *
- * Throws a `GraphError` when the source does not exist. Directed traversal is
- * outgoing by default and can be changed with `direction`.
+ * **When to use**
+ *
+ * Use when every edge represents one step and you need hop counts from one
+ * source.
+ *
+ * **Details**
+ *
+ * Directed traversal is outgoing by default and can be changed with
+ * `direction`.
+ *
+ * **Gotchas**
+ *
+ * Throws a `GraphError` when the source does not exist.
+ *
+ * @see {@link hasPath} when only a reachability boolean is needed
+ * @see {@link bfs} for lazy traversal in increasing hop distance
+ * @see {@link dijkstra} for weighted shortest paths
  *
  * @category algorithms
  * @since 4.0.0
@@ -4670,8 +4882,22 @@ export const unweightedDistances: {
 /**
  * Tests whether a target is reachable from a source.
  *
- * Throws a `GraphError` when either endpoint does not exist. Directed traversal
- * is outgoing by default and can be changed with `direction`.
+ * **When to use**
+ *
+ * Use when you only need a reachability boolean rather than distances or a
+ * reconstructed path.
+ *
+ * **Details**
+ *
+ * Directed traversal is outgoing by default and can be changed with
+ * `direction`. A node is reachable from itself.
+ *
+ * **Gotchas**
+ *
+ * Throws a `GraphError` when either endpoint does not exist.
+ *
+ * @see {@link unweightedDistances} for hop distances to all reachable nodes
+ * @see {@link dijkstra} for a minimum-cost path
  *
  * @category predicates
  * @since 4.0.0
@@ -4748,8 +4974,20 @@ export const hasPath: {
 })
 
 /**
- * Finds connected components in an undirected graph.
- * Each component is represented as an array of node indices.
+ * Returns the connected components of an undirected graph.
+ *
+ * **When to use**
+ *
+ * Use when partitioning an undirected graph into groups connected by paths.
+ *
+ * **Details**
+ *
+ * Each component is represented as an array of node indices. Isolated nodes
+ * form singleton components.
+ *
+ * **Gotchas**
+ *
+ * Throws a `GraphError` when used with a directed graph.
  *
  * **Example** (Finding connected components)
  *
@@ -4768,6 +5006,9 @@ export const hasPath: {
  * Graph.connectedComponents(graph) // => [[0, 1], [2, 3]]
  * ```
  *
+ * @see {@link isConnected} when only a boolean connectivity check is needed
+ * @see {@link weaklyConnectedComponents} for directed graphs with orientation ignored
+ * @see {@link stronglyConnectedComponents} for mutual directed reachability
  * @category algorithms
  * @since 3.18.0
  */
@@ -4960,10 +5201,20 @@ const analyzeLowLinks = <N, E>(
 /**
  * Returns the edges whose removal increases the number of connected components.
  *
- * The graph must be undirected. Parent edges are tracked by edge index, so a
- * parallel edge prevents either edge from being a bridge. Self-loops are never
- * bridges. Results follow graph edge order. The iterative low-link traversal is
- * stack-safe and runs in `O(V + E)` time.
+ * **When to use**
+ *
+ * Use when locating single-edge failure points in an undirected network.
+ *
+ * **Details**
+ *
+ * Parent edges are tracked by edge index, so a parallel edge prevents either
+ * edge from being a bridge. Self-loops are never bridges. Results follow graph
+ * edge order. The iterative low-link traversal is stack-safe and runs in
+ * `O(V + E)` time.
+ *
+ * **Gotchas**
+ *
+ * Throws a `GraphError` when used with a directed graph.
  *
  * **Example** (Finding bridge edges)
  *
@@ -4979,6 +5230,8 @@ const analyzeLowLinks = <N, E>(
  * Graph.bridges(graph) // => [0, 1]
  * ```
  *
+ * @see {@link articulationPoints} for single-node failure points
+ * @see {@link biconnectedComponents} for maximal regions without an articulation split
  * @category algorithms
  * @since 4.0.0
  */
@@ -4989,9 +5242,19 @@ export const bridges = <N, E>(
 /**
  * Returns the nodes whose removal increases the number of connected components.
  *
- * The graph must be undirected. Disconnected components, parallel edges, and
- * self-loops are handled by an iterative, stack-safe low-link traversal in
- * `O(V + E)` time. Results follow graph node order.
+ * **When to use**
+ *
+ * Use when locating single-node failure points in an undirected network.
+ *
+ * **Details**
+ *
+ * Disconnected components, parallel edges, and self-loops are handled by an
+ * iterative, stack-safe low-link traversal in `O(V + E)` time. Results follow
+ * graph node order.
+ *
+ * **Gotchas**
+ *
+ * Throws a `GraphError` when used with a directed graph.
  *
  * **Example** (Finding articulation points)
  *
@@ -5007,6 +5270,8 @@ export const bridges = <N, E>(
  * Graph.articulationPoints(graph) // => [1]
  * ```
  *
+ * @see {@link bridges} for single-edge failure points
+ * @see {@link biconnectedComponents} for the regions joined at articulation points
  * @category algorithms
  * @since 4.0.0
  */
@@ -5017,11 +5282,22 @@ export const articulationPoints = <N, E>(
 /**
  * Returns the maximal biconnected node components of an undirected graph.
  *
+ * **When to use**
+ *
+ * Use when decomposing an undirected graph into maximal regions that remain
+ * connected after removing any one node from the region.
+ *
+ * **Details**
+ *
  * Articulation points can occur in more than one component. Isolated vertices
  * are excluded, while a vertex with a self-loop forms a singleton component.
  * Nodes within components and the components themselves follow graph order.
  * Parallel edges are treated independently. The iterative low-link traversal
  * is stack-safe and runs in `O(V + E)` time.
+ *
+ * **Gotchas**
+ *
+ * Throws a `GraphError` when used with a directed graph.
  *
  * **Example** (Finding biconnected components)
  *
@@ -5041,6 +5317,8 @@ export const articulationPoints = <N, E>(
  * Graph.biconnectedComponents(graph) // => [[0, 1, 2], [2, 3, 4]]
  * ```
  *
+ * @see {@link articulationPoints} for the nodes shared between components
+ * @see {@link bridges} for edges whose removal disconnects the graph
  * @category algorithms
  * @since 4.0.0
  */
@@ -5051,10 +5329,21 @@ export const biconnectedComponents = <N, E>(
 /**
  * Configuration for source-to-target flow algorithms.
  *
+ * **When to use**
+ *
+ * Use when defining endpoints and edge capacities for `maximumFlow` or
+ * `minimumCut`.
+ *
+ * **Details**
+ *
  * `capacity` receives stored edge data and must return a finite,
  * non-negative number.
  *
- * @category models
+ * **Gotchas**
+ *
+ * The source and target must be distinct existing nodes in a directed graph.
+ *
+ * @category configuration
  * @since 4.0.0
  */
 export interface MaximumFlowConfig<E> {
@@ -5065,6 +5354,11 @@ export interface MaximumFlowConfig<E> {
 
 /**
  * Maximum flow value, per-edge flows, and a corresponding minimum cut.
+ *
+ * **Details**
+ *
+ * `flows` contains every original edge, including zero-flow edges. `cut`
+ * contains the crossing edge identifiers of the corresponding minimum cut.
  *
  * @category models
  * @since 4.0.0
@@ -5077,6 +5371,11 @@ export interface MaximumFlowResult {
 
 /**
  * Minimum cut value, crossing edges, and residual-reachability partitions.
+ *
+ * **Details**
+ *
+ * `source` contains nodes residual-reachable from the configured source and
+ * `target` contains the remaining nodes.
  *
  * @category models
  * @since 4.0.0
@@ -5238,11 +5537,22 @@ const solveMaximumFlow = <N, E>(
 /**
  * Returns a maximum flow and corresponding minimum cut for a directed graph.
  *
- * Capacities must be finite and non-negative. Missing or equal endpoints and a
- * total flow outside the finite number range throw a `GraphError`. Parallel
- * edges retain independent capacities, self-loops carry no source-to-target
- * flow, and the flow map includes every original edge in graph order, including
- * zero-flow edges. Edmonds-Karp runs in `O(V * E^2)` time.
+ * **When to use**
+ *
+ * Use when computing the greatest transferable capacity from one node to
+ * another and per-edge flow values are required.
+ *
+ * **Details**
+ *
+ * Parallel edges retain independent capacities, self-loops carry no
+ * source-to-target flow, and the flow map includes every original edge in graph
+ * order, including zero-flow edges. Edmonds-Karp runs in `O(V * E^2)` time.
+ *
+ * **Gotchas**
+ *
+ * The graph must be directed. Capacities must be finite and non-negative.
+ * Missing or equal endpoints, invalid capacities, and a total flow outside the
+ * finite number range throw a `GraphError`. Self-loops always carry zero flow.
  *
  * **Example** (Computing maximum flow)
  *
@@ -5282,11 +5592,23 @@ export const maximumFlow: {
 /**
  * Returns a minimum cut and its node partitions for a directed graph.
  *
+ * **When to use**
+ *
+ * Use when identifying the minimum-capacity edges that separate a source from
+ * a target, together with the resulting node partitions.
+ *
+ * **Details**
+ *
  * The source partition contains nodes reachable from the source in the final
  * residual network; the target partition contains its complement. Both follow
  * graph node order. Cut edges follow graph edge order, and their total capacity
  * equals the returned maximum-flow value. Validation, parallel-edge,
  * self-loop, and `O(V * E^2)` complexity behavior match `maximumFlow`.
+ *
+ * **Gotchas**
+ *
+ * The graph must be directed. Invalid capacities, missing endpoints, or equal
+ * source and target nodes throw a `GraphError`.
  *
  * **Example** (Partitioning a minimum cut)
  *
@@ -5330,8 +5652,22 @@ export const minimumCut: {
 /**
  * Finds weakly connected components in a directed graph.
  *
- * Edge direction is ignored while partitioning nodes. Throws a `GraphError`
- * when used with an undirected graph.
+ * **When to use**
+ *
+ * Use when grouping directed nodes by connectivity while ignoring edge
+ * orientation.
+ *
+ * **Details**
+ *
+ * Edge direction is ignored while partitioning nodes. Isolated nodes form
+ * singleton components.
+ *
+ * **Gotchas**
+ *
+ * Throws a `GraphError` when used with an undirected graph.
+ *
+ * @see {@link isWeaklyConnected} when only a boolean check is needed
+ * @see {@link stronglyConnectedComponents} for mutual directed reachability
  *
  * @category algorithms
  * @since 4.0.0
@@ -5382,8 +5718,17 @@ export const weaklyConnectedComponents = <N, E>(
 }
 
 /**
- * Finds strongly connected components in a directed graph using Kosaraju's algorithm.
- * Each SCC is represented as an array of node indices.
+ * Returns the strongly connected components of a directed graph.
+ *
+ * **When to use**
+ *
+ * Use when grouping nodes so every node in a component can reach every other
+ * node in that component.
+ *
+ * **Details**
+ *
+ * Each component is represented as an array of node indices and is computed
+ * with Kosaraju's algorithm.
  *
  * **Gotchas**
  *
@@ -5406,6 +5751,8 @@ export const weaklyConnectedComponents = <N, E>(
  * Graph.stronglyConnectedComponents(graph) // => [[0, 2, 1]]
  * ```
  *
+ * @see {@link isStronglyConnected} when only a boolean check is needed
+ * @see {@link weaklyConnectedComponents} when edge orientation should be ignored
  * @category algorithms
  * @since 3.18.0
  */
@@ -5527,8 +5874,17 @@ const csrReachesAll = (
 /**
  * Tests whether an undirected graph has at most one connected component.
  *
+ * **When to use**
+ *
+ * Use when checking undirected connectivity without allocating the component
+ * partition.
+ *
+ * **Gotchas**
+ *
  * The empty graph is considered connected. Throws a `GraphError` when used
  * with a directed graph.
+ *
+ * @see {@link connectedComponents} for the component partition
  *
  * @category predicates
  * @since 4.0.0
@@ -5546,8 +5902,17 @@ export const isConnected = <N, E>(
 /**
  * Tests whether a directed graph has at most one weakly connected component.
  *
+ * **When to use**
+ *
+ * Use when checking whether a directed graph is connected after ignoring edge
+ * orientation.
+ *
+ * **Gotchas**
+ *
  * The empty graph is considered weakly connected. Throws a `GraphError` when
  * used with an undirected graph.
+ *
+ * @see {@link isStronglyConnected} when edge orientation must be respected
  *
  * @category predicates
  * @since 4.0.0
@@ -5566,8 +5931,17 @@ export const isWeaklyConnected = <N, E>(
 /**
  * Tests whether a directed graph has at most one strongly connected component.
  *
+ * **When to use**
+ *
+ * Use when checking that every node in a directed graph can reach every other
+ * node.
+ *
+ * **Gotchas**
+ *
  * The empty graph is considered strongly connected. Throws a `GraphError` when
  * used with an undirected graph.
+ *
+ * @see {@link isWeaklyConnected} when edge orientation should be ignored
  *
  * @category predicates
  * @since 4.0.0
@@ -5586,8 +5960,14 @@ export const isStronglyConnected = <N, E>(
 /**
  * Tests whether a non-empty undirected graph is a tree.
  *
- * Parallel edges and self-loops prevent a graph from being a tree. Throws a
- * `GraphError` when used with a directed graph.
+ * **When to use**
+ *
+ * Use when validating that an undirected graph is connected and has no cycle.
+ *
+ * **Gotchas**
+ *
+ * The empty graph is not a tree. Parallel edges and self-loops prevent a graph
+ * from being a tree. Throws a `GraphError` when used with a directed graph.
  *
  * @category predicates
  * @since 4.0.0
@@ -5606,10 +5986,22 @@ export const isTree = <N, E>(
  * Returns a minimum spanning forest of an undirected graph using Kruskal's
  * algorithm.
  *
+ * **When to use**
+ *
+ * Use when selecting a minimum-cost acyclic connector for every connected
+ * component of an undirected graph.
+ *
+ * **Details**
+ *
  * All node indices and selected edge indices are preserved. Negative finite
  * weights are allowed, `Infinity` marks an unavailable edge, and equal weights
- * are resolved by original edge order. Throws a `GraphError` for a directed
- * graph or when a weight is `NaN` or `-Infinity`.
+ * are resolved by original edge order. Disconnected inputs produce a forest,
+ * and isolated nodes remain present.
+ *
+ * **Gotchas**
+ *
+ * Throws a `GraphError` for a directed graph or when a weight is `NaN` or
+ * `-Infinity`. Edges weighted `Infinity` are omitted.
  *
  * @category algorithms
  * @since 4.0.0
@@ -5699,8 +6091,19 @@ export const minimumSpanningForest: {
 /**
  * Returns the transitive reduction of a directed acyclic graph.
  *
+ * **When to use**
+ *
+ * Use when simplifying a dependency DAG while preserving which nodes can
+ * reach which other nodes.
+ *
+ * **Details**
+ *
  * The result preserves reachability with the fewest structural source-target
- * pairs. Node and retained edge indices are preserved; parallel edges are
+ * pairs. Node and retained edge indices are preserved.
+ *
+ * **Gotchas**
+ *
+ * This operation is structural and ignores edge costs. Parallel edges are
  * coalesced by retaining the first edge for each required pair. Throws a
  * `GraphError` for an undirected graph or cyclic input.
  *
@@ -5794,11 +6197,6 @@ export const transitiveReduction = <N, E>(
  *
  * `costs` contains original edge data, not the numeric output of the cost
  * function unless the edge data is numeric.
- *
- * @see {@link dijkstra} for shortest paths with non-negative edge costs
- * @see {@link astar} for heuristic shortest-path search
- * @see {@link bellmanFord} for shortest paths that may include negative edge weights
- * @see {@link AllPairsResult} for the all-pairs shortest-path result shape
  *
  * @category models
  * @since 3.18.0
@@ -6003,11 +6401,7 @@ const denseMinHeapPop = (heap: DenseMinHeap): boolean => {
  * `dijkstra` throws a `GraphError` when either endpoint does not exist or when
  * the cost function returns a negative weight or `NaN`.
  *
- * @see {@link dijkstra} for the algorithm that consumes this configuration
- * @see {@link AstarConfig} for heuristic shortest-path search
- * @see {@link BellmanFordConfig} for shortest paths that may include negative edge weights
- *
- * @category models
+ * @category configuration
  * @since 3.18.0
  */
 export interface DijkstraConfig<E> {
@@ -6020,12 +6414,21 @@ export interface DijkstraConfig<E> {
  * Finds the shortest path from the configured source node to the target node
  * using Dijkstra's algorithm.
  *
+ * **When to use**
+ *
+ * Use when you need one source-to-target shortest path and every edge cost is
+ * non-negative.
+ *
  * **Details**
  *
  * Edge costs must be non-negative and not `NaN`. `Infinity` is allowed and
  * behaves like an impassable edge. Returns `Option.none()` when the target is
- * not reachable, and throws a `GraphError` when either endpoint is missing or an
- * edge cost is negative or `NaN`.
+ * not reachable.
+ *
+ * **Gotchas**
+ *
+ * Throws a `GraphError` when either endpoint is missing or an edge cost is
+ * negative or `NaN`.
  *
  * **Example** (Finding shortest paths with Dijkstra)
  *
@@ -6050,6 +6453,9 @@ export interface DijkstraConfig<E> {
  * Option.map(result, ({ distance, path }) => [distance, path] as const) // => Option.some([7, [0, 1, 2]])
  * ```
  *
+ * @see {@link astar} when a useful heuristic can guide the search
+ * @see {@link bellmanFord} when edge costs may be negative
+ * @see {@link floydWarshall} when shortest paths are needed for all pairs
  * @category algorithms
  * @since 3.18.0
  */
@@ -6175,10 +6581,8 @@ export const dijkstra: {
  * **Details**
  *
  * Contains distance, node-path, edge-index-path, and edge-data maps keyed by
- * source and target node indices.
- *
- * @see {@link floydWarshall} for computing an all-pairs shortest path result
- * @see {@link PathResult} for the single source-to-target result shape used by path-finding algorithms
+ * source and target node indices. Unreachable pairs have distance `Infinity`,
+ * path `null`, and empty edge and cost arrays.
  *
  * @category models
  * @since 3.18.0
@@ -6194,12 +6598,21 @@ export interface AllPairsResult<E> {
  * Finds shortest paths between all pairs of nodes using the Floyd-Warshall
  * algorithm.
  *
+ * **When to use**
+ *
+ * Use when many or all node pairs will be queried and cubic computation plus
+ * quadratic result storage is acceptable.
+ *
  * **Details**
  *
  * Computes distances, reconstructed node paths, and edge-data paths for every
  * source and target pair in O(V^3) time. Negative edge weights are allowed, and
- * `Infinity` behaves like an impassable edge. A `GraphError` is thrown if any
- * edge weight is `NaN` or `-Infinity`, or if any negative cycle is detected.
+ * `Infinity` behaves like an impassable edge.
+ *
+ * **Gotchas**
+ *
+ * A `GraphError` is thrown if any edge weight is `NaN` or `-Infinity`, or if
+ * any negative cycle is detected.
  *
  * **Example** (Finding all-pairs shortest paths)
  *
@@ -6220,6 +6633,8 @@ export interface AllPairsResult<E> {
  * shortest // => { distance: 5, path: [0, 1, 2] }
  * ```
  *
+ * @see {@link dijkstra} for one query with non-negative edge costs
+ * @see {@link bellmanFord} for one query that may include negative edge costs
  * @category algorithms
  * @since 3.18.0
  */
@@ -6367,13 +6782,14 @@ export const floydWarshall: {
  *
  * Specifies the source and target node indices, an edge-cost function that maps
  * edge data to non-negative weights, and a heuristic that estimates the
- * remaining cost from a node to the target. Heuristic values must be finite.
+ * remaining cost from a node to the target.
  *
- * @see {@link astar} for the algorithm that consumes this configuration
- * @see {@link DijkstraConfig} for shortest paths without a heuristic
- * @see {@link BellmanFordConfig} for shortest paths that may include negative edge weights
+ * **Gotchas**
  *
- * @category models
+ * Heuristic values must be finite and the heuristic must be consistent for A*
+ * to guarantee a shortest path.
+ *
+ * @category configuration
  * @since 3.18.0
  */
 export interface AstarConfig<E, N> {
@@ -6387,16 +6803,24 @@ export interface AstarConfig<E, N> {
  * Finds the shortest path from the configured source node to the target node
  * using the A* pathfinding algorithm.
  *
+ * **When to use**
+ *
+ * Use when a meaningful heuristic can reduce point-to-point search compared
+ * with Dijkstra's algorithm.
+ *
  * **Details**
  *
  * The edge-cost function must return non-negative weights and not `NaN`.
- * `Infinity` is allowed and behaves like an impassable edge. The heuristic
- * must return finite values and should be consistent to preserve shortest-path guarantees. Returns
- * `Option.none()` when the target is not reachable, and throws a `GraphError`
- * when either endpoint is missing, an edge cost is negative or `NaN`, or a
- * heuristic value is not finite.
+ * `Infinity` is allowed and behaves like an impassable edge. Returns
+ * `Option.none()` when the target is not reachable.
  *
- * **Example** (Finding shortest paths with A-star)
+ * **Gotchas**
+ *
+ * The heuristic must be consistent for the shortest-path guarantee and must
+ * return finite values. Missing endpoints, invalid edge costs, or non-finite
+ * heuristic values throw a `GraphError`.
+ *
+ * **Example** (Finding shortest paths with A*)
  *
  * ```ts import.meta.vitest
  * import { Graph, Option } from "effect"
@@ -6425,6 +6849,8 @@ export interface AstarConfig<E, N> {
  * Option.map(result, ({ distance, path }) => [distance, path] as const) // => Option.some([2, [0, 1, 2]])
  * ```
  *
+ * @see {@link dijkstra} when no useful heuristic is available
+ * @see {@link bellmanFord} when edge costs may be negative
  * @category algorithms
  * @since 3.18.0
  */
@@ -6565,11 +6991,7 @@ export const astar: {
  * Specifies the source and target node indices, plus a cost function that maps
  * each edge's data to a numeric weight.
  *
- * @see {@link bellmanFord} for the algorithm that consumes this configuration
- * @see {@link DijkstraConfig} for non-negative edge costs
- * @see {@link AstarConfig} for heuristic shortest-path search
- *
- * @category models
+ * @category configuration
  * @since 3.18.0
  */
 export interface BellmanFordConfig<E> {
@@ -6582,13 +7004,22 @@ export interface BellmanFordConfig<E> {
  * Finds the shortest path from the configured source node to the target node
  * using the Bellman-Ford algorithm.
  *
+ * **When to use**
+ *
+ * Use when one source-to-target shortest-path query may traverse negative-cost
+ * edges.
+ *
  * **Details**
  *
  * Negative edge weights are allowed, and `Infinity` behaves like an impassable
- * edge. Returns `Option.none()` when the target is unreachable. Throws a
- * `GraphError` when a reachable negative cycle can affect the target, either
- * endpoint is missing, an edge weight is `NaN` or `-Infinity`, or finite
- * distance arithmetic exceeds the finite number range.
+ * edge. Returns `Option.none()` when the target is unreachable. A reachable
+ * negative cycle only causes failure when it can affect the target.
+ *
+ * **Gotchas**
+ *
+ * Missing endpoints, unsupported weights, finite-range overflow, or a relevant
+ * negative cycle throw a `GraphError`. In an undirected graph, any reachable
+ * negative edge forms a negative cycle because it can be traversed both ways.
  *
  * **Example** (Finding shortest paths with Bellman-Ford)
  *
@@ -6613,6 +7044,7 @@ export interface BellmanFordConfig<E> {
  * Option.map(result, ({ distance, path }) => [distance, path] as const) // => Option.some([2, [0, 1, 2]])
  * ```
  *
+ * @see {@link dijkstra} for non-negative edge costs
  * @category algorithms
  * @since 3.18.0
  */
@@ -6769,6 +7201,14 @@ export const bellmanFord: {
 /**
  * A repeatable lazy iterable of edge-aware graph paths.
  *
+ * **When to use**
+ *
+ * Use as the lazy result of graph path-enumeration functions.
+ *
+ * **Details**
+ *
+ * Each fresh iterator repeats the path enumeration.
+ *
  * @category models
  * @since 4.0.0
  */
@@ -6777,9 +7217,19 @@ export interface PathWalker<E> extends Iterable<PathResult<E>> {}
 /**
  * Configuration for lazy simple-path enumeration.
  *
+ * **When to use**
+ *
+ * Use when bounding enumeration of loop-free routes between two nodes.
+ *
+ * **Details**
+ *
  * `limit` bounds the number of yielded paths and defaults to `Infinity`.
  *
- * @category models
+ * **Gotchas**
+ *
+ * `limit` must be a non-negative integer or `Infinity`.
+ *
+ * @category configuration
  * @since 4.0.0
  */
 export interface SimplePathsConfig {
@@ -6791,10 +7241,20 @@ export interface SimplePathsConfig {
 /**
  * Configuration for enumerating all tied shortest paths.
  *
+ * **When to use**
+ *
+ * Use when bounding enumeration of every route tied for minimum total cost.
+ *
+ * **Details**
+ *
  * Edge costs must be non-negative. `limit` bounds the number of yielded paths
  * and defaults to `Infinity`.
  *
- * @category models
+ * **Gotchas**
+ *
+ * Invalid costs and limits throw a `GraphError` when evaluated.
+ *
+ * @category configuration
  * @since 4.0.0
  */
 export interface AllShortestPathsConfig<E> extends DijkstraConfig<E> {
@@ -6816,10 +7276,23 @@ const pathWalker = <E>(iterator: () => Iterator<PathResult<E>>): PathWalker<E> =
 /**
  * Lazily enumerates simple source-to-target paths in depth-first edge order.
  *
+ * **When to use**
+ *
+ * Use when you need possible loop-free routes rather than only an optimal
+ * route.
+ *
+ * **Details**
+ *
  * Nodes are never repeated within a path, so enumeration is finite even for
- * cyclic graphs. Path distance is the number of traversed edges. Throws a
- * `GraphError` for missing endpoints or an invalid `limit`.
- * Mutable graphs are snapshotted when iteration begins.
+ * cyclic graphs. Path distance is the number of traversed edges.
+ *
+ * **Gotchas**
+ *
+ * The number of simple paths can be exponential. Missing endpoints or an
+ * invalid `limit` throw a `GraphError`. Mutable graphs are snapshotted when
+ * iteration begins.
+ *
+ * @see {@link allShortestPaths} for enumerating only minimum-cost routes
  *
  * @category algorithms
  * @since 4.0.0
@@ -6917,10 +7390,23 @@ export const simplePaths: {
 /**
  * Lazily enumerates all simple paths tied for minimum total cost.
  *
+ * **When to use**
+ *
+ * Use when every distinct route tied for the minimum total cost is required.
+ *
+ * **Details**
+ *
  * Parallel edges produce distinct paths. Edge costs must be non-negative;
- * `Infinity` behaves as unavailable. Throws a `GraphError` for missing
- * endpoints, invalid costs, or an invalid `limit`.
- * Mutable graphs are snapshotted when iteration begins.
+ * `Infinity` behaves as unavailable.
+ *
+ * **Gotchas**
+ *
+ * The number of tied paths can still be large. Missing endpoints, invalid
+ * costs, or an invalid `limit` throw a `GraphError`. Mutable graphs are
+ * snapshotted when iteration begins.
+ *
+ * @see {@link dijkstra} when one shortest path is sufficient
+ * @see {@link simplePaths} for routes regardless of cost
  *
  * @category algorithms
  * @since 4.0.0
@@ -7102,13 +7588,12 @@ export class Walker<T, N> implements Iterable<[T, N]> {
   readonly [Symbol.iterator]: () => Iterator<[T, N]>
 
   /**
-   * Visits each element and maps it to a value using the provided function.
+   * Lazily maps each walker entry with the provided function.
    *
    * **Details**
    *
-   * Takes a function that receives the index and data,
-   * and returns an iterable of the mapped values. Skips elements that
-   * no longer exist in the graph.
+   * The function receives the index and data and runs as the returned iterable
+   * is consumed.
    *
    * **Example** (Visiting walker elements)
    *
@@ -7135,36 +7620,6 @@ export class Walker<T, N> implements Iterable<[T, N]> {
   readonly visit: <U>(f: (index: T, data: N) => U) => Iterable<U>
 
   constructor(
-    /**
-     * Visits each element and maps it to a value using the provided function.
-     *
-     * Takes a function that receives the index and data,
-     * and returns an iterable of the mapped values. Skips elements that
-     * no longer exist in the graph.
-     *
-     * **Example** (Visiting walker elements)
-     *
-     * ```ts import.meta.vitest
-     * import { Graph } from "effect"
-     *
-     * const graph = Graph.directed<string, number>((mutable) => {
-     *   const a = Graph.addNode(mutable, "A")
-     *   const b = Graph.addNode(mutable, "B")
-     *   Graph.addEdge(mutable, a, b, 1)
-     * })
-     *
-     * const dfs = Graph.dfs(graph, { start: [0] })
-     *
-     * // Map to just the node data
-     * Array.from(dfs.visit((index, data) => data)) // => ["A", "B"]
-     *
-     * // Map to custom objects
-     * Array.from(dfs.visit((index, data) => ({ id: index, name: data }))) // => [{ id: 0, name: "A" }, { id: 1, name: "B" }]
-     * ```
-     *
-     * @category iterators
-     * @since 4.0.0
-     */
     visit: <U>(f: (index: T, data: N) => U) => Iterable<U>
   ) {
     this.visit = visit
@@ -7339,11 +7794,7 @@ export const entries = <T, N>(walker: Walker<T, N>): Iterable<[T, N]> =>
  * revalidates those starts against the graph snapshot it captures. Later
  * mutations are not observed by an active iterator.
  *
- * @see {@link dfs} for depth-first traversal
- * @see {@link bfs} for breadth-first traversal
- * @see {@link dfsPostOrder} for depth-first postorder traversal
- *
- * @category models
+ * @category configuration
  * @since 3.18.0
  */
 export interface SearchConfig {
@@ -7356,18 +7807,22 @@ export interface SearchConfig {
  * Creates a lazy depth-first traversal iterator from the configured start
  * nodes.
  *
+ * **When to use**
+ *
+ * Use when exploring one branch deeply before visiting sibling branches.
+ *
  * **Details**
  *
  * If no start nodes are supplied, the iterator is empty. The `direction` option
  * chooses whether to follow outgoing or incoming edges. The `radius` option
  * limits traversal by edge distance from the start nodes. It accepts
  * non-negative integers and `Infinity`; omitting it means unbounded traversal.
- * Throws a `GraphError` for an invalid radius or missing start node.
  *
  * **Gotchas**
  *
- * Traversing a mutable graph captures a snapshot when iteration begins; later
- * mutations are not observed by that iterator.
+ * An invalid radius or missing start node throws a `GraphError`. Traversing a
+ * mutable graph captures a snapshot when iteration begins; later mutations are
+ * not observed by that iterator.
  *
  * **Example** (Traversing depth-first)
  *
@@ -7385,10 +7840,11 @@ export interface SearchConfig {
  * // Start from a specific node
  * Array.from(Graph.indices(Graph.dfs(graph, { start: [0] }))) // => [0, 1, 2]
  *
- * // Empty iterator (no starting nodes)
- * Graph.dfs(graph)
+ * Array.from(Graph.indices(Graph.dfs(graph))) // => []
  * ```
  *
+ * @see {@link bfs} for traversal in increasing hop distance
+ * @see {@link dfsPostOrder} for emitting descendants before ancestors
  * @category iterators
  * @since 3.18.0
  */
@@ -7527,18 +7983,23 @@ export const dfs: {
  * Creates a lazy breadth-first traversal iterator from the configured start
  * nodes.
  *
+ * **When to use**
+ *
+ * Use when visiting nodes in increasing unweighted distance from the start
+ * nodes.
+ *
  * **Details**
  *
  * If no start nodes are supplied, the iterator is empty. The `direction` option
  * chooses whether to follow outgoing or incoming edges. The `radius` option
  * limits traversal by edge distance from the start nodes. It accepts
  * non-negative integers and `Infinity`; omitting it means unbounded traversal.
- * Throws a `GraphError` for an invalid radius or missing start node.
  *
  * **Gotchas**
  *
- * Traversing a mutable graph captures a snapshot when iteration begins; later
- * mutations are not observed by that iterator.
+ * An invalid radius or missing start node throws a `GraphError`. Traversing a
+ * mutable graph captures a snapshot when iteration begins; later mutations are
+ * not observed by that iterator.
  *
  * **Example** (Traversing breadth-first)
  *
@@ -7556,10 +8017,11 @@ export const dfs: {
  * // Start from a specific node
  * Array.from(Graph.indices(Graph.bfs(graph, { start: [0] }))) // => [0, 1, 2]
  *
- * // Empty iterator (no starting nodes)
- * Graph.bfs(graph)
+ * Array.from(Graph.indices(Graph.bfs(graph))) // => []
  * ```
  *
+ * @see {@link dfs} for branch-first traversal
+ * @see {@link unweightedDistances} for collecting hop counts
  * @category iterators
  * @since 3.18.0
  */
@@ -7688,9 +8150,7 @@ export const bfs: {
  *
  * Throws a `GraphError` when any initial node has incoming edges.
  *
- * @see {@link topo} for the iterator that consumes this configuration
- *
- * @category models
+ * @category configuration
  * @since 3.18.0
  */
 export interface TopoConfig {
@@ -7698,17 +8158,24 @@ export interface TopoConfig {
 }
 
 /**
- * Creates a new topological sort iterator with optional configuration.
+ * Creates a lazy topological-order iterator for a directed acyclic graph.
+ *
+ * **When to use**
+ *
+ * Use when processing dependencies so every predecessor is emitted before the
+ * nodes that depend on it.
  *
  * **Details**
  *
- * The iterator uses Kahn's algorithm to lazily produce nodes in topological order.
- * Throws an error if the graph contains cycles.
+ * The iterator uses Kahn's algorithm. Multiple valid orders may exist;
+ * `initials` prioritizes eligible zero in-degree nodes without excluding other
+ * nodes.
  *
  * **Gotchas**
  *
- * Traversing a mutable graph captures a snapshot when iteration begins; later
- * mutations are not observed by that iterator.
+ * Undirected or cyclic graphs, missing initial nodes, and initial nodes with
+ * incoming edges throw a `GraphError`. Traversing a mutable graph captures a
+ * snapshot when iteration begins; later mutations are not observed.
  *
  * **Example** (Sorting topologically)
  *
@@ -7723,23 +8190,10 @@ export interface TopoConfig {
  *   Graph.addEdge(mutable, b, c, 1)
  * })
  *
- * // Standard topological sort
  * Array.from(Graph.indices(Graph.topo(graph))) // => [0, 1, 2]
- *
- * // With initial nodes
- * Graph.topo(graph, { initials: [0] })
- *
- * // Check before sorting a cyclic graph
- * const cyclicGraph = Graph.directed<string, number>((mutable) => {
- *   const a = Graph.addNode(mutable, "A")
- *   const b = Graph.addNode(mutable, "B")
- *   Graph.addEdge(mutable, a, b, 1)
- *   Graph.addEdge(mutable, b, a, 2) // Creates cycle
- * })
- *
- * Graph.isAcyclic(cyclicGraph) // => false
  * ```
  *
+ * @see {@link isAcyclic} for checking the required graph property
  * @category iterators
  * @since 3.18.0
  */
@@ -7844,6 +8298,11 @@ export const topo: {
  * Creates a lazy depth-first postorder traversal iterator from the configured
  * start nodes.
  *
+ * **When to use**
+ *
+ * Use when reachable descendants must be emitted before the nodes that lead to
+ * them.
+ *
  * **Details**
  *
  * Nodes are emitted after their reachable descendants have been processed. If
@@ -7851,16 +8310,14 @@ export const topo: {
  * chooses whether to follow outgoing or incoming edges. The `radius` option
  * limits traversal by edge distance from the start nodes. It accepts
  * non-negative integers and `Infinity`; omitting it means unbounded traversal.
- * Invalid radii and missing start nodes throw a `GraphError`.
+ * With a finite `radius`, a bounded breadth-first pass first determines
+ * shortest-distance membership before nodes are emitted in postorder.
  *
  * **Gotchas**
  *
- * Traversing a mutable graph captures a snapshot when iteration begins; later
- * mutations are not observed by that iterator.
- *
- * With a finite `radius`, iteration first performs a bounded breadth-first
- * traversal to determine shortest-distance membership before emitting nodes in
- * postorder.
+ * Invalid radii and missing start nodes throw a `GraphError`. Traversing a
+ * mutable graph captures a snapshot when iteration begins; later mutations are
+ * not observed by that iterator.
  *
  * **Example** (Traversing in postorder)
  *
@@ -7879,6 +8336,7 @@ export const topo: {
  * Array.from(Graph.indices(Graph.dfsPostOrder(graph, { start: [0] }))) // => [1, 2, 0]
  * ```
  *
+ * @see {@link dfs} for emitting nodes when first visited
  * @category iterators
  * @since 3.18.0
  */
@@ -8001,12 +8459,12 @@ export const dfsPostOrder: {
 })
 
 /**
- * Creates an iterator over all node indices in the graph.
+ * Creates a walker over all node index and payload entries in the graph.
  *
  * **Details**
  *
- * The iterator produces node indices in the order they were added to the graph.
- * This provides access to all nodes regardless of connectivity.
+ * Entries follow graph node order and include all nodes regardless of
+ * connectivity. Use `indices` or `values` to project one side of each entry.
  *
  * **Gotchas**
  *
@@ -8053,12 +8511,12 @@ export const nodes = <N, E, T extends Kind = "directed">(
   }))
 
 /**
- * Creates an iterator over all edge indices in the graph.
+ * Creates a walker over all edge index and edge entries in the graph.
  *
  * **Details**
  *
- * The iterator produces edge indices in the order they were added to the graph.
- * This provides access to all edges regardless of connectivity.
+ * Entries follow graph edge order and include all edges regardless of
+ * connectivity. Use `indices` or `values` to project one side of each entry.
  *
  * **Gotchas**
  *
@@ -8120,9 +8578,7 @@ export const edges = <N, E, T extends Kind = "directed">(
  * nodes with no incoming edges. If omitted, `direction` defaults to
  * `"outgoing"`.
  *
- * @see {@link externals} for the iterator that consumes this configuration
- *
- * @category models
+ * @category configuration
  * @since 3.18.0
  */
 export interface ExternalsConfig {
@@ -8132,16 +8588,20 @@ export interface ExternalsConfig {
 /**
  * Creates an iterator over external nodes (nodes without edges in the specified direction).
  *
+ * **When to use**
+ *
+ * Use when locating sources, sinks, or isolated boundary nodes.
+ *
  * **Details**
  *
  * External nodes have no outgoing edges (`direction: "outgoing"`) or no
- * incoming edges (`direction: "incoming"`). These are useful for finding
- * sources, sinks, or isolated nodes.
+ * incoming edges (`direction: "incoming"`).
  *
  * **Gotchas**
  *
- * Mutable graphs are not snapshotted; mutations may affect the remaining
- * iteration.
+ * For undirected graphs, incoming and outgoing adjacency are equivalent, so
+ * only isolated nodes are external. Mutable graphs are not snapshotted;
+ * mutations may affect the remaining iteration.
  *
  * **Example** (Iterating external nodes)
  *


### PR DESCRIPTION
## Summary

- add practical selection guidance for Graph traversal and algorithm APIs
- document snapshot, mutation-scope, set-operation, and identifier behavior under the standard JSDoc sections
- cover the newer bulk removal, bipartite matching, low-link analysis, maximum-flow, and minimum-cut APIs
- normalize categories, reduce redundant links, and simplify oversized examples

## Validation

- `pnpm lint`
- `pnpm doctest --run packages/effect/src/Graph.ts` (73 tests)
