### PR TITLE
fix(platform-node): prevent writing the HTTP response onto an upgraded WebSocket connection

### DIFF
--- a/.changeset/upgraded-request-skips-http-response-write.md
+++ b/.changeset/upgraded-request-skips-http-response-write.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node": patch
+---
+
+Prevent NodeHttpServer from writing the route's HTTP response onto a connection that was upgraded to a WebSocket connection because stricter clients will interpret those bytes as WebSocket frames, logging "Invalid frame header" and failing the connection with an untyped 1006 error instead of the actual close code that the server sent.

--- a/packages/platform-node/src/internal/httpServer.ts
+++ b/packages/platform-node/src/internal/httpServer.ts
@@ -170,14 +170,19 @@ export const makeUpgradeHandler = <R, E>(
       socket: Duplex,
       head: Buffer
     ) {
+      let upgraded = false
       let nodeResponse_: Http.ServerResponse | undefined = undefined
       const nodeResponse = () => {
         if (nodeResponse_ === undefined) {
           nodeResponse_ = new Http.ServerResponse(nodeRequest)
-          nodeResponse_.assignSocket(socket as any)
-          nodeResponse_.on("finish", () => {
-            socket.end()
-          })
+          if (upgraded) {
+            nodeResponse_.end()
+          } else {
+            nodeResponse_.assignSocket(socket as any)
+            nodeResponse_.on("finish", () => {
+              socket.end()
+            })
+          }
         }
         return nodeResponse_
       }
@@ -187,6 +192,7 @@ export const makeUpgradeHandler = <R, E>(
           Effect.acquireRelease(
             Effect.async<globalThis.WebSocket>((resume) =>
               wss.handleUpgrade(nodeRequest, socket, head, (ws) => {
+                upgraded = true
                 resume(Effect.succeed(ws as any))
               })
             ),

--- a/packages/platform-node/test/HttpServer.test.ts
+++ b/packages/platform-node/test/HttpServer.test.ts
@@ -14,6 +14,7 @@ import {
   HttpServerRespondable,
   HttpServerResponse,
   Multipart,
+  Socket,
   UrlParams
 } from "@effect/platform"
 import { NodeHttpServer } from "@effect/platform-node"
@@ -21,10 +22,13 @@ import { assert, describe, expect, it } from "@effect/vitest"
 import { Deferred, Duration, Fiber, Stream } from "effect"
 import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
+import { constVoid } from "effect/Function"
 import * as Option from "effect/Option"
 import * as Schema from "effect/Schema"
 import * as Tracer from "effect/Tracer"
 import * as Buffer from "node:buffer"
+import { randomBytes } from "node:crypto"
+import { createConnection } from "node:net"
 
 const Todo = Schema.Struct({
   id: Schema.Number,
@@ -793,4 +797,169 @@ describe("HttpServer", () => {
         assert.deepStrictEqual(json, { received: { message: "hello" } })
       }).pipe(Effect.provide(NodeHttpServer.layerTest)))
   })
+
+  describe("HttpServerRequest.upgrade", () => {
+    it.scoped("does not write the HTTP response to an upgraded connection", () =>
+      Effect.gen(function*() {
+        yield* HttpRouter.empty.pipe(
+          HttpRouter.get(
+            "/ws",
+            Effect.gen(function*() {
+              const socket = yield* HttpServerRequest.upgrade
+              yield* Effect.forkScoped(socket.runRaw(constVoid))
+              const write = yield* socket.writer
+              yield* write("refused")
+              yield* write(new Socket.CloseEvent(4400, "refused"))
+              return HttpServerResponse.empty()
+            }).pipe(Effect.scoped)
+          ),
+          HttpServer.serveEffect()
+        )
+        const address = (yield* HttpServer.HttpServer).address
+        assert(address._tag === "TcpAddress")
+        const { frames, trailing } = yield* Effect.promise(() => rawWebSocket(address.port, "/ws"))
+        assert.strictEqual(frames.length, 2)
+        assert.strictEqual(frames[0].opcode, 1)
+        assert.strictEqual(frames[0].payload.toString(), "refused")
+        assert.strictEqual(frames[1].opcode, 8)
+        assert.strictEqual(frames[1].payload.readUInt16BE(0), 4400)
+        assert.strictEqual(trailing.toString(), "")
+      }).pipe(Effect.provide(NodeHttpServer.layerTest)))
+
+    it.scoped("writes the HTTP response when the upgrade is not consumed", () =>
+      Effect.gen(function*() {
+        yield* HttpRouter.empty.pipe(
+          HttpRouter.get("/no-ws", HttpServerResponse.text("upgrade refused", { status: 426 })),
+          HttpServer.serveEffect()
+        )
+        const address = (yield* HttpServer.HttpServer).address
+        assert(address._tag === "TcpAddress")
+        const response = yield* Effect.promise(() => rawUpgradeRequest(address.port, "/no-ws"))
+        assert.match(response, /^HTTP\/1\.1 426/)
+        assert.match(response, /upgrade refused/)
+      }).pipe(Effect.provide(NodeHttpServer.layerTest)))
+  })
 })
