### PR TITLE
Allow path-level parameters in OpenAPI generator inputs

### DIFF
--- a/.changeset/openapi-path-parameters.md
+++ b/.changeset/openapi-path-parameters.md
@@ -1,0 +1,6 @@
+---
+"effect": patch
+"@effect/openapi-generator": patch
+---
+
+Allow path-level common parameters in OpenAPI generator input types.

--- a/packages/effect/src/unstable/httpapi/OpenApi.ts
+++ b/packages/effect/src/unstable/httpapi/OpenApi.ts
@@ -1051,13 +1051,18 @@ export type OpenAPISpecMethodName =
 
 /**
  * Generated OpenAPI path item mapping HTTP methods to operations for a single route path.
+ * Parameters declared here are shared by every operation on the path.
  *
  * @category models
  * @since 4.0.0
  */
-export type OpenAPISpecPathItem = {
-  [K in OpenAPISpecMethodName]?: OpenAPISpecOperation
-}
+export type OpenAPISpecPathItem =
+  & {
+    [K in OpenAPISpecMethodName]?: OpenAPISpecOperation
+  }
+  & {
+    parameters?: Array<OpenAPISpecParameter>
+  }
 
 /**
  * Generated OpenAPI parameter object for path, query, header, or cookie parameters.

--- a/packages/tools/openapi-generator/src/OpenApiGenerator.ts
+++ b/packages/tools/openapi-generator/src/OpenApiGenerator.ts
@@ -290,8 +290,8 @@ const parseOpenApi = (
 
       const schemaId = Utils.identifier(operation.operationId ?? path)
 
-      const pathParameters = Predicate.isObject(methods) && Array.isArray((methods as any).parameters)
-        ? (methods as any).parameters as ReadonlyArray<unknown>
+      const pathParameters = Array.isArray(methods.parameters)
+        ? methods.parameters
         : undefined
       const parameters = resolveOperationParameters(
         pathParameters,

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -1370,7 +1370,7 @@ export const TestClientError = <Tag extends string, E>(
                 tags: ["Applications"],
                 security: []
               }
-            } as any
+            }
           },
           components: {
             schemas: {},


### PR DESCRIPTION
## Summary

- expose optional path-level common parameters on `OpenAPISpecPathItem`
- consume the typed property in the generator without an `any` cast
- turn the existing path-parameter generation coverage into a compile-time regression test
- add patch changesets for `effect` and `@effect/openapi-generator`

## Root cause

The generator already inherited Path Item Object parameters at runtime, but `OpenAPISpecPathItem` only modeled HTTP method keys. Valid OpenAPI input therefore required a cast even though the runtime supported it.

## Validation

- `nix develop -c pnpm vitest run --project @effect/openapi-generator packages/tools/openapi-generator/test/OpenApiGenerator.test.ts`
- `nix develop -c pnpm check`
- `nix develop -c pnpm lint`

Closes EFF-701
Closes #7318