### PR TITLE
fix(RequestResolver): evict cancelled pending cache entries

### DIFF
--- a/.changeset/request-cache-cancellation.md
+++ b/.changeset/request-cache-cancellation.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `RequestResolver.withCache` retaining abandoned entries when a pending request is cancelled, which could cause later equal requests to hang. Results containing interruptions are no longer cached; completed successes and other failures remain cached, and cancelling one caller does not interrupt requests shared with other callers.

--- a/.changeset/request-cache-cancellation.md
+++ b/.changeset/request-cache-cancellation.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix `RequestResolver.withCache` retaining abandoned entries when a pending request is cancelled, which could cause later equal requests to hang. Results containing interruptions are no longer cached; completed successes and other failures remain cached, and cancelling one caller does not interrupt requests shared with other callers.
+Fix `RequestResolver.withCache` retaining abandoned entries when a pending request is cancelled

--- a/packages/effect/src/RequestResolver.ts
+++ b/packages/effect/src/RequestResolver.ts
@@ -1118,8 +1118,9 @@ export const asCache: {
  *
  * **Gotchas**
  *
- * Entries do not expire by time, and completed failures are cached the same as
- * successes. Request equality controls cache hits.
+ * Entries do not expire by time, and completed failures without interruptions
+ * are cached the same as successes. Results containing interruptions are not
+ * cached. Request equality controls cache hits.
  *
  * @see {@link asCache} for exposing the resolver as a `Cache` with time-to-live and service lookup controls
  * @see {@link persisted} for backing persistable requests with the configured persistence store
@@ -1167,7 +1168,14 @@ export const withCache: {
           MutableHashMap.set(cache, entry.request, cached)
           const prevComplete = entry.completeUnsafe
           entry.completeUnsafe = function(exit) {
-            cached.exit = exit as any
+            if (Exit.hasInterrupts(exit)) {
+              const current = MutableHashMap.get(cache, entry.request)
+              if (current._tag === "Some" && current.value === cached) {
+                MutableHashMap.remove(cache, entry.request)
+              }
+            } else {
+              cached.exit = exit as any
+            }
             prevComplete(exit)
           }
           return true

--- a/packages/effect/src/internal/request.ts
+++ b/packages/effect/src/internal/request.ts
@@ -105,8 +105,9 @@ const addEntry = <A extends Request.Any>(
     completeUnsafe(effect) {
       if (completed) return
       completed = true
+      // Removed entries still notify resolver hooks, but not their cancelled callers.
+      if (batch && !batch.entrySet.delete(entry)) return
       resume(effect)
-      batch?.entrySet.delete(entry)
     }
   })
   if (resolver.preCheck !== undefined && !resolver.preCheck(entry)) {
@@ -184,13 +185,17 @@ const removeEntryUnsafe = <A extends Request.Any>(
   const batch = batchMap.get(key)
   if (!batch) return
 
-  batch.entries.delete(entry)
+  if (!batch.entries.delete(entry)) return
   batch.entrySet.delete(entry)
 
+  let fiber: Fiber<void, unknown> | undefined
   if (batch.entries.size === 0) {
     batchMap.delete(key)
-    batch.fiber?.interruptUnsafe()
+    fiber = batch.fiber
   }
+  // Delay finalizers may enqueue new requests, so complete the removed entry first.
+  entry.completeUnsafe(effect.exitInterrupt())
+  fiber?.interruptUnsafe()
 }
 
 const maybeRemoveEntry = <A extends Request.Any>(

--- a/packages/effect/test/Request.test.ts
+++ b/packages/effect/test/Request.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, expect, it } from "@effect/vitest"
-import { Array, Context, Data, Equal, Fiber, Hash } from "effect"
+import { Array, Context, Data, Deferred, Equal, Fiber, Hash } from "effect"
 import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
@@ -269,6 +269,217 @@ describe.sequential("Request", () => {
       assert.strictEqual(resolverExecuted, false)
     })
   )
+
+  for (const cached of [false, true]) {
+    it.effect(`repro: cancelling a pending batch does not poison ${cached ? "cached" : "uncached"} requests`, () =>
+      Effect.gen(function*() {
+        const gate = yield* Deferred.make<void>()
+        const base = Resolver.make<GetNameById>((entries) =>
+          Effect.sync(() => {
+            for (const entry of entries) entry.completeUnsafe(Exit.succeed("Alice"))
+          })
+        ).pipe(Resolver.setDelayEffect(Deferred.await(gate)))
+        const resolver = cached ? yield* Resolver.withCache(base, { capacity: 10 }) : base
+        const request = new GetNameById({ id: 1 })
+
+        const first = yield* Effect.request(request, resolver).pipe(Effect.forkChild({ startImmediately: true }))
+        yield* Fiber.interrupt(first)
+        const next = yield* Effect.request(request, resolver).pipe(Effect.forkChild({ startImmediately: true }))
+
+        // Allow execution only after cancelling the first batch and retrying.
+        yield* Deferred.succeed(gate, undefined)
+        yield* Effect.yieldNow
+        const exit = next.pollUnsafe()
+        yield* Fiber.interrupt(next)
+
+        assert.deepStrictEqual(exit, Exit.succeed("Alice"))
+      }))
+  }
+
+  it.effect("withCache removes cancelled entries from a surviving batch", () =>
+    Effect.gen(function*() {
+      const gate = yield* Deferred.make<void>()
+      const batches: Array<Array<number>> = []
+      const resolver = yield* Resolver.make<GetNameById>((entries) =>
+        Effect.sync(() => {
+          batches.push(entries.map((entry) => entry.request.id))
+          for (const entry of entries) entry.completeUnsafe(Exit.succeed(String(entry.request.id)))
+        })
+      ).pipe(
+        Resolver.setDelayEffect(Effect.andThen(Effect.yieldNow, Deferred.await(gate))),
+        Resolver.withCache({ capacity: 10 })
+      )
+      const first = yield* Effect.request(new GetNameById({ id: 1 }), resolver).pipe(
+        Effect.forkChild({ startImmediately: true })
+      )
+      const other = yield* Effect.request(new GetNameById({ id: 2 }), resolver).pipe(
+        Effect.forkChild({ startImmediately: true })
+      )
+      yield* Fiber.interrupt(first)
+      yield* Deferred.succeed(gate, undefined)
+      yield* Effect.yieldNow
+      assert.deepStrictEqual(other.pollUnsafe(), Exit.succeed("2"))
+      assert.deepStrictEqual(batches, [[2]])
+
+      const retry = yield* Effect.request(new GetNameById({ id: 1 }), resolver).pipe(
+        Effect.forkChild({ startImmediately: true })
+      )
+      yield* Effect.yieldNow
+      assert.deepStrictEqual(retry.pollUnsafe(), Exit.succeed("1"))
+      assert.deepStrictEqual(batches, [[2], [1]])
+    }))
+
+  for (const cancelFirst of [false, true]) {
+    it.effect(`withCache preserves coalesced requests when the ${cancelFirst ? "first" : "second"} caller cancels`, () =>
+      Effect.gen(function*() {
+        const gate = yield* Deferred.make<void>()
+        const batches: Array<number> = []
+        const resolver = yield* Resolver.make<GetNameById>((entries) =>
+          Effect.sync(() => {
+            batches.push(entries.length)
+            for (const entry of entries) entry.completeUnsafe(Exit.succeed("Alice"))
+          })
+        ).pipe(Resolver.setDelayEffect(Deferred.await(gate)), Resolver.withCache({ capacity: 10 }))
+        const first = yield* Effect.request(new GetNameById({ id: 1 }), resolver).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+        const second = yield* Effect.request(new GetNameById({ id: 1 }), resolver).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+        const cancelled = cancelFirst ? first : second
+        const remaining = cancelFirst ? second : first
+        yield* Fiber.interrupt(cancelled)
+        assert.isTrue(Exit.hasInterrupts(yield* Fiber.await(cancelled)))
+        assert.deepStrictEqual(batches, [])
+        yield* Deferred.succeed(gate, undefined)
+        yield* Effect.yieldNow
+
+        assert.deepStrictEqual(remaining.pollUnsafe(), Exit.succeed("Alice"))
+        assert.strictEqual(yield* Effect.request(new GetNameById({ id: 1 }), resolver), "Alice")
+        assert.deepStrictEqual(batches, [1])
+      }))
+  }
+
+  it.effect("withCache still caches completed failures", () =>
+    Effect.gen(function*() {
+      let calls = 0
+      const resolver = yield* Resolver.make<GetNameById>((entries) =>
+        Effect.sync(() => {
+          calls++
+          for (const entry of entries) entry.completeUnsafe(Exit.fail("Not Found"))
+        })
+      ).pipe(Resolver.withCache({ capacity: 10 }))
+
+      for (let i = 0; i < 2; i++) {
+        assert.deepStrictEqual(
+          yield* Effect.exit(Effect.request(new GetNameById({ id: 1 }), resolver)),
+          Exit.fail("Not Found")
+        )
+      }
+      assert.strictEqual(calls, 1)
+    }))
+
+  it.effect("withCache does not cache interrupted resolver results", () =>
+    Effect.gen(function*() {
+      let calls = 0
+      const resolver = yield* Resolver.make<GetNameById>((entries) =>
+        Effect.sync(() => {
+          calls++
+          for (const entry of entries) {
+            entry.completeUnsafe(calls === 1 ? Exit.interrupt() : Exit.succeed("Alice"))
+          }
+        })
+      ).pipe(Resolver.withCache({ capacity: 10 }))
+
+      assert.isTrue(Exit.hasInterrupts(yield* Effect.exit(Effect.request(new GetNameById({ id: 1 }), resolver))))
+      assert.strictEqual(yield* Effect.request(new GetNameById({ id: 1 }), resolver), "Alice")
+      assert.strictEqual(calls, 2)
+    }))
+
+  it.effect("withCache cancellation does not evict a replacement entry", () =>
+    Effect.gen(function*() {
+      const gate = yield* Deferred.make<void>()
+      const batches: Array<Array<number>> = []
+      let delays = 0
+      const resolver = yield* Resolver.make<GetNameById>((entries) =>
+        Effect.sync(() => {
+          batches.push(entries.map((entry) => entry.request.id))
+          for (const entry of entries) entry.completeUnsafe(Exit.succeed("Alice"))
+        })
+      ).pipe(
+        Resolver.grouped(({ request }) => request.id),
+        Resolver.setDelayEffect(Effect.suspend(() => ++delays === 1 ? Deferred.await(gate) : Effect.yieldNow)),
+        Resolver.withCache({ capacity: 1 })
+      )
+      const first = yield* Effect.request(new GetNameById({ id: 1 }), resolver).pipe(
+        Effect.forkChild({ startImmediately: true })
+      )
+      yield* Effect.yieldNow
+      // Completing another group evicts the first entry while its batch is still pending.
+      yield* Effect.request(new GetNameById({ id: 2 }), resolver)
+      yield* Effect.yieldNow
+      const replacement = yield* Effect.request(new GetNameById({ id: 1 }), resolver).pipe(
+        Effect.forkChild({ startImmediately: true })
+      )
+      yield* Fiber.interrupt(first)
+      const coalesced = yield* Effect.request(new GetNameById({ id: 1 }), resolver).pipe(
+        Effect.forkChild({ startImmediately: true })
+      )
+      yield* Deferred.succeed(gate, undefined)
+      yield* Effect.yieldNow
+
+      assert.deepStrictEqual(replacement.pollUnsafe(), Exit.succeed("Alice"))
+      assert.deepStrictEqual(coalesced.pollUnsafe(), Exit.succeed("Alice"))
+      assert.deepStrictEqual(batches, [[2], [1]])
+    }))
+
+  it.effect("withCache allows an equal retry from the cancelled delay's finalizer", () =>
+    Effect.gen(function*() {
+      const gate = yield* Deferred.make<void>()
+      const context = yield* Effect.context<never>()
+      const results: Array<Request.Result<GetNameById>> = []
+      const batches: Array<number> = []
+      let cancelledCallbacks = 0
+      let finalizers = 0
+      const resolver = yield* Resolver.make<GetNameById>((entries) =>
+        Effect.sync(() => {
+          batches.push(entries.length)
+          for (const entry of entries) entry.completeUnsafe(Exit.succeed("Alice"))
+        })
+      ).pipe(
+        Resolver.setDelayEffect(
+          Deferred.await(gate).pipe(
+            Effect.onInterrupt(() =>
+              Effect.sync(() => {
+                finalizers++
+                Effect.requestUnsafe(new GetNameById({ id: 1 }), {
+                  resolver,
+                  context,
+                  onExit: (exit) => results.push(exit)
+                })
+              })
+            )
+          )
+        ),
+        Resolver.withCache({ capacity: 10 })
+      )
+      const cancel = Effect.requestUnsafe(new GetNameById({ id: 1 }), {
+        resolver,
+        context,
+        onExit: () => cancelledCallbacks++
+      })
+      cancel()
+      assert.strictEqual(finalizers, 1)
+      assert.deepStrictEqual(results, [])
+      cancel()
+      yield* Deferred.succeed(gate, undefined)
+      yield* Effect.yieldNow
+
+      assert.strictEqual(cancelledCallbacks, 0)
+      assert.strictEqual(finalizers, 1)
+      assert.deepStrictEqual(results, [Exit.succeed("Alice")])
+      assert.deepStrictEqual(batches, [1])
+    }))
 
   it.effect(
     "batching preserves individual & identical requests",


### PR DESCRIPTION
## Type

- [x] Bug Fix
- [x] Documentation Update

## Description

### Why

Cancelling a request before its batch runs removes it from the batch but leaves an unfinished entry in `RequestResolver.withCache`. An equal retry attaches to that abandoned entry and never reaches the resolver.

### What Changes

Complete removed pending entries internally with interruption and evict their cache entries. Suppress notifications to cancelled callers, preserve entry-identity guards, and finish cache cleanup before interrupting the delay fiber, whose finalizers may immediately retry.

| Scenario | Before | After |
| --- | --- | --- |
| Cancel pending request, retry equal request | Retry stays suspended | Retry executes successfully |
| Delay cancellation finalizer immediately retries | Retry attaches to abandoned work | Retry sees a fresh cache entry |
| One of two coalesced callers cancels | Other caller remains active | Unchanged |
| Success or ordinary failure completes | Result cached | Unchanged |

### Scope

Pending-request cancellation and interruption-result caching, with an `effect` patch changeset and matching JSDoc. Shared work retains its existing cancellation protection; no blanket uninterruptibility is added.

### Verification

```bash
pnpm test --run packages/effect/test/Request.test.ts
pnpm lint
pnpm check
pnpm jsdocs --check
git diff --check origin/main
```

All 23 tests pass. The original cached-retry regression fails without the fix, while the uncached control passes. Coverage includes surviving batches, either coalesced caller cancelling, ordinary failure caching, interruption results, replacement entries, and silent/idempotent cancellation with finalizer-triggered retry. Lint, typecheck, JSDoc, and whitespace checks pass.

## Related

Closes #7582.

## Audit

Runtime correctness audit; intended label: `audit`.
