### PR TITLE
Reject head-side IPv4 tails in the PostgreSQL inet codec

### DIFF
--- a/packages/sql/pg/src/PgTypes.ts
+++ b/packages/sql/pg/src/PgTypes.ts
@@ -680,6 +680,7 @@ const parseIPv6 = (text: string): Uint8Array | undefined => {
   const embedded = trailing.includes(".") ? parseIPv4(trailing) : undefined
   if (trailing.includes(".") && embedded === undefined) return undefined
   if (embedded !== undefined) {
+    if (halves.length === 2 && tail.length === 0) return undefined
     if (tail.length > 0) tail.pop()
     else head.pop()
   }

--- a/packages/sql/pg/test/PgTypes.test.ts
+++ b/packages/sql/pg/test/PgTypes.test.ts
@@ -353,6 +353,10 @@ describe("PgTypes", () => {
       assertThrowsTagged("PgTypesCodecError", () => PgTypes.encode("2001:db8::1/32", PgTypes.OID.cidr))
     })
 
+    it("rejects an embedded IPv4 address before IPv6 compression", () => {
+      assertThrowsTagged("PgTypesCodecError", () => PgTypes.encode("1.2.3.4::", PgTypes.OID.inet))
+    })
+
     it("rejects invalid network masks and CIDR host bits on decode", () => {
       for (
         const [wire, oid] of [


### PR DESCRIPTION
## Summary

- reject an embedded IPv4 group that appears before IPv6 `::` compression
- cover the invalid `1.2.3.4::` input through the public `PgTypes.encode` API

## Testing

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/sql/pg/test/PgTypes.test.ts`
- `nix develop -c pnpm check`

Closes EFF-946
