### PR TITLE
fix(cluster): bound teardown interrupt classification

### DIFF
--- a/.changeset/cluster-active-teardowns.md
+++ b/.changeset/cluster-active-teardowns.md
@@ -1,0 +1,10 @@
+---
+"effect": patch
+---
+
+Cluster no longer retains fiber ids for every local teardown.
+
+Transient persisted interrupts are now classified from live teardown state
+(entity, shard, singleton, entity type, and node shutdown) instead of a
+process-lifetime set of fiber ids. The registry is bounded by in-flight
+teardowns and returns to baseline after entity reap storms.

--- a/packages/effect/src/unstable/cluster/Sharding.ts
+++ b/packages/effect/src/unstable/cluster/Sharding.ts
@@ -45,7 +45,7 @@ import { AlreadyProcessingMessage, EntityNotAssignedToRunner } from "./ClusterEr
 import * as ClusterMetrics from "./ClusterMetrics.ts"
 import { Persisted } from "./ClusterSchema.ts"
 import * as ClusterSchema from "./ClusterSchema.ts"
-import type { CurrentAddress, CurrentRunnerAddress, Entity, HandlersFrom } from "./Entity.ts"
+import { CurrentAddress, type CurrentRunnerAddress, type Entity, type HandlersFrom } from "./Entity.ts"
 import type { EntityAddress } from "./EntityAddress.ts"
 import { make as makeEntityAddress } from "./EntityAddress.ts"
 import type { EntityId } from "./EntityId.ts"
@@ -55,7 +55,7 @@ import * as ClusterAbandon from "./internal/clusterAbandon.ts"
 import * as EntityManager from "./internal/entityManager.ts"
 import { EntityReaper } from "./internal/entityReaper.ts"
 import { hashString } from "./internal/hash.ts"
-import { internalInterruptors } from "./internal/interruptors.ts"
+import * as ActiveTeardown from "./internal/interruptors.ts"
 import { ResourceMap } from "./internal/resourceMap.ts"
 import { effectiveInterval } from "./internal/shardLock.ts"
 import * as Message from "./Message.ts"
