### PR TITLE
Resolve Match terminal combinators for Match.value on generic inputs

### DIFF
--- a/.changeset/match-generic-value-terminals.md
+++ b/.changeset/match-generic-value-terminals.md
@@ -1,0 +1,35 @@
+---
+"effect": patch
+---
+
+Resolve `Match` terminal combinators for `Match.value` on generic inputs.
+
+`Match.value` used to place the provided input type in the `Matcher` union's
+`Provided` slot, so terminal combinators branched on `[Pr] extends [never]` to
+tell the two matcher flavors apart. When the input type contained a type
+parameter, TypeScript deferred that conditional and the whole pipeline failed
+to typecheck, even though every arm was fine:
+
+```ts
+type Closed = { readonly _tag: "Closed" }
+
+const describe = <Open extends { readonly _tag: "Open" }>(
+  state: Closed | Open,
+  describeOpen: (open: Open) => string
+): string =>
+  Match.value(state).pipe(
+    Match.tag("Closed", () => "closed"),
+    Match.orElse((open) => describeOpen(open)) // was: unresolved conditional type
+  )
+```
+
+`Match.value` now marks the matcher with the fixed literal `"value"` in that
+slot instead of the input type, so the flavor check resolves eagerly and
+generic inputs work with every terminal combinator (`orElse`, `orElseAbsurd`,
+`exhaustive`, `option`, `result`, and friends). `ValueMatcher` still carries
+the real provided type.
+
+Note for hand-written annotations: the fifth type argument of `Matcher` for a
+value matcher is now `"value"` rather than the input type, so annotations such
+as `Matcher<A, F, RA, R, A>` should become `Matcher<A, F, RA, R, "value">`.
+Type-matcher annotations (`Pr = never`) are unchanged.

--- a/.changeset/match-generic-value-terminals.md
+++ b/.changeset/match-generic-value-terminals.md
@@ -2,34 +2,8 @@
 "effect": patch
 ---
 
-Resolve `Match` terminal combinators for `Match.value` on generic inputs.
+Fix `Match.value` terminal combinators failing to typecheck when the input
+contains a generic type parameter.
 
-`Match.value` used to place the provided input type in the `Matcher` union's
-`Provided` slot, so terminal combinators branched on `[Pr] extends [never]` to
-tell the two matcher flavors apart. When the input type contained a type
-parameter, TypeScript deferred that conditional and the whole pipeline failed
-to typecheck, even though every arm was fine:
-
-```ts
-type Closed = { readonly _tag: "Closed" }
-
-const describe = <Open extends { readonly _tag: "Open" }>(
-  state: Closed | Open,
-  describeOpen: (open: Open) => string
-): string =>
-  Match.value(state).pipe(
-    Match.tag("Closed", () => "closed"),
-    Match.orElse((open) => describeOpen(open)) // was: unresolved conditional type
-  )
-```
-
-`Match.value` now marks the matcher with the fixed literal `"value"` in that
-slot instead of the input type, so the flavor check resolves eagerly and
-generic inputs work with every terminal combinator (`orElse`, `orElseAbsurd`,
-`exhaustive`, `option`, `result`, and friends). `ValueMatcher` still carries
-the real provided type.
-
-Note for hand-written annotations: the fifth type argument of `Matcher` for a
-value matcher is now `"value"` rather than the input type, so annotations such
-as `Matcher<A, F, RA, R, A>` should become `Matcher<A, F, RA, R, "value">`.
-Type-matcher annotations (`Pr = never`) are unchanged.
+The fifth type argument of `Matcher` for value matchers is now `"value"`;
+update hand-written value-matcher annotations accordingly.

--- a/.changeset/match-generic-value-terminals.md
+++ b/.changeset/match-generic-value-terminals.md
@@ -5,5 +5,6 @@
 Fix `Match.value` terminal combinators failing to typecheck when the input
 contains a generic type parameter.
 
-The fifth type argument of `Matcher` for value matchers is now `"value"`;
-update hand-written value-matcher annotations accordingly.
+The fifth type argument of `Matcher` for value matchers is now `ValueFlavor`,
+and `ValueMatcher` has a seventh flavor argument; update hand-written
+annotations accordingly.

