### PR TITLE
Update v3-to-v4 migration docs for MessagePack and Arbitrary removals

### DIFF
--- a/migration/annotations/effect__Arbitrary.yaml
+++ b/migration/annotations/effect__Arbitrary.yaml
@@ -1,17 +1,20 @@
+"effect/Arbitrary":
+  replacement: "effect/unstable/arbitrary/Arbitrary"
+  note: "Schema-derived generation moved to the native Arbitrary module. Effect no longer bridges to fast-check."
 "effect/Arbitrary#ArbitraryAnnotation":
   replacement: "Schema.Annotations.ToArbitrary.Declaration"
-  note: "Arbitrary derivation annotations now live in Schema.Annotations and use the toArbitrary key."
+  note: "Arbitrary derivation annotations now live in Schema.Annotations. Attach a toCodecArbitrary declaration callback that returns a Schema Link."
 "effect/Arbitrary#ArbitraryGenerationContext":
-  replacement: "Schema.Annotations.ToArbitrary.Context"
-  note: "Use the v4 arbitrary-derivation context type from Schema.Annotations."
+  replacement: "Schema.Annotations.ToArbitrary.DeclarationInput"
+  note: "Native arbitrary callbacks receive DeclarationInput with decoded type-parameter schemas and normalized constraints."
 "effect/Arbitrary#LazyArbitrary":
-  replacement: "Schema.Arbitrary"
-  note: "The arbitrary factory type moved onto Schema."
+  replacement: "effect/unstable/arbitrary/Arbitrary#Arbitrary"
+  note: "The generated-value description is now the native Arbitrary interface from effect/unstable/arbitrary."
 "effect/Arbitrary#make":
-  replacement: "Schema.toArbitrary"
-  note: "Arbitrary derivation is now exposed directly by Schema."
-  example: "Schema.toArbitrary(schema)(FastCheck)"
+  replacement: "effect/unstable/arbitrary/Arbitrary#schema"
+  note: "Derive a native Arbitrary from a Schema. Effect no longer bridges to fast-check."
+  example: "Arbitrary.schema(schema)"
 "effect/Arbitrary#makeLazy":
-  replacement: "Schema.toArbitrary"
-  note: "Lazy arbitrary derivation is now exposed directly by Schema."
-  example: "Schema.toArbitrary(schema)"
+  replacement: "effect/unstable/arbitrary/Arbitrary#schema"
+  note: "Lazy and eager Schema derivation are the same native Arbitrary.schema constructor."
+  example: "Arbitrary.schema(schema)"

--- a/migration/annotations/effect__FastCheck.yaml
+++ b/migration/annotations/effect__FastCheck.yaml
@@ -1,88 +1,91 @@
+"effect/FastCheck":
+  replacement: "fast-check"
+  note: "Effect no longer re-exports fast-check. Depend on the fast-check package and import it directly. For Schema-derived generation, use Arbitrary.schema from effect/unstable/arbitrary."
 "effect/FastCheck#ascii":
   replacement: "FastCheck.string"
-  note: "Import FastCheck from effect/testing. fast-check v4 replaced character arbitraries with string units."
+  note: "Depend on fast-check and import it directly. fast-check v4 replaced character arbitraries with string units."
   example: "FastCheck.string({ unit: \"binary-ascii\", minLength: 1, maxLength: 1 })"
 "effect/FastCheck#asciiString":
   replacement: "FastCheck.string"
-  note: "Import FastCheck from effect/testing. Use the binary-ascii string unit."
+  note: "Depend on fast-check and import it directly. Use the binary-ascii string unit."
   example: "FastCheck.string({ ...constraints, unit: \"binary-ascii\" })"
 "effect/FastCheck#base64":
   replacement: "FastCheck.constantFrom"
-  note: "Import FastCheck from effect/testing. Generate one base64 alphabet character; base64String remains for complete encoded strings."
+  note: "Depend on fast-check and import it directly. Generate one base64 alphabet character; base64String remains for complete encoded strings."
   example: "FastCheck.constantFrom(...\"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/\")"
 "effect/FastCheck#bigIntN":
   replacement: "FastCheck.bigInt"
-  note: "Import FastCheck from effect/testing. Express the signed bit range with min and max constraints."
+  note: "Depend on fast-check and import it directly. Express the signed bit range with min and max constraints."
 "effect/FastCheck#bigUint":
   replacement: "FastCheck.bigInt"
-  note: "Import FastCheck from effect/testing. Use a minimum of 0n and the previous maximum."
+  note: "Depend on fast-check and import it directly. Use a minimum of 0n and the previous maximum."
   example: "FastCheck.bigInt({ min: 0n, max })"
 "effect/FastCheck#BigUintConstraints":
   replacement: "FastCheck.BigIntConstraints"
-  note: "Import FastCheck from effect/testing. Unsigned bigint constraints were consolidated into BigIntConstraints with min: 0n."
+  note: "Depend on fast-check and import it directly. Unsigned bigint constraints were consolidated into BigIntConstraints with min: 0n."
 "effect/FastCheck#bigUintN":
   replacement: "FastCheck.bigInt"
-  note: "Import FastCheck from effect/testing. Express the unsigned bit range with min and max constraints."
+  note: "Depend on fast-check and import it directly. Express the unsigned bit range with min and max constraints."
   example: "FastCheck.bigInt({ min: 0n, max: (1n << BigInt(n)) - 1n })"
 "effect/FastCheck#char":
   replacement: "FastCheck.string"
-  note: "Import FastCheck from effect/testing. Use a one-unit printable ASCII string."
+  note: "Depend on fast-check and import it directly. Use a one-unit printable ASCII string."
   example: "FastCheck.string({ unit: \"grapheme-ascii\", minLength: 1, maxLength: 1 })"
 "effect/FastCheck#char16bits":
   replacement: "FastCheck.nat"
-  note: "Import FastCheck from effect/testing. Map a 16-bit natural number through String.fromCharCode."
+  note: "Depend on fast-check and import it directly. Map a 16-bit natural number through String.fromCharCode."
   example: "FastCheck.nat({ max: 0xffff }).map(String.fromCharCode)"
 "effect/FastCheck#check":
   replacement: "FastCheck.check"
-  note: "Import FastCheck from effect/testing. The runner remains, but RunDetails.error was replaced by errorInstance in fast-check v4."
+  note: "Depend on fast-check and import it directly. The runner remains, but RunDetails.error was replaced by errorInstance in fast-check v4."
 "effect/FastCheck#constant":
   replacement: "FastCheck.constant"
-  note: "Import FastCheck from effect/testing. The API remains; v4 infers literal types by default."
+  note: "Depend on fast-check and import it directly. The API remains; v4 infers literal types by default."
 "effect/FastCheck#context":
   replacement: "FastCheck.context"
-  note: "Import FastCheck from effect/testing. The API is otherwise unchanged."
+  note: "Depend on fast-check and import it directly. The API is otherwise unchanged."
 "effect/FastCheck#fullUnicode":
   replacement: "FastCheck.string"
-  note: "Import FastCheck from effect/testing. Use a one-unit binary Unicode string."
+  note: "Depend on fast-check and import it directly. Use a one-unit binary Unicode string."
   example: "FastCheck.string({ unit: \"binary\", minLength: 1, maxLength: 1 })"
 "effect/FastCheck#fullUnicodeString":
   replacement: "FastCheck.string"
-  note: "Import FastCheck from effect/testing. Use the binary string unit."
+  note: "Depend on fast-check and import it directly. Use the binary string unit."
   example: "FastCheck.string({ ...constraints, unit: \"binary\" })"
 "effect/FastCheck#hexa":
   replacement: "FastCheck.integer"
-  note: "Import FastCheck from effect/testing. Map an integer from 0 through 15 to a hexadecimal character."
+  note: "Depend on fast-check and import it directly. Map an integer from 0 through 15 to a hexadecimal character."
 "effect/FastCheck#hexaString":
   replacement: "FastCheck.string"
-  note: "Import FastCheck from effect/testing. Pass a hexadecimal-character arbitrary as the string unit."
+  note: "Depend on fast-check and import it directly. Pass a hexadecimal-character arbitrary as the string unit."
 "effect/FastCheck#stream":
   replacement: "FastCheck.stream"
