### PR TITLE
Fix open object type generation

### DIFF
--- a/.changeset/open-objects-intersect.md
+++ b/.changeset/open-objects-intersect.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+"@effect/openapi-generator": patch
+---
+
+Emit mixed struct and record schema types as intersections, preventing optional
+properties in open OpenAPI objects from conflicting with their index signature.

--- a/packages/effect/src/internal/schema/toCodeDocument.ts
+++ b/packages/effect/src/internal/schema/toCodeDocument.ts
@@ -543,11 +543,11 @@ export function toCodeDocument(
           `Schema.Record(${signature.parameter.runtime}, ${signature.type.runtime})`
         ).join(", ")
         const indexTypes = indexSignatures.map((signature) =>
-          `readonly [x: ${signature.parameter.Type}]: ${signature.type.Type}`
-        ).join(", ")
+          `{ readonly [x: ${signature.parameter.Type}]: ${signature.type.Type} }`
+        )
         return makeCode(
           `Schema.StructWithRest(Schema.Struct({ ${propertyRuntimes} }), [${indexRuntimes}])`,
-          `{ ${propertyTypes}${properties.length > 0 ? ", " : ""}${indexTypes} }`
+          [`{ ${propertyTypes} }`, ...indexTypes].join(" & ")
         )
       }
       case "Union": {

--- a/packages/effect/src/internal/schema/toCodeDocument.ts
+++ b/packages/effect/src/internal/schema/toCodeDocument.ts
@@ -543,11 +543,17 @@ export function toCodeDocument(
           `Schema.Record(${signature.parameter.runtime}, ${signature.type.runtime})`
         ).join(", ")
         const indexTypes = indexSignatures.map((signature) =>
-          `{ readonly [x: ${signature.parameter.Type}]: ${signature.type.Type} }`
+          `readonly [x: ${signature.parameter.Type}]: ${signature.type.Type}`
         )
+        if (properties.length === 0) {
+          return makeCode(
+            `Schema.StructWithRest(Schema.Struct({ ${propertyRuntimes} }), [${indexRuntimes}])`,
+            `{ ${indexTypes.join(", ")} }`
+          )
+        }
         return makeCode(
           `Schema.StructWithRest(Schema.Struct({ ${propertyRuntimes} }), [${indexRuntimes}])`,
-          [`{ ${propertyTypes} }`, ...indexTypes].join(" & ")
+          [`{ ${propertyTypes} }`, ...indexTypes.map((indexType) => `{ ${indexType} }`)].join(" & ")
         )
       }
       case "Union": {

--- a/packages/effect/test/schema/representation/toCodeDocument.test.ts
+++ b/packages/effect/test/schema/representation/toCodeDocument.test.ts
@@ -1308,7 +1308,7 @@ describe("toCodeDocument", () => {
       {
         codes: makeCode(
           `Schema.StructWithRest(Schema.Struct({ "a": Schema.Number }), [Schema.Record(Schema.String, Schema.Number)])`,
-          `{ readonly "a": number, readonly [x: string]: number }`
+          `{ readonly "a": number } & { readonly [x: string]: number }`
         )
       }
     )
@@ -1321,7 +1321,7 @@ describe("toCodeDocument", () => {
       {
         codes: makeCode(
           `Schema.StructWithRest(Schema.Struct({ "a": Schema.Number }), [Schema.Record(Schema.String, Schema.Number)]).annotate({ "description": "a" })`,
-          `{ readonly "a": number, readonly [x: string]: number }`
+          `{ readonly "a": number } & { readonly [x: string]: number }`
         )
       }
     )

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -87,7 +87,13 @@ function assertTypeOnlyIncludes(
   )
 }
 
-function assertGeneratedClientsCompile(spec: OpenAPISpec) {
+function assertGeneratedClientsCompile(
+  spec: OpenAPISpec,
+  options: {
+    readonly exactOptionalPropertyTypes?: boolean | undefined
+    readonly formats?: ReadonlyArray<"httpclient" | "httpclient-type-only"> | undefined
+  } = {}
+) {
   const generate = (
     format: "httpclient" | "httpclient-type-only",
     layer: typeof OpenApiGenerator.layerTransformerSchema
@@ -98,23 +104,29 @@ function assertGeneratedClientsCompile(spec: OpenAPISpec) {
     }).pipe(Effect.provide(layer))
 
   return Effect.gen(function*() {
-    const [schemaClient, typeOnlyClient] = yield* Effect.all([
-      generate("httpclient", OpenApiGenerator.layerTransformerSchema),
-      generate("httpclient-type-only", OpenApiGenerator.layerTransformerTs)
-    ])
+    const formats = options.formats ?? ["httpclient", "httpclient-type-only"]
+    const clients = yield* Effect.all(formats.map((format) =>
+      generate(
+        format,
+        format === "httpclient"
+          ? OpenApiGenerator.layerTransformerSchema
+          : OpenApiGenerator.layerTransformerTs
+      )
+    ))
     const directory = mkdtempSync(join(dirname(fileURLToPath(import.meta.url)), ".generated-clients-"))
     try {
-      const schemaPath = join(directory, "SchemaClient.ts")
-      const typeOnlyPath = join(directory, "TypeOnlyClient.ts")
-      writeFileSync(schemaPath, schemaClient)
-      writeFileSync(typeOnlyPath, typeOnlyClient)
+      const files = clients.map((client, index) => {
+        const path = join(directory, `Client${index}.ts`)
+        writeFileSync(path, client)
+        return path
+      })
       const configPath = join(directory, "tsconfig.json")
       writeFileSync(
         configPath,
         JSON.stringify({
           compilerOptions: {
             allowImportingTsExtensions: true,
-            exactOptionalPropertyTypes: true,
+            exactOptionalPropertyTypes: options.exactOptionalPropertyTypes ?? true,
             lib: ["ESNext", "DOM"],
             module: "NodeNext",
             noEmit: true,
@@ -124,7 +136,7 @@ function assertGeneratedClientsCompile(spec: OpenAPISpec) {
             types: [],
             verbatimModuleSyntax: true
           },
-          files: [schemaPath, typeOnlyPath]
+          files
         })
       )
       const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "../../../..")
@@ -2770,5 +2782,54 @@ export const __HttpApiMultipartFiles = Multipart.FilesSchema`,
           operationId: "getUser"
         }
       ]))
+
+    it.effect("emits compilable open objects with optional properties", () =>
+      assertGeneratedClientsCompile(
+        {
+          openapi: "3.1.0",
+          info: {
+            title: "Open object regression API",
+            version: "1.0.0"
+          },
+          paths: {
+            "/widget": {
+              get: {
+                operationId: "getWidget",
+                parameters: [],
+                responses: {
+                  200: {
+                    description: "OK",
+                    content: {
+                      "application/json": {
+                        schema: {
+                          type: "object",
+                          properties: {
+                            optionalValue: {
+                              type: "string"
+                            }
+                          },
+                          additionalProperties: true
+                        }
+                      }
+                    }
+                  }
+                },
+                tags: ["Widgets"],
+                security: []
+              }
+            }
+          },
+          components: {
+            schemas: {},
+            securitySchemes: {}
+          },
+          security: [],
+          tags: []
+        },
+        {
+          exactOptionalPropertyTypes: false,
+          formats: ["httpclient"]
+        }
+      ))
   })
 })


### PR DESCRIPTION
## Summary

- emit mixed struct and record schema types as intersections
- add compile-level regression coverage for open objects with optional properties
- document the patch for `effect` and `@effect/openapi-generator`

## Root cause

`Schema.StructWithRest` models its fixed struct and record portions as an intersection, but `SchemaRepresentation.toCodeDocument` flattened both into one type literal. With TypeScript's default optional-property semantics, the flattened declaration made an optional property include `undefined` and conflict with the JSON index signature.

Keeping the generated type as an intersection matches the schema model and produces valid TypeScript without widening accepted additional-property values.

## Validation

- `nix develop -c pnpm check`
- `nix develop -c pnpm lint`
- `nix develop -c pnpm vitest packages/tools/openapi-generator/test/OpenApiGenerator.test.ts packages/effect/test/schema/representation/toCodeDocument.test.ts --run`

Closes EFF-702
Closes #7319
