### PR TITLE
Preserve omitted additionalProperties in OpenAPI schemas

### DIFF
--- a/.changeset/openapi-omitted-additional-properties.md
+++ b/.changeset/openapi-omitted-additional-properties.md
@@ -1,0 +1,5 @@
+---
+"@effect/openapi-generator": patch
+---
+
+Preserve omitted `additionalProperties` when generating schemas from OpenAPI documents.

--- a/packages/ai/anthropic/codegen.yml
+++ b/packages/ai/anthropic/codegen.yml
@@ -13,6 +13,7 @@ header: |
    */
 excludeAnnotations:
   - examples
+disableAdditionalProperties: true
 replacements:
   # Schema.Unknown doesn't work with Schema.toCodecJson (used by HttpClientResponse.schemaBodyJson)
   # Replace with Schema.Json which properly handles arbitrary JSON values
@@ -59,4 +60,3 @@ replacements:
   # Make context_management optional in BetaMessageDeltaEvent (API may omit this field)
   - from: '"context_management": Schema.Union([BetaResponseContextManagement, Schema.Null]).annotate({ "description": "Information about context management strategies applied during the request", "default": null }),'
     to: '"context_management": Schema.optionalKey(Schema.Union([BetaResponseContextManagement, Schema.Null]).annotate({ "description": "Information about context management strategies applied during the request", "default": null })),'
-

--- a/packages/tools/openapi-generator/src/JsonSchemaGenerator.ts
+++ b/packages/tools/openapi-generator/src/JsonSchemaGenerator.ts
@@ -224,9 +224,6 @@ function makeWithRepresentation() {
         if (cached !== undefined) return cached
 
         const out = { ...js }
-        if (out.type === "object" && out.additionalProperties === undefined) {
-          out.additionalProperties = false
-        }
         const transformed = { ...(options?.onEnter === undefined ? out : options.onEnter(out)) }
         preparedSchemas.set(js, transformed)
         preparedOutputs.add(transformed)

--- a/packages/tools/openapi-generator/test/JsonSchemaGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/JsonSchemaGenerator.test.ts
@@ -57,6 +57,59 @@ export const A = Schema.String.annotate({ "description": "desc", "examples": ["e
 `)
   })
 
+  const definitions = {
+    A: {
+      type: "object",
+      properties: { a: { type: "string" } },
+      required: ["a"]
+    },
+    B: {
+      type: "object",
+      properties: { b: { type: "string" } },
+      required: ["b"]
+    }
+  } as const
+
+  for (
+    const [keyword, expected] of [
+      ["oneOf", "Schema.Union(["],
+      ["anyOf", "Schema.Union(["],
+      ["allOf", "Schema.StructWithRest(Schema.Struct({ \"a\": Schema.String, \"b\": Schema.String })"]
+    ] as const
+  ) {
+    it(`preserves omitted additionalProperties with ${keyword}`, () => {
+      const generator = JsonSchemaGenerator.make()
+      generator.addSchema("Choice", {
+        type: "object",
+        [keyword]: [
+          { $ref: "#/components/schemas/A" },
+          { $ref: "#/components/schemas/B" }
+        ]
+      })
+
+      const result = generator.generate("openapi-3.1", definitions, false)
+
+      expect(result).toContain(expected)
+      expect(result).not.toContain("Schema.Never")
+    })
+  }
+
+  it("honors explicit additionalProperties false with oneOf", () => {
+    const generator = JsonSchemaGenerator.make()
+    generator.addSchema("Choice", {
+      type: "object",
+      additionalProperties: false,
+      oneOf: [
+        { $ref: "#/components/schemas/A" },
+        { $ref: "#/components/schemas/B" }
+      ]
+    })
+
+    const result = generator.generate("openapi-3.1", definitions, false)
+
+    expect(result).toContain("export const Choice = Schema.Never")
+  })
+
   it("generateHttpApi emits explicit type and const declarations", () => {
     const generator = JsonSchemaGenerator.make()
     generator.addSchema("A", { type: "string" })

--- a/packages/tools/openapi-generator/test/JsonSchemaGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/JsonSchemaGenerator.test.ts
@@ -70,11 +70,19 @@ export const A = Schema.String.annotate({ "description": "desc", "examples": ["e
     }
   } as const
 
+  const openA =
+    `Schema.StructWithRest(Schema.Struct({ "a": Schema.String }), [Schema.Record(Schema.String, Schema.Json.annotate({ "expected": "JSON value" }))])`
+  const openB =
+    `Schema.StructWithRest(Schema.Struct({ "b": Schema.String }), [Schema.Record(Schema.String, Schema.Json.annotate({ "expected": "JSON value" }))])`
+
   for (
     const [keyword, expected] of [
-      ["oneOf", "Schema.Union(["],
-      ["anyOf", "Schema.Union(["],
-      ["allOf", "Schema.StructWithRest(Schema.Struct({ \"a\": Schema.String, \"b\": Schema.String })"]
+      ["oneOf", `export const Choice = Schema.Union([${openA}, ${openB}], { mode: "oneOf" })`],
+      ["anyOf", `export const Choice = Schema.Union([${openA}, ${openB}])`],
+      [
+        "allOf",
+        `export const Choice = Schema.StructWithRest(Schema.Struct({ "a": Schema.String, "b": Schema.String }), [Schema.Record(Schema.String, Schema.Json.annotate({ "expected": "JSON value" }))])`
+      ]
     ] as const
   ) {
     it(`preserves omitted additionalProperties with ${keyword}`, () => {
@@ -90,7 +98,6 @@ export const A = Schema.String.annotate({ "description": "desc", "examples": ["e
       const result = generator.generate("openapi-3.1", definitions, false)
 
       expect(result).toContain(expected)
-      expect(result).not.toContain("Schema.Never")
     })
   }
 
@@ -107,6 +114,7 @@ export const A = Schema.String.annotate({ "description": "desc", "examples": ["e
 
     const result = generator.generate("openapi-3.1", definitions, false)
 
+    // The closed outer object forbids the properties required by both branches.
     expect(result).toContain("export const Choice = Schema.Never")
   })
 


### PR DESCRIPTION
## Summary

- preserve omitted `additionalProperties` when importing OpenAPI object schemas
- keep explicit `additionalProperties: false` behavior unchanged
- cover `oneOf`, `anyOf`, and `allOf` with exact generated runtime assertions
- add a patch changeset for `@effect/openapi-generator`

## Generated providers

The checked-in AI provider clients retain their existing closed-object behavior. OpenAI and OpenRouter already set `disableAdditionalProperties: true`; this PR makes the same choice explicit for Anthropic. No generated provider files need to change.

The public OpenAPI generator no longer applies that provider-specific policy globally, so third-party schemas get the standard omitted-`additionalProperties` behavior.

## Testing

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/tools/openapi-generator/test` (87 tests)
- `nix develop -c pnpm check`
- `nix develop -c pnpm changeset status --since HEAD`

The first Snapshot job failed while `pkg-pr-new` called its publish service, which returned HTTP 404 after a retry. This push retriggers that external check.

Closes EFF-983
Closes #7544
