### PR TITLE
Drop invalid OpenAPI schema examples

### DIFF
--- a/.changeset/fix-invalid-openapi-examples.md
+++ b/.changeset/fix-invalid-openapi-examples.md
@@ -1,0 +1,5 @@
+---
+"@effect/openapi-generator": patch
+---
+
+Drop invalid OpenAPI schema examples from generated Effect Schema annotations.

--- a/packages/tools/openapi-generator/src/JsonSchemaGenerator.ts
+++ b/packages/tools/openapi-generator/src/JsonSchemaGenerator.ts
@@ -19,8 +19,11 @@
  * @since 4.0.0
  */
 import * as Arr from "effect/Array"
+import * as Fn from "effect/Function"
 import * as JsonSchema from "effect/JsonSchema"
 import * as Rec from "effect/Record"
+import * as Schema from "effect/Schema"
+import * as SchemaAST from "effect/SchemaAST"
 import * as SchemaRepresentation from "effect/SchemaRepresentation"
 
 type Source = "openapi-3.0" | "openapi-3.1"
@@ -221,7 +224,10 @@ function makeWithRepresentation() {
         return options?.onEnter === undefined ? out : options.onEnter(out)
       }
     }
-    const rootSchemas = SchemaRepresentation.fromJsonSchemaMultiDocument(document, importerOptions)
+    const rootSchemas = Arr.map(
+      SchemaRepresentation.fromJsonSchemaMultiDocument(document, importerOptions),
+      (schema) => schema.rebuild(dropInvalidExamples(schema.ast))
+    )
     const codeDocument = SchemaRepresentation.toCodeDocument(
       SchemaRepresentation.toRepresentations(Arr.map(rootSchemas, (schema) => schema.ast))
     )
@@ -234,6 +240,19 @@ function makeWithRepresentation() {
 
   return { addSchema, generate, generateHttpApi } as const
 }
