### PR TITLE
Skip empty remote journal write callbacks

### DIFF
--- a/.changeset/eff-851-skip-empty-remote-write.md
+++ b/.changeset/eff-851-skip-empty-remote-write.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Skip remote event journal write callbacks when there are no uncommitted entries.

--- a/.changeset/eff-851-skip-empty-remote-write.md
+++ b/.changeset/eff-851-skip-empty-remote-write.md
@@ -2,4 +2,5 @@
 "effect": patch
 ---
 
-Skip remote event journal write callbacks when there are no uncommitted entries.
+Skip remote event journal write callbacks when there are no uncommitted entries and return an `Option` indicating
+whether the callback ran.

--- a/packages/effect/src/unstable/eventlog/EventJournal.ts
+++ b/packages/effect/src/unstable/eventlog/EventJournal.ts
@@ -11,6 +11,7 @@
  *
  * @since 4.0.0
  */
+import * as Arr from "../../Array.ts"
 import type { Brand } from "../../Brand.ts"
 import * as Context from "../../Context.ts"
 import * as Data from "../../Data.ts"
@@ -18,6 +19,7 @@ import * as DateTime from "../../DateTime.ts"
 import * as Effect from "../../Effect.ts"
 import * as Uuid from "../../internal/uuid.ts"
 import * as Layer from "../../Layer.ts"
+import type { Option } from "../../Option.ts"
 import * as Order from "../../Order.ts"
 import * as PubSub from "../../PubSub.ts"
 import * as Schema from "../../Schema.ts"
@@ -80,12 +82,14 @@ export class EventJournal extends Context.Service<EventJournal, {
   /**
    * Run an effect with the uncommitted entries for a remote source.
    *
-   * The effect is not run when there are no uncommitted entries.
+   * The effect is not run when there are no uncommitted entries, in which case
+   * `Option.none()` is returned. Otherwise, its result is wrapped in
+   * `Option.some()`.
    */
   readonly withRemoteUncommited: <A, E, R>(
     remoteId: RemoteId,
-    f: (entries: ReadonlyArray<Entry>) => Effect.Effect<A, E, R>
-  ) => Effect.Effect<A | void, EventJournalError | E, R>
+    f: (entries: Arr.NonEmptyReadonlyArray<Entry>) => Effect.Effect<A, E, R>
+  ) => Effect.Effect<Option<A>, EventJournalError | E, R>
 
   /**
    * Retrieve the first unused sequence number for a remote source.
@@ -473,7 +477,7 @@ export const makeMemory: Effect.Effect<EventJournal["Service"]> = Effect.gen(fun
     withRemoteUncommited: (remoteId, f) =>
       Effect.acquireUseRelease(
         Effect.sync(() => ensureRemote(remoteId).missing.slice()),
-        (entries) => entries.length === 0 ? Effect.void : f(entries),
+        (entries) => Arr.isReadonlyArrayNonEmpty(entries) ? Effect.asSome(f(entries)) : Effect.succeedNone,
         (entries, exit) =>
           Effect.sync(() => {
             if (exit._tag === "Failure") return
@@ -707,7 +711,7 @@ export const makeIndexedDb = (options?: {
           return Effect.sync(() => tx.abort())
         }).pipe(
           Effect.flatMap((entries) => {
-            if (entries.length === 0) return Effect.void
+            if (!Arr.isReadonlyArrayNonEmpty(entries)) return Effect.succeedNone
             const entryId = entries[entries.length - 1].id
             return Effect.uninterruptibleMask((restore) =>
               restore(f(entries)).pipe(
@@ -717,7 +721,8 @@ export const makeIndexedDb = (options?: {
                       remoteId,
                       entryId
                     }))
-                )
+                ),
+                Effect.asSome
               )
             )
           })

--- a/packages/effect/src/unstable/eventlog/EventJournal.ts
+++ b/packages/effect/src/unstable/eventlog/EventJournal.ts
@@ -78,12 +78,14 @@ export class EventJournal extends Context.Service<EventJournal, {
   }, EventJournalError>
 
   /**
-   * Return the uncommitted entries for a remote source.
+   * Run an effect with the uncommitted entries for a remote source.
+   *
+   * The effect is not run when there are no uncommitted entries.
    */
   readonly withRemoteUncommited: <A, E, R>(
     remoteId: RemoteId,
     f: (entries: ReadonlyArray<Entry>) => Effect.Effect<A, E, R>
-  ) => Effect.Effect<A, EventJournalError | E, R>
+  ) => Effect.Effect<A | void, EventJournalError | E, R>
 
   /**
    * Retrieve the first unused sequence number for a remote source.
@@ -471,7 +473,7 @@ export const makeMemory: Effect.Effect<EventJournal["Service"]> = Effect.gen(fun
     withRemoteUncommited: (remoteId, f) =>
       Effect.acquireUseRelease(
         Effect.sync(() => ensureRemote(remoteId).missing.slice()),
-        f,
+        (entries) => entries.length === 0 ? Effect.void : f(entries),
         (entries, exit) =>
           Effect.sync(() => {
             if (exit._tag === "Failure") return
@@ -705,7 +707,7 @@ export const makeIndexedDb = (options?: {
           return Effect.sync(() => tx.abort())
         }).pipe(
           Effect.flatMap((entries) => {
-            if (entries.length === 0) return f(entries)
+            if (entries.length === 0) return Effect.void
             const entryId = entries[entries.length - 1].id
             return Effect.uninterruptibleMask((restore) =>
               restore(f(entries)).pipe(

--- a/packages/effect/src/unstable/eventlog/SqlEventJournal.ts
+++ b/packages/effect/src/unstable/eventlog/SqlEventJournal.ts
@@ -249,6 +249,7 @@ export const make = (options?: {
             Effect.flatMap(decodeEntryRows),
             Effect.map(toEntries)
           )
+          if (entries.length === 0) return
           return yield* f(entries)
         },
         withTracerDisabled,

--- a/packages/effect/src/unstable/eventlog/SqlEventJournal.ts
+++ b/packages/effect/src/unstable/eventlog/SqlEventJournal.ts
@@ -8,6 +8,7 @@
  *
  * @since 4.0.0
  */
