### PR TITLE
Encode integral SchemaBinary numbers as varints

### DIFF
--- a/.changeset/schema-binary-varint-numbers.md
+++ b/.changeset/schema-binary-varint-numbers.md
@@ -1,0 +1,7 @@
+---
+"effect": minor
+---
+
+Encode integral `SchemaBinary` numbers as varints.
+
+A `Number` now takes a sign-magnitude varint when its value is integral and IEEE 754 binary64 otherwise, with the enclosing length telling the two apart. When the schema proves the value is an integer (`Schema.Int`, `Schema.Natural`, any `isInt` check) the layout drops the f64 form and writes a bare varint. This shrinks the benchmark payloads by 19% to 43% and is a wire change: a payload written by an earlier build of this unreleased module does not read back.

--- a/packages/effect/benchmark/schema/SchemaBinary.md
+++ b/packages/effect/benchmark/schema/SchemaBinary.md
@@ -18,35 +18,52 @@ Treat the measurements as a per-machine comparison within one run. Runtime versi
 
 ## Measured comparison
 
-One run on Node 26.7.0, Linux x64. One-shot throughput is the average of 1,000 measured
+One run on Node 26.7.0, Linux x64, on the wire format that encodes integral
+numbers as varints. One-shot throughput is the average of 1,000 measured
 samples per task; treat these as a within-run comparison, not a portable score.
+
+Payload sizes are exact and portable, so they are the part of this table worth
+comparing across machines.
+
+| Case                   | SchemaBinary |  JSON | Msgpack | SchemaBinary vs Msgpack |
+| ---------------------- | -----------: | ----: | ------: | ----------------------: |
+| small record           |           58 |    89 |      69 |           1.19x smaller |
+| nested payload         |          318 |   453 |     385 |           1.21x smaller |
+| collections            |         1452 |  1828 |    1462 |           1.01x smaller |
+| large repeated records |        27646 | 57529 |   51283 |           1.85x smaller |
+
+Encoding integral numbers as varints took these payloads from 72, 347, 2553 and
+31486 bytes. The collections case stays close to Msgpack because it is
+dominated by genuinely non-integral floats, which stay in the eight-byte f64
+form.
 
 The encode rows exercise both ownership models on every case. Decode does not depend on output ownership, so the arena rows below are compared with Msgpack.
 
 | Case                   | SchemaBinary arena | SchemaBinary copy | Arena vs copy | Msgpack |
 | ---------------------- | -----------------: | ----------------: | ------------: | ------: |
-| small record           |            462,238 |           444,428 |         1.04x | 470,631 |
-| nested payload         |            235,971 |           223,358 |         1.06x | 209,940 |
-| collections            |             34,632 |            34,224 |         1.01x |  22,340 |
-| large repeated records |              6,196 |             6,094 |         1.02x |   3,514 |
+| small record           |            462,101 |           488,902 |         0.95x | 480,796 |
+| nested payload         |            237,505 |           223,273 |         1.06x | 210,144 |
+| collections            |             34,139 |            33,853 |         1.01x |  22,929 |
+| large repeated records |              6,001 |             5,932 |         1.01x |   3,461 |
 
 | Case                   | SchemaBinary decode | Msgpack decode | SchemaBinary vs Msgpack |
 | ---------------------- | ------------------: | -------------: | ----------------------: |
-| small record           |             485,041 |        471,327 |                   1.03x |
-| nested payload         |             223,300 |        203,587 |                   1.10x |
-| collections            |              37,881 |         21,442 |                   1.77x |
-| large repeated records |               6,129 |          4,066 |                   1.51x |
+| small record           |             489,273 |        483,113 |                   1.01x |
+| nested payload         |             231,041 |        203,513 |                   1.14x |
+| collections            |              38,306 |         22,508 |                   1.70x |
+| large repeated records |               6,142 |          4,116 |                   1.49x |
 
 Both codecs run the same Schema parser, which costs roughly 140 us per
 direction on the largest case and sets a floor neither format can go below.
 The numbers above therefore understate the difference between the two
 serialization layers.
 
-Removing the output copy matters most for the 72-byte small record, where the
-arena was 4% faster than the ownership-copy control and nearly closed the gap
-with msgpackr. The other three cases were 1-6% faster than the copy control;
-none showed a material regression. Results returned by the arena keep an exact
-byte range but can share a larger backing buffer, as documented by
+The small record is now the noisiest case rather than the slowest one: at 58
+bytes both encode paths are dominated by fixed per-call cost, the arena row
+carried a 6.9% relative margin of error in this run, and arena and copy trade
+places between runs. The other three cases put the arena 1-6% ahead of the
+ownership-copy control. Results returned by the arena keep an exact byte range
+but can share a larger backing buffer, as documented by
 `SchemaBinary.toCodec`.
 
 ## Streaming decode comparison
@@ -55,9 +72,9 @@ Each sample decodes 32 concatenated frames with parser state reused between samp
 
 | Case                   | SchemaBinary parser | Msgpack unpackMultiple | SchemaBinary vs Msgpack |
 | ---------------------- | ------------------: | ---------------------: | ----------------------: |
