### PR TITLE
fix(Struct): honor numeric property selections

### DIFF
--- a/.changeset/struct-numeric-selection.md
+++ b/.changeset/struct-numeric-selection.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Honor numeric property selectors in Struct selection and mapping utilities.

--- a/packages/effect/src/Struct.ts
+++ b/packages/effect/src/Struct.ts
@@ -209,7 +209,8 @@ export const pick: {
 } = dual(
   2,
   <S extends object, const Keys extends ReadonlyArray<keyof S>>(self: S, keys: Keys) => {
-    return buildStruct(self, (k, v) => (keys.includes(k) ? [k, v] : undefined))
+    const selected = normalizePropertyKeys(keys)
+    return buildStruct(self, (k, v) => (selected.has(k) ? [k, v] : undefined))
   }
 )
 
@@ -245,7 +246,8 @@ export const omit: {
 } = dual(
   2,
   <S extends object, Keys extends ReadonlyArray<keyof S>>(self: S, keys: Keys) => {
-    return buildStruct(self, (k, v) => (!keys.includes(k) ? [k, v] : undefined))
+    const selected = normalizePropertyKeys(keys)
+    return buildStruct(self, (k, v) => (!selected.has(k) ? [k, v] : undefined))
   }
 )
 
@@ -762,7 +764,8 @@ export const mapPick: {
     keys: Keys,
     lambda: L
   ) => {
-    return buildStruct(self, (k, v) => [k, keys.includes(k) ? lambda(v) : v])
+    const selected = normalizePropertyKeys(keys)
+    return buildStruct(self, (k, v) => [k, selected.has(k) ? lambda(v) : v])
   }
 )
 
@@ -816,9 +819,18 @@ export const mapOmit: {
     keys: Keys,
     lambda: L
   ) => {
-    return buildStruct(self, (k, v) => [k, !keys.includes(k) ? lambda(v) : v])
+    const selected = normalizePropertyKeys(keys)
+    return buildStruct(self, (k, v) => [k, !selected.has(k) ? lambda(v) : v])
   }
 )
