### PR TITLE
Drop unreachable concurrency guard in iteratorEagerImpl

### DIFF
--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -4747,7 +4747,7 @@ const iterateEagerImpl = <S, A, X, E, R, E2>(options: {
     if (concurrency === 1) {
       return runSequential(state, items, 0, end)
     }
-    const orderedStep = opts?.orderedStep === true && concurrency > 1
+    const orderedStep = opts?.orderedStep === true
     let done = false
     let parentFiber: Fiber.Fiber<any, any> | undefined
     let fibers: Set<Fiber.Fiber<any, any>> | undefined


### PR DESCRIPTION
## Summary

Remove the `&& concurrency > 1` condition from the `orderedStep` check in `iterateEagerImpl`. This condition cannot become true.

The callers of this code never pass `concurrency <= 1`:

- `Effect.forEach` uses `Math.max(1, …)` to set the minimum concurrency to 1. When concurrency is 1, `Effect.forEach` uses `forEachSequential`.
- The Schema function `resolveConcurrency` sends `{ concurrency }` only when the value is more than 1. Then union parse sets `orderedStep` to `true`.

This change does not change the public API. Patch changeset included.

## Validation

All existing tests are green.

No new tests were added. The combination of `concurrency === 1` and `orderedStep: true` cannot occur in the internal code.