### PR TITLE
fix(cluster): never surface transient routing states for persisted messages

### DIFF
--- a/.changeset/cold-shards-continue.md
+++ b/.changeset/cold-shards-continue.md
@@ -1,0 +1,15 @@
+---
+"effect": patch
+---
+
+Transient routing states for persisted cluster messages no longer surface as errors.
+
+If an entity moves runners or is shut down before replying, the caller keeps
+waiting for the reply via message storage while the entity moves. If the local
+runner is shutting down while a caller is waiting, the call is interrupted
+instead of failing with `EntityNotAssignedToRunner`: the request is already
+durable and will be served under the next owner.
+
+Durable workflows treat such an interrupt as an abandoned run attempt: the run
+stops with nothing persisted, without running compensations or resuming the
+parent, ready to replay on the replacement runner.

--- a/packages/effect/src/unstable/cluster/ClusterSchema.ts
+++ b/packages/effect/src/unstable/cluster/ClusterSchema.ts
@@ -6,11 +6,29 @@
  *
  * @since 4.0.0
  */
+import * as Cause from "../../Cause.ts"
 import * as Context from "../../Context.ts"
-import { constFalse, constTrue, identity } from "../../Function.ts"
+import { constFalse, constTrue, constUndefined, identity } from "../../Function.ts"
 import type * as Rpc from "../rpc/Rpc.ts"
 import type { EntityId } from "./EntityId.ts"
 import type { Request } from "./Envelope.ts"
+
+/**
+ * Annotation carried by an interruption when a persisted cluster request is
+ * abandoned by its current runner and must continue under another owner.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export class Abandon extends Context.Service<Abandon, true>()("effect/cluster/ClusterSchema/Abandon") {
+  static annotation = this.context(true).pipe(
+    Context.add(Cause.StackTrace, {
+      name: "ClusterAbandon",
+      stack: constUndefined,
+      parent: undefined
+    })
+  )
+}
 
 /**
  * Annotation that marks whether a cluster request should be persisted in mailbox

--- a/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
+++ b/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
@@ -6,7 +6,6 @@
  *
  * @since 4.0.0
  */
-import * as Cause from "../../Cause.ts"
 import * as Context from "../../Context.ts"
 import * as DateTime from "../../DateTime.ts"
 import * as Duration from "../../Duration.ts"
@@ -37,6 +36,7 @@ import * as EntityAddress from "./EntityAddress.ts"
 import * as EntityId from "./EntityId.ts"
 import * as EntityType from "./EntityType.ts"
 import * as Envelope from "./Envelope.ts"
+import * as ClusterAbandon from "./internal/clusterAbandon.ts"
 import * as Message from "./Message.ts"
 import { MessageStorage } from "./MessageStorage.ts"
 import type { WithExitEncoded } from "./Reply.ts"
