### PR TITLE
Fix `Prompt.file` swallowing `j` and `k` while filtering

### DIFF
--- a/.changeset/file-prompt-jk-filter.md
+++ b/.changeset/file-prompt-jk-filter.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Prompt.file` swallowing `j` and `k` while typing a filter query.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -963,6 +963,11 @@ export const date = (options: DateOptions): Prompt<Date> => {
  * The prompt can be configured to select files, directories, or either path
  * type.
  *
+ * You can also type to filter the listed entries. Every printable character is
+ * appended to the filter query, so navigation is bound to the arrow keys,
+ * `tab`, and the `Ctrl+P` / `Ctrl+N` chords used by `readline` and `fzf`
+ * (`Ctrl+K` also moves up). `Ctrl+U` clears the query.
+ *
  * @category constructors
  * @since 4.0.0
  */
@@ -2553,21 +2558,32 @@ const processSelection = Effect.fnUntraced(function*(state: FileState, options: 
 
 const handleFileProcess = (options: FileOptionsReq) => {
   return Effect.fnUntraced(function*(input: Terminal.UserInput, state: FileState) {
+    // Navigation is bound to ctrl chords rather than bare `j`/`k`, so that every
+    // printable character reaches the filter input.
     if (input.key.ctrl) {
-      if (input.key.name === "u") {
-        if (showConfirmation(state.confirm)) {
+      switch (input.key.name) {
+        case "u": {
+          if (showConfirmation(state.confirm)) {
+            return Action.Beep()
+          }
+          return yield* processFileClear(state)
+        }
+        case "p":
+        case "k": {
+          return yield* processFileCursorUp(state)
+        }
+        case "n": {
+          return yield* processFileCursorDown(state)
+        }
+        default: {
           return Action.Beep()
         }
-        return yield* processFileClear(state)
       }
-      return Action.Beep()
     }
     switch (input.key.name) {
-      case "k":
       case "up": {
         return yield* processFileCursorUp(state)
       }
-      case "j":
       case "down":
       case "tab": {
         return yield* processFileCursorDown(state)

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -854,6 +854,97 @@ describe("Prompt.file", () => {
       assert.isFalse(narrowedFrame?.includes("basket.txt"))
       assert.isTrue(expandedFrame?.includes("basket.txt"))
     }).pipe(Effect.provide(FilePromptLayer)))
+
+  const JkFilePromptLayer = Layer.mergeAll(
+    FileSystem.layerNoop({
+      exists: () => Effect.succeed(true),
+      readDirectory: (directory) =>
+        Effect.succeed(
+          directory === "/workspace"
+            ? ["jest.config.ts", "package.json", "readme.md"]
+            : []
+        ),
+      stat: () => Effect.succeed({ type: "File" } as any)
+    }),
+    PathLayer,
+    TerminalLayer
+  )
+
+  it.effect("keeps `j` in the filter query instead of moving the cursor", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.file({
+        message: "Pick file",
+        startingPath: "/workspace"
+      })
+
+      yield* MockTerminal.inputText("jest")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(result, "/workspace/jest.config.ts")
+
+      const output = yield* MockTerminal.displayLines
+      const frames = toFrames(output)
+      const filteredFrame = findFrame(frames, "[filter: jest]")
+
+      assert.isTrue(filteredFrame !== undefined)
+      assert.isTrue(filteredFrame?.includes("jest.config.ts"))
+      assert.isFalse(filteredFrame?.includes("readme.md"))
+    }).pipe(Effect.provide(JkFilePromptLayer)))
+
+  it.effect("keeps `k` in the filter query instead of moving the cursor", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.file({
+        message: "Pick file",
+        startingPath: "/workspace"
+      })
+
+      yield* MockTerminal.inputText("package")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(result, "/workspace/package.json")
+
+      const output = yield* MockTerminal.displayLines
+      const frames = toFrames(output)
+      const filteredFrame = findFrame(frames, "[filter: package]")
+
+      assert.isTrue(filteredFrame !== undefined)
+      assert.isTrue(filteredFrame?.includes("package.json"))
+      assert.isFalse(filteredFrame?.includes("readme.md"))
+    }).pipe(Effect.provide(JkFilePromptLayer)))
+
+  it.effect("moves the cursor with ctrl-n and ctrl-p", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.file({
+        message: "Pick file",
+        startingPath: "/workspace"
+      })
+
+      yield* MockTerminal.inputKey("n", { ctrl: true })
+      yield* MockTerminal.inputKey("n", { ctrl: true })
+      yield* MockTerminal.inputKey("p", { ctrl: true })
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(result, "/workspace/alpha.txt")
+    }).pipe(Effect.provide(FilePromptLayer)))
+
+  it.effect("moves the cursor up with ctrl-k", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.file({
+        message: "Pick file",
+        startingPath: "/workspace"
+      })
+
+      yield* MockTerminal.inputKey("down")
+      yield* MockTerminal.inputKey("down")
+      yield* MockTerminal.inputKey("k", { ctrl: true })
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(result, "/workspace/alpha.txt")
+    }).pipe(Effect.provide(FilePromptLayer)))
 })
 
 describe("Prompt.multiSelect", () => {


### PR DESCRIPTION
Follow-up to #7393. That PR fixed this defect in `Prompt.autoComplete`, but `handleFileProcess` has its own copy of the key handling, and it has exactly the same problem.

## What is the problem

`Prompt.file` lets you type to filter the files in the current directory. But a plain `j` and a plain `k` were sent to the cursor (down and up) before the filter received them. Because of this, any query that contains one of these two letters was changed, and the user was not told about it:

| you type | real filter | real result |
| --- | --- | --- |
| `jest` | `est` | the wrong file, or no file at all, because the `j` moved the cursor |
| `package` | `pacage` | no match. After `enter` the prompt beeps and then waits forever |

This matters more here than in `autoComplete`, because file names hit these two letters very often. `package.json` contains both, so it can never be typed. The same is true for `Makefile`, `jest.config.ts`, `knip.json`, and every `.jsx` or `.tsx` file in a path that has a `k` in it.

## What this PR changes

`packages/effect/src/unstable/cli/Prompt.ts`, `handleFileProcess`, using the same shape as #7393:

- The plain `j` and `k` cases are removed, so every printable character now reaches the filter.
- The `ctrl` branch is now a `switch`. Before, it only handled `Ctrl+U` and let all other ctrl keys beep. Now it also handles navigation:
  - `Ctrl+P` and `Ctrl+K` move the cursor up
  - `Ctrl+N` moves the cursor down
  - `Ctrl+U` clears the query, as before
  - everything else still beeps
- The arrow keys, `tab`, `backspace` and `enter` are not changed. `tab` still moves the cursor down, which is different from `autoComplete`, so this is not a copy of the earlier patch.
- The `y`/`t` and `n`/`f` answers to the overwrite question are not changed.
- The documentation comment of `file` now names these keys, because the prompt itself does not show them anywhere.

## Tests

Four new tests in `describe("Prompt.file", ...)`. All four were written first and all four failed before the fix:

| test | how it failed before |
| --- | --- |
| keeps `j` in the filter query instead of moving the cursor | no `[filter: jest]` frame, the query was `est` |
| keeps `k` in the filter query instead of moving the cursor | timeout, because `pacage` matches nothing and the prompt then waits |
| moves the cursor with ctrl-n and ctrl-p | timeout, the keys did nothing |
| moves the cursor up with ctrl-k | returned `banana.txt` instead of `alpha.txt` |

Results after the fix:

- full `effect` package: 8659 pass, 47 skipped, 0 failures
- `tsc -b`, `oxlint` and `dprint` are clean

## Other prompts

I checked every other place in `Prompt.ts` that binds `j` or `k`. Only `file` and `autoComplete` have a text filter, so only these two were affected. `date`, `integer`, `float`, `select`, `multiSelect` and `toggle` have no free text input, and their `j` and `k` keys are correct.

## Behavior change for `j` and `k` users

Anyone who used `j` and `k` to move inside a `file` prompt will notice the difference. But that was the bug, so this is what needs to change. These users can now press `Ctrl+P` and `Ctrl+N`, or `Ctrl+K` for up, or use the arrow keys as before.

The changeset is a `patch`, which matches how the other changes in the current `4.0.0-rc` series are released.
