### PR TITLE
Update cluster migration guidance for RPC codecs

### DIFF
--- a/migration/annotations/effect__cluster__Message.yaml
+++ b/migration/annotations/effect__cluster__Message.yaml
@@ -1,3 +1,3 @@
 "@effect/cluster/Message#serialize":
   replacement: "effect/unstable/cluster/Message#serialize"
-  note: "Moved into core Effect. It now returns Envelope.Partial; use serializeEnvelope for the JSON Envelope.Encoded form."
+  note: "Moved into core Effect. Pass the transport's codecFor as the second argument; use serializeEnvelope for the JSON Envelope.Encoded form."

--- a/migration/annotations/effect__cluster__Reply.yaml
+++ b/migration/annotations/effect__cluster__Reply.yaml
@@ -1,9 +1,9 @@
 "@effect/cluster/Reply#ReplyEncoded":
   replacement: "effect/unstable/cluster/Reply#Encoded"
-  note: "Renamed to Encoded and no longer parameterized by an Rpc; payload fields are unknown and validated by Reply.Reply(rpc)."
+  note: "Renamed to Encoded and no longer parameterized by an Rpc; payload fields are unknown and validated by Reply.Reply(rpc, codecFor) with the transport's codec."
 "@effect/cluster/Reply#serialize":
   replacement: "effect/unstable/cluster/Reply#serialize"
-  note: "Moved into core Effect and now returns the non-generic Reply.Encoded wire union."
+  note: "Moved into core Effect and now returns the non-generic Reply.Encoded wire union. Pass the transport's codecFor as the second argument."
 "@effect/cluster/Reply#TypeId":
   replacement: "none"
   note: "The reply marker is private in v4. Use Reply.isReply for runtime refinement."

--- a/migration/annotations/effect__cluster__Runners.yaml
+++ b/migration/annotations/effect__cluster__Runners.yaml
@@ -3,7 +3,7 @@
   note: "Moved into core Effect with the same no-op runner communication layer."
 "@effect/cluster/Runners#make":
   replacement: "effect/unstable/cluster/Runners#make"
-  note: "Moved into core Effect with the same callbacks and requirements; Context service projections now use Service instead of Type."
+  note: "Moved into core Effect. Its options now require codecFor; pass the codec used by the remote runner transport, such as RpcSerialization.json.codecFor for JSON. Context service projections now use Service instead of Type."
 "@effect/cluster/Runners#makeNoop":
   replacement: "effect/unstable/cluster/Runners#makeNoop"
   note: "Moved into core Effect; it returns the Context.Service implementation through the Service projection instead of Type."

--- a/migration/annotations/effect__rpc__RpcServer.yaml
+++ b/migration/annotations/effect__rpc__RpcServer.yaml
@@ -36,7 +36,7 @@
   note: "HttpApp became HttpEffect; the result contains the WebSocket protocol and upgrade effect."
 "@effect/rpc/RpcServer#Protocol":
   replacement: "effect/unstable/rpc/RpcServer#Protocol"
-  note: "Retained as a Context.Service; custom transports now expose a disconnect queue and explicit capability flags."
+  note: "Retained as a Context.Service; custom transports now expose a disconnect queue, explicit capability flags, and codecFor for schema-aware payload and exit encoding."
 "@effect/rpc/RpcServer#toHttpApp":
   replacement: "effect/unstable/rpc/RpcServer#toHttpEffect"
   note: "Renamed for the v4 HTTP effect model; it starts the RPC server and returns the request effect."

--- a/migration/v3-to-v4.md
+++ b/migration/v3-to-v4.md
@@ -4,7 +4,7 @@
 
 Base: `3d390f232bdbc3f0d3d6a2ae3c775084f494b547` (`3d390f232bdbc3f0d3d6a2ae3c775084f494b547`)
 
-Head: `origin/main` (`648f566dd259898e7697c7fcb796183ccbc474ab`)
+Head: `origin/main` (`20cb4f260e45d37fa417c292c57be015314efe16`)
 
 This file is generated from the API diff and `migration/annotations/*.yaml`.
 
