### PR TITLE
Cache SchemaBinary RPC codecs and test reconnect isolation

### DIFF
--- a/.changeset/eff-860-schema-binary-reconnect.md
+++ b/.changeset/eff-860-schema-binary-reconnect.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Cache SchemaBinary RPC payload codecs per serialization service so repeated requests reuse compiled schemas.

--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -600,9 +600,17 @@ const makeSchemaBinary = (options?: {
   readonly fingerprintPayloads?: boolean | undefined
 }): RpcSerialization["Service"] => {
   const maxFrameSize = options?.maxFrameSize ?? defaultSchemaBinaryMaxFrameSize
-  const codecFor: CodecFor = options?.fingerprintPayloads === true
-    ? (schema) => SchemaBinary.toCodecDirect(schema, { fingerprint: true })
-    : SchemaBinary.toCodecDirect
+  const codecOptions = options?.fingerprintPayloads === true ? { fingerprint: true } as const : undefined
+  const codecCache = new WeakMap<Schema.Top, Schema.Top>()
+  const codecFor: CodecFor = <S extends Schema.Top>(schema: S) => {
+    const cached = codecCache.get(schema)
+    if (cached !== undefined) {
+      return cached as Schema.Codec<S["Type"], unknown, S["DecodingServices"], S["EncodingServices"]>
+    }
+    const codec = SchemaBinary.toCodecDirect(schema, codecOptions)
+    codecCache.set(schema, codec)
+    return codec
+  }
   // The envelope repeats itself: the same RPC tag, header names, and trace ids
   // come back on message after message. A dictionary shared by every frame on
   // the connection sends each of those once and references it afterwards, so

--- a/packages/effect/test/rpc/RpcClient.test.ts
+++ b/packages/effect/test/rpc/RpcClient.test.ts
@@ -189,6 +189,70 @@ describe("RpcClient", () => {
       assert.strictEqual(error.reason.message, "HTTP response ended before RPC request completed")
     }))
 
