### PR TITLE
Merge resource usage and finalizer failures

### DIFF
--- a/.changeset/merge-resource-failures.md
+++ b/.changeset/merge-resource-failures.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Merge effect and finalizer failure causes instead of dropping the original cause. `Effect.onExitPrimitive` now folds a failing finalizer's cause into the original failure cause, so `Effect.onExit`, `Effect.ensuring`, `Effect.onError`, `Effect.acquireUseRelease`, scoped resources, and Channel bracket cleanup all inherit the merge. The `Pull` done filters treat a `Cause.Done` signal merged with other failures as a real failure, stripping the done signal from the cause.
+Merge effect and finalizer failures during cleanup, preserving other failures alongside `Cause.Done`.

--- a/.changeset/merge-resource-failures.md
+++ b/.changeset/merge-resource-failures.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Merge effect and finalizer failure causes instead of dropping the original cause. This applies to `Effect.onExit`, `Effect.ensuring`, `Effect.onError` and everything built on them, including `Effect.acquireUseRelease`, scoped resources, and Channel bracket cleanup. The low-level `Effect.onExitPrimitive` keeps its replace semantics.
+Merge effect and finalizer failure causes instead of dropping the original cause. `Effect.onExitPrimitive` now folds a failing finalizer's cause into the original failure cause, so `Effect.onExit`, `Effect.ensuring`, `Effect.onError`, `Effect.acquireUseRelease`, scoped resources, and Channel bracket cleanup all inherit the merge. The `Pull` done filters treat a `Cause.Done` signal merged with other failures as a real failure, stripping the done signal from the cause.

--- a/.changeset/merge-resource-failures.md
+++ b/.changeset/merge-resource-failures.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Preserve both usage and finalizer causes when bracketed Effect, scoped, and Channel resources fail during cleanup.
+Merge effect and finalizer failure causes instead of dropping the original cause. This applies to `Effect.onExit`, `Effect.ensuring`, `Effect.onError` and everything built on them, including `Effect.acquireUseRelease`, scoped resources, and Channel bracket cleanup. The low-level `Effect.onExitPrimitive` keeps its replace semantics.

