### PR TITLE
Add RPC HTTP stream backpressure

### DIFF
--- a/.changeset/quiet-rpcs-buffer.md
+++ b/.changeset/quiet-rpcs-buffer.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add configurable backpressure for framed RPC server HTTP response streams.

--- a/.changeset/quiet-rpcs-buffer.md
+++ b/.changeset/quiet-rpcs-buffer.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Add configurable backpressure for framed RPC server HTTP response streams.
+Bound framed RPC server HTTP response streams to 16 items by default, with a configurable buffer size or an unbounded opt-out.

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -1356,7 +1356,7 @@ const layerMcpProtocolHttp = (options: {
 > =>
   Layer.effect(RpcServer.Protocol)(Effect.gen(function*() {
     const state = yield* McpProtocolState
-    const { httpEffect, protocol } = yield* RpcServer.makeProtocolWithHttpEffect({})
+    const { httpEffect, protocol } = yield* RpcServer.makeProtocolWithHttpEffect()
     const router = yield* HttpRouter.HttpRouter
     yield* router.add("POST", options.path, (request) => {
       if (!isAllowedMcpOrigin(request, options.allowedOrigins)) {

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -1356,7 +1356,7 @@ const layerMcpProtocolHttp = (options: {
 > =>
   Layer.effect(RpcServer.Protocol)(Effect.gen(function*() {
     const state = yield* McpProtocolState
-    const { httpEffect, protocol } = yield* RpcServer.makeProtocolWithHttpEffect
+    const { httpEffect, protocol } = yield* RpcServer.makeProtocolWithHttpEffect({})
     const router = yield* HttpRouter.HttpRouter
     yield* router.add("POST", options.path, (request) => {
       if (!isAllowedMcpOrigin(request, options.allowedOrigins)) {

--- a/packages/effect/src/unstable/rpc/RpcServer.ts
+++ b/packages/effect/src/unstable/rpc/RpcServer.ts
@@ -806,6 +806,7 @@ export const layerHttp = <Rpcs extends Rpc.Any>(options: {
   readonly spanAttributes?: Record<string, unknown> | undefined
   readonly concurrency?: number | "unbounded" | undefined
   readonly disableFatalDefects?: boolean | undefined
+  readonly streamBufferSize?: number | undefined
 }): Layer.Layer<
   never,
   never,
@@ -983,7 +984,11 @@ export const makeProtocolWithHttpEffect: Effect.Effect<
   },
   never,
   RpcSerialization.RpcSerialization
-> = Effect.gen(function*() {
+> = Effect.suspend(() => makeProtocolWithHttpEffectOptions({}))
+
+const makeProtocolWithHttpEffectOptions = Effect.fnUntraced(function*(options: {
+  readonly streamBufferSize?: number | undefined
+}) {
   const serialization = yield* RpcSerialization.RpcSerialization
   const includesFraming = serialization.includesFraming
   const isBinary = !serialization.contentType.includes("json")
@@ -1018,7 +1023,9 @@ export const makeProtocolWithHttpEffect: Effect.Effect<
       isBinary ? Effect.map(request.arrayBuffer, (buf) => new Uint8Array(buf)) : request.text
     )
     const id = clientId++
-    const queue = yield* Queue.make<Uint8Array | FromServerEncoded, Cause.Done>()
+    const queue = yield* Queue.make<Uint8Array | FromServerEncoded, Cause.Done>({
+      capacity: includesFraming ? options.streamBufferSize : undefined
+    })
     const parser = serialization.makeUnsafe()
     const requestIds: Array<RequestId> = []
 
@@ -1146,12 +1153,13 @@ const mergeUint8Arrays = (arrays: ReadonlyArray<Uint8Array>) => {
  */
 export const makeProtocolHttp: (options: {
   readonly path: HttpRouter.PathInput
+  readonly streamBufferSize?: number | undefined
 }) => Effect.Effect<
   Protocol["Service"],
   never,
   RpcSerialization.RpcSerialization | HttpRouter.HttpRouter
 > = Effect.fnUntraced(function*(options) {
-  const { httpEffect, protocol } = yield* makeProtocolWithHttpEffect
+  const { httpEffect, protocol } = yield* makeProtocolWithHttpEffectOptions(options)
   const router = yield* HttpRouter.HttpRouter
   yield* router.add("POST", options.path, httpEffect)
   return protocol
@@ -1166,6 +1174,7 @@ export const makeProtocolHttp: (options: {
  */
 export const layerProtocolHttp = (options: {
   readonly path: HttpRouter.PathInput
+  readonly streamBufferSize?: number | undefined
 }): Layer.Layer<Protocol, never, RpcSerialization.RpcSerialization | HttpRouter.HttpRouter> => {
   return Layer.effect(Protocol)(makeProtocolHttp(options))
 }
@@ -1184,6 +1193,7 @@ export const toHttpEffect: <Rpcs extends Rpc.Any>(
     readonly spanPrefix?: string | undefined
     readonly spanAttributes?: Record<string, unknown> | undefined
     readonly disableFatalDefects?: boolean | undefined
+    readonly streamBufferSize?: number | undefined
   } | undefined
 ) => Effect.Effect<
   Effect.Effect<HttpServerResponse.HttpServerResponse, never, Scope.Scope | HttpServerRequest.HttpServerRequest>,
@@ -1200,9 +1210,10 @@ export const toHttpEffect: <Rpcs extends Rpc.Any>(
     readonly spanPrefix?: string | undefined
     readonly spanAttributes?: Record<string, unknown> | undefined
     readonly disableFatalDefects?: boolean | undefined
+    readonly streamBufferSize?: number | undefined
   }
 ) {
-  const { httpEffect, protocol } = yield* makeProtocolWithHttpEffect
+  const { httpEffect, protocol } = yield* makeProtocolWithHttpEffectOptions(options ?? {})
   yield* make(group, options).pipe(
     Effect.provideService(Protocol, protocol),
     Effect.forkScoped

--- a/packages/effect/src/unstable/rpc/RpcServer.ts
+++ b/packages/effect/src/unstable/rpc/RpcServer.ts
@@ -806,7 +806,7 @@ export const layerHttp = <Rpcs extends Rpc.Any>(options: {
   readonly spanAttributes?: Record<string, unknown> | undefined
   readonly concurrency?: number | "unbounded" | undefined
   readonly disableFatalDefects?: boolean | undefined
-  readonly streamBufferSize?: number | undefined
+  readonly streamBufferSize?: number | "unbounded" | undefined
 }): Layer.Layer<
   never,
   never,
@@ -987,7 +987,7 @@ export const makeProtocolWithHttpEffect: Effect.Effect<
 > = Effect.suspend(() => makeProtocolWithHttpEffectOptions({}))
 
 const makeProtocolWithHttpEffectOptions = Effect.fnUntraced(function*(options: {
-  readonly streamBufferSize?: number | undefined
+  readonly streamBufferSize?: number | "unbounded" | undefined
 }) {
   const serialization = yield* RpcSerialization.RpcSerialization
   const includesFraming = serialization.includesFraming
@@ -1024,7 +1024,9 @@ const makeProtocolWithHttpEffectOptions = Effect.fnUntraced(function*(options: {
     )
     const id = clientId++
     const queue = yield* Queue.make<Uint8Array | FromServerEncoded, Cause.Done>({
-      capacity: includesFraming ? options.streamBufferSize : undefined
+      capacity: includesFraming && options.streamBufferSize !== "unbounded"
+        ? options.streamBufferSize ?? 16
+        : undefined
     })
     const parser = serialization.makeUnsafe()
     const requestIds: Array<RequestId> = []
@@ -1153,7 +1155,7 @@ const mergeUint8Arrays = (arrays: ReadonlyArray<Uint8Array>) => {
  */
 export const makeProtocolHttp: (options: {
   readonly path: HttpRouter.PathInput
-  readonly streamBufferSize?: number | undefined
+  readonly streamBufferSize?: number | "unbounded" | undefined
 }) => Effect.Effect<
   Protocol["Service"],
   never,
@@ -1174,7 +1176,7 @@ export const makeProtocolHttp: (options: {
  */
 export const layerProtocolHttp = (options: {
   readonly path: HttpRouter.PathInput
-  readonly streamBufferSize?: number | undefined
+  readonly streamBufferSize?: number | "unbounded" | undefined
 }): Layer.Layer<Protocol, never, RpcSerialization.RpcSerialization | HttpRouter.HttpRouter> => {
   return Layer.effect(Protocol)(makeProtocolHttp(options))
 }
@@ -1193,7 +1195,7 @@ export const toHttpEffect: <Rpcs extends Rpc.Any>(
     readonly spanPrefix?: string | undefined
     readonly spanAttributes?: Record<string, unknown> | undefined
     readonly disableFatalDefects?: boolean | undefined
-    readonly streamBufferSize?: number | undefined
+    readonly streamBufferSize?: number | "unbounded" | undefined
   } | undefined
 ) => Effect.Effect<
   Effect.Effect<HttpServerResponse.HttpServerResponse, never, Scope.Scope | HttpServerRequest.HttpServerRequest>,
@@ -1210,7 +1212,7 @@ export const toHttpEffect: <Rpcs extends Rpc.Any>(
     readonly spanPrefix?: string | undefined
     readonly spanAttributes?: Record<string, unknown> | undefined
     readonly disableFatalDefects?: boolean | undefined
-    readonly streamBufferSize?: number | undefined
+    readonly streamBufferSize?: number | "unbounded" | undefined
   }
 ) {
   const { httpEffect, protocol } = yield* makeProtocolWithHttpEffectOptions(options ?? {})

--- a/packages/effect/src/unstable/rpc/RpcServer.ts
+++ b/packages/effect/src/unstable/rpc/RpcServer.ts
@@ -973,7 +973,9 @@ export const layerProtocolWebsocket = (options: {
  * @category protocols
  * @since 4.0.0
  */
-export const makeProtocolWithHttpEffect: Effect.Effect<
+export const makeProtocolWithHttpEffect: (options: {
+  readonly streamBufferSize?: number | "unbounded" | undefined
+}) => Effect.Effect<
   {
     readonly protocol: Protocol["Service"]
     readonly httpEffect: Effect.Effect<
@@ -984,11 +986,7 @@ export const makeProtocolWithHttpEffect: Effect.Effect<
   },
   never,
   RpcSerialization.RpcSerialization
-> = Effect.suspend(() => makeProtocolWithHttpEffectOptions({}))
-
-const makeProtocolWithHttpEffectOptions = Effect.fnUntraced(function*(options: {
-  readonly streamBufferSize?: number | "unbounded" | undefined
-}) {
+> = Effect.fnUntraced(function*(options) {
   const serialization = yield* RpcSerialization.RpcSerialization
   const includesFraming = serialization.includesFraming
   const isBinary = !serialization.contentType.includes("json")
@@ -1161,7 +1159,7 @@ export const makeProtocolHttp: (options: {
   never,
   RpcSerialization.RpcSerialization | HttpRouter.HttpRouter
 > = Effect.fnUntraced(function*(options) {
-  const { httpEffect, protocol } = yield* makeProtocolWithHttpEffectOptions(options)
+  const { httpEffect, protocol } = yield* makeProtocolWithHttpEffect(options)
   const router = yield* HttpRouter.HttpRouter
   yield* router.add("POST", options.path, httpEffect)
   return protocol
@@ -1215,7 +1213,7 @@ export const toHttpEffect: <Rpcs extends Rpc.Any>(
     readonly streamBufferSize?: number | "unbounded" | undefined
   }
 ) {
-  const { httpEffect, protocol } = yield* makeProtocolWithHttpEffectOptions(options ?? {})
+  const { httpEffect, protocol } = yield* makeProtocolWithHttpEffect(options ?? {})
   yield* make(group, options).pipe(
     Effect.provideService(Protocol, protocol),
     Effect.forkScoped

--- a/packages/effect/src/unstable/rpc/RpcServer.ts
+++ b/packages/effect/src/unstable/rpc/RpcServer.ts
@@ -973,9 +973,11 @@ export const layerProtocolWebsocket = (options: {
  * @category protocols
  * @since 4.0.0
  */
-export const makeProtocolWithHttpEffect: (options: {
-  readonly streamBufferSize?: number | "unbounded" | undefined
-}) => Effect.Effect<
+export const makeProtocolWithHttpEffect: (
+  options?: {
+    readonly streamBufferSize?: number | "unbounded" | undefined
+  } | undefined
+) => Effect.Effect<
   {
     readonly protocol: Protocol["Service"]
     readonly httpEffect: Effect.Effect<
@@ -986,7 +988,7 @@ export const makeProtocolWithHttpEffect: (options: {
   },
   never,
   RpcSerialization.RpcSerialization
-> = Effect.fnUntraced(function*(options) {
+> = Effect.fnUntraced(function*(options = {}) {
   const serialization = yield* RpcSerialization.RpcSerialization
   const includesFraming = serialization.includesFraming
   const isBinary = !serialization.contentType.includes("json")
@@ -1213,7 +1215,7 @@ export const toHttpEffect: <Rpcs extends Rpc.Any>(
     readonly streamBufferSize?: number | "unbounded" | undefined
   }
 ) {
-  const { httpEffect, protocol } = yield* makeProtocolWithHttpEffect(options ?? {})
+  const { httpEffect, protocol } = yield* makeProtocolWithHttpEffect(options)
   yield* make(group, options).pipe(
     Effect.provideService(Protocol, protocol),
     Effect.forkScoped

--- a/packages/effect/test/rpc/RpcServer.test.ts
+++ b/packages/effect/test/rpc/RpcServer.test.ts
@@ -1,9 +1,53 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Deferred, Effect, Layer } from "effect"
-import { RpcSerialization, RpcServer } from "effect/unstable/rpc"
+import { Deferred, Effect, Layer, Schema, Stream } from "effect"
+import { HttpRouter } from "effect/unstable/http"
+import { Rpc, RpcGroup, RpcSerialization, RpcServer } from "effect/unstable/rpc"
 import { Socket, SocketServer } from "effect/unstable/socket"
 
 describe("RpcServer", () => {
+  it.effect("applies backpressure to framed HTTP responses when configured", () =>
+    Effect.gen(function*() {
+      let produced = 0
+      const Rpcs = RpcGroup.make(Rpc.make("events", {
+        payload: Schema.Struct({}),
+        success: Schema.Number,
+        stream: true
+      }))
+      const Handlers = Rpcs.toLayerHandler(
+        "events",
+        () => Stream.fromEffectRepeat(Effect.sync(() => ++produced)).pipe(Stream.take(10_000))
+      )
+      const Server = RpcServer.layerHttp({
+        group: Rpcs,
+        path: "/rpc",
+        protocol: "http",
+        streamBufferSize: 1
+      }).pipe(
+        Layer.provide(Handlers),
+        Layer.provide(RpcSerialization.layerNdjson)
+      )
+      const { dispose, handler } = HttpRouter.toWebHandler(Server)
+      yield* Effect.addFinalizer(() => Effect.promise(dispose))
+
+      const response = yield* Effect.promise(() =>
+        handler(
+          new Request("http://test/rpc", {
+            method: "POST",
+            body: `{"_tag":"Request","id":1,"tag":"events","payload":{},"headers":[]}\n`
+          })
+        )
+      )
+      yield* Effect.addFinalizer(() =>
+        response.body === null ? Effect.void : Effect.promise(() => response.body!.cancel())
+      )
+      for (let i = 0; i < 100; i++) {
+        yield* Effect.yieldNow
+      }
+
+      assert.isAbove(produced, 0)
+      assert.isBelow(produced, 10_000)
+    }))
+
   it.effect("closes a socket when the serialization buffer limit is exceeded", () =>
     Effect.gen(function*() {
       const handledChunks: Array<string> = []

--- a/packages/effect/test/rpc/RpcServer.test.ts
+++ b/packages/effect/test/rpc/RpcServer.test.ts
@@ -4,8 +4,72 @@ import { HttpRouter } from "effect/unstable/http"
 import { Rpc, RpcGroup, RpcSerialization, RpcServer } from "effect/unstable/rpc"
 import { Socket, SocketServer } from "effect/unstable/socket"
 
+const producedWithoutReadingFramedBody = Effect.fnUntraced(function*(
+  streamBufferSize?: number | "unbounded"
+) {
+  let produced = 0
+  const Rpcs = RpcGroup.make(Rpc.make("events", {
+    payload: Schema.Struct({}),
+    success: Schema.Number,
+    stream: true
+  }))
+  const Handlers = Rpcs.toLayerHandler(
+    "events",
+    () => Stream.fromEffectRepeat(Effect.sync(() => ++produced)).pipe(Stream.take(10_000))
+  )
+  const Server = RpcServer.layerHttp({
+    group: Rpcs,
+    path: "/rpc",
+    protocol: "http",
+    ...(streamBufferSize === undefined ? {} : { streamBufferSize })
+  }).pipe(
+    Layer.provide(Handlers),
+    Layer.provide(RpcSerialization.layerNdjson)
+  )
+  const { dispose, handler } = HttpRouter.toWebHandler(Server)
+  yield* Effect.addFinalizer(() => Effect.promise(dispose))
+
+  const response = yield* Effect.promise(() =>
+    handler(
+      new Request("http://test/rpc", {
+        method: "POST",
+        body: `{"_tag":"Request","id":1,"tag":"events","payload":{},"headers":[]}\n`
+      })
+    )
+  )
+  yield* Effect.addFinalizer(() => response.body === null ? Effect.void : Effect.promise(() => response.body!.cancel()))
+  for (let i = 0; i < 100; i++) {
+    yield* Effect.yieldNow
+  }
+
+  return produced
+})
+
 describe("RpcServer", () => {
-  it.effect("applies backpressure to framed HTTP responses when configured", () =>
+  it.effect("applies backpressure to framed HTTP responses by default", () =>
+    Effect.gen(function*() {
+      const produced = yield* producedWithoutReadingFramedBody()
+
+      assert.isAbove(produced, 0)
+      assert.isBelow(produced, 10_000)
+    }))
+
+  it.effect("uses the configured framed HTTP response buffer size", () =>
+    Effect.gen(function*() {
+      const produced = yield* producedWithoutReadingFramedBody(1)
+
+      assert.isAbove(produced, 0)
+      assert.isBelow(produced, 16)
+    }))
+
+  it.effect("allows unbounded framed HTTP response buffering", () =>
+    Effect.gen(function*() {
+      const produced = yield* producedWithoutReadingFramedBody("unbounded")
+
+      assert.strictEqual(produced, 10_000)
+    }))
+
+  it.effect("keeps non-framed HTTP responses unbounded", () =>
     Effect.gen(function*() {
       let produced = 0
       const Rpcs = RpcGroup.make(Rpc.make("events", {
@@ -15,7 +79,7 @@ describe("RpcServer", () => {
       }))
       const Handlers = Rpcs.toLayerHandler(
         "events",
-        () => Stream.fromEffectRepeat(Effect.sync(() => ++produced)).pipe(Stream.take(10_000))
+        () => Stream.fromEffectRepeat(Effect.sync(() => ++produced)).pipe(Stream.take(100))
       )
       const Server = RpcServer.layerHttp({
         group: Rpcs,
@@ -24,28 +88,21 @@ describe("RpcServer", () => {
         streamBufferSize: 1
       }).pipe(
         Layer.provide(Handlers),
-        Layer.provide(RpcSerialization.layerNdjson)
+        Layer.provide(RpcSerialization.layerJson)
       )
       const { dispose, handler } = HttpRouter.toWebHandler(Server)
       yield* Effect.addFinalizer(() => Effect.promise(dispose))
 
-      const response = yield* Effect.promise(() =>
+      yield* Effect.promise(() =>
         handler(
           new Request("http://test/rpc", {
             method: "POST",
-            body: `{"_tag":"Request","id":1,"tag":"events","payload":{},"headers":[]}\n`
+            body: `{"_tag":"Request","id":1,"tag":"events","payload":{},"headers":[]}`
           })
         )
       )
-      yield* Effect.addFinalizer(() =>
-        response.body === null ? Effect.void : Effect.promise(() => response.body!.cancel())
-      )
-      for (let i = 0; i < 100; i++) {
-        yield* Effect.yieldNow
-      }
 
-      assert.isAbove(produced, 0)
-      assert.isBelow(produced, 10_000)
+      assert.strictEqual(produced, 100)
     }))
 
   it.effect("closes a socket when the serialization buffer limit is exceeded", () =>

--- a/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
@@ -492,7 +492,7 @@ describe("McpServer", () => {
     Effect.gen(function*() {
       const serverLayer = Layer.effectDiscard(Effect.gen(function*() {
         const router = yield* HttpRouter.HttpRouter
-        const { httpEffect, protocol } = yield* RpcServer.makeProtocolWithHttpEffect({})
+        const { httpEffect, protocol } = yield* RpcServer.makeProtocolWithHttpEffect()
         yield* protocol.run((clientId, message) => {
           if (message._tag !== "Request") {
             return Effect.void

--- a/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
@@ -492,7 +492,7 @@ describe("McpServer", () => {
     Effect.gen(function*() {
       const serverLayer = Layer.effectDiscard(Effect.gen(function*() {
         const router = yield* HttpRouter.HttpRouter
-        const { httpEffect, protocol } = yield* RpcServer.makeProtocolWithHttpEffect
+        const { httpEffect, protocol } = yield* RpcServer.makeProtocolWithHttpEffect({})
         yield* protocol.run((clientId, message) => {
           if (message._tag !== "Request") {
             return Effect.void

--- a/packages/effect/typetest/unstable/rpc/RpcServer.tst.ts
+++ b/packages/effect/typetest/unstable/rpc/RpcServer.tst.ts
@@ -16,30 +16,6 @@ describe("RpcServer", () => {
     })
   })
 
-  it("HTTP server options accept streamBufferSize", () => {
-    RpcServer.layerHttp({
-      group: Group,
-      path: "/rpc",
-      protocol: "http",
-      streamBufferSize: 16
-    })
-    RpcServer.layerProtocolHttp({ path: "/rpc", streamBufferSize: 16 })
-    void RpcServer.makeProtocolHttp({ path: "/rpc", streamBufferSize: 16 })
-    void RpcServer.makeProtocolWithHttpEffect({ streamBufferSize: 16 })
-    void RpcServer.toHttpEffect(Group, { streamBufferSize: 16 })
-
-    RpcServer.layerHttp({
-      group: Group,
-      path: "/rpc",
-      protocol: "http",
-      streamBufferSize: "unbounded"
-    })
-    RpcServer.layerProtocolHttp({ path: "/rpc", streamBufferSize: "unbounded" })
-    void RpcServer.makeProtocolHttp({ path: "/rpc", streamBufferSize: "unbounded" })
-    void RpcServer.makeProtocolWithHttpEffect({ streamBufferSize: "unbounded" })
-    void RpcServer.toHttpEffect(Group, { streamBufferSize: "unbounded" })
-  })
-
   it("toHttpEffect accepts disableFatalDefects", () => {
     void RpcServer.toHttpEffect(Group, { disableFatalDefects: true })
   })

--- a/packages/effect/typetest/unstable/rpc/RpcServer.tst.ts
+++ b/packages/effect/typetest/unstable/rpc/RpcServer.tst.ts
@@ -16,6 +16,18 @@ describe("RpcServer", () => {
     })
   })
 
+  it("HTTP server options accept streamBufferSize", () => {
+    RpcServer.layerHttp({
+      group: Group,
+      path: "/rpc",
+      protocol: "http",
+      streamBufferSize: 16
+    })
+    RpcServer.layerProtocolHttp({ path: "/rpc", streamBufferSize: 16 })
+    void RpcServer.makeProtocolHttp({ path: "/rpc", streamBufferSize: 16 })
+    void RpcServer.toHttpEffect(Group, { streamBufferSize: 16 })
+  })
+
   it("toHttpEffect accepts disableFatalDefects", () => {
     void RpcServer.toHttpEffect(Group, { disableFatalDefects: true })
   })

--- a/packages/effect/typetest/unstable/rpc/RpcServer.tst.ts
+++ b/packages/effect/typetest/unstable/rpc/RpcServer.tst.ts
@@ -26,6 +26,16 @@ describe("RpcServer", () => {
     RpcServer.layerProtocolHttp({ path: "/rpc", streamBufferSize: 16 })
     void RpcServer.makeProtocolHttp({ path: "/rpc", streamBufferSize: 16 })
     void RpcServer.toHttpEffect(Group, { streamBufferSize: 16 })
+
+    RpcServer.layerHttp({
+      group: Group,
+      path: "/rpc",
+      protocol: "http",
+      streamBufferSize: "unbounded"
+    })
+    RpcServer.layerProtocolHttp({ path: "/rpc", streamBufferSize: "unbounded" })
+    void RpcServer.makeProtocolHttp({ path: "/rpc", streamBufferSize: "unbounded" })
+    void RpcServer.toHttpEffect(Group, { streamBufferSize: "unbounded" })
   })
 
   it("toHttpEffect accepts disableFatalDefects", () => {

--- a/packages/effect/typetest/unstable/rpc/RpcServer.tst.ts
+++ b/packages/effect/typetest/unstable/rpc/RpcServer.tst.ts
@@ -25,6 +25,7 @@ describe("RpcServer", () => {
     })
     RpcServer.layerProtocolHttp({ path: "/rpc", streamBufferSize: 16 })
     void RpcServer.makeProtocolHttp({ path: "/rpc", streamBufferSize: 16 })
+    void RpcServer.makeProtocolWithHttpEffect({ streamBufferSize: 16 })
     void RpcServer.toHttpEffect(Group, { streamBufferSize: 16 })
 
     RpcServer.layerHttp({
@@ -35,6 +36,7 @@ describe("RpcServer", () => {
     })
     RpcServer.layerProtocolHttp({ path: "/rpc", streamBufferSize: "unbounded" })
     void RpcServer.makeProtocolHttp({ path: "/rpc", streamBufferSize: "unbounded" })
+    void RpcServer.makeProtocolWithHttpEffect({ streamBufferSize: "unbounded" })
     void RpcServer.toHttpEffect(Group, { streamBufferSize: "unbounded" })
   })
 


### PR DESCRIPTION
## Summary

- bound framed RPC HTTP response queues to 16 items by default
- allow `streamBufferSize` to select a numeric capacity or `"unbounded"`
- keep non-framed buffered responses unbounded
- cover the default, numeric override, unbounded opt-out, and non-framed behavior

The framed HTTP transport previously created an unbounded per-request output queue, so an unread response body could not slow a streaming RPC handler. The stream pump already awaits each queue offer; using a bounded queue supplies the missing backpressure without changing the pump.

## Checks

- `pnpm vitest --run packages/effect/test/rpc/RpcServer.test.ts`
- `pnpm test-types RpcServer.tst.ts`
- `pnpm lint`
- `pnpm check`

Closes EFF-741