### PR TITLE
unstable/ai: route tool param validation through failureMode and drop ToolParameterValidationError.toolParams

### DIFF
--- a/.changeset/eff-1008-tool-param-failure-mode.md
+++ b/.changeset/eff-1008-tool-param-failure-mode.md
@@ -7,9 +7,3 @@
 ---
 
 Route tool call parameter validation failures through the tool's `failureMode` and drop `ToolParameterValidationError.toolParams`.
-
-With `failureMode: "return"`, invalid tool call parameters now produce a failed tool result (`isFailure: true`) instead of failing the effect or killing the `streamText` stream, matching how tool handler failures are treated. The default `failureMode: "error"` still fails with `ToolParameterValidationError`. This applies to the provider packages as well: the OpenAI, OpenAI-compat, and Anthropic packages no longer fail the response when tool call parameters do not match the tool's schema. Instead they convert valid parameters into the tool's standard encoded form and pass invalid parameters through unchanged, leaving `Toolkit` as the single authority for parameter validation.
-
-`ToolParameterValidationError` no longer carries a `toolParams` field, which previously made error construction throw for non-JSON parameter values such as `NaN` or `Infinity`.
-
-**Breaking runtime/type change**: when tool call resolution is enabled, tool call parts emitted by `generateText` / `streamText` now carry the raw (encoded) parameters instead of decoded ones, and their `params` field is typed as `unknown` (see the new `Response.ToolParametersMode`). Code that read decoded `params` off returned tool calls must decode them itself or read handler inputs instead. Provider-executed tool calls are still validated against the tool's parameter schema and fail with `InvalidOutputError` on mismatch, as before.

--- a/.changeset/eff-1008-tool-param-failure-mode.md
+++ b/.changeset/eff-1008-tool-param-failure-mode.md
@@ -1,0 +1,13 @@
+---
+"effect": patch
+"@effect/ai-anthropic": patch
+"@effect/ai-openai": patch
+"@effect/ai-openai-compat": patch
+"@effect/ai-openrouter": patch
+---
+
+Route tool call parameter validation failures through the tool's `failureMode` and drop `ToolParameterValidationError.toolParams`.
+
+With `failureMode: "return"`, invalid tool call parameters now produce a failed tool result (`isFailure: true`) instead of failing the effect or killing the `streamText` stream, matching how tool handler failures are treated. The default `failureMode: "error"` still fails with `ToolParameterValidationError`.
+
+`ToolParameterValidationError` no longer carries a `toolParams` field, which previously made error construction throw for non-JSON parameter values such as `NaN` or `Infinity`.

--- a/.changeset/eff-1008-tool-param-failure-mode.md
+++ b/.changeset/eff-1008-tool-param-failure-mode.md
@@ -8,6 +8,8 @@
 
 Route tool call parameter validation failures through the tool's `failureMode` and drop `ToolParameterValidationError.toolParams`.
 
-With `failureMode: "return"`, invalid tool call parameters now produce a failed tool result (`isFailure: true`) instead of failing the effect or killing the `streamText` stream, matching how tool handler failures are treated. The default `failureMode: "error"` still fails with `ToolParameterValidationError`.
+With `failureMode: "return"`, invalid tool call parameters now produce a failed tool result (`isFailure: true`) instead of failing the effect or killing the `streamText` stream, matching how tool handler failures are treated. The default `failureMode: "error"` still fails with `ToolParameterValidationError`. This applies to the provider packages as well: the OpenAI, OpenAI-compat, and Anthropic packages no longer fail the response when tool call parameters do not match the tool's schema. Instead they convert valid parameters into the tool's standard encoded form and pass invalid parameters through unchanged, leaving `Toolkit` as the single authority for parameter validation.
 
 `ToolParameterValidationError` no longer carries a `toolParams` field, which previously made error construction throw for non-JSON parameter values such as `NaN` or `Infinity`.
