### PR TITLE
Add exact ByteSize value module

### DIFF
--- a/.changeset/exact-byte-size.md
+++ b/.changeset/exact-byte-size.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add an exact `ByteSize` value module with unambiguous decimal (`kB`, `MB`) and binary (`KiB`, `MiB`) units, parsing, formatting, checked arithmetic, and safe number conversion. Add `Schema.ByteSize*` codecs and `Config.ByteSize` for exact non-negative bigint-backed byte counts.

--- a/packages/effect/src/ByteSize.ts
+++ b/packages/effect/src/ByteSize.ts
@@ -46,12 +46,12 @@ export interface ByteSize extends Equal.Equal, Pipeable, Inspectable.Inspectable
 export type Input = ByteSize | bigint | number | string
 
 /**
- * Canonical decimal and binary byte unit symbols.
+ * Canonical decimal byte unit symbols.
  *
  * @category models
  * @since 4.0.0
  */
-export type Unit =
+export type DecimalUnit =
   | "B"
   | "kB"
   | "MB"
@@ -63,6 +63,15 @@ export type Unit =
   | "YB"
   | "RB"
   | "QB"
+
+/**
+ * Canonical binary byte unit symbols.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type BinaryUnit =
+  | "B"
   | "KiB"
   | "MiB"
   | "GiB"
@@ -73,17 +82,34 @@ export type Unit =
   | "YiB"
 
 /**
+ * Canonical decimal and binary byte unit symbols.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type Unit = DecimalUnit | BinaryUnit
+
+/**
  * Options controlling compact byte-size formatting.
  *
  * @category models
  * @since 4.0.0
  */
