### PR TITLE
Add selector and equality support to Atom React hooks

### DIFF
--- a/.changeset/calm-atoms-select.md
+++ b/.changeset/calm-atoms-select.md
@@ -1,0 +1,5 @@
+---
+"@effect/atom-react": patch
+---
+
+Add selector and equality support to `useAtomSuspense`, and equality support to `useAtomValue`.

--- a/packages/atom/react/src/Hooks.ts
+++ b/packages/atom/react/src/Hooks.ts
@@ -10,8 +10,9 @@
 
 import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
+import * as Equal from "effect/Equal"
 import * as Exit from "effect/Exit"
-import type * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 import * as Atom from "effect/unstable/reactivity/Atom"
 import type * as AtomRef from "effect/unstable/reactivity/AtomRef"
 import * as AtomRegistry from "effect/unstable/reactivity/AtomRegistry"
@@ -55,6 +56,71 @@ function useStore<A>(registry: AtomRegistry.AtomRegistry, atom: Atom.Atom<A>): A
   const store = makeStore(registry, atom)
 
   return React.useSyncExternalStore(store.subscribe, store.snapshot, store.getServerSnapshot)
+}
+
+interface SelectionInstance<A> {
+  hasValue: boolean
+  value: A
+}
+
+const identity = <A>(value: A): A => value
+
+function useStoreWithSelector<A, B>(
+  registry: AtomRegistry.AtomRegistry,
+  atom: Atom.Atom<A>,
+  select: (_: A) => B,
+  equals: (previous: B, next: B) => boolean
+): B {
+  const store = makeStore(registry, atom)
+  const instanceRef = React.useRef<SelectionInstance<B> | null>(null)
+  if (instanceRef.current === null) {
+    instanceRef.current = { hasValue: false, value: undefined as B }
+  }
+  const instance = instanceRef.current
+
+  const [getSnapshot, getServerSnapshot] = React.useMemo(() => {
+    let hasMemo = false
+    let memoizedSnapshot: A
+    let memoizedSelection: B
+
+    const memoizedSelect = (snapshot: A): B => {
+      if (!hasMemo) {
+        const selection = select(snapshot)
+        let selected = selection
+        if (instance.hasValue && equals(instance.value, selection)) {
+          selected = instance.value
+        }
+        hasMemo = true
+        memoizedSnapshot = snapshot
+        memoizedSelection = selected
+        return selected
+      }
+      if (Object.is(memoizedSnapshot, snapshot)) {
+        return memoizedSelection
+      }
+      const selection = select(snapshot)
+      if (equals(memoizedSelection, selection)) {
+        memoizedSnapshot = snapshot
+        return memoizedSelection
+      }
+      memoizedSnapshot = snapshot
+      memoizedSelection = selection
+      return selection
+    }
+
+    return [
+      () => memoizedSelect(store.snapshot()),
+      () => memoizedSelect(store.getServerSnapshot())
+    ] as const
+  }, [store, select, equals, instance])
+
+  const value = React.useSyncExternalStore(store.subscribe, getSnapshot, getServerSnapshot)
+  React.useEffect(() => {
+    instance.hasValue = true
+    instance.value = value
+  }, [instance, value])
+
+  return value
 }
 
 const initialValuesSet = new WeakMap<AtomRegistry.AtomRegistry, WeakSet<Atom.Atom<any>>>()
