### PR TITLE
Add Alchemy deployment for the Cloudflare cluster

### DIFF
--- a/.changeset/cloudflare-alchemy-cluster.md
+++ b/.changeset/cloudflare-alchemy-cluster.md
@@ -1,0 +1,22 @@
+---
+"effect": patch
+---
+
+Add Alchemy v2 deployment for the Cloudflare cluster to
+`@effect/platform-cloudflare`.
+
+`AlchemyCloudflareCluster.make` runs inside an Effect-native
+`Cloudflare.Worker` init program: it registers the four cluster Durable
+Object classes on the hosting Worker (Alchemy owns bindings, class exports,
+and SQLite migrations), builds the cluster layer together with the user's
+handler layer into the isolate-lifetime scope, and returns a handle with
+`provide`, `wake`, the four native namespace bindings, and the built
+`context`. The user never declares or re-exports Durable Object classes, and
+Cron Triggers stay user-declared via
+`Cloudflare.Workers.cron(expr, cluster.wake(name))`.
+
+The new `CloudflareDurableObjectPrograms` module exposes the class-independent
+programs behind the bundled Durable Object classes (entity, workflow, durable
+queue, singleton) so a framework that creates its own native classes can run
+the same behavior. The Wrangler path is unchanged and never imports `alchemy`;
+the `alchemy` peer dependency (`>=2.0.0-beta <3`) is optional.

--- a/.changeset/cloudflare-alchemy-cluster.md
+++ b/.changeset/cloudflare-alchemy-cluster.md
@@ -1,5 +1,5 @@
 ---
-"effect": patch
+"@effect/platform-cloudflare": patch
 ---
 
 Add Alchemy v2 deployment for the Cloudflare cluster to

--- a/.github/workflows/alchemy-canary.yml
+++ b/.github/workflows/alchemy-canary.yml
@@ -1,0 +1,29 @@
+name: Alchemy Canary
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+# Typechecks the @effect/platform-cloudflare Alchemy integration (module,
+# example, and typetests) against the latest alchemy@beta instead of the
+# pinned devDependency. Credential-free; run it manually when an alchemy
+# release may have moved the surface the integration depends on.
+jobs:
+  canary:
+    name: Canary
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+      - name: Install latest alchemy@beta
+        run: |
+          pnpm --dir packages/platform/cloudflare add --save-dev --config.minimumReleaseAge=0 alchemy@beta
+          pnpm ls --dir packages/platform/cloudflare alchemy
+      - name: Typecheck module, example, and typetests
+        run: pnpm check
+      - name: Run typetests
+        run: pnpm test-types --target '>=5.9' AlchemyCloudflareCluster

--- a/.github/workflows/alchemy-canary.yml
+++ b/.github/workflows/alchemy-canary.yml
@@ -24,6 +24,6 @@ jobs:
           pnpm --dir packages/platform/cloudflare add --save-dev --config.minimumReleaseAge=0 alchemy@beta
           pnpm ls --dir packages/platform/cloudflare alchemy
       - name: Typecheck module, example, and typetests
-        run: pnpm check
+        run: pnpm exec tsc -b packages/platform/cloudflare/tsconfig.alchemy.json
       - name: Run typetests
         run: pnpm test-types --target '>=5.9' AlchemyCloudflareCluster

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,6 +50,8 @@ jobs:
         with:
           deno-version: v2.9.4
       - run: pnpm check
+      - name: Typecheck Alchemy integration
+        run: pnpm exec tsc -b packages/platform/cloudflare/tsconfig.alchemy.json
       - run: deno check .
       - run: pnpm test-types --target '>=5.9'
 

--- a/packages/platform/cloudflare/README.md
+++ b/packages/platform/cloudflare/README.md
@@ -118,6 +118,94 @@ export default {
 
 `Entity.client` stays the user API. The Worker encodes `(type, id)` into the Durable Object name and resolves the object with `getByName`; an unknown entity type fails at the Worker before any Durable Object is contacted.
 
+## Deploying with Alchemy
+
+[Alchemy](https://alchemy.run) v2 ("Infrastructure as Effects") is the second
+deployment story, behind the optional `alchemy` peer dependency
+(`>=2.0.0-beta <3`). The Wrangler path above never imports it.
+
+```sh
+npm install alchemy@beta
+```
+
+With Alchemy there is no wrangler config, no class re-exports, and no
+initializer: `AlchemyCloudflareCluster.make` runs inside the Effect-native
+`Cloudflare.Worker` init program and registers the four Durable Object
+classes itself, so Alchemy owns the bindings, class exports, and SQLite
+migrations across deploys. Cron Triggers stay user-declared through
+`cluster.wake`:
+
+```ts
+// src/worker.ts
+import * as AlchemyCloudflareCluster from "@effect/platform-cloudflare/AlchemyCloudflareCluster"
+import * as Cloudflare from "alchemy/Cloudflare"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+export default Cloudflare.Worker(
+  "MyApp",
+  {
+    main: import.meta.url
+  },
+  Effect.gen(function*() {
+    const cluster = yield* AlchemyCloudflareCluster.make({
+      entities: [Counter],
+      layer: Layer.mergeAll(CounterLayer, MaintenanceLayer)
+    })
+
+    yield* Cloudflare.Workers.cron("0 * * * *", cluster.wake("hourly-maintenance"))
+
+    return {
+      // routes using Entity.client, etc.
+      fetch: cluster.provide(handler)
+    }
+  }).pipe(Effect.provide(Cloudflare.Workers.CronEventSourceLive))
+)
+```
+
+```ts
+// alchemy.run.ts
+import * as Alchemy from "alchemy"
+import * as Cloudflare from "alchemy/Cloudflare"
+import * as Effect from "effect/Effect"
+import App from "./src/worker.ts"
+
+export default Alchemy.Stack(
+  "MyApp",
+  { providers: Cloudflare.providers(), state: Cloudflare.state() },
+  Effect.gen(function*() {
+    const app = yield* App
+    return { url: app.url }
+  })
+)
+```
+
+`make` builds the cluster layer merged with your handler layer into the
+isolate-lifetime scope and hands back `provide` for the Worker's handlers, so
+do not wrap the init program in `Effect.provide` for cluster services — that
+would tear the layer down when init returns. The handle also exposes the four
+native namespace bindings (`entityNamespace`, `workflowNamespace`,
+`queueNamespace`, `singletonNamespace`) as escape hatches.
+
+A complete runnable example (one entity, one singleton, one Cron Trigger)
+lives at [`examples/alchemy`](./examples/alchemy).
+
+### Manual live smoke
+
+Alchemy tracks the published `effect` release, so CI covers this integration
+with typechecks only (plus the manual `Alchemy Canary` workflow against the
+latest `alchemy@beta`). After changing the integration, run one live smoke
+with Cloudflare credentials configured:
+
+1. `cd packages/platform/cloudflare/examples/alchemy`
+2. `alchemy deploy` — expect the Worker plus the four SQLite-backed Durable
+   Object classes (`ClusterEntity`, `ClusterWorkflow`, `ClusterDurableQueue`,
+   `ClusterSingleton`) and the `0 * * * *` Cron Trigger.
+3. `curl https://<worker-url>/counter-1` twice — expect `1` then `2`.
+4. Trigger the cron (or wait for the top of the hour) and check the Worker
+   logs for `Running hourly maintenance`.
+5. `alchemy destroy` to clean up.
+
 ## Worker routes
 
 The existing `EntityProxy` / `EntityProxyServer` and `WorkflowProxy` /

--- a/packages/platform/cloudflare/README.md
+++ b/packages/platform/cloudflare/README.md
@@ -185,12 +185,17 @@ isolate-lifetime scope and hands back `provide` for the Worker's handlers, so
 do not wrap the init program in `Effect.provide` for cluster services — that
 would tear the layer down when init returns. The handle also exposes the four
 native namespace bindings (`entityNamespace`, `workflowNamespace`,
-`queueNamespace`, `singletonNamespace`) as escape hatches.
+`queueNamespace`, `singletonNamespace`) as escape hatches. These bindings and
+`context` are runtime-only; reading them during plan evaluation throws a
+diagnostic. During planning, `provide` passes through its Effect and `wake`
+does nothing.
 
 A complete runnable example (one entity, one singleton, one Cron Trigger)
 lives at [`examples/alchemy`](./examples/alchemy).
 
 ### Manual live smoke
+
+The live deployment smoke has not yet been verified.
 
 Alchemy tracks the published `effect` release, so CI covers this integration
 with typechecks only (plus the manual `Alchemy Canary` workflow against the

--- a/packages/platform/cloudflare/examples/alchemy/alchemy.run.ts
+++ b/packages/platform/cloudflare/examples/alchemy/alchemy.run.ts
@@ -1,0 +1,17 @@
+/**
+ * The Alchemy stack for `worker.ts`. Run `alchemy deploy` (or `alchemy dev`)
+ * with Cloudflare credentials configured.
+ */
+import * as Alchemy from "alchemy"
+import * as Cloudflare from "alchemy/Cloudflare"
+import * as Effect from "effect/Effect"
+import App from "./worker.ts"
+
+export default Alchemy.Stack(
+  "EffectCluster",
+  { providers: Cloudflare.providers(), state: Cloudflare.state() },
+  Effect.gen(function*() {
+    const app = yield* App
+    return { url: app.url }
+  })
+)

--- a/packages/platform/cloudflare/examples/alchemy/worker.ts
+++ b/packages/platform/cloudflare/examples/alchemy/worker.ts
@@ -1,0 +1,60 @@
+/**
+ * Minimal Alchemy deployment of the Cloudflare cluster: one entity, one
+ * singleton, and one user-declared Cron Trigger.
+ *
+ * Deploy with `alchemy deploy` from this directory (see `alchemy.run.ts`).
+ */
+import * as AlchemyCloudflareCluster from "@effect/platform-cloudflare/AlchemyCloudflareCluster"
+import * as Cloudflare from "alchemy/Cloudflare"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import * as Schema from "effect/Schema"
+import { Entity, Singleton } from "effect/unstable/cluster"
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest"
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse"
+import { Rpc } from "effect/unstable/rpc"
+
+const Counter = Entity.make("Counter", [
+  Rpc.make("Increment", { success: Schema.Number })
+])
+
+// Handlers are built once per entity Durable Object wake; this count is
+// in-memory demo state, not durable storage.
+const CounterLayer = Counter.toLayer(
+  Effect.sync(() => {
+    let count = 0
+    return Counter.of({
+      Increment: () => Effect.sync(() => ++count)
+    })
+  })
+)
+
+const MaintenanceLayer = Singleton.make(
+  "hourly-maintenance",
+  Effect.logInfo("Running hourly maintenance")
+)
+
+export default Cloudflare.Worker(
+  "EffectCluster",
+  {
+    main: import.meta.url
+  },
+  Effect.gen(function*() {
+    const cluster = yield* AlchemyCloudflareCluster.make({
+      entities: [Counter],
+      layer: Layer.mergeAll(CounterLayer, MaintenanceLayer)
+    })
+
+    yield* Cloudflare.Workers.cron("0 * * * *", cluster.wake("hourly-maintenance"))
+
+    return {
+      fetch: cluster.provide(Effect.gen(function*() {
+        const request = yield* HttpServerRequest
+        const makeCounter = yield* Counter.client
+        const counterId = new URL(request.url, "http://cluster").pathname.slice(1) || "default"
+        const value = yield* Effect.orDie(makeCounter(counterId).Increment(void 0))
+        return HttpServerResponse.text(String(value))
+      }))
+    }
+  }).pipe(Effect.provide(Cloudflare.Workers.CronEventSourceLive))
+)

--- a/packages/platform/cloudflare/package.json
+++ b/packages/platform/cloudflare/package.json
@@ -63,12 +63,19 @@
     "check": "tsc -b tsconfig.json"
   },
   "peerDependencies": {
+    "alchemy": ">=2.0.0-beta <3",
     "effect": "workspace:^"
+  },
+  "peerDependenciesMeta": {
+    "alchemy": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@cloudflare/workers-types": "^5.20260822.1"
   },
   "devDependencies": {
+    "alchemy": "2.0.0-beta.76",
     "effect": "workspace:^",
     "esbuild": "^0.25.12",
     "miniflare": "^4.20260730.0"

--- a/packages/platform/cloudflare/src/AlchemyCloudflareCluster.ts
+++ b/packages/platform/cloudflare/src/AlchemyCloudflareCluster.ts
@@ -1,0 +1,308 @@
+/**
+ * Deploys the Cloudflare cluster with Alchemy v2 ("Infrastructure as
+ * Effects").
+ *
+ * `make` runs inside an Effect-native `Cloudflare.Worker` init program. It
+ * registers the four cluster Durable Object classes on the hosting Worker
+ * (bindings, class exports, and SQLite migrations are all owned by Alchemy),
+ * builds the cluster layer together with the user's handler layer into the
+ * isolate-lifetime scope, and returns a handle for wiring the built context
+ * into the Worker's handlers. The user never declares or re-exports Durable
+ * Object classes.
+ *
+ * The Wrangler path (`CloudflareDurableObjects` + `CloudflareCluster.layer`)
+ * never imports this module; `alchemy` is an optional peer dependency needed
+ * only here.
+ *
+ * ```ts
+ * import * as Cloudflare from "alchemy/Cloudflare"
+ * import * as Effect from "effect/Effect"
+ * import * as Layer from "effect/Layer"
+ * import * as AlchemyCloudflareCluster from "@effect/platform-cloudflare/AlchemyCloudflareCluster"
+ *
+ * export default Cloudflare.Worker("MyApp", {
+ *   main: import.meta.url
+ * }, Effect.gen(function*() {
+ *   const cluster = yield* AlchemyCloudflareCluster.make({
+ *     entities: [Counter],
+ *     layer: Layer.mergeAll(CounterLayer, MaintenanceLayer)
+ *   })
+ *
+ *   yield* Cloudflare.Workers.cron("0 * * * *", cluster.wake("hourly-maintenance"))
+ *
+ *   return {
+ *     fetch: cluster.provide(handler)
+ *   }
+ * }))
+ * ```
+ *
+ * @since 4.0.0
+ */
+import * as Cloudflare from "alchemy/Cloudflare"
+import type * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import type * as Layer from "effect/Layer"
+import type * as Entity from "effect/unstable/cluster/Entity"
+import type { Sharding } from "effect/unstable/cluster/Sharding"
+import type { PersistedQueueFactory } from "effect/unstable/persistence/PersistedQueue"
+import type { WorkflowEngine } from "effect/unstable/workflow/WorkflowEngine"
+import {
+  type ClusterDurableQueueProgram,
+  type ClusterEntityProgram,
+  type ClusterSingletonProgram,
+  type ClusterWorkflowProgram,
+  type DurableObjectProgramState,
+  type EntityDeliveryOptions,
+  makeClusterDurableQueueProgram,
+  makeClusterEntityProgram,
+  makeClusterSingletonProgram,
+  makeClusterWorkflowProgram
+} from "./CloudflareDurableObjectPrograms.ts"
+import { inertClusterHandle, makeClusterHandle } from "./internal/alchemyCluster.ts"
+
+/**
+ * The services `make` builds on top of the user layer: the cluster `Sharding`
+ * service, the workflow engine, and the persisted queue factory.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type ClusterServices = Sharding | WorkflowEngine | PersistedQueueFactory
+
+/**
+ * The handle returned by {@link make}.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface Cluster<in R = never> {
+  /**
+   * Attaches the built cluster context to a user Effect, for the Worker's
+   * `fetch` handler and other entrypoints. Only provides the already-built
+   * Context; it does not open a new Scope.
+   */
+  readonly provide: <A, E, R2>(effect: Effect.Effect<A, E, R2>) => Effect.Effect<A, E, Exclude<R2, R>>
+  /**
+   * A handler that wakes the named singleton, for `Cloudflare.Workers.cron`.
+   * The name is the singleton name without the `Singleton/` prefix, and the
+   * returned handler is already context-provided.
+   */
+  readonly wake: (name: string) => () => Effect.Effect<void>
+  /**
+   * The native namespace binding of the cluster entity class.
+   */
+  readonly entityNamespace: DurableObjectNamespace
+  /**
+   * The native namespace binding of the workflow class.
+   */
+  readonly workflowNamespace: DurableObjectNamespace
+  /**
+   * The native namespace binding of the durable queue class.
+   */
+  readonly queueNamespace: DurableObjectNamespace
+  /**
+   * The native namespace binding of the singleton class.
+   */
+  readonly singletonNamespace: DurableObjectNamespace
+  /**
+   * The Context built from the cluster layer and the user layer into the
+   * isolate-lifetime Scope.
+   */
+  readonly context: Context.Context<R>
+}
+
+/**
+ * The entity definitions and handler layer the cluster is built from.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface MakeOptions<ROut, E, RIn> {
+  /**
+   * The complete set of entity definitions the Worker serves, as in
+   * `CloudflareCluster.LayerOptions`.
+   */
+  readonly entities: ReadonlyArray<Entity.Entity<any, any>>
+  /**
+   * The user's merged handler layers: entity handlers, singletons, workflow
+   * handlers, and any services they need.
+   */
+  readonly layer: Layer.Layer<ROut, E, RIn>
+}
+
+const programState = (state: Cloudflare.DurableObjectState["Service"]): DurableObjectProgramState => {
+  const raw = state.raw as unknown as {
+    readonly id: { readonly name?: string | undefined }
+    readonly storage: DurableObjectProgramState["storage"]
+    readonly exports: Record<string, unknown>
+    waitUntil(promise: Promise<unknown>): void
+  }
+  return {
+    id: raw.id,
+    storage: raw.storage,
+    exports: raw.exports,
+    waitUntil: (promise) => raw.waitUntil(promise)
+  }
+}
+
+interface EntityShape {
+  readonly alarm: () => Effect.Effect<void>
+  readonly hold: () => Effect.Effect<void>
+  readonly invoke: ClusterEntityProgram["invoke"]
+  readonly acknowledge: ClusterEntityProgram["acknowledge"]
+  readonly interrupt: ClusterEntityProgram["interrupt"]
+  readonly reset: ClusterEntityProgram["reset"]
+  readonly deliverReply: ClusterEntityProgram["deliverReply"]
+}
+
+const ClusterEntity = Cloudflare.DurableObject<EntityShape>()(
+  "ClusterEntity",
+  Effect.gen(function*() {
+    const state = yield* Cloudflare.DurableObjectState
+    return Effect.gen(function*() {
+      const program = yield* makeClusterEntityProgram(programState(state))
+      return {
+        alarm: () => program.alarm(),
+        hold: () => program.hold(),
+        invoke: (envelopeText: string, discard: boolean, delivery?: EntityDeliveryOptions) =>
+          program.invoke(envelopeText, discard, delivery),
+        acknowledge: program.acknowledge,
+        interrupt: program.interrupt,
+        reset: program.reset,
+        deliverReply: program.deliverReply
+      }
+    })
+  })
+)
+
+interface WorkflowShape {
+  readonly alarm: () => Effect.Effect<void>
+  readonly run: ClusterWorkflowProgram["run"]
+  readonly poll: ClusterWorkflowProgram["poll"]
+  readonly resume: ClusterWorkflowProgram["resume"]
+  readonly interrupt: ClusterWorkflowProgram["interrupt"]
+  readonly interruptUnsafe: ClusterWorkflowProgram["interruptUnsafe"]
+  readonly deferredDone: ClusterWorkflowProgram["deferredDone"]
+  readonly scheduleClock: ClusterWorkflowProgram["scheduleClock"]
+}
+
+const ClusterWorkflow = Cloudflare.DurableObject<WorkflowShape>()(
+  "ClusterWorkflow",
+  Effect.gen(function*() {
+    const state = yield* Cloudflare.DurableObjectState
+    return Effect.gen(function*() {
+      const program = yield* makeClusterWorkflowProgram(programState(state))
+      return {
+        alarm: () => program.alarm(),
+        run: program.run,
+        poll: program.poll,
+        resume: program.resume,
+        interrupt: program.interrupt,
+        interruptUnsafe: program.interruptUnsafe,
+        deferredDone: program.deferredDone,
+        scheduleClock: program.scheduleClock
+      }
+    })
+  })
+)
+
+interface DurableQueueShape {
+  readonly alarm: () => Effect.Effect<void>
+  readonly offer: ClusterDurableQueueProgram["offer"]
+  readonly take: ClusterDurableQueueProgram["take"]
+  readonly cancelTake: ClusterDurableQueueProgram["cancelTake"]
+  readonly complete: ClusterDurableQueueProgram["complete"]
+  readonly fail: ClusterDurableQueueProgram["fail"]
+  readonly release: ClusterDurableQueueProgram["release"]
+  readonly extend: ClusterDurableQueueProgram["extend"]
+}
+
+const ClusterDurableQueue = Cloudflare.DurableObject<DurableQueueShape>()(
+  "ClusterDurableQueue",
+  Effect.gen(function*() {
+    const state = yield* Cloudflare.DurableObjectState
+    return Effect.gen(function*() {
+      const program = yield* makeClusterDurableQueueProgram(programState(state))
+      return {
+        alarm: () => program.alarm(),
+        offer: program.offer,
+        take: program.take,
+        cancelTake: program.cancelTake,
+        complete: program.complete,
+        fail: program.fail,
+        release: program.release,
+        extend: program.extend
+      }
+    })
+  })
+)
+
+interface SingletonShape {
+  readonly alarm: () => Effect.Effect<void>
+  readonly wake: ClusterSingletonProgram["wake"]
+}
+
+const ClusterSingleton = Cloudflare.DurableObject<SingletonShape>()(
+  "ClusterSingleton",
+  Effect.gen(function*() {
+    const state = yield* Cloudflare.DurableObjectState
+    return Effect.gen(function*() {
+      const program = yield* makeClusterSingletonProgram(programState(state))
+      return {
+        alarm: () => program.alarm(),
+        wake: program.wake
+      }
+    })
+  })
+)
+
+const makeUnsafe = Effect.fnUntraced(function*(options: MakeOptions<any, any, any>) {
+  // Register the four Durable Object classes on the hosting Worker. At plan
+  // time this declares the bindings and class exports Alchemy deploys; at
+  // runtime it resolves the same bindings in every isolate, Worker and
+  // Durable Object alike.
+  yield* ClusterEntity
+  yield* ClusterWorkflow
+  yield* ClusterDurableQueue
+  yield* ClusterSingleton
+
+  if (!globalThis.__ALCHEMY_RUNTIME__) {
+    // Plan/deploy evaluation only discovers the declarations above.
+    return inertClusterHandle()
+  }
+
+  const env = yield* Cloudflare.WorkerEnvironment
+  return yield* makeClusterHandle({
+    entities: options.entities,
+    layer: options.layer,
+    env
+  })
+})
+
+/**
+ * Builds the Cloudflare cluster inside an Effect-native Alchemy Worker.
+ *
+ * **Details**
+ *
+ * Always registers all four Durable Object classes (entity, workflow, durable
+ * queue, singleton) on the hosting Worker, so Alchemy owns their bindings and
+ * SQLite migrations across deploys. At runtime it builds
+ * `CloudflareCluster.layer` merged with the user's handler layer into the
+ * isolate-lifetime Scope — the Scope is never closed, so do not wrap the
+ * Worker init program in `Effect.provide(layer)` for cluster services.
+ *
+ * The returned handle exposes `provide` for the Worker's handlers, `wake` for
+ * user-declared Cron Triggers
+ * (`Cloudflare.Workers.cron(expr, cluster.wake("name"))`), and the four
+ * native namespace bindings as escape hatches.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const make: <ROut, E, RIn>(
+  options: MakeOptions<ROut, E, RIn>
+) => Effect.Effect<
+  Cluster<ROut | ClusterServices>,
+  E,
+  Cloudflare.Worker | Exclude<RIn, ClusterServices>
+> = makeUnsafe as any

--- a/packages/platform/cloudflare/src/AlchemyCloudflareCluster.ts
+++ b/packages/platform/cloudflare/src/AlchemyCloudflareCluster.ts
@@ -40,7 +40,6 @@
  * @since 4.0.0
  */
 import * as Cloudflare from "alchemy/Cloudflare"
-import type * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import type * as Layer from "effect/Layer"
 import type * as Entity from "effect/unstable/cluster/Entity"
@@ -55,6 +54,7 @@ import {
   makeClusterWorkflowProgram
 } from "./CloudflareDurableObjectPrograms.ts"
 import { inertClusterHandle, makeClusterHandle } from "./internal/alchemyCluster.ts"
+import type { Cluster } from "./internal/cluster.ts"
 
 /**
  * The services `make` builds on top of the user layer: the cluster `Sharding`
@@ -65,53 +65,21 @@ import { inertClusterHandle, makeClusterHandle } from "./internal/alchemyCluster
  */
 export type ClusterServices = Sharding | WorkflowEngine | PersistedQueueFactory
 
