### PR TITLE
Stabilize SQL runner blackhole recovery test

### DIFF
--- a/packages/platform/node/test/cluster/SqlRunnerStorage.integration.test.ts
+++ b/packages/platform/node/test/cluster/SqlRunnerStorage.integration.test.ts
@@ -128,7 +128,9 @@ describe("SqlRunnerStorage", () => {
       restoreConnection(partitioned)
       expect(
         yield* storage.refresh(runnerAddress1, shards).pipe(
-          Effect.retry({ times: 5, schedule: Schedule.spaced(20) })
+          // The integration shard can delay a healthy replacement beyond a
+          // handful of 100 ms lock-operation deadlines under load.
+          Effect.retry({ times: 20, schedule: Schedule.spaced(20) })
         )
       ).toEqual(shards)
       assert.isAtLeast(partitioned.interruptedQueries, 1)


### PR DESCRIPTION
## Summary

- give the blackholed-query recovery assertion enough attempts for a replacement connection to become usable under CI load
- keep recovery bounded so persistent failures still fail the test

## Failure mechanism

The first timed-out query interrupts and asynchronously rebuilds the reserved SQL connection. After restoring the simulated partition, the test allowed only five attempts, each with a 100 ms lock-operation deadline. On the loaded integration shard, the replacement was not ready within that window and the transient `PersistenceError` escaped. The adjacent stalled-release recovery case already uses twenty attempts for the same scheduling constraint.

## Testing

- focused failing case, 20 consecutive runs (20/20 passed)
- complete `SqlRunnerStorage.integration.test.ts` file (22/22 passed)
- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`

Closes EFF-897