--- a/packages/effect/src/Match.ts
+++ b/packages/effect/src/Match.ts
@@ -21,14 +21,22 @@ import type { Unify } from "./Unify.ts"
 const TypeId = internal.TypeId
 
 /**
+ * Marker used by `Matcher` to distinguish matchers created with `Match.value`.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type ValueFlavor = "value"
+
+/**
  * Union type for matchers created by `Match.type` and `Match.value`.
  *
  * **Details**
  *
  * A `Matcher` carries the input type, accumulated filters, remaining cases,
- * result type, and a `Provided` flag distinguishing the two flavors: `never`
- * for matchers created with `Match.type` and `"value"` for matchers created
- * with `Match.value`. Because the flag never depends on the input type,
+ * result type, and a flavor distinguishing the two matcher variants: `never`
+ * for matchers created with `Match.type` and `ValueFlavor` for matchers created
+ * with `Match.value`. Because the flavor never depends on the input type,
  * terminal combinators resolve even when the input contains type parameters.
  *
  * **Example** (Matching string and number values)
@@ -56,9 +64,9 @@ const TypeId = internal.TypeId
  * @category models
  * @since 4.0.0
  */
-export type Matcher<Input, Filters, RemainingApplied, Result, Provided, Return = any> =
+export type Matcher<Input, Filters, RemainingApplied, Result, Flavor, Return = any> =
   | TypeMatcher<Input, Filters, RemainingApplied, Result, Return>
-  | ValueMatcher<Input, Filters, RemainingApplied, Result, Input, Return, Provided>
+  | ValueMatcher<Input, Filters, RemainingApplied, Result, Input, Return, Flavor>
 
 /**
  * Represents a pattern matcher that operates on types rather than specific values.
@@ -109,7 +117,8 @@ export interface TypeMatcher<in Input, out Filters, out Remaining, out Result, o
  *
  * A `ValueMatcher` is created when using `Match.value(someValue)` and contains
  * the actual value to be matched against. It tracks both the provided value
- * and the result of applying patterns to determine matches.
+ * and the result of applying patterns to determine matches. Its optional
+ * seventh type parameter is the matcher flavor and defaults to `ValueFlavor`.
  *
  * **Example** (Creating a value matcher)
  *
@@ -138,7 +147,7 @@ export interface ValueMatcher<
   out Result,
   Provided,
   out Return = any,
-  out Pr = "value"
+  out Flavor = ValueFlavor
 > extends Pipeable {
   readonly _tag: "ValueMatcher"
   readonly [TypeId]: {
@@ -146,11 +155,11 @@ export interface ValueMatcher<
     readonly _filters: T.Covariant<Filters>
     readonly _result: T.Covariant<Result>
     readonly _return: T.Covariant<Return>
-    readonly _pr: T.Covariant<Pr>
+    readonly _flavor: T.Covariant<Flavor>
   }
   readonly provided: Provided
   readonly value: Result.Result<Provided, Remaining>
-  add<I, R, RA, A, Pr>(_case: Case): ValueMatcher<I, R, RA, A, Pr>
+  add<I, R, RA, A, Provided>(_case: Case): ValueMatcher<I, R, RA, A, Provided>
 }
 
 /**
@@ -332,7 +341,7 @@ export const type: <I>() => Matcher<I, Types.Without<never>, I, never, never> = 
  */
 export const value: <const I>(
   i: I
-) => Matcher<I, Types.Without<never>, I, never, "value"> = internal.value
+) => Matcher<I, Types.Without<never>, I, never, ValueFlavor> = internal.value
 
 /**
  * Creates a match function for a specific value with discriminated union handling.

--- a/packages/effect/src/Match.ts
+++ b/packages/effect/src/Match.ts
@@ -26,7 +26,10 @@ const TypeId = internal.TypeId
  * **Details**
  *
  * A `Matcher` carries the input type, accumulated filters, remaining cases,
- * result type, and, for value matchers, the provided value being matched.
+ * result type, and a `Provided` flag distinguishing the two flavors: `never`
+ * for matchers created with `Match.type` and `"value"` for matchers created
+ * with `Match.value`. Because the flag never depends on the input type,
+ * terminal combinators resolve even when the input contains type parameters.
  *
  * **Example** (Matching string and number values)
  *
@@ -55,7 +58,7 @@ const TypeId = internal.TypeId
  */
 export type Matcher<Input, Filters, RemainingApplied, Result, Provided, Return = any> =
   | TypeMatcher<Input, Filters, RemainingApplied, Result, Return>
