### PR TITLE
Preserve encoded AI tool parameters for manual resolution

### DIFF
--- a/.changeset/tidy-tools-handle.md
+++ b/.changeset/tidy-tools-handle.md
@@ -2,4 +2,5 @@
 "effect": patch
 ---
 
-Preserve encoded AI tool call parameters when automatic tool call resolution is disabled.
+Preserve encoded AI tool call parameters when automatic tool call resolution is disabled, and update
+`Toolkit.handle` to accept the encoded parameter type it decodes at runtime.

--- a/.changeset/tidy-tools-handle.md
+++ b/.changeset/tidy-tools-handle.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve encoded AI tool call parameters when automatic tool call resolution is disabled.

--- a/packages/effect/src/unstable/ai/Chat.ts
+++ b/packages/effect/src/unstable/ai/Chat.ts
@@ -240,7 +240,7 @@ export interface Service {
         readonly toolkit: LanguageModel.ToolkitInput<Tools>
       }
     ): Effect.Effect<
-      LanguageModel.GenerateTextResponse<Tools>,
+      LanguageModel.GenerateTextResponse<Tools, LanguageModel.ExtractEncodedToolParameters<Options>>,
       LanguageModel.ExtractError<Options>,
       LanguageModel.LanguageModel | LanguageModel.ExtractServices<Options>
     >
@@ -253,7 +253,10 @@ export interface Service {
         readonly toolkit: Options["toolkit"]
       }
     ): Effect.Effect<
-      LanguageModel.GenerateTextResponse<LanguageModel.ExtractTools<Options>>,
+      LanguageModel.GenerateTextResponse<
+        LanguageModel.ExtractTools<Options>,
+        LanguageModel.ExtractEncodedToolParameters<Options>
+      >,
       LanguageModel.ExtractError<Options>,
       LanguageModel.LanguageModel | LanguageModel.ExtractServices<Options>
     >
@@ -319,7 +322,7 @@ export interface Service {
         readonly toolkit: LanguageModel.ToolkitInput<Tools>
       }
     ): Stream.Stream<
-      Response.StreamPart<Tools>,
+      Response.StreamPart<Tools, LanguageModel.ExtractEncodedToolParameters<Options>>,
       LanguageModel.ExtractError<Options>,
       LanguageModel.LanguageModel | LanguageModel.ExtractServices<Options>
     >
@@ -332,7 +335,10 @@ export interface Service {
         readonly toolkit: Options["toolkit"]
       }
     ): Stream.Stream<
-      Response.StreamPart<LanguageModel.ExtractTools<Options>>,
+      Response.StreamPart<
+        LanguageModel.ExtractTools<Options>,
+        LanguageModel.ExtractEncodedToolParameters<Options>
+      >,
       LanguageModel.ExtractError<Options>,
       LanguageModel.LanguageModel | LanguageModel.ExtractServices<Options>
     >
