### PR TITLE
Skip stack capture for SchemaError

### DIFF
--- a/.changeset/eff-806-schema-error-stack.md
+++ b/.changeset/eff-806-schema-error-stack.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Improve `SchemaError` construction performance by skipping stack frame capture.

--- a/packages/effect/benchmark/schema/SchemaError.ts
+++ b/packages/effect/benchmark/schema/SchemaError.ts
@@ -1,0 +1,46 @@
+import { Schema, SchemaIssue } from "effect"
+import { Bench } from "tinybench"
+
+const batchSize = 1_000
+const bench = new Bench({
+  iterations: 1_000,
+  time: 0,
+  warmupIterations: 100,
+  warmupTime: 0,
+  timestampProvider: "hrtimeNow"
+})
+const issue = new SchemaIssue.InvalidValue({ message: "Expected string" })
+let sink: Schema.SchemaError | undefined
+
+bench.add("SchemaError construction", () => {
+  let error = new Schema.SchemaError(issue)
+  for (let index = 1; index < batchSize; index++) {
+    error = new Schema.SchemaError(issue)
+  }
+  sink = error
+})
+
+await bench.run()
+
+if (sink === undefined) {
+  throw new Error("Benchmark did not run")
+}
+
+console.table(bench.table((task) => {
+  const result = task.result
+  if (result?.state !== "completed") {
+    return {
+      "Task name": task.name,
+      State: result?.state ?? "missing result"
+    }
+  }
+  const latencyToNs = (value: number) => value * 1_000_000 / batchSize
+  return {
+    "Task name": task.name,
+    "Latency avg (ns/op)": latencyToNs(result.latency.mean).toFixed(2),
+    "Latency med (ns/op)": latencyToNs(result.latency.p50).toFixed(2),
+    "Latency RME": `${result.latency.rme.toFixed(2)}%`,
+    "Throughput avg (ops/s)": Math.round(result.throughput.mean * batchSize),
+    Samples: result.latency.samplesCount
+  }
+}))

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -44,6 +44,7 @@ import * as InternalArbitrary from "./internal/schema/toArbitrary.ts"
 import * as InternalEquivalence from "./internal/schema/toEquivalence.ts"
 import * as InternalToJsonSchemaDocument from "./internal/schema/toJsonSchemaDocument.ts"
 import * as InternalToRepresentation from "./internal/schema/toRepresentation.ts"
+import { getStackTraceLimit, setStackTraceLimit } from "./internal/stackTraceLimit.ts"
 import * as JsonPatch from "./JsonPatch.ts"
 import * as JsonSchema from "./JsonSchema.ts"
 import { remainder } from "./Number.ts"
@@ -1181,7 +1182,13 @@ export class SchemaError extends Data.TaggedError("SchemaError")<{
 }> {
   readonly [SchemaErrorTypeId]: typeof SchemaErrorTypeId = SchemaErrorTypeId
   constructor(issue: SchemaIssue.Issue) {
-    super({ issue })
+    const stackTraceLimit = getStackTraceLimit()
+    setStackTraceLimit(0)
+    try {
+      super({ issue })
+    } finally {
+      setStackTraceLimit(stackTraceLimit)
+    }
   }
   override get message() {
     return SchemaIssue.defaultFormatter(this.issue)

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -112,6 +112,18 @@ describe("Schema", () => {
       strictEqual(error.message, "Expected string")
       strictEqual(String(error), "SchemaError(Expected string)")
     })
+
+    it("does not capture stack frames", () => {
+      const result = SchemaParser.decodeUnknownResult(Schema.String)(null)
+      assertTrue(Result.isFailure(result))
+      const ErrorWithLimit = Error as typeof Error & { stackTraceLimit?: number | undefined }
+      const stackTraceLimit = ErrorWithLimit.stackTraceLimit
+
+      const error = new Schema.SchemaError(result.failure)
+
+      strictEqual(error.stack, "SchemaError: Expected string")
+      strictEqual(ErrorWithLimit.stackTraceLimit, stackTraceLimit)
+    })
   })
 
   describe("parseOptions annotation", () => {


### PR DESCRIPTION
Skip V8 stack frame capture while constructing `SchemaError`, then restore the previous global limit in a `finally` block. This preserves the error name and message while avoiding work on a hot failure path.

The included Tinybench case constructs 1,000 errors per sample over 1,000 samples. On this runner, three baseline runs measured 3,111-3,160 ns/op; three patched runs measured 436-445 ns/op. That is about 7.1x faster, or 86% lower latency.

Tests cover the stackless result and restoration of `Error.stackTraceLimit`.

Validation:

- `nix develop -c pnpm test packages/effect/test/schema/Schema.test.ts --run`
- `nix develop -c pnpm --dir packages/effect check`
- `nix develop -c pnpm lint`

Closes EFF-806
