### PR TITLE
fix(cluster): run the empty shard-lock liveness probe on the shared pool

### DIFF
--- a/.changeset/violet-pugs-tickle.md
+++ b/.changeset/violet-pugs-tickle.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Cluster shard-lock recovery no longer stalls behind a wedged reserved SQL connection.
+
+While lock storage is unhealthy, the empty liveness probe (`refresh(address, [])`) now runs on the shared pool instead of the reserved lock connection, so a hung reserved connection cannot block recovery. Failed probes are also logged as warnings instead of being silently swallowed.

--- a/packages/effect/src/unstable/cluster/Sharding.ts
+++ b/packages/effect/src/unstable/cluster/Sharding.ts
@@ -559,7 +559,7 @@ const make = Effect.gen(function*() {
     const probeShardLocks = runnerStorage.refresh(selfAddress, []).pipe(
       Effect.timeout(shardLockInterval),
       Effect.andThen(markShardLocksHealthy),
-      Effect.catchCause(() => Effect.void)
+      Effect.catchCause((cause) => Effect.logWarning("Shard lock storage is still unhealthy", cause))
     )
 
     // Refresh shard locks at the lease-safe interval, or probe storage while

--- a/packages/effect/src/unstable/cluster/SqlRunnerStorage.ts
+++ b/packages/effect/src/unstable/cluster/SqlRunnerStorage.ts
@@ -737,18 +737,28 @@ export const make = Effect.fnUntraced(function*(options: {
         withTracerDisabled
       ),
 
-    refresh: (address, shardIds) =>
-      withLockOperationDeadline(
-        sql`UPDATE ${runnersTableSql} SET last_heartbeat = ${sqlNow} WHERE address = ${address}`.pipe(
+    refresh: (address, shardIds) => {
+      const heartbeat = sql`UPDATE ${runnersTableSql} SET last_heartbeat = ${sqlNow} WHERE address = ${address}`
+      // An empty refresh is the liveness probe used while lock storage is
+      // unhealthy. Run it on the shared pool, so a wedged reserved lock
+      // connection cannot block recovery.
+      if (shardIds.length === 0) {
+        return withDeadline(heartbeat).pipe(
+          Effect.as([]),
+          PersistenceError.refail,
+          withTracerDisabled
+        )
+      }
+      return withLockOperationDeadline(
+        heartbeat.pipe(
           execWithLockConn,
-          shardIds.length > 0 ?
-            Effect.andThen(refreshShards(address, shardIds)) :
-            Effect.as([])
+          Effect.andThen(refreshShards(address, shardIds))
         )
       ).pipe(
         PersistenceError.refail,
         withTracerDisabled
-      ),
+      )
+    },
 
     release: (address, shardId) =>
       withLockOperationDeadline(releaseShard(address, shardId)).pipe(

--- a/packages/effect/test/cluster/Sharding.test.ts
+++ b/packages/effect/test/cluster/Sharding.test.ts
@@ -1498,6 +1498,12 @@ describe.concurrent("Sharding residency cap", () => {
 describe("Sharding shard lock failover", () => {
   it.effect("interrupts entities and reacquires shards after lock storage recovers", () =>
     Effect.gen(function*() {
+      const warnings: Array<unknown> = []
+      const logger = Logger.make<unknown, void>((options) => {
+        if (options.logLevel === "Warn") {
+          warnings.push(options.message)
+        }
+      })
       const storageState = makeFailoverStorageState()
       const runnerStorage = Layer.effect(
         RunnerStorage.RunnerStorage,
@@ -1579,6 +1585,65 @@ describe("Sharding shard lock failover", () => {
         assert(storageState.acquireCalls.at(-1)!.shards.some((shard) => shard.id === shardId.id))
         assert.deepStrictEqual(yield* client.GetUserVolatile({ id: 2 }), new User({ id: 2, name: "User 2" }))
         assert.strictEqual(Queue.sizeUnsafe(entityState.envelopes), 2)
+        assert.isTrue(warnings.some((message) =>
+          globalThis.Array.isArray(message) && message.includes("Shard lock storage is still unhealthy")
+        ))
+      }).pipe(Effect.provide(layer), Effect.withLogger(logger), Effect.scoped)
+    }))
+
+  it.effect("reacquires shards when the liveness probe succeeds while lock refresh is hung", () =>
+    Effect.gen(function*() {
+      const storageState = makeFailoverStorageState()
+      const runnerStorage = Layer.effect(
+        RunnerStorage.RunnerStorage,
+        Effect.map(Clock.Clock, (clock) => makeFailoverStorage(storageState, clock))
+      )
+      const config = ShardingConfig.layer({
+        runnerAddress: Option.some(RunnerAddress.make("localhost", 1234)),
+        shardsPerGroup: 1,
+        shardLockExpiration: 300,
+        shardLockRefreshInterval: 1000,
+        entityTerminationTimeout: 30_000,
+        entityMessagePollInterval: 10,
+        refreshAssignmentsInterval: 10,
+        sendRetryInterval: 10
+      })
+      const layer = TestEntityNoState.pipe(
+        Layer.provideMerge(Sharding.layer),
+        Layer.provide(runnerStorage),
+        Layer.provide(RunnerHealth.layerNoop),
+        Layer.provideMerge(TestEntityState.layer),
+        Layer.provide(Runners.layerNoop),
+        Layer.provide([MessageStorage.layerMemory, Snowflake.layerGenerator]),
+        Layer.provide(config)
+      )
+
+      yield* Effect.gen(function*() {
+        const sharding = yield* Sharding.Sharding
+        const makeClient = yield* TestEntity.client
+        const client = makeClient("1")
+        const shardId = sharding.getShardId(EntityId.make("1"), "default")
+
+        while (!sharding.hasShardId(shardId)) {
+          yield* TestClock.adjust(10)
+        }
+        while (!storageState.refreshCalls.some((call) => call.shards.length > 0)) {
+          yield* TestClock.adjust(100)
+        }
+
+        const acquireCount = storageState.acquireCalls.length
+        storageState.blackholeNonEmptyRefresh = true
+        yield* TestClock.adjust(201)
+        assert.isFalse(sharding.hasShardId(shardId))
+
+        // recovery only needs the empty liveness probe to succeed
+        while (!sharding.hasShardId(shardId)) {
+          yield* TestClock.adjust(10)
+        }
+
+        assert.isAbove(storageState.acquireCalls.length, acquireCount)
+        assert(storageState.refreshCalls.some((call) => call.shards.length === 0))
+        assert.deepStrictEqual(yield* client.GetUserVolatile({ id: 3 }), new User({ id: 3, name: "User 3" }))
       }).pipe(Effect.provide(layer), Effect.scoped)
     }))
 
@@ -1812,6 +1877,8 @@ describe("Sharding shard lock failover", () => {
 
 interface FailoverStorageState {
   blackholed: boolean
+  /** Hang only non-empty refreshes, so the empty liveness probe can succeed. */
+  blackholeNonEmptyRefresh: boolean
   assignSelf: boolean
   otherRunnerHealthy: boolean
   /** Test clock duration `releaseAll` stays in flight for. */
@@ -1833,6 +1900,7 @@ const makeFailoverStorageState = (
   overrides?: Partial<FailoverStorageState>
 ): FailoverStorageState => ({
   blackholed: false,
+  blackholeNonEmptyRefresh: false,
   assignSelf: true,
   otherRunnerHealthy: false,
   releaseAllDuration: 0,
@@ -1874,7 +1942,9 @@ const makeFailoverStorage = (state: FailoverStorageState, clock: Clock.Clock) =>
           at: clock.currentTimeMillisUnsafe(),
           shards
         })
-        return state.blackholed ? Effect.never : Effect.succeed(shards)
+        return (state.blackholed || (state.blackholeNonEmptyRefresh && shards.length > 0))
+          ? Effect.never
+          : Effect.succeed(shards)
       }),
     release: (_address, shardId) =>
       Effect.sync(() => {

--- a/packages/platform/node/test/cluster/SqlRunnerStorage.integration.test.ts
+++ b/packages/platform/node/test/cluster/SqlRunnerStorage.integration.test.ts
@@ -99,6 +99,52 @@ describe("SqlRunnerStorage", () => {
     )
   }, 60_000)
 
+  it.effect("empty liveness probe bypasses a wedged reserved connection", () => {
+    const partitioned = makePartitionState()
+    const layer = StorageLayer.pipe(
+      Layer.provideMerge(blackholeReservedConnection(partitioned, true)),
+      Layer.provide(ShardingConfig.layer({
+        shardLockExpiration: 1000,
+        shardLockRefreshInterval: 100
+      }))
+    )
+
+    return Effect.gen(function*() {
+      const storage = yield* RunnerStorage.RunnerStorage
+      const runner = Runner.make({
+        address: runnerAddress1,
+        groups: ["default"],
+        weight: 1
+      })
+      const shards = [ShardId.make("default", 1)]
+
+      yield* storage.register(runner, true)
+      yield* storage.acquire(runnerAddress1, shards)
+      partitionConnection(partitioned)
+
+      // shard lock operations are stuck behind the wedged reserved connection
+      const exit = yield* storage.refresh(runnerAddress1, shards).pipe(Effect.exit)
+      assert(Exit.isFailure(exit))
+
+      // the liveness probe runs on the shared pool, so it must succeed while
+      // the reserved connection stays wedged
+      expect(yield* storage.refresh(runnerAddress1, [])).toEqual([])
+
+      restoreConnection(partitioned)
+      expect(
+        yield* storage.refresh(runnerAddress1, shards).pipe(
+          Effect.retry({ times: 20, schedule: Schedule.spaced(20) })
+        )
+      ).toEqual(shards)
+    }).pipe(
+      Effect.ensuring(Effect.sync(() => {
+        restoreConnection(partitioned)
+      })),
+      Effect.provide(layer),
+      TestClock.withLive
+    )
+  }, 60_000)
+
   it.effect("recovers when a blackholed query cannot resume after the partition clears", () => {
     const partitioned = makePartitionState()
     const layer = StorageLayer.pipe(


### PR DESCRIPTION
## Why

A runner that lost its SQL connection (Azure Postgres `ETIMEDOUT`) logged `Shard lock storage is unhealthy` and never recovered until a process restart, even though the recovery loop (`probeShardLocks`, every ~10s) was running the whole time. Validated in patroza/effect#17:

- the empty liveness probe (`refresh(address, [])`) was routed through the reserved lock connection, the exact connection that was wedged on hung TCP, so the probe could never succeed
- failed probes were swallowed by `catchCause(() => Effect.void)`, so operators saw one "unhealthy" log line and then silence

## What

The simplest fix, two small changes:

- `SqlRunnerStorage.refresh`: an empty refresh is the liveness probe, so run it on the shared pool with a deadline instead of the reserved lock connection. A wedged reserved connection can no longer block recovery; the existing rebuild-on-error machinery replaces it once lock operations resume.
- `Sharding.probeShardLocks`: log a warning on probe failure instead of swallowing it.

Compared to patroza/effect#17, the `Effect.timeout` on the lock-conn `sql.reserve` is dropped: on `main`, `rebuildLockConn` already bounds every rebuild with `withDeadline`, which interrupts the rebuild fiber after the lock-operation interval, so the reserve is already deadline-bound.

## Tests

- Integration (`SqlRunnerStorage.integration.test.ts`, real Postgres): with the reserved connection wedged, non-empty refresh fails but the empty liveness probe succeeds, and lock operations recover after the partition clears. Red on `main` before the fix (probe failed with `PersistenceError`), green after.
- Unit (`Sharding.test.ts`): shards are reacquired when only the empty liveness probe succeeds while non-empty lock refresh is hung, and the existing failover test now asserts the "still unhealthy" warning is logged while storage is down.

`pnpm vitest run --project effect packages/effect/test/cluster/Sharding.test.ts`: 53 passed.
`EFFECT_INTEGRATION_TESTS=1 pnpm vitest run --project "@effect/platform-node" packages/platform/node/test/cluster/SqlRunnerStorage.integration.test.ts`: 23 passed (pg, mysql, vitess, sqlite).

Closes EFF-989