@@ -367,15 +367,18 @@ export const make = Effect.gen(function*() {
                 return execute(workflow.payloadSchema.make(request.payload) as object, executionId).pipe(
                   Effect.onExit((exit) => {
                     const suspendOnFailure = Context.get(workflow.annotations, Workflow.SuspendOnFailure)
-                    // An interrupt that is neither a suspend nor a durable
-                    // interrupt is an abandoned run attempt (e.g. the runner
-                    // is shutting down): do not resume the parent, but still
-                    // allow a pending durable interrupt to take effect.
-                    const abandoned = exit._tag === "Failure" &&
-                      Cause.hasInterruptsOnly(exit.cause) &&
+                    // An annotated cluster abandonment means this owner can no
+                    // longer finish the run. Do not resume the parent, but
+                    // still allow a pending durable interrupt to take effect.
+                    instance.abandoned ||= exit._tag === "Failure" && ClusterAbandon.isCause(exit.cause)
+                    if (instance.abandoned) {
+                      instance.suspended = false
+                    }
+                    if (
                       !instance.suspended &&
-                      !instance.interrupted
-                    if (!instance.suspended && !abandoned && !(suspendOnFailure && exit._tag === "Failure")) {
+                      !instance.abandoned &&
+                      !(suspendOnFailure && exit._tag === "Failure")
+                    ) {
                       return parent ? ensureSuccess(sendResumeParent(parent)) : Effect.void
                     }
                     return engine.deferredResult(InterruptSignal).pipe(

--- a/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
+++ b/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
@@ -6,6 +6,7 @@
  *
  * @since 4.0.0
  */
+import * as Cause from "../../Cause.ts"
 import * as Context from "../../Context.ts"
 import * as DateTime from "../../DateTime.ts"
 import * as Duration from "../../Duration.ts"
@@ -360,15 +361,21 @@ export const make = Effect.gen(function*() {
             return {
               run: (request: Entity.Request<any>) => {
                 const instance = WorkflowEngine.WorkflowInstance.initial(workflow, executionId)
-                const payload = request.payload as any
-                let parent: { workflowName: string; executionId: string } | undefined
-                if (payload[payloadParentKey]) {
-                  parent = payload[payloadParentKey]
-                }
-                return execute(workflow.payloadSchema.make(payload) as object, executionId).pipe(
+                const parent = (request.payload as any)[payloadParentKey] as
+                  | { workflowName: string; executionId: string }
+                  | undefined
+                return execute(workflow.payloadSchema.make(request.payload) as object, executionId).pipe(
                   Effect.onExit((exit) => {
                     const suspendOnFailure = Context.get(workflow.annotations, Workflow.SuspendOnFailure)
-                    if (!instance.suspended && !(suspendOnFailure && exit._tag === "Failure")) {
+                    // An interrupt that is neither a suspend nor a durable
+                    // interrupt is an abandoned run attempt (e.g. the runner
+                    // is shutting down): do not resume the parent, but still
+                    // allow a pending durable interrupt to take effect.
+                    const abandoned = exit._tag === "Failure" &&
+                      Cause.hasInterruptsOnly(exit.cause) &&
+                      !instance.suspended &&
+                      !instance.interrupted
+                    if (!instance.suspended && !abandoned && !(suspendOnFailure && exit._tag === "Failure")) {
                       return parent ? ensureSuccess(sendResumeParent(parent)) : Effect.void
                     }
                     return engine.deferredResult(InterruptSignal).pipe(

--- a/packages/effect/src/unstable/cluster/MessageStorage.ts
+++ b/packages/effect/src/unstable/cluster/MessageStorage.ts
@@ -121,8 +121,16 @@ export class MessageStorage extends Context.Service<MessageStorage, {
 
   /**
    * Unregister the reply handlers for the specified ShardId.
+   *
+   * By default the waiters are resumed with `EntityNotAssignedToRunner`, so
+   * they can re-route the wait. With `interrupt: true` the waiters are
+   * interrupted instead, for when the runner is shutting down and the reply
+   * can never be observed here.
    */
-  readonly unregisterShardReplyHandlers: (shardId: ShardId.ShardId) => Effect.Effect<void>
+  readonly unregisterShardReplyHandlers: (
+    shardId: ShardId.ShardId,
+    options?: { readonly interrupt?: boolean | undefined }
+  ) => Effect.Effect<void>
 
   /**
    * Retrieves the unprocessed messages for the specified shards.
@@ -551,7 +559,7 @@ export const make = (
             ))
           }
         }),
-      unregisterShardReplyHandlers: (shardId) =>
+      unregisterShardReplyHandlers: (shardId, options) =>
         Effect.sync(() => {
           const id = shardId.toString()
           const shardSet = replyHandlersShard.get(id)
@@ -559,11 +567,13 @@ export const make = (
           replyHandlersShard.delete(id)
           shardSet.forEach((handler) => {
             replyHandlers.delete(handler.message.envelope.requestId)
-            handler.resume(Effect.fail(
-              new EntityNotAssignedToRunner({
-                address: handler.message.envelope.address
-              })
-            ))
+            handler.resume(
+              options?.interrupt ? Effect.interrupt : Effect.fail(
+                new EntityNotAssignedToRunner({
+                  address: handler.message.envelope.address
+                })
+              )
+            )
           })
         }),
       saveReply(reply) {

--- a/packages/effect/src/unstable/cluster/MessageStorage.ts
+++ b/packages/effect/src/unstable/cluster/MessageStorage.ts
@@ -28,6 +28,7 @@ import { EntityNotAssignedToRunner, MalformedMessage, type PersistenceError } fr
 import * as DeliverAt from "./DeliverAt.ts"
 import type { EntityAddress } from "./EntityAddress.ts"
 import * as Envelope from "./Envelope.ts"
+import * as ClusterAbandon from "./internal/clusterAbandon.ts"
 import * as Message from "./Message.ts"
 import * as Reply from "./Reply.ts"
 import * as ShardId from "./ShardId.ts"
@@ -124,8 +125,8 @@ export class MessageStorage extends Context.Service<MessageStorage, {
    *
    * By default the waiters are resumed with `EntityNotAssignedToRunner`, so
    * they can re-route the wait. With `interrupt: true` the waiters are
-   * interrupted instead, for when the runner is shutting down and the reply
-   * can never be observed here.
+   * interrupted with a cluster-abandon annotation instead, for when the runner
+   * is shutting down and the reply can never be observed here.
    */
   readonly unregisterShardReplyHandlers: (
     shardId: ShardId.ShardId,
@@ -568,7 +569,7 @@ export const make = (
           shardSet.forEach((handler) => {
             replyHandlers.delete(handler.message.envelope.requestId)
             handler.resume(
-              options?.interrupt ? Effect.interrupt : Effect.fail(
+              options?.interrupt ? ClusterAbandon.interrupt : Effect.fail(
                 new EntityNotAssignedToRunner({
                   address: handler.message.envelope.address
                 })

--- a/packages/effect/src/unstable/cluster/Sharding.ts
+++ b/packages/effect/src/unstable/cluster/Sharding.ts
@@ -51,6 +51,7 @@ import { make as makeEntityAddress } from "./EntityAddress.ts"
 import type { EntityId } from "./EntityId.ts"
 import { make as makeEntityId } from "./EntityId.ts"
 import * as Envelope from "./Envelope.ts"
+import * as ClusterAbandon from "./internal/clusterAbandon.ts"
 import * as EntityManager from "./internal/entityManager.ts"
 import { EntityReaper } from "./internal/entityReaper.ts"
 import { hashString } from "./internal/hash.ts"
@@ -1124,7 +1125,7 @@ const make = Effect.gen(function*() {
             // longer observe the reply, so interrupt the caller instead: the
             // request will be served under the next owner.
             ? message._tag === "OutgoingRequest"
-              ? Effect.interrupt
+              ? ClusterAbandon.interrupt
               : Effect.fail(error)
             : Effect.logWarning("Persisting outgoing message abandoned during shutdown", message.envelope.address)
         )

--- a/packages/effect/src/unstable/cluster/Sharding.ts
+++ b/packages/effect/src/unstable/cluster/Sharding.ts
@@ -317,7 +317,13 @@ const make = Effect.gen(function*() {
       for (const shardId of shardIds) {
         MutableHashSet.remove(releasingShards, shardId)
         MutableHashSet.remove(forceReleasingShards, shardId)
-        yield* storage.unregisterShardReplyHandlers(shardId)
+        // During shutdown, parked waiters are interrupted: this runner will
+        // never observe the reply. During a rebalance the waiters are resumed
+        // with `EntityNotAssignedToRunner`, and the client falls back to
+        // waiting for the reply via storage while the entity moves.
+        yield* storage.unregisterShardReplyHandlers(shardId, {
+          interrupt: MutableRef.get(isShutdown)
+        })
       }
     })
     const retryShardRelease =
@@ -1113,7 +1119,13 @@ const make = Effect.gen(function*() {
       return Effect.catchTag(persist, "MalformedMessage", Effect.die).pipe(
         Effect.andThen(
           shouldFail
-            ? Effect.fail(error)
+            // The message is durable, so a transient routing state is never an
+            // error for the caller. The runner is tearing down and can no
+            // longer observe the reply, so interrupt the caller instead: the
+            // request will be served under the next owner.
+            ? message._tag === "OutgoingRequest"
+              ? Effect.interrupt
+              : Effect.fail(error)
             : Effect.logWarning("Persisting outgoing message abandoned during shutdown", message.envelope.address)
         )
       )

--- a/packages/effect/src/unstable/cluster/internal/clusterAbandon.ts
+++ b/packages/effect/src/unstable/cluster/internal/clusterAbandon.ts
@@ -1,0 +1,14 @@
+import type * as Cause from "../../../Cause.ts"
+import * as Effect from "../../../Effect.ts"
+import * as Fiber from "../../../Fiber.ts"
+import { Abandon } from "../ClusterSchema.ts"
+
+export const interrupt: Effect.Effect<never> = Effect.interruptible(
+  Effect.callback<never>(() => {
+    const fiber = Fiber.getCurrent()!
+    fiber.interruptUnsafe(fiber.id, Abandon.annotation)
+  })
+)
+
+export const isCause = (cause: Cause.Cause<unknown>): boolean =>
+  cause.reasons.some((reason) => reason._tag === "Interrupt" && reason.annotations.has(Abandon.key))

--- a/packages/effect/src/unstable/workflow/Workflow.ts
+++ b/packages/effect/src/unstable/workflow/Workflow.ts
@@ -671,6 +671,11 @@ export const intoResult = <A, E, R>(
       Effect.interruptible,
       suspendOnFailure
         ? Effect.catchCause((cause) => {
+          // An interrupt that is neither a suspend nor a durable interrupt is
+          // an abandoned run attempt, which replays instead of suspending.
+          if (Cause.hasInterruptsOnly(cause) && !instance.suspended && !instance.interrupted) {
+            return Effect.failCause(cause)
+          }
           instance.suspended = true
           if (!Cause.hasInterruptsOnly(cause)) {
             instance.cause = Cause.die(Cause.squash(cause))
@@ -688,10 +693,18 @@ export const intoResult = <A, E, R>(
           )
           const hasInterruptsOnly = interrupts.length === cause.reasons.length
           const filtered = reasons.length === 0 ? cause : Cause.fromReasons(reasons)
-          return instance.suspended && hasInterruptsOnly
-            ? Effect.succeed(new Suspended({ cause: instance.cause }))
-            : (!instance.interrupted && hasInterruptsOnly) ||
-                (!captureDefects && Cause.hasDies(cause))
+          if (instance.suspended && hasInterruptsOnly) {
+            return Effect.succeed(new Suspended({ cause: instance.cause }))
+          }
+          if (!instance.interrupted && hasInterruptsOnly) {
+            // The run attempt was abandoned (e.g. the runner is shutting
+            // down). Release owner-local resources without running durable
+            // workflow finalizers, and exit without a result so the run can
+            // replay elsewhere.
+            instance.replaying = true
+            return Effect.failCause(filtered as Cause.Cause<never>)
+          }
+          return !captureDefects && Cause.hasDies(cause)
             ? Effect.failCause(filtered as Cause.Cause<never>)
             : Effect.succeed(new Complete({ exit: Exit.failCause(filtered) }))
         }
@@ -804,9 +817,12 @@ export const addFinalizer: <R>(
 > = Effect.fnUntraced(function*<R>(
   f: (exit: Exit.Exit<unknown, unknown>) => Effect.Effect<void, never, R>
 ) {
-  const scope = (yield* InstanceTag).scope
+  const instance = yield* InstanceTag
   const services = yield* Effect.context<R>()
-  yield* Scope.addFinalizerExit(scope, (exit) => Effect.provideContext(f(exit), services))
+  yield* Scope.addFinalizerExit(
+    instance.scope,
+    (exit) => instance.replaying ? Effect.void : Effect.provideContext(f(exit), services)
+  )
 })
 
 /**

--- a/packages/effect/src/unstable/workflow/Workflow.ts
+++ b/packages/effect/src/unstable/workflow/Workflow.ts
@@ -701,7 +701,7 @@ export const intoResult = <A, E, R>(
             // down). Release owner-local resources without running durable
             // workflow finalizers, and exit without a result so the run can
             // replay elsewhere.
-            instance.replaying = true
+            instance.abandoned = true
             return Effect.failCause(filtered as Cause.Cause<never>)
           }
           return !captureDefects && Cause.hasDies(cause)
@@ -821,7 +821,7 @@ export const addFinalizer: <R>(
   const services = yield* Effect.context<R>()
   yield* Scope.addFinalizerExit(
     instance.scope,
-    (exit) => instance.replaying ? Effect.void : Effect.provideContext(f(exit), services)
+    (exit) => instance.abandoned ? Effect.void : Effect.provideContext(f(exit), services)
   )
 })
 

--- a/packages/effect/src/unstable/workflow/Workflow.ts
+++ b/packages/effect/src/unstable/workflow/Workflow.ts
@@ -671,9 +671,7 @@ export const intoResult = <A, E, R>(
       Effect.interruptible,
       suspendOnFailure
         ? Effect.catchCause((cause) => {
-          // An interrupt that is neither a suspend nor a durable interrupt is
-          // an abandoned run attempt, which replays instead of suspending.
-          if (Cause.hasInterruptsOnly(cause) && !instance.suspended && !instance.interrupted) {
+          if (instance.abandoned) {
             return Effect.failCause(cause)
           }
           instance.suspended = true
@@ -693,15 +691,16 @@ export const intoResult = <A, E, R>(
           )
           const hasInterruptsOnly = interrupts.length === cause.reasons.length
           const filtered = reasons.length === 0 ? cause : Cause.fromReasons(reasons)
-          if (instance.suspended && hasInterruptsOnly) {
+          const abandoned = instance.abandoned && !instance.interrupted && hasInterruptsOnly
+          instance.abandoned = abandoned
+          if (instance.suspended && hasInterruptsOnly && !abandoned) {
             return Effect.succeed(new Suspended({ cause: instance.cause }))
           }
           if (!instance.interrupted && hasInterruptsOnly) {
-            // The run attempt was abandoned (e.g. the runner is shutting
-            // down). Release owner-local resources without running durable
-            // workflow finalizers, and exit without a result so the run can
-            // replay elsewhere.
-            instance.abandoned = true
+            // External interrupts exit without a result. When the cluster has
+            // marked this attempt abandoned, owner-local resources are
+            // released without running durable workflow finalizers so the run
+            // can replay elsewhere.
             return Effect.failCause(filtered as Cause.Cause<never>)
           }
           return !captureDefects && Cause.hasDies(cause)
@@ -802,8 +801,13 @@ export const provideScope = <A, E, R>(
  * Adds an exit finalizer to the current workflow scope, preserving the
  * services available when the finalizer is registered.
  *
+ * **Details**
+ *
  * Body-level `Effect.onExit` finalizers cannot observe a deposited workflow
  * interrupt. Use this function for terminal-state work that must observe it.
+ * Finalizers are skipped when a cluster owner abandons a run attempt for
+ * replay; owner-local scope finalizers registered with {@link provideScope}
+ * still run.
  *
  * @category resource management
  * @since 4.0.0

--- a/packages/effect/src/unstable/workflow/WorkflowEngine.ts
+++ b/packages/effect/src/unstable/workflow/WorkflowEngine.ts
@@ -256,9 +256,9 @@ export class WorkflowInstance extends Context.Service<
     interrupted: boolean
 
     /**
-     * Whether the workflow scope is being closed for replay rather than completion.
+     * Whether the current workflow run has been abandoned.
      */
-    replaying: boolean
+    abandoned: boolean
 
     /**
      * When SuspendOnFailure is triggered, the cause of the failure is stored
@@ -286,7 +286,7 @@ export class WorkflowInstance extends Context.Service<
       scope,
       suspended: false,
       interrupted: false,
-      replaying: false,
+      abandoned: false,
       cause: undefined,
       awaitedDeferreds: new Set(),
       activityState: {

--- a/packages/effect/src/unstable/workflow/WorkflowEngine.ts
+++ b/packages/effect/src/unstable/workflow/WorkflowEngine.ts
@@ -256,6 +256,11 @@ export class WorkflowInstance extends Context.Service<
     interrupted: boolean
 
     /**
+     * Whether the workflow scope is being closed for replay rather than completion.
+     */
+    replaying: boolean
+
+    /**
      * When SuspendOnFailure is triggered, the cause of the failure is stored
      * here.
      */
@@ -281,6 +286,7 @@ export class WorkflowInstance extends Context.Service<
       scope,
       suspended: false,
       interrupted: false,
+      replaying: false,
       cause: undefined,
       awaitedDeferreds: new Set(),
       activityState: {

--- a/packages/effect/src/unstable/workflow/WorkflowEngine.ts
+++ b/packages/effect/src/unstable/workflow/WorkflowEngine.ts
@@ -256,7 +256,9 @@ export class WorkflowInstance extends Context.Service<
     interrupted: boolean
 
     /**
-     * Whether the current workflow run has been abandoned.
+     * Whether the current workflow run has been abandoned for replay. When
+     * `true`, callbacks registered with `Workflow.addFinalizer` are skipped as
+     * the owner-local scope closes.
      */
     abandoned: boolean
 

--- a/packages/effect/test/cluster/MessageStorage.test.ts
+++ b/packages/effect/test/cluster/MessageStorage.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "@effect/vitest"
-import { Context, Effect, Exit, Fiber, Latch, Layer, Option, Schema } from "effect"
+import { assert, describe, expect, it } from "@effect/vitest"
+import { Cause, Context, Effect, Exit, Fiber, Latch, Layer, Option, Schema } from "effect"
 import { TestClock } from "effect/testing"
 import {
+  ClusterError,
+  ClusterSchema,
   EntityAddress,
   EntityId,
   EntityType,
@@ -206,6 +208,49 @@ describe("MessageStorage", () => {
         yield* storage.saveReply(yield* makeReply(request))
         yield* latch.await
         yield* Fiber.await(fiber)
+      }).pipe(Effect.provide(MemoryLayer)))
+
+    it.effect("unregisterShardReplyHandlers fails parked waiters during rebalance", () =>
+      Effect.gen(function*() {
+        const storage = yield* MessageStorage.MessageStorage
+        const request = yield* makeRequest()
+        const fiber = yield* storage.registerReplyHandler(
+          new Message.OutgoingRequest({
+            ...request,
+            respond: () => Effect.void
+          })
+        ).pipe(Effect.forkChild({ startImmediately: true }))
+        yield* TestClock.adjust(1)
+
+        yield* storage.unregisterShardReplyHandlers(request.envelope.address.shardId)
+        const exit = yield* Fiber.await(fiber)
+
+        assert(Exit.isFailure(exit))
+        const error = Cause.findErrorOption(exit.cause)
+        assert(Option.isSome(error))
+        assert(error.value instanceof ClusterError.EntityNotAssignedToRunner)
+      }).pipe(Effect.provide(MemoryLayer)))
+
+    it.effect("unregisterShardReplyHandlers annotates parked waiters during shutdown", () =>
+      Effect.gen(function*() {
+        const storage = yield* MessageStorage.MessageStorage
+        const request = yield* makeRequest()
+        const fiber = yield* storage.registerReplyHandler(
+          new Message.OutgoingRequest({
+            ...request,
+            respond: () => Effect.void
+          })
+        ).pipe(Effect.forkChild({ startImmediately: true }))
+        yield* TestClock.adjust(1)
+
+        yield* storage.unregisterShardReplyHandlers(request.envelope.address.shardId, { interrupt: true })
+        const exit = yield* Fiber.await(fiber)
+
+        assert(Exit.isFailure(exit))
+        assert(Cause.hasInterruptsOnly(exit.cause))
+        assert(exit.cause.reasons.some((reason) =>
+          reason._tag === "Interrupt" && reason.annotations.has(ClusterSchema.Abandon.key)
+        ))
       }).pipe(Effect.provide(MemoryLayer)))
 
     it.effect("reply handlers receive the persisted defect fallback for unencodable replies", () =>

--- a/packages/effect/test/cluster/Sharding.test.ts
+++ b/packages/effect/test/cluster/Sharding.test.ts
@@ -1364,9 +1364,19 @@ describe("Sharding shard lock failover", () => {
   it.effect("keeps the graceful timeout for normal shard reassignment", () =>
     Effect.gen(function*() {
       const storageState = makeFailoverStorageState()
+      const unregisterInterrupts: Array<boolean> = []
       const runnerStorage = Layer.effect(
         RunnerStorage.RunnerStorage,
         Effect.map(Clock.Clock, (clock) => makeFailoverStorage(storageState, clock))
+      )
+      const shardingLayer = Sharding.layer.pipe(
+        Layer.updateService(MessageStorage.MessageStorage, (storage) => ({
+          ...storage,
+          unregisterShardReplyHandlers: (shardId, options) =>
+            Effect.sync(() => unregisterInterrupts.push(options?.interrupt ?? false)).pipe(
+              Effect.andThen(storage.unregisterShardReplyHandlers(shardId, options))
+            )
+        }))
       )
       const config = ShardingConfig.layer({
         runnerAddress: Option.some(RunnerAddress.make("localhost", 1234)),
@@ -1379,7 +1389,7 @@ describe("Sharding shard lock failover", () => {
         sendRetryInterval: 10
       })
       const layer = TestEntityNoState.pipe(
-        Layer.provideMerge(Sharding.layer),
+        Layer.provideMerge(shardingLayer),
         Layer.provide(runnerStorage),
         Layer.provide(RunnerHealth.layerNoop),
         Layer.provideMerge(TestEntityState.layer),
@@ -1422,6 +1432,7 @@ describe("Sharding shard lock failover", () => {
         const entityExit = entityFiber.pollUnsafe()
         assert(entityExit && Exit.hasInterrupts(entityExit))
         assert.strictEqual(storageState.releaseCalls.length, 1)
+        assert.deepStrictEqual(unregisterInterrupts, [false])
       }).pipe(Effect.provide(layer), Effect.scoped)
     }))
 

--- a/packages/effect/test/cluster/Sharding.test.ts
+++ b/packages/effect/test/cluster/Sharding.test.ts
@@ -299,9 +299,16 @@ describe.concurrent("Sharding", () => {
           assert(!Exit.hasDies(completed.value), "finalizer defected instead of failing cleanly")
           const exit = yield* Deferred.await(requestExit)
           assert(Exit.isFailure(exit), "request succeeded instead of failing during shutdown")
-          const failure = Cause.findErrorOption(exit.cause)
-          assert(Option.isSome(failure), "request did not fail with a typed error")
-          assert(failure.value instanceof ClusterError.EntityNotAssignedToRunner)
+          if (persisted) {
+            // A persisted request is durable, so a transient routing state is
+            // not an error: the caller is interrupted instead, and the request
+            // is served under the next owner.
+            assert(Cause.hasInterruptsOnly(exit.cause), "persisted request was not interrupted")
+          } else {
+            const failure = Cause.findErrorOption(exit.cause)
+            assert(Option.isSome(failure), "request did not fail with a typed error")
+            assert(failure.value instanceof ClusterError.EntityNotAssignedToRunner)
+          }
           assert.strictEqual(driver.journal.length, persisted ? 1 : 0)
         }),
       20_000

--- a/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
+++ b/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Exit, Fiber, Layer, Option, Ref, Schema, Scope } from "effect"
+import { Effect, Exit, Fiber, Latch, Layer, Option, Ref, Schema, Scope } from "effect"
 import { TestClock } from "effect/testing"
 import { DurableDeferred, Workflow, WorkflowEngine } from "effect/unstable/workflow"
 
@@ -142,6 +142,40 @@ describe("WorkflowEngine", () => {
       yield* Scope.close(scope, Exit.void)
       const exit = yield* Fiber.await(fiber)
       assert(Exit.hasInterrupts(exit))
+    }))
+
+  it.effect("layerMemory runs compensations when the engine is shut down", () =>
+    Effect.gen(function*() {
+      const ready = Latch.makeUnsafe()
+      const compensated: Array<string> = []
+      const Stuck = Workflow.make("WorkflowEngine/ShutdownCompensation", {
+        payload: { id: Schema.String },
+        idempotencyKey: ({ id }) => id
+      })
+      const layer = Stuck.toLayer(() =>
+        Effect.gen(function*() {
+          yield* Effect.succeed("a").pipe(
+            Stuck.withCompensation((value) => Effect.sync(() => compensated.push(value)))
+          )
+          ready.openUnsafe()
+          return yield* Effect.never
+        })
+      ).pipe(
+        Layer.provideMerge(WorkflowEngine.layerMemory)
+      )
+      const scope = yield* Scope.make()
+      const context = yield* Scope.provide(Layer.build(layer), scope)
+      const fiber = yield* Stuck.execute({ id: "one" }).pipe(
+        Effect.provideContext(context),
+        Effect.forkChild({ startImmediately: true })
+      )
+      yield* ready.await
+
+      yield* Scope.close(scope, Exit.void)
+      const exit = yield* Fiber.await(fiber)
+
+      assert(Exit.hasInterrupts(exit))
+      assert.deepStrictEqual(compensated, ["a"])
     }))
 
   it.effect("layerMemory closes finalizers registered before suspension", () =>

--- a/packages/platform/node/test/cluster-integration/Entity.test.ts
+++ b/packages/platform/node/test/cluster-integration/Entity.test.ts
@@ -1,6 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Cause, Clock, Effect, Exit, Fiber, Latch, Layer, Option, PrimaryKey, Schema, Scope } from "effect"
-import { ClusterError, ClusterSchema, Entity, EntityResource, Singleton } from "effect/unstable/cluster"
+import { ClusterSchema, Entity, EntityResource, Singleton } from "effect/unstable/cluster"
 import { Rpc } from "effect/unstable/rpc"
 import { type Backend, type ClusterRunner, make } from "./harness.ts"
 
@@ -153,7 +153,7 @@ const findIdsByRunner = Effect.fnUntraced(function*(
 
 describe("cluster entity integration", () => {
   for (const backend of ["pg", "mysql"] satisfies ReadonlyArray<Backend>) {
-    it.live(`${backend}: fails an unroutable reply during runner shutdown without hanging teardown`, () =>
+    it.live(`${backend}: interrupts an unroutable reply during runner shutdown without hanging teardown`, () =>
       Effect.gen(function*() {
         const finalizerEntered = Latch.makeUnsafe()
         const sendReply = Latch.makeUnsafe()
@@ -193,11 +193,12 @@ describe("cluster entity integration", () => {
         sendReply.openUnsafe()
         yield* Fiber.join(stopping)
 
+        // The request is durable, so the caller is interrupted rather than
+        // failed: the send is not an error, this runner just cannot observe
+        // the reply.
         assert.isDefined(requestExit)
         assert(Exit.isFailure(requestExit!))
-        const failure = Cause.findErrorOption(requestExit!.cause)
-        assert(Option.isSome(failure))
-        assert(failure.value instanceof ClusterError.EntityNotAssignedToRunner)
+        assert(Cause.hasInterruptsOnly(requestExit!.cause))
       }))
 
     for (const persisted of [false, true] as const) {
@@ -571,6 +572,7 @@ describe("cluster entity integration", () => {
         orderGate.openUnsafe()
         assert.strictEqual(yield* Fiber.join(request), 1)
         yield* Fiber.join(stopping)
+        yield* cluster.waitForStableAssignments()
 
         const killId = `kill-${backend}`
         const killed = yield* cluster.ownerOfEntity(StateEntity, killId)

--- a/packages/platform/node/test/cluster-integration/Entity.test.ts
+++ b/packages/platform/node/test/cluster-integration/Entity.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Cause, Clock, Effect, Exit, Fiber, Latch, Layer, Option, PrimaryKey, Schema, Scope } from "effect"
+import { Cause, Clock, Effect, Exit, Fiber, Latch, Layer, PrimaryKey, Schema, Scope } from "effect"
 import { ClusterSchema, Entity, EntityResource, Singleton } from "effect/unstable/cluster"
 import { Rpc } from "effect/unstable/rpc"
 import { type Backend, type ClusterRunner, make } from "./harness.ts"

--- a/packages/platform/node/test/cluster-integration/Workflow.test.ts
+++ b/packages/platform/node/test/cluster-integration/Workflow.test.ts
@@ -1,6 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Cause, Clock, Duration, Effect, Exit, Fiber, Latch, Layer, Option, Schema } from "effect"
-import { ClusterWorkflowEngine, Entity, EntityId } from "effect/unstable/cluster"
+import { ClusterWorkflowEngine, Entity, EntityId, Sharding } from "effect/unstable/cluster"
 import { PersistedQueue } from "effect/unstable/persistence"
 import { Rpc } from "effect/unstable/rpc"
 import {
@@ -277,6 +277,137 @@ const InterruptWorkflow = Workflow.make("ClusterIntegrationInterrupt", {
 })
 
 const InterruptWorkflowLayer = InterruptWorkflow.toLayer(() => DurableDeferred.await(InterruptGate))
+
+const ShutdownActivityWorkflow = Workflow.make("ClusterIntegrationShutdownActivity", {
+  payload: { id: Schema.String },
+  success: Schema.String,
+  idempotencyKey: ({ id }) => id
+})
+
+const ShutdownSuspendActivityWorkflow = Workflow.make("ClusterIntegrationShutdownSuspendActivity", {
+  payload: { id: Schema.String },
+  success: Schema.String,
+  idempotencyKey: ({ id }) => id
+}).annotate(Workflow.SuspendOnFailure, true)
+
+const activityHandoffState = {
+  ready: Latch.makeUnsafe(),
+  start: Latch.makeUnsafe(),
+  faultArmed: false,
+  persisted: Latch.makeUnsafe(),
+  faultRelease: Latch.makeUnsafe(true),
+  runs: new Map<string, number>(),
+  compensations: new Set<string>(),
+  resourceEvents: new Map<string, Array<"acquire" | "release">>()
+}
+
+const resetActivityHandoffState = (id: string) => {
+  activityHandoffState.ready = Latch.makeUnsafe()
+  activityHandoffState.start = Latch.makeUnsafe()
+  activityHandoffState.faultArmed = false
+  activityHandoffState.persisted = Latch.makeUnsafe()
+  activityHandoffState.runs.delete(id)
+  activityHandoffState.compensations.delete(id)
+  activityHandoffState.resourceEvents.set(id, [])
+}
+
+const ShutdownActivityWorkflowLayer = ShutdownActivityWorkflow.toLayer(({ id }) =>
+  Effect.gen(function*() {
+    yield* Effect.succeed(id).pipe(
+      ShutdownActivityWorkflow.withCompensation(() => Effect.sync(() => activityHandoffState.compensations.add(id)))
+    )
+    yield* Effect.acquireRelease(
+      Effect.sync(() => activityHandoffState.resourceEvents.get(id)!.push("acquire")),
+      () => Effect.sync(() => activityHandoffState.resourceEvents.get(id)!.push("release"))
+    ).pipe(Workflow.provideScope)
+    activityHandoffState.ready.openUnsafe()
+    yield* activityHandoffState.start.await
+    return yield* Activity.make({
+      name: "ShutdownActivity",
+      success: Schema.String,
+      execute: Effect.sync(() => {
+        activityHandoffState.runs.set(id, (activityHandoffState.runs.get(id) ?? 0) + 1)
+        return `completed:${id}`
+      })
+    })
+  })
+)
+
+const ShutdownSuspendActivityWorkflowLayer = ShutdownSuspendActivityWorkflow.toLayer(({ id }) =>
+  Effect.gen(function*() {
+    yield* Effect.succeed(id).pipe(
+      ShutdownSuspendActivityWorkflow.withCompensation(() =>
+        Effect.sync(() => activityHandoffState.compensations.add(id))
+      )
+    )
+    yield* Effect.acquireRelease(
+      Effect.sync(() => activityHandoffState.resourceEvents.get(id)!.push("acquire")),
+      () => Effect.sync(() => activityHandoffState.resourceEvents.get(id)!.push("release"))
+    ).pipe(Workflow.provideScope)
+    activityHandoffState.ready.openUnsafe()
+    yield* activityHandoffState.start.await
+    return yield* Activity.make({
+      name: "ShutdownActivity",
+      success: Schema.String,
+      execute: Effect.sync(() => {
+        activityHandoffState.runs.set(id, (activityHandoffState.runs.get(id) ?? 0) + 1)
+        return `completed:${id}`
+      })
+    })
+  })
+)
+
+const ActivityHandoffShardingLayer = Layer.effect(
+  Sharding.Sharding,
+  Effect.gen(function*() {
+    const sharding = yield* Sharding.Sharding
+    return Sharding.Sharding.of({
+      ...sharding,
+      makeClient: (entity) =>
+        // The wrapped factory returns the same dynamic RPC client shape, but
+        // its generic relationship to the entity protocol is no longer visible.
+        Effect.map(sharding.makeClient(entity), (makeClient) => (entityId: string) => {
+          // RPC clients expose their protocol methods dynamically, so the
+          // Proxy type cannot retain this client's generated method shape.
+          return new Proxy(makeClient(entityId), {
+            get(target, property, receiver) {
+              if (property !== "activity") return Reflect.get(target, property, receiver)
+              const activity = Reflect.get(target, property, receiver) as (
+                payload: { readonly name: string },
+                options?: object
+              ) => Effect.Effect<unknown, unknown, unknown>
+              return (payload: { readonly name: string }, options?: object) => {
+                if (!activityHandoffState.faultArmed) {
+                  return activity(payload, options)
+                }
+                activityHandoffState.faultArmed = false
+                // Mirror sendOutgoing's persisted abandon branch during a
+                // runner shutdown: accept the durable request, then interrupt
+                // the caller because this runner can never observe the reply.
+                return activity(payload, { ...options, discard: true }).pipe(
+                  Effect.tap(() => activityHandoffState.persisted.open),
+                  Effect.andThen(activityHandoffState.faultRelease.await),
+                  Effect.andThen(Effect.interrupt)
+                )
+              }
+            }
+          }) as any
+        }) as any
+    })
+  })
+)
+
+const ShutdownActivityEntities = Layer.mergeAll(
+  ShutdownActivityWorkflowLayer,
+  ShutdownSuspendActivityWorkflowLayer
+).pipe(
+  Layer.provide(Layer.effect(
+    WorkflowEngine.WorkflowEngine,
+    ClusterWorkflowEngine.make
+  )),
+  Layer.provide(ActivityHandoffShardingLayer),
+  Layer.orDie
+)
 
 const CompleteDeferred = Rpc.make("CompleteDeferred", {
   payload: {
@@ -719,6 +850,127 @@ describe("cluster workflow integration", () => {
         assert(Exit.isFailure(result.exit))
         assert.isTrue(Exit.hasInterrupts(result.exit))
         assert.isTrue(Cause.hasInterrupts(result.exit.cause))
+      }))
+
+    it.live(`${backend}: replays a persisted activity handoff without leaking workflow resources`, () =>
+      Effect.gen(function*() {
+        const cluster = yield* make({ backend, entities: ShutdownActivityEntities })
+        yield* cluster.start(3)
+        yield* cluster.waitForStableAssignments()
+        for (
+          const [suffix, workflow] of [
+            ["default", ShutdownActivityWorkflow],
+            ["suspend-on-failure", ShutdownSuspendActivityWorkflow]
+          ] as const
+        ) {
+          const id = `${backend}-shutdown-activity-${suffix}`
+          resetActivityHandoffState(id)
+          const executionId = yield* withWorkflow(
+            cluster,
+            workflow.execute({ id }, { discard: true })
+          )
+          yield* cluster.waitUntil(
+            "The shutdown activity workflow did not start",
+            Effect.as(activityHandoffState.ready.await, true)
+          )
+
+          activityHandoffState.faultArmed = true
+          activityHandoffState.start.openUnsafe()
+
+          const result = yield* waitForComplete(cluster, workflow, executionId)
+          assert.isTrue(activityHandoffState.persisted.isOpen())
+          assert.deepStrictEqual(result.exit, Exit.succeed(`completed:${id}`))
+          assert.strictEqual(activityHandoffState.runs.get(id), 1)
+          assert.isFalse(activityHandoffState.compensations.has(id))
+          assert.deepStrictEqual(activityHandoffState.resourceEvents.get(id), [
+            "acquire",
+            "release",
+            "acquire",
+            "release"
+          ])
+        }
+      }))
+
+    it.live(`${backend}: preserves a safe interrupt during a persisted activity handoff`, () => {
+      activityHandoffState.faultRelease = Latch.makeUnsafe()
+      return Effect.gen(function*() {
+        const id = `${backend}-shutdown-activity-interrupt`
+        resetActivityHandoffState(id)
+        const cluster = yield* make({ backend, entities: ShutdownActivityEntities })
+        yield* cluster.start(3)
+        yield* cluster.waitForStableAssignments()
+        const executionId = yield* withWorkflow(
+          cluster,
+          ShutdownActivityWorkflow.execute({ id }, { discard: true })
+        )
+        yield* cluster.waitUntil(
+          "The shutdown activity workflow did not start",
+          Effect.as(activityHandoffState.ready.await, true)
+        )
+
+        activityHandoffState.faultArmed = true
+        yield* withWorkflow(cluster, ShutdownActivityWorkflow.interrupt(executionId))
+        activityHandoffState.start.openUnsafe()
+        yield* cluster.waitUntil(
+          "The shutdown activity request was not persisted",
+          Effect.as(activityHandoffState.persisted.await, true)
+        )
+        yield* cluster.waitUntil(
+          "The shutdown activity request was not processed",
+          Effect.sync(() => activityHandoffState.runs.get(id) === 1)
+        )
+        activityHandoffState.faultRelease.openUnsafe()
+
+        const result = yield* waitForComplete(cluster, ShutdownActivityWorkflow, executionId)
+        assert.isTrue(Exit.isFailure(result.exit))
+        assert.isTrue(Exit.hasInterrupts(result.exit))
+      }).pipe(
+        Effect.ensuring(Effect.sync(() => {
+          activityHandoffState.faultRelease.openUnsafe()
+        }))
+      )
+    })
+
+    it.live(`${backend}: recovers a persisted activity across an actual owner handoff`, () =>
+      Effect.gen(function*() {
+        const id = `${backend}-shutdown-activity-handoff`
+        resetActivityHandoffState(id)
+        const cluster = yield* make({
+          backend,
+          config: { entityTerminationTimeout: 100 },
+          entities: ShutdownActivityWorkflowLayer.pipe(
+            Layer.provide(ClusterWorkflowEngine.layer),
+            Layer.orDie
+          )
+        })
+        yield* cluster.start(3)
+        yield* cluster.waitForStableAssignments()
+        const executionId = yield* withWorkflow(
+          cluster,
+          ShutdownActivityWorkflow.execute({ id }, { discard: true })
+        )
+        yield* cluster.waitUntil(
+          "The shutdown activity workflow did not start",
+          Effect.as(activityHandoffState.ready.await, true)
+        )
+
+        const owner = workflowOwner(cluster, executionId)
+        assert.isDefined(owner)
+        const stopping = yield* cluster.stop(owner!).pipe(Effect.forkChild({ startImmediately: true }))
+        activityHandoffState.start.openUnsafe()
+        yield* cluster.waitUntil(
+          "The shutdown activity workflow was not handed to another runner",
+          Effect.sync(() => {
+            const nextOwner = workflowOwner(cluster, executionId)
+            return nextOwner !== undefined && nextOwner !== owner
+          })
+        )
+
+        const result = yield* waitForComplete(cluster, ShutdownActivityWorkflow, executionId)
+        yield* Fiber.join(stopping)
+        assert.deepStrictEqual(result.exit, Exit.succeed(`completed:${id}`))
+        assert.strictEqual(activityHandoffState.runs.get(id), 1)
+        assert.strictEqual((yield* cluster.messageCounts()).unprocessed, 0)
       }))
   }
 })

--- a/packages/platform/node/test/cluster-integration/Workflow.test.ts
+++ b/packages/platform/node/test/cluster-integration/Workflow.test.ts
@@ -1,6 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Cause, Clock, Duration, Effect, Exit, Fiber, Latch, Layer, Option, Schema } from "effect"
-import { ClusterWorkflowEngine, Entity, EntityId, Sharding } from "effect/unstable/cluster"
+import { ClusterSchema, ClusterWorkflowEngine, Entity, EntityId, Sharding } from "effect/unstable/cluster"
 import { PersistedQueue } from "effect/unstable/persistence"
 import { Rpc } from "effect/unstable/rpc"
 import {
@@ -301,11 +301,17 @@ const activityHandoffState = {
   resourceEvents: new Map<string, Array<"acquire" | "release">>()
 }
 
-const resetActivityHandoffState = (id: string) => {
+const abandon = Effect.interruptible(Effect.callback<never>(() => {
+  const fiber = Fiber.getCurrent()!
+  fiber.interruptUnsafe(fiber.id, ClusterSchema.Abandon.annotation)
+}))
+
+const resetActivityHandoffState = (id: string, options?: { readonly faultReleaseOpen?: boolean }) => {
   activityHandoffState.ready = Latch.makeUnsafe()
   activityHandoffState.start = Latch.makeUnsafe()
   activityHandoffState.faultArmed = false
   activityHandoffState.persisted = Latch.makeUnsafe()
+  activityHandoffState.faultRelease = Latch.makeUnsafe(options?.faultReleaseOpen ?? true)
   activityHandoffState.runs.delete(id)
   activityHandoffState.compensations.delete(id)
   activityHandoffState.resourceEvents.set(id, [])
@@ -387,7 +393,7 @@ const ActivityHandoffShardingLayer = Layer.effect(
                 return activity(payload, { ...options, discard: true }).pipe(
                   Effect.tap(() => activityHandoffState.persisted.open),
                   Effect.andThen(activityHandoffState.faultRelease.await),
-                  Effect.andThen(Effect.interrupt)
+                  Effect.andThen(abandon)
                 )
               }
             }
@@ -891,11 +897,10 @@ describe("cluster workflow integration", () => {
         }
       }))
 
-    it.live(`${backend}: preserves a safe interrupt during a persisted activity handoff`, () => {
-      activityHandoffState.faultRelease = Latch.makeUnsafe()
-      return Effect.gen(function*() {
+    it.live(`${backend}: preserves a safe interrupt during a persisted activity handoff`, () =>
+      Effect.gen(function*() {
         const id = `${backend}-shutdown-activity-interrupt`
-        resetActivityHandoffState(id)
+        resetActivityHandoffState(id, { faultReleaseOpen: false })
         const cluster = yield* make({ backend, entities: ShutdownActivityEntities })
         yield* cluster.start(3)
         yield* cluster.waitForStableAssignments()
@@ -924,12 +929,12 @@ describe("cluster workflow integration", () => {
         const result = yield* waitForComplete(cluster, ShutdownActivityWorkflow, executionId)
         assert.isTrue(Exit.isFailure(result.exit))
         assert.isTrue(Exit.hasInterrupts(result.exit))
+        assert.isTrue(activityHandoffState.compensations.has(id))
       }).pipe(
         Effect.ensuring(Effect.sync(() => {
           activityHandoffState.faultRelease.openUnsafe()
         }))
-      )
-    })
+      ))
 
     it.live(`${backend}: recovers a persisted activity across an actual owner handoff`, () =>
       Effect.gen(function*() {


### PR DESCRIPTION
Sharding can persist a request and then fail the caller with `EntityNotAssignedToRunner` during a runner shutdown. For durable workflows this converted a transient routing state into a terminal `Complete(Failure(Die(...)))`, which happens frequently with rolling deployments.

This PR fixes the semantics at the layers they belong to, instead of handling the error in the workflow engine:

- **If an entity moves runners before replying, the caller keeps waiting.** This already worked (`replyFromStorage` waits are requestId-scoped, and rebalance-released waiters re-route into the storage wait) and is unchanged.
- **If the local runner is shutting down while a caller waits, the call is interrupted.** `sendOutgoing`'s abandon path persists the request and then interrupts the caller instead of failing: the message is durable, so the routing state is not an error, this runner just can never observe the reply. Shard release during shutdown now interrupts parked reply waiters for the same reason (`unregisterShardReplyHandlers` gains an `interrupt` option); rebalance release keeps the resume-with-error so re-routing still works. `AckChunk` abandons still fail, since a stream cannot resume under a new owner.
- **A workflow stops with nothing persisted, ready to resume elsewhere.** `Workflow.intoResult` treats an interrupt that is neither a suspend nor a durable interrupt as an abandoned run attempt: it releases owner-local resources without running durable finalizers (compensations), does not resume the parent, and exits with the interrupt cause so no reply is stored. The unanswered run request is then replayed by the replacement owner through the entityManager's existing no-reply-on-interrupt rule.

### Before

```mermaid
stateDiagram-v2
  [*] --> Running
  Running --> ActivityPersisted: Start activity
  ActivityPersisted --> HandoffError: Owner shuts down
  HandoffError --> TerminalFailure: Capture routing error as defect
  TerminalFailure --> [*]

  note right of TerminalFailure
    The activity is durable,
    but its parent cannot replay.
  end note
```

### After

```mermaid
stateDiagram-v2
  [*] --> Running
  Running --> ActivityPersisted: Start activity
  ActivityPersisted --> CallerInterrupted: Owner shuts down
  CallerInterrupted --> Replayable: Abandon run, nothing persisted
  Replayable --> Running: New owner replays workflow
  Running --> Completed: Resume persisted activity
  Completed --> [*]
```

### Tests

- Cluster integration tests cover the abandoned handoff (deterministic fault injection), a durable interrupt racing a handoff, and a real owner shutdown with replay on the replacement runner, for both default and `SuspendOnFailure` workflows, asserting no compensations run and workflow-scoped resources are released exactly once per attempt.
- Two tests pinned the old error contract and now assert interruption for persisted requests; the non-persisted case still asserts `EntityNotAssignedToRunner`.
- Fixed a race in the rebalance test that surfaced now that shutdown unwinds promptly (owner read without waiting for stable assignments).

Alternative to #7464.

Closes EFF-900

_This PR was raised with support from Claude (Fable 5)._
