### PR TITLE
Defer OpenAPI documentation generation until first request

### DIFF
--- a/.changeset/lazy-openapi-initialization.md
+++ b/.changeset/lazy-openapi-initialization.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Defer built-in OpenAPI response generation until the documentation route is first requested, retrying after generation defects.

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -15,7 +15,7 @@ import * as Effect from "../../Effect.ts"
 import * as Encoding from "../../Encoding.ts"
 import * as Fiber from "../../Fiber.ts"
 import type { FileSystem } from "../../FileSystem.ts"
-import { identity } from "../../Function.ts"
+import * as Function from "../../Function.ts"
 import { stringOrRedacted } from "../../internal/redacted.ts"
 import * as Layer from "../../Layer.ts"
 import type { Path } from "../../Path.ts"
@@ -100,16 +100,13 @@ export const layer = <Id extends string, Groups extends HttpApiGroup.Constraint>
     }
     yield* (router.addAll(routes) as Effect.Effect<void>)
     if (options?.openapiPath) {
-      let response: HttpServerResponse | undefined
+      const makeResponse = Function.memoize((api: HttpApi.HttpApi<Id, Groups>): HttpServerResponse =>
+        Response.jsonUnsafe(OpenApi.fromApi(api))
+      )
       yield* router.add(
         "GET",
         options.openapiPath,
-        Effect.sync(() => {
-          if (response !== undefined) return response
-          const spec = OpenApi.fromApi(api)
-          response = Response.jsonUnsafe(spec)
-          return response
-        })
+        Effect.sync(() => makeResponse(api))
       )
     }
   }))
@@ -893,7 +890,7 @@ const makeSecurityMiddleware = (
     middleware: service[securityKey]
   }))
   if (entries.length === 0) {
-    return identity
+    return Function.identity
   }
 
   const middleware = Effect.fnUntraced(function*(handler: Effect.Effect<any, any, any>, options: {
@@ -1067,7 +1064,7 @@ function encodeSseStream(
         event: "message",
         data: value
       })) :
-      identity,
+      Function.identity,
     Stream.mapArrayEffect((chunk) => Effect.orDie(encoder.encodeEvents(chunk))),
     Stream.catchCause((cause) => Stream.fromEffect(encodeFailureEvent(cause, encoder))),
     Stream.map(renderSseEvent),

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -100,8 +100,17 @@ export const layer = <Id extends string, Groups extends HttpApiGroup.Constraint>
     }
     yield* (router.addAll(routes) as Effect.Effect<void>)
     if (options?.openapiPath) {
-      const spec = OpenApi.fromApi(api)
-      yield* router.add("GET", options.openapiPath, Effect.succeed(Response.jsonUnsafe(spec)))
+      let response: HttpServerResponse | undefined
+      yield* router.add(
+        "GET",
+        options.openapiPath,
+        Effect.sync(() => {
+          if (response !== undefined) return response
+          const spec = OpenApi.fromApi(api)
+          response = Response.jsonUnsafe(spec)
+          return response
+        })
+      )
     }
   }))
 

--- a/packages/effect/src/unstable/httpapi/HttpApiScalar.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiScalar.ts
@@ -9,6 +9,7 @@
  * @since 4.0.0
  */
 import * as Effect from "../../Effect.ts"
+import * as Function from "../../Function.ts"
 import type * as Layer from "../../Layer.ts"
 import * as HttpRouter from "../http/HttpRouter.ts"
 import * as HttpServerResponse from "../http/HttpServerResponse.ts"
