### PR TITLE
Preserve unsafe workflow interrupts across replay

### DIFF
--- a/.changeset/preserve-unsafe-workflow-interrupts.md
+++ b/.changeset/preserve-unsafe-workflow-interrupts.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve unsafe in-memory workflow interrupts across replay.

--- a/packages/effect/src/unstable/workflow/WorkflowEngine.ts
+++ b/packages/effect/src/unstable/workflow/WorkflowEngine.ts
@@ -782,7 +782,7 @@ export const layerMemory: Layer.Layer<WorkflowEngine> = Layer.effect(WorkflowEng
       interruptUnsafe: Effect.fnUntraced(function*(_workflow, executionId) {
         const state = executions.get(executionId)
         if (!state) return
-        state.instance.interrupted = true
+        state.interrupted = true
         if (state.fiber) {
           yield* Fiber.interrupt(state.fiber)
         }

--- a/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
+++ b/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
@@ -248,4 +248,38 @@ describe("WorkflowEngine", () => {
         assert.deepStrictEqual(yield* Ref.get(observed), [true])
       }).pipe(Effect.provide(layer))
     }))
+
+  it.effect("layerMemory preserves interruptUnsafe across a suspended replay", () =>
+    Effect.gen(function*() {
+      const gate = DurableDeferred.make("WorkflowEngine/InterruptUnsafeReplay/Gate")
+      const Suspends = Workflow.make("WorkflowEngine/InterruptUnsafeReplay", {
+        payload: { id: Schema.String },
+        idempotencyKey: ({ id }) => id
+      })
+      const layer = Suspends.toLayer(() => DurableDeferred.await(gate)).pipe(
+        Layer.provideMerge(WorkflowEngine.layerMemory)
+      )
+
+      yield* Effect.gen(function*() {
+        const engine = yield* WorkflowEngine.WorkflowEngine
+        const payload = { id: "one" }
+        const executionId = yield* Suspends.execute(payload, { discard: true })
+        let result = yield* Suspends.poll(executionId)
+        while (Option.isNone(result) || result.value._tag !== "Suspended") {
+          yield* Effect.yieldNow
+          result = yield* Suspends.poll(executionId)
+        }
+
+        yield* engine.interruptUnsafe(Suspends, executionId)
+        const token = DurableDeferred.tokenFromExecutionId(gate, { workflow: Suspends, executionId })
+        yield* DurableDeferred.succeed(gate, { token, value: void 0 })
+        while (Option.isNone(result) || result.value._tag !== "Complete") {
+          yield* Effect.yieldNow
+          result = yield* Suspends.poll(executionId)
+        }
+
+        assert(Option.isSome(result) && result.value._tag === "Complete")
+        assert(Exit.hasInterrupts(result.value.exit))
+      }).pipe(Effect.provide(layer))
+    }))
 })


### PR DESCRIPTION
## Summary

- persist `interruptUnsafe` on the in-memory execution state introduced by #7350
- cover a suspended execution that is interrupted unsafely and then replayed by a durable deferred completion
- add an `effect` patch changeset for the shipped fix

## Root cause and impact

#7350 stopped copying `WorkflowInstance.interrupted` into replay instances, but `interruptUnsafe` still wrote to that stale field. When a suspended workflow was interrupted and later resumed, the replay could complete successfully. Writing the deposit to `ExecutionState.interrupted` preserves the interrupt while the existing live-fiber interrupt remains unchanged.

This follow-up does not change the cluster engine or address the pre-existing memory/cluster asymmetries noted during review.

## Validation

- `pnpm test --run packages/effect/test/unstable/workflow/WorkflowEngine.test.ts packages/effect/test/unstable/workflow/DurableQueue.test.ts packages/effect/test/cluster/ClusterWorkflowEngine.test.ts` (37 passed)
- `pnpm lint-fix`
- `pnpm check`

Closes EFF-735
