### PR TITLE
Fix NodeTerminal.readLine not echo input

### DIFF
--- a/packages/platform/node-shared/src/NodeTerminal.ts
+++ b/packages/platform/node-shared/src/NodeTerminal.ts
@@ -53,7 +53,7 @@ export const make: (
     const rlRef = yield* RcRef.make({
       acquire: Effect.acquireRelease(
         Effect.sync(() => {
-          const rl = readline.createInterface({ input: stdin, escapeCodeTimeout: 50 })
+          const rl = readline.createInterface({ input: stdin, output: stdout, escapeCodeTimeout: 50 })
           const onLine = (line: string) => Queue.offerUnsafe(lines, line)
           const onClose = () => {
             readlineActive = false


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`NodeTerminal` created its `readline` interface without an `output` stream, so `terminal` resolved to `input.isTTY && output.isTTY` = `false` even on a real TTY.

## Related

- Related Issue https://github.com/Effect-TS/effect/issues/7529
