### PR TITLE
Fix SchemaBinary dictionary and number array handling

### DIFF
--- a/packages/effect/src/unstable/encoding/SchemaBinary.ts
+++ b/packages/effect/src/unstable/encoding/SchemaBinary.ts
@@ -3680,7 +3680,7 @@ function encodeArray(ctx: EncodeContext, layout: ArrayLayout, arr: ReadonlyArray
   const uniform = layout.uniform
   if (uniform !== undefined) {
     if (layout.uniformNumbers) {
-      encodeNumberRun(arr, count, w)
+      encodeNumberRun(ctx, arr, count, w)
       return
     }
     // Only a run field holding an array of strings hands over an intern table.
@@ -3721,22 +3721,23 @@ function encodeArray(ctx: EncodeContext, layout: ArrayLayout, arr: ReadonlyArray
 // synchronous `encodeNumberRun` call.
 const numberRunScales: Array<number> = []
 
-function encodeNumberRun(arr: ReadonlyArray<unknown>, count: number, w: Writer) {
+function encodeNumberRun(ctx: EncodeContext, arr: ReadonlyArray<unknown>, count: number, w: Writer) {
   let varint = true
   let decimal = true
   for (let i = 0; i < count; i++) {
     const value = arr[i]
+    if (typeof value !== "number") {
+      issuePath[issuePathLen++] = i
+      encodeFail("a number", value, ctx.options)
+    }
     if (isVarintNumber(value)) {
-      const magnitude = (value as number) < 0 ? -(value as number) : value as number
+      const magnitude = value < 0 ? -value : value
       if (magnitude > DECIMAL_MANTISSA_MAX) decimal = false
     } else {
       varint = false
-      if (typeof value !== "number") decimal = false
-      else {
-        const scale = decimalScale(value)
-        if (scale === 0) decimal = false
-        else numberRunScales[i] = scale
-      }
+      const scale = decimalScale(value)
+      if (scale === 0) decimal = false
+      else numberRunScales[i] = scale
     }
     if (!varint && !decimal) break
   }
@@ -4460,8 +4461,15 @@ function decodeInterned(table: Array<unknown>, layout: Layout, r: Reader): unkno
     if (ref >= table.length) invalid("a known back-reference", undefined, r.options)
     return table[ref]
   }
-  // Strings consume their whole region, so they skip the reader window.
+  // Plain strings consume their whole region, so they skip the reader window.
   if (layout._ === "string") {
+    if (r.dict !== undefined) {
+      const saved = r.enter(code / 2)
+      const value = decodeChecked(layout, r)
+      r.exit(saved)
+      table.push(value)
+      return value
+    }
     const value = r.readUtf8(code / 2)
     table.push(value)
     return value
@@ -4669,7 +4677,7 @@ function decodeArray(layout: ArrayLayout, r: Reader): unknown {
     if (uniform._ === "string") {
       for (let i = 0; i < count; i++) {
         issuePath[issuePathLen++] = i
-        out[i] = r.readUtf8(r.uvarint())
+        out[i] = r.dict === undefined ? r.readUtf8(r.uvarint()) : decodeSized(uniform, r)
         issuePathLen--
       }
       return out

--- a/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
+++ b/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
@@ -388,6 +388,15 @@ describe("SchemaBinary", () => {
       )
     })
 
+    it("rejects non-number elements in uniform number arrays", () => {
+      const codec = SchemaBinary.toCodec(Schema.Array(Schema.Number))
+      for (const value of ["x", undefined, null, 1n]) {
+        const error = schemaError(() => Schema.encodeUnknownSync(codec)([1, value, 3] as any))
+        assert.include(error.message, "Expected a number")
+        assert.include(error.message, "at [1]")
+      }
+    })
+
     it("length-prefixes each number slot of a tuple", () => {
       const pair = Schema.Tuple([Schema.Number, Schema.Number])
       assert.strictEqual(encode(pair, [1, 2]).length, 6)
@@ -2748,6 +2757,39 @@ describe("SchemaBinary", () => {
       }
     })
 
+    it("round-trips arrays of strings across frames", () => {
+      const values = [["a", "b"], ["a", "c"], ["a", "a"]]
+      const encoder = SchemaBinary.encoder(Schema.Array(Schema.String), { dictionary: true })
+      const parser = SchemaBinary.parser(Schema.Array(Schema.String), { dictionary: true })
+      const decoded = values.flatMap((value) => parser.feedSync(encoder.encode(value)))
+      assert.deepStrictEqual(decoded, values)
+
+      const Message = Schema.Struct({ name: Schema.String, tags: Schema.Array(Schema.String) })
+      const messages = [
+        { name: "shared", tags: ["a", "b"] },
+        { name: "other", tags: ["shared", "c"] },
+        { name: "shared", tags: ["a", "a"] }
+      ]
+      const messageEncoder = SchemaBinary.encoder(Message, { dictionary: true })
+      const messageParser = SchemaBinary.parser(Message, { dictionary: true })
+      const decodedMessages = messages.flatMap((value) => messageParser.feedSync(messageEncoder.encode(value)))
+      assert.deepStrictEqual(decodedMessages, messages)
+    })
+
+    it("round-trips arrays of strings inside row runs across frames", () => {
+      const Row = Schema.Struct({ id: Schema.Number, tags: Schema.Array(Schema.String) })
+      const Rows = Schema.Array(Row)
+      const values = [
+        [{ id: 1, tags: ["x"] }],
+        [{ id: 2, tags: ["x"] }],
+        [{ id: 3, tags: ["x"] }]
+      ]
+      const encoder = SchemaBinary.encoder(Rows, { dictionary: true })
+      const parser = SchemaBinary.parser(Rows, { dictionary: true })
+      const decoded = values.flatMap((value) => parser.feedSync(encoder.encode(value)))
+      assert.deepStrictEqual(decoded, values)
+    })
+
     it("round-trips batched frames and fragmented feeds", () => {
       const encoder = SchemaBinary.encoder(Message, { dictionary: true })
       const parser = SchemaBinary.parser(Message, { dictionary: true })
@@ -2898,6 +2940,20 @@ describe("SchemaBinary", () => {
         )
 
         assert.deepStrictEqual([...frames], [concat(encode(Person, ada), encode(Person, grace))])
+      }))
+
+    it.effect("encode rejects non-number elements in uniform number arrays", () =>
+      Effect.gen(function*() {
+        for (const value of ["x", undefined, null]) {
+          const error = yield* Stream.make([1, value, 3] as any).pipe(
+            Stream.pipeThroughChannel(SchemaBinary.encode(Schema.Array(Schema.Number))()),
+            Stream.runCollect,
+            Effect.flip
+          )
+          assert.instanceOf(error, Schema.SchemaError)
+          assert.include(error.message, "Expected a number")
+          assert.include(error.message, "at [1]")
+        }
       }))
 
     it.effect("decodes a value split across byte chunks", () =>


### PR DESCRIPTION
Fix SchemaBinary's dictionary-aware decoding for uniform string arrays and row-run interned strings, keeping connection dictionary slots synchronized across frames.

Validate uniform number-array elements during run classification so invalid values fail with a `SchemaError` at the array index instead of being coerced or escaping as a defect.

Regression coverage includes top-level and struct string arrays, string arrays inside row runs, derived codecs, and the encode channel.

Tests:

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/effect/test/unstable/encoding/SchemaBinary.test.ts`
- `nix develop -c pnpm check`

Closes EFF-948
Closes EFF-949
