### PR TITLE
fix(Deferred): clear resumes before resuming waiters on completion

### DIFF
--- a/.changeset/deferred-resume-starvation.md
+++ b/.changeset/deferred-resume-starvation.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Deferred` completion skipping waiters when an earlier waiter dies during resume. Completing a `Deferred` with an interrupt cause kills a suspended waiter synchronously inside its resume; the dying waiter's `await` cleanup spliced the shared `resumes` array mid-iteration, so the next waiter was never resumed and hung forever. Completion now clears `resumes` before resuming waiters.

--- a/packages/effect/src/Deferred.ts
+++ b/packages/effect/src/Deferred.ts
@@ -857,10 +857,14 @@ export const doneUnsafe = <A, E>(self: Deferred<A, E>, effect: Effect<A, E>): bo
   if (self.effect) return false
   self.effect = effect
   if (self.resumes) {
-    for (let i = 0; i < self.resumes.length; i++) {
-      self.resumes[i](effect)
-    }
+    // Clear `resumes` before resuming: a waiter resumed with an interrupt
+    // cause dies synchronously inside `resume`, and its await cleanup would
+    // otherwise splice this array mid-iteration and skip the next waiter.
+    const resumes = self.resumes
     self.resumes = undefined
+    for (let i = 0; i < resumes.length; i++) {
+      resumes[i](effect)
+    }
   }
   return true
 }

--- a/packages/effect/test/Deferred.test.ts
+++ b/packages/effect/test/Deferred.test.ts
@@ -3,6 +3,7 @@ import { Deferred, Fiber, Option } from "effect"
 import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
+import * as TestClock from "effect/testing/TestClock"
 
 describe("Deferred", () => {
   describe("success", () => {
@@ -143,6 +144,34 @@ describe("Deferred", () => {
         assert.isFalse(Exit.hasDies(exit))
 
         assert.strictEqual(yield* Fiber.join(live), 42)
+      }))
+
+    it.effect("done with an interrupt cause resumes every suspended waiter", () =>
+      Effect.gen(function*() {
+        const deferred = yield* Deferred.make<number>()
+        const first = yield* Deferred.await(deferred).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+        const second = yield* Deferred.await(deferred).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+        assert.strictEqual(deferred.resumes?.length, 2)
+
+        // Resuming the first waiter with an interrupt cause kills it
+        // synchronously, so its await cleanup must not shift later waiters
+        // out from under the completion loop.
+        assert.isTrue(yield* Deferred.done(deferred, Exit.failCause(Cause.interrupt())))
+
+        const settled = yield* Fiber.awaitAll([first, second]).pipe(
+          Effect.timeoutOption(1000),
+          Effect.forkChild({ startImmediately: true })
+        )
+        yield* TestClock.adjust(1000)
+        const exits = yield* Fiber.join(settled)
+        assert.isTrue(Option.isSome(exits), "every waiter should settle")
+        for (const exit of Option.getOrThrow(exits)) {
+          assert.isTrue(Exit.hasInterrupts(exit))
+        }
       }))
   })
 


### PR DESCRIPTION
Fixes #7365

## Summary

Completing a `Deferred` whose completion effect carries an interrupt cause can permanently starve later waiters. `doneUnsafe` iterates `self.resumes` live:

```ts
if (self.resumes) {
  for (let i = 0; i < self.resumes.length; i++) {
    self.resumes[i](effect)
  }
  self.resumes = undefined
}
```

When the completion effect is e.g. `Exit.failCause(Cause.interrupt())`, resuming a suspended waiter kills that waiter fiber synchronously inside `resume(effect)`. The dying waiter's `Deferred.await` cleanup then runs while `self.resumes` is still defined and splices its own entry out of the array mid-iteration. The next waiter shifts down into the just-visited index, the loop index moves past it, and that waiter is never resumed — it hangs forever.

Concretely: with two suspended waiters, waiter 0 resumes (and dies of interruption), its cleanup splices `resumes[0]`, waiter 1 becomes `resumes[0]`, the loop advances to `i = 1` against `length = 1`, and waiter 1 is skipped. Observed empirically in `effect@4.0.0-beta.107`.

This is the starvation counterpart to #7194: that fix guarded the `_await` cleanup against running *after* completion (`resumes === undefined`), but the cleanup still mutates the array when it fires *during* the completion loop.

## Fix

Snapshot and clear `resumes` before resuming, matching the swap-before-resume pattern `Latch` already uses for exactly this reentrancy hazard:

```ts
if (self.resumes) {
  const resumes = self.resumes
  self.resumes = undefined
  for (let i = 0; i < resumes.length; i++) {
    resumes[i](effect)
  }
}
```

Clearing first also makes a dying waiter's cleanup a no-op during completion (the `resumes === undefined` guard from #7193 short-circuits), so the loop iterates a stable snapshot.

All completion paths (`done`, `complete`, `completeWith`, `fail`, `die`, `interrupt`, `into`, and external `doneUnsafe` callers in `PubSub`, `ScopedCache`, `FiberMap`, `FiberHandle`, `Socket`) funnel through `doneUnsafe`, so this single change covers them. `Queue` resumes takers via `Set` iteration and `Latch` already snapshots, so neither shares the bug.

## Reproducer

The added test forks two waiters, lets both suspend, then completes the `Deferred` with `Exit.failCause(Cause.interrupt())`. On unpatched `main` the second waiter never settles and the test's timeout fires; with the fix both waiters settle with the interrupt cause.

## Testing

- `pnpm vitest run --project effect test/Deferred.test.ts` — new test fails before the fix, all 16 pass after
- `pnpm vitest run --project effect test/Latch.test.ts test/PubSub.test.ts test/Queue.test.ts test/ScopedCache.test.ts test/FiberMap.test.ts test/FiberHandle.test.ts` — 204 passed
- `pnpm check` in `packages/effect`, repo lint on touched files

