### PR TITLE
Align in-memory workflow interrupt finalization

### DIFF
--- a/.changeset/fix-memory-workflow-interrupt.md
+++ b/.changeset/fix-memory-workflow-interrupt.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Align in-memory workflow interrupt finalization with the cluster workflow engine.

--- a/packages/effect/src/unstable/workflow/Workflow.ts
+++ b/packages/effect/src/unstable/workflow/Workflow.ts
@@ -789,6 +789,9 @@ export const provideScope = <A, E, R>(
  * Adds an exit finalizer to the current workflow scope, preserving the
  * services available when the finalizer is registered.
  *
+ * Body-level `Effect.onExit` finalizers cannot observe a deposited workflow
+ * interrupt. Use this function for terminal-state work that must observe it.
+ *
  * @category resource management
  * @since 4.0.0
  */

--- a/packages/effect/src/unstable/workflow/WorkflowEngine.ts
+++ b/packages/effect/src/unstable/workflow/WorkflowEngine.ts
@@ -681,6 +681,7 @@ export const layerMemory: Layer.Layer<WorkflowEngine> = Layer.effect(WorkflowEng
       ) => Effect.Effect<unknown, unknown, WorkflowInstance | WorkflowEngine>
       readonly parent: string | undefined
       instance: WorkflowInstance["Service"]
+      interrupted: boolean
       fiber: Fiber.Fiber<Workflow.Result<unknown, unknown>> | undefined
     }
     const executions = new Map<string, ExecutionState>()
@@ -708,13 +709,13 @@ export const layerMemory: Layer.Layer<WorkflowEngine> = Layer.effect(WorkflowEng
         state.instance.executionId,
         state.instance.scope
       )
