### PR TITLE
Persist chats through an appendable store

### DIFF
--- a/.changeset/chat-store.md
+++ b/.changeset/chat-store.md
@@ -1,0 +1,11 @@
+---
+"effect": patch
+---
+
+Persist chats through an appendable `ChatStore`.
+
+`Chat.Persisted` stored a conversation as a single value and rewrote all of it on every save, so persisting a chat was quadratic in the number of turns and a chat could only ever be loaded whole. It is now backed by `Chat.ChatStore`, which writes only the messages a turn added, reads ranges, and lists the chats in a store.
+
+`Chat.layerPersisted` now requires `ChatStore` rather than `BackingPersistence`. `Chat.layerStoreMemory` is the in-memory implementation, and `Chat.layerStoreBacking` provides a `ChatStore` from an existing `BackingPersistence` for applications that want their current backend.
+
+Saving a chat also no longer mutates the messages it stamps with a message identifier: history is rebuilt with replacement messages instead, so a message already handed to a caller does not change underneath them.

--- a/.changeset/persisted-chat-incremental-encode.md
+++ b/.changeset/persisted-chat-incremental-encode.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Encode persisted chat history incrementally. `Chat.Persisted` re-encoded every message in a conversation on every save, making persistence quadratic in the number of turns and stalling other fibers while it ran. Messages are now encoded once and reused across saves.
+
+Saving a chat also no longer mutates the messages it stamps with a message identifier: history is rebuilt with replacement messages instead, so a message already handed to a caller does not change underneath them. Persisted output is unchanged.

--- a/.changeset/persisted-chat-incremental-encode.md
+++ b/.changeset/persisted-chat-incremental-encode.md
@@ -1,7 +1,0 @@
----
-"effect": patch
----
-
-Encode persisted chat history incrementally. `Chat.Persisted` re-encoded every message in a conversation on every save, making persistence quadratic in the number of turns and stalling other fibers while it ran. Messages are now encoded once and reused across saves.
-
-Saving a chat also no longer mutates the messages it stamps with a message identifier: history is rebuilt with replacement messages instead, so a message already handed to a caller does not change underneath them. Persisted output is unchanged.

--- a/packages/effect/src/unstable/ai/Chat.ts
+++ b/packages/effect/src/unstable/ai/Chat.ts
@@ -408,6 +408,7 @@ export interface Service {
 
 const decodeHistory = Schema.decodeUnknownEffect(Prompt.Prompt)
 const encodeHistory = Schema.encodeUnknownEffect(Prompt.Prompt)
+const encodeMessage = Schema.encodeUnknownEffect(Prompt.Message)
 const decodeHistoryJson = Schema.decodeUnknownEffect(Schema.fromJsonString(Prompt.Prompt))
 const encodeHistoryJson = Schema.encodeUnknownEffect(Schema.fromJsonString(Prompt.Prompt))
 
@@ -792,6 +793,30 @@ export interface Persisted extends Service {
 }
 
 /**
+ * Returns the message with its persistence message identifier attached.
+ *
+ * The message is replaced rather than mutated so that a message already handed
+ * to a caller - or already encoded by a previous save - never changes
+ * underneath them.
+ */
+const withMessageId = <M extends Prompt.Message>(message: M, messageId: string): M => ({
+  ...message,
+  options: { ...message.options, [Persistence.key]: { messageId } }
+})
+
+/** Stamps every message from `start` onwards with `messageId`. */
+const stampMessages = (history: Prompt.Prompt, start: number, messageId: string): Prompt.Prompt => {
+  if (start >= history.content.length) {
+    return history
+  }
+  const content = history.content.slice()
+  for (let i = start; i < content.length; i++) {
+    content[i] = withMessageId(content[i], messageId)
+  }
+  return Prompt.fromMessages(content)
+}
+
+/**
  * Creates a new chat persistence service.
  *
  * **When to use**
@@ -821,6 +846,28 @@ export const makePersisted = Effect.fnUntraced(function*(options: {
         Effect.map(Option.getOrElse(() => IdGenerator.defaultIdGenerator))
       )
 
+      // Encoding the whole history on every save makes persisting a chat
+      // quadratic in the number of turns: turn `n` re-encodes the `n - 1`
+      // messages that have not changed since the previous save. Messages are
+      // immutable values, so a message that changes is a different object and
+      // simply misses this cache; weak keys let a message that leaves history
+      // take its encoding with it.
+      const encodedMessages = new WeakMap<Prompt.Message, unknown>()
+      const exportHistory = Effect.fnUntraced(function*(history: Prompt.Prompt) {
+        const messages = history.content
+        const content = new Array<unknown>(messages.length)
+        for (let i = 0; i < messages.length; i++) {
+          const message = messages[i]
+          let encoded = encodedMessages.get(message)
+          if (Predicate.isUndefined(encoded)) {
+            encoded = yield* encodeMessage(message)
+            encodedMessages.set(message, encoded)
+          }
+          content[i] = encoded
+        }
+        return { content }
+      })
+
       const saveChat = Effect.fnUntraced(
         function*(prevHistory: Prompt.Prompt) {
           // Get the current chat history
@@ -839,15 +886,13 @@ export const makePersisted = Effect.fnUntraced(function*(options: {
           if (Predicate.isUndefined(messageId)) {
             messageId = yield* idGenerator.generateId()
           }
-          // Mutate the new messages to add the generated message identifier
-          for (let i = prevHistory.content.length; i < history.content.length; i++) {
-            const message = history.content[i]
-            ;(message.options as any)[Persistence.key] = { messageId }
-          }
-          // Save the mutated history back to the ref
-          yield* Ref.set(chat.history, history)
-          // Export the chat history
-          const exported = yield* Effect.orDie(chat.export)
+          // Stamp the messages added since the previous save
+          const stamped = stampMessages(history, prevHistory.content.length, messageId)
+          // Save the stamped history back to the ref
+          yield* Ref.set(chat.history, stamped)
+          // Export the chat history, reusing the encoding of every message
+          // that was already persisted by a previous save
+          const exported = yield* Effect.orDie(exportHistory(stamped))
           const timeToLive = Predicate.isNotUndefined(ttl)
             ? Option.getOrUndefined(Duration.fromInput(ttl))
             : undefined

--- a/packages/effect/src/unstable/ai/Chat.ts
+++ b/packages/effect/src/unstable/ai/Chat.ts
@@ -12,7 +12,9 @@
  */
 import * as Channel from "../../Channel.ts"
 import * as Chunk from "../../Chunk.ts"
+import * as Clock from "../../Clock.ts"
 import * as Context from "../../Context.ts"
+import * as DateTime from "../../DateTime.ts"
 import * as Duration from "../../Duration.ts"
 import * as Effect from "../../Effect.ts"
 import * as Layer from "../../Layer.ts"
@@ -20,11 +22,12 @@ import * as Option from "../../Option.ts"
 import * as Predicate from "../../Predicate.ts"
 import * as Ref from "../../Ref.ts"
 import * as Schema from "../../Schema.ts"
+import * as Scope from "../../Scope.ts"
 import * as Semaphore from "../../Semaphore.ts"
 import * as Stream from "../../Stream.ts"
 import type { NoExcessProperties } from "../../Types.ts"
-import type { PersistenceError } from "../persistence/Persistence.ts"
-import { BackingPersistence } from "../persistence/Persistence.ts"
+import type { BackingPersistenceStore } from "../persistence/Persistence.ts"
+import { BackingPersistence, PersistenceError, unsafeTtlToExpires } from "../persistence/Persistence.ts"
 import * as AiError from "./AiError.ts"
 import * as IdGenerator from "./IdGenerator.ts"
 import * as LanguageModel from "./LanguageModel.ts"
@@ -408,7 +411,8 @@ export interface Service {
 
 const decodeHistory = Schema.decodeUnknownEffect(Prompt.Prompt)
 const encodeHistory = Schema.encodeUnknownEffect(Prompt.Prompt)
-const encodeMessage = Schema.encodeUnknownEffect(Prompt.Message)
+const encodeMessages = Schema.encodeUnknownEffect(Schema.Array(Prompt.Message))
+const decodeMessages = Schema.decodeUnknownEffect(Schema.Array(Prompt.Message))
 const decodeHistoryJson = Schema.decodeUnknownEffect(Schema.fromJsonString(Prompt.Prompt))
 const encodeHistoryJson = Schema.encodeUnknownEffect(Schema.fromJsonString(Prompt.Prompt))
 
@@ -804,6 +808,17 @@ const withMessageId = <M extends Prompt.Message>(message: M, messageId: string):
   options: { ...message.options, [Persistence.key]: { messageId } }
 })
 
