### PR TITLE
fix(rpc): forward every worker-runner disconnect to the server

### DIFF
--- a/.changeset/worker-runner-multi-disconnect.md
+++ b/.changeset/worker-runner-multi-disconnect.md
@@ -3,5 +3,3 @@
 ---
 
 Forward every worker-runner client disconnect to the RPC server, not just the first one.
-
-`RpcServer.makeProtocolWorkerRunner` consumed the platform's `disconnects` queue with a single `Queue.take`, so the forwarding fiber completed after the first disconnected client. For multi-client worker runners (for example several `MessagePort` clients attached to one runner), the second and later disconnected clients never reached `server.disconnect`, leaking their request scopes and stream fibers on the server.

--- a/.changeset/worker-runner-multi-disconnect.md
+++ b/.changeset/worker-runner-multi-disconnect.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Forward every worker-runner client disconnect to the RPC server, not just the first one.
+
+`RpcServer.makeProtocolWorkerRunner` consumed the platform's `disconnects` queue with a single `Queue.take`, so the forwarding fiber completed after the first disconnected client. For multi-client worker runners (for example several `MessagePort` clients attached to one runner), the second and later disconnected clients never reached `server.disconnect`, leaking their request scopes and stream fibers on the server.

--- a/packages/effect/src/unstable/rpc/RpcServer.ts
+++ b/packages/effect/src/unstable/rpc/RpcServer.ts
@@ -1361,6 +1361,7 @@ export const makeProtocolWorkerRunner: Effect.Effect<
         clientIds.delete(clientId)
         return Queue.offer(disconnects, clientId)
       }),
+      Effect.forever,
       Effect.forkScoped
     )
   }


### PR DESCRIPTION
## Summary

`RpcServer.makeProtocolWorkerRunner` consumes the worker platform's `disconnects` queue with a single `Queue.take`:

```ts
if (backing.disconnects) {
  yield* Queue.take(backing.disconnects).pipe(
    Effect.tap((clientId) => {
      clientIds.delete(clientId)
      return Queue.offer(disconnects, clientId)
    }),
    Effect.forkScoped
  )
}
```

The forked fiber completes after forwarding **one** disconnect. When a worker runner serves multiple clients (e.g. an Electron utility process accepting several transferred `MessagePort`s through a custom `WorkerRunnerPlatform`), only the first disconnected client ever reaches the server's disconnect loop (`RpcServer.ts` — the `Effect.whileLoop` that calls `server.disconnect(clientId)`). Every later disconnected client leaks its request scopes and stream fibers on the server for the lifetime of the process, and `clientIds` retains the stale entries.

The fix is `Effect.forever` on the forwarding pipeline, mirroring the server-side consumer which already loops.

## Reproduction

Observed in a real multi-client Electron setup and reduced to: a worker-runner RPC server with one streaming rpc; connect three clients over `worker_threads` `MessageChannel` ports; each starts a stream (with `Stream.ensuring` to observe release); disconnect them one at a time. The first client's stream finalizer runs; the second and third never do. With this patch all three release. (Test harness: three clients → three disconnects → three observed stream releases; client 2 of 3 times out on current main.)

## Notes

- One-line fix plus a `patch` changeset.
- The equivalent consumer in `makeProtocol`'s server loop already uses `Effect.whileLoop`, so this brings the worker-runner protocol in line with the socket/http protocols' disconnect handling.
