### PR TITLE
Align type IDs with module paths

### DIFF
--- a/.changeset/align-type-id-paths.md
+++ b/.changeset/align-type-id-paths.md
@@ -1,0 +1,6 @@
+---
+"effect": patch
+"@effect/opentelemetry": patch
+---
+
+Align runtime type IDs with their module paths. Effect markers now omit legacy grouping prefixes and the `unstable` path segment, while OpenTelemetry spans use the `OtelTracer` module path. Custom implementations that copy these marker strings must adopt the corrected IDs.

--- a/packages/effect/src/Chunk.ts
+++ b/packages/effect/src/Chunk.ts
@@ -31,7 +31,7 @@ import * as R from "./Result.ts"
 import type { Result } from "./Result.ts"
 import type { Covariant, NoInfer } from "./Types.ts"
 
-const TypeId = "~effect/collections/Chunk"
+const TypeId = "~effect/Chunk"
 
 /**
  * A Chunk is an immutable, ordered collection optimized for efficient concatenation and access patterns.

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -25,7 +25,7 @@ import * as Result from "./Result.ts"
 import * as String from "./String.ts"
 import type { Mutable } from "./Types.ts"
 
-const TypeId = "~effect/time/Cron"
+const TypeId = "~effect/Cron"
 
 /**
  * Represents a cron schedule with time constraints and timezone information.
@@ -435,7 +435,7 @@ const lookup = {
   }
 }
 
-const CronParseErrorTypeId = "~effect/time/Cron/CronParseError"
+const CronParseErrorTypeId = "~effect/Cron/CronParseError"
 
 /**
  * Represents an error that occurs when parsing a cron expression fails.

--- a/packages/effect/src/Crypto.ts
+++ b/packages/effect/src/Crypto.ts
@@ -14,7 +14,7 @@ import * as Effect from "./Effect.ts"
 import * as Uuid from "./internal/uuid.ts"
 import * as PlatformError from "./PlatformError.ts"
 
-const TypeId = "~effect/platform/Crypto"
+const TypeId = "~effect/Crypto"
 
 /**
  * Digest algorithms supported by the platform `Crypto` service.

--- a/packages/effect/src/Duration.ts
+++ b/packages/effect/src/Duration.ts
@@ -23,7 +23,7 @@ import { pipeArguments } from "./Pipeable.ts"
 import { hasProperty, isNumber } from "./Predicate.ts"
 import * as Reducer from "./Reducer.ts"
 
-const TypeId = "~effect/time/Duration"
+const TypeId = "~effect/Duration"
 
 const bigint0 = BigInt(0)
 const bigint1 = BigInt(1)

--- a/packages/effect/src/Encoding.ts
+++ b/packages/effect/src/Encoding.ts
@@ -34,7 +34,7 @@ import * as Result from "./Result.ts"
  * @category type IDs
  * @since 4.0.0
  */
-export const EncodingErrorTypeId = "~effect/encoding/EncodingError" as const
+export const EncodingErrorTypeId = "~effect/Encoding/EncodingError" as const
 
 /**
  * Literal type of the `EncodingErrorTypeId` marker.

--- a/packages/effect/src/Equal.ts
+++ b/packages/effect/src/Equal.ts
@@ -52,7 +52,7 @@ import { hasProperty } from "./Predicate.ts"
  * @category symbols
  * @since 2.0.0
  */
-export const symbol = "~effect/interfaces/Equal"
+export const symbol = "~effect/Equal"
 
 /**
  * The interface for types that define their own equality logic.

--- a/packages/effect/src/FileSystem.ts
+++ b/packages/effect/src/FileSystem.ts
@@ -25,7 +25,7 @@ import type { Scope } from "./Scope.ts"
 import * as Sink from "./Sink.ts"
 import * as Stream from "./Stream.ts"
 
-const TypeId = "~effect/platform/FileSystem"
+const TypeId = "~effect/FileSystem"
 
 /**
  * Core interface for file system operations in Effect.
@@ -969,7 +969,7 @@ export const layerNoop = (fileSystem: Partial<FileSystem>): Layer.Layer<FileSyst
  * @category type IDs
  * @since 4.0.0
  */
-export const FileTypeId = "~effect/platform/FileSystem/File"
+export const FileTypeId = "~effect/FileSystem/File"
 
 /**
  * Returns `true` if a value is a `File` handle by checking for the

--- a/packages/effect/src/Hash.ts
+++ b/packages/effect/src/Hash.ts
@@ -28,7 +28,7 @@ import { hasProperty } from "./Predicate.ts"
  * @category symbols
  * @since 2.0.0
  */
