### PR TITLE
fix(Pool): preserve reservations during borrower release

### DIFF
--- a/.changeset/pool-preserve-reservations.md
+++ b/.changeset/pool-preserve-reservations.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Keep `Pool.reserve` items out of shared circulation when other borrowers return or overlapping reservations close. Restore available slots only after the last reservation closes.

--- a/.changeset/pool-preserve-reservations.md
+++ b/.changeset/pool-preserve-reservations.md
@@ -3,3 +3,5 @@
 ---
 
 Keep `Pool.reserve` items out of shared circulation when other borrowers return or overlapping reservations close. Restore available slots only after the last reservation closes.
+
+Overlapping reservations on the same item now count `usage` once instead of once per reservation, and the usage TTL strategy no longer reclaims reserved items, acquiring a fresh item for waiters instead. `Pool.reserve` is now a full no-op when per-item concurrency is `1`; previously it removed the item from availability while leaving its capacity unchanged.

--- a/.changeset/pool-preserve-reservations.md
+++ b/.changeset/pool-preserve-reservations.md
@@ -3,5 +3,3 @@
 ---
 
 Keep `Pool.reserve` items out of shared circulation when other borrowers return or overlapping reservations close. Restore available slots only after the last reservation closes.
-
-Overlapping reservations on the same item now count `usage` once instead of once per reservation, and the usage TTL strategy no longer reclaims reserved items, acquiring a fresh item for waiters instead. `Pool.reserve` is now a full no-op when per-item concurrency is `1`; previously it removed the item from availability while leaving its capacity unchanged.