+/** The index of the first message at which two histories differ. */
+const divergence = (left: ReadonlyArray<Prompt.Message>, right: ReadonlyArray<Prompt.Message>): number => {
+  const shared = Math.min(left.length, right.length)
+  for (let i = 0; i < shared; i++) {
+    if (left[i] !== right[i]) {
+      return i
+    }
+  }
+  return shared
+}
+
 /** Stamps every message from `start` onwards with `messageId`. */
 const stampMessages = (history: Prompt.Prompt, start: number, messageId: string): Prompt.Prompt => {
   if (start >= history.content.length) {
@@ -815,6 +830,354 @@ const stampMessages = (history: Prompt.Prompt, start: number, messageId: string)
   }
   return Prompt.fromMessages(content)
 }
+
+/**
+ * The storage backing a persisted `Chat`.
+ *
+ * **When to use**
+ *
+ * Use to back {@link Persistence} with a store that can append to a chat
+ * instead of rewriting it. Implementations exist for memory and for an
+ * existing `BackingPersistence`; a backend can implement this natively to
+ * append, read ranges, and list chats without loading whole conversations.
+ *
+ * **Details**
+ *
+ * A chat is an ordered list of encoded messages. Values are opaque here:
+ * `Chat` encodes and decodes them, so a store never sees a `Prompt`.
+ *
+ * The interface is deliberately narrow - write, read, list, remove, clean up -
+ * so that every backend can implement all of it. Anything richer, such as
+ * searching message content, belongs in the backend's own client rather than
+ * here, where only some backends could honour it.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export class ChatStore extends Context.Service<ChatStore, {
+  /**
+   * Replaces the messages of a chat from `from` onwards, creating the chat
+   * when it does not exist.
+   *
+   * Appending is `from` equal to the number of messages already stored.
+   * Rewriting history, as summarizing or redacting a conversation does, is a
+   * smaller `from`. A `from` beyond the end of the chat fails rather than
+   * leaving a hole, and so does a `from` that does not match what the caller
+   * last saw, which is how two writers racing on one chat is caught instead of
+   * silently losing one of them.
+   */
+  readonly write: (options: {
+    readonly storeId: string
+    readonly chatId: string
+    readonly from: number
+    readonly messages: ReadonlyArray<unknown>
+    readonly timeToLive: Duration.Duration | undefined
+  }) => Effect.Effect<void, PersistenceError>
+
+  /**
+   * Reads `limit` messages of a chat starting at `from`, or all of them when
+   * `limit` is not given. Returns `undefined` when the chat does not exist,
+   * which is distinct from a chat that exists and has no messages.
+   */
+  readonly read: (options: {
+    readonly storeId: string
+    readonly chatId: string
+    readonly from: number
+    readonly limit: number | undefined
+  }) => Effect.Effect<ReadonlyArray<unknown> | undefined, PersistenceError>
+
+  /**
+   * Reads the last `limit` messages of a chat, oldest first. Returns
+   * `undefined` when the chat does not exist.
+   */
+  readonly readBackwards: (options: {
+    readonly storeId: string
+    readonly chatId: string
+    readonly limit: number
+  }) => Effect.Effect<ReadonlyArray<unknown> | undefined, PersistenceError>
+
+  /**
+   * Lists the chats in a store, most recently written first.
+   */
+  readonly list: (options: {
+    readonly storeId: string
+    readonly after: string | undefined
+    readonly limit: number
+  }) => Effect.Effect<ReadonlyArray<ChatSummary>, PersistenceError>
+
+  readonly remove: (options: {
+    readonly storeId: string
+    readonly chatId: string
+  }) => Effect.Effect<void, PersistenceError>
+
+  /**
+   * Removes chats that have not been written to within `olderThan`.
+   */
+  readonly cleanup: (options: {
+    readonly storeId: string
+    readonly olderThan: Duration.Duration
+  }) => Effect.Effect<void, PersistenceError>
+}>()("effect/ai/Chat/ChatStore") {}
+
+/**
+ * What {@link ChatStore.list} reports about a chat without reading it.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ChatSummary {
+  readonly chatId: string
+  readonly messages: number
+  readonly updatedAt: DateTime.Utc
+}
+
+const outOfRange = (chatId: string, from: number, length: number) =>
+  new PersistenceError({
+    message: `Cannot write chat '${chatId}' from index ${from}; it has ${length} messages`
+  })
+
+interface MemoryChat {
+  messages: Array<unknown>
+  updatedAt: number
+  expiresAt: number | null
+}
+
+/**
+ * Provides an in-memory `ChatStore`. The store is process-local and volatile.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layerStoreMemory: Layer.Layer<ChatStore> = Layer.effect(ChatStore)(
+  Effect.gen(function*() {
+    const clock = yield* Clock.Clock
+    const stores = new Map<string, Map<string, MemoryChat>>()
+    const storeOf = (storeId: string) => {
+      let store = stores.get(storeId)
+      if (Predicate.isUndefined(store)) {
+        store = new Map()
+        stores.set(storeId, store)
+      }
+      return store
+    }
+    const live = (storeId: string, chatId: string): MemoryChat | undefined => {
+      const store = storeOf(storeId)
+      const chat = store.get(chatId)
+      if (Predicate.isUndefined(chat)) {
+        return undefined
+      }
+      if (chat.expiresAt !== null && chat.expiresAt <= clock.currentTimeMillisUnsafe()) {
+        store.delete(chatId)
+        return undefined
+      }
+      return chat
+    }
+    return ChatStore.of({
+      write: (options) =>
+        Effect.suspend(() => {
+          const now = clock.currentTimeMillisUnsafe()
+          const existing = live(options.storeId, options.chatId)
+          const messages = Predicate.isUndefined(existing) ? [] : existing.messages
+          if (options.from > messages.length) {
+            return Effect.fail(outOfRange(options.chatId, options.from, messages.length))
+          }
+          messages.length = options.from
+          messages.push(...options.messages)
+          storeOf(options.storeId).set(options.chatId, {
+            messages,
+            updatedAt: now,
+            expiresAt: unsafeTtlToExpires(clock, options.timeToLive)
+          })
+          return Effect.void
+        }),
+      read: (options) =>
+        Effect.sync(() => {
+          const chat = live(options.storeId, options.chatId)
+          if (Predicate.isUndefined(chat)) {
+            return undefined
+          }
+          return Predicate.isUndefined(options.limit)
+            ? chat.messages.slice(options.from)
+            : chat.messages.slice(options.from, options.from + options.limit)
+        }),
+      readBackwards: (options) =>
+        Effect.sync(() => {
+          const chat = live(options.storeId, options.chatId)
+          return Predicate.isUndefined(chat)
+            ? undefined
+            : chat.messages.slice(Math.max(0, chat.messages.length - options.limit))
+        }),
+      list: (options) =>
+        Effect.sync(() => {
+          const summaries: Array<ChatSummary & { readonly at: number }> = []
+          for (const chatId of storeOf(options.storeId).keys()) {
+            const chat = live(options.storeId, chatId)
+            if (Predicate.isNotUndefined(chat)) {
+              summaries.push({
+                chatId,
+                messages: chat.messages.length,
+                updatedAt: DateTime.makeUnsafe(chat.updatedAt),
+                at: chat.updatedAt
+              })
+            }
+          }
+          summaries.sort((left, right) => right.at - left.at || left.chatId.localeCompare(right.chatId))
+          const start = Predicate.isUndefined(options.after)
+            ? 0
+            : summaries.findIndex((summary) => summary.chatId === options.after) + 1
+          return summaries.slice(start, start + options.limit)
+        }),
+      remove: (options) =>
+        Effect.sync(() => {
+          storeOf(options.storeId).delete(options.chatId)
+        }),
+      cleanup: (options) =>
+        Effect.sync(() => {
+          const cutoff = clock.currentTimeMillisUnsafe() - Duration.toMillis(options.olderThan)
+          const store = storeOf(options.storeId)
+          for (const [chatId, chat] of store) {
+            if (chat.updatedAt <= cutoff) {
+              store.delete(chatId)
+            }
+          }
+        })
+    })
+  })
+)
+
+interface BackingChat {
+  readonly messages: ReadonlyArray<unknown>
+  readonly updatedAt: number
+}
+
+/**
+ * Provides a `ChatStore` on top of an existing `BackingPersistence`.
+ *
+ * **Details**
+ *
+ * A key/value store cannot append, so every write reads the chat, applies the
+ * change, and writes the whole chat back. This reproduces the cost of storing
+ * a chat as a single value and exists so that an application already using
+ * `BackingPersistence` keeps working; prefer a store that appends natively.
+ *
+ * Listing is served from an index kept alongside the chats, since the backing
+ * interface cannot enumerate keys.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layerStoreBacking: Layer.Layer<ChatStore, never, BackingPersistence> = Layer.effect(ChatStore)(
+  Effect.gen(function*() {
+    const clock = yield* Clock.Clock
+    const backing = yield* BackingPersistence
+    const scope = yield* Effect.scope
+    const stores = new Map<string, BackingPersistenceStore>()
+    const storeOf = (storeId: string) =>
+      Effect.suspend(() => {
+        const existing = stores.get(storeId)
+        if (Predicate.isNotUndefined(existing)) {
+          return Effect.succeed(existing)
+        }
+        // The store lives as long as the layer, not as long as one call
+        return backing.make(storeId).pipe(
+          Effect.provideService(Scope.Scope, scope),
+          Effect.tap((store) => Effect.sync(() => stores.set(storeId, store)))
+        )
+      })
+    const indexKey = "effect/ai/Chat/index"
+    const readChat = Effect.fnUntraced(function*(storeId: string, chatId: string) {
+      const store = yield* storeOf(storeId)
+      const value = yield* store.get(chatId)
+      return value as BackingChat | undefined
+    })
+    const readIndex = Effect.fnUntraced(function*(storeId: string) {
+      const store = yield* storeOf(storeId)
+      const value = yield* store.get(indexKey)
+      return Predicate.isUndefined(value) ? [] : (value as { readonly chatIds: Array<string> }).chatIds
+    })
+    const writeIndex = Effect.fnUntraced(function*(storeId: string, chatIds: ReadonlyArray<string>) {
+      const store = yield* storeOf(storeId)
+      yield* store.set(indexKey, { chatIds }, undefined)
+    })
+    return ChatStore.of({
+      write: Effect.fnUntraced(function*(options) {
+        const store = yield* storeOf(options.storeId)
+        const existing = yield* readChat(options.storeId, options.chatId)
+        const messages = Predicate.isUndefined(existing) ? [] : existing.messages.slice()
+        if (options.from > messages.length) {
+          return yield* Effect.fail(outOfRange(options.chatId, options.from, messages.length))
+        }
+        messages.length = options.from
+        messages.push(...options.messages)
+        yield* store.set(
+          options.chatId,
+          { messages, updatedAt: clock.currentTimeMillisUnsafe() } satisfies BackingChat,
+          options.timeToLive
+        )
+        const chatIds = yield* readIndex(options.storeId)
+        if (!chatIds.includes(options.chatId)) {
+          yield* writeIndex(options.storeId, [...chatIds, options.chatId])
+        }
+      }),
+      read: Effect.fnUntraced(function*(options) {
+        const chat = yield* readChat(options.storeId, options.chatId)
+        if (Predicate.isUndefined(chat)) {
+          return undefined
+        }
+        return Predicate.isUndefined(options.limit)
+          ? chat.messages.slice(options.from)
+          : chat.messages.slice(options.from, options.from + options.limit)
+      }),
+      readBackwards: Effect.fnUntraced(function*(options) {
+        const chat = yield* readChat(options.storeId, options.chatId)
+        return Predicate.isUndefined(chat)
+          ? undefined
+          : chat.messages.slice(Math.max(0, chat.messages.length - options.limit))
+      }),
+      list: Effect.fnUntraced(function*(options) {
+        const chatIds = yield* readIndex(options.storeId)
+        const summaries: Array<ChatSummary & { readonly at: number }> = []
+        for (const chatId of chatIds) {
+          const chat = yield* readChat(options.storeId, chatId)
+          if (Predicate.isNotUndefined(chat)) {
+            summaries.push({
+              chatId,
+              messages: chat.messages.length,
+              updatedAt: DateTime.makeUnsafe(chat.updatedAt),
+              at: chat.updatedAt
+            })
+          }
+        }
+        summaries.sort((left, right) => right.at - left.at || left.chatId.localeCompare(right.chatId))
+        const start = Predicate.isUndefined(options.after)
+          ? 0
+          : summaries.findIndex((summary) => summary.chatId === options.after) + 1
+        return summaries.slice(start, start + options.limit)
+      }),
+      remove: Effect.fnUntraced(function*(options) {
+        const store = yield* storeOf(options.storeId)
+        yield* store.remove(options.chatId)
+        const chatIds = yield* readIndex(options.storeId)
+        yield* writeIndex(options.storeId, chatIds.filter((chatId) => chatId !== options.chatId))
+      }),
+      cleanup: Effect.fnUntraced(function*(options) {
+        const cutoff = clock.currentTimeMillisUnsafe() - Duration.toMillis(options.olderThan)
+        const store = yield* storeOf(options.storeId)
+        const chatIds = yield* readIndex(options.storeId)
+        const kept: Array<string> = []
+        for (const chatId of chatIds) {
+          const chat = yield* readChat(options.storeId, chatId)
+          if (Predicate.isNotUndefined(chat) && chat.updatedAt > cutoff) {
+            kept.push(chatId)
+          } else {
+            yield* store.remove(chatId)
+          }
+        }
+        yield* writeIndex(options.storeId, kept)
+      })
+    })
+  })
+)
 
 /**
  * Creates a new chat persistence service.
@@ -837,36 +1200,27 @@ const stampMessages = (history: Prompt.Prompt, start: number, messageId: string)
 export const makePersisted = Effect.fnUntraced(function*(options: {
   readonly storeId: string
 }) {
-  const persistence = yield* BackingPersistence
-  const store = yield* persistence.make(options.storeId)
+  const store = yield* ChatStore
+  const storeId = options.storeId
 
   const toPersisted = Effect.fnUntraced(
-    function*(chatId: string, chat: Service, ttl: Duration.Input | undefined) {
+    function*(
+      chatId: string,
+      chat: Service,
+      persisted: ReadonlyArray<Prompt.Message>,
+      ttl: Duration.Input | undefined
+    ) {
       const idGenerator = yield* Effect.serviceOption(IdGenerator.IdGenerator).pipe(
         Effect.map(Option.getOrElse(() => IdGenerator.defaultIdGenerator))
       )
-
-      // Encoding the whole history on every save makes persisting a chat
-      // quadratic in the number of turns: turn `n` re-encodes the `n - 1`
-      // messages that have not changed since the previous save. Messages are
-      // immutable values, so a message that changes is a different object and
-      // simply misses this cache; weak keys let a message that leaves history
-      // take its encoding with it.
-      const encodedMessages = new WeakMap<Prompt.Message, unknown>()
-      const exportHistory = Effect.fnUntraced(function*(history: Prompt.Prompt) {
-        const messages = history.content
-        const content = new Array<unknown>(messages.length)
-        for (let i = 0; i < messages.length; i++) {
-          const message = messages[i]
-          let encoded = encodedMessages.get(message)
-          if (Predicate.isUndefined(encoded)) {
-            encoded = yield* encodeMessage(message)
-            encodedMessages.set(message, encoded)
-          }
-          content[i] = encoded
-        }
-        return { content }
-      })
+      const timeToLive = Predicate.isNotUndefined(ttl)
+        ? Option.getOrUndefined(Duration.fromInput(ttl))
+        : undefined
+      // The messages the store already holds. Comparing them by identity finds
+      // the first message a save has to write, so an ordinary turn writes only
+      // what it added and a rewritten history writes only from where it
+      // diverged.
+      const stored = yield* Ref.make(persisted)
 
       const saveChat = Effect.fnUntraced(
         function*(prevHistory: Prompt.Prompt) {
@@ -890,18 +1244,19 @@ export const makePersisted = Effect.fnUntraced(function*(options: {
           const stamped = stampMessages(history, prevHistory.content.length, messageId)
           // Save the stamped history back to the ref
           yield* Ref.set(chat.history, stamped)
-          // Export the chat history, reusing the encoding of every message
-          // that was already persisted by a previous save
-          const exported = yield* Effect.orDie(exportHistory(stamped))
-          const timeToLive = Predicate.isNotUndefined(ttl)
-            ? Option.getOrUndefined(Duration.fromInput(ttl))
-            : undefined
-          // Save the chat to the backing store
-          yield* store.set(chatId, exported as object, timeToLive)
+          // Write only the messages the store does not already hold
+          const previous = yield* Ref.get(stored)
+          const from = divergence(previous, stamped.content)
+          const added = stamped.content.slice(from)
+          if (from < previous.length || added.length > 0) {
+            const messages = yield* Effect.orDie(encodeMessages(added))
+            yield* store.write({ storeId, chatId, from, messages, timeToLive })
+            yield* Ref.set(stored, stamped.content)
+          }
         }
       )
 
-      const persisted: Persisted = {
+      const persistedChat: Persisted = {
         ...chat,
         id: chatId,
         save: Effect.flatMap(Ref.get(chat.history), saveChat),
@@ -910,7 +1265,7 @@ export const makePersisted = Effect.fnUntraced(function*(options: {
           return yield* chat.generateText(options).pipe(
             Effect.ensuring(Effect.orDie(saveChat(history)))
           )
-        }) as Service["generateText"],
+        }),
         generateObject: Effect.fnUntraced(function*(options) {
           const history = yield* Ref.get(chat.history)
           return yield* chat.generateObject(options).pipe(
@@ -926,42 +1281,35 @@ export const makePersisted = Effect.fnUntraced(function*(options: {
         }, Stream.unwrap) as Service["streamText"]
       }
 
-      return persisted
+      return persistedChat
     }
   )
 
-  const createChat = Effect.fnUntraced(
-    function*(chatId: string, ttl: Duration.Input | undefined) {
-      // Create an empty chat
-      const chat = yield* empty
-      // Export the chat history
-      const history = yield* Effect.orDie(chat.export)
-      // Save the history for the newly created chat
-      const timeToLive = Predicate.isNotUndefined(ttl)
-        ? Option.getOrUndefined(Duration.fromInput(ttl))
-        : undefined
-      yield* store.set(chatId, history as object, timeToLive)
-      // Convert the chat to a persisted chat
-      return yield* toPersisted(chatId, chat, ttl)
-    }
-  )
+  const createChat = Effect.fnUntraced(function*(chatId: string, ttl: Duration.Input | undefined) {
+    const chat = yield* empty
+    const timeToLive = Predicate.isNotUndefined(ttl)
+      ? Option.getOrUndefined(Duration.fromInput(ttl))
+      : undefined
+    // Record the chat so that it can be told apart from one that does not exist
+    yield* store.write({ storeId, chatId, from: 0, messages: [], timeToLive })
+    return yield* toPersisted(chatId, chat, [], ttl)
+  })
 
   const getChat = Effect.fnUntraced(
     function*(chatId: string, ttl: Duration.Input | undefined) {
-      // Create an empty chat
       const chat = yield* empty
-      // Attempt to retrieve the previous history from the store
-      const previousHistory = yield* store.get(chatId)
-      // If the previous history was not found, raise an error
-      if (Predicate.isUndefined(previousHistory)) {
+      // Attempt to retrieve the previous messages from the store
+      const encoded = yield* store.read({ storeId, chatId, from: 0, limit: undefined })
+      // If the chat was not found, raise an error
+      if (Predicate.isUndefined(encoded)) {
         return yield* new ChatNotFoundError({ chatId })
       }
-      // Decode the encoded previous history
-      const history = yield* decodeHistory(previousHistory)
+      // Decode the encoded previous messages
+      const messages = yield* decodeMessages(encoded)
       // Hydrate the chat history
-      yield* Ref.set(chat.history, history)
+      yield* Ref.set(chat.history, Prompt.fromMessages(messages))
       // Convert the chat to a persisted chat
-      return yield* toPersisted(chatId, chat, ttl)
+      return yield* toPersisted(chatId, chat, messages, ttl)
     },
     Effect.catchTag("SchemaError", Effect.die)
   )
@@ -1018,4 +1366,4 @@ export const makePersisted = Effect.fnUntraced(function*(options: {
  */
 export const layerPersisted = (options: {
   readonly storeId: string
-}): Layer.Layer<Persistence, never, BackingPersistence> => Layer.effect(Persistence)(makePersisted(options))
+}): Layer.Layer<Persistence, never, ChatStore> => Layer.effect(Persistence)(makePersisted(options))

