### PR TITLE
Fix tagsExhaustive Effect.fn handler inference

### DIFF
--- a/.changeset/fair-matches-infer.md
+++ b/.changeset/fair-matches-infer.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix contextual typing for `Match` tag and discriminator handler maps when handlers use `Effect.fn` or `Effect.fnUntraced`.

--- a/packages/effect/src/Match.ts
+++ b/packages/effect/src/Match.ts
@@ -1161,11 +1161,17 @@ export const tagsExhaustive: <
     & { readonly [Tag in Types.Tags<"_tag", R> & string]: (_: Extract<R, Record<"_tag", Tag>>) => Ret }
     & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", R>>]: never }
 >(
-  fields: P
+  // Preserve contextual types through nested generic calls (microsoft/TypeScript#52864).
+  fields: [P] extends [never] ? {
+      readonly [Tag in Types.Tags<"_tag", R> & string]: (
+        _: Extract<R, Record<"_tag", Tag>>
+      ) => Ret
+    }
+    : P
 ) => <I, F, A, Pr>(
   self: Matcher<I, F, R, A, Pr, Ret>
-) => [Pr] extends [never] ? (u: I) => Unify<A | ReturnType<P[keyof P]>> : Unify<A | ReturnType<P[keyof P]>> =
-  internal.tagsExhaustive
+) => [Pr] extends [never] ? (u: I) => Unify<A | ReturnType<P[keyof P]>> : Unify<A | ReturnType<P[keyof P]>> = internal
+  .tagsExhaustive as any
 
 /**
  * Creates a pattern that excludes a specific value while allowing all others.

--- a/packages/effect/src/Match.ts
+++ b/packages/effect/src/Match.ts
@@ -20,8 +20,21 @@ import type { Unify } from "./Unify.ts"
 
 const TypeId = internal.TypeId
 
-// Work around microsoft/TypeScript#52864 so nested generic calls receive contextual types.
-type Contextual<P, Fallback> = [P] extends [never] ? Fallback : P
+// The conditional must stay deferred until P is inferred. Replacing it with an
+// intersection loses contextual typing for nested generic calls (microsoft/TypeScript#52864).
+type Contextual<P, Fallback> = internal.Contextual<P, Fallback>
+
+type TagHandlers<D extends string, R, Ret> = {
+  readonly [Tag in Types.Tags<D, R> & string]: (_: Extract<R, Record<D, Tag>>) => Ret
+}
+
+type PartialTagHandlers<D extends string, R, Ret> = {
+  readonly [Tag in Types.Tags<D, R> & string]?: ((_: Extract<R, Record<D, Tag>>) => Ret) | undefined
+}
+
+type ValueTagHandlers<I> = {
+  readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any
+}
 
 /**
  * Marker used by `Matcher` to distinguish matchers created with `Match.value`.
@@ -422,29 +435,19 @@ export const valueTags: {
   <
     const I,
     P extends
-      & { readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any }
+      & ValueTagHandlers<I>
       & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", I>>]: never }
   >(
-    fields: Contextual<
-      P,
-      {
-        readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any
-      }
-    >
+    fields: Contextual<P, ValueTagHandlers<I>>
   ): (input: I) => Unify<ReturnType<P[keyof P]>>
   <
     const I,
     P extends
-      & { readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any }
+      & ValueTagHandlers<I>
       & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", I>>]: never }
   >(
     input: I,
-    fields: Contextual<
-      P,
-      {
-        readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any
-      }
-    >
+    fields: Contextual<P, ValueTagHandlers<I>>
   ): Unify<ReturnType<P[keyof P]>>
 } = internal.valueTags
 
@@ -898,15 +901,10 @@ export const discriminators: <D extends string>(
   R,
   Ret,
   P extends
-    & { readonly [Tag in Types.Tags<D, R> & string]?: ((_: Extract<R, Record<D, Tag>>) => Ret) | undefined }
+    & PartialTagHandlers<D, R, Ret>
     & { readonly [Tag in Exclude<keyof P, Types.Tags<D, R>>]: never }
 >(
-  fields: Contextual<
-    P,
-    {
-      readonly [Tag in Types.Tags<D, R> & string]?: ((_: Extract<R, Record<D, Tag>>) => Ret) | undefined
-    }
-  >
+  fields: Contextual<P, PartialTagHandlers<D, R, Ret>>
 ) => <I, F, A, Pr>(
   self: Matcher<I, F, R, A, Pr, Ret>
 ) => Matcher<
@@ -966,15 +964,10 @@ export const discriminatorsExhaustive: <D extends string>(
   R,
   Ret,
   P extends
-    & { readonly [Tag in Types.Tags<D, R> & string]: (_: Extract<R, Record<D, Tag>>) => Ret }
+    & TagHandlers<D, R, Ret>
     & { readonly [Tag in Exclude<keyof P, Types.Tags<D, R>>]: never }
 >(
-  fields: Contextual<
-    P,
-    {
-      readonly [Tag in Types.Tags<D, R> & string]: (_: Extract<R, Record<D, Tag>>) => Ret
-    }
-  >
+  fields: Contextual<P, TagHandlers<D, R, Ret>>
 ) => <I, F, A, Pr>(
   self: Matcher<I, F, R, A, Pr, Ret>
 ) => [Pr] extends [never] ? (u: I) => Unify<A | ReturnType<P[keyof P]>> : Unify<A | ReturnType<P[keyof P]>> =
@@ -1131,15 +1124,10 @@ export const tags: <
   R,
   Ret,
   P extends
-    & { readonly [Tag in Types.Tags<"_tag", R> & string]?: ((_: Extract<R, Record<"_tag", Tag>>) => Ret) | undefined }
+    & PartialTagHandlers<"_tag", R, Ret>
     & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", R>>]: never }
 >(
-  fields: Contextual<
-    P,
-    {
-      readonly [Tag in Types.Tags<"_tag", R> & string]?: ((_: Extract<R, Record<"_tag", Tag>>) => Ret) | undefined
-    }
-  >
+  fields: Contextual<P, PartialTagHandlers<"_tag", R, Ret>>
 ) => <I, F, A, Pr>(
   self: Matcher<I, F, R, A, Pr, Ret>
 ) => Matcher<
@@ -1191,15 +1179,10 @@ export const tagsExhaustive: <
   R,
   Ret,
   P extends
-    & { readonly [Tag in Types.Tags<"_tag", R> & string]: (_: Extract<R, Record<"_tag", Tag>>) => Ret }
+    & TagHandlers<"_tag", R, Ret>
     & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", R>>]: never }
 >(
-  fields: Contextual<
-    P,
-    {
-      readonly [Tag in Types.Tags<"_tag", R> & string]: (_: Extract<R, Record<"_tag", Tag>>) => Ret
-    }
-  >
+  fields: Contextual<P, TagHandlers<"_tag", R, Ret>>
 ) => <I, F, A, Pr>(
   self: Matcher<I, F, R, A, Pr, Ret>
 ) => [Pr] extends [never] ? (u: I) => Unify<A | ReturnType<P[keyof P]>> : Unify<A | ReturnType<P[keyof P]>> =

--- a/packages/effect/src/Match.ts
+++ b/packages/effect/src/Match.ts
@@ -20,6 +20,9 @@ import type { Unify } from "./Unify.ts"
 
 const TypeId = internal.TypeId
 
+// Work around microsoft/TypeScript#52864 so nested generic calls receive contextual types.
+type Contextual<P, Fallback> = [P] extends [never] ? Fallback : P
+
 /**
  * Marker used by `Matcher` to distinguish matchers created with `Match.value`.
  *
@@ -421,13 +424,28 @@ export const valueTags: {
     P extends
       & { readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any }
       & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", I>>]: never }
-  >(fields: P): (input: I) => Unify<ReturnType<P[keyof P]>>
+  >(
+    fields: Contextual<
+      P,
+      {
+        readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any
+      }
+    >
+  ): (input: I) => Unify<ReturnType<P[keyof P]>>
   <
     const I,
     P extends
       & { readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any }
       & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", I>>]: never }
-  >(input: I, fields: P): Unify<ReturnType<P[keyof P]>>
+  >(
+    input: I,
+    fields: Contextual<
+      P,
+      {
+        readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any
+      }
+    >
+  ): Unify<ReturnType<P[keyof P]>>
 } = internal.valueTags
 
 /**
@@ -883,7 +901,12 @@ export const discriminators: <D extends string>(
     & { readonly [Tag in Types.Tags<D, R> & string]?: ((_: Extract<R, Record<D, Tag>>) => Ret) | undefined }
     & { readonly [Tag in Exclude<keyof P, Types.Tags<D, R>>]: never }
 >(
-  fields: P
+  fields: Contextual<
+    P,
+    {
+      readonly [Tag in Types.Tags<D, R> & string]?: ((_: Extract<R, Record<D, Tag>>) => Ret) | undefined
+    }
+  >
 ) => <I, F, A, Pr>(
   self: Matcher<I, F, R, A, Pr, Ret>
 ) => Matcher<
@@ -946,7 +969,12 @@ export const discriminatorsExhaustive: <D extends string>(
     & { readonly [Tag in Types.Tags<D, R> & string]: (_: Extract<R, Record<D, Tag>>) => Ret }
     & { readonly [Tag in Exclude<keyof P, Types.Tags<D, R>>]: never }
 >(
-  fields: P
+  fields: Contextual<
+    P,
+    {
+      readonly [Tag in Types.Tags<D, R> & string]: (_: Extract<R, Record<D, Tag>>) => Ret
+    }
+  >
 ) => <I, F, A, Pr>(
   self: Matcher<I, F, R, A, Pr, Ret>
 ) => [Pr] extends [never] ? (u: I) => Unify<A | ReturnType<P[keyof P]>> : Unify<A | ReturnType<P[keyof P]>> =
@@ -1106,7 +1134,12 @@ export const tags: <
     & { readonly [Tag in Types.Tags<"_tag", R> & string]?: ((_: Extract<R, Record<"_tag", Tag>>) => Ret) | undefined }
     & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", R>>]: never }
 >(
-  fields: P
+  fields: Contextual<
+    P,
+    {
+      readonly [Tag in Types.Tags<"_tag", R> & string]?: ((_: Extract<R, Record<"_tag", Tag>>) => Ret) | undefined
+    }
+  >
 ) => <I, F, A, Pr>(
   self: Matcher<I, F, R, A, Pr, Ret>
 ) => Matcher<
@@ -1161,17 +1194,16 @@ export const tagsExhaustive: <
     & { readonly [Tag in Types.Tags<"_tag", R> & string]: (_: Extract<R, Record<"_tag", Tag>>) => Ret }
     & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", R>>]: never }
 >(
-  // Preserve contextual types through nested generic calls (microsoft/TypeScript#52864).
-  fields: [P] extends [never] ? {
-      readonly [Tag in Types.Tags<"_tag", R> & string]: (
-        _: Extract<R, Record<"_tag", Tag>>
-      ) => Ret
+  fields: Contextual<
+    P,
+    {
+      readonly [Tag in Types.Tags<"_tag", R> & string]: (_: Extract<R, Record<"_tag", Tag>>) => Ret
     }
-    : P
+  >
 ) => <I, F, A, Pr>(
   self: Matcher<I, F, R, A, Pr, Ret>
-) => [Pr] extends [never] ? (u: I) => Unify<A | ReturnType<P[keyof P]>> : Unify<A | ReturnType<P[keyof P]>> = internal
-  .tagsExhaustive as any
+) => [Pr] extends [never] ? (u: I) => Unify<A | ReturnType<P[keyof P]>> : Unify<A | ReturnType<P[keyof P]>> =
+  internal.tagsExhaustive
 
 /**
  * Creates a pattern that excludes a specific value while allowing all others.

--- a/packages/effect/src/internal/matcher.ts
+++ b/packages/effect/src/internal/matcher.ts
@@ -19,6 +19,8 @@ import type { Unify } from "../Unify.ts"
 /** @internal */
 export const TypeId = "~effect/match/Match/Matcher"
 
