### PR TITLE
Fix escaped OpenAPI reference tokens

### DIFF
--- a/.changeset/openapi-pointer-references.md
+++ b/.changeset/openapi-pointer-references.md
@@ -1,0 +1,5 @@
+---
+"@effect/openapi-generator": patch
+---
+
+Decode JSON Pointer escapes when resolving local OpenAPI references.

--- a/packages/tools/openapi-generator/src/OpenApiGenerator.ts
+++ b/packages/tools/openapi-generator/src/OpenApiGenerator.ts
@@ -118,6 +118,8 @@ const methodNames: ReadonlyArray<OpenAPISpecMethodName> = [
   "trace"
 ]
 
+const decodeJsonPointerToken = (token: string): string => token.replaceAll("~1", "/").replaceAll("~0", "~")
+
 /**
  * Constructs the OpenAPI generator service implementation.
  *
@@ -137,7 +139,7 @@ export const make = Effect.gen(function*() {
       }
 
       function resolveRef(ref: string) {
-        const parts = ref.split("/").slice(1)
+        const parts = ref.split("/").slice(1).map(decodeJsonPointerToken)
         let current: any = spec
         for (const part of parts) {
           current = current[part]

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -794,14 +794,16 @@ export const TestClientError = <Tag extends string, E>(
               get: {
                 operationId: "listWidgets",
                 parameters: [
-                  { $ref: "#/components/parameters/Page~1Limit" },
-                  { $ref: "#/components/parameters/Tilde~0Name" }
+                  { $ref: "#/components/parameters/Page~1Limit" } as any,
+                  { $ref: "#/components/parameters/Tilde~0Name" } as any
                 ],
                 responses: {
                   204: {
                     description: "No content"
                   }
-                }
+                },
+                tags: ["Widgets"],
+                security: []
               }
             }
           },
@@ -821,7 +823,9 @@ export const TestClientError = <Tag extends string, E>(
                 schema: { type: "string" }
               }
             }
-          }
+          } as any,
+          security: [],
+          tags: [{ name: "Widgets" }]
         },
         [
           `readonly "limit"?: number`,

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -781,6 +781,55 @@ export const TestClientError = <Tag extends string, E>(
   }) as any`
       ))
 
+    it.effect("resolves JSON Pointer-escaped local references", () =>
+      assertRuntimeIncludes(
+        {
+          openapi: "3.1.0",
+          info: {
+            title: "Test API",
+            version: "1.0.0"
+          },
+          paths: {
+            "/widgets": {
+              get: {
+                operationId: "listWidgets",
+                parameters: [
+                  { $ref: "#/components/parameters/Page~1Limit" },
+                  { $ref: "#/components/parameters/Tilde~0Name" }
+                ],
+                responses: {
+                  204: {
+                    description: "No content"
+                  }
+                }
+              }
+            }
+          },
+          components: {
+            schemas: {},
+            parameters: {
+              "Page/Limit": {
+                name: "limit",
+                in: "query",
+                required: false,
+                schema: { type: "integer" }
+              },
+              "Tilde~Name": {
+                name: "tilde",
+                in: "query",
+                required: false,
+                schema: { type: "string" }
+              }
+            }
+          }
+        },
+        [
+          `readonly "limit"?: number`,
+          `readonly "tilde"?: string`,
+          `HttpClientRequest.setUrlParams({ "limit": options?.params?.["limit"] as any, "tilde": options?.params?.["tilde"] as any })`
+        ]
+      ))
+
     it.effect("sse operation decodes event payload from json string", () =>
       assertRuntimeIncludes(
         {


### PR DESCRIPTION
## Summary

- decode RFC 6901 `~1` and `~0` escapes while resolving local OpenAPI references
- preserve the required decoding order so escaped tildes remain correct
- add regression coverage for parameter component names containing `/` and `~`

## Validation

- `nix develop -c pnpm exec vitest run packages/tools/openapi-generator/test/OpenApiGenerator.test.ts` (32 tests passed)
- `nix develop -c pnpm --dir packages/tools/openapi-generator check`
- `nix develop -c pnpm lint`

Closes EFF-703
Closes #7320