### PR TITLE
Improve Pool performance

### DIFF
--- a/.changeset/eff-825-pool-performance.md
+++ b/.changeset/eff-825-pool-performance.md
@@ -1,0 +1,16 @@
+---
+"effect": patch
+---
+
+Improve Pool performance with a synchronous fast path for get and release.
+
+`Pool.get` now leases an available item in a single step, without semaphore or
+latch round-trips, and release finalizers are pre-allocated per item. The pool
+tracks usage incrementally instead of scanning every item, keeps available
+items in an intrusive FIFO list, and no longer forks background fibers for
+no-op strategies or pools with `min: 0`.
+
+The `Pool.State` and `Pool.PoolItem` interfaces changed to support this:
+`State` loses `semaphore`, `availableLatch` and the numeric `waiters` counter,
+gains `usage`, `availableHead`/`availableTail` and a `waiters` set of wake-up
+callbacks. `PoolItem` gains intrusive-list and release fields.

--- a/.changeset/eff-825-pool-performance.md
+++ b/.changeset/eff-825-pool-performance.md
@@ -7,8 +7,8 @@ Improve Pool performance with a synchronous fast path for get and release.
 `Pool.get` now leases an available item in a single step, without semaphore or
 latch round-trips, and release finalizers are pre-allocated per item. The pool
 tracks usage incrementally instead of scanning every item, keeps available
-items in an intrusive FIFO list, and no longer forks background fibers for
-no-op strategies or pools with `min: 0`.
+items in an intrusive FIFO list, allocates items with a fused scope step, and
+no longer forks background fibers for no-op strategies or pools with `min: 0`.
 
 The `Pool.State` and `Pool.PoolItem` interfaces changed to support this:
 `State` loses `semaphore`, `availableLatch` and the numeric `waiters` counter,

--- a/.changeset/eff-825-pool-performance.md
+++ b/.changeset/eff-825-pool-performance.md
@@ -2,15 +2,7 @@
 "effect": patch
 ---
 
-Improve Pool performance with a synchronous fast path for get and release.
-
-`Pool.get` now leases an available item in a single step, without semaphore or
-latch round-trips, and release finalizers are pre-allocated per item. The pool
-tracks usage incrementally instead of scanning every item, keeps available
-items in an intrusive FIFO list, allocates items with a fused scope step, and
-no longer forks background fibers for no-op strategies or pools with `min: 0`.
-
-The `Pool.State` and `Pool.PoolItem` interfaces changed to support this:
-`State` loses `semaphore`, `availableLatch` and the numeric `waiters` counter,
-gains `usage`, `availableHead`/`availableTail` and a `waiters` set of wake-up
-callbacks. `PoolItem` gains intrusive-list and release fields.
+Improve Pool acquisition and release performance. Pool now tracks usage
+incrementally, stores available items in an intrusive FIFO, and skips work for
+fixed and empty pools. This changes the public `Pool.State` and `Pool.PoolItem`
+interfaces.

--- a/.changeset/eff-825-pool-use.md
+++ b/.changeset/eff-825-pool-use.md
@@ -1,0 +1,11 @@
+---
+"effect": patch
+---
+
+Add `Pool.use` for borrowing a pool item without a `Scope`.
+
+`Pool.use(pool, f)` leases an item just for the duration of `f` and returns it
+to the pool when `f` completes, fails, or is interrupted. It skips the scope
+creation and finalizer bookkeeping that `Effect.scoped(Pool.get(pool))`
+requires, making it the fastest way to run a single operation with a pooled
+item.

--- a/.changeset/eff-825-pool-use.md
+++ b/.changeset/eff-825-pool-use.md
@@ -2,10 +2,5 @@
 "effect": patch
 ---
 
-Add `Pool.use` for borrowing a pool item without a `Scope`.
-
-`Pool.use(pool, f)` leases an item just for the duration of `f` and returns it
-to the pool when `f` completes, fails, or is interrupted. It skips the scope
-creation and finalizer bookkeeping that `Effect.scoped(Pool.get(pool))`
-requires, making it the fastest way to run a single operation with a pooled
-item.
+Add `Pool.use`, which borrows an item while an effect runs and returns it on any
+exit. Unlike `Effect.scoped(Pool.get(pool))`, it does not require a `Scope`.

--- a/.changeset/eff-825-scope-single-finalizer.md
+++ b/.changeset/eff-825-scope-single-finalizer.md
@@ -1,0 +1,14 @@
+---
+"effect": patch
+---
+
+Store a single Scope finalizer inline instead of allocating a Map.
+
+Most scopes only ever hold one finalizer (for example `Effect.scoped` around a
+resource acquisition), so `Scope.State.Open` now keeps the first finalizer in
+dedicated fields and only materializes the `finalizers` map when a second one
+is added. This removes a Map allocation from every scoped acquisition and
+speeds up `Pool.get` by a further ~13%.
+
+`Scope.State.Open` changed shape: `finalizers` is now `Map | undefined`, and
+the new `finalizerKey` / `finalizer` fields hold a sole registered finalizer.

--- a/.changeset/eff-825-scope-single-finalizer.md
+++ b/.changeset/eff-825-scope-single-finalizer.md
@@ -2,13 +2,6 @@
 "effect": patch
 ---
 
-Store a single Scope finalizer inline instead of allocating a Map.
-
-Most scopes only ever hold one finalizer (for example `Effect.scoped` around a
-resource acquisition), so `Scope.State.Open` now keeps the first finalizer in
-dedicated fields and only materializes the `finalizers` map when a second one
-is added. This removes a Map allocation from every scoped acquisition and
-speeds up `Pool.get` by a further ~13%.
-
-`Scope.State.Open` changed shape: `finalizers` is now `Map | undefined`, and
-the new `finalizerKey` / `finalizer` fields hold a sole registered finalizer.
+Reduce scoped resource acquisition allocations by storing the first Scope
+finalizer inline and allocating a Map only when a second is added. This changes
+the public `Scope.State.Open` interface.

