### PR TITLE
Fix zero-TTL PostgreSQL pool churn

### DIFF
--- a/.changeset/fresh-pools-rotate.md
+++ b/.changeset/fresh-pools-rotate.md
@@ -1,0 +1,6 @@
+---
+"@effect/sql-pg": patch
+---
+
+Allow each PostgreSQL pool connection to complete its first checkout before applying `connectionTTL`, so a zero TTL
+disables connection reuse without entering an invalidate/reconnect loop.

--- a/packages/sql/pg/src/PgPool.ts
+++ b/packages/sql/pg/src/PgPool.ts
@@ -49,6 +49,7 @@ export type TypeId = "~@effect/sql-pg/PgPool"
  *
  * The defaults are 0 to 10 connections and a 10-second idle timeout.
  * `connectionTTL` replaces connections that exceed the configured lifetime.
+ * Every connection is used at least once, so a TTL of zero disables reuse.
  *
  * With `multiplex` enabled, fibers may share pooled connections for pipelined
  * queries. Reserved connections remain exclusive. Without multiplexing, every
@@ -142,6 +143,7 @@ export const make = Effect.fnUntraced(function*(options: Config): Effect.fn.Retu
     : undefined
   const deadConnections = new Set<PgConnection.PgConnection>()
   const createdAt = new WeakMap<PgConnection.PgConnection, number>()
+  const checkedOut = new WeakSet<PgConnection.PgConnection>()
 
   // Assigned below, once the pool exists. `acquire` only runs when the pool
   // opens a connection, which is always after that.
@@ -177,6 +179,10 @@ export const make = Effect.fnUntraced(function*(options: Config): Effect.fn.Retu
   const expired = (connection: PgConnection.PgConnection): boolean => {
     if (connectionInternals(connection).deadError() !== undefined) return true
     if (connectionTTL === undefined) return false
+    if (!checkedOut.has(connection)) {
+      checkedOut.add(connection)
+      return false
+    }
     const openedAt = createdAt.get(connection)
     return openedAt !== undefined && clock.currentTimeMillisUnsafe() - openedAt >= connectionTTL
   }

--- a/packages/sql/pg/test/PgPool.integration.test.ts
+++ b/packages/sql/pg/test/PgPool.integration.test.ts
@@ -26,6 +26,17 @@ it.layer(PgContainer.layer, { timeout: "30 seconds" })("PgPool", (it) => {
       assert.strictEqual(first, second)
     }))
 
+  it.effect("uses a connection once when its TTL is zero", () =>
+    Effect.gen(function*() {
+      const pool = yield* PgPool.make({ ...(yield* poolConfig), connectionTTL: 0, maxConnections: 1 })
+      const checkout = Effect.scoped(Effect.map(pool.get, (connection) => connection.processId)).pipe(
+        Effect.timeout("1 second")
+      )
+      const first = yield* checkout
+      const second = yield* checkout
+      assert.notStrictEqual(first, second)
+    }))
+
   it.effect("streams rows incrementally and cancels on early abort", () =>
     Effect.gen(function*() {
       const pool = yield* PgPool.make(yield* poolConfig)


### PR DESCRIPTION
## Summary

- let every PostgreSQL pool connection complete its first checkout before applying `connectionTTL`
- define a zero TTL as "use once, then replace" instead of entering an invalidate/reconnect loop
- add an integration regression that requires prompt checkout and a fresh backend session on reuse

## Validation

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`
- `EFFECT_INTEGRATION_TESTS=1 nix develop -c pnpm test --run packages/sql/pg/test/PgPool.integration.test.ts`

The repository-wide `pnpm jsdocs --check` still fails on existing JSDoc violations across the tree.

Closes EFF-945