+
+function normalizePropertyKeys(keys: ReadonlyArray<PropertyKey>): Set<PropertyKey> {
+  const normalized = new Set<PropertyKey>()
+  for (const key of keys) {
+    normalized.add(typeof key === "number" ? String(key) : key)
+  }
+  return normalized
+}
 
 /**
  * Walk `source`; for each key decide what to emit via the small callback.

--- a/packages/effect/src/Struct.ts
+++ b/packages/effect/src/Struct.ts
@@ -209,8 +209,7 @@ export const pick: {
 } = dual(
   2,
   <S extends object, const Keys extends ReadonlyArray<keyof S>>(self: S, keys: Keys) => {
-    const selected = normalizePropertyKeys(keys)
-    return buildStruct(self, (k, v) => (selected.has(k) ? [k, v] : undefined))
+    return buildStruct(self, (k, v) => (hasPropertyKey(keys, k) ? [k, v] : undefined))
   }
 )
 
@@ -246,8 +245,7 @@ export const omit: {
 } = dual(
   2,
   <S extends object, Keys extends ReadonlyArray<keyof S>>(self: S, keys: Keys) => {
-    const selected = normalizePropertyKeys(keys)
-    return buildStruct(self, (k, v) => (!selected.has(k) ? [k, v] : undefined))
+    return buildStruct(self, (k, v) => (!hasPropertyKey(keys, k) ? [k, v] : undefined))
   }
 )
 
@@ -764,8 +762,7 @@ export const mapPick: {
     keys: Keys,
     lambda: L
   ) => {
-    const selected = normalizePropertyKeys(keys)
-    return buildStruct(self, (k, v) => [k, selected.has(k) ? lambda(v) : v])
+    return buildStruct(self, (k, v) => [k, hasPropertyKey(keys, k) ? lambda(v) : v])
   }
 )
 
@@ -819,17 +816,12 @@ export const mapOmit: {
     keys: Keys,
     lambda: L
   ) => {
-    const selected = normalizePropertyKeys(keys)
-    return buildStruct(self, (k, v) => [k, !selected.has(k) ? lambda(v) : v])
+    return buildStruct(self, (k, v) => [k, !hasPropertyKey(keys, k) ? lambda(v) : v])
   }
 )
 
-function normalizePropertyKeys(keys: ReadonlyArray<PropertyKey>): Set<PropertyKey> {
-  const normalized = new Set<PropertyKey>()
-  for (const key of keys) {
-    normalized.add(typeof key === "number" ? String(key) : key)
-  }
-  return normalized
+function hasPropertyKey(keys: ReadonlyArray<PropertyKey>, key: PropertyKey): boolean {
+  return keys.some((candidate) => candidate === key || typeof candidate === "number" && String(candidate) === key)
 }
 
 /**

--- a/packages/effect/test/Struct.test.ts
+++ b/packages/effect/test/Struct.test.ts
@@ -32,6 +32,12 @@ describe("Struct", () => {
       deepStrictEqual(pipe(s, Struct.pick(["a", "b"])), { b: 1 })
       deepStrictEqual(Struct.pick(s, ["a", "b"]), { b: 1 })
     })
+
+    it("numeric properties", () => {
+      const s: { 1: string; 2: number } = { 1: "a", 2: 1 }
+      deepStrictEqual(pipe(s, Struct.pick([1])), { 1: "a" })
+      deepStrictEqual(Struct.pick(s, [1]), { 1: "a" })
+    })
   })
 
   describe("omit", () => {
@@ -45,6 +51,12 @@ describe("Struct", () => {
       const s: { a?: string; b?: number; c?: boolean } = { b: 1, c: true }
       deepStrictEqual(pipe(s, Struct.omit(["c"])), { b: 1 })
       deepStrictEqual(Struct.omit(s, ["c"]), { b: 1 })
+    })
+
+    it("numeric properties", () => {
+      const s: { 1: string; 2: number } = { 1: "a", 2: 1 }
+      deepStrictEqual(pipe(s, Struct.omit([2])), { 1: "a" })
+      deepStrictEqual(Struct.omit(s, [2]), { 1: "a" })
     })
 
     it("ignores non-enumerable properties", () => {
@@ -125,6 +137,16 @@ describe("Struct", () => {
     )
   })
 
+  it("mapPick numeric properties", () => {
+    equals(
+      Struct.mapPick({ 1: Schema.String, 2: Schema.Number }, [1], Schema.NullOr),
+      {
+        1: Schema.NullOr(Schema.String),
+        2: Schema.Number
+      }
+    )
+  })
+
   it("mapOmit", () => {
     equals(
       pipe({ a: Schema.String, b: Schema.Number }, Struct.mapOmit(["b"], Schema.NullOr)),
@@ -138,6 +160,16 @@ describe("Struct", () => {
       {
         a: Schema.NullOr(Schema.String),
         b: Schema.Number
+      }
+    )
+  })
+
+  it("mapOmit numeric properties", () => {
+    equals(
+      Struct.mapOmit({ 1: Schema.String, 2: Schema.Number }, [2], Schema.NullOr),
+      {
+        1: Schema.NullOr(Schema.String),
+        2: Schema.Number
       }
     )
   })


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

### Why

`Struct.pick({ 1: "a", 2: "b" }, [1])` returns `{}`, while `omit` retains the key it should remove. Numeric selectors are supported by the existing type tests, but they do not match the string property names produced by enumeration.

### What changes

Match selectors through one shared `hasPropertyKey` predicate used by `pick`, `omit`, `mapPick`, and `mapOmit`. Strings and symbols use exact comparison; numeric candidates match their runtime string form without allocating a `Set`.

### Scope

Only Struct selection, its tests, and an `effect` patch changeset are changed. Shared traversal, property enumeration, and public types are unchanged.

### Verification

```sh
nix develop -c pnpm lint-fix
nix develop -c pnpm test --run packages/effect/test/Struct.test.ts
nix develop -c pnpm check
git diff --check 0af0985d5c132b33e14a2df59e0567d7ba2a1710..HEAD
```

The focused suite passes all 27 tests. Lint, the root typecheck, and whitespace checks also pass.

## Related

Closes #7618
Closes EFF-1021

## Audit

Runtime correctness audit; intended label: `audit`.
