### PR TITLE
Report MCP toolkit failures before recovery

### DIFF
--- a/.changeset/report-mcp-tool-failures.md
+++ b/.changeset/report-mcp-tool-failures.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+McpServer now reports toolkit failures through configured `ErrorReporter`s before converting them into MCP tool error results.

--- a/.changeset/report-mcp-tool-failures.md
+++ b/.changeset/report-mcp-tool-failures.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-McpServer now reports toolkit failures through configured `ErrorReporter`s before converting them into MCP tool error results.
+Report recovered MCP toolkit failures and defects to configured `ErrorReporter`s, including declared tool failures returned with `isError: true`.

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -1573,9 +1573,6 @@ export const registerToolkit: <Tools extends Record<string, Tool.Any>>(
           Stream.unwrap,
           Stream.run(Sink.last()),
           Effect.flatMap(Effect.fromOption),
-          Effect.provideContext(
-            services as Context.Context<Tool.HandlerServices<Tools[keyof Tools]>>
-          ),
           Effect.map((result) =>
             new CallToolResult({
               isError: false,
@@ -1585,6 +1582,10 @@ export const registerToolkit: <Tools extends Record<string, Tool.Any>>(
                 text: JSON.stringify(result.encodedResult)
               }]
             })
+          ),
+          Effect.withErrorReporting,
+          Effect.provideContext(
+            services as Context.Context<Tool.HandlerServices<Tools[keyof Tools]>>
           ),
           Effect.tapCause(Effect.logError),
           Effect.catch((error) => {

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -15,6 +15,7 @@ import * as Cause from "../../Cause.ts"
 import * as Context from "../../Context.ts"
 import * as Data from "../../Data.ts"
 import * as Effect from "../../Effect.ts"
+import * as ErrorReporter from "../../ErrorReporter.ts"
 import * as Exit from "../../Exit.ts"
 import * as Fiber from "../../Fiber.ts"
 import * as Layer from "../../Layer.ts"
@@ -1583,27 +1584,31 @@ export const registerToolkit: <Tools extends Record<string, Tool.Any>>(
               }]
             })
           ),
-          Effect.withErrorReporting,
           Effect.provideContext(
             services as Context.Context<Tool.HandlerServices<Tools[keyof Tools]>>
           ),
           Effect.tapCause(Effect.logError),
-          Effect.catch((error) => {
-            if (AiError.isAiError(error)) {
-              const reason = (error as AiError.AiError).reason
-              return reason._tag === "ToolParameterValidationError"
-                ? Effect.fail(new InvalidParams({ message: reason.message }))
-                : Effect.succeed(toolErrorResult(INTERNAL_TOOL_ERROR_MESSAGE))
+          Effect.catchCause((cause) => {
+            const failure = Cause.findError(cause)
+            let message = INTERNAL_TOOL_ERROR_MESSAGE
+            if (Result.isSuccess(failure)) {
+              const error = failure.success
+              if (AiError.isAiError(error)) {
+                const reason = (error as AiError.AiError).reason
+                if (reason._tag === "ToolParameterValidationError") {
+                  return Effect.fail(new InvalidParams({ message: reason.message }))
+                }
+              } else if (isDeclaredFailure(error) && error instanceof Error) {
+                message = error.message
+              }
+            } else if (!Cause.hasDies(cause)) {
+              return Effect.failCause(failure.failure)
             }
-            if (isDeclaredFailure(error)) {
-              const message = error instanceof Error
-                ? error.message
-                : INTERNAL_TOOL_ERROR_MESSAGE
-              return Effect.succeed(toolErrorResult(message))
-            }
-            return Effect.succeed(toolErrorResult(INTERNAL_TOOL_ERROR_MESSAGE))
-          }),
-          Effect.catchDefect(() => Effect.succeed(toolErrorResult(INTERNAL_TOOL_ERROR_MESSAGE)))
+            return ErrorReporter.report(cause).pipe(
+              Effect.provideContext(services),
+              Effect.as(toolErrorResult(message))
+            )
+          })
         )
       }
     })

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -1538,6 +1538,7 @@ export const registerToolkit: <Tools extends Record<string, Tool.Any>>(
     Exclude<Tool.HandlersFor<Tools>, McpServerClient>
   >)
   const services = yield* Effect.context<never>()
