### PR TITLE
Add context-based CLI prompt themes

### DIFF
--- a/.changeset/theme-cli-prompts.md
+++ b/.changeset/theme-cli-prompts.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Replace per-prompt prefix options with a context-based theme for CLI prompt rendering.

--- a/.changeset/theme-cli-prompts.md
+++ b/.changeset/theme-cli-prompts.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Replace per-prompt prefix options with a context-based theme for CLI prompt rendering.
+Replace per-prompt prefix options with a context-based theme for CLI prompt symbols and colors.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -182,6 +182,16 @@ export interface Theme {
   readonly passwordMask: string
   /** The separator between toggle labels. */
   readonly toggleSeparator: string
+  /** The color used for active prompt elements. */
+  readonly primaryColor: string
+  /** The color used for secondary prompt elements. */
+  readonly mutedColor: string
+  /** The color used for completed prompt markers. */
+  readonly successColor: string
+  /** The color used for validation errors. */
+  readonly errorColor: string
+  /** The color used for submitted values. */
+  readonly submittedColor: string
 }
 
 /**
@@ -597,7 +607,12 @@ const defaultTheme: Theme = {
   pointer: "❯",
   descriptionSeparator: "- ",
   passwordMask: "*",
-  toggleSeparator: "/"
+  toggleSeparator: "/",
+  primaryColor: Ansi.cyanBright,
+  mutedColor: Ansi.blackBright,
+  successColor: Ansi.green,
+  errorColor: Ansi.red,
+  submittedColor: Ansi.white
 }
 
 const windowsTheme: Theme = {
@@ -785,7 +800,8 @@ export const all: <
 }
 
 const annotateLine = (line: string): string => Ansi.annotate(line, Ansi.bold)
-const annotateErrorLine = (line: string): string => Ansi.annotate(line, Ansi.combine(Ansi.italicized, Ansi.red))
+const annotateErrorLine = (line: string, color: string): string =>
+  Ansi.annotate(line, Ansi.combine(Ansi.italicized, color))
 const annotateSymbol = (symbol: string, ...styles: Array<string | Array<string>>): string =>
   symbol.length === 0 ? "" : Ansi.annotate(symbol, ...styles)
 const separateSymbol = (symbol: string, text: string): string => symbol.length === 0 ? text : symbol + " " + text
@@ -1564,23 +1580,23 @@ const renderConfirmOutput = (
 
 const renderConfirmNextFrame = Effect.fnUntraced(function*(state: ConfirmState, options: ConfirmOptionsReq) {
   const figures = yield* getTheme(options)
-  const leadingSymbol = annotateSymbol(figures.prefix, Ansi.cyanBright)
-  const trailingSymbol = annotateSymbol(figures.pointerSmall, Ansi.blackBright)
+  const leadingSymbol = annotateSymbol(figures.prefix, figures.primaryColor)
+  const trailingSymbol = annotateSymbol(figures.pointerSmall, figures.mutedColor)
   // Marking these explicitly as present with `!` because they always will be
   // and there is really no value in adding a `DeepRequired` type helper just
   // for these internal cases
   const confirmMessage = state.value
     ? options.placeholder.defaultConfirm!
     : options.placeholder.defaultDeny!
-  const confirm = Ansi.annotate(confirmMessage, Ansi.blackBright)
+  const confirm = Ansi.annotate(confirmMessage, figures.mutedColor)
   const promptMsg = renderConfirmOutput(confirm, leadingSymbol, trailingSymbol, options)
   return Ansi.cursorHide + promptMsg
 })
 
 const renderConfirmSubmission = Effect.fnUntraced(function*(value: boolean, options: ConfirmOptionsReq) {
   const figures = yield* getTheme(options)
-  const leadingSymbol = annotateSymbol(figures.tick, Ansi.green)
-  const trailingSymbol = annotateSymbol(figures.ellipsis, Ansi.blackBright)
+  const leadingSymbol = annotateSymbol(figures.tick, figures.successColor)
+  const trailingSymbol = annotateSymbol(figures.ellipsis, figures.mutedColor)
   const confirmMessage = value ? options.label.confirm : options.label.deny
   const promptMsg = renderConfirmOutput(confirmMessage, leadingSymbol, trailingSymbol, options)
   return promptMsg + "\n"
@@ -1642,26 +1658,26 @@ const handleDateClear = (options: DateOptionsReq) => {
   })
 }
 
-const renderDateError = (state: DateState, pointer: string): string => {
+const renderDateError = (state: DateState, pointer: string, theme: Theme): string => {
   if (Option.isSome(state.error)) {
     const errorLines = state.error.value.split(NEWLINE_REGEXP)
     if (Arr.isReadonlyArrayNonEmpty(errorLines)) {
-      const prefix = annotateSymbol(pointer, Ansi.red)
-      const lines = Arr.map(errorLines, (str) => annotateErrorLine(str))
+      const prefix = annotateSymbol(pointer, theme.errorColor)
+      const lines = Arr.map(errorLines, (str) => annotateErrorLine(str, theme.errorColor))
       return Ansi.cursorSavePosition + "\n" + separateSymbol(prefix, lines.join("\n")) + Ansi.cursorRestorePosition
     }
   }
   return ""
 }
 
-const renderParts = (state: DateState, submitted: boolean = false) => {
+const renderParts = (state: DateState, theme: Theme, submitted: boolean = false) => {
   return Arr.reduce(
     state.dateParts,
     "",
     (doc, part, currentIndex) => {
       const partDoc = part.toString()
       if (currentIndex === state.cursor && !submitted) {
-        const annotation = Ansi.combine(Ansi.underlined, Ansi.cyanBright)
+        const annotation = Ansi.combine(Ansi.underlined, theme.primaryColor)
         return doc + Ansi.annotate(partDoc, annotation)
       }
       return doc + partDoc
@@ -1679,19 +1695,19 @@ const renderDateOutput = (
 
 const renderDateNextFrame = Effect.fnUntraced(function*(state: DateState, options: DateOptionsReq) {
   const figures = yield* getTheme(options)
-  const leadingSymbol = annotateSymbol(figures.prefix, Ansi.cyanBright)
-  const trailingSymbol = annotateSymbol(figures.pointerSmall, Ansi.blackBright)
-  const parts = renderParts(state)
+  const leadingSymbol = annotateSymbol(figures.prefix, figures.primaryColor)
+  const trailingSymbol = annotateSymbol(figures.pointerSmall, figures.mutedColor)
+  const parts = renderParts(state, figures)
   const promptMsg = renderDateOutput(leadingSymbol, trailingSymbol, parts, options)
-  const errorMsg = renderDateError(state, figures.pointerSmall)
+  const errorMsg = renderDateError(state, figures.pointerSmall, figures)
   return Ansi.cursorHide + promptMsg + errorMsg
 })
 
 const renderDateSubmission = Effect.fnUntraced(function*(state: DateState, options: DateOptionsReq) {
   const figures = yield* getTheme(options)
-  const leadingSymbol = annotateSymbol(figures.tick, Ansi.green)
-  const trailingSymbol = annotateSymbol(figures.ellipsis, Ansi.blackBright)
-  const parts = renderParts(state, true)
+  const leadingSymbol = annotateSymbol(figures.tick, figures.successColor)
+  const trailingSymbol = annotateSymbol(figures.ellipsis, figures.mutedColor)
+  const parts = renderParts(state, figures, true)
   const promptMsg = renderDateOutput(leadingSymbol, trailingSymbol, parts, options)
   return promptMsg + "\n"
 })
@@ -2281,9 +2297,15 @@ const handleFileClear = (options: FileOptionsReq) => {
     const isConfirming = showConfirmation(state.confirm)
     const promptText = isConfirming
       ? renderPrompt("(Y/n)", CONFIRM_MESSAGE, figures.prefix, figures.pointerSmall, { plain: true })
-      : renderPrompt(renderFileFilter(state, { plain: true }), options.message, figures.tick, figures.ellipsis, {
-        plain: true
-      })
+      : renderPrompt(
+        renderFileFilter(state, figures, { plain: true }),
+        options.message,
+        figures.tick,
+        figures.ellipsis,
+        {
+          plain: true
+        }
+      )
     const filesText = isConfirming
       ? ""
       : renderFiles(state, state.files, figures, options, { plain: true })
@@ -2349,28 +2371,33 @@ const renderPrefix = (
   if (state.cursor === currentIndex) {
     return renderOptions?.plain === true
       ? figures.pointer + prefix
-      : annotateSymbol(figures.pointer, Ansi.cyanBright) + prefix
+      : annotateSymbol(figures.pointer, figures.primaryColor) + prefix
   }
   return prefix + (figures.pointer.length === 0 ? "" : " ".repeat(figures.pointer.length))
 }
 
-const renderFileName = (file: string, isSelected: boolean, renderOptions?: RenderOptions | undefined) => {
+const renderFileName = (
+  file: string,
+  isSelected: boolean,
+  theme: Theme,
+  renderOptions?: RenderOptions | undefined
+) => {
   if (renderOptions?.plain === true) {
     return file
   }
   return isSelected
-    ? Ansi.annotate(file, Ansi.combine(Ansi.underlined, Ansi.cyanBright))
+    ? Ansi.annotate(file, Ansi.combine(Ansi.underlined, theme.primaryColor))
     : file
 }
 
-const renderFileFilter = (state: FileState, renderOptions?: RenderOptions | undefined) => {
+const renderFileFilter = (state: FileState, theme: Theme, renderOptions?: RenderOptions | undefined) => {
   const filterValue = state.query.length === 0
     ? renderOptions?.plain === true
       ? FILE_FILTER_PLACEHOLDER
-      : Ansi.annotate(FILE_FILTER_PLACEHOLDER, Ansi.blackBright)
+      : Ansi.annotate(FILE_FILTER_PLACEHOLDER, theme.mutedColor)
     : renderOptions?.plain === true
     ? state.query
-    : Ansi.annotate(state.query, Ansi.combine(Ansi.underlined, Ansi.cyanBright))
+    : Ansi.annotate(state.query, Ansi.combine(Ansi.underlined, theme.primaryColor))
   return `[${FILE_FILTER_LABEL}: ${filterValue}]`
 }
 
@@ -2385,14 +2412,14 @@ const renderFiles = (
   if (length === 0) {
     return renderOptions?.plain === true
       ? FILE_EMPTY_MESSAGE
-      : Ansi.annotate(FILE_EMPTY_MESSAGE, Ansi.blackBright)
+      : Ansi.annotate(FILE_EMPTY_MESSAGE, figures.mutedColor)
   }
   const toDisplay = entriesToDisplay(state.cursor, length, options.maxPerPage)
   const documents: Array<string> = []
   for (let index = toDisplay.startIndex; index < toDisplay.endIndex; index++) {
     const isSelected = state.cursor === index
     const prefix = renderPrefix(state, toDisplay, index, length, figures, renderOptions)
-    const fileName = renderFileName(files[index], isSelected, renderOptions)
+    const fileName = renderFileName(files[index], isSelected, figures, renderOptions)
     documents.push(prefix + fileName)
   }
   return documents.join("\n")
@@ -2404,28 +2431,28 @@ const renderFileNextFrame = Effect.fnUntraced(function*(state: FileState, option
   const currentPath = yield* resolveCurrentPath(state.path, options)
   const selectedPath = state.files[state.cursor]
   const resolvedPath = selectedPath === undefined ? currentPath : path.resolve(currentPath, selectedPath)
-  const resolvedPathMsg = Ansi.annotate(separateSymbol(figures.pointerSmall, resolvedPath), Ansi.blackBright)
+  const resolvedPathMsg = Ansi.annotate(separateSymbol(figures.pointerSmall, resolvedPath), figures.mutedColor)
 
   if (showConfirmation(state.confirm)) {
-    const leadingSymbol = annotateSymbol(figures.prefix, Ansi.cyanBright)
-    const trailingSymbol = annotateSymbol(figures.pointerSmall, Ansi.blackBright)
-    const confirm = Ansi.annotate("(Y/n)", Ansi.blackBright)
+    const leadingSymbol = annotateSymbol(figures.prefix, figures.primaryColor)
+    const trailingSymbol = annotateSymbol(figures.pointerSmall, figures.mutedColor)
+    const confirm = Ansi.annotate("(Y/n)", figures.mutedColor)
     const promptMsg = renderPrompt(confirm, CONFIRM_MESSAGE, leadingSymbol, trailingSymbol)
     return Ansi.cursorHide + promptMsg + "\n" + resolvedPathMsg
   }
-  const leadingSymbol = annotateSymbol(figures.tick, Ansi.green)
-  const trailingSymbol = annotateSymbol(figures.ellipsis, Ansi.blackBright)
-  const promptMsg = renderPrompt(renderFileFilter(state), options.message, leadingSymbol, trailingSymbol)
+  const leadingSymbol = annotateSymbol(figures.tick, figures.successColor)
+  const trailingSymbol = annotateSymbol(figures.ellipsis, figures.mutedColor)
+  const promptMsg = renderPrompt(renderFileFilter(state, figures), options.message, leadingSymbol, trailingSymbol)
   const files = renderFiles(state, state.files, figures, options)
   return Ansi.cursorHide + promptMsg + "\n" + resolvedPathMsg + "\n" + files
 })
 
 const renderFileSubmission = Effect.fnUntraced(function*(state: FileState, value: string, options: FileOptionsReq) {
   const figures = yield* getTheme(options)
-  const leadingSymbol = annotateSymbol(figures.tick, Ansi.green)
-  const trailingSymbol = annotateSymbol(figures.ellipsis, Ansi.blackBright)
-  const promptMsg = renderPrompt(renderFileFilter(state), options.message, leadingSymbol, trailingSymbol)
-  return promptMsg + " " + Ansi.annotate(value, Ansi.white) + "\n"
+  const leadingSymbol = annotateSymbol(figures.tick, figures.successColor)
+  const trailingSymbol = annotateSymbol(figures.ellipsis, figures.mutedColor)
+  const promptMsg = renderPrompt(renderFileFilter(state, figures), options.message, leadingSymbol, trailingSymbol)
+  return promptMsg + " " + Ansi.annotate(value, figures.submittedColor) + "\n"
 })
 
 const handleFileRender = (options: FileOptionsReq) => {
@@ -2603,6 +2630,7 @@ type MultiSelectState = {
 const renderMultiSelectError = (
   state: MultiSelectState,
   pointer: string,
+  theme: Theme,
   renderOptions?: RenderOptions | undefined
 ): string => {
   if (Option.isSome(state.error)) {
@@ -2612,8 +2640,8 @@ const renderMultiSelectError = (
         if (renderOptions?.plain === true) {
           return separateSymbol(pointer, errorLines.join("\n"))
         }
-        const prefix = annotateSymbol(pointer, Ansi.red)
-        const lines = Arr.map(errorLines, (str) => annotateErrorLine(str))
+        const prefix = annotateSymbol(pointer, theme.errorColor)
+        const lines = Arr.map(errorLines, (str) => annotateErrorLine(str, theme.errorColor))
         return Ansi.cursorSavePosition + "\n" + separateSymbol(prefix, lines.join("\n")) + Ansi.cursorRestorePosition
       }
     })
@@ -2633,7 +2661,7 @@ const renderChoiceDescription = <A>(
     }
     return renderOptions?.plain === true
       ? theme.descriptionSeparator + choice.description
-      : Ansi.annotate(theme.descriptionSeparator + choice.description, Ansi.blackBright)
+      : Ansi.annotate(theme.descriptionSeparator + choice.description, theme.mutedColor)
   }
   return ""
 }
@@ -2643,12 +2671,13 @@ const metaOptionsCount = 2
 const renderMultiSelectTitle = (
   title: string,
   isHighlighted: boolean,
+  theme: Theme,
   renderOptions?: RenderOptions | undefined
 ) => {
   if (renderOptions?.plain === true || !isHighlighted) {
     return title
   }
-  return Ansi.annotate(title, Ansi.combine(Ansi.underlined, Ansi.cyanBright))
+  return Ansi.annotate(title, Ansi.combine(Ansi.underlined, theme.primaryColor))
 }
 
 const renderMultiSelectChoices = <A>(
@@ -2686,7 +2715,7 @@ const renderMultiSelectChoices = <A>(
     }
     if (index < metaOptions.length) {
       // Meta options
-      const title = renderMultiSelectTitle(choice.title, isHighlighted, renderOptions)
+      const title = renderMultiSelectTitle(choice.title, isHighlighted, figures, renderOptions)
       documents.push(prefix + (prefix.length === 0 ? "" : " ") + title)
     } else {
       // Regular choices
@@ -2694,10 +2723,10 @@ const renderMultiSelectChoices = <A>(
       const isSelected = state.selectedIndices.has(choiceIndex)
       const checkbox = isSelected ? figures.checkboxOn : figures.checkboxOff
       const annotatedCheckbox = isHighlighted && renderOptions?.plain !== true
-        ? Ansi.annotate(checkbox, Ansi.cyanBright)
+        ? Ansi.annotate(checkbox, figures.primaryColor)
         : checkbox
       const selectChoice = choice as SelectChoice<A>
-      const title = renderChoiceTitle(selectChoice, isHighlighted, renderOptions)
+      const title = renderChoiceTitle(selectChoice, isHighlighted, figures, renderOptions)
       const description = renderChoiceDescription(selectChoice, isHighlighted, figures, renderOptions)
       const checkboxPrefix = checkbox.length === 0 ? "" : annotatedCheckbox + " "
       const descriptionPrefix = description.length === 0 || figures.descriptionSeparator.length > 0 ? " " : ""
@@ -2713,10 +2742,10 @@ const renderMultiSelectNextFrame = Effect.fnUntraced(
   function*<A>(state: MultiSelectState, options: SelectOptionsReq<A>) {
     const figures = yield* getTheme(options)
     const choices = renderMultiSelectChoices(state, options, figures)
-    const leadingSymbol = annotateSymbol(figures.prefix, Ansi.cyanBright)
-    const trailingSymbol = annotateSymbol(figures.pointerSmall, Ansi.blackBright)
+    const leadingSymbol = annotateSymbol(figures.prefix, figures.primaryColor)
+    const trailingSymbol = annotateSymbol(figures.pointerSmall, figures.mutedColor)
     const promptMsg = renderSelectOutput(leadingSymbol, trailingSymbol, options)
-    const error = renderMultiSelectError(state, figures.pointer)
+    const error = renderMultiSelectError(state, figures.pointer, figures)
     return Ansi.cursorHide + promptMsg + "\n" + choices + error
   }
 )
@@ -2728,10 +2757,10 @@ const renderMultiSelectSubmission = Effect.fnUntraced(
       options.choices[index].title
     )
     const selectedText = selectedChoices.join(", ")
-    const leadingSymbol = annotateSymbol(figures.tick, Ansi.green)
-    const trailingSymbol = annotateSymbol(figures.ellipsis, Ansi.blackBright)
+    const leadingSymbol = annotateSymbol(figures.tick, figures.successColor)
+    const trailingSymbol = annotateSymbol(figures.ellipsis, figures.mutedColor)
     const promptMsg = renderSelectOutput(leadingSymbol, trailingSymbol, options)
-    return promptMsg + " " + Ansi.annotate(selectedText, Ansi.white) + "\n"
+    return promptMsg + " " + Ansi.annotate(selectedText, figures.submittedColor) + "\n"
   }
 )
 
@@ -2791,7 +2820,7 @@ const handleMultiSelectClear = <A>(options: SelectOptionsReq<A>) =>
     const clearPrompt = Ansi.eraseLine + Ansi.cursorLeft
     const promptText = renderSelectOutput(figures.prefix, figures.pointerSmall, options, { plain: true })
     const choicesText = renderMultiSelectChoices(state, options, figures, { plain: true })
-    const errorText = renderMultiSelectError(state, figures.pointer, { plain: true })
+    const errorText = renderMultiSelectError(state, figures.pointer, figures, { plain: true })
     const clearOutput = clearOutputWithError(`${promptText}\n${choicesText}`, columns, errorText)
     return clearOutput + clearPrompt
   })
@@ -2861,8 +2890,10 @@ const handleNumberClear = (options: IntegerOptionsReq) => {
     const columns = yield* terminal.columns
     const figures = yield* getTheme(options)
     const resetCurrentLine = Ansi.eraseLine + Ansi.cursorLeft
-    const errorText = renderNumberError(state, figures.pointerSmall, { plain: true })
-    const promptText = renderNumberOutput(state, figures.prefix, figures.pointerSmall, options, { plain: true })
+    const errorText = renderNumberError(state, figures.pointerSmall, figures, { plain: true })
+    const promptText = renderNumberOutput(state, figures.prefix, figures.pointerSmall, options, figures, {
+      plain: true
+    })
     const clearOutput = clearOutputWithError(promptText, columns, errorText)
     return clearOutput + resetCurrentLine
   })
@@ -2871,6 +2902,7 @@ const handleNumberClear = (options: IntegerOptionsReq) => {
 const renderNumberInput = (
   state: NumberState,
   submitted: boolean,
+  theme: Theme,
   renderOptions?: RenderOptions | undefined
 ): string => {
   const value = state.value === "" ? "" : `${state.value}`
@@ -2878,14 +2910,15 @@ const renderNumberInput = (
     return value
   }
   const annotation = Option.isSome(state.error) ?
-    Ansi.red :
-    Ansi.combine(Ansi.underlined, Ansi.cyanBright)
+    theme.errorColor :
+    Ansi.combine(Ansi.underlined, theme.primaryColor)
   return Ansi.annotate(value, annotation)
 }
 
 const renderNumberError = (
   state: NumberState,
   pointer: string,
+  theme: Theme,
   renderOptions?: RenderOptions | undefined
 ) => {
   if (Option.isSome(state.error)) {
@@ -2895,8 +2928,8 @@ const renderNumberError = (
         if (renderOptions?.plain === true) {
           return separateSymbol(pointer, errorLines.join("\n"))
         }
-        const prefix = annotateSymbol(pointer, Ansi.red)
-        const lines = Arr.map(errorLines, (str) => annotateErrorLine(str))
+        const prefix = annotateSymbol(pointer, theme.errorColor)
+        const lines = Arr.map(errorLines, (str) => annotateErrorLine(str, theme.errorColor))
         return Ansi.cursorSavePosition + "\n" + separateSymbol(prefix, lines.join("\n")) + Ansi.cursorRestorePosition
       }
     })
@@ -2909,27 +2942,28 @@ const renderNumberOutput = (
   leadingSymbol: string,
   trailingSymbol: string,
   options: IntegerOptionsReq,
+  theme: Theme,
   renderOptions?: RenderOptions | undefined,
   submitted: boolean = false
 ) => {
-  const value = renderNumberInput(state, submitted, renderOptions)
+  const value = renderNumberInput(state, submitted, theme, renderOptions)
   return renderPrompt(value, options.message, leadingSymbol, trailingSymbol, renderOptions)
 }
 
 const renderNumberNextFrame = Effect.fnUntraced(function*(state: NumberState, options: IntegerOptionsReq) {
   const figures = yield* getTheme(options)
-  const leadingSymbol = annotateSymbol(figures.prefix, Ansi.cyanBright)
-  const trailingSymbol = annotateSymbol(figures.pointerSmall, Ansi.blackBright)
-  const errorMsg = renderNumberError(state, figures.pointerSmall)
-  const promptMsg = renderNumberOutput(state, leadingSymbol, trailingSymbol, options)
+  const leadingSymbol = annotateSymbol(figures.prefix, figures.primaryColor)
+  const trailingSymbol = annotateSymbol(figures.pointerSmall, figures.mutedColor)
+  const errorMsg = renderNumberError(state, figures.pointerSmall, figures)
+  const promptMsg = renderNumberOutput(state, leadingSymbol, trailingSymbol, options, figures)
   return promptMsg + errorMsg
 })
 
 const renderNumberSubmission = Effect.fnUntraced(function*(nextState: NumberState, options: IntegerOptionsReq) {
   const figures = yield* getTheme(options)
-  const leadingSymbol = annotateSymbol(figures.tick, Ansi.green)
-  const trailingSymbol = annotateSymbol(figures.ellipsis, Ansi.blackBright)
-  const promptMsg = renderNumberOutput(nextState, leadingSymbol, trailingSymbol, options, undefined, true)
+  const leadingSymbol = annotateSymbol(figures.tick, figures.successColor)
+  const trailingSymbol = annotateSymbol(figures.ellipsis, figures.mutedColor)
+  const promptMsg = renderNumberOutput(nextState, leadingSymbol, trailingSymbol, options, figures, undefined, true)
   return promptMsg + "\n"
 })
 
@@ -3193,15 +3227,16 @@ const renderSelectOutput = <A>(
 const renderAutoCompleteFilter = <A>(
   state: AutoCompleteState,
   options: AutoCompleteOptionsReq<A>,
+  theme: Theme,
   renderOptions?: RenderOptions | undefined
 ) => {
   const filterValue = state.query.length === 0
     ? renderOptions?.plain === true
       ? options.filterPlaceholder
-      : Ansi.annotate(options.filterPlaceholder, Ansi.blackBright)
+      : Ansi.annotate(options.filterPlaceholder, theme.mutedColor)
     : renderOptions?.plain === true
     ? state.query
-    : Ansi.annotate(state.query, Ansi.combine(Ansi.underlined, Ansi.cyanBright))
+    : Ansi.annotate(state.query, Ansi.combine(Ansi.underlined, theme.primaryColor))
   return `[${options.filterLabel}: ${filterValue}]`
 }
 
@@ -3210,9 +3245,10 @@ const renderAutoCompleteOutput = <A>(
   leadingSymbol: string,
   trailingSymbol: string,
   options: AutoCompleteOptionsReq<A>,
+  theme: Theme,
   renderOptions?: RenderOptions | undefined
 ) => {
-  const filter = renderAutoCompleteFilter(state, options, renderOptions)
+  const filter = renderAutoCompleteFilter(state, options, theme, renderOptions)
   return renderPrompt(filter, options.message, leadingSymbol, trailingSymbol, renderOptions)
 }
 
@@ -3236,13 +3272,13 @@ const renderChoicePrefix = <A>(
       : prefix + (figures.pointer.length === 0 ? "" : " ".repeat(figures.pointer.length))
   }
   if (choices[currentIndex].disabled) {
-    const annotation = Ansi.combine(Ansi.bold, Ansi.blackBright)
+    const annotation = Ansi.combine(Ansi.bold, figures.mutedColor)
     return state === currentIndex
       ? annotateSymbol(figures.pointer, annotation) + prefix
       : prefix + (figures.pointer.length === 0 ? "" : " ".repeat(figures.pointer.length))
   }
   return state === currentIndex
-    ? annotateSymbol(figures.pointer, Ansi.cyanBright) + prefix
+    ? annotateSymbol(figures.pointer, figures.primaryColor) + prefix
     : prefix + (figures.pointer.length === 0 ? "" : " ".repeat(figures.pointer.length))
 }
 
@@ -3268,19 +3304,20 @@ const renderAutoCompleteChoicePrefix = <A>(
   }
   const choice = options.choices[choiceIndex]
   if (choice.disabled) {
-    const annotation = Ansi.combine(Ansi.bold, Ansi.blackBright)
+    const annotation = Ansi.combine(Ansi.bold, figures.mutedColor)
     return state.index === choiceIndex
       ? annotateSymbol(figures.pointer, annotation) + prefix
       : prefix + (figures.pointer.length === 0 ? "" : " ".repeat(figures.pointer.length))
   }
   return state.index === choiceIndex
-    ? annotateSymbol(figures.pointer, Ansi.cyanBright) + prefix
+    ? annotateSymbol(figures.pointer, figures.primaryColor) + prefix
     : prefix + (figures.pointer.length === 0 ? "" : " ".repeat(figures.pointer.length))
 }
 
 const renderChoiceTitle = <A>(
   choice: SelectChoice<A>,
   isSelected: boolean,
+  theme: Theme,
   renderOptions?: RenderOptions | undefined
 ) => {
   if (renderOptions?.plain === true) {
@@ -3289,11 +3326,11 @@ const renderChoiceTitle = <A>(
   const title = choice.title
   if (isSelected) {
     return choice.disabled
-      ? Ansi.annotate(title, Ansi.combine(Ansi.underlined, Ansi.blackBright))
-      : Ansi.annotate(title, Ansi.combine(Ansi.underlined, Ansi.cyanBright))
+      ? Ansi.annotate(title, Ansi.combine(Ansi.underlined, theme.mutedColor))
+      : Ansi.annotate(title, Ansi.combine(Ansi.underlined, theme.primaryColor))
   }
   return choice.disabled
-    ? Ansi.annotate(title, Ansi.combine(Ansi.strikethrough, Ansi.blackBright))
+    ? Ansi.annotate(title, Ansi.combine(Ansi.strikethrough, theme.mutedColor))
     : title
 }
 
@@ -3310,7 +3347,7 @@ const renderSelectChoices = <A>(
     const choice = choices[index]
     const isSelected = state === index
     const prefix = renderChoicePrefix(state, choices, toDisplay, index, figures, renderOptions)
-    const title = renderChoiceTitle(choice, isSelected, renderOptions)
+    const title = renderChoiceTitle(choice, isSelected, figures, renderOptions)
     const description = renderChoiceDescription(choice, isSelected, figures, renderOptions)
     const descriptionPrefix = description.length === 0 || figures.descriptionSeparator.length > 0 ? " " : ""
     documents.push(prefix + title + descriptionPrefix + description)
@@ -3327,7 +3364,7 @@ const renderAutoCompleteChoices = <A>(
   if (state.filtered.length === 0) {
     return renderOptions?.plain === true
       ? options.emptyMessage
-      : Ansi.annotate(options.emptyMessage, Ansi.blackBright)
+      : Ansi.annotate(options.emptyMessage, figures.mutedColor)
   }
   const cursor = autoCompleteCursor(state)
   const toDisplay = entriesToDisplay(cursor, state.filtered.length, options.maxPerPage)
@@ -3337,7 +3374,7 @@ const renderAutoCompleteChoices = <A>(
     const choice = options.choices[choiceIndex]
     const isSelected = state.index === choiceIndex
     const prefix = renderAutoCompleteChoicePrefix(state, options, toDisplay, index, figures, renderOptions)
-    const title = renderChoiceTitle(choice, isSelected, renderOptions)
+    const title = renderChoiceTitle(choice, isSelected, figures, renderOptions)
     const description = renderChoiceDescription(choice, isSelected, figures, renderOptions)
     const descriptionPrefix = description.length === 0 || figures.descriptionSeparator.length > 0 ? " " : ""
     documents.push(prefix + title + descriptionPrefix + description)
@@ -3348,8 +3385,8 @@ const renderAutoCompleteChoices = <A>(
 const renderSelectNextFrame = Effect.fnUntraced(function*<A>(state: SelectState, options: SelectOptionsReq<A>) {
   const figures = yield* getTheme(options)
   const choices = renderSelectChoices(state, options, figures)
-  const leadingSymbol = annotateSymbol(figures.prefix, Ansi.cyanBright)
-  const trailingSymbol = annotateSymbol(figures.pointerSmall, Ansi.blackBright)
+  const leadingSymbol = annotateSymbol(figures.prefix, figures.primaryColor)
+  const trailingSymbol = annotateSymbol(figures.pointerSmall, figures.mutedColor)
   const promptMsg = renderSelectOutput(leadingSymbol, trailingSymbol, options)
   return Ansi.cursorHide + promptMsg + "\n" + choices
 })
@@ -3360,19 +3397,19 @@ const renderAutoCompleteNextFrame = Effect.fnUntraced(function*<A>(
 ) {
   const figures = yield* getTheme(options)
   const choices = renderAutoCompleteChoices(state, options, figures)
-  const leadingSymbol = annotateSymbol(figures.prefix, Ansi.cyanBright)
-  const trailingSymbol = annotateSymbol(figures.pointerSmall, Ansi.blackBright)
-  const promptMsg = renderAutoCompleteOutput(state, leadingSymbol, trailingSymbol, options)
+  const leadingSymbol = annotateSymbol(figures.prefix, figures.primaryColor)
+  const trailingSymbol = annotateSymbol(figures.pointerSmall, figures.mutedColor)
+  const promptMsg = renderAutoCompleteOutput(state, leadingSymbol, trailingSymbol, options, figures)
   return Ansi.cursorHide + promptMsg + "\n" + choices
 })
 
 const renderSelectSubmission = Effect.fnUntraced(function*<A>(state: SelectState, options: SelectOptionsReq<A>) {
   const figures = yield* getTheme(options)
   const selected = options.choices[state].title
-  const leadingSymbol = annotateSymbol(figures.tick, Ansi.green)
-  const trailingSymbol = annotateSymbol(figures.ellipsis, Ansi.blackBright)
+  const leadingSymbol = annotateSymbol(figures.tick, figures.successColor)
+  const trailingSymbol = annotateSymbol(figures.ellipsis, figures.mutedColor)
   const promptMsg = renderSelectOutput(leadingSymbol, trailingSymbol, options)
-  return promptMsg + " " + Ansi.annotate(selected, Ansi.white) + "\n"
+  return promptMsg + " " + Ansi.annotate(selected, figures.submittedColor) + "\n"
 })
 
 const renderAutoCompleteSubmission = Effect.fnUntraced(function*<A>(
@@ -3381,10 +3418,10 @@ const renderAutoCompleteSubmission = Effect.fnUntraced(function*<A>(
 ) {
   const figures = yield* getTheme(options)
   const selected = options.choices[state.index].title
-  const leadingSymbol = annotateSymbol(figures.tick, Ansi.green)
-  const trailingSymbol = annotateSymbol(figures.ellipsis, Ansi.blackBright)
-  const promptMsg = renderAutoCompleteOutput(state, leadingSymbol, trailingSymbol, options)
-  return promptMsg + " " + Ansi.annotate(selected, Ansi.white) + "\n"
+  const leadingSymbol = annotateSymbol(figures.tick, figures.successColor)
+  const trailingSymbol = annotateSymbol(figures.ellipsis, figures.mutedColor)
+  const promptMsg = renderAutoCompleteOutput(state, leadingSymbol, trailingSymbol, options, figures)
+  return promptMsg + " " + Ansi.annotate(selected, figures.submittedColor) + "\n"
 })
 
 const processSelectCursorUp = <A>(state: SelectState, choices: SelectOptionsReq<A>["choices"]) => {
@@ -3482,7 +3519,14 @@ const handleAutoCompleteClear = <A>(options: AutoCompleteOptionsReq<A>) =>
     const columns = yield* terminal.columns
     const figures = yield* getTheme(options)
     const clearPrompt = Ansi.eraseLine + Ansi.cursorLeft
-    const promptText = renderAutoCompleteOutput(state, figures.prefix, figures.pointerSmall, options, { plain: true })
+    const promptText = renderAutoCompleteOutput(
+      state,
+      figures.prefix,
+      figures.pointerSmall,
+      options,
+      figures,
+      { plain: true }
+    )
     const choicesText = renderAutoCompleteChoices(state, options, figures, { plain: true })
     const clearOutput = eraseText(`${promptText}\n${choicesText}`, columns)
     return clearOutput + clearPrompt
@@ -3576,7 +3620,7 @@ const renderClearScreen = Effect.fnUntraced(function*(state: TextState, options:
   const columns = yield* terminal.columns
   const figures = yield* getTheme(options)
   const resetCurrentLine = Ansi.eraseLine + Ansi.cursorLeft
-  const errorText = renderTextError(state, figures.pointerSmall, { plain: true })
+  const errorText = renderTextError(state, figures.pointerSmall, figures, { plain: true })
   const clearOutput = clearOutputWithError(
     renderTextOutput(state, figures.prefix, figures.pointerSmall, options, figures, { plain: true }),
     columns,
@@ -3612,12 +3656,12 @@ const renderTextInput = (
   }
 
   const annotation = Option.isSome(nextState.error) ?
-    Ansi.red
+    theme.errorColor
     : submitted ?
-    Ansi.white
+    theme.submittedColor
     : nextState.value.length === 0 ?
-    Ansi.blackBright
-    : Ansi.combine(Ansi.underlined, Ansi.cyanBright)
+    theme.mutedColor
+    : Ansi.combine(Ansi.underlined, theme.primaryColor)
 
   switch (options.type) {
     case "hidden": {
@@ -3635,6 +3679,7 @@ const renderTextInput = (
 const renderTextError = (
   nextState: TextState,
   pointer: string,
+  theme: Theme,
   renderOptions?: RenderOptions | undefined
 ): string => {
   if (Option.isSome(nextState.error)) {
@@ -3644,8 +3689,8 @@ const renderTextError = (
         if (renderOptions?.plain === true) {
           return separateSymbol(pointer, errorLines.join("\n"))
         }
-        const prefix = annotateSymbol(pointer, Ansi.red)
-        const lines = Arr.map(errorLines, (str) => annotateErrorLine(str))
+        const prefix = annotateSymbol(pointer, theme.errorColor)
+        const lines = Arr.map(errorLines, (str) => annotateErrorLine(str, theme.errorColor))
         return Ansi.cursorSavePosition + "\n" + separateSymbol(prefix, lines.join("\n")) + Ansi.cursorRestorePosition
       }
     })
@@ -3668,18 +3713,18 @@ const renderTextOutput = (
 
 const renderTextNextFrame = Effect.fnUntraced(function*(state: TextState, options: TextOptionsReq) {
   const figures = yield* getTheme(options)
-  const leadingSymbol = annotateSymbol(figures.prefix, Ansi.cyanBright)
-  const trailingSymbol = annotateSymbol(figures.pointerSmall, Ansi.blackBright)
+  const leadingSymbol = annotateSymbol(figures.prefix, figures.primaryColor)
+  const trailingSymbol = annotateSymbol(figures.pointerSmall, figures.mutedColor)
   const promptMsg = renderTextOutput(state, leadingSymbol, trailingSymbol, options, figures)
-  const errorMsg = renderTextError(state, figures.pointerSmall)
+  const errorMsg = renderTextError(state, figures.pointerSmall, figures)
   const offset = state.cursor - state.value.length
   return promptMsg + errorMsg + Ansi.cursorMove(offset)
 })
 
 const renderTextSubmission = Effect.fnUntraced(function*(state: TextState, options: TextOptionsReq) {
   const figures = yield* getTheme(options)
-  const leadingSymbol = annotateSymbol(figures.tick, Ansi.green)
-  const trailingSymbol = annotateSymbol(figures.ellipsis, Ansi.blackBright)
+  const leadingSymbol = annotateSymbol(figures.tick, figures.successColor)
+  const trailingSymbol = annotateSymbol(figures.ellipsis, figures.mutedColor)
   const promptMsg = renderTextOutput(state, leadingSymbol, trailingSymbol, options, figures, undefined, true)
   return promptMsg + "\n"
 })
@@ -3886,8 +3931,11 @@ const renderToggle = (
   theme: Theme,
   submitted: boolean = false
 ) => {
-  const separator = annotateSymbol(theme.toggleSeparator, Ansi.blackBright)
-  const selectedAnnotation = Ansi.combine(Ansi.underlined, submitted ? Ansi.white : Ansi.cyanBright)
+  const separator = annotateSymbol(theme.toggleSeparator, theme.mutedColor)
+  const selectedAnnotation = Ansi.combine(
+    Ansi.underlined,
+    submitted ? theme.submittedColor : theme.primaryColor
+  )
   const inactive = value
     ? options.inactive
     : Ansi.annotate(options.inactive, selectedAnnotation)
@@ -3908,8 +3956,8 @@ const renderToggleOutput = (
 
 const renderToggleNextFrame = Effect.fnUntraced(function*(state: ToggleState, options: ToggleOptionsReq) {
   const figures = yield* getTheme(options)
-  const leadingSymbol = annotateSymbol(figures.prefix, Ansi.cyanBright)
-  const trailingSymbol = annotateSymbol(figures.pointerSmall, Ansi.blackBright)
+  const leadingSymbol = annotateSymbol(figures.prefix, figures.primaryColor)
+  const trailingSymbol = annotateSymbol(figures.pointerSmall, figures.mutedColor)
   const toggle = renderToggle(state, options, figures)
   const promptMsg = renderToggleOutput(toggle, leadingSymbol, trailingSymbol, options)
   return Ansi.cursorHide + promptMsg
@@ -3917,8 +3965,8 @@ const renderToggleNextFrame = Effect.fnUntraced(function*(state: ToggleState, op
 
 const renderToggleSubmission = Effect.fnUntraced(function*(value: boolean, options: ToggleOptionsReq) {
   const figures = yield* getTheme(options)
-  const leadingSymbol = annotateSymbol(figures.tick, Ansi.green)
-  const trailingSymbol = annotateSymbol(figures.ellipsis, Ansi.blackBright)
+  const leadingSymbol = annotateSymbol(figures.tick, figures.successColor)
+  const trailingSymbol = annotateSymbol(figures.ellipsis, figures.mutedColor)
   const toggle = renderToggle(value, options, figures, true)
   const promptMsg = renderToggleOutput(toggle, leadingSymbol, trailingSymbol, options)
   return promptMsg + "\n"

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -205,6 +205,8 @@ export interface ThemeOptions {
   readonly theme?: Partial<Theme>
 }
 
+type OptionsReq<A> = Required<Omit<A, "theme">> & ThemeOptions
+
 /**
  * Options for a confirmation prompt that asks the user to choose a boolean
  * yes/no value.
@@ -625,16 +627,28 @@ const windowsTheme: Theme = {
   pointer: ">"
 }
 
+const mergeTheme = (base: Theme, overrides: Partial<Theme> | undefined): Theme => {
+  if (overrides === undefined) {
+    return base
+  }
+  const theme = { ...base }
+  for (const key of Object.keys(overrides) as Array<keyof Theme>) {
+    const value = overrides[key]
+    if (value !== undefined) {
+      Object.assign(theme, { [key]: value })
+    }
+  }
+  return theme
+}
+
 /**
  * Creates a prompt theme using the current platform defaults.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const makeTheme = (options?: Partial<Theme>): Theme => ({
-  ...(process.platform === "win32" ? windowsTheme : defaultTheme),
-  ...options
-})
+export const makeTheme = (options?: Partial<Theme>): Theme =>
+  mergeTheme(process.platform === "win32" ? windowsTheme : defaultTheme, options)
 
 /**
  * Context reference for the theme used by built-in prompts.
@@ -649,11 +663,8 @@ export const Theme: Context.Reference<Theme> = Context.Reference("effect/unstabl
   defaultValue: makeTheme
 })
 
-/** @internal */
-export const platformFigures = Theme
-
 const getTheme = (options: ThemeOptions): Effect.Effect<Theme> =>
