### PR TITLE
Speed up SchemaBinary RPC serialization

### DIFF
--- a/packages/effect/benchmark/schema/SchemaBinary.md
+++ b/packages/effect/benchmark/schema/SchemaBinary.md
@@ -6,7 +6,7 @@ Run from the repository root:
 nix develop -c pnpm --dir packages/effect exec node benchmark/schema/SchemaBinary.ts
 ```
 
-These results are from one full run at commit `ef9b90a9b` on Linux x86_64 with Node 26.7.0. Codec and schema construction are excluded. One-shot tasks use 100 warmups and 1,000 measured samples; streaming tasks use 25 warmups and 250 measured samples. Throughput is machine-local and should only be compared within this run.
+These results are from one full run at commit `96c14d07d` on Linux x86_64 (AMD EPYC 4344P) with Node 26.7.0. Codec and schema construction are excluded. One-shot tasks use 100 warmups and 1,000 measured samples; streaming tasks use 25 warmups and 250 measured samples. Throughput is machine-local and should only be compared within this run.
 
 Fingerprint mode omits field identifiers when the schema fingerprint matches. JSON, Msgpack, and NDJSON use the same `Schema.toCodecJson` representation.
 
@@ -47,23 +47,23 @@ Average encode operations per second:
 
 | Case                   |   Default | Fingerprint |    JSON | Msgpack |
 | ---------------------- | --------: | ----------: | ------: | ------: |
-| small record           | 1,138,225 |   1,147,081 | 452,215 | 715,571 |
-| nested payload         |   395,240 |     408,163 | 263,498 | 281,540 |
-| collections            |    35,376 |      35,651 |  21,778 |  22,134 |
-| index signatures / 128 |    14,096 |      14,167 |  35,928 |  35,077 |
-| index signatures / 512 |     2,871 |       2,867 |   6,508 |   6,314 |
-| 200-row array payload  |     6,995 |       8,128 |   6,125 |   4,038 |
+| small record           | 1,065,900 |   1,080,059 | 435,725 | 714,056 |
+| nested payload         |   388,172 |     400,080 | 259,110 | 283,972 |
+| collections            |    51,759 |      52,710 |  21,663 |  22,084 |
+| index signatures / 128 |    46,450 |      46,188 |  35,472 |  34,156 |
+| index signatures / 512 |     8,651 |       8,628 |   6,624 |   6,189 |
+| 200-row array payload  |     7,241 |       8,153 |   7,066 |   4,148 |
 
 Average decode operations per second:
 
 | Case                   |   Default | Fingerprint |    JSON | Msgpack |
 | ---------------------- | --------: | ----------: | ------: | ------: |
-| small record           | 1,121,650 |   1,115,901 | 418,359 | 687,335 |
-| nested payload         |   354,482 |     376,201 | 217,858 | 266,371 |
-| collections            |    39,697 |      39,708 |  20,723 |  21,943 |
-| index signatures / 128 |    20,589 |      20,675 |  28,624 |  29,884 |
-| index signatures / 512 |     4,988 |       4,969 |   5,411 |   4,562 |
-| 200-row array payload  |     7,233 |       7,934 |   5,630 |   4,761 |
+| small record           | 1,138,076 |   1,191,656 | 397,099 | 703,826 |
+| nested payload         |   509,577 |     563,020 | 217,638 | 269,363 |
+| collections            |   112,757 |     112,050 |  20,628 |  21,790 |
+| index signatures / 128 |    62,691 |      60,577 |  28,104 |  29,824 |
+| index signatures / 512 |    16,281 |      15,704 |   5,392 |   4,463 |
+| 200-row array payload  |    10,923 |      12,927 |   5,672 |   4,811 |
 
 ## Streaming decode throughput
 
@@ -71,28 +71,28 @@ Average decoded values per second for batched input:
 
 | Case                   |   Default | Fingerprint | Msgpack |  NDJSON |
 | ---------------------- | --------: | ----------: | ------: | ------: |
-| small record           | 4,385,709 |   5,493,837 | 901,253 | 849,385 |
-| nested payload         |   819,281 |     977,777 | 284,386 | 306,687 |
-| collections            |   118,938 |     119,806 |  21,189 |  20,364 |
-| index signatures / 128 |    58,715 |      58,699 |  27,863 |  28,431 |
-| index signatures / 512 |     8,374 |       8,322 |   4,055 |   5,064 |
-| 200-row array payload  |    11,147 |      12,996 |   6,345 |   4,953 |
-| 200 single-row frames  | 2,127,598 |   2,382,278 | 856,723 | 946,703 |
+| small record           | 4,285,263 |   5,158,250 | 913,285 | 848,614 |
+| nested payload         |   795,946 |     934,861 | 284,120 | 311,612 |
+| collections            |   120,368 |     119,858 |  21,554 |  20,806 |
+| index signatures / 128 |    64,893 |      62,403 |  27,823 |  28,348 |
+| index signatures / 512 |    15,587 |      15,115 |   4,072 |   5,019 |
+| 200-row array payload  |    10,641 |      12,425 |   6,597 |   4,867 |
+| 200 single-row frames  | 2,122,428 |   2,395,816 | 864,717 | 966,175 |
 
 Average decoded values per second for single and first-byte-fragmented input:
 
 | Case                   | Default single | Default fragmented | Fingerprint single | Fingerprint fragmented | NDJSON single | NDJSON fragmented |
 | ---------------------- | -------------: | -----------------: | -----------------: | ---------------------: | ------------: | ----------------: |
-| small record           |      2,585,851 |          2,296,255 |          3,131,403 |              2,871,336 |       137,242 |           142,477 |
-| nested payload         |        710,222 |            699,114 |            836,484 |                826,233 |       109,985 |           108,842 |
-| collections            |        116,964 |            116,132 |            117,837 |                116,882 |        18,463 |            18,438 |
-| index signatures / 128 |         57,343 |             57,974 |             58,448 |                 58,763 |        24,688 |            24,643 |
-| index signatures / 512 |          8,414 |              8,704 |              8,793 |                  8,619 |         5,218 |             5,195 |
-| 200-row array payload  |         11,419 |             11,474 |             13,312 |                 13,295 |         5,206 |             5,127 |
-| 200 single-row frames  |      1,390,397 |          1,369,513 |          1,594,590 |              1,512,635 |       130,684 |           127,909 |
+| small record           |      2,433,121 |          2,203,554 |          2,965,099 |              2,615,759 |       135,622 |           143,223 |
+| nested payload         |        711,825 |            677,588 |            811,717 |                802,630 |       111,122 |           108,762 |
+| collections            |        118,465 |            118,782 |            118,533 |                116,825 |        18,860 |            19,120 |
+| index signatures / 128 |         63,670 |             63,413 |             62,223 |                 61,576 |        24,527 |            24,281 |
+| index signatures / 512 |         15,695 |             15,902 |             15,635 |                 15,285 |         5,160 |             5,168 |
+| 200-row array payload  |         10,993 |             10,901 |             12,667 |                 12,695 |         5,251 |             5,192 |
+| 200 single-row frames  |      1,365,753 |          1,165,356 |          1,527,233 |              1,329,314 |       130,472 |           124,134 |
 
 ## Analysis
 
-- SchemaBinary leads JSON and Msgpack on struct- and collection-heavy one-shot cases. JSON and Msgpack remain faster on large index-signature encodes, where field lookup dominates and the binary layout offers little structural advantage.
+- SchemaBinary leads JSON and Msgpack on every one-shot case, index signatures included. Schemas the binary layer validates on its own skip the schema pass that used to run over each decoded value, and a lone string index signature no longer matches keys one at a time.
 - SchemaBinary is faster than both text and Msgpack streaming in every batch case. NDJSON and Msgpack batch throughput are close and trade places by shape, but NDJSON single-frame throughput is dominated by running a complete Effect Channel for each value.
 - NDJSON is the largest raw stream in every case. Compression changes the ranking for repeated keys: NDJSON has the smallest zstd output for collections and both index-signature cases. Fingerprint SchemaBinary remains the smallest raw format for struct-heavy values.

--- a/packages/effect/benchmark/schema/SchemaBinary.md
+++ b/packages/effect/benchmark/schema/SchemaBinary.md
@@ -6,7 +6,7 @@ Run from the repository root:
 nix develop -c pnpm --dir packages/effect exec node benchmark/schema/SchemaBinary.ts
 ```
 
