### PR TITLE
Fix Effect.fn self transform binding

### DIFF
--- a/.changeset/fix-effect-fn-self.md
+++ b/.changeset/fix-effect-fn-self.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Effect.fn` binding the final transform as the generator body when using the `{ self }` overload.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -1257,7 +1257,7 @@ const makeFn = (
 ) => {
   const body = typeof bodyOrOptions === "function"
     ? bodyOrOptions
-    : (pipeables.pop()!).bind(bodyOrOptions.self)
+    : (pipeables.shift()!).bind(bodyOrOptions.self)
 
   return defineFunctionLength(body.length, function(this: any, ...args: Array<any>) {
     let result = suspend(() => {

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -3144,6 +3144,21 @@ describe("Effect", () => {
       })
     })
 
+    it.effect("should support self with pipeable arguments", () => {
+      const self = { prefix: "bound" }
+      const fn = Effect.fn(
+        { self },
+        function*(this: typeof self, value: string) {
+          return `${this.prefix}:${value}`
+        },
+        Effect.map((value) => value.toUpperCase())
+      )
+      return Effect.gen(function*() {
+        const result = yield* fn("value")
+        assert.strictEqual(result, "BOUND:VALUE")
+      })
+    })
+
     it("should proxy body length", () => {
       const traced = Effect.fn(function*(a: string, b: number) {
         return a.length + b


### PR DESCRIPTION
## Summary

- preserve the generator body when `Effect.fn` binds `{ self }`
- keep subsequent pipeable transforms in their original order
- add regression coverage for the bound-self overload with a transform
- add a patch changeset for the runtime behavior fix

## Root cause

`makeFn` removed the last pipeable when resolving the generator body for the `{ self }` overload. With one or more transforms, this bound the final transform as the body and left the actual generator to execute as a transform.

## Impact

Bound `Effect.fn` definitions can now safely use pipeable transforms without returning an invalid generator value at runtime.

## Validation

- `pnpm test --run packages/effect/test/Effect.test.ts` (240 tests passed)
- `pnpm lint-fix`
- `pnpm check`

Closes EFF-721