### PR TITLE
Fix SchemaBinary decoder limits

### DIFF
--- a/packages/effect/src/unstable/encoding/SchemaBinary.ts
+++ b/packages/effect/src/unstable/encoding/SchemaBinary.ts
@@ -897,6 +897,15 @@ const NUMBER_RUN_F64 = 0
 const NUMBER_RUN_VARINT = 1
 const NUMBER_RUN_DECIMAL = 2
 
+// Recursive layouts must fail before the JavaScript stack does. This is high
+// enough for practical payloads while keeping the decoder's stack bounded.
+const MAX_NESTING_DEPTH = 512
+
+// Variable-width elements must be backed by frame bytes apart from a bounded
+// allowance. Provably zero-width elements need their own absolute bound.
+const ARRAY_ALLOCATION_SLACK = 1_048_576
+const ZERO_WIDTH_ARRAY_MAX = 4_194_304
+
 // Struct field tags pack the field id with enough information to skip the
 // payload without consulting the schema. Decimal is a sign-magnitude mantissa
 // varint followed by an unsigned scale varint.
@@ -1443,6 +1452,7 @@ const EMPTY_READER_VIEW = new DataView(EMPTY_READER_ARRAY_BUFFER)
 
 class Reader {
   pos = 0
+  nesting = 0
   buf: Uint8Array = EMPTY_READER_BUFFER
   // Frames of varints and strings never need a view, so it is built on demand
   // and reused while the reader stays on one buffer.
@@ -1469,6 +1479,7 @@ class Reader {
     positional: boolean,
     dict: DictRead | undefined
   ) {
+    this.nesting = 0
     this.view = undefined
     this.buf = buf
     this.pos = start
@@ -1480,7 +1491,7 @@ class Reader {
     this.dict = dict
   }
   release() {
-    this.pos = this.end = 0
+    this.pos = this.end = this.nesting = 0
     this.buf = EMPTY_READER_BUFFER
     this.view = undefined
     this.viewCache = EMPTY_READER_VIEW
@@ -1905,6 +1916,10 @@ function packedSize(layout: Layout): number | undefined {
 function isInlineSlot(layout: Layout): boolean {
   return packedSize(layout) !== undefined || isSelfDelimiting(layout) ||
     layout._ === "null" || layout._ === "undefined"
+}
+
+function isZeroWidthSlot(layout: Layout): boolean {
+  return layout._ === "literal" ? isZeroWidthSlot(layout.leaf) : layout._ === "null" || layout._ === "undefined"
 }
 
 // One registry row per natively supported declaration: its wire kind and
@@ -4632,10 +4647,6 @@ function decodeRunSlot(
 function decodeArray(layout: ArrayLayout, r: Reader): unknown {
   const elementLen = layout.elements.length
   const count = layout.hasCount ? r.uvarint() : elementLen
-  // Cap allocation amplification from zero-width slots.
-  if (layout.hasCount && count > r.remaining + 1_048_576) {
-    invalid("array count within allocation limit", count, r.options)
-  }
   if (layout.rest.length === 0 && count > elementLen) {
     issuePath[issuePathLen++] = elementLen
     throw issueError(new SchemaIssue.UnexpectedKey(layout.ast, undefined, r.options))
@@ -4643,6 +4654,12 @@ function decodeArray(layout: ArrayLayout, r: Reader): unknown {
   if (count < layout.minCount) {
     issuePath[issuePathLen++] = count
     throw issueError(new SchemaIssue.MissingKey(undefined))
+  }
+  if (layout.hasCount) {
+    const allocationLimit = layout.rest.length > 0 && isZeroWidthSlot(layout.rest[0])
+      ? ZERO_WIDTH_ARRAY_MAX
+      : r.remaining + ARRAY_ALLOCATION_SLACK
+    if (count > allocationLimit) invalid("array count within allocation limit", count, r.options)
   }
   if (count > 0) {
     const plan = runPlan(layout)
@@ -4812,6 +4829,18 @@ function requirePresent(value: unknown): unknown {
 }
 
 function decodeValue(layout: Layout, r: Reader): unknown {
+  if (r.nesting >= MAX_NESTING_DEPTH) {
+    invalid(`nesting depth at most ${MAX_NESTING_DEPTH}`, r.nesting + 1, r.options)
+  }
+  r.nesting++
+  try {
+    return decodeValueUnchecked(layout, r)
+  } finally {
+    r.nesting--
+  }
+}
+
+function decodeValueUnchecked(layout: Layout, r: Reader): unknown {
   switch (layout._) {
     case "literal": {
       const value = decodeValue(layout.leaf, r)
@@ -4857,10 +4886,11 @@ function decodeValue(layout: Layout, r: Reader): unknown {
     case "int64": {
       if (r.remaining !== 8) invalid("int64", undefined, r.options)
       const millis = Number(r.i64())
-      if (layout.flavor !== "date") return DateTime.makeUnsafe(millis)
       const date = new Date(millis)
-      if (Number.isNaN(date.getTime())) invalid("a valid Date", millis, r.options)
-      return date
+      if (Number.isNaN(date.getTime())) {
+        invalid(layout.flavor === "date" ? "a valid Date" : "a valid DateTime", millis, r.options)
+      }
+      return layout.flavor === "date" ? date : DateTime.makeUnsafe(millis)
     }
     case "dateTimeZoned": {
       const millis = Number(r.i64())

--- a/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
+++ b/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
@@ -43,6 +43,46 @@ const concat = (...chunks: ReadonlyArray<Uint8Array>): Uint8Array => {
   return out
 }
 
+const uvarint = (value: number): Array<number> => {
+  const out: Array<number> = []
+  while (value > 0x7F) {
+    out.push((value & 0x7F) | 0x80)
+    value = Math.floor(value / 128)
+  }
+  out.push(value)
+  return out
+}
+
+const nestedArrayFrame = (depth: number): Uint8Array<ArrayBuffer> => {
+  const lengths = [1]
+  for (let i = 0; i < depth; i++) {
+    const childLength = lengths[i]
+    lengths.push(1 + uvarint(childLength).length + childLength)
+  }
+  const bodyLength = lengths[depth]
+  const header = uvarint(bodyLength + 1)
+  const out = new Uint8Array(header.length + 1 + bodyLength)
+  out.set(header)
+  let offset = header.length
+  out[offset++] = 0x20
+  for (let i = depth; i > 0; i--) {
+    out[offset++] = 1
+    const childHeader = uvarint(lengths[i - 1])
+    out.set(childHeader, offset)
+    offset += childHeader.length
+  }
+  out[offset] = 0
+  return out
+}
+
+const int64Frame = (value: bigint): Uint8Array<ArrayBuffer> => {
+  const out = new Uint8Array(10)
+  out[0] = 9
+  out[1] = 0x20
+  new DataView(out.buffer).setBigInt64(2, value, true)
+  return out
+}
+
 const sameNumber = (actual: unknown, expected: number) => {
   assert.isTrue(
     Object.is(actual, expected),
@@ -990,6 +1030,16 @@ describe("SchemaBinary", () => {
       parser.endSync()
     })
 
+    it("fails deeply nested recursive frames with SchemaError", () => {
+      type Nested = ReadonlyArray<Nested>
+      let Nested: Schema.Codec<Nested>
+      Nested = Schema.Array(Schema.suspend(() => Nested))
+      const parser = SchemaBinary.parser(Nested)
+
+      assert.match(schemaError(() => parser.feedSync(nestedArrayFrame(10_000))).message, /nesting depth at most/)
+      assert.match(schemaError(() => parser.feedSync(new Uint8Array())).message, /parser is spent/)
+    })
+
     it("keeps __proto__ safe on the exact parser path", () => {
       const schema = Schema.Struct({ ["__proto__"]: Schema.String, value: Schema.Number })
       const value = { ["__proto__"]: "own", value: 1 }
@@ -1341,6 +1391,20 @@ describe("SchemaBinary", () => {
         const decoded = roundtrip(Schema.DateTimeZoned, zoned)
         assert.strictEqual(DateTime.toEpochMillis(decoded), DateTime.toEpochMillis(zoned))
         assert.strictEqual(DateTime.zoneToString(decoded.zone), DateTime.zoneToString(zoned.zone))
+      }
+    })
+
+    it("validates DateTimeUtc epoch millisecond boundaries", () => {
+      const codec = SchemaBinary.toCodec(Schema.DateTimeUtc)
+      for (const millis of [-8_640_000_000_000_000n, 8_640_000_000_000_000n]) {
+        const decoded = Schema.decodeUnknownSync(codec)(int64Frame(millis))
+        assert.strictEqual(DateTime.toEpochMillis(decoded), Number(millis))
+      }
+      for (const millis of [-8_640_000_000_000_001n, 8_640_000_000_000_001n]) {
+        assert.match(
+          schemaError(() => Schema.decodeUnknownSync(codec)(int64Frame(millis))).message,
+          /valid DateTime/
+        )
       }
     })
 
@@ -1769,6 +1833,23 @@ describe("SchemaBinary", () => {
         schemaError(() => Schema.decodeUnknownSync(codec)(bytes)).message,
         /array count within allocation limit/
       )
+    })
+
+    it("round-trips zero-width arrays across the allocation slack boundary", () => {
+      const verify = <A, I>(schema: Schema.Codec<A, I>, value: A) => {
+        const codec = SchemaBinary.toCodec(Schema.Array(schema))
+        for (const count of [1_048_576, 1_048_577]) {
+          const bytes = Schema.encodeUnknownSync(codec)(new Array<A>(count).fill(value))
+          assert.strictEqual(bytes.length, 5)
+          const decoded = Schema.decodeUnknownSync(codec)(bytes)
+          assert.strictEqual(decoded.length, count)
+          assert.strictEqual(decoded[0], value)
+          assert.strictEqual(decoded[count - 1], value)
+        }
+      }
+
+      verify(Schema.Null, null)
+      verify(Schema.Undefined, undefined)
     })
 
     it("rejects duplicate struct field ids and extra keys", () => {
@@ -2976,6 +3057,21 @@ describe("SchemaBinary", () => {
         )
 
         assert.deepStrictEqual([...values], [ada, grace])
+      }))
+
+    it.effect("fails deeply nested recursive frames in the error channel", () =>
+      Effect.gen(function*() {
+        type Nested = ReadonlyArray<Nested>
+        let Nested: Schema.Codec<Nested>
+        Nested = Schema.Array(Schema.suspend(() => Nested))
+        const error = yield* Stream.make(nestedArrayFrame(10_000)).pipe(
+          Stream.pipeThroughChannel(SchemaBinary.decode(Nested)()),
+          Stream.runCollect,
+          Effect.flip
+        )
+
+        assert.instanceOf(error, Schema.SchemaError)
+        assert.include(error.message, "nesting depth at most")
       }))
 
     it.effect("fails when the stream ends with an incomplete frame", () =>


### PR DESCRIPTION
## Summary

- reject recursive binary frames at a fixed nesting depth with `SchemaError`
- give provably zero-width arrays a separate bounded allocation limit
- validate `DateTimeUtc` epoch milliseconds before constructing the value

## Testing

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`
- `nix develop -c pnpm test --run packages/effect/test/unstable/encoding/SchemaBinary.test.ts`

Closes EFF-953
Closes EFF-954
Closes EFF-955