@@ -101,8 +167,9 @@ export const useAtomInitialValues = (initialValues: Iterable<readonly [Atom.Atom
  *
  * **Details**
  *
- * When a selector is provided, the hook maps the atom before subscribing so the
- * component reads the selected value from the current `RegistryContext`.
+ * When a selector is provided, the hook subscribes to its result. The component
+ * re-renders only when the selected value changes according to `equals`, which
+ * defaults to `Object.is`. Selectors do not need stable function identity.
  *
  * @see {@link useAtom} for reading and updating a writable atom from one component
  * @see {@link useAtomRef} for reading an `AtomRef` directly
@@ -112,14 +179,19 @@ export const useAtomInitialValues = (initialValues: Iterable<readonly [Atom.Atom
  */
 export const useAtomValue: {
   <A>(atom: Atom.Atom<A>): A
-  <A, B>(atom: Atom.Atom<A>, f: (_: A) => B): B
-} = <A>(atom: Atom.Atom<A>, f?: (_: A) => A): A => {
+  <A, B>(atom: Atom.Atom<A>, select: (_: A) => B, equals?: (previous: B, next: B) => boolean): B
+} = <A, B = A>(
+  atom: Atom.Atom<A>,
+  select?: (_: A) => B,
+  equals?: (previous: B, next: B) => boolean
+): B => {
   const registry = React.useContext(RegistryContext)
-  if (f) {
-    const atomB = React.useMemo(() => Atom.map(atom, f), [atom, f])
-    return useStore(registry, atomB)
-  }
-  return useStore(registry, atom)
+  return useStoreWithSelector(
+    registry,
+    atom,
+    select ?? identity as (_: A) => B,
+    equals ?? Object.is
+  )
 }
 
 function mountAtom<A>(registry: AtomRegistry.AtomRegistry, atom: Atom.Atom<A>): void {
@@ -332,21 +404,79 @@ function atomToPromise<A, E>(
   return promise
 }
 
-function atomResultOrSuspend<A, E>(
+const selectAsyncResult = <A, E, B>(
+  result: AsyncResult.AsyncResult<A, E>,
+  select: (_: A) => B,
+  includeFailure: boolean
+): AsyncResult.AsyncResult<B, E> =>
+  result._tag === "Failure" && !includeFailure
+    ? result as unknown as AsyncResult.Failure<B, E>
+    : AsyncResult.map(result, select)
+
+function atomResultOrSuspendWithSelector<A, E, B>(
   registry: AtomRegistry.AtomRegistry,
   atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>,
-  suspendOnWaiting: boolean
+  suspendOnWaiting: boolean,
+  select: ((_: A) => B) | undefined,
+  equals: (previous: B, next: B) => boolean,
+  includeFailure: boolean
 ) {
-  const value = useStore(registry, atom)
+  const value = useStoreWithSelector(
+    registry,
+    atom,
+    select === undefined
+      ? identity as (_: AsyncResult.AsyncResult<A, E>) => AsyncResult.AsyncResult<B, E>
+      : (result) => selectAsyncResult(result, select, includeFailure),
+    select === undefined ? Object.is : selectedResultEquals(equals, includeFailure)
+  )
   if (value._tag === "Initial" || (suspendOnWaiting && value.waiting)) {
     throw atomToPromise(registry, atom, suspendOnWaiting)
   }
   return value
 }
 
+const selectedResultEquals = <A, E>(
+  equals: (previous: A, next: A) => boolean,
+  includeFailure: boolean
+): (previous: AsyncResult.AsyncResult<A, E>, next: AsyncResult.AsyncResult<A, E>) => boolean =>
+(previous, next) => {
+  if (previous === next) {
+    return true
+  }
+  if (previous._tag !== next._tag || previous.waiting !== next.waiting) {
+    return false
+  }
+  switch (previous._tag) {
+    case "Initial":
+      return true
+    case "Success":
+      return equals(previous.value, (next as AsyncResult.Success<A, E>).value)
+    case "Failure": {
+      const nextFailure = next as AsyncResult.Failure<A, E>
+      if (!Equal.equals(previous.cause, nextFailure.cause)) {
+        return false
+      }
+      if (!includeFailure) {
+        return true
+      }
+      const previousSuccess = previous.previousSuccess
+      const nextSuccess = nextFailure.previousSuccess
+      if (previousSuccess._tag !== nextSuccess._tag) {
+        return false
+      }
+      if (previousSuccess._tag === "None" || nextSuccess._tag === "None") {
+        return true
+      }
+      return previousSuccess.value.waiting === nextSuccess.value.waiting &&
+        equals(previousSuccess.value.value, nextSuccess.value.value)
+    }
+  }
+}
+
 /**
  * Reads an `AsyncResult` atom through React Suspense, suspending while the
- * result is initial or configured as waiting.
+ * result is initial or configured as waiting, and optionally selects from the
+ * successful value.
  *
  * **When to use**
  *
@@ -356,28 +486,64 @@ function atomResultOrSuspend<A, E>(
  * **Details**
  *
  * `suspendOnWaiting` defaults to `false`. When `includeFailure` is `true`, a
- * failure result is returned instead of being thrown.
+ * failure result is returned instead of being thrown. When `select` is
+ * provided, the hook subscribes to the selected success value and uses
+ * `equals`, defaulting to `Object.is`, to avoid unrelated re-renders. Changes
+ * to the result variant, waiting state, or failure cause are not hidden by
+ * selection equality.
  *
  * **Gotchas**
  *
  * Without `includeFailure`, failure results are thrown with
  * `Cause.squash(result.cause)`, so callers need an error boundary for failures.
+ * When selected Success values compare equal, the previous selected Success,
+ * including its timestamp, is retained.
  *
  * @see {@link useAtomValue} for reading the raw `AsyncResult` value without Suspense
  *
  * @category hooks
  * @since 4.0.0
  */
-export const useAtomSuspense = <A, E, const IncludeFailure extends boolean = false>(
+export const useAtomSuspense: {
+  <A, E, B, const IncludeFailure extends boolean = false>(
+    atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>,
+    options: {
+      readonly select: (_: A) => B
+      readonly equals?: ((previous: B, next: B) => boolean) | undefined
+      readonly suspendOnWaiting?: boolean | undefined
+      readonly includeFailure?: IncludeFailure | undefined
+    }
+  ): AsyncResult.Success<B, E> | (IncludeFailure extends true ? AsyncResult.Failure<B, E> : never)
+  <A, E, const IncludeFailure extends boolean = false>(
+    atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>,
+    options?: {
+      readonly select?: undefined
+      readonly equals?: undefined
+      readonly suspendOnWaiting?: boolean | undefined
+      readonly includeFailure?: IncludeFailure | undefined
+    }
+  ): AsyncResult.Success<A, E> | (IncludeFailure extends true ? AsyncResult.Failure<A, E> : never)
+} = <A, E, B = A, const IncludeFailure extends boolean = false>(
   atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>,
   options?: {
+    readonly select?: ((_: A) => B) | undefined
+    readonly equals?: ((previous: B, next: B) => boolean) | undefined
     readonly suspendOnWaiting?: boolean | undefined
     readonly includeFailure?: IncludeFailure | undefined
   }
-): AsyncResult.Success<A, E> | (IncludeFailure extends true ? AsyncResult.Failure<A, E> : never) => {
+): AsyncResult.Success<B, E> | (IncludeFailure extends true ? AsyncResult.Failure<B, E> : never) => {
   const registry = React.useContext(RegistryContext)
-  const result = atomResultOrSuspend(registry, atom, options?.suspendOnWaiting ?? false)
-  if (result._tag === "Failure" && !options?.includeFailure) {
+  const suspendOnWaiting = options?.suspendOnWaiting ?? false
+  const includeFailure = options?.includeFailure === true
+  const result = atomResultOrSuspendWithSelector(
+    registry,
+    atom,
+    suspendOnWaiting,
+    options?.select,
+    options?.equals ?? Object.is,
+    includeFailure
+  )
+  if (result._tag === "Failure" && !includeFailure) {
     throw Cause.squash(result.cause)
   }
   return result as any

--- a/packages/atom/react/src/Hooks.ts
+++ b/packages/atom/react/src/Hooks.ts
@@ -58,71 +58,6 @@ function useStore<A>(registry: AtomRegistry.AtomRegistry, atom: Atom.Atom<A>): A
   return React.useSyncExternalStore(store.subscribe, store.snapshot, store.getServerSnapshot)
 }
 
-interface SelectionInstance<A> {
-  hasValue: boolean
-  value: A
-}
-
-const identity = <A>(value: A): A => value
-
-function useStoreWithSelector<A, B>(
-  registry: AtomRegistry.AtomRegistry,
-  atom: Atom.Atom<A>,
-  select: (_: A) => B,
-  equals: (previous: B, next: B) => boolean
-): B {
-  const store = makeStore(registry, atom)
-  const instanceRef = React.useRef<SelectionInstance<B> | null>(null)
-  if (instanceRef.current === null) {
-    instanceRef.current = { hasValue: false, value: undefined as B }
-  }
-  const instance = instanceRef.current
-
-  const [getSnapshot, getServerSnapshot] = React.useMemo(() => {
-    let hasMemo = false
-    let memoizedSnapshot: A
-    let memoizedSelection: B
-
-    const memoizedSelect = (snapshot: A): B => {
-      if (!hasMemo) {
-        const selection = select(snapshot)
-        let selected = selection
-        if (instance.hasValue && equals(instance.value, selection)) {
-          selected = instance.value
-        }
-        hasMemo = true
-        memoizedSnapshot = snapshot
-        memoizedSelection = selected
-        return selected
-      }
-      if (Object.is(memoizedSnapshot, snapshot)) {
-        return memoizedSelection
-      }
-      const selection = select(snapshot)
-      if (equals(memoizedSelection, selection)) {
-        memoizedSnapshot = snapshot
-        return memoizedSelection
-      }
-      memoizedSnapshot = snapshot
-      memoizedSelection = selection
-      return selection
-    }
-
-    return [
-      () => memoizedSelect(store.snapshot()),
-      () => memoizedSelect(store.getServerSnapshot())
-    ] as const
-  }, [store, select, equals, instance])
-
-  const value = React.useSyncExternalStore(store.subscribe, getSnapshot, getServerSnapshot)
-  React.useEffect(() => {
-    instance.hasValue = true
-    instance.value = value
-  }, [instance, value])
-
-  return value
-}
-
 const initialValuesSet = new WeakMap<AtomRegistry.AtomRegistry, WeakSet<Atom.Atom<any>>>()
 
 /**
@@ -167,9 +102,9 @@ export const useAtomInitialValues = (initialValues: Iterable<readonly [Atom.Atom
  *
  * **Details**
  *
- * When a selector is provided, the hook subscribes to its result. The component
- * re-renders only when the selected value changes according to `equals`, which
- * defaults to `Object.is`. Selectors do not need stable function identity.
+ * When a selector is provided, the hook subscribes to an internally derived
+ * atom. The derived atom uses `equals`, which defaults to `Object.is`, to
+ * suppress updates when the selected value has not changed.
  *
  * @see {@link useAtom} for reading and updating a writable atom from one component
  * @see {@link useAtomRef} for reading an `AtomRef` directly
@@ -186,12 +121,14 @@ export const useAtomValue: {
   equals?: (previous: B, next: B) => boolean
 ): B => {
   const registry = React.useContext(RegistryContext)
-  return useStoreWithSelector(
-    registry,
-    atom,
-    select ?? identity as (_: A) => B,
-    equals ?? Object.is
+  const selectedAtom = React.useMemo(
+    () =>
+      select === undefined
+        ? atom
+        : Atom.map(atom, select).pipe(Atom.withEquality(equals ?? Object.is)),
+    [atom, equals, select]
   )
+  return useStore(registry, selectedAtom as Atom.Atom<B>)
 }
 
 function mountAtom<A>(registry: AtomRegistry.AtomRegistry, atom: Atom.Atom<A>): void {
@@ -413,22 +350,12 @@ const selectAsyncResult = <A, E, B>(
     ? result as unknown as AsyncResult.Failure<B, E>
     : AsyncResult.map(result, select)
 
-function atomResultOrSuspendWithSelector<A, E, B>(
+function atomResultOrSuspend<A, E>(
   registry: AtomRegistry.AtomRegistry,
   atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>,
-  suspendOnWaiting: boolean,
-  select: ((_: A) => B) | undefined,
-  equals: (previous: B, next: B) => boolean,
-  includeFailure: boolean
+  suspendOnWaiting: boolean
 ) {
-  const value = useStoreWithSelector(
-    registry,
-    atom,
-    select === undefined
-      ? identity as (_: AsyncResult.AsyncResult<A, E>) => AsyncResult.AsyncResult<B, E>
-      : (result) => selectAsyncResult(result, select, includeFailure),
-    select === undefined ? Object.is : selectedResultEquals(equals, includeFailure)
-  )
+  const value = useStore(registry, atom)
   if (value._tag === "Initial" || (suspendOnWaiting && value.waiting)) {
     throw atomToPromise(registry, atom, suspendOnWaiting)
   }
@@ -487,10 +414,10 @@ const selectedResultEquals = <A, E>(
  *
  * `suspendOnWaiting` defaults to `false`. When `includeFailure` is `true`, a
  * failure result is returned instead of being thrown. When `select` is
- * provided, the hook subscribes to the selected success value and uses
- * `equals`, defaulting to `Object.is`, to avoid unrelated re-renders. Changes
- * to the result variant, waiting state, or failure cause are not hidden by
- * selection equality.
+ * provided, the hook subscribes to an internally derived atom whose successful
+ * value is selected. The derived atom uses `equals`, defaulting to `Object.is`,
+ * to avoid unrelated updates. Changes to the result variant, waiting state, or
+ * failure cause are not hidden by selection equality.
  *
  * **Gotchas**
  *
@@ -535,13 +462,22 @@ export const useAtomSuspense: {
   const registry = React.useContext(RegistryContext)
   const suspendOnWaiting = options?.suspendOnWaiting ?? false
   const includeFailure = options?.includeFailure === true
-  const result = atomResultOrSuspendWithSelector(
+  const select = options?.select
+  const equals = options?.equals ?? Object.is
+  const selectedAtom = React.useMemo(
+    () =>
+      select === undefined
+        ? atom
+        : Atom.map(
+          atom,
+          (result) => selectAsyncResult(result, select, includeFailure)
+        ).pipe(Atom.withEquality(selectedResultEquals(equals, includeFailure))),
+    [atom, equals, includeFailure, select]
+  )
+  const result = atomResultOrSuspend(
     registry,
-    atom,
-    suspendOnWaiting,
-    options?.select,
-    options?.equals ?? Object.is,
-    includeFailure
+    selectedAtom as Atom.Atom<AsyncResult.AsyncResult<B, E>>,
+    suspendOnWaiting
   )
   if (result._tag === "Failure" && !includeFailure) {
     throw Cause.squash(result.cause)

--- a/packages/atom/react/test/index.test.tsx
+++ b/packages/atom/react/test/index.test.tsx
@@ -1,6 +1,7 @@
 // <reference types="@testing-library/jest-dom" />
+import { assert } from "@effect/vitest"
 import { act, render, screen, waitFor } from "@testing-library/react"
-import { Cause, Context, Effect, Latch, Layer } from "effect"
+import { Cause, Context, Effect, Latch, Layer, Option } from "effect"
 import * as Schema from "effect/Schema"
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 import * as Atom from "effect/unstable/reactivity/Atom"
@@ -119,6 +120,78 @@ describe("atom-react", () => {
       expect(screen.getByTestId("value")).toHaveTextContent("20")
     })
 
+    it("isolates renders with an inline selector and equality", async () => {
+      const atom = Atom.make({ count: 1, ignored: 0 })
+      const renders = vi.fn()
+
+      function TestComponent() {
+        renders()
+        const value = useAtomValue(
+          atom,
+          (value) => ({ count: value.count }),
+          (previous, next) => previous.count === next.count
+        )
+        return <div data-testid="selected-value">{value.count}</div>
+      }
+
+      const view = render(
+        <RegistryContext.Provider value={registry}>
+          <TestComponent />
+        </RegistryContext.Provider>
+      )
+      assert.strictEqual(renders.mock.calls.length, 1)
+
+      view.rerender(
+        <RegistryContext.Provider value={registry}>
+          <TestComponent />
+        </RegistryContext.Provider>
+      )
+      assert.strictEqual(renders.mock.calls.length, 2)
+
+      act(() => {
+        registry.set(atom, { count: 1, ignored: 1 })
+      })
+      assert.strictEqual(renders.mock.calls.length, 2)
+
+      act(() => {
+        registry.set(atom, { count: 2, ignored: 1 })
+      })
+      await waitFor(() => {
+        assert.strictEqual(screen.getByTestId("selected-value").textContent, "2")
+      })
+      assert.strictEqual(renders.mock.calls.length, 3)
+    })
+
+    it("cleans up a selected subscription in Strict Mode", () => {
+      const atom = Atom.make(1)
+      const select = vi.fn((value: number) => value)
+
+      function TestComponent() {
+        return <div>{useAtomValue(atom, select)}</div>
+      }
+
+      const view = render(
+        <React.StrictMode>
+          <RegistryContext.Provider value={registry}>
+            <TestComponent />
+          </RegistryContext.Provider>
+        </React.StrictMode>
+      )
+      const node = registry.getNodes().get(atom)!
+      assert.strictEqual(node.listeners.size, 1)
+
+      const callsBeforeUnmount = select.mock.calls.length
+      view.unmount()
+      assert.strictEqual(node.listeners.size, 0)
+
+      act(() => {
+        registry.set(atom, 2)
+      })
+      assert.strictEqual(select.mock.calls.length, callsBeforeUnmount)
+    })
+  })
+
+  describe("useAtomSuspense", () => {
     test("suspense success", () => {
       const atom = Atom.make(Effect.never)
 
@@ -136,13 +209,41 @@ describe("atom-react", () => {
       expect(screen.getByTestId("loading")).toBeInTheDocument()
     })
 
+    test("suspense error", () => {
+      const atom = Atom.make(Effect.fail(new Error("test")))
+      function TestComponent() {
+        const value = useAtomSuspense(atom).value
+        return <div data-testid="value">{value}</div>
+      }
+
+      render(
+        <ErrorBoundary fallback={<div data-testid="error">Error</div>}>
+          <Suspense fallback={<div data-testid="loading">Loading...</div>}>
+            <TestComponent />
+          </Suspense>
+        </ErrorBoundary>,
+        {
+          onCaughtError: ((error: unknown) => {
+            if (error instanceof Error && error.message === "test") {
+              return
+            }
+            // eslint-disable-next-line no-console
+            console.error(error)
+          }) as unknown as undefined // todo: fix idk why the types are weird
+        }
+      )
+
+      expect(screen.getByTestId("error")).toBeInTheDocument()
+    })
+
     test("suspense subscriptions are isolated per registry", async () => {
-      const atom = Atom.make(AsyncResult.initial<string>())
+      const atom = Atom.make(AsyncResult.initial<{ readonly value: string }>())
       const firstRegistry = AtomRegistry.make()
       const secondRegistry = AtomRegistry.make()
+      const select = vi.fn((value: { readonly value: string }) => value.value)
 
       function TestComponent({ id }: { readonly id: string }) {
-        const value = useAtomSuspense(atom).value
+        const value = useAtomSuspense(atom, { select }).value
         return <div data-testid={`${id}-value`}>{value}</div>
       }
 
@@ -160,9 +261,10 @@ describe("atom-react", () => {
           </Suspense>
         </RegistryContext.Provider>
       )
+      assert.strictEqual(select.mock.calls.length, 0)
 
       act(() => {
-        secondRegistry.set(atom, AsyncResult.success("second"))
+        secondRegistry.set(atom, AsyncResult.success({ value: "second" }))
       })
 
       await waitFor(() => {
@@ -171,12 +273,242 @@ describe("atom-react", () => {
       expect(screen.getByTestId("first-loading")).toBeInTheDocument()
 
       act(() => {
-        firstRegistry.set(atom, AsyncResult.success("first"))
+        firstRegistry.set(atom, AsyncResult.success({ value: "first" }))
       })
 
       await waitFor(() => {
         expect(screen.getByTestId("first-value")).toHaveTextContent("first")
       })
+    })
+
+    it("isolates renders with an inline selector and equality", async () => {
+      const atom = Atom.make(AsyncResult.success({ count: 1, ignored: 0 }))
+      const renders = vi.fn()
+
+      function TestComponent() {
+        renders()
+        const result = useAtomSuspense(atom, {
+          select: (value) => ({ count: value.count }),
+          equals: (previous, next) => previous.count === next.count
+        })
+        return <div data-testid="selected-result">{result.value.count}</div>
+      }
+
+      const view = render(
+        <RegistryContext.Provider value={registry}>
+          <TestComponent />
+        </RegistryContext.Provider>
+      )
+      assert.strictEqual(renders.mock.calls.length, 1)
+
+      view.rerender(
+        <RegistryContext.Provider value={registry}>
+          <TestComponent />
+        </RegistryContext.Provider>
+      )
+      assert.strictEqual(renders.mock.calls.length, 2)
+
+      act(() => {
+        registry.set(atom, AsyncResult.success({ count: 1, ignored: 1 }))
+      })
+      assert.strictEqual(renders.mock.calls.length, 2)
+
+      act(() => {
+        registry.set(atom, AsyncResult.success({ count: 2, ignored: 1 }))
+      })
+      await waitFor(() => {
+        assert.strictEqual(screen.getByTestId("selected-result").textContent, "2")
+      })
+      assert.strictEqual(renders.mock.calls.length, 3)
+    })
+
+    it("observes unselected Success timestamp updates", async () => {
+      const value = { count: 1 }
+      const atom = Atom.make(AsyncResult.success(value, { timestamp: 1 }))
+
+      function TestComponent() {
+        const result = useAtomSuspense(atom)
+        return <div data-testid="success-timestamp">{result.timestamp}</div>
+      }
+
+      render(
+        <RegistryContext.Provider value={registry}>
+          <TestComponent />
+        </RegistryContext.Provider>
+      )
+      assert.strictEqual(screen.getByTestId("success-timestamp").textContent, "1")
+
+      act(() => {
+        registry.set(atom, AsyncResult.success(value, { timestamp: 2 }))
+      })
+      await waitFor(() => {
+        assert.strictEqual(screen.getByTestId("success-timestamp").textContent, "2")
+      })
+    })
+
+    it("preserves waiting transitions", async () => {
+      const atom = Atom.make(AsyncResult.success({ count: 1 }, { waiting: true }))
+
+      function Current() {
+        const result = useAtomSuspense(atom, { select: (value) => value.count })
+        return <div data-testid="current-result">{`${result.value}:${result.waiting}`}</div>
+      }
+
+      function Waiting() {
+        const result = useAtomSuspense(atom, {
+          select: (value) => value.count,
+          suspendOnWaiting: true
+        })
+        return <div data-testid="waiting-result">{result.value}</div>
+      }
+
+      render(
+        <RegistryContext.Provider value={registry}>
+          <Current />
+          <Suspense fallback={<div data-testid="waiting-loading">Loading</div>}>
+            <Waiting />
+          </Suspense>
+        </RegistryContext.Provider>
+      )
+      assert.strictEqual(screen.getByTestId("current-result").textContent, "1:true")
+      assert.strictEqual(screen.getByTestId("waiting-loading").textContent, "Loading")
+
+      act(() => {
+        registry.set(atom, AsyncResult.success({ count: 1 }))
+      })
+      await waitFor(() => {
+        assert.strictEqual(screen.getByTestId("current-result").textContent, "1:false")
+        assert.strictEqual(screen.getByTestId("waiting-result").textContent, "1")
+      })
+    })
+
+    it("does not hide failures behind selection equality", async () => {
+      const atom = Atom.make(AsyncResult.success({ count: 1 }))
+
+      function TestComponent() {
+        const result = useAtomSuspense(atom, {
+          select: (value) => value.count,
+          equals: () => true
+        })
+        return <div data-testid="failure-value">{result.value}</div>
+      }
+
+      render(
+        <ErrorBoundary fallback={<div data-testid="error">Error</div>}>
+          <TestComponent />
+        </ErrorBoundary>,
+        {
+          wrapper: ({ children }) => <RegistryContext.Provider value={registry}>{children}</RegistryContext.Provider>,
+          onCaughtError: (() => {}) as unknown as undefined
+        }
+      )
+      assert.strictEqual(screen.getByTestId("failure-value").textContent, "1")
+
+      act(() => {
+        registry.set(atom, AsyncResult.failure(Cause.fail(new Error("test"))))
+      })
+      await waitFor(() => {
+        assert.strictEqual(screen.getByTestId("error").textContent, "Error")
+      })
+    })
+
+    it("throws the original failure without selecting its previous success", () => {
+      const originalError = new Error("original")
+      const select = vi.fn((): number => {
+        throw new Error("selector")
+      })
+      const atom = Atom.make(
+        AsyncResult.failure<{ count: number }, Error>(Cause.fail(originalError), {
+          previousSuccess: Option.some(AsyncResult.success({ count: 1 }))
+        })
+      )
+
+      function TestComponent() {
+        useAtomSuspense(atom, { select })
+        return null
+      }
+
+      render(
+        <ErrorBoundary
+          fallbackRender={({ error }) => <div data-testid="original-error">{error.message}</div>}
+        >
+          <TestComponent />
+        </ErrorBoundary>,
+        {
+          wrapper: ({ children }) => <RegistryContext.Provider value={registry}>{children}</RegistryContext.Provider>,
+          onCaughtError: (() => {}) as unknown as undefined
+        }
+      )
+
+      assert.strictEqual(screen.getByTestId("original-error").textContent, "original")
+      assert.strictEqual(select.mock.calls.length, 0)
+    })
+
+    it("observes failure cause changes despite selection equality", async () => {
+      const previousSuccess = Option.some(AsyncResult.success({ count: 1 }))
+      const atom = Atom.make(
+        AsyncResult.failure<{ count: number }, Error>(Cause.fail(new Error("first")), {
+          previousSuccess
+        })
+      )
+      const renders = vi.fn()
+
+      function TestComponent() {
+        renders()
+        const result = useAtomSuspense(atom, {
+          select: (value) => value.count,
+          equals: () => true,
+          includeFailure: true
+        })
+        if (result._tag === "Success") {
+          return null
+        }
+        const error = Cause.squash(result.cause)
+        return <div data-testid="failure-cause">{error instanceof Error ? error.message : String(error)}</div>
+      }
+
+      render(
+        <RegistryContext.Provider value={registry}>
+          <TestComponent />
+        </RegistryContext.Provider>
+      )
+      assert.strictEqual(screen.getByTestId("failure-cause").textContent, "first")
+
+      act(() => {
+        registry.set(
+          atom,
+          AsyncResult.failure(Cause.fail(new Error("second")), { previousSuccess })
+        )
+      })
+      await waitFor(() => {
+        assert.strictEqual(screen.getByTestId("failure-cause").textContent, "second")
+      })
+      assert.strictEqual(renders.mock.calls.length, 2)
+    })
+
+    it("maps a failure's previous success", () => {
+      const atom = Atom.make(
+        AsyncResult.failure<{ count: number }, string>(Cause.fail("test"), {
+          previousSuccess: Option.some(AsyncResult.success({ count: 2 }))
+        })
+      )
+
+      function TestComponent() {
+        const result = useAtomSuspense(atom, {
+          select: (value) => value.count * 2,
+          includeFailure: true
+        })
+        return result._tag === "Failure"
+          ? <div data-testid="previous-success">{Option.getOrThrow(result.previousSuccess).value}</div>
+          : null
+      }
+
+      render(
+        <RegistryContext.Provider value={registry}>
+          <TestComponent />
+        </RegistryContext.Provider>
+      )
+      assert.strictEqual(screen.getByTestId("previous-success").textContent, "4")
     })
   })
 
@@ -289,33 +621,6 @@ describe("atom-react", () => {
         expect(screen.getByTestId("value")).toHaveTextContent("1")
       })
     })
-  })
-
-  test("suspense error", () => {
-    const atom = Atom.make(Effect.fail(new Error("test")))
-    function TestComponent() {
-      const value = useAtomSuspense(atom).value
-      return <div data-testid="value">{value}</div>
-    }
-
-    render(
-      <ErrorBoundary fallback={<div data-testid="error">Error</div>}>
-        <Suspense fallback={<div data-testid="loading">Loading...</div>}>
-          <TestComponent />
-        </Suspense>
-      </ErrorBoundary>,
-      {
-        onCaughtError: ((error: unknown) => {
-          if (error instanceof Error && error.message === "test") {
-            return
-          }
-          // eslint-disable-next-line no-console
-          console.error(error)
-        }) as unknown as undefined // todo: fix idk why the types are weird
-      }
-    )
-
-    expect(screen.getByTestId("error")).toBeInTheDocument()
   })
 
   describe("hydration", () => {
@@ -660,6 +965,22 @@ describe("atom-react", () => {
 
       expect(getCount).toHaveBeenCalled()
       expect(screen.getByText("0")).toBeInTheDocument()
+    })
+
+    it("selects from a suspense server snapshot", () => {
+      const atom = Atom.make(AsyncResult.success({ count: 1, ignored: 0 }))
+
+      function TestComponent() {
+        const result = useAtomSuspense(atom, { select: (value) => value.count })
+        return <div>{result.value}</div>
+      }
+
+      const html = renderToString(
+        <RegistryContext.Provider value={registry}>
+          <TestComponent />
+        </RegistryContext.Provider>
+      )
+      assert.strictEqual(html.includes(">1<"), true)
     })
   })
 

--- a/packages/atom/react/test/index.test.tsx
+++ b/packages/atom/react/test/index.test.tsx
@@ -177,12 +177,13 @@ describe("atom-react", () => {
           </RegistryContext.Provider>
         </React.StrictMode>
       )
-      const node = registry.getNodes().get(atom)!
-      assert.strictEqual(node.listeners.size, 1)
+      const selectedNode = Array.from(registry.getNodes()).find(([candidate]) => candidate !== atom)?.[1]
+      assert.isDefined(selectedNode)
+      assert.strictEqual(selectedNode.listeners.size, 1)
 
       const callsBeforeUnmount = select.mock.calls.length
       view.unmount()
-      assert.strictEqual(node.listeners.size, 0)
+      assert.strictEqual(selectedNode.listeners.size, 0)
 
       act(() => {
         registry.set(atom, 2)


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Added support for `select` and `equality` to `useAtomSuspense`, and equality support to `useAtomValue`.

This allows to re-render based on a custom equality check, and add select support also to `useAtomSuspense` (which was already available in `useAtomValue`).

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

Related to `@typeonce/effect-machine` for adding custom equality to machine atom hooks ([reference PR](https://github.com/typeonce-dev/effect-machine/pull/192)):

```tsx
const makeAuthMachine = MachineAtoms.factory(authMachine);

function AuthCard({ input }: { input: AuthMachineInput }) {
  const machine = useMachineAtom(() => makeAuthMachine(input));

  const passwordMode = useAtomSuspense(
    AtomMachine.matches(machine, "Editing.Password")
  ).value;

  const email = useAtomSuspense(
    AtomMachine.select(machine, "Editing"),
    {
      // 👇
      select: Option.map(({ email }) => email),
    }
  ).value;

}
```