### PR TITLE
Make server notifications first-class RPC messages

### DIFF
--- a/.changeset/rpc-server-notifications.md
+++ b/.changeset/rpc-server-notifications.md
@@ -2,4 +2,5 @@
 "effect": patch
 ---
 
-Add support for server-originated RPC requests and notifications.
+Add support for server-originated RPC requests and notifications. Buffered
+JSON-RPC HTTP drops notifications until streaming responses are available.

--- a/.changeset/rpc-server-notifications.md
+++ b/.changeset/rpc-server-notifications.md
@@ -2,12 +2,4 @@
 "effect": patch
 ---
 
-Make server notifications first-class RPC messages.
-
-`RpcMessage.FromServerEncoded` now includes `RequestEncoded`, so servers can
-send server-originated requests and notifications (`isNotification: true`)
-through `RpcServer.Protocol.send`. `RpcServer.Protocol` gains a
-`supportsNotifications` flag, and the JSON-RPC serialization encodes
-notifications as id-less requests. Buffered HTTP responses drop notifications
-instead of folding them into the response batch. `McpServer` uses this instead
-of casting notifications to untyped responses.
+Add support for server-originated RPC requests and notifications.

--- a/.changeset/rpc-server-notifications.md
+++ b/.changeset/rpc-server-notifications.md
@@ -1,0 +1,13 @@
+---
+"effect": patch
+---
+
+Make server notifications first-class RPC messages.
+
+`RpcMessage.FromServerEncoded` now includes `RequestEncoded`, so servers can
+send server-originated requests and notifications (`isNotification: true`)
+through `RpcServer.Protocol.send`. `RpcServer.Protocol` gains a
+`supportsNotifications` flag, and the JSON-RPC serialization encodes
+notifications as id-less requests. Buffered HTTP responses drop notifications
+instead of folding them into the response batch. `McpServer` uses this instead
+of casting notifications to untyped responses.

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -1066,7 +1066,9 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
           server.initializedClients.delete(clientId)
           continue
         }
-        if (!protocol.supportsNotifications) {
+        // This must stay below stale-client cleanup so transports without
+        // notification support still prune initializedClients.
+        if (!patchedProtocol.supportsNotifications) {
           continue
         }
         const selectedProtocol = clientProtocols.get(clientId)

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -719,13 +719,18 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
         return {
           send(id, request, _transferables) {
             cid = id
-            return protocol.send(key.clientId, {
-              ...request,
-              headers: undefined,
-              traceId: undefined,
-              spanId: undefined,
-              sampled: undefined
-            } as any)
+            if (request._tag === "Request") {
+              return protocol.send(key.clientId, {
+                _tag: "Request",
+                id: request.id,
+                tag: request.tag,
+                payload: request.payload,
+                headers: []
+              })
+            }
+            // Ack & co are not part of FromServerEncoded, but the JSON-RPC
+            // serializer encodes them symmetrically for reverse control flow
+            return protocol.send(key.clientId, request as any)
           },
           supportsAck: true,
           supportsTransferables: false,
@@ -1061,6 +1066,9 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
           server.initializedClients.delete(clientId)
           continue
         }
+        if (!protocol.supportsNotifications) {
+          continue
+        }
         const selectedProtocol = clientProtocols.get(clientId)
         if (!selectedProtocol) {
           continue
@@ -1088,14 +1096,14 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
             return
           }
           const encoded = yield* selectedProtocol.payloadCodecs(rpc).encode(projected.payload)
-          // TODO: Extend RpcServer.Protocol's outbound message contract with server-originated
-          // notifications so MCP does not need to treat this notification as an RPC response.
-          const message: RpcMessage.RequestEncoded = {
+          yield* patchedProtocol.send(clientId, {
             _tag: "Request",
+            id: "",
             tag: projected.tag,
-            payload: encoded
-          } as any
-          yield* patchedProtocol.send(clientId, message as any)
+            payload: encoded,
+            headers: [],
+            isNotification: true
+          })
         }).pipe(Effect.catchCause(() => Effect.void))
       }
     })),

