### PR TITLE
Fix Atom idleTTL cleanup for stale derived nodes

### DIFF
--- a/packages/effect/src/unstable/reactivity/AtomRegistry.ts
+++ b/packages/effect/src/unstable/reactivity/AtomRegistry.ts
@@ -793,11 +793,9 @@ class NodeImpl<A> {
     this.state = NodeState.removed
     this.listeners.clear()
 
-    if (this.lifetime === undefined) {
-      return
+    if (this.lifetime !== undefined) {
+      this.disposeLifetime()
     }
-
-    this.disposeLifetime()
 
     if (this.previousParents === undefined) {
       return

--- a/packages/effect/test/reactivity/Atom.test.ts
+++ b/packages/effect/test/reactivity/Atom.test.ts
@@ -8,6 +8,7 @@ import {
   Latch,
   Layer,
   Option,
+  Queue,
   Result,
   Schema,
   Stream,
@@ -1145,6 +1146,35 @@ describe.sequential("Atom", () => {
     expect(r.get(state)).toEqual(0)
     expect(r.get(state2)).toEqual(0)
     expect(r.get(state3)).toEqual(0)
+  })
+
+  it("releases a stream-backed atom consumed through a derived atom after idleTTL", async () => {
+    let released = false
+    const source = Stream.callback<number>((queue) =>
+      Effect.acquireRelease(
+        Effect.sync(() => setInterval(() => Queue.offerUnsafe(queue, Date.now()), 100)),
+        (handle) =>
+          Effect.sync(() => {
+            released = true
+            clearInterval(handle)
+          })
+      ).pipe(Effect.asVoid)
+    )
+    const feed = Atom.make(() => source)
+    const derived = Atom.make((get) => AsyncResult.isSuccess(get(feed)) ? "ready" : "initial")
+    const r = AtomRegistry.make({ defaultIdleTTL: 400 })
+
+    try {
+      const unsubscribe = r.subscribe(derived, () => {}, { immediate: true })
+      await vitest.advanceTimersByTimeAsync(600)
+      unsubscribe()
+
+      await vitest.advanceTimersByTimeAsync(2000)
+
+      expect(released).toEqual(true)
+    } finally {
+      r.dispose()
+    }
   })
 
   it("idleTTL fn", async () => {


### PR DESCRIPTION
## Summary

- clean up parent dependencies when a stale derived atom is removed after its lifetime was already disposed
- add regression coverage for a stream resource emitting more frequently than the registry's `idleTTL`

## Testing

- `nix develop -c pnpm test --run packages/effect/test/reactivity/Atom.test.ts`
- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`

Closes EFF-971
Closes #7526
