### PR TITLE
Add Match.fn selector matchers

### DIFF
--- a/.changeset/tidy-matches-select.md
+++ b/.changeset/tidy-matches-select.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Match.fn` for reusable matchers that select a value from multiple arguments.

--- a/packages/effect/src/Match.ts
+++ b/packages/effect/src/Match.ts
@@ -64,8 +64,16 @@ export type ValueFlavor = "value"
  * @category models
  * @since 4.0.0
  */
-export type Matcher<Input, Filters, RemainingApplied, Result, Flavor, Return = any> =
-  | TypeMatcher<Input, Filters, RemainingApplied, Result, Return>
+export type Matcher<
+  Input,
+  Filters,
+  RemainingApplied,
+  Result,
+  Flavor,
+  Return = any,
+  Args extends Array<any> = []
+> =
+  | TypeMatcher<Input, Filters, RemainingApplied, Result, Return, Args>
   | ValueMatcher<Input, Filters, RemainingApplied, Result, Input, Return, Flavor>
 
 /**
@@ -97,7 +105,14 @@ export type Matcher<Input, Filters, RemainingApplied, Result, Flavor, Return = a
  * @category models
  * @since 4.0.0
  */
-export interface TypeMatcher<in Input, out Filters, out Remaining, out Result, out Return = any> extends Pipeable {
+export interface TypeMatcher<
+  in Input,
+  out Filters,
+  out Remaining,
+  out Result,
+  out Return = any,
+  in Args extends Array<any> = []
+> extends Pipeable {
   readonly _tag: "TypeMatcher"
   readonly [TypeId]: {
     readonly _input: T.Contravariant<Input>
@@ -105,9 +120,11 @@ export interface TypeMatcher<in Input, out Filters, out Remaining, out Result, o
     readonly _remaining: T.Covariant<Remaining>
     readonly _result: T.Covariant<Result>
     readonly _return: T.Covariant<Return>
+    readonly _args: T.Contravariant<Args>
   }
   readonly cases: ReadonlyArray<Case>
-  add<I, R, RA, A>(_case: Case): TypeMatcher<I, R, RA, A>
+  readonly select: (...args: Array<any>) => unknown
+  add<I, R, RA, A>(_case: Case): TypeMatcher<I, R, RA, A, Return, Args>
 }
 
 /**
@@ -215,7 +232,7 @@ export type Case = When | Not
 export interface When {
   readonly _tag: "When"
   guard(u: unknown): boolean
-  evaluate(input: unknown): any
+  evaluate(input: unknown, ...args: Array<any>): any
 }
 
 /**
@@ -249,7 +266,7 @@ export interface When {
 export interface Not {
   readonly _tag: "Not"
   guard(u: unknown): boolean
-  evaluate(input: unknown): any
+  evaluate(input: unknown, ...args: Array<any>): any
 }
 
 /**
@@ -295,6 +312,32 @@ export interface Not {
  * @since 4.0.0
  */
 export const type: <I>() => Matcher<I, Types.Without<never>, I, never, never> = internal.type
+
+/**
+ * Creates a reusable matcher from a function that selects the value to match.
+ *
+ * The compiled matcher keeps the selector's original argument list. Case
+ * handlers receive the narrowed selected value followed by those arguments.
+ *
+ * @example
+ * ```ts import.meta.vitest
+ * import { Match } from "effect"
+ *
+ * const format = Match.fn((prefix: string, value: "a" | "b") => value).pipe(
+ *   Match.when("a", (_value, prefix) => `${prefix}: A`),
+ *   Match.when("b", (_value, prefix) => `${prefix}: B`),
+ *   Match.exhaustive
+ * )
+ *
+ * format("status", "a") // => "status: A"
+ * ```
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const fn: <Args extends Array<any>, I>(
+  select: (...args: Args) => I
+) => Matcher<I, Types.Without<never>, I, never, never, any, Args> = internal.fn
 
 /**
  * Creates a matcher from a specific value.
@@ -483,9 +526,9 @@ export const typeTags: {
  * @category utility types
  * @since 4.0.0
  */
-export const withReturnType: <Ret>() => <I, F, R, A, Pr, _>(
-  self: Matcher<I, F, R, A, Pr, _>
-) => [Ret] extends [[A] extends [never] ? any : A] ? Matcher<I, F, R, A, Pr, Ret>
+export const withReturnType: <Ret>() => <I, F, R, A, Pr, _, Args extends Array<any>>(
+  self: Matcher<I, F, R, A, Pr, _, Args>
+) => [Ret] extends [[A] extends [never] ? any : A] ? Matcher<I, F, R, A, Pr, Ret, Args>
   : "withReturnType constraint does not extend Result type" = internal.withReturnType
 
 /**
@@ -540,19 +583,21 @@ export const when: <
   R,
   const P extends Types.PatternPrimitive<R> | Types.PatternBase<R>,
   Ret,
-  Fn extends (_: Types.WhenMatch<R, P>) => Ret
+  Args extends Array<any>,
+  Fn extends (_: Types.WhenMatch<R, P>, ...args: Args) => Ret
 >(
   pattern: P,
   f: Fn
 ) => <I, F, A, Pr>(
-  self: Matcher<I, F, R, A, Pr, Ret>
+  self: Matcher<I, F, R, A, Pr, Ret, Args>
 ) => Matcher<
   I,
   Types.AddWithout<F, Types.PForExclude<P>>,
   Types.ApplyFilters<I, Types.AddWithout<F, Types.PForExclude<P>>>,
   A | ReturnType<Fn>,
   Pr,
-  Ret
+  Ret,
+  Args
 > = internal.when
 
 /**
@@ -600,18 +645,20 @@ export const whenOr: <
   R,
   const P extends ReadonlyArray<Types.PatternPrimitive<R> | Types.PatternBase<R>>,
   Ret,
-  Fn extends (_: Types.WhenMatch<R, P[number]>) => Ret
+  Args extends Array<any>,
+  Fn extends (_: Types.WhenMatch<R, P[number]>, ...args: Args) => Ret
 >(
   ...args: [...patterns: P, f: Fn]
 ) => <I, F, A, Pr>(
-  self: Matcher<I, F, R, A, Pr, Ret>
+  self: Matcher<I, F, R, A, Pr, Ret, Args>
 ) => Matcher<
   I,
   Types.AddWithout<F, Types.PForExclude<P[number]>>,
   Types.ApplyFilters<I, Types.AddWithout<F, Types.PForExclude<P[number]>>>,
   A | ReturnType<Fn>,
   Pr,
-  Ret
+  Ret,
+  Args
 > = internal.whenOr
 
 /**
@@ -656,17 +703,20 @@ export const whenAnd: <
   R,
   const P extends ReadonlyArray<Types.PatternPrimitive<R> | Types.PatternBase<R>>,
   Ret,
-  Fn extends (_: Types.WhenMatch<R, T.UnionToIntersection<P[number]>>) => Ret
+  Args extends Array<any>,
+  Fn extends (_: Types.WhenMatch<R, T.UnionToIntersection<P[number]>>, ...args: Args) => Ret
 >(
   ...args: [...patterns: P, f: Fn]
 ) => <I, F, A, Pr>(
-  self: Matcher<I, F, R, A, Pr, Ret>
+  self: Matcher<I, F, R, A, Pr, Ret, Args>
 ) => Matcher<
   I,
   Types.AddWithout<F, Types.PForExclude<T.UnionToIntersection<P[number]>>>,
   Types.ApplyFilters<I, Types.AddWithout<F, Types.PForExclude<T.UnionToIntersection<P[number]>>>>,
   A | ReturnType<Fn>,
-  Pr
+  Pr,
+  Ret,
+  Args
 > = internal.whenAnd
 
 /**
@@ -948,18 +998,20 @@ export const tag: <
   R,
   P extends Types.Tags<"_tag", R> & string,
   Ret,
-  Fn extends (_: Extract<R, Record<"_tag", P>>) => Ret
+  Args extends Array<any>,
+  Fn extends (_: Extract<R, Record<"_tag", P>>, ...args: Args) => Ret
 >(
   ...pattern: [first: P, ...values: Array<P>, f: Fn]
 ) => <I, F, A, Pr>(
-  self: Matcher<I, F, R, A, Pr, Ret>
+  self: Matcher<I, F, R, A, Pr, Ret, Args>
 ) => Matcher<
   I,
   Types.AddWithout<F, Extract<R, Record<"_tag", P>>>,
   Types.ApplyFilters<I, Types.AddWithout<F, Extract<R, Record<"_tag", P>>>>,
   ReturnType<Fn> | A,
   Pr,
-  Ret
+  Ret,
+  Args
 > = internal.tag
 
 /**
@@ -1155,19 +1207,21 @@ export const not: <
   R,
   const P extends Types.PatternPrimitive<R> | Types.PatternBase<R>,
   Ret,
-  Fn extends (_: Types.NotMatch<R, P>) => Ret
+  Args extends Array<any>,
+  Fn extends (_: Types.NotMatch<R, P>, ...args: Args) => Ret
 >(
   pattern: P,
   f: Fn
 ) => <I, F, A, Pr>(
-  self: Matcher<I, F, R, A, Pr, Ret>
+  self: Matcher<I, F, R, A, Pr, Ret, Args>
 ) => Matcher<
   I,
   Types.AddOnly<F, Types.WhenMatch<R, P>>,
   Types.ApplyFilters<I, Types.AddOnly<F, Types.WhenMatch<R, P>>>,
   A | ReturnType<Fn>,
   Pr,
-  Ret
+  Ret,
+  Args
 > = internal.not
 
 /**
@@ -1811,11 +1865,13 @@ export const instanceOfUnsafe: <A extends abstract new(...args: any) => any>(
  * @category completion
  * @since 4.0.0
  */
-export const orElse: <RA, Ret, F extends (_: RA) => Ret>(
+export const orElse: <RA, Ret, Args extends Array<any>, F extends (_: RA, ...args: Args) => Ret>(
   f: F
 ) => <I, R, A, Pr>(
-  self: Matcher<I, R, RA, A, Pr, Ret>
-) => [Pr] extends [never] ? (input: I) => Unify<ReturnType<F> | A> : Unify<ReturnType<F> | A> = internal.orElse
+  self: Matcher<I, R, RA, A, Pr, Ret, Args>
+) => [Pr] extends [never] ? [Args] extends [[]] ? (input: I) => Unify<ReturnType<F> | A>
+  : (...args: Args) => Unify<ReturnType<F> | A>
+  : Unify<ReturnType<F> | A> = internal.orElse
 
 // TODO(4.0): Rename to "orThrow"? Like Result.getOrThrow
 /**
@@ -1861,9 +1917,10 @@ export const orElse: <RA, Ret, F extends (_: RA) => Ret>(
  * @category completion
  * @since 4.0.0
  */
-export const orElseAbsurd: <I, R, RA, A, Pr, Ret>(
-  self: Matcher<I, R, RA, A, Pr, Ret>
-) => [Pr] extends [never] ? (input: I) => Unify<A> : Unify<A> = internal.orElseAbsurd
+export const orElseAbsurd: <I, R, RA, A, Pr, Ret, Args extends Array<any>>(
+  self: Matcher<I, R, RA, A, Pr, Ret, Args>
+) => [Pr] extends [never] ? [Args] extends [[]] ? (input: I) => Unify<A> : (...args: Args) => Unify<A> : Unify<A> =
+  internal.orElseAbsurd
 
 /**
  * Wraps the match result in a `Result`, distinguishing matched and unmatched
@@ -1902,9 +1959,11 @@ export const orElseAbsurd: <I, R, RA, A, Pr, Ret>(
  * @category completion
  * @since 4.0.0
  */
-export const result: <I, F, R, A, Pr, Ret>(
-  self: Matcher<I, F, R, A, Pr, Ret>
-) => [Pr] extends [never] ? (input: I) => Result.Result<Unify<A>, R> : Result.Result<Unify<A>, R> = internal.result
+export const result: <I, F, R, A, Pr, Ret, Args extends Array<any>>(
+  self: Matcher<I, F, R, A, Pr, Ret, Args>
+) => [Pr] extends [never] ? [Args] extends [[]] ? (input: I) => Result.Result<Unify<A>, R>
+  : (...args: Args) => Result.Result<Unify<A>, R>
+  : Result.Result<Unify<A>, R> = internal.result
 
 /**
  * Wraps the match result in an `Option`, representing an optional match.
@@ -1949,9 +2008,11 @@ export const result: <I, F, R, A, Pr, Ret>(
  * @category completion
  * @since 4.0.0
  */
-export const option: <I, F, R, A, Pr, Ret>(
-  self: Matcher<I, F, R, A, Pr, Ret>
-) => [Pr] extends [never] ? (input: I) => Option.Option<Unify<A>> : Option.Option<Unify<A>> = internal.option
+export const option: <I, F, R, A, Pr, Ret, Args extends Array<any>>(
+  self: Matcher<I, F, R, A, Pr, Ret, Args>
+) => [Pr] extends [never] ? [Args] extends [[]] ? (input: I) => Option.Option<Unify<A>>
+  : (...args: Args) => Option.Option<Unify<A>>
+  : Option.Option<Unify<A>> = internal.option
 
 /**
  * Completes a matcher that handles every remaining input case.
@@ -1985,9 +2046,10 @@ export const option: <I, F, R, A, Pr, Ret>(
  * @category completion
  * @since 4.0.0
  */
-export const exhaustive: <I, F, A, Pr, Ret>(
-  self: Matcher<I, F, never, A, Pr, Ret>
-) => [Pr] extends [never] ? (u: I) => Unify<A> : Unify<A> = internal.exhaustive
+export const exhaustive: <I, F, A, Pr, Ret, Args extends Array<any>>(
+  self: Matcher<I, F, never, A, Pr, Ret, Args>
+) => [Pr] extends [never] ? [Args] extends [[]] ? (u: I) => Unify<A> : (...args: Args) => Unify<A> : Unify<A> =
+  internal.exhaustive
 
 const SafeRefinementId = "~effect/match/Match/SafeRefinement"
 

--- a/packages/effect/src/internal/matcher.ts
+++ b/packages/effect/src/internal/matcher.ts
@@ -19,30 +19,33 @@ import type { Unify } from "../Unify.ts"
 /** @internal */
 export const TypeId = "~effect/match/Match/Matcher"
 
-const TypeMatcherProto: Omit<TypeMatcher<any, any, any, any>, "cases"> = {
+const TypeMatcherProto: Omit<TypeMatcher<any, any, any, any, any, any>, "cases" | "select"> = {
   [TypeId]: {
     _input: identity,
     _filters: identity,
     _remaining: identity,
     _result: identity,
-    _return: identity
+    _return: identity,
+    _args: identity
   },
   _tag: "TypeMatcher",
   add<I, R, RA, A>(
-    this: TypeMatcher<any, any, any, any>,
+    this: TypeMatcher<any, any, any, any, any, any>,
     _case: Case
-  ): TypeMatcher<I, R, RA, A> {
-    return makeTypeMatcher([...this.cases, _case])
+  ): TypeMatcher<I, R, RA, A, any, any> {
+    return makeTypeMatcher(this.select, [...this.cases, _case])
   },
   pipe() {
     return pipeArguments(this, arguments)
   }
 }
 
-function makeTypeMatcher<I, R, RA, A>(
+function makeTypeMatcher<I, R, RA, A, Ret, Args extends Array<any>>(
+  select: (...args: any) => I,
   cases: ReadonlyArray<Case>
-): TypeMatcher<I, R, RA, A> {
+): TypeMatcher<I, R, RA, A, Ret, Args> {
   const matcher = Object.create(TypeMatcherProto)
+  matcher.select = select
   matcher.cases = cases
   return matcher
 }
@@ -98,7 +101,7 @@ function makeValueMatcher<I, R, RA, A, Provided>(
 
 const makeWhen = (
   guard: (u: unknown) => boolean,
-  evaluate: (input: unknown) => any
+  evaluate: (input: unknown, ...args: Array<any>) => any
 ): When => ({
   _tag: "When",
   guard,
@@ -107,7 +110,7 @@ const makeWhen = (
 
 const makeNot = (
   guard: (u: unknown) => boolean,
-  evaluate: (input: unknown) => any
+  evaluate: (input: unknown, ...args: Array<any>) => any
 ): Not => ({
   _tag: "Not",
   guard,
@@ -200,7 +203,12 @@ export const type = <I>(): Matcher<
   I,
   never,
   never
-> => makeTypeMatcher([])
+> => makeTypeMatcher(identity, [])
+
+/** @internal */
+export const fn = <Args extends Array<any>, I>(
+  select: (...args: Args) => I
+): Matcher<I, Types.Without<never>, I, never, never, any, Args> => makeTypeMatcher(select, [])
 
 /** @internal */
 export const value = <const I>(
@@ -229,7 +237,7 @@ export const valueTags: {
       & { readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any }
       & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", I>>]: never }
   >(input: I, fields: P): Unify<ReturnType<P[keyof P]>> => {
-    const match: any = tagsExhaustive(fields as any)(makeTypeMatcher([]))
+    const match: any = tagsExhaustive(fields as any)(makeTypeMatcher(identity, []))
     return match(input)
   }
 )
@@ -245,36 +253,39 @@ export const typeTags = <I>() =>
 >(
   fields: P
 ) => {
-  const match: any = tagsExhaustive(fields as any)(makeTypeMatcher([]))
+  const match: any = tagsExhaustive(fields as any)(makeTypeMatcher(identity, []))
   return (input: I): Unify<ReturnType<P[keyof P]>> => match(input)
 }
 
 /** @internal */
-export const withReturnType = <Ret>() =>
-<I, F, R, A, Pr, _>(self: Matcher<I, F, R, A, Pr, _>): [Ret] extends [
-  [A] extends [never] ? any : A
-] ? Matcher<I, F, R, A, Pr, Ret>
-  : "withReturnType constraint does not extend Result type" => self as any
+export const withReturnType =
+  <Ret>() =>
+  <I, F, R, A, Pr, _, Args extends Array<any>>(self: Matcher<I, F, R, A, Pr, _, Args>): [Ret] extends [
+    [A] extends [never] ? any : A
+  ] ? Matcher<I, F, R, A, Pr, Ret, Args>
+    : "withReturnType constraint does not extend Result type" => self as any
 
 /** @internal */
 export const when = <
   R,
   const P extends Types.PatternPrimitive<R> | Types.PatternBase<R>,
   Ret,
-  Fn extends (_: Types.WhenMatch<R, P>) => Ret
+  Args extends Array<any>,
+  Fn extends (_: Types.WhenMatch<R, P>, ...args: Args) => Ret
 >(
   pattern: P,
   f: Fn
 ) =>
 <I, F, A, Pr>(
-  self: Matcher<I, F, R, A, Pr, Ret>
+  self: Matcher<I, F, R, A, Pr, Ret, Args>
 ): Matcher<
   I,
   Types.AddWithout<F, Types.PForExclude<P>>,
   Types.ApplyFilters<I, Types.AddWithout<F, Types.PForExclude<P>>>,
   A | ReturnType<Fn>,
   Pr,
-  Ret
+  Ret,
+  Args
 > => (self as any).add(makeWhen(makePredicate(pattern), f as any))
 
 /** @internal */
@@ -284,19 +295,21 @@ export const whenOr = <
     Types.PatternPrimitive<R> | Types.PatternBase<R>
   >,
   Ret,
-  Fn extends (_: Types.WhenMatch<R, P[number]>) => Ret
+  Args extends Array<any>,
+  Fn extends (_: Types.WhenMatch<R, P[number]>, ...args: Args) => Ret
 >(
   ...args: [...patterns: P, f: Fn]
 ) =>
 <I, F, A, Pr>(
-  self: Matcher<I, F, R, A, Pr, Ret>
+  self: Matcher<I, F, R, A, Pr, Ret, Args>
 ): Matcher<
   I,
   Types.AddWithout<F, Types.PForExclude<P[number]>>,
   Types.ApplyFilters<I, Types.AddWithout<F, Types.PForExclude<P[number]>>>,
   A | ReturnType<Fn>,
   Pr,
-  Ret
+  Ret,
+  Args
 > => {
   const onMatch = args[args.length - 1] as any
   const patterns = args.slice(0, -1) as unknown as P
@@ -310,12 +323,13 @@ export const whenAnd = <
     Types.PatternPrimitive<R> | Types.PatternBase<R>
   >,
   Ret,
-  Fn extends (_: Types.WhenMatch<R, Types.ArrayToIntersection<P>>) => Ret
+  Args extends Array<any>,
+  Fn extends (_: Types.WhenMatch<R, Types.ArrayToIntersection<P>>, ...args: Args) => Ret
 >(
   ...args: [...patterns: P, f: Fn]
 ) =>
 <I, F, A, Pr>(
-  self: Matcher<I, F, R, A, Pr, Ret>
+  self: Matcher<I, F, R, A, Pr, Ret, Args>
 ): Matcher<
   I,
   Types.AddWithout<F, Types.PForExclude<Types.ArrayToIntersection<P>>>,
@@ -324,7 +338,9 @@ export const whenAnd = <
     Types.AddWithout<F, Types.PForExclude<Types.ArrayToIntersection<P>>>
   >,
   A | ReturnType<Fn>,
-  Pr
+  Pr,
+  Ret,
+  Args
 > => {
   const onMatch = args[args.length - 1] as any
   const patterns = args.slice(0, -1) as unknown as P
@@ -451,7 +467,8 @@ export const tag: <
   R,
   P extends Types.Tags<"_tag", R> & string,
   Ret,
-  Fn extends (_: Extract<R, Record<"_tag", P>>) => Ret
+  Args extends Array<any>,
+  Fn extends (_: Extract<R, Record<"_tag", P>>, ...args: Args) => Ret
 >(
   ...pattern: [
     first: P,
@@ -459,15 +476,16 @@ export const tag: <
     f: Fn
   ]
 ) => <I, F, A, Pr>(
-  self: Matcher<I, F, R, A, Pr, Ret>
+  self: Matcher<I, F, R, A, Pr, Ret, Args>
 ) => Matcher<
   I,
   Types.AddWithout<F, Extract<R, Record<"_tag", P>>>,
   Types.ApplyFilters<I, Types.AddWithout<F, Extract<R, Record<"_tag", P>>>>,
   ReturnType<Fn> | A,
   Pr,
-  Ret
-> = discriminator("_tag")
+  Ret,
+  Args
+> = discriminator("_tag") as any
 
 /** @internal */
 export const tagStartsWith = discriminatorStartsWith("_tag")
@@ -483,20 +501,22 @@ export const not = <
   R,
   const P extends Types.PatternPrimitive<R> | Types.PatternBase<R>,
   Ret,
-  Fn extends (_: Types.NotMatch<R, P>) => Ret
+  Args extends Array<any>,
+  Fn extends (_: Types.NotMatch<R, P>, ...args: Args) => Ret
 >(
   pattern: P,
   f: Fn
 ) =>
 <I, F, A, Pr>(
-  self: Matcher<I, F, R, A, Pr, Ret>
+  self: Matcher<I, F, R, A, Pr, Ret, Args>
 ): Matcher<
   I,
   Types.AddOnly<F, Types.WhenMatch<R, P>>,
   Types.ApplyFilters<I, Types.AddOnly<F, Types.WhenMatch<R, P>>>,
   A | ReturnType<Fn>,
   Pr,
-  Ret
+  Ret,
+  Args
 > => (self as any).add(makeNot(makePredicate(pattern), f as any))
 
 /** @internal */
@@ -533,35 +553,44 @@ export const instanceOf = <A extends abstract new(...args: any) => any>(
 
 /** @internal */
 export const orElse =
-  <RA, Ret, F extends (_: RA) => Ret>(f: F) =>
-  <I, R, A, Pr>(self: Matcher<I, R, RA, A, Pr, Ret>): [Pr] extends [never] ? (input: I) => Unify<ReturnType<F> | A>
+  <RA, Ret, Args extends Array<any>, F extends (_: RA, ...args: Args) => Ret>(f: F) =>
+  <I, R, A, Pr>(
+    self: Matcher<I, R, RA, A, Pr, Ret, Args>
+  ): [Pr] extends [never] ? [Args] extends [[]] ? (input: I) => Unify<ReturnType<F> | A>
+    : (...args: Args) => Unify<ReturnType<F> | A>
     : Unify<ReturnType<F> | A> =>
   {
     const toResult = result(self)
 
     if (Result.isResult(toResult)) {
-      return toResult._tag === "Success" ? toResult.success as any : f(toResult.failure) as any
+      return toResult._tag === "Success" ? toResult.success as any : (f as any)(toResult.failure)
     }
 
     // @ts-expect-error
-    return (input: I) => {
-      const a = toResult(input)
-      return Result.isSuccess(a) ? a.success : f(a.failure)
+    return (...args: Array<any>) => {
+      const a = (toResult as any)(...args)
+      return Result.isSuccess(a) ? a.success : (f as any)(a.failure, ...args)
     }
   }
 
 /** @internal */
-export const orElseAbsurd = <I, R, RA, A, Pr, Ret>(
-  self: Matcher<I, R, RA, A, Pr, Ret>
-): [Pr] extends [never] ? (input: I) => Unify<A> : Unify<A> =>
-  orElse(() => {
-    throw new Error("effect/Match/orElseAbsurd: absurd")
-  })(self)
+export const orElseAbsurd: <I, R, RA, A, Pr, Ret, Args extends Array<any>>(
+  self: Matcher<I, R, RA, A, Pr, Ret, Args>
+  // oxlint-disable-next-line max-len
+) => [Pr] extends [never] ? [Args] extends [[]] ? (input: I) => Unify<A> : (...args: Args) => Unify<A> : Unify<A> = ((
+  self: Matcher<any, any, any, any, any, any, any>
+) =>
+  orElse(
+    (() => {
+      throw new Error("effect/Match/orElseAbsurd: absurd")
+    }) as any
+  )(self)) as any
 
 /** @internal */
-export const result: <I, F, R, A, Pr, Ret>(
-  self: Matcher<I, F, R, A, Pr, Ret>
-) => [Pr] extends [never] ? (input: I) => Result.Result<Unify<A>, R>
+export const result: <I, F, R, A, Pr, Ret, Args extends Array<any>>(
+  self: Matcher<I, F, R, A, Pr, Ret, Args>
+) => [Pr] extends [never] ? [Args] extends [[]] ? (input: I) => Result.Result<Unify<A>, R>
+  : (...args: Args) => Result.Result<Unify<A>, R>
   : Result.Result<Unify<A>, R> = (<I, R, RA, A>(self: Matcher<I, R, RA, A, I>) => {
     if (self._tag === "ValueMatcher") {
       return self.value
@@ -570,22 +599,24 @@ export const result: <I, F, R, A, Pr, Ret>(
     const len = self.cases.length
     if (len === 1) {
       const _case = self.cases[0]
-      return (input: I): Result.Result<A, RA> => {
+      return (...args: Array<any>): Result.Result<A, RA> => {
+        const input = self.select(...args)
         if (_case._tag === "When" && _case.guard(input) === true) {
-          return Result.succeed(_case.evaluate(input))
+          return Result.succeed(_case.evaluate(input, ...args))
         } else if (_case._tag === "Not" && _case.guard(input) === false) {
-          return Result.succeed(_case.evaluate(input))
+          return Result.succeed(_case.evaluate(input, ...args))
         }
         return Result.fail(input as any)
       }
     }
-    return (input: I): Result.Result<A, RA> => {
+    return (...args: Array<any>): Result.Result<A, RA> => {
+      const input = self.select(...args)
       for (let i = 0; i < len; i++) {
         const _case = self.cases[i]
         if (_case._tag === "When" && _case.guard(input) === true) {
-          return Result.succeed(_case.evaluate(input))
+          return Result.succeed(_case.evaluate(input, ...args))
         } else if (_case._tag === "Not" && _case.guard(input) === false) {
-          return Result.succeed(_case.evaluate(input))
+          return Result.succeed(_case.evaluate(input, ...args))
         }
       }
 
@@ -594,9 +625,10 @@ export const result: <I, F, R, A, Pr, Ret>(
   }) as any
 
 /** @internal */
-export const option: <I, F, R, A, Pr, Ret>(
-  self: Matcher<I, F, R, A, Pr, Ret>
-) => [Pr] extends [never] ? (input: I) => Option.Option<Unify<A>>
+export const option: <I, F, R, A, Pr, Ret, Args extends Array<any>>(
+  self: Matcher<I, F, R, A, Pr, Ret, Args>
+) => [Pr] extends [never] ? [Args] extends [[]] ? (input: I) => Option.Option<Unify<A>>
+  : (...args: Args) => Option.Option<Unify<A>>
   : Option.Option<Unify<A>> = (<I, A>(self: Matcher<I, any, any, A, I>) => {
     const toResult = result(self)
     if (Result.isResult(toResult)) {
@@ -605,8 +637,8 @@ export const option: <I, F, R, A, Pr, Ret>(
         onSuccess: Option.some
       })
     }
-    return (input: I): Option.Option<A> =>
-      Result.match((toResult as any)(input), {
+    return (...args: Array<any>): Option.Option<A> =>
+      Result.match((toResult as any)(...args), {
         onFailure: () => Option.none(),
         onSuccess: Option.some as any
       })
@@ -615,29 +647,30 @@ export const option: <I, F, R, A, Pr, Ret>(
 const getExhaustiveAbsurdErrorMessage = "effect/match/Match/exhaustive: absurd"
 
 /** @internal */
-export const exhaustive: <I, F, A, Pr, Ret>(
-  self: Matcher<I, F, never, A, Pr, Ret>
-) => [Pr] extends [never] ? (u: I) => Unify<A> : Unify<A> = (<I, F, A>(
-  self: Matcher<I, F, never, A, I>
-) => {
-  const toResult = result(self as any)
+export const exhaustive: <I, F, A, Pr, Ret, Args extends Array<any>>(
+  self: Matcher<I, F, never, A, Pr, Ret, Args>
+) => [Pr] extends [never] ? [Args] extends [[]] ? (u: I) => Unify<A> : (...args: Args) => Unify<A>
+  : Unify<A> = (<I, F, A>(
+    self: Matcher<I, F, never, A, I>
+  ) => {
+    const toResult = result(self as any)
 
-  if (Result.isResult(toResult)) {
-    if (Result.isSuccess(toResult)) {
-      return toResult.success
+    if (Result.isResult(toResult)) {
+      if (Result.isSuccess(toResult)) {
+        return toResult.success
+      }
+
+      throw new Error(getExhaustiveAbsurdErrorMessage)
     }
 
-    throw new Error(getExhaustiveAbsurdErrorMessage)
-  }
+    return (...args: Array<any>): A => {
+      // @ts-expect-error
+      const result = toResult(...args)
 
-  return (u: I): A => {
-    // @ts-expect-error
-    const result = toResult(u)
+      if (Result.isSuccess(result)) {
+        return result.success as any
+      }
 
-    if (Result.isSuccess(result)) {
-      return result.success as any
+      throw new Error(getExhaustiveAbsurdErrorMessage)
     }
-
-    throw new Error(getExhaustiveAbsurdErrorMessage)
-  }
-}) as any
+  }) as any

--- a/packages/effect/test/Match.test.ts
+++ b/packages/effect/test/Match.test.ts
@@ -3,6 +3,38 @@ import { Match, pipe } from "effect"
 import { strictEqual } from "./utils/assert.ts"
 
 describe("Match", () => {
+  it("fn keeps the selector arguments", () => {
+    type Todo = { readonly completed: boolean }
+    type Todos = Array<Todo>
+    type Filter = "All" | "Active" | "Completed"
+
+    const filterTodos = Match.fn((_todos: Todos, filter: Filter) => filter).pipe(
+      Match.withReturnType<Todos>(),
+      Match.when("All", (_filter, todos) => todos),
+      Match.when("Active", (_filter, todos) => todos.filter((todo) => !todo.completed)),
+      Match.when("Completed", (_filter, todos) => todos.filter((todo) => todo.completed)),
+      Match.exhaustive
+    )
+    const todos: Todos = [{ completed: false }, { completed: true }]
+
+    strictEqual(filterTodos(todos, "All"), todos)
+    strictEqual(filterTodos(todos, "Active").length, 1)
+    strictEqual(filterTodos(todos, "Active")[0], todos[0])
+    strictEqual(filterTodos(todos, "Completed").length, 1)
+    strictEqual(filterTodos(todos, "Completed")[0], todos[1])
+  })
+
+  it("fn can match a projected value", () => {
+    type Todo = { readonly status: "Active" | "Completed"; readonly title: string }
+    const formatTodo = Match.fn((todo: Todo) => todo.status).pipe(
+      Match.when("Active", (_status, todo) => `Active: ${todo.title}`),
+      Match.when("Completed", (_status, todo) => `Completed: ${todo.title}`),
+      Match.exhaustive
+    )
+
+    strictEqual(formatTodo({ status: "Active", title: "Write tests" }), "Active: Write tests")
+  })
+
   it("tag matches an exact _tag and falls through for null", () => {
     const match = pipe(
       Match.type<{ _tag: "A" } | null>(),

--- a/packages/effect/typetest/Match.tst.ts
+++ b/packages/effect/typetest/Match.tst.ts
@@ -3,9 +3,85 @@ import { describe, expect, it } from "tstyche"
 
 type Closed = { readonly _tag: "Closed" }
 
+type Todo = { readonly completed: boolean }
+type Todos = Array<Todo>
+type Filter = "All" | "Active" | "Completed"
+
 declare const stringOrNumber: string | number
 
 describe("Match", () => {
+  it("fn infers the selected value and original arguments", () => {
+    const filterTodos = Match.fn((_todos: Todos, filter: Filter) => filter).pipe(
+      Match.when("All", (_filter, todos) => todos),
+      Match.when("Active", (_filter, todos) => todos.filter((todo) => !todo.completed)),
+      Match.when("Completed", (_filter, todos) => todos.filter((todo) => todo.completed)),
+      Match.exhaustive
+    )
+
+    expect(filterTodos).type.toBe<
+      (
+        todos: Todos,
+        filter: Filter
+      ) => Todos
+    >()
+
+    const withoutExtraParameters = Match.fn((_todos: Todos, filter: Filter) => filter).pipe(
+      Match.when("All", () => "all" as const),
+      Match.orElse(() => "filtered" as const)
+    )
+    expect(withoutExtraParameters).type.toBe<(todos: Todos, filter: Filter) => "all" | "filtered">()
+
+    Match.fn((_todos: Todos, filter: Filter) => filter).pipe(
+      // @ts-expect-error Argument of type
+      Match.when("All", (_filter, _todos: Array<string>) => "all")
+    )
+  })
+
+  it("fn threads arguments through handlers and terminals", () => {
+    const whenOr = Match.fn((_prefix: string, value: "a" | "b" | "c") => value).pipe(
+      Match.whenOr("a", "b", (_value, prefix) => prefix.length),
+      Match.when("c", (_value, prefix) => prefix.length),
+      Match.exhaustive
+    )
+    expect(whenOr).type.toBe<(prefix: string, value: "a" | "b" | "c") => number>()
+
+    const whenAnd = Match.fn((_context: boolean, value: { readonly kind: "a"; readonly active: boolean }) => value)
+      .pipe(
+        Match.whenAnd({ kind: "a" }, { active: true }, (_value, context) => context),
+        Match.orElse((_value, context) => context)
+      )
+    expect(whenAnd).type.toBe<
+      (
+        context: boolean,
+        value: { readonly kind: "a"; readonly active: boolean }
+      ) => boolean
+    >()
+
+    const not = Match.fn((_context: boolean, value: "a" | "b") => value).pipe(
+      Match.not("a", (_value, context) => context),
+      Match.orElse((_value, context) => context)
+    )
+    expect(not).type.toBe<(context: boolean, value: "a" | "b") => boolean>()
+
+    type Event = { readonly _tag: "A" } | { readonly _tag: "B" }
+    const tag = Match.fn((_context: boolean, event: Event) => event).pipe(
+      Match.tag("A", (_event, context) => context),
+      Match.tag("B", (_event, context) => context),
+      Match.exhaustive
+    )
+    expect(tag).type.toBe<(context: boolean, event: Event) => boolean>()
+
+    const partial = Match.fn((_prefix: string, value: string | number) => value).pipe(
+      Match.when(Match.string, (value, prefix) => prefix + value)
+    )
+    expect(partial.pipe(Match.option)).type.toBe<
+      (prefix: string, value: string | number) => Option.Option<string>
+    >()
+    expect(partial.pipe(Match.result)).type.toBe<
+      (prefix: string, value: string | number) => Result.Result<string, number>
+    >()
+  })
+
   it("value matchers resolve terminals for generic inputs", () => {
     // https://github.com/Effect-TS/effect/issues/7315
     const orElse = <Open extends { readonly _tag: "Open" }>(


### PR DESCRIPTION
## Summary

- add `Match.fn` to precompile a matcher around a selector while preserving its argument tuple
- pass the narrowed selected value and original arguments to handlers
- carry selector arguments through handler combinators and terminal return types without changing `Match.type` or `Match.value`
- cover inference, rejected argument types, runtime selection, projections, and terminal types

## Validation

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test-types Match.tst.ts`
- `nix develop -c pnpm test --run packages/effect/test/Match.test.ts`
- `nix develop -c pnpm doctest --run packages/effect/src/Match.ts`
- `nix develop -c pnpm check`

Closes EFF-768
