### PR TITLE
fix(Cache): enforce capacity when publishing refreshed entries

### DIFF
--- a/.changeset/cache-refresh-capacity.md
+++ b/.changeset/cache-refresh-capacity.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Cache.refresh` and `ScopedCache.refresh` exceeding capacity when an existing key is evicted while its refresh is in progress. Publishing the refreshed entry now evicts older entries as needed, releasing their resources in `ScopedCache`.

--- a/packages/effect/src/Cache.ts
+++ b/packages/effect/src/Cache.ts
@@ -1181,6 +1181,7 @@ export const refresh: {
           : undefined
         if (existing) {
           MutableHashMap.set(self.map, key, entry)
+          checkCapacity(self)
         }
       })
       return entry.await()

--- a/packages/effect/src/ScopedCache.ts
+++ b/packages/effect/src/ScopedCache.ts
@@ -656,6 +656,7 @@ export const refresh: {
       if (!newEntry) {
         const oentry = MutableHashMap.get(self.state.map, key)
         MutableHashMap.set(self.state.map, key, entry)
+        yield* checkCapacity(fiber, self.state.map, self.capacity)
         if (Option.isSome(oentry)) {
           yield* Scope.close(oentry.value.scope, effect.exitVoid)
         }

--- a/packages/effect/test/Cache.test.ts
+++ b/packages/effect/test/Cache.test.ts
@@ -719,17 +719,44 @@ describe("Cache", () => {
           assert.strictEqual(result, 2)
         }))
 
-      it.effect("refresh non-existent key invokes lookup", () =>
+      it.effect("refresh non-existent key invokes lookup and enforces capacity", () =>
         Effect.gen(function*() {
           let counter = 0
           const cache = yield* Cache.make<string, number>({
-            capacity: 10,
+            capacity: 1,
             lookup: (_key) => Effect.sync(() => ++counter)
           })
 
+          yield* Cache.set(cache, "other", 99)
           const result = yield* Cache.refresh(cache, "test")
 
           assert.strictEqual(result, 1)
+          assert.strictEqual(yield* Cache.size(cache), 1)
+          assert.deepStrictEqual(Array.from(yield* Cache.keys(cache)), ["test"])
+        }))
+
+      it.effect("refresh enforces capacity when the existing key is evicted during lookup", () =>
+        Effect.gen(function*() {
+          const started = yield* Deferred.make<void>()
+          const result = yield* Deferred.make<number>()
+          const cache = yield* Cache.make<string, number>({
+            capacity: 1,
+            lookup: () => Deferred.succeed(started, void 0).pipe(Effect.andThen(Deferred.await(result)))
+          })
+
+          yield* Cache.set(cache, "a", 1)
+          const refresh = yield* Cache.refresh(cache, "a").pipe(Effect.forkChild({ startImmediately: true }))
+          yield* Deferred.await(started)
+          yield* Cache.set(cache, "b", 99)
+          assert.isFalse(yield* Cache.has(cache, "a"))
+
+          yield* Deferred.succeed(result, 2)
+          assert.strictEqual(yield* Fiber.join(refresh), 2)
+          assert.deepStrictEqual({
+            size: yield* Cache.size(cache),
+            keys: Array.from(yield* Cache.keys(cache)).sort()
+          }, { size: 1, keys: ["a"] })
+          assert.deepStrictEqual(yield* Cache.getSuccess(cache, "a"), Option.some(2))
         }))
 
       it.effect("repro: interrupting a missing-key refresh does not remove a newer set value", () =>

--- a/packages/effect/test/ScopedCache.test.ts
+++ b/packages/effect/test/ScopedCache.test.ts
@@ -834,17 +834,59 @@ describe("ScopedCache", () => {
           assert.strictEqual(result, 2)
         }))
 
-      it.effect("refresh non-existent key invokes lookup", () =>
+      it.effect("refresh non-existent key invokes lookup and enforces capacity", () =>
         Effect.gen(function*() {
           let counter = 0
           const cache = yield* ScopedCache.make({
-            capacity: 10,
+            capacity: 1,
             lookup: (_key: string) => Effect.sync(() => ++counter)
           })
 
+          yield* ScopedCache.set(cache, "other", 99)
           const result = yield* ScopedCache.refresh(cache, "test")
 
           assert.strictEqual(result, 1)
+          assert.strictEqual(yield* ScopedCache.size(cache), 1)
+          assert.deepStrictEqual(yield* ScopedCache.keys(cache), ["test"])
+        }))
+
+      it.effect("refresh enforces capacity when the existing key is evicted during lookup", () =>
+        Effect.gen(function*() {
+          const started = yield* Deferred.make<void>()
+          const result = yield* Deferred.make<number>()
+          const released: Array<number> = []
+          const cache = yield* ScopedCache.make({
+            capacity: 1,
+            lookup: (key: string) =>
+              Effect.gen(function*() {
+                const value = key === "a"
+                  ? yield* Deferred.succeed(started, void 0).pipe(Effect.andThen(Deferred.await(result)))
+                  : 99
+                return yield* Effect.acquireRelease(
+                  Effect.succeed(value),
+                  (value) => Effect.sync(() => released.push(value))
+                )
+              })
+          })
+
+          yield* ScopedCache.set(cache, "a", 1)
+          const refresh = yield* ScopedCache.refresh(cache, "a").pipe(Effect.forkChild({ startImmediately: true }))
+          yield* Deferred.await(started)
+          assert.strictEqual(yield* ScopedCache.get(cache, "b"), 99)
+          assert.isFalse(yield* ScopedCache.has(cache, "a"))
+          assert.deepStrictEqual(released, [])
+
+          yield* Deferred.succeed(result, 2)
+          assert.strictEqual(yield* Fiber.join(refresh), 2)
+          assert.deepStrictEqual({
+            size: yield* ScopedCache.size(cache),
+            keys: (yield* ScopedCache.keys(cache)).sort(),
+            released: released.slice()
+          }, { size: 1, keys: ["a"], released: [99] })
+          assert.deepStrictEqual(yield* ScopedCache.getSuccess(cache, "a"), Option.some(2))
+
+          yield* ScopedCache.invalidateAll(cache)
+          assert.deepStrictEqual(released, [99, 2])
         }))
 
       it.effect("refresh updates TTL", () =>


### PR DESCRIPTION
## Type
- [x] Bug Fix

## Description

### Why
If an existing key is evicted while refresh is pending, completion republishes it without checking capacity. A capacity-one `Cache` or `ScopedCache` can retain two entries.

### What Changes
Call the existing capacity helper after publishing the refreshed entry: two added source lines. Size remains one; ScopedCache also releases the evicted entry's resources before refresh returns.

### Scope
Preserves refresh publication policy and missing-key insertion. Includes gated regressions, scoped cleanup assertions, and an `effect` patch changeset.

### Verification
```bash
pnpm test --run packages/effect/test/Cache.test.ts packages/effect/test/ScopedCache.test.ts
pnpm lint-fix
pnpm check
git diff --check origin/main
```
All 203 tests and checks pass. Both capacity regressions fail before the fix.

## Related
Closes #7593.

## Audit

Runtime correctness audit; intended label: `audit`.
