### PR TITLE
fix(Queue): prevent duplicate messages from resumed producers

### DIFF
--- a/.changeset/queue-reentrant-producers.md
+++ b/.changeset/queue-reentrant-producers.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Queue` message duplication, capacity overruns, and consumer defects when a resumed producer synchronously uses the same queue. Zero-capacity queues now reserve each handed-off message for its consumer before resuming the producer.

--- a/packages/effect/src/Queue.ts
+++ b/packages/effect/src/Queue.ts
@@ -1564,10 +1564,7 @@ export const takeUnsafe = <A, E>(self: Dequeue<A, E>): Exit<A, E> | undefined =>
     releaseCapacity(self)
     return core.exitSucceed(message)
   } else if (self.capacity <= 0 && self.state.offers.size > 0) {
-    self.capacity = 1
-    releaseCapacity(self)
-    self.capacity = 0
-    const message = MutableList.take(self.messages)!
+    const message = takeOfferUnsafe(self.state.offers)
     releaseCapacity(self)
     return core.exitSucceed(message)
   }
@@ -1872,11 +1869,8 @@ const takeBetweenUnsafe = <A, E>(
     return self.state.exit
   } else if (max <= 0 || min <= 0) {
     return core.exitSucceed([])
-  } else if (self.capacity <= 0 && self.state.offers.size > 0) {
-    self.capacity = 1
-    releaseCapacity(self)
-    self.capacity = 0
-    const messages = [MutableList.take(self.messages)!]
+  } else if (self.capacity <= 0 && self.messages.length === 0 && self.state.offers.size > 0) {
+    const messages = [takeOfferUnsafe(self.state.offers)]
     releaseCapacity(self)
     return core.exitSucceed(messages)
   }
@@ -1923,6 +1917,22 @@ const offerRemainingArray = <A, E>(self: Enqueue<A, E>, remaining: Array<A>) => 
   })
 }
 
+// Reserve a pending message for the consumer before the producer can reenter.
+const takeOfferUnsafe = <A>(offers: Set<Queue.OfferEntry<A>>): A => {
+  const entry = offers.values().next().value!
+  if (entry._tag === "Single") {
+    offers.delete(entry)
+    entry.resume(exitTrue)
+    return entry.message
+  }
+  const message = entry.remaining[entry.offset++]
+  if (entry.offset === entry.remaining.length) {
+    offers.delete(entry)
+    entry.resume(core.exitSucceed([]))
+  }
+  return message
+}
+
 const releaseCapacity = <A, E>(self: Dequeue<A, E>): boolean => {
   if (self.state._tag === "Done") {
     return Pull.isDoneCause(self.state.exit.cause)
@@ -1936,22 +1946,22 @@ const releaseCapacity = <A, E>(self: Dequeue<A, E>): boolean => {
     }
     return false
   }
-  let n = self.capacity - self.messages.length
+  // Resuming a producer can synchronously take, offer, or shut down this queue.
   for (const entry of self.state.offers) {
-    if (n === 0) break
+    let n = self.capacity - self.messages.length
+    if (n <= 0) break
     else if (entry._tag === "Single") {
       MutableList.append(self.messages, entry.message)
-      n--
-      entry.resume(exitTrue)
       self.state.offers.delete(entry)
+      entry.resume(exitTrue)
     } else {
       for (; entry.offset < entry.remaining.length; entry.offset++) {
         if (n === 0) return false
         MutableList.append(self.messages, entry.remaining[entry.offset])
         n--
       }
-      entry.resume(core.exitSucceed([]))
       self.state.offers.delete(entry)
+      entry.resume(core.exitSucceed([]))
     }
   }
   return false
@@ -1976,10 +1986,7 @@ const takeAllUnsafe = <A, E>(self: Dequeue<A, E>) => {
     releaseCapacity(self)
     return messages
   } else if (self.state._tag !== "Done" && self.state.offers.size > 0) {
-    self.capacity = 1
-    releaseCapacity(self)
-    self.capacity = 0
-    const messages = [MutableList.take(self.messages)!]
+    const messages = [takeOfferUnsafe(self.state.offers)]
     releaseCapacity(self)
     return messages
   }

--- a/packages/effect/test/Queue.test.ts
+++ b/packages/effect/test/Queue.test.ts
@@ -69,6 +69,27 @@ describe("Queue", () => {
       assert.deepStrictEqual(fiber.pollUnsafe(), Exit.succeed([]))
     }))
 
+  it.effect("resuming a blocked producer does not enqueue its message twice", () =>
+    Effect.gen(function*() {
+      const queue = yield* Queue.bounded<number>(1)
+      yield* Queue.offer(queue, 0)
+      const producer = yield* Effect.forkChild(
+        Effect.gen(function*() {
+          yield* Queue.offer(queue, 1)
+          return yield* Queue.take(queue)
+        }),
+        { startImmediately: true }
+      )
+
+      const first = yield* Queue.take(queue)
+      const second = yield* Fiber.join(producer)
+      const remaining = yield* Queue.clear(queue)
+      yield* Queue.shutdown(queue)
+
+      assert.deepStrictEqual([first, second], [0, 1])
+      assert.deepStrictEqual(remaining, [])
+    }))
+
   it.effect("takeN", () =>
     Effect.gen(function*() {
       const queue = yield* Queue.unbounded<number>()

--- a/packages/effect/test/Queue.test.ts
+++ b/packages/effect/test/Queue.test.ts
@@ -90,6 +90,74 @@ describe("Queue", () => {
       assert.deepStrictEqual(remaining, [])
     }))
 
+  for (const method of ["offer", "offerAll"]) {
+    for (const take of ["take", "takeAll", "clear"]) {
+      it.effect(`zero-capacity ${take} reserves the message before resuming ${method}`, () =>
+        Effect.gen(function*() {
+          const queue = yield* Queue.bounded<number>(0)
+          const producer = yield* Effect.forkChild(
+            Effect.gen(function*() {
+              if (method === "offer") yield* Queue.offer(queue, 1)
+              else yield* Queue.offerAll(queue, [1])
+              return yield* Queue.take(queue)
+            }),
+            { startImmediately: true }
+          )
+
+          const first = take === "take"
+            ? [yield* Queue.take(queue)]
+            : take === "takeAll"
+            ? yield* Queue.takeAll(queue)
+            : yield* Queue.clear(queue)
+          const producerExit = producer.pollUnsafe()
+          yield* Queue.shutdown(queue)
+
+          assert.deepStrictEqual({ first, producerExit }, { first: [1], producerExit: undefined })
+        }))
+    }
+
+    it.effect(`resuming ${method} can shut down the queue without defecting the consumer`, () =>
+      Effect.gen(function*() {
+        const queue = yield* Queue.bounded<number>(1)
+        yield* Queue.offer(queue, 0)
+        const producer = yield* Effect.forkChild(
+          Effect.gen(function*() {
+            if (method === "offer") yield* Queue.offer(queue, 1)
+            else yield* Queue.offerAll(queue, [1])
+            yield* Queue.shutdown(queue)
+          }),
+          { startImmediately: true }
+        )
+
+        const exit = yield* Effect.exit(Queue.take(queue))
+        yield* Fiber.join(producer)
+
+        assert.deepStrictEqual(exit, Exit.succeed(0))
+      }))
+
+    it.effect(`resuming ${method} does not overfill the queue with reentrant offers`, () =>
+      Effect.gen(function*() {
+        const queue = yield* Queue.bounded<number>(2)
+        yield* Queue.offerAll(queue, [0, 1])
+        yield* Effect.forkChild(
+          Effect.gen(function*() {
+            if (method === "offer") yield* Queue.offer(queue, 2)
+            else yield* Queue.offerAll(queue, [2])
+            yield* Queue.offer(queue, 3)
+          }),
+          { startImmediately: true }
+        )
+        yield* Effect.forkChild(Queue.offer(queue, 4), { startImmediately: true })
+
+        const first = yield* Queue.takeAll(queue)
+        const size = Queue.sizeUnsafe(queue)
+        yield* Queue.shutdown(queue)
+
+        assert.deepStrictEqual(first, [0, 1])
+        assert.isAtMost(size, 2)
+      }))
+  }
+
   it.effect("takeN", () =>
     Effect.gen(function*() {
       const queue = yield* Queue.unbounded<number>()
@@ -388,5 +456,38 @@ describe("Queue", () => {
       yield* Queue.offer(queue, 2)
       result = yield* Fiber.join(fiber)
       assert.strictEqual(result, 2)
+    }))
+
+  it.effect("zero-capacity takeAll consumes buffered messages before pending offers", () =>
+    Effect.gen(function*() {
+      const queue = yield* Queue.bounded<number>(0)
+      const waiting = yield* Queue.take(queue).pipe(Effect.forkChild({ startImmediately: true }))
+      const producer = yield* Queue.offerAll(queue, [1, 2]).pipe(Effect.forkChild({ startImmediately: true }))
+
+      const batch = yield* Queue.takeAll(queue)
+      const next = yield* Fiber.join(waiting)
+      yield* Fiber.join(producer)
+
+      assert.deepStrictEqual(batch, [1])
+      assert.strictEqual(next, 2)
+    }))
+
+  it.effect("zero-capacity offerAll drains in order and completes a closing queue", () =>
+    Effect.gen(function*() {
+      const queue = yield* Queue.bounded<number, Cause.Done>(0)
+      const producer = yield* Queue.offerAll(queue, [1, 2, 3]).pipe(Effect.forkChild({ startImmediately: true }))
+
+      const first = yield* Queue.takeAll(queue)
+      yield* Queue.end(queue)
+      const second = yield* Queue.clear(queue)
+      const third = yield* Queue.poll(queue)
+      const producerExit = producer.pollUnsafe()
+      const done = yield* Effect.exit(Queue.await(queue))
+
+      assert.deepStrictEqual(first, [1])
+      assert.deepStrictEqual(second, [2])
+      assert.deepStrictEqual(third, Option.some(3))
+      assert.deepStrictEqual(producerExit, Exit.succeed([]))
+      assert.deepStrictEqual(done, Exit.void)
     }))
 })


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

### Why

A bounded queue can retain an extra copy of a message after both offered messages have been consumed. Resuming a blocked producer can synchronously reenter the same queue while the outer operation is still updating its state, also allowing capacity overruns or consumer defects.

### What Changes

Finish admitting each pending offer before resuming its producer, and preserve the queue's invariants if that producer immediately takes, offers, or shuts down the queue.

| Scenario | Before | After |
| --- | --- | --- |
| Offer `0` and `1`, consume both | Extra `[1]` remains | Queue is empty |
| Resumed producer shuts down the queue | Consumer defects with a `TypeError` | Consumer returns its already-taken message |
| Resumed producer offers again | Capacity-two queue can hold three messages | Capacity remains respected |
| Zero-capacity producer immediately takes | Message can be duplicated or stolen from the consumer | Consumer receives the reserved message; producer waits |

### Producer Resumption

- Remove completed pending offers before invoking their resume callbacks, for both `offer` and `offerAll`.
- Recompute available capacity between callbacks instead of relying on a stale count.
- Hand zero-capacity messages directly from pending offers to consumers, without temporarily increasing capacity or exposing the reserved message in the buffer. Preserve buffered-first ordering and closing-queue completion.

Producer resumption remains synchronous; no scheduling workaround is introduced.

### Scope

Queue implementation, focused regression coverage, and an `effect` patch changeset. No public API changes.

### Verification

```bash
pnpm lint-fix
pnpm test --run packages/effect/test/Queue.test.ts
pnpm test --run packages/effect/test/Stream.test.ts -t 'buffer|partitionQueue'
pnpm check
git diff --check
```

All 38 Queue tests and 19 selected Stream tests pass. Lint, typecheck, and diff checks pass. The duplicate-message, shutdown, capacity, and zero-capacity reentrancy cases were reproduced as assertion failures before their fixes. Tests cover both producer forms, all three handoff paths, partial batches, FIFO ordering, and queue completion. No full-suite run.

## Related

- Closes #7575.