-export interface FormatOptions {
-  readonly system?: "decimal" | "binary" | undefined
-  readonly unit?: Unit | undefined
-  readonly precision?: number | undefined
-  readonly trailingZeros?: boolean | undefined
-}
+export type FormatOptions =
+  & {
+    readonly precision?: number | undefined
+    readonly trailingZeros?: boolean | undefined
+  }
+  & (
+    | {
+      readonly system?: "decimal" | undefined
+      readonly unit?: DecimalUnit | undefined
+    }
+    | {
+      readonly system?: "binary" | undefined
+      readonly unit?: BinaryUnit | undefined
+    }
+  )
 
 interface UnitInfo {
   readonly symbol: Unit
@@ -133,7 +159,7 @@ const ByteSizeProto: Omit<ByteSize, "value"> = {
     return `${this.value} ${this.value === bigint1 ? "byte" : "bytes"}`
   },
   toJSON(this: ByteSize) {
-    return { _id: "ByteSize", bytes: globalThis.String(this.value) }
+    return { _id: "ByteSize", bytes: `${this.value}` }
   },
   [NodeInspectSymbol]() {
     return this.toJSON()
@@ -144,13 +170,10 @@ const ByteSizeProto: Omit<ByteSize, "value"> = {
 }
 
 const make = (value: bigint): ByteSize => {
-  if (value === bigint0 && zeroValue !== undefined) return zeroValue
   const byteSize = Object.create(ByteSizeProto)
   byteSize.value = value
   return byteSize
 }
-
-let zeroValue: ByteSize | undefined
 
 /**
  * The byte size containing zero bytes.
@@ -158,7 +181,7 @@ let zeroValue: ByteSize | undefined
  * @category constants
  * @since 4.0.0
  */
-export const zero: ByteSize = zeroValue = make(bigint0)
+export const zero: ByteSize = make(bigint0)
 
 const invalid = (message: string): never => {
   throw new Error(`Invalid ByteSize: ${message}`)
@@ -215,7 +238,7 @@ export const fromInputUnsafe = (input: Input): ByteSize => {
     case "object":
       if (isByteSize(input)) return input
   }
-  return invalid(`unsupported input ${globalThis.String(input)}`)
+  return invalid(`unsupported input ${input}`)
 }
 
 /**
@@ -382,12 +405,12 @@ export const isByteSize = (input: unknown): input is ByteSize => hasProperty(inp
 export const isZero = (self: ByteSize): boolean => self.value === bigint0
 
 /**
- * Returns the exact byte count.
+ * Returns the exact byte count as a bigint.
  *
  * @category getters
  * @since 4.0.0
  */
-export const toBytes = (self: ByteSize): bigint => self.value
+export const toBigInt = (self: ByteSize): bigint => self.value
 
 /**
  * Converts a byte size to a safe integer, returning `None` when it is too large.
@@ -622,7 +645,7 @@ const formatWithUnit = (value: bigint, unit: UnitInfo, precision: number, traili
   const rounded = (value * scale * BigInt(2) + unit.factor) / (unit.factor * BigInt(2))
   const whole = rounded / scale
   if (precision === 0) return `${whole} ${unit.symbol}`
-  let fraction = globalThis.String(rounded % scale).padStart(precision, "0")
+  let fraction = `${rounded % scale}`.padStart(precision, "0")
   if (!trailingZeros) fraction = fraction.replace(/0+$/, "")
   return `${whole}${fraction.length === 0 ? "" : `.${fraction}`} ${unit.symbol}`
 }

--- a/packages/effect/src/ByteSize.ts
+++ b/packages/effect/src/ByteSize.ts
@@ -1,0 +1,677 @@
+/**
+ * Represents exact, non-negative, integral byte counts.
+ *
+ * Decimal units use powers of 1,000 and binary units use powers of 1,024.
+ *
+ * @since 4.0.0
+ */
+import * as Combiner from "./Combiner.ts"
+import * as Equal from "./Equal.ts"
+import type * as Equ from "./Equivalence.ts"
+import { dual } from "./Function.ts"
+import * as Hash from "./Hash.ts"
+import type * as Inspectable from "./Inspectable.ts"
+import { NodeInspectSymbol } from "./Inspectable.ts"
+import * as Option from "./Option.ts"
+import * as order from "./Order.ts"
+import type { Pipeable } from "./Pipeable.ts"
+import { pipeArguments } from "./Pipeable.ts"
+import { hasProperty } from "./Predicate.ts"
+import * as Reducer from "./Reducer.ts"
+
+const TypeId = "~effect/ByteSize"
+
+const bigint0 = BigInt(0)
+const bigint1 = BigInt(1)
+const decimalBase = BigInt(1000)
+const binaryBase = BigInt(1024)
+
+/**
+ * Represents an exact, non-negative number of bytes.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ByteSize extends Equal.Equal, Pipeable, Inspectable.Inspectable {
+  readonly [TypeId]: typeof TypeId
+  readonly value: bigint
+}
+
+/**
+ * Values accepted by byte-size decoding operations.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type Input = ByteSize | bigint | number | string
+
+/**
+ * Canonical decimal and binary byte unit symbols.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type Unit =
+  | "B"
+  | "kB"
+  | "MB"
+  | "GB"
+  | "TB"
+  | "PB"
+  | "EB"
+  | "ZB"
+  | "YB"
+  | "RB"
+  | "QB"
+  | "KiB"
+  | "MiB"
+  | "GiB"
+  | "TiB"
+  | "PiB"
+  | "EiB"
+  | "ZiB"
+  | "YiB"
+
+/**
+ * Options controlling compact byte-size formatting.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface FormatOptions {
+  readonly system?: "decimal" | "binary" | undefined
+  readonly unit?: Unit | undefined
+  readonly precision?: number | undefined
+  readonly trailingZeros?: boolean | undefined
+}
+
+interface UnitInfo {
+  readonly symbol: Unit
+  readonly factor: bigint
+  readonly names: ReadonlyArray<string>
+}
+
+const decimalUnits: ReadonlyArray<UnitInfo> = [
+  { symbol: "B", factor: bigint1, names: ["B", "byte", "bytes"] },
+  { symbol: "kB", factor: decimalBase, names: ["kB", "kilobyte", "kilobytes"] },
+  { symbol: "MB", factor: decimalBase ** BigInt(2), names: ["MB", "megabyte", "megabytes"] },
+  { symbol: "GB", factor: decimalBase ** BigInt(3), names: ["GB", "gigabyte", "gigabytes"] },
+  { symbol: "TB", factor: decimalBase ** BigInt(4), names: ["TB", "terabyte", "terabytes"] },
+  { symbol: "PB", factor: decimalBase ** BigInt(5), names: ["PB", "petabyte", "petabytes"] },
+  { symbol: "EB", factor: decimalBase ** BigInt(6), names: ["EB", "exabyte", "exabytes"] },
+  { symbol: "ZB", factor: decimalBase ** BigInt(7), names: ["ZB", "zettabyte", "zettabytes"] },
+  { symbol: "YB", factor: decimalBase ** BigInt(8), names: ["YB", "yottabyte", "yottabytes"] },
+  { symbol: "RB", factor: decimalBase ** BigInt(9), names: ["RB", "ronnabyte", "ronnabytes"] },
+  { symbol: "QB", factor: decimalBase ** BigInt(10), names: ["QB", "quettabyte", "quettabytes"] }
+]
+
+const binaryUnits: ReadonlyArray<UnitInfo> = [
+  decimalUnits[0],
+  { symbol: "KiB", factor: binaryBase, names: ["KiB", "kibibyte", "kibibytes"] },
+  { symbol: "MiB", factor: binaryBase ** BigInt(2), names: ["MiB", "mebibyte", "mebibytes"] },
+  { symbol: "GiB", factor: binaryBase ** BigInt(3), names: ["GiB", "gibibyte", "gibibytes"] },
+  { symbol: "TiB", factor: binaryBase ** BigInt(4), names: ["TiB", "tebibyte", "tebibytes"] },
+  { symbol: "PiB", factor: binaryBase ** BigInt(5), names: ["PiB", "pebibyte", "pebibytes"] },
+  { symbol: "EiB", factor: binaryBase ** BigInt(6), names: ["EiB", "exbibyte", "exbibytes"] },
+  { symbol: "ZiB", factor: binaryBase ** BigInt(7), names: ["ZiB", "zebibyte", "zebibytes"] },
+  { symbol: "YiB", factor: binaryBase ** BigInt(8), names: ["YiB", "yobibyte", "yobibytes"] }
+]
+
+const allUnits = [...decimalUnits, ...binaryUnits.slice(1)]
+const unitsByName = new Map(allUnits.flatMap((unit) => unit.names.map((name) => [name, unit] as const)))
+const unitsBySymbol = new Map(allUnits.map((unit) => [unit.symbol, unit] as const))
+
+const ByteSizeProto: Omit<ByteSize, "value"> = {
+  [TypeId]: TypeId,
+  [Hash.symbol](this: ByteSize) {
+    return Hash.hash(this.value)
+  },
+  [Equal.symbol](this: ByteSize, that: unknown): boolean {
+    return isByteSize(that) && this.value === that.value
+  },
+  toString(this: ByteSize) {
+    return `${this.value} ${this.value === bigint1 ? "byte" : "bytes"}`
+  },
+  toJSON(this: ByteSize) {
+    return { _id: "ByteSize", bytes: globalThis.String(this.value) }
+  },
+  [NodeInspectSymbol]() {
+    return this.toJSON()
+  },
+  pipe() {
+    return pipeArguments(this, arguments)
+  }
+}
+
+const make = (value: bigint): ByteSize => {
+  if (value === bigint0 && zeroValue !== undefined) return zeroValue
+  const byteSize = Object.create(ByteSizeProto)
+  byteSize.value = value
+  return byteSize
+}
+
+let zeroValue: ByteSize | undefined
+
+/**
+ * The byte size containing zero bytes.
+ *
+ * @category constants
+ * @since 4.0.0
+ */
+export const zero: ByteSize = zeroValue = make(bigint0)
+
+const invalid = (message: string): never => {
+  throw new Error(`Invalid ByteSize: ${message}`)
+}
+
+const fromNumber = (input: number): ByteSize => {
+  if (!Number.isSafeInteger(input) || input < 0) {
+    return invalid(`expected a non-negative safe integer, received ${input}`)
+  }
+  return make(BigInt(input))
+}
+
+const fromQuantity = (quantity: number | bigint, unit: UnitInfo): ByteSize => {
+  if (typeof quantity === "bigint") {
+    if (quantity < bigint0) return invalid(`expected a non-negative quantity, received ${quantity}`)
+    return make(quantity * unit.factor)
+  }
+  const value = quantity * Number(unit.factor)
+  if (!Number.isSafeInteger(value) || value < 0) {
+    return invalid(`expected an exact non-negative safe-integer byte result, received ${quantity} ${unit.symbol}`)
+  }
+  return make(BigInt(value))
+}
+
+const parse = (input: string): ByteSize => {
+  const match = /^\s*(\d+)(?:\.(\d+))?\s*([A-Za-z]+)\s*$/.exec(input)
+  if (match === null) return invalid(`unsupported syntax ${JSON.stringify(input)}`)
+  const unit = unitsByName.get(match[3])
+  if (unit === undefined) return invalid(`unsupported unit ${JSON.stringify(match[3])}`)
+  const fraction = match[2] ?? ""
+  const scale = BigInt(10) ** BigInt(fraction.length)
+  const numerator = BigInt(match[1] + fraction) * unit.factor
+  if (numerator % scale !== bigint0) {
+    return invalid(`${JSON.stringify(input)} does not represent an integral number of bytes`)
+  }
+  return make(numerator / scale)
+}
+
+/**
+ * Decodes a trusted input into a byte size and throws for invalid input.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const fromInputUnsafe = (input: Input): ByteSize => {
+  switch (typeof input) {
+    case "bigint":
+      if (input < bigint0) return invalid(`expected a non-negative bigint, received ${input}`)
+      return make(input)
+    case "number":
+      return fromNumber(input)
+    case "string":
+      return parse(input)
+    case "object":
+      if (isByteSize(input)) return input
+  }
+  return invalid(`unsupported input ${globalThis.String(input)}`)
+}
+
+/**
+ * Decodes an input into a byte size, returning `None` for invalid input.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const fromInput: (input: Input) => Option.Option<ByteSize> = Option.liftThrowable(fromInputUnsafe)
+
+/**
+ * Creates a byte size from a non-negative byte count.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const bytes = (value: number | bigint): ByteSize =>
+  typeof value === "bigint" ? fromInputUnsafe(value) : fromNumber(value)
+
+const unitConstructor = (symbol: Unit) => (value: number | bigint): ByteSize =>
+  fromQuantity(value, unitsBySymbol.get(symbol)!)
+
+/**
+ * Creates a decimal kilobyte value.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const kilobytes = unitConstructor("kB")
+/**
+ * Creates a decimal megabyte value.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const megabytes = unitConstructor("MB")
+/**
+ * Creates a decimal gigabyte value.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const gigabytes = unitConstructor("GB")
+/**
+ * Creates a decimal terabyte value.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const terabytes = unitConstructor("TB")
+/**
+ * Creates a decimal petabyte value.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const petabytes = unitConstructor("PB")
+/**
+ * Creates a decimal exabyte value.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const exabytes = unitConstructor("EB")
+/**
+ * Creates a decimal zettabyte value.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const zettabytes = unitConstructor("ZB")
+/**
+ * Creates a decimal yottabyte value.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const yottabytes = unitConstructor("YB")
+/**
+ * Creates a decimal ronnabyte value.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const ronnabytes = unitConstructor("RB")
+/**
+ * Creates a decimal quettabyte value.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const quettabytes = unitConstructor("QB")
+/**
+ * Creates a binary kibibyte value.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const kibibytes = unitConstructor("KiB")
+/**
+ * Creates a binary mebibyte value.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const mebibytes = unitConstructor("MiB")
+/**
+ * Creates a binary gibibyte value.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const gibibytes = unitConstructor("GiB")
+/**
+ * Creates a binary tebibyte value.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const tebibytes = unitConstructor("TiB")
+/**
+ * Creates a binary pebibyte value.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const pebibytes = unitConstructor("PiB")
+/**
+ * Creates a binary exbibyte value.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const exbibytes = unitConstructor("EiB")
+/**
+ * Creates a binary zebibyte value.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const zebibytes = unitConstructor("ZiB")
+/**
+ * Creates a binary yobibyte value.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const yobibytes = unitConstructor("YiB")
+
+/**
+ * Checks whether a value is a byte size.
+ *
+ * @category guards
+ * @since 4.0.0
+ */
+export const isByteSize = (input: unknown): input is ByteSize => hasProperty(input, TypeId)
+
+/**
+ * Checks whether a byte size is zero.
+ *
+ * @category predicates
+ * @since 4.0.0
+ */
+export const isZero = (self: ByteSize): boolean => self.value === bigint0
+
+/**
+ * Returns the exact byte count.
+ *
+ * @category getters
+ * @since 4.0.0
+ */
+export const toBytes = (self: ByteSize): bigint => self.value
+
+/**
+ * Converts a byte size to a safe integer, returning `None` when it is too large.
+ *
+ * @category converting
+ * @since 4.0.0
+ */
+export const toNumber = (self: ByteSize): Option.Option<number> => {
+  const value = Number(self.value)
+  return Number.isSafeInteger(value) ? Option.some(value) : Option.none()
+}
+
+/**
+ * Converts a byte size to a safe integer and throws when it is too large.
+ *
+ * @category unsafe
+ * @since 4.0.0
+ */
+export const toNumberUnsafe = (self: ByteSize): number =>
+  Option.getOrThrowWith(toNumber(self), () => new Error(`ByteSize exceeds Number.MAX_SAFE_INTEGER: ${self.value}`))
+
+/**
+ * Converts a byte size to an approximate number of the specified unit.
+ *
+ * @category converting
+ * @since 4.0.0
+ */
+export const toUnit: {
+  (unit: Unit): (self: ByteSize) => number
+  (self: ByteSize, unit: Unit): number
+} = dual(2, (self: ByteSize, unit: Unit) => Number(self.value) / Number(unitsBySymbol.get(unit)!.factor))
+
+/**
+ * Provides an order for byte sizes.
+ *
+ * @category instances
+ * @since 4.0.0
+ */
+export const Order: order.Order<ByteSize> = order.make((self, that) =>
+  self.value < that.value ? -1 : self.value > that.value ? 1 : 0
+)
+
+/**
+ * Provides an equivalence for byte sizes.
+ *
+ * @category instances
+ * @since 4.0.0
+ */
+export const Equivalence: Equ.Equivalence<ByteSize> = (self, that) => self.value === that.value
+
+/**
+ * Returns whether a byte size is in an inclusive range.
+ *
+ * @category predicates
+ * @since 4.0.0
+ */
+export const between: {
+  (options: { minimum: ByteSize; maximum: ByteSize }): (self: ByteSize) => boolean
+  (self: ByteSize, options: { minimum: ByteSize; maximum: ByteSize }): boolean
+} = order.isBetween(Order)
+
+/**
+ * Returns the smaller byte size.
+ *
+ * @category ordering
+ * @since 4.0.0
+ */
+export const min: {
+  (that: ByteSize): (self: ByteSize) => ByteSize
+  (self: ByteSize, that: ByteSize): ByteSize
+} = order.min(Order)
+
+/**
+ * Returns the larger byte size.
+ *
+ * @category ordering
+ * @since 4.0.0
+ */
+export const max: {
+  (that: ByteSize): (self: ByteSize) => ByteSize
+  (self: ByteSize, that: ByteSize): ByteSize
+} = order.max(Order)
+
+/**
+ * Constrains a byte size to an inclusive range.
+ *
+ * @category ordering
+ * @since 4.0.0
+ */
+export const clamp: {
+  (options: { minimum: ByteSize; maximum: ByteSize }): (self: ByteSize) => ByteSize
+  (self: ByteSize, options: { minimum: ByteSize; maximum: ByteSize }): ByteSize
+} = order.clamp(Order)
+
+/**
+ * Checks whether the first byte size is less than the second.
+ *
+ * @category predicates
+ * @since 4.0.0
+ */
+export const isLessThan: {
+  (that: ByteSize): (self: ByteSize) => boolean
+  (self: ByteSize, that: ByteSize): boolean
+} = order.isLessThan(Order)
+
+/**
+ * Checks whether the first byte size is at most the second.
+ *
+ * @category predicates
+ * @since 4.0.0
+ */
+export const isLessThanOrEqualTo: {
+  (that: ByteSize): (self: ByteSize) => boolean
+  (self: ByteSize, that: ByteSize): boolean
+} = order.isLessThanOrEqualTo(Order)
+
+/**
+ * Checks whether the first byte size is greater than the second.
+ *
+ * @category predicates
+ * @since 4.0.0
+ */
+export const isGreaterThan: {
+  (that: ByteSize): (self: ByteSize) => boolean
+  (self: ByteSize, that: ByteSize): boolean
+} = order.isGreaterThan(Order)
+
+/**
+ * Checks whether the first byte size is at least the second.
+ *
+ * @category predicates
+ * @since 4.0.0
+ */
+export const isGreaterThanOrEqualTo: {
+  (that: ByteSize): (self: ByteSize) => boolean
+  (self: ByteSize, that: ByteSize): boolean
+} = order.isGreaterThanOrEqualTo(Order)
+
+/**
+ * Checks whether two byte sizes contain the same count.
+ *
+ * @category predicates
+ * @since 4.0.0
+ */
+export const equals: {
+  (that: ByteSize): (self: ByteSize) => boolean
+  (self: ByteSize, that: ByteSize): boolean
+} = dual(2, Equivalence)
+
+/**
+ * Adds two byte sizes exactly.
+ *
+ * @category math
+ * @since 4.0.0
+ */
+export const sum: {
+  (that: ByteSize): (self: ByteSize) => ByteSize
+  (self: ByteSize, that: ByteSize): ByteSize
+} = dual(2, (self: ByteSize, that: ByteSize) => make(self.value + that.value))
+
+/**
+ * Subtracts byte sizes, returning `None` on underflow.
+ *
+ * @category math
+ * @since 4.0.0
+ */
+export const subtract: {
+  (that: ByteSize): (self: ByteSize) => Option.Option<ByteSize>
+  (self: ByteSize, that: ByteSize): Option.Option<ByteSize>
+} = dual(
+  2,
+  (self: ByteSize, that: ByteSize) =>
+    self.value < that.value ? Option.none() : Option.some(make(self.value - that.value))
+)
+
+/**
+ * Subtracts byte sizes and throws on underflow.
+ *
+ * @category unsafe
+ * @since 4.0.0
+ */
+export const subtractUnsafe: {
+  (that: ByteSize): (self: ByteSize) => ByteSize
+  (self: ByteSize, that: ByteSize): ByteSize
+} = dual(2, (self: ByteSize, that: ByteSize) => {
+  if (self.value < that.value) throw new Error(`ByteSize subtraction underflow: ${self.value} - ${that.value}`)
+  return make(self.value - that.value)
+})
+
+const scalar = (input: number | bigint, positive: boolean): bigint | undefined => {
+  if (typeof input === "bigint") return input >= (positive ? bigint1 : bigint0) ? input : undefined
+  return Number.isSafeInteger(input) && input >= (positive ? 1 : 0) ? BigInt(input) : undefined
+}
+
+/**
+ * Multiplies a byte size by a non-negative integer scalar.
+ *
+ * @category math
+ * @since 4.0.0
+ */
+export const times: {
+  (multiplier: number | bigint): (self: ByteSize) => Option.Option<ByteSize>
+  (self: ByteSize, multiplier: number | bigint): Option.Option<ByteSize>
+} = dual(2, (self: ByteSize, multiplier: number | bigint) => {
+  const value = scalar(multiplier, false)
+  return value === undefined ? Option.none() : Option.some(make(self.value * value))
+})
+
+/**
+ * Divides a byte size by a positive integer, discarding any remainder.
+ *
+ * @category math
+ * @since 4.0.0
+ */
+export const divide: {
+  (divisor: number | bigint): (self: ByteSize) => Option.Option<ByteSize>
+  (self: ByteSize, divisor: number | bigint): Option.Option<ByteSize>
+} = dual(2, (self: ByteSize, divisor: number | bigint) => {
+  const value = scalar(divisor, true)
+  return value === undefined ? Option.none() : Option.some(make(self.value / value))
+})
+
+const validatePrecision = (precision: number): number => {
+  if (!Number.isSafeInteger(precision) || precision < 0 || precision > 20) {
+    throw new Error(`ByteSize format precision must be an integer from 0 to 20, received ${precision}`)
+  }
+  return precision
+}
+
+const formatWithUnit = (value: bigint, unit: UnitInfo, precision: number, trailingZeros: boolean): string => {
+  const scale = BigInt(10) ** BigInt(precision)
+  const rounded = (value * scale * BigInt(2) + unit.factor) / (unit.factor * BigInt(2))
+  const whole = rounded / scale
+  if (precision === 0) return `${whole} ${unit.symbol}`
+  let fraction = globalThis.String(rounded % scale).padStart(precision, "0")
+  if (!trailingZeros) fraction = fraction.replace(/0+$/, "")
+  return `${whole}${fraction.length === 0 ? "" : `.${fraction}`} ${unit.symbol}`
+}
+
+/**
+ * Formats a byte size with canonical decimal or binary unit symbols.
+ *
+ * @category converting
+ * @since 4.0.0
+ */
+export const format = (self: ByteSize, options: FormatOptions = {}): string => {
+  const precision = validatePrecision(options.precision ?? 2)
+  const trailingZeros = options.trailingZeros ?? false
+  if (options.unit !== undefined) {
+    return formatWithUnit(self.value, unitsBySymbol.get(options.unit)!, precision, trailingZeros)
+  }
+  const units = options.system === "decimal" ? decimalUnits : binaryUnits
+  if (self.value === bigint0) return "0 B"
+  let index = units.length - 1
+  while (index > 0 && self.value < units[index].factor) index--
+  if (index < units.length - 1) {
+    const scale = BigInt(10) ** BigInt(precision)
+    const rounded = (self.value * scale * BigInt(2) + units[index].factor) / (units[index].factor * BigInt(2))
+    const base = options.system === "decimal" ? decimalBase : binaryBase
+    if (rounded >= base * scale) index++
+  }
+  return formatWithUnit(self.value, units[index], precision, trailingZeros)
+}
+
+/**
+ * Reducer that sums byte sizes from zero.
+ *
+ * @category math
+ * @since 4.0.0
+ */
+export const ReducerSum: Reducer.Reducer<ByteSize> = Reducer.make(sum, zero)
+
+/**
+ * Combiner that keeps the largest byte size.
+ *
+ * @category math
+ * @since 4.0.0
+ */
+export const CombinerMax: Combiner.Combiner<ByteSize> = Combiner.max(Order)
+
+/**
+ * Combiner that keeps the smallest byte size.
+ *
+ * @category math
+ * @since 4.0.0
+ */
+export const CombinerMin: Combiner.Combiner<ByteSize> = Combiner.min(Order)

--- a/packages/effect/src/Config.ts
+++ b/packages/effect/src/Config.ts
@@ -1360,6 +1360,21 @@ export function Duration(name?: string) {
 }
 
 /**
+ * Creates a config for an exact, human-readable byte-size value.
+ *
+ * **Details**
+ *
+ * Decimal symbols such as `kB` use powers of 1,000, while binary symbols such
+ * as `KiB` use powers of 1,024.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export function ByteSize(name?: string) {
+  return schema(Schema.ByteSizeFromString, name)
+}
+
+/**
  * Creates a config for a port number (integer in 1–65535).
  *
  * **When to use**

--- a/packages/effect/src/Config.ts
+++ b/packages/effect/src/Config.ts
@@ -1371,7 +1371,7 @@ export function Duration(name?: string) {
  * @since 4.0.0
  */
 export function ByteSize(name?: string) {
-  return schema(Schema.ByteSizeFromString, name)
+  return schema(Schema.ByteSize, name)
 }
 
 /**

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -12247,8 +12247,9 @@ export interface ByteSize extends declare<ByteSize_.ByteSize> {
  *
  * **Details**
  *
- * The JSON codec uses a bigint string, preserving values beyond JavaScript's
- * safe-integer range.
+ * The JSON codec encodes the byte count as a bigint string, preserving values
+ * beyond JavaScript's safe-integer range. The StringTree codec uses the
+ * human-readable byte-size syntax exposed by {@link ByteSizeFromString}.
  *
  * @category schemas
  * @since 4.0.0
@@ -12273,6 +12274,11 @@ export const ByteSize: ByteSize = declare(
           decode: ByteSize_.bytes,
           encode: ByteSize_.toBigInt
         })
+      ),
+    toCodecStringTree: () =>
+      link<ByteSize_.ByteSize>()(
+        ByteSizeString,
+        SchemaTransformation.byteSizeFromString
       )
   }
 )

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -16,6 +16,7 @@
 import * as Arr from "./Array.ts"
 import * as BigDecimal_ from "./BigDecimal.ts"
 import type * as Brand from "./Brand.ts"
+import * as ByteSize_ from "./ByteSize.ts"
 import * as Cause_ from "./Cause.ts"
 import * as Chunk_ from "./Chunk.ts"
 import * as Data from "./Data.ts"
@@ -12229,6 +12230,126 @@ export interface DurationFromMillis extends decodeTo<Duration, Number> {
  */
 export const DurationFromMillis: DurationFromMillis = Number.pipe(
   decodeTo(Duration, SchemaTransformation.durationFromMillis)
+)
+
+/**
+ * Type-level representation of {@link ByteSize}.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ByteSize extends declare<ByteSize_.ByteSize> {
+  readonly "Rebuild": ByteSize
+}
+
+/**
+ * Schema for exact, non-negative `ByteSize` values.
+ *
+ * **Details**
+ *
+ * The JSON codec uses `{ _id: "ByteSize", bytes: string }`, preserving values
+ * beyond JavaScript's safe-integer range.
+ *
+ * @category schemas
+ * @since 4.0.0
+ */
+export const ByteSize: ByteSize = declare(
+  ByteSize_.isByteSize,
+  {
+    representation: {
+      id: "effect/schema/ByteSize",
+      payload: null
+    },
+    toCode: () => ({
+      runtime: `Schema.ByteSize`,
+      Type: `ByteSize.ByteSize`,
+      importDeclarations: [`import * as ByteSize from "effect/ByteSize"`]
+    }),
+    expected: "ByteSize",
+    toCodecJson: () =>
+      link<ByteSize_.ByteSize>()(
+        Struct({ _id: Literal("ByteSize"), bytes: BigInt.check(isGreaterThanOrEqualToBigInt(globalThis.BigInt(0))) }),
+        SchemaTransformation.transform({
+          decode: (input) => ByteSize_.bytes(input.bytes),
+          encode: (byteSize) => ({ _id: "ByteSize", bytes: ByteSize_.toBytes(byteSize) } as const)
+        })
+      )
+  }
+)
+
+/**
+ * Reviver for persisted {@link ByteSize} declarations.
+ *
+ * @category schemas
+ * @since 4.0.0
+ */
+export const ByteSizeReviver = makeFixedDeclarationReviver(
+  "effect/schema/ByteSize",
+  ByteSize
+)
+
+const ByteSizeString = String.annotate({ expected: "a string that will be decoded as a ByteSize" })
+
+/**
+ * Type-level representation of {@link ByteSizeFromString}.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ByteSizeFromString extends decodeTo<ByteSize, String> {
+  readonly "Rebuild": ByteSizeFromString
+}
+
+/**
+ * Schema that decodes exact human-readable byte-size strings.
+ *
+ * @category schemas
+ * @since 4.0.0
+ */
+export const ByteSizeFromString: ByteSizeFromString = ByteSizeString.pipe(
+  decodeTo(ByteSize, SchemaTransformation.byteSizeFromString)
+)
+
+/**
+ * Type-level representation of {@link ByteSizeFromBigInt}.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ByteSizeFromBigInt extends decodeTo<ByteSize, BigInt> {
+  readonly "Rebuild": ByteSizeFromBigInt
+}
+
+/**
+ * Schema that decodes non-negative bigint byte counts.
+ *
+ * @category schemas
+ * @since 4.0.0
+ */
+export const ByteSizeFromBigInt: ByteSizeFromBigInt = BigInt.pipe(
+  decodeTo(ByteSize, SchemaTransformation.byteSizeFromBigInt)
+)
+
+/**
+ * Type-level representation of {@link ByteSizeFromNumber}.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ByteSizeFromNumber extends decodeTo<ByteSize, Number> {
+  readonly "Rebuild": ByteSizeFromNumber
+}
+
+/**
+ * Schema that decodes non-negative safe-integer byte counts.
+ *
+ * Encoding fails when the byte count exceeds `Number.MAX_SAFE_INTEGER`.
+ *
+ * @category schemas
+ * @since 4.0.0
+ */
+export const ByteSizeFromNumber: ByteSizeFromNumber = Number.pipe(
+  decodeTo(ByteSize, SchemaTransformation.byteSizeFromNumber)
 )
 
 /**

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -12271,7 +12271,7 @@ export const ByteSize: ByteSize = declare(
         Struct({ _id: Literal("ByteSize"), bytes: BigInt.check(isGreaterThanOrEqualToBigInt(globalThis.BigInt(0))) }),
         SchemaTransformation.transform({
           decode: (input) => ByteSize_.bytes(input.bytes),
-          encode: (byteSize) => ({ _id: "ByteSize", bytes: ByteSize_.toBytes(byteSize) } as const)
+          encode: (byteSize) => ({ _id: "ByteSize", bytes: ByteSize_.toBigInt(byteSize) } as const)
         })
       )
   }

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -12307,7 +12307,30 @@ export interface ByteSizeFromString extends decodeTo<ByteSize, String> {
 }
 
 /**
- * Schema that decodes exact human-readable byte-size strings.
+ * Schema that decodes byte-size strings into exact, non-negative `ByteSize`
+ * values.
+ *
+ * **Details**
+ *
+ * Decoding accepts an unsigned base-10 integer or decimal followed by optional
+ * whitespace and one of these case-sensitive units:
+ *
+ * - bytes: `B`, `byte`, or `bytes`
+ * - decimal SI units (powers of 1,000): `kB`, `MB`, `GB`, `TB`, `PB`, `EB`,
+ *   `ZB`, `YB`, `RB`, or `QB`, plus their lowercase singular and plural names
+ * - binary IEC units (powers of 1,024): `KiB`, `MiB`, `GiB`, `TiB`, `PiB`,
+ *   `EiB`, `ZiB`, or `YiB`, plus their lowercase singular and plural names
+ *
+ * Leading and trailing whitespace is ignored. A decimal quantity must resolve
+ * to an integral number of bytes, so `1.5 kB` is accepted while `0.1 KiB` is
+ * rejected.
+ *
+ * Encoding returns the exact byte count as `<count> byte` or `<count> bytes`.
+ *
+ * **Gotchas**
+ *
+ * A unit is required. Signs, exponent notation, digit separators, and ambiguous
+ * unit spellings such as `KB`, `mb`, `Mb`, or `b` are rejected.
  *
  * @category schemas
  * @since 4.0.0

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -12247,8 +12247,8 @@ export interface ByteSize extends declare<ByteSize_.ByteSize> {
  *
  * **Details**
  *
- * The JSON codec uses `{ _id: "ByteSize", bytes: string }`, preserving values
- * beyond JavaScript's safe-integer range.
+ * The JSON codec uses a bigint string, preserving values beyond JavaScript's
+ * safe-integer range.
  *
  * @category schemas
  * @since 4.0.0
@@ -12268,10 +12268,10 @@ export const ByteSize: ByteSize = declare(
     expected: "ByteSize",
     toCodecJson: () =>
       link<ByteSize_.ByteSize>()(
-        Struct({ _id: Literal("ByteSize"), bytes: BigInt.check(isGreaterThanOrEqualToBigInt(globalThis.BigInt(0))) }),
+        BigInt.check(isGreaterThanOrEqualToBigInt(globalThis.BigInt(0))),
         SchemaTransformation.transform({
-          decode: (input) => ByteSize_.bytes(input.bytes),
-          encode: (byteSize) => ({ _id: "ByteSize", bytes: ByteSize_.toBigInt(byteSize) } as const)
+          decode: ByteSize_.bytes,
+          encode: ByteSize_.toBigInt
         })
       )
   }

--- a/packages/effect/src/SchemaTransformation.ts
+++ b/packages/effect/src/SchemaTransformation.ts
@@ -13,6 +13,7 @@
  */
 
 import * as BigDecimal from "./BigDecimal.ts"
+import * as ByteSize from "./ByteSize.ts"
 import * as DateTime from "./DateTime.ts"
 import * as Duration from "./Duration.ts"
 import * as Effect from "./Effect.ts"
@@ -1069,6 +1070,83 @@ export const durationFromNanos: Transformation<Duration.Duration, bigint> = tran
 export const durationFromMillis: Transformation<Duration.Duration, number> = transform({
   decode: (i) => Duration.millis(i),
   encode: (a) => Duration.toMillis(a)
+})
+
+/**
+ * Decodes a string into a `ByteSize` and encodes it as an exact string.
+ *
+ * @category transforming
+ * @since 4.0.0
+ */
+export const byteSizeFromString: Transformation<ByteSize.ByteSize, string> = transformOrFail({
+  decode: (input, options) =>
+    Option.match(ByteSize.fromInput(input), {
+      onNone: () =>
+        Effect.fail(
+          new SchemaIssue.InvalidValue(
+            { expected: "a valid ByteSize string" },
+            input,
+            options
+          )
+        ),
+      onSome: Effect.succeed
+    }),
+  encode: (byteSize) => Effect.succeed(globalThis.String(byteSize))
+})
+
+/**
+ * Decodes a non-negative bigint byte count into a `ByteSize`.
+ *
+ * @category transforming
+ * @since 4.0.0
+ */
+export const byteSizeFromBigInt: Transformation<ByteSize.ByteSize, bigint> = transformOrFail({
+  decode: (input, options) =>
+    Option.match(ByteSize.fromInput(input), {
+      onNone: () =>
+        Effect.fail(
+          new SchemaIssue.InvalidValue(
+            { expected: "a non-negative bigint byte count" },
+            input,
+            options
+          )
+        ),
+      onSome: Effect.succeed
+    }),
+  encode: (byteSize) => Effect.succeed(ByteSize.toBytes(byteSize))
+})
+
+/**
+ * Decodes a non-negative safe-integer byte count into a `ByteSize`.
+ *
+ * @category transforming
+ * @since 4.0.0
+ */
+export const byteSizeFromNumber: Transformation<ByteSize.ByteSize, number> = transformOrFail({
+  decode: (input, options) =>
+    Option.match(ByteSize.fromInput(input), {
+      onNone: () =>
+        Effect.fail(
+          new SchemaIssue.InvalidValue(
+            { expected: "a non-negative safe-integer byte count" },
+            input,
+            options
+          )
+        ),
+      onSome: Effect.succeed
+    }),
+  encode: (byteSize, options) =>
+    Option.match(ByteSize.toNumber(byteSize), {
+      onNone: () =>
+        Effect.fail(
+          new SchemaIssue.InvalidValue(
+            { expected: "a ByteSize representable as a safe integer" },
+            byteSize,
+            options
+          )
+        ),
+      onSome: Effect.succeed
+    })
 })
 
 type JsonError = {

--- a/packages/effect/src/SchemaTransformation.ts
+++ b/packages/effect/src/SchemaTransformation.ts
@@ -1113,7 +1113,7 @@ export const byteSizeFromBigInt: Transformation<ByteSize.ByteSize, bigint> = tra
         ),
       onSome: Effect.succeed
     }),