-/**
- * The handle returned by {@link make}.
- *
- * **Gotchas**
- *
- * Namespace bindings and `context` are available only in the deployed runtime.
- * Reading them during plan evaluation throws a diagnostic; `provide` and
- * `wake` remain inert during planning.
- *
- * @category models
- * @since 4.0.0
- */
-export interface Cluster<in R = never> {
+export type {
   /**
-   * Attaches the built cluster context to a user Effect, for the Worker's
-   * `fetch` handler and other entrypoints. Only provides the already-built
-   * Context; it does not open a new Scope.
+   * The handle returned by {@link make}.
+   *
+   * **Gotchas**
+   *
+   * Namespace bindings and `context` are available only in the deployed runtime.
+   * Reading them during plan evaluation throws a diagnostic; `provide` and
+   * `wake` remain inert during planning.
+   *
+   * @category models
+   * @since 4.0.0
    */
-  readonly provide: <A, E, R2>(effect: Effect.Effect<A, E, R2>) => Effect.Effect<A, E, Exclude<R2, R>>
-  /**
-   * A handler that wakes the named singleton, for `Cloudflare.Workers.cron`.
-   * The name is the singleton name without the `Singleton/` prefix, and the
-   * returned handler is already context-provided.
-   */
-  readonly wake: (name: string) => () => Effect.Effect<void>
-  /**
-   * The native namespace binding of the cluster entity class.
-   */
-  readonly entityNamespace: DurableObjectNamespace
-  /**
-   * The native namespace binding of the workflow class.
-   */
-  readonly workflowNamespace: DurableObjectNamespace
-  /**
-   * The native namespace binding of the durable queue class.
-   */
-  readonly queueNamespace: DurableObjectNamespace
-  /**
-   * The native namespace binding of the singleton class.
-   */
-  readonly singletonNamespace: DurableObjectNamespace
-  /**
-   * The Context built from the cluster layer and the user layer into the
-   * isolate-lifetime Scope.
-   */
-  readonly context: Context.Context<R>
-}
+  Cluster
+} from "./internal/cluster.ts"
 
 /**
  * The entity definitions and handler layer the cluster is built from.

--- a/packages/platform/cloudflare/src/AlchemyCloudflareCluster.ts
+++ b/packages/platform/cloudflare/src/AlchemyCloudflareCluster.ts
@@ -14,16 +14,17 @@
  * never imports this module; `alchemy` is an optional peer dependency needed
  * only here.
  *
+ * **Example** (Declaring a cluster)
+ *
  * ```ts
  * import * as Cloudflare from "alchemy/Cloudflare"
- * import * as Effect from "effect/Effect"
- * import * as Layer from "effect/Layer"
- * import * as AlchemyCloudflareCluster from "@effect/platform-cloudflare/AlchemyCloudflareCluster"
+ * import { Effect, Layer } from "effect"
+ * import { make } from "@effect/platform-cloudflare/AlchemyCloudflareCluster"
  *
  * export default Cloudflare.Worker("MyApp", {
  *   main: import.meta.url
  * }, Effect.gen(function*() {
- *   const cluster = yield* AlchemyCloudflareCluster.make({
+ *   const cluster = yield* make({
  *     entities: [Counter],
  *     layer: Layer.mergeAll(CounterLayer, MaintenanceLayer)
  *   })
@@ -71,6 +72,12 @@ export type ClusterServices = Sharding | WorkflowEngine | PersistedQueueFactory
 
 /**
  * The handle returned by {@link make}.
+ *
+ * **Gotchas**
+ *
+ * Namespace bindings and `context` are available only in the deployed runtime.
+ * Reading them during plan evaluation throws a diagnostic; `provide` and
+ * `wake` remain inert during planning.
  *
  * @category models
  * @since 4.0.0
@@ -155,6 +162,8 @@ interface EntityShape {
   readonly deliverReply: ClusterEntityProgram["deliverReply"]
 }
 
+// These classes intentionally omit fetch: Alchemy returns its default 404.
+// Cluster RPCs use native bindings; Wrangler classes keep their fetch rejection.
 const ClusterEntity = Cloudflare.DurableObject<EntityShape>()(
   "ClusterEntity",
   Effect.gen(function*() {

--- a/packages/platform/cloudflare/src/AlchemyCloudflareCluster.ts
+++ b/packages/platform/cloudflare/src/AlchemyCloudflareCluster.ts
@@ -48,12 +48,7 @@ import type { Sharding } from "effect/unstable/cluster/Sharding"
 import type { PersistedQueueFactory } from "effect/unstable/persistence/PersistedQueue"
 import type { WorkflowEngine } from "effect/unstable/workflow/WorkflowEngine"
 import {
-  type ClusterDurableQueueProgram,
-  type ClusterEntityProgram,
-  type ClusterSingletonProgram,
-  type ClusterWorkflowProgram,
   type DurableObjectProgramState,
-  type EntityDeliveryOptions,
   makeClusterDurableQueueProgram,
   makeClusterEntityProgram,
   makeClusterSingletonProgram,
@@ -137,133 +132,26 @@ export interface MakeOptions<ROut, E, RIn> {
   readonly layer: Layer.Layer<ROut, E, RIn>
 }
 
-const programState = (state: Cloudflare.DurableObjectState["Service"]): DurableObjectProgramState => {
-  const raw = state.raw as unknown as {
-    readonly id: { readonly name?: string | undefined }
-    readonly storage: DurableObjectProgramState["storage"]
-    readonly exports: Record<string, unknown>
-    waitUntil(promise: Promise<unknown>): void
-  }
-  return {
-    id: raw.id,
-    storage: raw.storage,
-    exports: raw.exports,
-    waitUntil: (promise) => raw.waitUntil(promise)
-  }
-}
+// One alchemy Durable Object class per cluster program. The outer effect
+// resolves the instance state; the inner effect runs per activation, under
+// alchemy's blockConcurrencyWhile, once the shared isolate init (and so the
+// user's handler registrations) has completed. The program handle is the RPC
+// shape: every method returns an Effect and `alarm` matches alchemy's hook.
+// `fetch` is omitted on purpose: cluster RPCs use the native bindings, so
+// alchemy's default 404 stands in for the Wrangler classes' rejection.
+const durableObject = <Shape extends Record<string, (...args: Array<any>) => Effect.Effect<any>>>(
+  className: string,
+  program: (state: DurableObjectProgramState) => Effect.Effect<Shape>
+) =>
+  Cloudflare.DurableObject<Shape>()(
+    className,
+    Effect.map(Cloudflare.DurableObjectState, (state) => program(state.raw as DurableObjectProgramState))
+  )
 
-interface EntityShape {
-  readonly alarm: () => Effect.Effect<void>
-  readonly hold: () => Effect.Effect<void>
-  readonly invoke: ClusterEntityProgram["invoke"]
-  readonly acknowledge: ClusterEntityProgram["acknowledge"]
-  readonly interrupt: ClusterEntityProgram["interrupt"]
-  readonly reset: ClusterEntityProgram["reset"]
-  readonly deliverReply: ClusterEntityProgram["deliverReply"]
-}
-
-// These classes intentionally omit fetch: Alchemy returns its default 404.
-// Cluster RPCs use native bindings; Wrangler classes keep their fetch rejection.
-const ClusterEntity = Cloudflare.DurableObject<EntityShape>()(
-  "ClusterEntity",
-  Effect.gen(function*() {
-    const state = yield* Cloudflare.DurableObjectState
-    return Effect.gen(function*() {
-      const program = yield* makeClusterEntityProgram(programState(state))
-      return {
-        alarm: () => program.alarm(),
-        hold: () => program.hold(),
-        invoke: (envelopeText: string, discard: boolean, delivery?: EntityDeliveryOptions) =>
-          program.invoke(envelopeText, discard, delivery),
-        acknowledge: program.acknowledge,
-        interrupt: program.interrupt,
-        reset: program.reset,
-        deliverReply: program.deliverReply
-      }
-    })
-  })
-)
-
-interface WorkflowShape {
-  readonly alarm: () => Effect.Effect<void>
-  readonly run: ClusterWorkflowProgram["run"]
-  readonly poll: ClusterWorkflowProgram["poll"]
-  readonly resume: ClusterWorkflowProgram["resume"]
-  readonly interrupt: ClusterWorkflowProgram["interrupt"]
-  readonly interruptUnsafe: ClusterWorkflowProgram["interruptUnsafe"]
-  readonly deferredDone: ClusterWorkflowProgram["deferredDone"]
-  readonly scheduleClock: ClusterWorkflowProgram["scheduleClock"]
-}
-
-const ClusterWorkflow = Cloudflare.DurableObject<WorkflowShape>()(
-  "ClusterWorkflow",
-  Effect.gen(function*() {
-    const state = yield* Cloudflare.DurableObjectState
-    return Effect.gen(function*() {
-      const program = yield* makeClusterWorkflowProgram(programState(state))
-      return {
-        alarm: () => program.alarm(),
-        run: program.run,
-        poll: program.poll,
-        resume: program.resume,
-        interrupt: program.interrupt,
-        interruptUnsafe: program.interruptUnsafe,
-        deferredDone: program.deferredDone,
-        scheduleClock: program.scheduleClock
-      }
-    })
-  })
-)
-
-interface DurableQueueShape {
-  readonly alarm: () => Effect.Effect<void>
-  readonly offer: ClusterDurableQueueProgram["offer"]
-  readonly take: ClusterDurableQueueProgram["take"]
-  readonly cancelTake: ClusterDurableQueueProgram["cancelTake"]
-  readonly complete: ClusterDurableQueueProgram["complete"]
-  readonly fail: ClusterDurableQueueProgram["fail"]
-  readonly release: ClusterDurableQueueProgram["release"]
-  readonly extend: ClusterDurableQueueProgram["extend"]
-}
-
-const ClusterDurableQueue = Cloudflare.DurableObject<DurableQueueShape>()(
-  "ClusterDurableQueue",
-  Effect.gen(function*() {
-    const state = yield* Cloudflare.DurableObjectState
-    return Effect.gen(function*() {
-      const program = yield* makeClusterDurableQueueProgram(programState(state))
-      return {
-        alarm: () => program.alarm(),
-        offer: program.offer,
-        take: program.take,
-        cancelTake: program.cancelTake,
-        complete: program.complete,
-        fail: program.fail,
-        release: program.release,
-        extend: program.extend
-      }
-    })
-  })
-)
-
-interface SingletonShape {
-  readonly alarm: () => Effect.Effect<void>
-  readonly wake: ClusterSingletonProgram["wake"]
-}
-
-const ClusterSingleton = Cloudflare.DurableObject<SingletonShape>()(
-  "ClusterSingleton",
-  Effect.gen(function*() {
-    const state = yield* Cloudflare.DurableObjectState
-    return Effect.gen(function*() {
-      const program = yield* makeClusterSingletonProgram(programState(state))
-      return {
-        alarm: () => program.alarm(),
-        wake: program.wake
-      }
-    })
-  })
-)
+const ClusterEntity = durableObject("ClusterEntity", makeClusterEntityProgram)
+const ClusterWorkflow = durableObject("ClusterWorkflow", makeClusterWorkflowProgram)
+const ClusterDurableQueue = durableObject("ClusterDurableQueue", makeClusterDurableQueueProgram)
+const ClusterSingleton = durableObject("ClusterSingleton", makeClusterSingletonProgram)
 
 const makeUnsafe = Effect.fnUntraced(function*(options: MakeOptions<any, any, any>) {
   // Register the four Durable Object classes on the hosting Worker. At plan

--- a/packages/platform/cloudflare/src/AlchemyCloudflareCluster.ts
+++ b/packages/platform/cloudflare/src/AlchemyCloudflareCluster.ts
@@ -34,7 +34,7 @@
  *   return {
  *     fetch: cluster.provide(handler)
  *   }
- * }))
+ * }).pipe(Effect.provide(Cloudflare.Workers.CronEventSourceLive)))
  * ```
  *
  * @since 4.0.0

--- a/packages/platform/cloudflare/src/CloudflareDurableObjectPrograms.ts
+++ b/packages/platform/cloudflare/src/CloudflareDurableObjectPrograms.ts
@@ -1,0 +1,438 @@
+/**
+ * Class-independent Durable Object programs behind the Cloudflare cluster
+ * integration.
+ *
+ * The bundled classes in `CloudflareDurableObjects` bind these behaviors to
+ * `cloudflare:workers` base classes for the Wrangler path. A framework that
+ * creates its own Durable Object classes (for example the Alchemy integration
+ * in `AlchemyCloudflareCluster`) runs these programs instead and forwards its
+ * class methods to the returned handles.
+ *
+ * @since 4.0.0
+ */
+import type { DurableObjectStorage } from "@cloudflare/workers-types"
+import * as Effect from "effect/Effect"
+import * as ClusterMetrics from "effect/unstable/cluster/ClusterMetrics"
+import * as EntityAddress from "effect/unstable/cluster/EntityAddress"
+import * as EntityId from "effect/unstable/cluster/EntityId"
+import * as EntityType from "effect/unstable/cluster/EntityType"
+import * as ShardId from "effect/unstable/cluster/ShardId"
+import { decodeName, encodeName } from "./internal/clusterName.ts"
+import { makeEntityKeepAlive } from "./internal/entityKeepAlive.ts"
+import { makeEntityManager } from "./internal/entityRuntime.ts"
+import { armAlarm, earliestDeliverAt, ensureEntityStorage } from "./internal/entityStorage.ts"
+import { makeQueueRuntime } from "./internal/queueRuntime.ts"
+import { earliestLeaseExpiry } from "./internal/queueStorage.ts"
+import { getSingletonRegistration } from "./internal/singletonRegistry.ts"
+import { makeSingletonRuntime } from "./internal/singletonRuntime.ts"
+import { ensureSingletonStorage, loadSingletonState, rememberSingletonName } from "./internal/singletonStorage.ts"
+import type { WorkflowStub } from "./internal/workflowRegistry.ts"
+import { makeWorkflowRuntime } from "./internal/workflowRuntime.ts"
+import { earliestClockWakeUp, ensureWorkflowStorage, loadExecution } from "./internal/workflowStorage.ts"
+
+/**
+ * The native Durable Object capabilities a cluster program is built from.
+ *
+ * **Details**
+ *
+ * A `DurableObjectState` from `cloudflare:workers` satisfies this shape
+ * directly. The program only reads the object name, opens SQLite storage,
+ * resolves same-Worker class exports, and extends the current event with
+ * `waitUntil`.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface DurableObjectProgramState {
+  readonly id: { readonly name?: string | undefined }
+  readonly storage: DurableObjectStorage
+  readonly exports: Record<string, unknown>
+  readonly waitUntil: (promise: Promise<unknown>) => void
+}
+
+const exportedNamespace = <Stub>(
+  state: DurableObjectProgramState,
+  className: string
+): { readonly getByName: (name: string) => Stub } | undefined =>
+  state.exports[className] as
+    | { readonly getByName: (name: string) => Stub }
+    | undefined
+
+/**
+ * Delivery options accepted by the cluster entity transport program.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface EntityDeliveryOptions {
+  readonly deliverAt?: number | undefined
+  readonly primaryKey?: string | null | undefined
+  readonly replyTo?: string | undefined
+}
+
+/**
+ * Result returned by the cluster entity transport program.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type EntityInvokeResult = {
+  readonly _tag: "Success"
+  readonly requestId: string
+  readonly replies: ReadonlyArray<string>
+} | {
+  readonly _tag: "MailboxFull"
+} | {
+  readonly _tag: "EncodedMessageTooLarge"
+} | {
+  readonly _tag: "AskDeduplicatedToTell"
+}
+
+/**
+ * Effect-valued program for one cluster entity Durable Object instance.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ClusterEntityProgram {
+  readonly alarm: () => Effect.Effect<void>
+  readonly hold: () => Effect.Effect<void>
+  readonly invoke: (
+    envelopeText: string,
+    discard: boolean,
+    delivery?: EntityDeliveryOptions
+  ) => Effect.Effect<EntityInvokeResult>
+  readonly acknowledge: (requestId: string, replyId: string) => Effect.Effect<ReadonlyArray<string>>
+  readonly interrupt: (storageRequestId: string, clientRequestId?: string) => Effect.Effect<void>
+  readonly reset: (requestId: string) => Effect.Effect<void>
+  readonly deliverReply: (requestId: string, reply: string) => Effect.Effect<boolean>
+}
+
+/**
+ * Creates the program behind one cluster entity Durable Object.
+ *
+ * **When to use**
+ *
+ * Use when a framework creates the native Durable Object class itself and
+ * needs the entity mailbox, alarm, and same-Worker RPC behavior without
+ * extending the bundled `ClusterEntity` class.
+ *
+ * **Details**
+ *
+ * Run the returned Effect once per Durable Object activation, after the
+ * Worker application (the entity handler registrations) is initialized. It
+ * ensures the mailbox tables and re-arms the single alarm from the earliest
+ * pending `deliver_at` before returning the handler object. The host class
+ * must be exported from the Worker entry as `ClusterEntity`; keep-alive and
+ * reply delivery resolve that export through `state.exports`.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const makeClusterEntityProgram = Effect.fnUntraced(function*(state: DurableObjectProgramState) {
+  const entityName = state.id.name ?? ""
+  const name = decodeName(entityName)
+  if (name === undefined) {
+    return yield* Effect.die(new Error("ClusterEntity requires a canonical entity Durable Object name"))
+  }
+  const keepAlive = makeEntityKeepAlive(() => {
+    const namespace = exportedNamespace<{ readonly hold: () => Promise<void> }>(state, "ClusterEntity")
+    if (namespace === undefined) {
+      return Promise.reject(
+        new Error("CloudflareCluster: ClusterEntity export is unavailable for keep-alive")
+      )
+    }
+    return namespace.getByName(entityName).hold()
+  })
+  const manager = makeEntityManager({
+    storage: state.storage,
+    address: EntityAddress.make({
+      shardId: ShardId.make("default", 1),
+      entityType: EntityType.make(name.type),
+      entityId: EntityId.make(name.id)
+    }),
+    entityName,
+    keepAlive,
+    waitUntil: (effect) => state.waitUntil(Effect.runPromise(effect)),
+    getNamespace: () =>
+      exportedNamespace<{
+        readonly deliverReply: (requestId: string, reply: string) => Promise<boolean>
+      }>(state, "ClusterEntity")
+  })
+  const sql = state.storage.sql
+  ensureEntityStorage(sql)
+  const deliverAt = earliestDeliverAt(sql)
+  if (deliverAt !== undefined) {
+    yield* armAlarm(state.storage, deliverAt)
+  }
+  const program: ClusterEntityProgram = {
+    alarm: () => manager.alarm,
+    hold: () => keepAlive.await,
+    invoke: (envelopeText, discard, delivery) => manager.invoke(envelopeText, discard, delivery),
+    acknowledge: manager.acknowledge,
+    interrupt: manager.interrupt,
+    reset: manager.reset,
+    deliverReply: manager.deliverReply
+  }
+  return program
+})
+
+/**
+ * Execution options accepted by the workflow program's `run`.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ClusterWorkflowRunOptions {
+  readonly discard: boolean
+  readonly parent?: { readonly workflowName: string; readonly executionId: string } | undefined
+}
+
+/**
+ * Effect-valued program for one workflow execution Durable Object.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ClusterWorkflowProgram {
+  readonly run: (payload: string, options: ClusterWorkflowRunOptions) => Effect.Effect<string>
+  readonly poll: () => Effect.Effect<string | undefined>
+  readonly resume: () => Effect.Effect<void>
+  readonly interrupt: () => Effect.Effect<void>
+  readonly interruptUnsafe: () => Effect.Effect<void>
+  readonly deferredDone: (name: string, exit: string) => Effect.Effect<void>
+  readonly scheduleClock: (name: string, deferredName: string, wakeUp: number) => Effect.Effect<void>
+  readonly alarm: () => Effect.Effect<void>
+}
+
+/**
+ * Creates the program behind one workflow execution Durable Object.
+ *
+ * **When to use**
+ *
+ * Use when a framework creates the native Durable Object class itself and
+ * needs the Effect Workflow journal, alarm, and same-Worker RPC behavior
+ * without extending the bundled `ClusterWorkflow` class.
+ *
+ * **Details**
+ *
+ * Run the returned Effect once per Durable Object activation, after the
+ * Worker application (the workflow handler registrations) is initialized. It
+ * ensures the workflow tables and re-arms the single alarm from the earliest
+ * pending clock before returning the handler object. The host class must be
+ * exported from the Worker entry as `ClusterWorkflow`; child and parent
+ * workflow delivery resolves that export through `state.exports`.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const makeClusterWorkflowProgram = Effect.fnUntraced(function*(state: DurableObjectProgramState) {
+  const sql = state.storage.sql
+  ensureWorkflowStorage(sql)
+  let name: string | undefined
+  if (state.id.name !== undefined) {
+    if (decodeName(state.id.name) === undefined) {
+      return yield* Effect.die(new Error("ClusterWorkflow requires a canonical workflow Durable Object name"))
+    }
+    name = state.id.name
+  } else {
+    // An alarm wake carries no `id.name`; recover it from the stored
+    // execution so due clocks still fire after eviction.
+    const stored = loadExecution(sql)
+    name = stored === undefined ? undefined : encodeName(stored.workflowName, stored.executionId)
+  }
+  let runtime: ReturnType<typeof makeWorkflowRuntime> | undefined
+  const getRuntime = () => {
+    if (runtime !== undefined) return runtime
+    if (name === undefined) {
+      throw new Error("ClusterWorkflow requires a canonical workflow Durable Object name")
+    }
+    runtime = makeWorkflowRuntime({
+      name,
+      sql,
+      alarm: state.storage,
+      now: () => Date.now(),
+      waitUntil: (promise) => state.waitUntil(promise),
+      getStub: (stubName) => {
+        const namespace = exportedNamespace<WorkflowStub>(state, "ClusterWorkflow")
+        if (namespace === undefined) {
+          throw new Error("CloudflareCluster: ClusterWorkflow export is unavailable for workflow delivery")
+        }
+        return namespace.getByName(stubName)
+      }
+    })
+    return runtime
+  }
+  const wakeUp = earliestClockWakeUp(sql)
+  if (wakeUp !== undefined) {
+    yield* armAlarm(state.storage, wakeUp)
+  }
+  const program: ClusterWorkflowProgram = {
+    run: (payload, options) => Effect.promise(() => getRuntime().run(payload, options)),
+    poll: () => Effect.promise(() => getRuntime().poll()),
+    resume: () => Effect.promise(() => getRuntime().resume()),
+    interrupt: () => Effect.promise(() => getRuntime().interrupt()),
+    interruptUnsafe: () => Effect.promise(() => getRuntime().interruptUnsafe()),
+    deferredDone: (deferredName, exit) => Effect.promise(() => getRuntime().deferredDone(deferredName, exit)),
+    scheduleClock: (clockName, deferredName, wakeAt) =>
+      Effect.promise(() => getRuntime().scheduleClock(clockName, deferredName, wakeAt)),
+    // No stored execution means no clock could have armed this alarm.
+    alarm: () => name === undefined ? Effect.void : Effect.promise(() => getRuntime().runAlarm())
+  }
+  return program
+})
+
+/**
+ * Item leased from the durable queue program.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface DurableQueueItem {
+  readonly id: string
+  readonly element: string
+  readonly attempts: number
+}
+
+/**
+ * Effect-valued program for one durable queue Durable Object.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ClusterDurableQueueProgram {
+  readonly offer: (id: string, element: string) => Effect.Effect<void>
+  readonly take: (takerId: string, maxAttempts: number, leaseMillis: number) => Effect.Effect<DurableQueueItem>
+  readonly cancelTake: (takerId: string) => Effect.Effect<void>
+  readonly complete: (id: string) => Effect.Effect<void>
+  readonly fail: (id: string, lastFailure: string) => Effect.Effect<void>
+  readonly release: (id: string) => Effect.Effect<void>
+  readonly extend: (id: string, leaseMillis: number) => Effect.Effect<void>
+  readonly alarm: () => Effect.Effect<void>
+}
+
+/**
+ * Creates the program behind one durable queue Durable Object.
+ *
+ * **When to use**
+ *
+ * Use when a framework creates the native Durable Object class itself and
+ * needs the queue persistence, leasing, and alarm behavior without extending
+ * the bundled `ClusterDurableQueue` class.
+ *
+ * **Details**
+ *
+ * Run the returned Effect once per Durable Object activation. It ensures the
+ * queue table and re-arms the single alarm from the earliest pending lease
+ * expiry before returning the handler object.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const makeClusterDurableQueueProgram = Effect.fnUntraced(function*(state: DurableObjectProgramState) {
+  if (state.id.name !== undefined && decodeName(state.id.name) === undefined) {
+    return yield* Effect.die(new Error("ClusterDurableQueue requires a canonical queue Durable Object name"))
+  }
+  const runtime = makeQueueRuntime({
+    sql: state.storage.sql,
+    alarm: state.storage,
+    now: () => Date.now()
+  })
+  const expiry = earliestLeaseExpiry(state.storage.sql)
+  if (expiry !== undefined) {
+    yield* armAlarm(state.storage, expiry)
+  }
+  const program: ClusterDurableQueueProgram = {
+    offer: (id, element) => Effect.promise(() => runtime.offer(id, element)),
+    take: (takerId, maxAttempts, leaseMillis) => Effect.promise(() => runtime.take(takerId, maxAttempts, leaseMillis)),
+    cancelTake: (takerId) => Effect.promise(() => runtime.cancelTake(takerId)),
+    complete: (id) => Effect.promise(() => runtime.complete(id)),
+    fail: (id, lastFailure) => Effect.promise(() => runtime.fail(id, lastFailure)),
+    release: (id) => Effect.promise(() => runtime.release(id)),
+    extend: (id, leaseMillis) => Effect.promise(() => runtime.extend(id, leaseMillis)),
+    alarm: () => Effect.promise(() => runtime.runAlarm())
+  }
+  return program
+})
+
+/**
+ * Effect-valued program for one cluster singleton Durable Object.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ClusterSingletonProgram {
+  readonly wake: () => Effect.Effect<void>
+  readonly alarm: () => Effect.Effect<void>
+}
+
+/**
+ * Creates the program behind one cluster singleton Durable Object.
+ *
+ * **When to use**
+ *
+ * Use when a framework creates the native Durable Object class itself and
+ * needs the singleton wake and watchdog behavior without extending the
+ * bundled `ClusterSingleton` class.
+ *
+ * **Details**
+ *
+ * Run the returned Effect once per Durable Object activation, after the
+ * Worker application (the singleton registrations) is initialized. It ensures
+ * the singleton state table and re-arms the watchdog alarm for a wake
+ * interrupted by isolate loss before returning the handler object.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const makeClusterSingletonProgram = Effect.fnUntraced(function*(state: DurableObjectProgramState) {
+  const sql = state.storage.sql
+  ensureSingletonStorage(sql)
+  if (state.id.name !== undefined) {
+    if (!state.id.name.startsWith("Singleton/")) {
+      return yield* Effect.die(new Error("ClusterSingleton requires a Singleton/<name> Durable Object name"))
+    }
+    rememberSingletonName(sql, state.id.name)
+  }
+  const stored = loadSingletonState(sql)
+  const name = state.id.name ?? stored.name
+  let runtime: ReturnType<typeof makeSingletonRuntime> | undefined
+  const getRuntime = () => {
+    if (runtime !== undefined) return runtime
+    if (name === undefined) {
+      throw new Error("ClusterSingleton requires a Singleton/<name> Durable Object name")
+    }
+    const singletonName = name.slice("Singleton/".length)
+    const registration = getSingletonRegistration(singletonName)
+    if (registration === undefined) {
+      throw new Error(`CloudflareCluster: no singleton registered under the name "${singletonName}"`)
+    }
+    const run = Effect.sync(() => {
+      ClusterMetrics.singletons.modifyUnsafe(BigInt(1), registration.context)
+    }).pipe(
+      Effect.andThen(registration.run),
+      Effect.scoped,
+      Effect.ensuring(Effect.sync(() => {
+        ClusterMetrics.singletons.modifyUnsafe(BigInt(-1), registration.context)
+      })),
+      Effect.provideContext(registration.context),
+      Effect.orDie
+    )
+    runtime = makeSingletonRuntime({
+      sql,
+      alarm: state.storage,
+      now: () => Date.now(),
+      run
+    })
+    return runtime
+  }
+  if (stored.wakeAt !== undefined) {
+    yield* armAlarm(state.storage, stored.wakeAt)
+  }
+  const program: ClusterSingletonProgram = {
+    wake: () => Effect.promise(() => getRuntime().wake()),
+    alarm: () =>
+      loadSingletonState(sql).wakeAt === undefined ? Effect.void : Effect.promise(() => getRuntime().runAlarm())
+  }
+  return program
+})

--- a/packages/platform/cloudflare/src/CloudflareDurableObjectPrograms.ts
+++ b/packages/platform/cloudflare/src/CloudflareDurableObjectPrograms.ts
@@ -11,6 +11,7 @@
  * @since 4.0.0
  */
 import type { DurableObjectStorage } from "@cloudflare/workers-types"
+import * as Clock from "effect/Clock"
 import * as Effect from "effect/Effect"
 import * as ClusterMetrics from "effect/unstable/cluster/ClusterMetrics"
 import * as EntityAddress from "effect/unstable/cluster/EntityAddress"