+
+interface WebSocketFrame {
+  readonly opcode: number
+  readonly payload: Buffer.Buffer
+}
+
+const parseWebSocketFrames = (
+  stream: Buffer.Buffer
+): { readonly frames: ReadonlyArray<WebSocketFrame>; readonly trailing: Buffer.Buffer } => {
+  const frames: Array<WebSocketFrame> = []
+  let offset = 0
+  while (stream.length - offset >= 2) {
+    const first = stream[offset]
+    const second = stream[offset + 1]
+    const opcode = first & 0x0f
+    let length = second & 0x7f
+    let headerSize = 2
+    if (length === 126) {
+      if (stream.length - offset < 4) break
+      length = stream.readUInt16BE(offset + 2)
+      headerSize = 4
+    } else if (length === 127) {
+      break
+    }
+    const controlFrame = (opcode & 0x8) !== 0
+    if (
+      (first & 0x70) !== 0 || (second & 0x80) !== 0 ||
+      ![0x0, 0x1, 0x2, 0x8, 0x9, 0xa].includes(opcode) ||
+      (controlFrame && length > 125)
+    ) {
+      break
+    }
+    if (stream.length - offset < headerSize + length) break
+    frames.push({ opcode, payload: stream.subarray(offset + headerSize, offset + headerSize + length) })
+    offset += headerSize + length
+  }
+  return { frames, trailing: stream.subarray(offset) }
+}
+
+const upgradeRequest = (path: string): string =>
+  [
+    `GET ${path} HTTP/1.1`,
+    "Host: 127.0.0.1",
+    "Upgrade: websocket",
+    "Connection: Upgrade",
+    `Sec-WebSocket-Key: ${randomBytes(16).toString("base64")}`,
+    "Sec-WebSocket-Version: 13",
+    "",
+    ""
+  ].join("\r\n")
+
+const closeFrame = (code: number): Buffer.Buffer => {
+  const payload = Buffer.Buffer.alloc(2)
+  payload.writeUInt16BE(code, 0)
+  const mask = randomBytes(4)
+  const masked = Buffer.Buffer.from(payload)
+  for (let index = 0; index < masked.length; index++) {
+    masked[index] = masked[index] ^ mask[index % 4]
+  }
+  return Buffer.Buffer.concat([Buffer.Buffer.from([0x88, 0x80 | payload.length]), mask, masked])
+}
+
+const rawWebSocket = (
+  port: number,
+  path: string
+): Promise<{ readonly frames: ReadonlyArray<WebSocketFrame>; readonly trailing: Buffer.Buffer }> =>
+  new Promise((resolve, reject) => {
+    const socket = createConnection({ host: "127.0.0.1", port })
+    const timer = setTimeout(() => {
+      socket.destroy()
+      reject(new Error("the websocket conversation did not finish in time"))
+    }, 5000)
+    let upgraded = false
+    let stream = Buffer.Buffer.alloc(0)
+    let closeEchoed = false
+    socket.on("connect", () => socket.write(upgradeRequest(path)))
+    socket.on("data", (data) => {
+      stream = Buffer.Buffer.concat([stream, data])
+      if (!upgraded) {
+        const headerEnd = stream.indexOf("\r\n\r\n")
+        if (headerEnd === -1) return
+        if (!stream.subarray(0, headerEnd).toString().includes("101")) {
+          clearTimeout(timer)
+          socket.destroy()
+          reject(new Error("the upgrade was refused"))
+          return
+        }
+        upgraded = true
+        stream = Buffer.Buffer.from(stream.subarray(headerEnd + 4))
+      }
+      if (!closeEchoed) {
+        const close = parseWebSocketFrames(stream).frames.find((frame) => frame.opcode === 8)
+        if (close !== undefined) {
+          closeEchoed = true
+          socket.write(closeFrame(close.payload.length >= 2 ? close.payload.readUInt16BE(0) : 1000))
+        }
+      }
+    })
+    socket.on("error", constVoid)
+    socket.on("close", () => {
+      clearTimeout(timer)
+      resolve(parseWebSocketFrames(stream))
+    })
+  })
+
+const rawUpgradeRequest = (port: number, path: string): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const socket = createConnection({ host: "127.0.0.1", port })
+    const timer = setTimeout(() => {
+      socket.destroy()
+      reject(new Error("the upgrade request was not answered in time"))
+    }, 5000)
+    let stream = Buffer.Buffer.alloc(0)
+    socket.on("connect", () => socket.write(upgradeRequest(path)))
+    socket.on("data", (data) => {
+      stream = Buffer.Buffer.concat([stream, data])
+    })
+    socket.on("error", constVoid)
+    socket.on("close", () => {
+      clearTimeout(timer)
+      resolve(stream.toString())
+    })
+  })


