### PR TITLE
fix(httpapi): transform middleware-declared errors like endpoint errors

### DIFF
--- a/.changeset/httpapi-middleware-error-dedupe.md
+++ b/.changeset/httpapi-middleware-error-dedupe.md
@@ -1,0 +1,23 @@
+---
+"effect": patch
+---
+
+Fix `HttpApiMiddleware` errors duplicating an endpoint's response schema
+
+An endpoint stored its declared errors as response codecs (`transformResponseSchema`)
+while a middleware stored the schemas it was given, raw. Everything downstream merges
+the two sets by identity, so a middleware error could never match an endpoint error —
+even when both sides declared the exact same schema.
+
+Two consequences, both fixed:
+
+- `OpenApi.fromApi` emitted `anyOf: [{ $ref: "#/components/schemas/Err" }, { $ref: "#/components/schemas/Err" }]`
+  for the shared status on every endpoint the middleware was attached to.
+- A middleware error whose encoded form is not JSON-serializable (a `Schema.BigInt`
+  field, for example) failed to encode at runtime with
+  `Expected a JSON-serializable response body`.
+
+Middleware errors now go through the same response transform as endpoint errors, and
+that transform is memoized on its input schema, so declaring one schema in both places
+yields one instance. Middleware errors that are genuinely new for a status are still
+documented, and two different schemas on one status still produce an `anyOf`.

--- a/.changeset/httpapi-middleware-error-dedupe.md
+++ b/.changeset/httpapi-middleware-error-dedupe.md
@@ -17,7 +17,11 @@ Two consequences, both fixed:
   field, for example) failed to encode at runtime with
   `Expected a JSON-serializable response body`.
 
-Middleware errors now go through the same response transform as endpoint errors, and
-that transform is memoized on its input schema, so declaring one schema in both places
-yields one instance. Middleware errors that are genuinely new for a status are still
-documented, and two different schemas on one status still produce an `anyOf`.
+`HttpApiEndpoint.getErrorSchemas` now gives a middleware's declared errors the same
+treatment the endpoint gave its own, so a middleware attached to endpoints with
+different `disableCodecs` settings is resolved correctly for each. The transform is
+memoized on its input schema, so declaring one schema in both places yields one
+instance.
+
+Middleware errors that are genuinely new for a status are still documented, and two
+different schemas on one status still produce an `anyOf`.

--- a/.changeset/httpapi-middleware-error-dedupe.md
+++ b/.changeset/httpapi-middleware-error-dedupe.md
@@ -2,26 +2,7 @@
 "effect": patch
 ---
 
-Fix `HttpApiMiddleware` errors duplicating an endpoint's response schema
+Fix `HttpApiMiddleware`-declared errors being duplicated and mis-encoded:
 
-An endpoint stored its declared errors as response codecs (`transformResponseSchema`)
-while a middleware stored the schemas it was given, raw. Everything downstream merges
-the two sets by identity, so a middleware error could never match an endpoint error —
-even when both sides declared the exact same schema.
-
-Two consequences, both fixed:
-
-- `OpenApi.fromApi` emitted `anyOf: [{ $ref: "#/components/schemas/Err" }, { $ref: "#/components/schemas/Err" }]`
-  for the shared status on every endpoint the middleware was attached to.
-- A middleware error whose encoded form is not JSON-serializable (a `Schema.BigInt`
-  field, for example) failed to encode at runtime with
-  `Expected a JSON-serializable response body`.
-
-`HttpApiEndpoint.getErrorSchemas` now gives a middleware's declared errors the same
-treatment the endpoint gave its own, so a middleware attached to endpoints with
-different `disableCodecs` settings is resolved correctly for each. The transform is
-memoized on its input schema, so declaring one schema in both places yields one
-instance.
-
-Middleware errors that are genuinely new for a status are still documented, and two
-different schemas on one status still produce an `anyOf`.
+- `OpenApi.fromApi` emitted a duplicated `anyOf` for the middleware's status on every endpoint it was attached to, even when the middleware declared the same schema the endpoint already declared.
+- A middleware error whose encoded form is not JSON-serializable (a `Schema.BigInt` field, for example) failed to encode with `Expected a JSON-serializable response body`.

--- a/.changeset/httpapi-middleware-error-dedupe.md
+++ b/.changeset/httpapi-middleware-error-dedupe.md
@@ -2,7 +2,4 @@
 "effect": patch
 ---
 
