### PR TITLE
Simplify Cloudflare Durable Object framework integration

### DIFF
--- a/.changeset/cloudflare-cluster.md
+++ b/.changeset/cloudflare-cluster.md
@@ -6,8 +6,8 @@ Add the `@effect/platform-cloudflare` package, running Effect Cluster on
 Cloudflare Workers and Durable Objects.
 
 One entity instance is one Durable Object with its SQLite storage as the
-system of record. The package provides the four Durable Object classes
-(entity, workflow, durable queue, singleton), the length-prefixed entity name
+system of record. The package provides the four Durable Object classes and
+class-independent programs (entity, workflow, durable queue, singleton), the length-prefixed entity name
 encoding, and `CloudflareCluster.layer`, which wires the cluster `Sharding`
 service, the `WorkflowEngine`, and the `PersistedQueueFactory` from the
 same-Worker namespace bindings. The `Entity`, `Workflow`, `Activity`,

--- a/.changeset/cloudflare-cluster.md
+++ b/.changeset/cloudflare-cluster.md
@@ -13,4 +13,7 @@ service, the `WorkflowEngine`, and the `PersistedQueueFactory` from the
 same-Worker namespace bindings. The `Entity`, `Workflow`, `Activity`,
 `DurableClock`, `DurableQueue`, `Singleton`, and `ClusterCron` user APIs are
 unchanged on this path; every `DurableClock` is durable through the object's
-alarm.
+alarm. Workflow Durable Objects receive their `Workflow.toLayer` handlers when
+the program is configured or the class is created through
+`ClusterWorkflow.make`, so every activation can replay from SQLite without
+depending on isolate-global registration state.

--- a/packages/platform/cloudflare/README.md
+++ b/packages/platform/cloudflare/README.md
@@ -10,7 +10,9 @@ npm install effect@rc @effect/platform-cloudflare@rc
 
 ## Usage
 
-The package ships four Durable Object classes. Re-export them from your Worker entry module and bind each one as a SQLite-backed class:
+The package ships three fixed Durable Object classes and a configurable
+workflow Durable Object class. Export them from your Worker entry module and
+bind each one as a SQLite-backed class:
 
 ```jsonc
 // wrangler.jsonc
@@ -45,17 +47,29 @@ The package ships four Durable Object classes. Re-export them from your Worker e
 
 ```ts
 // src/worker.ts
-import { CloudflareCluster } from "@effect/platform-cloudflare"
+import { CloudflareCluster, CloudflareDurableObjects } from "@effect/platform-cloudflare"
 import { Effect, Layer, Schema } from "effect"
 import { Entity, Singleton } from "effect/unstable/cluster"
 import { Rpc } from "effect/unstable/rpc"
+import { Workflow } from "effect/unstable/workflow"
 
 export {
   ClusterDurableQueue,
   ClusterEntity,
-  ClusterSingleton,
-  ClusterWorkflow
+  ClusterSingleton
 } from "@effect/platform-cloudflare/CloudflareDurableObjects"
