### PR TITLE
fix(PartitionedSemaphore): preserve new waiters during stale cleanup

### DIFF
--- a/.changeset/partitioned-semaphore-stale-cleanup.md
+++ b/.changeset/partitioned-semaphore-stale-cleanup.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `PartitionedSemaphore` leaving a new waiter suspended when a previously resumed waiter for the same partition is interrupted before its acquisition completes.

--- a/packages/effect/src/PartitionedSemaphore.ts
+++ b/packages/effect/src/PartitionedSemaphore.ts
@@ -216,8 +216,7 @@ export const makeUnsafe = <K = unknown>(options: {
       }
 
       const cleanup = () => {
-        waiters.delete(entry)
-        if (waiters.size === 0) {
+        if (waiters.delete(entry) && waiters.size === 0) {
           MutableHashMap.remove(partitions, key)
         }
       }

--- a/packages/effect/test/PartitionedSemaphore.test.ts
+++ b/packages/effect/test/PartitionedSemaphore.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Fiber, Option, PartitionedSemaphore } from "effect"
+import { Effect, Exit, Fiber, Option, PartitionedSemaphore, Scheduler } from "effect"
 
 describe("PartitionedSemaphore", () => {
   it.effect("module-level combinators delegate to the instance api", () =>
@@ -89,4 +89,47 @@ describe("PartitionedSemaphore", () => {
       assert.strictEqual(yield* PartitionedSemaphore.available(sem), 4)
       yield* PartitionedSemaphore.take(sem, "c", 4)
     }))
+
+  for (const key of ["other", "same"]) {
+    it.effect(`repro: interrupting a resumed waiter preserves the next ${key}-key waiter`, () =>
+      Effect.gen(function*() {
+        const tasks: Array<() => void> = []
+        let shouldYield = false
+        const scheduler: Scheduler.Scheduler = {
+          executionMode: "async",
+          makeDispatcher() {
+            return {
+              scheduleTask(task) {
+                tasks.push(task)
+              },
+              flush() {}
+            }
+          },
+          shouldYield: () => {
+            if (!shouldYield) return false
+            shouldYield = false
+            return true
+          }
+        }
+
+        const sem = yield* PartitionedSemaphore.make<string>({ permits: 1 })
+        yield* sem.take("holder", 1)
+        const first = yield* sem.take("same", 1).pipe(
+          Effect.provideService(Scheduler.Scheduler, scheduler),
+          Effect.forkChild({ startImmediately: true })
+        )
+
+        // Pause the selected waiter before its take effect finishes.
+        shouldYield = true
+        yield* sem.release(1)
+        const next = yield* sem.take(key, 1).pipe(Effect.forkChild({ startImmediately: true }))
+        yield* Fiber.interrupt(first)
+        while (tasks.length > 0) tasks.shift()!()
+
+        const exit = next.pollUnsafe()
+        yield* Fiber.interrupt(next)
+
+        assert.deepStrictEqual(exit, Exit.void)
+      }))
+  }
 })

--- a/packages/effect/test/PartitionedSemaphore.test.ts
+++ b/packages/effect/test/PartitionedSemaphore.test.ts
@@ -91,7 +91,7 @@ describe("PartitionedSemaphore", () => {
     }))
 
   for (const key of ["other", "same"]) {
-    it.effect(`repro: interrupting a resumed waiter preserves the next ${key}-key waiter`, () =>
+    it.effect(`interrupting a resumed waiter preserves the next ${key}-key waiter`, () =>
       Effect.gen(function*() {
         const tasks: Array<() => void> = []
         let shouldYield = false


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

### Why

Interrupting a selected waiter before its acquisition finishes can run cleanup twice. If another waiter has registered under the same key, the second cleanup deletes that replacement partition and leaves its waiter suspended despite the permit refund.

### What Changes

Remove a partition only when cleanup actually deletes its last waiter. Keep permit refunds outside that guard.

**Before:** the same-key waiter remains suspended; the different-key control succeeds.

**After:** both waiters acquire their refunded permit successfully.

### Scope

One conditional change, a deterministic same-key regression and different-key control, and an `effect` patch changeset. The scheduler fixture follows the existing semaphore tests and does not fabricate private semaphore state.

### Verification

```bash
pnpm test --run packages/effect/test/PartitionedSemaphore.test.ts packages/effect/test/Semaphore.test.ts
pnpm lint
pnpm check
git diff --check origin/main
```

All 26 tests pass. The same-key regression fails on the original runtime while its control passes. Lint, typecheck, and whitespace checks pass.

## Related

Closes #7580.

## Audit

Runtime correctness audit; intended label: `audit`.