@@ -233,6 +234,7 @@ export type ClusterWorkflowProgram = {
  * @since 4.0.0
  */
 export const makeClusterWorkflowProgram = Effect.fnUntraced(function*(state: DurableObjectProgramState) {
+  const clock = yield* Clock.Clock
   const sql = state.storage.sql
   ensureWorkflowStorage(sql)
   let name: string | undefined
@@ -257,7 +259,7 @@ export const makeClusterWorkflowProgram = Effect.fnUntraced(function*(state: Dur
       name,
       sql,
       alarm: state.storage,
-      now: () => Date.now(),
+      now: () => clock.currentTimeMillisUnsafe(),
       waitUntil: (promise) => state.waitUntil(promise),
       getStub: (stubName) => {
         const namespace = exportedNamespace<WorkflowStub>(state, "ClusterWorkflow")
@@ -336,13 +338,14 @@ export type ClusterDurableQueueProgram = {
  * @since 4.0.0
  */
 export const makeClusterDurableQueueProgram = Effect.fnUntraced(function*(state: DurableObjectProgramState) {
+  const clock = yield* Clock.Clock
   if (state.id.name !== undefined && decodeName(state.id.name) === undefined) {
     return yield* Effect.die(new Error("ClusterDurableQueue requires a canonical queue Durable Object name"))
   }
   const runtime = makeQueueRuntime({
     sql: state.storage.sql,
     alarm: state.storage,
-    now: () => Date.now()
+    now: () => clock.currentTimeMillisUnsafe()
   })
   const expiry = earliestLeaseExpiry(state.storage.sql)
   if (expiry !== undefined) {
@@ -392,6 +395,7 @@ export type ClusterSingletonProgram = {
  * @since 4.0.0
  */
 export const makeClusterSingletonProgram = Effect.fnUntraced(function*(state: DurableObjectProgramState) {
+  const clock = yield* Clock.Clock
   const sql = state.storage.sql
   ensureSingletonStorage(sql)
   if (state.id.name !== undefined) {
@@ -427,7 +431,7 @@ export const makeClusterSingletonProgram = Effect.fnUntraced(function*(state: Du
     runtime = makeSingletonRuntime({
       sql,
       alarm: state.storage,
-      now: () => Date.now(),
+      now: () => clock.currentTimeMillisUnsafe(),
       run
     })
     return runtime
@@ -438,7 +442,9 @@ export const makeClusterSingletonProgram = Effect.fnUntraced(function*(state: Du
   const program: ClusterSingletonProgram = {
     wake: () => Effect.promise(() => getRuntime().wake()),
     alarm: () =>
-      loadSingletonState(sql).wakeAt === undefined ? Effect.void : Effect.promise(() => getRuntime().runAlarm())
+      Effect.suspend(() =>
+        loadSingletonState(sql).wakeAt === undefined ? Effect.void : Effect.promise(() => getRuntime().runAlarm())
+      )
   }
   return program
 })

--- a/packages/platform/cloudflare/src/CloudflareDurableObjectPrograms.ts
+++ b/packages/platform/cloudflare/src/CloudflareDurableObjectPrograms.ts
@@ -36,9 +36,9 @@ import { earliestClockWakeUp, ensureWorkflowStorage, loadExecution } from "./int
  * **Details**
  *
  * A `DurableObjectState` from `cloudflare:workers` satisfies this shape
- * directly. The program only reads the object name, opens SQLite storage,
- * resolves same-Worker class exports, and extends the current event with
- * `waitUntil`.
+ * directly, so pass it as is. The program only reads the object name, opens
+ * SQLite storage, resolves same-Worker class exports, and extends the current
+ * event with `waitUntil`.
  *
  * @category models
  * @since 4.0.0
@@ -46,7 +46,7 @@ import { earliestClockWakeUp, ensureWorkflowStorage, loadExecution } from "./int
 export interface DurableObjectProgramState {
   readonly id: { readonly name?: string | undefined }
   readonly storage: DurableObjectStorage
-  readonly exports: Record<string, unknown>
+  readonly exports: object
   readonly waitUntil: (promise: Promise<unknown>) => void
 }
 
@@ -54,7 +54,7 @@ const exportedNamespace = <Stub>(
   state: DurableObjectProgramState,
   className: string
 ): { readonly getByName: (name: string) => Stub } | undefined =>
-  state.exports[className] as
+  (state.exports as Record<string, unknown>)[className] as
     | { readonly getByName: (name: string) => Stub }
     | undefined
 
@@ -100,7 +100,7 @@ export type EntityInvokeResult = {
  * @category models
  * @since 4.0.0
  */
-export interface ClusterEntityProgram {
+export type ClusterEntityProgram = {
   readonly alarm: () => Effect.Effect<void>
   readonly hold: () => Effect.Effect<void>
   readonly invoke: (
@@ -200,7 +200,7 @@ export interface ClusterWorkflowRunOptions {
  * @category models
  * @since 4.0.0
  */
-export interface ClusterWorkflowProgram {
+export type ClusterWorkflowProgram = {
   readonly run: (payload: string, options: ClusterWorkflowRunOptions) => Effect.Effect<string>
   readonly poll: () => Effect.Effect<string | undefined>
   readonly resume: () => Effect.Effect<void>
@@ -306,7 +306,7 @@ export interface DurableQueueItem {
  * @category models
  * @since 4.0.0
  */
-export interface ClusterDurableQueueProgram {
+export type ClusterDurableQueueProgram = {
   readonly offer: (id: string, element: string) => Effect.Effect<void>
   readonly take: (takerId: string, maxAttempts: number, leaseMillis: number) => Effect.Effect<DurableQueueItem>
   readonly cancelTake: (takerId: string) => Effect.Effect<void>
@@ -367,7 +367,7 @@ export const makeClusterDurableQueueProgram = Effect.fnUntraced(function*(state:
  * @category models
  * @since 4.0.0
  */
-export interface ClusterSingletonProgram {
+export type ClusterSingletonProgram = {
   readonly wake: () => Effect.Effect<void>
   readonly alarm: () => Effect.Effect<void>
 }

--- a/packages/platform/cloudflare/src/CloudflareDurableObjectPrograms.ts
+++ b/packages/platform/cloudflare/src/CloudflareDurableObjectPrograms.ts
@@ -91,6 +91,12 @@ export type EntityInvokeResult = {
 /**
  * Effect-valued program for one cluster entity Durable Object instance.
  *
+ * **Gotchas**
+ *
+ * All program methods must keep their error channel `never`: Alchemy encodes
+ * typed failures as envelopes, but the native namespace transport expects
+ * plain results and rejected defects.
+ *
  * @category models
  * @since 4.0.0
  */

--- a/packages/platform/cloudflare/src/CloudflareDurableObjects.ts
+++ b/packages/platform/cloudflare/src/CloudflareDurableObjects.ts
@@ -17,7 +17,6 @@ import {
   type ClusterSingletonProgram,
   type ClusterWorkflowProgram,
   type ClusterWorkflowRunOptions,
-  type DurableObjectProgramState,
   type DurableQueueItem,
   type EntityDeliveryOptions,
   type EntityInvokeResult,
@@ -25,37 +24,6 @@ import {
   makeClusterEntityProgram,
   makeClusterSingletonProgram,
   makeClusterWorkflowProgram
-} from "./CloudflareDurableObjectPrograms.ts"
-
-export type {
-  /**
-   * Execution options shared with the workflow program.
-   *
-   * @category re-exports
-   * @since 4.0.0
-   */
-  ClusterWorkflowRunOptions,
-  /**
-   * Item leased from the durable queue program.
-   *
-   * @category re-exports
-   * @since 4.0.0
-   */
-  DurableQueueItem,
-  /**
-   * Delivery options shared with the entity program.
-   *
-   * @category re-exports
-   * @since 4.0.0
-   */
-  EntityDeliveryOptions,
-  /**
-   * Result returned by the entity transport program.
-   *
-   * @category re-exports
-   * @since 4.0.0
-   */
-  EntityInvokeResult
 } from "./CloudflareDurableObjectPrograms.ts"
 
 const notExposed = (className: string) => () => {
@@ -142,13 +110,6 @@ const blockOnInitialization = (
   })
 }
 
-const programState = (ctx: DurableObjectState): DurableObjectProgramState => ({
-  id: ctx.id,
-  storage: ctx.storage,
-  exports: ctx.exports as Record<string, unknown>,
-  waitUntil: (promise) => ctx.waitUntil(promise)
-})
-
 /**
  * The shared entity class. One instance holds one entity address; the handlers
  * for every `EntityType` are registered at Worker init.
@@ -171,7 +132,7 @@ export class ClusterEntity extends DurableObject<unknown> {
   constructor(ctx: DurableObjectState, env: unknown) {
     super(ctx, env)
     blockOnInitialization(ctx, env, async () => {
-      this.#program = await Effect.runPromise(makeClusterEntityProgram(programState(ctx)))
+      this.#program = await Effect.runPromise(makeClusterEntityProgram(ctx))
     })
   }
 
@@ -235,7 +196,7 @@ export class ClusterWorkflow extends DurableObject<unknown> {
   constructor(ctx: DurableObjectState, env: unknown) {
     super(ctx, env)
     blockOnInitialization(ctx, env, async () => {
-      this.#program = await Effect.runPromise(makeClusterWorkflowProgram(programState(ctx)))
+      this.#program = await Effect.runPromise(makeClusterWorkflowProgram(ctx))
     })
   }
 
@@ -303,7 +264,7 @@ export class ClusterDurableQueue extends DurableObject<unknown> {
   constructor(ctx: DurableObjectState, env: unknown) {
     super(ctx, env)
     blockOnInitialization(ctx, env, async () => {
-      this.#program = await Effect.runPromise(makeClusterDurableQueueProgram(programState(ctx)))
+      this.#program = await Effect.runPromise(makeClusterDurableQueueProgram(ctx))
     })
   }
 
@@ -372,7 +333,7 @@ export class ClusterSingleton extends DurableObject<unknown> {
   constructor(ctx: DurableObjectState, env: unknown) {
     super(ctx, env)
     blockOnInitialization(ctx, env, async () => {
-      this.#program = await Effect.runPromise(makeClusterSingletonProgram(programState(ctx)))
+      this.#program = await Effect.runPromise(makeClusterSingletonProgram(ctx))
     })
   }
 

--- a/packages/platform/cloudflare/src/CloudflareDurableObjects.ts
+++ b/packages/platform/cloudflare/src/CloudflareDurableObjects.ts
@@ -11,45 +11,58 @@
  */
 import { DurableObject } from "cloudflare:workers"
 import * as Effect from "effect/Effect"
-import * as ClusterMetrics from "effect/unstable/cluster/ClusterMetrics"
-import * as EntityAddress from "effect/unstable/cluster/EntityAddress"
-import * as EntityId from "effect/unstable/cluster/EntityId"
-import * as EntityType from "effect/unstable/cluster/EntityType"
-import * as ShardId from "effect/unstable/cluster/ShardId"
-import { decodeName, encodeName } from "./internal/clusterName.ts"
-import { makeEntityKeepAlive } from "./internal/entityKeepAlive.ts"
-import { makeEntityManager } from "./internal/entityRuntime.ts"
-import { armAlarm, earliestDeliverAt, ensureEntityStorage } from "./internal/entityStorage.ts"
-import { makeQueueRuntime } from "./internal/queueRuntime.ts"
-import { earliestLeaseExpiry, type QueueItem } from "./internal/queueStorage.ts"
-import { getSingletonRegistration } from "./internal/singletonRegistry.ts"
-import { makeSingletonRuntime } from "./internal/singletonRuntime.ts"
-import { ensureSingletonStorage, loadSingletonState, rememberSingletonName } from "./internal/singletonStorage.ts"
-import type { WorkflowRunOptions, WorkflowStub } from "./internal/workflowRegistry.ts"
-import { makeWorkflowRuntime } from "./internal/workflowRuntime.ts"
-import { earliestClockWakeUp, ensureWorkflowStorage, loadExecution } from "./internal/workflowStorage.ts"
+import {
+  type ClusterDurableQueueProgram,
+  type ClusterEntityProgram,
+  type ClusterSingletonProgram,
+  type ClusterWorkflowProgram,
+  type ClusterWorkflowRunOptions,
+  type DurableObjectProgramState,
+  type DurableQueueItem,
+  type EntityDeliveryOptions,
+  type EntityInvokeResult,
+  makeClusterDurableQueueProgram,
+  makeClusterEntityProgram,
+  makeClusterSingletonProgram,
+  makeClusterWorkflowProgram
+} from "./CloudflareDurableObjectPrograms.ts"
+
+export type {
+  /**
+   * Execution options shared with the workflow program.
+   *
+   * @category re-exports
+   * @since 4.0.0
+   */
+  ClusterWorkflowRunOptions,
+  /**
+   * Item leased from the durable queue program.
+   *
+   * @category re-exports
+   * @since 4.0.0
+   */
+  DurableQueueItem,
+  /**
+   * Delivery options shared with the entity program.
+   *
+   * @category re-exports
+   * @since 4.0.0
+   */
+  EntityDeliveryOptions,
+  /**
+   * Result returned by the entity transport program.
+   *
+   * @category re-exports
+   * @since 4.0.0
+   */
+  EntityInvokeResult
+} from "./CloudflareDurableObjectPrograms.ts"
 
 const notExposed = (className: string) => () => {
   throw new Error(
     `@effect/platform-cloudflare: ${className} is not exposed over fetch, use the same-Worker namespace binding`
   )
 }
-
-const exportedNamespace = <Stub>(
-  state: DurableObjectState,
-  className: string
-): { readonly getByName: (name: string) => Stub } | undefined =>
-  (state.exports as Record<string, unknown>)[className] as
-    | { readonly getByName: (name: string) => Stub }
-    | undefined
-
-type EntityManager = ReturnType<typeof makeEntityManager>
-
-type WorkflowRuntime = ReturnType<typeof makeWorkflowRuntime>
-
-type QueueRuntime = ReturnType<typeof makeQueueRuntime>
-
-type SingletonRuntime = ReturnType<typeof makeSingletonRuntime>
 
 /**
  * Initializes the Worker application before a Cloudflare cluster Durable
@@ -129,25 +142,12 @@ const blockOnInitialization = (
   })
 }
 
-// Mirrors entityWire's InvokeResult and entityRuntime's DeliveryOptions: the
-// exported class cannot reference an @internal type in its method signatures.
-type InvokeResult = {
-  readonly _tag: "Success"
-  readonly requestId: string
-  readonly replies: ReadonlyArray<string>
-} | {
-  readonly _tag: "MailboxFull"
-} | {
-  readonly _tag: "EncodedMessageTooLarge"
-} | {
-  readonly _tag: "AskDeduplicatedToTell"
-}
-
-interface DeliveryOptions {
-  readonly deliverAt?: number | undefined
-  readonly primaryKey?: string | null | undefined
-  readonly replyTo?: string | undefined
-}
+const programState = (ctx: DurableObjectState): DurableObjectProgramState => ({
+  id: ctx.id,
+  storage: ctx.storage,
+  exports: ctx.exports as Record<string, unknown>,
+  waitUntil: (promise) => ctx.waitUntil(promise)
+})
 
 /**
  * The shared entity class. One instance holds one entity address; the handlers
@@ -165,80 +165,48 @@ interface DeliveryOptions {
  * @since 4.0.0
  */
 export class ClusterEntity extends DurableObject<unknown> {
-  readonly #keepAlive
-  readonly #manager: EntityManager
+  // blockConcurrencyWhile completes this assignment before any RPC or alarm.
+  #program!: ClusterEntityProgram
 
   constructor(ctx: DurableObjectState, env: unknown) {
     super(ctx, env)
-    const entityName = ctx.id.name ?? ""
-    const name = decodeName(entityName)
-    if (name === undefined) throw new Error("ClusterEntity requires a canonical entity Durable Object name")
-    this.#keepAlive = makeEntityKeepAlive(() => {
-      const namespace = exportedNamespace<{ readonly hold: () => Promise<void> }>(ctx, "ClusterEntity")
-      if (namespace === undefined) {
-        return Promise.reject(
-          new Error("CloudflareCluster: ClusterEntity export is unavailable for keep-alive")
-        )
-      }
-      return namespace.getByName(entityName).hold()
+    blockOnInitialization(ctx, env, async () => {
+      this.#program = await Effect.runPromise(makeClusterEntityProgram(programState(ctx)))
     })
-    this.#manager = makeEntityManager({
-      storage: ctx.storage,
-      address: EntityAddress.make({
-        shardId: ShardId.make("default", 1),
-        entityType: EntityType.make(name.type),
-        entityId: EntityId.make(name.id)
-      }),
-      entityName,
-      keepAlive: this.#keepAlive,
-      waitUntil: (effect) => ctx.waitUntil(Effect.runPromise(effect)),
-      getNamespace: () =>
-        exportedNamespace<{
-          readonly deliverReply: (requestId: string, reply: string) => Promise<boolean>
-        }>(ctx, "ClusterEntity")
-    })
-    const sql = ctx.storage.sql
-    ensureEntityStorage(sql)
-    const deliverAt = earliestDeliverAt(sql)
-    blockOnInitialization(
-      ctx,
-      env,
-      deliverAt === undefined ? undefined : () => Effect.runPromise(armAlarm(ctx.storage, deliverAt))
-    )
   }
 
   override alarm(): Promise<void> {
-    return Effect.runPromise(this.#manager.alarm)
+    return Effect.runPromise(this.#program.alarm())
   }
 
   /** @internal Keeps this object non-hibernateable while entity resources have holders. */
   hold(): Promise<void> {
-    return Effect.runPromise(this.#keepAlive.await)
+    return Effect.runPromise(this.#program.hold())
   }
 
   /** @internal Same-Worker RPC transport used by `CloudflareCluster.layer`. */
-  invoke(envelopeText: string, discard: boolean, delivery?: DeliveryOptions): Promise<InvokeResult> {
-    return Effect.runPromise(this.#manager.invoke(envelopeText, discard, delivery))
+  invoke(envelopeText: string, discard: boolean, delivery?: EntityDeliveryOptions): Promise<EntityInvokeResult> {
+    return Effect.runPromise(this.#program.invoke(envelopeText, discard, delivery))
   }
 
   /** @internal Acknowledges a streamed chunk. */
   acknowledge(requestId: string, replyId: string): Promise<ReadonlyArray<string>> {
-    return Effect.runPromise(this.#manager.acknowledge(requestId, replyId))
+    return Effect.runPromise(this.#program.acknowledge(requestId, replyId))
   }
 
   /** @internal Interrupts a handler execution and completes its persisted ask, if any. */
   interrupt(storageRequestId: string, clientRequestId = storageRequestId): Promise<void> {
-    return Effect.runPromise(this.#manager.interrupt(storageRequestId, clientRequestId))
+    return Effect.runPromise(this.#program.interrupt(storageRequestId, clientRequestId))
   }
 
   /** @internal Clears stored replies so a reset request replays from scratch. */
   reset(requestId: string): Promise<void> {
-    return Effect.runPromise(this.#manager.reset(requestId))
+    return Effect.runPromise(this.#program.reset(requestId))
   }
 
   /** @internal Completes an in-memory delayed ask owned by this entity object. */
   deliverReply(requestId: string, reply: string): Promise<boolean> {
-    return Effect.runPromise(this.#manager.deliverReply(requestId, reply))
+    return Effect.runPromise(this.#program.deliverReply(requestId, reply))
   }
 
   override fetch: () => never = notExposed("ClusterEntity")
@@ -261,95 +229,53 @@ export class ClusterEntity extends DurableObject<unknown> {
  * @since 4.0.0
  */
 export class ClusterWorkflow extends DurableObject<unknown> {
-  readonly #state: DurableObjectState
-  readonly #name: string | undefined
-  #runtime: WorkflowRuntime | undefined
+  // blockConcurrencyWhile completes this assignment before any RPC or alarm.
+  #program!: ClusterWorkflowProgram
 
   constructor(ctx: DurableObjectState, env: unknown) {
     super(ctx, env)
-    this.#state = ctx
-    ensureWorkflowStorage(ctx.storage.sql)
-    if (ctx.id.name !== undefined) {
-      if (decodeName(ctx.id.name) === undefined) {
-        throw new Error("ClusterWorkflow requires a canonical workflow Durable Object name")
-      }
-      this.#name = ctx.id.name
-    } else {
-      // An alarm wake carries no `id.name`; recover it from the stored
-      // execution so due clocks still fire after eviction.
-      const stored = loadExecution(ctx.storage.sql)
-      this.#name = stored === undefined ? undefined : encodeName(stored.workflowName, stored.executionId)
-    }
-    const wakeUp = earliestClockWakeUp(ctx.storage.sql)
-    blockOnInitialization(
-      ctx,
-      env,
-      wakeUp === undefined ? undefined : () => Effect.runPromise(armAlarm(ctx.storage, wakeUp))
-    )
-  }
-
-  #getRuntime(): WorkflowRuntime {
-    if (this.#runtime === undefined) {
-      if (this.#name === undefined) {
-        throw new Error("ClusterWorkflow requires a canonical workflow Durable Object name")
-      }
-      this.#runtime = makeWorkflowRuntime({
-        name: this.#name,
-        sql: this.#state.storage.sql,
-        alarm: this.#state.storage,
-        now: () => Date.now(),
-        waitUntil: (promise) => this.#state.waitUntil(promise),
-        getStub: (name) => {
-          const namespace = exportedNamespace<WorkflowStub>(this.#state, "ClusterWorkflow")
-          if (namespace === undefined) {
-            throw new Error("CloudflareCluster: ClusterWorkflow export is unavailable for workflow delivery")
-          }
-          return namespace.getByName(name)
-        }
-      })
-    }
-    return this.#runtime
+    blockOnInitialization(ctx, env, async () => {
+      this.#program = await Effect.runPromise(makeClusterWorkflowProgram(programState(ctx)))
+    })
   }
 
   /** @internal Same-Worker RPC transport used by `CloudflareWorkflowEngine`. */
-  run(payload: string, options: WorkflowRunOptions): Promise<string> {
-    return this.#getRuntime().run(payload, options)
+  run(payload: string, options: ClusterWorkflowRunOptions): Promise<string> {
+    return Effect.runPromise(this.#program.run(payload, options))
   }
 
   /** @internal */
   poll(): Promise<string | undefined> {
-    return this.#getRuntime().poll()
+    return Effect.runPromise(this.#program.poll())
   }
 
   /** @internal */
   resume(): Promise<void> {
-    return this.#getRuntime().resume()
+    return Effect.runPromise(this.#program.resume())
   }
 
   /** @internal */
   interrupt(): Promise<void> {
-    return this.#getRuntime().interrupt()
+    return Effect.runPromise(this.#program.interrupt())
   }
 
   /** @internal */
   interruptUnsafe(): Promise<void> {
-    return this.#getRuntime().interruptUnsafe()
+    return Effect.runPromise(this.#program.interruptUnsafe())
   }
 
   /** @internal Records a durable deferred exit and resumes the execution. */
   deferredDone(name: string, exit: string): Promise<void> {
-    return this.#getRuntime().deferredDone(name, exit)
+    return Effect.runPromise(this.#program.deferredDone(name, exit))
   }
 
   /** @internal Persists a durable clock and arms the single alarm. */
   scheduleClock(name: string, deferredName: string, wakeUp: number): Promise<void> {
-    return this.#getRuntime().scheduleClock(name, deferredName, wakeUp)
+    return Effect.runPromise(this.#program.scheduleClock(name, deferredName, wakeUp))
   }
 
   override alarm(): Promise<void> {
-    // No stored execution means no clock could have armed this alarm.
-    if (this.#name === undefined) return Promise.resolve()
-    return this.#getRuntime().runAlarm()
+    return Effect.runPromise(this.#program.alarm())
   }
 
   override fetch: () => never = notExposed("ClusterWorkflow")
@@ -371,63 +297,53 @@ export class ClusterWorkflow extends DurableObject<unknown> {
  * @since 4.0.0
  */
 export class ClusterDurableQueue extends DurableObject<unknown> {
-  readonly #runtime: QueueRuntime
+  // blockConcurrencyWhile completes this assignment before any RPC or alarm.
+  #program!: ClusterDurableQueueProgram
 
   constructor(ctx: DurableObjectState, env: unknown) {
     super(ctx, env)
-    if (ctx.id.name !== undefined && decodeName(ctx.id.name) === undefined) {
-      throw new Error("ClusterDurableQueue requires a canonical queue Durable Object name")
-    }
-    this.#runtime = makeQueueRuntime({
-      sql: ctx.storage.sql,
-      alarm: ctx.storage,
-      now: () => Date.now()
+    blockOnInitialization(ctx, env, async () => {
+      this.#program = await Effect.runPromise(makeClusterDurableQueueProgram(programState(ctx)))
     })
-    const expiry = earliestLeaseExpiry(ctx.storage.sql)
-    blockOnInitialization(
-      ctx,
-      env,
-      expiry === undefined ? undefined : () => Effect.runPromise(armAlarm(ctx.storage, expiry))
-    )
   }
 
   /** @internal Same-Worker RPC transport used by `CloudflarePersistedQueue.layer`. */
   offer(id: string, element: string): Promise<void> {
-    return this.#runtime.offer(id, element)
+    return Effect.runPromise(this.#program.offer(id, element))
   }
 
   /** @internal Waits until an item is available, then leases it to the caller. */
-  take(takerId: string, maxAttempts: number, leaseMillis: number): Promise<QueueItem> {
-    return this.#runtime.take(takerId, maxAttempts, leaseMillis)
+  take(takerId: string, maxAttempts: number, leaseMillis: number): Promise<DurableQueueItem> {
+    return Effect.runPromise(this.#program.take(takerId, maxAttempts, leaseMillis))
   }
 
   /** @internal Cancels a waiting take, releasing an item already leased to it. */
   cancelTake(takerId: string): Promise<void> {
-    return this.#runtime.cancelTake(takerId)
+    return Effect.runPromise(this.#program.cancelTake(takerId))
   }
 
   /** @internal */
   complete(id: string): Promise<void> {
-    return this.#runtime.complete(id)
+    return Effect.runPromise(this.#program.complete(id))
   }
 
   /** @internal Records a failed attempt and requeues the item. */
   fail(id: string, lastFailure: string): Promise<void> {
-    return this.#runtime.fail(id, lastFailure)
+    return Effect.runPromise(this.#program.fail(id, lastFailure))
   }
 
   /** @internal Requeues the item without counting an attempt. */
   release(id: string): Promise<void> {
-    return this.#runtime.release(id)
+    return Effect.runPromise(this.#program.release(id))
   }
 
   /** @internal Extends the lease of an item still being processed. */
   extend(id: string, leaseMillis: number): Promise<void> {
-    return this.#runtime.extend(id, leaseMillis)
+    return Effect.runPromise(this.#program.extend(id, leaseMillis))
   }
 
   override alarm(): Promise<void> {
-    return this.#runtime.runAlarm()
+    return Effect.runPromise(this.#program.alarm())
   }
 
   override fetch: () => never = notExposed("ClusterDurableQueue")
@@ -450,68 +366,23 @@ export class ClusterDurableQueue extends DurableObject<unknown> {
  * @since 4.0.0
  */
 export class ClusterSingleton extends DurableObject<unknown> {
-  readonly #state: DurableObjectState
-  readonly #name: string | undefined
-  #runtime: SingletonRuntime | undefined
+  // blockConcurrencyWhile completes this assignment before any RPC or alarm.
+  #program!: ClusterSingletonProgram
 
   constructor(ctx: DurableObjectState, env: unknown) {
     super(ctx, env)
-    this.#state = ctx
-    const sql = ctx.storage.sql
-    ensureSingletonStorage(sql)
-    if (ctx.id.name !== undefined) {
-      if (!ctx.id.name.startsWith("Singleton/")) {
-        throw new Error("ClusterSingleton requires a Singleton/<name> Durable Object name")
-      }
-      rememberSingletonName(sql, ctx.id.name)
-    }
-    const stored = loadSingletonState(sql)
-    this.#name = ctx.id.name ?? stored.name
-    blockOnInitialization(
-      ctx,
-      env,
-      stored.wakeAt === undefined ? undefined : () => Effect.runPromise(armAlarm(ctx.storage, stored.wakeAt!))
-    )
-  }
-
-  #getRuntime(): SingletonRuntime {
-    if (this.#runtime !== undefined) return this.#runtime
-    if (this.#name === undefined) {
-      throw new Error("ClusterSingleton requires a Singleton/<name> Durable Object name")
-    }
-    const name = this.#name.slice("Singleton/".length)
-    const registration = getSingletonRegistration(name)
-    if (registration === undefined) {
-      throw new Error(`CloudflareCluster: no singleton registered under the name "${name}"`)
-    }
-    const run = Effect.sync(() => {
-      ClusterMetrics.singletons.modifyUnsafe(BigInt(1), registration.context)
-    }).pipe(
-      Effect.andThen(registration.run),
-      Effect.scoped,
-      Effect.ensuring(Effect.sync(() => {
-        ClusterMetrics.singletons.modifyUnsafe(BigInt(-1), registration.context)
-      })),
-      Effect.provideContext(registration.context),
-      Effect.orDie
-    )
-    this.#runtime = makeSingletonRuntime({
-      sql: this.#state.storage.sql,
-      alarm: this.#state.storage,
-      now: () => Date.now(),
-      run
+    blockOnInitialization(ctx, env, async () => {
+      this.#program = await Effect.runPromise(makeClusterSingletonProgram(programState(ctx)))
     })
-    return this.#runtime
   }
 
   /** @internal Runs one Cron Trigger fire, coalescing a concurrent duplicate. */
   wake(): Promise<void> {
-    return this.#getRuntime().wake()
+    return Effect.runPromise(this.#program.wake())
   }
 
   override alarm(): Promise<void> {
-    if (loadSingletonState(this.#state.storage.sql).wakeAt === undefined) return Promise.resolve()
-    return this.#getRuntime().runAlarm()
+    return Effect.runPromise(this.#program.alarm())
   }
 
   override fetch: () => never = notExposed("ClusterSingleton")

--- a/packages/platform/cloudflare/src/index.ts
+++ b/packages/platform/cloudflare/src/index.ts
@@ -2,12 +2,20 @@
  * @since 4.0.0
  */
 
-// @barrel: Auto-generated exports. Do not edit manually.
+// The index stays free of the optional `alchemy` peer dependency, so the
+// Alchemy integration is exposed only through its own entrypoint:
+// `@effect/platform-cloudflare/AlchemyCloudflareCluster`.
+// @barrel(Cloudflare*.ts): Auto-generated exports. Do not edit manually.
 
 /**
  * @since 4.0.0
  */
 export * as CloudflareCluster from "./CloudflareCluster.ts"
+
+/**
+ * @since 4.0.0
+ */
+export * as CloudflareDurableObjectPrograms from "./CloudflareDurableObjectPrograms.ts"
 
 /**
  * @since 4.0.0

--- a/packages/platform/cloudflare/src/internal/alchemyCluster.ts
+++ b/packages/platform/cloudflare/src/internal/alchemyCluster.ts
@@ -1,0 +1,95 @@
+/**
+ * The alchemy-free half of `AlchemyCloudflareCluster.make`: building the
+ * cluster handle from resolved namespace bindings. Kept separate so it can be
+ * exercised without importing `alchemy`, whose runtime must match the
+ * published `effect` release rather than this workspace.
+ *
+ * @internal
+ */
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import * as Scope from "effect/Scope"
+import type * as Entity from "effect/unstable/cluster/Entity"
+import * as CloudflareCluster from "../CloudflareCluster.ts"
+
+/** @internal */
+export interface ClusterHandle {
+  readonly provide: <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, any>
+  readonly wake: (name: string) => () => Effect.Effect<void>
+  readonly entityNamespace: DurableObjectNamespace
+  readonly workflowNamespace: DurableObjectNamespace
+  readonly queueNamespace: DurableObjectNamespace
+  readonly singletonNamespace: DurableObjectNamespace
+  readonly context: Context.Context<never>
+}
+
+/** @internal */
+export interface ClusterHandleOptions {
+  readonly entities: ReadonlyArray<Entity.Entity<any, any>>
+  readonly layer: Layer.Layer<never, any, any>
+  readonly env: Record<string, unknown>
+}
+
+/** @internal */
+export const makeClusterHandle = Effect.fnUntraced(function*(options: ClusterHandleOptions) {
+  const entityNamespace = options.env.ClusterEntity as DurableObjectNamespace
+  const workflowNamespace = options.env.ClusterWorkflow as DurableObjectNamespace
+  const queueNamespace = options.env.ClusterDurableQueue as DurableObjectNamespace
+  const singletonNamespace = options.env.ClusterSingleton as DurableObjectNamespace
+
+  // The isolate-lifetime scope. workerd has no isolate-teardown hook, so it
+  // is never closed; the built services live for the isolate, exactly like
+  // the Wrangler path's `setInitializer` build.
+  const scope = Scope.makeUnsafe()
+  const context = yield* Layer.buildWithScope(
+    options.layer.pipe(
+      Layer.provideMerge(CloudflareCluster.layer({
+        entities: options.entities,
+        entityNamespace,
+        workflowNamespace,
+        queueNamespace,
+        singletonNamespace
+      }))
+    ),
+    scope
+  ).pipe(
+    // Drop the build's memo map so a Layer the user provides inside a
+    // handler builds per event instead of sharing one instance pinned to
+    // the first request's IoContext.
+    Effect.map(Context.omit(Layer.CurrentMemoMap))
+  )
+
+  const handle: ClusterHandle = {
+    provide: (effect) => Effect.provideContext(effect, context),
+    wake: (name) => () =>
+      Effect.promise(() =>
+        (singletonNamespace.getByName(`Singleton/${name}`) as unknown as {
+          readonly wake: () => Promise<void>
+        }).wake()
+      ),
+    entityNamespace,
+    workflowNamespace,
+    queueNamespace,
+    singletonNamespace,
+    context
+  }
+  return handle
+})
+
+/**
+ * The plan-time handle: the deploy-machine evaluation only discovers the
+ * Durable Object declarations, and nothing returned from the Worker init
+ * program runs outside the deployed isolate.
+ *
+ * @internal
+ */
+export const inertClusterHandle = (): ClusterHandle => ({
+  provide: (effect) => effect as Effect.Effect<any, any, any>,
+  wake: () => () => Effect.void,
+  entityNamespace: undefined as unknown as DurableObjectNamespace,
+  workflowNamespace: undefined as unknown as DurableObjectNamespace,
+  queueNamespace: undefined as unknown as DurableObjectNamespace,
+  singletonNamespace: undefined as unknown as DurableObjectNamespace,
+  context: undefined as unknown as Context.Context<never>
+})

--- a/packages/platform/cloudflare/src/internal/alchemyCluster.ts
+++ b/packages/platform/cloudflare/src/internal/alchemyCluster.ts
@@ -11,18 +11,8 @@ import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import * as Scope from "effect/Scope"
 import type * as Entity from "effect/unstable/cluster/Entity"
+import type { Cluster } from "../AlchemyCloudflareCluster.ts"
 import * as CloudflareCluster from "../CloudflareCluster.ts"
-
-/** @internal */
-export interface ClusterHandle {
-  readonly provide: <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, any>
-  readonly wake: (name: string) => () => Effect.Effect<void>
-  readonly entityNamespace: DurableObjectNamespace
-  readonly workflowNamespace: DurableObjectNamespace
-  readonly queueNamespace: DurableObjectNamespace
-  readonly singletonNamespace: DurableObjectNamespace
-  readonly context: Context.Context<never>
-}
 
 /** @internal */
 export interface ClusterHandleOptions {
@@ -60,7 +50,7 @@ export const makeClusterHandle = Effect.fnUntraced(function*(options: ClusterHan
     Effect.map(Context.omit(Layer.CurrentMemoMap))
   )
 
-  const handle: ClusterHandle = {
+  const handle: Cluster<never> = {
     provide: (effect) => Effect.provideContext(effect, context),
     wake: (name) => () =>
       Effect.promise(() =>
@@ -84,8 +74,8 @@ export const makeClusterHandle = Effect.fnUntraced(function*(options: ClusterHan
  *
  * @internal
  */
-export const inertClusterHandle = (): ClusterHandle => ({
-  provide: (effect) => effect as Effect.Effect<any, any, any>,
+export const inertClusterHandle = (): Cluster<never> => ({
+  provide: (effect) => effect,
   wake: () => () => Effect.void,
   get entityNamespace() {
     return planTimeOnly("entityNamespace")

--- a/packages/platform/cloudflare/src/internal/alchemyCluster.ts
+++ b/packages/platform/cloudflare/src/internal/alchemyCluster.ts
@@ -87,9 +87,25 @@ export const makeClusterHandle = Effect.fnUntraced(function*(options: ClusterHan
 export const inertClusterHandle = (): ClusterHandle => ({
   provide: (effect) => effect as Effect.Effect<any, any, any>,
   wake: () => () => Effect.void,
-  entityNamespace: undefined as unknown as DurableObjectNamespace,
-  workflowNamespace: undefined as unknown as DurableObjectNamespace,
-  queueNamespace: undefined as unknown as DurableObjectNamespace,
-  singletonNamespace: undefined as unknown as DurableObjectNamespace,
-  context: undefined as unknown as Context.Context<never>
+  get entityNamespace() {
+    return planTimeOnly("entityNamespace")
+  },
+  get workflowNamespace() {
+    return planTimeOnly("workflowNamespace")
+  },
+  get queueNamespace() {
+    return planTimeOnly("queueNamespace")
+  },
+  get singletonNamespace() {
+    return planTimeOnly("singletonNamespace")
+  },
+  get context() {
+    return planTimeOnly("context")
+  }
 })
+
+const planTimeOnly = (field: string): never => {
+  throw new Error(
+    `AlchemyCloudflareCluster: '${field}' is only available at runtime, not during plan evaluation`
+  )
+}

--- a/packages/platform/cloudflare/src/internal/alchemyCluster.ts
+++ b/packages/platform/cloudflare/src/internal/alchemyCluster.ts
@@ -11,8 +11,8 @@ import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import * as Scope from "effect/Scope"
 import type * as Entity from "effect/unstable/cluster/Entity"
-import type { Cluster } from "../AlchemyCloudflareCluster.ts"
 import * as CloudflareCluster from "../CloudflareCluster.ts"
+import type { Cluster } from "./cluster.ts"
 
 /** @internal */
 export interface ClusterHandleOptions {

--- a/packages/platform/cloudflare/src/internal/cluster.ts
+++ b/packages/platform/cloudflare/src/internal/cluster.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared cluster handle types without the Alchemy dependency graph.
+ *
+ * @since 4.0.0
+ */
+import type * as Context from "effect/Context"
+import type * as Effect from "effect/Effect"
+
+/**
+ * The handle returned by `AlchemyCloudflareCluster.make`.
+ *
+ * **Gotchas**
+ *
+ * Namespace bindings and `context` are available only in the deployed runtime.
+ * Reading them during plan evaluation throws a diagnostic; `provide` and
+ * `wake` remain inert during planning.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface Cluster<in R = never> {
+  /**
+   * Attaches the built cluster context to a user Effect, for the Worker's
+   * `fetch` handler and other entrypoints. Only provides the already-built
+   * Context; it does not open a new Scope.
+   */
+  readonly provide: <A, E, R2>(effect: Effect.Effect<A, E, R2>) => Effect.Effect<A, E, Exclude<R2, R>>
+  /**
+   * A handler that wakes the named singleton, for `Cloudflare.Workers.cron`.
+   * The name is the singleton name without the `Singleton/` prefix, and the
+   * returned handler is already context-provided.
+   */
+  readonly wake: (name: string) => () => Effect.Effect<void>
+  /**
+   * The native namespace binding of the cluster entity class.
+   */
+  readonly entityNamespace: DurableObjectNamespace
+  /**
+   * The native namespace binding of the workflow class.
+   */
+  readonly workflowNamespace: DurableObjectNamespace
+  /**
+   * The native namespace binding of the durable queue class.
+   */
+  readonly queueNamespace: DurableObjectNamespace
+  /**
+   * The native namespace binding of the singleton class.
+   */
+  readonly singletonNamespace: DurableObjectNamespace
+  /**
+   * The Context built from the cluster layer and the user layer into the
+   * isolate-lifetime Scope.
+   */
+  readonly context: Context.Context<R>
+}

--- a/packages/platform/cloudflare/src/internal/entityRuntime.ts
+++ b/packages/platform/cloudflare/src/internal/entityRuntime.ts
@@ -25,7 +25,7 @@ import * as Reply from "effect/unstable/cluster/Reply"
 import * as RunnerAddress from "effect/unstable/cluster/RunnerAddress"
 import * as Rpc from "effect/unstable/rpc/Rpc"
 import * as RpcSchema from "effect/unstable/rpc/RpcSchema"
-import type { EntityDeliveryOptions } from "../CloudflareDurableObjectPrograms.ts"
+import type { EntityDeliveryOptions, EntityInvokeResult } from "../CloudflareDurableObjectPrograms.ts"
 import { encodeName } from "./clusterName.ts"
 import type { EntityKeepAlive } from "./entityKeepAlive.ts"
 import {
@@ -44,7 +44,7 @@ import {
 import { type EntityRegistration, getEntityRegistration } from "./entityRegistry.ts"
 import { CurrentEntityName, CurrentReplyRegistry, type EntityReplyRegistry, makeReplyRegistry } from "./entityReply.ts"
 import { armAlarm, earliestDeliverAt, withTransaction } from "./entityStorage.ts"
-import { decodeReplyFor, decodeRequest, encodeReplyFor, type InvokeResult, peekEnvelopeTag } from "./entityWire.ts"
+import { decodeReplyFor, decodeRequest, encodeReplyFor, peekEnvelopeTag } from "./entityWire.ts"
 
 interface CachedHandlers {
   readonly handlers: Record<string, (request: any) => any>
@@ -230,7 +230,7 @@ interface Session {
 
 interface WorkerWaiter {
   readonly clientRequestId: string
-  readonly deferred: Deferred.Deferred<InvokeResult>
+  readonly deferred: Deferred.Deferred<EntityInvokeResult>
 }
 
 interface ReplayFiber {
@@ -242,9 +242,6 @@ interface RunOptions {
   readonly scheduled?: boolean
   readonly replyTos?: ReadonlyArray<string> | undefined
 }
-
-/** @internal */
-export type DeliveryOptions = EntityDeliveryOptions
 
 /** @internal */
 export interface EntityManagerOptions {
@@ -265,8 +262,8 @@ export interface EntityManager {
   readonly invoke: (
     envelopeText: string,
     discard: boolean,
-    delivery?: DeliveryOptions | undefined
-  ) => Effect.Effect<InvokeResult>
+    delivery?: EntityDeliveryOptions | undefined
+  ) => Effect.Effect<EntityInvokeResult>
   readonly acknowledge: (requestId: string, replyId: string) => Effect.Effect<ReadonlyArray<string>>
   readonly interrupt: (storageRequestId: string, clientRequestId?: string) => Effect.Effect<void>
   readonly reset: (requestId: string) => Effect.Effect<void>
@@ -274,7 +271,7 @@ export interface EntityManager {
   readonly deliverReply: (requestId: string, reply: string) => Effect.Effect<boolean>
 }
 
-const success = (requestId: string, replies: ReadonlyArray<string>): InvokeResult => ({
+const success = (requestId: string, replies: ReadonlyArray<string>): EntityInvokeResult => ({
   _tag: "Success",
   requestId,
   replies
@@ -644,9 +641,9 @@ export const makeEntityManager = (options: EntityManagerOptions): EntityManager 
     discard: boolean,
     replyTo: string | undefined,
     clientRequestId = requestId
-  ): Effect.Effect<InvokeResult> => {
+  ): Effect.Effect<EntityInvokeResult> => {
     if (discard || replyTo !== undefined) return Effect.succeed(success(requestId, []))
-    const deferred = Deferred.makeUnsafe<InvokeResult>()
+    const deferred = Deferred.makeUnsafe<EntityInvokeResult>()
     const waiters = workerWaiters.get(requestId) ?? []
     waiters.push({ clientRequestId, deferred })
     workerWaiters.set(requestId, waiters)
@@ -658,8 +655,8 @@ export const makeEntityManager = (options: EntityManagerOptions): EntityManager 
   const invokeEntry = (
     envelopeText: string,
     discard: boolean,
-    delivery: DeliveryOptions | undefined
-  ): Effect.Effect<Effect.Effect<InvokeResult>> => {
+    delivery: EntityDeliveryOptions | undefined
+  ): Effect.Effect<Effect.Effect<EntityInvokeResult>> => {
     const registration = getEntityRegistration(options.address.entityType)
     if (registration === undefined) {
       return Effect.die(`No handlers registered for entity type: ${options.address.entityType}`)
@@ -678,7 +675,7 @@ export const makeEntityManager = (options: EntityManagerOptions): EntityManager 
       const finish = (
         requestId: string,
         continuation: Effect.Effect<ReadonlyArray<string>>
-      ): Effect.Effect<InvokeResult> =>
+      ): Effect.Effect<EntityInvokeResult> =>
         Effect.andThen(Fiber.awaitAll(replayFibers), continuation).pipe(
           Effect.map((replies) => success(requestId, replies))
         )
@@ -689,7 +686,7 @@ export const makeEntityManager = (options: EntityManagerOptions): EntityManager 
       const finishTell = (
         requestId: string,
         continuation: Effect.Effect<ReadonlyArray<string>>
-      ): Effect.Effect<Effect.Effect<InvokeResult>> =>
+      ): Effect.Effect<Effect.Effect<EntityInvokeResult>> =>
         Effect.as(
           Effect.forkDetach(Effect.catchCause(
             Effect.asVoid(continuation),
@@ -729,7 +726,7 @@ export const makeEntityManager = (options: EntityManagerOptions): EntityManager 
         )
       )
       if (Result.isFailure(persistedResult)) {
-        return Effect.succeed<InvokeResult>(
+        return Effect.succeed<EntityInvokeResult>(
           persistedResult.failure._tag === "MailboxFull"
             ? { _tag: "MailboxFull" }
             : { _tag: "EncodedMessageTooLarge" }
@@ -740,7 +737,7 @@ export const makeEntityManager = (options: EntityManagerOptions): EntityManager 
         const original = yield* loadMessage(sql, persisted.originalId)
         if (original === undefined) return yield* Effect.die("Duplicate mailbox row disappeared")
         if (original.discard && !discard) {
-          return Effect.succeed<InvokeResult>({ _tag: "AskDeduplicatedToTell" })
+          return Effect.succeed<EntityInvokeResult>({ _tag: "AskDeduplicatedToTell" })
         }
         const nextReply = yield* loadNextReply(sql, persisted.originalId)
         if (nextReply !== undefined) {
@@ -787,8 +784,8 @@ export const makeEntityManager = (options: EntityManagerOptions): EntityManager 
   const invoke = (
     envelopeText: string,
     discard: boolean,
-    delivery?: DeliveryOptions | undefined
-  ): Effect.Effect<InvokeResult> =>
+    delivery?: EntityDeliveryOptions | undefined
+  ): Effect.Effect<EntityInvokeResult> =>
     Effect.flatten(Semaphore.withPermit(semaphore, invokeEntry(envelopeText, discard, delivery)))
 
   const acknowledge = (requestId: string, replyId: string): Effect.Effect<ReadonlyArray<string>> =>

--- a/packages/platform/cloudflare/src/internal/entityRuntime.ts
+++ b/packages/platform/cloudflare/src/internal/entityRuntime.ts
@@ -25,6 +25,7 @@ import * as Reply from "effect/unstable/cluster/Reply"
 import * as RunnerAddress from "effect/unstable/cluster/RunnerAddress"
 import * as Rpc from "effect/unstable/rpc/Rpc"
 import * as RpcSchema from "effect/unstable/rpc/RpcSchema"
+import type { EntityDeliveryOptions } from "../CloudflareDurableObjectPrograms.ts"
 import { encodeName } from "./clusterName.ts"
 import type { EntityKeepAlive } from "./entityKeepAlive.ts"
 import {
@@ -243,11 +244,7 @@ interface RunOptions {
 }
 
 /** @internal */
-export interface DeliveryOptions {
-  readonly deliverAt?: number | undefined
-  readonly primaryKey?: string | null | undefined
-  readonly replyTo?: string | undefined
-}
+export type DeliveryOptions = EntityDeliveryOptions
 
 /** @internal */
 export interface EntityManagerOptions {

--- a/packages/platform/cloudflare/src/internal/entityWire.ts
+++ b/packages/platform/cloudflare/src/internal/entityWire.ts
@@ -35,10 +35,7 @@ export const InvokeResult = Schema.Union([
 ]) satisfies Schema.Codec<EntityInvokeResult>
 
 /** @internal */
-export type InvokeResult = EntityInvokeResult
-
-/** @internal */
-export const decodeInvokeResult = (value: unknown): Effect.Effect<InvokeResult> =>
+export const decodeInvokeResult = (value: unknown): Effect.Effect<EntityInvokeResult> =>
   Effect.orDie(Schema.decodeUnknownEffect(InvokeResult)(value))
 
 const EnvelopePeek = Schema.Struct({ tag: Schema.optional(Schema.String) })

--- a/packages/platform/cloudflare/src/internal/entityWire.ts
+++ b/packages/platform/cloudflare/src/internal/entityWire.ts
@@ -11,6 +11,7 @@ import * as ShardId from "effect/unstable/cluster/ShardId"
 import * as Headers from "effect/unstable/http/Headers"
 import * as Rpc from "effect/unstable/rpc/Rpc"
 import * as RpcSchema from "effect/unstable/rpc/RpcSchema"
+import type { EntityInvokeResult } from "../CloudflareDurableObjectPrograms.ts"
 import type { EntityRegistration } from "./entityRegistry.ts"
 
 type EncodedRequest = Extract<Envelope.Encoded, { readonly _tag: "Request" }>
@@ -31,10 +32,10 @@ export const InvokeResult = Schema.Union([
   Schema.Struct({ _tag: Schema.Literal("MailboxFull") }),
   Schema.Struct({ _tag: Schema.Literal("EncodedMessageTooLarge") }),
   Schema.Struct({ _tag: Schema.Literal("AskDeduplicatedToTell") })
-])
+]) satisfies Schema.Codec<EntityInvokeResult>
 
 /** @internal */
-export type InvokeResult = typeof InvokeResult.Type
+export type InvokeResult = EntityInvokeResult
 
 /** @internal */
 export const decodeInvokeResult = (value: unknown): Effect.Effect<InvokeResult> =>

--- a/packages/platform/cloudflare/src/internal/queueStorage.ts
+++ b/packages/platform/cloudflare/src/internal/queueStorage.ts
@@ -11,6 +11,7 @@
  * @internal
  */
 import type { SqlStorage } from "@cloudflare/workers-types"
+import type { DurableQueueItem } from "../CloudflareDurableObjectPrograms.ts"
 
 const ddl = [
   `CREATE TABLE IF NOT EXISTS queue_items (
@@ -41,11 +42,7 @@ export const ensureQueueStorage = (sql: SqlStorage): void => {
 }
 
 /** @internal */
-export interface QueueItem {
-  readonly id: string
-  readonly element: string
-  readonly attempts: number
-}
+export type QueueItem = DurableQueueItem
 
 type QueueItemRow = {
   readonly id: string

--- a/packages/platform/cloudflare/src/internal/workflowRegistry.ts
+++ b/packages/platform/cloudflare/src/internal/workflowRegistry.ts
@@ -11,6 +11,7 @@ import * as Context from "effect/Context"
 import type * as Effect from "effect/Effect"
 import type * as Workflow from "effect/unstable/workflow/Workflow"
 import * as WorkflowEngine from "effect/unstable/workflow/WorkflowEngine"
+import type { ClusterWorkflowRunOptions } from "../CloudflareDurableObjectPrograms.ts"
 import { makeRegistry } from "./registry.ts"
 
 /** @internal */
@@ -35,10 +36,7 @@ export const registerWorkflow: (name: string, registration: WorkflowRegistration
 export const unregisterWorkflow: (name: string, registration: WorkflowRegistration) => void = registry.unregister
 
 /** @internal */
-export interface WorkflowRunOptions {
-  readonly discard: boolean
-  readonly parent?: { readonly workflowName: string; readonly executionId: string } | undefined
-}
+export type WorkflowRunOptions = ClusterWorkflowRunOptions
 
 /**
  * The transport shared by workflow Durable Object stubs and same-isolate

--- a/packages/platform/cloudflare/test/AlchemyCloudflareCluster.test.ts
+++ b/packages/platform/cloudflare/test/AlchemyCloudflareCluster.test.ts
@@ -1,0 +1,61 @@
+import { inertClusterHandle, makeClusterHandle } from "@effect/platform-cloudflare/internal/alchemyCluster"
+import { assert, describe, it } from "@effect/vitest"
+import { Context, Effect } from "effect"
+import { Singleton } from "effect/unstable/cluster"
+import { Sharding } from "effect/unstable/cluster/Sharding"
+
+// The public `AlchemyCloudflareCluster.make` wires these handles to alchemy's
+// Durable Object declarations. The alchemy runtime tracks the published
+// `effect` release rather than this workspace, so the alchemy-importing glue
+// is covered by the typetest and the examples typecheck instead of executing
+// here.
+describe("AlchemyCloudflareCluster", () => {
+  it.effect("builds the cluster context from the namespace bindings", () =>
+    Effect.gen(function*() {
+      const getByNameCalls: Array<string> = []
+      const wakeCalls: Array<string> = []
+      const fakeNamespace = {
+        getByName: (name: string) => {
+          getByNameCalls.push(name)
+          return {
+            wake: () => {
+              wakeCalls.push(name)
+              return Promise.resolve()
+            }
+          }
+        }
+      }
+
+      const cluster = yield* makeClusterHandle({
+        entities: [],
+        layer: Singleton.make("maintenance", Effect.void),
+        env: {
+          ClusterEntity: fakeNamespace,
+          ClusterWorkflow: fakeNamespace,
+          ClusterDurableQueue: fakeNamespace,
+          ClusterSingleton: fakeNamespace
+        }
+      })
+
+      // The singleton registration fail-fast resolved its object eagerly.
+      assert.include(getByNameCalls, "Singleton/maintenance")
+
+      // The built context carries the cluster services and backs `provide`.
+      assert.isTrue(Context.getOption(cluster.context, Sharding)._tag === "Some")
+      assert.strictEqual(cluster.entityNamespace, fakeNamespace as any)
+      assert.strictEqual(yield* cluster.provide(Effect.succeed("ok")), "ok")
+
+      // `wake` resolves the singleton object lazily and calls its wake().
+      const wake = cluster.wake("maintenance")
+      assert.deepStrictEqual(wakeCalls, [])
+      yield* wake()
+      assert.deepStrictEqual(wakeCalls, ["Singleton/maintenance"])
+    }))
+
+  it.effect("the plan-time handle is inert", () =>
+    Effect.gen(function*() {
+      const cluster = inertClusterHandle()
+      assert.strictEqual(yield* cluster.provide(Effect.succeed("ok")), "ok")
+      yield* cluster.wake("maintenance")()
+    }))
+})

--- a/packages/platform/cloudflare/test/AlchemyCloudflareCluster.test.ts
+++ b/packages/platform/cloudflare/test/AlchemyCloudflareCluster.test.ts
@@ -26,13 +26,16 @@ describe("AlchemyCloudflareCluster", () => {
         }
       }
 
+      const entityNamespace = { getByName: () => undefined }
+      const workflowNamespace = { getByName: () => undefined }
+      const queueNamespace = { getByName: () => undefined }
       const cluster = yield* makeClusterHandle({
         entities: [],
         layer: Singleton.make("maintenance", Effect.void),
         env: {
-          ClusterEntity: fakeNamespace,
-          ClusterWorkflow: fakeNamespace,
-          ClusterDurableQueue: fakeNamespace,
+          ClusterEntity: entityNamespace,
+          ClusterWorkflow: workflowNamespace,
+          ClusterDurableQueue: queueNamespace,
           ClusterSingleton: fakeNamespace
         }
       })
@@ -42,7 +45,10 @@ describe("AlchemyCloudflareCluster", () => {
 
       // The built context carries the cluster services and backs `provide`.
       assert.isTrue(Context.getOption(cluster.context, Sharding)._tag === "Some")
-      assert.strictEqual(cluster.entityNamespace, fakeNamespace as any)
+      assert.strictEqual(cluster.entityNamespace, entityNamespace as any)
+      assert.strictEqual(cluster.workflowNamespace, workflowNamespace as any)
+      assert.strictEqual(cluster.queueNamespace, queueNamespace as any)
+      assert.strictEqual(cluster.singletonNamespace, fakeNamespace as any)
       assert.strictEqual(yield* cluster.provide(Effect.succeed("ok")), "ok")
 
       // `wake` resolves the singleton object lazily and calls its wake().
@@ -51,6 +57,25 @@ describe("AlchemyCloudflareCluster", () => {
       yield* wake()
       assert.deepStrictEqual(wakeCalls, ["Singleton/maintenance"])
     }))
+
+  for (
+    const field of [
+      "entityNamespace",
+      "workflowNamespace",
+      "queueNamespace",
+      "singletonNamespace",
+      "context"
+    ] as const
+  ) {
+    it(`diagnoses access to ${field} during plan evaluation`, () => {
+      const cluster = inertClusterHandle()
+      assert.throws(
+        () => cluster[field],
+        Error,
+        `AlchemyCloudflareCluster: '${field}' is only available at runtime, not during plan evaluation`
+      )
+    })
+  }
 
   it.effect("the plan-time handle is inert", () =>
     Effect.gen(function*() {

--- a/packages/platform/cloudflare/test/CloudflareDurableObjectPrograms.test.ts
+++ b/packages/platform/cloudflare/test/CloudflareDurableObjectPrograms.test.ts
@@ -1,0 +1,165 @@
+import type { DurableObjectProgramState } from "@effect/platform-cloudflare/CloudflareDurableObjectPrograms"
+import {
+  makeClusterDurableQueueProgram,
+  makeClusterEntityProgram,
+  makeClusterSingletonProgram,
+  makeClusterWorkflowProgram
+} from "@effect/platform-cloudflare/CloudflareDurableObjectPrograms"
+import { encodeName } from "@effect/platform-cloudflare/internal/clusterName"
+import { registerSingleton } from "@effect/platform-cloudflare/internal/singletonRegistry"
+import { assert, describe, it } from "@effect/vitest"
+import { Context, Effect, Exit } from "effect"
+
+class FakeSql {
+  readonly statements: Array<string> = []
+  earliestDeliverAt: number | null = null
+  earliestClockWakeUp: number | null = null
+  earliestLeaseExpiry: number | null = null
+  singletonState: { name: string | null; wake_at: number | null } | undefined
+  storedExecution: Record<string, unknown> | undefined
+
+  exec(query: string, ..._bindings: Array<unknown>) {
+    this.statements.push(query)
+    let rows: Array<Record<string, unknown>> = []
+    if (query.includes("min(deliver_at)")) {
+      rows = [{ deliver_at: this.earliestDeliverAt }]
+    } else if (query.includes("min(wake_up)")) {
+      rows = [{ wake_up: this.earliestClockWakeUp }]
+    } else if (query.includes("min(lease_until)")) {
+      rows = [{ lease_until: this.earliestLeaseExpiry }]
+    } else if (query.includes("FROM singleton_state")) {
+      rows = this.singletonState === undefined ? [] : [this.singletonState]
+    } else if (query.includes("FROM workflow_execution")) {
+      rows = this.storedExecution === undefined ? [] : [this.storedExecution]
+    }
+    return { toArray: () => rows }
+  }
+}
+
+class FakeState {
+  readonly sql = new FakeSql()
+  readonly alarms: Array<number> = []
+  name: string | undefined
+
+  constructor(name?: string) {
+    this.name = name
+  }
+
+  get state(): DurableObjectProgramState {
+    const sql = this.sql
+    const alarms = this.alarms
+    return {
+      id: { name: this.name },
+      storage: {
+        sql,
+        getAlarm: () => Promise.resolve(null),
+        setAlarm: (scheduledTime: number) => {
+          alarms.push(scheduledTime)
+          return Promise.resolve()
+        },
+        deleteAlarm: () => Promise.resolve()
+      } as unknown as DurableObjectProgramState["storage"],
+      exports: {},
+      waitUntil: () => {}
+    }
+  }
+}
+
+describe("CloudflareDurableObjectPrograms", () => {
+  describe("makeClusterEntityProgram", () => {
+    it.effect("dies on a non-canonical entity name", () =>
+      Effect.gen(function*() {
+        const exit = yield* Effect.exit(makeClusterEntityProgram(new FakeState("not-canonical").state))
+        assert.isTrue(Exit.hasDies(exit))
+      }))
+
+    it.effect("ensures the mailbox tables and re-arms the pending alarm", () =>
+      Effect.gen(function*() {
+        const fake = new FakeState(encodeName("User", "42"))
+        fake.sql.earliestDeliverAt = 1_234
+        yield* makeClusterEntityProgram(fake.state)
+        assert.isTrue(fake.sql.statements.some((statement) => statement.includes("cluster_messages")))
+        assert.deepStrictEqual(fake.alarms, [1_234])
+      }))
+
+    it.effect("skips the alarm without pending deliveries", () =>
+      Effect.gen(function*() {
+        const fake = new FakeState(encodeName("User", "42"))
+        yield* makeClusterEntityProgram(fake.state)
+        assert.deepStrictEqual(fake.alarms, [])
+      }))
+  })
+
+  describe("makeClusterWorkflowProgram", () => {
+    it.effect("dies on a non-canonical workflow name", () =>
+      Effect.gen(function*() {
+        const exit = yield* Effect.exit(makeClusterWorkflowProgram(new FakeState("not-canonical").state))
+        assert.isTrue(Exit.hasDies(exit))
+      }))
+
+    it.effect("re-arms the pending clock alarm", () =>
+      Effect.gen(function*() {
+        const fake = new FakeState(encodeName("SendEmail", "execution-1"))
+        fake.sql.earliestClockWakeUp = 5_678
+        yield* makeClusterWorkflowProgram(fake.state)
+        assert.isTrue(fake.sql.statements.some((statement) => statement.includes("workflow_execution")))
+        assert.deepStrictEqual(fake.alarms, [5_678])
+      }))
+
+    it.effect("treats an alarm without a stored execution as a no-op", () =>
+      Effect.gen(function*() {
+        const fake = new FakeState(undefined)
+        const program = yield* makeClusterWorkflowProgram(fake.state)
+        yield* program.alarm()
+      }))
+  })
+
+  describe("makeClusterDurableQueueProgram", () => {
+    it.effect("dies on a non-canonical queue name", () =>
+      Effect.gen(function*() {
+        const exit = yield* Effect.exit(makeClusterDurableQueueProgram(new FakeState("not-canonical").state))
+        assert.isTrue(Exit.hasDies(exit))
+      }))
+
+    it.effect("ensures the queue table and re-arms the pending lease alarm", () =>
+      Effect.gen(function*() {
+        const fake = new FakeState(encodeName("queue", "emails"))
+        fake.sql.earliestLeaseExpiry = 9_876
+        yield* makeClusterDurableQueueProgram(fake.state)
+        assert.isTrue(fake.sql.statements.some((statement) => statement.includes("queue_items")))
+        assert.deepStrictEqual(fake.alarms, [9_876])
+      }))
+  })
+
+  describe("makeClusterSingletonProgram", () => {
+    it.effect("dies without the Singleton/ name prefix", () =>
+      Effect.gen(function*() {
+        const exit = yield* Effect.exit(makeClusterSingletonProgram(new FakeState("not-prefixed").state))
+        assert.isTrue(Exit.hasDies(exit))
+      }))
+
+    it.effect("remembers the name and re-arms the watchdog alarm", () =>
+      Effect.gen(function*() {
+        const fake = new FakeState("Singleton/maintenance")
+        fake.sql.singletonState = { name: "Singleton/maintenance", wake_at: 4_321 }
+        yield* makeClusterSingletonProgram(fake.state)
+        assert.isTrue(fake.sql.statements.some((statement) => statement.includes("INSERT INTO singleton_state")))
+        assert.deepStrictEqual(fake.alarms, [4_321])
+      }))
+
+    it.effect("wakes the registered singleton", () =>
+      Effect.gen(function*() {
+        let ran = false
+        registerSingleton("program-test", {
+          run: Effect.sync(() => {
+            ran = true
+          }),
+          context: Context.empty()
+        })
+        const fake = new FakeState("Singleton/program-test")
+        const program = yield* makeClusterSingletonProgram(fake.state)
+        yield* program.wake()
+        assert.isTrue(ran)
+      }))
+  })
+})

--- a/packages/platform/cloudflare/test/CloudflareDurableObjectPrograms.test.ts
+++ b/packages/platform/cloudflare/test/CloudflareDurableObjectPrograms.test.ts
@@ -9,17 +9,21 @@ import { encodeName } from "@effect/platform-cloudflare/internal/clusterName"
 import { registerSingleton } from "@effect/platform-cloudflare/internal/singletonRegistry"
 import { assert, describe, it } from "@effect/vitest"
 import { Cause, Context, Effect, Exit } from "effect"
+import { TestClock } from "effect/testing"
 
 class FakeSql {
   readonly statements: Array<string> = []
+  readonly executions: Array<{ query: string; bindings: Array<unknown> }> = []
+  singletonReadError: Error | undefined
   earliestDeliverAt: number | null = null
   earliestClockWakeUp: number | null = null
   earliestLeaseExpiry: number | null = null
   singletonState: { name: string | null; wake_at: number | null } | undefined
   storedExecution: Record<string, unknown> | undefined
 
-  exec(query: string, ..._bindings: Array<unknown>) {
+  exec(query: string, ...bindings: Array<unknown>) {
     this.statements.push(query)
+    this.executions.push({ query, bindings })
     let rows: Array<Record<string, unknown>> = []
     if (query.includes("min(deliver_at)")) {
       rows = [{ deliver_at: this.earliestDeliverAt }]
@@ -30,6 +34,7 @@ class FakeSql {
     } else if (query.includes("UPDATE singleton_state SET wake_at = NULL")) {
       if (this.singletonState !== undefined) this.singletonState.wake_at = null
     } else if (query.includes("FROM singleton_state")) {
+      if (this.singletonReadError !== undefined) throw this.singletonReadError
       rows = this.singletonState === undefined ? [] : [this.singletonState]
     } else if (query.includes("FROM workflow_execution")) {
       rows = this.storedExecution === undefined ? [] : [this.storedExecution]
@@ -139,6 +144,19 @@ describe("CloudflareDurableObjectPrograms", () => {
   })
 
   describe("makeClusterWorkflowProgram", () => {
+    it.effect("uses the current TestClock time when finding due workflow clocks", () =>
+      Effect.gen(function*() {
+        yield* TestClock.setTime(1_000)
+        const fake = new FakeState(encodeName("SendEmail", "clock-test"))
+        const program = yield* makeClusterWorkflowProgram(fake.state)
+        yield* TestClock.adjust(500)
+        yield* program.alarm()
+        yield* TestClock.adjust(500)
+        yield* program.alarm()
+        const reads = fake.sql.executions.filter(({ query }) => query.includes("wake_up <= ?"))
+        assert.deepStrictEqual(reads.map(({ bindings }) => bindings), [[1_500], [2_000]])
+      }))
+
     it.effect("dies on a non-canonical workflow name", () =>
       Effect.gen(function*() {
         const exit = yield* Effect.exit(makeClusterWorkflowProgram(new FakeState("not-canonical").state))
@@ -180,6 +198,19 @@ describe("CloudflareDurableObjectPrograms", () => {
   })
 
   describe("makeClusterDurableQueueProgram", () => {
+    it.effect("uses the current TestClock time for queue lease extensions", () =>
+      Effect.gen(function*() {
+        yield* TestClock.setTime(1_000)
+        const fake = new FakeState(encodeName("queue", "clock-test"))
+        const program = yield* makeClusterDurableQueueProgram(fake.state)
+        yield* TestClock.adjust(500)
+        yield* program.extend("item-1", 300)
+        yield* TestClock.adjust(500)
+        yield* program.extend("item-1", 300)
+        const updates = fake.sql.executions.filter(({ query }) => query.includes("SET lease_until = ?"))
+        assert.deepStrictEqual(updates.map(({ bindings }) => bindings), [[1_800, "item-1"], [2_300, "item-1"]])
+      }))
+
     it.effect("dies on a non-canonical queue name", () =>
       Effect.gen(function*() {
         const exit = yield* Effect.exit(makeClusterDurableQueueProgram(new FakeState("not-canonical").state))
@@ -197,6 +228,65 @@ describe("CloudflareDurableObjectPrograms", () => {
   })
 
   describe("makeClusterSingletonProgram", () => {
+    it.effect("defers singleton state reads until the alarm Effect executes", () =>
+      Effect.gen(function*() {
+        const fake = new FakeState()
+        const program = yield* makeClusterSingletonProgram(fake.state)
+        const before = fake.sql.statements.length
+        const alarm = program.alarm()
+        assert.strictEqual(fake.sql.statements.length, before)
+        yield* alarm
+        assert.isAbove(fake.sql.statements.length, before)
+      }))
+
+    it.effect("captures singleton alarm storage errors in the Effect defect channel", () =>
+      Effect.gen(function*() {
+        const fake = new FakeState()
+        const program = yield* makeClusterSingletonProgram(fake.state)
+        const error = new Error("singleton state unavailable")
+        fake.sql.singletonReadError = error
+        // Construct the Effect directly: an eager throw here must fail this
+        // test, rather than being caught by an extra test-owned suspension.
+        const exit = yield* Effect.exit(program.alarm())
+        assert.isTrue(Exit.hasDies(exit))
+        if (Exit.isFailure(exit)) assert.strictEqual(Cause.squash(exit.cause), error)
+      }))
+
+    it.effect("observes a pending wake added after constructing the alarm Effect", () =>
+      Effect.gen(function*() {
+        let runs = 0
+        registerSingleton("program-deferred-state", {
+          run: Effect.sync(() => {
+            runs++
+          }),
+          context: Context.empty()
+        })
+        const fake = new FakeState("Singleton/program-deferred-state")
+        const program = yield* makeClusterSingletonProgram(fake.state)
+        const alarm = program.alarm()
+        fake.sql.singletonState = { name: "Singleton/program-deferred-state", wake_at: 1_000 }
+        yield* alarm
+        assert.strictEqual(runs, 1)
+        assert.strictEqual(fake.sql.singletonState.wake_at, null)
+        // Reusing the same Effect must observe the now-cleared pending wake.
+        yield* alarm
+        assert.strictEqual(runs, 1)
+        assert.strictEqual(fake.deletedAlarms, 1)
+      }))
+
+    it.effect("uses the current TestClock time for singleton watchdog alarms", () =>
+      Effect.gen(function*() {
+        yield* TestClock.setTime(1_000)
+        registerSingleton("program-clock", { run: Effect.void, context: Context.empty() })
+        const fake = new FakeState("Singleton/program-clock")
+        const program = yield* makeClusterSingletonProgram(fake.state)
+        yield* TestClock.adjust(500)
+        yield* program.wake()
+        yield* TestClock.adjust(500)
+        yield* program.wake()
+        assert.deepStrictEqual(fake.alarms, [1_500, 2_000])
+      }))
+
     it.effect("dies without the Singleton/ name prefix", () =>
       Effect.gen(function*() {
         const exit = yield* Effect.exit(makeClusterSingletonProgram(new FakeState("not-prefixed").state))

--- a/packages/platform/cloudflare/test/CloudflareDurableObjectPrograms.test.ts
+++ b/packages/platform/cloudflare/test/CloudflareDurableObjectPrograms.test.ts
@@ -8,7 +8,7 @@ import {
 import { encodeName } from "@effect/platform-cloudflare/internal/clusterName"
 import { registerSingleton } from "@effect/platform-cloudflare/internal/singletonRegistry"
 import { assert, describe, it } from "@effect/vitest"
-import { Context, Effect, Exit } from "effect"
+import { Cause, Context, Effect, Exit } from "effect"
 
 class FakeSql {
   readonly statements: Array<string> = []
@@ -27,6 +27,8 @@ class FakeSql {
       rows = [{ wake_up: this.earliestClockWakeUp }]
     } else if (query.includes("min(lease_until)")) {
       rows = [{ lease_until: this.earliestLeaseExpiry }]
+    } else if (query.includes("UPDATE singleton_state SET wake_at = NULL")) {
+      if (this.singletonState !== undefined) this.singletonState.wake_at = null
     } else if (query.includes("FROM singleton_state")) {
       rows = this.singletonState === undefined ? [] : [this.singletonState]
     } else if (query.includes("FROM workflow_execution")) {
@@ -39,6 +41,9 @@ class FakeSql {
 class FakeState {
   readonly sql = new FakeSql()
   readonly alarms: Array<number> = []
+  currentAlarm: number | null = null
+  alarmError: Error | undefined
+  deletedAlarms = 0
   name: string | undefined
 
   constructor(name?: string) {
@@ -52,12 +57,16 @@ class FakeState {
       id: { name: this.name },
       storage: {
         sql,
-        getAlarm: () => Promise.resolve(null),
+        getAlarm: () => Promise.resolve(this.currentAlarm),
         setAlarm: (scheduledTime: number) => {
+          if (this.alarmError !== undefined) return Promise.reject(this.alarmError)
           alarms.push(scheduledTime)
           return Promise.resolve()
         },
-        deleteAlarm: () => Promise.resolve()
+        deleteAlarm: () => {
+          this.deletedAlarms++
+          return Promise.resolve()
+        }
       } as unknown as DurableObjectProgramState["storage"],
       exports: {},
       waitUntil: () => {}
@@ -66,6 +75,45 @@ class FakeState {
 }
 
 describe("CloudflareDurableObjectPrograms", () => {
+  const constructors = [
+    ["entity", makeClusterEntityProgram],
+    ["workflow", makeClusterWorkflowProgram],
+    ["queue", makeClusterDurableQueueProgram],
+    ["singleton", makeClusterSingletonProgram]
+  ] as const
+
+  for (const [kind, make] of constructors) {
+    const pendingState = () => {
+      const fake = new FakeState(kind === "singleton" ? "Singleton/alarm-test" : encodeName("Test", "1"))
+      fake.sql.earliestDeliverAt = 2_000
+      fake.sql.earliestClockWakeUp = 2_000
+      fake.sql.earliestLeaseExpiry = 2_000
+      fake.sql.singletonState = { name: "Singleton/alarm-test", wake_at: 2_000 }
+      return fake
+    }
+
+    it.effect(`${kind} preserves an earlier alarm during construction`, () =>
+      Effect.gen(function*() {
+        const fake = pendingState()
+        fake.currentAlarm = 1_000
+        yield* make(fake.state)
+        assert.deepStrictEqual(fake.alarms, [])
+      }))
+
+    it.effect(`${kind} propagates failure to re-arm persisted work`, () =>
+      Effect.gen(function*() {
+        const fake = pendingState()
+        const error = new Error("alarm storage unavailable")
+        fake.alarmError = error
+        const construction: Effect.Effect<unknown> = make(fake.state)
+        const exit = yield* Effect.exit(construction)
+        assert.isTrue(Exit.isFailure(exit))
+        if (Exit.isFailure(exit)) {
+          assert.deepStrictEqual(Cause.squash(exit.cause), error)
+        }
+      }))
+  }
+
   describe("makeClusterEntityProgram", () => {
     it.effect("dies on a non-canonical entity name", () =>
       Effect.gen(function*() {
@@ -104,6 +152,23 @@ describe("CloudflareDurableObjectPrograms", () => {
         yield* makeClusterWorkflowProgram(fake.state)
         assert.isTrue(fake.sql.statements.some((statement) => statement.includes("workflow_execution")))
         assert.deepStrictEqual(fake.alarms, [5_678])
+      }))
+
+    it.effect("recovers the workflow name and persisted result after eviction", () =>
+      Effect.gen(function*() {
+        const fake = new FakeState()
+        const result = "{\"_tag\":\"Complete\"}"
+        fake.sql.storedExecution = {
+          workflow_name: "SendEmail",
+          execution_id: "execution-1",
+          payload: "{}",
+          parent_name: null,
+          parent_execution_id: null,
+          result,
+          resume_pending: 0
+        }
+        const program = yield* makeClusterWorkflowProgram(fake.state)
+        assert.strictEqual(yield* program.poll(), result)
       }))
 
     it.effect("treats an alarm without a stored execution as a no-op", () =>
@@ -145,6 +210,33 @@ describe("CloudflareDurableObjectPrograms", () => {
         yield* makeClusterSingletonProgram(fake.state)
         assert.isTrue(fake.sql.statements.some((statement) => statement.includes("INSERT INTO singleton_state")))
         assert.deepStrictEqual(fake.alarms, [4_321])
+      }))
+
+    it.effect("recovers the singleton name and completes a pending wake after eviction", () =>
+      Effect.gen(function*() {
+        let runs = 0
+        registerSingleton("program-recovered", {
+          run: Effect.sync(() => {
+            runs++
+          }),
+          context: Context.empty()
+        })
+        const fake = new FakeState()
+        fake.sql.singletonState = { name: "Singleton/program-recovered", wake_at: 4_321 }
+        const program = yield* makeClusterSingletonProgram(fake.state)
+        assert.strictEqual(runs, 0)
+        yield* program.alarm()
+        assert.strictEqual(runs, 1)
+        assert.strictEqual(fake.sql.singletonState.wake_at, null)
+        assert.strictEqual(fake.deletedAlarms, 1)
+        yield* program.alarm()
+        assert.strictEqual(runs, 1)
+      }))
+
+    it.effect("ignores an alarm without a pending singleton wake or registration", () =>
+      Effect.gen(function*() {
+        const program = yield* makeClusterSingletonProgram(new FakeState().state)
+        yield* program.alarm()
       }))
 
     it.effect("wakes the registered singleton", () =>

--- a/packages/platform/cloudflare/tsconfig.alchemy.json
+++ b/packages/platform/cloudflare/tsconfig.alchemy.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  // The Alchemy integration surface (examples + typetests) compiles in its
+  // own project: the alchemy type graph loads bun globals that would clash
+  // with the shared tests project's node globals.
+  "extends": "../../../tsconfig.base.json",
+  "include": ["examples", "typetest"],
+  "references": [{ "path": "../../../tsconfig.packages.json" }],
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "erasableSyntaxOnly": false,
+    "types": ["@cloudflare/workers-types"],
+    "paths": {
+      "effect": ["../../effect/src/index.ts"],
+      "effect/*": ["../../effect/src/*.ts"],
+      "@effect/platform-cloudflare": ["./src/index.ts"],
+      "@effect/platform-cloudflare/*": ["./src/*.ts"]
+    }
+  }
+}

--- a/packages/platform/cloudflare/tsconfig.alchemy.json
+++ b/packages/platform/cloudflare/tsconfig.alchemy.json
@@ -4,7 +4,7 @@
   // own project: the alchemy type graph loads bun globals that would clash
   // with the shared tests project's node globals.
   "extends": "../../../tsconfig.base.json",
-  "include": ["examples", "typetest"],
+  "include": ["examples", "typetest/AlchemyCloudflareCluster.tst.ts"],
   "references": [{ "path": "../../../tsconfig.packages.json" }],
   "compilerOptions": {
     "rootDir": ".",

--- a/packages/platform/cloudflare/typetest/AlchemyCloudflareCluster.tst.ts
+++ b/packages/platform/cloudflare/typetest/AlchemyCloudflareCluster.tst.ts
@@ -1,0 +1,142 @@
+/// <reference types="@cloudflare/workers-types" />
+import * as AlchemyCloudflareCluster from "@effect/platform-cloudflare/AlchemyCloudflareCluster"
+import * as Cloudflare from "alchemy/Cloudflare"
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import * as Schema from "effect/Schema"
+import { Entity, Singleton } from "effect/unstable/cluster"
+import { Sharding } from "effect/unstable/cluster/Sharding"
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse"
+import { Rpc } from "effect/unstable/rpc"
+import { describe, expect, test } from "tstyche"
+
+const Counter = Entity.make("Counter", [
+  Rpc.make("Increment", { success: Schema.Number })
+])
+
+const CounterLayer = Counter.toLayer(
+  Effect.sync(() =>
+    Counter.of({
+      Increment: () => Effect.succeed(1)
+    })
+  )
+)
+
+const MaintenanceLayer = Singleton.make("hourly-maintenance", Effect.void)
+
+class UserService extends Context.Service<UserService, "user">()("UserService") {}
+
+const made = AlchemyCloudflareCluster.make({
+  entities: [Counter],
+  layer: Layer.mergeAll(CounterLayer, MaintenanceLayer)
+})
+
+declare const cluster: Effect.Success<typeof made>
+
+describe("make", () => {
+  test("a layer needing only cluster services leaves just the Worker requirement", () => {
+    expect(made).type.toBe<
+      Effect.Effect<
+        AlchemyCloudflareCluster.Cluster<AlchemyCloudflareCluster.ClusterServices>,
+        never,
+        Cloudflare.Worker
+      >
+    >()
+  })
+
+  test("unsatisfied user layer requirements surface on the init program", () => {
+    const withService = AlchemyCloudflareCluster.make({
+      entities: [Counter],
+      layer: Layer.effectDiscard(Effect.gen(function*() {
+        yield* UserService
+      })).pipe(Layer.provideMerge(CounterLayer))
+    })
+    expect(withService).type.toBe<
+      Effect.Effect<
+        AlchemyCloudflareCluster.Cluster<AlchemyCloudflareCluster.ClusterServices>,
+        never,
+        Cloudflare.Worker | UserService
+      >
+    >()
+  })
+
+  test("user layer outputs join the handle context", () => {
+    const withOutput = AlchemyCloudflareCluster.make({
+      entities: [Counter],
+      layer: Layer.succeed(UserService, "user")
+    })
+    expect(withOutput).type.toBe<
+      Effect.Effect<
+        AlchemyCloudflareCluster.Cluster<UserService | AlchemyCloudflareCluster.ClusterServices>,
+        never,
+        Cloudflare.Worker
+      >
+    >()
+  })
+})
+
+describe("Cluster handle", () => {
+  test("provide eliminates the cluster services from user Effects", () => {
+    const handler = Effect.gen(function*() {
+      const makeCounter = yield* Counter.client
+      const value = yield* Effect.orDie(makeCounter("counter-1").Increment(void 0))
+      return HttpServerResponse.text(String(value))
+    })
+    expect(cluster.provide(handler)).type.toBe<
+      Effect.Effect<HttpServerResponse.HttpServerResponse>
+    >()
+  })
+
+  test("wake produces a handler acceptable to Cloudflare.Workers.cron", () => {
+    expect(cluster.wake("hourly-maintenance")).type.toBe<() => Effect.Effect<void>>()
+    expect(Cloudflare.Workers.cron).type.toBeCallableWith(
+      "0 * * * *",
+      cluster.wake("hourly-maintenance")
+    )
+  })
+
+  test("the namespace escape hatches are native bindings", () => {
+    expect(cluster.entityNamespace).type.not.toBe<any>()
+    expect(cluster.entityNamespace.getByName).type.toBeCallableWith("name")
+    expect(cluster.workflowNamespace).type.toBe<typeof cluster.entityNamespace>()
+    expect(cluster.queueNamespace).type.toBe<typeof cluster.entityNamespace>()
+    expect(cluster.singletonNamespace).type.toBe<typeof cluster.entityNamespace>()
+  })
+
+  test("the context carries the built services", () => {
+    expect(Context.get(cluster.context, Sharding)).type.toBe<Sharding["Service"]>()
+  })
+})
+
+describe("binding wiring", () => {
+  const app = Cloudflare.Worker(
+    "EffectCluster",
+    {
+      main: "./worker.ts"
+    },
+    Effect.gen(function*() {
+      const cluster = yield* made
+      yield* Cloudflare.Workers.cron("0 * * * *", cluster.wake("hourly-maintenance"))
+      return {
+        fetch: cluster.provide(Effect.succeed(HttpServerResponse.empty()))
+      }
+    }).pipe(Effect.provide(Cloudflare.Workers.CronEventSourceLive))
+  )
+
+  test("the worker init program satisfies the Effect-native Worker contract", () => {
+    expect(app).type.not.toBe<any>()
+    expect<Effect.Success<typeof app>>().type.toBeAssignableTo<Cloudflare.Worker>()
+  })
+
+  // The cluster's Durable Object bindings are declared at runtime via
+  // `worker.bind`, so they deliberately never appear in `InferEnv`; user env
+  // bindings resolve through it as usual.
+  test("user env bindings resolve through InferEnv", () => {
+    const withEnv = Cloudflare.Worker("EffectClusterEnv", {
+      main: "./worker.ts",
+      env: { COUNTER_HOST: "example.com" as string }
+    })
+    expect<Cloudflare.InferEnv<typeof withEnv>["COUNTER_HOST"]>().type.toBe<string>()
+  })
+})

--- a/packages/platform/cloudflare/typetest/AlchemyCloudflareCluster.tst.ts
+++ b/packages/platform/cloudflare/typetest/AlchemyCloudflareCluster.tst.ts
@@ -97,11 +97,11 @@ describe("Cluster handle", () => {
   })
 
   test("the namespace escape hatches are native bindings", () => {
-    expect(cluster.entityNamespace).type.not.toBe<any>()
-    expect(cluster.entityNamespace.getByName).type.toBeCallableWith("name")
-    expect(cluster.workflowNamespace).type.toBe<typeof cluster.entityNamespace>()
-    expect(cluster.queueNamespace).type.toBe<typeof cluster.entityNamespace>()
-    expect(cluster.singletonNamespace).type.toBe<typeof cluster.entityNamespace>()
+    expect(cluster.entityNamespace).type.toBe<DurableObjectNamespace>()
+    expect(cluster.workflowNamespace).type.toBe<DurableObjectNamespace>()
+    expect(cluster.queueNamespace).type.toBe<DurableObjectNamespace>()
+    expect(cluster.singletonNamespace).type.toBe<DurableObjectNamespace>()
+    expect(cluster.entityNamespace.getByName("name")).type.toBe<DurableObjectStub>()
   })
 
   test("the context carries the built services", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,6 +432,9 @@ importers:
         specifier: ^5.20260822.1
         version: 5.20260905.1
     devDependencies:
+      alchemy:
+        specifier: 2.0.0-beta.76
+        version: 2.0.0-beta.76(@effect/platform-bun@4.0.0-rc.112(effect@packages+effect))(@effect/platform-node@4.0.0-rc.112(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1)))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.4.1)(effect@packages+effect))(@effect/sql-pg@4.0.0-rc.112(effect@packages+effect))(@types/node@26.4.1)(@types/react@19.2.18)(effect@packages+effect)(mysql2@3.24.3(@types/node@26.4.1))(pg@8.23.0)(react-devtools-core@6.1.5)(typescript@7.0.2)(vite@8.2.2(@types/node@26.4.1)(esbuild@0.25.12)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vitest@5.0.0)(ws@8.21.3)
       effect:
         specifier: workspace:^
         version: link:../../effect
@@ -1060,6 +1063,37 @@ packages:
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
+  '@alcalzone/ansi-tokenize@0.2.5':
+    resolution: {integrity: sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==}
+    engines: {node: '>=18'}
+
+  '@alchemy.run/cloudflare-runtime@2.0.0-beta.76':
+    resolution: {integrity: sha512-rH5BFh0Xq7aExpSpITyQbC+Jqfc9XgwJXidHVHTi1tNRC6/KAWg4tOzBfwiFIxljFLLYcApzlYFvLa/fTYcEjw==}
+    peerDependencies:
+      '@distilled.cloud/cloudflare': 1.0.0-rc.8
+      '@effect/platform-bun': '>=4.0.0-rc.112 || >=4.0.0'
+      '@effect/platform-node': '>=4.0.0-rc.112 || >=4.0.0'
+      effect: '>=4.0.0-rc.112 || >=4.0.0'
+      rolldown: 1.2.5
+      vite: ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@effect/platform-bun':
+        optional: true
+      '@effect/platform-node':
+        optional: true
+      rolldown:
+        optional: true
+      vite:
+        optional: true
+
+  '@alchemy.run/floci@2.0.0-beta.76':
+    resolution: {integrity: sha512-UIKd+Hki3t5seDpLfyRBwWiNukKlbAqDCTOYBD+n49b/WQIgEWHhYXzGtnwC7OY/b3KAv5p7gsdn8IpPnRXR8g==}
+    peerDependencies:
+      effect: '>=4.0.0-rc.112 || >=4.0.0'
+
+  '@alchemy.run/node-utils@2.0.0-beta.76':
+    resolution: {integrity: sha512-KUAlGdoeWeMEToUP1V3I+mEf6FVzUjU+6Tc8savNvMsXN9t3uwZVqD1FeMzTMzMTJJijjxVljQTCtyoeE9W43w==}
+
   '@asamuzakjp/css-color@6.0.5':
     resolution: {integrity: sha512-mbhpPMmnw/kwW19aRNmSUl1QzLbdGo1SCuE49BT98MNwqF6zaHb3o2owssFc/PEO/4t2UjqtCNwocuDtJornzA==}
     engines: {node: ^22.13.0 || >=24.0.0}
@@ -1067,6 +1101,81 @@ packages:
   '@asamuzakjp/dom-selector@8.3.0':
     resolution: {integrity: sha512-UJLfKXBhrc8i1vH2eJXuYQMwlsLKWFw3O+CPqXSuVEiikeAim3UgrfWX0k4tA/X8cRFM8iZ7OaqBokFGbYusdg==}
     engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/core@3.977.9':
+    resolution: {integrity: sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.69':
+    resolution: {integrity: sha512-vpsh9VWmQVC/nsdzf72F2yUMBOFT1aq+hoLseYV03zjVXVHkjqSNJskFRKPFxc3MRFrHNbSSmOwsbYE15u9ecw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    resolution: {integrity: sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    resolution: {integrity: sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    resolution: {integrity: sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    resolution: {integrity: sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.82':
+    resolution: {integrity: sha512-znDkEOGXB8W3kG1LJUKP3foBZY/9qLM0eil/DxWXSp37XsdsRLQHE/d/OaCGGVgKpA6znR38h/+INk8do1FjiA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    resolution: {integrity: sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    resolution: {integrity: sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    resolution: {integrity: sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-providers@3.1127.0':
+    resolution: {integrity: sha512-zyoeKOan26lklS12+Iwj1aX8EidoAheQaVRmltee0EAC3eydTy+AIXtLOsVicYSOVsDjPJMiVykT/7n47ARpag==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.44':
+    resolution: {integrity: sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    resolution: {integrity: sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1116.0':
+    resolution: {integrity: sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.5':
+    resolution: {integrity: sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.40':
+    resolution: {integrity: sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@azure-rest/core-client@2.9.0':
     resolution: {integrity: sha512-6933vNLqh06RR7rumnrq3UZIeBtRLeBHDPMrieDPIljiCaMMwt0nRw++nd3TOxiohtasNtm29rC+b/9ZVKCOqg==}
@@ -1599,6 +1708,18 @@ packages:
     resolution: {integrity: sha512-q/ThtP9gcnEP6xlv7LrY26C2mHqdGBti/MmOVngt/M/oIGYkssmQGxPK9WzBNt2juVcH/vml2WQ+ra8LXYOTaA==}
     engines: {node: ^22.11 || ^24 || >=26}
 
+  '@chevrotain/cst-dts-gen@10.5.0':
+    resolution: {integrity: sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==}
+
+  '@chevrotain/gast@10.5.0':
+    resolution: {integrity: sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==}
+
+  '@chevrotain/types@10.5.0':
+    resolution: {integrity: sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==}
+
+  '@chevrotain/utils@10.5.0':
+    resolution: {integrity: sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==}
+
   '@clack/core@1.4.3':
     resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
     engines: {node: '>= 20.12.0'}
@@ -1611,6 +1732,21 @@ packages:
     resolution: {integrity: sha512-vs3/Zc1dHvT171btW5nMoPsPCJ6QVJ5pp7obxzO5sjqwFx/jjz9wwCAqcFOdc2DhprugDBaVn+4dVY8hG3A9nw==}
     engines: {node: '>=20'}
 
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260704.1':
+    resolution: {integrity: sha512-XO+vvdhhTNZSsIWCkZ+JaE/JrFUmQAB0H0y/sVkAf32xa2TYBRvFUMwjSqf6WxtlxcKPQvmbLfpO/UQ0l/q4eQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
   '@cloudflare/workerd-darwin-64@1.20260730.1':
     resolution: {integrity: sha512-+MBHmPaiTe2KajryW0T24rZvWFxb41hD3d8anNzQqHzft6vSEb18+sp0znSwxgij7ApPhSM1+vhkNg4f3YMguA==}
     engines: {node: '>=16'}
@@ -1621,6 +1757,12 @@ packages:
     resolution: {integrity: sha512-FG+4mGxAXhKiL/1temH42alevIkumtYXNidhTa//3yULpzux6APw5UNVocI/vCQ1yG1YOEZRfbVy8lyuipM9MQ==}
     engines: {node: '>=16'}
     cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260704.1':
+    resolution: {integrity: sha512-6iI7nbOOO8PzEQ6UZVBZB/hv95m8jl0yvyjMuWrF5cJbiLb5zPw3KnpqvGi+aeOs2ZmUkc81i1FWKfXwLXzPRA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
     os: [darwin]
 
   '@cloudflare/workerd-darwin-arm64@1.20260730.1':
@@ -1635,6 +1777,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@cloudflare/workerd-linux-64@1.20260704.1':
+    resolution: {integrity: sha512-3mT0YHtxT7eLjghu3hKSJDUQoz+AYv8FM43nLPYhM0YiHOxr8OlmvnCb2Lp7v/U3bwd3Gnx7WEqjSppR583mGg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
   '@cloudflare/workerd-linux-64@1.20260730.1':
     resolution: {integrity: sha512-ouyPOSMbiKPeSwUJUvxtMcxGAXs2J4aPE4T5ABIYX5ClcQx5j5bbHTmnqOQEY8sAuLTPjH7dY+iB6UI5ISlwwA==}
     engines: {node: '>=16'}
@@ -1645,6 +1793,12 @@ packages:
     resolution: {integrity: sha512-/VEvvtQ/XKf6HlBbg6FbvpwcpfYUcx6Fv6RkASY8DyEmUyuJ8rc7Qxil83ClRFoBzz/GY0BV94UZ6F+wers/hg==}
     engines: {node: '>=16'}
     cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260704.1':
+    resolution: {integrity: sha512-Opo7cPTPg4x0WwK+eZSDszCyFLKQkOGNCWxF005HRTJ5SJH8h0K9KyrC1k4LBwx3haXSVi+E1eGqo1gZ1Hmhkg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
     os: [linux]
 
   '@cloudflare/workerd-linux-arm64@1.20260730.1':
@@ -1658,6 +1812,12 @@ packages:
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260704.1':
+    resolution: {integrity: sha512-a97Ecnzhy04x3U052VKPCNp863F7Wf00WY7Ga5P0SbtYvaO1PDzylsHrvFMPKeiDFcOwqiredawmJ+v6bhIgeQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
 
   '@cloudflare/workerd-windows-64@1.20260730.1':
     resolution: {integrity: sha512-27fAN+vUECW1oYVc1KOcHYpkL8COM2Uxtxql7TL595kxbjoqS5yckw7NLz7bTf2pALFCZWjqXDjZGJ/xbG4ZKQ==}
@@ -1721,6 +1881,51 @@ packages:
   '@discoveryjs/json-ext@1.1.0':
     resolution: {integrity: sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA==}
     engines: {node: '>=14.17.0'}
+
+  '@distilled.cloud/aws@1.0.0-rc.8':
+    resolution: {integrity: sha512-eL4tRACU4TSykk/6+ItwUTZs93r3tRlrBn36ohqaUxqYYOfmssYlt/SLCzos4nlLgCxb+1T6BAstgYC848v1EQ==}
+    peerDependencies:
+      effect: '>=4.0.0-rc.112 || >=4.0.0'
+
+  '@distilled.cloud/axiom@1.0.0-rc.8':
+    resolution: {integrity: sha512-lczeM0FPuF1mLZu7V8vcj8Klm9b1VSo4A75PP2a4km/cjphDl9LKamUwrSGLEY9denmqd1nn4+g2Svw1UmGpEw==}
+    peerDependencies:
+      effect: '>=4.0.0-rc.112 || >=4.0.0'
+
+  '@distilled.cloud/cloudflare@1.0.0-rc.8':
+    resolution: {integrity: sha512-nhEyGOaupi/JmT0PS1DEMH5Ebwu004pvQv3Emzt9MJz3mF3LTdiuAnxP86rf3jsFtfa826TDokKArVMq55OKRA==}
+    peerDependencies:
+      effect: '>=4.0.0-rc.112 || >=4.0.0'
+
+  '@distilled.cloud/core@1.0.0-rc.8':
+    resolution: {integrity: sha512-baZMSaBh9kEyAqdhO+UbkvVDK+wqyI8d0UW0paSp5CqVResOl7ydHU4tCbBUOLoxOrqLRWfmImKrhW9SY1R8qw==}
+    peerDependencies:
+      effect: '>=4.0.0-rc.112 || >=4.0.0'
+
+  '@distilled.cloud/fly-io@1.0.0-rc.8':
+    resolution: {integrity: sha512-0HqVLIpBxmuvrIrnmziz8iK39F5cBxkHlz43WR2s+tFidbPlCzmnci6gxixxiwMBCzcmiRmv57xQxuQzgfDQMw==}
+    peerDependencies:
+      effect: '>=4.0.0-rc.112 || >=4.0.0'
+
+  '@distilled.cloud/hetzner@1.0.0-rc.8':
+    resolution: {integrity: sha512-CAPj912qUQXMetyFvJEc7PJnSG4DR6RBvGXCOfQcJVgGTspt/IdT3iIeIInTUf6rgFRsqoGiRfS4ywTqWoqLFA==}
+    peerDependencies:
+      effect: '>=4.0.0-rc.112 || >=4.0.0'
+
+  '@distilled.cloud/neon@1.0.0-rc.8':
+    resolution: {integrity: sha512-xIgxgoDyIs/G5lW8T2r4oyHpOcRzBO1wu7p46lU3ppuJ2rlJR4pmP9dF7KxStAVglr9yK3wmmmnraLoCAtd8Sg==}
+    peerDependencies:
+      effect: '>=4.0.0-rc.112 || >=4.0.0'
+
+  '@distilled.cloud/planetscale@1.0.0-rc.8':
+    resolution: {integrity: sha512-D0mnkT2Gnk/SKWoz05rkf7+sngH8+5m5ugjQ1GycsFMfTxUVSIVUIHX9yrO5vFrTsMlNsmrMR+7a9R3ZMGCWkA==}
+    peerDependencies:
+      effect: '>=4.0.0-rc.112 || >=4.0.0'
+
+  '@distilled.cloud/railway@1.0.0-rc.8':
+    resolution: {integrity: sha512-VW2YdbblVHhYww5JVtOjFlv3jBFl7xlt6/xTfkNxxgXgzJ5GYVlD3gPgBIpGy9Pcnv9rVRA6CL7QZeYeu47c9Q==}
+    peerDependencies:
+      effect: '>=4.0.0-rc.112 || >=4.0.0'
 
   '@dprint/android-arm64@0.57.3':
     resolution: {integrity: sha512-/HJd2SefzKS+Z+n1T7IJYAumG53g3+w8idxCyV8Q/dqX2utjXHTH5zTKTZousERy/4UR2M7CwaNxiHS+IN6PKA==}
@@ -1819,6 +2024,44 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
+  '@effect/platform-bun@4.0.0-rc.112':
+    resolution: {integrity: sha512-Y5n2HhV/vsbrJls9ukX42RL7zqXQxISHegWFsP9njsCyDmGTnq7QYSO82rglwrLPwtTrv5dkSRTuGw4+oXxgMg==}
+    peerDependencies:
+      effect: ^4.0.0-rc.112
+
+  '@effect/platform-node-shared@4.0.0-rc.112':
+    resolution: {integrity: sha512-ttjz0xKamFN7vL8pNDYVwddJLjZvqKePc05djlz2VcdaKbLsnYbtMnL1rbOfHgEnIUSHGh7FkjaN4DM1Ov81sQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      effect: ^4.0.0-rc.112
+
+  '@effect/platform-node@4.0.0-rc.112':
+    resolution: {integrity: sha512-/BMAcdNGQQskLmI0Zoa95KfTZkr9HV9N4NSxaSrusG6GeW6Ulp9KvZ+Rlaiw8lnOt43CXjFLdfll5/k5rxL4hQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      effect: ^4.0.0-rc.112
+      redis: '>=5.0.0 <7.0.0'
+
+  '@effect/sql-d1@4.0.0-rc.112':
+    resolution: {integrity: sha512-Wxdr6aU3pBHqhyBiybzbHmEK7qZ2w4iy0IxBgJHe9BLleYzCxObOaBQI9qq/VZSqEvc0IaOBMpbk2zh3dlPNSQ==}
+    peerDependencies:
+      effect: ^4.0.0-rc.112
+
+  '@effect/sql-mysql2@4.0.0-rc.112':
+    resolution: {integrity: sha512-2tInSVhOGCfuWiBD+RF2QBmadr5L7woA7Hz+Z9d21AZQftw5IACo30hdm8wKE4QIzffSjAy8qaJIC7NcCqZ9hQ==}
+    peerDependencies:
+      effect: ^4.0.0-rc.112
+
+  '@effect/sql-pg@4.0.0-rc.112':
+    resolution: {integrity: sha512-UYUA3LAGH1Pg88Yau7eTlTLHRrIb/uTdxdPGxVcRdIjjrTzxtA7iKHR4hcmUeq5lQEcGLCopN7E4ffsAKF8vEQ==}
+    peerDependencies:
+      effect: ^4.0.0-rc.112
+
+  '@effect/sql-sqlite-do@4.0.0-rc.112':
+    resolution: {integrity: sha512-PewNVasimmhrdxYbNU91O0YlCcalIHOoF0H5XAWXrmzcEQrKM7kVCyb5h0gmJAZjBM4ZgWRvPY0PUOfbNmWchQ==}
+    peerDependencies:
+      effect: ^4.0.0-rc.112
+
   '@effect/tsgo-darwin-arm64@0.41.0':
     resolution: {integrity: sha512-3iEPtcHF72yDjv7T5YpnX+Io1LDLywJb1oGG3Fp/Fth4xmqiT1Vacyz5wnPCfEWGQ6CyrlyCZSSjUxPyJ70+DQ==}
     cpu: [arm64]
@@ -1858,8 +2101,28 @@ packages:
     resolution: {integrity: sha512-C/U7lFM0AXsfpqRilDOgwu+llBhAo8bcdIlzgbRWf1LWlU4KZKB2UsUvBPL3qPnm+wmbCvQLeTQc4BjV9oJrcg==}
     hasBin: true
 
+  '@effect/vitest@4.0.0-rc.112':
+    resolution: {integrity: sha512-mEKh/FI64mt8JK1/v9mpOrJYdnp+UFZdRUBMEdZMiKz7klg6NPqVgg/oeAGH6wOOQc2iAPcfc2H9BbAv1KyzMQ==}
+    peerDependencies:
+      effect: ^4.0.0-rc.112
+      vitest: '>=4.1.0 <5.0.0'
+
   '@effect/wa-sqlite@0.2.1':
     resolution: {integrity: sha512-vMnGIHKWSIFnDf7+n7lP2vyXPzORJotkaRI8LKyJw3eNjsvFopHYVaaGSeMSSVTm/w45pC5T4JdLrD6nxSR4oQ==}
+
+  '@electric-sql/pglite-socket@0.0.20':
+    resolution: {integrity: sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg==}
+    hasBin: true
+    peerDependencies:
+      '@electric-sql/pglite': 0.3.15
+
+  '@electric-sql/pglite-tools@0.2.20':
+    resolution: {integrity: sha512-BK50ZnYa3IG7ztXhtgYf0Q7zijV32Iw1cYS8C+ThdQlwx12V5VZ9KRJ42y82Hyb4PkTxZQklVQA9JHyUlex33A==}
+    peerDependencies:
+      '@electric-sql/pglite': 0.3.15
+
+  '@electric-sql/pglite@0.3.15':
+    resolution: {integrity: sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==}
 
   '@electric-sql/pglite@0.5.8':
     resolution: {integrity: sha512-n9tsbUOhwx2epK1V0ZG9Ar4SHWUju04dhmzZXiSBXwBoleOvIfals33NAaWgagQVAL4Rbvx/Ptsu3P+pA09f6Q==}
@@ -2209,6 +2472,12 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  '@hono/node-server@1.19.9':
+    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -2219,8 +2488,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@img/sharp-darwin-arm64@0.35.4':
+    resolution: {integrity: sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-darwin-x64@0.35.2':
     resolution: {integrity: sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.35.4':
+    resolution: {integrity: sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [darwin]
@@ -2230,8 +2511,18 @@ packages:
     engines: {node: '>=20.9.0'}
     os: [freebsd]
 
+  '@img/sharp-freebsd-wasm32@0.35.4':
+    resolution: {integrity: sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
   '@img/sharp-libvips-darwin-arm64@1.3.1':
     resolution: {integrity: sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.3':
+    resolution: {integrity: sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==}
     cpu: [arm64]
     os: [darwin]
 
@@ -2240,8 +2531,19 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-darwin-x64@1.3.3':
+    resolution: {integrity: sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==}
+    cpu: [x64]
+    os: [darwin]
+
   '@img/sharp-libvips-linux-arm64@1.3.1':
     resolution: {integrity: sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm64@1.3.3':
+    resolution: {integrity: sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -2252,8 +2554,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-arm@1.3.3':
+    resolution: {integrity: sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-ppc64@1.3.1':
     resolution: {integrity: sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.3':
+    resolution: {integrity: sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -2264,8 +2578,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-riscv64@1.3.3':
+    resolution: {integrity: sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-s390x@1.3.1':
     resolution: {integrity: sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.3.3':
+    resolution: {integrity: sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -2276,8 +2602,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-x64@1.3.3':
+    resolution: {integrity: sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
     resolution: {integrity: sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
+    resolution: {integrity: sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
@@ -2288,8 +2626,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
+    resolution: {integrity: sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-linux-arm64@0.35.2':
     resolution: {integrity: sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm64@0.35.4':
+    resolution: {integrity: sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
@@ -2302,8 +2653,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-arm@0.35.4':
+    resolution: {integrity: sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-ppc64@0.35.2':
     resolution: {integrity: sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.35.4':
+    resolution: {integrity: sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==}
     engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
@@ -2316,8 +2681,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-riscv64@0.35.4':
+    resolution: {integrity: sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-s390x@0.35.2':
     resolution: {integrity: sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.35.4':
+    resolution: {integrity: sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==}
     engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
@@ -2330,8 +2709,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-x64@0.35.4':
+    resolution: {integrity: sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linuxmusl-arm64@0.35.2':
     resolution: {integrity: sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-arm64@0.35.4':
+    resolution: {integrity: sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
@@ -2344,8 +2737,19 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-linuxmusl-x64@0.35.4':
+    resolution: {integrity: sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-wasm32@0.35.2':
     resolution: {integrity: sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-wasm32@0.35.4':
+    resolution: {integrity: sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==}
     engines: {node: '>=20.9.0'}
 
   '@img/sharp-webcontainers-wasm32@0.35.2':
@@ -2353,8 +2757,19 @@ packages:
     engines: {node: '>=20.9.0'}
     cpu: [wasm32]
 
+  '@img/sharp-webcontainers-wasm32@0.35.4':
+    resolution: {integrity: sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
   '@img/sharp-win32-arm64@0.35.2':
     resolution: {integrity: sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-arm64@0.35.4':
+    resolution: {integrity: sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
@@ -2365,8 +2780,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@img/sharp-win32-ia32@0.35.4':
+    resolution: {integrity: sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@img/sharp-win32-x64@0.35.2':
     resolution: {integrity: sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.4':
+    resolution: {integrity: sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
@@ -2485,8 +2912,14 @@ packages:
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
 
+  '@libsql/client@0.17.4':
+    resolution: {integrity: sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw==}
+
   '@libsql/client@0.18.0':
     resolution: {integrity: sha512-zMCCo58vv7w27j7+cnt/GW+X6/Rih6cHZ86PKi0AxCMOqMfrVgG9OZ5lW2bDMJhSeOjsv2szH2nJF3A9l36UmA==}
+
+  '@libsql/core@0.17.4':
+    resolution: {integrity: sha512-LqF9gIvnJ38nmAH1y/ChizHqDO/MO1wLgA96XrraulEEbqXxLjleSH92YWTolbuJKgPUmGu4aJk9W3UnAcxLOQ==}
 
   '@libsql/core@0.18.0':
     resolution: {integrity: sha512-N8RR2CIpcgtbKZnXs2KVpw2lJQfinUj3I56e7qRDRpK18Hty0Rr8nr00VmFb4R/DsqOanPB/TaP3+QAQLZeXMg==}
@@ -2554,6 +2987,10 @@ packages:
     resolution: {integrity: sha512-6QEf6yqFbETdwGITKq57aYoPfX/3K8XFNwsAlx0C1M7o8cb79sv1M3w+tWuWvIcSbNqrLF7OD7YpZMVVz335hQ==}
     engines: {node: '>=20.0.0'}
 
+  '@mrleebo/prisma-ast@0.13.1':
+    resolution: {integrity: sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw==}
+    engines: {node: '>=16'}
+
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
     engines: {node: ^22.20 || ^24.12 || >=25}
@@ -2563,6 +3000,90 @@ packages:
 
   '@neon-rs/load@0.0.4':
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
+
+  '@nodable/entities@3.0.0':
+    resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.8':
+    resolution: {integrity: sha512-L7y8eYc+AwxGr2PWI4WFt1VG4TiJ66c26BD16mXpYIlXxG0SMigM1+m4aTSlYyBr5BlQsGAlz8uDCoZN4SEMcg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.5':
+    resolution: {integrity: sha512-iXa654H3yFafF/ieHkukfbgWo2rmXD2ceD0ZOtrPhw1bc3FDch1d9N/TNs0FQ1/cIbwb7kspUX8jzIs8nzb9DQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.5':
+    resolution: {integrity: sha512-bt/hm03LeU6Vy7FwTrkkC9p3XGT/lBwClglMqxBSe5/q0E5CdJTXeAqEI0vlw89/LF/G6tryTIH8HirZ3prMVg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/openapi-types@29.0.1':
+    resolution: {integrity: sha512-9qWOMFNxxLokERcms42rU0PTLqQmVs7g5E41TI4mCOxmpFayD1rfC7XxOL55cG9MBZLFlC31BrR37myMKardwg==}
+
+  '@octokit/openapi-webhooks-types@12.1.0':
+    resolution: {integrity: sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA==}
+
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-request-log@6.0.0':
+    resolution: {integrity: sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/request-error@7.1.2':
+    resolution: {integrity: sha512-XZRuT3xZ84D3gYErI1DZvhJ33dCWVV6uzBtWkaBB4TvA/L6eOeTZodxLFVB44bBEEo3vEx7y00UfX1tBLrtLRg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.16':
+    resolution: {integrity: sha512-A0zWGjHzISIb+9ccG8s0dq7LKO5zVpJLRICjgUb+sJxEWqn8RUHB1rD3AE51+PECvXHIxqZ1VVvs4fHTSD9nUQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/rest@22.0.1':
+    resolution: {integrity: sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@octokit/types@18.0.0':
+    resolution: {integrity: sha512-l6bAF43PNxkJp6g+W4PjoUSSkxHomXw2nOum5CTftJz1NlV3vu93NImgOYtLf6CbBUb5j+fiuzW0PPQ5JTSvZA==}
+
+  '@octokit/webhooks-methods@6.0.0':
+    resolution: {integrity: sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/webhooks@14.2.0':
+    resolution: {integrity: sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw==}
+    engines: {node: '>= 20'}
 
   '@op-engineering/op-sqlite@18.2.0':
     resolution: {integrity: sha512-H3zWRYL2rJvmxNb2wwdhQJW42QutxJG8q8m4a4XBaDzNYYfGVqv6z1QWUVQ0rV4pjyEVYm5zMs75Z4jeVaow+A==}
@@ -2669,6 +3190,9 @@ packages:
   '@opentelemetry/semantic-conventions@1.43.0':
     resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
     engines: {node: '>=14'}
+
+  '@oxc-project/types@0.146.0':
+    resolution: {integrity: sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==}
 
   '@oxc-project/types@0.148.0':
     resolution: {integrity: sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==}
@@ -2819,6 +3343,18 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
+  '@prisma/debug@7.2.0':
+    resolution: {integrity: sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==}
+
+  '@prisma/dev@0.20.0':
+    resolution: {integrity: sha512-ovlBYwWor0OzG+yH4J3Ot+AneD818BttLA+Ii7wjbcLHUrnC4tbUPVGyNd3c/+71KETPKZfjhkTSpdS15dmXNQ==}
+
+  '@prisma/get-platform@7.2.0':
+    resolution: {integrity: sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==}
+
+  '@prisma/query-plan-executor@7.2.0':
+    resolution: {integrity: sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==}
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -2845,6 +3381,19 @@ packages:
 
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
+
+  '@puppeteer/browsers@3.2.2':
+    resolution: {integrity: sha512-q2BU4YfO9h/Wt7IcWPcggpOOqLk2Tbs1hDwolvKZrweRjy751OJBKMN9zO5bfD0pzU7X/tvKw/exQds4pM/LOg==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+    peerDependencies:
+      proxy-agent: '>=8.0.1'
+      yauzl: ^2.10.0 || ^3.4.0
+    peerDependenciesMeta:
+      proxy-agent:
+        optional: true
+      yauzl:
+        optional: true
 
   '@react-native/assets-registry@0.83.0':
     resolution: {integrity: sha512-EmGSKDvmnEnBrTK75T+0Syt6gy/HACOTfziw5+392Kr1Bb28Rv26GyOIkvptnT+bb2VDHU0hx9G0vSy5/S3rmQ==}
@@ -2948,10 +3497,22 @@ packages:
     resolution: {integrity: sha512-o/0VgsBXgwcY1lyeqcVtSGdTQAPnVggo0fbFVPlxl5XVDKUcVH0OLRqt3CbkwByT5FU305E0iE0O7MzThjDblw==}
     engines: {node: '>=18.17.0', npm: '>=9.5.0'}
 
+  '@rolldown/binding-android-arm-eabi@1.2.5':
+    resolution: {integrity: sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@rolldown/binding-android-arm-eabi@1.2.7':
     resolution: {integrity: sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.2.5':
+    resolution: {integrity: sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
     os: [android]
 
   '@rolldown/binding-android-arm64@1.2.7':
@@ -2960,10 +3521,22 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-darwin-arm64@1.2.5':
+    resolution: {integrity: sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rolldown/binding-darwin-arm64@1.2.7':
     resolution: {integrity: sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.5':
+    resolution: {integrity: sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.2.7':
@@ -2972,17 +3545,36 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-freebsd-x64@1.2.5':
+    resolution: {integrity: sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@rolldown/binding-freebsd-x64@1.2.7':
     resolution: {integrity: sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.5':
+    resolution: {integrity: sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm-gnueabihf@1.2.7':
     resolution: {integrity: sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.5':
+    resolution: {integrity: sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.2.7':
     resolution: {integrity: sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==}
@@ -2991,6 +3583,13 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-arm64-musl@1.2.5':
+    resolution: {integrity: sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-linux-arm64-musl@1.2.7':
     resolution: {integrity: sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2998,10 +3597,24 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-ppc64-gnu@1.2.5':
+    resolution: {integrity: sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-ppc64-gnu@1.2.7':
     resolution: {integrity: sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.5':
+    resolution: {integrity: sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
@@ -3012,12 +3625,26 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-x64-gnu@1.2.5':
+    resolution: {integrity: sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-x64-gnu@1.2.7':
     resolution: {integrity: sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.2.5':
+    resolution: {integrity: sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.2.7':
     resolution: {integrity: sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==}
@@ -3026,16 +3653,34 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-openharmony-arm64@1.2.5':
+    resolution: {integrity: sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@rolldown/binding-openharmony-arm64@1.2.7':
     resolution: {integrity: sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
+  '@rolldown/binding-win32-arm64-msvc@1.2.5':
+    resolution: {integrity: sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@rolldown/binding-win32-arm64-msvc@1.2.7':
     resolution: {integrity: sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.5':
+    resolution: {integrity: sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [win32]
 
   '@rolldown/binding-win32-x64-msvc@1.2.7':
@@ -3234,6 +3879,54 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
+  '@smithy/core@3.33.3':
+    resolution: {integrity: sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.5.2':
+    resolution: {integrity: sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.8.0':
+    resolution: {integrity: sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-config-provider@4.6.2':
+    resolution: {integrity: sha512-zMrXu/O5tPa7GLtra8L4wFG6DACcXT9QV4Ay+WEAjUhXm1dVq7c/q9Qv9gkJZNLY8hmQKg08778kDcxpKNMqOA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.12.1':
+    resolution: {integrity: sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.7.2':
+    resolution: {integrity: sha512-XsIDj5gVG4YRxGS4n4TiBDAogPWRHXKZyor6JW/sEuaa/7BvKADe9j45jI2dPYCnYbKkLBmbZ4qN9ns0sH+kMQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.7.3':
+    resolution: {integrity: sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.18.0':
+    resolution: {integrity: sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.6.2':
+    resolution: {integrity: sha512-wTQX1hPfElIqY6AzM/s6c4UgpMxCL4MwJ5u6340ksLPq78lur6Y+keheIDk5gMX4G3KFh4MERcDt6xhRq+ie1Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
   '@solidjs/testing-library@0.8.10':
     resolution: {integrity: sha512-qdeuIerwyq7oQTIrrKvV0aL9aFeuwTd86VYD3afdq5HYEwoox1OBTJy4y8A3TFZr8oAR0nujYgCzY/8wgHGfeQ==}
     engines: {node: '>= 14'}
@@ -3351,6 +4044,9 @@ packages:
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/aws-lambda@8.10.163':
+    resolution: {integrity: sha512-+4zuoEB3S8RIhimtOFT7zAEk2SbpwrKjjGl9CyYnQR6k08uynxfauIIB0pDU1ssr05F8oyGiETwpn+8eXZMqPw==}
 
   '@types/babel__code-frame@7.27.0':
     resolution: {integrity: sha512-Dwlo+LrxDx/0SpfmJ/BKveHf7QXWvLBLc+x03l5sbzykj3oB9nHygCpSECF1a+s+QIxbghe+KHqC90vGtxLRAA==}
@@ -3722,12 +4418,65 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
+  alchemy@2.0.0-beta.76:
+    resolution: {integrity: sha512-XpcsXWk38YV9nO0v7s5PPjlMVtF8OQPeP8YqLu1iMzrq33bwViEOqkwQn3cgFiD7/QsnNcCju+hCXyeBwXrdtg==}
+    hasBin: true
+    peerDependencies:
+      '@alchemy.run/frontend-frameworks': 2.0.0-beta.76
+      '@aws/durable-execution-sdk-js': ^2.1.0
+      '@effect/platform-bun': '>=4.0.0-rc.112 || >=4.0.0'
+      '@effect/platform-node': '>=4.0.0-rc.112 || >=4.0.0'
+      '@effect/sql-mysql2': '>=4.0.0-rc.112 || >=4.0.0'
+      '@effect/sql-pg': '>=4.0.0-rc.112 || >=4.0.0'
+      '@vercel/nft': ^1.10.2
+      drizzle-kit: 1.0.0-rc.5-ab785fc
+      drizzle-orm: 1.0.0-rc.5-ab785fc
+      effect: '>=4.0.0-rc.112 || >=4.0.0'
+      mongodb: ^6.10.0
+      mysql2: ^3.24.2
+      pg: ^8.22.0
+      vite: ^8.0.7
+      ws: ^8.20.0
+    peerDependenciesMeta:
+      '@alchemy.run/frontend-frameworks':
+        optional: true
+      '@aws/durable-execution-sdk-js':
+        optional: true
+      '@effect/platform-bun':
+        optional: true
+      '@effect/platform-node':
+        optional: true
+      '@effect/sql-mysql2':
+        optional: true
+      '@effect/sql-pg':
+        optional: true
+      '@vercel/nft':
+        optional: true
+      drizzle-kit:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mongodb:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      vite:
+        optional: true
+      ws:
+        optional: true
+
   anser@1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
+
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -3755,6 +4504,9 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
 
   app-module-path@2.2.0:
     resolution: {integrity: sha512-gkco+qxENJV+8vFcDiiFhuoSvRXb2a/QPqpSoWhVz829VNJfOTnELbBmPmNKFxf3xdNnw4DWCkzkDaavcX/1YQ==}
@@ -3807,12 +4559,19 @@ packages:
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
+  auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   autolinker@0.28.1:
     resolution: {integrity: sha512-zQAFO1Dlsn69eXaO6+7YZc+v84aquQKbwpzCE3L0stj56ERn9hutFxPopViLjo9G+rWwjozRhgS5KJ25Xy19cQ==}
 
   aws-ssl-profiles@1.1.2:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
+
+  aws4fetch@1.0.20:
+    resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
 
   b4a@1.8.1:
     resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
@@ -3911,6 +4670,9 @@ packages:
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -3919,6 +4681,9 @@ packages:
 
   bl@6.1.6:
     resolution: {integrity: sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
@@ -3995,6 +4760,18 @@ packages:
   caniuse-lite@1.0.30001810:
     resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
+  capnp-es@0.0.14:
+    resolution: {integrity: sha512-8lWj4GJISiqRSlAJGkWpI4Azib7QY5UDIkqxeHcI7aAnXVk9SFuWxl1Fme+2HhzNANV0WTJqwUZvvXvloc3sBA==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.7.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  capnweb@0.6.1:
+    resolution: {integrity: sha512-fmhV26QPd1ewf5R74h55oVZnGwIcSaRMzbfLQUy8+zOBjuTmT3KXoT8wxHvnp1m9Ht9BoUUS5ZwNLoVLfQTyBg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -4003,12 +4780,19 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   chalk@6.0.0:
     resolution: {integrity: sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==}
     engines: {node: '>=22'}
 
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
+  chevrotain@10.5.0:
+    resolution: {integrity: sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -4036,13 +4820,25 @@ packages:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
 
+  cli-boxes@3.0.0:
+    resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
+    engines: {node: '>=10'}
+
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
     engines: {node: '>=8'}
 
+  cli-cursor@4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
+
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
+    engines: {node: '>=20'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -4070,6 +4866,10 @@ packages:
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
+
+  code-excerpt@4.0.0:
+    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -4117,8 +4917,16 @@ packages:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
     engines: {node: '>= 0.10.0'}
 
+  content-type@3.0.0:
+    resolution: {integrity: sha512-AIi5H6p0xk5uknXcN3/rmhP8jgp69OfSe/JuKiQAFprJ7UGw7mwj7m4XcmDzlrnJDG+cGpphAINGdU3g3g7kDw==}
+    engines: {node: '>=22'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -4353,6 +5161,10 @@ packages:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
 
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
@@ -4368,6 +5180,9 @@ packages:
 
   es-module-lexer@2.3.2:
     resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
+
+  es-toolkit@1.52.0:
+    resolution: {integrity: sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA==}
 
   es6-promise@3.3.1:
     resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
@@ -4469,6 +5284,10 @@ packages:
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
@@ -4486,6 +5305,16 @@ packages:
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+
+  fast-xml-builder@1.3.1:
+    resolution: {integrity: sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==}
+
+  fast-xml-parser@5.11.1:
+    resolution: {integrity: sha512-TBw6K/fxoQGGjCmZDw9w/ZwP3uDcnTM4YH/g+PFRWr8sbe5idXtxNN6vITh4+1ruCZaho6uBFurElsA7F0zzgw==}
+    hasBin: true
+
+  fastq@1.20.3:
+    resolution: {integrity: sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==}
 
   fb-dotslash@0.5.8:
     resolution: {integrity: sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA==}
@@ -4606,12 +5435,19 @@ packages:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
 
+  get-port-please@3.2.0:
+    resolution: {integrity: sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==}
+
   get-port@5.1.1:
     resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
     engines: {node: '>=8'}
 
   get-tsconfig@4.14.3:
     resolution: {integrity: sha512-++QEw4DIY7WGoukz+/+A/8dGYPT9l9yIadnmSgZ8Rjr3YVSVDipQSO9CdnJo9ePqFqUUqh+wk9uIaoiAwsiPkA==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
@@ -4633,6 +5469,12 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  grammex@3.1.13:
+    resolution: {integrity: sha512-LnPnhOBLEJEVKS8WFDVaA397L9Kq55Q9oSITJiVLHVdhAclfUkWzQv74KhvZHKL2Q09Pb1XdsrOsZ4LfTFFTEg==}
+
+  graphmatch@1.1.1:
+    resolution: {integrity: sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==}
 
   gray-matter@3.1.1:
     resolution: {integrity: sha512-nZ1qjLmayEv0/wt3sHig7I0s3/sJO0dkAaKYQ5YAOApUtYEOonXSFdWvL1khvnZMTvov4UufkqlFsilPnejEXA==}
@@ -4669,6 +5511,10 @@ packages:
   hermes-parser@0.35.0:
     resolution: {integrity: sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==}
 
+  hono@4.11.4:
+    resolution: {integrity: sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==}
+    engines: {node: '>=16.9.0'}
+
   hono@4.13.7:
     resolution: {integrity: sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==}
     engines: {node: '>=16.9.0'}
@@ -4684,6 +5530,9 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
+
+  http-status-codes@2.3.0:
+    resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
 
   http2-client@1.3.5:
     resolution: {integrity: sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==}
@@ -4708,6 +5557,9 @@ packages:
     engines: {node: '>=16.x'}
     hasBin: true
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   immer@11.1.18:
     resolution: {integrity: sha512-EQyQtLiYW029lyoczMl/Hh4Xu7cDecSc58JRYpHyL4tIAu3eqd1yJzQX04d2BZHDkzFFvm6qJEJWOtfDSWAXbQ==}
 
@@ -4722,6 +5574,10 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
@@ -4735,6 +5591,19 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ink@6.8.0:
+    resolution: {integrity: sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@types/react': '>=19.0.0'
+      react: '>=19.0.0'
+      react-devtools-core: '>=6.1.2'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -4764,9 +5633,26 @@ packages:
     resolution: {integrity: sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==}
     engines: {node: '>=0.10.0'}
 
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-in-ci@2.0.0:
+    resolution: {integrity: sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   is-in-ssh@1.0.0:
     resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
@@ -4821,6 +5707,9 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  is-unsafe@2.0.2:
+    resolution: {integrity: sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==}
 
   is-url-superb@4.0.0:
     resolution: {integrity: sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==}
@@ -4955,6 +5844,9 @@ packages:
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
+  json-with-bigint@3.5.12:
+    resolution: {integrity: sha512-uwbF/wSSuOgC7qqlq27Xp5B6a2MHVug3t0idZdTqu0JnlFvgJuH7ju+KAk/J06C7GfhoYy2gnb9wz2INqcne7w==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -4966,6 +5858,9 @@ packages:
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
+
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
 
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
@@ -5008,10 +5903,19 @@ packages:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
 
+  libsodium-wrappers@0.8.4:
+    resolution: {integrity: sha512-mu8aAWucZjTB5O/BtGXtW4e1agy7uHxNYG7zPthmmD1jU43LCDmSWZLN4JhflbdPXj3yDO4lxM1O9hLDgIOXDw==}
+
+  libsodium@0.8.4:
+    resolution: {integrity: sha512-lMcYaRi0zcs7tarATsQUYC7rstliIXZuoq0c6zXSgNtSNtdvBgkSegjWhpMJAXzKX3SUSwIp7+zEsob+j3LuRw==}
+
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
     cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lighthouse-logger@1.4.2:
     resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
@@ -5090,6 +5994,10 @@ packages:
     resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
+  lilconfig@2.1.0:
+    resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
+    engines: {node: '>=10'}
+
   list-item@1.1.1:
     resolution: {integrity: sha512-S3D0WZ4J6hyM8o5SNKWaMYB1ALSacPZ2nHGEuCjmHZ+dc03gFeNZoNDcqfcnO4vDhTZmNrqrpYZCdXsRh22bzw==}
     engines: {node: '>=0.10.0'}
@@ -5138,6 +6046,9 @@ packages:
 
   lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -5220,6 +6131,10 @@ packages:
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
   metro-babel-transformer@0.83.7:
     resolution: {integrity: sha512-sBqBkt6kNut/88bv+Ucvm4yqdPetbvAEsHzi3MAgJEifOSYYzX5Z5Kgw3TFOrwf/mHJTOBG2ONlaMHoyfP15TA==}
     engines: {node: '>=20.19.4'}
@@ -5295,6 +6210,11 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  mime@4.1.0:
+    resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -5363,6 +6283,10 @@ packages:
   mock-xmlhttprequest@8.4.1:
     resolution: {integrity: sha512-2ORxRN+h40+3/Ylw9LKOtYGfQIoX6grGQlmbvMKqaeZ5/l7oeMvqdJxyG/ax3Poy7VbqMTADI6BwTmO7u10Wrw==}
     engines: {node: '>=16.0.0'}
+
+  modern-tar@0.8.5:
+    resolution: {integrity: sha512-snEhs+6G5Tjd4I7tLCDOaoln2RgE0bD19RzEKgvgK2hZ5VKy3MpLhLTZ2fWpXSTg4K2cyPwp+VHATFJhxfnOeA==}
+    engines: {node: '>=18.0.0'}
 
   module-definition@6.0.2:
     resolution: {integrity: sha512-SvAU3lB0+Yjbq55yHY3wkRZBOh+fhU1SnIF3IFbTewv6mtAh7yUT8ACHAJ2mGIJ7tCes2QuCL/cl6m0JSZ/ArA==}
@@ -5482,6 +6406,9 @@ packages:
     resolution: {integrity: sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==}
     engines: {node: '>=0.10.0'}
 
+  obuf@1.1.2:
+    resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
+
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
@@ -5561,6 +6488,9 @@ packages:
   package-manager-detector@1.8.0:
     resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parse-json@8.3.0:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
     engines: {node: '>=18'}
@@ -5576,6 +6506,10 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  patch-console@2.0.0:
+    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -5586,6 +6520,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-expression-matcher@1.6.2:
+    resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
+    engines: {node: '>=14.0.0'}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -5608,6 +6546,56 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-cursor@2.22.0:
+    resolution: {integrity: sha512-knzXLKqarTjOvb3qDSW0JiGsazmxwEKXrqHfWRte7XUsOYccQRafn3BLnQobWwInkzFJSyOej8y8cQRh2z3kGw==}
+    peerDependencies:
+      pg: ^8
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-numeric@1.0.2:
+    resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
+    engines: {node: '>=4'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.16.0:
+    resolution: {integrity: sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg-types@4.1.0:
+    resolution: {integrity: sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==}
+    engines: {node: '>=10'}
+
+  pg@8.23.0:
+    resolution: {integrity: sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -5667,6 +6655,41 @@ packages:
   postcss@8.5.28:
     resolution: {integrity: sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-array@3.0.4:
+    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
+    engines: {node: '>=12'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-bytea@3.0.0:
+    resolution: {integrity: sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==}
+    engines: {node: '>= 6'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@2.1.0:
+    resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
+    engines: {node: '>=12'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@3.0.0:
+    resolution: {integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==}
+    engines: {node: '>=12'}
+
+  postgres-range@1.1.4:
+    resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
 
   postgres@3.4.9:
     resolution: {integrity: sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==}
@@ -5740,6 +6763,9 @@ packages:
   pure-rand@8.4.2:
     resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
 
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
   queue@6.0.2:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
@@ -5792,6 +6818,12 @@ packages:
       '@types/react':
         optional: true
 
+  react-reconciler@0.33.0:
+    resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.2.0
+
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
@@ -5836,10 +6868,16 @@ packages:
   regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
+  regexp-to-ast@0.5.0:
+    resolution: {integrity: sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==}
+
   remarkable@1.7.4:
     resolution: {integrity: sha512-e6NKUXgX95whv7IgddywbeN/ItCkWbISmc2DiqHJb0wTrqZIexqdco5b8Z3XZoo/48IdNVKM9ZCvTPJ4F5uvhg==}
     engines: {node: '>= 0.10.0'}
     hasBin: true
+
+  remeda@2.33.4:
+    resolution: {integrity: sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==}
 
   repeat-element@1.1.4:
     resolution: {integrity: sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==}
@@ -5886,13 +6924,26 @@ packages:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
 
+  restore-cursor@4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
 
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  rolldown@1.2.5:
+    resolution: {integrity: sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   rolldown@1.2.7:
@@ -5974,6 +7025,9 @@ packages:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
 
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -6041,6 +7095,9 @@ packages:
     resolution: {integrity: sha512-9sVWOy+gthr+0G9DzqqLaYNA7+5OKkSmcqjL9cBpDEaZrr3ShQlyX2cZ/O/ozE41oxn/Tt0LGEM/w4Rub3A3gw==}
     engines: {node: '>=0.10.0'}
 
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
@@ -6051,6 +7108,15 @@ packages:
   sharp@0.35.2:
     resolution: {integrity: sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==}
     engines: {node: '>=20.9.0'}
+
+  sharp@0.35.4:
+    resolution: {integrity: sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -6107,6 +7173,10 @@ packages:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
 
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
+
   smob@1.6.2:
     resolution: {integrity: sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==}
     engines: {node: '>=20.0.0'}
@@ -6135,6 +7205,10 @@ packages:
 
   split-ca@1.0.1:
     resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -6174,6 +7248,9 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
@@ -6247,6 +7324,9 @@ packages:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
 
+  strnum@2.4.2:
+    resolution: {integrity: sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==}
+
   stylus-lookup@6.1.2:
     resolution: {integrity: sha512-O+Q/SJ8s1X2aMLh4213fQ9X/bND9M3dhSsyTRe+O1OXPcewGLiYmAtKCrnP7FDvDBaXB2ZHPkCt3zi4cJXBlCQ==}
     engines: {node: '>=18'}
@@ -6279,6 +7359,10 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
@@ -6306,6 +7390,10 @@ packages:
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  terminal-size@4.0.1:
+    resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
+    engines: {node: '>=18'}
 
   terser@5.51.2:
     resolution: {integrity: sha512-bWnjSNscmuI+GJze6ZupnHP8G/cTcsJF+bXCeQknk2SHQsgbNJnLrqiH9jZ2W4STPVXH2mDKKRX3iwPhc9Cn/Q==}
@@ -6477,6 +7565,10 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
+  type-fest@5.9.0:
+    resolution: {integrity: sha512-yANm3Jr3GiJ1qgJlxGAVxTOIcEOk1rhQHamlXtnrCK7EHP4HeM9OGxtMg/W7HFdrVzw/ZWJKGVIJusVH85sLtw==}
+    engines: {node: '>=20'}
+
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
@@ -6513,6 +7605,12 @@ packages:
     resolution: {integrity: sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==}
     engines: {node: '>=22.19.0'}
 
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -6536,6 +7634,14 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  valibot@1.2.0:
+    resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   valibot@1.4.2:
     resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
@@ -6698,6 +7804,15 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  widest-line@6.0.0:
+    resolution: {integrity: sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==}
+    engines: {node: '>=20'}
+
+  workerd@1.20260704.1:
+    resolution: {integrity: sha512-GDZ0jzIYDYfN7rCt/oFJv4BG3QJ+4IS2kfRvxEMY9VKIfPhzo63PH69Ir7ug8LfORCgCtmfkiQVXrqbot7pZTQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   workerd@1.20260730.1:
     resolution: {integrity: sha512-zmfNIjwYSWFY5chGBOjWtH3xAE7p97FTC6vR4Ep98290ho6AeAR/NVcBD274YCLEUYzqm8yxdtZlxMybU8a3jA==}
     engines: {node: '>=16'}
@@ -6779,6 +7894,10 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
+  xml-naming@0.3.0:
+    resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
+    engines: {node: '>=16.0.0'}
+
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
@@ -6825,11 +7944,21 @@ packages:
     resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
+  yauzl@3.4.0:
+    resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
+    engines: {node: '>=12'}
+
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+
   youch-core@0.3.3:
     resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
 
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
+
+  zeptomatch@2.1.0:
+    resolution: {integrity: sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==}
 
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
@@ -6841,6 +7970,40 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.5.0': {}
+
+  '@alcalzone/ansi-tokenize@0.2.5':
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  '@alchemy.run/cloudflare-runtime@2.0.0-beta.76(@distilled.cloud/cloudflare@1.0.0-rc.8(effect@packages+effect))(@effect/platform-bun@4.0.0-rc.112(effect@packages+effect))(@effect/platform-node@4.0.0-rc.112(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1)))(@types/node@26.4.1)(effect@packages+effect)(rolldown@1.2.5)(typescript@7.0.2)(vite@8.2.2(@types/node@26.4.1)(esbuild@0.25.12)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))':
+    dependencies:
+      '@alchemy.run/node-utils': 2.0.0-beta.76
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260704.1)
+      '@distilled.cloud/cloudflare': 1.0.0-rc.8(effect@packages+effect)
+      '@puppeteer/browsers': 3.2.2(yauzl@3.4.0)
+      capnp-es: 0.0.14(typescript@7.0.2)
+      effect: link:packages/effect
+      magic-string: 0.30.21
+      sharp: 0.35.4(@types/node@26.4.1)
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260704.1
+      yauzl: 3.4.0
+    optionalDependencies:
+      '@effect/platform-bun': 4.0.0-rc.112(effect@packages+effect)
+      '@effect/platform-node': 4.0.0-rc.112(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1))
+      rolldown: 1.2.5
+      vite: 8.2.2(@types/node@26.4.1)(esbuild@0.25.12)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - proxy-agent
+      - typescript
+
+  '@alchemy.run/floci@2.0.0-beta.76(effect@packages+effect)':
+    dependencies:
+      effect: link:packages/effect
+
+  '@alchemy.run/node-utils@2.0.0-beta.76': {}
 
   '@asamuzakjp/css-color@6.0.5':
     dependencies:
@@ -6856,6 +8019,179 @@ snapshots:
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.5.2
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.974.5
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.9':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@aws-sdk/xml-builder': 3.972.40
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.18.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.69':
+    dependencies:
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.8.0
+      '@smithy/node-http-handler': 4.12.1
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-login': 3.972.77
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.82':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-ini': 3.973.15
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/token-providers': 3.1116.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-providers@3.1127.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-cognito-identity': 3.972.69
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-ini': 3.973.15
+      '@aws-sdk/credential-provider-login': 3.972.77
+      '@aws-sdk/credential-provider-node': 3.972.82
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.44':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.8.0
+      '@smithy/node-http-handler': 4.12.1
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1116.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.5':
+    dependencies:
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.40':
+    dependencies:
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@azure-rest/core-client@2.9.0(supports-color@10.2.2)':
     dependencies:
@@ -7591,6 +8927,21 @@ snapshots:
       '@changesets/types': 7.0.0
       human-id: 4.2.1
 
+  '@chevrotain/cst-dts-gen@10.5.0':
+    dependencies:
+      '@chevrotain/gast': 10.5.0
+      '@chevrotain/types': 10.5.0
+      lodash: 4.17.21
+
+  '@chevrotain/gast@10.5.0':
+    dependencies:
+      '@chevrotain/types': 10.5.0
+      lodash: 4.17.21
+
+  '@chevrotain/types@10.5.0': {}
+
+  '@chevrotain/utils@10.5.0': {}
+
   '@clack/core@1.4.3':
     dependencies:
       fast-wrap-ansi: 0.2.2
@@ -7605,10 +8956,22 @@ snapshots:
 
   '@clickhouse/client@1.23.1': {}
 
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260704.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260704.1
+
+  '@cloudflare/workerd-darwin-64@1.20260704.1':
+    optional: true
+
   '@cloudflare/workerd-darwin-64@1.20260730.1':
     optional: true
 
   '@cloudflare/workerd-darwin-64@1.20260903.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260704.1':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20260730.1':
@@ -7617,16 +8980,25 @@ snapshots:
   '@cloudflare/workerd-darwin-arm64@1.20260903.1':
     optional: true
 
+  '@cloudflare/workerd-linux-64@1.20260704.1':
+    optional: true
+
   '@cloudflare/workerd-linux-64@1.20260730.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20260903.1':
     optional: true
 
+  '@cloudflare/workerd-linux-arm64@1.20260704.1':
+    optional: true
+
   '@cloudflare/workerd-linux-arm64@1.20260730.1':
     optional: true
 
   '@cloudflare/workerd-linux-arm64@1.20260903.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260704.1':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20260730.1':
@@ -7671,6 +9043,59 @@ snapshots:
       node-source-walk: 7.0.2
 
   '@discoveryjs/json-ext@1.1.0': {}
+
+  '@distilled.cloud/aws@1.0.0-rc.8(effect@packages+effect)':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/credential-providers': 3.1127.0
+      '@aws-sdk/types': 3.974.5
+      '@distilled.cloud/core': 1.0.0-rc.8(effect@packages+effect)
+      '@smithy/shared-ini-file-loader': 4.7.2
+      '@smithy/types': 4.18.0
+      '@smithy/util-base64': 4.6.2
+      aws4fetch: 1.0.20
+      effect: link:packages/effect
+      fast-xml-parser: 5.11.1
+
+  '@distilled.cloud/axiom@1.0.0-rc.8(effect@packages+effect)':
+    dependencies:
+      '@distilled.cloud/core': 1.0.0-rc.8(effect@packages+effect)
+      effect: link:packages/effect
+
+  '@distilled.cloud/cloudflare@1.0.0-rc.8(effect@packages+effect)':
+    dependencies:
+      '@distilled.cloud/core': 1.0.0-rc.8(effect@packages+effect)
+      effect: link:packages/effect
+
+  '@distilled.cloud/core@1.0.0-rc.8(effect@packages+effect)':
+    dependencies:
+      effect: link:packages/effect
+
+  '@distilled.cloud/fly-io@1.0.0-rc.8(effect@packages+effect)':
+    dependencies:
+      '@distilled.cloud/core': 1.0.0-rc.8(effect@packages+effect)
+      effect: link:packages/effect
+
+  '@distilled.cloud/hetzner@1.0.0-rc.8(effect@packages+effect)':
+    dependencies:
+      '@distilled.cloud/core': 1.0.0-rc.8(effect@packages+effect)
+      effect: link:packages/effect
+
+  '@distilled.cloud/neon@1.0.0-rc.8(effect@packages+effect)':
+    dependencies:
+      '@distilled.cloud/core': 1.0.0-rc.8(effect@packages+effect)
+      effect: link:packages/effect
+
+  '@distilled.cloud/planetscale@1.0.0-rc.8(effect@packages+effect)':
+    dependencies:
+      '@distilled.cloud/core': 1.0.0-rc.8(effect@packages+effect)
+      effect: link:packages/effect
+
+  '@distilled.cloud/railway@1.0.0-rc.8(effect@packages+effect)':
+    dependencies:
+      '@distilled.cloud/core': 1.0.0-rc.8(effect@packages+effect)
+      effect: link:packages/effect
 
   '@dprint/android-arm64@0.57.3':
     optional: true
@@ -7740,6 +9165,66 @@ snapshots:
       repeat-string: 1.6.1
       strip-color: 0.1.0
 
+  '@effect/platform-bun@4.0.0-rc.112(effect@packages+effect)':
+    dependencies:
+      '@effect/platform-node-shared': 4.0.0-rc.112(effect@packages+effect)
+      effect: link:packages/effect
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    optional: true
+
+  '@effect/platform-node-shared@4.0.0-rc.112(effect@packages+effect)':
+    dependencies:
+      '@types/ws': 8.18.1
+      effect: link:packages/effect
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    optional: true
+
+  '@effect/platform-node@4.0.0-rc.112(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@effect/platform-node-shared': 4.0.0-rc.112(effect@packages+effect)
+      effect: link:packages/effect
+      mime: 4.1.0
+      redis: 6.2.1(@opentelemetry/api@1.9.1)
+      undici: 8.10.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    optional: true
+
+  '@effect/sql-d1@4.0.0-rc.112(effect@packages+effect)':
+    dependencies:
+      '@cloudflare/workers-types': 5.20260905.1
+      effect: link:packages/effect
+
+  '@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.4.1)(effect@packages+effect)':
+    dependencies:
+      effect: link:packages/effect
+      mysql2: 3.24.3(@types/node@26.4.1)
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
+  '@effect/sql-pg@4.0.0-rc.112(effect@packages+effect)':
+    dependencies:
+      effect: link:packages/effect
+      pg: 8.23.0
+      pg-connection-string: 2.14.0
+      pg-cursor: 2.22.0(pg@8.23.0)
+      pg-pool: 3.14.0(pg@8.23.0)
+      pg-types: 4.1.0
+    transitivePeerDependencies:
+      - pg-native
+    optional: true
+
+  '@effect/sql-sqlite-do@4.0.0-rc.112(effect@packages+effect)':
+    dependencies:
+      effect: link:packages/effect
+
   '@effect/tsgo-darwin-arm64@0.41.0':
     optional: true
 
@@ -7771,7 +9256,22 @@ snapshots:
       '@effect/tsgo-win32-arm64': 0.41.0
       '@effect/tsgo-win32-x64': 0.41.0
 
+  '@effect/vitest@4.0.0-rc.112(effect@packages+effect)(vitest@5.0.0)':
+    dependencies:
+      effect: link:packages/effect
+      vitest: 5.0.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.1)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.14.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.1)(esbuild@0.25.12)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
+
   '@effect/wa-sqlite@0.2.1': {}
+
+  '@electric-sql/pglite-socket@0.0.20(@electric-sql/pglite@0.3.15)':
+    dependencies:
+      '@electric-sql/pglite': 0.3.15
+
+  '@electric-sql/pglite-tools@0.2.20(@electric-sql/pglite@0.3.15)':
+    dependencies:
+      '@electric-sql/pglite': 0.3.15
+
+  '@electric-sql/pglite@0.3.15': {}
 
   '@electric-sql/pglite@0.5.8': {}
 
@@ -7961,6 +9461,10 @@ snapshots:
       protobufjs: 7.6.6
       yargs: 17.7.3
 
+  '@hono/node-server@1.19.9(hono@4.11.4)':
+    dependencies:
+      hono: 4.11.4
+
   '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.35.2':
@@ -7968,9 +9472,19 @@ snapshots:
       '@img/sharp-libvips-darwin-arm64': 1.3.1
     optional: true
 
+  '@img/sharp-darwin-arm64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
+    optional: true
+
   '@img/sharp-darwin-x64@0.35.2':
     optionalDependencies:
       '@img/sharp-libvips-darwin-x64': 1.3.1
+    optional: true
+
+  '@img/sharp-darwin-x64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.3
     optional: true
 
   '@img/sharp-freebsd-wasm32@0.35.2':
@@ -7978,34 +9492,69 @@ snapshots:
       '@img/sharp-wasm32': 0.35.2
     optional: true
 
+  '@img/sharp-freebsd-wasm32@0.35.4':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.4
+    optional: true
+
   '@img/sharp-libvips-darwin-arm64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.3':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.3.1':
     optional: true
 
+  '@img/sharp-libvips-darwin-x64@1.3.3':
+    optional: true
+
   '@img/sharp-libvips-linux-arm64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.3':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.3.1':
     optional: true
 
+  '@img/sharp-libvips-linux-arm@1.3.3':
+    optional: true
+
   '@img/sharp-libvips-linux-ppc64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.3':
     optional: true
 
   '@img/sharp-libvips-linux-riscv64@1.3.1':
     optional: true
 
+  '@img/sharp-libvips-linux-riscv64@1.3.3':
+    optional: true
+
   '@img/sharp-libvips-linux-s390x@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.3':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.3.1':
     optional: true
 
+  '@img/sharp-libvips-linux-x64@1.3.3':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
     optional: true
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-x64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
     optional: true
 
   '@img/sharp-linux-arm64@0.35.2':
@@ -8013,9 +9562,19 @@ snapshots:
       '@img/sharp-libvips-linux-arm64': 1.3.1
     optional: true
 
+  '@img/sharp-linux-arm64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.3
+    optional: true
+
   '@img/sharp-linux-arm@0.35.2':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.3
     optional: true
 
   '@img/sharp-linux-ppc64@0.35.2':
@@ -8023,9 +9582,19 @@ snapshots:
       '@img/sharp-libvips-linux-ppc64': 1.3.1
     optional: true
 
+  '@img/sharp-linux-ppc64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
+    optional: true
+
   '@img/sharp-linux-riscv64@0.35.2':
     optionalDependencies:
       '@img/sharp-libvips-linux-riscv64': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
     optional: true
 
   '@img/sharp-linux-s390x@0.35.2':
@@ -8033,9 +9602,19 @@ snapshots:
       '@img/sharp-libvips-linux-s390x': 1.3.1
     optional: true
 
+  '@img/sharp-linux-s390x@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.3
+    optional: true
+
   '@img/sharp-linux-x64@0.35.2':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.3
     optional: true
 
   '@img/sharp-linuxmusl-arm64@0.35.2':
@@ -8043,12 +9622,27 @@ snapshots:
       '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
     optional: true
 
+  '@img/sharp-linuxmusl-arm64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
+    optional: true
+
   '@img/sharp-linuxmusl-x64@0.35.2':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.3.1
     optional: true
 
+  '@img/sharp-linuxmusl-x64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
+    optional: true
+
   '@img/sharp-wasm32@0.35.2':
+    dependencies:
+      '@emnapi/runtime': 1.11.3
+    optional: true
+
+  '@img/sharp-wasm32@0.35.4':
     dependencies:
       '@emnapi/runtime': 1.11.3
     optional: true
@@ -8058,13 +9652,27 @@ snapshots:
       '@img/sharp-wasm32': 0.35.2
     optional: true
 
+  '@img/sharp-webcontainers-wasm32@0.35.4':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.4
+    optional: true
+
   '@img/sharp-win32-arm64@0.35.2':
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.4':
     optional: true
 
   '@img/sharp-win32-ia32@0.35.2':
     optional: true
 
+  '@img/sharp-win32-ia32@0.35.4':
+    optional: true
+
   '@img/sharp-win32-x64@0.35.2':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.4':
     optional: true
 
   '@isaacs/cliui@8.0.2':
@@ -8232,6 +9840,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@libsql/client@0.17.4':
+    dependencies:
+      '@libsql/core': 0.17.4
+      '@libsql/hrana-client': 0.10.0
+      js-base64: 3.9.3
+      libsql: 0.5.29
+      promise-limit: 2.7.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@libsql/client@0.18.0':
     dependencies:
       '@libsql/core': 0.18.0
@@ -8242,6 +9861,10 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@libsql/core@0.17.4':
+    dependencies:
+      js-base64: 3.9.3
 
   '@libsql/core@0.18.0':
     dependencies:
@@ -8305,10 +9928,108 @@ snapshots:
       tinyglobby: 0.2.17
       yaml: 2.9.0
 
+  '@mrleebo/prisma-ast@0.13.1':
+    dependencies:
+      chevrotain: 10.5.0
+      lilconfig: 2.1.0
+
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
 
   '@neon-rs/load@0.0.4': {}
+
+  '@nodable/entities@3.0.0': {}
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.3
+
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/core@7.0.8':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.5
+      '@octokit/request': 10.0.16
+      '@octokit/request-error': 7.1.2
+      '@octokit/types': 18.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.5':
+    dependencies:
+      '@octokit/types': 18.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.5':
+    dependencies:
+      '@octokit/request': 10.0.16
+      '@octokit/types': 18.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/openapi-types@29.0.1': {}
+
+  '@octokit/openapi-webhooks-types@12.1.0': {}
+
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.8)':
+    dependencies:
+      '@octokit/core': 7.0.8
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.8)':
+    dependencies:
+      '@octokit/core': 7.0.8
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.8)':
+    dependencies:
+      '@octokit/core': 7.0.8
+      '@octokit/types': 16.0.0
+
+  '@octokit/request-error@7.1.2':
+    dependencies:
+      '@octokit/types': 18.0.0
+
+  '@octokit/request@10.0.16':
+    dependencies:
+      '@octokit/endpoint': 11.0.5
+      '@octokit/request-error': 7.1.2
+      '@octokit/types': 18.0.0
+      content-type: 3.0.0
+      json-with-bigint: 3.5.12
+      universal-user-agent: 7.0.3
+
+  '@octokit/rest@22.0.1':
+    dependencies:
+      '@octokit/core': 7.0.8
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.8)
+      '@octokit/plugin-request-log': 6.0.0(@octokit/core@7.0.8)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.8)
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
+
+  '@octokit/types@18.0.0':
+    dependencies:
+      '@octokit/openapi-types': 29.0.1
+
+  '@octokit/webhooks-methods@6.0.0': {}
+
+  '@octokit/webhooks@14.2.0':
+    dependencies:
+      '@octokit/openapi-webhooks-types': 12.1.0
+      '@octokit/request-error': 7.1.2
+      '@octokit/webhooks-methods': 6.0.0
 
   '@op-engineering/op-sqlite@18.2.0(react-native@0.83.0(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)':
     dependencies:
@@ -8420,6 +10141,8 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.43.0': {}
 
+  '@oxc-project/types@0.146.0': {}
+
   '@oxc-project/types@0.148.0': {}
 
   '@oxlint/binding-android-arm-eabi@1.81.0':
@@ -8501,6 +10224,36 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
+  '@prisma/debug@7.2.0': {}
+
+  '@prisma/dev@0.20.0(typescript@7.0.2)':
+    dependencies:
+      '@electric-sql/pglite': 0.3.15
+      '@electric-sql/pglite-socket': 0.0.20(@electric-sql/pglite@0.3.15)
+      '@electric-sql/pglite-tools': 0.2.20(@electric-sql/pglite@0.3.15)
+      '@hono/node-server': 1.19.9(hono@4.11.4)
+      '@mrleebo/prisma-ast': 0.13.1
+      '@prisma/get-platform': 7.2.0
+      '@prisma/query-plan-executor': 7.2.0
+      foreground-child: 3.3.1
+      get-port-please: 3.2.0
+      hono: 4.11.4
+      http-status-codes: 2.3.0
+      pathe: 2.0.3
+      proper-lockfile: 4.1.2
+      remeda: 2.33.4
+      std-env: 3.10.0
+      valibot: 1.2.0(typescript@7.0.2)
+      zeptomatch: 2.1.0
+    transitivePeerDependencies:
+      - typescript
+
+  '@prisma/get-platform@7.2.0':
+    dependencies:
+      '@prisma/debug': 7.2.0
+
+  '@prisma/query-plan-executor@7.2.0': {}
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -8520,6 +10273,13 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.2': {}
+
+  '@puppeteer/browsers@3.2.2(yauzl@3.4.0)':
+    dependencies:
+      modern-tar: 0.8.5
+      yargs: 18.1.0
+    optionalDependencies:
+      yauzl: 3.4.0
 
   '@react-native/assets-registry@0.83.0': {}
 
@@ -8633,46 +10393,91 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@rolldown/binding-android-arm-eabi@1.2.5':
+    optional: true
+
   '@rolldown/binding-android-arm-eabi@1.2.7':
+    optional: true
+
+  '@rolldown/binding-android-arm64@1.2.5':
     optional: true
 
   '@rolldown/binding-android-arm64@1.2.7':
     optional: true
 
+  '@rolldown/binding-darwin-arm64@1.2.5':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.2.7':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.5':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.2.7':
     optional: true
 
+  '@rolldown/binding-freebsd-x64@1.2.5':
+    optional: true
+
   '@rolldown/binding-freebsd-x64@1.2.7':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.5':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.2.7':
     optional: true
 
+  '@rolldown/binding-linux-arm64-gnu@1.2.5':
+    optional: true
+
   '@rolldown/binding-linux-arm64-gnu@1.2.7':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.5':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.2.7':
     optional: true
 
+  '@rolldown/binding-linux-ppc64-gnu@1.2.5':
+    optional: true
+
   '@rolldown/binding-linux-ppc64-gnu@1.2.7':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.5':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.2.7':
     optional: true
 
+  '@rolldown/binding-linux-x64-gnu@1.2.5':
+    optional: true
+
   '@rolldown/binding-linux-x64-gnu@1.2.7':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.5':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.2.7':
     optional: true
 
+  '@rolldown/binding-openharmony-arm64@1.2.5':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.2.7':
     optional: true
 
+  '@rolldown/binding-win32-arm64-msvc@1.2.5':
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.2.7':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.5':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.2.7':
@@ -8800,6 +10605,68 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@smithy/core@3.33.3':
+    dependencies:
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.5.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.8.0':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.6.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.12.1':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/shared-ini-file-loader@4.7.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.7.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/types@4.18.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.6.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
   '@solidjs/testing-library@0.8.10(solid-js@1.9.15)':
     dependencies:
       '@testing-library/dom': 10.4.1
@@ -8919,6 +10786,8 @@ snapshots:
       tinyglobby: 0.2.17
 
   '@types/aria-query@5.0.4': {}
+
+  '@types/aws-lambda@8.10.163': {}
 
   '@types/babel__code-frame@7.27.0': {}
 
@@ -9196,6 +11065,15 @@ snapshots:
     dependencies:
       '@vitest/istanbul-lib-coverage': 1.0.1
 
+  '@vitest/mocker@5.0.0(vite@8.2.2(@types/node@26.4.1)(esbuild@0.25.12)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@vitest/spy': 5.0.0
+      estree-walker: 3.0.3
+      magic-string: 1.2.3
+    optionalDependencies:
+      vite: 8.2.2(@types/node@26.4.1)(esbuild@0.25.12)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
+
   '@vitest/mocker@5.0.0(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -9313,9 +11191,73 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  alchemy@2.0.0-beta.76(@effect/platform-bun@4.0.0-rc.112(effect@packages+effect))(@effect/platform-node@4.0.0-rc.112(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1)))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.4.1)(effect@packages+effect))(@effect/sql-pg@4.0.0-rc.112(effect@packages+effect))(@types/node@26.4.1)(@types/react@19.2.18)(effect@packages+effect)(mysql2@3.24.3(@types/node@26.4.1))(pg@8.23.0)(react-devtools-core@6.1.5)(typescript@7.0.2)(vite@8.2.2(@types/node@26.4.1)(esbuild@0.25.12)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vitest@5.0.0)(ws@8.21.3):
+    dependencies:
+      '@alchemy.run/cloudflare-runtime': 2.0.0-beta.76(@distilled.cloud/cloudflare@1.0.0-rc.8(effect@packages+effect))(@effect/platform-bun@4.0.0-rc.112(effect@packages+effect))(@effect/platform-node@4.0.0-rc.112(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1)))(@types/node@26.4.1)(effect@packages+effect)(rolldown@1.2.5)(typescript@7.0.2)(vite@8.2.2(@types/node@26.4.1)(esbuild@0.25.12)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
+      '@alchemy.run/floci': 2.0.0-beta.76(effect@packages+effect)
+      '@alchemy.run/node-utils': 2.0.0-beta.76
+      '@aws-sdk/credential-providers': 3.1127.0
+      '@clack/prompts': 1.7.0
+      '@distilled.cloud/aws': 1.0.0-rc.8(effect@packages+effect)
+      '@distilled.cloud/axiom': 1.0.0-rc.8(effect@packages+effect)
+      '@distilled.cloud/cloudflare': 1.0.0-rc.8(effect@packages+effect)
+      '@distilled.cloud/core': 1.0.0-rc.8(effect@packages+effect)
+      '@distilled.cloud/fly-io': 1.0.0-rc.8(effect@packages+effect)
+      '@distilled.cloud/hetzner': 1.0.0-rc.8(effect@packages+effect)
+      '@distilled.cloud/neon': 1.0.0-rc.8(effect@packages+effect)
+      '@distilled.cloud/planetscale': 1.0.0-rc.8(effect@packages+effect)
+      '@distilled.cloud/railway': 1.0.0-rc.8(effect@packages+effect)
+      '@effect/sql-d1': 4.0.0-rc.112(effect@packages+effect)
+      '@effect/sql-sqlite-do': 4.0.0-rc.112(effect@packages+effect)
+      '@effect/vitest': 4.0.0-rc.112(effect@packages+effect)(vitest@5.0.0)
+      '@libsql/client': 0.17.4
+      '@octokit/rest': 22.0.1
+      '@octokit/webhooks': 14.2.0
+      '@prisma/dev': 0.20.0(typescript@7.0.2)
+      '@smithy/node-config-provider': 4.6.2
+      '@smithy/shared-ini-file-loader': 4.7.2
+      '@smithy/types': 4.18.0
+      '@types/aws-lambda': 8.10.163
+      aws4fetch: 1.0.20
+      capnweb: 0.6.1
+      effect: link:packages/effect
+      fast-glob: 3.3.3
+      fast-xml-parser: 5.11.1
+      ink: 6.8.0(@types/react@19.2.18)(react-devtools-core@6.1.5)(react@19.2.8)
+      jszip: 3.10.1
+      libsodium-wrappers: 0.8.4
+      pathe: 2.0.3
+      picomatch: 4.0.7
+      react: 19.2.8
+      rolldown: 1.2.5
+      undici: 7.29.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@effect/platform-bun': 4.0.0-rc.112(effect@packages+effect)
+      '@effect/platform-node': 4.0.0-rc.112(effect@packages+effect)(redis@6.2.1(@opentelemetry/api@1.9.1))
+      '@effect/sql-mysql2': 4.0.0-rc.112(@types/node@26.4.1)(effect@packages+effect)
+      '@effect/sql-pg': 4.0.0-rc.112(effect@packages+effect)
+      mysql2: 3.24.3(@types/node@26.4.1)
+      pg: 8.23.0
+      vite: 8.2.2(@types/node@26.4.1)(esbuild@0.25.12)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@types/react'
+      - bufferutil
+      - proxy-agent
+      - react-devtools-core
+      - typescript
+      - utf-8-validate
+      - vitest
+
   anser@1.4.10: {}
 
   ansi-colors@4.1.3: {}
+
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
 
   ansi-regex@5.0.1: {}
 
@@ -9335,6 +11277,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.2
+
+  anynum@1.0.1: {}
 
   app-module-path@2.2.0: {}
 
@@ -9398,11 +11342,15 @@ snapshots:
 
   async@3.2.6: {}
 
+  auto-bind@5.0.1: {}
+
   autolinker@0.28.1:
     dependencies:
       gulp-header: 1.8.12
 
   aws-ssl-profiles@1.1.2: {}
+
+  aws4fetch@1.0.20: {}
 
   b4a@1.8.1: {}
 
@@ -9510,6 +11458,8 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
+  before-after-hook@4.0.0: {}
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -9526,6 +11476,8 @@ snapshots:
       buffer: 6.0.3
       inherits: 2.0.4
       readable-stream: 4.7.0
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.16:
     dependencies:
@@ -9599,6 +11551,12 @@ snapshots:
 
   caniuse-lite@1.0.30001810: {}
 
+  capnp-es@0.0.14(typescript@7.0.2):
+    optionalDependencies:
+      typescript: 7.0.2
+
+  capnweb@0.6.1: {}
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -9606,9 +11564,20 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
   chalk@6.0.0: {}
 
   change-case@5.4.4: {}
+
+  chevrotain@10.5.0:
+    dependencies:
+      '@chevrotain/cst-dts-gen': 10.5.0
+      '@chevrotain/gast': 10.5.0
+      '@chevrotain/types': 10.5.0
+      '@chevrotain/utils': 10.5.0
+      lodash: 4.17.21
+      regexp-to-ast: 0.5.0
 
   chokidar@5.0.0:
     dependencies:
@@ -9642,11 +11611,22 @@ snapshots:
 
   ci-info@3.9.0: {}
 
+  cli-boxes@3.0.0: {}
+
   cli-cursor@3.1.0:
     dependencies:
       restore-cursor: 3.1.0
 
+  cli-cursor@4.0.0:
+    dependencies:
+      restore-cursor: 4.0.0
+
   cli-spinners@2.9.2: {}
+
+  cli-truncate@5.2.0:
+    dependencies:
+      slice-ansi: 8.0.0
+      string-width: 8.2.2
 
   cliui@8.0.1:
     dependencies:
@@ -9673,6 +11653,10 @@ snapshots:
   cluster-key-slot@1.1.2: {}
 
   code-block-writer@13.0.3: {}
+
+  code-excerpt@4.0.0:
+    dependencies:
+      convert-to-spaces: 2.0.1
 
   color-convert@2.0.1:
     dependencies:
@@ -9722,7 +11706,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  content-type@3.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  convert-to-spaces@2.0.1: {}
 
   cookie@1.1.1: {}
 
@@ -9961,6 +11949,8 @@ snapshots:
 
   entities@8.0.0: {}
 
+  environment@1.1.0: {}
+
   error-stack-parser-es@1.0.5: {}
 
   error-stack-parser@2.1.4:
@@ -9972,6 +11962,8 @@ snapshots:
   es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.3.2: {}
+
+  es-toolkit@1.52.0: {}
 
   es6-promise@3.3.1: {}
 
@@ -10097,6 +12089,14 @@ snapshots:
 
   fast-fifo@1.3.2: {}
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-json-stable-stringify@2.1.0: {}
 
   fast-safe-stringify@2.1.1: {}
@@ -10112,6 +12112,24 @@ snapshots:
   fast-wrap-ansi@0.2.2:
     dependencies:
       fast-string-width: 3.0.2
+
+  fast-xml-builder@1.3.1:
+    dependencies:
+      path-expression-matcher: 1.6.2
+      xml-naming: 0.3.0
+
+  fast-xml-parser@5.11.1:
+    dependencies:
+      '@nodable/entities': 3.0.0
+      fast-xml-builder: 1.3.1
+      is-unsafe: 2.0.2
+      path-expression-matcher: 1.6.2
+      strnum: 2.4.2
+      xml-naming: 0.3.0
+
+  fastq@1.20.3:
+    dependencies:
+      reusify: 1.1.0
 
   fb-dotslash@0.5.8: {}
 
@@ -10233,11 +12251,17 @@ snapshots:
 
   get-package-type@0.1.0: {}
 
+  get-port-please@3.2.0: {}
+
   get-port@5.1.1: {}
 
   get-tsconfig@4.14.3:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
 
   glob@10.5.0:
     dependencies:
@@ -10268,6 +12292,10 @@ snapshots:
       minimist: 1.2.8
 
   graceful-fs@4.2.11: {}
+
+  grammex@3.1.13: {}
+
+  graphmatch@1.1.1: {}
 
   gray-matter@3.1.1:
     dependencies:
@@ -10315,6 +12343,8 @@ snapshots:
     dependencies:
       hermes-estree: 0.35.0
 
+  hono@4.11.4: {}
+
   hono@4.13.7: {}
 
   html-encoding-sniffer@6.0.0:
@@ -10338,6 +12368,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http-status-codes@2.3.0: {}
+
   http2-client@1.3.5: {}
 
   https-proxy-agent@7.0.6(supports-color@10.2.2):
@@ -10359,6 +12391,8 @@ snapshots:
     dependencies:
       queue: 6.0.2
 
+  immediate@3.0.6: {}
+
   immer@11.1.18: {}
 
   import-meta-resolve@4.2.0: {}
@@ -10366,6 +12400,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  indent-string@5.0.0: {}
 
   index-to-position@1.2.0: {}
 
@@ -10377,6 +12413,41 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  ink@6.8.0(@types/react@19.2.18)(react-devtools-core@6.1.5)(react@19.2.8):
+    dependencies:
+      '@alcalzone/ansi-tokenize': 0.2.5
+      ansi-escapes: 7.3.0
+      ansi-styles: 6.2.3
+      auto-bind: 5.0.1
+      chalk: 5.6.2
+      cli-boxes: 3.0.0
+      cli-cursor: 4.0.0
+      cli-truncate: 5.2.0
+      code-excerpt: 4.0.0
+      es-toolkit: 1.52.0
+      indent-string: 5.0.0
+      is-in-ci: 2.0.0
+      patch-console: 2.0.0
+      react: 19.2.8
+      react-reconciler: 0.33.0(react@19.2.8)
+      scheduler: 0.27.0
+      signal-exit: 3.0.7
+      slice-ansi: 8.0.0
+      stack-utils: 2.0.6
+      string-width: 8.2.2
+      terminal-size: 4.0.1
+      type-fest: 5.9.0
+      widest-line: 6.0.0
+      wrap-ansi: 9.0.2
+      ws: 8.21.3
+      yoga-layout: 3.2.1
+    optionalDependencies:
+      '@types/react': 19.2.18
+      react-devtools-core: 6.1.5
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   invariant@2.2.4:
     dependencies:
@@ -10398,7 +12469,19 @@ snapshots:
     dependencies:
       is-plain-object: 2.0.4
 
+  is-extglob@2.1.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-in-ci@2.0.0: {}
 
   is-in-ssh@1.0.0: {}
 
@@ -10433,6 +12516,8 @@ snapshots:
   is-stream@2.0.1: {}
 
   is-unicode-supported@0.1.0: {}
+
+  is-unsafe@2.0.2: {}
 
   is-url-superb@4.0.0: {}
 
@@ -10622,6 +12707,8 @@ snapshots:
 
   json-schema-typed@8.0.2: {}
 
+  json-with-bigint@3.5.12: {}
+
   json5@2.2.3: {}
 
   jsonc-parser@3.3.1: {}
@@ -10638,6 +12725,13 @@ snapshots:
       lodash.once: 4.1.1
       ms: 2.1.3
       semver: 7.8.5
+
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
 
   jwa@2.0.1:
     dependencies:
@@ -10689,6 +12783,12 @@ snapshots:
 
   leven@3.1.0: {}
 
+  libsodium-wrappers@0.8.4:
+    dependencies:
+      libsodium: 0.8.4
+
+  libsodium@0.8.4: {}
+
   libsql@0.5.29:
     dependencies:
       '@neon-rs/load': 0.0.4
@@ -10703,6 +12803,10 @@ snapshots:
       '@libsql/linux-x64-gnu': 0.5.29
       '@libsql/linux-x64-musl': 0.5.29
       '@libsql/win32-x64-msvc': 0.5.29
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lighthouse-logger@1.4.2(supports-color@10.2.2):
     dependencies:
@@ -10760,6 +12864,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.33.0
       lightningcss-win32-x64-msvc: 1.33.0
 
+  lilconfig@2.1.0: {}
+
   list-item@1.1.1:
     dependencies:
       expand-range: 1.8.2
@@ -10804,6 +12910,8 @@ snapshots:
       lodash._reinterpolate: 3.0.0
 
   lodash.throttle@4.1.1: {}
+
+  lodash@4.17.21: {}
 
   lodash@4.18.1: {}
 
@@ -10887,6 +12995,8 @@ snapshots:
   memoize-one@5.2.1: {}
 
   merge-stream@2.0.0: {}
+
+  merge2@1.4.1: {}
 
   metro-babel-transformer@0.83.7(supports-color@10.2.2):
     dependencies:
@@ -11075,6 +13185,9 @@ snapshots:
 
   mime@1.6.0: {}
 
+  mime@4.1.0:
+    optional: true
+
   mimic-fn@2.1.0: {}
 
   min-indent@1.0.1: {}
@@ -11141,6 +13254,8 @@ snapshots:
   mock-socket@9.3.1: {}
 
   mock-xmlhttprequest@8.4.1: {}
+
+  modern-tar@0.8.5: {}
 
   module-definition@6.0.2:
     dependencies:
@@ -11255,6 +13370,9 @@ snapshots:
     dependencies:
       isobject: 3.0.1
 
+  obuf@1.1.2:
+    optional: true
+
   obug@2.1.4: {}
 
   on-finished@2.3.0:
@@ -11358,6 +13476,8 @@ snapshots:
 
   package-manager-detector@1.8.0: {}
 
+  pako@1.0.11: {}
+
   parse-json@8.3.0:
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -11372,11 +13492,15 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  patch-console@2.0.0: {}
+
   path-browserify@1.0.1: {}
 
   path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
+
+  path-expression-matcher@1.6.2: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -11395,6 +13519,69 @@ snapshots:
       minipass: 7.1.3
 
   pathe@2.0.3: {}
+
+  pend@1.2.0: {}
+
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0:
+    optional: true
+
+  pg-cursor@2.22.0(pg@8.23.0):
+    dependencies:
+      pg: 8.23.0
+    optional: true
+
+  pg-int8@1.0.1:
+    optional: true
+
+  pg-numeric@1.0.2:
+    optional: true
+
+  pg-pool@3.14.0(pg@8.23.0):
+    dependencies:
+      pg: 8.23.0
+    optional: true
+
+  pg-protocol@1.16.0:
+    optional: true
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+    optional: true
+
+  pg-types@4.1.0:
+    dependencies:
+      pg-int8: 1.0.1
+      pg-numeric: 1.0.2
+      postgres-array: 3.0.4
+      postgres-bytea: 3.0.0
+      postgres-date: 2.1.0
+      postgres-interval: 3.0.0
+      postgres-range: 1.1.4
+    optional: true
+
+  pg@8.23.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.23.0)
+      pg-protocol: 1.16.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+    optional: true
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+    optional: true
 
   picocolors@1.1.1: {}
 
@@ -11439,6 +13626,37 @@ snapshots:
       nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0:
+    optional: true
+
+  postgres-array@3.0.4:
+    optional: true
+
+  postgres-bytea@1.0.1:
+    optional: true
+
+  postgres-bytea@3.0.0:
+    dependencies:
+      obuf: 1.1.2
+    optional: true
+
+  postgres-date@1.0.7:
+    optional: true
+
+  postgres-date@2.1.0:
+    optional: true
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+    optional: true
+
+  postgres-interval@3.0.0:
+    optional: true
+
+  postgres-range@1.1.4:
+    optional: true
 
   postgres@3.4.9: {}
 
@@ -11534,6 +13752,8 @@ snapshots:
 
   pure-rand@8.4.2: {}
 
+  queue-microtask@1.2.3: {}
+
   queue@6.0.2:
     dependencies:
       inherits: 2.0.4
@@ -11626,6 +13846,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  react-reconciler@0.33.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      scheduler: 0.27.0
+
   react-refresh@0.14.2: {}
 
   react@19.2.8: {}
@@ -11688,10 +13913,14 @@ snapshots:
 
   regenerator-runtime@0.13.11: {}
 
+  regexp-to-ast@0.5.0: {}
+
   remarkable@1.7.4:
     dependencies:
       argparse: 1.0.10
       autolinker: 0.28.1
+
+  remeda@2.33.4: {}
 
   repeat-element@1.1.4: {}
 
@@ -11726,11 +13955,39 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
+  restore-cursor@4.0.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+
   retry@0.12.0: {}
+
+  reusify@1.1.0: {}
 
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  rolldown@1.2.5:
+    dependencies:
+      '@oxc-project/types': 0.146.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm-eabi': 1.2.5
+      '@rolldown/binding-android-arm64': 1.2.5
+      '@rolldown/binding-darwin-arm64': 1.2.5
+      '@rolldown/binding-darwin-x64': 1.2.5
+      '@rolldown/binding-freebsd-x64': 1.2.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.5
+      '@rolldown/binding-linux-arm64-gnu': 1.2.5
+      '@rolldown/binding-linux-arm64-musl': 1.2.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.5
+      '@rolldown/binding-linux-s390x-gnu': 1.2.5
+      '@rolldown/binding-linux-x64-gnu': 1.2.5
+      '@rolldown/binding-linux-x64-musl': 1.2.5
+      '@rolldown/binding-openharmony-arm64': 1.2.5
+      '@rolldown/binding-win32-arm64-msvc': 1.2.5
+      '@rolldown/binding-win32-x64-msvc': 1.2.5
 
   rolldown@1.2.7:
     dependencies:
@@ -11835,6 +14092,10 @@ snapshots:
 
   run-applescript@7.1.0: {}
 
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
@@ -11901,6 +14162,8 @@ snapshots:
     dependencies:
       to-object-path: 0.3.0
 
+  setimmediate@1.0.5: {}
+
   setprototypeof@1.2.0: {}
 
   shallow-clone@3.0.1:
@@ -11938,6 +14201,39 @@ snapshots:
       '@img/sharp-win32-arm64': 0.35.2
       '@img/sharp-win32-ia32': 0.35.2
       '@img/sharp-win32-x64': 0.35.2
+
+  sharp@0.35.4(@types/node@26.4.1):
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.4
+      '@img/sharp-darwin-x64': 0.35.4
+      '@img/sharp-freebsd-wasm32': 0.35.4
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
+      '@img/sharp-libvips-darwin-x64': 1.3.3
+      '@img/sharp-libvips-linux-arm': 1.3.3
+      '@img/sharp-libvips-linux-arm64': 1.3.3
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
+      '@img/sharp-libvips-linux-s390x': 1.3.3
+      '@img/sharp-libvips-linux-x64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
+      '@img/sharp-linux-arm': 0.35.4
+      '@img/sharp-linux-arm64': 0.35.4
+      '@img/sharp-linux-ppc64': 0.35.4
+      '@img/sharp-linux-riscv64': 0.35.4
+      '@img/sharp-linux-s390x': 0.35.4
+      '@img/sharp-linux-x64': 0.35.4
+      '@img/sharp-linuxmusl-arm64': 0.35.4
+      '@img/sharp-linuxmusl-x64': 0.35.4
+      '@img/sharp-webcontainers-wasm32': 0.35.4
+      '@img/sharp-win32-arm64': 0.35.4
+      '@img/sharp-win32-ia32': 0.35.4
+      '@img/sharp-win32-x64': 0.35.4
+      '@types/node': 26.4.1
 
   shebang-command@2.0.0:
     dependencies:
@@ -11992,6 +14288,11 @@ snapshots:
 
   slash@5.1.0: {}
 
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   smob@1.6.2: {}
 
   solid-js@1.9.15:
@@ -12014,6 +14315,9 @@ snapshots:
   source-map@0.8.0: {}
 
   split-ca@1.0.1: {}
+
+  split2@4.2.0:
+    optional: true
 
   sprintf-js@1.0.3: {}
 
@@ -12049,6 +14353,8 @@ snapshots:
   statuses@1.5.0: {}
 
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   std-env@4.2.0: {}
 
@@ -12130,6 +14436,10 @@ snapshots:
 
   strip-json-comments@2.0.1: {}
 
+  strnum@2.4.2:
+    dependencies:
+      anynum: 1.0.1
+
   stylus-lookup@6.1.2:
     dependencies:
       commander: 12.1.0
@@ -12165,6 +14475,8 @@ snapshots:
       - encoding
 
   symbol-tree@3.2.4: {}
+
+  tagged-tag@1.0.0: {}
 
   tapable@2.3.3: {}
 
@@ -12235,6 +14547,8 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  terminal-size@4.0.1: {}
 
   terser@5.51.2:
     dependencies:
@@ -12401,6 +14715,10 @@ snapshots:
 
   type-fest@4.41.0: {}
 
+  type-fest@5.9.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
   typedarray@0.0.6: {}
 
   typescript@5.9.3: {}
@@ -12440,6 +14758,12 @@ snapshots:
 
   undici@8.10.2: {}
 
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
+
+  universal-user-agent@7.0.3: {}
+
   unpipe@1.0.0: {}
 
   unplugin-utils@0.2.5:
@@ -12459,9 +14783,28 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
+  valibot@1.2.0(typescript@7.0.2):
+    optionalDependencies:
+      typescript: 7.0.2
+
   valibot@1.4.2(typescript@7.0.2):
     optionalDependencies:
       typescript: 7.0.2
+
+  vite@8.2.2(@types/node@26.4.1)(esbuild@0.25.12)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.7
+      postcss: 8.5.28
+      rolldown: 1.2.7
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.4.1
+      esbuild: 0.25.12
+      fsevents: 2.3.3
+      terser: 5.51.2
+      tsx: 4.23.13
+      yaml: 2.9.0
 
   vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0):
     dependencies:
@@ -12482,6 +14825,33 @@ snapshots:
     dependencies:
       mock-socket: 9.3.1
       vitest: 5.0.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.1)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.14.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
+
+  vitest@5.0.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.1)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.14.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.1)(esbuild@0.25.12)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/mocker': 5.0.0(vite@8.2.2(@types/node@26.4.1)(esbuild@0.25.12)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
+      chai: 6.2.2
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 1.2.3
+      obug: 2.1.4
+      picomatch: 4.0.7
+      std-env: 4.2.0
+      tinybench: 6.1.4
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      vite: 8.2.2(@types/node@26.4.1)(esbuild@0.25.12)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@edge-runtime/vm': 5.0.0
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 26.4.1
+      '@vitest/coverage-v8': 5.0.0(@vitest/browser@5.0.0)(vitest@5.0.0)
+      '@vitest/ui': 5.0.0(vitest@5.0.0)
+      happy-dom: 20.14.0
+      jsdom: 30.0.1
+    transitivePeerDependencies:
+      - msw
 
   vitest@5.0.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.1)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.14.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)):
     dependencies:
@@ -12576,6 +14946,18 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  widest-line@6.0.0:
+    dependencies:
+      string-width: 8.2.2
+
+  workerd@1.20260704.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260704.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260704.1
+      '@cloudflare/workerd-linux-64': 1.20260704.1
+      '@cloudflare/workerd-linux-arm64': 1.20260704.1
+      '@cloudflare/workerd-windows-64': 1.20260704.1
+
   workerd@1.20260730.1:
     optionalDependencies:
       '@cloudflare/workerd-darwin-64': 1.20260730.1
@@ -12639,6 +15021,8 @@ snapshots:
 
   xml-name-validator@5.0.0: {}
 
+  xml-naming@0.3.0: {}
+
   xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
@@ -12678,6 +15062,12 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 22.0.0
 
+  yauzl@3.4.0:
+    dependencies:
+      pend: 1.2.0
+
+  yoga-layout@3.2.1: {}
+
   youch-core@0.3.3:
     dependencies:
       '@poppinss/exception': 1.2.3
@@ -12690,6 +15080,11 @@ snapshots:
       '@speed-highlight/core': 1.2.24
       cookie: 1.1.1
       youch-core: 0.3.3
+
+  zeptomatch@2.1.0:
+    dependencies:
+      grammex: 3.1.13
+      graphmatch: 1.1.1
 
   zip-stream@6.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@types/ssh2>@types/node': ^26.2.0
+
 patchedDependencies:
   '@changesets/get-github-info@1.0.1': 4b2756eb490a2ad802075423f6b08a5f50f12307ec25e117b20a79e12236b625
 
@@ -4108,9 +4111,6 @@ packages:
   '@types/jsesc@2.5.1':
     resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
 
-  '@types/node@18.19.130':
-    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
-
   '@types/node@26.4.1':
     resolution: {integrity: sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==}
 
@@ -7587,9 +7587,6 @@ packages:
     engines: {node: '>=16.20.0'}
     hasBin: true
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
@@ -10863,10 +10860,6 @@ snapshots:
 
   '@types/jsesc@2.5.1': {}
 
-  '@types/node@18.19.130':
-    dependencies:
-      undici-types: 5.26.5
-
   '@types/node@26.4.1':
     dependencies:
       undici-types: 8.3.0
@@ -10902,7 +10895,7 @@ snapshots:
 
   '@types/ssh2@1.15.6':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 26.4.1
 
   '@types/stack-utils@2.0.3': {}
 
@@ -14747,8 +14740,6 @@ snapshots:
       '@typescript/typescript-sunos-x64': 7.0.2
       '@typescript/typescript-win32-arm64': 7.0.2
       '@typescript/typescript-win32-x64': 7.0.2
-
-  undici-types@5.26.5: {}
 
   undici-types@8.3.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,10 +30,8 @@ patchedDependencies:
   '@changesets/get-github-info@1.0.1': patches/@changesets__get-github-info@1.0.1.patch
 
 minimumReleaseAgeExclude:
-  - '@alchemy.run/cloudflare-runtime@2.0.0-beta.76'
-  - '@alchemy.run/floci@2.0.0-beta.76'
-  - '@alchemy.run/node-utils@2.0.0-beta.76'
-  - alchemy@2.0.0-beta.76
+  - '@alchemy.run/*'
+  - alchemy
 
 # alchemy's dependency tree pulls @types/ssh2, whose @types/node@18 would
 # otherwise join the shared tests compilation and clash with the workspace

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,3 +34,9 @@ minimumReleaseAgeExclude:
   - '@alchemy.run/floci@2.0.0-beta.76'
   - '@alchemy.run/node-utils@2.0.0-beta.76'
   - alchemy@2.0.0-beta.76
+
+# alchemy's dependency tree pulls @types/ssh2, whose @types/node@18 would
+# otherwise join the shared tests compilation and clash with the workspace
+# @types/node globals.
+overrides:
+  '@types/ssh2>@types/node': ^26.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,3 +28,9 @@ allowBuilds:
 
 patchedDependencies:
   '@changesets/get-github-info@1.0.1': patches/@changesets__get-github-info@1.0.1.patch
+
+minimumReleaseAgeExclude:
+  - '@alchemy.run/cloudflare-runtime@2.0.0-beta.76'
+  - '@alchemy.run/floci@2.0.0-beta.76'
+  - '@alchemy.run/node-utils@2.0.0-beta.76'
+  - alchemy@2.0.0-beta.76

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "include": [],
   "references": [
     { "path": "tsconfig.packages.json" },
-    { "path": "tsconfig.tests.json" }
+    { "path": "tsconfig.tests.json" },
+    { "path": "packages/platform/cloudflare/tsconfig.alchemy.json" }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
   "include": [],
   "references": [
     { "path": "tsconfig.packages.json" },
-    { "path": "tsconfig.tests.json" },
-    { "path": "packages/platform/cloudflare/tsconfig.alchemy.json" }
+    { "path": "tsconfig.tests.json" }
   ]
 }

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -14,7 +14,14 @@
     "./packages/**/typetest/**/*.ts",
     "./packages/**/benchmark/**/*.ts"
   ],
-  "exclude": ["**/node_modules/**", "**/dist/**", "./packages/platform/deno/**"],
+  "exclude": [
+    "**/node_modules/**",
+    "**/dist/**",
+    "./packages/platform/deno/**",
+    // Compiled by the package's own tsconfig.alchemy.json: the alchemy type
+    // graph loads bun globals that clash with this project's node globals.
+    "./packages/platform/cloudflare/typetest/**"
+  ],
   "compilerOptions": {
     "rootDir": ".",
     "noEmit": true,

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -20,7 +20,7 @@
     "./packages/platform/deno/**",
     // Compiled by the package's own tsconfig.alchemy.json: the alchemy type
     // graph loads bun globals that clash with this project's node globals.
-    "./packages/platform/cloudflare/typetest/**"
+    "./packages/platform/cloudflare/typetest/AlchemyCloudflareCluster.tst.ts"
   ],
   "compilerOptions": {
     "rootDir": ".",


### PR DESCRIPTION
Adds Alchemy v2 deployment for the Cloudflare cluster, stacked on #7322. Closes EFF-988.

`AlchemyCloudflareCluster.make({ entities, layer })` registers four library-owned Durable Object classes, builds the cluster and handler layers into the isolate-lifetime scope, and returns `provide`, `wake`, native namespace bindings, and `context`. Users own the Worker and cron declaration; they do not declare or re-export Alchemy Durable Object classes.

- Wrangler and Alchemy now use the same `CloudflareDurableObjectPrograms`. Wrangler builds each program inside its existing initialization barrier, then stores the completed program for RPCs and alarms. Transport types are shared with the internals.
- Plan-time namespace and context access throws a field-specific diagnostic. `provide` and `wake` remain inert during planning. Native namespace RPC methods retain a `never` error channel to avoid Alchemy typed-error envelopes. Alchemy's default fetch 404 and Wrangler's fetch rejection are deliberate.
- Alchemy is an optional peer (`>=2.0.0-beta <3`), pinned to `2.0.0-beta.76` for development. The Wrangler entry stays Alchemy-free. Release-age exclusions use package-name patterns; the existing Node type override remains necessary for Alchemy's dependency graph.
- The example and typetests have a dedicated Alchemy typecheck step in normal PR CI and the manual `Alchemy Canary` workflow. The example project is no longer referenced by the root typecheck. Only the Alchemy typetest is excluded from the shared tests project.

`wake(name)` returns the handler function required by `Cloudflare.Workers.cron`. The example provides `CronEventSourceLive` on Worker initialization; the cluster layer itself uses the isolate scope.

Validation: all 170 Cloudflare tests and 18 Alchemy typetests pass; root typecheck, dedicated Alchemy typecheck, lint, package build, stripped declaration emission, and a fresh dependency resolution pass. Test changes are confined to the supplied regression-test commit. Repository JSDoc validation reports unrelated existing errors in `packages/effect/src/Logger.ts`.

The Alchemy glue remains typecheck-only against workspace Effect because the pinned Alchemy runtime targets the published Effect API. The README live `alchemy deploy` smoke is explicitly **not verified**; it still requires Cloudflare credentials. Supersedes #7548.


Singleton alarm state reads are deferred with `Effect.suspend`, and workflow, queue, and singleton programs capture Effect's Clock service while reading its current timestamp on each operation. The public cron example now provides `CronEventSourceLive`. All six alarm and Clock regressions pass; the live smoke remains unverified.


`Cluster` has a single definition in the Alchemy-free `internal/cluster.ts` module and remains exported by `AlchemyCloudflareCluster`. A clean shared-tests compilation resolves zero Alchemy declarations; stripped declaration emission preserves the public type and its imports.