--- a/packages/effect/benchmark/Pool.ts
+++ b/packages/effect/benchmark/Pool.ts
@@ -58,11 +58,15 @@ const invalidateAndReplace = Effect.scoped(
 
 const bench = new Bench()
 
+const useItem = (item: number) => Effect.succeed(item)
+
 bench
   .add("make fixed pool (10 items)", () => Effect.runPromise(makeFixed))
   .add("make TTL pool (10 items)", () => Effect.runPromise(makeWithTTL))
   .add("get and release (fixed pool)", () => Effect.runPromise(Effect.scoped(Pool.get(fixedPool))))
   .add("get and release (TTL pool)", () => Effect.runPromise(Effect.scoped(Pool.get(ttlPool))))
+  .add("use (fixed pool)", () => Effect.runPromise(Pool.use(fixedPool, useItem)))
+  .add("use (TTL pool)", () => Effect.runPromise(Pool.use(ttlPool, useItem)))
   .add("get and release (10 concurrent)", () => Effect.runPromise(Effect.scoped(getAll(fixedPool))))
   .add("invalidate and replace", () => Effect.runPromise(invalidateAndReplace))
 

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -20,7 +20,7 @@ import * as Fiber from "./Fiber.ts"
 import type * as Filter from "./Filter.ts"
 import type { LazyArg } from "./Function.ts"
 import { constant, constTrue, constVoid, dual, identity as identity_ } from "./Function.ts"
-import { ClockRef, endSpan } from "./internal/effect.ts"
+import { ClockRef, endSpan, scopeFinalizerCountUnsafe } from "./internal/effect.ts"
 import { addSpanStackTrace } from "./internal/tracer.ts"
 import * as Iterable from "./Iterable.ts"
 import * as Latch from "./Latch.ts"
@@ -2500,7 +2500,7 @@ const flatMapSequential = <
       const catchHalt = Pull.catchDone((_) => {
         childPull = undefined
         // we can reuse the scope if the only finalizer is the "fork" one
-        if (childScope!.state._tag === "Open" && childScope!.state.finalizers.size === 1) {
+        if (childScope!.state._tag === "Open" && scopeFinalizerCountUnsafe(childScope!) === 1) {
           return makePull
         }
         const close = Scope.close(childScope!, Exit.void)

--- a/packages/effect/src/Pool.ts
+++ b/packages/effect/src/Pool.ts
@@ -100,8 +100,8 @@ export interface Config<A, E> {
  * inspection and implementation support; user code should prefer the
  * high-level pool operations.
  *
- * `usage` counts fibers currently getting or holding an item plus the total
- * reference count of leased items, and is what drives the pool's target size.
+ * `usage` counts fibers waiting for or currently holding an item, and is what
+ * drives the pool's target size.
  * `waiters` holds the wake-up callbacks of fibers waiting for an item to
  * become available.
  *

--- a/packages/effect/src/Pool.ts
+++ b/packages/effect/src/Pool.ts
@@ -16,9 +16,10 @@ import * as Duration from "./Duration.ts"
 import * as Effect from "./Effect.ts"
 import type * as Exit from "./Exit.ts"
 import * as Fiber from "./Fiber.ts"
-import { dual, identity } from "./Function.ts"
+import { constant, dual, identity } from "./Function.ts"
+import * as core from "./internal/core.ts"
+import * as internal from "./internal/effect.ts"
 import * as Iterable from "./Iterable.ts"
-import * as Latch from "./Latch.ts"
 import { type Pipeable, pipeArguments } from "./Pipeable.ts"
 import { hasProperty } from "./Predicate.ts"
 import * as Queue from "./Queue.ts"
@@ -94,9 +95,14 @@ export interface Config<A, E> {
  * **Details**
  *
  * This state tracks the pool scope, active and available items, invalidated
- * items, semaphores, waiters, and shutdown status. It is exposed for
+ * items, current usage, waiters, and shutdown status. It is exposed for
  * inspection and implementation support; user code should prefer the
  * high-level pool operations.
+ *
+ * `usage` counts fibers currently getting or holding an item plus the total
+ * reference count of leased items, and is what drives the pool's target size.
+ * `waiters` holds the wake-up callbacks of fibers waiting for an item to
+ * become available.
  *
  * @see {@link Pool} for the pool value exposing this state
  * @see {@link PoolItem} for the entries stored in the runtime item sets
@@ -109,13 +115,13 @@ export interface Config<A, E> {
 export interface State<A, E> {
   readonly scope: Scope.Scope
   isShuttingDown: boolean
-  readonly semaphore: Semaphore.Semaphore
+  usage: number
   readonly resizeSemaphore: Semaphore.Semaphore
   readonly items: Set<PoolItem<A, E>>
-  readonly available: Set<PoolItem<A, E>>
-  readonly availableLatch: Latch.Latch
+  availableHead: PoolItem<A, E> | undefined
+  availableTail: PoolItem<A, E> | undefined
   readonly invalidated: Set<PoolItem<A, E>>
-  waiters: number
+  readonly waiters: Set<() => void>
 }
 
 /**
@@ -144,6 +150,10 @@ export interface PoolItem<A, E> {
   finalizer: Effect.Effect<void>
   refCount: number
   disableReclaim: boolean
+  isAvailable: boolean
+  availablePrevious: PoolItem<A, E> | undefined
+  availableNext: PoolItem<A, E> | undefined
+  release: (exit: Exit.Exit<any, any>) => Effect.Effect<void>
 }
 
 /**
@@ -223,7 +233,7 @@ export const make = <A, E, R>(options: {
   readonly concurrency?: number | undefined
   readonly targetUtilization?: number | undefined
 }): Effect.Effect<Pool<A, E>, never, R | Scope.Scope> =>
-  makeWithStrategy({ ...options, min: options.size, max: options.size, strategy: strategyNoop() })
+  makeWithStrategy({ ...options, min: options.size, max: options.size, strategy: strategyNoop })
 
 /**
  * Creates a scoped pool with minimum and maximum sizes and a time-to-live
@@ -348,13 +358,13 @@ export const makeWithStrategy = <A, E, R>(options: {
     const state: State<A, E> = {
       scope,
       isShuttingDown: false,
-      semaphore: Semaphore.makeUnsafe(concurrency * options.max),
+      usage: 0,
       resizeSemaphore: Semaphore.makeUnsafe(1),
       items: new Set(),
-      available: new Set(),
-      availableLatch: Latch.makeUnsafe(false),
+      availableHead: undefined,
+      availableTail: undefined,
       invalidated: new Set(),
-      waiters: 0
+      waiters: new Set()
     }
     const self: Pool<A, E> = {
       [TypeId]: TypeId,
@@ -365,14 +375,18 @@ export const makeWithStrategy = <A, E, R>(options: {
       }
     }
     yield* Scope.addFinalizer(scope, shutdown(self))
-    yield* Effect.tap(
-      Effect.forkDetach(restore(resize(self))),
-      (fiber) => Scope.addFinalizer(scope, Fiber.interrupt(fiber))
-    )
-    yield* Effect.tap(
-      Effect.forkDetach(restore(options.strategy.run(self))),
-      (fiber) => Scope.addFinalizer(scope, Fiber.interrupt(fiber))
-    )
+    if (config.minSize > 0) {
+      yield* Effect.tap(
+        Effect.forkDetach(restore(resize(self))),
+        (fiber) => Scope.addFinalizer(scope, Fiber.interrupt(fiber))
+      )
+    }
+    if (options.strategy !== strategyNoop) {
+      yield* Effect.tap(
+        Effect.forkDetach(restore(options.strategy.run(self))),
+        (fiber) => Scope.addFinalizer(scope, Fiber.interrupt(fiber))
+      )
+    }
     return self
   }))
 
@@ -388,13 +402,17 @@ const shutdown = Effect.fnUntraced(function*<A, E>(self: Pool<A, E>) {
       yield* semaphore.take(1)
     } else {
       self.state.items.delete(item)
-      self.state.available.delete(item)
+      removeAvailable(self, item)
       self.state.invalidated.delete(item)
       yield* item.finalizer
     }
   }
   yield* semaphore.releaseAll
-  self.state.availableLatch.openUnsafe()
+  if (self.state.waiters.size > 0) {
+    const waiters = Array.from(self.state.waiters)
+    self.state.waiters.clear()
+    for (const notify of waiters) notify()
+  }
   yield* semaphore.take(size)
 })
 
@@ -421,73 +439,167 @@ const shutdown = Effect.fnUntraced(function*<A, E>(self: Pool<A, E>) {
  * @since 2.0.0
  */
 export const get = <A, E>(self: Pool<A, E>): Effect.Effect<A, E, Scope.Scope> =>
-  Effect.suspend(() => {
-    if (self.state.isShuttingDown) {
-      return Effect.interrupt
+  core.withFiber((fiber) => {
+    const state = self.state
+    if (state.isShuttingDown) return internal.interrupt
+    if (state.availableHead !== undefined) {
+      state.usage++
+      if (targetSize(self) <= activeSize(self)) {
+        return leaseItem(self, state.availableHead, fiber)
+      }
+      state.usage--
     }
-    return Effect.flatMap(getPoolItem(self), (item) => item.exit)
+    return getSlow(self)
   })
 
-const getPoolItem = <A, E>(self: Pool<A, E>): Effect.Effect<PoolItem<A, E>, never, Scope.Scope> =>
-  Effect.uninterruptibleMask((restore) =>
-    restore(self.state.semaphore.take(1)).pipe(
-      Effect.flatMap(() => Effect.scope),
-      Effect.flatMap((scope) =>
-        getPoolItemInner(self).pipe(
-          Effect.ensuring(Effect.sync(() => self.state.waiters--)),
-          Effect.tap((item) => {
-            if (item.exit._tag === "Failure") {
-              self.state.items.delete(item)
-              self.state.invalidated.delete(item)
-              self.state.available.delete(item)
-              return self.state.semaphore.release(1)
-            }
-            item.refCount++
-            self.state.available.delete(item)
-            if (item.refCount < self.config.concurrency) {
-              self.state.available.add(item)
-            }
-            return Scope.addFinalizerExit(scope, () =>
-              Effect.flatMap(
-                Effect.suspend(() => {
-                  item.refCount--
-                  if (self.state.invalidated.has(item)) {
-                    return invalidatePoolItem(self, item)
-                  }
-                  self.state.available.add(item)
-                  return Effect.void
-                }),
-                () => self.state.semaphore.release(1)
-              ))
-          }),
-          Effect.onInterrupt(() => self.state.semaphore.release(1))
-        )
-      )
+const getSlow = <A, E>(self: Pool<A, E>): Effect.Effect<A, E, Scope.Scope> =>
+  internal.uninterruptibleMask((restore) => {
+    const state = self.state
+    state.usage++
+    const wait: Effect.Effect<A, E, Scope.Scope> = internal.flatMap(
+      internal.onInterrupt(
+        restore(waitForItem(self)),
+        () =>
+          internal.sync(() => {
+            state.usage--
+          })
+      ),
+      () => loop
     )
-  )
-
-const getPoolItemInner = Effect.fnUntraced(function*<A, E>(
-  self: Pool<A, E>
-) {
-  self.state.waiters++
-  if (self.state.isShuttingDown) {
-    return yield* Effect.interrupt
-  } else if (targetSize(self) > activeSize(self)) {
-    while (true) {
-      yield* self.state.resizeSemaphore.withPermitsIfAvailable(1)(
-        Effect.forkIn(Effect.interruptible(resize(self)), self.state.scope)
-      )
-      if (self.state.isShuttingDown) {
-        return yield* Effect.interrupt
-      } else if (self.state.available.size > 0) {
-        return Iterable.headUnsafe(self.state.available)
+    const step: Effect.Effect<A, E, Scope.Scope> = core.withFiber((fiber) => {
+      if (state.isShuttingDown) {
+        state.usage--
+        return internal.interrupt
       }
-      self.state.availableLatch.closeUnsafe()
-      yield* self.state.availableLatch.await
-    }
+      if (state.availableHead !== undefined) {
+        return leaseItem(self, state.availableHead, fiber)
+      }
+      return wait
+    })
+    const loop: Effect.Effect<A, E, Scope.Scope> = internal.suspend(() => {
+      if (state.isShuttingDown) {
+        state.usage--
+        return internal.interrupt
+      }
+      return targetSize(self) > activeSize(self)
+        ? internal.flatMap(
+          state.resizeSemaphore.withPermitsIfAvailable(1)(
+            Effect.forkIn(Effect.interruptible(resize(self)), state.scope)
+          ),
+          () => step
+        )
+        : step
+    })
+    return loop
+  })
+
+const leaseItem = <A, E>(
+  self: Pool<A, E>,
+  item: PoolItem<A, E>,
+  fiber: Fiber.Fiber<unknown, unknown>
+): Effect.Effect<A, E> => {
+  const state = self.state
+  if (item.exit._tag === "Failure") {
+    state.usage--
+    state.items.delete(item)
+    state.invalidated.delete(item)
+    removeAvailable(self, item)
+    return item.exit
   }
-  return Iterable.headUnsafe(self.state.available)
-})
+  item.refCount++
+  if (item.refCount >= self.config.concurrency) {
+    removeAvailable(self, item)
+  }
+  const scope = Context.getUnsafe(fiber.context, Scope.Scope)
+  if (scope.state._tag === "Closed") {
+    return internal.flatMap(item.release(item.exit), () => item.exit)
+  }
+  internal.scopeAddFinalizerUnsafe(scope, {}, item.release)
+  return item.exit
+}
+
+const releaseItem = <A, E>(self: Pool<A, E>, item: PoolItem<A, E>): Effect.Effect<void> =>
+  core.withFiber((fiber) => {
+    const state = self.state
+    item.refCount--
+    state.usage--
+    if (state.invalidated.has(item)) {
+      return invalidatePoolItem(self, item)
+    }
+    if (item.refCount === self.config.concurrency - 1) {
+      addAvailable(self, item)
+      wakeWaiters(self, fiber, 1)
+    }
+    return internal.void
+  })
+
+const waitForItem = <A, E>(self: Pool<A, E>): Effect.Effect<void> =>
+  internal.callback((resume) => {
+    const state = self.state
+    if (state.availableHead !== undefined || state.isShuttingDown) {
+      return resume(internal.void)
+    }
+    const observer = () => {
+      state.waiters.delete(observer)
+      resume(internal.void)
+    }
+    state.waiters.add(observer)
+    return internal.sync(() => {
+      state.waiters.delete(observer)
+    })
+  })
+
+const wakeWaiters = <A, E>(self: Pool<A, E>, fiber: Fiber.Fiber<unknown, unknown>, count: number) => {
+  const waiters = self.state.waiters
+  if (waiters.size === 0) return
+  fiber.currentDispatcher.scheduleTask(() => {
+    let remaining = count
+    const toWake: Array<() => void> = []
+    for (const notify of waiters) {
+      if (remaining-- <= 0) break
+      toWake.push(notify)
+    }
+    for (let i = 0; i < toWake.length; i++) {
+      toWake[i]()
+    }
+  }, 0)
+}
+
+const wakeAll = <A, E>(self: Pool<A, E>): Effect.Effect<void> =>
+  core.withFiber((fiber) => {
+    wakeWaiters(self, fiber, Number.POSITIVE_INFINITY)
+    return internal.void
+  })
+
+const addAvailable = <A, E>(self: Pool<A, E>, item: PoolItem<A, E>): void => {
+  if (item.isAvailable) return
+  item.isAvailable = true
+  item.availablePrevious = self.state.availableTail
+  item.availableNext = undefined
+  if (self.state.availableTail !== undefined) {
+    self.state.availableTail.availableNext = item
+  } else {
+    self.state.availableHead = item
+  }
+  self.state.availableTail = item
+}
+
+const removeAvailable = <A, E>(self: Pool<A, E>, item: PoolItem<A, E>): void => {
+  if (!item.isAvailable) return
+  item.isAvailable = false
+  if (item.availablePrevious !== undefined) {
+    item.availablePrevious.availableNext = item.availableNext
+  } else {
+    self.state.availableHead = item.availableNext
+  }
+  if (item.availableNext !== undefined) {
+    item.availableNext.availablePrevious = item.availablePrevious
+  } else {
+    self.state.availableTail = item.availablePrevious
+  }
+  item.availablePrevious = undefined
+  item.availableNext = undefined
+}
 
 /**
  * Invalidates the specified item so the pool can remove it and reallocate the
@@ -529,7 +641,7 @@ const invalidatePoolItem = <A, E>(self: Pool<A, E>, poolItem: PoolItem<A, E>): E
       return Effect.void
     } else if (poolItem.refCount === 0) {
       self.state.items.delete(poolItem)
-      self.state.available.delete(poolItem)
+      removeAvailable(self, poolItem)
       self.state.invalidated.delete(poolItem)
       return Effect.asVoid(Effect.flatMap(
         poolItem.finalizer,
@@ -537,7 +649,7 @@ const invalidatePoolItem = <A, E>(self: Pool<A, E>, poolItem: PoolItem<A, E>): E
       ))
     }
     self.state.invalidated.add(poolItem)
-    self.state.available.delete(poolItem)
+    removeAvailable(self, poolItem)
     return Effect.void
   })
 
@@ -552,10 +664,19 @@ const resizeLoop = <A, E>(self: Pool<A, E>): Effect.Effect<void> =>
       return Effect.void
     }
     const toAcquire = target - active
-    return self.config.strategy.reclaim(self).pipe(
-      Effect.flatMap((item) => item ? Effect.succeed(item) : allocate(self)),
+    const acquireOne = Effect.flatMap(
+      self.config.strategy.reclaim(self),
+      (item) => item ? Effect.succeed(item) : allocate(self)
+    )
+    if (toAcquire === 1) {
+      return acquireOne.pipe(
+        Effect.tap(wakeAll(self)),
+        Effect.flatMap((item) => item.exit._tag === "Failure" ? Effect.void : resizeLoop(self))
+      )
+    }
+    return acquireOne.pipe(
       Effect.replicateEffect(toAcquire, { concurrency: toAcquire }),
-      Effect.tap(self.state.availableLatch.open),
+      Effect.tap(wakeAll(self)),
       Effect.flatMap((items) => items.some((_) => _.exit._tag === "Failure") ? Effect.void : resizeLoop(self))
     )
   })
@@ -572,10 +693,15 @@ const allocate = <A, E>(self: Pool<A, E>): Effect.Effect<PoolItem<A, E>> =>
             exit,
             finalizer: Effect.catchCause(Scope.close(scope, exit), reportUnhandledError),
             refCount: 0,
-            disableReclaim: false
+            disableReclaim: false,
+            isAvailable: false,
+            availablePrevious: undefined,
+            availableNext: undefined,
+            release: undefined as any
           }
+          item.release = constant(releaseItem(self, item))
           self.state.items.add(item)
-          self.state.available.add(item)
+          addAvailable(self, item)
           return Effect.as(
             exit._tag === "Success"
               ? self.config.strategy.onAcquire(item)
@@ -587,17 +713,9 @@ const allocate = <A, E>(self: Pool<A, E>): Effect.Effect<PoolItem<A, E>> =>
     (scope, exit) => exit._tag === "Failure" ? Scope.close(scope, exit) : Effect.void
   )
 
-const currentUsage = <A, E>(self: Pool<A, E>) => {
-  let count = self.state.waiters
-  for (const item of self.state.items) {
-    count += item.refCount
-  }
-  return count
-}
-
 const targetSize = <A, E>(self: Pool<A, E>) => {
   if (self.state.isShuttingDown) return 0
-  const utilization = currentUsage(self) / self.config.targetUtilization
+  const utilization = self.state.usage / self.config.targetUtilization
   const target = Math.ceil(utilization / self.config.concurrency)
   return Math.min(Math.max(self.config.minSize, target), self.config.maxSize)
 }
@@ -610,11 +728,11 @@ const activeSize = <A, E>(self: Pool<A, E>) => {
 // Strategy
 // -----------------------------------------------------------------------------
 
-const strategyNoop = <A, E>(): Strategy<A, E> => ({
+const strategyNoop: Strategy<any, any> = {
   run: (_) => Effect.void,
   onAcquire: (_) => Effect.void,
   reclaim: (_) => Effect.undefined
-})
+}
 
 const strategyCreationTTL = Effect.fnUntraced(function*<A, E>(ttl: Duration.Input) {
   const clock = yield* Clock
@@ -680,7 +798,7 @@ const strategyUsageTTL = Effect.fnUntraced(function*<A, E>(ttl: Duration.Input) 
         }
         pool.state.invalidated.delete(item.value)
         if (item.value.refCount < pool.config.concurrency) {
-          pool.state.available.add(item.value)
+          addAvailable(pool, item.value)
         }
         return Effect.as(Queue.offer(queue, item.value), item.value)
       })

--- a/packages/effect/src/Pool.ts
+++ b/packages/effect/src/Pool.ts
@@ -29,6 +29,14 @@ import * as Semaphore from "./Semaphore.ts"
 
 const TypeId = "~effect/Pool"
 
+const Acquire = Symbol()
+const AcquireContext = Symbol()
+
+interface PoolImpl<A, E> extends Pool<A, E> {
+  readonly [Acquire]: Effect.Effect<A, E, Scope.Scope>
+  readonly [AcquireContext]: Context.Context<Scope.Scope>
+}
+
 /**
  * A `Pool<A, E>` is a pool of items of type `A`, each of which may be
  * associated with the acquisition and release of resources. An attempt to get
@@ -368,8 +376,10 @@ export const makeWithStrategy = <A, E, R>(options: {
       invalidated: new Set(),
       waiters: new Set()
     }
-    const self: Pool<A, E> = {
+    const self: PoolImpl<A, E> = {
       [TypeId]: TypeId,
+      [Acquire]: options.acquire as Effect.Effect<A, E, Scope.Scope>,
+      [AcquireContext]: services as Context.Context<Scope.Scope>,
       config,
       state,
       pipe() {
@@ -379,7 +389,7 @@ export const makeWithStrategy = <A, E, R>(options: {
     yield* Scope.addFinalizer(scope, shutdown(self))
     if (config.minSize > 0) {
       yield* Effect.tap(
-        Effect.forkDetach(restore(resize(self))),
+        Effect.forkDetach(restore(resize(self)), { startImmediately: true }),
         (fiber) => Scope.addFinalizer(scope, Fiber.interrupt(fiber))
       )
     }
@@ -747,7 +757,7 @@ const invalidatePoolItem = <A, E>(self: Pool<A, E>, poolItem: PoolItem<A, E>): E
       self.state.invalidated.delete(poolItem)
       return Effect.asVoid(Effect.flatMap(
         poolItem.finalizer,
-        () => Effect.forkIn(Effect.interruptible(resize(self)), self.state.scope)
+        () => Effect.forkIn(Effect.interruptible(resize(self)), self.state.scope, { startImmediately: true })
       ))
     }
     self.state.invalidated.add(poolItem)
@@ -773,25 +783,31 @@ const resizeLoop = <A, E>(self: Pool<A, E>): Effect.Effect<void> =>
         (item) => item ? Effect.succeed(item) : allocate(self)
       )
     if (toAcquire === 1) {
-      return acquireOne.pipe(
-        Effect.tap(wakeAll(self)),
-        Effect.flatMap((item) => item.exit._tag === "Failure" ? Effect.void : resizeLoop(self))
-      )
+      const acquired = Effect.tap(acquireOne, wakeAll(self))
+      return self.config.isFixed
+        ? Effect.asVoid(acquired)
+        : Effect.flatMap(acquired, (item) => item.exit._tag === "Failure" ? Effect.void : resizeLoop(self))
     }
-    return acquireOne.pipe(
+    const acquired = acquireOne.pipe(
       Effect.replicateEffect(toAcquire, { concurrency: toAcquire }),
-      Effect.tap(wakeAll(self)),
-      Effect.flatMap((items) => items.some((_) => _.exit._tag === "Failure") ? Effect.void : resizeLoop(self))
+      Effect.tap(wakeAll(self))
     )
+    return self.config.isFixed
+      ? Effect.asVoid(acquired)
+      : Effect.flatMap(
+        acquired,
+        (items) => items.some((_) => _.exit._tag === "Failure") ? Effect.void : resizeLoop(self)
+      )
   })
 
 const allocate = <A, E>(self: Pool<A, E>): Effect.Effect<PoolItem<A, E>> =>
   internal.uninterruptibleMask((restore) =>
     core.withFiber((fiber) => {
+      const impl = self as PoolImpl<A, E>
       const scope = internal.scopeMakeUnsafe()
       const previousContext = fiber.context
-      fiber.setContext(Context.add(previousContext, Scope.Scope, scope))
-      const use = Effect.flatMap(Effect.exit(self.config.acquire), (exit) => {
+      fiber.setContext(Context.add(impl[AcquireContext], Scope.Scope, scope))
+      const use = Effect.flatMap(Effect.exit(impl[Acquire]), (exit) => {
         const item: PoolItem<A, E> = {
           exit,
           finalizer: Effect.catchCause(Scope.close(scope, exit), reportUnhandledError),

--- a/packages/effect/src/Pool.ts
+++ b/packages/effect/src/Pool.ts
@@ -77,6 +77,7 @@ export interface Pool<in out A, in out E = never> extends Pipeable {
 export interface Config<A, E> {
   readonly acquire: Effect.Effect<A, E, Scope.Scope>
   readonly concurrency: number
+  readonly isFixed: boolean
   readonly minSize: number
   readonly maxSize: number
   readonly strategy: Strategy<A, E>
@@ -350,6 +351,7 @@ export const makeWithStrategy = <A, E, R>(options: {
     const config: Config<A, E> = {
       acquire,
       concurrency,
+      isFixed: options.min === options.max,
       minSize: options.min,
       maxSize: options.max,
       strategy: options.strategy,
@@ -444,7 +446,7 @@ export const get = <A, E>(self: Pool<A, E>): Effect.Effect<A, E, Scope.Scope> =>
     if (state.isShuttingDown) return internal.interrupt
     if (state.availableHead !== undefined) {
       state.usage++
-      if (targetSize(self) <= activeSize(self)) {
+      if (self.config.isFixed || targetSize(self) <= activeSize(self)) {
         return leaseItem(self, state.availableHead, fiber)
       }
       state.usage--
@@ -664,10 +666,12 @@ const resizeLoop = <A, E>(self: Pool<A, E>): Effect.Effect<void> =>
       return Effect.void
     }
     const toAcquire = target - active
-    const acquireOne = Effect.flatMap(
-      self.config.strategy.reclaim(self),
-      (item) => item ? Effect.succeed(item) : allocate(self)
-    )
+    const acquireOne = self.config.strategy === strategyNoop
+      ? allocate(self)
+      : Effect.flatMap(
+        self.config.strategy.reclaim(self),
+        (item) => item ? Effect.succeed(item) : allocate(self)
+      )
     if (toAcquire === 1) {
       return acquireOne.pipe(
         Effect.tap(wakeAll(self)),
@@ -702,6 +706,9 @@ const allocate = <A, E>(self: Pool<A, E>): Effect.Effect<PoolItem<A, E>> =>
           item.release = constant(releaseItem(self, item))
           self.state.items.add(item)
           addAvailable(self, item)
+          if (self.config.strategy === strategyNoop) {
+            return exit._tag === "Success" ? Effect.succeed(item) : Effect.as(item.finalizer, item)
+          }
           return Effect.as(
             exit._tag === "Success"
               ? self.config.strategy.onAcquire(item)
@@ -715,6 +722,7 @@ const allocate = <A, E>(self: Pool<A, E>): Effect.Effect<PoolItem<A, E>> =>
 
 const targetSize = <A, E>(self: Pool<A, E>) => {
   if (self.state.isShuttingDown) return 0
+  if (self.config.isFixed) return self.config.minSize
   const utilization = self.state.usage / self.config.targetUtilization
   const target = Math.ceil(utilization / self.config.concurrency)
   return Math.min(Math.max(self.config.minSize, target), self.config.maxSize)

--- a/packages/effect/src/Pool.ts
+++ b/packages/effect/src/Pool.ts
@@ -103,15 +103,8 @@ export interface Config<A, E> {
  *
  * **Details**
  *
- * This state tracks the pool scope, active and available items, invalidated
- * items, current usage, waiters, and shutdown status. It is exposed for
- * inspection and implementation support; user code should prefer the
- * high-level pool operations.
- *
- * `usage` counts fibers waiting for or currently holding an item, and is what
- * drives the pool's target size.
- * `waiters` holds the wake-up callbacks of fibers waiting for an item to
- * become available.
+ * This state is exposed for inspection and implementation support. User code
+ * should prefer the high-level pool operations.
  *
  * @see {@link Pool} for the pool value exposing this state
  * @see {@link PoolItem} for the entries stored in the runtime item sets
@@ -465,20 +458,12 @@ export const get = <A, E>(self: Pool<A, E>): Effect.Effect<A, E, Scope.Scope> =>
   })
 
 /**
- * Borrows an item from the pool for the duration of a single effect, without
- * requiring a `Scope`.
+ * Borrows an item while an effect runs and returns it when the effect exits.
  *
  * **When to use**
  *
- * Use when an item is only needed to run one effect. Compared to wrapping
- * {@link get} in `Effect.scoped`, this skips scope creation and finalizer
- * bookkeeping, so it is the faster way to use a pooled item for a single
- * operation.
- *
- * **Details**
- *
- * The item is returned to the pool as soon as the provided effect completes,
- * whether it succeeds, fails, or is interrupted.
+ * Use when an item is needed by one effect. Unlike `Effect.scoped` with
+ * {@link get}, this avoids allocating a scope and registering a finalizer.
  *
  * **Example** (Running a single operation with a pooled item)
  *

--- a/packages/effect/src/Pool.ts
+++ b/packages/effect/src/Pool.ts
@@ -686,38 +686,44 @@ const resizeLoop = <A, E>(self: Pool<A, E>): Effect.Effect<void> =>
   })
 
 const allocate = <A, E>(self: Pool<A, E>): Effect.Effect<PoolItem<A, E>> =>
-  Effect.acquireUseRelease(
-    Scope.make(),
-    (scope) =>
-      self.config.acquire.pipe(
-        Scope.provide(scope),
-        Effect.exit,
-        Effect.flatMap((exit) => {
-          const item: PoolItem<A, E> = {
-            exit,
-            finalizer: Effect.catchCause(Scope.close(scope, exit), reportUnhandledError),
-            refCount: 0,
-            disableReclaim: false,
-            isAvailable: false,
-            availablePrevious: undefined,
-            availableNext: undefined,
-            release: undefined as any
-          }
-          item.release = constant(releaseItem(self, item))
-          self.state.items.add(item)
-          addAvailable(self, item)
-          if (self.config.strategy === strategyNoop) {
-            return exit._tag === "Success" ? Effect.succeed(item) : Effect.as(item.finalizer, item)
-          }
-          return Effect.as(
-            exit._tag === "Success"
-              ? self.config.strategy.onAcquire(item)
-              : Effect.flatMap(item.finalizer, () => self.config.strategy.onAcquire(item)),
-            item
-          )
-        })
-      ),
-    (scope, exit) => exit._tag === "Failure" ? Scope.close(scope, exit) : Effect.void
+  internal.uninterruptibleMask((restore) =>
+    core.withFiber((fiber) => {
+      const scope = internal.scopeMakeUnsafe()
+      const previousContext = fiber.context
+      fiber.setContext(Context.add(previousContext, Scope.Scope, scope))
+      const use = Effect.flatMap(Effect.exit(self.config.acquire), (exit) => {
+        const item: PoolItem<A, E> = {
+          exit,
+          finalizer: Effect.catchCause(Scope.close(scope, exit), reportUnhandledError),
+          refCount: 0,
+          disableReclaim: false,
+          isAvailable: false,
+          availablePrevious: undefined,
+          availableNext: undefined,
+          release: undefined as any
+        }
+        item.release = constant(releaseItem(self, item))
+        self.state.items.add(item)
+        addAvailable(self, item)
+        if (self.config.strategy === strategyNoop) {
+          return exit._tag === "Success" ? Effect.succeed(item) : Effect.as(item.finalizer, item)
+        }
+        return Effect.as(
+          exit._tag === "Success"
+            ? self.config.strategy.onAcquire(item)
+            : Effect.flatMap(item.finalizer, () => self.config.strategy.onAcquire(item)),
+          item
+        )
+      })
+      return internal.onExitPrimitive(
+        restore(use) as Effect.Effect<PoolItem<A, E>>,
+        (exit) => {
+          fiber.setContext(previousContext)
+          return exit._tag === "Failure" ? internal.scopeCloseUnsafe(scope, exit) : undefined
+        },
+        true
+      )
+    })
   )
 
 const targetSize = <A, E>(self: Pool<A, E>) => {

--- a/packages/effect/src/Pool.ts
+++ b/packages/effect/src/Pool.ts
@@ -451,14 +451,101 @@ export const get = <A, E>(self: Pool<A, E>): Effect.Effect<A, E, Scope.Scope> =>
       }
       state.usage--
     }
-    return getSlow(self)
+    return getSlowWith(self, leaseItemWith)
   })
 
-const getSlow = <A, E>(self: Pool<A, E>): Effect.Effect<A, E, Scope.Scope> =>
+/**
+ * Borrows an item from the pool for the duration of a single effect, without
+ * requiring a `Scope`.
+ *
+ * **When to use**
+ *
+ * Use when an item is only needed to run one effect. Compared to wrapping
+ * {@link get} in `Effect.scoped`, this skips scope creation and finalizer
+ * bookkeeping, so it is the faster way to use a pooled item for a single
+ * operation.
+ *
+ * **Details**
+ *
+ * The item is returned to the pool as soon as the provided effect completes,
+ * whether it succeeds, fails, or is interrupted.
+ *
+ * **Example** (Running a single operation with a pooled item)
+ *
+ * ```ts import.meta.vitest
+ * import { Effect, Pool } from "effect"
+ *
+ * const program = Effect.scoped(
+ *   Effect.flatMap(
+ *     Pool.make({ acquire: Effect.succeed("resource"), size: 2 }),
+ *     (pool) => Pool.use(pool, (item) => Effect.succeed(item.length))
+ *   )
+ * )
+ *
+ * await Effect.runPromise(program) // => 8
+ * ```
+ *
+ * @see {@link get} for borrowing an item for the lifetime of a scope
+ *
+ * @category combinators
+ * @since 4.0.0
+ */
+export const use: {
+  <A, B, E2, R2>(
+    f: (item: A) => Effect.Effect<B, E2, R2>
+  ): <E>(self: Pool<A, E>) => Effect.Effect<B, E | E2, R2>
+  <A, E, B, E2, R2>(
+    self: Pool<A, E>,
+    f: (item: A) => Effect.Effect<B, E2, R2>
+  ): Effect.Effect<B, E | E2, R2>
+} = dual(2, <A, E, B, E2, R2>(
+  self: Pool<A, E>,
+  f: (item: A) => Effect.Effect<B, E2, R2>
+): Effect.Effect<B, E | E2, R2> =>
+  internal.suspend(() => {
+    const state = self.state
+    if (state.isShuttingDown) return internal.interrupt
+    if (state.availableHead !== undefined) {
+      state.usage++
+      if (self.config.isFixed || targetSize(self) <= activeSize(self)) {
+        return useItem(self, state.availableHead, f)
+      }
+      state.usage--
+    }
+    return getSlowWith(self, (self, item, _fiber, restore) => useItem(self, item, f, restore))
+  }))
+
+const useItem = <A, E, B, E2, R2>(
+  self: Pool<A, E>,
+  item: PoolItem<A, E>,
+  f: (item: A) => Effect.Effect<B, E2, R2>,
+  restore?: <AX, EX, RX>(effect: Effect.Effect<AX, EX, RX>) => Effect.Effect<AX, EX, RX>
+): Effect.Effect<B, E | E2, R2> => {
+  if (!leaseItemBookkeeping(self, item)) {
+    return item.exit as Exit.Exit<never, E>
+  }
+  let body: Effect.Effect<B, E2, R2>
+  try {
+    body = f((item.exit as Exit.Success<A, E>).value)
+  } catch (defect) {
+    return internal.flatMap(item.release(item.exit), () => core.exitDie(defect))
+  }
+  return internal.onExitPrimitive(restore !== undefined ? restore(body) : body, item.release)
+}
+
+const getSlowWith = <A, E, X, R>(
+  self: Pool<A, E>,
+  lease: (
+    self: Pool<A, E>,
+    item: PoolItem<A, E>,
+    fiber: Fiber.Fiber<unknown, unknown>,
+    restore: <AX, EX, RX>(effect: Effect.Effect<AX, EX, RX>) => Effect.Effect<AX, EX, RX>
+  ) => Effect.Effect<X, any, R>
+): Effect.Effect<X, any, R> =>
   internal.uninterruptibleMask((restore) => {
     const state = self.state
     state.usage++
-    const wait: Effect.Effect<A, E, Scope.Scope> = internal.flatMap(
+    const wait: Effect.Effect<X, any, R> = internal.flatMap(
       internal.onInterrupt(
         restore(waitForItem(self)),
         () =>
@@ -468,17 +555,17 @@ const getSlow = <A, E>(self: Pool<A, E>): Effect.Effect<A, E, Scope.Scope> =>
       ),
       () => loop
     )
-    const step: Effect.Effect<A, E, Scope.Scope> = core.withFiber((fiber) => {
+    const step: Effect.Effect<X, any, R> = core.withFiber((fiber) => {
       if (state.isShuttingDown) {
         state.usage--
         return internal.interrupt
       }
       if (state.availableHead !== undefined) {
-        return leaseItem(self, state.availableHead, fiber)
+        return lease(self, state.availableHead, fiber, restore)
       }
       return wait
     })
-    const loop: Effect.Effect<A, E, Scope.Scope> = internal.suspend(() => {
+    const loop: Effect.Effect<X, any, R> = internal.suspend(() => {
       if (state.isShuttingDown) {
         state.usage--
         return internal.interrupt
@@ -495,22 +582,29 @@ const getSlow = <A, E>(self: Pool<A, E>): Effect.Effect<A, E, Scope.Scope> =>
     return loop
   })
 
-const leaseItem = <A, E>(
-  self: Pool<A, E>,
-  item: PoolItem<A, E>,
-  fiber: Fiber.Fiber<unknown, unknown>
-): Effect.Effect<A, E> => {
+const leaseItemBookkeeping = <A, E>(self: Pool<A, E>, item: PoolItem<A, E>): boolean => {
   const state = self.state
   if (item.exit._tag === "Failure") {
     state.usage--
     state.items.delete(item)
     state.invalidated.delete(item)
     removeAvailable(self, item)
-    return item.exit
+    return false
   }
   item.refCount++
   if (item.refCount >= self.config.concurrency) {
     removeAvailable(self, item)
+  }
+  return true
+}
+
+const leaseItem = <A, E>(
+  self: Pool<A, E>,
+  item: PoolItem<A, E>,
+  fiber: Fiber.Fiber<unknown, unknown>
+): Effect.Effect<A, E> => {
+  if (!leaseItemBookkeeping(self, item)) {
+    return item.exit
   }
   const scope = Context.getUnsafe(fiber.context, Scope.Scope)
   if (scope.state._tag === "Closed") {
@@ -519,6 +613,12 @@ const leaseItem = <A, E>(
   internal.scopeAddFinalizerUnsafe(scope, {}, item.release)
   return item.exit
 }
+
+const leaseItemWith = <A, E>(
+  self: Pool<A, E>,
+  item: PoolItem<A, E>,
+  fiber: Fiber.Fiber<unknown, unknown>
+): Effect.Effect<A, E, Scope.Scope> => leaseItem(self, item, fiber)
 
 const releaseItem = <A, E>(self: Pool<A, E>, item: PoolItem<A, E>): Effect.Effect<void> =>
   core.withFiber((fiber) => {

--- a/packages/effect/src/Scope.ts
+++ b/packages/effect/src/Scope.ts
@@ -126,6 +126,12 @@ export declare namespace State {
    * Represents an open scope state where finalizers can be added and
    * the scope is still accepting new resources.
    *
+   * **Details**
+   *
+   * A single registered finalizer is stored directly in `finalizerKey` /
+   * `finalizer`; once a second finalizer is added, all finalizers move into
+   * the `finalizers` map.
+   *
    * **Example** (Inspecting an open scope state)
    *
    * ```ts import.meta.vitest
@@ -138,7 +144,7 @@ export declare namespace State {
    * if (state._tag !== "Open") throw new Error("unexpected state")
    *
    * state._tag // => "Open"
-   * state.finalizers.size // => 1
+   * state.finalizer !== undefined // => true
    * ```
    *
    * @category models
@@ -146,7 +152,9 @@ export declare namespace State {
    */
   export type Open = {
     readonly _tag: "Open"
-    readonly finalizers: Map<{}, (exit: Exit<any, any>) => Effect<void>>
+    finalizerKey: {} | undefined
+    finalizer: ((exit: Exit<any, any>) => Effect<void>) | undefined
+    finalizers: Map<{}, (exit: Exit<any, any>) => Effect<void>> | undefined
   }
   /**
    * Represents a closed scope state where finalizers have been executed

--- a/packages/effect/src/Scope.ts
+++ b/packages/effect/src/Scope.ts
@@ -128,9 +128,8 @@ export declare namespace State {
    *
    * **Details**
    *
-   * A single registered finalizer is stored directly in `finalizerKey` /
-   * `finalizer`; once a second finalizer is added, all finalizers move into
-   * the `finalizers` map.
+   * Stores one finalizer inline and allocates the `finalizers` map when a
+   * second is added.
    *
    * **Example** (Inspecting an open scope state)
    *

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -3783,9 +3783,13 @@ export const scopeCloseUnsafe = <A, E>(self: Scope.Scope, exit_: Exit.Exit<A, E>
     self.state = closed
     return
   }
-  const { finalizers } = self.state
+  const state = self.state
   self.state = closed
-  if (finalizers.size === 0) {
+  if (state.finalizer !== undefined) {
+    return state.finalizer(exit_)
+  }
+  const finalizers = state.finalizers
+  if (finalizers === undefined || finalizers.size === 0) {
     return
   } else if (finalizers.size === 1) {
     return finalizers.values().next().value!(exit_)
@@ -3801,7 +3805,7 @@ const combineFinalizerCause = <A, E, XE, XR>(
 
 const scopeCloseFinalizers = fnUntraced(function*<A, E>(
   self: Scope.Scope,
-  finalizers: Scope.State.Open["finalizers"],
+  finalizers: NonNullable<Scope.State.Open["finalizers"]>,
   exit_: Exit.Exit<A, E>
 ) {
   let exits: Array<Exit.Exit<any, never>> = []
@@ -3866,9 +3870,20 @@ export const scopeAddFinalizerUnsafe = (
   finalizer: (exit: Exit.Exit<any, any>) => Effect.Effect<unknown>
 ): void => {
   if (scope.state._tag === "Empty") {
-    scope.state = { _tag: "Open", finalizers: new Map([[key, finalizer]]) }
+    scope.state = { _tag: "Open", finalizerKey: key, finalizer, finalizers: undefined }
   } else if (scope.state._tag === "Open") {
-    scope.state.finalizers.set(key, finalizer)
+    const state = scope.state
+    if (state.finalizer !== undefined) {
+      state.finalizers = new Map([[state.finalizerKey!, state.finalizer]])
+      state.finalizerKey = undefined
+      state.finalizer = undefined
+      state.finalizers.set(key, finalizer)
+    } else if (state.finalizers === undefined) {
+      state.finalizerKey = key
+      state.finalizer = finalizer
+    } else {
+      state.finalizers.set(key, finalizer)
+    }
   }
 }
 
@@ -3878,9 +3893,23 @@ export const scopeRemoveFinalizerUnsafe = (
   key: {}
 ): void => {
   if (scope.state._tag === "Open") {
-    scope.state.finalizers.delete(key)
+    const state = scope.state
+    if (state.finalizerKey === key) {
+      state.finalizerKey = undefined
+      state.finalizer = undefined
+    } else if (state.finalizers !== undefined) {
+      state.finalizers.delete(key)
+    }
   }
 }
+
+/** @internal */
+export const scopeFinalizerCountUnsafe = (scope: Scope.Scope): number =>
+  scope.state._tag !== "Open"
+    ? 0
+    : scope.state.finalizer !== undefined
+    ? 1
+    : (scope.state.finalizers?.size ?? 0)
 
 /** @internal */
 export const scopeMakeUnsafe = (finalizerStrategy: "sequential" | "parallel" = "sequential"): Scope.Closeable => ({

--- a/packages/effect/test/Pool.test.ts
+++ b/packages/effect/test/Pool.test.ts
@@ -399,6 +399,47 @@ describe("Pool", () => {
       deepStrictEqual(yield* Fiber.await(fiber), Exit.interrupt(fiberId))
     }))
 
+  it.effect("interrupts pending gets without leaking usage", () =>
+    Effect.gen(function*() {
+      const pool = yield* Pool.make({ acquire: Effect.succeed("resource"), size: 1 })
+      const scope = yield* Scope.make()
+      yield* Scope.provide(Pool.get(pool), scope)
+      const fibers: Array<Fiber.Fiber<string>> = []
+      for (let i = 0; i < 10; i++) {
+        fibers.push(yield* Effect.forkChild(Pool.get(pool), { startImmediately: true }))
+      }
+      yield* Effect.repeat(Effect.andThen(Effect.yieldNow, Effect.sync(() => pool.state.waiters.size)), {
+        until: (size) => size === fibers.length
+      })
+      yield* Effect.all(fibers.map(Fiber.interrupt), { concurrency: "unbounded", discard: true })
+      strictEqual(pool.state.waiters.size, 0)
+      strictEqual(pool.state.usage, 1)
+      yield* Scope.close(scope, Exit.void)
+      strictEqual(pool.state.usage, 0)
+    }))
+
+  it.effect("does not re-wake waiters registered during notification", () =>
+    Effect.gen(function*() {
+      const acquire = yield* Deferred.make<void>()
+      const pool = yield* Pool.makeWithTTL({
+        acquire: Effect.as(Deferred.await(acquire), "resource"),
+        min: 0,
+        max: 1,
+        timeToLive: Duration.infinity
+      })
+      const fibers: Array<Fiber.Fiber<string>> = []
+      for (let i = 0; i < 10; i++) {
+        fibers.push(yield* Effect.forkChild(Effect.scoped(Pool.get(pool)), { startImmediately: true }))
+      }
+      yield* Effect.repeat(Effect.andThen(Effect.yieldNow, Effect.sync(() => pool.state.waiters.size)), {
+        until: (size) => size === fibers.length
+      })
+      yield* Deferred.succeed(acquire, undefined)
+      yield* Effect.all(fibers.map(Fiber.join), { concurrency: "unbounded", discard: true })
+      strictEqual(pool.state.waiters.size, 0)
+      strictEqual(pool.state.usage, 0)
+    }))
+
   it.effect("finalizer is called for failed allocations", () =>
     Effect.gen(function*() {
       const scope = yield* Scope.make()

--- a/packages/effect/test/Pool.test.ts
+++ b/packages/effect/test/Pool.test.ts
@@ -440,6 +440,76 @@ describe("Pool", () => {
       strictEqual(pool.state.usage, 0)
     }))
 
+  it.effect("use borrows and returns an item", () =>
+    Effect.gen(function*() {
+      const count = yield* Ref.make(0)
+      const get = Effect.acquireRelease(
+        Ref.updateAndGet(count, (n) => n + 1),
+        () => Ref.update(count, (n) => n - 1)
+      )
+      const pool = yield* Pool.make({ acquire: get, size: 2 })
+      yield* Effect.repeat(Ref.get(count), { until: (n) => n === 2 })
+      const results: Array<number> = []
+      yield* Effect.repeat(
+        Effect.tap(Pool.use(pool, (item) => Effect.succeed(item)), (item) =>
+          Effect.sync(() => {
+            results.push(item)
+          })),
+        { times: 9 }
+      )
+      deepStrictEqual(results, [1, 2, 1, 2, 1, 2, 1, 2, 1, 2])
+      strictEqual(yield* Ref.get(count), 2)
+    }))
+
+  it.effect("use releases the item on failure", () =>
+    Effect.gen(function*() {
+      const pool = yield* Pool.make({ acquire: Effect.succeed("resource"), size: 1 })
+      const failure = yield* Effect.flip(Pool.use(pool, () => Effect.fail("boom")))
+      strictEqual(failure, "boom")
+      strictEqual(yield* Pool.use(pool, (item) => Effect.succeed(item)), "resource")
+    }))
+
+  it.effect("use releases the item on interruption", () =>
+    Effect.gen(function*() {
+      const started = yield* Deferred.make<void>()
+      const pool = yield* Pool.make({ acquire: Effect.succeed("resource"), size: 1 })
+      const fiber = yield* Effect.forkChild(
+        Pool.use(pool, () => Effect.andThen(Deferred.succeed(started, void 0), Effect.never)),
+        { startImmediately: true }
+      )
+      yield* Deferred.await(started)
+      yield* Fiber.interrupt(fiber)
+      strictEqual(yield* Pool.use(pool, (item) => Effect.succeed(item)), "resource")
+    }))
+
+  it.effect("use waits for an available item", () =>
+    Effect.gen(function*() {
+      const pool = yield* Pool.make({ acquire: Effect.succeed("resource"), size: 1 })
+      const scope = yield* Scope.make()
+      yield* Scope.provide(Pool.get(pool), scope)
+      const fiber = yield* Effect.forkChild(
+        Pool.use(pool, (item) => Effect.succeed(item)),
+        { startImmediately: true }
+      )
+      assert.isUndefined(fiber.pollUnsafe())
+      yield* Scope.close(scope, Exit.void)
+      strictEqual(yield* Fiber.join(fiber), "resource")
+      strictEqual(pool.state.usage, 0)
+    }))
+
+  it.effect("use reports acquire failures", () =>
+    Effect.gen(function*() {
+      const pool = yield* Pool.makeWithTTL({
+        acquire: Effect.fail("nope"),
+        min: 0,
+        max: 1,
+        timeToLive: Duration.infinity
+      })
+      const failure = yield* Effect.flip(Pool.use(pool, () => Effect.void))
+      strictEqual(failure, "nope")
+      strictEqual(pool.state.usage, 0)
+    }))
+
   it.effect("finalizer is called for failed allocations", () =>
     Effect.gen(function*() {
       const scope = yield* Scope.make()


### PR DESCRIPTION
Closes EFF-825

Rework the Pool internals so `get` and release run as a single synchronous step on the hot path, plus a second optimization round covering allocation, scope finalizers, and a new scope-free `Pool.use` API.

## What changed

**Round 1 — hot path rewrite**

- **Removed the checkout semaphore and availability latch.** An available item always implies lease capacity, so item availability is the only wait condition. Waiting fibers register a wake-up callback in a `waiters` set; releases wake one waiter, resize batches wake all. Wakes snapshot the waiters before notifying so a re-registering waiter cannot be re-visited by the same wake task.
- **Synchronous fast path for `get`.** When an item is available and no resize is needed, `get` leases it, registers the release finalizer directly on the current scope, and returns `item.exit` in one step.
- **Incremental usage tracking.** `state.usage` replaces the per-`get` scan over all items, making `targetSize` O(1).
- **Intrusive FIFO list for available items** (Codex Engineer) replaces the `Set`, giving allocation-free head access and O(1) removal.
- **Pre-allocated release finalizers**, fused allocation (Codex Engineer), fixed-size shortcut (Codex Engineer), and fewer background fibers (no strategy fiber for no-op strategies, no initial resize fiber for `min: 0` pools).

**Round 2 — allocation, scope, and API**

- **`Pool.use(pool, f)`** borrows an item just for one effect, with no `Scope` requirement — skips scope creation and finalizer bookkeeping entirely. It is the fastest way to run a single operation with a pooled item.
- **Single-finalizer fast slot in `Scope`.** Most scopes only ever hold one finalizer, so `Scope.State.Open` now stores the first finalizer inline and only materializes the `finalizers` map on the second add. This removes a Map allocation from every scoped acquisition, benefiting all scoped code, not just Pool.
- **Allocation context pinning** (Codex Engineer): item acquisition runs against the captured construction context with only the item scope swapped in, instead of re-merging contexts per allocation. This also stops invalidation-triggered acquisitions from observing the invalidator fiber's context.
- **Immediate resize fibers** (Codex Engineer): initial preallocation and invalidation replacement start synchronously, so synchronous acquires complete without a scheduler round-trip. Fixed pools also skip the redundant resize-loop recheck.

## Benchmarks

`packages/effect/benchmark/Pool.ts`, Node 24 (baseline = main before this PR):

| Benchmark | Before | After | Speedup |
|---|---:|---:|---:|
| make fixed pool (10 items) | 92.4 µs | 23.1 µs | 4.0x |
| make TTL pool (10 items) | 101.4 µs | 60.1 µs | 1.7x |
| get and release (fixed) | 2481 ns | 780 ns | 3.2x |
| get and release (TTL) | 2445 ns | 798 ns | 3.1x |
| use (fixed) | — | 711 ns | new |
| get and release (10 concurrent) | 24.3 µs | 7.6 µs | 3.2x |
| invalidate and replace | 13.0 µs | 3.3 µs | 4.0x |

The `runPromise(scoped(...))` harness floor is ~450 ns. We also benchmarked waking only newly-created capacity instead of all waiters during resize; it measured ~10% slower under 100-getter contention, so wake-all stays.

## Breaking changes

- `Pool.State` loses `semaphore`, `availableLatch`, `available: Set` and the numeric `waiters`; gains `usage`, `availableHead`/`availableTail` and a `waiters` set of wake-up callbacks. `Pool.PoolItem` gains `isAvailable`, `availablePrevious`, `availableNext` and `release`.
- `Scope.State.Open` changed shape: `finalizers` is now `Map | undefined`, with new `finalizerKey` / `finalizer` fields holding a sole registered finalizer.

No changes to `make`, `makeWithTTL`, `makeWithStrategy`, `get` or `invalidate` signatures. A follow-up worth considering: stop exposing mutable `State`/`PoolItem` internals and hand strategies a narrow context instead, so future data-structure changes are not API breaks.

## Validation

- `pnpm --filter effect test --run test/Pool.test.ts` — 28 tests (7 new: waiter interruption accounting, wake notification, and `Pool.use` semantics)
- Scope, Channel, Stream, Layer, Effect, Cache suites (718 tests) — the Scope change touches all scoped code
- `pnpm check` from the repository root; doctests for Pool and Scope; `pnpm lint-fix`