-  note: "Import FastCheck from effect/testing. The API remains; update custom generator and Random implementations for fast-check v4 typings."
+  note: "Depend on fast-check and import it directly. The API remains; update custom generator and Random implementations for fast-check v4 typings."
 "effect/FastCheck#string16bits":
   replacement: "FastCheck.string"
-  note: "Import FastCheck from effect/testing. Pass a char16bits-compatible arbitrary as the string unit."
+  note: "Depend on fast-check and import it directly. Pass a char16bits-compatible arbitrary as the string unit."
 "effect/FastCheck#stringOf":
   replacement: "FastCheck.string"
-  note: "Import FastCheck from effect/testing. Pass the former character arbitrary as the unit constraint."
+  note: "Depend on fast-check and import it directly. Pass the former character arbitrary as the unit constraint."
   example: "FastCheck.string({ ...constraints, unit: arbitrary })"
 "effect/FastCheck#unicode":
   replacement: "FastCheck.integer"
-  note: "Import FastCheck from effect/testing. Map BMP code points while excluding surrogate code points; prefer the binary string unit for full Unicode."
+  note: "Depend on fast-check and import it directly. Map BMP code points while excluding surrogate code points; prefer the binary string unit for full Unicode."
 "effect/FastCheck#unicodeJson":
   replacement: "FastCheck.json"
-  note: "Import FastCheck from effect/testing. Select binary or grapheme strings with stringUnit."
+  note: "Depend on fast-check and import it directly. Select binary or grapheme strings with stringUnit."
   example: "FastCheck.json({ stringUnit: \"binary\" })"
 "effect/FastCheck#UnicodeJsonSharedConstraints":
   replacement: "FastCheck.JsonSharedConstraints"
-  note: "Import FastCheck from effect/testing. Unicode JSON generation was consolidated into JsonSharedConstraints.stringUnit."
+  note: "Depend on fast-check and import it directly. Unicode JSON generation was consolidated into JsonSharedConstraints.stringUnit."
 "effect/FastCheck#unicodeJsonValue":
   replacement: "FastCheck.jsonValue"
-  note: "Import FastCheck from effect/testing. Select binary or grapheme strings with stringUnit."
+  note: "Depend on fast-check and import it directly. Select binary or grapheme strings with stringUnit."
   example: "FastCheck.jsonValue({ stringUnit: \"binary\" })"
 "effect/FastCheck#unicodeString":
   replacement: "FastCheck.string"
-  note: "Import FastCheck from effect/testing. Pass a BMP-code-point arbitrary as the unit constraint; prefer unit: binary for full Unicode."
+  note: "Depend on fast-check and import it directly. Pass a BMP-code-point arbitrary as the unit constraint; prefer unit: binary for full Unicode."
 "effect/FastCheck#uuidV":
   replacement: "FastCheck.uuid"
-  note: "Import FastCheck from effect/testing. Specify the UUID version through constraints."
+  note: "Depend on fast-check and import it directly. Specify the UUID version through constraints."
   example: "FastCheck.uuid({ version: 4 })"

--- a/migration/annotations/effect__SchemaAST.yaml
+++ b/migration/annotations/effect__SchemaAST.yaml
@@ -12,7 +12,7 @@
   note: "The v4 SchemaAST redesign renamed this primitive, collection, or guard while preserving its role."
 "effect/SchemaAST#ArbitraryAnnotationId":
   replacement: "Schema.Annotations.ToArbitrary"
-  note: "Symbol annotation IDs were removed; use the toArbitrary annotation key and its Schema.Annotations types."
+  note: "Symbol annotation IDs were removed. Declarations use the toCodecArbitrary annotation; filters use arbitraryConstraint."
 "effect/SchemaAST#AST":
   replacement: "SchemaAST.AST"
   note: "The name remains, but its constructor and fields changed in the v4 Base/check/context/encoding model."

--- a/migration/annotations/effect__TestConfig.yaml
+++ b/migration/annotations/effect__TestConfig.yaml
@@ -3,4 +3,4 @@
   note: "The v3 constructor only returned its parameter object. The TestConfig service was removed; keep a plain object only for application-owned configuration."
 "effect/TestConfig#TestConfig":
   replacement: "none"
-  note: "There is no v4 TestConfig service. Move runner settings to Vitest and FastCheck options, or define an application-specific Context.Reference if runtime access is needed."
+  note: "There is no v4 TestConfig service. Move runner settings to Vitest and native Arbitrary check options, or define an application-specific Context.Reference if runtime access is needed."

--- a/migration/annotations/effect__TestServices.yaml
+++ b/migration/annotations/effect__TestServices.yaml
@@ -47,11 +47,11 @@
   replacement: "Vitest TestOptions.retry"
   note: "Configure retry in Vitest test options. To retry an Effect inside a test, use Effect.retry."
 "effect/TestServices#samples":
-  replacement: "{ fastCheck: { numRuns } }"
-  note: "Pass the run count through @effect/vitest property-test options, for example it.effect.prop(..., { fastCheck: { numRuns: samples } })."
+  replacement: "{ arbitrary: { runs } }"
+  note: "Pass the run count through @effect/vitest property-test options, for example it.effect.prop(..., { arbitrary: { runs: samples } })."
 "effect/TestServices#shrinks":
-  replacement: "none"
-  note: "The legacy maximum-shrinks service setting was removed; @effect/vitest forwards FastCheck.Parameters, which has no equivalent service value."
+  replacement: "{ arbitrary: { maxShrinks } }"
+  note: "Pass maxShrinks through @effect/vitest property-test options, for example it.effect.prop(..., { arbitrary: { maxShrinks } })."
 "effect/TestServices#size":
   replacement: "CurrentSize"
   note: "Define a custom Context.Reference<number> and yield it to read the current size."
@@ -66,19 +66,19 @@
   note: "Use the custom reference's callback, or preferably yield CurrentSize in Effect.gen."
 "effect/TestServices#testConfig":
   replacement: "none"
-  note: "The runner no longer reads an Effect TestConfig service. Use Vitest TestOptions and property-test fastCheck options; model application state as a custom Context.Reference."
+  note: "The runner no longer reads an Effect TestConfig service. Use Vitest TestOptions and property-test arbitrary options; model application state as a custom Context.Reference."
 "effect/TestServices#testConfigLayer":
   replacement: "none"
-  note: "The runner no longer reads an Effect TestConfig service. Use Vitest TestOptions and property-test fastCheck options; model application state as a custom Context.Reference."
+  note: "The runner no longer reads an Effect TestConfig service. Use Vitest TestOptions and property-test arbitrary options; model application state as a custom Context.Reference."
 "effect/TestServices#testConfigWith":
   replacement: "none"
-  note: "The runner no longer reads an Effect TestConfig service. Use Vitest TestOptions and property-test fastCheck options; model application state as a custom Context.Reference."
+  note: "The runner no longer reads an Effect TestConfig service. Use Vitest TestOptions and property-test arbitrary options; model application state as a custom Context.Reference."
 "effect/TestServices#withTestConfig":
   replacement: "none"
-  note: "The runner no longer reads an Effect TestConfig service. Use Vitest TestOptions and property-test fastCheck options; model application state as a custom Context.Reference."
+  note: "The runner no longer reads an Effect TestConfig service. Use Vitest TestOptions and property-test arbitrary options; model application state as a custom Context.Reference."
 "effect/TestServices#withTestConfigScoped":
   replacement: "none"
-  note: "The runner no longer reads an Effect TestConfig service. Use Vitest TestOptions and property-test fastCheck options; model application state as a custom Context.Reference."
+  note: "The runner no longer reads an Effect TestConfig service. Use Vitest TestOptions and property-test arbitrary options; model application state as a custom Context.Reference."
 "effect/TestServices#TestServices":
   replacement: "TestClock.TestClock | TestConsole.TestConsole"
   note: "This is the v4 @effect/vitest test-environment union. it.effect provides both automatically; it.live provides neither override."

--- a/migration/annotations/effect__experimental__EventLogRemote.yaml
+++ b/migration/annotations/effect__experimental__EventLogRemote.yaml
@@ -6,16 +6,16 @@
   note: ChangesRpc replaces the separate request and response models with one streaming RPC.
 "@effect/experimental/EventLogRemote#decodeRequest":
   replacement: effect/unstable/eventlog/EventLogMessage#EventLogRemoteRpcs
