### PR TITLE
Fix CLI help spacing for long names

### DIFF
--- a/.changeset/pre/fix-cli-help-table-spacing.md
+++ b/.changeset/pre/fix-cli-help-table-spacing.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Keep long CLI subcommand and argument names separated from their descriptions in help output.

--- a/packages/effect/src/unstable/cli/CliOutput.ts
+++ b/packages/effect/src/unstable/cli/CliOutput.ts
@@ -411,7 +411,7 @@ interface Row {
 const renderTable = (rows: ReadonlyArray<Row>, widthCap?: number) => {
   const maxColumn = Math.max(...rows.map((r) => visualLength(r.left))) + 4
   const col = widthCap === undefined ? maxColumn : Math.min(maxColumn, widthCap)
-  return rows.map(({ left, right }) => `  ${pad(left, col)}${right}`).join("\n")
+  return rows.map(({ left, right }) => `  ${pad(left, Math.max(col, visualLength(left) + 1))}${right}`).join("\n")
 }
 
 const formatSubcommandName = (name: string, alias: string | undefined): string => alias ? `${name}, ${alias}` : name

--- a/packages/effect/test/unstable/cli/Help.test.ts
+++ b/packages/effect/test/unstable/cli/Help.test.ts
@@ -130,6 +130,29 @@ describe("Command help output", () => {
       expect(shortLine!.indexOf("Short flag description")).toBe(longLine!.indexOf("Long flag description"))
     }).pipe(Effect.provide(TestLayer)))
 
+  it.effect("separates long subcommand and argument names from their descriptions", () =>
+    Effect.gen(function*() {
+      const child = Command.make("account:set-password", {
+        account: Argument.string("existing-account-identifier").pipe(
+          Argument.withDescription("Account to update")
+        )
+      }).pipe(Command.withDescription("Rewrite the credential hash"))
+      const command = Command.make("demo").pipe(Command.withSubcommands([child]))
+      const run = Command.runWith(command, { version: "1.0.0" })
+
+      yield* run(["--help"])
+      const rootHelp = yield* TestConsole.logLines
+
+      yield* run(["account:set-password", "--help"])
+      const allHelp = yield* TestConsole.logLines
+      const childHelp = allHelp.slice(rootHelp.length)
+
+      assert.isTrue(rootHelp.some((line) => String(line).includes("account:set-password Rewrite the credential hash")))
+      assert.isTrue(
+        childHelp.some((line) => String(line).includes("existing-account-identifier string Account to update"))
+      )
+    }).pipe(Effect.provide(TestLayer)))
+
   it.effect("hides flags marked with withHidden from help output", () =>
     Effect.gen(function*() {
       const command = Command.make("tool", {


### PR DESCRIPTION
## Summary

- preserve at least one space between capped CLI table labels and their descriptions
- cover long subcommand and argument names through rendered `--help` output
- add a patch changeset for `effect`

## Testing

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/effect/test/unstable/cli/Help.test.ts`
- `nix develop -c pnpm check`

Closes EFF-876
Closes #7423
