### PR TITLE
Fix readonly SQLite transactions

### DIFF
--- a/.changeset/calm-readers-transact.md
+++ b/.changeset/calm-readers-transact.md
@@ -1,0 +1,7 @@
+---
+"@effect/sql-sqlite-bun": patch
+"@effect/sql-sqlite-node": patch
+---
+
+Allow read-only SQLite clients to use `withTransaction` when `PRAGMA query_only` is enabled. Writable clients continue
+to reserve the writer lock when a transaction starts.

--- a/packages/sql/sqlite-bun/src/SqliteClient.ts
+++ b/packages/sql/sqlite-bun/src/SqliteClient.ts
@@ -235,7 +235,7 @@ export const make = (
         acquirer,
         compiler,
         transactionAcquirer,
-        beginTransaction: "BEGIN IMMEDIATE",
+        beginTransaction: options.readonly === true ? "BEGIN" : "BEGIN IMMEDIATE",
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
           [ATTR_DB_SYSTEM_NAME, "sqlite"]

--- a/packages/sql/sqlite-bun/test/Client.test.ts
+++ b/packages/sql/sqlite-bun/test/Client.test.ts
@@ -62,11 +62,13 @@ describe("Client", () => {
 
       const sql = yield* SqliteClient.make({ filename, readonly: true })
       assert.deepStrictEqual(yield* sql`SELECT * FROM test`, [])
-      assert.deepStrictEqual(yield* sql.withTransaction(sql`SELECT * FROM test`), [])
 
       const error = yield* Effect.flip(sql`INSERT INTO test DEFAULT VALUES`)
       assert.strictEqual(error._tag, "SqlError")
       assert(error.reason.cause instanceof Error)
       assert.match(error.reason.cause.message, /attempt to write a readonly database/i)
+
+      yield* sql`PRAGMA query_only = ON`
+      assert.deepStrictEqual(yield* sql.withTransaction(sql`SELECT * FROM test`), [])
     }).pipe(Effect.provide(Reactivity.layer)))
 })

--- a/packages/sql/sqlite-node/src/SqliteClient.ts
+++ b/packages/sql/sqlite-node/src/SqliteClient.ts
@@ -320,7 +320,7 @@ export const make = (
         acquirer,
         compiler,
         transactionAcquirer,
-        beginTransaction: "BEGIN IMMEDIATE",
+        beginTransaction: options.readonly === true ? "BEGIN" : "BEGIN IMMEDIATE",
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
           [ATTR_DB_SYSTEM_NAME, "sqlite"]

--- a/packages/sql/sqlite-node/test/Client.test.ts
+++ b/packages/sql/sqlite-node/test/Client.test.ts
@@ -156,6 +156,7 @@ describe("Client", () => {
       )
 
       const sql = yield* SqliteClient.make({ filename, readonly: true })
+      yield* sql`PRAGMA query_only = ON`
       assert.deepStrictEqual(yield* sql.withTransaction(sql`SELECT * FROM test`), [])
     }).pipe(Effect.provide([NodeFileSystem.layer, Reactivity.layer])))
 


### PR DESCRIPTION
## Summary

- use deferred `BEGIN` for read-only Bun and Node SQLite clients
- retain `BEGIN IMMEDIATE` for writable clients
- cover `PRAGMA query_only = ON` with read-only `withTransaction` calls
- add patch changesets for both SQLite adapters

## Why

#7162 changed explicit SQLite transactions to `BEGIN IMMEDIATE` to acquire the writer lock up front and avoid read-to-write snapshot upgrade failures. That behavior is correct for writable clients, but it also applied to clients opened with `readonly: true`.

When a read-only connection enables SQLite's `PRAGMA query_only = ON`, even `withTransaction(SELECT)` then fails while opening the transaction because `BEGIN IMMEDIATE` requests a write transaction. Bun reports `SQLITE_READONLY`; Node reports SQLite error code 8.

This selects the transaction opener from the client's declared access mode. The existing contention tests continue to prove that writable transactions acquire the writer lock immediately.

Closes #7482.
