### PR TITLE
Update v3-to-v4 Socket and typeclass guidance

### DIFF
--- a/migration/annotations/effect__typeclass__Bounded.yaml
+++ b/migration/annotations/effect__typeclass__Bounded.yaml
@@ -10,6 +10,12 @@
 "@effect/typeclass/Bounded#clamp":
   replacement: "Order.clamp(B.compare)"
   note: "Use the v4 Order combinator with { minimum: B.minBound, maximum: B.maxBound }; the Bounded dictionary itself was removed."
+"@effect/typeclass/Bounded#max":
+  replacement: "Reducer.make(Combiner.max(B.compare).combine, B.minBound)"
+  note: "V4 removed Bounded dictionaries. Build the maximum Reducer from the separately retained Order and minimum bound."
+"@effect/typeclass/Bounded#min":
+  replacement: "Reducer.make(Combiner.min(B.compare).combine, B.maxBound)"
+  note: "V4 removed Bounded dictionaries. Build the minimum Reducer from the separately retained Order and maximum bound."
 "@effect/typeclass/Bounded#reverse":
   replacement: "Order.flip(B.compare)"
   note: "Flip the Order and swap the separately stored minimum and maximum bounds; v4 has no bundled Bounded dictionary."

--- a/migration/annotations/effect__typeclass__Monoid.yaml
+++ b/migration/annotations/effect__typeclass__Monoid.yaml
@@ -4,6 +4,12 @@
 "@effect/typeclass/Monoid#fromSemigroup":
   replacement: "Reducer.make(S.combine, empty)"
   note: "Construct a v4 Reducer from the replacement Combiner operation and identity value."
+"@effect/typeclass/Monoid#max":
+  replacement: "Reducer.make(Combiner.max(B.compare).combine, B.minBound)"
+  note: "Reducer replaces Monoid. Build it from the v4 maximum Combiner and the bounded order's minimum value."
+"@effect/typeclass/Monoid#min":
+  replacement: "Reducer.make(Combiner.min(B.compare).combine, B.maxBound)"
+  note: "Reducer replaces Monoid. Build it from the v4 minimum Combiner and the bounded order's maximum value."
 "@effect/typeclass/Monoid#Monoid":
   replacement: "Reducer.Reducer"
   note: "Reducer replaces Monoid in v4; empty is renamed initialValue and combineAll remains available."

--- a/migration/annotations/effect__typeclass__Semigroup.yaml
+++ b/migration/annotations/effect__typeclass__Semigroup.yaml
@@ -22,6 +22,12 @@
 "@effect/typeclass/Semigroup#make":
   replacement: "Combiner.make"
   note: "Combiner replaces Semigroup. V4 accepts only the binary combine function and has no combineMany override."
+"@effect/typeclass/Semigroup#max":
+  replacement: "Combiner.max"
+  note: "Combiner replaces Semigroup; pass the same Order to retain last-maximum tie behavior."
+"@effect/typeclass/Semigroup#min":
+  replacement: "Combiner.min"
+  note: "Combiner replaces Semigroup; pass the same Order to retain last-minimum tie behavior."
 "@effect/typeclass/Semigroup#Product":
   replacement: "none"
   note: "The @effect/typeclass package was removed in v4 with no generic typeclass layer replacement. Rewrite this abstraction against the concrete v4 data type and its module functions."

--- a/migration/v3-to-v4.md
+++ b/migration/v3-to-v4.md
@@ -4,7 +4,7 @@
 
 Base: `origin/v3` (`7c6e1e5d2ac9dfe00649a65fa80a61dcc14d55ae`)
 
-Head: `HEAD` (`f356bc2da6abb4dee05b8c22fb597af3823e2ef7`)
+Head: `origin/main` (`53843f6490f4eebaf1eeb91fdcc5f1c542b0e132`)
 
 This file is generated from the API diff and `migration/annotations/*.yaml`.
 
@@ -7378,9 +7378,15 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `Socket.WebSocketConstructor` -> `Socket.WebSocketConstructor`: The service moved to effect/unstable/socket/Socket and is now a Context.Service class.
 
