### PR TITLE
Redact values in CLI wizard command output

### DIFF
--- a/.changeset/redact-cli-wizard-values.md
+++ b/.changeset/redact-cli-wizard-values.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Redact password prompt values from CLI wizard command output.

--- a/packages/effect/src/unstable/cli/Command.ts
+++ b/packages/effect/src/unstable/cli/Command.ts
@@ -1626,7 +1626,8 @@ export const wizard = <Name extends string, Input, E, R, ContextInput>(
   options?: {
     readonly prefix?: ReadonlyArray<string> | undefined
   } | undefined
-): Effect.Effect<Array<string>, CliError.CliError | Terminal.QuitError, Environment> => Wizard.run(command, options)
+): Effect.Effect<Array<string>, CliError.CliError | Terminal.QuitError, Environment> =>
+  Effect.map(Wizard.run(command, options), (result) => result.args)
 
 const getOutOfScopeGlobalFlagErrors = (
   allFlags: ReadonlyArray<GlobalFlag.GlobalFlag<any>>,
@@ -1901,8 +1902,8 @@ export const runWith = <const Name extends string, Input, E, R, ContextInput>(
               command.name,
               ...args.filter((arg) => arg !== "--wizard" && !arg.startsWith("--wizard="))
             ]
-            const wizardArgs = yield* Wizard.run(command, { commandPath, prefix })
-            yield* Console.log(Wizard.renderCompletion(wizardArgs))
+            const wizardResult = yield* Wizard.run(command, { commandPath, prefix })
+            yield* Console.log(Wizard.renderCompletion(wizardResult.displayArgs))
             const shouldRun = yield* Prompt.run(Prompt.toggle({
               message: "Run this command?",
               initial: true,
@@ -1911,7 +1912,7 @@ export const runWith = <const Name extends string, Input, E, R, ContextInput>(
             }))
             if (shouldRun) {
               yield* Console.log()
-              yield* runWith(command, { ...config, renderErrors: false })(wizardArgs.slice(1))
+              yield* runWith(command, { ...config, renderErrors: false })(wizardResult.args.slice(1))
             }
           }).pipe(
             Effect.catchTag("QuitError", () => Console.log(Wizard.renderQuit()))

--- a/packages/effect/src/unstable/cli/internal/wizard.ts
+++ b/packages/effect/src/unstable/cli/internal/wizard.ts
@@ -16,17 +16,30 @@ export interface Options {
   readonly prefix?: ReadonlyArray<string> | undefined
 }
 
+export interface Result {
+  readonly args: Array<string>
+  readonly displayArgs: Array<string>
+}
+
+interface CommandLineArg {
+  readonly value: string
+  readonly displayValue: string
+}
+
 export const run: (
   command: Command.Command.Any,
   options?: Options
-) => Effect.Effect<Array<string>, CliError.CliError | Terminal.QuitError, Command.Environment> = Effect.fnUntraced(
+) => Effect.Effect<Result, CliError.CliError | Terminal.QuitError, Command.Environment> = Effect.fnUntraced(
   function*(command, options) {
     const commandPath = options?.commandPath ?? [command.name]
     const selected = getCommandAtPath(command, commandPath)
-    const commandLine = [...(options?.prefix ?? commandPath)]
+    const commandLine = (options?.prefix ?? commandPath).map((value) => commandLineArg(value))
     yield* logCurrentCommand(commandLine)
     yield* promptCommand(selected, commandLine, selected === command ? "ROOT" : selected.name)
-    return commandLine
+    return {
+      args: commandLine.map((arg) => arg.value),
+      displayArgs: commandLine.map((arg) => arg.displayValue)
+    }
   }
 )
 
@@ -49,7 +62,7 @@ const getCommandAtPath = (
 
 const promptCommand: (
   command: Command.Command.Any,
-  commandLine: Array<string>,
+  commandLine: Array<CommandLineArg>,
   sectionName: string
 ) => Effect.Effect<void, CliError.CliError | Terminal.QuitError, Command.Environment> = Effect.fnUntraced(
   function*(command, commandLine, sectionName) {
@@ -94,7 +107,7 @@ const promptCommand: (
       }))
     }))
     yield* Console.log()
-    commandLine.push(child.name)
+    commandLine.push(commandLineArg(child.name))
     if (hasWizardSteps(child)) {
       yield* logCurrentCommand(commandLine)
     }
