### PR TITLE
Fix Content-Length parsing

### DIFF
--- a/.changeset/strict-content-length.md
+++ b/.changeset/strict-content-length.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Parse `Content-Length` metadata strictly across HTTP request conversions, ignoring malformed or unsafe values instead of coercing numeric prefixes.
+Parse `Content-Length` metadata strictly across HTTP modules, ignoring malformed or unsafe values instead of coercing them.

--- a/.changeset/strict-content-length.md
+++ b/.changeset/strict-content-length.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Parse `Content-Length` metadata strictly across HTTP request conversions, ignoring malformed or unsafe values instead of coercing numeric prefixes.

--- a/packages/effect/src/unstable/http/HttpClientRequest.ts
+++ b/packages/effect/src/unstable/http/HttpClientRequest.ts
@@ -906,19 +906,8 @@ const fromWebBody = (request: globalThis.Request, method: HttpMethod): HttpBody.
   }
   return HttpBody.raw(request.body, {
     contentType: request.headers.get("content-type") ?? undefined,
-    contentLength: parseContentLength(request.headers.get("content-length"))
+    contentLength: bodyInternal.parseContentLength(request.headers.get("content-length"))
   })
-}
-
-const parseContentLength = (contentLength: string | null): number | undefined => {
-  if (contentLength === null) {
-    return undefined
-  }
-  if (!/^\d+$/.test(contentLength)) {
-    return undefined
-  }
-  const parsed = Number(contentLength)
-  return Number.isSafeInteger(parsed) ? parsed : undefined
 }
 
 /**

--- a/packages/effect/src/unstable/http/HttpClientRequest.ts
+++ b/packages/effect/src/unstable/http/HttpClientRequest.ts
@@ -914,8 +914,11 @@ const parseContentLength = (contentLength: string | null): number | undefined =>
   if (contentLength === null) {
     return undefined
   }
-  const parsed = Number.parseInt(contentLength, 10)
-  return Number.isNaN(parsed) ? undefined : parsed
+  if (!/^\d+$/.test(contentLength)) {
+    return undefined
+  }
+  const parsed = Number(contentLength)
+  return Number.isSafeInteger(parsed) ? parsed : undefined
 }
 
 /**

--- a/packages/effect/src/unstable/http/HttpMiddleware.ts
+++ b/packages/effect/src/unstable/http/HttpMiddleware.ts
@@ -32,6 +32,7 @@ import * as Response from "./HttpServerResponse.ts"
 import type { HttpServerResponse } from "./HttpServerResponse.ts"
 import * as TraceContext from "./HttpTraceContext.ts"
 import * as compressionInternal from "./internal/compression.ts"
+import * as bodyInternal from "./internal/httpBody.ts"
 import { appendPreResponseHandlerUnsafe } from "./internal/preResponseHandler.ts"
 
 /**
@@ -542,7 +543,7 @@ export const compression = (
     if (algorithm === undefined) {
       return Effect.succeed(withVary(response))
     }
-    const contentLength = body.contentLength ?? contentLengthHeader(response.headers)
+    const contentLength = body.contentLength ?? bodyInternal.parseContentLength(response.headers["content-length"])
     if (contentLength !== undefined && contentLength < minSize) {
       return Effect.succeed(withVary(response))
     }
@@ -575,12 +576,3 @@ const defaultLevels = {
 } as const
 
 const noTransformRegex = /(?:^|[\s,])no-transform(?:$|[\s,;])/i
-
-const contentLengthHeader = (headers: Headers.Headers): number | undefined => {
-  const value = headers["content-length"]
-  if (value === undefined) {
-    return undefined
-  }
-  const parsed = Number(value)
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined
-}

--- a/packages/effect/src/unstable/http/HttpServerRequest.ts
+++ b/packages/effect/src/unstable/http/HttpServerRequest.ts
@@ -454,8 +454,11 @@ const parseContentLength = (contentLength: string | undefined): number | undefin
   if (contentLength === undefined) {
     return undefined
   }
-  const parsed = Number.parseInt(contentLength, 10)
-  return Number.isNaN(parsed) ? undefined : parsed
+  if (!/^\d+$/.test(contentLength)) {
+    return undefined
+  }
+  const parsed = Number(contentLength)
+  return Number.isSafeInteger(parsed) ? parsed : undefined
 }
 
 const removeHost = (url: string) => {

--- a/packages/effect/src/unstable/http/HttpServerRequest.ts
+++ b/packages/effect/src/unstable/http/HttpServerRequest.ts
@@ -33,6 +33,7 @@ import * as HttpClientRequest from "./HttpClientRequest.ts"
 import * as HttpIncomingMessage from "./HttpIncomingMessage.ts"
 import { hasBody, type HttpMethod } from "./HttpMethod.ts"
 import { HttpServerError, type RequestError, RequestParseError } from "./HttpServerError.ts"
+import * as bodyInternal from "./internal/httpBody.ts"
 import * as Multipart from "./Multipart.ts"
 import * as UrlParams from "./UrlParams.ts"
 
@@ -423,18 +424,23 @@ export const fromWeb = (request: globalThis.Request): HttpServerRequest =>
  * @category converting
  * @since 4.0.0
  */