-- `Socket.currentSendQueueCapacity` -> `Socket.SendQueueCapacity`: The FiberRef was replaced by a defaulted Context.Reference.
+- `Socket.currentSendQueueCapacity` -> `none`: The send queue was removed. The v4 Socket is pull-based: acquire socket.reader in a scope and pull frame batches; writes apply the transport's native backpressure.
+
+- `Socket.defaultCloseCodeIsError` -> `none`: Sockets no longer classify close codes; every close fails the reader's pull with a SocketError wrapping SocketCloseError. Consumers that treat a close as normal catch the error.
+
+- `Socket.fromTransformStream` -> `Socket.fromTransformStream`: The constructor remains in effect/unstable/socket/Socket but drops closeCodeIsError; every close fails the reader's pull with a SocketError wrapping SocketCloseError.
 
 - `Socket.layerWebSocket` -> `Socket.layerWebSocket`: The constructor remains in effect/unstable/socket/Socket; its URL may now also be an Effect.
+
+- `Socket.toChannelMap` -> `none`: The v4 Socket read side is an Effect that never completes via Cause.Done; map frames by acquiring Socket.readerBytes or Socket.readerString, or Effect.map the reader from socket.reader, and use Socket.toChannel or Socket.toChannelString for duplex channels.
 
 ### `@effect/platform/SocketServer`
 
@@ -7924,6 +7930,10 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `Bounded.clamp` -> `Order.clamp(B.compare)`: Use the v4 Order combinator with { minimum: B.minBound, maximum: B.maxBound }; the Bounded dictionary itself was removed.
 
+- `Bounded.max` -> `Reducer.make(Combiner.max(B.compare).combine, B.minBound)`: V4 removed Bounded dictionaries. Build the maximum Reducer from the separately retained Order and minimum bound.
+
+- `Bounded.min` -> `Reducer.make(Combiner.min(B.compare).combine, B.maxBound)`: V4 removed Bounded dictionaries. Build the minimum Reducer from the separately retained Order and maximum bound.
+
 - `Bounded.reverse` -> `Order.flip(B.compare)`: Flip the Order and swap the separately stored minimum and maximum bounds; v4 has no bundled Bounded dictionary.
 
 ### `@effect/typeclass/Monoid`
@@ -7933,6 +7943,10 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 - `Monoid.array` -> `Array.makeReducerConcat`: Use the v4 array concatenation Reducer; Reducer replaces Monoid and names the identity initialValue.
 
 - `Monoid.fromSemigroup` -> `Reducer.make(S.combine, empty)`: Construct a v4 Reducer from the replacement Combiner operation and identity value.
+
+- `Monoid.max` -> `Reducer.make(Combiner.max(B.compare).combine, B.minBound)`: Reducer replaces Monoid. Build it from the v4 maximum Combiner and the bounded order's minimum value.
+
+- `Monoid.min` -> `Reducer.make(Combiner.min(B.compare).combine, B.maxBound)`: Reducer replaces Monoid. Build it from the v4 minimum Combiner and the bounded order's maximum value.
 
 - `Monoid.reverse` -> `Reducer.flip`: Use the v4 Reducer combinator; it preserves initialValue and reverses combine argument order.
 
@@ -7965,6 +7979,10 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 - `Semigroup.last` -> `Combiner.last`: Combiner replaces Semigroup in v4.
 
 - `Semigroup.make` -> `Combiner.make`: Combiner replaces Semigroup. V4 accepts only the binary combine function and has no combineMany override.
+
+- `Semigroup.max` -> `Combiner.max`: Combiner replaces Semigroup; pass the same Order to retain last-maximum tie behavior.
+
+- `Semigroup.min` -> `Combiner.min`: Combiner replaces Semigroup; pass the same Order to retain last-minimum tie behavior.
 
 - `Semigroup.reverse` -> `Combiner.flip`: Use the v4 Combiner combinator to reverse combine argument order.
 


### PR DESCRIPTION
## Summary

- refresh the generated Socket migration guidance for the pull-based API
- add stable migration annotations for the `Bounded`, `Monoid`, and `Semigroup` `min`/`max` APIs
- regenerate the v3-to-v4 reference at main SHA `53843f6490f4eebaf1eeb91fdcc5f1c542b0e132`

## Validation

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/tools/api-diff/test` (25 tests passed)
- `nix develop -c pnpm --dir packages/tools/api-diff check`
- `git diff --check`
- `nix develop -c pnpm api-diff --base-ref origin/v3 --head-ref origin/main --check` (expected nonzero result for 12 pre-existing annotation groups; the affected Socket and typeclass IDs are clean)

Closes EFF-978
