### PR TITLE
fix(RequestResolver): register requests before synchronous delays

### DIFF
--- a/.changeset/request-synchronous-delay.md
+++ b/.changeset/request-synchronous-delay.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix request resolvers with synchronous delay effects, such as `RequestResolver.setDelayEffect(Effect.void)`, executing an empty batch instead of resolving the request.

--- a/packages/effect/src/internal/request.ts
+++ b/packages/effect/src/internal/request.ts
@@ -128,7 +128,11 @@ const addEntry = <A extends Request.Any>(
         entrySet: new Set(),
         entries: new Set(),
         delayEffect: effect.flatMap(
-          effect.suspend(() => newBatch.resolver.delay),
+          effect.suspend(() => {
+            // Delay callbacks can re-enter addEntry before runForkWith returns.
+            newBatch.fiber = effect.getCurrentFiber()!
+            return newBatch.resolver.delay
+          }),
           (_) => runBatch(newBatch)
         ) as Effect<void>,
         run: effect.onExit(
@@ -161,15 +165,21 @@ const addEntry = <A extends Request.Any>(
       batch = newBatch
     }
     batchMap.set(key, batch)
-    batch.fiber = effect.runForkWith(fiber.context)(batch.delayEffect, { scheduler: fiber.currentScheduler })
+    batch.entrySet.add(entry)
+    batch.entries.add(entry)
+    const delayFiber = effect.runForkWith(fiber.context)(batch.delayEffect, { scheduler: fiber.currentScheduler })
+    // A synchronous delay may have already executed and recycled the batch.
+    if (completed || batchMap.get(key) !== batch) return entry
+    batch.fiber = delayFiber
+  } else {
+    batch.entrySet.add(entry)
+    batch.entries.add(entry)
   }
 
-  batch.entrySet.add(entry)
-  batch.entries.add(entry)
   if (batch.resolver.collectWhile(batch.entries)) return entry
 
   batch.fiber!.interruptUnsafe(fiber.id)
-  batch.fiber = effect.runForkWith(fiber.context)(runBatch(batch), { scheduler: fiber.currentScheduler })
+  effect.runForkWith(fiber.context)(runBatch(batch), { scheduler: fiber.currentScheduler })
   return entry
 }
 

--- a/packages/effect/test/Request.test.ts
+++ b/packages/effect/test/Request.test.ts
@@ -361,6 +361,83 @@ describe.sequential("Request", () => {
     })
   )
 
+  it.effect("synchronous delays execute a non-empty batch", () =>
+    Effect.gen(function*() {
+      const batches: Array<number> = []
+      const resolver = Resolver.make<GetRequestService>((entries) =>
+        Effect.sync(() => {
+          batches.push(entries.length)
+          for (const entry of entries) entry.completeUnsafe(Exit.succeed("ok"))
+        })
+      ).pipe(Resolver.setDelayEffect(Effect.void))
+
+      const exit = yield* Effect.exit(Effect.request(GetRequestService(), resolver))
+
+      assert.deepStrictEqual(batches, [1])
+      assert.deepStrictEqual(exit, Exit.succeed("ok"))
+    }))
+
+  it.effect("collectWhile preserves synchronous delay side effects across pooled batches", () =>
+    Effect.gen(function*() {
+      const events: Array<string> = []
+      const resolver = Resolver.makeWith<GetRequestService>({
+        batchKey: () => undefined,
+        delay: Effect.andThen(Effect.sync(() => events.push("delay")), Effect.never).pipe(
+          Effect.onInterrupt(() => Effect.sync(() => events.push("interrupt")))
+        ),
+        collectWhile(entries) {
+          events.push(`collect:${entries.size}`)
+          return false
+        },
+        runAll: (entries) =>
+          Effect.sync(() => {
+            events.push(`run:${entries.length}`)
+            for (const entry of entries) entry.completeUnsafe(Exit.succeed("ok"))
+          })
+      })
+
+      for (let i = 0; i < 2; i++) {
+        assert.strictEqual(yield* Effect.request(GetRequestService(), resolver), "ok")
+      }
+      assert.deepStrictEqual(events, [
+        "delay",
+        "collect:1",
+        "interrupt",
+        "run:1",
+        "delay",
+        "collect:1",
+        "interrupt",
+        "run:1"
+      ])
+    }))
+
+  it.effect("synchronous delay callbacks can enqueue requests that fill a batch", () =>
+    Effect.gen(function*() {
+      const context = yield* Effect.context<never>()
+      const batches: Array<number> = []
+      const results: Array<Request.Result<GetRequestService>> = []
+      const resolver = Resolver.make<GetRequestService>((entries) =>
+        Effect.sync(() => {
+          batches.push(entries.length)
+          for (const entry of entries) entry.completeUnsafe(Exit.succeed("ok"))
+        })
+      ).pipe(
+        Resolver.batchN(2),
+        Resolver.setDelayEffect(Effect.andThen(
+          Effect.sync(() => {
+            Effect.requestUnsafe(GetRequestService(), { resolver, context, onExit: (exit) => results.push(exit) })
+          }),
+          Effect.never
+        ))
+      )
+
+      for (let i = 0; i < 2; i++) {
+        assert.strictEqual(yield* Effect.request(GetRequestService(), resolver), "ok")
+      }
+      assert.deepStrictEqual(batches, [2, 2])
+      assert.deepStrictEqual(results, [Exit.succeed("ok"), Exit.succeed("ok")])
+    }))
+
   it.effect(
     "batch fibers use request services for delay effects",
     Effect.fnUntraced(function*() {


### PR DESCRIPTION
## Type
- [x] Bug Fix

## Description

### Why
`setDelayEffect(Effect.void)` starts an empty batch before registering the request. Cleanup recycles that batch, and registration then defects while reading `collectWhile`.

### What Changes
Register the entry before starting its delay. Publish the delay fiber before reentrant callbacks, and avoid accessing or updating a recycled batch. The resolver now receives one request and completes it successfully.

### Scope
Preserves synchronous side-effect order without adding an asynchronous scheduling boundary. Controls cover early collection, reentrant `batchN`, and pooled reuse. Includes an `effect` patch changeset; no cancellation changes from other PRs are bundled.

### Verification
```bash
pnpm test --run packages/effect/test/Request.test.ts
pnpm lint-fix
pnpm check
git diff --check origin/main
```
All 17 tests and checks pass. The empty-batch regression fails before the fix.

## Related
Closes #7589.

## Audit

Runtime correctness audit; intended label: `audit`.
