### PR TITLE
Remove Temporal polyfill from scratchpad

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -984,9 +984,6 @@ importers:
       '@effect/sql-sqlite-wasm':
         specifier: workspace:*
         version: link:../packages/sql/sqlite-wasm
-      '@js-temporal/polyfill':
-        specifier: ^0.5.1
-        version: 0.5.1
       effect:
         specifier: workspace:*
         version: link:../packages/effect
@@ -2233,10 +2230,6 @@ packages:
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
-
-  '@js-temporal/polyfill@0.5.1':
-    resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
-    engines: {node: '>=12'}
 
   '@jsr/db__redis@0.41.2':
     resolution: {integrity: sha512-pDHlF3sQaU5+VDwDH3jRkETBSD9gAIqdoaC3j0B4nrffr+H/Kh0Pbw7i/p5eD+9W5j38l8yRqZGbo4xgohYttg==, tarball: https://npm.jsr.io/~/11/@jsr/db__redis/0.41.2.tgz}
@@ -4724,9 +4717,6 @@ packages:
   js-yaml@4.3.1:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
-
-  jsbi@4.3.2:
-    resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
 
   jsc-safe-url@0.2.4:
     resolution: {integrity: sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==}
@@ -7866,10 +7856,6 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@js-temporal/polyfill@0.5.1':
-    dependencies:
-      jsbi: 4.3.2
-
   '@jsr/db__redis@0.41.2':
     dependencies:
       '@jsr/std__async': 1.5.0
@@ -10243,8 +10229,6 @@ snapshots:
   js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
-
-  jsbi@4.3.2: {}
 
   jsc-safe-url@0.2.4: {}
 

--- a/scratchpad/package.json
+++ b/scratchpad/package.json
@@ -22,7 +22,6 @@
     "@effect/sql-sqlite-node": "workspace:*",
     "@effect/sql-sqlite-react-native": "workspace:*",
     "@effect/sql-sqlite-wasm": "workspace:*",
-    "@js-temporal/polyfill": "^0.5.1",
     "effect": "workspace:*"
   }
 }


### PR DESCRIPTION
## Summary

- remove the unused `@js-temporal/polyfill` scratchpad dependency
- remove its orphaned lockfile entries

## Testing

- `pnpm install --lockfile-only --frozen-lockfile`