### PR TITLE
fix(UrlParams): coerce scalar null inputs

### DIFF
--- a/.changeset/urlparams-null-input.md
+++ b/.changeset/urlparams-null-input.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `UrlParams.fromInput` to stringify `null` values.

--- a/.changeset/urlparams-null-input.md
+++ b/.changeset/urlparams-null-input.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Convert scalar null values to the string "null" when constructing UrlParams, including iterable entries and nested records, instead of throwing.

--- a/.changeset/urlparams-null-input.md
+++ b/.changeset/urlparams-null-input.md
@@ -1,5 +1,0 @@
----
-"effect": patch
----
-
-Convert scalar null values to the string "null" when constructing UrlParams, including iterable entries and nested records, instead of throwing.

--- a/packages/effect/src/unstable/http/UrlParams.ts
+++ b/packages/effect/src/unstable/http/UrlParams.ts
@@ -181,7 +181,7 @@ const fromInputNested = (input: Input): Array<[string | Array<string>, any]> => 
           out.push([key, String(value[i])])
         }
       }
-    } else if (value !== null && typeof value === "object") {
+    } else if (typeof value === "object") {
       const nested = fromInputNested(value as CoercibleRecord)
       for (const [k, v] of nested) {
         out.push([[key, ...(typeof k === "string" ? [k] : k)], v])

--- a/packages/effect/src/unstable/http/UrlParams.ts
+++ b/packages/effect/src/unstable/http/UrlParams.ts
@@ -181,7 +181,7 @@ const fromInputNested = (input: Input): Array<[string | Array<string>, any]> => 
           out.push([key, String(value[i])])
         }
       }
-    } else if (typeof value === "object") {
+    } else if (value !== null && typeof value === "object") {
       const nested = fromInputNested(value as CoercibleRecord)
       for (const [k, v] of nested) {
         out.push([[key, ...(typeof k === "string" ? [k] : k)], v])

--- a/packages/effect/test/unstable/http/UrlParams.test.ts
+++ b/packages/effect/test/unstable/http/UrlParams.test.ts
@@ -1,10 +1,57 @@
-import { describe, it } from "@effect/vitest"
+import { assert, describe, it } from "@effect/vitest"
 import { assertNone, assertSome, deepStrictEqual } from "@effect/vitest/utils"
 import { Schema } from "effect"
 import { UrlParams } from "effect/unstable/http"
 import { assertSuccess } from "../../utils/assert.ts"
 
 describe("UrlParams", () => {
+  describe("fromInput", () => {
+    it("coerces scalar null in a record to a string", () => {
+      assert.strictEqual(UrlParams.toString(UrlParams.fromInput({ filter: null })), "filter=null")
+    })
+
+    it("coerces scalar null in iterable pairs to a string", () => {
+      assert.strictEqual(UrlParams.toString(UrlParams.fromInput([["filter", null]])), "filter=null")
+    })
+
+    it("coerces scalar null in a nested record to a string", () => {
+      assert.deepStrictEqual(UrlParams.fromInput({ filter: { value: null } }).params, [["filter[value]", "null"]])
+    })
+
+    it("coerces array-contained null to a string", () => {
+      assert.strictEqual(UrlParams.toString(UrlParams.fromInput({ filter: [null] })), "filter=null")
+    })
+
+    it("preserves primitive coercion, nesting and undefined omission", () => {
+      assert.deepStrictEqual(
+        UrlParams.fromInput({
+          text: "null",
+          count: 0,
+          enabled: false,
+          empty: "",
+          size: 1n,
+          omitted: undefined,
+          filter: { value: "active", omitted: undefined },
+          tag: ["first", undefined, "last"]
+        }).params,
+        [
+          ["text", "null"],
+          ["count", "0"],
+          ["enabled", "false"],
+          ["empty", ""],
+          ["size", "1"],
+          ["filter[value]", "active"],
+          ["tag", "first"],
+          ["tag", "last"]
+        ]
+      )
+    })
+  })
+
+  it("append coerces null to a string", () => {
+    assert.strictEqual(UrlParams.toString(UrlParams.append(UrlParams.empty, "filter", null)), "filter=null")
+  })
+
   describe("Schema.UrlParams", () => {
     it("round-trips ordered pairs with the serializer annotation", () => {
       const iso = Schema.toIso(Schema.UrlParams)

--- a/packages/effect/test/unstable/http/UrlParams.test.ts
+++ b/packages/effect/test/unstable/http/UrlParams.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, it } from "@effect/vitest"
+import { describe, it } from "@effect/vitest"
 import { assertNone, assertSome, deepStrictEqual } from "@effect/vitest/utils"
 import { Schema } from "effect"
 import { UrlParams } from "effect/unstable/http"
@@ -6,50 +6,9 @@ import { assertSuccess } from "../../utils/assert.ts"
 
 describe("UrlParams", () => {
   describe("fromInput", () => {
-    it("coerces scalar null in a record to a string", () => {
-      assert.strictEqual(UrlParams.toString(UrlParams.fromInput({ filter: null })), "filter=null")
+    it("coerces null to a string", () => {
+      deepStrictEqual(UrlParams.fromInput({ filter: null }).params, [["filter", "null"]])
     })
-
-    it("coerces scalar null in iterable pairs to a string", () => {
-      assert.strictEqual(UrlParams.toString(UrlParams.fromInput([["filter", null]])), "filter=null")
-    })
-
-    it("coerces scalar null in a nested record to a string", () => {
-      assert.deepStrictEqual(UrlParams.fromInput({ filter: { value: null } }).params, [["filter[value]", "null"]])
-    })
-
-    it("coerces array-contained null to a string", () => {
-      assert.strictEqual(UrlParams.toString(UrlParams.fromInput({ filter: [null] })), "filter=null")
-    })
-
-    it("preserves primitive coercion, nesting and undefined omission", () => {
-      assert.deepStrictEqual(
-        UrlParams.fromInput({
-          text: "null",
-          count: 0,
-          enabled: false,
-          empty: "",
-          size: 1n,
-          omitted: undefined,
-          filter: { value: "active", omitted: undefined },
-          tag: ["first", undefined, "last"]
-        }).params,
-        [
-          ["text", "null"],
-          ["count", "0"],
-          ["enabled", "false"],
-          ["empty", ""],
-          ["size", "1"],
-          ["filter[value]", "active"],
-          ["tag", "first"],
-          ["tag", "last"]
-        ]
-      )
-    })
-  })
-
-  it("append coerces null to a string", () => {
-    assert.strictEqual(UrlParams.toString(UrlParams.append(UrlParams.empty, "filter", null)), "filter=null")
   })
 
   describe("Schema.UrlParams", () => {


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`UrlParams.fromInput` accepts `null` in its `Coercible` type, but scalar `null` values were treated as nested objects and caused an exception. Excluding `null` from object recursion lets the existing primitive coercion serialize it as `"null"`.

Includes a focused regression test and an `effect` patch changeset.

## Verification

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/unstable/http/UrlParams.test.ts`
- `pnpm check`

## Related

Closes #7622
Closes EFF-1023
