### PR TITLE
Pin fixed next release action

### DIFF
--- a/.github/workflows/release-queue.yml
+++ b/.github/workflows/release-queue.yml
@@ -35,7 +35,7 @@ jobs:
         if: github.event.pull_request
         env:
           GITHUB_TOKEN: ${{ secrets.EFFECT_BOT_GH }}
-      - uses: Effect-TS/next-release-action@0901387026995718742a42e0f6bf7743d0d83c2f
+      - uses: Effect-TS/next-release-action@63daaa626282bc42fad44dcb89c7f7db9c53b786
         with:
           github_token: ${{ secrets.EFFECT_BOT_GH }}
           base_branch: main


### PR DESCRIPTION
## Summary

- update the release queue workflow to pin `Effect-TS/next-release-action` at `63daaa626282bc42fad44dcb89c7f7db9c53b786`
- pick up the action's standardized GitHub error cause handling

## Root cause

The workflow was pinned at `0901387026995718742a42e0f6bf7743d0d83c2f`. That bundle constructs `GithubError` with a mismatched payload, so API failures leave the retry predicate reading `status` from `undefined`. The fixed revision preserves the original request error under `cause` and uses `cause.status`, preventing the release queue job from crashing while handling API failures.

## Validation

- reproduced the failing `Cannot read properties of undefined (reading 'status')` path from recent release queue runs
- `nix develop -c pnpm exec vp test --run` in `Effect-TS/next-release-action` (8 tests passed)
- `nix develop -c pnpm exec vp check` in `Effect-TS/next-release-action`
- `git diff --check`
- confirmed the pinned SHA exists and contains the fixed bundled action

`vp pack` was also attempted locally, but Vite+ could not resolve the already-declared `@typescript/native-preview` alias from the global pnpm store in this environment.

Closes EFF-723