### PR TITLE
fix(Queue): prevent duplicate messages from resumed producers

### DIFF
--- a/.changeset/queue-release-capacity-reentry.md
+++ b/.changeset/queue-release-capacity-reentry.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix duplicate Queue messages when a resumed producer synchronously takes from the same queue. `releaseCapacity` now removes a pending offer before resuming its producer and recomputes available capacity on every iteration, so reentrant calls can no longer admit the same offer twice or exceed the queue's capacity.

--- a/packages/effect/src/Queue.ts
+++ b/packages/effect/src/Queue.ts
@@ -1936,22 +1936,28 @@ const releaseCapacity = <A, E>(self: Dequeue<A, E>): boolean => {
     }
     return false
   }
-  let n = self.capacity - self.messages.length
   for (const entry of self.state.offers) {
-    if (n === 0) break
-    else if (entry._tag === "Single") {
+    // `entry.resume` can run the producer fiber synchronously, which may
+    // reenter this function and mutate `self.state` and `self.messages`, so
+    // remove the entry before resuming and recompute capacity every iteration
+    const state = self.state as Queue.State<A, E>
+    if (state._tag === "Done") {
+      return Pull.isDoneCause(state.exit.cause)
+    }
+    let n = self.capacity - self.messages.length
+    if (n <= 0) break
+    if (entry._tag === "Single") {
       MutableList.append(self.messages, entry.message)
-      n--
+      state.offers.delete(entry)
       entry.resume(exitTrue)
-      self.state.offers.delete(entry)
     } else {
       for (; entry.offset < entry.remaining.length; entry.offset++) {
         if (n === 0) return false
         MutableList.append(self.messages, entry.remaining[entry.offset])
         n--
       }
+      state.offers.delete(entry)
       entry.resume(core.exitSucceed([]))
-      self.state.offers.delete(entry)
     }
   }
   return false

--- a/packages/effect/test/Queue.test.ts
+++ b/packages/effect/test/Queue.test.ts
@@ -69,6 +69,27 @@ describe("Queue", () => {
       assert.deepStrictEqual(fiber.pollUnsafe(), Exit.succeed([]))
     }))
 
+  it.effect("resuming a blocked producer does not enqueue its message twice", () =>
+    Effect.gen(function*() {
+      const queue = yield* Queue.bounded<number>(1)
+      yield* Queue.offer(queue, 0)
+      const producer = yield* Effect.forkChild(
+        Effect.gen(function*() {
+          yield* Queue.offer(queue, 1)
+          return yield* Queue.take(queue)
+        }),
+        { startImmediately: true }
+      )
+
+      const first = yield* Queue.take(queue)
+      const second = yield* Fiber.join(producer)
+      const remaining = yield* Queue.clear(queue)
+      yield* Queue.shutdown(queue)
+
+      assert.deepStrictEqual([first, second], [0, 1])
+      assert.deepStrictEqual(remaining, [])
+    }))
+
   it.effect("takeN", () =>
     Effect.gen(function*() {
       const queue = yield* Queue.unbounded<number>()


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

### Why

A bounded queue can retain an extra copy of a message after both offered messages have been consumed. `releaseCapacity` resumed a blocked producer before removing its pending offer from `state.offers`. When the resumed producer synchronously takes from the same queue, the take reenters `releaseCapacity` while the offer is still registered, so the same message is admitted twice.

### What Changes

In `releaseCapacity`:

- Remove the offer entry from `state.offers` before calling `entry.resume`, so a reentrant call cannot see it.
- Recompute available capacity on each loop iteration instead of caching it once, since a reentrant call can add or remove messages while the loop is suspended in `resume`.
- Bail out if a reentrant call transitioned the queue to `Done` mid-loop.

Includes the regression test from #7576 (thanks for the deterministic repro), which now passes.

### Verification

```bash
pnpm install
pnpm lint-fix
pnpm vitest --run packages/effect
pnpm check
git diff --check
```

All 285 test files pass (9003 tests), including the new regression test. Typecheck and lint are clean.

## Related

- Closes #7575
- Supersedes the reproduction-only draft #7576

Closes EFF-1006