+  const reportCause = (cause: Cause.Cause<unknown>) => Effect.provideContext(ErrorReporter.report(cause), services)
   for (const tool of Object.values(built.tools)) {
     const annotations = tool.annotations
     const toolMeta = Context.getOrUndefined(annotations, Tool.Meta)
@@ -1590,24 +1591,22 @@ export const registerToolkit: <Tools extends Record<string, Tool.Any>>(
           Effect.tapCause(Effect.logError),
           Effect.catchCause((cause) => {
             const failure = Cause.findError(cause)
-            let message = INTERNAL_TOOL_ERROR_MESSAGE
-            if (Result.isSuccess(failure)) {
-              const error = failure.success
-              if (AiError.isAiError(error)) {
-                const reason = (error as AiError.AiError).reason
-                if (reason._tag === "ToolParameterValidationError") {
-                  return Effect.fail(new InvalidParams({ message: reason.message }))
-                }
-              } else if (isDeclaredFailure(error) && error instanceof Error) {
-                message = error.message
-              }
-            } else if (!Cause.hasDies(cause)) {
-              return Effect.failCause(failure.failure)
+            if (Result.isFailure(failure)) {
+              return Cause.hasDies(cause)
+                ? Effect.as(reportCause(cause), toolErrorResult(INTERNAL_TOOL_ERROR_MESSAGE))
+                : Effect.failCause(failure.failure)
             }
-            return ErrorReporter.report(cause).pipe(
-              Effect.provideContext(services),
-              Effect.as(toolErrorResult(message))
-            )
+            const error = failure.success
+            if (AiError.isAiError(error)) {
+              const reason = (error as AiError.AiError).reason
+              return reason._tag === "ToolParameterValidationError"
+                ? Effect.fail(new InvalidParams({ message: reason.message }))
+                : Effect.as(reportCause(cause), toolErrorResult(INTERNAL_TOOL_ERROR_MESSAGE))
+            }
+            const message = isDeclaredFailure(error) && error instanceof Error
+              ? error.message
+              : INTERNAL_TOOL_ERROR_MESSAGE
+            return Effect.as(reportCause(cause), toolErrorResult(message))
           })
         )
       }

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -1596,9 +1596,9 @@ export const registerToolkit: <Tools extends Record<string, Tool.Any>>(
                 ? Effect.as(reportCause(cause), toolErrorResult(INTERNAL_TOOL_ERROR_MESSAGE))
                 : Effect.failCause(failure.failure)
             }
-            const error = failure.success
+            const error: unknown = failure.success
             if (AiError.isAiError(error)) {
-              const reason = (error as AiError.AiError).reason
+              const reason = error.reason
               return reason._tag === "ToolParameterValidationError"
                 ? Effect.fail(new InvalidParams({ message: reason.message }))
                 : Effect.as(reportCause(cause), toolErrorResult(INTERNAL_TOOL_ERROR_MESSAGE))

--- a/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
@@ -1,8 +1,10 @@
 import { assert, describe, it } from "@effect/vitest"
 import { assertTrue, strictEqual } from "@effect/vitest/utils"
+import * as Cause from "effect/Cause"
 import * as Context from "effect/Context"
 import * as Deferred from "effect/Deferred"
 import * as Effect from "effect/Effect"
+import * as ErrorReporter from "effect/ErrorReporter"
 import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
 import * as Queue from "effect/Queue"
@@ -45,6 +47,10 @@ const DefectTool = Tool.make("DefectTool", {
   success: Schema.String
 })
 
+const UnserializableResultTool = Tool.make("UnserializableResultTool", {
+  success: Schema.Unknown
+})
+
 const UntypedTool = Tool.make("UntypedTool")
 
 const StructuredResultTool = Tool.make("StructuredResultTool", {
@@ -68,6 +74,7 @@ const TestToolkit = Toolkit.make(
   PublicFailureTool,
   InternalAiErrorTool,
   DefectTool,
+  UnserializableResultTool,
   UntypedTool,
   StructuredResultTool,
   AnnotatedVoidTool,
@@ -76,16 +83,20 @@ const TestToolkit = Toolkit.make(
 )
 type TestToolkitHandlers = Toolkit.HandlersFrom<Toolkit.Tools<typeof TestToolkit>>
 
+const publicFailure = new Error("Public failure")
+const privateDefect = new Error("private defect details")
+
 const testToolkitHandlers = TestToolkit.of({
   OptionalStringTool: ({ signature }) => Effect.succeed(signature ?? "omitted"),
-  PublicFailureTool: () => Effect.fail(new Error("Public failure")),
+  PublicFailureTool: () => Effect.fail(publicFailure),
   InternalAiErrorTool: () => Effect.fail(new AiError.RateLimitError({})),
-  DefectTool: () => Effect.die("private defect details"),
+  DefectTool: () => Effect.die(privateDefect),
   UntypedTool: () => Effect.void,
   StructuredResultTool: () => Effect.succeed({ answer: "result" }),
   AnnotatedVoidTool: () => Effect.void,
   NullableResultTool: () => Effect.succeed(null),
-  ArrayResultTool: () => Effect.succeed(["first", "second"])
+  ArrayResultTool: () => Effect.succeed(["first", "second"]),
+  UnserializableResultTool: () => Effect.succeed(1n)
 })
 
 const INTERNAL_TOOL_ERROR_MESSAGE = "Tool execution failed due to an internal server error."
@@ -153,10 +164,14 @@ const makeRouterTestClient = (
   router: Layer.Layer<never, never, HttpRouter.HttpRouter>
 ) => makeTestClientWith(TestServerLayer, { routerLayer: router })
 
-const makeToolkitTestClient = Effect.fnUntraced(function*(handlers: TestToolkitHandlers = testToolkitHandlers) {
+const makeToolkitTestClient = Effect.fnUntraced(function*(
+  handlers: TestToolkitHandlers = testToolkitHandlers,
+  reporterLayer: Layer.Layer<never> = Layer.empty
+) {
   const serverLayer = McpServer.toolkit(TestToolkit).pipe(
     Layer.provideMerge(TestToolkit.toLayer(handlers)),
-    Layer.provide(TestServerLayer)
+    Layer.provide(TestServerLayer),
+    Layer.provide(reporterLayer)
   )
   const { client } = yield* makeTestClientWith(serverLayer)
   yield* client.initialize({
@@ -521,6 +536,48 @@ describe("McpServer", () => {
         assert.strictEqual(result.isError, true)
         const text = toolResultText(result)
         assert.strictEqual(text, INTERNAL_TOOL_ERROR_MESSAGE)
+      }))
+
+    it.effect("reports tool failures before converting them to public results", () =>
+      Effect.gen(function*() {
+        const reported: Array<Cause.Cause<unknown>> = []
+        const reporter = ErrorReporter.make(({ cause }) => {
+          reported.push(cause)
+        })
+        const client = yield* makeToolkitTestClient(
+          testToolkitHandlers,
+          ErrorReporter.layer([reporter])
+        )
+
+        const success = yield* client["tools/call"]({
+          name: "UntypedTool",
+          arguments: {}
+        })
+        assert.strictEqual(success.isError, false)
+        assert.lengthOf(reported, 0)
+
+        const publicFailureResult = yield* client["tools/call"]({
+          name: "PublicFailureTool",
+          arguments: {}
+        })
+        assert.strictEqual(toolResultText(publicFailureResult), "Public failure")
+
+        const defectResult = yield* client["tools/call"]({
+          name: "DefectTool",
+          arguments: {}
+        })
+        assert.strictEqual(toolResultText(defectResult), INTERNAL_TOOL_ERROR_MESSAGE)
+
+        const serializationResult = yield* client["tools/call"]({
+          name: "UnserializableResultTool",
+          arguments: {}
+        })
+        assert.strictEqual(toolResultText(serializationResult), INTERNAL_TOOL_ERROR_MESSAGE)
+
+        assert.lengthOf(reported, 3)
+        assert.strictEqual(Cause.squash(reported[0]), publicFailure)
+        assert.strictEqual(Cause.squash(reported[1]), privateDefect)
+        assert.instanceOf(Cause.squash(reported[2]), TypeError)
       }))
 
     it.effect("keeps unknown tools as protocol errors", () =>

--- a/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
@@ -185,6 +185,17 @@ const makeToolkitTestClient = Effect.fnUntraced(function*(
   return client
 })
 
+const makeReportingToolkitTestClient = Effect.fnUntraced(function*() {
+  const reported: Array<Cause.Cause<unknown>> = []
+  const client = yield* makeToolkitTestClient(
+    testToolkitHandlers,
+    ErrorReporter.layer([ErrorReporter.make(({ cause }) => {
+      reported.push(cause)
+    })])
+  )
+  return { client, reported }
+})
+
 const toolResultText = (result: McpSchema.CallToolResult): string => {
   const content = result.content[0]
   assertTrue(content?.type === "text", "Expected text tool-result content")
@@ -440,7 +451,7 @@ describe("McpServer", () => {
 
     it.effect("keeps void tool results successful", () =>
       Effect.gen(function*() {
-        const client = yield* makeToolkitTestClient()
+        const { client, reported } = yield* makeReportingToolkitTestClient()
 
         const result = yield* client["tools/call"]({
           name: "UntypedTool",
@@ -454,6 +465,7 @@ describe("McpServer", () => {
             content: []
           })
         )
+        assert.deepStrictEqual(reported, [])
       }))
 
     it.effect("carries object tool results as structured content", () =>
@@ -498,7 +510,7 @@ describe("McpServer", () => {
 
     it.effect("returns schema-validated messages for declared handler failures", () =>
       Effect.gen(function*() {
-        const client = yield* makeToolkitTestClient()
+        const { client, reported } = yield* makeReportingToolkitTestClient()
 
         const result = yield* client["tools/call"]({
           name: "PublicFailureTool",
@@ -508,6 +520,9 @@ describe("McpServer", () => {
         assert.strictEqual(result.isError, true)
         const text = toolResultText(result)
         assert.strictEqual(text, "Public failure")
+        assert.lengthOf(reported, 1)
+        assert.isTrue(Cause.hasFails(reported[0]))
+        assert.strictEqual(Cause.squash(reported[0]), publicFailure)
       }))
 
     it.effect("returns a generic message for non-validation AiError failures", () =>
@@ -526,7 +541,7 @@ describe("McpServer", () => {
 
     it.effect("returns a generic message for handler defects", () =>
       Effect.gen(function*() {
-        const client = yield* makeToolkitTestClient()
+        const { client, reported } = yield* makeReportingToolkitTestClient()
 
         const result = yield* client["tools/call"]({
           name: "DefectTool",
@@ -536,48 +551,25 @@ describe("McpServer", () => {
         assert.strictEqual(result.isError, true)
         const text = toolResultText(result)
         assert.strictEqual(text, INTERNAL_TOOL_ERROR_MESSAGE)
+        assert.lengthOf(reported, 1)
+        assert.isTrue(Cause.hasDies(reported[0]))
+        assert.strictEqual(Cause.squash(reported[0]), privateDefect)
       }))
 
-    it.effect("reports tool failures before converting them to public results", () =>
+    it.effect("reports response serialization defects before returning a generic message", () =>
       Effect.gen(function*() {
-        const reported: Array<Cause.Cause<unknown>> = []
-        const reporter = ErrorReporter.make(({ cause }) => {
-          reported.push(cause)
-        })
-        const client = yield* makeToolkitTestClient(
-          testToolkitHandlers,
-          ErrorReporter.layer([reporter])
-        )
+        const { client, reported } = yield* makeReportingToolkitTestClient()
 
-        const success = yield* client["tools/call"]({
-          name: "UntypedTool",
-          arguments: {}
-        })
-        assert.strictEqual(success.isError, false)
-        assert.lengthOf(reported, 0)
-
-        const publicFailureResult = yield* client["tools/call"]({
-          name: "PublicFailureTool",
-          arguments: {}
-        })
-        assert.strictEqual(toolResultText(publicFailureResult), "Public failure")
-
-        const defectResult = yield* client["tools/call"]({
-          name: "DefectTool",
-          arguments: {}
-        })
-        assert.strictEqual(toolResultText(defectResult), INTERNAL_TOOL_ERROR_MESSAGE)
-
-        const serializationResult = yield* client["tools/call"]({
+        const result = yield* client["tools/call"]({
           name: "UnserializableResultTool",
           arguments: {}
         })
-        assert.strictEqual(toolResultText(serializationResult), INTERNAL_TOOL_ERROR_MESSAGE)
 
-        assert.lengthOf(reported, 3)
-        assert.strictEqual(Cause.squash(reported[0]), publicFailure)
-        assert.strictEqual(Cause.squash(reported[1]), privateDefect)
-        assert.instanceOf(Cause.squash(reported[2]), TypeError)
+        assert.strictEqual(result.isError, true)
+        assert.strictEqual(toolResultText(result), INTERNAL_TOOL_ERROR_MESSAGE)
+        assert.lengthOf(reported, 1)
+        assert.isTrue(Cause.hasDies(reported[0]))
+        assert.instanceOf(Cause.squash(reported[0]), TypeError)
       }))
 
     it.effect("keeps unknown tools as protocol errors", () =>

--- a/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
@@ -84,12 +84,17 @@ const TestToolkit = Toolkit.make(
 type TestToolkitHandlers = Toolkit.HandlersFrom<Toolkit.Tools<typeof TestToolkit>>
 
 const publicFailure = new Error("Public failure")
+const internalAiError = AiError.make({
+  module: "TestToolkit",
+  method: "InternalAiErrorTool",
+  reason: new AiError.RateLimitError({})
+})
 const privateDefect = new Error("private defect details")
 
 const testToolkitHandlers = TestToolkit.of({
   OptionalStringTool: ({ signature }) => Effect.succeed(signature ?? "omitted"),
   PublicFailureTool: () => Effect.fail(publicFailure),
-  InternalAiErrorTool: () => Effect.fail(new AiError.RateLimitError({})),
+  InternalAiErrorTool: () => Effect.fail(internalAiError),
   DefectTool: () => Effect.die(privateDefect),
   UntypedTool: () => Effect.void,
   StructuredResultTool: () => Effect.succeed({ answer: "result" }),
@@ -164,10 +169,11 @@ const makeRouterTestClient = (
   router: Layer.Layer<never, never, HttpRouter.HttpRouter>
 ) => makeTestClientWith(TestServerLayer, { routerLayer: router })
 
-const makeToolkitTestClient = Effect.fnUntraced(function*(
-  handlers: TestToolkitHandlers = testToolkitHandlers,
-  reporterLayer: Layer.Layer<never> = Layer.empty
-) {
+const makeToolkitTestClient = Effect.fnUntraced(function*(handlers: TestToolkitHandlers = testToolkitHandlers) {
+  const reported: Array<Cause.Cause<unknown>> = []
+  const reporterLayer = ErrorReporter.layer([ErrorReporter.make(({ cause }) => {
+    reported.push(cause)
+  })])
   const serverLayer = McpServer.toolkit(TestToolkit).pipe(
     Layer.provideMerge(TestToolkit.toLayer(handlers)),
     Layer.provide(TestServerLayer),
@@ -182,17 +188,6 @@ const makeToolkitTestClient = Effect.fnUntraced(function*(
       version: "1.0.0"
     }
   })
-  return client
-})
-
-const makeReportingToolkitTestClient = Effect.fnUntraced(function*() {
-  const reported: Array<Cause.Cause<unknown>> = []
-  const client = yield* makeToolkitTestClient(
-    testToolkitHandlers,
-    ErrorReporter.layer([ErrorReporter.make(({ cause }) => {
-      reported.push(cause)
-    })])
-  )
   return { client, reported }
 })
 
@@ -377,7 +372,7 @@ describe("McpServer", () => {
   describe("registerToolkit", () => {
     it.effect("lists output schemas only for structured tool results", () =>
       Effect.gen(function*() {
-        const client = yield* makeToolkitTestClient()
+        const { client } = yield* makeToolkitTestClient()
 
         const result = yield* client["tools/list"]({})
         const structuredTool = result.tools.find((tool) => tool.name === "StructuredResultTool")
@@ -402,7 +397,7 @@ describe("McpServer", () => {
     it.effect("returns concise parameter-validation errors without invoking the handler", () =>
       Effect.gen(function*() {
         let handlerInvoked = false
-        const client = yield* makeToolkitTestClient(TestToolkit.of({
+        const { client, reported } = yield* makeToolkitTestClient(TestToolkit.of({
           ...testToolkitHandlers,
           OptionalStringTool: ({ signature }) => {
             handlerInvoked = true
@@ -421,12 +416,19 @@ describe("McpServer", () => {
         assert.match(error.message, /Invalid parameters for tool 'OptionalStringTool'/)
         assert.match(error.message, /Expected string \| undefined/)
         assert.match(error.message, /at \["signature"\]/)
+        assert.lengthOf(reported, 1)
+        assert.isTrue(Cause.hasFails(reported[0]))
+        assert.deepInclude(Cause.squash(reported[0]), {
+          _tag: "ProtocolError",
+          code: McpSchema.INVALID_PARAMS_ERROR_CODE,
+          message: error.message
+        })
       }))
 
     it.effect("preserves successful results when optional parameters are omitted", () =>
       Effect.gen(function*() {
         let handlerInvoked = false
-        const client = yield* makeToolkitTestClient(TestToolkit.of({
+        const { client } = yield* makeToolkitTestClient(TestToolkit.of({
           ...testToolkitHandlers,
           OptionalStringTool: ({ signature }) => {
             handlerInvoked = true
@@ -451,7 +453,7 @@ describe("McpServer", () => {
 
     it.effect("keeps void tool results successful", () =>
       Effect.gen(function*() {
-        const { client, reported } = yield* makeReportingToolkitTestClient()
+        const { client, reported } = yield* makeToolkitTestClient()
 
         const result = yield* client["tools/call"]({
           name: "UntypedTool",
@@ -470,7 +472,7 @@ describe("McpServer", () => {
 
     it.effect("carries object tool results as structured content", () =>
       Effect.gen(function*() {
-        const client = yield* makeToolkitTestClient()
+        const { client } = yield* makeToolkitTestClient()
 
         const result = yield* client["tools/call"]({
           name: "StructuredResultTool",
@@ -486,7 +488,7 @@ describe("McpServer", () => {
 
     it.effect("omits structured content for null and array tool results", () =>
       Effect.gen(function*() {
-        const client = yield* makeToolkitTestClient()
+        const { client } = yield* makeToolkitTestClient()
 
         const nullResult = yield* client["tools/call"]({
           name: "NullableResultTool",
@@ -510,7 +512,7 @@ describe("McpServer", () => {
 
     it.effect("returns schema-validated messages for declared handler failures", () =>
       Effect.gen(function*() {
-        const { client, reported } = yield* makeReportingToolkitTestClient()
+        const { client, reported } = yield* makeToolkitTestClient()
 
         const result = yield* client["tools/call"]({
           name: "PublicFailureTool",
@@ -527,7 +529,7 @@ describe("McpServer", () => {
 
     it.effect("returns a generic message for non-validation AiError failures", () =>
       Effect.gen(function*() {
-        const client = yield* makeToolkitTestClient()
+        const { client, reported } = yield* makeToolkitTestClient()
 
         const result = yield* client["tools/call"]({
           name: "InternalAiErrorTool",
@@ -537,11 +539,14 @@ describe("McpServer", () => {
         assert.strictEqual(result.isError, true)
         const text = toolResultText(result)
         assert.strictEqual(text, INTERNAL_TOOL_ERROR_MESSAGE)
+        assert.lengthOf(reported, 1)
+        assert.isTrue(Cause.hasFails(reported[0]))
+        assert.strictEqual(Cause.squash(reported[0]), internalAiError)
       }))
 
     it.effect("returns a generic message for handler defects", () =>
       Effect.gen(function*() {
-        const { client, reported } = yield* makeReportingToolkitTestClient()
+        const { client, reported } = yield* makeToolkitTestClient()
 
         const result = yield* client["tools/call"]({
           name: "DefectTool",
@@ -558,7 +563,7 @@ describe("McpServer", () => {
 
     it.effect("reports response serialization defects before returning a generic message", () =>
       Effect.gen(function*() {
-        const { client, reported } = yield* makeReportingToolkitTestClient()
+        const { client, reported } = yield* makeToolkitTestClient()
 
         const result = yield* client["tools/call"]({
           name: "UnserializableResultTool",
@@ -574,7 +579,7 @@ describe("McpServer", () => {
 
     it.effect("keeps unknown tools as protocol errors", () =>
       Effect.gen(function*() {
-        const client = yield* makeToolkitTestClient()
+        const { client } = yield* makeToolkitTestClient()
 
         const error = yield* client["tools/call"]({
           name: "UnknownTool",


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`McpServer.registerToolkit` converts tool failures and defects into safe MCP error results before the outer HTTP or RPC reporting boundaries can observe their original `Cause`. As a result, configured `ErrorReporter`s do not receive failures that the MCP server subsequently recovers.

This change:

- reports original causes from tool execution and result serialization immediately before recovery produces a tool error result
- leaves parameter-validation failures to the existing protocol reporting boundary
- runs reporting with the context captured during toolkit registration
- preserves existing public `CallToolResult` messages and protocol behavior
- adds coverage for declared failures, defects, response-serialization defects, and successful calls
- includes a patch changeset

Validation:

- `pnpm test --run packages/effect/test/unstable/ai/McpServer/McpServer.test.ts`
- `pnpm lint-fix`
- `pnpm check`

## Related

- Related: https://github.com/Effect-TS/effect/pull/6607
- Closes EFF-1316