### PR DESCRIPTION
## What happened

When a request is upgraded to a WebSocket via `HttpServerRequest.upgrade`, the route handler still returns an `HttpServerResponse`, and `handleResponse` still writes it to the underlying socket after the handler finishes. If the connection is still open at that point, the HTTP response bytes end up in the WebSocket stream, right after whatever the server last sent:

```
81 38 7b 22 74 79 70 65 ...   {"type":"error",...}      text frame
88 12 11 30 ...               close, code 4400          close frame
48 54 54 50 2f 31 2e 31 ...   HTTP/1.1 204 No Content   the route's response
```

Strict clients treat those bytes as WebSocket frames. Browsers log "Invalid frame header" and fail the connection with a 1006 instead of the close code the server sent, so anything the app does based on close codes (e.g. refresh the token on one code, log out on another) doesn't work in a browser.

This is easy to miss because the `ws` client stops parsing at the close frame, and if the client disconnects first the write goes to a dead socket and nothing happens.

## The fix

`makeUpgradeHandler` now remembers when the upgrade actually happened (in the `handleUpgrade` callback). If the lazy `ServerResponse` is created after that, it's `end()`ed before a socket is assigned to it, so the existing `writableEnded` check in `handleResponse` skips the write. Requests that have upgrade headers but get answered with a normal HTTP response are unchanged.

The flag lives in the `nodeResponse` closure instead of on `ServerRequestImpl` because `modify()` creates copies of the request (routers do this), and all copies share the same closure.

## Tests

Two tests in `HttpServer.test.ts`, using a small raw WebSocket client since the `ws` client can't see the problem:

- a route upgrades, sends a text frame and a close frame, and returns — the close frame has to be the last bytes on the wire. Without the fix this fails with `expected 'HTTP/1.1 204 No Content…' to equal ''`.
- a request with upgrade headers that gets a plain HTTP answer still receives the full response.

## Note

`main` (4.0.0-rc) has the same issue in `packages/platform/node/src/NodeHttpServer.ts`. Happy to port this there as a follow-up.
