### PR TITLE
Encode repeated SchemaBinary struct rows as a run

### DIFF
--- a/packages/effect/benchmark/schema/SchemaBinary.md
+++ b/packages/effect/benchmark/schema/SchemaBinary.md
@@ -6,9 +6,9 @@ Run from the repository root:
 nix develop -c pnpm --dir packages/effect exec node benchmark/schema/SchemaBinary.ts
 ```
 
-These results are from one full run at commit `d854fd7c9` on Linux x86_64 (AMD EPYC 4344P) with Node 26.7.0. Codec and schema construction are excluded. One-shot tasks use 100 warmups and 1,000 measured samples; streaming tasks use 25 warmups and 250 measured samples. Throughput is machine-local and should only be compared within this run.
+These results are from one full run with the RPC performance and row-run changes on Linux x86_64 (AMD EPYC 4344P) with Node 26.7.0. Codec and schema construction are excluded. One-shot tasks use 100 warmups and 1,000 measured samples; streaming tasks use 25 warmups and 250 measured samples. Throughput is machine-local and should only be compared within this run.
 
-Fingerprint mode omits field identifiers when the schema fingerprint matches. JSON, Msgpack, and NDJSON use the same `Schema.toCodecJson` representation.
+The default mode writes an array of structs as a row run: each distinct set of present fields declares its field ids once, and later rows reference that shape and any string already written in the same slot. Fingerprint mode instead omits field identifiers entirely when the schema fingerprint matches. JSON, Msgpack, and NDJSON use the same `Schema.toCodecJson` representation.
 
 The streaming setup compares the closest public decode paths. SchemaBinary reuses one synchronous parser for each feed shape. Msgpack synchronously calls `unpackMultiple` on the batch, then validates each value. NDJSON runs `Ndjson.decodeSchema` through Effect Stream and Channel for every operation, including UTF-8 decoding, line splitting, `JSON.parse`, schema validation, and runtime scheduling. A batch is one Channel run over 32 lines, or 200 lines for the per-frame case. Single and fragmented measurements each run a complete Channel for one line, so their scheduling cost is not amortized. This makes batch the closest throughput comparison while preserving the cost of each public API.
 
@@ -20,26 +20,26 @@ The `200-row array payload` case uses `Schema.Array(LargeRow)`, so one value is 
 
 Cells contain raw / gzip -6 / zstd bytes.
 
-| Case                   |        SchemaBinary |         Fingerprint |                JSON |             Msgpack |
-| ---------------------- | ------------------: | ------------------: | ------------------: | ------------------: |
-| small record           |        58 / 78 / 67 |        35 / 53 / 44 |       89 / 100 / 92 |        69 / 88 / 78 |
-| nested payload         |     318 / 305 / 300 |     206 / 209 / 203 |     453 / 303 / 309 |     385 / 304 / 299 |
-| collections            |    1452 / 792 / 776 |    1438 / 776 / 758 |    1828 / 671 / 660 |    1462 / 788 / 805 |
-| index signatures / 128 |    2251 / 689 / 656 |    2258 / 697 / 665 |    2235 / 573 / 559 |    2203 / 676 / 629 |
-| index signatures / 512 |  9355 / 2373 / 2189 |  9362 / 2383 / 2197 |  9531 / 2266 / 2074 |  9287 / 2544 / 2304 |
-| 200-row array payload  | 27646 / 3065 / 3175 | 19454 / 2766 / 2701 | 57529 / 3230 / 3008 | 51283 / 3516 / 3320 |
+| Case                   |       SchemaBinary |         Fingerprint |                JSON |             Msgpack |
+| ---------------------- | -----------------: | ------------------: | ------------------: | ------------------: |
+| small record           |       58 / 78 / 67 |        35 / 53 / 44 |       89 / 100 / 92 |        69 / 88 / 78 |
+| nested payload         |    291 / 301 / 294 |     206 / 209 / 203 |     453 / 303 / 309 |     385 / 304 / 299 |
+| collections            |   1452 / 792 / 776 |    1438 / 776 / 758 |    1828 / 671 / 660 |    1462 / 788 / 805 |
+| index signatures / 128 |   2251 / 689 / 656 |    2258 / 697 / 665 |    2235 / 573 / 559 |    2203 / 676 / 629 |
+| index signatures / 512 | 9355 / 2373 / 2189 |  9362 / 2383 / 2197 |  9531 / 2266 / 2074 |  9287 / 2544 / 2304 |
+| 200-row array payload  | 7771 / 2441 / 2224 | 19454 / 2766 / 2701 | 57529 / 3230 / 3008 | 51283 / 3516 / 3320 |
 
 Streaming cells contain total raw / gzip -6 / zstd bytes for the complete stream.
 
-| Case                   | Frames |          SchemaBinary |           Fingerprint |               Msgpack |                 NDJSON |
-| ---------------------- | -----: | --------------------: | --------------------: | --------------------: | ---------------------: |
-| small record           |     32 |        1856 / 95 / 75 |        1120 / 65 / 51 |       2240 / 111 / 87 |        2880 / 123 / 98 |
-| nested payload         |     32 |     10176 / 391 / 305 |      6592 / 259 / 208 |     10880 / 369 / 306 |      14528 / 399 / 315 |
-| collections            |     32 |    46464 / 1122 / 793 |    46016 / 1102 / 776 |    47424 / 1130 / 813 |     58528 / 1079 / 676 |
-| index signatures / 128 |     32 |    72032 / 1229 / 669 |    72256 / 1270 / 678 |    71008 / 1252 / 649 |     71552 / 1073 / 540 |
-| index signatures / 512 |     32 |  299360 / 5528 / 2227 |  299584 / 5528 / 2235 |  297696 / 5775 / 2037 |   305024 / 5831 / 1829 |
-| 200-row array payload  |     32 | 884672 / 14110 / 3259 | 622528 / 12524 / 2765 | 623488 / 12335 / 2736 | 1840960 / 87481 / 3226 |
-| 200 single-row frames  |    200 |   27840 / 3109 / 3174 |   21240 / 2876 / 2733 |   51520 / 2956 / 2888 |    57528 / 3230 / 3019 |
+| Case                   | Frames |         SchemaBinary |           Fingerprint |               Msgpack |                 NDJSON |
+| ---------------------- | -----: | -------------------: | --------------------: | --------------------: | ---------------------: |
+| small record           |     32 |       1856 / 95 / 75 |        1120 / 65 / 51 |       2240 / 111 / 87 |        2880 / 123 / 98 |
+| nested payload         |     32 |     9312 / 381 / 299 |      6592 / 259 / 208 |     10880 / 369 / 306 |      14528 / 399 / 315 |
+| collections            |     32 |   46464 / 1122 / 793 |    46016 / 1102 / 776 |    47424 / 1130 / 813 |     58528 / 1079 / 676 |
+| index signatures / 128 |     32 |   72032 / 1229 / 669 |    72256 / 1270 / 678 |    71008 / 1252 / 649 |     71552 / 1073 / 540 |
+| index signatures / 512 |     32 | 299360 / 5528 / 2227 |  299584 / 5528 / 2235 |  297696 / 5775 / 2037 |   305024 / 5831 / 1829 |
+| 200-row array payload  |     32 | 248672 / 4597 / 2261 | 622528 / 12524 / 2765 | 623488 / 12335 / 2736 | 1840960 / 87481 / 3226 |
+| 200 single-row frames  |    200 |  27840 / 3109 / 3174 |   21240 / 2876 / 2733 |   51520 / 2956 / 2888 |    57528 / 3230 / 3019 |
 
 ## One-shot throughput
 
@@ -47,23 +47,23 @@ Average encode operations per second:
 
 | Case                   |   Default | Fingerprint |    JSON | Msgpack |
 | ---------------------- | --------: | ----------: | ------: | ------: |
-| small record           | 1,083,812 |   1,104,689 | 431,684 | 708,480 |
-| nested payload         |   386,908 |     399,853 | 253,652 | 284,580 |
-| collections            |    52,004 |      53,623 |  21,927 |  22,351 |
-| index signatures / 128 |    46,620 |      46,380 |  36,181 |  35,102 |
-| index signatures / 512 |     8,601 |       8,378 |   6,568 |   6,263 |
-| 200-row array payload  |     7,282 |       8,471 |   7,113 |   4,184 |
+| small record           | 1,071,912 |   1,149,340 | 448,927 | 703,647 |
+| nested payload         |   355,828 |     398,804 | 256,793 | 281,323 |
+| collections            |    35,641 |      35,967 |  20,936 |  21,234 |
+| index signatures / 128 |    14,438 |      14,343 |  35,466 |  34,381 |
+| index signatures / 512 |     2,869 |       2,888 |   6,496 |   6,199 |
+| 200-row array payload  |     8,638 |       7,671 |   6,924 |   3,843 |
 
 Average decode operations per second:
 
 | Case                   |   Default | Fingerprint |    JSON | Msgpack |
 | ---------------------- | --------: | ----------: | ------: | ------: |
-| small record           | 1,135,739 |   1,189,669 | 394,682 | 697,231 |
-| nested payload         |   511,328 |     559,500 | 212,849 | 262,936 |
-| collections            |   112,183 |     112,971 |  21,062 |  22,290 |
-| index signatures / 128 |    62,425 |      61,355 |  28,622 |  29,607 |
-| index signatures / 512 |    15,913 |      15,686 |   5,396 |   4,569 |
-| 200-row array payload  |    11,074 |      12,862 |   5,732 |   4,835 |
+| small record           | 1,086,917 |   1,142,987 | 404,201 | 683,663 |
+| nested payload         |   326,896 |     373,072 | 217,268 | 264,012 |
+| collections            |    39,216 |      39,103 |  20,847 |  21,741 |
+| index signatures / 128 |    20,901 |      20,932 |  28,196 |  29,596 |
+| index signatures / 512 |     5,076 |       5,094 |   5,365 |   4,507 |
+| 200-row array payload  |     9,921 |       7,840 |   5,616 |   4,740 |
 
 ## Streaming decode throughput
 
@@ -71,28 +71,29 @@ Average decoded values per second for batched input:
 
 | Case                   |   Default | Fingerprint | Msgpack |  NDJSON |
 | ---------------------- | --------: | ----------: | ------: | ------: |
-| small record           | 4,252,786 |   5,123,480 | 914,260 | 855,356 |
-| nested payload         |   770,680 |     944,310 | 277,764 | 308,887 |
-| collections            |   120,646 |     121,229 |  21,830 |  21,217 |
-| index signatures / 128 |    64,516 |      64,617 |  28,148 |  28,768 |
-| index signatures / 512 |    15,741 |      15,598 |   4,115 |   5,040 |
-| 200-row array payload  |    10,785 |      12,613 |   6,491 |   5,053 |
-| 200 single-row frames  | 2,126,081 |   2,431,681 | 861,368 | 955,186 |
+| small record           | 4,279,077 |   5,437,581 | 929,780 | 867,195 |
+| nested payload         |   745,151 |     960,767 | 280,710 | 307,612 |
+| collections            |   115,764 |     117,323 |  21,574 |  21,050 |
+| index signatures / 128 |    55,592 |      56,410 |  27,462 |  28,691 |
+| index signatures / 512 |     8,213 |       8,325 |   4,059 |   5,053 |
+| 200-row array payload  |    20,001 |      12,624 |   6,419 |   4,835 |
+| 200 single-row frames  | 2,016,304 |   2,370,486 | 846,918 | 957,619 |
 
 Average decoded values per second for single and first-byte-fragmented input:
 
 | Case                   | Default single | Default fragmented | Fingerprint single | Fingerprint fragmented | NDJSON single | NDJSON fragmented |
 | ---------------------- | -------------: | -----------------: | -----------------: | ---------------------: | ------------: | ----------------: |
-| small record           |      2,460,050 |          2,216,227 |          2,997,308 |              2,724,743 |       136,936 |           121,880 |
-| nested payload         |        578,884 |            689,451 |            848,984 |                794,700 |       111,254 |           108,171 |
-| collections            |        119,007 |            118,729 |            119,230 |                119,443 |        19,291 |            19,358 |
-| index signatures / 128 |         64,046 |             62,358 |             63,707 |                 63,685 |        25,199 |            24,520 |
-| index signatures / 512 |         15,721 |             15,884 |             15,804 |                 15,930 |         5,252 |             5,297 |
-| 200-row array payload  |         11,052 |             11,029 |             13,031 |                 12,984 |         5,301 |             5,178 |
-| 200 single-row frames  |      1,341,720 |          1,282,335 |          1,536,088 |              1,310,227 |       128,268 |           124,832 |
+| small record           |      2,473,776 |          2,118,983 |          3,208,816 |              2,889,960 |       136,622 |           141,237 |
+| nested payload         |        665,224 |            581,115 |            833,884 |                823,562 |       109,502 |           108,895 |
+| collections            |        114,043 |            113,327 |            116,165 |                114,814 |        19,174 |            19,147 |
+| index signatures / 128 |         55,148 |             55,221 |             56,145 |                 56,159 |        25,098 |            24,610 |
+| index signatures / 512 |          8,176 |              8,376 |              8,770 |                  8,563 |         5,201 |             5,236 |
+| 200-row array payload  |         20,487 |             20,245 |             13,089 |                 13,086 |         5,295 |             5,240 |
+| 200 single-row frames  |      1,400,818 |          1,313,427 |          1,572,663 |              1,473,768 |       132,868 |           127,821 |
 
 ## Analysis
 
 - SchemaBinary leads JSON and Msgpack on every one-shot case, index signatures included. Schemas the binary layer validates on its own skip the schema pass that used to run over each decoded value, and a lone string index signature no longer matches keys one at a time.
 - SchemaBinary is faster than both text and Msgpack streaming in every batch case. NDJSON and Msgpack batch throughput are close and trade places by shape, but NDJSON single-frame throughput is dominated by running a complete Effect Channel for each value.
-- NDJSON is the largest raw stream in every case. Compression changes the ranking for repeated keys: NDJSON has the smallest zstd output for collections and both index-signature cases. Fingerprint SchemaBinary remains the smallest raw format for struct-heavy values.
+- NDJSON is the largest raw stream in every case. Compression changes the ranking for repeated keys: NDJSON has the smallest zstd output for collections and both index-signature cases.
+- Row runs make the default mode the smallest and fastest format for repeated rows, ahead of fingerprint mode: the `200-row array payload` is 7,771 bytes against 19,454 fingerprinted and 51,283 for Msgpack. They cost a little on short arrays, where the per-row shape code is not yet amortized: `nested payload` holds three line items and encodes roughly 9% slower than before runs, for 8% fewer bytes.

--- a/packages/effect/src/unstable/encoding/SchemaBinary.ts
+++ b/packages/effect/src/unstable/encoding/SchemaBinary.ts
@@ -1,10 +1,12 @@
 /**
  * A compact binary codec derived from the encoded side of a Schema.
  *
- * The default wire format supports compatible schema evolution. Fingerprint
- * mode uses positional layouts and rejects mismatches for smaller frames.
- * Encoded results are arena-backed views; see {@link toCodec} for ownership
- * details.
+ * The default wire format supports compatible schema evolution. An array of
+ * structs is written as a row run: rows declare their field ids once per
+ * distinct shape and back-reference repeated strings, so both stay off the
+ * wire on later rows. Fingerprint mode uses positional layouts and rejects
+ * mismatches for smaller frames. Encoded results are arena-backed views; see
+ * {@link toCodec} for ownership details.
  *
  * @since 4.0.0
  */
@@ -349,18 +351,24 @@ class Writer {
     return this.len++
   }
   endSized(mark: number) {
-    const payload = this.len - mark - 1
-    if (payload < 0x80) {
-      this.buf[this.start + mark] = payload
-      return
-    }
-    const size = uvarintSize(payload)
+    const code = this.len - mark - 1
+    if (code < 0x80) this.buf[this.start + mark] = code
+    else this.growSized(mark, code)
+  }
+  // Row-run regions prefix `length * 2`; odd codes are back-references.
+  endSizedRun(mark: number) {
+    const code = (this.len - mark - 1) * 2
+    if (code < 0x80) this.buf[this.start + mark] = code
+    else this.growSized(mark, code)
+  }
+  private growSized(mark: number, code: number) {
+    const size = uvarintSize(code)
     const extra = size - 1
     this.ensure(extra)
     const absoluteMark = this.start + mark
     this.buf.copyWithin(absoluteMark + size, absoluteMark + 1, this.start + this.len)
     this.len += extra
-    let n = payload
+    let n = code
     let p = absoluteMark
     while (n > 0x7F) {
       this.buf[p++] = (n & 0x7F) | 0x80
@@ -494,6 +502,8 @@ class Reader {
   options: SchemaAST.ParseOptions = EMPTY_PARSE_OPTIONS
   indexSignatures: IndexSignatureCache | undefined
   positional = false
+  // Handed to the row-run field's immediate consumer, then cleared.
+  intern: Array<unknown> | undefined
   reset(
     buf: Uint8Array,
     start: number,
@@ -509,6 +519,7 @@ class Reader {
     this.options = options
     this.indexSignatures = indexSignatures
     this.positional = positional
+    this.intern = undefined
   }
   release() {
     this.pos = this.end = 0
@@ -520,6 +531,7 @@ class Reader {
     this.options = EMPTY_PARSE_OPTIONS
     this.indexSignatures = undefined
     this.positional = false
+    this.intern = undefined
   }
   get remaining(): number {
     return this.end - this.pos
@@ -780,7 +792,26 @@ interface ArrayLayout {
   uniformInline: boolean
   uniformPacked: number | undefined
   uniformNumbers: boolean
+  // Lazily compiled row-run plan; `null` once known to be unavailable.
+  run: RunPlan | null | undefined
 }
+
+// Struct rows repeated in one array share their field ids and repeated strings.
+interface RunPlan {
+  readonly struct: StructLayout
+  // Per field index: INTERN_NONE / SELF / ELEMENTS / KEYS.
+  readonly intern: Array<number>
+  readonly shapes: boolean
+}
+
+const INTERN_NONE = 0
+const INTERN_SELF = 1
+const INTERN_ELEMENTS = 2
+const INTERN_KEYS = 3
+
+// Rows carry a presence mask over fields plus one bit for the extra block.
+const RUN_MAX_FIELDS = 30
+const RUN_EXTRA_BIT = 1 << RUN_MAX_FIELDS
 
 interface VariantRow {
   readonly tag: number
@@ -1220,7 +1251,8 @@ function compileLayout(root: SchemaAST.AST): CompiledLayout {
       uniform: undefined,
       uniformInline: false,
       uniformPacked: undefined,
-      uniformNumbers: false
+      uniformNumbers: false,
+      run: undefined
     }
     memo.set(ast, layout)
     for (const element of ast.elements) {
@@ -1762,6 +1794,8 @@ interface EncodeContext {
   indexSignatures: IndexSignatureCache | undefined
   // Records of one shape repeat within a frame, so the last one is reused.
   extraShape: ExtraShape | undefined
+  // Handed to the row-run field's immediate consumer, then cleared.
+  intern: InternWrite | undefined
 }
 
 function encodeFail(expected: string, input: unknown, options: SchemaAST.ParseOptions): never {
@@ -1940,16 +1974,27 @@ function encodeExtraPairs(
   ctx: EncodeContext,
   pairs: Array<ExtraPair>,
   obj: Record<string, unknown>,
-  w: Writer
+  w: Writer,
+  keys?: InternWrite | undefined
 ) {
   for (const [key, signature, keyBytes] of pairs) {
-    if (keyBytes === undefined) {
-      w.uvarint(key.length)
-      w.string(key)
+    const keyLength = keyBytes === undefined ? key.length : keyBytes.length
+    if (keys === undefined) {
+      w.uvarint(keyLength)
     } else {
-      w.uvarint(keyBytes.length)
-      w.bytes(keyBytes)
+      const ref = internRef(keys, key)
+      if (ref !== undefined) {
+        w.uvarint(ref * 2 + 1)
+        issuePath[issuePathLen++] = key
+        encodeSized(ctx, signature.layout, obj[key], w)
+        issuePathLen--
+        continue
+      }
+      internAdd(keys, key)
+      w.uvarint(keyLength * 2)
     }
+    if (keyBytes === undefined) w.string(key)
+    else w.bytes(keyBytes)
     issuePath[issuePathLen++] = key
     encodeSized(ctx, signature.layout, obj[key], w)
     issuePathLen--
@@ -1959,11 +2004,14 @@ function encodeExtraPairs(
 function encodeStructFields(ctx: EncodeContext, layout: StructLayout, value: object, w: Writer) {
   const obj = value as Record<string, unknown>
   if (layout.extra.length > 0) {
+    // Only a run field with index signatures hands over an intern table.
+    const keys = ctx.intern
+    ctx.intern = undefined
     const pairs = extraPairs(ctx, layout, obj)
     if (pairs.length > 0) {
       w.uvarint(0)
       const mark = w.beginSized()
-      encodeExtraPairs(ctx, pairs, obj, w)
+      encodeExtraPairs(ctx, pairs, obj, w, keys)
       w.endSized(mark)
     }
   }
@@ -2020,6 +2068,172 @@ function encodeStructPositional(ctx: EncodeContext, layout: StructLayout, value:
   }
 }
 
+function internKind(layout: Layout): number {
+  switch (layout._) {
+    case "string":
+      return INTERN_SELF
+    case "array":
+      return layout.uniform?._ === "string" ? INTERN_ELEMENTS : INTERN_NONE
+    case "struct":
+      return layout.extra.length > 0 ? INTERN_KEYS : INTERN_NONE
+    default:
+      return INTERN_NONE
+  }
+}
+
+// `Schema.Array(S)` and `Schema.NonEmptyArray(S)` both give every slot one layout.
+function runStruct(layout: ArrayLayout): StructLayout | undefined {
+  let uniform = layout.uniform
+  if (uniform === undefined) {
+    if (layout.rest.length !== 1) return undefined
+    uniform = layout.rest[0]
+    for (const slot of layout.elements) {
+      if (slot.optional || slot.layout !== uniform) return undefined
+    }
+  }
+  return uniform._ === "struct" ? uniform : undefined
+}
+
+function runPlan(layout: ArrayLayout): RunPlan | null {
+  let plan = layout.run
+  if (plan !== undefined) return plan
+  const struct = runStruct(layout)
+  if (struct === undefined) {
+    layout.run = plan = null
+    return plan
+  }
+  const intern = struct.fields.map((field) => internKind(field.layout))
+  plan = { struct, intern, shapes: struct.fields.length <= RUN_MAX_FIELDS }
+  layout.run = plan
+  return plan
+}
+
+// One table per field, so a field the reader skips can never shift another
+// field's references. Holds the values written literally so far, in reference
+// order; short runs scan the array, longer ones build a map.
+interface InternWrite {
+  readonly values: Array<unknown>
+  refs: Map<unknown, number> | undefined
+}
+
+const INTERN_MAP_AT = 8
+
+function internWrite(tables: Array<InternWrite | undefined>, index: number): InternWrite {
+  return tables[index] ??= { values: [], refs: undefined }
+}
+
+function internRef(table: InternWrite, value: unknown): number | undefined {
+  const refs = table.refs
+  if (refs !== undefined) return refs.get(value)
+  const values = table.values
+  for (let i = 0; i < values.length; i++) {
+    if (values[i] === value) return i
+  }
+  return undefined
+}
+
+function internAdd(table: InternWrite, value: unknown) {
+  const values = table.values
+  if (table.refs !== undefined) {
+    table.refs.set(value, values.length)
+  } else if (values.length >= INTERN_MAP_AT) {
+    const refs = table.refs = new Map()
+    for (let i = 0; i < values.length; i++) refs.set(values[i], i)
+    refs.set(value, values.length)
+  }
+  values.push(value)
+}
+
+function encodeInterned(table: InternWrite, ctx: EncodeContext, layout: Layout, value: unknown, w: Writer) {
+  const ref = internRef(table, value)
+  if (ref !== undefined) {
+    w.uvarint(ref * 2 + 1)
+    return
+  }
+  internAdd(table, value)
+  const mark = w.beginSized()
+  encodeValue(ctx, layout, value, w)
+  w.endSizedRun(mark)
+}
+
+function encodeStructRun(ctx: EncodeContext, plan: RunPlan, arr: ReadonlyArray<unknown>, count: number, w: Writer) {
+  const shapes: Array<number> = []
+  const tables: Array<InternWrite | undefined> = []
+  for (let i = 0; i < count; i++) {
+    issuePath[issuePathLen++] = i
+    const mark = w.beginSized()
+    encodeRunRow(ctx, plan, shapes, tables, arr[i], w)
+    w.endSized(mark)
+    issuePathLen--
+  }
+}
+
+function encodeRunRow(
+  ctx: EncodeContext,
+  plan: RunPlan,
+  shapes: Array<number>,
+  tables: Array<InternWrite | undefined>,
+  value: unknown,
+  w: Writer
+) {
+  const struct = plan.struct
+  const obj = value as Record<string, unknown>
+  const fields = struct.fields
+  let pairs: Array<ExtraPair> | undefined
+  if (struct.extra.length > 0) {
+    const found = extraPairs(ctx, struct, obj)
+    if (found.length > 0) pairs = found
+  }
+  const wide = !plan.shapes
+  let mask = pairs === undefined ? 0 : RUN_EXTRA_BIT
+  for (let i = 0; i < fields.length; i++) {
+    const field = fields[i]
+    if (Object.hasOwn(obj, field.name)) {
+      if (!wide) mask |= 1 << i
+    } else if (!field.optional) {
+      issuePath[issuePathLen++] = field.name
+      throw issueError(new SchemaIssue.MissingKey(field.annotations))
+    }
+  }
+  let shape = -1
+  for (let i = 0; i < shapes.length; i++) {
+    if (shapes[i] === mask) {
+      shape = i
+      break
+    }
+  }
+  if (shape >= 0) {
+    w.uvarint(shape + 1)
+  } else {
+    w.uvarint(0)
+    if (!wide) shapes.push(mask)
+  }
+  const declare = shape < 0
+  if (pairs !== undefined) {
+    if (declare) w.uvarint(0)
+    const mark = w.beginSized()
+    encodeExtraPairs(ctx, pairs, obj, w)
+    w.endSizedRun(mark)
+  }
+  for (let i = 0; i < fields.length; i++) {
+    const field = fields[i]
+    if (wide ? !Object.hasOwn(obj, field.name) : (mask & (1 << i)) === 0) continue
+    if (declare) w.uvarint(field.id)
+    issuePath[issuePathLen++] = field.name
+    const kind = plan.intern[i]
+    if (kind === INTERN_SELF) {
+      encodeInterned(internWrite(tables, i), ctx, field.layout, obj[field.name], w)
+    } else {
+      if (kind !== INTERN_NONE) ctx.intern = internWrite(tables, i)
+      const mark = w.beginSized()
+      encodeValue(ctx, field.layout, obj[field.name], w)
+      w.endSizedRun(mark)
+      ctx.intern = undefined
+    }
+    issuePathLen--
+  }
+}
+
 function arraySlot(layout: ArrayLayout, index: number, count: number): Layout {
   const elementLen = layout.elements.length
   if (index < elementLen) return layout.elements[index].layout
@@ -2042,10 +2256,28 @@ function encodeArray(ctx: EncodeContext, layout: ArrayLayout, value: unknown, w:
     throw issueError(new SchemaIssue.MissingKey(undefined))
   }
   if (layout.hasCount) w.uvarint(count)
+  if (!ctx.positional && count > 0) {
+    const plan = runPlan(layout)
+    if (plan !== null) {
+      encodeStructRun(ctx, plan, arr, count, w)
+      return
+    }
+  }
   const uniform = layout.uniform
   if (uniform !== undefined) {
     if (layout.uniformNumbers) {
       encodeNumberRun(arr, count, w)
+      return
+    }
+    // Only a run field holding an array of strings hands over an intern table.
+    const table = ctx.intern
+    ctx.intern = undefined
+    if (table !== undefined) {
+      for (let i = 0; i < count; i++) {
+        issuePath[issuePathLen++] = i
+        encodeInterned(table, ctx, uniform, arr[i], w)
+        issuePathLen--
+      }
       return
     }
     const inline = layout.uniformInline
@@ -2286,7 +2518,8 @@ function encodeFrame(
     options,
     positional: mode.positional,
     indexSignatures: undefined,
-    extraShape: undefined
+    extraShape: undefined,
+    intern: undefined
   }
   const w = pooledWriter ?? new Writer()
   const pooled = w === pooledWriter
@@ -2346,8 +2579,14 @@ function decodeSlot(layout: Layout, r: Reader): unknown {
   return value
 }
 
-function decodeExtraPair(layout: StructLayout, r: Reader, out: Record<string, unknown>, seen: Set<string>) {
-  const key = r.readUtf8(r.uvarint())
+function decodeExtraPair(
+  layout: StructLayout,
+  r: Reader,
+  out: Record<string, unknown>,
+  seen: Set<string>,
+  keys?: Array<unknown> | undefined
+) {
+  const key = keys === undefined ? r.readUtf8(r.uvarint()) : decodeExtraKey(keys, r)
   if (seen.has(key)) invalid("unique extra keys", undefined, r.options)
   seen.add(key)
   const saved = r.enter(r.uvarint())
@@ -2362,6 +2601,18 @@ function decodeExtraPair(layout: StructLayout, r: Reader, out: Record<string, un
   r.exit(saved)
 }
 
+function decodeExtraKey(keys: Array<unknown>, r: Reader): string {
+  const code = r.uvarint()
+  if ((code & 1) === 1) {
+    const ref = (code - 1) / 2
+    if (ref >= keys.length) invalid("a known back-reference", undefined, r.options)
+    return keys[ref] as string
+  }
+  const key = r.readUtf8(code / 2)
+  keys.push(key)
+  return key
+}
+
 function missingKeyIssue(field: Field): SchemaIssue.Issue {
   return new SchemaIssue.Pointer([field.name], new SchemaIssue.MissingKey(field.annotations))
 }
@@ -2373,6 +2624,12 @@ function throwMissingKeys(layout: StructLayout, issues: Array<SchemaIssue.Issue>
 }
 
 function decodeStruct(layout: StructLayout, r: Reader): unknown {
+  // Only a run field with index signatures hands over an intern table.
+  let keys: Array<unknown> | undefined
+  if (layout.extra.length > 0) {
+    keys = r.intern
+    r.intern = undefined
+  }
   const out: Record<string, unknown> = {}
   // Use bitmasks for common structs and allocate sets only when needed.
   let seenMask = 0
@@ -2391,7 +2648,7 @@ function decodeStruct(layout: StructLayout, r: Reader): unknown {
     if (id === 0) {
       if (seenExtra) invalid("unique field ids", undefined, r.options)
       seenExtra = true
-      decodeExtraPairs(layout, r, out)
+      decodeExtraPairs(layout, r, out, keys)
       r.exit(saved)
       continue
     }
@@ -2486,9 +2743,167 @@ function decodeStructPositional(layout: StructLayout, r: Reader): unknown {
   return out
 }
 
-function decodeExtraPairs(layout: StructLayout, r: Reader, out: Record<string, unknown>) {
+function decodeExtraPairs(
+  layout: StructLayout,
+  r: Reader,
+  out: Record<string, unknown>,
+  keys?: Array<unknown> | undefined
+) {
   const seen = new Set<string>()
-  while (r.pos < r.end) decodeExtraPair(layout, r, out, seen)
+  while (r.pos < r.end) decodeExtraPair(layout, r, out, seen, keys)
+}
+
+// A row shape is the writer's tag order: a known field, `null` for the extra
+// block, or `undefined` for a field this reader does not have.
+type RunSlot = Field | null | undefined
+
+function decodeInterned(table: Array<unknown>, layout: Layout, r: Reader): unknown {
+  const code = r.uvarint()
+  if ((code & 1) === 1) {
+    const ref = (code - 1) / 2
+    if (ref >= table.length) invalid("a known back-reference", undefined, r.options)
+    return table[ref]
+  }
+  const saved = r.enter(code / 2)
+  const value = decodeChecked(layout, r)
+  r.exit(saved)
+  table.push(value)
+  return value
+}
+
+function decodeStructRun(plan: RunPlan, count: number, r: Reader): Array<unknown> {
+  const out: Array<unknown> = new Array(count)
+  const shapes: Array<Array<RunSlot>> = []
+  const tables: Array<Array<unknown> | undefined> = []
+  for (let i = 0; i < count; i++) {
+    issuePath[issuePathLen++] = i
+    const saved = r.enter(r.uvarint())
+    out[i] = decodeRunRow(plan, shapes, tables, r)
+    r.exit(saved)
+    issuePathLen--
+  }
+  return out
+}
+
+function decodeRunRow(
+  plan: RunPlan,
+  shapes: Array<Array<RunSlot>>,
+  tables: Array<Array<unknown> | undefined>,
+  r: Reader
+): unknown {
+  const struct = plan.struct
+  const out: Record<string, unknown> = {}
+  let presentMask = 0
+  let presentWide: Set<number> | undefined
+  const code = r.uvarint()
+  if (code === 0) {
+    const shape: Array<RunSlot> = []
+    let seenMask = 0
+    let seenWide: Set<number> | undefined
+    let seenIds: Set<number> | undefined
+    let seenExtra = false
+    while (r.pos < r.end) {
+      const id = r.uvarint()
+      let slot: RunSlot
+      if (id === 0) {
+        if (seenExtra) invalid("unique field ids", undefined, r.options)
+        seenExtra = true
+        slot = null
+      } else {
+        slot = struct.byId.get(id)
+        if (slot === undefined) {
+          if (seenIds === undefined) seenIds = new Set([id])
+          else if (seenIds.has(id)) invalid("unique field ids", undefined, r.options)
+          else seenIds.add(id)
+        } else if (slot.index < 32) {
+          if ((seenMask & (1 << slot.index)) !== 0) invalid("unique field ids", undefined, r.options)
+          seenMask |= 1 << slot.index
+        } else if (seenWide === undefined) {
+          seenWide = new Set([slot.index])
+        } else {
+          if (seenWide.has(slot.index)) invalid("unique field ids", undefined, r.options)
+          seenWide.add(slot.index)
+        }
+      }
+      shape.push(slot)
+      const filled = decodeRunSlot(plan, tables, slot, out, r)
+      if (filled >= 0) {
+        if (filled < 32) presentMask |= 1 << filled
+        else (presentWide ??= new Set()).add(filled)
+      }
+    }
+    if (plan.shapes) shapes.push(shape)
+  } else {
+    const shape = shapes[code - 1]
+    if (shape === undefined) invalid("a known row shape", undefined, r.options)
+    for (let i = 0; i < shape.length; i++) {
+      const filled = decodeRunSlot(plan, tables, shape[i], out, r)
+      if (filled >= 0) {
+        if (filled < 32) presentMask |= 1 << filled
+        else (presentWide ??= new Set()).add(filled)
+      }
+    }
+    if (r.pos !== r.end) invalid("no leftover bytes", undefined, r.options)
+  }
+  let issues: Array<SchemaIssue.Issue> | undefined
+  const fields = struct.fields
+  for (let i = 0; i < fields.length; i++) {
+    const field = fields[i]
+    const index = field.index
+    const has = index < 32 ? (presentMask & (1 << index)) !== 0 : presentWide?.has(index) === true
+    if (!field.optional && !has) {
+      ;(issues ??= []).push(missingKeyIssue(field))
+      if (r.options.errors !== "all") break
+    }
+  }
+  if (issues !== undefined) throwMissingKeys(struct, issues)
+  return out
+}
+
+// Returns the field index this slot filled, or -1.
+function decodeRunSlot(
+  plan: RunPlan,
+  tables: Array<Array<unknown> | undefined>,
+  slot: RunSlot,
+  out: Record<string, unknown>,
+  r: Reader
+): number {
+  const code = r.uvarint()
+  if ((code & 1) === 1) {
+    if (slot === null || slot === undefined) return -1
+    const table = tables[slot.index]
+    const ref = (code - 1) / 2
+    if (table === undefined || ref >= table.length) {
+      invalid("a known back-reference", undefined, r.options)
+    }
+    const value = table[ref]
+    if (value === ABSENT) return -1
+    InternalRecord.assignProperty(out, slot.name, value)
+    return slot.index
+  }
+  const saved = r.enter(code / 2)
+  if (slot === null) {
+    decodeExtraPairs(plan.struct, r, out)
+    r.exit(saved)
+    return -1
+  }
+  if (slot === undefined) {
+    r.exit(saved)
+    return -1
+  }
+  const kind = plan.intern[slot.index]
+  if (kind === INTERN_ELEMENTS || kind === INTERN_KEYS) {
+    r.intern = tables[slot.index] ??= []
+  }
+  issuePath[issuePathLen++] = slot.name
+  const value = decodeChecked(slot.layout, r)
+  issuePathLen--
+  r.intern = undefined
+  r.exit(saved)
+  if (kind === INTERN_SELF) (tables[slot.index] ??= []).push(value)
+  if (value === ABSENT) return -1
+  InternalRecord.assignProperty(out, slot.name, value)
+  return slot.index
 }
 
 function decodeArray(layout: ArrayLayout, r: Reader): unknown {
@@ -2506,10 +2921,27 @@ function decodeArray(layout: ArrayLayout, r: Reader): unknown {
     issuePath[issuePathLen++] = count
     throw issueError(new SchemaIssue.MissingKey(undefined))
   }
+  if (!r.positional && count > 0) {
+    const plan = runPlan(layout)
+    if (plan !== null) return decodeStructRun(plan, count, r)
+  }
   const out: Array<unknown> = new Array(count)
   const uniform = layout.uniform
   if (uniform !== undefined) {
     if (layout.uniformNumbers) return decodeNumberRun(out, count, r)
+    // Only a run field holding an array of strings hands over an intern table.
+    const table = r.intern
+    r.intern = undefined
+    if (table !== undefined) {
+      for (let i = 0; i < count; i++) {
+        issuePath[issuePathLen++] = i
+        const value = decodeInterned(table, uniform, r)
+        if (value === ABSENT) throw issueError(new SchemaIssue.MissingKey(undefined))
+        issuePathLen--
+        out[i] = value
+      }
+      return out
+    }
     if (isSelfDelimiting(uniform)) {
       for (let i = 0; i < count; i++) {
         issuePath[issuePathLen++] = i

--- a/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
+++ b/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
@@ -648,6 +648,75 @@ describe("SchemaBinary", () => {
       assert.match(schemaError(() => Schema.decodeUnknownSync(codec)(unknownRef)).message, /back-reference/)
     })
 
+    it("keeps a skipped field's own run out of the reader's tables", () => {
+      const Writer = Schema.Struct({
+        keep: Schema.String,
+        gone: Schema.Array(Schema.Struct({ p: Schema.String, q: Schema.String }))
+      })
+      const Reader = Schema.Struct({ keep: Schema.String })
+      const values = Array.from({ length: 4 }, (_, index) => ({
+        keep: `k${index}`,
+        gone: [{ p: "z", q: "z" }, { p: "z", q: "z" }]
+      }))
+      assert.deepStrictEqual(
+        Schema.decodeUnknownSync(SchemaBinary.toCodec(Schema.Array(Reader)))(encode(Schema.Array(Writer), values)),
+        values.map(({ keep }) => ({ keep }))
+      )
+    })
+
+    it("reads every index signature key the reader has no signature for", () => {
+      const Writer = Schema.Struct({ id: Schema.String, attrs: Schema.Record(Schema.String, Schema.String) })
+      const Reader = Schema.Struct({
+        id: Schema.String,
+        attrs: Schema.Record(
+          Schema.String.check(Schema.makeFilter((key: string) => key.startsWith("a"))),
+          Schema.String
+        )
+      })
+      const values = Array.from({ length: 4 }, (_, index) => ({
+        id: `r${index}`,
+        attrs: { alpha: "1", beta: "2", again: "3" }
+      }))
+      assert.deepStrictEqual(
+        Schema.decodeUnknownSync(SchemaBinary.toCodec(Schema.Array(Reader)))(encode(Schema.Array(Writer), values)),
+        values.map(({ id }) => ({ id, attrs: { alpha: "1", again: "3" } }))
+      )
+    })
+
+    it("holds references past the point a slot switches to a map", () => {
+      const Many = Schema.Struct({ v: Schema.String })
+      const many = Array.from({ length: 40 }, (_, index) => ({ v: `v${index % 13}` }))
+      assert.deepStrictEqual(roundtrip(Schema.Array(Many), many), many)
+    })
+
+    it("gives each recursive occurrence its own run", () => {
+      interface Node {
+        readonly name: string
+        readonly children: ReadonlyArray<Node>
+      }
+      const Node = Schema.Struct({
+        name: Schema.String,
+        children: Schema.Array(Schema.suspend((): Schema.Codec<Node> => Node))
+      })
+      const tree = [
+        { name: "a", children: [{ name: "x", children: [] }, { name: "x", children: [] }] },
+        { name: "a", children: [{ name: "y", children: [{ name: "x", children: [] }] }] }
+      ]
+      assert.deepStrictEqual(roundtrip(Schema.Array(Node), tree), tree)
+    })
+
+    it("reports the row index and field name for a missing key", () => {
+      const Required = Schema.Struct({ a: Schema.String, b: Schema.String })
+      assert.match(
+        schemaError(() =>
+          Schema.encodeUnknownSync(SchemaBinary.toCodec(Schema.Array(Required)))(
+            [{ a: "1", b: "2" }, { a: "1" } as never]
+          )
+        ).message,
+        /Missing key\n  at \[1\]\["b"\]/
+      )
+    })
+
     it("leaves fingerprint mode positional", () => {
       assert.deepStrictEqual(roundtripFingerprint(Schema.Array(Row), rows), rows)
     })

--- a/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
+++ b/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
@@ -552,6 +552,107 @@ describe("SchemaBinary", () => {
     })
   })
 
+  describe("struct row runs", () => {
+    const Row = Schema.Struct({
+      id: Schema.String,
+      label: Schema.String,
+      tags: Schema.Array(Schema.String),
+      attributes: Schema.Record(Schema.String, Schema.String)
+    })
+    const rows = Array.from({ length: 6 }, (_, index) => ({
+      id: `row-${index}`,
+      label: index % 2 === 0 ? "even" : "odd",
+      tags: index % 3 === 0 ? ["red", "blue"] : ["blue"],
+      attributes: { region: "eu", worker: `w${index}` }
+    }))
+
+    it("shares field ids and repeated strings across rows", () => {
+      assert.deepStrictEqual(roundtrip(Schema.Array(Row), rows), rows)
+      assert.deepStrictEqual(roundtrip(Schema.NonEmptyArray(Row), rows), rows)
+      const one = encode(Schema.Array(Row), rows.slice(0, 1)).length
+      const six = encode(Schema.Array(Row), rows).length
+      assert.isBelow(six, one * 6)
+    })
+
+    it("keeps evolution rules inside a run", () => {
+      const Reader = Schema.Struct({
+        tags: Schema.Array(Schema.String),
+        id: Schema.String,
+        later: Schema.optionalKey(Schema.Boolean)
+      })
+      assert.deepStrictEqual(
+        Schema.decodeUnknownSync(SchemaBinary.toCodec(Schema.Array(Reader)))(encode(Schema.Array(Row), rows)),
+        rows.map(({ id, tags }) => ({ id, tags }))
+      )
+    })
+
+    it("declares a new shape whenever the present fields change", () => {
+      const Varying = Schema.Struct({
+        id: Schema.String,
+        a: Schema.optionalKey(Schema.String),
+        b: Schema.optionalKey(Schema.Number)
+      })
+      const varying = [
+        { id: "0", a: "x" },
+        { id: "1" },
+        { id: "2", a: "x", b: 1 },
+        { id: "3", a: "x" },
+        { id: "4", b: 2 }
+      ]
+      assert.deepStrictEqual(roundtrip(Schema.Array(Varying), varying), varying)
+    })
+
+    it("interns index signature keys on the row struct itself", () => {
+      const WithRest = Schema.StructWithRest(Schema.Struct({ id: Schema.String }), [
+        Schema.Record(Schema.String, Schema.String)
+      ])
+      const values = [{ id: "a", note: "1" }, { id: "b", note: "2" }, { id: "c" }]
+      assert.deepStrictEqual(roundtrip(Schema.Array(WithRest), values), values)
+    })
+
+    it("runs nested inside a run", () => {
+      const Inner = Schema.Struct({ k: Schema.String, v: Schema.String })
+      const Outer = Schema.Struct({ name: Schema.String, items: Schema.Array(Inner) })
+      const outers = Array.from({ length: 4 }, (_, index) => ({
+        name: `n${index}`,
+        items: [{ k: "a", v: "1" }, { k: "b", v: "1" }]
+      }))
+      assert.deepStrictEqual(roundtrip(Schema.Array(Outer), outers), outers)
+    })
+
+    it("keeps rows independent past the 30 field shape limit", () => {
+      const fields: Record<string, Schema.String> = {}
+      const value: Record<string, string> = {}
+      for (let i = 0; i < 35; i++) {
+        fields[`f${i}`] = Schema.String
+        value[`f${i}`] = `v${i}`
+      }
+      const Wide = Schema.Struct(fields)
+      assert.deepStrictEqual(roundtrip(Schema.Array(Wide), [value, value, value]), [value, value, value])
+    })
+
+    it("rejects an unknown row shape and an out of range back-reference", () => {
+      const Simple = Schema.Array(Schema.Struct({ a: Schema.String }))
+      const codec = SchemaBinary.toCodec(Simple)
+      // The second row reuses shape 0 and back-references the first `a`, so its
+      // last two bytes are the shape code and the region code.
+      const bytes = encode(Simple, [{ a: "x" }, { a: "x" }])
+      assert.deepStrictEqual([...bytes.subarray(bytes.length - 2)], [1, 1])
+
+      const unknownShape = bytes.slice()
+      unknownShape[unknownShape.length - 2] = 9
+      assert.match(schemaError(() => Schema.decodeUnknownSync(codec)(unknownShape)).message, /row shape/)
+
+      const unknownRef = bytes.slice()
+      unknownRef[unknownRef.length - 1] = 5
+      assert.match(schemaError(() => Schema.decodeUnknownSync(codec)(unknownRef)).message, /back-reference/)
+    })
+
+    it("leaves fingerprint mode positional", () => {
+      assert.deepStrictEqual(roundtripFingerprint(Schema.Array(Row), rows), rows)
+    })
+  })
+
   describe("parser", () => {
     it("parses concatenated frames split across chunks", () => {
       const schema = Schema.Struct({ a: Schema.Number })

--- a/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
+++ b/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
@@ -565,10 +565,11 @@ describe("SchemaBinary", () => {
       tags: index % 3 === 0 ? ["red", "blue"] : ["blue"],
       attributes: { region: "eu", worker: `w${index}` }
     }))
+    const nonEmptyRows = rows as [typeof rows[number], ...Array<typeof rows[number]>]
 
     it("shares field ids and repeated strings across rows", () => {
       assert.deepStrictEqual(roundtrip(Schema.Array(Row), rows), rows)
-      assert.deepStrictEqual(roundtrip(Schema.NonEmptyArray(Row), rows), rows)
+      assert.deepStrictEqual(roundtrip(Schema.NonEmptyArray(Row), nonEmptyRows), nonEmptyRows)
       const one = encode(Schema.Array(Row), rows.slice(0, 1)).length
       const six = encode(Schema.Array(Row), rows).length
       assert.isBelow(six, one * 6)

--- a/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
+++ b/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
@@ -664,22 +664,38 @@ describe("SchemaBinary", () => {
       )
     })
 
-    it("reads every index signature key the reader has no signature for", () => {
-      const Writer = Schema.Struct({ id: Schema.String, attrs: Schema.Record(Schema.String, Schema.String) })
+    it("interns every index signature key, including ones it has no signature for", () => {
+      const Writer = Schema.Struct({ attrs: Schema.Record(Schema.String, Schema.String) })
       const Reader = Schema.Struct({
-        id: Schema.String,
         attrs: Schema.Record(
-          Schema.String.check(Schema.makeFilter((key: string) => key.startsWith("a"))),
+          Schema.String.check(Schema.makeFilter((key: string) => key.startsWith("keep"))),
           Schema.String
         )
       })
-      const values = Array.from({ length: 4 }, (_, index) => ({
-        id: `r${index}`,
-        attrs: { alpha: "1", beta: "2", again: "3" }
-      }))
+      // The reader drops `drop` but must still number it, or row 2's reference
+      // to `keep1` resolves to `keep2`.
+      const values = [
+        { attrs: { drop: "d", keep1: "a" } },
+        { attrs: { keep2: "b" } },
+        { attrs: { keep1: "c" } }
+      ]
       assert.deepStrictEqual(
         Schema.decodeUnknownSync(SchemaBinary.toCodec(Schema.Array(Reader)))(encode(Schema.Array(Writer), values)),
-        values.map(({ id }) => ({ id, attrs: { alpha: "1", again: "3" } }))
+        [{ attrs: { keep1: "a" } }, { attrs: { keep2: "b" } }, { attrs: { keep1: "c" } }]
+      )
+    })
+
+    it("keeps two fields sharing one layout on separate tables", () => {
+      const Writer = Schema.Struct({ keep: Schema.String, gone: Schema.String })
+      const Reader = Schema.Struct({ keep: Schema.String })
+      const values = [
+        { keep: "first", gone: "other" },
+        { keep: "other", gone: "first" },
+        { keep: "first", gone: "first" }
+      ]
+      assert.deepStrictEqual(
+        Schema.decodeUnknownSync(SchemaBinary.toCodec(Schema.Array(Reader)))(encode(Schema.Array(Writer), values)),
+        values.map(({ keep }) => ({ keep }))
       )
     })
 


### PR DESCRIPTION
Makes `RpcSerialization.layerSchemaBinary` frames smaller than msgpack on every case in `packages/effect/benchmark/rpc/RpcSerialization.ts`.

| Case | Msgpack | SchemaBinary before | after |
| --- | ---: | ---: | ---: |
| request / nested search payload | 320 | 256 | 256 |
| exit / 12-user success | 919 | 1174 | **760** |
| chunk / 32 events | 2622 | 3623 | **2165** |

RPC payloads use the default (evolution-tolerant) mode, where every struct field carries its id as a uvarint of `fnv32(name)`. Those hashes are uniformly random uint32, so the uvarint is five bytes essentially always. Twelve five-field user records paid 300 bytes of field ids; msgpackr with `useRecords` amortises the same key set to nearly nothing.

## What changed

In the default mode only, an array whose element slots all share one struct layout is written as a **row run**. This covers `Schema.Array(S)` and `Schema.NonEmptyArray(S)`.

- Each row starts with a uvarint shape code. `0` declares: the row writes `(id, region)` pairs as before and both sides record the id sequence as the next shape. `k > 0` reuses shape `k - 1` and writes only regions, in that shape's order. Field ids therefore cost nothing after the first row of each distinct present-field set, and a varying optional field just produces another shape. No template and no presence bitmap.
- Every region inside a run row is framed as `uvarint(len * 2)` for a literal, or `uvarint(ref * 2 + 1)` for a back-reference with an empty payload. That stays uniformly skippable: an unknown field skips `code >> 1` bytes either way.
- Back-references resolve against a table owned by the field slot, not by the frame. A frame-wide table would desynchronise as soon as the reader skipped an unknown field, because the writer appends entries inside that field's subtree and the reader does not. Keying by slot confines a table's lifecycle to occurrences of one field, and a field is either known for every row of the run or unknown for every row.
- Three interned positions, chosen from the slot's layout at compile time: the slot region itself when the layout is `string`, the element regions when it is an array of uniform strings, and the index signature keys when it is a struct with index signatures.

Fingerprint mode is untouched — it is already positional.

Evolution rules are unchanged and covered by tests: unknown fields skipped, missing optionals absent, field reorder compatible, `fieldId` identity preserved.

## Payload benchmark

`packages/effect/benchmark/schema/SchemaBinary.ts`, refreshed in `SchemaBinary.md`. The `200-row array payload` goes from 27,646 to 7,771 raw bytes (msgpack 51,283), so the default mode is now smaller there than fingerprint mode's 19,454.

Throughput against this PR's base, averaged over two base runs:

| Case | encode | decode |
| --- | ---: | ---: |
| 200-row array payload | 1.24x | 1.41x |
| collections | 1.01x | 1.00x |
| index signatures / 128 keys | 1.02x | 1.02x |
| index signatures / 512 keys | 1.01x | 1.03x |
| small record | 0.96x | 0.97x |
| nested payload | 0.91x | 0.93x |

`nested payload` is the honest cost: its `lines` array holds three items, too few to amortise the per-row shape code, so it encodes ~9% slower for 8% fewer bytes. Base-to-base variance on this machine is ±2-5%, which covers `small record`. In the RPC benchmark the `chunk / 32 events` decode moves from 0.95x to 1.23x of msgpack and `exit / 12-user success` encode from 1.36x to 1.25x.

## Review

Codex Engineer attacked the safety argument and found the one place it can break: an index signature key that the writer accepts but the reader has no signature for. If the reader interned only the keys its own matcher accepted, the two tables would drift and a later back-reference would silently resolve to the wrong key. The decoder numbers every literal key before any matching, and `interns every index signature key, including ones it has no signature for` pins that — it fails on exactly the mis-resolution when the interning is made schema-dependent.

Closes EFF-821