@@ -390,7 +396,11 @@ export interface Service {
   >(
     options: Options & LanguageModel.GenerateObjectOptions<LanguageModel.ExtractTools<Options>, ObjectSchema>
   ) => Effect.Effect<
-    LanguageModel.GenerateObjectResponse<LanguageModel.ExtractTools<Options>, ObjectSchema["Type"]>,
+    LanguageModel.GenerateObjectResponse<
+      LanguageModel.ExtractTools<Options>,
+      ObjectSchema["Type"],
+      LanguageModel.ExtractEncodedToolParameters<Options>
+    >,
     LanguageModel.ExtractError<Options>,
     LanguageModel.ExtractServices<Options> | ObjectSchema["DecodingServices"] | LanguageModel.LanguageModel
   >

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -410,9 +410,7 @@ export class GenerateTextResponse<
   /**
    * Returns all tool call parts from the response.
    */
-  get toolCalls(): Array<
-    EncodedToolParameters extends true ? Response.ToolCallPartsEncoded<Tools> : Response.ToolCallParts<Tools>
-  > {
+  get toolCalls(): Array<Response.ToolCallParts<Tools, EncodedToolParameters>> {
     return this.content.filter((part) => part.type === "tool-call")
   }
 
@@ -1183,15 +1181,17 @@ export const make: (params: {
       }
     }
 
+    // Construct the response schema with the tools from the toolkit, keeping
+    // tool call parameters encoded when tool call resolution is disabled
+    const ResponseSchema = Schema.mutable(Schema.Array(Response.Part(
+      options.disableToolCallResolution === true ? makeToolkitWithEncodedParameters(toolkit) : toolkit
+    )))
+
     // If tool call resolution is disabled, return the response without
     // resolving the tool calls that were generated
     if (options.disableToolCallResolution === true) {
-      const encodedToolkit = makeToolkitWithEncodedParameters(toolkit)
-      const EncodedResponseSchema = Schema.mutable(
-        Schema.Array(Response.Part(encodedToolkit))
-      )
       const rawContent = yield* generateWithNonIncrementalFallback()
-      const content = yield* Schema.decodeEffect(EncodedResponseSchema)(rawContent)
+      const content = yield* Schema.decodeEffect(ResponseSchema)(rawContent)
       if (tracker) {
         const responseMetadata = content.find((part) => part.type === "response-metadata")
         if (Predicate.isNotUndefined(responseMetadata) && Predicate.isNotUndefined(responseMetadata.id)) {
@@ -1200,11 +1200,6 @@ export const make: (params: {
       }
       return content as Array<Response.Part<Tools>>
     }
-
-    // Construct the response schema with the tools from the toolkit
-    const ResponseSchema = Schema.mutable(
-      Schema.Array(Response.Part(toolkit))
-    )
 
     const rawContent = yield* generateWithNonIncrementalFallback()
 
@@ -1464,12 +1459,16 @@ export const make: (params: {
       }
     }
 
+    // Construct the response schema with the tools from the toolkit, keeping
+    // tool call parameters encoded when tool call resolution is disabled
+    const ResponseSchema = Schema.NonEmptyArray(Response.StreamPart(
+      options.disableToolCallResolution === true ? makeToolkitWithEncodedParameters(toolkit) : toolkit
+    ))
+    const decodeParts = Schema.decodeEffect(ResponseSchema)
+
     // If tool call resolution is disabled, return the response without
     // resolving the tool calls that were generated
     if (options.disableToolCallResolution === true) {
-      const encodedToolkit = makeToolkitWithEncodedParameters(toolkit)
-      const schema = Schema.NonEmptyArray(Response.StreamPart(encodedToolkit))
-      const decodeParts = Schema.decodeEffect(schema)
       return streamWithNonIncrementalFallback().pipe(
         Stream.mapArrayEffect((parts) =>
           decodeParts(parts).pipe(
@@ -1491,9 +1490,6 @@ export const make: (params: {
         IdGenerator
       >
     }
-
-    const ResponseSchema = Schema.NonEmptyArray(Response.StreamPart(toolkit))
-    const decodeParts = Schema.decodeEffect(ResponseSchema)
 
     // Queue for decoded parts and tool results
     const queue = yield* Queue.make<

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -115,7 +115,7 @@ export interface Service {
     >(
       options: Options & GenerateTextOptions<Tools> & { readonly toolkit: ToolkitInput<Tools> }
     ): Effect.Effect<
-      GenerateTextResponse<Tools>,
+      GenerateTextResponse<Tools, ExtractEncodedToolParameters<Options>>,
       ExtractError<Options>,
       ExtractServices<Options>
     >
@@ -127,7 +127,7 @@ export interface Service {
     >(
       options: Options & GenerateTextOptions<ExtractTools<Options>> & { readonly toolkit: Options["toolkit"] }
     ): Effect.Effect<
-      GenerateTextResponse<ExtractTools<Options>>,
+      GenerateTextResponse<ExtractTools<Options>, ExtractEncodedToolParameters<Options>>,
       ExtractError<Options>,
       ExtractServices<Options>
     >
@@ -147,7 +147,7 @@ export interface Service {
   >(
     options: Options & GenerateObjectOptions<Tools, StructuredOutputSchema>
   ) => Effect.Effect<
-    GenerateObjectResponse<Tools, StructuredOutputSchema["Type"]>,
+    GenerateObjectResponse<Tools, StructuredOutputSchema["Type"], ExtractEncodedToolParameters<Options>>,
     ExtractError<Options>,
     ExtractServices<Options> | StructuredOutputSchema["DecodingServices"]
   >
@@ -174,7 +174,7 @@ export interface Service {
     >(
       options: Options & GenerateTextOptions<Tools> & { readonly toolkit: ToolkitInput<Tools> }
     ): Stream.Stream<
-      Response.StreamPart<Tools>,
+      Response.StreamPart<Tools, ExtractEncodedToolParameters<Options>>,
       ExtractError<Options>,
       ExtractServices<Options>
     >
@@ -186,7 +186,7 @@ export interface Service {
     >(
       options: Options & GenerateTextOptions<ExtractTools<Options>> & { readonly toolkit: Options["toolkit"] }
     ): Stream.Stream<
-      Response.StreamPart<ExtractTools<Options>>,
+      Response.StreamPart<ExtractTools<Options>, ExtractEncodedToolParameters<Options>>,
       ExtractError<Options>,
       ExtractServices<Options>
     >
@@ -364,10 +364,13 @@ export type ToolChoice<ToolName extends string> =
  * @category models
  * @since 4.0.0
  */
-export class GenerateTextResponse<Tools extends Record<string, Tool.Any>> {
-  readonly content: Array<Response.Part<Tools>>
+export class GenerateTextResponse<
+  Tools extends Record<string, Tool.Any>,
+  EncodedToolParameters extends boolean = false
+> {
+  readonly content: Array<Response.Part<Tools, EncodedToolParameters>>
 
-  constructor(content: Array<Response.Part<Tools>>) {
+  constructor(content: Array<Response.Part<Tools, EncodedToolParameters>>) {
     this.content = content
   }
 
@@ -407,7 +410,9 @@ export class GenerateTextResponse<Tools extends Record<string, Tool.Any>> {
   /**
    * Returns all tool call parts from the response.
    */
-  get toolCalls(): Array<Response.ToolCallParts<Tools>> {
+  get toolCalls(): Array<
+    EncodedToolParameters extends true ? Response.ToolCallPartsEncoded<Tools> : Response.ToolCallParts<Tools>
+  > {
     return this.content.filter((part) => part.type === "tool-call")
   }
 
@@ -472,14 +477,15 @@ export class GenerateTextResponse<Tools extends Record<string, Tool.Any>> {
  */
 export class GenerateObjectResponse<
   Tools extends Record<string, Tool.Any>,
-  A
-> extends GenerateTextResponse<Tools> {
+  A,
+  EncodedToolParameters extends boolean = false
+> extends GenerateTextResponse<Tools, EncodedToolParameters> {
   /**
    * The parsed structured object that conforms to the provided schema.
    */
   readonly value: A
 
-  constructor(value: A, content: Array<Response.Part<Tools>>) {
+  constructor(value: A, content: Array<Response.Part<Tools, EncodedToolParameters>>) {
     super(content)
     this.value = value
   }
@@ -552,6 +558,18 @@ export type ExtractTools<Options> = Options extends {
   readonly toolkit: infer ToolkitValue
 } ? ExtractToolsFromToolkitOption<Exclude<ToolkitValue, undefined>>
   : {}
+
+/**
+ * Utility type that determines whether language model responses contain
+ * encoded tool call parameters.
+ *
+ * @category utility types
+ * @since 4.0.0
+ */
+export type ExtractEncodedToolParameters<Options> = Options extends {
+  readonly disableToolCallResolution: infer Disabled
+} ? Disabled extends true ? true : false
+  : false
 
 type ExtractErrorFromToolkitOption<ToolkitValue, DisableToolCallResolution extends boolean> = ToolkitValue extends
   Toolkit.WithHandler<infer Tools> ?
@@ -1173,8 +1191,12 @@ export const make: (params: {
     // If tool call resolution is disabled, return the response without
     // resolving the tool calls that were generated
     if (options.disableToolCallResolution === true) {
+      const rawToolkit = makeToolkitWithRawParameters(toolkit)
+      const RawResponseSchema = Schema.mutable(
+        Schema.Array(Response.Part(rawToolkit))
+      )
       const rawContent = yield* generateWithNonIncrementalFallback()
-      const content = yield* Schema.decodeEffect(ResponseSchema)(rawContent)
+      const content = yield* Schema.decodeEffect(RawResponseSchema)(rawContent)
       if (tracker) {
         const responseMetadata = content.find((part) => part.type === "response-metadata")
         if (Predicate.isNotUndefined(responseMetadata) && Predicate.isNotUndefined(responseMetadata.id)) {
@@ -1445,7 +1467,8 @@ export const make: (params: {
     // If tool call resolution is disabled, return the response without
     // resolving the tool calls that were generated
     if (options.disableToolCallResolution === true) {
-      const schema = Schema.NonEmptyArray(Response.StreamPart(toolkit))
+      const rawToolkit = makeToolkitWithRawParameters(toolkit)
+      const schema = Schema.NonEmptyArray(Response.StreamPart(rawToolkit))
       const decodeParts = Schema.decodeEffect(schema)
       return streamWithNonIncrementalFallback().pipe(
         Stream.mapArrayEffect((parts) =>
@@ -1663,7 +1686,7 @@ export const generateText: {
   >(
     options: Options & GenerateTextOptions<Tools> & { readonly toolkit: ToolkitInput<Tools> }
   ): Effect.Effect<
-    GenerateTextResponse<Tools>,
+    GenerateTextResponse<Tools, ExtractEncodedToolParameters<Options>>,
     ExtractError<Options>,
     LanguageModel | ExtractServices<Options>
   >
@@ -1675,7 +1698,7 @@ export const generateText: {
   >(
     options: Options & GenerateTextOptions<ExtractTools<Options>> & { readonly toolkit: Options["toolkit"] }
   ): Effect.Effect<
-    GenerateTextResponse<ExtractTools<Options>>,
+    GenerateTextResponse<ExtractTools<Options>, ExtractEncodedToolParameters<Options>>,
     ExtractError<Options>,
     ExtractServices<Options> | LanguageModel
   >
@@ -1741,7 +1764,11 @@ export const generateObject = <
 >(
   options: Options & GenerateObjectOptions<ExtractTools<Options>, StructuredOutputSchema>
 ): Effect.Effect<
-  GenerateObjectResponse<ExtractTools<Options>, StructuredOutputSchema["Type"]>,
+  GenerateObjectResponse<
+    ExtractTools<Options>,
+    StructuredOutputSchema["Type"],
+    ExtractEncodedToolParameters<Options>
+  >,
   ExtractError<Options>,
   ExtractServices<Options> | StructuredOutputSchema["DecodingServices"] | LanguageModel
 > =>
@@ -1807,7 +1834,7 @@ export const streamText: {
   >(
     options: Options & GenerateTextOptions<Tools> & { readonly toolkit: ToolkitInput<Tools> }
   ): Stream.Stream<
-    Response.StreamPart<Tools>,
+    Response.StreamPart<Tools, ExtractEncodedToolParameters<Options>>,
     ExtractError<Options>,
     ExtractServices<Options> | LanguageModel
   >
@@ -1819,7 +1846,7 @@ export const streamText: {
   >(
     options: Options & GenerateTextOptions<ExtractTools<Options>> & { readonly toolkit: Options["toolkit"] }
   ): Stream.Stream<
-    Response.StreamPart<ExtractTools<Options>>,
+    Response.StreamPart<ExtractTools<Options>, ExtractEncodedToolParameters<Options>>,
     ExtractError<Options>,
     ExtractServices<Options> | LanguageModel
   >
@@ -2196,6 +2223,13 @@ const resolveToolCalls = <Tools extends Record<string, Tool.Any>>(
 // =============================================================================
 // Utilities
 // =============================================================================
+
+const makeToolkitWithRawParameters = <Tools extends Record<string, Tool.Any>>(
+  toolkit: Toolkit.WithHandler<Tools>
+): Toolkit.Any =>
+  Toolkit.make(
+    ...Object.values(toolkit.tools).map((tool) => tool.setParameters(Schema.Unknown))
+  )
 
 const resolveToolkit = <Tools extends Record<string, Tool.Any>, E, R>(
   toolkit: ToolkitInput<Tools, E, R>

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -567,8 +567,8 @@ export type ExtractTools<Options> = Options extends {
  * @since 4.0.0
  */
 export type ExtractEncodedToolParameters<Options> = Options extends {
-  readonly disableToolCallResolution: infer Disabled
-} ? Disabled extends true ? true : false
+  readonly disableToolCallResolution: true
+} ? true
   : false
 
 type ExtractErrorFromToolkitOption<ToolkitValue, DisableToolCallResolution extends boolean> = ToolkitValue extends
@@ -1183,20 +1183,15 @@ export const make: (params: {
       }
     }
 
-    // Construct the response schema with the tools from the toolkit
-    const ResponseSchema = Schema.mutable(
-      Schema.Array(Response.Part(toolkit))
-    )
-
     // If tool call resolution is disabled, return the response without
     // resolving the tool calls that were generated
     if (options.disableToolCallResolution === true) {
-      const rawToolkit = makeToolkitWithRawParameters(toolkit)
-      const RawResponseSchema = Schema.mutable(
-        Schema.Array(Response.Part(rawToolkit))
+      const encodedToolkit = makeToolkitWithEncodedParameters(toolkit)
+      const EncodedResponseSchema = Schema.mutable(
+        Schema.Array(Response.Part(encodedToolkit))
       )
       const rawContent = yield* generateWithNonIncrementalFallback()
-      const content = yield* Schema.decodeEffect(RawResponseSchema)(rawContent)
+      const content = yield* Schema.decodeEffect(EncodedResponseSchema)(rawContent)
       if (tracker) {
         const responseMetadata = content.find((part) => part.type === "response-metadata")
         if (Predicate.isNotUndefined(responseMetadata) && Predicate.isNotUndefined(responseMetadata.id)) {
@@ -1205,6 +1200,11 @@ export const make: (params: {
       }
       return content as Array<Response.Part<Tools>>
     }
+
+    // Construct the response schema with the tools from the toolkit
+    const ResponseSchema = Schema.mutable(
+      Schema.Array(Response.Part(toolkit))
+    )
 
     const rawContent = yield* generateWithNonIncrementalFallback()
 
@@ -1467,8 +1467,8 @@ export const make: (params: {
     // If tool call resolution is disabled, return the response without
     // resolving the tool calls that were generated
     if (options.disableToolCallResolution === true) {
-      const rawToolkit = makeToolkitWithRawParameters(toolkit)
-      const schema = Schema.NonEmptyArray(Response.StreamPart(rawToolkit))
+      const encodedToolkit = makeToolkitWithEncodedParameters(toolkit)
+      const schema = Schema.NonEmptyArray(Response.StreamPart(encodedToolkit))
       const decodeParts = Schema.decodeEffect(schema)
       return streamWithNonIncrementalFallback().pipe(
         Stream.mapArrayEffect((parts) =>
@@ -2224,11 +2224,11 @@ const resolveToolCalls = <Tools extends Record<string, Tool.Any>>(
 // Utilities
 // =============================================================================
 
-const makeToolkitWithRawParameters = <Tools extends Record<string, Tool.Any>>(
+const makeToolkitWithEncodedParameters = <Tools extends Record<string, Tool.Any>>(
   toolkit: Toolkit.WithHandler<Tools>
 ): Toolkit.Any =>
   Toolkit.make(
-    ...Object.values(toolkit.tools).map((tool) => tool.setParameters(Schema.Unknown))
+    ...Object.values(toolkit.tools).map((tool) => tool.setParameters(Schema.toEncoded(tool.parametersSchema)))
   )
 
 const resolveToolkit = <Tools extends Record<string, Tool.Any>, E, R>(

--- a/packages/effect/src/unstable/ai/Response.ts
+++ b/packages/effect/src/unstable/ai/Response.ts
@@ -224,10 +224,13 @@ export const AllParts = <T extends Toolkit.Any | Toolkit.WithHandler<any>>(
  * @category models
  * @since 4.0.0
  */
-export type Part<Tools extends Record<string, Tool.Any>> =
+export type Part<
+  Tools extends Record<string, Tool.Any>,
+  EncodedToolParameters extends boolean = false
+> =
   | TextPart
   | ReasoningPart
-  | ToolCallParts<Tools>
+  | (EncodedToolParameters extends true ? ToolCallPartsEncoded<Tools> : ToolCallParts<Tools>)
   | ToolResultParts<Tools>
   | ToolApprovalRequestPart
   | FilePart
@@ -302,7 +305,10 @@ export const Part = <T extends Toolkit.Any | Toolkit.WithHandler<any>>(
  * @category models
  * @since 4.0.0
  */
-export type StreamPart<Tools extends Record<string, Tool.Any>> =
+export type StreamPart<
+  Tools extends Record<string, Tool.Any>,
+  EncodedToolParameters extends boolean = false
+> =
   | TextStartPart
   | TextDeltaPart
   | TextEndPart
@@ -312,7 +318,7 @@ export type StreamPart<Tools extends Record<string, Tool.Any>> =
   | ToolParamsStartPart
   | ToolParamsDeltaPart
   | ToolParamsEndPart
-  | ToolCallParts<Tools>
+  | (EncodedToolParameters extends true ? ToolCallPartsEncoded<Tools> : ToolCallParts<Tools>)
   | ToolResultParts<Tools>
   | ToolApprovalRequestPart
   | FilePart
@@ -404,6 +410,18 @@ export const StreamPart = <T extends Toolkit.Any | Toolkit.WithHandler<any>>(
  */
 export type ToolCallParts<Tools extends Record<string, Tool.Any>> = {
   [Name in keyof Tools]: Name extends string ? ToolCallPart<Name, Tool.Parameters<Tools[Name]>>
+    : never
+}[keyof Tools]
+
+/**
+ * Utility type that extracts tool call parts with encoded parameters from a set
+ * of tools.
+ *
+ * @category utility types
+ * @since 4.0.0
+ */
+export type ToolCallPartsEncoded<Tools extends Record<string, Tool.Any>> = {
+  [Name in keyof Tools]: Name extends string ? ToolCallPart<Name, Tool.ParametersEncoded<Tools[Name]>>
     : never
 }[keyof Tools]
 

--- a/packages/effect/src/unstable/ai/Response.ts
+++ b/packages/effect/src/unstable/ai/Response.ts
@@ -230,7 +230,7 @@ export type Part<
 > =
   | TextPart
   | ReasoningPart
-  | (EncodedToolParameters extends true ? ToolCallPartsEncoded<Tools> : ToolCallParts<Tools>)
+  | ToolCallParts<Tools, EncodedToolParameters>
   | ToolResultParts<Tools>
   | ToolApprovalRequestPart
   | FilePart
@@ -318,7 +318,7 @@ export type StreamPart<
   | ToolParamsStartPart
   | ToolParamsDeltaPart
   | ToolParamsEndPart
-  | (EncodedToolParameters extends true ? ToolCallPartsEncoded<Tools> : ToolCallParts<Tools>)
+  | ToolCallParts<Tools, EncodedToolParameters>
   | ToolResultParts<Tools>
   | ToolApprovalRequestPart
   | FilePart
@@ -408,20 +408,14 @@ export const StreamPart = <T extends Toolkit.Any | Toolkit.WithHandler<any>>(
  * @category utility types
  * @since 4.0.0
  */
-export type ToolCallParts<Tools extends Record<string, Tool.Any>> = {
-  [Name in keyof Tools]: Name extends string ? ToolCallPart<Name, Tool.Parameters<Tools[Name]>>
-    : never
-}[keyof Tools]
-
-/**
- * Utility type that extracts tool call parts with encoded parameters from a set
- * of tools.
- *
- * @category utility types
- * @since 4.0.0
- */
-export type ToolCallPartsEncoded<Tools extends Record<string, Tool.Any>> = {
-  [Name in keyof Tools]: Name extends string ? ToolCallPart<Name, Tool.ParametersEncoded<Tools[Name]>>
+export type ToolCallParts<
+  Tools extends Record<string, Tool.Any>,
+  EncodedParameters extends boolean = false
+> = {
+  [Name in keyof Tools]: Name extends string ? ToolCallPart<
+      Name,
+      EncodedParameters extends true ? Tool.ParametersEncoded<Tools[Name]> : Tool.Parameters<Tools[Name]>
+    >
     : never
 }[keyof Tools]
 

--- a/packages/effect/src/unstable/ai/Toolkit.ts
+++ b/packages/effect/src/unstable/ai/Toolkit.ts
@@ -206,9 +206,9 @@ export interface WithHandler<in out Tools extends Record<string, Tool.Any>> {
      */
     name: Name,
     /**
-     * Parameters to pass to the tool handler.
+     * Encoded parameters to decode and pass to the tool handler.
      */
-    params: Tool.Parameters<Tools[Name]>,
+    params: Tool.ParametersEncoded<Tools[Name]>,
     /**
      * The unique identifier of the tool call.
      */

--- a/packages/effect/test/unstable/ai/LanguageModel.test.ts
+++ b/packages/effect/test/unstable/ai/LanguageModel.test.ts
@@ -61,6 +61,28 @@ describe("LanguageModel", () => {
   }
 
   describe("generateText", () => {
+    it.effect("validates encoded tool parameters when tool call resolution is disabled", () =>
+      Effect.gen(function*() {
+        const error = yield* LanguageModel.generateText({
+          prompt: [],
+          toolkit: TransformToolkit,
+          disableToolCallResolution: true
+        }).pipe(
+          TestUtils.withLanguageModel({
+            generateText: [{
+              type: "tool-call",
+              id: "tool-invalid-transform",
+              name: "TransformTool",
+              params: { invalid: true }
+            }]
+          }),
+          Effect.provide(TransformToolkitLayer),
+          Effect.flip
+        )
+
+        strictEqual(error.reason._tag, "InvalidOutputError")
+      }))
+
     it.effect("preserves encoded tool parameters when tool call resolution is disabled", () =>
       Effect.gen(function*() {
         const response = yield* LanguageModel.generateText({
@@ -92,6 +114,29 @@ describe("LanguageModel", () => {
   })
 
   describe("streamText", () => {
+    it.effect("validates encoded tool parameters when tool call resolution is disabled", () =>
+      Effect.gen(function*() {
+        const error = yield* LanguageModel.streamText({
+          prompt: [],
+          toolkit: TransformToolkit,
+          disableToolCallResolution: true
+        }).pipe(
+          Stream.runDrain,
+          TestUtils.withLanguageModel({
+            streamText: [{
+              type: "tool-call",
+              id: "tool-invalid-transform",
+              name: "TransformTool",
+              params: { invalid: true }
+            }]
+          }),
+          Effect.provide(TransformToolkitLayer),
+          Effect.flip
+        )
+
+        strictEqual(error.reason._tag, "InvalidOutputError")
+      }))
+
     it.effect("preserves encoded tool parameters when tool call resolution is disabled", () =>
       Effect.gen(function*() {
         const parts = yield* LanguageModel.streamText({

--- a/packages/effect/test/unstable/ai/LanguageModel.test.ts
+++ b/packages/effect/test/unstable/ai/LanguageModel.test.ts
@@ -19,6 +19,17 @@ const MyToolkitLayer = MyToolkit.toLayer({
     )
 })
 
+const TransformTool = Tool.make("TransformTool", {
+  parameters: Schema.FiniteFromString,
+  success: Schema.Finite
+})
+
+const TransformToolkit = Toolkit.make(TransformTool)
+
+const TransformToolkitLayer = TransformToolkit.toLayer({
+  TransformTool: (value) => Effect.succeed(value * 2)
+})
+
 const ApprovalTool = Tool.make("ApprovalTool", {
   parameters: Schema.Struct({ action: Schema.String }),
   success: Schema.Struct({ result: Schema.String }),
@@ -49,7 +60,67 @@ describe("LanguageModel", () => {
     response: undefined
   }
 
+  describe("generateText", () => {
+    it.effect("preserves encoded tool parameters when tool call resolution is disabled", () =>
+      Effect.gen(function*() {
+        const response = yield* LanguageModel.generateText({
+          prompt: [],
+          toolkit: TransformToolkit,
+          disableToolCallResolution: true
+        })
+        const toolCall = response.toolCalls[0]!
+
+        strictEqual(toolCall.params, "21")
+
+        const toolkit = yield* TransformToolkit
+        const results = yield* toolkit.handle(toolCall.name, toolCall.params).pipe(
+          Effect.flatMap(Stream.runCollect)
+        )
+
+        strictEqual(results[0].result, 42)
+      }).pipe(
+        TestUtils.withLanguageModel({
+          generateText: [{
+            type: "tool-call",
+            id: "tool-transform",
+            name: "TransformTool",
+            params: "21"
+          }]
+        }),
+        Effect.provide(TransformToolkitLayer)
+      ))
+  })
+
   describe("streamText", () => {
+    it.effect("preserves encoded tool parameters when tool call resolution is disabled", () =>
+      Effect.gen(function*() {
+        const parts = yield* LanguageModel.streamText({
+          prompt: [],
+          toolkit: TransformToolkit,
+          disableToolCallResolution: true
+        }).pipe(Stream.runCollect)
+        const toolCall = parts.find((part) => part.type === "tool-call")!
+
+        strictEqual(toolCall.params, "21")
+
+        const toolkit = yield* TransformToolkit
+        const results = yield* toolkit.handle(toolCall.name, toolCall.params).pipe(
+          Effect.flatMap(Stream.runCollect)
+        )
+
+        strictEqual(results[0].result, 42)
+      }).pipe(
+        TestUtils.withLanguageModel({
+          streamText: [{
+            type: "tool-call",
+            id: "tool-transform",
+            name: "TransformTool",
+            params: "21"
+          }]
+        }),
+        Effect.provide(TransformToolkitLayer)
+      ))
+
     it.effect("should emit tool calls before executing tool handlers", () =>
       Effect.gen(function*() {
         const parts: Array<Response.StreamPart<Toolkit.Tools<typeof MyToolkit>>> = []

--- a/packages/effect/typetest/unstable/ai/LanguageModel.tst.ts
+++ b/packages/effect/typetest/unstable/ai/LanguageModel.tst.ts
@@ -31,8 +31,27 @@ const ToolWithRequestContext = Tool.make("ToolWithRequestContext", {
   dependencies: [RequestContext]
 })
 
+const TransformTool = Tool.make("TransformTool", {
+  parameters: Schema.FiniteFromString,
+  success: Schema.Finite
+})
+
 describe("LanguageModel", () => {
   describe("generateText", () => {
+    it("uses encoded tool parameters when tool call resolution is disabled", () => {
+      const toolkit = Toolkit.make(TransformTool)
+      const program = LanguageModel.generateText({
+        prompt: "hello",
+        toolkit,
+        disableToolCallResolution: true
+      })
+
+      type ProgramSuccess = typeof program extends Effect.Effect<infer A, any, any> ? A : never
+      type ToolCallParams = ProgramSuccess["toolCalls"][number]["params"]
+
+      expect<ToolCallParams>().type.toBe<string>()
+    })
+
     it("returns an empty tool record when no toolkit is provided", () => {
       const program = LanguageModel.generateText({
         prompt: "hello"

--- a/packages/effect/typetest/unstable/ai/LanguageModel.tst.ts
+++ b/packages/effect/typetest/unstable/ai/LanguageModel.tst.ts
@@ -1,5 +1,5 @@
 import { Context, Effect, Schema, type Stream } from "effect"
-import { type AiError, LanguageModel, Tool, Toolkit } from "effect/unstable/ai"
+import { type AiError, type Chat, LanguageModel, Tool, Toolkit } from "effect/unstable/ai"
 import type * as Response from "effect/unstable/ai/Response"
 import { describe, expect, it } from "tstyche"
 
@@ -50,6 +50,34 @@ describe("LanguageModel", () => {
       type ToolCallParams = ProgramSuccess["toolCalls"][number]["params"]
 
       expect<ToolCallParams>().type.toBe<string>()
+    })
+
+    it("uses decoded tool parameters when tool call resolution is enabled", () => {
+      const toolkit = Toolkit.make(TransformTool)
+      const program = LanguageModel.generateText({
+        prompt: "hello",
+        toolkit
+      })
+
+      type ProgramSuccess = typeof program extends Effect.Effect<infer A, any, any> ? A : never
+      type ToolCallParams = ProgramSuccess["toolCalls"][number]["params"]
+
+      expect<ToolCallParams>().type.toBe<number>()
+    })
+
+    it("uses decoded tool parameters for a non-literal resolution flag", () => {
+      const toolkit = Toolkit.make(TransformTool)
+      const disableToolCallResolution = null as unknown as boolean
+      const program = LanguageModel.generateText({
+        prompt: "hello",
+        toolkit,
+        disableToolCallResolution
+      })
+
+      type ProgramSuccess = typeof program extends Effect.Effect<infer A, any, any> ? A : never
+      type ToolCallParams = ProgramSuccess["toolCalls"][number]["params"]
+
+      expect<ToolCallParams>().type.toBe<number>()
     })
 
     it("returns an empty tool record when no toolkit is provided", () => {
@@ -175,6 +203,20 @@ describe("LanguageModel", () => {
   })
 
   describe("streamText", () => {
+    it("uses encoded tool parameters when tool call resolution is disabled", () => {
+      const toolkit = Toolkit.make(TransformTool)
+      const stream = LanguageModel.streamText({
+        prompt: "hello",
+        toolkit,
+        disableToolCallResolution: true
+      })
+
+      type StreamPart = typeof stream extends Stream.Stream<infer A, any, any> ? A : never
+      type ToolCallParams = Extract<StreamPart, { readonly type: "tool-call" }>["params"]
+
+      expect<ToolCallParams>().type.toBe<string>()
+    })
+
     it("returns an empty tool record when no toolkit is provided", () => {
       const stream = LanguageModel.streamText({
         prompt: "hello"
@@ -205,6 +247,40 @@ describe("LanguageModel", () => {
           readonly ToolWithRequestContext: typeof ToolWithRequestContext
         }>
       >()
+    })
+  })
+
+  describe("generateObject", () => {
+    it("uses encoded tool parameters when tool call resolution is disabled", () => {
+      const toolkit = Toolkit.make(TransformTool)
+      const program = LanguageModel.generateObject({
+        prompt: "hello",
+        toolkit,
+        schema: Schema.Struct({ answer: Schema.Number }),
+        disableToolCallResolution: true
+      })
+
+      type ProgramSuccess = typeof program extends Effect.Effect<infer A, any, any> ? A : never
+      type ToolCallParams = ProgramSuccess["toolCalls"][number]["params"]
+
+      expect<ToolCallParams>().type.toBe<string>()
+    })
+  })
+
+  describe("Chat", () => {
+    it("uses encoded tool parameters when tool call resolution is disabled", () => {
+      const chat = null as unknown as Chat.Service
+      const toolkit = Toolkit.make(TransformTool)
+      const program = chat.generateText({
+        prompt: "hello",
+        toolkit,
+        disableToolCallResolution: true
+      })
+
+      type ProgramSuccess = typeof program extends Effect.Effect<infer A, any, any> ? A : never
+      type ToolCallParams = ProgramSuccess["toolCalls"][number]["params"]
+
+      expect<ToolCallParams>().type.toBe<string>()
     })
   })
 })


### PR DESCRIPTION
## Summary

- Keep tool call parameters encoded when `disableToolCallResolution` is enabled for both `generateText` and `streamText`.
- Type those response parameters from each tool schema's encoded side and make `toolkit.handle` accept the encoded type it decodes at runtime.
- Add runtime and type-level regression coverage, plus a patch changeset.

## Root cause

The disabled-resolution path decoded provider responses with `Response.Part(toolkit)` or `Response.StreamPart(toolkit)`. Transforming parameter schemas therefore ran before callers manually passed the values to `toolkit.handle`, which decoded them a second time.

## Validation

- `pnpm test --run packages/effect/test/unstable/ai/LanguageModel.test.ts`
- `pnpm test-types packages/effect/typetest/unstable/ai/LanguageModel.tst.ts`
- `pnpm lint-fix`
- `pnpm check`

Closes EFF-743
Closes #7353