### PR TITLE
Make PostgreSQL listeners scoped and readiness-aware

### DIFF
--- a/.changeset/quiet-pandas-listen.md
+++ b/.changeset/quiet-pandas-listen.md
@@ -1,0 +1,6 @@
+---
+"@effect/sql-pg": patch
+"@effect/sql-pglite": patch
+---
+
+Make PostgreSQL `listen` subscriptions scoped and readiness-aware. `listen` now returns a dequeue after the subscription is installed, preserves empty payloads, shares a reference-counted listener connection, isolates concurrent subscriptions, and reports terminal listener failures.

--- a/packages/sql/pg/README.md
+++ b/packages/sql/pg/README.md
@@ -8,6 +8,48 @@ An Effect SQL client for PostgreSQL, built on the [`pg`](https://node-postgres.c
 npm install effect@rc @effect/sql-pg@rc
 ```
 
+## LISTEN / NOTIFY
+
+`listen` is a scoped subscription that returns after PostgreSQL has acknowledged
+the `LISTEN` command. The returned queue starts buffering notifications
+immediately, so it is safe to establish the subscription before reading initial
+state:
+
+```ts
+import { PgClient } from "@effect/sql-pg"
+import { Effect, Queue } from "effect"
+
+const program = Effect.gen(function*() {
+  const sql = yield* PgClient.PgClient
+  const notifications = yield* sql.listen("events")
+
+  // LISTEN is active here. Notifications received during this query are queued.
+  const initialRows = yield* sql<{ id: number }>`SELECT id FROM events ORDER BY id`
+  const nextPayload = yield* Queue.take(notifications)
+
+  return { initialRows, nextPayload }
+})
+```
+
+The subscription stays active for the surrounding scope. Subscriptions share a
+listener connection, and multiple subscribers to the same channel remain active
+until their individual scopes close. Empty notification payloads are delivered
+as empty strings, and connection failures fail the queue.
+
+To consume notifications as a stream:
+
+```ts
+import { PgClient } from "@effect/sql-pg"
+import { Effect, Stream } from "effect"
+
+const notifications = Stream.unwrap(
+  Effect.gen(function*() {
+    const sql = yield* PgClient.PgClient
+    return Stream.fromQueue(yield* sql.listen("events"))
+  })
+)
+```
+
 ## Documentation
 
 - [Effect website](https://effect.website)

--- a/packages/sql/pg/src/PgClient.ts
+++ b/packages/sql/pg/src/PgClient.ts
@@ -18,6 +18,7 @@ import * as Config from "effect/Config"
 import * as Context from "effect/Context"
 import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
 import * as Layer from "effect/Layer"
 import * as Number from "effect/Number"
@@ -80,7 +81,18 @@ export interface PgClient extends Client.SqlClient {
   readonly [TypeId]: TypeId
   readonly config: PgClientConfig
   readonly json: (_: unknown) => Fragment
-  readonly listen: (channel: string) => Stream.Stream<string, SqlError>
+  /**
+   * Subscribes to a PostgreSQL notification channel.
+   *
+   * The effect completes after PostgreSQL acknowledges `LISTEN`. Notifications
+   * are buffered in the returned dequeue, and the subscription remains active
+   * until the required scope closes. Subscriptions sharing a connection and
+   * channel are reference counted, so `UNLISTEN` runs only after the final
+   * subscription closes.
+   */
+  readonly listen: (
+    channel: string
+  ) => Effect.Effect<Queue.Dequeue<string, SqlError>, SqlError, Scope.Scope>
   readonly notify: (channel: string, payload: string) => Effect.Effect<void, SqlError>
 }
 
@@ -412,26 +424,26 @@ export const fromPool = Effect.fnUntraced(function*(
 
   const listenAcquirer = yield* RcRef.make({
     acquire: Effect.acquireRelease(
-      Effect.tryPromise({
-        try: async () => {
-          const client = new Pg.Client(pool.options)
-          await client.connect()
-          client.on("error", onListenClientError)
-          return client
-        },
-        catch: (cause) =>
-          new SqlError({
-            reason: classifyError(cause, "Failed to acquire connection for listen", "acquireConnection")
-          })
+      Effect.sync(() => {
+        const client = new Pg.Client(pool.options)
+        client.on("error", onListenClientError)
+        return client
       }),
       (client) =>
-        Effect.promise(() => {
-          client.off("error", onListenClientError)
-          return client.end()
-        }).pipe(
-          Effect.timeoutOption(1000)
-        ),
-      { interruptible: true }
+        Effect.promise(() => client.end()).pipe(
+          Effect.timeoutOption(1000),
+          Effect.ensuring(Effect.sync(() => client.off("error", onListenClientError)))
+        )
+    ).pipe(
+      Effect.tap((client) =>
+        Effect.tryPromise({
+          try: () => client.connect(),
+          catch: (cause) =>
+            new SqlError({
+              reason: classifyError(cause, "Failed to acquire connection for listen", "acquireConnection")
+            })
+        })
+      )
     )
   })
 
@@ -562,6 +574,143 @@ export const fromClient = Effect.fnUntraced(function*(
   })
 })
 
+type ListenClientState = {
+  readonly channels: Map<string, Set<Queue.Queue<string, SqlError>>>
+  readonly onNotification: (message: Pg.Notification) => void
+  readonly onError: (cause: Error) => void
+  readonly onEnd: () => void
+  terminalError: SqlError | undefined
+}
+
+const makeListen = (
+  acquireClient: Effect.Effect<Pg.ClientBase, SqlError, Scope.Scope>
+) => {
+  const lock = Semaphore.makeUnsafe(1)
+  const states = new WeakMap<Pg.ClientBase, ListenClientState>()
+
+  const fail = (state: ListenClientState, error: SqlError) => {
+    if (state.terminalError !== undefined) return
+    state.terminalError = error
+    const cause = Cause.fail(error)
+    for (const subscriptions of state.channels.values()) {
+      for (const queue of subscriptions) {
+        Queue.failCauseUnsafe(queue, cause)
+      }
+    }
+  }
+
+  const makeState = (client: Pg.ClientBase): ListenClientState => {
+    const state: ListenClientState = {
+      channels: new Map(),
+      terminalError: undefined,
+      onNotification(message) {
+        if (state.terminalError !== undefined) return
+        for (const queue of state.channels.get(message.channel) ?? []) {
+          Queue.offerUnsafe(queue, message.payload ?? "")
+        }
+      },
+      onError(cause) {
+        fail(
+          state,
+          new SqlError({
+            reason: new ConnectionError({
+              cause,
+              message: "Postgres listener connection failed",
+              operation: "listen"
+            })
+          })
+        )
+      },
+      onEnd() {
+        fail(
+          state,
+          new SqlError({
+            reason: new ConnectionError({
+              cause: new Error("Postgres listener connection ended"),
+              message: "Postgres listener connection ended",
+              operation: "listen"
+            })
+          })
+        )
+      }
+    }
+    client.on("notification", state.onNotification)
+    client.on("error", state.onError)
+    client.on("end", state.onEnd)
+    states.set(client, state)
+    return state
+  }
+
+  const release = (
+    client: Pg.ClientBase,
+    state: ListenClientState,
+    channel: string,
+    queue: Queue.Queue<string, SqlError>
+  ) =>
+    lock.withPermit(Effect.gen(function*() {
+      const subscriptions = state.channels.get(channel)
+      if (subscriptions?.delete(queue) && subscriptions.size === 0) {
+        if (state.terminalError === undefined) {
+          yield* Effect.tryPromise({
+            try: () => client.query(`UNLISTEN ${Pg.escapeIdentifier(channel)}`),
+            catch: () => undefined
+          }).pipe(
+            Effect.timeoutOption(1000),
+            Effect.ignore
+          )
+        }
+        state.channels.delete(channel)
+      }
+      if (state.channels.size === 0) {
+        client.off("notification", state.onNotification)
+        client.off("error", state.onError)
+        client.off("end", state.onEnd)
+        states.delete(client)
+      }
+      yield* Queue.shutdown(queue)
+    }))
+
+  return Effect.fnUntraced(function*(channel: string) {
+    const parentScope = yield* Scope.Scope
+    const subscriptionScope = Scope.forkUnsafe(parentScope)
+
+    return yield* Effect.gen(function*() {
+      const client = yield* acquireClient
+      const queue = yield* Queue.unbounded<string, SqlError>()
+
+      yield* lock.withPermit(Effect.uninterruptibleMask((restore) =>
+        Effect.gen(function*() {
+          const state = states.get(client) ?? makeState(client)
+          if (state.terminalError !== undefined) {
+            return yield* Effect.fail(state.terminalError)
+          }
+          let subscriptions = state.channels.get(channel)
+          const first = subscriptions === undefined
+          if (subscriptions === undefined) {
+            subscriptions = new Set()
+            state.channels.set(channel, subscriptions)
+          }
+          subscriptions.add(queue)
+          yield* Effect.addFinalizer(() => release(client, state, channel, queue))
+          if (first) {
+            yield* restore(Effect.tryPromise({
+              try: () => client.query(`LISTEN ${Pg.escapeIdentifier(channel)}`),
+              catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to listen", "listen") })
+            }))
+          }
+          if (state.terminalError !== undefined) {
+            return yield* Effect.fail(state.terminalError)
+          }
+        })
+      ))
+      return queue
+    }).pipe(
+      Effect.provideService(Scope.Scope, subscriptionScope),
+      Effect.tapCause((cause) => Scope.close(subscriptionScope, Exit.failCause(cause)))
+    )
+  })
+}
+
 /**
  * Creates a `PgClient` from SQL connection acquirers, a LISTEN acquirer, client configuration, and transformation options.
  *
@@ -599,6 +748,7 @@ export const makeWith = Effect.fnUntraced(function*(
     undefined
 
   const config = options.config
+  const listen = makeListen(options.listenAcquirer)
 
   return Object.assign(
     yield* Client.make({
@@ -618,26 +768,7 @@ export const makeWith = Effect.fnUntraced(function*(
       [TypeId]: TypeId as TypeId,
       config: options.config,
       json: (_: unknown) => Statement.fragment([PgJson(_)]),
-      listen: (channel: string) =>
-        Stream.callback<string, SqlError>(Effect.fnUntraced(function*(queue) {
-          const client = yield* options.listenAcquirer
-          function onNotification(msg: Pg.Notification) {
-            if (msg.channel === channel && msg.payload) {
-              Queue.offerUnsafe(queue, msg.payload)
-            }
-          }
-          yield* Effect.addFinalizer(() =>
-            Effect.promise(() => {
-              client.off("notification", onNotification)
-              return client.query(`UNLISTEN ${Pg.escapeIdentifier(channel)}`)
-            })
-          )
-          yield* Effect.tryPromise({
-            try: () => client.query(`LISTEN ${Pg.escapeIdentifier(channel)}`),
-            catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to listen", "listen") })
-          })
-          client.on("notification", onNotification)
-        })),
+      listen,
       notify: (channel: string, payload: string) =>
         Effect.asVoid(Effect.scoped(Effect.flatMap(
           options.acquirer,

--- a/packages/sql/pg/test/Client.integration.test.ts
+++ b/packages/sql/pg/test/Client.integration.test.ts
@@ -1,6 +1,6 @@
 import { PgClient } from "@effect/sql-pg"
 import { assert, expect, it } from "@effect/vitest"
-import { Deferred, Effect, Fiber, Option, Redacted, Stream, String } from "effect"
+import { Deferred, Effect, Exit, Fiber, Option, Queue, Redacted, Scope, Stream, String } from "effect"
 import { TestClock } from "effect/testing"
 import * as Reactivity from "effect/unstable/reactivity/Reactivity"
 import { SqlClient } from "effect/unstable/sql"
@@ -396,13 +396,7 @@ it.layer(PgContainer.layerClientSingleConnection, { timeout: "30 seconds" })("Pg
       const sql = yield* PgClient.PgClient
       const channel = "pool_connection_listen"
 
-      const listenFiber = yield* sql.listen(channel).pipe(
-        Stream.take(1),
-        Stream.runCollect,
-        Effect.forkScoped
-      )
-
-      yield* Effect.sleep("250 millis")
+      const notifications = yield* sql.listen(channel)
 
       const rows = yield* sql<{ value: number }>`SELECT 1 as value`.pipe(
         Effect.timeoutOrElse({
@@ -413,13 +407,13 @@ it.layer(PgContainer.layerClientSingleConnection, { timeout: "30 seconds" })("Pg
       expect(rows).toEqual([{ value: 1 }])
 
       yield* sql.notify(channel, "payload")
-      const payloads = yield* Fiber.join(listenFiber).pipe(
+      const payload = yield* Queue.take(notifications).pipe(
         Effect.timeoutOrElse({
           duration: "3 seconds",
           orElse: () => Effect.fail(new Error("listener did not receive notification in time"))
         })
       )
-      expect(Array.from(payloads)).toEqual(["payload"])
+      assert.strictEqual(payload, "payload")
     }).pipe(TestClock.withLive), 20_000)
 
   it.effect("notify sends payload", () =>
@@ -427,22 +421,83 @@ it.layer(PgContainer.layerClientSingleConnection, { timeout: "30 seconds" })("Pg
       const sql = yield* PgClient.PgClient
       const channel = "pool_connection_notify"
 
-      const listenFiber = yield* sql.listen(channel).pipe(
-        Stream.take(1),
-        Stream.runCollect,
-        Effect.forkScoped
-      )
+      const notifications = yield* sql.listen(channel)
 
-      yield* Effect.sleep("250 millis")
       yield* sql.notify(channel, "payload")
 
-      const payloads = yield* Fiber.join(listenFiber).pipe(
+      const payload = yield* Queue.take(notifications).pipe(
         Effect.timeoutOrElse({
           duration: "3 seconds",
           orElse: () => Effect.fail(new Error("listener did not receive notification in time"))
         })
       )
-      expect(Array.from(payloads)).toEqual(["payload"])
+      assert.strictEqual(payload, "payload")
+    }).pipe(TestClock.withLive), 20_000)
+
+  it.effect("notify sends an empty payload", () =>
+    Effect.gen(function*() {
+      const sql = yield* PgClient.PgClient
+      const channel = "pool_connection_notify_empty"
+
+      const notifications = yield* sql.listen(channel)
+
+      yield* sql.notify(channel, "")
+
+      const payload = yield* Queue.take(notifications).pipe(
+        Effect.timeoutOrElse({
+          duration: "3 seconds",
+          orElse: () => Effect.fail(new Error("listener did not receive empty notification in time"))
+        })
+      )
+      assert.strictEqual(payload, "")
+    }).pipe(TestClock.withLive), 20_000)
+
+  it.effect("one subscription closing does not affect another on the same channel", () =>
+    Effect.gen(function*() {
+      const sql = yield* PgClient.PgClient
+      const channel = "pool_connection_same_channel"
+      const firstScope = yield* Scope.make()
+
+      yield* sql.listen(channel).pipe(Effect.provideService(Scope.Scope, firstScope))
+      const second = yield* sql.listen(channel)
+      yield* Scope.close(firstScope, Exit.void)
+
+      yield* sql.notify(channel, "payload")
+      const payload = yield* Queue.take(second).pipe(
+        Effect.timeoutOrElse({
+          duration: "3 seconds",
+          orElse: () => Effect.fail(new Error("remaining listener did not receive notification in time"))
+        })
+      )
+
+      assert.strictEqual(payload, "payload")
+    }).pipe(TestClock.withLive), 20_000)
+
+  it.effect("listener connection termination fails the subscription", () =>
+    Effect.gen(function*() {
+      const sql = yield* PgClient.PgClient
+      const channel = "pool_connection_termination"
+      const notifications = yield* sql.listen(channel)
+      const rows = yield* sql.unsafe<{ pid: number }>(
+        `SELECT pid FROM pg_stat_activity
+         WHERE datname = current_database()
+           AND query = $1
+         ORDER BY backend_start DESC LIMIT 1`,
+        [`LISTEN "${channel}"`]
+      )
+      const listener = rows[0]
+      assert.isDefined(listener)
+
+      yield* sql.unsafe("SELECT pg_terminate_backend($1)", [listener.pid])
+      const result = yield* Queue.take(notifications).pipe(
+        Effect.result,
+        Effect.timeoutOrElse({
+          duration: "3 seconds",
+          orElse: () => Effect.fail(new Error("terminated listener did not fail in time"))
+        })
+      )
+
+      assert.strictEqual(result._tag, "Failure")
     }).pipe(TestClock.withLive), 20_000)
 })
 

--- a/packages/sql/pg/test/PgClient.test.ts
+++ b/packages/sql/pg/test/PgClient.test.ts
@@ -1,0 +1,259 @@
+import { PgClient } from "@effect/sql-pg"
+import { assert, it } from "@effect/vitest"
+import { Deferred, Effect, Exit, Fiber, Queue, Scope } from "effect"
+import * as Reactivity from "effect/unstable/reactivity/Reactivity"
+import * as Pg from "pg"
+import { vi } from "vitest"
+
+type Listener =
+  | ((notification: Pg.Notification) => void)
+  | ((error: Error) => void)
+  | (() => void)
+
+class FakeListenClient {
+  readonly queries: Array<string> = []
+  readonly listeners = new Map<string, Set<Listener>>()
+
+  constructor(
+    readonly queryImpl: (text: string, client: FakeListenClient) => Promise<unknown> = () => Promise.resolve()
+  ) {}
+
+  on(event: string, listener: Listener): this {
+    const listeners = this.listeners.get(event) ?? new Set()
+    listeners.add(listener)
+    this.listeners.set(event, listeners)
+    return this
+  }
+
+  off(event: string, listener: Listener): this {
+    this.listeners.get(event)?.delete(listener)
+    return this
+  }
+
+  query(text: string): Promise<unknown> {
+    this.queries.push(text)
+    return this.queryImpl(text, this)
+  }
+
+  emit(event: string, value?: Pg.Notification | Error): void {
+    for (const listener of this.listeners.get(event) ?? []) {
+      ;(listener as (value?: Pg.Notification | Error) => void)(value)
+    }
+  }
+}
+
+const makeClient = (client: FakeListenClient) =>
+  PgClient.makeWith({
+    acquirer: Effect.die("unused"),
+    transactionAcquirer: Effect.die("unused"),
+    listenAcquirer: Effect.succeed(client as unknown as Pg.ClientBase),
+    config: {}
+  }).pipe(Effect.provide(Reactivity.layer))
+
+const makePool = () =>
+  ({
+    options: {},
+    ending: false,
+    connect: () => undefined,
+    query: () => Promise.resolve({ rows: [] })
+  }) as unknown as Pg.Pool
+
+it.effect("listen is ready when it returns and preserves empty payloads", () =>
+  Effect.gen(function*() {
+    const client = new FakeListenClient((text, client) => {
+      if (text.startsWith("LISTEN")) {
+        client.emit("notification", {
+          channel: "events",
+          payload: "",
+          processId: 1
+        })
+      }
+      return Promise.resolve()
+    })
+    const sql = yield* makeClient(client)
+
+    const notifications = yield* sql.listen("events")
+    const payload = yield* Queue.take(notifications)
+
+    assert.strictEqual(payload, "")
+    assert.deepStrictEqual(client.queries, [`LISTEN "events"`])
+  }))
+
+it.effect("listen surfaces setup failures", () =>
+  Effect.gen(function*() {
+    const client = new FakeListenClient(() => Promise.reject(new Error("listen failed")))
+    const sql = yield* makeClient(client)
+
+    const error = yield* sql.listen("events").pipe(Effect.flip)
+
+    assert.strictEqual(error.reason._tag, "UnknownError")
+    assert.deepStrictEqual(client.queries, [`LISTEN "events"`, `UNLISTEN "events"`])
+    assert.isTrue(Array.from(client.listeners.values()).every((listeners) => listeners.size === 0))
+  }))
+
+it.effect("listen fails setup when the connection ends before acknowledgement", () =>
+  Effect.gen(function*() {
+    const client = new FakeListenClient((text, client) => {
+      if (text.startsWith("LISTEN")) {
+        client.emit("end")
+      }
+      return Promise.resolve()
+    })
+    const sql = yield* makeClient(client)
+
+    const error = yield* sql.listen("events").pipe(Effect.flip)
+
+    assert.strictEqual(error.reason._tag, "ConnectionError")
+    assert.strictEqual(error.reason.message, "Postgres listener connection ended")
+    assert.isTrue(Array.from(client.listeners.values()).every((listeners) => listeners.size === 0))
+  }))
+
+it.effect("listen surfaces connection errors through the dequeue", () =>
+  Effect.gen(function*() {
+    const client = new FakeListenClient()
+    const sql = yield* makeClient(client)
+    const notifications = yield* sql.listen("events")
+
+    client.emit("error", new Error("connection lost"))
+    const error = yield* Queue.take(notifications).pipe(Effect.flip)
+
+    assert.strictEqual(error.reason._tag, "ConnectionError")
+    assert.strictEqual(error.reason.message, "Postgres listener connection failed")
+  }))
+
+it.effect("listen surfaces connection end through the dequeue", () =>
+  Effect.gen(function*() {
+    const client = new FakeListenClient()
+    const sql = yield* makeClient(client)
+    const notifications = yield* sql.listen("events")
+
+    client.emit("end")
+    const error = yield* Queue.take(notifications).pipe(Effect.flip)
+
+    assert.strictEqual(error.reason._tag, "ConnectionError")
+    assert.strictEqual(error.reason.message, "Postgres listener connection ended")
+  }))
+
+it.effect("listen fails late subscriptions after the shared connection ends", () =>
+  Effect.gen(function*() {
+    const client = new FakeListenClient()
+    const sql = yield* makeClient(client)
+    const firstScope = yield* Scope.make()
+    const first = yield* sql.listen("events").pipe(Scope.provide(firstScope))
+    client.emit("end")
+
+    const firstError = yield* Queue.take(first).pipe(Effect.flip)
+    const secondError = yield* sql.listen("events").pipe(Effect.flip)
+
+    assert.strictEqual(firstError.reason._tag, "ConnectionError")
+    assert.strictEqual(secondError, firstError)
+    assert.deepStrictEqual(client.queries, [`LISTEN "events"`])
+    yield* Scope.close(firstScope, Exit.void)
+  }))
+
+it.effect("listen retries setup after a failed attempt", () =>
+  Effect.gen(function*() {
+    let attempts = 0
+    const client = new FakeListenClient((text) => {
+      if (text.startsWith("LISTEN") && attempts++ === 0) {
+        return Promise.reject(new Error("listen failed"))
+      }
+      return Promise.resolve()
+    })
+    const sql = yield* makeClient(client)
+
+    yield* sql.listen("events").pipe(Effect.flip)
+    yield* sql.listen("events")
+
+    assert.deepStrictEqual(client.queries, [
+      `LISTEN "events"`,
+      `UNLISTEN "events"`,
+      `LISTEN "events"`
+    ])
+  }))
+
+it.effect("listen releases the subscription with its scope", () =>
+  Effect.gen(function*() {
+    const client = new FakeListenClient()
+    const sql = yield* makeClient(client)
+    const scope = yield* Scope.make()
+    const notifications = yield* sql.listen("events").pipe(Scope.provide(scope))
+
+    yield* Scope.close(scope, Exit.void)
+
+    assert.deepStrictEqual(client.queries, [`LISTEN "events"`, `UNLISTEN "events"`])
+    assert.isTrue(Array.from(client.listeners.values()).every((listeners) => listeners.size === 0))
+    assert.isTrue(Exit.hasInterrupts(yield* Queue.take(notifications).pipe(Effect.exit)))
+  }))
+
+it.effect("listen reference counts subscriptions on the same connection and channel", () =>
+  Effect.gen(function*() {
+    const client = new FakeListenClient()
+    const sql = yield* makeClient(client)
+    const firstScope = yield* Scope.make()
+    const secondScope = yield* Scope.make()
+    yield* sql.listen("events").pipe(Scope.provide(firstScope))
+    const second = yield* sql.listen("events").pipe(Scope.provide(secondScope))
+
+    assert.deepStrictEqual(client.queries, [`LISTEN "events"`])
+    assert.isTrue(Array.from(client.listeners.values()).every((listeners) => listeners.size === 1))
+
+    yield* Scope.close(firstScope, Exit.void)
+    client.emit("notification", {
+      channel: "events",
+      payload: "hello",
+      processId: 1
+    })
+
+    assert.strictEqual(yield* Queue.take(second), "hello")
+    assert.deepStrictEqual(client.queries, [`LISTEN "events"`])
+
+    yield* Scope.close(secondScope, Exit.void)
+
+    assert.deepStrictEqual(client.queries, [`LISTEN "events"`, `UNLISTEN "events"`])
+  }))
+
+it.effect("fromPool closes a listener client when connect fails", () =>
+  Effect.gen(function*() {
+    const connect = vi.spyOn(Pg.Client.prototype, "connect").mockRejectedValue(new Error("connect failed"))
+    const end = vi.spyOn(Pg.Client.prototype, "end").mockResolvedValue(undefined)
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        connect.mockRestore()
+        end.mockRestore()
+      })
+    )
+    const sql = yield* PgClient.fromPool({ acquire: Effect.succeed(makePool()) }).pipe(
+      Effect.provide(Reactivity.layer)
+    )
+
+    const error = yield* sql.listen("events").pipe(Effect.flip)
+
+    assert.strictEqual(error.reason._tag, "UnknownError")
+    assert.strictEqual(end.mock.calls.length, 1)
+  }))
+
+it.effect("fromPool closes a listener client when connect is interrupted", () =>
+  Effect.gen(function*() {
+    const started = yield* Deferred.make<void>()
+    const connect = vi.spyOn(Pg.Client.prototype, "connect").mockImplementation(() => {
+      Deferred.doneUnsafe(started, Effect.void)
+      return new Promise<void>(() => {})
+    })
+    const end = vi.spyOn(Pg.Client.prototype, "end").mockResolvedValue(undefined)
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        connect.mockRestore()
+        end.mockRestore()
+      })
+    )
+    const sql = yield* PgClient.fromPool({ acquire: Effect.succeed(makePool()) }).pipe(
+      Effect.provide(Reactivity.layer)
+    )
+    const fiber = yield* sql.listen("events").pipe(Effect.forkChild)
+    yield* Deferred.await(started)
+
+    yield* Fiber.interrupt(fiber)
+
+    assert.strictEqual(end.mock.calls.length, 1)
+  }))

--- a/packages/sql/pglite/README.md
+++ b/packages/sql/pglite/README.md
@@ -8,6 +8,25 @@ An Effect SQL client for [PGlite](https://pglite.dev), a WASM build of PostgreSQ
 npm install effect@rc @effect/sql-pglite@rc
 ```
 
+## LISTEN / NOTIFY
+
+`listen` is a scoped subscription that returns after the listener is installed.
+It exposes notifications through a queue and keeps the subscription active for
+the surrounding scope:
+
+```ts
+import { PgliteClient } from "@effect/sql-pglite"
+import { Effect, Queue } from "effect"
+
+const program = Effect.gen(function*() {
+  const sql = yield* PgliteClient.PgliteClient
+  const notifications = yield* sql.listen("events")
+
+  yield* sql.notify("events", "ready")
+  return yield* Queue.take(notifications)
+})
+```
+
 ## Documentation
 
 - [Effect website](https://effect.website)

--- a/packages/sql/pglite/src/PgliteClient.ts
+++ b/packages/sql/pglite/src/PgliteClient.ts
@@ -68,7 +68,16 @@ export interface PgliteClient extends Client.SqlClient {
   readonly config: PgliteClientConfig
   readonly pglite: PGliteInterface
   readonly json: (_: unknown) => Fragment
-  readonly listen: (channel: string) => Stream.Stream<string, SqlError>
+  /**
+   * Subscribes to a PGlite notification channel.
+   *
+   * The effect completes after the listener is installed. Notifications are
+   * buffered in the returned dequeue, and the subscription remains active
+   * until the required scope closes.
+   */
+  readonly listen: (
+    channel: string
+  ) => Effect.Effect<Queue.Dequeue<string, SqlError>, SqlError, Scope.Scope>
   readonly notify: (channel: string, payload: string) => Effect.Effect<void, SqlError>
   readonly dumpDataDir: (compression?: "none" | "gzip" | "auto") => Effect.Effect<File | Blob, SqlError>
   readonly refreshArrayTypes: Effect.Effect<void, SqlError>
@@ -229,20 +238,22 @@ export const fromClient = (
         config,
         pglite,
         json: (_: unknown) => Statement.fragment([PgJson(_)]),
-        listen: (channel: string) =>
-          Stream.callback<string, SqlError>((queue) =>
-            Effect.acquireRelease(
-              Effect.tryPromise({
-                try: () =>
-                  pglite.listen(channel, (payload) => {
-                    Queue.offerUnsafe(queue, payload)
-                  }),
-                catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to listen", "listen") })
-              }),
-              (unlisten) => Effect.promise(() => unlisten()),
-              { interruptible: true }
-            )
-          ),
+        listen: Effect.fnUntraced(function*(channel: string) {
+          const queue = yield* Queue.unbounded<string, SqlError>()
+          yield* Effect.acquireRelease(
+            Effect.tryPromise({
+              try: () =>
+                pglite.listen(channel, (payload) => {
+                  Queue.offerUnsafe(queue, payload)
+                }),
+              catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to listen", "listen") })
+            }),
+            (unlisten) => Effect.promise(() => unlisten()),
+            { interruptible: true }
+          )
+          yield* Effect.addFinalizer(() => Queue.shutdown(queue))
+          return queue
+        }),
         notify: (channel: string, payload: string) =>
           Effect.tryPromise({
             try: () => pglite.exec(`NOTIFY ${escape(channel)}, ${escapeLiteral(payload)}`),

--- a/packages/sql/pglite/test/Client.test.ts
+++ b/packages/sql/pglite/test/Client.test.ts
@@ -1,7 +1,7 @@
 import { PgliteClient } from "@effect/sql-pglite"
 import { assert, describe, layer } from "@effect/vitest"
 import * as Pglite from "@electric-sql/pglite"
-import { Deferred, Effect, Layer } from "effect"
+import { Effect, Exit, Layer, Queue, Scope } from "effect"
 import { SqlClient } from "effect/unstable/sql/SqlClient"
 
 const ClientLayer = PgliteClient.layer()
@@ -92,14 +92,24 @@ describe("PgliteClient", () => {
     it.effect("listen + notify", () =>
       Effect.gen(function*() {
         const sql = yield* PgliteClient.PgliteClient
-        const deferred = yield* Deferred.make<string>()
-        const unsub = yield* Effect.tryPromise({
-          try: () => sql.pglite.listen("ch1", (payload) => Effect.runFork(Deferred.succeed(deferred, payload))),
-          catch: (cause) => cause
-        })
+        const notifications = yield* sql.listen("ch1")
+
         yield* sql.notify("ch1", "hello")
-        assert.strictEqual(yield* Deferred.await(deferred), "hello")
-        yield* Effect.promise(() => unsub())
+        assert.strictEqual(yield* Queue.take(notifications), "hello")
+
+        yield* sql.notify("ch1", "")
+        assert.strictEqual(yield* Queue.take(notifications), "")
+      }), { timeout: 15_000 })
+
+    it.effect("listen shuts down with its scope", () =>
+      Effect.gen(function*() {
+        const sql = yield* PgliteClient.PgliteClient
+        const scope = yield* Scope.make()
+        const notifications = yield* sql.listen("ch1").pipe(Scope.provide(scope))
+
+        yield* Scope.close(scope, Exit.void)
+
+        assert.isTrue(Exit.hasInterrupts(yield* Queue.take(notifications).pipe(Effect.exit)))
       }), { timeout: 15_000 })
 
     it.effect("provider extras", () =>


### PR DESCRIPTION
## Summary

- change PostgreSQL and PGlite `listen` from a lazy `Stream` to a scoped effect that returns a `Queue.Dequeue`
- complete the effect only after the listener is installed, giving callers an explicit readiness boundary
- share one lazy PostgreSQL listener connection while reference-counting channels and fanning notifications out to independent subscriber queues
- preserve empty payloads, propagate terminal connection failures, and close failed or interrupted acquisitions promptly

## Problem

The current stream API has no way to observe when PostgreSQL has acknowledged `LISTEN`:

```ts
const received = yield* sql.listen("events").pipe(
  Stream.runHead,
  Effect.forkScoped
)

// This can run before LISTEN is active, so the notification can be lost.
yield* sql.notify("events", "ready")
```

It also has several lifecycle issues:

- the notification handler is attached after the `LISTEN` query, leaving an additional delivery gap
- empty payloads are dropped by a truthiness check
- setup failures can leave the stream waiting indefinitely
- listener `error` and `end` events are not propagated to subscribers
- two subscribers on the same channel share a connection, but either finalizer runs `UNLISTEN` and silently disables the other
- a rejected or interrupted listener connection attempt can skip `client.end()`

## New API

`listen` returns a queue after PostgreSQL acknowledges the subscription:

```ts
const notifications = yield* sql.listen("events")

yield* sql.notify("events", "ready")
const payload = yield* Queue.take(notifications)
```

The readiness boundary also supports race-free snapshot-then-tail workflows:

```ts
const notifications = yield* sql.listen("events")

// Notifications received while this query runs are retained in the queue.
const currentRows = yield* sql<{ id: number }>`SELECT id FROM events ORDER BY id`
const nextPayload = yield* Queue.take(notifications)
```

The caller's scope owns the returned subscription. PostgreSQL subscriptions use a single per-client handler set and a serialized channel registry. The first subscriber performs `LISTEN`; the final subscriber performs bounded `UNLISTEN`. A terminal connection event fails every current queue and is retained so later subscribers cannot attach to a dead shared client.

Existing stream-based consumers can migrate without a sentinel value:

```ts
const notifications = Stream.unwrap(
  Effect.map(sql.listen("events"), Stream.fromQueue)
)
```

PGlite exposes the same readiness-aware scoped API.

## Verification

- `pnpm lint-fix`
- `pnpm check`
- `pnpm test --run packages/sql/pg/test packages/sql/pglite/test` — 228 tests passed
- `EFFECT_INTEGRATION_TESTS=1 pnpm test --run packages/sql/pg/test/Client.integration.test.ts -t "PgClient listen"` — 5 real PostgreSQL tests passed

The tests cover readiness, buffering during setup, empty and non-empty payloads, setup rejection and retry, interruption cleanup, connection acquisition cleanup, terminal fan-out, late subscription after terminal failure, same-channel reference counting, bounded scope cleanup, and PGlite parity.
