### PR TITLE
Restore Effect.timeout error message

### DIFF
--- a/.changeset/timeout-error-message.md
+++ b/.changeset/timeout-error-message.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Restore the `Effect.timeout` error message so `TimeoutError` includes the elapsed duration.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -3704,8 +3704,8 @@ export const timeoutOrElse: {
 )
 
 /** @internal */
-const timeoutErrorFromDuration = (duration: Duration.Input): TimeoutError =>
-  new TimeoutError(`Operation timed out after '${Duration.format(Duration.fromInputUnsafe(duration))}'`)
+const timeoutErrorFromDuration = (duration: Duration.Duration): TimeoutError =>
+  new TimeoutError(`Operation timed out after '${Duration.format(duration)}'`)
 
 /** @internal */
 export const timeout: {
@@ -3723,11 +3723,13 @@ export const timeout: {
   <A, E, R>(
     self: Effect.Effect<A, E, R>,
     duration: Duration.Input
-  ): Effect.Effect<A, E | TimeoutError, R> =>
-    timeoutOrElse(self, {
-      duration,
-      orElse: () => fail(timeoutErrorFromDuration(duration))
+  ): Effect.Effect<A, E | TimeoutError, R> => {
+    const decoded = Duration.fromInputUnsafe(duration)
+    return timeoutOrElse(self, {
+      duration: decoded,
+      orElse: () => fail(timeoutErrorFromDuration(decoded))
     })
+  }
 )
 
 /** @internal */

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -3704,6 +3704,10 @@ export const timeoutOrElse: {
 )
 
 /** @internal */
+const timeoutErrorFromDuration = (duration: Duration.Input): TimeoutError =>
+  new TimeoutError(`Operation timed out after '${Duration.format(Duration.fromInputUnsafe(duration))}'`)
+
+/** @internal */
 export const timeout: {
   (
     duration: Duration.Input
@@ -3722,7 +3726,7 @@ export const timeout: {
   ): Effect.Effect<A, E | TimeoutError, R> =>
     timeoutOrElse(self, {
       duration,
-      orElse: () => fail(new TimeoutError())
+      orElse: () => fail(timeoutErrorFromDuration(duration))
     })
 )
 

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -1515,6 +1515,21 @@ describe("Effect", () => {
   })
 
   describe("timeout", () => {
+    it.effect("timeout produces a useful error message", () =>
+      Effect.gen(function*() {
+        const duration = Duration.millis(1500)
+        const fiber = yield* Effect.never.pipe(
+          Effect.timeout(duration),
+          Effect.flip,
+          Effect.forkChild
+        )
+        yield* TestClock.adjust(Duration.millis(2000))
+        const result = yield* Fiber.join(fiber)
+        assert.include(
+          result.toString(),
+          "TimeoutError: Operation timed out after '1s 500ms'"
+        )
+      }))
     it.live("timeout a long computation", () =>
       Effect.gen(function*() {
         const result = yield* pipe(
@@ -1523,7 +1538,10 @@ describe("Effect", () => {
           Effect.timeout(10),
           Effect.flip
         )
-        assert.deepStrictEqual(result, new Cause.TimeoutError())
+        assert.deepStrictEqual(
+          result,
+          new Cause.TimeoutError("Operation timed out after '10ms'")
+        )
       }))
     it.effect("timeout interrupts the effect", () =>
       Effect.gen(function*() {
@@ -1540,7 +1558,10 @@ describe("Effect", () => {
         )
         yield* TestClock.adjust(10)
         const result = yield* Fiber.join(fiber)
-        assert.deepStrictEqual(result, new Cause.TimeoutError())
+        assert.deepStrictEqual(
+          result,
+          new Cause.TimeoutError("Operation timed out after '10ms'")
+        )
         assert.isTrue(interrupted)
       }))
   })


### PR DESCRIPTION
## Summary

- restore the v3 timeout message: `Operation timed out after '<duration>'`
- decode the duration once and format that value
- restore the `timeout produces a useful error message` test

## Testing

- `pnpm exec vitest run packages/effect/test/Effect.test.ts -t timeout`

Closes #7480