### PR TITLE
Fix fiber observer cancellation during exit

### DIFF
--- a/.changeset/fix-fiber-exit-observers.md
+++ b/.changeset/fix-fiber-exit-observers.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Ensure fiber observer cancellation during exit does not skip remaining observers.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -564,6 +564,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     }
     this._observers.push(cb)
     return () => {
+      if (this._exit) return
       const index = this._observers.indexOf(cb)
       if (index >= 0) {
         this._observers.splice(index, 1)

--- a/packages/effect/test/Fiber.test.ts
+++ b/packages/effect/test/Fiber.test.ts
@@ -7,6 +7,23 @@ describe("Fiber", () => {
     assert.isTrue(Fiber.isFiber(result))
   })
 
+  it("notifies all observers when an observer cancels during exit", () => {
+    const fiber = Effect.runFork(Effect.never)
+    const observed: Array<number> = []
+    let cancel = () => {}
+    cancel = fiber.addObserver(() => {
+      observed.push(1)
+      cancel()
+    })
+    fiber.addObserver(() => {
+      observed.push(2)
+    })
+
+    fiber.interruptUnsafe()
+
+    assert.deepStrictEqual(observed, [1, 2])
+  })
+
   describe("joinAll", () => {
     it.effect("cleans up observers on interruption", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Summary

- stop observer cancellation from mutating the observer array after a fiber has exited
- add focused regression coverage proving every observer is notified when one cancels during exit dispatch
- add a patch changeset for `effect`

## Root cause

The cancellation closure returned by `addObserver` could splice the live observer array while `FiberImpl.evaluate` was iterating it. Removing the current observer shifted the next observer backward, causing it to be skipped and allowing interruption cleanup to hang.

## Validation

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/Fiber.test.ts` (9 passed)
- `pnpm check` (passes with an existing `NodeWorker.ts` Promise-in-success warning)

Closes EFF-724