--- a/packages/effect/src/Pool.ts
+++ b/packages/effect/src/Pool.ts
@@ -789,8 +789,9 @@ export const reserve: {
         if (self.config.concurrency === 1) return undefined
         for (const poolItem of self.state.items) {
           if (poolItem.exit._tag !== "Success" || poolItem.exit.value !== item) continue
-          self.state.usage += self.config.concurrency - 1
-          reservations.set(poolItem, (reservations.get(poolItem) ?? 0) + 1)
+          const existing = reservations.get(poolItem)
+          if (existing === undefined) self.state.usage += self.config.concurrency - 1
+          reservations.set(poolItem, (existing ?? 0) + 1)
           removeAvailable(self, poolItem)
           return poolItem
         }
@@ -799,20 +800,20 @@ export const reserve: {
       (poolItem) =>
         core.withFiber((fiber) => {
           if (poolItem === undefined) return internal.void
-          self.state.usage -= self.config.concurrency - 1
-          const remaining = reservations.get(poolItem)! - 1
+          const remaining = (reservations.get(poolItem) ?? 1) - 1
           if (remaining > 0) {
             reservations.set(poolItem, remaining)
             return internal.void
           }
           reservations.delete(poolItem)
+          self.state.usage -= self.config.concurrency - 1
           if (
             !self.state.isShuttingDown &&
             self.state.items.has(poolItem) &&
             !self.state.invalidated.has(poolItem) &&
             poolItem.refCount < self.config.concurrency
           ) {
-            addAvailable(self, poolItem)
+            addAvailableFront(self, poolItem)
             wakeWaiters(self, fiber, self.config.concurrency - poolItem.refCount)
           }
           return internal.void
@@ -1000,7 +1001,7 @@ const strategyUsageTTL = Effect.fnUntraced(function*<A, E>(ttl: Duration.Input) 
           return Effect.undefined
         }
         const item = Iterable.head(
-          Iterable.filter(pool.state.invalidated, (item) => !item.disableReclaim)
+          Iterable.filter(pool.state.invalidated, (item) => !item.disableReclaim && !reservations.has(item))
         )
         if (item._tag === "None") {
           return Effect.undefined

--- a/packages/effect/src/Pool.ts
+++ b/packages/effect/src/Pool.ts
@@ -673,9 +673,12 @@ const wakeAll = <A, E>(self: Pool<A, E>): Effect.Effect<void> =>
     return internal.void
   })
 
+// Reservations prevent reuse without extending the lifetime of borrowed items.
+const reservations = new WeakMap<PoolItem<unknown, unknown>, number>()
+
 /** Adds a freshly acquired item, which has no use behind it, at the back. */
 const addAvailable = <A, E>(self: Pool<A, E>, item: PoolItem<A, E>): void => {
-  if (item.isAvailable) return
+  if (item.isAvailable || reservations.has(item)) return
   item.isAvailable = true
   item.availablePrevious = self.state.availableTail
   item.availableNext = undefined
@@ -701,7 +704,7 @@ const addAvailable = <A, E>(self: Pool<A, E>, item: PoolItem<A, E>): void => {
  * item is checked out either way.
  */
 const addAvailableFront = <A, E>(self: Pool<A, E>, item: PoolItem<A, E>): void => {
-  if (item.isAvailable) return
+  if (item.isAvailable || reservations.has(item)) return
   item.isAvailable = true
   item.availablePrevious = undefined
   item.availableNext = self.state.availableHead
@@ -783,9 +786,11 @@ export const reserve: {
   <A, E>(self: Pool<A, E>, item: A): Effect.Effect<void, never, Scope.Scope> =>
     Effect.asVoid(Effect.acquireRelease(
       Effect.sync(() => {
+        if (self.config.concurrency === 1) return undefined
         for (const poolItem of self.state.items) {
           if (poolItem.exit._tag !== "Success" || poolItem.exit.value !== item) continue
           self.state.usage += self.config.concurrency - 1
+          reservations.set(poolItem, (reservations.get(poolItem) ?? 0) + 1)
           removeAvailable(self, poolItem)
           return poolItem
         }
@@ -795,14 +800,21 @@ export const reserve: {
         core.withFiber((fiber) => {
           if (poolItem === undefined) return internal.void
           self.state.usage -= self.config.concurrency - 1
+          const remaining = reservations.get(poolItem)! - 1
+          if (remaining > 0) {
+            reservations.set(poolItem, remaining)
+            return internal.void
+          }
+          reservations.delete(poolItem)
           if (
+            !self.state.isShuttingDown &&
             self.state.items.has(poolItem) &&
             !self.state.invalidated.has(poolItem) &&
             poolItem.refCount < self.config.concurrency
           ) {
             addAvailable(self, poolItem)
+            wakeWaiters(self, fiber, self.config.concurrency - poolItem.refCount)
           }
-          wakeWaiters(self, fiber, self.config.concurrency - 1)
           return internal.void
         })
     ))

--- a/packages/effect/test/Pool.test.ts
+++ b/packages/effect/test/Pool.test.ts
@@ -338,8 +338,12 @@ describe("Pool", () => {
       yield* Pool.get(pool).pipe(Scope.provide(owner))
       yield* Pool.reserve(pool, "resource").pipe(Scope.provide(first))
       yield* Pool.reserve(pool, "resource").pipe(Scope.provide(second))
+      // One lease plus one reservation; the overlapping reservation must not
+      // count usage again.
+      assert.strictEqual(pool.state.usage, 2)
 
       yield* Scope.close(first, Exit.void)
+      assert.strictEqual(pool.state.usage, 2)
       const next = yield* Pool.use(pool, Effect.succeed).pipe(Effect.forkChild({ startImmediately: true }))
       const beforeRelease = next.pollUnsafe()
       yield* Scope.close(second, Exit.void)
@@ -376,7 +380,7 @@ describe("Pool", () => {
       assert.strictEqual(pool.state.usage, 0)
     }))
 
-  it.effect("usage TTL reclaim preserves a reservation", () =>
+  it.effect("usage TTL reclaim skips reserved items", () =>
     Effect.gen(function*() {
       let acquired = 0
       const pool = yield* Pool.makeWithTTL({
@@ -396,16 +400,15 @@ describe("Pool", () => {
       const first = yield* Pool.get(pool).pipe(Scope.provide(owner))
       yield* TestClock.adjust(0)
       const second = yield* Pool.get(pool).pipe(Scope.provide(owner))
-      const next = yield* Pool.use(pool, Effect.succeed).pipe(Effect.forkChild({ startImmediately: true }))
-      const beforeRelease = next.pollUnsafe()
+      // The invalidated item 1 is still reserved, so reclaim must not
+      // un-invalidate it; the waiter is served by a fresh item instead.
+      const result = yield* Pool.use(pool, Effect.succeed)
       yield* Scope.close(reservation, Exit.void)
-      const result = yield* Fiber.join(next)
       yield* Scope.close(owner, Exit.void)
 
       assert.deepStrictEqual([first, second], [2, 2])
-      assert.isUndefined(beforeRelease)
-      assert.strictEqual(result, 1)
-      assert.strictEqual(acquired, 2)
+      assert.strictEqual(result, 3)
+      assert.strictEqual(acquired, 3)
       assert.strictEqual(pool.state.usage, 0)
     }))
 

--- a/packages/effect/test/Pool.test.ts
+++ b/packages/effect/test/Pool.test.ts
@@ -308,6 +308,164 @@ describe("Pool", () => {
       yield* Scope.close(scope1, Exit.void)
     }))
 
+  it.effect("releasing a shared borrower preserves an active reservation", () =>
+    Effect.gen(function*() {
+      const pool = yield* Pool.make({ acquire: Effect.succeed("resource"), size: 1, concurrency: 2 })
+      const owner = yield* Scope.make()
+      const borrower = yield* Scope.make()
+      const reservation = yield* Scope.make()
+      yield* Pool.get(pool).pipe(Scope.provide(owner))
+      yield* Pool.get(pool).pipe(Scope.provide(borrower))
+      yield* Pool.reserve(pool, "resource").pipe(Scope.provide(reservation))
+
+      yield* Scope.close(borrower, Exit.void)
+      const next = yield* Pool.use(pool, Effect.succeed).pipe(Effect.forkChild({ startImmediately: true }))
+      const beforeRelease = next.pollUnsafe()
+      yield* Scope.close(reservation, Exit.void)
+      const result = yield* Fiber.join(next)
+      yield* Scope.close(owner, Exit.void)
+
+      assert.isUndefined(beforeRelease)
+      assert.strictEqual(result, "resource")
+    }))
+
+  it.effect("overlapping reservations keep an item reserved until both close", () =>
+    Effect.gen(function*() {
+      const pool = yield* Pool.make({ acquire: Effect.succeed("resource"), size: 1, concurrency: 2 })
+      const owner = yield* Scope.make()
+      const first = yield* Scope.make()
+      const second = yield* Scope.make()
+      yield* Pool.get(pool).pipe(Scope.provide(owner))
+      yield* Pool.reserve(pool, "resource").pipe(Scope.provide(first))
+      yield* Pool.reserve(pool, "resource").pipe(Scope.provide(second))
+
+      yield* Scope.close(first, Exit.void)
+      const next = yield* Pool.use(pool, Effect.succeed).pipe(Effect.forkChild({ startImmediately: true }))
+      const beforeRelease = next.pollUnsafe()
+      yield* Scope.close(second, Exit.void)
+      const result = yield* Fiber.join(next)
+      yield* Scope.close(owner, Exit.void)
+
+      assert.isUndefined(beforeRelease)
+      assert.strictEqual(result, "resource")
+      assert.strictEqual(pool.state.usage, 0)
+    }))
+
+  it.effect("releasing a reservation wakes all available slots after borrowers return", () =>
+    Effect.gen(function*() {
+      const pool = yield* Pool.make({ acquire: Effect.succeed("resource"), size: 1, concurrency: 2 })
+      const owner = yield* Scope.make()
+      const reservation = yield* Scope.make()
+      const borrowers = yield* Scope.make()
+      yield* Pool.get(pool).pipe(Scope.provide(owner))
+      yield* Pool.reserve(pool, "resource").pipe(Scope.provide(reservation))
+      yield* Scope.close(owner, Exit.void)
+
+      const first = yield* Pool.get(pool).pipe(Scope.provide(borrowers), Effect.forkChild({ startImmediately: true }))
+      const second = yield* Pool.get(pool).pipe(Scope.provide(borrowers), Effect.forkChild({ startImmediately: true }))
+      const beforeRelease = [first.pollUnsafe(), second.pollUnsafe()]
+      yield* Scope.close(reservation, Exit.void)
+      yield* TestClock.adjust(0)
+      const afterRelease = [first.pollUnsafe(), second.pollUnsafe()]
+      yield* Fiber.interrupt(first)
+      yield* Fiber.interrupt(second)
+      yield* Scope.close(borrowers, Exit.void)
+
+      assert.deepStrictEqual(beforeRelease, [undefined, undefined])
+      assert.deepStrictEqual(afterRelease, [Exit.succeed("resource"), Exit.succeed("resource")])
+      assert.strictEqual(pool.state.usage, 0)
+    }))
+
+  it.effect("usage TTL reclaim preserves a reservation", () =>
+    Effect.gen(function*() {
+      let acquired = 0
+      const pool = yield* Pool.makeWithTTL({
+        acquire: Effect.sync(() => ++acquired),
+        min: 0,
+        max: 2,
+        concurrency: 2,
+        timeToLive: 1000
+      })
+      const owner = yield* Scope.make()
+      const reservation = yield* Scope.make()
+      yield* Pool.get(pool).pipe(Scope.provide(owner))
+      yield* Pool.reserve(pool, 1).pipe(Scope.provide(reservation))
+      yield* Pool.use(pool, Effect.succeed)
+      yield* TestClock.adjust(1000)
+
+      const first = yield* Pool.get(pool).pipe(Scope.provide(owner))
+      yield* TestClock.adjust(0)
+      const second = yield* Pool.get(pool).pipe(Scope.provide(owner))
+      const next = yield* Pool.use(pool, Effect.succeed).pipe(Effect.forkChild({ startImmediately: true }))
+      const beforeRelease = next.pollUnsafe()
+      yield* Scope.close(reservation, Exit.void)
+      const result = yield* Fiber.join(next)
+      yield* Scope.close(owner, Exit.void)
+
+      assert.deepStrictEqual([first, second], [2, 2])
+      assert.isUndefined(beforeRelease)
+      assert.strictEqual(result, 1)
+      assert.strictEqual(acquired, 2)
+      assert.strictEqual(pool.state.usage, 0)
+    }))
+
+  it.effect("reserve is a no-op with concurrency one", () =>
+    Effect.gen(function*() {
+      const pool = yield* Pool.make({ acquire: Effect.succeed("resource"), size: 1 })
+      const owner = yield* Scope.make()
+      const reservation = yield* Scope.make()
+      yield* Pool.get(pool).pipe(Scope.provide(owner))
+      yield* Pool.reserve(pool, "resource").pipe(Scope.provide(reservation))
+      yield* Scope.close(owner, Exit.void)
+
+      const next = yield* Pool.use(pool, Effect.succeed).pipe(Effect.forkChild({ startImmediately: true }))
+      const beforeRelease = next.pollUnsafe()
+      yield* Scope.close(reservation, Exit.void)
+      yield* Fiber.interrupt(next)
+
+      assert.deepStrictEqual(beforeRelease, Exit.succeed("resource"))
+    }))
+
+  it.effect.each([false, true])(
+    "reservation cleanup does not revive removed items (shutdown: %s)",
+    (shutdown) =>
+      Effect.gen(function*() {
+        let acquired = 0
+        const released: Array<number> = []
+        const poolScope = yield* Scope.make()
+        const owner = yield* Scope.make()
+        const reservation = yield* Scope.make()
+        const pool = yield* Pool.make({
+          acquire: Effect.acquireRelease(
+            Effect.sync(() => ++acquired),
+            (item) => Effect.sync(() => released.push(item))
+          ),
+          size: 1,
+          concurrency: 2
+        }).pipe(Scope.provide(poolScope))
+        yield* Pool.get(pool).pipe(Scope.provide(owner))
+        yield* Pool.reserve(pool, 1).pipe(Scope.provide(reservation))
+        yield* Scope.close(owner, Exit.void)
+        if (shutdown) {
+          yield* Scope.close(poolScope, Exit.void)
+        } else {
+          yield* Pool.invalidate(pool, 1)
+        }
+        yield* Scope.close(reservation, Exit.void)
+        const next = yield* Effect.exit(Pool.use(pool, Effect.succeed))
+        yield* Scope.close(poolScope, Exit.void)
+
+        if (shutdown) {
+          assert.isTrue(Exit.hasInterrupts(next))
+          assert.deepStrictEqual(released, [1])
+        } else {
+          assert.deepStrictEqual(next, Exit.succeed(2))
+          assert.deepStrictEqual(released, [1, 2])
+        }
+        assert.strictEqual(pool.state.usage, 0)
+      })
+  )
+
   it.effect("scale to zero", () =>
     Effect.gen(function*() {
       const deferred = yield* Deferred.make<void>()


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

### Why
Returning another shared borrow can put a reserved item back into circulation before its reservation closes. Usage-TTL reclaim and overlapping reservations have the same problem. PostgreSQL multiplexing uses this API to pin connections.

### What Changes
Track active reservations separately from resource-owning leases and check them on both availability insertion paths.

| Event while reserved | Before | After |
| --- | --- | --- |
| Peer returns, TTL reclaims, or one overlapping reservation closes | Item becomes borrowable | Item stays reserved |
| Last reservation closes | Waiter count assumes one borrow remains | Wake all available slots |

### Scope
Preserves exported types and existing resource lifetime: reservations prevent reuse, not invalidation or shutdown cleanup. Includes controls for those boundaries and an `effect` patch changeset.

### Verification
```bash
pnpm test --run packages/effect/test/Pool.test.ts
EFFECT_INTEGRATION_TESTS=1 pnpm test --run packages/sql/pg/test/PgPool.integration.test.ts
pnpm lint
pnpm check
git diff --check
```
37 Pool tests and 15 PostgreSQL integration tests pass; lint and typecheck pass. Against the original Pool implementation, four regressions fail and 33 tests pass.

## Related

Closes #7599.

## Audit

Runtime correctness audit; intended label: `audit`.
