### PR TITLE
Optimize synchronous Schema parsing

### DIFF
--- a/.changeset/eff-798-schema-parser.md
+++ b/.changeset/eff-798-schema-parser.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Improve synchronous Schema decode and encode performance by preserving completed parser exits and using a direct loop for common struct parsers.

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -1518,6 +1518,13 @@ export function decodeUnknownEffect<S extends Constraint>(schema: S, options?: S
 function fromIssueEffect<A, R>(
   self: Effect.Effect<A, SchemaIssue.Issue, R>
 ): Effect.Effect<A, SchemaError, R> {
+  if (core.isExit(self)) {
+    return self._tag === "Success"
+      ? self as unknown as Effect.Effect<A, SchemaError, R>
+      : Exit_.failCause(
+        Cause_.map(self.cause as Cause_.Cause<SchemaIssue.Issue>, (issue) => new SchemaError(issue))
+      )
+  }
   return Effect.catchCause(
     self,
     (cause) => Effect.failCauseSync(() => Cause_.map(cause, (issue) => new SchemaError(issue)))

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -35,6 +35,7 @@ import * as Graph_ from "./Graph.ts"
 import * as HashMap_ from "./HashMap.ts"
 import * as HashSet_ from "./HashSet.ts"
 import * as core from "./internal/core.ts"
+import { effectIsExit } from "./internal/effect.ts"
 import * as InternalGraph from "./internal/graph.ts"
 import * as InternalRecord from "./internal/record.ts"
 import * as InternalAnnotations from "./internal/schema/annotations.ts"
@@ -1518,7 +1519,7 @@ export function decodeUnknownEffect<S extends Constraint>(schema: S, options?: S
 function fromIssueEffect<A, R>(
   self: Effect.Effect<A, SchemaIssue.Issue, R>
 ): Effect.Effect<A, SchemaError, R> {
-  if (core.isExit(self)) {
+  if (effectIsExit(self)) {
     return fromIssueExit(self as Exit_.Exit<A, SchemaIssue.Issue>)
   }
   return Effect.catchCause(

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -1519,11 +1519,7 @@ function fromIssueEffect<A, R>(
   self: Effect.Effect<A, SchemaIssue.Issue, R>
 ): Effect.Effect<A, SchemaError, R> {
   if (core.isExit(self)) {
-    return self._tag === "Success"
-      ? self as unknown as Effect.Effect<A, SchemaError, R>
-      : Exit_.failCause(
-        Cause_.map(self.cause as Cause_.Cause<SchemaIssue.Issue>, (issue) => new SchemaError(issue))
-      )
+    return fromIssueExit(self as Exit_.Exit<A, SchemaIssue.Issue>)
   }
   return Effect.catchCause(
     self,

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -2192,7 +2192,7 @@ export class Objects extends Base {
       }) :
       undefined
 
-    return Effect.fnUntracedEager(function*(input, options) {
+    const fallback: SchemaParser.Parser = Effect.fnUntracedEager(function*(input, options) {
       if (input === InternalParser.missing) {
         return InternalParser.missing
       }
@@ -2320,6 +2320,121 @@ export class Objects extends Base {
       }
       return out
     })
+
+    if (indexCount) return fallback
+
+    const finish = (state: ObjectParserState): Effect.Effect<unknown, SchemaIssue.Issue, any> => {
+      if (state.issues) {
+        return Effect.fail(
+          new SchemaIssue.Composite(ast, state.issues, state.input, state.options)
+        )
+      }
+      return InternalParser.succeed(state.out)
+    }
+    const resume = (
+      state: ObjectParserState,
+      index: number,
+      pending: Effect.Effect<unknown, SchemaIssue.Issue, any>
+    ): Effect.Effect<unknown, SchemaIssue.Issue, any> => {
+      const property = properties![index]
+      if (Object.hasOwn(state.input, property.name)) {
+        InternalRecord.assignProperty(state.out, property.name, state.input[property.name])
+      }
+      return Effect.flatMap(Effect.exit(pending), (exit) => {
+        const terminal = parsePropertyStep(state, property, exit)
+        if (terminal) return terminal
+        const remaining = properties!.slice(index + 1)
+        const effect = remaining.length === 0 ? undefined : parseProperties(state, remaining)
+        return effect ? Effect.flatMap(effect, () => finish(state)) : finish(state)
+      })
+    }
+    const fast: SchemaParser.Parser = (input, options) => {
+      if (input === InternalParser.missing) return InternalParser.missingExit
+      if (
+        options.errors === "all" ||
+        options.onExcessProperty !== undefined ||
+        options.propertyOrder === "original" ||
+        options.concurrency !== undefined
+      ) {
+        return fallback(input, options)
+      }
+      if (!(typeof input === "object" && input !== null && !Array.isArray(input))) {
+        return Effect.fail(new SchemaIssue.InvalidType(ast, input, options))
+      }
+      properties ??= ast.propertySignatures.map((property) => ({
+        parser: compileConstructorDefault(property.type),
+        name: property.name,
+        type: property.type
+      }))
+      const record = input as Record<PropertyKey, unknown>
+      const out: Record<PropertyKey, unknown> = {}
+      const state: ObjectParserState = {
+        ast,
+        input: record,
+        out,
+        issues: undefined,
+        options
+      }
+      try {
+        for (let index = 0; index < properties.length; index++) {
+          const property = properties[index]
+          const name = property.name
+          if (!Object.hasOwn(record, name)) {
+            const result = property.parser(InternalParser.missing, options)
+            if (!effectIsExit(result)) {
+              return resume(state, index, result)
+            }
+            if (result._tag === "Failure") {
+              return wrapPropertyKeyIssue(state, ast, name, result) ?? Exit.void
+            }
+            const value = (result as InternalParser.Success<unknown, SchemaIssue.Issue>)[InternalParser.args]
+            if (value === InternalParser.missing) {
+              if (isOptional(property.type)) continue
+              return Effect.fail(
+                new SchemaIssue.Composite(
+                  ast,
+                  [new SchemaIssue.Pointer([name], new SchemaIssue.MissingKey(property.type.context?.annotations))],
+                  input,
+                  options
+                )
+              )
+            }
+            InternalRecord.assignProperty(out, name, value)
+            continue
+          }
+
+          const value = record[name]
+          const result = property.parser(value, options)
+          if (!effectIsExit(result)) {
+            return resume(state, index, result)
+          }
+          if (result._tag === "Failure") {
+            return wrapPropertyKeyIssue(state, ast, name, result) ?? Exit.void
+          }
+          if (result === InternalParser.sameExit) {
+            InternalRecord.assignProperty(out, name, value)
+            continue
+          }
+          const parsed = (result as InternalParser.Success<unknown, SchemaIssue.Issue>)[InternalParser.args]
+          if (parsed === InternalParser.missing) {
+            if (isOptional(property.type)) continue
+            return Effect.fail(
+              new SchemaIssue.Composite(
+                ast,
+                [new SchemaIssue.Pointer([name], new SchemaIssue.MissingKey(property.type.context?.annotations))],
+                input,
+                options
+              )
+            )
+          }
+          InternalRecord.assignProperty(out, name, parsed)
+        }
+      } catch (error) {
+        return Effect.die(error)
+      }
+      return InternalParser.succeed(out)
+    }
+    return fast
   }
   private _rebuild(
     recur: (ast: AST) => AST,
@@ -2373,13 +2488,42 @@ type ObjectParserState = {
   readonly input: Record<PropertyKey, unknown>
   readonly options: ParseOptions
   readonly out: Record<PropertyKey, unknown>
-  issues: Array<SchemaIssue.Issue> | undefined
+  issues: Arr.NonEmptyArray<SchemaIssue.Issue> | undefined
 }
 
 type ParsedProperty = {
   readonly parser: SchemaParser.Parser
   readonly name: PropertyKey
   readonly type: AST
+}
+
+function parsePropertyStep(
+  s: ObjectParserState,
+  p: ParsedProperty,
+  exit: Exit.Exit<unknown, SchemaIssue.Issue>
+): Exit.Exit<void, SchemaIssue.Issue> | void {
+  if (exit._tag === "Failure") {
+    return wrapPropertyKeyIssue(s, s.ast, p.name, exit)
+  }
+  if (exit === InternalParser.sameExit) return
+  const value = (exit as InternalParser.Success<unknown, SchemaIssue.Issue>)[InternalParser.args]
+  if (value !== InternalParser.missing) {
+    InternalRecord.assignProperty(s.out, p.name, value)
+    return
+  }
+  delete s.out[p.name]
+  if (!isOptional(p.type)) {
+    const issue = new SchemaIssue.Pointer([p.name], new SchemaIssue.MissingKey(p.type.context?.annotations))
+    if (s.options.errors === "all") {
+      if (s.issues) s.issues.push(issue)
+      else s.issues = [issue]
+      return
+    } else {
+      return Exit.fail(
+        new SchemaIssue.Composite(s.ast, [issue], s.input, s.options)
+      )
+    }
+  }
 }
 
 const parseProperties = iterateEager<ObjectParserState, ParsedProperty>()({
@@ -2391,30 +2535,7 @@ const parseProperties = iterateEager<ObjectParserState, ParsedProperty>()({
     InternalRecord.assignProperty(s.out, p.name, value)
     return p.parser(value, s.options)
   },
-  step(s, p, exit) {
-    if (exit._tag === "Failure") {
-      return wrapPropertyKeyIssue(s, s.ast, p.name, exit)
-    }
-    if (exit === InternalParser.sameExit) return
-    const value = (exit as InternalParser.Success<unknown, SchemaIssue.Issue>)[InternalParser.args]
-    if (value !== InternalParser.missing) {
-      InternalRecord.assignProperty(s.out, p.name, value)
-      return
-    }
-    delete s.out[p.name]
-    if (!isOptional(p.type)) {
-      const issue = new SchemaIssue.Pointer([p.name], new SchemaIssue.MissingKey(p.type.context?.annotations))
-      if (s.options.errors === "all") {
-        if (s.issues) s.issues.push(issue)
-        else s.issues = [issue]
-        return
-      } else {
-        return Exit.fail(
-          new SchemaIssue.Composite(s.ast, [issue], s.input, s.options)
-        )
-      }
-    }
-  }
+  step: parsePropertyStep
 })
 
 function combineChecks(a: Checks | undefined, b: Checks | undefined): Checks | undefined {

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -2192,15 +2192,7 @@ export class Objects extends Base {
       }) :
       undefined
 
-    const fallback: SchemaParser.Parser = Effect.fnUntracedEager(function*(input, options) {
-      if (input === InternalParser.missing) {
-        return InternalParser.missing
-      }
-
-      // If the input is not a record, return early with an error
-      if (!(typeof input === "object" && input !== null && !Array.isArray(input))) {
-        return yield* Effect.fail(new SchemaIssue.InvalidType(ast, input, options))
-      }
+    const compileMembers = (): Array<ParsedProperty> => {
       if (!properties) {
         properties = ast.propertySignatures.map((ps) => ({
           parser: compileConstructorDefault(ps.type),
@@ -2215,6 +2207,19 @@ export class Objects extends Base {
           }))
           : undefined
       }
+      return properties
+    }
+
+    const fallback: SchemaParser.Parser = Effect.fnUntracedEager(function*(input, options) {
+      if (input === InternalParser.missing) {
+        return InternalParser.missing
+      }
+
+      // If the input is not a record, return early with an error
+      if (!(typeof input === "object" && input !== null && !Array.isArray(input))) {
+        return yield* Effect.fail(new SchemaIssue.InvalidType(ast, input, options))
+      }
+      compileMembers()
 
       const record = input as Record<PropertyKey, unknown>
       const out: Record<PropertyKey, unknown> = {}
@@ -2323,32 +2328,26 @@ export class Objects extends Base {
 
     if (indexCount) return fallback
 
-    const finish = (state: ObjectParserState): Effect.Effect<unknown, SchemaIssue.Issue, any> => {
-      if (state.issues) {
-        return Effect.fail(
-          new SchemaIssue.Composite(ast, state.issues, state.input, state.options)
-        )
-      }
-      return InternalParser.succeed(state.out)
-    }
+    // Resumes at the property whose parser suspended, without replaying the
+    // properties already parsed.
     const resume = (
       state: ObjectParserState,
       index: number,
       pending: Effect.Effect<unknown, SchemaIssue.Issue, any>
     ): Effect.Effect<unknown, SchemaIssue.Issue, any> => {
       const property = properties![index]
-      if (Object.hasOwn(state.input, property.name)) {
-        InternalRecord.assignProperty(state.out, property.name, state.input[property.name])
-      }
       return Effect.flatMap(Effect.exit(pending), (exit) => {
-        const terminal = parsePropertyStep(state, property, exit)
+        const terminal = stepProperty(state, property, exit)
         if (terminal) return terminal
-        const remaining = properties!.slice(index + 1)
-        const effect = remaining.length === 0 ? undefined : parseProperties(state, remaining)
-        return effect ? Effect.flatMap(effect, () => finish(state)) : finish(state)
+        const done = () => InternalParser.succeed(state.out)
+        const eff = parseProperties(state, properties!.slice(index + 1))
+        return eff ? Effect.flatMapEager(eff, done) : done()
       })
     }
-    const fast: SchemaParser.Parser = (input, options) => {
+
+    // Fast path: a struct without index signatures, under the default parse
+    // options, needs none of the generator the fallback runs per value.
+    return (input, options) => {
       if (input === InternalParser.missing) return InternalParser.missingExit
       if (
         options.errors === "all" ||
@@ -2361,80 +2360,33 @@ export class Objects extends Base {
       if (!(typeof input === "object" && input !== null && !Array.isArray(input))) {
         return Effect.fail(new SchemaIssue.InvalidType(ast, input, options))
       }
-      properties ??= ast.propertySignatures.map((property) => ({
-        parser: compileConstructorDefault(property.type),
-        name: property.name,
-        type: property.type
-      }))
+      const props = compileMembers()
       const record = input as Record<PropertyKey, unknown>
       const out: Record<PropertyKey, unknown> = {}
-      const state: ObjectParserState = {
-        ast,
-        input: record,
-        out,
-        issues: undefined,
-        options
-      }
+      const state: ObjectParserState = { ast, input: record, out, issues: undefined, options }
       try {
-        for (let index = 0; index < properties.length; index++) {
-          const property = properties[index]
+        for (let index = 0; index < props.length; index++) {
+          const property = props[index]
           const name = property.name
-          if (!Object.hasOwn(record, name)) {
-            const result = property.parser(InternalParser.missing, options)
-            if (!effectIsExit(result)) {
-              return resume(state, index, result)
-            }
-            if (result._tag === "Failure") {
-              return wrapPropertyKeyIssue(state, ast, name, result) ?? Exit.void
-            }
-            const value = (result as InternalParser.Success<unknown, SchemaIssue.Issue>)[InternalParser.args]
-            if (value === InternalParser.missing) {
-              if (isOptional(property.type)) continue
-              return Effect.fail(
-                new SchemaIssue.Composite(
-                  ast,
-                  [new SchemaIssue.Pointer([name], new SchemaIssue.MissingKey(property.type.context?.annotations))],
-                  input,
-                  options
-                )
-              )
-            }
-            InternalRecord.assignProperty(out, name, value)
+          const hasKey = Object.hasOwn(record, name)
+          const value = hasKey ? record[name] : InternalParser.missing
+          const exit = property.parser(value, options)
+          if (!effectIsExit(exit)) {
+            return resume(state, index, exit)
+          }
+          if (exit === InternalParser.sameExit) {
+            if (hasKey) InternalRecord.assignProperty(out, name, value)
             continue
           }
-
-          const value = record[name]
-          const result = property.parser(value, options)
-          if (!effectIsExit(result)) {
-            return resume(state, index, result)
-          }
-          if (result._tag === "Failure") {
-            return wrapPropertyKeyIssue(state, ast, name, result) ?? Exit.void
-          }
-          if (result === InternalParser.sameExit) {
-            InternalRecord.assignProperty(out, name, value)
-            continue
-          }
-          const parsed = (result as InternalParser.Success<unknown, SchemaIssue.Issue>)[InternalParser.args]
-          if (parsed === InternalParser.missing) {
-            if (isOptional(property.type)) continue
-            return Effect.fail(
-              new SchemaIssue.Composite(
-                ast,
-                [new SchemaIssue.Pointer([name], new SchemaIssue.MissingKey(property.type.context?.annotations))],
-                input,
-                options
-              )
-            )
-          }
-          InternalRecord.assignProperty(out, name, parsed)
+          const terminal = stepProperty(state, property, exit)
+          if (terminal) return terminal
         }
       } catch (error) {
+        // `Effect.fnUntracedEager` turns a synchronous throw into a defect
         return Effect.die(error)
       }
       return InternalParser.succeed(out)
     }
-    return fast
   }
   private _rebuild(
     recur: (ast: AST) => AST,
@@ -2488,7 +2440,7 @@ type ObjectParserState = {
   readonly input: Record<PropertyKey, unknown>
   readonly options: ParseOptions
   readonly out: Record<PropertyKey, unknown>
-  issues: Arr.NonEmptyArray<SchemaIssue.Issue> | undefined
+  issues: Array<SchemaIssue.Issue> | undefined
 }
 
 type ParsedProperty = {
@@ -2497,7 +2449,7 @@ type ParsedProperty = {
   readonly type: AST
 }
 
-function parsePropertyStep(
+function stepProperty(
   s: ObjectParserState,
   p: ParsedProperty,
   exit: Exit.Exit<unknown, SchemaIssue.Issue>
@@ -2535,7 +2487,7 @@ const parseProperties = iterateEager<ObjectParserState, ParsedProperty>()({
     InternalRecord.assignProperty(s.out, p.name, value)
     return p.parser(value, s.options)
   },
-  step: parsePropertyStep
+  step: stepProperty
 })
 
 function combineChecks(a: Checks | undefined, b: Checks | undefined): Checks | undefined {

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -48,6 +48,22 @@ const SnakeToCamel = Schema.String.pipe(
 )
 
 describe("Schema", () => {
+  it("keeps synchronous decode and encode effects eager", () => {
+    const decodeSuccess = Schema.decodeUnknownEffect(Schema.String)("a")
+    const decodeFailure = Schema.decodeUnknownEffect(Schema.String)(null)
+    const encodeSuccess = Schema.encodeUnknownEffect(Schema.String)("a")
+    const encodeFailure = Schema.encodeUnknownEffect(Schema.String)(null)
+
+    assertTrue(Exit.isSuccess(decodeSuccess))
+    assertTrue(Exit.isFailure(decodeFailure))
+    assertTrue(Exit.isSuccess(encodeSuccess))
+    assertTrue(Exit.isFailure(encodeFailure))
+    assertTrue(Cause.hasFails(decodeFailure.cause))
+    assertTrue(Cause.hasFails(encodeFailure.cause))
+    assertTrue(Schema.isSchemaError(decodeFailure.cause.reasons[0].error))
+    assertTrue(Schema.isSchemaError(encodeFailure.cause.reasons[0].error))
+  })
+
   it("isSchema", () => {
     class A extends Schema.Class<A>("A")(Schema.Struct({
       a: Schema.String

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -34,7 +34,14 @@ import {
 import { TestSchema } from "effect/testing"
 import { produce } from "immer"
 import { deepStrictEqual, fail, strictEqual } from "node:assert"
-import { assertFalse, assertInclude, assertSchemaIssueError, assertTrue, throws } from "../utils/assert.ts"
+import {
+  assertExitSuccess,
+  assertFalse,
+  assertInclude,
+  assertSchemaIssueError,
+  assertTrue,
+  throws
+} from "../utils/assert.ts"
 
 const verifyGeneration = true
 
@@ -49,19 +56,27 @@ const SnakeToCamel = Schema.String.pipe(
 
 describe("Schema", () => {
   it("keeps synchronous decode and encode effects eager", () => {
-    const decodeSuccess = Schema.decodeUnknownEffect(Schema.String)("a")
-    const decodeFailure = Schema.decodeUnknownEffect(Schema.String)(null)
-    const encodeSuccess = Schema.encodeUnknownEffect(Schema.String)("a")
-    const encodeFailure = Schema.encodeUnknownEffect(Schema.String)(null)
+    // A synchronous parser already produces an `Exit`, so the adapter must hand
+    // it back as-is instead of wrapping it in something a fiber has to run.
+    const eagerExit = <A>(effect: Effect.Effect<A, Schema.SchemaError>): Exit.Exit<A, Schema.SchemaError> => {
+      assertTrue(Exit.isExit(effect), "expected the adapter to return an Exit")
+      return effect as Exit.Exit<A, Schema.SchemaError>
+    }
+    const schemaError = <A>(exit: Exit.Exit<A, Schema.SchemaError>) =>
+      Exit.isFailure(exit) ? Cause.findErrorOption(exit.cause) : Option.none()
 
-    assertTrue(Exit.isSuccess(decodeSuccess))
-    assertTrue(Exit.isFailure(decodeFailure))
-    assertTrue(Exit.isSuccess(encodeSuccess))
-    assertTrue(Exit.isFailure(encodeFailure))
-    assertTrue(Cause.hasFails(decodeFailure.cause))
-    assertTrue(Cause.hasFails(encodeFailure.cause))
-    assertTrue(Schema.isSchemaError(decodeFailure.cause.reasons[0].error))
-    assertTrue(Schema.isSchemaError(encodeFailure.cause.reasons[0].error))
+    assertExitSuccess(eagerExit(Schema.decodeUnknownEffect(Schema.String)("a")), "a")
+    assertExitSuccess(eagerExit(Schema.encodeUnknownEffect(Schema.String)("a")), "a")
+
+    for (
+      const effect of [
+        Schema.decodeUnknownEffect(Schema.String)(null),
+        Schema.encodeUnknownEffect(Schema.String)(null)
+      ]
+    ) {
+      const error = schemaError(eagerExit(effect))
+      assertTrue(Option.isSome(error) && Schema.isSchemaError(error.value))
+    }
   })
 
   it("isSchema", () => {

--- a/packages/effect/test/schema/SchemaParser.test.ts
+++ b/packages/effect/test/schema/SchemaParser.test.ts
@@ -528,6 +528,18 @@ describe("SchemaParser", () => {
       strictEqual(calls.join(","), "a,b,c")
     })
 
+    it("converts synchronous property parser throws into defects", () => {
+      const field = Schema.declareConstructor<string>()([], () => () => {
+        throw new Error("property defect")
+      })
+      const schema = Schema.Struct({ field })
+
+      const exit = SchemaParser.decodeUnknownExit(schema)({ field: "value" })
+
+      assertTrue(Exit.isFailure(exit))
+      assertTrue(Cause.hasDies(exit.cause))
+    })
+
     it("keeps encoding-link parser compilation lazy for Suspend", () => {
       let evaluations = 0
       const schema = Schema.suspend(() => {


### PR DESCRIPTION
Preserve completed parser exits when adapting Schema issues to `SchemaError`, avoiding a fiber run for synchronous decode and encode calls.

Use a direct, resumable property loop for structs without index signatures under the common parse options. Suspended child parsers resume from their current property without replaying earlier fields; other option modes keep the existing interpreter.

Adds regression coverage for eager Schema adapters and defect conversion in the struct fast path.

Tests:

- `pnpm --dir packages/effect check`
- `pnpm lint`
- `pnpm test --run` (388 files, 9,981 passed, 1 expected failure, 55 skipped)

Closes EFF-798
