### PR TITLE
Honor uninterruptible Cloudflare entity requests

### DIFF
--- a/.changeset/cloudflare-uninterruptible-client.md
+++ b/.changeset/cloudflare-uninterruptible-client.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-cloudflare": patch
+---
+
+Prevent client interruption from cancelling Cloudflare Durable Object handlers annotated as uninterruptible.

--- a/packages/platform/cloudflare/src/CloudflareCluster.ts
+++ b/packages/platform/cloudflare/src/CloudflareCluster.ts
@@ -355,6 +355,7 @@ const make = Effect.fnUntraced(function*(options: LayerOptions) {
           entries.delete(clientRequestId)
           requestTargets.delete(clientRequestId)
           if (entry === undefined) return Effect.void
+          if (Context.get(entry.rpc.annotations, Uninterruptible) === true) return Effect.void
           return Effect.promise(() => target.stub.interrupt(entry.storageRequestId, clientRequestId))
         }
         default:

--- a/packages/platform/cloudflare/test/CloudflareCluster.test.ts
+++ b/packages/platform/cloudflare/test/CloudflareCluster.test.ts
@@ -21,6 +21,10 @@ const User = Entity.make("User", [
   Rpc.make("Ping", { success: Schema.String })
 ])
 
+const UninterruptibleUser = Entity.make("UninterruptibleUser", [
+  Rpc.make("Ping", { success: Schema.String }).annotate(ClusterSchema.Uninterruptible, true)
+])
+
 const PersistedUser = Entity.make("PersistedUser", [
   Rpc.make("Ping", { success: Schema.String }).annotate(ClusterSchema.Persisted, true)
 ])
@@ -277,6 +281,43 @@ describe("CloudflareCluster", () => {
         yield* Fiber.interrupt(fiber)
 
         assert.deepStrictEqual(interruptions, [[requestId, requestId]])
+      }).pipe(Effect.provide(CloudflareCluster.layer(options)))
+    })
+
+    it.effect("does not interrupt an Uninterruptible Durable Object handler", () => {
+      let resumeInvoked!: () => void
+      const invoked = new Promise<void>((resolve) => {
+        resumeInvoked = resolve
+      })
+      const interruptions: Array<ReadonlyArray<string | undefined>> = []
+      const stub = {
+        invoke() {
+          resumeInvoked()
+          return new Promise<never>(() => {})
+        },
+        acknowledge() {
+          return Promise.resolve([])
+        },
+        interrupt(storageRequestId: string, clientRequestId?: string) {
+          interruptions.push([storageRequestId, clientRequestId])
+          return Promise.resolve()
+        }
+      }
+      const options: CloudflareCluster.LayerOptions = {
+        entities: [UninterruptibleUser],
+        entityNamespace: new FakeNamespace(stub) as any,
+        workflowNamespace: new FakeNamespace() as any,
+        queueNamespace: new FakeNamespace() as any,
+        singletonNamespace: new FakeNamespace() as any
+      }
+
+      return Effect.gen(function*() {
+        const makeClient = yield* UninterruptibleUser.client
+        const fiber = yield* Effect.forkChild(makeClient("42").Ping(void 0))
+        yield* Effect.promise(() => invoked)
+        yield* Fiber.interrupt(fiber)
+
+        assert.isEmpty(interruptions)
       }).pipe(Effect.provide(CloudflareCluster.layer(options)))
     })
 


### PR DESCRIPTION
## Summary

- suppress Durable Object interrupt forwarding for RPCs annotated `ClusterSchema.Uninterruptible`
- add a regression test covering client-fiber interruption through `CloudflareCluster.layer`
- add a patch changeset for `@effect/platform-cloudflare`

## Root cause

The Cloudflare client interrupt handler removed its local request bookkeeping but always invoked the Durable Object stub's `interrupt` method without inspecting the RPC annotations. This diverged from the classic cluster client and allowed uninterruptible handlers to be cancelled remotely.

## Validation

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/platform/cloudflare/test/CloudflareCluster.test.ts` (19 tests)
- `nix develop -c pnpm check`

Closes EFF-730