### PR TITLE
Fix OpenAPI HttpClient response matching

### DIFF
--- a/.changeset/openapi-response-variants.md
+++ b/.changeset/openapi-response-variants.md
@@ -1,0 +1,6 @@
+---
+"@effect/openapi-generator": patch
+---
+
+Fix HttpClient response generation for mixed JSON-compatible representations,
+binary success bodies, and bodiless error statuses.

--- a/packages/tools/openapi-generator/src/OpenApiGenerator.ts
+++ b/packages/tools/openapi-generator/src/OpenApiGenerator.ts
@@ -497,19 +497,16 @@ const parseOpenApi = (
 
         let jsonSchemaName: string | undefined
         if (isHttpApi) {
-          const jsonResponseEntry = Object.entries(content ?? {}).find(([contentType]) =>
-            isJsonMediaType(normalizeMediaType(contentType))
+          const jsonResponseEntry = Object.entries(content ?? {}).find(([contentType, mediaType]) =>
+            isJsonMediaType(normalizeMediaType(contentType)) &&
+            Predicate.isObject(mediaType) &&
+            Predicate.isNotUndefined(mediaType.schema)
           )
-          if (
-            Predicate.isNotUndefined(jsonResponseEntry) &&
-            Predicate.isObject(jsonResponseEntry[1]) &&
-            Predicate.isNotUndefined(jsonResponseEntry[1].schema)
-          ) {
-            const jsonResponseMediaType = jsonResponseEntry[1]
-            const jsonResponseSchema = jsonResponseMediaType.schema as JsonSchema.JsonSchema
-            jsonSchemaName = addSchema(`${schemaId}${status}`, jsonResponseSchema, op)
+          if (Predicate.isNotUndefined(jsonResponseEntry)) {
+            const [contentType, mediaType] = jsonResponseEntry
+            jsonSchemaName = addSchema(`${schemaId}${status}`, mediaType.schema as JsonSchema.JsonSchema, op)
             representable.push({
-              contentType: jsonResponseEntry[0],
+              contentType,
               encoding: "json",
               schema: jsonSchemaName
             })
@@ -618,23 +615,20 @@ const parseOpenApi = (
         }
 
         if (Predicate.isNotUndefined(jsonSchemaName)) {
-          const schemaName = jsonSchemaName
-
           if (status === "default" && !isHttpApi) {
-            defaultSchema = schemaName
+            defaultSchema = jsonSchemaName
             continue
           }
 
-          const statusMajorNumber = Number(parsedStatus[0])
-          if (Number.isNaN(statusMajorNumber)) {
+          if (Number.isNaN(Number(parsedStatus[0]))) {
             continue
           }
-          if (statusMajorNumber < 4) {
+          if (isSuccessStatus(parsedStatus)) {
             if (!httpClientResponses.binarySuccessStatuses.has(normalizedStatus)) {
-              httpClientResponses.successSchemas.set(normalizedStatus, schemaName)
+              httpClientResponses.successSchemas.set(normalizedStatus, jsonSchemaName)
             }
           } else {
-            httpClientResponses.errorSchemas.set(normalizedStatus, schemaName)
+            httpClientResponses.errorSchemas.set(normalizedStatus, jsonSchemaName)
           }
         }
 

--- a/packages/tools/openapi-generator/src/OpenApiGenerator.ts
+++ b/packages/tools/openapi-generator/src/OpenApiGenerator.ts
@@ -496,14 +496,19 @@ const parseOpenApi = (
         const representable: Array<ParsedOperation.ParsedOperationMediaTypeSchema> = []
 
         let jsonSchemaName: string | undefined
+        let jsonResponseContentType: string | undefined
         if (isHttpApi) {
-          const jsonResponseEntry = Object.entries(content ?? {}).find(([contentType, mediaType]) =>
+          const jsonResponseEntries = Object.entries(content ?? {}).filter(([contentType, mediaType]) =>
             isJsonMediaType(normalizeMediaType(contentType)) &&
             Predicate.isObject(mediaType) &&
             Predicate.isNotUndefined(mediaType.schema)
           )
+          const jsonResponseEntry = jsonResponseEntries.find(([contentType]) =>
+            normalizeMediaType(contentType) === "application/json"
+          ) ?? jsonResponseEntries[0]
           if (Predicate.isNotUndefined(jsonResponseEntry)) {
             const [contentType, mediaType] = jsonResponseEntry
+            jsonResponseContentType = contentType
             jsonSchemaName = addSchema(`${schemaId}${status}`, mediaType.schema as JsonSchema.JsonSchema, op)
             representable.push({
               contentType,
@@ -530,7 +535,7 @@ const parseOpenApi = (
 
         if (isHttpApi) {
           for (const [contentType, mediaType] of Object.entries(content ?? {})) {
-            if (isJsonMediaType(normalizeMediaType(contentType))) {
+            if (contentType === jsonResponseContentType) {
               continue
             }
             if (!Predicate.isObject(mediaType)) {

--- a/packages/tools/openapi-generator/src/OpenApiGenerator.ts
+++ b/packages/tools/openapi-generator/src/OpenApiGenerator.ts
@@ -495,10 +495,24 @@ const parseOpenApi = (
         const representable: Array<ParsedOperation.ParsedOperationMediaTypeSchema> = []
 
         let jsonSchemaName: string | undefined
-        const jsonResponseSchema = content?.["application/json"]?.schema
-        if (Predicate.isNotUndefined(jsonResponseSchema)) {
-          jsonSchemaName = addSchema(`${schemaId}${status}`, jsonResponseSchema, op)
-          if (isHttpApi) {
+        const jsonResponses = Object.entries(content ?? {}).filter(
+          (entry): entry is [string, Record<string, any> & { schema: JsonSchema.JsonSchema }] =>
+            isJsonMediaType(entry[0].toLowerCase()) &&
+            Predicate.isObject(entry[1]) &&
+            Predicate.isNotUndefined(entry[1].schema)
+        )
+        if (!isHttpApi && jsonResponses.length > 0) {
+          jsonSchemaName = addSchema(
+            `${schemaId}${status}`,
+            jsonResponses.length === 1
+              ? jsonResponses[0][1].schema
+              : { anyOf: jsonResponses.map(([, mediaType]) => mediaType.schema) },
+            op
+          )
+        } else if (isHttpApi) {
+          const jsonResponseSchema = content?.["application/json"]?.schema
+          if (Predicate.isNotUndefined(jsonResponseSchema)) {
+            jsonSchemaName = addSchema(`${schemaId}${status}`, jsonResponseSchema, op)
             representable.push({
               contentType: "application/json",
               encoding: "json",
@@ -625,16 +639,26 @@ const parseOpenApi = (
           }
         }
 
-        if (Predicate.isNotUndefined(content?.["application/octet-stream"])) {
+        const hasBinaryResponse = Object.entries(content ?? {}).some(([contentType, mediaType]) =>
+          Predicate.isObject(mediaType) &&
+          (isBinaryMediaType(contentType.toLowerCase()) || isBinarySchema(mediaType.schema))
+        )
+        if (hasBinaryResponse) {
           const statusMajorNumber = Number(parsedStatus[0])
           if (!Number.isNaN(statusMajorNumber) && statusMajorNumber < 4) {
             op.binaryResponse = true
+            op.binarySuccessStatuses.add(parsedStatus.toLowerCase())
           }
         }
 
         if (isEmptyResponse) {
           if (parsedStatus !== "default") {
-            op.voidSchemas.add(parsedStatus.toLowerCase())
+            const normalizedStatus = parsedStatus.toLowerCase()
+            if (isErrorStatus(normalizedStatus)) {
+              op.voidErrorStatuses.add(normalizedStatus)
+            } else {
+              op.voidSchemas.add(normalizedStatus)
+            }
           }
         }
       }
@@ -924,7 +948,30 @@ const isTextMediaType = (contentType: string): boolean => contentType.startsWith
 
 const isBinaryMediaType = (contentType: string): boolean =>
   contentType === "application/octet-stream" ||
-  (contentType.startsWith("application/") && (contentType.includes("binary") || contentType.endsWith("+octet-stream")))
+  contentType === "application/pdf" ||
+  contentType === "application/zip" ||
+  contentType === "application/gzip" ||
+  contentType === "application/x-gzip" ||
+  contentType === "application/x-tar" ||
+  contentType === "application/x-zip-compressed" ||
+  contentType.startsWith("image/") ||
+  contentType.startsWith("audio/") ||
+  contentType.startsWith("video/") ||
+  contentType.startsWith("font/") ||
+  (contentType.startsWith("application/") &&
+    (contentType.includes("binary") ||
+      contentType.endsWith("+octet-stream") ||
+      contentType.endsWith("+zip") ||
+      contentType.endsWith("+gzip")))
+
+const isBinarySchema = (schema: unknown): boolean =>
+  Predicate.isObject(schema) &&
+  (
+    (typeof schema.format === "string" && schema.format.toLowerCase() === "binary") ||
+    (typeof schema.contentEncoding === "string" && schema.contentEncoding.toLowerCase() === "binary")
+  )
+
+const isErrorStatus = (status: string): boolean => status.startsWith("4") || status.startsWith("5")
 
 const getRequestMediaTypeEncoding = (
   contentType: string

--- a/packages/tools/openapi-generator/src/OpenApiGenerator.ts
+++ b/packages/tools/openapi-generator/src/OpenApiGenerator.ts
@@ -265,6 +265,7 @@ const parseOpenApi = (
         pathIds,
         pathTemplate
       })
+      const httpClientResponses = op.httpClientResponses
       op.path = path
       op.operationId = Utils.nonEmptyString(operation.operationId)
       op.tags = [...(operation.tags ?? [])]
@@ -613,23 +614,24 @@ const parseOpenApi = (
             continue
           }
           if (statusMajorNumber < 4) {
-            op.successSchemas.set(statusLower, schemaName)
+            httpClientResponses.successSchemas.set(statusLower, schemaName)
           } else {
-            op.errorSchemas.set(statusLower, schemaName)
+            httpClientResponses.errorSchemas.set(statusLower, schemaName)
           }
         }
 
         const sseMediaType = content?.["text/event-stream"]
         const sseResponseSchema = sseMediaType?.schema
         if (
-          !isHttpApi && Predicate.isUndefined(op.sseSchema) && Predicate.isNotUndefined(sseResponseSchema) &&
+          !isHttpApi && Predicate.isUndefined(httpClientResponses.sseSchema) &&
+          Predicate.isNotUndefined(sseResponseSchema) &&
           isSuccessStatus(parsedStatus)
         ) {
           const effectStream = sseMediaType["x-effect-stream"]
-          op.sseSchemaMode = getEffectStreamEncoding(sseMediaType) === "sse" ? "event" : "data"
-          op.sseSchema = addSchema(
+          httpClientResponses.sseSchemaMode = getEffectStreamEncoding(sseMediaType) === "sse" ? "event" : "data"
+          httpClientResponses.sseSchema = addSchema(
             `${schemaId}${status}Sse`,
-            op.sseSchemaMode === "event"
+            httpClientResponses.sseSchemaMode === "event"
               ? makeSseEventSchema(
                 resolveReference(sseResponseSchema, resolveRef),
                 effectStream?.encoding === "sse" ? effectStream.failureEvent : undefined
@@ -644,22 +646,23 @@ const parseOpenApi = (
           (isBinaryMediaType(contentType.toLowerCase()) || isBinarySchema(mediaType.schema))
         )
         if (hasBinaryResponse && isSuccessStatus(parsedStatus)) {
-          op.binaryResponse = true
-          op.binarySuccessStatuses.add(parsedStatus.toLowerCase())
+          httpClientResponses.binarySuccessStatuses.add(parsedStatus.toLowerCase())
         }
 
         if (isEmptyResponse && parsedStatus !== "default") {
           const normalizedStatus = parsedStatus.toLowerCase()
           if (isErrorStatus(normalizedStatus)) {
-            op.voidErrorStatuses.add(normalizedStatus)
+            httpClientResponses.voidErrorStatuses.add(normalizedStatus)
           } else {
-            op.voidSchemas.add(normalizedStatus)
+            httpClientResponses.voidSuccessStatuses.add(normalizedStatus)
           }
         }
       }
 
-      if (!isHttpApi && op.successSchemas.size === 0 && Predicate.isNotUndefined(defaultSchema)) {
-        op.successSchemas.set("2xx", defaultSchema)
+      if (
+        !isHttpApi && httpClientResponses.successSchemas.size === 0 && Predicate.isNotUndefined(defaultSchema)
+      ) {
+        httpClientResponses.successSchemas.set("2xx", defaultSchema)
         warnForOperation(emitWarning, op, {
           code: "default-response-remapped",
           message: "Default response was remapped to 2xx for the current HttpClient outputs."

--- a/packages/tools/openapi-generator/src/OpenApiGenerator.ts
+++ b/packages/tools/openapi-generator/src/OpenApiGenerator.ts
@@ -495,21 +495,7 @@ const parseOpenApi = (
         const representable: Array<ParsedOperation.ParsedOperationMediaTypeSchema> = []
 
         let jsonSchemaName: string | undefined
-        const jsonResponses = Object.entries(content ?? {}).filter(
-          (entry): entry is [string, Record<string, any> & { schema: JsonSchema.JsonSchema }] =>
-            isJsonMediaType(entry[0].toLowerCase()) &&
-            Predicate.isObject(entry[1]) &&
-            Predicate.isNotUndefined(entry[1].schema)
-        )
-        if (!isHttpApi && jsonResponses.length > 0) {
-          jsonSchemaName = addSchema(
-            `${schemaId}${status}`,
-            jsonResponses.length === 1
-              ? jsonResponses[0][1].schema
-              : { anyOf: jsonResponses.map(([, mediaType]) => mediaType.schema) },
-            op
-          )
-        } else if (isHttpApi) {
+        if (isHttpApi) {
           const jsonResponseSchema = content?.["application/json"]?.schema
           if (Predicate.isNotUndefined(jsonResponseSchema)) {
             jsonSchemaName = addSchema(`${schemaId}${status}`, jsonResponseSchema, op)
@@ -518,6 +504,21 @@ const parseOpenApi = (
               encoding: "json",
               schema: jsonSchemaName
             })
+          }
+        } else {
+          const jsonSchemas = Object.entries(content ?? {}).flatMap(([contentType, mediaType]) =>
+            isJsonMediaType(contentType.toLowerCase()) &&
+              Predicate.isObject(mediaType) &&
+              Predicate.isNotUndefined(mediaType.schema)
+              ? [mediaType.schema as JsonSchema.JsonSchema]
+              : []
+          )
+          if (jsonSchemas.length > 0) {
+            jsonSchemaName = addSchema(
+              `${schemaId}${status}`,
+              jsonSchemas.length === 1 ? jsonSchemas[0] : { anyOf: jsonSchemas },
+              op
+            )
           }
         }
 
@@ -530,8 +531,7 @@ const parseOpenApi = (
               continue
             }
 
-            const statusMajorNumber = Number(parsedStatus[0])
-            const streamEncoding = !Number.isNaN(statusMajorNumber) && statusMajorNumber < 4
+            const streamEncoding = isSuccessStatus(parsedStatus)
               ? getEffectStreamEncoding(mediaType)
               : undefined
             if (streamEncoding === "uint8array") {
@@ -621,44 +621,39 @@ const parseOpenApi = (
 
         const sseMediaType = content?.["text/event-stream"]
         const sseResponseSchema = sseMediaType?.schema
-        if (!isHttpApi && Predicate.isUndefined(op.sseSchema) && Predicate.isNotUndefined(sseResponseSchema)) {
-          const statusMajorNumber = Number(parsedStatus[0])
-          if (!Number.isNaN(statusMajorNumber) && statusMajorNumber < 4) {
-            const effectStream = sseMediaType["x-effect-stream"]
-            op.sseSchemaMode = getEffectStreamEncoding(sseMediaType) === "sse" ? "event" : "data"
-            op.sseSchema = addSchema(
-              `${schemaId}${status}Sse`,
-              op.sseSchemaMode === "event"
-                ? makeSseEventSchema(
-                  resolveReference(sseResponseSchema, resolveRef),
-                  effectStream?.encoding === "sse" ? effectStream.failureEvent : undefined
-                )
-                : sseResponseSchema,
-              op
-            )
-          }
+        if (
+          !isHttpApi && Predicate.isUndefined(op.sseSchema) && Predicate.isNotUndefined(sseResponseSchema) &&
+          isSuccessStatus(parsedStatus)
+        ) {
+          const effectStream = sseMediaType["x-effect-stream"]
+          op.sseSchemaMode = getEffectStreamEncoding(sseMediaType) === "sse" ? "event" : "data"
+          op.sseSchema = addSchema(
+            `${schemaId}${status}Sse`,
+            op.sseSchemaMode === "event"
+              ? makeSseEventSchema(
+                resolveReference(sseResponseSchema, resolveRef),
+                effectStream?.encoding === "sse" ? effectStream.failureEvent : undefined
+              )
+              : sseResponseSchema,
+            op
+          )
         }
 
         const hasBinaryResponse = Object.entries(content ?? {}).some(([contentType, mediaType]) =>
           Predicate.isObject(mediaType) &&
           (isBinaryMediaType(contentType.toLowerCase()) || isBinarySchema(mediaType.schema))
         )
-        if (hasBinaryResponse) {
-          const statusMajorNumber = Number(parsedStatus[0])
-          if (!Number.isNaN(statusMajorNumber) && statusMajorNumber < 4) {
-            op.binaryResponse = true
-            op.binarySuccessStatuses.add(parsedStatus.toLowerCase())
-          }
+        if (hasBinaryResponse && isSuccessStatus(parsedStatus)) {
+          op.binaryResponse = true
+          op.binarySuccessStatuses.add(parsedStatus.toLowerCase())
         }
 
-        if (isEmptyResponse) {
-          if (parsedStatus !== "default") {
-            const normalizedStatus = parsedStatus.toLowerCase()
-            if (isErrorStatus(normalizedStatus)) {
-              op.voidErrorStatuses.add(normalizedStatus)
-            } else {
-              op.voidSchemas.add(normalizedStatus)
-            }
+        if (isEmptyResponse && parsedStatus !== "default") {
+          const normalizedStatus = parsedStatus.toLowerCase()
+          if (isErrorStatus(normalizedStatus)) {
+            op.voidErrorStatuses.add(normalizedStatus)
+          } else {
+            op.voidSchemas.add(normalizedStatus)
           }
         }
       }
@@ -946,18 +941,21 @@ const isJsonMediaType = (contentType: string): boolean =>
 
 const isTextMediaType = (contentType: string): boolean => contentType.startsWith("text/")
 
+const binaryMediaTypes = new Set([
+  "application/octet-stream",
+  "application/pdf",
+  "application/zip",
+  "application/gzip",
+  "application/x-gzip",
+  "application/x-tar",
+  "application/x-zip-compressed"
+])
+
+const binaryMediaTypePrefixes = ["image/", "audio/", "video/", "font/"]
+
 const isBinaryMediaType = (contentType: string): boolean =>
-  contentType === "application/octet-stream" ||
-  contentType === "application/pdf" ||
-  contentType === "application/zip" ||
-  contentType === "application/gzip" ||
-  contentType === "application/x-gzip" ||
-  contentType === "application/x-tar" ||
-  contentType === "application/x-zip-compressed" ||
-  contentType.startsWith("image/") ||
-  contentType.startsWith("audio/") ||
-  contentType.startsWith("video/") ||
-  contentType.startsWith("font/") ||
+  binaryMediaTypes.has(contentType) ||
+  binaryMediaTypePrefixes.some((prefix) => contentType.startsWith(prefix)) ||
   (contentType.startsWith("application/") &&
     (contentType.includes("binary") ||
       contentType.endsWith("+octet-stream") ||
@@ -972,6 +970,11 @@ const isBinarySchema = (schema: unknown): boolean =>
   )
 
 const isErrorStatus = (status: string): boolean => status.startsWith("4") || status.startsWith("5")
+
+const isSuccessStatus = (status: string): boolean => {
+  const statusMajorNumber = Number(status[0])
+  return !Number.isNaN(statusMajorNumber) && statusMajorNumber < 4
+}
 
 const getRequestMediaTypeEncoding = (
   contentType: string

--- a/packages/tools/openapi-generator/src/OpenApiGenerator.ts
+++ b/packages/tools/openapi-generator/src/OpenApiGenerator.ts
@@ -497,18 +497,26 @@ const parseOpenApi = (
 
         let jsonSchemaName: string | undefined
         if (isHttpApi) {
-          const jsonResponseSchema = content?.["application/json"]?.schema
-          if (Predicate.isNotUndefined(jsonResponseSchema)) {
+          const jsonResponseEntry = Object.entries(content ?? {}).find(([contentType]) =>
+            isJsonMediaType(normalizeMediaType(contentType))
+          )
+          if (
+            Predicate.isNotUndefined(jsonResponseEntry) &&
+            Predicate.isObject(jsonResponseEntry[1]) &&
+            Predicate.isNotUndefined(jsonResponseEntry[1].schema)
+          ) {
+            const jsonResponseMediaType = jsonResponseEntry[1]
+            const jsonResponseSchema = jsonResponseMediaType.schema as JsonSchema.JsonSchema
             jsonSchemaName = addSchema(`${schemaId}${status}`, jsonResponseSchema, op)
             representable.push({
-              contentType: "application/json",
+              contentType: jsonResponseEntry[0],
               encoding: "json",
               schema: jsonSchemaName
             })
           }
         } else {
           const jsonSchemas = Object.entries(content ?? {}).flatMap(([contentType, mediaType]) =>
-            isJsonMediaType(contentType.toLowerCase()) &&
+            isJsonMediaType(normalizeMediaType(contentType)) &&
               Predicate.isObject(mediaType) &&
               Predicate.isNotUndefined(mediaType.schema)
               ? [mediaType.schema as JsonSchema.JsonSchema]
@@ -525,7 +533,7 @@ const parseOpenApi = (
 
         if (isHttpApi) {
           for (const [contentType, mediaType] of Object.entries(content ?? {})) {
-            if (contentType === "application/json") {
+            if (isJsonMediaType(normalizeMediaType(contentType))) {
               continue
             }
             if (!Predicate.isObject(mediaType)) {
@@ -600,6 +608,15 @@ const parseOpenApi = (
           op.defaultResponse = parsedResponse
         }
 
+        const normalizedStatus = parsedStatus.toLowerCase()
+        const hasBinaryResponse = Object.entries(content ?? {}).some(([contentType, mediaType]) =>
+          Predicate.isObject(mediaType) &&
+          (isBinaryMediaType(normalizeMediaType(contentType)) || isBinarySchema(mediaType.schema))
+        )
+        if (hasBinaryResponse && isSuccessStatus(parsedStatus)) {
+          httpClientResponses.binarySuccessStatuses.add(normalizedStatus)
+        }
+
         if (Predicate.isNotUndefined(jsonSchemaName)) {
           const schemaName = jsonSchemaName
 
@@ -608,15 +625,16 @@ const parseOpenApi = (
             continue
           }
 
-          const statusLower = parsedStatus.toLowerCase()
           const statusMajorNumber = Number(parsedStatus[0])
           if (Number.isNaN(statusMajorNumber)) {
             continue
           }
           if (statusMajorNumber < 4) {
-            httpClientResponses.successSchemas.set(statusLower, schemaName)
+            if (!httpClientResponses.binarySuccessStatuses.has(normalizedStatus)) {
+              httpClientResponses.successSchemas.set(normalizedStatus, schemaName)
+            }
           } else {
-            httpClientResponses.errorSchemas.set(statusLower, schemaName)
+            httpClientResponses.errorSchemas.set(normalizedStatus, schemaName)
           }
         }
 
@@ -641,20 +659,11 @@ const parseOpenApi = (
           )
         }
 
-        const hasBinaryResponse = Object.entries(content ?? {}).some(([contentType, mediaType]) =>
-          Predicate.isObject(mediaType) &&
-          (isBinaryMediaType(contentType.toLowerCase()) || isBinarySchema(mediaType.schema))
-        )
-        if (hasBinaryResponse && isSuccessStatus(parsedStatus)) {
-          httpClientResponses.binarySuccessStatuses.add(parsedStatus.toLowerCase())
-        }
-
         if (isEmptyResponse && parsedStatus !== "default") {
-          const normalizedStatus = parsedStatus.toLowerCase()
-          if (isErrorStatus(normalizedStatus)) {
-            httpClientResponses.voidErrorStatuses.add(normalizedStatus)
-          } else {
+          if (isSuccessStatus(normalizedStatus)) {
             httpClientResponses.voidSuccessStatuses.add(normalizedStatus)
+          } else {
+            httpClientResponses.voidErrorStatuses.add(normalizedStatus)
           }
         }
       }
@@ -942,6 +951,8 @@ const isJsonMediaType = (contentType: string): boolean =>
   contentType === "application/json" ||
   (contentType.startsWith("application/") && contentType.endsWith("+json"))
 
+const normalizeMediaType = (contentType: string): string => contentType.toLowerCase().split(";", 1)[0].trim()
+
 const isTextMediaType = (contentType: string): boolean => contentType.startsWith("text/")
 
 const binaryMediaTypes = new Set([
@@ -972,8 +983,6 @@ const isBinarySchema = (schema: unknown): boolean =>
     (typeof schema.contentEncoding === "string" && schema.contentEncoding.toLowerCase() === "binary")
   )
 
-const isErrorStatus = (status: string): boolean => status.startsWith("4") || status.startsWith("5")
-
 const isSuccessStatus = (status: string): boolean => {
   const statusMajorNumber = Number(status[0])
   return !Number.isNaN(statusMajorNumber) && statusMajorNumber < 4
@@ -982,7 +991,7 @@ const isSuccessStatus = (status: string): boolean => {
 const getRequestMediaTypeEncoding = (
   contentType: string
 ): ParsedOperation.ParsedOperationMediaTypeEncoding | undefined => {
-  const normalized = contentType.toLowerCase()
+  const normalized = normalizeMediaType(contentType)
   if (isJsonMediaType(normalized)) {
     return "json"
   }
@@ -1004,7 +1013,7 @@ const getRequestMediaTypeEncoding = (
 const getResponseMediaTypeEncoding = (
   contentType: string
 ): ParsedOperation.ParsedOperationMediaTypeEncoding | undefined => {
-  const normalized = contentType.toLowerCase()
+  const normalized = normalizeMediaType(contentType)
   if (isJsonMediaType(normalized)) {
     return "json"
   }

--- a/packages/tools/openapi-generator/src/OpenApiTransformer.ts
+++ b/packages/tools/openapi-generator/src/OpenApiTransformer.ts
@@ -670,17 +670,16 @@ ${clientErrorSource(name)}`
     if (requirements.eventStream) {
       helpers.push(sseRequestSourceTs)
     }
-    if (requirements.octetStream) {
-      helpers.push(decodeBinarySource)
-      helpers.push(binaryRequestSourceTs)
-    }
     const hasResponseVariants = operations.some((operation) =>
       operation.binarySuccessStatuses.size > 0 || operation.voidErrorStatuses.size > 0
     )
+    if (requirements.octetStream || hasResponseVariants) {
+      helpers.push(decodeBinarySource)
+    }
+    if (requirements.octetStream) {
+      helpers.push(binaryRequestSourceTs)
+    }
     if (hasResponseVariants) {
-      if (!requirements.octetStream) {
-        helpers.push(decodeBinarySource)
-      }
       helpers.push(decodeVoidErrorSource(name))
     }
 
@@ -729,7 +728,7 @@ export const make = (
         response.json as Effect.Effect<E, HttpClientError.HttpClientError>,
         (cause) => Effect.fail(${name}Error(tag, cause, response)),
       )
-  ${hasResponseVariants ? onRequestWithVariantsSource : onRequestSource}
+  ${onRequestSource(hasResponseVariants)}
   return {
     httpClient,
     ${implMethods.join(",\n    ")}
@@ -778,8 +777,8 @@ export const make = (
     const errorCodes = operation.errorSchemas.size > 0 &&
       Object.fromEntries(operation.errorSchemas.entries())
     const configAccessor = resolveConfigAccessor(operation, "options", "config")
-    const usesResponseVariants = operation.binarySuccessStatuses.size > 0 || operation.voidErrorStatuses.size > 0
-    if (usesResponseVariants) {
+    const requestArgs = [`[${singleSuccessCode ? `"2xx"` : successCodes}]`]
+    if (operation.binarySuccessStatuses.size > 0 || operation.voidErrorStatuses.size > 0) {
       const binaryCodesRaw = Array.from(operation.binarySuccessStatuses)
       const singleBinarySuccessCode = binaryCodesRaw.length === 1 &&
         binaryCodesRaw[0].startsWith("2") &&
@@ -790,18 +789,11 @@ export const make = (
         void: Array.from(operation.voidSchemas),
         voidError: Array.from(operation.voidErrorStatuses)
       }
-      pipeline.push(
-        `onRequest(${configAccessor})([${singleSuccessCode ? `"2xx"` : successCodes}], ${
-          errorCodes ? JSON.stringify(errorCodes) : "undefined"
-        }, ${JSON.stringify(responseCodes)})`
-      )
-    } else {
-      pipeline.push(
-        `onRequest(${configAccessor})([${singleSuccessCode ? `"2xx"` : successCodes}]${
-          errorCodes ? `, ${JSON.stringify(errorCodes)}` : ""
-        })`
-      )
+      requestArgs.push(errorCodes ? JSON.stringify(errorCodes) : "undefined", JSON.stringify(responseCodes))
+    } else if (errorCodes) {
+      requestArgs.push(JSON.stringify(errorCodes))
     }
+    pipeline.push(`onRequest(${configAccessor})(${requestArgs.join(", ")})`)
 
     return (
       `"${operation.id}": (${params}) => ` +
@@ -972,43 +964,17 @@ const decodeVoidErrorSource = (name: string) =>
     (response: HttpClientResponse.HttpClientResponse) =>
       Effect.fail(${name}Error(tag, undefined, response))`
 
-const onRequestSource = `const onRequest = <Config extends OperationConfig>(config: Config | undefined) => (
-    successCodes: ReadonlyArray<string>,
-    errorCodes?: Record<string, string>,
-  ) => {
-    const cases: any = { orElse: unexpectedStatus }
-    for (const code of successCodes) {
-      cases[code] = decodeSuccess
-    }
-    if (errorCodes) {
-      for (const [code, tag] of Object.entries(errorCodes)) {
-        cases[code] = decodeError(tag)
-      }
-    }
-    if (successCodes.length === 0) {
-      cases["2xx"] = decodeVoid
-    }
-    return withResponse(config)(HttpClientResponse.matchStatus(cases) as any)
-  }`
-
-const onRequestWithVariantsSource = `const onRequest = <Config extends OperationConfig>(config: Config | undefined) => (
-    successCodes: ReadonlyArray<string>,
-    errorCodes: Record<string, string> | undefined = undefined,
+const onRequestSource = (withResponseVariants: boolean) => {
+  const responseCodesParam = withResponseVariants
+    ? `
     responseCodes: {
       readonly binary: ReadonlyArray<string>
       readonly void: ReadonlyArray<string>
       readonly voidError: ReadonlyArray<string>
-    } = { binary: [], void: [], voidError: [] },
-  ) => {
-    const cases: any = { orElse: unexpectedStatus }
-    for (const code of successCodes) {
-      cases[code] = decodeSuccess
-    }
-    if (errorCodes) {
-      for (const [code, tag] of Object.entries(errorCodes)) {
-        cases[code] = decodeError(tag)
-      }
-    }
+    } = { binary: [], void: [], voidError: [] },`
+    : ""
+  const responseCodesCases = withResponseVariants
+    ? `
     for (const code of responseCodes.binary) {
       cases[code] = decodeBinary
     }
@@ -1017,12 +983,30 @@ const onRequestWithVariantsSource = `const onRequest = <Config extends Operation
     }
     for (const code of responseCodes.voidError) {
       cases[code] = decodeVoidError(code)
+    }`
+    : ""
+  const voidFallbackCondition = withResponseVariants
+    ? "successCodes.length === 0 && responseCodes.binary.length === 0 && responseCodes.void.length === 0"
+    : "successCodes.length === 0"
+  return `const onRequest = <Config extends OperationConfig>(config: Config | undefined) => (
+    successCodes: ReadonlyArray<string>,
+    errorCodes?: Record<string, string>,${responseCodesParam}
+  ) => {
+    const cases: any = { orElse: unexpectedStatus }
+    for (const code of successCodes) {
+      cases[code] = decodeSuccess
     }
-    if (successCodes.length === 0 && responseCodes.binary.length === 0 && responseCodes.void.length === 0) {
+    if (errorCodes) {
+      for (const [code, tag] of Object.entries(errorCodes)) {
+        cases[code] = decodeError(tag)
+      }
+    }${responseCodesCases}
+    if (${voidFallbackCondition}) {
       cases["2xx"] = decodeVoid
     }
     return withResponse(config)(HttpClientResponse.matchStatus(cases) as any)
   }`
+}
 
 const sseRequestSource = (_importName: string) =>
   `const sseRequest = <

--- a/packages/tools/openapi-generator/src/OpenApiTransformer.ts
+++ b/packages/tools/openapi-generator/src/OpenApiTransformer.ts
@@ -51,15 +51,16 @@ const computeImportRequirements = (operations: ReadonlyArray<ParsedOperation>): 
   let eventStreamSchema = false
   let octetStream = false
   for (const op of operations) {
-    if (op.sseSchema) {
+    const responses = op.httpClientResponses
+    if (responses.sseSchema) {
       eventStream = true
-      if (op.sseSchemaMode === "event") {
+      if (responses.sseSchemaMode === "event") {
         eventStreamSchema = true
       } else {
         eventStreamData = true
       }
     }
-    if (op.binaryResponse) {
+    if (responses.binarySuccessStatuses.size > 0) {
       octetStream = true
     }
   }
@@ -90,10 +91,10 @@ export const makeTransformerSchema = () => {
     const methods: Array<string> = []
     for (const op of operations) {
       methods.push(operationToMethod(name, op))
-      if (op.sseSchema) {
+      if (op.httpClientResponses.sseSchema) {
         methods.push(operationToSseMethod(name, op))
       }
-      if (op.binaryResponse) {
+      if (op.httpClientResponses.binarySuccessStatuses.size > 0) {
         methods.push(operationToBinaryMethod(name, op))
       }
     }
@@ -106,6 +107,7 @@ ${clientErrorSource(name)}`
   }
 
   const operationToMethod = (name: string, operation: ParsedOperation) => {
+    const responses = operation.httpClientResponses
     const args: Array<string> = []
     if (operation.pathIds.length > 0) {
       Utils.spreadElementsInto(operation.pathIds.map((id) => `${id}: string`), args)
@@ -132,22 +134,24 @@ ${clientErrorSource(name)}`
       args.push(`options: { ${options.join("; ")} } | undefined`)
     }
 
-    const successTypes = Array.from(operation.successSchemas.values())
-      .map((schema) => `typeof ${schema}.Type`)
-    if (operation.binarySuccessStatuses.size > 0) {
-      successTypes.push("Uint8Array")
+    const successTypes = new Set(Array.from(responses.successSchemas.values(), (schema) => `typeof ${schema}.Type`))
+    if (responses.binarySuccessStatuses.size > 0) {
+      successTypes.add("Uint8Array")
     }
-    const success = successTypes.length > 0 ? successTypes.join(" | ") : "void"
+    if (responses.voidSuccessStatuses.size > 0) {
+      successTypes.add("void")
+    }
+    const success = successTypes.size > 0 ? Array.from(successTypes).join(" | ") : "void"
     const errors = ["HttpClientError.HttpClientError", "SchemaError"]
-    if (operation.errorSchemas.size > 0) {
+    if (responses.errorSchemas.size > 0) {
       Utils.spreadElementsInto(
-        Array.from(operation.errorSchemas.values()).map(
+        Array.from(responses.errorSchemas.values()).map(
           (schema) => `${name}Error<"${schema}", typeof ${schema}.Type>`
         ),
         errors
       )
     }
-    for (const status of operation.voidErrorStatuses) {
+    for (const status of responses.voidErrorStatuses) {
       errors.push(`${name}Error<"${status}", undefined>`)
     }
 
@@ -160,6 +164,7 @@ ${clientErrorSource(name)}`
   }
 
   const operationToSseMethod = (_name: string, operation: ParsedOperation) => {
+    const responses = operation.httpClientResponses
     const args: Array<string> = []
     if (operation.pathIds.length > 0) {
       Utils.spreadElementsInto(operation.pathIds.map((id) => `${id}: string`), args)
@@ -185,11 +190,11 @@ ${clientErrorSource(name)}`
     const jsdoc = Utils.toComment(operation.description)
     const methodKey = `readonly "${operation.id}Sse"`
     const parameters = args.join(", ")
-    const value = operation.sseSchemaMode === "event"
-      ? `typeof ${operation.sseSchema}.Type`
-      : `{ readonly event: string; readonly id: string | undefined; readonly data: typeof ${operation.sseSchema}.Type }`
+    const value = responses.sseSchemaMode === "event"
+      ? `typeof ${responses.sseSchema}.Type`
+      : `{ readonly event: string; readonly id: string | undefined; readonly data: typeof ${responses.sseSchema}.Type }`
     const returnType =
-      `Stream.Stream<${value}, HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError, typeof ${operation.sseSchema}.DecodingServices>`
+      `Stream.Stream<${value}, HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError, typeof ${responses.sseSchema}.DecodingServices>`
     return `${jsdoc}${methodKey}: (${parameters}) => ${returnType}`
   }
 
@@ -232,10 +237,10 @@ ${clientErrorSource(name)}`
     const implMethods: Array<string> = []
     for (const op of operations) {
       implMethods.push(operationToImpl(op))
-      if (op.sseSchema) {
+      if (op.httpClientResponses.sseSchema) {
         implMethods.push(operationToSseImpl(importName, op))
       }
-      if (op.binaryResponse) {
+      if (op.httpClientResponses.binarySuccessStatuses.size > 0) {
         implMethods.push(operationToBinaryImpl(op))
       }
     }
@@ -251,7 +256,7 @@ ${clientErrorSource(name)}`
       helpers.push(decodeBinarySource)
       helpers.push(binaryRequestSource)
     }
-    if (operations.some((operation) => operation.voidErrorStatuses.size > 0)) {
+    if (operations.some((operation) => operation.httpClientResponses.voidErrorStatuses.size > 0)) {
       helpers.push(decodeVoidErrorSource(name))
     }
     return `export interface OperationConfig {
@@ -302,6 +307,7 @@ export const make = (
   }
 
   const operationToImpl = (operation: ParsedOperation) => {
+    const responses = operation.httpClientResponses
     const args: Array<string> = [...operation.pathIds, "options"]
     const params = `${args.join(", ")}`
 
@@ -334,27 +340,27 @@ export const make = (
     }
 
     const decodes: Array<string> = []
-    const singleSuccessCode = operation.successSchemas.size === 1 &&
-      operation.binarySuccessStatuses.size === 0 &&
-      operation.voidSchemas.size === 0
-    operation.successSchemas.forEach((schema, status) => {
+    const singleSuccessCode = responses.successSchemas.size === 1 &&
+      responses.binarySuccessStatuses.size === 0 &&
+      responses.voidSuccessStatuses.size === 0
+    responses.successSchemas.forEach((schema, status) => {
       const statusCode = singleSuccessCode && status.startsWith("2") ? "2xx" : status
       decodes.push(`"${statusCode}": decodeSuccess(${schema})`)
     })
-    const singleBinarySuccessCode = operation.binarySuccessStatuses.size === 1 &&
-      operation.successSchemas.size === 0 &&
-      operation.voidSchemas.size === 0
-    operation.binarySuccessStatuses.forEach((status) => {
+    const singleBinarySuccessCode = responses.binarySuccessStatuses.size === 1 &&
+      responses.successSchemas.size === 0 &&
+      responses.voidSuccessStatuses.size === 0
+    responses.binarySuccessStatuses.forEach((status) => {
       const statusCode = singleBinarySuccessCode && status.startsWith("2") ? "2xx" : status
       decodes.push(`"${statusCode}": decodeBinary`)
     })
-    operation.errorSchemas.forEach((schema, status) => {
+    responses.errorSchemas.forEach((schema, status) => {
       decodes.push(`"${status}": decodeError("${schema}", ${schema})`)
     })
-    operation.voidSchemas.forEach((status) => {
+    responses.voidSuccessStatuses.forEach((status) => {
       decodes.push(`"${status}": () => Effect.void`)
     })
-    operation.voidErrorStatuses.forEach((status) => {
+    responses.voidErrorStatuses.forEach((status) => {
       decodes.push(`"${status}": decodeVoidError("${status}")`)
     })
     decodes.push(`orElse: unexpectedStatus`)
@@ -372,6 +378,7 @@ export const make = (
   }
 
   const operationToSseImpl = (_importName: string, operation: ParsedOperation) => {
+    const responses = operation.httpClientResponses
     const args: Array<string> = [...operation.pathIds]
     const hasOptions = (operation.params && !operation.paramsOptional) || operation.payload
     if (hasOptions || operation.params || operation.payload) {
@@ -403,7 +410,7 @@ export const make = (
       pipeline.push(`HttpClientRequest.bodyJsonUnsafe(options.payload)`)
     }
 
-    pipeline.push(`${operation.sseSchemaMode === "event" ? "sseEventRequest" : "sseRequest"}(${operation.sseSchema})`)
+    pipeline.push(`${responses.sseSchemaMode === "event" ? "sseEventRequest" : "sseRequest"}(${responses.sseSchema})`)
 
     return (
       `"${operation.id}Sse": (${params}) => ` +
@@ -525,10 +532,10 @@ export const makeTransformerTs = () => {
     const methods: Array<string> = []
     for (const op of operations) {
       methods.push(operationToMethod(name, op))
-      if (op.sseSchema) {
+      if (op.httpClientResponses.sseSchema) {
         methods.push(operationToSseMethod(op))
       }
-      if (op.binaryResponse) {
+      if (op.httpClientResponses.binarySuccessStatuses.size > 0) {
         methods.push(operationToBinaryMethod(op))
       }
     }
@@ -541,6 +548,7 @@ ${clientErrorSource(name)}`
   }
 
   const operationToMethod = (name: string, operation: ParsedOperation) => {
+    const responses = operation.httpClientResponses
     const args: Array<string> = []
     if (operation.pathIds.length > 0) {
       Utils.spreadElementsInto(operation.pathIds.map((id) => `${id}: string`), args)
@@ -565,19 +573,22 @@ ${clientErrorSource(name)}`
       args.push(`options: { ${options.join("; ")} } | undefined`)
     }
 
-    const successTypes = Array.from(operation.successSchemas.values())
-    if (operation.binarySuccessStatuses.size > 0) {
-      successTypes.push("Uint8Array")
+    const successTypes = new Set(responses.successSchemas.values())
+    if (responses.binarySuccessStatuses.size > 0) {
+      successTypes.add("Uint8Array")
     }
-    const success = successTypes.length > 0 ? successTypes.join(" | ") : "void"
+    if (responses.voidSuccessStatuses.size > 0) {
+      successTypes.add("void")
+    }
+    const success = successTypes.size > 0 ? Array.from(successTypes).join(" | ") : "void"
 
     const errors = ["HttpClientError.HttpClientError"]
-    if (operation.errorSchemas.size > 0) {
-      for (const schema of operation.errorSchemas.values()) {
+    if (responses.errorSchemas.size > 0) {
+      for (const schema of responses.errorSchemas.values()) {
         errors.push(`${name}Error<"${schema}", ${schema}>`)
       }
     }
-    for (const status of operation.voidErrorStatuses) {
+    for (const status of responses.voidErrorStatuses) {
       errors.push(`${name}Error<"${status}", undefined>`)
     }
 
@@ -590,6 +601,7 @@ ${clientErrorSource(name)}`
   }
 
   const operationToSseMethod = (operation: ParsedOperation) => {
+    const responses = operation.httpClientResponses
     const args: Array<string> = []
     if (operation.pathIds.length > 0) {
       Utils.spreadElementsInto(operation.pathIds.map((id) => `${id}: string`), args)
@@ -615,7 +627,7 @@ ${clientErrorSource(name)}`
     const jsdoc = Utils.toComment(operation.description)
     const methodKey = `readonly "${operation.id}Sse"`
     const parameters = args.join(", ")
-    const returnType = `Stream.Stream<${operation.sseSchema}, HttpClientError.HttpClientError>`
+    const returnType = `Stream.Stream<${responses.sseSchema}, HttpClientError.HttpClientError>`
     return `${jsdoc}${methodKey}: (${parameters}) => ${returnType}`
   }
 
@@ -658,10 +670,10 @@ ${clientErrorSource(name)}`
     const implMethods: Array<string> = []
     for (const op of operations) {
       implMethods.push(operationToImpl(op))
-      if (op.sseSchema) {
+      if (op.httpClientResponses.sseSchema) {
         implMethods.push(operationToSseImpl(op))
       }
-      if (op.binaryResponse) {
+      if (op.httpClientResponses.binarySuccessStatuses.size > 0) {
         implMethods.push(operationToBinaryImpl(op))
       }
     }
@@ -671,7 +683,9 @@ ${clientErrorSource(name)}`
       helpers.push(sseRequestSourceTs)
     }
     const hasResponseVariants = operations.some((operation) =>
-      operation.binarySuccessStatuses.size > 0 || operation.voidErrorStatuses.size > 0
+      operation.httpClientResponses.binarySuccessStatuses.size > 0 ||
+      operation.httpClientResponses.voidSuccessStatuses.size > 0 ||
+      operation.httpClientResponses.voidErrorStatuses.size > 0
     )
     if (requirements.octetStream || hasResponseVariants) {
       helpers.push(decodeBinarySource)
@@ -737,6 +751,7 @@ export const make = (
   }
 
   const operationToImpl = (operation: ParsedOperation) => {
+    const responses = operation.httpClientResponses
     const args: Array<string> = [...operation.pathIds, "options"]
     const params = `${args.join(", ")}`
 
@@ -766,28 +781,32 @@ export const make = (
       pipeline.push(`HttpClientRequest.bodyJsonUnsafe(${payloadAccessor})`)
     }
 
-    const successCodesRaw = Array.from(operation.successSchemas.keys())
+    const successCodesRaw = Array.from(responses.successSchemas.keys())
     const successCodes = successCodesRaw
       .map((_) => JSON.stringify(_))
       .join(", ")
     const singleSuccessCode = successCodesRaw.length === 1 &&
       successCodesRaw[0].startsWith("2") &&
-      operation.binarySuccessStatuses.size === 0 &&
-      operation.voidSchemas.size === 0
-    const errorCodes = operation.errorSchemas.size > 0 &&
-      Object.fromEntries(operation.errorSchemas.entries())
+      responses.binarySuccessStatuses.size === 0 &&
+      responses.voidSuccessStatuses.size === 0
+    const errorCodes = responses.errorSchemas.size > 0 &&
+      Object.fromEntries(responses.errorSchemas.entries())
     const configAccessor = resolveConfigAccessor(operation, "options", "config")
     const requestArgs = [`[${singleSuccessCode ? `"2xx"` : successCodes}]`]
-    if (operation.binarySuccessStatuses.size > 0 || operation.voidErrorStatuses.size > 0) {
-      const binaryCodesRaw = Array.from(operation.binarySuccessStatuses)
+    if (
+      responses.binarySuccessStatuses.size > 0 ||
+      responses.voidSuccessStatuses.size > 0 ||
+      responses.voidErrorStatuses.size > 0
+    ) {
+      const binaryCodesRaw = Array.from(responses.binarySuccessStatuses)
       const singleBinarySuccessCode = binaryCodesRaw.length === 1 &&
         binaryCodesRaw[0].startsWith("2") &&
-        operation.successSchemas.size === 0 &&
-        operation.voidSchemas.size === 0
+        responses.successSchemas.size === 0 &&
+        responses.voidSuccessStatuses.size === 0
       const responseCodes = {
         binary: binaryCodesRaw.map((status) => singleBinarySuccessCode ? "2xx" : status),
-        void: Array.from(operation.voidSchemas),
-        voidError: Array.from(operation.voidErrorStatuses)
+        voidSuccess: Array.from(responses.voidSuccessStatuses),
+        voidError: Array.from(responses.voidErrorStatuses)
       }
       requestArgs.push(errorCodes ? JSON.stringify(errorCodes) : "undefined", JSON.stringify(responseCodes))
     } else if (errorCodes) {
@@ -969,16 +988,16 @@ const onRequestSource = (withResponseVariants: boolean) => {
     ? `
     responseCodes: {
       readonly binary: ReadonlyArray<string>
-      readonly void: ReadonlyArray<string>
+      readonly voidSuccess: ReadonlyArray<string>
       readonly voidError: ReadonlyArray<string>
-    } = { binary: [], void: [], voidError: [] },`
+    } = { binary: [], voidSuccess: [], voidError: [] },`
     : ""
   const responseCodesCases = withResponseVariants
     ? `
     for (const code of responseCodes.binary) {
       cases[code] = decodeBinary
     }
-    for (const code of responseCodes.void) {
+    for (const code of responseCodes.voidSuccess) {
       cases[code] = decodeVoid
     }
     for (const code of responseCodes.voidError) {
@@ -986,7 +1005,7 @@ const onRequestSource = (withResponseVariants: boolean) => {
     }`
     : ""
   const voidFallbackCondition = withResponseVariants
-    ? "successCodes.length === 0 && responseCodes.binary.length === 0 && responseCodes.void.length === 0"
+    ? "successCodes.length === 0 && responseCodes.binary.length === 0 && responseCodes.voidSuccess.length === 0"
     : "successCodes.length === 0"
   return `const onRequest = <Config extends OperationConfig>(config: Config | undefined) => (
     successCodes: ReadonlyArray<string>,

--- a/packages/tools/openapi-generator/src/OpenApiTransformer.ts
+++ b/packages/tools/openapi-generator/src/OpenApiTransformer.ts
@@ -13,7 +13,7 @@
 import * as Context from "effect/Context"
 import * as Layer from "effect/Layer"
 import * as Predicate from "effect/Predicate"
-import type { ParsedOpenApi, ParsedOperation } from "./ParsedOperation.ts"
+import type { ParsedOpenApi, ParsedOperation, ParsedOperationHttpClientResponses } from "./ParsedOperation.ts"
 import * as Utils from "./Utils.ts"
 
 /**
@@ -69,6 +69,16 @@ const computeImportRequirements = (operations: ReadonlyArray<ParsedOperation>): 
 
 const requiresStreaming = (requirements: ImportRequirements): boolean =>
   requirements.eventStream || requirements.octetStream
+
+const normalizeSuccessStatus = (
+  responses: ParsedOperationHttpClientResponses,
+  status: string
+): string => {
+  const successCount = responses.successSchemas.size +
+    responses.binarySuccessStatuses.size +
+    responses.voidSuccessStatuses.size
+  return successCount === 1 && status.startsWith("2") ? "2xx" : status
+}
 
 /**
  * Create the transformer used for schema-backed HttpClient output.
@@ -340,19 +350,11 @@ export const make = (
     }
 
     const decodes: Array<string> = []
-    const singleSuccessCode = responses.successSchemas.size === 1 &&
-      responses.binarySuccessStatuses.size === 0 &&
-      responses.voidSuccessStatuses.size === 0
     responses.successSchemas.forEach((schema, status) => {
-      const statusCode = singleSuccessCode && status.startsWith("2") ? "2xx" : status
-      decodes.push(`"${statusCode}": decodeSuccess(${schema})`)
+      decodes.push(`"${normalizeSuccessStatus(responses, status)}": decodeSuccess(${schema})`)
     })
-    const singleBinarySuccessCode = responses.binarySuccessStatuses.size === 1 &&
-      responses.successSchemas.size === 0 &&
-      responses.voidSuccessStatuses.size === 0
     responses.binarySuccessStatuses.forEach((status) => {
-      const statusCode = singleBinarySuccessCode && status.startsWith("2") ? "2xx" : status
-      decodes.push(`"${statusCode}": decodeBinary`)
+      decodes.push(`"${normalizeSuccessStatus(responses, status)}": decodeBinary`)
     })
     responses.errorSchemas.forEach((schema, status) => {
       decodes.push(`"${status}": decodeError("${schema}", ${schema})`)
@@ -687,7 +689,7 @@ ${clientErrorSource(name)}`
       operation.httpClientResponses.voidSuccessStatuses.size > 0 ||
       operation.httpClientResponses.voidErrorStatuses.size > 0
     )
-    if (requirements.octetStream || hasResponseVariants) {
+    if (hasResponseVariants) {
       helpers.push(decodeBinarySource)
     }
     if (requirements.octetStream) {
@@ -781,30 +783,26 @@ export const make = (
       pipeline.push(`HttpClientRequest.bodyJsonUnsafe(${payloadAccessor})`)
     }
 
-    const successCodesRaw = Array.from(responses.successSchemas.keys())
-    const successCodes = successCodesRaw
-      .map((_) => JSON.stringify(_))
+    const successCodes = Array.from(
+      responses.successSchemas.keys(),
+      (status) => normalizeSuccessStatus(responses, status)
+    )
+      .map((status) => JSON.stringify(status))
       .join(", ")
-    const singleSuccessCode = successCodesRaw.length === 1 &&
-      successCodesRaw[0].startsWith("2") &&
-      responses.binarySuccessStatuses.size === 0 &&
-      responses.voidSuccessStatuses.size === 0
     const errorCodes = responses.errorSchemas.size > 0 &&
       Object.fromEntries(responses.errorSchemas.entries())
     const configAccessor = resolveConfigAccessor(operation, "options", "config")
-    const requestArgs = [`[${singleSuccessCode ? `"2xx"` : successCodes}]`]
+    const requestArgs = [`[${successCodes}]`]
     if (
       responses.binarySuccessStatuses.size > 0 ||
       responses.voidSuccessStatuses.size > 0 ||
       responses.voidErrorStatuses.size > 0
     ) {
-      const binaryCodesRaw = Array.from(responses.binarySuccessStatuses)
-      const singleBinarySuccessCode = binaryCodesRaw.length === 1 &&
-        binaryCodesRaw[0].startsWith("2") &&
-        responses.successSchemas.size === 0 &&
-        responses.voidSuccessStatuses.size === 0
       const responseCodes = {
-        binary: binaryCodesRaw.map((status) => singleBinarySuccessCode ? "2xx" : status),
+        binary: Array.from(
+          responses.binarySuccessStatuses,
+          (status) => normalizeSuccessStatus(responses, status)
+        ),
         voidSuccess: Array.from(responses.voidSuccessStatuses),
         voidError: Array.from(responses.voidErrorStatuses)
       }
@@ -914,8 +912,12 @@ export const make = (
       if (requiresStreaming(requirements)) {
         imports.push(`import * as Stream from "effect/Stream"`)
       }
+      if (requiresStreaming(requirements)) {
+        imports.push(`import * as HttpClient from "effect/unstable/http/HttpClient"`)
+      } else {
+        imports.push(`import type * as HttpClient from "effect/unstable/http/HttpClient"`)
+      }
       imports.push(
-        `import type * as HttpClient from "effect/unstable/http/HttpClient"`,
         `import * as HttpClientError from "effect/unstable/http/HttpClientError"`,
         `import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest"`,
         `import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse"`

--- a/packages/tools/openapi-generator/src/OpenApiTransformer.ts
+++ b/packages/tools/openapi-generator/src/OpenApiTransformer.ts
@@ -132,12 +132,12 @@ ${clientErrorSource(name)}`
       args.push(`options: { ${options.join("; ")} } | undefined`)
     }
 
-    let success = "void"
-    if (operation.successSchemas.size > 0) {
-      success = Array.from(operation.successSchemas.values())
-        .map((schema) => `typeof ${schema}.Type`)
-        .join(" | ")
+    const successTypes = Array.from(operation.successSchemas.values())
+      .map((schema) => `typeof ${schema}.Type`)
+    if (operation.binarySuccessStatuses.size > 0) {
+      successTypes.push("Uint8Array")
     }
+    const success = successTypes.length > 0 ? successTypes.join(" | ") : "void"
     const errors = ["HttpClientError.HttpClientError", "SchemaError"]
     if (operation.errorSchemas.size > 0) {
       Utils.spreadElementsInto(
@@ -146,6 +146,9 @@ ${clientErrorSource(name)}`
         ),
         errors
       )
+    }
+    for (const status of operation.voidErrorStatuses) {
+      errors.push(`${name}Error<"${status}", undefined>`)
     }
 
     const jsdoc = Utils.toComment(operation.description)
@@ -245,9 +248,12 @@ ${clientErrorSource(name)}`
       helpers.push(sseEventRequestSource)
     }
     if (requirements.octetStream) {
+      helpers.push(decodeBinarySource)
       helpers.push(binaryRequestSource)
     }
-
+    if (operations.some((operation) => operation.voidErrorStatuses.size > 0)) {
+      helpers.push(decodeVoidErrorSource(name))
+    }
     return `export interface OperationConfig {
   /**
    * Whether or not the response should be included in the value returned from
@@ -328,16 +334,28 @@ export const make = (
     }
 
     const decodes: Array<string> = []
-    const singleSuccessCode = operation.successSchemas.size === 1
+    const singleSuccessCode = operation.successSchemas.size === 1 &&
+      operation.binarySuccessStatuses.size === 0 &&
+      operation.voidSchemas.size === 0
     operation.successSchemas.forEach((schema, status) => {
       const statusCode = singleSuccessCode && status.startsWith("2") ? "2xx" : status
       decodes.push(`"${statusCode}": decodeSuccess(${schema})`)
+    })
+    const singleBinarySuccessCode = operation.binarySuccessStatuses.size === 1 &&
+      operation.successSchemas.size === 0 &&
+      operation.voidSchemas.size === 0
+    operation.binarySuccessStatuses.forEach((status) => {
+      const statusCode = singleBinarySuccessCode && status.startsWith("2") ? "2xx" : status
+      decodes.push(`"${statusCode}": decodeBinary`)
     })
     operation.errorSchemas.forEach((schema, status) => {
       decodes.push(`"${status}": decodeError("${schema}", ${schema})`)
     })
     operation.voidSchemas.forEach((status) => {
       decodes.push(`"${status}": () => Effect.void`)
+    })
+    operation.voidErrorStatuses.forEach((status) => {
+      decodes.push(`"${status}": decodeVoidError("${status}")`)
     })
     decodes.push(`orElse: unexpectedStatus`)
 
@@ -547,16 +565,20 @@ ${clientErrorSource(name)}`
       args.push(`options: { ${options.join("; ")} } | undefined`)
     }
 
-    let success = "void"
-    if (operation.successSchemas.size > 0) {
-      success = Array.from(operation.successSchemas.values()).join(" | ")
+    const successTypes = Array.from(operation.successSchemas.values())
+    if (operation.binarySuccessStatuses.size > 0) {
+      successTypes.push("Uint8Array")
     }
+    const success = successTypes.length > 0 ? successTypes.join(" | ") : "void"
 
     const errors = ["HttpClientError.HttpClientError"]
     if (operation.errorSchemas.size > 0) {
       for (const schema of operation.errorSchemas.values()) {
         errors.push(`${name}Error<"${schema}", ${schema}>`)
       }
+    }
+    for (const status of operation.voidErrorStatuses) {
+      errors.push(`${name}Error<"${status}", undefined>`)
     }
 
     const jsdoc = Utils.toComment(operation.description)
@@ -649,7 +671,17 @@ ${clientErrorSource(name)}`
       helpers.push(sseRequestSourceTs)
     }
     if (requirements.octetStream) {
+      helpers.push(decodeBinarySource)
       helpers.push(binaryRequestSourceTs)
+    }
+    const hasResponseVariants = operations.some((operation) =>
+      operation.binarySuccessStatuses.size > 0 || operation.voidErrorStatuses.size > 0
+    )
+    if (hasResponseVariants) {
+      if (!requirements.octetStream) {
+        helpers.push(decodeBinarySource)
+      }
+      helpers.push(decodeVoidErrorSource(name))
     }
 
     return `export interface OperationConfig {
@@ -697,24 +729,7 @@ export const make = (
         response.json as Effect.Effect<E, HttpClientError.HttpClientError>,
         (cause) => Effect.fail(${name}Error(tag, cause, response)),
       )
-  const onRequest = <Config extends OperationConfig>(config: Config | undefined) => (
-    successCodes: ReadonlyArray<string>,
-    errorCodes?: Record<string, string>,
-  ) => {
-    const cases: any = { orElse: unexpectedStatus }
-    for (const code of successCodes) {
-      cases[code] = decodeSuccess
-    }
-    if (errorCodes) {
-      for (const [code, tag] of Object.entries(errorCodes)) {
-        cases[code] = decodeError(tag)
-      }
-    }
-    if (successCodes.length === 0) {
-      cases["2xx"] = decodeVoid
-    }
-    return withResponse(config)(HttpClientResponse.matchStatus(cases) as any)
-  }
+  ${hasResponseVariants ? onRequestWithVariantsSource : onRequestSource}
   return {
     httpClient,
     ${implMethods.join(",\n    ")}
@@ -756,15 +771,37 @@ export const make = (
     const successCodes = successCodesRaw
       .map((_) => JSON.stringify(_))
       .join(", ")
-    const singleSuccessCode = successCodesRaw.length === 1 && successCodesRaw[0].startsWith("2")
+    const singleSuccessCode = successCodesRaw.length === 1 &&
+      successCodesRaw[0].startsWith("2") &&
+      operation.binarySuccessStatuses.size === 0 &&
+      operation.voidSchemas.size === 0
     const errorCodes = operation.errorSchemas.size > 0 &&
       Object.fromEntries(operation.errorSchemas.entries())
     const configAccessor = resolveConfigAccessor(operation, "options", "config")
-    pipeline.push(
-      `onRequest(${configAccessor})([${singleSuccessCode ? `"2xx"` : successCodes}]${
-        errorCodes ? `, ${JSON.stringify(errorCodes)}` : ""
-      })`
-    )
+    const usesResponseVariants = operation.binarySuccessStatuses.size > 0 || operation.voidErrorStatuses.size > 0
+    if (usesResponseVariants) {
+      const binaryCodesRaw = Array.from(operation.binarySuccessStatuses)
+      const singleBinarySuccessCode = binaryCodesRaw.length === 1 &&
+        binaryCodesRaw[0].startsWith("2") &&
+        operation.successSchemas.size === 0 &&
+        operation.voidSchemas.size === 0
+      const responseCodes = {
+        binary: binaryCodesRaw.map((status) => singleBinarySuccessCode ? "2xx" : status),
+        void: Array.from(operation.voidSchemas),
+        voidError: Array.from(operation.voidErrorStatuses)
+      }
+      pipeline.push(
+        `onRequest(${configAccessor})([${singleSuccessCode ? `"2xx"` : successCodes}], ${
+          errorCodes ? JSON.stringify(errorCodes) : "undefined"
+        }, ${JSON.stringify(responseCodes)})`
+      )
+    } else {
+      pipeline.push(
+        `onRequest(${configAccessor})([${singleSuccessCode ? `"2xx"` : successCodes}]${
+          errorCodes ? `, ${JSON.stringify(errorCodes)}` : ""
+        })`
+      )
+    }
 
     return (
       `"${operation.id}": (${params}) => ` +
@@ -925,6 +962,66 @@ const commonSource = `const unexpectedStatus = (response: HttpClientResponse.Htt
             withOptionalResponse
           )
       : (request) => Effect.flatMap(httpClient.execute(request), withOptionalResponse)
+  }`
+
+const decodeBinarySource = `const decodeBinary = (response: HttpClientResponse.HttpClientResponse) =>
+    Effect.map(response.arrayBuffer, (buffer) => new Uint8Array(buffer))`
+
+const decodeVoidErrorSource = (name: string) =>
+  `const decodeVoidError = <const Tag extends string>(tag: Tag) =>
+    (response: HttpClientResponse.HttpClientResponse) =>
+      Effect.fail(${name}Error(tag, undefined, response))`
+
+const onRequestSource = `const onRequest = <Config extends OperationConfig>(config: Config | undefined) => (
+    successCodes: ReadonlyArray<string>,
+    errorCodes?: Record<string, string>,
+  ) => {
+    const cases: any = { orElse: unexpectedStatus }
+    for (const code of successCodes) {
+      cases[code] = decodeSuccess
+    }
+    if (errorCodes) {
+      for (const [code, tag] of Object.entries(errorCodes)) {
+        cases[code] = decodeError(tag)
+      }
+    }
+    if (successCodes.length === 0) {
+      cases["2xx"] = decodeVoid
+    }
+    return withResponse(config)(HttpClientResponse.matchStatus(cases) as any)
+  }`
+
+const onRequestWithVariantsSource = `const onRequest = <Config extends OperationConfig>(config: Config | undefined) => (
+    successCodes: ReadonlyArray<string>,
+    errorCodes: Record<string, string> | undefined = undefined,
+    responseCodes: {
+      readonly binary: ReadonlyArray<string>
+      readonly void: ReadonlyArray<string>
+      readonly voidError: ReadonlyArray<string>
+    } = { binary: [], void: [], voidError: [] },
+  ) => {
+    const cases: any = { orElse: unexpectedStatus }
+    for (const code of successCodes) {
+      cases[code] = decodeSuccess
+    }
+    if (errorCodes) {
+      for (const [code, tag] of Object.entries(errorCodes)) {
+        cases[code] = decodeError(tag)
+      }
+    }
+    for (const code of responseCodes.binary) {
+      cases[code] = decodeBinary
+    }
+    for (const code of responseCodes.void) {
+      cases[code] = decodeVoid
+    }
+    for (const code of responseCodes.voidError) {
+      cases[code] = decodeVoidError(code)
+    }
+    if (successCodes.length === 0 && responseCodes.binary.length === 0 && responseCodes.void.length === 0) {
+      cases["2xx"] = decodeVoid
+    }
+    return withResponse(config)(HttpClientResponse.matchStatus(cases) as any)
   }`
 
 const sseRequestSource = (_importName: string) =>

--- a/packages/tools/openapi-generator/src/OpenApiTransformer.ts
+++ b/packages/tools/openapi-generator/src/OpenApiTransformer.ts
@@ -70,6 +70,11 @@ const computeImportRequirements = (operations: ReadonlyArray<ParsedOperation>): 
 const requiresStreaming = (requirements: ImportRequirements): boolean =>
   requirements.eventStream || requirements.octetStream
 
+const hasResponseVariants = (responses: ParsedOperationHttpClientResponses): boolean =>
+  responses.binarySuccessStatuses.size > 0 ||
+  responses.voidSuccessStatuses.size > 0 ||
+  responses.voidErrorStatuses.size > 0
+
 const normalizeSuccessStatus = (
   responses: ParsedOperationHttpClientResponses,
   status: string
@@ -684,19 +689,13 @@ ${clientErrorSource(name)}`
     if (requirements.eventStream) {
       helpers.push(sseRequestSourceTs)
     }
-    const hasResponseVariants = operations.some((operation) =>
-      operation.httpClientResponses.binarySuccessStatuses.size > 0 ||
-      operation.httpClientResponses.voidSuccessStatuses.size > 0 ||
-      operation.httpClientResponses.voidErrorStatuses.size > 0
-    )
-    if (hasResponseVariants) {
+    const withResponseVariants = operations.some((op) => hasResponseVariants(op.httpClientResponses))
+    if (withResponseVariants) {
       helpers.push(decodeBinarySource)
+      helpers.push(decodeVoidErrorSource(name))
     }
     if (requirements.octetStream) {
       helpers.push(binaryRequestSourceTs)
-    }
-    if (hasResponseVariants) {
-      helpers.push(decodeVoidErrorSource(name))
     }
 
     return `export interface OperationConfig {
@@ -744,7 +743,7 @@ export const make = (
         response.json as Effect.Effect<E, HttpClientError.HttpClientError>,
         (cause) => Effect.fail(${name}Error(tag, cause, response)),
       )
-  ${onRequestSource(hasResponseVariants)}
+  ${onRequestSource(withResponseVariants)}
   return {
     httpClient,
     ${implMethods.join(",\n    ")}
@@ -785,19 +784,13 @@ export const make = (
 
     const successCodes = Array.from(
       responses.successSchemas.keys(),
-      (status) => normalizeSuccessStatus(responses, status)
-    )
-      .map((status) => JSON.stringify(status))
-      .join(", ")
+      (status) => JSON.stringify(normalizeSuccessStatus(responses, status))
+    ).join(", ")
     const errorCodes = responses.errorSchemas.size > 0 &&
       Object.fromEntries(responses.errorSchemas.entries())
     const configAccessor = resolveConfigAccessor(operation, "options", "config")
     const requestArgs = [`[${successCodes}]`]
-    if (
-      responses.binarySuccessStatuses.size > 0 ||
-      responses.voidSuccessStatuses.size > 0 ||
-      responses.voidErrorStatuses.size > 0
-    ) {
+    if (hasResponseVariants(responses)) {
       const responseCodes = {
         binary: Array.from(
           responses.binarySuccessStatuses,
@@ -910,10 +903,10 @@ export const make = (
         `import * as Effect from "effect/Effect"`
       ]
       if (requiresStreaming(requirements)) {
-        imports.push(`import * as Stream from "effect/Stream"`)
-      }
-      if (requiresStreaming(requirements)) {
-        imports.push(`import * as HttpClient from "effect/unstable/http/HttpClient"`)
+        imports.push(
+          `import * as Stream from "effect/Stream"`,
+          `import * as HttpClient from "effect/unstable/http/HttpClient"`
+        )
       } else {
         imports.push(`import type * as HttpClient from "effect/unstable/http/HttpClient"`)
       }

--- a/packages/tools/openapi-generator/src/ParsedOperation.ts
+++ b/packages/tools/openapi-generator/src/ParsedOperation.ts
@@ -177,6 +177,22 @@ export interface ParsedOperationResponse {
 export type ParsedOperationSecurityRequirement = Readonly<OpenAPISecurityRequirement>
 
 /**
+ * Response state used only by the generated HttpClient renderers.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ParsedOperationHttpClientResponses {
+  readonly successSchemas: ReadonlyMap<string, string>
+  readonly errorSchemas: ReadonlyMap<string, string>
+  readonly voidSuccessStatuses: ReadonlySet<string>
+  readonly voidErrorStatuses: ReadonlySet<string>
+  readonly sseSchema?: string
+  readonly sseSchemaMode: "data" | "event"
+  readonly binarySuccessStatuses: ReadonlySet<string>
+}
+
+/**
  * Normalized operation model shared by all OpenAPI generator backends.
  *
  * @category models
@@ -216,16 +232,7 @@ export interface ParsedOperation {
   readonly requestBodyRepresentable: ReadonlyArray<ParsedOperationMediaTypeSchema>
   readonly pathIds: ReadonlyArray<string>
   readonly pathTemplate: string
-  readonly successSchemas: ReadonlyMap<string, string>
-  readonly errorSchemas: ReadonlyMap<string, string>
-  readonly voidSchemas: ReadonlySet<string>
-  readonly voidErrorStatuses: ReadonlySet<string>
-  // SSE streaming response schema (text/event-stream)
-  readonly sseSchema?: string
-  readonly sseSchemaMode: "data" | "event"
-  // Binary response, including the statuses handled by the buffered method
-  readonly binaryResponse: boolean
-  readonly binarySuccessStatuses: ReadonlySet<string>
+  readonly httpClientResponses: ParsedOperationHttpClientResponses
 }
 
 /**
@@ -272,12 +279,13 @@ export const makeDeepMutable = (options: {
   headersSchema: undefined,
   headersSchemaOptional: true,
   requestBodyRepresentable: [],
-  successSchemas: new Map(),
-  errorSchemas: new Map(),
-  voidSchemas: new Set(),
-  voidErrorStatuses: new Set(),
-  paramsOptional: true,
-  sseSchemaMode: "data",
-  binaryResponse: false,
-  binarySuccessStatuses: new Set()
+  httpClientResponses: {
+    successSchemas: new Map(),
+    errorSchemas: new Map(),
+    voidSuccessStatuses: new Set(),
+    voidErrorStatuses: new Set(),
+    sseSchemaMode: "data",
+    binarySuccessStatuses: new Set()
+  },
+  paramsOptional: true
 })

--- a/packages/tools/openapi-generator/src/ParsedOperation.ts
+++ b/packages/tools/openapi-generator/src/ParsedOperation.ts
@@ -219,11 +219,13 @@ export interface ParsedOperation {
   readonly successSchemas: ReadonlyMap<string, string>
   readonly errorSchemas: ReadonlyMap<string, string>
   readonly voidSchemas: ReadonlySet<string>
+  readonly voidErrorStatuses: ReadonlySet<string>
   // SSE streaming response schema (text/event-stream)
   readonly sseSchema?: string
   readonly sseSchemaMode: "data" | "event"
-  // Binary stream response (application/octet-stream)
+  // Binary response, including the statuses handled by the buffered method
   readonly binaryResponse: boolean
+  readonly binarySuccessStatuses: ReadonlySet<string>
 }
 
 /**
@@ -273,7 +275,9 @@ export const makeDeepMutable = (options: {
   successSchemas: new Map(),
   errorSchemas: new Map(),
   voidSchemas: new Set(),
+  voidErrorStatuses: new Set(),
   paramsOptional: true,
   sseSchemaMode: "data",
-  binaryResponse: false
+  binaryResponse: false,
+  binarySuccessStatuses: new Set()
 })

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -52,6 +52,23 @@ function assertRuntimeIncludes(spec: OpenAPISpec, includes: ReadonlyArray<string
   )
 }
 
+function assertTypeOnlyIncludes(spec: OpenAPISpec, includes: ReadonlyArray<string>) {
+  return Effect.gen(function*() {
+    const generator = yield* OpenApiGenerator.OpenApiGenerator
+
+    const result = yield* generator.generate(spec, {
+      name: "TestClient",
+      format: "httpclient-type-only"
+    })
+
+    for (const expected of includes) {
+      assert.include(result, expected)
+    }
+  }).pipe(
+    Effect.provide(OpenApiGenerator.layerTransformerTs)
+  )
+}
+
 function assertHttpApiIncludes(
   spec: OpenAPISpec,
   includes: ReadonlyArray<string>,
@@ -284,6 +301,126 @@ const regressionSpec: OpenAPISpec = {
   },
   security: [],
   tags: [{ name: "Users" }]
+}
+
+const responseMatchingSpec: OpenAPISpec = {
+  openapi: "3.1.0",
+  info: {
+    title: "Response matching API",
+    version: "1.0.0"
+  },
+  paths: {
+    "/auth/device/token": {
+      post: {
+        operationId: "pollDeviceToken",
+        responses: {
+          400: {
+            description: "Problem details or OAuth polling state",
+            content: {
+              "application/problem+json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    kind: { const: "InvalidRequestError" },
+                    code: { type: "string" }
+                  },
+                  required: ["kind", "code"],
+                  additionalProperties: false
+                }
+              },
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    kind: { const: "DeviceTokenOAuthError" },
+                    error: { type: "string" }
+                  },
+                  required: ["kind", "error"],
+                  additionalProperties: false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/archive": {
+      get: {
+        operationId: "downloadArchive",
+        responses: {
+          200: {
+            description: "Archive",
+            content: {
+              "application/zip": {
+                schema: { type: "string", format: "binary" }
+              }
+            }
+          },
+          404: {
+            description: "Not found",
+            content: {
+              "application/problem+json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    title: { type: "string" }
+                  },
+                  required: ["title"],
+                  additionalProperties: false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/avatar": {
+      get: {
+        operationId: "downloadAvatar",
+        responses: {
+          200: {
+            description: "Avatar",
+            content: {
+              "image/png": {
+                schema: { type: "string" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/custom-binary": {
+      get: {
+        operationId: "downloadCustomBinary",
+        responses: {
+          200: {
+            description: "Custom binary",
+            content: {
+              "application/vnd.example.data": {
+                schema: { type: "string", format: "binary" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/resources/{id}": {
+      head: {
+        operationId: "checkResource",
+        parameters: [{
+          name: "id",
+          in: "path",
+          required: true,
+          schema: { type: "string" }
+        }],
+        responses: {
+          200: { description: "Exists" },
+          404: { description: "Not found" },
+          500: { description: "Server error" }
+        }
+      }
+    }
+  }
 }
 
 describe("OpenApiGenerator", () => {
@@ -649,6 +786,30 @@ export const TestClientError = <Tag extends string, E>(
           `readonly payload: typeof IssueTokenRequestFormUrlEncoded.Encoded`
         ]
       ))
+
+    it.effect("preserves response variants and routes binary and bodiless statuses", () =>
+      assertRuntimeIncludes(responseMatchingSpec, [
+        `export const PollDeviceToken400 = Schema.Union(`,
+        `Schema.Literal("InvalidRequestError")`,
+        `Schema.Literal("DeviceTokenOAuthError")`,
+        `"400": decodeError("PollDeviceToken400", PollDeviceToken400)`,
+        `export type DownloadArchive404 = { readonly "title": string }`,
+        `const decodeBinary = (response: HttpClientResponse.HttpClientResponse) =>`,
+        `Effect.map(response.arrayBuffer, (buffer) => new Uint8Array(buffer))`,
+        `"2xx": decodeBinary`,
+        `readonly "downloadArchive": <Config extends OperationConfig>(options: { readonly config?: Config | undefined } | undefined) => Effect.Effect<WithOptionalResponse<Uint8Array, Config>`,
+        `readonly "downloadArchiveStream": () => Stream.Stream<Uint8Array, HttpClientError.HttpClientError>`,
+        `readonly "downloadAvatarStream": () => Stream.Stream<Uint8Array, HttpClientError.HttpClientError>`,
+        `"downloadAvatar": (options) => HttpClientRequest.get(\`/avatar\`).pipe(
+    withResponse(options?.config)(HttpClientResponse.matchStatus({
+      "2xx": decodeBinary`,
+        `readonly "downloadCustomBinaryStream": () => Stream.Stream<Uint8Array, HttpClientError.HttpClientError>`,
+        `"200": () => Effect.void`,
+        `"404": decodeVoidError("404")`,
+        `"500": decodeVoidError("500")`,
+        `TestClientError<"404", undefined>`,
+        `TestClientError<"500", undefined>`
+      ]))
   })
 
   describe("type-only", () => {
@@ -848,6 +1009,25 @@ export const TestClientError = <Tag extends string, E>(
     request: response.request,
   }) as any`
       ))
+
+    it.effect("preserves response variants and routes binary and bodiless statuses", () =>
+      assertTypeOnlyIncludes(responseMatchingSpec, [
+        `export type PollDeviceToken400 =`,
+        `readonly "kind": "InvalidRequestError"`,
+        `readonly "kind": "DeviceTokenOAuthError"`,
+        `onRequest(options?.config)([], {"400":"PollDeviceToken400"})`,
+        `const decodeBinary = (response: HttpClientResponse.HttpClientResponse) =>`,
+        `onRequest(options?.config)([], {"404":"DownloadArchive404"}, {"binary":["2xx"],"void":[],"voidError":[]})`,
+        `readonly "downloadArchive": <Config extends OperationConfig>(options: { readonly config?: Config | undefined } | undefined) => Effect.Effect<WithOptionalResponse<Uint8Array, Config>`,
+        `readonly "downloadAvatarStream": () => Stream.Stream<Uint8Array, HttpClientError.HttpClientError>`,
+        `"downloadAvatar": (options) => HttpClientRequest.get(\`/avatar\`).pipe(
+    onRequest(options?.config)([], undefined, {"binary":["2xx"],"void":[],"voidError":[]})`,
+        `readonly "downloadCustomBinaryStream": () => Stream.Stream<Uint8Array, HttpClientError.HttpClientError>`,
+        `onRequest(options?.config)([], undefined, {"binary":[],"void":["200"],"voidError":["404","500"]})`,
+        `cases[code] = decodeVoidError(code)`,
+        `TestClientError<"404", undefined>`,
+        `TestClientError<"500", undefined>`
+      ]))
   })
 
   describe("httpapi", () => {

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -313,6 +313,9 @@ const responseMatchingSpec: OpenAPISpec = {
     "/auth/device/token": {
       post: {
         operationId: "pollDeviceToken",
+        parameters: [],
+        tags: ["ResponseMatching"],
+        security: [],
         responses: {
           400: {
             description: "Problem details or OAuth polling state",
@@ -347,6 +350,9 @@ const responseMatchingSpec: OpenAPISpec = {
     "/archive": {
       get: {
         operationId: "downloadArchive",
+        parameters: [],
+        tags: ["ResponseMatching"],
+        security: [],
         responses: {
           200: {
             description: "Archive",
@@ -377,6 +383,9 @@ const responseMatchingSpec: OpenAPISpec = {
     "/avatar": {
       get: {
         operationId: "downloadAvatar",
+        parameters: [],
+        tags: ["ResponseMatching"],
+        security: [],
         responses: {
           200: {
             description: "Avatar",
@@ -392,6 +401,9 @@ const responseMatchingSpec: OpenAPISpec = {
     "/custom-binary": {
       get: {
         operationId: "downloadCustomBinary",
+        parameters: [],
+        tags: ["ResponseMatching"],
+        security: [],
         responses: {
           200: {
             description: "Custom binary",
@@ -413,6 +425,8 @@ const responseMatchingSpec: OpenAPISpec = {
           required: true,
           schema: { type: "string" }
         }],
+        tags: ["ResponseMatching"],
+        security: [],
         responses: {
           200: { description: "Exists" },
           404: { description: "Not found" },
@@ -420,7 +434,13 @@ const responseMatchingSpec: OpenAPISpec = {
         }
       }
     }
-  }
+  },
+  components: {
+    schemas: {},
+    securitySchemes: {}
+  },
+  security: [],
+  tags: [{ name: "ResponseMatching" }]
 }
 
 describe("OpenApiGenerator", () => {

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -443,6 +443,52 @@ const responseMatchingSpec: OpenAPISpec = {
   tags: [{ name: "ResponseMatching" }]
 }
 
+const voidSuccessSpec: OpenAPISpec = {
+  openapi: "3.1.0",
+  info: {
+    title: "Void success API",
+    version: "1.0.0"
+  },
+  paths: {
+    "/mixed": {
+      get: {
+        operationId: "mixedSuccess",
+        parameters: [],
+        tags: ["VoidSuccess"],
+        security: [],
+        responses: {
+          200: {
+            description: "JSON value",
+            content: {
+              "application/json": {
+                schema: { type: "string" }
+              }
+            }
+          },
+          204: { description: "No content" }
+        }
+      }
+    },
+    "/cached": {
+      get: {
+        operationId: "cached",
+        parameters: [],
+        tags: ["VoidSuccess"],
+        security: [],
+        responses: {
+          304: { description: "Not modified" }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {},
+    securitySchemes: {}
+  },
+  security: [],
+  tags: [{ name: "VoidSuccess" }]
+}
+
 describe("OpenApiGenerator", () => {
   describe("schema", () => {
     it.effect("get operation", () =>
@@ -830,6 +876,14 @@ export const TestClientError = <Tag extends string, E>(
         `TestClientError<"404", undefined>`,
         `TestClientError<"500", undefined>`
       ]))
+
+    it.effect("routes mixed and non-2xx bodiless success responses", () =>
+      assertRuntimeIncludes(voidSuccessSpec, [
+        `"200": decodeSuccess(MixedSuccess200)`,
+        `"204": () => Effect.void`,
+        `"304": () => Effect.void`,
+        `WithOptionalResponse<typeof MixedSuccess200.Type | void, Config>`
+      ]))
   })
 
   describe("type-only", () => {
@@ -1037,16 +1091,23 @@ export const TestClientError = <Tag extends string, E>(
         `readonly "kind": "DeviceTokenOAuthError"`,
         `onRequest(options?.config)([], {"400":"PollDeviceToken400"})`,
         `const decodeBinary = (response: HttpClientResponse.HttpClientResponse) =>`,
-        `onRequest(options?.config)([], {"404":"DownloadArchive404"}, {"binary":["2xx"],"void":[],"voidError":[]})`,
+        `onRequest(options?.config)([], {"404":"DownloadArchive404"}, {"binary":["2xx"],"voidSuccess":[],"voidError":[]})`,
         `readonly "downloadArchive": <Config extends OperationConfig>(options: { readonly config?: Config | undefined } | undefined) => Effect.Effect<WithOptionalResponse<Uint8Array, Config>`,
         `readonly "downloadAvatarStream": () => Stream.Stream<Uint8Array, HttpClientError.HttpClientError>`,
         `"downloadAvatar": (options) => HttpClientRequest.get(\`/avatar\`).pipe(
-    onRequest(options?.config)([], undefined, {"binary":["2xx"],"void":[],"voidError":[]})`,
+    onRequest(options?.config)([], undefined, {"binary":["2xx"],"voidSuccess":[],"voidError":[]})`,
         `readonly "downloadCustomBinaryStream": () => Stream.Stream<Uint8Array, HttpClientError.HttpClientError>`,
-        `onRequest(options?.config)([], undefined, {"binary":[],"void":["200"],"voidError":["404","500"]})`,
+        `onRequest(options?.config)([], undefined, {"binary":[],"voidSuccess":["200"],"voidError":["404","500"]})`,
         `cases[code] = decodeVoidError(code)`,
         `TestClientError<"404", undefined>`,
         `TestClientError<"500", undefined>`
+      ]))
+
+    it.effect("routes mixed and non-2xx bodiless success responses", () =>
+      assertTypeOnlyIncludes(voidSuccessSpec, [
+        `onRequest(options?.config)(["200"], undefined, {"binary":[],"voidSuccess":["204"],"voidError":[]})`,
+        `onRequest(options?.config)([], undefined, {"binary":[],"voidSuccess":["304"],"voidError":[]})`,
+        `WithOptionalResponse<MixedSuccess200 | void, Config>`
       ]))
   })
 

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -1603,6 +1603,65 @@ export const CreatePayloadRequestText = Schema.String`,
         ]
       ))
 
+    it.effect("preserves multiple JSON response representations with application/json preferred", () =>
+      assertHttpApiIncludes(
+        {
+          openapi: "3.1.0",
+          info: {
+            title: "Test API",
+            version: "1.0.0"
+          },
+          paths: {
+            "/dual": {
+              get: {
+                operationId: "dualJson",
+                parameters: [],
+                responses: {
+                  200: {
+                    description: "Dual JSON response",
+                    content: {
+                      "application/problem+json": {
+                        schema: {
+                          type: "object",
+                          properties: {
+                            title: { type: "string" }
+                          },
+                          required: ["title"],
+                          additionalProperties: false
+                        }
+                      },
+                      "application/json": {
+                        schema: {
+                          type: "object",
+                          properties: {
+                            value: { type: "string" }
+                          },
+                          required: ["value"],
+                          additionalProperties: false
+                        }
+                      }
+                    }
+                  }
+                },
+                tags: ["DualJson"],
+                security: []
+              }
+            }
+          },
+          components: {
+            schemas: {},
+            securitySchemes: {}
+          },
+          security: [],
+          tags: [{ name: "DualJson" }]
+        },
+        [
+          `export type DualJson200 = { readonly "value": string }`,
+          `export type DualJson200ApplicationProblemJson = { readonly "title": string }`,
+          `HttpApiEndpoint.get("dualJson", "/dual", { success: [DualJson200, DualJson200ApplicationProblemJson.pipe(HttpApiSchema.asJson({ contentType: "application/problem+json" }))] })`
+        ]
+      ))
+
     it.effect("maps explicit SSE stream responses to HttpApiSchema.StreamSse", () =>
       assertHttpApiIncludes(
         {

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -2,6 +2,10 @@ import * as OpenApiGenerator from "@effect/openapi-generator/OpenApiGenerator"
 import { assert, describe, it } from "@effect/vitest"
 import * as Effect from "effect/Effect"
 import type { OpenAPISpec } from "effect/unstable/httpapi/OpenApi"
+import { spawnSync } from "node:child_process"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
 
 function assertRuntime(spec: OpenAPISpec, expected: string) {
   return Effect.gen(function*() {
@@ -35,7 +39,11 @@ function assertTypeOnly(spec: OpenAPISpec, expected: string) {
   )
 }
 
-function assertRuntimeIncludes(spec: OpenAPISpec, includes: ReadonlyArray<string>) {
+function assertRuntimeIncludes(
+  spec: OpenAPISpec,
+  includes: ReadonlyArray<string>,
+  excludes: ReadonlyArray<string> = []
+) {
   return Effect.gen(function*() {
     const generator = yield* OpenApiGenerator.OpenApiGenerator
 
@@ -47,12 +55,19 @@ function assertRuntimeIncludes(spec: OpenAPISpec, includes: ReadonlyArray<string
     for (const expected of includes) {
       assert.include(result, expected)
     }
+    for (const excluded of excludes) {
+      assert.notInclude(result, excluded)
+    }
   }).pipe(
     Effect.provide(OpenApiGenerator.layerTransformerSchema)
   )
 }
 
-function assertTypeOnlyIncludes(spec: OpenAPISpec, includes: ReadonlyArray<string>) {
+function assertTypeOnlyIncludes(
+  spec: OpenAPISpec,
+  includes: ReadonlyArray<string>,
+  excludes: ReadonlyArray<string> = []
+) {
   return Effect.gen(function*() {
     const generator = yield* OpenApiGenerator.OpenApiGenerator
 
@@ -64,9 +79,64 @@ function assertTypeOnlyIncludes(spec: OpenAPISpec, includes: ReadonlyArray<strin
     for (const expected of includes) {
       assert.include(result, expected)
     }
+    for (const excluded of excludes) {
+      assert.notInclude(result, excluded)
+    }
   }).pipe(
     Effect.provide(OpenApiGenerator.layerTransformerTs)
   )
+}
+
+function assertGeneratedClientsCompile(spec: OpenAPISpec) {
+  const generate = (
+    format: "httpclient" | "httpclient-type-only",
+    layer: typeof OpenApiGenerator.layerTransformerSchema
+  ) =>
+    Effect.gen(function*() {
+      const generator = yield* OpenApiGenerator.OpenApiGenerator
+      return yield* generator.generate(spec, { name: "TestClient", format })
+    }).pipe(Effect.provide(layer))
+
+  return Effect.gen(function*() {
+    const [schemaClient, typeOnlyClient] = yield* Effect.all([
+      generate("httpclient", OpenApiGenerator.layerTransformerSchema),
+      generate("httpclient-type-only", OpenApiGenerator.layerTransformerTs)
+    ])
+    const directory = mkdtempSync(join(dirname(fileURLToPath(import.meta.url)), ".generated-clients-"))
+    try {
+      const schemaPath = join(directory, "SchemaClient.ts")
+      const typeOnlyPath = join(directory, "TypeOnlyClient.ts")
+      writeFileSync(schemaPath, schemaClient)
+      writeFileSync(typeOnlyPath, typeOnlyClient)
+      const configPath = join(directory, "tsconfig.json")
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          compilerOptions: {
+            allowImportingTsExtensions: true,
+            exactOptionalPropertyTypes: true,
+            lib: ["ESNext", "DOM"],
+            module: "NodeNext",
+            noEmit: true,
+            skipLibCheck: true,
+            strict: true,
+            target: "ES2022",
+            types: [],
+            verbatimModuleSyntax: true
+          },
+          files: [schemaPath, typeOnlyPath]
+        })
+      )
+      const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "../../../..")
+      const result = spawnSync(join(repositoryRoot, "node_modules/.bin/tsc"), ["-p", configPath, "--pretty", "false"], {
+        cwd: repositoryRoot,
+        encoding: "utf8"
+      })
+      assert.strictEqual(result.status, 0, `${result.stdout}${result.stderr}`)
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
 }
 
 function assertHttpApiIncludes(
@@ -410,6 +480,45 @@ const responseMatchingSpec: OpenAPISpec = {
             content: {
               "application/vnd.example.data": {
                 schema: { type: "string", format: "binary" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mixed-content": {
+      get: {
+        operationId: "downloadMixedContent",
+        parameters: [],
+        tags: ["ResponseMatching"],
+        security: [],
+        responses: {
+          200: {
+            description: "JSON metadata or binary content",
+            content: {
+              "application/json; charset=utf-8": {
+                schema: {
+                  type: "object",
+                  properties: { href: { type: "string" } },
+                  required: ["href"],
+                  additionalProperties: false
+                }
+              },
+              "application/octet-stream; boundary=payload": {
+                schema: { type: "string" }
+              }
+            }
+          },
+          400: {
+            description: "Invalid request",
+            content: {
+              "application/problem+json; charset=utf-8": {
+                schema: {
+                  type: "object",
+                  properties: { title: { type: "string" } },
+                  required: ["title"],
+                  additionalProperties: false
+                }
               }
             }
           }
@@ -870,11 +979,17 @@ export const TestClientError = <Tag extends string, E>(
     withResponse(options?.config)(HttpClientResponse.matchStatus({
       "2xx": decodeBinary`,
         `readonly "downloadCustomBinaryStream": () => Stream.Stream<Uint8Array, HttpClientError.HttpClientError>`,
+        `"400": decodeError("DownloadMixedContent400", DownloadMixedContent400)`,
+        `readonly "downloadMixedContent": <Config extends OperationConfig>(options: { readonly config?: Config | undefined } | undefined) => Effect.Effect<WithOptionalResponse<Uint8Array, Config>`,
+        `readonly "downloadMixedContentStream": () => Stream.Stream<Uint8Array, HttpClientError.HttpClientError>`,
         `"200": () => Effect.void`,
         `"404": decodeVoidError("404")`,
         `"500": decodeVoidError("500")`,
         `TestClientError<"404", undefined>`,
         `TestClientError<"500", undefined>`
+      ], [
+        `"200": decodeSuccess(DownloadMixedContent200)`,
+        `typeof DownloadMixedContent200.Type | Uint8Array`
       ]))
 
     it.effect("routes mixed and non-2xx bodiless success responses", () =>
@@ -1097,10 +1212,16 @@ export const TestClientError = <Tag extends string, E>(
         `"downloadAvatar": (options) => HttpClientRequest.get(\`/avatar\`).pipe(
     onRequest(options?.config)([], undefined, {"binary":["2xx"],"voidSuccess":[],"voidError":[]})`,
         `readonly "downloadCustomBinaryStream": () => Stream.Stream<Uint8Array, HttpClientError.HttpClientError>`,
+        `import * as HttpClient from "effect/unstable/http/HttpClient"`,
+        `onRequest(options?.config)([], {"400":"DownloadMixedContent400"}, {"binary":["2xx"],"voidSuccess":[],"voidError":[]})`,
+        `readonly "downloadMixedContent": <Config extends OperationConfig>(options: { readonly config?: Config | undefined } | undefined) => Effect.Effect<WithOptionalResponse<Uint8Array, Config>`,
+        `readonly "downloadMixedContentStream": () => Stream.Stream<Uint8Array, HttpClientError.HttpClientError>`,
         `onRequest(options?.config)([], undefined, {"binary":[],"voidSuccess":["200"],"voidError":["404","500"]})`,
         `cases[code] = decodeVoidError(code)`,
         `TestClientError<"404", undefined>`,
         `TestClientError<"500", undefined>`
+      ], [
+        `DownloadMixedContent200 | Uint8Array`
       ]))
 
     it.effect("routes mixed and non-2xx bodiless success responses", () =>
@@ -1109,6 +1230,9 @@ export const TestClientError = <Tag extends string, E>(
         `onRequest(options?.config)([], undefined, {"binary":[],"voidSuccess":["304"],"voidError":[]})`,
         `WithOptionalResponse<MixedSuccess200 | void, Config>`
       ]))
+
+    it.effect("emits compilable clients for schema-backed and type-only formats", () =>
+      assertGeneratedClientsCompile(responseMatchingSpec))
   })
 
   describe("httpapi", () => {


### PR DESCRIPTION
## Summary

- preserve every JSON-compatible representation declared for a response status by generating a union schema
- preserve all JSON-compatible HttpApi response representations while preferring exact `application/json` as the primary schema
- decode binary success responses as `Uint8Array` in regular methods while retaining `*Stream` companions
- recognize parameterized JSON and binary media types, `+json`, common binary media types, and schema-declared binary bodies
- give binary decoding precedence when one success status declares both JSON and binary content, avoiding duplicate generated status keys
- route bodiless 4xx/5xx responses through typed client errors while routing every bodiless success explicitly
- group HttpClient-only response state, share success-status collapsing, derive binary capability from its statuses, and deduplicate public success types
- cover schema-backed and type-only HttpClient generation, including compiling generated clients for both formats, and add a patch changeset

## Root cause

HttpClient response parsing selected only exact `application/json` and `application/octet-stream` entries, then modeled JSON, binary, and empty responses in separate lossy collections. Generated status matchers consequently lacked handlers for binary success bodies and treated every empty response as successful.

When one status declared both JSON and binary content, both handlers were registered under the same generated object-literal key. Type-only binary clients also imported `HttpClient` as a type even though their stream helper uses it as a runtime value.

Type-only generation additionally activated explicit empty-success handlers only when an operation had a binary or bodiless-error response. Mixed JSON/empty successes and non-2xx empty successes therefore fell through to `unexpectedStatus`.

This consolidates and supersedes #6403 and #6404 so the shared response-matching path ships as one change.

## Validation

- `nix develop -c pnpm vitest packages/tools/openapi-generator/test --run` (80 tests passed, including generated-client compilation for both HttpClient formats)
- `nix develop -c pnpm check`
- `nix develop -c pnpm --filter @effect/openapi-generator check`
- `nix develop -c pnpm exec oxlint packages/tools/openapi-generator/src/OpenApiGenerator.ts packages/tools/openapi-generator/src/OpenApiTransformer.ts packages/tools/openapi-generator/test/OpenApiGenerator.test.ts`
- `nix develop -c pnpm exec dprint check packages/tools/openapi-generator/src/OpenApiGenerator.ts packages/tools/openapi-generator/src/OpenApiTransformer.ts packages/tools/openapi-generator/test/OpenApiGenerator.test.ts`

Closes EFF-700
Closes #6368
Closes #6372
Closes #6373
Closes #6374
