### PR TITLE
fix(Cache): preserve newer entries when refresh is interrupted

### DIFF
--- a/.changeset/cache-refresh-cancellation-ownership.md
+++ b/.changeset/cache-refresh-cancellation-ownership.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix interruption of `Cache.refresh` for a missing key removing a newer value written by `Cache.set`.

--- a/packages/effect/src/Cache.ts
+++ b/packages/effect/src/Cache.ts
@@ -1165,7 +1165,10 @@ export const refresh: {
       }
       entry.fiber.addObserver((exit) => {
         if (effect.exitHasInterrupts(exit)) {
-          if (!existing) MutableHashMap.remove(self.map, key)
+          const current = MutableHashMap.get(self.map, key)
+          if (Option.isSome(current) && current.value === entry) {
+            MutableHashMap.remove(self.map, key)
+          }
           return
         }
         const ttl = self.timeToLive(exit, key)

--- a/packages/effect/test/Cache.test.ts
+++ b/packages/effect/test/Cache.test.ts
@@ -732,6 +732,41 @@ describe("Cache", () => {
           assert.strictEqual(result, 1)
         }))
 
+      it.effect("repro: interrupting a missing-key refresh does not remove a newer set value", () =>
+        Effect.gen(function*() {
+          const lookupStarted = yield* Latch.make()
+          const cache = yield* Cache.make<string, number>({
+            capacity: 1,
+            lookup: () => lookupStarted.open.pipe(Effect.andThen(Effect.never))
+          })
+
+          const refresh = yield* Cache.refresh(cache, "key").pipe(Effect.forkChild({ startImmediately: true }))
+          yield* lookupStarted.await
+          yield* Cache.set(cache, "key", 99)
+          assert.deepStrictEqual(yield* Cache.getSuccess(cache, "key"), Option.some(99))
+
+          yield* Fiber.interrupt(refresh)
+
+          assert.deepStrictEqual(yield* Cache.getSuccess(cache, "key"), Option.some(99))
+        }))
+
+      it.effect("interrupting a missing-key refresh removes its pending entry", () =>
+        Effect.gen(function*() {
+          const lookupStarted = yield* Latch.make()
+          const cache = yield* Cache.make<string, number>({
+            capacity: 1,
+            lookup: () => lookupStarted.open.pipe(Effect.andThen(Effect.never))
+          })
+
+          const refresh = yield* Cache.refresh(cache, "key").pipe(Effect.forkChild({ startImmediately: true }))
+          yield* lookupStarted.await
+          assert.isTrue(yield* Cache.has(cache, "key"))
+
+          yield* Fiber.interrupt(refresh)
+
+          assert.isFalse(yield* Cache.has(cache, "key"))
+        }))
+
       it.effect("refresh updates TTL", () =>
         Effect.gen(function*() {
           const cache = yield* Cache.make<string, number>({


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

### Why

Interrupting a refresh that started on a missing key can delete a newer value written by `Cache.set`. Cleanup currently relies on the key having been absent when the refresh began, rather than checking ownership at cancellation time.

### What Changes

Remove an interrupted refresh's entry only when the cache still holds that exact entry, matching `Cache.get`'s cancellation behavior.

**Before:** start refresh, set 99, interrupt refresh; `Some(99)` becomes `None`.

**After:** the replacement remains `Some(99)`. Cancellation still removes the refresh's own pending entry when nothing replaced it.

### Scope

Cancellation cleanup only; successful refresh publication and TTL behavior are unchanged. Includes the replacement regression, ordinary-cleanup control, and an `effect` patch changeset.

### Verification

```bash
pnpm test --run packages/effect/test/Cache.test.ts
pnpm lint
pnpm check
git diff --check origin/main
```

All 87 tests pass. The replacement regression fails on the original runtime. Lint, typecheck, and whitespace checks pass.

## Related

Closes #7578.

## Audit

Runtime correctness audit; intended label: `audit`.
