### PR TITLE
fix(FiberMap): retain reentrant replacement ownership

### DIFF
--- a/.changeset/fiber-map-reentrant-replacement.md
+++ b/.changeset/fiber-map-reentrant-replacement.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `FiberMap` losing track of fibers started under the same key by a replaced fiber's synchronous finalizer, ensuring they are interrupted when the map's scope closes.

--- a/packages/effect/src/FiberMap.ts
+++ b/packages/effect/src/FiberMap.ts
@@ -373,10 +373,13 @@ export const setUnsafe: {
     } else if (previous.value === fiber) {
       return
     }
-    previous.value.interruptUnsafe(internalFiberId)
   }
 
+  // Install the replacement before interruption can re-enter the map through a finalizer.
   MutableHashMap.set(self.state.backing, key, fiber)
+  if (previous._tag === "Some") {
+    previous.value.interruptUnsafe(internalFiberId)
+  }
   fiber.addObserver((exit) => {
     if (self.state._tag === "Closed") {
       return

--- a/packages/effect/test/FiberMap.test.ts
+++ b/packages/effect/test/FiberMap.test.ts
@@ -4,6 +4,44 @@ import { Array, Deferred, Effect, Exit, Fiber, FiberMap, Option, pipe, Ref, Scop
 import { TestClock } from "effect/testing"
 
 describe("FiberMap", () => {
+  it.effect("retains ownership of replacements made by a synchronous finalizer", () =>
+    Effect.gen(function*() {
+      const scope = yield* Scope.make()
+      const map = yield* FiberMap.make<string>().pipe(Scope.provide(scope))
+      const run = yield* FiberMap.runtime(map)()
+      const fibers: Array<Fiber.Fiber<unknown, unknown>> = []
+      yield* Effect.addFinalizer(() => Fiber.interruptAll(fibers))
+
+      const previous = run(
+        "key",
+        Effect.never.pipe(
+          Effect.ensuring(Effect.sync(() => {
+            fibers.push(run("key", Effect.never))
+          }))
+        )
+      )
+      const replacement = run("key", Effect.never)
+      fibers.push(previous, replacement)
+      assert.strictEqual(fibers.length, 3)
+
+      yield* Scope.close(scope, Exit.void)
+
+      for (const fiber of fibers) {
+        assert.isDefined(fiber.pollUnsafe())
+      }
+    }))
+
+  it.effect("removes a synchronously completed replacement", () =>
+    Effect.gen(function*() {
+      const map = yield* FiberMap.make<string>()
+      const previous = yield* FiberMap.run(map, "key", Effect.never)
+      const replacement = yield* FiberMap.run(map, "key", Effect.succeed("done"))
+
+      assert.deepStrictEqual(yield* Fiber.join(replacement), "done")
+      assert.isTrue(Exit.hasInterrupts(yield* Fiber.await(previous)))
+      assert.strictEqual(yield* FiberMap.size(map), 0)
+    }))
+
   it.effect("interrupts fibers", () =>
     Effect.gen(function*() {
       const ref = yield* Ref.make(0)


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

### Why
A replaced fiber's synchronous finalizer can start another fiber under the same key. The outer replacement overwrites that entry without interrupting it, leaving a running fiber that survives map scope closure.

### What Changes
Install the replacement before interrupting its predecessor. Reentrant replacements remain owned by the map, and closing the scope now interrupts all three fibers in the reproducer rather than orphaning one.

### Scope
A small ordering change and an `effect` patch changeset. Existing observer identity checks and `onlyIfMissing` behavior remain intact. Includes a synchronous-completion control.

### Verification
```bash
pnpm test --run packages/effect/test/FiberMap.test.ts packages/effect/test/FiberSet.test.ts
pnpm lint
pnpm check
git diff --check origin/main
```
22 tests and all checks pass. The ownership regression fails on the original implementation.

## Related

Closes #7611.

## Audit

Runtime correctness audit; intended label: `audit`.