+import * as Arr from "../../Array.ts"
 import * as Effect from "../../Effect.ts"
 import * as Uuid from "../../internal/uuid.ts"
 import * as Layer from "../../Layer.ts"
@@ -249,8 +250,8 @@ export const make = (options?: {
             Effect.flatMap(decodeEntryRows),
             Effect.map(toEntries)
           )
-          if (entries.length === 0) return
-          return yield* f(entries)
+          if (!Arr.isReadonlyArrayNonEmpty(entries)) return yield* Effect.succeedNone
+          return yield* Effect.asSome(f(entries))
         },
         withTracerDisabled,
         Effect.mapError((cause) => new EventJournal.EventJournalError({ cause, method: "withRemoteUncommited" }))

--- a/packages/effect/test/unstable/eventlog/EventJournal.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventJournal.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect } from "effect"
+import { Effect, Option } from "effect"
 import * as EventJournal from "effect/unstable/eventlog/EventJournal"
 
 const entry = (msecs: number) =>
@@ -34,8 +34,8 @@ describe("EventJournal", () => {
           targetCalls++
           return entries
         }))
-      if (missing === undefined) assert.fail("Expected the callback result")
-      assert.deepStrictEqual(missing.map((item) => item.idString), [entry.idString])
+      if (Option.isNone(missing)) assert.fail("Expected the callback result")
+      assert.deepStrictEqual(missing.value.map((item) => item.idString), [entry.idString])
       assert.strictEqual(targetCalls, 1)
 
       let sourceCalls = 0
@@ -44,7 +44,7 @@ describe("EventJournal", () => {
           sourceCalls++
           return "called"
         }))
-      assert.strictEqual(sourceMissing, undefined)
+      assert.isTrue(Option.isNone(sourceMissing))
       assert.strictEqual(sourceCalls, 0)
     }))
 

--- a/packages/effect/test/unstable/eventlog/EventJournal.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventJournal.test.ts
@@ -28,10 +28,24 @@ describe("EventJournal", () => {
         entries: [new EventJournal.RemoteEntry({ remoteSequence: 0, entry })],
         effect: () => Effect.void
       })
-      const missing = yield* journal.withRemoteUncommited(target, Effect.succeed)
+      let targetCalls = 0
+      const missing = yield* journal.withRemoteUncommited(target, (entries) =>
+        Effect.sync(() => {
+          targetCalls++
+          return entries
+        }))
+      if (missing === undefined) assert.fail("Expected the callback result")
       assert.deepStrictEqual(missing.map((item) => item.idString), [entry.idString])
