### PR TITLE
Guard graph traversal callbacks from mutation

### DIFF
--- a/.changeset/bright-graphs-calculate.md
+++ b/.changeset/bright-graphs-calculate.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Reject graph shortest-path calculations that overflow or underflow the finite number range.

--- a/.changeset/fuzzy-graphs-transform.md
+++ b/.changeset/fuzzy-graphs-transform.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Add bulk node and edge removal operations, and disallow graph mutations from transformation callbacks to preserve graph invariants.
+Add bulk node and edge removal operations, and disallow graph mutations from callbacks that traverse or transform the same graph.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -6456,7 +6456,7 @@ export interface DijkstraConfig<E> {
  * **Gotchas**
  *
  * Throws a `GraphError` when either endpoint is missing or an edge cost is
- * negative or `NaN`.
+ * negative or `NaN`, or when a path distance exceeds the finite number range.
  *
  * **Example** (Finding shortest paths with Dijkstra)
  *
@@ -6564,6 +6564,9 @@ export const dijkstra: {
       const neighbor = outgoing.columnIndices[i]
       const edge = outgoing.edgeIndices[i]
       const nextDistance = currentDistance + edgeWeights[edge]
+      if (edgeWeights[edge] !== Infinity && !Number.isFinite(nextDistance)) {
+        throw new GraphError({ message: "Dijkstra distance calculation exceeded the finite number range" })
+      }
       if (nextDistance < distances[neighbor]) {
         distances[neighbor] = nextDistance
         previousNode[neighbor] = currentNode
@@ -6642,7 +6645,8 @@ export interface AllPairsResult<E> {
  * **Gotchas**
  *
  * A `GraphError` is thrown if any edge weight is `NaN` or `-Infinity`, or if
- * any negative cycle is detected.
+ * finite arithmetic overflows or underflows, or if any negative cycle is
+ * detected.
  *
  * **Example** (Finding all-pairs shortest paths)
  *
@@ -6732,8 +6736,14 @@ export const floydWarshall: {
       const nextIK = nextMatrix[iRow + k]
       for (let j = 0; j < size; j++) {
         const distanceKJ = distancesMatrix[kRow + j]
+        if (distanceKJ === Infinity) {
+          continue
+        }
         const candidate = distanceIK + distanceKJ
-        if (distanceKJ !== Infinity && candidate < distancesMatrix[iRow + j] && nextIK !== -1) {
+        if (!Number.isFinite(candidate)) {
+          throw new GraphError({ message: "Floyd-Warshall distance calculation exceeded the finite number range" })
+        }
+        if (candidate < distancesMatrix[iRow + j] && nextIK !== -1) {
           distancesMatrix[iRow + j] = candidate
           nextMatrix[iRow + j] = nextIK
         }
@@ -6850,7 +6860,7 @@ export interface AstarConfig<E, N> {
  *
  * The heuristic must be consistent for the shortest-path guarantee and must
  * return finite values. Missing endpoints, invalid edge costs, or non-finite
- * heuristic values throw a `GraphError`.
+ * heuristic values or arithmetic results throw a `GraphError`.
  *
  * **Example** (Finding shortest paths with A*)
  *
@@ -6979,11 +6989,17 @@ export const astar: {
       }
       const edge = outgoing.edgeIndices[i]
       const tentativeScore = currentScore + edgeWeights[edge]
+      if (edgeWeights[edge] !== Infinity && !Number.isFinite(tentativeScore)) {
+        throw new GraphError({ message: "A* distance calculation exceeded the finite number range" })
+      }
       if (tentativeScore < scores[neighbor]) {
         scores[neighbor] = tentativeScore
         previousNode[neighbor] = current
         previousEdge[neighbor] = edge
         const priority = tentativeScore + getHeuristic(cache.nodeData[neighbor] as N)
+        if (!Number.isFinite(priority)) {
+          throw new GraphError({ message: "A* priority calculation exceeded the finite number range" })
+        }
         denseMinHeapPush(openSet, neighbor, priority, sequence++)
       }
     }
@@ -7438,8 +7454,8 @@ export const simplePaths: {
  * **Gotchas**
  *
  * The number of tied paths can still be large. Missing endpoints, invalid
- * costs, or an invalid `limit` throw a `GraphError`. Mutable graphs are
- * snapshotted when iteration begins.
+ * costs, arithmetic overflow, or an invalid `limit` throw a `GraphError`.
+ * Mutable graphs are snapshotted when iteration begins.
  *
  * @see {@link dijkstra} when one shortest path is sufficient
  * @see {@link simplePaths} for routes regardless of cost
@@ -7513,6 +7529,9 @@ export const allShortestPaths: {
         const edge = outgoing.edgeIndices[i]
         const neighbor = outgoing.columnIndices[i]
         const nextDistance = current.priority + weights[edge]
+        if (weights[edge] !== Infinity && !Number.isFinite(nextDistance)) {
+          throw new GraphError({ message: "All shortest paths distance calculation exceeded the finite number range" })
+        }
         const known = distances[neighbor]
         const predecessor = { node: current.node, edge }
         if (nextDistance < known) {

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -213,6 +213,12 @@ export declare namespace Graph {
  * Use when adding, removing, or updating nodes and edges inside a graph
  * mutation scope.
  *
+ * **Gotchas**
+ *
+ * A callback invoked by another graph operation may query the same mutable
+ * graph, but cannot mutate or finalize it. Mutation is allowed in callbacks
+ * passed to graph constructors and `mutate`, where mutation is the purpose.
+ *
  * @see {@link Graph} for the immutable graph interface
  * @see {@link mutate} for scoped mutation of an immutable graph
  *
@@ -381,6 +387,12 @@ const getMutableImplForMutation = <N, E, T extends Kind>(
   csr.invalidate(graph)
   return internal.toImpl(graph)
 }
+
+/** @internal */
+const withMutationGuard = <N, E, T extends Kind, A>(
+  graph: Graph<N, E, T> | MutableGraph<N, E, T>,
+  evaluate: () => A
+): A => graph.mutable ? internal.withTransformation(graph, evaluate) : evaluate()
 
 // =============================================================================
 // Constructors
@@ -1846,12 +1858,14 @@ export const findNode: {
   predicate: (data: N) => boolean
 ): Option.Option<NodeIndex> => {
   const impl = internal.toImpl(graph)
-  for (const [index, data] of impl.nodes) {
-    if (predicate(data)) {
-      return Option.some(index)
+  return withMutationGuard(graph, () => {
+    for (const [index, data] of impl.nodes) {
+      if (predicate(data)) {
+        return Option.some(index)
+      }
     }
-  }
-  return Option.none()
+    return Option.none()
+  })
 })
 
 /**
@@ -1888,13 +1902,15 @@ export const findNodes: {
   predicate: (data: N) => boolean
 ): Array<NodeIndex> => {
   const impl = internal.toImpl(graph)
-  const results: Array<NodeIndex> = []
-  for (const [index, data] of impl.nodes) {
-    if (predicate(data)) {
-      results.push(index)
+  return withMutationGuard(graph, () => {
+    const results: Array<NodeIndex> = []
+    for (const [index, data] of impl.nodes) {
+      if (predicate(data)) {
+        results.push(index)
+      }
     }
-  }
-  return results
+    return results
+  })
 })
 
 /**
@@ -1933,12 +1949,14 @@ export const findEdge: {
   predicate: (data: E, source: NodeIndex, target: NodeIndex) => boolean
 ): Option.Option<EdgeIndex> => {
   const impl = internal.toImpl(graph)
-  for (const [edgeIndex, edgeData] of impl.edges) {
-    if (predicate(edgeData.data, edgeData.source, edgeData.target)) {
-      return Option.some(edgeIndex)
+  return withMutationGuard(graph, () => {
+    for (const [edgeIndex, edgeData] of impl.edges) {
+      if (predicate(edgeData.data, edgeData.source, edgeData.target)) {
+        return Option.some(edgeIndex)
+      }
     }
-  }
-  return Option.none()
+    return Option.none()
+  })
 })
 
 /**
@@ -1978,13 +1996,15 @@ export const findEdges: {
   predicate: (data: E, source: NodeIndex, target: NodeIndex) => boolean
 ): Array<EdgeIndex> => {
   const impl = internal.toImpl(graph)
-  const results: Array<EdgeIndex> = []
-  for (const [edgeIndex, edgeData] of impl.edges) {
-    if (predicate(edgeData.data, edgeData.source, edgeData.target)) {
-      results.push(edgeIndex)
+  return withMutationGuard(graph, () => {
+    const results: Array<EdgeIndex> = []
+    for (const [edgeIndex, edgeData] of impl.edges) {
+      if (predicate(edgeData.data, edgeData.source, edgeData.target)) {
+        results.push(edgeIndex)
+      }
     }
-  }
-  return results
+    return results
+  })
 })
 
 /**
@@ -3623,23 +3643,25 @@ export const toGraphViz: {
   const edgeOperator = isDirected ? "->" : "--"
   const graphId = `"${escapeGraphVizString(graphName)}"`
 
-  const lines: Array<string> = []
-  lines.push(`${graphType} ${graphId} {`)
+  return withMutationGuard(graph, () => {
+    const lines: Array<string> = []
+    lines.push(`${graphType} ${graphId} {`)
 
-  // Add nodes
-  for (const [nodeIndex, nodeData] of impl.nodes) {
-    const label = escapeGraphVizString(nodeLabel(nodeData))
-    lines.push(`  "${nodeIndex}" [label="${label}"];`)
-  }
+    // Add nodes
+    for (const [nodeIndex, nodeData] of impl.nodes) {
+      const label = escapeGraphVizString(nodeLabel(nodeData))
+      lines.push(`  "${nodeIndex}" [label="${label}"];`)
+    }
 
-  // Add edges
-  for (const [, edgeData] of impl.edges) {
-    const label = escapeGraphVizString(edgeLabel(edgeData.data))
-    lines.push(`  "${edgeData.source}" ${edgeOperator} "${edgeData.target}" [label="${label}"];`)
-  }
+    // Add edges
+    for (const [, edgeData] of impl.edges) {
+      const label = escapeGraphVizString(edgeLabel(edgeData.data))
+      lines.push(`  "${edgeData.source}" ${edgeOperator} "${edgeData.target}" [label="${label}"];`)
+    }
 
-  lines.push("}")
-  return lines.join("\n")
+    lines.push("}")
+    return lines.join("\n")
+  })
 })
 
 // =============================================================================
@@ -3959,34 +3981,36 @@ export const toMermaid: {
   const finalDiagramType = diagramType ??
     (graph.type === "directed" ? "flowchart" : "graph")
 
-  // Generate diagram header
-  const lines: Array<string> = []
-  lines.push(`${finalDiagramType} ${direction}`)
+  return withMutationGuard(graph, () => {
+    // Generate diagram header
+    const lines: Array<string> = []
+    lines.push(`${finalDiagramType} ${direction}`)
 
-  // Add nodes
-  for (const [nodeIndex, nodeData] of impl.nodes) {
-    const nodeId = String(nodeIndex)
-    const label = escapeMermaidLabel(nodeLabel(nodeData))
-    const shape = nodeShape(nodeData)
-    const formattedNode = formatMermaidNode(nodeId, label, shape)
-    lines.push(`  ${formattedNode}`)
-  }
-
-  // Add edges
-  const edgeOperator = finalDiagramType === "flowchart" ? "-->" : "---"
-  for (const [, edgeData] of impl.edges) {
-    const sourceId = String(edgeData.source)
-    const targetId = String(edgeData.target)
-    const label = escapeMermaidLabel(edgeLabel(edgeData.data))
-
-    if (label) {
-      lines.push(`  ${sourceId} ${edgeOperator}|"${label}"| ${targetId}`)
-    } else {
-      lines.push(`  ${sourceId} ${edgeOperator} ${targetId}`)
+    // Add nodes
+    for (const [nodeIndex, nodeData] of impl.nodes) {
+      const nodeId = String(nodeIndex)
+      const label = escapeMermaidLabel(nodeLabel(nodeData))
+      const shape = nodeShape(nodeData)
+      const formattedNode = formatMermaidNode(nodeId, label, shape)
+      lines.push(`  ${formattedNode}`)
     }
-  }
 
-  return lines.join("\n")
+    // Add edges
+    const edgeOperator = finalDiagramType === "flowchart" ? "-->" : "---"
+    for (const [, edgeData] of impl.edges) {
+      const sourceId = String(edgeData.source)
+      const targetId = String(edgeData.target)
+      const label = escapeMermaidLabel(edgeLabel(edgeData.data))
+
+      if (label) {
+        lines.push(`  ${sourceId} ${edgeOperator}|"${label}"| ${targetId}`)
+      } else {
+        lines.push(`  ${sourceId} ${edgeOperator} ${targetId}`)
+      }
+    }
+
+    return lines.join("\n")
+  })
 })
 
 // =============================================================================
@@ -5432,24 +5456,26 @@ const solveMaximumFlow = <N, E>(
   const forwardArc = new Int32Array(edges.length)
   forwardArc.fill(-1)
 
-  for (let edge = 0; edge < edges.length; edge++) {
-    const capacity = config.capacity(edges[edge].data)
-    if (!Number.isFinite(capacity) || capacity < 0) {
-      throw new GraphError({ message: `Edge ${edgeIds[edge]} capacity must be a finite non-negative number` })
+  withMutationGuard(graph, () => {
+    for (let edge = 0; edge < edges.length; edge++) {
+      const capacity = config.capacity(edges[edge].data)
+      if (!Number.isFinite(capacity) || capacity < 0) {
+        throw new GraphError({ message: `Edge ${edgeIds[edge]} capacity must be a finite non-negative number` })
+      }
+      capacities[edge] = capacity
+      const from = endpoints.sources[edge]
+      const to = endpoints.targets[edge]
+      if (from === to) {
+        continue
+      }
+      const index = arcs.length
+      forwardArc[edge] = index
+      adjacency[from].push(index)
+      arcs.push({ from, to, capacity, edge, flow: 0 })
+      adjacency[to].push(index + 1)
+      arcs.push({ from: to, to: from, capacity: 0, edge: -1, flow: 0 })
     }
-    capacities[edge] = capacity
-    const from = endpoints.sources[edge]
-    const to = endpoints.targets[edge]
-    if (from === to) {
-      continue
-    }
-    const index = arcs.length
-    forwardArc[edge] = index
-    adjacency[from].push(index)
-    arcs.push({ from, to, capacity, edge, flow: 0 })
-    adjacency[to].push(index + 1)
-    arcs.push({ from: to, to: from, capacity: 0, edge: -1, flow: 0 })
-  }
+  })
 
   const parentArc = new Int32Array(cache.nodeIds.length)
   const visited = new Uint8Array(cache.nodeIds.length)
@@ -6030,16 +6056,18 @@ export const minimumSpanningForest: {
   }
   const weightedEdges: Array<{ readonly index: EdgeIndex; readonly weight: number; readonly order: number }> = []
   let order = 0
-  for (const [index, edge] of impl.edges) {
-    const weight = cost(edge.data)
-    if (Number.isNaN(weight) || weight === -Infinity) {
-      throw new GraphError({ message: "Minimum spanning forest does not support NaN or -Infinity edge weights" })
+  withMutationGuard(graph, () => {
+    for (const [index, edge] of impl.edges) {
+      const weight = cost(edge.data)
+      if (Number.isNaN(weight) || weight === -Infinity) {
+        throw new GraphError({ message: "Minimum spanning forest does not support NaN or -Infinity edge weights" })
+      }
+      if (weight !== Infinity) {
+        weightedEdges.push({ index, weight, order })
+      }
+      order++
     }
-    if (weight !== Infinity) {
-      weightedEdges.push({ index, weight, order })
-    }
-    order++
-  }
+  })
   weightedEdges.sort((self, that) => self.weight - that.weight || self.order - that.order)
 
   const parents = new Uint32Array(nodes.length)
@@ -6487,13 +6515,15 @@ export const dijkstra: {
   const source = csr.getNodeIndex(cache, config.source)!
   const target = csr.getNodeIndex(cache, config.target)!
   const edgeWeights = new Float64Array(cachedEdges.length)
-  for (let i = 0; i < cachedEdges.length; i++) {
-    const weight = config.cost(cachedEdges[i].data)
-    if (Number.isNaN(weight) || weight < 0) {
-      throw new GraphError({ message: "Dijkstra's algorithm requires non-negative edge weights" })
+  withMutationGuard(graph, () => {
+    for (let i = 0; i < cachedEdges.length; i++) {
+      const weight = config.cost(cachedEdges[i].data)
+      if (Number.isNaN(weight) || weight < 0) {
+        throw new GraphError({ message: "Dijkstra's algorithm requires non-negative edge weights" })
+      }
+      edgeWeights[i] = weight
     }
-    edgeWeights[i] = weight
-  }
+  })
 
   // Early return if source equals target
   if (config.source === config.target) {
@@ -6666,28 +6696,30 @@ export const floydWarshall: {
     distancesMatrix[i * size + i] = 0
   }
 
-  for (let edge = 0; edge < edges.length; edge++) {
-    const weight = cost(edges[edge].data)
-    if (Number.isNaN(weight) || weight === -Infinity) {
-      throw new GraphError({ message: "Floyd-Warshall algorithm does not support NaN or -Infinity edge weights" })
-    }
-    const source = edgeCache.sources[edge]
-    const target = edgeCache.targets[edge]
-    const position = source * size + target
-    if (weight < distancesMatrix[position]) {
-      distancesMatrix[position] = weight
-      nextMatrix[position] = target
-      edgeMatrix[position] = edge
-    }
-    if (graph.type === "undirected") {
-      const reverse = target * size + source
-      if (weight < distancesMatrix[reverse]) {
-        distancesMatrix[reverse] = weight
-        nextMatrix[reverse] = source
-        edgeMatrix[reverse] = edge
+  withMutationGuard(graph, () => {
+    for (let edge = 0; edge < edges.length; edge++) {
+      const weight = cost(edges[edge].data)
+      if (Number.isNaN(weight) || weight === -Infinity) {
+        throw new GraphError({ message: "Floyd-Warshall algorithm does not support NaN or -Infinity edge weights" })
+      }
+      const source = edgeCache.sources[edge]
+      const target = edgeCache.targets[edge]
+      const position = source * size + target
+      if (weight < distancesMatrix[position]) {
+        distancesMatrix[position] = weight
+        nextMatrix[position] = target
+        edgeMatrix[position] = edge
+      }
+      if (graph.type === "undirected") {
+        const reverse = target * size + source
+        if (weight < distancesMatrix[reverse]) {
+          distancesMatrix[reverse] = weight
+          nextMatrix[reverse] = source
+          edgeMatrix[reverse] = edge
+        }
       }
     }
-  }
+  })
 
   for (let k = 0; k < size; k++) {
     const kRow = k * size
@@ -6884,17 +6916,19 @@ export const astar: {
   const sourceNodeData = cache.nodeData[source] as N
   const targetNodeData = cache.nodeData[target] as N
   const edgeWeights = new Float64Array(cachedEdges.length)
-  for (let i = 0; i < cachedEdges.length; i++) {
-    const weight = config.cost(cachedEdges[i].data)
-    if (Number.isNaN(weight) || weight < 0) {
-      throw new GraphError({ message: "A* algorithm requires non-negative edge weights" })
+  withMutationGuard(graph, () => {
+    for (let i = 0; i < cachedEdges.length; i++) {
+      const weight = config.cost(cachedEdges[i].data)
+      if (Number.isNaN(weight) || weight < 0) {
+        throw new GraphError({ message: "A* algorithm requires non-negative edge weights" })
+      }
+      edgeWeights[i] = weight
     }
-    edgeWeights[i] = weight
-  }
+  })
 
   // Early return if source equals target
   if (config.source === config.target) {
-    if (!Number.isFinite(config.heuristic(sourceNodeData, targetNodeData))) {
+    if (!Number.isFinite(withMutationGuard(graph, () => config.heuristic(sourceNodeData, targetNodeData)))) {
       throw new GraphError({ message: "A* algorithm requires finite heuristic values" })
     }
     return Option.some({
@@ -6906,7 +6940,7 @@ export const astar: {
   }
 
   const getHeuristic = (nodeData: N): number => {
-    const value = config.heuristic(nodeData, targetNodeData)
+    const value = withMutationGuard(graph, () => config.heuristic(nodeData, targetNodeData))
     if (!Number.isFinite(value)) {
       throw new GraphError({ message: "A* algorithm requires finite heuristic values" })
     }
@@ -7077,13 +7111,15 @@ export const bellmanFord: {
   const source = csr.getNodeIndex(cache, config.source)!
   const target = csr.getNodeIndex(cache, config.target)!
   const weights = new Float64Array(edges.length)
-  for (let i = 0; i < edges.length; i++) {
-    const weight = config.cost(edges[i].data)
-    if (Number.isNaN(weight) || weight === -Infinity) {
-      throw new GraphError({ message: "Bellman-Ford algorithm does not support NaN or -Infinity edge weights" })
+  withMutationGuard(graph, () => {
+    for (let i = 0; i < edges.length; i++) {
+      const weight = config.cost(edges[i].data)
+      if (Number.isNaN(weight) || weight === -Infinity) {
+        throw new GraphError({ message: "Bellman-Ford algorithm does not support NaN or -Infinity edge weights" })
+      }
+      weights[i] = weight
     }
-    weights[i] = weight
-  }
+  })
 
   const addWeight = (distance: number, weight: number): number => {
     if (distance === Infinity || weight === Infinity) {
@@ -7446,13 +7482,15 @@ export const allShortestPaths: {
     const edgeIds = csr.getEdgeIds(cache)
     const outgoing = csr.getOutgoingWithEdges(cache)
     const weights = new Float64Array(graphEdges.length)
-    for (let edge = 0; edge < graphEdges.length; edge++) {
-      const weight = config.cost(graphEdges[edge].data)
-      if (Number.isNaN(weight) || weight < 0) {
-        throw new GraphError({ message: "All shortest paths requires non-negative edge weights" })
+    withMutationGuard(graph, () => {
+      for (let edge = 0; edge < graphEdges.length; edge++) {
+        const weight = config.cost(graphEdges[edge].data)
+        if (Number.isNaN(weight) || weight < 0) {
+          throw new GraphError({ message: "All shortest paths requires non-negative edge weights" })
+        }
+        weights[edge] = weight
       }
-      weights[edge] = weight
-    }
+    })
     if (limit === 0) {
       return
     }
@@ -7633,7 +7671,8 @@ const makeCsrNodeWalker = <N, E, T extends Kind>(
 ): Walker<NodeIndex, N> => {
   return new Walker((f) => ({
     // Capture CSR at iterator creation so invalidation cannot change an in-flight mutable traversal.
-    [Symbol.iterator]: () => makeIterator(csr.get(graph), f)
+    [Symbol.iterator]: () =>
+      makeIterator(csr.get(graph), (index, data) => withMutationGuard(graph, () => f(index, data)))
   }))
 }
 
@@ -8504,7 +8543,7 @@ export const nodes = <N, E, T extends Kind = "directed">(
             return { done: true, value: undefined }
           }
           const [nodeIndex, nodeData] = result.value
-          return { done: false, value: f(nodeIndex, nodeData) }
+          return { done: false, value: withMutationGuard(graph, () => f(nodeIndex, nodeData)) }
         }
       }
     }
@@ -8557,7 +8596,7 @@ export const edges = <N, E, T extends Kind = "directed">(
             return { done: true, value: undefined }
           }
           const [edgeIndex, edgeData] = result.value
-          return { done: false, value: f(edgeIndex, copyEdge(edgeData)) }
+          return { done: false, value: withMutationGuard(graph, () => f(edgeIndex, copyEdge(edgeData))) }
         }
       }
     }
@@ -8660,7 +8699,7 @@ export const externals: {
 
           // Node is external if it has no edges in the specified direction
           if (adjacencyList === undefined || adjacencyList.length === 0) {
-            return { done: false, value: f(nodeIndex, nodeData) }
+            return { done: false, value: withMutationGuard(graph, () => f(nodeIndex, nodeData)) }
           }
           current = nodeIterator.next()
         }

--- a/packages/effect/src/internal/graph.ts
+++ b/packages/effect/src/internal/graph.ts
@@ -10,7 +10,7 @@ import { hasProperty } from "../Predicate.ts"
 export const TypeId = "~effect/collections/Graph"
 
 /** @internal */
-export interface GraphImpl<in out N, in out E, T extends Graph.Kind = "directed">
+export interface GraphImpl<in out N, in out E, T extends Graph.Kind>
   extends Iterable<readonly [Graph.NodeIndex, N]>, Equal.Equal
 {
   readonly [TypeId]: unknown
@@ -28,7 +28,7 @@ export interface GraphImpl<in out N, in out E, T extends Graph.Kind = "directed"
 }
 
 /** @internal */
-export const toImpl = <N, E, T extends Graph.Kind = "directed">(
+export const toImpl = <N, E, T extends Graph.Kind>(
   graph: Graph.Graph<N, E, T> | Graph.MutableGraph<N, E, T>
 ): GraphImpl<N, E, T> => graph as unknown as GraphImpl<N, E, T>
 
@@ -69,15 +69,15 @@ const ProtoGraph = {
     _N: (_: never) => _,
     _E: (_: never) => _
   },
-  [Symbol.iterator](this: GraphImpl<any, any>) {
+  [Symbol.iterator](this: GraphImpl<any, any, any>) {
     return this.nodes[Symbol.iterator]()
   },
-  [NodeInspectSymbol](this: GraphImpl<any, any>) {
+  [NodeInspectSymbol](this: GraphImpl<any, any, any>) {
     return this.toJSON()
   },
-  [Equal.symbol](this: GraphImpl<any, any>, that: Equal.Equal): boolean {
+  [Equal.symbol](this: GraphImpl<any, any, any>, that: Equal.Equal): boolean {
     if (hasProperty(that, TypeId)) {
-      const thatImpl = toImpl(that as Graph.Graph<unknown, unknown, Graph.Kind>)
+      const thatImpl = toImpl(that as Graph.Graph<any, any, any>)
       if (
         this.nodes.size !== thatImpl.nodes.size ||
         this.edges.size !== thatImpl.edges.size ||
@@ -100,7 +100,7 @@ const ProtoGraph = {
     }
     return false
   },
-  [Hash.symbol](this: GraphImpl<any, any>): number {
+  [Hash.symbol](this: GraphImpl<any, any, any>): number {
     let hash = Hash.string("Graph")
     hash = hash ^ Hash.string(this.type)
     hash = hash ^ Hash.number(this.nodes.size)
@@ -113,7 +113,7 @@ const ProtoGraph = {
     }
     return hash
   },
-  toJSON(this: GraphImpl<any, any>) {
+  toJSON(this: GraphImpl<any, any, any>) {
     return {
       _id: "Graph",
       nodeCount: this.nodes.size,
@@ -121,7 +121,7 @@ const ProtoGraph = {
       type: this.type
     }
   },
-  toString(this: GraphImpl<any, any>) {
+  toString(this: GraphImpl<any, any, any>) {
     return `Graph(${this.type}, ${this.nodes.size}, ${this.edges.size})`
   },
   pipe() {

--- a/packages/effect/src/internal/graph.ts
+++ b/packages/effect/src/internal/graph.ts
@@ -43,11 +43,12 @@ export const withTransformation = <N, E, T extends Graph.Kind, A>(
   evaluate: () => A
 ): A => {
   const impl = toImpl(graph)
+  const transforming = impl.transforming
   impl.transforming = true
   try {
     return evaluate()
   } finally {
-    impl.transforming = false
+    impl.transforming = transforming
   }
 }
 

--- a/packages/effect/src/internal/graphCsr.ts
+++ b/packages/effect/src/internal/graphCsr.ts
@@ -1,5 +1,5 @@
 import type * as Graph from "../Graph.ts"
-import { type GraphImpl, isTransforming, toImpl } from "./graph.ts"
+import { isTransforming, toImpl } from "./graph.ts"
 
 /** @internal */
 export interface Adjacency {
@@ -51,7 +51,7 @@ export interface Csr {
   indexByEdgeId: Map<Graph.EdgeIndex, number> | null | undefined
 }
 
-const cache = new WeakMap<GraphImpl<any, any, any>, Csr>()
+const cache = new WeakMap<Graph.Graph<any, any, any> | Graph.MutableGraph<any, any, any>, Csr>()
 
 /** @internal */
 export const getNodeIndex = (csr: Csr, nodeId: Graph.NodeIndex): number | undefined =>
@@ -212,30 +212,30 @@ export const getEdgeEndpoints = (csr: Csr): EdgeEndpoints => {
 /** @internal */
 export const peek = <N, E, T extends Graph.Kind>(
   graph: Graph.Graph<N, E, T> | Graph.MutableGraph<N, E, T>
-): Csr | undefined => cache.get(toImpl(graph))
+): Csr | undefined => cache.get(graph)
 
 /** @internal */
 export const invalidate = <N, E, T extends Graph.Kind>(
   graph: Graph.Graph<N, E, T> | Graph.MutableGraph<N, E, T>
 ): void => {
   // Existing iterators retain their Csr object; only subsequent lookups rebuild from the mutated graph.
-  cache.delete(toImpl(graph))
+  cache.delete(graph)
 }
 
 /** @internal */
 export const get = <N, E, T extends Graph.Kind>(
   graph: Graph.Graph<N, E, T> | Graph.MutableGraph<N, E, T>
 ): Csr => {
-  const impl = toImpl(graph)
   const cacheEnabled = !isTransforming(graph)
   if (cacheEnabled) {
-    const cached = cache.get(impl)
+    const cached = cache.get(graph)
     if (cached !== undefined) {
       return cached
     }
   }
 
   // Node ids and data are captured together so an iterator never consults mutable maps after it starts.
+  const impl = toImpl(graph)
   const nodeIds = new Array<Graph.NodeIndex>(impl.nodes.size)
   const nodeData = new Array<any>(impl.nodes.size)
   let compactNodeIds = true
@@ -272,7 +272,8 @@ export const get = <N, E, T extends Graph.Kind>(
   }
 
   if (cacheEnabled) {
-    cache.set(impl, result)
+    cache.set(graph, result)
   }
+
   return result
 }

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -1981,13 +1981,39 @@ describe("Graph", () => {
       }
       const overflow = directed([0, 1, 2], [[0, 1, Number.MAX_VALUE], [1, 2, Number.MAX_VALUE]])
       assertGraphError(
+        () => Graph.dijkstra(overflow, { source: 0, target: 2, cost: (edge) => edge }),
+        "Dijkstra distance calculation exceeded the finite number range"
+      )
+      assertGraphError(
+        () => Graph.astar(overflow, { source: 0, target: 2, cost: (edge) => edge, heuristic: () => 0 }),
+        "A* distance calculation exceeded the finite number range"
+      )
+      assertGraphError(
+        () =>
+          Graph.astar(directed([0, 1], [[0, 1, Number.MAX_VALUE]]), {
+            source: 0,
+            target: 1,
+            cost: (edge) => edge,
+            heuristic: (node) => node === 1 ? Number.MAX_VALUE : 0
+          }),
+        "A* priority calculation exceeded the finite number range"
+      )
+      assertGraphError(
         () => Graph.bellmanFord(overflow, { source: 0, target: 2, cost: (edge) => edge }),
         "Bellman-Ford distance calculation exceeded the finite number range"
       )
-      const underflow = directed([0, 1], [[0, 1, -Number.MAX_VALUE], [1, 0, -Number.MAX_VALUE]])
       assertGraphError(
-        () => Graph.bellmanFord(underflow, { source: 0, target: 0, cost: (edge) => edge }),
+        () => Graph.floydWarshall(overflow, (edge) => edge),
+        "Floyd-Warshall distance calculation exceeded the finite number range"
+      )
+      const underflow = directed([0, 1, 2], [[0, 1, -Number.MAX_VALUE], [1, 2, -Number.MAX_VALUE]])
+      assertGraphError(
+        () => Graph.bellmanFord(underflow, { source: 0, target: 2, cost: (edge) => edge }),
         "Bellman-Ford distance calculation exceeded the finite number range"
+      )
+      assertGraphError(
+        () => Graph.floydWarshall(underflow, (edge) => edge),
+        "Floyd-Warshall distance calculation exceeded the finite number range"
       )
     })
 
@@ -2176,6 +2202,11 @@ describe("Graph", () => {
       assertGraphError(
         () => Array.from(Graph.allShortestPaths(graph, { source: 0, target: 1, cost: (edge) => edge, limit: 0 })),
         "All shortest paths requires non-negative edge weights"
+      )
+      const overflow = directed([0, 1, 2], [[0, 1, Number.MAX_VALUE], [1, 2, Number.MAX_VALUE]])
+      assertGraphError(
+        () => Array.from(Graph.allShortestPaths(overflow, { source: 0, target: 2, cost: (edge) => edge })),
+        "All shortest paths distance calculation exceeded the finite number range"
       )
       assertGraphError(
         () => Graph.simplePaths(graph, { source: 0, target: 1, limit: -1 }),

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -540,6 +540,52 @@ describe("Graph", () => {
         assertGraphError(transformation, "Cannot mutate graph during a transformation")
       }
     })
+
+    it("guards read callbacks against nested mutation", () => {
+      const mutable = Graph.beginMutation(directed(["A", "B"], [[0, 1, 1]]))
+      const mutate = () => Graph.addNode(mutable, "C")
+      const operations: ReadonlyArray<() => unknown> = [
+        () =>
+          Graph.findNode(mutable, () => {
+            Graph.findNode(mutable, () => false)
+            mutate()
+            return false
+          }),
+        () => Graph.findNodes(mutable, () => (mutate(), false)),
+        () => Graph.findEdge(mutable, () => (mutate(), false)),
+        () => Graph.findEdges(mutable, () => (mutate(), false)),
+        () => Graph.toGraphViz(mutable, { edgeLabel: (edge) => (mutate(), String(edge)) }),
+        () => Graph.toMermaid(mutable, { nodeShape: () => (mutate(), "rectangle") }),
+        () => Graph.maximumFlow(mutable, { source: 0, target: 1, capacity: (edge) => (mutate(), edge) }),
+        () => Graph.minimumCut(mutable, { source: 0, target: 1, capacity: (edge) => (mutate(), edge) }),
+        () => Graph.dijkstra(mutable, { source: 0, target: 1, cost: (edge) => (mutate(), edge) }),
+        () => Graph.floydWarshall(mutable, (edge) => (mutate(), edge)),
+        () => Graph.astar(mutable, { source: 0, target: 1, cost: (edge) => (mutate(), edge), heuristic: () => 0 }),
+        () => Graph.astar(mutable, { source: 0, target: 1, cost: (edge) => edge, heuristic: () => (mutate(), 0) }),
+        () => Graph.bellmanFord(mutable, { source: 0, target: 1, cost: (edge) => (mutate(), edge) }),
+        () =>
+          Array.from(Graph.allShortestPaths(mutable, {
+            source: 0,
+            target: 1,
+            cost: (edge) => (mutate(), edge)
+          })),
+        () => Array.from(Graph.dfs(mutable, { start: [0] }).visit(() => mutate())),
+        () => Array.from(Graph.nodes(mutable).visit(() => mutate())),
+        () => Array.from(Graph.edges(mutable).visit(() => mutate())),
+        () => Array.from(Graph.externals(mutable).visit(() => mutate()))
+      ]
+
+      for (const operation of operations) {
+        assertGraphError(operation, "Cannot mutate graph during a transformation")
+      }
+
+      const undirectedMutable = Graph.beginMutation(undirected(["A", "B"], [[0, 1, 1]]))
+      assertGraphError(() =>
+        Graph.minimumSpanningForest(undirectedMutable, (edge) => {
+          Graph.addNode(undirectedMutable, "C")
+          return edge
+        }), "Cannot mutate graph during a transformation")
+    })
   })
 
   describe("node operations", () => {
@@ -1799,24 +1845,6 @@ describe("Graph", () => {
       }
     })
 
-    it("snapshots mutable adjacency before evaluating Dijkstra and A* costs", () => {
-      for (const algorithm of ["dijkstra", "astar"] as const) {
-        const mutable = Graph.beginMutation(directed(["A", "B", "C"], [[0, 1, 1], [1, 2, 1], [0, 2, 3]]))
-        let mutated = false
-        const cost = (edge: number) => {
-          if (!mutated) {
-            mutated = true
-            Graph.removeEdge(mutable, 1)
-          }
-          return edge
-        }
-        const result = algorithm === "dijkstra"
-          ? Graph.dijkstra(mutable, { source: 0, target: 2, cost })
-          : Graph.astar(mutable, { source: 0, target: 2, cost, heuristic: () => 0 })
-        assertPath(result, { path: [0, 1, 2], edges: [0, 1], distance: 2, costs: [1, 1] })
-      }
-    })
-
     it("handles unreachable and same-node paths completely", () => {
       const graph = directed<string, number>(["A", "B"], [])
       const expected = { path: [0], edges: [], distance: 0, costs: [] }
@@ -2121,25 +2149,6 @@ describe("Graph", () => {
       })
       assert.deepStrictEqual(Array.from(shortest), [
         { path: [0, 1, 3], edges: [0, 2], distance: 2, costs: [1, 1] }
-      ])
-    })
-
-    it("snapshots mutable adjacency before all-shortest-path cost callbacks", () => {
-      const mutable = Graph.beginMutation(directed([0, 1, 2], [[0, 1, 1], [1, 2, 1], [0, 2, 3]]))
-      let mutated = false
-      const paths = Graph.allShortestPaths(mutable, {
-        source: 0,
-        target: 2,
-        cost: (edge) => {
-          if (!mutated) {
-            mutated = true
-            Graph.removeEdge(mutable, 1)
-          }
-          return edge
-        }
-      })
-      assert.deepStrictEqual(Array.from(paths), [
-        { path: [0, 1, 2], edges: [0, 1], distance: 2, costs: [1, 1] }
       ])
     })
 


### PR DESCRIPTION
## Summary

- reject mutation or finalization of a mutable graph from callbacks that traverse or inspect that same graph
- cover finders, diagram exporters, weighted and flow algorithms, A* heuristics, lazy shortest paths, and graph-backed walker visitors
- preserve mutations between lazy iterator steps while making nested callback guards reentrant-safe
- document the callback mutation constraint and extend the existing changeset

## Testing

- `pnpm lint-fix`
- `pnpm --filter effect test --run test/Graph.test.ts`
- `pnpm check` (passes with existing duplicate-package warnings from `tmp/bundle-base`)
- `git diff --check`