### PR TITLE
Add Redis subscribe API

### DIFF
--- a/.changeset/redis-subscribe-api.md
+++ b/.changeset/redis-subscribe-api.md
@@ -1,0 +1,8 @@
+---
+"effect": patch
+"@effect/platform-bun": patch
+"@effect/platform-deno": patch
+"@effect/platform-node": patch
+---
+
+Add scoped Redis pub/sub subscriptions that expose received messages through an Effect queue.

--- a/packages/effect/src/unstable/persistence/Redis.ts
+++ b/packages/effect/src/unstable/persistence/Redis.ts
@@ -43,6 +43,11 @@ export interface RedisMessage {
 export class Redis extends Context.Service<Redis, {
   readonly send: <A = unknown>(command: string, ...args: ReadonlyArray<string>) => Effect.Effect<A, RedisError>
 
+  /**
+   * Subscribes to a Redis pub/sub channel for the lifetime of the current
+   * scope. Redis does not replay messages published while a connection is
+   * interrupted, so reconnecting subscribers can observe delivery gaps.
+   */
   readonly subscribe: (
     channel: string
   ) => Effect.Effect<Queue.Dequeue<RedisMessage, RedisError>, never, Scope.Scope>

--- a/packages/effect/src/unstable/persistence/Redis.ts
+++ b/packages/effect/src/unstable/persistence/Redis.ts
@@ -1,9 +1,9 @@
 /**
  * Redis support shared by persistence modules.
  *
- * This module defines a `Redis` service that can send Redis commands and run
- * Lua scripts. It does not create a Redis client itself; callers provide a
- * `send` function from their client or connection pool. The module also
+ * This module defines a `Redis` service that can send Redis commands, subscribe
+ * to pub/sub channels, and run Lua scripts. It does not create a Redis client
+ * itself; callers provide the client-specific operations. The module also
  * provides helpers for describing Lua scripts, loading them once, and running
  * them later by their cached Redis id.
  *
@@ -17,16 +17,34 @@ import * as Equal from "../../Equal.ts"
 import * as Exit from "../../Exit.ts"
 import { constant, identity } from "../../Function.ts"
 import * as Hash from "../../Hash.ts"
+import * as Queue from "../../Queue.ts"
 import * as Schema from "../../Schema.ts"
+import * as Scope from "../../Scope.ts"
 
 /**
- * Service for sending Redis commands and evaluating cached Lua scripts.
+ * A message received from a Redis pub/sub channel.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface RedisMessage {
+  readonly channel: string
+  readonly message: string
+}
+
+/**
+ * Service for sending Redis commands, subscribing to channels, and evaluating
+ * cached Lua scripts.
  *
  * @category services
  * @since 4.0.0
  */
 export class Redis extends Context.Service<Redis, {
   readonly send: <A = unknown>(command: string, ...args: ReadonlyArray<string>) => Effect.Effect<A, RedisError>
+
+  readonly subscribe: (
+    channel: string
+  ) => Effect.Effect<Queue.Dequeue<RedisMessage, RedisError>, never, Scope.Scope>
 
   readonly eval: <
     Config extends {
@@ -37,7 +55,7 @@ export class Redis extends Context.Service<Redis, {
 }>()("effect/persistence/Redis") {}
 
 /**
- * Creates a `Redis` service from a raw command sender.
+ * Creates a `Redis` service from raw command and subscription operations.
  *
  * **Details**
  *
@@ -50,6 +68,10 @@ export class Redis extends Context.Service<Redis, {
 export const make = Effect.fnUntraced(function*(
   options: {
     readonly send: <A = unknown>(command: string, ...args: ReadonlyArray<string>) => Effect.Effect<A, RedisError>
+    readonly subscribe: (
+      channel: string,
+      onMessage: (message: RedisMessage) => void
+    ) => Effect.Effect<Effect.Effect<void, RedisError>, RedisError, Scope.Scope>
   }
 ) {
   const scriptCache = yield* Cache.makeWith(
@@ -85,8 +107,29 @@ export const make = Effect.fnUntraced(function*(
     )
   }
 
+  const subscribe = (
+    channel: string
+  ): Effect.Effect<Queue.Dequeue<RedisMessage, RedisError>, never, Scope.Scope> =>
+    Effect.gen(function*() {
+      const queue = yield* Queue.unbounded<RedisMessage, RedisError>()
+      yield* Scope.addFinalizer(yield* Effect.scope, Queue.shutdown(queue))
+      const subscribeResult = yield* Effect.result(options.subscribe(channel, (message) => {
+        Queue.offerUnsafe(queue, message)
+      }))
+      if (subscribeResult._tag === "Failure") {
+        yield* Queue.fail(queue, subscribeResult.failure)
+        return queue
+      }
+      yield* subscribeResult.success.pipe(
+        Effect.catchCause((cause) => Queue.failCause(queue, cause).pipe(Effect.asVoid)),
+        Effect.forkScoped
+      )
+      return queue
+    })
+
   return identity<Redis["Service"]>({
     send: options.send,
+    subscribe,
     eval: eval_
   })
 })

--- a/packages/effect/src/unstable/persistence/Redis.ts
+++ b/packages/effect/src/unstable/persistence/Redis.ts
@@ -113,21 +113,18 @@ export const make = Effect.fnUntraced(function*(
     )
   }
 
-  const subscribe = (
-    channel: string
-  ): Effect.Effect<Queue.Dequeue<RedisMessage, RedisError>, never, Scope.Scope> =>
-    Effect.gen(function*() {
-      const queue = yield* Queue.unbounded<RedisMessage, RedisError>()
-      yield* Scope.addFinalizer(yield* Effect.scope, Queue.shutdown(queue))
-      const onFailure = (cause: Cause.Cause<RedisError>) => Queue.failCause(queue, cause).pipe(Effect.asVoid)
-      yield* options.subscribe(channel, (message) => {
-        Queue.offerUnsafe(queue, message)
-      }).pipe(
-        Effect.flatMap((listen) => Effect.forkScoped(Effect.catchCause(listen, onFailure))),
-        Effect.catchCause(onFailure)
-      )
-      return queue
-    })
+  const subscribe = Effect.fnUntraced(function*(channel: string) {
+    const queue = yield* Queue.unbounded<RedisMessage, RedisError>()
+    yield* Scope.addFinalizer(yield* Effect.scope, Queue.shutdown(queue))
+    const onFailure = (cause: Cause.Cause<RedisError>) => Queue.failCause(queue, cause).pipe(Effect.asVoid)
+    yield* options.subscribe(channel, (message) => {
+      Queue.offerUnsafe(queue, message)
+    }).pipe(
+      Effect.flatMap((listen) => Effect.forkScoped(Effect.catchCause(listen, onFailure))),
+      Effect.catchCause(onFailure)
+    )
+    return queue
+  })
 
   return identity<Redis["Service"]>({
     send: options.send,

--- a/packages/effect/src/unstable/persistence/Redis.ts
+++ b/packages/effect/src/unstable/persistence/Redis.ts
@@ -45,8 +45,10 @@ export class Redis extends Context.Service<Redis, {
 
   /**
    * Subscribes to a Redis pub/sub channel for the lifetime of the current
-   * scope. Redis does not replay messages published while a connection is
-   * interrupted, so reconnecting subscribers can observe delivery gaps.
+   * scope. Node and Deno subscribers reconnect and re-subscribe after an
+   * interruption, so messages published during recovery appear as delivery
+   * gaps. Bun subscribers do not reconnect: a dropped connection fails the
+   * dequeue, and the caller must subscribe again.
    */
   readonly subscribe: (
     channel: string

--- a/packages/effect/src/unstable/persistence/Redis.ts
+++ b/packages/effect/src/unstable/persistence/Redis.ts
@@ -10,6 +10,7 @@
  * @since 4.0.0
  */
 import * as Cache from "../../Cache.ts"
+import type * as Cause from "../../Cause.ts"
 import * as Context from "../../Context.ts"
 import * as Duration from "../../Duration.ts"
 import * as Effect from "../../Effect.ts"
@@ -113,16 +114,12 @@ export const make = Effect.fnUntraced(function*(
     Effect.gen(function*() {
       const queue = yield* Queue.unbounded<RedisMessage, RedisError>()
       yield* Scope.addFinalizer(yield* Effect.scope, Queue.shutdown(queue))
-      const subscribeResult = yield* Effect.result(options.subscribe(channel, (message) => {
+      const onFailure = (cause: Cause.Cause<RedisError>) => Queue.failCause(queue, cause).pipe(Effect.asVoid)
+      yield* options.subscribe(channel, (message) => {
         Queue.offerUnsafe(queue, message)
-      }))
-      if (subscribeResult._tag === "Failure") {
-        yield* Queue.fail(queue, subscribeResult.failure)
-        return queue
-      }
-      yield* subscribeResult.success.pipe(
-        Effect.catchCause((cause) => Queue.failCause(queue, cause).pipe(Effect.asVoid)),
-        Effect.forkScoped
+      }).pipe(
+        Effect.flatMap((listen) => Effect.forkScoped(Effect.catchCause(listen, onFailure))),
+        Effect.catchCause(onFailure)
       )
       return queue
     })

--- a/packages/effect/test/unstable/persistence/Redis.test.ts
+++ b/packages/effect/test/unstable/persistence/Redis.test.ts
@@ -151,7 +151,7 @@ describe("Redis", () => {
     }))
 
   it.effect("receives messages from a subscription", () =>
-    Effect.scoped(Effect.gen(function*() {
+    Effect.gen(function*() {
       const redis = yield* Redis.make({
         send: () => Effect.die("unused"),
         subscribe: (_channel, onMessage) =>
@@ -167,10 +167,10 @@ describe("Redis", () => {
         channel: "events",
         message: "hello"
       })
-    })))
+    }))
 
   it.effect("reports subscription setup failures through the dequeue", () =>
-    Effect.scoped(Effect.gen(function*() {
+    Effect.gen(function*() {
       const error = new Redis.RedisError({ cause: new Error("subscription failed") })
       const redis = yield* Redis.make({
         send: () => Effect.die("unused"),
@@ -180,10 +180,10 @@ describe("Redis", () => {
       const subscription = yield* redis.subscribe("events")
 
       assert.strictEqual(yield* Queue.take(subscription).pipe(Effect.flip), error)
-    })))
+    }))
 
   it.effect("reports listener failures through the dequeue", () =>
-    Effect.scoped(Effect.gen(function*() {
+    Effect.gen(function*() {
       const error = new Redis.RedisError({ cause: new Error("listener failed") })
       const redis = yield* Redis.make({
         send: () => Effect.die("unused"),
@@ -193,7 +193,7 @@ describe("Redis", () => {
       const subscription = yield* redis.subscribe("events")
 
       assert.strictEqual(yield* Queue.take(subscription).pipe(Effect.flip), error)
-    })))
+    }))
 
   it.effect("shuts down the dequeue and releases the subscriber with its scope", () =>
     Effect.gen(function*() {

--- a/packages/effect/test/unstable/persistence/Redis.test.ts
+++ b/packages/effect/test/unstable/persistence/Redis.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Duration, Effect, Layer, Queue } from "effect"
+import { Duration, Effect, Exit, Layer, Queue, Scope } from "effect"
 import { Persistence, Redis } from "effect/unstable/persistence"
 
 describe("Redis", () => {
@@ -169,7 +169,7 @@ describe("Redis", () => {
       })
     })))
 
-  it.effect("reports subscription failures through the dequeue", () =>
+  it.effect("reports subscription setup failures through the dequeue", () =>
     Effect.scoped(Effect.gen(function*() {
       const error = new Redis.RedisError({ cause: new Error("subscription failed") })
       const redis = yield* Redis.make({
@@ -181,4 +181,40 @@ describe("Redis", () => {
 
       assert.strictEqual(yield* Queue.take(subscription).pipe(Effect.flip), error)
     })))
+
+  it.effect("reports listener failures through the dequeue", () =>
+    Effect.scoped(Effect.gen(function*() {
+      const error = new Redis.RedisError({ cause: new Error("listener failed") })
+      const redis = yield* Redis.make({
+        send: () => Effect.die("unused"),
+        subscribe: () => Effect.succeed(Effect.fail(error))
+      })
+
+      const subscription = yield* redis.subscribe("events")
+
+      assert.strictEqual(yield* Queue.take(subscription).pipe(Effect.flip), error)
+    })))
+
+  it.effect("shuts down the dequeue and releases the subscriber with its scope", () =>
+    Effect.gen(function*() {
+      let released = false
+      const redis = yield* Redis.make({
+        send: () => Effect.die("unused"),
+        subscribe: () =>
+          Effect.acquireRelease(
+            Effect.void,
+            () =>
+              Effect.sync(() => {
+                released = true
+              })
+          ).pipe(Effect.as(Effect.never))
+      })
+      const scope = yield* Scope.make()
+      const subscription = yield* redis.subscribe("events").pipe(Scope.provide(scope))
+
+      yield* Scope.close(scope, Exit.void)
+
+      assert.isTrue(released)
+      assert.strictEqual(subscription.state._tag, "Done")
+    }))
 })

--- a/packages/effect/test/unstable/persistence/Redis.test.ts
+++ b/packages/effect/test/unstable/persistence/Redis.test.ts
@@ -24,7 +24,7 @@ describe("Redis", () => {
         }
         return Effect.succeed(undefined as unknown as A)
       },
-      subscribe: () => Effect.succeed(Effect.never),
+      subscribe: () => Queue.unbounded<Redis.RedisMessage, Redis.RedisError>(),
       eval: () => () => Effect.die("unused")
     })
     return Effect.gen(function*() {
@@ -44,7 +44,7 @@ describe("Redis", () => {
         commands.push([command, args])
         return Effect.succeed(undefined as unknown as A)
       },
-      subscribe: () => Effect.succeed(Effect.never),
+      subscribe: () => Queue.unbounded<Redis.RedisMessage, Redis.RedisError>(),
       eval:
         <Config extends { readonly params: ReadonlyArray<unknown>; readonly result: unknown }>() =>
         (...params: Config["params"]) => {

--- a/packages/effect/test/unstable/persistence/Redis.test.ts
+++ b/packages/effect/test/unstable/persistence/Redis.test.ts
@@ -215,6 +215,6 @@ describe("Redis", () => {
       yield* Scope.close(scope, Exit.void)
 
       assert.isTrue(released)
-      assert.strictEqual(subscription.state._tag, "Done")
+      assert.isTrue(Exit.hasInterrupts(yield* Queue.take(subscription).pipe(Effect.exit)))
     }))
 })

--- a/packages/effect/test/unstable/persistence/Redis.test.ts
+++ b/packages/effect/test/unstable/persistence/Redis.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Duration, Effect, Layer } from "effect"
+import { Duration, Effect, Layer, Queue } from "effect"
 import { Persistence, Redis } from "effect/unstable/persistence"
 
 describe("Redis", () => {
@@ -24,6 +24,7 @@ describe("Redis", () => {
         }
         return Effect.succeed(undefined as unknown as A)
       },
+      subscribe: () => Effect.succeed(Effect.never),
       eval: () => () => Effect.die("unused")
     })
     return Effect.gen(function*() {
@@ -43,6 +44,7 @@ describe("Redis", () => {
         commands.push([command, args])
         return Effect.succeed(undefined as unknown as A)
       },
+      subscribe: () => Effect.succeed(Effect.never),
       eval:
         <Config extends { readonly params: ReadonlyArray<unknown>; readonly result: unknown }>() =>
         (...params: Config["params"]) => {
@@ -87,7 +89,8 @@ describe("Redis", () => {
               return Effect.succeed("sha" as any)
             }
             return Effect.succeed("ok")
-          })
+          }),
+        subscribe: () => Effect.succeed(Effect.never)
       })
       const evalScript = redis.eval(
         Redis.script((key: string) => [key], {
@@ -126,7 +129,8 @@ describe("Redis", () => {
               return Effect.fail(new Redis.RedisError({ cause: new Error("NOSCRIPT No matching script") }))
             }
             return Effect.succeed("ok")
-          })
+          }),
+        subscribe: () => Effect.succeed(Effect.never)
       })
       const evalScript = redis.eval(
         Redis.script((key: string) => [key], {
@@ -145,4 +149,36 @@ describe("Redis", () => {
         "EVALSHA"
       ])
     }))
+
+  it.effect("receives messages from a subscription", () =>
+    Effect.scoped(Effect.gen(function*() {
+      const redis = yield* Redis.make({
+        send: () => Effect.die("unused"),
+        subscribe: (_channel, onMessage) =>
+          Effect.sync(() => {
+            onMessage({ channel: "events", message: "hello" })
+            return Effect.never
+          })
+      })
+
+      const subscription = yield* redis.subscribe("events")
+
+      assert.deepStrictEqual(yield* Queue.take(subscription), {
+        channel: "events",
+        message: "hello"
+      })
+    })))
+
+  it.effect("reports subscription failures through the dequeue", () =>
+    Effect.scoped(Effect.gen(function*() {
+      const error = new Redis.RedisError({ cause: new Error("subscription failed") })
+      const redis = yield* Redis.make({
+        send: () => Effect.die("unused"),
+        subscribe: () => Effect.fail(error)
+      })
+
+      const subscription = yield* redis.subscribe("events")
+
+      assert.strictEqual(yield* Queue.take(subscription).pipe(Effect.flip), error)
+    })))
 })

--- a/packages/platform/bun/src/BunRedis.ts
+++ b/packages/platform/bun/src/BunRedis.ts
@@ -49,7 +49,26 @@ const make = Effect.fnUntraced(function*(
       Effect.tryPromise({
         try: () => client.send(command, args as Array<string>) as Promise<A>,
         catch: (cause) => new Redis.RedisError({ cause })
-      })
+      }),
+    subscribe: (channel, onMessage) =>
+      Effect.acquireRelease(
+        Effect.tryPromise({
+          try: async () => {
+            const subscriber = new RedisClient(options?.url, options)
+            try {
+              await subscriber.subscribe(channel, (message, channel) => {
+                onMessage({ channel, message })
+              })
+              return subscriber
+            } catch (cause) {
+              subscriber.close()
+              throw cause
+            }
+          },
+          catch: (cause) => new Redis.RedisError({ cause })
+        }),
+        (subscriber) => Effect.sync(() => subscriber.close())
+      ).pipe(Effect.as(Effect.never))
   })
 
   const bunRedis = Fn.identity<BunRedis["Service"]>({

--- a/packages/platform/bun/src/BunRedis.ts
+++ b/packages/platform/bun/src/BunRedis.ts
@@ -12,6 +12,7 @@
 import { RedisClient, type RedisOptions } from "bun"
 import * as Config from "effect/Config"
 import * as Context from "effect/Context"
+import * as Deferred from "effect/Deferred"
 import * as Effect from "effect/Effect"
 import * as Fn from "effect/Function"
 import * as Layer from "effect/Layer"
@@ -37,6 +38,7 @@ const make = Effect.fnUntraced(function*(
   const scope = yield* Effect.scope
   yield* Scope.addFinalizer(scope, Effect.sync(() => client.close()))
   const client = new RedisClient(options?.url, options)
+  const runSync = Effect.runSyncWith(yield* Effect.context<never>())
 
   const use = <A>(f: (client: RedisClient) => Promise<A>) =>
     Effect.tryPromise({
@@ -51,24 +53,36 @@ const make = Effect.fnUntraced(function*(
         catch: (cause) => new Redis.RedisError({ cause })
       }),
     subscribe: (channel, onMessage) =>
-      Effect.acquireRelease(
-        Effect.tryPromise({
-          try: async () => {
-            const subscriber = new RedisClient(options?.url, options)
-            try {
-              await subscriber.subscribe(channel, (message, channel) => {
-                onMessage({ channel, message })
-              })
-              return subscriber
-            } catch (cause) {
+      Effect.gen(function*() {
+        const terminal = yield* Deferred.make<void, Redis.RedisError>()
+        yield* Effect.acquireRelease(
+          Effect.tryPromise({
+            try: async () => {
+              const subscriber = new RedisClient(options?.url, options)
+              subscriber.onclose = (cause) => {
+                runSync(Deferred.fail(terminal, new Redis.RedisError({ cause })))
+              }
+              try {
+                await subscriber.subscribe(channel, (message, channel) => {
+                  onMessage({ channel, message })
+                })
+                return subscriber
+              } catch (cause) {
+                subscriber.onclose = null
+                subscriber.close()
+                throw cause
+              }
+            },
+            catch: (cause) => new Redis.RedisError({ cause })
+          }),
+          (subscriber) =>
+            Effect.sync(() => {
+              subscriber.onclose = null
               subscriber.close()
-              throw cause
-            }
-          },
-          catch: (cause) => new Redis.RedisError({ cause })
-        }),
-        (subscriber) => Effect.sync(() => subscriber.close())
-      ).pipe(Effect.as(Effect.never))
+            })
+        )
+        return Deferred.await(terminal)
+      })
   })
 
   const bunRedis = Fn.identity<BunRedis["Service"]>({

--- a/packages/platform/bun/src/BunRedis.ts
+++ b/packages/platform/bun/src/BunRedis.ts
@@ -38,7 +38,6 @@ const make = Effect.fnUntraced(function*(
   const scope = yield* Effect.scope
   yield* Scope.addFinalizer(scope, Effect.sync(() => client.close()))
   const client = new RedisClient(options?.url, options)
-  const runSync = Effect.runSyncWith(yield* Effect.context<never>())
 
   const use = <A>(f: (client: RedisClient) => Promise<A>) =>
     Effect.tryPromise({
@@ -63,7 +62,7 @@ const make = Effect.fnUntraced(function*(
                 autoReconnect: false
               })
               subscriber.onclose = (cause) => {
-                runSync(Deferred.fail(terminal, new Redis.RedisError({ cause })))
+                Deferred.doneUnsafe(terminal, new Redis.RedisError({ cause }))
               }
               try {
                 await subscriber.subscribe(channel, (message, channel) => {

--- a/packages/platform/bun/src/BunRedis.ts
+++ b/packages/platform/bun/src/BunRedis.ts
@@ -58,7 +58,10 @@ const make = Effect.fnUntraced(function*(
         yield* Effect.acquireRelease(
           Effect.tryPromise({
             try: async () => {
-              const subscriber = new RedisClient(options?.url, options)
+              const subscriber = new RedisClient(options?.url, {
+                ...options,
+                autoReconnect: false
+              })
               subscriber.onclose = (cause) => {
                 runSync(Deferred.fail(terminal, new Redis.RedisError({ cause })))
               }

--- a/packages/platform/deno/src/DenoRedis.ts
+++ b/packages/platform/deno/src/DenoRedis.ts
@@ -81,6 +81,9 @@ const make = Effect.fnUntraced(function*(options: RedisOptions = {}) {
             const subscriber = await connectClient()
             try {
               const subscription = await subscriber.subscribe(channel)
+              // @db/redis resolves subscribe after writing the command, before
+              // reading its acknowledgement. This ordered reply proves that
+              // Redis processed SUBSCRIBE before the dequeue is returned.
               await subscriber.ping()
               return { subscriber, subscription }
             } catch (cause) {

--- a/packages/platform/deno/src/DenoRedis.ts
+++ b/packages/platform/deno/src/DenoRedis.ts
@@ -44,17 +44,19 @@ export class DenoRedis extends Context.Service<DenoRedis, {
 }>()("@effect/platform-deno/DenoRedis") {}
 
 const make = Effect.fnUntraced(function*(options: RedisOptions = {}) {
+  const connectClient = () => {
+    const { url, ...connectOptions } = options
+    const { name, ...parsed } = url === undefined ? { hostname: "localhost" } : parseURL(url)
+    return connect({
+      ...parsed,
+      ...(name === undefined ? {} : { username: name }),
+      ...Record.filter(connectOptions, Predicate.isNotUndefined)
+    })
+  }
+
   const client = yield* Effect.acquireRelease(
     Effect.tryPromise({
-      try: () => {
-        const { url, ...connectOptions } = options
-        const { name, ...parsed } = url === undefined ? { hostname: "localhost" } : parseURL(url)
-        return connect({
-          ...parsed,
-          ...(name === undefined ? {} : { username: name }),
-          ...Record.filter(connectOptions, Predicate.isNotUndefined)
-        })
-      },
+      try: connectClient,
       catch: (cause) => new Redis.RedisError({ cause })
     }),
     (client) => Effect.sync(() => client.close())
@@ -76,15 +78,10 @@ const make = Effect.fnUntraced(function*(options: RedisOptions = {}) {
       Effect.acquireRelease(
         Effect.tryPromise({
           try: async () => {
-            const { url, ...connectOptions } = options
-            const { name, ...parsed } = url === undefined ? { hostname: "localhost" } : parseURL(url)
-            const subscriber = await connect({
-              ...parsed,
-              ...(name === undefined ? {} : { username: name }),
-              ...Record.filter(connectOptions, Predicate.isNotUndefined)
-            })
+            const subscriber = await connectClient()
             try {
               const subscription = await subscriber.subscribe(channel)
+              await subscriber.ping()
               return { subscriber, subscription }
             } catch (cause) {
               subscriber.close()

--- a/packages/platform/deno/src/DenoRedis.ts
+++ b/packages/platform/deno/src/DenoRedis.ts
@@ -71,7 +71,41 @@ const make = Effect.fnUntraced(function*(options: RedisOptions = {}) {
       Effect.tryPromise({
         try: () => client.sendCommand(command, args as Array<string>) as Promise<A>,
         catch: (cause) => new Redis.RedisError({ cause })
-      })
+      }),
+    subscribe: (channel, onMessage) =>
+      Effect.acquireRelease(
+        Effect.tryPromise({
+          try: async () => {
+            const { url, ...connectOptions } = options
+            const { name, ...parsed } = url === undefined ? { hostname: "localhost" } : parseURL(url)
+            const subscriber = await connect({
+              ...parsed,
+              ...(name === undefined ? {} : { username: name }),
+              ...Record.filter(connectOptions, Predicate.isNotUndefined)
+            })
+            try {
+              const subscription = await subscriber.subscribe(channel)
+              return { subscriber, subscription }
+            } catch (cause) {
+              subscriber.close()
+              throw cause
+            }
+          },
+          catch: (cause) => new Redis.RedisError({ cause })
+        }),
+        ({ subscriber }) => Effect.sync(() => subscriber.close())
+      ).pipe(
+        Effect.map(({ subscription }) =>
+          Effect.tryPromise({
+            try: async () => {
+              for await (const message of subscription.receive()) {
+                onMessage(message)
+              }
+            },
+            catch: (cause) => new Redis.RedisError({ cause })
+          })
+        )
+      )
   })
 
   const denoRedis = Fn.identity<DenoRedis["Service"]>({

--- a/packages/platform/deno/test/DenoRedis.integration.test.ts
+++ b/packages/platform/deno/test/DenoRedis.integration.test.ts
@@ -1,8 +1,8 @@
 import * as DenoRedis from "@effect/platform-deno/DenoRedis"
 import { assert, it } from "@effect/vitest"
 import { RedisContainer } from "@testcontainers/redis"
-import { Deferred, Effect, Fiber, Layer, Schema } from "effect"
-import { PersistedQueue, Persistence } from "effect/unstable/persistence"
+import { Deferred, Effect, Fiber, Layer, Queue, Schema } from "effect"
+import { PersistedQueue, Persistence, Redis } from "effect/unstable/persistence"
 import * as PersistedCacheTest from "../../../effect/test/unstable/persistence/PersistedCacheTest.ts"
 import * as PersistedQueueTest from "../../../effect/test/unstable/persistence/PersistedQueueTest.ts"
 
@@ -47,6 +47,19 @@ const PersistedQueueRedisLayer = Layer.mergeAll(
 it.layer(PersistedQueueRedisLayer, { timeout: "30 seconds" })(
   "PersistedQueue (DenoRedis)",
   (it) => {
+    it.effect("receives published messages", () =>
+      Effect.gen(function*() {
+        const redis = yield* Redis.Redis
+        const subscription = yield* redis.subscribe("effect-test")
+
+        yield* redis.send("PUBLISH", "effect-test", "hello")
+
+        assert.deepStrictEqual(yield* Queue.take(subscription), {
+          channel: "effect-test",
+          message: "hello"
+        })
+      }))
+
     it.effect("moves exhausted elements to the failed list", () =>
       Effect.gen(function*() {
         const redis = yield* DenoRedis.DenoRedis

--- a/packages/platform/deno/test/DenoRedis.integration.test.ts
+++ b/packages/platform/deno/test/DenoRedis.integration.test.ts
@@ -52,7 +52,8 @@ it.layer(PersistedQueueRedisLayer, { timeout: "30 seconds" })(
         const redis = yield* Redis.Redis
         const subscription = yield* redis.subscribe("effect-test")
 
-        yield* redis.send("PUBLISH", "effect-test", "hello")
+        const subscribers = yield* redis.send<number>("PUBLISH", "effect-test", "hello")
+        assert.strictEqual(subscribers, 1)
 
         assert.deepStrictEqual(yield* Queue.take(subscription), {
           channel: "effect-test",

--- a/packages/platform/node/src/NodeRedis.ts
+++ b/packages/platform/node/src/NodeRedis.ts
@@ -87,7 +87,30 @@ const make = Effect.fnUntraced(function*(
       Effect.tryPromise({
         try: () => client.sendCommand([command, ...args]) as Promise<A>,
         catch: (cause) => new Redis.RedisError({ cause })
-      })
+      }),
+    subscribe: (channel, onMessage) =>
+      Effect.acquireRelease(
+        Effect.tryPromise({
+          try: async () => {
+            const subscriber = client.duplicate()
+            subscriber.on("error", (cause) => {
+              runSync(Effect.logWarning("NodeRedis subscriber error", cause))
+            })
+            try {
+              await subscriber.connect()
+              await subscriber.subscribe(channel, (message, channel) => {
+                onMessage({ channel, message })
+              })
+              return subscriber
+            } catch (cause) {
+              subscriber.destroy()
+              throw cause
+            }
+          },
+          catch: (cause) => new Redis.RedisError({ cause })
+        }),
+        (subscriber) => Effect.sync(() => subscriber.destroy())
+      ).pipe(Effect.as(Effect.never))
   })
 
   const nodeRedis = Fn.identity<NodeRedis["Service"]>({

--- a/packages/platform/node/src/NodeRedis.ts
+++ b/packages/platform/node/src/NodeRedis.ts
@@ -12,6 +12,7 @@
  */
 import * as Config from "effect/Config"
 import * as Context from "effect/Context"
+import * as Deferred from "effect/Deferred"
 import * as Effect from "effect/Effect"
 import * as Fn from "effect/Function"
 import * as Layer from "effect/Layer"
@@ -89,28 +90,38 @@ const make = Effect.fnUntraced(function*(
         catch: (cause) => new Redis.RedisError({ cause })
       }),
     subscribe: (channel, onMessage) =>
-      Effect.acquireRelease(
-        Effect.tryPromise({
-          try: async () => {
-            const subscriber = client.duplicate()
-            subscriber.on("error", (cause) => {
-              runSync(Effect.logWarning("NodeRedis subscriber error", cause))
-            })
-            try {
-              await subscriber.connect()
-              await subscriber.subscribe(channel, (message, channel) => {
-                onMessage({ channel, message })
+      Effect.gen(function*() {
+        const terminal = yield* Deferred.make<void, Redis.RedisError>()
+        yield* Effect.acquireRelease(
+          Effect.tryPromise({
+            try: async () => {
+              const subscriber = client.duplicate()
+              subscriber.on("error", (cause) => {
+                runSync(Effect.logWarning("NodeRedis subscriber error", cause))
+                if (!subscriber.isOpen) {
+                  runSync(Deferred.fail(terminal, new Redis.RedisError({ cause })))
+                }
               })
-              return subscriber
-            } catch (cause) {
-              subscriber.destroy()
-              throw cause
-            }
-          },
-          catch: (cause) => new Redis.RedisError({ cause })
-        }),
-        (subscriber) => Effect.sync(() => subscriber.destroy())
-      ).pipe(Effect.as(Effect.never))
+              try {
+                await subscriber.connect()
+                await subscriber.subscribe(channel, (message, channel) => {
+                  onMessage({ channel, message })
+                })
+                return subscriber
+              } catch (cause) {
+                if (subscriber.isOpen) subscriber.destroy()
+                throw cause
+              }
+            },
+            catch: (cause) => new Redis.RedisError({ cause })
+          }),
+          (subscriber) =>
+            Effect.sync(() => {
+              if (subscriber.isOpen) subscriber.destroy()
+            })
+        )
+        return Deferred.await(terminal)
+      })
   })
 
   const nodeRedis = Fn.identity<NodeRedis["Service"]>({

--- a/packages/platform/node/src/NodeRedis.ts
+++ b/packages/platform/node/src/NodeRedis.ts
@@ -95,7 +95,26 @@ const make = Effect.fnUntraced(function*(
         yield* Effect.acquireRelease(
           Effect.tryPromise({
             try: async () => {
-              const subscriber = client.duplicate()
+              let subscriberReady = false
+              const subscriber = client.duplicate(
+                socket?.reconnectStrategy === undefined
+                  ? {
+                    socket: {
+                      ...socket,
+                      reconnectStrategy: (retries, cause) => {
+                        if (!subscriberReady) return cause
+                        if (cause instanceof SocketTimeoutError) return false
+                        const jitter = Math.floor(Math.random() * 200)
+                        const delay = Math.min(2 ** retries * 50, 2000)
+                        return delay + jitter
+                      }
+                    }
+                  }
+                  : {}
+              )
+              subscriber.once("ready", () => {
+                subscriberReady = true
+              })
               subscriber.on("error", (cause) => {
                 runSync(Effect.logWarning("NodeRedis subscriber error", cause))
                 if (!subscriber.isOpen) {

--- a/packages/platform/node/test/NodeRedis.integration.test.ts
+++ b/packages/platform/node/test/NodeRedis.integration.test.ts
@@ -1,7 +1,7 @@
 import { NodeRedis } from "@effect/platform-node"
 import { assert, it } from "@effect/vitest"
 import { RedisContainer } from "@testcontainers/redis"
-import { Effect, Layer, Schema } from "effect"
+import { Effect, Layer, Queue, Schema } from "effect"
 import * as PersistedCacheTest from "effect-test/unstable/persistence/PersistedCacheTest"
 import * as PersistedQueueTest from "effect-test/unstable/persistence/PersistedQueueTest"
 import { PersistedQueue, Persistence, Redis } from "effect/unstable/persistence"
@@ -68,6 +68,19 @@ it.layer(PersistedQueueRedisLayer, { timeout: "30 seconds" })(
       Effect.gen(function*() {
         const redis = yield* NodeRedis.NodeRedis
         assert.strictEqual(redis.client.options.RESP, undefined)
+      }))
+
+    it.effect("receives published messages", () =>
+      Effect.gen(function*() {
+        const redis = yield* Redis.Redis
+        const subscription = yield* redis.subscribe("effect-test")
+
+        yield* redis.send("PUBLISH", "effect-test", "hello")
+
+        assert.deepStrictEqual(yield* Queue.take(subscription), {
+          channel: "effect-test",
+          message: "hello"
+        })
       }))
 
     // The shared PersistedQueue suite can only assert that exhausted elements


### PR DESCRIPTION
Adds scoped Redis pub/sub subscriptions to the portable Redis service.

- exposes received channel messages through a typed dequeue
- reports setup and listener failures through the dequeue
- uses dedicated subscription connections for Node, Deno, and Bun adapters
- adds shared unit coverage and Node/Deno Redis integration coverage

Closes EFF-733

Validation:
- `pnpm vitest run packages/effect/test/unstable/persistence/Redis.test.ts`
- Node Redis integration suite (14 tests)
- Deno Redis integration suite (15 tests)
- typechecks for `effect`, `@effect/platform-node`, `@effect/platform-deno`, and `@effect/platform-bun`
- `pnpm lint`