-  | ValueMatcher<Input, Filters, RemainingApplied, Result, Provided, Return>
+  | ValueMatcher<Input, Filters, RemainingApplied, Result, Input, Return, Provided>
 
 /**
  * Represents a pattern matcher that operates on types rather than specific values.
@@ -128,15 +131,22 @@ export interface TypeMatcher<in Input, out Filters, out Remaining, out Result, o
  * @category models
  * @since 4.0.0
  */
-export interface ValueMatcher<in Input, Filters, out Remaining, out Result, Provided, out Return = any>
-  extends Pipeable
-{
+export interface ValueMatcher<
+  in Input,
+  Filters,
+  out Remaining,
+  out Result,
+  Provided,
+  out Return = any,
+  out Pr = "value"
+> extends Pipeable {
   readonly _tag: "ValueMatcher"
   readonly [TypeId]: {
     readonly _input: T.Contravariant<Input>
     readonly _filters: T.Covariant<Filters>
     readonly _result: T.Covariant<Result>
     readonly _return: T.Covariant<Return>
+    readonly _pr: T.Covariant<Pr>
   }
   readonly provided: Provided
   readonly value: Result.Result<Provided, Remaining>
@@ -322,7 +332,7 @@ export const type: <I>() => Matcher<I, Types.Without<never>, I, never, never> = 
  */
 export const value: <const I>(
   i: I
-) => Matcher<I, Types.Without<never>, I, never, I> = internal.value
+) => Matcher<I, Types.Without<never>, I, never, "value"> = internal.value
 
 /**
  * Creates a match function for a specific value with discriminated union handling.

--- a/packages/effect/src/internal/matcher.ts
+++ b/packages/effect/src/internal/matcher.ts
@@ -1,5 +1,15 @@
 import { dual, identity } from "../Function.ts"
-import type { Case, Matcher, Not, SafeRefinement, TypeMatcher, Types, ValueMatcher, When } from "../Match.ts"
+import type {
+  Case,
+  Matcher,
+  Not,
+  SafeRefinement,
+  TypeMatcher,
+  Types,
+  ValueFlavor,
+  ValueMatcher,
+  When
+} from "../Match.ts"
 import * as Option from "../Option.ts"
 import { pipeArguments } from "../Pipeable.ts"
 import type * as Predicate from "../Predicate.ts"
@@ -46,13 +56,13 @@ const ValueMatcherProto: Omit<
     _filters: identity,
     _result: identity,
     _return: identity,
-    _pr: identity
+    _flavor: identity
   },
   _tag: "ValueMatcher",
-  add<I, R, RA, A, Pr>(
+  add<I, R, RA, A, Provided>(
     this: ValueMatcher<any, any, any, any, any>,
     _case: Case
-  ): ValueMatcher<I, R, RA, A, Pr> {
+  ): ValueMatcher<I, R, RA, A, Provided> {
     if (Result.isSuccess(this.value)) {
       return this
     }
@@ -76,10 +86,10 @@ const ValueMatcherProto: Omit<
   }
 }
 
-function makeValueMatcher<I, R, RA, A, Pr>(
-  provided: Pr,
-  value: Result.Result<Pr, RA>
-): ValueMatcher<I, R, RA, A, Pr> {
+function makeValueMatcher<I, R, RA, A, Provided>(
+  provided: Provided,
+  value: Result.Result<Provided, RA>
+): ValueMatcher<I, R, RA, A, Provided> {
   const matcher = Object.create(ValueMatcherProto)
   matcher.provided = provided
   matcher.value = value
@@ -195,7 +205,7 @@ export const type = <I>(): Matcher<
 /** @internal */
 export const value = <const I>(
   i: I
-): Matcher<I, Types.Without<never>, I, never, "value"> => makeValueMatcher(i, Result.fail(i))
+): Matcher<I, Types.Without<never>, I, never, ValueFlavor> => makeValueMatcher(i, Result.fail(i))
 
 /** @internal */
 export const valueTags: {

--- a/packages/effect/src/internal/matcher.ts
+++ b/packages/effect/src/internal/matcher.ts
@@ -45,7 +45,8 @@ const ValueMatcherProto: Omit<
     _input: identity,
     _filters: identity,
     _result: identity,
-    _return: identity
+    _return: identity,
+    _pr: identity
   },
   _tag: "ValueMatcher",
   add<I, R, RA, A, Pr>(
@@ -194,7 +195,7 @@ export const type = <I>(): Matcher<
 /** @internal */
 export const value = <const I>(
   i: I
-): Matcher<I, Types.Without<never>, I, never, I> => makeValueMatcher(i, Result.fail(i))
+): Matcher<I, Types.Without<never>, I, never, "value"> => makeValueMatcher(i, Result.fail(i))
 
 /** @internal */
 export const valueTags: {

--- a/packages/effect/typetest/Match.tst.ts
+++ b/packages/effect/typetest/Match.tst.ts
@@ -1,0 +1,116 @@
+import { Match, Option, pipe, type Result } from "effect"
+import { describe, expect, it } from "tstyche"
+
+type Closed = { readonly _tag: "Closed" }
+
+declare const stringOrNumber: string | number
+
+describe("Match", () => {
+  it("value matchers resolve terminals for generic inputs", () => {
+    // https://github.com/Effect-TS/effect/issues/7315
+    const orElse = <Open extends { readonly _tag: "Open" }>(
+      state: Closed | Open,
+      describeOpen: (open: Open) => string
+    ): string =>
+      Match.value(state).pipe(
+        Match.tag("Closed", () => "closed"),
+        Match.orElse((open) => describeOpen(open))
+      )
+    expect(orElse({ _tag: "Closed" }, () => "open")).type.toBe<string>()
+
+    const option = <Open extends { readonly _tag: "Open" }>(
+      state: Closed | Open
+    ): Option.Option<Open> =>
+      Match.value(state).pipe(
+        Match.tag("Closed", () => Option.none()),
+        Match.orElse((open) => Option.some(open))
+      )
+    expect(option<{ readonly _tag: "Open" }>({ _tag: "Closed" })).type.toBe<Option.Option<{ readonly _tag: "Open" }>>()
+
+    const terminalOption = <Open extends { readonly _tag: "Open" }>(
+      state: Closed | Open
+    ): Option.Option<string> =>
+      Match.value(state).pipe(
+        Match.tag("Closed", () => "closed"),
+        Match.option
+      )
+    expect(terminalOption({ _tag: "Closed" })).type.toBe<Option.Option<string>>()
+
+    const terminalResult = <Open extends { readonly _tag: "Open" }>(
+      state: Closed | Open
+    ): Result.Result<string, Open> =>
+      Match.value(state).pipe(
+        Match.tag("Closed", () => "closed"),
+        Match.result
+      )
+    expect(terminalResult<{ readonly _tag: "Open" }>({ _tag: "Closed" })).type.toBe<
+      Result.Result<string, { readonly _tag: "Open" }>
+    >()
+
+    const freePipe = <Open extends { readonly _tag: "Open" }>(
+      state: Closed | Open
+    ): string =>
+      pipe(
+        Match.value(state),
+        Match.tag("Closed", () => "closed"),
+        Match.orElse(() => "open")
+      )
+    expect(freePipe({ _tag: "Closed" })).type.toBe<string>()
+  })
+
+  it("value matchers return values for non-generic inputs", () => {
+    expect(
+      Match.value(stringOrNumber).pipe(
+        Match.when(Match.number, (n) => n),
+        Match.when(Match.string, (s) => s),
+        Match.exhaustive
+      )
+    ).type.toBe<string | number>()
+
+    expect(
+      Match.value(stringOrNumber).pipe(
+        Match.when(Match.number, (n) => n),
+        Match.option
+      )
+    ).type.toBe<Option.Option<number>>()
+
+    expect(
+      Match.value(stringOrNumber).pipe(
+        Match.when(Match.number, (n) => n),
+        Match.result
+      )
+    ).type.toBe<Result.Result<number, string>>()
+
+    expect(
+      Match.value(stringOrNumber).pipe(
+        Match.when(Match.number, (n) => n),
+        Match.orElse((s) => s)
+      )
+    ).type.toBe<string | number>()
+  })
+
+  it("type matchers still return functions", () => {
+    expect(
+      Match.type<string | number>().pipe(
+        Match.when(Match.number, (n) => n),
+        Match.when(Match.string, (s) => s),
+        Match.exhaustive
+      )
+    ).type.toBe<(u: string | number) => string | number>()
+
+    expect(
+      Match.type<string | number>().pipe(
+        Match.when(Match.number, (n) => n),
+        Match.option
+      )
+    ).type.toBe<(u: string | number) => Option.Option<number>>()
+  })
+
+  it("exhaustiveness checking is preserved", () => {
+    expect(
+      Match.value(stringOrNumber).pipe(
+        Match.when(Match.number, (n) => n)
+      )
+    ).type.not.toBeAssignableTo<Parameters<typeof Match.exhaustive>[0]>()
+  })
+})

--- a/packages/effect/typetest/Match.tst.ts
+++ b/packages/effect/typetest/Match.tst.ts
@@ -107,10 +107,15 @@ describe("Match", () => {
   })
 
   it("exhaustiveness checking is preserved", () => {
-    expect(
-      Match.value(stringOrNumber).pipe(
-        Match.when(Match.number, (n) => n)
-      )
-    ).type.not.toBeAssignableTo<Parameters<typeof Match.exhaustive>[0]>()
+    const incomplete = Match.value(stringOrNumber).pipe(
+      Match.when(Match.number, (n) => n)
+    )
+    const complete = Match.value(stringOrNumber).pipe(
+      Match.when(Match.number, (n) => n),
+      Match.when(Match.string, (s) => s)
+    )
+    // @ts-expect-error Argument of type
+    Match.exhaustive(incomplete)
+    expect(Match.exhaustive(complete)).type.toBe<string | number>()
   })
 })


