### PR TITLE
Reject overlong PostgreSQL channel names

### DIFF
--- a/.changeset/postgres-channel-names.md
+++ b/.changeset/postgres-channel-names.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-pg": patch
+---
+
+Reject PostgreSQL LISTEN and NOTIFY channel names longer than 63 UTF-8 bytes.

--- a/packages/sql/pg/src/PgClient.ts
+++ b/packages/sql/pg/src/PgClient.ts
@@ -21,6 +21,7 @@ import type { Custom, Fragment } from "effect/unstable/sql/Statement"
 import * as Statement from "effect/unstable/sql/Statement"
 import type { Duplex } from "node:stream"
 import type { ConnectionOptions } from "node:tls"
+import { validateChannelName } from "./internal/sqlError.ts"
 import * as PgConnection from "./PgConnection.ts"
 import * as PgPool from "./PgPool.ts"
 import * as PgTypes from "./PgTypes.ts"
@@ -230,11 +231,15 @@ const makeImpl = Effect.fnUntraced(function*(
       config,
       json: (_: unknown) => Statement.fragment([PgJson(_)]),
       listen,
-      notify: (channel: string, payload: string) =>
-        Effect.asVoid(Effect.scoped(Effect.flatMap(
-          options.acquirer,
-          (conn) => conn.executeRaw(`SELECT pg_notify($1, $2)`, [channel, payload])
-        )))
+      notify: (channel: string, payload: string) => {
+        const channelError = validateChannelName(channel, "notify")
+        return channelError !== undefined ?
+          Effect.fail(channelError) :
+          Effect.asVoid(Effect.scoped(Effect.flatMap(
+            options.acquirer,
+            (conn) => conn.executeRaw(`SELECT pg_notify($1, $2)`, [channel, payload])
+          )))
+      }
     }
   )
 })

--- a/packages/sql/pg/src/PgConnection.ts
+++ b/packages/sql/pg/src/PgConnection.ts
@@ -34,7 +34,7 @@ import type { Duplex } from "node:stream"
 import * as Tls from "node:tls"
 import type { ConnectionOptions } from "node:tls"
 import { type ConnectionInternals, internalsKey } from "./internal/connection.ts"
-import { classifySqlState } from "./internal/sqlError.ts"
+import { classifySqlState, validateChannelName } from "./internal/sqlError.ts"
 import * as PgAuth from "./PgAuth.ts"
 import * as PgProtocol from "./PgProtocol.ts"
 import * as PgTypes from "./PgTypes.ts"
@@ -1771,6 +1771,8 @@ const listenChannel = (
 ): Effect.Effect<Queue.Dequeue<Notification>, SqlError, Scope.Scope> =>
   Effect.uninterruptibleMask((restore) =>
     Effect.gen(function*() {
+      const channelError = validateChannelName(channel, "listen")
+      if (channelError !== undefined) return yield* Effect.fail(channelError)
       const parentScope = yield* Scope.Scope
       const scope = yield* Scope.fork(parentScope)
       return yield* restore(Effect.gen(function*() {

--- a/packages/sql/pg/src/internal/sqlError.ts
+++ b/packages/sql/pg/src/internal/sqlError.ts
@@ -6,6 +6,7 @@ import {
   DeadlockError,
   LockTimeoutError,
   SerializationError,
+  SqlError,
   type SqlErrorReason,
   SqlSyntaxError,
   StatementTimeoutError,
@@ -17,6 +18,14 @@ interface ErrorProps {
   readonly cause: unknown
   readonly message: string
   readonly operation: string
+}
+
+const channelNameEncoder = new TextEncoder()
+
+export const validateChannelName = (channel: string, operation: string): SqlError | undefined => {
+  if (channelNameEncoder.encode(channel).byteLength <= 63) return undefined
+  const message = "PostgreSQL channel names must not exceed 63 UTF-8 bytes"
+  return new SqlError({ reason: new UnknownError({ cause: new Error(message), message, operation }) })
 }
 
 const normalizeConstraint = (constraint: unknown): string => {

--- a/packages/sql/pg/test/Client.integration.test.ts
+++ b/packages/sql/pg/test/Client.integration.test.ts
@@ -528,4 +528,22 @@ it.layer(PgContainer.layerClientForListen, { timeout: "30 seconds" })("PgClient 
       )
       expect(payload.payload).toEqual("payload")
     }).pipe(TestClock.withLive), 20_000)
+
+  it.effect("listen rejects channel names longer than 63 UTF-8 bytes", () =>
+    Effect.gen(function*() {
+      const sql = yield* PgClient.PgClient
+      const error = yield* Effect.flip(sql.listen("é".repeat(32)))
+
+      assert.strictEqual(error.message, "PostgreSQL channel names must not exceed 63 UTF-8 bytes")
+      assert.strictEqual(error.reason.operation, "listen")
+    }))
+
+  it.effect("notify rejects channel names longer than 63 UTF-8 bytes", () =>
+    Effect.gen(function*() {
+      const sql = yield* PgClient.PgClient
+      const error = yield* Effect.flip(sql.notify("é".repeat(32), "payload"))
+
+      assert.strictEqual(error.message, "PostgreSQL channel names must not exceed 63 UTF-8 bytes")
+      assert.strictEqual(error.reason.operation, "notify")
+    }))
 })


### PR DESCRIPTION
## Summary

- reject LISTEN and NOTIFY channel names longer than PostgreSQL's 63-byte identifier limit
- measure UTF-8 bytes so multibyte names cannot bypass the check
- return a clear `SqlError` before reserving a listener connection or sending a query
- cover both public operations against PostgreSQL

## Validation

- `nix develop -c pnpm lint-fix`
- `EFFECT_INTEGRATION_TESTS=1 nix develop -c pnpm test --run packages/sql/pg/test/Client.integration.test.ts` (33 tests)
- `nix develop -c pnpm check`
- `nix develop -c pnpm exec changeset status`

Closes EFF-944
