### PR TITLE
Preserve Context accessor with loose object spread

### DIFF
--- a/.changeset/calm-contexts-rest.md
+++ b/.changeset/calm-contexts-rest.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve the `Context.mapUnsafe` accessor when code is compiled with loose object spread transforms.

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -584,12 +584,12 @@ const Proto: Omit<
   ContextImpl<never>,
   "cacheRoot" | "base" | "overlay" | "depth" | "_flat" | "baseHits"
 > = {
+  get mapUnsafe() {
+    return flatten(this as any as ContextImpl<any>)
+  },
   ...PipeInspectableProto,
   [TypeId]: {
     _Services: (_: never) => _
-  },
-  get mapUnsafe() {
-    return flatten(this as any as ContextImpl<any>)
   },
   toJSON(this: Context<never>) {
     return {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

  - [ ] Refactor
  - [ ] Feature
  - [x] Bug Fix
  - [ ] Optimization
  - [ ] Documentation Update

  ## Description

  Preserves the `Context.mapUnsafe` accessor when Effect is compiled with a loose object-spread transform.

  When `mapUnsafe` is declared after `...PipeInspectableProto`, loose transforms such as Expo's lower the object spread to `Object.assign`. This evaluates the getter against the temporary source object and
  stores `undefined` instead of preserving the accessor.

  Moving the getter before the spread ensures it remains defined on the resulting prototype.

  ## Related

  - Follow-up to #6659

## Testing

  - Existing `Context` test suite passes.
  - `pnpm check` passes.
  - Verified against Expo's loose object-spread transform, where the previous ordering converted `mapUnsafe` into an `undefined` data property.
