### PR TITLE
Stabilize SQL runner release recovery test

### DIFF
--- a/packages/platform/node/test/cluster/SqlRunnerStorage.integration.test.ts
+++ b/packages/platform/node/test/cluster/SqlRunnerStorage.integration.test.ts
@@ -230,7 +230,9 @@ describe("SqlRunnerStorage", () => {
 
       expect(
         yield* storage.refresh(runnerAddress1, shards).pipe(
-          Effect.retry({ times: 5, schedule: Schedule.spaced(20) })
+          // The integration shard can delay a healthy replacement beyond a
+          // handful of 100 ms lock-operation deadlines under load.
+          Effect.retry({ times: 20, schedule: Schedule.spaced(20) })
         )
       ).toEqual(shards)
     }).pipe(


### PR DESCRIPTION
## Summary

- give the stalled-release recovery assertion enough retries for a saturated integration shard
- keep the assertion focused on a successful `RunnerStorage.refresh`; persistent recovery failures still fail the test

## Root cause

The failed job exhausted five 100 ms lock-operation attempts while the replacement connection was recovering. The job's rerun passed, as did repeated isolated runs, which points to CI scheduling load rather than a storage regression.

## Testing

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`
- focused integration case, 20 consecutive runs (20/20 passed)
- complete `SqlRunnerStorage.integration.test.ts` file (22/22 passed)

Closes EFF-878
