### PR TITLE
Recommend Effect.fnUntraced in AI guide

### DIFF
--- a/LLMS.md
+++ b/LLMS.md
@@ -11,9 +11,11 @@ purposes. In practice, you would not include these comments in your code.
 
 ## Writing `Effect` code
 
-Prefer writing Effect code with `Effect.gen` & `Effect.fn("name")`. Then attach
-additional behaviour with combinators. This style is more readable and easier to
-maintain than using combinators alone.
+Prefer `Effect.gen` for inline Effect code. For reusable functions, prefer
+`Effect.fn("name")` when tracing is useful and `Effect.fnUntraced` when it is not,
+particularly in library implementations and hot paths. Avoid functions that only
+wrap and return `Effect.gen`. Attach additional behaviour with combinators; this
+style is more readable and easier to maintain than using combinators alone.
 
 ### Using Effect.gen
 
@@ -46,13 +48,16 @@ export class FileProcessingError extends Schema.TaggedError<FileProcessingError>
 }) {}
 ```
 
-### Using Effect.fn
+### Using Effect.fn and Effect.fnUntraced
 
-When writing functions that return an Effect, use `Effect.fn` to use the
-generator syntax.
+When writing reusable functions that return an Effect, use `Effect.fn` or
+`Effect.fnUntraced` to use the generator syntax.
 
-**Avoid creating functions that return an Effect.gen**, use `Effect.fn`
-instead.
+Use `Effect.fn("name")` when the function should create a tracing span. Prefer
+`Effect.fnUntraced` when tracing is not needed, particularly for library
+implementations and hot paths.
+
+**Avoid creating functions that only wrap and return an `Effect.gen`**.
 
 ```ts
 import { Effect, Schema } from "effect"
@@ -79,6 +84,16 @@ export const effectFunction = Effect.fn("effectFunction")(
     method: "effectFunction"
   })
 )
+
+// Effect.fnUntraced avoids tracing and stack-frame capture while still reusing
+// the generator body. This is preferred for library functions that do not
+// represent a useful tracing boundary.
+export const validateBatchSize = Effect.fnUntraced(function*(size: number): Effect.fn.Return<number, SomeError> {
+  if (!Number.isInteger(size) || size <= 0) {
+    return yield* new SomeError({ message: "Batch size must be a positive integer" })
+  }
+  return size
+})
 
 // Use Schema.TaggedError to define a custom error
 export class SomeError extends Schema.TaggedError<SomeError>()("SomeError", {

--- a/ai-docs/src/01_effect/01_basics/02_effect-fn.ts
+++ b/ai-docs/src/01_effect/01_basics/02_effect-fn.ts
@@ -1,11 +1,14 @@
 /**
- * @title Using Effect.fn
+ * @title Using Effect.fn and Effect.fnUntraced
  *
- * When writing functions that return an Effect, use `Effect.fn` to use the
- * generator syntax.
+ * When writing reusable functions that return an Effect, use `Effect.fn` or
+ * `Effect.fnUntraced` to use the generator syntax.
  *
- * **Avoid creating functions that return an Effect.gen**, use `Effect.fn`
- * instead.
+ * Use `Effect.fn("name")` when the function should create a tracing span. Prefer
+ * `Effect.fnUntraced` when tracing is not needed, particularly for library
+ * implementations and hot paths.
+ *
+ * **Avoid creating functions that only wrap and return an `Effect.gen`**.
  */
 
 import { Effect, Schema } from "effect"
@@ -32,6 +35,16 @@ export const effectFunction = Effect.fn("effectFunction")(
     method: "effectFunction"
   })
 )
+
+// Effect.fnUntraced avoids tracing and stack-frame capture while still reusing
+// the generator body. This is preferred for library functions that do not
+// represent a useful tracing boundary.
+export const validateBatchSize = Effect.fnUntraced(function*(size: number): Effect.fn.Return<number, SomeError> {
+  if (!Number.isInteger(size) || size <= 0) {
+    return yield* new SomeError({ message: "Batch size must be a positive integer" })
+  }
+  return size
+})
 
 // Use Schema.TaggedError to define a custom error
 export class SomeError extends Schema.TaggedError<SomeError>()("SomeError", {

--- a/ai-docs/src/01_effect/01_basics/index.md
+++ b/ai-docs/src/01_effect/01_basics/index.md
@@ -1,5 +1,7 @@
 ## Writing `Effect` code
 
-Prefer writing Effect code with `Effect.gen` & `Effect.fn("name")`. Then attach
-additional behaviour with combinators. This style is more readable and easier to
-maintain than using combinators alone.
+Prefer `Effect.gen` for inline Effect code. For reusable functions, prefer
+`Effect.fn("name")` when tracing is useful and `Effect.fnUntraced` when it is not,
+particularly in library implementations and hot paths. Avoid functions that only
+wrap and return `Effect.gen`. Attach additional behaviour with combinators; this
+style is more readable and easier to maintain than using combinators alone.


### PR DESCRIPTION
## Summary

- recommend `Effect.fnUntraced` for reusable library functions and hot paths where tracing is unnecessary
- clarify when to use traced `Effect.fn("name")` versus `Effect.fnUntraced`
- add an `Effect.fnUntraced` example and regenerate `LLMS.md`

## Validation

- `pnpm ai-docgen`
- `pnpm lint-fix`
- `pnpm check`
- `git diff --check`