### PR TITLE
fix(Cache): preserve replacement values after zero-TTL refresh

### DIFF
--- a/.changeset/cache-refresh-zero-ttl-ownership.md
+++ b/.changeset/cache-refresh-zero-ttl-ownership.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Cache.refresh` for an initially missing key deleting a newer cached value when the refresh completes with zero time to live.

--- a/packages/effect/src/Cache.ts
+++ b/packages/effect/src/Cache.ts
@@ -1173,7 +1173,10 @@ export const refresh: {
         }
         const ttl = self.timeToLive(exit, key)
         if (Duration.isZero(ttl)) {
-          MutableHashMap.remove(self.map, key)
+          const current = MutableHashMap.get(self.map, key)
+          if (existing || (Option.isSome(current) && current.value === entry)) {
+            MutableHashMap.remove(self.map, key)
+          }
           return effect.void
         }
         entry.expiresAt = Duration.isFinite(ttl)

--- a/packages/effect/test/Cache.test.ts
+++ b/packages/effect/test/Cache.test.ts
@@ -767,6 +767,40 @@ describe("Cache", () => {
           assert.isFalse(yield* Cache.has(cache, "key"))
         }))
 
+      it.effect.each([false, true])(
+        "zero-TTL refresh with replacement (existing: %s)",
+        (existing) =>
+          Effect.gen(function*() {
+            const gate = yield* Deferred.make<number, string>()
+            const cache = yield* Cache.makeWith((_key: string) => Deferred.await(gate), {
+              capacity: 1,
+              timeToLive: (exit) => Exit.isFailure(exit) ? 0 : "1 hour"
+            })
+            if (existing) yield* Cache.set(cache, "key", 1)
+
+            const refresh = yield* Cache.refresh(cache, "key").pipe(Effect.forkChild({ startImmediately: true }))
+            yield* Cache.set(cache, "key", 99)
+            yield* Deferred.fail(gate, "error")
+
+            assert.deepStrictEqual(yield* Fiber.await(refresh), Exit.fail("error"))
+            assert.deepStrictEqual(
+              yield* Cache.getSuccess(cache, "key"),
+              existing ? Option.none() : Option.some(99)
+            )
+          })
+      )
+
+      it.effect("zero-TTL refresh removes its own entry", () =>
+        Effect.gen(function*() {
+          const cache = yield* Cache.makeWith((_key: string) => Effect.fail("error"), {
+            capacity: 1,
+            timeToLive: () => 0
+          })
+
+          assert.deepStrictEqual(yield* Effect.exit(Cache.refresh(cache, "key")), Exit.fail("error"))
+          assert.isFalse(yield* Cache.has(cache, "key"))
+        }))
+
       it.effect("refresh updates TTL", () =>
         Effect.gen(function*() {
           const cache = yield* Cache.make<string, number>({


### PR DESCRIPTION
## Type
- [x] Bug Fix

## Description

### Why
A refresh started for a missing key can delete a newer `Cache.set` value when its lookup completes with zero TTL. With failure TTL `0`, a failed refresh can remove a successful replacement.

### What Changes
Remove the pending entry only if the refresh still owns it. After setting `99`, a late failed refresh now leaves `Some(99)` rather than `None`.

### Scope
Only zero-TTL completion for initially missing keys changes. Existing-key refresh policy and ordinary pending-entry cleanup are preserved by controls. Includes an `effect` patch changeset.

### Verification
```bash
pnpm test --run packages/effect/test/Cache.test.ts
pnpm lint-fix
pnpm check
git diff --check origin/main
```
All 90 tests and checks pass. The replacement regression fails before the fix.

## Related
Closes #7590.

## Audit

Runtime correctness audit; intended label: `audit`.