--- a/packages/effect/src/unstable/rpc/RpcMessage.ts
+++ b/packages/effect/src/unstable/rpc/RpcMessage.ts
@@ -54,6 +54,9 @@ export const RequestId = (id: string | number): RequestId => id as RequestId
  * The transport-encoded RPC request envelope, including the string request id,
  * RPC tag, encoded payload, headers, and optional trace context.
  *
+ * Requests flow in both directions: servers use them for server-originated
+ * requests and, with `isNotification` set, for server notifications.
+ *
  * @category models
  * @since 4.0.0
  */
@@ -195,6 +198,7 @@ export type FromServerEncoded =
   | ResponseDefectEncoded
   | Pong
   | ClientProtocolError
+  | RequestEncoded
 
 /**
  * The brand identifier used by the `ResponseId` type.

--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -401,12 +401,20 @@ function encodeJsonRpcResponse(
 function encodeJsonRpcMessage(response: RpcMessage.FromServerEncoded | RpcMessage.FromClientEncoded): JsonRpcMessage {
   switch (response._tag) {
     case "Request":
+      // a JSON-RPC notification is a request without an id
+      if (response.isNotification) {
+        return {
+          jsonrpc: "2.0",
+          method: response.tag,
+          params: response.payload
+        }
+      }
       return {
         jsonrpc: "2.0",
         method: response.tag,
         params: response.payload,
         id: response.id,
-        headers: response.headers,
+        ...(response.headers.length > 0 ? { headers: response.headers } : {}),
         traceId: response.traceId,
         spanId: response.spanId,
         sampled: response.sampled

--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -401,20 +401,13 @@ function encodeJsonRpcResponse(
 function encodeJsonRpcMessage(response: RpcMessage.FromServerEncoded | RpcMessage.FromClientEncoded): JsonRpcMessage {
   switch (response._tag) {
     case "Request":
-      // a JSON-RPC notification is a request without an id
-      if (response.isNotification) {
-        return {
-          jsonrpc: "2.0",
-          method: response.tag,
-          params: response.payload
-        }
-      }
       return {
         jsonrpc: "2.0",
         method: response.tag,
         params: response.payload,
-        id: response.id,
-        ...(response.headers.length > 0 ? { headers: response.headers } : {}),
+        // a JSON-RPC notification is a request without an id
+        ...(response.isNotification ? {} : { id: response.id }),
+        ...(response.headers?.length > 0 ? { headers: response.headers } : {}),
         traceId: response.traceId,
         spanId: response.spanId,
         sampled: response.sampled

--- a/packages/effect/src/unstable/rpc/RpcServer.ts
+++ b/packages/effect/src/unstable/rpc/RpcServer.ts
@@ -854,6 +854,7 @@ export class Protocol extends Context.Service<
     readonly supportsAck: boolean
     readonly supportsTransferables: boolean
     readonly supportsSpanPropagation: boolean
+    readonly supportsNotifications: boolean
   }
 >()("effect/rpc/RpcServer/Protocol") {
   /**
@@ -1025,7 +1026,11 @@ export const makeProtocolWithHttpEffect: Effect.Effect<
       typeof data === "string" ? Queue.offer(queue, encoder.encode(data)) : Queue.offer(queue, data)
     const client: Client = {
       write: !includesFraming
-        ? (response) => Queue.offer(queue, response)
+        ? (response) =>
+          // buffered responses cannot carry notifications, so they are dropped
+          response._tag === "Request" && response.isNotification === true
+            ? Effect.void
+            : Queue.offer(queue, response)
         : (response) => {
           try {
             const encoded = parser.encode(response)
@@ -1111,7 +1116,8 @@ export const makeProtocolWithHttpEffect: Effect.Effect<
       initialMessage: Effect.succeedNone,
       supportsAck: false,
       supportsTransferables: false,
-      supportsSpanPropagation: false
+      supportsSpanPropagation: false,
+      supportsNotifications: includesFraming
     })
   })
 
@@ -1302,7 +1308,8 @@ export const makeProtocolStdio = Effect.gen(function*() {
       initialMessage: Effect.succeedNone,
       supportsAck: true,
       supportsTransferables: false,
-      supportsSpanPropagation: true
+      supportsSpanPropagation: true,
+      supportsNotifications: true
     }
   }))
 })
@@ -1376,7 +1383,8 @@ export const makeProtocolWorkerRunner: Effect.Effect<
     initialMessage: Effect.asSome(Deferred.await(initialMessage)),
     supportsAck: true,
     supportsTransferables: true,
-    supportsSpanPropagation: true
+    supportsSpanPropagation: true,
+    supportsNotifications: true
   }
 }))
 
@@ -1497,7 +1505,8 @@ const makeSocketProtocol: Effect.Effect<
       initialMessage: Effect.succeedNone,
       supportsAck: true,
       supportsTransferables: false,
-      supportsSpanPropagation: true
+      supportsSpanPropagation: true,
+      supportsNotifications: true
     })
   })
 

--- a/packages/effect/test/rpc/RpcSerialization.test.ts
+++ b/packages/effect/test/rpc/RpcSerialization.test.ts
@@ -261,12 +261,15 @@ describe("RpcSerialization", () => {
       id: "",
       tag: "notifications/message",
       payload: { level: "info" },
-      headers: [],
+      headers: [["x-test", "value"]],
+      traceId: "trace",
+      spanId: "span",
+      sampled: true,
       isNotification: true
     })
     assert.strictEqual(
       encoded,
-      "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/message\",\"params\":{\"level\":\"info\"}}"
+      "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/message\",\"params\":{\"level\":\"info\"},\"headers\":[[\"x-test\",\"value\"]],\"traceId\":\"trace\",\"spanId\":\"span\",\"sampled\":true}"
     )
   })
 

--- a/packages/effect/test/rpc/RpcSerialization.test.ts
+++ b/packages/effect/test/rpc/RpcSerialization.test.ts
@@ -204,7 +204,7 @@ describe("RpcSerialization", () => {
     })
     assert.strictEqual(
       encoded,
-      "{\"jsonrpc\":\"2.0\",\"method\":\"users.get\",\"params\":null,\"id\":0,\"headers\":[]}"
+      "{\"jsonrpc\":\"2.0\",\"method\":\"users.get\",\"params\":null,\"id\":0}"
     )
   })
 
@@ -240,7 +240,33 @@ describe("RpcSerialization", () => {
     })
     assert.strictEqual(
       encoded,
-      "{\"jsonrpc\":\"2.0\",\"method\":\"users.get\",\"params\":null,\"id\":\"\",\"headers\":[]}"
+      "{\"jsonrpc\":\"2.0\",\"method\":\"users.get\",\"params\":null,\"id\":\"\"}"
+    )
+  })
+
+  it("jsonRpc encodes a notification without an id", () => {
+    const parser = RpcSerialization.jsonRpc().makeUnsafe()
+    const decoded = parser.decode("{\"jsonrpc\":\"2.0\",\"method\":\"notifications/message\"}")
+    assert.deepStrictEqual(decoded, [{
+      _tag: "Request",
+      id: "",
+      tag: "notifications/message",
+      payload: null,
+      headers: [],
+      isNotification: true
+    }])
+
+    const encoded = parser.encode({
+      _tag: "Request",
+      id: "",
+      tag: "notifications/message",
+      payload: { level: "info" },
+      headers: [],
+      isNotification: true
+    })
+    assert.strictEqual(
+      encoded,
+      "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/message\",\"params\":{\"level\":\"info\"}}"
     )
   })
 

--- a/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
@@ -488,6 +488,54 @@ describe("McpServer", () => {
       strictEqual(pingResponseBody.length > 0, true)
     }))
 
+  it.effect("drops server notifications from buffered JSON-RPC responses", () =>
+    Effect.gen(function*() {
+      const serverLayer = Layer.effectDiscard(Effect.gen(function*() {
+        const router = yield* HttpRouter.HttpRouter
+        const { httpEffect, protocol } = yield* RpcServer.makeProtocolWithHttpEffect
+        yield* protocol.run((clientId, message) => {
+          if (message._tag !== "Request") {
+            return Effect.void
+          }
+          return Effect.gen(function*() {
+            yield* protocol.send(clientId, {
+              _tag: "Request",
+              id: "",
+              tag: "notifications/message",
+              payload: { level: "info" },
+              headers: [],
+              isNotification: true
+            })
+            yield* protocol.send(clientId, {
+              _tag: "Exit",
+              requestId: message.id,
+              exit: { _tag: "Success", value: { ok: true } }
+            })
+            yield* protocol.end(clientId)
+          })
+        }).pipe(Effect.forkScoped)
+        yield* router.add("POST", "/mcp", () => httpEffect)
+      })).pipe(
+        Layer.provideMerge(HttpRouter.layer),
+        Layer.provide(RpcSerialization.layerJsonRpc())
+      )
+      const harness = yield* makeHttpHarness(serverLayer)
+
+      const response = yield* harness.post({
+        jsonrpc: "2.0",
+        method: "ping",
+        params: {},
+        id: 1
+      })
+
+      assert.strictEqual(response.status, 200)
+      assert.deepStrictEqual(yield* Effect.promise(() => response.json()), {
+        jsonrpc: "2.0",
+        id: 1,
+        result: { ok: true }
+      })
+    }))
+
   it.effect("validates supplied protocol versions on POST", () =>
     Effect.gen(function*() {
       const { client, httpClient } = yield* makeRouterTestClient(HttpRouter.cors())

--- a/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
@@ -561,12 +561,8 @@ describe("McpServer", () => {
     it.effect("should isolate resource update subscriptions between sessions", () =>
       Effect.gen(function*() {
         const clientIds = new Set([1, 2])
-        const client1Outbound = yield* Queue.unbounded<
-          RpcMessage.FromServerEncoded | RpcMessage.RequestEncoded
-        >()
-        const client2Outbound = yield* Queue.unbounded<
-          RpcMessage.FromServerEncoded | RpcMessage.RequestEncoded
-        >()
+        const client1Outbound = yield* Queue.unbounded<RpcMessage.FromServerEncoded>()
+        const client2Outbound = yield* Queue.unbounded<RpcMessage.FromServerEncoded>()
         const disconnects = yield* Queue.unbounded<number>()
         const writeRequest = yield* Deferred.make<
           (clientId: number, message: RpcMessage.FromClientEncoded) => Effect.Effect<void>
@@ -582,7 +578,8 @@ describe("McpServer", () => {
               initialMessage: Effect.succeedNone,
               supportsAck: false,
               supportsTransferables: false,
-              supportsSpanPropagation: false
+              supportsSpanPropagation: false,
+              supportsNotifications: true
             })
           )
         )


### PR DESCRIPTION
## Summary

- allow server-originated requests and notifications through `RpcServer.Protocol.send`
- expose notification support on protocols and drop notifications from buffered HTTP responses
- encode JSON-RPC notifications without an id and remove the untyped MCP notification casts

## Behavior notes

- buffered JSON-RPC HTTP drops server notifications instead of including them in an invalid response batch; notification delivery there requires a streaming response
- JSON-RPC requests omit `headers` when the collection is empty; decoders continue to normalize an absent field to `[]`

## Testing

- `pnpm check`
- `pnpm lint`
- `pnpm test --run packages/effect/test/rpc packages/effect/test/unstable/ai/McpServer` (709 passed, 44 skipped)

Closes EFF-736