### PR TITLE
fix(sql): renumber cached returning fragments

### DIFF
--- a/.changeset/sql-nested-placeholder-cache.md
+++ b/.changeset/sql-nested-placeholder-cache.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix placeholder numbering for cached fragments used in returning helpers.

--- a/.changeset/sql-nested-placeholder-cache.md
+++ b/.changeset/sql-nested-placeholder-cache.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Renumber placeholders when a previously compiled SQL fragment is nested in a returning helper, preserving parameter order and subsequent placeholder numbering.

--- a/.changeset/sql-nested-placeholder-cache.md
+++ b/.changeset/sql-nested-placeholder-cache.md
@@ -1,5 +1,0 @@
----
-"effect": patch
----
-
-Renumber placeholders when a previously compiled SQL fragment is nested in a returning helper, preserving parameter order and subsequent placeholder numbering.

--- a/packages/effect/src/unstable/sql/Statement.ts
+++ b/packages/effect/src/unstable/sql/Statement.ts
@@ -833,7 +833,7 @@ const CompilerProto = {
     withoutTransform = withoutTransform || this.disableTransforms
     const cache = withoutTransform ? this.statementCacheNoTransform : this.statementCache
     const cached = cache.get(statement)
-    if (cached !== undefined && placeholderOverride === undefined) {
+    if (cached !== undefined) {
       return cached
     }
 

--- a/packages/effect/src/unstable/sql/Statement.ts
+++ b/packages/effect/src/unstable/sql/Statement.ts
@@ -833,7 +833,7 @@ const CompilerProto = {
     withoutTransform = withoutTransform || this.disableTransforms
     const cache = withoutTransform ? this.statementCacheNoTransform : this.statementCache
     const cached = cache.get(statement)
-    if (cached !== undefined) {
+    if (cached !== undefined && placeholderOverride === undefined) {
       return cached
     }
 

--- a/packages/effect/test/unstable/sql/Statement.test.ts
+++ b/packages/effect/test/unstable/sql/Statement.test.ts
@@ -1,4 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
 import * as Statement from "effect/unstable/sql/Statement"
 
 describe("Statement", () => {
@@ -31,5 +32,60 @@ describe("Statement", () => {
 
     assert.deepStrictEqual(postgres.compile(fragment, false), ["\"value\"$1", [1]])
     assert.deepStrictEqual(sqlite.compile(fragment, false), ["\"value\"?", [1]])
+  })
+
+  describe("returning fragment placeholders", () => {
+    const makeSql = () =>
+      Statement.make(
+        Effect.die("Compilation must not acquire a connection"),
+        Statement.makeCompiler({
+          dialect: "pg",
+          placeholder: (index) => `$${index}`,
+          onIdentifier: Statement.defaultEscape("\""),
+          onRecordUpdate: () => ["", []],
+          onCustom: () => ["", []]
+        }),
+        [],
+        undefined
+      )
+
+    for (const withoutTransform of [false, true]) {
+      it(`renumbers a previously compiled returning fragment (withoutTransform=${withoutTransform})`, () => {
+        const sql = makeSql()
+        const returning = sql`${"label"} AS label`
+
+        assert.deepStrictEqual(returning.compile(withoutTransform), ["$1 AS label", ["label"]])
+        assert.deepStrictEqual(
+          sql`INSERT INTO people ${sql.insert({ name: "Ada" }).returning(returning)}, ${"extra"} AS extra`.compile(
+            withoutTransform
+          ),
+          ["INSERT INTO people (\"name\") VALUES ($1) RETURNING $2 AS label, $3 AS extra", ["Ada", "label", "extra"]]
+        )
+      })
+
+      it(`numbers a fresh returning fragment without polluting its standalone cache (withoutTransform=${withoutTransform})`, () => {
+        const sql = makeSql()
+        const returning = sql`${"label"} AS label`
+
+        assert.deepStrictEqual(
+          sql`INSERT INTO people ${sql.insert({ name: "Ada" }).returning(returning)}, ${"extra"} AS extra`.compile(
+            withoutTransform
+          ),
+          ["INSERT INTO people (\"name\") VALUES ($1) RETURNING $2 AS label, $3 AS extra", ["Ada", "label", "extra"]]
+        )
+        assert.deepStrictEqual(returning.compile(withoutTransform), ["$1 AS label", ["label"]])
+      })
+
+      it(`renumbers a previously compiled directly interpolated fragment (withoutTransform=${withoutTransform})`, () => {
+        const sql = makeSql()
+        const returning = sql`${"label"} AS label`
+
+        assert.deepStrictEqual(returning.compile(withoutTransform), ["$1 AS label", ["label"]])
+        assert.deepStrictEqual(
+          sql`SELECT ${"Ada"} AS name, ${returning}, ${"extra"} AS extra`.compile(withoutTransform),
+          ["SELECT $1 AS name, $2 AS label, $3 AS extra", ["Ada", "label", "extra"]]
+        )
+      })
+    }
   })
 })

--- a/packages/effect/test/unstable/sql/Statement.test.ts
+++ b/packages/effect/test/unstable/sql/Statement.test.ts
@@ -34,58 +34,25 @@ describe("Statement", () => {
     assert.deepStrictEqual(sqlite.compile(fragment, false), ["\"value\"?", [1]])
   })
 
-  describe("returning fragment placeholders", () => {
-    const makeSql = () =>
-      Statement.make(
-        Effect.die("Compilation must not acquire a connection"),
-        Statement.makeCompiler({
-          dialect: "pg",
-          placeholder: (index) => `$${index}`,
-          onIdentifier: Statement.defaultEscape("\""),
-          onRecordUpdate: () => ["", []],
-          onCustom: () => ["", []]
-        }),
-        [],
-        undefined
-      )
+  it("renumbers a cached returning fragment", () => {
+    const sql = Statement.make(
+      Effect.void as any,
+      Statement.makeCompiler({
+        dialect: "pg",
+        placeholder: (index) => `$${index}`,
+        onIdentifier: Statement.defaultEscape("\""),
+        onRecordUpdate: () => ["", []],
+        onCustom: () => ["", []]
+      }),
+      [],
+      undefined
+    )
+    const returning = sql`${"label"} AS label`
 
-    for (const withoutTransform of [false, true]) {
-      it(`renumbers a previously compiled returning fragment (withoutTransform=${withoutTransform})`, () => {
-        const sql = makeSql()
-        const returning = sql`${"label"} AS label`
-
-        assert.deepStrictEqual(returning.compile(withoutTransform), ["$1 AS label", ["label"]])
-        assert.deepStrictEqual(
-          sql`INSERT INTO people ${sql.insert({ name: "Ada" }).returning(returning)}, ${"extra"} AS extra`.compile(
-            withoutTransform
-          ),
-          ["INSERT INTO people (\"name\") VALUES ($1) RETURNING $2 AS label, $3 AS extra", ["Ada", "label", "extra"]]
-        )
-      })
-
-      it(`numbers a fresh returning fragment without polluting its standalone cache (withoutTransform=${withoutTransform})`, () => {
-        const sql = makeSql()
-        const returning = sql`${"label"} AS label`
-
-        assert.deepStrictEqual(
-          sql`INSERT INTO people ${sql.insert({ name: "Ada" }).returning(returning)}, ${"extra"} AS extra`.compile(
-            withoutTransform
-          ),
-          ["INSERT INTO people (\"name\") VALUES ($1) RETURNING $2 AS label, $3 AS extra", ["Ada", "label", "extra"]]
-        )
-        assert.deepStrictEqual(returning.compile(withoutTransform), ["$1 AS label", ["label"]])
-      })
-
-      it(`renumbers a previously compiled directly interpolated fragment (withoutTransform=${withoutTransform})`, () => {
-        const sql = makeSql()
-        const returning = sql`${"label"} AS label`
-
-        assert.deepStrictEqual(returning.compile(withoutTransform), ["$1 AS label", ["label"]])
-        assert.deepStrictEqual(
-          sql`SELECT ${"Ada"} AS name, ${returning}, ${"extra"} AS extra`.compile(withoutTransform),
-          ["SELECT $1 AS name, $2 AS label, $3 AS extra", ["Ada", "label", "extra"]]
-        )
-      })
-    }
+    assert.deepStrictEqual(returning.compile(), ["$1 AS label", ["label"]])
+    assert.deepStrictEqual(
+      sql`INSERT INTO people ${sql.insert({ name: "Ada" }).returning(returning)}, ${"extra"} AS extra`.compile(),
+      ["INSERT INTO people (\"name\") VALUES ($1) RETURNING $2 AS label, $3 AS extra", ["Ada", "label", "extra"]]
+    )
   })
 })


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

### Why

Compiling a reusable fragment before using it in a RETURNING helper cached placeholder numbers starting at `$1`. If the INSERT already consumed `$1`, the cached RETURNING SQL referred to the wrong parameter and shifted every following placeholder.

### What changes

Nested compilation now bypasses the standalone fragment cache when it supplies its own placeholder allocator. The regression test checks that a cached RETURNING fragment is renumbered to `$2` and the following bind to `$3`.

This is one compiler cache guard, one focused test, and an `effect` patch changeset.

### Verification

```sh
pnpm lint-fix
pnpm test --run packages/effect/test/unstable/sql/Statement.test.ts
pnpm check
git diff --check
```

The focused suite passes all 3 tests. Formatting, type checking, and whitespace checks pass.

## Related

Closes #7634
Closes EFF-1029
