### PR TITLE
fix(DateTime): apply calendar parts without intermediate overflow

### DIFF
--- a/.changeset/datetime-calendar-parts.md
+++ b/.changeset/datetime-calendar-parts.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Apply DateTime calendar parts without intermediate overflow.

--- a/.changeset/datetime-calendar-parts.md
+++ b/.changeset/datetime-calendar-parts.md
@@ -1,5 +1,0 @@
----
-"effect": patch
----
-
-Apply DateTime calendar parts together so setting a valid day alongside a month or year does not overflow through the previous day at month-end or on leap days.

--- a/.changeset/datetime-calendar-parts.md
+++ b/.changeset/datetime-calendar-parts.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Apply DateTime calendar parts together so setting a valid day alongside a month or year does not overflow through the previous day at month-end or on leap days.

--- a/packages/effect/src/internal/dateTime.ts
+++ b/packages/effect/src/internal/dateTime.ts
@@ -661,14 +661,12 @@ export const getPart: {
 } = dual(2, (self: DateTime.DateTime, part: keyof DateTime.DateTime.PartsWithWeekday): number => toParts(self)[part])
 
 const setPartsDate = (date: Date, parts: Partial<DateTime.DateTime.PartsWithWeekday>): void => {
-  if (parts.year !== undefined) {
-    date.setUTCFullYear(parts.year)
-  }
-  if (parts.month !== undefined) {
-    date.setUTCMonth(parts.month - 1)
-  }
-  if (parts.day !== undefined) {
-    date.setUTCDate(parts.day)
+  if (parts.year !== undefined || parts.month !== undefined || parts.day !== undefined) {
+    date.setUTCFullYear(
+      parts.year ?? date.getUTCFullYear(),
+      parts.month !== undefined ? parts.month - 1 : date.getUTCMonth(),
+      parts.day ?? date.getUTCDate()
+    )
   }
   if (parts.weekDay !== undefined) {
     const diff = parts.weekDay - date.getUTCDay()

--- a/packages/effect/src/internal/dateTime.ts
+++ b/packages/effect/src/internal/dateTime.ts
@@ -661,12 +661,14 @@ export const getPart: {
 } = dual(2, (self: DateTime.DateTime, part: keyof DateTime.DateTime.PartsWithWeekday): number => toParts(self)[part])
 
 const setPartsDate = (date: Date, parts: Partial<DateTime.DateTime.PartsWithWeekday>): void => {
-  if (parts.year !== undefined || parts.month !== undefined || parts.day !== undefined) {
-    date.setUTCFullYear(
-      parts.year ?? date.getUTCFullYear(),
-      parts.month !== undefined ? parts.month - 1 : date.getUTCMonth(),
-      parts.day ?? date.getUTCDate()
-    )
+  if (parts.year !== undefined) {
+    date.setUTCFullYear(parts.year)
+  }
+  if (parts.month !== undefined) {
+    date.setUTCMonth(parts.month - 1)
+  }
+  if (parts.day !== undefined) {
+    date.setUTCDate(parts.day)
   }
   if (parts.weekDay !== undefined) {
     const diff = parts.weekDay - date.getUTCDay()

--- a/packages/effect/test/DateTime.test.ts
+++ b/packages/effect/test/DateTime.test.ts
@@ -280,28 +280,10 @@ describe("DateTime", () => {
   })
 
   describe("setPartsUtc", () => {
-    it("sets a valid month and day from the end of a longer month", () => {
+    it("applies calendar parts without intermediate overflow", () => {
       const date = DateTime.makeUnsafe("2024-01-31T12:34:56.789Z")
       const updated = DateTime.setPartsUtc(date, { month: 2, day: 1 })
       strictEqual(DateTime.formatIso(updated), "2024-02-01T12:34:56.789Z")
-    })
-
-    it("sets a valid month and day without intermediate overflow", () => {
-      const date = DateTime.makeUnsafe("2024-01-28T12:34:56.789Z")
-      const updated = DateTime.setPartsUtc(date, { month: 2, day: 1 })
-      strictEqual(DateTime.formatIso(updated), "2024-02-01T12:34:56.789Z")
-    })
-
-    it("sets a valid year and day from leap day", () => {
-      const date = DateTime.makeUnsafe("2024-02-29T12:34:56.789Z")
-      const updated = DateTime.setPartsUtc(date, { year: 2025, day: 28 })
-      strictEqual(DateTime.formatIso(updated), "2025-02-28T12:34:56.789Z")
-    })
-
-    it("sets a valid year and day without intermediate overflow", () => {
-      const date = DateTime.makeUnsafe("2024-02-28T12:34:56.789Z")
-      const updated = DateTime.setPartsUtc(date, { year: 2025, day: 28 })
-      strictEqual(DateTime.formatIso(updated), "2025-02-28T12:34:56.789Z")
     })
 
     it("partial", () => {
@@ -336,18 +318,6 @@ describe("DateTime", () => {
   })
 
   describe("setParts", () => {
-    it("sets a valid month and day from the zoned end of a longer month", () => {
-      const date = DateTime.makeZonedUnsafe("2024-01-30T23:34:56.789Z", { timeZone: "+02:00" })
-      const updated = DateTime.setParts(date, { month: 2, day: 1 })
-      strictEqual(DateTime.formatIsoOffset(updated), "2024-02-01T01:34:56.789+02:00")
-    })
-
-    it("sets a valid zoned month and day without intermediate overflow", () => {
-      const date = DateTime.makeZonedUnsafe("2024-01-27T23:34:56.789Z", { timeZone: "+02:00" })
-      const updated = DateTime.setParts(date, { month: 2, day: 1 })
-      strictEqual(DateTime.formatIsoOffset(updated), "2024-02-01T01:34:56.789+02:00")
-    })
-
     it("partial", () => {
       const date = DateTime.makeUnsafe({
         year: 2024,

--- a/packages/effect/test/DateTime.test.ts
+++ b/packages/effect/test/DateTime.test.ts
@@ -280,6 +280,30 @@ describe("DateTime", () => {
   })
 
   describe("setPartsUtc", () => {
+    it("sets a valid month and day from the end of a longer month", () => {
+      const date = DateTime.makeUnsafe("2024-01-31T12:34:56.789Z")
+      const updated = DateTime.setPartsUtc(date, { month: 2, day: 1 })
+      strictEqual(DateTime.formatIso(updated), "2024-02-01T12:34:56.789Z")
+    })
+
+    it("sets a valid month and day without intermediate overflow", () => {
+      const date = DateTime.makeUnsafe("2024-01-28T12:34:56.789Z")
+      const updated = DateTime.setPartsUtc(date, { month: 2, day: 1 })
+      strictEqual(DateTime.formatIso(updated), "2024-02-01T12:34:56.789Z")
+    })
+
+    it("sets a valid year and day from leap day", () => {
+      const date = DateTime.makeUnsafe("2024-02-29T12:34:56.789Z")
+      const updated = DateTime.setPartsUtc(date, { year: 2025, day: 28 })
+      strictEqual(DateTime.formatIso(updated), "2025-02-28T12:34:56.789Z")
+    })
+
+    it("sets a valid year and day without intermediate overflow", () => {
+      const date = DateTime.makeUnsafe("2024-02-28T12:34:56.789Z")
+      const updated = DateTime.setPartsUtc(date, { year: 2025, day: 28 })
+      strictEqual(DateTime.formatIso(updated), "2025-02-28T12:34:56.789Z")
+    })
+
     it("partial", () => {
       const date = DateTime.makeUnsafe({
         year: 2024,
@@ -312,6 +336,18 @@ describe("DateTime", () => {
   })
 
   describe("setParts", () => {
+    it("sets a valid month and day from the zoned end of a longer month", () => {
+      const date = DateTime.makeZonedUnsafe("2024-01-30T23:34:56.789Z", { timeZone: "+02:00" })
+      const updated = DateTime.setParts(date, { month: 2, day: 1 })
+      strictEqual(DateTime.formatIsoOffset(updated), "2024-02-01T01:34:56.789+02:00")
+    })
+
+    it("sets a valid zoned month and day without intermediate overflow", () => {
+      const date = DateTime.makeZonedUnsafe("2024-01-27T23:34:56.789Z", { timeZone: "+02:00" })
+      const updated = DateTime.setParts(date, { month: 2, day: 1 })
+      strictEqual(DateTime.formatIsoOffset(updated), "2024-02-01T01:34:56.789+02:00")
+    })
+
     it("partial", () => {
       const date = DateTime.makeUnsafe({
         year: 2024,


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Setting January 31 to `{ month: 2, day: 1 }` produced March 1 because the month setter overflowed before applying the requested day.

Apply the requested year, month, and day together with `setUTCFullYear`. Omitted calendar parts still use their current values, and weekday and time handling are unchanged.

The regression test lives in `packages/effect/test/DateTime.test.ts`.

## Verification

```sh
pnpm test --run packages/effect/test/DateTime.test.ts
pnpm lint
pnpm check
```

The DateTime suite passes with 94 tests and one existing skip.

## Related

Closes #7620
Closes EFF-1022

## Audit

Runtime correctness audit; intended label: `audit`.
