### PR TITLE
Fix chunked multipart parsing after file parts

### DIFF
--- a/packages/effect/src/unstable/http/Multipart.ts
+++ b/packages/effect/src/unstable/http/Multipart.ts
@@ -456,6 +456,7 @@ export const makeChannel = <IE>(headers: Record<string, string>): Channel.Channe
     Effect.map(makeConfig(headers), (config) => {
       let partsBuffer: Array<Part> = []
       let exit = Option.none<Exit.Exit<never, IE | MultipartError | Cause.Done>>()
+      let ended = false
 
       const parser = MP.make({
         ...config,
@@ -503,7 +504,10 @@ export const makeChannel = <IE>(headers: Record<string, string>): Channel.Channe
         }),
         Effect.catchCause((cause) => {
           if (Pull.isDoneCause(cause)) {
-            parser.end()
+            if (!ended) {
+              ended = true
+              parser.end()
+            }
           } else {
             exit = Option.some(Exit.failCause(cause)) as any
           }

--- a/packages/effect/test/unstable/http/Multipart.test.ts
+++ b/packages/effect/test/unstable/http/Multipart.test.ts
@@ -81,6 +81,41 @@ describe("Multipart", () => {
       deepStrictEqual(contents, [encoder.encode("abcdef")])
     }))
 
+  it.effect("parses a field after a file when the body is split across chunks", () =>
+    Effect.gen(function*() {
+      const boundary = "----testboundary"
+      const encoder = new TextEncoder()
+      const body = encoder.encode(
+        `--${boundary}\r\n` +
+          `Content-Disposition: form-data; name="file"; filename="file.txt"\r\n` +
+          `Content-Type: text/plain\r\n\r\n` +
+          "file contents\r\n" +
+          `--${boundary}\r\n` +
+          `Content-Disposition: form-data; name="description"\r\n\r\n` +
+          "test file\r\n" +
+          `--${boundary}--\r\n`
+      )
+      const chunks = [body.subarray(0, 64), body.subarray(64, 128), body.subarray(128)]
+
+      const parts = yield* Stream.fromArray(chunks).pipe(
+        Stream.rechunk(1),
+        Stream.pipeThroughChannel(
+          Multipart.makeChannel({ "content-type": `multipart/form-data; boundary=${boundary}` })
+        ),
+        Stream.mapEffect((part) =>
+          part._tag === "File"
+            ? part.contentEffect.pipe(Effect.map((content) => [part.key, new TextDecoder().decode(content)] as const))
+            : Effect.succeed([part.key, part.value] as const)
+        ),
+        Stream.runCollect
+      )
+
+      deepStrictEqual(parts, [
+        ["file", "file contents"],
+        ["description", "test file"]
+      ])
+    }))
+
   it.effect("parses non-Latin-1 filenames", () =>
     Effect.gen(function*() {
       const data = new globalThis.FormData()


### PR DESCRIPTION
## Summary

- end the shared multipart parser only once when multiple consumers observe upstream completion
- cover a chunked multipart body with a text field after a streamed file

## Testing

- `nix develop -c pnpm vitest run packages/effect/test/unstable/http/Multipart.test.ts`
- `nix develop -c pnpm lint`
- `nix develop -c pnpm check`

Closes EFF-893
Closes #7455