-  note: Generic RPC framing and RpcSerialization.layerMsgPack replace the module-specific request decoder.
+  note: Generic RPC framing and RpcSerialization.layerSchemaBinary replace the module-specific request decoder.
 "@effect/experimental/EventLogRemote#decodeResponse":
   replacement: effect/unstable/eventlog/EventLogMessage#EventLogRemoteRpcs
-  note: Generic RPC framing and RpcSerialization.layerMsgPack replace the module-specific response decoder.
+  note: Generic RPC framing and RpcSerialization.layerSchemaBinary replace the module-specific response decoder.
 "@effect/experimental/EventLogRemote#encodeRequest":
   replacement: effect/unstable/eventlog/EventLogMessage#EventLogRemoteRpcs
-  note: Generic RPC framing and RpcSerialization.layerMsgPack replace the module-specific request encoder.
+  note: Generic RPC framing and RpcSerialization.layerSchemaBinary replace the module-specific request encoder.
 "@effect/experimental/EventLogRemote#encodeResponse":
   replacement: effect/unstable/eventlog/EventLogMessage#EventLogRemoteRpcs
-  note: Generic RPC framing and RpcSerialization.layerMsgPack replace the module-specific response encoder.
+  note: Generic RPC framing and RpcSerialization.layerSchemaBinary replace the module-specific response encoder.
 "@effect/experimental/EventLogRemote#EventLogRemote":
   replacement: effect/unstable/eventlog/EventLogRemote#EventLogRemote
   note: Use the v4 Context.Service; methods now take storeId-aware options.
@@ -27,7 +27,7 @@
   note: HelloResponse replaces Hello and includes the v4 authentication challenge; HelloRpc defines the endpoint.
 "@effect/experimental/EventLogRemote#layerWebSocket":
   replacement: effect/unstable/eventlog/EventLogRemote#layerEncrypted + effect/unstable/rpc/RpcClient#layerProtocolSocket
-  note: Compose the encrypted remote with the generic socket protocol, MsgPack serialization, and a Socket provider.
+  note: Compose the encrypted remote with the generic socket protocol, SchemaBinary serialization, and a Socket provider.
 "@effect/experimental/EventLogRemote#layerWebSocketBrowser":
   replacement: effect/unstable/eventlog/EventLogRemote#layerEncrypted + effect/unstable/rpc/RpcClient#layerProtocolSocket + @effect/platform-browser/BrowserSocket#layerWebSocket
   note: Compose the encrypted remote and generic RPC socket protocol with the browser WebSocket layer.
@@ -38,14 +38,14 @@
   replacement: effect/unstable/eventlog/EventLogMessage#EventLogRemoteRpcs
   note: EventLogRemoteRpcs and generic RPC serialization replace the old protocol request union.
 "@effect/experimental/EventLogRemote#ProtocolRequestMsgPack":
-  replacement: effect/unstable/rpc/RpcSerialization#layerMsgPack
-  note: Use the generic MsgPack RPC serialization layer instead of a request-specific schema.
+  replacement: effect/unstable/rpc/RpcSerialization#layerSchemaBinary
+  note: Use the generic SchemaBinary RPC serialization layer instead of a request-specific schema.
 "@effect/experimental/EventLogRemote#ProtocolResponse":
   replacement: effect/unstable/eventlog/EventLogMessage#EventLogRemoteRpcs
   note: EventLogRemoteRpcs and generic RPC serialization replace the old protocol response union.
 "@effect/experimental/EventLogRemote#ProtocolResponseMsgPack":
-  replacement: effect/unstable/rpc/RpcSerialization#layerMsgPack
-  note: Use the generic MsgPack RPC serialization layer instead of a response-specific schema.
+  replacement: effect/unstable/rpc/RpcSerialization#layerSchemaBinary
+  note: Use the generic SchemaBinary RPC serialization layer instead of a response-specific schema.
 "@effect/experimental/EventLogRemote#RemoteAdditions":
   replacement: none
   note: This unused protocol model has no v4 counterpart.

--- a/migration/annotations/effect__experimental__PersistedQueue.yaml
+++ b/migration/annotations/effect__experimental__PersistedQueue.yaml
@@ -7,6 +7,9 @@
 "@effect/experimental/PersistedQueue#make":
   replacement: effect/unstable/persistence/PersistedQueue#make
   note: Import make from the v4 unstable PersistedQueue module.
+"@effect/experimental/PersistedQueue#ErrorTypeId":
+  replacement: effect/unstable/persistence/PersistedQueue#ErrorTypeId
+  note: Retained as a string brand; the runtime marker now uses the persistence module path.
 "@effect/experimental/PersistedQueue#TypeId":
   replacement: effect/unstable/persistence/PersistedQueue#TypeId
   note: Import TypeId from the v4 unstable PersistedQueue module; it is now a string brand.

--- a/migration/annotations/effect__experimental__RateLimiter.yaml
+++ b/migration/annotations/effect__experimental__RateLimiter.yaml
@@ -10,6 +10,9 @@
 "@effect/experimental/RateLimiter#RateLimiterError":
   replacement: effect/unstable/persistence/RateLimiter#RateLimiterError
   note: The retained name is now a wrapper error class whose reason is RateLimitExceeded or RateLimitStoreError.
+"@effect/experimental/RateLimiter#ErrorTypeId":
+  replacement: effect/unstable/persistence/RateLimiter#ErrorTypeId
+  note: Retained as a string brand; the runtime marker now uses the persistence module path.
 "@effect/experimental/RateLimiter#TypeId":
   replacement: effect/unstable/persistence/RateLimiter#TypeId
   note: Import TypeId from the v4 unstable RateLimiter module; it is now a string brand.

--- a/migration/annotations/effect__platform__MsgPack.yaml
+++ b/migration/annotations/effect__platform__MsgPack.yaml
@@ -1,24 +1,30 @@
+"@effect/platform/MsgPack":
+  replacement: "effect/unstable/encoding/SchemaBinary"
+  note: "MessagePack support was removed. Schema-aware encode, decode, and duplex now live on SchemaBinary. Untyped MessagePack of unknown values has no replacement."
 "@effect/platform/MsgPack#duplex":
-  replacement: "Msgpack.duplex"
-  note: "The API moved to effect/unstable/encoding/Msgpack."
+  replacement: "SchemaBinary.duplex"
+  note: "MessagePack was removed. Wrap a byte channel with SchemaBinary.duplex and explicit input and output schemas."
 "@effect/platform/MsgPack#duplexSchema":
-  replacement: "Msgpack.duplexSchema"
-  note: "The API moved to effect/unstable/encoding/Msgpack and uses v4 Schema constraints."
+  replacement: "SchemaBinary.duplex"
+  note: "MessagePack was removed. Use SchemaBinary.duplex with the v4 Schema model."
 "@effect/platform/MsgPack#ErrorTypeId":
-  replacement: "Msgpack.MsgPackError"
-  note: "The public error type-id alias was removed; use the MsgPackError class."
+  replacement: "Schema.SchemaError"
+  note: "MsgPackError was removed with MessagePack. SchemaBinary channels fail with Schema.SchemaError."
+"@effect/platform/MsgPack#MsgPackError":
+  replacement: "Schema.SchemaError"
+  note: "MsgPackError was removed with MessagePack. SchemaBinary channels fail with Schema.SchemaError."
 "@effect/platform/MsgPack#pack":
-  replacement: "Msgpack.encode"
-  note: "The MessagePack channel constructor was renamed from pack to encode."
+  replacement: "SchemaBinary.encode"
+  note: "MessagePack was removed. Encode schema values to binary frames with SchemaBinary.encode."
 "@effect/platform/MsgPack#packSchema":
-  replacement: "Msgpack.encodeSchema"
-  note: "The schema-aware pack channel was renamed to encodeSchema."
+  replacement: "SchemaBinary.encode"
+  note: "MessagePack was removed. Use SchemaBinary.encode with the v4 Schema model."
 "@effect/platform/MsgPack#schema":
-  replacement: "Msgpack.schema"
-  note: "The schema helper remains in the moved module and uses the v4 Schema model."
+  replacement: "SchemaBinary.toCodec"
+  note: "MessagePack was removed. Derive a binary codec from a Schema with SchemaBinary.toCodec."
 "@effect/platform/MsgPack#unpack":
