### PR TITLE
fix(RcMap): preserve replacement entries during invalidated resource cleanup

### DIFF
--- a/.changeset/rcmap-invalidation-release.md
+++ b/.changeset/rcmap-invalidation-release.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Fix `RcMap` and `LayerMap` cleanup after invalidating an actively borrowed entry and reacquiring the same key.
+The invalidated resource is released when its last borrower closes, even with infinite idle TTL, without removing
+the replacement entry. Old idle timers also leave replacement entries untouched.

--- a/packages/effect/src/RcMap.ts
+++ b/packages/effect/src/RcMap.ts
@@ -274,7 +274,7 @@ export const make: {
         self.state = { _tag: "Closed" }
         return Effect.forEach(
           map,
-          ([, entry]) => Effect.exit(Scope.close(entry.scope, Exit.void))
+          ([, entry]) => Effect.exit(closeEntry(entry))
         ).pipe(
           Effect.tap(() =>
             Effect.sync(() => {
@@ -449,21 +449,26 @@ export const getOption: {
     })
 )
 
+const closeEntry = <A, E>(entry: State.Entry<A, E>) =>
+  entry.fiber
+    ? Fiber.interrupt(entry.fiber).pipe(Effect.andThen(Scope.close(entry.scope, Exit.void)))
+    : Scope.close(entry.scope, Exit.void)
+
 const release = <K, A, E>(self: RcMap<K, A, E>, key: K, entry: State.Entry<A, E>) =>
   Effect.withFiber((fiber) => {
     entry.refCount--
     if (entry.refCount > 0) {
       return Effect.void
     } else if (self.state._tag === "Closed") {
-      return Scope.close(entry.scope, Exit.void)
+      return closeEntry(entry)
     }
 
     const o = MutableHashMap.get(self.state.map, key)
     if (o._tag === "None" || o.value !== entry) {
-      return Scope.close(entry.scope, Exit.void)
+      return closeEntry(entry)
     } else if (Duration.isZero(entry.idleTimeToLive)) {
       MutableHashMap.remove(self.state.map, key)
-      return Scope.close(entry.scope, Exit.void)
+      return closeEntry(entry)
     } else if (!Duration.isFinite(entry.idleTimeToLive)) {
       return Effect.void
     }
@@ -595,8 +600,7 @@ export const invalidate: {
     const entry = o.value
     MutableHashMap.remove(self.state.map, key)
     if (entry.refCount > 0) return
-    if (entry.fiber) yield* Fiber.interrupt(entry.fiber)
-    yield* Scope.close(entry.scope, Exit.void)
+    yield* closeEntry(entry)
   }, Effect.uninterruptible)
 )
 

--- a/packages/effect/src/RcMap.ts
+++ b/packages/effect/src/RcMap.ts
@@ -454,14 +454,15 @@ const release = <K, A, E>(self: RcMap<K, A, E>, key: K, entry: State.Entry<A, E>
     entry.refCount--
     if (entry.refCount > 0) {
       return Effect.void
-    } else if (
-      self.state._tag === "Closed"
-      || !MutableHashMap.has(self.state.map, key)
-      || Duration.isZero(entry.idleTimeToLive)
-    ) {
-      if (self.state._tag === "Open") {
-        MutableHashMap.remove(self.state.map, key)
-      }
+    } else if (self.state._tag === "Closed") {
+      return Scope.close(entry.scope, Exit.void)
+    }
+
+    const o = MutableHashMap.get(self.state.map, key)
+    if (o._tag === "None" || o.value !== entry) {
+      return Scope.close(entry.scope, Exit.void)
+    } else if (Duration.isZero(entry.idleTimeToLive)) {
+      MutableHashMap.remove(self.state.map, key)
       return Scope.close(entry.scope, Exit.void)
     } else if (!Duration.isFinite(entry.idleTimeToLive)) {
       return Effect.void
@@ -476,6 +477,8 @@ const release = <K, A, E>(self: RcMap<K, A, E>, key: K, entry: State.Entry<A, E>
       const remaining = entry.expiresAt - now
       if (remaining <= 0) {
         if (self.state._tag === "Closed" || entry.refCount > 0) return Effect.void
+        const o = MutableHashMap.get(self.state.map, key)
+        if (o._tag === "None" || o.value !== entry) return Effect.void
         MutableHashMap.remove(self.state.map, key)
         return restore(Scope.close(entry.scope, Exit.void))
       }

--- a/packages/effect/test/RcMap.test.ts
+++ b/packages/effect/test/RcMap.test.ts
@@ -3,6 +3,93 @@ import { Cause, Data, Deferred, Effect, Exit, Fiber, Option, RcMap, Ref, Scope }
 import { TestClock } from "effect/testing"
 
 describe("RcMap", () => {
+  describe("invalidate", () => {
+    it.effect.each([0, 1000, Infinity])(
+      "releases only the invalidated entry with TTL %s",
+      (idleTimeToLive) =>
+        Effect.gen(function*() {
+          const acquired: Array<number> = []
+          const released: Array<number> = []
+          const mapScope = yield* Scope.make()
+          const oldScope = yield* Scope.make()
+          const newScope = yield* Scope.make()
+          const map = yield* RcMap.make({
+            lookup: (_key: string) =>
+              Effect.acquireRelease(
+                Effect.sync(() => {
+                  const value = acquired.length + 1
+                  acquired.push(value)
+                  return value
+                }),
+                (value) => Effect.sync(() => released.push(value))
+              ),
+            idleTimeToLive
+          }).pipe(Scope.provide(mapScope))
+
+          assert.strictEqual(yield* RcMap.get(map, "key").pipe(Scope.provide(oldScope)), 1)
+          yield* RcMap.invalidate(map, "key")
+          assert.isFalse(yield* RcMap.has(map, "key"))
+          assert.deepStrictEqual(released, [])
+          assert.strictEqual(yield* RcMap.get(map, "key").pipe(Scope.provide(newScope)), 2)
+
+          yield* Scope.close(oldScope, Exit.void)
+          const afterOldRelease = { released: [...released], has: yield* RcMap.has(map, "key") }
+          const replacement = yield* Effect.scoped(RcMap.getOption(map, "key"))
+          yield* Scope.close(newScope, Exit.void)
+          const afterNewRelease = [...released]
+          if (idleTimeToLive === 1000) {
+            yield* TestClock.adjust(999)
+            assert.isTrue(yield* RcMap.has(map, "key"))
+            yield* TestClock.adjust(1)
+            assert.isFalse(yield* RcMap.has(map, "key"))
+          }
+          yield* Scope.close(mapScope, Exit.void)
+
+          assert.deepStrictEqual(acquired, [1, 2])
+          assert.deepStrictEqual(afterOldRelease, { released: [1], has: true })
+          assert.deepStrictEqual(replacement, Option.some(2))
+          assert.deepStrictEqual(afterNewRelease, idleTimeToLive === 0 ? [1, 2] : [1])
+          assert.deepStrictEqual(released, [1, 2])
+        })
+    )
+
+    it.effect("an invalidated entry's idle timer cannot remove its replacement", () =>
+      Effect.gen(function*() {
+        const acquired = yield* Ref.make(0)
+        const released: Array<number> = []
+        const mapScope = yield* Scope.make()
+        const map = yield* RcMap.make({
+          lookup: (_key: string) =>
+            Effect.acquireRelease(
+              Ref.updateAndGet(acquired, (n) => n + 1),
+              (value) => Effect.sync(() => released.push(value))
+            ),
+          idleTimeToLive: 1000
+        }).pipe(Scope.provide(mapScope))
+
+        assert.strictEqual(yield* Effect.scoped(RcMap.get(map, "key")), 1)
+        yield* TestClock.adjust(500)
+        const oldScope = yield* Scope.make()
+        const newScope = yield* Scope.make()
+        assert.strictEqual(yield* RcMap.get(map, "key").pipe(Scope.provide(oldScope)), 1)
+        yield* RcMap.invalidate(map, "key")
+        assert.deepStrictEqual(released, [])
+        assert.strictEqual(yield* RcMap.get(map, "key").pipe(Scope.provide(newScope)), 2)
+        yield* Scope.close(oldScope, Exit.void)
+        yield* TestClock.adjust(1000)
+        const replacement = yield* Effect.scoped(RcMap.getOption(map, "key"))
+        const afterTimer = [...released]
+        yield* Scope.close(mapScope, Exit.void)
+        assert.deepStrictEqual(released, [1, 2])
+        yield* Scope.close(newScope, Exit.void)
+
+        assert.deepStrictEqual(replacement, Option.some(2))
+        assert.deepStrictEqual(afterTimer, [1])
+        assert.deepStrictEqual(released, [1, 2])
+        assert.strictEqual(yield* Ref.get(acquired), 2)
+      }))
+  })
+
   describe("getOption", () => {
     it.effect("returns None without lookup or capacity acquisition when missing", () =>
       Effect.gen(function*() {

--- a/packages/effect/test/RcMap.test.ts
+++ b/packages/effect/test/RcMap.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Cause, Data, Deferred, Effect, Exit, Fiber, Option, RcMap, Ref, Scope } from "effect"
+import { Cause, Data, Deferred, Effect, Exit, Fiber, MutableHashMap, Option, RcMap, Ref, Scope } from "effect"
 import { TestClock } from "effect/testing"
 
 describe("RcMap", () => {
@@ -69,6 +69,12 @@ describe("RcMap", () => {
 
         assert.strictEqual(yield* Effect.scoped(RcMap.get(map, "key")), 1)
         yield* TestClock.adjust(500)
+        const oldEntry = map.state._tag === "Open"
+          ? Option.getOrThrow(MutableHashMap.get(map.state.map, "key"))
+          : undefined
+        assert.isDefined(oldEntry)
+        assert.isDefined(oldEntry.fiber)
+        const idleFiber = oldEntry.fiber
         const oldScope = yield* Scope.make()
         const newScope = yield* Scope.make()
         assert.strictEqual(yield* RcMap.get(map, "key").pipe(Scope.provide(oldScope)), 1)
@@ -76,6 +82,9 @@ describe("RcMap", () => {
         assert.deepStrictEqual(released, [])
         assert.strictEqual(yield* RcMap.get(map, "key").pipe(Scope.provide(newScope)), 2)
         yield* Scope.close(oldScope, Exit.void)
+        const idleExit = idleFiber.pollUnsafe()
+        assert.isDefined(idleExit)
+        assert.isTrue(Exit.hasInterrupts(idleExit))
         yield* TestClock.adjust(1000)
         const replacement = yield* Effect.scoped(RcMap.getOption(map, "key"))
         const afterTimer = [...released]


### PR DESCRIPTION
## Why

Invalidating a borrowed resource and reacquiring its key lets old cleanup affect the replacement. Zero TTL removes the replacement mapping; infinite TTL leaves the detached old resource unfinalized. An existing finite idle timer can independently remove the replacement.

Closes #7515.
Closes EFF-974.

## What Changes

| Cleanup event | New behavior |
|---|---|
| Invalidated entry still has borrowers | Keep the old resource alive |
| Last borrower of an invalidated entry closes | Finalize only that resource, regardless of idle TTL |
| Last borrower of the current entry closes | Preserve existing TTL behavior |
| Old idle timer expires after replacement | Leave the replacement untouched |

Release and idle expiry check that the key still maps to the entry being cleaned up before removing it.

## Scope

A focused RcMap lifecycle fix, with regression coverage for zero, finite, and infinite TTL and a surviving old idle timer. Includes an `effect: patch` changeset covering the consumer-visible RcMap and LayerMap behavior. No public API changes.

## Verification

```sh
pnpm test --run packages/effect/test/RcMap.test.ts packages/effect/test/LayerMap.test.ts
pnpm check
pnpm exec oxlint -f unix packages/effect/src/RcMap.ts packages/effect/test/RcMap.test.ts
pnpm exec dprint check packages/effect/src/RcMap.ts packages/effect/test/RcMap.test.ts .changeset/rcmap-invalidation-release.md
pnpm exec changeset status
git diff --check
```

All four new regression cases failed before the fix. Fixing release alone passed the three TTL cases but left the stale-timer regression failing; the expiry identity check resolved that remaining failure.

Final result: 25 tests pass, comprising 19 RcMap and 6 LayerMap tests. Type checking, lint, formatting, and changeset validation pass. The standalone reproducer produces the expected results with the fix and no manual resource cleanup.

The full test suite and OpenCode integration were not run.
