### PR TITLE
fix(ai): keep non-object tool results out of structuredContent

### DIFF
--- a/.changeset/mcp-structured-content-object.md
+++ b/.changeset/mcp-structured-content-object.md
@@ -1,0 +1,15 @@
+---
+"effect": patch
+---
+
+MCP tool results no longer send `null` or arrays as `structuredContent`.
+
+The toolkit handler decided whether a result was structured with
+`typeof result.encodedResult === "object"`, which is also true for `null` and
+for arrays. A tool whose success schema encoded to either shape put a
+non-object into `structuredContent`, where MCP allows only a JSON object. Older
+clients that validate `CallToolResult` rejected the whole reply; on current
+protocol revisions the server itself failed the call with
+`non-object structured tool content is not supported`. Such results now travel
+as text content only, matching the fact that no `outputSchema` is advertised
+for them.

--- a/.changeset/mcp-structured-content-object.md
+++ b/.changeset/mcp-structured-content-object.md
@@ -2,14 +2,4 @@
 "effect": patch
 ---
 
-MCP tool results no longer send `null` or arrays as `structuredContent`.
-
-The toolkit handler decided whether a result was structured with
-`typeof result.encodedResult === "object"`, which is also true for `null` and
-for arrays. A tool whose success schema encoded to either shape put a
-non-object into `structuredContent`, where MCP allows only a JSON object. Older
-clients that validate `CallToolResult` rejected the whole reply; on current
-protocol revisions the server itself failed the call with
-`non-object structured tool content is not supported`. Such results now travel
-as text content only, matching the fact that no `outputSchema` is advertised
-for them.
+Stop sending MCP tool results that encode to `null` or an array as `structuredContent`, which MCP allows only to be a JSON object.

--- a/.changeset/mcp-structured-content-object.md
+++ b/.changeset/mcp-structured-content-object.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Stop sending MCP tool results that encode to `null` or an array as `structuredContent`, which MCP allows only to be a JSON object.
+McpServer no longer sends `null` or array tool results as `structuredContent`, which MCP requires to be a JSON object.

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -104,6 +104,15 @@ type ServerNotificationRequest<
 
 const BroadcastServerNotificationRpcs = ServerNotificationRpcs.omit("notifications/elicitation/complete")
 
