### PR TITLE
Fix ordered channel effects queue finalizer

### DIFF
--- a/.changeset/fix-channel-effects-finalizer.md
+++ b/.changeset/fix-channel-effects-finalizer.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Shut down the internal effects queue when ordered concurrent channel mapping closes.

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -2171,7 +2171,7 @@ const mapEffectConcurrent = <
           Effect.Effect<OutElem2, OutErr | EX | Cause.Done<OutDone>>,
           OutErr | EX | Cause.Done<OutDone>
         >(concurrencyN - 2)
-        yield* Scope.addFinalizer(forkedScope, Queue.shutdown(queue))
+        yield* Scope.addFinalizer(forkedScope, Queue.shutdown(effects))
 
         yield* Queue.take(effects).pipe(
           Effect.flatten,


### PR DESCRIPTION
## Summary

- shut down the ordered concurrent mapping `effects` queue when its forked scope closes
- add a patch changeset for `effect`

## Root cause

The finalizer registered after creating `effects` accidentally shut down the output `queue` a second time. That left the internal `effects` queue without its intended shutdown finalizer. The typo is currently benign because the fibers consuming the queue are interrupted with the same scope, so no public regression test can meaningfully distinguish the corrected cleanup behavior.

## Validation

- `pnpm --filter effect test --run test/Channel.test.ts`
- `pnpm lint-fix`
- `pnpm check` (passes with the existing `NodeWorker.ts` Promise-in-success warning)

Closes EFF-726