### PR TITLE
test(sql-mysql2): reuse Model test container

### DIFF
--- a/packages/sql/mysql2/test/Model.integration.test.ts
+++ b/packages/sql/mysql2/test/Model.integration.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, it } from "@effect/vitest"
+import { assert, it } from "@effect/vitest"
 import { Cause, Effect, Schema } from "effect"
 import { Model } from "effect/unstable/schema"
 import { SqlClient, SqlModel, SqlResolver } from "effect/unstable/sql"
@@ -22,67 +22,64 @@ class SoftDeleteUser extends Model.Class<SoftDeleteUser>("SoftDeleteUser")({
   )
 }) {}
 
-describe("SqlModel", () => {
+it.layer(MysqlContainer.layer, { timeout: "90 seconds", excludeTestServices: true })("SqlModel", (it) => {
   it.effect("insert returns result", () =>
     Effect.gen(function*() {
       const repo = yield* SqlModel.makeRepository(User, {
-        tableName: "users",
+        tableName: "users_insert",
         idColumn: "id",
         spanPrefix: "UserRepository"
       })
       const sql = yield* SqlClient.SqlClient
-      yield* sql`CREATE TABLE users (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), age INT)`
+      yield* sql`CREATE TABLE users_insert (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), age INT)`
 
       const result = yield* repo.insert(User.insert.make({ name: "Alice", age: 30 }))
       assert.deepStrictEqual(result, new User({ id: 1, name: "Alice", age: 30 }))
     }).pipe(
-      Effect.provide(MysqlContainer.layerClient),
-      Effect.catchTag("ContainerError", () => Effect.void)
+      Effect.provide(MysqlContainer.client)
     ), { timeout: 60_000 })
 
   it.effect("insert returns result with transforms", () =>
     Effect.gen(function*() {
       const repo = yield* SqlModel.makeRepository(User, {
-        tableName: "users",
+        tableName: "users_insert_transforms",
         idColumn: "id",
         spanPrefix: "UserRepository"
       })
       const sql = yield* SqlClient.SqlClient
-      yield* sql`CREATE TABLE users (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), age INT)`
+      yield* sql`CREATE TABLE users_insert_transforms (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), age INT)`
 
       const result = yield* repo.insert(User.insert.make({ name: "Alice", age: 30 }))
       assert.deepStrictEqual(result, new User({ id: 1, name: "Alice", age: 30 }))
     }).pipe(
-      Effect.provide(MysqlContainer.layerClientWithTransforms),
-      Effect.catchTag("ContainerError", () => Effect.void)
+      Effect.provide(MysqlContainer.clientWithTransforms)
     ), { timeout: 60_000 })
 
   it.effect("insertVoid", () =>
     Effect.gen(function*() {
       const repo = yield* SqlModel.makeRepository(User, {
-        tableName: "users",
+        tableName: "users_insert_void",
         idColumn: "id",
         spanPrefix: "UserRepository"
       })
       const sql = yield* SqlClient.SqlClient
-      yield* sql`CREATE TABLE users (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), age INT)`
+      yield* sql`CREATE TABLE users_insert_void (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), age INT)`
 
       const result = yield* repo.insertVoid(User.insert.make({ name: "Alice", age: 30 }))
       assert.strictEqual(result, void 0)
     }).pipe(
-      Effect.provide(MysqlContainer.layerClient),
-      Effect.catchTag("ContainerError", () => Effect.void)
+      Effect.provide(MysqlContainer.client)
     ), { timeout: 60_000 })
 
-  it.live("insert data loader returns result", () =>
+  it.effect("insert data loader returns result", () =>
     Effect.gen(function*() {
       const repo = yield* SqlModel.makeResolvers(User, {
-        tableName: "users",
+        tableName: "users_insert_loader",
         idColumn: "id",
         spanPrefix: "UserRepository"
       })
       const sql = yield* SqlClient.SqlClient
-      yield* sql`CREATE TABLE users (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), age INT)`
+      yield* sql`CREATE TABLE users_insert_loader (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), age INT)`
 
       const [alice, john] = yield* Effect.all([
         SqlResolver.request(User.insert.make({ name: "Alice", age: 30 }), repo.insert),
@@ -91,19 +88,18 @@ describe("SqlModel", () => {
       assert.deepStrictEqual(alice.name, "Alice")
       assert.deepStrictEqual(john.name, "John")
     }).pipe(
-      Effect.provide(MysqlContainer.layerClient),
-      Effect.catchTag("ContainerError", () => Effect.void)
+      Effect.provide(MysqlContainer.client)
     ), { timeout: 60_000 })
 
-  it.live("findById data loader", () =>
+  it.effect("findById data loader", () =>
     Effect.gen(function*() {
       const repo = yield* SqlModel.makeResolvers(User, {
-        tableName: "users",
+        tableName: "users_find_loader",
         idColumn: "id",
         spanPrefix: "UserRepository"
       })
       const sql = yield* SqlClient.SqlClient
-      yield* sql`CREATE TABLE users (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), age INT)`
+      yield* sql`CREATE TABLE users_find_loader (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), age INT)`
       const alice = yield* SqlResolver.request(User.insert.make({ name: "Alice", age: 30 }), repo.insert)
       const john = yield* SqlResolver.request(User.insert.make({ name: "John", age: 30 }), repo.insert)
 
@@ -115,8 +111,7 @@ describe("SqlModel", () => {
       assert.deepStrictEqual(alice2.name, "Alice")
       assert.deepStrictEqual(john2.name, "John")
     }).pipe(
-      Effect.provide(MysqlContainer.layerClient),
-      Effect.catchTag("ContainerError", () => Effect.void)
+      Effect.provide(MysqlContainer.client)
     ), { timeout: 60_000 })
 
   it.effect("findById ignores soft deleted rows", () =>
@@ -150,11 +145,10 @@ describe("SqlModel", () => {
       const deletedError = yield* Effect.flip(repo.findById(alice.id))
       assert.isTrue(Cause.isNoSuchElementError(deletedError))
     }).pipe(
-      Effect.provide(MysqlContainer.layerClient),
-      Effect.catchTag("ContainerError", () => Effect.void)
+      Effect.provide(MysqlContainer.client)
     ), { timeout: 60_000 })
 
-  it.live("findById data loader ignores soft deleted rows", () =>
+  it.effect("findById data loader ignores soft deleted rows", () =>
     Effect.gen(function*() {
       const repo = yield* SqlModel.makeResolvers(SoftDeleteUser, {
         tableName: "soft_delete_user_resolvers",
@@ -185,44 +179,41 @@ describe("SqlModel", () => {
       const deletedError = yield* Effect.flip(SqlResolver.request(alice.id, repo.findById))
       assert.isTrue(Cause.isNoSuchElementError(deletedError))
     }).pipe(
-      Effect.provide(MysqlContainer.layerClient),
-      Effect.catchTag("ContainerError", () => Effect.void)
+      Effect.provide(MysqlContainer.client)
     ), { timeout: 60_000 })
 
   it.effect("update returns result", () =>
     Effect.gen(function*() {
       const repo = yield* SqlModel.makeRepository(User, {
-        tableName: "users",
+        tableName: "users_update",
         idColumn: "id",
         spanPrefix: "UserRepository"
       })
       const sql = yield* SqlClient.SqlClient
-      yield* sql`CREATE TABLE users (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), age INT)`
+      yield* sql`CREATE TABLE users_update (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), age INT)`
 
       let result = yield* repo.insert(User.insert.make({ name: "Alice", age: 30 }))
       result = yield* repo.update(User.update.make({ ...result, name: "Bob" }))
       assert.deepStrictEqual(result, new User({ id: 1, name: "Bob", age: 30 }))
     }).pipe(
-      Effect.provide(MysqlContainer.layerClient),
-      Effect.catchTag("ContainerError", () => Effect.void)
+      Effect.provide(MysqlContainer.client)
     ), { timeout: 60_000 })
 
   it.effect("update returns result with transforms", () =>
     Effect.gen(function*() {
       const repo = yield* SqlModel.makeRepository(User, {
-        tableName: "users",
+        tableName: "users_update_transforms",
         idColumn: "id",
         spanPrefix: "UserRepository"
       })
       const sql = yield* SqlClient.SqlClient
-      yield* sql`CREATE TABLE users (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), age INT)`
+      yield* sql`CREATE TABLE users_update_transforms (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), age INT)`
 
       let result = yield* repo.insert(User.insert.make({ name: "Alice", age: 30 }))
       result = yield* repo.update(User.update.make({ ...result, name: "Bob" }))
       assert.deepStrictEqual(result, new User({ id: 1, name: "Bob", age: 30 }))
     }).pipe(
-      Effect.provide(MysqlContainer.layerClientWithTransforms),
-      Effect.catchTag("ContainerError", () => Effect.void)
+      Effect.provide(MysqlContainer.clientWithTransforms)
     ), { timeout: 60_000 })
 
   it("acquires one MySQL container for the test file", () => {

--- a/packages/sql/mysql2/test/Model.integration.test.ts
+++ b/packages/sql/mysql2/test/Model.integration.test.ts
@@ -2,7 +2,7 @@ import { assert, describe, it } from "@effect/vitest"
 import { Cause, Effect, Schema } from "effect"
 import { Model } from "effect/unstable/schema"
 import { SqlClient, SqlModel, SqlResolver } from "effect/unstable/sql"
-import { MysqlContainer } from "./utils.ts"
+import { getMysqlContainerAcquisitionCount, MysqlContainer } from "./utils.ts"
 
 class User extends Model.Class<User>("User")({
   id: Schema.Int.pipe(
@@ -224,4 +224,8 @@ describe("SqlModel", () => {
       Effect.provide(MysqlContainer.layerClientWithTransforms),
       Effect.catchTag("ContainerError", () => Effect.void)
     ), { timeout: 60_000 })
+
+  it("acquires one MySQL container for the test file", () => {
+    assert.strictEqual(getMysqlContainerAcquisitionCount(), 1)
+  })
 })

--- a/packages/sql/mysql2/test/Model.integration.test.ts
+++ b/packages/sql/mysql2/test/Model.integration.test.ts
@@ -2,7 +2,7 @@ import { assert, it } from "@effect/vitest"
 import { Cause, Effect, Schema } from "effect"
 import { Model } from "effect/unstable/schema"
 import { SqlClient, SqlModel, SqlResolver } from "effect/unstable/sql"
-import { getMysqlContainerAcquisitionCount, MysqlContainer } from "./utils.ts"
+import { MysqlContainer } from "./utils.ts"
 
 class User extends Model.Class<User>("User")({
   id: Schema.Int.pipe(
@@ -215,8 +215,4 @@ it.layer(MysqlContainer.layer, { timeout: "90 seconds", excludeTestServices: tru
     }).pipe(
       Effect.provide(MysqlContainer.clientWithTransforms)
     ), { timeout: 60_000 })
-
-  it("acquires one MySQL container for the test file", () => {
-    assert.strictEqual(getMysqlContainerAcquisitionCount(), 1)
-  })
 })

--- a/packages/sql/mysql2/test/utils.ts
+++ b/packages/sql/mysql2/test/utils.ts
@@ -50,7 +50,7 @@ export class MysqlContainer extends Context.Service<
 
   static layerClient = this.client.pipe(Layer.provide(this.layer))
 
-  static layerClientWithTransforms = Layer.unwrap(
+  static clientWithTransforms = Layer.unwrap(
     Effect.gen(function*() {
       const container = yield* MysqlContainer
       return MysqlClient.layer({
@@ -59,7 +59,9 @@ export class MysqlContainer extends Context.Service<
         transformResultNames: String.snakeToCamel
       })
     })
-  ).pipe(Layer.provide(this.layer))
+  )
+
+  static layerClientWithTransforms = this.clientWithTransforms.pipe(Layer.provide(this.layer))
 
   static layerVitest = Layer.effect(
     this,

--- a/packages/sql/mysql2/test/utils.ts
+++ b/packages/sql/mysql2/test/utils.ts
@@ -7,10 +7,6 @@ export class ContainerError extends Data.TaggedError("ContainerError")<{
   cause: unknown
 }> {}
 
-let mysqlContainerAcquisitions = 0
-
-export const getMysqlContainerAcquisitionCount = () => mysqlContainerAcquisitions
-
 const makeMysqlContainer = () =>
   new MySqlContainer("mysql:lts").withHealthCheck({
     test: [
@@ -29,10 +25,7 @@ export class MysqlContainer extends Context.Service<
   static readonly layer = Layer.effect(this)(
     Effect.acquireRelease(
       Effect.tryPromise({
-        try: () => {
-          mysqlContainerAcquisitions++
-          return makeMysqlContainer().start()
-        },
+        try: () => makeMysqlContainer().start(),
         catch: (cause) => new ContainerError({ cause })
       }),
       (container) => Effect.promise(() => container.stop())
@@ -60,8 +53,6 @@ export class MysqlContainer extends Context.Service<
       })
     })
   )
-
-  static layerClientWithTransforms = this.clientWithTransforms.pipe(Layer.provide(this.layer))
 
   static layerVitest = Layer.effect(
     this,

--- a/packages/sql/mysql2/test/utils.ts
+++ b/packages/sql/mysql2/test/utils.ts
@@ -7,6 +7,10 @@ export class ContainerError extends Data.TaggedError("ContainerError")<{
   cause: unknown
 }> {}
 
+let mysqlContainerAcquisitions = 0
+
+export const getMysqlContainerAcquisitionCount = () => mysqlContainerAcquisitions
+
 const makeMysqlContainer = () =>
   new MySqlContainer("mysql:lts").withHealthCheck({
     test: [
@@ -25,7 +29,10 @@ export class MysqlContainer extends Context.Service<
   static readonly layer = Layer.effect(this)(
     Effect.acquireRelease(
       Effect.tryPromise({
-        try: () => makeMysqlContainer().start(),
+        try: () => {
+          mysqlContainerAcquisitions++
+          return makeMysqlContainer().start()
+        },
         catch: (cause) => new ContainerError({ cause })
       }),
       (container) => Effect.promise(() => container.stop())


### PR DESCRIPTION
## Summary

- scope the Model integration suite to one MySQL container
- use distinct tables so concurrent cases stay isolated
- derive normal and transformed clients from the shared container
- stop swallowing `ContainerError`

## Verification

- `EFFECT_INTEGRATION_TESTS=1 pnpm test --run --project @effect/sql-mysql2 test/Model.integration.test.ts` (9 passed)
- `pnpm lint-fix`
- `pnpm check`

Closes EFF-1034