@@ -5674,7 +5674,7 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 ### `@effect/cluster/Message`
 
-- `Message.serialize` -> `effect/unstable/cluster/Message#serialize`: Moved into core Effect. It now returns Envelope.Partial; use serializeEnvelope for the JSON Envelope.Encoded form.
+- `Message.serialize` -> `effect/unstable/cluster/Message#serialize`: Moved into core Effect. Pass the transport's codecFor as the second argument; use serializeEnvelope for the JSON Envelope.Encoded form.
 
 ### `@effect/cluster/MessageStorage`
 
@@ -5686,11 +5686,11 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 ### `@effect/cluster/Reply`
 
-- `Reply.ReplyEncoded` -> `effect/unstable/cluster/Reply#Encoded`: Renamed to Encoded and no longer parameterized by an Rpc; payload fields are unknown and validated by Reply.Reply(rpc).
+- `Reply.ReplyEncoded` -> `effect/unstable/cluster/Reply#Encoded`: Renamed to Encoded and no longer parameterized by an Rpc; payload fields are unknown and validated by Reply.Reply(rpc, codecFor) with the transport's codec.
 
 - `Reply.TypeId` -> `none`: The reply marker is private in v4. Use Reply.isReply for runtime refinement.
 
-- `Reply.serialize` -> `effect/unstable/cluster/Reply#serialize`: Moved into core Effect and now returns the non-generic Reply.Encoded wire union.
+- `Reply.serialize` -> `effect/unstable/cluster/Reply#serialize`: Moved into core Effect and now returns the non-generic Reply.Encoded wire union. Pass the transport's codecFor as the second argument.
 
 ### `@effect/cluster/Runner`
 
@@ -5706,7 +5706,7 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 ### `@effect/cluster/Runners`
 
-- `Runners.make` -> `effect/unstable/cluster/Runners#make`: Moved into core Effect with the same callbacks and requirements; Context service projections now use Service instead of Type.
+- `Runners.make` -> `effect/unstable/cluster/Runners#make`: Moved into core Effect. Its options now require codecFor; pass the codec used by the remote runner transport, such as RpcSerialization.json.codecFor for JSON. Context service projections now use Service instead of Type.
 
 - `Runners.makeNoop` -> `effect/unstable/cluster/Runners#makeNoop`: Moved into core Effect; it returns the Context.Service implementation through the Service projection instead of Type.
 
@@ -7640,7 +7640,7 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 ### `@effect/rpc/RpcServer`
 
-- `RpcServer.Protocol` -> `effect/unstable/rpc/RpcServer#Protocol`: Retained as a Context.Service; custom transports now expose a disconnect queue and explicit capability flags.
+- `RpcServer.Protocol` -> `effect/unstable/rpc/RpcServer#Protocol`: Retained as a Context.Service; custom transports now expose a disconnect queue, explicit capability flags, and codecFor for schema-aware payload and exit encoding.
 
 - `RpcServer.fiberIdClientInterrupt` -> `effect/unstable/rpc/RpcSchema#ClientAbort`: The sentinel FiberId was replaced by a Cause annotation; inspect ClientAbort in the interruption cause when client cancellation must be distinguished.
 


### PR DESCRIPTION
Updates the v3-to-v4 migration reference for the schema-aware RPC serialization changes merged since the previous maintenance baseline.

- Documents the required transport `codecFor` argument for cluster message and reply serialization.
- Updates `Runners.make` and `RpcServer.Protocol` guidance for the same codec contract.
- Regenerates the reference header at main SHA `20cb4f260e45d37fa417c292c57be015314efe16`.

Validation:

- `pnpm vitest run --project @effect/api-diff` (25 tests passed)
- `pnpm --dir packages/tools/api-diff check`
- Targeted dprint and `git diff --check`
- The pinned full `api-diff --check` reports five current-main gaps outside the audited commits: `EventLogRemote.Ping`, `Sse.Parser`, `OpenApiJsonSchema.Unknown`, `Workflow.Complete`, and the `ParseResult` group (`ParseError`, `decode`, `encode`). No affected cluster or RPC IDs are missing.

Closes EFF-864