-export const toClientRequest = (request: HttpServerRequest): HttpClientRequest.HttpClientRequest =>
-  HttpClientRequest.setUrl(
+export const toClientRequest = (request: HttpServerRequest): HttpClientRequest.HttpClientRequest => {
+  const body = toClientBody(request)
+  const headers = body._tag !== "Empty" && body.contentLength === undefined
+    ? Headers.remove(request.headers, "content-length")
+    : request.headers
+  return HttpClientRequest.setUrl(
     HttpClientRequest.makeWith(
       request.method,
       "",
       UrlParams.empty,
       Option.none(),
-      request.headers,
-      toClientBody(request)
+      headers,
+      body
     ),
     Option.getOrElse(toURL(request), () => request.url)
   )
+}
 
 const toClientBody = (request: HttpServerRequest): HttpBody.HttpBody => {
   if (!hasBody(request.method)) {
@@ -445,20 +451,9 @@ const toClientBody = (request: HttpServerRequest): HttpBody.HttpBody => {
     ? HttpBody.stream(
       request.stream,
       request.headers["content-type"],
-      parseContentLength(request.headers["content-length"])
+      bodyInternal.parseContentLength(request.headers["content-length"])
     )
     : HttpBody.formData(formData)
-}
-
-const parseContentLength = (contentLength: string | undefined): number | undefined => {
-  if (contentLength === undefined) {
-    return undefined
-  }
-  if (!/^\d+$/.test(contentLength)) {
-    return undefined
-  }
-  const parsed = Number(contentLength)
-  return Number.isSafeInteger(parsed) ? parsed : undefined
 }
 
 const removeHost = (url: string) => {

--- a/packages/effect/src/unstable/http/HttpServerResponse.ts
+++ b/packages/effect/src/unstable/http/HttpServerResponse.ts
@@ -1292,7 +1292,7 @@ export const fromClientResponse = (
     body: Body.stream(
       Stream.catchIf(response.stream, isEmptyBodyError, () => Stream.empty),
       Option.getOrUndefined(Headers.get(headers, "content-type")),
-      getContentLength(headers)
+      bodyInternal.parseContentLength(headers["content-length"])
     )
   })
 }
@@ -1304,15 +1304,6 @@ const isEmptyBodyError = (
   error: HttpClientError.HttpClientError
 ): error is HttpClientError.HttpClientError =>
   HttpClientError.isHttpClientError(error) && error.reason._tag === "EmptyBodyError"
-
-const getContentLength = (headers: Headers.Headers): number | undefined => {
-  const contentLength = Option.getOrUndefined(Headers.get(headers, "content-length"))
-  if (contentLength === undefined) {
-    return undefined
-  }
-  const parsed = Number(contentLength)
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined
-}
 
 const Proto: Omit<
   HttpServerResponse,

--- a/packages/effect/src/unstable/http/internal/httpBody.ts
+++ b/packages/effect/src/unstable/http/internal/httpBody.ts
@@ -13,3 +13,12 @@ export const updateHeaders = (headers: Headers.Headers, body: HttpBody.HttpBody)
     ? Headers.remove(headers, "content-length")
     : Headers.set(headers, "content-length", body.contentLength.toString())
 }
+
+/** @internal */
+export const parseContentLength = (contentLength: string | null | undefined): number | undefined => {
+  if (contentLength === null || contentLength === undefined || !/^\d+$/.test(contentLength)) {
+    return undefined
+  }
+  const parsed = Number(contentLength)
+  return Number.isSafeInteger(parsed) ? parsed : undefined
+}

--- a/packages/effect/test/unstable/http/HttpClientRequest.test.ts
+++ b/packages/effect/test/unstable/http/HttpClientRequest.test.ts
@@ -201,6 +201,24 @@ describe("HttpClientRequest", () => {
         strictEqual(yield* Effect.promise(() => webRequest2.text()), "{\"foo\":\"bar\"}")
       }))
 
