### PR TITLE
Use Effect YAML parser in OpenAPI generator

### DIFF
--- a/.changeset/clean-yaks-parse.md
+++ b/.changeset/clean-yaks-parse.md
@@ -1,0 +1,5 @@
+---
+"@effect/openapi-generator": patch
+---
+
+Use Effect's YAML parser for OpenAPI patch files and remove the direct `yaml` dependency.

--- a/packages/tools/openapi-generator/package.json
+++ b/packages/tools/openapi-generator/package.json
@@ -72,7 +72,6 @@
     "@types/swagger2openapi": "^7.0.4",
     "effect": "workspace:^",
     "json-schema-typed": "^8.0.2",
-    "openapi-typescript": "^7.13.0",
-    "yaml": "^2.9.0"
+    "openapi-typescript": "^7.13.0"
   }
 }

--- a/packages/tools/openapi-generator/src/OpenApiPatch.ts
+++ b/packages/tools/openapi-generator/src/OpenApiPatch.ts
@@ -17,7 +17,7 @@ import * as JsonPatch from "effect/JsonPatch"
 import * as Path from "effect/Path"
 import * as Predicate from "effect/Predicate"
 import * as Schema from "effect/Schema"
-import * as Yaml from "yaml"
+import * as Yaml from "effect/unstable/encoding/Yaml"
 
 // =============================================================================
 // Error Types

--- a/packages/tools/openapi-generator/test/OpenApiPatch.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiPatch.test.ts
@@ -92,9 +92,10 @@ describe("OpenApiPatch", () => {
             "fixtures/patches/valid-patch.yaml"
           )
           const result = yield* OpenApiPatch.parsePatchInput(filePath)
-          assert.strictEqual(result.length, 2)
-          assert.strictEqual(result[0].op, "replace")
-          assert.strictEqual(result[1].op, "add")
+          assert.deepStrictEqual(result, [
+            { op: "replace", path: "/info/title", value: "YAML Patched Title" },
+            { op: "add", path: "/info/x-yaml-patch", value: true }
+          ])
         }).pipe(Effect.provide(testLayer)))
 
       it.effect("parses multiple operations from JSON file", () =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -883,9 +883,6 @@ importers:
       openapi-typescript:
         specifier: ^7.13.0
         version: 7.13.0(typescript@7.0.2)
-      yaml:
-        specifier: ^2.9.0
-        version: 2.9.0
 
   packages/tools/oxc:
     dependencies:


### PR DESCRIPTION
Switch the OpenAPI patch parser from the external `yaml` package to Effect's YAML module. The YAML fixture assertion now checks the complete decoded patch, including string and boolean values.

Tests:

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/tools/openapi-generator/test/OpenApiPatch.test.ts`
- `nix develop -c pnpm check`

Closes EFF-982
