### PR TITLE
Fix JSDoc validation violations

### DIFF
--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -7981,6 +7981,11 @@ export const runForEachWhile: {
 /**
  * Concatenates a channel's `Uint8Array` chunks into a single `Uint8Array`.
  *
+ * **Gotchas**
+ *
+ * This materializes the full content in memory. The source channel must not
+ * reuse or mutate emitted buffers, which are retained until collection completes.
+ *
  * **Example** (Joining channel byte chunks)
  *
  * ```ts import.meta.vitest
@@ -7994,11 +7999,6 @@ export const runForEachWhile: {
  * const bytes = Effect.runSync(Channel.mkUint8Array(channel))
  * Array.from(bytes) // => [1, 2, 3, 4]
  * ```
- *
- * **Gotchas**
- *
- * This materializes the full content in memory. The source channel must not
- * reuse or mutate emitted buffers, which are retained until collection completes.
  *
  * @category running
  * @since 4.0.0

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6948,6 +6948,8 @@ export const onExitPrimitive: <A, E, R, XE = never, XR = never>(
  * Ensures that a cleanup function runs whether this effect succeeds, fails, or
  * is interrupted.
  *
+ * **Details**
+ *
  * If both the effect and the cleanup function fail, the two causes are merged.
  *
  * **Example** (Observing every exit)

--- a/packages/effect/src/Encoding.ts
+++ b/packages/effect/src/Encoding.ts
@@ -409,6 +409,8 @@ export const encodeHex: (input: Uint8Array | string) => string = (input) =>
  * Generates a random lowercase hexadecimal string, optimized for lengths that
  * are multiples of 8.
  *
+ * **Details**
+ *
  * `length` is not validated. The function generates `length >>> 3` random
  * 8-character words, so non-negative lengths below `2 ** 32` are rounded down
  * to a multiple of 8 and other values follow JavaScript's unsigned 32-bit

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -777,7 +777,7 @@ const mutateScoped = <N, E, T extends Kind>(
  *
  * **When to use**
  *
- * Use for the usual immutable update workflow when several node or edge
+ * Use when several node or edge
  * mutations should be applied together.
  *
  * **Details**
@@ -3031,6 +3031,8 @@ export const edgeCount = <N, E, T extends Kind = "directed">(
 /**
  * Returns the indices of all edges incident to a node.
  *
+ * **Details**
+ *
  * Each edge is returned once in graph edge order, including self-loops.
  * Throws a `GraphError` when the node does not exist.
  *
@@ -3093,6 +3095,8 @@ export const incidentEdges: {
 /**
  * Returns the indices of outgoing edges for a node in a directed graph.
  *
+ * **Details**
+ *
  * Parallel edges and self-loops are returned separately in adjacency order.
  * Throws a `GraphError` for an undirected graph or missing node.
  *
@@ -3124,6 +3128,8 @@ export const outgoingEdges: {
 /**
  * Returns the indices of incoming edges for a node in a directed graph.
  *
+ * **Details**
+ *
  * Parallel edges and self-loops are returned separately in reverse-adjacency
  * order. Throws a `GraphError` for an undirected graph or missing node.
  *
@@ -3154,6 +3160,8 @@ export const incomingEdges: {
 
 /**
  * Returns all edge indices connecting the supplied nodes.
+ *
+ * **Details**
  *
  * Directed graphs only include edges from `source` to `target`; undirected
  * graphs include either stored orientation. Parallel edges are retained.
@@ -3202,6 +3210,8 @@ export const edgesBetween: {
 /**
  * Returns the degree of a node in an undirected graph.
  *
+ * **Details**
+ *
  * Parallel edges count separately and a self-loop contributes two. Throws a
  * `GraphError` for a directed graph or missing node.
  *
@@ -3230,6 +3240,8 @@ export const degree: {
 /**
  * Returns the out-degree of a node in a directed graph.
  *
+ * **Details**
+ *
  * Parallel edges count separately and a self-loop contributes one. Throws a
  * `GraphError` for an undirected graph or missing node.
  *
@@ -3257,6 +3269,8 @@ export const outDegree: {
 
 /**
  * Returns the in-degree of a node in a directed graph.
+ *
+ * **Details**
  *
  * Parallel edges count separately and a self-loop contributes one. Throws a
  * `GraphError` for an undirected graph or missing node.

--- a/packages/effect/src/Match.ts
+++ b/packages/effect/src/Match.ts
@@ -332,10 +332,13 @@ export const type: <I>() => Matcher<I, Types.Without<never>, I, never, never> = 
 /**
  * Creates a reusable matcher from a function that selects the value to match.
  *
+ * **Details**
+ *
  * The compiled matcher keeps the selector's original argument list. Case
  * handlers receive the narrowed selected value followed by those arguments.
  *
- * @example
+ * **Example** (Creating a reusable matcher)
+ *
  * ```ts import.meta.vitest
  * import { Match } from "effect"
  *

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -10087,6 +10087,8 @@ const RedactedRepresentationPayload: Decoder<RedactedRepresentationPayload> = Un
 /**
  * Schema for `Redacted` values, which hide their contents from inspection.
  *
+ * **Details**
+ *
  * Options:
  *
  * - `label`: When provided, the schema will behave as follows:
@@ -11200,6 +11202,8 @@ function graphToArbitrary<N, E, T extends Graph_.Kind>(
 
 /**
  * Creates a schema for immutable directed or undirected Effect graphs.
+ *
+ * **Details**
  *
  * Encoding preserves active node and edge indexes, payloads, endpoints,
  * isolated nodes, self-loops, parallel edges, and stored edge orientation. It
@@ -12371,6 +12375,8 @@ export interface ByteSizeFromNumber extends decodeTo<ByteSize, Number> {
 
 /**
  * Schema that decodes non-negative safe-integer byte counts.
+ *
+ * **Details**
  *
  * Encoding fails when the byte count exceeds `Number.MAX_SAFE_INTEGER`.
  *
@@ -16364,6 +16370,9 @@ export function resolveAnnotationsKey<S extends Constraint>(schema: S): Annotati
   return schema.ast.context?.annotations
 }
 
+/** @internal */
+type AnnotationSchemaConstraint = Constraint
+
 /**
  * The `Annotations` namespace groups all annotation interfaces used to attach
  * metadata to schemas. Annotations control documentation, validation messages,
@@ -16374,10 +16383,9 @@ export function resolveAnnotationsKey<S extends Constraint>(schema: S): Annotati
  * Use {@link resolveAnnotations} to read the annotations attached to a schema at
  * runtime.
  *
+ * @category models
  * @since 4.0.0
  */
-type AnnotationSchemaConstraint = Constraint
-
 export declare namespace Annotations {
   /**
    * This interface is used to define the annotations that can be attached to a
@@ -16577,6 +16585,8 @@ export declare namespace Annotations {
     /**
      * Returns the fallback link used by canonical codec derivations.
      *
+     * **Details**
+     *
      * Transformations may be asynchronous, may fail, and may use optional
      * services, but cannot require services absent from the derived codec type.
      */
@@ -16587,6 +16597,8 @@ export declare namespace Annotations {
      * Returns the link used to derive the declaration's JSON representation, or
      * `undefined` when the declaration is already in canonical JSON form.
      *
+     * **Details**
+     *
      * Transformations follow the execution and service constraints of `toCodec`.
      */
     readonly toCodecJson?:
@@ -16596,6 +16608,8 @@ export declare namespace Annotations {
      * Returns the link used to derive the declaration's StringTree
      * representation, or `undefined` when it is already canonical.
      *
+     * **Details**
+     *
      * Transformations follow the execution and service constraints of `toCodec`.
      */
     readonly toCodecStringTree?:
@@ -16604,6 +16618,8 @@ export declare namespace Annotations {
     /**
      * Returns the link used to derive the declaration's isomorphism
      * representation.
+     *
+     * **Details**
      *
      * Transformations may be asynchronous, may fail, and may use optional
      * services, but cannot require services because the derived `Codec` exposes
@@ -16683,6 +16699,8 @@ export declare namespace Annotations {
     readonly identifier?: string | undefined
     /**
      * Native arbitrary-generation hints for this filter.
+     *
+     * **Details**
      *
      * The value is declarative metadata merged with constraints from the other filters on the node. The filter
      * predicate remains authoritative.

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -567,7 +567,7 @@ export const defaultParseOptions: ParseOptions = {}
  * - `annotations` — key-level annotations (e.g. description of the key
  *   itself).
  *
- * @see {@link optionalKey}
+ * @see `Schema.optionalKey`
  * @see {@link isOptional}
  * @category models
  * @since 4.0.0
@@ -3735,7 +3735,7 @@ export function record(key: AST, value: AST): Objects {
  * Checks `ast.context?.isOptional`. Defaults to `false` when no
  * {@link Context} is set.
  *
- * @see {@link optionalKey}
+ * @see `Schema.optionalKey`
  * @see {@link Context}
  * @category predicates
  * @since 4.0.0

--- a/packages/effect/src/SchemaIssue.ts
+++ b/packages/effect/src/SchemaIssue.ts
@@ -950,6 +950,7 @@ export const defaultLeafHook: LeafHook = (issue): string => {
  *
  * - Returns `string` to override the message, or `undefined` to fall back to
  *   the default formatting.
+ *
  * @see {@link defaultCheckHook} — the built-in implementation
  * @see {@link Filter} — the issue type this hook formats
  *

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -10892,6 +10892,11 @@ export const mkString = <E, R>(self: Stream<string, E, R>): Effect.Effect<string
 /**
  * Concatenates the stream's `Uint8Array` chunks into a single `ArrayBuffer`.
  *
+ * **Gotchas**
+ *
+ * This materializes the full content in memory. The source stream must not
+ * reuse or mutate emitted buffers, which are retained until collection completes.
+ *
  * **Example** (Joining byte chunks into an ArrayBuffer)
  *
  * ```ts import.meta.vitest
@@ -10908,11 +10913,6 @@ export const mkString = <E, R>(self: Stream<string, E, R>): Effect.Effect<string
  * await Effect.runPromise(program) // => [1, 2, 3, 4]
  * ```
  *
- * **Gotchas**
- *
- * This materializes the full content in memory. The source stream must not
- * reuse or mutate emitted buffers, which are retained until collection completes.
- *
  * @category destructors
  * @since 4.0.0
  */
@@ -10921,6 +10921,11 @@ export const mkArrayBuffer = <E, R>(self: Stream<Uint8Array, E, R>): Effect.Effe
 
 /**
  * Concatenates the stream's `Uint8Array` chunks into a single `Uint8Array`.
+ *
+ * **Gotchas**
+ *
+ * This materializes the full content in memory. The source stream must not
+ * reuse or mutate emitted buffers, which are retained until collection completes.
  *
  * **Example** (Joining Uint8Array chunks)
  *
@@ -10935,11 +10940,6 @@ export const mkArrayBuffer = <E, R>(self: Stream<Uint8Array, E, R>): Effect.Effe
  *
  * await Effect.runPromise(program)
  * ```
- *
- * **Gotchas**
- *
- * This materializes the full content in memory. The source stream must not
- * reuse or mutate emitted buffers, which are retained until collection completes.
  *
  * @category destructors
  * @since 4.0.0

--- a/packages/effect/src/TxReentrantLock.ts
+++ b/packages/effect/src/TxReentrantLock.ts
@@ -282,6 +282,20 @@ const releaseReadFor = (self: TxReentrantLock, fiberId: number): Effect.Effect<n
     return newCount
   }).pipe(Effect.tx)
 
+/**
+ * Releases one read lock held by the current fiber.
+ *
+ * **When to use**
+ *
+ * Use to leave a manually acquired read lock.
+ *
+ * **Details**
+ *
+ * Returns the remaining number of read locks held by this fiber.
+ *
+ * @category mutations
+ * @since 2.0.0
+ */
 export const releaseRead = (self: TxReentrantLock): Effect.Effect<number> =>
   Effect.withFiber((fiber) => releaseReadFor(self, fiber.id))
 
@@ -328,6 +342,20 @@ const releaseWriteFor = (self: TxReentrantLock, fiberId: number): Effect.Effect<
     return newCount
   }).pipe(Effect.tx)
 
+/**
+ * Releases one write lock held by the current fiber.
+ *
+ * **When to use**
+ *
+ * Use to leave a manually acquired write lock.
+ *
+ * **Details**
+ *
+ * Returns the remaining number of write locks held by this fiber.
+ *
+ * @category mutations
+ * @since 2.0.0
+ */
 export const releaseWrite = (self: TxReentrantLock): Effect.Effect<number> =>
   Effect.withFiber((fiber) => releaseWriteFor(self, fiber.id))
 

--- a/packages/effect/src/unstable/cli/CliError.ts
+++ b/packages/effect/src/unstable/cli/CliError.ts
@@ -478,6 +478,8 @@ export class UnknownSubcommand extends Schema.TaggedError<UnknownSubcommand>(
 /**
  * Error wrapper for user handler failures in the CLI error channel.
  *
+ * **Details**
+ *
  * `userMessage` can provide safe, user-facing text independently of the
  * underlying cause. When omitted or empty, `message` uses a non-empty string
  * cause or `Error.message`, then falls back to `"An error occurred"`.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -151,6 +151,8 @@ export interface Handlers<State, Output, Input = Terminal.UserInput> {
 /**
  * Defines the symbols used to render built-in prompts.
  *
+ * **Details**
+ *
  * Set a symbol to an empty string to omit both the symbol and its adjacent
  * spacing.
  *
@@ -640,6 +642,8 @@ export const makeTheme = (options?: Partial<Theme>): Theme => ({
 
 /**
  * Context reference for the theme used by built-in prompts.
+ *
+ * **Details**
  *
  * Provide this reference once to theme every prompt in an application. A
  * prompt's `theme` option takes precedence over the context value.

--- a/packages/effect/src/unstable/encoding/Ini.ts
+++ b/packages/effect/src/unstable/encoding/Ini.ts
@@ -82,6 +82,8 @@ const unquote = (input: string | undefined): string => {
 /**
  * Parses an INI document into a null-prototype record.
  *
+ * **Details**
+ *
  * Section names separated by dots become nested records, repeated keys ending
  * in `[]` become arrays, and the scalar values `true`, `false`, and `null` are
  * decoded. Other scalar values remain strings.

--- a/packages/effect/src/unstable/encoding/SchemaBinary.ts
+++ b/packages/effect/src/unstable/encoding/SchemaBinary.ts
@@ -38,6 +38,8 @@ import * as SchemaTransformation from "../../SchemaTransformation.ts"
 /**
  * Selects the wire mode.
  *
+ * **Details**
+ *
  * The default mode supports compatible schema evolution. `fingerprint: true`
  * uses positional layouts and an 8-byte layout hash for smaller frames, but
  * requires peers to use the same schema definition.
@@ -47,6 +49,8 @@ import * as SchemaTransformation from "../../SchemaTransformation.ts"
  */
 export interface Options {
   /**
+   * Uses a compact positional layout with a schema fingerprint.
+   *
    * @since 4.0.0
    */
   readonly fingerprint?: boolean | undefined
@@ -75,6 +79,8 @@ const directFingerprintCodecCache = new WeakMap<Schema.Constraint, toCodec<any>>
 /**
  * Derives a compact binary codec from a schema.
  *
+ * **Details**
+ *
  * The wire layout is compiled from the encoded side of the schema. Each
  * encode/decode handles exactly one frame; use {@link parser} for streams.
  * Derived codecs are memoized by schema identity and wire mode.
@@ -82,7 +88,7 @@ const directFingerprintCodecCache = new WeakMap<Schema.Constraint, toCodec<any>>
  * Encoded results are arena-backed views and may share a larger buffer. Use
  * `bytes.slice()` when independent ownership is required.
  *
- * **Example**
+ * **Example** (Deriving a binary codec)
  *
  * ```ts
  * import { Schema } from "effect"
@@ -257,18 +263,26 @@ function concatFrames(frames: ReadonlyArray<Uint8Array<ArrayBuffer>>): Uint8Arra
  */
 export interface Parser<T> {
   /**
+   * Feeds another chunk into the parser and returns any completed values.
+   *
    * @since 4.0.0
    */
   feed(chunk: Uint8Array): Effect.Effect<ReadonlyArray<T>, Schema.SchemaError>
   /**
+   * Feeds another chunk into the parser synchronously.
+   *
    * @since 4.0.0
    */
   feedSync(chunk: Uint8Array): ReadonlyArray<T>
   /**
+   * Finishes parsing and fails if an incomplete frame remains.
+   *
    * @since 4.0.0
    */
   end: Effect.Effect<void, Schema.SchemaError>
   /**
+   * Finishes parsing synchronously and throws for an incomplete frame.
+   *
    * @since 4.0.0
    */
   endSync(): void
@@ -276,6 +290,8 @@ export interface Parser<T> {
 
 /**
  * Creates a stateful parser for a stream of concatenated frames.
+ *
+ * **Details**
  *
  * Values completed before a failure remain observable. After a failure, the
  * parser rejects further calls. Use `maxFrameSize` to limit buffered frames.
@@ -317,6 +333,8 @@ export interface StreamOptions {
    * string that repeats costs a reference after the first frame that carries
    * it. Frames stop standing alone: they only decode through the parser that
    * saw the frames before them, in order.
+   *
+   * **Gotchas**
    *
    * Both ends have to set it. A schema the binary layer does not fully
    * validate on its own cannot use it, and asking for it throws.
@@ -853,10 +871,15 @@ export const duplex: {
 /**
  * Assigns an explicit wire field id to a struct property.
  *
- * Use this to preserve the wire id across a rename or resolve a hash collision.
+ * **When to use**
+ *
+ * Use to preserve the wire id across a rename or resolve a hash collision.
+ *
+ * **Details**
+ *
  * Valid ids are integers from 1 through 4294967295.
  *
- * **Example**
+ * **Example** (Assigning a wire field id)
  *
  * ```ts
  * import { Schema } from "effect"

--- a/packages/effect/src/unstable/encoding/Toml.ts
+++ b/packages/effect/src/unstable/encoding/Toml.ts
@@ -495,6 +495,8 @@ class TomlParser {
 /**
  * Parses a TOML document into a null-prototype record.
  *
+ * **Details**
+ *
  * Offset date-times are represented by `Date`, matching the package this
  * parser replaces. Local dates and times remain strings.
  *

--- a/packages/effect/src/unstable/encoding/Yaml.ts
+++ b/packages/effect/src/unstable/encoding/Yaml.ts
@@ -517,6 +517,8 @@ class YamlParser {
 /**
  * Parses one YAML document into JavaScript values.
  *
+ * **Details**
+ *
  * The core YAML 1.2 scalar schema is used, so booleans, nulls, and numbers are
  * decoded while date-like values remain strings.
  *

--- a/packages/effect/src/unstable/http/FindMyWay.ts
+++ b/packages/effect/src/unstable/http/FindMyWay.ts
@@ -30,8 +30,10 @@ import * as internal from "./FindMyWay/internal/router.ts"
  */
 
 /**
- * @since 4.0.0
+ * Configuration for router path matching.
+ *
  * @category models
+ * @since 4.0.0
  */
 export interface RouterConfig {
   readonly ignoreTrailingSlash: boolean
@@ -41,14 +43,18 @@ export interface RouterConfig {
 }
 
 /**
- * @since 4.0.0
+ * Route path accepted by the router.
+ *
  * @category models
+ * @since 4.0.0
  */
 export type PathInput = `/${string}` | "*"
 
 /**
- * @since 4.0.0
+ * Mutable router used to register and resolve route handlers.
+ *
  * @category models
+ * @since 4.0.0
  */
 export interface Router<A> {
   readonly on: (method: string | Iterable<string>, path: PathInput, handler: A) => void
@@ -58,8 +64,10 @@ export interface Router<A> {
 }
 
 /**
- * @since 4.0.0
+ * Result of a successful route lookup.
+ *
  * @category models
+ * @since 4.0.0
  */
 export interface FindResult<A> {
   readonly handler: A
@@ -68,7 +76,9 @@ export interface FindResult<A> {
 }
 
 /**
- * @since 4.0.0
+ * Creates an empty mutable router.
+ *
  * @category constructors
+ * @since 4.0.0
  */
 export const make: <A>(options?: Partial<RouterConfig>) => Router<A> = internal.make

--- a/packages/effect/src/unstable/http/HttpMiddleware.ts
+++ b/packages/effect/src/unstable/http/HttpMiddleware.ts
@@ -457,7 +457,7 @@ export const cors = (options?: {
  * explicitly flush each input chunk, so incremental delivery depends on the
  * runtime's implementation.
  *
- * **Security**
+ * **Gotchas**
  *
  * Compression can expose secrets through BREACH-style attacks when one
  * response contains both secret data and attacker-controlled input and an

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -502,6 +502,8 @@ export interface WithHeaders<S extends Schema.Top, H extends Schema.Top> extends
  * The Type of a `WithHeaders` schema: what handlers return and what the
  * client resolves to, constructed via {@link withHeaders}.
  *
+ * **Details**
+ *
  * `body` is the inner success value. For stream success schemas it is the
  * `Stream` itself, so headers are decided before the body starts streaming.
  *
@@ -523,8 +525,12 @@ const withHeadersValueSchema = Schema.declare(isWithHeadersValue)
 /**
  * Wraps a success schema with a response headers schema.
  *
+ * **Details**
+ *
  * Headers accept either a schema or a fields shorthand, mirroring the
  * request-side headers option.
+ *
+ * **Example** (Adding response headers to a success schema)
  *
  * ```ts import.meta.vitest
  * import { Schema } from "effect"
@@ -571,6 +577,8 @@ export function WithHeaders(
 /**
  * Constructs a `WithHeaders` response value from a body and headers.
  *
+ * **Details**
+ *
  * The returned value is branded so servers and clients can detect it exactly,
  * including in mixed success unions. The same shape is used on both sides: a
  * value received from a client can be returned from another handler unchanged.
@@ -592,6 +600,8 @@ export const withHeaders = <A, H>(options: {
 
 /**
  * Returns `true` when a schema is a `WithHeaders` response schema.
+ *
+ * **Example** (Detecting a response headers schema)
  *
  * ```ts import.meta.vitest
  * import { Schema } from "effect"
@@ -662,6 +672,8 @@ export interface encodeToWithHeaders<
  * Streams used as the body schema turn mid-stream transport errors into
  * defects on the client. Stream responses should use {@link WithHeaders},
  * which preserves the body stream's error channel in the generated client.
+ *
+ * **Example** (Encoding an error with headers)
  *
  * ```ts import.meta.vitest
  * import { Schema } from "effect"

--- a/packages/effect/src/unstable/process/ChildProcess.ts
+++ b/packages/effect/src/unstable/process/ChildProcess.ts
@@ -436,6 +436,8 @@ export interface CommandOptions extends KillOptions {
    * If set to `true`, prevents the child process's console or GUI window from
    * becoming visible on Windows.
    *
+   * **Details**
+   *
    * Defaults to `true` unless `detached` is set to `true`. This option has no
    * effect on non-Windows platforms.
    */

--- a/packages/effect/src/unstable/rpc/RpcMessage.ts
+++ b/packages/effect/src/unstable/rpc/RpcMessage.ts
@@ -54,6 +54,8 @@ export const RequestId = (id: string | number): RequestId => id as RequestId
  * The transport-encoded RPC request envelope, including the string request id,
  * RPC tag, encoded payload, headers, and optional trace context.
  *
+ * **Details**
+ *
  * Requests flow in both directions: servers use them for server-originated
  * requests and, with `isNotification` set, for server notifications.
  *

--- a/packages/effect/src/unstable/socket/Socket.ts
+++ b/packages/effect/src/unstable/socket/Socket.ts
@@ -169,6 +169,8 @@ export interface TlsUpgradeOptions {
 /**
  * Constructs a `Socket` from a reader acquisition and a scoped writer.
  *
+ * **Details**
+ *
  * The reader must fail a suspended pull when its acquisition scope closes; see
  * `Socket` for why. A reader that leaves a pull blocked forever will hang any
  * consumer that shuts the socket down by closing that scope.
@@ -191,6 +193,8 @@ const encoder = new TextEncoder()
 /**
  * Acquires the socket's binary `pull`, encoding any string frames as UTF-8
  * bytes.
+ *
+ * **Details**
  *
  * When a pulled batch contains no string frames it is returned as-is, so
  * transports that only emit bytes (TCP) pay no per-chunk cost.
@@ -223,6 +227,8 @@ export const readerBytes = (
 /**
  * Acquires the socket's string `pull`, decoding binary frames with the optional
  * text encoding.
+ *
+ * **Details**
  *
  * The `TextDecoder` is created once per acquisition.
  *
@@ -576,6 +582,8 @@ const toChannelWithReader = <A extends Uint8Array | string, IE>(
  * incoming string frames as UTF-8 bytes and writing outgoing frame batches to
  * the socket.
  *
+ * **Details**
+ *
  * The read side is the socket's pull, so the channel is backpressured
  * end-to-end.
  *
@@ -678,6 +686,8 @@ export const makeChannel = <IE = never>(): Channel.Channel<
 /**
  * Event payload exposed by a WebSocket implementation.
  *
+ * **Details**
+ *
  * The socket adapter only reads `data`, `code`, and `reason`; implementations
  * may expose additional fields.
  *
@@ -693,6 +703,8 @@ export interface WebSocketEvent {
 
 /**
  * The subset of the WebSocket API required by `Socket`.
+ *
+ * **Details**
  *
  * This structural interface is intentionally independent of the DOM
  * `WebSocket` type. Node implementations such as `ws` expose the same
@@ -729,6 +741,8 @@ export interface WebSocketClientOptions {
   /**
    * Headers to include in the opening handshake.
    *
+   * **Details**
+   *
    * This is supported by Node and Bun WebSocket clients. Browser constructors
    * cannot set arbitrary handshake headers and must reject this option.
    */
@@ -737,6 +751,8 @@ export interface WebSocketClientOptions {
 
 /**
  * Options accepted by a `WebSocketConstructor`.
+ *
+ * **Details**
  *
  * Browser-compatible constructors accept a protocol string or list. Node and
  * Bun constructors additionally accept `WebSocketClientOptions`.

--- a/packages/effect/src/unstable/sql/SqlClient.ts
+++ b/packages/effect/src/unstable/sql/SqlClient.ts
@@ -126,6 +126,8 @@ export declare namespace SqlClient {
      * `ROLLBACK`, and the savepoint pair - can be prepared like any other
      * statement.
      *
+     * **Details**
+     *
      * They run on every transaction and never change, so a database that can
      * prepare them stops parsing them again each time. Off by default,
      * because several databases refuse to prepare transaction control at all;

--- a/packages/effect/src/unstable/sql/SqlConnection.ts
+++ b/packages/effect/src/unstable/sql/SqlConnection.ts
@@ -75,6 +75,8 @@ export type Acquirer = Effect<Connection, SqlError, Scope>
  * Lends a connection for the duration of one effect and takes it back on any
  * exit, without the caller opening a scope for it.
  *
+ * **Details**
+ *
  * A client that can do this offers it alongside its `Acquirer`, for statements
  * that finish with the effect that runs them. Long-lived work such as `stream`
  * still goes through the `Acquirer`, whose lease has to outlive the effect

--- a/packages/platform/deno/src/DenoSocket.ts
+++ b/packages/platform/deno/src/DenoSocket.ts
@@ -55,6 +55,8 @@ export class Conn extends Context.Service<Conn, Deno.Conn>()(
 /**
  * Adapts a Deno connection into an Effect socket.
  *
+ * **Details**
+ *
  * Readers over TCP connections can upgrade in place with `Deno.startTls`.
  * Deno exposes only the client side of this transition; Unix connections fail
  * the upgrade with a `SocketUpgradeError`.

--- a/packages/sql/pg/src/PgPool.ts
+++ b/packages/sql/pg/src/PgPool.ts
@@ -90,6 +90,8 @@ export interface PgPool {
    * Lends a session for the duration of one effect and takes it back on any
    * exit, without opening a scope for it.
    *
+   * **Details**
+   *
    * For work that finishes with the effect that runs it. A lease that has to
    * outlive its effect - a stream, a transaction - takes `get` or `reserve`.
    */

--- a/packages/sql/pglite/src/PgliteClient.ts
+++ b/packages/sql/pglite/src/PgliteClient.ts
@@ -71,6 +71,8 @@ export interface PgliteClient extends Client.SqlClient {
   /**
    * Subscribes to a PGlite notification channel.
    *
+   * **Details**
+   *
    * The effect completes after the listener is installed. Notifications are
    * buffered in the returned dequeue, and the subscription remains active
    * until the required scope closes.


### PR DESCRIPTION
## Summary

- move JSDoc prose into canonical sections and order gotchas before examples
- add missing public descriptions and disambiguate invalid cross-references
- give TypeScript examples canonical titled sections

## Validation

- `pnpm jsdocs --check`
- `pnpm lint`

Closes EFF-985