+  it.effect("encodes keepalives with the current serializer after reconnecting", () =>
+    Effect.gen(function*() {
+      const firstOpened = yield* Deferred.make<void>()
+      const secondOpened = yield* Deferred.make<void>()
+      const firstClosed = yield* Deferred.make<never, Socket.SocketError>()
+      const secondClosed = yield* Deferred.make<never, Socket.SocketError>()
+      const writes: Array<{ readonly connection: number; readonly message: unknown }> = []
+      let connection = 0
+      const socketError = new Socket.SocketError({
+        reason: new Socket.SocketOpenError({
+          kind: "Unknown",
+          cause: new Error("connection lost")
+        })
+      })
+      const socket = Socket.make({
+        runRaw: (_handler, options) =>
+          Effect.gen(function*() {
+            const current = connection++
+            if (options?.onOpen !== undefined) yield* options.onOpen
+            yield* Deferred.succeed(current === 0 ? firstOpened : secondOpened, void 0)
+            return yield* Deferred.await(current === 0 ? firstClosed : secondClosed)
+          }),
+        writer: Effect.succeed((chunk) =>
+          Effect.sync(() => {
+            if (typeof chunk !== "string") return
+            writes.push(JSON.parse(chunk))
+          })
+        )
+      })
+      let serializer = 0
+      const serialization = RpcSerialization.RpcSerialization.of({
+        contentType: "application/test",
+        includesFraming: true,
+        codecFor: RpcSerialization.json.codecFor,
+        makeUnsafe: () => {
+          const current = serializer++
+          return {
+            decode: () => [],
+            encode: (message) => JSON.stringify({ connection: current, message })
+          }
+        }
+      })
+
+      yield* RpcClient.makeProtocolSocket({
+        retryTransientErrors: true,
+        retryPolicy: Schedule.spaced("1 millis")
+      }).pipe(
+        Effect.provideService(Socket.Socket, socket),
+        Effect.provideService(RpcSerialization.RpcSerialization, serialization)
+      )
+
+      yield* Deferred.await(firstOpened)
+      yield* TestClock.adjust("5 seconds")
+      yield* Deferred.fail(firstClosed, socketError)
+      yield* TestClock.adjust("1 millis")
+      yield* Deferred.await(secondOpened)
+      yield* TestClock.adjust("5 seconds")
+
+      assert.deepStrictEqual(writes, [
+        { connection: 1, message: { _tag: "Ping" } },
+        { connection: 2, message: { _tag: "Ping" } }
+      ])
+    }))
+
   it.effect("reports transient socket open errors without failing in-flight streams", () =>
     Effect.gen(function*() {
       const requestSent = yield* Deferred.make<void>()

--- a/packages/effect/test/rpc/RpcSerialization.test.ts
+++ b/packages/effect/test/rpc/RpcSerialization.test.ts
@@ -525,6 +525,68 @@ describe("RpcSerialization", () => {
         )
       }).pipe(Effect.provide(RpcSerialization.layerSchemaBinary({ fingerprintPayloads: true }))))
 
+    it.effect("reuses payload codecs for the same schema", () =>
+      Effect.gen(function*() {
+        const serialization = yield* RpcSerialization.RpcSerialization
+        const Payload = Schema.Struct({ value: Schema.String })
+
+        assert.strictEqual(serialization.codecFor(Payload), serialization.codecFor(Payload))
+      }).pipe(Effect.provide(RpcSerialization.layerSchemaBinary())))
+
+    it.effect("does not carry a partial frame into a new connection", () =>
+      Effect.gen(function*() {
+        const serialization = yield* RpcSerialization.RpcSerialization
+        const request: RpcMessage.RequestEncoded = {
+          _tag: "Request",
+          id: 1,
+          tag: "Echo",
+          payload: Uint8Array.of(1, 2, 3),
+          headers: []
+        }
+        const staleSender = serialization.makeUnsafe()
+        const staleReceiver = serialization.makeUnsafe()
+        const staleFrame = staleSender.encode(request)
+        assert(staleFrame instanceof Uint8Array)
+        assert.deepStrictEqual(staleReceiver.decode(staleFrame.subarray(0, staleFrame.length - 1)), [])
+
+        const reconnectedSender = serialization.makeUnsafe()
+        const reconnectedReceiver = serialization.makeUnsafe()
+        const frame = reconnectedSender.encode(request)
+        assert(frame instanceof Uint8Array)
+        assert.deepStrictEqual(reconnectedReceiver.decode(frame), [request])
+      }).pipe(Effect.provide(RpcSerialization.layerSchemaBinary())))
+
+    it.effect("does not reuse one connection's dictionary in another connection", () =>
+      Effect.gen(function*() {
+        const clientSerialization = yield* RpcSerialization.RpcSerialization.pipe(
+          Effect.provide(RpcSerialization.layerSchemaBinary())
+        )
+        const serverSerialization = yield* RpcSerialization.RpcSerialization.pipe(
+          Effect.provide(RpcSerialization.layerSchemaBinary())
+        )
+        const firstClient = clientSerialization.makeUnsafe()
+        const request = (id: number): RpcMessage.RequestEncoded => ({
+          _tag: "Request",
+          id,
+          tag: "OnlyEncodedOnTheFirstConnection",
+          payload: Uint8Array.of(1),
+          headers: []
+        })
+
+        // This frame never reaches the server, so only the client's abandoned
+        // connection knows the string.
+        firstClient.encode(request(1))
+
+        const reconnectedClient = clientSerialization.makeUnsafe()
+        const reconnectedServer = serverSerialization.makeUnsafe()
+        const frame = reconnectedClient.encode(request(2))
+        assert(frame instanceof Uint8Array)
+        assert.deepStrictEqual(reconnectedServer.decode(frame), [request(2)])
+        const repeatedFrame = reconnectedClient.encode(request(3))
+        assert(repeatedFrame instanceof Uint8Array)
+        assert.deepStrictEqual(reconnectedServer.decode(repeatedFrame), [request(3)])
+      }))
+
     it.effect("uses fingerprinted envelope framing and the binary content type", () =>
       Effect.gen(function*() {
         const serialization = yield* RpcSerialization.RpcSerialization


### PR DESCRIPTION
## Summary

- Cache SchemaBinary payload codecs by schema identity within each RPC serialization service.
- Cover partial-frame and dictionary isolation when a client reconnects.
- Verify socket keepalives use the serializer created for the current connection.

## Testing

- `nix develop -c pnpm vitest run packages/effect/test/rpc`
- `nix develop -c pnpm --dir packages/effect check`
- `nix develop -c pnpm lint`

Closes EFF-860
