### PR TITLE
Add NodeSocketServer.makeTls

### DIFF
--- a/.changeset/eff-963-node-socket-server-tls.md
+++ b/.changeset/eff-963-node-socket-server-tls.md
@@ -1,0 +1,12 @@
+---
+"@effect/platform-node-shared": patch
+"@effect/platform-node": patch
+"@effect/platform-bun": patch
+---
+
+Add `NodeSocketServer.makeTls` and `NodeSocketServer.layerTls` for TLS socket servers.
+
+These mirror `make` / `layer` but build the server with `tls.createServer`, so they take the full `tls.TlsOptions` set
+alongside the usual listen options: certificates (`cert` / `key`), trust anchors for client certificates (`ca`), ALPN
+protocols, and SNI callbacks. Handlers run once the handshake completes and receive the `tls.TLSSocket` as
+`NodeSocket.NetSocket`. Connections that fail the handshake are destroyed; the server keeps listening.

--- a/.changeset/eff-963-node-socket-server-tls.md
+++ b/.changeset/eff-963-node-socket-server-tls.md
@@ -5,8 +5,3 @@
 ---
 
 Add `NodeSocketServer.makeTls` and `NodeSocketServer.layerTls` for TLS socket servers.
-
-These mirror `make` / `layer` but build the server with `tls.createServer`, so they take the full `tls.TlsOptions` set
-alongside the usual listen options: certificates (`cert` / `key`), trust anchors for client certificates (`ca`), ALPN
-protocols, and SNI callbacks. Handlers run once the handshake completes and receive the `tls.TLSSocket` as
-`NodeSocket.NetSocket`. Connections that fail the handshake are destroyed; the server keeps listening.

--- a/packages/platform/node-shared/src/NodeSocketServer.ts
+++ b/packages/platform/node-shared/src/NodeSocketServer.ts
@@ -1,12 +1,13 @@
 /**
  * Node socket server adapters for Effect's unstable socket server API.
  *
- * This module turns `node:net` TCP or Unix-domain servers and `ws` WebSocket
- * servers into scoped `SocketServer.SocketServer` services. Use the TCP
- * constructors when handlers should receive a `Socket.Socket` backed by a Node
- * `net.Socket`; use the WebSocket constructors when handlers should receive a
- * `Socket.Socket` backed by `ws` and have access to the per-connection
- * WebSocket and `IncomingMessage` services.
+ * This module turns `node:net` TCP or Unix-domain servers, `node:tls` servers,
+ * and `ws` WebSocket servers into scoped `SocketServer.SocketServer` services.
+ * Use the TCP and TLS constructors when handlers should receive a
+ * `Socket.Socket` backed by a Node `net.Socket`; use the WebSocket
+ * constructors when handlers should receive a `Socket.Socket` backed by `ws`
+ * and have access to the per-connection WebSocket and `IncomingMessage`
+ * services.
  *
  * @since 4.0.0
  */
@@ -25,6 +26,7 @@ import * as Socket from "effect/unstable/socket/Socket"
 import * as SocketServer from "effect/unstable/socket/SocketServer"
 import type * as Http from "node:http"
 import * as Net from "node:net"
+import * as Tls from "node:tls"
 import * as NodeSocket from "./NodeSocket.ts"
 import { NodeWS } from "./NodeSocket.ts"
 
@@ -48,125 +50,18 @@ export class IncomingMessage extends Context.Service<
  * @category constructors
  * @since 4.0.0
  */
