### PR TITLE
fix(RcRef): reject acquisitions completed after owner shutdown

### DIFF
--- a/.changeset/rcref-acquisition-shutdown.md
+++ b/.changeset/rcref-acquisition-shutdown.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Keep `RcRef` closed when an in-flight acquisition finishes after its owning scope has closed. Release the late-acquired resource and interrupt waiting borrowers instead of making the resource available again.

--- a/packages/effect/src/internal/rcRef.ts
+++ b/packages/effect/src/internal/rcRef.ts
@@ -116,7 +116,10 @@ const getState = <A, E>(self: RcRefImpl<A, E>) =>
               self.acquire as Effect.Effect<A, E>,
               Context.add(self.context, Scope.Scope, scope)
             )).pipe(
-              Effect.map((value) => {
+              Effect.flatMap((value) => {
+                if (self.state._tag === "Closed") {
+                  return Effect.interrupt
+                }
                 const state: State.Acquired<A> = {
                   _tag: "Acquired",
                   value,
@@ -126,7 +129,7 @@ const getState = <A, E>(self: RcRefImpl<A, E>) =>
                   invalidated: false
                 }
                 self.state = state
-                return state
+                return Effect.succeed(state)
               }),
               Effect.onExit((exit) => Exit.isFailure(exit) ? Scope.close(scope, exit) : Effect.void)
             )

--- a/packages/effect/test/RcRef.test.ts
+++ b/packages/effect/test/RcRef.test.ts
@@ -109,6 +109,51 @@ describe("RcRef", () => {
       assert.strictEqual(acquired, 1)
     }))
 
+  it.effect("acquisition completing after owner shutdown cannot reopen the reference", () =>
+    Effect.gen(function*() {
+      const owner = yield* Scope.make()
+      const borrower = yield* Scope.make()
+      const started = yield* Deferred.make<void>()
+      const finish = yield* Deferred.make<void>()
+      const released: Array<number> = []
+      const ref = yield* RcRef.make({
+        acquire: Effect.gen(function*() {
+          const value = yield* Effect.acquireRelease(
+            Effect.succeed(1),
+            (value) => Effect.sync(() => released.push(value))
+          )
+          yield* Deferred.succeed(started, undefined)
+          yield* Deferred.await(finish)
+          return value
+        })
+      }).pipe(Scope.provide(owner))
+      const pending = yield* RcRef.get(ref).pipe(
+        Scope.provide(borrower),
+        Effect.forkChild({ startImmediately: true })
+      )
+      yield* Deferred.await(started)
+      const queued = yield* RcRef.get(ref).pipe(
+        Scope.provide(borrower),
+        Effect.forkChild({ startImmediately: true })
+      )
+
+      yield* Scope.close(owner, Exit.void)
+      const before = yield* RcRef.get(ref).pipe(Effect.scoped, Effect.exit)
+      yield* Deferred.succeed(finish, undefined)
+      const pendingExit = yield* Fiber.await(pending)
+      const queuedExit = yield* Fiber.await(queued)
+      const after = yield* RcRef.get(ref).pipe(Effect.scoped, Effect.exit)
+      const releasedBeforeBorrowerClose = [...released]
+      yield* Scope.close(borrower, Exit.void)
+
+      assert.isTrue(Exit.hasInterrupts(before))
+      assert.isTrue(Exit.hasInterrupts(pendingExit))
+      assert.isTrue(Exit.hasInterrupts(queuedExit))
+      assert.isTrue(Exit.hasInterrupts(after))
+      assert.deepStrictEqual(releasedBeforeBorrowerClose, [1])
+      assert.deepStrictEqual(released, [1])
+    }))
+
   it.effect("releases resources acquired before acquisition failure", () =>
     Effect.gen(function*() {
       const acquired = yield* Ref.make(0)


### PR DESCRIPTION
## Type
- [x] Bug Fix

## Description

### Why
An acquisition can finish after its owner closes and overwrite `Closed` with `Acquired`, making subsequent gets succeed again.

### What Changes
Check for `Closed` before publishing the result. Return interruption so the existing failure finalizer releases the late resource. The regression covers the in-flight borrower, a queued borrower, future gets, and exactly-once cleanup.

### Scope
One completion-time guard and an `effect` patch changeset. No new cancellation mechanism; an acquisition that never finishes remains governed by its caller's interruption. Standalone against `main`, without the separate borrower-cleanup fix.

### Verification
```bash
pnpm test --run packages/effect/test/RcRef.test.ts
pnpm lint-fix
pnpm check
git diff --check origin/main
```
All 5 tests and checks pass. The regression fails before the fix.

## Related
Closes #7591.

## Audit

Runtime correctness audit; intended label: `audit`.