-  replacement: "Msgpack.decode"
-  note: "The MessagePack channel constructor was renamed from unpack to decode."
+  replacement: "SchemaBinary.decode"
+  note: "MessagePack was removed. Decode binary frames with SchemaBinary.decode."
 "@effect/platform/MsgPack#unpackSchema":
-  replacement: "Msgpack.decodeSchema"
-  note: "The schema-aware unpack channel was renamed to decodeSchema."
+  replacement: "SchemaBinary.decode"
+  note: "MessagePack was removed. Use SchemaBinary.decode with the v4 Schema model."

--- a/migration/annotations/effect__rpc__RpcSerialization.yaml
+++ b/migration/annotations/effect__rpc__RpcSerialization.yaml
@@ -1,0 +1,15 @@
+"@effect/rpc/RpcSerialization#RpcSerializationError":
+  replacement: "effect/unstable/rpc/RpcSerialization#MaxBufferSizeExceeded"
+  note: "Buffer-limit failures now use MaxBufferSizeExceeded. MessagePack-specific decode errors have no counterpart."
+"@effect/rpc/RpcSerialization#layerMsgPack":
+  replacement: "effect/unstable/rpc/RpcSerialization#layerSchemaBinary"
+  note: "MessagePack RPC serialization was removed. Use SchemaBinary, or layerNdjson when you need newline-delimited JSON framing."
+"@effect/rpc/RpcSerialization#layerMsgPackWith":
+  replacement: "effect/unstable/rpc/RpcSerialization#layerSchemaBinary"
+  note: "MessagePack RPC serialization was removed. Pass maxFrameSize to layerSchemaBinary; NDJSON buffer limits remain on layerNdjsonWith."
+"@effect/rpc/RpcSerialization#makeMsgPack":
+  replacement: "effect/unstable/rpc/RpcSerialization#layerSchemaBinary"
+  note: "MessagePack RPC serialization was removed. Construct SchemaBinary serialization with layerSchemaBinary."
+"@effect/rpc/RpcSerialization#msgPack":
+  replacement: "effect/unstable/rpc/RpcSerialization#layerSchemaBinary"
+  note: "The MessagePack RpcSerialization service value was removed. Provide layerSchemaBinary instead."

--- a/migration/annotations/effect__sql-pg__PgClient.yaml
+++ b/migration/annotations/effect__sql-pg__PgClient.yaml
@@ -1,6 +1,9 @@
+"@effect/sql-pg/PgClient#fromPool":
+  replacement: none
+  note: "Wrapping an existing node-pg Pool was removed with the native protocol client. Use PgClient.make or PgClient.layer with connection settings."
 "@effect/sql-pg/PgClient#layerFromPool":
-  replacement: "PgClient.layerFrom(PgClient.fromPool(options))"
-  note: "Compose fromPool with layerFrom; layerFrom now accepts an Effect acquiring a PgClient rather than pool options."
+  replacement: "PgClient.layer"
+  note: "Wrapping an existing node-pg Pool was removed. Provide connection settings to PgClient.layer instead."
 "@effect/sql-pg/PgClient#PgClient":
   replacement: "@effect/sql-pg/PgClient#PgClient"
   note: "Retained; the service value is now a Context.Service."
@@ -8,5 +11,5 @@
   replacement: "@effect/sql-pg/PgClient#PgClientConfig / PgPoolConfig"
   note: "Use PgClientConfig for base settings and PgPoolConfig for make/layer; pool sizing, idle timeout, and connection TTL moved to PgPoolConfig."
 "@effect/sql-pg/PgClient#PgClientFromPoolOptions":
-  replacement: "Parameters<typeof PgClient.fromPool>[0]"
-  note: "The named type was removed; derive the inline fromPool option type. PgPoolConfig is for creating a managed pool and is not equivalent."
+  replacement: none
+  note: "The node-pg Pool wrapper options were removed with fromPool. Use PgClient.PgPoolConfig with PgClient.make or PgClient.layer."

--- a/migration/v3-to-v4.md
+++ b/migration/v3-to-v4.md
@@ -2,9 +2,9 @@
 
 # v3 to v4 Migration Reference
 
-Base: `origin/v3` (`20596061bd24dd7f18c5b5c839111310d730d6e9`)
+Base: `origin/v3` (`7c6e1e5d2ac9dfe00649a65fa80a61dcc14d55ae`)
 
-Head: `HEAD` (`bda7819a3ce2995d568bac5321811665d68a8448`)
+Head: `HEAD` (`f356bc2da6abb4dee05b8c22fb597af3823e2ef7`)
 
 This file is generated from the API diff and `migration/annotations/*.yaml`.
 
@@ -31,7 +31,7 @@ effect/TReentrantLock -> effect/TxReentrantLock (barrel: effect)
 effect/TRef -> effect/TxRef (barrel: effect)
 effect/TSemaphore -> effect/TxSemaphore (barrel: effect)
 effect/TSubscriptionRef -> effect/TxSubscriptionRef (barrel: effect)
-effect/FastCheck -> effect/testing/FastCheck (barrel: effect/testing)
+effect/FastCheck -> fast-check
 effect/TestClock -> effect/testing/TestClock (barrel: effect/testing)
 @effect/cli/Args -> effect/unstable/cli/Argument (barrel: effect/unstable/cli)
 @effect/cli/ValidationError -> effect/unstable/cli/CliError (barrel: effect/unstable/cli)
@@ -84,7 +84,7 @@ effect/TestClock -> effect/testing/TestClock (barrel: effect/testing)
 @effect/experimental/DevTools/Client -> effect/unstable/devtools/DevToolsClient (barrel: effect/unstable/devtools)
 @effect/experimental/DevTools/Domain -> effect/unstable/devtools/DevToolsSchema (barrel: effect/unstable/devtools)
 @effect/experimental/DevTools/Server -> effect/unstable/devtools/DevToolsServer (barrel: effect/unstable/devtools)
-@effect/platform/MsgPack -> effect/unstable/encoding/Msgpack (barrel: effect/unstable/encoding)
+@effect/platform/MsgPack -> effect/unstable/encoding/SchemaBinary (barrel: effect/unstable/encoding)
 @effect/platform/Ndjson -> effect/unstable/encoding/Ndjson (barrel: effect/unstable/encoding)
 @effect/experimental/Sse -> effect/unstable/encoding/Sse (barrel: effect/unstable/encoding)
 @effect/ai/AiError -> effect/unstable/ai/AiError (barrel: effect/unstable/ai)
@@ -548,7 +548,7 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 - `@effect/platform/HttpServerResponse` -> `effect/unstable/http/HttpServerResponse`
 - `@effect/platform/HttpTraceContext` -> `effect/unstable/http/HttpTraceContext`
 - `@effect/platform/KeyValueStore` -> `effect/unstable/persistence/KeyValueStore`
-- `@effect/platform/MsgPack` -> `effect/unstable/encoding/Msgpack`
+- `@effect/platform/MsgPack` -> `effect/unstable/encoding/SchemaBinary`: MessagePack support was removed. Schema-aware encode, decode, and duplex now live on SchemaBinary. Untyped MessagePack of unknown values has no replacement.
 - `@effect/platform/Multipart` -> `effect/unstable/http/Multipart`
 - `@effect/platform/Ndjson` -> `effect/unstable/encoding/Ndjson`
 - `@effect/platform/OpenApi` -> `effect/unstable/httpapi/OpenApi`
@@ -682,14 +682,14 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 - `@effect/workflow/WorkflowEngine` -> `effect/unstable/workflow/WorkflowEngine`
 - `@effect/workflow/WorkflowProxy` -> `effect/unstable/workflow/WorkflowProxy`
 - `@effect/workflow/WorkflowProxyServer` -> `effect/unstable/workflow/WorkflowProxyServer`
