### PR TITLE
Expose final URL on HttpClientResponse

### DIFF
--- a/.changeset/resolved-client-urls.md
+++ b/.changeset/resolved-client-urls.md
@@ -1,0 +1,8 @@
+---
+"@effect/platform-browser": patch
+"@effect/platform-node": patch
+"effect": patch
+---
+
+Expose the final response URL on `HttpClientResponse`. Fetch and XMLHttpRequest clients now preserve the URL reported by
+the underlying response after redirects, while other clients report the URL of the request that produced the response.

--- a/.changeset/resolved-client-urls.md
+++ b/.changeset/resolved-client-urls.md
@@ -4,7 +4,5 @@
 "effect": patch
 ---
 
-Expose the resolved response URL on `HttpClientResponse`, including query parameters and excluding the hash. Fetch and
-XMLHttpRequest clients preserve the URL reported by the underlying response after redirects. Other clients report the
-resolved URL of the request that produced the response; Node clients follow redirects with `HttpClient.followRedirects`.
-Pass the originating request through `HttpApiTest` so its responses also expose the resolved URL.
+Add `HttpClientResponse.url`, including query parameters and excluding the hash. When redirects are followed, it reports
+the final URL.

--- a/.changeset/resolved-client-urls.md
+++ b/.changeset/resolved-client-urls.md
@@ -4,5 +4,7 @@
 "effect": patch
 ---
 
-Expose the final response URL on `HttpClientResponse`. Fetch and XMLHttpRequest clients now preserve the URL reported by
-the underlying response after redirects, while other clients report the URL of the request that produced the response.
+Expose the resolved response URL on `HttpClientResponse`, including query parameters and excluding the hash. Fetch and
+XMLHttpRequest clients preserve the URL reported by the underlying response after redirects. Other clients report the
+resolved URL of the request that produced the response; Node clients follow redirects with `HttpClient.followRedirects`.
+Pass the originating request through `HttpApiTest` so its responses also expose the resolved URL.

--- a/packages/effect/src/unstable/http/HttpClient.ts
+++ b/packages/effect/src/unstable/http/HttpClient.ts
@@ -1721,6 +1721,10 @@ class InterruptibleResponse implements HttpClientResponse.HttpClientResponse, Pi
     return this.original.request
   }
 
+  get url() {
+    return this.original.url
+  }
+
   get status() {
     return this.original.status
   }