### PR DESCRIPTION
## Summary

`Match.value` on an input whose type contains a type parameter left terminal combinators with an unresolved `[Pr] extends [never]` conditional, so otherwise valid pipelines failed to typecheck:

```ts
type Closed = { readonly _tag: "Closed" }

const describe = <Open extends { readonly _tag: "Open" }>(
  state: Closed | Open,
  describeOpen: (open: Open) => string
): string =>
  Match.value(state).pipe(
    Match.tag("Closed", () => "closed"),
    Match.orElse((open) => describeOpen(open)) // error TS2322: unresolved conditional type
  )
```

The root cause is the sentinel encoding, not the conditional: `Match.value` put the input type `I` in the `Matcher` union's `Provided` slot, so when `I` mentions a type parameter, TypeScript rightly defers `[Pr] extends [never]` (the caller could instantiate the parameter with `never`).

## Fix

Re-encode the flavor sentinel as a non-generic flag, keeping every combinator signature and every `[Pr] extends [never]` conditional as-is:

- `Match.value` returns `Pr = "value"` (a fixed literal) instead of `I`, so terminal conditionals resolve eagerly even for generic inputs.
- `ValueMatcher` gains a trailing phantom parameter `out Pr = "value"` (surfaced as `_pr` in the variance record so terminals can still infer the flag), and keeps its real provided type via `Input`, which is identical anyway.
- The `Matcher` alias forwards its fifth argument into the new slot.