-      const sourceMissing = yield* journal.withRemoteUncommited(source, Effect.succeed)
-      assert.deepStrictEqual(sourceMissing, [])
+      assert.strictEqual(targetCalls, 1)
+
+      let sourceCalls = 0
+      const sourceMissing = yield* journal.withRemoteUncommited(source, () =>
+        Effect.sync(() => {
+          sourceCalls++
+          return "called"
+        }))
+      assert.strictEqual(sourceMissing, undefined)
+      assert.strictEqual(sourceCalls, 0)
     }))
 
   it.effect("returns the next unused remote sequence", () =>

--- a/packages/sql/sqlite-node/test/SqlEventJournal.test.ts
+++ b/packages/sql/sqlite-node/test/SqlEventJournal.test.ts
@@ -81,15 +81,31 @@ describe("SqlEventJournal", () => {
       const next = yield* journal.nextRemoteSequence(remoteId)
       assert.strictEqual(next, 2)
 
+      let emptyCalls = 0
+      const emptyResult = yield* journal.withRemoteUncommited(remoteId, () =>
+        Effect.sync(() => {
+          emptyCalls++
+          return "called"
+        }))
+      assert.strictEqual(emptyResult, undefined)
+      assert.strictEqual(emptyCalls, 0)
+
       yield* journal.write({
         event: "LocalCreated",
         primaryKey: "local-1",
         payload: new Uint8Array([4]),
         effect: () => Effect.void
       })
-      const uncommitted = yield* journal.withRemoteUncommited(remoteId, (entries) => Effect.succeed(entries))
+      let uncommittedCalls = 0
+      const uncommitted = yield* journal.withRemoteUncommited(remoteId, (entries) =>
+        Effect.sync(() => {
+          uncommittedCalls++
+          return entries
+        }))
+      if (uncommitted === undefined) assert.fail("Expected the callback result")
       assert.strictEqual(uncommitted.length, 1)
       assert.strictEqual(uncommitted[0].event, "LocalCreated")
+      assert.strictEqual(uncommittedCalls, 1)
       assert.strictEqual(seenConflicts.length, 2)
       assert.strictEqual(seenConflicts[0][0]?.idString, entryA.idString)
       assert.strictEqual(seenConflicts[1][0]?.idString, entryB.idString)

--- a/packages/sql/sqlite-node/test/SqlEventJournal.test.ts
+++ b/packages/sql/sqlite-node/test/SqlEventJournal.test.ts
@@ -1,6 +1,6 @@
 import { SqliteClient } from "@effect/sql-sqlite-node"
 import { assert, describe, it } from "@effect/vitest"
-import { Effect } from "effect"
+import { Effect, Option } from "effect"
 import * as EventJournal from "effect/unstable/eventlog/EventJournal"
 import * as SqlEventJournal from "effect/unstable/eventlog/SqlEventJournal"
 import { Reactivity } from "effect/unstable/reactivity"
@@ -87,7 +87,7 @@ describe("SqlEventJournal", () => {
           emptyCalls++
           return "called"
         }))
-      assert.strictEqual(emptyResult, undefined)
+      assert.isTrue(Option.isNone(emptyResult))
       assert.strictEqual(emptyCalls, 0)
 
       yield* journal.write({
@@ -102,9 +102,9 @@ describe("SqlEventJournal", () => {
           uncommittedCalls++
           return entries
         }))
-      if (uncommitted === undefined) assert.fail("Expected the callback result")
-      assert.strictEqual(uncommitted.length, 1)
-      assert.strictEqual(uncommitted[0].event, "LocalCreated")
+      if (Option.isNone(uncommitted)) assert.fail("Expected the callback result")
+      assert.strictEqual(uncommitted.value.length, 1)
+      assert.strictEqual(uncommitted.value[0].event, "LocalCreated")
       assert.strictEqual(uncommittedCalls, 1)
       assert.strictEqual(seenConflicts.length, 2)
       assert.strictEqual(seenConflicts[0][0]?.idString, entryA.idString)


### PR DESCRIPTION
## Summary

- skip `withRemoteUncommited` callbacks when no entries are pending
- preserve callback results for non-empty memory, IndexedDB, and SQL journals
- cover empty and non-empty callback behavior in the memory and SQLite tests

## Validation

- `pnpm test --run packages/effect/test/unstable/eventlog/EventJournal.test.ts`
- `pnpm test --run packages/sql/sqlite-node/test/SqlEventJournal.test.ts`
- `pnpm lint-fix`
- `pnpm check`
- `git diff --check`

Closes EFF-851