-- `effect/Arbitrary`: No single module replacement; follow the curated per-API guidance below.
+- `effect/Arbitrary` -> `effect/unstable/arbitrary/Arbitrary`: Schema-derived generation moved to the native Arbitrary module. Effect no longer bridges to fast-check.
 - `effect/ChildExecutorDecision` -> `none`: Removed with the v3 channel executor and Channel.concatMapWithCustom. Choose Channel.flatMap, Channel.switchMap, or Channel.mergeAll instead; v4 exposes no child-executor decision ADT.
 - `effect/ConfigError`: No single module replacement; follow the curated per-API guidance below.
 - `effect/ConfigProviderPathPatch`: No single module replacement; follow the curated per-API guidance below.
 - `effect/DefaultServices`: No single module replacement; follow the curated per-API guidance below.
 - `effect/Either` -> `effect/Result`
 - `effect/ExecutionStrategy`: No single module replacement; follow the curated per-API guidance below.
-- `effect/FastCheck` -> `effect/testing/FastCheck`
+- `effect/FastCheck` -> `fast-check`: Effect no longer re-exports fast-check. Depend on the fast-check package and import it directly. For Schema-derived generation, use Arbitrary.schema from effect/unstable/arbitrary.
 - `effect/FiberId`: No single module replacement; follow the curated per-API guidance below.
 - `effect/FiberRef` -> `effect/References`
 - `effect/FiberRefs`: No single module replacement; follow the curated per-API guidance below.
@@ -5872,11 +5872,11 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `EventLogRemote.ProtocolRequest` -> `effect/unstable/eventlog/EventLogMessage#EventLogRemoteRpcs`: EventLogRemoteRpcs and generic RPC serialization replace the old protocol request union.
 
-- `EventLogRemote.ProtocolRequestMsgPack` -> `effect/unstable/rpc/RpcSerialization#layerMsgPack`: Use the generic MsgPack RPC serialization layer instead of a request-specific schema.
+- `EventLogRemote.ProtocolRequestMsgPack` -> `effect/unstable/rpc/RpcSerialization#layerSchemaBinary`: Use the generic SchemaBinary RPC serialization layer instead of a request-specific schema.
 
 - `EventLogRemote.ProtocolResponse` -> `effect/unstable/eventlog/EventLogMessage#EventLogRemoteRpcs`: EventLogRemoteRpcs and generic RPC serialization replace the old protocol response union.
 
-- `EventLogRemote.ProtocolResponseMsgPack` -> `effect/unstable/rpc/RpcSerialization#layerMsgPack`: Use the generic MsgPack RPC serialization layer instead of a response-specific schema.
+- `EventLogRemote.ProtocolResponseMsgPack` -> `effect/unstable/rpc/RpcSerialization#layerSchemaBinary`: Use the generic SchemaBinary RPC serialization layer instead of a response-specific schema.
 
 - `EventLogRemote.RemoteAdditions` -> `none`: This unused protocol model has no v4 counterpart.
 
@@ -5884,17 +5884,17 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `EventLogRemote.StopChanges` -> `none`: Interrupt the ChangesRpc stream instead of sending a StopChanges message.
 
-- `EventLogRemote.decodeRequest` -> `effect/unstable/eventlog/EventLogMessage#EventLogRemoteRpcs`: Generic RPC framing and RpcSerialization.layerMsgPack replace the module-specific request decoder.
+- `EventLogRemote.decodeRequest` -> `effect/unstable/eventlog/EventLogMessage#EventLogRemoteRpcs`: Generic RPC framing and RpcSerialization.layerSchemaBinary replace the module-specific request decoder.
 
-- `EventLogRemote.decodeResponse` -> `effect/unstable/eventlog/EventLogMessage#EventLogRemoteRpcs`: Generic RPC framing and RpcSerialization.layerMsgPack replace the module-specific response decoder.
+- `EventLogRemote.decodeResponse` -> `effect/unstable/eventlog/EventLogMessage#EventLogRemoteRpcs`: Generic RPC framing and RpcSerialization.layerSchemaBinary replace the module-specific response decoder.
 
-- `EventLogRemote.encodeRequest` -> `effect/unstable/eventlog/EventLogMessage#EventLogRemoteRpcs`: Generic RPC framing and RpcSerialization.layerMsgPack replace the module-specific request encoder.
+- `EventLogRemote.encodeRequest` -> `effect/unstable/eventlog/EventLogMessage#EventLogRemoteRpcs`: Generic RPC framing and RpcSerialization.layerSchemaBinary replace the module-specific request encoder.
 
-- `EventLogRemote.encodeResponse` -> `effect/unstable/eventlog/EventLogMessage#EventLogRemoteRpcs`: Generic RPC framing and RpcSerialization.layerMsgPack replace the module-specific response encoder.
+- `EventLogRemote.encodeResponse` -> `effect/unstable/eventlog/EventLogMessage#EventLogRemoteRpcs`: Generic RPC framing and RpcSerialization.layerSchemaBinary replace the module-specific response encoder.
 
 - `EventLogRemote.fromSocket` -> `effect/unstable/eventlog/EventLogRemote#makeEncrypted + effect/unstable/rpc/RpcClient#makeProtocolSocket`: Construct the encrypted remote separately from its generic RPC socket protocol.
 
-- `EventLogRemote.layerWebSocket` -> `effect/unstable/eventlog/EventLogRemote#layerEncrypted + effect/unstable/rpc/RpcClient#layerProtocolSocket`: Compose the encrypted remote with the generic socket protocol, MsgPack serialization, and a Socket provider.
+- `EventLogRemote.layerWebSocket` -> `effect/unstable/eventlog/EventLogRemote#layerEncrypted + effect/unstable/rpc/RpcClient#layerProtocolSocket`: Compose the encrypted remote with the generic socket protocol, SchemaBinary serialization, and a Socket provider.
 
 - `EventLogRemote.layerWebSocketBrowser` -> `effect/unstable/eventlog/EventLogRemote#layerEncrypted + effect/unstable/rpc/RpcClient#layerProtocolSocket + @effect/platform-browser/BrowserSocket#layerWebSocket`: Compose the encrypted remote and generic RPC socket protocol with the browser WebSocket layer.
 
@@ -5911,6 +5911,8 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 - `PersistedCache.make` -> `effect/unstable/persistence/PersistedCache#make`: Pass lookup as the first argument and options second; timeToLive now receives exit before request and the service is Persistence.Persistence.
 
 ### `@effect/experimental/PersistedQueue`
+
+- `PersistedQueue.ErrorTypeId` -> `effect/unstable/persistence/PersistedQueue#ErrorTypeId`: Retained as a string brand; the runtime marker now uses the persistence module path.
 
 - `PersistedQueue.TypeId` -> `effect/unstable/persistence/PersistedQueue#TypeId`: Import TypeId from the v4 unstable PersistedQueue module; it is now a string brand.
 
@@ -5973,6 +5975,8 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 - `Redis.make` -> `none`: V4 exposes Redis-backed layers over the Redis.Redis service, not a constructor that creates an ioredis client directly.
 
 ### `@effect/experimental/RateLimiter`
+
+- `RateLimiter.ErrorTypeId` -> `effect/unstable/persistence/RateLimiter#ErrorTypeId`: Retained as a string brand; the runtime marker now uses the persistence module path.
 
 - `RateLimiter.RateLimiterError` -> `effect/unstable/persistence/RateLimiter#RateLimiterError`: The retained name is now a wrapper error class whose reason is RateLimitExceeded or RateLimitStoreError.
 
@@ -7214,21 +7218,23 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 ### `@effect/platform/MsgPack`
 
-- `MsgPack.ErrorTypeId` -> `Msgpack.MsgPackError`: The public error type-id alias was removed; use the MsgPackError class.
+- `MsgPack.ErrorTypeId` -> `Schema.SchemaError`: MsgPackError was removed with MessagePack. SchemaBinary channels fail with Schema.SchemaError.
 
-- `MsgPack.duplex` -> `Msgpack.duplex`: The API moved to effect/unstable/encoding/Msgpack.
+- `MsgPack.MsgPackError` -> `Schema.SchemaError`: MsgPackError was removed with MessagePack. SchemaBinary channels fail with Schema.SchemaError.
 
-- `MsgPack.duplexSchema` -> `Msgpack.duplexSchema`: The API moved to effect/unstable/encoding/Msgpack and uses v4 Schema constraints.
+- `MsgPack.duplex` -> `SchemaBinary.duplex`: MessagePack was removed. Wrap a byte channel with SchemaBinary.duplex and explicit input and output schemas.
 
