### PR TITLE
fix(RequestResolver): preserve persisted batch failure results

### DIFF
--- a/.changeset/request-persisted-resolver-failures.md
+++ b/.changeset/request-persisted-resolver-failures.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `RequestResolver.persisted` to propagate and persist resolver failures and defects for incomplete requests without overwriting results from already completed requests. Thrown resolver callbacks now follow the same persistence path as effect defects.

--- a/.changeset/request-persisted-resolver-failures.md
+++ b/.changeset/request-persisted-resolver-failures.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix `RequestResolver.persisted` to propagate and persist resolver failures and defects for incomplete requests without overwriting results from already completed requests. Thrown resolver callbacks now follow the same persistence path as effect defects.
+Preserve completed results and propagate resolver failures from `RequestResolver.persisted`.

--- a/packages/effect/src/RequestResolver.ts
+++ b/packages/effect/src/RequestResolver.ts
@@ -1275,6 +1275,7 @@ export const persisted: {
         >)
         const leftover: Array<Request.Entry<A>> = []
         const toPersist = new Map<A, Request.Result<A>>()
+        const completed = new Set<Request.Entry<A>>()
         for (let i = 0; i < results.length; i++) {
           const entry = entries[i]
           const exit = results[i]
@@ -1284,6 +1285,7 @@ export const persisted: {
           ) {
             const prevComplete = entry.completeUnsafe
             entry.completeUnsafe = function(exit) {
+              completed.add(entry)
               toPersist.set(entry.request, exit as any)
               prevComplete(exit)
             }
@@ -1295,10 +1297,10 @@ export const persisted: {
         if (!Arr.isArrayNonEmpty(leftover)) {
           return
         }
-        yield* Effect.catchCause(self.runAll(leftover, key), (cause) => {
+        yield* Effect.catchCause(Effect.suspend(() => self.runAll(leftover, key)), (cause) => {
           for (let i = 0; i < leftover.length; i++) {
             const entry = leftover[i]
-            if (!toPersist.has(entry.request)) continue
+            if (completed.has(entry)) continue
             entry.completeUnsafe(Exit.failCause(cause) as any)
           }
           return Effect.void

--- a/packages/effect/test/Request.test.ts
+++ b/packages/effect/test/Request.test.ts
@@ -1,12 +1,13 @@
 import { assert, describe, expect, it } from "@effect/vitest"
-import { Array, Context, Data, Deferred, Equal, Fiber, Hash, Schema } from "effect"
+import { Array, Context, Data, Deferred, Equal, Fiber, Hash, Layer, Schema } from "effect"
 import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import { flow, pipe } from "effect/Function"
 import * as Request from "effect/Request"
 import * as Resolver from "effect/RequestResolver"
-import { Persistable, Persistence } from "effect/unstable/persistence"
+import * as Persistable from "effect/unstable/persistence/Persistable"
+import * as Persistence from "effect/unstable/persistence/Persistence"
 
 class Counter extends Context.Service<Counter, { count: number }>()("Counter") {}
 class Requests extends Context.Service<Requests, { count: number }>()("Requests") {}
@@ -543,6 +544,85 @@ describe.sequential("Request", () => {
       assert.strictEqual(yield* Effect.request(new GetName(), resolver), "Bob")
       assert.strictEqual(calls, 1)
     }).pipe(Effect.provide(Persistence.layerMemory)))
+  for (const failure of ["failure", "defect", "throw"] as const) {
+    it.effect(`persisted preserves completed results and propagates a resolver ${failure}`, () =>
+      Effect.gen(function*() {
+        class GetValue extends Persistable.Class<{ payload: { id: number } }>()("GetValue", {
+          primaryKey: ({ id }) => String(id),
+          success: Schema.String,
+          error: Persistence.PersistenceError
+        }) {}
+        const error = new Persistence.PersistenceError({ message: "backend failed" })
+        let calls = 0
+        const resolver = Resolver.make<GetValue>((entries) => {
+          calls++
+          entries[0].completeUnsafe(Exit.succeed("first"))
+          if (failure === "throw") throw "backend failed"
+          return failure === "failure" ? Effect.fail(error) : Effect.die("backend failed")
+        })
+        const expected = [
+          Exit.succeed("first"),
+          failure === "failure" ? Exit.fail(error) : Exit.die("backend failed")
+        ]
+        const requests = [new GetValue({ id: 1 }), new GetValue({ id: 2 })]
+
+        assert.deepStrictEqual(
+          yield* Effect.forEach(requests, (request) => Effect.exit(Effect.request(request, resolver)), {
+            concurrency: "unbounded"
+          }),
+          expected
+        )
+        const persisted = yield* Resolver.persisted(resolver, { storeId: "resolver-failure" })
+        assert.deepStrictEqual(
+          yield* Effect.forEach(requests, (request) => Effect.exit(Effect.request(request, persisted)), {
+            concurrency: "unbounded"
+          }),
+          expected
+        )
+        yield* Effect.yieldNow
+        assert.deepStrictEqual(
+          yield* Effect.forEach(requests, (request) => Effect.exit(Effect.request(request, persisted)), {
+            concurrency: "unbounded"
+          }),
+          expected
+        )
+        assert.strictEqual(calls, 2)
+      }).pipe(Effect.provide(Persistence.layer.pipe(Layer.provide(Persistence.layerBackingMemory)))))
+  }
+
+  it.effect("persisted completes separate entries sharing the same request object", () =>
+    Effect.gen(function*() {
+      class GetValue extends Persistable.Class()("GetSharedValue", {
+        primaryKey: () => "shared",
+        success: Schema.String,
+        error: Persistence.PersistenceError
+      }) {}
+      const request = new GetValue()
+      const error = new Persistence.PersistenceError({ message: "backend failed" })
+      const resolver = Resolver.make<GetValue>((entries) => {
+        assert.strictEqual(entries.length, 2)
+        assert.strictEqual(entries[0].request, entries[1].request)
+        entries[0].completeUnsafe(Exit.succeed("first"))
+        return Effect.fail(error)
+      })
+      const expected = [Exit.succeed("first"), Exit.fail(error)]
+
+      assert.deepStrictEqual(
+        yield* Effect.forEach([request, request], (request) => Effect.exit(Effect.request(request, resolver)), {
+          concurrency: "unbounded"
+        }),
+        expected
+      )
+      const persisted = yield* Resolver.persisted(resolver, { storeId: "shared-request" })
+      assert.deepStrictEqual(
+        yield* Effect.forEach([request, request], (request) => Effect.exit(Effect.request(request, persisted)), {
+          concurrency: "unbounded"
+        }),
+        expected
+      )
+      yield* Effect.yieldNow
+      assert.deepStrictEqual(yield* Effect.exit(Effect.request(request, persisted)), Exit.fail(error))
+    }).pipe(Effect.provide(Persistence.layer.pipe(Layer.provide(Persistence.layerBackingMemory)))))
 
   it.effect(
     "batching preserves individual & identical requests",

--- a/packages/effect/test/Request.test.ts
+++ b/packages/effect/test/Request.test.ts
@@ -1,13 +1,12 @@
 import { assert, describe, expect, it } from "@effect/vitest"
-import { Array, Context, Data, Deferred, Equal, Fiber, Hash, Layer, Schema } from "effect"
+import { Array, Context, Data, Deferred, Equal, Fiber, Hash, Schema } from "effect"
 import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import { flow, pipe } from "effect/Function"
 import * as Request from "effect/Request"
 import * as Resolver from "effect/RequestResolver"
-import * as Persistable from "effect/unstable/persistence/Persistable"
-import * as Persistence from "effect/unstable/persistence/Persistence"
+import { Persistable, Persistence } from "effect/unstable/persistence"
 
 class Counter extends Context.Service<Counter, { count: number }>()("Counter") {}
 class Requests extends Context.Service<Requests, { count: number }>()("Requests") {}
@@ -544,85 +543,50 @@ describe.sequential("Request", () => {
       assert.strictEqual(yield* Effect.request(new GetName(), resolver), "Bob")
       assert.strictEqual(calls, 1)
     }).pipe(Effect.provide(Persistence.layerMemory)))
-  for (const failure of ["failure", "defect", "throw"] as const) {
-    it.effect(`persisted preserves completed results and propagates a resolver ${failure}`, () =>
-      Effect.gen(function*() {
-        class GetValue extends Persistable.Class<{ payload: { id: number } }>()("GetValue", {
-          primaryKey: ({ id }) => String(id),
-          success: Schema.String,
-          error: Persistence.PersistenceError
-        }) {}
-        const error = new Persistence.PersistenceError({ message: "backend failed" })
-        let calls = 0
-        const resolver = Resolver.make<GetValue>((entries) => {
-          calls++
-          entries[0].completeUnsafe(Exit.succeed("first"))
-          if (failure === "throw") throw "backend failed"
-          return failure === "failure" ? Effect.fail(error) : Effect.die("backend failed")
-        })
-        const expected = [
-          Exit.succeed("first"),
-          failure === "failure" ? Exit.fail(error) : Exit.die("backend failed")
-        ]
-        const requests = [new GetValue({ id: 1 }), new GetValue({ id: 2 })]
 
-        assert.deepStrictEqual(
-          yield* Effect.forEach(requests, (request) => Effect.exit(Effect.request(request, resolver)), {
-            concurrency: "unbounded"
-          }),
-          expected
-        )
-        const persisted = yield* Resolver.persisted(resolver, { storeId: "resolver-failure" })
-        assert.deepStrictEqual(
-          yield* Effect.forEach(requests, (request) => Effect.exit(Effect.request(request, persisted)), {
-            concurrency: "unbounded"
-          }),
-          expected
-        )
-        yield* Effect.yieldNow
-        assert.deepStrictEqual(
-          yield* Effect.forEach(requests, (request) => Effect.exit(Effect.request(request, persisted)), {
-            concurrency: "unbounded"
-          }),
-          expected
-        )
-        assert.strictEqual(calls, 2)
-      }).pipe(Effect.provide(Persistence.layer.pipe(Layer.provide(Persistence.layerBackingMemory)))))
-  }
-
-  it.effect("persisted completes separate entries sharing the same request object", () =>
+  it.effect("persisted propagates failures to unfinished requests", () =>
     Effect.gen(function*() {
-      class GetValue extends Persistable.Class()("GetSharedValue", {
-        primaryKey: () => "shared",
+      class GetValue extends Persistable.Class<{ payload: { id: number } }>()("GetValue", {
+        primaryKey: ({ id }) => String(id),
         success: Schema.String,
         error: Persistence.PersistenceError
       }) {}
-      const request = new GetValue()
+      const request = new GetValue({ id: 1 })
       const error = new Persistence.PersistenceError({ message: "backend failed" })
       const resolver = Resolver.make<GetValue>((entries) => {
-        assert.strictEqual(entries.length, 2)
-        assert.strictEqual(entries[0].request, entries[1].request)
         entries[0].completeUnsafe(Exit.succeed("first"))
         return Effect.fail(error)
       })
-      const expected = [Exit.succeed("first"), Exit.fail(error)]
+      const persisted = yield* Resolver.persisted(resolver, { storeId: "resolver-failure" })
 
       assert.deepStrictEqual(
-        yield* Effect.forEach([request, request], (request) => Effect.exit(Effect.request(request, resolver)), {
-          concurrency: "unbounded"
-        }),
-        expected
+        yield* Effect.forEach(
+          [request, request, new GetValue({ id: 2 })],
+          (request) => Effect.exit(Effect.request(request, persisted)),
+          { concurrency: "unbounded" }
+        ),
+        [Exit.succeed("first"), Exit.fail(error), Exit.fail(error)]
       )
-      const persisted = yield* Resolver.persisted(resolver, { storeId: "shared-request" })
-      assert.deepStrictEqual(
-        yield* Effect.forEach([request, request], (request) => Effect.exit(Effect.request(request, persisted)), {
-          concurrency: "unbounded"
-        }),
-        expected
-      )
-      yield* Effect.yieldNow
-      assert.deepStrictEqual(yield* Effect.exit(Effect.request(request, persisted)), Exit.fail(error))
-    }).pipe(Effect.provide(Persistence.layer.pipe(Layer.provide(Persistence.layerBackingMemory)))))
+    }).pipe(Effect.provide(Persistence.layerMemory)))
+
+  it.effect("persisted stores synchronous resolver failures", () =>
+    Effect.gen(function*() {
+      class GetValue extends Persistable.Class()("ThrowingValue", {
+        primaryKey: () => "value",
+        success: Schema.String
+      }) {}
+      let calls = 0
+      const resolver = Resolver.make<GetValue>(() => {
+        calls++
+        throw "backend defect"
+      })
+      const persisted = yield* Resolver.persisted(resolver, { storeId: "resolver-throw" })
+      const request = new GetValue()
+
+      assert.deepStrictEqual(yield* Effect.exit(Effect.request(request, persisted)), Exit.die("backend defect"))
+      assert.deepStrictEqual(yield* Effect.exit(Effect.request(request, persisted)), Exit.die("backend defect"))
+      assert.strictEqual(calls, 1)
+    }).pipe(Effect.provide(Persistence.layerMemory)))
 
   it.effect(
     "batching preserves individual & identical requests",


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`RequestResolver.persisted` now tracks completed batch entries independently from request-keyed persistence. If a resolver completes part of a batch and then fails, completed results remain intact and unfinished callers receive the original failure.

Synchronous resolver throws now use the same failure path, so their results are persisted instead of rerunning the resolver on the next request.

## Verification

```bash
pnpm test --run packages/effect/test/Request.test.ts
pnpm lint-fix
pnpm check
git diff --check origin/main...HEAD
```

The focused suite passes all 27 tests.

Closes #7610
Closes EFF-1017
