### PR TITLE
Fix SchemaBinary strict encoding and field collisions

### DIFF
--- a/packages/effect/src/unstable/encoding/SchemaBinary.ts
+++ b/packages/effect/src/unstable/encoding/SchemaBinary.ts
@@ -183,7 +183,7 @@ export function encodeUnknownSync<S extends Schema.Constraint>(
   const { exact, exitSuccess, layout } = compileTarget(schema)
   const mode = compileMode(layout, options?.fingerprint)
   const parseOptions: SchemaAST.ParseOptions = options ?? SchemaAST.defaultParseOptions
-  if (!exact) {
+  if (!exact || parseOptions.onExcessProperty === "error") {
     const fallback = Schema.encodeUnknownSync(
       toCodec(schema, options) as unknown as Schema.ConstraintEncoder<unknown, never>,
       options
@@ -221,12 +221,12 @@ export function encodeManyUnknownSync<S extends Schema.Constraint>(
   options?: SchemaAST.ParseOptions & Options
 ): (values: ReadonlyArray<unknown>) => Uint8Array<ArrayBuffer> {
   const { exact, layout } = compileTarget(schema)
-  if (!exact) {
+  const parseOptions: SchemaAST.ParseOptions = options ?? SchemaAST.defaultParseOptions
+  if (!exact || parseOptions.onExcessProperty === "error") {
     const encode = encodeUnknownSync(schema, options)
     return (values) => concatFrames(values.map(encode))
   }
   const mode = compileMode(layout, options?.fingerprint)
-  const parseOptions: SchemaAST.ParseOptions = options ?? SchemaAST.defaultParseOptions
   return (values) => {
     try {
       return encodeFrames(layout, values, parseOptions, mode)
@@ -346,13 +346,19 @@ export function encoder<S extends Schema.Constraint>(
   schema: S,
   options?: SchemaAST.ParseOptions & Options & StreamOptions
 ): Encoder {
-  const { exact, layout } = compileTarget(schema)
+  const { exact, layout, target } = compileTarget(schema)
   const dictionary = requireDictionary(exact, options)
   const encode = encodeUnknownSync(schema, options)
   const encodeMany = encodeManyUnknownSync(schema, options)
   if (!dictionary) return { encode, encodeMany }
   const mode = compileMode(layout, options?.fingerprint)
   const parseOptions: SchemaAST.ParseOptions = options ?? SchemaAST.defaultParseOptions
+  const validate = parseOptions.onExcessProperty === "error"
+    ? Schema.encodeUnknownSync(
+      target as Schema.ConstraintEncoder<unknown, never>,
+      options
+    ) as (value: unknown) => unknown
+    : undefined
   const dict = makeDictWrite()
   const run = <A>(f: () => A): A => {
     try {
@@ -362,8 +368,18 @@ export function encoder<S extends Schema.Constraint>(
     }
   }
   return {
-    encode: (value) => run(() => encodeFrame(layout, value, parseOptions, mode, dict)),
-    encodeMany: (values) => run(() => encodeFrames(layout, values, parseOptions, mode, dict))
+    encode: (value) =>
+      run(() => encodeFrame(layout, validate === undefined ? value : validate(value), parseOptions, mode, dict)),
+    encodeMany: (values) =>
+      run(() =>
+        encodeFrames(
+          layout,
+          validate === undefined ? values : values.map(validate),
+          parseOptions,
+          mode,
+          dict
+        )
+      )
   }
 }
 
@@ -618,7 +634,7 @@ export const encode = <S extends Schema.Constraint>(
       return Effect.die(e)
     }
   }
-  if (exact) {
+  if (exact && parseOptions.onExcessProperty !== "error") {
     return Channel.fromTransform((upstream, _scope) => Effect.sync(() => Effect.flatMap(upstream, write)))
   }
   // One schema pass per chunk brings the values to the binary-adjusted encoded
@@ -4197,6 +4213,7 @@ function decodeExtraPair(
   const key = keys === undefined
     ? r.readUtf8(keyCode)
     : decodeExtraKey(keys, code, keyCode, r)
+  if (layout.names.has(key)) invalid("an extra key distinct from declared fields", key, r.options)
   if (seenKey(seen, key)) invalid("unique extra keys", undefined, r.options)
   const signature = layout.extraAll ??
     (r.indexSignatures ??= new IndexSignatureCache(r.options)).find(layout, key)

--- a/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
+++ b/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
@@ -1872,6 +1872,35 @@ describe("SchemaBinary", () => {
       )
     })
 
+    it("rejects declared field names in the extra-key map", () => {
+      const Declared = Schema.Struct({
+        id: Schema.String,
+        note: Schema.optionalKey(Schema.String)
+      })
+      const Reader = Schema.StructWithRest(
+        Declared,
+        [Schema.Record(Schema.String, Schema.Number)]
+      )
+      const extras = Schema.Record(Schema.String, Schema.Number)
+      const body = (frame: Uint8Array): Uint8Array => {
+        let offset = 0
+        while ((frame[offset] & 0x80) !== 0) offset++
+        assert.strictEqual(frame[++offset], 0x20)
+        return frame.subarray(offset + 1)
+      }
+      const collide = (key: "id" | "note") => {
+        const bytes = concat(body(encode(Declared, { id: "ok" })), body(encode(extras, { [key]: 7 })))
+        return concat(Uint8Array.from([...uvarint(bytes.length + 1), 0x20]), bytes)
+      }
+
+      for (const key of ["id", "note"] as const) {
+        assert.match(
+          schemaError(() => Schema.decodeUnknownSync(SchemaBinary.toCodec(Reader))(collide(key))).message,
+          /declared field/
+        )
+      }
+    })
+
     it("rejects a duplicate field id after an unknown union decodes as absent", () => {
       const A = Schema.Struct({ _tag: Schema.Literal("A") })
       const B = Schema.Struct({ _tag: Schema.Literal("B"), value: Schema.String })
@@ -1889,16 +1918,15 @@ describe("SchemaBinary", () => {
 
     it("does not satisfy wide-field presence from the extra-key map", () => {
       const fields: Record<string, typeof Schema.String> = {}
-      const value: Record<string, string> = {}
+      const extras: Record<string, string> = {}
       for (let i = 0; i < 34; i++) {
-        const key = `field${i}`
-        fields[key] = Schema.String
-        value[key] = key
+        fields[`field${i}`] = Schema.String
+        extras[`extra${i}`] = `value${i}`
       }
       const record = Schema.Record(Schema.String, Schema.String)
       const struct = Schema.StructWithRest(Schema.Struct(fields), [record])
       const error = schemaError(() =>
-        Schema.decodeUnknownSync(SchemaBinary.toCodec(struct), { errors: "all" })(encode(record, value))
+        Schema.decodeUnknownSync(SchemaBinary.toCodec(struct), { errors: "all" })(encode(record, extras))
       )
 
       assert.strictEqual(error.message.match(/Missing key/g)?.length, 34)
@@ -2706,6 +2734,14 @@ describe("SchemaBinary", () => {
       )
     })
 
+    it("reports excess properties through encodeUnknownSync", () => {
+      const excess = { name: "Ada", age: 36, extra: true }
+      assert.include(
+        schemaError(() => SchemaBinary.encodeUnknownSync(Person, { onExcessProperty: "error" })(excess)).message,
+        "extra"
+      )
+    })
+
     it("falls back to toCodec when the binary layer cannot prove the schema", () => {
       const NonNegative = Schema.Number.check(Schema.isGreaterThanOrEqualTo(0))
       const direct = SchemaBinary.toCodecDirect(NonNegative)
@@ -2740,6 +2776,16 @@ describe("SchemaBinary", () => {
         Array.from(concat(encode(Checked, { age: 1 }), encode(Checked, { age: 2 })))
       )
       assert.include(schemaError(() => checked([{ age: -1 }])).message, "greater than or equal to 0")
+    })
+
+    it("reports excess properties", () => {
+      const excess = { name: "Ada", age: 36, extra: true }
+      assert.include(
+        schemaError(() =>
+          SchemaBinary.encodeManyUnknownSync(Person, { onExcessProperty: "error" })([people[0], excess])
+        ).message,
+        "extra"
+      )
     })
   })
 
@@ -2908,6 +2954,24 @@ describe("SchemaBinary", () => {
       assert.deepStrictEqual(decoded, [first, next])
     })
 
+    it("reports excess properties before advancing the dictionary", () => {
+      const encoder = SchemaBinary.encoder(Message, {
+        dictionary: true,
+        onExcessProperty: "error"
+      })
+      const parser = SchemaBinary.parser(Message, { dictionary: true })
+      assert.include(
+        schemaError(() => encoder.encode({ ...message(0), extra: "NeverSent" })).message,
+        "extra"
+      )
+      assert.include(
+        schemaError(() => encoder.encodeMany([message(1), { ...message(2), extra: "NeverSent" }])).message,
+        "extra"
+      )
+      const next = message(3)
+      assert.deepStrictEqual(parser.feedSync(encoder.encode(next)), [next])
+    })
+
     it("costs nothing on a field whose strings never repeat", () => {
       const Unique = Schema.Struct({ s: Schema.String })
       const encoder = SchemaBinary.encoder(Unique, { dictionary: true })
@@ -3035,6 +3099,17 @@ describe("SchemaBinary", () => {
           assert.include(error.message, "Expected a number")
           assert.include(error.message, "at [1]")
         }
+      }))
+
+    it.effect("encode reports excess properties", () =>
+      Effect.gen(function*() {
+        const error = yield* Stream.make({ ...ada, extra: true }).pipe(
+          Stream.pipeThroughChannel(SchemaBinary.encode(Person, { onExcessProperty: "error" })()),
+          Stream.runCollect,
+          Effect.flip
+        )
+        assert.instanceOf(error, Schema.SchemaError)
+        assert.include(error.message, "extra")
       }))
 
     it.effect("decodes a value split across byte chunks", () =>


### PR DESCRIPTION
## Summary

- honor `onExcessProperty: "error"` across the exact single, batch, stateful dictionary, and channel encode paths
- reject crafted extra-map entries that collide with declared struct fields
- keep dictionary state unchanged when strict validation rejects a frame

## Tests

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/effect/test/unstable/encoding/SchemaBinary.test.ts`
- `nix develop -c pnpm check`

Closes EFF-956
Closes EFF-958
Closes EFF-959
