### PR TITLE
test: cover Ordering.reverse and Ordering.match

### DIFF
--- a/packages/effect/test/Ordering.test.ts
+++ b/packages/effect/test/Ordering.test.ts
@@ -15,4 +15,27 @@ describe("Ordering", () => {
     deepStrictEqual(R.combine(0, -1), -1)
     deepStrictEqual(R.combine(-1, 0), -1)
   })
+
+  it("reverse flips less-than and greater-than and leaves equal unchanged", () => {
+    deepStrictEqual(Ordering.reverse(-1), 1)
+    deepStrictEqual(Ordering.reverse(1), -1)
+    deepStrictEqual(Ordering.reverse(0), 0)
+  })
+
+  it("match selects the branch for the ordering in both data-first and data-last forms", () => {
+    const toMessage = Ordering.match({
+      onLessThan: () => "less than",
+      onEqual: () => "equal",
+      onGreaterThan: () => "greater than"
+    })
+
+    deepStrictEqual(toMessage(-1), "less than")
+    deepStrictEqual(toMessage(0), "equal")
+    deepStrictEqual(toMessage(1), "greater than")
+
+    deepStrictEqual(
+      Ordering.match(1, { onLessThan: () => "l", onEqual: () => "e", onGreaterThan: () => "g" }),
+      "g"
+    )
+  })
 })


### PR DESCRIPTION
## What

Adds unit-test coverage for the two `Ordering` exports that currently have no references in `packages/effect/test/Ordering.test.ts`:

- `reverse` — flips `LessThan`/`GreaterThan`, leaves `Equal` unchanged.
- `match` — pattern-matches an `Ordering` onto three branches (data-first and data-last).

With these, every export in the module is covered. Test-only change, following the existing `Ordering.test.ts` style (`import { Ordering } from "effect"`, `deepStrictEqual`); no source is touched.

## Verification

- Ran every assertion against the published v4 runtime (`effect@4.0.0-rc.110`): all pass. The `match` expectations mirror the runnable `import.meta.vitest` example in its JSDoc.
- Formatting checked against the repo `dprint.json` config (passes).

## AI tooling disclosure

Drafted with AI assistance, then reviewed and verified by hand against the runtime before submitting.
