### PR TITLE
Fix `Prompt.autoComplete` swallowing `j` and `k` while filtering

### DIFF
--- a/.changeset/autocomplete-jk-filter.md
+++ b/.changeset/autocomplete-jk-filter.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Fix `Prompt.autoComplete` swallowing `j` and `k` while typing a filter query. Closes [#7392](https://github.com/Effect-TS/effect/issues/7392).
+
+The key dispatch bound bare `j`/`k` to cursor down/up before the filter input saw them, so any query containing either letter was silently corrupted — typing `jira` filtered on `ira`, `worktree` on `wortree` — and a single `j` could submit the wrong choice with no error. Every printable character now reaches the filter. Navigation moves to `Ctrl+P` / `Ctrl+N` (as in `readline` and `fzf`), with `Ctrl+K` also moving up; the arrow keys, `tab`, and `Ctrl+U` are unchanged. `Prompt.select` and `Prompt.multiSelect`, which have no text input, keep their vi-style `j`/`k` bindings.

--- a/.changeset/autocomplete-jk-filter.md
+++ b/.changeset/autocomplete-jk-filter.md
@@ -2,6 +2,4 @@
 "effect": patch
 ---
 
-Fix `Prompt.autoComplete` swallowing `j` and `k` while typing a filter query. Closes [#7392](https://github.com/Effect-TS/effect/issues/7392).
-
-The key dispatch bound bare `j`/`k` to cursor down/up before the filter input saw them, so any query containing either letter was silently corrupted — typing `jira` filtered on `ira`, `worktree` on `wortree` — and a single `j` could submit the wrong choice with no error. Every printable character now reaches the filter. Navigation moves to `Ctrl+P` / `Ctrl+N` (as in `readline` and `fzf`), with `Ctrl+K` also moving up; the arrow keys, `tab`, and `Ctrl+U` are unchanged. `Prompt.select` and `Prompt.multiSelect`, which have no text input, keep their vi-style `j`/`k` bindings.
+Fix `Prompt.autoComplete` swallowing `j` and `k` while typing a filter query.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -1241,6 +1241,12 @@ export const select = <const A>(options: SelectOptions<A>): Prompt<A> => {
 /**
  * Creates a prompt that lets users filter select choices by typing.
  *
+ * **Details**
+ *
+ * Every printable character is appended to the filter query, so navigation is
+ * bound to the arrow keys, `tab`, and the `Ctrl+P` / `Ctrl+N` chords used by
+ * `readline` and `fzf` (`Ctrl+K` also moves up). `Ctrl+U` clears the query.
+ *
  * **Example** (Filtering choices with autocomplete)
  *
  * ```ts import.meta.vitest
@@ -3558,18 +3564,29 @@ const handleSelectProcess = <A>(options: SelectOptionsReq<A>) => {
 
 const handleAutoCompleteProcess = <A>(options: AutoCompleteOptionsReq<A>) => {
   return (input: Terminal.UserInput, state: AutoCompleteState) => {
+    // Navigation is bound to ctrl chords rather than bare `j`/`k`, so that every
+    // printable character reaches the filter input.
     if (input.key.ctrl) {
-      if (input.key.name === "u") {
-        return processAutoCompleteClear(state, options)
+      switch (input.key.name) {
+        case "u": {
+          return processAutoCompleteClear(state, options)
+        }
+        case "p":
+        case "k": {
+          return processAutoCompleteCursorUp(state)
+        }
+        case "n": {
+          return processAutoCompleteCursorDown(state)
+        }
+        default: {
+          return Effect.succeed(Action.Beep())
+        }
       }
-      return Effect.succeed(Action.Beep())
     }
     switch (input.key.name) {
-      case "k":
       case "up": {
         return processAutoCompleteCursorUp(state)
       }
-      case "j":
       case "down": {
         return processAutoCompleteCursorDown(state)
       }

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -679,6 +679,98 @@ describe("Prompt.autoComplete", () => {
 
       assert.isTrue(findFrame(frames, "No matches") !== undefined)
     }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("keeps `j` and `k` in the filter query instead of moving the cursor", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.autoComplete({
+        message: "Pick a branch",
+        choices: [
+          { title: "feat/jira-fetch-tool", value: "feat/jira-fetch-tool" },
+          { title: "main", value: "main" },
+          { title: "feat/worktree-tool", value: "feat/worktree-tool" }
+        ]
+      })
+
+      yield* MockTerminal.inputText("jira")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(result, "feat/jira-fetch-tool")
+
+      const output = yield* MockTerminal.displayLines
+      const frames = toFrames(output)
+      const filteredFrame = findFrame(frames, "[filter: jira]")
+
+      assert.isTrue(filteredFrame !== undefined)
+      assert.isTrue(filteredFrame?.includes("feat/jira-fetch-tool"))
+      assert.isFalse(filteredFrame?.includes("main"))
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("filters a query that merely contains a `k`", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.autoComplete({
+        message: "Pick a branch",
+        choices: [
+          { title: "main", value: "main" },
+          { title: "feat/jira-fetch-tool", value: "feat/jira-fetch-tool" },
+          { title: "feat/worktree-tool", value: "feat/worktree-tool" }
+        ]
+      })
+
+      yield* MockTerminal.inputText("worktree")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(result, "feat/worktree-tool")
+
+      const output = yield* MockTerminal.displayLines
+      const frames = toFrames(output)
+      const filteredFrame = findFrame(frames, "[filter: worktree]")
+
+      assert.isTrue(filteredFrame !== undefined)
+      assert.isTrue(filteredFrame?.includes("feat/worktree-tool"))
+      assert.isFalse(filteredFrame?.includes("feat/jira-fetch-tool"))
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("moves the cursor with ctrl-n and ctrl-p", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.autoComplete({
+        message: "Pick item",
+        choices: [
+          { title: "Alpha", value: "alpha" },
+          { title: "Beta", value: "beta" },
+          { title: "Delta", value: "delta" }
+        ]
+      })
+
+      yield* MockTerminal.inputKey("n", { ctrl: true })
+      yield* MockTerminal.inputKey("n", { ctrl: true })
+      yield* MockTerminal.inputKey("p", { ctrl: true })
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(result, "beta")
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("moves the cursor up with ctrl-k", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.autoComplete({
+        message: "Pick item",
+        choices: [
+          { title: "Alpha", value: "alpha" },
+          { title: "Beta", value: "beta" },
+          { title: "Delta", value: "delta" }
+        ]
+      })
+
+      yield* MockTerminal.inputKey("down")
+      yield* MockTerminal.inputKey("down")
+      yield* MockTerminal.inputKey("k", { ctrl: true })
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(result, "beta")
+    }).pipe(Effect.provide(TestLayer)))
 })
 
 describe("Prompt.file", () => {


### PR DESCRIPTION
Closes #7392

## What is the problem

`Prompt.autoComplete` is a prompt where the user types to filter the choices. But in `handleAutoCompleteProcess` a plain `j` and a plain `k` were sent to the cursor (down and up) before the filter received them. Because of this, any query that contains one of these two letters was changed, and the user was not told about it:

| you type | real filter | real result |
| --- | --- | --- |
| `fetch` (control, no `j`/`k`) | `fetch` | `feat/jira-fetch-tool` ✅ |
| `jira` | `ira` | correct value, but only by luck, because `ira` still matches |
| `worktree` | `wortree` | "No matches". After `enter` the prompt beeps and then waits forever |
| `j` (with `feat/jira-fetch-tool` first in the list) | *no change* | **`main`**, a wrong value returned without any error |
| `kot` on the choices from the documentation | `ot` | `Kotlin`, again only by luck |

Two points are important here:

- The `worktree` row shows that this is not only about vi navigation. A normal query is also changed, only because it contains a `k`.
- The `j` row shows the worst case. The prompt returns a value the user did not choose, and there is no error.

The example inside the documentation comment of `autoComplete` has the same problem. Its three choices are TypeScript, Rust and **Kotlin**, and `Kotlin` is exactly the one you cannot type for.

## What this PR changes

`packages/effect/src/unstable/cli/Prompt.ts`, `handleAutoCompleteProcess`:

- The plain `j` and `k` cases are removed, so every printable character now reaches the filter.
- The `ctrl` branch is now a `switch`. Before, it only handled `Ctrl+U` and let all other ctrl keys beep. Now it also handles navigation:
  - `Ctrl+P` and `Ctrl+K` move the cursor up
  - `Ctrl+N` moves the cursor down
  - `Ctrl+U` clears the query, as before
  - everything else still beeps
- The arrow keys, `tab`, `backspace` and `enter` are not changed.
- The documentation comment of `autoComplete` now has a short **Details** section that names these keys, because the prompt itself does not show them anywhere.

`Ctrl+N` and `Ctrl+P` are the default keys in readline and in `fzf`, so this should feel familiar.

`Prompt.select` and `Prompt.multiSelect` are **not** changed. They have no text input, so a plain `j` or `k` cannot be understood in two ways there, and their vi style keys still work.

### Why not `Ctrl+J`

The normal vi pair would be `Ctrl+J` and `Ctrl+K`. But the `Terminal` layer cannot tell the difference between `Ctrl+J` and `Enter`. `Ctrl+J` is ASCII `0x0A`, and `NodeTerminal` uses `readline.emitKeypressEvents`, which reports it as `{ name: "enter", ctrl: false }`:

```
\x0a (ctrl+j) -> { name: "enter",  ctrl: false }   # the same as Enter
\x0b (ctrl+k) -> { name: "k",      ctrl: true  }
\x0d (enter)  -> { name: "return", ctrl: false }
\x0e (ctrl+n) -> { name: "n",      ctrl: true  }
\x10 (ctrl+p) -> { name: "p",      ctrl: true  }
```

This is why `Ctrl+N` is used for "down".

## Tests

Four new tests in `describe("Prompt.autoComplete", ...)` (`packages/effect/test/unstable/cli/Prompt.test.ts`). All four were written first and all four failed before the fix:

| test | how it failed before |
| --- | --- |
| keeps `j` and `k` in the filter query instead of moving the cursor | wrong filter |
| filters a query that merely contains a `k` | timeout, because no match means beep and then wait |
| moves the cursor with ctrl-n and ctrl-p | returned `alpha`, the keys did nothing |
| moves the cursor up with ctrl-k | returned `delta`, the key did nothing |

Results after the fix:

- `Prompt.test.ts`: 53 tests pass
- full CLI suite: 377 tests pass in 12 files
- full `effect` package: 8644 pass, 47 skipped, 0 failures
- `tsc -b` and lint are clean

## Behavior change for `j` and `k` users

Anyone who used `j` and `k` to move inside an `autoComplete` prompt will notice the difference. But that was the bug, so this is what needs to change. These users can now press `Ctrl+P` and `Ctrl+N`, or `Ctrl+K` for up, or use the arrow keys as before. `select` and `multiSelect` are not affected.

The changeset is a `patch`, which matches how the other changes in the current `4.0.0-rc` series are released.
