### PR TITLE
Export Effect Cluster SQL row contracts

### DIFF
--- a/.changeset/cluster-sql-row-types.md
+++ b/.changeset/cluster-sql-row-types.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Export complete, scalar-parameterized row types for every SQL-backed Cluster message, reply, runner, and optional lock table dialect.

--- a/packages/effect/src/unstable/cluster/SqlMessageStorage.ts
+++ b/packages/effect/src/unstable/cluster/SqlMessageStorage.ts
@@ -38,6 +38,144 @@ import * as ShardId from "./ShardId.ts"
 import type { ShardingConfig } from "./ShardingConfig.ts"
 import * as Snowflake from "./Snowflake.ts"
 
+type MessageTableRow<BigIntValue, IntegerValue, BooleanValue, TimestampValue> = {
+  readonly id: BigIntValue
+  readonly message_id: string | null
+  readonly shard_id: string
+  readonly entity_type: string
+  readonly entity_id: string
+  readonly kind: IntegerValue
+  readonly tag: string | null
+  readonly payload: string | null
+  readonly headers: string | null
+  readonly trace_id: string | null
+  readonly span_id: string | null
+  readonly sampled: BooleanValue | null
+  readonly processed: BooleanValue
+  readonly request_id: BigIntValue
+  readonly reply_id: BigIntValue | null
+  readonly last_reply_id: BigIntValue | null
+  readonly last_read: TimestampValue | null
+  readonly deliver_at: BigIntValue | null
+}
+
+type MessageTableRowWithRowId<BigIntValue, IntegerValue, BooleanValue, TimestampValue> =
+  & MessageTableRow<BigIntValue, IntegerValue, BooleanValue, TimestampValue>
+  & { readonly rowid: BigIntValue }
+
+type ReplyTableRow<BigIntValue, IntegerValue, BooleanValue> = {
+  readonly id: BigIntValue
+  readonly kind: IntegerValue | null
+  readonly request_id: BigIntValue
+  readonly payload: string
+  readonly sequence: IntegerValue | null
+  readonly acked: BooleanValue
+}
+
+type ReplyTableRowWithRowId<BigIntValue, IntegerValue, BooleanValue> =
+  & ReplyTableRow<BigIntValue, IntegerValue, BooleanValue>
+  & { readonly rowid: BigIntValue }
+
+/**
+ * Complete PostgreSQL row stored in the cluster messages table, parameterized
+ * over driver-specific scalar representations.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type PgMessageRow<
+  BigIntValue = bigint,
+  BooleanValue = boolean,
+  TimestampValue = number
+> = MessageTableRowWithRowId<BigIntValue, number, BooleanValue, TimestampValue>
+
+/**
+ * Complete PostgreSQL row stored in the cluster replies table, parameterized
+ * over driver-specific scalar representations.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type PgReplyRow<
+  BigIntValue = bigint,
+  BooleanValue = boolean
+> = ReplyTableRowWithRowId<BigIntValue, number, BooleanValue>
+
+/**
+ * Complete MySQL row stored in the cluster messages table, parameterized over
+ * driver-specific scalar representations.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type MysqlMessageRow<
+  BigIntValue = number | string,
+  BooleanValue = number,
+  TimestampValue = Date | string
+> = MessageTableRowWithRowId<BigIntValue, number, BooleanValue, TimestampValue>
+
+/**
+ * Complete MySQL row stored in the cluster replies table, parameterized over
+ * driver-specific scalar representations.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type MysqlReplyRow<
+  BigIntValue = number | string,
+  BooleanValue = number
+> = ReplyTableRowWithRowId<BigIntValue, number, BooleanValue>
+
+/**
+ * Complete Microsoft SQL Server row stored in the cluster messages table,
+ * parameterized over driver-specific scalar representations.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type MssqlMessageRow<
+  BigIntValue = string,
+  BooleanValue = boolean,
+  TimestampValue = Date
+> = MessageTableRowWithRowId<BigIntValue, number, BooleanValue, TimestampValue>
+
+/**
+ * Complete Microsoft SQL Server row stored in the cluster replies table,
+ * parameterized over driver-specific scalar representations.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type MssqlReplyRow<
+  BigIntValue = string,
+  BooleanValue = boolean
+> = ReplyTableRowWithRowId<BigIntValue, number, BooleanValue>
+
+/**
+ * Complete SQLite row stored in the cluster messages table, parameterized over
+ * driver-specific scalar representations.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type SqliteMessageRow<
+  IntegerValue = number | bigint | string,
+  BooleanValue = boolean | number | bigint | string,
+  TimestampValue = string
+> = MessageTableRow<IntegerValue, IntegerValue, BooleanValue, TimestampValue>
+
+/**
+ * Complete SQLite row stored in the cluster replies table, parameterized over
+ * driver-specific scalar representations.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type SqliteReplyRow<
+  IntegerValue = number | bigint | string,
+  BooleanValue = boolean | number | bigint | string
+> = ReplyTableRow<IntegerValue, IntegerValue, BooleanValue>
+
 const withTracerDisabled = Effect.withTracerEnabled(false)
 
 /**
@@ -121,7 +259,7 @@ export const makeEncoded: (options?: {
     envelope: Envelope.Encoded,
     message_id: string | null,
     deliver_at: number | null
-  ): MessageRow => {
+  ): MessageInsertRow => {
     switch (envelope._tag) {
       case "Request":
         return {
@@ -186,7 +324,7 @@ export const makeEncoded: (options?: {
     }
   }
 
-  const replyToRow = (reply: Reply.Encoded): ReplyRow => ({
+  const replyToRow = (reply: Reply.Encoded): ReplyInsertRow => ({
     id: reply.id,
     kind: replyKind[reply._tag],
     request_id: reply.requestId,
@@ -280,7 +418,7 @@ export const makeEncoded: (options?: {
     `
 
   const insertEnvelope: (
-    row: MessageRow,
+    row: MessageInsertRow,
     message_id: string
   ) => Effect.Effect<ReadonlyArray<Row>, SqlError> = sql.onDialectOrElse({
     pg: () => (row, message_id) =>
@@ -424,7 +562,7 @@ export const makeEncoded: (options?: {
 
   const getUnprocessedMessagesForDialect = sql.onDialectOrElse({
     pg: () => (shardIds: ReadonlyArray<string>, now: number, filters: UnprocessedFilters) =>
-      sql<MessageJoinRow>`
+      sql<PgMessageRow & PgReplyJoinRow>`
         WITH messages AS (
           UPDATE ${messagesTableSql} m
           SET last_read = ${sqlNow}
@@ -609,7 +747,7 @@ export const makeEncoded: (options?: {
       // - the request is in the list
       // - the kind is WithExit
       // - or the kind is Chunk and has not been acked yet
-      sql<ReplyRow>`
+      sql<ReplyDecodeRow>`
         SELECT id, kind, request_id, payload, sequence
         FROM ${repliesTableSql}
         WHERE request_id IN (${sql.literal(requestIds.join(","))})
@@ -1148,7 +1286,7 @@ const replyKind = {
   "Chunk": null
 } as const satisfies Record<Reply.Reply<any>["_tag"], number | null>
 
-const replyFromRow = (row: ReplyRow): Reply.Encoded =>
+const replyFromRow = (row: ReplyDecodeRow): Reply.Encoded =>
   row.kind !== null && Number(row.kind) === replyKind.WithExit ?
     {
       _tag: "WithExit",
@@ -1164,38 +1302,43 @@ const replyFromRow = (row: ReplyRow): Reply.Encoded =>
       sequence: Number(row.sequence!)
     }
 
-type MessageRow = {
-  readonly id: string | bigint
-  readonly message_id: string | null
-  readonly shard_id: string
-  readonly entity_type: string
-  readonly entity_id: string
-  readonly kind: 0 | 1 | 2 | 0n | 1n | 2n
-  readonly tag: string | null
-  readonly payload: string | null
-  readonly headers: string | null
-  readonly trace_id: string | null
-  readonly span_id: string | null
-  readonly sampled: boolean | number | bigint | null
-  readonly request_id: string | bigint | null
-  readonly reply_id: string | bigint | null
-  readonly deliver_at: number | bigint | null
-}
+type MessageRow = PgMessageRow | MysqlMessageRow | MssqlMessageRow | SqliteMessageRow
 
-type ReplyRow = {
-  readonly id: string | bigint
-  readonly kind: 0 | null | 0n
-  readonly request_id: string | bigint
-  readonly payload: string
-  readonly sequence: number | bigint | null
+type MessageInsertRow = Pick<
+  MessageRow,
+  | "id"
+  | "message_id"
+  | "shard_id"
+  | "entity_type"
+  | "entity_id"
+  | "kind"
+  | "tag"
+  | "payload"
+  | "headers"
+  | "trace_id"
+  | "span_id"
+  | "sampled"
+  | "request_id"
+  | "reply_id"
+  | "deliver_at"
+>
+
+type ReplyRow = PgReplyRow | MysqlReplyRow | MssqlReplyRow | SqliteReplyRow
+
+type ReplyInsertRow = Pick<ReplyRow, "id" | "kind" | "request_id" | "payload" | "sequence">
+
+type ReplyDecodeRow = Pick<ReplyRow, "id" | "kind" | "request_id" | "payload" | "sequence">
+
+type PgReplyJoinRow = {
+  readonly reply_reply_id: PgReplyRow["id"] | null
+  readonly reply_payload: PgReplyRow["payload"] | null
+  readonly reply_sequence: PgReplyRow["sequence"]
 }
 
 type ReplyJoinRow = {
-  readonly reply_reply_id: string | bigint | null
-  readonly reply_payload: string | null
-  readonly reply_sequence: number | bigint | null
+  readonly reply_reply_id: ReplyRow["id"] | null
+  readonly reply_payload: ReplyRow["payload"] | null
+  readonly reply_sequence: ReplyRow["sequence"]
 }
 
-type MessageJoinRow = MessageRow & ReplyJoinRow & {
-  readonly sequence: number | bigint
-}
+type MessageJoinRow = MessageRow & ReplyJoinRow

--- a/packages/effect/src/unstable/cluster/SqlRunnerStorage.ts
+++ b/packages/effect/src/unstable/cluster/SqlRunnerStorage.ts
@@ -26,6 +26,105 @@ import * as RunnerStorage from "./RunnerStorage.ts"
 import * as ShardId from "./ShardId.ts"
 import * as ShardingConfig from "./ShardingConfig.ts"
 
+type RunnerTableRow<MachineIdValue, BooleanValue, TimestampValue> = {
+  readonly machine_id: MachineIdValue
+  readonly address: string
+  readonly runner: string
+  readonly healthy: BooleanValue
+  readonly last_heartbeat: TimestampValue
+}
+
+type LockTableRow<TimestampValue> = {
+  readonly shard_id: string
+  readonly address: string
+  readonly acquired_at: TimestampValue
+}
+
+/**
+ * Complete PostgreSQL row stored in the cluster runners table, parameterized
+ * over driver-specific scalar representations.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type PgRunnerRow<
+  BooleanValue = boolean,
+  TimestampValue = number
+> = RunnerTableRow<number, BooleanValue, TimestampValue>
+
+/**
+ * Complete PostgreSQL row stored in the optional cluster locks table,
+ * parameterized over driver-specific timestamp representations.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type PgLockRow<TimestampValue = number> = LockTableRow<TimestampValue>
+
+/**
+ * Complete MySQL row stored in the cluster runners table, parameterized over
+ * driver-specific scalar representations.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type MysqlRunnerRow<
+  BooleanValue = number,
+  TimestampValue = Date | string
+> = RunnerTableRow<number, BooleanValue, TimestampValue>
+
+/**
+ * Complete MySQL row stored in the optional cluster locks table, parameterized
+ * over driver-specific timestamp representations.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type MysqlLockRow<TimestampValue = Date | string> = LockTableRow<TimestampValue>
+
+/**
+ * Complete Microsoft SQL Server row stored in the cluster runners table,
+ * parameterized over driver-specific scalar representations.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type MssqlRunnerRow<
+  BooleanValue = boolean,
+  TimestampValue = Date
+> = RunnerTableRow<number, BooleanValue, TimestampValue>
+
+/**
+ * Complete Microsoft SQL Server row stored in the optional cluster locks table,
+ * parameterized over driver-specific timestamp representations.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type MssqlLockRow<TimestampValue = Date> = LockTableRow<TimestampValue>
+
+/**
+ * Complete SQLite row stored in the cluster runners table, parameterized over
+ * driver-specific scalar representations.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type SqliteRunnerRow<
+  IntegerValue = number | bigint | string,
+  BooleanValue = boolean | number | bigint | string,
+  TimestampValue = string
+> = RunnerTableRow<IntegerValue, BooleanValue, TimestampValue>
+
+/**
+ * Complete SQLite row stored in the optional cluster locks table, parameterized
+ * over driver-specific timestamp representations.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type SqliteLockRow<TimestampValue = string> = LockTableRow<TimestampValue>
+
 const withTracerDisabled = Effect.withTracerEnabled(false)
 
 // This exact FNV-1a hash, including its tag and UTF-8 encoding, is a persistent
@@ -320,7 +419,12 @@ export const make = Effect.fnUntraced(function*(options: {
 
   // Upsert runner and return machine_id
   const insertRunner = sql.onDialectOrElse({
-    mssql: () => (address: string, runner: string, healthy: boolean) =>
+    mssql: () =>
+    (
+      address: MssqlRunnerRow["address"],
+      runner: MssqlRunnerRow["runner"],
+      healthy: boolean
+    ) =>
       sql`
         MERGE ${runnersTableSql} AS target
         USING (SELECT ${address} AS address, ${runner} AS runner, ${sqlNow} AS last_heartbeat, ${
@@ -334,8 +438,13 @@ export const make = Effect.fnUntraced(function*(options: {
           VALUES (source.address, source.runner, source.last_heartbeat, source.healthy)
         OUTPUT INSERTED.machine_id;
       `.values,
-    mysql: () => (address: string, runner: string, healthy: boolean) =>
-      sql<{ machine_id: number }>`
+    mysql: () =>
+    (
+      address: MysqlRunnerRow["address"],
+      runner: MysqlRunnerRow["runner"],
+      healthy: boolean
+    ) =>
+      sql<Pick<MysqlRunnerRow, "machine_id">>`
         INSERT INTO ${runnersTableSql} (address, runner, last_heartbeat, healthy)
         VALUES (${address}, ${runner}, ${sqlNow}, ${healthy})
         ON DUPLICATE KEY UPDATE
@@ -346,7 +455,12 @@ export const make = Effect.fnUntraced(function*(options: {
       `.unprepared.pipe(
         Effect.map((results: any) => [[results[1][0].machine_id]])
       ),
-    pg: () => (address: string, runner: string, healthy: boolean) =>
+    pg: () =>
+    (
+      address: PgRunnerRow["address"],
+      runner: PgRunnerRow["runner"],
+      healthy: PgRunnerRow["healthy"]
+    ) =>
       sql`
         INSERT INTO ${runnersTableSql} (address, runner, last_heartbeat, healthy)
         VALUES (${address}, ${runner}, ${sqlNow}, ${healthy})
@@ -356,7 +470,12 @@ export const make = Effect.fnUntraced(function*(options: {
             healthy = EXCLUDED.healthy
         RETURNING machine_id
       `.values,
-    orElse: () => (address: string, runner: string, healthy: boolean) =>
+    orElse: () =>
+    (
+      address: SqliteRunnerRow["address"],
+      runner: SqliteRunnerRow["runner"],
+      healthy: boolean
+    ) =>
       // sqlite
       sql`
         INSERT INTO ${runnersTableSql} (address, runner, last_heartbeat, healthy)
@@ -594,7 +713,7 @@ export const make = Effect.fnUntraced(function*(options: {
   const refreshShards = sql.onDialectOrElse({
     pg: () => {
       if (!disableAdvisoryLocks) return acquireLock
-      return (address: string, shardIds: ReadonlyArray<string>) =>
+      return (address: PgLockRow["address"], shardIds: ReadonlyArray<PgLockRow["shard_id"]>) =>
         sql`
           UPDATE ${locksTableSql}
           SET acquired_at = ${sqlNow}
@@ -602,14 +721,14 @@ export const make = Effect.fnUntraced(function*(options: {
           RETURNING shard_id
         `.pipe(
           execWithLockConnValues,
-          Effect.map((rows) => rows.map((row) => row[0] as string))
+          Effect.map((rows) => rows.map((row) => row[0] as PgLockRow["shard_id"]))
         )
     },
     mysql: () => {
       if (!disableAdvisoryLocks) return acquireLock
-      return (address: string, shardIds: ReadonlyArray<string>) => {
+      return (address: MysqlLockRow["address"], shardIds: ReadonlyArray<MysqlLockRow["shard_id"]>) => {
         const shardIdsStr = stringLiteralArr(shardIds)
-        return sql<Array<{ shard_id: string }>>`
+        return sql<Array<Pick<MysqlLockRow, "shard_id">>>`
           UPDATE ${locksTableSql}
           SET acquired_at = ${sqlNow}
           WHERE address = ${address} AND shard_id IN ${shardIdsStr};
@@ -620,20 +739,26 @@ export const make = Effect.fnUntraced(function*(options: {
         )
       }
     },
-    mssql: () => (address: string, shardIds: ReadonlyArray<string>) =>
+    mssql: () => (address: MssqlLockRow["address"], shardIds: ReadonlyArray<MssqlLockRow["shard_id"]>) =>
       sql`
         UPDATE ${locksTableSql}
         SET acquired_at = ${sqlNow}
         OUTPUT inserted.shard_id
         WHERE address = ${address} AND shard_id IN ${stringLiteralArr(shardIds)}
-      `.pipe(execWithLockConnValues, Effect.map((rows) => rows.map((row) => row[0] as string))),
-    orElse: () => (address: string, shardIds: ReadonlyArray<string>) =>
+      `.pipe(
+        execWithLockConnValues,
+        Effect.map((rows) => rows.map((row) => row[0] as MssqlLockRow["shard_id"]))
+      ),
+    orElse: () => (address: SqliteLockRow["address"], shardIds: ReadonlyArray<SqliteLockRow["shard_id"]>) =>
       sql`
         UPDATE ${locksTableSql}
         SET acquired_at = ${sqlNow}
         WHERE address = ${address} AND shard_id IN ${stringLiteralArr(shardIds)}
         RETURNING shard_id
-      `.pipe(execWithLockConnValues, Effect.map((rows) => rows.map((row) => row[0] as string)))
+      `.pipe(
+        execWithLockConnValues,
+        Effect.map((rows) => rows.map((row) => row[0] as SqliteLockRow["shard_id"]))
+      )
   })
 
   const withLockOperationDeadline = <A, E, R>(operation: Effect.Effect<A, E, R>) =>

--- a/packages/effect/typetest/unstable/cluster/SqlStorage.tst.ts
+++ b/packages/effect/typetest/unstable/cluster/SqlStorage.tst.ts
@@ -1,0 +1,99 @@
+import type * as SqlMessageStorage from "effect/unstable/cluster/SqlMessageStorage"
+import type * as SqlRunnerStorage from "effect/unstable/cluster/SqlRunnerStorage"
+import { describe, expect, it } from "tstyche"
+
+type MessageRow<BigIntValue, IntegerValue, BooleanValue, TimestampValue> = {
+  readonly id: BigIntValue
+  readonly message_id: string | null
+  readonly shard_id: string
+  readonly entity_type: string
+  readonly entity_id: string
+  readonly kind: IntegerValue
+  readonly tag: string | null
+  readonly payload: string | null
+  readonly headers: string | null
+  readonly trace_id: string | null
+  readonly span_id: string | null
+  readonly sampled: BooleanValue | null
+  readonly processed: BooleanValue
+  readonly request_id: BigIntValue
+  readonly reply_id: BigIntValue | null
+  readonly last_reply_id: BigIntValue | null
+  readonly last_read: TimestampValue | null
+  readonly deliver_at: BigIntValue | null
+}
+
+type MessageRowWithRowId<BigIntValue, IntegerValue, BooleanValue, TimestampValue> =
+  & MessageRow<BigIntValue, IntegerValue, BooleanValue, TimestampValue>
+  & { readonly rowid: BigIntValue }
+
+type ReplyRow<BigIntValue, IntegerValue, BooleanValue> = {
+  readonly id: BigIntValue
+  readonly kind: IntegerValue | null
+  readonly request_id: BigIntValue
+  readonly payload: string
+  readonly sequence: IntegerValue | null
+  readonly acked: BooleanValue
+}
+
+type ReplyRowWithRowId<BigIntValue, IntegerValue, BooleanValue> =
+  & ReplyRow<BigIntValue, IntegerValue, BooleanValue>
+  & { readonly rowid: BigIntValue }
+
+type RunnerRow<MachineIdValue, BooleanValue, TimestampValue> = {
+  readonly machine_id: MachineIdValue
+  readonly address: string
+  readonly runner: string
+  readonly healthy: BooleanValue
+  readonly last_heartbeat: TimestampValue
+}
+
+type LockRow<TimestampValue> = {
+  readonly shard_id: string
+  readonly address: string
+  readonly acquired_at: TimestampValue
+}
+
+describe("SQL storage row contracts", () => {
+  it("describes PostgreSQL rows", () => {
+    expect<SqlMessageStorage.PgMessageRow>().type.toBe<MessageRowWithRowId<bigint, number, boolean, number>>()
+    expect<SqlMessageStorage.PgReplyRow>().type.toBe<ReplyRowWithRowId<bigint, number, boolean>>()
+    expect<SqlRunnerStorage.PgRunnerRow>().type.toBe<RunnerRow<number, boolean, number>>()
+    expect<SqlRunnerStorage.PgLockRow>().type.toBe<LockRow<number>>()
+  })
+
+  it("describes MySQL rows", () => {
+    expect<SqlMessageStorage.MysqlMessageRow>().type.toBe<
+      MessageRowWithRowId<number | string, number, number, Date | string>
+    >()
+    expect<SqlMessageStorage.MysqlReplyRow>().type.toBe<ReplyRowWithRowId<number | string, number, number>>()
+    expect<SqlRunnerStorage.MysqlRunnerRow>().type.toBe<RunnerRow<number, number, Date | string>>()
+    expect<SqlRunnerStorage.MysqlLockRow>().type.toBe<LockRow<Date | string>>()
+  })
+
+  it("describes Microsoft SQL Server rows", () => {
+    expect<SqlMessageStorage.MssqlMessageRow>().type.toBe<MessageRowWithRowId<string, number, boolean, Date>>()
+    expect<SqlMessageStorage.MssqlReplyRow>().type.toBe<ReplyRowWithRowId<string, number, boolean>>()
+    expect<SqlRunnerStorage.MssqlRunnerRow>().type.toBe<RunnerRow<number, boolean, Date>>()
+    expect<SqlRunnerStorage.MssqlLockRow>().type.toBe<LockRow<Date>>()
+  })
+
+  it("describes SQLite rows without a separate rowid column", () => {
+    type Integer = number | bigint | string
+    type Boolean = boolean | number | bigint | string
+
+    expect<SqlMessageStorage.SqliteMessageRow>().type.toBe<MessageRow<Integer, Integer, Boolean, string>>()
+    expect<SqlMessageStorage.SqliteReplyRow>().type.toBe<ReplyRow<Integer, Integer, Boolean>>()
+    expect<SqlRunnerStorage.SqliteRunnerRow>().type.toBe<RunnerRow<Integer, Boolean, string>>()
+    expect<SqlRunnerStorage.SqliteLockRow>().type.toBe<LockRow<string>>()
+  })
+
+  it("allows schema tools to select their scalar representations", () => {
+    expect<SqlMessageStorage.MysqlMessageRow<bigint, boolean, Date>>().type.toBe<
+      MessageRowWithRowId<bigint, number, boolean, Date>
+    >()
+    expect<SqlRunnerStorage.SqliteRunnerRow<number, boolean, Date>>().type.toBe<
+      RunnerRow<number, boolean, Date>
+    >()
+  })
+})


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Effect Cluster's SQL storage defines its physical table contracts through migration SQL and private implementation types. Applications whose schema tooling owns table provisioning cannot currently detect contract drift during an Effect upgrade.

This change:

- exports complete message, reply, runner, and optional lock row types for PostgreSQL, MySQL, Microsoft SQL Server, and SQLite
- parameterizes dialect-specific scalar representations so consumers can match their ORM models while preserving exact columns, nullability, and generated-column differences
- derives internal SQL encoder and decoder types from the exported contracts
- adds exact type-level coverage for every dialect and custom scalar mappings
- adds a minor changeset

Validation:

- `pnpm lint`
- `pnpm test-types packages/effect/typetest/unstable/cluster/SqlStorage.tst.ts`
- `pnpm check`
- `EFFECT_INTEGRATION_TESTS=1 pnpm test --run packages/platform/node/test/cluster/SqlMessageStorage.integration.test.ts packages/platform/node/test/cluster/SqlRunnerStorage.integration.test.ts -t sqlite` (21 passed)

PostgreSQL and MySQL integration tests were not run locally because no container runtime is available.

## Related

- Related Issue: N/A
- Closes: N/A