### PR TITLE
Refactor Graph tests

### DIFF
--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -1347,10 +1347,9 @@ describe("Graph", () => {
 
   describe("bipartite graphs", () => {
     it("recognizes even, odd, disconnected, and self-loop cases", () => {
-      assert.strictEqual(
-        Graph.isBipartite(undirected([0, 1, 2, 3], [[0, 1, 1], [1, 2, 1], [2, 3, 1], [3, 0, 1]])),
-        true
-      )
+      const even = undirected([0, 1, 2, 3], [[0, 1, 1], [1, 2, 1], [2, 3, 1], [3, 0, 1]])
+      assert.strictEqual(Graph.isBipartite(even), true)
+      assert.strictEqual(Graph.isBipartite(Graph.beginMutation(even)), true)
       assert.strictEqual(Graph.isBipartite(undirected([0, 1, 2], [[0, 1, 1], [1, 2, 1], [2, 0, 1]])), false)
       assert.strictEqual(Graph.isBipartite(undirected([0, 1, 2, 3], [[0, 1, 1], [2, 3, 1]])), true)
       assert.strictEqual(Graph.isBipartite(undirected([0], [[0, 0, 1]])), false)
@@ -1549,7 +1548,7 @@ describe("Graph", () => {
       assert.deepStrictEqual(Graph.maximumFlow(graph, { source: 0, target: 1, capacity: (edge) => edge }), {
         value: 1,
         flows: new Map([[0, 0], [1, 0], [2, 0.75], [3, 1], [4, 0.25]]),
-        cut: [2, 4]
+        cut: [1, 2, 4]
       })
       assert.deepStrictEqual(Graph.maximumFlow(graph, { source: 0, target: 3, capacity: (edge) => edge }), {
         value: 0,
@@ -1691,13 +1690,14 @@ describe("Graph", () => {
     it("returns complete Dijkstra and A* paths with deterministic ties and fixed mutable parity", () => {
       const dijkstra = { source: 0, target: 3, cost: (edge: number) => edge }
       const astar = { ...dijkstra, heuristic: () => 0 }
+      const bellmanFord = { path: [0, 2, 3], edges: [1, 2], distance: 2, costs: [1, 1] }
       assertPath(Graph.dijkstra(graph, dijkstra), expected)
       assertPath(Graph.dijkstra(Graph.beginMutation(graph), dijkstra), expected)
       assertPath(Graph.dijkstra(dijkstra)(graph), expected)
       assertPath(Graph.astar(graph, astar), expected)
       assertPath(Graph.astar(Graph.beginMutation(graph), astar), expected)
       assertPath(Graph.astar(astar)(graph), expected)
-      assertPath(Graph.bellmanFord(dijkstra)(graph), expected)
+      assertPath(Graph.bellmanFord(dijkstra)(graph), bellmanFord)
       const all = Graph.floydWarshall((edge: number) => edge)(graph)
       assert.strictEqual(all.distances.get(0)?.get(3), 2)
       assert.deepStrictEqual(all.paths.get(0)?.get(3), expected.path)
@@ -1819,18 +1819,20 @@ describe("Graph", () => {
 
     it("handles unreachable and same-node paths completely", () => {
       const graph = directed<string, number>(["A", "B"], [])
+      const expected = { path: [0], edges: [], distance: 0, costs: [] }
       assert.deepStrictEqual(Graph.dijkstra(graph, { source: 0, target: 1, cost: (edge) => edge }), Option.none())
-      assertPath(Graph.dijkstra(graph, { source: 0, target: 0, cost: (edge) => edge }), {
-        path: [0],
-        edges: [],
-        distance: 0,
-        costs: []
-      })
+      assertPath(Graph.dijkstra(graph, { source: 0, target: 0, cost: (edge) => edge }), expected)
+      assertPath(Graph.astar(graph, { source: 0, target: 0, cost: (edge) => edge, heuristic: () => 0 }), expected)
+      assertPath(Graph.bellmanFord(graph, { source: 0, target: 0, cost: (edge) => edge }), expected)
       const all = Graph.floydWarshall(graph, (edge) => edge)
       assert.strictEqual(all.distances.get(0)?.get(1), Infinity)
       assert.strictEqual(all.paths.get(0)?.get(1), null)
       assert.deepStrictEqual(all.edges.get(0)?.get(1), [])
       assert.deepStrictEqual(all.costs.get(0)?.get(1), [])
+      assert.strictEqual(all.distances.get(0)?.get(0), 0)
+      assert.deepStrictEqual(all.paths.get(0)?.get(0), [0])
+      assert.deepStrictEqual(all.edges.get(0)?.get(0), [])
+      assert.deepStrictEqual(all.costs.get(0)?.get(0), [])
     })
 
     it("uses negative Bellman-Ford edges in shortest paths", () => {
@@ -2143,10 +2145,13 @@ describe("Graph", () => {
 
     it("handles empty path enumerations", () => {
       const graph = directed<string, number>(["A", "B"], [])
+      const same = [{ path: [0], edges: [], distance: 0, costs: [] }]
 
-      assert.deepStrictEqual(Array.from(Graph.simplePaths(graph, { source: 0, target: 0 })), [
-        { path: [0], edges: [], distance: 0, costs: [] }
-      ])
+      assert.deepStrictEqual(Array.from(Graph.simplePaths(graph, { source: 0, target: 0 })), same)
+      assert.deepStrictEqual(
+        Array.from(Graph.allShortestPaths(graph, { source: 0, target: 0, cost: (edge) => edge })),
+        same
+      )
       assert.deepStrictEqual(
         Array.from(Graph.allShortestPaths(graph, { source: 0, target: 1, cost: (edge) => edge })),
         []

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -1,3595 +1,1233 @@
-import { assert } from "@effect/vitest"
-import { assertNone, assertSome, strictEqual, throws } from "@effect/vitest/utils"
+import { assert, describe, it } from "@effect/vitest"
 import { Equal, Graph, Hash, Option } from "effect"
-import { describe, expect, it } from "vitest"
 
-const assertSomeEdge = <E>(edge: Option.Option<Graph.Edge<E>>): Graph.Edge<E> => {
-  if (Option.isNone(edge)) {
-    throw new Error("Expected edge to be present")
-  }
-  return edge.value
-}
-
-const makeReversedUndirectedPath = () =>
-  Graph.undirected<string, number>((mutable) => {
-    const a = Graph.addNode(mutable, "A")
-    const b = Graph.addNode(mutable, "B")
-    const c = Graph.addNode(mutable, "C")
-    Graph.addEdge(mutable, a, b, 1)
-    Graph.addEdge(mutable, c, b, 1)
+const directed = <N, E>(
+  nodes: ReadonlyArray<N>,
+  edges: ReadonlyArray<readonly [Graph.NodeIndex, Graph.NodeIndex, E]>
+) =>
+  Graph.directed<N, E>((mutable) => {
+    for (const node of nodes) Graph.addNode(mutable, node)
+    for (const [source, target, data] of edges) Graph.addEdge(mutable, source, target, data)
   })
 
-const makeSingleEdgeGraph = (weight: number) =>
-  Graph.directed<string, number>((mutable) => {
-    const source = Graph.addNode(mutable, "source")
-    const target = Graph.addNode(mutable, "target")
-    Graph.addEdge(mutable, source, target, weight)
+const undirected = <N, E>(
+  nodes: ReadonlyArray<N>,
+  edges: ReadonlyArray<readonly [Graph.NodeIndex, Graph.NodeIndex, E]>
+) =>
+  Graph.undirected<N, E>((mutable) => {
+    for (const node of nodes) Graph.addNode(mutable, node)
+    for (const [source, target, data] of edges) Graph.addEdge(mutable, source, target, data)
   })
 
-const makeMutableWeightedPath = () =>
-  Graph.beginMutation(Graph.directed<string, number>((mutable) => {
-    Graph.addNode(mutable, "source")
-    Graph.addNode(mutable, "middle")
-    Graph.addNode(mutable, "target")
-    Graph.addEdge(mutable, 0, 1, 1)
-    Graph.addEdge(mutable, 1, 2, 1)
-    Graph.addEdge(mutable, 0, 2, 3)
-  }))
-
-const unsupportedEdgeWeights = [NaN, -Infinity] as const
-
-const assertGraphError = (thunk: () => void, message: string) => {
-  throws(thunk, (error) => {
-    strictEqual(error instanceof Graph.GraphError, true)
-    if (error instanceof Graph.GraphError) {
-      strictEqual(error.message, message)
-    }
-  })
+const assertGraphError = (thunk: () => unknown, message: string): void => {
+  let error: unknown
+  try {
+    thunk()
+  } catch (cause) {
+    error = cause
+  }
+  assert.ok(error instanceof Graph.GraphError)
+  assert.strictEqual(error.message, message)
 }
 
-type SetNode = { readonly id: string; readonly label: string }
-
-class SetNodeKey implements Equal.Equal {
-  readonly id: string
-
-  constructor(id: string) {
-    this.id = id
-  }
-
-  [Equal.symbol](that: Equal.Equal): boolean {
-    return that instanceof SetNodeKey && this.id === that.id
-  }
-
-  [Hash.symbol](): number {
-    return Hash.string(this.id)
-  }
+const assertSnapshot = <N, E, T extends Graph.Kind>(
+  graph: Graph.Graph<N, E, T> | Graph.MutableGraph<N, E, T>,
+  expected: Graph.Snapshot<N, E, T>
+): void => {
+  assert.deepStrictEqual(Graph.toSnapshot(graph), expected)
 }
 
-const graphNodeIds = <E, T extends Graph.Kind>(graph: Graph.Graph<SetNode, E, T>) =>
-  new Set(Array.from(graph, ([, node]) => node.id))
-
-const graphNodeLabels = <E, T extends Graph.Kind>(graph: Graph.Graph<SetNode, E, T>) =>
-  new Map(Array.from(graph, ([, node]) => [node.id, node.label]))
-
-const graphEdgeKeys = <E, T extends Graph.Kind>(graph: Graph.Graph<SetNode, E, T>) => {
-  const nodeIds = new Map(Array.from(graph, ([index, node]) => [index, node.id]))
-  return new Set(
-    Array.from(Graph.edges(graph), ([, edge]) =>
-      graph.type === "directed"
-        ? `${nodeIds.get(edge.source)}->${nodeIds.get(edge.target)}`
-        : `${nodeIds.get(edge.source)}--${nodeIds.get(edge.target)}`)
-  )
+const assertPath = <E>(actual: Option.Option<Graph.PathResult<E>>, expected: Graph.PathResult<E>): void => {
+  assert.deepStrictEqual(actual, Option.some(expected))
 }
 
-const graphEdgeData = <E, T extends Graph.Kind>(graph: Graph.Graph<SetNode, E, T>) => {
-  const nodeIds = new Map(Array.from(graph, ([index, node]) => [index, node.id]))
-  return new Map(
-    Array.from(
-      Graph.edges(graph),
-      ([, edge]) => [
-        graph.type === "directed"
-          ? `${nodeIds.get(edge.source)}->${nodeIds.get(edge.target)}`
-          : `${nodeIds.get(edge.source)}--${nodeIds.get(edge.target)}`,
-        edge.data
-      ]
-    )
-  )
+const assertComponents = (
+  actual: ReadonlyArray<ReadonlyArray<number>>,
+  expected: ReadonlyArray<ReadonlyArray<number>>
+) => {
+  const canonicalize = (components: ReadonlyArray<ReadonlyArray<number>>) =>
+    components.map((component) => Array.from(component).sort((a, b) => a - b)).sort((a, b) => a[0] - b[0])
+  assert.deepStrictEqual(canonicalize(actual), canonicalize(expected))
+}
+
+const assertIndices = <N>(walker: Graph.NodeWalker<N>, expected: ReadonlyArray<number>): void => {
+  assert.deepStrictEqual(Array.from(Graph.indices(walker)), expected)
 }
 
 describe("Graph", () => {
-  describe("constructors", () => {
-    it("should create empty directed graph", () => {
-      const graph = Graph.directed<string, number>()
-
-      expect(graph.type).toBe("directed")
-      expect(Graph.nodeCount(graph)).toBe(0)
-      expect(Graph.edgeCount(graph)).toBe(0)
-    })
-
-    it("should create empty undirected graph", () => {
-      const graph = Graph.undirected<string, number>()
-
-      expect(graph.type).toBe("undirected")
-      expect(Graph.nodeCount(graph)).toBe(0)
-      expect(Graph.edgeCount(graph)).toBe(0)
-    })
-
-    it("reconstructs a graph from a snapshot", () => {
-      const graph = Graph.fromSnapshot({
-        type: "directed",
-        nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }],
-        edges: [{ index: 3, source: 2, target: 5, data: 1 }]
-      })
-
-      assert.strictEqual(graph.mutable, false)
-      assert.deepStrictEqual(Array.from(graph), [[2, "A"], [5, "B"]])
-      assert.deepStrictEqual(
-        Array.from(Graph.edges(graph), ([index, edge]) => ({ index, ...edge })),
-        [{ index: 3, source: 2, target: 5, data: 1 }]
-      )
-      assert.deepStrictEqual(Graph.successors(graph, 2), [5])
-    })
-
-    it("rebuilds undirected adjacency and preserves edge orientation", () => {
-      const graph = Graph.fromSnapshot({
-        type: "undirected",
-        nodes: [{ index: 1, data: "A" }, { index: 4, data: "B" }],
-        edges: [{ index: 2, source: 4, target: 1, data: 1 }]
-      })
-
-      assert.deepStrictEqual(Graph.neighbors(graph, 1), [4])
-      assert.deepStrictEqual(Graph.neighbors(graph, 4), [1])
-      assert.deepStrictEqual(
-        Option.getOrThrow(Graph.getEdge(graph, 2)),
-        { source: 4, target: 1, data: 1 }
-      )
-    })
-
-    it("allocates after the highest snapshot indexes", () => {
-      const graph = Graph.fromSnapshot({
-        type: "directed",
-        nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }],
-        edges: [{ index: 4, source: 2, target: 5, data: 1 }]
-      })
-
-      Graph.mutate(graph, (mutable) => {
-        assert.strictEqual(Graph.addNode(mutable, "C"), 6)
-        assert.strictEqual(Graph.addEdge(mutable, 2, 5, 2), 5)
-      })
-    })
-
-    it("rejects allocations after the safe index range is exhausted", () => {
-      const nodesExhausted = Graph.fromSnapshot({
-        type: "directed",
-        nodes: [{ index: Number.MAX_SAFE_INTEGER, data: "A" }],
-        edges: []
-      })
-      const mutableNodes = Graph.beginMutation(nodesExhausted)
-      assertGraphError(() => Graph.addNode(mutableNodes, "B"), "Graph has exhausted safe node indexes")
-
-      const edgesExhausted = Graph.fromSnapshot({
-        type: "directed",
-        nodes: [{ index: 0, data: "A" }],
-        edges: [{ index: Number.MAX_SAFE_INTEGER, source: 0, target: 0, data: 1 }]
-      })
-      const mutableEdges = Graph.beginMutation(edgesExhausted)
-      assertGraphError(() => Graph.addEdge(mutableEdges, 0, 0, 2), "Graph has exhausted safe edge indexes")
-    })
-
-    it("rejects invalid snapshot indexes", () => {
-      assertGraphError(
-        () =>
-          Graph.fromSnapshot({ type: "invalid", nodes: [], edges: [] } as unknown as Graph.Snapshot<
-            never,
-            never,
-            Graph.Kind
-          >),
-        "Snapshot type must be directed or undirected"
-      )
-      assertGraphError(
-        () => Graph.fromSnapshot({ type: "directed", nodes: [{ index: -1, data: "A" }], edges: [] }),
-        "Node index at position 0 must be a non-negative safe integer"
-      )
-      assertGraphError(
-        () =>
-          Graph.fromSnapshot({
-            type: "directed",
-            nodes: [{ index: 1, data: "A" }, { index: 1, data: "B" }],
-            edges: []
-          }),
-        "Node indexes must be strictly increasing"
-      )
-      assertGraphError(
-        () =>
-          Graph.fromSnapshot({
-            type: "directed",
-            nodes: [{ index: 0, data: "A" }],
-            edges: [{ index: 0.5, source: 0, target: 0, data: 1 }]
-          }),
-        "Edge index at position 0 must be a non-negative safe integer"
-      )
-      assertGraphError(
-        () =>
-          Graph.fromSnapshot({
-            type: "directed",
-            nodes: [{ index: 0, data: "A" }],
-            edges: [
-              { index: 1, source: 0, target: 0, data: 1 },
-              { index: 1, source: 0, target: 0, data: 2 }
-            ]
-          }),
-        "Edge indexes must be strictly increasing"
-      )
-      assertGraphError(
-        () =>
-          Graph.fromSnapshot({
-            type: "directed",
-            nodes: [{ index: 0, data: "A" }],
-            edges: [{ index: 0, source: -1, target: 0, data: 1 }]
-          }),
-        "Edge source at position 0 must be a non-negative safe integer"
-      )
-      assertGraphError(
-        () => Graph.fromSnapshot({ type: "directed", nodes: new Array(1), edges: [] }),
-        "Node at position 0 must be defined"
-      )
-      assertGraphError(
-        () => Graph.fromSnapshot({ type: "directed", nodes: [], edges: new Array(1) }),
-        "Edge at position 0 must be defined"
-      )
-    })
-
-    it("rejects dangling snapshot endpoints", () => {
-      assertGraphError(
-        () =>
-          Graph.fromSnapshot({
-            type: "directed",
-            nodes: [{ index: 1, data: "A" }],
-            edges: [{ index: 0, source: 0, target: 1, data: 1 }]
-          }),
-        "Edge source 0 does not reference a node"
-      )
-      assertGraphError(
-        () =>
-          Graph.fromSnapshot({
-            type: "directed",
-            nodes: [{ index: 1, data: "A" }],
-            edges: [{ index: 0, source: 1, target: 2, data: 1 }]
-          }),
-        "Edge target 2 does not reference a node"
-      )
-    })
-
-    describe("toSnapshot", () => {
-      it("preserves empty graphs and supports mutable graphs", () => {
-        assert.deepStrictEqual(Graph.toSnapshot(Graph.directed()), { type: "directed", nodes: [], edges: [] })
-        const mutable = Graph.beginMutation(Graph.undirected<string, number>())
-        Graph.addNode(mutable, "A")
-        assert.deepStrictEqual(Graph.toSnapshot(mutable), {
-          type: "undirected",
-          nodes: [{ index: 0, data: "A" }],
-          edges: []
-        })
-      })
-
-      it("preserves sparse indexes, parallel edges, self-loops, and stored orientation", () => {
-        const graph = Graph.fromSnapshot({
-          type: "undirected",
-          nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }],
-          edges: [
-            { index: 3, source: 5, target: 2, data: "first" },
-            { index: 7, source: 5, target: 2, data: "parallel" },
-            { index: 11, source: 5, target: 5, data: "loop" }
-          ]
-        })
-        const snapshot = Graph.toSnapshot(graph)
-
-        assert.deepStrictEqual(snapshot, {
-          type: "undirected",
-          nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }],
-          edges: [
-            { index: 3, source: 5, target: 2, data: "first" },
-            { index: 7, source: 5, target: 2, data: "parallel" },
-            { index: 11, source: 5, target: 5, data: "loop" }
-          ]
-        })
-        assert.strictEqual(Equal.equals(Graph.fromSnapshot(snapshot), graph), true)
-      })
-
-      it("does not expose stored edge records", () => {
-        const graph = makeSingleEdgeGraph(1)
-        const snapshot = Graph.toSnapshot(graph)
-        const edge = snapshot.edges[0] as { source: number; target: number; data: number }
-        edge.source = 1
-        edge.data = 2
-
-        assert.deepStrictEqual(Option.getOrThrow(Graph.getEdge(graph, 0)), { source: 0, target: 1, data: 1 })
-      })
-    })
-  })
-
-  describe("equality and hashing", () => {
-    const makeGraph = (
-      type: Graph.Kind,
-      edges: ReadonlyArray<readonly [Graph.NodeIndex, Graph.NodeIndex, string]>
-    ) =>
-      Graph.make(type)<string, string>((mutable) => {
-        Graph.addNode(mutable, "A")
-        Graph.addNode(mutable, "B")
-        for (const [source, target, data] of edges) {
-          Graph.addEdge(mutable, source, target, data)
-        }
-      })
-
-    it("equal graphs have equal hashes", () => {
-      const cases = [
-        {
-          name: "directed graphs",
-          make: () => [makeGraph("directed", [[0, 1, "edge"]]), makeGraph("directed", [[0, 1, "edge"]])] as const
-        },
-        {
-          name: "undirected graphs with reversed endpoints",
-          make: () => [makeGraph("undirected", [[0, 1, "edge"]]), makeGraph("undirected", [[1, 0, "edge"]])] as const
-        },
-        {
-          name: "sparse indexes",
-          make: () => {
-            const snapshot = {
-              type: "directed",
-              nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }],
-              edges: [{ index: 4, source: 2, target: 5, data: "edge" }]
-            } as const
-            return [Graph.fromSnapshot(snapshot), Graph.fromSnapshot(snapshot)] as const
-          }
-        },
-        {
-          name: "self-loops",
-          make: () => [makeGraph("undirected", [[0, 0, "loop"]]), makeGraph("undirected", [[0, 0, "loop"]])] as const
-        },
-        {
-          name: "parallel edges",
-          make: () =>
-            [
-              makeGraph("undirected", [[0, 1, "first"], [0, 1, "second"]]),
-              makeGraph("undirected", [[1, 0, "first"], [1, 0, "second"]])
-            ] as const
-        },
-        {
-          name: "undefined payloads",
-          make: () => {
-            const make = () =>
-              Graph.directed<undefined, undefined>((mutable) => {
-                const source = Graph.addNode(mutable, undefined)
-                const target = Graph.addNode(mutable, undefined)
-                Graph.addEdge(mutable, source, target, undefined)
-              })
-            return [make(), make()] as const
-          }
-        }
-      ]
-
-      for (const { make, name } of cases) {
-        const [left, right] = make()
-        assert.strictEqual(Equal.equals(left, right), true, name)
-        assert.strictEqual(Hash.hash(left), Hash.hash(right), name)
-      }
-    })
-
-    it("treats undirected edge endpoints as unordered", () => {
-      const left = makeGraph("undirected", [[0, 1, "edge"]])
-      const right = makeGraph("undirected", [[1, 0, "edge"]])
-
-      strictEqual(Equal.equals(left, right), true)
-      strictEqual(Equal.equals(right, left), true)
-    })
-
-    it("keeps directed edge endpoints ordered", () => {
-      const left = makeGraph("directed", [[0, 1, "edge"]])
-      const right = makeGraph("directed", [[1, 0, "edge"]])
-
-      strictEqual(Equal.equals(left, right), false)
-      strictEqual(Equal.equals(right, left), false)
-    })
-
-    it("compares undirected edge data", () => {
-      const left = makeGraph("undirected", [[0, 1, "left"]])
-      const right = makeGraph("undirected", [[1, 0, "right"]])
-
-      strictEqual(Equal.equals(left, right), false)
-    })
-
-    it("keeps parallel edges paired by edge index", () => {
-      const left = makeGraph("undirected", [[0, 1, "first"], [0, 1, "second"]])
-      const reversed = makeGraph("undirected", [[1, 0, "first"], [1, 0, "second"]])
-      const reordered = makeGraph("undirected", [[1, 0, "second"], [1, 0, "first"]])
-
-      strictEqual(Equal.equals(left, reversed), true)
-      strictEqual(Equal.equals(left, reordered), false)
-    })
-
-    it("keeps Graph.Edge endpoint equality ordered", () => {
-      const left: Graph.Edge<string> = { source: 0, target: 1, data: "edge" }
-      const right: Graph.Edge<string> = { source: 1, target: 0, data: "edge" }
-
-      strictEqual(Equal.equals(left, right), false)
-    })
-
-    it("ignores removed trailing node allocation history", () => {
-      const left = makeGraph("directed", [[0, 1, "edge"]])
-      const right = Graph.directed<string, string>((mutable) => {
-        const source = Graph.addNode(mutable, "A")
-        const target = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, source, target, "edge")
-        const node = Graph.addNode(mutable, "removed")
-        Graph.removeNode(mutable, node)
-      })
-
-      assert.deepStrictEqual(Array.from(left), Array.from(right))
-      assert.deepStrictEqual(Array.from(Graph.edges(left)), Array.from(Graph.edges(right)))
-      strictEqual(Equal.equals(left, right), true)
-      strictEqual(Hash.hash(left), Hash.hash(right))
-
-      let leftNode: Graph.NodeIndex | undefined
-      let rightNode: Graph.NodeIndex | undefined
-      Graph.mutate(left, (mutable) => {
-        leftNode = Graph.addNode(mutable, "next")
-      })
-      Graph.mutate(right, (mutable) => {
-        rightNode = Graph.addNode(mutable, "next")
-      })
-
-      strictEqual(leftNode, 2)
-      strictEqual(rightNode, 3)
-    })
-
-    it("ignores removed trailing edge allocation history", () => {
-      const left = makeGraph("directed", [[0, 1, "edge"]])
-      const right = Graph.directed<string, string>((mutable) => {
-        const source = Graph.addNode(mutable, "A")
-        const target = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, source, target, "edge")
-        const edge = Graph.addEdge(mutable, source, target, "removed")
-        Graph.removeEdge(mutable, edge)
-      })
-
-      assert.deepStrictEqual(Array.from(left), Array.from(right))
-      assert.deepStrictEqual(Array.from(Graph.edges(left)), Array.from(Graph.edges(right)))
-      strictEqual(Equal.equals(left, right), true)
-      strictEqual(Hash.hash(left), Hash.hash(right))
-
-      let leftEdge: Graph.EdgeIndex | undefined
-      let rightEdge: Graph.EdgeIndex | undefined
-      Graph.mutate(left, (mutable) => {
-        leftEdge = Graph.addEdge(mutable, 0, 1, "next")
-      })
-      Graph.mutate(right, (mutable) => {
-        rightEdge = Graph.addEdge(mutable, 0, 1, "next")
-      })
-
-      strictEqual(leftEdge, 1)
-      strictEqual(rightEdge, 2)
-    })
-
-    it("preserves allocator equality and hashing through an empty mutation", () => {
-      const graph = Graph.directed<string, string>((mutable) => {
-        const source = Graph.addNode(mutable, "A")
-        const target = Graph.addNode(mutable, "B")
-        const removed = Graph.addNode(mutable, "removed")
-        Graph.removeNode(mutable, removed)
-        const edge = Graph.addEdge(mutable, source, target, "removed")
-        Graph.removeEdge(mutable, edge)
-      })
-      const clone = Graph.mutate(graph, () => {})
-
-      strictEqual(Equal.equals(graph, clone), true)
-      strictEqual(Hash.hash(graph), Hash.hash(clone))
-    })
-
-    it("uses stable reference equality and hashing for mutable graphs", () => {
-      const mutable = Graph.beginMutation(Graph.directed<string, string>())
-      const initialHash = Hash.hash(mutable)
-
-      strictEqual(Equal.equals(mutable, mutable), true)
-      const source = Graph.addNode(mutable, "A")
-      const target = Graph.addNode(mutable, "B")
-      Graph.addEdge(mutable, source, target, "edge")
-
-      strictEqual(Hash.hash(mutable), initialHash)
-      strictEqual(Equal.equals(mutable, mutable), true)
-    })
-
-    it("does not structurally compare independently constructed mutable graphs", () => {
-      const graph = makeGraph("directed", [[0, 1, "edge"]])
-      const left = Graph.beginMutation(graph)
-      const right = Graph.beginMutation(graph)
-
-      strictEqual(Equal.equals(left, right), false)
-      strictEqual(Equal.equals(right, left), false)
-    })
-
-    it("restores structural equality and hashing after finalization", () => {
-      const mutable = Graph.beginMutation(Graph.directed<string, string>())
-      Hash.hash(mutable)
-      const source = Graph.addNode(mutable, "A")
-      const target = Graph.addNode(mutable, "B")
-      Graph.addEdge(mutable, source, target, "edge")
-
-      const graph = Graph.endMutation(mutable)
-      const expected = makeGraph("directed", [[0, 1, "edge"]])
-
-      strictEqual(Equal.equals(graph, expected), true)
-      strictEqual(Hash.hash(graph), Hash.hash(expected))
-    })
-  })
-
-  describe("set operations", () => {
-    const makeLeft = () =>
-      Graph.directed<{ readonly id: string; readonly label: string }, string>((mutable) => {
-        const a = Graph.addNode(mutable, { id: "a", label: "A1" })
-        const b = Graph.addNode(mutable, { id: "b", label: "B1" })
-        const c = Graph.addNode(mutable, { id: "c", label: "C1" })
-        Graph.addEdge(mutable, a, b, "left-ab")
-        Graph.addEdge(mutable, b, c, "shared-bc")
-      })
-
-    const makeRight = () =>
-      Graph.directed<{ readonly id: string; readonly label: string }, string>((mutable) => {
-        const b = Graph.addNode(mutable, { id: "b", label: "B2" })
-        const c = Graph.addNode(mutable, { id: "c", label: "C2" })
-        const d = Graph.addNode(mutable, { id: "d", label: "D2" })
-        Graph.addEdge(mutable, b, c, "shared-bc")
-        Graph.addEdge(mutable, c, d, "right-cd")
-      })
-
-    it("compose merges nodes and edges by identity", () => {
-      const graph = Graph.compose(makeLeft(), makeRight(), { nodeIdentity: (node) => node.id })
-
-      assert.deepStrictEqual(graphNodeIds(graph), new Set(["a", "b", "c", "d"]))
-      assert.deepStrictEqual(
-        graphNodeLabels(graph),
-        new Map([
-          ["a", "A1"],
-          ["b", "B2"],
-          ["c", "C2"],
-          ["d", "D2"]
-        ])
-      )
-      assert.deepStrictEqual(graphEdgeKeys(graph), new Set(["a->b", "b->c", "c->d"]))
-      assert.deepStrictEqual(
-        graphEdgeData(graph),
-        new Map([
-          ["a->b", "left-ab"],
-          ["b->c", "shared-bc"],
-          ["c->d", "right-cd"]
-        ])
-      )
-    })
-
-    it("intersection keeps shared nodes and shared edges", () => {
-      const graph = Graph.intersection(makeLeft(), makeRight(), { nodeIdentity: (node) => node.id })
-
-      assert.deepStrictEqual(graphNodeIds(graph), new Set(["b", "c"]))
-      assert.deepStrictEqual(
-        graphNodeLabels(graph),
-        new Map([
-          ["b", "B1"],
-          ["c", "C1"]
-        ])
-      )
-      assert.deepStrictEqual(graphEdgeKeys(graph), new Set(["b->c"]))
-      assert.deepStrictEqual(graphEdgeData(graph), new Map([["b->c", "shared-bc"]]))
-    })
-
-    it("difference preserves self nodes and removes shared edges", () => {
-      const graph = Graph.difference(makeLeft(), makeRight(), { nodeIdentity: (node) => node.id })
-
-      assert.deepStrictEqual(graphNodeIds(graph), new Set(["a", "b", "c"]))
-      assert.deepStrictEqual(
-        graphNodeLabels(graph),
-        new Map([
-          ["a", "A1"],
-          ["b", "B1"],
-          ["c", "C1"]
-        ])
-      )
-      assert.deepStrictEqual(graphEdgeKeys(graph), new Set(["a->b"]))
-      assert.deepStrictEqual(graphEdgeData(graph), new Map([["a->b", "left-ab"]]))
-    })
-
-    it("symmetricDifference keeps edges present in exactly one graph", () => {
-      const graph = Graph.symmetricDifference(makeLeft(), makeRight(), { nodeIdentity: (node) => node.id })
-
-      assert.deepStrictEqual(graphNodeIds(graph), new Set(["a", "b", "c", "d"]))
-      assert.deepStrictEqual(
-        graphNodeLabels(graph),
-        new Map([
-          ["a", "A1"],
-          ["b", "B2"],
-          ["c", "C2"],
-          ["d", "D2"]
-        ])
-      )
-      assert.deepStrictEqual(graphEdgeKeys(graph), new Set(["a->b", "c->d"]))
-      assert.deepStrictEqual(
-        graphEdgeData(graph),
-        new Map([
-          ["a->b", "left-ab"],
-          ["c->d", "right-cd"]
-        ])
-      )
-    })
-
-    it("uses node data as identity by default", () => {
-      const left = Graph.directed<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, "shared")
-      })
-      const right = Graph.directed<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, "shared")
-      })
-
-      strictEqual(Graph.nodeCount(Graph.compose(left, right)), 2)
-      strictEqual(Graph.edgeCount(left.pipe(Graph.intersection(right))), 1)
-      strictEqual(Graph.edgeCount(Graph.difference(left, right)), 0)
-      strictEqual(Graph.edgeCount(left.pipe(Graph.symmetricDifference(right))), 0)
-    })
-
-    it("supports hashable node identities", () => {
-      const graph = Graph.compose(makeLeft(), makeRight(), {
-        nodeIdentity: (node) => new SetNodeKey(node.id)
-      })
-
-      strictEqual(Graph.nodeCount(graph), 4)
-      strictEqual(Graph.edgeCount(graph), 3)
-    })
-
-    it("supports undefined node data and identities", () => {
-      const left = Graph.directed<undefined, never>((mutable) => {
-        Graph.addNode(mutable, undefined)
-      })
-      const right = Graph.directed<undefined, never>((mutable) => {
-        Graph.addNode(mutable, undefined)
-      })
-
-      strictEqual(Graph.nodeCount(Graph.compose(left, right)), 1)
-    })
-
-    it("coalesces duplicate node identities", () => {
-      const left = Graph.directed<SetNode, string>((mutable) => {
-        const first = Graph.addNode(mutable, { id: "a", label: "first" })
-        const last = Graph.addNode(mutable, { id: "a", label: "last" })
-        Graph.addEdge(mutable, first, last, "same")
-      })
-      const right = Graph.directed<SetNode, string>()
-      const result = Graph.compose(left, right, { nodeIdentity: (node) => node.id })
-      const edge = Array.from(Graph.edges(result))[0][1]
-
-      strictEqual(Graph.nodeCount(result), 1)
-      strictEqual(Array.from(Graph.values(Graph.nodes(result)))[0].label, "last")
-      strictEqual(edge.source, edge.target)
-    })
-
-    it("includes edge data in edge identity", () => {
-      const left = Graph.directed<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, "left")
-      })
-      const right = Graph.directed<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, "right")
-      })
-
-      strictEqual(Graph.edgeCount(Graph.compose(left, right)), 2)
-      strictEqual(Graph.edgeCount(Graph.intersection(left, right)), 0)
-      strictEqual(Graph.edgeCount(Graph.difference(left, right)), 1)
-      strictEqual(Graph.edgeCount(Graph.symmetricDifference(left, right)), 2)
-    })
-
-    it("uses edge data from that for equivalent edges", () => {
-      const left = Graph.directed<string, { readonly id: string; readonly label: string }>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, { id: "shared", label: "left" })
-      })
-      const right = Graph.directed<string, { readonly id: string; readonly label: string }>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, { id: "shared", label: "right" })
-      })
-      const options = { edgeIdentity: (edge: { readonly id: string }) => edge.id }
-
-      strictEqual(Array.from(Graph.edges(Graph.compose(left, right, options)))[0][1].data.label, "right")
-      strictEqual(Array.from(Graph.edges(Graph.intersection(left, right, options)))[0][1].data.label, "right")
-    })
-
-    it("deduplicates equal edges in intersections", () => {
-      const left = Graph.directed<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, "shared")
-      })
-      const right = Graph.directed<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, "shared")
-        Graph.addEdge(mutable, a, b, "shared")
-      })
-
-      strictEqual(Graph.edgeCount(Graph.intersection(left, right)), 1)
-    })
-
-    it("treats equal parallel edges as set members rather than occurrences", () => {
-      const left = Graph.directed<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, "shared")
-        Graph.addEdge(mutable, a, b, "shared")
-      })
-      const empty = Graph.directed<string, string>()
-      const right = Graph.directed<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, "shared")
-      })
-
-      strictEqual(Graph.edgeCount(Graph.compose(left, empty)), 1)
-      strictEqual(Graph.edgeCount(Graph.intersection(left, right)), 1)
-      strictEqual(Graph.edgeCount(Graph.difference(left, empty)), 2)
-      strictEqual(Graph.edgeCount(Graph.difference(left, right)), 0)
-      strictEqual(Graph.edgeCount(Graph.symmetricDifference(left, empty)), 1)
-    })
-
-    it("rejects graphs with different kinds", () => {
-      const directed: Graph.Graph<string, string, Graph.Kind> = Graph.directed()
-      const undirected: Graph.Graph<string, string, Graph.Kind> = Graph.undirected()
-
-      throws(
-        () => Graph.compose(directed, undirected),
-        (error) => {
-          strictEqual(error instanceof Graph.GraphError, true)
-          if (error instanceof Graph.GraphError) {
-            strictEqual(error.message, "Cannot combine directed and undirected graphs")
-          }
-        }
-      )
-      throws(() => Graph.sum(directed, undirected), (error) => {
-        strictEqual(error instanceof Graph.GraphError, true)
-      })
-    })
-
-    it("matches undirected edges regardless of endpoint order", () => {
-      const left = Graph.undirected<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, "shared")
-      })
-      const right = Graph.undirected<string, string>((mutable) => {
-        const b = Graph.addNode(mutable, "B")
-        const a = Graph.addNode(mutable, "A")
-        Graph.addEdge(mutable, b, a, "shared")
-      })
-
-      const options = { nodeIdentity: (node: string) => new SetNodeKey(node) }
-      strictEqual(Graph.edgeCount(Graph.intersection(left, right, options)), 1)
-      strictEqual(Graph.edgeCount(Graph.difference(left, right, options)), 0)
-    })
-
-    it("complement adds missing directed edges", () => {
-      const graph = Graph.directed<SetNode, string>((mutable) => {
-        const a = Graph.addNode(mutable, { id: "a", label: "A" })
-        const b = Graph.addNode(mutable, { id: "b", label: "B" })
-        const c = Graph.addNode(mutable, { id: "c", label: "C" })
-        Graph.addEdge(mutable, a, b, "A-B")
-        Graph.addEdge(mutable, b, c, "B-C")
-      })
-
-      const result = Graph.complement(graph, (source, target) => `${source.label}-${target.label}`)
-
-      strictEqual(Graph.nodeCount(result), 3)
-      strictEqual(Graph.edgeCount(result), 4)
-      assert.deepStrictEqual(
-        graphEdgeData(result),
-        new Map([
-          ["a->c", "A-C"],
-          ["b->a", "B-A"],
-          ["c->a", "C-A"],
-          ["c->b", "C-B"]
-        ])
-      )
-    })
-
-    it("complement adds missing undirected edges once", () => {
-      const graph = Graph.undirected<SetNode, string>((mutable) => {
-        const a = Graph.addNode(mutable, { id: "A", label: "A" })
-        const b = Graph.addNode(mutable, { id: "B", label: "B" })
-        Graph.addNode(mutable, { id: "C", label: "C" })
-        Graph.addEdge(mutable, a, b, "A-B")
-      })
-
-      const result = Graph.complement(graph, (source, target) => `${source.label}-${target.label}`)
-
-      strictEqual(result.type, "undirected")
-      strictEqual(Graph.edgeCount(result), 2)
-      assert.deepStrictEqual(
-        graphEdgeData(result),
-        new Map([
-          ["A--C", "A-C"],
-          ["B--C", "B-C"]
-        ])
-      )
-    })
-
-    it("neighborhood returns the induced subgraph within radius", () => {
-      const graph = Graph.directed<SetNode, string>((mutable) => {
-        const a = Graph.addNode(mutable, { id: "A", label: "A" })
-        const b = Graph.addNode(mutable, { id: "B", label: "B" })
-        const c = Graph.addNode(mutable, { id: "C", label: "C" })
-        const d = Graph.addNode(mutable, { id: "D", label: "D" })
-        Graph.addEdge(mutable, a, b, "A-B")
-        Graph.addEdge(mutable, b, c, "B-C")
-        Graph.addEdge(mutable, c, d, "C-D")
-        Graph.addEdge(mutable, c, b, "C-B")
-      })
-
-      const result = Graph.neighborhood(graph, 1, { radius: 1, direction: "outgoing" })
-
-      assert.deepStrictEqual(graphNodeIds(result), new Set(["B", "C"]))
-      assert.deepStrictEqual(graphEdgeKeys(result), new Set(["B->C", "C->B"]))
-    })
-
-    it("neighborhood follows outgoing edges by default", () => {
-      const graph = Graph.directed<SetNode, string>((mutable) => {
-        const a = Graph.addNode(mutable, { id: "A", label: "A" })
-        const b = Graph.addNode(mutable, { id: "B", label: "B" })
-        const c = Graph.addNode(mutable, { id: "C", label: "C" })
-        Graph.addEdge(mutable, a, b, "A-B")
-        Graph.addEdge(mutable, b, c, "B-C")
-      })
-
-      const result = Graph.neighborhood(graph, 1)
-
-      assert.deepStrictEqual(graphNodeIds(result), new Set(["B", "C"]))
-      assert.deepStrictEqual(graphEdgeKeys(result), new Set(["B->C"]))
-    })
-
-    it("neighborhood can ignore edge direction", () => {
-      const graph = Graph.directed<SetNode, string>((mutable) => {
-        const a = Graph.addNode(mutable, { id: "A", label: "A" })
-        const b = Graph.addNode(mutable, { id: "B", label: "B" })
-        const c = Graph.addNode(mutable, { id: "C", label: "C" })
-        Graph.addEdge(mutable, a, b, "A-B")
-        Graph.addEdge(mutable, a, c, "A-C")
-      })
-
-      const result = Graph.neighborhood(graph, 1, { radius: 2, direction: "undirected" })
-
-      assert.deepStrictEqual(graphNodeIds(result), new Set(["A", "B", "C"]))
-      assert.deepStrictEqual(graphEdgeKeys(result), new Set(["A->B", "A->C"]))
-    })
-
-    it("neighborhood validates radius in data-first and data-last forms", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-      })
-
-      for (const radius of [NaN, -Infinity, -1, -0.5, 0.5, 1.5]) {
-        assertGraphError(
-          () => Graph.neighborhood(graph, 0, { radius }),
-          "Traversal radius must be a non-negative integer or Infinity"
-        )
-        assertGraphError(
-          () => Graph.neighborhood(0, { radius })(graph),
-          "Traversal radius must be a non-negative integer or Infinity"
-        )
-      }
-
-      for (const [radius, count] of [[Infinity, 1], [-0, 1], [0, 1], [1, 1]] as const) {
-        strictEqual(Graph.nodeCount(Graph.neighborhood(graph, 0, { radius })), count)
-      }
-    })
-
-    it("inducedSubgraph preserves sparse node and edge indexes", () => {
-      const graph = Graph.fromSnapshot({
-        type: "directed",
-        nodes: [
-          { index: 2, data: "A" },
-          { index: 5, data: "B" },
-          { index: 9, data: "C" }
-        ],
-        edges: [
-          { index: 3, source: 2, target: 5, data: "A-B" },
-          { index: 7, source: 5, target: 9, data: "B-C" },
-          { index: 11, source: 5, target: 5, data: "B-B" }
-        ]
-      })
-
-      const result = Graph.inducedSubgraph(graph, [9, 5, 5])
-
-      assert.deepStrictEqual(Array.from(Graph.nodes(result)), [[5, "B"], [9, "C"]])
-      assert.deepStrictEqual(Array.from(Graph.edges(result)), [
-        [7, { source: 5, target: 9, data: "B-C" }],
-        [11, { source: 5, target: 5, data: "B-B" }]
-      ])
-    })
-
-    it("inducedSubgraph preserves graph kind and handles empty selections", () => {
-      const graph = Graph.undirected<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-      })
-
-      const result = Graph.inducedSubgraph([])(graph)
-
-      assert.strictEqual(result.type, "undirected")
-      assert.strictEqual(Graph.nodeCount(result), 0)
-      assert.strictEqual(Graph.edgeCount(result), 0)
-    })
-
-    it("inducedSubgraph rejects missing nodes", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-      })
-
-      assertGraphError(() => Graph.inducedSubgraph(graph, [0, 1]), "Node 1 does not exist")
-    })
-
-    it("sum keeps equal nodes disjoint", () => {
-      const left = Graph.directed<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, "left")
-      })
-      const right = Graph.directed<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, "right")
-      })
-
-      const result = Graph.sum(left, right)
-
-      strictEqual(Graph.nodeCount(result), 4)
-      strictEqual(Graph.edgeCount(result), 2)
-      assert.deepStrictEqual(Array.from(Graph.values(Graph.nodes(result))), ["A", "B", "A", "B"])
-    })
-  })
-
-  it("toString", () => {
-    const graph = Graph.directed<undefined, number>((mutable) => {
-      const nodeA = Graph.addNode(mutable, undefined)
-      const nodeB = Graph.addNode(mutable, undefined)
-      Graph.addEdge(mutable, nodeA, nodeB, 1)
-    })
-    strictEqual(String(graph), "Graph(directed, 2, 1)")
-  })
-
-  describe("isGraph", () => {
-    it("should return true for graph instances", () => {
-      const directedGraph = Graph.directed<string, number>()
+  describe("construction and protocols", () => {
+    it("constructs directed and undirected graphs", () => {
+      const directedGraph = Graph.make("directed")<string, number>()
       const undirectedGraph = Graph.undirected<string, number>()
 
-      strictEqual(Graph.isGraph(directedGraph), true)
-      strictEqual(Graph.isGraph(undirectedGraph), true)
+      assert.strictEqual(directedGraph.type, "directed")
+      assert.strictEqual(undirectedGraph.type, "undirected")
+      assert.strictEqual(directedGraph.mutable, false)
+      assert.strictEqual(Graph.nodeCount(directedGraph), 0)
+      assert.strictEqual(Graph.edgeCount(undirectedGraph), 0)
     })
 
-    it("should return true for mutable graph instances", () => {
-      const directedGraph = Graph.beginMutation(Graph.directed<string, number>())
-      const undirectedGraph = Graph.beginMutation(Graph.undirected<string, number>())
-
-      strictEqual(Graph.isGraph(directedGraph), true)
-      strictEqual(Graph.isGraph(undirectedGraph), true)
-    })
-
-    it("should return false for non-graph values", () => {
-      strictEqual(Graph.isGraph({}), false)
-      strictEqual(Graph.isGraph(null), false)
-      strictEqual(Graph.isGraph(undefined), false)
-      strictEqual(Graph.isGraph("string"), false)
-      strictEqual(Graph.isGraph(42), false)
-      strictEqual(Graph.isGraph([]), false)
-    })
-
-    it("should be iterable using for...of syntax", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "Node A")
-        Graph.addNode(mutable, "Node B")
-        Graph.addNode(mutable, "Node C")
-      })
-
-      const collected: Array<readonly [number, string]> = []
-      for (const entry of graph) {
-        collected.push(entry)
+    it("recognizes immutable and mutable graphs only", () => {
+      assert.strictEqual(Graph.isGraph(Graph.directed()), true)
+      assert.strictEqual(Graph.isGraph(Graph.beginMutation(Graph.undirected())), true)
+      for (const value of [{}, null, undefined, "graph", 1, []]) {
+        assert.strictEqual(Graph.isGraph(value), false)
       }
-
-      expect(collected).toHaveLength(3)
-      expect(collected).toEqual([
-        [0, "Node A"],
-        [1, "Node B"],
-        [2, "Node C"]
-      ])
     })
 
-    it("should support manual iterator operations", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "Node A")
-        Graph.addNode(mutable, "Node B")
-      })
+    it("supports stringification, piping, and node iteration in graph order", () => {
+      const graph = directed(["A", "B"], [[0, 1, 1]])
 
+      assert.strictEqual(String(graph), "Graph(directed, 2, 1)")
+      assert.strictEqual(graph.pipe(Graph.nodeCount), 2)
+      assert.deepStrictEqual(Array.from(graph), [[0, "A"], [1, "B"]])
       const iterator = graph[Symbol.iterator]()
-      const first = iterator.next()
-      const second = iterator.next()
-      const third = iterator.next()
-
-      expect(first.done).toBe(false)
-      expect(first.value).toEqual([0, "Node A"])
-      expect(second.done).toBe(false)
-      expect(second.value).toEqual([1, "Node B"])
-      expect(third.done).toBe(true)
+      assert.deepStrictEqual(iterator.next(), { done: false, value: [0, "A"] })
+      assert.deepStrictEqual(iterator.next(), { done: false, value: [1, "B"] })
+      assert.deepStrictEqual(iterator.next(), { done: true, value: undefined })
     })
   })
 
-  describe("undefined data handling", () => {
-    describe("undefined node data", () => {
-      it("should allow adding nodes with undefined data", () => {
-        const graph = Graph.directed<undefined, number>((mutable) => {
-          const nodeA = Graph.addNode(mutable, undefined)
-          const nodeB = Graph.addNode(mutable, undefined)
-          Graph.addEdge(mutable, nodeA, nodeB, 1)
-        })
-
-        expect(Graph.nodeCount(graph)).toBe(2)
-        expect(Graph.edgeCount(graph)).toBe(1)
-        expect(Graph.getNode(graph, 0)).toEqual(Option.some(undefined))
-        expect(Graph.getNode(graph, 1)).toEqual(Option.some(undefined))
-      })
-
-      it("should correctly update nodes with undefined data", () => {
-        const graph = Graph.directed<undefined | string, number>((mutable) => {
-          Graph.addNode(mutable, undefined)
-          Graph.addNode(mutable, "defined")
-        })
-
-        const updated = Graph.mutate(graph, (mutable) => {
-          Graph.updateNode(mutable, 0, () => "now defined")
-          Graph.updateNode(mutable, 1, () => undefined)
-        })
-
-        expect(Graph.getNode(updated, 0)).toEqual(Option.some("now defined"))
-        expect(Graph.getNode(updated, 1)).toEqual(Option.some(undefined))
-      })
-
-      it("should correctly compare graphs with undefined node data", () => {
-        const graph1 = Graph.directed<undefined, number>((mutable) => {
-          Graph.addNode(mutable, undefined)
-          Graph.addNode(mutable, undefined)
-        })
-
-        const graph2 = Graph.directed<undefined, number>((mutable) => {
-          Graph.addNode(mutable, undefined)
-          Graph.addNode(mutable, undefined)
-        })
-
-        expect(Equal.equals(graph1, graph2)).toBe(true)
-      })
-
-      it("should find nodes with undefined data using predicates", () => {
-        const graph = Graph.directed<undefined | string, number>((mutable) => {
-          Graph.addNode(mutable, undefined)
-          Graph.addNode(mutable, "defined")
-          Graph.addNode(mutable, undefined)
-        })
-
-        const undefinedNode = Graph.findNode(graph, (data) => data === undefined)
-        const undefinedNodes = Graph.findNodes(graph, (data) => data === undefined)
-
-        expect(undefinedNode).toEqual(Option.some(0))
-        expect(undefinedNodes).toEqual([0, 2])
-      })
-
-      it("should iterate correctly over graphs with undefined node data", () => {
-        const graph = Graph.directed<undefined, number>((mutable) => {
-          Graph.addNode(mutable, undefined)
-          Graph.addNode(mutable, undefined)
-        })
-
-        const collected: Array<readonly [number, undefined]> = []
-        for (const entry of graph) {
-          collected.push(entry)
-        }
-
-        expect(collected).toEqual([
-          [0, undefined],
-          [1, undefined]
-        ])
-      })
-    })
-
-    describe("undefined edge data", () => {
-      it("should allow adding edges with undefined data", () => {
-        const graph = Graph.directed<string, undefined>((mutable) => {
-          const nodeA = Graph.addNode(mutable, "A")
-          const nodeB = Graph.addNode(mutable, "B")
-          Graph.addEdge(mutable, nodeA, nodeB, undefined)
-        })
-
-        expect(Graph.edgeCount(graph)).toBe(1)
-        expect(Graph.getEdge(graph, 0)).toEqual(Option.some({ source: 0, target: 1, data: undefined }))
-      })
-
-      it("should correctly update edges with undefined data", () => {
-        const graph = Graph.directed<string, undefined | number>((mutable) => {
-          const nodeA = Graph.addNode(mutable, "A")
-          const nodeB = Graph.addNode(mutable, "B")
-          Graph.addEdge(mutable, nodeA, nodeB, undefined)
-          Graph.addEdge(mutable, nodeB, nodeA, 42)
-        })
-
-        const updated = Graph.mutate(graph, (mutable) => {
-          Graph.updateEdge(mutable, 0, () => 100)
-          Graph.updateEdge(mutable, 1, () => undefined)
-        })
-
-        const edge0 = Graph.getEdge(updated, 0)
-        const edge1 = Graph.getEdge(updated, 1)
-
-        expect(edge0).toEqual(Option.some({ source: 0, target: 1, data: 100 }))
-        expect(edge1).toEqual(Option.some({ source: 1, target: 0, data: undefined }))
-      })
-
-      it("should correctly compare graphs with undefined edge data", () => {
-        const graph1 = Graph.directed<string, undefined>((mutable) => {
-          const a = Graph.addNode(mutable, "A")
-          const b = Graph.addNode(mutable, "B")
-          Graph.addEdge(mutable, a, b, undefined)
-        })
-
-        const graph2 = Graph.directed<string, undefined>((mutable) => {
-          const a = Graph.addNode(mutable, "A")
-          const b = Graph.addNode(mutable, "B")
-          Graph.addEdge(mutable, a, b, undefined)
-        })
-
-        expect(Equal.equals(graph1, graph2)).toBe(true)
-      })
-
-      it("should find edges with undefined data using predicates", () => {
-        const graph = Graph.directed<string, undefined | number>((mutable) => {
-          const a = Graph.addNode(mutable, "A")
-          const b = Graph.addNode(mutable, "B")
-          const c = Graph.addNode(mutable, "C")
-          Graph.addEdge(mutable, a, b, undefined)
-          Graph.addEdge(mutable, b, c, 42)
-          Graph.addEdge(mutable, c, a, undefined)
-        })
-
-        const undefinedEdge = Graph.findEdge(graph, (data) => data === undefined)
-        const undefinedEdges = Graph.findEdges(graph, (data) => data === undefined)
-
-        expect(undefinedEdge).toEqual(Option.some(0))
-        expect(undefinedEdges).toEqual([0, 2])
-      })
-
-      it("should correctly handle Equal.equals with graphs containing undefined edge data", () => {
-        const graph1 = Graph.directed<string, undefined | number>((mutable) => {
-          const a = Graph.addNode(mutable, "A")
-          const b = Graph.addNode(mutable, "B")
-          Graph.addEdge(mutable, a, b, undefined)
-        })
-
-        const graph2 = Graph.directed<string, undefined | number>((mutable) => {
-          const a = Graph.addNode(mutable, "A")
-          const b = Graph.addNode(mutable, "B")
-          Graph.addEdge(mutable, a, b, undefined)
-        })
-
-        const graph3 = Graph.directed<string, undefined | number>((mutable) => {
-          const a = Graph.addNode(mutable, "A")
-          const b = Graph.addNode(mutable, "B")
-          Graph.addEdge(mutable, a, b, 42)
-        })
-
-        // Equal graphs with undefined edge data should be equal
-        expect(Equal.equals(graph1, graph2)).toBe(true)
-
-        // Graphs with different edge data should not be equal
-        expect(Equal.equals(graph1, graph3)).toBe(false)
-      })
-    })
-
-    describe("mixed undefined scenarios", () => {
-      it("should handle graphs with both undefined nodes and edges", () => {
-        const graph = Graph.directed<undefined, undefined>((mutable) => {
-          const nodeA = Graph.addNode(mutable, undefined)
-          const nodeB = Graph.addNode(mutable, undefined)
-          Graph.addEdge(mutable, nodeA, nodeB, undefined)
-        })
-
-        expect(Graph.nodeCount(graph)).toBe(2)
-        expect(Graph.edgeCount(graph)).toBe(1)
-        expect(Graph.getNode(graph, 0)).toEqual(Option.some(undefined))
-        expect(Graph.getEdge(graph, 0)).toEqual(Option.some({ source: 0, target: 1, data: undefined }))
-      })
-
-      it("should correctly handle graph operations with mixed undefined data", () => {
-        const graph = Graph.directed<undefined | string, undefined | number>((mutable) => {
-          const a = Graph.addNode(mutable, undefined)
-          const b = Graph.addNode(mutable, "B")
-          const c = Graph.addNode(mutable, undefined)
-          Graph.addEdge(mutable, a, b, undefined)
-          Graph.addEdge(mutable, b, c, 42)
-          Graph.addEdge(mutable, c, a, undefined)
-        })
-
-        // Test neighbors
-        const neighborsOfA = Graph.neighbors(graph, 0)
-        const neighborsOfB = Graph.neighbors(graph, 1)
-
-        expect(neighborsOfA).toEqual([1])
-        expect(neighborsOfB).toEqual([2])
-
-        // Test filtering
-        const nodesWithUndefined = Graph.findNodes(graph, (data) => data === undefined)
-        const edgesWithUndefined = Graph.findEdges(graph, (data) => data === undefined)
-
-        expect(nodesWithUndefined).toEqual([0, 2])
-        expect(edgesWithUndefined).toEqual([0, 2])
-      })
-    })
-  })
-
-  describe("beginMutation", () => {
-    it("should create a mutable graph from an immutable graph", () => {
-      const graph = Graph.directed<string, number>()
-      const mutable = Graph.beginMutation(graph)
-
-      expect(mutable.type).toBe("directed")
-      expect(Graph.nodeCount(mutable)).toBe(Graph.nodeCount(graph))
-      expect(Graph.edgeCount(mutable)).toBe(Graph.edgeCount(graph))
-    })
-  })
-
-  describe("endMutation", () => {
-    it("should convert a mutable graph back to immutable", () => {
-      const graph = Graph.directed<string, number>()
-      const mutable = Graph.beginMutation(graph)
-      const result = Graph.endMutation(mutable)
-
-      expect(result.type).toBe("directed")
-      expect(Graph.nodeCount(result)).toBe(Graph.nodeCount(mutable))
-      expect(Graph.edgeCount(result)).toBe(Graph.edgeCount(mutable))
-    })
-
-    it("should reject mutations on a finalized mutable graph", () => {
-      let nodeA: Graph.NodeIndex
-      let nodeB: Graph.NodeIndex
-      let edgeIndex: Graph.EdgeIndex
-      const graph = Graph.directed<string, number>((mutable) => {
-        nodeA = Graph.addNode(mutable, "A")
-        nodeB = Graph.addNode(mutable, "B")
-        edgeIndex = Graph.addEdge(mutable, nodeA, nodeB, 1)
-      })
-
-      const mutable = Graph.beginMutation(graph)
-      const result = Graph.endMutation(mutable)
-
-      throws(
-        () => Graph.removeEdge(mutable, edgeIndex!),
-        (error) => {
-          strictEqual(error instanceof Graph.GraphError, true)
-          if (error instanceof Graph.GraphError) {
-            strictEqual(error.message, "Graph is not mutable")
-          }
-        }
-      )
-      strictEqual(Graph.hasEdge(result, nodeA!, nodeB!), true)
-      assert.deepStrictEqual(Graph.neighbors(result, nodeA!), [nodeB!])
-      assert.deepStrictEqual(Graph.predecessors(result, nodeB!), [nodeA!])
-    })
-
-    it("should reject a second finalization", () => {
-      const mutable = Graph.beginMutation(Graph.directed<string, number>())
-      Graph.endMutation(mutable)
-
-      assertGraphError(() => Graph.endMutation(mutable), "Graph is not mutable")
-    })
-  })
-
-  describe("mutate", () => {
-    it("should create a new graph instance", () => {
-      const graph = Graph.directed<string, number>()
-
-      const result = Graph.mutate(graph, () => {
-        // No mutations performed
-      })
-
-      expect(result).not.toBe(graph)
-      expect(Equal.equals(result, graph)).toBe(true) // Structural equality
-    })
-
-    it("should handle empty mutation function", () => {
-      const graph = Graph.directed<string, number>()
-
-      const result = Graph.mutate(graph, () => {
-        // Do nothing
-      })
-
-      expect(Graph.nodeCount(result)).toBe(0)
-      expect(Graph.edgeCount(result)).toBe(0)
-    })
-
-    it("should finalize the mutable graph when the callback throws", () => {
-      let mutable: Graph.MutableDirectedGraph<string, number> | undefined
-      const error = new Error("boom")
-
-      throws(
-        () =>
-          Graph.mutate(Graph.directed<string, number>(), (graph) => {
-            mutable = graph
-            throw error
-          }),
-        (cause) => {
-          strictEqual(cause, error)
-        }
-      )
-      assertGraphError(() => Graph.addNode(mutable!, "late"), "Graph is not mutable")
-    })
-
-    it("should reject manual finalization followed by a normal callback return", () => {
-      const graph = Graph.directed<string, number>()
-
-      assertGraphError(() => {
-        Graph.directed<string, number>((mutable) => {
-          Graph.endMutation(mutable)
-        })
-      }, "Graph is not mutable")
-      assertGraphError(() => {
-        Graph.undirected<string, number>((mutable) => {
-          Graph.endMutation(mutable)
-        })
-      }, "Graph is not mutable")
-      assertGraphError(() => {
-        Graph.make("directed")<string, number>((mutable) => {
-          Graph.endMutation(mutable)
-        })
-      }, "Graph is not mutable")
-      assertGraphError(() => {
-        Graph.make("undirected")<string, number>((mutable) => {
-          Graph.endMutation(mutable)
-        })
-      }, "Graph is not mutable")
-      assertGraphError(() => {
-        Graph.mutate(graph, (mutable) => {
-          Graph.endMutation(mutable)
-        })
-      }, "Graph is not mutable")
-      assertGraphError(() => {
-        Graph.mutate((mutable: Graph.MutableDirectedGraph<string, number>) => {
-          Graph.endMutation(mutable)
-        })(graph)
-      }, "Graph is not mutable")
-    })
-
-    it("should preserve a callback error after manual finalization", () => {
-      const error = new Error("callback failure")
-
-      for (
-        const run of [
-          (f: (mutable: Graph.MutableDirectedGraph<string, number>) => undefined) => Graph.directed(f),
-          (f: (mutable: Graph.MutableUndirectedGraph<string, number>) => undefined) => Graph.undirected(f),
-          (f: (mutable: Graph.MutableDirectedGraph<string, number>) => undefined) => Graph.make("directed")(f),
-          (f: (mutable: Graph.MutableUndirectedGraph<string, number>) => undefined) => Graph.make("undirected")(f),
-          (f: (mutable: Graph.MutableDirectedGraph<string, number>) => undefined) =>
-            Graph.mutate(Graph.directed<string, number>(), f),
-          (f: (mutable: Graph.MutableDirectedGraph<string, number>) => undefined) =>
-            Graph.mutate(f)(Graph.directed<string, number>())
+  describe("snapshots", () => {
+    it("round-trips sparse indexes, parallel edges, self-loops, and stored orientation", () => {
+      const snapshot = {
+        type: "undirected",
+        nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }],
+        edges: [
+          { index: 3, source: 5, target: 2, data: "first" },
+          { index: 7, source: 5, target: 2, data: "parallel" },
+          { index: 11, source: 5, target: 5, data: "loop" }
         ]
-      ) {
-        throws(
-          () =>
-            run((mutable) => {
-              Graph.endMutation(mutable)
-              throw error
-            }),
-          (cause) => {
-            strictEqual(cause, error)
-          }
-        )
-      }
+      } as const
+      const graph = Graph.fromSnapshot(snapshot)
+
+      assertSnapshot(graph, snapshot)
+      assert.deepStrictEqual(Graph.neighbors(graph, 2), [5])
+      assert.deepStrictEqual(Graph.neighbors(graph, 5), [2, 5])
+      assert.strictEqual(Equal.equals(Graph.fromSnapshot(Graph.toSnapshot(graph)), graph), true)
     })
 
-    it("should reject every mutation entry point on a retained finalized handle", () => {
-      let retained: Graph.MutableDirectedGraph<string, number> | undefined
-      let nodeA: Graph.NodeIndex
-      let nodeB: Graph.NodeIndex
-      let edge: Graph.EdgeIndex
-      const result = Graph.directed<string, number>((mutable) => {
-        retained = mutable
-        nodeA = Graph.addNode(mutable, "A")
-        nodeB = Graph.addNode(mutable, "B")
-        edge = Graph.addEdge(mutable, nodeA, nodeB, 1)
-      })
-
-      strictEqual(Graph.nodeCount(retained!), 2)
-      strictEqual(Graph.edgeCount(retained!), 1)
-      assert.deepStrictEqual(Graph.getNode(retained!, nodeA!), Option.some("A"))
-
-      const mutations: ReadonlyArray<() => unknown> = [
-        () => Graph.addNode(retained!, "C"),
-        () => Graph.updateNode(retained!, nodeA!, () => "updated"),
-        () => Graph.updateEdge(retained!, edge!, () => 2),
-        () => Graph.mapNodes(retained!, () => "mapped"),
-        () => Graph.mapEdges(retained!, () => 3),
-        () => Graph.reverse(retained!),
-        () => Graph.filterMapNodes(retained!, () => Option.none()),
-        () => Graph.filterMapEdges(retained!, () => Option.none()),
-        () => Graph.filterNodes(retained!, () => false),
-        () => Graph.filterEdges(retained!, () => false),
-        () => Graph.addEdge(retained!, nodeB!, nodeA!, 4),
-        () => Graph.removeNode(retained!, nodeA!),
-        () => Graph.removeNodes(retained!, [nodeA!]),
-        () => Graph.removeEdge(retained!, edge!),
-        () => Graph.removeEdges(retained!, [edge!])
-      ]
-      for (const mutation of mutations) {
-        assertGraphError(mutation, "Graph is not mutable")
-      }
-
-      strictEqual(Graph.nodeCount(result), 2)
-      strictEqual(Graph.edgeCount(result), 1)
-      assert.deepStrictEqual(Graph.getNode(result, nodeA!), Option.some("A"))
-      assert.deepStrictEqual(Graph.getEdge(result, edge!), Option.some({ source: nodeA!, target: nodeB!, data: 1 }))
-    })
-  })
-
-  describe("addNode", () => {
-    it("should add a node to a mutable graph and return its index", () => {
-      const graph = Graph.directed<string, number>()
-      let nodeIndex: Graph.NodeIndex
-
-      const result = Graph.mutate(graph, (mutable) => {
-        nodeIndex = Graph.addNode(mutable, "Node A")
-      })
-
-      expect(Graph.nodeCount(result)).toBe(1)
-      expect(Graph.getNode(result, nodeIndex!)).toEqual(Option.some("Node A"))
-    })
-  })
-
-  describe("getNode", () => {
-    it("should return the node data for existing nodes", () => {
-      let nodeA: Graph.NodeIndex
-      let nodeB: Graph.NodeIndex
-
-      const graph = Graph.directed<string, number>((mutable) => {
-        nodeA = Graph.addNode(mutable, "Node A")
-        nodeB = Graph.addNode(mutable, "Node B")
-      })
-
-      expect(Graph.getNode(graph, nodeA!)).toEqual(Option.some("Node A"))
-      expect(Graph.getNode(graph, nodeB!)).toEqual(Option.some("Node B"))
-    })
-
-    it("should return None for non-existent nodes", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "Node A")
-      })
-
-      const nonExistent = Graph.getNode(graph, 999)
-      expect(Option.isNone(nonExistent)).toBe(true)
-    })
-  })
-
-  describe("hasNode", () => {
-    it("should return true for existing nodes", () => {
-      let nodeA: Graph.NodeIndex
-      let nodeB: Graph.NodeIndex
-
-      const graph = Graph.directed<string, number>((mutable) => {
-        nodeA = Graph.addNode(mutable, "Node A")
-        nodeB = Graph.addNode(mutable, "Node B")
-      })
-
-      expect(Graph.hasNode(graph, nodeA!)).toBe(true)
-      expect(Graph.hasNode(graph, nodeB!)).toBe(true)
-    })
-
-    it("should return false for non-existent nodes", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "Node A")
-      })
-
-      expect(Graph.hasNode(graph, 999)).toBe(false)
-      expect(Graph.hasNode(graph, -1)).toBe(false)
-    })
-  })
-
-  describe("nodeCount", () => {
-    it("should return 0 for empty graph", () => {
-      const graph = Graph.directed<string, number>()
-      expect(Graph.nodeCount(graph)).toBe(0)
-    })
-
-    it("should return correct count after adding nodes", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        expect(Graph.nodeCount(mutable)).toBe(0)
-        Graph.addNode(mutable, "Node A")
-        expect(Graph.nodeCount(mutable)).toBe(1)
-        Graph.addNode(mutable, "Node B")
-        expect(Graph.nodeCount(mutable)).toBe(2)
-        Graph.addNode(mutable, "Node C")
-        expect(Graph.nodeCount(mutable)).toBe(3)
-      })
-
-      expect(Graph.nodeCount(graph)).toBe(3)
-    })
-  })
-
-  describe("findNode", () => {
-    it("should find node by predicate", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "Node A")
-        Graph.addNode(mutable, "Node B")
-        Graph.addNode(mutable, "Node C")
-      })
-
-      const result = Graph.findNode(graph, (data) => data === "Node B")
-      expect(result).toEqual(Option.some(1))
-    })
-
-    it("should return None when no node matches", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "Node A")
-        Graph.addNode(mutable, "Node B")
-      })
-
-      const result = Graph.findNode(graph, (data) => data === "Node C")
-      expect(result).toEqual(Option.none())
-    })
-
-    it("should find first matching node when multiple match", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "Start A")
-        Graph.addNode(mutable, "Start B")
-        Graph.addNode(mutable, "Start C")
-      })
-
-      const result = Graph.findNode(graph, (data) => data.startsWith("Start"))
-      expect(result).toEqual(Option.some(0))
-    })
-  })
-
-  describe("findNodes", () => {
-    it("should find all matching nodes", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "Start A")
-        Graph.addNode(mutable, "Node B")
-        Graph.addNode(mutable, "Start C")
-        Graph.addNode(mutable, "Start D")
-      })
-
-      const result = Graph.findNodes(graph, (data) => data.startsWith("Start"))
-      expect(result).toEqual([0, 2, 3])
-    })
-  })
-
-  describe("findEdge", () => {
-    it("should find edge by predicate", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const nodeA = Graph.addNode(mutable, "Node A")
-        const nodeB = Graph.addNode(mutable, "Node B")
-        const nodeC = Graph.addNode(mutable, "Node C")
-        Graph.addEdge(mutable, nodeA, nodeB, 10)
-        Graph.addEdge(mutable, nodeB, nodeC, 20)
-      })
-
-      const result = Graph.findEdge(graph, (data) => data === 20)
-      expect(result).toEqual(Option.some(1))
-    })
-
-    it("should return None when no edge matches", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const nodeA = Graph.addNode(mutable, "Node A")
-        const nodeB = Graph.addNode(mutable, "Node B")
-        Graph.addEdge(mutable, nodeA, nodeB, 10)
-      })
-
-      const result = Graph.findEdge(graph, (data) => data === 99)
-      expect(result).toEqual(Option.none())
-    })
-
-    it("should find first matching edge when multiple match", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const nodeA = Graph.addNode(mutable, "Node A")
-        const nodeB = Graph.addNode(mutable, "Node B")
-        const nodeC = Graph.addNode(mutable, "Node C")
-        Graph.addEdge(mutable, nodeA, nodeB, 15)
-        Graph.addEdge(mutable, nodeB, nodeC, 25)
-        Graph.addEdge(mutable, nodeC, nodeA, 35)
-      })
-
-      const result = Graph.findEdge(graph, (data) => data > 20)
-      expect(result).toEqual(Option.some(1))
-    })
-  })
-
-  describe("findEdges", () => {
-    it("should find all matching edges", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const nodeA = Graph.addNode(mutable, "Node A")
-        const nodeB = Graph.addNode(mutable, "Node B")
-        const nodeC = Graph.addNode(mutable, "Node C")
-        Graph.addEdge(mutable, nodeA, nodeB, 10)
-        Graph.addEdge(mutable, nodeB, nodeC, 20)
-        Graph.addEdge(mutable, nodeC, nodeA, 30)
-        Graph.addEdge(mutable, nodeA, nodeC, 25)
-      })
-
-      const result = Graph.findEdges(graph, (data) => data >= 20)
-      expect(result).toEqual([1, 2, 3])
-    })
-  })
-
-  describe("updateNode", () => {
-    it("should update node data", () => {
-      const updated = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "Node A")
-        Graph.addNode(mutable, "Node B")
-        Graph.updateNode(mutable, 0, (data) => data.toUpperCase())
-      })
-
-      const nodeData = Graph.getNode(updated, 0)
-      assertSome(nodeData, "NODE A")
-    })
-
-    it("should do nothing if node doesn't exist", () => {
-      let nodeA: Graph.NodeIndex
-
-      const graph = Graph.directed<string, number>((mutable) => {
-        nodeA = Graph.addNode(mutable, "Node A")
-        Graph.updateNode(mutable, 999, (data) => data.toUpperCase())
-      })
-
-      // Original node should be unchanged
-      const nodeData = Graph.getNode(graph, nodeA!)
-      assertSome(nodeData, "Node A")
-    })
-  })
-
-  describe("updateEdge", () => {
-    it("should update edge data", () => {
-      const result = Graph.mutate(Graph.directed<string, number>(), (mutable) => {
-        const nodeA = Graph.addNode(mutable, "Node A")
-        const nodeB = Graph.addNode(mutable, "Node B")
-        const edgeIndex = Graph.addEdge(mutable, nodeA, nodeB, 10)
-        Graph.updateEdge(mutable, edgeIndex, (data) => data * 2)
-      })
-
-      const edge = Graph.getEdge(result, 0)
-      assertSome(edge, { source: 0, target: 1, data: 20 })
-    })
-
-    it("should do nothing if edge doesn't exist", () => {
-      Graph.mutate(Graph.directed<string, number>(), (mutable) => {
-        const nodeA = Graph.addNode(mutable, "Node A")
-        const nodeB = Graph.addNode(mutable, "Node B")
-        const edgeIndex = Graph.addEdge(mutable, nodeA, nodeB, 10)
-
-        // Try to update non-existent edge
-        Graph.updateEdge(mutable, 999, (data) => data * 2)
-
-        // Original edge should be unchanged
-        const edge = Graph.getEdge(mutable, edgeIndex)
-        assertSome(edge, { source: 0, target: 1, data: 10 })
-      })
-    })
-  })
-
-  describe("mapNodes", () => {
-    it("should transform all node data", () => {
-      let nodeA: Graph.NodeIndex
-      let nodeB: Graph.NodeIndex
-      let nodeC: Graph.NodeIndex
-
-      const graph = Graph.directed<string, number>((mutable) => {
-        nodeA = Graph.addNode(mutable, "node a")
-        nodeB = Graph.addNode(mutable, "node b")
-        nodeC = Graph.addNode(mutable, "node c")
-        Graph.mapNodes(mutable, (data) => data.toUpperCase())
-      })
-
-      expect(Graph.getNode(graph, nodeA!)).toEqual(Option.some("NODE A"))
-      expect(Graph.getNode(graph, nodeB!)).toEqual(Option.some("NODE B"))
-      expect(Graph.getNode(graph, nodeC!)).toEqual(Option.some("NODE C"))
-    })
-
-    it("should apply transformation to all nodes", () => {
-      let firstNode: Graph.NodeIndex
-      let secondNode: Graph.NodeIndex
-      let thirdNode: Graph.NodeIndex
-
-      const graph = Graph.directed<string, number>((mutable) => {
-        firstNode = Graph.addNode(mutable, "first")
-        secondNode = Graph.addNode(mutable, "second")
-        thirdNode = Graph.addNode(mutable, "third")
-        Graph.mapNodes(mutable, (data) => data + " (transformed)")
-      })
-
-      const node0 = Graph.getNode(graph, firstNode!)
-      const node1 = Graph.getNode(graph, secondNode!)
-      const node2 = Graph.getNode(graph, thirdNode!)
-
-      assertSome(node0, "first (transformed)")
-      assertSome(node1, "second (transformed)")
-      assertSome(node2, "third (transformed)")
-    })
-
-    it("should modify graph in place during construction", () => {
-      let originalNode: Graph.NodeIndex
-
-      const graph = Graph.directed<string, number>((mutable) => {
-        originalNode = Graph.addNode(mutable, "original")
-        // Before transformation
-        const beforeData = Graph.getNode(mutable, originalNode!)
-        assertSome(beforeData, "original")
-
-        // Apply transformation
-        Graph.mapNodes(mutable, (data) => data.toUpperCase())
-      })
-
-      // After transformation
-      const afterData = Graph.getNode(graph, originalNode!)
-      assertSome(afterData, "ORIGINAL")
-    })
-  })
-
-  describe("mapEdges", () => {
-    it("should transform all edge data", () => {
-      let edgeAB: Graph.EdgeIndex
-      let edgeBC: Graph.EdgeIndex
-      let edgeCA: Graph.EdgeIndex
-
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        edgeAB = Graph.addEdge(mutable, a, b, 10)
-        edgeBC = Graph.addEdge(mutable, b, c, 20)
-        edgeCA = Graph.addEdge(mutable, c, a, 30)
-        Graph.mapEdges(mutable, (data) => data * 2)
-      })
-
-      const edge0 = Graph.getEdge(graph, edgeAB!)
-      const edge1 = Graph.getEdge(graph, edgeBC!)
-      const edge2 = Graph.getEdge(graph, edgeCA!)
-
-      assertSome(edge0, { source: 0, target: 1, data: 20 })
-      assertSome(edge1, { source: 1, target: 2, data: 40 })
-      assertSome(edge2, { source: 2, target: 0, data: 60 })
-
-      const expected = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 20)
-        Graph.addEdge(mutable, b, c, 40)
-        Graph.addEdge(mutable, c, a, 60)
-      })
-
-      strictEqual(Equal.equals(graph, expected), true)
-    })
-
-    it("should modify graph in place during construction", () => {
-      let edgeAB: Graph.EdgeIndex
-
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        edgeAB = Graph.addEdge(mutable, a, b, 10)
-
-        // Before transformation
-        const beforeData = Graph.getEdge(mutable, edgeAB!)
-        assertSome(beforeData, { source: 0, target: 1, data: 10 })
-
-        // Apply transformation
-        Graph.mapEdges(mutable, (data) => data * 5)
-      })
-
-      // After transformation
-      const afterData = Graph.getEdge(graph, edgeAB!)
-      expect(assertSomeEdge(afterData).data).toBe(50)
-    })
-  })
-
-  describe("callback-driven transformations", () => {
-    it("should reject finalization from a transform callback", () => {
-      const mutable = Graph.beginMutation(Graph.directed<string, never>((graph) => {
-        Graph.addNode(graph, "old")
-      }))
-      let finalized: Graph.DirectedGraph<string, never> | undefined
-
-      assertGraphError(
-        () =>
-          Graph.updateNode(mutable, 0, () => {
-            finalized = Graph.endMutation(mutable)
-            Array.from(Graph.bfs(finalized, { start: [0] }))
-            return "new"
-          }),
-        "Cannot mutate graph during a transformation"
-      )
-      assert.strictEqual(finalized, undefined)
-      assertSome(Graph.getNode(mutable, 0), "old")
-    })
-
-    it("should reject every mutation from a transform callback", () => {
-      const mutable = Graph.beginMutation(Graph.directed<string, number>((graph) => {
-        Graph.addNode(graph, "source")
-        Graph.addNode(graph, "target")
-        Graph.addEdge(graph, 0, 1, 1)
-      }))
-      const mutations: ReadonlyArray<() => unknown> = [
-        () => Graph.addNode(mutable, "new"),
-        () => Graph.updateNode(mutable, 0, () => "updated"),
-        () => Graph.updateEdge(mutable, 0, () => 2),
-        () => Graph.mapNodes(mutable, () => "mapped"),
-        () => Graph.mapEdges(mutable, () => 3),
-        () => Graph.reverse(mutable),
-        () => Graph.filterMapNodes(mutable, () => Option.none()),
-        () => Graph.filterMapEdges(mutable, () => Option.none()),
-        () => Graph.filterNodes(mutable, () => false),
-        () => Graph.filterEdges(mutable, () => false),
-        () => Graph.addEdge(mutable, 1, 0, 4),
-        () => Graph.removeNode(mutable, 0),
-        () => Graph.removeNodes(mutable, [0]),
-        () => Graph.removeEdge(mutable, 0),
-        () => Graph.removeEdges(mutable, [0]),
-        () => Graph.endMutation(mutable)
-      ]
-
-      for (const mutation of mutations) {
-        assertGraphError(
-          () =>
-            Graph.updateNode(mutable, 0, (data) => {
-              mutation()
-              return data
-            }),
-          "Cannot mutate graph during a transformation"
-        )
-      }
-
-      assert.deepStrictEqual(Graph.toSnapshot(mutable), {
+    it("snapshots mutable state without exposing stored records", () => {
+      const graph = directed(["A", "B"], [[0, 1, 1]])
+      const mutable = Graph.beginMutation(graph)
+      Graph.updateNode(mutable, 0, () => "updated")
+      const snapshot = Graph.toSnapshot(mutable)
+      ;(snapshot.nodes[0] as { index: number; data: string }).index = 1
+      ;(snapshot.nodes[0] as { index: number; data: string }).data = "exposed"
+      ;(snapshot.edges[0] as { source: number; data: number }).source = 1
+      ;(snapshot.edges[0] as { source: number; data: number }).data = 2
+
+      assertSnapshot(mutable, {
         type: "directed",
-        nodes: [{ index: 0, data: "source" }, { index: 1, data: "target" }],
+        nodes: [{ index: 0, data: "updated" }, { index: 1, data: "B" }],
         edges: [{ index: 0, source: 0, target: 1, data: 1 }]
       })
     })
 
-    it("should guard filter predicate callbacks", () => {
-      const mutable = Graph.beginMutation(Graph.directed<string, number>((graph) => {
-        Graph.addNode(graph, "source")
-        Graph.addNode(graph, "target")
-        Graph.addEdge(graph, 0, 1, 1)
+    it("continues allocation after the highest active snapshot indexes", () => {
+      const mutable = Graph.beginMutation(Graph.fromSnapshot({
+        type: "directed",
+        nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }],
+        edges: [{ index: 4, source: 2, target: 5, data: 1 }]
       }))
 
-      assertGraphError(
+      assert.strictEqual(Graph.addNode(mutable, "C"), 6)
+      assert.strictEqual(Graph.addEdge(mutable, 2, 5, 2), 5)
+    })
+
+    it("rejects malformed snapshot records and indexes", () => {
+      const cases: ReadonlyArray<readonly [() => unknown, string]> = [
+        [
+          () =>
+            Graph.fromSnapshot(
+              { type: "invalid", nodes: [], edges: [] } as unknown as Graph.Snapshot<never, never, Graph.Kind>
+            ),
+          "Snapshot type must be directed or undirected"
+        ],
+        [
+          () => Graph.fromSnapshot({ type: "directed", nodes: new Array(1), edges: [] }),
+          "Node at position 0 must be defined"
+        ],
+        [
+          () =>
+            Graph.fromSnapshot(
+              { type: "directed", nodes: [null], edges: [] } as unknown as Graph.Snapshot<never, never, "directed">
+            ),
+          "Node at position 0 must be defined"
+        ],
+        [
+          () => Graph.fromSnapshot({ type: "directed", nodes: [{ index: -1, data: "A" }], edges: [] }),
+          "Node index at position 0 must be a non-negative safe integer"
+        ],
+        [
+          () =>
+            Graph.fromSnapshot({
+              type: "directed",
+              nodes: [{ index: Number.MAX_SAFE_INTEGER + 1, data: "A" }],
+              edges: []
+            }),
+          "Node index at position 0 must be a non-negative safe integer"
+        ],
+        [
+          () =>
+            Graph.fromSnapshot({
+              type: "directed",
+              nodes: [{ index: 1, data: "A" }, { index: 1, data: "B" }],
+              edges: []
+            }),
+          "Node indexes must be strictly increasing"
+        ],
+        [
+          () => Graph.fromSnapshot({ type: "directed", nodes: [{ index: 0, data: "A" }], edges: new Array(1) }),
+          "Edge at position 0 must be defined"
+        ],
+        [
+          () =>
+            Graph.fromSnapshot({
+              type: "directed",
+              nodes: [{ index: 0, data: "A" }],
+              edges: [{ index: 0.5, source: 0, target: 0, data: 1 }]
+            }),
+          "Edge index at position 0 must be a non-negative safe integer"
+        ],
+        [
+          () =>
+            Graph.fromSnapshot({
+              type: "directed",
+              nodes: [{ index: 0, data: "A" }],
+              edges: [{ index: 1, source: 0, target: 0, data: 1 }, { index: 1, source: 0, target: 0, data: 2 }]
+            }),
+          "Edge indexes must be strictly increasing"
+        ],
+        [
+          () =>
+            Graph.fromSnapshot({
+              type: "directed",
+              nodes: [{ index: 0, data: "A" }],
+              edges: [{ index: 0, source: -1, target: 0, data: 1 }]
+            }),
+          "Edge source at position 0 must be a non-negative safe integer"
+        ],
+        [
+          () =>
+            Graph.fromSnapshot({
+              type: "directed",
+              nodes: [{ index: 0, data: "A" }],
+              edges: [{ index: 0, source: 0, target: 0.5, data: 1 }]
+            }),
+          "Edge target at position 0 must be a non-negative safe integer"
+        ],
+        [
+          () =>
+            Graph.fromSnapshot({
+              type: "directed",
+              nodes: [{ index: 1, data: "A" }],
+              edges: [{ index: 0, source: 0, target: 1, data: 1 }]
+            }),
+          "Edge source 0 does not reference a node"
+        ],
+        [
+          () =>
+            Graph.fromSnapshot({
+              type: "directed",
+              nodes: [{ index: 1, data: "A" }],
+              edges: [{ index: 0, source: 1, target: 2, data: 1 }]
+            }),
+          "Edge target 2 does not reference a node"
+        ]
+      ]
+
+      for (const [run, message] of cases) assertGraphError(run, message)
+    })
+
+    it("rejects allocation after safe indexes are exhausted", () => {
+      const nodes = Graph.beginMutation(Graph.fromSnapshot({
+        type: "directed",
+        nodes: [{ index: Number.MAX_SAFE_INTEGER, data: "A" }],
+        edges: []
+      }))
+      const edges = Graph.beginMutation(Graph.fromSnapshot({
+        type: "directed",
+        nodes: [{ index: 0, data: "A" }],
+        edges: [{ index: Number.MAX_SAFE_INTEGER, source: 0, target: 0, data: 1 }]
+      }))
+
+      assertGraphError(() => Graph.addNode(nodes, "B"), "Graph has exhausted safe node indexes")
+      assertGraphError(() => Graph.addEdge(edges, 0, 0, 2), "Graph has exhausted safe edge indexes")
+    })
+  })
+
+  describe("equality and hashing", () => {
+    it("gives equal immutable graphs equal hashes", () => {
+      const left = undirected(["A", "B"], [[0, 1, "first"], [0, 1, "second"], [0, 0, "loop"]])
+      const right = undirected(["A", "B"], [[1, 0, "first"], [1, 0, "second"], [0, 0, "loop"]])
+
+      assert.strictEqual(Equal.equals(left, right), true)
+      assert.strictEqual(Hash.hash(left), Hash.hash(right))
+    })
+
+    it("distinguishes node payload, edge payload, missing edge, kind, and sparse indexes", () => {
+      const base = directed(["A", "B"], [[0, 1, "edge"]])
+      const cases: ReadonlyArray<Graph.Graph<unknown, unknown, Graph.Kind>> = [
+        directed(["changed", "B"], [[0, 1, "edge"]]),
+        directed(["A", "B"], [[0, 1, "changed"]]),
+        directed(["A", "B"], []),
+        undirected(["A", "B"], [[0, 1, "edge"]]),
+        Graph.fromSnapshot({
+          type: "directed",
+          nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }],
+          edges: [{ index: 3, source: 2, target: 5, data: "edge" }]
+        })
+      ]
+
+      for (const candidate of cases) {
+        assert.strictEqual(Equal.equals(base, candidate), false)
+        assert.strictEqual(Equal.equals(candidate, base), false)
+      }
+    })
+
+    it("keeps directed endpoints and parallel-edge index pairing ordered", () => {
+      const directedLeft = directed(["A", "B"], [[0, 1, "edge"]])
+      const directedRight = directed(["A", "B"], [[1, 0, "edge"]])
+      const parallel = undirected(["A", "B"], [[0, 1, "first"], [0, 1, "second"]])
+      const reordered = undirected(["A", "B"], [[1, 0, "second"], [1, 0, "first"]])
+
+      assert.strictEqual(Equal.equals(directedLeft, directedRight), false)
+      assert.strictEqual(Equal.equals(parallel, reordered), false)
+    })
+
+    it("ignores removed trailing allocator history while preserving future allocation", () => {
+      const left = directed(["A", "B"], [[0, 1, "edge"]])
+      const right = Graph.directed<string, string>((mutable) => {
+        Graph.addNode(mutable, "A")
+        Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, 0, 1, "edge")
+        const node = Graph.addNode(mutable, "removed")
+        const edge = Graph.addEdge(mutable, 0, 1, "removed")
+        Graph.removeNode(mutable, node)
+        Graph.removeEdge(mutable, edge)
+      })
+
+      assert.strictEqual(Equal.equals(left, right), true)
+      assert.strictEqual(Hash.hash(left), Hash.hash(right))
+      Graph.mutate(left, (mutable) => {
+        assert.strictEqual(Graph.addNode(mutable, "next"), 2)
+      })
+      Graph.mutate(right, (mutable) => {
+        assert.strictEqual(Graph.addNode(mutable, "next"), 3)
+      })
+      Graph.mutate(left, (mutable) => {
+        assert.strictEqual(Graph.addEdge(mutable, 0, 1, "next"), 1)
+      })
+      Graph.mutate(right, (mutable) => {
+        assert.strictEqual(Graph.addEdge(mutable, 0, 1, "next"), 2)
+      })
+    })
+
+    it("uses reference equality for mutable graphs and structural equality after finalization", () => {
+      const graph = directed(["A", "B"], [[0, 1, "edge"]])
+      const left = Graph.beginMutation(graph)
+      const right = Graph.beginMutation(graph)
+      const hash = Hash.hash(left)
+
+      assert.strictEqual(Equal.equals(left, right), false)
+      Graph.addNode(left, "C")
+      assert.strictEqual(Hash.hash(left), hash)
+      const finalized = Graph.endMutation(left)
+      assert.strictEqual(Equal.equals(finalized, directed(["A", "B", "C"], [[0, 1, "edge"]])), true)
+    })
+
+    it("supports undefined node and edge payloads structurally", () => {
+      const make = () => directed<undefined, undefined>([undefined, undefined], [[0, 1, undefined]])
+      assert.strictEqual(Equal.equals(make(), make()), true)
+      assert.strictEqual(Hash.hash(make()), Hash.hash(make()))
+    })
+  })
+
+  describe("mutation lifecycle", () => {
+    it("isolates mutable changes from the source and finalizes to a new immutable graph", () => {
+      const source = directed(["A", "B"], [[0, 1, 1]])
+      const mutable = Graph.beginMutation(source)
+      Graph.addNode(mutable, "C")
+      const result = Graph.endMutation(mutable)
+
+      assert.strictEqual(Graph.nodeCount(source), 2)
+      assert.strictEqual(Graph.nodeCount(result), 3)
+      assert.notStrictEqual(result, source)
+      assert.strictEqual(result.mutable, false)
+    })
+
+    it("supports data-first and data-last scoped mutation", () => {
+      const graph = Graph.directed<string, number>()
+      const first = Graph.mutate(graph, (mutable) => {
+        Graph.addNode(mutable, "A")
+      })
+      const last = graph.pipe(Graph.mutate((mutable) => {
+        Graph.addNode(mutable, "A")
+      }))
+
+      assertSnapshot(first, { type: "directed", nodes: [{ index: 0, data: "A" }], edges: [] })
+      assertSnapshot(last, { type: "directed", nodes: [{ index: 0, data: "A" }], edges: [] })
+    })
+
+    it("finalizes retained handles when callbacks return or throw", () => {
+      let returned: Graph.MutableDirectedGraph<string, number> | undefined
+      Graph.directed<string, number>((mutable) => {
+        returned = mutable
+      })
+      assertGraphError(() => Graph.addNode(returned!, "late"), "Graph is not mutable")
+
+      let thrown: Graph.MutableDirectedGraph<string, number> | undefined
+      const cause = new Error("boom")
+      let actual: unknown
+      try {
+        Graph.mutate(Graph.directed<string, number>(), (mutable) => {
+          thrown = mutable
+          throw cause
+        })
+      } catch (error) {
+        actual = error
+      }
+      assert.strictEqual(actual, cause)
+      assertGraphError(() => Graph.addNode(thrown!, "late"), "Graph is not mutable")
+    })
+
+    it("rejects normal callback return after manual finalization", () => {
+      assertGraphError(() => {
+        Graph.directed<string, number>((mutable) => {
+          Graph.endMutation(mutable)
+        })
+      }, "Graph is not mutable")
+      assertGraphError(() => {
+        Graph.mutate(Graph.directed<string, number>(), (mutable) => {
+          Graph.endMutation(mutable)
+        })
+      }, "Graph is not mutable")
+    })
+
+    it("preserves callback errors after manual finalization", () => {
+      const cause = new Error("callback failure")
+      for (
+        const run of [
+          () =>
+            Graph.directed<string, number>((mutable) => {
+              Graph.endMutation(mutable)
+              throw cause
+            }),
+          () =>
+            Graph.mutate(Graph.directed<string, number>(), (mutable) => {
+              Graph.endMutation(mutable)
+              throw cause
+            })
+        ]
+      ) {
+        let actual: unknown
+        try {
+          run()
+        } catch (error) {
+          actual = error
+        }
+        assert.strictEqual(actual, cause)
+      }
+    })
+
+    it("rejects every mutation entry point on a finalized handle", () => {
+      const mutable = Graph.beginMutation(directed(["A", "B"], [[0, 1, 1]]))
+      Graph.endMutation(mutable)
+      const mutations: ReadonlyArray<() => unknown> = [
+        () => Graph.addNode(mutable, "C"),
+        () => Graph.addEdge(mutable, 1, 0, 2),
+        () => Graph.updateNode(mutable, 0, () => "updated"),
+        () => Graph.updateEdge(mutable, 0, () => 2),
+        () => Graph.removeNode(mutable, 0),
+        () => Graph.removeNodes(mutable, [0]),
+        () => Graph.removeEdge(mutable, 0),
+        () => Graph.removeEdges(mutable, [0]),
+        () => Graph.mapNodes(mutable, () => "mapped"),
+        () => Graph.mapEdges(mutable, () => 3),
+        () => Graph.filterMapNodes(mutable, () => Option.none()),
+        () => Graph.filterMapEdges(mutable, () => Option.none()),
+        () => Graph.filterNodes(mutable, () => true),
+        () => Graph.filterEdges(mutable, () => true),
+        () => Graph.reverse(mutable),
+        () => Graph.endMutation(mutable)
+      ]
+      for (const mutation of mutations) assertGraphError(mutation, "Graph is not mutable")
+    })
+
+    it("rejects nested mutation or finalization from transformation callbacks", () => {
+      const mutable = Graph.beginMutation(directed(["A", "B"], [[0, 1, 1]]))
+      const mutations: ReadonlyArray<() => unknown> = [
+        () => Graph.addNode(mutable, "C"),
+        () => Graph.addEdge(mutable, 1, 0, 2),
+        () => Graph.updateNode(mutable, 0, () => "updated"),
+        () => Graph.updateEdge(mutable, 0, () => 2),
+        () => Graph.removeNode(mutable, 0),
+        () => Graph.removeNodes(mutable, [0]),
+        () => Graph.removeEdge(mutable, 0),
+        () => Graph.removeEdges(mutable, [0]),
+        () => Graph.mapNodes(mutable, (node) => node),
+        () => Graph.mapEdges(mutable, (edge) => edge),
+        () => Graph.filterMapNodes(mutable, (node) => Option.some(node)),
+        () => Graph.filterMapEdges(mutable, (edge) => Option.some(edge)),
+        () => Graph.filterNodes(mutable, () => true),
+        () => Graph.filterEdges(mutable, () => true),
+        () => Graph.reverse(mutable),
+        () => Graph.endMutation(mutable)
+      ]
+
+      for (const mutation of mutations) {
+        assertGraphError(() =>
+          Graph.updateNode(mutable, 0, (node) => {
+            mutation()
+            return node
+          }), "Cannot mutate graph during a transformation")
+      }
+      assertSnapshot(mutable, {
+        type: "directed",
+        nodes: [{ index: 0, data: "A" }, { index: 1, data: "B" }],
+        edges: [{ index: 0, source: 0, target: 1, data: 1 }]
+      })
+    })
+
+    it("guards every transformation callback against nested mutation", () => {
+      const mutable = Graph.beginMutation(directed(["A", "B"], [[0, 1, 1]]))
+      const mutate = () => Graph.addNode(mutable, "C")
+      const transformations: ReadonlyArray<() => unknown> = [
+        () =>
+          Graph.updateNode(mutable, 0, (node) => {
+            mutate()
+            return node
+          }),
+        () =>
+          Graph.updateEdge(mutable, 0, (edge) => {
+            mutate()
+            return edge
+          }),
+        () =>
+          Graph.mapNodes(mutable, (node) => {
+            mutate()
+            return node
+          }),
+        () =>
+          Graph.mapEdges(mutable, (edge) => {
+            mutate()
+            return edge
+          }),
+        () =>
+          Graph.filterMapNodes(mutable, (node) => {
+            mutate()
+            return Option.some(node)
+          }),
+        () =>
+          Graph.filterMapEdges(mutable, (edge) => {
+            mutate()
+            return Option.some(edge)
+          }),
         () =>
           Graph.filterNodes(mutable, () => {
-            Graph.removeNode(mutable, 0)
+            mutate()
             return true
           }),
-        "Cannot mutate graph during a transformation"
-      )
-      assertGraphError(
         () =>
           Graph.filterEdges(mutable, () => {
-            Graph.removeEdge(mutable, 0)
+            mutate()
             return true
-          }),
-        "Cannot mutate graph during a transformation"
-      )
-    })
-
-    it("should not retain node data cached by updateNode callbacks", () => {
-      const mutable = Graph.beginMutation(Graph.directed<string, never>((graph) => {
-        Graph.addNode(graph, "old")
-      }))
-
-      Graph.updateNode(mutable, 0, () => {
-        assert.deepStrictEqual(Array.from(Graph.values(Graph.bfs(mutable, { start: [0] }))), ["old"])
-        return "new"
-      })
-
-      assert.deepStrictEqual(Array.from(Graph.values(Graph.bfs(mutable, { start: [0] }))), ["new"])
-    })
-
-    it("should not retain edge data cached by updateEdge callbacks", () => {
-      const mutable = Graph.beginMutation(Graph.directed<string, number>((graph) => {
-        Graph.addNode(graph, "source")
-        Graph.addNode(graph, "target")
-        Graph.addEdge(graph, 0, 1, 1)
-      }))
-
-      Graph.updateEdge(mutable, 0, () => {
-        assert.deepStrictEqual(Array.from(Graph.simplePaths(mutable, { source: 0, target: 1 }))[0].costs, [1])
-        return 2
-      })
-
-      assert.deepStrictEqual(Array.from(Graph.simplePaths(mutable, { source: 0, target: 1 }))[0].costs, [2])
-    })
-
-    it("should expose earlier node writes to later bulk transform callbacks", () => {
-      const run = (transform: (mutable: Graph.MutableDirectedGraph<string, never>) => void) => {
-        const mutable = Graph.beginMutation(Graph.directed<string, never>((graph) => {
-          Graph.addNode(graph, "a")
-          Graph.addNode(graph, "b")
-        }))
-        transform(mutable)
-        return Array.from(Graph.values(Graph.bfs(mutable, { start: [0, 1] })))
-      }
-
-      assert.deepStrictEqual(
-        run((mutable) => {
-          const seen: Array<Array<string>> = []
-          Graph.mapNodes(mutable, (data) => {
-            seen.push(Array.from(Graph.values(Graph.bfs(mutable, { start: [0, 1] }))))
-            return data.toUpperCase()
           })
-          assert.deepStrictEqual(seen, [["a", "b"], ["A", "b"]])
-        }),
-        ["A", "B"]
-      )
+      ]
 
-      assert.deepStrictEqual(
-        run((mutable) => {
-          const seen: Array<Array<string>> = []
-          Graph.filterMapNodes(mutable, (data) => {
-            seen.push(Array.from(Graph.values(Graph.bfs(mutable, { start: [0, 1] }))))
-            return Option.some(data.toUpperCase())
-          })
-          assert.deepStrictEqual(seen, [["a", "b"], ["A", "b"]])
-        }),
-        ["A", "B"]
-      )
-    })
-
-    it("should expose earlier edge writes to later bulk transform callbacks", () => {
-      const run = (transform: (mutable: Graph.MutableDirectedGraph<string, number>) => void) => {
-        const mutable = Graph.beginMutation(Graph.directed<string, number>((graph) => {
-          Graph.addNode(graph, "source")
-          Graph.addNode(graph, "middle")
-          Graph.addNode(graph, "target")
-          Graph.addEdge(graph, 0, 1, 1)
-          Graph.addEdge(graph, 1, 2, 2)
-        }))
-        transform(mutable)
-        return Option.getOrThrow(Graph.dijkstra(mutable, { source: 0, target: 2, cost: (edge) => edge })).distance
+      for (const transformation of transformations) {
+        assertGraphError(transformation, "Cannot mutate graph during a transformation")
       }
-      const assertTransform = (
-        transform: (
-          mutable: Graph.MutableDirectedGraph<string, number>,
-          inspect: () => number
-        ) => void
-      ) => {
-        const seen: Array<number> = []
-        const distance = run((mutable) =>
-          transform(mutable, () => {
-            const current = Option.getOrThrow(
-              Graph.dijkstra(mutable, { source: 0, target: 2, cost: (edge) => edge })
-            ).distance
-            seen.push(current)
-            return current
-          })
-        )
-        assert.deepStrictEqual(seen, [3, 4])
-        assert.strictEqual(distance, 6)
-      }
-
-      assertTransform((mutable, inspect) =>
-        Graph.mapEdges(mutable, (data) => {
-          inspect()
-          return data * 2
-        })
-      )
-      assertTransform((mutable, inspect) =>
-        Graph.filterMapEdges(mutable, (data) => {
-          inspect()
-          return Option.some(data * 2)
-        })
-      )
     })
   })
 
-  describe("reverse", () => {
-    it("should reverse all edge directions", () => {
-      let nodeA: Graph.NodeIndex
-      let nodeB: Graph.NodeIndex
-      let nodeC: Graph.NodeIndex
-      let edgeAB: Graph.EdgeIndex
-      let edgeBC: Graph.EdgeIndex
-      let edgeCA: Graph.EdgeIndex
+  describe("node operations", () => {
+    it("allocates stable indexes and supports lookup, membership, and count", () => {
+      const mutable = Graph.beginMutation(Graph.directed<string | undefined, never>())
+      assert.strictEqual(Graph.addNode(mutable, undefined), 0)
+      assert.strictEqual(Graph.addNode(mutable, "B"), 1)
 
-      const graph = Graph.directed<string, number>((mutable) => {
-        nodeA = Graph.addNode(mutable, "A")
-        nodeB = Graph.addNode(mutable, "B")
-        nodeC = Graph.addNode(mutable, "C")
-        edgeAB = Graph.addEdge(mutable, nodeA, nodeB, 1) // A -> B
-        edgeBC = Graph.addEdge(mutable, nodeB, nodeC, 2) // B -> C
-        edgeCA = Graph.addEdge(mutable, nodeC, nodeA, 3) // C -> A
-        Graph.reverse(mutable) // Now B -> A, C -> B, A -> C
-      })
-
-      const edge0 = Graph.getEdge(graph, edgeAB!)
-      const edge1 = Graph.getEdge(graph, edgeBC!)
-      const edge2 = Graph.getEdge(graph, edgeCA!)
-
-      assertSome(edge0, { source: nodeB!, target: nodeA!, data: 1 })
-      assertSome(edge1, { source: nodeC!, target: nodeB!, data: 2 })
-      assertSome(edge2, { source: nodeA!, target: nodeC!, data: 3 })
+      assert.strictEqual(Graph.nodeCount(mutable), 2)
+      assert.strictEqual(Graph.hasNode(mutable, 0), true)
+      assert.strictEqual(Graph.hasNode(mutable, 2), false)
+      assert.deepStrictEqual(Graph.getNode(mutable, 0), Option.some(undefined))
+      assert.deepStrictEqual(Graph.getNode(0)(mutable), Option.some(undefined))
+      assert.deepStrictEqual(Graph.getNode(mutable, 2), Option.none())
     })
 
-    it("should update adjacency lists correctly", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1) // A -> B
-        Graph.addEdge(mutable, a, c, 2) // A -> C
-        Graph.reverse(mutable) // Now B -> A, C -> A
-      })
+    it("updates existing payloads and ignores missing indexes", () => {
+      const mutable = Graph.beginMutation(directed<string | undefined, never>([undefined, "B"], []))
+      Graph.updateNode(mutable, 0, () => "A")
+      Graph.updateNode(mutable, 1, () => undefined)
+      Graph.updateNode(mutable, 99, () => "missing")
 
-      // After reversal:
-      // - Node A should have no outgoing edges
-      // - Node B should have edge to A
-      // - Node C should have edge to A
-
-      const neighborsA = Graph.neighbors(graph, 0)
-      const neighborsB = Graph.neighbors(graph, 1)
-      const neighborsC = Graph.neighbors(graph, 2)
-
-      expect(Array.from(neighborsA)).toEqual([]) // A has no outgoing edges
-      expect(Array.from(neighborsB)).toEqual([0]) // B -> A
-      expect(Array.from(neighborsC)).toEqual([0]) // C -> A
+      assert.deepStrictEqual(Array.from(mutable), [[0, "A"], [1, undefined]])
     })
 
-    it("should preserve adjacency lists when adding edges after reversal", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
+    it("finds the first and all matching nodes in graph order", () => {
+      const graph = directed<string | undefined, never>([undefined, "B", undefined], [])
 
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.reverse(mutable)
-        Graph.addEdge(mutable, a, b, 2)
-      })
-
-      expect(Graph.edgeCount(graph)).toBe(2)
-      expect(Graph.neighbors(graph, 0)).toEqual([1])
-      expect(Graph.hasEdge(graph, 0, 1)).toBe(true)
-      expect(Graph.hasEdge(graph, 1, 0)).toBe(true)
-    })
-
-    it("should be a no-op for undirected graphs", () => {
-      const graph = Graph.undirected<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.reverse(mutable)
-      })
-
-      expect(Graph.neighbors(graph, 0)).toEqual([1])
-      expect(Graph.neighbors(graph, 1)).toEqual([0])
-      expect(Graph.hasEdge(graph, 0, 1)).toBe(true)
-      expect(Graph.hasEdge(graph, 1, 0)).toBe(true)
+      assert.deepStrictEqual(Graph.findNode(graph, (node) => node === undefined), Option.some(0))
+      assert.deepStrictEqual(Graph.findNode((node: string | undefined) => node === "missing")(graph), Option.none())
+      assert.deepStrictEqual(Graph.findNodes(graph, (node) => node === undefined), [0, 2])
     })
   })
 
-  describe("filterMapNodes", () => {
-    it("should filter and transform nodes", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "active")
-        Graph.addNode(mutable, "inactive")
-        Graph.addNode(mutable, "active")
-        Graph.addNode(mutable, "pending")
-
-        // Keep only "active" nodes and transform to uppercase
-        Graph.filterMapNodes(mutable, (data) => data === "active" ? Option.some(data.toUpperCase()) : Option.none())
+  describe("edge operations", () => {
+    it("allocates parallel edges and self-loops with exact stored orientation", () => {
+      const graph = Graph.undirected<string, string>((mutable) => {
+        Graph.addNode(mutable, "A")
+        Graph.addNode(mutable, "B")
+        assert.strictEqual(Graph.addEdge(mutable, 1, 0, "first"), 0)
+        assert.strictEqual(Graph.addEdge(mutable, 1, 0, "parallel"), 1)
+        assert.strictEqual(Graph.addEdge(mutable, 0, 0, "loop"), 2)
       })
 
-      // Should only have 2 nodes remaining (the "active" ones)
-      expect(Graph.nodeCount(graph)).toBe(2)
-
-      // Check the remaining nodes have been transformed
-      const nodeData0 = Graph.getNode(graph, 0)
-      const nodeData2 = Graph.getNode(graph, 2)
-
-      expect(Option.isSome(nodeData0)).toBe(true)
-      expect(Option.isSome(nodeData2)).toBe(true)
-
-      if (Option.isSome(nodeData0) && Option.isSome(nodeData2)) {
-        expect(nodeData0.value).toBe("ACTIVE")
-        expect(nodeData2.value).toBe("ACTIVE")
-      }
-
-      // Filtered out nodes should not exist
-      expect(Option.isNone(Graph.getNode(graph, 1))).toBe(true)
-      expect(Option.isNone(Graph.getNode(graph, 3))).toBe(true)
+      assertSnapshot(graph, {
+        type: "undirected",
+        nodes: [{ index: 0, data: "A" }, { index: 1, data: "B" }],
+        edges: [
+          { index: 0, source: 1, target: 0, data: "first" },
+          { index: 1, source: 1, target: 0, data: "parallel" },
+          { index: 2, source: 0, target: 0, data: "loop" }
+        ]
+      })
     })
 
-    it("should remove edges connected to filtered nodes", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "keep")
-        const b = Graph.addNode(mutable, "remove")
-        const c = Graph.addNode(mutable, "keep")
-
-        Graph.addEdge(mutable, a, b, 1) // keep -> remove
-        Graph.addEdge(mutable, b, c, 2) // remove -> keep
-        Graph.addEdge(mutable, a, c, 3) // keep -> keep
-
-        // Filter out "remove" nodes
-        Graph.filterMapNodes(mutable, (data) => data === "keep" ? Option.some(data) : Option.none())
-      })
-
-      // Should have 2 nodes and 1 edge remaining
-      expect(Graph.nodeCount(graph)).toBe(2)
-      expect(Graph.edgeCount(graph)).toBe(1)
-
-      // Only the keep -> keep edge should remain
-      const remainingEdge = Graph.getEdge(graph, 2)
-      assertSome(remainingEdge, { source: 0, target: 2, data: 3 })
-
-      // Edges involving removed node should be gone
-      expect(Graph.getEdge(graph, 0)).toEqual(Option.none())
-      expect(Graph.getEdge(graph, 1)).toEqual(Option.none())
+    it("rejects missing edge endpoints", () => {
+      const mutable = Graph.beginMutation(directed<string, number>(["A"], []))
+      assertGraphError(() => Graph.addEdge(mutable, 1, 0, 1), "Node 1 does not exist")
+      assertGraphError(() => Graph.addEdge(mutable, 0, 1, 1), "Node 1 does not exist")
     })
 
-    it("should handle transformation without filtering", () => {
-      const graph = Graph.directed<number, string>((mutable) => {
-        Graph.addNode(mutable, 1)
-        Graph.addNode(mutable, 2)
-        Graph.addNode(mutable, 3)
+    it("gets and updates undefined edge data without exposing stored records", () => {
+      const mutable = Graph.beginMutation(directed<string, number | undefined>(["A", "B"], [[0, 1, undefined]]))
+      const fromGetter = Option.getOrThrow(Graph.getEdge(mutable, 0))
+      const fromWalker = Array.from(Graph.values(Graph.edges(mutable)))[0]
+      ;(fromGetter as { source: number; data: number | undefined }).source = 1
+      ;(fromGetter as { source: number; data: number | undefined }).data = 1
+      ;(fromWalker as { target: number; data: number | undefined }).target = 0
+      ;(fromWalker as { target: number; data: number | undefined }).data = 1
 
-        // Transform all nodes by doubling them
-        Graph.filterMapNodes(mutable, (data) => Option.some(data * 2))
+      assert.deepStrictEqual(Graph.getEdge(mutable, 0), Option.some({ source: 0, target: 1, data: undefined }))
+      assertSnapshot(mutable, {
+        type: "directed",
+        nodes: [{ index: 0, data: "A" }, { index: 1, data: "B" }],
+        edges: [{ index: 0, source: 0, target: 1, data: undefined }]
       })
+      assert.deepStrictEqual(Graph.neighbors(mutable, 0), [1])
+      assert.deepStrictEqual(Graph.neighbors(mutable, 1), [])
 
-      expect(Graph.nodeCount(graph)).toBe(3)
+      Graph.updateEdge(mutable, 0, () => 2)
+      Graph.updateEdge(mutable, 99, () => 3)
 
-      const node0 = Graph.getNode(graph, 0)
-      const node1 = Graph.getNode(graph, 1)
-      const node2 = Graph.getNode(graph, 2)
-
-      assertSome(node0, 2)
-      assertSome(node1, 4)
-      assertSome(node2, 6)
+      assert.deepStrictEqual(Graph.getEdge(mutable, 0), Option.some({ source: 0, target: 1, data: 2 }))
+      assert.deepStrictEqual(Graph.getEdge(99)(mutable), Option.none())
+      assertSnapshot(mutable, {
+        type: "directed",
+        nodes: [{ index: 0, data: "A" }, { index: 1, data: "B" }],
+        edges: [{ index: 0, source: 0, target: 1, data: 2 }]
+      })
+      assert.deepStrictEqual(Graph.neighbors(mutable, 0), [1])
     })
 
-    it("should handle filtering without transformation", () => {
-      const graph = Graph.directed<number, string>((mutable) => {
-        Graph.addNode(mutable, 1)
-        Graph.addNode(mutable, 2)
-        Graph.addNode(mutable, 3)
-        Graph.addNode(mutable, 4)
+    it("removes parallel undirected edges and self-loops independently", () => {
+      const mutable = Graph.beginMutation(undirected(["A", "B"], [[1, 0, "first"], [0, 1, "second"], [1, 1, "loop"]]))
+      Graph.removeEdge(mutable, 0)
+      Graph.removeEdge(mutable, 2)
+      Graph.removeEdge(mutable, 99)
 
-        // Keep only even numbers
-        Graph.filterMapNodes(mutable, (data) => data % 2 === 0 ? Option.some(data) : Option.none())
+      assertSnapshot(mutable, {
+        type: "undirected",
+        nodes: [{ index: 0, data: "A" }, { index: 1, data: "B" }],
+        edges: [{ index: 1, source: 0, target: 1, data: "second" }]
       })
+      assert.deepStrictEqual(Graph.neighbors(mutable, 0), [1])
+      assert.deepStrictEqual(Graph.neighbors(mutable, 1), [0])
+    })
 
-      expect(Graph.nodeCount(graph)).toBe(2)
+    it("removes undirected nodes with reversed edges, parallel edges, and self-loops", () => {
+      const mutable = Graph.beginMutation(undirected(["A", "B", "C"], [
+        [1, 0, "reverse"],
+        [0, 1, "parallel"],
+        [1, 1, "loop"],
+        [2, 0, "keep"]
+      ]))
+      Graph.removeNode(mutable, 1)
 
-      const node1 = Graph.getNode(graph, 1)
-      const node3 = Graph.getNode(graph, 3)
+      assertSnapshot(mutable, {
+        type: "undirected",
+        nodes: [{ index: 0, data: "A" }, { index: 2, data: "C" }],
+        edges: [{ index: 3, source: 2, target: 0, data: "keep" }]
+      })
+    })
 
-      assertSome(node1, 2)
-      assertSome(node3, 4)
+    it("collects graph-backed iterables before bulk removal", () => {
+      const edges = Graph.beginMutation(directed(["A", "B"], [[0, 1, 1], [1, 0, 2]]))
+      Graph.removeEdges(edges, Graph.indices(Graph.edges(edges)))
+      assert.strictEqual(Graph.edgeCount(edges), 0)
 
-      // Odd numbers should be removed
-      assertNone(Graph.getNode(graph, 0))
-      assertNone(Graph.getNode(graph, 2))
+      const nodes = Graph.beginMutation(directed<string, never>(["A", "B"], []))
+      Graph.removeNodes(nodes, Graph.indices(Graph.nodes(nodes)))
+      assert.strictEqual(Graph.nodeCount(nodes), 0)
     })
   })
 
-  describe("filterMapEdges", () => {
-    it("should filter and transform edges", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 5) // Remove (< 10)
-        Graph.addEdge(mutable, b, c, 15) // Keep and double (30)
-        Graph.addEdge(mutable, c, a, 25) // Keep and double (50)
+  describe("transformations", () => {
+    it("maps nodes and edges while preserving indexes and structure", () => {
+      const mutable = Graph.beginMutation(directed(["a", "b"], [[0, 1, 2]]))
+      Graph.mapNodes(mutable, (node) => node.toUpperCase())
+      Graph.mapEdges(mutable, (edge) => edge * 3)
 
-        // Keep only edges with weight >= 10 and double their weight
-        Graph.filterMapEdges(mutable, (data) => data >= 10 ? Option.some(data * 2) : Option.none())
+      assertSnapshot(mutable, {
+        type: "directed",
+        nodes: [{ index: 0, data: "A" }, { index: 1, data: "B" }],
+        edges: [{ index: 0, source: 0, target: 1, data: 6 }]
       })
-
-      // Should have 2 edges remaining
-      expect(Graph.edgeCount(graph)).toBe(2)
-      expect(Graph.nodeCount(graph)).toBe(3) // All nodes should remain
-
-      // Check that remaining edges have been transformed
-      const edge1 = Graph.getEdge(graph, 1)
-      const edge2 = Graph.getEdge(graph, 2)
-
-      assertSome(edge1, { source: 1, target: 2, data: 30 }) // 15 * 2
-      assertSome(edge2, { source: 2, target: 0, data: 50 }) // 25 * 2
-
-      // Filtered out edge should not exist
-      expect(Graph.getEdge(graph, 0)).toEqual(Option.none())
-
-      const expected = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        const removed = Graph.addEdge(mutable, a, b, 5)
-        Graph.addEdge(mutable, b, c, 30)
-        Graph.addEdge(mutable, c, a, 50)
-        Graph.removeEdge(mutable, removed)
-      })
-
-      strictEqual(Equal.equals(graph, expected), true)
     })
 
-    it("should update adjacency lists when removing edges", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
+    it("filter-maps nodes and removes incident edges", () => {
+      const mutable = Graph.beginMutation(directed([1, 2, 3], [[0, 1, "remove"], [1, 2, "remove"], [0, 2, "keep"]]))
+      Graph.filterMapNodes(mutable, (node) => node === 2 ? Option.none() : Option.some(node * 10))
 
-        Graph.addEdge(mutable, a, b, 1) // Keep
-        Graph.addEdge(mutable, a, c, 2) // Remove
-        Graph.addEdge(mutable, b, c, 3) // Keep
-
-        // Keep only odd numbers
-        Graph.filterMapEdges(mutable, (data) => data % 2 === 1 ? Option.some(data) : Option.none())
+      assertSnapshot(mutable, {
+        type: "directed",
+        nodes: [{ index: 0, data: 10 }, { index: 2, data: 30 }],
+        edges: [{ index: 2, source: 0, target: 2, data: "keep" }]
       })
-
-      // Should have 2 edges remaining (1 and 3)
-      expect(Graph.edgeCount(graph)).toBe(2)
-
-      // Check adjacency: A should only connect to B now
-      const neighborsA = Array.from(Graph.neighbors(graph, 0))
-      expect(neighborsA).toEqual([1]) // A -> B only
-
-      // Check that B still connects to C
-      const neighborsB = Array.from(Graph.neighbors(graph, 1))
-      expect(neighborsB).toEqual([2]) // B -> C
-
-      // Check that C has no outgoing edges
-      const neighborsC = Array.from(Graph.neighbors(graph, 2))
-      expect(neighborsC).toEqual([]) // C has no outgoing edges
     })
 
-    it("should handle transformation without filtering", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 10)
-        Graph.addEdge(mutable, b, c, 20)
-        Graph.addEdge(mutable, c, a, 30)
+    it("filter-maps edges without removing nodes", () => {
+      const mutable = Graph.beginMutation(directed(["A", "B", "C"], [[0, 1, 1], [1, 2, 2], [2, 0, 3]]))
+      Graph.filterMapEdges(mutable, (edge) => edge % 2 === 0 ? Option.none() : Option.some(edge * 10))
 
-        // Transform all edges by adding 100
-        Graph.filterMapEdges(mutable, (data) => Option.some(data + 100))
+      assertSnapshot(mutable, {
+        type: "directed",
+        nodes: [{ index: 0, data: "A" }, { index: 1, data: "B" }, { index: 2, data: "C" }],
+        edges: [{ index: 0, source: 0, target: 1, data: 10 }, { index: 2, source: 2, target: 0, data: 30 }]
       })
-
-      expect(Graph.edgeCount(graph)).toBe(3)
-
-      const edge0 = Graph.getEdge(graph, 0)
-      const edge1 = Graph.getEdge(graph, 1)
-      const edge2 = Graph.getEdge(graph, 2)
-
-      expect(assertSomeEdge(edge0).data).toBe(110)
-      expect(assertSomeEdge(edge1).data).toBe(120)
-      expect(assertSomeEdge(edge2).data).toBe(130)
     })
 
-    it("should handle filtering without transformation", () => {
-      const graph = Graph.directed<string, { weight: number; type: string }>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, { weight: 10, type: "primary" })
-        Graph.addEdge(mutable, b, c, { weight: 20, type: "secondary" })
-        Graph.addEdge(mutable, c, a, { weight: 30, type: "primary" })
-
-        // Keep only "primary" edges
-        Graph.filterMapEdges(mutable, (data) => data.type === "primary" ? Option.some(data) : Option.none())
-      })
-
-      expect(Graph.edgeCount(graph)).toBe(2)
-
-      const edge0 = Graph.getEdge(graph, 0)
-      const edge2 = Graph.getEdge(graph, 2)
-
-      expect(assertSomeEdge(edge0).data.type).toBe("primary")
-      expect(assertSomeEdge(edge2).data.type).toBe("primary")
-
-      // Secondary edge should be removed
-      expect(Graph.getEdge(graph, 1)).toEqual(Option.none())
-    })
-  })
-
-  describe("filterNodes", () => {
-    it("should filter nodes by predicate", () => {
-      let activeNode1: Graph.NodeIndex
-      let inactiveNode: Graph.NodeIndex
-      let activeNode2: Graph.NodeIndex
-      let pendingNode: Graph.NodeIndex
-
-      const graph = Graph.directed<string, number>((mutable) => {
-        activeNode1 = Graph.addNode(mutable, "active")
-        inactiveNode = Graph.addNode(mutable, "inactive")
-        activeNode2 = Graph.addNode(mutable, "active")
-        pendingNode = Graph.addNode(mutable, "pending")
-
-        // Keep only "active" nodes
-        Graph.filterNodes(mutable, (data) => data === "active")
-      })
-
-      expect(Graph.nodeCount(graph)).toBe(2)
-
-      const node0 = Graph.getNode(graph, activeNode1!)
-      const node2 = Graph.getNode(graph, activeNode2!)
-
-      assertSome(node0, "active")
-      assertSome(node2, "active")
-
-      // Filtered out nodes should be removed
-      assertNone(Graph.getNode(graph, inactiveNode!))
-      assertNone(Graph.getNode(graph, pendingNode!))
-    })
-
-    it("should remove connected edges when filtering nodes", () => {
-      let edgeAB: Graph.EdgeIndex
-      let edgeBC: Graph.EdgeIndex
-      let edgeAC: Graph.EdgeIndex
-
-      const graph = Graph.directed<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "keep")
-        const b = Graph.addNode(mutable, "remove")
-        const c = Graph.addNode(mutable, "keep")
-
-        edgeAB = Graph.addEdge(mutable, a, b, "A-B")
-        edgeBC = Graph.addEdge(mutable, b, c, "B-C")
-        edgeAC = Graph.addEdge(mutable, a, c, "A-C")
-
-        // Remove node "remove"
-        Graph.filterNodes(mutable, (data) => data === "keep")
-      })
-
-      expect(Graph.nodeCount(graph)).toBe(2) // Only "keep" nodes remain
-      expect(Graph.edgeCount(graph)).toBe(1) // Only A-C edge remains
-
-      // Check remaining edge
-      const edge2 = Graph.getEdge(graph, edgeAC!)
-      assertSome(edge2, { source: 0, target: 2, data: "A-C" })
-
-      // Check removed edges
-      expect(Graph.getEdge(graph, edgeAB!)).toEqual(Option.none()) // A-B removed
-      expect(Graph.getEdge(graph, edgeBC!)).toEqual(Option.none()) // B-C removed
-    })
-  })
-
-  describe("filterEdges", () => {
-    it("should filter edges by predicate", () => {
-      let edgeAB: Graph.EdgeIndex
-      let edgeBC: Graph.EdgeIndex
-      let edgeCA: Graph.EdgeIndex
-
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-
-        edgeAB = Graph.addEdge(mutable, a, b, 5)
-        edgeBC = Graph.addEdge(mutable, b, c, 15)
-        edgeCA = Graph.addEdge(mutable, c, a, 25)
-
-        // Keep only edges with weight >= 10
-        Graph.filterEdges(mutable, (data) => data >= 10)
-      })
-
-      expect(Graph.nodeCount(graph)).toBe(3) // All nodes remain
-      expect(Graph.edgeCount(graph)).toBe(2) // Edge with weight 5 removed
-
-      const edge1 = Graph.getEdge(graph, edgeBC!)
-      const edge2 = Graph.getEdge(graph, edgeCA!)
-
-      assertSome(edge1, { source: 1, target: 2, data: 15 })
-      assertSome(edge2, { source: 2, target: 0, data: 25 })
-
-      // Edge with weight 5 should be removed
-      expect(Graph.getEdge(graph, edgeAB!)).toEqual(Option.none())
-    })
-
-    it("should update adjacency lists when filtering edges", () => {
-      let nodeA: Graph.NodeIndex
-      let nodeB: Graph.NodeIndex
-      let nodeC: Graph.NodeIndex
-
-      const graph = Graph.directed<string, string>((mutable) => {
-        nodeA = Graph.addNode(mutable, "A")
-        nodeB = Graph.addNode(mutable, "B")
-        nodeC = Graph.addNode(mutable, "C")
-
-        Graph.addEdge(mutable, nodeA, nodeB, "primary")
-        Graph.addEdge(mutable, nodeA, nodeC, "secondary")
-        Graph.addEdge(mutable, nodeB, nodeC, "primary")
-
-        // Keep only "primary" edges
-        Graph.filterEdges(mutable, (data) => data === "primary")
-      })
-
-      expect(Graph.edgeCount(graph)).toBe(2)
-
-      // Check adjacency - A should only connect to B now
-      const neighborsA = Array.from(Graph.neighbors(graph, nodeA!))
-      expect(neighborsA).toEqual([nodeB!]) // A -> B only
-
-      const neighborsB = Array.from(Graph.neighbors(graph, nodeB!))
-      expect(neighborsB).toEqual([nodeC!]) // B -> C
-
-      const neighborsC = Array.from(Graph.neighbors(graph, nodeC!))
-      expect(neighborsC).toEqual([]) // C has no outgoing edges
-    })
-  })
-
-  describe("addEdge", () => {
-    it("should add an edge between two existing nodes", () => {
-      let edgeIndex: Graph.EdgeIndex
-
-      const result = Graph.directed<string, number>((mutable) => {
-        const nodeA = Graph.addNode(mutable, "Node A")
-        const nodeB = Graph.addNode(mutable, "Node B")
-        edgeIndex = Graph.addEdge(mutable, nodeA, nodeB, 42)
-      })
-
-      expect(edgeIndex!).toBe(0)
-      expect(Graph.edgeCount(result)).toBe(1)
-    })
-
-    it("should add multiple edges with sequential indices", () => {
-      let edgeA: Graph.EdgeIndex
-      let edgeB: Graph.EdgeIndex
-      let edgeC: Graph.EdgeIndex
-
-      const result = Graph.directed<string, number>((mutable) => {
-        const nodeA = Graph.addNode(mutable, "Node A")
-        const nodeB = Graph.addNode(mutable, "Node B")
-        const nodeC = Graph.addNode(mutable, "Node C")
-
-        edgeA = Graph.addEdge(mutable, nodeA, nodeB, 10)
-        edgeB = Graph.addEdge(mutable, nodeB, nodeC, 20)
-        edgeC = Graph.addEdge(mutable, nodeA, nodeC, 30)
-      })
-
-      expect(edgeA!).toBe(0)
-      expect(edgeB!).toBe(1)
-      expect(edgeC!).toBe(2)
-      expect(Graph.edgeCount(result)).toBe(3)
-    })
-
-    it("should throw error when source node doesn't exist", () => {
-      expect(() => {
-        Graph.directed<string, number>((mutable) => {
-          const nodeB = Graph.addNode(mutable, "Node B")
-          const nonExistentNode = 999
-          Graph.addEdge(mutable, nonExistentNode, nodeB, 42)
-        })
-      }).toThrow("Node 999 does not exist")
-    })
-
-    it("should throw error when target node doesn't exist", () => {
-      expect(() => {
-        Graph.directed<string, number>((mutable) => {
-          const nodeA = Graph.addNode(mutable, "Node A")
-          const nonExistentNode = 999
-          Graph.addEdge(mutable, nodeA, nonExistentNode, 42)
-        })
-      }).toThrow("Node 999 does not exist")
-    })
-  })
-
-  describe("removeNode", () => {
-    it("should remove a node and all its incident edges", () => {
-      const result = Graph.directed<string, number>((mutable) => {
-        const nodeA = Graph.addNode(mutable, "Node A")
-        const nodeB = Graph.addNode(mutable, "Node B")
-        const nodeC = Graph.addNode(mutable, "Node C")
-
-        Graph.addEdge(mutable, nodeA, nodeB, 10)
-        Graph.addEdge(mutable, nodeB, nodeC, 20)
-        Graph.addEdge(mutable, nodeC, nodeA, 30)
-
-        expect(Graph.nodeCount(mutable)).toBe(3)
-        expect(Graph.edgeCount(mutable)).toBe(3)
-
-        // Remove nodeB which has 2 incident edges
-        Graph.removeNode(mutable, nodeB)
-
-        expect(Graph.nodeCount(mutable)).toBe(2)
-        expect(Graph.edgeCount(mutable)).toBe(1) // Only nodeC -> nodeA edge remains
-      })
-
-      expect(Graph.nodeCount(result)).toBe(2)
-      expect(Graph.edgeCount(result)).toBe(1)
-    })
-
-    it("should handle removing non-existent node gracefully", () => {
-      const result = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "Node A") // Just need one node for count
-        const nonExistentNode = 999
-
-        expect(Graph.nodeCount(mutable)).toBe(1)
-        Graph.removeNode(mutable, nonExistentNode) // Should not throw
-        expect(Graph.nodeCount(mutable)).toBe(1) // Should remain unchanged
-      })
-
-      expect(Graph.nodeCount(result)).toBe(1)
-    })
-
-    it("should handle isolated node removal", () => {
-      const result = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "Node A") // Keep for final count
-        const nodeB = Graph.addNode(mutable, "Node B") // Isolated node to remove
-
-        expect(Graph.nodeCount(mutable)).toBe(2)
-        expect(Graph.edgeCount(mutable)).toBe(0)
-
-        Graph.removeNode(mutable, nodeB)
-
-        expect(Graph.nodeCount(mutable)).toBe(1)
-        expect(Graph.edgeCount(mutable)).toBe(0)
-      })
-
-      expect(Graph.nodeCount(result)).toBe(1)
-    })
-  })
-
-  describe("removeNodes", () => {
-    it("should remove nodes, incident edges, and ignore duplicate or missing indices", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        for (const node of ["A", "B", "C"]) {
-          Graph.addNode(mutable, node)
-        }
-        Graph.addEdge(mutable, 0, 1, 1)
-        Graph.addEdge(mutable, 1, 2, 2)
-        Graph.addEdge(mutable, 2, 0, 3)
-
-        Graph.removeNodes(mutable, [1, 1, 999])
-      })
-
-      assert.deepStrictEqual(Graph.toSnapshot(graph), {
+    it("filters nodes and removes their incident edges", () => {
+      const nodes = Graph.beginMutation(directed(["A", "B", "C"], [[0, 1, 1], [1, 2, 2], [0, 2, 3]]))
+      Graph.filterNodes(nodes, (node) => node !== "B")
+      assertSnapshot(nodes, {
         type: "directed",
         nodes: [{ index: 0, data: "A" }, { index: 2, data: "C" }],
-        edges: [{ index: 2, source: 2, target: 0, data: 3 }]
+        edges: [{ index: 2, source: 0, target: 2, data: 3 }]
       })
     })
 
-    it("should collect graph-backed iterables before removing nodes", () => {
-      const graph = Graph.directed<string, never>((mutable) => {
-        Graph.addNode(mutable, "A")
-        Graph.addNode(mutable, "B")
-
-        Graph.removeNodes(mutable, Graph.indices(Graph.nodes(mutable)))
+    it("filters edges without removing nodes", () => {
+      const edges = Graph.beginMutation(directed(["A", "B", "C"], [[0, 1, 1], [1, 2, 2], [0, 2, 3]]))
+      Graph.filterEdges(edges, (edge) => edge % 2 === 1)
+      assertSnapshot(edges, {
+        type: "directed",
+        nodes: [{ index: 0, data: "A" }, { index: 1, data: "B" }, { index: 2, data: "C" }],
+        edges: [{ index: 0, source: 0, target: 1, data: 1 }, { index: 2, source: 0, target: 2, data: 3 }]
       })
-
-      strictEqual(Graph.nodeCount(graph), 0)
-    })
-  })
-
-  describe("removeEdge", () => {
-    it("should remove an edge between two nodes", () => {
-      let edgeIndex: Graph.EdgeIndex
-
-      const result = Graph.directed<string, number>((mutable) => {
-        const nodeA = Graph.addNode(mutable, "Node A")
-        const nodeB = Graph.addNode(mutable, "Node B")
-        edgeIndex = Graph.addEdge(mutable, nodeA, nodeB, 42)
-
-        expect(Graph.edgeCount(mutable)).toBe(1)
-
-        Graph.removeEdge(mutable, edgeIndex)
-
-        expect(Graph.edgeCount(mutable)).toBe(0)
-      })
-
-      expect(Graph.edgeCount(result)).toBe(0)
     })
 
-    it("should handle removing non-existent edge gracefully", () => {
-      const result = Graph.directed<string, number>((mutable) => {
-        const nodeA = Graph.addNode(mutable, "Node A")
-        const nodeB = Graph.addNode(mutable, "Node B")
-        Graph.addEdge(mutable, nodeA, nodeB, 42)
-
-        const nonExistentEdge = 999
-
-        expect(Graph.edgeCount(mutable)).toBe(1)
-        Graph.removeEdge(mutable, nonExistentEdge) // Should not throw
-        expect(Graph.edgeCount(mutable)).toBe(1) // Should remain unchanged
+    it("exposes earlier bulk writes to later callbacks", () => {
+      const nodes = Graph.beginMutation(directed<string, never>(["a", "b"], []))
+      const nodeStates: Array<Array<string>> = []
+      Graph.mapNodes(nodes, (node) => {
+        nodeStates.push(Array.from(Graph.values(Graph.nodes(nodes))))
+        return node.toUpperCase()
       })
+      assert.deepStrictEqual(nodeStates, [["a", "b"], ["A", "b"]])
 
-      expect(Graph.edgeCount(result)).toBe(1)
+      const edges = Graph.beginMutation(directed(["A", "B", "C"], [[0, 1, 1], [1, 2, 2]]))
+      const edgeStates: Array<Array<number>> = []
+      Graph.mapEdges(edges, (edge) => {
+        edgeStates.push(Array.from(Graph.values(Graph.edges(edges)), (value) => value.data))
+        return edge * 2
+      })
+      assert.deepStrictEqual(edgeStates, [[1, 2], [2, 2]])
     })
 
-    it("should handle multiple edges between same nodes", () => {
-      const result = Graph.directed<string, number>((mutable) => {
-        const nodeA = Graph.addNode(mutable, "Node A")
-        const nodeB = Graph.addNode(mutable, "Node B")
-
-        const edge1 = Graph.addEdge(mutable, nodeA, nodeB, 10)
-        const edge2 = Graph.addEdge(mutable, nodeA, nodeB, 20)
-
-        expect(Graph.edgeCount(mutable)).toBe(2)
-
-        Graph.removeEdge(mutable, edge1)
-
-        expect(Graph.edgeCount(mutable)).toBe(1)
-
-        // Verify second edge still exists
-        assertSome(Graph.getEdge(mutable, edge2), { source: nodeA, target: nodeB, data: 20 })
+    it("publishes updated callback values to subsequent graph reads", () => {
+      const nodes = Graph.beginMutation(directed<string, never>(["old"], []))
+      Graph.updateNode(nodes, 0, () => {
+        assert.deepStrictEqual(Array.from(Graph.values(Graph.bfs(nodes, { start: [0] }))), ["old"])
+        return "new"
       })
+      assert.deepStrictEqual(Array.from(Graph.values(Graph.bfs(nodes, { start: [0] }))), ["new"])
 
-      expect(Graph.edgeCount(result)).toBe(1)
+      const edges = Graph.beginMutation(directed(["source", "target"], [[0, 1, 1]]))
+      Graph.updateEdge(edges, 0, () => {
+        assert.deepStrictEqual(Array.from(Graph.simplePaths(edges, { source: 0, target: 1 }))[0].costs, [1])
+        return 2
+      })
+      assert.deepStrictEqual(Array.from(Graph.simplePaths(edges, { source: 0, target: 1 }))[0].costs, [2])
+    })
+
+    it("reverses directed edges and leaves undirected stored orientation unchanged", () => {
+      const directedMutable = Graph.beginMutation(directed(["A", "B", "C"], [[0, 1, 1], [1, 2, 2]]))
+      Graph.reverse(directedMutable)
+      Graph.addEdge(directedMutable, 0, 1, 3)
+      assert.deepStrictEqual(Graph.toSnapshot(directedMutable).edges, [
+        { index: 0, source: 1, target: 0, data: 1 },
+        { index: 1, source: 2, target: 1, data: 2 },
+        { index: 2, source: 0, target: 1, data: 3 }
+      ])
+      assert.deepStrictEqual(Graph.neighbors(directedMutable, 2), [1])
+      assert.strictEqual(Graph.hasEdge(directedMutable, 1, 0), true)
+      assert.strictEqual(Graph.hasEdge(directedMutable, 0, 1), true)
+
+      const undirectedMutable = Graph.beginMutation(undirected(["A", "B"], [[1, 0, 1]]))
+      Graph.reverse(undirectedMutable)
+      assert.deepStrictEqual(Graph.toSnapshot(undirectedMutable).edges, [{ index: 0, source: 1, target: 0, data: 1 }])
     })
   })
 
-  describe("removeEdges", () => {
-    it("should remove edges and ignore duplicate or missing indices", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-        Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, 0, 1, 1)
-        Graph.addEdge(mutable, 1, 0, 2)
+  describe("set operations", () => {
+    type Node = { readonly id: string; readonly label: string }
+    const left = () =>
+      directed<Node, string>(
+        [{ id: "a", label: "A1" }, { id: "b", label: "B1" }, { id: "c", label: "C1" }],
+        [[0, 1, "left"], [1, 2, "shared"]]
+      )
+    const right = () =>
+      directed<Node, string>(
+        [{ id: "b", label: "B2" }, { id: "c", label: "C2" }, { id: "d", label: "D2" }],
+        [[0, 1, "shared"], [1, 2, "right"]]
+      )
+    const identity = { nodeIdentity: (node: Node) => node.id }
+    const semantic = (graph: Graph.Graph<Node, string>) => {
+      const nodes = new Map(Array.from(graph, ([index, node]) => [index, node]))
+      return {
+        nodes: Array.from(nodes.values(), (node) => `${node.id}:${node.label}`).sort(),
+        edges: Array.from(
+          Graph.values(Graph.edges(graph)),
+          (edge) => `${nodes.get(edge.source)!.id}->${nodes.get(edge.target)!.id}:${edge.data}`
+        ).sort()
+      }
+    }
 
-        Graph.removeEdges(mutable, [0, 0, 999])
-      })
-
-      assert.deepStrictEqual(Graph.toSnapshot(graph).edges, [{ index: 1, source: 1, target: 0, data: 2 }])
+    it("composes, intersects, differs, and symmetrically differs by projected identity", () => {
+      const composed = {
+        nodes: ["a:A1", "b:B2", "c:C2", "d:D2"],
+        edges: ["a->b:left", "b->c:shared", "c->d:right"]
+      }
+      const intersected = {
+        nodes: ["b:B1", "c:C1"],
+        edges: ["b->c:shared"]
+      }
+      const differed = {
+        nodes: ["a:A1", "b:B1", "c:C1"],
+        edges: ["a->b:left"]
+      }
+      const symmetric = {
+        nodes: ["a:A1", "b:B2", "c:C2", "d:D2"],
+        edges: ["a->b:left", "c->d:right"]
+      }
+      assert.deepStrictEqual(semantic(Graph.compose(left(), right(), identity)), composed)
+      assert.deepStrictEqual(semantic(Graph.compose(right(), identity)(left())), composed)
+      assert.deepStrictEqual(semantic(Graph.intersection(left(), right(), identity)), intersected)
+      assert.deepStrictEqual(semantic(Graph.intersection(right(), identity)(left())), intersected)
+      assert.deepStrictEqual(semantic(Graph.difference(left(), right(), identity)), differed)
+      assert.deepStrictEqual(semantic(Graph.difference(right(), identity)(left())), differed)
+      assert.deepStrictEqual(semantic(Graph.symmetricDifference(left(), right(), identity)), symmetric)
+      assert.deepStrictEqual(semantic(Graph.symmetricDifference(right(), identity)(left())), symmetric)
     })
 
-    it("should collect graph-backed iterables before removing edges", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-        Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, 0, 1, 1)
-        Graph.addEdge(mutable, 1, 0, 2)
-
-        Graph.removeEdges(mutable, Graph.indices(Graph.edges(mutable)))
-      })
-
-      strictEqual(Graph.edgeCount(graph), 0)
-    })
-  })
-
-  describe("getEdge", () => {
-    it("should return edge data for existing edge", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const nodeA = Graph.addNode(mutable, "Node A")
-        const nodeB = Graph.addNode(mutable, "Node B")
-        Graph.addEdge(mutable, nodeA, nodeB, 42)
-      })
-
-      const edgeIndex = 0
-      const edge = Graph.getEdge(graph, edgeIndex)
-
-      assertSome(edge, { source: 0, target: 1, data: 42 })
-    })
-
-    it("should return None for non-existent edge", () => {
-      const graph = Graph.directed<string, number>()
-      const edgeIndex = 999
-      const edge = Graph.getEdge(graph, edgeIndex)
-
-      expect(edge).toEqual(Option.none())
-    })
-
-    it("does not expose internally stored edges", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const source = Graph.addNode(mutable, "source")
-        const target = Graph.addNode(mutable, "target")
-        Graph.addEdge(mutable, source, target, 1)
-      })
-      const fromGetter = Option.getOrThrow(Graph.getEdge(graph, 0))
-      const fromWalker = Array.from(Graph.values(Graph.edges(graph)))[0]
-      ;(fromGetter as any).source = 1
-      ;(fromWalker as any).target = 0
-
-      assertSome(Graph.getEdge(graph, 0), { source: 0, target: 1, data: 1 })
-      assert.deepStrictEqual(Graph.neighbors(graph, 0), [1])
-    })
-
-    describe("hasEdge", () => {
-      it("should return true for existing edge", () => {
-        const graph = Graph.directed<string, number>((mutable) => {
-          const nodeA = Graph.addNode(mutable, "Node A")
-          const nodeB = Graph.addNode(mutable, "Node B")
-          Graph.addEdge(mutable, nodeA, nodeB, 42)
-        })
-
-        const nodeA = 0
-        const nodeB = 1
-
-        expect(Graph.hasEdge(graph, nodeA, nodeB)).toBe(true)
-      })
-
-      it("should return false for non-existent edge", () => {
-        const graph = Graph.directed<string, number>((mutable) => {
-          const nodeA = Graph.addNode(mutable, "Node A")
-          const nodeB = Graph.addNode(mutable, "Node B")
-          Graph.addNode(mutable, "Node C")
-          Graph.addEdge(mutable, nodeA, nodeB, 42)
-        })
-
-        const nodeA = 0
-        const nodeC = 2
-
-        expect(Graph.hasEdge(graph, nodeA, nodeC)).toBe(false)
-      })
-
-      it("should return false for non-existent source node", () => {
-        const graph = Graph.directed<string, number>()
-        const nodeA = 0
-        const nodeB = 1
-
-        expect(Graph.hasEdge(graph, nodeA, nodeB)).toBe(false)
-      })
-
-      it("should be symmetric for undirected graphs", () => {
-        const graph = Graph.undirected<string, number>((mutable) => {
-          const nodeA = Graph.addNode(mutable, "Node A")
-          const nodeB = Graph.addNode(mutable, "Node B")
-          Graph.addEdge(mutable, nodeA, nodeB, 42)
-        })
-
-        expect(Graph.hasEdge(graph, 0, 1)).toBe(true)
-        expect(Graph.hasEdge(graph, 1, 0)).toBe(true)
-      })
-    })
-
-    describe("edgeCount", () => {
-      it("should return 0 for empty graph", () => {
-        const graph = Graph.directed<string, number>()
-        expect(Graph.edgeCount(graph)).toBe(0)
-      })
-
-      it("should return correct edge count", () => {
-        const graph = Graph.directed<string, number>((mutable) => {
-          const nodeA = Graph.addNode(mutable, "Node A")
-          const nodeB = Graph.addNode(mutable, "Node B")
-          const nodeC = Graph.addNode(mutable, "Node C")
-          Graph.addEdge(mutable, nodeA, nodeB, 1)
-          Graph.addEdge(mutable, nodeB, nodeC, 2)
-          Graph.addEdge(mutable, nodeC, nodeA, 3)
-        })
-
-        expect(Graph.edgeCount(graph)).toBe(3)
-      })
-    })
-
-    describe("edge and degree queries", () => {
-      it("should preserve directed parallel edges and self-loops", () => {
-        const graph = Graph.directed<string, number>((mutable) => {
-          Graph.addNode(mutable, "A")
-          Graph.addNode(mutable, "B")
-          Graph.addEdge(mutable, 0, 1, 1)
-          Graph.addEdge(mutable, 0, 1, 2)
-          Graph.addEdge(mutable, 1, 0, 3)
-          Graph.addEdge(mutable, 0, 0, 4)
-        })
-
-        assert.deepStrictEqual(Graph.incidentEdges(graph, 0), [0, 1, 2, 3])
-        assert.deepStrictEqual(Graph.outgoingEdges(graph, 0), [0, 1, 3])
-        assert.deepStrictEqual(Graph.incomingEdges(graph, 0), [2, 3])
-        assert.deepStrictEqual(Graph.edgesBetween(graph, 0, 1), [0, 1])
-        assert.deepStrictEqual(Graph.edgesBetween(graph, 1, 0), [2])
-        assert.strictEqual(Graph.outDegree(graph, 0), 3)
-        assert.strictEqual(Graph.inDegree(graph, 0), 2)
-      })
-
-      it("should count undirected self-loops twice only for degree", () => {
-        const graph = Graph.undirected<string, number>((mutable) => {
-          Graph.addNode(mutable, "A")
-          Graph.addNode(mutable, "B")
-          Graph.addEdge(mutable, 0, 1, 1)
-          Graph.addEdge(mutable, 1, 0, 2)
-          Graph.addEdge(mutable, 0, 0, 3)
-        })
-
-        assert.deepStrictEqual(Graph.incidentEdges(graph, 0), [0, 1, 2])
-        assert.deepStrictEqual(Graph.edgesBetween(graph, 0, 1), [0, 1])
-        assert.deepStrictEqual(Graph.edgesBetween(graph, 0, 0), [2])
-        assert.strictEqual(Graph.degree(graph, 0), 4)
-      })
-
-      it("should support data-last calls and mutable graphs", () => {
-        const mutable = Graph.beginMutation(Graph.directed<string, number>((graph) => {
-          Graph.addNode(graph, "A")
-          Graph.addNode(graph, "B")
-          Graph.addEdge(graph, 0, 1, 1)
-        }))
-
-        assert.deepStrictEqual(Graph.incidentEdges(0)(mutable), [0])
-        assert.deepStrictEqual(Graph.outgoingEdges(0)(mutable), [0])
-        assert.deepStrictEqual(Graph.incomingEdges(1)(mutable), [0])
-        assert.deepStrictEqual(Graph.edgesBetween(0, 1)(mutable), [0])
-        assert.strictEqual(Graph.outDegree(0)(mutable), 1)
-        assert.strictEqual(Graph.inDegree(1)(mutable), 1)
-      })
-
-      it("should reject invalid kinds and missing nodes", () => {
-        const directed = Graph.directed<string, number>((mutable) => {
-          Graph.addNode(mutable, "A")
-        })
-        const undirected = Graph.undirected<string, number>((mutable) => {
-          Graph.addNode(mutable, "A")
-        })
-
-        assertGraphError(() => Graph.degree(directed as any, 0), "Cannot get degree of directed graph")
-        assertGraphError(
-          () => Graph.outgoingEdges(undirected as any, 0),
-          "Cannot get outgoing edges of undirected graph"
-        )
-        assertGraphError(
-          () => Graph.incomingEdges(undirected as any, 0),
-          "Cannot get incoming edges of undirected graph"
-        )
-        assertGraphError(() => Graph.outDegree(undirected as any, 0), "Cannot get outgoing edges of undirected graph")
-        assertGraphError(() => Graph.inDegree(undirected as any, 0), "Cannot get incoming edges of undirected graph")
-        assertGraphError(() => Graph.incidentEdges(directed, 1), "Node 1 does not exist")
-        assertGraphError(() => Graph.edgesBetween(directed, 0, 1), "Node 1 does not exist")
-        assertGraphError(() => Graph.outDegree(directed, 1), "Node 1 does not exist")
-        assertGraphError(() => Graph.inDegree(directed, 1), "Node 1 does not exist")
-      })
-    })
-
-    describe("neighbors", () => {
-      it("should return correct neighbors for directed graph", () => {
-        const graph = Graph.directed<string, number>((mutable) => {
-          const nodeA = Graph.addNode(mutable, "Node A")
-          const nodeB = Graph.addNode(mutable, "Node B")
-          const nodeC = Graph.addNode(mutable, "Node C")
-          Graph.addEdge(mutable, nodeA, nodeB, 1)
-          Graph.addEdge(mutable, nodeA, nodeC, 2)
-        })
-
-        const nodeA = 0
-        const nodeB = 1
-        const nodeC = 2
-
-        const neighborsA = Graph.neighbors(graph, nodeA)
-        expect(neighborsA).toContain(nodeB)
-        expect(neighborsA).toContain(nodeC)
-        expect(neighborsA).toHaveLength(2)
-
-        const neighborsB = Graph.neighbors(graph, nodeB)
-        expect(neighborsB).toEqual([])
-      })
-    })
-
-    describe("neighbors with undirected graphs", () => {
-      it("should return correct neighbors for single edge", () => {
-        const graph = Graph.undirected<number, void>((mutable) => {
-          Graph.addNode(mutable, 0)
-          Graph.addNode(mutable, 1)
-          Graph.addEdge(mutable, 0, 1, undefined)
-        })
-
-        expect(Graph.neighbors(graph, 0)).toEqual([1])
-        expect(Graph.neighbors(graph, 1)).toEqual([0])
-      })
-
-      it("should return correct neighbors for linear graph", () => {
-        const graph = Graph.undirected<number, void>((mutable) => {
-          Graph.addNode(mutable, 0)
-          Graph.addNode(mutable, 1)
-          Graph.addNode(mutable, 2)
-          Graph.addEdge(mutable, 0, 1, undefined)
-          Graph.addEdge(mutable, 1, 2, undefined)
-        })
-
-        expect(Graph.neighbors(graph, 0)).toEqual([1])
-        expect(Graph.neighbors(graph, 1).sort()).toEqual([0, 2])
-        expect(Graph.neighbors(graph, 2)).toEqual([1])
-      })
-
-      it("should handle multiple edges between same nodes", () => {
-        const graph = Graph.undirected<number, void>((mutable) => {
-          Graph.addNode(mutable, 0)
-          Graph.addNode(mutable, 1)
-          Graph.addEdge(mutable, 0, 1, undefined)
-          Graph.addEdge(mutable, 0, 1, undefined)
-        })
-
-        // Should deduplicate neighbors
-        expect(Graph.neighbors(graph, 0)).toEqual([1])
-        expect(Graph.neighbors(graph, 1)).toEqual([0])
-      })
-
-      it("should handle self-loops", () => {
-        const graph = Graph.undirected<number, void>((mutable) => {
-          Graph.addNode(mutable, 0)
-          Graph.addEdge(mutable, 0, 0, undefined)
-        })
-
-        expect(Graph.neighbors(graph, 0)).toEqual([0])
-      })
-
-      it("should handle node with no neighbors", () => {
-        const graph = Graph.undirected<number, void>((mutable) => {
-          Graph.addNode(mutable, 0)
-          Graph.addNode(mutable, 1)
-        })
-
-        expect(Graph.neighbors(graph, 0)).toEqual([])
-        expect(Graph.neighbors(graph, 1)).toEqual([])
-      })
-    })
-
-    describe("successors and predecessors", () => {
-      it("should return outgoing and incoming directed neighbors", () => {
-        const graph = Graph.directed<string, number>((mutable) => {
-          const nodeA = Graph.addNode(mutable, "Node A")
-          const nodeB = Graph.addNode(mutable, "Node B")
-          const nodeC = Graph.addNode(mutable, "Node C")
-          Graph.addEdge(mutable, nodeA, nodeB, 1)
-          Graph.addEdge(mutable, nodeC, nodeB, 2)
-        })
-
-        expect(Graph.successors(graph, 0)).toEqual([1])
-        expect(Graph.predecessors(graph, 1).sort()).toEqual([0, 2])
-      })
-
-      it("should return unique directed neighbors in first edge order", () => {
-        const graph = Graph.directed<string, number>((mutable) => {
-          for (let i = 0; i < 3; i++) {
-            Graph.addNode(mutable, String(i))
-          }
-          Graph.addEdge(mutable, 0, 1, 5)
-          Graph.addEdge(mutable, 2, 0, 8)
-          Graph.addEdge(mutable, 0, 1, 1)
-          Graph.addEdge(mutable, 0, 0, 3)
-          Graph.addEdge(mutable, 1, 0, 4)
-          Graph.addEdge(mutable, 0, 2, 2)
-          Graph.addEdge(mutable, 2, 0, 7)
-        })
-        const mutable = Graph.beginMutation(graph)
-
-        const assertNeighbors = (input: typeof graph | typeof mutable) => {
-          assert.deepStrictEqual(Graph.neighbors(input, 0), [1, 0, 2])
-          assert.deepStrictEqual(Graph.successors(input, 0), [1, 0, 2])
-          assert.deepStrictEqual(Graph.predecessors(input, 0), [2, 0, 1])
-          assert.deepStrictEqual(Graph.neighborsDirected(input, 0, "outgoing"), [1, 0, 2])
-          assert.deepStrictEqual(Graph.neighborsDirected(input, 0, "incoming"), [2, 0, 1])
+    it("supports Effect Equal and Hash node identities", () => {
+      class NodeKey implements Equal.Equal {
+        constructor(readonly id: string) {}
+        [Equal.symbol](that: Equal.Equal): boolean {
+          return that instanceof NodeKey && this.id === that.id
         }
+        [Hash.symbol](): number {
+          return Hash.string(this.id)
+        }
+      }
 
-        assertNeighbors(graph)
-        Array.from(Graph.bfs(graph, { start: [0] }))
-        assertNeighbors(graph)
-        assertNeighbors(mutable)
-        Array.from(Graph.bfs(mutable, { start: [0] }))
-        assertNeighbors(mutable)
-      })
-
-      it("should preserve parallel edges for topological and weighted algorithms", () => {
-        const graph = Graph.directed<string, number>((mutable) => {
-          for (let i = 0; i < 3; i++) {
-            Graph.addNode(mutable, String(i))
-          }
-          Graph.addEdge(mutable, 0, 1, 10)
-          Graph.addEdge(mutable, 0, 1, 1)
-          Graph.addEdge(mutable, 1, 2, 2)
-        })
-        const mutable = Graph.beginMutation(graph)
-        const config = { source: 0, target: 2, cost: (weight: number) => weight }
-
-        assert.deepStrictEqual(Array.from(Graph.indices(Graph.topo(graph))), [0, 1, 2])
-        assert.deepStrictEqual(Array.from(Graph.indices(Graph.topo(mutable))), [0, 1, 2])
-        assertSome(Graph.dijkstra(graph, config), {
-          path: [0, 1, 2],
-          edges: [1, 2],
-          distance: 3,
-          costs: [1, 2]
-        })
-        assert.deepStrictEqual(Graph.dijkstra(mutable, config), Graph.dijkstra(graph, config))
-      })
-
-      it("should reject non-integer indexes consistently after caching traversal", () => {
-        const graph = Graph.directed<string, number>((mutable) => {
-          const source = Graph.addNode(mutable, "source")
-          const target = Graph.addNode(mutable, "target")
-          Graph.addEdge(mutable, source, target, 1)
-        })
-
-        assert.deepStrictEqual(Graph.successors(graph, 0.5), [])
-        Array.from(Graph.bfs(graph, { start: [0] }))
-        assert.deepStrictEqual(Graph.successors(graph, 0.5), [])
-      })
-
-      it("should throw for undirected graphs", () => {
-        const graph = Graph.undirected<string, number>((mutable) => {
-          const nodeA = Graph.addNode(mutable, "Node A")
-          const nodeB = Graph.addNode(mutable, "Node B")
-          Graph.addEdge(mutable, nodeA, nodeB, 1)
-        })
-
-        expect(() => Graph.successors(graph as any, 0)).toThrow("Cannot get successors of undirected graph")
-        expect(() => Graph.predecessors(graph as any, 0)).toThrow("Cannot get predecessors of undirected graph")
+      const result = Graph.compose(left(), right(), { nodeIdentity: (node) => new NodeKey(node.id) })
+      assert.deepStrictEqual(semantic(result), {
+        nodes: ["a:A1", "b:B2", "c:C2", "d:D2"],
+        edges: ["a->b:left", "b->c:shared", "c->d:right"]
       })
     })
 
-    describe("neighborsDirected", () => {
-      it("should return incoming neighbors", () => {
-        let nodeA: Graph.NodeIndex
-        let nodeB: Graph.NodeIndex
-        let nodeC: Graph.NodeIndex
+    it("coalesces duplicate identities to the last payload and redirects edges", () => {
+      const graph = directed<Node, string>([{ id: "a", label: "first" }, { id: "a", label: "last" }], [[
+        0,
+        1,
+        "edge"
+      ]])
+      const result = Graph.compose(graph, Graph.directed<Node, string>(), identity)
+      const edge = Array.from(Graph.values(Graph.edges(result)))[0]
 
-        const graph = Graph.directed<string, number>((mutable) => {
-          nodeA = Graph.addNode(mutable, "Node A")
-          nodeB = Graph.addNode(mutable, "Node B")
-          nodeC = Graph.addNode(mutable, "Node C")
-          Graph.addEdge(mutable, nodeA, nodeB, 1)
-          Graph.addEdge(mutable, nodeC, nodeB, 2)
-        })
+      assert.deepStrictEqual(Array.from(Graph.values(Graph.nodes(result))), [{ id: "a", label: "last" }])
+      assert.strictEqual(edge.source, edge.target)
+    })
 
-        const incomingB = Graph.neighborsDirected(graph, nodeB!, "incoming")
-        expect(incomingB.sort()).toEqual([nodeA!, nodeC!].sort())
+    it("uses right edge payloads for custom-identity compose and intersection", () => {
+      type Edge = { readonly id: string; readonly label: string }
+      const left = directed<string, Edge>(["A", "B"], [[0, 1, { id: "shared", label: "left" }]])
+      const right = directed<string, Edge>(["A", "B"], [[0, 1, { id: "shared", label: "right" }]])
+      const options = { edgeIdentity: (edge: Edge) => edge.id }
 
-        const incomingA = Graph.neighborsDirected(graph, nodeA!, "incoming")
-        expect(incomingA).toEqual([])
+      assert.strictEqual(
+        Array.from(Graph.values(Graph.edges(Graph.compose(left, right, options))))[0].data.label,
+        "right"
+      )
+      assert.strictEqual(
+        Array.from(Graph.values(Graph.edges(Graph.intersection(left, right, options))))[0].data.label,
+        "right"
+      )
+    })
+
+    it("includes edge data in the default edge identity", () => {
+      const first = directed(["A", "B"], [[0, 1, "left"]])
+      const second = directed(["A", "B"], [[0, 1, "right"]])
+
+      assert.strictEqual(Graph.edgeCount(Graph.compose(first, second)), 2)
+      assert.strictEqual(Graph.edgeCount(Graph.intersection(first, second)), 0)
+      assert.strictEqual(Graph.edgeCount(Graph.difference(first, second)), 1)
+      assert.strictEqual(Graph.edgeCount(Graph.symmetricDifference(first, second)), 2)
+    })
+
+    it("uses undefined node data as the default node identity", () => {
+      assert.strictEqual(
+        Graph.nodeCount(Graph.compose(directed<undefined, never>([undefined], []), directed([undefined], []))),
+        1
+      )
+    })
+
+    it("treats equal parallel edges as set members while difference preserves unmatched occurrences", () => {
+      const parallel = directed(["A", "B"], [[0, 1, "same"], [0, 1, "same"]])
+      const one = directed(["A", "B"], [[0, 1, "same"]])
+      const empty = Graph.directed<string, string>()
+
+      assert.strictEqual(Graph.edgeCount(Graph.compose(parallel, empty)), 1)
+      assert.strictEqual(Graph.edgeCount(Graph.intersection(parallel, one)), 1)
+      assert.strictEqual(Graph.edgeCount(Graph.difference(parallel, empty)), 2)
+      assert.strictEqual(Graph.edgeCount(Graph.difference(parallel, one)), 0)
+      assert.strictEqual(Graph.edgeCount(Graph.symmetricDifference(parallel, empty)), 1)
+    })
+
+    it("matches undirected identities independent of stored orientation", () => {
+      const first = undirected(["A", "B"], [[0, 1, "same"]])
+      const second = undirected(["B", "A"], [[0, 1, "same"]])
+      assert.strictEqual(Graph.edgeCount(Graph.intersection(first, second)), 1)
+      assert.strictEqual(Graph.edgeCount(Graph.difference(first, second)), 0)
+    })
+
+    it("rejects runtime kind mismatches for every binary set operation", () => {
+      const first = Graph.directed<string, string>() as Graph.Graph<string, string, Graph.Kind>
+      const second = Graph.undirected<string, string>() as Graph.Graph<string, string, Graph.Kind>
+      const operations: ReadonlyArray<() => unknown> = [
+        () => Graph.compose(first, second),
+        () => Graph.intersection(first, second),
+        () => Graph.difference(first, second),
+        () => Graph.symmetricDifference(first, second),
+        () => Graph.sum(first, second)
+      ]
+      for (const operation of operations) {
+        assertGraphError(operation, "Cannot combine directed and undirected graphs")
+      }
+    })
+
+    it("builds directed and undirected complements without self-loops", () => {
+      assertSnapshot(Graph.complement(directed(["A", "B"], [[0, 1, "existing"]]), (a, b) => `${a}-${b}`), {
+        type: "directed",
+        nodes: [{ index: 0, data: "A" }, { index: 1, data: "B" }],
+        edges: [{ index: 0, source: 1, target: 0, data: "B-A" }]
       })
-
-      it("should return outgoing neighbors", () => {
-        let nodeA: Graph.NodeIndex
-        let nodeB: Graph.NodeIndex
-        let nodeC: Graph.NodeIndex
-
-        const graph = Graph.directed<string, number>((mutable) => {
-          nodeA = Graph.addNode(mutable, "Node A")
-          nodeB = Graph.addNode(mutable, "Node B")
-          nodeC = Graph.addNode(mutable, "Node C")
-          Graph.addEdge(mutable, nodeA, nodeB, 1)
-          Graph.addEdge(mutable, nodeA, nodeC, 2)
-        })
-
-        const outgoingA = Graph.neighborsDirected(graph, nodeA!, "outgoing")
-        expect(outgoingA.sort()).toEqual([nodeB!, nodeC!].sort())
-
-        const outgoingB = Graph.neighborsDirected(graph, nodeB!, "outgoing")
-        expect(outgoingB).toEqual([])
+      assertSnapshot(Graph.complement(undirected(["A", "B", "C"], [[0, 1, "existing"]]), (a, b) => `${a}-${b}`), {
+        type: "undirected",
+        nodes: [{ index: 0, data: "A" }, { index: 1, data: "B" }, { index: 2, data: "C" }],
+        edges: [{ index: 0, source: 0, target: 2, data: "A-C" }, { index: 1, source: 1, target: 2, data: "B-C" }]
       })
+    })
 
-      it("should handle node with no connections", () => {
-        let nodeA: Graph.NodeIndex
-
-        const graph = Graph.directed<string, number>((mutable) => {
-          nodeA = Graph.addNode(mutable, "Node A")
-        })
-
-        expect(Graph.neighborsDirected(graph, nodeA!, "incoming")).toEqual([])
-        expect(Graph.neighborsDirected(graph, nodeA!, "outgoing")).toEqual([])
+    it("returns induced neighborhoods and validates radius", () => {
+      const graph = directed(["A", "B", "C", "D"], [[0, 1, "AB"], [1, 2, "BC"], [2, 1, "CB"], [2, 3, "CD"]])
+      assertSnapshot(Graph.neighborhood(graph, 1, { radius: 1 }), {
+        type: "directed",
+        nodes: [{ index: 0, data: "B" }, { index: 1, data: "C" }],
+        edges: [{ index: 0, source: 0, target: 1, data: "BC" }, { index: 1, source: 1, target: 0, data: "CB" }]
       })
-
-      it("should throw for undirected graphs", () => {
-        const graph = Graph.undirected<string, number>((mutable) => {
-          const nodeA = Graph.addNode(mutable, "Node A")
-          const nodeB = Graph.addNode(mutable, "Node B")
-          Graph.addEdge(mutable, nodeA, nodeB, 1)
-        })
-
-        expect(() => Graph.neighborsDirected(graph as any, 0, "outgoing"))
-          .toThrow("Cannot get directed neighbors of undirected graph")
+      assertSnapshot(Graph.neighborhood(1, { radius: Infinity })(graph), {
+        type: "directed",
+        nodes: [{ index: 0, data: "B" }, { index: 1, data: "C" }, { index: 2, data: "D" }],
+        edges: [
+          { index: 0, source: 0, target: 1, data: "BC" },
+          { index: 1, source: 1, target: 0, data: "CB" },
+          { index: 2, source: 1, target: 2, data: "CD" }
+        ]
       })
+      for (const radius of [NaN, -1, 0.5]) {
+        assertGraphError(
+          () => Graph.neighborhood(graph, 1, { radius }),
+          "Traversal radius must be a non-negative integer or Infinity"
+        )
+      }
+    })
+
+    it("can ignore edge direction when selecting a neighborhood", () => {
+      const graph = directed(["A", "B", "C"], [[0, 1, "AB"], [0, 2, "AC"]])
+      assertSnapshot(Graph.neighborhood(graph, 1, { radius: 2, direction: "undirected" }), {
+        type: "directed",
+        nodes: [{ index: 0, data: "B" }, { index: 1, data: "A" }, { index: 2, data: "C" }],
+        edges: [{ index: 0, source: 1, target: 0, data: "AB" }, { index: 1, source: 1, target: 2, data: "AC" }]
+      })
+    })
+
+    it("preserves sparse indexes in induced subgraphs and rejects missing nodes", () => {
+      const graph = Graph.fromSnapshot({
+        type: "directed",
+        nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }, { index: 9, data: "C" }],
+        edges: [
+          { index: 3, source: 2, target: 5, data: "AB" },
+          { index: 7, source: 5, target: 9, data: "BC" },
+          { index: 11, source: 5, target: 5, data: "loop" }
+        ]
+      })
+      assertSnapshot(Graph.inducedSubgraph([9, 5, 5])(graph), {
+        type: "directed",
+        nodes: [{ index: 5, data: "B" }, { index: 9, data: "C" }],
+        edges: [{ index: 7, source: 5, target: 9, data: "BC" }, { index: 11, source: 5, target: 5, data: "loop" }]
+      })
+      assertGraphError(() => Graph.inducedSubgraph(graph, [2, 4]), "Node 4 does not exist")
+    })
+
+    it("preserves graph kind for empty induced subgraphs", () => {
+      assertSnapshot(Graph.inducedSubgraph(Graph.undirected<string, never>(), []), {
+        type: "undirected",
+        nodes: [],
+        edges: []
+      })
+    })
+
+    it("keeps equal nodes and their edges disjoint in sums", () => {
+      const expected = {
+        type: "directed",
+        nodes: [
+          { index: 0, data: "A" },
+          { index: 1, data: "B" },
+          { index: 2, data: "A" },
+          { index: 3, data: "B" }
+        ],
+        edges: [
+          { index: 0, source: 0, target: 1, data: "left" },
+          { index: 1, source: 2, target: 3, data: "right" }
+        ]
+      } as const
+      const first = directed(["A", "B"], [[0, 1, "left"]])
+      const second = directed(["A", "B"], [[0, 1, "right"]])
+      assertSnapshot(Graph.sum(first, second), expected)
+      assertSnapshot(Graph.sum(second)(first), expected)
     })
   })
 
-  describe("toGraphViz", () => {
-    it("should export empty directed graph", () => {
-      const graph = Graph.directed<string, number>()
-      const dot = Graph.toGraphViz(graph)
+  describe("queries", () => {
+    const graph = directed(["A", "B", "C"], [
+      [0, 1, "first"],
+      [0, 1, "parallel"],
+      [2, 0, "incoming"],
+      [0, 0, "loop"],
+      [0, 2, "last"]
+    ])
 
-      expect(dot).toBe("digraph \"G\" {\n}")
+    it("reports exact edge order, multiplicity, and directed degrees", () => {
+      assert.deepStrictEqual(Graph.incidentEdges(graph, 0), [0, 1, 2, 3, 4])
+      assert.deepStrictEqual(Graph.outgoingEdges(graph, 0), [0, 1, 3, 4])
+      assert.deepStrictEqual(Graph.incomingEdges(graph, 0), [2, 3])
+      assert.deepStrictEqual(Graph.edgesBetween(graph, 0, 1), [0, 1])
+      assert.deepStrictEqual(Graph.edgesBetween(graph, 1, 0), [])
+      assert.strictEqual(Graph.outDegree(graph, 0), 4)
+      assert.strictEqual(Graph.inDegree(graph, 0), 2)
     })
 
-    it("should export empty undirected graph", () => {
-      const graph = Graph.undirected<string, number>()
-      const dot = Graph.toGraphViz(graph)
-
-      expect(dot).toBe("graph \"G\" {\n}")
+    it("deduplicates neighbors in first-edge occurrence order", () => {
+      assert.deepStrictEqual(Graph.neighbors(graph, 0), [1, 0, 2])
+      assert.deepStrictEqual(Graph.successors(0)(graph), [1, 0, 2])
+      assert.deepStrictEqual(Graph.predecessors(graph, 0), [2, 0])
+      assert.deepStrictEqual(Graph.neighborsDirected(graph, 0, "outgoing"), [1, 0, 2])
+      assert.deepStrictEqual(Graph.successors(graph, 0.5), [])
     })
 
-    it("should export directed graph with nodes and edges", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const nodeA = Graph.addNode(mutable, "Node A")
-        const nodeB = Graph.addNode(mutable, "Node B")
-        const nodeC = Graph.addNode(mutable, "Node C")
-        Graph.addEdge(mutable, nodeA, nodeB, 1)
-        Graph.addEdge(mutable, nodeB, nodeC, 2)
-        Graph.addEdge(mutable, nodeC, nodeA, 3)
-      })
-
-      const dot = Graph.toGraphViz(graph)
-
-      expect(dot).toContain("digraph \"G\" {")
-      expect(dot).toContain("\"0\" [label=\"Node A\"];")
-      expect(dot).toContain("\"1\" [label=\"Node B\"];")
-      expect(dot).toContain("\"2\" [label=\"Node C\"];")
-      expect(dot).toContain("\"0\" -> \"1\" [label=\"1\"];")
-      expect(dot).toContain("\"1\" -> \"2\" [label=\"2\"];")
-      expect(dot).toContain("\"2\" -> \"0\" [label=\"3\"];")
-      expect(dot).toContain("}")
+    it("handles undirected orientation, self-loops, parallel edges, and degree", () => {
+      const graph = undirected(["A", "B"], [[1, 0, 1], [0, 1, 2], [0, 0, 3]])
+      assert.deepStrictEqual(Graph.neighbors(graph, 0), [1, 0])
+      assert.deepStrictEqual(Graph.neighbors(graph, 1), [0])
+      assert.deepStrictEqual(Graph.incidentEdges(graph, 0), [0, 1, 2])
+      assert.deepStrictEqual(Graph.edgesBetween(graph, 0, 1), [0, 1])
+      assert.strictEqual(Graph.degree(graph, 0), 4)
+      assert.strictEqual(Graph.hasEdge(graph, 0, 1), true)
+      assert.strictEqual(Graph.hasEdge(graph, 1, 0), true)
     })
 
-    it("should export undirected graph with correct edge format", () => {
-      const graph = Graph.undirected<string, number>((mutable) => {
-        const nodeA = Graph.addNode(mutable, "A")
-        const nodeB = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, nodeA, nodeB, 1)
-      })
-
-      const dot = Graph.toGraphViz(graph)
-
-      expect(dot).toContain("graph \"G\" {")
-      expect(dot).toContain("\"0\" -- \"1\" [label=\"1\"];")
+    it("reports directed edge membership without assuming symmetry", () => {
+      const graph = directed(["A", "B", "C"], [[0, 1, 1]])
+      assert.strictEqual(Graph.hasEdge(graph, 0, 1), true)
+      assert.strictEqual(Graph.hasEdge(graph, 1, 0), false)
+      assert.strictEqual(Graph.hasEdge(graph, 0, 2), false)
+      assert.strictEqual(Graph.hasEdge(graph, 99, 0), false)
     })
 
-    it("should support custom node and edge labels", () => {
-      const graph = Graph.directed<{ name: string }, { weight: number }>((mutable) => {
-        const nodeA = Graph.addNode(mutable, { name: "Alice" })
-        const nodeB = Graph.addNode(mutable, { name: "Bob" })
-        Graph.addEdge(mutable, nodeA, nodeB, { weight: 42 })
-      })
-
-      const dot = Graph.toGraphViz(graph, {
-        nodeLabel: (data) => data.name,
-        edgeLabel: (data) => `weight: ${data.weight}`,
-        graphName: "MyGraph"
-      })
-
-      expect(dot).toContain("digraph \"MyGraph\" {")
-      expect(dot).toContain("\"0\" [label=\"Alice\"];")
-      expect(dot).toContain("\"1\" [label=\"Bob\"];")
-      expect(dot).toContain("\"0\" -> \"1\" [label=\"weight: 42\"];")
+    it("passes stored endpoints to edge finder predicates", () => {
+      const graph = undirected(["A", "B", "C"], [[2, 0, "match"], [0, 1, "match"]])
+      const calls: Array<readonly [string, number, number]> = []
+      assert.deepStrictEqual(
+        Graph.findEdge(graph, (data, source, target) => {
+          calls.push([data, source, target])
+          return source === 0
+        }),
+        Option.some(1)
+      )
+      assert.deepStrictEqual(calls, [["match", 2, 0], ["match", 0, 1]])
+      assert.deepStrictEqual(Graph.findEdges(graph, (_, source, target) => source > target), [0])
     })
 
-    it("should escape quotes in labels", () => {
-      const graph = Graph.directed<string, string>((mutable) => {
-        const nodeA = Graph.addNode(mutable, "Node \"A\"")
-        const nodeB = Graph.addNode(mutable, "Node \"B\"")
-        Graph.addEdge(mutable, nodeA, nodeB, "Edge \"1\"")
-      })
-
-      const dot = Graph.toGraphViz(graph)
-
-      expect(dot).toContain("\"0\" [label=\"Node \\\"A\\\"\"];")
-      expect(dot).toContain("\"1\" [label=\"Node \\\"B\\\"\"];")
-      expect(dot).toContain("\"0\" -> \"1\" [label=\"Edge \\\"1\\\"\"];")
+    it("finds undefined edge payloads", () => {
+      const graph = directed<string, number | undefined>(["A", "B", "C"], [
+        [0, 1, undefined],
+        [1, 2, 42],
+        [2, 0, undefined]
+      ])
+      assert.deepStrictEqual(Graph.findEdge(graph, (edge) => edge === undefined), Option.some(0))
+      assert.deepStrictEqual(Graph.findEdges(graph, (edge) => edge === undefined), [0, 2])
     })
 
-    it("should quote graph names", () => {
-      const graph = Graph.directed<string, string>()
-
-      strictEqual(Graph.toGraphViz(graph, { graphName: "MyGraph" }), "digraph \"MyGraph\" {\n}")
-      strictEqual(Graph.toGraphViz(graph, { graphName: "My Graph" }), "digraph \"My Graph\" {\n}")
-      strictEqual(Graph.toGraphViz(graph, { graphName: "" }), "digraph \"\" {\n}")
-      strictEqual(Graph.toGraphViz(graph, { graphName: "graph" }), "digraph \"graph\" {\n}")
-      strictEqual(Graph.toGraphViz(graph, { graphName: "Node" }), "digraph \"Node\" {\n}")
-      strictEqual(Graph.toGraphViz(graph, { graphName: "My \"Graph\"" }), "digraph \"My \\\"Graph\\\"\" {\n}")
+    it("reports kind and missing-node errors consistently", () => {
+      const one = directed<string, number>(["A"], [])
+      const undirectedOne = undirected<string, number>(["A"], [])
+      assertGraphError(
+        () => Graph.degree(one as unknown as Graph.UndirectedGraph<string, number>, 0),
+        "Cannot get degree of directed graph"
+      )
+      assertGraphError(
+        () => Graph.outgoingEdges(undirectedOne as unknown as Graph.DirectedGraph<string, number>, 0),
+        "Cannot get outgoing edges of undirected graph"
+      )
+      assertGraphError(
+        () => Graph.incomingEdges(undirectedOne as unknown as Graph.DirectedGraph<string, number>, 0),
+        "Cannot get incoming edges of undirected graph"
+      )
+      assertGraphError(
+        () => Graph.successors(undirectedOne as unknown as Graph.DirectedGraph<string, number>, 0),
+        "Cannot get successors of undirected graph"
+      )
+      assertGraphError(() => Graph.incidentEdges(one, 1), "Node 1 does not exist")
+      assertGraphError(() => Graph.edgesBetween(one, 0, 1), "Node 1 does not exist")
     })
+  })
 
-    it("should escape labels as literal text", () => {
-      const graph = Graph.directed<string, string>((mutable) => {
-        const nodeA = Graph.addNode(mutable, "C:\\new\\path")
-        const nodeB = Graph.addNode(mutable, "Line 1\nLine 2")
-        Graph.addEdge(mutable, nodeA, nodeB, "edge\\label\nnext")
-      })
-
-      const dot = Graph.toGraphViz(graph)
-
-      strictEqual(
-        dot,
+  describe("serialization", () => {
+    it("serializes representative directed and undirected GraphViz graphs exactly", () => {
+      const directedGraph = directed(["A", "B"], [[0, 1, 1]])
+      const directedExpected = [
+        "digraph \"G\" {",
+        "  \"0\" [label=\"A\"];",
+        "  \"1\" [label=\"B\"];",
+        "  \"0\" -> \"1\" [label=\"1\"];",
+        "}"
+      ].join("\n")
+      assert.strictEqual(Graph.toGraphViz(directedGraph), directedExpected)
+      assert.strictEqual(Graph.toGraphViz()(directedGraph), directedExpected)
+      assert.strictEqual(
+        Graph.toGraphViz(undirected(["A", "B"], [[1, 0, "edge"]])),
         [
-          "digraph \"G\" {",
-          "  \"0\" [label=\"C:\\\\new\\\\path\"];",
-          "  \"1\" [label=\"Line 1\\nLine 2\"];",
-          "  \"0\" -> \"1\" [label=\"edge\\\\label\\nnext\"];",
+          "graph \"G\" {",
+          "  \"0\" [label=\"A\"];",
+          "  \"1\" [label=\"B\"];",
+          "  \"1\" -- \"0\" [label=\"edge\"];",
           "}"
         ].join("\n")
       )
     })
 
-    it("should demonstrate graph visualization", () => {
-      // Create a simple directed graph representing a dependency graph
-      const graph = Graph.directed<string, string>((mutable) => {
-        const app = Graph.addNode(mutable, "App")
-        const auth = Graph.addNode(mutable, "Auth")
-        const db = Graph.addNode(mutable, "Database")
-        const cache = Graph.addNode(mutable, "Cache")
-
-        Graph.addEdge(mutable, app, auth, "uses")
-        Graph.addEdge(mutable, app, db, "stores")
-        Graph.addEdge(mutable, auth, db, "validates")
-        Graph.addEdge(mutable, app, cache, "caches")
-      })
-
-      const dot = Graph.toGraphViz(graph, {
-        graphName: "DependencyGraph"
-      })
-
-      // Uncomment the next line to see the GraphViz output in test console
-      // console.log("\nDependency Graph DOT format:\n" + dot)
-
-      expect(dot).toContain("digraph \"DependencyGraph\" {")
-      expect(dot).toContain("\"0\" [label=\"App\"];")
-      expect(dot).toContain("\"0\" -> \"1\" [label=\"uses\"];")
-      expect(dot).toContain("\"0\" -> \"2\" [label=\"stores\"];")
-      expect(dot).toContain("\"1\" -> \"2\" [label=\"validates\"];")
-      expect(dot).toContain("\"0\" -> \"3\" [label=\"caches\"];")
+    it("escapes GraphViz graph names and labels exactly", () => {
+      const graph = directed([{ label: "C:\\new\n\"line\"" }, { label: "end" }], [[
+        0,
+        1,
+        { label: "edge\\path\n\"quoted\"" }
+      ]])
+      assert.strictEqual(
+        Graph.toGraphViz(graph, {
+          graphName: "My \"Graph\"",
+          nodeLabel: (node) => `node:${node.label}`,
+          edgeLabel: (edge) => edge.label
+        }),
+        [
+          "digraph \"My \\\"Graph\\\"\" {",
+          "  \"0\" [label=\"node:C:\\\\new\\n\\\"line\\\"\"];",
+          "  \"1\" [label=\"node:end\"];",
+          "  \"0\" -> \"1\" [label=\"edge\\\\path\\n\\\"quoted\\\"\"];",
+          "}"
+        ].join("\n")
+      )
     })
 
-    it("should demonstrate undirected graph visualization", () => {
-      // Create a simple social network graph
-      const graph = Graph.undirected<string, string>((mutable) => {
-        const alice = Graph.addNode(mutable, "Alice")
-        const bob = Graph.addNode(mutable, "Bob")
-        const charlie = Graph.addNode(mutable, "Charlie")
-        const diana = Graph.addNode(mutable, "Diana")
-
-        Graph.addEdge(mutable, alice, bob, "friends")
-        Graph.addEdge(mutable, bob, charlie, "friends")
-        Graph.addEdge(mutable, charlie, diana, "friends")
-        Graph.addEdge(mutable, alice, diana, "friends")
-      })
-
-      const dot = Graph.toGraphViz(graph, {
-        graphName: "SocialNetwork"
-      })
-
-      // Uncomment the next line to see the GraphViz output in test console
-      // console.log("\nSocial Network DOT format:\n" + dot)
-
-      expect(dot).toContain("graph \"SocialNetwork\" {")
-      expect(dot).toContain("\"0\" [label=\"Alice\"];")
-      expect(dot).toContain("\"0\" -- \"1\" [label=\"friends\"];")
-      expect(dot).toContain("\"1\" -- \"2\" [label=\"friends\"];")
-      expect(dot).toContain("\"2\" -- \"3\" [label=\"friends\"];")
-      expect(dot).toContain("\"0\" -- \"3\" [label=\"friends\"];")
-    })
-  })
-
-  describe("toMermaid", () => {
-    it("should export empty directed graph", () => {
-      const graph = Graph.directed<string, number>()
-      const mermaid = Graph.toMermaid(graph)
-      expect(mermaid).toBe("flowchart TD")
+    it("serializes representative directed and undirected Mermaid graphs exactly", () => {
+      const directedGraph = directed(["A", "B"], [[0, 1, "edge"]])
+      const directedExpected = [
+        "flowchart TD",
+        "  0[\"A\"]",
+        "  1[\"B\"]",
+        "  0 -->|\"edge\"| 1"
+      ].join("\n")
+      assert.strictEqual(Graph.toMermaid(directedGraph), directedExpected)
+      assert.strictEqual(Graph.toMermaid()(directedGraph), directedExpected)
+      assert.strictEqual(
+        Graph.toMermaid(undirected(["A", "B"], [[1, 0, ""]])),
+        [
+          "graph TD",
+          "  0[\"A\"]",
+          "  1[\"B\"]",
+          "  1 --- 0"
+        ].join("\n")
+      )
     })
 
-    it("should export empty undirected graph", () => {
-      const graph = Graph.undirected<string, number>()
-      const mermaid = Graph.toMermaid(graph)
-      expect(mermaid).toBe("graph TD")
-    })
-
-    it("should export directed graph with nodes", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "Node A")
-        Graph.addNode(mutable, "Node B")
-        Graph.addNode(mutable, "Node C")
-      })
-
-      const mermaid = Graph.toMermaid(graph)
-      expect(mermaid).toContain("flowchart TD")
-      expect(mermaid).toContain("0[\"Node A\"]")
-      expect(mermaid).toContain("1[\"Node B\"]")
-      expect(mermaid).toContain("2[\"Node C\"]")
-    })
-
-    it("should export undirected graph with nodes", () => {
-      const graph = Graph.undirected<string, number>((mutable) => {
-        Graph.addNode(mutable, "Alice")
-        Graph.addNode(mutable, "Bob")
-      })
-
-      const mermaid = Graph.toMermaid(graph)
-      expect(mermaid).toContain("graph TD")
-      expect(mermaid).toContain("0[\"Alice\"]")
-      expect(mermaid).toContain("1[\"Bob\"]")
-    })
-
-    it("should support all node shapes", () => {
-      const shapes: Array<[string, any]> = [
-        ["rectangle", "rectangle"],
-        ["rounded", "rounded"],
-        ["circle", "circle"],
-        ["diamond", "diamond"],
-        ["hexagon", "hexagon"],
-        ["stadium", "stadium"],
-        ["subroutine", "subroutine"],
-        ["cylindrical", "cylindrical"]
-      ]
-
-      shapes.forEach(([shapeName, shapeValue]) => {
-        const graph = Graph.directed<string, number>((mutable) => {
-          Graph.addNode(mutable, "Test")
-        })
-
-        const mermaid = Graph.toMermaid(graph, {
-          nodeShape: () => shapeValue
-        })
-
-        expect(mermaid).toContain("flowchart TD")
-
-        // Test expected shape format
-        switch (shapeName) {
-          case "rectangle":
-            expect(mermaid).toContain("0[\"Test\"]")
-            break
-          case "rounded":
-            expect(mermaid).toContain("0(\"Test\")")
-            break
-          case "circle":
-            expect(mermaid).toContain("0((\"Test\"))")
-            break
-          case "diamond":
-            expect(mermaid).toContain("0{\"Test\"}")
-            break
-          case "hexagon":
-            expect(mermaid).toContain("0{{\"Test\"}}")
-            break
-          case "stadium":
-            expect(mermaid).toContain("0([\"Test\"])")
-            break
-          case "subroutine":
-            expect(mermaid).toContain("0[[\"Test\"]]")
-            break
-          case "cylindrical":
-            expect(mermaid).toContain("0[(\"Test\")]")
-            break
-        }
-      })
-    })
-
-    it("should escape special characters in labels", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "Node with \"quotes\"")
-        Graph.addNode(mutable, "Node with [brackets]")
-        Graph.addNode(mutable, "Node with | pipe")
-        Graph.addNode(mutable, "Node with \\ backslash")
-        Graph.addNode(mutable, "Node with \n newline")
-        Graph.addNode(mutable, "Node with \r\n CRLF")
-        Graph.addNode(mutable, "Node with \r carriage return")
-      })
-
-      const mermaid = Graph.toMermaid(graph)
-
-      expect(mermaid).toContain("0[\"Node with #quot;quotes#quot;\"]")
-      expect(mermaid).toContain("1[\"Node with #91;brackets#93;\"]")
-      expect(mermaid).toContain("2[\"Node with #124; pipe\"]")
-      expect(mermaid).toContain("3[\"Node with #92; backslash\"]")
-      expect(mermaid).toContain("4[\"Node with <br/> newline\"]")
-      expect(mermaid).toContain("5[\"Node with <br/> CRLF\"]")
-      expect(mermaid).toContain("6[\"Node with <br/> carriage return\"]")
-      expect(mermaid).not.toContain("\r")
-    })
-
-    it("should export directed graph with edges", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const nodeA = Graph.addNode(mutable, "Node A")
-        const nodeB = Graph.addNode(mutable, "Node B")
-        const nodeC = Graph.addNode(mutable, "Node C")
-        Graph.addEdge(mutable, nodeA, nodeB, 1)
-        Graph.addEdge(mutable, nodeB, nodeC, 2)
-        Graph.addEdge(mutable, nodeC, nodeA, 3)
-      })
-
-      const mermaid = Graph.toMermaid(graph)
-      expect(mermaid).toContain("flowchart TD")
-      expect(mermaid).toContain("0[\"Node A\"]")
-      expect(mermaid).toContain("1[\"Node B\"]")
-      expect(mermaid).toContain("2[\"Node C\"]")
-      expect(mermaid).toContain("0 -->|\"1\"| 1")
-      expect(mermaid).toContain("1 -->|\"2\"| 2")
-      expect(mermaid).toContain("2 -->|\"3\"| 0")
-    })
-
-    it("should export undirected graph with edges", () => {
-      const graph = Graph.undirected<string, string>((mutable) => {
-        const alice = Graph.addNode(mutable, "Alice")
-        const bob = Graph.addNode(mutable, "Bob")
-        const charlie = Graph.addNode(mutable, "Charlie")
-        Graph.addEdge(mutable, alice, bob, "friends")
-        Graph.addEdge(mutable, bob, charlie, "colleagues")
-      })
-
-      const mermaid = Graph.toMermaid(graph)
-      expect(mermaid).toContain("graph TD")
-      expect(mermaid).toContain("0[\"Alice\"]")
-      expect(mermaid).toContain("1[\"Bob\"]")
-      expect(mermaid).toContain("2[\"Charlie\"]")
-      expect(mermaid).toContain("0 ---|\"friends\"| 1")
-      expect(mermaid).toContain("1 ---|\"colleagues\"| 2")
-    })
-
-    it("should handle empty edge labels", () => {
-      const graph = Graph.directed<string, string>((mutable) => {
-        const nodeA = Graph.addNode(mutable, "A")
-        const nodeB = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, nodeA, nodeB, "")
-      })
-
-      const mermaid = Graph.toMermaid(graph)
-      expect(mermaid).toContain("0 --> 1")
-    })
-
-    it("should support all diagram directions", () => {
-      const directions = ["TB", "TD", "BT", "RL", "LR"] as const
-
-      directions.forEach((dir) => {
-        const graph = Graph.directed<string, number>((mutable) => {
-          Graph.addNode(mutable, "A")
-          Graph.addNode(mutable, "B")
-        })
-
-        const mermaid = Graph.toMermaid(graph, { direction: dir })
-        expect(mermaid).toContain(`flowchart ${dir}`)
-        expect(mermaid).toContain("0[\"A\"]")
-        expect(mermaid).toContain("1[\"B\"]")
-      })
-    })
-
-    it("should auto-detect diagram type based on graph type", () => {
-      // Directed graph should auto-detect as flowchart
-      const directedGraph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-      })
-      const directedMermaid = Graph.toMermaid(directedGraph)
-      expect(directedMermaid).toContain("flowchart TD")
-
-      // Undirected graph should auto-detect as graph
-      const undirectedGraph = Graph.undirected<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-      })
-      const undirectedMermaid = Graph.toMermaid(undirectedGraph)
-      expect(undirectedMermaid).toContain("graph TD")
-    })
-
-    it("should allow manual diagram type override", () => {
-      // Override directed graph to use 'graph' type
-      const directedGraph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-      })
-      const overriddenMermaid = Graph.toMermaid(directedGraph, {
-        diagramType: "graph"
-      })
-      expect(overriddenMermaid).toContain("graph TD")
-
-      // Override undirected graph to use 'flowchart' type
-      const undirectedGraph = Graph.undirected<string, number>((mutable) => {
-        Graph.addNode(mutable, "B")
-      })
-      const overriddenFlowchart = Graph.toMermaid(undirectedGraph, {
-        diagramType: "flowchart"
-      })
-      expect(overriddenFlowchart).toContain("flowchart TD")
-    })
-
-    it("should combine direction and diagram type options", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "Test")
-      })
-
-      const mermaid = Graph.toMermaid(graph, {
+    it("escapes Mermaid labels and applies direction, type, and custom labels", () => {
+      const graph = directed([{ id: "#\"<>&[]{}()|\\" }, { id: "B\r\n2\r3\n4" }], [[0, 1, { weight: 2 }]])
+      const serialized = Graph.toMermaid(graph, {
         direction: "LR",
-        diagramType: "graph"
+        diagramType: "graph",
+        nodeLabel: (node) => node.id,
+        edgeLabel: (edge) => `w(${edge.weight})`
       })
-
-      expect(mermaid).toContain("graph LR")
-      expect(mermaid).toContain("0[\"Test\"]")
+      assert.strictEqual(
+        serialized,
+        [
+          "graph LR",
+          "  0[\"#35;#quot;#lt;#gt;#amp;#91;#93;#123;#125;#40;#41;#124;#92;\"]",
+          "  1[\"B<br/>2<br/>3<br/>4\"]",
+          "  0 ---|\"w#40;2#41;\"| 1"
+        ].join("\n")
+      )
+      assert.strictEqual(serialized.includes("\r"), false)
     })
 
-    it("should handle self-loops correctly", () => {
-      const graph = Graph.directed<string, string>((mutable) => {
-        const nodeA = Graph.addNode(mutable, "A")
-        Graph.addEdge(mutable, nodeA, nodeA, "self")
-      })
-
-      const mermaid = Graph.toMermaid(graph)
-      expect(mermaid).toContain("flowchart TD")
-      expect(mermaid).toContain("0[\"A\"]")
-      expect(mermaid).toContain("0 -->|\"self\"| 0")
-    })
-
-    it("should handle multi-edges correctly", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const nodeA = Graph.addNode(mutable, "A")
-        const nodeB = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, nodeA, nodeB, 1)
-        Graph.addEdge(mutable, nodeA, nodeB, 2)
-        Graph.addEdge(mutable, nodeA, nodeB, 3)
-      })
-
-      const mermaid = Graph.toMermaid(graph)
-      expect(mermaid).toContain("flowchart TD")
-      expect(mermaid).toContain("0[\"A\"]")
-      expect(mermaid).toContain("1[\"B\"]")
-      // Should contain all three edges
-      expect(mermaid).toContain("0 -->|\"1\"| 1")
-      expect(mermaid).toContain("0 -->|\"2\"| 1")
-      expect(mermaid).toContain("0 -->|\"3\"| 1")
-    })
-
-    it("should handle disconnected components", () => {
-      const graph = Graph.directed<string, string>((mutable) => {
-        // Component 1: A -> B
-        const nodeA = Graph.addNode(mutable, "A")
-        const nodeB = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, nodeA, nodeB, "A->B")
-
-        // Component 2: C -> D (disconnected)
-        const nodeC = Graph.addNode(mutable, "C")
-        const nodeD = Graph.addNode(mutable, "D")
-        Graph.addEdge(mutable, nodeC, nodeD, "C->D")
-
-        // Isolated node E
-        Graph.addNode(mutable, "E")
-      })
-
-      const mermaid = Graph.toMermaid(graph)
-      expect(mermaid).toContain("flowchart TD")
-      expect(mermaid).toContain("0[\"A\"]")
-      expect(mermaid).toContain("1[\"B\"]")
-      expect(mermaid).toContain("2[\"C\"]")
-      expect(mermaid).toContain("3[\"D\"]")
-      expect(mermaid).toContain("4[\"E\"]")
-      expect(mermaid).toContain("0 -->|\"A-#gt;B\"| 1")
-      expect(mermaid).toContain("2 -->|\"C-#gt;D\"| 3")
-    })
-
-    it("should handle custom labels with complex data", () => {
-      interface NodeData {
-        id: string
-        value: number
-        metadata: { type: string }
+    it("supports every Mermaid node shape", () => {
+      const expected: ReadonlyArray<readonly [Graph.MermaidNodeShape, string]> = [
+        ["rectangle", "0[\"A\"]"],
+        ["rounded", "0(\"A\")"],
+        ["circle", "0((\"A\"))"],
+        ["diamond", "0{\"A\"}"],
+        ["hexagon", "0{{\"A\"}}"],
+        ["stadium", "0([\"A\"])"],
+        ["subroutine", "0[[\"A\"]]"],
+        ["cylindrical", "0[(\"A\")]"]
+      ]
+      for (const [shape, node] of expected) {
+        assert.strictEqual(
+          Graph.toMermaid(directed<string, never>(["A"], []), { nodeShape: () => shape }),
+          `flowchart TD\n  ${node}`
+        )
       }
-
-      interface EdgeData {
-        weight: number
-        type: string
-      }
-
-      const graph = Graph.directed<NodeData, EdgeData>((mutable) => {
-        const node1 = Graph.addNode(mutable, {
-          id: "node1",
-          value: 42,
-          metadata: { type: "input" }
-        })
-        const node2 = Graph.addNode(mutable, {
-          id: "node2",
-          value: 84,
-          metadata: { type: "processing" }
-        })
-        Graph.addEdge(mutable, node1, node2, { weight: 1.5, type: "data" })
-      })
-
-      const mermaid = Graph.toMermaid(graph, {
-        nodeLabel: (data) => `${data.id}:${data.value}`,
-        edgeLabel: (data) => `${data.type}(${data.weight})`,
-        direction: "LR"
-      })
-
-      expect(mermaid).toContain("flowchart LR")
-      expect(mermaid).toContain("0[\"node1:42\"]")
-      expect(mermaid).toContain("1[\"node2:84\"]")
-      expect(mermaid).toContain("0 -->|\"data#40;1.5#41;\"| 1")
     })
   })
 
-  describe("findCycle", () => {
-    it("should return directed node and edge witnesses", () => {
-      const graph = Graph.fromSnapshot({
+  describe("cycles and connectivity", () => {
+    it("returns exact sparse cycle witnesses including self-loops and parallel edges", () => {
+      const directedCycle = Graph.fromSnapshot({
         type: "directed",
         nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }, { index: 9, data: "C" }],
         edges: [
@@ -3598,285 +1236,151 @@ describe("Graph", () => {
           { index: 11, source: 9, target: 2, data: 1 }
         ]
       })
-
-      assertSome(Graph.findCycle(graph), { path: [2, 5, 9, 2], edges: [3, 7, 11] })
-      assertSome(Graph.findCycle(Graph.beginMutation(graph)), { path: [2, 5, 9, 2], edges: [3, 7, 11] })
+      assert.deepStrictEqual(Graph.findCycle(directedCycle), Option.some({ path: [2, 5, 9, 2], edges: [3, 7, 11] }))
+      assert.deepStrictEqual(Graph.findCycle(undirected(["A"], [[0, 0, 1]])), Option.some({ path: [0, 0], edges: [0] }))
+      assert.deepStrictEqual(
+        Graph.findCycle(undirected(["A", "B"], [[0, 1, 1], [1, 0, 2]])),
+        Option.some({
+          path: [0, 1, 0],
+          edges: [0, 1]
+        })
+      )
     })
 
-    it("should return self-loop and parallel-edge witnesses", () => {
-      const selfLoop = Graph.undirected<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-        Graph.addEdge(mutable, 0, 0, 1)
-      })
-      const parallel = Graph.undirected<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-        Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, 0, 1, 1)
-        Graph.addEdge(mutable, 0, 1, 2)
-      })
-
-      assertSome(Graph.findCycle(selfLoop), { path: [0, 0], edges: [0] })
-      assertSome(Graph.findCycle(parallel), { path: [0, 1, 0], edges: [0, 1] })
+    it("returns None for acyclic directed and reversed-storage undirected graphs", () => {
+      assert.deepStrictEqual(Graph.findCycle(directed([0, 1, 2], [[0, 1, 1], [1, 2, 1]])), Option.none())
+      assert.deepStrictEqual(Graph.findCycle(undirected([0, 1, 2], [[0, 1, 1], [2, 1, 1]])), Option.none())
     })
 
-    it("should return None for acyclic graphs", () => {
-      assertNone(Graph.findCycle(makeReversedUndirectedPath()))
-      assertNone(Graph.findCycle(Graph.directed()))
-    })
-  })
-
-  describe("isAcyclic", () => {
-    it("should detect acyclic directed graphs (DAGs)", () => {
-      const dag = Graph.directed<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        const d = Graph.addNode(mutable, "D")
-        Graph.addEdge(mutable, a, b, "A->B")
-        Graph.addEdge(mutable, a, c, "A->C")
-        Graph.addEdge(mutable, b, d, "B->D")
-        Graph.addEdge(mutable, c, d, "C->D")
-      })
-
-      expect(Graph.isAcyclic(dag)).toBe(true)
+    it("invalidates acyclic results after adding and removing a cycle edge", () => {
+      const mutable = Graph.beginMutation(directed(["A", "B", "C"], [[0, 1, 1], [1, 2, 1]]))
+      assert.strictEqual(Graph.isAcyclic(mutable), true)
+      const cycle = Graph.addEdge(mutable, 2, 0, 1)
+      assert.strictEqual(Graph.isAcyclic(mutable), false)
+      Graph.removeEdge(mutable, cycle)
+      assert.strictEqual(Graph.isAcyclic(mutable), true)
     })
 
-    it("should detect cycles in directed graphs", () => {
-      const cyclic = Graph.directed<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, "A->B")
-        Graph.addEdge(mutable, b, c, "B->C")
-        Graph.addEdge(mutable, c, a, "C->A") // Creates cycle
-      })
-
-      expect(Graph.isAcyclic(cyclic)).toBe(false)
+    it("handles undirected reversed orientation, self-loops, and parallel cycles", () => {
+      assert.strictEqual(Graph.isAcyclic(undirected(["A", "B", "C"], [[0, 1, 1], [2, 1, 1]])), true)
+      assert.strictEqual(Graph.isAcyclic(undirected(["A"], [[0, 0, 1]])), false)
+      assert.strictEqual(Graph.isAcyclic(undirected(["A", "B"], [[0, 1, 1], [0, 1, 2]])), false)
     })
 
-    it("should handle disconnected components", () => {
-      const disconnected = Graph.directed<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        const d = Graph.addNode(mutable, "D")
-        Graph.addEdge(mutable, a, b, "A->B") // Component 1: A->B (acyclic)
-        Graph.addEdge(mutable, c, d, "C->D") // Component 2: C->D (acyclic)
-        // No connections between components
-      })
+    it("returns complete connected, weak, and strong component partitions", () => {
+      const connected = undirected(["A", "B", "C", "D", "E"], [[0, 1, 1], [2, 3, 1]])
+      const directedGraph = directed(["A", "B", "C", "D", "E"], [[0, 1, 1], [1, 0, 1], [2, 1, 1], [3, 4, 1]])
 
-      expect(Graph.isAcyclic(disconnected)).toBe(true)
+      assertComponents(Graph.connectedComponents(connected), [[0, 1], [2, 3], [4]])
+      assertComponents(Graph.weaklyConnectedComponents(directedGraph), [[0, 1, 2], [3, 4]])
+      assertComponents(Graph.stronglyConnectedComponents(directedGraph), [[0, 1], [2], [3], [4]])
+      assertComponents(Graph.connectedComponents(Graph.beginMutation(connected)), [[0, 1], [2, 3], [4]])
+      assertComponents(Graph.stronglyConnectedComponents(Graph.beginMutation(directedGraph)), [[0, 1], [2], [3], [4]])
     })
 
-    it("should detect cycles in one component of disconnected graph", () => {
-      const mixedComponents = Graph.directed<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        const d = Graph.addNode(mutable, "D")
-        Graph.addEdge(mutable, a, b, "A->B") // Component 1: A->B (acyclic)
-        Graph.addEdge(mutable, c, d, "C->D") // Component 2: C->D->C (cyclic)
-        Graph.addEdge(mutable, d, c, "D->C")
-      })
-
-      expect(Graph.isAcyclic(mixedComponents)).toBe(false)
-    })
-
-    it("should treat a reversed-storage undirected chain as acyclic", () => {
-      const graph = makeReversedUndirectedPath()
-
-      expect(Graph.isAcyclic(graph)).toBe(true)
-    })
-
-    it("should treat a single undirected edge as acyclic", () => {
-      const graph = Graph.undirected<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, 1)
-      })
-
-      strictEqual(Graph.isAcyclic(graph), true)
-    })
-
-    it("should detect parallel undirected edges as a cycle", () => {
-      const graph = Graph.undirected<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, a, b, 2)
-      })
-
-      strictEqual(Graph.isAcyclic(graph), false)
-    })
-
-    it("should detect undirected self-loops as cycles", () => {
-      const graph = Graph.undirected<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        Graph.addEdge(mutable, a, a, 1)
-      })
-
-      strictEqual(Graph.isAcyclic(graph), false)
-    })
-
-    it("should detect cycles in undirected graphs", () => {
-      const graph = Graph.undirected<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, b, c, 1)
-        Graph.addEdge(mutable, c, a, 1)
-      })
-
-      expect(Graph.isAcyclic(graph)).toBe(false)
-    })
-  })
-
-  describe("isBipartite", () => {
-    it("should detect bipartite undirected graphs", () => {
-      const bipartite = Graph.undirected<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        const d = Graph.addNode(mutable, "D")
-        Graph.addEdge(mutable, a, b, "edge") // Set 1: {A, C}, Set 2: {B, D}
-        Graph.addEdge(mutable, b, c, "edge")
-        Graph.addEdge(mutable, c, d, "edge")
-        Graph.addEdge(mutable, d, a, "edge")
-      })
-
-      expect(Graph.isBipartite(bipartite)).toBe(true)
-    })
-
-    it("should detect non-bipartite graphs (odd cycles)", () => {
-      const triangle = Graph.undirected<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, "edge")
-        Graph.addEdge(mutable, b, c, "edge")
-        Graph.addEdge(mutable, c, a, "edge") // Triangle (3-cycle)
-      })
-
-      expect(Graph.isBipartite(triangle)).toBe(false)
-    })
-
-    it("should handle path graphs (always bipartite)", () => {
-      const path = Graph.undirected<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        const d = Graph.addNode(mutable, "D")
-        Graph.addEdge(mutable, a, b, "edge")
-        Graph.addEdge(mutable, b, c, "edge")
-        Graph.addEdge(mutable, c, d, "edge")
-      })
-
-      expect(Graph.isBipartite(path)).toBe(true)
-    })
-
-    it("should handle disconnected components", () => {
-      const disconnected = Graph.undirected<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        const d = Graph.addNode(mutable, "D")
-        Graph.addEdge(mutable, a, b, "edge") // Component 1: A-B (bipartite)
-        Graph.addEdge(mutable, c, d, "edge") // Component 2: C-D (bipartite)
-        // No connections between components
-      })
-
-      expect(Graph.isBipartite(disconnected)).toBe(true)
-    })
-
-    it("should detect non-bipartite component in disconnected graph", () => {
-      const mixedComponents = Graph.undirected<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        const d = Graph.addNode(mutable, "D")
-        const e = Graph.addNode(mutable, "E")
-        Graph.addEdge(mutable, a, b, "edge") // Component 1: A-B (bipartite)
-        Graph.addEdge(mutable, c, d, "edge") // Component 2: triangle (non-bipartite)
-        Graph.addEdge(mutable, d, e, "edge")
-        Graph.addEdge(mutable, e, c, "edge")
-      })
-
-      expect(Graph.isBipartite(mixedComponents)).toBe(false)
-    })
-  })
-
-  describe("maximumBipartiteMatching", () => {
-    it("handles empty graphs and isolated nodes", () => {
-      assert.deepStrictEqual(Graph.maximumBipartiteMatching(Graph.undirected()), [])
-      const graph = Graph.undirected<void, void>((mutable) => {
-        Graph.addNode(mutable, undefined)
-        Graph.addNode(mutable, undefined)
-      })
-      assert.deepStrictEqual(Graph.maximumBipartiteMatching(graph), [])
-    })
-
-    it("finds single, perfect, and non-perfect maximum matchings", () => {
-      const single = Graph.undirected<void, void>((mutable) => {
-        Graph.addNode(mutable, undefined)
-        Graph.addNode(mutable, undefined)
-        Graph.addEdge(mutable, 0, 1, undefined)
-      })
-      assert.deepStrictEqual(Graph.maximumBipartiteMatching(single), [{ left: 0, right: 1, edge: 0 }])
-
-      const graph = Graph.undirected<void, void>((mutable) => {
-        for (let i = 0; i < 5; i++) Graph.addNode(mutable, undefined)
-        Graph.addEdge(mutable, 0, 2, undefined)
-        Graph.addEdge(mutable, 0, 3, undefined)
-        Graph.addEdge(mutable, 1, 2, undefined)
-        Graph.addEdge(mutable, 1, 4, undefined)
-      })
-      assert.deepStrictEqual(Graph.maximumBipartiteMatching(graph), [
-        { left: 0, right: 2, edge: 0 },
-        { left: 1, right: 4, edge: 3 }
+    it("computes reachability in outgoing, incoming, and undirected modes", () => {
+      const graph = directed(["A", "B", "C", "D"], [[0, 1, 1], [1, 2, 1], [3, 1, 1]])
+      assert.deepStrictEqual(Array.from(Graph.unweightedDistances(graph, 0)), [[0, 0], [1, 1], [2, 2]])
+      assert.deepStrictEqual(Array.from(Graph.unweightedDistances(graph, 2, { direction: "incoming" })), [
+        [0, 2],
+        [1, 1],
+        [2, 0],
+        [3, 2]
       ])
-      assert.strictEqual(Graph.maximumBipartiteMatching(graph).length, 2)
+      assert.strictEqual(Graph.hasPath(graph, 0, 2), true)
+      assert.strictEqual(Graph.hasPath(graph, 2, 0), false)
+      assert.strictEqual(Graph.hasPath(2, 0, { direction: "incoming" })(graph), true)
+      assert.strictEqual(Graph.hasPath(graph, 2, 3), false)
+      assert.strictEqual(Graph.hasPath(graph, 2, 3, { direction: "undirected" }), true)
     })
 
-    it("is deterministic across disconnected components and possible matchings", () => {
-      const graph = Graph.undirected<void, void>((mutable) => {
-        for (let i = 0; i < 8; i++) Graph.addNode(mutable, undefined)
-        for (const [source, target] of [[0, 2], [0, 3], [1, 2], [1, 3], [4, 6], [5, 7]] as const) {
-          Graph.addEdge(mutable, source, target, undefined)
-        }
-      })
+    it("updates connectivity results after mutable changes", () => {
+      const mutable = Graph.beginMutation(directed(["A", "B", "C"], [[0, 1, 1]]))
+      assertComponents(Graph.weaklyConnectedComponents(mutable), [[0, 1], [2]])
+      assert.strictEqual(Graph.hasPath(mutable, 0, 2), false)
+      Graph.addEdge(mutable, 1, 2, 1)
+      assertComponents(Graph.weaklyConnectedComponents(mutable), [[0, 1, 2]])
+      assert.strictEqual(Graph.hasPath(mutable, 0, 2), true)
+    })
 
+    it("checks connected, weak, strong, and tree predicates including empty graphs", () => {
+      const tree = undirected(["A", "B", "C"], [[0, 1, 1], [1, 2, 1]])
+      const disconnected = undirected<string, number>(["A", "B"], [])
+      const weak = directed(["A", "B", "C"], [[0, 1, 1], [1, 2, 1]])
+      const weaklyDisconnected = directed<string, number>(["A", "B"], [])
+      const strong = Graph.mutate(weak, (mutable) => {
+        Graph.addEdge(mutable, 2, 0, 1)
+      })
+      assert.strictEqual(Graph.isConnected(tree), true)
+      assert.strictEqual(Graph.isConnected(disconnected), false)
+      assert.strictEqual(Graph.isTree(tree), true)
+      assert.strictEqual(Graph.isWeaklyConnected(weak), true)
+      assert.strictEqual(Graph.isWeaklyConnected(weaklyDisconnected), false)
+      assert.strictEqual(Graph.isStronglyConnected(weak), false)
+      assert.strictEqual(Graph.isStronglyConnected(strong), true)
+      assert.strictEqual(Graph.isConnected(Graph.undirected()), true)
+      assert.strictEqual(Graph.isTree(Graph.undirected()), false)
+    })
+
+    it("rejects runtime connectivity kind mismatches and missing endpoints", () => {
+      const directedGraph = Graph.directed() as unknown as Graph.Graph<never, never, Graph.Kind>
+      const undirectedGraph = Graph.undirected() as unknown as Graph.Graph<never, never, Graph.Kind>
+      assertGraphError(
+        () => Graph.connectedComponents(directedGraph as Graph.UndirectedGraph<never, never>),
+        "Cannot find connected components of directed graph"
+      )
+      assertGraphError(
+        () => Graph.weaklyConnectedComponents(undirectedGraph as Graph.DirectedGraph<never, never>),
+        "Cannot find weakly connected components of undirected graph"
+      )
+      assertGraphError(
+        () => Graph.stronglyConnectedComponents(undirectedGraph as Graph.DirectedGraph<never, never>),
+        "Cannot find strongly connected components of undirected graph"
+      )
+      assertGraphError(
+        () => Graph.isTree(directedGraph as Graph.UndirectedGraph<never, never>),
+        "Cannot determine tree status of directed graph"
+      )
+      assertGraphError(() => Graph.hasPath(Graph.directed(), 0, 1), "Node 0 does not exist")
+    })
+  })
+
+  describe("bipartite graphs", () => {
+    it("recognizes even, odd, disconnected, and self-loop cases", () => {
+      assert.strictEqual(
+        Graph.isBipartite(undirected([0, 1, 2, 3], [[0, 1, 1], [1, 2, 1], [2, 3, 1], [3, 0, 1]])),
+        true
+      )
+      assert.strictEqual(Graph.isBipartite(undirected([0, 1, 2], [[0, 1, 1], [1, 2, 1], [2, 0, 1]])), false)
+      assert.strictEqual(Graph.isBipartite(undirected([0, 1, 2, 3], [[0, 1, 1], [2, 3, 1]])), true)
+      assert.strictEqual(Graph.isBipartite(undirected([0], [[0, 0, 1]])), false)
+    })
+
+    it("returns deterministic maximum matches and the first parallel edge", () => {
+      const graph = undirected([0, 1, 2, 3], [[0, 2, "first"], [2, 0, "parallel"], [0, 3, "edge"], [1, 2, "edge"], [
+        1,
+        3,
+        "edge"
+      ]])
       assert.deepStrictEqual(Graph.maximumBipartiteMatching(graph), [
         { left: 0, right: 2, edge: 0 },
-        { left: 1, right: 3, edge: 3 },
-        { left: 4, right: 6, edge: 4 },
-        { left: 5, right: 7, edge: 5 }
+        { left: 1, right: 3, edge: 4 }
+      ])
+      assert.deepStrictEqual(Graph.maximumBipartiteMatching(Graph.beginMutation(graph)), [
+        { left: 0, right: 2, edge: 0 },
+        { left: 1, right: 3, edge: 4 }
       ])
     })
 
-    it("uses the first parallel edge without changing cardinality", () => {
-      const graph = Graph.undirected<void, string>((mutable) => {
-        Graph.addNode(mutable, undefined)
-        Graph.addNode(mutable, undefined)
-        Graph.addEdge(mutable, 1, 0, "first")
-        Graph.addEdge(mutable, 0, 1, "second")
-      })
-
-      assert.deepStrictEqual(Graph.maximumBipartiteMatching(graph), [{ left: 0, right: 1, edge: 0 }])
-    })
-
-    it("matches a brute-force oracle for all three-by-three bipartite graphs", () => {
+    it("matches a brute-force oracle for every three-by-three bipartite graph", () => {
       const oracle = (adjacency: ReadonlyArray<ReadonlyArray<number>>, left = 0, used = 0): number => {
         if (left === adjacency.length) return 0
         let best = oracle(adjacency, left + 1, used)
         for (const right of adjacency[left]) {
-          if ((used & (1 << right)) === 0) {
-            best = Math.max(best, 1 + oracle(adjacency, left + 1, used | (1 << right)))
-          }
+          if ((used & (1 << right)) === 0) best = Math.max(best, 1 + oracle(adjacency, left + 1, used | (1 << right)))
         }
         return best
       }
-
       for (let mask = 0; mask < 1 << 9; mask++) {
         const adjacency: Array<Array<number>> = [[], [], []]
         const graph = Graph.undirected<void, void>((mutable) => {
@@ -3890,166 +1394,45 @@ describe("Graph", () => {
             }
           }
         })
-        assert.strictEqual(Graph.maximumBipartiteMatching(graph).length, oracle(adjacency))
+        const matching = Graph.maximumBipartiteMatching(graph)
+        assert.strictEqual(matching.length, oracle(adjacency))
+        assert.strictEqual(new Set(matching.map((match) => match.left)).size, matching.length)
+        assert.strictEqual(new Set(matching.map((match) => match.right)).size, matching.length)
+        for (const match of matching) {
+          assert.ok(match.left >= 0 && match.left < 3)
+          assert.ok(match.right >= 3 && match.right < 6)
+          const edge = Option.getOrThrow(Graph.getEdge(graph, match.edge))
+          assert.ok(
+            (edge.source === match.left && edge.target === match.right) ||
+              (edge.source === match.right && edge.target === match.left)
+          )
+        }
       }
     })
 
-    it("rejects self-loops, odd cycles, and directed graphs", () => {
-      const loop = Graph.undirected<void, void>((mutable) => {
-        Graph.addNode(mutable, undefined)
-        Graph.addEdge(mutable, 0, 0, undefined)
-      })
-      const triangle = Graph.undirected<void, void>((mutable) => {
-        for (let i = 0; i < 3; i++) Graph.addNode(mutable, undefined)
-        Graph.addEdge(mutable, 0, 1, undefined)
-        Graph.addEdge(mutable, 1, 2, undefined)
-        Graph.addEdge(mutable, 2, 0, undefined)
-      })
-
+    it("rejects directed and non-bipartite graphs", () => {
       assertGraphError(
-        () => Graph.maximumBipartiteMatching(loop),
-        "Cannot find bipartite matching of non-bipartite graph"
-      )
-      assertGraphError(
-        () => Graph.maximumBipartiteMatching(triangle),
-        "Cannot find bipartite matching of non-bipartite graph"
-      )
-      assertGraphError(
-        () => Graph.maximumBipartiteMatching(Graph.directed() as any),
+        () => Graph.maximumBipartiteMatching(Graph.directed() as unknown as Graph.UndirectedGraph<never, never>),
         "Cannot find bipartite matching of directed graph"
       )
-    })
-  })
-
-  describe("connectedComponents", () => {
-    it("should find connected components in disconnected undirected graph", () => {
-      const graph = Graph.undirected<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        const d = Graph.addNode(mutable, "D")
-        Graph.addNode(mutable, "E")
-        Graph.addEdge(mutable, a, b, "edge") // Component 1: A-B
-        Graph.addEdge(mutable, c, d, "edge") // Component 2: C-D
-        // E is isolated - Component 3: E
-      })
-
-      const components = Graph.connectedComponents(graph)
-      expect(components).toHaveLength(3)
-
-      // Sort components by size and first element for deterministic testing
-      components.sort((a, b) => a.length - b.length || a[0] - b[0])
-      expect(components[0]).toEqual([4]) // E isolated
-      expect(components[1]).toHaveLength(2) // A-B or C-D
-      expect(components[2]).toHaveLength(2) // A-B or C-D
-    })
-
-    it("should handle fully connected component", () => {
-      const graph = Graph.undirected<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, "edge")
-        Graph.addEdge(mutable, b, c, "edge")
-        Graph.addEdge(mutable, c, a, "edge")
-      })
-
-      const components = Graph.connectedComponents(graph)
-      expect(components).toHaveLength(1)
-      expect(components[0]).toHaveLength(3)
-      expect(components[0].sort()).toEqual([0, 1, 2])
-    })
-
-    it("should preserve component order with parallel edges", () => {
-      const graph = Graph.undirected<string, number>((mutable) => {
-        const root = Graph.addNode(mutable, "root")
-        const first = Graph.addNode(mutable, "first")
-        const second = Graph.addNode(mutable, "second")
-        Graph.addEdge(mutable, root, first, 1)
-        Graph.addEdge(mutable, root, second, 2)
-        Graph.addEdge(mutable, root, first, 3)
-      })
-
-      assert.deepStrictEqual(Graph.connectedComponents(graph), [[0, 2, 1]])
-      assert.deepStrictEqual(Graph.connectedComponents(Graph.beginMutation(graph)), [[0, 2, 1]])
+      assertGraphError(
+        () => Graph.maximumBipartiteMatching(undirected([0, 1, 2], [[0, 1, 1], [1, 2, 1], [2, 0, 1]])),
+        "Cannot find bipartite matching of non-bipartite graph"
+      )
     })
   })
 
   describe("low-link connectivity", () => {
-    const analyze = <N, E>(graph: Graph.UndirectedGraph<N, E>) => ({
+    const analyze = <N, E>(graph: Graph.UndirectedGraph<N, E> | Graph.MutableUndirectedGraph<N, E>) => ({
       bridges: Graph.bridges(graph),
       articulationPoints: Graph.articulationPoints(graph),
       biconnectedComponents: Graph.biconnectedComponents(graph)
     })
 
-    it("handles empty graphs and isolated nodes", () => {
-      assert.deepStrictEqual(analyze(Graph.undirected()), {
-        bridges: [],
-        articulationPoints: [],
-        biconnectedComponents: []
-      })
-      const isolated = Graph.undirected<void, void>((mutable) => {
-        Graph.addNode(mutable, undefined)
-      })
-      assert.deepStrictEqual(analyze(isolated), {
-        bridges: [],
-        articulationPoints: [],
-        biconnectedComponents: []
-      })
-    })
-
-    it("handles a single edge, paths, and cycles", () => {
-      const single = Graph.undirected<void, void>((mutable) => {
-        Graph.addNode(mutable, undefined)
-        Graph.addNode(mutable, undefined)
-        Graph.addEdge(mutable, 0, 1, undefined)
-      })
-      assert.deepStrictEqual(analyze(single), {
-        bridges: [0],
-        articulationPoints: [],
-        biconnectedComponents: [[0, 1]]
-      })
-
-      const path = Graph.undirected<void, void>((mutable) => {
-        for (let i = 0; i < 3; i++) Graph.addNode(mutable, undefined)
-        Graph.addEdge(mutable, 0, 1, undefined)
-        Graph.addEdge(mutable, 1, 2, undefined)
-      })
-      assert.deepStrictEqual(analyze(path), {
-        bridges: [0, 1],
-        articulationPoints: [1],
-        biconnectedComponents: [[0, 1], [1, 2]]
-      })
-
-      const cycle = Graph.mutate(path, (mutable) => {
-        Graph.addEdge(mutable, 2, 0, undefined)
-      })
-      assert.deepStrictEqual(analyze(cycle), {
-        bridges: [],
-        articulationPoints: [],
-        biconnectedComponents: [[0, 1, 2]]
-      })
-    })
-
-    it("handles shared articulation points and disconnected components", () => {
-      const graph = Graph.undirected<void, void>((mutable) => {
-        for (let i = 0; i < 8; i++) Graph.addNode(mutable, undefined)
-        for (const [source, target] of [[0, 1], [1, 2], [2, 0], [2, 3], [3, 4], [4, 2], [5, 6]] as const) {
-          Graph.addEdge(mutable, source, target, undefined)
-        }
-      })
-
-      assert.deepStrictEqual(analyze(graph), {
-        bridges: [6],
-        articulationPoints: [2],
-        biconnectedComponents: [[0, 1, 2], [2, 3, 4], [5, 6]]
-      })
-    })
-
-    it("handles parallel edges, self-loops, and sparse indexes", () => {
+    it("handles paths, cycles, disconnected components, parallel edges, loops, and sparse indexes", () => {
       const graph = Graph.fromSnapshot({
         type: "undirected",
-        nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }, { index: 9, data: "C" }],
+        nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }, { index: 9, data: "C" }, { index: 12, data: "D" }],
         edges: [
           { index: 3, source: 5, target: 2, data: "first" },
           { index: 7, source: 2, target: 5, data: "parallel" },
@@ -4057,438 +1440,170 @@ describe("Graph", () => {
           { index: 13, source: 9, target: 9, data: "loop" }
         ]
       })
-
-      assert.deepStrictEqual(analyze(graph), {
+      const expected = {
         bridges: [11],
         articulationPoints: [5],
         biconnectedComponents: [[2, 5], [5, 9], [9]]
+      }
+      assert.deepStrictEqual(analyze(graph), expected)
+      assert.deepStrictEqual(analyze(Graph.beginMutation(graph)), expected)
+    })
+
+    it("groups cycles sharing an articulation point across disconnected components", () => {
+      const graph = undirected<void, void>(new Array(8).fill(undefined), [
+        [0, 1, undefined],
+        [1, 2, undefined],
+        [2, 0, undefined],
+        [2, 3, undefined],
+        [3, 4, undefined],
+        [4, 2, undefined],
+        [5, 6, undefined]
+      ])
+      assert.deepStrictEqual(analyze(graph), {
+        bridges: [6],
+        articulationPoints: [2],
+        biconnectedComponents: [[0, 1, 2], [2, 3, 4], [5, 6]]
+      })
+    })
+
+    it("returns empty results for empty and isolated graphs", () => {
+      assert.deepStrictEqual(analyze(Graph.undirected()), {
+        bridges: [],
+        articulationPoints: [],
+        biconnectedComponents: []
+      })
+      assert.deepStrictEqual(analyze(undirected<void, never>([undefined], [])), {
+        bridges: [],
+        articulationPoints: [],
+        biconnectedComponents: []
       })
     })
 
     it("rejects directed graphs at runtime", () => {
-      const graph = Graph.directed() as any
+      const graph = Graph.directed() as unknown as Graph.UndirectedGraph<never, never>
       for (const operation of [Graph.bridges, Graph.articulationPoints, Graph.biconnectedComponents]) {
         assertGraphError(() => operation(graph), "Cannot analyze undirected connectivity of directed graph")
       }
     })
   })
 
-  describe("stronglyConnectedComponents", () => {
-    it("should find strongly connected components in directed graph", () => {
-      const graph = Graph.directed<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        const d = Graph.addNode(mutable, "D")
-        Graph.addEdge(mutable, a, b, "A->B")
-        Graph.addEdge(mutable, b, c, "B->C")
-        Graph.addEdge(mutable, c, a, "C->A") // SCC: A-B-C
-        Graph.addEdge(mutable, b, d, "B->D") // D is separate
-      })
-
-      const sccs = Graph.stronglyConnectedComponents(graph)
-      expect(sccs).toHaveLength(2)
-
-      // Sort SCCs by size for deterministic testing
-      sccs.sort((a, b) => a.length - b.length)
-      expect(sccs[0]).toEqual([3]) // D is alone
-      expect(sccs[1]).toHaveLength(3) // A-B-C cycle
-      expect(sccs[1].sort()).toEqual([0, 1, 2])
+  describe("flow", () => {
+    it("returns fixed flow and cut results in data-first and data-last forms", () => {
+      const graph = directed(["source", "target"], [[0, 1, 3]])
+      const config = { source: 0, target: 1, capacity: (edge: number) => edge }
+      const flow = { value: 3, flows: new Map([[0, 3]]), cut: [0] }
+      const cut = { value: 3, edges: [0], source: [0], target: [1] }
+      assert.deepStrictEqual(Graph.maximumFlow(graph, config), flow)
+      assert.deepStrictEqual(Graph.maximumFlow(config)(graph), flow)
+      assert.deepStrictEqual(Graph.minimumCut(graph, config), cut)
+      assert.deepStrictEqual(Graph.minimumCut(config)(Graph.beginMutation(graph)), cut)
     })
 
-    it("should handle acyclic directed graph (each node is its own SCC)", () => {
-      const dag = Graph.directed<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, "A->B")
-        Graph.addEdge(mutable, b, c, "B->C")
-      })
-
-      const sccs = Graph.stronglyConnectedComponents(dag)
-      expect(sccs).toHaveLength(3)
-      // Each SCC should contain exactly one node
-      sccs.forEach((scc) => {
-        expect(scc).toHaveLength(1)
-      })
-    })
-
-    it("should handle fully connected components", () => {
-      const graph = Graph.directed<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        // Create bidirectional edges (fully connected)
-        Graph.addEdge(mutable, a, b, "A->B")
-        Graph.addEdge(mutable, b, a, "B->A")
-        Graph.addEdge(mutable, b, c, "B->C")
-        Graph.addEdge(mutable, c, b, "C->B")
-        Graph.addEdge(mutable, a, c, "A->C")
-        Graph.addEdge(mutable, c, a, "C->A")
-      })
-
-      const sccs = Graph.stronglyConnectedComponents(graph)
-      expect(sccs).toHaveLength(1)
-      expect(sccs[0]).toHaveLength(3)
-      expect(sccs[0].sort()).toEqual([0, 1, 2])
-    })
-
-    it("should handle disconnected components with cycles", () => {
-      const graph = Graph.directed<string, string>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        const d = Graph.addNode(mutable, "D")
-        // First SCC: A->B->A
-        Graph.addEdge(mutable, a, b, "A->B")
-        Graph.addEdge(mutable, b, a, "B->A")
-        // Second SCC: C->D->C
-        Graph.addEdge(mutable, c, d, "C->D")
-        Graph.addEdge(mutable, d, c, "D->C")
-      })
-
-      const sccs = Graph.stronglyConnectedComponents(graph)
-      expect(sccs).toHaveLength(2)
-      sccs.forEach((scc) => {
-        expect(scc).toHaveLength(2)
-      })
-    })
-
-    it("should throw for undirected graphs", () => {
-      const graph = makeReversedUndirectedPath()
-
-      expect(() => Graph.stronglyConnectedComponents(graph as any))
-        .toThrow("Cannot find strongly connected components of undirected graph")
-    })
-  })
-
-  describe("reachability and connectivity", () => {
-    it("should compute unweighted distances in each directed traversal mode", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        for (let i = 0; i < 4; i++) {
-          Graph.addNode(mutable, String(i))
-        }
-        Graph.addEdge(mutable, 0, 1, 1)
-        Graph.addEdge(mutable, 1, 2, 1)
-        Graph.addEdge(mutable, 3, 1, 1)
-      })
-
-      assert.deepStrictEqual(Array.from(Graph.unweightedDistances(graph, 0)), [[0, 0], [1, 1], [2, 2]])
-      assert.deepStrictEqual(Array.from(Graph.unweightedDistances(graph, 2, { direction: "incoming" })), [
-        [0, 2],
-        [1, 1],
-        [2, 0],
-        [3, 2]
-      ])
-      assert.deepStrictEqual(Array.from(Graph.unweightedDistances(graph, 0, { direction: "undirected" })), [
-        [0, 0],
-        [1, 1],
-        [2, 2],
-        [3, 2]
-      ])
-      assert.strictEqual(Graph.hasPath(graph, 0, 2), true)
-      assert.strictEqual(Graph.hasPath(graph, 2, 0), false)
-      assert.strictEqual(Graph.hasPath(graph, 2, 0, { direction: "incoming" }), true)
-      assert.strictEqual(Graph.hasPath(3, 2, { direction: "undirected" })(Graph.beginMutation(graph)), true)
-      assert.strictEqual(Graph.hasPath(graph, 0, 0), true)
-      assertGraphError(() => Graph.hasPath(graph, 0, 4), "Node 4 does not exist")
-    })
-
-    it("should find weak components and connectivity for immutable and mutable graphs", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        for (let i = 0; i < 4; i++) {
-          Graph.addNode(mutable, String(i))
-        }
-        Graph.addEdge(mutable, 0, 1, 1)
-        Graph.addEdge(mutable, 2, 1, 1)
-      })
-
+    it("enforces capacities, conservation, and max-flow/min-cut equality", () => {
+      const capacities = [16, 13, 10, 4, 12, 9, 14, 7, 20, 4]
+      const endpoints = [[0, 1], [0, 2], [1, 2], [2, 1], [1, 3], [3, 2], [2, 4], [4, 3], [3, 5], [4, 5]] as const
+      const graph = directed<void, number>(
+        new Array(6).fill(undefined),
+        endpoints.map(([source, target], index) => [source, target, capacities[index]])
+      )
+      const config = { source: 0, target: 5, capacity: (edge: number) => edge }
       for (const candidate of [graph, Graph.beginMutation(graph)]) {
-        const components = Graph.weaklyConnectedComponents(candidate).map((component) => component.sort())
-        components.sort((a, b) => a[0] - b[0])
-        assert.deepStrictEqual(components, [[0, 1, 2], [3]])
-        assert.strictEqual(Graph.isWeaklyConnected(candidate), false)
-        assert.strictEqual(Graph.isStronglyConnected(candidate), false)
-      }
-    })
-
-    it("should preserve weak component traversal order", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "root")
-        Graph.addNode(mutable, "first")
-        Graph.addNode(mutable, "second")
-        Graph.addEdge(mutable, 0, 1, 1)
-        Graph.addEdge(mutable, 0, 2, 2)
-      })
-
-      assert.deepStrictEqual(Graph.weaklyConnectedComponents(graph), [[0, 2, 1]])
-      assert.deepStrictEqual(Graph.weaklyConnectedComponents(Graph.beginMutation(graph)), [[0, 2, 1]])
-    })
-
-    it("should rebuild CSR after graph mutation", () => {
-      const mutable = Graph.beginMutation(Graph.directed<string, number>((graph) => {
-        Graph.addNode(graph, "A")
-        Graph.addNode(graph, "B")
-        Graph.addNode(graph, "C")
-        Graph.addEdge(graph, 0, 1, 1)
-      }))
-
-      assert.strictEqual(Graph.weaklyConnectedComponents(mutable).length, 2)
-      assert.deepStrictEqual(Array.from(Graph.unweightedDistances(mutable, 0)), [[0, 0], [1, 1]])
-
-      Graph.addEdge(mutable, 1, 2, 1)
-
-      assert.strictEqual(Graph.weaklyConnectedComponents(mutable).length, 1)
-      assert.deepStrictEqual(Array.from(Graph.unweightedDistances(mutable, 0)), [[0, 0], [1, 1], [2, 2]])
-
-      Graph.addNode(mutable, "D")
-      assert.strictEqual(Graph.hasPath(mutable, 0, 3), false)
-
-      Graph.addEdge(mutable, 2, 3, 1)
-      assert.strictEqual(Graph.hasPath(mutable, 0, 3), true)
-    })
-
-    it("should identify undirected trees and connected graphs", () => {
-      const tree = Graph.undirected<string, number>((mutable) => {
-        for (let i = 0; i < 3; i++) {
-          Graph.addNode(mutable, String(i))
+        const flow = Graph.maximumFlow(candidate, config)
+        const cut = Graph.minimumCut(candidate, config)
+        const balance = new Float64Array(6)
+        for (let edge = 0; edge < endpoints.length; edge++) {
+          const value = flow.flows.get(edge)!
+          assert.ok(value >= 0 && value <= capacities[edge])
+          balance[endpoints[edge][0]] -= value
+          balance[endpoints[edge][1]] += value
         }
-        Graph.addEdge(mutable, 0, 1, 1)
-        Graph.addEdge(mutable, 1, 2, 1)
-      })
-      const cycle = Graph.mutate(tree, (mutable) => {
-        Graph.addEdge(mutable, 2, 0, 1)
-      })
-
-      assert.strictEqual(Graph.isConnected(tree), true)
-      assert.strictEqual(Graph.isTree(tree), true)
-      assert.strictEqual(Graph.isTree(cycle), false)
-      assert.strictEqual(Graph.isConnected(Graph.undirected()), true)
-      assert.strictEqual(Graph.isTree(Graph.undirected()), false)
-      assert.strictEqual(Graph.isWeaklyConnected(Graph.directed()), true)
-      assert.strictEqual(Graph.isStronglyConnected(Graph.directed()), true)
-    })
-
-    it("should test connectivity without constructing components", () => {
-      const connected = Graph.undirected<void, void>((mutable) => {
-        Graph.addNode(mutable, undefined)
-        Graph.addNode(mutable, undefined)
-        Graph.addEdge(mutable, 0, 1, undefined)
-      })
-      const disconnected = Graph.mutate(connected, (mutable) => {
-        Graph.addNode(mutable, undefined)
-      })
-      const weak = Graph.directed<void, void>((mutable) => {
-        Graph.addNode(mutable, undefined)
-        Graph.addNode(mutable, undefined)
-        Graph.addNode(mutable, undefined)
-        Graph.addEdge(mutable, 0, 1, undefined)
-        Graph.addEdge(mutable, 1, 2, undefined)
-      })
-      const strong = Graph.mutate(weak, (mutable) => {
-        Graph.addEdge(mutable, 2, 0, undefined)
-      })
-
-      for (const candidate of [connected, Graph.beginMutation(connected)]) {
-        assert.strictEqual(Graph.isConnected(candidate), true)
+        assert.strictEqual(flow.value, 23)
+        assert.strictEqual(cut.value, 23)
+        assert.strictEqual(cut.edges.reduce((total, edge) => total + capacities[edge], 0), 23)
+        assert.deepStrictEqual(Array.from(balance), [-23, 0, 0, 0, 0, 23])
+        assert.deepStrictEqual([...cut.source, ...cut.target].sort((a, b) => a - b), [0, 1, 2, 3, 4, 5])
       }
-      for (const candidate of [disconnected, Graph.beginMutation(disconnected)]) {
-        assert.strictEqual(Graph.isConnected(candidate), false)
-      }
-      for (const candidate of [weak, Graph.beginMutation(weak)]) {
-        assert.strictEqual(Graph.isWeaklyConnected(candidate), true)
-        assert.strictEqual(Graph.isStronglyConnected(candidate), false)
-      }
-      for (const candidate of [strong, Graph.beginMutation(strong)]) {
-        assert.strictEqual(Graph.isWeaklyConnected(candidate), true)
-        assert.strictEqual(Graph.isStronglyConnected(candidate), true)
-      }
-    })
-
-    it("should reject directed graphs when testing trees before short-circuiting", () => {
-      assertGraphError(() => Graph.isTree(Graph.directed() as any), "Cannot determine tree status of directed graph")
-      const directed = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-        Graph.addNode(mutable, "B")
-      })
-      assertGraphError(() => Graph.isTree(directed as any), "Cannot determine tree status of directed graph")
-    })
-
-    it("should reject missing nodes and mismatched connectivity kinds", () => {
-      const directed = Graph.directed<string, number>()
-      const undirected = Graph.undirected<string, number>()
-
-      assertGraphError(() => Graph.unweightedDistances(directed, 0), "Node 0 does not exist")
-      assertGraphError(() => Graph.hasPath(directed, 0, 1), "Node 0 does not exist")
-      assertGraphError(
-        () => Graph.connectedComponents(directed as any),
-        "Cannot find connected components of directed graph"
-      )
-      assertGraphError(
-        () => Graph.weaklyConnectedComponents(undirected as any),
-        "Cannot find weakly connected components of undirected graph"
-      )
-      assertGraphError(
-        () => Graph.isConnected(directed as any),
-        "Cannot find connected components of directed graph"
-      )
-      assertGraphError(
-        () => Graph.isWeaklyConnected(undirected as any),
-        "Cannot find weakly connected components of undirected graph"
-      )
-      assertGraphError(
-        () => Graph.isStronglyConnected(undirected as any),
-        "Cannot find strongly connected components of undirected graph"
-      )
-    })
-  })
-
-  describe("maximumFlow and minimumCut", () => {
-    const config = { source: 0, target: 2, capacity: (edge: number) => edge }
-
-    it("rejects missing or equal endpoints and undirected graphs", () => {
-      const graph = Graph.directed<void, number>((mutable) => {
-        Graph.addNode(mutable, undefined)
-        Graph.addNode(mutable, undefined)
-      })
-      assertGraphError(() => Graph.maximumFlow(graph, config), "Node 2 does not exist")
-      assertGraphError(
-        () => Graph.minimumCut(graph, { ...config, source: 2 }),
-        "Node 2 does not exist"
-      )
-      assertGraphError(
-        () => Graph.maximumFlow(graph, { ...config, source: 0, target: 0 }),
-        "Flow source and target must be different nodes"
-      )
-      assertGraphError(
-        () => Graph.maximumFlow(Graph.undirected() as any, config),
-        "Cannot compute flow of undirected graph"
-      )
-    })
-
-    it("computes a single-edge flow in data-first and data-last forms", () => {
-      const graph = makeSingleEdgeGraph(3)
-      const expected = { value: 3, flows: new Map([[0, 3]]), cut: [0] }
-
-      assert.deepStrictEqual(Graph.maximumFlow(graph, { ...config, target: 1 }), expected)
-      assert.deepStrictEqual(Graph.maximumFlow({ ...config, target: 1 })(graph), expected)
-      assert.deepStrictEqual(Graph.minimumCut(graph, { ...config, target: 1 }), {
-        value: 3,
-        edges: [0],
-        source: [0],
-        target: [1]
-      })
-    })
-
-    it("handles multiple paths, bottlenecks, and parallel edges", () => {
-      const graph = Graph.directed<void, number>((mutable) => {
-        for (let i = 0; i < 4; i++) Graph.addNode(mutable, undefined)
-        Graph.addEdge(mutable, 0, 1, 3)
-        Graph.addEdge(mutable, 0, 1, 2)
-        Graph.addEdge(mutable, 0, 2, 2)
-        Graph.addEdge(mutable, 1, 2, 1)
-        Graph.addEdge(mutable, 1, 3, 3)
-        Graph.addEdge(mutable, 2, 3, 3)
-      })
-      const result = Graph.maximumFlow(graph, { source: 0, target: 3, capacity: (edge) => edge })
-
-      assert.strictEqual(result.value, 6)
-      assert.deepStrictEqual(Array.from(result.flows.keys()), [0, 1, 2, 3, 4, 5])
-      assert.strictEqual((result.flows.get(0) ?? 0) + (result.flows.get(1) ?? 0), 4)
     })
 
     it("uses reverse residual edges to reroute flow", () => {
-      const graph = Graph.directed<void, number>((mutable) => {
-        for (let i = 0; i < 6; i++) Graph.addNode(mutable, undefined)
-        for (const [source, target] of [[0, 1], [0, 2], [1, 3], [2, 3], [3, 5], [1, 4], [4, 5]] as const) {
-          Graph.addEdge(mutable, source, target, 1)
-        }
-      })
-
+      const graph = directed<void, number>(new Array(6).fill(undefined), [
+        [0, 1, 1],
+        [0, 2, 1],
+        [1, 3, 1],
+        [2, 3, 1],
+        [3, 5, 1],
+        [1, 4, 1],
+        [4, 5, 1]
+      ])
       assert.strictEqual(Graph.maximumFlow(graph, { source: 0, target: 5, capacity: (edge) => edge }).value, 2)
     })
 
-    it("handles zero capacity, disconnected targets, self-loops, and fractions", () => {
-      const graph = Graph.directed<void, number>((mutable) => {
-        for (let i = 0; i < 4; i++) Graph.addNode(mutable, undefined)
-        Graph.addEdge(mutable, 0, 0, 100)
-        Graph.addEdge(mutable, 0, 1, 0)
-        Graph.addEdge(mutable, 0, 2, 0.75)
-        Graph.addEdge(mutable, 2, 1, 0.5)
+    it("handles parallel edges, self-loops, fractions, and disconnected targets", () => {
+      const graph = directed<void, number>(new Array(4).fill(undefined), [
+        [0, 0, 100],
+        [0, 1, 0],
+        [0, 2, 0.75],
+        [2, 1, 1],
+        [0, 2, 0.25]
+      ])
+      assert.deepStrictEqual(Graph.maximumFlow(graph, { source: 0, target: 1, capacity: (edge) => edge }), {
+        value: 1,
+        flows: new Map([[0, 0], [1, 0], [2, 0.75], [3, 1], [4, 0.25]]),
+        cut: [2, 4]
       })
-      const result = Graph.maximumFlow(graph, { source: 0, target: 1, capacity: (edge) => edge })
-
-      assert.strictEqual(result.value, 0.5)
-      assert.deepStrictEqual(result.flows, new Map([[0, 0], [1, 0], [2, 0.5], [3, 0.5]]))
-      assert.strictEqual(Graph.maximumFlow(graph, { source: 0, target: 3, capacity: (edge) => edge }).value, 0)
+      assert.deepStrictEqual(Graph.maximumFlow(graph, { source: 0, target: 3, capacity: (edge) => edge }), {
+        value: 0,
+        flows: new Map([[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]]),
+        cut: []
+      })
     })
 
-    it("rejects negative, NaN, and infinite capacities, including self-loops", () => {
+    it("rejects invalid graphs, endpoints, capacities, and finite-range overflow", () => {
+      const graph = directed<void, number>([undefined, undefined], [])
+      assertGraphError(
+        () => Graph.maximumFlow(graph, { source: 0, target: 2, capacity: (edge) => edge }),
+        "Node 2 does not exist"
+      )
+      assertGraphError(
+        () => Graph.maximumFlow(graph, { source: 0, target: 0, capacity: (edge) => edge }),
+        "Flow source and target must be different nodes"
+      )
+      assertGraphError(
+        () =>
+          Graph.maximumFlow(Graph.undirected() as unknown as Graph.DirectedGraph<never, number>, {
+            source: 0,
+            target: 1,
+            capacity: (edge) => edge
+          }),
+        "Cannot compute flow of undirected graph"
+      )
       for (const capacity of [-1, NaN, Infinity, -Infinity]) {
-        const graph = Graph.directed<void, number>((mutable) => {
-          Graph.addNode(mutable, undefined)
-          Graph.addNode(mutable, undefined)
-          Graph.addEdge(mutable, 0, 0, capacity)
-        })
+        const invalid = directed<void, number>([undefined, undefined], [[0, 0, capacity]])
         assertGraphError(
-          () => Graph.maximumFlow(graph, { source: 0, target: 1, capacity: (edge) => edge }),
+          () => Graph.maximumFlow(invalid, { source: 0, target: 1, capacity: (edge) => edge }),
           "Edge 0 capacity must be a finite non-negative number"
         )
       }
-    })
-
-    it("rejects a total flow outside the finite number range", () => {
-      const graph = Graph.directed<void, number>((mutable) => {
-        Graph.addNode(mutable, undefined)
-        Graph.addNode(mutable, undefined)
-        Graph.addEdge(mutable, 0, 1, Number.MAX_VALUE)
-        Graph.addEdge(mutable, 0, 1, Number.MAX_VALUE)
-      })
-
+      const overflow = directed<void, number>([undefined, undefined], [[0, 1, Number.MAX_VALUE], [
+        0,
+        1,
+        Number.MAX_VALUE
+      ]])
       assertGraphError(
-        () => Graph.maximumFlow(graph, { source: 0, target: 1, capacity: (edge) => edge }),
+        () => Graph.maximumFlow(overflow, { source: 0, target: 1, capacity: (edge) => edge }),
         "Maximum flow exceeds the finite number range"
       )
     })
-
-    it("enforces capacity bounds, conservation, and max-flow/min-cut equality", () => {
-      const capacities = [16, 13, 10, 4, 12, 9, 14, 7, 20, 4]
-      const endpoints = [[0, 1], [0, 2], [1, 2], [2, 1], [1, 3], [3, 2], [2, 4], [4, 3], [3, 5], [4, 5]] as const
-      const graph = Graph.directed<void, number>((mutable) => {
-        for (let i = 0; i < 6; i++) Graph.addNode(mutable, undefined)
-        for (let i = 0; i < endpoints.length; i++) {
-          Graph.addEdge(mutable, endpoints[i][0], endpoints[i][1], capacities[i])
-        }
-      })
-      const flowConfig = { source: 0, target: 5, capacity: (edge: number) => edge }
-      const flow = Graph.maximumFlow(graph, flowConfig)
-      const cut = Graph.minimumCut(graph, flowConfig)
-      const balance = new Float64Array(6)
-
-      for (let edge = 0; edge < endpoints.length; edge++) {
-        const value = flow.flows.get(edge)!
-        assert.strictEqual(value >= 0 && value <= capacities[edge], true)
-        balance[endpoints[edge][0]] -= value
-        balance[endpoints[edge][1]] += value
-      }
-      assert.strictEqual(flow.value, 23)
-      assert.strictEqual(cut.value, flow.value)
-      assert.strictEqual(cut.edges.reduce((sum, edge) => sum + capacities[edge], 0), flow.value)
-      assert.deepStrictEqual(Array.from(balance), [-23, 0, 0, 0, 0, 23])
-      assert.deepStrictEqual([...cut.source, ...cut.target].sort((a, b) => a - b), [0, 1, 2, 3, 4, 5])
-    })
   })
 
-  describe("minimumSpanningForest", () => {
-    it("should preserve sparse indexes and include isolated nodes", () => {
+  describe("spanning forests and reductions", () => {
+    it("preserves sparse indexes, isolated nodes, and fixed mutable parity in minimum spanning forests", () => {
       const graph = Graph.fromSnapshot({
         type: "undirected",
-        nodes: [
-          { index: 2, data: "A" },
-          { index: 5, data: "B" },
-          { index: 9, data: "C" },
-          { index: 20, data: "isolated" }
-        ],
+        nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }, { index: 9, data: "C" }, {
+          index: 20,
+          data: "isolated"
+        }],
         edges: [
           { index: 3, source: 2, target: 5, data: 4 },
           { index: 7, source: 2, target: 5, data: 1 },
@@ -4497,50 +1612,27 @@ describe("Graph", () => {
           { index: 17, source: 9, target: 20, data: Infinity }
         ]
       })
-
-      for (const candidate of [graph, Graph.beginMutation(graph)]) {
-        const result = Graph.minimumSpanningForest(candidate, (edge) => edge)
-        assert.deepStrictEqual(Array.from(Graph.indices(Graph.nodes(result))), [2, 5, 9, 20])
-        assert.deepStrictEqual(Array.from(Graph.indices(Graph.edges(result))), [7, 11])
-      }
+      const expected = {
+        type: "undirected",
+        nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }, { index: 9, data: "C" }, {
+          index: 20,
+          data: "isolated"
+        }],
+        edges: [{ index: 7, source: 2, target: 5, data: 1 }, { index: 11, source: 5, target: 9, data: -2 }]
+      } as const
+      assertSnapshot(Graph.minimumSpanningForest(graph, (edge) => edge), expected)
+      assertSnapshot(Graph.minimumSpanningForest(Graph.beginMutation(graph), (edge) => edge), expected)
     })
 
-    it("should break equal-weight ties by edge order", () => {
-      const graph = Graph.undirected<string, number>((mutable) => {
-        for (let i = 0; i < 3; i++) {
-          Graph.addNode(mutable, String(i))
-        }
-        Graph.addEdge(mutable, 0, 1, 1)
-        Graph.addEdge(mutable, 1, 2, 1)
-        Graph.addEdge(mutable, 0, 2, 1)
-      })
-
-      const result = Graph.minimumSpanningForest(graph, (edge) => edge)
-
-      assert.deepStrictEqual(Array.from(Graph.indices(Graph.edges(result))), [0, 1])
-    })
-
-    it("should reject directed graphs and unsupported weights", () => {
-      assertGraphError(
-        () => Graph.minimumSpanningForest(Graph.directed() as any, () => 1),
-        "Cannot find minimum spanning forest of directed graph"
+    it("breaks equal spanning-forest weights by first edge order", () => {
+      const graph = undirected([0, 1, 2], [[0, 1, 1], [1, 2, 1], [0, 2, 1]])
+      assert.deepStrictEqual(
+        Graph.toSnapshot(Graph.minimumSpanningForest(graph, (edge) => edge)).edges.map((edge) => edge.index),
+        [0, 1]
       )
-      for (const weight of [NaN, -Infinity]) {
-        const graph = Graph.undirected<string, number>((mutable) => {
-          Graph.addNode(mutable, "A")
-          Graph.addNode(mutable, "B")
-          Graph.addEdge(mutable, 0, 1, weight)
-        })
-        assertGraphError(
-          () => Graph.minimumSpanningForest(graph, (edge) => edge),
-          "Minimum spanning forest does not support NaN or -Infinity edge weights"
-        )
-      }
     })
-  })
 
-  describe("transitiveReduction", () => {
-    it("should preserve sparse indexes and coalesce parallel edges", () => {
+    it("preserves sparse reachability and first parallel edges in transitive reductions", () => {
       const graph = Graph.fromSnapshot({
         type: "directed",
         nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }, { index: 9, data: "C" }],
@@ -4551,134 +1643,104 @@ describe("Graph", () => {
           { index: 11, source: 2, target: 9, data: "redundant" }
         ]
       })
-
-      for (const candidate of [graph, Graph.beginMutation(graph)]) {
-        const result = Graph.transitiveReduction(candidate)
-        assert.deepStrictEqual(Array.from(Graph.indices(Graph.nodes(result))), [2, 5, 9])
-        assert.deepStrictEqual(Array.from(Graph.indices(Graph.edges(result))), [3, 7])
-        assert.strictEqual(Graph.hasPath(result, 2, 9), true)
-      }
+      const expected = {
+        type: "directed",
+        nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }, { index: 9, data: "C" }],
+        edges: [{ index: 3, source: 2, target: 5, data: "first" }, { index: 7, source: 5, target: 9, data: "next" }]
+      } as const
+      assertSnapshot(Graph.transitiveReduction(graph), expected)
+      assertSnapshot(Graph.transitiveReduction(Graph.beginMutation(graph)), expected)
     })
 
-    it("should retain both branches of a diamond", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        for (let i = 0; i < 4; i++) {
-          Graph.addNode(mutable, String(i))
-        }
-        Graph.addEdge(mutable, 0, 1, 1)
-        Graph.addEdge(mutable, 0, 2, 1)
-        Graph.addEdge(mutable, 1, 3, 1)
-        Graph.addEdge(mutable, 2, 3, 1)
-      })
-
-      assert.deepStrictEqual(
-        Array.from(Graph.indices(Graph.edges(Graph.transitiveReduction(graph)))),
-        [0, 1, 2, 3]
-      )
+    it("keeps both branches of a diamond", () => {
+      const graph = directed([0, 1, 2, 3], [[0, 1, 1], [0, 2, 1], [1, 3, 1], [2, 3, 1]])
+      assert.deepStrictEqual(Array.from(Graph.indices(Graph.edges(Graph.transitiveReduction(graph)))), [0, 1, 2, 3])
     })
 
-    it("should reject undirected and cyclic graphs", () => {
+    it("rejects invalid kinds, weights, and cyclic reductions", () => {
       assertGraphError(
-        () => Graph.transitiveReduction(Graph.undirected() as any),
+        () => Graph.minimumSpanningForest(Graph.directed() as unknown as Graph.UndirectedGraph<never, number>, () => 1),
+        "Cannot find minimum spanning forest of directed graph"
+      )
+      for (const weight of [NaN, -Infinity]) {
+        assertGraphError(
+          () => Graph.minimumSpanningForest(undirected([0, 1], [[0, 1, weight]]), (edge) => edge),
+          "Minimum spanning forest does not support NaN or -Infinity edge weights"
+        )
+      }
+      assertGraphError(
+        () => Graph.transitiveReduction(Graph.undirected() as unknown as Graph.DirectedGraph<never, never>),
         "Cannot transitively reduce undirected graph"
       )
-      const cyclic = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-        Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, 0, 1, 1)
-        Graph.addEdge(mutable, 1, 0, 1)
-      })
-      assertGraphError(() => Graph.transitiveReduction(cyclic), "Cannot transitively reduce cyclic graph")
+      assertGraphError(
+        () => Graph.transitiveReduction(directed([0, 1], [[0, 1, 1], [1, 0, 1]])),
+        "Cannot transitively reduce cyclic graph"
+      )
     })
   })
 
-  describe("dijkstra", () => {
-    it("should find shortest path in simple graph", () => {
-      let nodeA: Graph.NodeIndex
-      let nodeB: Graph.NodeIndex
-      let nodeC: Graph.NodeIndex
+  describe("pathfinding", () => {
+    const graph = directed(["source", "first", "second", "target"], [
+      [0, 1, 1],
+      [0, 2, 1],
+      [2, 3, 1],
+      [1, 3, 1]
+    ])
+    const expected = { path: [0, 1, 3], edges: [0, 3], distance: 2, costs: [1, 1] }
 
-      const graph = Graph.directed<string, number>((mutable) => {
-        nodeA = Graph.addNode(mutable, "A")
-        nodeB = Graph.addNode(mutable, "B")
-        nodeC = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, nodeA, nodeB, 5)
-        Graph.addEdge(mutable, nodeA, nodeC, 10)
-        Graph.addEdge(mutable, nodeB, nodeC, 2)
-      })
-
-      const result = Graph.dijkstra(graph, {
-        source: nodeA!,
-        target: nodeC!,
-        cost: (edge) => edge
-      })
-
-      assertSome(result, { path: [nodeA!, nodeB!, nodeC!], edges: [0, 2], distance: 7, costs: [5, 2] })
+    it("returns complete Dijkstra and A* paths with deterministic ties and fixed mutable parity", () => {
+      const dijkstra = { source: 0, target: 3, cost: (edge: number) => edge }
+      const astar = { ...dijkstra, heuristic: () => 0 }
+      assertPath(Graph.dijkstra(graph, dijkstra), expected)
+      assertPath(Graph.dijkstra(Graph.beginMutation(graph), dijkstra), expected)
+      assertPath(Graph.dijkstra(dijkstra)(graph), expected)
+      assertPath(Graph.astar(graph, astar), expected)
+      assertPath(Graph.astar(Graph.beginMutation(graph), astar), expected)
+      assertPath(Graph.astar(astar)(graph), expected)
+      assertPath(Graph.bellmanFord(dijkstra)(graph), expected)
+      const all = Graph.floydWarshall((edge: number) => edge)(graph)
+      assert.strictEqual(all.distances.get(0)?.get(3), 2)
+      assert.deepStrictEqual(all.paths.get(0)?.get(3), expected.path)
+      assert.deepStrictEqual(all.edges.get(0)?.get(3), expected.edges)
+      assert.deepStrictEqual(all.costs.get(0)?.get(3), expected.costs)
     })
 
-    it("should preserve insertion order for equal priorities", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const source = Graph.addNode(mutable, "source")
-        const first = Graph.addNode(mutable, "first")
-        const second = Graph.addNode(mutable, "second")
-        const target = Graph.addNode(mutable, "target")
-        Graph.addEdge(mutable, source, first, 1)
-        Graph.addEdge(mutable, source, second, 1)
-        Graph.addEdge(mutable, first, target, 1)
-        Graph.addEdge(mutable, second, target, 1)
-      })
+    it("preserves parallel edges for topological and weighted algorithms", () => {
+      const graph = directed([0, 1, 2], [[0, 1, 10], [0, 1, 1], [1, 2, 2]])
 
-      const result = Graph.dijkstra(graph, {
-        source: 0,
-        target: 3,
-        cost: (edge) => edge
+      assertIndices(Graph.topo(graph), [0, 1, 2])
+      assertPath(Graph.dijkstra(graph, { source: 0, target: 2, cost: (edge) => edge }), {
+        path: [0, 1, 2],
+        edges: [1, 2],
+        distance: 3,
+        costs: [1, 2]
       })
-
-      assertSome(result, { path: [0, 1, 3], edges: [0, 2], distance: 2, costs: [1, 1] })
     })
 
-    it("should preserve insertion order when target edges have the opposite order", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const source = Graph.addNode(mutable, "source")
-        const first = Graph.addNode(mutable, "first")
-        const second = Graph.addNode(mutable, "second")
-        const target = Graph.addNode(mutable, "target")
-        Graph.addEdge(mutable, source, first, 1)
-        Graph.addEdge(mutable, source, second, 1)
-        Graph.addEdge(mutable, second, target, 1)
-        Graph.addEdge(mutable, first, target, 1)
-      })
-      const mutable = Graph.beginMutation(graph)
-      const config = { source: 0, target: 3, cost: (edge: number) => edge }
-
-      const immutableResult = Graph.dijkstra(graph, config)
-      const mutableResult = Graph.dijkstra(mutable, config)
-
-      assertSome(immutableResult, { path: [0, 1, 3], edges: [0, 3], distance: 2, costs: [1, 1] })
-      assert.deepStrictEqual(immutableResult, mutableResult)
-    })
-
-    it("should skip stale priority queue entries", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const source = Graph.addNode(mutable, "source")
-        const improved = Graph.addNode(mutable, "improved")
-        const shortcut = Graph.addNode(mutable, "shortcut")
-        const middle = Graph.addNode(mutable, "middle")
-        const target = Graph.addNode(mutable, "target")
-        Graph.addEdge(mutable, source, improved, 10)
-        Graph.addEdge(mutable, source, shortcut, 1)
-        Graph.addEdge(mutable, shortcut, improved, 1)
-        Graph.addEdge(mutable, improved, middle, 20)
-        Graph.addEdge(mutable, middle, target, 20)
+    it("handles decreased Dijkstra priorities with fresh order and stale entries", () => {
+      const reordered = directed(["source", "improved", "shortcut", "direct", "target"], [
+        [0, 1, 10],
+        [0, 2, 1],
+        [0, 3, 2],
+        [2, 1, 1],
+        [1, 4, 1],
+        [3, 4, 1]
+      ])
+      assertPath(Graph.dijkstra(reordered, { source: 0, target: 4, cost: (edge) => edge }), {
+        path: [0, 3, 4],
+        edges: [2, 5],
+        distance: 3,
+        costs: [2, 1]
       })
 
-      const result = Graph.dijkstra(graph, {
-        source: 0,
-        target: 4,
-        cost: (edge) => edge
-      })
-
-      assertSome(result, {
+      const stale = directed(["source", "improved", "shortcut", "middle", "target"], [
+        [0, 1, 10],
+        [0, 2, 1],
+        [2, 1, 1],
+        [1, 3, 20],
+        [3, 4, 20]
+      ])
+      assertPath(Graph.dijkstra(stale, { source: 0, target: 4, cost: (edge) => edge }), {
         path: [0, 2, 1, 3, 4],
         edges: [1, 2, 3, 4],
         distance: 42,
@@ -4686,894 +1748,284 @@ describe("Graph", () => {
       })
     })
 
-    it("should assign a fresh insertion order when decreasing a priority", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const source = Graph.addNode(mutable, "source")
-        const improved = Graph.addNode(mutable, "improved")
-        const shortcut = Graph.addNode(mutable, "shortcut")
-        const direct = Graph.addNode(mutable, "direct")
-        const target = Graph.addNode(mutable, "target")
-        Graph.addEdge(mutable, source, improved, 10)
-        Graph.addEdge(mutable, source, shortcut, 1)
-        Graph.addEdge(mutable, source, direct, 2)
-        Graph.addEdge(mutable, shortcut, improved, 1)
-        Graph.addEdge(mutable, improved, target, 1)
-        Graph.addEdge(mutable, direct, target, 1)
-      })
-      const config = { source: 0, target: 4, cost: (edge: number) => edge }
-      const expected = Option.some({ path: [0, 3, 4], edges: [2, 5], distance: 3, costs: [2, 1] })
-
-      assert.deepStrictEqual(Graph.dijkstra(graph, config), expected)
-      assert.deepStrictEqual(Graph.dijkstra(Graph.beginMutation(graph), config), expected)
-    })
-
-    it("should snapshot mutable adjacency before evaluating costs", () => {
-      const mutable = makeMutableWeightedPath()
-      let mutated = false
-      const result = Graph.dijkstra(mutable, {
-        source: 0,
-        target: 2,
-        cost: (edge) => {
-          if (!mutated) {
-            mutated = true
-            Graph.removeEdge(mutable, 1)
-          }
-          return edge
-        }
+    it("skips stale A* entries and does not reopen closed nodes", () => {
+      const stale = directed(["source", "improved", "shortcut", "middle", "target"], [
+        [0, 1, 10],
+        [0, 2, 1],
+        [2, 1, 1],
+        [1, 3, 20],
+        [3, 4, 20]
+      ])
+      assertPath(Graph.astar(stale, { source: 0, target: 4, cost: (edge) => edge, heuristic: () => 0 }), {
+        path: [0, 2, 1, 3, 4],
+        edges: [1, 2, 3, 4],
+        distance: 42,
+        costs: [1, 1, 20, 20]
       })
 
-      assertSome(result, { path: [0, 1, 2], edges: [0, 1], distance: 2, costs: [1, 1] })
-      assert.strictEqual(Graph.edgeCount(mutable), 2)
-    })
-
-    it("should return None for unreachable nodes", () => {
-      let nodeA: Graph.NodeIndex
-      let nodeB: Graph.NodeIndex
-      let nodeC: Graph.NodeIndex
-
-      const graph = Graph.directed<string, number>((mutable) => {
-        nodeA = Graph.addNode(mutable, "A")
-        nodeB = Graph.addNode(mutable, "B")
-        nodeC = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, nodeA, nodeB, 1)
-        // No path from A to C
-      })
-
-      const result = Graph.dijkstra(graph, {
-        source: nodeA!,
-        target: nodeC!,
-        cost: (edge) => edge
-      })
-
-      expect(result).toEqual(Option.none())
-    })
-
-    it("should handle same source and target", () => {
-      let nodeA: Graph.NodeIndex
-
-      const graph = Graph.directed<string, number>((mutable) => {
-        nodeA = Graph.addNode(mutable, "A")
-      })
-
-      const result = Graph.dijkstra(graph, {
-        source: nodeA!,
-        target: nodeA!,
-        cost: (edge) => edge
-      })
-
-      assertSome(result, { path: [nodeA!], edges: [], distance: 0, costs: [] })
-    })
-
-    it("should throw for negative weights", () => {
-      let nodeA: Graph.NodeIndex
-      let nodeB: Graph.NodeIndex
-
-      const graph = Graph.directed<string, number>((mutable) => {
-        nodeA = Graph.addNode(mutable, "A")
-        nodeB = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, nodeA, nodeB, -1)
-      })
-
-      expect(() =>
-        Graph.dijkstra(graph, {
-          source: nodeA!,
-          target: nodeB!,
-          cost: (edge) => edge
-        })
-      ).toThrow(
-        "Dijkstra's algorithm requires non-negative edge weights"
+      const closed = directed(["source", "closed", "later", "target"], [
+        [0, 1, 10],
+        [1, 3, 1],
+        [0, 2, 1],
+        [2, 1, 1]
+      ])
+      assertPath(
+        Graph.astar(closed, {
+          source: 0,
+          target: 3,
+          cost: (edge) => edge,
+          heuristic: (node) => node === "closed" ? -100 : 0
+        }),
+        { path: [0, 1, 3], edges: [0, 1], distance: 11, costs: [10, 1] }
       )
     })
 
-    it("should throw for NaN and negative infinity weights", () => {
-      for (const weight of unsupportedEdgeWeights) {
-        const graph = makeSingleEdgeGraph(weight)
-
-        assertGraphError(
-          () =>
-            Graph.dijkstra(graph, {
-              source: 0,
-              target: 1,
-              cost: (edge) => edge
-            }),
-          "Dijkstra's algorithm requires non-negative edge weights"
-        )
-      }
-    })
-
-    it("should treat infinity weights as unreachable", () => {
-      const graph = makeSingleEdgeGraph(Infinity)
-
-      const result = Graph.dijkstra(graph, {
-        source: 0,
-        target: 1,
-        cost: (edge) => edge
-      })
-
-      assertNone(result)
-    })
-
-    it("should throw for negative weights before early target termination", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const source = Graph.addNode(mutable, "source")
-        const target = Graph.addNode(mutable, "target")
-        const other = Graph.addNode(mutable, "other")
-        Graph.addEdge(mutable, source, target, 1)
-        Graph.addEdge(mutable, source, other, 2)
-        Graph.addEdge(mutable, other, target, -5)
-      })
-
-      expect(() =>
-        Graph.dijkstra(graph, {
-          source: 0,
-          target: 1,
-          cost: (edge) => edge
-        })
-      ).toThrow("Dijkstra's algorithm requires non-negative edge weights")
-    })
-
-    it("should validate weights before returning same source and target", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const node = Graph.addNode(mutable, "node")
-        Graph.addEdge(mutable, node, node, -1)
-      })
-
-      expect(() =>
-        Graph.dijkstra(graph, {
-          source: 0,
-          target: 0,
-          cost: (edge) => edge
-        })
-      ).toThrow("Dijkstra's algorithm requires non-negative edge weights")
-    })
-
-    it("should throw for non-existent nodes", () => {
-      const graph = Graph.directed<string, number>()
-
-      expect(() =>
-        Graph.dijkstra(graph, {
-          source: 0,
-          target: 1,
-          cost: (edge) => edge
-        })
-      ).toThrow("Node 0 does not exist")
-    })
-
-    it("should traverse undirected edges in reverse storage direction", () => {
-      const graph = makeReversedUndirectedPath()
-
-      const result = Graph.dijkstra(graph, {
-        source: 0,
-        target: 2,
-        cost: (edge) => edge
-      })
-
-      assertSome(result, { path: [0, 1, 2], edges: [0, 1], distance: 2, costs: [1, 1] })
-    })
-
-    it("should support sparse snapshot indexes", () => {
+    it("preserves sparse parallel edge identity across all shortest-path algorithms", () => {
       const graph = Graph.fromSnapshot({
         type: "directed",
-        nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }, { index: 1_000_000, data: "C" }],
-        edges: [
-          { index: 3, source: 2, target: 5, data: 2 },
-          { index: 1_000_000, source: 5, target: 1_000_000, data: 3 }
-        ]
+        nodes: [{ index: 2, data: "source" }, { index: 5, data: "target" }],
+        edges: [{ index: 3, source: 2, target: 5, data: 1 }, { index: 1_000_000, source: 2, target: 5, data: 1 }]
       })
-
-      const result = Graph.dijkstra(graph, {
-        source: 2,
-        target: 1_000_000,
-        cost: (edge) => edge
-      })
-
-      assertSome(result, { path: [2, 5, 1_000_000], edges: [3, 1_000_000], distance: 5, costs: [2, 3] })
-    })
-  })
-
-  describe("astar", () => {
-    it("should find shortest path with heuristic", () => {
-      let nodeA: Graph.NodeIndex
-      let nodeB: Graph.NodeIndex
-      let nodeC: Graph.NodeIndex
-
-      const graph = Graph.directed<{ x: number; y: number }, number>((mutable) => {
-        nodeA = Graph.addNode(mutable, { x: 0, y: 0 })
-        nodeB = Graph.addNode(mutable, { x: 1, y: 0 })
-        nodeC = Graph.addNode(mutable, { x: 2, y: 0 })
-        Graph.addEdge(mutable, nodeA, nodeB, 1)
-        Graph.addEdge(mutable, nodeB, nodeC, 1)
-      })
-
-      const heuristic = (source: { x: number; y: number }, target: { x: number; y: number }) =>
-        Math.abs(source.x - target.x) + Math.abs(source.y - target.y)
-
-      const result = Graph.astar(graph, {
-        source: nodeA!,
-        target: nodeC!,
-        cost: (edge) => edge,
-        heuristic
-      })
-
-      assertSome(result, { path: [nodeA!, nodeB!, nodeC!], edges: [0, 1], distance: 2, costs: [1, 1] })
-    })
-
-    it("should preserve insertion order for equal priorities", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const source = Graph.addNode(mutable, "source")
-        const first = Graph.addNode(mutable, "first")
-        const second = Graph.addNode(mutable, "second")
-        const target = Graph.addNode(mutable, "target")
-        Graph.addEdge(mutable, source, first, 1)
-        Graph.addEdge(mutable, source, second, 1)
-        Graph.addEdge(mutable, first, target, 1)
-        Graph.addEdge(mutable, second, target, 1)
-      })
-
-      const result = Graph.astar(graph, {
-        source: 0,
-        target: 3,
-        cost: (edge) => edge,
-        heuristic: () => 0
-      })
-
-      assertSome(result, { path: [0, 1, 3], edges: [0, 2], distance: 2, costs: [1, 1] })
-    })
-
-    it("should skip stale open set entries", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const source = Graph.addNode(mutable, "source")
-        const improved = Graph.addNode(mutable, "improved")
-        const shortcut = Graph.addNode(mutable, "shortcut")
-        const middle = Graph.addNode(mutable, "middle")
-        const target = Graph.addNode(mutable, "target")
-        Graph.addEdge(mutable, source, improved, 10)
-        Graph.addEdge(mutable, source, shortcut, 1)
-        Graph.addEdge(mutable, shortcut, improved, 1)
-        Graph.addEdge(mutable, improved, middle, 20)
-        Graph.addEdge(mutable, middle, target, 20)
-      })
-
-      const result = Graph.astar(graph, {
-        source: 0,
-        target: 4,
-        cost: (edge) => edge,
-        heuristic: () => 0
-      })
-
-      assertSome(result, {
-        path: [0, 2, 1, 3, 4],
-        edges: [1, 2, 3, 4],
-        distance: 42,
-        costs: [1, 1, 20, 20]
-      })
-    })
-
-    it("should not update paths through closed nodes", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        for (const node of ["source", "closed", "later", "target"]) {
-          Graph.addNode(mutable, node)
-        }
-        Graph.addEdge(mutable, 0, 1, 10)
-        Graph.addEdge(mutable, 1, 3, 1)
-        Graph.addEdge(mutable, 0, 2, 1)
-        Graph.addEdge(mutable, 2, 1, 1)
-      })
-      const config = {
-        source: 0,
-        target: 3,
-        cost: (edge: number) => edge,
-        heuristic: (node: string) => node === "closed" ? -100 : 0
+      const expected = { path: [2, 5], edges: [3], distance: 1, costs: [1] }
+      for (const candidate of [graph, Graph.beginMutation(graph)]) {
+        assertPath(Graph.dijkstra(candidate, { source: 2, target: 5, cost: (edge) => edge }), expected)
+        assertPath(Graph.astar(candidate, { source: 2, target: 5, cost: (edge) => edge, heuristic: () => 0 }), expected)
+        assertPath(Graph.bellmanFord(candidate, { source: 2, target: 5, cost: (edge) => edge }), expected)
+        const all = Graph.floydWarshall(candidate, (edge) => edge)
+        assert.strictEqual(all.distances.get(2)?.get(5), 1)
+        assert.deepStrictEqual(all.paths.get(2)?.get(5), [2, 5])
+        assert.deepStrictEqual(all.edges.get(2)?.get(5), [3])
+        assert.deepStrictEqual(all.costs.get(2)?.get(5), [1])
       }
-      const expected = Option.some({ path: [0, 1, 3], edges: [0, 1], distance: 11, costs: [10, 1] })
-
-      assert.deepStrictEqual(Graph.astar(graph, config), expected)
-      assert.deepStrictEqual(Graph.astar(Graph.beginMutation(graph), config), expected)
     })
 
-    it("should snapshot mutable adjacency before evaluating costs", () => {
-      const mutable = makeMutableWeightedPath()
-      let mutated = false
-      const result = Graph.astar(mutable, {
-        source: 0,
-        target: 2,
-        cost: (edge) => {
+    it("snapshots mutable adjacency before evaluating Dijkstra and A* costs", () => {
+      for (const algorithm of ["dijkstra", "astar"] as const) {
+        const mutable = Graph.beginMutation(directed(["A", "B", "C"], [[0, 1, 1], [1, 2, 1], [0, 2, 3]]))
+        let mutated = false
+        const cost = (edge: number) => {
           if (!mutated) {
             mutated = true
             Graph.removeEdge(mutable, 1)
           }
           return edge
-        },
-        heuristic: () => 0
-      })
-
-      assertSome(result, { path: [0, 1, 2], edges: [0, 1], distance: 2, costs: [1, 1] })
-      assert.strictEqual(Graph.edgeCount(mutable), 2)
-    })
-
-    it("should return None for unreachable nodes", () => {
-      const graph = Graph.directed<{ x: number; y: number }, number>((mutable) => {
-        const a = Graph.addNode(mutable, { x: 0, y: 0 })
-        const b = Graph.addNode(mutable, { x: 1, y: 0 })
-        Graph.addNode(mutable, { x: 2, y: 0 })
-        Graph.addEdge(mutable, a, b, 1)
-        // No path from A to C
-      })
-
-      const heuristic = (source: { x: number; y: number }, target: { x: number; y: number }) =>
-        Math.abs(source.x - target.x) + Math.abs(source.y - target.y)
-
-      const result = Graph.astar(graph, {
-        source: 0,
-        target: 2,
-        cost: (edge) => edge,
-        heuristic
-      })
-      assertNone(result)
-    })
-
-    it("should handle same source and target", () => {
-      const graph = Graph.directed<{ x: number; y: number }, number>((mutable) => {
-        Graph.addNode(mutable, { x: 0, y: 0 })
-      })
-
-      const heuristic = (source: { x: number; y: number }, target: { x: number; y: number }) =>
-        Math.abs(source.x - target.x) + Math.abs(source.y - target.y)
-
-      const result = Graph.astar(graph, {
-        source: 0,
-        target: 0,
-        cost: (edge) => edge,
-        heuristic
-      })
-
-      assertSome(result, { path: [0], edges: [], distance: 0, costs: [] })
-    })
-
-    it("should throw for negative weights", () => {
-      const graph = Graph.directed<{ x: number; y: number }, number>((mutable) => {
-        const a = Graph.addNode(mutable, { x: 0, y: 0 })
-        const b = Graph.addNode(mutable, { x: 1, y: 0 })
-        Graph.addEdge(mutable, a, b, -1)
-      })
-
-      const heuristic = (source: { x: number; y: number }, target: { x: number; y: number }) =>
-        Math.abs(source.x - target.x) + Math.abs(source.y - target.y)
-
-      expect(() =>
-        Graph.astar(graph, {
-          source: 0,
-          target: 1,
-          cost: (edge) => edge,
-          heuristic
-        })
-      ).toThrow("A* algorithm requires non-negative edge weights")
-    })
-
-    it("should throw for NaN and negative infinity weights", () => {
-      for (const weight of unsupportedEdgeWeights) {
-        const graph = makeSingleEdgeGraph(weight)
-
-        assertGraphError(
-          () =>
-            Graph.astar(graph, {
-              source: 0,
-              target: 1,
-              cost: (edge) => edge,
-              heuristic: () => 0
-            }),
-          "A* algorithm requires non-negative edge weights"
-        )
-      }
-    })
-
-    it("should throw for non-finite heuristic values", () => {
-      for (const heuristicValue of [NaN, Infinity, -Infinity]) {
-        const graph = Graph.directed<string, number>((mutable) => {
-          const source = Graph.addNode(mutable, "source")
-          const target = Graph.addNode(mutable, "target")
-          const via = Graph.addNode(mutable, "via")
-          Graph.addEdge(mutable, source, target, 10)
-          Graph.addEdge(mutable, source, via, 1)
-          Graph.addEdge(mutable, via, target, 1)
-        })
-
-        assertGraphError(
-          () =>
-            Graph.astar(graph, {
-              source: 0,
-              target: 1,
-              cost: (edge) => edge,
-              heuristic: (node) => node === "via" ? heuristicValue : 0
-            }),
-          "A* algorithm requires finite heuristic values"
-        )
-      }
-    })
-
-    it("should validate the heuristic when source equals target", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "source")
-      })
-
-      for (const candidate of [graph, Graph.beginMutation(graph)]) {
-        assertGraphError(
-          () =>
-            Graph.astar(candidate, {
-              source: 0,
-              target: 0,
-              cost: (edge) => edge,
-              heuristic: () => NaN
-            }),
-          "A* algorithm requires finite heuristic values"
-        )
-      }
-    })
-
-    it("should treat infinity weights as unreachable", () => {
-      const graph = makeSingleEdgeGraph(Infinity)
-
-      const result = Graph.astar(graph, {
-        source: 0,
-        target: 1,
-        cost: (edge) => edge,
-        heuristic: () => 0
-      })
-
-      assertNone(result)
-    })
-
-    it("should throw for negative weights before early target termination", () => {
-      const graph = Graph.directed<{ x: number; y: number }, number>((mutable) => {
-        const source = Graph.addNode(mutable, { x: 0, y: 0 })
-        const target = Graph.addNode(mutable, { x: 1, y: 0 })
-        const other = Graph.addNode(mutable, { x: 2, y: 0 })
-        Graph.addEdge(mutable, source, target, 1)
-        Graph.addEdge(mutable, source, other, 2)
-        Graph.addEdge(mutable, other, target, -5)
-      })
-
-      expect(() =>
-        Graph.astar(graph, {
-          source: 0,
-          target: 1,
-          cost: (edge) => edge,
-          heuristic: () => 0
-        })
-      ).toThrow("A* algorithm requires non-negative edge weights")
-    })
-
-    it("should validate weights before returning same source and target", () => {
-      const graph = Graph.directed<{ x: number; y: number }, number>((mutable) => {
-        const node = Graph.addNode(mutable, { x: 0, y: 0 })
-        Graph.addEdge(mutable, node, node, -1)
-      })
-
-      expect(() =>
-        Graph.astar(graph, {
-          source: 0,
-          target: 0,
-          cost: (edge) => edge,
-          heuristic: () => 0
-        })
-      ).toThrow("A* algorithm requires non-negative edge weights")
-    })
-
-    it("should traverse undirected edges in reverse storage direction", () => {
-      const graph = makeReversedUndirectedPath()
-
-      const result = Graph.astar(graph, {
-        source: 0,
-        target: 2,
-        cost: (edge) => edge,
-        heuristic: () => 0
-      })
-
-      assertSome(result, { path: [0, 1, 2], edges: [0, 1], distance: 2, costs: [1, 1] })
-    })
-  })
-
-  describe("Bellman-Ford", () => {
-    it("should find shortest path with negative weights", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, -1)
-        Graph.addEdge(mutable, b, c, 3)
-        Graph.addEdge(mutable, a, c, 5)
-      })
-
-      const result = Graph.bellmanFord(graph, {
-        source: 0,
-        target: 2,
-        cost: (edge) => edge
-      })
-
-      assertSome(result, { path: [0, 1, 2], edges: [0, 1], distance: 2, costs: [-1, 3] })
-    })
-
-    it("should return None for unreachable nodes", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        // No path from A to C
-      })
-
-      const result = Graph.bellmanFord(graph, {
-        source: 0,
-        target: 2,
-        cost: (edge) => edge
-      })
-
-      assertNone(result)
-    })
-
-    it("should handle same source and target", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-      })
-
-      const result = Graph.bellmanFord(graph, {
-        source: 0,
-        target: 0,
-        cost: (edge) => edge
-      })
-
-      assertSome(result, { path: [0], edges: [], distance: 0, costs: [] })
-    })
-
-    it("should throw for NaN and negative infinity weights", () => {
-      for (const weight of unsupportedEdgeWeights) {
-        const graph = makeSingleEdgeGraph(weight)
-
-        assertGraphError(
-          () =>
-            Graph.bellmanFord(graph, {
-              source: 0,
-              target: 1,
-              cost: (edge) => edge
-            }),
-          "Bellman-Ford algorithm does not support NaN or -Infinity edge weights"
-        )
-      }
-    })
-
-    it("should treat infinity weights as unreachable", () => {
-      const graph = makeSingleEdgeGraph(Infinity)
-
-      const result = Graph.bellmanFord(graph, {
-        source: 0,
-        target: 1,
-        cost: (edge) => edge
-      })
-
-      assertNone(result)
-    })
-
-    it("should reject finite distance arithmetic outside the number range", () => {
-      const underflow = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-        Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, 0, 1, -Number.MAX_VALUE)
-        Graph.addEdge(mutable, 1, 0, -Number.MAX_VALUE)
-      })
-      const overflow = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-        Graph.addNode(mutable, "B")
-        Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, 0, 1, Number.MAX_VALUE)
-        Graph.addEdge(mutable, 1, 2, Number.MAX_VALUE)
-      })
-      const error = "Bellman-Ford distance calculation exceeded the finite number range"
-
-      for (const graph of [underflow, Graph.beginMutation(underflow)]) {
-        assertGraphError(() => Graph.bellmanFord(graph, { source: 0, target: 0, cost: (edge) => edge }), error)
-      }
-      for (const graph of [overflow, Graph.beginMutation(overflow)]) {
-        assertGraphError(() => Graph.bellmanFord(graph, { source: 0, target: 2, cost: (edge) => edge }), error)
-      }
-    })
-
-    it("should detect a directed negative self-loop when source equals target", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const node = Graph.addNode(mutable, "A")
-        Graph.addEdge(mutable, node, node, -1)
-      })
-
-      assertGraphError(
-        () => Graph.bellmanFord(graph, { source: 0, target: 0, cost: (edge) => edge }),
-        "Negative cycle affects path to node 0"
-      )
-    })
-
-    it("should detect an undirected negative self-loop when source equals target", () => {
-      const graph = Graph.undirected<string, number>((mutable) => {
-        const node = Graph.addNode(mutable, "A")
-        Graph.addEdge(mutable, node, node, -1)
-      })
-
-      assertGraphError(
-        () => Graph.bellmanFord(graph, { source: 0, target: 0, cost: (edge) => edge }),
-        "Negative cycle affects path to node 0"
-      )
-    })
-
-    it("should detect negative cycles", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, b, c, -3)
-        Graph.addEdge(mutable, c, a, 1)
-      })
-
-      assertGraphError(
-        () => Graph.bellmanFord(graph, { source: 0, target: 2, cost: (edge) => edge }),
-        "Negative cycle affects path to node 2"
-      )
-    })
-
-    it("should traverse undirected edges in reverse storage direction", () => {
-      const graph = makeReversedUndirectedPath()
-
-      const result = Graph.bellmanFord(graph, {
-        source: 0,
-        target: 2,
-        cost: (edge) => edge
-      })
-
-      assertSome(result, { path: [0, 1, 2], edges: [0, 1], distance: 2, costs: [1, 1] })
-    })
-
-    it("should treat a reachable negative undirected edge as a negative cycle", () => {
-      const graph = Graph.undirected<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, -1)
-      })
-
-      assertGraphError(
-        () => Graph.bellmanFord(graph, { source: 0, target: 1, cost: (edge) => edge }),
-        "Negative cycle affects path to node 1"
-      )
-    })
-
-    it("should ignore negative cycles that cannot affect the target", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        for (let i = 0; i < 4; i++) {
-          Graph.addNode(mutable, String(i))
         }
-        Graph.addEdge(mutable, 0, 1, 1)
-        Graph.addEdge(mutable, 1, 2, -2)
-        Graph.addEdge(mutable, 2, 1, 1)
-        Graph.addEdge(mutable, 0, 3, 5)
-      })
-      const expected = { path: [0, 3], edges: [3], distance: 5, costs: [5] }
+        const result = algorithm === "dijkstra"
+          ? Graph.dijkstra(mutable, { source: 0, target: 2, cost })
+          : Graph.astar(mutable, { source: 0, target: 2, cost, heuristic: () => 0 })
+        assertPath(result, { path: [0, 1, 2], edges: [0, 1], distance: 2, costs: [1, 1] })
+      }
+    })
 
-      assertSome(Graph.bellmanFord(graph, { source: 0, target: 3, cost: (edge) => edge }), expected)
-      assertSome(
+    it("handles unreachable and same-node paths completely", () => {
+      const graph = directed<string, number>(["A", "B"], [])
+      assert.deepStrictEqual(Graph.dijkstra(graph, { source: 0, target: 1, cost: (edge) => edge }), Option.none())
+      assertPath(Graph.dijkstra(graph, { source: 0, target: 0, cost: (edge) => edge }), {
+        path: [0],
+        edges: [],
+        distance: 0,
+        costs: []
+      })
+      const all = Graph.floydWarshall(graph, (edge) => edge)
+      assert.strictEqual(all.distances.get(0)?.get(1), Infinity)
+      assert.strictEqual(all.paths.get(0)?.get(1), null)
+      assert.deepStrictEqual(all.edges.get(0)?.get(1), [])
+      assert.deepStrictEqual(all.costs.get(0)?.get(1), [])
+    })
+
+    it("uses negative Bellman-Ford edges in shortest paths", () => {
+      assertPath(
+        Graph.bellmanFord(directed([0, 1, 2], [[0, 1, -1], [1, 2, 3], [0, 2, 5]]), {
+          source: 0,
+          target: 2,
+          cost: (edge) => edge
+        }),
+        { path: [0, 1, 2], edges: [0, 1], distance: 2, costs: [-1, 3] }
+      )
+    })
+
+    it("ignores negative cycles that cannot affect the Bellman-Ford target", () => {
+      const graph = directed([0, 1, 2, 3], [[0, 1, 1], [1, 2, -2], [2, 1, 1], [0, 3, 5]])
+      const expected = { path: [0, 3], edges: [3], distance: 5, costs: [5] }
+      assertPath(Graph.bellmanFord(graph, { source: 0, target: 3, cost: (edge) => edge }), expected)
+      assertPath(
         Graph.bellmanFord(Graph.beginMutation(graph), { source: 0, target: 3, cost: (edge) => edge }),
         expected
       )
     })
-  })
 
-  describe("Floyd-Warshall", () => {
-    it("should find all-pairs shortest paths", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 3)
-        Graph.addEdge(mutable, b, c, 2)
-        Graph.addEdge(mutable, a, c, 7)
-      })
-
-      const result = Graph.floydWarshall(graph, (edge) => edge)
-
-      // Check distance A to C (should be 5 via B, not 7 direct)
-      expect(result.distances.get(0)?.get(2)).toBe(5)
-      expect(result.paths.get(0)?.get(2)).toEqual([0, 1, 2])
-      assert.deepStrictEqual(result.edges.get(0)?.get(2), [0, 1])
-      expect(result.costs.get(0)?.get(2)).toEqual([3, 2])
-
-      // Check distance A to B
-      expect(result.distances.get(0)?.get(1)).toBe(3)
-      expect(result.paths.get(0)?.get(1)).toEqual([0, 1])
-
-      // Check distance B to C
-      expect(result.distances.get(1)?.get(2)).toBe(2)
-      expect(result.paths.get(1)?.get(2)).toEqual([1, 2])
-    })
-
-    it("should handle unreachable nodes", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        // No path from A to C
-      })
-
-      const result = Graph.floydWarshall(graph, (edge) => edge)
-
-      expect(result.distances.get(0)?.get(2)).toBe(Infinity)
-      expect(result.paths.get(0)?.get(2)).toBeNull()
-      assert.deepStrictEqual(result.edges.get(0)?.get(2), [])
-    })
-
-    it("should handle same source and target", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-      })
-
-      const result = Graph.floydWarshall(graph, (edge) => edge)
-
-      expect(result.distances.get(0)?.get(0)).toBe(0)
-      expect(result.paths.get(0)?.get(0)).toEqual([0])
-      assert.deepStrictEqual(result.edges.get(0)?.get(0), [])
-      expect(result.costs.get(0)?.get(0)).toEqual([])
-    })
-
-    it("should throw for NaN and negative infinity weights", () => {
-      for (const weight of unsupportedEdgeWeights) {
-        const graph = makeSingleEdgeGraph(weight)
-
+    it("detects directed and undirected negative self-loops when source equals target", () => {
+      for (const graph of [directed([0], [[0, 0, -1]]), undirected([0], [[0, 0, -1]])]) {
         assertGraphError(
-          () => Graph.floydWarshall(graph, (edge) => edge),
-          "Floyd-Warshall algorithm does not support NaN or -Infinity edge weights"
+          () => Graph.bellmanFord(graph, { source: 0, target: 0, cost: (edge) => edge }),
+          "Negative cycle affects path to node 0"
         )
       }
     })
 
-    it("should treat infinity weights as unreachable", () => {
-      const graph = makeSingleEdgeGraph(Infinity)
-
-      const result = Graph.floydWarshall(graph, (edge) => edge)
-
-      expect(result.distances.get(0)?.get(1)).toBe(Infinity)
-      expect(result.paths.get(0)?.get(1)).toBeNull()
-      assert.deepStrictEqual(result.edges.get(0)?.get(1), [])
-      expect(result.costs.get(0)?.get(1)).toEqual([])
-    })
-
-    it("should preserve null edge data in direct paths", () => {
-      const graph = Graph.directed<string, null>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, null)
-      })
-
-      const result = Graph.floydWarshall(graph, () => 1)
-
-      assert.strictEqual(result.distances.get(0)?.get(1), 1)
-      assert.deepStrictEqual(result.paths.get(0)?.get(1), [0, 1])
-      assert.deepStrictEqual(result.edges.get(0)?.get(1), [0])
-      assert.deepStrictEqual(result.costs.get(0)?.get(1), [null])
-    })
-
-    it("should preserve null edge data in multihop paths", () => {
-      type EdgeData = null | { readonly weight: number }
-
-      const graph = Graph.directed<string, EdgeData>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, null)
-        Graph.addEdge(mutable, b, c, null)
-        Graph.addEdge(mutable, a, c, { weight: 10 })
-      })
-
+    it("preserves null edge payloads in Floyd-Warshall multihop paths", () => {
+      type Edge = null | { readonly weight: number }
+      const graph = directed<string, Edge>(["A", "B", "C"], [
+        [0, 1, null],
+        [1, 2, null],
+        [0, 2, { weight: 10 }]
+      ])
       const result = Graph.floydWarshall(graph, (edge) => edge === null ? 1 : edge.weight)
-
       assert.strictEqual(result.distances.get(0)?.get(2), 2)
       assert.deepStrictEqual(result.paths.get(0)?.get(2), [0, 1, 2])
       assert.deepStrictEqual(result.edges.get(0)?.get(2), [0, 1])
       assert.deepStrictEqual(result.costs.get(0)?.get(2), [null, null])
     })
 
-    it("should detect negative cycles", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, b, c, -3)
-        Graph.addEdge(mutable, c, a, 1)
-      })
-
-      expect(() => Graph.floydWarshall(graph, (edge) => edge)).toThrow("Negative cycle detected")
+    it("treats positive Infinity as unreachable in every shortest-path algorithm", () => {
+      const graph = directed([0, 1], [[0, 1, Infinity]])
+      assert.deepStrictEqual(Graph.dijkstra(graph, { source: 0, target: 1, cost: (edge) => edge }), Option.none())
+      assert.deepStrictEqual(
+        Graph.astar(graph, { source: 0, target: 1, cost: (edge) => edge, heuristic: () => 0 }),
+        Option.none()
+      )
+      assert.deepStrictEqual(Graph.bellmanFord(graph, { source: 0, target: 1, cost: (edge) => edge }), Option.none())
+      const all = Graph.floydWarshall(graph, (edge) => edge)
+      assert.strictEqual(all.distances.get(0)?.get(1), Infinity)
+      assert.strictEqual(all.paths.get(0)?.get(1), null)
+      assert.deepStrictEqual(all.edges.get(0)?.get(1), [])
+      assert.deepStrictEqual(all.costs.get(0)?.get(1), [])
     })
 
-    it("should traverse undirected edges in reverse storage direction", () => {
-      const graph = makeReversedUndirectedPath()
-
-      const result = Graph.floydWarshall(graph, (edge) => edge)
-
-      expect(result.distances.get(0)?.get(2)).toBe(2)
-      expect(result.paths.get(0)?.get(2)).toEqual([0, 1, 2])
-      assert.deepStrictEqual(result.edges.get(0)?.get(2), [0, 1])
-      expect(result.costs.get(0)?.get(2)).toEqual([1, 1])
+    it("reports relevant Bellman-Ford and Floyd-Warshall negative cycles", () => {
+      const cycle = directed([0, 1, 2], [[0, 1, 1], [1, 2, -3], [2, 0, 1]])
+      assertGraphError(
+        () => Graph.bellmanFord(cycle, { source: 0, target: 2, cost: (edge) => edge }),
+        "Negative cycle affects path to node 2"
+      )
+      assertGraphError(() => Graph.floydWarshall(cycle, (edge) => edge), "Negative cycle detected involving node 0")
+      const negativeUndirected = undirected([0, 1], [[0, 1, -1]])
+      assertGraphError(
+        () => Graph.bellmanFord(negativeUndirected, { source: 0, target: 1, cost: (edge) => edge }),
+        "Negative cycle affects path to node 1"
+      )
     })
 
-    it("should treat negative undirected edges as negative cycles", () => {
-      const graph = Graph.undirected<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, -1)
-      })
+    it("validates endpoints, edge weights, heuristics, and finite arithmetic", () => {
+      assertGraphError(
+        () => Graph.dijkstra(Graph.directed(), { source: 0, target: 1, cost: () => 1 }),
+        "Node 0 does not exist"
+      )
+      for (const weight of [-1, NaN, -Infinity]) {
+        const invalid = directed([0, 1], [[0, 1, weight]])
+        assertGraphError(
+          () => Graph.dijkstra(invalid, { source: 0, target: 1, cost: (edge) => edge }),
+          "Dijkstra's algorithm requires non-negative edge weights"
+        )
+        assertGraphError(
+          () => Graph.astar(invalid, { source: 0, target: 1, cost: (edge) => edge, heuristic: () => 0 }),
+          "A* algorithm requires non-negative edge weights"
+        )
+      }
+      for (const heuristic of [NaN, Infinity, -Infinity]) {
+        assertGraphError(() =>
+          Graph.astar(directed<string, never>(["A"], []), {
+            source: 0,
+            target: 0,
+            cost: () => 1,
+            heuristic: () => heuristic
+          }), "A* algorithm requires finite heuristic values")
+        assertGraphError(() =>
+          Graph.astar(directed(["source", "middle", "target"], [[0, 1, 1], [1, 2, 1]]), {
+            source: 0,
+            target: 2,
+            cost: (edge) => edge,
+            heuristic: (node) => node === "middle" ? heuristic : 0
+          }), "A* algorithm requires finite heuristic values")
+      }
+      for (const weight of [NaN, -Infinity]) {
+        const invalid = directed([0, 1], [[0, 1, weight]])
+        assertGraphError(
+          () => Graph.bellmanFord(invalid, { source: 0, target: 1, cost: (edge) => edge }),
+          "Bellman-Ford algorithm does not support NaN or -Infinity edge weights"
+        )
+        assertGraphError(
+          () => Graph.floydWarshall(invalid, (edge) => edge),
+          "Floyd-Warshall algorithm does not support NaN or -Infinity edge weights"
+        )
+      }
+      const overflow = directed([0, 1, 2], [[0, 1, Number.MAX_VALUE], [1, 2, Number.MAX_VALUE]])
+      assertGraphError(
+        () => Graph.bellmanFord(overflow, { source: 0, target: 2, cost: (edge) => edge }),
+        "Bellman-Ford distance calculation exceeded the finite number range"
+      )
+      const underflow = directed([0, 1], [[0, 1, -Number.MAX_VALUE], [1, 0, -Number.MAX_VALUE]])
+      assertGraphError(
+        () => Graph.bellmanFord(underflow, { source: 0, target: 0, cost: (edge) => edge }),
+        "Bellman-Ford distance calculation exceeded the finite number range"
+      )
+    })
 
-      expect(() => Graph.floydWarshall(graph, (edge) => edge)).toThrow("Negative cycle detected")
+    it("validates negative Dijkstra and A* weights before early returns", () => {
+      const early = directed([0, 1, 2], [[0, 1, 1], [0, 2, 2], [2, 1, -5]])
+      const same = directed([0], [[0, 0, -1]])
+      for (const [graph, source, target] of [[early, 0, 1], [same, 0, 0]] as const) {
+        assertGraphError(
+          () => Graph.dijkstra(graph, { source, target, cost: (edge) => edge }),
+          "Dijkstra's algorithm requires non-negative edge weights"
+        )
+        assertGraphError(
+          () => Graph.astar(graph, { source, target, cost: (edge) => edge, heuristic: () => 0 }),
+          "A* algorithm requires non-negative edge weights"
+        )
+      }
+    })
+
+    it("traverses undirected edges against stored orientation", () => {
+      const graph = undirected(["A", "B", "C"], [[0, 1, 1], [2, 1, 1]])
+      const expected = { path: [0, 1, 2], edges: [0, 1], distance: 2, costs: [1, 1] }
+      assertPath(Graph.dijkstra(graph, { source: 0, target: 2, cost: (edge) => edge }), expected)
+      assertPath(Graph.astar(graph, { source: 0, target: 2, cost: (edge) => edge, heuristic: () => 0 }), expected)
+      assertPath(Graph.bellmanFord(graph, { source: 0, target: 2, cost: (edge) => edge }), expected)
+      const all = Graph.floydWarshall(graph, (edge) => edge)
+      assert.strictEqual(all.distances.get(0)?.get(2), 2)
+      assert.deepStrictEqual(all.paths.get(0)?.get(2), [0, 1, 2])
+      assert.deepStrictEqual(all.edges.get(0)?.get(2), [0, 1])
+      assert.deepStrictEqual(all.costs.get(0)?.get(2), [1, 1])
     })
   })
 
-  describe("lazy path enumeration", () => {
-    it("should lazily enumerate repeatable simple paths with exact edges", () => {
-      const graph = Graph.directed<string, string>((mutable) => {
-        for (let i = 0; i < 4; i++) {
-          Graph.addNode(mutable, String(i))
-        }
-        Graph.addEdge(mutable, 0, 1, "0-1")
-        Graph.addEdge(mutable, 0, 2, "0-2")
-        Graph.addEdge(mutable, 1, 2, "1-2")
-        Graph.addEdge(mutable, 1, 3, "1-3")
-        Graph.addEdge(mutable, 2, 3, "2-3")
-        Graph.addEdge(mutable, 2, 1, "2-1")
-      })
+  describe("path enumeration", () => {
+    it("lazily and repeatably enumerates complete simple paths in edge order", () => {
+      const graph = directed([0, 1, 2, 3], [
+        [0, 1, "01"],
+        [0, 2, "02"],
+        [1, 2, "12"],
+        [1, 3, "13"],
+        [2, 3, "23"],
+        [2, 1, "21"]
+      ])
       const paths = Graph.simplePaths(graph, { source: 0, target: 3, limit: 3 })
       const expected = [
-        { path: [0, 1, 2, 3], edges: [0, 2, 4], distance: 3, costs: ["0-1", "1-2", "2-3"] },
-        { path: [0, 1, 3], edges: [0, 3], distance: 2, costs: ["0-1", "1-3"] },
-        { path: [0, 2, 3], edges: [1, 4], distance: 2, costs: ["0-2", "2-3"] }
+        { path: [0, 1, 2, 3], edges: [0, 2, 4], distance: 3, costs: ["01", "12", "23"] },
+        { path: [0, 1, 3], edges: [0, 3], distance: 2, costs: ["01", "13"] },
+        { path: [0, 2, 3], edges: [1, 4], distance: 2, costs: ["02", "23"] }
       ]
-
       assert.deepStrictEqual(Array.from(paths), expected)
       assert.deepStrictEqual(Array.from(paths), expected)
+      assert.deepStrictEqual(Array.from(Graph.simplePaths({ source: 0, target: 3, limit: 3 })(graph)), expected)
     })
 
-    it("should enumerate parallel and structurally tied shortest paths", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        for (let i = 0; i < 4; i++) {
-          Graph.addNode(mutable, String(i))
-        }
-        Graph.addEdge(mutable, 0, 1, 1)
-        Graph.addEdge(mutable, 0, 2, 1)
-        Graph.addEdge(mutable, 1, 3, 1)
-        Graph.addEdge(mutable, 2, 3, 1)
-        Graph.addEdge(mutable, 0, 1, 1)
-      })
-
-      const result = Array.from(Graph.allShortestPaths(graph, { source: 0, target: 3, cost: (edge) => edge }))
-
-      assert.deepStrictEqual(result, [
+    it("enumerates parallel and structurally tied shortest paths exactly", () => {
+      const graph = directed([0, 1, 2, 3], [[0, 1, 1], [0, 2, 1], [1, 3, 1], [2, 3, 1], [0, 1, 1]])
+      const expected = [
         { path: [0, 1, 3], edges: [0, 2], distance: 2, costs: [1, 1] },
         { path: [0, 1, 3], edges: [4, 2], distance: 2, costs: [1, 1] },
         { path: [0, 2, 3], edges: [1, 3], distance: 2, costs: [1, 1] }
-      ])
+      ]
+      assert.deepStrictEqual(
+        Array.from(Graph.allShortestPaths(graph, { source: 0, target: 3, cost: (edge) => edge })),
+        expected
+      )
+      assert.deepStrictEqual(
+        Array.from(Graph.allShortestPaths({ source: 0, target: 3, cost: (edge: number) => edge })(graph)),
+        expected
+      )
       assert.deepStrictEqual(
         Array.from(Graph.allShortestPaths(Graph.beginMutation(graph), {
           source: 0,
@@ -5581,98 +2033,97 @@ describe("Graph", () => {
           cost: (edge) => edge,
           limit: 2
         })),
-        result.slice(0, 2)
+        expected.slice(0, 2)
       )
     })
 
-    it("should handle empty path enumerations", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-        Graph.addNode(mutable, "B")
-      })
-
-      assert.deepStrictEqual(Array.from(Graph.simplePaths(graph, { source: 0, target: 0 })), [
-        { path: [0], edges: [], distance: 0, costs: [] }
-      ])
+    it("terminates zero-cost predecessor cycles and emits only simple shortest paths", () => {
+      const graph = directed([0, 1, 2, 3], [[0, 1, 0], [1, 2, 0], [2, 1, 0], [1, 3, 1], [2, 3, 1]])
       assert.deepStrictEqual(
-        Array.from(Graph.allShortestPaths(graph, { source: 0, target: 1, cost: (edge) => edge })),
-        []
+        Array.from(Graph.allShortestPaths(graph, { source: 0, target: 3, cost: (edge) => edge })),
+        [
+          { path: [0, 1, 3], edges: [0, 3], distance: 1, costs: [0, 1] },
+          { path: [0, 1, 2, 3], edges: [0, 1, 4], distance: 1, costs: [0, 0, 1] }
+        ]
       )
-      assert.deepStrictEqual(Array.from(Graph.simplePaths(graph, { source: 0, target: 1, limit: 0 })), [])
     })
 
-    it("should defer shortest-path computation until iteration", () => {
-      const graph = makeSingleEdgeGraph(1)
-      let costCalls = 0
-      const paths = Graph.allShortestPaths(graph, {
+    it("defers shortest-path cost evaluation until iteration", () => {
+      let calls = 0
+      const paths = Graph.allShortestPaths(directed([0, 1], [[0, 1, 1]]), {
         source: 0,
         target: 1,
         cost: (edge) => {
-          costCalls++
+          calls++
           return edge
         }
       })
-
-      assert.strictEqual(costCalls, 0)
+      assert.strictEqual(calls, 0)
       assert.deepStrictEqual(Array.from(paths), [{ path: [0, 1], edges: [0], distance: 1, costs: [1] }])
-      assert.strictEqual(costCalls, 1)
+      assert.strictEqual(calls, 1)
     })
 
-    it("should revalidate mutable path endpoints when iteration starts", () => {
-      const makeMutable = () =>
-        Graph.beginMutation(Graph.directed<string, number>((graph) => {
-          Graph.addNode(graph, "A")
-          Graph.addNode(graph, "B")
-          Graph.addEdge(graph, 0, 1, 1)
-        }))
-      const simpleGraph = makeMutable()
-      const simple = Graph.simplePaths(simpleGraph, { source: 0, target: 1 })
-      Graph.removeNode(simpleGraph, 0)
-      assertGraphError(() => Array.from(simple), "Node 0 does not exist")
+    it("revalidates mutable endpoints and isolates active snapshots", () => {
+      const removed = Graph.beginMutation(directed([0, 1], [[0, 1, 1]]))
+      const pending = Graph.simplePaths(removed, { source: 0, target: 1 })
+      Graph.removeNode(removed, 0)
+      assertGraphError(() => Array.from(pending), "Node 0 does not exist")
 
-      const shortestGraph = makeMutable()
-      const shortest = Graph.allShortestPaths(shortestGraph, { source: 0, target: 1, cost: (edge) => edge })
-      Graph.removeNode(shortestGraph, 1)
-      assertGraphError(() => Array.from(shortest), "Node 1 does not exist")
+      const shortestRemoved = Graph.beginMutation(directed([0, 1], [[0, 1, 1]]))
+      const shortestPending = Graph.allShortestPaths(shortestRemoved, {
+        source: 0,
+        target: 1,
+        cost: (edge) => edge
+      })
+      Graph.removeNode(shortestRemoved, 1)
+      assertGraphError(() => Array.from(shortestPending), "Node 1 does not exist")
+
+      const mutable = Graph.beginMutation(directed([0, 1, 2, 3], [[0, 1, 1], [0, 2, 1], [1, 3, 1], [2, 3, 1]]))
+      const paths = Graph.simplePaths(mutable, { source: 0, target: 3 })
+      const iterator = paths[Symbol.iterator]()
+      assert.deepStrictEqual(iterator.next().value, {
+        path: [0, 1, 3],
+        edges: [0, 2],
+        distance: 2,
+        costs: [1, 1]
+      })
+      Graph.removeEdge(mutable, 1)
+      assert.deepStrictEqual(iterator.next().value, {
+        path: [0, 2, 3],
+        edges: [1, 3],
+        distance: 2,
+        costs: [1, 1]
+      })
+      assert.deepStrictEqual(Array.from(paths), [{ path: [0, 1, 3], edges: [0, 2], distance: 2, costs: [1, 1] }])
+
+      const shortestMutable = Graph.beginMutation(directed([0, 1, 2, 3], [
+        [0, 1, 1],
+        [0, 2, 1],
+        [1, 3, 1],
+        [2, 3, 1]
+      ]))
+      const shortest = Graph.allShortestPaths(shortestMutable, { source: 0, target: 3, cost: (edge) => edge })
+      const shortestIterator = shortest[Symbol.iterator]()
+      assert.deepStrictEqual(shortestIterator.next().value, {
+        path: [0, 1, 3],
+        edges: [0, 2],
+        distance: 2,
+        costs: [1, 1]
+      })
+      Graph.removeEdge(shortestMutable, 1)
+      assert.deepStrictEqual(shortestIterator.next().value, {
+        path: [0, 2, 3],
+        edges: [1, 3],
+        distance: 2,
+        costs: [1, 1]
+      })
+      assert.deepStrictEqual(Array.from(shortest), [
+        { path: [0, 1, 3], edges: [0, 2], distance: 2, costs: [1, 1] }
+      ])
     })
 
-    it("should isolate active mutable path iterations from later mutations", () => {
-      const makeMutable = () =>
-        Graph.beginMutation(Graph.directed<string, number>((graph) => {
-          for (let i = 0; i < 4; i++) {
-            Graph.addNode(graph, String(i))
-          }
-          Graph.addEdge(graph, 0, 1, 1)
-          Graph.addEdge(graph, 0, 2, 1)
-          Graph.addEdge(graph, 1, 3, 1)
-          Graph.addEdge(graph, 2, 3, 1)
-        }))
-      const assertSnapshot = (paths: Graph.PathWalker<number>, mutable: Graph.MutableDirectedGraph<string, number>) => {
-        const iterator = paths[Symbol.iterator]()
-        assert.deepStrictEqual(iterator.next().value?.edges, [0, 2])
-        Graph.removeEdge(mutable, 1)
-        assert.deepStrictEqual(iterator.next().value?.edges, [1, 3])
-      }
-
-      const simpleGraph = makeMutable()
-      assertSnapshot(Graph.simplePaths(simpleGraph, { source: 0, target: 3 }), simpleGraph)
-
-      const shortestGraph = makeMutable()
-      assertSnapshot(
-        Graph.allShortestPaths(shortestGraph, { source: 0, target: 3, cost: (edge) => edge }),
-        shortestGraph
-      )
-    })
-
-    it("should snapshot mutable adjacency before evaluating shortest-path costs", () => {
-      const mutable = Graph.beginMutation(Graph.directed<string, number>((graph) => {
-        Graph.addNode(graph, "A")
-        Graph.addNode(graph, "B")
-        Graph.addNode(graph, "C")
-        Graph.addEdge(graph, 0, 1, 1)
-        Graph.addEdge(graph, 1, 2, 1)
-        Graph.addEdge(graph, 0, 2, 3)
-      }))
+    it("snapshots mutable adjacency before all-shortest-path cost callbacks", () => {
+      const mutable = Graph.beginMutation(directed([0, 1, 2], [[0, 1, 1], [1, 2, 1], [0, 2, 3]]))
       let mutated = false
       const paths = Graph.allShortestPaths(mutable, {
         source: 0,
@@ -5685,15 +2136,25 @@ describe("Graph", () => {
           return edge
         }
       })
-
       assert.deepStrictEqual(Array.from(paths), [
         { path: [0, 1, 2], edges: [0, 1], distance: 2, costs: [1, 1] }
       ])
     })
 
-    it("should validate path enumeration options", () => {
-      const graph = makeSingleEdgeGraph(-1)
+    it("handles empty path enumerations", () => {
+      const graph = directed<string, number>(["A", "B"], [])
 
+      assert.deepStrictEqual(Array.from(Graph.simplePaths(graph, { source: 0, target: 0 })), [
+        { path: [0], edges: [], distance: 0, costs: [] }
+      ])
+      assert.deepStrictEqual(
+        Array.from(Graph.allShortestPaths(graph, { source: 0, target: 1, cost: (edge) => edge })),
+        []
+      )
+    })
+
+    it("validates limits, endpoints, and non-negative shortest-path costs", () => {
+      const graph = directed([0, 1], [[0, 1, -1]])
       assertGraphError(
         () => Array.from(Graph.allShortestPaths(graph, { source: 0, target: 1, cost: (edge) => edge })),
         "All shortest paths requires non-negative edge weights"
@@ -5707,1098 +2168,182 @@ describe("Graph", () => {
         "Path enumeration limit must be a non-negative integer or Infinity"
       )
       assertGraphError(() => Graph.simplePaths(graph, { source: 0, target: 2 }), "Node 2 does not exist")
+      assert.deepStrictEqual(Array.from(Graph.simplePaths(graph, { source: 0, target: 1, limit: 0 })), [])
     })
   })
 
-  describe("path edge indexes", () => {
-    it("should preserve sparse parallel edge identity across algorithms and mutability", () => {
-      const graph = Graph.fromSnapshot({
-        type: "directed",
-        nodes: [{ index: 2, data: "source" }, { index: 5, data: "target" }],
-        edges: [
-          { index: 3, source: 2, target: 5, data: 1 },
-          { index: 1_000_000, source: 2, target: 5, data: 1 }
-        ]
-      })
-      const mutable = Graph.beginMutation(graph)
-      const expected = { path: [2, 5], edges: [3], distance: 1, costs: [1] }
+  describe("traversal", () => {
+    const graph = directed(["A", "B", "C", "D"], [[0, 1, 1], [0, 2, 2], [1, 3, 3], [2, 3, 4]])
 
-      for (const candidate of [graph, mutable]) {
-        assertSome(Graph.dijkstra(candidate, { source: 2, target: 5, cost: (edge) => edge }), expected)
-        assertSome(
-          Graph.astar(candidate, { source: 2, target: 5, cost: (edge) => edge, heuristic: () => 0 }),
-          expected
-        )
-        assertSome(Graph.bellmanFord(candidate, { source: 2, target: 5, cost: (edge) => edge }), expected)
-
-        const allPairs = Graph.floydWarshall(candidate, (edge) => edge)
-        assert.deepStrictEqual(allPairs.paths.get(2)?.get(5), [2, 5])
-        assert.deepStrictEqual(allPairs.edges.get(2)?.get(5), [3])
-      }
-    })
-  })
-
-  describe("immutable algorithm cache", () => {
-    it("should preserve mutable structural and pathfinding results", () => {
-      const graph = Graph.directed<number | undefined, number>((mutable) => {
-        for (let i = 0; i < 6; i++) {
-          Graph.addNode(mutable, i === 3 ? undefined : i)
-        }
-        Graph.addEdge(mutable, 0, 1, 2)
-        Graph.addEdge(mutable, 0, 2, 1)
-        Graph.addEdge(mutable, 2, 1, 1)
-        Graph.addEdge(mutable, 1, 3, 2)
-        Graph.addEdge(mutable, 3, 2, 1)
-        Graph.addEdge(mutable, 3, 4, 3)
-      })
-      const mutable = Graph.beginMutation(graph)
-      const pathConfig = { source: 0, target: 4, cost: (weight: number) => weight }
-
-      assert.deepStrictEqual(Graph.stronglyConnectedComponents(graph), Graph.stronglyConnectedComponents(mutable))
-      assert.strictEqual(Graph.isAcyclic(graph), Graph.isAcyclic(mutable))
-      assert.deepStrictEqual(
-        Graph.astar(graph, { ...pathConfig, heuristic: () => 0 }),
-        Graph.astar(mutable, { ...pathConfig, heuristic: () => 0 })
-      )
-      assert.deepStrictEqual(Graph.bellmanFord(graph, pathConfig), Graph.bellmanFord(mutable, pathConfig))
-      assert.deepStrictEqual(Graph.floydWarshall(graph, pathConfig.cost), Graph.floydWarshall(mutable, pathConfig.cost))
+    it("traverses DFS, BFS, and postorder in documented order", () => {
+      assertIndices(Graph.dfs(graph, { start: [0] }), [0, 1, 3, 2])
+      assertIndices(Graph.bfs(graph, { start: [0] }), [0, 1, 2, 3])
+      assertIndices(Graph.dfsPostOrder(graph, { start: [0] }), [3, 1, 2, 0])
+      assertIndices(Graph.dfs(graph), [])
     })
 
-    it("should preserve mutable undirected and topological results", () => {
-      const undirected = Graph.undirected<string, number>((mutable) => {
-        for (let i = 0; i < 5; i++) Graph.addNode(mutable, String(i))
-        Graph.addEdge(mutable, 0, 1, 1)
-        Graph.addEdge(mutable, 0, 2, 2)
-        Graph.addEdge(mutable, 0, 1, 3)
-        Graph.addEdge(mutable, 3, 4, 4)
-      })
-      const mutableUndirected = Graph.beginMutation(undirected)
-      assert.strictEqual(Graph.isAcyclic(undirected), Graph.isAcyclic(mutableUndirected))
-      assert.strictEqual(Graph.isBipartite(undirected), Graph.isBipartite(mutableUndirected))
-      assert.deepStrictEqual(Graph.connectedComponents(undirected), Graph.connectedComponents(mutableUndirected))
-
-      const dag = Graph.directed<string, number>((mutable) => {
-        for (let i = 0; i < 5; i++) Graph.addNode(mutable, String(i))
-        Graph.addEdge(mutable, 0, 2, 1)
-        Graph.addEdge(mutable, 1, 2, 2)
-        Graph.addEdge(mutable, 2, 3, 3)
-      })
-      assert.deepStrictEqual(
-        Array.from(Graph.indices(Graph.topo(dag, { initials: [1, 0] }))),
-        Array.from(Graph.indices(Graph.topo(Graph.beginMutation(dag), { initials: [1, 0] })))
+    it("uses shortest distance for radius membership and supports traversal directions", () => {
+      const graph = directed([0, 1, 2, 3], [[0, 1, 1], [1, 2, 1], [0, 2, 1], [2, 3, 1]])
+      assertIndices(Graph.dfs(graph, { start: [0], radius: 2 }), [0, 1, 2, 3])
+      assertIndices(Graph.bfs(graph, { start: [2], direction: "incoming" }), [2, 1, 0])
+      assertIndices(Graph.dfsPostOrder(graph, { start: [2], direction: "incoming" }), [0, 1, 2])
+      assertIndices(Graph.bfs(graph, { start: [1], direction: "undirected", radius: 1 }), [1, 2, 0])
+      assertIndices(
+        Graph.dfsPostOrder(directed([0, 1, 2], [[0, 1, 1], [1, 2, 1]]), {
+          start: [0],
+          radius: 1
+        }),
+        [1, 0]
       )
     })
 
-    it("should support sparse indexes across cached algorithms", () => {
-      const graph = Graph.fromSnapshot({
-        type: "directed",
-        nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }, { index: 1_000_000, data: "C" }],
-        edges: [
-          { index: 3, source: 2, target: 5, data: 2 },
-          { index: 1_000_000, source: 5, target: 1_000_000, data: 3 }
-        ]
-      })
-      const mutable = Graph.beginMutation(graph)
-      const config = { source: 2, target: 1_000_000, cost: (weight: number) => weight }
+    it("preserves bounded undirected DFS order for reciprocal neighbors", () => {
+      const graph = directed<void, number>(new Array(5).fill(undefined), [[0, 1, 1], [4, 1, 2], [1, 4, 3]])
 
-      assert.deepStrictEqual(Graph.stronglyConnectedComponents(graph), Graph.stronglyConnectedComponents(mutable))
-      assert.deepStrictEqual(Graph.bellmanFord(graph, config), Graph.bellmanFord(mutable, config))
-      assert.deepStrictEqual(Graph.floydWarshall(graph, config.cost), Graph.floydWarshall(mutable, config.cost))
-      assert.deepStrictEqual(
-        Array.from(Graph.indices(Graph.topo(graph))),
-        Array.from(Graph.indices(Graph.topo(mutable)))
-      )
+      assertIndices(Graph.dfs(graph, { start: [1], direction: "undirected", radius: 2 }), [1, 4, 0])
     })
-  })
 
-  describe("Iterator Base Methods", () => {
-    const makeMutableTraversalGraph = () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-        Graph.addNode(mutable, "B")
-        Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, 0, 1, 1)
-        Graph.addEdge(mutable, 1, 2, 2)
-      })
-      return Graph.beginMutation(graph)
-    }
-
-    const traversalRadiusError = "Traversal radius must be a non-negative integer or Infinity"
-
-    it("validates traversal radius eagerly in data-first and data-last forms", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-      })
-      const traversals = [
-        {
-          dataFirst: (radius: number) => Graph.dfs(graph, { start: [], radius }),
-          dataLast: (radius: number) => Graph.dfs({ start: [], radius })(graph)
-        },
-        {
-          dataFirst: (radius: number) => Graph.bfs(graph, { start: [], radius }),
-          dataLast: (radius: number) => Graph.bfs({ start: [], radius })(graph)
-        },
-        {
-          dataFirst: (radius: number) => Graph.dfsPostOrder(graph, { start: [], radius }),
-          dataLast: (radius: number) => Graph.dfsPostOrder({ start: [], radius })(graph)
-        }
-      ]
-
-      for (const radius of [NaN, -Infinity, -1, -0.5, 0.5, 1.5]) {
-        for (const traversal of traversals) {
-          assertGraphError(() => traversal.dataFirst(radius), traversalRadiusError)
-          assertGraphError(() => traversal.dataLast(radius), traversalRadiusError)
-        }
+    it("validates radius in data-first and data-last forms", () => {
+      for (const radius of [NaN, -Infinity, -1, 0.5]) {
+        for (
+          const run of [
+            () => Graph.dfs(graph, { start: [0], radius }),
+            () => Graph.bfs({ start: [0], radius })(graph),
+            () => Graph.dfsPostOrder(graph, { start: [0], radius })
+          ]
+        ) assertGraphError(run, "Traversal radius must be a non-negative integer or Infinity")
       }
     })
 
-    it("accepts omitted, infinite, negative zero, and non-negative integer radii", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-        Graph.addNode(mutable, "B")
-        Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, 0, 1, 1)
-        Graph.addEdge(mutable, 1, 2, 2)
-      })
-
-      const cases = [
-        { radius: undefined, preorder: [0, 1, 2], postorder: [2, 1, 0] },
-        { radius: Infinity, preorder: [0, 1, 2], postorder: [2, 1, 0] },
-        { radius: -0, preorder: [0], postorder: [0] },
-        { radius: 0, preorder: [0], postorder: [0] },
-        { radius: 1, preorder: [0, 1], postorder: [1, 0] },
-        { radius: 2, preorder: [0, 1, 2], postorder: [2, 1, 0] }
-      ]
-
-      for (const { postorder, preorder, radius } of cases) {
-        const config = radius === undefined ? { start: [0] } : { start: [0], radius }
-        assert.deepStrictEqual(Array.from(Graph.indices(Graph.dfs(graph, config))), preorder)
-        assert.deepStrictEqual(Array.from(Graph.indices(Graph.bfs(graph, config))), preorder)
-        assert.deepStrictEqual(Array.from(Graph.indices(Graph.dfsPostOrder(graph, config))), postorder)
-      }
-    })
-
-    it("copies configured starts for every traversal", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-        Graph.addNode(mutable, "B")
-      })
+    it("copies starts, prioritizes distinct roots, and preserves sparse indexes", () => {
       const start = [0]
-      const dfs = Graph.dfs(graph, { start })
-      const bfs = Graph.bfs(graph, { start })
-      const postorder = Graph.dfsPostOrder(graph, { start })
+      const walkers = [Graph.dfs(graph, { start }), Graph.bfs(graph, { start }), Graph.dfsPostOrder(graph, { start })]
+      start[0] = 3
+      assertIndices(walkers[0], [0, 1, 3, 2])
+      assertIndices(walkers[1], [0, 1, 2, 3])
+      assertIndices(walkers[2], [3, 1, 2, 0])
+      assertIndices(Graph.bfs(graph, { start: [0, 0, 2, 2] }), [0, 2, 1, 3])
 
-      start[0] = 1
-
-      assert.deepStrictEqual(Array.from(Graph.indices(dfs)), [0])
-      assert.deepStrictEqual(Array.from(Graph.indices(bfs)), [0])
-      assert.deepStrictEqual(Array.from(Graph.indices(postorder)), [0])
-    })
-
-    it("revalidates copied starts for every fresh iterator snapshot", () => {
-      const mutable = makeMutableTraversalGraph()
-      const dfs = Graph.indices(Graph.dfs(mutable, { start: [0] }))
-      const bfs = Graph.indices(Graph.bfs(mutable, { start: [0] }))
-      const postorder = Graph.indices(Graph.dfsPostOrder(mutable, { start: [0] }))
-
-      Graph.removeNode(mutable, 0)
-
-      for (const traversal of [dfs, bfs, postorder]) {
-        assertGraphError(() => traversal[Symbol.iterator](), "Node 0 does not exist")
-      }
-    })
-
-    it("keeps active traversal snapshots isolated while fresh iterators see mutations", () => {
-      const mutable = makeMutableTraversalGraph()
-      const dfs = Graph.indices(Graph.dfs(mutable, { start: [0] }))
-      const bfs = Graph.indices(Graph.bfs(mutable, { start: [0] }))
-      const postorder = Graph.indices(Graph.dfsPostOrder(mutable, { start: [0], radius: 2 }))
-      const activeDfs = dfs[Symbol.iterator]()
-      const activeBfs = bfs[Symbol.iterator]()
-      const activePostorder = postorder[Symbol.iterator]()
-
-      Graph.removeNode(mutable, 1)
-
-      assert.deepStrictEqual(Array.from({ [Symbol.iterator]: () => activeDfs }), [0, 1, 2])
-      assert.deepStrictEqual(Array.from({ [Symbol.iterator]: () => activeBfs }), [0, 1, 2])
-      assert.deepStrictEqual(Array.from({ [Symbol.iterator]: () => activePostorder }), [2, 1, 0])
-      assert.deepStrictEqual(Array.from(dfs), [0])
-      assert.deepStrictEqual(Array.from(bfs), [0])
-      assert.deepStrictEqual(Array.from(postorder), [0])
-    })
-
-    it("prioritizes distinct roots in supplied order without duplicate output", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        for (let i = 0; i < 4; i++) {
-          Graph.addNode(mutable, String(i))
-        }
-        Graph.addEdge(mutable, 0, 1, 1)
-        Graph.addEdge(mutable, 2, 3, 2)
-      })
-      const config = { start: [0, 0, 2, 2] }
-
-      assert.deepStrictEqual(Array.from(Graph.indices(Graph.dfs(graph, config))), [0, 1, 2, 3])
-      assert.deepStrictEqual(Array.from(Graph.indices(Graph.dfs(graph, { ...config, radius: 1 }))), [0, 1, 2, 3])
-      assert.deepStrictEqual(Array.from(Graph.indices(Graph.bfs(graph, config))), [0, 2, 1, 3])
-      assert.deepStrictEqual(Array.from(Graph.indices(Graph.dfsPostOrder(graph, config))), [1, 0, 3, 2])
-    })
-
-    it("should provide values() method for DFS iterator", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, b, c, 2)
-      })
-
-      const dfsIterator = Graph.dfs(graph, { start: [0] })
-      const values = Array.from(Graph.values(dfsIterator))
-
-      expect(values).toEqual(["A", "B", "C"])
-    })
-
-    it("should provide entries() method for DFS iterator", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, b, c, 2)
-      })
-
-      const dfsIterator = Graph.dfs(graph, { start: [0] })
-      const entries = Array.from(Graph.entries(dfsIterator))
-
-      expect(entries).toEqual([[0, "A"], [1, "B"], [2, "C"]])
-    })
-
-    it("should provide values() method for BFS iterator", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, a, c, 2)
-      })
-
-      const bfsIterator = Graph.bfs(graph, { start: [0] })
-      const values = Array.from(Graph.values(bfsIterator))
-
-      expect(values).toEqual(["A", "B", "C"])
-    })
-
-    it("should provide entries() method for BFS iterator", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, a, c, 2)
-      })
-
-      const bfsIterator = Graph.bfs(graph, { start: [0] })
-      const entries = Array.from(Graph.entries(bfsIterator))
-
-      expect(entries).toEqual([[0, "A"], [1, "B"], [2, "C"]])
-    })
-
-    it("should snapshot mutable BFS when iteration begins", () => {
-      const mutable = makeMutableTraversalGraph()
-      const traversal = Graph.indices(Graph.bfs(mutable, { start: [0] }))
-      const iterator = traversal[Symbol.iterator]()
-
-      Graph.removeNode(mutable, 1)
-
-      assert.deepStrictEqual([iterator.next().value, iterator.next().value, iterator.next().value], [0, 1, 2])
-      assert.deepStrictEqual(Array.from(traversal), [0])
-    })
-
-    it("should snapshot mutable DFS when iteration begins", () => {
-      const mutable = makeMutableTraversalGraph()
-      const iterator = Graph.indices(Graph.dfs(mutable, { start: [0] }))[Symbol.iterator]()
-
-      Graph.removeNode(mutable, 1)
-
-      assert.deepStrictEqual([iterator.next().value, iterator.next().value, iterator.next().value], [0, 1, 2])
-      assert.deepStrictEqual(Array.from(Graph.indices(Graph.dfs(mutable, { start: [0] }))), [0])
-    })
-
-    it("should traverse sparse snapshot indexes", () => {
-      const graph = Graph.fromSnapshot({
+      const sparse = Graph.fromSnapshot({
         type: "directed",
         nodes: [{ index: 2, data: "A" }, { index: 5, data: "B" }, { index: 1_000_000, data: "C" }],
-        edges: [
-          { index: 3, source: 2, target: 5, data: 1 },
-          { index: 1_000_000, source: 5, target: 1_000_000, data: 2 }
-        ]
+        edges: [{ index: 3, source: 2, target: 5, data: 1 }, {
+          index: 1_000_000,
+          source: 5,
+          target: 1_000_000,
+          data: 2
+        }]
       })
-
-      assert.deepStrictEqual(Array.from(Graph.indices(Graph.bfs(graph, { start: [2] }))), [2, 5, 1_000_000])
-      assert.deepStrictEqual(Array.from(Graph.indices(Graph.dfs(graph, { start: [2] }))), [2, 5, 1_000_000])
-      assert.deepStrictEqual(Array.from(Graph.indices(Graph.dfsPostOrder(graph, { start: [2] }))), [1_000_000, 5, 2])
+      assertIndices(Graph.bfs(sparse, { start: [2] }), [2, 5, 1_000_000])
+      assertIndices(Graph.dfsPostOrder(sparse, { start: [2] }), [1_000_000, 5, 2])
     })
 
-    it("should preserve immutable and mutable depth-first traversal semantics", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        for (let i = 0; i < 5; i++) {
-          Graph.addNode(mutable, String(i))
-        }
-        Graph.addEdge(mutable, 0, 1, 1)
-        Graph.addEdge(mutable, 0, 2, 2)
-        Graph.addEdge(mutable, 1, 3, 3)
-        Graph.addEdge(mutable, 2, 3, 4)
-        Graph.addEdge(mutable, 4, 2, 5)
-      })
-      const mutable = Graph.beginMutation(graph)
-      const configurations: Array<Graph.SearchConfig> = [
-        { start: [0] },
-        { start: [3], direction: "incoming" },
-        { start: [1], direction: "undirected", radius: 2 },
-        { start: [0, 4], radius: 1 }
+    it("revalidates missing starts for fresh DFS, BFS, and postorder iterators", () => {
+      const mutable = Graph.beginMutation(directed([0, 1], [[0, 1, 1]]))
+      const walkers = [
+        Graph.indices(Graph.dfs(mutable, { start: [0] })),
+        Graph.indices(Graph.bfs(mutable, { start: [0] })),
+        Graph.indices(Graph.dfsPostOrder(mutable, { start: [0] }))
       ]
-
-      for (const config of configurations) {
-        assert.deepStrictEqual(
-          Array.from(Graph.indices(Graph.dfs(graph, config))),
-          Array.from(Graph.indices(Graph.dfs(mutable, config)))
-        )
-        assert.deepStrictEqual(
-          Array.from(Graph.indices(Graph.dfsPostOrder(graph, config))),
-          Array.from(Graph.indices(Graph.dfsPostOrder(mutable, config)))
-        )
-      }
-    })
-
-    it("should preserve bounded DFS order for reciprocal neighbors", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        for (let i = 0; i < 5; i++) {
-          Graph.addNode(mutable, String(i))
-        }
-        Graph.addEdge(mutable, 0, 1, 1)
-        Graph.addEdge(mutable, 4, 1, 2)
-        Graph.addEdge(mutable, 1, 4, 3)
-      })
-
-      assert.deepStrictEqual(
-        Array.from(Graph.indices(Graph.dfs(graph, { start: [1], direction: "undirected", radius: 2 }))),
-        [1, 4, 0]
-      )
-    })
-
-    it("should limit DFS traversal by radius", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        const d = Graph.addNode(mutable, "D")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, b, c, 2)
-        Graph.addEdge(mutable, c, d, 3)
-      })
-
-      const dfsIterator = Graph.dfs(graph, { start: [0], radius: 1 })
-
-      assert.deepStrictEqual(Array.from(Graph.indices(dfsIterator)), [0, 1])
-    })
-
-    it("should use the shortest discovered depth when limiting DFS traversal", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        const d = Graph.addNode(mutable, "D")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, b, c, 2)
-        Graph.addEdge(mutable, a, c, 3)
-        Graph.addEdge(mutable, c, d, 4)
-      })
-
-      const dfsIterator = Graph.dfs(graph, { start: [0], radius: 2 })
-
-      assert.deepStrictEqual(Array.from(Graph.indices(dfsIterator)), [0, 1, 2, 3])
-    })
-
-    it("should preserve DFS order when a finite radius includes every reachable node", () => {
-      const graph = Graph.directed<number, void>((mutable) => {
-        for (let i = 0; i < 4; i++) {
-          Graph.addNode(mutable, i)
-        }
-        Graph.addEdge(mutable, 2, 1, undefined)
-        Graph.addEdge(mutable, 2, 3, undefined)
-        Graph.addEdge(mutable, 2, 0, undefined)
-        Graph.addEdge(mutable, 1, 0, undefined)
-      })
-
-      for (const candidate of [graph, Graph.beginMutation(graph)]) {
-        const unbounded = Array.from(Graph.indices(Graph.dfs(candidate, { start: [2] })))
-        const bounded = Array.from(Graph.indices(Graph.dfs(candidate, { start: [2], radius: 4 })))
-        assert.deepStrictEqual(bounded, unbounded)
-      }
-    })
-
-    it("should limit BFS traversal by radius", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        const d = Graph.addNode(mutable, "D")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, a, c, 2)
-        Graph.addEdge(mutable, b, d, 3)
-      })
-
-      const bfsIterator = Graph.bfs(graph, { start: [0], radius: 1 })
-
-      assert.deepStrictEqual(Array.from(Graph.indices(bfsIterator)), [0, 1, 2])
-    })
-
-    it("should traverse incoming and undirected directions", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const source = Graph.addNode(mutable, "source")
-        const first = Graph.addNode(mutable, "first")
-        const second = Graph.addNode(mutable, "second")
-        Graph.addEdge(mutable, source, first, 1)
-        Graph.addEdge(mutable, source, second, 2)
-      })
-
-      assert.deepStrictEqual(
-        Array.from(Graph.indices(Graph.bfs(graph, { start: [1], direction: "incoming" }))),
-        [1, 0]
-      )
-      assert.deepStrictEqual(
-        Array.from(Graph.indices(Graph.bfs(graph, { start: [1], direction: "undirected", radius: 1 }))),
-        [1, 0]
-      )
-      assert.deepStrictEqual(
-        Array.from(Graph.indices(Graph.bfs(graph, { start: [1], direction: "undirected" }))),
-        [1, 0, 2]
-      )
-    })
-
-    it("should only include start nodes when radius is zero", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, 1)
-      })
-
-      assert.deepStrictEqual(Array.from(Graph.indices(Graph.dfs(graph, { start: [0], radius: 0 }))), [0])
-      assert.deepStrictEqual(Array.from(Graph.indices(Graph.bfs(graph, { start: [0], radius: 0 }))), [0])
-    })
-
-    it("should provide values() method for Topo iterator", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, b, c, 2)
-      })
-
-      const topoIterator = Graph.topo(graph)
-
-      const values = Array.from(Graph.values(topoIterator))
-      expect(values).toEqual(["A", "B", "C"])
-    })
-
-    it("should provide entries() method for Topo iterator", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, b, c, 2)
-      })
-
-      const topoIterator = Graph.topo(graph)
-
-      const entries = Array.from(Graph.entries(topoIterator))
-      expect(entries).toEqual([[0, "A"], [1, "B"], [2, "C"]])
-    })
-
-    it("should snapshot mutable topological sort when iteration begins", () => {
-      const mutable = makeMutableTraversalGraph()
-      const iterator = Graph.indices(Graph.topo(mutable))[Symbol.iterator]()
-
-      Graph.removeNode(mutable, 1)
-
-      assert.deepStrictEqual([iterator.next().value, iterator.next().value, iterator.next().value], [0, 1, 2])
-      assert.deepStrictEqual(Array.from(Graph.indices(Graph.topo(mutable))), [0, 2])
-    })
-
-    it("should reject cycles introduced before topological iteration", () => {
-      const mutable = Graph.beginMutation(Graph.directed<string, number>((graph) => {
-        Graph.addNode(graph, "A")
-        Graph.addNode(graph, "B")
-      }))
-      const walker = Graph.topo(mutable)
-
-      Graph.addEdge(mutable, 0, 1, 1)
-      Graph.addEdge(mutable, 1, 0, 2)
-
-      assertGraphError(
-        () => Array.from(Graph.indices(walker)),
-        "Cannot perform topological sort on cyclic graph"
-      )
-    })
-
-    it("should use fresh graph state for each topological iteration", () => {
-      const mutable = Graph.beginMutation(Graph.directed<string, number>((graph) => {
-        Graph.addNode(graph, "A")
-        Graph.addNode(graph, "B")
-      }))
-      const walker = Graph.topo(mutable)
-
-      assert.deepStrictEqual(Array.from(Graph.indices(walker)), [0, 1])
-      Graph.addEdge(mutable, 0, 1, 1)
-      Graph.addEdge(mutable, 1, 0, 2)
-
-      assertGraphError(
-        () => Array.from(Graph.indices(walker)),
-        "Cannot perform topological sort on cyclic graph"
-      )
-    })
-
-    it("should prioritize valid initials and still include all nodes", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        const d = Graph.addNode(mutable, "D")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, c, d, 2)
-      })
-
-      const order = Array.from(Graph.indices(Graph.topo(graph, { initials: [2] })))
-      expect(order).toEqual([2, 0, 3, 1])
-    })
-
-    it("should copy initials when creating a topological walker", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-        Graph.addNode(mutable, "B")
-      })
-      const initials = [0]
-      const walker = Graph.topo(graph, { initials })
-
-      initials[0] = 1
-
-      assert.deepStrictEqual(Array.from(Graph.indices(walker)), [0, 1])
-    })
-
-    it("should revalidate initials when topological iteration begins", () => {
-      const mutable = Graph.beginMutation(Graph.directed<string, number>((graph) => {
-        Graph.addNode(graph, "A")
-        Graph.addNode(graph, "B")
-      }))
-      const walker = Graph.topo(mutable, { initials: [0] })
-
       Graph.removeNode(mutable, 0)
-
-      assertGraphError(() => Array.from(Graph.indices(walker)), "Node 0 does not exist")
+      for (const walker of walkers) assertGraphError(() => walker[Symbol.iterator](), "Node 0 does not exist")
     })
 
-    it("should reject initials with incoming edges", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, 1)
-      })
-
-      expect(() => Array.from(Graph.topo(graph, { initials: [1] })))
-        .toThrow("Initial node 1 has incoming edges")
+    it("isolates active mutable traversal snapshots while fresh iterators see mutations", () => {
+      const mutable = Graph.beginMutation(directed(["A", "B", "C"], [[0, 1, 1], [1, 2, 2]]))
+      const walkers = [
+        Graph.indices(Graph.dfs(mutable, { start: [0] })),
+        Graph.indices(Graph.bfs(mutable, { start: [0] })),
+        Graph.indices(Graph.dfsPostOrder(mutable, { start: [0] }))
+      ]
+      const active = walkers.map((walker) => walker[Symbol.iterator]())
+      Graph.removeNode(mutable, 1)
+      assert.deepStrictEqual(Array.from({ [Symbol.iterator]: () => active[0] }), [0, 1, 2])
+      assert.deepStrictEqual(Array.from({ [Symbol.iterator]: () => active[1] }), [0, 1, 2])
+      assert.deepStrictEqual(Array.from({ [Symbol.iterator]: () => active[2] }), [2, 1, 0])
+      for (const walker of walkers) assert.deepStrictEqual(Array.from(walker), [0])
     })
 
-    it("should throw for cyclic graphs", () => {
-      const cyclicGraph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, b, a, 2) // Creates cycle
-      })
+    it("topologically sorts with prioritized initials and validates fresh mutable state", () => {
+      const graph = directed(["A", "B", "C", "D"], [[0, 1, 1], [2, 3, 1]])
+      assertIndices(Graph.topo(graph, { initials: [2] }), [2, 0, 3, 1])
 
-      expect(() => Graph.topo(cyclicGraph)).toThrow("Cannot perform topological sort on cyclic graph")
+      const mutable = Graph.beginMutation(directed<string, number>(["A", "B"], []))
+      const walker = Graph.topo(mutable)
+      assertIndices(walker, [0, 1])
+      Graph.addEdge(mutable, 0, 1, 1)
+      Graph.addEdge(mutable, 1, 0, 2)
+      assertGraphError(() => Array.from(Graph.indices(walker)), "Cannot perform topological sort on cyclic graph")
     })
 
-    it("should throw for undirected graphs", () => {
-      const graph = makeReversedUndirectedPath()
-
-      expect(() => Graph.topo(graph as any)).toThrow("Cannot perform topological sort on undirected graph")
-    })
-
-    it("should handle corrupted graph state during topological sort", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, 1)
-      })
-
-      // Test edge case by corrupting graph internals during iteration
-      const mutableGraph = graph as any
-      const originalGetNode = mutableGraph.nodes.get
-
-      let callCount = 0
-      // Mock getNode to return undefined for certain calls to trigger the recursive edge case
-      mutableGraph.nodes.get = function(key: any) {
-        callCount++
-        // On specific call, return undefined to trigger the Option.isNone path
-        if (callCount === 2) {
-          return undefined
-        }
-        return originalGetNode.call(this, key)
-      }
-
-      const iterator = Graph.topo(graph)
-      const results = Array.from(iterator)
-
-      // Restore original method
-      mutableGraph.nodes.get = originalGetNode
-
-      // Should complete without crashing
-      expect(results.length).toBeGreaterThanOrEqual(0)
-    })
-
-    it("should provide values() method for DfsPostOrder iterator", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, b, c, 2)
-      })
-
-      const dfsPostIterator = Graph.dfsPostOrder(graph, { start: [0] })
-      const values = Array.from(Graph.values(dfsPostIterator))
-
-      expect(values).toEqual(["C", "B", "A"]) // Postorder: children before parents
-    })
-
-    it("should provide entries() method for DfsPostOrder iterator", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, b, c, 2)
-      })
-
-      const dfsPostIterator = Graph.dfsPostOrder(graph, { start: [0] })
-      const entries = Array.from(Graph.entries(dfsPostIterator))
-
-      expect(entries).toEqual([[2, "C"], [1, "B"], [0, "A"]]) // Postorder: children before parents
-    })
-
-    it("should snapshot mutable DFS postorder when iteration begins", () => {
-      const mutable = makeMutableTraversalGraph()
-      const iterator = Graph.indices(Graph.dfsPostOrder(mutable, { start: [0] }))[Symbol.iterator]()
-
+    it("isolates active mutable topological snapshots while fresh iterators see mutations", () => {
+      const mutable = Graph.beginMutation(directed([0, 1, 2], [[0, 1, 1], [1, 2, 1]]))
+      const walker = Graph.indices(Graph.topo(mutable))
+      const active = walker[Symbol.iterator]()
       Graph.removeNode(mutable, 1)
 
-      assert.deepStrictEqual([iterator.next().value, iterator.next().value, iterator.next().value], [2, 1, 0])
-      assert.deepStrictEqual(Array.from(Graph.indices(Graph.dfsPostOrder(mutable, { start: [0] }))), [0])
+      assert.deepStrictEqual(Array.from({ [Symbol.iterator]: () => active }), [0, 1, 2])
+      assert.deepStrictEqual(Array.from(walker), [0, 2])
     })
 
-    it("should traverse undirected edges in reverse storage direction", () => {
-      const graph = makeReversedUndirectedPath()
-
-      expect(Array.from(Graph.indices(Graph.dfs(graph, { start: [0] })))).toEqual([0, 1, 2])
-      expect(Array.from(Graph.indices(Graph.dfs(graph, { start: [0], direction: "incoming" })))).toEqual([0, 1, 2])
-      expect(Array.from(Graph.indices(Graph.bfs(graph, { start: [0] })))).toEqual([0, 1, 2])
-      expect(Array.from(Graph.indices(Graph.dfsPostOrder(graph, { start: [0] })))).toEqual([2, 1, 0])
+    it("rejects invalid topological graphs and initials", () => {
+      assertGraphError(
+        () => Graph.topo(Graph.undirected() as unknown as Graph.DirectedGraph<never, never>),
+        "Cannot perform topological sort on undirected graph"
+      )
+      assertGraphError(
+        () => Graph.topo(directed([0, 1], [[0, 1, 1], [1, 0, 1]])),
+        "Cannot perform topological sort on cyclic graph"
+      )
+      const graph = directed([0, 1], [[0, 1, 1]])
+      assertGraphError(() => Array.from(Graph.topo(graph, { initials: [1] })), "Initial node 1 has incoming edges")
+      assertGraphError(() => Graph.topo(graph, { initials: [2] }), "Node 2 does not exist")
     })
 
-    it("should ignore edge direction during traversal", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, a, c, 2)
-      })
+    it("keeps nodes, edges, and externals live on mutable graphs", () => {
+      const mutable = Graph.beginMutation(directed(["A", "B"], [[0, 1, 1]]))
+      const nodes = Graph.indices(Graph.nodes(mutable))[Symbol.iterator]()
+      const edges = Graph.indices(Graph.edges(mutable))[Symbol.iterator]()
+      const externals = Graph.indices(Graph.externals(mutable))[Symbol.iterator]()
+      assert.strictEqual(nodes.next().value, 0)
+      assert.strictEqual(edges.next().value, 0)
+      assert.strictEqual(externals.next().value, 1)
 
-      assert.deepStrictEqual(
-        Array.from(Graph.indices(Graph.dfs(graph, { start: [1], direction: "undirected" }))),
-        [1, 0, 2]
-      )
-      assert.deepStrictEqual(
-        Array.from(Graph.indices(Graph.bfs(graph, { start: [1], direction: "undirected" }))),
-        [1, 0, 2]
-      )
+      Graph.addNode(mutable, "C")
+      Graph.addEdge(mutable, 1, 2, 2)
+      assert.deepStrictEqual(Array.from({ [Symbol.iterator]: () => nodes }), [1, 2])
+      assert.deepStrictEqual(Array.from({ [Symbol.iterator]: () => edges }), [1])
+      assert.deepStrictEqual(Array.from({ [Symbol.iterator]: () => externals }), [2])
+    })
+
+    it("selects outgoing sinks and incoming sources", () => {
+      const graph = directed(["source", "middle", "sink", "isolated"], [[0, 1, 1], [1, 2, 2]])
+      assertIndices(Graph.externals(graph), [2, 3])
+      assertIndices(Graph.externals(graph, { direction: "outgoing" }), [2, 3])
+      assertIndices(Graph.externals(graph, { direction: "incoming" }), [0, 3])
     })
   })
 
-  describe("DfsPostOrder Iterator", () => {
-    it("should limit traversal by radius", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, b, c, 2)
+  describe("Walker", () => {
+    it("projects representative walkers through indices, values, entries, and visit", () => {
+      const walker = new Graph.Walker<number, string>(function*(visit) {
+        yield visit(2, "A")
+        yield visit(5, "B")
       })
 
-      assert.deepStrictEqual(
-        Array.from(Graph.indices(Graph.dfsPostOrder(graph, { start: [0], radius: 1 }))),
-        [1, 0]
-      )
+      assert.deepStrictEqual(Array.from(Graph.indices(walker)), [2, 5])
+      assert.deepStrictEqual(Array.from(Graph.values(walker)), ["A", "B"])
+      assert.deepStrictEqual(Array.from(Graph.entries(walker)), [[2, "A"], [5, "B"]])
+      assert.deepStrictEqual(Array.from(walker.visit((index, value) => `${index}:${value}`)), ["2:A", "5:B"])
     })
 
-    it("should traverse in postorder for simple chain", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, b, c, 2)
+    it("is repeatable and gives independent iterators fresh state", () => {
+      const walker = new Graph.Walker<number, string>(function*(visit) {
+        yield visit(0, "A")
+        yield visit(1, "B")
       })
-
-      const postOrder = Array.from(Graph.indices(Graph.dfsPostOrder(graph, { start: [0] })))
-      expect(postOrder).toEqual([2, 1, 0]) // Children before parents
-    })
-
-    it("should traverse in postorder for branching tree", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const root = Graph.addNode(mutable, "root") // 0
-        const left = Graph.addNode(mutable, "left") // 1
-        const right = Graph.addNode(mutable, "right") // 2
-        const leaf1 = Graph.addNode(mutable, "leaf1") // 3
-        const leaf2 = Graph.addNode(mutable, "leaf2") // 4
-
-        Graph.addEdge(mutable, root, left, 1)
-        Graph.addEdge(mutable, root, right, 2)
-        Graph.addEdge(mutable, left, leaf1, 3)
-        Graph.addEdge(mutable, right, leaf2, 4)
-      })
-
-      const postOrder = Array.from(Graph.indices(Graph.dfsPostOrder(graph, { start: [0] })))
-      // Should visit leaves first, then parents
-      expect(postOrder).toEqual([3, 1, 4, 2, 0])
-    })
-
-    it("should handle empty start nodes", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-      })
-
-      const postOrder = Array.from(Graph.dfsPostOrder(graph, { start: [] }))
-      expect(postOrder).toEqual([])
-    })
-
-    it("should handle disconnected components with multiple start nodes", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        const d = Graph.addNode(mutable, "D")
-
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, c, d, 2)
-        // No connection between (A,B) and (C,D)
-      })
-
-      const postOrder = Array.from(Graph.indices(Graph.dfsPostOrder(graph, { start: [0, 2] })))
-      expect(postOrder).toEqual([1, 0, 3, 2]) // Each component in postorder
-    })
-
-    it("should support incoming direction", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, b, c, 2)
-      })
-
-      // Starting from C, going backwards
-      const postOrder = Array.from(
-        Graph.indices(Graph.dfsPostOrder(graph, {
-          start: [2],
-          direction: "incoming"
-        }))
-      )
-      expect(postOrder).toEqual([0, 1, 2]) // A, B, C in reverse postorder
-    })
-
-    it("should handle cycles correctly", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, b, c, 2)
-        Graph.addEdge(mutable, c, a, 3) // Creates cycle
-      })
-
-      const postOrder = Array.from(Graph.indices(Graph.dfsPostOrder(graph, { start: [0] })))
-      // Should handle cycle without infinite loop, visiting each node once
-      expect(postOrder.length).toBe(3)
-      expect(new Set(postOrder)).toEqual(new Set([0, 1, 2]))
-    })
-
-    it("should throw error for non-existent start node", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        Graph.addNode(mutable, "A")
-      })
-
-      expect(() => Graph.dfsPostOrder(graph, { start: [99] }))
-        .toThrow("Node 99 does not exist")
-    })
-
-    it("should be iterable multiple times with fresh state", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, 1)
-      })
-
-      const iterator = Graph.dfsPostOrder(graph, { start: [0] })
-
-      const firstRun = Array.from(Graph.indices(iterator))
-      const secondRun = Array.from(Graph.indices(iterator))
-
-      expect(firstRun).toEqual([1, 0])
-      expect(secondRun).toEqual([1, 0])
-      expect(firstRun).toEqual(secondRun)
-    })
-
-    it("should handle corrupted graph state during iteration", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, 1)
-      })
-
-      // Test edge case by corrupting graph internals during iteration
-      const mutableGraph = graph as any
-      const originalGetNode = mutableGraph.nodes.get
-
-      let callCount = 0
-      // Mock getNode to return undefined for certain calls to trigger the recursive edge case
-      mutableGraph.nodes.get = function(key: any) {
-        callCount++
-        // On specific call, return undefined to trigger the Option.isNone path
-        if (callCount === 3) {
-          return undefined
-        }
-        return originalGetNode.call(this, key)
-      }
-
-      const iterator = Graph.dfsPostOrder(graph, { start: [0] })
-      const results = Array.from(iterator)
-
-      // Restore original method
-      mutableGraph.nodes.get = originalGetNode
-
-      // Should complete without crashing
-      expect(results.length).toBeGreaterThanOrEqual(0)
-    })
-  })
-
-  describe("Graph Element Iterators", () => {
-    describe("nodes", () => {
-      it("should iterate over all node indices", () => {
-        const graph = Graph.directed<string, number>((mutable) => {
-          Graph.addNode(mutable, "A")
-          Graph.addNode(mutable, "B")
-          Graph.addNode(mutable, "C")
-        })
-
-        const indices = Array.from(Graph.indices(Graph.nodes(graph)))
-        expect(indices).toEqual([0, 1, 2])
-      })
-
-      it("should work with manual iterator control", () => {
-        const graph = Graph.directed<string, number>((mutable) => {
-          Graph.addNode(mutable, "A")
-          Graph.addNode(mutable, "B")
-        })
-
-        const iterator = Graph.indices(Graph.nodes(graph))[Symbol.iterator]()
-        expect(iterator.next().value).toBe(0)
-        expect(iterator.next().value).toBe(1)
-        expect(iterator.next().done).toBe(true)
-      })
-    })
-
-    describe("edges", () => {
-      it("should iterate over all edge indices", () => {
-        const graph = Graph.directed<string, number>((mutable) => {
-          const a = Graph.addNode(mutable, "A")
-          const b = Graph.addNode(mutable, "B")
-          const c = Graph.addNode(mutable, "C")
-          Graph.addEdge(mutable, a, b, 1)
-          Graph.addEdge(mutable, b, c, 2)
-          Graph.addEdge(mutable, c, a, 3)
-        })
-
-        const indices = Array.from(Graph.indices(Graph.edges(graph)))
-        expect(indices).toEqual([0, 1, 2])
-      })
-
-      it("should handle graph with no edges", () => {
-        const graph = Graph.directed<string, number>((mutable) => {
-          Graph.addNode(mutable, "A")
-          Graph.addNode(mutable, "B")
-        })
-
-        const indices = Array.from(Graph.indices(Graph.edges(graph)))
-        expect(indices).toEqual([])
-      })
-    })
-
-    describe("externals", () => {
-      it("should find nodes with no outgoing edges (sinks)", () => {
-        const graph = Graph.directed<string, number>((mutable) => {
-          const source = Graph.addNode(mutable, "source") // 0
-          const middle = Graph.addNode(mutable, "middle") // 1
-          const sink = Graph.addNode(mutable, "sink") // 2
-          Graph.addNode(mutable, "isolated") // 3
-
-          Graph.addEdge(mutable, source, middle, 1)
-          Graph.addEdge(mutable, middle, sink, 2)
-          // No outgoing edges from sink (2) or isolated (3)
-        })
-
-        const sinks = Array.from(Graph.indices(Graph.externals(graph, { direction: "outgoing" })))
-        expect(sinks.sort()).toEqual([2, 3])
-      })
-
-      it("should find nodes with no incoming edges (sources)", () => {
-        const graph = Graph.directed<string, number>((mutable) => {
-          const source = Graph.addNode(mutable, "source") // 0
-          const middle = Graph.addNode(mutable, "middle") // 1
-          const sink = Graph.addNode(mutable, "sink") // 2
-          Graph.addNode(mutable, "isolated") // 3
-
-          Graph.addEdge(mutable, source, middle, 1)
-          Graph.addEdge(mutable, middle, sink, 2)
-          // No incoming edges to source (0) or isolated (3)
-        })
-
-        const sources = Array.from(Graph.indices(Graph.externals(graph, { direction: "incoming" })))
-        expect(sources.sort()).toEqual([0, 3])
-      })
-
-      it("should default to outgoing direction", () => {
-        const graph = Graph.directed<string, number>((mutable) => {
-          const a = Graph.addNode(mutable, "A")
-          const b = Graph.addNode(mutable, "B")
-          Graph.addEdge(mutable, a, b, 1)
-          // b has no outgoing edges
-        })
-
-        const externalsDefault = Array.from(Graph.indices(Graph.externals(graph)))
-        const externalsExplicit = Array.from(Graph.indices(Graph.externals(graph, { direction: "outgoing" })))
-
-        expect(externalsDefault).toEqual(externalsExplicit)
-        expect(externalsDefault).toEqual([1])
-      })
-
-      it("should handle fully connected components", () => {
-        const graph = Graph.directed<string, number>((mutable) => {
-          const a = Graph.addNode(mutable, "A")
-          const b = Graph.addNode(mutable, "B")
-          const c = Graph.addNode(mutable, "C")
-          Graph.addEdge(mutable, a, b, 1)
-          Graph.addEdge(mutable, b, c, 2)
-          Graph.addEdge(mutable, c, a, 3) // Creates cycle
-        })
-
-        const outgoingExternals = Array.from(Graph.indices(Graph.externals(graph, { direction: "outgoing" })))
-        const incomingExternals = Array.from(Graph.indices(Graph.externals(graph, { direction: "incoming" })))
-
-        expect(outgoingExternals).toEqual([]) // All nodes have outgoing edges
-        expect(incomingExternals).toEqual([]) // All nodes have incoming edges
-      })
-
-      it("should work with manual iterator control", () => {
-        const graph = Graph.directed<string, number>((mutable) => {
-          const a = Graph.addNode(mutable, "A")
-          const b = Graph.addNode(mutable, "B")
-          Graph.addNode(mutable, "C")
-          Graph.addEdge(mutable, a, b, 1)
-          // b and c have no outgoing edges
-        })
-
-        const iterator = Graph.indices(Graph.externals(graph, { direction: "outgoing" }))[Symbol.iterator]()
-
-        const first = iterator.next().value
-        const second = iterator.next().value
-        const third = iterator.next()
-
-        expect([first, second].sort()).toEqual([1, 2])
-        expect(third.done).toBe(true)
-      })
-    })
-
-    it("should allow combining different element iterators", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, 100)
-      })
-
-      // Combine different iterators
-      const nodeCount = Array.from(Graph.indices(Graph.nodes(graph))).length
-      const edgeCount = Array.from(Graph.indices(Graph.edges(graph))).length
-      const nodeData = Array.from(Graph.values(Graph.nodes(graph)))
-      const edge = Array.from(Graph.values(Graph.edges(graph)))
-
-      expect(nodeCount).toBe(2)
-      expect(edgeCount).toBe(1)
-      expect(nodeData).toEqual(["A", "B"])
-      expect(edge).toEqual([{ source: 0, target: 1, data: 100 }])
-    })
-  })
-
-  describe("GraphIterable abstraction", () => {
-    it("should enable iteration over different types", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, b, c, 2)
-      })
-
-      // Should work with different iterator types
-      const dfsIterable = Graph.dfs(graph, { start: [0] })
-      const nodesIterable = Graph.nodes(graph)
-      const externalsIterable = Graph.externals(graph)
-
-      // All should be iterable and have expected structure
-      expect(Array.from(dfsIterable)).toHaveLength(3)
-      expect(Array.from(nodesIterable)).toHaveLength(3)
-      expect(Array.from(externalsIterable)).toHaveLength(1) // Only one node with no outgoing edges
-    })
-
-    it("should preserve the receiver for iterable iterator methods", () => {
-      const walker = new Graph.Walker<number, string>((f) => new Set([f(0, "A"), f(1, "B")]))
-
       assert.deepStrictEqual(Array.from(walker), [[0, "A"], [1, "B"]])
-    })
-
-    it("should create fresh iterators for generator-backed walkers", () => {
-      const walker = new Graph.Walker<number, string>(function*(f) {
-        yield f(0, "A")
-        yield f(1, "B")
-      })
-
-      const assertRepeated = <A>(iterable: Iterable<A>, expected: Array<A>) => {
-        assert.deepStrictEqual(Array.from(iterable), expected)
-        assert.deepStrictEqual(Array.from(iterable), expected)
-      }
-
-      assertRepeated(walker, [[0, "A"], [1, "B"]])
-      assert.deepStrictEqual(Array.from(walker.visit((index, data) => `${index}:${data}`)), ["0:A", "1:B"])
-      assert.deepStrictEqual(Array.from(walker.visit((index, data) => `${index}:${data}`)), ["0:A", "1:B"])
-      assert.deepStrictEqual(Array.from(Graph.indices(walker)), [0, 1])
-      assert.deepStrictEqual(Array.from(Graph.indices(walker)), [0, 1])
-      assert.deepStrictEqual(Array.from(Graph.values(walker)), ["A", "B"])
-      assert.deepStrictEqual(Array.from(Graph.values(walker)), ["A", "B"])
-      assert.deepStrictEqual(Array.from(Graph.entries(walker)), [[0, "A"], [1, "B"]])
-      assert.deepStrictEqual(Array.from(Graph.entries(walker)), [[0, "A"], [1, "B"]])
+      assert.deepStrictEqual(Array.from(walker), [[0, "A"], [1, "B"]])
 
       const left = walker[Symbol.iterator]()
       const right = walker[Symbol.iterator]()
@@ -6806,169 +2351,11 @@ describe("Graph", () => {
       assert.deepStrictEqual(right.next(), { done: false, value: [0, "A"] })
       assert.deepStrictEqual(left.next(), { done: false, value: [1, "B"] })
       assert.deepStrictEqual(right.next(), { done: false, value: [1, "B"] })
-      assert.deepStrictEqual(left.next(), { done: true, value: undefined })
-      assert.deepStrictEqual(right.next(), { done: true, value: undefined })
-    })
-  })
-
-  describe("NodeIterable abstraction", () => {
-    it("should provide common interface for node index iterables", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, b, c, 2)
-      })
-
-      // Utility function that works with any NodeWalker
-      function collectNodes<N>(
-        nodeIterable: Graph.NodeWalker<N>
-      ): Array<number> {
-        return Array.from(Graph.indices(nodeIterable)).sort()
-      }
-
-      // Both traversal and element iterators implement NodeWalker
-      const dfsNodes = Graph.dfs(graph, { start: [0] })
-      const allNodes = Graph.nodes(graph)
-      const externalNodes = Graph.externals(graph, { direction: "outgoing" })
-
-      // All should work with the same utility function
-      expect(collectNodes(dfsNodes)).toEqual([0, 1, 2])
-      expect(collectNodes(allNodes)).toEqual([0, 1, 2])
-      expect(collectNodes(externalNodes)).toEqual([2]) // Only node 2 has no outgoing edges
     })
 
-    it("should allow type-safe node iterable operations", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, 1)
-      })
-
-      const nodeIterable: Graph.NodeWalker<string> = Graph.nodes(graph)
-      const traversalIterable: Graph.NodeWalker<string> = Graph.dfs(graph, {
-        start: [0]
-      })
-
-      expect(Array.from(Graph.indices(nodeIterable))).toEqual([0, 1])
-      expect(Array.from(Graph.indices(traversalIterable))).toEqual([0, 1])
-    })
-  })
-
-  describe("Standalone utility functions", () => {
-    it("should work with values() function on any NodeIterable", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        const c = Graph.addNode(mutable, "C")
-        Graph.addEdge(mutable, a, b, 1)
-        Graph.addEdge(mutable, b, c, 2)
-      })
-
-      // Test with traversal iterators
-      const dfsIterable = Graph.dfs(graph, { start: [0] })
-      const dfsValues = Array.from(Graph.values(dfsIterable))
-      expect(dfsValues).toEqual(["A", "B", "C"])
-
-      // Test with element iterators
-      const nodesIterable = Graph.nodes(graph)
-      const nodeValues = Array.from(Graph.values(nodesIterable))
-      expect(nodeValues.sort()).toEqual(["A", "B", "C"])
-
-      // Test with externals iterator
-      const externalsIterable = Graph.externals(graph, { direction: "outgoing" })
-      const externalValues = Array.from(Graph.values(externalsIterable))
-      expect(externalValues).toEqual(["C"]) // Only C has no outgoing edges
-    })
-
-    it("should work with entries() function on any NodeIterable", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, 1)
-      })
-
-      // Test with traversal iterator
-      const dfsIterable = Graph.dfs(graph, { start: [0] })
-      const dfsEntries = Array.from(Graph.entries(dfsIterable))
-      expect(dfsEntries).toEqual([[0, "A"], [1, "B"]])
-
-      // Test with element iterator
-      const nodesIterable = Graph.nodes(graph)
-      const nodeEntries = Array.from(Graph.entries(nodesIterable))
-      expect(nodeEntries.sort()).toEqual([[0, "A"], [1, "B"]])
-
-      // Test with externals iterator
-      const externalsIterable = Graph.externals(graph, { direction: "outgoing" })
-      const externalEntries = Array.from(Graph.entries(externalsIterable))
-      expect(externalEntries).toEqual([[1, "B"]]) // Only B has no outgoing edges
-    })
-
-    it("should work with instance methods", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, 1)
-      })
-
-      const dfs = Graph.dfs(graph, { start: [0] })
-
-      // Instance methods should work
-      const instanceValues = Array.from(Graph.values(dfs))
-      const instanceEntries = Array.from(Graph.entries(dfs))
-
-      expect(instanceValues).toEqual(["A", "B"])
-      expect(instanceEntries).toEqual([[0, "A"], [1, "B"]])
-    })
-
-    it("should work with mapEntry for NodeIterable", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, 1)
-      })
-
-      const dfs = Graph.dfs(graph, { start: [0] })
-
-      // Test mapEntry with custom mapping
-      const custom = Array.from(dfs.visit((index, data) => ({ id: index, name: data })))
-      expect(custom).toEqual([{ id: 0, name: "A" }, { id: 1, name: "B" }])
-
-      // Test that values() is implemented using mapEntry
-      const values = Array.from(Graph.values(dfs))
-      expect(values).toEqual(["A", "B"])
-
-      // Test that entries() is implemented using mapEntry
-      const entries = Array.from(Graph.entries(dfs))
-      expect(entries).toEqual([[0, "A"], [1, "B"]])
-    })
-
-    it("should work with mapEntry for EdgeIterable", () => {
-      const graph = Graph.directed<string, number>((mutable) => {
-        const a = Graph.addNode(mutable, "A")
-        const b = Graph.addNode(mutable, "B")
-        Graph.addEdge(mutable, a, b, 42)
-      })
-
-      const edgesIterable = Graph.edges(graph)
-
-      // Test mapEntry with custom mapping
-      const connections = Array.from(edgesIterable.visit((index, edge) => ({
-        id: index,
-        from: edge.source,
-        to: edge.target,
-        weight: edge.data
-      })))
-      expect(connections).toEqual([{ id: 0, from: 0, to: 1, weight: 42 }])
-
-      // Test that values() is implemented using mapEntry
-      const weights = Array.from(edgesIterable.visit((_, edge) => edge.data))
-      expect(weights).toEqual([42])
-
-      // Test that entries() is implemented using mapEntry
-      const entries = Array.from(Graph.entries(edgesIterable))
-      expect(entries).toEqual([[0, { source: 0, target: 1, data: 42 }]])
+    it("preserves receivers supplied by iterable iterator methods", () => {
+      const walker = new Graph.Walker<number, string>((visit) => new Set([visit(0, "A"), visit(1, "B")]))
+      assert.deepStrictEqual(Array.from(walker), [[0, "A"], [1, "B"]])
     })
   })
 })


### PR DESCRIPTION
## Summary

- consolidate the Graph test suite around observable behavior and shared helpers
- remove broad parity matrices, duplicate invocation checks, and implementation-coupled cases
- retain focused regressions for edge-copy isolation, parallel edges and capacities, finite arithmetic, path boundaries, traversal radius, undirected reachability, and Mermaid escaping

## Validation

- `pnpm lint-fix`
- `pnpm --filter effect test --run test/Graph.test.ts`
- `pnpm check` (passes with existing duplicate-package warnings from `tmp/bundle-base`)
- `git diff --check -- packages/effect/test/Graph.test.ts`