-| small record           |             819,397 |                605,873 |                   1.35x |
-| nested payload         |             264,288 |                194,432 |                   1.36x |
-| collections            |              37,852 |                 20,760 |                   1.82x |
-| large repeated records |               5,823 |                  4,910 |                   1.19x |
+| small record           |             820,916 |                626,090 |                   1.31x |
+| nested payload         |             260,545 |                196,463 |                   1.33x |
+| collections            |              37,921 |                 21,565 |                   1.76x |
+| large repeated records |               5,725 |                  5,038 |                   1.14x |
 
-The stream-size table printed by the benchmark matters here. A persistent Msgpack `Packr` can reuse record definitions across frames, so its large repeated-record stream averages 19,484 bytes per frame versus 31,486 bytes for SchemaBinary in this run. The throughput comparison still favors SchemaBinary, but the two formats make different size-versus-parse-cost tradeoffs.
+The stream-size table printed by the benchmark matters here. A persistent Msgpack `Packr` can reuse record definitions across frames, so its large repeated-record stream averages 19,484 bytes per frame versus 27,646 bytes for SchemaBinary in this run. The throughput comparison still favors SchemaBinary, but the two formats make different size-versus-parse-cost tradeoffs.

--- a/packages/effect/src/unstable/encoding/SchemaBinary.ts
+++ b/packages/effect/src/unstable/encoding/SchemaBinary.ts
@@ -5,6 +5,13 @@
  * wire, unknown struct fields are skipped, missing optionals decode as
  * absent, and field reorder is compatible.
  *
+ * A `Number` takes whichever of two forms is smaller and the enclosing length
+ * says which: a sign-magnitude varint for integral values, IEEE 754 binary64
+ * otherwise. When the schema proves the value is an integer (`Schema.Int`,
+ * `Schema.Natural`, any `isInt` check) the layout drops the f64 form and emits
+ * a bare varint, so a checked number and an unchecked one are different wire
+ * layouts for the same value.
+ *
  * @since 4.0.0
  */
 import * as BigDecimal from "../../BigDecimal.ts"
@@ -33,12 +40,51 @@ const ENVELOPE = 0x10 // version nibble 1, flags 0
 const MAX_SAFE_BIGINT = BigInt(Number.MAX_SAFE_INTEGER)
 const BIGINT_ZERO = BigInt(0)
 const BIGINT_ONE = BigInt(1)
+const BIGINT_TWO = BigInt(2)
 const BIGINT_SEVEN = BigInt(7)
 const BIGINT_VARINT_MASK = BigInt(0x7F)
 const BIGINT_NANOS_PER_MILLI = BigInt(1_000_000)
 
 const utf8Encode = new TextEncoder()
 const utf8DecodeFatal = new TextDecoder("utf-8", { fatal: true })
+
+// -----------------------------------------------------------------------------
+// number forms
+// -----------------------------------------------------------------------------
+
+// A general `Number` takes one of two forms and the enclosing length says
+// which: eight bytes are the f64 form, one to seven bytes are the varint form.
+// Capping the varint at seven bytes is what keeps the two apart, and f64 is
+// exact for every integer well past that cap, so nothing is lost above it.
+const NUMBER_VARINT_MAX_BYTES = 7
+
+// Largest magnitude whose sign-magnitude code (`2 * magnitude + sign`) still
+// fits in seven varint bytes, i.e. in 49 bits.
+const NUMBER_VARINT_MAX_MAGNITUDE = 281_474_976_710_655 // 2 ** 48 - 1
+
+// Largest magnitude whose code is still a safe integer; above this the code is
+// built with bigint arithmetic so a schema-proven integer keeps its exact
+// value.
+const EXACT_MAGNITUDE_MAX = 4_503_599_627_370_495 // 2 ** 52 - 1
+
+// A uniform array of general numbers writes one mode byte and then a run in
+// that single form, rather than paying a discriminator per element.
+const NUMBER_RUN_F64 = 0
+const NUMBER_RUN_VARINT = 1
+
+function isVarintNumber(value: unknown): boolean {
+  return typeof value === "number" && Number.isInteger(value) &&
+    value >= -NUMBER_VARINT_MAX_MAGNITUDE && value <= NUMBER_VARINT_MAX_MAGNITUDE
+}
+
+// Sign-magnitude: the low bit is the sign, the rest is the magnitude. Unlike
+// plain zigzag this leaves `-0` a code of its own (`1`), so the varint form
+// covers every integral JavaScript number rather than needing an f64 escape
+// for the one value zigzag cannot express.
+function decodeSignMagnitude(code: number): number {
+  const magnitude = Math.floor(code / 2)
+  return code % 2 === 1 ? -magnitude : magnitude
+}
 
 // -----------------------------------------------------------------------------
 // wire kinds
