### PR TITLE
Set sql-pg multiplex concurrency default to 32

### DIFF
--- a/.changeset/flat-pipelines-share.md
+++ b/.changeset/flat-pipelines-share.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-pg": patch
+---
+
+Set the default `multiplexConcurrency` to 32 when PostgreSQL connection multiplexing is enabled. Set a lower value explicitly to limit how many statements share each connection.

--- a/packages/sql/pg/src/PgClient.ts
+++ b/packages/sql/pg/src/PgClient.ts
@@ -106,11 +106,9 @@ export interface PgClientConfig {
   readonly multiplex?: boolean | undefined
   /**
    * How many statements may share one connection when `multiplex` is on.
-   *
-   * Higher trades tail latency for throughput: the statements sharing a
-   * connection are pipelined into one write, and they also queue behind the
-   * slowest of them. The default suits a server that is a cheap round trip
-   * away; one reached across a virtual or real network is worth more.
+   * Defaults to `32`. Higher values trade tail latency for throughput: the
+   * statements sharing a connection are pipelined into one write, and they
+   * also queue behind the slowest of them.
    */
   readonly multiplexConcurrency?: number | undefined
   /**

--- a/packages/sql/pg/src/PgPool.ts
+++ b/packages/sql/pg/src/PgPool.ts
@@ -13,18 +13,7 @@ import type { SqlError } from "effect/unstable/sql/SqlError"
 import { connectionInternals } from "./internal/connection.ts"
 import * as PgConnection from "./PgConnection.ts"
 
-/**
- * How many statements share one connection when nothing says otherwise.
- *
- * Deliberately low. The backend runs a connection's pipelined statements in
- * the order it received them, so everything sharing a connection queues behind
- * the slowest of them, and spreading over the connections the pool may open
- * costs nothing in throughput against a server a cheap round trip away. It is
- * not the fastest setting everywhere: the further away the server, the more a
- * round trip costs and the more a deeper pipeline is worth. That is what
- * `multiplexConcurrency` is for.
- */
-const defaultMultiplexConcurrency = (maxConnections: number): number => Math.max(4, Math.ceil(32 / maxConnections))
+const defaultMultiplexConcurrency = 32
 
 /**
  * The runtime type identifier for `PgPool`.
@@ -65,12 +54,9 @@ export interface Config extends PgConnection.Config {
   readonly connectionTTL?: Duration.Input | undefined
   /**
    * How many statements may share one connection when `multiplex` is on.
-   *
-   * They are pipelined into one write, so a higher number means fewer round
-   * trips, and it also means a slow statement holds up more of the statements
-   * queued behind it. The default suits a server that is a cheap round trip
-   * away; one reached across a virtual or real network is worth a deeper
-   * pipeline, where settings of 16 to 32 have measured considerably faster.
+   * Defaults to `32`. Statements are pipelined into one write, so a higher
+   * number means fewer round trips, but it also means a slow statement holds
+   * up more of the statements queued behind it.
    */
   readonly multiplexConcurrency?: number | undefined
 }
@@ -170,7 +156,7 @@ export const make = Effect.fnUntraced(function*(options: Config): Effect.fn.Retu
     min: options.minConnections ?? 0,
     max: maxConnections,
     concurrency: multiplex
-      ? Math.max(1, options.multiplexConcurrency ?? defaultMultiplexConcurrency(maxConnections))
+      ? Math.max(1, options.multiplexConcurrency ?? defaultMultiplexConcurrency)
       : 1,
     timeToLive: options.idleTimeout ?? Duration.seconds(10),
     timeToLiveStrategy: "usage"

--- a/packages/sql/pg/test/PgPool.integration.test.ts
+++ b/packages/sql/pg/test/PgPool.integration.test.ts
@@ -147,12 +147,9 @@ it.layer(PgContainer.layer, { timeout: "30 seconds" })("PgPool", (it) => {
         yield* realSleep
       }
     }))
-  it.effect("spreads multiplexed statements across the connections it may open", () =>
+  it.effect("defaults multiplex concurrency to 32", () =>
     Effect.gen(function*() {
       const pool = yield* PgPool.make({ ...(yield* poolConfig), maxConnections: 4, multiplex: true })
-      // Enough statements at once to fill every connection the pool may open.
-      // Letting them all share one would put every statement behind the
-      // slowest, so the pool has to reach for the rest.
       const processIds = yield* Effect.all(
         Array.from({ length: 32 }, () =>
           Effect.scoped(Effect.flatMap(pool.get, (connection) =>
@@ -162,7 +159,7 @@ it.layer(PgContainer.layer, { timeout: "30 seconds" })("PgPool", (it) => {
             )))),
         { concurrency: "unbounded" }
       )
-      assert.strictEqual(new Set(processIds).size, 4)
+      assert.strictEqual(new Set(processIds).size, 1)
     }))
   it.effect("invalidates a reserved connection", () =>
     Effect.gen(function*() {


### PR DESCRIPTION
## Summary

- use a flat default of 32 statements per multiplexed PostgreSQL connection
- document the new default in `PgPool.Config` and `PgClientConfig`
- update the pool regression test and add a patch changeset

## Validation

- `EFFECT_INTEGRATION_TESTS=1 pnpm test --run packages/sql/pg/test/PgPool.integration.test.ts`
- `pnpm check`
- `pnpm lint`
- `pnpm exec changeset status`

`pnpm jsdocs --check` still reports existing repository-wide JSDoc diagnostics. The updated `PgClientConfig` comment is clean; `PgPool.ts` retains its pre-existing file-level diagnostics outside this change.

Closes EFF-960
