### PR TITLE
Default TCP cluster serialization to SchemaBinary

### DIFF
--- a/.changeset/tcp-schema-binary-default.md
+++ b/.changeset/tcp-schema-binary-default.md
@@ -6,3 +6,5 @@
 ---
 
 Use SchemaBinary as the default RPC serialization for TCP cluster connections, including configurable frame limits.
+
+Cluster payloads are encoded with the binary codec on the wire. When a persisted reply cannot be encoded for JSON storage, the defect fallback that storage records is now also the reply delivered to waiting callers, so live replies always match what was persisted.

--- a/.changeset/tcp-schema-binary-default.md
+++ b/.changeset/tcp-schema-binary-default.md
@@ -1,0 +1,7 @@
+---
+"@effect/platform-bun": patch
+"@effect/platform-deno": patch
+"@effect/platform-node": patch
+---
+
+Use SchemaBinary as the default RPC serialization for TCP cluster connections.

--- a/.changeset/tcp-schema-binary-default.md
+++ b/.changeset/tcp-schema-binary-default.md
@@ -2,6 +2,7 @@
 "@effect/platform-bun": patch
 "@effect/platform-deno": patch
 "@effect/platform-node": patch
+"effect": patch
 ---
 
-Use SchemaBinary as the default RPC serialization for TCP cluster connections.
+Use SchemaBinary as the default RPC serialization for TCP cluster connections, including configurable frame limits.

--- a/.changeset/tcp-schema-binary-default.md
+++ b/.changeset/tcp-schema-binary-default.md
@@ -9,4 +9,4 @@ Use SchemaBinary as the default RPC serialization for TCP cluster connections, i
 
 Cluster payloads are encoded with the binary codec on the wire. When a persisted reply cannot be encoded for JSON storage, the defect fallback that storage records is now also the reply delivered to waiting callers, so live replies always match what was persisted.
 
-SchemaBinary payload codecs are memoized by schema, so per-message codec requests reuse the compiled layout instead of recompiling it.
+SchemaBinary codecs are memoized by schema identity and wire mode, so per-message codec requests reuse the derived codec instead of rebuilding it.

--- a/.changeset/tcp-schema-binary-default.md
+++ b/.changeset/tcp-schema-binary-default.md
@@ -8,3 +8,5 @@
 Use SchemaBinary as the default RPC serialization for TCP cluster connections, including configurable frame limits.
 
 Cluster payloads are encoded with the binary codec on the wire. When a persisted reply cannot be encoded for JSON storage, the defect fallback that storage records is now also the reply delivered to waiting callers, so live replies always match what was persisted.
+
+SchemaBinary payload codecs are memoized by schema, so per-message codec requests reuse the compiled layout instead of recompiling it.

