### PR TITLE
Fix Set-Cookie name validation

### DIFF
--- a/.changeset/strict-cookie-names.md
+++ b/.changeset/strict-cookie-names.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Ignore `Set-Cookie` headers whose cookie names do not satisfy the RFC 6265 token syntax.

--- a/packages/effect/src/unstable/http/Cookies.ts
+++ b/packages/effect/src/unstable/http/Cookies.ts
@@ -288,7 +288,7 @@ function parseSetCookie(header: string): Cookie | undefined {
     return undefined
   }
   const name = parts[0].slice(0, firstEqual)
-  if (!fieldContentRegExp.test(name)) {
+  if (!cookieNameRegExp.test(name)) {
     return undefined
   }
 

--- a/packages/effect/test/unstable/http/Cookies.test.ts
+++ b/packages/effect/test/unstable/http/Cookies.test.ts
@@ -40,6 +40,18 @@ describe("Cookies", () => {
     })
   })
 
+  describe("fromSetCookie", () => {
+    it("ignores invalid cookie names", () => {
+      const cookies = Cookies.fromSetCookie([
+        "bad name=value",
+        "session=abc"
+      ])
+
+      assertNone(Cookies.get(cookies, "bad name"))
+      assertSome(Cookies.getValue(cookies, "session"), "abc")
+    })
+  })
+
   describe("toSetCookieHeaders", () => {
     const invalidCookie = {
       name: "session",


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`Cookies.fromSetCookie` validated parsed cookie names with `fieldContentRegExp`, which allowed invalid names containing characters such as spaces. This was inconsistent with `Cookies.makeCookie`, which already validates names using the RFC 6265 token syntax.

This PR:

- uses `cookieNameRegExp` when parsing `Set-Cookie` headers;
- ignores cookies with invalid names;
- preserves valid cookies received alongside invalid ones;
- adds focused regression coverage;
- adds an `effect` patch changeset.

### Validation

- `pnpm test --run packages/effect/test/unstable/http/Cookies.test.ts` — 10 tests passed
- `NODE_OPTIONS=--experimental-strip-types pnpm lint-fix`
- `pnpm check`

## Related

No related issue.