### PR TITLE
fix(ScopedCache): detach invalidated entries before finalization

### DIFF
--- a/.changeset/scoped-cache-invalidate-all-reentrancy.md
+++ b/.changeset/scoped-cache-invalidate-all-reentrancy.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `ScopedCache.invalidateAll` discarding entries created by reentrant resource finalizers without releasing them. Entries are now removed before their finalizers run, so replacement resources remain cached and are released when the cache closes.

--- a/packages/effect/src/ScopedCache.ts
+++ b/packages/effect/src/ScopedCache.ts
@@ -692,11 +692,13 @@ const invalidateAllImpl = <Key, A, E>(
   parent: Fiber.Fiber<unknown, unknown>,
   map: MutableHashMap.MutableHashMap<Key, Entry<A, E>>
 ): Effect.Effect<void> => {
+  // Detach the batch before finalizers can reenter the cache.
+  const entries = Array.from(MutableHashMap.values(map))
+  MutableHashMap.clear(map)
   const fibers = Arr.empty<Fiber.Fiber<unknown, unknown>>()
-  for (const [, entry] of map) {
+  for (const entry of entries) {
     fibers.push(effect.forkUnsafe(parent as any, Scope.close(entry.scope, effect.exitVoid), true, true))
   }
-  MutableHashMap.clear(map)
   return effect.fiberAwaitAll(fibers)
 }
 

--- a/packages/effect/test/ScopedCache.test.ts
+++ b/packages/effect/test/ScopedCache.test.ts
@@ -899,6 +899,66 @@ describe("ScopedCache", () => {
     })
 
     describe("invalidateAll", () => {
+      it.effect.each([false, true])(
+        "retains ownership of entries refreshed by finalizers (yield: %s)",
+        (yieldBeforeRefresh) =>
+          Effect.gen(function*() {
+            let acquired = 0
+            const released: Array<number> = []
+
+            const cached = yield* Effect.scoped(Effect.gen(function*() {
+              const cache: ScopedCache.ScopedCache<string, number> = yield* ScopedCache.make({
+                capacity: 10,
+                lookup: (_key: string) =>
+                  Effect.acquireRelease(
+                    Effect.sync(() => ++acquired),
+                    (value) =>
+                      Effect.gen(function*() {
+                        released.push(value)
+                        if (value === 1) {
+                          if (yieldBeforeRefresh) {
+                            yield* Effect.yieldNow
+                          }
+                          yield* ScopedCache.refresh(cache, "key")
+                        }
+                      })
+                  )
+              })
+
+              yield* ScopedCache.get(cache, "key")
+              yield* ScopedCache.invalidateAll(cache)
+              assert.deepStrictEqual(released, [1])
+              return yield* ScopedCache.getSuccess(cache, "key")
+            }))
+
+            assert.strictEqual(acquired, 2)
+            assert.deepStrictEqual(released, [1, 2])
+            assert.deepStrictEqual(cached, Option.some(2))
+          })
+      )
+
+      it.effect("removes all entries before running finalizers", () =>
+        Effect.gen(function*() {
+          const observedKeys: Array<Array<string>> = []
+          const cache: ScopedCache.ScopedCache<string, string> = yield* ScopedCache.make({
+            capacity: 10,
+            lookup: (key: string) =>
+              Effect.acquireRelease(
+                Effect.succeed(key),
+                () =>
+                  Effect.gen(function*() {
+                    observedKeys.push(yield* ScopedCache.keys(cache))
+                  })
+              )
+          })
+
+          yield* ScopedCache.get(cache, "first")
+          yield* ScopedCache.get(cache, "second")
+          yield* ScopedCache.invalidateAll(cache)
+
+          assert.deepStrictEqual(observedKeys, [[], []])
+        }))
+
       it.effect("clears all entries", () =>
         Effect.gen(function*() {
           const cache = yield* ScopedCache.make({


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

### Why
A resource finalizer can synchronously refresh its key during `ScopedCache.invalidateAll`. Bulk invalidation then clears the replacement without closing its resource scope, leaking it even after the cache closes.

### What Changes
Snapshot and clear the original entries before starting their finalizers.

| Reentrant refresh during invalidation | Before | After |
| --- | --- | --- |
| Replacement after invalidation | Discarded | Still cached |
| Releases after owner closure | `[1]` | `[1, 2]` |

### Scope
Only bulk-invalidation ordering changes. Finalizers are still awaited; owner shutdown still closes the cache before finalization. Includes a yielding control and an `effect` patch changeset.

### Verification
```bash
pnpm test --run packages/effect/test/ScopedCache.test.ts
pnpm lint
pnpm check
git diff --check
```
117 tests pass; lint and typecheck pass. On the original implementation, two regressions fail and the yielding control passes.

## Related

Closes #7602.

## Audit

Runtime correctness audit; intended label: `audit`.