-Fix `HttpApiMiddleware`-declared errors being duplicated and mis-encoded:
-
-- `OpenApi.fromApi` emitted a duplicated `anyOf` for the middleware's status on every endpoint it was attached to, even when the middleware declared the same schema the endpoint already declared.
-- A middleware error whose encoded form is not JSON-serializable (a `Schema.BigInt` field, for example) failed to encode with `Expected a JSON-serializable response body`.
+Fix `HttpApiMiddleware`-declared errors being duplicated and mis-encoded.

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -1157,7 +1157,18 @@ function getSuccessResponse(
   return new Set(disableCodecs ? schemas : schemas.map(transformResponseSchema))
 }
 
-function transformResponseSchema(schema: Schema.Top): Schema.Top {
+const transformedResponseSchemas = new WeakMap<Schema.Top, Schema.Top>()
+
+/** @internal */
+export function transformResponseSchema(schema: Schema.Top): Schema.Top {
+  const cached = transformedResponseSchemas.get(schema)
+  if (cached !== undefined) return cached
+  const transformed = transformResponseSchemaUncached(schema)
+  transformedResponseSchemas.set(schema, transformed)
+  return transformed
+}
+
+function transformResponseSchemaUncached(schema: Schema.Top): Schema.Top {
   if (HttpApiSchema.isStreamSchema(schema)) return schema
   if (HttpApiSchema.isWithHeaders(schema)) {
     const inner = HttpApiSchema.isStreamSchema(schema.schema)

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -187,11 +187,6 @@ export interface HttpApiEndpoint<
   readonly error: ReadonlySet<Schema.Top>
   readonly annotations: Context.Context<never>
   readonly middlewares: ReadonlySet<Context.Key<Middleware, any>>
-  /**
-   * Whether the endpoint was declared with `disableCodecs`. When `true` the
-   * schemas above are stored as declared instead of being wrapped in the
-   * automatic request and response codecs.
-   */
   readonly disableCodecs: boolean
 
   /**
@@ -288,10 +283,6 @@ export function getSuccessSchemas(endpoint: Top): [Schema.Top, ...Array<Schema.T
 /** @internal */
 export function getErrorSchemas(endpoint: Top): Array<Schema.Top> {
   const schemas = new Set<Schema.Top>(endpoint.error)
-  // Middleware stores its declared errors as given, because one middleware can be
-  // attached to endpoints with different `disableCodecs` settings. Apply the same
-  // treatment the endpoint gave its own errors, so that declaring one schema on
-  // both sides yields one entry rather than two that only differ by wrapping.
   const transform = endpoint.disableCodecs ? identity : transformResponseSchema
   for (const middleware of endpoint.middlewares) {
     const key = middleware as any as HttpApiMiddleware.AnyService

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -15,7 +15,7 @@ import * as Arr from "../../Array.ts"
 import type { Brand } from "../../Brand.ts"
 import * as Context from "../../Context.ts"
 import type { Effect } from "../../Effect.ts"
-import { identity } from "../../Function.ts"
+import { identity, memoize } from "../../Function.ts"
 import { type Pipeable, pipeArguments } from "../../Pipeable.ts"
 import * as Predicate from "../../Predicate.ts"
 import * as Schema from "../../Schema.ts"
@@ -1171,17 +1171,7 @@ function getSuccessResponse(
   return new Set(disableCodecs ? schemas : schemas.map(transformResponseSchema))
 }
 
-const transformedResponseSchemas = new WeakMap<Schema.Top, Schema.Top>()
-
-function transformResponseSchema(schema: Schema.Top): Schema.Top {
-  const cached = transformedResponseSchemas.get(schema)
-  if (cached !== undefined) return cached
-  const transformed = transformResponseSchemaUncached(schema)
-  transformedResponseSchemas.set(schema, transformed)
-  return transformed
-}
-
-function transformResponseSchemaUncached(schema: Schema.Top): Schema.Top {
+const transformResponseSchema = memoize((schema: Schema.Top): Schema.Top => {
   if (HttpApiSchema.isStreamSchema(schema)) return schema
   if (HttpApiSchema.isWithHeaders(schema)) {
     const inner = HttpApiSchema.isStreamSchema(schema.schema)
@@ -1190,7 +1180,7 @@ function transformResponseSchemaUncached(schema: Schema.Top): Schema.Top {
     return HttpApiSchema.rebuildWithHeaders(schema, inner, Schema.toCodecStringTree(schema.headers))
   }
   return transformResponse(schema)
-}
+})
 
 function getErrorResponse(
   error: Schema.Top | ReadonlyArray<Schema.Top> | undefined,

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -187,6 +187,12 @@ export interface HttpApiEndpoint<
   readonly error: ReadonlySet<Schema.Top>
   readonly annotations: Context.Context<never>
   readonly middlewares: ReadonlySet<Context.Key<Middleware, any>>
+  /**
+   * Whether the endpoint was declared with `disableCodecs`. When `true` the
+   * schemas above are stored as declared instead of being wrapped in the
+   * automatic request and response codecs.
+   */
+  readonly disableCodecs: boolean
 
   /**
    * Add a prefix to the path of the endpoint.
@@ -282,10 +288,15 @@ export function getSuccessSchemas(endpoint: Top): [Schema.Top, ...Array<Schema.T
 /** @internal */
 export function getErrorSchemas(endpoint: Top): Array<Schema.Top> {
   const schemas = new Set<Schema.Top>(endpoint.error)
+  // Middleware stores its declared errors as given, because one middleware can be
+  // attached to endpoints with different `disableCodecs` settings. Apply the same
+  // treatment the endpoint gave its own errors, so that declaring one schema on
+  // both sides yields one entry rather than two that only differ by wrapping.
+  const transform = endpoint.disableCodecs ? identity : transformResponseSchema
   for (const middleware of endpoint.middlewares) {
     const key = middleware as any as HttpApiMiddleware.AnyService
     for (const schema of key.error) {
-      schemas.add(schema)
+      schemas.add(transform(schema))
     }
   }
   return Array.from(schemas)
@@ -833,7 +844,8 @@ const optionsFromEndpoint = (endpoint: Top) => ({
   success: endpoint.success,
   error: endpoint.error,
   annotations: endpoint.annotations,
-  middlewares: endpoint.middlewares
+  middlewares: endpoint.middlewares,
+  disableCodecs: endpoint.disableCodecs
 })
 
 function makeProto<
@@ -860,6 +872,7 @@ function makeProto<
   readonly error: ReadonlySet<Schema.Top>
   readonly annotations: Context.Context<never>
   readonly middlewares: ReadonlySet<Context.Key<Middleware, any>>
+  readonly disableCodecs: boolean
 }): HttpApiEndpoint<
   Identifier,
   Method,
@@ -1090,7 +1103,8 @@ export const make = <Method extends HttpMethod>(method: Method): {
     success: getSuccessResponse(options?.success, method, disableCodecs),
     error: getErrorResponse(options?.error, disableCodecs),
     annotations: Context.empty(),
-    middlewares: new Set()
+    middlewares: new Set(),
+    disableCodecs
   })
 }
 
@@ -1159,8 +1173,7 @@ function getSuccessResponse(
 
 const transformedResponseSchemas = new WeakMap<Schema.Top, Schema.Top>()
 
-/** @internal */
-export function transformResponseSchema(schema: Schema.Top): Schema.Top {
+function transformResponseSchema(schema: Schema.Top): Schema.Top {
   const cached = transformedResponseSchemas.get(schema)
   if (cached !== undefined) return cached
   const transformed = transformResponseSchemaUncached(schema)

--- a/packages/effect/src/unstable/httpapi/HttpApiMiddleware.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiMiddleware.ts
@@ -26,7 +26,7 @@ import type * as HttpClientRequest from "../http/HttpClientRequest.ts"
 import type * as HttpClientResponse from "../http/HttpClientResponse.ts"
 import type * as HttpRouter from "../http/HttpRouter.ts"
 import type { HttpServerResponse } from "../http/HttpServerResponse.ts"
-import type * as HttpApiEndpoint from "./HttpApiEndpoint.ts"
+import * as HttpApiEndpoint from "./HttpApiEndpoint.ts"
 import { HttpApiSchemaError } from "./HttpApiError.ts"
 import type * as HttpApiGroup from "./HttpApiGroup.ts"
 import type * as HttpApiSecurity from "./HttpApiSecurity.ts"
@@ -380,7 +380,8 @@ export const Service = <
 
 function getError(error: ErrorConstraint | undefined): ReadonlySet<Schema.Top> {
   if (error === undefined) return new Set()
-  return new Set(Array.isArray(error) ? error : [error])
+  const schemas = Array.isArray(error) ? error : [error]
+  return new Set(schemas.map(HttpApiEndpoint.transformResponseSchema))
 }
 
 /**

--- a/packages/effect/src/unstable/httpapi/HttpApiMiddleware.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiMiddleware.ts
@@ -26,7 +26,7 @@ import type * as HttpClientRequest from "../http/HttpClientRequest.ts"
 import type * as HttpClientResponse from "../http/HttpClientResponse.ts"
 import type * as HttpRouter from "../http/HttpRouter.ts"
 import type { HttpServerResponse } from "../http/HttpServerResponse.ts"
-import * as HttpApiEndpoint from "./HttpApiEndpoint.ts"
+import type * as HttpApiEndpoint from "./HttpApiEndpoint.ts"
 import { HttpApiSchemaError } from "./HttpApiError.ts"
 import type * as HttpApiGroup from "./HttpApiGroup.ts"
 import type * as HttpApiSecurity from "./HttpApiSecurity.ts"
@@ -380,8 +380,7 @@ export const Service = <
 
 function getError(error: ErrorConstraint | undefined): ReadonlySet<Schema.Top> {
   if (error === undefined) return new Set()
-  const schemas = Array.isArray(error) ? error : [error]
-  return new Set(schemas.map(HttpApiEndpoint.transformResponseSchema))
+  return new Set(Array.isArray(error) ? error : [error])
 }
 
 /**

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -1371,3 +1371,34 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
       assert.deepStrictEqual(error, new HandlerFailure({ message: "handler failed" }))
     }))
 })
+
+it.layer(TestServices)("HttpApiBuilder middleware error responses", (it) => {
+  it.effect("encodes a middleware error through the response codec", () =>
+    Effect.gen(function*() {
+      const RateLimited = Schema.Struct({ retryAfter: Schema.BigInt }).pipe(HttpApiSchema.status(429))
+
+      class RateLimit extends HttpApiMiddleware.Service<RateLimit>()("RateLimit", {
+        error: RateLimited
+      }) {}
+
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("limited", "/limited", { success: Schema.String }).middleware(RateLimit)
+        )
+      )
+      const GroupLayer = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) => handlers.handle("limited", () => Effect.succeed("ok"))
+      )
+      const RateLimitLayer = Layer.succeed(RateLimit)(() => Effect.fail({ retryAfter: 30n }))
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(
+        Effect.provide(GroupLayer),
+        Effect.provide(RateLimitLayer)
+      )
+      const error = yield* Effect.flip(client.test.limited())
+
+      assert.deepStrictEqual(error, { retryAfter: 30n })
+    }))
+})

--- a/packages/effect/test/unstable/httpapi/HttpApiEndpoint.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiEndpoint.test.ts
@@ -1,6 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Schema } from "effect"
-import { HttpApiEndpoint, HttpApiSchema } from "effect/unstable/httpapi"
+import { HttpApiEndpoint, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
 
 const Events = Schema.Struct({
   event: Schema.Literal("user.created"),
@@ -376,6 +376,18 @@ describe("HttpApiEndpoint WithHeaders schemas", () => {
     })
 
     assert.isTrue(endpoint.success.has(wrapped))
+  })
+
+  it("preserves disableCodecs through derived endpoints", () => {
+    const endpoint = HttpApiEndpoint.get("list", "/users", {
+      disableCodecs: true,
+      success: Schema.Struct({ a: Schema.String })
+    })
+
+    assert.isTrue(endpoint.disableCodecs)
+    assert.isTrue(endpoint.prefix("/api").disableCodecs)
+    assert.isTrue(endpoint.annotate(OpenApi.Title, "Users").disableCodecs)
+    assert.isFalse(HttpApiEndpoint.get("plain", "/plain").disableCodecs)
   })
 
   it("keeps a wrapped stream schema as the inner schema", () => {

--- a/packages/effect/test/unstable/httpapi/OpenApi.test.ts
+++ b/packages/effect/test/unstable/httpapi/OpenApi.test.ts
@@ -363,6 +363,35 @@ describe("OpenApi", () => {
     })
   })
 
+  it("resolves one shared middleware error per endpoint codec mode", () => {
+    const ApiError = Schema.Struct({ code: Schema.String }).annotate({ identifier: "ApiError" })
+
+    class SharedError extends HttpApiMiddleware.Service<SharedError>()("SharedError", {
+      error: ApiError
+    }) {}
+
+    // The same middleware instance is attached to both endpoints, so its single
+    // error set has to be resolved against each endpoint's `disableCodecs`.
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("test")
+        .add(HttpApiEndpoint.get("codecs", "/codecs", { error: ApiError }))
+        .add(HttpApiEndpoint.get("raw", "/raw", { disableCodecs: true, error: ApiError }))
+    ).middleware(SharedError)
+
+    const spec = OpenApi.fromApi(Api)
+
+    assert.deepStrictEqual(spec.paths["/codecs"]?.get?.responses[500]?.content, {
+      "application/json": {
+        schema: { $ref: "#/components/schemas/ApiError" }
+      }
+    })
+    assert.deepStrictEqual(spec.paths["/raw"]?.get?.responses[500]?.content, {
+      "application/json": {
+        schema: { $ref: "#/components/schemas/ApiError" }
+      }
+    })
+  })
+
   it("emits an anyOf for a middleware error that differs from the endpoint error", () => {
     const EndpointError = Schema.Struct({ code: Schema.String }).annotate({ identifier: "EndpointError" })
     const MiddlewareError = Schema.Struct({ reason: Schema.String }).annotate({ identifier: "MiddlewareError" })

--- a/packages/effect/test/unstable/httpapi/OpenApi.test.ts
+++ b/packages/effect/test/unstable/httpapi/OpenApi.test.ts
@@ -338,6 +338,31 @@ describe("OpenApi", () => {
     })
   })
 
+  it("collapses a repeated middleware error when the endpoint disables codecs", () => {
+    const ApiError = Schema.Struct({ code: Schema.String }).annotate({ identifier: "ApiError" })
+
+    class SameError extends HttpApiMiddleware.Service<SameError>()("SameErrorNoCodecs", {
+      error: ApiError
+    }) {}
+
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("test").add(
+        HttpApiEndpoint.get("error", "/error", {
+          disableCodecs: true,
+          error: ApiError
+        })
+      )
+    ).middleware(SameError)
+
+    const spec = OpenApi.fromApi(Api)
+
+    assert.deepStrictEqual(spec.paths["/error"]?.get?.responses[500]?.content, {
+      "application/json": {
+        schema: { $ref: "#/components/schemas/ApiError" }
+      }
+    })
+  })
+
   it("emits an anyOf for a middleware error that differs from the endpoint error", () => {
     const EndpointError = Schema.Struct({ code: Schema.String }).annotate({ identifier: "EndpointError" })
     const MiddlewareError = Schema.Struct({ reason: Schema.String }).annotate({ identifier: "MiddlewareError" })

--- a/packages/effect/test/unstable/httpapi/OpenApi.test.ts
+++ b/packages/effect/test/unstable/httpapi/OpenApi.test.ts
@@ -316,6 +316,111 @@ describe("OpenApi", () => {
     })
   })
 
+  it("collapses a middleware error that repeats an endpoint error", () => {
+    const ApiError = Schema.Struct({ code: Schema.String }).annotate({ identifier: "ApiError" })
+
+    class SameError extends HttpApiMiddleware.Service<SameError>()("SameError", {
+      error: ApiError
+    }) {}
+
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("test").add(
+        HttpApiEndpoint.get("error", "/error", { error: ApiError })
+      )
+    ).middleware(SameError)
+
+    const spec = OpenApi.fromApi(Api)
+
+    assert.deepStrictEqual(spec.paths["/error"]?.get?.responses[500]?.content, {
+      "application/json": {
+        schema: { $ref: "#/components/schemas/ApiError" }
+      }
+    })
+  })
+
+  it("emits an anyOf for a middleware error that differs from the endpoint error", () => {
+    const EndpointError = Schema.Struct({ code: Schema.String }).annotate({ identifier: "EndpointError" })
+    const MiddlewareError = Schema.Struct({ reason: Schema.String }).annotate({ identifier: "MiddlewareError" })
+
+    class OtherError extends HttpApiMiddleware.Service<OtherError>()("OtherError", {
+      error: MiddlewareError
+    }) {}
+
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("test").add(
+        HttpApiEndpoint.get("error", "/error", { error: EndpointError })
+      )
+    ).middleware(OtherError)
+
+    const spec = OpenApi.fromApi(Api)
+
+    assert.deepStrictEqual(spec.paths["/error"]?.get?.responses[500]?.content, {
+      "application/json": {
+        schema: {
+          anyOf: [
+            { $ref: "#/components/schemas/EndpointError" },
+            { $ref: "#/components/schemas/MiddlewareError" }
+          ]
+        }
+      }
+    })
+  })
+
+  it("emits an anyOf for two different endpoint errors sharing a status", () => {
+    const FirstError = Schema.Struct({ code: Schema.String }).annotate({ identifier: "FirstError" })
+    const SecondError = Schema.Struct({ reason: Schema.String }).annotate({ identifier: "SecondError" })
+
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("test").add(
+        HttpApiEndpoint.get("error", "/error", { error: [FirstError, SecondError] })
+      )
+    )
+
+    const spec = OpenApi.fromApi(Api)
+
+    assert.deepStrictEqual(spec.paths["/error"]?.get?.responses[500]?.content, {
+      "application/json": {
+        schema: {
+          anyOf: [
+            { $ref: "#/components/schemas/FirstError" },
+            { $ref: "#/components/schemas/SecondError" }
+          ]
+        }
+      }
+    })
+  })
+
+  it("documents a middleware error for a status the endpoint does not declare", () => {
+    const Unauthorized = Schema.Struct({ message: Schema.String }).pipe(HttpApiSchema.status(401)).annotate({
+      identifier: "Unauthorized"
+    })
+
+    class Auth extends HttpApiMiddleware.Service<Auth>()("Auth", {
+      error: Unauthorized
+    }) {}
+
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("test").add(
+        HttpApiEndpoint.get("error", "/error", {
+          error: Schema.Struct({ code: Schema.String }).annotate({ identifier: "ServerError" })
+        })
+      )
+    ).middleware(Auth)
+
+    const spec = OpenApi.fromApi(Api)
+
+    assert.deepStrictEqual(spec.paths["/error"]?.get?.responses[401]?.content, {
+      "application/json": {
+        schema: { $ref: "#/components/schemas/Unauthorized" }
+      }
+    })
+    assert.deepStrictEqual(spec.paths["/error"]?.get?.responses[500]?.content, {
+      "application/json": {
+        schema: { $ref: "#/components/schemas/ServerError" }
+      }
+    })
+  })
+
   it("emits stream response headers", () => {
     const Api = HttpApi.make("Api").add(
       HttpApiGroup.make("test").add(

--- a/packages/platform/node/test/__snapshots__/HttpApi.test.ts.snap
+++ b/packages/platform/node/test/__snapshots__/HttpApi.test.ts.snap
@@ -479,14 +479,7 @@ exports[`HttpApi > original tests > OpenAPI spec > fixture 1`] = `
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/UserErrorEncoded",
-                    },
-                    {
-                      "$ref": "#/components/schemas/UserErrorEncoded",
-                    },
-                  ],
+                  "$ref": "#/components/schemas/UserErrorEncoded",
                 },
               },
             },


### PR DESCRIPTION
## Problem

Attaching an `HttpApiMiddleware` that declares an `error` schema rewrote the response for that status on **every** endpoint, even when the middleware declared the exact same schema object the endpoint already declared:

```jsonc
"500": { "schema": { "anyOf": [
  { "$ref": "#/components/schemas/Err" },
  { "$ref": "#/components/schemas/Err" }   // duplicate
] } }
```

Endpoints store declared errors as response codecs (transformResponseSchema → Schema.toCodecJson); middleware stored them raw. Everything downstream merges the two by object identity, so they could never match.

This also broke encoding, not just the document: getResponseEncode runs JSON.stringify over the schema's encoded form, and a raw schema's encoded form isn't JSON-safe. A middleware error with a Schema.BigInt field fails at response time with Expected a JSON-serializable response body. (It looked fine for Schema.Date only because JSON.stringify happens to reproduce the ISO string.)

Fix

- Middleware errors now go through the same response transform as endpoint errors, so middleware.error and endpoint.error hold the same kind of thing.
- transformResponseSchema is memoized on its input schema, so one declaration yields one instance and the existing Set in getErrorSchemas collapses it.

Behavior preserved

A middleware error that is genuinely new for a status is still documented; two different schemas on one status still emit an anyOf.

Note on the snapshot change

The updated platform/node snapshot is the same bug via a different door: the fixture declares error: [UserError, UserError]. The transform ran per element, so the Set couldn't collapse those either. Status 400 is now a single $ref.

Tests

Five cases across OpenApi.test.ts and HttpApiBuilder.test.ts. Two fail on main (same schema collapses; middleware error encodes through the response codec); three pass before and after, guarding against over-correction.

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

