### PR TITLE
fix(Headers): match stateful redaction patterns independently

### DIFF
--- a/.changeset/headers-stateful-patterns.md
+++ b/.changeset/headers-stateful-patterns.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Test each header name independently when redaction patterns use global or sticky regular expressions, preventing matching values from being skipped.

--- a/.changeset/headers-stateful-patterns.md
+++ b/.changeset/headers-stateful-patterns.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Match each header independently when redaction patterns use global or sticky regular expressions.
+Fix `Headers.redact` and `Headers.isRedactedName` skipping matches when a redaction pattern is a global or sticky regular expression.

--- a/.changeset/headers-stateful-patterns.md
+++ b/.changeset/headers-stateful-patterns.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Test each header name independently when redaction patterns use global or sticky regular expressions, preventing matching values from being skipped.
+Match each header independently when redaction patterns use global or sticky regular expressions.

--- a/packages/effect/src/unstable/http/Headers.ts
+++ b/packages/effect/src/unstable/http/Headers.ts
@@ -354,8 +354,7 @@ export const redact: {
         }
       } else {
         for (const name in self) {
-          if (key.global || key.sticky) key.lastIndex = 0
-          if (key.test(name)) {
+          if (name.search(key) !== -1) {
             out[name] = Redacted.make(self[name])
           }
         }
@@ -394,11 +393,8 @@ export const isRedactedName = (
       if (pattern.toLowerCase() === name) {
         return true
       }
-    } else {
-      if (pattern.global || pattern.sticky) pattern.lastIndex = 0
-      if (pattern.test(name)) {
-        return true
-      }
+    } else if (name.search(pattern) !== -1) {
+      return true
     }
   }
   return false

--- a/packages/effect/src/unstable/http/Headers.ts
+++ b/packages/effect/src/unstable/http/Headers.ts
@@ -354,6 +354,7 @@ export const redact: {
         }
       } else {
         for (const name in self) {
+          if (key.global || key.sticky) key.lastIndex = 0
           if (key.test(name)) {
             out[name] = Redacted.make(self[name])
           }
@@ -393,8 +394,11 @@ export const isRedactedName = (
       if (pattern.toLowerCase() === name) {
         return true
       }
-    } else if (pattern.test(name)) {
-      return true
+    } else {
+      if (pattern.global || pattern.sticky) pattern.lastIndex = 0
+      if (pattern.test(name)) {
+        return true
+      }
     }
   }
   return false

--- a/packages/effect/test/unstable/http/Headers.test.ts
+++ b/packages/effect/test/unstable/http/Headers.test.ts
@@ -71,50 +71,24 @@ describe("Headers", () => {
     assertNone(Headers.get(headers, "missing"))
   })
 
-  describe("redact", () => {
-    it("accepts frozen non-stateful patterns", () => {
-      const pattern = Object.freeze(/^x-secret-/)
-      const headers = Headers.fromInput({ "x-secret-one": "one" })
-      assert.strictEqual(Redacted.isRedacted(Headers.redact(headers, pattern)["x-secret-one"]), true)
-      assert.strictEqual(Headers.isRedactedName("x-secret-one", [pattern]), true)
-    })
+  it("redacts each header independently with a global pattern", () => {
+    const result = Headers.redact(
+      Headers.fromInput({ "x-secret-one": "one", "x-secret-two": "two" }),
+      /^x-secret-/g
+    )
 
-    it.each(["", "g", "y"])("matches independent header names with RegExp flags %j", (flags) => {
-      const input: Record<string, string> = { "x-secret-one": "one", "x-secret-two": "two", "x-public": "ok" }
-      const headers = Headers.fromInput(input)
-      const result = Headers.redact(headers, new RegExp("^x-secret-", flags))
-
-      assert.strictEqual(result["x-public"], "ok")
-      assert.deepStrictEqual({ ...headers }, input)
-      assert.deepStrictEqual([
-        Redacted.isRedacted(result["x-secret-one"]),
-        Redacted.isRedacted(result["x-secret-two"])
-      ], [true, true])
-    })
-
-    it("preserves sticky matching at the start of a header name", () => {
-      const headers = Headers.fromInput({ "x-secret-one": "one" })
-
-      assert.strictEqual(Redacted.isRedacted(Headers.redact(headers, /secret/g)["x-secret-one"]), true)
-      assert.strictEqual(Headers.redact(headers, /secret/y)["x-secret-one"], "one")
-    })
+    assert.deepStrictEqual([
+      Redacted.isRedacted(result["x-secret-one"]),
+      Redacted.isRedacted(result["x-secret-two"])
+    ], [true, true])
   })
 
-  describe("isRedactedName", () => {
-    it.each(["", "g", "y"])("matches independent header names with RegExp flags %j", (flags) => {
-      const patterns = [new RegExp("^x-secret-", flags)]
+  it("checks each header independently with a sticky pattern", () => {
+    const pattern = /^x-secret-/y
 
-      assert.deepStrictEqual([
-        Headers.isRedactedName("x-secret-one", patterns),
-        Headers.isRedactedName("x-secret-two", patterns),
-        Headers.isRedactedName("x-secret-one", patterns),
-        Headers.isRedactedName("x-public", patterns)
-      ], [true, true, true, false])
-    })
-
-    it("preserves sticky matching at the start of a header name", () => {
-      assert.strictEqual(Headers.isRedactedName("x-secret-one", [/secret/g]), true)
-      assert.strictEqual(Headers.isRedactedName("x-secret-one", [/secret/y]), false)
-    })
+    assert.deepStrictEqual([
+      Headers.isRedactedName("x-secret-one", [pattern]),
+      Headers.isRedactedName("x-secret-two", [pattern])
+    ], [true, true])
   })
 })

--- a/packages/effect/test/unstable/http/Headers.test.ts
+++ b/packages/effect/test/unstable/http/Headers.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from "@effect/vitest"
+import { assert, describe, it } from "@effect/vitest"
 import { assertNone, assertSome, deepStrictEqual, doesNotThrow, strictEqual } from "@effect/vitest/utils"
-import { Schema } from "effect"
+import { Redacted, Schema } from "effect"
 import { Headers } from "effect/unstable/http"
 import { assertSuccess } from "../../utils/assert.ts"
 
@@ -69,5 +69,52 @@ describe("Headers", () => {
     const headers = Headers.fromInput({ foo: "bar" })
     assertSome(Headers.get(headers, "foo"), "bar")
     assertNone(Headers.get(headers, "missing"))
+  })
+
+  describe("redact", () => {
+    it("accepts frozen non-stateful patterns", () => {
+      const pattern = Object.freeze(/^x-secret-/)
+      const headers = Headers.fromInput({ "x-secret-one": "one" })
+      assert.strictEqual(Redacted.isRedacted(Headers.redact(headers, pattern)["x-secret-one"]), true)
+      assert.strictEqual(Headers.isRedactedName("x-secret-one", [pattern]), true)
+    })
+
+    it.each(["", "g", "y"])("matches independent header names with RegExp flags %j", (flags) => {
+      const input: Record<string, string> = { "x-secret-one": "one", "x-secret-two": "two", "x-public": "ok" }
+      const headers = Headers.fromInput(input)
+      const result = Headers.redact(headers, new RegExp("^x-secret-", flags))
+
+      assert.strictEqual(result["x-public"], "ok")
+      assert.deepStrictEqual({ ...headers }, input)
+      assert.deepStrictEqual([
+        Redacted.isRedacted(result["x-secret-one"]),
+        Redacted.isRedacted(result["x-secret-two"])
+      ], [true, true])
+    })
+
+    it("preserves sticky matching at the start of a header name", () => {
+      const headers = Headers.fromInput({ "x-secret-one": "one" })
+
+      assert.strictEqual(Redacted.isRedacted(Headers.redact(headers, /secret/g)["x-secret-one"]), true)
+      assert.strictEqual(Headers.redact(headers, /secret/y)["x-secret-one"], "one")
+    })
+  })
+
+  describe("isRedactedName", () => {
+    it.each(["", "g", "y"])("matches independent header names with RegExp flags %j", (flags) => {
+      const patterns = [new RegExp("^x-secret-", flags)]
+
+      assert.deepStrictEqual([
+        Headers.isRedactedName("x-secret-one", patterns),
+        Headers.isRedactedName("x-secret-two", patterns),
+        Headers.isRedactedName("x-secret-one", patterns),
+        Headers.isRedactedName("x-public", patterns)
+      ], [true, true, true, false])
+    })
+
+    it("preserves sticky matching at the start of a header name", () => {
+      assert.strictEqual(Headers.isRedactedName("x-secret-one", [/secret/g]), true)
+      assert.strictEqual(Headers.isRedactedName("x-secret-one", [/secret/y]), false)
+    })
   })
 })

--- a/packages/effect/test/unstable/http/Headers.test.ts
+++ b/packages/effect/test/unstable/http/Headers.test.ts
@@ -91,4 +91,16 @@ describe("Headers", () => {
       Headers.isRedactedName("x-secret-two", [pattern])
     ], [true, true])
   })
