### PR TITLE
fix(platform-bun): load Bun's RedisClient lazily so the barrel imports under Node

### DIFF
--- a/.changeset/lazy-bun-redis-import.md
+++ b/.changeset/lazy-bun-redis-import.md
@@ -3,7 +3,3 @@
 ---
 
 Load Bun's `RedisClient` lazily in `BunRedis`.
-
-The top-level `import ... from "bun"` made `@effect/platform-bun` unimportable outside Bun, since the
-barrel re-exports every module. The constructor is now resolved inside the layer's build effect, so the
-package can be imported anywhere and only fails where it needs Bun.

--- a/.changeset/lazy-bun-redis-import.md
+++ b/.changeset/lazy-bun-redis-import.md
@@ -1,0 +1,9 @@
+---
+"@effect/platform-bun": patch
+---
+
+Load Bun's `RedisClient` lazily in `BunRedis`.
+
+The top-level `import ... from "bun"` made `@effect/platform-bun` unimportable outside Bun, since the
+barrel re-exports every module. The constructor is now resolved inside the layer's build effect, so the
+package can be imported anywhere and only fails where it needs Bun.

--- a/packages/platform/bun/src/BunRedis.ts
+++ b/packages/platform/bun/src/BunRedis.ts
@@ -9,7 +9,7 @@
  *
  * @since 4.0.0
  */
-import { RedisClient, type RedisOptions } from "bun"
+import type { RedisClient, RedisOptions } from "bun"
 import * as Config from "effect/Config"
 import * as Context from "effect/Context"
 import * as Deferred from "effect/Deferred"
@@ -35,6 +35,7 @@ const make = Effect.fnUntraced(function*(
     readonly url?: string
   } & RedisOptions
 ) {
+  const { RedisClient } = yield* Effect.promise(() => import("bun"))
   const scope = yield* Effect.scope
   yield* Scope.addFinalizer(scope, Effect.sync(() => client.close()))
   const client = new RedisClient(options?.url, options)


### PR DESCRIPTION
`BunRedis` has a top-level `import { RedisClient } from "bun"`, and `index.ts` re-exports every module, so importing `@effect/platform-bun` from Node fails outright:

```
Error: Cannot find package 'bun' imported from .../@effect/platform-bun/dist/BunRedis.js
```

It's the only one of the package's 23 modules that imports `bun` at the top level; the other 22 load under Node fine. The easiest way to hit it is a Node test runner collecting a file that transitively reaches the barrel, without meaning to use Bun at all. Subpath imports work around it.

This makes the import type-only and resolves the constructor inside `make`, where Bun is actually needed. No signatures change.

`--project @effect/platform-bun` still passes under Bun. Nothing there covers `BunRedis`, so I also ran a PING through `layer` against a local server to check the lazily-resolved constructor behaves the same. Under Node all 23 modules and the barrel import now.

The other option is dropping `BunRedis` from the generated barrel, though that breaks `import { BunRedis } from "@effect/platform-bun"` for Bun users. Say if you'd rather have that.
