### PR TITLE
fix(platform-node-shared): keep cooked mode for NodeTerminal.readLine on TTY

### DIFF
--- a/.changeset/node-terminal-readline-tty.md
+++ b/.changeset/node-terminal-readline-tty.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+NodeTerminal: keep stdin in cooked mode for `readLine` on a TTY so typed input is echoed and Ctrl+C interrupts as expected. Raw mode is now enabled only while reading key input.

--- a/packages/platform/node-shared/src/NodeTerminal.ts
+++ b/packages/platform/node-shared/src/NodeTerminal.ts
@@ -4,7 +4,7 @@
  * `NodeTerminal` adapts Node's `readline` APIs plus the current process
  * `stdin` and `stdout` streams into {@link Terminal.Terminal}. The service can
  * display output, read a line, stream key input, and read terminal dimensions.
- * `make` manages readline and TTY raw mode in a scope, while `layer` provides
+ * `make` manages readline and enables TTY raw mode only for key input, while `layer` provides
  * the default service that ends key input on Ctrl+C or Ctrl+D.
  *
  * @since 4.0.0
@@ -23,7 +23,7 @@ import * as readline from "node:readline"
 
 /**
  * Creates a scoped process-backed `Terminal` using Node `readline`, enabling
- * TTY raw mode while in scope and using the supplied predicate to decide when
+ * TTY raw mode for key input and using the supplied predicate to decide when
  * key input should end.
  *
  * @category constructors
@@ -53,7 +53,7 @@ export const make: (
     const rlRef = yield* RcRef.make({
       acquire: Effect.acquireRelease(
         Effect.sync(() => {
-          const rl = readline.createInterface({ input: stdin, escapeCodeTimeout: 50 })
+          const rl = readline.createInterface({ input: stdin, output: stdout, escapeCodeTimeout: 50 })
           const onLine = (line: string) => Queue.offerUnsafe(lines, line)
           const onClose = () => {
             readlineActive = false
@@ -63,10 +63,6 @@ export const make: (
           readline.emitKeypressEvents(stdin, rl)
           rl.on("line", onLine)
           rl.once("close", onClose)
-
-          if (stdin.isTTY) {
-            stdin.setRawMode(true)
-          }
           return { rl, onClose, onLine }
         }),
         ({ rl, onClose, onLine }) =>
@@ -74,9 +70,6 @@ export const make: (
             readlineActive = false
             rl.off("line", onLine)
             rl.off("close", onClose)
-            if (stdin.isTTY) {
-              stdin.setRawMode(false)
-            }
             rl.close()
             if (inputEnded) {
               Queue.endUnsafe(lines)
@@ -115,8 +108,14 @@ export const make: (
           clearInterval(keepAlive)
           stdin.off("keypress", handleKeypress)
           stdin.off("end", handleEnd)
+          if (stdin.isTTY) {
+            stdin.setRawMode(false)
+          }
         })
       )
+      if (stdin.isTTY) {
+        stdin.setRawMode(true)
+      }
       stdin.on("keypress", handleKeypress)
       if (inputEnded) {
         handleEnd()

--- a/packages/platform/node-shared/test/NodeTerminal.test.ts
+++ b/packages/platform/node-shared/test/NodeTerminal.test.ts
@@ -6,14 +6,12 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 const fixture = join(__dirname, "fixtures", "node-terminal.ts")
-const nodeOptions = "--experimental-strip-types --experimental-transform-types"
 
 const runFixture = (mode: string, input: string) =>
   spawnSync(process.execPath, [fixture, mode], {
     encoding: "utf8",
     input,
-    timeout: 2_000,
-    env: { ...process.env, NODE_OPTIONS: nodeOptions }
+    timeout: 2_000
   })
 
 const runTtyFixture = (mode: string, input: string) => {
@@ -26,8 +24,7 @@ const runTtyFixture = (mode: string, input: string) => {
       {
         encoding: "utf8",
         input,
-        timeout: 5_000,
-        env: { ...process.env, NODE_OPTIONS: nodeOptions }
+        timeout: 5_000
       }
     )
     const output = readFileSync(logFile, "utf8")
@@ -53,9 +50,7 @@ const assertResult = (mode: string, input: string, expected: string) => {
 
 const assertOpenResult = (mode: string, input: string, expected: string) =>
   Effect.callback<void>((resume) => {
-    const child = spawn(process.execPath, [fixture, mode], {
-      env: { ...process.env, NODE_OPTIONS: nodeOptions }
-    })
+    const child = spawn(process.execPath, [fixture, mode])
     let stderr = ""
     child.stderr.setEncoding("utf8")
     child.stderr.on("data", (data) => {

--- a/packages/platform/node-shared/test/NodeTerminal.test.ts
+++ b/packages/platform/node-shared/test/NodeTerminal.test.ts
@@ -1,16 +1,48 @@
 import { assert, describe, it } from "@effect/vitest"
 import * as Effect from "effect/Effect"
 import { spawn, spawnSync } from "node:child_process"
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
 import { join } from "node:path"
+import { tmpdir } from "node:os"
 
 const fixture = join(__dirname, "fixtures", "node-terminal.ts")
+const nodeOptions = "--experimental-strip-types --experimental-transform-types"
 
 const runFixture = (mode: string, input: string) =>
   spawnSync(process.execPath, [fixture, mode], {
     encoding: "utf8",
     input,
-    timeout: 2_000
+    timeout: 2_000,
+    env: { ...process.env, NODE_OPTIONS: nodeOptions }
   })
+
+const runTtyFixture = (mode: string, input: string) => {
+  const logDir = mkdtempSync(join(tmpdir(), "node-terminal-"))
+  const logFile = join(logDir, "tty.log")
+  try {
+    const result = spawnSync(
+      "script",
+      ["-q", "-f", "-c", `${process.execPath} ${fixture} ${mode}`, logFile],
+      {
+        encoding: "utf8",
+        input,
+        timeout: 5_000,
+        env: { ...process.env, NODE_OPTIONS: nodeOptions }
+      }
+    )
+    const output = readFileSync(logFile, "utf8")
+    return { ...result, stderr: output }
+  } finally {
+    rmSync(logDir, { force: true, recursive: true })
+  }
+}
+
+const assertTtyResult = (mode: string, input: string, expected: string) => {
+  const result = runTtyFixture(mode, input)
+  assert.isUndefined(result.error)
+  assert.strictEqual(result.status, 0, result.stderr)
+  assert.isTrue(result.stderr.includes(`RESULT ${expected}`), result.stderr)
+}
 
 const assertResult = (mode: string, input: string, expected: string) => {
   const result = runFixture(mode, input)
@@ -21,7 +53,9 @@ const assertResult = (mode: string, input: string, expected: string) => {
 
 const assertOpenResult = (mode: string, input: string, expected: string) =>
   Effect.callback<void>((resume) => {
-    const child = spawn(process.execPath, [fixture, mode])
+    const child = spawn(process.execPath, [fixture, mode], {
+      env: { ...process.env, NODE_OPTIONS: nodeOptions }
+    })
     let stderr = ""
     child.stderr.setEncoding("utf8")
     child.stderr.on("data", (data) => {
@@ -64,6 +98,20 @@ describe("NodeTerminal", () => {
 
   it("fails readLine with QuitError when stdin ended before initialization", () => {
     assertResult("read-line-after-end", "", "\"QuitError\"")
+  })
+
+  it("keeps stdin in cooked mode while waiting for readLine on a TTY", () => {
+    assertTtyResult("read-line-raw-mode", "hello\n", "{\"isRaw\":false,\"line\":\"hello\"}")
+  })
+
+  it("enables raw mode while waiting for readInput on a TTY", () => {
+    assertTtyResult("read-input-raw-mode", "y", "{\"isRaw\":true,\"first\":\"y\"}")
+  })
+
+  it("interrupts readLine on Ctrl+C when stdin is a TTY", () => {
+    const result = runTtyFixture("read-line-sigint", "\u0003")
+    assert.isUndefined(result.error)
+    assert.isFalse(result.stderr.includes("RESULT "), result.stderr)
   })
 
   it.effect("disposes readline after its idle TTL", () =>

--- a/packages/platform/node-shared/test/NodeTerminal.test.ts
+++ b/packages/platform/node-shared/test/NodeTerminal.test.ts
@@ -2,8 +2,8 @@ import { assert, describe, it } from "@effect/vitest"
 import * as Effect from "effect/Effect"
 import { spawn, spawnSync } from "node:child_process"
 import { mkdtempSync, readFileSync, rmSync } from "node:fs"
-import { join } from "node:path"
 import { tmpdir } from "node:os"
+import { join } from "node:path"
 
 const fixture = join(__dirname, "fixtures", "node-terminal.ts")
 const nodeOptions = "--experimental-strip-types --experimental-transform-types"

--- a/packages/platform/node-shared/test/fixtures/node-terminal.ts
+++ b/packages/platform/node-shared/test/fixtures/node-terminal.ts
@@ -1,6 +1,7 @@
 import * as NodeTerminal from "@effect/platform-node-shared/NodeTerminal"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
+import * as Fiber from "effect/Fiber"
 import * as FileSystem from "effect/FileSystem"
 import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
@@ -79,6 +80,39 @@ const readLineDisposed = Effect.gen(function*() {
   return { line, duringTtl, dataListeners: process.stdin.listenerCount("data") }
 })
 
+const readLineRawMode = Effect.scoped(
+  Effect.gen(function*() {
+    const terminal = yield* Terminal.Terminal
+    const fiber = yield* Effect.forkScoped(terminal.readLine)
+    yield* Effect.sleep("50 millis")
+    const isRaw = process.stdin.isTTY
+      ? (process.stdin as NodeJS.ReadStream & { isRaw: boolean }).isRaw
+      : null
+    const line = yield* Fiber.join(fiber)
+    return { isRaw, line }
+  })
+)
+
+const readInputRawMode = Effect.scoped(
+  Effect.gen(function*() {
+    const terminal = yield* Terminal.Terminal
+    const input = yield* terminal.readInput
+    yield* Effect.sleep("50 millis")
+    const isRaw = process.stdin.isTTY
+      ? (process.stdin as NodeJS.ReadStream & { isRaw: boolean }).isRaw
+      : null
+    const first = yield* Queue.take(input)
+    return { isRaw, first: Option.getOrNull(first.input) }
+  })
+)
+
+const readLineSigint = Effect.gen(function*() {
+  const terminal = yield* Terminal.Terminal
+  yield* terminal.display("prompt")
+  const line = yield* terminal.readLine
+  return line
+})
+
 const mode = process.argv[2]
 const program = Effect.gen(function*() {
   if (mode === "prompts") {
@@ -95,6 +129,12 @@ const program = Effect.gen(function*() {
     return yield* readLineAfterEnd
   } else if (mode === "read-line-disposed") {
     return yield* readLineDisposed
+  } else if (mode === "read-line-raw-mode") {
+    return yield* readLineRawMode
+  } else if (mode === "read-input-raw-mode") {
+    return yield* readInputRawMode
+  } else if (mode === "read-line-sigint") {
+    return yield* readLineSigint
   }
   return yield* Effect.die(`Unknown mode: ${mode}`)
 })


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`NodeTerminal` enabled stdin raw mode whenever its shared readline interface was acquired. That is required for `readInput` keypress handling, but it breaks `readLine` on a TTY: typed characters are not echoed and Ctrl+C no longer interrupts the process.

This change keeps stdin in cooked mode for `readLine`, enables raw mode only while `readInput` is active, and passes `stdout` to `readline.createInterface` so line editing works on a TTY.

Fixes #7529

## Testing

- `pnpm test --run packages/platform/node-shared/test/NodeTerminal.test.ts`
- Added TTY regression coverage for cooked-mode `readLine`, raw-mode `readInput`, and Ctrl+C interruption