-export const symbol = "~effect/interfaces/Hash"
+export const symbol = "~effect/Hash"
 
 /**
  * A type that represents an object that can be hashed.

--- a/packages/effect/src/HashRing.ts
+++ b/packages/effect/src/HashRing.ts
@@ -17,7 +17,7 @@ import type { Pipeable } from "./Pipeable.ts"
 import { hasProperty } from "./Predicate.ts"
 import * as PrimaryKey from "./PrimaryKey.ts"
 
-const TypeId = "~effect/cluster/HashRing" as const
+const TypeId = "~effect/HashRing" as const
 
 /**
  * A weighted consistent-hashing ring for assigning inputs to nodes with stable

--- a/packages/effect/src/Match.ts
+++ b/packages/effect/src/Match.ts
@@ -2072,7 +2072,7 @@ export const exhaustive: <I, F, A, Pr, Ret, Args extends Array<any>>(
 ) => [Pr] extends [never] ? [Args] extends [[]] ? (u: I) => Unify<A> : (...args: Args) => Unify<A> : Unify<A> =
   internal.exhaustive
 
-const SafeRefinementId = "~effect/match/Match/SafeRefinement"
+const SafeRefinementId = "~effect/Match/SafeRefinement"
 
 /**
  * A safe refinement that narrows types without runtime errors.

--- a/packages/effect/src/Metric.ts
+++ b/packages/effect/src/Metric.ts
@@ -1609,7 +1609,7 @@ export const CurrentMetricAttributes = Context.Reference<Metric.AttributeSet>(Cu
   defaultValue: () => ({})
 })
 
-const MetricRegistryKey = "~effect/observability/Metric/MetricRegistryKey"
+const MetricRegistryKey = "~effect/Metric/MetricRegistryKey"
 
 /**
  * Context reference for the metric registry in the current context.
@@ -1642,7 +1642,7 @@ export const MetricRegistry = Context.Reference<Map<string, Metric.Metadata<any,
   { defaultValue: () => new Map() }
 )
 
-const TypeId = "~effect/observability/Metric"
+const TypeId = "~effect/Metric"
 
 abstract class Metric$<in Input, out State> implements Metric<Input, State> {
   readonly [TypeId] = TypeId

--- a/packages/effect/src/MutableHashMap.ts
+++ b/packages/effect/src/MutableHashMap.ts
@@ -20,7 +20,7 @@ import type { Pipeable } from "./Pipeable.ts"
 import { pipeArguments } from "./Pipeable.ts"
 import { hasProperty } from "./Predicate.ts"
 
-const TypeId = "~effect/collections/MutableHashMap"
+const TypeId = "~effect/MutableHashMap"
 
 /**
  * A mutable hash map that stores key-value pairs and supports both referential

--- a/packages/effect/src/MutableHashSet.ts
+++ b/packages/effect/src/MutableHashSet.ts
@@ -17,7 +17,7 @@ import type { Pipeable } from "./Pipeable.ts"
 import { pipeArguments } from "./Pipeable.ts"
 import { hasProperty } from "./Predicate.ts"
 
-const TypeId = "~effect/collections/MutableHashSet"
+const TypeId = "~effect/MutableHashSet"
 
 /**
  * A mutable hash set for storing unique values with Effect structural equality

--- a/packages/effect/src/Option.ts
+++ b/packages/effect/src/Option.ts
@@ -33,7 +33,7 @@ import type { Covariant, NoInfer, NotFunction } from "./Types.ts"
 import type * as Unify from "./Unify.ts"
 import type * as Gen from "./Utils.ts"
 
-const TypeId = "~effect/data/Option"
+const TypeId = "~effect/Option"
 
 /**
  * The `Option` data type represents optional values. An `Option<A>` is either

--- a/packages/effect/src/Path.ts
+++ b/packages/effect/src/Path.ts
@@ -29,7 +29,7 @@ import { BadArgument } from "./PlatformError.ts"
  * @category type IDs
  * @since 4.0.0
  */
-export const TypeId = "~effect/platform/Path"
+export const TypeId = "~effect/Path"
 
 /**
  * Defines the service interface for platform-specific path manipulation.

--- a/packages/effect/src/PlatformError.ts
+++ b/packages/effect/src/PlatformError.ts
@@ -11,7 +11,7 @@
  */
 import * as Data from "./Data.ts"
 
-const TypeId = "~effect/platform/PlatformError"
+const TypeId = "~effect/PlatformError"
 
 /**
  * Error data for an invalid argument passed to a platform API.

--- a/packages/effect/src/PrimaryKey.ts
+++ b/packages/effect/src/PrimaryKey.ts
@@ -24,7 +24,7 @@ import { hasProperty } from "./Predicate.ts"
  * @category symbols
  * @since 2.0.0
  */