--- a/packages/effect/test/unstable/ai/Chat.test.ts
+++ b/packages/effect/test/unstable/ai/Chat.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Layer, Predicate, Ref, Schema } from "effect"
+import { Duration, Effect, Layer, Predicate, Ref, Schema } from "effect"
 import { TestClock } from "effect/testing"
 import { Chat, IdGenerator, Prompt } from "effect/unstable/ai"
 import { Persistence } from "effect/unstable/persistence"
@@ -10,176 +10,297 @@ const withConstantIdGenerator = (id: string) =>
     generateId: () => Effect.succeed(id)
   })
 
-const PersistenceLayer = Layer.provideMerge(
-  Chat.layerPersisted({ storeId: "chat" }),
-  Persistence.layerBackingMemory
-)
+const decodeMessages = Schema.decodeUnknownEffect(Schema.Array(Prompt.Message))
 
-describe("Chat", () => {
-  it.effect("should persist chat history to the backing persistence store", () =>
-    Effect.gen(function*() {
-      const storeId = "chat"
-      const chatId = "1"
+/** Reads a chat back out of whichever `ChatStore` is provided. */
+const storedHistory = (chatId: string) =>
+  Effect.gen(function*() {
+    const store = yield* Chat.ChatStore
+    const messages = yield* store.read({ storeId: "chat", chatId, from: 0, limit: undefined })
+    return Predicate.isUndefined(messages)
+      ? undefined
+      : Prompt.fromMessages(yield* decodeMessages(messages))
+  })
 
-      const backing = yield* Persistence.BackingPersistence
-      const persistence = yield* Chat.Persistence
+const stores = [
+  ["memory", Chat.layerStoreMemory],
+  ["backing", Layer.provide(Chat.layerStoreBacking, Persistence.layerBackingMemory)]
+] as const
 
-      const store = yield* backing.make(storeId)
-      const chat = yield* persistence.getOrCreate(chatId)
+for (const [name, StoreLayer] of stores) {
+  const PersistenceLayer = Layer.provideMerge(
+    Chat.layerPersisted({ storeId: "chat" }),
+    StoreLayer
+  )
 
-      yield* chat.generateText({ prompt: "test user message" }).pipe(
-        TestUtils.withLanguageModel({
-          generateText: [{
-            type: "text",
-            text: "test assistant message"
-          }]
+  describe(`Chat (${name} store)`, () => {
+    it.effect("should persist chat history to the store", () =>
+      Effect.gen(function*() {
+        const chatId = "1"
+        const persistence = yield* Chat.Persistence
+        const chat = yield* persistence.getOrCreate(chatId)
+
+        yield* chat.generateText({ prompt: "test user message" }).pipe(
+          TestUtils.withLanguageModel({
+            generateText: [{
+              type: "text",
+              text: "test assistant message"
+            }]
+          })
+        )
+
+        const chatHistory = yield* Ref.get(chat.history)
+        const options = { [Chat.Persistence.key]: { messageId: "msg_abc123" } }
+        const expectedHistory = Prompt.make([
+          { role: "user", content: [{ type: "text", text: "test user message" }], options },
+          { role: "assistant", content: [{ type: "text", text: "test assistant message" }], options }
+        ])
+
+        assert.deepStrictEqual(chatHistory, expectedHistory)
+        assert.deepStrictEqual(yield* storedHistory(chatId), expectedHistory)
+      }).pipe(withConstantIdGenerator("msg_abc123"), Effect.provide(PersistenceLayer)))
+
+    it.effect("should respect the specified time to live", () =>
+      Effect.gen(function*() {
+        const chatId = "1"
+        const persistence = yield* Chat.Persistence
+        const chat = yield* persistence.getOrCreate(chatId, {
+          timeToLive: "30 days"
         })
-      )
 
-      const chatHistory = yield* Ref.get(chat.history)
-      const encodedHistory = yield* store.get(chatId)
-      const storedHistory = Predicate.isNotUndefined(encodedHistory)
-        ? yield* Schema.decodeUnknownEffect(Prompt.Prompt)(encodedHistory)
-        : undefined
+        yield* chat.generateText({ prompt: "test user message" }).pipe(
+          TestUtils.withLanguageModel({
+            generateText: [{
+              type: "text",
+              text: "test assistant message"
+            }]
+          })
+        )
 
-      const options = { [Chat.Persistence.key]: { messageId: "msg_abc123" } }
-      const expectedHistory = Prompt.make([
-        { role: "user", content: [{ type: "text", text: "test user message" }], options },
-        { role: "assistant", content: [{ type: "text", text: "test assistant message" }], options }
-      ])
+        const options = { [Chat.Persistence.key]: { messageId: "msg_abc123" } }
+        const expectedHistory = Prompt.make([
+          { role: "user", content: [{ type: "text", text: "test user message" }], options },
+          { role: "assistant", content: [{ type: "text", text: "test assistant message" }], options }
+        ])
 
-      assert.deepStrictEqual(chatHistory, expectedHistory)
-      assert.deepStrictEqual(chatHistory, storedHistory)
-    }).pipe(withConstantIdGenerator("msg_abc123"), Effect.provide(PersistenceLayer)))
+        assert.deepStrictEqual(yield* storedHistory(chatId), expectedHistory)
 
-  it.effect("should respect the specified time to live", () =>
-    Effect.gen(function*() {
-      const storeId = "chat"
-      const chatId = "1"
+        // Simulate chat expiration
+        yield* TestClock.adjust("30 days")
 
-      const backing = yield* Persistence.BackingPersistence
-      const persistence = yield* Chat.Persistence
+        assert.isUndefined(yield* storedHistory(chatId))
+      }).pipe(withConstantIdGenerator("msg_abc123"), Effect.provide(PersistenceLayer)))
 
-      const store = yield* backing.make(storeId)
-      const chat = yield* persistence.getOrCreate(chatId, {
-        timeToLive: "30 days"
+    it.effect("should prefer the message identifier of the most recent assistant message", () =>
+      Effect.gen(function*() {
+        const chatId = "2"
+        const persistence = yield* Chat.Persistence
+        const chat = yield* persistence.getOrCreate(chatId)
+
+        const options = { [Chat.Persistence.key]: { messageId: "msg_123abc" } }
+        const history = Prompt.make([
+          { role: "user", content: "first user message", options },
+          { role: "assistant", content: "first assistant message", options }
+        ])
+        yield* Ref.set(chat.history, history)
+        yield* chat.save
+
+        yield* chat.generateText({ prompt: "second user message" }).pipe(
+          TestUtils.withLanguageModel({
+            generateText: [{
+              type: "text",
+              text: "second assistant message"
+            }]
+          })
+        )
+
+        const expectedHistory = Prompt.concat(history, [
+          { role: "user", content: "second user message", options },
+          { role: "assistant", content: "second assistant message", options }
+        ])
+
+        assert.deepStrictEqual(yield* storedHistory(chatId), expectedHistory)
+      }).pipe(withConstantIdGenerator("msg_abc123"), Effect.provide(PersistenceLayer)))
+
+    it.effect("should persist messages that were rewritten rather than appended", () =>
+      Effect.gen(function*() {
+        const chatId = "1"
+        const persistence = yield* Chat.Persistence
+        const chat = yield* persistence.getOrCreate(chatId)
+
+        yield* chat.generateText({ prompt: "test user message" }).pipe(
+          TestUtils.withLanguageModel({
+            generateText: [{
+              type: "text",
+              text: "test assistant message"
+            }]
+          })
+        )
+
+        // Replace a message that has already been persisted, the shape a caller
+        // summarizing or redacting history produces, and save without appending
+        const options = { [Chat.Persistence.key]: { messageId: "msg_abc123" } }
+        const rewritten = Prompt.make([
+          { role: "user", content: [{ type: "text", text: "rewritten user message" }], options },
+          { role: "assistant", content: [{ type: "text", text: "test assistant message" }], options }
+        ])
+        yield* Ref.set(chat.history, rewritten)
+        yield* chat.save
+
+        assert.deepStrictEqual(yield* storedHistory(chatId), rewritten)
+      }).pipe(withConstantIdGenerator("msg_abc123"), Effect.provide(PersistenceLayer)))
+
+    it.effect("should shorten a chat that was truncated", () =>
+      Effect.gen(function*() {
+        const chatId = "1"
+        const persistence = yield* Chat.Persistence
+        const chat = yield* persistence.getOrCreate(chatId)
+
+        yield* chat.generateText({ prompt: "test user message" }).pipe(
+          TestUtils.withLanguageModel({
+            generateText: [{ type: "text", text: "test assistant message" }]
+          })
+        )
+
+        const options = { [Chat.Persistence.key]: { messageId: "msg_abc123" } }
+        const truncated = Prompt.make([
+          { role: "user", content: [{ type: "text", text: "only message" }], options }
+        ])
+        yield* Ref.set(chat.history, truncated)
+        yield* chat.save
+
+        assert.deepStrictEqual(yield* storedHistory(chatId), truncated)
+      }).pipe(withConstantIdGenerator("msg_abc123"), Effect.provide(PersistenceLayer)))
+
+    it.effect("should reload a chat from the store", () =>
+      Effect.gen(function*() {
+        const chatId = "1"
+        const persistence = yield* Chat.Persistence
+        const chat = yield* persistence.getOrCreate(chatId)
+
+        yield* chat.generateText({ prompt: "first user message" }).pipe(
+          TestUtils.withLanguageModel({
+            generateText: [{ type: "text", text: "first assistant message" }]
+          })
+        )
+
+        const reloaded = yield* persistence.get(chatId)
+        yield* reloaded.generateText({ prompt: "second user message" }).pipe(
+          TestUtils.withLanguageModel({
+            generateText: [{ type: "text", text: "second assistant message" }]
+          })
+        )
+
+        const history = yield* Ref.get(reloaded.history)
+        assert.strictEqual(history.content.length, 4)
+        assert.deepStrictEqual(yield* storedHistory(chatId), history)
+      }).pipe(withConstantIdGenerator("msg_abc123"), Effect.provide(PersistenceLayer)))
+
+    it.effect("should raise an error when retrieving a chat that does not exist", () =>
+      Effect.gen(function*() {
+        const persistence = yield* Chat.Persistence
+
+        const result = yield* Effect.flip(persistence.get("chat-321"))
+
+        assert.instanceOf(result, Chat.ChatNotFoundError)
+        assert.strictEqual(result.chatId, "chat-321")
+      }).pipe(Effect.provide(PersistenceLayer)))
+  })
+
+  describe(`ChatStore (${name})`, () => {
+    const write = (chatId: string, from: number, messages: ReadonlyArray<string>) =>
+      Effect.gen(function*() {
+        const store = yield* Chat.ChatStore
+        yield* store.write({
+          storeId: "chat",
+          chatId,
+          from,
+          messages: messages.map((text) => ({ role: "user", content: [{ type: "text", text }] })),
+          timeToLive: undefined
+        })
       })
 
-      yield* chat.generateText({ prompt: "test user message" }).pipe(
-        TestUtils.withLanguageModel({
-          generateText: [{
-            type: "text",
-            text: "test assistant message"
-          }]
-        })
-      )
+    const texts = (messages: ReadonlyArray<unknown> | undefined) =>
+      messages?.map((message) => (message as { content: Array<{ text: string }> }).content[0].text)
 
-      const encodedHistory = yield* store.get(chatId)
-      const storedHistory = Predicate.isNotUndefined(encodedHistory)
-        ? yield* Schema.decodeUnknownEffect(Prompt.Prompt)(encodedHistory)
-        : undefined
+    it.effect("appends, reads ranges, and reads backwards", () =>
+      Effect.gen(function*() {
+        const store = yield* Chat.ChatStore
+        yield* write("a", 0, ["one", "two"])
+        yield* write("a", 2, ["three"])
 
-      const options = { [Chat.Persistence.key]: { messageId: "msg_abc123" } }
-      const expectedHistory = Prompt.make([
-        { role: "user", content: [{ type: "text", text: "test user message" }], options },
-        { role: "assistant", content: [{ type: "text", text: "test assistant message" }], options }
-      ])
+        const all = yield* store.read({ storeId: "chat", chatId: "a", from: 0, limit: undefined })
+        assert.deepStrictEqual(texts(all), ["one", "two", "three"])
 
-      assert.deepStrictEqual(storedHistory, expectedHistory)
+        const range = yield* store.read({ storeId: "chat", chatId: "a", from: 1, limit: 1 })
+        assert.deepStrictEqual(texts(range), ["two"])
 
-      // Simulate chat expiration
-      yield* TestClock.adjust("30 days")
+        const last = yield* store.readBackwards({ storeId: "chat", chatId: "a", limit: 2 })
+        assert.deepStrictEqual(texts(last), ["two", "three"])
+      }).pipe(Effect.provide(StoreLayer)))
 
-      const afterExpiration = yield* store.get(chatId)
+    it.effect("replaces from an earlier index", () =>
+      Effect.gen(function*() {
+        const store = yield* Chat.ChatStore
+        yield* write("a", 0, ["one", "two", "three"])
+        yield* write("a", 1, ["rewritten"])
 
-      assert.isUndefined(afterExpiration)
-    }).pipe(withConstantIdGenerator("msg_abc123"), Effect.provide(PersistenceLayer)))
+        const all = yield* store.read({ storeId: "chat", chatId: "a", from: 0, limit: undefined })
+        assert.deepStrictEqual(texts(all), ["one", "rewritten"])
+      }).pipe(Effect.provide(StoreLayer)))
 
-  it.effect("should prefer the message identifier of the most recent assistant message", () =>
-    Effect.gen(function*() {
-      const storeId = "chat"
-      const chatId = "2"
+    it.effect("refuses a write that would leave a hole", () =>
+      Effect.gen(function*() {
+        yield* write("a", 0, ["one"])
 
-      const backing = yield* Persistence.BackingPersistence
-      const persistence = yield* Chat.Persistence
+        const error = yield* Effect.flip(write("a", 5, ["five"]))
 
-      const store = yield* backing.make(storeId)
-      const chat = yield* persistence.getOrCreate(chatId)
+        assert.include(error.message, "from index 5")
+      }).pipe(Effect.provide(StoreLayer)))
 
-      const options = { [Chat.Persistence.key]: { messageId: "msg_123abc" } }
-      const history = Prompt.make([
-        { role: "user", content: "first user message", options },
-        { role: "assistant", content: "first assistant message", options }
-      ])
-      yield* Ref.set(chat.history, history)
-      yield* chat.save
+    it.effect("distinguishes an empty chat from a missing one", () =>
+      Effect.gen(function*() {
+        const store = yield* Chat.ChatStore
+        yield* write("a", 0, [])
 
-      yield* chat.generateText({ prompt: "second user message" }).pipe(
-        TestUtils.withLanguageModel({
-          generateText: [{
-            type: "text",
-            text: "second assistant message"
-          }]
-        })
-      )
+        assert.deepStrictEqual(
+          yield* store.read({ storeId: "chat", chatId: "a", from: 0, limit: undefined }),
+          []
+        )
+        assert.isUndefined(
+          yield* store.read({ storeId: "chat", chatId: "missing", from: 0, limit: undefined })
+        )
+      }).pipe(Effect.provide(StoreLayer)))
 
-      const encodedHistory = yield* store.get(chatId)
-      const storedHistory = Predicate.isNotUndefined(encodedHistory)
-        ? yield* Schema.decodeUnknownEffect(Prompt.Prompt)(encodedHistory)
-        : undefined
-      const expectedHistory = Prompt.concat(history, [
-        { role: "user", content: "second user message", options },
-        { role: "assistant", content: "second assistant message", options }
-      ])
+    it.effect("lists chats most recently written first", () =>
+      Effect.gen(function*() {
+        const store = yield* Chat.ChatStore
+        yield* write("a", 0, ["one"])
+        yield* TestClock.adjust("1 second")
+        yield* write("b", 0, ["one", "two"])
 
-      assert.deepStrictEqual(storedHistory, expectedHistory)
-    }).pipe(withConstantIdGenerator("msg_abc123"), Effect.provide(PersistenceLayer)))
+        const listed = yield* store.list({ storeId: "chat", after: undefined, limit: 10 })
+        assert.deepStrictEqual(listed.map((summary) => summary.chatId), ["b", "a"])
+        assert.deepStrictEqual(listed.map((summary) => summary.messages), [2, 1])
 
-  it.effect("should persist messages that were rewritten rather than appended", () =>
-    Effect.gen(function*() {
-      const storeId = "chat"
-      const chatId = "1"
+        const page = yield* store.list({ storeId: "chat", after: "b", limit: 10 })
+        assert.deepStrictEqual(page.map((summary) => summary.chatId), ["a"])
+      }).pipe(Effect.provide(StoreLayer)))
 
-      const backing = yield* Persistence.BackingPersistence
-      const persistence = yield* Chat.Persistence
+    it.effect("removes a chat and cleans up stale ones", () =>
+      Effect.gen(function*() {
+        const store = yield* Chat.ChatStore
+        yield* write("a", 0, ["one"])
+        yield* write("b", 0, ["one"])
 
-      const store = yield* backing.make(storeId)
-      const chat = yield* persistence.getOrCreate(chatId)
+        yield* store.remove({ storeId: "chat", chatId: "a" })
+        assert.isUndefined(yield* store.read({ storeId: "chat", chatId: "a", from: 0, limit: undefined }))
 
-      yield* chat.generateText({ prompt: "test user message" }).pipe(
-        TestUtils.withLanguageModel({
-          generateText: [{
-            type: "text",
-            text: "test assistant message"
-          }]
-        })
-      )
+        yield* TestClock.adjust("2 hours")
+        yield* store.cleanup({ storeId: "chat", olderThan: Duration.hours(1) })
 
-      // Replace a message that has already been persisted, the shape a caller
-      // summarizing or redacting history produces, and save without appending
-      const options = { [Chat.Persistence.key]: { messageId: "msg_abc123" } }
-      const rewritten = Prompt.make([
-        { role: "user", content: [{ type: "text", text: "rewritten user message" }], options },
-        { role: "assistant", content: [{ type: "text", text: "test assistant message" }], options }
-      ])
-      yield* Ref.set(chat.history, rewritten)
-      yield* chat.save
-
-      const encodedHistory = yield* store.get(chatId)
-      const storedHistory = Predicate.isNotUndefined(encodedHistory)
-        ? yield* Schema.decodeUnknownEffect(Prompt.Prompt)(encodedHistory)
-        : undefined
-
-      assert.deepStrictEqual(storedHistory, rewritten)
-    }).pipe(withConstantIdGenerator("msg_abc123"), Effect.provide(PersistenceLayer)))
-
-  it.effect("should raise an error when retrieving a chat that does not exist", () =>
-    Effect.gen(function*() {
-      const persistence = yield* Chat.Persistence
-
-      const result = yield* Effect.flip(persistence.get("chat-321"))
-
-      assert.instanceOf(result, Chat.ChatNotFoundError)
-      assert.strictEqual(result.chatId, "chat-321")
-    }).pipe(Effect.provide(PersistenceLayer)))
-})
+        assert.isUndefined(yield* store.read({ storeId: "chat", chatId: "b", from: 0, limit: undefined }))
+        assert.deepStrictEqual(yield* store.list({ storeId: "chat", after: undefined, limit: 10 }), [])
+      }).pipe(Effect.provide(StoreLayer)))
+  })
+}

--- a/packages/effect/test/unstable/ai/Chat.test.ts
+++ b/packages/effect/test/unstable/ai/Chat.test.ts
@@ -135,6 +135,44 @@ describe("Chat", () => {
       assert.deepStrictEqual(storedHistory, expectedHistory)
     }).pipe(withConstantIdGenerator("msg_abc123"), Effect.provide(PersistenceLayer)))
 
+  it.effect("should persist messages that were rewritten rather than appended", () =>
+    Effect.gen(function*() {
+      const storeId = "chat"
+      const chatId = "1"
+
+      const backing = yield* Persistence.BackingPersistence
+      const persistence = yield* Chat.Persistence
+
+      const store = yield* backing.make(storeId)
+      const chat = yield* persistence.getOrCreate(chatId)
+
+      yield* chat.generateText({ prompt: "test user message" }).pipe(
+        TestUtils.withLanguageModel({
+          generateText: [{
+            type: "text",
+            text: "test assistant message"
+          }]
+        })
+      )
+
+      // Replace a message that has already been persisted, the shape a caller
+      // summarizing or redacting history produces, and save without appending
+      const options = { [Chat.Persistence.key]: { messageId: "msg_abc123" } }
+      const rewritten = Prompt.make([
+        { role: "user", content: [{ type: "text", text: "rewritten user message" }], options },
+        { role: "assistant", content: [{ type: "text", text: "test assistant message" }], options }
+      ])
+      yield* Ref.set(chat.history, rewritten)
+      yield* chat.save
+
+      const encodedHistory = yield* store.get(chatId)
+      const storedHistory = Predicate.isNotUndefined(encodedHistory)
+        ? yield* Schema.decodeUnknownEffect(Prompt.Prompt)(encodedHistory)
+        : undefined
+
+      assert.deepStrictEqual(storedHistory, rewritten)
+    }).pipe(withConstantIdGenerator("msg_abc123"), Effect.provide(PersistenceLayer)))
+
   it.effect("should raise an error when retrieving a chat that does not exist", () =>
     Effect.gen(function*() {
       const persistence = yield* Chat.Persistence


### PR DESCRIPTION
## Problem

`Chat.Persisted` stores a conversation as a single value under one key and rewrites all of it on every save. Two consequences:

- Persisting a chat is quadratic in the number of turns. Over 2000 turns, 1.65 GB is written to persist an 800 KB conversation, and the schema encode alone — non-yielding CPU — stalls every other fiber in the process for tens of milliseconds per save.
- A chat can only be loaded whole. There is no way to read the last N messages, list the chats in a store, or expire stale ones, because `BackingPersistenceStore` is `get` / `set` / `remove` / `clear` and cannot append or enumerate.

## Change

`Chat.Persisted` is now backed by a new `Chat.ChatStore`:

```ts
write:         { storeId, chatId, from, messages, timeToLive } => void
read:          { storeId, chatId, from, limit }                => ReadonlyArray<unknown> | undefined
readBackwards: { storeId, chatId, limit }                      => ReadonlyArray<unknown> | undefined
list:          { storeId, after, limit }                       => ReadonlyArray<ChatSummary>
remove:        { storeId, chatId }                             => void
cleanup:       { storeId, olderThan }                          => void
```

`write` replaces a chat's messages from `from` onwards. Appending is `from` equal to the number of messages already stored; rewriting history — what summarizing or redacting a conversation produces — is a smaller `from`. A `from` past the end fails rather than leaving a hole, and a `from` that does not match what the caller last saw is how two writers racing on one chat is caught instead of silently losing one.

Values are opaque to the store: `Chat` encodes and decodes them, so a store never sees a `Prompt`. This is the same split `PersistedQueue` uses with `PersistedQueueStore`.

The interface is deliberately narrow, so that every backend can implement all of it. Anything richer — searching message content, filtering by metadata — belongs in a backend's own client, where SQL can be SQL, rather than in an abstraction only some backends could honour.

A save now finds the first message it has to write by comparing history against what it last stored, by identity. An ordinary turn writes the two messages it added. That requires messages in history to be immutable, which they nearly were: the exception was `saveChat`, which stamped message identifiers by mutating `message.options` in place (`(message.options as any)[Persistence.key] = ...`) and then wrote the object it had just mutated back into the `Ref`. That is now done by replacement, so a message already handed to a caller never changes underneath them, and the `as any` is gone.

## Layers

- `Chat.layerStoreMemory` — in-memory, process-local.
- `Chat.layerStoreBacking` — a `ChatStore` over an existing `BackingPersistence`. Every write reads, applies, and writes the whole chat back, so it costs what today costs; it exists so an application already on `BackingPersistence` keeps working. Listing is served from an index kept alongside the chats, since the backing interface cannot enumerate keys.

`Chat.layerPersisted` now requires `ChatStore` instead of `BackingPersistence`. Existing wiring becomes:

```diff
-Layer.provide(Chat.layerPersisted({ storeId }), Persistence.layerBackingMemory)
+Layer.provide(Chat.layerPersisted({ storeId }), Layer.provide(Chat.layerStoreBacking, Persistence.layerBackingMemory))
```

## Not in this PR

Native `layerStoreSql` and `layerStoreRedis`. Those are where the byte amplification actually goes away — a messages table with an index on `(chat_id, seq)`, or a Redis list with `LRANGE` — and they are a few hundred lines each, following `makeStoreSql` / `makeStoreRedis` in `PersistedQueue`. I would rather agree on the interface before writing them; I am happy to follow up with both.

## Verification

- The existing `Chat` tests now run against both stores, unchanged in intent.
- New tests cover the store contract directly, for both implementations: append, read a range, read backwards, replace from an earlier index, truncate, refuse a write that would leave a hole, tell an empty chat from a missing one, list most-recently-written first with paging, remove, and cleanup.
- New `Chat` tests cover reloading a chat from the store and continuing it, and truncating a chat.
- `Chat.test.ts`: 26 tests. `packages/effect/test/unstable/ai`: 24 files, 1076 passed / 44 skipped. Doctests for `Chat.ts` pass. `tsc -b tsconfig.json`, `oxlint`, and `dprint check` are clean.