@@ -109,57 +122,58 @@ const hasWizardSteps = (command: Command.Command.Any): boolean => {
 
 const promptParam: (
   param: Param.Any
-) => Effect.Effect<Array<string>, CliError.CliError | Terminal.QuitError, Command.Environment> = Effect.fnUntraced(
-  function*(param) {
-    const single = Param.getUnderlyingSingleOrThrow(param)
-    const metadata = Param.getParamMetadata(param)
+) => Effect.Effect<Array<CommandLineArg>, CliError.CliError | Terminal.QuitError, Command.Environment> = Effect
+  .fnUntraced(
+    function*(param) {
+      const single = Param.getUnderlyingSingleOrThrow(param)
+      const metadata = Param.getParamMetadata(param)
 
-    if (metadata.isOptional) {
-      const include = yield* Prompt.run(Prompt.confirm({
-        message: `Set ${renderParamLabel(single)}?`,
-        initial: false
-      }))
-      if (!include) {
-        yield* Console.log()
-        return []
+      if (metadata.isOptional) {
+        const include = yield* Prompt.run(Prompt.confirm({
+          message: `Set ${renderParamLabel(single)}?`,
+          initial: false
+        }))
+        if (!include) {
+          yield* Console.log()
+          return []
+        }
       }
-    }
 
-    const count = !metadata.isVariadic
-      ? 1
-      : yield* Prompt.run(Prompt.integer({
-        message: `${renderParamLabel(single)} count`,
-        default: Option.getOrElse(metadata.variadicMin, () => 0),
-        min: Option.getOrElse(metadata.variadicMin, () => 0),
-        ...(Option.isSome(metadata.variadicMax) ? { max: metadata.variadicMax.value } : {})
-      }))
-    const values: Array<string> = []
-    for (let i = 0; i < count; i++) {
-      values.push(yield* promptSingle(single))
-    }
-
-    const parsed = single.kind === Param.flagKind
-      ? {
-        flags: { [single.name]: values },
-        arguments: []
+      const count = !metadata.isVariadic
+        ? 1
+        : yield* Prompt.run(Prompt.integer({
+          message: `${renderParamLabel(single)} count`,
+          default: Option.getOrElse(metadata.variadicMin, () => 0),
+          min: Option.getOrElse(metadata.variadicMin, () => 0),
+          ...(Option.isSome(metadata.variadicMax) ? { max: metadata.variadicMax.value } : {})
+        }))
+      const values: Array<CommandLineArg> = []
+      for (let i = 0; i < count; i++) {
+        values.push(yield* promptSingle(single))
       }
-      : {
-        flags: {},
-        arguments: values
-      }
-    yield* param.parse(parsed)
-    yield* Console.log()
 
-    if (single.kind === Param.argumentKind) {
-      return values
+      const parsed = single.kind === Param.flagKind
+        ? {
+          flags: { [single.name]: values.map((arg) => arg.value) },
+          arguments: []
+        }
+        : {
+          flags: {},
+          arguments: values.map((arg) => arg.value)
+        }
+      yield* param.parse(parsed)
+      yield* Console.log()
+
+      if (single.kind === Param.argumentKind) {
+        return values
+      }
+      return values.flatMap((value) => [commandLineArg(`--${single.name}`), value])
     }
-    return values.flatMap((value) => [`--${single.name}`, value])
-  }
-)
+  )
 
 const promptSingle = (
   single: Param.Single<Param.ParamKind, unknown>
-): Effect.Effect<string, Terminal.QuitError, Command.Environment> => {
+): Effect.Effect<CommandLineArg, Terminal.QuitError, Command.Environment> => {
   const message = renderParamMessage(single)
   switch (single.primitiveType._tag) {
     case "Boolean":
@@ -175,27 +189,35 @@ const promptSingle = (
             defaultDeny: "(t/F)"
           }
         })),
-        String
+        (value) => commandLineArg(String(value))
       )
     case "Choice": {
       const choices = Primitive.getChoiceKeys(single.primitiveType) ?? []
-      return Prompt.run(Prompt.select({
-        message,
-        choices: choices.map((choice) => ({ title: choice, value: choice }))
-      }))
+      return Effect.map(
+        Prompt.run(Prompt.select({
+          message,
+          choices: choices.map((choice) => ({ title: choice, value: choice }))
+        })),
+        commandLineArg
+      )
     }
     case "Date":
-      return Effect.map(Prompt.run(Prompt.date({ message })), (date) => date.toISOString())
+      return Effect.map(Prompt.run(Prompt.date({ message })), (date) => commandLineArg(date.toISOString()))
     case "Float":
-      return Effect.map(Prompt.run(Prompt.float({ message })), String)
+      return Effect.map(Prompt.run(Prompt.float({ message })), (value) => commandLineArg(String(value)))
     case "Integer":
-      return Effect.map(Prompt.run(Prompt.integer({ message })), String)
+      return Effect.map(Prompt.run(Prompt.integer({ message })), (value) => commandLineArg(String(value)))
     case "Redacted":
-      return Effect.map(Prompt.run(Prompt.password({ message })), Redacted.value)
+      return Effect.map(
+        Prompt.run(Prompt.password({ message })),
+        (value) => commandLineArg(Redacted.value(value), "<redacted>")
+      )
     default:
-      return Prompt.run(Prompt.text({ message }))
+      return Effect.map(Prompt.run(Prompt.text({ message })), commandLineArg)
   }
 }