+/**
+ * MCP models `structuredContent` as a JSON object, so a `null` or array
+ * encoded result must be omitted rather than sent through as-is.
+ */
+const toStructuredContent = (value: unknown): Schema.JsonObject | undefined =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Schema.JsonObject
+    : undefined
+
 const validateStructuredContent = (
   toolName: string,
   value: unknown
@@ -1570,7 +1579,7 @@ export const registerToolkit: <Tools extends Record<string, Tool.Any>>(
           Effect.map((result) =>
             new CallToolResult({
               isError: false,
-              structuredContent: typeof result.encodedResult === "object" ? result.encodedResult : undefined,
+              structuredContent: toStructuredContent(result.encodedResult),
               content: result.encodedResult === undefined ? [] : [{
                 type: "text",
                 text: JSON.stringify(result.encodedResult)

--- a/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
@@ -403,6 +403,22 @@ describe("McpServer", () => {
         )
       }))
 
+    it.effect("carries object tool results as structured content", () =>
+      Effect.gen(function*() {
+        const client = yield* makeToolkitTestClient()
+
+        const result = yield* client["tools/call"]({
+          name: "StructuredResultTool",
+          arguments: {}
+        })
+
+        assert.deepStrictEqual(result.structuredContent, { answer: "result" })
+        assert.deepStrictEqual(result.content, [{
+          type: "text",
+          text: JSON.stringify({ answer: "result" })
+        }])
+      }))
+
     it.effect("omits structured content for null and array tool results", () =>
       Effect.gen(function*() {
         const client = yield* makeToolkitTestClient()
@@ -412,26 +428,19 @@ describe("McpServer", () => {
           arguments: {}
         })
 
-        assert.deepStrictEqual(
-          nullResult,
-          new McpSchema.CallToolResult({
-            isError: false,
-            content: [{ type: "text", text: "null" }]
-          })
-        )
+        assert.isUndefined(nullResult.structuredContent)
+        assert.deepStrictEqual(nullResult.content, [{ type: "text", text: "null" }])
 
         const arrayResult = yield* client["tools/call"]({
           name: "ArrayResultTool",
           arguments: {}
         })
 
-        assert.deepStrictEqual(
-          arrayResult,
-          new McpSchema.CallToolResult({
-            isError: false,
-            content: [{ type: "text", text: JSON.stringify(["first", "second"]) }]
-          })
-        )
+        assert.isUndefined(arrayResult.structuredContent)
+        assert.deepStrictEqual(arrayResult.content, [{
+          type: "text",
+          text: JSON.stringify(["first", "second"])
+        }])
       }))
 
     it.effect("returns schema-validated messages for declared handler failures", () =>

--- a/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
@@ -55,6 +55,14 @@ const AnnotatedVoidTool = Tool.make("AnnotatedVoidTool", {
   success: Schema.Void.annotate({ description: "No output" })
 })
 
+const NullableResultTool = Tool.make("NullableResultTool", {
+  success: Schema.NullOr(Schema.Struct({ answer: Schema.String }))
+})
+
+const ArrayResultTool = Tool.make("ArrayResultTool", {
+  success: Schema.Array(Schema.String)
+})
+
 const TestToolkit = Toolkit.make(
   OptionalStringTool,
   PublicFailureTool,
@@ -62,7 +70,9 @@ const TestToolkit = Toolkit.make(
   DefectTool,
   UntypedTool,
   StructuredResultTool,
-  AnnotatedVoidTool
+  AnnotatedVoidTool,
+  NullableResultTool,
+  ArrayResultTool
 )
 type TestToolkitHandlers = Toolkit.HandlersFrom<Toolkit.Tools<typeof TestToolkit>>
 
@@ -73,7 +83,9 @@ const testToolkitHandlers = TestToolkit.of({
   DefectTool: () => Effect.die("private defect details"),
   UntypedTool: () => Effect.void,
   StructuredResultTool: () => Effect.succeed({ answer: "result" }),
-  AnnotatedVoidTool: () => Effect.void
+  AnnotatedVoidTool: () => Effect.void,
+  NullableResultTool: () => Effect.succeed(null),
+  ArrayResultTool: () => Effect.succeed(["first", "second"])
 })
 
 const INTERNAL_TOOL_ERROR_MESSAGE = "Tool execution failed due to an internal server error."
@@ -387,6 +399,37 @@ describe("McpServer", () => {
           new McpSchema.CallToolResult({
             isError: false,
             content: []
+          })
+        )
+      }))
+
+    it.effect("omits structured content for null and array tool results", () =>
+      Effect.gen(function*() {
+        const client = yield* makeToolkitTestClient()
+
+        const nullResult = yield* client["tools/call"]({
+          name: "NullableResultTool",
+          arguments: {}
+        })
+
+        assert.deepStrictEqual(
+          nullResult,
+          new McpSchema.CallToolResult({
+            isError: false,
+            content: [{ type: "text", text: "null" }]
+          })
+        )
+
+        const arrayResult = yield* client["tools/call"]({
+          name: "ArrayResultTool",
+          arguments: {}
+        })
+
+        assert.deepStrictEqual(
+          arrayResult,
+          new McpSchema.CallToolResult({
+            isError: false,
+            content: [{ type: "text", text: JSON.stringify(["first", "second"]) }]
           })
         )
       }))


### PR DESCRIPTION
Closes #7494.

## The defect

`packages/effect/src/unstable/ai/McpServer.ts` decided whether a toolkit result was structured with:

```ts
structuredContent: typeof result.encodedResult === "object" ? result.encodedResult : undefined,
```

`typeof` also reports `"object"` for `null` and for arrays. A tool whose success schema encoded to either shape put a non-object into `structuredContent`, which MCP requires to be a JSON object.

## Symptom, with one correction to the issue

The issue reports clients rejecting `structuredContent: null` while validating `CallToolResult`. That is what happens on `4.0.0-beta.103`.

On `main` the failure is different. I reproduced both cases against a live server, a `Schema.NullOr(...)` tool returning `null` and a `Schema.Array(Schema.String)` tool, and the bad value never reaches the client. The protocol adapter in `internal/mcpProtocol/v2025_06_18.ts:106` already screens structured content correctly and fails the call first:

```
code: -32602, message: "non-object structured tool content is not supported by MCP 2025-06-18"
```

Same root cause, but a valid tool call becomes a protocol error instead of a malformed reply.

The `void` case in the issue does not bite. `Schema.Void` encodes to `undefined`, not `null`, and an existing test already covers it. The shapes that actually break are nullable and array success schemas.

## The fix

Test the value instead of its `typeof`, so `null` and arrays fall through to `undefined`:

```ts
const toStructuredContent = (value: unknown): Schema.JsonObject | undefined =>
  typeof value === "object" && value !== null && !Array.isArray(value)
    ? value as Schema.JsonObject
    : undefined
```

Those results now go out as text content only, which matches what the server advertises. `outputSchema` is set only when the JSON schema type is `object`, so these tools never claimed structured output in the first place. `tools/list` confirms it:

```
TOOL NullTool:  outputSchema=undefined
TOOL ArrayTool: outputSchema=undefined
TOOL ObjTool:   outputSchema={"type":"object", ...}
```

The data is still there. An array comes back as JSON in `content[0].text`, so a client reads the same bytes and parses them itself.

## Tests

`McpServer.test.ts` had no coverage of `structuredContent` at all, so the new tests pin both directions.

`carries object tool results as structured content` checks that `StructuredResultTool` still emits the field. Without it, a fix that simply never emits `structuredContent` would pass the whole file.

`omits structured content for null and array tool results` checks that `NullableResultTool` and `ArrayResultTool` come back with the field absent.

I ran three variants of the source against them. The fix passes. The original `typeof` check fails the second test. A stub that always returns `undefined` fails the first.

`packages/effect` typechecks clean, and all 24 `unstable/ai` test files pass with 1054 tests and 44 skipped.

## One thing this does not resolve

The check for emitting `structuredContent` reads the runtime value, while the check for advertising `outputSchema` reads the schema, so the two can disagree. `NullTool` advertises no `outputSchema`, but when its handler returns an object rather than `null` that value does go out as `structuredContent`. The same tool varies its reply shape by runtime value. MCP permits unschema'd `structuredContent`, so nothing breaks, but deriving the flag from `outputSchema !== undefined` would make the two agree. I kept this change minimal and value-based to match the issue. Happy to align them if reviewers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MjDyCJcEoLsS2LvMCEfedh
