### PR TITLE
fix(RcMap): handle synchronous lookup defects

### DIFF
--- a/.changeset/rcmap-throwing-lookup.md
+++ b/.changeset/rcmap-throwing-lookup.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `RcMap` entries getting stuck when the lookup function throws synchronously. Later borrowers now receive the defect, and unused entries are released according to their idle TTL instead of permanently consuming capacity.

--- a/packages/effect/src/RcMap.ts
+++ b/packages/effect/src/RcMap.ts
@@ -370,7 +370,7 @@ export const get: {
           context.set(key, value)
         })
         context.set(Scope.Scope.key, entry.scope)
-        self.lookup(key).pipe(
+        Effect.suspend(() => self.lookup(key)).pipe(
           Effect.runForkWith(Context.makeUnsafe(context)),
           Fiber.runIn(entry.scope)
         ).addObserver((exit) => Deferred.doneUnsafe(entry.deferred, exit))

--- a/packages/effect/test/RcMap.test.ts
+++ b/packages/effect/test/RcMap.test.ts
@@ -3,6 +3,53 @@ import { Cause, Data, Deferred, Effect, Exit, Fiber, MutableHashMap, Option, RcM
 import { TestClock } from "effect/testing"
 
 describe("RcMap", () => {
+  describe("lookup defects", () => {
+    for (const throws of [false, true]) {
+      it.effect.each([0, 1000])(
+        `releases capacity after a ${throws ? "throwing" : "dying"} lookup with TTL %s`,
+        (idleTimeToLive) =>
+          Effect.gen(function*() {
+            const map = yield* RcMap.make({
+              lookup: (key: string) => {
+                if (key !== "bad") return Effect.succeed(key)
+                if (throws) throw "boom"
+                return Effect.die("boom")
+              },
+              capacity: 1,
+              idleTimeToLive
+            })
+
+            assert.deepStrictEqual(yield* RcMap.get(map, "bad").pipe(Effect.scoped, Effect.exit), Exit.die("boom"))
+            if (idleTimeToLive > 0) {
+              assert.isTrue(yield* RcMap.has(map, "bad"))
+              yield* TestClock.adjust(idleTimeToLive)
+            }
+            assert.deepStrictEqual(yield* RcMap.get(map, "good").pipe(Effect.exit), Exit.succeed("good"))
+            assert.isFalse(yield* RcMap.has(map, "bad"))
+          })
+      )
+
+      it.effect(`shares a ${throws ? "throwing" : "dying"} lookup's defect with later borrowers`, () =>
+        Effect.gen(function*() {
+          const map = yield* RcMap.make({
+            lookup: (_key: string): Effect.Effect<string> => {
+              if (throws) throw "boom"
+              return Effect.die("boom")
+            }
+          })
+
+          assert.deepStrictEqual(yield* RcMap.get(map, "bad").pipe(Effect.exit), Exit.die("boom"))
+          const borrower = yield* RcMap.getOption(map, "bad").pipe(
+            Effect.exit,
+            Effect.timeoutOption(1000),
+            Effect.forkChild({ startImmediately: true })
+          )
+          yield* TestClock.adjust(1000)
+          assert.deepStrictEqual(yield* Fiber.join(borrower), Option.some(Exit.die("boom")))
+        }))
+    }
+  })
+
   describe("invalidate", () => {
     it.effect.each([0, 1000, Infinity])(
       "releases only the invalidated entry with TTL %s",


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

### Why
A synchronous throw from `RcMap.lookup` leaves an inserted entry without its result observer or borrower finalizer. Later borrowers hang, and the entry permanently consumes capacity.

### What Changes
Wrap callback evaluation in `Effect.suspend` so the existing lookup fiber handles the defect.

| After a throwing lookup | Before | After |
| --- | --- | --- |
| Later borrower of the same entry | Waits indefinitely | Receives the defect |
| Borrower closes; idle TTL expires | Capacity remains occupied | Entry releases capacity |

### Scope
One source-line change, with zero/finite TTL and `Effect.die` controls. The throw remains a defect; lookup and ownership policy are unchanged. Includes an `effect` patch changeset.

### Verification
```bash
pnpm test --run packages/effect/test/RcMap.test.ts packages/effect/test/LayerMap.test.ts
pnpm lint
pnpm check
git diff --check
```
31 tests pass; lint and typecheck pass. On the original implementation, three throwing-lookup regressions fail and three `Effect.die` controls pass.

## Related

Closes #7600.

## Audit

Runtime correctness audit; intended label: `audit`.
