### PR TITLE
Speed up SchemaBinary RPC payload codecs

### DIFF
--- a/packages/effect/benchmark/schema/SchemaBinary.md
+++ b/packages/effect/benchmark/schema/SchemaBinary.md
@@ -6,7 +6,7 @@ Run from the repository root:
 nix develop -c pnpm --dir packages/effect exec node benchmark/schema/SchemaBinary.ts
 ```
 
-These results are from one full run with the RPC performance and row-run changes on Linux x86_64 (AMD EPYC 4344P) with Node 26.7.0. Codec and schema construction are excluded. One-shot tasks use 100 warmups and 1,000 measured samples; streaming tasks use 25 warmups and 250 measured samples. Throughput is machine-local and should only be compared within this run.
+These results are from one full run with the RPC serialization performance changes on Linux x86_64 (AMD EPYC 4344P) with Node 26.7.0. Codec and schema construction are excluded. One-shot tasks use 100 warmups and 1,000 measured samples; streaming tasks use 25 warmups and 250 measured samples. Throughput is machine-local and should only be compared within this run.
 
 The default mode writes an array of structs as a row run: each distinct set of present fields declares its field ids once, and later rows reference that shape and any string already written in the same slot. Fingerprint mode instead omits field identifiers entirely when the schema fingerprint matches. JSON, Msgpack, and NDJSON use the same `Schema.toCodecJson` representation.
 
@@ -45,25 +45,25 @@ Streaming cells contain total raw / gzip -6 / zstd bytes for the complete stream
 
 Average encode operations per second:
 
-| Case                   |   Default | Fingerprint |    JSON | Msgpack |
-| ---------------------- | --------: | ----------: | ------: | ------: |
-| small record           | 1,071,912 |   1,149,340 | 448,927 | 703,647 |
-| nested payload         |   355,828 |     398,804 | 256,793 | 281,323 |
-| collections            |    35,641 |      35,967 |  20,936 |  21,234 |
-| index signatures / 128 |    14,438 |      14,343 |  35,466 |  34,381 |
-| index signatures / 512 |     2,869 |       2,888 |   6,496 |   6,199 |
-| 200-row array payload  |     8,638 |       7,671 |   6,924 |   3,843 |
+| Case                   | Default | Fingerprint |    JSON | Msgpack |
+| ---------------------- | ------: | ----------: | ------: | ------: |
+| small record           | 987,083 |   1,057,894 | 434,772 | 693,322 |
+| nested payload         | 340,043 |     388,632 | 258,224 | 280,441 |
+| collections            |  52,497 |      53,515 |  21,669 |  22,003 |
+| index signatures / 128 |  45,920 |      45,668 |  34,467 |  34,815 |
+| index signatures / 512 |   8,295 |       8,234 |   6,493 |   6,250 |
+| 200-row array payload  |   8,862 |       7,941 |   7,036 |   4,142 |
 
 Average decode operations per second:
 
 | Case                   |   Default | Fingerprint |    JSON | Msgpack |
 | ---------------------- | --------: | ----------: | ------: | ------: |
-| small record           | 1,086,917 |   1,142,987 | 404,201 | 683,663 |
-| nested payload         |   326,896 |     373,072 | 217,268 | 264,012 |
-| collections            |    39,216 |      39,103 |  20,847 |  21,741 |
-| index signatures / 128 |    20,901 |      20,932 |  28,196 |  29,596 |
-| index signatures / 512 |     5,076 |       5,094 |   5,365 |   4,507 |
-| 200-row array payload  |     9,921 |       7,840 |   5,616 |   4,740 |
+| small record           | 1,138,760 |   1,220,001 | 395,051 | 687,043 |
+| nested payload         |   485,669 |     590,166 | 214,371 | 265,124 |
+| collections            |   115,283 |     117,103 |  20,841 |  21,984 |
+| index signatures / 128 |    63,905 |      64,299 |  27,683 |  29,426 |
+| index signatures / 512 |    16,881 |      16,896 |   5,339 |   4,405 |
+| 200-row array payload  |    21,327 |      14,130 |   5,671 |   4,769 |
 
 ## Streaming decode throughput
 
@@ -71,25 +71,25 @@ Average decoded values per second for batched input:
 
 | Case                   |   Default | Fingerprint | Msgpack |  NDJSON |
 | ---------------------- | --------: | ----------: | ------: | ------: |
-| small record           | 4,279,077 |   5,437,581 | 929,780 | 867,195 |
-| nested payload         |   745,151 |     960,767 | 280,710 | 307,612 |
-| collections            |   115,764 |     117,323 |  21,574 |  21,050 |
-| index signatures / 128 |    55,592 |      56,410 |  27,462 |  28,691 |
-| index signatures / 512 |     8,213 |       8,325 |   4,059 |   5,053 |
-| 200-row array payload  |    20,001 |      12,624 |   6,419 |   4,835 |
-| 200 single-row frames  | 2,016,304 |   2,370,486 | 846,918 | 957,619 |
+| small record           | 4,456,048 |   5,548,628 | 898,346 | 859,955 |
+| nested payload         |   815,628 |   1,045,211 | 283,177 | 310,424 |
+| collections            |   125,527 |     126,655 |  21,691 |  20,743 |
+| index signatures / 128 |    67,711 |      67,884 |  27,862 |  28,125 |
+| index signatures / 512 |    16,665 |      16,502 |   4,078 |   4,961 |
+| 200-row array payload  |    21,338 |      13,808 |   6,474 |   4,925 |
+| 200 single-row frames  | 2,350,690 |   2,679,206 | 842,493 | 934,514 |
 
 Average decoded values per second for single and first-byte-fragmented input:
 
 | Case                   | Default single | Default fragmented | Fingerprint single | Fingerprint fragmented | NDJSON single | NDJSON fragmented |
 | ---------------------- | -------------: | -----------------: | -----------------: | ---------------------: | ------------: | ----------------: |
-| small record           |      2,473,776 |          2,118,983 |          3,208,816 |              2,889,960 |       136,622 |           141,237 |
-| nested payload         |        665,224 |            581,115 |            833,884 |                823,562 |       109,502 |           108,895 |
-| collections            |        114,043 |            113,327 |            116,165 |                114,814 |        19,174 |            19,147 |
-| index signatures / 128 |         55,148 |             55,221 |             56,145 |                 56,159 |        25,098 |            24,610 |
-| index signatures / 512 |          8,176 |              8,376 |              8,770 |                  8,563 |         5,201 |             5,236 |
-| 200-row array payload  |         20,487 |             20,245 |             13,089 |                 13,086 |         5,295 |             5,240 |
-| 200 single-row frames  |      1,400,818 |          1,313,427 |          1,572,663 |              1,473,768 |       132,868 |           127,821 |
+| small record           |      2,640,444 |          2,386,118 |          3,273,254 |              2,847,462 |       137,766 |           140,172 |
+| nested payload         |        691,466 |            669,088 |            895,487 |                867,845 |       109,905 |           108,189 |
+| collections            |        121,150 |            122,453 |            109,056 |                122,698 |        18,981 |            18,843 |
+| index signatures / 128 |         65,398 |             66,875 |             67,436 |                 67,437 |        24,341 |            24,239 |
+| index signatures / 512 |         16,755 |             16,676 |             16,181 |                 16,807 |         4,968 |             5,006 |
+| 200-row array payload  |         21,773 |             21,219 |             14,064 |                 13,930 |         5,288 |             5,180 |
+| 200 single-row frames  |      1,458,546 |          1,327,697 |          1,645,932 |              1,398,527 |       126,531 |           124,882 |
 
 ## Analysis
 

--- a/packages/effect/benchmark/schema/SchemaBinary.md
+++ b/packages/effect/benchmark/schema/SchemaBinary.md
@@ -45,25 +45,25 @@ Streaming cells contain total raw / gzip -6 / zstd bytes for the complete stream
 
 Average encode operations per second:
 
-| Case                   | Default | Fingerprint |    JSON | Msgpack |
-| ---------------------- | ------: | ----------: | ------: | ------: |
-| small record           | 987,083 |   1,057,894 | 434,772 | 693,322 |
-| nested payload         | 340,043 |     388,632 | 258,224 | 280,441 |
-| collections            |  52,497 |      53,515 |  21,669 |  22,003 |
-| index signatures / 128 |  45,920 |      45,668 |  34,467 |  34,815 |
-| index signatures / 512 |   8,295 |       8,234 |   6,493 |   6,250 |
-| 200-row array payload  |   8,862 |       7,941 |   7,036 |   4,142 |
+| Case                   |   Default | Fingerprint |    JSON | Msgpack |
+| ---------------------- | --------: | ----------: | ------: | ------: |
+| small record           | 1,011,552 |   1,077,114 | 446,188 | 706,861 |
+| nested payload         |   349,822 |     396,800 | 259,586 | 283,297 |
+| collections            |    53,117 |      54,030 |  22,431 |  22,807 |
+| index signatures / 128 |    46,741 |      46,716 |  35,839 |  34,648 |
+| index signatures / 512 |     8,679 |       8,569 |   6,658 |   6,255 |
+| 200-row array payload  |     8,870 |       8,074 |   6,960 |   4,117 |
 
 Average decode operations per second:
 
 | Case                   |   Default | Fingerprint |    JSON | Msgpack |
 | ---------------------- | --------: | ----------: | ------: | ------: |
-| small record           | 1,138,760 |   1,220,001 | 395,051 | 687,043 |
-| nested payload         |   485,669 |     590,166 | 214,371 | 265,124 |
-| collections            |   115,283 |     117,103 |  20,841 |  21,984 |
-| index signatures / 128 |    63,905 |      64,299 |  27,683 |  29,426 |
-| index signatures / 512 |    16,881 |      16,896 |   5,339 |   4,405 |
-| 200-row array payload  |    21,327 |      14,130 |   5,671 |   4,769 |
+| small record           | 1,153,245 |   1,211,218 | 408,812 | 702,051 |
+| nested payload         |   493,924 |     594,944 | 217,904 | 268,354 |
+| collections            |   114,286 |     118,563 |  21,460 |  22,682 |
+| index signatures / 128 |    64,143 |      64,186 |  28,494 |  29,758 |
+| index signatures / 512 |    16,768 |      16,825 |   5,414 |   4,611 |
+| 200-row array payload  |    21,796 |      14,412 |   5,623 |   4,734 |
 
 ## Streaming decode throughput
 
@@ -71,25 +71,25 @@ Average decoded values per second for batched input:
 
 | Case                   |   Default | Fingerprint | Msgpack |  NDJSON |
 | ---------------------- | --------: | ----------: | ------: | ------: |
-| small record           | 4,456,048 |   5,548,628 | 898,346 | 859,955 |
-| nested payload         |   815,628 |   1,045,211 | 283,177 | 310,424 |
-| collections            |   125,527 |     126,655 |  21,691 |  20,743 |
-| index signatures / 128 |    67,711 |      67,884 |  27,862 |  28,125 |
-| index signatures / 512 |    16,665 |      16,502 |   4,078 |   4,961 |
-| 200-row array payload  |    21,338 |      13,808 |   6,474 |   4,925 |
-| 200 single-row frames  | 2,350,690 |   2,679,206 | 842,493 | 934,514 |
+| small record           | 4,426,179 |   5,388,646 | 766,173 | 818,260 |
+| nested payload         |   811,488 |   1,056,372 | 284,944 | 302,941 |
+| collections            |   124,300 |     126,566 |  22,013 |  20,884 |
+| index signatures / 128 |    65,585 |      64,306 |  27,277 |  27,592 |
+| index signatures / 512 |    15,596 |      15,186 |   4,110 |   5,052 |
+| 200-row array payload  |    21,733 |      14,028 |   6,428 |   4,802 |
+| 200 single-row frames  | 2,200,444 |   2,622,259 | 835,329 | 942,351 |
 
 Average decoded values per second for single and first-byte-fragmented input:
 
 | Case                   | Default single | Default fragmented | Fingerprint single | Fingerprint fragmented | NDJSON single | NDJSON fragmented |
 | ---------------------- | -------------: | -----------------: | -----------------: | ---------------------: | ------------: | ----------------: |
-| small record           |      2,640,444 |          2,386,118 |          3,273,254 |              2,847,462 |       137,766 |           140,172 |
-| nested payload         |        691,466 |            669,088 |            895,487 |                867,845 |       109,905 |           108,189 |
-| collections            |        121,150 |            122,453 |            109,056 |                122,698 |        18,981 |            18,843 |
-| index signatures / 128 |         65,398 |             66,875 |             67,436 |                 67,437 |        24,341 |            24,239 |
-| index signatures / 512 |         16,755 |             16,676 |             16,181 |                 16,807 |         4,968 |             5,006 |
-| 200-row array payload  |         21,773 |             21,219 |             14,064 |                 13,930 |         5,288 |             5,180 |
-| 200 single-row frames  |      1,458,546 |          1,327,697 |          1,645,932 |              1,398,527 |       126,531 |           124,882 |
+| small record           |      2,715,454 |          2,381,647 |          3,085,750 |              2,959,535 |       129,391 |           132,853 |
+| nested payload         |        708,896 |            680,227 |            900,923 |                903,819 |       104,936 |           103,205 |
+| collections            |        123,191 |            122,735 |            124,366 |                124,134 |        19,035 |            18,901 |
+| index signatures / 128 |         63,861 |             65,455 |             65,209 |                 64,575 |        24,281 |            23,620 |
+| index signatures / 512 |         16,305 |             15,889 |             16,118 |                 16,071 |         5,128 |             5,320 |
+| 200-row array payload  |         22,120 |             21,915 |             14,346 |                 14,276 |         5,277 |             5,170 |
+| 200 single-row frames  |      1,498,907 |          1,478,629 |          1,736,823 |              1,643,647 |       133,664 |           127,811 |
 
 ## Analysis
 

--- a/packages/effect/src/unstable/encoding/SchemaBinary.ts
+++ b/packages/effect/src/unstable/encoding/SchemaBinary.ts
@@ -199,26 +199,33 @@ function decodeUtf8(
   const len = end - start
   if (len === 0) return ""
   if (len <= UTF8_INLINE_LIMIT) {
-    let ascii = true
-    for (let i = start; i < end; i++) {
-      if (buf[i] > 0x7F) {
-        ascii = false
-        break
-      }
-    }
-    if (ascii) {
-      let out = ""
-      let i = start
-      for (; i + 4 <= end; i += 4) out += String.fromCharCode(buf[i], buf[i + 1], buf[i + 2], buf[i + 3])
-      for (; i < end; i++) out += String.fromCharCode(buf[i])
-      return out
-    }
+    const ascii = decodeAscii(buf, start, end)
+    if (ascii !== undefined) return ascii
   }
   try {
     return utf8DecodeFatal.decode(buf.subarray(start, end))
   } catch {
     invalid("utf-8", undefined, options)
   }
+}
+
+// Eight code units per concatenation, checking their high bits together and
+// giving up on the first non-ASCII byte.
+function decodeAscii(buf: Uint8Array, start: number, end: number): string | undefined {
+  let out = ""
+  let i = start
+  for (; i + 8 <= end; i += 8) {
+    const a = buf[i], b = buf[i + 1], c = buf[i + 2], d = buf[i + 3]
+    const e = buf[i + 4], f = buf[i + 5], g = buf[i + 6], h = buf[i + 7]
+    if ((a | b | c | d | e | f | g | h) > 0x7F) return undefined
+    out += String.fromCharCode(a, b, c, d, e, f, g, h)
+  }
+  for (; i < end; i++) {
+    const c = buf[i]
+    if (c > 0x7F) return undefined
+    out += String.fromCharCode(c)
+  }
+  return out
 }
 
 const OUTPUT_ARENA_SIZE = 8 * 1024
@@ -558,6 +565,13 @@ class Reader {
     this.pos += n
     return out
   }
+  // Decoded bytes outlive the parser's buffer, so they are copied, not viewed.
+  takeCopy(n: number): Uint8Array<ArrayBuffer> {
+    if (this.pos + n > this.end) invalid("complete value", undefined, this.options)
+    const out = this.buf.slice(this.pos, this.pos + n) as Uint8Array<ArrayBuffer>
+    this.pos += n
+    return out
+  }
   // Decode a bounded child value without allocating another reader.
   enter(len: number): number {
     if (this.pos + len > this.end) invalid("complete value", undefined, this.options)
@@ -832,11 +846,19 @@ interface UnionPosition {
   readonly layout: Layout
 }
 
+// A key every variant pins to its own literal, so encoding picks the variant
+// with one lookup instead of scanning.
+interface Discriminator {
+  readonly key: PropertyKey
+  readonly rows: Map<unknown, VariantRow>
+}
+
 interface UnionLayout {
   readonly _: "union"
   readonly ast: SchemaAST.AST
   readonly variants: Array<VariantRow>
   readonly byTag: Map<number, VariantRow>
+  discriminator: Discriminator | undefined
   readonly others: Array<UnionMember>
   readonly byKind: Map<number, Layout>
   // Canonical order used by fingerprint mode.
@@ -1413,6 +1435,7 @@ function compileLayout(root: SchemaAST.AST): CompiledLayout {
       ast,
       variants: [],
       byTag: new Map(),
+      discriminator: undefined,
       others: [],
       byKind: new Map(),
       byPos: []
@@ -1466,6 +1489,7 @@ function compileLayout(root: SchemaAST.AST): CompiledLayout {
     }
     // Probe specific runtime guards before `json`, which matches anything.
     layout.others.sort((a, b) => matchRank(a.layout) - matchRank(b.layout))
+    layout.discriminator = findDiscriminator(layout.variants)
     return layout
   }
 
@@ -2242,8 +2266,7 @@ function arraySlot(layout: ArrayLayout, index: number, count: number): Layout {
   return index >= tailThreshold ? layout.rest[index - tailThreshold + 1] : layout.rest[0]
 }
 
-function encodeArray(ctx: EncodeContext, layout: ArrayLayout, value: unknown, w: Writer) {
-  const arr = value as ReadonlyArray<unknown>
+function encodeArray(ctx: EncodeContext, layout: ArrayLayout, arr: ReadonlyArray<unknown>, w: Writer) {
   const count = arr.length
   if (layout.rest.length === 0 && count > layout.elements.length) {
     issuePath[issuePathLen++] = layout.elements.length
@@ -2319,24 +2342,65 @@ function encodeNumberRun(arr: ReadonlyArray<unknown>, count: number, w: Writer) 
   }
 }
 
+function findDiscriminator(variants: ReadonlyArray<VariantRow>): Discriminator | undefined {
+  if (variants.length < 2 || variants.some((variant) => variant.tuple)) return undefined
+  for (const candidate of variants[0].sentinels) {
+    const rows = new Map<unknown, VariantRow>()
+    for (const variant of variants) {
+      const sentinel = variant.sentinels.find((s) => s.key === candidate.key)
+      // `NaN` matches under `Map`'s key equality but not under `===`.
+      if (sentinel === undefined || rows.has(sentinel.literal) || Number.isNaN(sentinel.literal)) break
+      rows.set(sentinel.literal, variant)
+    }
+    if (rows.size === variants.length) return { key: candidate.key, rows }
+  }
+  return undefined
+}
+
+function hasSentinels(variant: VariantRow, value: Record<PropertyKey, unknown>): boolean {
+  const sentinels = variant.sentinels
+  for (let i = 0; i < sentinels.length; i++) {
+    if (value[sentinels[i].key] !== sentinels[i].literal) return false
+  }
+  return true
+}
+
 function matchesVariant(variant: VariantRow, value: unknown): boolean {
   return variant.tuple
-    ? Array.isArray(value) && variant.sentinels.every((s) => value[s.key as number] === s.literal)
+    ? Array.isArray(value) && hasSentinels(variant, value as unknown as Record<PropertyKey, unknown>)
     : Predicate.isObject(value) && !Array.isArray(value) &&
-      variant.sentinels.every((s) => (value as Record<PropertyKey, unknown>)[s.key] === s.literal)
+      hasSentinels(variant, value as Record<PropertyKey, unknown>)
+}
+
+function encodeVariant(ctx: EncodeContext, variant: VariantRow, value: unknown, w: Writer) {
+  if (ctx.positional) {
+    w.uvarint(variant.position)
+  } else {
+    w.byte(K.variant)
+    w.u32le(variant.tag)
+  }
+  encodeValue(ctx, variant.payload, value, w)
 }
 
 function encodeUnion(ctx: EncodeContext, layout: UnionLayout, value: unknown, w: Writer) {
-  for (const variant of layout.variants) {
-    if (matchesVariant(variant, value)) {
-      if (ctx.positional) {
-        w.uvarint(variant.position)
-      } else {
-        w.byte(K.variant)
-        w.u32le(variant.tag)
+  const discriminator = layout.discriminator
+  if (discriminator !== undefined) {
+    // A miss rules out every variant, because each one pins this key to a
+    // literal no other variant uses.
+    if (Predicate.isObject(value) && !Array.isArray(value)) {
+      const record = value as Record<PropertyKey, unknown>
+      const variant = discriminator.rows.get(record[discriminator.key])
+      if (variant !== undefined && hasSentinels(variant, record)) {
+        encodeVariant(ctx, variant, value, w)
+        return
       }
-      encodeValue(ctx, variant.payload, value, w)
-      return
+    }
+  } else {
+    for (const variant of layout.variants) {
+      if (matchesVariant(variant, value)) {
+        encodeVariant(ctx, variant, value, w)
+        return
+      }
     }
   }
   for (const member of layout.others) {
@@ -2357,14 +2421,19 @@ function encodeValue(ctx: EncodeContext, layout: Layout, value: unknown, w: Writ
       encodeValue(ctx, layout.leaf, value, w)
       return
     case "bool":
+      if (typeof value !== "boolean") encodeFail("a boolean", value, ctx.options)
       w.byte(value === true ? 1 : 0)
       return
     case "null":
+      if (value !== null) encodeFail("null", value, ctx.options)
+      return
     case "undefined":
+      if (value !== undefined) encodeFail("undefined", value, ctx.options)
       return
     case "number":
-      if (isVarintNumber(value)) w.numberVarint(value as number)
-      else w.f64(value as number)
+      if (typeof value !== "number") encodeFail("a number", value, ctx.options)
+      if (isVarintNumber(value)) w.numberVarint(value)
+      else w.f64(value)
       return
     case "int": {
       // `disableChecks` can bypass the integer check used to select this layout.
@@ -2373,24 +2442,32 @@ function encodeValue(ctx: EncodeContext, layout: Layout, value: unknown, w: Writ
       return
     }
     case "string":
-      w.string(value as string)
+      if (typeof value !== "string") encodeFail("a string", value, ctx.options)
+      w.string(value)
       return
     case "symbol":
+      if (typeof value !== "symbol") encodeFail("a symbol", value, ctx.options)
       encodeSymbol(ctx, value, w)
       return
     case "bytes":
-      w.bytes(value as Uint8Array)
+      if (!(value instanceof Uint8Array)) encodeFail("a Uint8Array", value, ctx.options)
+      w.bytes(value)
       return
     case "bigint":
-      w.zigzag(value as bigint)
+      if (typeof value !== "bigint") encodeFail("a bigint", value, ctx.options)
+      w.zigzag(value)
       return
     case "int64": {
+      if (!matchesLayout(layout, value)) {
+        encodeFail(layout.flavor === "date" ? "a Date" : "a DateTime.Utc", value, ctx.options)
+      }
       const millis = layout.flavor === "date" ? (value as Date).getTime() : (value as DateTime.Utc).epochMilliseconds
       if (Number.isNaN(millis)) encodeFail("a valid Date", value, ctx.options)
       w.i64(BigInt(millis))
       return
     }
     case "dateTimeZoned": {
+      if (!matchesLayout(layout, value)) encodeFail("a DateTime.Zoned", value, ctx.options)
       const zoned = value as DateTime.Zoned
       w.i64(BigInt(zoned.epochMilliseconds))
       if (zoned.zone._tag === "Offset") {
@@ -2403,7 +2480,8 @@ function encodeValue(ctx: EncodeContext, layout: Layout, value: unknown, w: Writ
       return
     }
     case "duration": {
-      const duration = (value as Duration.Duration).value
+      if (!Duration.isDuration(value)) encodeFail("a Duration", value, ctx.options)
+      const duration = value.value
       switch (duration._tag) {
         case "Infinity":
           w.byte(1)
@@ -2423,7 +2501,8 @@ function encodeValue(ctx: EncodeContext, layout: Layout, value: unknown, w: Writ
       return
     }
     case "bigDecimal": {
-      const normalized = BigDecimal.normalize(value as BigDecimal.BigDecimal)
+      if (!BigDecimal.isBigDecimal(value)) encodeFail("a BigDecimal", value, ctx.options)
+      const normalized = BigDecimal.normalize(value)
       w.zigzag(normalized.value)
       w.zigzag(BigInt(normalized.scale))
       return
@@ -2443,7 +2522,8 @@ function encodeValue(ctx: EncodeContext, layout: Layout, value: unknown, w: Writ
       return
     }
     case "option": {
-      const option = value as Option.Option<unknown>
+      if (!Option.isOption(value)) encodeFail("an Option", value, ctx.options)
+      const option = value
       if (option._tag === "None") {
         w.byte(0)
       } else {
@@ -2453,7 +2533,8 @@ function encodeValue(ctx: EncodeContext, layout: Layout, value: unknown, w: Writ
       return
     }
     case "result": {
-      const result = value as Result.Result<unknown, unknown>
+      if (!Result.isResult(value)) encodeFail("a Result", value, ctx.options)
+      const result = value
       if (result._tag === "Success") {
         w.byte(0)
         encodeValue(ctx, layout.success, result.success, w)
@@ -2464,7 +2545,8 @@ function encodeValue(ctx: EncodeContext, layout: Layout, value: unknown, w: Writ
       return
     }
     case "exit": {
-      const exit = value as Exit.Exit<unknown, unknown>
+      if (!Exit.isExit(value)) encodeFail("an Exit", value, ctx.options)
+      const exit = value
       if (exit._tag === "Success") {
         w.byte(0)
         encodeValue(ctx, layout.value, exit.value, w)
@@ -2475,7 +2557,8 @@ function encodeValue(ctx: EncodeContext, layout: Layout, value: unknown, w: Writ
       return
     }
     case "cause": {
-      const reasons = (value as Cause.Cause<unknown>).reasons
+      if (!Cause.isCause(value)) encodeFail("a Cause", value, ctx.options)
+      const reasons = value.reasons
       w.uvarint(reasons.length)
       for (const reason of reasons) {
         const mark = w.beginSized()
@@ -2485,15 +2568,18 @@ function encodeValue(ctx: EncodeContext, layout: Layout, value: unknown, w: Writ
       return
     }
     case "causeReason": {
+      if (!Cause.isReason(value)) encodeFail("a Cause.Reason", value, ctx.options)
       encodeReason(ctx, layout, value, w)
       return
     }
     case "struct": {
-      if (ctx.positional) encodeStructPositional(ctx, layout, value as object, w)
-      else encodeStructFields(ctx, layout, value as object, w)
+      if (!Predicate.isObject(value) || Array.isArray(value)) encodeFail("an object", value, ctx.options)
+      if (ctx.positional) encodeStructPositional(ctx, layout, value, w)
+      else encodeStructFields(ctx, layout, value, w)
       return
     }
     case "array": {
+      if (!Array.isArray(value)) encodeFail("an array", value, ctx.options)
       encodeArray(ctx, layout, value, w)
       return
     }
@@ -2507,6 +2593,50 @@ function encodeValue(ctx: EncodeContext, layout: Layout, value: unknown, w: Writ
 
 // Reuse one top-level writer while allowing nested codecs to allocate their own.
 let pooledWriter: Writer | undefined = new Writer()
+
+function writeFrame(ctx: EncodeContext, layout: Layout, value: unknown, mode: Mode, w: Writer) {
+  const mark = w.beginSized()
+  w.byte(mode.envelope)
+  if (mode.positional) {
+    w.u32le(mode.fingerprintLo)
+    w.u32le(mode.fingerprintHi)
+  }
+  encodeValue(ctx, layout, value, w)
+  w.endSized(mark)
+}
+
+function encodeFrames(
+  layout: Layout,
+  values: ReadonlyArray<unknown>,
+  options: SchemaAST.ParseOptions,
+  mode: Mode
+): Uint8Array<ArrayBuffer> {
+  // One context and one writer across the batch, so the caches built for the
+  // first frame serve the rest and the frames need no second pass to join.
+  const ctx: EncodeContext = {
+    options,
+    positional: mode.positional,
+    indexSignatures: undefined,
+    extraShape: undefined,
+    intern: undefined
+  }
+  const w = pooledWriter ?? new Writer()
+  const pooled = w === pooledWriter
+  if (pooled) pooledWriter = undefined
+  w.reset()
+  const savedPathLen = issuePathLen
+  try {
+    for (let i = 0; i < values.length; i++) {
+      issuePathLen = 0
+      writeFrame(ctx, layout, values[i], mode, w)
+    }
+    return w.out()
+  } finally {
+    w.abort()
+    issuePathLen = savedPathLen
+    if (pooled) pooledWriter = w
+  }
+}
 
 function encodeFrame(
   layout: Layout,
@@ -2528,14 +2658,7 @@ function encodeFrame(
   const savedPathLen = issuePathLen
   issuePathLen = 0
   try {
-    const mark = w.beginSized()
-    w.byte(mode.envelope)
-    if (mode.positional) {
-      w.u32le(mode.fingerprintLo)
-      w.u32le(mode.fingerprintHi)
-    }
-    encodeValue(ctx, layout, value, w)
-    w.endSized(mark)
+    writeFrame(ctx, layout, value, mode, w)
     return w.out()
   } finally {
     w.abort()
@@ -3099,7 +3222,7 @@ function decodeValue(layout: Layout, r: Reader): unknown {
     case "symbol":
       return globalThis.Symbol.for(r.readUtf8(r.end - r.pos))
     case "bytes":
-      return r.take(r.remaining).slice()
+      return r.takeCopy(r.end - r.pos)
     case "bigint":
       return r.zigzag()
     case "int64": {
@@ -3326,6 +3449,17 @@ function withTrustedDecode(target: Schema.Constraint, trusted: WeakSet<object>):
   )
 }
 
+// An exact schema is fully validated by the binary layer in both directions, so
+// this target adds nothing. It is not a sound `Schema.is` guard, which is why
+// only {@link toCodecDirect} uses it.
+function passThrough(target: Schema.Constraint): Schema.Constraint {
+  return Schema.declareConstructor<unknown>()(
+    [Schema.make(SchemaAST.toType(target.ast))],
+    () => Effect.succeed,
+    { identifier: "binary value" }
+  )
+}
+
 // Skip the cycle walk once for structurally decoded values.
 function withCycleGuard(target: Schema.Constraint): Schema.Constraint {
   const type = Schema.make(SchemaAST.toType(target.ast))
@@ -3424,6 +3558,28 @@ export function toCodec<S extends Schema.Constraint>(schema: S, options?: Option
 }
 
 /**
+ * Derives the {@link toCodec} codec without the schema pass around the binary
+ * layer.
+ *
+ * Only schemas the binary layer already validates on its own take the direct
+ * path; anything else falls back to {@link toCodec}. A direct codec encodes and
+ * decodes the same values as {@link toCodec} but is not a sound `Schema.is`
+ * guard, so it is only for callers that never guard on it.
+ *
+ * @internal
+ */
+export function toCodecDirect<S extends Schema.Constraint>(schema: S, options?: Options): toCodec<S> {
+  const { exact, layout, target } = compileTarget(schema)
+  if (!exact) return toCodec(schema, options)
+  return (Schema.Uint8Array as Schema.instanceOf<Uint8Array<ArrayBuffer>>).pipe(
+    Schema.decodeTo(
+      passThrough(target),
+      makeTransformation(layout, compileMode(layout, options?.fingerprint), undefined)
+    )
+  ) as unknown as toCodec<S>
+}
+
+/**
  * Encodes one frame without the schema pass {@link toCodec} wraps around it.
  *
  * Only schemas the binary layer already validates on its own take the direct
@@ -3449,6 +3605,45 @@ export function encodeUnknownSync<S extends Schema.Constraint>(
   return (value) => {
     try {
       return encodeFrame(layout, value, parseOptions, mode)
+    } catch (e) {
+      throw e instanceof IssueError ? new Schema.SchemaError(e.issue) : e
+    }
+  }
+}
+
+/**
+ * Encodes concatenated frames in one writer pass, so a batch costs no more
+ * allocations than a single frame.
+ *
+ * Shares {@link encodeUnknownSync}'s direct path and its fallback.
+ *
+ * @internal
+ */
+export function encodeManyUnknownSync<S extends Schema.Constraint>(
+  schema: S,
+  options?: SchemaAST.ParseOptions & Options
+): (values: ReadonlyArray<unknown>) => Uint8Array<ArrayBuffer> {
+  const { exact, layout } = compileTarget(schema)
+  if (!exact) {
+    const encode = encodeUnknownSync(schema, options)
+    return (values) => {
+      const frames = values.map(encode)
+      let length = 0
+      for (const frame of frames) length += frame.length
+      const out = new Uint8Array(length)
+      let offset = 0
+      for (const frame of frames) {
+        out.set(frame, offset)
+        offset += frame.length
+      }
+      return out
+    }
+  }
+  const mode = compileMode(layout, options?.fingerprint)
+  const parseOptions: SchemaAST.ParseOptions = options ?? EMPTY_PARSE_OPTIONS
+  return (values) => {
+    try {
+      return encodeFrames(layout, values, parseOptions, mode)
     } catch (e) {
       throw e instanceof IssueError ? new Schema.SchemaError(e.issue) : e
     }

--- a/packages/effect/src/unstable/encoding/SchemaBinary.ts
+++ b/packages/effect/src/unstable/encoding/SchemaBinary.ts
@@ -2357,10 +2357,12 @@ function findDiscriminator(variants: ReadonlyArray<VariantRow>): Discriminator |
   return undefined
 }
 
+// An inherited sentinel does not select a variant, matching the schema pass.
 function hasSentinels(variant: VariantRow, value: Record<PropertyKey, unknown>): boolean {
   const sentinels = variant.sentinels
   for (let i = 0; i < sentinels.length; i++) {
-    if (value[sentinels[i].key] !== sentinels[i].literal) return false
+    const { key, literal } = sentinels[i]
+    if (value[key] !== literal || !Object.hasOwn(value, key)) return false
   }
   return true
 }
@@ -3450,12 +3452,16 @@ function withTrustedDecode(target: Schema.Constraint, trusted: WeakSet<object>):
 }
 
 // An exact schema is fully validated by the binary layer in both directions, so
-// this target adds nothing. It is not a sound `Schema.is` guard, which is why
-// only {@link toCodecDirect} uses it.
+// this target adds nothing, except under `onExcessProperty: "error"`: the binary
+// layer drops unknown keys instead of reporting them. It is not a sound
+// `Schema.is` guard, which is why only {@link toCodecDirect} uses it.
 function passThrough(target: Schema.Constraint): Schema.Constraint {
+  const type = Schema.make(SchemaAST.toType(target.ast))
+  const decodeType = SchemaParser.decodeUnknownEffect(type as Schema.ConstraintDecoder<unknown>)
   return Schema.declareConstructor<unknown>()(
-    [Schema.make(SchemaAST.toType(target.ast))],
-    () => Effect.succeed,
+    [type],
+    () => (input, _ast, options) =>
+      options.onExcessProperty === "error" ? decodeType(input, options) : Effect.succeed(input),
     { identifier: "binary value" }
   )
 }

--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -598,10 +598,13 @@ const makeSchemaBinary = (options?: {
 }): RpcSerialization["Service"] => {
   const maxFrameSize = options?.maxFrameSize ?? defaultSchemaBinaryMaxFrameSize
   const encodeEnvelope = SchemaBinary.encodeUnknownSync(RpcMessage.EncodedSchema, { fingerprint: true })
+  const encodeEnvelopes = SchemaBinary.encodeManyUnknownSync(RpcMessage.EncodedSchema, { fingerprint: true })
   return RpcSerialization.of({
     contentType: "application/vnd.effect.rpc+schema-binary",
     includesFraming: true,
-    codecFor: SchemaBinary.toCodec as CodecFor,
+    // The hole codec is only ever encoded and decoded, never used as a type
+    // guard, so it can skip the schema pass the binary layer already covers.
+    codecFor: SchemaBinary.toCodecDirect as CodecFor,
     makeUnsafe: () => {
       const parser = SchemaBinary.parser(RpcMessage.EncodedSchema, { fingerprint: true, maxFrameSize })
       const encoder = new TextEncoder()
@@ -612,20 +615,7 @@ const makeSchemaBinary = (options?: {
             return encodeEnvelope(response)
           }
           if (response.length === 0) return undefined
-          const frames = new Array<Uint8Array>(response.length)
-          let length = 0
-          for (let i = 0; i < response.length; i++) {
-            const frame = encodeEnvelope(response[i])
-            frames[i] = frame
-            length += frame.length
-          }
-          const encoded = new Uint8Array(length)
-          let offset = 0
-          for (let i = 0; i < frames.length; i++) {
-            encoded.set(frames[i], offset)
-            offset += frames[i].length
-          }
-          return encoded
+          return encodeEnvelopes(response)
         }
       }
     }

--- a/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
+++ b/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
@@ -1989,6 +1989,85 @@ describe("SchemaBinary", () => {
     })
   })
 
+  describe("direct codec", () => {
+    const Person = Schema.Struct({ name: Schema.String, age: Schema.Number })
+
+    it("matches toCodec on the wire and round-trips", () => {
+      const direct = SchemaBinary.toCodecDirect(Person)
+      const value = { name: "Ada", age: 36 }
+      const bytes = Schema.encodeUnknownSync(direct)(value)
+      assert.deepStrictEqual(Array.from(bytes), Array.from(encode(Person, value)))
+      assert.deepStrictEqual(Schema.decodeUnknownSync(direct)(bytes), value)
+    })
+
+    it("still rejects invalid input, through the binary layer", () => {
+      const direct = SchemaBinary.toCodecDirect(Person)
+      assert.include(schemaError(() => Schema.encodeUnknownSync(direct)({ name: "Ada", age: "old" })).message, "age")
+      assert.include(schemaError(() => Schema.encodeUnknownSync(direct)({ name: "Ada" })).message, "age")
+      assert.include(schemaError(() => Schema.encodeUnknownSync(direct)("Ada")).message, "Expected an object")
+    })
+
+    it("rejects a wrong runtime type for every leaf an exact schema can reach", () => {
+      const cases: ReadonlyArray<readonly [Schema.Top, unknown, string]> = [
+        [Schema.String, 1, "a string"],
+        [Schema.Number, "1", "a number"],
+        [Schema.Boolean, 1, "a boolean"],
+        [Schema.BigInt, 1, "a bigint"],
+        [Schema.Symbol, "s", "a symbol"],
+        [Schema.Null, 1, "null"],
+        [Schema.Undefined, 1, "undefined"],
+        [Schema.Uint8Array, [1, 2], "a Uint8Array"],
+        [Schema.Date, 0, "a Date"],
+        [Schema.Array(Schema.String), "ab", "an array"],
+        [Schema.Struct({ a: Schema.String }), "a", "an object"]
+      ]
+      for (const [schema, value, expected] of cases) {
+        const direct = SchemaBinary.toCodecDirect(schema as Schema.Codec<unknown>)
+        assert.include(
+          schemaError(() => Schema.encodeUnknownSync(direct)(value)).message,
+          `Expected ${expected}`,
+          `${expected} for ${globalThis.String(value)}`
+        )
+      }
+    })
+
+    it("falls back to toCodec when the binary layer cannot prove the schema", () => {
+      const NonNegative = Schema.Number.check(Schema.isGreaterThanOrEqualTo(0))
+      const direct = SchemaBinary.toCodecDirect(NonNegative)
+      assert.isTrue(Schema.is(direct)(1))
+      assert.isFalse(Schema.is(direct)(-1))
+      assert.include(schemaError(() => Schema.encodeUnknownSync(direct)(-1)).message, "greater than or equal to 0")
+    })
+  })
+
+  describe("encodeManyUnknownSync", () => {
+    const Person = Schema.Struct({ name: Schema.String, age: Schema.Number })
+    const people = [{ name: "Ada", age: 36 }, { name: "Grace", age: 45 }]
+
+    it("writes the same bytes as concatenated single frames", () => {
+      const many = SchemaBinary.encodeManyUnknownSync(Person, { fingerprint: true })
+      assert.deepStrictEqual(
+        Array.from(many(people)),
+        Array.from(concat(...people.map((person) => encodeFingerprint(Person, person))))
+      )
+      assert.deepStrictEqual(SchemaBinary.parser(Person, { fingerprint: true }).feedSync(many(people)), people)
+      assert.deepStrictEqual(Array.from(many([])), [])
+    })
+
+    it("reports the failing frame and takes the fallback path for checked schemas", () => {
+      const many = SchemaBinary.encodeManyUnknownSync(Person)
+      assert.include(schemaError(() => many([people[0], { name: "Grace" }])).message, "age")
+
+      const Checked = Schema.Struct({ age: Schema.Number.check(Schema.isGreaterThanOrEqualTo(0)) })
+      const checked = SchemaBinary.encodeManyUnknownSync(Checked)
+      assert.deepStrictEqual(
+        Array.from(checked([{ age: 1 }, { age: 2 }])),
+        Array.from(concat(encode(Checked, { age: 1 }), encode(Checked, { age: 2 })))
+      )
+      assert.include(schemaError(() => checked([{ age: -1 }])).message, "greater than or equal to 0")
+    })
+  })
+
   describe("fingerprint mode parser", () => {
     const Person = Schema.Struct({ name: Schema.String, age: Schema.Number })
     const first = { name: "Ada", age: 36 }

--- a/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
+++ b/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
@@ -2031,6 +2031,31 @@ describe("SchemaBinary", () => {
       }
     })
 
+    it("rejects an inherited discriminator, like the schema pass", () => {
+      const schema = Schema.Union([
+        Schema.Struct({ _tag: Schema.Literal("A"), value: Schema.Number }),
+        Schema.Struct({ _tag: Schema.Literal("B"), value: Schema.String })
+      ])
+      const inherited = Object.assign(Object.create({ _tag: "A" }), { value: 1 })
+      for (const options of [undefined, { fingerprint: true }]) {
+        const encodeDirect = Schema.encodeUnknownSync(SchemaBinary.toCodecDirect(schema, options))
+        assert.isDefined(schemaError(() => encodeDirect(inherited)))
+      }
+    })
+
+    it("reports excess properties when the call site asks for it", () => {
+      const direct = SchemaBinary.toCodecDirect(Person)
+      const excess = { name: "Ada", age: 36, extra: true }
+      assert.deepStrictEqual(
+        Array.from(Schema.encodeUnknownSync(direct)(excess)),
+        Array.from(encode(Person, { name: "Ada", age: 36 }))
+      )
+      assert.include(
+        schemaError(() => Schema.encodeUnknownSync(direct, { onExcessProperty: "error" })(excess)).message,
+        "extra"
+      )
+    })
+
     it("falls back to toCodec when the binary layer cannot prove the schema", () => {
       const NonNegative = Schema.Number.check(Schema.isGreaterThanOrEqualTo(0))
       const direct = SchemaBinary.toCodecDirect(NonNegative)


### PR DESCRIPTION
## Summary

`RpcSerialization`'s `codecFor` was `SchemaBinary.toCodec`, which runs a full schema pass over every RPC payload on **encode**, on top of the binary encoder. `toCodec` already skips that pass on decode for `isExact` schemas via the `trusted` weak set, but the encode side has no equivalent and cannot get one: a declaration's `run` fires in both directions, `checks` and `encodingChecks` both run regardless of `flip`, and `Schema.is` soundness on `toCodec` is pinned by a test.

- add an internal `SchemaBinary.toCodecDirect` that, for `isExact` schemas only, builds the same codec with a pass-through target, so neither direction pays the schema pass; anything else falls back to `toCodec` with its checks and transformations intact
- point the SchemaBinary `codecFor` at it, since the hole codec is only ever encoded and decoded and never used as a type guard
- type-check leaf values in `encodeValue`, which is what makes that direct path sound (see below)
- add an internal `SchemaBinary.encodeManyUnknownSync` that writes a batch of frames in one writer pass, so the array branch of the SchemaBinary RPC encoder drops its frame array and its joining copy
- compile a discriminator map for unions whose variants pin a shared key to distinct literals, so encoding picks a variant with one lookup instead of scanning
- decode UTF-8 eight code units per concatenation, checking their high bits together, in one pass instead of scan-then-build
- copy decoded bytes once instead of `subarray().slice()`

The wire format is unchanged; every payload size in `benchmark/schema/SchemaBinary.md` is byte-identical.

## The encode-side validation gap

Writing the first `toCodecDirect` test surfaced a real bug. `encodeValue` did not check leaf runtime types:

- `Schema.Struct({ age: Schema.Number })` with `{ age: "old" }` reached `w.f64("old")`, which wrote NaN
- `w.string(123)` read `123.length`, got `undefined`, and silently wrote an empty string
- `case "bool"` coerced anything other than `true` to `0`
- `encodeArray` read `.length` off non-arrays

Every case that assumed a runtime type had the same hole, so the existing internal `encodeUnknownSync` comment — "Only schemas the binary layer already validates on its own take the direct path" — was not true on the encode side, and the RPC envelope encoder already depended on it. Each such case now guards with the predicate `matchesLayout` already uses. This costs 3–6% on encode and is not optional for the direct codec to be sound.

## Benchmarks

`benchmark/rpc/RpcSerialization.ts`, median of three runs, Linux x86_64 (AMD EPYC 4344P), Node 26.7.0.

| Case | Direction | Before | After | Change | vs Msgpack before | after |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| request / nested search payload | encode | 394,215 | 527,820 | 1.34x | 1.14x | 1.51x |
| request / nested search payload | decode | 395,210 | 467,365 | 1.18x | 1.06x | 1.24x |
| exit / 12-user success | encode | 115,301 | 115,250 | 1.00x | 1.34x | 1.31x |
| exit / 12-user success | decode | 116,731 | 128,662 | 1.10x | 1.21x | 1.32x |
| chunk / 32 events | encode | 36,613 | 64,257 | 1.76x | 1.83x | 3.19x |
| chunk / 32 events | decode | 55,212 | 60,339 | 1.09x | 2.21x | 2.38x |

`exit` encode is flat. `Rpc.exitSchema` contains `Schema.Defect()`, which has a real transformation, so it is never `isExact` and cannot take the direct path — it pays for the new leaf guards without the benefit. It remains 1.31x Msgpack. Making the `Exit.Success` branch trusted independently of the defect branch looks worth ~1.7x encode and ~1.8x decode on that case, but it needs branch-sensitive exactness and is left for a follow-up.

Batched envelope encoding, same machine: 1.28x at four frames, 1.42x at 16, 1.28x at 64.

`benchmark/schema/SchemaBinary.md` is refreshed from one full run on this head. The standalone codec gains too: one-shot decode 3–11% faster, streaming decode 3–41% faster, encode flat.

## Verification

- `nix develop -c pnpm lint`
- `nix develop -c pnpm check`
- `nix develop -c pnpm circular`
- `nix develop -c pnpm vitest run packages/effect/test` (8,785 passed)
- `nix develop -c pnpm vitest run --project @effect/platform-node --project @effect/platform`
- `nix develop -c pnpm --dir packages/effect exec node benchmark/rpc/RpcSerialization.ts`
- `nix develop -c pnpm --dir packages/effect exec node benchmark/schema/SchemaBinary.ts`

New tests cover the direct codec's wire equality with `toCodec`, its fallback for non-exact schemas, the batch encoder against concatenated single frames, and a wrong runtime type for every leaf an exact schema can reach.

Codex Engineer reviewed the first commit against `toCodec` and found two behavioural breaks, both fixed in the second commit and covered by tests: a union variant could be selected from an inherited discriminator, and a call-site `onExcessProperty: "error"` was ignored on the direct path. Its independent benchmark run reproduced these numbers within a percent, and it confirmed `Suspend` cannot reach the direct path, so `withCycleGuard` is never skipped.

Closes EFF-822