-These results are from one full run at commit `96c14d07d` on Linux x86_64 (AMD EPYC 4344P) with Node 26.7.0. Codec and schema construction are excluded. One-shot tasks use 100 warmups and 1,000 measured samples; streaming tasks use 25 warmups and 250 measured samples. Throughput is machine-local and should only be compared within this run.
+These results are from one full run at commit `d854fd7c9` on Linux x86_64 (AMD EPYC 4344P) with Node 26.7.0. Codec and schema construction are excluded. One-shot tasks use 100 warmups and 1,000 measured samples; streaming tasks use 25 warmups and 250 measured samples. Throughput is machine-local and should only be compared within this run.
 
 Fingerprint mode omits field identifiers when the schema fingerprint matches. JSON, Msgpack, and NDJSON use the same `Schema.toCodecJson` representation.
 
@@ -47,23 +47,23 @@ Average encode operations per second:
 
 | Case                   |   Default | Fingerprint |    JSON | Msgpack |
 | ---------------------- | --------: | ----------: | ------: | ------: |
-| small record           | 1,065,900 |   1,080,059 | 435,725 | 714,056 |
-| nested payload         |   388,172 |     400,080 | 259,110 | 283,972 |
-| collections            |    51,759 |      52,710 |  21,663 |  22,084 |
-| index signatures / 128 |    46,450 |      46,188 |  35,472 |  34,156 |
-| index signatures / 512 |     8,651 |       8,628 |   6,624 |   6,189 |
-| 200-row array payload  |     7,241 |       8,153 |   7,066 |   4,148 |
+| small record           | 1,083,812 |   1,104,689 | 431,684 | 708,480 |
+| nested payload         |   386,908 |     399,853 | 253,652 | 284,580 |
+| collections            |    52,004 |      53,623 |  21,927 |  22,351 |
+| index signatures / 128 |    46,620 |      46,380 |  36,181 |  35,102 |
+| index signatures / 512 |     8,601 |       8,378 |   6,568 |   6,263 |
+| 200-row array payload  |     7,282 |       8,471 |   7,113 |   4,184 |
 
 Average decode operations per second:
 
 | Case                   |   Default | Fingerprint |    JSON | Msgpack |
 | ---------------------- | --------: | ----------: | ------: | ------: |
-| small record           | 1,138,076 |   1,191,656 | 397,099 | 703,826 |
-| nested payload         |   509,577 |     563,020 | 217,638 | 269,363 |
-| collections            |   112,757 |     112,050 |  20,628 |  21,790 |
-| index signatures / 128 |    62,691 |      60,577 |  28,104 |  29,824 |
-| index signatures / 512 |    16,281 |      15,704 |   5,392 |   4,463 |
-| 200-row array payload  |    10,923 |      12,927 |   5,672 |   4,811 |
+| small record           | 1,135,739 |   1,189,669 | 394,682 | 697,231 |
+| nested payload         |   511,328 |     559,500 | 212,849 | 262,936 |
+| collections            |   112,183 |     112,971 |  21,062 |  22,290 |
+| index signatures / 128 |    62,425 |      61,355 |  28,622 |  29,607 |
+| index signatures / 512 |    15,913 |      15,686 |   5,396 |   4,569 |
+| 200-row array payload  |    11,074 |      12,862 |   5,732 |   4,835 |
 
 ## Streaming decode throughput
 
@@ -71,25 +71,25 @@ Average decoded values per second for batched input:
 
 | Case                   |   Default | Fingerprint | Msgpack |  NDJSON |
 | ---------------------- | --------: | ----------: | ------: | ------: |
-| small record           | 4,285,263 |   5,158,250 | 913,285 | 848,614 |
-| nested payload         |   795,946 |     934,861 | 284,120 | 311,612 |
-| collections            |   120,368 |     119,858 |  21,554 |  20,806 |
-| index signatures / 128 |    64,893 |      62,403 |  27,823 |  28,348 |
-| index signatures / 512 |    15,587 |      15,115 |   4,072 |   5,019 |
-| 200-row array payload  |    10,641 |      12,425 |   6,597 |   4,867 |
-| 200 single-row frames  | 2,122,428 |   2,395,816 | 864,717 | 966,175 |
+| small record           | 4,252,786 |   5,123,480 | 914,260 | 855,356 |
+| nested payload         |   770,680 |     944,310 | 277,764 | 308,887 |
+| collections            |   120,646 |     121,229 |  21,830 |  21,217 |
+| index signatures / 128 |    64,516 |      64,617 |  28,148 |  28,768 |
+| index signatures / 512 |    15,741 |      15,598 |   4,115 |   5,040 |
+| 200-row array payload  |    10,785 |      12,613 |   6,491 |   5,053 |
+| 200 single-row frames  | 2,126,081 |   2,431,681 | 861,368 | 955,186 |
 
 Average decoded values per second for single and first-byte-fragmented input:
 
 | Case                   | Default single | Default fragmented | Fingerprint single | Fingerprint fragmented | NDJSON single | NDJSON fragmented |
 | ---------------------- | -------------: | -----------------: | -----------------: | ---------------------: | ------------: | ----------------: |
-| small record           |      2,433,121 |          2,203,554 |          2,965,099 |              2,615,759 |       135,622 |           143,223 |
-| nested payload         |        711,825 |            677,588 |            811,717 |                802,630 |       111,122 |           108,762 |
-| collections            |        118,465 |            118,782 |            118,533 |                116,825 |        18,860 |            19,120 |
-| index signatures / 128 |         63,670 |             63,413 |             62,223 |                 61,576 |        24,527 |            24,281 |
-| index signatures / 512 |         15,695 |             15,902 |             15,635 |                 15,285 |         5,160 |             5,168 |
-| 200-row array payload  |         10,993 |             10,901 |             12,667 |                 12,695 |         5,251 |             5,192 |
-| 200 single-row frames  |      1,365,753 |          1,165,356 |          1,527,233 |              1,329,314 |       130,472 |           124,134 |
+| small record           |      2,460,050 |          2,216,227 |          2,997,308 |              2,724,743 |       136,936 |           121,880 |
+| nested payload         |        578,884 |            689,451 |            848,984 |                794,700 |       111,254 |           108,171 |
+| collections            |        119,007 |            118,729 |            119,230 |                119,443 |        19,291 |            19,358 |
+| index signatures / 128 |         64,046 |             62,358 |             63,707 |                 63,685 |        25,199 |            24,520 |
+| index signatures / 512 |         15,721 |             15,884 |             15,804 |                 15,930 |         5,252 |             5,297 |
+| 200-row array payload  |         11,052 |             11,029 |             13,031 |                 12,984 |         5,301 |             5,178 |
+| 200 single-row frames  |      1,341,720 |          1,282,335 |          1,536,088 |              1,310,227 |       128,268 |           124,832 |
 
 ## Analysis
 

