### PR TITLE
Align PGlite listen with PostgreSQL

### DIFF
--- a/.changeset/quiet-pandas-listen.md
+++ b/.changeset/quiet-pandas-listen.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-pglite": patch
+---
+
+Align PGlite `listen` with the PostgreSQL client. It now returns a scoped dequeue after the listener is installed, providing an explicit readiness boundary and preserving notifications received before the first take.

--- a/packages/sql/pglite/README.md
+++ b/packages/sql/pglite/README.md
@@ -8,6 +8,25 @@ An Effect SQL client for [PGlite](https://pglite.dev), a WASM build of PostgreSQ
 npm install effect@rc @effect/sql-pglite@rc
 ```
 
+## LISTEN / NOTIFY
+
+`listen` is a scoped subscription that returns after the listener is installed.
+It exposes notifications through a queue and keeps the subscription active for
+the surrounding scope:
+
+```ts
+import { PgliteClient } from "@effect/sql-pglite"
+import { Effect, Queue } from "effect"
+
+const program = Effect.gen(function*() {
+  const sql = yield* PgliteClient.PgliteClient
+  const notifications = yield* sql.listen("events")
+
+  yield* sql.notify("events", "ready")
+  return yield* Queue.take(notifications)
+})
+```
+
 ## Documentation
 
 - [Effect website](https://effect.website)

--- a/packages/sql/pglite/src/PgliteClient.ts
+++ b/packages/sql/pglite/src/PgliteClient.ts
@@ -68,7 +68,16 @@ export interface PgliteClient extends Client.SqlClient {
   readonly config: PgliteClientConfig
   readonly pglite: PGliteInterface
   readonly json: (_: unknown) => Fragment
-  readonly listen: (channel: string) => Stream.Stream<string, SqlError>
+  /**
+   * Subscribes to a PGlite notification channel.
+   *
+   * The effect completes after the listener is installed. Notifications are
+   * buffered in the returned dequeue, and the subscription remains active
+   * until the required scope closes.
+   */
+  readonly listen: (
+    channel: string
+  ) => Effect.Effect<Queue.Dequeue<string>, SqlError, Scope.Scope>
   readonly notify: (channel: string, payload: string) => Effect.Effect<void, SqlError>
   readonly dumpDataDir: (compression?: "none" | "gzip" | "auto") => Effect.Effect<File | Blob, SqlError>
   readonly refreshArrayTypes: Effect.Effect<void, SqlError>
@@ -229,20 +238,22 @@ export const fromClient = (
         config,
         pglite,
         json: (_: unknown) => Statement.fragment([PgJson(_)]),
-        listen: (channel: string) =>
-          Stream.callback<string, SqlError>((queue) =>
-            Effect.acquireRelease(
-              Effect.tryPromise({
-                try: () =>
-                  pglite.listen(channel, (payload) => {
-                    Queue.offerUnsafe(queue, payload)
-                  }),
-                catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to listen", "listen") })
-              }),
-              (unlisten) => Effect.promise(() => unlisten()),
-              { interruptible: true }
-            )
-          ),
+        listen: Effect.fnUntraced(function*(channel: string) {
+          const queue = yield* Queue.unbounded<string>()
+          yield* Effect.acquireRelease(
+            Effect.tryPromise({
+              try: () =>
+                pglite.listen(channel, (payload) => {
+                  Queue.offerUnsafe(queue, payload)
+                }),
+              catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to listen", "listen") })
+            }),
+            (unlisten) => Effect.promise(() => unlisten()),
+            { interruptible: true }
+          )
+          yield* Effect.addFinalizer(() => Queue.shutdown(queue))
+          return queue
+        }),
         notify: (channel: string, payload: string) =>
           Effect.tryPromise({
             try: () => pglite.exec(`NOTIFY ${escape(channel)}, ${escapeLiteral(payload)}`),

--- a/packages/sql/pglite/test/Client.test.ts
+++ b/packages/sql/pglite/test/Client.test.ts
@@ -1,7 +1,7 @@
 import { PgliteClient } from "@effect/sql-pglite"
 import { assert, describe, layer } from "@effect/vitest"
 import * as Pglite from "@electric-sql/pglite"
-import { Deferred, Effect, Layer } from "effect"
+import { Effect, Exit, Layer, Queue, Scope } from "effect"
 import { SqlClient } from "effect/unstable/sql/SqlClient"
 
 const ClientLayer = PgliteClient.layer()
@@ -92,14 +92,24 @@ describe("PgliteClient", () => {
     it.effect("listen + notify", () =>
       Effect.gen(function*() {
         const sql = yield* PgliteClient.PgliteClient
-        const deferred = yield* Deferred.make<string>()
-        const unsub = yield* Effect.tryPromise({
-          try: () => sql.pglite.listen("ch1", (payload) => Effect.runFork(Deferred.succeed(deferred, payload))),
-          catch: (cause) => cause
-        })
+        const notifications = yield* sql.listen("ch1")
+
         yield* sql.notify("ch1", "hello")
-        assert.strictEqual(yield* Deferred.await(deferred), "hello")
-        yield* Effect.promise(() => unsub())
+        assert.strictEqual(yield* Queue.take(notifications), "hello")
+
+        yield* sql.notify("ch1", "")
+        assert.strictEqual(yield* Queue.take(notifications), "")
+      }), { timeout: 15_000 })
+
+    it.effect("listen shuts down with its scope", () =>
+      Effect.gen(function*() {
+        const sql = yield* PgliteClient.PgliteClient
+        const scope = yield* Scope.make()
+        const notifications = yield* sql.listen("ch1").pipe(Scope.provide(scope))
+
+        yield* Scope.close(scope, Exit.void)
+
+        assert.isTrue(Exit.hasInterrupts(yield* Queue.take(notifications).pipe(Effect.exit)))
       }), { timeout: 15_000 })
 
     it.effect("provider extras", () =>


### PR DESCRIPTION
## Summary

- align `PgliteClient.listen` with the scoped, readiness-aware PostgreSQL API introduced by #7426
- return a `Queue.Dequeue` only after PGlite installs the listener
- buffer notifications immediately, preserve empty payloads, and release the listener with the caller's scope

## Problem

`PgClient.listen` now has an explicit readiness boundary, while PGlite still exposes a lazy `Stream`. A caller cannot establish the PGlite subscription before doing an initial read or sending a notification without separately managing `pglite.listen`:

```ts
const notifications = yield* sql.listen("events")

// The listener is installed here; notifications are buffered immediately.
yield* sql.notify("events", "ready")
const payload = yield* Queue.take(notifications)
```

The returned dequeue belongs to the surrounding scope. Closing that scope unregisters the PGlite listener and shuts down the queue.

## Context

This extracts the remaining PGlite portion of #7449. Its PostgreSQL implementation was superseded by the native protocol client in #7426, which already provides the scoped queue API and acknowledgement boundary.

## Validation

- `pnpm lint-fix`
- `pnpm test --run packages/sql/pglite/test/Client.test.ts` — 13 tests passed
- `pnpm check`
