### PR TITLE
fix(PubSub): preserve empty sentinel values in batched polling

### DIFF
--- a/packages/effect/src/PubSub.ts
+++ b/packages/effect/src/PubSub.ts
@@ -2025,11 +2025,10 @@ class BoundedPubSubSingleSubscription<in out A> implements PubSub.BackingSubscri
   }
 
   pollUpTo(n: number): Array<A> {
-    if (Count.normalize(n) < 1) {
+    if (Count.normalize(n) < 1 || this.isEmpty()) {
       return []
     }
-    const elem = this.poll()
-    return elem === MutableList.Empty ? [] : [elem]
+    return [this.poll() as A]
   }
 
   unsubscribe(): void {

--- a/packages/effect/test/PubSub.test.ts
+++ b/packages/effect/test/PubSub.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Array, Effect, Exit, Fiber, Latch, PubSub, Scope, Stream } from "effect"
+import { Array, Effect, Exit, Fiber, Latch, MutableList, PubSub, Scope, Stream } from "effect"
 import { pipe } from "effect/Function"
 
 describe("PubSub", () => {
@@ -462,6 +462,14 @@ describe("PubSub", () => {
     assert.deepStrictEqual(replay.takeAll(), [2, 3])
   })
 
+  it("polls MutableList.Empty as a value", () => {
+    const pubsub = PubSub.makeAtomicBounded<symbol>(1)
+    const subscription = pubsub.subscribe()
+    pubsub.publish(MutableList.Empty)
+
+    assert.deepStrictEqual(subscription.pollUpTo(1), [MutableList.Empty])
+  })
+
   it("publishes after a capacity-one subscriber unsubscribes from a slid message", () => {
     const pubsub = PubSub.makeAtomicBounded<number>(1)
     const subscription = pubsub.subscribe()
@@ -469,9 +477,10 @@ describe("PubSub", () => {
     pubsub.slide()
     subscription.unsubscribe()
 
+    const next = pubsub.subscribe()
     assert.isTrue(pubsub.publish(2))
-    assert.strictEqual(pubsub.size(), 0)
-    assert.isFalse(pubsub.isFull())
+    assert.strictEqual(pubsub.size(), 1)
+    assert.deepStrictEqual(next.pollUpTo(1), [2])
   })
 
   describe("replay", () => {


### PR DESCRIPTION
## Summary

- Check the capacity-one subscription state before delegating `pollUpTo` to `poll`, preserving `MutableList.Empty` when it is the published value.
- Strengthen the slid-message unsubscribe regression test to resubscribe and consume a later publication end to end.
- Add coverage for polling `MutableList.Empty` as a real value.

Follow-up to #7603.

## Verification

```bash
pnpm lint-fix
pnpm test --run packages/effect/test/PubSub.test.ts
pnpm check
git diff --check
```

49 PubSub tests pass; lint, formatting, and typecheck are clean.

Closes EFF-1013
