### PR TITLE
fix(openapi): pass custom schema annotations

### DIFF
--- a/.changeset/fuzzy-schemas-annotate.md
+++ b/.changeset/fuzzy-schemas-annotate.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Allow `OpenApi.fromApi` to include selected custom schema annotations in generated OpenAPI documents.

--- a/packages/effect/src/unstable/httpapi/OpenApi.ts
+++ b/packages/effect/src/unstable/httpapi/OpenApi.ts
@@ -214,16 +214,18 @@ export const annotations: (
 const apiCache = new WeakMap<HttpApi.Constraint, OpenAPISpec>()
 
 type CompileSchemas = (
-  asts: readonly [SchemaAST.AST, ...Array<SchemaAST.AST>]
+  asts: readonly [SchemaAST.AST, ...Array<SchemaAST.AST>],
+  options?: FromApiOptions
 ) => JsonSchema.MultiDocument<"openapi-3.1">
 
-const compileSchemas: CompileSchemas = (asts) =>
+const compileSchemas: CompileSchemas = (asts, options) =>
   JsonSchema.toMultiDocumentOpenApi3_1(
     InternalToJsonSchemaDocument.toJsonSchemaMultiDocument(
       InternalToRepresentation.toRepresentations(
         Arr.map(asts, Schema.toCodecJsonAST),
         InternalToJsonSchemaDocument.toRepresentationOptions
-      )
+      ),
+      options
     )
   )
 
@@ -258,6 +260,23 @@ function processAnnotation<Services, S, I>(
 }
 
 /**
+ * Options for {@link fromApi}.
+ *
+ * @category options
+ * @since 4.0.0
+ */
+export interface FromApiOptions {
+  /**
+   * A predicate that controls which additional schema annotation keys are
+   * included in the generated OpenAPI document.
+   *
+   * Standard JSON Schema keys are always included. Use this for vendor
+   * extensions such as `x-*`.
+   */
+  readonly includeAnnotationKey?: Schema.ToJsonSchemaOptions["includeAnnotationKey"]
+}
+
+/**
  * Converts an `HttpApi` instance into an OpenAPI Specification object.
  *
  * **Details**
@@ -272,23 +291,27 @@ function processAnnotation<Services, S, I>(
  * The function also deduplicates schemas, applies transformations, and
  * integrates annotations like descriptions, summaries, external documentation,
  * and overrides. Cached results are used for better performance when the same
- * `HttpApi` instance is processed multiple times.
+ * `HttpApi` instance is processed multiple times without schema options.
  *
  * @category constructors
  * @since 4.0.0
  */
 export function fromApi<Id extends string, Groups extends HttpApiGroup.Constraint>(
-  api: HttpApi.HttpApi<Id, Groups>
+  api: HttpApi.HttpApi<Id, Groups>,
+  options?: FromApiOptions
 ): OpenAPISpec {
-  return fromApiWith(api, apiCache, compileSchemas)
+  if (options?.includeAnnotationKey === undefined) {
+    return fromApiWith(api, apiCache, compileSchemas)
+  }
+  return fromApiWith(api, undefined, (asts) => compileSchemas(asts, options))
 }
 
 function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
   api: HttpApi.HttpApi<Id, Groups>,
-  cache: WeakMap<HttpApi.Constraint, OpenAPISpec>,
+  cache: WeakMap<HttpApi.Constraint, OpenAPISpec> | undefined,
   compileSchemas: CompileSchemas
 ): OpenAPISpec {
-  const cached = cache.get(api)
+  const cached = cache?.get(api)
   if (cached !== undefined) {
     return cloneOpenAPISpec(cached)
   }
@@ -699,7 +722,7 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
     spec = transformFn(spec) as OpenAPISpec
   })
 
-  cache.set(api, cloneOpenAPISpec(spec))
+  cache?.set(api, cloneOpenAPISpec(spec))
 
   return spec
 }

--- a/packages/effect/test/unstable/httpapi/OpenApi.test.ts
+++ b/packages/effect/test/unstable/httpapi/OpenApi.test.ts
@@ -109,6 +109,36 @@ describe("OpenApi", () => {
     assert.strictEqual(cached.info.title, "Api")
   })
 
+  it("includes selected schema annotations", () => {
+    const Value = Schema.String.annotate({
+      identifier: "Value",
+      "x-test-brand": "Value"
+    })
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("test").add(
+        HttpApiEndpoint.get("value", "/value", { success: Value })
+      )
+    )
+
+    assert.deepStrictEqual(OpenApi.fromApi(Api).components.schemas, {
+      Value: { type: "string" }
+    })
+
+    assert.deepStrictEqual(
+      OpenApi.fromApi(Api, { includeAnnotationKey: (key) => key === "x-test-brand" }).components.schemas,
+      {
+        Value: {
+          type: "string",
+          "x-test-brand": "Value"
+        }
+      }
+    )
+
+    assert.deepStrictEqual(OpenApi.fromApi(Api).components.schemas, {
+      Value: { type: "string" }
+    })
+  })
+
   it("preserves every declared payload content type for normalized equivalents", () => {
     const profileA = "Application/Vnd.Effect+JSON; Profile=A"
     const profileB = "application/vnd.effect+json; profile=b"


### PR DESCRIPTION
## Summary

`Schema.toJsonSchemaDocument` already supports `includeAnnotationKey`, which is the opt-in mechanism for carrying custom JSON Schema annotation keys such as vendor extensions. `OpenApi.fromApi` did not pass that option to the same converter, so those annotations were silently dropped from generated OpenAPI schemas.

This is separate from [#7192](https://github.com/Effect-TS/effect/issues/7192) and [#7203](https://github.com/Effect-TS/effect/pull/7203), which concern annotations being lost while schemas are lowered across encoding links. This change fixes the missing OpenAPI pass-through.

## Change

- Add an optional `FromApiOptions` parameter to `OpenApi.fromApi`.
- Forward `includeAnnotationKey` to the existing JSON Schema compiler.
- Keep the existing cached path unchanged when no schema options are supplied.
- Avoid caching option-dependent output so different predicates cannot share a result.

The reproduction and test use only generic names:

```ts
const Value = Schema.String.annotate({
  identifier: "Value",
  "x-test-brand": "Value"
})

OpenApi.fromApi(Api, {
  includeAnnotationKey: (key) => key === "x-test-brand"
})
```

Before this change, the generated component was `{ type: "string" }`. With the change, it is `{ type: "string", "x-test-brand": "Value" }`.

## Verification

- `pnpm vitest run packages/effect/test/schema/toJsonSchemaDocument.test.ts packages/effect/test/unstable/httpapi/OpenApi.test.ts --project effect`
- `pnpm check`
- `pnpm lint`

The bug was found and fixed in this patch by Codex, OpenAI's coding agent, while investigating a generated OpenAPI schema integration. The reproduction deliberately contains no application-specific identifiers.