@@ -48,7 +94,8 @@ const K = {
   bool: 1,
   null: 2,
   undefined: 3,
-  f64: 4,
+  // both number forms, general and schema-proven integer
+  number: 4,
   string: 5,
   bytes: 6,
   bigint: 7,
@@ -260,6 +307,16 @@ class Writer {
   zigzag(n: bigint) {
     this.uvarintBig(n >= BIGINT_ZERO ? n << BIGINT_ONE : (-n << BIGINT_ONE) - BIGINT_ONE)
   }
+  // Sign-magnitude varint of an integral number. See `decodeSignMagnitude`.
+  numberVarint(n: number) {
+    const negative = n < 0 || (n === 0 && 1 / n < 0)
+    const magnitude = negative ? -n : n
+    if (magnitude <= EXACT_MAGNITUDE_MAX) {
+      this.uvarint(magnitude * 2 + (negative ? 1 : 0))
+    } else {
+      this.uvarintBig(BigInt(magnitude) * BIGINT_TWO + (negative ? BIGINT_ONE : BIGINT_ZERO))
+    }
+  }
   f64(n: number) {
     this.ensure(8)
     this.view.setFloat64(this.start + this.len, n, true)
@@ -460,6 +517,34 @@ class Reader {
       shift += BIGINT_SEVEN
     }
   }
+  // Reads a sign-magnitude varint. Seven groups cover every code the capped
+  // general form can produce; only the schema-proven integer layout reaches
+  // further, and those rare codes are re-read through bigint so the magnitude
+  // stays exact.
+  numberVarint(): number {
+    const buf = this.buf
+    const end = this.end
+    let pos = this.pos
+    let value = 0
+    let scale = 1
+    for (let i = 0; i < NUMBER_VARINT_MAX_BYTES; i++) {
+      if (pos >= end) {
+        this.pos = pos
+        invalid("complete value", undefined, this.options)
+      }
+      const b = buf[pos++]
+      value += (b & 0x7F) * scale
+      if (b < 0x80) {
+        this.pos = pos
+        return decodeSignMagnitude(value)
+      }
+      scale *= 128
+    }
+    const code = this.uvarintBig()
+    const magnitude = Number(code >> BIGINT_ONE)
+    if (!Number.isFinite(magnitude)) invalid("safe integer length", undefined, this.options)
+    return (code & BIGINT_ONE) === BIGINT_ONE ? -magnitude : magnitude
+  }
   zigzag(): bigint {
     const u = this.uvarintBig()
     return (u & BIGINT_ONE) === BIGINT_ONE
@@ -500,7 +585,10 @@ type LeafKind =
   | "bool"
   | "null"
   | "undefined"
-  | "f64"
+  // a general number: varint when integral and within the cap, f64 otherwise
+  | "number"
+  // a number the encoded-side schema proves is an integer: always a varint
+  | "int"
   | "string"
   | "symbol"
   | "bytes"
@@ -565,6 +653,9 @@ interface ArrayLayout {
   // True when that uniform slot is written without a length prefix.
   uniformInline: boolean
   uniformPacked: number | undefined
+  // True when the uniform slot is a general number, which is written as one
+  // mode byte followed by a run in a single form.
+  uniformNumbers: boolean
 }
 
 interface VariantRow {
@@ -591,8 +682,9 @@ function kindByte(layout: Layout): number {
       return K.null
     case "undefined":
       return K.undefined
-    case "f64":
-      return K.f64
+    case "number":
+    case "int":
+      return K.number
     case "string":
     case "symbol":
       return K.string
@@ -630,11 +722,16 @@ function kindByte(layout: Layout): number {
   }
 }
 
+// A slot whose encoding delimits itself, so it needs no length prefix even
+// though its width varies.
+function isSelfDelimiting(layout: Layout): boolean {
+  return layout._ === "int"
+}
+
 function packedSize(layout: Layout): number | undefined {
   switch (layout._) {
     case "bool":
       return 1
-    case "f64":
     case "int64":
       return 8
     default:
@@ -777,6 +874,21 @@ function isJsonDeclaration(ast: SchemaAST.Declaration): boolean {
   return Predicate.isFunction(ast.annotations?.toCodecJson)
 }
 
+// True when an encoded-side `Number` carries an `isInt` check, so every value
+// reaching the wire is an integer and the layout can drop the f64 form.
+// `Schema.Int` and `Schema.Natural` are the common spellings; a `FilterGroup`
+// such as `Schema.isInt32()` nests the same check.
+function provesInteger(ast: SchemaAST.AST): boolean {
+  const checks = ast.checks
+  if (checks === undefined) return false
+  const go = (check: SchemaAST.Check<never>): boolean => {
+    const id = check.annotations?.representation?.id
+    if (id === "effect/schema/isInt") return true
+    return check._tag === "FilterGroup" && check.checks.some(go)
+  }
+  return checks.some(go)
+}
+
 function resolveSuspend(ast: SchemaAST.AST): SchemaAST.AST {
   while (ast._tag === "Suspend") {
     ast = ast.thunk()
@@ -813,7 +925,7 @@ function literalKind(literal: SchemaAST.LiteralValue): LeafKind {
     case "string":
       return "string"
     case "number":
-      return "f64"
+      return "number"
     case "boolean":
       return "bool"
     default:
@@ -842,7 +954,7 @@ function astKind(ast: SchemaAST.AST): number {
     case "Void":
       return K.undefined
     case "Number":
-      return K.f64
+      return K.number
     case "BigInt":
       return K.bigint
     case "Literal":
@@ -850,7 +962,7 @@ function astKind(ast: SchemaAST.AST): number {
         case "string":
           return K.string
         case "number":
-          return K.f64
+          return K.number
         case "boolean":
           return K.bool
         default:
@@ -913,7 +1025,7 @@ function compileLayout(root: SchemaAST.AST): CompiledLayout {
       case "Void":
         return { _: "undefined" }
       case "Number":
-        return { _: "f64" }
+        return provesInteger(ast) ? { _: "int" } : { _: "number" }
       case "BigInt":
         return { _: "bigint" }
       case "Literal":
@@ -1018,7 +1130,8 @@ function compileLayout(root: SchemaAST.AST): CompiledLayout {
       minCount: requiredElements + tailLen,
       uniform: undefined,
       uniformInline: false,
-      uniformPacked: undefined
+      uniformPacked: undefined,
+      uniformNumbers: false
     }
     memo.set(ast, layout)
     for (const element of ast.elements) {
@@ -1034,7 +1147,9 @@ function compileLayout(root: SchemaAST.AST): CompiledLayout {
       const slot = layout.rest[0]
       layout.uniform = slot
       layout.uniformPacked = packedSize(slot)
-      layout.uniformInline = layout.uniformPacked !== undefined || slot._ === "null" || slot._ === "undefined"
+      layout.uniformNumbers = slot._ === "number"
+      layout.uniformInline = layout.uniformPacked !== undefined || isSelfDelimiting(slot) ||
+        slot._ === "null" || slot._ === "undefined"
     }
     return layout
   }
@@ -1230,7 +1345,8 @@ function matchesLayout(layout: Layout, value: unknown): boolean {
       return value === null
     case "undefined":
       return value === undefined
-    case "f64":
+    case "number":
+    case "int":
       return typeof value === "number"
     case "string":
       return typeof value === "string"
@@ -1473,6 +1589,10 @@ function encodeArray(ctx: EncodeContext, layout: ArrayLayout, value: unknown, w:
   // and packing lookups can be hoisted out of the loop.
   const uniform = layout.uniform
   if (uniform !== undefined) {
+    if (layout.uniformNumbers) {
+      encodeNumberRun(arr, count, w)
+      return
+    }
     const inline = layout.uniformInline
     for (let i = 0; i < count; i++) {
       issuePath[issuePathLen++] = i
@@ -1485,12 +1605,34 @@ function encodeArray(ctx: EncodeContext, layout: ArrayLayout, value: unknown, w:
   for (let i = 0; i < count; i++) {
     const slot = arraySlot(layout, i, count)
     issuePath[issuePathLen++] = i
-    if (packedSize(slot) !== undefined || slot._ === "null" || slot._ === "undefined") {
+    if (
+      packedSize(slot) !== undefined || isSelfDelimiting(slot) || slot._ === "null" || slot._ === "undefined"
+    ) {
       encodeValue(ctx, slot, arr[i], w)
     } else {
       encodeSized(ctx, slot, arr[i], w)
     }
     issuePathLen--
+  }
+}
+
+// A run of general numbers pays one mode byte for the whole array instead of a
+// length prefix per element: every element takes the varint form, or every
+// element takes the f64 form.
+function encodeNumberRun(arr: ReadonlyArray<unknown>, count: number, w: Writer) {
+  let varint = true
+  for (let i = 0; i < count; i++) {
+    if (!isVarintNumber(arr[i])) {
+      varint = false
+      break
+    }
+  }
+  if (varint) {
+    w.byte(NUMBER_RUN_VARINT)
+    for (let i = 0; i < count; i++) w.numberVarint(arr[i] as number)
+  } else {
+    w.byte(NUMBER_RUN_F64)
+    for (let i = 0; i < count; i++) w.f64(arr[i] as number)
   }
 }
 
@@ -1525,9 +1667,18 @@ function encodeValue(ctx: EncodeContext, layout: Layout, value: unknown, w: Writ
     case "null":
     case "undefined":
       return
-    case "f64":
-      w.f64(value as number)
+    case "number":
+      if (isVarintNumber(value)) w.numberVarint(value as number)
+      else w.f64(value as number)
       return
+    case "int": {
+      // The `isInt` check normally rejects a non-integer before the value
+      // reaches this layout; `disableChecks` is the one path that does not,
+      // and a bare varint has no form to fall back to.
+      if (!Number.isSafeInteger(value)) encodeFail("an integer", value, ctx.options)
+      w.numberVarint(value as number)
+      return
+    }
     case "string":
       w.string(value as string)
       return
@@ -1831,6 +1982,15 @@ function decodeArray(layout: ArrayLayout, r: Reader): unknown {
   const uniform = layout.uniform
   if (uniform !== undefined) {
     // `Schema.Array(S)`: one layout for every slot, none of them optional.
+    if (layout.uniformNumbers) return decodeNumberRun(out, count, r)
+    if (isSelfDelimiting(uniform)) {
+      for (let i = 0; i < count; i++) {
+        issuePath[issuePathLen++] = i
+        out[i] = decodeValue(uniform, r)
+        issuePathLen--
+      }
+      return out
+    }
     const packed = layout.uniformPacked
     const inline = layout.uniformInline
     for (let i = 0; i < count; i++) {
@@ -1854,6 +2014,11 @@ function decodeArray(layout: ArrayLayout, r: Reader): unknown {
       throw issueError(new SchemaIssue.MissingKey(undefined))
     }
     issuePath[issuePathLen++] = i
+    if (isSelfDelimiting(slot)) {
+      out[i] = decodeValue(slot, r)
+      issuePathLen--
+      continue
+    }
     const size = packedSize(slot)
     const saved = size !== undefined
       ? r.enter(size)
@@ -1872,6 +2037,23 @@ function decodeArray(layout: ArrayLayout, r: Reader): unknown {
   if (!layout.hasCount && r.pos < r.end) {
     issuePath[issuePathLen++] = elementLen
     throw issueError(new SchemaIssue.UnexpectedKey(layout.ast, undefined, r.options))
+  }
+  return out
+}
+
+// Mirror of `encodeNumberRun`: one mode byte, then a run in that single form.
+function decodeNumberRun(out: Array<unknown>, count: number, r: Reader): Array<unknown> {
+  const mode = r.byte()
+  if (mode === NUMBER_RUN_F64) {
+    if (r.remaining !== count * 8) invalid("f64", undefined, r.options)
+    for (let i = 0; i < count; i++) out[i] = r.f64()
+    return out
+  }
+  if (mode !== NUMBER_RUN_VARINT) invalid("f64", undefined, r.options)
+  for (let i = 0; i < count; i++) {
+    issuePath[issuePathLen++] = i
+    out[i] = r.numberVarint()
+    issuePathLen--
   }
   return out
 }
@@ -1942,9 +2124,15 @@ function decodeValue(layout: Layout, r: Reader): unknown {
     case "undefined":
       if (r.remaining !== 0) invalid("empty", undefined, r.options)
       return undefined
-    case "f64":
-      if (r.remaining !== 8) invalid("f64", undefined, r.options)
-      return r.f64()
+    case "number": {
+      // the enclosing length is the discriminator
+      const len = r.remaining
+      if (len === 8) return r.f64()
+      if (len === 0 || len > NUMBER_VARINT_MAX_BYTES) invalid("f64", undefined, r.options)
+      return r.numberVarint()
+    }
+    case "int":
+      return r.numberVarint()
     case "string":
       return r.readUtf8(r.end - r.pos)
     case "symbol":

--- a/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
+++ b/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
@@ -36,6 +36,13 @@ const concat = (...chunks: ReadonlyArray<Uint8Array>): Uint8Array => {
   return out
 }
 
+const sameNumber = (actual: unknown, expected: number) => {
+  assert.isTrue(
+    Object.is(actual, expected),
+    `expected ${globalThis.String(actual)} to be exactly ${globalThis.String(expected)}`
+  )
+}
+
 const schemaError = (f: () => unknown): Schema.SchemaError => {
   try {
     f()
@@ -52,7 +59,8 @@ describe("SchemaBinary", () => {
       const numbers = [1.5, Number.NaN, -0, Number.POSITIVE_INFINITY]
       const numberBytes = encode(Schema.Array(Schema.Number), numbers)
       const decoded = roundtrip(Schema.Array(Schema.Number), numbers)
-      assert.strictEqual(numberBytes.length, 35)
+      // length, envelope, count, mode byte, four f64 elements
+      assert.strictEqual(numberBytes.length, 36)
       assert.strictEqual(decoded[0], 1.5)
       assert.isTrue(Number.isNaN(decoded[1]))
       assert.isTrue(Object.is(decoded[2], -0))
@@ -84,7 +92,8 @@ describe("SchemaBinary", () => {
 
     it("omits the count for fixed tuples and includes it for optional tuples", () => {
       const pair = Schema.Tuple([Schema.String, Schema.Number])
-      assert.strictEqual(encode(pair, ["key", 42]).length, 14)
+      // length, envelope, then a length-prefixed slot each: "key" and varint 42
+      assert.strictEqual(encode(pair, ["key", 42]).length, 8)
       assert.deepStrictEqual(roundtrip(pair, ["key", 42]), ["key", 42])
 
       const optional = Schema.Tuple([Schema.Number, Schema.optionalKey(Schema.Number)])
@@ -104,7 +113,7 @@ describe("SchemaBinary", () => {
     it("writes a length-first frame and rejects envelope or leftovers", () => {
       const codec = SchemaBinary.toCodec(Schema.Number)
       const bytes = Schema.encodeUnknownSync(codec)(1)
-      assert.deepStrictEqual(Array.from(bytes.slice(0, 2)), [9, 0x10])
+      assert.deepStrictEqual(Array.from(bytes), [2, 0x10, 0x02])
 
       const flags = bytes.slice()
       flags[1] = 0x11
@@ -176,6 +185,170 @@ describe("SchemaBinary", () => {
         yield* Effect.yieldNow
         assert.deepStrictEqual(encoded.map((bytes) => decode(bytes)), values)
       })
+    })
+  })
+
+  describe("numbers", () => {
+    it("encodes integral values as sign-magnitude varints", () => {
+      assert.deepStrictEqual(Array.from(encode(Schema.Number, 0)), [2, 0x10, 0])
+      assert.deepStrictEqual(Array.from(encode(Schema.Number, -0)), [2, 0x10, 1])
+      assert.deepStrictEqual(Array.from(encode(Schema.Number, 1)), [2, 0x10, 2])
+      assert.deepStrictEqual(Array.from(encode(Schema.Number, -1)), [2, 0x10, 3])
+      for (const value of [0, -0, 1, -1, 42, -42, 127, -128]) {
+        sameNumber(roundtrip(Schema.Number, value), value)
+      }
+    })
+
+    it("covers every varint width up to the seven byte cap, both signs", () => {
+      for (let width = 1; width <= 7; width++) {
+        // the widest magnitude this many varint bytes can hold, and the first
+        // magnitude that needs one more
+        const last = 2 ** (7 * width - 1) - 1
+        const next = 2 ** (7 * width - 1)
+        for (const sign of [1, -1]) {
+          const inside = sign * last
+          const outside = sign * next
+          assert.strictEqual(encode(Schema.Number, inside).length, 2 + width, `${inside}`)
+          sameNumber(roundtrip(Schema.Number, inside), inside)
+          // past the cap the value takes the f64 form instead of an eighth byte
+          assert.strictEqual(encode(Schema.Number, outside).length, width === 7 ? 10 : 3 + width, `${outside}`)
+          sameNumber(roundtrip(Schema.Number, outside), outside)
+        }
+      }
+    })
+
+    it("keeps f64 for values no capped varint can hold", () => {
+      const values = [
+        1.5,
+        -1.5,
+        Number.EPSILON,
+        Number.NaN,
+        Number.POSITIVE_INFINITY,
+        Number.NEGATIVE_INFINITY,
+        Number.MAX_SAFE_INTEGER,
+        Number.MIN_SAFE_INTEGER,
+        Number.MAX_VALUE,
+        2 ** 48,
+        -(2 ** 48)
+      ]
+      for (const value of values) {
+        assert.strictEqual(encode(Schema.Number, value).length, 10, `${value}`)
+        sameNumber(roundtrip(Schema.Number, value), value)
+      }
+    })
+
+    it("discriminates the two forms by the enclosing field length", () => {
+      const schema = Schema.Struct({ n: Schema.Number })
+      // length, envelope, five-byte field id, field length, payload
+      assert.strictEqual(encode(schema, { n: 7 }).length, 9)
+      assert.strictEqual(encode(schema, { n: 7.5 }).length, 16)
+      assert.deepStrictEqual(roundtrip(schema, { n: 7 }), { n: 7 })
+      assert.deepStrictEqual(roundtrip(schema, { n: 7.5 }), { n: 7.5 })
+      sameNumber(roundtrip(schema, { n: -0 }).n, -0)
+    })
+
+    it("packs a uniform number array behind one mode byte", () => {
+      const integers = [0, -0, 1, -1, 1000, -1000]
+      // length, envelope, count, mode, four one-byte and two two-byte varints
+      assert.strictEqual(encode(Schema.Array(Schema.Number), integers).length, 12)
+      const decoded = roundtrip(Schema.Array(Schema.Number), integers)
+      integers.forEach((value, index) => sameNumber(decoded[index], value))
+
+      // one value outside the varint form moves the whole run to f64
+      const mixed = [1, 2.5]
+      assert.strictEqual(encode(Schema.Array(Schema.Number), mixed).length, 20)
+      assert.deepStrictEqual(roundtrip(Schema.Array(Schema.Number), mixed), mixed)
+      assert.deepStrictEqual(roundtrip(Schema.Array(Schema.Number), []), [])
+      assert.deepStrictEqual(
+        roundtrip(Schema.Array(Schema.Array(Schema.Number)), [[1, 2], [], [3.5]]),
+        [[1, 2], [], [3.5]]
+      )
+    })
+
+    it("length-prefixes each number slot of a tuple", () => {
+      const pair = Schema.Tuple([Schema.Number, Schema.Number])
+      assert.strictEqual(encode(pair, [1, 2]).length, 6)
+      assert.strictEqual(encode(pair, [1, 2.5]).length, 13)
+      assert.deepStrictEqual(roundtrip(pair, [1, 2.5]), [1, 2.5])
+      const rest = Schema.TupleWithRest(Schema.Tuple([Schema.String]), [Schema.Number])
+      assert.deepStrictEqual(roundtrip(rest, ["head", 1, 2.5, 3]), ["head", 1, 2.5, 3])
+    })
+
+    it("carries both forms behind the union kind byte", () => {
+      const schema = Schema.Union([Schema.Number, Schema.String])
+      assert.strictEqual(encode(schema, 5).length, 4)
+      assert.strictEqual(encode(schema, 5.5).length, 11)
+      assert.strictEqual(roundtrip(schema, 5), 5)
+      assert.strictEqual(roundtrip(schema, 5.5), 5.5)
+      assert.strictEqual(roundtrip(schema, "x"), "x")
+      sameNumber(roundtrip(schema, -0), -0)
+
+      const tagged = Schema.Union([
+        Schema.Struct({ _tag: Schema.Literal("A"), n: Schema.Number }),
+        Schema.Struct({ _tag: Schema.Literal("B"), n: Schema.Int })
+      ])
+      assert.deepStrictEqual(roundtrip(tagged, { _tag: "A", n: 1.5 }), { _tag: "A", n: 1.5 })
+      assert.deepStrictEqual(roundtrip(tagged, { _tag: "B", n: -7 }), { _tag: "B", n: -7 })
+    })
+
+    it("parses a stream whose numbers change width", () => {
+      const values = [0, -0, 1, -1, 63, 64, 1_000_000, -1_000_000, 1.5, Number.NaN, Number.MAX_SAFE_INTEGER]
+      const bytes = concat(...values.map((value) => encode(Schema.Number, value)))
+      const parser = SchemaBinary.parser(Schema.Number)
+      const out: Array<number> = []
+      for (const byte of bytes) out.push(...parser.feedSync(Uint8Array.of(byte)))
+      parser.endSync()
+      assert.strictEqual(out.length, values.length)
+      values.forEach((value, index) => sameNumber(out[index], value))
+    })
+
+    it("emits a bare varint when the schema proves the value is an integer", () => {
+      assert.deepStrictEqual(Array.from(encode(Schema.Int, 1)), [2, 0x10, 2])
+      assert.deepStrictEqual(Array.from(encode(Schema.Natural, 1)), [2, 0x10, 2])
+      assert.deepStrictEqual(Array.from(encode(Schema.Number.check(Schema.isInt32()), 1)), [2, 0x10, 2])
+
+      // no mode byte for an array, no length prefix for a tuple slot
+      assert.strictEqual(encode(Schema.Array(Schema.Int), [1, 2, 3]).length, 6)
+      assert.strictEqual(encode(Schema.Array(Schema.Number), [1, 2, 3]).length, 7)
+      assert.strictEqual(encode(Schema.Tuple([Schema.Int, Schema.Int]), [1, 2]).length, 4)
+      assert.strictEqual(encode(Schema.Tuple([Schema.Number, Schema.Number]), [1, 2]).length, 6)
+
+      for (const value of [0, -0, 1, -1, 2 ** 48, -(2 ** 48), Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER]) {
+        sameNumber(roundtrip(Schema.Int, value), value)
+        sameNumber(roundtrip(Schema.Array(Schema.Int), [value])[0], value)
+        sameNumber(roundtrip(Schema.Struct({ n: Schema.Int }), { n: value }).n, value)
+      }
+      assert.deepStrictEqual(
+        roundtrip(Schema.Array(Schema.Int), [1, -2, 3]),
+        [1, -2, 3]
+      )
+    })
+
+    it("rejects a non-integer that reaches the integer layout", () => {
+      const codec = SchemaBinary.toCodec(Schema.Int)
+      assert.match(
+        schemaError(() => Schema.encodeUnknownSync(codec, { disableChecks: true })(1.5)).message,
+        /an integer/
+      )
+    })
+
+    it("rejects malformed number payloads", () => {
+      const codec = SchemaBinary.toCodec(Schema.Number)
+      // nine payload bytes are neither the varint nor the f64 form
+      const wide = new Uint8Array([10, 0x10, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+      assert.match(schemaError(() => Schema.decodeUnknownSync(codec)(wide)).message, /Expected f64/)
+      // a varint that never terminates inside its extent
+      const truncated = new Uint8Array([3, 0x10, 0x80, 0x80])
+      assert.match(schemaError(() => Schema.decodeUnknownSync(codec)(truncated)).message, /complete value/)
+
+      const arrayCodec = SchemaBinary.toCodec(Schema.Array(Schema.Number))
+      const run = Schema.encodeUnknownSync(arrayCodec)([1, 2, 3])
+      const unknownMode = run.slice()
+      unknownMode[3] = 2
+      assert.match(schemaError(() => Schema.decodeUnknownSync(arrayCodec)(unknownMode)).message, /Expected f64/)
+      const shortRun = run.slice(0, run.length - 1)
+      shortRun[0] -= 1
+      assert.match(schemaError(() => Schema.decodeUnknownSync(arrayCodec)(shortRun)).message, /complete value/)
     })
   })
 
@@ -310,7 +483,7 @@ describe("SchemaBinary", () => {
 
     it("delivers completed values before reporting a later failure", () => {
       const good = encode(Schema.Number, 1)
-      const bad = encode(Schema.Number, 2).slice(0, 4)
+      const bad = encode(Schema.Number, 2).slice(0, 2)
       const parser = SchemaBinary.parser(Schema.Number)
       assert.deepStrictEqual(parser.feedSync(concat(good, bad)), [1])
       assert.match(schemaError(() => parser.endSync()).message, /complete value/)
@@ -526,14 +699,15 @@ describe("SchemaBinary", () => {
 
   describe("parse options", () => {
     it("honors checks and disableChecks", () => {
-      const bytes = encode(Schema.Number, 1.5)
+      const NonNegative = Schema.Number.check(Schema.isGreaterThanOrEqualTo(0))
+      const bytes = encode(Schema.Number, -1.5)
       assert.match(
-        schemaError(() => Schema.decodeUnknownSync(SchemaBinary.toCodec(Schema.Int))(bytes)).message,
-        /integer/
+        schemaError(() => Schema.decodeUnknownSync(SchemaBinary.toCodec(NonNegative))(bytes)).message,
+        /greater than or equal to 0/
       )
 
-      const parser = SchemaBinary.parser(Schema.Int, { disableChecks: true })
-      assert.deepStrictEqual(parser.feedSync(bytes), [1.5])
+      const parser = SchemaBinary.parser(NonNegative, { disableChecks: true })
+      assert.deepStrictEqual(parser.feedSync(bytes), [-1.5])
       parser.endSync()
     })
 
@@ -549,10 +723,10 @@ describe("SchemaBinary", () => {
       })
       let Reader: Schema.Codec<Node>
       Reader = Schema.Struct({
-        value: Schema.Int,
+        value: Schema.Number.check(Schema.isGreaterThanOrEqualTo(0)),
         children: Schema.Array(Schema.suspend(() => Reader))
       })
-      const value: Node = { value: 1.5, children: [] }
+      const value: Node = { value: -1.5, children: [] }
       const parser = SchemaBinary.parser(Reader, { disableChecks: true })
 
       assert.deepStrictEqual(parser.feedSync(encode(Writer, value)), [value])


### PR DESCRIPTION
Stacked on [#7366](https://github.com/Effect-TS/effect/pull/7366) (base branch `agent/codex-engineer/58cacc24`, head `c0945662b`). Review the top commit only.

Closes EFF-778

## What changed

A `SchemaBinary` `Number` spent eight bytes on every value, including `42` and `2`. Attributing the benchmark payloads showed a third of the small record and 78% of the collections case going to f64 for values that are integral.

A `Number` now takes whichever of two forms is smaller, and the enclosing length says which:

- eight bytes are the f64 form
- one to seven bytes are a varint

Capping the varint at seven bytes is what keeps the two apart, and f64 is exact for integers well past that cap, so nothing is lost above it. Where no length is available the container defines the form: a uniform number array writes one mode byte and then a run in a single form, and a tuple slot keeps its length prefix.

The varint is **sign-magnitude** rather than plain zigzag: the low bit is the sign and the rest is the magnitude. That gives `-0` a code of its own, so the varint form covers every integral JavaScript number instead of needing an f64 escape for the one value zigzag cannot express. `NaN`, the infinities, fractional values and integers past the cap stay f64.

When the encoded-side schema proves the value is an integer (`Schema.Int`, `Schema.Natural`, any `isInt` check) the layout drops the f64 form and writes a bare varint, so an integer array costs neither a mode byte nor a length prefix per element. A checked number and an unchecked one are different wire layouts for the same value: switching a field between `Schema.Number` and `Schema.Int` is a break, like any other field type change.

This is a deliberate wire change to an unstable, unreleased module.

## Sizes

| Case | Before | After | Msgpack |
| --- | ---: | ---: | ---: |
| small record | 72 | **58** | 69 |
| nested payload | 347 | **318** | 385 |
| collections | 2553 | **1452** | 1462 |
| large repeated records | 31486 | **27646** | 51283 |

SchemaBinary is now ahead of Msgpack on all four payload sizes. Encode and decode throughput are unchanged within run-to-run noise; `benchmark/schema/SchemaBinary.md` carries the refreshed tables.

## Verification

- New public-API tests at every varint width through the seven-byte cap in both signs, the varint/f64 transition, `-0`, `NaN`, the infinities, fractional values, the safe-integer limits, and malformed number payloads, across structs, arrays, tuples, unions, the streaming parser, and schema-proven integer layouts.
- A differential harness against `c0945662b` over 27 shapes and 400 randomized values each: both implementations decode to the same value, the new one round-trips exactly across the whole number domain, the streaming parser agrees with the one-shot codec, framing errors behave identically, and single-byte corruption introduces no new failure mode. Total corpus size fell 14.7%.
- Repository lint, full typecheck, the 86 unstable encoding tests, and the full 8,675-test `effect` suite.

One pre-existing finding, unchanged by this commit and not fixed here: corrupting the int64 payload of a `Schema.DateTimeUtc` makes `DateTime.makeUnsafe` throw a `RangeError` instead of failing with a `SchemaError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