@@ -1341,6 +1341,13 @@ const make = Effect.gen(function*() {
     never
   > = yield* ResourceMap.make(
     Effect.fnUntraced(function*(entity: Entity<string, any>) {
+      const clientScope = yield* Effect.scope
+      yield* Scope.addFinalizer(
+        clientScope,
+        Effect.sync(() => {
+          ActiveTeardown.releaseEntityType(entity.type)
+        })
+      )
       const client = yield* RpcClient.makeNoSerialization(entity.protocol, {
         spanPrefix: `${entity.type}.client`,
         disableTracing: !Context.get(entity.protocol.annotations, ClusterSchema.ClientTracingEnabled),
@@ -1419,8 +1426,10 @@ const make = Effect.gen(function*() {
               }
               // for durable messages, we ignore interrupts on shutdown or as a
               // result of a shard being resassigned
+              const caller = Context.getOption(entry.context, CurrentAddress).valueOrUndefined
               const isTransientInterrupt = MutableRef.get(isShutdown) ||
-                options.message.interruptors.some((id) => internalInterruptors.has(id))
+                ActiveTeardown.isActive(address) ||
+                (caller !== undefined && ActiveTeardown.isActive(caller))
               if (isTransientInterrupt && Context.get(entry.message.annotations, Persisted)) {
                 return Effect.void
               }
@@ -1443,10 +1452,9 @@ const make = Effect.gen(function*() {
       })
 
       yield* Scope.addFinalizer(
-        yield* Effect.scope,
-        Effect.withFiber((fiber) => {
-          internalInterruptors.add(fiber.id)
-          return Effect.void
+        clientScope,
+        Effect.sync(() => {
+          ActiveTeardown.acquireEntityType(entity.type)
         })
       )
 
@@ -1580,8 +1588,13 @@ const make = Effect.gen(function*() {
         const shouldBeRunning = MutableHashSet.has(acquiredShards, shardId)
         if (running && !shouldBeRunning) {
           yield* Effect.logDebug("Stopping singleton", address)
-          internalInterruptors.add(yield* Effect.fiberId)
-          yield* FiberMap.remove(singletonFibers, address)
+          yield* ActiveTeardown.aroundSingleton(
+            address,
+            ActiveTeardown.aroundShard(
+              address.shardId,
+              FiberMap.remove(singletonFibers, address)
+            )
+          )
         } else if (!running && shouldBeRunning) {
           yield* Effect.logDebug("Starting singleton", address)
           yield* FiberMap.run(singletonFibers, address, run)
@@ -1630,12 +1643,12 @@ const make = Effect.gen(function*() {
       }
       yield* Scope.addFinalizer(
         scope,
-        Effect.withFiber((fiber) => {
+        Effect.suspend(() => {
           state.status = "closing"
-          internalInterruptors.add(fiber.id)
-          // if preemptive shutdown is enabled, we start shutting down Sharding
-          // too
-          return config.preemptiveShutdown ? shutdown() : Effect.void
+          return ActiveTeardown.aroundEntityType(
+            entity.type,
+            config.preemptiveShutdown ? shutdown() : Effect.void
+          )
         })
       )
 
@@ -1717,9 +1730,7 @@ const make = Effect.gen(function*() {
       )
     }
 
-    internalInterruptors.add(yield* Effect.fiberId)
     if (isShutdown.current) return
-
     MutableRef.set(isShutdown, true)
     if (selfRunner) {
       yield* Effect.ignore(runnerStorage.unregister(selfRunner.address))

--- a/packages/effect/src/unstable/cluster/Sharding.ts
+++ b/packages/effect/src/unstable/cluster/Sharding.ts
@@ -1428,7 +1428,6 @@ const make = Effect.gen(function*() {
               // result of a shard being resassigned
               const caller = Context.getOption(entry.context, CurrentAddress).valueOrUndefined
               const isTransientInterrupt = MutableRef.get(isShutdown) ||
-                ActiveTeardown.isActive(address) ||
                 (caller !== undefined && ActiveTeardown.isActive(caller))
               if (isTransientInterrupt && Context.get(entry.message.annotations, Persisted)) {
                 return Effect.void
@@ -1588,12 +1587,9 @@ const make = Effect.gen(function*() {
         const shouldBeRunning = MutableHashSet.has(acquiredShards, shardId)
         if (running && !shouldBeRunning) {
           yield* Effect.logDebug("Stopping singleton", address)
-          yield* ActiveTeardown.aroundSingleton(
-            address,
-            ActiveTeardown.aroundShard(
-              address.shardId,
-              FiberMap.remove(singletonFibers, address)
-            )
+          yield* ActiveTeardown.aroundShard(
+            address.shardId,
+            FiberMap.remove(singletonFibers, address)
           )
         } else if (!running && shouldBeRunning) {
           yield* Effect.logDebug("Starting singleton", address)

--- a/packages/effect/src/unstable/cluster/internal/entityManager.ts
+++ b/packages/effect/src/unstable/cluster/internal/entityManager.ts
@@ -37,7 +37,7 @@ import type { Sharding } from "../Sharding.ts"
 import { ShardingConfig } from "../ShardingConfig.ts"
 import * as Snowflake from "../Snowflake.ts"
 import { EntityReaper } from "./entityReaper.ts"
-import { internalInterruptors } from "./interruptors.ts"
+import { acquireEntity, releaseEntity } from "./interruptors.ts"
 import { ResourceMap } from "./resourceMap.ts"
 import { ResourceRef } from "./resourceRef.ts"
 
@@ -167,6 +167,13 @@ export const make = Effect.fnUntraced(function*<
       closed: Latch.makeUnsafe(),
       force: Latch.makeUnsafe()
     }
+
+    yield* Scope.addFinalizer(
+      scope,
+      Effect.sync(() => {
+        releaseEntity(address)
+      })
+    )
 
     // on shutdown, reset the storage for the entity
     yield* Scope.addFinalizerExit(
@@ -356,7 +363,8 @@ export const make = Effect.fnUntraced(function*<
         }
 
         return server.write
-      })
+      }),
+      address
     )
 
     function onDefect(cause: Cause.Cause<never>): Effect.Effect<void> {
@@ -405,9 +413,9 @@ export const make = Effect.fnUntraced(function*<
     // If the termination timeout is reached, let the server clean itself up
     yield* Scope.addFinalizer(
       scope,
-      Effect.withFiber((fiber) => {
+      Effect.suspend(() => {
         activeServers.delete(address.entityId)
-        internalInterruptors.add(fiber.id)
+        acquireEntity(address)
         return Effect.raceFirst(
           state.write(0, { _tag: "Eof" }).pipe(
             Effect.andThen(endLatch.await),

--- a/packages/effect/src/unstable/cluster/internal/interruptors.ts
+++ b/packages/effect/src/unstable/cluster/internal/interruptors.ts
@@ -1,2 +1,68 @@
+import * as Effect from "../../../Effect.ts"
+import type { EntityAddress } from "../EntityAddress.ts"
+import type { ShardId } from "../ShardId.ts"
+import type { SingletonAddress } from "../SingletonAddress.ts"
+
+const counts = new Map<string, number>()
+
+const acquire = (key: string) => {
+  counts.set(key, (counts.get(key) ?? 0) + 1)
+}
+
+const release = (key: string) => {
+  const n = counts.get(key)
+  if (n === undefined) return
+  if (n <= 1) counts.delete(key)
+  else counts.set(key, n - 1)
+}
+
+const around = <A, E, R>(key: string, effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+  Effect.suspend(() => {
+    acquire(key)
+    return Effect.ensuring(effect, Effect.sync(() => release(key)))
+  })
+
+const entityKey = (address: EntityAddress): string =>
+  `entity:${address.entityType}:${address.entityId}:${address.shardId.toString()}`
+
+const shardKey = (shardId: ShardId): string => `shard:${shardId.toString()}`
+
+const singletonKey = (address: SingletonAddress): string => `singleton:${address.name}:${address.shardId.toString()}`
+
+const entityTypeKey = (entityType: string): string => `type:${entityType}`
+
 /** @internal */
-export const internalInterruptors = new Set<number>()
+export const acquireEntity = (address: EntityAddress): void => acquire(entityKey(address))
+
+/** @internal */
+export const releaseEntity = (address: EntityAddress): void => release(entityKey(address))
+
+/** @internal */
+export const acquireEntityType = (entityType: string): void => acquire(entityTypeKey(entityType))
+
+/** @internal */
+export const releaseEntityType = (entityType: string): void => release(entityTypeKey(entityType))
+
+/** @internal */
+export const aroundShard = <A, E, R>(
+  shardId: ShardId,
+  effect: Effect.Effect<A, E, R>
+): Effect.Effect<A, E, R> => around(shardKey(shardId), effect)
+
+/** @internal */
+export const aroundSingleton = <A, E, R>(
+  address: SingletonAddress,
+  effect: Effect.Effect<A, E, R>
+): Effect.Effect<A, E, R> => around(singletonKey(address), effect)
+
+/** @internal */
+export const aroundEntityType = <A, E, R>(
+  entityType: string,
+  effect: Effect.Effect<A, E, R>
+): Effect.Effect<A, E, R> => around(entityTypeKey(entityType), effect)
+
+/** @internal */
+export const isActive = (address: EntityAddress): boolean =>
+  counts.has(entityKey(address)) ||
+  counts.has(shardKey(address.shardId)) ||
+  counts.has(entityTypeKey(address.entityType))

--- a/packages/effect/src/unstable/cluster/internal/interruptors.ts
+++ b/packages/effect/src/unstable/cluster/internal/interruptors.ts
@@ -1,7 +1,6 @@
 import * as Effect from "../../../Effect.ts"
 import type { EntityAddress } from "../EntityAddress.ts"
 import type { ShardId } from "../ShardId.ts"
-import type { SingletonAddress } from "../SingletonAddress.ts"
 
 const counts = new Map<string, number>()
 
@@ -27,8 +26,6 @@ const entityKey = (address: EntityAddress): string =>
 
 const shardKey = (shardId: ShardId): string => `shard:${shardId.toString()}`
 
-const singletonKey = (address: SingletonAddress): string => `singleton:${address.name}:${address.shardId.toString()}`
-
 const entityTypeKey = (entityType: string): string => `type:${entityType}`
 
 /** @internal */
@@ -48,12 +45,6 @@ export const aroundShard = <A, E, R>(
   shardId: ShardId,
   effect: Effect.Effect<A, E, R>
 ): Effect.Effect<A, E, R> => around(shardKey(shardId), effect)
-
-/** @internal */
-export const aroundSingleton = <A, E, R>(
-  address: SingletonAddress,
-  effect: Effect.Effect<A, E, R>
-): Effect.Effect<A, E, R> => around(singletonKey(address), effect)
 
 /** @internal */
 export const aroundEntityType = <A, E, R>(

--- a/packages/effect/src/unstable/cluster/internal/resourceRef.ts
+++ b/packages/effect/src/unstable/cluster/internal/resourceRef.ts
@@ -82,38 +82,37 @@ export class ResourceRef<A, E = never> {
     const scope = Scope.makeUnsafe()
     this.latch.closeUnsafe()
     MutableRef.set(this.state, { _tag: "Acquiring", scope })
-    const close = Scope.close(prevScope, Exit.void)
     const teardownAddress = this.teardownAddress
-    if (teardownAddress) {
+    return Effect.suspend(() => {
+      const close = Scope.close(prevScope, Exit.void)
+      if (!teardownAddress) return close
       acquireEntity(teardownAddress)
-    }
-    return (teardownAddress
-      ? Effect.ensuring(close, Effect.sync(() => releaseEntity(teardownAddress)))
-      : close).pipe(
-        Effect.andThen(this.acquire(scope)),
-        Effect.flatMap((value) => {
-          if (this.state.current._tag === "Closed") {
-            return Effect.interrupt
-          }
-          MutableRef.set(this.state, { _tag: "Acquired", scope, value })
-          return this.latch.open
-        })
-      ).pipe(
-        Effect.onExit((exit) => {
-          if (Exit.isSuccess(exit)) {
-            return Effect.void
-          }
-          return Scope.close(scope, exit).pipe(
-            Effect.ensuring(Effect.sync(() => {
-              const state = this.state.current
-              if (state._tag === "Acquiring" && state.scope === scope) {
-                MutableRef.set(this.state, { _tag: "Failed", scope, cause: exit.cause })
-                this.latch.openUnsafe()
-              }
-            }))
-          )
-        })
-      )
+      return Effect.ensuring(close, Effect.sync(() => releaseEntity(teardownAddress)))
+    }).pipe(
+      Effect.andThen(this.acquire(scope)),
+      Effect.flatMap((value) => {
+        if (this.state.current._tag === "Closed") {
+          return Effect.interrupt
+        }
+        MutableRef.set(this.state, { _tag: "Acquired", scope, value })
+        return this.latch.open
+      })
+    ).pipe(
+      Effect.onExit((exit) => {
+        if (Exit.isSuccess(exit)) {
+          return Effect.void
+        }
+        return Scope.close(scope, exit).pipe(
+          Effect.ensuring(Effect.sync(() => {
+            const state = this.state.current
+            if (state._tag === "Acquiring" && state.scope === scope) {
+              MutableRef.set(this.state, { _tag: "Failed", scope, cause: exit.cause })
+              this.latch.openUnsafe()
+            }
+          }))
+        )
+      })
+    )
   }
 
   await: Effect.Effect<A, E> = Effect.suspend(() => {

--- a/packages/effect/src/unstable/cluster/internal/resourceRef.ts
+++ b/packages/effect/src/unstable/cluster/internal/resourceRef.ts
@@ -5,7 +5,8 @@ import * as Latch from "../../../Latch.ts"
 import * as MutableRef from "../../../MutableRef.ts"
 import * as Option from "../../../Option.ts"
 import * as Scope from "../../../Scope.ts"
-import { internalInterruptors } from "./interruptors.ts"
+import type { EntityAddress } from "../EntityAddress.ts"
+import { acquireEntity, releaseEntity } from "./interruptors.ts"
 
 /** @internal */
 export type State<A, E> = {
@@ -27,7 +28,8 @@ export type State<A, E> = {
 export class ResourceRef<A, E = never> {
   static from = Effect.fnUntraced(function*<A, E>(
     parentScope: Scope.Scope,
-    acquire: (scope: Scope.Scope) => Effect.Effect<A, E>
+    acquire: (scope: Scope.Scope) => Effect.Effect<A, E>,
+    teardownAddress?: EntityAddress
   ) {
     const state = MutableRef.make<State<A, E>>({ _tag: "Closed" })
 
@@ -46,17 +48,20 @@ export class ResourceRef<A, E = never> {
     const value = yield* acquire(scope)
     MutableRef.set(state, { _tag: "Acquired", scope, value })
 
-    return new ResourceRef(state, acquire)
+    return new ResourceRef(state, acquire, teardownAddress)
   })
 
   readonly state: MutableRef.MutableRef<State<A, E>>
   readonly acquire: (scope: Scope.Scope) => Effect.Effect<A, E>
+  readonly teardownAddress: EntityAddress | undefined
   constructor(
     state: MutableRef.MutableRef<State<A, E>>,
-    acquire: (scope: Scope.Scope) => Effect.Effect<A, E>
+    acquire: (scope: Scope.Scope) => Effect.Effect<A, E>,
+    teardownAddress?: EntityAddress
   ) {
     this.state = state
     this.acquire = acquire
+    this.teardownAddress = teardownAddress
   }
 
   latch = Latch.makeUnsafe(true)
@@ -77,34 +82,38 @@ export class ResourceRef<A, E = never> {
     const scope = Scope.makeUnsafe()
     this.latch.closeUnsafe()
     MutableRef.set(this.state, { _tag: "Acquiring", scope })
-    return Effect.withFiber((fiber) => {
-      internalInterruptors.add(fiber.id)
-      return Scope.close(prevScope, Exit.void)
-    }).pipe(
-      Effect.andThen(this.acquire(scope)),
-      Effect.flatMap((value) => {
-        if (this.state.current._tag === "Closed") {
-          return Effect.interrupt
-        }
-        MutableRef.set(this.state, { _tag: "Acquired", scope, value })
-        return this.latch.open
-      })
-    ).pipe(
-      Effect.onExit((exit) => {
-        if (Exit.isSuccess(exit)) {
-          return Effect.void
-        }
-        return Scope.close(scope, exit).pipe(
-          Effect.ensuring(Effect.sync(() => {
-            const state = this.state.current
-            if (state._tag === "Acquiring" && state.scope === scope) {
-              MutableRef.set(this.state, { _tag: "Failed", scope, cause: exit.cause })
-              this.latch.openUnsafe()
-            }
-          }))
-        )
-      })
-    )
+    const close = Scope.close(prevScope, Exit.void)
+    const teardownAddress = this.teardownAddress
+    if (teardownAddress) {
+      acquireEntity(teardownAddress)
+    }
+    return (teardownAddress
+      ? Effect.ensuring(close, Effect.sync(() => releaseEntity(teardownAddress)))
+      : close).pipe(
+        Effect.andThen(this.acquire(scope)),
+        Effect.flatMap((value) => {
+          if (this.state.current._tag === "Closed") {
+            return Effect.interrupt
+          }
+          MutableRef.set(this.state, { _tag: "Acquired", scope, value })
+          return this.latch.open
+        })
+      ).pipe(
+        Effect.onExit((exit) => {
+          if (Exit.isSuccess(exit)) {
+            return Effect.void
+          }
+          return Scope.close(scope, exit).pipe(
+            Effect.ensuring(Effect.sync(() => {
+              const state = this.state.current
+              if (state._tag === "Acquiring" && state.scope === scope) {
+                MutableRef.set(this.state, { _tag: "Failed", scope, cause: exit.cause })
+                this.latch.openUnsafe()
+              }
+            }))
+          )
+        })
+      )
   }
 
   await: Effect.Effect<A, E> = Effect.suspend(() => {

--- a/packages/effect/test/cluster/ResourceRef.test.ts
+++ b/packages/effect/test/cluster/ResourceRef.test.ts
@@ -1,5 +1,7 @@
 import { assert, it } from "@effect/vitest"
 import { Deferred, Effect, Exit, Fiber, Option, Scope } from "effect"
+import { EntityAddress, EntityId, EntityType, ShardId } from "effect/unstable/cluster"
+import { isActive } from "effect/unstable/cluster/internal/interruptors"
 import { ResourceRef } from "effect/unstable/cluster/internal/resourceRef"
 
 it.live("does not wedge await after a failed rebuild", () =>
@@ -62,4 +64,44 @@ it.effect("does not let a stale rebuild overwrite a newer acquisition", () =>
     yield* Deferred.succeed(newerAcquire, void 0)
     yield* Fiber.join(newerRebuild)
     assert.strictEqual(yield* ref.await, 2)
+  })))
+
+it.effect("does not leak teardown membership when a rebuild is discarded", () =>
+  Effect.scoped(Effect.gen(function*() {
+    const parentScope = yield* Effect.scope
+    const address = EntityAddress.make({
+      shardId: ShardId.make("resource-ref-discard", 1),
+      entityType: EntityType.make("ResourceRefDiscard"),
+      entityId: EntityId.make("1")
+    })
+    const ref = yield* ResourceRef.from(parentScope, () => Effect.succeed(1), address)
+    const discarded = ref.rebuildUnsafe()
+    assert.isDefined(discarded)
+    assert.isFalse(isActive(address))
+    yield* ref.rebuildUnsafe()
+    assert.isFalse(isActive(address))
+    assert.strictEqual(yield* ref.await, 1)
+  })))
+
+it.effect("does not leak teardown membership when a rebuild is interrupted", () =>
+  Effect.scoped(Effect.gen(function*() {
+    const parentScope = yield* Effect.scope
+    const address = EntityAddress.make({
+      shardId: ShardId.make("resource-ref-interrupt", 1),
+      entityType: EntityType.make("ResourceRefInterrupt"),
+      entityId: EntityId.make("1")
+    })
+    const release = yield* Deferred.make<void>()
+    const ref = yield* ResourceRef.from(
+      parentScope,
+      (scope) =>
+        Scope.addFinalizer(scope, Deferred.await(release)).pipe(
+          Effect.andThen(Effect.succeed(1))
+        ),
+      address
+    )
+    const fiber = yield* Effect.forkChild(ref.rebuildUnsafe())
+    yield* Fiber.interrupt(fiber)
+    yield* Deferred.succeed(release, void 0)
+    assert.isFalse(isActive(address))
   })))

--- a/packages/effect/test/cluster/Sharding.test.ts
+++ b/packages/effect/test/cluster/Sharding.test.ts
@@ -1242,6 +1242,33 @@ describe.concurrent("Sharding active teardowns", () => {
       assert.strictEqual(Queue.sizeUnsafe(state.interrupts), 1)
     }).pipe(Effect.provide(TestSharding)))
 
+  it.effect("forwards interrupts from an external same-node caller during entity teardown", () =>
+    Effect.gen(function*() {
+      const driver = yield* MessageStorage.MemoryDriver
+      const state = yield* TestEntityState
+      const sharding = yield* Sharding.Sharding
+      const makeClient = yield* TestEntity.client
+      yield* TestClock.adjust(1)
+      const entityId = EntityId.make("external-teardown")
+      const client = makeClient("external-teardown")
+      const address = EntityAddress.make({
+        shardId: sharding.getShardId(entityId, "default"),
+        entityType: EntityType.make(TestEntity.type),
+        entityId
+      })
+
+      const fiber = yield* client.Never().pipe(Effect.forkChild({ startImmediately: true }))
+      yield* TestClock.adjust(1)
+      ActiveTeardown.acquireEntity(address)
+      yield* Fiber.interrupt(fiber).pipe(
+        Effect.ensuring(Effect.sync(() => ActiveTeardown.releaseEntity(address)))
+      )
+      yield* TestClock.adjust(1)
+
+      assert.strictEqual(journalInterrupts(driver), 1)
+      assert.strictEqual(Queue.sizeUnsafe(state.interrupts), 1)
+    }).pipe(Effect.provide(TestSharding)))
+
   it.effect("returns registry size to baseline after entity reap storms", () =>
     Effect.gen(function*() {
       yield* TestClock.adjust(1)

--- a/packages/effect/test/cluster/Sharding.test.ts
+++ b/packages/effect/test/cluster/Sharding.test.ts
@@ -40,6 +40,7 @@ import {
   ShardingConfig,
   Snowflake
 } from "effect/unstable/cluster"
+import * as ActiveTeardown from "effect/unstable/cluster/internal/interruptors"
 import { Headers } from "effect/unstable/http"
 import { Rpc } from "effect/unstable/rpc"
 import {
@@ -1082,6 +1083,199 @@ describe.concurrent("Sharding", () => {
     }))
 })
 
+const ActiveTeardownCaller = Entity.make("ActiveTeardownCaller", [
+  Rpc.make("Arm").annotate(ClusterSchema.Persisted, false)
+])
+
+const ActiveTeardownCallerLayer = ActiveTeardownCaller.toLayer(Effect.gen(function*() {
+  const receiver = yield* TestEntity.client
+  yield* receiver("nested-target").Never().pipe(Effect.forkScoped)
+  return { Arm: () => Effect.void }
+}))
+
+const journalInterrupts = (driver: MessageStorage.MemoryDriver["Service"]) =>
+  driver.journal.filter((envelope) => envelope._tag === "Interrupt").length
+
+const waitForIdleReap = Effect.fnUntraced(function*(
+  sharding: { readonly activeEntityCount: Effect.Effect<number> },
+  remaining: number
+) {
+  for (let i = 0; i < 12; i++) {
+    if ((yield* sharding.activeEntityCount) <= remaining) return
+    yield* TestClock.adjust(5000)
+  }
+  assert.isAtMost(yield* sharding.activeEntityCount, remaining)
+})
+
+describe.concurrent("Sharding active teardowns", () => {
+  it.effect("swallows persisted interrupts from an idle-reaped nested proxy call", () =>
+    Effect.gen(function*() {
+      yield* TestClock.adjust(1)
+      const driver = yield* MessageStorage.MemoryDriver
+      const state = yield* TestEntityState
+      const sharding = yield* Sharding.Sharding
+      const caller = (yield* ActiveTeardownCaller.client)("1")
+      yield* caller.Arm()
+      yield* TestClock.adjust(1)
+      assert.strictEqual(Queue.sizeUnsafe(state.envelopes), 1)
+      assert.strictEqual(journalInterrupts(driver), 0)
+
+      yield* waitForIdleReap(sharding, 1)
+      assert.strictEqual(Queue.sizeUnsafe(state.envelopes), 1)
+      assert.strictEqual(Queue.sizeUnsafe(state.interrupts), 0)
+      assert.strictEqual(journalInterrupts(driver), 0)
+    }).pipe(Effect.provide(ActiveTeardownSharding({ entityMaxIdleTime: 1 }))))
+
+  it.effect("swallows persisted interrupts when the caller's shard is released", () =>
+    Effect.gen(function*() {
+      const storageState = makeFailoverStorageState()
+      const runnerStorage = Layer.effect(
+        RunnerStorage.RunnerStorage,
+        Effect.map(Clock.Clock, (clock) => makeFailoverStorage(storageState, clock))
+      )
+      const layer = ActiveTeardownCallerLayer.pipe(
+        Layer.merge(TestEntityNoState),
+        Layer.provideMerge(Sharding.layer),
+        Layer.provide(runnerStorage),
+        Layer.provide(RunnerHealth.layerNoop),
+        Layer.provideMerge(TestEntityState.layer),
+        Layer.provide(Runners.layerNoop),
+        Layer.provideMerge(MessageStorage.layerMemory),
+        Layer.provide(Snowflake.layerGenerator),
+        Layer.provide(ShardingConfig.layer({
+          runnerAddress: Option.some(RunnerAddress.make("localhost", 1234)),
+          shardsPerGroup: 1,
+          entityTerminationTimeout: 0,
+          entityMessagePollInterval: 10,
+          refreshAssignmentsInterval: 10,
+          sendRetryInterval: 10
+        }))
+      )
+
+      yield* Effect.gen(function*() {
+        const driver = yield* MessageStorage.MemoryDriver
+        const state = yield* TestEntityState
+        const sharding = yield* Sharding.Sharding
+        const shardId = sharding.getShardId(EntityId.make("1"), "default")
+        while (!sharding.hasShardId(shardId)) {
+          yield* TestClock.adjust(10)
+        }
+
+        yield* (yield* ActiveTeardownCaller.client)("1").Arm()
+        yield* TestClock.adjust(1)
+        assert.strictEqual(Queue.sizeUnsafe(state.envelopes), 1)
+
+        storageState.assignSelf = false
+        while (sharding.hasShardId(shardId)) {
+          yield* TestClock.adjust(10)
+        }
+        while ((yield* sharding.activeEntityCount) > 0) {
+          yield* TestClock.adjust(1)
+        }
+
+        assert.strictEqual(journalInterrupts(driver), 0)
+      }).pipe(Effect.provide(layer), Effect.scoped)
+    }))
+
+  it.effect("treats node shutdown interrupts as transient via isShutdown", () =>
+    Effect.gen(function*() {
+      let driver!: MessageStorage.MemoryDriver["Service"]
+      let state!: TestEntityState["Service"]
+      yield* Effect.gen(function*() {
+        driver = yield* MessageStorage.MemoryDriver
+        state = yield* TestEntityState
+        yield* TestClock.adjust(1)
+        yield* (yield* ActiveTeardownCaller.client)("1").Arm()
+        yield* TestClock.adjust(1)
+        assert.strictEqual(Queue.sizeUnsafe(state.envelopes), 1)
+      }).pipe(Effect.provide(ActiveTeardownSharding()))
+
+      assert.strictEqual(journalInterrupts(driver), 0)
+      assert.strictEqual(driver.journal.length, 1)
+    }))
+
+  it.effect("forwards replayed storage interrupts that have no local provenance", () =>
+    Effect.gen(function*() {
+      const driver = yield* MessageStorage.MemoryDriver
+      const state = yield* TestEntityState
+      const sharding = yield* Sharding.Sharding
+      const makeClient = yield* TestEntity.client
+      yield* TestClock.adjust(1)
+      const client = makeClient("1")
+
+      yield* client.Never().pipe(Effect.forkChild({ startImmediately: true }))
+      yield* TestClock.adjust(1)
+      assert.strictEqual(Queue.sizeUnsafe(state.envelopes), 1)
+
+      const request = driver.journal[0]
+      assert.strictEqual(request._tag, "Request")
+      yield* driver.encoded.saveEnvelope({
+        envelope: {
+          id: String(yield* sharding.getSnowflake),
+          _tag: "Interrupt",
+          requestId: request.requestId,
+          address: request.address
+        },
+        primaryKey: null,
+        deliverAt: null
+      })
+
+      yield* TestClock.adjust(5000)
+      assert.strictEqual(Queue.sizeUnsafe(state.interrupts), 1)
+      assert.strictEqual(journalInterrupts(driver), 1)
+    }).pipe(Effect.provide(TestSharding)))
+
+  it.effect("forwards interrupts from an external same-node caller", () =>
+    Effect.gen(function*() {
+      const driver = yield* MessageStorage.MemoryDriver
+      const state = yield* TestEntityState
+      const makeClient = yield* TestEntity.client
+      yield* TestClock.adjust(1)
+      const client = makeClient("1")
+
+      const fiber = yield* client.Never().pipe(Effect.forkChild({ startImmediately: true }))
+      yield* TestClock.adjust(1)
+      yield* Fiber.interrupt(fiber)
+      yield* TestClock.adjust(1)
+
+      assert.strictEqual(journalInterrupts(driver), 1)
+      assert.strictEqual(Queue.sizeUnsafe(state.interrupts), 1)
+    }).pipe(Effect.provide(TestSharding)))
+
+  it.effect("returns registry size to baseline after entity reap storms", () =>
+    Effect.gen(function*() {
+      yield* TestClock.adjust(1)
+      const sharding = yield* Sharding.Sharding
+      const makeClient = yield* ReapStormEntity.client
+
+      const storm = Effect.fnUntraced(function*(offset: number) {
+        for (let i = 0; i < 20; i++) {
+          yield* makeClient(String(offset + i)).Ping()
+        }
+        assert.strictEqual(yield* sharding.activeEntityCount, 20)
+        yield* waitForIdleReap(sharding, 0)
+        assert.strictEqual(yield* sharding.activeEntityCount, 0)
+        for (let i = 0; i < 20; i++) {
+          const entityId = EntityId.make(String(offset + i))
+          assert.isFalse(ActiveTeardown.isActive(EntityAddress.make({
+            shardId: sharding.getShardId(entityId, "default"),
+            entityType: EntityType.make("ReapStormEntity"),
+            entityId
+          })))
+        }
+      })
+
+      yield* storm(0)
+      yield* storm(100)
+    }).pipe(Effect.provide(ReapStormSharding)))
+})
+
+const ReapStormEntity = Entity.make("ReapStormEntity", [
+  Rpc.make("Ping").annotate(ClusterSchema.Persisted, false)
+])
+
+const ReapStormEntityLayer = ReapStormEntity.toLayer({ Ping: () => Effect.void })
+
 describe.concurrent("Sharding residency cap", () => {
   it.effect("bounds resident entities to maxResidentEntities", () =>
     Effect.gen(function*() {
@@ -1731,6 +1925,33 @@ const CappedSharding = (
 }
 
 const ContextBleedSharding = ContextBleedLayer.pipe(Layer.provideMerge(TestSharding))
+
+const ActiveTeardownSharding = (
+  config?: Partial<ShardingConfig.ShardingConfig["Service"]>
+) =>
+  ActiveTeardownCallerLayer.pipe(
+    Layer.merge(TestEntityNoState),
+    Layer.provideMerge(Sharding.layer),
+    Layer.provide(RunnerStorage.layerMemory),
+    Layer.provide(RunnerHealth.layerNoop),
+    Layer.provideMerge(TestEntityState.layer),
+    Layer.provide(Runners.layerNoop),
+    Layer.provideMerge(MessageStorage.layerMemory),
+    Layer.provide(ShardingConfig.layer({ ...testConfigDefaults, ...config }))
+  )
+
+const ReapStormSharding = ReapStormEntityLayer.pipe(
+  Layer.provideMerge(Sharding.layer),
+  Layer.provide(RunnerStorage.layerMemory),
+  Layer.provide(RunnerHealth.layerNoop),
+  Layer.provide(Runners.layerNoop),
+  Layer.provideMerge(MessageStorage.layerMemory),
+  Layer.provide(ShardingConfig.layer({
+    ...testConfigDefaults,
+    entityMaxIdleTime: 1,
+    entityTerminationTimeout: 0
+  }))
+)
 
 // saves a persisted GetUser request directly to storage, bypassing the client,
 // so the storage read loop only learns about it from the next poll

--- a/packages/effect/test/cluster/interruptors.test.ts
+++ b/packages/effect/test/cluster/interruptors.test.ts
@@ -1,0 +1,37 @@
+import { assert, it } from "@effect/vitest"
+import { Effect } from "effect"
+import { EntityAddress, EntityId, EntityType, ShardId } from "effect/unstable/cluster"
+import { acquireEntity, aroundEntityType, isActive, releaseEntity } from "effect/unstable/cluster/internal/interruptors"
+
+const address = EntityAddress.make({
+  shardId: ShardId.make("active-teardown-unit", 1),
+  entityType: EntityType.make("ActiveTeardownUnit"),
+  entityId: EntityId.make("1")
+})
+
+it("releases entity keys so membership returns to baseline", () => {
+  acquireEntity(address)
+  assert.isTrue(isActive(address))
+  releaseEntity(address)
+  assert.isFalse(isActive(address))
+})
+
+it("refcounts overlapping acquires", () => {
+  acquireEntity(address)
+  acquireEntity(address)
+  releaseEntity(address)
+  assert.isTrue(isActive(address))
+  releaseEntity(address)
+  assert.isFalse(isActive(address))
+})
+
+it.effect("aroundEntityType restores the key after the effect", () =>
+  Effect.gen(function*() {
+    yield* aroundEntityType(
+      "ActiveTeardownUnit",
+      Effect.sync(() => {
+        assert.isTrue(isActive(address))
+      })
+    )
+    assert.isFalse(isActive(address))
+  }))


### PR DESCRIPTION
Closes EFF-934
Closes #7467

Replace the process-lifetime `internalInterruptors` fiber-id Set with a
refcounted registry of in-flight teardowns (entity, shard, singleton, entity
type), plus the existing `isShutdown` flag.

`onFromClient` classifies persisted interrupts by joining the call's target and
caller addresses against that registry. The six former `.add()` sites acquire
and release those keys, so registry size returns to baseline after reap storms.
Network-replayed interrupts still have no local provenance and stay
non-transient. External same-node caller interrupts are still forwarded.
