### PR TITLE
Fix IndexedDB equals typing without key paths

### DIFF
--- a/.changeset/pre/eff-861-indexeddb-equals.md
+++ b/.changeset/pre/eff-861-indexeddb-equals.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-browser": patch
+---
+
+Fix IndexedDB `.equals` queries on tables without key paths to accept out-of-line `IDBValidKey` values.

--- a/packages/platform/browser/src/IndexedDbQueryBuilder.ts
+++ b/packages/platform/browser/src/IndexedDbQueryBuilder.ts
@@ -227,7 +227,8 @@ export declare namespace IndexedDbQuery {
     Index extends keyof Table["indexes"],
     KeyPath = [Index] extends [never] ? Table["keyPath"] : Table["indexes"][Index],
     Type = Table["tableSchema"]["Encoded"]
-  > = KeyPath extends keyof Type ? Type[KeyPath]
+  > = [KeyPath] extends [undefined] ? IDBValidKey
+    : KeyPath extends keyof Type ? Type[KeyPath]
     : { [I in keyof KeyPath]: KeyPath[I] extends keyof Type ? Type[KeyPath[I]] | [] : never }
 
   /**

--- a/packages/platform/browser/test/IndexedDbQueryBuilder.test.ts
+++ b/packages/platform/browser/test/IndexedDbQueryBuilder.test.ts
@@ -231,6 +231,27 @@ describe.sequential("IndexedDbQueryBuilder", () => {
       }).pipe(provideDb(Db))
     })
 
+    it.effect("select equals in no keypath table", () => {
+      class Db extends IndexedDbDatabase.make(
+        V1,
+        Effect.fn(function*(api) {
+          yield* api.createObjectStore("no-keypath")
+          yield* api
+            .from("no-keypath")
+            .insert({ username: "user", index: 1, key: 5 })
+        })
+      ) {}
+
+      return Effect.gen(function*() {
+        const api = yield* Db
+        const data = yield* api.from("no-keypath").select().equals(5)
+
+        assert.deepStrictEqual(data, [
+          { username: "user", index: 1, key: 5 }
+        ])
+      }).pipe(provideDb(Db))
+    })
+
     it.effect("select equals with index", () => {
       class Db extends IndexedDbDatabase.make(
         V1,


### PR DESCRIPTION
## Summary

- use `IDBValidKey` for `.equals` queries when an IndexedDB table has no key path
- cover an out-of-line numeric key with a compile-time and runtime regression test
- add a patch changeset for `@effect/platform-browser`

## Testing

- `nix develop -c pnpm test packages/platform/browser/test/IndexedDbQueryBuilder.test.ts --run`
- `nix develop -c pnpm check`
- `nix develop -c pnpm lint`

Closes EFF-861
Closes #7432
