### PR TITLE
fix(RequestResolver): preserve cached race winners

### DIFF
--- a/.changeset/request-race-cache.md
+++ b/.changeset/request-race-cache.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Keep completed results in `RequestResolver.withCache` when a losing `RequestResolver.race` resolver is interrupted after the winner completes, avoiding repeated backend requests on subsequent equal lookups.

--- a/packages/effect/src/RequestResolver.ts
+++ b/packages/effect/src/RequestResolver.ts
@@ -1169,9 +1169,11 @@ export const withCache: {
           const prevComplete = entry.completeUnsafe
           entry.completeUnsafe = function(exit) {
             if (Exit.hasInterrupts(exit)) {
-              const current = MutableHashMap.get(cache, entry.request)
-              if (current._tag === "Some" && current.value === cached) {
-                MutableHashMap.remove(cache, entry.request)
+              if (cached.exit === undefined) {
+                const current = MutableHashMap.get(cache, entry.request)
+                if (current._tag === "Some" && current.value === cached) {
+                  MutableHashMap.remove(cache, entry.request)
+                }
               }
             } else {
               cached.exit = exit as any

--- a/packages/effect/test/Request.test.ts
+++ b/packages/effect/test/Request.test.ts
@@ -1,11 +1,12 @@
 import { assert, describe, expect, it } from "@effect/vitest"
-import { Array, Context, Data, Deferred, Equal, Fiber, Hash } from "effect"
+import { Array, Context, Data, Deferred, Equal, Fiber, Hash, Schema } from "effect"
 import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import { flow, pipe } from "effect/Function"
 import * as Request from "effect/Request"
 import * as Resolver from "effect/RequestResolver"
+import { Persistable, Persistence } from "effect/unstable/persistence"
 
 class Counter extends Context.Service<Counter, { count: number }>()("Counter") {}
 class Requests extends Context.Service<Requests, { count: number }>()("Requests") {}
@@ -480,6 +481,68 @@ describe.sequential("Request", () => {
       assert.deepStrictEqual(results, [Exit.succeed("Alice")])
       assert.deepStrictEqual(batches, [1])
     }))
+
+  it.effect("withCache preserves the race winner when the losing resolver is interrupted", () =>
+    Effect.gen(function*() {
+      const finished = yield* Deferred.make<void>()
+      let calls = 0
+      let interruptions = 0
+      const fast = Resolver.fromEffect<GetNameById>(() =>
+        Effect.andThen(
+          Effect.yieldNow,
+          Effect.sync(() => {
+            calls++
+            return "Alice"
+          })
+        )
+      )
+      const slow = Resolver.fromEffect<GetNameById>(() =>
+        Effect.never.pipe(Effect.onInterrupt(() =>
+          Effect.sync(() => {
+            interruptions++
+          })
+        ))
+      )
+      const resolver = yield* Resolver.race(fast, slow).pipe(
+        Resolver.around(() => Effect.void, () => Deferred.succeed(finished, undefined)),
+        Resolver.withCache({ capacity: 10 })
+      )
+
+      assert.strictEqual(yield* Effect.request(new GetNameById({ id: 1 }), resolver), "Alice")
+      // Wait for the losing resolver's interruption before reading the cache again.
+      yield* Deferred.await(finished)
+      assert.strictEqual(interruptions, 1)
+      assert.deepStrictEqual(
+        yield* Effect.exit(Effect.request(new GetNameById({ id: 1 }), resolver)),
+        Exit.succeed("Alice")
+      )
+      assert.strictEqual(calls, 1)
+    }))
+
+  it.effect("withCache accepts refreshed results from stale-while-revalidate", () =>
+    Effect.gen(function*() {
+      class GetName extends Persistable.Class()("GetName", {
+        primaryKey: () => "name",
+        success: Schema.String
+      }) {}
+      const store = yield* (yield* Persistence.Persistence).make({ storeId: "names" })
+      yield* store.set(new GetName(), Exit.succeed("Alice"))
+      const finished = yield* Deferred.make<void>()
+      let calls = 0
+      const persisted = yield* Resolver.fromFunction<GetName>(() => {
+        calls++
+        return "Bob"
+      }).pipe(Resolver.persisted({ storeId: "names", staleWhileRevalidate: () => true }))
+      const resolver = yield* persisted.pipe(
+        Resolver.around(() => Effect.void, () => Deferred.succeed(finished, undefined)),
+        Resolver.withCache({ capacity: 10 })
+      )
+
+      assert.strictEqual(yield* Effect.request(new GetName(), resolver), "Alice")
+      yield* Deferred.await(finished)
+      assert.strictEqual(yield* Effect.request(new GetName(), resolver), "Bob")
+      assert.strictEqual(calls, 1)
+    }).pipe(Effect.provide(Persistence.layerMemory)))
 
   it.effect(
     "batching preserves individual & identical requests",


### PR DESCRIPTION
## Type
- [x] Bug Fix

## Description

### Why
After a cached resolver race succeeds, the interrupted loser can overwrite the winning result. The next equal request receives interruption instead of the cached success.

### What Changes
Do not overwrite a completed cached result with a later interruption. Both equal requests now succeed with one backend call. Continue accepting later non-interrupted results, as verified by a memory-backed stale-while-revalidate control.

### Scope
One guard and an `effect` patch changeset. Standalone against `main`; pending-request cancellation and initial-interruption caching policy are unchanged.

### Verification
```bash
pnpm test --run packages/effect/test/Request.test.ts
pnpm lint-fix
pnpm check
git diff --check origin/main
```
All 25 tests and checks pass. The race reproducer fails on the original runtime.

## Related
Closes #7592.
Closes EFF-1015

## Audit

Runtime correctness audit; intended label: `audit`.
