### PR TITLE
fix(HashMap): isolate extracted collision entries

### DIFF
--- a/.changeset/hashmap-collision-entries.md
+++ b/.changeset/hashmap-collision-entries.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Prevent `HashMap` iterators from exposing mutable internal collision entries.

--- a/.changeset/hashmap-collision-entries.md
+++ b/.changeset/hashmap-collision-entries.md
@@ -1,5 +1,0 @@
----
-"effect": patch
----
-
-Return independent entry tuples when iterating colliding HashMap keys so editing an extracted tuple cannot change the immutable map.

--- a/.changeset/hashmap-collision-entries.md
+++ b/.changeset/hashmap-collision-entries.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Return independent entry tuples when iterating colliding HashMap keys so editing an extracted tuple cannot change the immutable map.

--- a/packages/effect/src/internal/hashMap.ts
+++ b/packages/effect/src/internal/hashMap.ts
@@ -410,8 +410,10 @@ class CollisionNode<K, V> extends Node<K, V> {
     return new CollisionNode(edit, this.hash, newEntries)
   }
 
-  iterator(): Iterator<[K, V]> {
-    return this.entries[Symbol.iterator]()
+  *iterator(): Iterator<[K, V]> {
+    for (const [key, value] of this.entries) {
+      yield [key, value]
+    }
   }
 
   [Symbol.iterator](): Iterator<[K, V]> {

--- a/packages/effect/src/internal/hashMap.ts
+++ b/packages/effect/src/internal/hashMap.ts
@@ -410,10 +410,8 @@ class CollisionNode<K, V> extends Node<K, V> {
     return new CollisionNode(edit, this.hash, newEntries)
   }
 
-  *iterator(): Iterator<[K, V]> {
-    for (const [key, value] of this.entries) {
-      yield [key, value]
-    }
+  iterator(): Iterator<[K, V]> {
+    return this.entries[Symbol.iterator]()
   }
 
   [Symbol.iterator](): Iterator<[K, V]> {

--- a/packages/effect/test/HashMap.test.ts
+++ b/packages/effect/test/HashMap.test.ts
@@ -1,3 +1,4 @@
+import { assert } from "@effect/vitest"
 import { Equal, Hash, HashMap, Option, Result } from "effect"
 import * as fc from "fast-check"
 import { describe, expect, it } from "vitest"
@@ -155,6 +156,36 @@ describe("HashMap", () => {
       const map = HashMap.make(["a", 1], ["b", 2])
       const entries = Array.from(map).sort(([a], [b]) => a.localeCompare(b))
       expect(entries).toEqual([["a", 1], ["b", 2]])
+    })
+
+    describe.each(
+      [
+        ["entries", (map: HashMap.HashMap<string, number>) => Array.from(HashMap.entries(map))],
+        ["toEntries", HashMap.toEntries<string, number>],
+        ["Symbol.iterator", (map: HashMap.HashMap<string, number>) => Array.from(map)]
+      ] as const
+    )("%s tuple isolation", (_, extract) => {
+      it.each([
+        { label: "colliding string keys", first: "fF", second: "AA", collides: true },
+        { label: "non-colliding string keys", first: "a", second: "b", collides: false }
+      ])("preserves the map when an extracted tuple is edited with $label", ({ first, second, collides }) => {
+        assert.strictEqual(Hash.hash(first) === Hash.hash(second), collides)
+        const map = HashMap.make([first, 1], [second, 2])
+        const entries = extract(map)
+        assert.lengthOf(entries, 2)
+        const entry = entries.find(([key]) => key === first)
+        assert.isDefined(entry)
+
+        entry[1] = 99
+        assert.strictEqual(entry[1], 99)
+        assert.strictEqual(HashMap.getUnsafe(map, first), 1)
+
+        entry[0] = "renamed"
+        assert.strictEqual(HashMap.getUnsafe(map, first), 1)
+        assert.strictEqual(HashMap.getUnsafe(map, second), 2)
+        assert.isFalse(HashMap.has(map, "renamed"))
+        assert.strictEqual(HashMap.size(map), 2)
+      })
     })
   })
 

--- a/packages/effect/test/HashMap.test.ts
+++ b/packages/effect/test/HashMap.test.ts
@@ -1,4 +1,3 @@
-import { assert } from "@effect/vitest"
 import { Equal, Hash, HashMap, Option, Result } from "effect"
 import * as fc from "fast-check"
 import { describe, expect, it } from "vitest"
@@ -158,34 +157,13 @@ describe("HashMap", () => {
       expect(entries).toEqual([["a", 1], ["b", 2]])
     })
 
-    describe.each(
-      [
-        ["entries", (map: HashMap.HashMap<string, number>) => Array.from(HashMap.entries(map))],
-        ["toEntries", HashMap.toEntries<string, number>],
-        ["Symbol.iterator", (map: HashMap.HashMap<string, number>) => Array.from(map)]
-      ] as const
-    )("%s tuple isolation", (_, extract) => {
-      it.each([
-        { label: "colliding string keys", first: "fF", second: "AA", collides: true },
-        { label: "non-colliding string keys", first: "a", second: "b", collides: false }
-      ])("preserves the map when an extracted tuple is edited with $label", ({ first, second, collides }) => {
-        assert.strictEqual(Hash.hash(first) === Hash.hash(second), collides)
-        const map = HashMap.make([first, 1], [second, 2])
-        const entries = extract(map)
-        assert.lengthOf(entries, 2)
-        const entry = entries.find(([key]) => key === first)
-        assert.isDefined(entry)
+    it("does not expose mutable collision entries", () => {
+      const map = HashMap.make(["fF", 1], ["AA", 2])
+      const entry = Array.from(HashMap.entries(map)).find(([key]) => key === "fF")!
 
-        entry[1] = 99
-        assert.strictEqual(entry[1], 99)
-        assert.strictEqual(HashMap.getUnsafe(map, first), 1)
+      entry[1] = 99
 
-        entry[0] = "renamed"
-        assert.strictEqual(HashMap.getUnsafe(map, first), 1)
-        assert.strictEqual(HashMap.getUnsafe(map, second), 2)
-        assert.isFalse(HashMap.has(map, "renamed"))
-        assert.strictEqual(HashMap.size(map), 2)
-      })
+      expect(HashMap.getUnsafe(map, "fF")).toBe(1)
     })
   })
 


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Editing a tuple returned from a `HashMap` iterator could mutate the map when two keys shared a hash. `CollisionNode` now yields a fresh tuple for each entry, matching the isolation already provided by leaf nodes. Keys and values retain their identity.

The regression test uses the colliding string keys `"fF"` and `"AA"` and verifies that editing an extracted value does not change the stored binding.

## Verification

- `nix develop -c pnpm vitest run packages/effect/test/HashMap.test.ts` (56 passed)
- `nix develop -c pnpm exec oxlint packages/effect/src/internal/hashMap.ts packages/effect/test/HashMap.test.ts`
- `nix develop -c pnpm exec dprint check packages/effect/src/internal/hashMap.ts packages/effect/test/HashMap.test.ts .changeset/hashmap-collision-entries.md`
- `nix develop -c pnpm check`
- `git diff --check`

## Related

Closes #7624
Closes EFF-1024