+    it("fromWeb ignores malformed or unsafe content lengths", () => {
+      for (const contentLength of ["2junk", "1.5", "1e3", "9007199254740992"]) {
+        const request = HttpClientRequest.fromWeb(
+          new Request("http://localhost:3000", {
+            method: "POST",
+            headers: { "content-length": contentLength },
+            body: "hello"
+          })
+        )
+
+        strictEqual(request.headers["content-length"], undefined)
+        strictEqual(request.body._tag, "Raw")
+        if (request.body._tag === "Raw") {
+          strictEqual(request.body.contentLength, undefined)
+        }
+      }
+    })
+
     it.effect("toWeb stream body", () =>
       Effect.gen(function*() {
         const body = new Uint8Array([104, 101, 108, 108, 111])

--- a/packages/effect/test/unstable/http/HttpCompression.test.ts
+++ b/packages/effect/test/unstable/http/HttpCompression.test.ts
@@ -189,6 +189,19 @@ describe("HttpCompression", () => {
     assert.strictEqual(response.headers.get("content-encoding"), "gzip")
   })
 
+  it("ignores malformed content lengths when checking minSize", async () => {
+    for (const contentLength of ["1e3", "1.5"]) {
+      const app = Effect.succeed(
+        HttpServerResponse.stream(Stream.succeed(new TextEncoder().encode(bigJson)), {
+          contentType: "application/json",
+          headers: { "content-length": contentLength }
+        })
+      )
+      const response = await get(makeHandler(app), { "accept-encoding": "gzip" })
+      assert.strictEqual(response.headers.get("content-encoding"), "gzip")
+    }
+  })
+
   it("skips non-compressible content types without Vary", async () => {
     const app = Effect.succeed(
       HttpServerResponse.uint8Array(randomBytes(2048), { contentType: "image/png" })

--- a/packages/effect/test/unstable/http/HttpServerRequest.test.ts
+++ b/packages/effect/test/unstable/http/HttpServerRequest.test.ts
@@ -65,20 +65,23 @@ describe("HttpServerRequest", () => {
     }
   })
 
-  it("toClientRequest removes malformed content length metadata", () => {
-    const clientRequest = HttpServerRequest.toClientRequest(
-      HttpServerRequest.fromWeb(
-        new Request("http://localhost:3000", {
-          method: "POST",
-          headers: { "content-length": "2junk" },
-          body: "hello"
-        })
+  it("toClientRequest ignores malformed or unsafe content lengths", () => {
+    for (const contentLength of ["2junk", "1.5", "1e3", "9007199254740992"]) {
+      const clientRequest = HttpServerRequest.toClientRequest(
+        HttpServerRequest.fromWeb(
+          new Request("http://localhost:3000", {
+            method: "POST",
+            headers: { "content-length": contentLength },
+            body: "hello"
+          })
+        )
       )
-    )
 
-    strictEqual(clientRequest.body._tag, "Stream")
-    if (clientRequest.body._tag === "Stream") {
-      strictEqual(clientRequest.body.contentLength, undefined)
+      strictEqual(clientRequest.headers["content-length"], undefined)
+      strictEqual(clientRequest.body._tag, "Stream")
+      if (clientRequest.body._tag === "Stream") {
+        strictEqual(clientRequest.body.contentLength, undefined)
+      }
     }
   })
 

--- a/packages/effect/test/unstable/http/HttpServerRequest.test.ts
+++ b/packages/effect/test/unstable/http/HttpServerRequest.test.ts
@@ -65,6 +65,23 @@ describe("HttpServerRequest", () => {
     }
   })
 
+  it("toClientRequest removes malformed content length metadata", () => {
+    const clientRequest = HttpServerRequest.toClientRequest(
+      HttpServerRequest.fromWeb(
+        new Request("http://localhost:3000", {
+          method: "POST",
+          headers: { "content-length": "2junk" },
+          body: "hello"
+        })
+      )
+    )
+
+    strictEqual(clientRequest.body._tag, "Stream")
+    if (clientRequest.body._tag === "Stream") {
+      strictEqual(clientRequest.body.contentLength, undefined)
+    }
+  })
+
   it("toClientRequest keeps empty bodies empty", () => {
     const clientRequest = HttpServerRequest.toClientRequest(
       HttpServerRequest.fromWeb(

--- a/packages/effect/test/unstable/http/HttpServerResponse.test.ts
+++ b/packages/effect/test/unstable/http/HttpServerResponse.test.ts
@@ -86,6 +86,22 @@ describe("HttpServerResponse", () => {
       assert.strictEqual(yield* roundTrip.text, "")
     }))
 
+  it("fromClientResponse ignores malformed or unsafe content lengths", () => {
+    const request = HttpClientRequest.get("http://localhost:3000")
+    for (const contentLength of ["2junk", "1.5", "1e3", "9007199254740992"]) {
+      const clientResponse = HttpClientResponse.fromWeb(
+        request,
+        new Response("hello", { headers: { "content-length": contentLength } })
+      )
+      const response = HttpServerResponse.fromClientResponse(clientResponse)
+
+      assert.strictEqual(response.body._tag, "Stream")
+      if (response.body._tag === "Stream") {
+        assert.strictEqual(response.body.contentLength, undefined)
+      }
+    }
+  })
+
   it("synchronizes body metadata headers for empty and replaced bodies", () => {
     const emptyBytes = HttpServerResponse.uint8Array(new Uint8Array())
     assert.strictEqual(emptyBytes.headers["content-length"], "0")


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`HttpClientRequest.fromWeb` and `HttpServerRequest.toClientRequest` parsed `Content-Length` values using `Number.parseInt`. Since `parseInt` accepts numeric prefixes, malformed values such as `"2junk"` were converted into valid-looking body metadata such as `2`.

This PR:

- requires the entire `Content-Length` value to contain only decimal digits;
- accepts the parsed value only when it is a JavaScript safe integer;
- ignores malformed, fractional, exponential, and unsafe values instead of coercing them;
- adds focused regression coverage for both request conversion paths;
- adds an `effect` patch changeset.

### Validation

- `pnpm test --run packages/effect/test/unstable/http/HttpClientRequest.test.ts packages/effect/test/unstable/http/HttpServerRequest.test.ts` — 33 tests passed
- `NODE_OPTIONS=--experimental-strip-types pnpm lint-fix`
- `pnpm check`

## Related

No related issue.