-  encode: (byteSize) => Effect.succeed(ByteSize.toBytes(byteSize))
+  encode: (byteSize) => Effect.succeed(ByteSize.toBigInt(byteSize))
 })
 
 /**

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -59,6 +59,11 @@ export * as Brand from "./Brand.ts"
 /**
  * @since 4.0.0
  */
+export * as ByteSize from "./ByteSize.ts"
+
+/**
+ * @since 4.0.0
+ */
 export * as Cache from "./Cache.ts"
 
 /**

--- a/packages/effect/test/ByteSize.test.ts
+++ b/packages/effect/test/ByteSize.test.ts
@@ -8,7 +8,7 @@ import {
   strictEqual,
   throws
 } from "@effect/vitest/utils"
-import { ByteSize, Equal, Hash } from "effect"
+import { ByteSize, Equal, Hash, Option } from "effect"
 import * as fc from "fast-check"
 
 const arb = fc.bigInt({ min: 0n, max: 10n ** 40n }).map(ByteSize.bytes)
@@ -43,13 +43,10 @@ describe("ByteSize", () => {
     binary.forEach((constructor, index) => {
       strictEqual(ByteSize.toBytes(constructor(1n)), 1_024n ** BigInt(index + 1))
     })
-    assertFalse(ByteSize.equals(ByteSize.kilobytes(1), ByteSize.kibibytes(1)))
-    assertFalse(ByteSize.equals(ByteSize.megabytes(1), ByteSize.mebibytes(1)))
   })
 
   it("validates primitive and unit constructor inputs", () => {
     strictEqual(ByteSize.bytes(-0), ByteSize.zero)
-    strictEqual(ByteSize.bytes(0), ByteSize.zero)
     assertTrue(ByteSize.bytes(0n) === ByteSize.zero)
     for (const value of [-1, 0.5, Number.MAX_SAFE_INTEGER + 1, NaN, Infinity, -Infinity]) {
       throws(() => ByteSize.bytes(value))
@@ -118,14 +115,9 @@ describe("ByteSize", () => {
     const one = ByteSize.bytes(1)
     const two = ByteSize.bytes(2)
     const three = ByteSize.bytes(3)
-    assertTrue(ByteSize.between(two, { minimum: one, maximum: three }))
-    deepStrictEqual(ByteSize.min(one, two), one)
-    deepStrictEqual(ByteSize.max(one, two), two)
-    deepStrictEqual(ByteSize.clamp(three, { minimum: one, maximum: two }), two)
-    assertTrue(ByteSize.isLessThan(one, two))
-    assertTrue(ByteSize.isLessThanOrEqualTo(two, two))
-    assertTrue(ByteSize.isGreaterThan(two, one))
-    assertTrue(ByteSize.isGreaterThanOrEqualTo(two, two))
+    strictEqual(ByteSize.Order(one, two), -1)
+    strictEqual(ByteSize.Order(two, two), 0)
+    strictEqual(ByteSize.Order(two, one), 1)
     deepStrictEqual(ByteSize.sum(one, two), three)
     assertSome(ByteSize.subtract(three, one), two)
     assertNone(ByteSize.subtract(one, two))
@@ -153,33 +145,29 @@ describe("ByteSize", () => {
     throws(() => ByteSize.format(ByteSize.zero, { precision: 21 }))
   })
 
-  it("satisfies parsing, hash, ordering, addition, and division properties", () => {
+  it("roundtrips canonical strings", () => {
     fc.assert(fc.property(arb, (value) => {
       deepStrictEqual(ByteSize.fromInputUnsafe(String(value)), value)
-      strictEqual(Hash.hash(ByteSize.fromInputUnsafe(String(value))), Hash.hash(value))
-      strictEqual(ByteSize.Order(value, value), 0)
     }))
-    fc.assert(fc.property(arb, arb, arb, (a, b, c) => {
-      deepStrictEqual(ByteSize.sum(a, b), ByteSize.sum(b, a))
-      deepStrictEqual(ByteSize.sum(ByteSize.sum(a, b), c), ByteSize.sum(a, ByteSize.sum(b, c)))
-      deepStrictEqual(ByteSize.sum(a, ByteSize.zero), a)
+  })
+
+  it("preserves arithmetic invariants", () => {
+    fc.assert(fc.property(arb, arb, (a, b) => {
       if (ByteSize.isGreaterThanOrEqualTo(a, b)) {
         deepStrictEqual(ByteSize.sum(ByteSize.subtractUnsafe(a, b), b), a)
       } else {
         assertNone(ByteSize.subtract(a, b))
       }
-      if (ByteSize.Order(a, b) <= 0 && ByteSize.Order(b, c) <= 0) assertTrue(ByteSize.Order(a, c) <= 0)
     }))
     fc.assert(fc.property(arb, fc.bigInt({ min: 1n, max: 1_000n }), (value, divisor) => {
-      const quotient = ByteSize.divide(value, divisor).pipe((option) =>
-        option._tag === "Some" ? option.value : ByteSize.zero
-      )
-      const product = ByteSize.times(quotient, divisor).pipe((option) =>
-        option._tag === "Some" ? option.value : ByteSize.zero
-      )
+      const quotient = Option.getOrThrow(ByteSize.divide(value, divisor))
+      const product = Option.getOrThrow(ByteSize.times(quotient, divisor))
       assertTrue(ByteSize.isLessThanOrEqualTo(product, value))
       assertTrue(ByteSize.isLessThan(value, ByteSize.sum(product, ByteSize.bytes(divisor))))
     }))
+  })
+
+  it("is total for arbitrary strings", () => {
     fc.assert(fc.property(fc.string(), (input) => {
       ByteSize.fromInput(input)
     }))

--- a/packages/effect/test/ByteSize.test.ts
+++ b/packages/effect/test/ByteSize.test.ts
@@ -1,0 +1,187 @@
+import { describe, it } from "@effect/vitest"
+import {
+  assertFalse,
+  assertNone,
+  assertSome,
+  assertTrue,
+  deepStrictEqual,
+  strictEqual,
+  throws
+} from "@effect/vitest/utils"
+import { ByteSize, Equal, Hash } from "effect"
+import * as fc from "fast-check"
+
+const arb = fc.bigInt({ min: 0n, max: 10n ** 40n }).map(ByteSize.bytes)
+
+describe("ByteSize", () => {
+  it("constructs exact decimal and binary units", () => {
+    const decimal = [
+      ByteSize.kilobytes,
+      ByteSize.megabytes,
+      ByteSize.gigabytes,
+      ByteSize.terabytes,
+      ByteSize.petabytes,
+      ByteSize.exabytes,
+      ByteSize.zettabytes,
+      ByteSize.yottabytes,
+      ByteSize.ronnabytes,
+      ByteSize.quettabytes
+    ]
+    const binary = [
+      ByteSize.kibibytes,
+      ByteSize.mebibytes,
+      ByteSize.gibibytes,
+      ByteSize.tebibytes,
+      ByteSize.pebibytes,
+      ByteSize.exbibytes,
+      ByteSize.zebibytes,
+      ByteSize.yobibytes
+    ]
+    decimal.forEach((constructor, index) => {
+      strictEqual(ByteSize.toBytes(constructor(1n)), 1_000n ** BigInt(index + 1))
+    })
+    binary.forEach((constructor, index) => {
+      strictEqual(ByteSize.toBytes(constructor(1n)), 1_024n ** BigInt(index + 1))
+    })
+    assertFalse(ByteSize.equals(ByteSize.kilobytes(1), ByteSize.kibibytes(1)))
+    assertFalse(ByteSize.equals(ByteSize.megabytes(1), ByteSize.mebibytes(1)))
+  })
+
+  it("validates primitive and unit constructor inputs", () => {
+    strictEqual(ByteSize.bytes(-0), ByteSize.zero)
+    strictEqual(ByteSize.bytes(0), ByteSize.zero)
+    assertTrue(ByteSize.bytes(0n) === ByteSize.zero)
+    for (const value of [-1, 0.5, Number.MAX_SAFE_INTEGER + 1, NaN, Infinity, -Infinity]) {
+      throws(() => ByteSize.bytes(value))
+    }
+    throws(() => ByteSize.bytes(-1n))
+    deepStrictEqual(ByteSize.kilobytes(1.5), ByteSize.bytes(1500))
+    deepStrictEqual(ByteSize.kibibytes(0.5), ByteSize.bytes(512))
+    throws(() => ByteSize.kibibytes(0.1))
+  })
+
+  it("parses strict SI and IEC strings exactly", () => {
+    const cases: ReadonlyArray<readonly [string, bigint]> = [
+      ["0 B", 0n],
+      ["1 byte", 1n],
+      ["1500 bytes", 1500n],
+      ["1.5 kB", 1500n],
+      ["1.5KiB", 1536n],
+      ["0.001 kB", 1n],
+      ["2 megabytes", 2_000_000n],
+      ["2 mebibytes", 2_097_152n],
+      ["  9007199254740993 B  ", 9_007_199_254_740_993n]
+    ]
+    for (const [input, expected] of cases) {
+      deepStrictEqual(ByteSize.fromInputUnsafe(input), ByteSize.bytes(expected))
+    }
+  })
+
+  it("rejects ambiguous, negative, and fractional-byte strings", () => {
+    const invalid = [
+      "",
+      "1",
+      "+1 B",
+      "-1 B",
+      "1e3 B",
+      "1_000 B",
+      "0.5 B",
+      "0.1 KiB",
+      "1 KB",
+      "1 mb",
+      "1 Mb",
+      "1 K",
+      "1 b",
+      "1 MiB trailing"
+    ]
+    for (const input of invalid) assertNone(ByteSize.fromInput(input))
+  })
+
+  it("has exact canonical serialization and value behavior", () => {
+    const value = ByteSize.bytes(9_007_199_254_740_993n)
+    strictEqual(String(value), "9007199254740993 bytes")
+    deepStrictEqual(value.toJSON(), { _id: "ByteSize", bytes: "9007199254740993" })
+    assertTrue(Equal.equals(value, ByteSize.fromInputUnsafe(String(value))))
+    strictEqual(Hash.hash(value), Hash.hash(ByteSize.bytes(value.value)))
+    assertTrue(ByteSize.isByteSize(value))
+    assertFalse(ByteSize.isByteSize(value.value))
+  })
+
+  it("converts to numbers only within the safe-integer range", () => {
+    assertSome(ByteSize.toNumber(ByteSize.bytes(BigInt(Number.MAX_SAFE_INTEGER))), Number.MAX_SAFE_INTEGER)
+    assertNone(ByteSize.toNumber(ByteSize.bytes(BigInt(Number.MAX_SAFE_INTEGER) + 1n)))
+    throws(() => ByteSize.toNumberUnsafe(ByteSize.bytes(BigInt(Number.MAX_SAFE_INTEGER) + 1n)))
+    strictEqual(ByteSize.toUnit(ByteSize.kibibytes(3), "KiB"), 3)
+  })
+
+  it("supports ordering and checked arithmetic", () => {
+    const one = ByteSize.bytes(1)
+    const two = ByteSize.bytes(2)
+    const three = ByteSize.bytes(3)
+    assertTrue(ByteSize.between(two, { minimum: one, maximum: three }))
+    deepStrictEqual(ByteSize.min(one, two), one)
+    deepStrictEqual(ByteSize.max(one, two), two)
+    deepStrictEqual(ByteSize.clamp(three, { minimum: one, maximum: two }), two)
+    assertTrue(ByteSize.isLessThan(one, two))
+    assertTrue(ByteSize.isLessThanOrEqualTo(two, two))
+    assertTrue(ByteSize.isGreaterThan(two, one))
+    assertTrue(ByteSize.isGreaterThanOrEqualTo(two, two))
+    deepStrictEqual(ByteSize.sum(one, two), three)
+    assertSome(ByteSize.subtract(three, one), two)
+    assertNone(ByteSize.subtract(one, two))
+    throws(() => ByteSize.subtractUnsafe(one, two))
+    assertSome(ByteSize.times(three, 2), ByteSize.bytes(6))
+    assertNone(ByteSize.times(three, -1))
+    assertNone(ByteSize.times(three, 0.5))
+    assertSome(ByteSize.divide(ByteSize.bytes(7), 2), three)
+    assertNone(ByteSize.divide(three, 0))
+    assertNone(ByteSize.divide(three, 0.5))
+    deepStrictEqual(ByteSize.ReducerSum.combineAll([one, two]), three)
+    deepStrictEqual(ByteSize.ReducerSum.combineAll([]), ByteSize.zero)
+    deepStrictEqual(ByteSize.CombinerMin.combine(one, two), one)
+    deepStrictEqual(ByteSize.CombinerMax.combine(one, two), two)
+  })
+
+  it("formats without losing the represented value", () => {
+    strictEqual(ByteSize.format(ByteSize.bytes(0)), "0 B")
+    strictEqual(ByteSize.format(ByteSize.bytes(1536)), "1.5 KiB")
+    strictEqual(ByteSize.format(ByteSize.bytes(1536), { system: "decimal" }), "1.54 kB")
+    strictEqual(ByteSize.format(ByteSize.bytes(1500), { unit: "kB", precision: 3, trailingZeros: true }), "1.500 kB")
+    strictEqual(ByteSize.format(ByteSize.mebibytes(1)), "1 MiB")
+    strictEqual(ByteSize.format(ByteSize.mebibytes(1).pipe(ByteSize.subtractUnsafe(ByteSize.bytes(1)))), "1 MiB")
+    strictEqual(ByteSize.format(ByteSize.bytes(10n ** 35n), { system: "decimal" }), "100000 QB")
+    throws(() => ByteSize.format(ByteSize.zero, { precision: 21 }))
+  })
+
+  it("satisfies parsing, hash, ordering, addition, and division properties", () => {
+    fc.assert(fc.property(arb, (value) => {
+      deepStrictEqual(ByteSize.fromInputUnsafe(String(value)), value)
+      strictEqual(Hash.hash(ByteSize.fromInputUnsafe(String(value))), Hash.hash(value))
+      strictEqual(ByteSize.Order(value, value), 0)
+    }))
+    fc.assert(fc.property(arb, arb, arb, (a, b, c) => {
+      deepStrictEqual(ByteSize.sum(a, b), ByteSize.sum(b, a))
+      deepStrictEqual(ByteSize.sum(ByteSize.sum(a, b), c), ByteSize.sum(a, ByteSize.sum(b, c)))
+      deepStrictEqual(ByteSize.sum(a, ByteSize.zero), a)
+      if (ByteSize.isGreaterThanOrEqualTo(a, b)) {
+        deepStrictEqual(ByteSize.sum(ByteSize.subtractUnsafe(a, b), b), a)
+      } else {
+        assertNone(ByteSize.subtract(a, b))
+      }
+      if (ByteSize.Order(a, b) <= 0 && ByteSize.Order(b, c) <= 0) assertTrue(ByteSize.Order(a, c) <= 0)
+    }))
+    fc.assert(fc.property(arb, fc.bigInt({ min: 1n, max: 1_000n }), (value, divisor) => {
+      const quotient = ByteSize.divide(value, divisor).pipe((option) =>
+        option._tag === "Some" ? option.value : ByteSize.zero
+      )
+      const product = ByteSize.times(quotient, divisor).pipe((option) =>
+        option._tag === "Some" ? option.value : ByteSize.zero
+      )
+      assertTrue(ByteSize.isLessThanOrEqualTo(product, value))
+      assertTrue(ByteSize.isLessThan(value, ByteSize.sum(product, ByteSize.bytes(divisor))))
+    }))
+    fc.assert(fc.property(fc.string(), (input) => {
+      ByteSize.fromInput(input)
+    }))
+  })
+})

--- a/packages/effect/test/ByteSize.test.ts
+++ b/packages/effect/test/ByteSize.test.ts
@@ -38,16 +38,16 @@ describe("ByteSize", () => {
       ByteSize.yobibytes
     ]
     decimal.forEach((constructor, index) => {
-      strictEqual(ByteSize.toBytes(constructor(1n)), 1_000n ** BigInt(index + 1))
+      strictEqual(ByteSize.toBigInt(constructor(1n)), 1_000n ** BigInt(index + 1))
     })
     binary.forEach((constructor, index) => {
-      strictEqual(ByteSize.toBytes(constructor(1n)), 1_024n ** BigInt(index + 1))
+      strictEqual(ByteSize.toBigInt(constructor(1n)), 1_024n ** BigInt(index + 1))
     })
   })
 
   it("validates primitive and unit constructor inputs", () => {
-    strictEqual(ByteSize.bytes(-0), ByteSize.zero)
-    assertTrue(ByteSize.bytes(0n) === ByteSize.zero)
+    deepStrictEqual(ByteSize.bytes(-0), ByteSize.zero)
+    deepStrictEqual(ByteSize.bytes(0n), ByteSize.zero)
     for (const value of [-1, 0.5, Number.MAX_SAFE_INTEGER + 1, NaN, Infinity, -Infinity]) {
       throws(() => ByteSize.bytes(value))
     }

--- a/packages/effect/test/Config.test.ts
+++ b/packages/effect/test/Config.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import {
+  ByteSize,
   Config,
   ConfigProvider,
   Duration,
@@ -1244,6 +1245,30 @@ Expected "Infinity" | "-Infinity" | "NaN"
           `Expected a valid Duration string
   at ["failure"]`
         )
+      })
+
+      it("decodes exact decimal and binary byte sizes", async () => {
+        const provider = ConfigProvider.fromUnknown({
+          binary: "10 MiB",
+          decimal: "10 MB",
+          fractional: "1.5 kB",
+          huge: "9007199254740993 B",
+          ambiguous: "10 MBi",
+          negative: "-1 B",
+          fractionalByte: "0.1 KiB"
+        })
+
+        await assertSuccess(Config.ByteSize("binary"), provider, ByteSize.mebibytes(10))
+        await assertSuccess(Config.ByteSize("decimal"), provider, ByteSize.megabytes(10))
+        await assertSuccess(Config.ByteSize("fractional"), provider, ByteSize.bytes(1500))
+        await assertSuccess(Config.ByteSize("huge"), provider, ByteSize.bytes(9_007_199_254_740_993n))
+        for (const name of ["ambiguous", "negative", "fractionalByte"]) {
+          await assertFailure(
+            Config.ByteSize(name),
+            provider,
+            `Expected a valid ByteSize string\n  at ["${name}"]`
+          )
+        }
       })
 
       it("validates port ranges", async () => {

--- a/packages/effect/test/Config.test.ts
+++ b/packages/effect/test/Config.test.ts
@@ -1247,28 +1247,18 @@ Expected "Infinity" | "-Infinity" | "NaN"
         )
       })
 
-      it("decodes exact decimal and binary byte sizes", async () => {
+      it("decodes exact byte sizes and reports invalid input", async () => {
         const provider = ConfigProvider.fromUnknown({
-          binary: "10 MiB",
-          decimal: "10 MB",
-          fractional: "1.5 kB",
           huge: "9007199254740993 B",
-          ambiguous: "10 MBi",
-          negative: "-1 B",
-          fractionalByte: "0.1 KiB"
+          invalid: "10 MBi"
         })
 
-        await assertSuccess(Config.ByteSize("binary"), provider, ByteSize.mebibytes(10))
-        await assertSuccess(Config.ByteSize("decimal"), provider, ByteSize.megabytes(10))
-        await assertSuccess(Config.ByteSize("fractional"), provider, ByteSize.bytes(1500))
         await assertSuccess(Config.ByteSize("huge"), provider, ByteSize.bytes(9_007_199_254_740_993n))
-        for (const name of ["ambiguous", "negative", "fractionalByte"]) {
-          await assertFailure(
-            Config.ByteSize(name),
-            provider,
-            `Expected a valid ByteSize string\n  at ["${name}"]`
-          )
-        }
+        await assertFailure(
+          Config.ByteSize("invalid"),
+          provider,
+          `Expected a valid ByteSize string\n  at ["invalid"]`
+        )
       })
 
       it("validates port ranges", async () => {

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "@effect/vitest"
 import {
   BigDecimal,
   Brand,
+  ByteSize,
   Cause,
   Chunk,
   Context,
@@ -5552,6 +5553,50 @@ Expected a value between -2147483648 and 2147483647`
     await encoding.succeed(Duration.millis(5000), 5000)
     await encoding.succeed(Duration.millis(0.1), 0.1)
     await encoding.succeed(Duration.nanos(5000n), 0.005)
+  })
+
+  it("ByteSize", async () => {
+    const asserts = new TestSchema.Asserts(Schema.ByteSize)
+    if (verifyGeneration) asserts.arbitrary().verifyGeneration()
+
+    const json = new TestSchema.Asserts(Schema.toCodecJson(Schema.ByteSize))
+    await json.decoding().succeed(
+      { _id: "ByteSize", bytes: "9007199254740993" },
+      ByteSize.bytes(9_007_199_254_740_993n)
+    )
+    await json.encoding().succeed(
+      ByteSize.bytes(9_007_199_254_740_993n),
+      { _id: "ByteSize", bytes: "9007199254740993" }
+    )
+  })
+
+  it("ByteSizeFromString", async () => {
+    const asserts = new TestSchema.Asserts(Schema.ByteSizeFromString)
+    await asserts.decoding().succeed("10 MiB", ByteSize.mebibytes(10))
+    await asserts.decoding().succeed("1.5 kB", ByteSize.bytes(1500))
+    await asserts.decoding().fail("1 KB", "Expected a valid ByteSize string")
+    await asserts.encoding().succeed(ByteSize.bytes(1500), "1500 bytes")
+  })
+
+  it("ByteSizeFromBigInt", async () => {
+    const asserts = new TestSchema.Asserts(Schema.ByteSizeFromBigInt)
+    if (verifyGeneration) asserts.arbitrary().verifyGeneration()
+    await asserts.decoding().succeed(9_007_199_254_740_993n, ByteSize.bytes(9_007_199_254_740_993n))
+    await asserts.decoding().fail(-1n, "Expected a non-negative bigint byte count")
+    await asserts.encoding().succeed(ByteSize.bytes(9_007_199_254_740_993n), 9_007_199_254_740_993n)
+  })
+
+  it("ByteSizeFromNumber", async () => {
+    const asserts = new TestSchema.Asserts(Schema.ByteSizeFromNumber)
+    await asserts.decoding().succeed(Number.MAX_SAFE_INTEGER, ByteSize.bytes(Number.MAX_SAFE_INTEGER))
+    await asserts.decoding().fail(-1, "Expected a non-negative safe-integer byte count")
+    await asserts.decoding().fail(0.5, "Expected a non-negative safe-integer byte count")
+    await asserts.decoding().fail(Number.MAX_SAFE_INTEGER + 1, "Expected a non-negative safe-integer byte count")
+    await asserts.encoding().succeed(ByteSize.bytes(1500), 1500)
+    await asserts.encoding().fail(
+      ByteSize.bytes(BigInt(Number.MAX_SAFE_INTEGER) + 1n),
+      "Expected a ByteSize representable as a safe integer"
+    )
   })
 
   it("BigDecimal", async () => {

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -5560,14 +5560,8 @@ Expected a value between -2147483648 and 2147483647`
     if (verifyGeneration) asserts.arbitrary().verifyGeneration()
 
     const json = new TestSchema.Asserts(Schema.toCodecJson(Schema.ByteSize))
-    await json.decoding().succeed(
-      { _id: "ByteSize", bytes: "9007199254740993" },
-      ByteSize.bytes(9_007_199_254_740_993n)
-    )
-    await json.encoding().succeed(
-      ByteSize.bytes(9_007_199_254_740_993n),
-      { _id: "ByteSize", bytes: "9007199254740993" }
-    )
+    await json.decoding().succeed("9007199254740993", ByteSize.bytes(9_007_199_254_740_993n))
+    await json.encoding().succeed(ByteSize.bytes(9_007_199_254_740_993n), "9007199254740993")
   })
 
   it("ByteSizeFromString", async () => {

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -5572,7 +5572,6 @@ Expected a value between -2147483648 and 2147483647`
 
   it("ByteSizeFromString", async () => {
     const asserts = new TestSchema.Asserts(Schema.ByteSizeFromString)
-    await asserts.decoding().succeed("10 MiB", ByteSize.mebibytes(10))
     await asserts.decoding().succeed("1.5 kB", ByteSize.bytes(1500))
     await asserts.decoding().fail("1 KB", "Expected a valid ByteSize string")
     await asserts.encoding().succeed(ByteSize.bytes(1500), "1500 bytes")

--- a/packages/effect/test/schema/representation/builtInRevivers.test.ts
+++ b/packages/effect/test/schema/representation/builtInRevivers.test.ts
@@ -930,6 +930,15 @@ describe("SchemaRepresentation built-in declaration revivers", () => {
     })
   })
 
+  it("revives ByteSize", () => {
+    assertDeclarationReviver({
+      schema: Schema.ByteSize,
+      id: "effect/schema/ByteSize",
+      payload: null,
+      reviver: Schema.ByteSizeReviver
+    })
+  })
+
   it("revives BigDecimal", () => {
     assertDeclarationReviver({
       schema: Schema.BigDecimal,

--- a/packages/effect/typetest/ByteSize.tst.ts
+++ b/packages/effect/typetest/ByteSize.tst.ts
@@ -4,6 +4,24 @@ import { describe, expect, it } from "tstyche"
 declare const value: ByteSizeType.ByteSize
 
 describe("ByteSize", () => {
+  it("distinguishes decimal and binary units", () => {
+    expect("B").type.toBeAssignableTo<ByteSizeType.DecimalUnit>()
+    expect("B").type.toBeAssignableTo<ByteSizeType.BinaryUnit>()
+    expect("kB").type.toBeAssignableTo<ByteSizeType.DecimalUnit>()
+    expect("kB").type.not.toBeAssignableTo<ByteSizeType.BinaryUnit>()
+    expect("KiB").type.toBeAssignableTo<ByteSizeType.BinaryUnit>()
+    expect("KiB").type.not.toBeAssignableTo<ByteSizeType.DecimalUnit>()
+  })
+
+  it("requires the format unit to match the system", () => {
+    expect({ system: "decimal", unit: "kB" } as const).type.toBeAssignableTo<ByteSizeType.FormatOptions>()
+    expect({ system: "binary", unit: "KiB" } as const).type.toBeAssignableTo<ByteSizeType.FormatOptions>()
+    expect({ unit: "kB" } as const).type.toBeAssignableTo<ByteSizeType.FormatOptions>()
+    expect({ unit: "KiB" } as const).type.toBeAssignableTo<ByteSizeType.FormatOptions>()
+    expect({ system: "decimal", unit: "KiB" } as const).type.not.toBeAssignableTo<ByteSizeType.FormatOptions>()
+    expect({ system: "binary", unit: "kB" } as const).type.not.toBeAssignableTo<ByteSizeType.FormatOptions>()
+  })
+
   it("infers data-last arithmetic", () => {
     expect(ByteSize.sum(value)(value)).type.toBe<ByteSizeType.ByteSize>()
     expect(ByteSize.times(2)(value)).type.toBe<Option.Option<ByteSizeType.ByteSize>>()

--- a/packages/effect/typetest/ByteSize.tst.ts
+++ b/packages/effect/typetest/ByteSize.tst.ts
@@ -4,17 +4,8 @@ import { describe, expect, it } from "tstyche"
 declare const value: ByteSizeType.ByteSize
 
 describe("ByteSize", () => {
-  it("has exact constructor and conversion types", () => {
-    expect(ByteSize.bytes(1n)).type.toBe<ByteSizeType.ByteSize>()
-    expect(ByteSize.fromInput("1 MiB")).type.toBe<Option.Option<ByteSizeType.ByteSize>>()
-    expect(ByteSize.toBytes(value)).type.toBe<bigint>()
-    expect(ByteSize.toNumber(value)).type.toBe<Option.Option<number>>()
-  })
-
-  it("supports data-first and data-last arithmetic", () => {
-    expect(ByteSize.sum(value, value)).type.toBe<ByteSizeType.ByteSize>()
+  it("infers data-last arithmetic", () => {
     expect(ByteSize.sum(value)(value)).type.toBe<ByteSizeType.ByteSize>()
-    expect(ByteSize.subtract(value, value)).type.toBe<Option.Option<ByteSizeType.ByteSize>>()
     expect(ByteSize.times(2)(value)).type.toBe<Option.Option<ByteSizeType.ByteSize>>()
   })
 

--- a/packages/effect/typetest/ByteSize.tst.ts
+++ b/packages/effect/typetest/ByteSize.tst.ts
@@ -1,0 +1,26 @@
+import { ByteSize, type ByteSize as ByteSizeType, type Config, type Option, type Schema } from "effect"
+import { describe, expect, it } from "tstyche"
+
+declare const value: ByteSizeType.ByteSize
+
+describe("ByteSize", () => {
+  it("has exact constructor and conversion types", () => {
+    expect(ByteSize.bytes(1n)).type.toBe<ByteSizeType.ByteSize>()
+    expect(ByteSize.fromInput("1 MiB")).type.toBe<Option.Option<ByteSizeType.ByteSize>>()
+    expect(ByteSize.toBytes(value)).type.toBe<bigint>()
+    expect(ByteSize.toNumber(value)).type.toBe<Option.Option<number>>()
+  })
+
+  it("supports data-first and data-last arithmetic", () => {
+    expect(ByteSize.sum(value, value)).type.toBe<ByteSizeType.ByteSize>()
+    expect(ByteSize.sum(value)(value)).type.toBe<ByteSizeType.ByteSize>()
+    expect(ByteSize.subtract(value, value)).type.toBe<Option.Option<ByteSizeType.ByteSize>>()
+    expect(ByteSize.times(2)(value)).type.toBe<Option.Option<ByteSizeType.ByteSize>>()
+  })
+
+  it("integrates with Schema and Config", () => {
+    expect<Schema.Schema.Type<typeof Schema.ByteSize>>().type.toBe<ByteSizeType.ByteSize>()
+    expect<Schema.Codec.Encoded<typeof Schema.ByteSizeFromString>>().type.toBe<string>()
+    expect<ReturnType<typeof Config.ByteSize>>().type.toBe<Config.Config<ByteSizeType.ByteSize>>()
+  })
+})


### PR DESCRIPTION
## Summary

- add an exact, non-negative, bigint-backed `ByteSize` value module with SI and IEC units, parsing, formatting, checked arithmetic, ordering, and safe number conversion
- add `Schema.ByteSize`, string/bigint/number transformations, JSON revival support, and `Config.ByteSize`
- add runtime and type tests, the implementation plan, and a patch changeset

## Testing

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/ByteSize.test.ts packages/effect/test/Config.test.ts packages/effect/test/schema/Schema.test.ts packages/effect/test/schema/representation/builtInRevivers.test.ts`
- `pnpm test-types ByteSize.tst.ts`
- `pnpm check`