+
+const commandLineArg = (value: string, displayValue: string = value): CommandLineArg => ({ value, displayValue })
 
 const formatName = (single: Param.Single<Param.ParamKind, unknown>): string =>
   single.kind === Param.flagKind ? `--${single.name}` : single.name
@@ -216,8 +238,8 @@ const humanize = (name: string): string => {
   return [words[0][0].toUpperCase() + words[0].slice(1), ...words.slice(1)].join(" ")
 }
 
-const logCurrentCommand = (commandLine: ReadonlyArray<string>): Effect.Effect<void> =>
-  Console.log(renderCommandBlock("Current command", commandLine, Ansi.magenta))
+const logCurrentCommand = (commandLine: ReadonlyArray<CommandLineArg>): Effect.Effect<void> =>
+  Console.log(renderCommandBlock("Current command", commandLine.map((arg) => arg.displayValue), Ansi.magenta))
 
 const renderSection = (commandName: string, section: string): string =>
   `${Ansi.annotate(commandName.toUpperCase(), Ansi.bold, Ansi.cyanBright)} ${Ansi.annotate("·", Ansi.blackBright)} ${

--- a/packages/effect/src/unstable/cli/internal/wizard.ts
+++ b/packages/effect/src/unstable/cli/internal/wizard.ts
@@ -120,56 +120,57 @@ const hasWizardSteps = (command: Command.Command.Any): boolean => {
   return hasVisibleSubcommands || toImpl(command).config.orderedParams.length > 0
 }
 
-const promptParam: (
-  param: Param.Any
-) => Effect.Effect<Array<CommandLineArg>, CliError.CliError | Terminal.QuitError, Command.Environment> = Effect
-  .fnUntraced(
-    function*(param) {
-      const single = Param.getUnderlyingSingleOrThrow(param)
-      const metadata = Param.getParamMetadata(param)
+const promptParam = Effect.fnUntraced(
+  function*(param: Param.Any): Effect.fn.Return<
+    Array<CommandLineArg>,
+    CliError.CliError | Terminal.QuitError,
+    Command.Environment
+  > {
+    const single = Param.getUnderlyingSingleOrThrow(param)
+    const metadata = Param.getParamMetadata(param)
 
-      if (metadata.isOptional) {
-        const include = yield* Prompt.run(Prompt.confirm({
-          message: `Set ${renderParamLabel(single)}?`,
-          initial: false
-        }))
-        if (!include) {
-          yield* Console.log()
-          return []
-        }
+    if (metadata.isOptional) {
+      const include = yield* Prompt.run(Prompt.confirm({
+        message: `Set ${renderParamLabel(single)}?`,
+        initial: false
+      }))
+      if (!include) {
+        yield* Console.log()
+        return []
       }
-
-      const count = !metadata.isVariadic
-        ? 1
-        : yield* Prompt.run(Prompt.integer({
-          message: `${renderParamLabel(single)} count`,
-          default: Option.getOrElse(metadata.variadicMin, () => 0),
-          min: Option.getOrElse(metadata.variadicMin, () => 0),
-          ...(Option.isSome(metadata.variadicMax) ? { max: metadata.variadicMax.value } : {})
-        }))
-      const values: Array<CommandLineArg> = []
-      for (let i = 0; i < count; i++) {
-        values.push(yield* promptSingle(single))
-      }
-
-      const parsed = single.kind === Param.flagKind
-        ? {
-          flags: { [single.name]: values.map((arg) => arg.value) },
-          arguments: []
-        }
-        : {
-          flags: {},
-          arguments: values.map((arg) => arg.value)
-        }
-      yield* param.parse(parsed)
-      yield* Console.log()
-
-      if (single.kind === Param.argumentKind) {
-        return values
-      }
-      return values.flatMap((value) => [commandLineArg(`--${single.name}`), value])
     }
-  )
+
+    const count = !metadata.isVariadic
+      ? 1
+      : yield* Prompt.run(Prompt.integer({
+        message: `${renderParamLabel(single)} count`,
+        default: Option.getOrElse(metadata.variadicMin, () => 0),
+        min: Option.getOrElse(metadata.variadicMin, () => 0),
+        ...(Option.isSome(metadata.variadicMax) ? { max: metadata.variadicMax.value } : {})
+      }))
+    const values: Array<CommandLineArg> = []
+    for (let i = 0; i < count; i++) {
+      values.push(yield* promptSingle(single))
+    }
+
+    const parsed = single.kind === Param.flagKind
+      ? {
+        flags: { [single.name]: values.map((arg) => arg.value) },
+        arguments: []
+      }
+      : {
+        flags: {},
+        arguments: values.map((arg) => arg.value)
+      }
+    yield* param.parse(parsed)
+    yield* Console.log()
+
+    if (single.kind === Param.argumentKind) {
+      return values
+    }
+    return values.flatMap((value) => [commandLineArg(`--${single.name}`), value])
+  }
+)
 
 const promptSingle = (
   single: Param.Single<Param.ParamKind, unknown>

--- a/packages/effect/test/unstable/cli/Command.test.ts
+++ b/packages/effect/test/unstable/cli/Command.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, expect, it } from "@effect/vitest"
-import { Context, Effect, Fiber, FileSystem, Layer, Option, Path, Runtime, Stdio } from "effect"
+import { Context, Effect, Fiber, FileSystem, Layer, Option, Path, Redacted, Runtime, Stdio } from "effect"
 import { TestConsole } from "effect/testing"
 import { Argument, CliConfig, CliError, CliOutput, Command, Flag, GlobalFlag } from "effect/unstable/cli"
 import { toImpl } from "effect/unstable/cli/internal/command"
@@ -163,6 +163,38 @@ describe("Command", () => {
         assert.include(output, "Command ready")
         assert.include(output, "$ greet --name 'Alice Smith'")
         assert.include(output, "Run this command?")
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("should redact values in wizard command output", () =>
+      Effect.gen(function*() {
+        const secret = "hunter2-secret"
+        const captured: Array<readonly [string, string]> = []
+        const command = Command.make("login", {
+          password: Flag.redacted("password"),
+          account: Argument.string("account")
+        }, ({ account, password }) =>
+          Effect.sync(() => {
+            captured.push([Redacted.value(password), account])
+          }))
+
+        const fiber = yield* Command.runWith(command, { version: "1.0.0" })(["--wizard"]).pipe(Effect.forkChild)
+        yield* MockTerminal.inputText(secret)
+        yield* MockTerminal.inputKey("enter")
+        yield* MockTerminal.inputText("alice")
+        yield* MockTerminal.inputKey("enter")
+        yield* MockTerminal.inputKey("enter")
+        yield* Fiber.join(fiber)
+
+        const output = [...yield* TestConsole.logLines, ...yield* MockTerminal.displayLines].join("\n")
+        const currentCommand = output.slice(output.indexOf("Current command"), output.indexOf("Command ready"))
+        const commandReady = output.slice(output.indexOf("Command ready"))
+
+        assert.deepStrictEqual(captured, [[secret, "alice"]])
+        assert.include(currentCommand, "--password")
+        assert.include(currentCommand, "<redacted>")
+        assert.include(commandReady, "--password")
+        assert.include(commandReady, "<redacted>")
+        assert.notInclude(output, secret)
       }).pipe(Effect.provide(TestLayer)))
 
     it.effect("should print a message when wizard mode is cancelled", () =>


### PR DESCRIPTION
## Summary

- keep separate execution and display values for wizard-generated arguments
- render redacted prompt values as `<redacted>` in intermediate and final command blocks
- cover both command displays while verifying the handler still receives the actual value

## Testing

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/effect/test/unstable/cli/Command.test.ts`
- `nix develop -c pnpm check`

Closes EFF-877
Closes #7422
