### PR TITLE
fix(SchemaGetter): preserve duplicate array-valued leaves

### DIFF
--- a/.changeset/schema-array-leaf-aggregation.md
+++ b/.changeset/schema-array-leaf-aggregation.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Preserve array-valued leaves and avoid mutating caller input when SchemaGetter.makeTreeRecord aggregates duplicate paths.
+Preserve array-valued leaves when `SchemaGetter.makeTreeRecord` aggregates duplicate paths.

--- a/.changeset/schema-array-leaf-aggregation.md
+++ b/.changeset/schema-array-leaf-aggregation.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve array-valued leaves and avoid mutating caller input when SchemaGetter.makeTreeRecord aggregates duplicate paths.

--- a/packages/effect/src/SchemaGetter.ts
+++ b/packages/effect/src/SchemaGetter.ts
@@ -1919,6 +1919,7 @@ export function makeTreeRecord<A>(
 ): Schema.TreeRecord<A> {
   const out: any = {}
   const containers = new WeakSet<object>()
+  const duplicates = new WeakSet<object>()
 
   function getOrCreateContainer(self: any, key: PropertyKey, shouldBeArray: boolean): any {
     const current = Object.hasOwn(self, key) ? self[key] : undefined
@@ -1952,10 +1953,12 @@ export function makeTreeRecord<A>(
         // If we're setting a value at a path that already exists
         // convert it to an array to support multiple values for the same key
         const hasOwn = Object.hasOwn(cur, token)
-        if (hasOwn && Array.isArray(cur[token])) {
+        if (hasOwn && Array.isArray(cur[token]) && (containers.has(cur[token]) || duplicates.has(cur[token]))) {
           cur[token].push(value)
         } else if (hasOwn) {
-          InternalRecord.assignProperty(cur, token, [cur[token], value])
+          const values = [cur[token], value]
+          duplicates.add(values)
+          InternalRecord.assignProperty(cur, token, values)
         } else {
           InternalRecord.assignProperty(cur, token, value)
         }

--- a/packages/effect/test/schema/SchemaGetter.test.ts
+++ b/packages/effect/test/schema/SchemaGetter.test.ts
@@ -47,6 +47,81 @@ describe("SchemaGetter", () => {
   })
 
   describe("makeTreeRecord", () => {
+    it("preserves array-valued leaves when merging duplicate paths", () => {
+      assert.deepStrictEqual(
+        SchemaGetter.makeTreeRecord<ReadonlyArray<string>>([
+          ["permissions", ["read"]],
+          ["permissions", ["write"]],
+          ["permissions", ["share"]]
+        ]),
+        { permissions: [["read"], ["write"], ["share"]] }
+      )
+    })
+
+    it("does not mutate array-valued leaves when merging duplicate paths", () => {
+      const first = ["read"]
+      const second = ["write"]
+      SchemaGetter.makeTreeRecord<ReadonlyArray<string>>([
+        ["permissions", first],
+        ["permissions", second]
+      ])
+      assert.deepStrictEqual(first, ["read"])
+      assert.deepStrictEqual(second, ["write"])
+    })
+
+    it("merges frozen array-valued leaves at duplicate paths", () => {
+      assert.deepStrictEqual(
+        SchemaGetter.makeTreeRecord<ReadonlyArray<string>>([
+          ["permissions", Object.freeze(["read"])],
+          ["permissions", Object.freeze(["write"])],
+          ["permissions", Object.freeze(["share"])]
+        ]),
+        { permissions: [["read"], ["write"], ["share"]] }
+      )
+    })
+
+    it("preserves a singleton frozen array-valued leaf", () => {
+      assert.deepStrictEqual(
+        SchemaGetter.makeTreeRecord<ReadonlyArray<string>>([
+          ["permissions", Object.freeze(["read"])]
+        ]),
+        { permissions: ["read"] }
+      )
+    })
+
+    it("merges three scalar leaves at duplicate paths", () => {
+      assert.deepStrictEqual(
+        SchemaGetter.makeTreeRecord<string>([
+          ["permissions", "read"],
+          ["permissions", "write"],
+          ["permissions", "share"]
+        ]),
+        { permissions: ["read", "write", "share"] }
+      )
+    })
+
+    it("merges frozen object-valued leaves at duplicate paths", () => {
+      assert.deepStrictEqual(
+        SchemaGetter.makeTreeRecord<Readonly<{ permission: string }>>([
+          ["permissions", Object.freeze({ permission: "read" })],
+          ["permissions", Object.freeze({ permission: "write" })],
+          ["permissions", Object.freeze({ permission: "share" })]
+        ]),
+        { permissions: [{ permission: "read" }, { permission: "write" }, { permission: "share" }] }
+      )
+    })
+
+    it("preserves frozen array-valued leaves with indexed and append paths", () => {
+      assert.deepStrictEqual(
+        SchemaGetter.makeTreeRecord<ReadonlyArray<string>>([
+          ["permissions[0]", Object.freeze(["read"])],
+          ["permissions[]", Object.freeze(["write"])],
+          ["permissions[]", Object.freeze(["share"])]
+        ]),
+        { permissions: [["read"], ["write"], ["share"]] }
+      )
+    })
+
     it("replaces conflicting leaf values with containers", () => {
       deepStrictEqual(
         SchemaGetter.makeTreeRecord([

--- a/packages/effect/test/schema/SchemaGetter.test.ts
+++ b/packages/effect/test/schema/SchemaGetter.test.ts
@@ -47,76 +47,12 @@ describe("SchemaGetter", () => {
   })
 
   describe("makeTreeRecord", () => {
-    it("preserves array-valued leaves when merging duplicate paths", () => {
-      assert.deepStrictEqual(
-        SchemaGetter.makeTreeRecord<ReadonlyArray<string>>([
+    it("preserves array-valued leaves at duplicate paths", () => {
+      deepStrictEqual(
+        SchemaGetter.makeTreeRecord([
           ["permissions", ["read"]],
           ["permissions", ["write"]],
           ["permissions", ["share"]]
-        ]),
-        { permissions: [["read"], ["write"], ["share"]] }
-      )
-    })
-
-    it("does not mutate array-valued leaves when merging duplicate paths", () => {
-      const first = ["read"]
-      const second = ["write"]
-      SchemaGetter.makeTreeRecord<ReadonlyArray<string>>([
-        ["permissions", first],
-        ["permissions", second]
-      ])
-      assert.deepStrictEqual(first, ["read"])
-      assert.deepStrictEqual(second, ["write"])
-    })
-
-    it("merges frozen array-valued leaves at duplicate paths", () => {
-      assert.deepStrictEqual(
-        SchemaGetter.makeTreeRecord<ReadonlyArray<string>>([
-          ["permissions", Object.freeze(["read"])],
-          ["permissions", Object.freeze(["write"])],
-          ["permissions", Object.freeze(["share"])]
-        ]),
-        { permissions: [["read"], ["write"], ["share"]] }
-      )
-    })
-
-    it("preserves a singleton frozen array-valued leaf", () => {
-      assert.deepStrictEqual(
-        SchemaGetter.makeTreeRecord<ReadonlyArray<string>>([
-          ["permissions", Object.freeze(["read"])]
-        ]),
-        { permissions: ["read"] }
-      )
-    })
-
-    it("merges three scalar leaves at duplicate paths", () => {
-      assert.deepStrictEqual(
-        SchemaGetter.makeTreeRecord<string>([
-          ["permissions", "read"],
-          ["permissions", "write"],
-          ["permissions", "share"]
-        ]),
-        { permissions: ["read", "write", "share"] }
-      )
-    })
-
-    it("merges frozen object-valued leaves at duplicate paths", () => {
-      assert.deepStrictEqual(
-        SchemaGetter.makeTreeRecord<Readonly<{ permission: string }>>([
-          ["permissions", Object.freeze({ permission: "read" })],
-          ["permissions", Object.freeze({ permission: "write" })],
-          ["permissions", Object.freeze({ permission: "share" })]
-        ]),
-        { permissions: [{ permission: "read" }, { permission: "write" }, { permission: "share" }] }
-      )
-    })
-
-    it("preserves frozen array-valued leaves with indexed and append paths", () => {
-      assert.deepStrictEqual(
-        SchemaGetter.makeTreeRecord<ReadonlyArray<string>>([
-          ["permissions[0]", Object.freeze(["read"])],
-          ["permissions[]", Object.freeze(["write"])],
-          ["permissions[]", Object.freeze(["share"])]
         ]),
         { permissions: [["read"], ["write"], ["share"]] }
       )


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`SchemaGetter.makeTreeRecord` treated a caller-provided array leaf as its duplicate-value buffer. Repeating a path could mutate the first input and flatten that leaf into the result.

The fix tracks internally allocated duplicate buffers separately from structural containers. Duplicate array-valued leaves now remain distinct, while repeated scalar values and bracket-path arrays keep their existing behavior.

The regression test is in `packages/effect/test/schema/SchemaGetter.test.ts`.

## Verification

```sh
pnpm lint-fix
pnpm test --run packages/effect/test/schema/SchemaGetter.test.ts
pnpm check
git diff --check
```

## Related

Closes #7640
Closes EFF-1032
