### PR TITLE
fix(PubSub): advance sliding subscribers past dropped messages

### DIFF
--- a/.changeset/pubsub-sliding-single-subscriber.md
+++ b/.changeset/pubsub-sliding-single-subscriber.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix `PubSub.sliding(1)` delivering duplicate messages to lagging subscribers and losing messages for other subscribers after consumption or unsubscription.
+Fix capacity-one PubSub subscriber cursors after sliding past messages, including duplicate delivery and invalid state when unsubscribing from a slid message.

--- a/.changeset/pubsub-sliding-single-subscriber.md
+++ b/.changeset/pubsub-sliding-single-subscriber.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `PubSub.sliding(1)` delivering duplicate messages to lagging subscribers and losing messages for other subscribers after consumption or unsubscription.

--- a/packages/effect/src/PubSub.ts
+++ b/packages/effect/src/PubSub.ts
@@ -2025,24 +2025,18 @@ class BoundedPubSubSingleSubscription<in out A> implements PubSub.BackingSubscri
   }
 
   pollUpTo(n: number): Array<A> {
-    n = Count.normalize(n)
-    if (this.isEmpty() || n < 1) {
+    if (Count.normalize(n) < 1) {
       return []
     }
-    const a = this.self.value
-    this.self.subscribers -= 1
-    if (this.self.subscribers === 0) {
-      this.self.value = AbsentValue as unknown as A
-    }
-    this.subscriberIndex = this.self.publisherIndex
-    return [a]
+    const elem = this.poll()
+    return elem === MutableList.Empty ? [] : [elem]
   }
 
   unsubscribe(): void {
     if (!this.unsubscribed) {
       this.unsubscribed = true
       this.self.subscriberCount -= 1
-      if (this.subscriberIndex !== this.self.publisherIndex) {
+      if (this.self.subscribers !== 0 && this.subscriberIndex !== this.self.publisherIndex) {
         this.self.subscribers -= 1
         if (this.self.subscribers === 0) {
           this.self.value = AbsentValue as unknown as A

--- a/packages/effect/src/PubSub.ts
+++ b/packages/effect/src/PubSub.ts
@@ -2020,7 +2020,7 @@ class BoundedPubSubSingleSubscription<in out A> implements PubSub.BackingSubscri
     if (this.self.subscribers === 0) {
       this.self.value = AbsentValue as unknown as A
     }
-    this.subscriberIndex += 1
+    this.subscriberIndex = this.self.publisherIndex
     return elem
   }
 
@@ -2034,7 +2034,7 @@ class BoundedPubSubSingleSubscription<in out A> implements PubSub.BackingSubscri
     if (this.self.subscribers === 0) {
       this.self.value = AbsentValue as unknown as A
     }
-    this.subscriberIndex += 1
+    this.subscriberIndex = this.self.publisherIndex
     return [a]
   }
 

--- a/packages/effect/test/PubSub.test.ts
+++ b/packages/effect/test/PubSub.test.ts
@@ -1,8 +1,47 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Array, Effect, Exit, Fiber, Latch, PubSub, Stream } from "effect"
+import { Array, Effect, Exit, Fiber, Latch, PubSub, Scope, Stream } from "effect"
 import { pipe } from "effect/Function"
 
 describe("PubSub", () => {
+  for (const batch of [false, true]) {
+    it.effect.each([1, 2, 3])(
+      `sliding capacity %s delivers each retained message once per subscriber (batch: ${batch})`,
+      (capacity) =>
+        Effect.gen(function*() {
+          const pubsub = yield* PubSub.sliding<number>(capacity)
+          const first = yield* PubSub.subscribe(pubsub)
+          const second = yield* PubSub.subscribe(pubsub)
+          const values = Array.range(1, capacity + 1)
+          yield* PubSub.publishAll(pubsub, values)
+
+          const received = batch
+            ? yield* PubSub.takeAll(first)
+            : yield* Effect.forEach(values.slice(1), () => PubSub.take(first))
+          const duplicate = yield* PubSub.takeUpTo(first, capacity)
+          const other = yield* PubSub.takeUpTo(second, capacity)
+
+          assert.deepStrictEqual([received, duplicate, other], [values.slice(1), [], values.slice(1)])
+        })
+    )
+  }
+
+  it.effect.each([1, 2, 3])(
+    "unsubscribing after a slide preserves the other subscriber's messages (capacity: %s)",
+    (capacity) =>
+      Effect.gen(function*() {
+        const pubsub = yield* PubSub.sliding<number>(capacity)
+        const scope = yield* Scope.make()
+        const first = yield* PubSub.subscribe(pubsub).pipe(Scope.provide(scope))
+        const second = yield* PubSub.subscribe(pubsub)
+        const values = Array.range(1, capacity + 1)
+        yield* PubSub.publishAll(pubsub, values)
+        yield* PubSub.takeAll(first)
+        yield* Scope.close(scope, Exit.void)
+
+        assert.deepStrictEqual(yield* PubSub.takeUpTo(second, capacity), values.slice(1))
+      })
+  )
+
   it.effect("publishAll - capacity 2 (BoundedPubSubPow2)", () => {
     const messages = [1, 2]
     return PubSub.bounded<number>(2).pipe(

--- a/packages/effect/test/PubSub.test.ts
+++ b/packages/effect/test/PubSub.test.ts
@@ -11,16 +11,17 @@ describe("PubSub", () => {
           const pubsub = yield* PubSub.sliding<number>(capacity)
           const first = yield* PubSub.subscribe(pubsub)
           const second = yield* PubSub.subscribe(pubsub)
-          const values = Array.range(1, capacity + 1)
+          const values = Array.range(1, capacity + 2)
+          const retained = values.slice(-capacity)
           yield* PubSub.publishAll(pubsub, values)
 
           const received = batch
             ? yield* PubSub.takeAll(first)
-            : yield* Effect.forEach(values.slice(1), () => PubSub.take(first))
+            : yield* Effect.forEach(retained, () => PubSub.take(first))
           const duplicate = yield* PubSub.takeUpTo(first, capacity)
           const other = yield* PubSub.takeUpTo(second, capacity)
 
-          assert.deepStrictEqual([received, duplicate, other], [values.slice(1), [], values.slice(1)])
+          assert.deepStrictEqual([received, duplicate, other], [retained, [], retained])
         })
     )
   }
@@ -33,12 +34,13 @@ describe("PubSub", () => {
         const scope = yield* Scope.make()
         const first = yield* PubSub.subscribe(pubsub).pipe(Scope.provide(scope))
         const second = yield* PubSub.subscribe(pubsub)
-        const values = Array.range(1, capacity + 1)
+        const values = Array.range(1, capacity + 2)
+        const retained = values.slice(-capacity)
         yield* PubSub.publishAll(pubsub, values)
         yield* PubSub.takeAll(first)
         yield* Scope.close(scope, Exit.void)
 
-        assert.deepStrictEqual(yield* PubSub.takeUpTo(second, capacity), values.slice(1))
+        assert.deepStrictEqual(yield* PubSub.takeUpTo(second, capacity), retained)
       })
   )
 
@@ -458,6 +460,18 @@ describe("PubSub", () => {
     assert.deepStrictEqual(replay.takeN(1.9), [1])
     assert.deepStrictEqual(replay.takeN(Number.NaN), [])
     assert.deepStrictEqual(replay.takeAll(), [2, 3])
+  })
+
+  it("publishes after a capacity-one subscriber unsubscribes from a slid message", () => {
+    const pubsub = PubSub.makeAtomicBounded<number>(1)
+    const subscription = pubsub.subscribe()
+    pubsub.publish(1)
+    pubsub.slide()
+    subscription.unsubscribe()
+
+    assert.isTrue(pubsub.publish(2))
+    assert.strictEqual(pubsub.size(), 0)
+    assert.isFalse(pubsub.isFull())
   })
 
   describe("replay", () => {


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

### Why

After `PubSub.sliding(1)` drops a message, a lagging subscriber can consume the retained message twice and deprive another subscriber of it. Unsubscribing directly from a slid message through the low-level atomic API can also leave the capacity-one implementation permanently full.

### What Changes

- Advance the subscriber cursor directly to the publisher position after polling.
- Have `pollUpTo` delegate to `poll` so the cursor logic cannot drift between the two paths.
- Do not decrement the subscriber count when unsubscribing after a slide has already removed the message.

| Two subscribers; publish `[1, 2]` | Before | After |
| --- | --- | --- |
| First read, repeated read, other subscriber | `[[2], [2], []]` | `[[2], [], [2]]` |

### Scope

`BoundedPubSubSingle` backs every capacity-one PubSub, including bounded and dropping strategies. The cursor change is a no-op for bounded and dropping because those strategies never call `slide()`; `publish` also prevents the publisher cursor from moving more than one position ahead of a non-empty subscriber.

Tests cover single and batched reads, unsubscribe behavior, and a low-level unsubscribe after `slide()`. Capacity-two and capacity-three cases remain as controls. Includes an `effect` patch changeset.

### Verification

```bash
pnpm test --run packages/effect/test/PubSub.test.ts
pnpm lint-fix
pnpm check
git diff --check
```

48 tests pass; formatting, lint, and typecheck pass.

## Related

Closes EFF-1013
Closes #7601

## Audit

Runtime correctness audit; intended label: `audit`.