+
+const dropInvalidExamples = Fn.memoizeIdempotent((ast: SchemaAST.AST): SchemaAST.AST => {
+  const out = "recur" in ast ? ast.recur(dropInvalidExamples) : ast
+  const schema = Schema.make(out)
+  const examples = Schema.resolveAnnotations(schema)?.examples
+  if (!Array.isArray(examples)) return out
+
+  const isValid = Schema.is(schema)
+  const validExamples = examples.filter(isValid)
+  return validExamples.length === examples.length
+    ? out
+    : SchemaAST.annotate(out, { examples: validExamples.length === 0 ? undefined : validExamples })
+})
 
 function fromSchemaOpenApi(source: Source, jsonSchema: JsonSchema.JsonSchema) {
   switch (source) {

--- a/packages/tools/openapi-generator/src/JsonSchemaGenerator.ts
+++ b/packages/tools/openapi-generator/src/JsonSchemaGenerator.ts
@@ -19,11 +19,9 @@
  * @since 4.0.0
  */
 import * as Arr from "effect/Array"
-import * as Fn from "effect/Function"
 import * as JsonSchema from "effect/JsonSchema"
 import * as Rec from "effect/Record"
 import * as Schema from "effect/Schema"
-import * as SchemaAST from "effect/SchemaAST"
 import * as SchemaRepresentation from "effect/SchemaRepresentation"
 
 type Source = "openapi-3.0" | "openapi-3.1"
@@ -214,20 +212,48 @@ function makeWithRepresentation() {
       schemas,
       definitions
     }
+    const schemasWithExamples: Array<JsonSchema.JsonSchema> = []
+    const preparedSchemas = new WeakMap<JsonSchema.JsonSchema, JsonSchema.JsonSchema>()
+    const preparedOutputs = new WeakSet<JsonSchema.JsonSchema>()
     const importerOptions: SchemaRepresentation.FromJsonSchemaOptions = {
       patterns: "apply",
       onEnter(js: JsonSchema.JsonSchema) {
+        if (preparedOutputs.has(js)) return js
+        const cached = preparedSchemas.get(js)
+        if (cached !== undefined) return cached
+
         const out = { ...js }
         if (out.type === "object" && out.additionalProperties === undefined) {
           out.additionalProperties = false
         }
-        return options?.onEnter === undefined ? out : options.onEnter(out)
+        const transformed = { ...(options?.onEnter === undefined ? out : options.onEnter(out)) }
+        preparedSchemas.set(js, transformed)
+        preparedOutputs.add(transformed)
+        if (Array.isArray(transformed.examples)) {
+          schemasWithExamples.push(transformed)
+        }
+        return transformed
       }
     }
-    const rootSchemas = Arr.map(
-      SchemaRepresentation.fromJsonSchemaMultiDocument(document, importerOptions),
-      (schema) => schema.rebuild(dropInvalidExamples(schema.ast))
-    )
+    let rootSchemas = SchemaRepresentation.fromJsonSchemaMultiDocument(document, importerOptions)
+    if (Arr.isArrayNonEmpty(schemasWithExamples)) {
+      const exampleSchemas = SchemaRepresentation.fromJsonSchemaMultiDocument(
+        { ...document, schemas: schemasWithExamples },
+        importerOptions
+      )
+      for (let i = 0; i < schemasWithExamples.length; i++) {
+        const node = schemasWithExamples[i]
+        const examples = node.examples as ReadonlyArray<unknown>
+        const validExamples = examples.filter(Schema.is(exampleSchemas[i]))
+        if (validExamples.length === examples.length) continue
+        if (validExamples.length === 0) {
+          delete node.examples
+        } else {
+          node.examples = validExamples
+        }
+      }
+      rootSchemas = SchemaRepresentation.fromJsonSchemaMultiDocument(document, importerOptions)
+    }
     const codeDocument = SchemaRepresentation.toCodeDocument(
       SchemaRepresentation.toRepresentations(Arr.map(rootSchemas, (schema) => schema.ast))
     )
@@ -240,19 +266,6 @@ function makeWithRepresentation() {
 
   return { addSchema, generate, generateHttpApi } as const
 }
-
-const dropInvalidExamples = Fn.memoizeIdempotent((ast: SchemaAST.AST): SchemaAST.AST => {
-  const out = "recur" in ast ? ast.recur(dropInvalidExamples) : ast
-  const schema = Schema.make(out)
-  const examples = Schema.resolveAnnotations(schema)?.examples
-  if (!Array.isArray(examples)) return out
-
-  const isValid = Schema.is(schema)
-  const validExamples = examples.filter(isValid)
-  return validExamples.length === examples.length
-    ? out
-    : SchemaAST.annotate(out, { examples: validExamples.length === 0 ? undefined : validExamples })
-})
 
 function fromSchemaOpenApi(source: Source, jsonSchema: JsonSchema.JsonSchema) {
   switch (source) {

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -2706,6 +2706,45 @@ export const __HttpApiMultipartFiles = Multipart.FilesSchema`,
   })
 
   describe("regression", () => {
+    it.effect("emits compilable clients when schema examples are invalid", () =>
+      assertGeneratedClientsCompile({
+        openapi: "3.0.3",
+        info: {
+          title: "Invalid examples API",
+          version: "1.0.0"
+        },
+        paths: {
+          "/triggers": {
+            get: {
+              operationId: "getTriggers",
+              parameters: [],
+              responses: {
+                200: {
+                  description: "OK",
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "array",
+                        items: { type: "string" },
+                        example: "create"
+                      }
+                    }
+                  }
+                }
+              },
+              tags: ["Triggers"],
+              security: []
+            }
+          }
+        },
+        components: {
+          schemas: {},
+          securitySchemes: {}
+        },
+        security: [],
+        tags: [{ name: "Triggers" }]
+      } as unknown as OpenAPISpec))
+
     it.effect("runtime warnings do not report additional-tags-dropped outside httpapi", () =>
       assertRuntimeStableWithWarnings(
         {


### PR DESCRIPTION
## Summary

- validate OpenAPI schema examples against the generated Effect Schema node
- preserve valid examples while dropping values that would make generated annotations type-invalid
- add a regression that compiles generated schema-backed and type-only clients for the reported OpenAPI 3.0 case
- add a patch changeset for `@effect/openapi-generator`

## Validation

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/tools/openapi-generator/test/OpenApiGenerator.test.ts`
- `nix develop -c pnpm check`

Closes EFF-704
Closes #6356