### PR TITLE
fix(Cache): preserve replacements during conditional invalidation

### DIFF
--- a/.changeset/cache-invalidate-when-replacement.md
+++ b/.changeset/cache-invalidate-when-replacement.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix `Cache.invalidateWhen` and `ScopedCache.invalidateWhen` deleting a replacement entry while waiting for an earlier lookup. They now return `false` when the original entry is no longer cached, preserving the replacement value and ensuring scoped replacement resources are released when the cache's owning scope closes.
+Fix `Cache.invalidateWhen` and `ScopedCache.invalidateWhen` deleting a replacement entry while waiting for an earlier lookup.

--- a/.changeset/cache-invalidate-when-replacement.md
+++ b/.changeset/cache-invalidate-when-replacement.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Cache.invalidateWhen` and `ScopedCache.invalidateWhen` deleting a replacement entry while waiting for an earlier lookup. They now return `false` when the original entry is no longer cached, preserving the replacement value and ensuring scoped replacement resources are released when the cache's owning scope closes.

--- a/packages/effect/src/Cache.ts
+++ b/packages/effect/src/Cache.ts
@@ -1041,6 +1041,10 @@ export const invalidateWhen: {
       return oentry.await().pipe(
         effect.map((value) => {
           if (f(value)) {
+            const current = MutableHashMap.get(self.map, key)
+            if (Option.isNone(current) || current.value !== oentry) {
+              return false
+            }
             MutableHashMap.remove(self.map, key)
             return true
           }

--- a/packages/effect/src/ScopedCache.ts
+++ b/packages/effect/src/ScopedCache.ts
@@ -588,6 +588,10 @@ export const invalidateWhen: {
               if (self.state._tag === "Closed") {
                 return effect.succeed(false)
               } else if (f(value)) {
+                const current = MutableHashMap.get(self.state.map, key)
+                if (Option.isNone(current) || current.value !== entry) {
+                  return effect.succeed(false)
+                }
                 MutableHashMap.remove(self.state.map, key)
                 return effect.as(Scope.close(entry.scope, effect.exitVoid), true)
               }

--- a/packages/effect/test/Cache.test.ts
+++ b/packages/effect/test/Cache.test.ts
@@ -650,6 +650,39 @@ describe("Cache", () => {
     })
 
     describe("invalidateWhen", () => {
+      it.effect.each([Exit.succeed(1), Exit.fail("error")])(
+        "preserves a newer set value after an old lookup completes (%#)",
+        (exit) =>
+          Effect.gen(function*() {
+            const gate = yield* Deferred.make<number, string>()
+            const values: Array<number> = []
+            const cache = yield* Cache.make<string, number, string>({
+              capacity: 1,
+              lookup: () => Deferred.await(gate)
+            })
+            const lookup = yield* Cache.get(cache, "key").pipe(
+              Effect.exit,
+              Effect.forkChild({ startImmediately: true })
+            )
+            const invalidator = yield* Cache.invalidateWhen(cache, "key", (value) => {
+              values.push(value)
+              return value === 1
+            }).pipe(
+              Effect.forkChild({ startImmediately: true })
+            )
+
+            yield* Cache.set(cache, "key", 99)
+            yield* Deferred.done(gate, exit)
+            const original = yield* Fiber.join(lookup)
+            const invalidated = yield* Fiber.join(invalidator)
+
+            assert.deepStrictEqual(original, exit)
+            assert.deepStrictEqual(values, Exit.isSuccess(exit) ? [1] : [])
+            assert.isFalse(invalidated)
+            assert.deepStrictEqual(yield* Cache.getSuccess(cache, "key"), Option.some(99))
+          })
+      )
+
       it.effect("invalidates when predicate matches", () =>
         Effect.gen(function*() {
           const cache = yield* Cache.make<string, number>({

--- a/packages/effect/test/ScopedCache.test.ts
+++ b/packages/effect/test/ScopedCache.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Clock, Context, Data, Deferred, Duration, Effect, Exit, Fiber, Option, ScopedCache } from "effect"
+import { Clock, Context, Data, Deferred, Duration, Effect, Exit, Fiber, Option, Scope, ScopedCache } from "effect"
 import { TestClock } from "effect/testing"
 
 describe("ScopedCache", () => {
@@ -752,6 +752,57 @@ describe("ScopedCache", () => {
     })
 
     describe("invalidateWhen", () => {
+      it.effect.each([Exit.succeed(1), Exit.fail("error")])(
+        "preserves a replacement resource after an old lookup completes (%#)",
+        (exit) =>
+          Effect.gen(function*() {
+            let acquired = 0
+            const released: Array<number> = []
+            const values: Array<number> = []
+            const gate = yield* Deferred.make<number, string>()
+            const owner = yield* Scope.make()
+            const cache = yield* ScopedCache.make({
+              capacity: 1,
+              lookup: (_key: string) =>
+                Effect.gen(function*() {
+                  const id = yield* Effect.acquireRelease(
+                    Effect.sync(() => ++acquired),
+                    (value) => Effect.sync(() => released.push(value))
+                  )
+                  if (id === 1) return yield* Deferred.await(gate)
+                  return id
+                })
+            }).pipe(Scope.provide(owner))
+            const lookup = yield* ScopedCache.get(cache, "key").pipe(
+              Effect.exit,
+              Effect.forkChild({ startImmediately: true })
+            )
+            const invalidator = yield* ScopedCache.invalidateWhen(cache, "key", (value) => {
+              values.push(value)
+              return value === 1
+            }).pipe(
+              Effect.forkChild({ startImmediately: true })
+            )
+
+            yield* ScopedCache.invalidate(cache, "key")
+            const replacement = yield* ScopedCache.get(cache, "key")
+            yield* Deferred.done(gate, exit)
+            const original = yield* Fiber.join(lookup)
+            const invalidated = yield* Fiber.join(invalidator)
+            const cached = yield* ScopedCache.getSuccess(cache, "key")
+            const releasedBeforeClose = [...released]
+            yield* Scope.close(owner, Exit.void)
+
+            assert.deepStrictEqual(releasedBeforeClose, [1])
+            assert.deepStrictEqual(original, exit)
+            assert.deepStrictEqual(values, Exit.isSuccess(exit) ? [1] : [])
+            assert.deepStrictEqual(
+              { invalidated, replacement, cached, released },
+              { invalidated: false, replacement: 2, cached: Option.some(2), released: [1, 2] }
+            )
+          })
+      )
+
       it.effect("invalidates when predicate matches", () =>
         Effect.gen(function*() {
           const cache = yield* ScopedCache.make({


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

### Why

`Cache.invalidateWhen` and `ScopedCache.invalidateWhen` can remove a replacement entry after awaiting an older lookup. The predicate matches the old value, not the replacement; ScopedCache additionally loses ownership of the replacement's resources.

### What Changes

Recheck entry identity after predicate evaluation. Return `false` if the original entry is no longer cached, leaving the replacement intact.

| Observation | Before | After |
| --- | --- | --- |
| Old value 1 matches; key was replaced with 99 | Returns true, deletes 99 | Returns false, keeps 99 |
| Scoped resource 1 replaced with 2 | Release log after shutdown omits 2 | Resource 2 stays live until shutdown, then releases |
| Old lookup fails | Predicate skipped | Unchanged |

### Scope

Identity guards in both conditional-invalidation implementations, success/failure regressions and resource-lifetime assertions, and an `effect` patch changeset. No new abstractions or public API changes.

### Verification

```bash
pnpm test --run packages/effect/test/Cache.test.ts packages/effect/test/ScopedCache.test.ts
pnpm lint
pnpm check
git diff --check origin/main
```

All 203 tests pass. Both successful-old-lookup regressions fail on the original runtime; failed-old-lookup controls continue to pass. Lint, typecheck, and whitespace checks pass.

## Related

Closes #7581.

## Audit

Runtime correctness audit; intended label: `audit`.
