### PR TITLE
Relax atom-react React peer dependency

### DIFF
--- a/.changeset/calm-atoms-relax.md
+++ b/.changeset/calm-atoms-relax.md
@@ -1,0 +1,5 @@
+---
+"@effect/atom-react": patch
+---
+
+Support React 19.2.3 and later.

--- a/.changeset/calm-atoms-relax.md
+++ b/.changeset/calm-atoms-relax.md
@@ -2,4 +2,4 @@
 "@effect/atom-react": patch
 ---
 
-Support React 19.2.3 and later.
+Relax react peer dependency range

--- a/packages/atom/react/package.json
+++ b/packages/atom/react/package.json
@@ -61,8 +61,8 @@
   },
   "peerDependencies": {
     "effect": "workspace:^",
-    "react": ">=19.2.3 <20.0.0",
-    "scheduler": ">=0.27.0 <0.28.0"
+    "react": ">=19.0.0 <20.0.0",
+    "scheduler": ">=0.25.0 <0.28.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/packages/atom/react/package.json
+++ b/packages/atom/react/package.json
@@ -61,7 +61,7 @@
   },
   "peerDependencies": {
     "effect": "workspace:^",
-    "react": ">=19.2.7 <20.0.0",
+    "react": ">=19.2.3 <20.0.0",
     "scheduler": ">=0.27.0 <0.28.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Lower the `@effect/atom-react` React peer dependency floor to 19.0.0 so the package supports every React 19 release, including React Native and Expo SDK versions pinned below the repository's test dependency.

The scheduler peer moves with it: React DOM 19.0 uses scheduler 0.25, React DOM 19.1 uses scheduler 0.26, and React DOM 19.2 uses scheduler 0.27. Keeping the scheduler floor at 0.27 would leave peer conflicts for React 19.0 and 19.1.

The package only uses React APIs available before React 19. React 18 support remains out of scope because its type definitions currently fail the package check and would need dedicated CI coverage.

## Validation

- Atom React suite passed with React 19.2, 19.1, and 19.0 (23 tests each)
- `pnpm vitest --run packages/atom/react/test/index.test.tsx`
- `pnpm --filter @effect/atom-react check`
- `pnpm peers check --filter @effect/atom-react`

Closes EFF-867