-      instance.interrupted = state.instance.interrupted
       state.instance = instance
       state.fiber = yield* state.execute(state.payload, state.instance.executionId).pipe(
         Effect.onExit(() => {
-          if (!instance.interrupted) {
+          if (!state.interrupted) {
             return Effect.void
           }
+          instance.interrupted = true
           instance.suspended = false
           return Effect.withFiber((fiber) => Effect.interruptible(Fiber.interrupt(fiber)))
         }),
@@ -755,6 +756,7 @@ export const layerMemory: Layer.Layer<WorkflowEngine> = Layer.effect(WorkflowEng
             payload: options.payload,
             execute: entry.execute,
             instance: WorkflowInstance.initial(workflow, options.executionId),
+            interrupted: false,
             fiber: undefined,
             parent: options.parent?.executionId
           }
@@ -774,7 +776,7 @@ export const layerMemory: Layer.Layer<WorkflowEngine> = Layer.effect(WorkflowEng
       interrupt: Effect.fnUntraced(function*(_workflow, executionId) {
         const state = executions.get(executionId)
         if (!state) return
-        state.instance.interrupted = true
+        state.interrupted = true
         yield* resume(executionId)
       }),
       interruptUnsafe: Effect.fnUntraced(function*(_workflow, executionId) {

--- a/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
+++ b/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Exit, Fiber, Layer, Option, Schema, Scope } from "effect"
+import { Effect, Exit, Fiber, Layer, Option, Ref, Schema, Scope } from "effect"
 import { TestClock } from "effect/testing"
 import { DurableDeferred, Workflow, WorkflowEngine } from "effect/unstable/workflow"
 
@@ -175,6 +175,77 @@ describe("WorkflowEngine", () => {
         yield* Suspends.execute(payload)
 
         assert.deepStrictEqual(finalized, [2, 1])
+      }).pipe(Effect.provide(layer))
+    }))
+
+  it.effect("layerMemory hides deposited interrupts from body finalizers", () =>
+    Effect.gen(function*() {
+      const gate = DurableDeferred.make("WorkflowEngine/InterruptBodyFinalizer/Gate")
+      const observed = yield* Ref.make<ReadonlyArray<boolean>>([])
+      const Suspends = Workflow.make("WorkflowEngine/InterruptBodyFinalizer", {
+        payload: { id: Schema.String },
+        idempotencyKey: ({ id }) => id
+      })
+      const layer = Suspends.toLayer(Effect.fnUntraced(function*() {
+        const instance = yield* WorkflowEngine.WorkflowInstance
+        return yield* DurableDeferred.await(gate).pipe(
+          Effect.onExit(() => Ref.update(observed, (values) => [...values, instance.interrupted]))
+        )
+      })).pipe(Layer.provideMerge(WorkflowEngine.layerMemory))
+
+      yield* Effect.gen(function*() {
+        const payload = { id: "one" }
+        const executionId = yield* Suspends.execute(payload, { discard: true })
+        let result = yield* Suspends.poll(executionId)
+        while (Option.isNone(result) || result.value._tag !== "Suspended") {
+          yield* Effect.yieldNow
+          result = yield* Suspends.poll(executionId)
+        }
+
+        yield* Suspends.interrupt(executionId)
+        while (Option.isNone(result) || result.value._tag !== "Complete") {
+          yield* Effect.yieldNow
+          result = yield* Suspends.poll(executionId)
+        }
+
+        assert.deepStrictEqual(yield* Ref.get(observed), [false, false])
+      }).pipe(Effect.provide(layer))
+    }))
+
+  it.effect("layerMemory exposes deposited interrupts to workflow finalizers", () =>
+    Effect.gen(function*() {
+      const gate = DurableDeferred.make("WorkflowEngine/InterruptWorkflowFinalizer/Gate")
+      const observed = yield* Ref.make<ReadonlyArray<boolean>>([])
+      const runs = yield* Ref.make(0)
+      const Suspends = Workflow.make("WorkflowEngine/InterruptWorkflowFinalizer", {
+        payload: { id: Schema.String },
+        idempotencyKey: ({ id }) => id
+      })
+      const layer = Suspends.toLayer(Effect.fnUntraced(function*() {
+        const run = yield* Ref.getAndUpdate(runs, (run) => run + 1)
+        const instance = yield* WorkflowEngine.WorkflowInstance
+        if (run === 1) {
+          yield* Workflow.addFinalizer(() => Ref.update(observed, (values) => [...values, instance.interrupted]))
+        }
+        return yield* DurableDeferred.await(gate)
+      })).pipe(Layer.provideMerge(WorkflowEngine.layerMemory))
+
+      yield* Effect.gen(function*() {
+        const payload = { id: "one" }
+        const executionId = yield* Suspends.execute(payload, { discard: true })
+        let result = yield* Suspends.poll(executionId)
+        while (Option.isNone(result) || result.value._tag !== "Suspended") {
+          yield* Effect.yieldNow
+          result = yield* Suspends.poll(executionId)
+        }
+
+        yield* Suspends.interrupt(executionId)
+        while (Option.isNone(result) || result.value._tag !== "Complete") {
+          yield* Effect.yieldNow
+          result = yield* Suspends.poll(executionId)
+        }
+
+        assert.deepStrictEqual(yield* Ref.get(observed), [true])
       }).pipe(Effect.provide(layer))
     }))
 })


### PR DESCRIPTION
## Summary

- store deposited interrupts on the in-memory execution instead of pre-copying them onto replay instances
- apply the interrupt in the engine `onExit`, matching `ClusterWorkflowEngine` ordering
- document `Workflow.addFinalizer` as the terminal-state hook and cover both finalizer boundaries

## Root cause and impact

`WorkflowEngine.layerMemory` exposed `WorkflowInstance.interrupted` inside body-level `Effect.onExit` handlers before the cluster engine could. Tests could therefore validate behavior that failed in production. Replays now begin with `interrupted: false`; the engine sets the flag only after body finalizers have run, before the workflow scope closes.

`interruptUnsafe` remains a direct interrupt of the live fiber. `ClusterWorkflowEngine` is unchanged.

## Validation

- `pnpm test --run packages/effect/test/unstable/workflow/WorkflowEngine.test.ts`
- `pnpm test --run packages/effect/test/cluster/ClusterWorkflowEngine.test.ts -t "nested workflows"`
- `pnpm lint-fix`
- `pnpm check`

Closes EFF-735
Closes #7332