--- a/packages/effect/benchmark/rpc/RpcSerialization.ts
+++ b/packages/effect/benchmark/rpc/RpcSerialization.ts
@@ -211,7 +211,7 @@ console.log(
   "End-to-end operations include the payload codec plus RPC envelope framing; codec construction is excluded."
 )
 console.log(
-  "Msgpack uses RpcSerialization.msgPack defaults, including records. SchemaBinary fingerprints envelopes only and shares one string dictionary across the frames of a connection."
+  "Msgpack uses RpcSerialization.msgPack defaults, including records. SchemaBinary fingerprints envelopes only and keeps every frame independently decodable."
 )
 console.log(
   "First-frame sizes use a fresh serializer; steady sizes and throughput reuse one as on a long-lived connection, and decode walks a stream in frame order."

--- a/packages/effect/src/unstable/cluster/MessageStorage.ts
+++ b/packages/effect/src/unstable/cluster/MessageStorage.ts
@@ -478,10 +478,23 @@ export type EncodedRepliesOptions<A> = {
  * @since 4.0.0
  */
 export const make = (
-  storage: Omit<
-    MessageStorage["Service"],
-    "registerReplyHandler" | "unregisterReplyHandler" | "unregisterShardReplyHandlers"
-  >
+  storage:
+    & Omit<
+      MessageStorage["Service"],
+      "saveReply" | "registerReplyHandler" | "unregisterReplyHandler" | "unregisterShardReplyHandlers"
+    >
+    & {
+      /**
+       * Save the provided `Reply`, returning the reply as it was persisted.
+       *
+       * Implementations that persist a different representation, such as a
+       * defect reply when the original cannot be encoded, return that fallback
+       * so reply handlers deliver exactly what storage recorded.
+       */
+      readonly saveReply: <R extends Rpc.Any>(
+        reply: Reply.ReplyWithContext<R>
+      ) => Effect.Effect<Reply.ReplyWithContext<R>, PersistenceError | MalformedMessage>
+    }
 ): Effect.Effect<MessageStorage["Service"]> =>
   Effect.sync(() => {
     type ReplyHandler = {
@@ -555,11 +568,11 @@ export const make = (
         }),
       saveReply(reply) {
         const requestId = reply.reply.requestId
-        return Effect.flatMap(storage.saveReply(reply), () => {
+        return Effect.flatMap(storage.saveReply(reply), (persisted) => {
           const handlers = replyHandlers.get(requestId)
           if (!handlers) {
             return Effect.void
-          } else if (reply.reply._tag === "WithExit") {
+          } else if (persisted.reply._tag === "WithExit") {
             replyHandlers.delete(requestId)
             for (let i = 0; i < handlers.length; i++) {
               const handler = handlers[i]
@@ -568,8 +581,8 @@ export const make = (
             }
           }
           return handlers.length === 1
-            ? handlers[0].respond(reply)
-            : Effect.forEach(handlers, (handler) => handler.respond(reply))
+            ? handlers[0].respond(persisted)
+            : Effect.forEach(handlers, (handler) => handler.respond(persisted))
         })
       }
     })
@@ -634,7 +647,22 @@ export const makeEncoded: (encoded: Encoded) => Effect.Effect<
         ),
         Effect.asVoid
       ),
-    saveReply: (reply) => Effect.flatMap(Reply.serializeOrDefect(reply, codecForJson), encoded.saveReply),
+    saveReply: (reply) =>
+      Reply.serialize(reply, codecForJson).pipe(
+        Effect.map((encodedReply) => ({ encodedReply, persisted: reply })),
+        Effect.catchTag("MalformedMessage", (error) => {
+          const persisted = Reply.ReplyWithContext.fromDefect({
+            id: reply.reply.id,
+            requestId: reply.reply.requestId,
+            defect: error
+          })
+          return Effect.map(
+            Effect.orDie(Reply.serialize(persisted, codecForJson)),
+            (encodedReply) => ({ encodedReply, persisted })
+          )
+        }),
+        Effect.flatMap(({ encodedReply, persisted }) => Effect.as(encoded.saveReply(encodedReply), persisted))
+      ),
     clearReplies: encoded.clearReplies,
     repliesFor: Effect.fnUntraced(function*(messages) {
       const requestIds = Arr.empty<string>()
@@ -658,7 +686,7 @@ export const makeEncoded: (encoded: Encoded) => Effect.Effect<
       return encoded.requestIdForPrimaryKey(primaryKey)
     },
     unprocessedMessages(shardIds, options) {
-      const storage = this as MessageStorage["Service"]
+      const storage = this as unknown as MessageStorage["Service"]
       const shards = Array.from(shardIds, (id) => id.toString())
       if (!Arr.isArrayNonEmpty(shards)) return Effect.succeed([])
       if (options?.addresses !== undefined && options.addresses.length === 0) return Effect.succeed([])
@@ -668,7 +696,7 @@ export const makeEncoded: (encoded: Encoded) => Effect.Effect<
       )
     },
     unprocessedMessagesById(messageIds) {
-      const storage = this as MessageStorage["Service"]
+      const storage = this as unknown as MessageStorage["Service"]
       const ids = Array.from(messageIds)
       if (!Arr.isArrayNonEmpty(ids)) return Effect.succeed([])
       return Effect.flatMap(
@@ -799,7 +827,7 @@ export const makeEncoded: (encoded: Encoded) => Effect.Effect<
 export const noop: MessageStorage["Service"] = Effect.runSync(make({
   saveRequest: () => Effect.succeed(SaveResult.Success()),
   saveEnvelope: () => Effect.void,
-  saveReply: () => Effect.void,
+  saveReply: (reply) => Effect.succeed(reply),
   clearReplies: () => Effect.void,
   repliesFor: () => Effect.succeed([]),
   repliesForUnfiltered: () => Effect.succeed([]),

--- a/packages/effect/src/unstable/encoding/SchemaBinary.ts
+++ b/packages/effect/src/unstable/encoding/SchemaBinary.ts
@@ -67,11 +67,17 @@ export interface toCodec<S extends Schema.Constraint> extends
   >
 {}
 
+const codecCache = new WeakMap<Schema.Constraint, toCodec<any>>()
+const fingerprintCodecCache = new WeakMap<Schema.Constraint, toCodec<any>>()
+const directCodecCache = new WeakMap<Schema.Constraint, toCodec<any>>()
+const directFingerprintCodecCache = new WeakMap<Schema.Constraint, toCodec<any>>()
+
 /**
  * Derives a compact binary codec from a schema.
  *
  * The wire layout is compiled from the encoded side of the schema. Each
  * encode/decode handles exactly one frame; use {@link parser} for streams.
+ * Derived codecs are memoized by schema identity and wire mode.
  *
  * Encoded results are arena-backed views and may share a larger buffer. Use
  * `bytes.slice()` when independent ownership is required.
@@ -93,15 +99,20 @@ export interface toCodec<S extends Schema.Constraint> extends
  * @since 4.0.0
  */
 export function toCodec<S extends Schema.Constraint>(schema: S, options?: Options): toCodec<S> {
+  const cache = options?.fingerprint === true ? fingerprintCodecCache : codecCache
+  const cached = cache.get(schema)
+  if (cached !== undefined) return cached
   const { exact, layout, recursive, target } = compileTarget(schema)
   const mode = compileMode(layout, options?.fingerprint)
   const trusted: Trusted | undefined = exact ? { value: undefined } : undefined
-  return assembleCodec(
+  const codec = assembleCodec<S>(
     trusted === undefined ? target : withTrustedDecode(target, trusted, !recursive),
     layout,
     mode,
     trusted
   )
+  cache.set(schema, codec)
+  return codec
 }
 
 /**
@@ -111,24 +122,37 @@ export function toCodec<S extends Schema.Constraint>(schema: S, options?: Option
  * Only schemas the binary layer already validates on its own take the direct
  * path; anything else falls back to {@link toCodec}. A direct codec encodes and
  * decodes the same values as {@link toCodec} but is not a sound `Schema.is`
- * guard, so it is only for callers that never guard on it.
+ * guard, so it is only for callers that never guard on it. Derived codecs are
+ * memoized by schema identity and wire mode.
  *
  * @internal
  */
 export function toCodecDirect<S extends Schema.Constraint>(schema: S, options?: Options): toCodec<S> {
+  const cache = options?.fingerprint === true ? directFingerprintCodecCache : directCodecCache
+  const cached = cache.get(schema)
+  if (cached !== undefined) return cached
   const { exact, exitSuccess, layout, target } = compileTarget(schema)
   if (!exact) {
     if (!exitSuccess) return toCodec(schema, options)
     const trusted: Trusted = { value: undefined }
-    return assembleCodec(
+    const codec = assembleCodec<S>(
       withExitSuccessDecode(target, trusted),
       layout,
       compileMode(layout, options?.fingerprint),
       trusted,
       true
     )
+    cache.set(schema, codec)
+    return codec
   }
-  return assembleCodec(passThrough(target), layout, compileMode(layout, options?.fingerprint), undefined)
+  const codec = assembleCodec<S>(
+    passThrough(target),
+    layout,
+    compileMode(layout, options?.fingerprint),
+    undefined
+  )
+  cache.set(schema, codec)
+  return codec
 }
 
 function assembleCodec<S extends Schema.Constraint>(

--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -602,21 +602,9 @@ const makeSchemaBinary = (options?: {
   const maxFrameSize = options?.maxFrameSize === "unbounded"
     ? undefined
     : options?.maxFrameSize ?? defaultSchemaBinaryMaxFrameSize
-  const makeCodec: CodecFor = options?.fingerprintPayloads === true
+  const codecFor: CodecFor = options?.fingerprintPayloads === true
     ? (schema) => SchemaBinary.toCodecDirect(schema, { fingerprint: true })
     : SchemaBinary.toCodecDirect
-  // Deriving a binary codec compiles the schema layout, which is far more
-  // expensive than a per-message encode. Callers such as the cluster message
-  // paths request the codec per message, so memoize by schema identity.
-  const codecCache = new WeakMap<Schema.Top, ReturnType<CodecFor>>()
-  const codecFor: CodecFor = (schema) => {
-    let codec = codecCache.get(schema)
-    if (codec === undefined) {
-      codec = makeCodec(schema)
-      codecCache.set(schema, codec)
-    }
-    return codec as any
-  }
   const envelopeOptions = { fingerprint: true } as const
   return RpcSerialization.of({
     contentType: "application/vnd.effect.rpc+schema-binary",

--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -602,9 +602,21 @@ const makeSchemaBinary = (options?: {
   const maxFrameSize = options?.maxFrameSize === "unbounded"
     ? undefined
     : options?.maxFrameSize ?? defaultSchemaBinaryMaxFrameSize
-  const codecFor: CodecFor = options?.fingerprintPayloads === true
+  const makeCodec: CodecFor = options?.fingerprintPayloads === true
     ? (schema) => SchemaBinary.toCodecDirect(schema, { fingerprint: true })
     : SchemaBinary.toCodecDirect
+  // Deriving a binary codec compiles the schema layout, which is far more
+  // expensive than a per-message encode. Callers such as the cluster message
+  // paths request the codec per message, so memoize by schema identity.
+  const codecCache = new WeakMap<Schema.Top, ReturnType<CodecFor>>()
+  const codecFor: CodecFor = (schema) => {
+    let codec = codecCache.get(schema)
+    if (codec === undefined) {
+      codec = makeCodec(schema)
+      codecCache.set(schema, codec)
+    }
+    return codec as any
+  }
   const envelopeOptions = { fingerprint: true } as const
   return RpcSerialization.of({
     contentType: "application/vnd.effect.rpc+schema-binary",

--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -596,10 +596,12 @@ const defaultSchemaBinaryMaxFrameSize = 16 * 1024 * 1024
 const schemaBinaryTextEncoder = new TextEncoder()
 
 const makeSchemaBinary = (options?: {
-  readonly maxFrameSize?: number | undefined
+  readonly maxFrameSize?: number | "unbounded" | undefined
   readonly fingerprintPayloads?: boolean | undefined
 }): RpcSerialization["Service"] => {
-  const maxFrameSize = options?.maxFrameSize ?? defaultSchemaBinaryMaxFrameSize
+  const maxFrameSize = options?.maxFrameSize === "unbounded"
+    ? undefined
+    : options?.maxFrameSize ?? defaultSchemaBinaryMaxFrameSize
   const codecFor: CodecFor = options?.fingerprintPayloads === true
     ? (schema) => SchemaBinary.toCodecDirect(schema, { fingerprint: true })
     : SchemaBinary.toCodecDirect
@@ -715,12 +717,13 @@ export const layerMsgPackWith = (
 /**
  * RPC serialization layer that uses SchemaBinary with fingerprinted RPC
  * envelopes. Payload fingerprints are disabled by default to support compatible
- * schema evolution. Frames default to a 16 MiB maximum size.
+ * schema evolution. Frames default to a 16 MiB maximum size. Use `"unbounded"`
+ * to disable the frame-size limit.
  *
  * @category layers
  * @since 4.0.0
  */
 export const layerSchemaBinary = (options?: {
-  readonly maxFrameSize?: number | undefined
+  readonly maxFrameSize?: number | "unbounded" | undefined
   readonly fingerprintPayloads?: boolean | undefined
 }): Layer.Layer<RpcSerialization> => Layer.sync(RpcSerialization)(() => makeSchemaBinary(options))

--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -594,23 +594,22 @@ export const msgPack: RpcSerialization["Service"] = makeMsgPack({ useRecords: tr
 const defaultSchemaBinaryMaxFrameSize = 16 * 1024 * 1024
 
 const schemaBinaryTextEncoder = new TextEncoder()
+const codecForJsonBinary: CodecFor = (schema) => SchemaBinary.toCodec(Schema.toCodecJson(schema)) as any
 
 const makeSchemaBinary = (options?: {
   readonly maxFrameSize?: number | "unbounded" | undefined
   readonly fingerprintPayloads?: boolean | undefined
+  readonly payloadEncoding?: "schemaBinary" | "json" | undefined
 }): RpcSerialization["Service"] => {
   const maxFrameSize = options?.maxFrameSize === "unbounded"
     ? undefined
     : options?.maxFrameSize ?? defaultSchemaBinaryMaxFrameSize
-  const codecFor: CodecFor = options?.fingerprintPayloads === true
+  const codecFor: CodecFor = options?.payloadEncoding === "json"
+    ? codecForJsonBinary
+    : options?.fingerprintPayloads === true
     ? (schema) => SchemaBinary.toCodecDirect(schema, { fingerprint: true })
     : SchemaBinary.toCodecDirect
-  // The envelope repeats itself: the same RPC tag, header names, and trace ids
-  // come back on message after message. A dictionary shared by every frame on
-  // the connection sends each of those once and references it afterwards, so
-  // the writer and the reader here are a matched pair and neither one works
-  // against a peer that was built without the other.
-  const envelopeOptions = { fingerprint: true, dictionary: true } as const
+  const envelopeOptions = { fingerprint: true } as const
   return RpcSerialization.of({
     contentType: "application/vnd.effect.rpc+schema-binary",
     includesFraming: true,
@@ -718,7 +717,8 @@ export const layerMsgPackWith = (
  * RPC serialization layer that uses SchemaBinary with fingerprinted RPC
  * envelopes. Payload fingerprints are disabled by default to support compatible
  * schema evolution. Frames default to a 16 MiB maximum size. Use `"unbounded"`
- * to disable the frame-size limit.
+ * to disable the frame-size limit. Set `payloadEncoding` to `"json"` when the
+ * encoded payloads must remain compatible with JSON-only persistence.
  *
  * @category layers
  * @since 4.0.0
@@ -726,4 +726,5 @@ export const layerMsgPackWith = (
 export const layerSchemaBinary = (options?: {
   readonly maxFrameSize?: number | "unbounded" | undefined
   readonly fingerprintPayloads?: boolean | undefined
+  readonly payloadEncoding?: "schemaBinary" | "json" | undefined
 }): Layer.Layer<RpcSerialization> => Layer.sync(RpcSerialization)(() => makeSchemaBinary(options))

--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -594,19 +594,15 @@ export const msgPack: RpcSerialization["Service"] = makeMsgPack({ useRecords: tr
 const defaultSchemaBinaryMaxFrameSize = 16 * 1024 * 1024
 
 const schemaBinaryTextEncoder = new TextEncoder()
-const codecForJsonBinary: CodecFor = (schema) => SchemaBinary.toCodec(Schema.toCodecJson(schema)) as any
 
 const makeSchemaBinary = (options?: {
   readonly maxFrameSize?: number | "unbounded" | undefined
   readonly fingerprintPayloads?: boolean | undefined
-  readonly payloadEncoding?: "schemaBinary" | "json" | undefined
 }): RpcSerialization["Service"] => {
   const maxFrameSize = options?.maxFrameSize === "unbounded"
     ? undefined
     : options?.maxFrameSize ?? defaultSchemaBinaryMaxFrameSize
-  const codecFor: CodecFor = options?.payloadEncoding === "json"
-    ? codecForJsonBinary
-    : options?.fingerprintPayloads === true
+  const codecFor: CodecFor = options?.fingerprintPayloads === true
     ? (schema) => SchemaBinary.toCodecDirect(schema, { fingerprint: true })
     : SchemaBinary.toCodecDirect
   const envelopeOptions = { fingerprint: true } as const
@@ -717,8 +713,7 @@ export const layerMsgPackWith = (
  * RPC serialization layer that uses SchemaBinary with fingerprinted RPC
  * envelopes. Payload fingerprints are disabled by default to support compatible
  * schema evolution. Frames default to a 16 MiB maximum size. Use `"unbounded"`
- * to disable the frame-size limit. Set `payloadEncoding` to `"json"` when the
- * encoded payloads must remain compatible with JSON-only persistence.
+ * to disable the frame-size limit.
  *
  * @category layers
  * @since 4.0.0
@@ -726,5 +721,4 @@ export const layerMsgPackWith = (
 export const layerSchemaBinary = (options?: {
   readonly maxFrameSize?: number | "unbounded" | undefined
   readonly fingerprintPayloads?: boolean | undefined
-  readonly payloadEncoding?: "schemaBinary" | "json" | undefined
 }): Layer.Layer<RpcSerialization> => Layer.sync(RpcSerialization)(() => makeSchemaBinary(options))

--- a/packages/effect/test/cluster/MessageStorage.test.ts
+++ b/packages/effect/test/cluster/MessageStorage.test.ts
@@ -207,11 +207,55 @@ describe("MessageStorage", () => {
         yield* latch.await
         yield* Fiber.await(fiber)
       }).pipe(Effect.provide(MemoryLayer)))
+
+    it.effect("reply handlers receive the persisted defect fallback for unencodable replies", () =>
+      Effect.gen(function*() {
+        const storage = yield* MessageStorage.MessageStorage
+        const snowflake = yield* Snowflake.Generator
+        const latch = yield* Latch.make()
+        const request = yield* makeRequest({ rpc: UnknownSuccessRpc })
+        yield* storage.saveRequest(request)
+        let received: Reply.Reply<any> | undefined
+        const fiber = yield* storage.registerReplyHandler(
+          new Message.OutgoingRequest({
+            ...request,
+            respond: (reply) => {
+              received = reply
+              return latch.open
+            }
+          })
+        ).pipe(Effect.forkChild)
+        yield* TestClock.adjust(1)
+        yield* storage.saveReply(
+          new Reply.ReplyWithContext({
+            reply: new Reply.WithExit({
+              id: snowflake.nextUnsafe(),
+              requestId: request.envelope.requestId,
+              exit: Exit.succeed(new Error("not json encodable")) as any
+            }),
+            context: request.context,
+            rpc: request.rpc
+          })
+        )
+        yield* latch.await
+        yield* Fiber.await(fiber)
+        expect(received?._tag).toEqual("WithExit")
+        const exit = (received as Reply.WithExit<any>).exit
+        expect(Exit.isFailure(exit)).toBe(true)
+        expect(JSON.stringify(exit)).toContain("MalformedMessage")
+        const stored = yield* storage.repliesForUnfiltered([request.envelope.requestId])
+        expect(JSON.stringify(stored)).toContain("MalformedMessage")
+      }).pipe(Effect.provide(MemoryLayer)))
   })
 })
 
 export const GetUserRpc = Rpc.make("GetUser", {
   payload: { id: Schema.Number }
+})
+
+const UnknownSuccessRpc = Rpc.make("UnknownSuccess", {
+  payload: { id: Schema.Number },
+  success: Schema.Unknown
 })
 
 export const makeRequest = Effect.fnUntraced(function*(options?: {

--- a/packages/effect/test/rpc/RpcSerialization.test.ts
+++ b/packages/effect/test/rpc/RpcSerialization.test.ts
@@ -544,22 +544,29 @@ describe("RpcSerialization", () => {
         assert.deepStrictEqual(parser.decode(frame), [request])
       }).pipe(Effect.provide(RpcSerialization.layerSchemaBinary())))
 
-    it.effect("keeps frames decodable across parser replacement", () =>
+    it.effect("keeps varied frames decodable across parser replacement", () =>
       Effect.gen(function*() {
         const serialization = yield* RpcSerialization.RpcSerialization
         const encoder = serialization.makeUnsafe()
-        const request: RpcMessage.RequestEncoded = {
+        const requests: Array<RpcMessage.RequestEncoded> = Array.from({ length: 200 }, (_, index) => ({
           _tag: "Request",
-          id: 1,
-          tag: "Echo",
-          payload: Uint8Array.of(1, 2, 3),
-          headers: []
+          id: index % 2 === 0 ? index : `request-${index}`,
+          tag: `Echo${index % 7}`,
+          payload: Uint8Array.from({ length: index % 17 }, (_, offset) => (index + offset) & 0xFF),
+          headers: Array.from({ length: index % 4 }, (_, offset) => [`x-${offset}`, `${index}`]),
+          ...(index % 3 === 0
+            ? { traceId: `trace-${index}`, spanId: `span-${index}`, sampled: index % 2 === 0 }
+            : undefined)
+        }))
+
+        for (const request of requests) {
+          const frame = encoder.encode(request)
+          assert.instanceOf(frame, Uint8Array)
+          const split = 1 + request.tag.length % (frame.length - 1)
+          const parser = serialization.makeUnsafe()
+          assert.deepStrictEqual(parser.decode(frame.subarray(0, split)), [])
+          assert.deepStrictEqual(parser.decode(frame.subarray(split)), [request])
         }
-
-        encoder.encode(request)
-        const frame = encoder.encode({ ...request, id: 2 })
-
-        assert.deepStrictEqual(serialization.makeUnsafe().decode(frame!), [{ ...request, id: 2 }])
       }).pipe(Effect.provide(RpcSerialization.layerSchemaBinary())))
 
     it.effect("owns encoded frames without copying envelope holes", () =>

--- a/packages/effect/test/rpc/RpcSerialization.test.ts
+++ b/packages/effect/test/rpc/RpcSerialization.test.ts
@@ -562,6 +562,12 @@ describe("RpcSerialization", () => {
         assert.deepStrictEqual(serialization.makeUnsafe().decode(frame!), [{ ...request, id: 2 }])
       }).pipe(Effect.provide(RpcSerialization.layerSchemaBinary())))
 
+    it.effect("memoizes codecFor by schema", () =>
+      Effect.gen(function*() {
+        const serialization = yield* RpcSerialization.RpcSerialization
+        assert.strictEqual(serialization.codecFor(Schema.Date), serialization.codecFor(Schema.Date))
+      }).pipe(Effect.provide(RpcSerialization.layerSchemaBinary())))
+
     it.effect("owns encoded frames without copying envelope holes", () =>
       Effect.gen(function*() {
         const serialization = yield* RpcSerialization.RpcSerialization

--- a/packages/effect/test/rpc/RpcSerialization.test.ts
+++ b/packages/effect/test/rpc/RpcSerialization.test.ts
@@ -562,12 +562,6 @@ describe("RpcSerialization", () => {
         assert.deepStrictEqual(serialization.makeUnsafe().decode(frame!), [{ ...request, id: 2 }])
       }).pipe(Effect.provide(RpcSerialization.layerSchemaBinary())))
 
-    it.effect("memoizes codecFor by schema", () =>
-      Effect.gen(function*() {
-        const serialization = yield* RpcSerialization.RpcSerialization
-        assert.strictEqual(serialization.codecFor(Schema.Date), serialization.codecFor(Schema.Date))
-      }).pipe(Effect.provide(RpcSerialization.layerSchemaBinary())))
-
     it.effect("owns encoded frames without copying envelope holes", () =>
       Effect.gen(function*() {
         const serialization = yield* RpcSerialization.RpcSerialization

--- a/packages/effect/test/rpc/RpcSerialization.test.ts
+++ b/packages/effect/test/rpc/RpcSerialization.test.ts
@@ -586,6 +586,12 @@ describe("RpcSerialization", () => {
         assert.deepStrictEqual(serialization.makeUnsafe().decode(uvarint(4)), [])
         assert.throws(() => serialization.makeUnsafe().decode(uvarint(5)), /frame within maxFrameSize/)
       }).pipe(Effect.provide(RpcSerialization.layerSchemaBinary({ maxFrameSize: 4 }))))
+
+    it.effect("layerSchemaBinary allows an unbounded maxFrameSize", () =>
+      Effect.gen(function*() {
+        const serialization = yield* RpcSerialization.RpcSerialization
+        assert.deepStrictEqual(serialization.makeUnsafe().decode(uvarint(16 * 1024 * 1024 + 1)), [])
+      }).pipe(Effect.provide(RpcSerialization.layerSchemaBinary({ maxFrameSize: "unbounded" }))))
   })
 
   describe("codecFor", () => {

--- a/packages/effect/test/rpc/RpcSerialization.test.ts
+++ b/packages/effect/test/rpc/RpcSerialization.test.ts
@@ -544,6 +544,34 @@ describe("RpcSerialization", () => {
         assert.deepStrictEqual(parser.decode(frame), [request])
       }).pipe(Effect.provide(RpcSerialization.layerSchemaBinary())))
 
+    it.effect("keeps frames decodable across parser replacement", () =>
+      Effect.gen(function*() {
+        const serialization = yield* RpcSerialization.RpcSerialization
+        const encoder = serialization.makeUnsafe()
+        const request: RpcMessage.RequestEncoded = {
+          _tag: "Request",
+          id: 1,
+          tag: "Echo",
+          payload: Uint8Array.of(1, 2, 3),
+          headers: []
+        }
+
+        encoder.encode(request)
+        const frame = encoder.encode({ ...request, id: 2 })
+
+        assert.deepStrictEqual(serialization.makeUnsafe().decode(frame!), [{ ...request, id: 2 }])
+      }).pipe(Effect.provide(RpcSerialization.layerSchemaBinary())))
+
+    it.effect("supports JSON-encoded payloads", () =>
+      Effect.gen(function*() {
+        const serialization = yield* RpcSerialization.RpcSerialization
+        const codec = serialization.codecFor(Schema.Date)
+        const encoded = Schema.encodeSync(codec)(new Date(0))
+
+        assert.instanceOf(encoded, Uint8Array)
+        assert.deepStrictEqual(Schema.decodeSync(codec)(encoded), new Date(0))
+      }).pipe(Effect.provide(RpcSerialization.layerSchemaBinary({ payloadEncoding: "json" }))))
+
     it.effect("owns encoded frames without copying envelope holes", () =>
       Effect.gen(function*() {
         const serialization = yield* RpcSerialization.RpcSerialization

--- a/packages/effect/test/rpc/RpcSerialization.test.ts
+++ b/packages/effect/test/rpc/RpcSerialization.test.ts
@@ -562,16 +562,6 @@ describe("RpcSerialization", () => {
         assert.deepStrictEqual(serialization.makeUnsafe().decode(frame!), [{ ...request, id: 2 }])
       }).pipe(Effect.provide(RpcSerialization.layerSchemaBinary())))
 
-    it.effect("supports JSON-encoded payloads", () =>
-      Effect.gen(function*() {
-        const serialization = yield* RpcSerialization.RpcSerialization
-        const codec = serialization.codecFor(Schema.Date)
-        const encoded = Schema.encodeSync(codec)(new Date(0))
-
-        assert.instanceOf(encoded, Uint8Array)
-        assert.deepStrictEqual(Schema.decodeSync(codec)(encoded), new Date(0))
-      }).pipe(Effect.provide(RpcSerialization.layerSchemaBinary({ payloadEncoding: "json" }))))
-
     it.effect("owns encoded frames without copying envelope holes", () =>
       Effect.gen(function*() {
         const serialization = yield* RpcSerialization.RpcSerialization

--- a/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
+++ b/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
@@ -23,6 +23,7 @@ import {
   SchemaTransformation,
   Stream
 } from "effect"
+import * as FastCheck from "effect/testing/FastCheck"
 import * as SchemaBinary from "effect/unstable/encoding/SchemaBinary"
 
 const encode = <A, I>(schema: Schema.Codec<A, I>, value: A): Uint8Array<ArrayBuffer> =>
@@ -457,6 +458,15 @@ describe("SchemaBinary", () => {
         schemaError(() => Schema.encodeUnknownSync(codec, { disableChecks: true })(1.5)).message,
         /an integer/
       )
+    })
+
+    it("rejects integer varints outside the safe-number range", () => {
+      const codec = SchemaBinary.toCodec(Schema.Int)
+      // Sign-magnitude encoding of Number.MAX_SAFE_INTEGER + 2. Converting it
+      // to number would silently round it down to MAX_SAFE_INTEGER + 1.
+      const unsafe = Uint8Array.of(9, 0x20, 0x82, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x20)
+
+      assert.match(schemaError(() => Schema.decodeUnknownSync(codec)(unsafe)).message, /integer/)
     })
 
     it("rejects malformed number payloads", () => {
@@ -2356,6 +2366,112 @@ describe("SchemaBinary", () => {
         directFingerprintCodec
       )
       assert.notStrictEqual(directFingerprintCodec, directCodec)
+    })
+  })
+
+  describe("generated regressions", () => {
+    const Event = Schema.Union([
+      Schema.Struct({ _tag: Schema.tag("Text"), value: Schema.String }),
+      Schema.Struct({ _tag: Schema.tag("Count"), value: Schema.Number })
+    ])
+    const Generated = Schema.Struct({
+      flag: Schema.Boolean,
+      count: Schema.Int,
+      ratio: Schema.Number,
+      label: Schema.String,
+      bytes: Schema.Uint8Array,
+      big: Schema.BigInt,
+      optional: Schema.optionalKey(Schema.String),
+      tuple: Schema.Tuple([Schema.String, Schema.Number, Schema.Boolean]),
+      items: Schema.Array(Schema.Struct({ id: Schema.Int, name: Schema.String })),
+      attributes: Schema.Record(
+        Schema.String,
+        Schema.Union([Schema.String, Schema.Number, Schema.Boolean, Schema.Null])
+      ),
+      event: Event
+    })
+    const generated = Schema.toArbitrary(Generated)(FastCheck)
+
+    it("keeps every encoding entry point equivalent for generated nested values", () => {
+      FastCheck.assert(
+        FastCheck.property(generated, (value) => {
+          for (const fingerprint of [false, true]) {
+            const options = { fingerprint } as const
+            const codec = SchemaBinary.toCodec(Generated, options)
+            const direct = SchemaBinary.toCodecDirect(Generated, options)
+            const frame = Schema.encodeUnknownSync(codec)(value)
+            const optimizedFrame = SchemaBinary.encodeUnknownSync(Generated, options)(value)
+            const statefulFrame = SchemaBinary.encoder(Generated, options).encode(value)
+
+            assert.deepStrictEqual(optimizedFrame, frame)
+            assert.deepStrictEqual(statefulFrame, frame)
+            assert.deepStrictEqual(Schema.decodeUnknownSync(codec)(frame), value)
+            assert.deepStrictEqual(Schema.decodeUnknownSync(direct)(frame), value)
+            assert.deepStrictEqual(SchemaBinary.parser(Generated, options).feedSync(frame), [value])
+          }
+        }),
+        { numRuns: 200 }
+      )
+    })
+
+    it("parses generated batches across arbitrary chunk boundaries", () => {
+      FastCheck.assert(
+        FastCheck.property(
+          FastCheck.array(generated, { maxLength: 20 }),
+          FastCheck.array(FastCheck.integer({ min: 1, max: 64 }), { minLength: 1, maxLength: 30 }),
+          FastCheck.boolean(),
+          (values, chunkSizes, fingerprint) => {
+            const options = fingerprint ? { fingerprint: true } as const : undefined
+            const bytes = SchemaBinary.encodeManyUnknownSync(Generated, options)(values)
+            const parser = SchemaBinary.parser(Generated, options)
+            const decoded: Array<typeof Generated.Type> = []
+            let offset = 0
+            for (const size of chunkSizes) {
+              if (offset >= bytes.length) break
+              const end = Math.min(offset + size, bytes.length)
+              decoded.push(...parser.feedSync(bytes.subarray(offset, end)))
+              offset = end
+            }
+            if (offset < bytes.length) decoded.push(...parser.feedSync(bytes.subarray(offset)))
+            parser.endSync()
+            assert.deepStrictEqual(decoded, values)
+          }
+        ),
+        { numRuns: 100 }
+      )
+    })
+
+    it("rejects every generated truncated frame", () => {
+      FastCheck.assert(
+        FastCheck.property(generated, FastCheck.nat(), FastCheck.boolean(), (value, offset, fingerprint) => {
+          const options = fingerprint ? { fingerprint: true } as const : undefined
+          const bytes = SchemaBinary.encodeUnknownSync(Generated, options)(value)
+          const cut = 1 + offset % (bytes.length - 1)
+          const parser = SchemaBinary.parser(Generated, options)
+
+          assert.deepStrictEqual(parser.feedSync(bytes.subarray(0, cut)), [])
+          assert.match(schemaError(() => parser.endSync()).message, /complete value/)
+        }),
+        { numRuns: 100 }
+      )
+    })
+
+    it("owns buffered and decoded bytes independently of caller buffers", () => {
+      const schema = Schema.Struct({ label: Schema.String, bytes: Schema.Uint8Array })
+      const value = { label: "fragmented", bytes: Uint8Array.of(1, 2, 3, 4) }
+      const frame = encode(schema, value)
+      const split = Math.floor(frame.length / 2)
+      const prefix = frame.slice(0, split)
+      const parser = SchemaBinary.parser(schema)
+
+      assert.deepStrictEqual(parser.feedSync(prefix), [])
+      prefix.fill(0)
+      const [decoded] = parser.feedSync(frame.subarray(split))
+      frame.fill(0)
+
+      assert.deepStrictEqual(decoded, value)
+      assert.notStrictEqual(decoded.bytes.buffer, frame.buffer)
+      parser.endSync()
     })
   })
 

--- a/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
+++ b/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
@@ -23,7 +23,6 @@ import {
   SchemaTransformation,
   Stream
 } from "effect"
-import * as FastCheck from "effect/testing/FastCheck"
 import * as SchemaBinary from "effect/unstable/encoding/SchemaBinary"
 
 const encode = <A, I>(schema: Schema.Codec<A, I>, value: A): Uint8Array<ArrayBuffer> =>
@@ -2390,11 +2389,11 @@ describe("SchemaBinary", () => {
       ),
       event: Event
     })
-    const generated = Schema.toArbitrary(Generated)(FastCheck)
-
-    it("keeps every encoding entry point equivalent for generated nested values", () => {
-      FastCheck.assert(
-        FastCheck.property(generated, (value) => {
+    it.live.prop(
+      "keeps every encoding entry point equivalent for generated nested values",
+      { value: Generated },
+      ({ value }) =>
+        Effect.sync(() => {
           for (const fingerprint of [false, true]) {
             const options = { fingerprint } as const
             const codec = SchemaBinary.toCodec(Generated, options)
@@ -2410,40 +2409,47 @@ describe("SchemaBinary", () => {
             assert.deepStrictEqual(SchemaBinary.parser(Generated, options).feedSync(frame), [value])
           }
         }),
-        { numRuns: 200 }
-      )
-    })
+      { fastCheck: { numRuns: 200 } }
+    )
 
-    it("parses generated batches across arbitrary chunk boundaries", () => {
-      FastCheck.assert(
-        FastCheck.property(
-          FastCheck.array(generated, { maxLength: 20 }),
-          FastCheck.array(FastCheck.integer({ min: 1, max: 64 }), { minLength: 1, maxLength: 30 }),
-          FastCheck.boolean(),
-          (values, chunkSizes, fingerprint) => {
-            const options = fingerprint ? { fingerprint: true } as const : undefined
-            const bytes = SchemaBinary.encodeManyUnknownSync(Generated, options)(values)
-            const parser = SchemaBinary.parser(Generated, options)
-            const decoded: Array<typeof Generated.Type> = []
-            let offset = 0
-            for (const size of chunkSizes) {
-              if (offset >= bytes.length) break
-              const end = Math.min(offset + size, bytes.length)
-              decoded.push(...parser.feedSync(bytes.subarray(offset, end)))
-              offset = end
-            }
-            if (offset < bytes.length) decoded.push(...parser.feedSync(bytes.subarray(offset)))
-            parser.endSync()
-            assert.deepStrictEqual(decoded, values)
+    it.live.prop(
+      "parses generated batches across arbitrary chunk boundaries",
+      {
+        values: Schema.Array(Generated).check(Schema.isMaxLength(20)),
+        chunkSizes: Schema.Array(
+          Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 64 }))
+        ).check(Schema.isMinLength(1), Schema.isMaxLength(30)),
+        fingerprint: Schema.Boolean
+      },
+      ({ chunkSizes, fingerprint, values }) =>
+        Effect.sync(() => {
+          const options = fingerprint ? { fingerprint: true } as const : undefined
+          const bytes = SchemaBinary.encodeManyUnknownSync(Generated, options)(values)
+          const parser = SchemaBinary.parser(Generated, options)
+          const decoded: Array<typeof Generated.Type> = []
+          let offset = 0
+          for (const size of chunkSizes) {
+            if (offset >= bytes.length) break
+            const end = Math.min(offset + size, bytes.length)
+            decoded.push(...parser.feedSync(bytes.subarray(offset, end)))
+            offset = end
           }
-        ),
-        { numRuns: 100 }
-      )
-    })
+          if (offset < bytes.length) decoded.push(...parser.feedSync(bytes.subarray(offset)))
+          parser.endSync()
+          assert.deepStrictEqual(decoded, values)
+        }),
+      { fastCheck: { numRuns: 100 } }
+    )
 
-    it("rejects every generated truncated frame", () => {
-      FastCheck.assert(
-        FastCheck.property(generated, FastCheck.nat(), FastCheck.boolean(), (value, offset, fingerprint) => {
+    it.live.prop(
+      "rejects every generated truncated frame",
+      {
+        value: Generated,
+        offset: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+        fingerprint: Schema.Boolean
+      },
+      ({ fingerprint, offset, value }) =>
+        Effect.sync(() => {
           const options = fingerprint ? { fingerprint: true } as const : undefined
           const bytes = SchemaBinary.encodeUnknownSync(Generated, options)(value)
           const cut = 1 + offset % (bytes.length - 1)
@@ -2452,9 +2458,8 @@ describe("SchemaBinary", () => {
           assert.deepStrictEqual(parser.feedSync(bytes.subarray(0, cut)), [])
           assert.match(schemaError(() => parser.endSync()).message, /complete value/)
         }),
-        { numRuns: 100 }
-      )
-    })
+      { fastCheck: { numRuns: 100 } }
+    )
 
     it("owns buffered and decoded bytes independently of caller buffers", () => {
       const schema = Schema.Struct({ label: Schema.String, bytes: Schema.Uint8Array })

--- a/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
+++ b/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
@@ -2369,23 +2369,39 @@ describe("SchemaBinary", () => {
   })
 
   describe("generated regressions", () => {
+    const isWellFormedString = (value: string): boolean => {
+      for (let index = 0; index < value.length; index++) {
+        const code = value.charCodeAt(index)
+        if (code >= 0xD800 && code <= 0xDBFF) {
+          if (index + 1 >= value.length) return false
+          const trailing = value.charCodeAt(++index)
+          if (trailing < 0xDC00 || trailing > 0xDFFF) return false
+        } else if (code >= 0xDC00 && code <= 0xDFFF) {
+          return false
+        }
+      }
+      return true
+    }
+    const WellFormedString = Schema.String.check(
+      Schema.makeFilter(isWellFormedString, { expected: "a well-formed Unicode string" })
+    )
     const Event = Schema.Union([
-      Schema.Struct({ _tag: Schema.tag("Text"), value: Schema.String }),
+      Schema.Struct({ _tag: Schema.tag("Text"), value: WellFormedString }),
       Schema.Struct({ _tag: Schema.tag("Count"), value: Schema.Number })
     ])
     const Generated = Schema.Struct({
       flag: Schema.Boolean,
       count: Schema.Int,
       ratio: Schema.Number,
-      label: Schema.String,
+      label: WellFormedString,
       bytes: Schema.Uint8Array,
       big: Schema.BigInt,
-      optional: Schema.optionalKey(Schema.String),
-      tuple: Schema.Tuple([Schema.String, Schema.Number, Schema.Boolean]),
-      items: Schema.Array(Schema.Struct({ id: Schema.Int, name: Schema.String })),
+      optional: Schema.optionalKey(WellFormedString),
+      tuple: Schema.Tuple([WellFormedString, Schema.Number, Schema.Boolean]),
+      items: Schema.Array(Schema.Struct({ id: Schema.Int, name: WellFormedString })),
       attributes: Schema.Record(
-        Schema.String,
-        Schema.Union([Schema.String, Schema.Number, Schema.Boolean, Schema.Null])
+        WellFormedString,
+        Schema.Union([WellFormedString, Schema.Number, Schema.Boolean, Schema.Null])
       ),
       event: Event
     })
@@ -2409,7 +2425,7 @@ describe("SchemaBinary", () => {
             assert.deepStrictEqual(SchemaBinary.parser(Generated, options).feedSync(frame), [value])
           }
         }),
-      { fastCheck: { numRuns: 200 } }
+      { arbitrary: { runs: 200 } }
     )
 
     it.live.prop(
@@ -2438,7 +2454,7 @@ describe("SchemaBinary", () => {
           parser.endSync()
           assert.deepStrictEqual(decoded, values)
         }),
-      { fastCheck: { numRuns: 100 } }
+      { arbitrary: { runs: 100 } }
     )
 
     it.live.prop(
@@ -2458,7 +2474,7 @@ describe("SchemaBinary", () => {
           assert.deepStrictEqual(parser.feedSync(bytes.subarray(0, cut)), [])
           assert.match(schemaError(() => parser.endSync()).message, /complete value/)
         }),
-      { fastCheck: { numRuns: 100 } }
+      { arbitrary: { runs: 100 } }
     )
 
     it("owns buffered and decoded bytes independently of caller buffers", () => {

--- a/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
+++ b/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
@@ -2333,6 +2333,32 @@ describe("SchemaBinary", () => {
     })
   })
 
+  describe("codec memoization", () => {
+    it("memoizes by schema and wire mode", () => {
+      const schema = Schema.Struct({ id: Schema.Number, label: Schema.String })
+
+      const codec = SchemaBinary.toCodec(schema)
+      assert.strictEqual(SchemaBinary.toCodec(schema), codec)
+      assert.strictEqual(SchemaBinary.toCodec(schema, {}), codec)
+      assert.strictEqual(SchemaBinary.toCodec(schema, { fingerprint: false }), codec)
+
+      const fingerprintCodec = SchemaBinary.toCodec(schema, { fingerprint: true })
+      assert.strictEqual(SchemaBinary.toCodec(schema, { fingerprint: true }), fingerprintCodec)
+      assert.notStrictEqual(fingerprintCodec, codec)
+
+      const directCodec = SchemaBinary.toCodecDirect(schema)
+      assert.strictEqual(SchemaBinary.toCodecDirect(schema), directCodec)
+      assert.strictEqual(SchemaBinary.toCodecDirect(schema, { fingerprint: false }), directCodec)
+
+      const directFingerprintCodec = SchemaBinary.toCodecDirect(schema, { fingerprint: true })
+      assert.strictEqual(
+        SchemaBinary.toCodecDirect(schema, { fingerprint: true }),
+        directFingerprintCodec
+      )
+      assert.notStrictEqual(directFingerprintCodec, directCodec)
+    })
+  })
+
   describe("direct codec", () => {
     const Person = Schema.Struct({ name: Schema.String, age: Schema.Number })
 

--- a/packages/platform/bun/src/BunClusterSocket.ts
+++ b/packages/platform/bun/src/BunClusterSocket.ts
@@ -124,7 +124,9 @@ export const layer = <
     Layer.provide(
       options?.serialization === "ndjson"
         ? RpcSerialization.layerNdjsonWith({ maxBufferSize: options?.serializationMaxBufferSize })
-        : RpcSerialization.layerMsgPackWith({ maxBufferSize: options?.serializationMaxBufferSize })
+        : options?.serialization === "msgpack"
+        ? RpcSerialization.layerMsgPackWith({ maxBufferSize: options?.serializationMaxBufferSize })
+        : RpcSerialization.layerSchemaBinary()
     )
   ) as any
 }

--- a/packages/platform/bun/src/BunClusterSocket.ts
+++ b/packages/platform/bun/src/BunClusterSocket.ts
@@ -126,7 +126,9 @@ export const layer = <
         ? RpcSerialization.layerNdjsonWith({ maxBufferSize: options?.serializationMaxBufferSize })
         : options?.serialization === "msgpack"
         ? RpcSerialization.layerMsgPackWith({ maxBufferSize: options?.serializationMaxBufferSize })
-        : RpcSerialization.layerSchemaBinary()
+        : RpcSerialization.layerSchemaBinary({
+          maxFrameSize: options?.serializationMaxBufferSize
+        })
     )
   ) as any
 }

--- a/packages/platform/bun/src/BunClusterSocket.ts
+++ b/packages/platform/bun/src/BunClusterSocket.ts
@@ -127,7 +127,8 @@ export const layer = <
         : options?.serialization === "msgpack"
         ? RpcSerialization.layerMsgPackWith({ maxBufferSize: options?.serializationMaxBufferSize })
         : RpcSerialization.layerSchemaBinary({
-          maxFrameSize: options?.serializationMaxBufferSize
+          maxFrameSize: options?.serializationMaxBufferSize,
+          payloadEncoding: "json"
         })
     )
   ) as any

--- a/packages/platform/bun/src/BunClusterSocket.ts
+++ b/packages/platform/bun/src/BunClusterSocket.ts
@@ -127,8 +127,7 @@ export const layer = <
         : options?.serialization === "msgpack"
         ? RpcSerialization.layerMsgPackWith({ maxBufferSize: options?.serializationMaxBufferSize })
         : RpcSerialization.layerSchemaBinary({
-          maxFrameSize: options?.serializationMaxBufferSize,
-          payloadEncoding: "json"
+          maxFrameSize: options?.serializationMaxBufferSize
         })
     )
   ) as any

--- a/packages/platform/deno/src/DenoClusterSocket.ts
+++ b/packages/platform/deno/src/DenoClusterSocket.ts
@@ -161,7 +161,9 @@ export const layer = <
     Layer.provide(
       options?.serialization === "ndjson"
         ? RpcSerialization.layerNdjsonWith({ maxBufferSize: options?.serializationMaxBufferSize })
-        : RpcSerialization.layerMsgPackWith({ maxBufferSize: options?.serializationMaxBufferSize })
+        : options?.serialization === "msgpack"
+        ? RpcSerialization.layerMsgPackWith({ maxBufferSize: options?.serializationMaxBufferSize })
+        : RpcSerialization.layerSchemaBinary()
     )
   ) as any
 }

--- a/packages/platform/deno/src/DenoClusterSocket.ts
+++ b/packages/platform/deno/src/DenoClusterSocket.ts
@@ -164,8 +164,7 @@ export const layer = <
         : options?.serialization === "msgpack"
         ? RpcSerialization.layerMsgPackWith({ maxBufferSize: options?.serializationMaxBufferSize })
         : RpcSerialization.layerSchemaBinary({
-          maxFrameSize: options?.serializationMaxBufferSize,
-          payloadEncoding: "json"
+          maxFrameSize: options?.serializationMaxBufferSize
         })
     )
   ) as any

--- a/packages/platform/deno/src/DenoClusterSocket.ts
+++ b/packages/platform/deno/src/DenoClusterSocket.ts
@@ -164,7 +164,8 @@ export const layer = <
         : options?.serialization === "msgpack"
         ? RpcSerialization.layerMsgPackWith({ maxBufferSize: options?.serializationMaxBufferSize })
         : RpcSerialization.layerSchemaBinary({
-          maxFrameSize: options?.serializationMaxBufferSize
+          maxFrameSize: options?.serializationMaxBufferSize,
+          payloadEncoding: "json"
         })
     )
   ) as any

--- a/packages/platform/deno/src/DenoClusterSocket.ts
+++ b/packages/platform/deno/src/DenoClusterSocket.ts
@@ -163,7 +163,9 @@ export const layer = <
         ? RpcSerialization.layerNdjsonWith({ maxBufferSize: options?.serializationMaxBufferSize })
         : options?.serialization === "msgpack"
         ? RpcSerialization.layerMsgPackWith({ maxBufferSize: options?.serializationMaxBufferSize })
-        : RpcSerialization.layerSchemaBinary()
+        : RpcSerialization.layerSchemaBinary({
+          maxFrameSize: options?.serializationMaxBufferSize
+        })
     )
   ) as any
 }

--- a/packages/platform/deno/test/cluster/SocketRunner.test.ts
+++ b/packages/platform/deno/test/cluster/SocketRunner.test.ts
@@ -56,7 +56,7 @@ const makeRunnerLayer = (port: number, entities: Layer.Layer<never, never, Shard
       entityMessagePollInterval: 5000,
       sendRetryInterval: 100
     })),
-    Layer.provide(RpcSerialization.layerSchemaBinary({ payloadEncoding: "json" }))
+    Layer.provide(RpcSerialization.layerSchemaBinary())
   )
 
 const makeClientLayer = (port: number) =>
@@ -69,7 +69,7 @@ const makeClientLayer = (port: number) =>
       entityMessagePollInterval: 5000,
       sendRetryInterval: 100
     })),
-    Layer.provide(RpcSerialization.layerSchemaBinary({ payloadEncoding: "json" }))
+    Layer.provide(RpcSerialization.layerSchemaBinary())
   )
 
 const IsolationEntity = Entity

--- a/packages/platform/deno/test/cluster/SocketRunner.test.ts
+++ b/packages/platform/deno/test/cluster/SocketRunner.test.ts
@@ -56,7 +56,7 @@ const makeRunnerLayer = (port: number, entities: Layer.Layer<never, never, Shard
       entityMessagePollInterval: 5000,
       sendRetryInterval: 100
     })),
-    Layer.provide(RpcSerialization.layerMsgPack)
+    Layer.provide(RpcSerialization.layerSchemaBinary({ payloadEncoding: "json" }))
   )
 
 const makeClientLayer = (port: number) =>
@@ -69,7 +69,7 @@ const makeClientLayer = (port: number) =>
       entityMessagePollInterval: 5000,
       sendRetryInterval: 100
     })),
-    Layer.provide(RpcSerialization.layerMsgPack)
+    Layer.provide(RpcSerialization.layerSchemaBinary({ payloadEncoding: "json" }))
   )
 
 const IsolationEntity = Entity
@@ -88,7 +88,7 @@ const ISOLATION_PORT = 50_126
 
 // BigDecimal.normalize creates a circular `normalized` self-reference.
 // When a persisted message is sent with discard: true, the notify path in Runners.makeRpc
-// passes the raw envelope (with circular BigDecimal payload) to the runner via msgpack,
+// passes the raw envelope (with circular BigDecimal payload) to the runner,
 // causing RangeError: Maximum call stack size exceeded.
 //
 // Volatile discard should complete after the request is sent, without waiting for the

--- a/packages/platform/node/src/NodeClusterSocket.ts
+++ b/packages/platform/node/src/NodeClusterSocket.ts
@@ -131,7 +131,8 @@ export const layer = <
         : options?.serialization === "msgpack"
         ? RpcSerialization.layerMsgPackWith({ maxBufferSize: options?.serializationMaxBufferSize })
         : RpcSerialization.layerSchemaBinary({
-          maxFrameSize: options?.serializationMaxBufferSize
+          maxFrameSize: options?.serializationMaxBufferSize,
+          payloadEncoding: "json"
         })
     )
   ) as any

--- a/packages/platform/node/src/NodeClusterSocket.ts
+++ b/packages/platform/node/src/NodeClusterSocket.ts
@@ -128,7 +128,9 @@ export const layer = <
     Layer.provide(
       options?.serialization === "ndjson"
         ? RpcSerialization.layerNdjsonWith({ maxBufferSize: options?.serializationMaxBufferSize })
-        : RpcSerialization.layerMsgPackWith({ maxBufferSize: options?.serializationMaxBufferSize })
+        : options?.serialization === "msgpack"
+        ? RpcSerialization.layerMsgPackWith({ maxBufferSize: options?.serializationMaxBufferSize })
+        : RpcSerialization.layerSchemaBinary()
     )
   ) as any
 }

--- a/packages/platform/node/src/NodeClusterSocket.ts
+++ b/packages/platform/node/src/NodeClusterSocket.ts
@@ -131,8 +131,7 @@ export const layer = <
         : options?.serialization === "msgpack"
         ? RpcSerialization.layerMsgPackWith({ maxBufferSize: options?.serializationMaxBufferSize })
         : RpcSerialization.layerSchemaBinary({
-          maxFrameSize: options?.serializationMaxBufferSize,
-          payloadEncoding: "json"
+          maxFrameSize: options?.serializationMaxBufferSize
         })
     )
   ) as any

--- a/packages/platform/node/src/NodeClusterSocket.ts
+++ b/packages/platform/node/src/NodeClusterSocket.ts
@@ -130,7 +130,9 @@ export const layer = <
         ? RpcSerialization.layerNdjsonWith({ maxBufferSize: options?.serializationMaxBufferSize })
         : options?.serialization === "msgpack"
         ? RpcSerialization.layerMsgPackWith({ maxBufferSize: options?.serializationMaxBufferSize })
-        : RpcSerialization.layerSchemaBinary()
+        : RpcSerialization.layerSchemaBinary({
+          maxFrameSize: options?.serializationMaxBufferSize
+        })
     )
   ) as any
 }

--- a/packages/platform/node/test/cluster-integration/harness.ts
+++ b/packages/platform/node/test/cluster-integration/harness.ts
@@ -380,7 +380,7 @@ export const socketRunnerLayer = (
       ...config,
       runnerAddress: Option.some(address)
     })),
-    Layer.provide(RpcSerialization.layerSchemaBinary({ payloadEncoding: "json" }))
+    Layer.provide(RpcSerialization.layerSchemaBinary())
   )
 
 export type RunnerLayer = typeof socketRunnerLayer
@@ -392,7 +392,7 @@ const clientLayer = (
   SocketRunner.layerClientOnly.pipe(
     Layer.provide(clientProtocol),
     Layer.provide(ShardingConfig.layer(config)),
-    Layer.provide(RpcSerialization.layerSchemaBinary({ payloadEncoding: "json" }))
+    Layer.provide(RpcSerialization.layerSchemaBinary())
   )
 
 const parseReply = (payload: MessageRow["reply_payload"]): Record<string, unknown> | undefined => {

--- a/packages/platform/node/test/cluster-integration/harness.ts
+++ b/packages/platform/node/test/cluster-integration/harness.ts
@@ -380,7 +380,7 @@ export const socketRunnerLayer = (
       ...config,
       runnerAddress: Option.some(address)
     })),
-    Layer.provide(RpcSerialization.layerMsgPack)
+    Layer.provide(RpcSerialization.layerSchemaBinary({ payloadEncoding: "json" }))
   )
 
 export type RunnerLayer = typeof socketRunnerLayer
@@ -392,7 +392,7 @@ const clientLayer = (
   SocketRunner.layerClientOnly.pipe(
     Layer.provide(clientProtocol),
     Layer.provide(ShardingConfig.layer(config)),
-    Layer.provide(RpcSerialization.layerMsgPack)
+    Layer.provide(RpcSerialization.layerSchemaBinary({ payloadEncoding: "json" }))
   )
 
 const parseReply = (payload: MessageRow["reply_payload"]): Record<string, unknown> | undefined => {

--- a/packages/platform/node/test/cluster/SocketRunner.test.ts
+++ b/packages/platform/node/test/cluster/SocketRunner.test.ts
@@ -164,7 +164,7 @@ const ISOLATION_PORT = 50_124
 describe("SocketRunner", () => {
   it.live(
     "uses SchemaBinary by default for TCP connections",
-    () => assertSerialization(50_120, RpcSerialization.layerSchemaBinary({ payloadEncoding: "json" })),
+    () => assertSerialization(50_120, RpcSerialization.layerSchemaBinary()),
     15_000
   )
 
@@ -182,7 +182,7 @@ describe("SocketRunner", () => {
           makeRunnerLayer(
             50_122,
             SerializationEntityLayer,
-            RpcSerialization.layerSchemaBinary({ payloadEncoding: "json" })
+            RpcSerialization.layerSchemaBinary()
           )
         ).pipe(Effect.forkScoped)
         yield* Effect.sleep("2 seconds")

--- a/packages/platform/node/test/cluster/SocketRunner.test.ts
+++ b/packages/platform/node/test/cluster/SocketRunner.test.ts
@@ -46,7 +46,11 @@ const SharedStorage = Layer.mergeAll(
   Layer.provide(ShardingConfig.layerDefaults)
 )
 
-const makeRunnerLayer = (port: number, entities: Layer.Layer<never, never, Sharding.Sharding>) =>
+const makeRunnerLayer = (
+  port: number,
+  entities: Layer.Layer<never, never, Sharding.Sharding>,
+  serialization: Layer.Layer<RpcSerialization.RpcSerialization> = RpcSerialization.layerMsgPack
+) =>
   entities.pipe(
     Layer.provideMerge(SocketRunner.layer),
     Layer.provide(RunnerHealth.layerNoop),
@@ -58,7 +62,7 @@ const makeRunnerLayer = (port: number, entities: Layer.Layer<never, never, Shard
       entityMessagePollInterval: 5000,
       sendRetryInterval: 100
     })),
-    Layer.provide(RpcSerialization.layerMsgPack)
+    Layer.provide(serialization)
   )
 
 const makeClientLayer = (port: number) =>
@@ -73,6 +77,53 @@ const makeClientLayer = (port: number) =>
     })),
     Layer.provide(RpcSerialization.layerMsgPack)
   )
+
+const makeConfiguredClientLayer = (port: number, serialization?: "msgpack" | "ndjson") =>
+  NodeClusterSocket.layer({
+    clientOnly: true,
+    storage: "byo",
+    ...(serialization === undefined ? undefined : { serialization }),
+    shardingConfig: {
+      runnerAddress: Option.some(RunnerAddress.make("localhost", port)),
+      runnerListenAddress: Option.some(RunnerAddress.make("localhost", port)),
+      entityTerminationTimeout: 0,
+      entityMessagePollInterval: 5000,
+      sendRetryInterval: 100
+    }
+  })
+
+const SerializationEntity = Entity
+  .make("SerializationEntity", [
+    Rpc.make("Ping", {
+      success: Schema.String
+    })
+  ])
+  .annotateRpcs(ClusterSchema.Persisted, false)
+
+const SerializationEntityLayer = SerializationEntity.toLayer(
+  Effect.succeed({ Ping: () => Effect.succeed("pong") })
+)
+
+const assertSerialization = (
+  port: number,
+  serverSerialization: Layer.Layer<RpcSerialization.RpcSerialization>,
+  clientSerialization?: "msgpack" | "ndjson"
+) =>
+  Effect.gen(function*() {
+    yield* Layer.launch(makeRunnerLayer(port, SerializationEntityLayer, serverSerialization)).pipe(Effect.forkScoped)
+    yield* Effect.sleep("2 seconds")
+
+    const result = yield* Effect.gen(function*() {
+      const makeClient = yield* SerializationEntity.client
+      yield* Effect.sleep("3 seconds")
+      return yield* makeClient("serialization-entity").Ping()
+    }).pipe(
+      Effect.provide(makeConfiguredClientLayer(port, clientSerialization)),
+      Effect.scoped
+    )
+
+    assert.strictEqual(result, "pong")
+  }).pipe(Effect.provide(SharedStorage))
 
 // An entity whose reply cannot be serialized: the handler returns a
 // non-integer for a `Schema.Int` success schema, so `Reply.serialize` fails
@@ -106,6 +157,18 @@ const ISOLATION_PORT = 50_124
 // Volatile discard should complete after the request is sent, without waiting for the
 // host runner to finish handling it.
 describe("SocketRunner", () => {
+  it.live(
+    "uses SchemaBinary by default for TCP connections",
+    () => assertSerialization(50_120, RpcSerialization.layerSchemaBinary()),
+    15_000
+  )
+
+  it.live(
+    "preserves an explicit MessagePack selection",
+    () => assertSerialization(50_121, RpcSerialization.layerMsgPack, "msgpack"),
+    15_000
+  )
+
   it.live(
     "discarded persisted requests serialize circular values and volatile requests do not wait for replies",
     () =>

--- a/packages/platform/node/test/cluster/SocketRunner.test.ts
+++ b/packages/platform/node/test/cluster/SocketRunner.test.ts
@@ -78,11 +78,16 @@ const makeClientLayer = (port: number) =>
     Layer.provide(RpcSerialization.layerMsgPack)
   )
 
-const makeConfiguredClientLayer = (port: number, serialization?: "msgpack" | "ndjson") =>
+const makeConfiguredClientLayer = (
+  port: number,
+  serialization?: "msgpack" | "ndjson",
+  serializationMaxBufferSize?: number | "unbounded"
+) =>
   NodeClusterSocket.layer({
     clientOnly: true,
     storage: "byo",
     ...(serialization === undefined ? undefined : { serialization }),
+    ...(serializationMaxBufferSize === undefined ? undefined : { serializationMaxBufferSize }),
     shardingConfig: {
       runnerAddress: Option.some(RunnerAddress.make("localhost", port)),
       runnerListenAddress: Option.some(RunnerAddress.make("localhost", port)),
@@ -166,6 +171,30 @@ describe("SocketRunner", () => {
   it.live(
     "preserves an explicit MessagePack selection",
     () => assertSerialization(50_121, RpcSerialization.layerMsgPack, "msgpack"),
+    15_000
+  )
+
+  it.live(
+    "applies serializationMaxBufferSize to the default SchemaBinary parser",
+    () =>
+      Effect.gen(function*() {
+        yield* Layer.launch(
+          makeRunnerLayer(50_122, SerializationEntityLayer, RpcSerialization.layerSchemaBinary())
+        ).pipe(Effect.forkScoped)
+        yield* Effect.sleep("2 seconds")
+
+        const exit = yield* Effect.gen(function*() {
+          const makeClient = yield* SerializationEntity.client
+          yield* Effect.sleep("3 seconds")
+          return yield* makeClient("serialization-limit-entity").Ping().pipe(Effect.timeout("1 second"))
+        }).pipe(
+          Effect.provide(makeConfiguredClientLayer(50_122, undefined, 1)),
+          Effect.scoped,
+          Effect.exit
+        )
+
+        assert.isTrue(Exit.isFailure(exit), "the configured frame limit must reject the response")
+      }).pipe(Effect.provide(SharedStorage)),
     15_000
   )
 

--- a/packages/platform/node/test/cluster/SocketRunner.test.ts
+++ b/packages/platform/node/test/cluster/SocketRunner.test.ts
@@ -156,7 +156,7 @@ const ISOLATION_PORT = 50_124
 
 // BigDecimal.normalize creates a circular `normalized` self-reference.
 // When a persisted message is sent with discard: true, the notify path in Runners.makeRpc
-// passes the raw envelope (with circular BigDecimal payload) to the runner via msgpack,
+// passes the raw envelope (with circular BigDecimal payload) to the runner,
 // causing RangeError: Maximum call stack size exceeded.
 //
 // Volatile discard should complete after the request is sent, without waiting for the
@@ -164,7 +164,7 @@ const ISOLATION_PORT = 50_124
 describe("SocketRunner", () => {
   it.live(
     "uses SchemaBinary by default for TCP connections",
-    () => assertSerialization(50_120, RpcSerialization.layerSchemaBinary()),
+    () => assertSerialization(50_120, RpcSerialization.layerSchemaBinary({ payloadEncoding: "json" })),
     15_000
   )
 
@@ -179,7 +179,11 @@ describe("SocketRunner", () => {
     () =>
       Effect.gen(function*() {
         yield* Layer.launch(
-          makeRunnerLayer(50_122, SerializationEntityLayer, RpcSerialization.layerSchemaBinary())
+          makeRunnerLayer(
+            50_122,
+            SerializationEntityLayer,
+            RpcSerialization.layerSchemaBinary({ payloadEncoding: "json" })
+          )
         ).pipe(Effect.forkScoped)
         yield* Effect.sleep("2 seconds")
 


### PR DESCRIPTION
Change the Bun, Deno, and Node TCP cluster layers to use SchemaBinary when no serialization option is supplied. Explicit MessagePack and NDJSON selections remain unchanged.

SchemaBinary already rejects declared frames above 16 MiB before buffering their bodies. This change also forwards the cluster `serializationMaxBufferSize` option to that frame limit and supports `"unbounded"`, matching the configuration available to the other streaming serializers.

Cluster payloads use the SchemaBinary direct encoding on the wire. The conflict with JSON-only persistence is resolved at the storage boundary instead of lowering payloads to JSON: `MessageStorage` reply handlers now deliver the reply exactly as it was persisted. When a reply cannot be encoded for JSON storage and falls back to a serializable defect, waiting callers receive that same defect rather than a transport-encoded copy of the original value, so live replies and stored replies can no longer diverge.

Benchmarking the Runner server/client over TCP (see EFF-857) exposed a performance defect: the cluster message paths request `codecFor(payloadSchema)` per message, and deriving a SchemaBinary codec costs about 15 us versus 0.4 us for reuse on a small schema. SchemaBinary now memoizes its regular and direct codec constructors by schema identity and wire mode, rather than caching at the RPC layer. After the fix, SchemaBinary beats msgpack on throughput and latency for small, medium, and large workloads while producing 5-50% smaller frames.

SchemaBinary envelope frames are independently decodable, since encoded frames can outlive a single TCP connection.

Regression coverage verifies the SchemaBinary default, frame limits, parser replacement, codec memoization, persisted reply fallback delivery, persisted cluster workflows, and an explicit MessagePack override.

Tests:

- `nix develop -c env EFFECT_CLUSTER_TESTS=1 pnpm test-cluster`: 107/107 passed on the final run. Two earlier runs each lost a cron timing test to a shard-stabilization deadline; each failed case passed immediately when rerun alone.
- `nix develop -c deno task test --run packages/platform/deno/test/cluster/SocketRunner.test.ts`: 2/2 passed.
- `nix develop -c pnpm vitest run packages/effect/test/cluster`: 111/111 passed, including a new MessageStorage regression test for the persisted defect fallback.
- `nix develop -c pnpm vitest run packages/effect/test/unstable/encoding/SchemaBinary.test.ts`: 174/174 passed.
- `nix develop -c pnpm vitest run packages/effect/test/rpc/RpcSerialization.test.ts`: 39/39 passed.
- `nix develop -c pnpm vitest run packages/platform/node/test/cluster/SocketRunner.test.ts`: 5/5 passed.
- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`

Closes EFF-857