+
+**Breaking runtime/type change**: when tool call resolution is enabled, tool call parts emitted by `generateText` / `streamText` now carry the raw (encoded) parameters instead of decoded ones, and their `params` field is typed as `unknown` (see the new `Response.ToolParametersMode`). Code that read decoded `params` off returned tool calls must decode them itself or read handler inputs instead. Provider-executed tool calls are still validated against the tool's parameter schema and fail with `InvalidOutputError` on mismatch, as before.

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -3103,10 +3103,7 @@ const transformToolCallParams = Effect.fnUntraced(function*<Tools extends Readon
 
   const { codec } = yield* tryCodecTransform(tool.parametersSchema, "makeResponse")
 
-  // Convert provider wire parameters into the tool's standard encoded form.
-  // Validation failures pass the raw parameters through unchanged: Toolkit is
-  // the single authority for parameter validation and routes failures through
-  // the tool's failure mode.
+  // Normalize valid parameters; leave invalid ones for Toolkit.
   return yield* (
     Schema.decodeEffect(codec)(toolParams) as Effect.Effect<unknown, Schema.SchemaError>
   ).pipe(

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -3116,7 +3116,6 @@ const transformToolCallParams = Effect.fnUntraced(function*<Tools extends Readon
       method: "makeResponse",
       reason: new AiError.ToolParameterValidationError({
         toolName,
-        toolParams,
         description: formatIssue(error.issue)
       })
     })

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -20,7 +20,6 @@ import * as Predicate from "effect/Predicate"
 import * as Redactable from "effect/Redactable"
 import * as Schema from "effect/Schema"
 import * as SchemaAST from "effect/SchemaAST"
-import * as SchemaIssue from "effect/SchemaIssue"
 import * as Stream from "effect/Stream"
 import type { Span } from "effect/Tracer"
 import type { Mutable, Simplify } from "effect/Types"
@@ -39,8 +38,6 @@ import { addGenAIAnnotations } from "./AnthropicTelemetry.ts"
 import type { AnthropicTool } from "./AnthropicTool.ts"
 import type * as Generated from "./Generated.ts"
 import * as InternalUtilities from "./internal/utilities.ts"
-
-const formatIssue = SchemaIssue.makeFormatterDefault()
 
 /**
  * Known Anthropic Claude model identifiers exposed by the generated Anthropic schema.
@@ -3106,18 +3103,16 @@ const transformToolCallParams = Effect.fnUntraced(function*<Tools extends Readon
 
   const { codec } = yield* tryCodecTransform(tool.parametersSchema, "makeResponse")
 
-  const transform = Schema.decodeEffect(codec)
-
+  // Convert provider wire parameters into the tool's standard encoded form.
+  // Validation failures pass the raw parameters through unchanged: Toolkit is
+  // the single authority for parameter validation and routes failures through
+  // the tool's failure mode.
   return yield* (
-    transform(toolParams) as Effect.Effect<unknown, Schema.SchemaError>
-  ).pipe(Effect.mapError((error) =>
-    AiError.make({
-      module: "AnthropicLanguageModel",
-      method: "makeResponse",
-      reason: new AiError.ToolParameterValidationError({
-        toolName,
-        description: formatIssue(error.issue)
-      })
-    })
-  ))
+    Schema.decodeEffect(codec)(toolParams) as Effect.Effect<unknown, Schema.SchemaError>
+  ).pipe(
+    Effect.flatMap((decoded) =>
+      Schema.encodeUnknownEffect(tool.parametersSchema)(decoded) as Effect.Effect<unknown, Schema.SchemaError>
+    ),
+    Effect.orElseSucceed(() => toolParams)
+  )
 })

--- a/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
+++ b/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
@@ -2,6 +2,7 @@ import { AnthropicClient, AnthropicLanguageModel, AnthropicTool } from "@effect/
 import { assert, describe, it } from "@effect/vitest"
 import { Effect, Layer, Redacted, Schema, Stream } from "effect"
 import {
+  type AiError,
   AnthropicStructuredOutput,
   LanguageModel,
   Prompt,
@@ -117,6 +118,113 @@ describe("AnthropicLanguageModel", () => {
 
         assert.strictEqual(toolCall.name, "GlobTool")
         assert.deepStrictEqual(toolCall.params, toolParams)
+      }))
+
+    it.effect("routes invalid tool call params through failureMode: return without failing the stream", () =>
+      Effect.gen(function*() {
+        const layer = AnthropicClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) =>
+              Effect.succeed(sseResponse(request, [
+                {
+                  type: "message_start",
+                  message: {
+                    id: "msg_test_1",
+                    type: "message",
+                    role: "assistant",
+                    model: "claude-sonnet-4-20250514",
+                    content: [],
+                    stop_reason: null,
+                    stop_sequence: null,
+                    usage: {
+                      cache_creation: null,
+                      cache_creation_input_tokens: null,
+                      cache_read_input_tokens: null,
+                      inference_geo: null,
+                      input_tokens: 10,
+                      output_tokens: 0,
+                      service_tier: null
+                    }
+                  }
+                },
+                {
+                  type: "content_block_start",
+                  index: 0,
+                  content_block: {
+                    type: "tool_use",
+                    id: "toolu_test_1",
+                    name: "GlobTool",
+                    input: {}
+                  }
+                },
+                {
+                  type: "content_block_delta",
+                  index: 0,
+                  delta: {
+                    type: "input_json_delta",
+                    partial_json: JSON.stringify({ pattern: 123 })
+                  }
+                },
+                {
+                  type: "content_block_stop",
+                  index: 0
+                },
+                {
+                  type: "message_delta",
+                  delta: {
+                    stop_reason: "tool_use",
+                    stop_sequence: null
+                  },
+                  usage: {
+                    cache_creation_input_tokens: null,
+                    cache_read_input_tokens: null,
+                    input_tokens: null,
+                    output_tokens: 5
+                  }
+                },
+                {
+                  type: "message_stop"
+                }
+              ]))
+            )
+          ))
+        )
+
+        const GlobTool = Tool.make("GlobTool", {
+          description: "Search for files",
+          failureMode: "return",
+          parameters: Schema.Struct({ pattern: Schema.String }),
+          success: Schema.String,
+          failure: Schema.String
+        })
+
+        const toolkit = Toolkit.make(GlobTool)
+        const toolkitLayer = toolkit.toLayer({
+          GlobTool: () => Effect.succeed("found.ts")
+        })
+
+        const partsChunk = yield* LanguageModel.streamText({
+          prompt: "find ts files",
+          toolkit
+        }).pipe(
+          Stream.runCollect,
+          Effect.provide(AnthropicLanguageModel.model("claude-sonnet-4-20250514")),
+          Effect.provide(toolkitLayer),
+          Effect.provide(layer)
+        )
+
+        const parts = globalThis.Array.from(partsChunk)
+        const toolResult = parts.find((part) => part.type === "tool-result")
+        assert.isDefined(toolResult)
+        if (toolResult?.type !== "tool-result") {
+          return
+        }
+
+        assert.strictEqual(toolResult.isFailure, true)
+        const failure = toolResult.result as AiError.AiError
+        assert.strictEqual(failure._tag, "AiError")
+        assert.strictEqual(failure.reason._tag, "ToolParameterValidationError")
       }))
 
     const codeExecutionCases = [

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -1448,10 +1448,7 @@ const transformToolCallParams = Effect.fnUntraced(function*<Tools extends Readon
 
   const { codec } = yield* tryCodecTransform(tool.parametersSchema, "makeResponse")
 
-  // Convert provider wire parameters into the tool's standard encoded form.
-  // Validation failures pass the raw parameters through unchanged: Toolkit is
-  // the single authority for parameter validation and routes failures through
-  // the tool's failure mode.
+  // Normalize valid parameters; leave invalid ones for Toolkit.
   return yield* (
     Schema.decodeEffect(codec)(toolParams) as Effect.Effect<unknown, Schema.SchemaError>
   ).pipe(

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -1099,7 +1099,6 @@ const makeResponse = Effect.fnUntraced(
                 method: "makeResponse",
                 reason: new AiError.ToolParameterValidationError({
                   toolName,
-                  toolParams: {},
                   description: `Failed to securely JSON parse tool parameters: ${cause}`
                 })
               })
@@ -1192,7 +1191,6 @@ const makeStreamResponse = Effect.fnUntraced(
                   method: "makeStreamResponse",
                   reason: new AiError.ToolParameterValidationError({
                     toolName: toolCall.name,
-                    toolParams: {},
                     description: `Failed to securely JSON parse tool parameters: ${cause}`
                   })
                 })
@@ -1462,7 +1460,6 @@ const transformToolCallParams = Effect.fnUntraced(function*<Tools extends Readon
       method: "makeResponse",
       reason: new AiError.ToolParameterValidationError({
         toolName,
-        toolParams,
         description: formatIssue(error.issue)
       })
     })

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -20,7 +20,6 @@ import * as Rec from "effect/Record"
 import * as Redactable from "effect/Redactable"
 import * as Schema from "effect/Schema"
 import * as AST from "effect/SchemaAST"
-import * as SchemaIssue from "effect/SchemaIssue"
 import * as Stream from "effect/Stream"
 import type { Span } from "effect/Tracer"
 import type { DeepMutable, Simplify } from "effect/Types"
@@ -54,8 +53,6 @@ import {
   type UnknownChatCompletionEvent
 } from "./OpenAiClient.ts"
 import { addGenAIAnnotations } from "./OpenAiTelemetry.ts"
-
-const formatIssue = SchemaIssue.makeFormatterDefault()
 
 /**
  * Image detail level for vision requests.
@@ -1450,20 +1447,19 @@ const transformToolCallParams = Effect.fnUntraced(function*<Tools extends Readon
   }
 
   const { codec } = yield* tryCodecTransform(tool.parametersSchema, "makeResponse")
-  const transform = Schema.decodeEffect(codec)
 
+  // Convert provider wire parameters into the tool's standard encoded form.
+  // Validation failures pass the raw parameters through unchanged: Toolkit is
+  // the single authority for parameter validation and routes failures through
+  // the tool's failure mode.
   return yield* (
-    transform(toolParams) as Effect.Effect<unknown, Schema.SchemaError>
-  ).pipe(Effect.mapError((error) =>
-    AiError.make({
-      module: "OpenAiLanguageModel",
-      method: "makeResponse",
-      reason: new AiError.ToolParameterValidationError({
-        toolName,
-        description: formatIssue(error.issue)
-      })
-    })
-  ))
+    Schema.decodeEffect(codec)(toolParams) as Effect.Effect<unknown, Schema.SchemaError>
+  ).pipe(
+    Effect.flatMap((decoded) =>
+      Schema.encodeUnknownEffect(tool.parametersSchema)(decoded) as Effect.Effect<unknown, Schema.SchemaError>
+    ),
+    Effect.orElseSucceed(() => toolParams)
+  )
 })
 
 const prepareTools = Effect.fnUntraced(function*<Tools extends ReadonlyArray<Tool.Any>>({

--- a/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
@@ -1,7 +1,7 @@
 import { OpenAiClient, OpenAiLanguageModel } from "@effect/ai-openai-compat"
 import { assert, describe, it } from "@effect/vitest"
 import { Effect, Layer, Redacted, Ref, Schema, Stream } from "effect"
-import { LanguageModel, Prompt, Tool, Toolkit } from "effect/unstable/ai"
+import { type AiError, LanguageModel, Prompt, Tool, Toolkit } from "effect/unstable/ai"
 import { HttpClient, type HttpClientError, type HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
 describe("OpenAiLanguageModel", () => {
@@ -46,6 +46,67 @@ describe("OpenAiLanguageModel", () => {
         const requestBody = yield* getRequestBody(capturedRequest)
         assert.strictEqual(requestBody.model, "gpt-4o-mini")
         assert.strictEqual(requestBody.messages[0]?.content, "hello")
+      }))
+
+    it.effect("routes invalid tool call params through failureMode: return without failing the effect", () =>
+      Effect.gen(function*() {
+        const layer = OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) =>
+              Effect.succeed(jsonResponse(
+                request,
+                makeChatCompletion({
+                  choices: [{
+                    index: 0,
+                    finish_reason: "tool_calls",
+                    message: {
+                      role: "assistant",
+                      content: null,
+                      tool_calls: [{
+                        id: "call_1",
+                        type: "function",
+                        function: {
+                          name: "ReturnModeTool",
+                          arguments: JSON.stringify({ input: 123 })
+                        }
+                      }]
+                    }
+                  }]
+                })
+              ))
+            )
+          ))
+        )
+
+        const ReturnModeTool = Tool.make("ReturnModeTool", {
+          description: "A test tool",
+          failureMode: "return",
+          parameters: Schema.Struct({ input: Schema.String }),
+          success: Schema.Struct({ output: Schema.String }),
+          failure: Schema.Struct({ error: Schema.String })
+        })
+
+        const toolkit = Toolkit.make(ReturnModeTool)
+        const toolkitLayer = toolkit.toLayer({
+          ReturnModeTool: ({ input }) => Effect.succeed({ output: `processed: ${input}` })
+        })
+
+        const result = yield* LanguageModel.generateText({
+          prompt: "use the tool",
+          toolkit
+        }).pipe(
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+          Effect.provide(toolkitLayer),
+          Effect.provide(layer)
+        )
+
+        assert.strictEqual(result.toolResults.length, 1)
+        const toolResult = result.toolResults[0]!
+        assert.strictEqual(toolResult.isFailure, true)
+        const failure = toolResult.result as AiError.AiError
+        assert.strictEqual(failure._tag, "AiError")
+        assert.strictEqual(failure.reason._tag, "ToolParameterValidationError")
       }))
 
     it.effect("forwards reasoning config to chat completions request", () =>

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -1045,7 +1045,6 @@ const prepareMessages = Effect.fnUntraced(
                         method: "prepareMessages",
                         reason: new AiError.ToolParameterValidationError({
                           toolName: "local_shell",
-                          toolParams: part.params as Schema.Json,
                           description: error.message
                         })
                       })
@@ -1071,7 +1070,6 @@ const prepareMessages = Effect.fnUntraced(
                         method: "prepareMessages",
                         reason: new AiError.ToolParameterValidationError({
                           toolName: "shell",
-                          toolParams: part.params as Schema.Json,
                           description: error.message
                         })
                       })
@@ -1398,7 +1396,6 @@ const makeResponse = Effect.fnUntraced(
                 method: "makeResponse",
                 reason: new AiError.ToolParameterValidationError({
                   toolName,
-                  toolParams: {},
                   description: `Faled to securely JSON parse tool parameters: ${cause}`
                 })
               })
@@ -2147,7 +2144,6 @@ const makeStreamResponse = Effect.fnUntraced(
                       method: "makeStreamResponse",
                       reason: new AiError.ToolParameterValidationError({
                         toolName,
-                        toolParams: {},
                         description: `Failed securely JSON parse tool parameters: ${cause}`
                       })
                     })
@@ -2450,7 +2446,6 @@ const makeStreamResponse = Effect.fnUntraced(
                     method: "makeStreamResponse",
                     reason: new AiError.ToolParameterValidationError({
                       toolName: toolCall.name,
-                      toolParams: {},
                       description: `Failed securely JSON parse tool parameters: ${cause}`
                     })
                   })
@@ -3104,7 +3099,6 @@ const normalizeMcpToolCall = Effect.fnUntraced(function*<Tools extends ReadonlyA
         method,
         reason: new AiError.ToolParameterValidationError({
           toolName,
-          toolParams,
           description: `Failed to securely JSON parse tool parameters: ${cause}`
         })
       })
@@ -3205,7 +3199,6 @@ const transformToolCallParams = Effect.fnUntraced(function*<Tools extends Readon
       method: "makeResponse",
       reason: new AiError.ToolParameterValidationError({
         toolName,
-        toolParams,
         description: formatIssue(error.issue)
       })
     })

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -19,7 +19,6 @@ import * as Predicate from "effect/Predicate"
 import * as Redactable from "effect/Redactable"
 import * as Schema from "effect/Schema"
 import * as AST from "effect/SchemaAST"
-import * as SchemaIssue from "effect/SchemaIssue"
 import * as Stream from "effect/Stream"
 import type { Span } from "effect/Tracer"
 import type { DeepMutable, Mutable, Simplify } from "effect/Types"
@@ -39,8 +38,6 @@ import { OpenAiClient } from "./OpenAiClient.ts"
 import type * as OpenAiSchema from "./OpenAiSchema.ts"
 import { addGenAIAnnotations } from "./OpenAiTelemetry.ts"
 import type * as OpenAiTool from "./OpenAiTool.ts"
-
-const formatIssue = SchemaIssue.makeFormatterDefault()
 
 const ResponseModelIds = Generated.ModelIdsResponses.members[1]
 const SharedModelIds = Generated.ModelIdsShared.members[1]
@@ -3189,18 +3186,16 @@ const transformToolCallParams = Effect.fnUntraced(function*<Tools extends Readon
 
   const { codec } = yield* tryCodecTransform(tool.parametersSchema, "makeResponse")
 
-  const transform = Schema.decodeEffect(codec)
-
+  // Convert provider wire parameters into the tool's standard encoded form.
+  // Validation failures pass the raw parameters through unchanged: Toolkit is
+  // the single authority for parameter validation and routes failures through
+  // the tool's failure mode.
   return yield* (
-    transform(toolParams) as Effect.Effect<unknown, Schema.SchemaError>
-  ).pipe(Effect.mapError((error) =>
-    AiError.make({
-      module: "OpenAiLanguageModel",
-      method: "makeResponse",
-      reason: new AiError.ToolParameterValidationError({
-        toolName,
-        description: formatIssue(error.issue)
-      })
-    })
-  ))
+    Schema.decodeEffect(codec)(toolParams) as Effect.Effect<unknown, Schema.SchemaError>
+  ).pipe(
+    Effect.flatMap((decoded) =>
+      Schema.encodeUnknownEffect(tool.parametersSchema)(decoded) as Effect.Effect<unknown, Schema.SchemaError>
+    ),
+    Effect.orElseSucceed(() => toolParams)
+  )
 })

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -3186,10 +3186,7 @@ const transformToolCallParams = Effect.fnUntraced(function*<Tools extends Readon
 
   const { codec } = yield* tryCodecTransform(tool.parametersSchema, "makeResponse")
 
-  // Convert provider wire parameters into the tool's standard encoded form.
-  // Validation failures pass the raw parameters through unchanged: Toolkit is
-  // the single authority for parameter validation and routes failures through
-  // the tool's failure mode.
+  // Normalize valid parameters; leave invalid ones for Toolkit.
   return yield* (
     Schema.decodeEffect(codec)(toolParams) as Effect.Effect<unknown, Schema.SchemaError>
   ).pipe(

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -2108,7 +2108,6 @@ class ParamEncodeService extends Context.Service<ParamEncodeService, {
   readonly use: Effect.Effect<void>
 }>()("ParamEncodeService") {}
 
-// Decoding is service-free while encoding requires `ParamEncodeService`
 const AsymmetricParam = Schema.String.pipe(
   Schema.decodeTo(Schema.String, {
     decode: SchemaGetter.passthrough(),

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -1051,6 +1051,29 @@ describe("OpenAiLanguageModel", () => {
           }))
         ))
 
+      it.effect("provides parameter encoding services to provider normalization when tool call resolution is disabled", () =>
+        Effect.gen(function*() {
+          const used = yield* Ref.make(false)
+          const toolkit = Toolkit.make(AsymmetricParamsTool)
+
+          const result = yield* LanguageModel.generateText({
+            prompt: "Use the tool",
+            toolkit,
+            disableToolCallResolution: true
+          }).pipe(
+            Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+            Effect.provideService(ParamEncodeService, { use: Ref.set(used, true) })
+          )
+
+          strictEqual(yield* Ref.get(used), true)
+          const toolCall = result.toolCalls[0]!
+          deepStrictEqual(toolCall.params, { input: "hello" })
+        }).pipe(
+          Effect.provide(makeTestLayer({
+            body: { output: [makeFunctionCall("AsymmetricParamsTool", { input: "hello" })] }
+          }))
+        ))
+
       it.effect("uses canonical OpenAiMcp name for mcp_call", () =>
         Effect.gen(function*() {
           const result = yield* LanguageModel.generateText({

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -2,7 +2,7 @@ import { type Generated, OpenAiClient, OpenAiLanguageModel, OpenAiSchema, OpenAi
 import { assert, describe, it } from "@effect/vitest"
 import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import { Array, Context, Effect, Layer, Redacted, Ref, Schema, Stream } from "effect"
-import { LanguageModel, Prompt, Response as AiResponse, Tool, Toolkit } from "effect/unstable/ai"
+import { type AiError, LanguageModel, Prompt, Response as AiResponse, Tool, Toolkit } from "effect/unstable/ai"
 import { HttpClient, type HttpClientError, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
 describe("OpenAiLanguageModel", () => {
@@ -968,6 +968,63 @@ describe("OpenAiLanguageModel", () => {
           ])
         ))
 
+      it.effect("routes invalid tool call params through failureMode: return without failing the effect", () =>
+        Effect.gen(function*() {
+          const toolkit = Toolkit.make(ReturnModeTool)
+          const handlers = toolkit.toLayer({
+            ReturnModeTool: ({ input }) => Effect.succeed({ output: `processed: ${input}` })
+          })
+
+          const result = yield* LanguageModel.generateText({
+            prompt: "Use the tool",
+            toolkit
+          }).pipe(
+            Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+            Effect.provide(handlers)
+          )
+
+          strictEqual(result.toolResults.length, 1)
+          const toolResult = result.toolResults[0]!
+          strictEqual(toolResult.isFailure, true)
+          const failure = toolResult.result as AiError.AiError
+          strictEqual(failure._tag, "AiError")
+          strictEqual(failure.reason._tag, "ToolParameterValidationError")
+        }).pipe(
+          Effect.provide(makeTestLayer({
+            body: { output: [makeFunctionCall("ReturnModeTool", { input: 123 })] }
+          }))
+        ))
+
+      it.effect("converts transformed tool call params to the tool's standard encoded form", () =>
+        Effect.gen(function*() {
+          const received = yield* Ref.make<number | undefined>(undefined)
+          const toolkit = Toolkit.make(TransformParamsTool)
+          const handlers = toolkit.toLayer({
+            TransformParamsTool: ({ input }) =>
+              Ref.set(received, input).pipe(
+                Effect.as({ output: input * 2 })
+              )
+          })
+
+          const result = yield* LanguageModel.generateText({
+            prompt: "Use the tool",
+            toolkit
+          }).pipe(
+            Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+            Effect.provide(handlers)
+          )
+
+          const toolCall = result.toolCalls[0]!
+          deepStrictEqual(toolCall.params, { input: "21" })
+          strictEqual(yield* Ref.get(received), 21)
+          strictEqual(result.toolResults[0]!.isFailure, false)
+          deepStrictEqual(result.toolResults[0]!.result, { output: 42 })
+        }).pipe(
+          Effect.provide(makeTestLayer({
+            body: { output: [makeFunctionCall("TransformParamsTool", { input: "21" })] }
+          }))
+        ))
+
       it.effect("uses canonical OpenAiMcp name for mcp_call", () =>
         Effect.gen(function*() {
           const result = yield* LanguageModel.generateText({
@@ -1371,6 +1428,78 @@ describe("OpenAiLanguageModel", () => {
 
         const toolParamsEnd = parts.find((part) => part.type === "tool-params-end" && part.id === "call_1")
         assert.isDefined(toolParamsEnd)
+      }))
+
+    it.effect("routes invalid tool call params through failureMode: return without failing the stream", () =>
+      Effect.gen(function*() {
+        const toolkit = Toolkit.make(ReturnModeTool)
+        const handlers = toolkit.toLayer({
+          ReturnModeTool: ({ input }) => Effect.succeed({ output: `processed: ${input}` })
+        })
+
+        const streamEvents = [
+          {
+            type: "response.created",
+            sequence_number: 1,
+            response: makeDefaultResponse({
+              id: "resp_invalid_params",
+              status: "in_progress",
+              output: []
+            })
+          },
+          {
+            type: "response.output_item.added",
+            sequence_number: 2,
+            output_index: 0,
+            item: {
+              type: "function_call",
+              id: "fc_1",
+              call_id: "call_1",
+              name: "ReturnModeTool",
+              arguments: "",
+              status: "in_progress"
+            }
+          },
+          {
+            type: "response.function_call_arguments.done",
+            sequence_number: 3,
+            output_index: 0,
+            item_id: "fc_1",
+            name: "ReturnModeTool",
+            arguments: "{\"input\":123}"
+          },
+          {
+            type: "response.completed",
+            sequence_number: 4,
+            response: makeDefaultResponse({
+              id: "resp_invalid_params",
+              status: "completed",
+              output: []
+            })
+          }
+        ] as unknown as ReadonlyArray<typeof Generated.ResponseStreamEvent.Type>
+
+        const partsChunk = yield* LanguageModel.streamText({
+          prompt: "Use the test tool",
+          toolkit
+        }).pipe(
+          Stream.runCollect,
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+          Effect.provide(makeStreamTestLayer(streamEvents)),
+          Effect.provide(handlers)
+        )
+
+        const parts = globalThis.Array.from(partsChunk)
+        const toolResults = parts.filter((part) => part.type === "tool-result")
+        strictEqual(toolResults.length, 1)
+        const toolResult = toolResults[0]
+        if (toolResult?.type === "tool-result") {
+          strictEqual(toolResult.isFailure, true)
+          const result = toolResult.result as AiError.AiError
+          strictEqual(result._tag, "AiError")
+          strictEqual(result.reason._tag, "ToolParameterValidationError")
+        }
+        assert.isDefined(parts.find((part) => part.type === "finish"))
       }))
 
     it.effect("waits for the stable streamed web search action before emitting the tool call", () =>
@@ -1910,6 +2039,20 @@ const TestTool = Tool.make("TestTool", {
   description: "A test tool",
   parameters: Schema.Struct({ input: Schema.String }),
   success: Schema.Struct({ output: Schema.String })
+})
+
+const ReturnModeTool = Tool.make("ReturnModeTool", {
+  description: "A test tool",
+  failureMode: "return",
+  parameters: Schema.Struct({ input: Schema.String }),
+  success: Schema.Struct({ output: Schema.String }),
+  failure: Schema.Struct({ error: Schema.String })
+})
+
+const TransformParamsTool = Tool.make("TransformParamsTool", {
+  description: "A test tool",
+  parameters: Schema.Struct({ input: Schema.FiniteFromString }),
+  success: Schema.Struct({ output: Schema.Finite })
 })
 
 const TestToolkit = Toolkit.make(TestTool)

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -1,7 +1,7 @@
 import { type Generated, OpenAiClient, OpenAiLanguageModel, OpenAiSchema, OpenAiTool } from "@effect/ai-openai"
 import { assert, describe, it } from "@effect/vitest"
 import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
-import { Array, Context, Effect, Layer, Redacted, Ref, Schema, Stream } from "effect"
+import { Array, Context, Effect, Layer, Redacted, Ref, Schema, SchemaGetter, Stream } from "effect"
 import { type AiError, LanguageModel, Prompt, Response as AiResponse, Tool, Toolkit } from "effect/unstable/ai"
 import { HttpClient, type HttpClientError, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
@@ -1022,6 +1022,32 @@ describe("OpenAiLanguageModel", () => {
         }).pipe(
           Effect.provide(makeTestLayer({
             body: { output: [makeFunctionCall("TransformParamsTool", { input: "21" })] }
+          }))
+        ))
+
+      it.effect("provides parameter encoding services to provider normalization", () =>
+        Effect.gen(function*() {
+          const used = yield* Ref.make(false)
+          const toolkit = Toolkit.make(AsymmetricParamsTool)
+          const handlers = toolkit.toLayer({
+            AsymmetricParamsTool: ({ input }) => Effect.succeed({ output: `processed: ${input}` })
+          })
+
+          const result = yield* LanguageModel.generateText({
+            prompt: "Use the tool",
+            toolkit
+          }).pipe(
+            Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+            Effect.provide(handlers),
+            Effect.provideService(ParamEncodeService, { use: Ref.set(used, true) })
+          )
+
+          strictEqual(yield* Ref.get(used), true)
+          strictEqual(result.toolResults[0]!.isFailure, false)
+          deepStrictEqual(result.toolResults[0]!.result, { output: "processed: hello" })
+        }).pipe(
+          Effect.provide(makeTestLayer({
+            body: { output: [makeFunctionCall("AsymmetricParamsTool", { input: "hello" })] }
           }))
         ))
 
@@ -2053,6 +2079,29 @@ const TransformParamsTool = Tool.make("TransformParamsTool", {
   description: "A test tool",
   parameters: Schema.Struct({ input: Schema.FiniteFromString }),
   success: Schema.Struct({ output: Schema.Finite })
+})
+
+class ParamEncodeService extends Context.Service<ParamEncodeService, {
+  readonly use: Effect.Effect<void>
+}>()("ParamEncodeService") {}
+
+// Decoding is service-free while encoding requires `ParamEncodeService`
+const AsymmetricParam = Schema.String.pipe(
+  Schema.decodeTo(Schema.String, {
+    decode: SchemaGetter.passthrough(),
+    encode: SchemaGetter.transformOrFail<string, string, ParamEncodeService>((value) =>
+      Effect.service(ParamEncodeService).pipe(
+        Effect.flatMap((service) => service.use),
+        Effect.as(value)
+      )
+    )
+  })
+)
+
+const AsymmetricParamsTool = Tool.make("AsymmetricParamsTool", {
+  description: "A test tool",
+  parameters: Schema.Struct({ input: AsymmetricParam }),
+  success: Schema.Struct({ output: Schema.String })
 })
 
 const TestToolkit = Toolkit.make(TestTool)

--- a/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
+++ b/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
@@ -1046,7 +1046,6 @@ const makeResponse = Effect.fnUntraced(
               method: "makeResponse",
               reason: new AiError.ToolParameterValidationError({
                 toolName,
-                toolParams: {},
                 description: `Failed to securely JSON parse tool parameters: ${cause}`
               })
             })

--- a/packages/effect/src/unstable/ai/AiError.ts
+++ b/packages/effect/src/unstable/ai/AiError.ts
@@ -1055,7 +1055,6 @@ export class ToolNotFoundError extends Schema.Error<ToolNotFoundError>(
  *
  * const error = new AiError.ToolParameterValidationError({
  *   toolName: "GetWeather",
- *   toolParams: { location: 123 },
  *   description: "Expected string, got number"
  * })
  *
@@ -1070,7 +1069,6 @@ export class ToolParameterValidationError extends Schema.Error<ToolParameterVali
 )({
   _tag: Schema.tag("ToolParameterValidationError"),
   toolName: Schema.String,
-  toolParams: Schema.Json,
   description: Schema.String
 }) {
   /**

--- a/packages/effect/src/unstable/ai/Chat.ts
+++ b/packages/effect/src/unstable/ai/Chat.ts
@@ -240,7 +240,7 @@ export interface Service {
         readonly toolkit: LanguageModel.ToolkitInput<Tools>
       }
     ): Effect.Effect<
-      LanguageModel.GenerateTextResponse<Tools, LanguageModel.ExtractEncodedToolParameters<Options>>,
+      LanguageModel.GenerateTextResponse<Tools, LanguageModel.ExtractToolParametersMode<Options>>,
       LanguageModel.ExtractError<Options>,
       LanguageModel.LanguageModel | LanguageModel.ExtractServices<Options>
     >
@@ -255,7 +255,7 @@ export interface Service {
     ): Effect.Effect<
       LanguageModel.GenerateTextResponse<
         LanguageModel.ExtractTools<Options>,
-        LanguageModel.ExtractEncodedToolParameters<Options>
+        LanguageModel.ExtractToolParametersMode<Options>
       >,
       LanguageModel.ExtractError<Options>,
       LanguageModel.LanguageModel | LanguageModel.ExtractServices<Options>
@@ -322,7 +322,7 @@ export interface Service {
         readonly toolkit: LanguageModel.ToolkitInput<Tools>
       }
     ): Stream.Stream<
-      Response.StreamPart<Tools, LanguageModel.ExtractEncodedToolParameters<Options>>,
+      Response.StreamPart<Tools, LanguageModel.ExtractToolParametersMode<Options>>,
       LanguageModel.ExtractError<Options>,
       LanguageModel.LanguageModel | LanguageModel.ExtractServices<Options>
     >
@@ -337,7 +337,7 @@ export interface Service {
     ): Stream.Stream<
       Response.StreamPart<
         LanguageModel.ExtractTools<Options>,
-        LanguageModel.ExtractEncodedToolParameters<Options>
+        LanguageModel.ExtractToolParametersMode<Options>
       >,
       LanguageModel.ExtractError<Options>,
       LanguageModel.LanguageModel | LanguageModel.ExtractServices<Options>
@@ -399,7 +399,7 @@ export interface Service {
     LanguageModel.GenerateObjectResponse<
       LanguageModel.ExtractTools<Options>,
       ObjectSchema["Type"],
-      LanguageModel.ExtractEncodedToolParameters<Options>
+      LanguageModel.ExtractToolParametersMode<Options>
     >,
     LanguageModel.ExtractError<Options>,
     LanguageModel.ExtractServices<Options> | ObjectSchema["DecodingServices"] | LanguageModel.LanguageModel

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -590,6 +590,7 @@ type ExtractErrorFromToolkitOption<ToolkitValue, DisableToolCallResolution exten
 type ExtractServicesFromToolkitOption<ToolkitValue> = ToolkitValue extends Toolkit.WithHandler<infer Tools> ?
     | Tool.HandlerServices<Tools[keyof Tools]>
     | Tool.ResultDecodingServices<Tools[keyof Tools]>
+    | Tool.ParametersEncodingServices<Tools[keyof Tools]>
   : ToolkitValue extends Effect.Effect<
     Toolkit.WithHandler<infer Tools>,
     infer _E,
@@ -597,6 +598,7 @@ type ExtractServicesFromToolkitOption<ToolkitValue> = ToolkitValue extends Toolk
   > ?
       | Tool.HandlerServices<Tools[keyof Tools]>
       | Tool.ResultDecodingServices<Tools[keyof Tools]>
+      | Tool.ParametersEncodingServices<Tools[keyof Tools]>
       | R
   : never
 

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -115,7 +115,7 @@ export interface Service {
     >(
       options: Options & GenerateTextOptions<Tools> & { readonly toolkit: ToolkitInput<Tools> }
     ): Effect.Effect<
-      GenerateTextResponse<Tools, ExtractEncodedToolParameters<Options>>,
+      GenerateTextResponse<Tools, ExtractToolParametersMode<Options>>,
       ExtractError<Options>,
       ExtractServices<Options>
     >
@@ -127,7 +127,7 @@ export interface Service {
     >(
       options: Options & GenerateTextOptions<ExtractTools<Options>> & { readonly toolkit: Options["toolkit"] }
     ): Effect.Effect<
-      GenerateTextResponse<ExtractTools<Options>, ExtractEncodedToolParameters<Options>>,
+      GenerateTextResponse<ExtractTools<Options>, ExtractToolParametersMode<Options>>,
       ExtractError<Options>,
       ExtractServices<Options>
     >
@@ -147,7 +147,7 @@ export interface Service {
   >(
     options: Options & GenerateObjectOptions<Tools, StructuredOutputSchema>
   ) => Effect.Effect<
-    GenerateObjectResponse<Tools, StructuredOutputSchema["Type"], ExtractEncodedToolParameters<Options>>,
+    GenerateObjectResponse<Tools, StructuredOutputSchema["Type"], ExtractToolParametersMode<Options>>,
     ExtractError<Options>,
     ExtractServices<Options> | StructuredOutputSchema["DecodingServices"]
   >
@@ -174,7 +174,7 @@ export interface Service {
     >(
       options: Options & GenerateTextOptions<Tools> & { readonly toolkit: ToolkitInput<Tools> }
     ): Stream.Stream<
-      Response.StreamPart<Tools, ExtractEncodedToolParameters<Options>>,
+      Response.StreamPart<Tools, ExtractToolParametersMode<Options>>,
       ExtractError<Options>,
       ExtractServices<Options>
     >
@@ -186,7 +186,7 @@ export interface Service {
     >(
       options: Options & GenerateTextOptions<ExtractTools<Options>> & { readonly toolkit: Options["toolkit"] }
     ): Stream.Stream<
-      Response.StreamPart<ExtractTools<Options>, ExtractEncodedToolParameters<Options>>,
+      Response.StreamPart<ExtractTools<Options>, ExtractToolParametersMode<Options>>,
       ExtractError<Options>,
       ExtractServices<Options>
     >
@@ -366,11 +366,11 @@ export type ToolChoice<ToolName extends string> =
  */
 export class GenerateTextResponse<
   Tools extends Record<string, Tool.Any>,
-  EncodedToolParameters extends Response.ToolParametersMode = false
+  ParametersMode extends Response.ToolParametersMode = "decoded"
 > {
-  readonly content: Array<Response.Part<Tools, EncodedToolParameters>>
+  readonly content: Array<Response.Part<Tools, ParametersMode>>
 
-  constructor(content: Array<Response.Part<Tools, EncodedToolParameters>>) {
+  constructor(content: Array<Response.Part<Tools, ParametersMode>>) {
     this.content = content
   }
 
@@ -410,7 +410,7 @@ export class GenerateTextResponse<
   /**
    * Returns all tool call parts from the response.
    */
-  get toolCalls(): Array<Response.ToolCallParts<Tools, EncodedToolParameters>> {
+  get toolCalls(): Array<Response.ToolCallParts<Tools, ParametersMode>> {
     return this.content.filter((part) => part.type === "tool-call")
   }
 
@@ -476,14 +476,14 @@ export class GenerateTextResponse<
 export class GenerateObjectResponse<
   Tools extends Record<string, Tool.Any>,
   A,
-  EncodedToolParameters extends Response.ToolParametersMode = false
-> extends GenerateTextResponse<Tools, EncodedToolParameters> {
+  ParametersMode extends Response.ToolParametersMode = "decoded"
+> extends GenerateTextResponse<Tools, ParametersMode> {
   /**
    * The parsed structured object that conforms to the provided schema.
    */
   readonly value: A
 
-  constructor(value: A, content: Array<Response.Part<Tools, EncodedToolParameters>>) {
+  constructor(value: A, content: Array<Response.Part<Tools, ParametersMode>>) {
     super(content)
     this.value = value
   }
@@ -558,15 +558,15 @@ export type ExtractTools<Options> = Options extends {
   : {}
 
 /**
- * Resolves to `true` for encoded parameters when tool call resolution is
+ * Resolves to `"encoded"` when tool call resolution is
  * disabled, otherwise `"opaque"`.
  *
  * @category utility types
  * @since 4.0.0
  */
-export type ExtractEncodedToolParameters<Options> = Options extends {
+export type ExtractToolParametersMode<Options> = Options extends {
   readonly disableToolCallResolution: true
-} ? true
+} ? "encoded"
   : "opaque"
 
 type ExtractErrorFromToolkitOption<ToolkitValue, DisableToolCallResolution extends boolean> = ToolkitValue extends
@@ -877,7 +877,7 @@ export const make: (params: {
   >(
     options: Options & GenerateObjectOptions<Tools, StructuredOutputSchema>
   ): Effect.Effect<
-    GenerateObjectResponse<Tools, StructuredOutputSchema["Type"], ExtractEncodedToolParameters<Options>>,
+    GenerateObjectResponse<Tools, StructuredOutputSchema["Type"], ExtractToolParametersMode<Options>>,
     ExtractError<Options>,
     ExtractServices<Options> | StructuredOutputSchema["DecodingServices"]
   > => {
@@ -1783,7 +1783,7 @@ export const generateText: {
   >(
     options: Options & GenerateTextOptions<Tools> & { readonly toolkit: ToolkitInput<Tools> }
   ): Effect.Effect<
-    GenerateTextResponse<Tools, ExtractEncodedToolParameters<Options>>,
+    GenerateTextResponse<Tools, ExtractToolParametersMode<Options>>,
     ExtractError<Options>,
     LanguageModel | ExtractServices<Options>
   >
@@ -1795,7 +1795,7 @@ export const generateText: {
   >(
     options: Options & GenerateTextOptions<ExtractTools<Options>> & { readonly toolkit: Options["toolkit"] }
   ): Effect.Effect<
-    GenerateTextResponse<ExtractTools<Options>, ExtractEncodedToolParameters<Options>>,
+    GenerateTextResponse<ExtractTools<Options>, ExtractToolParametersMode<Options>>,
     ExtractError<Options>,
     ExtractServices<Options> | LanguageModel
   >
@@ -1864,7 +1864,7 @@ export const generateObject = <
   GenerateObjectResponse<
     ExtractTools<Options>,
     StructuredOutputSchema["Type"],
-    ExtractEncodedToolParameters<Options>
+    ExtractToolParametersMode<Options>
   >,
   ExtractError<Options>,
   ExtractServices<Options> | StructuredOutputSchema["DecodingServices"] | LanguageModel
@@ -1931,7 +1931,7 @@ export const streamText: {
   >(
     options: Options & GenerateTextOptions<Tools> & { readonly toolkit: ToolkitInput<Tools> }
   ): Stream.Stream<
-    Response.StreamPart<Tools, ExtractEncodedToolParameters<Options>>,
+    Response.StreamPart<Tools, ExtractToolParametersMode<Options>>,
     ExtractError<Options>,
     ExtractServices<Options> | LanguageModel
   >
@@ -1943,7 +1943,7 @@ export const streamText: {
   >(
     options: Options & GenerateTextOptions<ExtractTools<Options>> & { readonly toolkit: Options["toolkit"] }
   ): Stream.Stream<
-    Response.StreamPart<ExtractTools<Options>, ExtractEncodedToolParameters<Options>>,
+    Response.StreamPart<ExtractTools<Options>, ExtractToolParametersMode<Options>>,
     ExtractError<Options>,
     ExtractServices<Options> | LanguageModel
   >

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -366,7 +366,7 @@ export type ToolChoice<ToolName extends string> =
  */
 export class GenerateTextResponse<
   Tools extends Record<string, Tool.Any>,
-  EncodedToolParameters extends boolean = false
+  EncodedToolParameters extends Response.ToolParametersMode = false
 > {
   readonly content: Array<Response.Part<Tools, EncodedToolParameters>>
 
@@ -476,7 +476,7 @@ export class GenerateTextResponse<
 export class GenerateObjectResponse<
   Tools extends Record<string, Tool.Any>,
   A,
-  EncodedToolParameters extends boolean = false
+  EncodedToolParameters extends Response.ToolParametersMode = false
 > extends GenerateTextResponse<Tools, EncodedToolParameters> {
   /**
    * The parsed structured object that conforms to the provided schema.
@@ -558,8 +558,15 @@ export type ExtractTools<Options> = Options extends {
   : {}
 
 /**
- * Utility type that determines whether language model responses contain
- * encoded tool call parameters.
+ * Utility type that determines how tool call parameters are typed on language
+ * model response parts.
+ *
+ * **Details**
+ *
+ * When tool call resolution is disabled, tool call parts preserve the encoded
+ * parameters. When tool call resolution is enabled, transport decode keeps the
+ * parameters opaque (typed as `unknown`) and `Toolkit` is the single authority
+ * for parameter validation.
  *
  * @category utility types
  * @since 4.0.0
@@ -567,7 +574,7 @@ export type ExtractTools<Options> = Options extends {
 export type ExtractEncodedToolParameters<Options> = Options extends {
   readonly disableToolCallResolution: true
 } ? true
-  : false
+  : "opaque"
 
 type ExtractErrorFromToolkitOption<ToolkitValue, DisableToolCallResolution extends boolean> = ToolkitValue extends
   Toolkit.WithHandler<infer Tools> ?
@@ -860,7 +867,7 @@ export const make: (params: {
   >(
     options: Options & GenerateObjectOptions<Tools, StructuredOutputSchema>
   ): Effect.Effect<
-    GenerateObjectResponse<Tools, StructuredOutputSchema["Type"]>,
+    GenerateObjectResponse<Tools, StructuredOutputSchema["Type"], ExtractEncodedToolParameters<Options>>,
     ExtractError<Options>,
     ExtractServices<Options> | StructuredOutputSchema["DecodingServices"]
   > => {
@@ -1212,6 +1219,7 @@ export const make: (params: {
     // Validates the complete response before tool handlers can perform side
     // effects
     const content = yield* Schema.decodeEffect(ResponseSchema)(rawContent)
+    yield* validateProviderExecutedToolCalls(toolkit, rawContent)
 
     // Resolve the generated tool calls. When the finish reason indicates an
     // incomplete response, handlers do not run and every executable tool call
@@ -1620,6 +1628,7 @@ export const make: (params: {
       Stream.runForEachArray(
         Effect.fnUntraced(function*(chunk) {
           const parts = (yield* decodeParts(chunk)) as ReadonlyArray<Response.StreamPart<Tools>>
+          yield* validateProviderExecutedToolCalls(toolkit, chunk)
           if (tracker) {
             for (const part of parts) {
               if (part.type === "response-metadata" && part.id) {
@@ -1703,7 +1712,7 @@ export const make: (params: {
 
   return {
     generateText: generateText as Service["generateText"],
-    generateObject,
+    generateObject: generateObject as Service["generateObject"],
     streamText: streamText as Service["streamText"]
   } as const
 })
@@ -1794,7 +1803,7 @@ export const generateText: {
     ExtractServices<Options> | LanguageModel
   >
 } = (options: GenerateTextOptions<any>): Effect.Effect<
-  GenerateTextResponse<any>,
+  GenerateTextResponse<any, any>,
   AiError.AiError,
   LanguageModel
 > =>
@@ -2369,6 +2378,31 @@ const makeToolkitWithOpaqueParameters = <Tools extends Record<string, Tool.Any>>
 ): Toolkit.Any =>
   Toolkit.make(
     ...Object.values(toolkit.tools).map((tool) => tool.setParameters(Schema.Unknown))
+  )
+
+// With tool call resolution enabled, transport decode keeps tool parameters
+// opaque so Toolkit can route validation failures through the tool's failure
+// mode. Provider-executed tool calls never reach Toolkit, so their parameters
+// are validated here as part of response validation.
+const validateProviderExecutedToolCalls = <Tools extends Record<string, Tool.Any>>(
+  toolkit: Toolkit.WithHandler<Tools>,
+  parts: ReadonlyArray<Response.PartEncoded | Response.StreamPartEncoded>
+): Effect.Effect<void, Schema.SchemaError> =>
+  Effect.forEach(
+    parts,
+    (part) => {
+      if (part.type !== "tool-call" || part.providerExecuted !== true) {
+        return Effect.void
+      }
+      const tool = toolkit.tools[part.name]
+      if (Predicate.isUndefined(tool) || !Schema.isSchema(tool.parametersSchema)) {
+        return Effect.void
+      }
+      return Effect.asVoid(
+        Schema.decodeUnknownEffect(tool.parametersSchema)(part.params)
+      ) as Effect.Effect<void, Schema.SchemaError>
+    },
+    { discard: true }
   )
 
 const resolveToolkit = <Tools extends Record<string, Tool.Any>, E, R>(

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -558,15 +558,8 @@ export type ExtractTools<Options> = Options extends {
   : {}
 
 /**
- * Utility type that determines how tool call parameters are typed on language
- * model response parts.
- *
- * **Details**
- *
- * When tool call resolution is disabled, tool call parts preserve the encoded
- * parameters. When tool call resolution is enabled, transport decode keeps the
- * parameters opaque (typed as `unknown`) and `Toolkit` is the single authority
- * for parameter validation.
+ * Resolves to `true` for encoded parameters when tool call resolution is
+ * disabled, otherwise `"opaque"`.
  *
  * @category utility types
  * @since 4.0.0
@@ -602,13 +595,8 @@ type ExtractServicesFromToolkitOption<ToolkitValue> = ToolkitValue extends Toolk
       | R
   : never
 
-// When tool call resolution is disabled, tool handlers never run and results
-// are never decoded, so those requirements are omitted. Provider packages
-// still normalize tool call parameters into their standard encoded form, so
-// parameter encoding services remain required. A bare `Toolkit` is matched
-// before the generic `Effect` branch so its `HandlersFor` requirement is also
-// omitted; toolkits supplied as arbitrary effects keep their resolution
-// requirements because the effect still runs.
+// Disabled resolution needs parameter encoding but not handlers or result
+// decoding. Match Toolkit before Effect to omit its handler requirement.
 type ExtractDisabledResolutionServicesFromToolkitOption<ToolkitValue> = ToolkitValue extends
   Toolkit.WithHandler<infer Tools> ? Tool.ParametersEncodingServices<Tools[keyof Tools]>
   : ToolkitValue extends Toolkit.Toolkit<infer Tools> ? Tool.ParametersEncodingServices<Tools[keyof Tools]>
@@ -1210,12 +1198,6 @@ export const make: (params: {
       }
     }
 
-    // Construct the response schema with the tools from the toolkit, keeping
-    // tool call parameters encoded when tool call resolution is disabled.
-    // When tool call resolution is enabled, tool parameters remain opaque so
-    // their validation happens in Toolkit, which uses the more specific
-    // ToolParameterValidationError and routes failures through the tool's
-    // failure mode.
     const ResponseSchema = Schema.mutable(Schema.Array(Response.Part(
       options.disableToolCallResolution === true
         ? makeToolkitWithEncodedParameters(toolkit)
@@ -1238,8 +1220,7 @@ export const make: (params: {
 
     const rawContent = yield* generateWithNonIncrementalFallback()
 
-    // Validates the complete response before tool handlers can perform side
-    // effects
+    // Validate before running tool handlers.
     const content = yield* Schema.decodeEffect(ResponseSchema)(rawContent)
     yield* validateProviderExecutedToolCalls(toolkit, rawContent)
 
@@ -1520,12 +1501,6 @@ export const make: (params: {
       }
     }
 
-    // Construct the response schema with the tools from the toolkit, keeping
-    // tool call parameters encoded when tool call resolution is disabled.
-    // When tool call resolution is enabled, tool parameters remain opaque so
-    // their validation happens in Toolkit, which uses the more specific
-    // ToolParameterValidationError and routes failures through the tool's
-    // failure mode instead of failing the stream.
     const ResponseSchema = Schema.NonEmptyArray(Response.StreamPart(
       options.disableToolCallResolution === true
         ? makeToolkitWithEncodedParameters(toolkit)
@@ -2402,10 +2377,7 @@ const makeToolkitWithOpaqueParameters = <Tools extends Record<string, Tool.Any>>
     ...Object.values(toolkit.tools).map((tool) => tool.setParameters(Schema.Unknown))
   )
 
-// With tool call resolution enabled, transport decode keeps tool parameters
-// opaque so Toolkit can route validation failures through the tool's failure
-// mode. Provider-executed tool calls never reach Toolkit, so their parameters
-// are validated here as part of response validation.
+// Provider-executed tools bypass Toolkit, so validate their parameters here.
 const validateProviderExecutedToolCalls = <Tools extends Record<string, Tool.Any>>(
   toolkit: Toolkit.WithHandler<Tools>,
   parts: ReadonlyArray<Response.PartEncoded | Response.StreamPartEncoded>

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -1182,9 +1182,15 @@ export const make: (params: {
     }
 
     // Construct the response schema with the tools from the toolkit, keeping
-    // tool call parameters encoded when tool call resolution is disabled
+    // tool call parameters encoded when tool call resolution is disabled.
+    // When tool call resolution is enabled, tool parameters remain opaque so
+    // their validation happens in Toolkit, which uses the more specific
+    // ToolParameterValidationError and routes failures through the tool's
+    // failure mode.
     const ResponseSchema = Schema.mutable(Schema.Array(Response.Part(
-      options.disableToolCallResolution === true ? makeToolkitWithEncodedParameters(toolkit) : toolkit
+      options.disableToolCallResolution === true
+        ? makeToolkitWithEncodedParameters(toolkit)
+        : makeToolkitWithOpaqueParameters(toolkit)
     )))
 
     // If tool call resolution is disabled, return the response without
@@ -1201,18 +1207,11 @@ export const make: (params: {
       return content as Array<Response.Part<Tools>>
     }
 
-    // Validates the complete response before tool handlers can perform side
-    // effects. Tool parameters remain opaque here so their validation keeps
-    // using Toolkit's more specific ToolParameterValidationError; rawContent
-    // is decoded a second time with ResponseSchema below to produce the
-    // typed response.
-    const PrevalidationSchema = Schema.mutable(
-      Schema.Array(Response.Part(makeToolkitWithOpaqueParameters(toolkit)))
-    )
-
     const rawContent = yield* generateWithNonIncrementalFallback()
 
-    yield* Schema.decodeEffect(PrevalidationSchema)(rawContent)
+    // Validates the complete response before tool handlers can perform side
+    // effects
+    const content = yield* Schema.decodeEffect(ResponseSchema)(rawContent)
 
     // Resolve the generated tool calls. When the finish reason indicates an
     // incomplete response, handlers do not run and every executable tool call
@@ -1239,8 +1238,6 @@ export const make: (params: {
         ),
         Stream.runCollect
       )
-
-    const content = yield* Schema.decodeEffect(ResponseSchema)(rawContent)
 
     if (tracker) {
       const responseMetadata = content.find((part) => part.type === "response-metadata")
@@ -1494,9 +1491,15 @@ export const make: (params: {
     }
 
     // Construct the response schema with the tools from the toolkit, keeping
-    // tool call parameters encoded when tool call resolution is disabled
+    // tool call parameters encoded when tool call resolution is disabled.
+    // When tool call resolution is enabled, tool parameters remain opaque so
+    // their validation happens in Toolkit, which uses the more specific
+    // ToolParameterValidationError and routes failures through the tool's
+    // failure mode instead of failing the stream.
     const ResponseSchema = Schema.NonEmptyArray(Response.StreamPart(
-      options.disableToolCallResolution === true ? makeToolkitWithEncodedParameters(toolkit) : toolkit
+      options.disableToolCallResolution === true
+        ? makeToolkitWithEncodedParameters(toolkit)
+        : makeToolkitWithOpaqueParameters(toolkit)
     ))
     const decodeParts = Schema.decodeEffect(ResponseSchema)
 
@@ -1616,7 +1619,7 @@ export const make: (params: {
     yield* streamWithNonIncrementalFallback().pipe(
       Stream.runForEachArray(
         Effect.fnUntraced(function*(chunk) {
-          const parts = yield* decodeParts(chunk)
+          const parts = (yield* decodeParts(chunk)) as ReadonlyArray<Response.StreamPart<Tools>>
           if (tracker) {
             for (const part of parts) {
               if (part.type === "response-metadata" && part.id) {

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -602,6 +602,23 @@ type ExtractServicesFromToolkitOption<ToolkitValue> = ToolkitValue extends Toolk
       | R
   : never
 
+// When tool call resolution is disabled, tool handlers never run and results
+// are never decoded, so those requirements are omitted. Provider packages
+// still normalize tool call parameters into their standard encoded form, so
+// parameter encoding services remain required. A bare `Toolkit` is matched
+// before the generic `Effect` branch so its `HandlersFor` requirement is also
+// omitted; toolkits supplied as arbitrary effects keep their resolution
+// requirements because the effect still runs.
+type ExtractDisabledResolutionServicesFromToolkitOption<ToolkitValue> = ToolkitValue extends
+  Toolkit.WithHandler<infer Tools> ? Tool.ParametersEncodingServices<Tools[keyof Tools]>
+  : ToolkitValue extends Toolkit.Toolkit<infer Tools> ? Tool.ParametersEncodingServices<Tools[keyof Tools]>
+  : ToolkitValue extends Effect.Effect<
+    Toolkit.WithHandler<infer Tools>,
+    infer _E,
+    infer R
+  > ? Tool.ParametersEncodingServices<Tools[keyof Tools]> | R
+  : never
+
 type ExtractToolkitResolutionError<ToolkitValue> = ToolkitValue extends Effect.Effect<
   Toolkit.WithHandler<infer _Tools>,
   infer E,
@@ -651,10 +668,13 @@ export type ExtractError<Options> = Options extends {
  */
 export type ExtractServices<Options> = Options extends {
   readonly disableToolCallResolution: true
-} ? never
+} ? Options extends {
+    readonly toolkit: infer ToolkitValue
+  } ? ExtractDisabledResolutionServicesFromToolkitOption<Exclude<ToolkitValue, undefined>>
+  : never
   : Options extends {
-    readonly toolkit: infer Toolkit
-  } ? ExtractServicesFromToolkitOption<Exclude<Toolkit, undefined>>
+    readonly toolkit: infer ToolkitValue
+  } ? ExtractServicesFromToolkitOption<Exclude<ToolkitValue, undefined>>
   : never
 
 // =============================================================================

--- a/packages/effect/src/unstable/ai/Response.ts
+++ b/packages/effect/src/unstable/ai/Response.ts
@@ -226,11 +226,11 @@ export const AllParts = <T extends Toolkit.Any | Toolkit.WithHandler<any>>(
  */
 export type Part<
   Tools extends Record<string, Tool.Any>,
-  EncodedToolParameters extends ToolParametersMode = false
+  ParametersMode extends ToolParametersMode = "decoded"
 > =
   | TextPart
   | ReasoningPart
-  | ToolCallParts<Tools, EncodedToolParameters>
+  | ToolCallParts<Tools, ParametersMode>
   | ToolResultParts<Tools>
   | ToolApprovalRequestPart
   | FilePart
@@ -307,7 +307,7 @@ export const Part = <T extends Toolkit.Any | Toolkit.WithHandler<any>>(
  */
 export type StreamPart<
   Tools extends Record<string, Tool.Any>,
-  EncodedToolParameters extends ToolParametersMode = false
+  ParametersMode extends ToolParametersMode = "decoded"
 > =
   | TextStartPart
   | TextDeltaPart
@@ -318,7 +318,7 @@ export type StreamPart<
   | ToolParamsStartPart
   | ToolParamsDeltaPart
   | ToolParamsEndPart
-  | ToolCallParts<Tools, EncodedToolParameters>
+  | ToolCallParts<Tools, ParametersMode>
   | ToolResultParts<Tools>
   | ToolApprovalRequestPart
   | FilePart
@@ -410,26 +410,25 @@ export const StreamPart = <T extends Toolkit.Any | Toolkit.WithHandler<any>>(
  */
 export type ToolCallParts<
   Tools extends Record<string, Tool.Any>,
-  EncodedParameters extends ToolParametersMode = false
-> = ToolCallPartForName<Tools, EncodedParameters, keyof Tools>
+  ParametersMode extends ToolParametersMode = "decoded"
+> = ToolCallPartForName<Tools, ParametersMode, keyof Tools>
 
 /**
- * Controls tool parameter types: decoded (`false`), encoded (`true`), or
- * `unknown` (`"opaque"`).
+ * Controls whether tool parameters are decoded, encoded, or opaque.
  *
  * @category utility types
  * @since 4.0.0
  */
-export type ToolParametersMode = boolean | "opaque"
+export type ToolParametersMode = "decoded" | "encoded" | "opaque"
 
 type ToolCallPartForName<
   Tools extends Record<string, Tool.Any>,
-  EncodedParameters extends ToolParametersMode,
+  ParametersMode extends ToolParametersMode,
   Name extends keyof Tools
 > = Name extends string ? ToolCallPart<
     Name,
-    EncodedParameters extends true ? Tool.ParametersEncoded<Tools[Name]>
-      : EncodedParameters extends "opaque" ? unknown
+    ParametersMode extends "encoded" ? Tool.ParametersEncoded<Tools[Name]>
+      : ParametersMode extends "opaque" ? unknown
       : Tool.Parameters<Tools[Name]>
   >
   : never

--- a/packages/effect/src/unstable/ai/Response.ts
+++ b/packages/effect/src/unstable/ai/Response.ts
@@ -414,15 +414,8 @@ export type ToolCallParts<
 > = ToolCallPartForName<Tools, EncodedParameters, keyof Tools>
 
 /**
- * Utility type that determines how tool call parameters are typed on response
- * parts.
- *
- * **Details**
- *
- * - `false`: parameters are fully decoded via the tool's parameter schema
- * - `true`: parameters are typed in their encoded form
- * - `"opaque"`: parameters are typed as `unknown` because transport decode
- *   leaves them untouched and validation happens in `Toolkit`
+ * Controls tool parameter types: decoded (`false`), encoded (`true`), or
+ * `unknown` (`"opaque"`).
  *
  * @category utility types
  * @since 4.0.0

--- a/packages/effect/src/unstable/ai/Response.ts
+++ b/packages/effect/src/unstable/ai/Response.ts
@@ -226,7 +226,7 @@ export const AllParts = <T extends Toolkit.Any | Toolkit.WithHandler<any>>(
  */
 export type Part<
   Tools extends Record<string, Tool.Any>,
-  EncodedToolParameters extends boolean = false
+  EncodedToolParameters extends ToolParametersMode = false
 > =
   | TextPart
   | ReasoningPart
@@ -307,7 +307,7 @@ export const Part = <T extends Toolkit.Any | Toolkit.WithHandler<any>>(
  */
 export type StreamPart<
   Tools extends Record<string, Tool.Any>,
-  EncodedToolParameters extends boolean = false
+  EncodedToolParameters extends ToolParametersMode = false
 > =
   | TextStartPart
   | TextDeltaPart
@@ -410,16 +410,34 @@ export const StreamPart = <T extends Toolkit.Any | Toolkit.WithHandler<any>>(
  */
 export type ToolCallParts<
   Tools extends Record<string, Tool.Any>,
-  EncodedParameters extends boolean = false
+  EncodedParameters extends ToolParametersMode = false
 > = ToolCallPartForName<Tools, EncodedParameters, keyof Tools>
+
+/**
+ * Utility type that determines how tool call parameters are typed on response
+ * parts.
+ *
+ * **Details**
+ *
+ * - `false`: parameters are fully decoded via the tool's parameter schema
+ * - `true`: parameters are typed in their encoded form
+ * - `"opaque"`: parameters are typed as `unknown` because transport decode
+ *   leaves them untouched and validation happens in `Toolkit`
+ *
+ * @category utility types
+ * @since 4.0.0
+ */
+export type ToolParametersMode = boolean | "opaque"
 
 type ToolCallPartForName<
   Tools extends Record<string, Tool.Any>,
-  EncodedParameters extends boolean,
+  EncodedParameters extends ToolParametersMode,
   Name extends keyof Tools
 > = Name extends string ? ToolCallPart<
     Name,
-    EncodedParameters extends true ? Tool.ParametersEncoded<Tools[Name]> : Tool.Parameters<Tools[Name]>
+    EncodedParameters extends true ? Tool.ParametersEncoded<Tools[Name]>
+      : EncodedParameters extends "opaque" ? unknown
+      : Tool.Parameters<Tools[Name]>
   >
   : never
 

--- a/packages/effect/src/unstable/ai/Tool.ts
+++ b/packages/effect/src/unstable/ai/Tool.ts
@@ -933,14 +933,7 @@ export type ResultDecodingServices<T> = T extends Tool<
   : never
 
 /**
- * A utility type to extract the requirements needed to encode the parameters
- * of a `Tool` call.
- *
- * **Details**
- *
- * Provider packages normalize valid tool call parameters into the tool's
- * standard encoded form before tool call resolution, which requires the
- * parameter schema's encoding services.
+ * Extracts the services required to encode tool parameters.
  *
  * @category utility types
  * @since 4.0.0

--- a/packages/effect/src/unstable/ai/Tool.ts
+++ b/packages/effect/src/unstable/ai/Tool.ts
@@ -933,6 +933,26 @@ export type ResultDecodingServices<T> = T extends Tool<
   : never
 
 /**
+ * A utility type to extract the requirements needed to encode the parameters
+ * of a `Tool` call.
+ *
+ * **Details**
+ *
+ * Provider packages normalize valid tool call parameters into the tool's
+ * standard encoded form before tool call resolution, which requires the
+ * parameter schema's encoding services.
+ *
+ * @category utility types
+ * @since 4.0.0
+ */
+export type ParametersEncodingServices<T> = T extends Tool<
+  infer _Name,
+  infer _Config,
+  infer _Requirements
+> ? _Config["parameters"]["EncodingServices"]
+  : never
+
+/**
  * Represents an `Tool` that has been implemented within the application.
  *
  * @category models

--- a/packages/effect/src/unstable/ai/Toolkit.ts
+++ b/packages/effect/src/unstable/ai/Toolkit.ts
@@ -19,6 +19,7 @@ import * as InternalRecord from "../../internal/record.ts"
 import * as Layer from "../../Layer.ts"
 import * as Predicate from "../../Predicate.ts"
 import * as Queue from "../../Queue.ts"
+import * as Result from "../../Result.ts"
 import * as Schema from "../../Schema.ts"
 import type * as Scope from "../../Scope.ts"
 import * as Stream from "../../Stream.ts"
@@ -293,20 +294,47 @@ const Proto = {
         // Fetch cached schemas / handlers for the tool
         const schemas = getSchemas(tool)
 
-        // Decode the tool call parameters which will be passed to the handler
-        const decodedParams = yield* schemas.decodeParameters(params).pipe(
-          Effect.mapError((cause) =>
-            AiError.make({
-              module: "Toolkit",
-              method: `${name}.handle`,
-              reason: new AiError.ToolParameterValidationError({
-                toolName: name,
-                toolParams: params,
-                description: cause.message
+        const encodeResult = (result: any) =>
+          schemas.encodeResult(result).pipe(
+            Effect.mapError((cause) =>
+              AiError.make({
+                module: "Toolkit",
+                method: `${name}.handle`,
+                reason: new AiError.ToolResultEncodingError({
+                  toolName: name,
+                  toolResult: result,
+                  description: cause.message
+                })
               })
-            })
+            )
           )
-        )
+
+        // Decode the tool call parameters which will be passed to the handler.
+        // When the tool's failure mode is "return", a validation failure is
+        // surfaced as a failed tool result instead of failing the effect.
+        const decodedParamsResult = yield* Effect.result(schemas.decodeParameters(params))
+        if (Result.isFailure(decodedParamsResult)) {
+          const error = AiError.make({
+            module: "Toolkit",
+            method: `${name}.handle`,
+            reason: new AiError.ToolParameterValidationError({
+              toolName: name,
+              description: decodedParamsResult.failure.message
+            })
+          })
+          if (tool.failureMode === "error") {
+            return yield* error
+          }
+          return Stream.fromEffect(
+            Effect.map(encodeResult(error), (encodedResult) => ({
+              result: error,
+              isFailure: true,
+              preliminary: false,
+              encodedResult
+            }))
+          ) satisfies Stream.Stream<Tool.HandlerResult<any>, any>
+        }
+        const decodedParams = decodedParamsResult.success
 
         // Setup the handler context
         const queue = yield* Queue.make<{
@@ -333,21 +361,6 @@ const Proto = {
           }),
           Effect.forkChild
         )
-
-        const encodeResult = (result: any) =>
-          schemas.encodeResult(result).pipe(
-            Effect.mapError((cause) =>
-              AiError.make({
-                module: "Toolkit",
-                method: `${name}.handle`,
-                reason: new AiError.ToolResultEncodingError({
-                  toolName: name,
-                  toolResult: result,
-                  description: cause.message
-                })
-              })
-            )
-          )
 
         const normalizeError = (error: unknown) => {
           // Schema errors indicate handler returned invalid data

--- a/packages/effect/src/unstable/ai/Toolkit.ts
+++ b/packages/effect/src/unstable/ai/Toolkit.ts
@@ -309,9 +309,6 @@ const Proto = {
             )
           )
 
-        // Decode the tool call parameters which will be passed to the handler.
-        // When the tool's failure mode is "return", a validation failure is
-        // surfaced as a failed tool result instead of failing the effect.
         const decodedParamsResult = yield* Effect.result(schemas.decodeParameters(params))
         if (Result.isFailure(decodedParamsResult)) {
           const error = AiError.make({

--- a/packages/effect/test/unstable/ai/AiError.test.ts
+++ b/packages/effect/test/unstable/ai/AiError.test.ts
@@ -270,7 +270,6 @@ describe("AiError", () => {
       it("should be retryable", () => {
         const error = new AiError.ToolParameterValidationError({
           toolName: "GetWeather",
-          toolParams: { location: "NYC" },
           description: "Expected string"
         })
         assert.isTrue(error.isRetryable)
@@ -279,7 +278,6 @@ describe("AiError", () => {
       it("should format message with tool name", () => {
         const error = new AiError.ToolParameterValidationError({
           toolName: "GetWeather",
-          toolParams: { location: "NYC" },
           description: "Expected string"
         })
         assert.match(error.message, /Invalid parameters for tool 'GetWeather'/)
@@ -288,26 +286,23 @@ describe("AiError", () => {
       it("should format message with validation message", () => {
         const error = new AiError.ToolParameterValidationError({
           toolName: "GetWeather",
-          toolParams: { location: 123 },
           description: "Expected string, got number"
         })
         assert.match(error.message, /Expected string, got number/)
       })
 
-      it("should store tool params", () => {
-        const params = { location: 123 }
+      it("should construct when validated params contain non-JSON values", () => {
         const error = new AiError.ToolParameterValidationError({
           toolName: "GetWeather",
-          toolParams: params,
-          description: "Expected string"
+          description: `Expected finite number, got NaN at ["city"]`
         })
-        assert.deepStrictEqual(error.toolParams, params)
+        assert.strictEqual(error._tag, "ToolParameterValidationError")
+        assert.match(error.message, /NaN/)
       })
 
       it("should have _tag set correctly", () => {
         const error = new AiError.ToolParameterValidationError({
           toolName: "Test",
-          toolParams: {},
           description: "Error"
         })
         assert.strictEqual(error._tag, "ToolParameterValidationError")
@@ -768,7 +763,6 @@ describe("AiError", () => {
       Effect.gen(function*() {
         const error = new AiError.ToolParameterValidationError({
           toolName: "GetWeather",
-          toolParams: { location: 123 },
           description: "Expected string"
         })
         const encoded = yield* Schema.encodeEffect(AiError.ToolParameterValidationError)(error)
@@ -854,7 +848,6 @@ describe("AiError", () => {
 
         const paramError: AiError.AiErrorReason = new AiError.ToolParameterValidationError({
           toolName: "Test",
-          toolParams: {},
           description: "Error"
         })
         const paramEncoded = yield* Schema.encodeEffect(AiError.AiErrorReason)(paramError)

--- a/packages/effect/test/unstable/ai/LanguageModel.test.ts
+++ b/packages/effect/test/unstable/ai/LanguageModel.test.ts
@@ -225,6 +225,99 @@ describe("LanguageModel", () => {
         }),
         Effect.provide(TransformToolkitLayer)
       ))
+
+    it.effect("preserves encoded tool parameters when tool call resolution is enabled", () =>
+      Effect.gen(function*() {
+        const response = yield* LanguageModel.generateText({
+          prompt: [],
+          toolkit: TransformToolkit
+        })
+
+        const toolCall = response.toolCalls[0]!
+        strictEqual(toolCall.params, "21")
+
+        const toolResult = response.toolResults[0]!
+        strictEqual(toolResult.isFailure, false)
+        strictEqual(toolResult.result, 42)
+      }).pipe(
+        TestUtils.withLanguageModel({
+          generateText: [{
+            type: "tool-call",
+            id: "tool-transform",
+            name: "TransformTool",
+            params: "21"
+          }]
+        }),
+        Effect.provide(TransformToolkitLayer)
+      ))
+
+    it.effect("validates provider-executed tool call parameters", () =>
+      Effect.gen(function*() {
+        const calls = yield* Ref.make(0)
+        const handlers = MyToolkit.toLayer({
+          MyTool: () =>
+            Ref.update(calls, (n) => n + 1).pipe(
+              Effect.as({ testSuccess: "test-success" })
+            )
+        })
+
+        const error = yield* LanguageModel.generateText({
+          prompt: [],
+          toolkit: MyToolkit
+        }).pipe(
+          TestUtils.withLanguageModel({
+            generateText: [
+              {
+                type: "tool-call",
+                id: "tool-provider-executed",
+                name: "MyTool",
+                providerExecuted: true,
+                params: { testParam: 123 }
+              } as any,
+              finishPart
+            ]
+          }),
+          Effect.provide(handlers),
+          Effect.flip
+        )
+
+        strictEqual(error.reason._tag, "InvalidOutputError")
+        strictEqual(yield* Ref.get(calls), 0)
+      }))
+
+    it.effect("accepts provider-executed tool calls with valid parameters", () =>
+      Effect.gen(function*() {
+        const calls = yield* Ref.make(0)
+        const handlers = MyToolkit.toLayer({
+          MyTool: () =>
+            Ref.update(calls, (n) => n + 1).pipe(
+              Effect.as({ testSuccess: "test-success" })
+            )
+        })
+
+        const response = yield* LanguageModel.generateText({
+          prompt: [],
+          toolkit: MyToolkit
+        }).pipe(
+          TestUtils.withLanguageModel({
+            generateText: [
+              {
+                type: "tool-call",
+                id: "tool-provider-executed",
+                name: "MyTool",
+                providerExecuted: true,
+                params: { testParam: "test-param" }
+              },
+              finishPart
+            ]
+          }),
+          Effect.provide(handlers)
+        )
+
+        strictEqual(response.toolCalls.length, 1)
+        deepStrictEqual(response.toolCalls[0]!.params, { testParam: "test-param" })
+        strictEqual(yield* Ref.get(calls), 0)
+      }))
   })
 
   describe("streamText", () => {
@@ -242,7 +335,7 @@ describe("LanguageModel", () => {
             )
         })
         const providerQueue = yield* Queue.make<Response.StreamPartEncoded, Cause.Done>()
-        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof MyToolkit>>> = []
+        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof MyToolkit>, "opaque">> = []
 
         const fiber = yield* LanguageModel.streamText({
           prompt: [],
@@ -383,7 +476,7 @@ describe("LanguageModel", () => {
 
     it.effect("keeps results of handlers that completed before an incomplete finish", () =>
       Effect.gen(function*() {
-        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof MyToolkit>>> = []
+        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof MyToolkit>, "opaque">> = []
         const toolCallObserved = yield* Latch.make()
         const resultObserved = yield* Latch.make()
         const providerQueue = yield* Queue.make<Response.StreamPartEncoded, Cause.Done>()
@@ -439,7 +532,7 @@ describe("LanguageModel", () => {
 
     it.effect("does not synthesize results for tool calls awaiting approval on an incomplete finish", () =>
       Effect.gen(function*() {
-        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof ApprovalToolkit>>> = []
+        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof ApprovalToolkit>, "opaque">> = []
         const toolCallObserved = yield* Latch.make()
         const approvalObserved = yield* Latch.make()
         const providerQueue = yield* Queue.make<Response.StreamPartEncoded, Cause.Done>()
@@ -541,9 +634,73 @@ describe("LanguageModel", () => {
         Effect.provide(TransformToolkitLayer)
       ))
 
+    it.effect("preserves encoded tool parameters when tool call resolution is enabled", () =>
+      Effect.gen(function*() {
+        const parts = yield* LanguageModel.streamText({
+          prompt: [],
+          toolkit: TransformToolkit
+        }).pipe(Stream.runCollect)
+
+        const toolCall = parts.find((part) => part.type === "tool-call")!
+        strictEqual(toolCall.params, "21")
+
+        const toolResult = parts.find((part) => part.type === "tool-result")!
+        strictEqual(toolResult.isFailure, false)
+        strictEqual(toolResult.result, 42)
+      }).pipe(
+        TestUtils.withLanguageModel({
+          streamText: [
+            {
+              type: "tool-call",
+              id: "tool-transform",
+              name: "TransformTool",
+              params: "21"
+            },
+            finishPart
+          ]
+        }),
+        Effect.provide(TransformToolkitLayer)
+      ))
+
+    it.effect("validates provider-executed tool call parameters", () =>
+      Effect.gen(function*() {
+        const calls = yield* Ref.make(0)
+        const handlers = MyToolkit.toLayer({
+          MyTool: () =>
+            Ref.update(calls, (n) => n + 1).pipe(
+              Effect.as({ testSuccess: "test-success" })
+            )
+        })
+
+        const error = yield* LanguageModel.streamText({
+          prompt: [],
+          toolkit: MyToolkit
+        }).pipe(
+          Stream.runDrain,
+          TestUtils.withLanguageModel({
+            streamText: [
+              {
+                type: "tool-call",
+                id: "tool-provider-executed",
+                name: "MyTool",
+                providerExecuted: true,
+                params: { testParam: 123 }
+              } as any,
+              finishPart
+            ]
+          }),
+          Effect.provide(handlers),
+          Effect.flip
+        )
+
+        strictEqual(error._tag, "AiError")
+        strictEqual((error as AiError.AiError).reason._tag, "InvalidOutputError")
+        strictEqual(yield* Ref.get(calls), 0)
+      }))
+
     it.effect("executes tool handlers once the stream moves past the tool call", () =>
       Effect.gen(function*() {
-        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof MyToolkit>>> = []
+        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof MyToolkit>, "opaque">> = []
         const toolCallObserved = yield* Latch.make()
         const handlerCalled = yield* Latch.make()
         const providerQueue = yield* Queue.make<Response.StreamPartEncoded, Cause.Done>()
@@ -757,7 +914,7 @@ describe("LanguageModel", () => {
 
     it.effect("emits finish after resolved tool results", () =>
       Effect.gen(function*() {
-        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof MyToolkit>>> = []
+        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof MyToolkit>, "opaque">> = []
         const latch = yield* Latch.make()
 
         const fiber = yield* LanguageModel.streamText({
@@ -1847,7 +2004,7 @@ describe("LanguageModel", () => {
   describe("tool approval", () => {
     it.effect("emits tool-approval-request when tool has needsApproval: true", () =>
       Effect.gen(function*() {
-        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof ApprovalToolkit>>> = []
+        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof ApprovalToolkit>, "opaque">> = []
 
         const toolCallId = "call-123"
         const toolName = "ApprovalTool"
@@ -2290,7 +2447,7 @@ describe("LanguageModel", () => {
 
     it.effect("dynamic needsApproval returns true when condition met", () =>
       Effect.gen(function*() {
-        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof ApprovalToolkit>>> = []
+        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof ApprovalToolkit>, "opaque">> = []
 
         const toolCallId = "call-dyn-1"
 
@@ -2326,7 +2483,7 @@ describe("LanguageModel", () => {
 
     it.effect("dynamic needsApproval returns false when condition not met", () =>
       Effect.gen(function*() {
-        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof ApprovalToolkit>>> = []
+        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof ApprovalToolkit>, "opaque">> = []
 
         const toolCallId = "call-dyn-2"
 
@@ -2362,7 +2519,7 @@ describe("LanguageModel", () => {
 
     it.effect("tool without needsApproval executes normally", () =>
       Effect.gen(function*() {
-        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof MyToolkit>>> = []
+        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof MyToolkit>, "opaque">> = []
 
         const toolCallId = "call-normal"
         const latch = yield* Latch.make()
@@ -2556,7 +2713,7 @@ describe("LanguageModel", () => {
       Effect.gen(function*() {
         const toolCallId = "call-emit"
         const approvalId = "approval-emit"
-        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof ApprovalToolkit>>> = []
+        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof ApprovalToolkit>, "opaque">> = []
 
         const prompt: Array<Prompt.Message> = [
           Prompt.assistantMessage({

--- a/packages/effect/test/unstable/ai/LanguageModel.test.ts
+++ b/packages/effect/test/unstable/ai/LanguageModel.test.ts
@@ -30,6 +30,15 @@ const TransformToolkitLayer = TransformToolkit.toLayer({
   TransformTool: (value) => Effect.succeed(value * 2)
 })
 
+const ReturnModeTool = Tool.make("ReturnModeTool", {
+  failureMode: "return",
+  parameters: Schema.Struct({ testParam: Schema.String }),
+  success: Schema.Struct({ testSuccess: Schema.String }),
+  failure: Schema.Struct({ testFailure: Schema.String })
+})
+
+const ReturnModeToolkit = Toolkit.make(ReturnModeTool)
+
 const ApprovalTool = Tool.make("ApprovalTool", {
   parameters: Schema.Struct({ action: Schema.String }),
   success: Schema.Struct({ result: Schema.String }),
@@ -669,6 +678,80 @@ describe("LanguageModel", () => {
 
         strictEqual(error._tag, "AiError")
         strictEqual((error as AiError.AiError).reason._tag, "InvalidOutputError")
+        strictEqual(yield* Ref.get(calls), 0)
+      }))
+
+    it.effect("emits a failed tool result and keeps streaming when tool params are invalid and failure mode is return", () =>
+      Effect.gen(function*() {
+        const calls = yield* Ref.make(0)
+        const handlers = ReturnModeToolkit.toLayer({
+          ReturnModeTool: () =>
+            Ref.update(calls, (n) => n + 1).pipe(
+              Effect.as({ testSuccess: "test-success" })
+            )
+        })
+
+        const parts = yield* LanguageModel.streamText({
+          prompt: [],
+          toolkit: ReturnModeToolkit
+        }).pipe(
+          Stream.runCollect,
+          TestUtils.withLanguageModel({
+            streamText: [
+              {
+                type: "tool-call",
+                id: "tool-invalid-params",
+                name: "ReturnModeTool",
+                params: { testParam: 123 }
+              } as any,
+              finishPart
+            ]
+          }),
+          Effect.provide(handlers)
+        )
+
+        const toolResults = parts.filter((part) => part.type === "tool-result")
+        strictEqual(toolResults.length, 1)
+        strictEqual(toolResults[0].isFailure, true)
+        const result = toolResults[0].result as AiError.AiError
+        strictEqual(result._tag, "AiError")
+        strictEqual(result.reason._tag, "ToolParameterValidationError")
+        strictEqual(parts.some((part) => part.type === "finish"), true)
+        strictEqual(yield* Ref.get(calls), 0)
+      }))
+
+    it.effect("fails the stream when tool params are invalid and failure mode is error", () =>
+      Effect.gen(function*() {
+        const calls = yield* Ref.make(0)
+        const handlers = MyToolkit.toLayer({
+          MyTool: () =>
+            Ref.update(calls, (n) => n + 1).pipe(
+              Effect.as({ testSuccess: "test-success" })
+            )
+        })
+
+        const error = yield* LanguageModel.streamText({
+          prompt: [],
+          toolkit: MyToolkit
+        }).pipe(
+          Stream.runDrain,
+          TestUtils.withLanguageModel({
+            streamText: [
+              {
+                type: "tool-call",
+                id: "tool-invalid-params",
+                name: "MyTool",
+                params: { testParam: 123 }
+              } as any,
+              finishPart
+            ]
+          }),
+          Effect.provide(handlers),
+          Effect.flip
+        )
+
+        strictEqual(error._tag, "AiError")
+        strictEqual((error as AiError.AiError).reason._tag, "ToolParameterValidationError")
         strictEqual(yield* Ref.get(calls), 0)
       }))
 

--- a/packages/effect/test/unstable/ai/Tool.test.ts
+++ b/packages/effect/test/unstable/ai/Tool.test.ts
@@ -158,7 +158,7 @@ describe("Tool", () => {
         deepStrictEqual(response, toolResult)
       }))
 
-    it.effect("should raise an error when tool call parameters are invalid", () =>
+    it.effect("should return a failed tool result when tool call parameters are invalid and failure mode is return", () =>
       Effect.gen(function*() {
         const toolkit = Toolkit.make(FailureModeReturn)
 
@@ -182,6 +182,96 @@ describe("Tool", () => {
               params: {}
             }]
           }),
+          Effect.provide(handlers)
+        )
+
+        const description = `Missing key\n  at ["testParam"]`
+        deepStrictEqual(response.toolResults, [
+          Response.toolResultPart({
+            id: toolCallId,
+            name: toolName,
+            isFailure: true,
+            providerExecuted: false,
+            preliminary: false,
+            result: AiError.make({
+              module: "Toolkit",
+              method: "FailureModeReturn.handle",
+              reason: new AiError.ToolParameterValidationError({
+                toolName,
+                description
+              })
+            }),
+            encodedResult: {
+              _tag: "AiError",
+              module: "Toolkit",
+              method: "FailureModeReturn.handle",
+              reason: {
+                _tag: "ToolParameterValidationError",
+                toolName,
+                description
+              }
+            }
+          })
+        ])
+      }))
+
+    it.effect("should return a failed tool result when tool call parameters contain NaN and failure mode is return", () =>
+      Effect.gen(function*() {
+        const toolkit = Toolkit.make(FailureModeReturn)
+
+        const handlers = toolkit.toLayer({
+          FailureModeReturn: () => Effect.succeed({ testSuccess: "unused" })
+        })
+
+        const toolCallId = "tool-123"
+        const toolName = "FailureModeReturn"
+
+        const response = yield* LanguageModel.generateText({
+          prompt: "Test",
+          toolkit
+        }).pipe(
+          TestUtils.withLanguageModel({
+            generateText: [{
+              type: "tool-call",
+              id: toolCallId,
+              name: toolName,
+              params: { testParam: NaN }
+            }]
+          }),
+          Effect.provide(handlers)
+        )
+
+        strictEqual(response.toolResults.length, 1)
+        const toolResult = response.toolResults[0]
+        strictEqual(toolResult.isFailure, true)
+        const result = toolResult.result as AiError.AiError
+        strictEqual(result._tag, "AiError")
+        strictEqual(result.reason._tag, "ToolParameterValidationError")
+      }))
+
+    it.effect("should raise an error when tool call parameters are invalid and failure mode is error", () =>
+      Effect.gen(function*() {
+        const toolkit = Toolkit.make(FailureModeError)
+
+        const handlers = toolkit.toLayer({
+          FailureModeError: () => Effect.succeed({ testSuccess: "unused" })
+        })
+
+        const toolCallId = "tool-123"
+        const toolName = "FailureModeError"
+
+        const response = yield* LanguageModel.generateText({
+          prompt: "Test",
+          toolkit
+        }).pipe(
+          TestUtils.withLanguageModel({
+            generateText: [{
+              type: "tool-call",
+              id: toolCallId,
+              name: toolName,
+              params: { testParam: NaN }
+            }]
+          }),
           Effect.provide(handlers),
           Effect.flip
         )
@@ -190,11 +280,10 @@ describe("Tool", () => {
           response,
           AiError.make({
             module: "Toolkit",
-            method: "FailureModeReturn.handle",
+            method: "FailureModeError.handle",
             reason: new AiError.ToolParameterValidationError({
-              toolName: "FailureModeReturn",
-              toolParams: {},
-              description: `Missing key\n  at ["testParam"]`
+              toolName: "FailureModeError",
+              description: `Expected string\n  at ["testParam"]`
             })
           })
         )
@@ -870,7 +959,7 @@ describe("Tool", () => {
         deepStrictEqual(response, toolResult)
       }))
 
-    it.effect("should raise an error when tool call parameters are invalid", () =>
+    it.effect("should return a failed tool result when tool call parameters are invalid and failure mode is return", () =>
       Effect.gen(function*() {
         const tool = HandlerRequired({
           failureMode: "return",
@@ -902,22 +991,37 @@ describe("Tool", () => {
               }
             ]
           }),
-          Effect.provide(handlers),
-          Effect.flip
+          Effect.provide(handlers)
         )
 
-        deepStrictEqual(
-          response,
-          AiError.make({
-            module: "Toolkit",
-            method: "HandlerRequired.handle",
-            reason: new AiError.ToolParameterValidationError({
-              toolName: "HandlerRequired",
-              toolParams: {},
-              description: `Missing key\n  at ["testParam"]`
-            })
+        const description = `Missing key\n  at ["testParam"]`
+        deepStrictEqual(response.toolResults, [
+          Response.toolResultPart({
+            id: toolCallId,
+            name: tool.name,
+            isFailure: true,
+            providerExecuted: false,
+            preliminary: false,
+            result: AiError.make({
+              module: "Toolkit",
+              method: "HandlerRequired.handle",
+              reason: new AiError.ToolParameterValidationError({
+                toolName: "HandlerRequired",
+                description
+              })
+            }),
+            encodedResult: {
+              _tag: "AiError",
+              module: "Toolkit",
+              method: "HandlerRequired.handle",
+              reason: {
+                _tag: "ToolParameterValidationError",
+                toolName: "HandlerRequired",
+                description
+              }
+            }
           })
-        )
+        ])
       }))
 
     describe("addDependency", () => {

--- a/packages/effect/typetest/unstable/ai/LanguageModel.tst.ts
+++ b/packages/effect/typetest/unstable/ai/LanguageModel.tst.ts
@@ -151,6 +151,32 @@ describe("LanguageModel", () => {
       >()
     })
 
+    it("includes parameter encoding services when tool call resolution is disabled", () => {
+      const toolkit = Toolkit.make(AsymmetricParamsTool)
+      const program = LanguageModel.generateText({
+        prompt: "hello",
+        toolkit,
+        disableToolCallResolution: true
+      })
+
+      type ProgramRequirements = typeof program extends Effect.Effect<any, any, infer R> ? R : never
+
+      expect<ProgramRequirements>().type.toBe<LanguageModel.LanguageModel | ParamEncodeService>()
+    })
+
+    it("omits handler and result requirements when tool call resolution is disabled", () => {
+      const toolkit = Toolkit.make(ToolWithRequestContext)
+      const program = LanguageModel.generateText({
+        prompt: "hello",
+        toolkit,
+        disableToolCallResolution: true
+      })
+
+      type ProgramRequirements = typeof program extends Effect.Effect<any, any, infer R> ? R : never
+
+      expect<ProgramRequirements>().type.toBe<LanguageModel.LanguageModel>()
+    })
+
     it("includes tool request dependencies for resolved toolkits with handlers", () => {
       const toolkit: Toolkit.WithHandler<{
         readonly ToolWithRequestContext: typeof ToolWithRequestContext

--- a/packages/effect/typetest/unstable/ai/LanguageModel.tst.ts
+++ b/packages/effect/typetest/unstable/ai/LanguageModel.tst.ts
@@ -52,7 +52,7 @@ describe("LanguageModel", () => {
       expect<ToolCallParams>().type.toBe<string>()
     })
 
-    it("uses decoded tool parameters when tool call resolution is enabled", () => {
+    it("uses opaque tool parameters when tool call resolution is enabled", () => {
       const toolkit = Toolkit.make(TransformTool)
       const program = LanguageModel.generateText({
         prompt: "hello",
@@ -62,10 +62,10 @@ describe("LanguageModel", () => {
       type ProgramSuccess = typeof program extends Effect.Effect<infer A, any, any> ? A : never
       type ToolCallParams = ProgramSuccess["toolCalls"][number]["params"]
 
-      expect<ToolCallParams>().type.toBe<number>()
+      expect<ToolCallParams>().type.toBe<unknown>()
     })
 
-    it("uses decoded tool parameters for a non-literal resolution flag", () => {
+    it("uses opaque tool parameters for a non-literal resolution flag", () => {
       const toolkit = Toolkit.make(TransformTool)
       const disableToolCallResolution = null as unknown as boolean
       const program = LanguageModel.generateText({
@@ -77,7 +77,7 @@ describe("LanguageModel", () => {
       type ProgramSuccess = typeof program extends Effect.Effect<infer A, any, any> ? A : never
       type ToolCallParams = ProgramSuccess["toolCalls"][number]["params"]
 
-      expect<ToolCallParams>().type.toBe<number>()
+      expect<ToolCallParams>().type.toBe<unknown>()
     })
 
     it("returns an empty tool record when no toolkit is provided", () => {
@@ -197,7 +197,7 @@ describe("LanguageModel", () => {
       expect<ProgramSuccess>().type.toBe<
         LanguageModel.GenerateTextResponse<{
           readonly ToolWithRequestContext: typeof ToolWithRequestContext
-        }>
+        }, "opaque">
       >()
     })
   })
@@ -245,8 +245,21 @@ describe("LanguageModel", () => {
       expect<StreamPart>().type.toBe<
         Response.StreamPart<{
           readonly ToolWithRequestContext: typeof ToolWithRequestContext
-        }>
+        }, "opaque">
       >()
+    })
+
+    it("uses opaque tool parameters when tool call resolution is enabled", () => {
+      const toolkit = Toolkit.make(TransformTool)
+      const stream = LanguageModel.streamText({
+        prompt: "hello",
+        toolkit
+      })
+
+      type StreamPart = typeof stream extends Stream.Stream<infer A, any, any> ? A : never
+      type ToolCallParams = Extract<StreamPart, { readonly type: "tool-call" }>["params"]
+
+      expect<ToolCallParams>().type.toBe<unknown>()
     })
   })
 

--- a/packages/effect/typetest/unstable/ai/LanguageModel.tst.ts
+++ b/packages/effect/typetest/unstable/ai/LanguageModel.tst.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Schema, type Stream } from "effect"
+import { Context, Effect, Schema, SchemaGetter, type Stream } from "effect"
 import { type AiError, type Chat, LanguageModel, Tool, Toolkit } from "effect/unstable/ai"
 import type * as Response from "effect/unstable/ai/Response"
 import { describe, expect, it } from "tstyche"
@@ -34,6 +34,25 @@ const ToolWithRequestContext = Tool.make("ToolWithRequestContext", {
 const TransformTool = Tool.make("TransformTool", {
   parameters: Schema.FiniteFromString,
   success: Schema.Finite
+})
+
+class ParamEncodeService extends Context.Service<ParamEncodeService, {
+  readonly use: Effect.Effect<void>
+}>()("ParamEncodeService") {}
+
+// Decoding is service-free while encoding requires `ParamEncodeService`
+const AsymmetricParam = Schema.String.pipe(
+  Schema.decodeTo(Schema.String, {
+    decode: SchemaGetter.passthrough(),
+    encode: SchemaGetter.transformOrFail<string, string, ParamEncodeService>((value) =>
+      Effect.as(Effect.service(ParamEncodeService), value)
+    )
+  })
+)
+
+const AsymmetricParamsTool = Tool.make("AsymmetricParamsTool", {
+  parameters: Schema.Struct({ input: AsymmetricParam }),
+  success: Schema.Struct({ output: Schema.String })
 })
 
 describe("LanguageModel", () => {
@@ -115,6 +134,20 @@ describe("LanguageModel", () => {
 
       expect<ProgramRequirements>().type.toBe<
         LanguageModel.LanguageModel | RequestContext | Tool.HandlersFor<Toolkit.Tools<typeof toolkit>>
+      >()
+    })
+
+    it("includes parameter encoding services in the requirements", () => {
+      const toolkit = Toolkit.make(AsymmetricParamsTool)
+      const program = LanguageModel.generateText({
+        prompt: "hello",
+        toolkit
+      })
+
+      type ProgramRequirements = typeof program extends Effect.Effect<any, any, infer R> ? R : never
+
+      expect<ProgramRequirements>().type.toBe<
+        LanguageModel.LanguageModel | ParamEncodeService | Tool.HandlersFor<Toolkit.Tools<typeof toolkit>>
       >()
     })
 

--- a/packages/effect/typetest/unstable/ai/LanguageModel.tst.ts
+++ b/packages/effect/typetest/unstable/ai/LanguageModel.tst.ts
@@ -40,7 +40,6 @@ class ParamEncodeService extends Context.Service<ParamEncodeService, {
   readonly use: Effect.Effect<void>
 }>()("ParamEncodeService") {}
 
-// Decoding is service-free while encoding requires `ParamEncodeService`
 const AsymmetricParam = Schema.String.pipe(
   Schema.decodeTo(Schema.String, {
     decode: SchemaGetter.passthrough(),

--- a/packages/effect/typetest/unstable/ai/Response.tst.ts
+++ b/packages/effect/typetest/unstable/ai/Response.tst.ts
@@ -24,11 +24,11 @@ describe("Response", () => {
     const narrow = <
       StaticTools extends Record<string, Tool.Any>,
       DynamicTools extends Record<string, Tool.Any>,
-      EncodedParameters extends boolean
-    >(part: Response.StreamPart<StaticTools & DynamicTools, EncodedParameters>) => {
+      ParametersMode extends Response.ToolParametersMode
+    >(part: Response.StreamPart<StaticTools & DynamicTools, ParametersMode>) => {
       if (part.type === "error") return
 
-      const narrowed: Response.StreamPart<StaticTools & DynamicTools, EncodedParameters> = part
+      const narrowed: Response.StreamPart<StaticTools & DynamicTools, ParametersMode> = part
       return narrowed
     }
 
@@ -36,19 +36,22 @@ describe("Response", () => {
   })
 
   it("preserves tool names with decoded and encoded parameters", () => {
-    const decoded = null as unknown as Response.ToolCallParts<Tools>
+    const decoded = null as unknown as Response.ToolCallParts<Tools, "decoded">
     if (decoded.name === "BooleanTool") {
       expect(decoded.params).type.toBe<boolean>()
     } else {
       expect(decoded.params).type.toBe<number>()
     }
 
-    const encoded = null as unknown as Response.ToolCallParts<Tools, true>
+    const encoded = null as unknown as Response.ToolCallParts<Tools, "encoded">
     if (encoded.name === "BooleanTool") {
       expect(encoded.params).type.toBe<boolean>()
     } else {
       expect(encoded.params).type.toBe<string>()
     }
+
+    const opaque = null as unknown as Response.ToolCallParts<Tools, "opaque">
+    expect(opaque.params).type.toBe<unknown>()
   })
 
   it("preserves tool names with success and failure results", () => {


### PR DESCRIPTION
## Summary

Fixes two related `unstable/ai` bugs around tool call parameter validation:

- Constructing `ToolParameterValidationError` threw when the invalid params contained non-JSON values such as `NaN` or `Infinity`, turning a typed tool error into a defect (#7416).
- A tool-call parameter decode failure bypassed `failureMode: "return"` and killed the whole `streamText` stream (#6335) — both in `LanguageModel` transport decode and in the provider packages' own parameter validation.

## Changes

- **`AiError.ToolParameterValidationError`**: removed the `toolParams` field (typed `Schema.Json`, it crashed construction on non-JSON values and could not encode safely). `message` is built from `toolName` and `description` only. All construction sites were updated.
- **`Toolkit.handle`**: parameter decode failures now route through the tool's `failureMode`. With `"return"`, the handle stream emits a `tool-result` with the normalized `AiError` as `result` and `isFailure: true`, running through the existing `encodeResult` path exactly like handler failures. The default `"error"` mode still fails with `ToolParameterValidationError`.
- **Provider packages (OpenAI, OpenAI-compat, Anthropic)**: `transformToolCallParams` no longer fails the response on schema drift. It decodes wire parameters with the provider codec (handling provider-specific rewrites such as strict-mode nullable optionals) and re-encodes them into the tool's standard encoded form; when that validation fails, the raw parameters pass through unchanged so `Toolkit` — the single authority for parameter validation — routes the failure through `failureMode`. This also fixes a latent bug where transforming parameter schemas (e.g. `Schema.FiniteFromString`) were decoded twice on the provider path. OpenRouter already passed parsed params through untouched.
- **`LanguageModel.streamText` / `generateText`**: with tool call resolution enabled, response parts are decoded with opaque tool parameters, so schema-drifted params can no longer produce an `InvalidOutputError` that kills the stream/effect before `Toolkit` runs. `generateText`'s previous prevalidation/final double decode collapsed into one decode.
- **Provider-executed tool calls**: since they never reach `Toolkit`, their parameters are validated explicitly as part of response validation and fail with `InvalidOutputError` on mismatch, preserving `main`'s behavior.
- **Emitted `params` typing**: with resolution enabled, tool-call parts carry raw (encoded) params at runtime and are now typed `params: unknown` via the new `Response.ToolParametersMode` (`false` = decoded, `true` = encoded, `"opaque"` = unknown), threaded through `ExtractEncodedToolParameters`, `GenerateTextResponse`, and `Response.Part`/`StreamPart`. This replaces the previous internal cast that typed raw params as decoded.

## Testing

- Toolkit/LanguageModel: `failureMode: "return"` with invalid and `NaN` params yields an `isFailure` tool result for `generateText` and `streamText` (stream stays alive, handler never runs); `failureMode: "error"` still fails without a defect; transforming parameter schemas with resolution enabled preserve encoded params on emitted parts while handlers receive decoded values; provider-executed tool calls fail with `InvalidOutputError` on invalid params and pass through on valid ones.
- Providers: mocked OpenAI response/stream tests prove schema-drifted params route through `failureMode: "return"` instead of failing, and that transformed params reach handlers decoded; an equivalent Anthropic streaming test covers the same path.
- All `unstable/ai` and `packages/ai/*` suites pass (1269 tests), plus `pnpm check`, `pnpm lint`, `pnpm jsdocs --check`, and the AiError doctests.

Closes EFF-1008
Closes #7416
Closes #6335
