### PR TITLE
Surface the provider's explanation on AuthenticationError

### DIFF
--- a/.changeset/authentication-error-description.md
+++ b/.changeset/authentication-error-description.md
@@ -1,0 +1,9 @@
+---
+"effect": patch
+"@effect/ai-anthropic": patch
+"@effect/ai-openai": patch
+"@effect/ai-openai-compat": patch
+"@effect/ai-openrouter": patch
+---
+
+Add an optional `description` to `AiError.AuthenticationError`, rendered after the kind-based suggestion, and pass the provider's own error text through it on HTTP 401 and 403, so authentication failures report what actually went wrong instead of only a category.

--- a/packages/ai/anthropic/src/internal/errors.ts
+++ b/packages/ai/anthropic/src/internal/errors.ts
@@ -260,7 +260,7 @@ export const buildHttpContext = (params: {
 // HTTP Status Code
 // =============================================================================
 
-const buildInvalidRequestDescription = (params: {
+const buildErrorDescription = (params: {
   readonly status: number
   readonly message: string | undefined
   readonly method: string
@@ -305,7 +305,7 @@ export const mapStatusCodeToReason = ({ status, headers, message, metadata, http
   readonly metadata: AnthropicErrorMetadata
   readonly http: typeof AiError.HttpContext.Type
 }): AiError.AiErrorReason => {
-  const invalidRequestDescription = buildInvalidRequestDescription({
+  const errorDescription = buildErrorDescription({
     status,
     message,
     method: http.request.method,
@@ -318,31 +318,33 @@ export const mapStatusCodeToReason = ({ status, headers, message, metadata, http
   switch (status) {
     case 400:
       return new AiError.InvalidRequestError({
-        description: invalidRequestDescription,
+        description: errorDescription,
         metadata: { anthropic: metadata },
         http
       })
     case 401:
       return new AiError.AuthenticationError({
         kind: "InvalidKey",
+        description: errorDescription,
         metadata: { anthropic: metadata },
         http
       })
     case 403:
       return new AiError.AuthenticationError({
         kind: "InsufficientPermissions",
+        description: errorDescription,
         metadata: { anthropic: metadata },
         http
       })
     case 404:
       return new AiError.InvalidRequestError({
-        description: invalidRequestDescription,
+        description: errorDescription,
         metadata: { anthropic: metadata },
         http
       })
     case 422:
       return new AiError.InvalidRequestError({
-        description: invalidRequestDescription,
+        description: errorDescription,
         metadata: { anthropic: metadata },
         http
       })

--- a/packages/ai/anthropic/test/AnthropicClient.test.ts
+++ b/packages/ai/anthropic/test/AnthropicClient.test.ts
@@ -44,6 +44,71 @@ describe("AnthropicClient", () => {
         request_id: null
       }
     }))))
+
+  it.effect("surfaces the provider message on 401 AuthenticationError", () =>
+    Effect.gen(function*() {
+      const client = yield* AnthropicClient.AnthropicClient
+
+      const result = yield* client.createMessage({
+        payload: {
+          model: "claude-sonnet-4-20250514",
+          max_tokens: 1,
+          messages: [{ role: "user", content: "hello" }]
+        }
+      }).pipe(Effect.flip)
+
+      assert.strictEqual(result.reason._tag, "AuthenticationError")
+      if (result.reason._tag !== "AuthenticationError") {
+        return yield* Effect.die(new Error("Expected AuthenticationError"))
+      }
+      assert.strictEqual(result.reason.kind, "InvalidKey")
+      assert.include(result.reason.description ?? "", "invalid x-api-key")
+      assert.include(result.reason.message, "invalid x-api-key")
+      assert.strictEqual(
+        result.reason.message,
+        "InvalidKey: Verify your API key is correct. invalid x-api-key (POST https://api.anthropic.com/v1/messages?beta=true) [type: authentication_error]"
+      )
+    }).pipe(Effect.provide(makeTestLayer({
+      _tag: "Json",
+      status: 401,
+      body: {
+        type: "error",
+        error: { type: "authentication_error", message: "invalid x-api-key" },
+        request_id: null
+      }
+    }))))
+
+  it.effect("surfaces the provider message on 403 AuthenticationError", () =>
+    Effect.gen(function*() {
+      const client = yield* AnthropicClient.AnthropicClient
+
+      const result = yield* client.createMessage({
+        payload: {
+          model: "claude-sonnet-4-20250514",
+          max_tokens: 1,
+          messages: [{ role: "user", content: "hello" }]
+        }
+      }).pipe(Effect.flip)
+
+      assert.strictEqual(result.reason._tag, "AuthenticationError")
+      if (result.reason._tag !== "AuthenticationError") {
+        return yield* Effect.die(new Error("Expected AuthenticationError"))
+      }
+      assert.strictEqual(result.reason.kind, "InsufficientPermissions")
+      assert.include(result.reason.description ?? "", "not available for this account")
+      assert.include(result.reason.message, "not available for this account")
+    }).pipe(Effect.provide(makeTestLayer({
+      _tag: "Json",
+      status: 403,
+      body: {
+        type: "error",
+        error: {
+          type: "permission_error",
+          message: "claude-sonnet-4-20250514 is not available for this account"
+        },
+        request_id: null
+      }
+    }))))
 })
 
 type MockResponse =

--- a/packages/ai/openai-compat/src/internal/errors.ts
+++ b/packages/ai/openai-compat/src/internal/errors.ts
@@ -207,7 +207,7 @@ export const buildHttpContext = (params: {
   body: params.body
 })
 
-const buildInvalidRequestDescription = (params: {
+const buildErrorDescription = (params: {
   readonly status: number
   readonly message: string | undefined
   readonly method: string
@@ -255,7 +255,7 @@ export const mapStatusCodeToReason = ({ status, headers, message, metadata, http
   readonly metadata: OpenAiErrorMetadata
   readonly http: typeof AiError.HttpContext.Type
 }): AiError.AiErrorReason => {
-  const invalidRequestDescription = buildInvalidRequestDescription({
+  const errorDescription = buildErrorDescription({
     status,
     message,
     method: http.request.method,
@@ -269,32 +269,34 @@ export const mapStatusCodeToReason = ({ status, headers, message, metadata, http
   switch (status) {
     case 400:
       return new AiError.InvalidRequestError({
-        description: invalidRequestDescription,
+        description: errorDescription,
         metadata: { openai: metadata },
         http
       })
     case 401:
       return new AiError.AuthenticationError({
         kind: "InvalidKey",
+        description: errorDescription,
         metadata,
         http
       })
     case 403:
       return new AiError.AuthenticationError({
         kind: "InsufficientPermissions",
+        description: errorDescription,
         metadata,
         http
       })
     case 404:
       return new AiError.InvalidRequestError({
-        description: invalidRequestDescription,
+        description: errorDescription,
         metadata: { openai: metadata },
         http
       })
     case 409:
     case 422:
       return new AiError.InvalidRequestError({
-        description: invalidRequestDescription,
+        description: errorDescription,
         metadata: { openai: metadata },
         http
       })

--- a/packages/ai/openai-compat/test/OpenAiClient.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiClient.test.ts
@@ -376,6 +376,62 @@ describe("OpenAiClient", () => {
         }
       }))))
 
+    it.effect("surfaces the provider message on 401 AuthenticationError", () =>
+      Effect.gen(function*() {
+        const client = yield* OpenAiClient.OpenAiClient
+
+        const error = yield* client.createResponse({
+          model: "gpt-4o-mini",
+          messages: [{ role: "user", content: "hello" }]
+        }).pipe(Effect.flip)
+
+        assert.strictEqual(error.reason._tag, "AuthenticationError")
+        if (error.reason._tag !== "AuthenticationError") {
+          return yield* Effect.die(new Error("Expected AuthenticationError"))
+        }
+        assert.strictEqual(error.reason.kind, "InvalidKey")
+        assert.include(error.reason.description ?? "", "Incorrect API key provided")
+        assert.include(error.reason.message, "Incorrect API key provided")
+      }).pipe(Effect.provide(makeTestLayer({
+        _tag: "Json",
+        status: 401,
+        body: {
+          error: {
+            message: "Incorrect API key provided",
+            type: "invalid_request_error",
+            code: "invalid_api_key"
+          }
+        }
+      }))))
+
+    it.effect("surfaces the provider message on 403 AuthenticationError", () =>
+      Effect.gen(function*() {
+        const client = yield* OpenAiClient.OpenAiClient
+
+        const error = yield* client.createResponse({
+          model: "gpt-4o-mini",
+          messages: [{ role: "user", content: "hello" }]
+        }).pipe(Effect.flip)
+
+        assert.strictEqual(error.reason._tag, "AuthenticationError")
+        if (error.reason._tag !== "AuthenticationError") {
+          return yield* Effect.die(new Error("Expected AuthenticationError"))
+        }
+        assert.strictEqual(error.reason.kind, "InsufficientPermissions")
+        assert.include(error.reason.description ?? "", "Country, region, or territory not supported")
+        assert.include(error.reason.message, "Country, region, or territory not supported")
+      }).pipe(Effect.provide(makeTestLayer({
+        _tag: "Json",
+        status: 403,
+        body: {
+          error: {
+            message: "Country, region, or territory not supported",
+            type: "permission_error",
+            code: null
+          }
+        }
+      }))))
+
     it.effect("maps insufficient quota errors to QuotaExhaustedError", () =>
       Effect.gen(function*() {
         const client = yield* OpenAiClient.OpenAiClient

--- a/packages/ai/openai/src/internal/errors.ts
+++ b/packages/ai/openai/src/internal/errors.ts
@@ -241,7 +241,7 @@ export const buildHttpContext = (params: {
 // HTTP Status Code
 // =============================================================================
 
-const buildInvalidRequestDescription = (params: {
+const buildErrorDescription = (params: {
   readonly status: number
   readonly message: string | undefined
   readonly method: string
@@ -294,7 +294,7 @@ export const mapStatusCodeToReason = ({ status, headers, message, metadata, http
   readonly metadata: OpenAiErrorMetadata
   readonly http: typeof AiError.HttpContext.Type
 }): AiError.AiErrorReason => {
-  const invalidRequestDescription = buildInvalidRequestDescription({
+  const errorDescription = buildErrorDescription({
     status,
     message,
     method: http.request.method,
@@ -308,32 +308,34 @@ export const mapStatusCodeToReason = ({ status, headers, message, metadata, http
   switch (status) {
     case 400:
       return new AiError.InvalidRequestError({
-        description: invalidRequestDescription,
+        description: errorDescription,
         metadata: { openai: metadata },
         http
       })
     case 401:
       return new AiError.AuthenticationError({
         kind: "InvalidKey",
+        description: errorDescription,
         metadata,
         http
       })
     case 403:
       return new AiError.AuthenticationError({
         kind: "InsufficientPermissions",
+        description: errorDescription,
         metadata,
         http
       })
     case 404:
       return new AiError.InvalidRequestError({
-        description: invalidRequestDescription,
+        description: errorDescription,
         metadata: { openai: metadata },
         http
       })
     case 409:
     case 422:
       return new AiError.InvalidRequestError({
-        description: invalidRequestDescription,
+        description: errorDescription,
         metadata: { openai: metadata },
         http
       })

--- a/packages/ai/openai/test/OpenAiClient.test.ts
+++ b/packages/ai/openai/test/OpenAiClient.test.ts
@@ -291,6 +291,8 @@ describe("OpenAiClient", () => {
         assert.strictEqual(result.reason._tag, "AuthenticationError")
         if (result.reason._tag === "AuthenticationError") {
           assert.strictEqual(result.reason.kind, "InvalidKey")
+          assert.include(result.reason.description ?? "", "Invalid API key")
+          assert.include(result.reason.message, "Invalid API key")
         }
       }).pipe(Effect.provide(makeTestLayer(undefined, {
         _tag: "Json",
@@ -307,6 +309,8 @@ describe("OpenAiClient", () => {
         assert.strictEqual(result.reason._tag, "AuthenticationError")
         if (result.reason._tag === "AuthenticationError") {
           assert.strictEqual(result.reason.kind, "InsufficientPermissions")
+          assert.include(result.reason.description ?? "", "Access denied")
+          assert.include(result.reason.message, "Access denied")
         }
       }).pipe(Effect.provide(makeTestLayer(undefined, {
         _tag: "Json",

--- a/packages/ai/openrouter/src/internal/errors.ts
+++ b/packages/ai/openrouter/src/internal/errors.ts
@@ -256,7 +256,7 @@ export const buildHttpContext = (params: {
 // HTTP Status Code
 // =============================================================================
 
-const buildInvalidRequestDescription = (params: {
+const buildErrorDescription = (params: {
   readonly status: number
   readonly message: string | undefined
   readonly method: string
@@ -304,7 +304,7 @@ export const mapStatusCodeToReason = ({ status, headers, message, metadata, http
   readonly metadata: OpenRouterErrorMetadata
   readonly http: typeof AiError.HttpContext.Type
 }): AiError.AiErrorReason => {
-  const invalidRequestDescription = buildInvalidRequestDescription({
+  const errorDescription = buildErrorDescription({
     status,
     message,
     method: http.request.method,
@@ -318,19 +318,21 @@ export const mapStatusCodeToReason = ({ status, headers, message, metadata, http
   switch (status) {
     case 400:
       return new AiError.InvalidRequestError({
-        description: invalidRequestDescription,
+        description: errorDescription,
         metadata: { openrouter: metadata },
         http
       })
     case 401:
       return new AiError.AuthenticationError({
         kind: "InvalidKey",
+        description: errorDescription,
         metadata: { openrouter: metadata },
         http
       })
     case 403:
       return new AiError.AuthenticationError({
         kind: "InsufficientPermissions",
+        description: errorDescription,
         metadata: { openrouter: metadata },
         http
       })
@@ -338,7 +340,7 @@ export const mapStatusCodeToReason = ({ status, headers, message, metadata, http
     case 409:
     case 422:
       return new AiError.InvalidRequestError({
-        description: invalidRequestDescription,
+        description: errorDescription,
         metadata: { openrouter: metadata },
         http
       })

--- a/packages/ai/openrouter/test/OpenRouterClient.test.ts
+++ b/packages/ai/openrouter/test/OpenRouterClient.test.ts
@@ -30,6 +30,60 @@ describe("OpenRouterClient", () => {
         }
       }
     }))))
+
+  it.effect("surfaces the provider message on 401 AuthenticationError", () =>
+    Effect.gen(function*() {
+      const client = yield* OpenRouterClient.OpenRouterClient
+
+      const result = yield* client.createChatCompletion({
+        model: "openai/gpt-4o-mini",
+        messages: [{ role: "user", content: "hello" }]
+      }).pipe(Effect.flip)
+
+      assert.strictEqual(result.reason._tag, "AuthenticationError")
+      if (result.reason._tag !== "AuthenticationError") {
+        return yield* Effect.die(new Error("Expected AuthenticationError"))
+      }
+      assert.strictEqual(result.reason.kind, "InvalidKey")
+      assert.include(result.reason.description ?? "", "No auth credentials found")
+      assert.include(result.reason.message, "No auth credentials found")
+    }).pipe(Effect.provide(makeTestLayer({
+      _tag: "Json",
+      status: 401,
+      body: {
+        error: {
+          code: 401,
+          message: "No auth credentials found"
+        }
+      }
+    }))))
+
+  it.effect("surfaces the provider message on 403 AuthenticationError", () =>
+    Effect.gen(function*() {
+      const client = yield* OpenRouterClient.OpenRouterClient
+
+      const result = yield* client.createChatCompletion({
+        model: "openai/gpt-4o-mini",
+        messages: [{ role: "user", content: "hello" }]
+      }).pipe(Effect.flip)
+
+      assert.strictEqual(result.reason._tag, "AuthenticationError")
+      if (result.reason._tag !== "AuthenticationError") {
+        return yield* Effect.die(new Error("Expected AuthenticationError"))
+      }
+      assert.strictEqual(result.reason.kind, "InsufficientPermissions")
+      assert.include(result.reason.description ?? "", "Key does not have permission")
+      assert.include(result.reason.message, "Key does not have permission")
+    }).pipe(Effect.provide(makeTestLayer({
+      _tag: "Json",
+      status: 403,
+      body: {
+        error: {
+          code: 403,
+          message: "Key does not have permission"
+        }
+      }
+    }))))
 })
 
 type MockResponse =

--- a/packages/effect/src/unstable/ai/AiError.ts
+++ b/packages/effect/src/unstable/ai/AiError.ts
@@ -468,6 +468,13 @@ export class QuotaExhaustedError extends Schema.Error<QuotaExhaustedError>(
  * })
  *
  * const result = [authError.kind, authError.isRetryable] // => ["InvalidKey", false]
+ *
+ * const detailed = new AiError.AuthenticationError({
+ *   kind: "InsufficientPermissions",
+ *   description: "Token expired"
+ * })
+ *
+ * detailed.message // => "InsufficientPermissions: Your API key lacks required permissions. Token expired"
  * ```
  *
  * @category errors
@@ -478,6 +485,7 @@ export class AuthenticationError extends Schema.Error<AuthenticationError>(
 )({
   _tag: Schema.tag("AuthenticationError"),
   kind: Schema.Literals(["InvalidKey", "ExpiredKey", "MissingKey", "InsufficientPermissions", "Unknown"]),
+  description: Schema.optional(Schema.String),
   metadata: providerMetadataWithDefaults<AuthenticationErrorMetadata>(),
   http: Schema.optional(HttpContext)
 }) {
@@ -505,7 +513,9 @@ export class AuthenticationError extends Schema.Error<AuthenticationError>(
       InsufficientPermissions: "Your API key lacks required permissions",
       Unknown: "Authentication failed. Check your credentials"
     }
-    return `${this.kind}: ${suggestions[this.kind]}`
+    let msg = `${this.kind}: ${suggestions[this.kind]}`
+    if (this.description) msg += `. ${this.description}`
+    return msg
   }
 }
 

--- a/packages/effect/test/unstable/ai/AiError.test.ts
+++ b/packages/effect/test/unstable/ai/AiError.test.ts
@@ -64,6 +64,36 @@ describe("AiError", () => {
         const error = new AiError.AuthenticationError({ kind: "Unknown" })
         assert.strictEqual(error._tag, "AuthenticationError")
       })
+
+      it("should render the description after the kind suggestion when present", () => {
+        const error = new AiError.AuthenticationError({
+          kind: "InsufficientPermissions",
+          description: "anthropic.claude-sonnet-5 is not available for this account"
+        })
+        assert.strictEqual(
+          error.message,
+          "InsufficientPermissions: Your API key lacks required permissions. anthropic.claude-sonnet-5 is not available for this account"
+        )
+      })
+
+      it("should render the message unchanged when description is absent", () => {
+        const error = new AiError.AuthenticationError({ kind: "InsufficientPermissions" })
+        assert.strictEqual(
+          error.message,
+          "InsufficientPermissions: Your API key lacks required permissions"
+        )
+        assert.isUndefined(error.description)
+      })
+
+      it("should round-trip the description through the schema", () => {
+        const error = new AiError.AuthenticationError({
+          kind: "ExpiredKey",
+          description: "The security token included in the request is expired"
+        })
+        const encoded = Schema.encodeUnknownSync(AiError.AuthenticationError)(error)
+        const decoded = Schema.decodeUnknownSync(AiError.AuthenticationError)(encoded)
+        assert.strictEqual(decoded.description, "The security token included in the request is expired")
+      })
     })
 
     describe("ContentPolicyError", () => {
@@ -549,6 +579,18 @@ describe("AiError", () => {
         assert.strictEqual(reason._tag, "AuthenticationError")
         if (reason._tag === "AuthenticationError") {
           assert.strictEqual(reason.kind, "InsufficientPermissions")
+        }
+      })
+
+      it("should thread the description into 401/403 AuthenticationError", () => {
+        const reason = AiError.reasonFromHttpStatus({
+          status: 403,
+          description: "User is not authorized to perform: bedrock:InvokeModel"
+        })
+        assert.strictEqual(reason._tag, "AuthenticationError")
+        if (reason._tag === "AuthenticationError") {
+          assert.strictEqual(reason.description, "User is not authorized to perform: bedrock:InvokeModel")
+          assert.include(reason.message, "User is not authorized to perform: bedrock:InvokeModel")
         }
       })
 


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`AiError.AuthenticationError` gets a new optional `description` field. It is shown after the kind-based suggestion, in the same way `InvalidRequestError` already shows its own description:

```
InvalidKey: Verify your API key is correct. invalid x-api-key (POST https://api.anthropic.com/v1/messages?beta=true) [type: authentication_error]
```

Before this change, the message came only from `kind`. The provider's own 401/403 error text was thrown away, and the generic message could point the user in the wrong direction. The problem was found while using Amazon Bedrock (the Bedrock integration is a downstream project, not part of this repo). Bedrock returns HTTP 403 for several different problems: `ExpiredTokenException` ("The security token included in the request is expired") and `UnrecognizedClientException` ("The security token included in the request is invalid.") are credential problems, not permission problems. But both were shown as `InsufficientPermissions: Your API key lacks required permissions`. That message suggests fixing IAM policies, while the real fix was to refresh or correct a credential. The in-tree providers lose information in the same way: Anthropic's `invalid x-api-key`, OpenAI's `Incorrect API key provided: …`, and errors about organization/project scope or region restrictions were all reduced to the generic category. Because `description` is part of the core error type, downstream providers such as the Bedrock integration can pass their messages through in the same way.

All four providers (anthropic, openai, openai-compat, openrouter) now pass the provider message through on HTTP 401 and 403, exactly as they already did for `InvalidRequestError` at 400/404/422. The description also includes the request context, and the error type/code when the body cannot be parsed.

When `description` is absent, the rendered message is exactly the same as before, and `isRetryable` does not change. The provider-internal helper `buildInvalidRequestDescription` is renamed to `buildErrorDescription`, because it no longer serves only invalid-request errors.

## Validation

- `pnpm lint`
- `pnpm check`
- `pnpm vitest run packages/effect/test/unstable/ai/AiError.test.ts packages/ai/anthropic/test/AnthropicClient.test.ts packages/ai/openai/test/OpenAiClient.test.ts packages/ai/openai-compat/test/OpenAiClient.test.ts packages/ai/openrouter/test/OpenRouterClient.test.ts`
- `pnpm doctest --run packages/effect/src/unstable/ai/AiError.ts`
- `pnpm test-types typetest/unstable/ai`
- `pnpm ai-docgen` (no diff)