-export const symbol = "~effect/interfaces/PrimaryKey"
+export const symbol = "~effect/PrimaryKey"
 
 /**
  * An interface for objects that can provide a string-based primary key.

--- a/packages/effect/src/Redacted.ts
+++ b/packages/effect/src/Redacted.ts
@@ -19,7 +19,7 @@ import type { Pipeable } from "./Pipeable.ts"
 import { hasProperty, isString } from "./Predicate.ts"
 import type { Covariant } from "./Types.ts"
 
-const TypeId = "~effect/data/Redacted"
+const TypeId = "~effect/Redacted"
 
 /**
  * A wrapper for sensitive values whose string, JSON, and inspection output is

--- a/packages/effect/src/Result.ts
+++ b/packages/effect/src/Result.ts
@@ -27,7 +27,7 @@ import type { Covariant, NoInfer, NotFunction } from "./Types.ts"
 import type * as Unify from "./Unify.ts"
 import type * as Gen from "./Utils.ts"
 
-const TypeId = "~effect/data/Result"
+const TypeId = "~effect/Result"
 
 /**
  * A value that is either `Success<A, E>` or `Failure<A, E>`.

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -1143,7 +1143,7 @@ export interface Optic<out T, out Iso> extends Schema<T> {
   readonly "Rebuild": Optic<T, Iso>
 }
 
-const SchemaErrorTypeId = "~effect/SchemaError/SchemaError"
+const SchemaErrorTypeId = "~effect/Schema/SchemaError"
 
 /**
  * Error thrown or returned when schema decoding or encoding fails.

--- a/packages/effect/src/Terminal.ts
+++ b/packages/effect/src/Terminal.ts
@@ -19,7 +19,7 @@ import type * as Queue from "./Queue.ts"
 import * as Schema from "./Schema.ts"
 import type * as Scope from "./Scope.ts"
 
-const TypeId = "~effect/platform/Terminal"
+const TypeId = "~effect/Terminal"
 
 /**
  * A `Terminal` represents a command-line interface which can read input from a

--- a/packages/effect/src/TxChunk.ts
+++ b/packages/effect/src/TxChunk.ts
@@ -21,7 +21,7 @@ import { pipeArguments } from "./Pipeable.ts"
 import * as TxRef from "./TxRef.ts"
 import type { NoInfer } from "./Types.ts"
 
-const TypeId = "~effect/transactions/TxChunk"
+const TypeId = "~effect/TxChunk"
 
 /**
  * TxChunk is a transactional chunk data structure that provides Software Transactional Memory (STM)

--- a/packages/effect/src/TxDeferred.ts
+++ b/packages/effect/src/TxDeferred.ts
@@ -23,7 +23,7 @@ import type { Result } from "./Result.ts"
 import * as Res from "./Result.ts"
 import * as TxRef from "./TxRef.ts"
 
-const TypeId = "~effect/transactions/TxDeferred"
+const TypeId = "~effect/TxDeferred"
 
 /**
  * A transactional deferred is a write-once cell readable within transactions.

--- a/packages/effect/src/TxHashMap.ts
+++ b/packages/effect/src/TxHashMap.ts
@@ -23,7 +23,7 @@ import { hasProperty } from "./Predicate.ts"
 import type { Result } from "./Result.ts"
 import * as TxRef from "./TxRef.ts"
 
-const TypeId = "~effect/transactions/TxHashMap"
+const TypeId = "~effect/TxHashMap"
 
 const TxHashMapProto = {
   [TypeId]: TypeId,

--- a/packages/effect/src/TxHashSet.ts
+++ b/packages/effect/src/TxHashSet.ts
@@ -25,7 +25,7 @@ import { hasProperty, type Predicate, type Refinement } from "./Predicate.ts"
 import * as TxRef from "./TxRef.ts"
 import type { NoInfer } from "./Types.ts"
 
-const TypeId = "~effect/transactions/TxHashSet"
+const TypeId = "~effect/TxHashSet"
 
 const TxHashSetProto = {
   [TypeId]: TypeId,

--- a/packages/effect/src/TxPriorityQueue.ts
+++ b/packages/effect/src/TxPriorityQueue.ts
@@ -26,7 +26,7 @@ import { pipeArguments } from "./Pipeable.ts"
 import { hasProperty, type Predicate } from "./Predicate.ts"
 import * as TxRef from "./TxRef.ts"
 
-const TypeId = "~effect/transactions/TxPriorityQueue"
+const TypeId = "~effect/TxPriorityQueue"
 
 /**
  * A transactional priority queue backed by a sorted `Chunk`.

--- a/packages/effect/src/TxPubSub.ts
+++ b/packages/effect/src/TxPubSub.ts
@@ -21,7 +21,7 @@ import type * as Scope from "./Scope.ts"
 import * as TxQueue from "./TxQueue.ts"
 import * as TxRef from "./TxRef.ts"
 
-const TypeId = "~effect/transactions/TxPubSub"
+const TypeId = "~effect/TxPubSub"
 
 /**
  * A TxPubSub represents a transactional publish/subscribe hub that broadcasts messages

--- a/packages/effect/src/TxQueue.ts
+++ b/packages/effect/src/TxQueue.ts
@@ -59,9 +59,9 @@ export type State<_A, E> =
     readonly cause: Cause.Cause<E>
   }
 
-const EnqueueTypeId = "~effect/transactions/TxQueue/Enqueue"
-const DequeueTypeId = "~effect/transactions/TxQueue/Dequeue"
-const TypeId = "~effect/transactions/TxQueue"
+const EnqueueTypeId = "~effect/TxQueue/Enqueue"
+const DequeueTypeId = "~effect/TxQueue/Dequeue"
+const TypeId = "~effect/TxQueue"
 
 /**
  * Namespace containing type definitions for TxEnqueue variance annotations.

--- a/packages/effect/src/TxReentrantLock.ts
+++ b/packages/effect/src/TxReentrantLock.ts
@@ -21,7 +21,7 @@ import { hasProperty } from "./Predicate.ts"
 import type * as Scope from "./Scope.ts"
 import * as TxRef from "./TxRef.ts"
 
-const TypeId = "~effect/transactions/TxReentrantLock"
+const TypeId = "~effect/TxReentrantLock"
 
 /**
  * @category models

--- a/packages/effect/src/TxRef.ts
+++ b/packages/effect/src/TxRef.ts
@@ -17,7 +17,7 @@ import { pipeArguments } from "./Pipeable.ts"
 import type { Pipeable } from "./Pipeable.ts"
 import type { NoInfer } from "./Types.ts"
 
-const TypeId = "~effect/transactions/TxRef"
+const TypeId = "~effect/TxRef"
 
 /**
  * TxRef is a transactional value, it can be read and modified within the body of a transaction.

--- a/packages/effect/src/TxSemaphore.ts
+++ b/packages/effect/src/TxSemaphore.ts
@@ -19,7 +19,7 @@ import { hasProperty } from "./Predicate.ts"
 import type * as Scope from "./Scope.ts"
 import * as TxRef from "./TxRef.ts"
 
-const TypeId = "~effect/transactions/TxSemaphore"
+const TypeId = "~effect/TxSemaphore"
 
 /**
  * A transactional semaphore that manages permits using Software Transactional

--- a/packages/effect/src/TxSubscriptionRef.ts
+++ b/packages/effect/src/TxSubscriptionRef.ts
@@ -22,7 +22,7 @@ import * as TxPubSub from "./TxPubSub.ts"
 import * as TxQueue from "./TxQueue.ts"
 import * as TxRef from "./TxRef.ts"
 
-const TypeId = "~effect/transactions/TxSubscriptionRef"
+const TypeId = "~effect/TxSubscriptionRef"
 
 /**
  * A TxSubscriptionRef is a transactional reference that allows subscribing to all

--- a/packages/effect/src/internal/arbitrary/runner.ts
+++ b/packages/effect/src/internal/arbitrary/runner.ts
@@ -23,7 +23,7 @@ import * as Model from "./model.ts"
 import * as Compiler from "./schema.ts"
 
 /** @internal */