+
+const Greeting = Workflow.make("Greeting", {
+  payload: { name: Schema.String },
+  success: Schema.String,
+  idempotencyKey: ({ name }) => name
+})
+
+const WorkflowLayer = Greeting.toLayer(({ name }) => Effect.succeed(`Hello, ${name}!`))
+
+export class ClusterWorkflow extends CloudflareDurableObjects.ClusterWorkflow.make({
+  workflows: WorkflowLayer
+}) {}
 
 // The same Entity + RpcGroup definitions as on every other cluster path
 const Counter = Entity.make("Counter", [

--- a/packages/platform/cloudflare/src/CloudflareCluster.ts
+++ b/packages/platform/cloudflare/src/CloudflareCluster.ts
@@ -496,8 +496,8 @@ const make = Effect.fnUntraced(function*(options: LayerOptions) {
  * unknown entity type or a bad encode fails at the Worker before any Durable
  * Object is contacted. Entity handlers registered with `Entity.toLayer` are
  * recorded per `EntityType` at Worker init and built once per Durable Object
- * wake; workflow handlers registered with `Workflow.toLayer` follow the same
- * pattern on the workflow class.
+ * wake. Workflow handlers are supplied to the workflow Durable Object program
+ * or `ClusterWorkflow.make` and rebuilt on each activation.
  *
  * @category layers
  * @since 4.0.0

--- a/packages/platform/cloudflare/src/CloudflareDurableObjectPrograms.ts
+++ b/packages/platform/cloudflare/src/CloudflareDurableObjectPrograms.ts
@@ -6,11 +6,14 @@
  */
 import type { DurableObjectStorage } from "@cloudflare/workers-types"
 import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
 import * as ClusterMetrics from "effect/unstable/cluster/ClusterMetrics"
 import * as EntityAddress from "effect/unstable/cluster/EntityAddress"
 import * as EntityId from "effect/unstable/cluster/EntityId"
 import * as EntityType from "effect/unstable/cluster/EntityType"
 import * as ShardId from "effect/unstable/cluster/ShardId"
+import * as WorkflowEngine from "effect/unstable/workflow/WorkflowEngine"
+import { makeWithRegistry } from "./CloudflareWorkflowEngine.ts"
 import { decodeName, encodeName } from "./internal/clusterName.ts"
 import { makeEntityKeepAlive } from "./internal/entityKeepAlive.ts"
 import { makeEntityManager } from "./internal/entityRuntime.ts"
@@ -20,7 +23,7 @@ import { earliestLeaseExpiry } from "./internal/queueStorage.ts"
 import { getSingletonRegistration } from "./internal/singletonRegistry.ts"
 import { makeSingletonRuntime } from "./internal/singletonRuntime.ts"
 import { ensureSingletonStorage, loadSingletonState, rememberSingletonName } from "./internal/singletonStorage.ts"
-import type { WorkflowStub } from "./internal/workflowRegistry.ts"
+import { makeWorkflowRegistry, type WorkflowStub } from "./internal/workflowRegistry.ts"
 import { makeWorkflowRuntime } from "./internal/workflowRuntime.ts"
 import { earliestClockWakeUp, ensureWorkflowStorage, loadExecution } from "./internal/workflowStorage.ts"
 
@@ -187,6 +190,23 @@ export interface ClusterWorkflowProgram {
 }
 
 /**
+ * Configuration for a workflow Durable Object program.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ClusterWorkflowProgramOptions<E = never, R = never> {
+  /** Workflow handlers built once for each Durable Object activation. */
+  readonly workflows: Layer.Layer<never, E, WorkflowEngine.WorkflowEngine | R>
+  /**
+   * Exported Durable Object class used for child and parent workflow delivery.
+   *
+   * @default "ClusterWorkflow"
+   */
+  readonly workflowClassName?: string | undefined
+}
+
+/**
  * Creates an Effect that initializes and returns the handlers for a workflow
  * execution Durable Object.
  *
@@ -194,17 +214,37 @@ export interface ClusterWorkflowProgram {
  *
  * Use when a framework creates the native Durable Object class and needs the
  * Effect Workflow journal, alarm, and RPC behavior without extending the
- * bundled `ClusterWorkflow` class.
+ * generated workflow Durable Object class.
  *
  * **Details**
  *
- * Run the returned Effect during Durable Object initialization. It restores
- * persisted alarms before returning the handler object.
+ * Run the returned Effect during Durable Object initialization. It installs
+ * the supplied workflow handlers in an activation-local registry, validates a
+ * persisted execution against that registry, and restores persisted alarms
+ * before returning the handler object.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const makeClusterWorkflowProgram = Effect.fnUntraced(function*(state: DurableObjectProgramState) {
+export const makeClusterWorkflowProgram = Effect.fnUntraced(function*<E, R>(
+  state: DurableObjectProgramState,
+  options: ClusterWorkflowProgramOptions<E, R>
+) {
+  const workflowClassName = options.workflowClassName ?? "ClusterWorkflow"
+  const namespace = exportedNamespace<WorkflowStub>(state, workflowClassName)
+  if (namespace === undefined) {
+    return yield* Effect.die(
+      `CloudflareCluster: ${workflowClassName} export is unavailable for workflow delivery`
+    )
+  }
+  const getWorkflowStub = (name: string) => namespace.getByName(name)
+  const registry = makeWorkflowRegistry()
+  const engine = yield* makeWithRegistry({ getByName: getWorkflowStub }, registry)
+  const scope = yield* Effect.scope
+  yield* options.workflows.pipe(
+    Layer.provide(Layer.succeed(WorkflowEngine.WorkflowEngine)(engine)),
+    Layer.buildWithScope(scope)
+  )
   ensureWorkflowStorage(state.storage.sql)
   let name: string | undefined
   if (state.id.name !== undefined) {
@@ -215,6 +255,12 @@ export const makeClusterWorkflowProgram = Effect.fnUntraced(function*(state: Dur
   } else {
     const stored = loadExecution(state.storage.sql)
     name = stored === undefined ? undefined : encodeName(stored.workflowName, stored.executionId)
+  }
+  const workflowName = name === undefined ? undefined : decodeName(name)?.type
+  if (workflowName !== undefined && registry.get(workflowName) === undefined) {
+    return yield* Effect.die(
+      `ClusterWorkflow: workflow '${workflowName}' is not configured for this Durable Object class`
+    )
   }
   let runtime: ReturnType<typeof makeWorkflowRuntime> | undefined
   const getRuntime = () => {
@@ -228,13 +274,8 @@ export const makeClusterWorkflowProgram = Effect.fnUntraced(function*(state: Dur
       alarm: state.storage,
       now: () => Date.now(),
       waitUntil: (promise) => state.waitUntil(promise),
-      getStub: (objectName) => {
-        const namespace = exportedNamespace<WorkflowStub>(state, "ClusterWorkflow")
-        if (namespace === undefined) {
-          throw new Error("CloudflareCluster: ClusterWorkflow export is unavailable for workflow delivery")
-        }
-        return namespace.getByName(objectName)
-      }
+      getStub: getWorkflowStub,
+      getRegistration: registry.get
     })
     return runtime
   }

--- a/packages/platform/cloudflare/src/CloudflareDurableObjectPrograms.ts
+++ b/packages/platform/cloudflare/src/CloudflareDurableObjectPrograms.ts
@@ -1,0 +1,407 @@
+/**
+ * Class-independent Durable Object programs behind the Cloudflare cluster
+ * integration.
+ *
+ * @since 4.0.0
+ */
+import type { DurableObjectStorage } from "@cloudflare/workers-types"
+import * as Effect from "effect/Effect"
+import * as ClusterMetrics from "effect/unstable/cluster/ClusterMetrics"
+import * as EntityAddress from "effect/unstable/cluster/EntityAddress"
+import * as EntityId from "effect/unstable/cluster/EntityId"
+import * as EntityType from "effect/unstable/cluster/EntityType"
+import * as ShardId from "effect/unstable/cluster/ShardId"
+import { decodeName, encodeName } from "./internal/clusterName.ts"
+import { makeEntityKeepAlive } from "./internal/entityKeepAlive.ts"
+import { makeEntityManager } from "./internal/entityRuntime.ts"
+import { armAlarm, earliestDeliverAt, ensureEntityStorage } from "./internal/entityStorage.ts"
+import { makeQueueRuntime } from "./internal/queueRuntime.ts"
+import { earliestLeaseExpiry } from "./internal/queueStorage.ts"
+import { getSingletonRegistration } from "./internal/singletonRegistry.ts"
+import { makeSingletonRuntime } from "./internal/singletonRuntime.ts"
+import { ensureSingletonStorage, loadSingletonState, rememberSingletonName } from "./internal/singletonStorage.ts"
+import type { WorkflowStub } from "./internal/workflowRegistry.ts"
+import { makeWorkflowRuntime } from "./internal/workflowRuntime.ts"
+import { earliestClockWakeUp, ensureWorkflowStorage, loadExecution } from "./internal/workflowStorage.ts"
+
+const exportedNamespace = <Stub>(
+  state: DurableObjectProgramState,
+  className: string
+): { readonly getByName: (name: string) => Stub } | undefined =>
+  state.exports[className] as
+    | { readonly getByName: (name: string) => Stub }
+    | undefined
+
+/**
+ * Native Durable Object capabilities required by the cluster programs.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface DurableObjectProgramState {
+  readonly id: { readonly name?: string | undefined }
+  readonly storage: DurableObjectStorage
+  readonly exports: Record<string, unknown>
+  readonly waitUntil: (promise: Promise<unknown>) => void
+}
+
+/**
+ * Delivery options accepted by the cluster entity transport program.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface EntityDeliveryOptions {
+  readonly deliverAt?: number | undefined
+  readonly primaryKey?: string | null | undefined
+  readonly replyTo?: string | undefined
+}
+
+/**
+ * Result returned by the cluster entity transport program.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type EntityInvokeResult = {
+  readonly _tag: "Success"
+  readonly requestId: string
+  readonly replies: ReadonlyArray<string>
+} | {
+  readonly _tag: "MailboxFull"
+} | {
+  readonly _tag: "EncodedMessageTooLarge"
+} | {
+  readonly _tag: "AskDeduplicatedToTell"
+}
+
+/**
+ * Effect-valued program for one cluster entity Durable Object instance.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ClusterEntityProgram {
+  readonly alarm: () => Effect.Effect<void>
+  readonly hold: () => Effect.Effect<void>
+  readonly invoke: (
+    envelopeText: string,
+    discard: boolean,
+    delivery?: EntityDeliveryOptions
+  ) => Effect.Effect<EntityInvokeResult>
+  readonly acknowledge: (requestId: string, replyId: string) => Effect.Effect<ReadonlyArray<string>>
+  readonly interrupt: (storageRequestId: string, clientRequestId?: string) => Effect.Effect<void>
+  readonly reset: (requestId: string) => Effect.Effect<void>
+  readonly deliverReply: (requestId: string, reply: string) => Effect.Effect<boolean>
+}
+
+/**
+ * Creates an Effect that initializes and returns the handlers for a cluster
+ * entity Durable Object.
+ *
+ * **When to use**
+ *
+ * Use when a framework creates the native Durable Object class and needs the
+ * entity persistence, alarm, and RPC behavior without extending the bundled
+ * `ClusterEntity` class.
+ *
+ * **Details**
+ *
+ * Run the returned Effect during Durable Object initialization. It restores
+ * persisted alarms before returning the handler object.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const makeClusterEntityProgram = Effect.fnUntraced(function*(state: DurableObjectProgramState) {
+  const entityName = state.id.name ?? ""
+  const name = decodeName(entityName)
+  if (name === undefined) throw new Error("ClusterEntity requires a canonical entity Durable Object name")
+  const keepAlive = makeEntityKeepAlive(() => {
+    const namespace = exportedNamespace<{ readonly hold: () => Promise<void> }>(state, "ClusterEntity")
+    if (namespace === undefined) {
+      return Promise.reject(
+        new Error("CloudflareCluster: ClusterEntity export is unavailable for keep-alive")
+      )
+    }
+    return namespace.getByName(entityName).hold()
+  })
+  const manager = makeEntityManager({
+    storage: state.storage,
+    address: EntityAddress.make({
+      shardId: ShardId.make("default", 1),
+      entityType: EntityType.make(name.type),
+      entityId: EntityId.make(name.id)
+    }),
+    entityName,
+    keepAlive,
+    waitUntil: (effect) => state.waitUntil(Effect.runPromise(effect)),
+    getNamespace: () =>
+      exportedNamespace<{
+        readonly deliverReply: (requestId: string, reply: string) => Promise<boolean>
+      }>(state, "ClusterEntity")
+  })
+  const sql = state.storage.sql
+  ensureEntityStorage(sql)
+  const deliverAt = earliestDeliverAt(sql)
+  if (deliverAt !== undefined) {
+    yield* armAlarm(state.storage, deliverAt)
+  }
+  return {
+    alarm: () => manager.alarm,
+    hold: () => keepAlive.await,
+    invoke: (envelopeText, discard, delivery) => manager.invoke(envelopeText, discard, delivery),
+    acknowledge: manager.acknowledge,
+    interrupt: manager.interrupt,
+    reset: manager.reset,
+    deliverReply: manager.deliverReply
+  } satisfies ClusterEntityProgram
+})
+
+/**
+ * Execution options accepted by the cluster workflow program.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ClusterWorkflowRunOptions {
+  readonly discard: boolean
+  readonly parent?: { readonly workflowName: string; readonly executionId: string } | undefined
+}
+
+/**
+ * Effect-valued program for one workflow execution Durable Object.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ClusterWorkflowProgram {
+  readonly run: (payload: string, options: ClusterWorkflowRunOptions) => Effect.Effect<string>
+  readonly poll: () => Effect.Effect<string | undefined>
+  readonly resume: () => Effect.Effect<void>
+  readonly interrupt: () => Effect.Effect<void>
+  readonly interruptUnsafe: () => Effect.Effect<void>
+  readonly deferredDone: (name: string, exit: string) => Effect.Effect<void>
+  readonly scheduleClock: (name: string, deferredName: string, wakeUp: number) => Effect.Effect<void>
+  readonly alarm: () => Effect.Effect<void>
+}
+
+/**
+ * Creates an Effect that initializes and returns the handlers for a workflow
+ * execution Durable Object.
+ *
+ * **When to use**
+ *
+ * Use when a framework creates the native Durable Object class and needs the
+ * Effect Workflow journal, alarm, and RPC behavior without extending the
+ * bundled `ClusterWorkflow` class.
+ *
+ * **Details**
+ *
+ * Run the returned Effect during Durable Object initialization. It restores
+ * persisted alarms before returning the handler object.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const makeClusterWorkflowProgram = Effect.fnUntraced(function*(state: DurableObjectProgramState) {
+  ensureWorkflowStorage(state.storage.sql)
+  let name: string | undefined
+  if (state.id.name !== undefined) {
+    if (decodeName(state.id.name) === undefined) {
+      throw new Error("ClusterWorkflow requires a canonical workflow Durable Object name")
+    }
+    name = state.id.name
+  } else {
+    const stored = loadExecution(state.storage.sql)
+    name = stored === undefined ? undefined : encodeName(stored.workflowName, stored.executionId)
+  }
+  let runtime: ReturnType<typeof makeWorkflowRuntime> | undefined
+  const getRuntime = () => {
+    if (runtime !== undefined) return runtime
+    if (name === undefined) {
+      throw new Error("ClusterWorkflow requires a canonical workflow Durable Object name")
+    }
+    runtime = makeWorkflowRuntime({
+      name,
+      sql: state.storage.sql,
+      alarm: state.storage,
+      now: () => Date.now(),
+      waitUntil: (promise) => state.waitUntil(promise),
+      getStub: (objectName) => {
+        const namespace = exportedNamespace<WorkflowStub>(state, "ClusterWorkflow")
+        if (namespace === undefined) {
+          throw new Error("CloudflareCluster: ClusterWorkflow export is unavailable for workflow delivery")
+        }
+        return namespace.getByName(objectName)
+      }
+    })
+    return runtime
+  }
+  const wakeUp = earliestClockWakeUp(state.storage.sql)
+  if (wakeUp !== undefined) {
+    yield* armAlarm(state.storage, wakeUp)
+  }
+  return {
+    run: (payload, options) => Effect.promise(() => getRuntime().run(payload, options)),
+    poll: () => Effect.promise(() => getRuntime().poll()),
+    resume: () => Effect.promise(() => getRuntime().resume()),
+    interrupt: () => Effect.promise(() => getRuntime().interrupt()),
+    interruptUnsafe: () => Effect.promise(() => getRuntime().interruptUnsafe()),
+    deferredDone: (deferredName, exit) => Effect.promise(() => getRuntime().deferredDone(deferredName, exit)),
+    scheduleClock: (clockName, deferredName, wakeAt) =>
+      Effect.promise(() => getRuntime().scheduleClock(clockName, deferredName, wakeAt)),
+    alarm: () => name === undefined ? Effect.void : Effect.promise(() => getRuntime().runAlarm())
+  } satisfies ClusterWorkflowProgram
+})
+
+/**
+ * Item leased from the durable queue program.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface DurableQueueItem {
+  readonly id: string
+  readonly element: string
+  readonly attempts: number
+}
+
+/**
+ * Effect-valued program for one durable queue Durable Object.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ClusterDurableQueueProgram {
+  readonly offer: (id: string, element: string) => Effect.Effect<void>
+  readonly take: (takerId: string, maxAttempts: number, leaseMillis: number) => Effect.Effect<DurableQueueItem>
+  readonly cancelTake: (takerId: string) => Effect.Effect<void>
+  readonly complete: (id: string) => Effect.Effect<void>
+  readonly fail: (id: string, lastFailure: string) => Effect.Effect<void>
+  readonly release: (id: string) => Effect.Effect<void>
+  readonly extend: (id: string, leaseMillis: number) => Effect.Effect<void>
+  readonly alarm: () => Effect.Effect<void>
+}
+
+/**
+ * Creates an Effect that initializes and returns the handlers for a durable
+ * queue Durable Object.
+ *
+ * **When to use**
+ *
+ * Use when a framework creates the native Durable Object class and needs the
+ * queue persistence, leasing, and alarm behavior without extending the
+ * bundled `ClusterDurableQueue` class.
+ *
+ * **Details**
+ *
+ * Run the returned Effect during Durable Object initialization. It restores
+ * persisted alarms before returning the handler object.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const makeClusterDurableQueueProgram = Effect.fnUntraced(function*(state: DurableObjectProgramState) {
+  if (state.id.name !== undefined && decodeName(state.id.name) === undefined) {
+    throw new Error("ClusterDurableQueue requires a canonical queue Durable Object name")
+  }
+  const runtime = makeQueueRuntime({
+    sql: state.storage.sql,
+    alarm: state.storage,
+    now: () => Date.now()
+  })
+  const expiry = earliestLeaseExpiry(state.storage.sql)
+  if (expiry !== undefined) {
+    yield* armAlarm(state.storage, expiry)
+  }
+  return {
+    offer: (id, element) => Effect.promise(() => runtime.offer(id, element)),
+    take: (takerId, maxAttempts, leaseMillis) => Effect.promise(() => runtime.take(takerId, maxAttempts, leaseMillis)),
+    cancelTake: (takerId) => Effect.promise(() => runtime.cancelTake(takerId)),
+    complete: (id) => Effect.promise(() => runtime.complete(id)),
+    fail: (id, lastFailure) => Effect.promise(() => runtime.fail(id, lastFailure)),
+    release: (id) => Effect.promise(() => runtime.release(id)),
+    extend: (id, leaseMillis) => Effect.promise(() => runtime.extend(id, leaseMillis)),
+    alarm: () => Effect.promise(() => runtime.runAlarm())
+  } satisfies ClusterDurableQueueProgram
+})
+
+/**
+ * Effect-valued program for one cluster singleton Durable Object.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ClusterSingletonProgram {
+  readonly wake: () => Effect.Effect<void>
+  readonly alarm: () => Effect.Effect<void>
+}
+
+/**
+ * Creates an Effect that initializes and returns the handlers for a cluster
+ * singleton Durable Object.
+ *
+ * **When to use**
+ *
+ * Use when a framework creates the native Durable Object class and needs the
+ * singleton wake and watchdog behavior without extending the bundled
+ * `ClusterSingleton` class.
+ *
+ * **Details**
+ *
+ * Run the returned Effect during Durable Object initialization. It restores
+ * persisted alarms before returning the handler object.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const makeClusterSingletonProgram = Effect.fnUntraced(function*(state: DurableObjectProgramState) {
+  const sql = state.storage.sql
+  ensureSingletonStorage(sql)
+  if (state.id.name !== undefined) {
+    if (!state.id.name.startsWith("Singleton/")) {
+      throw new Error("ClusterSingleton requires a Singleton/<name> Durable Object name")
+    }
+    rememberSingletonName(sql, state.id.name)
+  }
+  const stored = loadSingletonState(sql)
+  const name = state.id.name ?? stored.name
+  let runtime: ReturnType<typeof makeSingletonRuntime> | undefined
+  const getRuntime = () => {
+    if (runtime !== undefined) return runtime
+    if (name === undefined) {
+      throw new Error("ClusterSingleton requires a Singleton/<name> Durable Object name")
+    }
+    const registration = getSingletonRegistration(name.slice("Singleton/".length))
+    if (registration === undefined) {
+      throw new Error(`CloudflareCluster: no singleton registered under the name "${name.slice("Singleton/".length)}"`)
+    }
+    const run = Effect.sync(() => {
+      ClusterMetrics.singletons.modifyUnsafe(BigInt(1), registration.context)
+    }).pipe(
+      Effect.andThen(registration.run),
+      Effect.scoped,
+      Effect.ensuring(Effect.sync(() => {
+        ClusterMetrics.singletons.modifyUnsafe(BigInt(-1), registration.context)
+      })),
+      Effect.provideContext(registration.context),
+      Effect.orDie
+    )
+    runtime = makeSingletonRuntime({
+      sql,
+      alarm: state.storage,
+      now: () => Date.now(),
+      run
+    })
+    return runtime
+  }
+  if (stored.wakeAt !== undefined) {
+    yield* armAlarm(state.storage, stored.wakeAt)
+  }
+  return {
+    wake: () => Effect.promise(() => getRuntime().wake()),
+    alarm: () =>
+      loadSingletonState(sql).wakeAt === undefined ? Effect.void : Effect.promise(() => getRuntime().runAlarm())
+  } satisfies ClusterSingletonProgram
+})

--- a/packages/platform/cloudflare/src/CloudflareDurableObjects.ts
+++ b/packages/platform/cloudflare/src/CloudflareDurableObjects.ts
@@ -11,11 +11,13 @@
  */
 import { DurableObject } from "cloudflare:workers"
 import * as Effect from "effect/Effect"
+import * as Scope from "effect/Scope"
 import {
   type ClusterDurableQueueProgram,
   type ClusterEntityProgram,
   type ClusterSingletonProgram,
   type ClusterWorkflowProgram,
+  type ClusterWorkflowProgramOptions,
   type ClusterWorkflowRunOptions,
   type DurableQueueItem,
   type EntityDeliveryOptions,
@@ -91,31 +93,73 @@ export class ClusterEntity extends DurableObject<unknown> {
 }
 
 /**
- * The workflow execution class behind `CloudflareWorkflowEngine`. One
- * instance holds one workflow execution: run state, activity results keyed
- * `${name}/${attempt}`, durable deferred exits, and the clock due table.
+ * Constructor for a configured `ClusterWorkflow` Durable Object class.
  *
- * **Details**
+ * @category models
+ * @since 4.0.0
+ */
+export interface ClusterWorkflowDurableObjectClass {
+  new(ctx: DurableObjectState, env: unknown): ClusterWorkflow
+}
+
+/**
+ * Durable Object class for workflow executions that installs configured
+ * handlers on every activation.
  *
- * The constructor stays cheap: it opens SQLite, ensures the workflow tables,
- * and re-arms the single alarm from the earliest pending clock. Workflow
- * handlers are looked up in the module-level registry and built once per
- * wake.
+ * **When to use**
+ *
+ * Use when exporting a native workflow Durable Object class from a Cloudflare
+ * Worker by extending the class returned by `ClusterWorkflow.make`.
+ *
+ * **Gotchas**
+ *
+ * Its protected constructor means it must be configured through `make` rather
+ * than bound directly. Provide all handler dependencies to `workflows` before
+ * calling `make`.
  *
  * @category durable objects
  * @since 4.0.0
  */
 export class ClusterWorkflow extends DurableObject<unknown> {
   readonly #program: Promise<ClusterWorkflowProgram>
+  readonly #workflowClassName: string
 
-  constructor(ctx: DurableObjectState, env: unknown) {
+  protected constructor(
+    ctx: DurableObjectState,
+    env: unknown,
+    options: ClusterWorkflowProgramOptions<unknown>
+  ) {
     super(ctx, env)
-    this.#program = ctx.blockConcurrencyWhile(() => Effect.runPromise(makeClusterWorkflowProgram(ctx)))
+    this.#workflowClassName = options.workflowClassName ?? "ClusterWorkflow"
+    const scope = Scope.makeUnsafe()
+    this.#program = ctx.blockConcurrencyWhile(() =>
+      Effect.runPromise(
+        makeClusterWorkflowProgram(ctx, options).pipe(Effect.provideService(Scope.Scope, scope))
+      )
+    )
+  }
+
+  /**
+   * Creates a configured workflow Durable Object class.
+   *
+   * **Gotchas**
+   *
+   * `workflowClassName` must match the name used to export and bind the
+   * returned class.
+   *
+   * @since 4.0.0
+   */
+  static make<E>(options: ClusterWorkflowProgramOptions<E>): ClusterWorkflowDurableObjectClass {
+    return class extends ClusterWorkflow {
+      constructor(ctx: DurableObjectState, env: unknown) {
+        super(ctx, env, options)
+      }
+    }
   }
 
   /** @internal Same-Worker RPC transport used by `CloudflareWorkflowEngine`. */
-  run(payload: string, options: ClusterWorkflowRunOptions): Promise<string> {
-    return this.#program.then((program) => Effect.runPromise(program.run(payload, options)))
+  run(payload: string, runOptions: ClusterWorkflowRunOptions): Promise<string> {
+    return this.#program.then((program) => Effect.runPromise(program.run(payload, runOptions)))
   }
 
   /** @internal */
@@ -152,7 +196,11 @@ export class ClusterWorkflow extends DurableObject<unknown> {
     return this.#program.then((program) => Effect.runPromise(program.alarm()))
   }
 
-  override fetch: () => never = notExposed("ClusterWorkflow")
+  override fetch(): never {
+    throw new Error(
+      `@effect/platform-cloudflare: ${this.#workflowClassName} is not exposed over fetch, use the same-Worker namespace binding`
+    )
+  }
 }
 
 /**

--- a/packages/platform/cloudflare/src/CloudflareDurableObjects.ts
+++ b/packages/platform/cloudflare/src/CloudflareDurableObjects.ts
@@ -11,64 +11,25 @@
  */
 import { DurableObject } from "cloudflare:workers"
 import * as Effect from "effect/Effect"
-import * as ClusterMetrics from "effect/unstable/cluster/ClusterMetrics"
-import * as EntityAddress from "effect/unstable/cluster/EntityAddress"
-import * as EntityId from "effect/unstable/cluster/EntityId"
-import * as EntityType from "effect/unstable/cluster/EntityType"
-import * as ShardId from "effect/unstable/cluster/ShardId"
-import { decodeName, encodeName } from "./internal/clusterName.ts"
-import { makeEntityKeepAlive } from "./internal/entityKeepAlive.ts"
-import { makeEntityManager } from "./internal/entityRuntime.ts"
-import { armAlarm, earliestDeliverAt, ensureEntityStorage } from "./internal/entityStorage.ts"
-import { makeQueueRuntime } from "./internal/queueRuntime.ts"
-import { earliestLeaseExpiry, type QueueItem } from "./internal/queueStorage.ts"
-import { getSingletonRegistration } from "./internal/singletonRegistry.ts"
-import { makeSingletonRuntime } from "./internal/singletonRuntime.ts"
-import { ensureSingletonStorage, loadSingletonState, rememberSingletonName } from "./internal/singletonStorage.ts"
-import type { WorkflowRunOptions, WorkflowStub } from "./internal/workflowRegistry.ts"
-import { makeWorkflowRuntime } from "./internal/workflowRuntime.ts"
-import { earliestClockWakeUp, ensureWorkflowStorage, loadExecution } from "./internal/workflowStorage.ts"
+import {
+  type ClusterDurableQueueProgram,
+  type ClusterEntityProgram,
+  type ClusterSingletonProgram,
+  type ClusterWorkflowProgram,
+  type ClusterWorkflowRunOptions,
+  type DurableQueueItem,
+  type EntityDeliveryOptions,
+  type EntityInvokeResult,
+  makeClusterDurableQueueProgram,
+  makeClusterEntityProgram,
+  makeClusterSingletonProgram,
+  makeClusterWorkflowProgram
+} from "./CloudflareDurableObjectPrograms.ts"
 
 const notExposed = (className: string) => () => {
   throw new Error(
     `@effect/platform-cloudflare: ${className} is not exposed over fetch, use the same-Worker namespace binding`
   )
-}
-
-const exportedNamespace = <Stub>(
-  state: DurableObjectState,
-  className: string
-): { readonly getByName: (name: string) => Stub } | undefined =>
-  (state.exports as Record<string, unknown>)[className] as
-    | { readonly getByName: (name: string) => Stub }
-    | undefined
-
-type EntityManager = ReturnType<typeof makeEntityManager>
-
-type WorkflowRuntime = ReturnType<typeof makeWorkflowRuntime>
-
-type QueueRuntime = ReturnType<typeof makeQueueRuntime>
-
-type SingletonRuntime = ReturnType<typeof makeSingletonRuntime>
-
-// Mirrors entityWire's InvokeResult and entityRuntime's DeliveryOptions: the
-// exported class cannot reference an @internal type in its method signatures.
-type InvokeResult = {
-  readonly _tag: "Success"
-  readonly requestId: string
-  readonly replies: ReadonlyArray<string>
-} | {
-  readonly _tag: "MailboxFull"
-} | {
-  readonly _tag: "EncodedMessageTooLarge"
-} | {
-  readonly _tag: "AskDeduplicatedToTell"
-}
-
-interface DeliveryOptions {
-  readonly deliverAt?: number | undefined
-  readonly primaryKey?: string | null | undefined
-  readonly replyTo?: string | undefined
 }
 
 /**
@@ -85,78 +46,45 @@ interface DeliveryOptions {
  * @since 4.0.0
  */
 export class ClusterEntity extends DurableObject<unknown> {
-  readonly #keepAlive
-  readonly #manager: EntityManager
+  readonly #program: Promise<ClusterEntityProgram>
 
   constructor(ctx: DurableObjectState, env: unknown) {
     super(ctx, env)
-    const entityName = ctx.id.name ?? ""
-    const name = decodeName(entityName)
-    if (name === undefined) throw new Error("ClusterEntity requires a canonical entity Durable Object name")
-    this.#keepAlive = makeEntityKeepAlive(() => {
-      const namespace = exportedNamespace<{ readonly hold: () => Promise<void> }>(ctx, "ClusterEntity")
-      if (namespace === undefined) {
-        return Promise.reject(
-          new Error("CloudflareCluster: ClusterEntity export is unavailable for keep-alive")
-        )
-      }
-      return namespace.getByName(entityName).hold()
-    })
-    this.#manager = makeEntityManager({
-      storage: ctx.storage,
-      address: EntityAddress.make({
-        shardId: ShardId.make("default", 1),
-        entityType: EntityType.make(name.type),
-        entityId: EntityId.make(name.id)
-      }),
-      entityName,
-      keepAlive: this.#keepAlive,
-      waitUntil: (effect) => ctx.waitUntil(Effect.runPromise(effect)),
-      getNamespace: () =>
-        exportedNamespace<{
-          readonly deliverReply: (requestId: string, reply: string) => Promise<boolean>
-        }>(ctx, "ClusterEntity")
-    })
-    const sql = ctx.storage.sql
-    ensureEntityStorage(sql)
-    const deliverAt = earliestDeliverAt(sql)
-    if (deliverAt !== undefined) {
-      void ctx.blockConcurrencyWhile(() => Effect.runPromise(armAlarm(ctx.storage, deliverAt)))
-    }
+    this.#program = ctx.blockConcurrencyWhile(() => Effect.runPromise(makeClusterEntityProgram(ctx)))
   }
 
   override alarm(): Promise<void> {
-    return Effect.runPromise(this.#manager.alarm)
+    return this.#program.then((program) => Effect.runPromise(program.alarm()))
   }
 
   /** @internal Keeps this object non-hibernateable while entity resources have holders. */
   hold(): Promise<void> {
-    return Effect.runPromise(this.#keepAlive.await)
+    return this.#program.then((program) => Effect.runPromise(program.hold()))
   }
 
   /** @internal Same-Worker RPC transport used by `CloudflareCluster.layer`. */
-  invoke(envelopeText: string, discard: boolean, delivery?: DeliveryOptions): Promise<InvokeResult> {
-    return Effect.runPromise(this.#manager.invoke(envelopeText, discard, delivery))
+  invoke(envelopeText: string, discard: boolean, delivery?: EntityDeliveryOptions): Promise<EntityInvokeResult> {
+    return this.#program.then((program) => Effect.runPromise(program.invoke(envelopeText, discard, delivery)))
   }
 
   /** @internal Acknowledges a streamed chunk. */
   acknowledge(requestId: string, replyId: string): Promise<ReadonlyArray<string>> {
-    return Effect.runPromise(this.#manager.acknowledge(requestId, replyId))
+    return this.#program.then((program) => Effect.runPromise(program.acknowledge(requestId, replyId)))
   }
 
   /** @internal Interrupts a handler execution and completes its persisted ask, if any. */
   interrupt(storageRequestId: string, clientRequestId = storageRequestId): Promise<void> {
-    return Effect.runPromise(this.#manager.interrupt(storageRequestId, clientRequestId))
+    return this.#program.then((program) => Effect.runPromise(program.interrupt(storageRequestId, clientRequestId)))
   }
 
   /** @internal Clears stored replies so a reset request replays from scratch. */
   reset(requestId: string): Promise<void> {
-    return Effect.runPromise(this.#manager.reset(requestId))
+    return this.#program.then((program) => Effect.runPromise(program.reset(requestId)))
   }
 
   /** @internal Completes an in-memory delayed ask owned by this entity object. */
   deliverReply(requestId: string, reply: string): Promise<boolean> {
-    return Effect.runPromise(this.#manager.deliverReply(requestId, reply))
+    return this.#program.then((program) => Effect.runPromise(program.deliverReply(requestId, reply)))
   }
 
   override fetch: () => never = notExposed("ClusterEntity")
@@ -178,93 +106,50 @@ export class ClusterEntity extends DurableObject<unknown> {
  * @since 4.0.0
  */
 export class ClusterWorkflow extends DurableObject<unknown> {
-  readonly #state: DurableObjectState
-  readonly #name: string | undefined
-  #runtime: WorkflowRuntime | undefined
+  readonly #program: Promise<ClusterWorkflowProgram>
 
   constructor(ctx: DurableObjectState, env: unknown) {
     super(ctx, env)
-    this.#state = ctx
-    ensureWorkflowStorage(ctx.storage.sql)
-    if (ctx.id.name !== undefined) {
-      if (decodeName(ctx.id.name) === undefined) {
-        throw new Error("ClusterWorkflow requires a canonical workflow Durable Object name")
-      }
-      this.#name = ctx.id.name
-    } else {
-      // An alarm wake carries no `id.name`; recover it from the stored
-      // execution so due clocks still fire after eviction.
-      const stored = loadExecution(ctx.storage.sql)
-      this.#name = stored === undefined ? undefined : encodeName(stored.workflowName, stored.executionId)
-    }
-    const wakeUp = earliestClockWakeUp(ctx.storage.sql)
-    if (wakeUp !== undefined) {
-      void ctx.blockConcurrencyWhile(() => Effect.runPromise(armAlarm(ctx.storage, wakeUp)))
-    }
-  }
-
-  #getRuntime(): WorkflowRuntime {
-    if (this.#runtime === undefined) {
-      if (this.#name === undefined) {
-        throw new Error("ClusterWorkflow requires a canonical workflow Durable Object name")
-      }
-      this.#runtime = makeWorkflowRuntime({
-        name: this.#name,
-        sql: this.#state.storage.sql,
-        alarm: this.#state.storage,
-        now: () => Date.now(),
-        waitUntil: (promise) => this.#state.waitUntil(promise),
-        getStub: (name) => {
-          const namespace = exportedNamespace<WorkflowStub>(this.#state, "ClusterWorkflow")
-          if (namespace === undefined) {
-            throw new Error("CloudflareCluster: ClusterWorkflow export is unavailable for workflow delivery")
-          }
-          return namespace.getByName(name)
-        }
-      })
-    }
-    return this.#runtime
+    this.#program = ctx.blockConcurrencyWhile(() => Effect.runPromise(makeClusterWorkflowProgram(ctx)))
   }
 
   /** @internal Same-Worker RPC transport used by `CloudflareWorkflowEngine`. */
-  run(payload: string, options: WorkflowRunOptions): Promise<string> {
-    return this.#getRuntime().run(payload, options)
+  run(payload: string, options: ClusterWorkflowRunOptions): Promise<string> {
+    return this.#program.then((program) => Effect.runPromise(program.run(payload, options)))
   }
 
   /** @internal */
   poll(): Promise<string | undefined> {
-    return this.#getRuntime().poll()
+    return this.#program.then((program) => Effect.runPromise(program.poll()))
   }
 
   /** @internal */
   resume(): Promise<void> {
-    return this.#getRuntime().resume()
+    return this.#program.then((program) => Effect.runPromise(program.resume()))
   }
 
   /** @internal */
   interrupt(): Promise<void> {
-    return this.#getRuntime().interrupt()
+    return this.#program.then((program) => Effect.runPromise(program.interrupt()))
   }
 
   /** @internal */
   interruptUnsafe(): Promise<void> {
-    return this.#getRuntime().interruptUnsafe()
+    return this.#program.then((program) => Effect.runPromise(program.interruptUnsafe()))
   }
 
   /** @internal Records a durable deferred exit and resumes the execution. */
   deferredDone(name: string, exit: string): Promise<void> {
-    return this.#getRuntime().deferredDone(name, exit)
+    return this.#program.then((program) => Effect.runPromise(program.deferredDone(name, exit)))
   }
 
   /** @internal Persists a durable clock and arms the single alarm. */
   scheduleClock(name: string, deferredName: string, wakeUp: number): Promise<void> {
-    return this.#getRuntime().scheduleClock(name, deferredName, wakeUp)
+    return this.#program.then((program) => Effect.runPromise(program.scheduleClock(name, deferredName, wakeUp)))
   }
 
   override alarm(): Promise<void> {
-    // No stored execution means no clock could have armed this alarm.
-    if (this.#name === undefined) return Promise.resolve()
-    return this.#getRuntime().runAlarm()
+    return this.#program.then((program) => Effect.runPromise(program.alarm()))
   }
 
   override fetch: () => never = notExposed("ClusterWorkflow")
@@ -285,61 +170,50 @@ export class ClusterWorkflow extends DurableObject<unknown> {
  * @since 4.0.0
  */
 export class ClusterDurableQueue extends DurableObject<unknown> {
-  readonly #runtime: QueueRuntime
+  readonly #program: Promise<ClusterDurableQueueProgram>
 
   constructor(ctx: DurableObjectState, env: unknown) {
     super(ctx, env)
-    if (ctx.id.name !== undefined && decodeName(ctx.id.name) === undefined) {
-      throw new Error("ClusterDurableQueue requires a canonical queue Durable Object name")
-    }
-    this.#runtime = makeQueueRuntime({
-      sql: ctx.storage.sql,
-      alarm: ctx.storage,
-      now: () => Date.now()
-    })
-    const expiry = earliestLeaseExpiry(ctx.storage.sql)
-    if (expiry !== undefined) {
-      void ctx.blockConcurrencyWhile(() => Effect.runPromise(armAlarm(ctx.storage, expiry)))
-    }
+    this.#program = ctx.blockConcurrencyWhile(() => Effect.runPromise(makeClusterDurableQueueProgram(ctx)))
   }
 
   /** @internal Same-Worker RPC transport used by `CloudflarePersistedQueue.layer`. */
   offer(id: string, element: string): Promise<void> {
-    return this.#runtime.offer(id, element)
+    return this.#program.then((program) => Effect.runPromise(program.offer(id, element)))
   }
 
   /** @internal Waits until an item is available, then leases it to the caller. */
-  take(takerId: string, maxAttempts: number, leaseMillis: number): Promise<QueueItem> {
-    return this.#runtime.take(takerId, maxAttempts, leaseMillis)
+  take(takerId: string, maxAttempts: number, leaseMillis: number): Promise<DurableQueueItem> {
+    return this.#program.then((program) => Effect.runPromise(program.take(takerId, maxAttempts, leaseMillis)))
   }
 
   /** @internal Cancels a waiting take, releasing an item already leased to it. */
   cancelTake(takerId: string): Promise<void> {
-    return this.#runtime.cancelTake(takerId)
+    return this.#program.then((program) => Effect.runPromise(program.cancelTake(takerId)))
   }
 
   /** @internal */
   complete(id: string): Promise<void> {
-    return this.#runtime.complete(id)
+    return this.#program.then((program) => Effect.runPromise(program.complete(id)))
   }
 
   /** @internal Records a failed attempt and requeues the item. */
   fail(id: string, lastFailure: string): Promise<void> {
-    return this.#runtime.fail(id, lastFailure)
+    return this.#program.then((program) => Effect.runPromise(program.fail(id, lastFailure)))
   }
 
   /** @internal Requeues the item without counting an attempt. */
   release(id: string): Promise<void> {
-    return this.#runtime.release(id)
+    return this.#program.then((program) => Effect.runPromise(program.release(id)))
   }
 
   /** @internal Extends the lease of an item still being processed. */
   extend(id: string, leaseMillis: number): Promise<void> {
-    return this.#runtime.extend(id, leaseMillis)
+    return this.#program.then((program) => Effect.runPromise(program.extend(id, leaseMillis)))
   }
 
   override alarm(): Promise<void> {
-    return this.#runtime.runAlarm()
+    return this.#program.then((program) => Effect.runPromise(program.alarm()))
   }
 
   override fetch: () => never = notExposed("ClusterDurableQueue")
@@ -360,66 +234,20 @@ export class ClusterDurableQueue extends DurableObject<unknown> {
  * @since 4.0.0
  */
 export class ClusterSingleton extends DurableObject<unknown> {
-  readonly #state: DurableObjectState
-  readonly #name: string | undefined
-  #runtime: SingletonRuntime | undefined
+  readonly #program: Promise<ClusterSingletonProgram>
 
   constructor(ctx: DurableObjectState, env: unknown) {
     super(ctx, env)
-    this.#state = ctx
-    const sql = ctx.storage.sql
-    ensureSingletonStorage(sql)
-    if (ctx.id.name !== undefined) {
-      if (!ctx.id.name.startsWith("Singleton/")) {
-        throw new Error("ClusterSingleton requires a Singleton/<name> Durable Object name")
-      }
-      rememberSingletonName(sql, ctx.id.name)
-    }
-    const stored = loadSingletonState(sql)
-    this.#name = ctx.id.name ?? stored.name
-    if (stored.wakeAt !== undefined) {
-      void ctx.blockConcurrencyWhile(() => Effect.runPromise(armAlarm(ctx.storage, stored.wakeAt!)))
-    }
-  }
-
-  #getRuntime(): SingletonRuntime {
-    if (this.#runtime !== undefined) return this.#runtime
-    if (this.#name === undefined) {
-      throw new Error("ClusterSingleton requires a Singleton/<name> Durable Object name")
-    }
-    const name = this.#name.slice("Singleton/".length)
-    const registration = getSingletonRegistration(name)
-    if (registration === undefined) {
-      throw new Error(`CloudflareCluster: no singleton registered under the name "${name}"`)
-    }
-    const run = Effect.sync(() => {
-      ClusterMetrics.singletons.modifyUnsafe(BigInt(1), registration.context)
-    }).pipe(
-      Effect.andThen(registration.run),
-      Effect.scoped,
-      Effect.ensuring(Effect.sync(() => {
-        ClusterMetrics.singletons.modifyUnsafe(BigInt(-1), registration.context)
-      })),
-      Effect.provideContext(registration.context),
-      Effect.orDie
-    )
-    this.#runtime = makeSingletonRuntime({
-      sql: this.#state.storage.sql,
-      alarm: this.#state.storage,
-      now: () => Date.now(),
-      run
-    })
-    return this.#runtime
+    this.#program = ctx.blockConcurrencyWhile(() => Effect.runPromise(makeClusterSingletonProgram(ctx)))
   }
 
   /** @internal Runs one Cron Trigger fire, coalescing a concurrent duplicate. */
   wake(): Promise<void> {
-    return this.#getRuntime().wake()
+    return this.#program.then((program) => Effect.runPromise(program.wake()))
   }
 
   override alarm(): Promise<void> {
-    if (loadSingletonState(this.#state.storage.sql).wakeAt === undefined) return Promise.resolve()
-    return this.#getRuntime().runAlarm()
+    return this.#program.then((program) => Effect.runPromise(program.alarm()))
   }
 
   override fetch: () => never = notExposed("ClusterSingleton")

--- a/packages/platform/cloudflare/src/CloudflareWorkflowEngine.ts
+++ b/packages/platform/cloudflare/src/CloudflareWorkflowEngine.ts
@@ -28,9 +28,9 @@ import { encodeName } from "./internal/clusterName.ts"
 import {
   CurrentExecutionHandle,
   deferredState,
-  registerWorkflow,
-  unregisterWorkflow,
+  makeWorkflowRegistry,
   type WorkflowRegistration,
+  type WorkflowRegistry,
   type WorkflowStub
 } from "./internal/workflowRegistry.ts"
 import { decodeExit, decodeResult, encodeExit, encodePayload } from "./internal/workflowWire.ts"
@@ -72,21 +72,11 @@ export type LayerOptions = Types.Simplify<{
 const call = <A>(result: WorkflowCall<A>): Effect.Effect<A> =>
   Effect.isEffect(result) ? Effect.orDie(result) : Effect.promise(() => result)
 
-/**
- * Creates the `WorkflowEngine` service backed by the workflow Durable Object
- * namespace binding.
- *
- * **Details**
- *
- * Inside a workflow Durable Object the engine operates on the local execution
- * handle, so activities and deferred reads never leave the object. Everywhere
- * else it resolves the target execution's object with `getByName` and drives
- * it over the same-Worker binding.
- *
- * @category constructors
- * @since 4.0.0
- */
-export const make = Effect.fnUntraced(function*(options: LayerOptions) {
+/** @internal */
+export const makeWithRegistry = Effect.fnUntraced(function*(
+  options: { readonly getByName: (name: string) => WorkflowClient },
+  registry: WorkflowRegistry
+) {
   const clock = yield* Clock
 
   // Inside a run the execution's own handle avoids a self-RPC; every other
@@ -96,7 +86,7 @@ export const make = Effect.fnUntraced(function*(options: LayerOptions) {
     if (Option.isSome(handle) && handle.value.executionId === executionId) {
       return handle.value as WorkflowStub
     }
-    return options.workflowNamespace.getByName(encodeName(workflowName, executionId)) as unknown as WorkflowClient
+    return options.getByName(encodeName(workflowName, executionId))
   })
 
   const localHandle = Effect.fnUntraced(function*(operation: string) {
@@ -114,10 +104,12 @@ export const make = Effect.fnUntraced(function*(options: LayerOptions) {
     register: Effect.fnUntraced(function*(workflow, execute) {
       const context = yield* Effect.context<never>()
       const registration: WorkflowRegistration = { workflow, execute, context }
-      if (!registerWorkflow(workflow._tag, registration)) return
+      if (!registry.register(workflow._tag, registration)) {
+        return yield* Effect.die(`Workflow '${workflow._tag}' is already registered`)
+      }
       yield* Effect.addFinalizer(() =>
         Effect.sync(() => {
-          unregisterWorkflow(workflow._tag, registration)
+          registry.unregister(workflow._tag, registration)
         })
       )
     }),
@@ -191,6 +183,29 @@ export const make = Effect.fnUntraced(function*(options: LayerOptions) {
       yield* call(stub.scheduleClock(opts.clock.name, opts.clock.deferred.name, wakeUp))
     })
   })
+})
+
+/**
+ * Creates the `WorkflowEngine` service backed by the workflow Durable Object
+ * namespace binding.
+ *
+ * **Details**
+ *
+ * Inside a workflow Durable Object the engine operates on the local execution
+ * handle, so activities and deferred reads never leave the object. Everywhere
+ * else it resolves the target execution's object with `getByName` and drives
+ * it over the same-Worker binding.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const make = Effect.fnUntraced(function*(options: LayerOptions) {
+  return yield* makeWithRegistry(
+    {
+      getByName: (name) => options.workflowNamespace.getByName(name) as unknown as WorkflowClient
+    },
+    makeWorkflowRegistry()
+  )
 })
 
 /**

--- a/packages/platform/cloudflare/src/CloudflareWorkflowEngine.ts
+++ b/packages/platform/cloudflare/src/CloudflareWorkflowEngine.ts
@@ -20,8 +20,10 @@ import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
+import type * as Types from "effect/Types"
 import * as Workflow from "effect/unstable/workflow/Workflow"
 import * as WorkflowEngine from "effect/unstable/workflow/WorkflowEngine"
+import type { ClusterWorkflowRunOptions } from "./CloudflareDurableObjectPrograms.ts"
 import { encodeName } from "./internal/clusterName.ts"
 import {
   CurrentExecutionHandle,
@@ -34,14 +36,41 @@ import {
 import { decodeExit, decodeResult, encodeExit, encodePayload } from "./internal/workflowWire.ts"
 
 /**
- * The workflow Durable Object namespace binding the engine is built from.
+ * Result of invoking a workflow Durable Object through a framework namespace.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type WorkflowCall<A> = Promise<A> | Effect.Effect<A, unknown>
+
+/**
+ * Framework-neutral client for one workflow Durable Object.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface WorkflowClient {
+  readonly run: (payload: string, options: ClusterWorkflowRunOptions) => WorkflowCall<string>
+  readonly poll: () => WorkflowCall<string | undefined>
+  readonly resume: () => WorkflowCall<void>
+  readonly interrupt: () => WorkflowCall<void>
+  readonly interruptUnsafe: () => WorkflowCall<void>
+  readonly deferredDone: (name: string, exit: string) => WorkflowCall<void>
+  readonly scheduleClock: (name: string, deferredName: string, wakeUp: number) => WorkflowCall<void>
+}
+
+/**
+ * Workflow Durable Object namespace binding the engine is built from.
  *
  * @category layers
  * @since 4.0.0
  */
-export interface LayerOptions {
-  readonly workflowNamespace: DurableObjectNamespace
-}
+export type LayerOptions = Types.Simplify<{
+  readonly workflowNamespace: Pick<DurableObjectNamespace, "getByName">
+}>
+
+const call = <A>(result: WorkflowCall<A>): Effect.Effect<A> =>
+  Effect.isEffect(result) ? Effect.orDie(result) : Effect.promise(() => result)
 
 /**
  * Creates the `WorkflowEngine` service backed by the workflow Durable Object
@@ -67,7 +96,7 @@ export const make = Effect.fnUntraced(function*(options: LayerOptions) {
     if (Option.isSome(handle) && handle.value.executionId === executionId) {
       return handle.value as WorkflowStub
     }
-    return options.workflowNamespace.getByName(encodeName(workflowName, executionId)) as unknown as WorkflowStub
+    return options.workflowNamespace.getByName(encodeName(workflowName, executionId)) as unknown as WorkflowClient
   })
 
   const localHandle = Effect.fnUntraced(function*(operation: string) {
@@ -100,7 +129,7 @@ export const make = Effect.fnUntraced(function*(options: LayerOptions) {
       const parent = opts.parent === undefined
         ? undefined
         : { workflowName: opts.parent.workflow._tag, executionId: opts.parent.executionId }
-      const text = yield* Effect.promise(() => stub.run(payload, { discard: opts.discard, parent }))
+      const text = yield* call(stub.run(payload, { discard: opts.discard, parent }))
       if (opts.discard) return undefined
       return yield* decodeResult(workflow, text, context)
     }) as WorkflowEngine.Encoded["execute"],
@@ -108,19 +137,19 @@ export const make = Effect.fnUntraced(function*(options: LayerOptions) {
     poll: Effect.fnUntraced(function*(workflow, executionId) {
       const context = yield* Effect.context<never>()
       const stub = yield* stubFor(workflow._tag, executionId)
-      const text = yield* Effect.promise(() => stub.poll())
+      const text = yield* call(stub.poll())
       if (text === undefined) return Option.none()
       return Option.some(yield* decodeResult(workflow, text, context))
     }),
 
     interrupt: (workflow, executionId) =>
-      Effect.flatMap(stubFor(workflow._tag, executionId), (stub) => Effect.promise(() => stub.interrupt())),
+      Effect.flatMap(stubFor(workflow._tag, executionId), (stub) => call(stub.interrupt())),
 
     interruptUnsafe: (workflow, executionId) =>
-      Effect.flatMap(stubFor(workflow._tag, executionId), (stub) => Effect.promise(() => stub.interruptUnsafe())),
+      Effect.flatMap(stubFor(workflow._tag, executionId), (stub) => call(stub.interruptUnsafe())),
 
     resume: (workflow, executionId) =>
-      Effect.flatMap(stubFor(workflow._tag, executionId), (stub) => Effect.promise(() => stub.resume())),
+      Effect.flatMap(stubFor(workflow._tag, executionId), (stub) => call(stub.resume())),
 
     activityExecute: Effect.fnUntraced(function*(activity, attempt) {
       const { handle, instance } = yield* localHandle("Activity execution")
@@ -153,13 +182,13 @@ export const make = Effect.fnUntraced(function*(options: LayerOptions) {
     deferredDone: Effect.fnUntraced(function*({ deferredName, executionId, exit, workflowName }) {
       const text = yield* encodeExit(exit, Context.empty())
       const stub = yield* stubFor(workflowName, executionId)
-      yield* Effect.promise(() => stub.deferredDone(deferredName, text))
+      yield* call(stub.deferredDone(deferredName, text))
     }),
 
     scheduleClock: Effect.fnUntraced(function*(workflow, opts) {
       const wakeUp = clock.currentTimeMillisUnsafe() + Math.ceil(Duration.toMillis(opts.clock.duration))
       const stub = yield* stubFor(workflow._tag, opts.executionId)
-      yield* Effect.promise(() => stub.scheduleClock(opts.clock.name, opts.clock.deferred.name, wakeUp))
+      yield* call(stub.scheduleClock(opts.clock.name, opts.clock.deferred.name, wakeUp))
     })
   })
 })

--- a/packages/platform/cloudflare/src/index.ts
+++ b/packages/platform/cloudflare/src/index.ts
@@ -12,6 +12,11 @@ export * as CloudflareCluster from "./CloudflareCluster.ts"
 /**
  * @since 4.0.0
  */
+export * as CloudflareDurableObjectPrograms from "./CloudflareDurableObjectPrograms.ts"
+
+/**
+ * @since 4.0.0
+ */
 export * as CloudflareDurableObjects from "./CloudflareDurableObjects.ts"
 
 /**

--- a/packages/platform/cloudflare/src/internal/workflowRegistry.ts
+++ b/packages/platform/cloudflare/src/internal/workflowRegistry.ts
@@ -1,9 +1,6 @@
 /**
- * Module-level workflow state shared between the Worker layer and the workflow
- * Durable Object instances of the same isolate. Registrations are recorded at
- * Worker init; a running execution provides its own handle through
- * `CurrentExecutionHandle` so engine operations inside the run hit local
- * SQLite instead of a self-RPC.
+ * Workflow registration state. Each engine or Durable Object activation owns
+ * its registry so independently scoped handlers cannot interfere.
  *
  * @internal
  */
@@ -11,7 +8,7 @@ import * as Context from "effect/Context"
 import type * as Effect from "effect/Effect"
 import type * as Workflow from "effect/unstable/workflow/Workflow"
 import * as WorkflowEngine from "effect/unstable/workflow/WorkflowEngine"
-import { makeRegistry } from "./registry.ts"
+import { makeRegistry, type Registry } from "./registry.ts"
 
 /** @internal */
 export interface WorkflowRegistration {
@@ -23,16 +20,11 @@ export interface WorkflowRegistration {
   readonly context: Context.Context<never>
 }
 
-const registry = makeRegistry<WorkflowRegistration>()
+/** @internal */
+export type WorkflowRegistry = Registry<WorkflowRegistration>
 
 /** @internal */
-export const getWorkflowRegistration: (name: string) => WorkflowRegistration | undefined = registry.get
-
-/** @internal */
-export const registerWorkflow: (name: string, registration: WorkflowRegistration) => boolean = registry.register
-
-/** @internal */
-export const unregisterWorkflow: (name: string, registration: WorkflowRegistration) => void = registry.unregister
+export const makeWorkflowRegistry = (): WorkflowRegistry => makeRegistry()
 
 /** @internal */
 export interface WorkflowRunOptions {

--- a/packages/platform/cloudflare/src/internal/workflowRuntime.ts
+++ b/packages/platform/cloudflare/src/internal/workflowRuntime.ts
@@ -2,9 +2,9 @@
  * The workflow Durable Object runtime. One object holds one workflow
  * execution: its payload, run result, activity results keyed
  * `${name}/${attempt}`, durable deferred exits, and the clock due table behind
- * the single alarm. Handlers are looked up in the module-level workflow
- * registry and built once per wake; a crash or hibernation wipes RAM and the
- * next contact replays the execution from SQLite.
+ * the single alarm. Handlers are looked up in the activation's workflow
+ * registry; a crash or hibernation wipes RAM and the next activation rebuilds
+ * that registry before replaying the execution from SQLite.
  *
  * @internal
  */
@@ -24,7 +24,7 @@ import { armAlarm, type EntityAlarm } from "./entityStorage.ts"
 import {
   CurrentExecutionHandle,
   deferredState,
-  getWorkflowRegistration,
+  type WorkflowRegistration,
   type WorkflowRunOptions,
   type WorkflowStub
 } from "./workflowRegistry.ts"
@@ -49,6 +49,7 @@ export interface WorkflowRuntimeOptions {
   readonly now: () => number
   readonly waitUntil: (promise: Promise<unknown>) => void
   readonly getStub: (name: string) => WorkflowStub
+  readonly getRegistration: (name: string) => WorkflowRegistration | undefined
 }
 
 /** @internal */
@@ -103,7 +104,7 @@ export const makeWorkflowRuntime = (options: WorkflowRuntimeOptions): WorkflowRu
     )
 
   const startAttempt = (row: WorkflowStorage.ExecutionRow): Promise<string> => {
-    const registration = getWorkflowRegistration(workflowName)
+    const registration = options.getRegistration(workflowName)
     if (registration === undefined) {
       return Promise.reject(new Error(`No workflow registered for name: ${workflowName}`))
     }

--- a/packages/platform/cloudflare/test/CloudflareDurableObjects.test.ts
+++ b/packages/platform/cloudflare/test/CloudflareDurableObjects.test.ts
@@ -46,6 +46,20 @@ describe("CloudflareDurableObjects", () => {
       }
     }), 60_000)
 
+  it.effect("runs a configured workflow Durable Object class", () =>
+    Effect.gen(function*() {
+      const miniflare = yield* makeMiniflare
+      const response = yield* Effect.promise(() =>
+        Promise.race([
+          miniflare.dispatchFetch("http://placeholder/workflow-run?id=class-api"),
+          new Promise<never>((_, reject) => setTimeout(() => reject(new Error("workflow RPC did not return")), 2_000))
+        ])
+      )
+      const body = yield* Effect.promise(() => response.json())
+      assert.strictEqual(response.status, 200)
+      assert.deepStrictEqual(body, { status: "complete" })
+    }), 60_000)
+
   it.effect("journals only persisted RPCs and deduplicates primary keys", () =>
     Effect.gen(function*() {
       const miniflare = yield* makeMiniflare

--- a/packages/platform/cloudflare/test/CloudflareWorkflowEngine.test.ts
+++ b/packages/platform/cloudflare/test/CloudflareWorkflowEngine.test.ts
@@ -187,7 +187,7 @@ class FakeWorkflowNamespace {
 
   get effectLayer() {
     const workflowNamespace = {
-      getByName: (name) => {
+      getByName: (name: string) => {
         const stub = this.getByName(name)
         return {
           run: (payload, options) => Effect.promise(() => stub.run(payload, options)),
@@ -198,7 +198,7 @@ class FakeWorkflowNamespace {
           deferredDone: (deferredName, exit) => Effect.promise(() => stub.deferredDone(deferredName, exit)),
           scheduleClock: (clockName, deferredName, wakeUp) =>
             Effect.promise(() => stub.scheduleClock(clockName, deferredName, wakeUp))
-        }
+        } satisfies CloudflareWorkflowEngine.WorkflowClient
       }
     }
     return CloudflareWorkflowEngine.layer({ workflowNamespace: workflowNamespace as never })

--- a/packages/platform/cloudflare/test/CloudflareWorkflowEngine.test.ts
+++ b/packages/platform/cloudflare/test/CloudflareWorkflowEngine.test.ts
@@ -1,15 +1,18 @@
 import type { DurableObjectStorage, SqlStorage } from "@cloudflare/workers-types"
 import {
+  type ClusterWorkflowProgram,
   type DurableObjectProgramState,
   makeClusterWorkflowProgram
 } from "@effect/platform-cloudflare/CloudflareDurableObjectPrograms"
 import * as CloudflareWorkflowEngine from "@effect/platform-cloudflare/CloudflareWorkflowEngine"
 import { encodeName } from "@effect/platform-cloudflare/internal/clusterName"
 import type { EntityAlarm } from "@effect/platform-cloudflare/internal/entityStorage"
+import { makeWorkflowRegistry } from "@effect/platform-cloudflare/internal/workflowRegistry"
 import { makeWorkflowRuntime, type WorkflowRuntime } from "@effect/platform-cloudflare/internal/workflowRuntime"
 import { loadExecution } from "@effect/platform-cloudflare/internal/workflowStorage"
+import { decodeResult, encodeExit, encodePayload } from "@effect/platform-cloudflare/internal/workflowWire"
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Exit, Layer, Option, Schema } from "effect"
+import { Cause, Context, Effect, Exit, Layer, Option, Schema, Scope } from "effect"
 import { RpcTest } from "effect/unstable/rpc"
 import {
   Activity,
@@ -135,6 +138,7 @@ class FakeAlarm {
 class FakeWorkflowNamespace {
   readonly stores = new Map<string, { readonly sql: FakeSql; readonly alarm: FakeAlarm }>()
   readonly runtimes = new Map<string, WorkflowRuntime>()
+  readonly registry = makeWorkflowRegistry()
   now = 0
 
   store(name: string) {
@@ -158,7 +162,8 @@ class FakeWorkflowNamespace {
         waitUntil: (promise) => {
           void promise
         },
-        getStub: (stubName) => this.getByName(stubName)
+        getStub: (stubName) => this.getByName(stubName),
+        getRegistration: this.registry.get
       })
       this.runtimes.set(name, runtime)
     }
@@ -182,7 +187,9 @@ class FakeWorkflowNamespace {
   }
 
   get layer() {
-    return CloudflareWorkflowEngine.layer({ workflowNamespace: this })
+    return Layer.effect(WorkflowEngine.WorkflowEngine)(
+      CloudflareWorkflowEngine.makeWithRegistry({ getByName: (name) => this.getByName(name) }, this.registry)
+    )
   }
 
   get effectLayer() {
@@ -201,7 +208,9 @@ class FakeWorkflowNamespace {
         } satisfies CloudflareWorkflowEngine.WorkflowClient
       }
     }
-    return CloudflareWorkflowEngine.layer({ workflowNamespace: workflowNamespace as never })
+    return Layer.effect(WorkflowEngine.WorkflowEngine)(
+      CloudflareWorkflowEngine.makeWithRegistry(workflowNamespace, this.registry)
+    )
   }
 }
 
@@ -212,6 +221,21 @@ const pollUntil = Effect.fnUntraced(function*<
     const result = yield* workflow.poll(executionId)
     if (Option.isSome(result) && result.value._tag === tag) return result.value
     yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 1)))
+  }
+})
+
+const pollProgramUntil = Effect.fnUntraced(function*(
+  program: ClusterWorkflowProgram,
+  workflow: Workflow.Any,
+  tag: "Complete" | "Suspended"
+) {
+  while (true) {
+    const text = yield* program.poll()
+    if (text !== undefined) {
+      const result = yield* decodeResult(workflow, text, Context.empty())
+      if (result._tag === tag) return result
+    }
+    yield* Effect.yieldNow
   }
 })
 
@@ -238,14 +262,88 @@ describe("CloudflareWorkflowEngine", () => {
       const state: DurableObjectProgramState = {
         id: {},
         storage,
-        exports: {},
+        exports: {
+          CustomWorkflow: {
+            getByName: () => {
+              throw new Error("Unexpected workflow stub lookup")
+            }
+          }
+        },
         waitUntil: () => undefined
       }
+      const Restarted = Workflow.make("Restarted", {
+        payload: {},
+        idempotencyKey: () => "execution"
+      })
 
-      const program = yield* makeClusterWorkflowProgram(state)
+      const program = yield* makeClusterWorkflowProgram(state, {
+        workflows: Restarted.toLayer(() => Effect.void),
+        workflowClassName: "CustomWorkflow"
+      })
 
       assert.strictEqual(alarm.current, 1_000)
       assert.isUndefined(yield* program.poll())
+    }))
+
+  it.effect("rebuilds workflow registrations after an isolate loss", () =>
+    Effect.gen(function*() {
+      const sql = new FakeSql()
+      const alarm = new FakeAlarm()
+      const state: DurableObjectProgramState = {
+        id: { name: encodeName("ProgramResumable", "execution") },
+        storage: {
+          sql: sql.sql,
+          getAlarm: () => alarm.getAlarm(),
+          setAlarm: (scheduledTime: number) => alarm.setAlarm(scheduledTime)
+        } as DurableObjectStorage,
+        exports: {
+          CustomWorkflow: {
+            getByName: () => {
+              throw new Error("Unexpected workflow stub lookup")
+            }
+          }
+        },
+        waitUntil: (promise) => {
+          void promise
+        }
+      }
+      const Gate = DurableDeferred.make("ProgramResumable/Gate", { success: Schema.String })
+      let runs = 0
+      const ProgramResumable = Workflow.make("ProgramResumable", {
+        payload: { id: Schema.String },
+        success: Schema.String,
+        idempotencyKey: ({ id }) => id
+      })
+      const workflows = ProgramResumable.toLayer(Effect.fnUntraced(function*({ id }) {
+        runs++
+        const value = yield* DurableDeferred.await(Gate)
+        return `${value}-${id}`
+      }))
+      const payload = yield* encodePayload(ProgramResumable, { id: "one" }, Context.empty())
+
+      const firstScope = Scope.makeUnsafe()
+      const first = yield* makeClusterWorkflowProgram(state, {
+        workflows,
+        workflowClassName: "CustomWorkflow"
+      }).pipe(Effect.provideService(Scope.Scope, firstScope))
+      yield* first.run(payload, { discard: true })
+      yield* pollProgramUntil(first, ProgramResumable, "Suspended")
+      assert.strictEqual(runs, 1)
+      yield* Scope.close(firstScope, Exit.void)
+
+      const secondScope = Scope.makeUnsafe()
+      const second = yield* makeClusterWorkflowProgram(state, {
+        workflows,
+        workflowClassName: "CustomWorkflow"
+      }).pipe(Effect.provideService(Scope.Scope, secondScope))
+      const exit = yield* encodeExit(Exit.succeed("world"), Context.empty())
+      yield* second.deferredDone(Gate.name, exit)
+      const result = yield* pollProgramUntil(second, ProgramResumable, "Complete")
+
+      assert(result._tag === "Complete" && Exit.isSuccess(result.exit))
+      assert.strictEqual(result.exit.value, "world-one")
+      assert.strictEqual(runs, 2)
+      yield* Scope.close(secondScope, Exit.void)
     }))
 
   it.effect("routes generated workflow proxy handlers through the encoded Durable Object name", () => {
@@ -272,6 +370,24 @@ describe("CloudflareWorkflowEngine", () => {
       Effect.provide(WorkflowProxyServer.layerRpcHandlers(workflows)),
       Effect.provide(workflowLayer)
     )
+  })
+
+  it.effect("rejects duplicate workflow registrations", () => {
+    const namespace = new FakeWorkflowNamespace()
+    const Duplicate = Workflow.make("Duplicate", {
+      payload: {},
+      idempotencyKey: () => "duplicate"
+    })
+    const workflows = Layer.merge(
+      Duplicate.toLayer(() => Effect.void),
+      Duplicate.toLayer(() => Effect.void)
+    ).pipe(Layer.provideMerge(namespace.layer))
+
+    return Effect.gen(function*() {
+      const exit = yield* Effect.exit(Layer.build(workflows))
+      assert(Exit.isFailure(exit))
+      assert.include(Cause.pretty(exit.cause), "Workflow 'Duplicate' is already registered")
+    })
   })
 
   it.effect("persists a suspended execution and resumes it after an isolate loss", () => {

--- a/packages/platform/cloudflare/test/CloudflareWorkflowEngine.test.ts
+++ b/packages/platform/cloudflare/test/CloudflareWorkflowEngine.test.ts
@@ -1,4 +1,8 @@
-import type { SqlStorage } from "@cloudflare/workers-types"
+import type { DurableObjectStorage, SqlStorage } from "@cloudflare/workers-types"
+import {
+  type DurableObjectProgramState,
+  makeClusterWorkflowProgram
+} from "@effect/platform-cloudflare/CloudflareDurableObjectPrograms"
 import * as CloudflareWorkflowEngine from "@effect/platform-cloudflare/CloudflareWorkflowEngine"
 import { encodeName } from "@effect/platform-cloudflare/internal/clusterName"
 import type { EntityAlarm } from "@effect/platform-cloudflare/internal/entityStorage"
@@ -178,7 +182,26 @@ class FakeWorkflowNamespace {
   }
 
   get layer() {
-    return CloudflareWorkflowEngine.layer({ workflowNamespace: this as never })
+    return CloudflareWorkflowEngine.layer({ workflowNamespace: this })
+  }
+
+  get effectLayer() {
+    const workflowNamespace = {
+      getByName: (name) => {
+        const stub = this.getByName(name)
+        return {
+          run: (payload, options) => Effect.promise(() => stub.run(payload, options)),
+          poll: () => Effect.promise(() => stub.poll()),
+          resume: () => Effect.promise(() => stub.resume()),
+          interrupt: () => Effect.promise(() => stub.interrupt()),
+          interruptUnsafe: () => Effect.promise(() => stub.interruptUnsafe()),
+          deferredDone: (deferredName, exit) => Effect.promise(() => stub.deferredDone(deferredName, exit)),
+          scheduleClock: (clockName, deferredName, wakeUp) =>
+            Effect.promise(() => stub.scheduleClock(clockName, deferredName, wakeUp))
+        }
+      }
+    }
+    return CloudflareWorkflowEngine.layer({ workflowNamespace: workflowNamespace as never })
   }
 }
 
@@ -193,6 +216,38 @@ const pollUntil = Effect.fnUntraced(function*<
 })
 
 describe("CloudflareWorkflowEngine", () => {
+  it.effect("re-arms persisted clocks before exposing the workflow handlers", () =>
+    Effect.gen(function*() {
+      const sql = new FakeSql()
+      const alarm = new FakeAlarm()
+      sql.execution = {
+        workflow_name: "Restarted",
+        execution_id: "execution",
+        payload: "{}",
+        parent_name: null,
+        parent_execution_id: null,
+        result: null,
+        resume_pending: 0
+      }
+      sql.clocks.set("sleep", { deferredName: "DurableClock/sleep", wakeUp: 1_000, fired: false })
+      const storage = {
+        sql: sql.sql,
+        getAlarm: () => alarm.getAlarm(),
+        setAlarm: (scheduledTime: number) => alarm.setAlarm(scheduledTime)
+      } as unknown as DurableObjectStorage
+      const state: DurableObjectProgramState = {
+        id: {},
+        storage,
+        exports: {},
+        waitUntil: () => undefined
+      }
+
+      const program = yield* makeClusterWorkflowProgram(state)
+
+      assert.strictEqual(alarm.current, 1_000)
+      assert.isUndefined(yield* program.poll())
+    }))
+
   it.effect("routes generated workflow proxy handlers through the encoded Durable Object name", () => {
     const namespace = new FakeWorkflowNamespace()
     const Proxied = Workflow.make("Proxied", {
@@ -290,7 +345,7 @@ describe("CloudflareWorkflowEngine", () => {
           return Effect.succeed(42)
         })
       })
-    ).pipe(Layer.provideMerge(namespace.layer))
+    ).pipe(Layer.provideMerge(namespace.effectLayer))
 
     return Effect.gen(function*() {
       const executionId = yield* Crashing.executionId({ id: "one" })

--- a/packages/platform/cloudflare/test/fixtures/worker.ts
+++ b/packages/platform/cloudflare/test/fixtures/worker.ts
@@ -1,14 +1,23 @@
-export {
-  ClusterDurableQueue,
-  ClusterSingleton,
-  ClusterWorkflow
+export { ClusterDurableQueue, ClusterSingleton } from "@effect/platform-cloudflare/CloudflareDurableObjects"
+import {
+  ClusterEntity as BaseClusterEntity,
+  ClusterWorkflow as BaseClusterWorkflow
 } from "@effect/platform-cloudflare/CloudflareDurableObjects"
-import { ClusterEntity as BaseClusterEntity } from "@effect/platform-cloudflare/CloudflareDurableObjects"
 import { encodeName } from "@effect/platform-cloudflare/internal/clusterName"
 import { registerEntity } from "@effect/platform-cloudflare/internal/entityRegistry"
-import { Context, Deferred, Effect, Schema, Stream } from "effect"
+import { decodeResult, encodePayload } from "@effect/platform-cloudflare/internal/workflowWire"
+import { Context, Deferred, Effect, Exit, Schema, Stream } from "effect"
 import { ClusterSchema, Entity } from "effect/unstable/cluster"
 import { Rpc, RpcSchema } from "effect/unstable/rpc"
+import { Workflow } from "effect/unstable/workflow"
+
+const FixtureWorkflow = Workflow.make("User", {
+  payload: {},
+  idempotencyKey: () => "fixture"
+})
+export class ClusterWorkflow extends BaseClusterWorkflow.make({
+  workflows: FixtureWorkflow.toLayer(() => Effect.void)
+}) {}
 
 const Add = Rpc.make("Add", {
   payload: { operationId: Schema.String },
@@ -195,6 +204,16 @@ registerEntity("Mailbox", {
 export default {
   async fetch(request: Request, env: Record<string, any>): Promise<Response> {
     const url = new URL(request.url)
+    if (url.pathname === "/workflow-run") {
+      const id = url.searchParams.get("id") ?? "fixture"
+      const payload = await Effect.runPromise(encodePayload(FixtureWorkflow, {}, Context.empty()))
+      const stub = env.CLUSTER_WORKFLOW.getByName(encodeName("User", id))
+      const text = await stub.run(payload, { discard: false })
+      const result = await Effect.runPromise(decodeResult(FixtureWorkflow, text, Context.empty()))
+      return result._tag === "Complete" && Exit.isSuccess(result.exit)
+        ? Response.json({ status: "complete" })
+        : Response.json({ status: "failed" })
+    }
     if (url.pathname === "/scheduled-rows") {
       const id = url.searchParams.get("id") ?? "scheduled"
       const stub = env.CLUSTER_ENTITY.getByName(`7:Mailbox${id}`)


### PR DESCRIPTION
## Motivation

Frameworks such as Alchemy can generate the native Durable Object class, but the existing integration requires consumers to reconstruct internal lifecycle details: manually retain an unsafe scope, register workflows inside the object isolate, branch on optional program readiness, forward every RPC method, and read the workflow namespace from an untyped Worker environment. Those steps are easy to attach to the wrong lifetime and make the class-independent API harder to use safely.

This change makes the Durable Object lifecycle explicit while keeping Effect Workflow, Cluster, and the Cloudflare runtime independent of any deployment framework.

## Changes

- Add class-independent initialization Effects for entity, workflow, durable queue, and singleton Durable Objects.
- Restore persisted alarms before returning each Effect-valued handler object, eliminating separate `program.ready` handling.
- Delegate the bundled native classes to the same programs through `blockConcurrencyWhile`.
- Let the workflow engine consume the namespace `getByName` capability and both Promise- and Effect-valued workflow RPC methods.
- Export the program module publicly.
- Add focused coverage for initialization, alarm restoration, alarm-wake name recovery, and Effect-valued RPC clients.

## Alchemy integration

Alchemy can yield its generated Durable Object namespace directly and construct ordinary Layers during Worker initialization:

```ts
const workflowNamespace = yield* ClusterWorkflow
const MainLayer = GreetingWorkflowLayer.pipe(
  Layer.provideMerge(CloudflareWorkflowEngine.layer({ workflowNamespace }))
)
const context = yield* Layer.build(MainLayer)
```

The generated Durable Object definition only obtains its platform state and returns `makeClusterWorkflowProgram(state.raw)`. It does not need `WorkerEnvironment`, `Scope.makeUnsafe()`, a readiness branch, registry knowledge, or method-by-method forwarding. Alchemy remains responsible only for deployment and native class generation.

## Lifecycle

Workflow registration is built in the Worker initialization scope, which Alchemy retains for the isolate lifetime. Durable Object reconstruction remains storage-driven, alarms recover execution identity from SQLite, and detached work continues through native `waitUntil`. Native classes preserve their existing behavior while sharing the framework-neutral implementation.

## Validation

- `nix develop --command pnpm lint-fix`
- `nix develop --command pnpm --filter @effect/platform-cloudflare check`
- Targeted `CloudflareWorkflowEngine.test.ts`
- Targeted `CloudflareDurableObjects.test.ts`
- Local Alchemy workflow start, durable sleep, completion, and restart persistence smoke check