### PR TITLE
fix(effect): drop unreachable concurrency guard in iteratorEagerImpl

### DIFF
--- a/.changeset/thirty-forks-march.md
+++ b/.changeset/thirty-forks-march.md
@@ -1,0 +1,6 @@
+---
+"effect": patch
+---
+
+Drop unreachable concurrency guard in iteratorEagerImpl
+  

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -4747,7 +4747,7 @@ const iterateEagerImpl = <S, A, X, E, R, E2>(options: {
     if (concurrency === 1) {
       return runSequential(state, items, 0, end)
     }
-    const orderedStep = opts?.orderedStep === true && concurrency > 1
+    const orderedStep = opts?.orderedStep === true
     let done = false
     let parentFiber: Fiber.Fiber<any, any> | undefined
     let fibers: Set<Fiber.Fiber<any, any>> | undefined


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Optimization

### Drop unreachable concurrency guard in iteratorEagerImpl

Remove the `&& concurrency > 1` condition from the `orderedStep` check in `iterateEagerImpl`. This condition cannot become true.

The callers of this code never pass `concurrency <= 1`:

- `Effect.forEach` uses `Math.max(1, …)` to set the minimum concurrency to 1. When concurrency is 1, `Effect.forEach` uses `forEachSequential`.
- The Schema function `resolveConcurrency` sends `{ concurrency }` only when the value is more than 1. 

This change does not change the public API. Patch changeset included.

### Validation
All existing tests are green.

No new tests were added.

