### PR TITLE
fix(RcRef): preserve replacement resources during borrower cleanup

### DIFF
--- a/.changeset/rcref-release-ownership.md
+++ b/.changeset/rcref-release-ownership.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Prevent `RcRef` borrower cleanup from discarding replacement resources after invalidation or reopening a reference after its owner scope has closed.

--- a/packages/effect/src/internal/rcRef.ts
+++ b/packages/effect/src/internal/rcRef.ts
@@ -150,7 +150,9 @@ export const get = Effect.fnUntraced(function*<A, E>(
       return Effect.void
     }
     if (self.idleTimeToLive === undefined) {
-      self.state = stateEmpty
+      if (self.state === state) {
+        self.state = stateEmpty
+      }
       return Scope.close(state.scope, Exit.void)
     } else if (state.invalidated) {
       return Scope.close(state.scope, Exit.void)

--- a/packages/effect/src/internal/rcRef.ts
+++ b/packages/effect/src/internal/rcRef.ts
@@ -149,19 +149,17 @@ export const get = Effect.fnUntraced(function*<A, E>(
     if (state.refCount > 0) {
       return Effect.void
     }
-    if (self.idleTimeToLive === undefined) {
+    if (self.idleTimeToLive === undefined || state.invalidated) {
       if (self.state === state) {
         self.state = stateEmpty
       }
-      return Scope.close(state.scope, Exit.void)
-    } else if (state.invalidated) {
       return Scope.close(state.scope, Exit.void)
     } else if (!isFinite) {
       return Effect.void
     }
     state.fiber = Effect.sleep(self.idleTimeToLive).pipe(
       Effect.flatMap(() => {
-        if (self.state._tag === "Acquired" && self.state.refCount === 0) {
+        if (self.state === state && state.refCount === 0) {
           self.state = stateEmpty
           return Scope.close(state.scope, Exit.void)
         }

--- a/packages/effect/test/RcRef.test.ts
+++ b/packages/effect/test/RcRef.test.ts
@@ -60,6 +60,55 @@ describe("RcRef", () => {
       assert.isTrue(Exit.hasInterrupts(exit))
     }))
 
+  it.effect("releasing an invalidated borrower preserves the replacement resource", () =>
+    Effect.gen(function*() {
+      let acquired = 0
+      const released: Array<number> = []
+      const owner = yield* Scope.make()
+      const scopeA = yield* Scope.make()
+      const scopeB = yield* Scope.make()
+      const scopeC = yield* Scope.make()
+      const ref = yield* RcRef.make({
+        acquire: Effect.acquireRelease(
+          Effect.sync(() => ++acquired),
+          (id) => Effect.sync(() => released.push(id))
+        )
+      }).pipe(Scope.provide(owner))
+
+      const first = yield* RcRef.get(ref).pipe(Scope.provide(scopeA))
+      yield* RcRef.invalidate(ref)
+      const replacement = yield* RcRef.get(ref).pipe(Scope.provide(scopeB))
+      yield* Scope.close(scopeA, Exit.void)
+      const next = yield* RcRef.get(ref).pipe(Scope.provide(scopeC))
+      yield* Scope.close(owner, Exit.void)
+      const releasedAtOwnerClose = [...released]
+      yield* Scope.close(scopeB, Exit.void)
+      yield* Scope.close(scopeC, Exit.void)
+
+      assert.deepStrictEqual(
+        { first, replacement, next, releasedAtOwnerClose },
+        { first: 1, replacement: 2, next: 2, releasedAtOwnerClose: [1, 2] }
+      )
+    }))
+
+  it.effect("releasing a borrower after owner shutdown does not reopen the reference", () =>
+    Effect.gen(function*() {
+      let acquired = 0
+      const owner = yield* Scope.make()
+      const borrower = yield* Scope.make()
+      const ref = yield* RcRef.make({
+        acquire: Effect.sync(() => ++acquired)
+      }).pipe(Scope.provide(owner))
+
+      yield* RcRef.get(ref).pipe(Scope.provide(borrower))
+      yield* Scope.close(owner, Exit.void)
+      yield* Scope.close(borrower, Exit.void)
+      const exit = yield* RcRef.get(ref).pipe(Effect.scoped, Effect.exit)
+
+      assert.isTrue(Exit.hasInterrupts(exit))
+      assert.strictEqual(acquired, 1)
+    }))
+
   it.effect("releases resources acquired before acquisition failure", () =>
     Effect.gen(function*() {
       const acquired = yield* Ref.make(0)

--- a/packages/effect/test/RcRef.test.ts
+++ b/packages/effect/test/RcRef.test.ts
@@ -86,8 +86,8 @@ describe("RcRef", () => {
       yield* Scope.close(scopeC, Exit.void)
 
       assert.deepStrictEqual(
-        { first, replacement, next, releasedAtOwnerClose },
-        { first: 1, replacement: 2, next: 2, releasedAtOwnerClose: [1, 2] }
+        { first, replacement, next, releasedAtOwnerClose, released },
+        { first: 1, replacement: 2, next: 2, releasedAtOwnerClose: [1, 2], released: [1, 2] }
       )
     }))
 


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

### Why

Closing the last borrower of an invalidated resource can discard a replacement resource from `RcRef`. A later get acquires a third resource instead of sharing the replacement, and owner shutdown misses the replacement's cleanup. Late borrower cleanup can also overwrite `Closed` and reopen the reference.

### What Changes

Only clear the shared state if it still belongs to the resource being released. Always close the released resource's own scope.

| Sequence | Before | After |
| --- | --- | --- |
| Borrow 1, invalidate, borrow 2, release 1, get again | Acquires 3 | Reuses 2 |
| Close owner, then close borrower, then get again | Acquires again | Remains interrupted |

### Scope

One state-identity guard, two lifecycle regressions, and an `effect` patch changeset. No API changes.

### Verification

```bash
pnpm test --run packages/effect/test/RcRef.test.ts
pnpm lint
pnpm check
git diff --check origin/main
```

All 6 tests pass, including both regressions confirmed failing on the original runtime. Lint, typecheck, and whitespace checks pass.

## Related

Closes #7579.

## Audit

Runtime correctness audit; intended label: `audit`.
