### PR TITLE
fix(effect): type Cause.Reason#annotate as Context-only

### DIFF
--- a/.changeset/reason-annotate-context-only.md
+++ b/.changeset/reason-annotate-context-only.md
@@ -1,0 +1,8 @@
+---
+"effect": patch
+---
+
+Type `Cause.Reason#annotate` as accepting a `Context` only.
+
+The declaration also allowed a `ReadonlyMap`, but the implementation reads `annotations.mapUnsafe` and
+throws on one. The standalone `Cause.annotate` was already `Context`-only.

--- a/.changeset/reason-annotate-context-only.md
+++ b/.changeset/reason-annotate-context-only.md
@@ -3,6 +3,3 @@
 ---
 
 Type `Cause.Reason#annotate` as accepting a `Context` only.
-
-The declaration also allowed a `ReadonlyMap`, but the implementation reads `annotations.mapUnsafe` and
-throws on one. The standalone `Cause.annotate` was already `Context`-only.

--- a/packages/effect/src/Cause.ts
+++ b/packages/effect/src/Cause.ts
@@ -261,7 +261,7 @@ export declare namespace Cause {
     readonly [ReasonTypeId]: typeof ReasonTypeId
     readonly _tag: Tag
     readonly annotations: ReadonlyMap<string, unknown>
-    annotate(annotations: Context.Context<never> | ReadonlyMap<string, unknown>, options?: {
+    annotate(annotations: Context.Context<never>, options?: {
       readonly overwrite?: boolean | undefined
     }): this
   }


### PR DESCRIPTION
`ReasonProto.annotate` is declared as taking a `Context` or a `ReadonlyMap`:

```ts
// Cause.ts:264
annotate(annotations: Context.Context<never> | ReadonlyMap<string, unknown>, options?: {
  readonly overwrite?: boolean | undefined
}): this
```

The implementation only handles the `Context` arm — it reads `annotations.mapUnsafe` on its first line, so a `Map` throws:

```ts
const reason = Cause.makeFailReason("boom")

class RequestId extends Context.Service<RequestId, string>()("RequestId") {}
reason.annotate(Context.make(RequestId, "req-1"))   // fine

reason.annotate(new Map([["requestId", "req-1"]]))  // TypeError: Cannot read properties of undefined (reading 'size')
reason.annotate(new Map())                          // same, even empty
```

`tsc --strict` is clean on that. Found on `4.0.0-rc.112`.

The implementation's own signature is already `Context.Context<never>` (internal/core.ts:209) and the standalone `Cause.annotate` (Cause.ts:1720) is `Context`-only too, so the union member looks stale rather than intended. Nothing in the repo passes a `Map`. This drops it, which only affects call sites that throw today.

If you'd rather the implementation learn to accept a `Map`, I'm happy to redo it that way instead.

`pnpm check`, `oxlint`, `dprint check` are green, and the Cause suites pass (2 files, 124 tests).
