### PR TITLE
Fix Worker.run hanging when a worker dies before the ready handshake

### DIFF
--- a/.changeset/worker-run-early-exit.md
+++ b/.changeset/worker-run-early-exit.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix `Worker.run` hanging uninterruptibly when a worker dies before the ready handshake. The ready wait now races the worker's failure signal, so an early exit fails `run` with a `WorkerError`, and the wait is interruptible.
+Fix `Worker.run` hanging uninterruptibly when a worker dies before the ready handshake.

--- a/.changeset/worker-run-early-exit.md
+++ b/.changeset/worker-run-early-exit.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Worker.run` hanging uninterruptibly when a worker dies before the ready handshake. The ready wait now races the worker's failure signal, so an early exit fails `run` with a `WorkerError`, and the wait is interruptible.

--- a/packages/effect/src/unstable/workers/Worker.ts
+++ b/packages/effect/src/unstable/workers/Worker.ts
@@ -216,7 +216,9 @@ export const makePlatform = <W>() =>
                   },
                   deferred: fiberSet.deferred as any
                 })
-                yield* ready.await
+                // Fail fast if the worker dies before signalling readiness,
+                // and allow interruption while waiting for the handshake.
+                yield* restore(Effect.raceFirst(ready.await, FiberSet.join(fiberSet)))
                 currentPort = port
                 if (buffer.length > 0) {
                   for (const [message, transfers] of buffer) {

--- a/packages/effect/test/unstable/workers/Worker.test.ts
+++ b/packages/effect/test/unstable/workers/Worker.test.ts
@@ -1,0 +1,91 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Deferred, Effect, Exit, Fiber } from "effect"
+import * as Worker from "effect/unstable/workers/Worker"
+import { isWorkerError, WorkerError, WorkerReceiveError } from "effect/unstable/workers/WorkerError"
+
+interface TestPort {
+  readonly postMessage: (message: any, transfers?: any) => void
+}
+
+const testPort: TestPort = { postMessage: () => {} }
+
+const makePlatform = (
+  onListen: (options: {
+    readonly emit: (data: any) => void
+    readonly deferred: Deferred.Deferred<never, WorkerError>
+  }) => void
+) =>
+  Worker.makePlatform<TestPort>()({
+    setup: ({ worker }) => Effect.succeed(worker),
+    listen: ({ deferred, emit }) => Effect.sync(() => onListen({ deferred, emit }))
+  })
+
+const spawnerLayer = Worker.layerSpawner(() => testPort)
+
+const exitError = new WorkerError({
+  reason: new WorkerReceiveError({ message: "The worker has exited with code: 1" })
+})
+
+describe("Worker", () => {
+  it.effect("run fails when the worker exits before the ready message", () =>
+    Effect.gen(function*() {
+      const platform = makePlatform(({ deferred }) => {
+        Deferred.doneUnsafe(deferred, exitError)
+      })
+      const worker = yield* platform.spawn(0)
+      const error = yield* Effect.flip(worker.run(() => Effect.void))
+      assert.isTrue(isWorkerError(error))
+    }).pipe(Effect.provide(spawnerLayer)))
+
+  it.effect("run fails when the worker exits while waiting for ready", () =>
+    Effect.gen(function*() {
+      let deferred: Deferred.Deferred<never, WorkerError> | undefined
+      const platform = makePlatform((options) => {
+        deferred = options.deferred
+      })
+      const worker = yield* platform.spawn(0)
+      const fiber = yield* Effect.forkChild(
+        worker.run(() => Effect.void),
+        { startImmediately: true }
+      )
+      assert.isUndefined(fiber.pollUnsafe())
+
+      Deferred.doneUnsafe(deferred!, exitError)
+      const exit = yield* Fiber.await(fiber)
+      assert.isTrue(Exit.isFailure(exit))
+    }).pipe(Effect.provide(spawnerLayer)))
+
+  it.effect("run is interruptible while waiting for ready", () =>
+    Effect.gen(function*() {
+      const platform = makePlatform(() => {})
+      const worker = yield* platform.spawn(0)
+      const fiber = yield* Effect.forkChild(
+        worker.run(() => Effect.void),
+        { startImmediately: true }
+      )
+      assert.isUndefined(fiber.pollUnsafe())
+
+      yield* Fiber.interrupt(fiber)
+      const exit = yield* Fiber.await(fiber)
+      assert.isTrue(Exit.hasInterrupts(exit))
+    }).pipe(Effect.provide(spawnerLayer)))
+
+  it.effect("run still fails on worker exit after ready", () =>
+    Effect.gen(function*() {
+      let deferred: Deferred.Deferred<never, WorkerError> | undefined
+      const platform = makePlatform((options) => {
+        deferred = options.deferred
+        options.emit([0])
+      })
+      const worker = yield* platform.spawn(0)
+      const fiber = yield* Effect.forkChild(
+        worker.run(() => Effect.void),
+        { startImmediately: true }
+      )
+      assert.isUndefined(fiber.pollUnsafe())
+
+      Deferred.doneUnsafe(deferred!, exitError)
+      const exit = yield* Fiber.await(fiber)
+      assert.isTrue(Exit.isFailure(exit))
+    }).pipe(Effect.provide(spawnerLayer)))
+})


### PR DESCRIPTION
`Worker.run` wraps its body in `Effect.uninterruptibleMask` and waited on the ready latch with a bare `yield* ready.await`. When a worker dies before sending the platform ready message, the platform `listen` hook fails `fiberSet.deferred`, but nothing observes that failure until `FiberSet.join` after the latch wait, so the fiber parks forever in an uninterruptible region. Neither `Fiber.interrupt` nor `Effect.timeout` can unwind it, and `RpcClient.layerProtocolWorker`'s retry never fires because the fiber hangs instead of failing.

The ready wait now races the latch against `FiberSet.join(fiberSet)` under `restore`:

- A worker exiting (or erroring) before the handshake fails `run` with the `WorkerError` from the platform listen hook, which also lets the `RpcClient` retry schedule kick in.
- The handshake wait is interruptible, so callers can time out or interrupt while waiting for readiness. Scope finalizers still run on interruption, terminating the worker.

Added tests in `packages/effect/test/unstable/workers/Worker.test.ts` using an in-memory platform covering: death before `run` starts waiting, death while waiting, interruption while waiting, and death after the handshake. The first three hang on the previous code.

Validation: `pnpm lint-fix`, `pnpm check`, targeted runs of the new Worker tests, `WorkerError.test.ts`, `rpc/RpcClient.test.ts`, and platform-node `RpcServer.test.ts` (95 tests, exercises NodeWorker end to end).

Closes #7566
Closes EFF-999