-  Effect.map(Theme, (theme) => ({ ...theme, ...options.theme }))
+  Effect.map(Theme, (theme) => mergeTheme(theme, options.theme))
 
 /**
  * Type alias for any `Prompt`, regardless of its output type.
@@ -805,6 +816,16 @@ const annotateErrorLine = (line: string, color: string): string =>
 const annotateSymbol = (symbol: string, ...styles: Array<string | Array<string>>): string =>
   symbol.length === 0 ? "" : Ansi.annotate(symbol, ...styles)
 const separateSymbol = (symbol: string, text: string): string => symbol.length === 0 ? text : symbol + " " + text
+const renderPagingPrefix = (theme: Theme, showArrowUp: boolean, showArrowDown: boolean): string => {
+  const width = Math.max(theme.arrowUp.length, theme.arrowDown.length)
+  if (showArrowUp) {
+    return theme.arrowUp.padEnd(width)
+  }
+  if (showArrowDown) {
+    return theme.arrowDown.padEnd(width)
+  }
+  return " ".repeat(width)
+}
 
 /**
  * Creates a confirmation prompt that asks the user to choose a boolean yes/no
@@ -825,10 +846,9 @@ const separateSymbol = (symbol: string, text: string): string => symbol.length =
  * @since 4.0.0
  */
 export const confirm = (options: ConfirmOptions): Prompt<boolean> => {
-  const opts: Required<ConfirmOptions> = {
+  const opts: ConfirmOptionsReq = {
     initial: false,
     ...options,
-    theme: options.theme ?? {},
     label: {
       confirm: "yes",
       deny: "no",
@@ -921,12 +941,11 @@ export const custom: {
  * @since 4.0.0
  */
 export const date = (options: DateOptions): Prompt<Date> => {
-  const opts: Required<DateOptions> = {
+  const opts: DateOptionsReq = {
     initial: new Date(),
     dateMask: "YYYY-MM-DD HH:mm:ss",
     validate: Effect.succeed,
     ...options,
-    theme: options.theme ?? {},
     locales: {
       ...defaultLocales,
       ...options.locales
@@ -961,9 +980,9 @@ export const date = (options: DateOptions): Prompt<Date> => {
  */
 export const file = (options: FileOptions = {}): Prompt<string> => {
   const opts: FileOptionsReq = {
+    ...options,
     type: options.type ?? "file",
     message: options.message ?? `Choose a file`,
-    theme: options.theme ?? {},
     startingPath: Option.fromUndefinedOr(options.startingPath),
     default: Option.fromUndefinedOr(options.default),
     maxPerPage: options.maxPerPage ?? 10,
@@ -1052,8 +1071,7 @@ export const float = (options: FloatOptions): Prompt<number> => {
       }
       return Effect.succeed(n)
     },
-    ...options,
-    theme: options.theme ?? {}
+    ...options
   }
   const initialValue = options.default === undefined ? "" : `${opts.default}`
   const initialState: NumberState = {
@@ -1105,8 +1123,7 @@ export const integer = (options: IntegerOptions): Prompt<number> => {
       }
       return Effect.succeed(n)
     },
-    ...options,
-    theme: options.theme ?? {}
+    ...options
   }
   const initialValue = options.default === undefined ? "" : `${opts.default}`
   const initialState: NumberState = {
@@ -1223,8 +1240,7 @@ const getSelectInitialIndex = <A>(choices: ReadonlyArray<SelectChoice<A>>): numb
 export const select = <const A>(options: SelectOptions<A>): Prompt<A> => {
   const opts: SelectOptionsReq<A> = {
     maxPerPage: 10,
-    ...options,
-    theme: options.theme ?? {}
+    ...options
   }
   const initialIndex = getSelectInitialIndex(opts.choices)
   return custom(initialIndex, {
@@ -1263,8 +1279,7 @@ export const autoComplete = <const A>(options: AutoCompleteOptions<A>): Prompt<A
     filterLabel: "filter",
     filterPlaceholder: "type to filter",
     emptyMessage: "No matches",
-    ...options,
-    theme: options.theme ?? {}
+    ...options
   }
   const initialIndex = getSelectInitialIndex(opts.choices)
   const filtered = filterAutoCompleteChoices(opts.choices, "")
@@ -1302,8 +1317,7 @@ export const multiSelect = <const A>(
 ): Prompt<Array<A>> => {
   const opts: SelectOptionsReq<A> & MultiSelectOptionsReq = {
     maxPerPage: 10,
-    ...options,
-    theme: options.theme ?? {}
+    ...options
   }
   // Seed initial selection from choices marked as selected: true
   const initialSelected = new Set<number>()
@@ -1362,8 +1376,7 @@ export const toggle = (options: ToggleOptions): Prompt<boolean> => {
     initial: false,
     active: "on",
     inactive: "off",
-    ...options,
-    theme: options.theme ?? {}
+    ...options
   }
   return custom(opts.initial, {
     render: handleToggleRender(opts),
@@ -1539,7 +1552,7 @@ const clearOutputWithError = (outputText: string, columns: number, errorText?: s
   return eraseText(outputText, columns)
 }
 
-interface ConfirmOptionsReq extends Required<ConfirmOptions> {}
+interface ConfirmOptionsReq extends OptionsReq<ConfirmOptions> {}
 
 interface ConfirmState {
   readonly value: boolean
@@ -1629,7 +1642,7 @@ const handleConfirmProcess = (input: Terminal.UserInput, defaultValue: boolean) 
   return Effect.succeed(Action.Beep())
 }
 
-interface DateOptionsReq extends Required<DateOptions> {}
+interface DateOptionsReq extends OptionsReq<DateOptions> {}
 
 interface DateState {
   readonly typed: string
@@ -2178,7 +2191,7 @@ class Meridiem extends DatePart {
   }
 }
 
-interface FileOptionsReq extends Required<Omit<FileOptions, "startingPath" | "default">> {
+interface FileOptionsReq extends OptionsReq<Omit<FileOptions, "startingPath" | "default">> {
   readonly startingPath: Option.Option<string>
   readonly default: Option.Option<string>
 }
@@ -2359,21 +2372,20 @@ const renderPrefix = (
   toDisplay: { readonly startIndex: number; readonly endIndex: number },
   currentIndex: number,
   length: number,
-  figures: Effect.Success<typeof platformFigures>,
+  figures: Theme,
   renderOptions?: RenderOptions | undefined
 ) => {
-  let prefix = figures.arrowUp.length === 0 && figures.arrowDown.length === 0 ? "" : " "
-  if (currentIndex === toDisplay.startIndex && toDisplay.startIndex > 0) {
-    prefix = figures.arrowUp
-  } else if (currentIndex === toDisplay.endIndex - 1 && toDisplay.endIndex < length) {
-    prefix = figures.arrowDown
-  }
+  const prefix = renderPagingPrefix(
+    figures,
+    currentIndex === toDisplay.startIndex && toDisplay.startIndex > 0,
+    currentIndex === toDisplay.endIndex - 1 && toDisplay.endIndex < length
+  )
   if (state.cursor === currentIndex) {
     return renderOptions?.plain === true
       ? figures.pointer + prefix
       : annotateSymbol(figures.pointer, figures.primaryColor) + prefix
   }
-  return prefix + (figures.pointer.length === 0 ? "" : " ".repeat(figures.pointer.length))
+  return prefix + " ".repeat(figures.pointer.length)
 }
 
 const renderFileName = (
@@ -2404,7 +2416,7 @@ const renderFileFilter = (state: FileState, theme: Theme, renderOptions?: Render
 const renderFiles = (
   state: FileState,
   files: ReadonlyArray<string>,
-  figures: Effect.Success<typeof platformFigures>,
+  figures: Theme,
   options: FileOptionsReq,
   renderOptions?: RenderOptions | undefined
 ) => {
@@ -2618,7 +2630,7 @@ const handleFileProcess = (options: FileOptionsReq) => {
   })
 }
 
-interface SelectOptionsReq<A> extends Required<SelectOptions<A>> {}
+interface SelectOptionsReq<A> extends OptionsReq<SelectOptions<A>> {}
 interface MultiSelectOptionsReq extends MultiSelectOptions {}
 
 type MultiSelectState = {
@@ -2683,10 +2695,11 @@ const renderMultiSelectTitle = (
 const renderMultiSelectChoices = <A>(
   state: MultiSelectState,
   options: SelectOptionsReq<A> & MultiSelectOptionsReq,
-  figures: Effect.Success<typeof platformFigures>,
+  figures: Theme,
   renderOptions?: RenderOptions | undefined
 ) => {
   const choices = options.choices
+  const checkboxWidth = Math.max(figures.checkboxOn.length, figures.checkboxOff.length)
   const selectableCount = choices.filter((choice) => !choice.disabled).length
   const selectedCount = Array.from(state.selectedIndices).filter((index) => !choices[index].disabled).length
   const allSelected = selectedCount === selectableCount
@@ -2707,12 +2720,11 @@ const renderMultiSelectChoices = <A>(
   for (let index = toDisplay.startIndex; index < toDisplay.endIndex; index++) {
     const choice = allChoices[index]
     const isHighlighted = state.index === index
-    let prefix = figures.arrowUp.length === 0 && figures.arrowDown.length === 0 ? "" : " "
-    if (index === toDisplay.startIndex && toDisplay.startIndex > 0) {
-      prefix = figures.arrowUp
-    } else if (index === toDisplay.endIndex - 1 && toDisplay.endIndex < allChoices.length) {
-      prefix = figures.arrowDown
-    }
+    const prefix = renderPagingPrefix(
+      figures,
+      index === toDisplay.startIndex && toDisplay.startIndex > 0,
+      index === toDisplay.endIndex - 1 && toDisplay.endIndex < allChoices.length
+    )
     if (index < metaOptions.length) {
       // Meta options
       const title = renderMultiSelectTitle(choice.title, isHighlighted, figures, renderOptions)
@@ -2728,10 +2740,11 @@ const renderMultiSelectChoices = <A>(
       const selectChoice = choice as SelectChoice<A>
       const title = renderChoiceTitle(selectChoice, isHighlighted, figures, renderOptions)
       const description = renderChoiceDescription(selectChoice, isHighlighted, figures, renderOptions)
-      const checkboxPrefix = checkbox.length === 0 ? "" : annotatedCheckbox + " "
-      const descriptionPrefix = description.length === 0 || figures.descriptionSeparator.length > 0 ? " " : ""
+      const checkboxPrefix = checkboxWidth === 0
+        ? ""
+        : annotatedCheckbox + " ".repeat(checkboxWidth - checkbox.length + 1)
       documents.push(
-        prefix + (prefix.length === 0 ? "" : " ") + checkboxPrefix + title + descriptionPrefix + description
+        prefix + (prefix.length === 0 ? "" : " ") + checkboxPrefix + title + " " + description
       )
     }
   }
@@ -2875,8 +2888,8 @@ const handleMultiSelectRender = <A>(options: SelectOptionsReq<A>) => {
   }
 }
 
-interface IntegerOptionsReq extends Required<IntegerOptions> {}
-interface FloatOptionsReq extends Required<FloatOptions> {}
+interface IntegerOptionsReq extends OptionsReq<IntegerOptions> {}
+interface FloatOptionsReq extends OptionsReq<FloatOptions> {}
 
 interface NumberState {
   readonly cursor: number
@@ -3185,8 +3198,8 @@ type AutoCompleteState = {
   readonly filtered: ReadonlyArray<number>
 }
 
-interface SelectOptionsReq<A> extends Required<SelectOptions<A>> {}
-interface AutoCompleteOptionsReq<A> extends Required<AutoCompleteOptions<A>> {}
+interface SelectOptionsReq<A> extends OptionsReq<SelectOptions<A>> {}
+interface AutoCompleteOptionsReq<A> extends OptionsReq<AutoCompleteOptions<A>> {}
 
 const filterAutoCompleteChoices = <A>(choices: ReadonlyArray<SelectChoice<A>>, query: string) => {
   const normalizedQuery = query.toLowerCase()
@@ -3257,29 +3270,28 @@ const renderChoicePrefix = <A>(
   choices: SelectOptionsReq<A>["choices"],
   toDisplay: { readonly startIndex: number; readonly endIndex: number },
   currentIndex: number,
-  figures: Effect.Success<typeof platformFigures>,
+  figures: Theme,
   renderOptions?: RenderOptions | undefined
 ) => {
-  let prefix = figures.arrowUp.length === 0 && figures.arrowDown.length === 0 ? "" : " "
-  if (currentIndex === toDisplay.startIndex && toDisplay.startIndex > 0) {
-    prefix = figures.arrowUp
-  } else if (currentIndex === toDisplay.endIndex - 1 && toDisplay.endIndex < choices.length) {
-    prefix = figures.arrowDown
-  }
+  const prefix = renderPagingPrefix(
+    figures,
+    currentIndex === toDisplay.startIndex && toDisplay.startIndex > 0,
+    currentIndex === toDisplay.endIndex - 1 && toDisplay.endIndex < choices.length
+  )
   if (renderOptions?.plain === true) {
     return state === currentIndex
       ? figures.pointer + prefix
-      : prefix + (figures.pointer.length === 0 ? "" : " ".repeat(figures.pointer.length))
+      : prefix + " ".repeat(figures.pointer.length)
   }
   if (choices[currentIndex].disabled) {
     const annotation = Ansi.combine(Ansi.bold, figures.mutedColor)
     return state === currentIndex
       ? annotateSymbol(figures.pointer, annotation) + prefix
-      : prefix + (figures.pointer.length === 0 ? "" : " ".repeat(figures.pointer.length))
+      : prefix + " ".repeat(figures.pointer.length)
   }
   return state === currentIndex
     ? annotateSymbol(figures.pointer, figures.primaryColor) + prefix
-    : prefix + (figures.pointer.length === 0 ? "" : " ".repeat(figures.pointer.length))
+    : prefix + " ".repeat(figures.pointer.length)
 }
 
 const renderAutoCompleteChoicePrefix = <A>(
@@ -3287,31 +3299,30 @@ const renderAutoCompleteChoicePrefix = <A>(
   options: AutoCompleteOptionsReq<A>,
   toDisplay: { readonly startIndex: number; readonly endIndex: number },
   currentIndex: number,
-  figures: Effect.Success<typeof platformFigures>,
+  figures: Theme,
   renderOptions?: RenderOptions | undefined
 ) => {
-  let prefix = figures.arrowUp.length === 0 && figures.arrowDown.length === 0 ? "" : " "
-  if (currentIndex === toDisplay.startIndex && toDisplay.startIndex > 0) {
-    prefix = figures.arrowUp
-  } else if (currentIndex === toDisplay.endIndex - 1 && toDisplay.endIndex < state.filtered.length) {
-    prefix = figures.arrowDown
-  }
+  const prefix = renderPagingPrefix(
+    figures,
+    currentIndex === toDisplay.startIndex && toDisplay.startIndex > 0,
+    currentIndex === toDisplay.endIndex - 1 && toDisplay.endIndex < state.filtered.length
+  )
   const choiceIndex = state.filtered[currentIndex]
   if (renderOptions?.plain === true) {
     return state.index === choiceIndex
       ? figures.pointer + prefix
-      : prefix + (figures.pointer.length === 0 ? "" : " ".repeat(figures.pointer.length))
+      : prefix + " ".repeat(figures.pointer.length)
   }
   const choice = options.choices[choiceIndex]
   if (choice.disabled) {
     const annotation = Ansi.combine(Ansi.bold, figures.mutedColor)
     return state.index === choiceIndex
       ? annotateSymbol(figures.pointer, annotation) + prefix
-      : prefix + (figures.pointer.length === 0 ? "" : " ".repeat(figures.pointer.length))
+      : prefix + " ".repeat(figures.pointer.length)
   }
   return state.index === choiceIndex
     ? annotateSymbol(figures.pointer, figures.primaryColor) + prefix
-    : prefix + (figures.pointer.length === 0 ? "" : " ".repeat(figures.pointer.length))
+    : prefix + " ".repeat(figures.pointer.length)
 }
 
 const renderChoiceTitle = <A>(
@@ -3337,7 +3348,7 @@ const renderChoiceTitle = <A>(
 const renderSelectChoices = <A>(
   state: SelectState,
   options: SelectOptionsReq<A>,
-  figures: Effect.Success<typeof platformFigures>,
+  figures: Theme,
   renderOptions?: RenderOptions | undefined
 ) => {
   const choices = options.choices
@@ -3349,8 +3360,7 @@ const renderSelectChoices = <A>(
     const prefix = renderChoicePrefix(state, choices, toDisplay, index, figures, renderOptions)
     const title = renderChoiceTitle(choice, isSelected, figures, renderOptions)
     const description = renderChoiceDescription(choice, isSelected, figures, renderOptions)
-    const descriptionPrefix = description.length === 0 || figures.descriptionSeparator.length > 0 ? " " : ""
-    documents.push(prefix + title + descriptionPrefix + description)
+    documents.push(prefix + title + " " + description)
   }
   return documents.join("\n")
 }
@@ -3358,7 +3368,7 @@ const renderSelectChoices = <A>(
 const renderAutoCompleteChoices = <A>(
   state: AutoCompleteState,
   options: AutoCompleteOptionsReq<A>,
-  figures: Effect.Success<typeof platformFigures>,
+  figures: Theme,
   renderOptions?: RenderOptions | undefined
 ) => {
   if (state.filtered.length === 0) {
@@ -3376,8 +3386,7 @@ const renderAutoCompleteChoices = <A>(
     const prefix = renderAutoCompleteChoicePrefix(state, options, toDisplay, index, figures, renderOptions)
     const title = renderChoiceTitle(choice, isSelected, figures, renderOptions)
     const description = renderChoiceDescription(choice, isSelected, figures, renderOptions)
-    const descriptionPrefix = description.length === 0 || figures.descriptionSeparator.length > 0 ? " " : ""
-    documents.push(prefix + title + descriptionPrefix + description)
+    documents.push(prefix + title + " " + description)
   }
   return documents.join("\n")
 }
@@ -3602,7 +3611,7 @@ const handleAutoCompleteProcess = <A>(options: AutoCompleteOptionsReq<A>) => {
   }
 }
 
-interface TextOptionsReq extends Required<TextOptions> {
+interface TextOptionsReq extends OptionsReq<TextOptions> {
   /**
    * The type of the text option.
    */
@@ -3652,6 +3661,8 @@ const renderTextInput = (
   }
 
   if (text.length === 0) {
+    // Avoid wrapping an empty value in ANSI codes, which would make renderPrompt
+    // add spacing for content that occupies no terminal columns.
     return ""
   }
 
@@ -3717,7 +3728,8 @@ const renderTextNextFrame = Effect.fnUntraced(function*(state: TextState, option
   const trailingSymbol = annotateSymbol(figures.pointerSmall, figures.mutedColor)
   const promptMsg = renderTextOutput(state, leadingSymbol, trailingSymbol, options, figures)
   const errorMsg = renderTextError(state, figures.pointerSmall, figures)
-  const offset = state.cursor - state.value.length
+  const cursorWidth = options.type === "password" ? figures.passwordMask.length : 1
+  const offset = (state.cursor - state.value.length) * cursorWidth
   return promptMsg + errorMsg + Ansi.cursorMove(offset)
 })
 
@@ -3892,8 +3904,7 @@ const basePrompt = (
     default: "",
     type,
     validate: Effect.succeed,
-    ...options,
-    theme: options.theme ?? {}
+    ...options
   }
 
   const initialState: TextState = {
@@ -3908,7 +3919,7 @@ const basePrompt = (
   })
 }
 
-interface ToggleOptionsReq extends Required<ToggleOptions> {}
+interface ToggleOptionsReq extends OptionsReq<ToggleOptions> {}
 
 type ToggleState = boolean
 

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -13,6 +13,7 @@
 import * as Arr from "../../Array.ts"
 import type { NoSuchElementError } from "../../Cause.ts"
 import type * as Cause from "../../Cause.ts"
+import * as Context from "../../Context.ts"
 import * as Data from "../../Data.ts"
 import * as Effect from "../../Effect.ts"
 import * as Effectable from "../../Effectable.ts"
@@ -148,21 +149,64 @@ export interface Handlers<State, Output, Input = Terminal.UserInput> {
 }
 
 /**
+ * Defines the symbols used to render built-in prompts.
+ *
+ * Set a symbol to an empty string to omit both the symbol and its adjacent
+ * spacing.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface Theme {
+  /** The leading symbol on an active prompt line. */
+  readonly prefix: string
+  /** The marker for the highlighted choice. */
+  readonly pointer: string
+  /** The trailing prompt and validation marker. */
+  readonly pointerSmall: string
+  /** The marker shown when a prompt has been submitted. */
+  readonly ellipsis: string
+  /** The leading symbol on a completed prompt line. */
+  readonly tick: string
+  /** The marker indicating choices above the current page. */
+  readonly arrowUp: string
+  /** The marker indicating choices below the current page. */
+  readonly arrowDown: string
+  /** The marker for a selected multi-select choice. */
+  readonly checkboxOn: string
+  /** The marker for an unselected multi-select choice. */
+  readonly checkboxOff: string
+  /** The separator between a choice and its description. */
+  readonly descriptionSeparator: string
+  /** The character used to mask password input. */
+  readonly passwordMask: string
+  /** The separator between toggle labels. */
+  readonly toggleSeparator: string
+}
+
+/**
+ * Options shared by built-in prompts that support theme overrides.
+ *
+ * @category options
+ * @since 4.0.0
+ */
+export interface ThemeOptions {
+  /** Overrides the context theme for this prompt. */
+  readonly theme?: Partial<Theme>
+}
+
+/**
  * Options for a confirmation prompt that asks the user to choose a boolean
  * yes/no value.
  *
  * @category options
  * @since 4.0.0
  */
-export interface ConfirmOptions {
+export interface ConfirmOptions extends ThemeOptions {
   /**
    * The message to display in the prompt.
    */
   readonly message: string
-  /**
-   * The single-column prefix to display at the start of the prompt (defaults to `"?"`).
-   */
-  readonly prefix?: string
   /**
    * The initial value of the confirm prompt (defaults to `false`).
    */
@@ -204,15 +248,11 @@ export interface ConfirmOptions {
  * @category options
  * @since 4.0.0
  */
-export interface DateOptions {
+export interface DateOptions extends ThemeOptions {
   /**
    * The message to display in the prompt.
    */
   readonly message: string
-  /**
-   * The single-column prefix to display at the start of the prompt (defaults to `"?"`).
-   */
-  readonly prefix?: string
   /**
    * The initial date value to display in the prompt (defaults to the current
    * date).
@@ -283,15 +323,11 @@ export interface DateOptions {
  * @category options
  * @since 4.0.0
  */
-export interface IntegerOptions {
+export interface IntegerOptions extends ThemeOptions {
   /**
    * The message to display in the prompt.
    */
   readonly message: string
-  /**
-   * The single-column prefix to display at the start of the prompt (defaults to `"?"`).
-   */
-  readonly prefix?: string
   /**
    * The default value of the integer prompt.
    */
@@ -364,7 +400,7 @@ export interface ListOptions extends TextOptions {
  * @category options
  * @since 4.0.0
  */
-export interface FileOptions {
+export interface FileOptions extends ThemeOptions {
   /**
    * The path type that will be selected, defaulting to `"file"`.
    */
@@ -373,11 +409,6 @@ export interface FileOptions {
    * The message to display in the prompt, defaulting to `"Choose a file"`.
    */
   readonly message?: string
-  /**
-   * The single-column prefix to display at the start of the directory traversal
-   * confirmation prompt (defaults to `"?"`).
-   */
-  readonly prefix?: string
   /**
    * Where the user will initially be prompted to select files from, defaulting
    * to the current working directory.
@@ -405,15 +436,11 @@ export interface FileOptions {
  * @category options
  * @since 4.0.0
  */
-export interface SelectOptions<A> {
+export interface SelectOptions<A> extends ThemeOptions {
   /**
    * The message to display in the prompt.
    */
   readonly message: string
-  /**
-   * The single-column prefix to display at the start of the prompt (defaults to `"?"`).
-   */
-  readonly prefix?: string
   /**
    * The choices to display to the user.
    */
@@ -514,15 +541,11 @@ export interface SelectChoice<A> {
  * @category options
  * @since 4.0.0
  */
-export interface TextOptions {
+export interface TextOptions extends ThemeOptions {
   /**
    * The message to display in the prompt.
    */
   readonly message: string
-  /**
-   * The single-column prefix to display at the start of the prompt (defaults to `"?"`).
-   */
-  readonly prefix?: string
   /**
    * The default value of the text option.
    */
@@ -541,15 +564,11 @@ export interface TextOptions {
  * @category options
  * @since 4.0.0
  */
-export interface ToggleOptions {
+export interface ToggleOptions extends ThemeOptions {
   /**
    * The message to display in the prompt.
    */
   readonly message: string
-  /**
-   * The single-column prefix to display at the start of the prompt (defaults to `"?"`).
-   */
-  readonly prefix?: string
   /**
    * The intitial value of the toggle prompt (defaults to `false`).
    */
@@ -566,47 +585,60 @@ export interface ToggleOptions {
   readonly inactive?: string
 }
 
-const defaultFigures = {
+const defaultTheme: Theme = {
+  prefix: "?",
   arrowUp: "↑",
   arrowDown: "↓",
-  arrowLeft: "←",
-  arrowRight: "→",
-  radioOn: "◉",
-  radioOff: "◯",
   checkboxOn: "☒",
   checkboxOff: "☐",
   tick: "✔",
-  cross: "✖",
   ellipsis: "…",
   pointerSmall: "›",
-  line: "─",
-  pointer: "❯"
+  pointer: "❯",
+  descriptionSeparator: "- ",
+  passwordMask: "*",
+  toggleSeparator: "/"
 }
 
-const DEFAULT_PREFIX = "?"
-
-const windowsFigures = {
-  arrowUp: defaultFigures.arrowUp,
-  arrowDown: defaultFigures.arrowDown,
-  arrowLeft: defaultFigures.arrowLeft,
-  arrowRight: defaultFigures.arrowRight,
-  radioOn: "(*)",
-  radioOff: "( )",
+const windowsTheme: Theme = {
+  ...defaultTheme,
   checkboxOn: "[*]",
   checkboxOff: "[ ]",
   tick: "√",
-  cross: "×",
   ellipsis: "...",
   pointerSmall: "»",
-  line: "─",
   pointer: ">"
 }
 
+/**
+ * Creates a prompt theme using the current platform defaults.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const makeTheme = (options?: Partial<Theme>): Theme => ({
+  ...(process.platform === "win32" ? windowsTheme : defaultTheme),
+  ...options
+})
+
+/**
+ * Context reference for the theme used by built-in prompts.
+ *
+ * Provide this reference once to theme every prompt in an application. A
+ * prompt's `theme` option takes precedence over the context value.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Theme: Context.Reference<Theme> = Context.Reference("effect/unstable/cli/Prompt/Theme", {
+  defaultValue: makeTheme
+})
+
 /** @internal */
-export const platformFigures = Effect.map(
-  Effect.sync(() => process.platform === "win32"),
-  (isWindows) => isWindows ? windowsFigures : defaultFigures
-)
+export const platformFigures = Theme
+
+const getTheme = (options: ThemeOptions): Effect.Effect<Theme> =>
+  Effect.map(Theme, (theme) => ({ ...theme, ...options.theme }))
 
 /**
  * Type alias for any `Prompt`, regardless of its output type.
@@ -754,6 +786,9 @@ export const all: <
 
 const annotateLine = (line: string): string => Ansi.annotate(line, Ansi.bold)
 const annotateErrorLine = (line: string): string => Ansi.annotate(line, Ansi.combine(Ansi.italicized, Ansi.red))
+const annotateSymbol = (symbol: string, ...styles: Array<string | Array<string>>): string =>
+  symbol.length === 0 ? "" : Ansi.annotate(symbol, ...styles)
+const separateSymbol = (symbol: string, text: string): string => symbol.length === 0 ? text : symbol + " " + text
 
 /**
  * Creates a confirmation prompt that asks the user to choose a boolean yes/no
@@ -777,7 +812,7 @@ export const confirm = (options: ConfirmOptions): Prompt<boolean> => {
   const opts: Required<ConfirmOptions> = {
     initial: false,
     ...options,
-    prefix: options.prefix ?? DEFAULT_PREFIX,
+    theme: options.theme ?? {},
     label: {
       confirm: "yes",
       deny: "no",
@@ -875,7 +910,7 @@ export const date = (options: DateOptions): Prompt<Date> => {
     dateMask: "YYYY-MM-DD HH:mm:ss",
     validate: Effect.succeed,
     ...options,
-    prefix: options.prefix ?? DEFAULT_PREFIX,
+    theme: options.theme ?? {},
     locales: {
       ...defaultLocales,
       ...options.locales
@@ -912,7 +947,7 @@ export const file = (options: FileOptions = {}): Prompt<string> => {
   const opts: FileOptionsReq = {
     type: options.type ?? "file",
     message: options.message ?? `Choose a file`,
-    prefix: options.prefix ?? DEFAULT_PREFIX,
+    theme: options.theme ?? {},
     startingPath: Option.fromUndefinedOr(options.startingPath),
     default: Option.fromUndefinedOr(options.default),
     maxPerPage: options.maxPerPage ?? 10,
@@ -1002,7 +1037,7 @@ export const float = (options: FloatOptions): Prompt<number> => {
       return Effect.succeed(n)
     },
     ...options,
-    prefix: options.prefix ?? DEFAULT_PREFIX
+    theme: options.theme ?? {}
   }
   const initialValue = options.default === undefined ? "" : `${opts.default}`
   const initialState: NumberState = {
@@ -1055,7 +1090,7 @@ export const integer = (options: IntegerOptions): Prompt<number> => {
       return Effect.succeed(n)
     },
     ...options,
-    prefix: options.prefix ?? DEFAULT_PREFIX
+    theme: options.theme ?? {}
   }
   const initialValue = options.default === undefined ? "" : `${opts.default}`
   const initialState: NumberState = {
@@ -1173,7 +1208,7 @@ export const select = <const A>(options: SelectOptions<A>): Prompt<A> => {
   const opts: SelectOptionsReq<A> = {
     maxPerPage: 10,
     ...options,
-    prefix: options.prefix ?? DEFAULT_PREFIX
+    theme: options.theme ?? {}
   }
   const initialIndex = getSelectInitialIndex(opts.choices)
   return custom(initialIndex, {
@@ -1213,7 +1248,7 @@ export const autoComplete = <const A>(options: AutoCompleteOptions<A>): Prompt<A
     filterPlaceholder: "type to filter",
     emptyMessage: "No matches",
     ...options,
-    prefix: options.prefix ?? DEFAULT_PREFIX
+    theme: options.theme ?? {}
   }
   const initialIndex = getSelectInitialIndex(opts.choices)
   const filtered = filterAutoCompleteChoices(opts.choices, "")
@@ -1252,7 +1287,7 @@ export const multiSelect = <const A>(
   const opts: SelectOptionsReq<A> & MultiSelectOptionsReq = {
     maxPerPage: 10,
     ...options,
-    prefix: options.prefix ?? DEFAULT_PREFIX
+    theme: options.theme ?? {}
   }
   // Seed initial selection from choices marked as selected: true
   const initialSelected = new Set<number>()
@@ -1312,7 +1347,7 @@ export const toggle = (options: ToggleOptions): Prompt<boolean> => {
     active: "on",
     inactive: "off",
     ...options,
-    prefix: options.prefix ?? DEFAULT_PREFIX
+    theme: options.theme ?? {}
   }
   return custom(opts.initial, {
     render: handleToggleRender(opts),
@@ -1502,13 +1537,13 @@ const handleConfirmClear = (options: ConfirmOptionsReq) => {
   return Effect.fnUntraced(function*(state: ConfirmState, _: Action<ConfirmState, boolean>) {
     const terminal = yield* Terminal.Terminal
     const columns = yield* terminal.columns
-    const figures = yield* platformFigures
+    const figures = yield* getTheme(options)
     const confirmMessage = state.value
       ? options.placeholder.defaultConfirm!
       : options.placeholder.defaultDeny!
     const promptText = renderConfirmOutput(
       confirmMessage,
-      options.prefix,
+      figures.prefix,
       figures.pointerSmall,
       options,
       { plain: true }
@@ -1528,9 +1563,9 @@ const renderConfirmOutput = (
 ) => renderPrompt(confirm, options.message, leadingSymbol, trailingSymbol, renderOptions)
 
 const renderConfirmNextFrame = Effect.fnUntraced(function*(state: ConfirmState, options: ConfirmOptionsReq) {
-  const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate(options.prefix, Ansi.cyanBright)
-  const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
+  const figures = yield* getTheme(options)
+  const leadingSymbol = annotateSymbol(figures.prefix, Ansi.cyanBright)
+  const trailingSymbol = annotateSymbol(figures.pointerSmall, Ansi.blackBright)
   // Marking these explicitly as present with `!` because they always will be
   // and there is really no value in adding a `DeepRequired` type helper just
   // for these internal cases
@@ -1543,9 +1578,9 @@ const renderConfirmNextFrame = Effect.fnUntraced(function*(state: ConfirmState, 
 })
 
 const renderConfirmSubmission = Effect.fnUntraced(function*(value: boolean, options: ConfirmOptionsReq) {
-  const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate(figures.tick, Ansi.green)
-  const trailingSymbol = Ansi.annotate(figures.ellipsis, Ansi.blackBright)
+  const figures = yield* getTheme(options)
+  const leadingSymbol = annotateSymbol(figures.tick, Ansi.green)
+  const trailingSymbol = annotateSymbol(figures.ellipsis, Ansi.blackBright)
   const confirmMessage = value ? options.label.confirm : options.label.deny
   const promptMsg = renderConfirmOutput(confirmMessage, leadingSymbol, trailingSymbol, options)
   return promptMsg + "\n"
@@ -1592,14 +1627,14 @@ const handleDateClear = (options: DateOptionsReq) => {
   return Effect.fnUntraced(function*(state: DateState, _: Action<DateState, globalThis.Date>) {
     const terminal = yield* Terminal.Terminal
     const columns = yield* terminal.columns
-    const figures = yield* platformFigures
+    const figures = yield* getTheme(options)
     const resetCurrentLine = Ansi.eraseLine + Ansi.cursorLeft
     const parts = Arr.reduce(state.dateParts, "", (doc, part) => doc + part.toString())
-    const promptText = renderDateOutput(options.prefix, figures.pointerSmall, parts, options, { plain: true })
+    const promptText = renderDateOutput(figures.prefix, figures.pointerSmall, parts, options, { plain: true })
     const errorText = Option.isSome(state.error)
       ? Arr.match(state.error.value.split(NEWLINE_REGEXP), {
         onEmpty: () => "",
-        onNonEmpty: (errorLines) => `${figures.pointerSmall} ${errorLines.join("\n")}`
+        onNonEmpty: (errorLines) => separateSymbol(figures.pointerSmall, errorLines.join("\n"))
       })
       : ""
     const clearOutput = clearOutputWithError(promptText, columns, errorText)
@@ -1611,9 +1646,9 @@ const renderDateError = (state: DateState, pointer: string): string => {
   if (Option.isSome(state.error)) {
     const errorLines = state.error.value.split(NEWLINE_REGEXP)
     if (Arr.isReadonlyArrayNonEmpty(errorLines)) {
-      const prefix = Ansi.annotate(pointer, Ansi.red) + " "
+      const prefix = annotateSymbol(pointer, Ansi.red)
       const lines = Arr.map(errorLines, (str) => annotateErrorLine(str))
-      return Ansi.cursorSavePosition + "\n" + prefix + lines.join("\n") + Ansi.cursorRestorePosition
+      return Ansi.cursorSavePosition + "\n" + separateSymbol(prefix, lines.join("\n")) + Ansi.cursorRestorePosition
     }
   }
   return ""
@@ -1643,9 +1678,9 @@ const renderDateOutput = (
 ) => renderPrompt(parts, options.message, leadingSymbol, trailingSymbol, renderOptions)
 
 const renderDateNextFrame = Effect.fnUntraced(function*(state: DateState, options: DateOptionsReq) {
-  const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate(options.prefix, Ansi.cyanBright)
-  const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
+  const figures = yield* getTheme(options)
+  const leadingSymbol = annotateSymbol(figures.prefix, Ansi.cyanBright)
+  const trailingSymbol = annotateSymbol(figures.pointerSmall, Ansi.blackBright)
   const parts = renderParts(state)
   const promptMsg = renderDateOutput(leadingSymbol, trailingSymbol, parts, options)
   const errorMsg = renderDateError(state, figures.pointerSmall)
@@ -1653,9 +1688,9 @@ const renderDateNextFrame = Effect.fnUntraced(function*(state: DateState, option
 })
 
 const renderDateSubmission = Effect.fnUntraced(function*(state: DateState, options: DateOptionsReq) {
-  const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate(figures.tick, Ansi.green)
-  const trailingSymbol = Ansi.annotate(figures.ellipsis, Ansi.blackBright)
+  const figures = yield* getTheme(options)
+  const leadingSymbol = annotateSymbol(figures.tick, Ansi.green)
+  const trailingSymbol = annotateSymbol(figures.ellipsis, Ansi.blackBright)
   const parts = renderParts(state, true)
   const promptMsg = renderDateOutput(leadingSymbol, trailingSymbol, parts, options)
   return promptMsg + "\n"
@@ -2238,14 +2273,14 @@ const handleFileClear = (options: FileOptionsReq) => {
     const terminal = yield* Terminal.Terminal
     const columns = yield* terminal.columns
     const path = yield* Path.Path
-    const figures = yield* platformFigures
+    const figures = yield* getTheme(options)
     const currentPath = yield* resolveCurrentPath(state.path, options)
     const selectedPath = state.files[state.cursor]
     const resolvedPath = selectedPath === undefined ? currentPath : path.resolve(currentPath, selectedPath)
-    const resolvedPathText = `${figures.pointerSmall} ${resolvedPath}`
+    const resolvedPathText = separateSymbol(figures.pointerSmall, resolvedPath)
     const isConfirming = showConfirmation(state.confirm)
     const promptText = isConfirming
-      ? renderPrompt("(Y/n)", CONFIRM_MESSAGE, options.prefix, figures.pointerSmall, { plain: true })
+      ? renderPrompt("(Y/n)", CONFIRM_MESSAGE, figures.prefix, figures.pointerSmall, { plain: true })
       : renderPrompt(renderFileFilter(state, { plain: true }), options.message, figures.tick, figures.ellipsis, {
         plain: true
       })
@@ -2272,15 +2307,27 @@ const renderPrompt = (
   trailingSymbol: string,
   options?: RenderOptions | undefined
 ) => {
-  const prefix = leadingSymbol + " "
+  const prefix = leadingSymbol.length === 0 ? "" : leadingSymbol + " "
+  const renderLine = (line: string) => {
+    let output = prefix + line
+    if (trailingSymbol.length > 0) {
+      output += " " + trailingSymbol
+    }
+    if (confirm.length > 0) {
+      output += " " + confirm
+    } else if (trailingSymbol.length > 0) {
+      output += " "
+    }
+    return output
+  }
   const annotate = options?.plain === true
     ? (line: string) => line
     : annotateLine
   return Arr.match(message.split(NEWLINE_REGEXP), {
-    onEmpty: () => prefix + " " + trailingSymbol + " " + confirm,
+    onEmpty: () => renderLine(""),
     onNonEmpty: (promptLines) => {
       const lines = Arr.map(promptLines, (line) => annotate(line))
-      return prefix + lines.join("\n") + " " + trailingSymbol + " " + confirm
+      return renderLine(lines.join("\n"))
     }
   })
 }
@@ -2293,7 +2340,7 @@ const renderPrefix = (
   figures: Effect.Success<typeof platformFigures>,
   renderOptions?: RenderOptions | undefined
 ) => {
-  let prefix = " "
+  let prefix = figures.arrowUp.length === 0 && figures.arrowDown.length === 0 ? "" : " "
   if (currentIndex === toDisplay.startIndex && toDisplay.startIndex > 0) {
     prefix = figures.arrowUp
   } else if (currentIndex === toDisplay.endIndex - 1 && toDisplay.endIndex < length) {
@@ -2302,9 +2349,9 @@ const renderPrefix = (
   if (state.cursor === currentIndex) {
     return renderOptions?.plain === true
       ? figures.pointer + prefix
-      : Ansi.annotate(figures.pointer, Ansi.cyanBright) + prefix
+      : annotateSymbol(figures.pointer, Ansi.cyanBright) + prefix
   }
-  return prefix + " "
+  return prefix + (figures.pointer.length === 0 ? "" : " ".repeat(figures.pointer.length))
 }
 
 const renderFileName = (file: string, isSelected: boolean, renderOptions?: RenderOptions | undefined) => {
@@ -2353,30 +2400,30 @@ const renderFiles = (
 
 const renderFileNextFrame = Effect.fnUntraced(function*(state: FileState, options: FileOptionsReq) {
   const path = yield* Path.Path
-  const figures = yield* platformFigures
+  const figures = yield* getTheme(options)
   const currentPath = yield* resolveCurrentPath(state.path, options)
   const selectedPath = state.files[state.cursor]
   const resolvedPath = selectedPath === undefined ? currentPath : path.resolve(currentPath, selectedPath)
-  const resolvedPathMsg = Ansi.annotate(figures.pointerSmall + " " + resolvedPath, Ansi.blackBright)
+  const resolvedPathMsg = Ansi.annotate(separateSymbol(figures.pointerSmall, resolvedPath), Ansi.blackBright)
 
   if (showConfirmation(state.confirm)) {
-    const leadingSymbol = Ansi.annotate(options.prefix, Ansi.cyanBright)
-    const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
+    const leadingSymbol = annotateSymbol(figures.prefix, Ansi.cyanBright)
+    const trailingSymbol = annotateSymbol(figures.pointerSmall, Ansi.blackBright)
     const confirm = Ansi.annotate("(Y/n)", Ansi.blackBright)
     const promptMsg = renderPrompt(confirm, CONFIRM_MESSAGE, leadingSymbol, trailingSymbol)
     return Ansi.cursorHide + promptMsg + "\n" + resolvedPathMsg
   }
-  const leadingSymbol = Ansi.annotate(figures.tick, Ansi.green)
-  const trailingSymbol = Ansi.annotate(figures.ellipsis, Ansi.blackBright)
+  const leadingSymbol = annotateSymbol(figures.tick, Ansi.green)
+  const trailingSymbol = annotateSymbol(figures.ellipsis, Ansi.blackBright)
   const promptMsg = renderPrompt(renderFileFilter(state), options.message, leadingSymbol, trailingSymbol)
   const files = renderFiles(state, state.files, figures, options)
   return Ansi.cursorHide + promptMsg + "\n" + resolvedPathMsg + "\n" + files
 })
 
 const renderFileSubmission = Effect.fnUntraced(function*(state: FileState, value: string, options: FileOptionsReq) {
-  const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate(figures.tick, Ansi.green)
-  const trailingSymbol = Ansi.annotate(figures.ellipsis, Ansi.blackBright)
+  const figures = yield* getTheme(options)
+  const leadingSymbol = annotateSymbol(figures.tick, Ansi.green)
+  const trailingSymbol = annotateSymbol(figures.ellipsis, Ansi.blackBright)
   const promptMsg = renderPrompt(renderFileFilter(state), options.message, leadingSymbol, trailingSymbol)
   return promptMsg + " " + Ansi.annotate(value, Ansi.white) + "\n"
 })
@@ -2563,11 +2610,11 @@ const renderMultiSelectError = (
       onEmpty: () => "",
       onNonEmpty: (errorLines) => {
         if (renderOptions?.plain === true) {
-          return `${pointer} ${errorLines.join("\n")}`
+          return separateSymbol(pointer, errorLines.join("\n"))
         }
-        const prefix = Ansi.annotate(pointer, Ansi.red) + " "
+        const prefix = annotateSymbol(pointer, Ansi.red)
         const lines = Arr.map(errorLines, (str) => annotateErrorLine(str))
-        return Ansi.cursorSavePosition + "\n" + prefix + lines.join("\n") + Ansi.cursorRestorePosition
+        return Ansi.cursorSavePosition + "\n" + separateSymbol(prefix, lines.join("\n")) + Ansi.cursorRestorePosition
       }
     })
   }
@@ -2577,12 +2624,16 @@ const renderMultiSelectError = (
 const renderChoiceDescription = <A>(
   choice: SelectChoice<A>,
   isActive: boolean,
+  theme: Theme,
   renderOptions?: RenderOptions | undefined
 ) => {
   if (!choice.disabled && choice.description && isActive) {
+    if (theme.descriptionSeparator.length === 0) {
+      return choice.description
+    }
     return renderOptions?.plain === true
-      ? "- " + choice.description
-      : Ansi.annotate("- " + choice.description, Ansi.blackBright)
+      ? theme.descriptionSeparator + choice.description
+      : Ansi.annotate(theme.descriptionSeparator + choice.description, Ansi.blackBright)
   }
   return ""
 }
@@ -2627,7 +2678,7 @@ const renderMultiSelectChoices = <A>(
   for (let index = toDisplay.startIndex; index < toDisplay.endIndex; index++) {
     const choice = allChoices[index]
     const isHighlighted = state.index === index
-    let prefix = " "
+    let prefix = figures.arrowUp.length === 0 && figures.arrowDown.length === 0 ? "" : " "
     if (index === toDisplay.startIndex && toDisplay.startIndex > 0) {
       prefix = figures.arrowUp
     } else if (index === toDisplay.endIndex - 1 && toDisplay.endIndex < allChoices.length) {
@@ -2636,7 +2687,7 @@ const renderMultiSelectChoices = <A>(
     if (index < metaOptions.length) {
       // Meta options
       const title = renderMultiSelectTitle(choice.title, isHighlighted, renderOptions)
-      documents.push(prefix + " " + title)
+      documents.push(prefix + (prefix.length === 0 ? "" : " ") + title)
     } else {
       // Regular choices
       const choiceIndex = index - metaOptions.length
@@ -2647,8 +2698,12 @@ const renderMultiSelectChoices = <A>(
         : checkbox
       const selectChoice = choice as SelectChoice<A>
       const title = renderChoiceTitle(selectChoice, isHighlighted, renderOptions)
-      const description = renderChoiceDescription(selectChoice, isHighlighted, renderOptions)
-      documents.push(prefix + " " + annotatedCheckbox + " " + title + " " + description)
+      const description = renderChoiceDescription(selectChoice, isHighlighted, figures, renderOptions)
+      const checkboxPrefix = checkbox.length === 0 ? "" : annotatedCheckbox + " "
+      const descriptionPrefix = description.length === 0 || figures.descriptionSeparator.length > 0 ? " " : ""
+      documents.push(
+        prefix + (prefix.length === 0 ? "" : " ") + checkboxPrefix + title + descriptionPrefix + description
+      )
     }
   }
   return documents.join("\n")
@@ -2656,10 +2711,10 @@ const renderMultiSelectChoices = <A>(
 
 const renderMultiSelectNextFrame = Effect.fnUntraced(
   function*<A>(state: MultiSelectState, options: SelectOptionsReq<A>) {
-    const figures = yield* platformFigures
+    const figures = yield* getTheme(options)
     const choices = renderMultiSelectChoices(state, options, figures)
-    const leadingSymbol = Ansi.annotate(options.prefix, Ansi.cyanBright)
-    const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
+    const leadingSymbol = annotateSymbol(figures.prefix, Ansi.cyanBright)
+    const trailingSymbol = annotateSymbol(figures.pointerSmall, Ansi.blackBright)
     const promptMsg = renderSelectOutput(leadingSymbol, trailingSymbol, options)
     const error = renderMultiSelectError(state, figures.pointer)
     return Ansi.cursorHide + promptMsg + "\n" + choices + error
@@ -2668,13 +2723,13 @@ const renderMultiSelectNextFrame = Effect.fnUntraced(
 
 const renderMultiSelectSubmission = Effect.fnUntraced(
   function*<A>(state: MultiSelectState, options: SelectOptionsReq<A>) {
-    const figures = yield* platformFigures
+    const figures = yield* getTheme(options)
     const selectedChoices = Array.from(state.selectedIndices).sort(EffectNumber.Order).map((index) =>
       options.choices[index].title
     )
     const selectedText = selectedChoices.join(", ")
-    const leadingSymbol = Ansi.annotate(figures.tick, Ansi.green)
-    const trailingSymbol = Ansi.annotate(figures.ellipsis, Ansi.blackBright)
+    const leadingSymbol = annotateSymbol(figures.tick, Ansi.green)
+    const trailingSymbol = annotateSymbol(figures.ellipsis, Ansi.blackBright)
     const promptMsg = renderSelectOutput(leadingSymbol, trailingSymbol, options)
     return promptMsg + " " + Ansi.annotate(selectedText, Ansi.white) + "\n"
   }
@@ -2732,9 +2787,9 @@ const handleMultiSelectClear = <A>(options: SelectOptionsReq<A>) =>
   Effect.fnUntraced(function*(state: MultiSelectState, _: Action<MultiSelectState, Array<A>>) {
     const terminal = yield* Terminal.Terminal
     const columns = yield* terminal.columns
-    const figures = yield* platformFigures
+    const figures = yield* getTheme(options)
     const clearPrompt = Ansi.eraseLine + Ansi.cursorLeft
-    const promptText = renderSelectOutput(options.prefix, figures.pointerSmall, options, { plain: true })
+    const promptText = renderSelectOutput(figures.prefix, figures.pointerSmall, options, { plain: true })
     const choicesText = renderMultiSelectChoices(state, options, figures, { plain: true })
     const errorText = renderMultiSelectError(state, figures.pointer, { plain: true })
     const clearOutput = clearOutputWithError(`${promptText}\n${choicesText}`, columns, errorText)
@@ -2804,10 +2859,10 @@ const handleNumberClear = (options: IntegerOptionsReq) => {
   return Effect.fnUntraced(function*(state: NumberState, _: Action<NumberState, number>) {
     const terminal = yield* Terminal.Terminal
     const columns = yield* terminal.columns
-    const figures = yield* platformFigures
+    const figures = yield* getTheme(options)
     const resetCurrentLine = Ansi.eraseLine + Ansi.cursorLeft
     const errorText = renderNumberError(state, figures.pointerSmall, { plain: true })
-    const promptText = renderNumberOutput(state, options.prefix, figures.pointerSmall, options, { plain: true })
+    const promptText = renderNumberOutput(state, figures.prefix, figures.pointerSmall, options, { plain: true })
     const clearOutput = clearOutputWithError(promptText, columns, errorText)
     return clearOutput + resetCurrentLine
   })
@@ -2838,11 +2893,11 @@ const renderNumberError = (
       onEmpty: () => "",
       onNonEmpty: (errorLines) => {
         if (renderOptions?.plain === true) {
-          return `${pointer} ${errorLines.join("\n")}`
+          return separateSymbol(pointer, errorLines.join("\n"))
         }
-        const prefix = Ansi.annotate(pointer, Ansi.red) + " "
+        const prefix = annotateSymbol(pointer, Ansi.red)
         const lines = Arr.map(errorLines, (str) => annotateErrorLine(str))
-        return Ansi.cursorSavePosition + "\n" + prefix + lines.join("\n") + Ansi.cursorRestorePosition
+        return Ansi.cursorSavePosition + "\n" + separateSymbol(prefix, lines.join("\n")) + Ansi.cursorRestorePosition
       }
     })
   }
@@ -2862,18 +2917,18 @@ const renderNumberOutput = (
 }
 
 const renderNumberNextFrame = Effect.fnUntraced(function*(state: NumberState, options: IntegerOptionsReq) {
-  const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate(options.prefix, Ansi.cyanBright)
-  const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
+  const figures = yield* getTheme(options)
+  const leadingSymbol = annotateSymbol(figures.prefix, Ansi.cyanBright)
+  const trailingSymbol = annotateSymbol(figures.pointerSmall, Ansi.blackBright)
   const errorMsg = renderNumberError(state, figures.pointerSmall)
   const promptMsg = renderNumberOutput(state, leadingSymbol, trailingSymbol, options)
   return promptMsg + errorMsg
 })
 
 const renderNumberSubmission = Effect.fnUntraced(function*(nextState: NumberState, options: IntegerOptionsReq) {
-  const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate(figures.tick, Ansi.green)
-  const trailingSymbol = Ansi.annotate(figures.ellipsis, Ansi.blackBright)
+  const figures = yield* getTheme(options)
+  const leadingSymbol = annotateSymbol(figures.tick, Ansi.green)
+  const trailingSymbol = annotateSymbol(figures.ellipsis, Ansi.blackBright)
   const promptMsg = renderNumberOutput(nextState, leadingSymbol, trailingSymbol, options, undefined, true)
   return promptMsg + "\n"
 })
@@ -3169,7 +3224,7 @@ const renderChoicePrefix = <A>(
   figures: Effect.Success<typeof platformFigures>,
   renderOptions?: RenderOptions | undefined
 ) => {
-  let prefix = " "
+  let prefix = figures.arrowUp.length === 0 && figures.arrowDown.length === 0 ? "" : " "
   if (currentIndex === toDisplay.startIndex && toDisplay.startIndex > 0) {
     prefix = figures.arrowUp
   } else if (currentIndex === toDisplay.endIndex - 1 && toDisplay.endIndex < choices.length) {
@@ -3178,17 +3233,17 @@ const renderChoicePrefix = <A>(
   if (renderOptions?.plain === true) {
     return state === currentIndex
       ? figures.pointer + prefix
-      : prefix + " "
+      : prefix + (figures.pointer.length === 0 ? "" : " ".repeat(figures.pointer.length))
   }
   if (choices[currentIndex].disabled) {
     const annotation = Ansi.combine(Ansi.bold, Ansi.blackBright)
     return state === currentIndex
-      ? Ansi.annotate(figures.pointer, annotation) + prefix
-      : prefix + " "
+      ? annotateSymbol(figures.pointer, annotation) + prefix
+      : prefix + (figures.pointer.length === 0 ? "" : " ".repeat(figures.pointer.length))
   }
   return state === currentIndex
-    ? Ansi.annotate(figures.pointer, Ansi.cyanBright) + prefix
-    : prefix + " "
+    ? annotateSymbol(figures.pointer, Ansi.cyanBright) + prefix
+    : prefix + (figures.pointer.length === 0 ? "" : " ".repeat(figures.pointer.length))
 }
 
 const renderAutoCompleteChoicePrefix = <A>(
@@ -3199,7 +3254,7 @@ const renderAutoCompleteChoicePrefix = <A>(
   figures: Effect.Success<typeof platformFigures>,
   renderOptions?: RenderOptions | undefined
 ) => {
-  let prefix = " "
+  let prefix = figures.arrowUp.length === 0 && figures.arrowDown.length === 0 ? "" : " "
   if (currentIndex === toDisplay.startIndex && toDisplay.startIndex > 0) {
     prefix = figures.arrowUp
   } else if (currentIndex === toDisplay.endIndex - 1 && toDisplay.endIndex < state.filtered.length) {
@@ -3209,18 +3264,18 @@ const renderAutoCompleteChoicePrefix = <A>(
   if (renderOptions?.plain === true) {
     return state.index === choiceIndex
       ? figures.pointer + prefix
-      : prefix + " "
+      : prefix + (figures.pointer.length === 0 ? "" : " ".repeat(figures.pointer.length))
   }
   const choice = options.choices[choiceIndex]
   if (choice.disabled) {
     const annotation = Ansi.combine(Ansi.bold, Ansi.blackBright)
     return state.index === choiceIndex
-      ? Ansi.annotate(figures.pointer, annotation) + prefix
-      : prefix + " "
+      ? annotateSymbol(figures.pointer, annotation) + prefix
+      : prefix + (figures.pointer.length === 0 ? "" : " ".repeat(figures.pointer.length))
   }
   return state.index === choiceIndex
-    ? Ansi.annotate(figures.pointer, Ansi.cyanBright) + prefix
-    : prefix + " "
+    ? annotateSymbol(figures.pointer, Ansi.cyanBright) + prefix
+    : prefix + (figures.pointer.length === 0 ? "" : " ".repeat(figures.pointer.length))
 }
 
 const renderChoiceTitle = <A>(
@@ -3256,8 +3311,9 @@ const renderSelectChoices = <A>(
     const isSelected = state === index
     const prefix = renderChoicePrefix(state, choices, toDisplay, index, figures, renderOptions)
     const title = renderChoiceTitle(choice, isSelected, renderOptions)
-    const description = renderChoiceDescription(choice, isSelected, renderOptions)
-    documents.push(prefix + title + " " + description)
+    const description = renderChoiceDescription(choice, isSelected, figures, renderOptions)
+    const descriptionPrefix = description.length === 0 || figures.descriptionSeparator.length > 0 ? " " : ""
+    documents.push(prefix + title + descriptionPrefix + description)
   }
   return documents.join("\n")
 }
@@ -3282,17 +3338,18 @@ const renderAutoCompleteChoices = <A>(
     const isSelected = state.index === choiceIndex
     const prefix = renderAutoCompleteChoicePrefix(state, options, toDisplay, index, figures, renderOptions)
     const title = renderChoiceTitle(choice, isSelected, renderOptions)
-    const description = renderChoiceDescription(choice, isSelected, renderOptions)
-    documents.push(prefix + title + " " + description)
+    const description = renderChoiceDescription(choice, isSelected, figures, renderOptions)
+    const descriptionPrefix = description.length === 0 || figures.descriptionSeparator.length > 0 ? " " : ""
+    documents.push(prefix + title + descriptionPrefix + description)
   }
   return documents.join("\n")
 }
 
 const renderSelectNextFrame = Effect.fnUntraced(function*<A>(state: SelectState, options: SelectOptionsReq<A>) {
-  const figures = yield* platformFigures
+  const figures = yield* getTheme(options)
   const choices = renderSelectChoices(state, options, figures)
-  const leadingSymbol = Ansi.annotate(options.prefix, Ansi.cyanBright)
-  const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
+  const leadingSymbol = annotateSymbol(figures.prefix, Ansi.cyanBright)
+  const trailingSymbol = annotateSymbol(figures.pointerSmall, Ansi.blackBright)
   const promptMsg = renderSelectOutput(leadingSymbol, trailingSymbol, options)
   return Ansi.cursorHide + promptMsg + "\n" + choices
 })
@@ -3301,19 +3358,19 @@ const renderAutoCompleteNextFrame = Effect.fnUntraced(function*<A>(
   state: AutoCompleteState,
   options: AutoCompleteOptionsReq<A>
 ) {
-  const figures = yield* platformFigures
+  const figures = yield* getTheme(options)
   const choices = renderAutoCompleteChoices(state, options, figures)
-  const leadingSymbol = Ansi.annotate(options.prefix, Ansi.cyanBright)
-  const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
+  const leadingSymbol = annotateSymbol(figures.prefix, Ansi.cyanBright)
+  const trailingSymbol = annotateSymbol(figures.pointerSmall, Ansi.blackBright)
   const promptMsg = renderAutoCompleteOutput(state, leadingSymbol, trailingSymbol, options)
   return Ansi.cursorHide + promptMsg + "\n" + choices
 })
 
 const renderSelectSubmission = Effect.fnUntraced(function*<A>(state: SelectState, options: SelectOptionsReq<A>) {
-  const figures = yield* platformFigures
+  const figures = yield* getTheme(options)
   const selected = options.choices[state].title
-  const leadingSymbol = Ansi.annotate(figures.tick, Ansi.green)
-  const trailingSymbol = Ansi.annotate(figures.ellipsis, Ansi.blackBright)
+  const leadingSymbol = annotateSymbol(figures.tick, Ansi.green)
+  const trailingSymbol = annotateSymbol(figures.ellipsis, Ansi.blackBright)
   const promptMsg = renderSelectOutput(leadingSymbol, trailingSymbol, options)
   return promptMsg + " " + Ansi.annotate(selected, Ansi.white) + "\n"
 })
@@ -3322,10 +3379,10 @@ const renderAutoCompleteSubmission = Effect.fnUntraced(function*<A>(
   state: AutoCompleteState,
   options: AutoCompleteOptionsReq<A>
 ) {
-  const figures = yield* platformFigures
+  const figures = yield* getTheme(options)
   const selected = options.choices[state.index].title
-  const leadingSymbol = Ansi.annotate(figures.tick, Ansi.green)
-  const trailingSymbol = Ansi.annotate(figures.ellipsis, Ansi.blackBright)
+  const leadingSymbol = annotateSymbol(figures.tick, Ansi.green)
+  const trailingSymbol = annotateSymbol(figures.ellipsis, Ansi.blackBright)
   const promptMsg = renderAutoCompleteOutput(state, leadingSymbol, trailingSymbol, options)
   return promptMsg + " " + Ansi.annotate(selected, Ansi.white) + "\n"
 })
@@ -3411,9 +3468,9 @@ const handleSelectClear = <A>(options: SelectOptionsReq<A>) =>
   Effect.fnUntraced(function*(state: SelectState, _: Action<SelectState, A>) {
     const terminal = yield* Terminal.Terminal
     const columns = yield* terminal.columns
-    const figures = yield* platformFigures
+    const figures = yield* getTheme(options)
     const clearPrompt = Ansi.eraseLine + Ansi.cursorLeft
-    const promptText = renderSelectOutput(options.prefix, figures.pointerSmall, options, { plain: true })
+    const promptText = renderSelectOutput(figures.prefix, figures.pointerSmall, options, { plain: true })
     const choicesText = renderSelectChoices(state, options, figures, { plain: true })
     const clearOutput = eraseText(`${promptText}\n${choicesText}`, columns)
     return clearOutput + clearPrompt
@@ -3423,9 +3480,9 @@ const handleAutoCompleteClear = <A>(options: AutoCompleteOptionsReq<A>) =>
   Effect.fnUntraced(function*(state: AutoCompleteState, _: Action<AutoCompleteState, A>) {
     const terminal = yield* Terminal.Terminal
     const columns = yield* terminal.columns
-    const figures = yield* platformFigures
+    const figures = yield* getTheme(options)
     const clearPrompt = Ansi.eraseLine + Ansi.cursorLeft
-    const promptText = renderAutoCompleteOutput(state, options.prefix, figures.pointerSmall, options, { plain: true })
+    const promptText = renderAutoCompleteOutput(state, figures.prefix, figures.pointerSmall, options, { plain: true })
     const choicesText = renderAutoCompleteChoices(state, options, figures, { plain: true })
     const clearOutput = eraseText(`${promptText}\n${choicesText}`, columns)
     return clearOutput + clearPrompt
@@ -3517,11 +3574,11 @@ interface TextState {
 const renderClearScreen = Effect.fnUntraced(function*(state: TextState, options: TextOptionsReq) {
   const terminal = yield* Terminal.Terminal
   const columns = yield* terminal.columns
-  const figures = yield* platformFigures
+  const figures = yield* getTheme(options)
   const resetCurrentLine = Ansi.eraseLine + Ansi.cursorLeft
   const errorText = renderTextError(state, figures.pointerSmall, { plain: true })
   const clearOutput = clearOutputWithError(
-    renderTextOutput(state, options.prefix, figures.pointerSmall, options, { plain: true }),
+    renderTextOutput(state, figures.prefix, figures.pointerSmall, options, figures, { plain: true }),
     columns,
     errorText
   )
@@ -3531,6 +3588,7 @@ const renderClearScreen = Effect.fnUntraced(function*(state: TextState, options:
 const renderTextInput = (
   nextState: TextState,
   options: TextOptionsReq,
+  theme: Theme,
   submitted: boolean,
   renderOptions?: RenderOptions | undefined
 ) => {
@@ -3541,12 +3599,16 @@ const renderTextInput = (
         return ""
       }
       case "password": {
-        return "*".repeat(text.length)
+        return theme.passwordMask.repeat(text.length)
       }
       case "text": {
         return text
       }
     }
+  }
+
+  if (text.length === 0) {
+    return ""
   }
 
   const annotation = Option.isSome(nextState.error) ?
@@ -3562,7 +3624,7 @@ const renderTextInput = (
       return ""
     }
     case "password": {
-      return Ansi.annotate("*".repeat(text.length), annotation)
+      return annotateSymbol(theme.passwordMask.repeat(text.length), annotation)
     }
     case "text": {
       return Ansi.annotate(text, annotation)
@@ -3580,11 +3642,11 @@ const renderTextError = (
       onEmpty: () => "",
       onNonEmpty: (errorLines) => {
         if (renderOptions?.plain === true) {
-          return `${pointer} ${errorLines.join("\n")}`
+          return separateSymbol(pointer, errorLines.join("\n"))
         }
-        const prefix = Ansi.annotate(pointer, Ansi.red) + " "
+        const prefix = annotateSymbol(pointer, Ansi.red)
         const lines = Arr.map(errorLines, (str) => annotateErrorLine(str))
-        return Ansi.cursorSavePosition + "\n" + prefix + lines.join("\n") + Ansi.cursorRestorePosition
+        return Ansi.cursorSavePosition + "\n" + separateSymbol(prefix, lines.join("\n")) + Ansi.cursorRestorePosition
       }
     })
   }
@@ -3596,28 +3658,29 @@ const renderTextOutput = (
   leadingSymbol: string,
   trailingSymbol: string,
   options: TextOptionsReq,
+  theme: Theme,
   renderOptions?: RenderOptions | undefined,
   submitted: boolean = false
 ) => {
-  const value = renderTextInput(nextState, options, submitted, renderOptions)
+  const value = renderTextInput(nextState, options, theme, submitted, renderOptions)
   return renderPrompt(value, options.message, leadingSymbol, trailingSymbol, renderOptions)
 }
 
 const renderTextNextFrame = Effect.fnUntraced(function*(state: TextState, options: TextOptionsReq) {
-  const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate(options.prefix, Ansi.cyanBright)
-  const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
-  const promptMsg = renderTextOutput(state, leadingSymbol, trailingSymbol, options)
+  const figures = yield* getTheme(options)
+  const leadingSymbol = annotateSymbol(figures.prefix, Ansi.cyanBright)
+  const trailingSymbol = annotateSymbol(figures.pointerSmall, Ansi.blackBright)
+  const promptMsg = renderTextOutput(state, leadingSymbol, trailingSymbol, options, figures)
   const errorMsg = renderTextError(state, figures.pointerSmall)
   const offset = state.cursor - state.value.length
   return promptMsg + errorMsg + Ansi.cursorMove(offset)
 })
 
 const renderTextSubmission = Effect.fnUntraced(function*(state: TextState, options: TextOptionsReq) {
-  const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate(figures.tick, Ansi.green)
-  const trailingSymbol = Ansi.annotate(figures.ellipsis, Ansi.blackBright)
-  const promptMsg = renderTextOutput(state, leadingSymbol, trailingSymbol, options, undefined, true)
+  const figures = yield* getTheme(options)
+  const leadingSymbol = annotateSymbol(figures.tick, Ansi.green)
+  const trailingSymbol = annotateSymbol(figures.ellipsis, Ansi.blackBright)
+  const promptMsg = renderTextOutput(state, leadingSymbol, trailingSymbol, options, figures, undefined, true)
   return promptMsg + "\n"
 })
 
@@ -3785,7 +3848,7 @@ const basePrompt = (
     type,
     validate: Effect.succeed,
     ...options,
-    prefix: options.prefix ?? DEFAULT_PREFIX
+    theme: options.theme ?? {}
   }
 
   const initialState: TextState = {
@@ -3807,10 +3870,12 @@ type ToggleState = boolean
 const handleToggleClear = Effect.fnUntraced(function*(options: ToggleOptionsReq) {
   const terminal = yield* Terminal.Terminal
   const columns = yield* terminal.columns
-  const figures = yield* platformFigures
+  const figures = yield* getTheme(options)
   const clearPrompt = Ansi.eraseLine + Ansi.cursorLeft
-  const toggleText = `${options.active} / ${options.inactive}`
-  const promptText = renderPrompt(toggleText, options.message, options.prefix, figures.pointerSmall, { plain: true })
+  const toggleText = options.active
+    + (figures.toggleSeparator.length === 0 ? "" : ` ${figures.toggleSeparator} `)
+    + options.inactive
+  const promptText = renderPrompt(toggleText, options.message, figures.prefix, figures.pointerSmall, { plain: true })
   const clearOutput = eraseText(promptText, columns)
   return clearOutput + clearPrompt
 })
@@ -3818,9 +3883,10 @@ const handleToggleClear = Effect.fnUntraced(function*(options: ToggleOptionsReq)
 const renderToggle = (
   value: boolean,
   options: ToggleOptionsReq,
+  theme: Theme,
   submitted: boolean = false
 ) => {
-  const separator = Ansi.annotate("/", Ansi.blackBright)
+  const separator = annotateSymbol(theme.toggleSeparator, Ansi.blackBright)
   const selectedAnnotation = Ansi.combine(Ansi.underlined, submitted ? Ansi.white : Ansi.cyanBright)
   const inactive = value
     ? options.inactive
@@ -3828,7 +3894,7 @@ const renderToggle = (
   const active = value
     ? Ansi.annotate(options.active, selectedAnnotation)
     : options.active
-  return active + " " + separator + " " + inactive
+  return active + (separator.length === 0 ? "" : " " + separator + " ") + inactive
 }
 
 const renderToggleOutput = (
@@ -3837,29 +3903,23 @@ const renderToggleOutput = (
   trailingSymbol: string,
   options: ToggleOptionsReq
 ) => {
-  const promptLines = options.message.split(NEWLINE_REGEXP)
-  const prefix = leadingSymbol + " "
-  if (Arr.isReadonlyArrayNonEmpty(promptLines)) {
-    const lines = Arr.map(promptLines, (line) => annotateLine(line))
-    return prefix + lines.join("\n") + " " + trailingSymbol + " " + toggle
-  }
-  return prefix + " " + trailingSymbol + " " + toggle
+  return renderPrompt(toggle, options.message, leadingSymbol, trailingSymbol)
 }
 
 const renderToggleNextFrame = Effect.fnUntraced(function*(state: ToggleState, options: ToggleOptionsReq) {
-  const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate(options.prefix, Ansi.cyanBright)
-  const trailingSymbol = Ansi.annotate(figures.pointerSmall, Ansi.blackBright)
-  const toggle = renderToggle(state, options)
+  const figures = yield* getTheme(options)
+  const leadingSymbol = annotateSymbol(figures.prefix, Ansi.cyanBright)
+  const trailingSymbol = annotateSymbol(figures.pointerSmall, Ansi.blackBright)
+  const toggle = renderToggle(state, options, figures)
   const promptMsg = renderToggleOutput(toggle, leadingSymbol, trailingSymbol, options)
   return Ansi.cursorHide + promptMsg
 })
 
 const renderToggleSubmission = Effect.fnUntraced(function*(value: boolean, options: ToggleOptionsReq) {
-  const figures = yield* platformFigures
-  const leadingSymbol = Ansi.annotate(figures.tick, Ansi.green)
-  const trailingSymbol = Ansi.annotate(figures.ellipsis, Ansi.blackBright)
-  const toggle = renderToggle(value, options, true)
+  const figures = yield* getTheme(options)
+  const leadingSymbol = annotateSymbol(figures.tick, Ansi.green)
+  const trailingSymbol = annotateSymbol(figures.ellipsis, Ansi.blackBright)
+  const toggle = renderToggle(value, options, figures, true)
   const promptMsg = renderToggleOutput(toggle, leadingSymbol, trailingSymbol, options)
   return promptMsg + "\n"
 })

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -627,28 +627,16 @@ const windowsTheme: Theme = {
   pointer: ">"
 }
 
-const mergeTheme = (base: Theme, overrides: Partial<Theme> | undefined): Theme => {
-  if (overrides === undefined) {
-    return base
-  }
-  const theme = { ...base }
-  for (const key of Object.keys(overrides) as Array<keyof Theme>) {
-    const value = overrides[key]
-    if (value !== undefined) {
-      Object.assign(theme, { [key]: value })
-    }
-  }
-  return theme
-}
-
 /**
  * Creates a prompt theme using the current platform defaults.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const makeTheme = (options?: Partial<Theme>): Theme =>
-  mergeTheme(process.platform === "win32" ? windowsTheme : defaultTheme, options)
+export const makeTheme = (options?: Partial<Theme>): Theme => ({
+  ...(process.platform === "win32" ? windowsTheme : defaultTheme),
+  ...options
+})
 
 /**
  * Context reference for the theme used by built-in prompts.
@@ -664,7 +652,7 @@ export const Theme: Context.Reference<Theme> = Context.Reference("effect/unstabl
 })
 
 const getTheme = (options: ThemeOptions): Effect.Effect<Theme> =>
-  Effect.map(Theme, (theme) => mergeTheme(theme, options.theme))
+  Effect.map(Theme, (theme) => ({ ...theme, ...options.theme }))
 
 /**
  * Type alias for any `Prompt`, regardless of its output type.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -2668,12 +2668,10 @@ const renderChoiceDescription = <A>(
   renderOptions?: RenderOptions | undefined
 ) => {
   if (!choice.disabled && choice.description && isActive) {
-    if (theme.descriptionSeparator.length === 0) {
-      return choice.description
-    }
+    const text = theme.descriptionSeparator + choice.description
     return renderOptions?.plain === true
-      ? theme.descriptionSeparator + choice.description
-      : Ansi.annotate(theme.descriptionSeparator + choice.description, theme.mutedColor)
+      ? text
+      : Ansi.annotate(text, theme.mutedColor)
   }
   return ""
 }
@@ -3670,8 +3668,6 @@ const renderTextInput = (
     theme.errorColor
     : submitted ?
     theme.submittedColor
-    : nextState.value.length === 0 ?
-    theme.mutedColor
     : Ansi.combine(Ansi.underlined, theme.primaryColor)
 
   switch (options.type) {
@@ -3928,9 +3924,7 @@ const handleToggleClear = Effect.fnUntraced(function*(options: ToggleOptionsReq)
   const columns = yield* terminal.columns
   const figures = yield* getTheme(options)
   const clearPrompt = Ansi.eraseLine + Ansi.cursorLeft
-  const toggleText = options.active
-    + (figures.toggleSeparator.length === 0 ? "" : ` ${figures.toggleSeparator} `)
-    + options.inactive
+  const toggleText = options.active + " " + separateSymbol(figures.toggleSeparator, options.inactive)
   const promptText = renderPrompt(toggleText, options.message, figures.prefix, figures.pointerSmall, { plain: true })
   const clearOutput = eraseText(promptText, columns)
   return clearOutput + clearPrompt
@@ -3953,7 +3947,7 @@ const renderToggle = (
   const active = value
     ? Ansi.annotate(options.active, selectedAnnotation)
     : options.active
-  return active + (separator.length === 0 ? "" : " " + separator + " ") + inactive
+  return active + " " + separateSymbol(separator, inactive)
 }
 
 const renderToggleOutput = (

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -189,6 +189,54 @@ describe("Prompt.text", () => {
       assert.include(frames.at(-1) ?? "", "+ Name ~")
     }).pipe(Effect.provide(TestLayer)))
 
+  it.effect("renders theme colors from context with per-prompt overrides", () =>
+    Effect.gen(function*() {
+      yield* MockTerminal.inputText("A")
+      yield* MockTerminal.inputKey("enter")
+
+      yield* Prompt.run(Prompt.text({
+        message: "Name",
+        theme: { primaryColor: `${escape}[35m` }
+      })).pipe(
+        Effect.provideService(
+          Prompt.Theme,
+          Prompt.makeTheme({
+            primaryColor: `${escape}[31m`,
+            mutedColor: `${escape}[34m`,
+            successColor: `${escape}[33m`,
+            submittedColor: `${escape}[36m`
+          })
+        )
+      )
+
+      const output = toRawFrames(yield* MockTerminal.displayLines).join("\n")
+      assert.include(output, `${escape}[35m?`)
+      assert.include(output, `${escape}[34m›`)
+      assert.include(output, `${escape}[33m✔`)
+      assert.include(output, `${escape}[36mA`)
+      assert.notInclude(output, `${escape}[31m?`)
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("renders validation errors with the theme error color", () =>
+    Effect.gen(function*() {
+      yield* MockTerminal.inputText("bad")
+      yield* MockTerminal.inputKey("enter")
+      yield* MockTerminal.inputKey("u", { ctrl: true })
+      yield* MockTerminal.inputText("ok")
+      yield* MockTerminal.inputKey("enter")
+
+      yield* Prompt.run(Prompt.text({
+        message: "Name",
+        validate: (value) => value === "bad" ? Effect.fail("Try again") : Effect.succeed(value),
+        theme: { errorColor: `${escape}[35m` }
+      }))
+
+      const output = toRawFrames(yield* MockTerminal.displayLines).join("\n")
+      assert.include(output, `${escape}[35m›`)
+      assert.include(output, `${escape}[35mbad`)
+      assert.notInclude(output, `${escape}[31m›`)
+    }).pipe(Effect.provide(TestLayer)))
+
   it.effect("omits spacing for empty theme symbols", () =>
     Effect.gen(function*() {
       yield* MockTerminal.inputKey("enter")
@@ -325,6 +373,28 @@ describe("Prompt.select", () => {
       const frames = toFrames(yield* MockTerminal.displayLines)
       assert.strictEqual(frames.filter((frame) => frame.includes("! Pick item")).length, 2)
       assert.isTrue(frames.some((frame) => frame.includes("> Second : two")))
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("renders selection colors from the prompt theme", () =>
+    Effect.gen(function*() {
+      yield* MockTerminal.inputKey("enter")
+
+      yield* Prompt.run(Prompt.select({
+        message: "Pick item",
+        theme: {
+          primaryColor: `${escape}[35m`,
+          mutedColor: `${escape}[34m`,
+          successColor: `${escape}[33m`,
+          submittedColor: `${escape}[36m`
+        },
+        choices: [{ title: "First", value: "first", description: "one" }]
+      }))
+
+      const output = toRawFrames(yield* MockTerminal.displayLines).join("\n")
+      assert.include(output, `${escape}[35m❯`)
+      assert.include(output, `${escape}[34m- one`)
+      assert.include(output, `${escape}[33m✔`)
+      assert.include(output, `${escape}[36mFirst`)
     }).pipe(Effect.provide(TestLayer)))
 })
 

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -189,19 +189,6 @@ describe("Prompt.text", () => {
       assert.include(frames.at(-1) ?? "", "+ Name ~")
     }).pipe(Effect.provide(TestLayer)))
 
-  it.effect("keeps theme defaults when a JavaScript override is undefined", () =>
-    Effect.gen(function*() {
-      yield* MockTerminal.inputKey("enter")
-
-      yield* Prompt.run(Prompt.text({
-        message: "Name",
-        theme: { prefix: undefined } as unknown as Partial<Prompt.Theme>
-      }))
-
-      const frames = toFrames(yield* MockTerminal.displayLines)
-      assert.include(frames[0] ?? "", "? Name")
-    }).pipe(Effect.provide(TestLayer)))
-
   it.effect("renders theme colors from context with per-prompt overrides", () =>
     Effect.gen(function*() {
       yield* MockTerminal.inputText("A")

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -189,6 +189,19 @@ describe("Prompt.text", () => {
       assert.include(frames.at(-1) ?? "", "+ Name ~")
     }).pipe(Effect.provide(TestLayer)))
 
+  it.effect("keeps theme defaults when a JavaScript override is undefined", () =>
+    Effect.gen(function*() {
+      yield* MockTerminal.inputKey("enter")
+
+      yield* Prompt.run(Prompt.text({
+        message: "Name",
+        theme: { prefix: undefined } as unknown as Partial<Prompt.Theme>
+      }))
+
+      const frames = toFrames(yield* MockTerminal.displayLines)
+      assert.include(frames[0] ?? "", "? Name")
+    }).pipe(Effect.provide(TestLayer)))
+
   it.effect("renders theme colors from context with per-prompt overrides", () =>
     Effect.gen(function*() {
       yield* MockTerminal.inputText("A")
@@ -396,6 +409,43 @@ describe("Prompt.select", () => {
       assert.include(output, `${escape}[33m✔`)
       assert.include(output, `${escape}[36mFirst`)
     }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("keeps title and description separated when the theme separator is empty", () =>
+    Effect.gen(function*() {
+      yield* MockTerminal.inputKey("enter")
+
+      yield* Prompt.run(Prompt.select({
+        message: "Pick item",
+        theme: { descriptionSeparator: "" },
+        choices: [{ title: "First", value: "first", description: "one" }]
+      }))
+
+      const frames = toFrames(yield* MockTerminal.displayLines)
+      assert.isTrue(frames.some((frame) => frame.includes("First one")))
+      assert.isFalse(frames.some((frame) => frame.includes("Firstone")))
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("aligns choices when paging arrows have different widths", () =>
+    Effect.gen(function*() {
+      yield* MockTerminal.inputKey("down")
+      yield* MockTerminal.inputKey("down")
+      yield* MockTerminal.inputKey("enter")
+
+      yield* Prompt.run(Prompt.select({
+        message: "Pick item",
+        maxPerPage: 2,
+        theme: { arrowUp: "", arrowDown: "vvv" },
+        choices: [
+          { title: "Alpha", value: "alpha" },
+          { title: "Beta", value: "beta" },
+          { title: "Gamma", value: "gamma" }
+        ]
+      }))
+
+      const frames = toFrames(yield* MockTerminal.displayLines)
+      assert.isTrue(frames.some((frame) => frame.includes("❯   Alpha") && frame.includes("vvv Beta")))
+      assert.isTrue(frames.some((frame) => frame.includes("    Beta") && frame.includes("❯   Gamma")))
+    }).pipe(Effect.provide(TestLayer)))
 })
 
 describe("Prompt.password", () => {
@@ -411,6 +461,21 @@ describe("Prompt.password", () => {
       const frames = toFrames(yield* MockTerminal.displayLines)
       assert.isTrue(frames.some((frame) => frame.includes("•••")))
       assert.isFalse(frames.some((frame) => frame.includes("***")))
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("keeps cursor movement aligned with a multi-character password mask", () =>
+    Effect.gen(function*() {
+      yield* MockTerminal.inputText("abc")
+      yield* MockTerminal.inputKey("left")
+      yield* MockTerminal.inputKey("enter")
+
+      yield* Prompt.run(Prompt.password({
+        message: "Password",
+        theme: { passwordMask: "**" }
+      }))
+
+      const frames = toRawFrames(yield* MockTerminal.displayLines)
+      assert.isTrue(frames.some((frame) => frame.includes("******") && frame.endsWith(`${escape}[2D`)))
     }).pipe(Effect.provide(TestLayer)))
 
   it.effect("starts from the default value so it can be edited", () =>
@@ -719,6 +784,29 @@ describe("Prompt.multiSelect", () => {
       const frames = toFrames(yield* MockTerminal.displayLines)
       assert.isTrue(frames.some((frame) => frame.includes("v [ ] Alpha")))
       assert.isTrue(frames.some((frame) => frame.includes("[x] Alpha")))
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("aligns choices when checkbox symbols have different widths", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.multiSelect({
+        message: "Pick items",
+        theme: { checkboxOn: "[x]", checkboxOff: "" },
+        choices: [
+          { title: "Alpha", value: "alpha", selected: true },
+          { title: "Beta", value: "beta" }
+        ]
+      })
+      yield* MockTerminal.inputKey("enter")
+
+      yield* Prompt.run(prompt)
+
+      const frame = toFrames(yield* MockTerminal.displayLines).find((frame) =>
+        frame.includes("[x] Alpha") && frame.includes("Beta")
+      )
+      assert.isTrue(frame !== undefined)
+      const alpha = frame?.split("\n").find((line) => line.includes("Alpha")) ?? ""
+      const beta = frame?.split("\n").find((line) => line.includes("Beta")) ?? ""
+      assert.strictEqual(alpha.indexOf("Alpha"), beta.indexOf("Beta"))
     }).pipe(Effect.provide(TestLayer)))
 
   it.effect("does not allow a disabled multi-select choice to be selected", () =>

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -416,13 +416,19 @@ describe("Prompt.select", () => {
 
       yield* Prompt.run(Prompt.select({
         message: "Pick item",
-        theme: { descriptionSeparator: "" },
+        theme: {
+          descriptionSeparator: "",
+          mutedColor: `${escape}[34m`
+        },
         choices: [{ title: "First", value: "first", description: "one" }]
       }))
 
-      const frames = toFrames(yield* MockTerminal.displayLines)
+      const output = yield* MockTerminal.displayLines
+      const frames = toFrames(output)
+      const rawFrames = toRawFrames(output)
       assert.isTrue(frames.some((frame) => frame.includes("First one")))
       assert.isFalse(frames.some((frame) => frame.includes("Firstone")))
+      assert.isTrue(rawFrames.some((frame) => frame.includes(`${escape}[34mone${escape}[0m`)))
     }).pipe(Effect.provide(TestLayer)))
 
   it.effect("aligns choices when paging arrows have different widths", () =>
@@ -520,6 +526,20 @@ describe("Prompt.toggle", () => {
       const frames = toFrames(yield* MockTerminal.displayLines)
       assert.isTrue(frames.some((frame) => frame.includes("on | off")))
       assert.isFalse(frames.some((frame) => frame.includes("on / off")))
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("keeps labels separated when the theme separator is empty", () =>
+    Effect.gen(function*() {
+      yield* MockTerminal.inputKey("enter")
+
+      yield* Prompt.run(Prompt.toggle({
+        message: "Enabled",
+        theme: { toggleSeparator: "" }
+      }))
+
+      const frames = toFrames(yield* MockTerminal.displayLines)
+      assert.isTrue(frames.some((frame) => frame.includes("on off")))
+      assert.isFalse(frames.some((frame) => frame.includes("onoff")))
     }).pipe(Effect.provide(TestLayer)))
 })
 

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -158,26 +158,48 @@ describe("Prompt.float", () => {
 })
 
 describe("Prompt.text", () => {
-  it.effect("uses the default prompt prefix when prefix is explicitly undefined", () =>
+  it.effect("renders the default prompt theme", () =>
     Effect.gen(function*() {
       yield* MockTerminal.inputKey("enter")
 
-      const options = { message: "Name", prefix: undefined } as unknown as Prompt.TextOptions
-      yield* Prompt.run(Prompt.text(options))
+      yield* Prompt.run(Prompt.text({ message: "Name" }))
 
       const frames = toFrames(yield* MockTerminal.displayLines)
       assert.include(frames[0] ?? "", "? Name")
-      assert.notInclude(frames[0] ?? "", "undefined")
     }).pipe(Effect.provide(TestLayer)))
 
-  it.effect("renders a custom prompt prefix", () =>
+  it.effect("renders the prompt theme from context", () =>
     Effect.gen(function*() {
       yield* MockTerminal.inputKey("enter")
 
-      yield* Prompt.run(Prompt.text({ message: "Name", prefix: "!" }))
+      yield* Prompt.run(Prompt.text({ message: "Name" })).pipe(
+        Effect.provideService(
+          Prompt.Theme,
+          Prompt.makeTheme({
+            prefix: "!",
+            pointerSmall: ">",
+            tick: "+",
+            ellipsis: "~"
+          })
+        )
+      )
 
       const frames = toFrames(yield* MockTerminal.displayLines)
-      assert.include(frames[0] ?? "", "! Name")
+      assert.include(frames[0] ?? "", "! Name >")
+      assert.include(frames.at(-1) ?? "", "+ Name ~")
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("omits spacing for empty theme symbols", () =>
+    Effect.gen(function*() {
+      yield* MockTerminal.inputKey("enter")
+
+      yield* Prompt.run(Prompt.text({
+        message: "Name",
+        theme: { prefix: "", pointerSmall: "" }
+      }))
+
+      const frames = toFrames(yield* MockTerminal.displayLines)
+      assert.strictEqual(frames[0], "Name")
     }).pipe(Effect.provide(TestLayer)))
 
   it.effect("starts from the default value so it can be edited", () =>
@@ -281,27 +303,46 @@ describe("Prompt.text", () => {
 })
 
 describe("Prompt.select", () => {
-  it.effect("preserves a custom prompt prefix across redraws", () =>
+  it.effect("renders a per-prompt theme across redraws", () =>
     Effect.gen(function*() {
       yield* MockTerminal.inputKey("down")
       yield* MockTerminal.inputKey("enter")
 
       const result = yield* Prompt.run(Prompt.select({
         message: "Pick item",
-        prefix: "!",
+        theme: {
+          prefix: "!",
+          pointer: ">",
+          descriptionSeparator: ": "
+        },
         choices: [
-          { title: "First", value: "first" },
-          { title: "Second", value: "second" }
+          { title: "First", value: "first", description: "one" },
+          { title: "Second", value: "second", description: "two" }
         ]
       }))
 
       assert.strictEqual(result, "second")
       const frames = toFrames(yield* MockTerminal.displayLines)
       assert.strictEqual(frames.filter((frame) => frame.includes("! Pick item")).length, 2)
+      assert.isTrue(frames.some((frame) => frame.includes("> Second : two")))
     }).pipe(Effect.provide(TestLayer)))
 })
 
 describe("Prompt.password", () => {
+  it.effect("renders the password mask from the prompt theme", () =>
+    Effect.gen(function*() {
+      yield* MockTerminal.inputText("abc")
+      yield* MockTerminal.inputKey("enter")
+
+      yield* Prompt.run(Prompt.password({ message: "Password" })).pipe(
+        Effect.provideService(Prompt.Theme, Prompt.makeTheme({ passwordMask: "•" }))
+      )
+
+      const frames = toFrames(yield* MockTerminal.displayLines)
+      assert.isTrue(frames.some((frame) => frame.includes("•••")))
+      assert.isFalse(frames.some((frame) => frame.includes("***")))
+    }).pipe(Effect.provide(TestLayer)))
+
   it.effect("starts from the default value so it can be edited", () =>
     Effect.gen(function*() {
       const prompt = Prompt.password({
@@ -328,6 +369,22 @@ describe("Prompt.password", () => {
 
       const result = yield* Prompt.run(prompt)
       assert.strictEqual(Redacted.value(result), "")
+    }).pipe(Effect.provide(TestLayer)))
+})
+
+describe("Prompt.toggle", () => {
+  it.effect("renders the separator from the prompt theme", () =>
+    Effect.gen(function*() {
+      yield* MockTerminal.inputKey("enter")
+
+      yield* Prompt.run(Prompt.toggle({
+        message: "Enabled",
+        theme: { toggleSeparator: "|" }
+      }))
+
+      const frames = toFrames(yield* MockTerminal.displayLines)
+      assert.isTrue(frames.some((frame) => frame.includes("on | off")))
+      assert.isFalse(frames.some((frame) => frame.includes("on / off")))
     }).pipe(Effect.provide(TestLayer)))
 })
 
@@ -566,6 +623,34 @@ describe("Prompt.file", () => {
 })
 
 describe("Prompt.multiSelect", () => {
+  it.effect("renders paging and checkbox symbols from the prompt theme", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.multiSelect({
+        message: "Pick items",
+        maxPerPage: 3,
+        theme: {
+          arrowDown: "v",
+          checkboxOn: "[x]",
+          checkboxOff: "[ ]"
+        },
+        choices: [
+          { title: "Alpha", value: "alpha" },
+          { title: "Beta", value: "beta" }
+        ]
+      })
+      yield* MockTerminal.inputKey("down")
+      yield* MockTerminal.inputKey("down")
+      yield* MockTerminal.inputKey("space")
+      yield* MockTerminal.inputKey("enter")
+
+      const value = yield* Prompt.run(prompt)
+
+      assert.deepStrictEqual(value, ["alpha"])
+      const frames = toFrames(yield* MockTerminal.displayLines)
+      assert.isTrue(frames.some((frame) => frame.includes("v [ ] Alpha")))
+      assert.isTrue(frames.some((frame) => frame.includes("[x] Alpha")))
+    }).pipe(Effect.provide(TestLayer)))
+
   it.effect("does not allow a disabled multi-select choice to be selected", () =>
     Effect.gen(function*() {
       const prompt = Prompt.multiSelect({

--- a/packages/effect/typetest/unstable/cli/Prompt.tst.ts
+++ b/packages/effect/typetest/unstable/cli/Prompt.tst.ts
@@ -8,8 +8,11 @@ declare const objectEvents: Queue.Dequeue<{ readonly tick: number }, never>
 describe("Prompt", () => {
   describe("Theme", () => {
     it("supports context and per-prompt customization", () => {
-      expect(Prompt.makeTheme({ prefix: "!" })).type.toBe<Prompt.Theme>()
-      expect(Prompt.text).type.toBeCallableWith({ message: "Name", theme: { prefix: "!" } })
+      expect(Prompt.makeTheme({ prefix: "!", primaryColor: "primary" })).type.toBe<Prompt.Theme>()
+      expect(Prompt.text).type.toBeCallableWith({
+        message: "Name",
+        theme: { prefix: "!", errorColor: "error" }
+      })
     })
 
     it("does not expose the replaced prefix option", () => {

--- a/packages/effect/typetest/unstable/cli/Prompt.tst.ts
+++ b/packages/effect/typetest/unstable/cli/Prompt.tst.ts
@@ -6,6 +6,17 @@ declare const stringEvents: Queue.Dequeue<string, never>
 declare const objectEvents: Queue.Dequeue<{ readonly tick: number }, never>
 
 describe("Prompt", () => {
+  describe("Theme", () => {
+    it("supports context and per-prompt customization", () => {
+      expect(Prompt.makeTheme({ prefix: "!" })).type.toBe<Prompt.Theme>()
+      expect(Prompt.text).type.toBeCallableWith({ message: "Name", theme: { prefix: "!" } })
+    })
+
+    it("does not expose the replaced prefix option", () => {
+      expect(Prompt.text).type.not.toBeCallableWith({ message: "Name", prefix: "!" })
+    })
+  })
+
   describe("custom", () => {
     it("without events, process receives Terminal.UserInput", () => {
       Prompt.custom(


### PR DESCRIPTION
## Summary

- replace per-prompt `prefix` options with a `Prompt.Theme` context reference
- support partial per-prompt theme overrides for symbols, masks, separators, and semantic prompt colors
- preserve the existing platform-specific symbols and ANSI colors as defaults
- keep partially empty or multi-character theme elements aligned and add focused runtime and type coverage

## Validation

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm lint`
- `nix develop -c pnpm test --run packages/effect/test/unstable/cli` (366 tests)
- `nix develop -c pnpm test-types packages/effect/typetest/unstable/cli/Prompt.tst.ts` (TypeScript 5.9 and 6.0)
- `nix develop -c pnpm check`
- `nix develop -c pnpm changeset status --since origin/main`

Closes EFF-797