-export const TypeId = "~effect/unstable/arbitrary/Arbitrary"
+export const TypeId = "~effect/arbitrary/Arbitrary"
 
 type FailureTag = PropertyFailure<unknown>["_tag"]
 

--- a/packages/effect/src/internal/dateTime.ts
+++ b/packages/effect/src/internal/dateTime.ts
@@ -17,10 +17,10 @@ import type { Mutable } from "../Types.ts"
 import * as effect from "./effect.ts"
 
 /** @internal */
-export const TypeId = "~effect/time/DateTime"
+export const TypeId = "~effect/DateTime"
 
 /** @internal */
-export const TimeZoneTypeId = "~effect/time/DateTime/TimeZone"
+export const TimeZoneTypeId = "~effect/DateTime/TimeZone"
 
 const Proto = {
   [TypeId]: TypeId,

--- a/packages/effect/src/internal/graph.ts
+++ b/packages/effect/src/internal/graph.ts
@@ -7,7 +7,7 @@ import { pipeArguments } from "../Pipeable.ts"
 import { hasProperty } from "../Predicate.ts"
 
 /** @internal */
-export const TypeId = "~effect/collections/Graph"
+export const TypeId = "~effect/Graph"
 
 /** @internal */
 export interface GraphImpl<in out N, in out E, T extends Graph.Kind>

--- a/packages/effect/src/internal/hashMap.ts
+++ b/packages/effect/src/internal/hashMap.ts
@@ -16,7 +16,7 @@ import * as Result from "../Result.ts"
 import type { NoInfer } from "../Types.ts"
 
 /** @internal */
-export const HashMapTypeId = "~effect/collections/HashMap"
+export const HashMapTypeId = "~effect/HashMap"
 
 /** @internal */
 export type HashMapTypeId = typeof HashMapTypeId

--- a/packages/effect/src/internal/hashSet.ts
+++ b/packages/effect/src/internal/hashSet.ts
@@ -13,7 +13,7 @@ import { hasProperty } from "../Predicate.ts"
 import * as HashMap from "./hashMap.ts"
 
 /** @internal */
-export const HashSetTypeId = "~effect/collections/HashSet"
+export const HashSetTypeId = "~effect/HashSet"
 
 /** @internal */
 export type HashSetTypeId = typeof HashSetTypeId

--- a/packages/effect/src/internal/matcher.ts
+++ b/packages/effect/src/internal/matcher.ts
@@ -17,7 +17,7 @@ import * as Result from "../Result.ts"
 import type { Unify } from "../Unify.ts"
 
 /** @internal */
-export const TypeId = "~effect/match/Match/Matcher"
+export const TypeId = "~effect/Match/Matcher"
 
 /** @internal */
 export type Contextual<P, Fallback> = [P] extends [never] ? Fallback : P

--- a/packages/effect/src/internal/option.ts
+++ b/packages/effect/src/internal/option.ts
@@ -10,7 +10,7 @@ import { hasProperty } from "../Predicate.ts"
 import { SingleShotGen } from "../Utils.ts"
 import { PipeInspectableProto } from "./core.ts"
 
-const TypeId = "~effect/data/Option"
+const TypeId = "~effect/Option"
 
 const CommonProto = {
   [TypeId]: {

--- a/packages/effect/src/internal/result.ts
+++ b/packages/effect/src/internal/result.ts
@@ -10,7 +10,7 @@ import { SingleShotGen } from "../Utils.ts"
 import { PipeInspectableProto } from "./core.ts"
 import * as option from "./option.ts"
 
-const TypeId = "~effect/data/Result"
+const TypeId = "~effect/Result"
 
 const CommonProto = {
   [TypeId]: {

--- a/packages/effect/src/internal/trie.ts
+++ b/packages/effect/src/internal/trie.ts
@@ -12,7 +12,7 @@ import type * as TR from "../Trie.ts"
 import type { NoInfer } from "../Types.ts"
 
 /** @internal */
-export const TrieTypeId = "~effect/collections/Trie"
+export const TrieTypeId = "~effect/Trie"
 
 type TraversalMap<K, V, A> = (k: K, v: V) => A
 

--- a/packages/effect/src/unstable/ai/AiError.ts
+++ b/packages/effect/src/unstable/ai/AiError.ts
@@ -22,7 +22,7 @@ import * as Schema from "../../Schema.ts"
 import type * as HttpClientError from "../http/HttpClientError.ts"
 import { HttpRequestDetails, HttpResponseDetails } from "./Response.ts"
 
-const ReasonTypeId = "~effect/unstable/ai/AiError/Reason" as const
+const ReasonTypeId = "~effect/ai/AiError/Reason" as const
 
 const providerMetadataWithDefaults = <Metadata extends ProviderMetadata>() =>
   (ProviderMetadata as unknown as typeof ProviderMetadata & Schema.Schema<Metadata>).pipe(
@@ -1452,7 +1452,7 @@ export const AiErrorReason: Schema.Union<[
 // Top-Level AiError
 // =============================================================================
 
-const TypeId = "~effect/unstable/ai/AiError/AiError" as const
+const TypeId = "~effect/ai/AiError" as const
 
 /**
  * Schema for the top-level AI error wrapper using the `reason` pattern.

--- a/packages/effect/src/unstable/ai/Prompt.ts
+++ b/packages/effect/src/unstable/ai/Prompt.ts
@@ -1785,7 +1785,7 @@ export const Message: Schema.Codec<Message, MessageEncoded> = Schema.Union([
 // Prompt
 // =============================================================================
 
-const TypeId = "~effect/unstable/ai/Prompt" as const
+const TypeId = "~effect/ai/Prompt" as const
 
 /**
  * Type guard to check if a value is a Prompt.

--- a/packages/effect/src/unstable/ai/Response.ts
+++ b/packages/effect/src/unstable/ai/Response.ts
@@ -19,7 +19,7 @@ import * as SchemaTransformation from "../../SchemaTransformation.ts"
 import type * as Tool from "./Tool.ts"
 import type * as Toolkit from "./Toolkit.ts"
 
-const PartTypeId = "~effect/ai/Content/Part" as const
+const PartTypeId = "~effect/ai/Response/Part" as const
 
 // =============================================================================
 // All Parts
@@ -627,7 +627,7 @@ export interface TextPartMetadata extends ProviderMetadata {}
 export const TextPart: Schema.Struct<{
   readonly type: Schema.tag<"text">
   readonly text: Schema.String
-  readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
+  readonly "~effect/ai/Response/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Response/Part">>
   readonly metadata: Schema.withDecodingDefault<
     Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
   >
@@ -686,7 +686,7 @@ export interface TextStartPartMetadata extends ProviderMetadata {}
 export const TextStartPart: Schema.Struct<{
   readonly type: Schema.tag<"text-start">
   readonly id: Schema.String
-  readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
+  readonly "~effect/ai/Response/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Response/Part">>
   readonly metadata: Schema.withDecodingDefault<
     Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
   >
@@ -754,7 +754,7 @@ export const TextDeltaPart: Schema.Struct<{
   readonly type: Schema.tag<"text-delta">
   readonly id: Schema.String
   readonly delta: Schema.String
-  readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
+  readonly "~effect/ai/Response/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Response/Part">>
   readonly metadata: Schema.withDecodingDefault<
     Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
   >
@@ -813,7 +813,7 @@ export interface TextEndPartMetadata extends ProviderMetadata {}
 export const TextEndPart: Schema.Struct<{
   readonly type: Schema.tag<"text-end">
   readonly id: Schema.String
-  readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
+  readonly "~effect/ai/Response/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Response/Part">>
   readonly metadata: Schema.withDecodingDefault<
     Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
   >
@@ -885,7 +885,7 @@ export interface ReasoningPartMetadata extends ProviderMetadata {}
 export const ReasoningPart: Schema.Struct<{
   readonly type: Schema.tag<"reasoning">
   readonly text: Schema.String
-  readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
+  readonly "~effect/ai/Response/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Response/Part">>
   readonly metadata: Schema.withDecodingDefault<
     Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
   >
@@ -944,7 +944,7 @@ export interface ReasoningStartPartMetadata extends ProviderMetadata {}
 export const ReasoningStartPart: Schema.Struct<{
   readonly type: Schema.tag<"reasoning-start">
   readonly id: Schema.String
-  readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
+  readonly "~effect/ai/Response/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Response/Part">>
   readonly metadata: Schema.withDecodingDefault<
     Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
   >
@@ -1012,7 +1012,7 @@ export const ReasoningDeltaPart: Schema.Struct<{
   readonly type: Schema.tag<"reasoning-delta">
   readonly id: Schema.String
   readonly delta: Schema.String
-  readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
+  readonly "~effect/ai/Response/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Response/Part">>
   readonly metadata: Schema.withDecodingDefault<
     Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
   >
@@ -1071,7 +1071,7 @@ export interface ReasoningEndPartMetadata extends ProviderMetadata {}
 export const ReasoningEndPart: Schema.Struct<{
   readonly type: Schema.tag<"reasoning-end">
   readonly id: Schema.String
-  readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
+  readonly "~effect/ai/Response/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Response/Part">>
   readonly metadata: Schema.withDecodingDefault<
     Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
   >
@@ -1154,7 +1154,7 @@ export const ToolParamsStartPart: Schema.Struct<{
   readonly id: Schema.String
   readonly name: Schema.String
   readonly providerExecuted: Schema.withDecodingDefaultKey<Schema.Boolean>
-  readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
+  readonly "~effect/ai/Response/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Response/Part">>
   readonly metadata: Schema.withDecodingDefault<
     Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
   >
@@ -1231,7 +1231,7 @@ export const ToolParamsDeltaPart: Schema.Struct<{
   readonly type: Schema.tag<"tool-params-delta">
   readonly id: Schema.String
   readonly delta: Schema.String
-  readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
+  readonly "~effect/ai/Response/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Response/Part">>
   readonly metadata: Schema.withDecodingDefault<
     Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
   >
@@ -1298,7 +1298,7 @@ export interface ToolParamsEndPartMetadata extends ProviderMetadata {}
 export const ToolParamsEndPart: Schema.Struct<{
   readonly type: Schema.tag<"tool-params-end">
   readonly id: Schema.String
-  readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
+  readonly "~effect/ai/Response/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Response/Part">>
   readonly metadata: Schema.withDecodingDefault<
     Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
   >
@@ -1415,7 +1415,7 @@ export const ToolCallPart: <const Name extends string, Params extends Schema.Con
     readonly name: Schema.Literal<Name>
     readonly params: Params
     readonly providerExecuted: Schema.withDecodingDefaultKey<Schema.Boolean>
-    readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
+    readonly "~effect/ai/Response/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Response/Part">>
     readonly metadata: Schema.withDecodingDefault<
       Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
     >
@@ -1630,7 +1630,7 @@ export const ToolResultPart: <
 ) => Schema.decodeTo<
   Schema.Struct<
     {
-      readonly "~effect/ai/Content/Part": Schema.Literal<"~effect/ai/Content/Part">
+      readonly "~effect/ai/Response/Part": Schema.Literal<"~effect/ai/Response/Part">
       readonly result: Schema.Union<readonly [Success, Failure]>
       readonly providerExecuted: Schema.Boolean
       readonly metadata: Schema.$Record<
@@ -1812,7 +1812,7 @@ export const ToolApprovalRequestPart: Schema.Struct<{
   readonly type: Schema.tag<"tool-approval-request">
   readonly approvalId: Schema.String
   readonly toolCallId: Schema.String
-  readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
+  readonly "~effect/ai/Response/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Response/Part">>
   readonly metadata: Schema.withDecodingDefault<
     Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
   >
@@ -1914,7 +1914,7 @@ export const FilePart: Schema.Struct<{
   readonly type: Schema.tag<"file">
   readonly mediaType: Schema.String
   readonly data: Schema.Uint8ArrayFromBase64
-  readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
+  readonly "~effect/ai/Response/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Response/Part">>
   readonly metadata: Schema.withDecodingDefault<
     Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
   >
@@ -2024,7 +2024,7 @@ export const DocumentSourcePart: Schema.Struct<{
   readonly mediaType: Schema.String
   readonly title: Schema.String
   readonly fileName: Schema.optionalKey<Schema.String>
-  readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
+  readonly "~effect/ai/Response/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Response/Part">>
   readonly metadata: Schema.withDecodingDefault<
     Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
   >
@@ -2114,7 +2114,7 @@ export const UrlSourcePart: Schema.Struct<{
   readonly id: Schema.String
   readonly url: Schema.URLFromString
   readonly title: Schema.String
-  readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
+  readonly "~effect/ai/Response/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Response/Part">>
   readonly metadata: Schema.withDecodingDefault<
     Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
   >
@@ -2305,7 +2305,7 @@ export const ResponseMetadataPart: Schema.Struct<{
   readonly modelId: Schema.optional<Schema.String>
   readonly timestamp: Schema.optional<Schema.DateTimeUtcFromString>
   readonly request: Schema.optional<typeof HttpRequestDetails>
-  readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
+  readonly "~effect/ai/Response/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Response/Part">>
   readonly metadata: Schema.withDecodingDefault<
     Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
   >
@@ -2531,7 +2531,7 @@ export const FinishPart: Schema.Struct<{
   ]>
   readonly usage: typeof Usage
   readonly response: Schema.optional<typeof HttpResponseDetails>
-  readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
+  readonly "~effect/ai/Response/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Response/Part">>
   readonly metadata: Schema.withDecodingDefault<
     Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
   >
@@ -2606,7 +2606,7 @@ export interface ErrorPartMetadata extends ProviderMetadata {}
 export const ErrorPart: Schema.Struct<{
   readonly type: Schema.tag<"error">
   readonly error: Schema.Unknown
-  readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
+  readonly "~effect/ai/Response/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Response/Part">>
   readonly metadata: Schema.withDecodingDefault<
     Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
   >

--- a/packages/effect/src/unstable/arbitrary/Arbitrary.ts
+++ b/packages/effect/src/unstable/arbitrary/Arbitrary.ts
@@ -29,7 +29,7 @@ export const TypeId: TypeId = Internal.TypeId
  * @category type IDs
  * @since 4.0.0
  */
-export type TypeId = "~effect/unstable/arbitrary/Arbitrary"
+export type TypeId = "~effect/arbitrary/Arbitrary"
 
 /**
  * Represents a pure description of values that can be generated and shrunk.

--- a/packages/effect/src/unstable/persistence/PersistedQueue.ts
+++ b/packages/effect/src/unstable/persistence/PersistedQueue.ts
@@ -202,7 +202,7 @@ export const layer: Layer.Layer<
  * @category type IDs
  * @since 4.0.0
  */
-export const ErrorTypeId: ErrorTypeId = "~@effect/experimental/PersistedQueue/PersistedQueueError"
+export const ErrorTypeId: ErrorTypeId = "~effect/persistence/PersistedQueue/PersistedQueueError"
 
 /**
  * Type-level identifier used to brand `PersistedQueueError` values.
@@ -210,7 +210,7 @@ export const ErrorTypeId: ErrorTypeId = "~@effect/experimental/PersistedQueue/Pe
  * @category type IDs
  * @since 4.0.0
  */
-export type ErrorTypeId = "~@effect/experimental/PersistedQueue/PersistedQueueError"
+export type ErrorTypeId = "~effect/persistence/PersistedQueue/PersistedQueueError"
 
 /**
  * Error raised by persisted queue store operations.

--- a/packages/effect/src/unstable/persistence/RateLimiter.ts
+++ b/packages/effect/src/unstable/persistence/RateLimiter.ts
@@ -370,7 +370,7 @@ export function sleep(self: RateLimiter, options?: {
  * @category type IDs
  * @since 4.0.0
  */
-export const ErrorTypeId: ErrorTypeId = "~@effect/experimental/RateLimiter/RateLimiterError"
+export const ErrorTypeId: ErrorTypeId = "~effect/persistence/RateLimiter/RateLimiterError"
 
 /**
  * Type-level identifier used to brand `RateLimiterError` values.
@@ -378,7 +378,7 @@ export const ErrorTypeId: ErrorTypeId = "~@effect/experimental/RateLimiter/RateL
  * @category type IDs
  * @since 4.0.0
  */
-export type ErrorTypeId = "~@effect/experimental/RateLimiter/RateLimiterError"
+export type ErrorTypeId = "~effect/persistence/RateLimiter/RateLimiterError"
 
 /**
  * Error reason for a rate-limit check that exceeded the configured limit.

--- a/packages/effect/src/unstable/process/ChildProcess.ts
+++ b/packages/effect/src/unstable/process/ChildProcess.ts
@@ -21,7 +21,7 @@ import type * as Sink from "../../Sink.ts"
 import type * as Stream from "../../Stream.ts"
 import { type ChildProcessHandle, ChildProcessSpawner } from "./ChildProcessSpawner.ts"
 
-const TypeId = "~effect/unstable/process/ChildProcess"
+const TypeId = "~effect/process/ChildProcess"
 
 /**
  * A command that can be built using `make`, combined using `pipeTo`, and executed using `exec` or `spawn`.

--- a/packages/effect/src/unstable/process/ChildProcessSpawner.ts
+++ b/packages/effect/src/unstable/process/ChildProcessSpawner.ts
@@ -68,7 +68,7 @@ export const ProcessId: Brand.Constructor<ProcessId> = Brand.nominal<ProcessId>(
  */
 export type Reref = Effect.Effect<void, PlatformError.PlatformError>
 
-const HandleTypeId = "~effect/ChildProcessSpawner/ChildProcessHandle"
+const HandleTypeId = "~effect/process/ChildProcessSpawner/ChildProcessHandle"
 
 /**
  * A handle to a running child process.

--- a/packages/effect/src/unstable/reactivity/Hydration.ts
+++ b/packages/effect/src/unstable/reactivity/Hydration.ts
@@ -21,7 +21,7 @@ import type * as AtomRegistry from "./AtomRegistry.ts"
  * @since 4.0.0
  */
 export interface DehydratedAtom {
-  readonly "~effect/reactivity/DehydratedAtom": true
+  readonly "~effect/reactivity/Hydration/DehydratedAtom": true
 }
 
 /**
@@ -90,7 +90,7 @@ export const dehydrate = (
     }
 
     arr.push({
-      "~effect/reactivity/DehydratedAtom": true,
+      "~effect/reactivity/Hydration/DehydratedAtom": true,
       key: key as string,
       value: encodedValue,
       dehydratedAt: now,

--- a/packages/effect/src/unstable/rpc/RpcMessage.ts
+++ b/packages/effect/src/unstable/rpc/RpcMessage.ts
@@ -206,7 +206,7 @@ export type FromServerEncoded =
  * @category type IDs
  * @since 4.0.0
  */
-export const ResponseIdTypeId = "~effect//rpc/RpcServer/ResponseId"
+export const ResponseIdTypeId = "~effect/rpc/RpcMessage/ResponseId"
 
 /**
  * The literal type of the `ResponseId` brand identifier.

--- a/packages/effect/src/unstable/sql/Statement.ts
+++ b/packages/effect/src/unstable/sql/Statement.ts
@@ -25,7 +25,7 @@ import type * as Tracer from "../../Tracer.ts"
 import type { Acquirer, Borrower, Connection, Row } from "./SqlConnection.ts"
 import type { SqlError } from "./SqlError.ts"
 
-const FragmentTypeId = "~effect/sql/Fragment"
+const FragmentTypeId = "~effect/sql/Statement/Fragment"
 
 /**
  * Composable SQL fragment represented as low-level segments that can be

--- a/packages/effect/test/Crypto.test.ts
+++ b/packages/effect/test/Crypto.test.ts
@@ -25,6 +25,13 @@ const makeCrypto = (value: bigint) =>
   })
 
 describe("Crypto", () => {
+  it("uses the module path for its type ID", () => {
+    assert.strictEqual(
+      (testCrypto as unknown as Record<string, unknown>)["~effect/Crypto"],
+      "~effect/Crypto"
+    )
+  })
+
   it("supports string literal digest algorithms", () => {
     const algorithm: Crypto.DigestAlgorithm = "SHA-256"
     assert.strictEqual(algorithm, "SHA-256")

--- a/packages/effect/test/reactivity/Atom.test.ts
+++ b/packages/effect/test/reactivity/Atom.test.ts
@@ -2497,7 +2497,7 @@ describe.sequential("Atom", () => {
         { reactivityKeys: ["counter"] }
       )
       const dehydratedState: Array<Hydration.DehydratedAtomValue> = [{
-        "~effect/reactivity/DehydratedAtom": true,
+        "~effect/reactivity/Hydration/DehydratedAtom": true,
         key: "hydrated-counter",
         value: 10,
         dehydratedAt: 0

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -105,7 +105,7 @@ describe("Schema", () => {
 
       assertTrue(error instanceof Error)
       assertTrue(Schema.isSchemaError(error))
-      assertFalse(Schema.isSchemaError({ "~effect/SchemaError/SchemaError": false }))
+      assertFalse(Schema.isSchemaError({ "~effect/Schema/SchemaError": false }))
       strictEqual(error._tag, "SchemaError")
       strictEqual(error.name, "SchemaError")
       strictEqual(error.issue, result.failure)

--- a/packages/opentelemetry/src/OtelTracer.ts
+++ b/packages/opentelemetry/src/OtelTracer.ts
@@ -380,7 +380,7 @@ export const withSpanContext: {
 // Internals
 // =============================================================================
 
-const OtelSpanTypeId = "~@effect/opentelemetry/Tracer/OtelSpan"
+const OtelSpanTypeId = "~@effect/opentelemetry/OtelTracer/OtelSpan"
 
 const kindMap = {
   "internal": Otel.SpanKind.INTERNAL,


### PR DESCRIPTION
## Summary

- align Effect runtime type IDs with their module paths
- remove legacy grouping and `unstable` prefixes, and fix renamed or malformed nested markers
- align the OpenTelemetry span marker and add a release changeset

## Validation

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`
- 10 targeted Vitest files covering Crypto, Schema, reactivity, AI, persistence, process, SQL, and OpenTelemetry (858 tests)

Closes EFF-913
