### PR TITLE
Fix CLI help alignment for Unicode graphemes

### DIFF
--- a/.changeset/eff-1004-cli-display-width.md
+++ b/.changeset/eff-1004-cli-display-width.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Align CLI help tables by terminal display width for wide, emoji, combining, and zero-width graphemes.

--- a/packages/effect/src/unstable/cli/CliOutput.ts
+++ b/packages/effect/src/unstable/cli/CliOutput.ts
@@ -380,10 +380,47 @@ const stripAnsi = (text: string): string => {
 }
 
 /**
- * Gets the visual length of a string (excluding ANSI codes).
+ * Gets the terminal display width of a string (excluding ANSI codes).
  * @internal
  */
-const visualLength = (text: string): number => stripAnsi(text).length
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" })
+
+const zeroWidthCodePoints = /[\p{Mark}\p{Control}\p{Default_Ignorable_Code_Point}]/gu
+const emojiPresentation = /\p{Emoji_Presentation}/u
+
+const isFullWidthCodePoint = (codePoint: number): boolean => {
+  if (codePoint < 0x1100) return false
+
+  return codePoint <= 0x115f ||
+    codePoint === 0x2329 ||
+    codePoint === 0x232a ||
+    (codePoint >= 0x2e80 && codePoint <= 0x303e) ||
+    (codePoint >= 0x3040 && codePoint <= 0xa4cf) ||
+    (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
+    (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+    (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
+    (codePoint >= 0xfe30 && codePoint <= 0xfe6f) ||
+    (codePoint >= 0xff00 && codePoint <= 0xff60) ||
+    (codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
+    (codePoint >= 0x1b000 && codePoint <= 0x1b2ff) ||
+    (codePoint >= 0x1f200 && codePoint <= 0x1f251) ||
+    (codePoint >= 0x20000 && codePoint <= 0x3fffd)
+}
+
+const graphemeWidth = (grapheme: string): number => {
+  const visible = grapheme.replace(zeroWidthCodePoints, "")
+  if (visible.length === 0) return 0
+  if (emojiPresentation.test(grapheme) || grapheme.includes("\uFE0F")) return 2
+  return isFullWidthCodePoint(visible.codePointAt(0)!) ? 2 : 1
+}
+
+const visualLength = (text: string): number => {
+  let length = 0
+  for (const { segment } of graphemeSegmenter.segment(stripAnsi(text))) {
+    length += graphemeWidth(segment)
+  }
+  return length
+}
 
 /**
  * Helper function to pad strings to a specified width.

--- a/packages/effect/test/unstable/cli/Help.test.ts
+++ b/packages/effect/test/unstable/cli/Help.test.ts
@@ -130,6 +130,40 @@ describe("Command help output", () => {
       expect(shortLine!.indexOf("Short flag description")).toBe(longLine!.indexOf("Long flag description"))
     }).pipe(Effect.provide(TestLayer)))
 
+  it.effect("aligns flag descriptions when flag names contain wide graphemes", () =>
+    Effect.gen(function*() {
+      const command = Command.make("tool", {
+        file: Flag.boolean("ファイル").pipe(Flag.withDescription("Wide flag description")),
+        emoji: Flag.boolean("👩‍💻").pipe(Flag.withDescription("Emoji flag description")),
+        verbose: Flag.boolean("verbose").pipe(Flag.withDescription("ASCII flag description"))
+      })
+      const run = Command.runWith(command, { version: "1.0.0" })
+
+      yield* run(["--help"])
+
+      const lines = (yield* TestConsole.logLines).join("\n").split("\n")
+      assert.include(lines, "  --ファイル    Wide flag description")
+      assert.include(lines, "  --👩‍💻          Emoji flag description")
+      assert.include(lines, "  --verbose     ASCII flag description")
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("aligns flag descriptions when flag names contain zero-width code points", () =>
+    Effect.gen(function*() {
+      const command = Command.make("tool", {
+        combining: Flag.boolean("e\u0301").pipe(Flag.withDescription("Combining flag description")),
+        zeroWidth: Flag.boolean("a\u200Bb").pipe(Flag.withDescription("Zero-width flag description")),
+        ascii: Flag.boolean("abcd").pipe(Flag.withDescription("ASCII flag description"))
+      })
+      const run = Command.runWith(command, { version: "1.0.0" })
+
+      yield* run(["--help"])
+
+      const lines = (yield* TestConsole.logLines).join("\n").split("\n")
+      assert.include(lines, "  --e\u0301       Combining flag description")
+      assert.include(lines, "  --a\u200Bb      Zero-width flag description")
+      assert.include(lines, "  --abcd    ASCII flag description")
+    }).pipe(Effect.provide(TestLayer)))
+
   it.effect("separates long subcommand and argument names from their descriptions", () =>
     Effect.gen(function*() {
       const child = Command.make("account:set-password", {


### PR DESCRIPTION
## Summary

- measure CLI help table padding in terminal display cells
- handle CJK, emoji, combining marks, and zero-width code points by grapheme
- add rendered-help regressions and a patch changeset

## Testing

- `nix develop -c pnpm test packages/effect/test/unstable/cli --run`
- `nix develop -c pnpm --filter effect check`
- oxlint and dprint checks for the changed files

Closes EFF-1004
Closes #7557
