### PR TITLE
fix(openapi-generator): declare yaml as a runtime dependency

### DIFF
--- a/.changeset/fix-openapi-generator-yaml-runtime-dependency.md
+++ b/.changeset/fix-openapi-generator-yaml-runtime-dependency.md
@@ -1,0 +1,5 @@
+---
+"@effect/openapi-generator": patch
+---
+
+Declare `yaml` as a runtime dependency so `openapigen` works with package managers that enforce dependency boundaries.

--- a/packages/tools/openapi-generator/package.json
+++ b/packages/tools/openapi-generator/package.json
@@ -66,13 +66,13 @@
     "effect": "workspace:^"
   },
   "dependencies": {
-    "swagger2openapi": "^7.0.8"
+    "swagger2openapi": "^7.0.8",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@types/swagger2openapi": "^7.0.4",
     "effect": "workspace:^",
     "json-schema-typed": "^8.0.2",
-    "openapi-typescript": "^7.13.0",
-    "yaml": "^2.9.0"
+    "openapi-typescript": "^7.13.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -870,6 +870,9 @@ importers:
       swagger2openapi:
         specifier: ^7.0.8
         version: 7.0.8
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@types/swagger2openapi':
         specifier: ^7.0.4
@@ -883,9 +886,6 @@ importers:
       openapi-typescript:
         specifier: ^7.13.0
         version: 7.13.0(typescript@7.0.2)
-      yaml:
-        specifier: ^2.9.0
-        version: 2.9.0
 
   packages/tools/oxc:
     dependencies:


### PR DESCRIPTION
Fixes #7542.

`openapigen` imports `yaml` through `OpenApiPatch` during CLI module loading. Declaring it as a runtime dependency lets strict package managers resolve the import.

## Worth a close look

- The only behavior change is the published package manifest.
- `pnpm` can mask the problem because `swagger2openapi` also depends on `yaml`; Yarn Plug'n'Play exposes the undeclared direct import.

## Verified

- `pnpm check` passed.
- `pnpm vitest run --project @effect/openapi-generator`: 83 tests passed.
- `pnpm lint` passed.
- Packed the artifact and installed it in a fresh Yarn 4.9.1 Plug'n'Play project. `yarn openapigen --help` succeeds.