+
+  it("preserves caller-owned stateful pattern cursors", () => {
+    const redactPattern = /^x-secret/g
+    const namePattern = /^x-secret/y
+    redactPattern.lastIndex = 3
+    namePattern.lastIndex = 4
+
+    Headers.redact(Headers.fromInput({ "x-secret": "value" }), redactPattern)
+    Headers.isRedactedName("x-secret", [namePattern])
+
+    assert.deepStrictEqual([redactPattern.lastIndex, namePattern.lastIndex], [3, 4])
+  })
 })

--- a/packages/effect/test/unstable/http/Headers.test.ts
+++ b/packages/effect/test/unstable/http/Headers.test.ts
@@ -1,5 +1,5 @@
-import { assert, describe, it } from "@effect/vitest"
-import { assertNone, assertSome, deepStrictEqual, doesNotThrow, strictEqual } from "@effect/vitest/utils"
+import { describe, it } from "@effect/vitest"
+import { assertNone, assertSome, assertTrue, deepStrictEqual, doesNotThrow, strictEqual } from "@effect/vitest/utils"
 import { Redacted, Schema } from "effect"
 import { Headers } from "effect/unstable/http"
 import { assertSuccess } from "../../utils/assert.ts"
@@ -77,19 +77,15 @@ describe("Headers", () => {
       /^x-secret-/g
     )
 
-    assert.deepStrictEqual([
-      Redacted.isRedacted(result["x-secret-one"]),
-      Redacted.isRedacted(result["x-secret-two"])
-    ], [true, true])
+    assertTrue(Redacted.isRedacted(result["x-secret-one"]))
+    assertTrue(Redacted.isRedacted(result["x-secret-two"]))
   })
 
   it("checks each header independently with a sticky pattern", () => {
     const pattern = /^x-secret-/y
 
-    assert.deepStrictEqual([
-      Headers.isRedactedName("x-secret-one", [pattern]),
-      Headers.isRedactedName("x-secret-two", [pattern])
-    ], [true, true])
+    assertTrue(Headers.isRedactedName("x-secret-one", [pattern]))
+    assertTrue(Headers.isRedactedName("x-secret-two", [pattern]))
   })
 
   it("preserves caller-owned stateful pattern cursors", () => {
@@ -101,6 +97,7 @@ describe("Headers", () => {
     Headers.redact(Headers.fromInput({ "x-secret": "value" }), redactPattern)
     Headers.isRedactedName("x-secret", [namePattern])
 
-    assert.deepStrictEqual([redactPattern.lastIndex, namePattern.lastIndex], [3, 4])
+    strictEqual(redactPattern.lastIndex, 3)
+    strictEqual(namePattern.lastIndex, 4)
   })
 })


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Global and sticky regular expressions carry `lastIndex` between `test` calls, so one successful header-name match could cause the next matching name to be skipped.

Use `String.prototype.search` to match each name independently in `Headers.redact` and `Headers.isRedactedName` without mutating the caller's regular expression. Focused regressions cover global matching, sticky matching, and preservation of caller-owned cursors.

## Verification

```sh
pnpm lint-fix
pnpm test --run packages/effect/test/unstable/http/Headers.test.ts
pnpm check
git diff --check
```

Closes #7626
Closes EFF-1025
