### PR TITLE
fix(sql): compile identifiers in returning helpers

### DIFF
--- a/.changeset/sql-returning-identifier.md
+++ b/.changeset/sql-returning-identifier.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Compile Identifier arguments passed to SQL insert, update, and updateValues returning helpers with the dialect's identifier escaping instead of throwing.
+Fix SQL returning helpers to compile identifiers with dialect-specific escaping.

--- a/.changeset/sql-returning-identifier.md
+++ b/.changeset/sql-returning-identifier.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Compile Identifier arguments passed to SQL insert, update, and updateValues returning helpers with the dialect's identifier escaping instead of throwing.

--- a/packages/effect/src/unstable/sql/Statement.ts
+++ b/packages/effect/src/unstable/sql/Statement.ts
@@ -256,7 +256,7 @@ const RecordInsertHelperProto = {
   returning(this: RecordInsertHelper, sql: string | Identifier | Fragment) {
     const self = Object.create(Object.getPrototypeOf(this))
     Object.assign(self, this, {
-      returningIdentifier: sql
+      returningIdentifier: typeof sql === "string" || isFragment(sql) ? sql : fragment([sql])
     })
     return self
   }

--- a/packages/sql/mssql/test/Client.test.ts
+++ b/packages/sql/mssql/test/Client.test.ts
@@ -132,6 +132,43 @@ describe("mssql", () => {
     expect(params).toEqual(["Tim"])
   })
 
+  for (
+    const [name, returning] of [
+      ["Identifier", sql("INSERTED.name")],
+      ["wrapped Identifier", sql`${sql("INSERTED.name")}`]
+    ] as const
+  ) {
+    it(`insert helper returning ${name}`, () => {
+      const result = sql`INSERT INTO ${sql("people")} ${sql.insert({ name: "Rowan", age: 10 }).returning(returning)}`
+        .compile()
+
+      assert.deepStrictEqual(result, [
+        `INSERT INTO [people] ([name],[age]) OUTPUT [INSERTED].[name] VALUES (@1,@2)`,
+        ["Rowan", 10]
+      ])
+    })
+
+    it(`update helper returning ${name}`, () => {
+      const result = sql`UPDATE people SET ${sql.update({ name: "Rowan" }).returning(returning)}`.compile()
+
+      assert.deepStrictEqual(result, [
+        `UPDATE people SET [name] = @1 OUTPUT [INSERTED].[name]`,
+        ["Rowan"]
+      ])
+    })
+
+    it(`updateValues helper returning ${name}`, () => {
+      const result = sql`UPDATE people SET name = data.name ${
+        sql.updateValues([{ name: "Rowan" }, { name: "Mira" }], "data").returning(returning)
+      }`.compile()
+
+      assert.deepStrictEqual(result, [
+        `UPDATE people SET name = data.name OUTPUT [INSERTED].[name] FROM (values (@1),(@2)) AS data([name])`,
+        ["Rowan", "Mira"]
+      ])
+    })
+  }
+
   it("array helper", () => {
     const [query, params] = sql`SELECT * FROM ${sql("people")} WHERE id IN ${sql.in([1, 2, "string"])}`.compile()
     expect(query).toEqual(`SELECT * FROM [people] WHERE id IN (@1,@2,@3)`)


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

### Why

SQL `returning` helpers explicitly accept an `Identifier`, but `.returning(sql("INSERTED.name"))` throws during compilation. The shared helper stores the identifier segment where the compiler expects a fragment with `segments`.

### What Changes

Wrap identifier arguments in a fragment before storing them. Strings and existing fragments pass through unchanged, and dialect-specific escaping remains in the compiler.

[Executable MSSQL compiler tests](https://github.com/kitlangton/effect/blob/audit/i1-sql-identifier/packages/sql/mssql/test/Client.test.ts) cover insert, update, and updateValues. Direct identifiers now produce `OUTPUT [INSERTED].[name]`, matching wrapped-identifier controls and preserving binds.

### Scope

One shared SQL-core line, compiler tests, and an `effect` patch changeset. No driver runtime changes or live database requirements.

### Verification

```sh
pnpm lint-fix
pnpm test --run packages/sql/mssql/test/Client.test.ts
pnpm check
git diff --check 0af0985d5c132b33e14a2df59e0567d7ba2a1710 HEAD
git diff --check
```

On that base: 3 failures and 14 passes. With the fix: 17 passes. Lint, root typecheck, and whitespace checks pass. These tests validate compilation without a database connection.

## Related

Closes #7632
Closes EFF-1028

## Audit

Runtime correctness audit; intended label: `audit`.
