### PR TITLE
Support WebSocket clients across runtimes

### DIFF
--- a/.changeset/bright-sockets-connect.md
+++ b/.changeset/bright-sockets-connect.md
@@ -1,0 +1,9 @@
+---
+"@effect/ai-openai": patch
+"@effect/platform-bun": patch
+"@effect/platform-node": patch
+"effect": patch
+---
+
+Allow sockets to use browser, Bun, and Node WebSocket implementations without consumer casts. Platform constructors
+now support typed opening-handshake headers where available.

--- a/packages/ai/openai/src/OpenAiClient.ts
+++ b/packages/ai/openai/src/OpenAiClient.ts
@@ -510,7 +510,7 @@ const makeSocket = Effect.gen(function*() {
         Effect.provideService(Socket.WebSocketConstructor, (url) =>
           makeWebSocket(url, {
             headers: request.headers
-          } as any))
+          }))
       )
       const write = yield* socket.writer
 

--- a/packages/effect/src/unstable/socket/Socket.ts
+++ b/packages/effect/src/unstable/socket/Socket.ts
@@ -594,7 +594,7 @@ export interface WebSocketClientOptions {
    * This is supported by Node and Bun WebSocket clients. Browser constructors
    * cannot set arbitrary handshake headers and must reject this option.
    */
-  readonly headers?: Readonly<Record<string, string>>
+  readonly headers?: Readonly<Record<string, string>> | undefined
 }
 
 /**
@@ -713,7 +713,7 @@ export const fromWebSocket = <RO, WS extends WebSocketLike>(
         let open = false
 
         function onMessage(event: WebSocketEvent) {
-          const data = event.data
+          const data = event.data as Blob | ArrayBuffer | Uint8Array | string
           if (data instanceof Blob) {
             const effect = Effect.flatMap(
               Effect.promise(() => data.arrayBuffer()),
@@ -723,9 +723,6 @@ export const fromWebSocket = <RO, WS extends WebSocketLike>(
               }
             )
             return run(effect)
-          }
-          if (typeof data !== "string" && !(data instanceof ArrayBuffer) && !(data instanceof Uint8Array)) {
-            return
           }
           const result = handler(data instanceof ArrayBuffer ? new Uint8Array(data) : data)
           if (Effect.isEffect(result)) {

--- a/packages/effect/src/unstable/socket/Socket.ts
+++ b/packages/effect/src/unstable/socket/Socket.ts
@@ -538,26 +538,97 @@ export const makeChannel = <IE = never>(): Channel.Channel<
 export const defaultCloseCodeIsError = (_code: number) => true
 
 /**
+ * Event payload exposed by a WebSocket implementation.
+ *
+ * The socket adapter only reads `data`, `code`, and `reason`; implementations
+ * may expose additional fields.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface WebSocketEvent {
+  readonly type?: string
+  readonly data?: unknown
+  readonly code?: number
+  readonly reason?: string
+}
+
+/**
+ * The subset of the WebSocket API required by `Socket`.
+ *
+ * This structural interface is intentionally independent of the DOM
+ * `WebSocket` type. Node implementations such as `ws` expose the same
+ * event-target methods, but are not assignable to `globalThis.WebSocket`
+ * because their event payload types are runtime-specific.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface WebSocketLike {
+  readonly readyState: number
+  addEventListener(
+    type: "open" | "message" | "error" | "close",
+    listener: (event: WebSocketEvent) => void,
+    options?: {
+      readonly once?: boolean
+    }
+  ): void
+  removeEventListener(
+    type: "open" | "message" | "error" | "close",
+    listener: (event: WebSocketEvent) => void
+  ): void
+  close(code?: number, reason?: string): void
+  send(data: string | Uint8Array<ArrayBuffer>): void
+}
+
+/**
+ * Common options understood by a WebSocket client implementation.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface WebSocketClientOptions {
+  /**
+   * Headers to include in the opening handshake.
+   *
+   * This is supported by Node and Bun WebSocket clients. Browser constructors
+   * cannot set arbitrary handshake headers and must reject this option.
+   */
+  readonly headers?: Readonly<Record<string, string>>
+}
+
+/**
+ * Options accepted by a `WebSocketConstructor`.
+ *
+ * Browser-compatible constructors accept a protocol string or list. Node and
+ * Bun constructors additionally accept `WebSocketClientOptions`.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type WebSocketConstructorOptions = string | Array<string> | WebSocketClientOptions
+
+/**
  * Context service for the active `WebSocket` instance available while a
  * WebSocket-backed socket run is handling events.
  *
  * @category services
  * @since 4.0.0
  */
