### PR TITLE
fix(platform-node): prevent writing the HTTP response onto an upgraded WebSocket connection

### DIFF
--- a/.changeset/upgraded-request-skips-http-response-write.md
+++ b/.changeset/upgraded-request-skips-http-response-write.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node": patch
+---
+
+Prevent NodeHttpServer from writing the route's HTTP response onto a connection that was upgraded to a WebSocket connection because stricter clients will interpret those bytes as WebSocket frames, logging "Invalid frame header" and failing the connection with an untyped 1006 error instead of the actual close code that the server sent.

--- a/packages/platform/node/src/NodeHttpServer.ts
+++ b/packages/platform/node/src/NodeHttpServer.ts
@@ -249,14 +249,22 @@ export const makeUpgradeHandler = <
       socket: Duplex,
       head: Buffer
     ) {
+      let upgraded = false
       let nodeResponse_: Http.ServerResponse | undefined = undefined
       const nodeResponse = () => {
         if (nodeResponse_ === undefined) {
           nodeResponse_ = new Http.ServerResponse(nodeRequest)
-          nodeResponse_.assignSocket(socket as any)
-          nodeResponse_.on("finish", () => {
-            socket.end()
-          })
+          if (upgraded) {
+            // the connection now carries WebSocket frames, so end the response
+            // before a socket is assigned to it to make handleResponse skip the
+            // write (writableEnded check)
+            nodeResponse_.end()
+          } else {
+            nodeResponse_.assignSocket(socket as any)
+            nodeResponse_.on("finish", () => {
+              socket.end()
+            })
+          }
         }
         return nodeResponse_
       }
@@ -266,6 +274,7 @@ export const makeUpgradeHandler = <
           Effect.acquireRelease(
             Effect.callback<globalThis.WebSocket>((resume) =>
               wss.handleUpgrade(nodeRequest, socket, head, (ws) => {
+                upgraded = true
                 resume(Effect.succeed(ws as any))
               })
             ),

--- a/packages/platform/node/test/NodeHttpServer.test.ts
+++ b/packages/platform/node/test/NodeHttpServer.test.ts
@@ -5,6 +5,7 @@ import { assert, describe, expect, it } from "@effect/vitest"
 import { Effect, Option } from "effect"
 import * as Duration from "effect/Duration"
 import * as Fiber from "effect/Fiber"
+import { constVoid } from "effect/Function"
 import * as Latch from "effect/Latch"
 import * as Layer from "effect/Layer"
 import * as ManagedRuntime from "effect/ManagedRuntime"
@@ -28,7 +29,9 @@ import {
   UrlParams
 } from "effect/unstable/http"
 import * as HttpApiError from "effect/unstable/httpapi/HttpApiError"
+import { Socket } from "effect/unstable/socket"
 import * as Buffer from "node:buffer"
+import { randomBytes } from "node:crypto"
 import { EventEmitter } from "node:events"
 import * as Http from "node:http"
 import * as Net from "node:net"
@@ -926,6 +929,52 @@ describe("HttpServer", () => {
       const response = yield* HttpClient.get("/")
       expect(response.status).toEqual(200)
     }).pipe(Effect.provide(layerTestWebsocket)))
+
+  it.effect("does not write the HTTP response to an upgraded connection", () =>
+    Effect.gen(function*() {
+      yield* HttpRouter.add(
+        "GET",
+        "/ws",
+        Effect.gen(function*() {
+          const request = yield* HttpServerRequest.HttpServerRequest
+          const socket = yield* Effect.orDie(request.upgrade)
+          yield* Effect.forkScoped(socket.runRaw(constVoid))
+          const write = yield* socket.writer
+          yield* write("refused")
+          yield* write(new Socket.CloseEvent(4400, "refused"))
+          return HttpServerResponse.empty()
+        }).pipe(Effect.scoped)
+      ).pipe(
+        HttpRouter.serve,
+        Layer.build
+      )
+      const server = yield* HttpServer.HttpServer
+      const port = (server.address as HttpServer.TcpAddress).port
+      const { frames, trailing } = yield* Effect.promise(() => rawWebSocket(port, "/ws"))
+      assert.strictEqual(frames.length, 2)
+      assert.strictEqual(frames[0].opcode, 1)
+      assert.strictEqual(frames[0].payload.toString(), "refused")
+      assert.strictEqual(frames[1].opcode, 8)
+      assert.strictEqual(frames[1].payload.readUInt16BE(0), 4400)
+      assert.strictEqual(trailing.toString(), "")
+    }).pipe(Effect.provide(layerTestWebsocket)))
+
+  it.effect("writes the HTTP response when the upgrade is not consumed", () =>
+    Effect.gen(function*() {
+      yield* HttpRouter.add(
+        "GET",
+        "/no-ws",
+        HttpServerResponse.text("upgrade refused", { status: 426 })
+      ).pipe(
+        HttpRouter.serve,
+        Layer.build
+      )
+      const server = yield* HttpServer.HttpServer
+      const port = (server.address as HttpServer.TcpAddress).port
+      const response = yield* Effect.promise(() => rawUpgradeRequest(port, "/no-ws"))
+      assert.match(response, /^HTTP\/1\.1 426/)
+      assert.match(response, /upgrade refused/)
+    }).pipe(Effect.provide(layerTestWebsocket)))
 })
 
 const layerTestWebsocket = HttpServer.layerTestClient.pipe(
@@ -945,3 +994,126 @@ const tcpPort = (server: Http.Server): number => {
   assert(address !== null && typeof address !== "string")
   return address.port
 }
+
+interface WebSocketFrame {
+  readonly opcode: number
+  readonly payload: Buffer.Buffer
+}
+
+const parseWebSocketFrames = (
+  stream: Buffer.Buffer
+): { readonly frames: ReadonlyArray<WebSocketFrame>; readonly trailing: Buffer.Buffer } => {
+  const frames: Array<WebSocketFrame> = []
+  let offset = 0
+  while (stream.length - offset >= 2) {
+    const first = stream[offset]
+    const second = stream[offset + 1]
+    const opcode = first & 0x0f
+    let length = second & 0x7f
+    let headerSize = 2
+    if (length === 126) {
+      if (stream.length - offset < 4) break
+      length = stream.readUInt16BE(offset + 2)
+      headerSize = 4
+    } else if (length === 127) {
+      break
+    }
+    const controlFrame = (opcode & 0x8) !== 0
+    if (
+      (first & 0x70) !== 0 || (second & 0x80) !== 0 ||
+      ![0x0, 0x1, 0x2, 0x8, 0x9, 0xa].includes(opcode) ||
+      (controlFrame && length > 125)
+    ) {
+      break
+    }
+    if (stream.length - offset < headerSize + length) break
+    frames.push({ opcode, payload: stream.subarray(offset + headerSize, offset + headerSize + length) })
+    offset += headerSize + length
+  }
+  return { frames, trailing: stream.subarray(offset) }
+}
+
+const upgradeRequest = (path: string): string =>
+  [
+    `GET ${path} HTTP/1.1`,
+    "Host: 127.0.0.1",
+    "Upgrade: websocket",
+    "Connection: Upgrade",
+    `Sec-WebSocket-Key: ${randomBytes(16).toString("base64")}`,
+    "Sec-WebSocket-Version: 13",
+    "",
+    ""
+  ].join("\r\n")
+
+const closeFrame = (code: number): Buffer.Buffer => {
+  const payload = Buffer.Buffer.alloc(2)
+  payload.writeUInt16BE(code, 0)
+  const mask = randomBytes(4)
+  const masked = Buffer.Buffer.from(payload)
+  for (let index = 0; index < masked.length; index++) {
+    masked[index] = masked[index] ^ mask[index % 4]
+  }
+  return Buffer.Buffer.concat([Buffer.Buffer.from([0x88, 0x80 | payload.length]), mask, masked])
+}
+
+const rawWebSocket = (
+  port: number,
+  path: string
+): Promise<{ readonly frames: ReadonlyArray<WebSocketFrame>; readonly trailing: Buffer.Buffer }> =>
+  new Promise((resolve, reject) => {
+    const socket = Net.createConnection({ host: "127.0.0.1", port })
+    const timer = setTimeout(() => {
+      socket.destroy()
+      reject(new Error("the websocket conversation did not finish in time"))
+    }, 5000)
+    let upgraded = false
+    let stream = Buffer.Buffer.alloc(0)
+    let closeEchoed = false
+    socket.on("connect", () => socket.write(upgradeRequest(path)))
+    socket.on("data", (data) => {
+      stream = Buffer.Buffer.concat([stream, Buffer.Buffer.from(data)])
+      if (!upgraded) {
+        const headerEnd = stream.indexOf("\r\n\r\n")
+        if (headerEnd === -1) return
+        if (!stream.subarray(0, headerEnd).toString().includes("101")) {
+          clearTimeout(timer)
+          socket.destroy()
+          reject(new Error("the upgrade was refused"))
+          return
+        }
+        upgraded = true
+        stream = Buffer.Buffer.from(stream.subarray(headerEnd + 4))
+      }
+      if (!closeEchoed) {
+        const close = parseWebSocketFrames(stream).frames.find((frame) => frame.opcode === 8)
+        if (close !== undefined) {
+          closeEchoed = true
+          socket.write(closeFrame(close.payload.length >= 2 ? close.payload.readUInt16BE(0) : 1000))
+        }
+      }
+    })
+    socket.on("error", constVoid)
+    socket.on("close", () => {
+      clearTimeout(timer)
+      resolve(parseWebSocketFrames(stream))
+    })
+  })
+
+const rawUpgradeRequest = (port: number, path: string): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const socket = Net.createConnection({ host: "127.0.0.1", port })
+    const timer = setTimeout(() => {
+      socket.destroy()
+      reject(new Error("the upgrade request was not answered in time"))
+    }, 5000)
+    let stream = Buffer.Buffer.alloc(0)
+    socket.on("connect", () => socket.write(upgradeRequest(path)))
+    socket.on("data", (data) => {
+      stream = Buffer.Buffer.concat([stream, Buffer.Buffer.from(data)])
+    })
+    socket.on("error", constVoid)
+    socket.on("close", () => {
+      clearTimeout(timer)
+      resolve(stream.toString())
+    })
+  })


