### PR TITLE
fix(Prompt): retain JSON-restorable response attachments

### DIFF
--- a/.changeset/prompt-response-files.md
+++ b/.changeset/prompt-response-files.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve generated files when converting AI responses to prompts.

--- a/.changeset/prompt-response-files.md
+++ b/.changeset/prompt-response-files.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve generated file attachments, media types, and provider metadata when converting response parts into prompt history, using base64 data so JSON chat exports can be restored.

--- a/.changeset/prompt-response-files.md
+++ b/.changeset/prompt-response-files.md
@@ -1,5 +1,0 @@
----
-"effect": patch
----
-
-Preserve generated file attachments, media types, and provider metadata when converting response parts into prompt history, using base64 data so JSON chat exports can be restored.

--- a/packages/effect/src/unstable/ai/Prompt.ts
+++ b/packages/effect/src/unstable/ai/Prompt.ts
@@ -11,7 +11,6 @@
  */
 import * as Arr from "../../Array.ts"
 import * as Effect from "../../Effect.ts"
-import * as Encoding from "../../Encoding.ts"
 import { dual } from "../../Function.ts"
 import { type Pipeable, pipeArguments } from "../../Pipeable.ts"
 import * as Predicate from "../../Predicate.ts"
@@ -2123,16 +2122,6 @@ export const fromResponseParts = (parts: ReadonlyArray<Response.AnyPart>): Promp
           active.options = mergeOptions(active.options, part.metadata)
           assistantParts.push(makePart("reasoning", active))
         }
-        break
-      }
-
-      // File Parts
-      case "file": {
-        assistantParts.push(makePart("file", {
-          data: Encoding.encodeBase64(part.data),
-          mediaType: part.mediaType,
-          options: part.metadata
-        }))
         break
       }
 

--- a/packages/effect/src/unstable/ai/Prompt.ts
+++ b/packages/effect/src/unstable/ai/Prompt.ts
@@ -11,6 +11,7 @@
  */
 import * as Arr from "../../Array.ts"
 import * as Effect from "../../Effect.ts"
+import * as Encoding from "../../Encoding.ts"
 import { dual } from "../../Function.ts"
 import { type Pipeable, pipeArguments } from "../../Pipeable.ts"
 import * as Predicate from "../../Predicate.ts"
@@ -2122,6 +2123,16 @@ export const fromResponseParts = (parts: ReadonlyArray<Response.AnyPart>): Promp
           active.options = mergeOptions(active.options, part.metadata)
           assistantParts.push(makePart("reasoning", active))
         }
+        break
+      }
+
+      // File Parts
+      case "file": {
+        assistantParts.push(makePart("file", {
+          data: Encoding.encodeBase64(part.data),
+          mediaType: part.mediaType,
+          options: part.metadata
+        }))
         break
       }
 