-- `MsgPack.pack` -> `Msgpack.encode`: The MessagePack channel constructor was renamed from pack to encode.
+- `MsgPack.duplexSchema` -> `SchemaBinary.duplex`: MessagePack was removed. Use SchemaBinary.duplex with the v4 Schema model.
 
-- `MsgPack.packSchema` -> `Msgpack.encodeSchema`: The schema-aware pack channel was renamed to encodeSchema.
+- `MsgPack.pack` -> `SchemaBinary.encode`: MessagePack was removed. Encode schema values to binary frames with SchemaBinary.encode.
 
-- `MsgPack.schema` -> `Msgpack.schema`: The schema helper remains in the moved module and uses the v4 Schema model.
+- `MsgPack.packSchema` -> `SchemaBinary.encode`: MessagePack was removed. Use SchemaBinary.encode with the v4 Schema model.
 
-- `MsgPack.unpack` -> `Msgpack.decode`: The MessagePack channel constructor was renamed from unpack to decode.
+- `MsgPack.schema` -> `SchemaBinary.toCodec`: MessagePack was removed. Derive a binary codec from a Schema with SchemaBinary.toCodec.
 
-- `MsgPack.unpackSchema` -> `Msgpack.decodeSchema`: The schema-aware unpack channel was renamed to decodeSchema.
+- `MsgPack.unpack` -> `SchemaBinary.decode`: MessagePack was removed. Decode binary frames with SchemaBinary.decode.
+
+- `MsgPack.unpackSchema` -> `SchemaBinary.decode`: MessagePack was removed. Use SchemaBinary.decode with the v4 Schema model.
 
 ### `@effect/platform/Multipart`
 
@@ -7650,7 +7656,15 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 ### `@effect/rpc/RpcSerialization`
 
-- `RpcSerialization.RpcSerializationError`: TODO: needs guidance
+- `RpcSerialization.RpcSerializationError` -> `effect/unstable/rpc/RpcSerialization#MaxBufferSizeExceeded`: Buffer-limit failures now use MaxBufferSizeExceeded. MessagePack-specific decode errors have no counterpart.
+
+- `RpcSerialization.layerMsgPack` -> `effect/unstable/rpc/RpcSerialization#layerSchemaBinary`: MessagePack RPC serialization was removed. Use SchemaBinary, or layerNdjson when you need newline-delimited JSON framing.
+
+- `RpcSerialization.layerMsgPackWith` -> `effect/unstable/rpc/RpcSerialization#layerSchemaBinary`: MessagePack RPC serialization was removed. Pass maxFrameSize to layerSchemaBinary; NDJSON buffer limits remain on layerNdjsonWith.
+
+- `RpcSerialization.makeMsgPack` -> `effect/unstable/rpc/RpcSerialization#layerSchemaBinary`: MessagePack RPC serialization was removed. Construct SchemaBinary serialization with layerSchemaBinary.
+
+- `RpcSerialization.msgPack` -> `effect/unstable/rpc/RpcSerialization#layerSchemaBinary`: The MessagePack RpcSerialization service value was removed. Provide layerSchemaBinary instead.
 
 ### `@effect/rpc/RpcServer`
 
@@ -7774,11 +7788,11 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `PgClient.PgClientConfig` -> `@effect/sql-pg/PgClient#PgClientConfig / PgPoolConfig`: Use PgClientConfig for base settings and PgPoolConfig for make/layer; pool sizing, idle timeout, and connection TTL moved to PgPoolConfig.
 
-- `PgClient.PgClientFromPoolOptions` -> `Parameters<typeof PgClient.fromPool>[0]`: The named type was removed; derive the inline fromPool option type. PgPoolConfig is for creating a managed pool and is not equivalent.
+- `PgClient.PgClientFromPoolOptions` -> `none`: The node-pg Pool wrapper options were removed with fromPool. Use PgClient.PgPoolConfig with PgClient.make or PgClient.layer.
 
-- `PgClient.fromPool`: TODO: needs guidance
+- `PgClient.fromPool` -> `none`: Wrapping an existing node-pg Pool was removed with the native protocol client. Use PgClient.make or PgClient.layer with connection settings.
 
-- `PgClient.layerFromPool` -> `PgClient.layerFrom(PgClient.fromPool(options))`: Compose fromPool with layerFrom; layerFrom now accepts an Effect acquiring a PgClient rather than pool options.
+- `PgClient.layerFromPool` -> `PgClient.layer`: Wrapping an existing node-pg Pool was removed. Provide connection settings to PgClient.layer instead.
 
 ### `@effect/sql-sqlite-bun/SqliteClient`
 
@@ -8530,34 +8544,34 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 ### `effect/Arbitrary`
 
-- `Arbitrary.ArbitraryAnnotation` -> `Schema.Annotations.ToArbitrary.Declaration`: Arbitrary derivation annotations now live in Schema.Annotations and use the toArbitrary key.
+- `Arbitrary.ArbitraryAnnotation` -> `Schema.Annotations.ToArbitrary.Declaration`: Arbitrary derivation annotations now live in Schema.Annotations. Attach a toCodecArbitrary declaration callback that returns a Schema Link.
 
-- `Arbitrary.ArbitraryGenerationContext` -> `Schema.Annotations.ToArbitrary.Context`: Use the v4 arbitrary-derivation context type from Schema.Annotations.
+- `Arbitrary.ArbitraryGenerationContext` -> `Schema.Annotations.ToArbitrary.DeclarationInput`: Native arbitrary callbacks receive DeclarationInput with decoded type-parameter schemas and normalized constraints.
 
-- `Arbitrary.LazyArbitrary` -> `Schema.Arbitrary`: The arbitrary factory type moved onto Schema.
+- `Arbitrary.LazyArbitrary` -> `effect/unstable/arbitrary/Arbitrary#Arbitrary`: The generated-value description is now the native Arbitrary interface from effect/unstable/arbitrary.
 
 #### `Arbitrary.make`
 
-**Replacement:** `Schema.toArbitrary`
+**Replacement:** `effect/unstable/arbitrary/Arbitrary#schema`
 
-Arbitrary derivation is now exposed directly by Schema.
+Derive a native Arbitrary from a Schema. Effect no longer bridges to fast-check.
 
 **Example**
 
 ```ts
-Schema.toArbitrary(schema)(FastCheck)
+Arbitrary.schema(schema)
 ```
 
 #### `Arbitrary.makeLazy`
 
-**Replacement:** `Schema.toArbitrary`
+**Replacement:** `effect/unstable/arbitrary/Arbitrary#schema`
 
-Lazy arbitrary derivation is now exposed directly by Schema.
+Lazy and eager Schema derivation are the same native Arbitrary.schema constructor.
 
 **Example**
 
 ```ts
-Schema.toArbitrary(schema)
+Arbitrary.schema(schema)
 ```
 
 ### `effect/Array`
@@ -10200,7 +10214,7 @@ Schema.toArbitrary(schema)
 
 - `FastCheck.BigIntConstraints`: TODO: needs guidance
 
-- `FastCheck.BigUintConstraints` -> `FastCheck.BigIntConstraints`: Import FastCheck from effect/testing. Unsigned bigint constraints were consolidated into BigIntConstraints with min: 0n.
+- `FastCheck.BigUintConstraints` -> `FastCheck.BigIntConstraints`: Depend on fast-check and import it directly. Unsigned bigint constraints were consolidated into BigIntConstraints with min: 0n.
 
 - `FastCheck.CloneValue`: TODO: needs guidance
 
@@ -10346,7 +10360,7 @@ Schema.toArbitrary(schema)
 
 - `FastCheck.SubarrayConstraints`: TODO: needs guidance
 
-- `FastCheck.UnicodeJsonSharedConstraints` -> `FastCheck.JsonSharedConstraints`: Import FastCheck from effect/testing. Unicode JSON generation was consolidated into JsonSharedConstraints.stringUnit.
+- `FastCheck.UnicodeJsonSharedConstraints` -> `FastCheck.JsonSharedConstraints`: Depend on fast-check and import it directly. Unicode JSON generation was consolidated into JsonSharedConstraints.stringUnit.
 
 - `FastCheck.UniqueArrayConstraints`: TODO: needs guidance
 
