### PR TITLE
Preserve response part assignability after narrowing

### DIFF
--- a/.changeset/tidy-parts-narrow.md
+++ b/.changeset/tidy-parts-narrow.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix response tool part assignability after narrowing generic intersected tool records.

--- a/packages/effect/src/unstable/ai/Response.ts
+++ b/packages/effect/src/unstable/ai/Response.ts
@@ -411,13 +411,17 @@ export const StreamPart = <T extends Toolkit.Any | Toolkit.WithHandler<any>>(
 export type ToolCallParts<
   Tools extends Record<string, Tool.Any>,
   EncodedParameters extends boolean = false
-> = {
-  [Name in keyof Tools]: Name extends string ? ToolCallPart<
-      Name,
-      EncodedParameters extends true ? Tool.ParametersEncoded<Tools[Name]> : Tool.Parameters<Tools[Name]>
-    >
-    : never
-}[keyof Tools]
+> = ToolCallPartForName<Tools, EncodedParameters, keyof Tools>
+
+type ToolCallPartForName<
+  Tools extends Record<string, Tool.Any>,
+  EncodedParameters extends boolean,
+  Name extends keyof Tools
+> = Name extends string ? ToolCallPart<
+    Name,
+    EncodedParameters extends true ? Tool.ParametersEncoded<Tools[Name]> : Tool.Parameters<Tools[Name]>
+  >
+  : never
 
 /**
  * Utility type that extracts tool result parts from a set of tools.
@@ -425,11 +429,12 @@ export type ToolCallParts<
  * @category utility types
  * @since 4.0.0
  */
-export type ToolResultParts<Tools extends Record<string, Tool.Any>> = {
-  [Name in keyof Tools]: Name extends string
-    ? ToolResultPart<Name, Tool.Success<Tools[Name]>, Tool.FailureResult<Tools[Name]>>
-    : never
-}[keyof Tools]
+export type ToolResultParts<Tools extends Record<string, Tool.Any>> = ToolResultPartForName<Tools, keyof Tools>
+
+type ToolResultPartForName<
+  Tools extends Record<string, Tool.Any>,
+  Name extends keyof Tools
+> = Name extends string ? ToolResultPart<Name, Tool.Success<Tools[Name]>, Tool.FailureResult<Tools[Name]>> : never
 
 // =============================================================================
 // Base Part

--- a/packages/effect/typetest/unstable/ai/Response.tst.ts
+++ b/packages/effect/typetest/unstable/ai/Response.tst.ts
@@ -1,0 +1,68 @@
+import { Schema } from "effect"
+import { type Response, Tool } from "effect/unstable/ai"
+import { describe, expect, it } from "tstyche"
+
+const BooleanTool = Tool.make("BooleanTool", {
+  parameters: Schema.Boolean,
+  success: Schema.String,
+  failure: Schema.Boolean
+})
+
+const TransformTool = Tool.make("TransformTool", {
+  parameters: Schema.FiniteFromString,
+  success: Schema.Number,
+  failure: Schema.Struct({ message: Schema.String })
+})
+
+type Tools = {
+  readonly BooleanTool: typeof BooleanTool
+  readonly TransformTool: typeof TransformTool
+}
+
+describe("Response", () => {
+  it("preserves generic intersected tool records after narrowing", () => {
+    const narrow = <
+      StaticTools extends Record<string, Tool.Any>,
+      DynamicTools extends Record<string, Tool.Any>,
+      EncodedParameters extends boolean
+    >(part: Response.StreamPart<StaticTools & DynamicTools, EncodedParameters>) => {
+      if (part.type === "error") return
+
+      const narrowed: Response.StreamPart<StaticTools & DynamicTools, EncodedParameters> = part
+      return narrowed
+    }
+
+    void narrow
+  })
+
+  it("preserves tool names with decoded and encoded parameters", () => {
+    const decoded = null as unknown as Response.ToolCallParts<Tools>
+    if (decoded.name === "BooleanTool") {
+      expect(decoded.params).type.toBe<boolean>()
+    } else {
+      expect(decoded.params).type.toBe<number>()
+    }
+
+    const encoded = null as unknown as Response.ToolCallParts<Tools, true>
+    if (encoded.name === "BooleanTool") {
+      expect(encoded.params).type.toBe<boolean>()
+    } else {
+      expect(encoded.params).type.toBe<string>()
+    }
+  })
+
+  it("preserves tool names with success and failure results", () => {
+    const result = null as unknown as Response.ToolResultParts<Tools>
+    if (result.name === "BooleanTool") {
+      if (result.isFailure) {
+        expect(result.result).type.toBe<boolean>()
+      } else {
+        expect(result.result).type.toBe<string>()
+      }
+    } else if (result.isFailure) {
+      expect(result.result).type.toBe<{ readonly message: string }>()
+    } else {
+      expect(result.result).type.toBe<number>()
+    }
+  })
+})


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Problem

`Response.StreamPart<Tools>` becomes unstable after ordinary discriminant narrowing when `Tools` is an intersection of generic tool records. This occurs in wrappers that combine statically known tools with dynamically supplied tools, then inspect a response part before forwarding it.

## Minimal reproduction

```ts
import type { Response, Tool } from "effect/unstable/ai"

const forward = <
  StaticTools extends Record<string, Tool.Any>,
  DynamicTools extends Record<string, Tool.Any>
>(part: Response.StreamPart<StaticTools & DynamicTools>) => {
  if (part.type === "error") return

  const forwarded: Response.StreamPart<StaticTools & DynamicTools> = part
  //    ^ TS2322 before this PR
  return forwarded
}
```

Before this PR, the assignment fails because narrowing expands the mapped/indexed `ToolCallParts` and `ToolResultParts` unions into a form that TypeScript no longer considers assignable to the original generic type. No runtime behavior is involved.

The exact reproduction fails with TS2322 under TypeScript 5.9.3, 6.0.3, and `7.0.2+effect-tsgo.0.36.5`. TypeScript 7 made the issue visible in a downstream workflow, but it is not a TypeScript 7-only regression.

## Fix

Express `ToolCallParts<Tools>` and `ToolResultParts<Tools>` through small conditional helper types that distribute directly over `keyof Tools`. The resulting unions are equivalent, but remain assignable after narrowing and preserve each tool name correlation with:

- decoded parameters
- encoded parameters
- success results
- failure results

## Verification

The type tests include the generic intersection reproduction above in both decoded and encoded-parameter modes. A concrete two-tool matrix also verifies name-to-parameter and name-to-result correlations.

The regression test fails on the pre-fix implementation and passes with TypeScript 5.9.3, 6.0.3, and `7.0.2+effect-tsgo.0.36.5`. The complete upstream Node, Deno, Bun, lint, type, build, bundle, and documentation matrix is green.

## Related

- Related Issue #
- Closes #