-export const make = Effect.fnUntraced(function*(
+export const make = (
   options: Net.ServerOpts & Net.ListenOptions
-) {
-  const errorDeferred = Deferred.makeUnsafe<never, Error>()
-  const pending = new Map<Net.Socket, () => void>()
-  function defaultOnConnection(conn: Net.Socket) {
-    const remove = () => {
-      pending.delete(conn)
-      conn.off("close", remove)
-      conn.off("error", remove)
-    }
-    pending.set(conn, remove)
-    conn.on("close", remove)
-    conn.on("error", remove)
-  }
-  let onConnection = defaultOnConnection
-  // oxlint-disable-next-line prefer-const
-  let server: Net.Server | undefined
-  yield* Effect.addFinalizer(() =>
-    Effect.callback<void>((resume) => {
-      pending.forEach((remove, conn) => {
-        remove()
-        conn.destroy()
-      })
-      server?.close(() => resume(Effect.void))
-    })
-  )
-  // pause immediately so nothing is dropped before a handler acquires the
-  // socket's reader
-  server = Net.createServer(options, (conn) => {
-    conn.pause()
-    onConnection(conn)
+): Effect.Effect<
+  SocketServer.SocketServer["Service"],
+  SocketServer.SocketServerError,
+  Scope.Scope
+> =>
+  makeNetServer({
+    listenOptions: options,
+    connectionEvent: "connection",
+    createServer: () => Net.createServer(options)
   })
-  server.on("error", (err) => Deferred.doneUnsafe(errorDeferred, Exit.fail(err)))
-
-  yield* Effect.callback<void, SocketServer.SocketServerError>((resume) => {
-    server.listen(options, () => resume(Effect.void))
-  }).pipe(
-    Effect.raceFirst(Effect.mapError(Deferred.await(errorDeferred), (err) =>
-      new SocketServer.SocketServerError({
-        reason: new SocketServer.SocketServerOpenError({
-          cause: err
-        })
-      })))
-  )
-
-  const run = Effect.fnUntraced(function*<R, E, _>(handler: (socket: Socket.Socket) => Effect.Effect<_, E, R>) {
-    const scope = yield* Scope.make()
-    const services = Context.omit(Scope.Scope)(yield* Effect.context<R>()) as Context.Context<R>
-    const trackFiber = Fiber.runIn(scope)
-    const prevOnConnection = onConnection
-    onConnection = function(conn: Net.Socket) {
-      let error: Error | undefined
-      conn.on("error", (err) => {
-        error = err
-      })
-      pipe(
-        NodeSocket.fromDuplex(
-          Effect.acquireRelease(
-            Effect.suspend((): Effect.Effect<Net.Socket, Socket.SocketError> => {
-              if (error) {
-                return Effect.fail(
-                  new Socket.SocketError({
-                    reason: new Socket.SocketOpenError({
-                      kind: "Unknown",
-                      cause: error
-                    })
-                  })
-                )
-              } else if (conn.closed) {
-                return Effect.fail(
-                  new Socket.SocketError({
-                    reason: new Socket.SocketCloseError({ code: 1000 })
-                  })
-                )
-              }
-              return Effect.succeed(conn)
-            }),
-            (conn) =>
-              Effect.sync(() => {
-                if (conn.closed === false) {
-                  conn.destroySoon()
-                }
-              })
-          )
-        ),
-        Effect.flatMap(handler),
-        Effect.catchCause(reportUnhandledError),
-        Effect.runForkWith(Context.add(services, NodeSocket.NetSocket, conn)),
-        trackFiber
-      )
-    }
-    pending.forEach((remove, conn) => {
-      remove()
-      onConnection(conn)
-    })
-    return yield* Effect.callback<never>((_resume) => {
-      return Effect.suspend(() => {
-        onConnection = prevOnConnection
-        return Scope.close(scope, Exit.void)
-      })
-    })
-  })
-
-  const address = server.address()!
-  return SocketServer.SocketServer.of({
-    address: typeof address === "string" ?
-      {
-        _tag: "UnixAddress",
-        path: address
-      } :
-      {
-        _tag: "TcpAddress",
-        hostname: address.address,
-        port: address.port
-      },
-    run
-  })
-})
 
 /**
  * Provides a TCP `SocketServer` by creating and managing a scoped Node
@@ -181,6 +76,54 @@ export const layer: (
   SocketServer.SocketServer,
   SocketServer.SocketServerError
 > = Function.flow(make, Layer.effect(SocketServer.SocketServer))
+
+/**
+ * Creates a scoped TLS `SocketServer` from a Node `tls.Server`, starts
+ * listening with the supplied options, queues pending connections until `run`
+ * is called, and closes the server when the scope ends.
+ *
+ * **Details**
+ *
+ * Connections reach `run` only once their handshake has completed, and the
+ * handler receives a `Socket.Socket` backed by the `tls.TLSSocket`, which is
+ * also provided as `NodeSocket.NetSocket`. Connections that fail the handshake
+ * are destroyed and the server keeps listening.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const makeTls = (
+  options: Tls.TlsOptions & Net.ListenOptions
+): Effect.Effect<
+  SocketServer.SocketServer["Service"],
+  SocketServer.SocketServerError,
+  Scope.Scope
+> =>
+  makeNetServer({
+    listenOptions: options,
+    connectionEvent: "secureConnection",
+    createServer: () => {
+      const server = Tls.createServer(options)
+      server.on("tlsClientError", (_error, socket) => {
+        socket.destroy()
+      })
+      return server
+    }
+  })
+
+/**
+ * Provides a TLS `SocketServer` by creating and managing a scoped Node
+ * `tls.Server` with the supplied TLS and listen options.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layerTls: (
+  options: Tls.TlsOptions & Net.ListenOptions
+) => Layer.Layer<
+  SocketServer.SocketServer,
+  SocketServer.SocketServerError
+> = Function.flow(makeTls, Layer.effect(SocketServer.SocketServer))
 
 /**
  * Creates a scoped WebSocket `SocketServer` backed by the `ws` package,
@@ -321,3 +264,126 @@ const reportUnhandledError = <E>(cause: Cause<E>) =>
     }
     return Effect.void
   })
+
+const makeNetServer = Effect.fnUntraced(function*(options: {
+  readonly createServer: () => Net.Server
+  readonly connectionEvent: "connection" | "secureConnection"
+  readonly listenOptions: Net.ListenOptions
+}) {
+  const errorDeferred = Deferred.makeUnsafe<never, Error>()
+  const pending = new Map<Net.Socket, () => void>()
+  function defaultOnConnection(conn: Net.Socket) {
+    const remove = () => {
+      pending.delete(conn)
+      conn.off("close", remove)
+      conn.off("error", remove)
+    }
+    pending.set(conn, remove)
+    conn.on("close", remove)
+    conn.on("error", remove)
+  }
+  let onConnection = defaultOnConnection
+  // oxlint-disable-next-line prefer-const
+  let server: Net.Server | undefined
+  yield* Effect.addFinalizer(() =>
+    Effect.callback<void>((resume) => {
+      pending.forEach((remove, conn) => {
+        remove()
+        conn.destroy()
+      })
+      server?.close(() => resume(Effect.void))
+    })
+  )
+  server = options.createServer()
+  server.on(options.connectionEvent, (conn: Net.Socket) => {
+    // pause immediately so nothing is dropped before a handler acquires the
+    // socket's reader
+    conn.pause()
+    onConnection(conn)
+  })
+  server.on("error", (err) => Deferred.doneUnsafe(errorDeferred, Exit.fail(err)))
+
+  yield* Effect.callback<void, SocketServer.SocketServerError>((resume) => {
+    server.listen(options.listenOptions, () => resume(Effect.void))
+  }).pipe(
+    Effect.raceFirst(Effect.mapError(Deferred.await(errorDeferred), (err) =>
+      new SocketServer.SocketServerError({
+        reason: new SocketServer.SocketServerOpenError({
+          cause: err
+        })
+      })))
+  )
+
+  const run = Effect.fnUntraced(function*<R, E, _>(handler: (socket: Socket.Socket) => Effect.Effect<_, E, R>) {
+    const scope = yield* Scope.make()
+    const services = Context.omit(Scope.Scope)(yield* Effect.context<R>()) as Context.Context<R>
+    const trackFiber = Fiber.runIn(scope)
+    const prevOnConnection = onConnection
+    onConnection = function(conn: Net.Socket) {
+      let error: Error | undefined
+      conn.on("error", (err) => {
+        error = err
+      })
+      pipe(
+        NodeSocket.fromDuplex(
+          Effect.acquireRelease(
+            Effect.suspend((): Effect.Effect<Net.Socket, Socket.SocketError> => {
+              if (error) {
+                return Effect.fail(
+                  new Socket.SocketError({
+                    reason: new Socket.SocketOpenError({
+                      kind: "Unknown",
+                      cause: error
+                    })
+                  })
+                )
+              } else if (conn.closed) {
+                return Effect.fail(
+                  new Socket.SocketError({
+                    reason: new Socket.SocketCloseError({ code: 1000 })
+                  })
+                )
+              }
+              return Effect.succeed(conn)
+            }),
+            (conn) =>
+              Effect.sync(() => {
+                if (conn.closed === false) {
+                  conn.destroySoon()
+                }
+              })
+          )
+        ),
+        Effect.flatMap(handler),
+        Effect.catchCause(reportUnhandledError),
+        Effect.runForkWith(Context.add(services, NodeSocket.NetSocket, conn)),
+        trackFiber
+      )
+    }
+    pending.forEach((remove, conn) => {
+      remove()
+      onConnection(conn)
+    })
+    return yield* Effect.callback<never>((_resume) => {
+      return Effect.suspend(() => {
+        onConnection = prevOnConnection
+        return Scope.close(scope, Exit.void)
+      })
+    })
+  })
+
+  const address = server.address()!
+  return SocketServer.SocketServer.of({
+    address: typeof address === "string" ?
+      {
+        _tag: "UnixAddress",
+        path: address
+      } :
+      {
+        _tag: "TcpAddress",
+        hostname: address.address,
+        port: address.port
+      },
+    run
+  })
+})

--- a/packages/platform/node/test/NodeSocket.test.ts
+++ b/packages/platform/node/test/NodeSocket.test.ts
@@ -325,6 +325,48 @@ describe("Socket", () => {
         }))
       )
     })
+
+    it.effect("echoes through a NodeSocketServer.makeTls server", () =>
+      Effect.gen(function*() {
+        const server = yield* NodeSocketServer.makeTls({ host: "127.0.0.1", port: 0, cert, key })
+        yield* server.run((socket) =>
+          Effect.gen(function*() {
+            const writer = yield* socket.writer
+            const pull = yield* socket.reader
+            while (true) {
+              yield* writer.writeAll(yield* pull)
+            }
+          }).pipe(
+            Effect.scoped,
+            Effect.catchTag("SocketError", () => Effect.void)
+          )
+        ).pipe(Effect.forkScoped)
+
+        const socket = yield* NodeSocket.fromDuplex(Effect.acquireRelease(
+          Effect.callback<Tls.TLSSocket>((resume) => {
+            const conn = Tls.connect({
+              host: "127.0.0.1",
+              port: (server.address as SocketServer.TcpAddress).port,
+              ca: [cert]
+            })
+            conn.once("secureConnect", () => resume(Effect.succeed(conn)))
+          }),
+          (conn) => Effect.sync(() => conn.destroy())
+        ))
+
+        const received = yield* Effect.gen(function*() {
+          const writer = yield* socket.writer
+          const pull = yield* Socket.readerString(socket)
+          yield* writer.writeAll(["Hello", "World"])
+          let text = ""
+          while (text.length < 10) {
+            text += (yield* pull).join("")
+          }
+          return text
+        }).pipe(Effect.scoped)
+
+        assert.strictEqual(received, "HelloWorld")
+      }))
   })
 
   describe("WebSocket", () => {


### PR DESCRIPTION
Adds `NodeSocketServer.makeTls` / `layerTls` in `@effect/platform-node-shared`, mirroring the existing `make` / `layer`
TCP pair. `@effect/platform-node` and `@effect/platform-bun` pick them up through their re-exports.

- Built with `tls.createServer(options)`; `run` handlers fire on `secureConnection`, so a connection reaches the
  handler only after the handshake completes.
- `tlsClientError` destroys the offending socket and the server keeps listening. It does not fail the `SocketServer`.
- Listen errors and address mapping (Unix vs TCP) behave exactly as in `make`.
- Handlers still get `NodeSocket.NetSocket` for the connection. The `TLSSocket` extends `net.Socket`, so there is no
  new service. SNI, mTLS, and ALPN stay as plain Node options on `TlsOptions`.

The listen / pending / `run` loop moved into a private `makeNetServer` helper at the bottom of the module. `make` and
`makeTls` only pick the create-server call and the connection event. `make` is otherwise unchanged.

`NodeSocket.makeTls` (client side) is out of scope here and already landed in #7511.

## Test

The new echo round-trip lives in the `TLS` block of `packages/platform/node/test/NodeSocket.test.ts` rather than beside
the plaintext `make` echo test, so it reuses the self-signed key/cert fixtures #7511 added to that block instead of
duplicating a PEM blob in the same file. The client is `tls.connect` + `NodeSocket.fromDuplex` with `ca: [cert]`, not
`rejectUnauthorized: false`.

Closes EFF-963