+type Contextual<P, Fallback> = [P] extends [never] ? Fallback : P
+
 const TypeMatcherProto: Omit<TypeMatcher<any, any, any, any, any, any>, "cases" | "select"> = {
   [TypeId]: {
     _input: identity,
@@ -222,13 +224,28 @@ export const valueTags: {
     P extends
       & { readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any }
       & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", I>>]: never }
-  >(fields: P): (input: I) => Unify<ReturnType<P[keyof P]>>
+  >(
+    fields: Contextual<
+      P,
+      {
+        readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any
+      }
+    >
+  ): (input: I) => Unify<ReturnType<P[keyof P]>>
   <
     const I,
     P extends
       & { readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any }
       & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", I>>]: never }
-  >(input: I, fields: P): Unify<ReturnType<P[keyof P]>>
+  >(
+    input: I,
+    fields: Contextual<
+      P,
+      {
+        readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any
+      }
+    >
+  ): Unify<ReturnType<P[keyof P]>>
 } = dual(
   2,
   <
@@ -236,7 +253,15 @@ export const valueTags: {
     P extends
       & { readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any }
       & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", I>>]: never }
-  >(input: I, fields: P): Unify<ReturnType<P[keyof P]>> => {
+  >(
+    input: I,
+    fields: Contextual<
+      P,
+      {
+        readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any
+      }
+    >
+  ): Unify<ReturnType<P[keyof P]>> => {
     const match: any = tagsExhaustive(fields as any)(makeTypeMatcher(identity, []))
     return match(input)
   }
@@ -420,7 +445,12 @@ export const discriminators = <D extends string>(field: D) =>
     }
     & { readonly [Tag in Exclude<keyof P, Types.Tags<D, R>>]: never }
 >(
-  fields: P
+  fields: Contextual<
+    P,
+    {
+      readonly [Tag in Types.Tags<D, R> & string]?: ((_: Extract<R, Record<D, Tag>>) => Ret) | undefined
+    }
+  >
 ) => {
   const predicate = makeWhen(
     (arg: any) => arg != null && Object.hasOwn(fields, arg[field]),
@@ -453,7 +483,12 @@ export const discriminatorsExhaustive: <D extends string>(
     }
     & { readonly [Tag in Exclude<keyof P, Types.Tags<D, R>>]: never }
 >(
-  fields: P
+  fields: Contextual<
+    P,
+    {
+      readonly [Tag in Types.Tags<D, R> & string]: (_: Extract<R, Record<D, Tag>>) => Ret
+    }
+  >
 ) => <I, F, A, Pr>(
   self: Matcher<I, F, R, A, Pr, Ret>
 ) => [Pr] extends [never] ? (u: I) => Unify<A | ReturnType<P[keyof P]>>

--- a/packages/effect/src/internal/matcher.ts
+++ b/packages/effect/src/internal/matcher.ts
@@ -19,7 +19,20 @@ import type { Unify } from "../Unify.ts"
 /** @internal */
 export const TypeId = "~effect/match/Match/Matcher"
 
-type Contextual<P, Fallback> = [P] extends [never] ? Fallback : P
+/** @internal */
+export type Contextual<P, Fallback> = [P] extends [never] ? Fallback : P
+
+type TagHandlers<D extends string, R, Ret> = {
+  readonly [Tag in Types.Tags<D, R> & string]: (_: Extract<R, Record<D, Tag>>) => Ret
+}
+
+type PartialTagHandlers<D extends string, R, Ret> = {
+  readonly [Tag in Types.Tags<D, R> & string]?: ((_: Extract<R, Record<D, Tag>>) => Ret) | undefined
+}
+
+type ValueTagHandlers<I> = {
+  readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any
+}
 
 const TypeMatcherProto: Omit<TypeMatcher<any, any, any, any, any, any>, "cases" | "select"> = {
   [TypeId]: {
@@ -222,45 +235,30 @@ export const valueTags: {
   <
     const I,
     P extends
-      & { readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any }
+      & ValueTagHandlers<I>
       & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", I>>]: never }
   >(
-    fields: Contextual<
-      P,
-      {
-        readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any
-      }
-    >
+    fields: Contextual<P, ValueTagHandlers<I>>
   ): (input: I) => Unify<ReturnType<P[keyof P]>>
   <
     const I,
     P extends
-      & { readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any }
+      & ValueTagHandlers<I>
       & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", I>>]: never }
   >(
     input: I,
-    fields: Contextual<
-      P,
-      {
-        readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any
-      }
-    >
+    fields: Contextual<P, ValueTagHandlers<I>>
   ): Unify<ReturnType<P[keyof P]>>
 } = dual(
   2,
   <
     const I,
     P extends
-      & { readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any }
+      & ValueTagHandlers<I>
       & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", I>>]: never }
   >(
     input: I,
-    fields: Contextual<
-      P,
-      {
-        readonly [Tag in Types.Tags<"_tag", I> & string]: (_: Extract<I, { readonly _tag: Tag }>) => any
-      }
-    >
+    fields: Contextual<P, ValueTagHandlers<I>>
   ): Unify<ReturnType<P[keyof P]>> => {
     const match: any = tagsExhaustive(fields as any)(makeTypeMatcher(identity, []))
     return match(input)
@@ -438,19 +436,10 @@ export const discriminators = <D extends string>(field: D) =>
   R,
   Ret,
   P extends
-    & {
-      readonly [Tag in Types.Tags<D, R> & string]?:
-        | ((_: Extract<R, Record<D, Tag>>) => Ret)
-        | undefined
-    }
+    & PartialTagHandlers<D, R, Ret>
     & { readonly [Tag in Exclude<keyof P, Types.Tags<D, R>>]: never }
 >(
-  fields: Contextual<
-    P,
-    {
-      readonly [Tag in Types.Tags<D, R> & string]?: ((_: Extract<R, Record<D, Tag>>) => Ret) | undefined
-    }
-  >
+  fields: Contextual<P, PartialTagHandlers<D, R, Ret>>
 ) => {
   const predicate = makeWhen(
     (arg: any) => arg != null && Object.hasOwn(fields, arg[field]),
@@ -476,19 +465,10 @@ export const discriminatorsExhaustive: <D extends string>(
   R,
   Ret,
   P extends
-    & {
-      readonly [Tag in Types.Tags<D, R> & string]: (
-        _: Extract<R, Record<D, Tag>>
-      ) => Ret
-    }
+    & TagHandlers<D, R, Ret>
     & { readonly [Tag in Exclude<keyof P, Types.Tags<D, R>>]: never }
 >(
-  fields: Contextual<
-    P,
-    {
-      readonly [Tag in Types.Tags<D, R> & string]: (_: Extract<R, Record<D, Tag>>) => Ret
-    }
-  >
+  fields: Contextual<P, TagHandlers<D, R, Ret>>
 ) => <I, F, A, Pr>(
   self: Matcher<I, F, R, A, Pr, Ret>
 ) => [Pr] extends [never] ? (u: I) => Unify<A | ReturnType<P[keyof P]>>

--- a/packages/effect/typetest/Match.tst.ts
+++ b/packages/effect/typetest/Match.tst.ts
@@ -11,6 +11,9 @@ declare const stringOrNumber: string | number
 declare const taggedInput:
   | { readonly _tag: "A"; readonly a: string }
   | { readonly _tag: "B"; readonly b: number }
+declare const discriminatedInput:
+  | { readonly kind: "A"; readonly a: string }
+  | { readonly kind: "B"; readonly b: number }
 
 describe("Match", () => {
   it("fn infers the selected value and original arguments", () => {
@@ -201,6 +204,46 @@ describe("Match", () => {
   it("tagsExhaustive contextually types Effect.fn handlers", () => {
     Match.value(taggedInput).pipe(
       Match.tagsExhaustive({
+        A: Effect.fn(function*(value) {
+          expect(value).type.toBe<{ readonly _tag: "A"; readonly a: string }>()
+          return value.a
+        }),
+        B: Effect.fnUntraced(function*(value) {
+          expect(value).type.toBe<{ readonly _tag: "B"; readonly b: number }>()
+          return value.b
+        })
+      })
+    )
+  })
+
+  it("related handler maps contextually type nested Effect.fn calls", () => {
+    Match.value(taggedInput).pipe(
+      Match.tags({
+        A: Effect.fn(function*(value) {
+          expect(value).type.toBe<{ readonly _tag: "A"; readonly a: string }>()
+          return value.a
+        })
+      })
+    )
+
+    Match.value(discriminatedInput).pipe(
+      Match.discriminators("kind")({
+        A: Effect.fn(function*(value) {
+          expect(value).type.toBe<{ readonly kind: "A"; readonly a: string }>()
+          return value.a
+        })
+      }),
+      Match.discriminatorsExhaustive("kind")({
+        B: Effect.fnUntraced(function*(value) {
+          expect(value).type.toBe<{ readonly kind: "B"; readonly b: number }>()
+          return value.b
+        })
+      })
+    )
+
+    pipe(
+      taggedInput,
+      Match.valueTags({
         A: Effect.fn(function*(value) {
           expect(value).type.toBe<{ readonly _tag: "A"; readonly a: string }>()
           return value.a

--- a/packages/effect/typetest/Match.tst.ts
+++ b/packages/effect/typetest/Match.tst.ts
@@ -216,6 +216,37 @@ describe("Match", () => {
     )
   })
 
+  it("Effect.fn handler return types survive", () => {
+    expect(
+      Match.value(taggedInput).pipe(
+        Match.tagsExhaustive({
+          A: Effect.fn(function*(value) {
+            return value.a
+          }),
+          B: Effect.fnUntraced(function*(value) {
+            return value.b
+          })
+        })
+      )
+    ).type.toBe<Effect.Effect<string | number>>()
+  })
+
+  it("tagsExhaustive rejects missing and unknown tags", () => {
+    Match.value(taggedInput).pipe(
+      // @ts-expect-error Property 'B' is missing
+      Match.tagsExhaustive({ A: (value) => value.a })
+    )
+
+    Match.value(taggedInput).pipe(
+      Match.tagsExhaustive({
+        A: (value) => value.a,
+        B: (value) => value.b,
+        // @ts-expect-error Type '() => number' is not assignable to type 'never'
+        C: () => 1
+      })
+    )
+  })
+
   it("related handler maps contextually type nested Effect.fn calls", () => {
     Match.value(taggedInput).pipe(
       Match.tags({

--- a/packages/effect/typetest/Match.tst.ts
+++ b/packages/effect/typetest/Match.tst.ts
@@ -1,4 +1,4 @@
-import { Match, Option, pipe, type Result } from "effect"
+import { Effect, Match, Option, pipe, type Result } from "effect"
 import { describe, expect, it } from "tstyche"
 
 type Closed = { readonly _tag: "Closed" }
@@ -8,6 +8,9 @@ type Todos = Array<Todo>
 type Filter = "All" | "Active" | "Completed"
 
 declare const stringOrNumber: string | number
+declare const taggedInput:
+  | { readonly _tag: "A"; readonly a: string }
+  | { readonly _tag: "B"; readonly b: number }
 
 describe("Match", () => {
   it("fn infers the selected value and original arguments", () => {
@@ -193,5 +196,20 @@ describe("Match", () => {
     // @ts-expect-error Argument of type
     Match.exhaustive(incomplete)
     expect(Match.exhaustive(complete)).type.toBe<string | number>()
+  })
+
+  it("tagsExhaustive contextually types Effect.fn handlers", () => {
+    Match.value(taggedInput).pipe(
+      Match.tagsExhaustive({
+        A: Effect.fn(function*(value) {
+          expect(value).type.toBe<{ readonly _tag: "A"; readonly a: string }>()
+          return value.a
+        }),
+        B: Effect.fnUntraced(function*(value) {
+          expect(value).type.toBe<{ readonly _tag: "B"; readonly b: number }>()
+          return value.b
+        })
+      })
+    )
   })
 })


### PR DESCRIPTION
## Summary

- preserve tagged-member contextual types through nested `Effect.fn` and `Effect.fnUntraced` calls in `Match.tagsExhaustive`, `Match.tags`, `Match.valueTags`, `Match.discriminators`, and `Match.discriminatorsExhaustive`
- keep the public and internal declarations aligned without casts, with shared handler-map aliases and a documented deferred conditional for TypeScript's nested inference limitation
- cover handler narrowing, inferred return types, exhaustiveness, and unknown-tag rejection with type tests
- add an `effect` patch changeset

## Testing

- `pnpm test-types Match.tst.ts`
- `pnpm check`
- `pnpm exec oxlint packages/effect/src/Match.ts packages/effect/src/internal/matcher.ts packages/effect/typetest/Match.tst.ts`
- `pnpm exec dprint check packages/effect/src/Match.ts packages/effect/src/internal/matcher.ts packages/effect/typetest/Match.tst.ts`
- `git diff --check`

Closes EFF-895
Closes #7454
