### PR TITLE
Fix Graph runtime guards and bulk removal caching

### DIFF
--- a/.changeset/quiet-graphs-guard.md
+++ b/.changeset/quiet-graphs-guard.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Keep graph caches consistent during bulk removals and validate graph kinds at runtime.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -587,6 +587,9 @@ export const toSnapshot = <N, E, T extends Kind = "directed">(
  */
 export const make =
   <T extends Kind>(type: T) => <N, E>(mutate?: (mutable: MutableGraph<N, E, T>) => undefined): Graph<N, E, T> => {
+    if (type !== "directed" && type !== "undirected") {
+      throw new GraphError({ message: "Graph type must be directed or undirected" })
+    }
     if (mutate === undefined) {
       return internal.make<N, E, T>(type, false) as unknown as Graph<N, E, T>
     }
@@ -2688,8 +2691,12 @@ export const removeNodes = <N, E, T extends Kind = "directed">(
   mutable: MutableGraph<N, E, T>,
   nodeIndices: Iterable<NodeIndex>
 ): void => {
+  assertMutable(mutable)
+  if (internal.isTransforming(mutable)) {
+    throw new GraphError({ message: "Cannot mutate graph during a transformation" })
+  }
+  const indices = internal.withTransformation(mutable, () => Array.from(nodeIndices))
   const impl = getMutableImplForMutation(mutable)
-  const indices = Array.from(nodeIndices)
 
   let removed = false
   for (const nodeIndex of indices) {
@@ -2810,8 +2817,12 @@ export const removeEdges = <N, E, T extends Kind = "directed">(
   mutable: MutableGraph<N, E, T>,
   edgeIndices: Iterable<EdgeIndex>
 ): void => {
+  assertMutable(mutable)
+  if (internal.isTransforming(mutable)) {
+    throw new GraphError({ message: "Cannot mutate graph during a transformation" })
+  }
+  const indices = internal.withTransformation(mutable, () => Array.from(edgeIndices))
   const impl = getMutableImplForMutation(mutable)
-  const indices = Array.from(edgeIndices)
 
   let removed = false
   for (const edgeIndex of indices) {
@@ -4336,6 +4347,9 @@ export const isAcyclic = <N, E, T extends Kind = "directed">(
 export const isBipartite = <N, E>(
   graph: Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
 ): boolean => {
+  if ((graph as Graph<N, E, Kind> | MutableGraph<N, E, Kind>).type === "directed") {
+    throw new GraphError({ message: "Cannot determine bipartite status of directed graph" })
+  }
   const cache = csr.get(graph)
   const outgoing = csr.getOutgoing(cache)
   // -1 is uncolored; compact indices let coloring and the queue stay in typed arrays.

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -67,6 +67,13 @@ describe("Graph", () => {
       assert.strictEqual(Graph.edgeCount(undirectedGraph), 0)
     })
 
+    it("rejects invalid runtime graph kinds", () => {
+      assertGraphError(
+        () => Graph.make("invalid" as Graph.Kind)<never, never>(),
+        "Graph type must be directed or undirected"
+      )
+    })
+
     it("recognizes immutable and mutable graphs only", () => {
       assert.strictEqual(Graph.isGraph(Graph.directed()), true)
       assert.strictEqual(Graph.isGraph(Graph.beginMutation(Graph.undirected())), true)
@@ -717,6 +724,39 @@ describe("Graph", () => {
       const nodes = Graph.beginMutation(directed<string, never>(["A", "B"], []))
       Graph.removeNodes(nodes, Graph.indices(Graph.nodes(nodes)))
       assert.strictEqual(Graph.nodeCount(nodes), 0)
+    })
+
+    it("keeps caches fresh when bulk-removal iterables query the graph", () => {
+      const edges = Graph.beginMutation(directed(["A", "B"], [[0, 1, 1]]))
+      Graph.removeEdges(edges, {
+        *[Symbol.iterator]() {
+          assert.strictEqual(Graph.hasPath(edges, 0, 1), true)
+          yield 0
+        }
+      })
+      assert.strictEqual(Graph.hasPath(edges, 0, 1), false)
+
+      const nodes = Graph.beginMutation(directed(["A", "B"], [[0, 1, 1], [1, 0, 2]]))
+      Graph.removeNodes(nodes, {
+        *[Symbol.iterator]() {
+          assert.strictEqual(Graph.isAcyclic(nodes), false)
+          yield 1
+        }
+      })
+      assert.strictEqual(Graph.isAcyclic(nodes), true)
+    })
+
+    it("rejects finalization from bulk-removal iterables", () => {
+      const mutable = Graph.beginMutation(directed(["A", "B"], [[0, 1, 1]]))
+      assertGraphError(() =>
+        Graph.removeEdges(mutable, {
+          *[Symbol.iterator]() {
+            Graph.endMutation(mutable)
+            yield 0
+          }
+        }), "Cannot mutate graph during a transformation")
+      assert.strictEqual(mutable.mutable, true)
+      assert.strictEqual(Graph.edgeCount(mutable), 1)
     })
   })
 
@@ -1490,6 +1530,10 @@ describe("Graph", () => {
     })
 
     it("rejects directed and non-bipartite graphs", () => {
+      assertGraphError(
+        () => Graph.isBipartite(Graph.directed() as unknown as Graph.UndirectedGraph<never, never>),
+        "Cannot determine bipartite status of directed graph"
+      )
       assertGraphError(
         () => Graph.maximumBipartiteMatching(Graph.directed() as unknown as Graph.UndirectedGraph<never, never>),
         "Cannot find bipartite matching of directed graph"


### PR DESCRIPTION
## Summary

- collect bulk-removal iterables under the graph transformation guard so reads cannot repopulate stale CSR caches
- prevent nested mutation and finalization while bulk-removal inputs are evaluated
- validate graph kinds at runtime in `Graph.make` and `Graph.isBipartite`
- add regression coverage and a patch changeset

## Testing

- `pnpm --filter effect test --run test/Graph.test.ts`
- `pnpm lint-fix`
- `pnpm lint`
- `pnpm check`
- `git diff --check`

`pnpm check` completes successfully with an existing warning in `packages/platform/node/src/NodeWorker.ts:56`.