-export class WebSocket extends Context.Service<WebSocket, globalThis.WebSocket>()(
+export class WebSocket extends Context.Service<WebSocket, WebSocketLike>()(
   "~effect/socket/Socket/WebSocket"
 ) {}
 
 /**
  * Context service for constructing `WebSocket` instances from a URL and
- * optional protocols.
+ * optional protocols or platform-specific options.
  *
  * @category services
  * @since 4.0.0
  */
 export class WebSocketConstructor extends Context.Service<
   WebSocketConstructor,
-  (url: string, protocols?: string | Array<string> | undefined) => globalThis.WebSocket
+  (url: string, options?: WebSocketConstructorOptions | undefined) => WebSocketLike
 >()("@effect/platform/Socket/WebSocketConstructor") {}
 
 /**
@@ -567,7 +638,12 @@ export class WebSocketConstructor extends Context.Service<
  * @since 4.0.0
  */
 export const layerWebSocketConstructorGlobal: Layer.Layer<WebSocketConstructor> = Layer.succeed(WebSocketConstructor)(
-  (url, protocols) => new globalThis.WebSocket(url, protocols)
+  (url, options) => {
+    if (options !== undefined && typeof options !== "string" && !Array.isArray(options)) {
+      throw new TypeError("WebSocket client options are not supported by the global WebSocket constructor")
+    }
+    return new globalThis.WebSocket(url, options)
+  }
 )
 
 /**
@@ -603,8 +679,8 @@ export const makeWebSocket = (url: string | Effect.Effect<string>, options?: {
  * @category constructors
  * @since 4.0.0
  */
-export const fromWebSocket = <RO>(
-  acquire: Effect.Effect<globalThis.WebSocket, SocketError, RO>,
+export const fromWebSocket = <RO, WS extends WebSocketLike>(
+  acquire: Effect.Effect<WS, SocketError, RO>,
   options?: {
     readonly closeCodeIsError?: ((code: number) => boolean) | undefined
     readonly openTimeout?: Duration.Input | undefined
@@ -615,11 +691,11 @@ export const fromWebSocket = <RO>(
      * @category options
      * @since 4.0.0
      */
-    readonly onInitialRun?: ((ws: globalThis.WebSocket) => ReadonlyArray<MessageEvent>) | undefined
+    readonly onInitialRun?: ((ws: WS) => ReadonlyArray<WebSocketEvent>) | undefined
   } | undefined
 ): Effect.Effect<Socket, never, Exclude<RO, Scope.Scope>> =>
   Effect.withFiber((fiber) => {
-    let currentWS: globalThis.WebSocket | undefined
+    let currentWS: WebSocketLike | undefined
     let initial = true
     const latch = Latch.makeUnsafe(false)
     const acquireContext = fiber.context as Context.Context<RO>
@@ -636,10 +712,11 @@ export const fromWebSocket = <RO>(
         const run = yield* Effect.provideService(FiberSet.runtime(fiberSet)<R>(), WebSocket, ws)
         let open = false
 
-        function onMessage(event: MessageEvent) {
-          if (event.data instanceof Blob) {
+        function onMessage(event: WebSocketEvent) {
+          const data = event.data
+          if (data instanceof Blob) {
             const effect = Effect.flatMap(
-              Effect.promise(() => event.data.arrayBuffer() as Promise<ArrayBuffer>),
+              Effect.promise(() => data.arrayBuffer()),
               (buffer) => {
                 const result = handler(new Uint8Array(buffer))
                 return Effect.isEffect(result) ? result : Effect.void
@@ -647,12 +724,15 @@ export const fromWebSocket = <RO>(
             )
             return run(effect)
           }
-          const result = handler(event.data instanceof ArrayBuffer ? new Uint8Array(event.data) : event.data)
+          if (typeof data !== "string" && !(data instanceof ArrayBuffer) && !(data instanceof Uint8Array)) {
+            return
+          }
+          const result = handler(data instanceof ArrayBuffer ? new Uint8Array(data) : data)
           if (Effect.isEffect(result)) {
             run(result)
           }
         }
-        function onError(cause: Event) {
+        function onError(cause: WebSocketEvent) {
           ws.removeEventListener("message", onMessage)
           ws.removeEventListener("close", onClose)
           Deferred.doneUnsafe(
@@ -671,7 +751,7 @@ export const fromWebSocket = <RO>(
             )
           )
         }
-        function onClose(event: globalThis.CloseEvent) {
+        function onClose(event: WebSocketEvent) {
           const code = typeof event.code === "number" ? event.code : 1001
           ws.removeEventListener("message", onMessage)
           ws.removeEventListener("error", onError)

--- a/packages/effect/typetest/unstable/socket/Socket.tst.ts
+++ b/packages/effect/typetest/unstable/socket/Socket.tst.ts
@@ -10,6 +10,7 @@ describe("Socket", () => {
       expect({ headers: { Authorization: "Bearer test" } }).type.toBeAssignableTo<
         Socket.WebSocketConstructorOptions
       >()
+      expect({ headers: undefined }).type.toBeAssignableTo<Socket.WebSocketConstructorOptions>()
     })
 
     it("rejects non-string header values", () => {

--- a/packages/effect/typetest/unstable/socket/Socket.tst.ts
+++ b/packages/effect/typetest/unstable/socket/Socket.tst.ts
@@ -1,0 +1,33 @@
+import type { Effect } from "effect"
+import { Socket } from "effect/unstable/socket"
+import { describe, expect, it } from "tstyche"
+
+describe("Socket", () => {
+  describe("WebSocketConstructorOptions", () => {
+    it("accepts protocols and string-valued headers", () => {
+      expect("protocol").type.toBeAssignableTo<Socket.WebSocketConstructorOptions>()
+      expect(["protocol"]).type.toBeAssignableTo<Socket.WebSocketConstructorOptions>()
+      expect({ headers: { Authorization: "Bearer test" } }).type.toBeAssignableTo<
+        Socket.WebSocketConstructorOptions
+      >()
+    })
+
+    it("rejects non-string header values", () => {
+      expect({ headers: { Authorization: 1 } }).type.not.toBeAssignableTo<Socket.WebSocketConstructorOptions>()
+    })
+  })
+
+  it("accepts the global WebSocket implementation", () => {
+    expect(new globalThis.WebSocket("ws://localhost")).type.toBeAssignableTo<Socket.WebSocketLike>()
+  })
+
+  it("preserves the concrete WebSocket type", () => {
+    const acquire = null as unknown as Effect.Effect<globalThis.WebSocket, Socket.SocketError>
+    Socket.fromWebSocket(acquire, {
+      onInitialRun: (socket) => {
+        expect(socket).type.toBe<globalThis.WebSocket>()
+        return []
+      }
+    })
+  })
+})

--- a/packages/platform/bun/src/BunSocket.ts
+++ b/packages/platform/bun/src/BunSocket.ts
@@ -28,14 +28,12 @@ export * from "@effect/platform-node-shared/NodeSocket"
  */
 export const layerWebSocketConstructor: Layer.Layer<
   Socket.WebSocketConstructor
-> = Layer.succeed(Socket.WebSocketConstructor)((url, options) => {
-  // `bun-types` defers to the DOM constructor when `lib.dom` is loaded, which
-  // hides Bun's supported `WebSocketOptions` overload.
-  const WebSocket = globalThis.WebSocket as {
-    new(url: string, options?: Socket.WebSocketConstructorOptions): Socket.WebSocketLike
-  }
-  return new WebSocket(url, options)
-})
+> = Layer.succeed(Socket.WebSocketConstructor)(
+  (url, options) =>
+    // Bun accepts `WebSocketOptions`, but `bun-types` selects the DOM overload
+    // when `lib.dom` is loaded and hides those constructor options.
+    new globalThis.WebSocket(url, options as string | Array<string> | undefined)
+)
 
 /**
  * Creates a `Socket.Socket` layer for a WebSocket URL using Bun's global

--- a/packages/platform/bun/src/BunSocket.ts
+++ b/packages/platform/bun/src/BunSocket.ts
@@ -28,9 +28,14 @@ export * from "@effect/platform-node-shared/NodeSocket"
  */
 export const layerWebSocketConstructor: Layer.Layer<
   Socket.WebSocketConstructor
-> = Layer.succeed(Socket.WebSocketConstructor)(
-  (url, protocols) => new globalThis.WebSocket(url, protocols)
-)
+> = Layer.succeed(Socket.WebSocketConstructor)((url, options) => {
+  // `bun-types` defers to the DOM constructor when `lib.dom` is loaded, which
+  // hides Bun's supported `WebSocketOptions` overload.
+  const WebSocket = globalThis.WebSocket as {
+    new(url: string, options?: Socket.WebSocketConstructorOptions): Socket.WebSocketLike
+  }
+  return new WebSocket(url, options)
+})
 
 /**
  * Creates a `Socket.Socket` layer for a WebSocket URL using Bun's global

--- a/packages/platform/node-shared/src/NodeSocketServer.ts
+++ b/packages/platform/node-shared/src/NodeSocketServer.ts
@@ -195,7 +195,7 @@ export const makeWebSocket: (
   options: NodeWS.ServerOptions
 ) {
   const pendingConnections = new Map<
-    globalThis.WebSocket,
+    NodeWS.WebSocket,
     readonly [request: Http.IncomingMessage, remove: () => void]
   >()
   const server = yield* Effect.acquireRelease(
@@ -204,13 +204,12 @@ export const makeWebSocket: (
       Effect.callback<void>((resume) => {
         pendingConnections.forEach(([, remove], conn) => {
           remove()
-          const socket = conn as unknown as NodeWS.WebSocket
-          socket.terminate()
+          conn.terminate()
         })
         server.close(() => resume(Effect.void))
       })
   )
-  function defaultHandler(conn: globalThis.WebSocket, req: Http.IncomingMessage) {
+  function defaultHandler(conn: NodeWS.WebSocket, req: Http.IncomingMessage) {
     const remove = () => {
       pendingConnections.delete(conn)
       conn.removeEventListener("close", remove)
@@ -219,7 +218,7 @@ export const makeWebSocket: (
     conn.addEventListener("close", remove)
   }
   let onConnection = defaultHandler
-  server.on("connection", (conn, req) => onConnection(conn as any, req))
+  server.on("connection", (conn, req) => onConnection(conn, req))
 
   yield* Effect.callback<void, SocketServer.SocketServerError>((resume) => {
     server.once("error", (error) => {
@@ -241,10 +240,10 @@ export const makeWebSocket: (
     const services = Context.omit(Scope.Scope)(yield* Effect.context<R>()) as Context.Context<R>
     const trackFiber = Fiber.runIn(scope)
     const prevOnConnection = onConnection
-    onConnection = function(conn: globalThis.WebSocket, req: Http.IncomingMessage) {
+    onConnection = function(conn: NodeWS.WebSocket, req: Http.IncomingMessage) {
       let context = services
       context = Context.add(context, IncomingMessage, req)
-      context = Context.add(context, Socket.WebSocket, conn as any)
+      context = Context.add(context, Socket.WebSocket, conn)
       pipe(
         Socket.fromWebSocket(
           Effect.acquireRelease(

--- a/packages/platform/node/src/NodeHttpServer.ts
+++ b/packages/platform/node/src/NodeHttpServer.ts
@@ -272,10 +272,10 @@ export const makeUpgradeHandler = <
         lazyWss,
         (wss) =>
           Effect.acquireRelease(
-            Effect.callback<globalThis.WebSocket>((resume) =>
+            Effect.callback<NodeWS.WebSocket>((resume) =>
               wss.handleUpgrade(nodeRequest, socket, head, (ws) => {
                 upgraded = true
-                resume(Effect.succeed(ws as any))
+                resume(Effect.succeed(ws))
               })
             ),
             (ws) => Effect.sync(() => ws.close())

--- a/packages/platform/node/src/NodeSocket.ts
+++ b/packages/platform/node/src/NodeSocket.ts
@@ -21,12 +21,8 @@ import * as Socket from "effect/unstable/socket/Socket"
  */
 export * from "@effect/platform-node-shared/NodeSocket"
 
-const makeWebSocketWS: Socket.WebSocketConstructor["Service"] = (url, options) => {
-  if (options === undefined || typeof options === "string" || Array.isArray(options)) {
-    return new WS.WebSocket(url, options)
-  }
-  return new WS.WebSocket(url, options)
-}
+const makeWebSocketWS: Socket.WebSocketConstructor["Service"] = (url, options) =>
+  new WS.WebSocket(url, options as WS.ClientOptions)
 
 /**
  * Provides a `Socket.WebSocketConstructor`, using `globalThis.WebSocket` when

--- a/packages/platform/node/src/NodeSocket.ts
+++ b/packages/platform/node/src/NodeSocket.ts
@@ -21,6 +21,13 @@ import * as Socket from "effect/unstable/socket/Socket"
  */
 export * from "@effect/platform-node-shared/NodeSocket"
 
+const makeWebSocketWS: Socket.WebSocketConstructor["Service"] = (url, options) => {
+  if (options === undefined || typeof options === "string" || Array.isArray(options)) {
+    return new WS.WebSocket(url, options)
+  }
+  return new WS.WebSocket(url, options)
+}
+
 /**
  * Provides a `Socket.WebSocketConstructor`, using `globalThis.WebSocket` when
  * available and falling back to the `ws` package otherwise.
@@ -32,9 +39,14 @@ export const layerWebSocketConstructor: Layer.Layer<
   Socket.WebSocketConstructor
 > = Layer.sync(Socket.WebSocketConstructor)(() => {
   if ("WebSocket" in globalThis) {
-    return (url, protocols) => new globalThis.WebSocket(url, protocols)
+    return (url, options) => {
+      if (options === undefined || typeof options === "string" || Array.isArray(options)) {
+        return new globalThis.WebSocket(url, options)
+      }
+      return makeWebSocketWS(url, options)
+    }
   }
-  return (url, protocols) => new WS.WebSocket(url, protocols) as unknown as globalThis.WebSocket
+  return makeWebSocketWS
 })
 
 /**
@@ -46,9 +58,7 @@ export const layerWebSocketConstructor: Layer.Layer<
  */
 export const layerWebSocketConstructorWS: Layer.Layer<
   Socket.WebSocketConstructor
-> = Layer.succeed(Socket.WebSocketConstructor)(
-  (url, protocols) => new WS.WebSocket(url, protocols) as unknown as globalThis.WebSocket
-)
+> = Layer.succeed(Socket.WebSocketConstructor)(makeWebSocketWS)
 
 /**
  * Creates a `Socket.Socket` layer for a WebSocket URL using the Node WebSocket

--- a/packages/platform/node/test/NodeSocket.test.ts
+++ b/packages/platform/node/test/NodeSocket.test.ts
@@ -1,6 +1,6 @@
 import { NodeSocket, NodeSocketServer } from "@effect/platform-node"
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Queue } from "effect"
+import { Deferred, Effect, Queue } from "effect"
 import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
 import * as Scope from "effect/Scope"
@@ -104,6 +104,35 @@ describe("Socket", () => {
         })
     )
 
+    it.effect("passes headers to the opening handshake", () =>
+      Effect.gen(function*() {
+        const authorization = yield* Deferred.make<string | undefined>()
+        const server = yield* NodeSocketServer.makeWebSocket({
+          host: "127.0.0.1",
+          port: 0,
+          verifyClient: ({ req }: Parameters<NodeSocket.NodeWS.VerifyClientCallbackSync>[0]) => {
+            Deferred.doneUnsafe(authorization, Effect.succeed(req.headers.authorization))
+            return true
+          }
+        })
+        assert.strictEqual(server.address._tag, "TcpAddress")
+        if (server.address._tag !== "TcpAddress") return
+        const port = server.address.port
+
+        const makeWebSocket = yield* Socket.WebSocketConstructor
+        const client = yield* Effect.acquireRelease(
+          Effect.sync(() =>
+            makeWebSocket(`ws://127.0.0.1:${port}`, {
+              headers: { Authorization: "Bearer test" }
+            })
+          ),
+          (client) => Effect.sync(() => client.close())
+        )
+        client.addEventListener("error", () => {})
+
+        assert.strictEqual(yield* Deferred.await(authorization).pipe(Effect.timeout("1 second")), "Bearer test")
+      }).pipe(Effect.provide(NodeSocket.layerWebSocketConstructorWS)))
+
     it.effect("messages", () =>
       Effect.gen(function*() {
         const server = yield* makeServer
@@ -176,7 +205,7 @@ describe("Socket", () => {
         const socket = yield* Socket.makeWebSocket(Effect.succeed(url), { closeCodeIsError: () => false }).pipe(
           Effect.provideService(
             Socket.WebSocketConstructor,
-            () => webSocket as unknown as globalThis.WebSocket
+            () => webSocket
           )
         )
         const exit = yield* Effect.scoped(Effect.gen(function*() {


### PR DESCRIPTION
`Socket.fromWebSocket` was tied to the DOM `WebSocket` type, so Node clients and authenticated OpenAI connections needed casts even though they already had the required runtime behavior.

This introduces a small shared WebSocket interface and adds typed handshake headers to the constructor. `Socket.fromWebSocket` also preserves the concrete acquired socket type for lifecycle hooks. Node uses `ws` when headers are needed, Bun forwards its native constructor options, and browsers reject header options with a clear error. The related casts in the Node server and OpenAI client are removed.

The Bun adapter keeps one local type assertion because `bun-types` exposes the DOM constructor overload when `lib.dom` is loaded, hiding Bun custom options from TypeScript.

Type tests cover cross-runtime compatibility and concrete socket type preservation on TypeScript 5.9 and 6.0. A Node integration test verifies that handshake headers reach a real WebSocket server.