--- a/packages/effect/src/unstable/http/HttpClientResponse.ts
+++ b/packages/effect/src/unstable/http/HttpClientResponse.ts
@@ -66,6 +66,8 @@ export const TypeId = "~effect/http/HttpClientResponse"
 export interface HttpClientResponse extends HttpIncomingMessage.HttpIncomingMessage<Error.HttpClientError>, Pipeable {
   readonly [TypeId]: typeof TypeId
   readonly request: HttpClientRequest.HttpClientRequest
+  /** The final response URL after redirects. */
+  readonly url: string
   readonly status: number
   readonly cookies: Cookies.Cookies
   readonly formData: Effect.Effect<FormData, Error.HttpClientError>
@@ -275,6 +277,10 @@ class WebHttpClientResponse extends Inspectable.Class implements HttpClientRespo
 
   get status(): number {
     return this.source.status
+  }
+
+  get url(): string {
+    return this.source.url || this.request.url
   }
 
   get headers(): Headers.Headers {

--- a/packages/effect/src/unstable/http/HttpClientResponse.ts
+++ b/packages/effect/src/unstable/http/HttpClientResponse.ts
@@ -21,7 +21,7 @@ import type { Unify } from "../../Unify.ts"
 import * as Cookies from "./Cookies.ts"
 import * as Headers from "./Headers.ts"
 import * as Error from "./HttpClientError.ts"
-import type * as HttpClientRequest from "./HttpClientRequest.ts"
+import * as HttpClientRequest from "./HttpClientRequest.ts"
 import * as HttpIncomingMessage from "./HttpIncomingMessage.ts"
 import * as UrlParams from "./UrlParams.ts"
 
@@ -66,7 +66,12 @@ export const TypeId = "~effect/http/HttpClientResponse"
 export interface HttpClientResponse extends HttpIncomingMessage.HttpIncomingMessage<Error.HttpClientError>, Pipeable {
   readonly [TypeId]: typeof TypeId
   readonly request: HttpClientRequest.HttpClientRequest
-  /** The final response URL after redirects. */
+  /**
+   * The resolved response URL, including query parameters and excluding the hash.
+   * Reflects the final URL when redirects are followed. Node clients require
+   * `HttpClient.followRedirects` to follow redirects.
+   * Empty when the response URL is unknown and the request URL cannot be resolved.
+   */
   readonly url: string
   readonly status: number
   readonly cookies: Cookies.Cookies
@@ -280,7 +285,11 @@ class WebHttpClientResponse extends Inspectable.Class implements HttpClientRespo
   }
 
   get url(): string {
-    return this.source.url || this.request.url
+    if (this.source.url) return this.source.url.split("#")[0]
+    const url = HttpClientRequest.toUrl(this.request)
+    if (Option.isNone(url)) return ""
+    url.value.hash = ""
+    return url.value.href
   }
 
   get headers(): Headers.Headers {

--- a/packages/effect/src/unstable/http/HttpClientResponse.ts
+++ b/packages/effect/src/unstable/http/HttpClientResponse.ts
@@ -67,10 +67,8 @@ export interface HttpClientResponse extends HttpIncomingMessage.HttpIncomingMess
   readonly [TypeId]: typeof TypeId
   readonly request: HttpClientRequest.HttpClientRequest
   /**
-   * The resolved response URL, including query parameters and excluding the hash.
-   * Reflects the final URL when redirects are followed. Node clients require
-   * `HttpClient.followRedirects` to follow redirects.
-   * Empty when the response URL is unknown and the request URL cannot be resolved.
+   * The resolved URL, including query parameters and excluding the hash.
+   * Uses the final URL when redirects are followed. Empty if unknown.
    */
   readonly url: string
   readonly status: number

--- a/packages/effect/src/unstable/http/HttpServerResponse.ts
+++ b/packages/effect/src/unstable/http/HttpServerResponse.ts
@@ -1102,6 +1102,10 @@ class ServerHttpClientResponse extends Inspectable.Class implements HttpClientRe
     return this.response.status
   }
 
+  get url(): string {
+    return this.request.url
+  }
+
   private cachedHeaders?: Headers.Headers
   get headers(): Headers.Headers {
     return this.cachedHeaders ??= this.response.body._tag === "FormData"

--- a/packages/effect/src/unstable/http/HttpServerResponse.ts
+++ b/packages/effect/src/unstable/http/HttpServerResponse.ts
@@ -1056,7 +1056,8 @@ export const toWeb = (
  * **Details**
  *
  * An optional request can be supplied for client-response metadata and decode
- * errors.
+ * errors. The response URL includes query parameters and excludes the hash.
+ * Without a request, the response URL is an empty string.
  *
  * @category converting
  * @since 4.0.0
@@ -1103,7 +1104,11 @@ class ServerHttpClientResponse extends Inspectable.Class implements HttpClientRe
   }
 
   get url(): string {
-    return this.request.url
+    if (this.request === HttpClientRequest.empty) return ""
+    const url = HttpClientRequest.toUrl(this.request)
+    if (Option.isNone(url)) return ""
+    url.value.hash = ""
+    return url.value.href
   }
 
   private cachedHeaders?: Headers.Headers

--- a/packages/effect/src/unstable/http/HttpServerResponse.ts
+++ b/packages/effect/src/unstable/http/HttpServerResponse.ts
@@ -1051,13 +1051,8 @@ export const toWeb = (
 }
 
 /**
- * Wraps an `HttpServerResponse` as an `HttpClientResponse`.
- *
- * **Details**
- *
- * An optional request can be supplied for client-response metadata and decode
- * errors. The response URL includes query parameters and excludes the hash.
- * Without a request, the response URL is an empty string.
+ * Wraps an `HttpServerResponse` as an `HttpClientResponse`, using the optional
+ * request for metadata and decode errors. Without a request, `url` is empty.
  *
  * @category converting
  * @since 4.0.0

--- a/packages/effect/src/unstable/httpapi/HttpApiTest.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiTest.ts
@@ -108,7 +108,7 @@ export const groups = Effect.fnUntraced(function*<
       Effect.provideService(HttpServerRequest.HttpServerRequest, serverRequest),
       Effect.orDie
     )
-    return HttpServerResponse.toClientResponse(response)
+    return HttpServerResponse.toClientResponse(response, { request })
   }, Effect.scoped))
 
   return yield* HttpApiClient.makeWith(api, {

--- a/packages/effect/test/HttpClient.test.ts
+++ b/packages/effect/test/HttpClient.test.ts
@@ -118,10 +118,10 @@ const TestServerLayer = Layer.unwrap(Effect.promise(() =>
         const client = (yield* HttpClient.HttpClient).pipe(
           HttpClient.followRedirects()
         )
-        const response = yield* client.get("/redirect").pipe(
-          Effect.flatMap((_) => _.text)
-        )
-        expect(response).toBe("test")
+        const response = yield* client.get("/redirect")
+        expect(new URL(response.request.url).pathname).toBe("/redirect")
+        expect(new URL(response.url).pathname).toBe("/")
+        expect(yield* response.text).toBe("test")
       }).pipe(Effect.provide(testLayer)))
 
     it.effect("stream", () =>

--- a/packages/effect/test/HttpClient.test.ts
+++ b/packages/effect/test/HttpClient.test.ts
@@ -119,7 +119,7 @@ const TestServerLayer = Layer.unwrap(Effect.promise(() =>
           HttpClient.followRedirects()
         )
         const response = yield* client.get("/redirect")
-        // Fetch follows redirects natively, so the response retains the original request.
+        // Fetch follows redirects natively and retains the original request.
         expect(new URL(response.request.url).pathname).toBe("/redirect")
         expect(new URL(response.url).pathname).toBe("/")
         assert.strictEqual(new URL(response.url).search, "?value=a%23b")

--- a/packages/effect/test/HttpClient.test.ts
+++ b/packages/effect/test/HttpClient.test.ts
@@ -1,4 +1,4 @@
-import { expect, it } from "@effect/vitest"
+import { assert, expect, it } from "@effect/vitest"
 import { Context, Effect, Layer, Schema, Stream, Struct } from "effect"
 import { TestClock } from "effect/testing"
 import {
@@ -41,7 +41,7 @@ const JsonPlaceholderLayer = Layer.effect(JsonPlaceholder)(makeJsonPlaceholder)
 const TestRoutes = HttpRouter.serve(HttpRouter.use(Effect.fnUntraced(function*(router) {
   yield* router.addAll([
     HttpRouter.route("GET", "/", Effect.succeed(HttpServerResponse.text("test"))),
-    HttpRouter.route("GET", "/redirect", Effect.succeed(HttpServerResponse.redirect("/"))),
+    HttpRouter.route("GET", "/redirect", Effect.succeed(HttpServerResponse.redirect("/?value=a%23b#fragment"))),
     HttpRouter.route(
       "GET",
       "/stream",
@@ -119,8 +119,11 @@ const TestServerLayer = Layer.unwrap(Effect.promise(() =>
           HttpClient.followRedirects()
         )
         const response = yield* client.get("/redirect")
+        // Fetch follows redirects natively, so the response retains the original request.
         expect(new URL(response.request.url).pathname).toBe("/redirect")
         expect(new URL(response.url).pathname).toBe("/")
+        assert.strictEqual(new URL(response.url).search, "?value=a%23b")
+        assert.strictEqual(new URL(response.url).hash, "")
         expect(yield* response.text).toBe("test")
       }).pipe(Effect.provide(testLayer)))
 

--- a/packages/effect/test/unstable/http/FetchHttpClient.test.ts
+++ b/packages/effect/test/unstable/http/FetchHttpClient.test.ts
@@ -6,10 +6,11 @@ describe("FetchHttpClient", () => {
   it.effect("sends bodies from Web requests", () =>
     Effect.gen(function*() {
       const request = HttpClientRequest.fromWeb(
-        new Request("https://example.test/", { method: "POST", body: "hello" })
-      )
+        new Request("https://example.test/?existing=1#fragment", { method: "POST", body: "hello" })
+      ).pipe(HttpClientRequest.setUrlParam("value", "a#b"))
       const client = yield* HttpClient.HttpClient
       const response = yield* client.execute(request)
+      assert.strictEqual(response.url, "https://example.test/?existing=1&value=a%23b")
       assert.strictEqual(yield* response.text, "hello")
     }).pipe(
       Effect.provide(FetchHttpClient.layer),

--- a/packages/effect/test/unstable/http/HttpServerResponse.test.ts
+++ b/packages/effect/test/unstable/http/HttpServerResponse.test.ts
@@ -28,7 +28,10 @@ describe("HttpServerResponse", () => {
 
   it.effect("fromClientResponse preserves status, headers, cookies, and json", () =>
     Effect.gen(function*() {
-      const request = HttpClientRequest.get("http://localhost:3000/todos/1")
+      const request = HttpClientRequest.get("http://localhost:3000/todos/1?existing=1", {
+        urlParams: { value: "a#b" },
+        hash: "fragment"
+      })
       const clientResponse = HttpServerResponse.toClientResponse(
         HttpServerResponse.jsonUnsafe({ foo: "bar" }, { status: 201 }).pipe(
           HttpServerResponse.setHeader("x-test", "ok"),
@@ -40,6 +43,8 @@ describe("HttpServerResponse", () => {
       const response = HttpServerResponse.fromClientResponse(clientResponse)
       const roundTrip = HttpServerResponse.toClientResponse(response, { request })
 
+      assert.strictEqual(clientResponse.url, "http://localhost:3000/todos/1?existing=1&value=a%23b")
+      assert.strictEqual(roundTrip.url, clientResponse.url)
       assert.strictEqual(response.status, 201)
       assert.strictEqual(response.headers["content-type"], "application/json")
       assert.strictEqual(response.headers["x-test"], "ok")
@@ -61,6 +66,7 @@ describe("HttpServerResponse", () => {
 
       const response = HttpServerResponse.fromClientResponse(clientResponse)
       const roundTrip = HttpServerResponse.toClientResponse(response)
+      assert.strictEqual(roundTrip.url, "")
       const text = yield* roundTrip.text.pipe(
         Effect.provideService(TestValue, 420)
       )

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -52,6 +52,7 @@ it.layer(TestServices)("HttpApiTest pre-response handlers", (it) => {
       const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const response = yield* client.test.get({ responseMode: "response-only" })
 
+      assert.strictEqual(response.url, "http://localhost:3000/fixture")
       assert.strictEqual(response.status, 200)
       assert.strictEqual(response.headers["x-fixture"], "present")
       assert.strictEqual(yield* response.text, "ok")

--- a/packages/platform/browser/src/BrowserHttpClient.ts
+++ b/packages/platform/browser/src/BrowserHttpClient.ts
@@ -408,6 +408,10 @@ class ClientResponseImpl extends IncomingMessageImpl<HttpClientError.HttpClientE
     return this.source.status
   }
 
+  get url() {
+    return this.source.responseURL || this.request.url
+  }
+
   get formData(): Effect.Effect<FormData, HttpClientError.HttpClientError> {
     return Effect.flatMap(this.arrayBuffer, (body) =>
       Effect.tryPromise({

--- a/packages/platform/browser/src/BrowserHttpClient.ts
+++ b/packages/platform/browser/src/BrowserHttpClient.ts
@@ -147,7 +147,7 @@ const makeXmlHttpRequest = HttpClient.make(
           const onChange = () => {
             if (!sent && xhr.readyState >= 2) {
               sent = true
-              resume(Effect.succeed(new ClientResponseImpl(request, xhr)))
+              resume(Effect.succeed(new ClientResponseImpl(request, xhr, url.href)))
             }
           }
           xhr.onreadystatechange = onChange
@@ -387,10 +387,12 @@ class ClientResponseImpl extends IncomingMessageImpl<HttpClientError.HttpClientE
 {
   readonly [HttpClientResponse.TypeId]: typeof HttpClientResponse.TypeId
   readonly request: HttpClientRequest.HttpClientRequest
+  private readonly requestUrl: string
 
   constructor(
     request: HttpClientRequest.HttpClientRequest,
-    source: globalThis.XMLHttpRequest
+    source: globalThis.XMLHttpRequest,
+    requestUrl: string
   ) {
     super(source, (cause) =>
       new HttpClientError.HttpClientError({
@@ -401,6 +403,7 @@ class ClientResponseImpl extends IncomingMessageImpl<HttpClientError.HttpClientE
         })
       }))
     this.request = request
+    this.requestUrl = requestUrl
     this[HttpClientResponse.TypeId] = HttpClientResponse.TypeId
   }
 
@@ -409,7 +412,7 @@ class ClientResponseImpl extends IncomingMessageImpl<HttpClientError.HttpClientE
   }
 
   get url() {
-    return this.source.responseURL || this.request.url
+    return (this.source.responseURL || this.requestUrl).split("#")[0]
   }
 
   get formData(): Effect.Effect<FormData, HttpClientError.HttpClientError> {

--- a/packages/platform/browser/test/BrowserHttpClient.test.ts
+++ b/packages/platform/browser/test/BrowserHttpClient.test.ts
@@ -18,10 +18,9 @@ const layer = (...args: Parameters<typeof MXHR.newServer>) =>
 describe("BrowserHttpClient", () => {
   it.effect("json", () =>
     Effect.gen(function*() {
-      const body = yield* HttpClient.get("http://localhost:8080/my/url").pipe(
-        Effect.flatMap((_) => _.json)
-      )
-      assert.deepStrictEqual(body, { message: "Success!" })
+      const response = yield* HttpClient.get("http://localhost:8080/my/url")
+      assert.strictEqual(response.url, "http://localhost:8080/my/url")
+      assert.deepStrictEqual(yield* response.json, { message: "Success!" })
     }).pipe(Effect.provide(layer({
       get: ["http://localhost:8080/my/url", {
         headers: { "Content-Type": "application/json" },

--- a/packages/platform/browser/test/BrowserHttpClient.test.ts
+++ b/packages/platform/browser/test/BrowserHttpClient.test.ts
@@ -7,11 +7,15 @@ import * as Cookies from "effect/unstable/http/Cookies"
 import * as HttpClient from "effect/unstable/http/HttpClient"
 import * as MXHR from "mock-xmlhttprequest"
 
-const layer = (...args: Parameters<typeof MXHR.newServer>) =>
+const layer = (routes: Parameters<typeof MXHR.newServer>[0], responseURL = "") =>
   Layer.unwrap(Effect.sync(() => {
-    const server = MXHR.newServer(...args)
+    const server = MXHR.newServer(routes)
     return BrowserHttpClient.layerXMLHttpRequest.pipe(
-      Layer.provide(Layer.succeed(BrowserHttpClient.XMLHttpRequest, server.xhrFactory))
+      Layer.provide(Layer.succeed(BrowserHttpClient.XMLHttpRequest, () => {
+        const xhr = server.xhrFactory()
+        xhr.responseURL = responseURL
+        return xhr
+      }))
     )
   }))
 
@@ -19,28 +23,26 @@ describe("BrowserHttpClient", () => {
   it.effect("json", () =>
     Effect.gen(function*() {
       const response = yield* HttpClient.get("http://localhost:8080/my/url")
-      assert.strictEqual(response.url, "http://localhost:8080/my/url")
+      assert.strictEqual(response.url, "http://localhost:8080/final?value=1")
       assert.deepStrictEqual(yield* response.json, { message: "Success!" })
     }).pipe(Effect.provide(layer({
       get: ["http://localhost:8080/my/url", {
         headers: { "Content-Type": "application/json" },
         body: "{ \"message\": \"Success!\" }"
       }]
-    }))))
+    }, "http://localhost:8080/final?value=1#fragment"))))
 
   it.effect("stream", () =>
     Effect.gen(function*() {
-      const body = yield* HttpClient.get("http://localhost:8080/my/url").pipe(
-        Effect.flatMap((response) =>
-          response.stream.pipe(
-            Stream.decodeText(),
-            Stream.mkString
-          )
-        )
-      )
+      const response = yield* HttpClient.get("http://localhost:8080/my/url?existing=1", {
+        urlParams: { value: "a#b" },
+        hash: "fragment"
+      })
+      assert.strictEqual(response.url, "http://localhost:8080/my/url?existing=1&value=a%23b")
+      const body = yield* response.stream.pipe(Stream.decodeText(), Stream.mkString)
       assert.deepStrictEqual(body, "{ \"message\": \"Success!\" }")
     }).pipe(Effect.provide(layer({
-      get: ["http://localhost:8080/my/url", {
+      get: ["http://localhost:8080/my/url?existing=1&value=a%23b#fragment", {
         headers: { "Content-Type": "application/json" },
         body: "{ \"message\": \"Success!\" }"
       }]

--- a/packages/platform/node/src/NodeHttpClient.ts
+++ b/packages/platform/node/src/NodeHttpClient.ts
@@ -220,6 +220,10 @@ class UndiciResponse extends Inspectable.Class implements HttpClientResponse, Pi
     return this.source.statusCode!
   }
 
+  get url() {
+    return this.request.url
+  }
+
   get statusText() {
     return undefined
   }
@@ -589,6 +593,10 @@ class NodeHttpResponse extends NodeHttpIncomingMessage<Error.HttpClientError> im
 
   get status() {
     return this.source.statusCode!
+  }
+
+  get url() {
+    return this.request.url
   }
 
   cachedCookies?: Cookies.Cookies

--- a/packages/platform/node/src/NodeHttpClient.ts
+++ b/packages/platform/node/src/NodeHttpClient.ts
@@ -156,7 +156,7 @@ export const makeUndici = Effect.gen(function*() {
               method: request.method,
               headers: request.headers,
               origin: url.origin,
-              path: url.pathname + url.search + url.hash,
+              path: url.pathname + url.search,
               body,
               // leave timeouts to Effect.timeout etc
               headersTimeout: 60 * 60 * 1000,
@@ -171,7 +171,7 @@ export const makeUndici = Effect.gen(function*() {
             })
         })
       ),
-      Effect.map((response) => new UndiciResponse(request, response))
+      Effect.map((response) => new UndiciResponse(request, response, url.href.split("#")[0]))
     )
   )
 })
@@ -203,25 +203,24 @@ class UndiciResponse extends Inspectable.Class implements HttpClientResponse, Pi
   readonly [Response.TypeId]: typeof Response.TypeId
   readonly request: HttpClientRequest
   readonly source: Undici.Dispatcher.ResponseData
+  readonly url: string
 
   constructor(
     request: HttpClientRequest,
-    source: Undici.Dispatcher.ResponseData
+    source: Undici.Dispatcher.ResponseData,
+    url: string
   ) {
     super()
     this[IncomingMessage.TypeId] = IncomingMessage.TypeId
     this[Response.TypeId] = Response.TypeId
     this.request = request
     this.source = source
+    this.url = url
     source.body.on("error", noopErrorHandler)
   }
 
   get status() {
     return this.source.statusCode!
-  }
-
-  get url() {
-    return this.request.url
   }
 
   get statusText() {
@@ -454,7 +453,7 @@ export const makeNodeHttp = Effect.gen(function*() {
       sendBody(nodeRequest, request, request.body).pipe(Effect.andThen(Effect.never))
     ).pipe(
       Effect.onError(() => Effect.sync(() => nodeRequest.destroy())),
-      Effect.map((_) => new NodeHttpResponse(request, _))
+      Effect.map((_) => new NodeHttpResponse(request, _, url.href.split("#")[0]))
     )
   })
 })
@@ -574,10 +573,12 @@ const waitForFinish = (nodeRequest: Http.ClientRequest, request: HttpClientReque
 class NodeHttpResponse extends NodeHttpIncomingMessage<Error.HttpClientError> implements HttpClientResponse, Pipeable {
   readonly [Response.TypeId]: typeof Response.TypeId
   readonly request: HttpClientRequest
+  readonly url: string
 
   constructor(
     request: HttpClientRequest,
-    source: Http.IncomingMessage
+    source: Http.IncomingMessage,
+    url: string
   ) {
     super(source, (cause) =>
       new Error.HttpClientError({
@@ -589,14 +590,11 @@ class NodeHttpResponse extends NodeHttpIncomingMessage<Error.HttpClientError> im
       }))
     this[Response.TypeId] = Response.TypeId
     this.request = request
+    this.url = url
   }
 
   get status() {
     return this.source.statusCode!
-  }
-
-  get url() {
-    return this.request.url
   }
 
   cachedCookies?: Cookies.Cookies

--- a/packages/platform/node/test/NodeHttpClient.test.ts
+++ b/packages/platform/node/test/NodeHttpClient.test.ts
@@ -154,10 +154,9 @@ const LocalServerRoutes = HttpRouter.serve(HttpRouter.addAll([
         const client = (yield* HttpClient.HttpClient).pipe(
           HttpClient.followRedirects()
         )
-        const response = yield* client.get("/redirect").pipe(
-          Effect.flatMap((_) => _.text)
-        )
-        expect(response).toBe("redirected")
+        const response = yield* client.get("/redirect")
+        expect(new URL(response.url).pathname).toBe("/redirected")
+        expect(yield* response.text).toBe("redirected")
       }).pipe(Effect.provide(localServerTestLayer)))
 
     it.effect("text stream", () =>

--- a/packages/platform/node/test/NodeHttpClient.test.ts
+++ b/packages/platform/node/test/NodeHttpClient.test.ts
@@ -127,10 +127,15 @@ const LocalServerRoutes = HttpRouter.serve(HttpRouter.addAll([
   describe(`NodeHttpClient - ${name}`, () => {
     it.effect("text", () =>
       Effect.gen(function*() {
-        const response = yield* HttpClient.get("/text").pipe(
-          Effect.flatMap((_) => _.text)
-        )
-        expect(response).toBe("test")
+        const response = yield* HttpClient.get("/text?existing=1", {
+          urlParams: { value: "a#b" },
+          hash: "fragment"
+        })
+        const url = new URL(response.url)
+        assert.strictEqual(url.pathname, "/text")
+        assert.strictEqual(url.search, "?existing=1&value=a%23b")
+        assert.strictEqual(url.hash, "")
+        expect(yield* response.text).toBe("test")
       }).pipe(Effect.provide(localServerTestLayer)))
 
     it.effect("accessing text preserves response bytes", () =>


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Expose `HttpClientResponse.url` as the resolved response URL, including query parameters and excluding the hash. Fetch and XMLHttpRequest preserve the underlying response URL after redirects. Node clients report the resolved request URL and follow redirects with `HttpClient.followRedirects`.

Web response fallbacks and server response adapters resolve query parameters too. `HttpApiTest` passes through the originating request. Server responses without a request expose an empty URL, as documented.

Includes a changeset, redirect coverage for Fetch and Node, and mocked XHR coverage for `responseURL` and its fallback. Existing assertions cover query parameters, encoded hashes, and fragment removal.

## Validation

136 targeted tests pass. `pnpm lint-fix` and `pnpm check` pass.

## Related

Closes EFF-1300
