### PR TITLE
Allow configuring PostgreSQL backend message size

### DIFF
--- a/.changeset/large-postgres-messages.md
+++ b/.changeset/large-postgres-messages.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-pg": patch
+---
+
+Add a `maxMessageSize` connection option so PostgreSQL clients can receive backend messages larger than the 16 MiB default.

--- a/packages/sql/pg/src/PgClient.ts
+++ b/packages/sql/pg/src/PgClient.ts
@@ -119,6 +119,8 @@ export interface PgClientConfig {
   readonly prepare?: boolean | undefined
   /** How many statements a connection keeps prepared. Defaults to `100`. */
   readonly preparedStatementCacheSize?: number | undefined
+  /** Maximum backend message size in bytes. Defaults to 16 MiB. */
+  readonly maxMessageSize?: number | undefined
 }
 
 /**

--- a/packages/sql/pg/src/PgConnection.ts
+++ b/packages/sql/pg/src/PgConnection.ts
@@ -94,6 +94,8 @@ export interface Config {
   readonly multiplex?: boolean | undefined
   readonly prepare?: boolean | undefined
   readonly preparedStatementCacheSize?: number | undefined
+  /** Maximum backend message size in bytes. Defaults to 16 MiB. */
+  readonly maxMessageSize?: number | undefined
 }
 
 /**
@@ -2010,7 +2012,7 @@ const connect = (config: ResolvedConfig): Effect.Effect<Session, SqlError> =>
     }
 
     const startup = (): void => {
-      parser = PgProtocol.makeParser<unknown>()
+      parser = PgProtocol.makeParser<unknown>({ maxMessageSize: config.maxMessageSize })
       socket.on("data", onData)
       socket.write(PgProtocol.encodeStartupMessage({
         user: config.username,
@@ -2022,7 +2024,7 @@ const connect = (config: ResolvedConfig): Effect.Effect<Session, SqlError> =>
     const onSslResponse = (chunk: Uint8Array): void => {
       if (done) return
       if (sslErrorParser !== undefined || chunk[0] === 0x45) {
-        sslErrorParser ??= PgProtocol.makeParser()
+        sslErrorParser ??= PgProtocol.makeParser({ maxMessageSize: config.maxMessageSize })
         let messages: ReadonlyArray<PgProtocol.BackendMessage>
         try {
           messages = sslErrorParser.push(chunk)
@@ -2117,6 +2119,7 @@ interface ResolvedConfig {
   readonly connectTimeout: Duration.Duration
   readonly applicationName: string
   readonly stream: (() => Duplex) | undefined
+  readonly maxMessageSize: number | undefined
 }
 
 const configError = (message: string, cause?: unknown): SqlError =>
@@ -2151,7 +2154,8 @@ const resolveConfig = (options: Config): Effect.Effect<ResolvedConfig, SqlError>
       password: options.password !== undefined ? Redacted.value(options.password) : url.password,
       connectTimeout: Duration.fromInputUnsafe(options.connectTimeout ?? url.connectTimeout ?? Duration.seconds(5)),
       applicationName: options.applicationName ?? url.applicationName ?? "@effect/sql-pg",
-      stream: options.stream
+      stream: options.stream,
+      maxMessageSize: options.maxMessageSize
     })
   })
 

--- a/packages/sql/pg/test/PgConnection.in-process.test.ts
+++ b/packages/sql/pg/test/PgConnection.in-process.test.ts
@@ -20,6 +20,12 @@ const int32 = (value: number): Buffer => {
   return bytes
 }
 
+const int16 = (value: number): Buffer => {
+  const bytes = Buffer.allocUnsafe(2)
+  bytes.writeInt16BE(value)
+  return bytes
+}
+
 const authentication = (method: number, payload: Uint8Array = Buffer.alloc(0)): Buffer =>
   backendMessage("R", Buffer.concat([int32(method), payload]))
 
@@ -142,6 +148,61 @@ const withUnixServer = (
   )
 
 describe("PgConnection in-process server", () => {
+  it.effect("accepts backend messages over the default limit when configured", () =>
+    Effect.gen(function*() {
+      const fieldSize = 16 * 1024 * 1024
+      const field = Buffer.alloc(fieldSize, 0x78)
+      const rowDescription = backendMessage(
+        "T",
+        Buffer.concat([
+          int16(1),
+          Buffer.from("big\0"),
+          int32(0),
+          int16(0),
+          int32(25),
+          int16(-1),
+          int32(-1),
+          int16(1)
+        ])
+      )
+      const dataRow = backendMessage("D", Buffer.concat([int16(1), int32(field.length), field]))
+      const result = Buffer.concat([
+        backendMessage("1", Buffer.alloc(0)),
+        backendMessage("2", Buffer.alloc(0)),
+        rowDescription,
+        dataRow,
+        backendMessage("C", Buffer.from("SELECT 1\0")),
+        readyForQuery
+      ])
+      let writes = 0
+      const socket: Duplex = new Duplex({
+        read() {},
+        write(_chunk: Buffer, _encoding, callback) {
+          writes++
+          queueMicrotask(() => {
+            socket.push(
+              writes === 1
+                ? Buffer.concat([authenticationOk, backendKeyData, readyForQuery])
+                : writes === 2
+                ? result
+                : emptyQueryResult
+            )
+          })
+          callback()
+        }
+      })
+      const connection = yield* PgConnection.make({
+        username: "test",
+        stream: () => socket,
+        maxMessageSize: 17 * 1024 * 1024
+      })
+
+      const oversized = yield* connection.query("SELECT repeat('x', 16777216) AS big")
+      assert.strictEqual(typeof oversized.rows[0].big, "string")
+      assert.strictEqual((oversized.rows[0].big as string).length, fieldSize)
+      assert.deepStrictEqual((yield* connection.query("SELECT 1")).rows, [])
+    }))
+
   it.effect("flushes concurrently submitted multiplexed queries in one write", () =>
     Effect.gen(function*() {
       const writes: Array<Buffer> = []


### PR DESCRIPTION
## Summary

- expose `maxMessageSize` on PostgreSQL connection and client configuration
- pass the configured limit to startup, TLS-error, and session parsers
- cover a 16 MiB `DataRow` and verify the connection remains usable

## Validation

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/sql/pg/test/PgConnection.in-process.test.ts`
- `nix develop -c pnpm check`
- `nix develop -c pnpm exec changeset status`

Closes EFF-942
