### PR TITLE
Add partial matching to Schema.TaggedUnion

### DIFF
--- a/.changeset/eff-802-tagged-union-match-or-else.md
+++ b/.changeset/eff-802-tagged-union-match-or-else.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Schema.TaggedUnion.matchOrElse` for partial case matching with a typed fallback.

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -6201,14 +6201,6 @@ type Flatten<Schemas> = Schemas extends readonly [infer Head, ...infer Tail]
   : [Head, ...Flatten<Tail>]
   : []
 
-type MatchCasesResult<Cases> = {
-  [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => infer R ? R : never
-}[keyof Cases]
-
-type MatchOrElseResult<Cases, OrElse extends (...args: Array<any>) => any> = Unify<
-  MatchCasesResult<Cases> | ReturnType<OrElse>
->
-
 type TaggedUnionUtils<
   Tag extends PropertyKey,
   Members extends ReadonlyArray<Constraint & { readonly Type: { readonly [K in Tag]: PropertyKey } }>,
@@ -6241,29 +6233,15 @@ type TaggedUnionUtils<
       : never
   }
   readonly matchOrElse: {
-    <
-      Cases extends
-        & { [M in Flattened[number] as M["Type"][Tag]]+?: (value: M["Type"]) => any }
-        & { [K in Exclude<keyof Cases, Flattened[number]["Type"][Tag]>]: never },
-      OrElse extends (
-        value: Exclude<Members[number]["Type"], { readonly [K in Tag]: keyof Cases }>
-      ) => any
-    >(
+    <Output>(
       value: Members[number]["Type"],
-      cases: Cases,
-      orElse: OrElse
-    ): MatchOrElseResult<Cases, OrElse>
-    <
-      Cases extends
-        & { [M in Flattened[number] as M["Type"][Tag]]+?: (value: M["Type"]) => any }
-        & { [K in Exclude<keyof Cases, Flattened[number]["Type"][Tag]>]: never },
-      OrElse extends (
-        value: Exclude<Members[number]["Type"], { readonly [K in Tag]: keyof Cases }>
-      ) => any
-    >(
-      cases: Cases,
-      orElse: OrElse
-    ): (value: Members[number]["Type"]) => MatchOrElseResult<Cases, OrElse>
+      cases: { [M in Flattened[number] as M["Type"][Tag]]+?: (value: M["Type"]) => Output },
+      orElse: (value: Members[number]["Type"]) => Output
+    ): Output
+    <Output>(
+      cases: { [M in Flattened[number] as M["Type"][Tag]]+?: (value: M["Type"]) => Output },
+      orElse: (value: Members[number]["Type"]) => Output
+    ): (value: Members[number]["Type"]) => Output
   }
 }
 
@@ -6421,29 +6399,15 @@ export interface TaggedUnion<Cases extends Record<string, Constraint>> extends
     ): Output
   }
   readonly matchOrElse: {
-    <
-      MatchCases extends
-        & { [K in keyof Cases]+?: (value: Cases[K]["Type"]) => any }
-        & { [K in Exclude<keyof MatchCases, keyof Cases>]: never },
-      OrElse extends (
-        value: Exclude<Cases[keyof Cases]["Type"], { readonly _tag: keyof MatchCases }>
-      ) => any
-    >(
-      cases: MatchCases,
-      orElse: OrElse
-    ): (value: Cases[keyof Cases]["Type"]) => MatchOrElseResult<MatchCases, OrElse>
-    <
-      MatchCases extends
-        & { [K in keyof Cases]+?: (value: Cases[K]["Type"]) => any }
-        & { [K in Exclude<keyof MatchCases, keyof Cases>]: never },
-      OrElse extends (
-        value: Exclude<Cases[keyof Cases]["Type"], { readonly _tag: keyof MatchCases }>
-      ) => any
-    >(
+    <Output>(
       value: Cases[keyof Cases]["Type"],
-      cases: MatchCases,
-      orElse: OrElse
-    ): MatchOrElseResult<MatchCases, OrElse>
+      cases: { [K in keyof Cases]?: (value: Cases[K]["Type"]) => Output },
+      orElse: (value: Cases[keyof Cases]["Type"]) => Output
+    ): Output
+    <Output>(
+      cases: { [K in keyof Cases]?: (value: Cases[K]["Type"]) => Output },
+      orElse: (value: Cases[keyof Cases]["Type"]) => Output
+    ): (value: Cases[keyof Cases]["Type"]) => Output
   }
 }
 

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -6351,7 +6351,7 @@ export function toTaggedUnion<const Tag extends PropertyKey>(tag: Tag) {
         const orElse = arguments[1]
         return function(value: any) {
           const key = value[tag]
-          const handler = Object.hasOwn(cases, key) ? cases[key] : orElse
+          const handler = Object.hasOwn(cases, key) ? cases[key] ?? orElse : orElse
           return handler(value)
         }
       }
@@ -6359,7 +6359,7 @@ export function toTaggedUnion<const Tag extends PropertyKey>(tag: Tag) {
       const cases = arguments[1]
       const orElse = arguments[2]
       const key = value[tag]
-      const handler = Object.hasOwn(cases, key) ? cases[key] : orElse
+      const handler = Object.hasOwn(cases, key) ? cases[key] ?? orElse : orElse
       return handler(value)
     }
   }

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -6201,6 +6201,14 @@ type Flatten<Schemas> = Schemas extends readonly [infer Head, ...infer Tail]
   : [Head, ...Flatten<Tail>]
   : []
 
+type MatchCasesResult<Cases> = {
+  [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => infer R ? R : never
+}[keyof Cases]
+
+type MatchOrElseResult<Cases, OrElse extends (...args: Array<any>) => any> = Unify<
+  MatchCasesResult<Cases> | ReturnType<OrElse>
+>
+
 type TaggedUnionUtils<
   Tag extends PropertyKey,
   Members extends ReadonlyArray<Constraint & { readonly Type: { readonly [K in Tag]: PropertyKey } }>,
@@ -6231,6 +6239,31 @@ type TaggedUnionUtils<
       cases: Cases
     ): (value: Members[number]["Type"]) => Cases[keyof Cases] extends (value: any) => infer R ? Unify<R>
       : never
+  }
+  readonly matchOrElse: {
+    <
+      Cases extends
+        & { [M in Flattened[number] as M["Type"][Tag]]+?: (value: M["Type"]) => any }
+        & { [K in Exclude<keyof Cases, Flattened[number]["Type"][Tag]>]: never },
+      OrElse extends (
+        value: Exclude<Members[number]["Type"], { readonly [K in Tag]: keyof Cases }>
+      ) => any
+    >(
+      value: Members[number]["Type"],
+      cases: Cases,
+      orElse: OrElse
+    ): MatchOrElseResult<Cases, OrElse>
+    <
+      Cases extends
+        & { [M in Flattened[number] as M["Type"][Tag]]+?: (value: M["Type"]) => any }
+        & { [K in Exclude<keyof Cases, Flattened[number]["Type"][Tag]>]: never },
+      OrElse extends (
+        value: Exclude<Members[number]["Type"], { readonly [K in Tag]: keyof Cases }>
+      ) => any
+    >(
+      cases: Cases,
+      orElse: OrElse
+    ): (value: Members[number]["Type"]) => MatchOrElseResult<Cases, OrElse>
   }
 }
 
@@ -6287,7 +6320,7 @@ export function toTaggedUnion<const Tag extends PropertyKey>(tag: Tag) {
 
     walk(self)
 
-    return Object.assign(self, { cases, discriminants, isAnyOf, guards, match }) as any
+    return Object.assign(self, { cases, discriminants, isAnyOf, guards, match, matchOrElse }) as any
 
     function walk(schema: Constraint) {
       const ast = schema.ast
@@ -6333,6 +6366,24 @@ export function toTaggedUnion<const Tag extends PropertyKey>(tag: Tag) {
       const handler = Object.hasOwn(cases, key) ? cases[key] : undefined
       return handler(value)
     }
+
+    function matchOrElse() {
+      if (arguments.length === 2) {
+        const cases = arguments[0]
+        const orElse = arguments[1]
+        return function(value: any) {
+          const key = value[tag]
+          const handler = Object.hasOwn(cases, key) ? cases[key] : orElse
+          return handler(value)
+        }
+      }
+      const value = arguments[0]
+      const cases = arguments[1]
+      const orElse = arguments[2]
+      const key = value[tag]
+      const handler = Object.hasOwn(cases, key) ? cases[key] : orElse
+      return handler(value)
+    }
   }
 }
 
@@ -6369,12 +6420,37 @@ export interface TaggedUnion<Cases extends Record<string, Constraint>> extends
       cases: { [K in keyof Cases]: (value: Cases[K]["Type"]) => Output }
     ): Output
   }
+  readonly matchOrElse: {
+    <
+      MatchCases extends
+        & { [K in keyof Cases]+?: (value: Cases[K]["Type"]) => any }
+        & { [K in Exclude<keyof MatchCases, keyof Cases>]: never },
+      OrElse extends (
+        value: Exclude<Cases[keyof Cases]["Type"], { readonly _tag: keyof MatchCases }>
+      ) => any
+    >(
+      cases: MatchCases,
+      orElse: OrElse
+    ): (value: Cases[keyof Cases]["Type"]) => MatchOrElseResult<MatchCases, OrElse>
+    <
+      MatchCases extends
+        & { [K in keyof Cases]+?: (value: Cases[K]["Type"]) => any }
+        & { [K in Exclude<keyof MatchCases, keyof Cases>]: never },
+      OrElse extends (
+        value: Exclude<Cases[keyof Cases]["Type"], { readonly _tag: keyof MatchCases }>
+      ) => any
+    >(
+      value: Cases[keyof Cases]["Type"],
+      cases: MatchCases,
+      orElse: OrElse
+    ): MatchOrElseResult<MatchCases, OrElse>
+  }
 }
 
 /**
  * Builds a discriminated union from a record of field sets, one per variant.
  * Each key becomes the `_tag` literal and the value is passed to {@link TaggedStruct}.
- * The result includes `cases`, `guards`, `isAnyOf`, and `match` utilities.
+ * The result includes `cases`, `guards`, `isAnyOf`, `match`, and `matchOrElse` utilities.
  *
  * **Example** (Pattern matching a discriminated union)
  *
@@ -6409,8 +6485,8 @@ export function TaggedUnion<const CasesByTag extends Record<string, Struct.Field
     members.push(member)
   }
   const union = Union(members)
-  const { guards, isAnyOf, match } = toTaggedUnion("_tag")(union)
-  return make(union.ast, { cases, isAnyOf, guards, match })
+  const { guards, isAnyOf, match, matchOrElse } = toTaggedUnion("_tag")(union)
+  return make(union.ast, { cases, isAnyOf, guards, match, matchOrElse })
 }
 
 /**

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -6201,6 +6201,14 @@ type Flatten<Schemas> = Schemas extends readonly [infer Head, ...infer Tail]
   : [Head, ...Flatten<Tail>]
   : []
 
+type MatchCasesResult<Cases> = {
+  [K in keyof Cases]-?: NonNullable<Cases[K]> extends (...args: Array<any>) => infer R ? R : never
+}[keyof Cases]
+
+type MatchOrElseResult<Cases, OrElse extends (...args: Array<any>) => any> = Unify<
+  MatchCasesResult<Cases> | ReturnType<OrElse>
+>
+
 type TaggedUnionUtils<
   Tag extends PropertyKey,
   Members extends ReadonlyArray<Constraint & { readonly Type: { readonly [K in Tag]: PropertyKey } }>,
@@ -6233,15 +6241,29 @@ type TaggedUnionUtils<
       : never
   }
   readonly matchOrElse: {
-    <Output>(
+    <
+      Cases extends
+        & { [M in Flattened[number] as M["Type"][Tag]]+?: (value: M["Type"]) => any }
+        & { [K in Exclude<keyof Cases, Flattened[number]["Type"][Tag]>]: never },
+      OrElse extends (
+        value: Exclude<Members[number]["Type"], { readonly [K in Tag]: keyof Cases }>
+      ) => any
+    >(
       value: Members[number]["Type"],
-      cases: { [M in Flattened[number] as M["Type"][Tag]]+?: (value: M["Type"]) => Output },
-      orElse: (value: Members[number]["Type"]) => Output
-    ): Output
-    <Output>(
-      cases: { [M in Flattened[number] as M["Type"][Tag]]+?: (value: M["Type"]) => Output },
-      orElse: (value: Members[number]["Type"]) => Output
-    ): (value: Members[number]["Type"]) => Output
+      cases: Cases,
+      orElse: OrElse
+    ): MatchOrElseResult<Cases, OrElse>
+    <
+      Cases extends
+        & { [M in Flattened[number] as M["Type"][Tag]]+?: (value: M["Type"]) => any }
+        & { [K in Exclude<keyof Cases, Flattened[number]["Type"][Tag]>]: never },
+      OrElse extends (
+        value: Exclude<Members[number]["Type"], { readonly [K in Tag]: keyof Cases }>
+      ) => any
+    >(
+      cases: Cases,
+      orElse: OrElse
+    ): (value: Members[number]["Type"]) => MatchOrElseResult<Cases, OrElse>
   }
 }
 

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -9149,8 +9149,17 @@ pointed message
           "A"
         )
         deepStrictEqual(
+          schema.matchOrElse({ _tag: b, b: 1 }, { A: () => "A" }, (value) => value._tag),
+          b
+        )
+        deepStrictEqual(
           pipe({ _tag: b, b: 1 }, schema.matchOrElse({ A: () => "A" }, (value) => value._tag)),
           b
+        )
+        const undefinedCases = { A: undefined } as unknown as { A?: () => string }
+        deepStrictEqual(
+          schema.matchOrElse({ _tag: "A", a: "a" }, undefinedCases, () => "fallback"),
+          "fallback"
         )
       })
 
@@ -9283,6 +9292,10 @@ pointed message
         deepStrictEqual(
           schema.matchOrElse({ _tag: "A", a: "a" }, { A: (value) => value.a }, () => "fallback"),
           "a"
+        )
+        deepStrictEqual(
+          schema.matchOrElse({ _tag: "B", b: 1 }, { A: () => "A" }, (value) => value._tag),
+          "B"
         )
         deepStrictEqual(
           pipe({ _tag: "B", b: 1 }, schema.matchOrElse({ A: () => "A" }, (value) => value._tag)),

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -9142,6 +9142,16 @@ pointed message
           ),
           "D"
         )
+
+        // matchOrElse
+        deepStrictEqual(
+          schema.matchOrElse({ _tag: "A", a: "a" }, { A: () => "A" }, () => "fallback"),
+          "A"
+        )
+        deepStrictEqual(
+          pipe({ _tag: b, b: 1 }, schema.matchOrElse({ A: () => "A" }, (value) => value._tag)),
+          b
+        )
       })
 
       it("should support multiple tags", () => {
@@ -9267,6 +9277,16 @@ pointed message
         deepStrictEqual(
           pipe({ _tag: "C", c: true }, schema.match({ A: () => "A", B: () => "B", C: () => "C" })),
           "C"
+        )
+
+        // matchOrElse
+        deepStrictEqual(
+          schema.matchOrElse({ _tag: "A", a: "a" }, { A: (value) => value.a }, () => "fallback"),
+          "a"
+        )
+        deepStrictEqual(
+          pipe({ _tag: "B", b: 1 }, schema.matchOrElse({ A: () => "A" }, (value) => value._tag)),
+          "B"
         )
       })
     })

--- a/packages/effect/typetest/schema/Union.tst.ts
+++ b/packages/effect/typetest/schema/Union.tst.ts
@@ -203,7 +203,7 @@ describe("Union", () => {
     })
 
     describe("matchOrElse", () => {
-      it("should type partial cases and narrow the fallback", () => {
+      it("should type partial cases with a shared output", () => {
         const schema = Schema.TaggedUnion({
           A: { a: Schema.String },
           B: { b: Schema.Number },
@@ -211,22 +211,23 @@ describe("Union", () => {
         })
         const value = hole<Schema.Schema.Type<typeof schema>>()
 
-        const result = schema.matchOrElse(value, {
+        const result = schema.matchOrElse<string>(value, {
           A: (value) => {
             expect(value).type.toBe<{ readonly _tag: "A"; readonly a: string }>()
-            return Effect.succeed(value.a)
+            return value.a
           }
         }, (value) => {
           expect(value).type.toBe<
+            | { readonly _tag: "A"; readonly a: string }
             | { readonly _tag: "B"; readonly b: number }
             | { readonly _tag: "C"; readonly c: boolean }
           >()
-          return Effect.fail(value._tag)
+          return value._tag
         })
 
-        expect(result).type.toBe<Effect.Effect<string, "B" | "C">>()
-        expect(schema.matchOrElse({ A: () => "A" as const }, (value) => value._tag)).type.toBeAssignableTo<
-          (value: Schema.Schema.Type<typeof schema>) => "A" | "B" | "C"
+        expect(result).type.toBe<string>()
+        expect(schema.matchOrElse<string>({ A: () => "A" }, (value) => value._tag)).type.toBe<
+          (value: Schema.Schema.Type<typeof schema>) => string
         >()
         expect(schema.matchOrElse).type.not.toBeCallableWith({ D: () => "D" }, () => "fallback")
       })

--- a/packages/effect/typetest/schema/Union.tst.ts
+++ b/packages/effect/typetest/schema/Union.tst.ts
@@ -203,6 +203,30 @@ describe("Union", () => {
     })
 
     describe("matchOrElse", () => {
+      it("should preserve toTaggedUnion branch outputs and narrow the fallback", () => {
+        const schema = Schema.Union([
+          Schema.TaggedStruct("A", { a: Schema.String }),
+          Schema.TaggedStruct("B", { b: Schema.Number }),
+          Schema.TaggedStruct("C", { c: Schema.Boolean })
+        ]).pipe(Schema.toTaggedUnion("_tag"))
+        const value = hole<Schema.Schema.Type<typeof schema>>()
+        const cases: {
+          readonly A?: (value: { readonly _tag: "A"; readonly a: string }) => Effect.Effect<string>
+        } = {
+          A: (value) => Effect.succeed(value.a)
+        }
+
+        const result = schema.matchOrElse(value, cases, (value) => {
+          expect(value).type.toBe<
+            | { readonly _tag: "B"; readonly b: number }
+            | { readonly _tag: "C"; readonly c: boolean }
+          >()
+          return Effect.fail(value._tag)
+        })
+
+        expect(result).type.toBe<Effect.Effect<string, "B" | "C">>()
+      })
+
       it("should type partial cases with a shared output", () => {
         const schema = Schema.TaggedUnion({
           A: { a: Schema.String },

--- a/packages/effect/typetest/schema/Union.tst.ts
+++ b/packages/effect/typetest/schema/Union.tst.ts
@@ -202,6 +202,36 @@ describe("Union", () => {
       })
     })
 
+    describe("matchOrElse", () => {
+      it("should type partial cases and narrow the fallback", () => {
+        const schema = Schema.TaggedUnion({
+          A: { a: Schema.String },
+          B: { b: Schema.Number },
+          C: { c: Schema.Boolean }
+        })
+        const value = hole<Schema.Schema.Type<typeof schema>>()
+
+        const result = schema.matchOrElse(value, {
+          A: (value) => {
+            expect(value).type.toBe<{ readonly _tag: "A"; readonly a: string }>()
+            return Effect.succeed(value.a)
+          }
+        }, (value) => {
+          expect(value).type.toBe<
+            | { readonly _tag: "B"; readonly b: number }
+            | { readonly _tag: "C"; readonly c: boolean }
+          >()
+          return Effect.fail(value._tag)
+        })
+
+        expect(result).type.toBe<Effect.Effect<string, "B" | "C">>()
+        expect(schema.matchOrElse({ A: () => "A" as const }, (value) => value._tag)).type.toBeAssignableTo<
+          (value: Schema.Schema.Type<typeof schema>) => "A" | "B" | "C"
+        >()
+        expect(schema.matchOrElse).type.not.toBeCallableWith({ D: () => "D" }, () => "fallback")
+      })
+    })
+
     describe("TaggedUnion", () => {
       it("should depends on the order of the cases", () => {
         const schema = Schema.TaggedUnion({


### PR DESCRIPTION
## Summary

- add `matchOrElse` to `Schema.TaggedUnion` and tagged unions created with `toTaggedUnion`
- use Tim's single-`Output` signature for `TaggedUnion`, with the full union passed to its fallback
- preserve branch-output unification and fallback narrowing for `toTaggedUnion`, including pre-built optional case maps
- preserve own-property dispatch while falling back for missing or `undefined` handlers

## Testing

- `nix develop -c pnpm check`
- `nix develop -c deno check .`
- `nix develop -c pnpm vitest run packages/effect/test/schema/Schema.test.ts`
- `nix develop -c pnpm tstyche packages/effect/typetest/schema/Union.tst.ts --target '>=5.9'`
- targeted oxlint and dprint checks

Closes EFF-802