@@ -10398,7 +10412,7 @@ Schema.toArbitrary(schema)
 
 **Replacement:** `FastCheck.string`
 
-Import FastCheck from effect/testing. fast-check v4 replaced character arbitraries with string units.
+Depend on fast-check and import it directly. fast-check v4 replaced character arbitraries with string units.
 
 **Example**
 
@@ -10410,7 +10424,7 @@ FastCheck.string({ unit: "binary-ascii", minLength: 1, maxLength: 1 })
 
 **Replacement:** `FastCheck.string`
 
-Import FastCheck from effect/testing. Use the binary-ascii string unit.
+Depend on fast-check and import it directly. Use the binary-ascii string unit.
 
 **Example**
 
@@ -10434,7 +10448,7 @@ FastCheck.string({ ...constraints, unit: "binary-ascii" })
 
 **Replacement:** `FastCheck.constantFrom`
 
-Import FastCheck from effect/testing. Generate one base64 alphabet character; base64String remains for complete encoded strings.
+Depend on fast-check and import it directly. Generate one base64 alphabet character; base64String remains for complete encoded strings.
 
 **Example**
 
@@ -10448,13 +10462,13 @@ FastCheck.constantFrom(..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0
 
 - `FastCheck.bigInt64Array`: TODO: needs guidance
 
-- `FastCheck.bigIntN` -> `FastCheck.bigInt`: Import FastCheck from effect/testing. Express the signed bit range with min and max constraints.
+- `FastCheck.bigIntN` -> `FastCheck.bigInt`: Depend on fast-check and import it directly. Express the signed bit range with min and max constraints.
 
 #### `FastCheck.bigUint`
 
 **Replacement:** `FastCheck.bigInt`
 
-Import FastCheck from effect/testing. Use a minimum of 0n and the previous maximum.
+Depend on fast-check and import it directly. Use a minimum of 0n and the previous maximum.
 
 **Example**
 
@@ -10468,7 +10482,7 @@ FastCheck.bigInt({ min: 0n, max })
 
 **Replacement:** `FastCheck.bigInt`
 
-Import FastCheck from effect/testing. Express the unsigned bit range with min and max constraints.
+Depend on fast-check and import it directly. Express the unsigned bit range with min and max constraints.
 
 **Example**
 
@@ -10482,7 +10496,7 @@ FastCheck.bigInt({ min: 0n, max: (1n << BigInt(n)) - 1n })
 
 **Replacement:** `FastCheck.string`
 
-Import FastCheck from effect/testing. Use a one-unit printable ASCII string.
+Depend on fast-check and import it directly. Use a one-unit printable ASCII string.
 
 **Example**
 
@@ -10494,7 +10508,7 @@ FastCheck.string({ unit: "grapheme-ascii", minLength: 1, maxLength: 1 })
 
 **Replacement:** `FastCheck.nat`
 
-Import FastCheck from effect/testing. Map a 16-bit natural number through String.fromCharCode.
+Depend on fast-check and import it directly. Map a 16-bit natural number through String.fromCharCode.
 
 **Example**
 
@@ -10502,7 +10516,7 @@ Import FastCheck from effect/testing. Map a 16-bit natural number through String
 FastCheck.nat({ max: 0xffff }).map(String.fromCharCode)
 ```
 
-- `FastCheck.check` -> `FastCheck.check`: Import FastCheck from effect/testing. The runner remains, but RunDetails.error was replaced by errorInstance in fast-check v4.
+- `FastCheck.check` -> `FastCheck.check`: Depend on fast-check and import it directly. The runner remains, but RunDetails.error was replaced by errorInstance in fast-check v4.
 
 - `FastCheck.clone`: TODO: needs guidance
 
@@ -10518,11 +10532,11 @@ FastCheck.nat({ max: 0xffff }).map(String.fromCharCode)
 
 - `FastCheck.configureGlobal`: TODO: needs guidance
 
-- `FastCheck.constant` -> `FastCheck.constant`: Import FastCheck from effect/testing. The API remains; v4 infers literal types by default.
+- `FastCheck.constant` -> `FastCheck.constant`: Depend on fast-check and import it directly. The API remains; v4 infers literal types by default.
 
 - `FastCheck.constantFrom`: TODO: needs guidance
 
-- `FastCheck.context` -> `FastCheck.context`: Import FastCheck from effect/testing. The API is otherwise unchanged.
+- `FastCheck.context` -> `FastCheck.context`: Depend on fast-check and import it directly. The API is otherwise unchanged.
 
 - `FastCheck.createDepthIdentifier`: TODO: needs guidance
 
@@ -10550,7 +10564,7 @@ FastCheck.nat({ max: 0xffff }).map(String.fromCharCode)
 
 **Replacement:** `FastCheck.string`
 
-Import FastCheck from effect/testing. Use a one-unit binary Unicode string.
+Depend on fast-check and import it directly. Use a one-unit binary Unicode string.
 
 **Example**
 
@@ -10562,7 +10576,7 @@ FastCheck.string({ unit: "binary", minLength: 1, maxLength: 1 })
 
 **Replacement:** `FastCheck.string`
 
-Import FastCheck from effect/testing. Use the binary string unit.
+Depend on fast-check and import it directly. Use the binary string unit.
 
 **Example**
 
@@ -10584,9 +10598,9 @@ FastCheck.string({ ...constraints, unit: "binary" })
 
 - `FastCheck.hash`: TODO: needs guidance
 
-- `FastCheck.hexa` -> `FastCheck.integer`: Import FastCheck from effect/testing. Map an integer from 0 through 15 to a hexadecimal character.
+- `FastCheck.hexa` -> `FastCheck.integer`: Depend on fast-check and import it directly. Map an integer from 0 through 15 to a hexadecimal character.
 
-- `FastCheck.hexaString` -> `FastCheck.string`: Import FastCheck from effect/testing. Pass a hexadecimal-character arbitrary as the string unit.
+- `FastCheck.hexaString` -> `FastCheck.string`: Depend on fast-check and import it directly. Pass a hexadecimal-character arbitrary as the string unit.
 
 - `FastCheck.infiniteStream`: TODO: needs guidance
 
@@ -10662,11 +10676,11 @@ FastCheck.string({ ...constraints, unit: "binary" })
 
 - `FastCheck.statistics`: TODO: needs guidance
 
-- `FastCheck.stream` -> `FastCheck.stream`: Import FastCheck from effect/testing. The API remains; update custom generator and Random implementations for fast-check v4 typings.
+- `FastCheck.stream` -> `FastCheck.stream`: Depend on fast-check and import it directly. The API remains; update custom generator and Random implementations for fast-check v4 typings.
 
 - `FastCheck.string`: TODO: needs guidance
 
-- `FastCheck.string16bits` -> `FastCheck.string`: Import FastCheck from effect/testing. Pass a char16bits-compatible arbitrary as the string unit.
+- `FastCheck.string16bits` -> `FastCheck.string`: Depend on fast-check and import it directly. Pass a char16bits-compatible arbitrary as the string unit.
 
 - `FastCheck.stringMatching`: TODO: needs guidance
 
@@ -10674,7 +10688,7 @@ FastCheck.string({ ...constraints, unit: "binary" })
 
 **Replacement:** `FastCheck.string`
 
-Import FastCheck from effect/testing. Pass the former character arbitrary as the unit constraint.
+Depend on fast-check and import it directly. Pass the former character arbitrary as the unit constraint.
 
 **Example**
 
@@ -10698,13 +10712,13 @@ FastCheck.string({ ...constraints, unit: arbitrary })
 
 - `FastCheck.ulid`: TODO: needs guidance
 
-- `FastCheck.unicode` -> `FastCheck.integer`: Import FastCheck from effect/testing. Map BMP code points while excluding surrogate code points; prefer the binary string unit for full Unicode.
+- `FastCheck.unicode` -> `FastCheck.integer`: Depend on fast-check and import it directly. Map BMP code points while excluding surrogate code points; prefer the binary string unit for full Unicode.
 
 #### `FastCheck.unicodeJson`
 
 **Replacement:** `FastCheck.json`
 
-Import FastCheck from effect/testing. Select binary or grapheme strings with stringUnit.
+Depend on fast-check and import it directly. Select binary or grapheme strings with stringUnit.
 
 **Example**
 
@@ -10716,7 +10730,7 @@ FastCheck.json({ stringUnit: "binary" })
 
 **Replacement:** `FastCheck.jsonValue`
 
-Import FastCheck from effect/testing. Select binary or grapheme strings with stringUnit.
+Depend on fast-check and import it directly. Select binary or grapheme strings with stringUnit.
 
 **Example**
 
@@ -10724,7 +10738,7 @@ Import FastCheck from effect/testing. Select binary or grapheme strings with str
 FastCheck.jsonValue({ stringUnit: "binary" })
 ```
 
-- `FastCheck.unicodeString` -> `FastCheck.string`: Import FastCheck from effect/testing. Pass a BMP-code-point arbitrary as the unit constraint; prefer unit: binary for full Unicode.
+- `FastCheck.unicodeString` -> `FastCheck.string`: Depend on fast-check and import it directly. Pass a BMP-code-point arbitrary as the unit constraint; prefer unit: binary for full Unicode.
 
 - `FastCheck.uniqueArray`: TODO: needs guidance
 
@@ -10734,7 +10748,7 @@ FastCheck.jsonValue({ stringUnit: "binary" })
 
 **Replacement:** `FastCheck.uuid`
 
-Import FastCheck from effect/testing. Specify the UUID version through constraints.
+Depend on fast-check and import it directly. Specify the UUID version through constraints.
 
 **Example**
 
@@ -14755,7 +14769,7 @@ Schema.toFormatter(schema)
 
 - `SchemaAST.AnyKeyword` -> `SchemaAST.Any`: The v4 SchemaAST redesign renamed this primitive, collection, or guard while preserving its role.
 
-- `SchemaAST.ArbitraryAnnotationId` -> `Schema.Annotations.ToArbitrary`: Symbol annotation IDs were removed; use the toArbitrary annotation key and its Schema.Annotations types.
+- `SchemaAST.ArbitraryAnnotationId` -> `Schema.Annotations.ToArbitrary`: Symbol annotation IDs were removed. Declarations use the toCodecArbitrary annotation; filters use arbitraryConstraint.
 
 - `SchemaAST.BatchingAnnotation` -> `none`: Per-schema batching annotations were removed; control asynchronous parsing with ParseOptions.concurrency.
 
@@ -16344,7 +16358,7 @@ Exit.isExit(take)
 
 ### `effect/TestConfig`
 
-- `TestConfig.TestConfig` -> `none`: There is no v4 TestConfig service. Move runner settings to Vitest and FastCheck options, or define an application-specific Context.Reference if runtime access is needed.
+- `TestConfig.TestConfig` -> `none`: There is no v4 TestConfig service. Move runner settings to Vitest and native Arbitrary check options, or define an application-specific Context.Reference if runtime access is needed.
 
 - `TestConfig.make` -> `{ repeats, retries, samples, shrinks }`: The v3 constructor only returned its parameter object. The TestConfig service was removed; keep a plain object only for application-owned configuration.
 
@@ -16392,9 +16406,9 @@ Exit.isExit(take)
 
 - `TestServices.retries` -> `Vitest TestOptions.retry`: Configure retry in Vitest test options. To retry an Effect inside a test, use Effect.retry.
 
-- `TestServices.samples` -> `{ fastCheck: { numRuns } }`: Pass the run count through @effect/vitest property-test options, for example it.effect.prop(..., { fastCheck: { numRuns: samples } }).
+- `TestServices.samples` -> `{ arbitrary: { runs } }`: Pass the run count through @effect/vitest property-test options, for example it.effect.prop(..., { arbitrary: { runs: samples } }).
 
-- `TestServices.shrinks` -> `none`: The legacy maximum-shrinks service setting was removed; @effect/vitest forwards FastCheck.Parameters, which has no equivalent service value.
+- `TestServices.shrinks` -> `{ arbitrary: { maxShrinks } }`: Pass maxShrinks through @effect/vitest property-test options, for example it.effect.prop(..., { arbitrary: { maxShrinks } }).
 
 - `TestServices.size` -> `CurrentSize`: Define a custom Context.Reference\<number\> and yield it to read the current size.
 
@@ -16406,11 +16420,11 @@ Exit.isExit(take)
 
 - `TestServices.supervisedFibers` -> `none`: The annotation service was removed. Use Vitest metadata/options for runner concerns, an ordinary Ref or Context.Reference for application-owned test state, and FiberSet for explicit fiber tracking.
 
-- `TestServices.testConfig` -> `none`: The runner no longer reads an Effect TestConfig service. Use Vitest TestOptions and property-test fastCheck options; model application state as a custom Context.Reference.
+- `TestServices.testConfig` -> `none`: The runner no longer reads an Effect TestConfig service. Use Vitest TestOptions and property-test arbitrary options; model application state as a custom Context.Reference.
 
-- `TestServices.testConfigLayer` -> `none`: The runner no longer reads an Effect TestConfig service. Use Vitest TestOptions and property-test fastCheck options; model application state as a custom Context.Reference.
+- `TestServices.testConfigLayer` -> `none`: The runner no longer reads an Effect TestConfig service. Use Vitest TestOptions and property-test arbitrary options; model application state as a custom Context.Reference.
 
-- `TestServices.testConfigWith` -> `none`: The runner no longer reads an Effect TestConfig service. Use Vitest TestOptions and property-test fastCheck options; model application state as a custom Context.Reference.
+- `TestServices.testConfigWith` -> `none`: The runner no longer reads an Effect TestConfig service. Use Vitest TestOptions and property-test arbitrary options; model application state as a custom Context.Reference.
 
 - `TestServices.withAnnotations` -> `none`: The annotation service was removed. Use Vitest metadata/options for runner concerns, an ordinary Ref or Context.Reference for application-owned test state, and FiberSet for explicit fiber tracking.
 
@@ -16424,9 +16438,9 @@ Exit.isExit(take)
 
 - `TestServices.withSizedScoped` -> `Effect.updateServiceScoped(CurrentSize, () => size)`: For a scope-bounded override use updateServiceScoped; otherwise prefer wrapping the workflow with Effect.provideService.
 
-- `TestServices.withTestConfig` -> `none`: The runner no longer reads an Effect TestConfig service. Use Vitest TestOptions and property-test fastCheck options; model application state as a custom Context.Reference.
+- `TestServices.withTestConfig` -> `none`: The runner no longer reads an Effect TestConfig service. Use Vitest TestOptions and property-test arbitrary options; model application state as a custom Context.Reference.
 
-- `TestServices.withTestConfigScoped` -> `none`: The runner no longer reads an Effect TestConfig service. Use Vitest TestOptions and property-test fastCheck options; model application state as a custom Context.Reference.
+- `TestServices.withTestConfigScoped` -> `none`: The runner no longer reads an Effect TestConfig service. Use Vitest TestOptions and property-test arbitrary options; model application state as a custom Context.Reference.
 
 ### `effect/TestSized`
 


### PR DESCRIPTION
Updates the v3-to-v4 migration reference for public API removals merged since the previous maintenance baseline.

- MessagePack encoding and RPC serialization now point at SchemaBinary / `layerSchemaBinary`.
- Schema-derived FastCheck generation now points at native `Arbitrary.schema`. Effect no longer re-exports fast-check.
- `PgClient.fromPool` / `layerFromPool` are documented as removed with the native PostgreSQL client.
- Regenerates the reference header at main SHA `f356bc2da6abb4dee05b8c22fb597af3823e2ef7`.

Validation:

- `pnpm vitest run --project @effect/api-diff` (25 tests passed)
- `pnpm --dir packages/tools/api-diff check`
- `git diff --check`
- The pinned full `api-diff --check` still exits nonzero. In-scope IDs from this range are annotated. Remaining gaps: `EventLogRemote.Ping`, `OpenApiJsonSchema.Unknown`, `Workflow.Complete`, the `ParseResult` group (`ParseError`, `decode`, `encode`), plus FastCheck combinators that still exist in the `fast-check` package (module-level guidance only), and a few out-of-scope current-main gaps (`EmbeddingModel.Result`, `Args.mapEffect`, `Command.Config`, `Either.flatMap`, `Exit.flatMap`, `List.flatMap`, `SortedSet.flatMap`).

Closes EFF-937