### PR TITLE
Stabilize Deno SocketRunner isolation test

### DIFF
--- a/packages/platform/deno/test/cluster/SocketRunner.test.ts
+++ b/packages/platform/deno/test/cluster/SocketRunner.test.ts
@@ -84,13 +84,6 @@ const IsolationEntity = Entity
   ])
   .annotateRpcs(ClusterSchema.Persisted, false)
 
-const IsolationEntityLayer = IsolationEntity.toLayer(
-  Effect.succeed({
-    BadReply: () => Effect.succeed(1.5),
-    Slow: () => Effect.as(Effect.sleep("2 seconds"), "done")
-  })
-)
-
 const ISOLATION_PORT = 50_126
 
 // BigDecimal.normalize creates a circular `normalized` self-reference.
@@ -157,6 +150,17 @@ describe("SocketRunner", () => {
     "a reply serialization failure fails only its own request",
     () =>
       Effect.gen(function*() {
+        const slowStarted = yield* Deferred.make<void>()
+        const IsolationEntityLayer = IsolationEntity.toLayer(
+          Effect.succeed({
+            BadReply: () => Effect.succeed(1.5),
+            Slow: () =>
+              Deferred.succeed(slowStarted, void 0).pipe(
+                Effect.andThen(Effect.as(Effect.sleep("2 seconds"), "done"))
+              )
+          })
+        )
+
         yield* Layer.launch(makeRunnerLayer(ISOLATION_PORT, IsolationEntityLayer)).pipe(Effect.forkScoped)
         yield* Effect.sleep("2 seconds")
 
@@ -165,7 +169,7 @@ describe("SocketRunner", () => {
           yield* Effect.sleep("3 seconds")
 
           const slowFiber = yield* makeClient("slow-entity").Slow().pipe(Effect.forkChild)
-          yield* Effect.sleep("300 millis")
+          yield* Deferred.await(slowStarted)
 
           const badExit = yield* makeClient("bad-entity").BadReply({ id: 1 }).pipe(Effect.exit)
           assert.isTrue(Exit.isFailure(badExit), "the unencodable reply must fail the request")


### PR DESCRIPTION
## Summary

- wait for the slow entity handler to start before triggering the malformed reply
- remove the 300 ms timing assumption from the Deno SocketRunner isolation test

## Testing

- targeted Deno test, 10 consecutive runs
- full Deno SocketRunner test file
- `pnpm check`
- `pnpm lint`

Closes EFF-879