--- a/packages/effect/test/unstable/ai/Prompt.test.ts
+++ b/packages/effect/test/unstable/ai/Prompt.test.ts
@@ -1,7 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Ref, Schema, Stream } from "effect"
-import { Chat, Prompt, Response } from "effect/unstable/ai"
-import * as TestUtils from "./utils.ts"
+import { Schema } from "effect"
+import { Prompt, Response } from "effect/unstable/ai"
 
 describe("Prompt", () => {
   describe("part schemas", () => {
@@ -56,65 +55,6 @@ describe("Prompt", () => {
   })
 
   describe("fromResponseParts", () => {
-    for (const streaming of [false, true]) {
-      it.effect(`preserves generated files through JSON chat export (streaming: ${streaming})`, () =>
-        Effect.gen(function*() {
-          const file: Response.FilePartEncoded = {
-            type: "file",
-            data: "AH+A/w==",
-            mediaType: "application/octet-stream",
-            metadata: { example: { id: "attachment-1", generated: true } }
-          }
-          const chat = yield* Chat.empty
-          yield* (streaming
-            ? Stream.runDrain(chat.streamText({ prompt: "Create an attachment" }))
-            : chat.generateText({ prompt: "Create an attachment" })).pipe(
-              TestUtils.withLanguageModel({ generateText: [file], streamText: [file] })
-            )
-          const restored = yield* Chat.fromJson(yield* chat.exportJson)
-          const history = yield* Ref.get(restored.history)
-          assert.deepStrictEqual(
-            history,
-            Prompt.make([
-              { role: "user", content: "Create an attachment" },
-              {
-                role: "assistant",
-                content: [{
-                  type: "file",
-                  data: "AH+A/w==",
-                  mediaType: "application/octet-stream",
-                  options: { example: { id: "attachment-1", generated: true } }
-                }]
-              }
-            ])
-          )
-        }))
-    }
-
-    it("accepts byte attachments in response and assistant message schemas", () => {
-      const data = new Uint8Array([0, 127, 128, 255])
-      const mediaType = "application/octet-stream"
-      const metadata = { example: { id: "attachment-1", generated: true } }
-      const responsePart = Response.makePart("file", { data, mediaType, metadata })
-      const promptPart = Prompt.filePart({ data, mediaType, options: metadata })
-      const prompt = Prompt.fromMessages([Prompt.assistantMessage({ content: [promptPart] })])
-
-      assert.isTrue(Schema.is(Response.FilePart)(responsePart))
-      assert.isTrue(Schema.is(Prompt.AssistantMessage)(prompt.content[0]))
-      assert.deepStrictEqual(
-        prompt,
-        Prompt.make([{
-          role: "assistant",
-          content: [{
-            type: "file",
-            data: new Uint8Array([0, 127, 128, 255]),
-            mediaType: "application/octet-stream",
-            options: { example: { id: "attachment-1", generated: true } }
-          }]
-        }])
-      )
-    })
-
     it("preserves file-only responses as assistant messages", () => {
       const file = Response.makePart("file", {
         data: new Uint8Array([0, 127, 128, 255]),
@@ -133,77 +73,6 @@ describe("Prompt", () => {
             options: { example: { id: "attachment-1", generated: true } }
           }]
         }])
-      )
-    })
-
-    it.each([false, true])("preserves text and tool order and metadata (file included: %s)", (includeFile) => {
-      const parts = [
-        Response.makePart("text", { text: "Before", metadata: { example: { id: "before" } } }),
-        Response.makePart("tool-call", {
-          id: "call-1",
-          name: "read_attachment",
-          params: { id: "attachment-1" },
-          providerExecuted: false,
-          metadata: { example: { id: "call" } }
-        }),
-        ...(includeFile
-          ? [Response.makePart("file", {
-            data: new Uint8Array([0, 127, 128, 255]),
-            mediaType: "application/octet-stream",
-            metadata: { example: { id: "attachment-1", generated: true } }
-          })]
-          : []),
-        Response.makePart("text", { text: "After", metadata: { example: { id: "after" } } }),
-        Response.makePart("tool-result", {
-          id: "call-1",
-          name: "read_attachment",
-          isFailure: false,
-          result: { size: 4 },
-          encodedResult: { size: 4 },
-          preliminary: false,
-          providerExecuted: false,
-          metadata: { example: { id: "result" } }
-        })
-      ]
-
-      assert.deepStrictEqual(
-        Prompt.fromResponseParts(parts),
-        Prompt.make([
-          {
-            role: "assistant",
-            content: [
-              { type: "text", text: "Before", options: { example: { id: "before" } } },
-              {
-                type: "tool-call",
-                id: "call-1",
-                name: "read_attachment",
-                params: { id: "attachment-1" },
-                providerExecuted: false,
-                options: { example: { id: "call" } }
-              },
-              ...(includeFile
-                ? [Prompt.filePart({
-                  data: "AH+A/w==",
-                  mediaType: "application/octet-stream",
-                  options: { example: { id: "attachment-1", generated: true } }
-                })]
-                : []),
-              { type: "text", text: "After", options: { example: { id: "after" } } }
-            ]
-          },
-          {
-            role: "tool",
-            content: [{
-              type: "tool-result",
-              id: "call-1",
-              name: "read_attachment",
-              isFailure: false,
-              result: { size: 4 },
-              providerExecuted: false,
-              options: { example: { id: "result" } }
-            }]
-          }
-        ])
       )
     })
 

--- a/packages/effect/test/unstable/ai/Prompt.test.ts
+++ b/packages/effect/test/unstable/ai/Prompt.test.ts
@@ -1,6 +1,7 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Schema } from "effect"
-import { Prompt, Response } from "effect/unstable/ai"
+import { Effect, Ref, Schema, Stream } from "effect"
+import { Chat, Prompt, Response } from "effect/unstable/ai"
+import * as TestUtils from "./utils.ts"
 
 describe("Prompt", () => {
   describe("part schemas", () => {
@@ -55,6 +56,157 @@ describe("Prompt", () => {
   })
 
   describe("fromResponseParts", () => {
+    for (const streaming of [false, true]) {
+      it.effect(`preserves generated files through JSON chat export (streaming: ${streaming})`, () =>
+        Effect.gen(function*() {
+          const file: Response.FilePartEncoded = {
+            type: "file",
+            data: "AH+A/w==",
+            mediaType: "application/octet-stream",
+            metadata: { example: { id: "attachment-1", generated: true } }
+          }
+          const chat = yield* Chat.empty
+          yield* (streaming
+            ? Stream.runDrain(chat.streamText({ prompt: "Create an attachment" }))
+            : chat.generateText({ prompt: "Create an attachment" })).pipe(
+              TestUtils.withLanguageModel({ generateText: [file], streamText: [file] })
+            )
+          const restored = yield* Chat.fromJson(yield* chat.exportJson)
+          const history = yield* Ref.get(restored.history)
+          assert.deepStrictEqual(
+            history,
+            Prompt.make([
+              { role: "user", content: "Create an attachment" },
+              {
+                role: "assistant",
+                content: [{
+                  type: "file",
+                  data: "AH+A/w==",
+                  mediaType: "application/octet-stream",
+                  options: { example: { id: "attachment-1", generated: true } }
+                }]
+              }
+            ])
+          )
+        }))
+    }
+
+    it("accepts byte attachments in response and assistant message schemas", () => {
+      const data = new Uint8Array([0, 127, 128, 255])
+      const mediaType = "application/octet-stream"
+      const metadata = { example: { id: "attachment-1", generated: true } }
+      const responsePart = Response.makePart("file", { data, mediaType, metadata })
+      const promptPart = Prompt.filePart({ data, mediaType, options: metadata })
+      const prompt = Prompt.fromMessages([Prompt.assistantMessage({ content: [promptPart] })])
+
+      assert.isTrue(Schema.is(Response.FilePart)(responsePart))
+      assert.isTrue(Schema.is(Prompt.AssistantMessage)(prompt.content[0]))
+      assert.deepStrictEqual(
+        prompt,
+        Prompt.make([{
+          role: "assistant",
+          content: [{
+            type: "file",
+            data: new Uint8Array([0, 127, 128, 255]),
+            mediaType: "application/octet-stream",
+            options: { example: { id: "attachment-1", generated: true } }
+          }]
+        }])
+      )
+    })
+
+    it("preserves file-only responses as assistant messages", () => {
+      const file = Response.makePart("file", {
+        data: new Uint8Array([0, 127, 128, 255]),
+        mediaType: "application/octet-stream",
+        metadata: { example: { id: "attachment-1", generated: true } }
+      })
+
+      assert.deepStrictEqual(
+        Prompt.fromResponseParts([file]),
+        Prompt.make([{
+          role: "assistant",
+          content: [{
+            type: "file",
+            data: "AH+A/w==",
+            mediaType: "application/octet-stream",
+            options: { example: { id: "attachment-1", generated: true } }
+          }]
+        }])
+      )
+    })
+
+    it.each([false, true])("preserves text and tool order and metadata (file included: %s)", (includeFile) => {
+      const parts = [
+        Response.makePart("text", { text: "Before", metadata: { example: { id: "before" } } }),
+        Response.makePart("tool-call", {
+          id: "call-1",
+          name: "read_attachment",
+          params: { id: "attachment-1" },
+          providerExecuted: false,
+          metadata: { example: { id: "call" } }
+        }),
+        ...(includeFile
+          ? [Response.makePart("file", {
+            data: new Uint8Array([0, 127, 128, 255]),
+            mediaType: "application/octet-stream",
+            metadata: { example: { id: "attachment-1", generated: true } }
+          })]
+          : []),
+        Response.makePart("text", { text: "After", metadata: { example: { id: "after" } } }),
+        Response.makePart("tool-result", {
+          id: "call-1",
+          name: "read_attachment",
+          isFailure: false,
+          result: { size: 4 },
+          encodedResult: { size: 4 },
+          preliminary: false,
+          providerExecuted: false,
+          metadata: { example: { id: "result" } }
+        })
+      ]
+
+      assert.deepStrictEqual(
+        Prompt.fromResponseParts(parts),
+        Prompt.make([
+          {
+            role: "assistant",
+            content: [
+              { type: "text", text: "Before", options: { example: { id: "before" } } },
+              {
+                type: "tool-call",
+                id: "call-1",
+                name: "read_attachment",
+                params: { id: "attachment-1" },
+                providerExecuted: false,
+                options: { example: { id: "call" } }
+              },
+              ...(includeFile
+                ? [Prompt.filePart({
+                  data: "AH+A/w==",
+                  mediaType: "application/octet-stream",
+                  options: { example: { id: "attachment-1", generated: true } }
+                })]
+                : []),
+              { type: "text", text: "After", options: { example: { id: "after" } } }
+            ]
+          },
+          {
+            role: "tool",
+            content: [{
+              type: "tool-result",
+              id: "call-1",
+              name: "read_attachment",
+              isFailure: false,
+              result: { size: 4 },
+              providerExecuted: false,
+              options: { example: { id: "result" } }
+            }]
+          }
+        ])
+      )
+    })
+
     it("folds streamed text and reasoning deltas into an assistant message", () => {
       const parts = [
         Response.makePart("text-start", { id: "1" }),


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`Prompt.fromResponseParts` ignored generated file parts, so file-only responses became empty prompts and attachments disappeared from chat history.

Response files are now converted to assistant file parts with their media type and provider metadata intact. Their bytes use the existing base64 representation so exported chat history remains JSON-restorable.

## Verification

- `nix develop -c pnpm test --run packages/effect/test/unstable/ai/Prompt.test.ts` (19 passed)
- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`

## Related

Closes EFF-1031

Closes #7638