--- a/.changeset/merge-resource-failures.md
+++ b/.changeset/merge-resource-failures.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve both usage and finalizer causes when bracketed Effect, scoped, and Channel resources fail during cleanup.

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -406,8 +406,16 @@ export const fromTransformBracket = <OutElem, OutErr, OutDone, InElem, InErr, In
   fromTransform(
     Effect.fnUntraced(function*(upstream, scope) {
       const closableScope = Scope.forkUnsafe(scope)
-      const onCause = (cause: Cause.Cause<EX | OutErr | Cause.Done<OutDone>>) =>
-        Scope.close(closableScope, Pull.doneExitFromCause(cause))
+      const onCause = (cause: Cause.Cause<EX | OutErr | Cause.Done<OutDone>>): Effect.Effect<void> => {
+        const exit = Pull.doneExitFromCause(cause)
+        const close = Scope.close(closableScope, exit)
+        return Exit.isFailure(exit)
+          ? Effect.catchCause(
+            close,
+            (closeCause) => Effect.failCause(Cause.combine(exit.cause, closeCause)) as Effect.Effect<never>
+          )
+          : close
+      }
       const pull = yield* Effect.onError(
         f(upstream, scope, closableScope),
         onCause

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -20,7 +20,7 @@ import * as Fiber from "./Fiber.ts"
 import type * as Filter from "./Filter.ts"
 import type { LazyArg } from "./Function.ts"
 import { constant, constTrue, constVoid, dual, identity as identity_ } from "./Function.ts"
-import { ClockRef, endSpan } from "./internal/effect.ts"
+import { ClockRef, endSpan, scopeCloseWithExit } from "./internal/effect.ts"
 import { addSpanStackTrace } from "./internal/tracer.ts"
 import * as Iterable from "./Iterable.ts"
 import * as Latch from "./Latch.ts"
@@ -406,16 +406,10 @@ export const fromTransformBracket = <OutElem, OutErr, OutDone, InElem, InErr, In
   fromTransform(
     Effect.fnUntraced(function*(upstream, scope) {
       const closableScope = Scope.forkUnsafe(scope)
-      const onCause = (cause: Cause.Cause<EX | OutErr | Cause.Done<OutDone>>): Effect.Effect<void> => {
-        const exit = Pull.doneExitFromCause(cause)
-        const close = Scope.close(closableScope, exit)
-        return Exit.isFailure(exit)
-          ? Effect.catchCause(
-            close,
-            (closeCause) => Effect.failCause(Cause.combine(exit.cause, closeCause)) as Effect.Effect<never>
-          )
-          : close
-      }
+      const onCause = (cause: Cause.Cause<EX | OutErr | Cause.Done<OutDone>>) =>
+        Effect.suspend(() =>
+          scopeCloseWithExit(closableScope, Pull.doneExitFromCause(cause)) ?? Effect.void
+        ) as Effect.Effect<void>
       const pull = yield* Effect.onError(
         f(upstream, scope, closableScope),
         onCause

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -20,7 +20,7 @@ import * as Fiber from "./Fiber.ts"
 import type * as Filter from "./Filter.ts"
 import type { LazyArg } from "./Function.ts"
 import { constant, constTrue, constVoid, dual, identity as identity_ } from "./Function.ts"
-import { ClockRef, endSpan, scopeCloseWithExit } from "./internal/effect.ts"
+import { ClockRef, endSpan } from "./internal/effect.ts"
 import { addSpanStackTrace } from "./internal/tracer.ts"
 import * as Iterable from "./Iterable.ts"
 import * as Latch from "./Latch.ts"
@@ -406,20 +406,13 @@ export const fromTransformBracket = <OutElem, OutErr, OutDone, InElem, InErr, In
   fromTransform(
     Effect.fnUntraced(function*(upstream, scope) {
       const closableScope = Scope.forkUnsafe(scope)
-      // Uses the replace-semantics onExitPrimitive instead of onError: merging
-      // a close failure into a Cause.Done cause would make consumers read the
-      // combined cause as graceful completion and drop the close failure.
-      const onExitClose = (exit: Exit.Exit<unknown, EX | OutErr | Cause.Done<OutDone>>) =>
-        Exit.isSuccess(exit)
-          ? undefined
-          : Effect.suspend(() =>
-            scopeCloseWithExit(closableScope, Pull.doneExitFromCause(exit.cause)) ?? Effect.void
-          ) as Effect.Effect<void>
-      const pull = yield* Effect.onExitPrimitive(
+      const onCause = (cause: Cause.Cause<EX | OutErr | Cause.Done<OutDone>>) =>
+        Scope.close(closableScope, Pull.doneExitFromCause(cause))
+      const pull = yield* Effect.onError(
         f(upstream, scope, closableScope),
-        onExitClose
+        onCause
       )
-      return Effect.onExitPrimitive(pull, onExitClose)
+      return Effect.onError(pull, onCause)
     })
   )
 

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -406,15 +406,20 @@ export const fromTransformBracket = <OutElem, OutErr, OutDone, InElem, InErr, In
   fromTransform(
     Effect.fnUntraced(function*(upstream, scope) {
       const closableScope = Scope.forkUnsafe(scope)
-      const onCause = (cause: Cause.Cause<EX | OutErr | Cause.Done<OutDone>>) =>
-        Effect.suspend(() =>
-          scopeCloseWithExit(closableScope, Pull.doneExitFromCause(cause)) ?? Effect.void
-        ) as Effect.Effect<void>
-      const pull = yield* Effect.onError(
+      // Uses the replace-semantics onExitPrimitive instead of onError: merging
+      // a close failure into a Cause.Done cause would make consumers read the
+      // combined cause as graceful completion and drop the close failure.
+      const onExitClose = (exit: Exit.Exit<unknown, EX | OutErr | Cause.Done<OutDone>>) =>
+        Exit.isSuccess(exit)
+          ? undefined
+          : Effect.suspend(() =>
+            scopeCloseWithExit(closableScope, Pull.doneExitFromCause(exit.cause)) ?? Effect.void
+          ) as Effect.Effect<void>
+      const pull = yield* Effect.onExitPrimitive(
         f(upstream, scope, closableScope),
-        onCause
+        onExitClose
       )
-      return Effect.onError(pull, onCause)
+      return Effect.onExitPrimitive(pull, onExitClose)
     })
   )
 

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6947,6 +6947,8 @@ export const onExitPrimitive: <A, E, R, XE = never, XR = never>(
  * Ensures that a cleanup function runs whether this effect succeeds, fails, or
  * is interrupted.
  *
+ * If both the effect and the cleanup function fail, the two causes are merged.
+ *
  * **Example** (Observing every exit)
  *
  * ```ts import.meta.vitest

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6930,7 +6930,8 @@ export const onErrorFilter: {
  * **Details**
  *
  * This low-level operator preserves the source effect's result unless the
- * finalizer fails. Prefer `onExit` for normal cleanup logic.
+ * finalizer fails. If both the source effect and the finalizer fail, the two
+ * causes are merged. Prefer `onExit` for normal cleanup logic.
  *
  * @see {@link onExit} for ordinary exit-aware cleanup whose finalizer always returns an effect
  *

--- a/packages/effect/src/Pull.ts
+++ b/packages/effect/src/Pull.ts
@@ -214,19 +214,35 @@ export const isDoneFailure = <E>(
  *
  * **Details**
  *
- * Returns a successful `Result` with the `Cause.Done` value when one is
- * present, otherwise returns a failed `Result` containing the non-done cause.
+ * Returns a successful `Result` with the `Cause.Done` value when the cause
+ * contains a done signal and no other failures besides interruptions. When the
+ * done signal was merged with a real failure (for example a failing
+ * finalizer), the `Result` fails with the remaining cause, stripped of the
+ * done signal. Without a done signal the `Result` fails with the original
+ * cause.
  *
  * @category filtering
  * @since 4.0.0
  */
 export const filterDone: <E>(
   input: Cause.Cause<E>
-) => Result.Result<Cause.Done.Only<E>, Cause.Cause<ExcludeDone<E>>> = Filter
-  .composePassthrough(
-    Cause.findError,
-    (e) => Cause.isDone(e) ? Result.succeed(e) : Result.fail(e)
-  ) as any
+) => Result.Result<Cause.Done.Only<E>, Cause.Cause<ExcludeDone<E>>> = <E>(
+  cause: Cause.Cause<E>
+): Result.Result<any, any> => {
+  let done: Cause.Done<any> | undefined
+  let hasFailure = false
+  for (const reason of cause.reasons) {
+    if (isDoneFailure(reason)) {
+      done ??= reason.error
+    } else if (reason._tag !== "Interrupt") {
+      hasFailure = true
+    }
+  }
+  if (done === undefined) return Result.fail(cause)
+  return hasFailure
+    ? Result.fail(Cause.fromReasons(cause.reasons.filter((reason) => !isDoneFailure(reason))))
+    : Result.succeed(done)
+}
 
 /**
  * Finds a `Cause.Done` failure in a cause whose done value is not used.
@@ -238,8 +254,8 @@ export const filterDone: <E>(
  *
  * **Details**
  *
- * Returns a successful `Result` with the done marker when present, otherwise
- * returns a failed `Result` with the non-done cause.
+ * Returns a successful `Result` with the done marker when it is the only
+ * failure, otherwise returns a failed `Result` with the non-done cause.
  *
  * @see {@link filterDone} for preserving the typed `Cause.Done` value when the done payload matters
  * @see {@link filterDoneLeftover} for extracting only the done leftover value
@@ -250,10 +266,7 @@ export const filterDone: <E>(
  */
 export const filterDoneVoid: <E extends Cause.Done>(
   input: Cause.Cause<E>
-) => Result.Result<Cause.Done, Cause.Cause<Exclude<E, Cause.Done>>> = Filter.composePassthrough(
-  Cause.findError,
-  (e) => Cause.isDone(e) ? Result.succeed(e) : Result.fail(e)
-) as any
+) => Result.Result<Cause.Done, Cause.Cause<Exclude<E, Cause.Done>>> = filterDone as any
 
 /**
  * Keeps a `Cause` only when it contains no `Cause.Done` failures.
@@ -296,10 +309,10 @@ export const filterNoDone: <E>(
  */
 export const filterDoneLeftover: <E>(
   cause: Cause.Cause<E>
-) => Result.Result<Cause.Done.Extract<E>, Cause.Cause<ExcludeDone<E>>> = Filter.composePassthrough(
-  Cause.findError,
-  (e) => Cause.isDone(e) ? Result.succeed(e.value) : Result.fail(e)
-) as any
+) => Result.Result<Cause.Done.Extract<E>, Cause.Cause<ExcludeDone<E>>> = ((cause: Cause.Cause<any>) => {
+  const done = filterDone(cause)
+  return Result.isFailure(done) ? done : Result.succeed(done.success.value)
+}) as any
 
 /**
  * Converts a `Cause` into an `Exit`, treating `Cause.Done` as successful
@@ -313,8 +326,9 @@ export const filterDoneLeftover: <E>(
  *
  * **Details**
  *
- * If the cause contains a done value, that leftover becomes the successful
- * value. Otherwise the non-done cause becomes the failure cause.
+ * If the done signal is the only failure in the cause, its leftover becomes
+ * the successful value. Otherwise the non-done cause becomes the failure
+ * cause.
  *
  * @see {@link filterDone} for extracting the done signal without converting the cause to an `Exit`
  * @see {@link matchEffect} for handling `Pull` success, failure, and done outcomes directly

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -3932,7 +3932,7 @@ export const scopeUse: {
 } = dual(
   2,
   <A, E, R>(self: Effect.Effect<A, E, R>, scope: Scope.Closeable): Effect.Effect<A, E, Exclude<R, Scope.Scope>> =>
-    onExit(provideScope(self, scope), (exit) => suspend(() => scopeCloseWithExit(scope, exit) ?? void_))
+    onExit(provideScope(self, scope), (exit) => suspend(() => scopeCloseUnsafe(scope, exit) ?? void_))
 )
 
 /** @internal */
@@ -3941,7 +3941,7 @@ export const scopedWith = <A, E, R>(
 ): Effect.Effect<A, E, R> =>
   suspend(() => {
     const scope = scopeMakeUnsafe()
-    return onExit(f(scope), (exit) => suspend(() => scopeCloseWithExit(scope, exit) ?? void_))
+    return onExit(f(scope), (exit) => suspend(() => scopeCloseUnsafe(scope, exit) ?? void_))
   })
 
 /** @internal */
@@ -4014,7 +4014,10 @@ export const onExit: {
     self: Effect.Effect<A, E, R>,
     f: (exit: Exit.Exit<A, E>) => Effect.Effect<void, XE, XR>
   ): Effect.Effect<A, E | XE, R | XR>
-} = dual(2, onExitPrimitive)
+} = dual(2, <A, E, R, XE = never, XR = never>(
+  self: Effect.Effect<A, E, R>,
+  f: (exit: Exit.Exit<A, E>) => Effect.Effect<void, XE, XR>
+): Effect.Effect<A, E | XE, R | XR> => onExitPrimitive(self, (exit) => combineFinalizerCause(exit, f(exit))))
 
 /** @internal */
 export const ensuring: {

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -3793,10 +3793,16 @@ export const scopeCloseUnsafe = <A, E>(self: Scope.Scope, exit_: Exit.Exit<A, E>
   return scopeCloseFinalizers(self, finalizers, exit_)
 }
 
-const scopeCloseWithExit = <A, E>(self: Scope.Scope, exit_: Exit.Exit<A, E>) => {
+const combineFinalizerCause = <A, E, XE, XR>(
+  exit_: Exit.Exit<A, E>,
+  finalizer: Effect.Effect<void, XE, XR>
+): Effect.Effect<void, E | XE, XR> =>
+  exitIsSuccess(exit_) ? finalizer : catchCause(finalizer, (cause) => failCause(causeCombine(exit_.cause, cause)))
+
+/** @internal */
+export const scopeCloseWithExit = <A, E>(self: Scope.Scope, exit_: Exit.Exit<A, E>) => {
   const close = scopeCloseUnsafe(self, exit_)
-  if (close === undefined || exitIsSuccess(exit_)) return close
-  return catchCause(close, (cause) => failCause(causeCombine(exit_.cause, cause)))
+  return close && combineFinalizerCause(exit_, close)
 }
 
 const scopeCloseFinalizers = fnUntraced(function*<A, E>(
@@ -4175,16 +4181,12 @@ export const acquireUseRelease = <Resource, E, R, A, E2, R2, E3, R3>(
   release: (a: Resource, exit: Exit.Exit<A, E2>) => Effect.Effect<void, E3, R3>
 ): Effect.Effect<A, E | E2 | E3, R | R2 | R3> =>
   uninterruptibleMask((restore) =>
-    flatMap(
-      acquire,
-      (a) =>
-        flatMap(exit(restore(use(a))), (useExit) =>
-          flatMap(exit(release(a, useExit)), (releaseExit) => {
-            if (exitIsSuccess(releaseExit)) return useExit
-            if (exitIsSuccess(useExit)) return failCause(releaseExit.cause)
-            return exitFailCause(causeCombine(useExit.cause, releaseExit.cause))
-          }))
-    )
+    flatMap(acquire, (a) =>
+      onExitPrimitive(
+        restore(use(a)),
+        (exit) => combineFinalizerCause(exit, release(a, exit)),
+        true
+      ))
   )
 
 /** @internal */

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -3799,12 +3799,6 @@ const combineFinalizerCause = <A, E, XE, XR>(
 ): Effect.Effect<void, E | XE, XR> =>
   exitIsSuccess(exit_) ? finalizer : catchCause(finalizer, (cause) => failCause(causeCombine(exit_.cause, cause)))
 
-/** @internal */
-export const scopeCloseWithExit = <A, E>(self: Scope.Scope, exit_: Exit.Exit<A, E>) => {
-  const close = scopeCloseUnsafe(self, exit_)
-  return close && combineFinalizerCause(exit_, close)
-}
-
 const scopeCloseFinalizers = fnUntraced(function*<A, E>(
   self: Scope.Scope,
   finalizers: Scope.State.Open["finalizers"],
@@ -3919,7 +3913,7 @@ export const scoped = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, 
     fiber.setContext(Context.add(fiber.context, scopeTag, scope))
     return onExitPrimitive(self, (exit) => {
       fiber.setContext(prev)
-      return scopeCloseWithExit(scope, exit)
+      return scopeCloseUnsafe(scope, exit)
     })
   }) as any
 
@@ -4001,7 +3995,7 @@ export const onExitPrimitive: <A, E, R, XE = never, XR = never>(
   [contE](cause, _, exit) {
     exit ??= exitFailCause(cause)
     const eff = this[args][1](exit)
-    return eff ? flatMap(eff, (_) => exit) : exit
+    return eff ? flatMap(combineFinalizerCause(exit, eff), (_) => exit) : exit
   }
 })
 
@@ -4014,10 +4008,7 @@ export const onExit: {
     self: Effect.Effect<A, E, R>,
     f: (exit: Exit.Exit<A, E>) => Effect.Effect<void, XE, XR>
   ): Effect.Effect<A, E | XE, R | XR>
-} = dual(2, <A, E, R, XE = never, XR = never>(
-  self: Effect.Effect<A, E, R>,
-  f: (exit: Exit.Exit<A, E>) => Effect.Effect<void, XE, XR>
-): Effect.Effect<A, E | XE, R | XR> => onExitPrimitive(self, (exit) => combineFinalizerCause(exit, f(exit))))
+} = dual(2, onExitPrimitive)
 
 /** @internal */
 export const ensuring: {
@@ -4187,7 +4178,7 @@ export const acquireUseRelease = <Resource, E, R, A, E2, R2, E3, R3>(
     flatMap(acquire, (a) =>
       onExitPrimitive(
         restore(use(a)),
-        (exit) => combineFinalizerCause(exit, release(a, exit)),
+        (exit) => release(a, exit),
         true
       ))
   )

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -3793,6 +3793,12 @@ export const scopeCloseUnsafe = <A, E>(self: Scope.Scope, exit_: Exit.Exit<A, E>
   return scopeCloseFinalizers(self, finalizers, exit_)
 }
 
+const scopeCloseWithExit = <A, E>(self: Scope.Scope, exit_: Exit.Exit<A, E>) => {
+  const close = scopeCloseUnsafe(self, exit_)
+  if (close === undefined || exitIsSuccess(exit_)) return close
+  return catchCause(close, (cause) => failCause(causeCombine(exit_.cause, cause)))
+}
+
 const scopeCloseFinalizers = fnUntraced(function*<A, E>(
   self: Scope.Scope,
   finalizers: Scope.State.Open["finalizers"],
@@ -3907,7 +3913,7 @@ export const scoped = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, 
     fiber.setContext(Context.add(fiber.context, scopeTag, scope))
     return onExitPrimitive(self, (exit) => {
       fiber.setContext(prev)
-      return scopeCloseUnsafe(scope, exit)
+      return scopeCloseWithExit(scope, exit)
     })
   }) as any
 
@@ -3920,7 +3926,7 @@ export const scopeUse: {
 } = dual(
   2,
   <A, E, R>(self: Effect.Effect<A, E, R>, scope: Scope.Closeable): Effect.Effect<A, E, Exclude<R, Scope.Scope>> =>
-    onExit(provideScope(self, scope), (exit) => suspend(() => scopeCloseUnsafe(scope, exit) ?? void_))
+    onExit(provideScope(self, scope), (exit) => suspend(() => scopeCloseWithExit(scope, exit) ?? void_))
 )
 
 /** @internal */
@@ -3929,7 +3935,7 @@ export const scopedWith = <A, E, R>(
 ): Effect.Effect<A, E, R> =>
   suspend(() => {
     const scope = scopeMakeUnsafe()
-    return onExit(f(scope), (exit) => suspend(() => scopeCloseUnsafe(scope, exit) ?? void_))
+    return onExit(f(scope), (exit) => suspend(() => scopeCloseWithExit(scope, exit) ?? void_))
   })
 
 /** @internal */
@@ -4169,12 +4175,16 @@ export const acquireUseRelease = <Resource, E, R, A, E2, R2, E3, R3>(
   release: (a: Resource, exit: Exit.Exit<A, E2>) => Effect.Effect<void, E3, R3>
 ): Effect.Effect<A, E | E2 | E3, R | R2 | R3> =>
   uninterruptibleMask((restore) =>
-    flatMap(acquire, (a) =>
-      onExitPrimitive(
-        restore(use(a)),
-        (exit) => release(a, exit),
-        true
-      ))
+    flatMap(
+      acquire,
+      (a) =>
+        flatMap(exit(restore(use(a))), (useExit) =>
+          flatMap(exit(release(a, useExit)), (releaseExit) => {
+            if (exitIsSuccess(releaseExit)) return useExit
+            if (exitIsSuccess(useExit)) return failCause(releaseExit.cause)
+            return exitFailCause(causeCombine(useExit.cause, releaseExit.cause))
+          }))
+    )
   )
 
 /** @internal */

--- a/packages/effect/test/Channel.test.ts
+++ b/packages/effect/test/Channel.test.ts
@@ -181,6 +181,16 @@ describe("Channel", () => {
           Exit.failCause(Cause.combine(Cause.fail("usage failure"), Cause.die("release failure")))
         )
       }))
+
+    it.effect("acquireUseRelease surfaces release failure after successful usage", () =>
+      Effect.gen(function*() {
+        const result = yield* Channel.acquireUseRelease(
+          Effect.void,
+          () => Channel.succeed(1),
+          () => Effect.die("release failure")
+        ).pipe(Channel.runDrain, Effect.exit)
+        assert.deepStrictEqual(result, Exit.die("release failure"))
+      }))
   })
 
   describe("destructors", () => {

--- a/packages/effect/test/Channel.test.ts
+++ b/packages/effect/test/Channel.test.ts
@@ -168,6 +168,19 @@ describe("Channel", () => {
         assert.isTrue(yield* Ref.get(acquired))
         assert.isTrue(yield* Ref.get(released))
       }))
+
+    it.effect("acquireUseRelease combines usage and release failures", () =>
+      Effect.gen(function*() {
+        const result = yield* Channel.acquireUseRelease(
+          Effect.void,
+          () => Channel.fail("usage failure"),
+          () => Effect.die("release failure")
+        ).pipe(Channel.runDrain, Effect.exit)
+        assert.deepStrictEqual(
+          result,
+          Exit.failCause(Cause.combine(Cause.fail("usage failure"), Cause.die("release failure")))
+        )
+      }))
   })
 
   describe("destructors", () => {

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -2114,6 +2114,18 @@ describe("Effect", () => {
         assert.isFalse(reported !== undefined && Exit.isSuccess(reported))
       }))
 
+    it.effect("scoped combines usage and finalizer failures", () =>
+      Effect.gen(function*() {
+        const result = yield* Effect.gen(function*() {
+          yield* Effect.addFinalizer(() => Effect.die("finalizer failure"))
+          return yield* Effect.fail("usage failure")
+        }).pipe(Effect.scoped, Effect.exit)
+        assert.deepStrictEqual(
+          result,
+          Exit.failCause(Cause.combine(Cause.fail("usage failure"), Cause.die("finalizer failure")))
+        )
+      }))
+
     it.effect("acquireUseRelease usage result", () =>
       Effect.gen(function*() {
         const result = yield* Effect.acquireUseRelease(
@@ -2161,6 +2173,19 @@ describe("Effect", () => {
           Effect.exit
         )
         assert.deepStrictEqual(result, Exit.fail(ExampleError))
+      }))
+
+    it.effect("combines usage and release failures", () =>
+      Effect.gen(function*() {
+        const result = yield* Effect.acquireUseRelease(
+          Effect.void,
+          () => Effect.fail("usage failure"),
+          () => Effect.fail("release failure")
+        ).pipe(Effect.exit)
+        assert.deepStrictEqual(
+          result,
+          Exit.failCause(Cause.combine(Cause.fail("usage failure"), Cause.fail("release failure")))
+        )
       }))
 
     it.effect("rethrown caught error in acquisition", () =>

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -2077,7 +2077,7 @@ describe("Effect", () => {
         assert.isTrue(finalized)
       }))
 
-    it.effect("finalizer errors not caught", () =>
+    it.effect("finalizer errors merged", () =>
       Effect.gen(function*() {
         const e2 = new Error("e2")
         const e3 = new Error("e3")
@@ -2089,7 +2089,10 @@ describe("Effect", () => {
           Effect.flip,
           Effect.map((cause) => cause)
         )
-        assert.deepStrictEqual(result, Cause.die(e3))
+        assert.deepStrictEqual(
+          result,
+          Cause.combine(Cause.combine(Cause.fail(ExampleError), Cause.die(e2)), Cause.die(e3))
+        )
       }))
 
     it.effect("finalizer errors reported", () =>

--- a/packages/effect/test/Pull.test.ts
+++ b/packages/effect/test/Pull.test.ts
@@ -1,0 +1,40 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Cause, Exit, Result } from "effect"
+import * as Pull from "effect/Pull"
+
+describe("Pull", () => {
+  describe("filterDone", () => {
+    it("succeeds when the done signal is the only failure", () => {
+      const result = Pull.filterDone(Cause.fail(Cause.Done("leftover")))
+      assert.deepStrictEqual(result, Result.succeed(Cause.Done("leftover")))
+    })
+
+    it("strips the done signal when merged with other failures", () => {
+      const cause = Cause.combine(Cause.fail(Cause.Done("leftover")), Cause.die("boom"))
+      const result = Pull.filterDone(cause)
+      assert.deepStrictEqual(result, Result.fail(Cause.die("boom")))
+    })
+
+    it("fails with the original cause when no done signal is present", () => {
+      const cause = Cause.fail("error")
+      assert.deepStrictEqual(Pull.filterDone(cause), Result.fail(cause))
+    })
+
+    it("succeeds when the done signal is merged only with interruptions", () => {
+      const cause = Cause.combine(Cause.interrupt(1), Cause.fail(Cause.Done("leftover")))
+      assert.deepStrictEqual(Pull.filterDone(cause), Result.succeed(Cause.Done("leftover")))
+    })
+  })
+
+  describe("doneExitFromCause", () => {
+    it("treats a pure done cause as success", () => {
+      const exit = Pull.doneExitFromCause(Cause.fail(Cause.Done("leftover")))
+      assert.deepStrictEqual(exit, Exit.succeed("leftover"))
+    })
+
+    it("fails with the stripped cause when the done signal was merged with a failure", () => {
+      const cause = Cause.combine(Cause.fail(Cause.Done("leftover")), Cause.die("boom"))
+      assert.deepStrictEqual(Pull.doneExitFromCause(cause), Exit.failCause(Cause.die("boom")))
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- `Effect.onExitPrimitive` now folds a failing finalizer's cause into the original failure cause, so `Effect.onExit`, `Effect.ensuring`, `Effect.onError`, `Effect.acquireUseRelease`, scoped resources, and Channel bracket cleanup all inherit the merge from the one primitive
- the `Pull` done filters (`filterDone`, `filterDoneVoid`, `filterDoneLeftover`, `doneExitFromCause`) handle merged causes: a `Cause.Done` signal alongside only interruptions still reads as graceful completion, while a done signal merged with a real failure yields that failure with the done signal stripped
- add focused regressions (including `Pull` filter tests and a Channel test that a release failure after successful usage still surfaces) and a patch changeset

## Root cause

`onExitPrimitive` replaced the original failure cause when the finalizer effect failed. With the merge in the primitive, causes can now carry a `Cause.Done` completion signal next to other reasons, so the done detection in `Pull` partitions reasons instead of reading the first `Fail` error.

## Validation

- full `effect` package test suite (279 files, 8608 tests)
- `pnpm lint`
- `pnpm check`

Closes EFF-742

🤖 Generated with [Claude Code](https://claude.com/claude-code)