The alternative proposed in the issue (overloading terminals on `ValueMatcher` / `TypeMatcher`) was prototyped and rejected: TypeScript cannot infer through overloaded signatures inside `pipe`, which breaks currently-working non-generic pipelines.

Out of scope, per the issue: `tagsExhaustive` key-checking on a generic union fails separately because `Types.Tags` is a distributive conditional; that is a TypeScript limitation this change neither helps nor hurts.

## Compatibility note

The public meaning of `Matcher`'s fifth type argument for value matchers changes from "provided value type" to the `"value"` flag. Hand-written annotations like `Matcher<A, F, RA, R, A>` need to become `Matcher<A, F, RA, R, "value">`; type-matcher annotations (`Pr = never`) are unchanged. This is noted in the changeset.

## Testing

- New `packages/effect/typetest/Match.tst.ts` covering the issue's repros (generic input with `orElse`, `option`, `result`, free-function `pipe`), non-generic value pipelines, type-matcher pipelines, and a negative case confirming exhaustiveness checking still rejects incomplete matchers.
- `pnpm test-types Match.tst.ts`, `pnpm test --run packages/effect/test/Match.test.ts` (3/3), `pnpm doctest --run packages/effect/src/Match.ts` (54/54), full `pnpm check`, and `pnpm lint-fix` all pass.

Closes #7315
Closes EFF-696

🤖 Generated with [Claude Code](https://claude.com/claude-code)
