### PR TITLE
fix(Chunk): preserve sliced elements during concatenation

### DIFF
--- a/.changeset/chunk-slice-concatenation.md
+++ b/.changeset/chunk-slice-concatenation.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve sliced Chunk elements when subsequent appends or prepends rebalance concatenations.

--- a/.changeset/chunk-slice-concatenation.md
+++ b/.changeset/chunk-slice-concatenation.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Preserve sliced Chunk elements when subsequent appends or prepends rebalance concatenations.
+Fix `Chunk` concatenation to preserve sliced elements.

--- a/packages/effect/src/Chunk.ts
+++ b/packages/effect/src/Chunk.ts
@@ -249,7 +249,7 @@ const makeChunk = <A>(backing: Backing<A>): Chunk<A> => {
     }
     case "ISlice": {
       chunk.length = backing.length
-      chunk.depth = backing.chunk.depth + 1
+      chunk.depth = 0
       chunk.left = _empty
       chunk.right = _empty
       break

--- a/packages/effect/test/Chunk.test.ts
+++ b/packages/effect/test/Chunk.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effect/vitest"
+import { assert, describe, it } from "@effect/vitest"
 import {
   assertEquals,
   assertFalse,
@@ -537,6 +537,58 @@ describe("Chunk", () => {
   })
 
   describe("concat", () => {
+    for (
+      const { name, slice } of [
+        { name: "take", slice: () => Chunk.take(Chunk.make(2, 3, 4), 2) },
+        { name: "drop", slice: () => Chunk.drop(Chunk.make(1, 2, 3), 1) }
+      ]
+    ) {
+      describe(`with ${name} slices`, () => {
+        it("preserves an unmaterialized slice when appending after a prefix", () => {
+          const chunk = Chunk.appendAll(Chunk.of(1), slice())
+          // Observing the intermediate chunk would materialize it and mask the regression.
+          const result = Chunk.append(chunk, 5)
+          assert.deepStrictEqual(Chunk.toArray(result), [1, 2, 3, 5])
+        })
+
+        it("preserves an unmaterialized slice when prepending before a suffix", () => {
+          const chunk = Chunk.appendAll(slice(), Chunk.of(4))
+          const result = Chunk.prepend(chunk, 0)
+          assert.deepStrictEqual(Chunk.toArray(result), [0, 2, 3, 4])
+        })
+
+        it("preserves a slice when appending without a prefix", () => {
+          assert.deepStrictEqual(Chunk.toArray(Chunk.append(slice(), 5)), [2, 3, 5])
+        })
+
+        it("preserves a slice when prepending without a suffix", () => {
+          assert.deepStrictEqual(Chunk.toArray(Chunk.prepend(slice(), 0)), [0, 2, 3])
+        })
+
+        it("preserves a materialized concatenation when appending", () => {
+          const chunk = Chunk.appendAll(Chunk.of(1), slice())
+          assert.deepStrictEqual(Chunk.toArray(chunk), [1, 2, 3])
+          assert.deepStrictEqual(Chunk.toArray(Chunk.append(chunk, 5)), [1, 2, 3, 5])
+        })
+
+        it("preserves a materialized concatenation when prepending", () => {
+          const chunk = Chunk.appendAll(slice(), Chunk.of(4))
+          assert.deepStrictEqual(Chunk.toArray(chunk), [2, 3, 4])
+          assert.deepStrictEqual(Chunk.toArray(Chunk.prepend(chunk, 0)), [0, 2, 3, 4])
+        })
+      })
+    }
+
+    it("preserves an unsliced chunk when appending after a prefix", () => {
+      const chunk = Chunk.appendAll(Chunk.of(1), Chunk.make(2, 3))
+      assert.deepStrictEqual(Chunk.toArray(Chunk.append(chunk, 5)), [1, 2, 3, 5])
+    })
+
+    it("preserves an unsliced chunk when prepending before a suffix", () => {
+      const chunk = Chunk.appendAll(Chunk.make(2, 3), Chunk.of(4))
+      assert.deepStrictEqual(Chunk.toArray(Chunk.prepend(chunk, 0)), [0, 2, 3, 4])
+    })
+
     describe("Given 2 chunks of the same length", () => {
       const chunk1 = Chunk.fromArrayUnsafe([0, 1])
       const chunk2 = Chunk.fromArrayUnsafe([2, 3])

--- a/packages/effect/test/Chunk.test.ts
+++ b/packages/effect/test/Chunk.test.ts
@@ -537,56 +537,14 @@ describe("Chunk", () => {
   })
 
   describe("concat", () => {
-    for (
-      const { name, slice } of [
-        { name: "take", slice: () => Chunk.take(Chunk.make(2, 3, 4), 2) },
-        { name: "drop", slice: () => Chunk.drop(Chunk.make(1, 2, 3), 1) }
-      ]
-    ) {
-      describe(`with ${name} slices`, () => {
-        it("preserves an unmaterialized slice when appending after a prefix", () => {
-          const chunk = Chunk.appendAll(Chunk.of(1), slice())
-          // Observing the intermediate chunk would materialize it and mask the regression.
-          const result = Chunk.append(chunk, 5)
-          assert.deepStrictEqual(Chunk.toArray(result), [1, 2, 3, 5])
-        })
-
-        it("preserves an unmaterialized slice when prepending before a suffix", () => {
-          const chunk = Chunk.appendAll(slice(), Chunk.of(4))
-          const result = Chunk.prepend(chunk, 0)
-          assert.deepStrictEqual(Chunk.toArray(result), [0, 2, 3, 4])
-        })
-
-        it("preserves a slice when appending without a prefix", () => {
-          assert.deepStrictEqual(Chunk.toArray(Chunk.append(slice(), 5)), [2, 3, 5])
-        })
-
-        it("preserves a slice when prepending without a suffix", () => {
-          assert.deepStrictEqual(Chunk.toArray(Chunk.prepend(slice(), 0)), [0, 2, 3])
-        })
-
-        it("preserves a materialized concatenation when appending", () => {
-          const chunk = Chunk.appendAll(Chunk.of(1), slice())
-          assert.deepStrictEqual(Chunk.toArray(chunk), [1, 2, 3])
-          assert.deepStrictEqual(Chunk.toArray(Chunk.append(chunk, 5)), [1, 2, 3, 5])
-        })
-
-        it("preserves a materialized concatenation when prepending", () => {
-          const chunk = Chunk.appendAll(slice(), Chunk.of(4))
-          assert.deepStrictEqual(Chunk.toArray(chunk), [2, 3, 4])
-          assert.deepStrictEqual(Chunk.toArray(Chunk.prepend(chunk, 0)), [0, 2, 3, 4])
-        })
-      })
-    }
-
-    it("preserves an unsliced chunk when appending after a prefix", () => {
-      const chunk = Chunk.appendAll(Chunk.of(1), Chunk.make(2, 3))
-      assert.deepStrictEqual(Chunk.toArray(Chunk.append(chunk, 5)), [1, 2, 3, 5])
-    })
-
-    it("preserves an unsliced chunk when prepending before a suffix", () => {
-      const chunk = Chunk.appendAll(Chunk.make(2, 3), Chunk.of(4))
-      assert.deepStrictEqual(Chunk.toArray(Chunk.prepend(chunk, 0)), [0, 2, 3, 4])
+    it("preserves a sliced chunk when appending after a prefix", () => {
+      const chunk = pipe(
+        Chunk.make(2, 3, 4),
+        Chunk.take(2),
+        Chunk.prependAll(Chunk.of(1)),
+        Chunk.append(5)
+      )
+      assert.deepStrictEqual(Chunk.toArray(chunk), [1, 2, 3, 5])
     })
 
     describe("Given 2 chunks of the same length", () => {

--- a/packages/effect/test/Chunk.test.ts
+++ b/packages/effect/test/Chunk.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, it } from "@effect/vitest"
+import { describe, it } from "@effect/vitest"
 import {
   assertEquals,
   assertFalse,
@@ -544,7 +544,7 @@ describe("Chunk", () => {
         Chunk.prependAll(Chunk.of(1)),
         Chunk.append(5)
       )
-      assert.deepStrictEqual(Chunk.toArray(chunk), [1, 2, 3, 5])
+      deepStrictEqual(Chunk.toArray(chunk), [1, 2, 3, 5])
     })
 
     describe("Given 2 chunks of the same length", () => {


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Appending after a concatenation containing an unmaterialized `Chunk` slice could discard the sliced elements. For example, prefixing `[1]` to a slice containing `[2, 3]` and then appending `5` returned `[1, 5]`.

Slices are leaves in the concatenation tree. Reporting the backing chunk's depth made balancing treat a slice as a concat node and read its empty children. This change gives slices leaf depth and adds one regression test through the public `Chunk` API.

## Verification

```sh
pnpm lint-fix
pnpm test --run packages/effect/test/Chunk.test.ts
pnpm check
git diff --check
```

The targeted suite passes all 100 tests.

## Related

Closes #7616
Closes EFF-1020
