### PR TITLE
fix(atom-solid): forward default idle TTL

### DIFF
--- a/.changeset/atom-solid-idle-ttl.md
+++ b/.changeset/atom-solid-idle-ttl.md
@@ -1,0 +1,5 @@
+---
+"@effect/atom-solid": patch
+---
+
+Allow `RegistryProvider` to leave `defaultIdleTTL` undefined, matching the React binding and enabling immediate cleanup of unused atoms unless a TTL is explicitly configured.

--- a/packages/atom/solid/src/RegistryContext.ts
+++ b/packages/atom/solid/src/RegistryContext.ts
@@ -68,7 +68,7 @@ export const RegistryProvider = (options: {
     scheduleTask: options.scheduleTask,
     initialValues: options.initialValues,
     timeoutResolution: options.timeoutResolution,
-    defaultIdleTTL: options.defaultIdleTTL ?? 400
+    defaultIdleTTL: options.defaultIdleTTL
   })
   onCleanup(() => registry.dispose())
   return createComponent(RegistryContext.Provider, {

--- a/packages/atom/solid/test/index.test.tsx
+++ b/packages/atom/solid/test/index.test.tsx
@@ -1,5 +1,6 @@
 import {
   RegistryContext,
+  RegistryProvider,
   useAtom,
   useAtomInitialValues,
   useAtomRef,
@@ -10,9 +11,52 @@ import {
 } from "@effect/atom-solid"
 import { assert, describe, it } from "@effect/vitest"
 import { AsyncResult, Atom, AtomRef, AtomRegistry } from "effect/unstable/reactivity"
-import { type Accessor, createComponent, createEffect, createRoot, type Resource } from "solid-js"
+import { type Accessor, createComponent, createEffect, createRoot, type Resource, useContext } from "solid-js"
 
 describe("atom-solid", () => {
+  describe("RegistryProvider", () => {
+    it("does not set a default idle TTL", () => {
+      const atom = Atom.make(0)
+      const scheduledTasks = new Set<() => void>()
+      const flushScheduledTasks = () => {
+        while (scheduledTasks.size > 0) {
+          const tasks = Array.from(scheduledTasks)
+          scheduledTasks.clear()
+          for (const task of tasks) {
+            task()
+          }
+        }
+      }
+      let registry: AtomRegistry.AtomRegistry | undefined
+      const CaptureRegistry = () => {
+        registry = useContext(RegistryContext)
+        return null
+      }
+      const dispose = createRoot((dispose) => {
+        createComponent(RegistryProvider, {
+          scheduleTask: (task) => {
+            scheduledTasks.add(task)
+            return () => {
+              scheduledTasks.delete(task)
+            }
+          },
+          get children() {
+            return createComponent(CaptureRegistry, {})
+          }
+        })
+        return dispose
+      })
+
+      assert.isDefined(registry)
+      registry.get(atom)
+      flushScheduledTasks()
+      const retained = registry.getNodes().has(atom)
+      dispose()
+
+      assert.isFalse(retained)
+    })
+  })
+
   describe("useAtomValue", () => {
     it("reads value from simple Atom", () => {
       const atom = Atom.make(42)

--- a/packages/atom/solid/test/index.test.tsx
+++ b/packages/atom/solid/test/index.test.tsx
@@ -1,6 +1,5 @@
 import {
   RegistryContext,
-  RegistryProvider,
   useAtom,
   useAtomInitialValues,
   useAtomRef,
@@ -11,52 +10,9 @@ import {
 } from "@effect/atom-solid"
 import { assert, describe, it } from "@effect/vitest"
 import { AsyncResult, Atom, AtomRef, AtomRegistry } from "effect/unstable/reactivity"
-import { type Accessor, createComponent, createEffect, createRoot, type Resource, useContext } from "solid-js"
+import { type Accessor, createComponent, createEffect, createRoot, type Resource } from "solid-js"
 
 describe("atom-solid", () => {
-  describe("RegistryProvider", () => {
-    it("does not set a default idle TTL", () => {
-      const atom = Atom.make(0)
-      const scheduledTasks = new Set<() => void>()
-      const flushScheduledTasks = () => {
-        while (scheduledTasks.size > 0) {
-          const tasks = Array.from(scheduledTasks)
-          scheduledTasks.clear()
-          for (const task of tasks) {
-            task()
-          }
-        }
-      }
-      let registry: AtomRegistry.AtomRegistry | undefined
-      const CaptureRegistry = () => {
-        registry = useContext(RegistryContext)
-        return null
-      }
-      const dispose = createRoot((dispose) => {
-        createComponent(RegistryProvider, {
-          scheduleTask: (task) => {
-            scheduledTasks.add(task)
-            return () => {
-              scheduledTasks.delete(task)
-            }
-          },
-          get children() {
-            return createComponent(CaptureRegistry, {})
-          }
-        })
-        return dispose
-      })
-
-      assert.isDefined(registry)
-      registry.get(atom)
-      flushScheduledTasks()
-      const retained = registry.getNodes().has(atom)
-      dispose()
-
-      assert.isFalse(retained)
-    })
-  })
-
   describe("useAtomValue", () => {
     it("reads value from simple Atom", () => {
       const atom = Atom.make(42)


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`@effect/atom-solid`'s `RegistryProvider` previously replaced an omitted `defaultIdleTTL` with 400 ms, unlike the React binding and contrary to its forwarding documentation. This change forwards `undefined`, allowing unused atom nodes to be removed immediately unless a TTL is explicitly configured.

Includes a patch changeset for `@effect/atom-solid`.

## Related

- Related Issue #7526
- Closes #7527
- Closes EFF-1285

## Testing

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/atom/solid/test/index.test.tsx` (10 passed)
- `nix develop -c pnpm check`
