### PR TITLE
Fix custom HTTP server span header redaction

### DIFF
--- a/.changeset/calm-headers-hide.md
+++ b/.changeset/calm-headers-hide.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Respect custom HTTP header redaction when recording server span attributes.

--- a/packages/effect/src/unstable/http/HttpMiddleware.ts
+++ b/packages/effect/src/unstable/http/HttpMiddleware.ts
@@ -196,6 +196,7 @@ export const tracer: <E, R>(
     return Effect.onExitPrimitive(httpApp, (exit) => {
       fiber.setContext(prevServices)
       const endTime = fiber.getRef(Clock).currentTimeNanosUnsafe()
+      const redactedHeaderNames = fiber.getRef(Headers.CurrentRedactedNames)
       fiber.currentDispatcher.scheduleTask(() => {
         let response: HttpServerResponse
         let spanExit = exit
@@ -207,7 +208,6 @@ export const tracer: <E, R>(
           response = exit.value
         }
         if (span.sampled) {
-          const redactedHeaderNames = fiber.getRef(Headers.CurrentRedactedNames)
           span.attribute("http.request.method", request.method)
           if (request.url.startsWith("/")) {
             const host = request.headers.host ?? "localhost"

--- a/packages/effect/test/unstable/http/HttpMiddleware.test.ts
+++ b/packages/effect/test/unstable/http/HttpMiddleware.test.ts
@@ -6,6 +6,7 @@ import * as Exit from "effect/Exit"
 import * as Logger from "effect/Logger"
 import * as References from "effect/References"
 import * as Tracer from "effect/Tracer"
+import * as Headers from "effect/unstable/http/Headers"
 import * as HttpMiddleware from "effect/unstable/http/HttpMiddleware"
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest"
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse"
@@ -94,17 +95,22 @@ describe("HttpMiddleware", () => {
             method: "POST",
             headers: {
               "user-agent": "test-agent",
-              "x-request": "request"
+              "x-request": "request",
+              "x-request-secret": "request-secret"
             }
           })
         )
         const response = HttpServerResponse.empty({
           status: 201,
-          headers: { "x-response": "response" }
+          headers: {
+            "x-response": "response",
+            "x-response-secret": "response-secret"
+          }
         })
 
         yield* HttpMiddleware.tracer(Effect.succeed(response)).pipe(
           Effect.provideService(HttpServerRequest.HttpServerRequest, request),
+          Effect.provideService(Headers.CurrentRedactedNames, ["x-request-secret", "x-response-secret"]),
           Effect.provideService(Tracer.Tracer, tracer)
         )
         yield* Effect.yieldNow
@@ -116,8 +122,10 @@ describe("HttpMiddleware", () => {
         assert.strictEqual(serverSpan.attributes.get("url.query"), "foo=bar")
         assert.strictEqual(serverSpan.attributes.get("user_agent.original"), "test-agent")
         assert.strictEqual(serverSpan.attributes.get("http.request.header.x-request"), "request")
+        assert.strictEqual(serverSpan.attributes.get("http.request.header.x-request-secret"), "<redacted>")
         assert.strictEqual(serverSpan.attributes.get("http.response.status_code"), 201)
         assert.strictEqual(serverSpan.attributes.get("http.response.header.x-response"), "response")
+        assert.strictEqual(serverSpan.attributes.get("http.response.header.x-response-secret"), "<redacted>")
       }))
 
     it.effect("skips attributes for unsampled spans", () =>


### PR DESCRIPTION
Custom `Headers.CurrentRedactedNames` values were read from the request fiber inside the deferred server-span callback. Since completed fibers now clear their context, that lookup fell back to the default redaction policy and could record application-specific sensitive headers in plaintext.

Capture the redacted header names before scheduling span finalization. The existing `span.sampled` condition remains unchanged inside the callback, preserving the span-processing control flow.

The regression test covers custom request and response header redaction while ensuring unconfigured headers remain unchanged.

Closes #7562
