### PR TITLE
Await Node worker termination

### DIFF
--- a/packages/platform/node/src/NodeWorker.ts
+++ b/packages/platform/node/src/NodeWorker.ts
@@ -58,7 +58,7 @@ export const layerPlatform: Layer.Layer<Worker.WorkerPlatform> = Layer.succeed(W
             return Deferred.await(exitDeferred)
           }).pipe(
             Effect.timeout(5000),
-            Effect.catchCause(() => Effect.sync(() => thing.kill()))
+            Effect.catchCause(() => Effect.promise(() => Promise.resolve(thing.kill())))
           )
         ),
         thing


### PR DESCRIPTION
## Summary

- Await the worker-thread termination promise in the shutdown timeout fallback.
- Normalize the synchronous child-process kill result through the same Effect promise boundary.

## Verification

- `nix develop -c pnpm check`
- `nix develop -c pnpm lint`

Closes EFF-828