--- a/packages/effect/src/unstable/encoding/SchemaBinary.ts
+++ b/packages/effect/src/unstable/encoding/SchemaBinary.ts
@@ -1756,6 +1756,8 @@ interface EncodeContext {
   readonly options: SchemaAST.ParseOptions
   readonly positional: boolean
   indexSignatures: IndexSignatureCache | undefined
+  // Records of one shape repeat within a frame, so the last one is reused.
+  extraShape: ExtraShape | undefined
 }
 
 function encodeFail(expected: string, input: unknown, options: SchemaAST.ParseOptions): never {
@@ -1890,13 +1892,30 @@ function isAscii(key: string): boolean {
   return true
 }
 
+interface ExtraShape {
+  readonly layout: StructLayout
+  readonly keys: ReadonlyArray<string>
+  readonly pairs: Array<ExtraPair>
+}
+
+function sameShape(shape: ExtraShape, layout: StructLayout, keys: ReadonlyArray<string>): boolean {
+  if (shape.layout !== layout || shape.keys.length !== keys.length) return false
+  for (let i = 0; i < keys.length; i++) {
+    if (shape.keys[i] !== keys[i]) return false
+  }
+  return true
+}
+
 // Sort extra keys by raw UTF-8 for deterministic output.
 function extraPairs(ctx: EncodeContext, layout: StructLayout, obj: Record<string, unknown>): Array<ExtraPair> {
+  const keys = Object.keys(obj)
+  const shape = ctx.extraShape
+  if (shape !== undefined && sameShape(shape, layout, keys)) return shape.pairs
   const named = layout.names
   const every = layout.extraAll
   const pairs: Array<ExtraPair> = []
   let ascii = true
-  for (const key of Object.keys(obj)) {
+  for (const key of keys) {
     if (named.has(key)) continue
     const signature = every ?? (ctx.indexSignatures ??= new IndexSignatureCache(ctx.options)).find(layout, key)
     if (signature === undefined) continue
@@ -1905,10 +1924,11 @@ function extraPairs(ctx: EncodeContext, layout: StructLayout, obj: Record<string
   }
   if (ascii) {
     pairs.sort((a, b) => a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0)
-    return pairs
+  } else {
+    for (const pair of pairs) pair[2] = utf8Encode.encode(pair[0])
+    pairs.sort((a, b) => compareBytes(a[2]!, b[2]!))
   }
-  for (const pair of pairs) pair[2] = utf8Encode.encode(pair[0])
-  pairs.sort((a, b) => compareBytes(a[2]!, b[2]!))
+  ctx.extraShape = { layout, keys, pairs }
   return pairs
 }
 
@@ -2261,7 +2281,8 @@ function encodeFrame(
   const ctx: EncodeContext = {
     options,
     positional: mode.positional,
-    indexSignatures: undefined
+    indexSignatures: undefined,
+    extraShape: undefined
   }
   const w = pooledWriter ?? new Writer()
   const pooled = w === pooledWriter

--- a/packages/effect/src/unstable/encoding/SchemaBinary.ts
+++ b/packages/effect/src/unstable/encoding/SchemaBinary.ts
@@ -2858,12 +2858,13 @@ function compileTarget(
 // every other input, `Schema.is` included, still runs the real check.
 function withTrustedDecode(target: Schema.Constraint, trusted: WeakSet<object>): Schema.Constraint {
   const type = Schema.make(SchemaAST.toType(target.ast))
+  const decodeType = SchemaParser.decodeUnknownEffect(type as Schema.ConstraintDecoder<unknown>)
   return Schema.declareConstructor<unknown>()(
     [type],
-    ([type]) => (input, _ast, options) =>
+    () => (input, _ast, options) =>
       Predicate.isObjectOrArray(input) && trusted.delete(input)
         ? Effect.succeed(input)
-        : SchemaParser.decodeUnknownEffect(type)(input, options),
+        : decodeType(input, options),
     { identifier: "binary value" }
   )
 }

--- a/packages/effect/src/unstable/encoding/SchemaBinary.ts
+++ b/packages/effect/src/unstable/encoding/SchemaBinary.ts
@@ -694,6 +694,7 @@ type LeafKind =
 
 type Layout =
   | { readonly _: LeafKind }
+  | LiteralLayout
   | { readonly _: "int64"; readonly flavor: "date" | "utc" }
   | { readonly _: "never"; readonly ast: SchemaAST.AST }
   | StructLayout
@@ -703,6 +704,22 @@ type Layout =
   | { readonly _: "result"; success: Layout; failure: Layout }
   | { readonly _: "exit"; value: Layout; cause: ReasonLayout }
   | ReasonLayout
+
+// Literal values are validated here rather than by a downstream schema pass.
+interface LiteralLayout {
+  readonly _: "literal"
+  readonly leaf: Layout
+  readonly values: ReadonlyArray<SchemaAST.LiteralValue>
+}
+
+function hasLiteral(layout: LiteralLayout, value: unknown): boolean {
+  const values = layout.values
+  return values.length === 1 ? value === values[0] : values.includes(value as SchemaAST.LiteralValue)
+}
+
+function literalExpected(layout: LiteralLayout): string {
+  return layout.values.map((value) => typeof value === "string" ? JSON.stringify(value) : String(value)).join(" | ")
+}
 
 interface ReasonLayout {
   readonly _: "cause" | "causeReason"
@@ -786,11 +803,13 @@ interface UnionLayout {
 }
 
 function isSelfDelimiting(layout: Layout): boolean {
-  return layout._ === "int"
+  return layout._ === "literal" ? isSelfDelimiting(layout.leaf) : layout._ === "int"
 }
 
 function packedSize(layout: Layout): number | undefined {
   switch (layout._) {
+    case "literal":
+      return packedSize(layout.leaf)
     case "bool":
       return 1
     case "int64":
@@ -1045,11 +1064,11 @@ function astKind(ast: SchemaAST.AST): number {
 interface CompiledLayout {
   readonly layout: Layout
   readonly recursive: boolean
-  readonly decodeExact: boolean
+  readonly exact: boolean
 }
 
 function compileLayout(root: SchemaAST.AST): CompiledLayout {
-  const decodeExact = isDecodeExact(root)
+  const exact = isExact(root)
   root = SchemaAST.toEncoded(root)
   const memo = new Map<SchemaAST.AST, Layout>()
   let recursive = false
@@ -1082,7 +1101,7 @@ function compileLayout(root: SchemaAST.AST): CompiledLayout {
       case "BigInt":
         return { _: "bigint" }
       case "Literal":
-        return { _: literalKind(ast.literal) }
+        return { _: "literal", leaf: { _: literalKind(ast.literal) }, values: [ast.literal] }
       case "Unknown":
       case "Any":
       case "ObjectKeyword":
@@ -1282,6 +1301,7 @@ function compileLayout(root: SchemaAST.AST): CompiledLayout {
     const variantMembers: Array<{ member: SchemaAST.AST; sentinels: ReadonlyArray<SchemaAST.Sentinel> }> = []
     const rowMembers: Array<{ member: SchemaAST.AST; kind: number }> = []
     const literalRows = new Map<number, Layout>()
+    const literalValues = new Map<number, Array<SchemaAST.LiteralValue>>()
     const addLiteralRow = (kind: number, row: Layout) => {
       const existing = literalRows.get(kind)
       if (existing !== undefined && existing._ !== row._) {
@@ -1291,7 +1311,13 @@ function compileLayout(root: SchemaAST.AST): CompiledLayout {
     }
     for (const member of members) {
       if (member._tag === "Literal") {
-        addLiteralRow(astKind(member), { _: literalKind(member.literal) })
+        const kind = astKind(member)
+        const values = literalValues.get(kind)
+        if (values === undefined) {
+          literalValues.set(kind, [member.literal])
+        } else if (!values.includes(member.literal)) {
+          values.push(member.literal)
+        }
         continue
       }
       if (member._tag === "UniqueSymbol") {
@@ -1312,6 +1338,9 @@ function compileLayout(root: SchemaAST.AST): CompiledLayout {
         }
       }
       rowMembers.push({ member, kind: astKind(member) })
+    }
+    for (const [kind, values] of literalValues) {
+      addLiteralRow(kind, { _: "literal", leaf: { _: literalKind(values[0]) }, values })
     }
     if (variantMembers.length === 0 && rowMembers.length === 0 && literalRows.size === 1) {
       return literalRows.values().next().value!
@@ -1397,17 +1426,20 @@ function compileLayout(root: SchemaAST.AST): CompiledLayout {
   }
 
   const layout = compile(root)
-  return { layout, recursive, decodeExact }
+  return { layout, recursive, exact }
 }
 
 // The parser may return the binary decoder's value directly only when that
 // decoder proves every predicate and no Schema parser behavior can change it.
-function isDecodeExact(root: SchemaAST.AST): boolean {
+// Schemas whose decoded values the binary layer already produces and validates
+// on its own, so the schema pass around it would only repeat work. Constructor
+// defaults are ignored because they only run during construction.
+function isExact(root: SchemaAST.AST): boolean {
   const exact = (ast: SchemaAST.AST): boolean => {
     if (
       ast.encoding !== undefined || ast.checks !== undefined ||
       (ast as { readonly encodingChecks?: SchemaAST.Checks }).encodingChecks !== undefined ||
-      ast.annotations?.parseOptions !== undefined || ast.context?.constructorDefault !== undefined
+      ast.annotations?.parseOptions !== undefined
     ) {
       return false
     }
@@ -1420,6 +1452,7 @@ function isDecodeExact(root: SchemaAST.AST): boolean {
       case "Void":
       case "Number":
       case "BigInt":
+      case "Literal":
         return true
       case "Arrays":
         return ast.elements.every(exact) && ast.rest.every(exact)
@@ -1428,6 +1461,10 @@ function isDecodeExact(root: SchemaAST.AST): boolean {
           ast.indexSignatures.every((signature) =>
             signature.parameter._tag === "String" && exact(signature.parameter) && exact(signature.type)
           )
+      case "Union":
+        return ast.mode === "anyOf" && ast.types.every(exact)
+      case "Declaration":
+        return representationId(ast) === "effect/schema/Uint8Array"
       default:
         return false
     }
@@ -1461,7 +1498,8 @@ const F = {
   result: 21,
   exit: 22,
   cause: 23,
-  causeReason: 24
+  causeReason: 24,
+  literal: 25
 } as const
 
 // Hash the compiled layout graph, including cycle back-edge distances.
@@ -1511,6 +1549,18 @@ function layoutFingerprint(root: Layout): bigint {
       case "dateTimeZoned":
         out.push(F[layout._])
         return out
+      case "literal": {
+        out.push(F.literal)
+        pushBytes(out, structure(layout.leaf))
+        pushUvarint(out, layout.values.length)
+        for (const value of layout.values) {
+          out.push(sentinelLiteralKind(value))
+          const bytes = utf8Encode.encode(sentinelLiteralString(value))
+          pushUvarint(out, bytes.length)
+          pushBytes(out, bytes)
+        }
+        return out
+      }
       case "int64":
         out.push(layout.flavor === "date" ? F.date : F.dateTimeUtc)
         return out
@@ -1621,6 +1671,8 @@ function matchRank(layout: Layout): number {
 
 function matchesLayout(layout: Layout, value: unknown): boolean {
   switch (layout._) {
+    case "literal":
+      return hasLiteral(layout, value)
     case "bool":
       return typeof value === "boolean"
     case "null":
@@ -1992,6 +2044,10 @@ function encodeUnion(ctx: EncodeContext, layout: UnionLayout, value: unknown, w:
 
 function encodeValue(ctx: EncodeContext, layout: Layout, value: unknown, w: Writer): void {
   switch (layout._) {
+    case "literal":
+      if (!hasLiteral(layout, value)) encodeFail(literalExpected(layout), value, ctx.options)
+      encodeValue(ctx, layout.leaf, value, w)
+      return
     case "bool":
       w.byte(value === true ? 1 : 0)
       return
@@ -2503,6 +2559,11 @@ function requirePresent(value: unknown): unknown {
 
 function decodeValue(layout: Layout, r: Reader): unknown {
   switch (layout._) {
+    case "literal": {
+      const value = decodeValue(layout.leaf, r)
+      if (!hasLiteral(layout, value)) invalid(literalExpected(layout), value, r.options)
+      return value
+    }
     case "bool": {
       if (r.remaining !== 1) invalid("bool", undefined, r.options)
       const b = r.byte()
@@ -2711,7 +2772,7 @@ function compileMode(layout: Layout, fingerprint: boolean | undefined): Mode {
 interface CompiledTarget {
   readonly target: Schema.Constraint
   readonly layout: Layout
-  readonly decodeExact: boolean
+  readonly exact: boolean
 }
 
 const compileTargetCache = new WeakMap<SchemaAST.AST, CompiledTarget>()
@@ -2722,9 +2783,9 @@ function compileTarget(
   const cached = compileTargetCache.get(schema.ast)
   if (cached !== undefined) return cached
   const raw = Schema.make<Schema.Constraint>(toBinaryAST(schema.ast))
-  const { decodeExact, layout, recursive } = compileLayout(raw.ast)
+  const { exact, layout, recursive } = compileLayout(raw.ast)
   // Only recursive schemas need the cycle walk.
-  const compiled = { target: recursive ? withCycleGuard(raw) : raw, layout, decodeExact }
+  const compiled = { target: recursive ? withCycleGuard(raw) : raw, layout, exact }
   compileTargetCache.set(schema.ast, compiled)
   return compiled
 }
@@ -2822,6 +2883,37 @@ export function toCodec<S extends Schema.Constraint>(schema: S, options?: Option
 }
 
 /**
+ * Encodes one frame without the schema pass {@link toCodec} wraps around it.
+ *
+ * Only schemas the binary layer already validates on its own take the direct
+ * path; anything else falls back to the codec, so checks and transformations
+ * still run.
+ *
+ * @internal
+ */
+export function encodeUnknownSync<S extends Schema.Constraint>(
+  schema: S,
+  options?: SchemaAST.ParseOptions & Options
+): (value: unknown) => Uint8Array<ArrayBuffer> {
+  const { exact, layout } = compileTarget(schema)
+  if (!exact) {
+    return Schema.encodeUnknownSync(
+      toCodec(schema, options) as unknown as Schema.ConstraintEncoder<unknown, never>,
+      options
+    ) as (value: unknown) => Uint8Array<ArrayBuffer>
+  }
+  const mode = compileMode(layout, options?.fingerprint)
+  const parseOptions: SchemaAST.ParseOptions = options ?? EMPTY_PARSE_OPTIONS
+  return (value) => {
+    try {
+      return encodeFrame(layout, value, parseOptions, mode)
+    } catch (e) {
+      throw e instanceof IssueError ? new Schema.SchemaError(e.issue) : e
+    }
+  }
+}
+
+/**
  * A stateful frame parser for concatenated {@link toCodec} outputs.
  *
  * @category models
@@ -2859,11 +2951,11 @@ export function parser<S extends Schema.Constraint>(
   schema: S,
   options?: SchemaAST.ParseOptions & Options & { readonly maxFrameSize?: number | undefined }
 ): Parser<S["Type"]> {
-  const { decodeExact, layout, target } = compileTarget(schema)
+  const { exact, layout, target } = compileTarget(schema)
   const mode = compileMode(layout, options?.fingerprint)
   const parseOptions: SchemaAST.ParseOptions = options ?? {}
   const maxFrameSize = options?.maxFrameSize
-  const decodeEncoded = decodeExact
+  const decodeEncoded = exact
     ? undefined
     : Schema.decodeUnknownSync(target as Schema.ConstraintDecoder<unknown>, parseOptions)
   let buffer = new Uint8Array(0)

--- a/packages/effect/src/unstable/encoding/SchemaBinary.ts
+++ b/packages/effect/src/unstable/encoding/SchemaBinary.ts
@@ -480,29 +480,16 @@ const EMPTY_READER_BUFFER = new Uint8Array(EMPTY_READER_ARRAY_BUFFER)
 const EMPTY_READER_VIEW = new DataView(EMPTY_READER_ARRAY_BUFFER)
 const EMPTY_PARSE_OPTIONS: SchemaAST.ParseOptions = {}
 
-let lastReaderBuffer: ArrayBufferLike = EMPTY_READER_ARRAY_BUFFER
-let lastReaderOffset = 0
-let lastReaderLength = 0
-let lastReaderView: DataView = EMPTY_READER_VIEW
-
-function readerView(buf: Uint8Array): DataView {
-  if (
-    buf.buffer !== lastReaderBuffer ||
-    buf.byteOffset !== lastReaderOffset ||
-    buf.byteLength !== lastReaderLength
-  ) {
-    lastReaderBuffer = buf.buffer
-    lastReaderOffset = buf.byteOffset
-    lastReaderLength = buf.byteLength
-    lastReaderView = new DataView(buf.buffer, buf.byteOffset, buf.byteLength)
-  }
-  return lastReaderView
-}
-
 class Reader {
   pos = 0
   buf: Uint8Array = EMPTY_READER_BUFFER
-  view: DataView = EMPTY_READER_VIEW
+  // Frames of varints and strings never need a view, so it is built on demand
+  // and reused while the reader stays on one buffer.
+  view: DataView | undefined
+  viewCache: DataView = EMPTY_READER_VIEW
+  viewBuffer: ArrayBufferLike = EMPTY_READER_ARRAY_BUFFER
+  viewOffset = 0
+  viewLength = 0
   end = 0
   options: SchemaAST.ParseOptions = EMPTY_PARSE_OPTIONS
   indexSignatures: IndexSignatureCache | undefined
@@ -515,7 +502,7 @@ class Reader {
     indexSignatures: IndexSignatureCache | undefined,
     positional: boolean
   ) {
-    this.view = readerView(buf)
+    this.view = undefined
     this.buf = buf
     this.pos = start
     this.end = end
@@ -526,13 +513,28 @@ class Reader {
   release() {
     this.pos = this.end = 0
     this.buf = EMPTY_READER_BUFFER
-    this.view = EMPTY_READER_VIEW
+    this.view = undefined
+    this.viewCache = EMPTY_READER_VIEW
+    this.viewBuffer = EMPTY_READER_ARRAY_BUFFER
+    this.viewOffset = this.viewLength = 0
     this.options = EMPTY_PARSE_OPTIONS
     this.indexSignatures = undefined
     this.positional = false
   }
   get remaining(): number {
     return this.end - this.pos
+  }
+  dataView(): DataView {
+    const buf = this.buf
+    if (
+      buf.buffer !== this.viewBuffer || buf.byteOffset !== this.viewOffset || buf.byteLength !== this.viewLength
+    ) {
+      this.viewBuffer = buf.buffer
+      this.viewOffset = buf.byteOffset
+      this.viewLength = buf.byteLength
+      this.viewCache = new DataView(buf.buffer, buf.byteOffset, buf.byteLength)
+    }
+    return this.view = this.viewCache
   }
   byte(): number {
     if (this.pos >= this.end) invalid("complete value", undefined, this.options)
@@ -659,25 +661,25 @@ class Reader {
   }
   f64(): number {
     if (this.pos + 8 > this.end) invalid("complete value", undefined, this.options)
-    const value = this.view.getFloat64(this.pos, true)
+    const value = (this.view ?? this.dataView()).getFloat64(this.pos, true)
     this.pos += 8
     return value
   }
   i64(): bigint {
     if (this.pos + 8 > this.end) invalid("complete value", undefined, this.options)
-    const value = this.view.getBigInt64(this.pos, true)
+    const value = (this.view ?? this.dataView()).getBigInt64(this.pos, true)
     this.pos += 8
     return value
   }
   u32le(): number {
     if (this.pos + 4 > this.end) invalid("complete value", undefined, this.options)
-    const value = this.view.getUint32(this.pos, true)
+    const value = (this.view ?? this.dataView()).getUint32(this.pos, true)
     this.pos += 4
     return value
   }
   i32le(): number {
     if (this.pos + 4 > this.end) invalid("complete value", undefined, this.options)
-    const value = this.view.getInt32(this.pos, true)
+    const value = (this.view ?? this.dataView()).getInt32(this.pos, true)
     this.pos += 4
     return value
   }
@@ -1641,12 +1643,24 @@ function layoutFingerprint(root: Layout): bigint {
   return go(root)
 }
 
+// A frame header the decoder can compare byte by byte, so frames that hold no
+// wide numbers never build a DataView.
+function fingerprintBytes(lo: number, hi: number): Uint8Array {
+  const out = new Uint8Array(8)
+  for (let i = 0; i < 4; i++) {
+    out[i] = (lo >>> (i * 8)) & 0xFF
+    out[i + 4] = (hi >>> (i * 8)) & 0xFF
+  }
+  return out
+}
+
 interface Mode {
   readonly positional: boolean
   readonly envelope: number
   readonly expectedEnvelope: string
   readonly fingerprintLo: number
   readonly fingerprintHi: number
+  readonly fingerprint: Uint8Array
 }
 
 const defaultMode: Mode = {
@@ -1654,17 +1668,21 @@ const defaultMode: Mode = {
   envelope: ENVELOPE,
   expectedEnvelope: "version 1 envelope, flags 0",
   fingerprintLo: 0,
-  fingerprintHi: 0
+  fingerprintHi: 0,
+  fingerprint: new Uint8Array(8)
 }
 
 function fingerprintMode(layout: Layout): Mode {
   const fingerprint = layoutFingerprint(layout)
+  const lo = Number(fingerprint & BIGINT_U32_MASK)
+  const hi = Number((fingerprint >> BIGINT_THIRTY_TWO) & BIGINT_U32_MASK)
   return {
     positional: true,
     envelope: ENVELOPE_FINGERPRINT,
     expectedEnvelope: "version 1 envelope, flags 1",
-    fingerprintLo: Number(fingerprint & BIGINT_U32_MASK),
-    fingerprintHi: Number((fingerprint >> BIGINT_THIRTY_TWO) & BIGINT_U32_MASK)
+    fingerprintLo: lo,
+    fingerprintHi: hi,
+    fingerprint: fingerprintBytes(lo, hi)
   }
 }
 
@@ -2729,9 +2747,13 @@ function decodeFrameBody(layout: Layout, r: Reader, mode: Mode): unknown {
   if (envelope !== mode.envelope) invalid(mode.expectedEnvelope, envelope, r.options)
   if (mode.positional) {
     if (r.remaining < 8) invalid("complete value", undefined, r.options)
-    if (r.u32le() !== mode.fingerprintLo || r.u32le() !== mode.fingerprintHi) {
-      invalid("matching layout fingerprint", undefined, r.options)
+    const buf = r.buf
+    const expected = mode.fingerprint
+    const pos = r.pos
+    for (let i = 0; i < 8; i++) {
+      if (buf[pos + i] !== expected[i]) invalid("matching layout fingerprint", undefined, r.options)
     }
+    r.pos = pos + 8
   }
   const value = decodeChecked(layout, r)
   if (value === ABSENT) throw issueError(new SchemaIssue.MissingKey(undefined))

--- a/packages/effect/src/unstable/encoding/SchemaBinary.ts
+++ b/packages/effect/src/unstable/encoding/SchemaBinary.ts
@@ -403,6 +403,12 @@ class Writer {
 
 // Index-signature predicates are not part of the fingerprint, so unmatched
 // keys are dropped in both modes.
+// A plain string parameter accepts every key without running the matcher.
+function matchesEveryKey(parameter: SchemaAST.AST): boolean {
+  const ast = SchemaAST.toEncoded(parameter)
+  return ast._tag === "String" && ast.checks === undefined
+}
+
 function matchIndexSignature(
   layout: StructLayout,
   key: string,
@@ -749,6 +755,8 @@ interface StructLayout {
   readonly fields: Array<Field>
   readonly byId: Map<number, Field>
   readonly extra: Array<ExtraSignature>
+  // The lone signature every key matches, so lookups skip the cache.
+  readonly extraAll: ExtraSignature | undefined
   readonly names: Set<string>
   optionalCount: number
 }
@@ -1175,6 +1183,7 @@ function compileLayout(root: SchemaAST.AST): CompiledLayout {
       fields,
       byId: new Map(),
       extra,
+      extraAll: extra.length === 1 && matchesEveryKey(extra[0].parameter) ? extra[0] : undefined,
       names: new Set(fields.map((f) => f.name)),
       optionalCount: 0
     }
@@ -1390,6 +1399,7 @@ function compileLayout(root: SchemaAST.AST): CompiledLayout {
           fields,
           byId: new Map(fields.map((f) => [f.id, f])),
           extra: struct.extra,
+          extraAll: struct.extraAll,
           names: struct.names,
           optionalCount: fields.reduce((count, f) => f.optional ? count + 1 : count, 0)
         }
@@ -1849,19 +1859,36 @@ function encodeReason(ctx: EncodeContext, layout: ReasonLayout, value: unknown, 
   }
 }
 
-type ExtraPair = [keyBytes: Uint8Array, key: string, signature: ExtraSignature]
+// `keyBytes` stays undefined while every key is ASCII, where code unit order
+// and length already match raw UTF-8.
+type ExtraPair = [key: string, signature: ExtraSignature, keyBytes: Uint8Array | undefined]
+
+function isAscii(key: string): boolean {
+  for (let i = 0; i < key.length; i++) {
+    if (key.charCodeAt(i) > 0x7F) return false
+  }
+  return true
+}
 
 // Sort extra keys by raw UTF-8 for deterministic output.
 function extraPairs(ctx: EncodeContext, layout: StructLayout, obj: Record<string, unknown>): Array<ExtraPair> {
   const named = layout.names
+  const every = layout.extraAll
   const pairs: Array<ExtraPair> = []
+  let ascii = true
   for (const key of Object.keys(obj)) {
     if (named.has(key)) continue
-    const signature = (ctx.indexSignatures ??= new IndexSignatureCache(ctx.options)).find(layout, key)
+    const signature = every ?? (ctx.indexSignatures ??= new IndexSignatureCache(ctx.options)).find(layout, key)
     if (signature === undefined) continue
-    pairs.push([utf8Encode.encode(key), key, signature])
+    if (ascii && !isAscii(key)) ascii = false
+    pairs.push([key, signature, undefined])
   }
-  pairs.sort((a, b) => compareBytes(a[0], b[0]))
+  if (ascii) {
+    pairs.sort((a, b) => a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0)
+    return pairs
+  }
+  for (const pair of pairs) pair[2] = utf8Encode.encode(pair[0])
+  pairs.sort((a, b) => compareBytes(a[2]!, b[2]!))
   return pairs
 }
 
@@ -1871,9 +1898,14 @@ function encodeExtraPairs(
   obj: Record<string, unknown>,
   w: Writer
 ) {
-  for (const [keyBytes, key, signature] of pairs) {
-    w.uvarint(keyBytes.length)
-    w.bytes(keyBytes)
+  for (const [key, signature, keyBytes] of pairs) {
+    if (keyBytes === undefined) {
+      w.uvarint(key.length)
+      w.string(key)
+    } else {
+      w.uvarint(keyBytes.length)
+      w.bytes(keyBytes)
+    }
     issuePath[issuePathLen++] = key
     encodeSized(ctx, signature.layout, obj[key], w)
     issuePathLen--
@@ -2274,7 +2306,8 @@ function decodeExtraPair(layout: StructLayout, r: Reader, out: Record<string, un
   if (seen.has(key)) invalid("unique extra keys", undefined, r.options)
   seen.add(key)
   const saved = r.enter(r.uvarint())
-  const signature = (r.indexSignatures ??= new IndexSignatureCache(r.options)).find(layout, key)
+  const signature = layout.extraAll ??
+    (r.indexSignatures ??= new IndexSignatureCache(r.options)).find(layout, key)
   if (signature !== undefined) {
     issuePath[issuePathLen++] = key
     const value = decodeChecked(signature.layout, r)

--- a/packages/effect/src/unstable/encoding/SchemaBinary.ts
+++ b/packages/effect/src/unstable/encoding/SchemaBinary.ts
@@ -1475,8 +1475,10 @@ function isExact(root: SchemaAST.AST): boolean {
           )
       case "Union":
         return ast.mode === "anyOf" && ast.types.every(exact)
-      case "Declaration":
-        return representationId(ast) === "effect/schema/Uint8Array"
+      case "Declaration": {
+        const id = representationId(ast)
+        return id === "effect/schema/Uint8Array" || id === "effect/schema/Date"
+      }
       default:
         return false
     }
@@ -2646,7 +2648,10 @@ function decodeValue(layout: Layout, r: Reader): unknown {
     case "int64": {
       if (r.remaining !== 8) invalid("int64", undefined, r.options)
       const millis = Number(r.i64())
-      return layout.flavor === "date" ? new Date(millis) : DateTime.makeUnsafe(millis)
+      if (layout.flavor !== "date") return DateTime.makeUnsafe(millis)
+      const date = new Date(millis)
+      if (Number.isNaN(date.getTime())) invalid("a valid Date", millis, r.options)
+      return date
     }
     case "dateTimeZoned": {
       const millis = Number(r.i64())
@@ -2792,12 +2797,15 @@ function decodeOneShot(
 
 function makeTransformation(
   layout: Layout,
-  mode: Mode
+  mode: Mode,
+  trusted: WeakSet<object> | undefined
 ): SchemaTransformation.Transformation<unknown, Uint8Array<ArrayBuffer>> {
   return SchemaTransformation.transformOrFail({
     decode: (bytes: Uint8Array<ArrayBuffer>, options) => {
       try {
-        return Effect.succeed(decodeOneShot(layout, bytes, options, mode))
+        const value = decodeOneShot(layout, bytes, options, mode)
+        if (trusted !== undefined && Predicate.isObjectOrArray(value)) trusted.add(value)
+        return Effect.succeed(value)
       } catch (e) {
         return e instanceof IssueError ? Effect.fail(e.issue) : Effect.die(e)
       }
@@ -2843,6 +2851,21 @@ function compileTarget(
   const compiled = { target: recursive ? withCycleGuard(raw) : raw, layout, exact }
   compileTargetCache.set(schema.ast, compiled)
   return compiled
+}
+
+// The binary layer already validates an exact schema, so the schema pass around
+// it repeats that work. Values it just decoded pass straight through, while
+// every other input, `Schema.is` included, still runs the real check.
+function withTrustedDecode(target: Schema.Constraint, trusted: WeakSet<object>): Schema.Constraint {
+  const type = Schema.make(SchemaAST.toType(target.ast))
+  return Schema.declareConstructor<unknown>()(
+    [type],
+    ([type]) => (input, _ast, options) =>
+      Predicate.isObjectOrArray(input) && trusted.delete(input)
+        ? Effect.succeed(input)
+        : SchemaParser.decodeUnknownEffect(type)(input, options),
+    { identifier: "binary value" }
+  )
 }
 
 // Skip the cycle walk once for structurally decoded values.
@@ -2931,9 +2954,14 @@ export interface toCodec<S extends Schema.Constraint> extends
  * @since 4.0.0
  */
 export function toCodec<S extends Schema.Constraint>(schema: S, options?: Options): toCodec<S> {
-  const { layout, target } = compileTarget(schema)
+  const { exact, layout, target } = compileTarget(schema)
+  const mode = compileMode(layout, options?.fingerprint)
+  const trusted = exact ? new WeakSet<object>() : undefined
   return (Schema.Uint8Array as Schema.instanceOf<Uint8Array<ArrayBuffer>>).pipe(
-    Schema.decodeTo(target, makeTransformation(layout, compileMode(layout, options?.fingerprint)))
+    Schema.decodeTo(
+      trusted === undefined ? target : withTrustedDecode(target, trusted),
+      makeTransformation(layout, mode, trusted)
+    )
   ) as unknown as toCodec<S>
 }
 
@@ -2958,6 +2986,7 @@ export function encodeUnknownSync<S extends Schema.Constraint>(
     ) as (value: unknown) => Uint8Array<ArrayBuffer>
   }
   const mode = compileMode(layout, options?.fingerprint)
+
   const parseOptions: SchemaAST.ParseOptions = options ?? EMPTY_PARSE_OPTIONS
   return (value) => {
     try {

--- a/packages/effect/src/unstable/encoding/SchemaBinary.ts
+++ b/packages/effect/src/unstable/encoding/SchemaBinary.ts
@@ -1567,9 +1567,13 @@ function layoutFingerprint(root: Layout): bigint {
         out.push(F.literal)
         pushBytes(out, structure(layout.leaf))
         pushUvarint(out, layout.values.length)
-        for (const value of layout.values) {
-          out.push(sentinelLiteralKind(value))
-          const bytes = utf8Encode.encode(sentinelLiteralString(value))
+        // Sorted, so a union hashes the same whatever order it declares.
+        const sorted = layout.values
+          .map((value) => [sentinelLiteralKind(value), sentinelLiteralString(value)] as const)
+          .sort((a, b) => a[1] < b[1] ? -1 : a[1] > b[1] ? 1 : a[0] - b[0])
+        for (const [kind, text] of sorted) {
+          out.push(kind)
+          const bytes = utf8Encode.encode(text)
           pushUvarint(out, bytes.length)
           pushBytes(out, bytes)
         }

--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -597,8 +597,7 @@ const makeSchemaBinary = (options?: {
   readonly maxFrameSize?: number | undefined
 }): RpcSerialization["Service"] => {
   const maxFrameSize = options?.maxFrameSize ?? defaultSchemaBinaryMaxFrameSize
-  const envelopeCodec = SchemaBinary.toCodec(RpcMessage.EncodedSchema, { fingerprint: true })
-  const encodeEnvelope = Schema.encodeUnknownSync(envelopeCodec)
+  const encodeEnvelope = SchemaBinary.encodeUnknownSync(RpcMessage.EncodedSchema, { fingerprint: true })
   return RpcSerialization.of({
     contentType: "application/vnd.effect.rpc+schema-binary",
     includesFraming: true,

--- a/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
+++ b/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
@@ -409,6 +409,16 @@ describe("SchemaBinary", () => {
       )
     })
 
+    it("keeps canonical key order when record shapes change within a frame", () => {
+      const rows = Schema.Array(Schema.Record(Schema.String, Schema.Number))
+      const mixed = [{ b: 2, a: 1 }, { a: 1, b: 2 }, { a: 1 }, { c: 3, a: 1 }, { a: 1, b: 2 }]
+      assert.deepStrictEqual(roundtrip(rows, mixed), mixed)
+      assert.deepStrictEqual(
+        [...encode(rows, mixed)],
+        [...encode(rows, [{ a: 1, b: 2 }, { b: 2, a: 1 }, { a: 1 }, { a: 1, c: 3 }, { b: 2, a: 1 }])]
+      )
+    })
+
     it("uses fieldId as the encoded-side field identity", () => {
       const Before = Schema.Struct({ oldName: Schema.String.pipe(SchemaBinary.fieldId(1)) })
       const After = Schema.Struct({ newName: Schema.String.pipe(SchemaBinary.fieldId(1)) })

--- a/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
+++ b/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
@@ -393,6 +393,22 @@ describe("SchemaBinary", () => {
       assert.deepStrictEqual([...encode(OrderedA, { a: 1, b: "x" })], [...encode(OrderedB, { a: 1, b: "x" })])
     })
 
+    it("orders extra keys by raw UTF-8 whatever the insertion order", () => {
+      const record = Schema.Record(Schema.String, Schema.Number)
+      // Code unit order puts the surrogate pair first, raw UTF-8 does not.
+      const wide = "\u{10000}"
+      const replacement = "\uFFFD"
+      assert.deepStrictEqual(
+        [...encode(record, { [wide]: 1, [replacement]: 2 })],
+        [...encode(record, { [replacement]: 2, [wide]: 1 })]
+      )
+      assert.deepStrictEqual(roundtrip(record, { [wide]: 1, [replacement]: 2 }), { [wide]: 1, [replacement]: 2 })
+      assert.deepStrictEqual(
+        [...encode(record, { b: 1, a: 2 })],
+        [...encode(record, { a: 2, b: 1 })]
+      )
+    })
+
     it("uses fieldId as the encoded-side field identity", () => {
       const Before = Schema.Struct({ oldName: Schema.String.pipe(SchemaBinary.fieldId(1)) })
       const After = Schema.Struct({ newName: Schema.String.pipe(SchemaBinary.fieldId(1)) })
@@ -1234,6 +1250,35 @@ describe("SchemaBinary", () => {
       )
 
       assert.strictEqual(error.message.match(/Missing key/g)?.length, 34)
+    })
+
+    it("validates literals instead of leaning on the schema pass", () => {
+      const Tagged = Schema.Struct({ kind: Schema.Literal("ok") })
+      const Loose = Schema.Struct({ kind: Schema.String })
+      assert.match(
+        schemaError(() => Schema.decodeUnknownSync(SchemaBinary.toCodec(Tagged))(encode(Loose, { kind: "nope" })))
+          .message,
+        /"ok"/
+      )
+      assert.match(schemaError(() => encode(Tagged, { kind: "nope" } as never)).message, /"ok"/)
+
+      const Level = Schema.Struct({ kind: Schema.Literals(["info", "warning"]) })
+      assert.deepStrictEqual(
+        Schema.decodeUnknownSync(SchemaBinary.toCodec(Level))(encode(Loose, { kind: "warning" })),
+        { kind: "warning" }
+      )
+      assert.match(
+        schemaError(() => Schema.decodeUnknownSync(SchemaBinary.toCodec(Level))(encode(Loose, { kind: "debug" })))
+          .message,
+        /"info" \| "warning"/
+      )
+    })
+
+    it("rejects a Date outside the representable range", () => {
+      const codec = SchemaBinary.toCodec(Schema.Date)
+      const bytes = Schema.encodeUnknownSync(codec)(new Date(0))
+      bytes.set(Uint8Array.of(0, 0, 0, 0, 0, 0, 0, 0x7F), bytes.length - 8)
+      assert.match(schemaError(() => Schema.decodeUnknownSync(codec)(bytes)).message, /a valid Date/)
     })
 
     it("fails Never values and unregistered symbols through SchemaError", () => {

--- a/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
+++ b/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
@@ -1561,6 +1561,18 @@ describe("SchemaBinary", () => {
       )
     })
 
+    it("does not depend on the order a literal union declares its members", () => {
+      assert.strictEqual(
+        fingerprintOf(Schema.Literals(["a", "b", "c"]), "a"),
+        fingerprintOf(Schema.Literals(["c", "a", "b"]), "a")
+      )
+      assert.notStrictEqual(
+        fingerprintOf(Schema.Literals(["a", "b"]), "a"),
+        fingerprintOf(Schema.Literals(["a", "c"]), "a")
+      )
+      assert.notStrictEqual(fingerprintOf(Schema.Literal("a"), "a"), fingerprintOf(Schema.String, "a"))
+    })
+
     it("does not depend on whether an acyclic sub-schema is shared or repeated", () => {
       const Point = Schema.Struct({ x: Schema.Number, y: Schema.Number })
       const pair = { a: { x: 1, y: 2 }, b: { x: 3, y: 4 } }


### PR DESCRIPTION
Closes EFF-819

`RpcSerialization.layerSchemaBinary` lost to `msgPack` on small requests and on chunks of records. It now wins every case in `benchmark/rpc/RpcSerialization.ts`.

Median of 3 runs, throughput relative to Msgpack:

| Case | Direction | Before | After |
| --- | --- | ---: | ---: |
| request / nested search payload | encode | 0.69x | 1.13x |
| request / nested search payload | decode | 0.57x | 1.10x |
| exit / 12-user success | encode | 1.36x | 1.45x |
| exit / 12-user success | decode | 1.07x | 1.12x |
| chunk / 32 events | encode | 0.89x | 1.83x |
| chunk / 32 events | decode | 0.94x | 1.60x |

The wire format is unchanged. Payload sizes in `benchmark/schema/SchemaBinary.md` are byte for byte what they were; only layout fingerprints move, and both peers derive those from the schema.

## Stop running the schema pass twice

Most of the cost was `SchemaBinary` decoding a frame, validating it structurally along the way, and then handing the result to the surrounding `Schema` codec to validate all over again. The parser already skipped that for schemas it proved exact, but the proof rejected almost everything real, and `toCodec` never skipped at all.

- `isExact` now also proves `Literal`, `Union`, and native `Uint8Array` declarations, and no longer rejects a `constructorDefault` — that link only runs during construction, never during decode. `RpcMessage.EncodedSchema` qualifies, so RPC envelopes stop being re-walked.
- Literals earn that by being validated where they are decoded. A new `literal` layout carries its allowed values; before this, a frame claiming `_tag: "Requestx"` decoded fine at the binary layer and was caught only by the schema pass behind it. Union literal rows collapse per wire kind and keep the whole value set. `layoutFingerprint` hashes those values, which also fixes `Literal("a")` and `Literal("b")` having had identical fingerprints.
- `toCodec` wraps an exact target in a declaration that trusts the values the binary decoder just produced, so the schema pass skips them. Every other input, `Schema.is(codec)` included, still runs the real check. Nested payload one-shot decode: 1.48us to 0.92us.
- `Schema.Date` joins the exact set now that the int64 decode rejects an out-of-range instant instead of returning an Invalid Date for Schema to catch.
- Internal `SchemaBinary.encodeUnknownSync` encodes a frame directly for exact schemas and falls back to the codec otherwise. `makeSchemaBinary` uses it for envelopes.

Exact values now decode with keys in field-id order rather than declaration order, which is what `parser` has always returned for them.

## Index signatures

`Record(String, String)` cost more than the data it carried.

- A struct whose lone index signature is a plain string parameter records it as `extraAll` at compile time, so encode and decode stop asking the matcher, key by key, which signature applies.
- Encode writes ASCII keys straight into the writer instead of allocating a `Uint8Array` per key through `TextEncoder`. Non-ASCII keys still sort by raw UTF-8 bytes.
- Records repeat their shape, so one `(layout, keys) -> sorted pairs` slot on the encode context is enough to reuse the signature lookups and the sort across every record in a frame.

One-shot index-signature throughput, 128 keys: encode 14,315 to 46,620, decode 20,362 to 62,425. It now beats JSON and Msgpack in every one-shot case, so the analysis bullet in the report that said otherwise is gone.

## Reader views

`readerView` kept one global `DataView` slot, and the RPC path alternates between the parser's buffer and each hole's bytes, so it missed every time. The view is now lazy and memoized per `Reader`, and the layout fingerprint is compared byte by byte, so a frame of varints and strings never builds one at all.

## Tests

New coverage for literal enforcement on both directions, the `Date` range rejection, raw UTF-8 key ordering where code unit order disagrees, and record shapes changing within one frame. `benchmark/schema/SchemaBinary.md` is regenerated from a full run on one machine.
