### PR TITLE
Terminate `Stream.fromEventListener` after one item if `once: true`

### DIFF
--- a/.changeset/ninety-books-sit.md
+++ b/.changeset/ninety-books-sit.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Terminate the `Stream.fromEventListener` stream after one item if `once: true`.

--- a/.changeset/spotty-masks-own.md
+++ b/.changeset/spotty-masks-own.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Loosen Stream.addEventListener type parameter

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -1411,21 +1411,19 @@ export const fromEventListener = <A = unknown>(
     readonly once?: boolean
     readonly bufferSize?: number | undefined
   } | undefined
-): Stream<A> => {
-  const stream = callback<A>((queue) => {
+): Stream<A> =>
+  callback<A>((queue) => {
+    const once = typeof options === "object" && options.once
+
     function emit(event: A) {
       Queue.offerUnsafe(queue, event)
+      if (once) Queue.endUnsafe(queue)
     }
     return Effect.acquireRelease(
       Effect.sync(() => target.addEventListener(type, emit, options)),
       () => Effect.sync(() => target.removeEventListener(type, emit, options))
     )
   }, { bufferSize: typeof options === "object" ? options.bufferSize : undefined })
-
-  const once = typeof options === "object" && options.once
-
-  return once ? take(stream, 1) : stream
-}
 
 /**
  * Creates a stream by repeatedly applying an effectful step function to a

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -1350,7 +1350,7 @@ export const fromSubscription = <A>(pubsub: PubSub.Subscription<A>): Stream<A> =
  * @category models
  * @since 3.4.0
  */
-export interface EventListener<A> {
+export interface EventListener<A = unknown> {
   addEventListener(
     event: string,
     f: (event: A) => void,
@@ -1403,7 +1403,7 @@ export interface EventListener<A> {
  * @since 3.1.0
  */
 export const fromEventListener = <A = unknown>(
-  target: EventListener<A>,
+  target: EventListener,
   type: string,
   options?: boolean | {
     readonly capture?: boolean
@@ -1415,7 +1415,7 @@ export const fromEventListener = <A = unknown>(
   callback<A>((queue) => {
     const once = typeof options === "object" && options.once
 
-    function emit(event: A) {
+    function emit(event: any) {
       Queue.offerUnsafe(queue, event)
       if (once) Queue.endUnsafe(queue)
     }

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -1411,8 +1411,8 @@ export const fromEventListener = <A = unknown>(
     readonly once?: boolean
     readonly bufferSize?: number | undefined
   } | undefined
-): Stream<A> =>
-  callback<A>((queue) => {
+): Stream<A> => {
+  const stream = callback<A>((queue) => {
     function emit(event: A) {
       Queue.offerUnsafe(queue, event)
     }
@@ -1421,6 +1421,11 @@ export const fromEventListener = <A = unknown>(
       () => Effect.sync(() => target.removeEventListener(type, emit, options))
     )
   }, { bufferSize: typeof options === "object" ? options.bufferSize : undefined })
+
+  const once = typeof options === "object" && options.once
+
+  return once ? take(stream, 1) : stream
+}
 
 /**
  * Creates a stream by repeatedly applying an effectful step function to a

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -5207,11 +5207,11 @@ describe("Stream", () => {
           target.dispatchEvent(new CustomEvent("test", { detail: 4 }))
         })
 
-        const stream = Stream.fromEventListener(target, "test")
+        const stream = Stream.fromEventListener<CustomEvent>(target, "test")
 
         const [result] = yield* Effect.all([
           stream.pipe(
-            Stream.map((event) => (event as CustomEvent).detail),
+            Stream.map((event) => event.detail),
             // take is required because the stream will never terminate on its own
             Stream.take(4),
             Stream.runCollect
@@ -5221,6 +5221,7 @@ describe("Stream", () => {
 
         assert.deepStrictEqual(result, [1, 2, 3, 4])
       }))
+
     it.effect("ends after the first event with once: true", () =>
       Effect.gen(function*() {
         const target = new EventTarget()
@@ -5231,11 +5232,11 @@ describe("Stream", () => {
           target.dispatchEvent(new CustomEvent("test", { detail: 2 }))
         })
 
-        const stream = Stream.fromEventListener(target, "test", { once: true })
+        const stream = Stream.fromEventListener<CustomEvent>(target, "test", { once: true })
 
         const [result] = yield* Effect.all([
           stream.pipe(
-            Stream.map((event) => (event as CustomEvent).detail),
+            Stream.map((event) => event.detail),
             Stream.runCollect
           ),
           dispatchEvents

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -5193,6 +5193,57 @@ describe("Stream", () => {
         assert.deepStrictEqual(result, [Exit.fail("boom"), Exit.fail("boom")])
       }))
   })
+
+  describe("fromEventListener", () => {
+    it.effect("subscribes and emits events", () =>
+      Effect.gen(function*() {
+        const target = new EventTarget()
+
+        const dispatchEvents = Effect.gen(function*() {
+          yield* Effect.yieldNow
+          target.dispatchEvent(new CustomEvent("test", { detail: 1 }))
+          target.dispatchEvent(new CustomEvent("test", { detail: 2 }))
+          target.dispatchEvent(new CustomEvent("test", { detail: 3 }))
+          target.dispatchEvent(new CustomEvent("test", { detail: 4 }))
+        })
+
+        const stream = Stream.fromEventListener(target, "test")
+
+        const [result] = yield* Effect.all([
+          stream.pipe(
+            Stream.map((event) => (event as CustomEvent).detail),
+            // take is required because the stream will never terminate on its own
+            Stream.take(4),
+            Stream.runCollect
+          ),
+          dispatchEvents
+        ], { concurrency: "unbounded" })
+
+        assert.deepStrictEqual(result, [1, 2, 3, 4])
+      }))
+    it.effect("ends after the first event with once: true", () =>
+      Effect.gen(function*() {
+        const target = new EventTarget()
+
+        const dispatchEvents = Effect.gen(function*() {
+          yield* Effect.yieldNow
+          target.dispatchEvent(new CustomEvent("test", { detail: 1 }))
+          target.dispatchEvent(new CustomEvent("test", { detail: 2 }))
+        })
+
+        const stream = Stream.fromEventListener(target, "test", { once: true })
+
+        const [result] = yield* Effect.all([
+          stream.pipe(
+            Stream.map((event) => (event as CustomEvent).detail),
+            Stream.runCollect
+          ),
+          dispatchEvents
+        ], { concurrency: "unbounded" })
+
+        assert.deepStrictEqual(result, [1])
+      }))
+  })
 })
 
 const grouped = <A>(arr: Array<A>, size: number): Array<NonEmptyArray<A>> => {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Currently, the stream returned by `Stream.fromEventListener()` does not terminate after the first item when `once` is set to `true` in the `options` parameter. Though it's not explicitly documented I believe this is a bug because after the first item, the stream will never emit additional items, so you would expect it to end.

This change applies `take(1)` to the stream returned by `Stream.fromEventListener` if `options.once` is `true`.

I've also added a basic test for `fromEventListener` as well as a test that verifies the stream emits one item and terminates.

**Feel free to close this if the existing behavior is intentional.**

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->
<!--
- Related Issue #
- Closes #
-->