@@ -144,10 +145,8 @@ const makeHandler = <Id extends string, Groups extends HttpApiGroup.Constraint>(
   readonly source: ScalarSource
   readonly scalar: ScalarConfig | undefined
 }) => {
-  let response: HttpServerResponse.HttpServerResponse | undefined
-  return Effect.sync(() => {
-    if (response !== undefined) return response
-    const spec = OpenApi.fromApi(options.api)
+  const makeResponse = Function.memoize((api: HttpApi.HttpApi<Id, Groups>) => {
+    const spec = OpenApi.fromApi(api)
     const { customFetch, ...scalar } = options.scalar ?? {}
     const scalarConfig = {
       _integration: "html",
@@ -162,7 +161,7 @@ const makeHandler = <Id extends string, Groups extends HttpApiGroup.Constraint>(
         )
       }" crossorigin></script>`
       : `<script>${options.source.source}</script>`
-    response = HttpServerResponse.html(`<!doctype html>
+    return HttpServerResponse.html(`<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -195,8 +194,8 @@ const makeHandler = <Id extends string, Groups extends HttpApiGroup.Constraint>(
     </script>
   </body>
 </html>`)
-    return response
   })
+  return Effect.sync(() => makeResponse(options.api))
 }
 
 /**

--- a/packages/effect/src/unstable/httpapi/HttpApiScalar.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiScalar.ts
@@ -144,36 +144,39 @@ const makeHandler = <Id extends string, Groups extends HttpApiGroup.Constraint>(
   readonly source: ScalarSource
   readonly scalar: ScalarConfig | undefined
 }) => {
-  const spec = OpenApi.fromApi(options.api)
-  const { customFetch, ...scalar } = options.scalar ?? {}
-  const scalarConfig = {
-    _integration: "html",
-    ...scalar
-  }
-  const scalarScript = options.source._tag === "Cdn"
-    ? `<script src="${
-      Html.escapeAttribute(
-        `https://cdn.jsdelivr.net/npm/@scalar/api-reference@${
-          encodeURIComponent(options.source.version ?? "latest")
-        }/dist/browser/standalone.min.js`
-      )
-    }" crossorigin></script>`
-    : `<script>${options.source.source}</script>`
-  const response = HttpServerResponse.html(`<!doctype html>
+  let response: HttpServerResponse.HttpServerResponse | undefined
+  return Effect.sync(() => {
+    if (response !== undefined) return response
+    const spec = OpenApi.fromApi(options.api)
+    const { customFetch, ...scalar } = options.scalar ?? {}
+    const scalarConfig = {
+      _integration: "html",
+      ...scalar
+    }
+    const scalarScript = options.source._tag === "Cdn"
+      ? `<script src="${
+        Html.escapeAttribute(
+          `https://cdn.jsdelivr.net/npm/@scalar/api-reference@${
+            encodeURIComponent(options.source.version ?? "latest")
+          }/dist/browser/standalone.min.js`
+        )
+      }" crossorigin></script>`
+      : `<script>${options.source.source}</script>`
+    response = HttpServerResponse.html(`<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
     <title>${Html.escape(spec.info.title)}</title>
     ${
-    !spec.info.description
-      ? ""
-      : `<meta name="description" content="${Html.escapeAttribute(spec.info.description)}"/>`
-  }
+      !spec.info.description
+        ? ""
+        : `<meta name="description" content="${Html.escapeAttribute(spec.info.description)}"/>`
+    }
     ${
-    !spec.info.description
-      ? ""
-      : `<meta name="og:description" content="${Html.escapeAttribute(spec.info.description)}"/>`
-  }
+      !spec.info.description
+        ? ""
+        : `<meta name="og:description" content="${Html.escapeAttribute(spec.info.description)}"/>`
+    }
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1" />
@@ -185,14 +188,15 @@ const makeHandler = <Id extends string, Groups extends HttpApiGroup.Constraint>(
       window.Scalar.createApiReference(document.getElementById('api-reference-container'), {
         ...${Html.escapeJson(scalarConfig)},
         content: ${Html.escapeJson(spec)}${
-    customFetch === undefined ? "" : `,
+      customFetch === undefined ? "" : `,
         customFetch: ${customFetch}`
-  }
+    }
       })
     </script>
   </body>
 </html>`)
-  return Effect.succeed(response)
+    return response
+  })
 }
 
 /**

--- a/packages/effect/src/unstable/httpapi/HttpApiSwagger.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSwagger.ts
@@ -21,8 +21,11 @@ import * as OpenApi from "./OpenApi.ts"
 const makeHandler = <Id extends string, Groups extends HttpApiGroup.Constraint>(options: {
   readonly api: HttpApi.HttpApi<Id, Groups>
 }) => {
-  const spec = OpenApi.fromApi(options.api)
-  const response = HttpServerResponse.html(`<!DOCTYPE html>
+  let response: HttpServerResponse.HttpServerResponse | undefined
+  return Effect.sync(() => {
+    if (response !== undefined) return response
+    const spec = OpenApi.fromApi(options.api)
+    response = HttpServerResponse.html(`<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
@@ -46,7 +49,8 @@ const makeHandler = <Id extends string, Groups extends HttpApiGroup.Constraint>(
   </script>
 </body>
 </html>`)
-  return Effect.succeed(response)
+    return response
+  })
 }
 
 /**

--- a/packages/effect/src/unstable/httpapi/HttpApiSwagger.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSwagger.ts
@@ -9,6 +9,7 @@
  * @since 4.0.0
  */
 import * as Effect from "../../Effect.ts"
+import * as Function from "../../Function.ts"
 import type * as Layer from "../../Layer.ts"
 import * as HttpRouter from "../http/HttpRouter.ts"
 import * as HttpServerResponse from "../http/HttpServerResponse.ts"
@@ -21,11 +22,9 @@ import * as OpenApi from "./OpenApi.ts"
 const makeHandler = <Id extends string, Groups extends HttpApiGroup.Constraint>(options: {
   readonly api: HttpApi.HttpApi<Id, Groups>
 }) => {
-  let response: HttpServerResponse.HttpServerResponse | undefined
-  return Effect.sync(() => {
-    if (response !== undefined) return response
-    const spec = OpenApi.fromApi(options.api)
-    response = HttpServerResponse.html(`<!DOCTYPE html>
+  const makeResponse = Function.memoize((api: HttpApi.HttpApi<Id, Groups>) => {
+    const spec = OpenApi.fromApi(api)
+    return HttpServerResponse.html(`<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
@@ -49,8 +48,8 @@ const makeHandler = <Id extends string, Groups extends HttpApiGroup.Constraint>(
   </script>
 </body>
 </html>`)
-    return response
   })
+  return Effect.sync(() => makeResponse(options.api))
 }
 
 /**

--- a/packages/effect/test/unstable/httpapi/HttpApiDocumentation.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiDocumentation.test.ts
@@ -1,9 +1,185 @@
-import { assert, describe, it } from "@effect/vitest"
-import { Effect, type Layer } from "effect"
-import { HttpRouter } from "effect/unstable/http"
-import { HttpApi, HttpApiScalar, HttpApiSwagger, OpenApi } from "effect/unstable/httpapi"
+import { assert, describe, it, vi } from "@effect/vitest"
+import { Effect, FileSystem, Layer, Path } from "effect"
+import { Etag, HttpPlatform, HttpRouter, HttpServerResponse } from "effect/unstable/http"
+import { HttpApi, HttpApiBuilder, HttpApiScalar, HttpApiSwagger, OpenApi } from "effect/unstable/httpapi"
+
+const TestServices = Layer.mergeAll(
+  Path.layer,
+  Etag.layerWeak,
+  HttpPlatform.layer
+).pipe(Layer.provideMerge(FileSystem.layerNoop({})))
+
+describe("HttpApiBuilder", () => {
+  it.effect("defers and memoizes successful openapiPath responses", () =>
+    Effect.gen(function*() {
+      let transforms = 0
+      const Api = HttpApi.make("OpenApiPath").annotate(
+        OpenApi.Transform,
+        (spec) => {
+          transforms++
+          return spec
+        }
+      )
+      const Health = HttpRouter.use((router) => router.add("GET", "/health", HttpServerResponse.text("OK")))
+
+      yield* Effect.acquireUseRelease(
+        Effect.sync(() => vi.spyOn(HttpServerResponse, "jsonUnsafe")),
+        (jsonUnsafe) =>
+          withHandler(
+            Layer.merge(HttpApiBuilder.layer(Api, { openapiPath: "/openapi.json" }), Health).pipe(
+              Layer.provide(TestServices)
+            ),
+            (handler) =>
+              Effect.gen(function*() {
+                const health = yield* Effect.promise(() => handler(new Request("http://test/health")))
+                assert.strictEqual(health.status, 200)
+                assert.strictEqual(transforms, 0)
+                assert.strictEqual(jsonUnsafe.mock.calls.length, 0)
+
+                const firstRequests = yield* Effect.promise(() =>
+                  Promise.all(
+                    Array.from({ length: 20 }, () => handler(new Request("http://test/openapi.json")))
+                  )
+                )
+                assert.ok(firstRequests.every((response) => response.status === 200))
+                assert.strictEqual(transforms, 1)
+                assert.strictEqual(jsonUnsafe.mock.calls.length, 1)
+
+                const cached = yield* Effect.promise(() => handler(new Request("http://test/openapi.json")))
+                assert.strictEqual(cached.status, 200)
+                assert.strictEqual(transforms, 1)
+                assert.strictEqual(jsonUnsafe.mock.calls.length, 1)
+              })
+          ),
+        (jsonUnsafe) => Effect.sync(() => jsonUnsafe.mockRestore())
+      )
+    }))
+
+  it.effect("retries openapiPath generation after a defect", () =>
+    Effect.gen(function*() {
+      let transforms = 0
+      const Api = HttpApi.make("OpenApiPathRecovery").annotate(
+        OpenApi.Transform,
+        (spec) => {
+          transforms++
+          if (transforms === 1) throw new Error("OpenAPI generation defect")
+          return spec
+        }
+      )
+
+      yield* withHandler(
+        HttpApiBuilder.layer(Api, { openapiPath: "/openapi.json" }).pipe(Layer.provide(TestServices)),
+        (handler) =>
+          Effect.gen(function*() {
+            const first = yield* Effect.promise(() => handler(new Request("http://test/openapi.json")))
+            assert.strictEqual(first.status, 500)
+            assert.strictEqual(transforms, 1)
+
+            const second = yield* Effect.promise(() => handler(new Request("http://test/openapi.json")))
+            assert.strictEqual(second.status, 200)
+            assert.strictEqual(transforms, 2)
+
+            const cached = yield* Effect.promise(() => handler(new Request("http://test/openapi.json")))
+            assert.strictEqual(cached.status, 200)
+            assert.strictEqual(transforms, 2)
+          })
+      )
+    }))
+})
 
 describe("HttpApiScalar", () => {
+  it.effect("defers and memoizes successful OpenAPI responses", () =>
+    Effect.gen(function*() {
+      let transforms = 0
+      const Api = HttpApi.make("Docs").annotate(
+        OpenApi.Transform,
+        (spec) => {
+          transforms++
+          return spec
+        }
+      )
+      const Health = HttpRouter.use((router) => router.add("GET", "/health", HttpServerResponse.text("OK")))
+
+      yield* Effect.acquireUseRelease(
+        Effect.sync(() => vi.spyOn(HttpServerResponse, "html")),
+        (html) =>
+          withHandler(Layer.merge(HttpApiScalar.layerCdn(Api), Health), (handler) =>
+            Effect.gen(function*() {
+              const health = yield* Effect.promise(() => handler(new Request("http://test/health")))
+              assert.strictEqual(health.status, 200)
+              assert.strictEqual(transforms, 0)
+              assert.strictEqual(html.mock.calls.length, 0)
+
+              const firstRequests = yield* Effect.promise(() =>
+                Promise.all(
+                  Array.from({ length: 20 }, () => handler(new Request("http://test/docs")))
+                )
+              )
+              assert.ok(firstRequests.every((response) => response.status === 200))
+              assert.strictEqual(transforms, 1)
+              assert.strictEqual(html.mock.calls.length, 1)
+
+              const cached = yield* Effect.promise(() => handler(new Request("http://test/docs")))
+              assert.strictEqual(cached.status, 200)
+              assert.strictEqual(transforms, 1)
+              assert.strictEqual(html.mock.calls.length, 1)
+            })),
+        (html) => Effect.sync(() => html.mockRestore())
+      )
+    }))
+
+  it.effect("retries OpenAPI generation after a defect", () =>
+    Effect.gen(function*() {
+      let transforms = 0
+      const Api = HttpApi.make("ScalarRecovery").annotate(
+        OpenApi.Transform,
+        (spec) => {
+          transforms++
+          if (transforms === 1) throw new Error("OpenAPI generation defect")
+          return spec
+        }
+      )
+
+      yield* withHandler(HttpApiScalar.layerCdn(Api), (handler) =>
+        Effect.gen(function*() {
+          const first = yield* Effect.promise(() => handler(new Request("http://test/docs")))
+          assert.strictEqual(first.status, 500)
+          assert.strictEqual(transforms, 1)
+
+          const second = yield* Effect.promise(() => handler(new Request("http://test/docs")))
+          assert.strictEqual(second.status, 200)
+          assert.strictEqual(transforms, 2)
+
+          const cached = yield* Effect.promise(() => handler(new Request("http://test/docs")))
+          assert.strictEqual(cached.status, 200)
+          assert.strictEqual(transforms, 2)
+        }))
+    }))
+
+  it.effect("defers inline Scalar generation until the route is requested", () =>
+    Effect.gen(function*() {
+      let transforms = 0
+      const Api = HttpApi.make("ScalarInline").annotate(
+        OpenApi.Transform,
+        (spec) => {
+          transforms++
+          return spec
+        }
+      )
+      const Health = HttpRouter.use((router) => router.add("GET", "/health", HttpServerResponse.text("OK")))
+
+      yield* withHandler(Layer.merge(HttpApiScalar.layer(Api), Health), (handler) =>
+        Effect.gen(function*() {
+          const health = yield* Effect.promise(() => handler(new Request("http://test/health")))
+          assert.strictEqual(health.status, 200)
+          assert.strictEqual(transforms, 0)
+
+          const docs = yield* Effect.promise(() => handler(new Request("http://test/docs")))
+          assert.strictEqual(docs.status, 200)
+          assert.strictEqual(transforms, 1)
+        }))
+    }))
+
   it.effect("escapes OpenAPI metadata in its HTML contexts", () =>
     Effect.gen(function*() {
       const title = `Docs "title" </title><script>`
@@ -40,6 +216,74 @@ describe("HttpApiScalar", () => {
 })
 
 describe("HttpApiSwagger", () => {
+  it.effect("defers and memoizes successful OpenAPI responses", () =>
+    Effect.gen(function*() {
+      let transforms = 0
+      const Api = HttpApi.make("Docs").annotate(
+        OpenApi.Transform,
+        (spec) => {
+          transforms++
+          return spec
+        }
+      )
+      const Health = HttpRouter.use((router) => router.add("GET", "/health", HttpServerResponse.text("OK")))
+
+      yield* Effect.acquireUseRelease(
+        Effect.sync(() => vi.spyOn(HttpServerResponse, "html")),
+        (html) =>
+          withHandler(Layer.merge(HttpApiSwagger.layer(Api), Health), (handler) =>
+            Effect.gen(function*() {
+              const health = yield* Effect.promise(() => handler(new Request("http://test/health")))
+              assert.strictEqual(health.status, 200)
+              assert.strictEqual(transforms, 0)
+              assert.strictEqual(html.mock.calls.length, 0)
+
+              const firstRequests = yield* Effect.promise(() =>
+                Promise.all(
+                  Array.from({ length: 20 }, () => handler(new Request("http://test/docs")))
+                )
+              )
+              assert.ok(firstRequests.every((response) => response.status === 200))
+              assert.strictEqual(transforms, 1)
+              assert.strictEqual(html.mock.calls.length, 1)
+
+              const cached = yield* Effect.promise(() => handler(new Request("http://test/docs")))
+              assert.strictEqual(cached.status, 200)
+              assert.strictEqual(transforms, 1)
+              assert.strictEqual(html.mock.calls.length, 1)
+            })),
+        (html) => Effect.sync(() => html.mockRestore())
+      )
+    }))
+
+  it.effect("retries OpenAPI generation after a defect", () =>
+    Effect.gen(function*() {
+      let transforms = 0
+      const Api = HttpApi.make("SwaggerRecovery").annotate(
+        OpenApi.Transform,
+        (spec) => {
+          transforms++
+          if (transforms === 1) throw new Error("OpenAPI generation defect")
+          return spec
+        }
+      )
+
+      yield* withHandler(HttpApiSwagger.layer(Api), (handler) =>
+        Effect.gen(function*() {
+          const first = yield* Effect.promise(() => handler(new Request("http://test/docs")))
+          assert.strictEqual(first.status, 500)
+          assert.strictEqual(transforms, 1)
+
+          const second = yield* Effect.promise(() => handler(new Request("http://test/docs")))
+          assert.strictEqual(second.status, 200)
+          assert.strictEqual(transforms, 2)
+
+          const cached = yield* Effect.promise(() => handler(new Request("http://test/docs")))
+          assert.strictEqual(cached.status, 200)
+          assert.strictEqual(transforms, 2)
+        }))
+    }))
+
   it.effect("escapes script end-tag variants in OpenAPI data", () =>
     Effect.gen(function*() {
       const injectedTag = `<script id="script-data-injected">`
@@ -53,16 +297,22 @@ describe("HttpApiSwagger", () => {
     }))
 })
 
-const render = (layer: Layer.Layer<never, never, HttpRouter.HttpRouter>) =>
+const withHandler = <A, E, R>(
+  layer: Layer.Layer<never, never, HttpRouter.HttpRouter>,
+  use: (handler: (request: Request) => Promise<Response>) => Effect.Effect<A, E, R>
+) =>
   Effect.acquireUseRelease(
     Effect.sync(() => HttpRouter.toWebHandler(layer, { disableLogger: true })),
-    ({ handler }) =>
-      Effect.flatMap(
-        Effect.promise(() => handler(new Request("http://test/docs"))),
-        (response) => Effect.promise(() => response.text())
-      ),
+    ({ handler }) => use(handler),
     ({ dispose }) => Effect.promise(dispose)
   )
+
+const render = (layer: Layer.Layer<never, never, HttpRouter.HttpRouter>) =>
+  withHandler(layer, (handler) =>
+    Effect.flatMap(
+      Effect.promise(() => handler(new Request("http://test/docs"))),
+      (response) => Effect.promise(() => response.text())
+    ))
 
 function extractSpec(html: string): unknown {
   const marker = "        content: "


### PR DESCRIPTION
## Summary

- defer Scalar, Swagger, and `openapiPath` generation until their routes are first requested
- cache successful responses and retry after generation defects

`OpenApi.fromApi` already caches successful specifications. This moves its first invocation and response serialization out of Layer acquisition.

## Testing

- `pnpm test --run packages/effect/test/unstable/httpapi/HttpApiDocumentation.test.ts` (10 tests)
- `pnpm check`
- `pnpm lint-fix`