### PR DESCRIPTION
Ports the fix from #7457 to `main`.

## What happened

When a request is upgraded to a WebSocket via `HttpServerRequest.upgrade`, the route handler still returns an `HttpServerResponse`, and `handleResponse` writes it to the underlying socket after the handler finishes. If the connection is still open at that point, the HTTP response bytes land in the WebSocket stream after the server's last frame. Strict clients treat those bytes as WebSocket frames, log "Invalid frame header", and fail the connection with a 1006 instead of the close code the server sent.

## The fix

Same approach as #7457, re-applied by hand to the restructured `main` implementation: `makeUpgradeHandler` records when the upgrade actually happened (in the `wss.handleUpgrade` callback). If the lazy `ServerResponse` is created after that, it is `end()`ed before a socket is assigned to it, so the existing `writableEnded` check in `handleResponse` skips the write. Requests with upgrade headers that get answered with a normal HTTP response are unchanged.

The flag lives in the `nodeResponse` closure because `modify()` copies of the request (created by routers) share that closure.

## Tests

Both regression tests from #7457, ported to the v4 APIs in `packages/platform/node/test/NodeHttpServer.test.ts`:

- a route upgrades, sends a text frame and a close frame, and returns: the close frame must be the last bytes on the wire. Fails without the fix (`expected 'HTTP/1.1 204 No Content…' to equal ''`).
- a request with upgrade headers that gets a plain HTTP answer still receives the full response.

Verified locally: `pnpm check`, `pnpm lint`, and the `NodeHttpServer.test.ts` suite pass; the first new test fails when the source change is reverted.

Closes EFF-892
