### PR TITLE
Prevent resolving tool calls from incomplete responses

### DIFF
--- a/.changeset/tidy-tools-finish.md
+++ b/.changeset/tidy-tools-finish.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Prevent tool handlers from running when language model generation returns an incomplete or invalid response. Incremental streaming fallback now occurs only before the provider emits its first response part.

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -14,7 +14,6 @@
 import type * as Cause from "../../Cause.ts"
 import * as Context from "../../Context.ts"
 import * as Effect from "../../Effect.ts"
-import * as FiberSet from "../../FiberSet.ts"
 import { constFalse, identity, pipe } from "../../Function.ts"
 import type * as JsonSchema from "../../JsonSchema.ts"
 import * as Option from "../../Option.ts"
@@ -22,7 +21,6 @@ import * as Predicate from "../../Predicate.ts"
 import * as Queue from "../../Queue.ts"
 import * as Schema from "../../Schema.ts"
 import * as SchemaAST from "../../SchemaAST.ts"
-import * as Semaphore from "../../Semaphore.ts"
 import * as Sink from "../../Sink.ts"
 import * as Stream from "../../Stream.ts"
 import type { Span } from "../../Tracer.ts"
@@ -1203,20 +1201,29 @@ export const make: (params: {
 
     const rawContent = yield* generateWithNonIncrementalFallback()
 
+    // Validate the complete response before tool handlers can perform side
+    // effects. Tool parameters remain opaque here so their validation keeps
+    // using Toolkit's more specific ToolParameterValidationError.
+    yield* Schema.decodeEffect(
+      Schema.mutable(Schema.Array(Response.Part(makeToolkitWithOpaqueParameters(toolkit))))
+    )(rawContent)
+
     // Resolve the generated tool calls
-    const toolResults = yield* resolveToolCalls(
-      rawContent,
-      toolkit,
-      providerOptions.prompt.content,
-      concurrency
-    ).pipe(
-      Stream.filter(
-        (result) =>
-          result.type === "tool-approval-request" ||
-          result.preliminary === false
-      ),
-      Stream.runCollect
-    )
+    const toolResults = hasIncompleteFinish(rawContent)
+      ? []
+      : yield* resolveToolCalls(
+        rawContent,
+        toolkit,
+        providerOptions.prompt.content,
+        concurrency
+      ).pipe(
+        Stream.filter(
+          (result) =>
+            result.type === "tool-approval-request" ||
+            result.preliminary === false
+        ),
+        Stream.runCollect
+      )
 
     const content = yield* Schema.decodeEffect(ResponseSchema)(rawContent)
 
@@ -1272,9 +1279,14 @@ export const make: (params: {
         incrementalPrompt: undefined,
         previousResponseId: undefined
       }
+      let emitted = false
       return requestOptions.incrementalPrompt
         ? params.streamText(requestOptions).pipe(
-          Stream.catchReason("AiError", "InvalidRequestError", (_) => params.streamText(fallbackOptions))
+          Stream.tap(() => Effect.sync(() => emitted = true)),
+          Stream.catchTag("AiError", (error) =>
+            error.reason._tag === "InvalidRequestError" && !emitted
+              ? params.streamText(fallbackOptions)
+              : Stream.fail(error))
         )
         : params.streamText(requestOptions)
     }
@@ -1499,6 +1511,7 @@ export const make: (params: {
       | Schema.SchemaError
     >()
     const deferredFinishParts: Array<Response.StreamPart<Tools>> = []
+    const deferredToolCalls: Array<Response.ToolCallPartEncoded> = []
 
     // Emit pre-resolved tool results so Chat.streamText persists them to
     // history. This ensures collectToolApprovals({ excludeResolved }) can
@@ -1506,12 +1519,6 @@ export const make: (params: {
     if (preResolvedStreamParts.length > 0) {
       yield* Queue.offerAll(queue, preResolvedStreamParts)
     }
-
-    // FiberSet to track concurrent tool call handlers
-    const toolCallFibers = yield* FiberSet.make<void, AiError.AiError>()
-    const toolCallSemaphore = concurrency === "unbounded"
-      ? undefined
-      : yield* Semaphore.make(concurrency)
 
     // Helper function to handle tool calls with approval logic
     const handleToolCall = Effect.fnUntraced(function*(part: Response.ToolCallPartEncoded) {
@@ -1573,25 +1580,24 @@ export const make: (params: {
           if (immediateParts.length > 0) {
             yield* Queue.offerAll(queue, immediateParts)
           }
-          // Fork tool call handlers - use the raw chunk for encoded params
+          // Defer tool call handlers until the provider has completed so an
+          // incomplete finish cannot trigger side effects.
           for (const part of chunk) {
             if (part.type === "tool-call" && part.providerExecuted !== true) {
-              const effect = handleToolCall(part)
-              yield* FiberSet.run(
-                toolCallFibers,
-                toolCallSemaphore ? toolCallSemaphore.withPermit(effect) : effect
-              )
+              deferredToolCalls.push(part)
             }
           }
         })
       ),
-      // Wait for all tool calls to either:
-      // - complete (FiberSet.awaitEmpty)
-      // - fail (FiberSet.join)
       Effect.andThen(
-        Effect.raceFirst(
-          FiberSet.join(toolCallFibers),
-          FiberSet.awaitEmpty(toolCallFibers)
+        Effect.suspend(() =>
+          hasIncompleteFinish(deferredFinishParts)
+            ? Effect.void
+            : Effect.forEach(
+              deferredToolCalls,
+              handleToolCall,
+              { concurrency, discard: true }
+            )
         )
       ),
       Effect.andThen(
@@ -2112,6 +2118,15 @@ const createDenialResults = (
 // Tool Call Resolution
 // =============================================================================
 
+const hasIncompleteFinish = (
+  content: ReadonlyArray<{ readonly type: string; readonly reason?: unknown }>
+): boolean =>
+  content.some(
+    (part) =>
+      part.type === "finish" &&
+      (part.reason === "length" || part.reason === "content-filter" || part.reason === "error")
+  )
+
 type ToolResolutionResult<Tools extends Record<string, Tool.Any>> =
   | Response.ToolResultPart<
     Tool.Name<Tools[keyof Tools]>,
@@ -2225,6 +2240,13 @@ const makeToolkitWithEncodedParameters = <Tools extends Record<string, Tool.Any>
 ): Toolkit.Any =>
   Toolkit.make(
     ...Object.values(toolkit.tools).map((tool) => tool.setParameters(Schema.toEncoded(tool.parametersSchema)))
+  )
+
+const makeToolkitWithOpaqueParameters = <Tools extends Record<string, Tool.Any>>(
+  toolkit: Toolkit.WithHandler<Tools>
+): Toolkit.Any =>
+  Toolkit.make(
+    ...Object.values(toolkit.tools).map((tool) => tool.setParameters(Schema.Unknown))
   )
 
 const resolveToolkit = <Tools extends Record<string, Tool.Any>, E, R>(

--- a/packages/effect/test/unstable/ai/LanguageModel.test.ts
+++ b/packages/effect/test/unstable/ai/LanguageModel.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@effect/vitest"
 import { assertDefined, assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
-import { Effect, Fiber, Latch, Option, Ref, Schema, Stream } from "effect"
+import { type Cause, Effect, Fiber, Latch, Option, Queue, Ref, Schema, Stream } from "effect"
 import { TestClock } from "effect/testing"
 import { AiError, LanguageModel, Prompt, Response, ResponseIdTracker, Tool, Toolkit } from "effect/unstable/ai"
 import * as TestUtils from "./utils.ts"
@@ -61,6 +61,76 @@ describe("LanguageModel", () => {
   }
 
   describe("generateText", () => {
+    it.effect("does not resolve tool calls after an incomplete finish", () =>
+      Effect.gen(function*() {
+        const calls = yield* Ref.make(0)
+        const handlers = MyToolkit.toLayer({
+          MyTool: () =>
+            Ref.update(calls, (n) => n + 1).pipe(
+              Effect.as({ testSuccess: "test-success" })
+            )
+        })
+
+        for (const reason of ["length", "content-filter", "error"] as const) {
+          const response = yield* LanguageModel.generateText({
+            prompt: [],
+            toolkit: MyToolkit
+          }).pipe(
+            TestUtils.withLanguageModel({
+              generateText: [
+                {
+                  type: "tool-call",
+                  id: `tool-${reason}`,
+                  name: "MyTool",
+                  params: { testParam: "test-param" }
+                },
+                { ...finishPart, reason }
+              ]
+            }),
+            Effect.provide(handlers)
+          )
+
+          strictEqual(response.finishReason, reason)
+          strictEqual(response.toolCalls.length, 1)
+          strictEqual(response.toolResults.length, 0)
+        }
+
+        strictEqual(yield* Ref.get(calls), 0)
+      }))
+
+    it.effect("validates the complete response before resolving tool calls", () =>
+      Effect.gen(function*() {
+        const calls = yield* Ref.make(0)
+        const handlers = MyToolkit.toLayer({
+          MyTool: () =>
+            Ref.update(calls, (n) => n + 1).pipe(
+              Effect.as({ testSuccess: "test-success" })
+            )
+        })
+
+        const error = yield* LanguageModel.generateText({
+          prompt: [],
+          toolkit: MyToolkit
+        }).pipe(
+          TestUtils.withLanguageModel({
+            generateText: [
+              {
+                type: "tool-call",
+                id: "tool-before-invalid-part",
+                name: "MyTool",
+                params: { testParam: "test-param" }
+              },
+              { type: "text", text: 123 } as any
+            ]
+          }),
+          Effect.provide(handlers),
+          Effect.flip
+        )
+
+        strictEqual(error.reason._tag, "InvalidOutputError")
+        strictEqual(yield* Ref.get(calls), 0)
+      }))
+
     it.effect("validates encoded tool parameters when tool call resolution is disabled", () =>
       Effect.gen(function*() {
         const error = yield* LanguageModel.generateText({
@@ -114,6 +184,43 @@ describe("LanguageModel", () => {
   })
 
   describe("streamText", () => {
+    it.effect("does not resolve tool calls after an incomplete finish", () =>
+      Effect.gen(function*() {
+        const calls = yield* Ref.make(0)
+        const handlers = MyToolkit.toLayer({
+          MyTool: () =>
+            Ref.update(calls, (n) => n + 1).pipe(
+              Effect.as({ testSuccess: "test-success" })
+            )
+        })
+
+        for (const reason of ["length", "content-filter", "error"] as const) {
+          const parts = yield* LanguageModel.streamText({
+            prompt: [],
+            toolkit: MyToolkit
+          }).pipe(
+            Stream.runCollect,
+            TestUtils.withLanguageModel({
+              streamText: [
+                {
+                  type: "tool-call",
+                  id: `tool-${reason}`,
+                  name: "MyTool",
+                  params: { testParam: "test-param" }
+                },
+                { ...finishPart, reason }
+              ]
+            }),
+            Effect.provide(handlers)
+          )
+
+          deepStrictEqual(parts.map((part) => part.type), ["tool-call", "finish"])
+          strictEqual(parts.find((part) => part.type === "finish")?.reason, reason)
+        }
+
+        strictEqual(yield* Ref.get(calls), 0)
+      }))
+
     it.effect("validates encoded tool parameters when tool call resolution is disabled", () =>
       Effect.gen(function*() {
         const error = yield* LanguageModel.streamText({
@@ -166,70 +273,92 @@ describe("LanguageModel", () => {
         Effect.provide(TransformToolkitLayer)
       ))
 
-    it.effect("should emit tool calls before executing tool handlers", () =>
+    it.effect("does not execute tool handlers until the provider stream completes", () =>
       Effect.gen(function*() {
         const parts: Array<Response.StreamPart<Toolkit.Tools<typeof MyToolkit>>> = []
-        const latch = yield* Latch.make()
+        const toolCallObserved = yield* Latch.make()
+        const providerQueue = yield* Queue.make<Response.StreamPartEncoded, Cause.Done>()
+        const calls = yield* Ref.make(0)
+        const handlers = MyToolkit.toLayer({
+          MyTool: () =>
+            Ref.update(calls, (n) => n + 1).pipe(
+              Effect.as({ testSuccess: "test-success" })
+            )
+        })
 
         const toolCallId = "tool-abc123"
         const toolName = "MyTool"
         const toolParams = { testParam: "test-param" }
-        const toolResult = { testSuccess: "test-success" }
+        yield* Queue.offer(providerQueue, {
+          type: "tool-call",
+          id: toolCallId,
+          name: toolName,
+          params: toolParams
+        })
 
         const fiber = yield* LanguageModel.streamText({
           prompt: [],
           toolkit: MyToolkit
         }).pipe(
           Stream.runForEach((part) =>
-            Effect.andThen(
-              latch.open,
-              Effect.sync(() => {
-                parts.push(part)
-              })
+            Effect.sync(() => parts.push(part)).pipe(
+              Effect.andThen(part.type === "tool-call" ? toolCallObserved.open : Effect.void)
             )
           ),
           TestUtils.withLanguageModel({
-            streamText: [
-              {
-                type: "tool-call",
-                id: toolCallId,
-                name: toolName,
-                params: toolParams
-              }
-            ]
+            streamText: () => Stream.fromQueue(providerQueue)
           }),
-          Effect.provide(MyToolkitLayer),
+          Effect.provide(handlers),
           Effect.forkScoped
         )
 
-        yield* latch.await
+        yield* toolCallObserved.await
 
-        const toolCallPart = Response.makePart("tool-call", {
-          id: toolCallId,
-          name: toolName,
-          params: toolParams,
-          providerExecuted: false
-        })
+        strictEqual(yield* Ref.get(calls), 0)
+        deepStrictEqual(parts.map((part) => part.type), ["tool-call"])
 
-        const toolResultPart = Response.toolResultPart({
-          id: toolCallId,
-          name: toolName,
-          result: toolResult,
-          encodedResult: toolResult,
-          isFailure: false,
-          providerExecuted: false,
-          preliminary: false
-        })
-
-        deepStrictEqual(parts, [toolCallPart])
-
-        // `TestClock.adjust` wakes the sleeping tool handler but returns before
-        // its result has propagated all the way downstream, so join the stream
-        // fiber to observe the completed sequence of parts.
-        yield* TestClock.adjust("10 seconds")
+        yield* Queue.offer(providerQueue, finishPart)
+        yield* Queue.end(providerQueue)
         yield* Fiber.join(fiber)
 
-        deepStrictEqual(parts, [toolCallPart, toolResultPart])
+        strictEqual(yield* Ref.get(calls), 1)
+        deepStrictEqual(parts.map((part) => part.type), ["tool-call", "tool-result", "finish"])
+      }))
+
+    it.effect("does not execute deferred tool calls when the provider stream fails", () =>
+      Effect.gen(function*() {
+        const calls = yield* Ref.make(0)
+        const handlers = MyToolkit.toLayer({
+          MyTool: () =>
+            Ref.update(calls, (n) => n + 1).pipe(
+              Effect.as({ testSuccess: "test-success" })
+            )
+        })
+        const providerError = AiError.make({
+          module: "LanguageModelTest",
+          method: "streamText",
+          reason: new AiError.InvalidRequestError({ description: "provider stream failed" })
+        })
+
+        yield* LanguageModel.streamText({
+          prompt: [],
+          toolkit: MyToolkit
+        }).pipe(
+          Stream.runDrain,
+          TestUtils.withLanguageModel({
+            streamText: () =>
+              Stream.succeed<Response.StreamPartEncoded>({
+                type: "tool-call",
+                id: "tool-before-failure",
+                name: "MyTool",
+                params: { testParam: "test-param" }
+              }).pipe(Stream.concat(Stream.fail(providerError)))
+          }),
+          Effect.provide(handlers),
+          Effect.flip
+        )
+
+        strictEqual(yield* Ref.get(calls), 0)
       }))
 
     it.effect("emits finish after resolved tool results", () =>
@@ -752,6 +881,58 @@ describe("LanguageModel", () => {
         strictEqual(calls[1]!.previousResponseId, undefined)
         strictEqual(calls[1]!.incrementalPrompt, undefined)
         deepStrictEqual(calls[1]!.prompt, fullPrompt)
+      }))
+
+    it.effect("does not retry an incremental stream after emitting a tool call", () =>
+      Effect.gen(function*() {
+        const prompt = Prompt.make([
+          Prompt.userMessage({ content: [Prompt.textPart({ text: "full prompt" })] })
+        ])
+        const incrementalPrompt = Prompt.make([
+          Prompt.userMessage({ content: [Prompt.textPart({ text: "incremental prompt" })] })
+        ])
+        const handlerCalls = yield* Ref.make(0)
+        const handlers = MyToolkit.toLayer({
+          MyTool: () =>
+            Ref.update(handlerCalls, (n) => n + 1).pipe(
+              Effect.as({ testSuccess: "test-success" })
+            )
+        })
+        let providerCalls = 0
+        const providerError = AiError.make({
+          module: "LanguageModelTest",
+          method: "streamText",
+          reason: new AiError.InvalidRequestError({ description: "incremental stream failed" })
+        })
+
+        yield* LanguageModel.streamText({ prompt, toolkit: MyToolkit }).pipe(
+          Stream.runDrain,
+          TestUtils.withLanguageModel({
+            streamText: () => {
+              providerCalls++
+              return Stream.succeed<Response.StreamPartEncoded>({
+                type: "tool-call",
+                id: "tool-before-incremental-failure",
+                name: "MyTool",
+                params: { testParam: "test-param" }
+              }).pipe(Stream.concat(Stream.fail(providerError)))
+            }
+          }),
+          Effect.provideService(ResponseIdTracker.ResponseIdTracker, {
+            clearUnsafe() {},
+            markParts() {},
+            prepareUnsafe: () =>
+              Option.some({
+                previousResponseId: "resp_prev",
+                prompt: incrementalPrompt
+              })
+          }),
+          Effect.provide(handlers),
+          Effect.flip
+        )
+
+        strictEqual(providerCalls, 1)
+        strictEqual(yield* Ref.get(handlerCalls), 0)
       }))
 
     it.effect("uses tracker prepareUnsafe and markParts in generateText without toolkit", () =>

--- a/packages/effect/test/unstable/ai/utils.ts
+++ b/packages/effect/test/unstable/ai/utils.ts
@@ -1,6 +1,6 @@
 import { Effect, Predicate, Stream } from "effect"
 import { dual } from "effect/Function"
-import type { Response } from "effect/unstable/ai"
+import type { AiError, IdGenerator, Response } from "effect/unstable/ai"
 import { LanguageModel } from "effect/unstable/ai"
 
 export const withLanguageModel: {
@@ -9,36 +9,36 @@ export const withLanguageModel: {
       | Array<Response.PartEncoded>
       | ((options: LanguageModel.ProviderOptions) =>
         | Array<Response.PartEncoded>
-        | Effect.Effect<Array<Response.PartEncoded>>)
+        | Effect.Effect<Array<Response.PartEncoded>, AiError.AiError, IdGenerator.IdGenerator>)
     readonly streamText?:
       | Array<Response.StreamPartEncoded>
       | ((options: LanguageModel.ProviderOptions) =>
         | Array<Response.StreamPartEncoded>
-        | Stream.Stream<Response.StreamPartEncoded>)
+        | Stream.Stream<Response.StreamPartEncoded, AiError.AiError, IdGenerator.IdGenerator>)
   }): <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, LanguageModel.LanguageModel>>
   <A, E, R>(effect: Effect.Effect<A, E, R>, options: {
     readonly generateText?:
       | Array<Response.PartEncoded>
       | ((options: LanguageModel.ProviderOptions) =>
         | Array<Response.PartEncoded>
-        | Effect.Effect<Array<Response.PartEncoded>>)
+        | Effect.Effect<Array<Response.PartEncoded>, AiError.AiError, IdGenerator.IdGenerator>)
     readonly streamText?:
       | Array<Response.StreamPartEncoded>
       | ((options: LanguageModel.ProviderOptions) =>
         | Array<Response.StreamPartEncoded>
-        | Stream.Stream<Response.StreamPartEncoded>)
+        | Stream.Stream<Response.StreamPartEncoded, AiError.AiError, IdGenerator.IdGenerator>)
   }): Effect.Effect<A, E, Exclude<R, LanguageModel.LanguageModel>>
 } = dual(2, <A, E, R>(effect: Effect.Effect<A, E, R>, options: {
   readonly generateText?:
     | Array<Response.PartEncoded>
     | ((options: LanguageModel.ProviderOptions) =>
       | Array<Response.PartEncoded>
-      | Effect.Effect<Array<Response.PartEncoded>>)
+      | Effect.Effect<Array<Response.PartEncoded>, AiError.AiError, IdGenerator.IdGenerator>)
   readonly streamText?:
     | Array<Response.StreamPartEncoded>
     | ((options: LanguageModel.ProviderOptions) =>
       | Array<Response.StreamPartEncoded>
-      | Stream.Stream<Response.StreamPartEncoded>)
+      | Stream.Stream<Response.StreamPartEncoded, AiError.AiError, IdGenerator.IdGenerator>)
 }): Effect.Effect<A, E, Exclude<R, LanguageModel.LanguageModel>> =>
   Effect.provideServiceEffect(
     effect,


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Problem

Automatic tool resolution currently starts handlers even when the provider response is incomplete. For example, a model can emit a valid tool call and then finish with `length`; the handler still runs although its arguments may have been truncated. A malformed later response part can likewise fail validation only after the handler has already performed its side effect.

Incremental streaming has a related edge case: after emitting part of the first attempt, an `InvalidRequestError` can trigger the full-prompt fallback. Deferred tool calls from the failed attempt are then mixed into the fallback response.

## Minimal reproduction

```ts
import { Effect, Schema, Stream } from "effect"
import { LanguageModel, Tool, Toolkit } from "effect/unstable/ai"

const Echo = Tool.make("Echo", {
  parameters: Schema.Struct({ value: Schema.String }),
  success: Schema.String
})
const toolkit = Toolkit.make(Echo)
let calls = 0

const model = LanguageModel.make({
  generateText: () => Effect.succeed([
    {
      type: "tool-call",
      id: "call-1",
      name: "Echo",
      params: { value: "possibly truncated" }
    },
    {
      type: "finish",
      reason: "length",
      usage: { inputTokens: {}, outputTokens: {} },
      response: undefined
    }
  ]),
  streamText: () => Stream.empty
})

const program = LanguageModel.generateText({ prompt: [], toolkit }).pipe(
  Effect.provideServiceEffect(LanguageModel.LanguageModel, model),
  Effect.provide(toolkit.toLayer({
    Echo: ({ value }) => Effect.sync(() => {
      calls++
      return value
    })
  }))
)

await Effect.runPromise(program)
console.log(calls)
```

Before this PR, the program prints `1`. The incomplete response caused a user handler to run. After this PR, it prints `0`; the tool-call part remains in the response, but no tool result is synthesized.

The same issue exists in `streamText`: a tool-call part is observable before the terminal finish reason is known, so executing its handler immediately can commit a side effect before the provider reports `length`, `content-filter`, `error`, or a stream failure.

## Fix

- Delay automatic tool resolution until the provider response completes.
- Skip handlers for `length`, `content-filter`, and `error` finishes.
- Structurally validate a complete non-streaming response before side effects, while leaving parameters opaque so Toolkit still reports `ToolParameterValidationError` with the tool name and arguments.
- Run deferred handlers with `Effect.forEach` and the configured concurrency, preserving approvals and tool-result-before-finish ordering.
- Permit incremental full-prompt fallback only before the provider emits its first part.

## Verification

Regression tests cover:

- all three incomplete finish reasons in `generateText` and `streamText`
- malformed response content after a valid tool call
- observing a streamed tool call while proving its handler has not started
- provider failure after emitting a tool call
- incremental failure after partial output
- existing bounded concurrency, approvals, ordering, and parameter-validation semantics

The complete upstream matrix passes on Node, Deno, and Bun, together with lint, types, build, bundle, circular-dependency, and documentation checks.

## Related

- Related Issue #
- Closes #