### PR TITLE
fix(Prompt): preserve text parts during serialization

### DIFF
--- a/.changeset/prompt-lossless-text-serialization.md
+++ b/.changeset/prompt-lossless-text-serialization.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve text parts and provider options when serializing prompts.

--- a/packages/effect/src/unstable/ai/Prompt.ts
+++ b/packages/effect/src/unstable/ai/Prompt.ts
@@ -1385,7 +1385,9 @@ export const UserMessage: Schema.Struct<{
   ...BaseMessage.fields,
   role: Schema.Literal("user"),
   content: Schema.Union([
-    ContentFromString,
+    ContentFromString.check(
+      Schema.makeFilter((content) => content.length === 1 && Object.keys(content[0].options).length === 0)
+    ),
     Schema.Array(Schema.Union([TextPart, FilePart]))
   ])
 }).annotate({ identifier: "UserMessage" })
@@ -1585,7 +1587,9 @@ export const AssistantMessage: Schema.Struct<{
   ...BaseMessage.fields,
   role: Schema.Literal("assistant"),
   content: Schema.Union([
-    ContentFromString,
+    ContentFromString.check(
+      Schema.makeFilter((content) => content.length === 1 && Object.keys(content[0].options).length === 0)
+    ),
     Schema.Array(Schema.Union([
       TextPart,
       FilePart,

--- a/packages/effect/test/unstable/ai/Prompt.test.ts
+++ b/packages/effect/test/unstable/ai/Prompt.test.ts
@@ -3,6 +3,29 @@ import { Schema } from "effect"
 import { Prompt, Response } from "effect/unstable/ai"
 
 describe("Prompt", () => {
+  describe("serialization", () => {
+    it("preserves text parts during serialization", () => {
+      const prompt = Prompt.make([
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "first" },
+            { type: "text", text: "second" }
+          ]
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "response", options: { test: { cache: "ephemeral" } } }]
+        }
+      ])
+
+      assert.deepStrictEqual(
+        Schema.decodeSync(Prompt.Prompt)(Schema.encodeSync(Prompt.Prompt)(prompt)),
+        prompt
+      )
+    })
+  })
+
   describe("part schemas", () => {
     it("exports schemas for all parts and message-specific parts", () => {
       const parts = {


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Prompt message schemas now use compact string encoding only for a single text part without provider options. Multiple text parts and text parts with options use the existing array encoding, so serialization preserves their full content while plain text keeps its compact wire form.

The regression test covers both losses in one `Prompt.Prompt` round trip.

## Verification

```sh
pnpm test --run packages/effect/test/unstable/ai/Prompt.test.ts
pnpm lint-fix
pnpm check
```

All 19 Prompt tests pass, along with linting and typechecking.

## Related

Closes EFF-1030
Closes #7636
