### PR TITLE
Reduce allocations in Effect primitives and fibers

### DIFF
--- a/.changeset/eff-1036-fiber-allocations.md
+++ b/.changeset/eff-1036-fiber-allocations.md
@@ -1,0 +1,19 @@
+---
+"effect": patch
+"@effect/opentelemetry": patch
+---
+
+Reduce allocations in Effect primitives and fibers.
+
+Effect primitives, `Exit`, `Option`, `Result`, and `Deferred` values are now
+constructed with exactly-sized constructors instead of `Object.create`, hot
+combinators (`map`, `as`, `tap`, `andThen`) no longer allocate per-call
+closures, and fibers share a per-context cache of derived values.
+
+Breaking: the context-derived fields on the `Fiber` interface
+(`currentScheduler`, `currentSpan`, `currentLogLevel`, `minimumLogLevel`,
+`currentStackFrame`, `maxOpsBeforeYield`, `currentPreventYield`) moved to a
+shared read-only `fiber.cache` object: use `fiber.cache.scheduler`,
+`fiber.cache.span`, `fiber.cache.logLevel`, `fiber.cache.minimumLogLevel`,
+`fiber.cache.stackFrame`, `fiber.cache.maxOpsBeforeYield`, and
+`fiber.cache.preventYield` instead.

--- a/.changeset/eff-1036-fiber-allocations.md
+++ b/.changeset/eff-1036-fiber-allocations.md
@@ -3,17 +3,10 @@
 "@effect/opentelemetry": patch
 ---
 
-Reduce allocations in Effect primitives and fibers.
+Reduce memory usage in Effect primitives and fibers.
 
-Effect primitives, `Exit`, `Option`, `Result`, and `Deferred` values are now
-constructed with exactly-sized constructors instead of `Object.create`, hot
-combinators (`map`, `as`, `tap`, `andThen`) no longer allocate per-call
-closures, and fibers share a per-context cache of derived values.
-
-Breaking: the context-derived fields on the `Fiber` interface
-(`currentScheduler`, `currentSpan`, `currentLogLevel`, `minimumLogLevel`,
-`currentStackFrame`, `maxOpsBeforeYield`, `currentPreventYield`) moved to a
-shared read-only `fiber.cache` object: use `fiber.cache.scheduler`,
-`fiber.cache.span`, `fiber.cache.logLevel`, `fiber.cache.minimumLogLevel`,
-`fiber.cache.stackFrame`, `fiber.cache.maxOpsBeforeYield`, and
-`fiber.cache.preventYield` instead.
+Breaking: context-derived `Fiber` fields now live under `fiber.cache`. The
+`currentScheduler`, `currentSpan`, `currentLogLevel`, `currentStackFrame`, and
+`currentPreventYield` fields are now `scheduler`, `span`, `logLevel`,
+`stackFrame`, and `preventYield`. Access `minimumLogLevel` and
+`maxOpsBeforeYield` through `cache` as well.

--- a/migration/annotations/effect__Logger.yaml
+++ b/migration/annotations/effect__Logger.yaml
@@ -95,8 +95,8 @@ effect/Logger#withMinimumLogLevel:
   replacement: "Effect.provideService(effect, References.MinimumLogLevel, level)"
   note: "Replace the FiberRef-local helper with reference provisioning."
 effect/Logger#withSpanAnnotations:
-  replacement: "custom Logger.make wrapper using options.fiber.currentSpan"
-  note: "No transparent generic equivalent remains. Read span identity from options.fiber.currentSpan and add it to custom output as needed."
+  replacement: "custom Logger.make wrapper using options.fiber.cache.span"
+  note: "No transparent generic equivalent remains. Read span identity from options.fiber.cache.span and add it to custom output as needed."
 effect/Logger#zip:
   replacement: "Logger.make(options => [left.log(options), right.log(options)])"
   note: "No named combinator remains; invoke both loggers and return their output tuple."

--- a/packages/effect/src/Deferred.ts
+++ b/packages/effect/src/Deferred.ts
@@ -117,6 +117,12 @@ const DeferredProto = {
   }
 }
 
+function DeferredImpl(this: any) {
+  this.resumes = undefined
+  this.effect = undefined
+}
+DeferredImpl.prototype = DeferredProto
+
 /**
  * Creates an empty `Deferred` synchronously outside the `Effect` runtime.
  *
@@ -137,12 +143,7 @@ const DeferredProto = {
  * @category unsafe
  * @since 4.0.0
  */
-export const makeUnsafe = <A, E = never>(): Deferred<A, E> => {
-  const self = Object.create(DeferredProto)
-  self.resumes = undefined
-  self.effect = undefined
-  return self
-}
+export const makeUnsafe = <A, E = never>(): Deferred<A, E> => new (DeferredImpl as any)()
 
 /**
  * Creates a new `Deferred`.

--- a/packages/effect/src/Deferred.ts
+++ b/packages/effect/src/Deferred.ts
@@ -117,10 +117,10 @@ const DeferredProto = {
   }
 }
 
-function DeferredImpl(this: any) {
+const DeferredImpl = function(this: any) {
   this.resumes = undefined
   this.effect = undefined
-}
+} as unknown as { new<A, E>(): Deferred<A, E>; prototype: any }
 DeferredImpl.prototype = DeferredProto
 
 /**
@@ -143,7 +143,7 @@ DeferredImpl.prototype = DeferredProto
  * @category unsafe
  * @since 4.0.0
  */
-export const makeUnsafe = <A, E = never>(): Deferred<A, E> => new (DeferredImpl as any)()
+export const makeUnsafe = <A, E = never>(): Deferred<A, E> => new DeferredImpl<A, E>()
 
 /**
  * Creates a new `Deferred`.

--- a/packages/effect/src/Fiber.ts
+++ b/packages/effect/src/Fiber.ts
@@ -13,12 +13,13 @@ import type { Effect } from "./Effect.ts"
 import type { Exit } from "./Exit.ts"
 import * as effect from "./internal/effect.ts"
 import type { LogLevel } from "./LogLevel.ts"
+import type { FiberRuntimeMetricsService } from "./Metric.ts"
 import type { Pipeable } from "./Pipeable.ts"
 import { hasProperty } from "./Predicate.ts"
 import type { StackFrame } from "./References.ts"
 import type { Scheduler, SchedulerDispatcher } from "./Scheduler.ts"
 import type { Scope } from "./Scope.ts"
-import type { AnySpan } from "./Tracer.ts"
+import type { AnySpan, Tracer } from "./Tracer.ts"
 import type { Covariant } from "./Types.ts"
 
 const TypeId = "~effect/Fiber"
@@ -75,14 +76,8 @@ export interface Fiber<out A, out E = never> extends Pipeable {
   readonly getRef: <A>(ref: Context.Reference<A>) => A
   readonly context: Context.Context<never>
   setContext(context: Context.Context<never>): void
-  readonly currentScheduler: Scheduler
+  readonly cache: Fiber.Cache
   readonly currentDispatcher: SchedulerDispatcher
-  readonly currentSpan?: AnySpan | undefined
-  readonly currentLogLevel: LogLevel
-  readonly minimumLogLevel: LogLevel
-  readonly currentStackFrame?: StackFrame | undefined
-  readonly maxOpsBeforeYield: number
-  readonly currentPreventYield: boolean
   readonly addObserver: (cb: (exit: Exit<A, E>) => void) => () => void
   readonly interruptUnsafe: (
     fiberId?: number | undefined,
@@ -154,6 +149,34 @@ export declare namespace Fiber {
   export interface Variance<out A, out E = never> {
     readonly _A: Covariant<A>
     readonly _E: Covariant<E>
+  }
+
+  /**
+   * Context-derived values cached for the fiber's current `Context`.
+   *
+   * **When to use**
+   *
+   * Use to read runtime services resolved from the fiber's context, such as
+   * the scheduler, current span, or log levels.
+   *
+   * **Details**
+   *
+   * The cache object is computed once per context cache root and shared by
+   * every fiber running with that root, so it must be treated as immutable.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Cache {
+    readonly scheduler: Scheduler
+    readonly tracerContext: Tracer["context"] | undefined
+    readonly span: AnySpan | undefined
+    readonly logLevel: LogLevel
+    readonly minimumLogLevel: LogLevel
+    readonly stackFrame: StackFrame | undefined
+    readonly runtimeMetrics: FiberRuntimeMetricsService | undefined
+    readonly maxOpsBeforeYield: number
+    readonly preventYield: boolean
   }
 }
 

--- a/packages/effect/src/ManagedRuntime.ts
+++ b/packages/effect/src/ManagedRuntime.ts
@@ -317,7 +317,7 @@ export const make = <R, ER>(
               self.cachedContext = context
             })
         ),
-        { ...defaultRunOptions, scheduler: fiber.currentScheduler }
+        { ...defaultRunOptions, scheduler: fiber.cache.scheduler }
       )
     }
     return Effect.flatten(Fiber.await(buildFiber))

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -172,7 +172,7 @@ export class MixedScheduler implements Scheduler {
    * @since 2.0.0
    */
   shouldYield(fiber: Fiber.Fiber<unknown, unknown>) {
-    return fiber.currentOpCount >= fiber.maxOpsBeforeYield
+    return fiber.currentOpCount >= fiber.cache.maxOpsBeforeYield
   }
 
   /**

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -451,11 +451,17 @@ export const makePrimitive = <
   ) => void | ((value: any, fiber: FiberImpl) => void)
 }): Fn => {
   const Proto = makePrimitiveProto(options as any)
-  return function() {
-    const self = Object.create(Proto)
-    self[args] = options.single === false ? arguments : arguments[0]
-    return self
-  } as Fn
+  function Primitive(this: any, value: any) {
+    this[args] = value
+  }
+  Primitive.prototype = Proto
+  return (options.single === false
+    ? function() {
+      return new (Primitive as any)(arguments)
+    }
+    : function(value: any) {
+      return new (Primitive as any)(value)
+    }) as Fn
 }
 
 /** @internal */
@@ -498,10 +504,12 @@ export const makeExit = <
       return Hash.combine(Hash.string(options.op), Hash.hash(this[args]))
     }
   }
+  function ExitPrimitive(this: any, value: unknown) {
+    this[args] = value
+  }
+  ExitPrimitive.prototype = Proto
   return function(value: unknown) {
-    const self = Object.create(Proto)
-    self[args] = value
-    return self
+    return new (ExitPrimitive as any)(value)
   } as Fn
 }
 

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -380,6 +380,11 @@ export interface Primitive {
   [evaluate](fiber: FiberImpl): Primitive | Yield
 }
 
+interface PrimitiveClass {
+  new(value: any): Primitive
+  prototype: any
+}
+
 function defaultEvaluate(_fiber: FiberImpl): Primitive | Yield {
   return exitDie(`Effect.evaluate: Not implemented`) as any
 }
@@ -451,12 +456,12 @@ export const makePrimitive = <
   ) => void | ((value: any, fiber: FiberImpl) => void)
 }): Fn => {
   const Proto = makePrimitiveProto(options as any)
-  function Primitive(this: any, value: any) {
+  const PrimitiveImpl = function(this: any, value: any) {
     this[args] = value
-  }
-  Primitive.prototype = Proto
+  } as unknown as PrimitiveClass
+  PrimitiveImpl.prototype = Proto
   return function(value: any) {
-    return new (Primitive as any)(value)
+    return new PrimitiveImpl(value)
   } as Fn
 }
 
@@ -500,12 +505,12 @@ export const makeExit = <
       return Hash.combine(Hash.string(options.op), Hash.hash(this[args]))
     }
   }
-  function ExitPrimitive(this: any, value: unknown) {
+  const ExitPrimitive = function(this: any, value: unknown) {
     this[args] = value
-  }
+  } as unknown as PrimitiveClass
   ExitPrimitive.prototype = Proto
   return function(value: unknown) {
-    return new (ExitPrimitive as any)(value)
+    return new ExitPrimitive(value)
   } as Fn
 }
 

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -536,8 +536,8 @@ export const exitFailCause: <E>(cause: Cause.Cause<E>) => Exit.Exit<never, E> = 
   [evaluate](fiber) {
     let cause = this[args]
     let annotated = false
-    if (fiber.currentStackFrame) {
-      cause = causeAnnotate(cause, { mapUnsafe: new Map([[StackTraceKey.key, fiber.currentStackFrame]]) } as any)
+    if (fiber.cache.stackFrame) {
+      cause = causeAnnotate(cause, { mapUnsafe: new Map([[StackTraceKey.key, fiber.cache.stackFrame]]) } as any)
       annotated = true
     }
     let cont = fiber.getCont(contE)

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -418,20 +418,18 @@ export const makePrimitiveProto = <Op extends string>(options: {
 
 /** @internal */
 export const makePrimitive = <
-  Fn extends (...args: Array<any>) => any,
-  Single extends boolean = true
+  Fn extends (...args: Array<any>) => any
 >(options: {
   readonly op: string
-  readonly single?: Single
   readonly [evaluate]?: (
     this: Primitive & {
-      readonly [args]: Single extends true ? Parameters<Fn>[0] : Parameters<Fn>
+      readonly [args]: Parameters<Fn>[0]
     },
     fiber: FiberImpl
   ) => Primitive | Effect.Effect<any, any, any> | Yield
   readonly [contA]?: (
     this: Primitive & {
-      readonly [args]: Single extends true ? Parameters<Fn>[0] : Parameters<Fn>
+      readonly [args]: Parameters<Fn>[0]
     },
     value: any,
     fiber: FiberImpl,
@@ -439,7 +437,7 @@ export const makePrimitive = <
   ) => Primitive | Effect.Effect<any, any, any> | Yield
   readonly [contE]?: (
     this: Primitive & {
-      readonly [args]: Single extends true ? Parameters<Fn>[0] : Parameters<Fn>
+      readonly [args]: Parameters<Fn>[0]
     },
     cause: Cause.Cause<any>,
     fiber: FiberImpl,
@@ -447,7 +445,7 @@ export const makePrimitive = <
   ) => Primitive | Effect.Effect<any, any, any> | Yield
   readonly [contAll]?: (
     this: Primitive & {
-      readonly [args]: Single extends true ? Parameters<Fn>[0] : Parameters<Fn>
+      readonly [args]: Parameters<Fn>[0]
     },
     fiber: FiberImpl
   ) => void | ((value: any, fiber: FiberImpl) => void)
@@ -457,13 +455,9 @@ export const makePrimitive = <
     this[args] = value
   }
   Primitive.prototype = Proto
-  return (options.single === false
-    ? function() {
-      return new (Primitive as any)(arguments)
-    }
-    : function(value: any) {
-      return new (Primitive as any)(value)
-    }) as Fn
+  return function(value: any) {
+    return new (Primitive as any)(value)
+  } as Fn
 }
 
 /** @internal */

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -393,12 +393,14 @@ export const makePrimitiveProto = <Op extends string>(options: {
   readonly [contA]?: (
     this: Primitive,
     value: any,
-    fiber: FiberImpl
+    fiber: FiberImpl,
+    exit?: Exit.Exit<any, any>
   ) => Primitive | Effect.Effect<any, any, any> | Yield
   readonly [contE]?: (
     this: Primitive,
     cause: Cause.Cause<any>,
-    fiber: FiberImpl
+    fiber: FiberImpl,
+    exit?: Exit.Exit<any, any>
   ) => Primitive | Effect.Effect<any, any, any> | Yield
   readonly [contAll]?: (
     this: Primitive,

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -520,6 +520,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     this._yielded = undefined
     this._running = false
     this._deferredInterrupt = false
+    this._parent = undefined
     this.runtimeMetrics?.recordFiberStart(this.context)
   }
 
@@ -536,6 +537,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   _yielded: Exit.Exit<any, any> | (() => void) | undefined
   _running: boolean
   _deferredInterrupt: boolean
+  _parent: FiberImpl<any, any> | undefined
 
   // set in setContext
   context!: Context.Context<never>
@@ -638,6 +640,10 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
 
     this._exit = exit
     this.runtimeMetrics?.recordFiberEnd(this.context, this._exit)
+    if (this._parent) {
+      this._parent._children?.delete(this)
+      this._parent = undefined
+    }
     for (let i = 0; i < this._observers.length; i++) {
       this._observers[i](exit)
     }
@@ -1453,11 +1459,24 @@ export const as: {
   <A, E, R, B>(
     self: Effect.Effect<A, E, R>,
     value: B
-  ): Effect.Effect<B, E, R> => {
-    const b = succeed(value)
-    return flatMap(self, (_) => b)
-  }
+  ): Effect.Effect<B, E, R> => new (AsImpl as any)(self, succeed(value))
 )
+
+const AsProto = makePrimitiveProto({
+  op: "As",
+  [evaluate](this: any, fiber: FiberImpl): Primitive {
+    fiber._stack.push(this)
+    return this[args]
+  },
+  [contA](this: any, _value, _fiber) {
+    return this.exit
+  }
+})
+function AsImpl(this: any, self: any, exit: any) {
+  this[args] = self
+  this.exit = exit
+}
+AsImpl.prototype = AsProto
 
 /** @internal */
 export const asSome = <A, E, R>(
@@ -1526,7 +1545,7 @@ export const tap: {
 /** @internal */
 export const asVoid = <A, E, R>(
   self: Effect.Effect<A, E, R>
-): Effect.Effect<void, E, R> => flatMap(self, (_) => exitVoid)
+): Effect.Effect<void, E, R> => new (AsImpl as any)(self, exitVoid)
 
 /** @internal */
 export const sandbox = <A, E, R>(
@@ -1830,8 +1849,24 @@ export const map: {
   <A, E, R, B>(
     self: Effect.Effect<A, E, R>,
     f: (a: A) => B
-  ): Effect.Effect<B, E, R> => flatMap(self, (a) => succeed(internalCall(() => f(a))))
+  ): Effect.Effect<B, E, R> => new (MapImpl as any)(self, f)
 )
+
+const MapProto = makePrimitiveProto({
+  op: "Map",
+  [evaluate](this: any, fiber: FiberImpl): Primitive {
+    fiber._stack.push(this)
+    return this[args]
+  },
+  [contA](this: any, value, _fiber) {
+    return succeed(internalCall(() => this.f(value)))
+  }
+})
+function MapImpl(this: any, self: any, f: any) {
+  this[args] = self
+  this.f = f
+}
+MapImpl.prototype = MapProto
 
 /** @internal */
 export const mapEager: {
@@ -5361,7 +5396,7 @@ export const forkUnsafe = <FA, FE, A, E, R>(
   }
   if (!daemon && !child._exit) {
     parentRuntime.children().add(child)
-    child.addObserver(() => parentRuntime._children!.delete(child))
+    child._parent = parentRuntime
   }
   return child
 }

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -18,7 +18,6 @@ import * as Iterable from "../Iterable.ts"
 import type * as _Latch from "../Latch.ts"
 import type * as Logger from "../Logger.ts"
 import type * as LogLevel from "../LogLevel.ts"
-import type * as Metric from "../Metric.ts"
 import * as Option from "../Option.ts"
 import * as Order from "../Order.ts"
 import { pipeArguments } from "../Pipeable.ts"
@@ -521,7 +520,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     this._running = false
     this._deferredInterrupt = false
     this._parent = undefined
-    this.runtimeMetrics?.recordFiberStart(this.context)
+    this.cache.runtimeMetrics?.recordFiberStart(this.context)
   }
 
   readonly [FiberTypeId]: Fiber.Fiber.Variance<A, E>
@@ -541,39 +540,11 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
 
   // set in setContext
   context!: Context.Context<never>
-  _ctxCache!: FiberContextCache
-
-  get currentScheduler(): Scheduler.Scheduler {
-    return this._ctxCache.scheduler
-  }
-  get currentTracerContext(): Tracer.Tracer["context"] {
-    return this._ctxCache.tracerContext
-  }
-  get currentSpan(): Tracer.AnySpan | undefined {
-    return this._ctxCache.span
-  }
-  get currentLogLevel(): LogLevel.LogLevel {
-    return this._ctxCache.logLevel
-  }
-  get minimumLogLevel(): LogLevel.LogLevel {
-    return this._ctxCache.minimumLogLevel
-  }
-  get currentStackFrame(): StackFrame | undefined {
-    return this._ctxCache.stackFrame
-  }
-  get runtimeMetrics(): Metric.FiberRuntimeMetricsService | undefined {
-    return this._ctxCache.runtimeMetrics
-  }
-  get maxOpsBeforeYield(): number {
-    return this._ctxCache.maxOpsBeforeYield
-  }
-  get currentPreventYield(): boolean {
-    return this._ctxCache.preventYield
-  }
+  cache!: Fiber.Fiber.Cache
 
   _dispatcher: Scheduler.SchedulerDispatcher | undefined = undefined
   get currentDispatcher(): Scheduler.SchedulerDispatcher {
-    return this._dispatcher ??= this.currentScheduler.makeDispatcher()
+    return this._dispatcher ??= this.cache.scheduler.makeDispatcher()
   }
 
   getRef<X>(ref: Context.Reference<X>): X {
@@ -602,8 +573,8 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
       return
     }
     let cause = causeInterrupt(fiberId)
-    if (this.currentStackFrame) {
-      cause = causeAnnotate(cause, Context.make(CauseStackTrace, this.currentStackFrame))
+    if (this.cache.stackFrame) {
+      cause = causeAnnotate(cause, Context.make(CauseStackTrace, this.cache.stackFrame))
     }
     if (annotations) {
       cause = causeAnnotate(cause, annotations)
@@ -643,7 +614,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     }
 
     this._exit = exit
-    this.runtimeMetrics?.recordFiberEnd(this.context, this._exit)
+    this.cache.runtimeMetrics?.recordFiberEnd(this.context, this._exit)
     if (this._parent) {
       this._parent._children?.delete(this)
       this._parent = undefined
@@ -676,15 +647,15 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
         this.currentOpCount++
         if (
           !yielding &&
-          !this.currentPreventYield &&
-          this.currentScheduler.shouldYield(this as any)
+          !this.cache.preventYield &&
+          this.cache.scheduler.shouldYield(this as any)
         ) {
           yielding = true
           const prev = current
           current = flatMap(yieldNow, () => prev as any) as any
         }
-        current = this.currentTracerContext
-          ? this.currentTracerContext(current as any, this)
+        current = this.cache.tracerContext
+          ? this.cache.tracerContext(current as any, this)
           : (current as any)[evaluate](this)
         if (current === Yield) {
           const yielded = this._yielded!
@@ -749,30 +720,19 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     // the derived cache object is computed once per root and shared by all
     // fibers running with that root (forked fibers reuse the parent's).
     const root: any = (context as any).cacheRoot
-    const cache: FiberContextCache = root._fiberCache ??= makeFiberContextCache(context)
-    if (this._ctxCache !== undefined && this._ctxCache.scheduler !== cache.scheduler) {
+    const cache: Fiber.Fiber.Cache = root._fiberCache ??= makeFiberContextCache(context)
+    if (this.cache !== undefined && this.cache.scheduler !== cache.scheduler) {
       this._dispatcher = undefined
     }
-    this._ctxCache = cache
+    this.cache = cache
   }
   get currentSpanLocal(): Tracer.Span | undefined {
-    return this.currentSpan?._tag === "Span" ? this.currentSpan : undefined
+    const span = this.cache.span
+    return span?._tag === "Span" ? span : undefined
   }
 }
 
-interface FiberContextCache {
-  readonly scheduler: Scheduler.Scheduler
-  readonly tracerContext: Tracer.Tracer["context"]
-  readonly span: Tracer.AnySpan | undefined
-  readonly logLevel: LogLevel.LogLevel
-  readonly minimumLogLevel: LogLevel.LogLevel
-  readonly stackFrame: StackFrame | undefined
-  readonly runtimeMetrics: Metric.FiberRuntimeMetricsService | undefined
-  readonly maxOpsBeforeYield: number
-  readonly preventYield: boolean
-}
-
-const makeFiberContextCache = (context: Context.Context<never>): FiberContextCache => {
+const makeFiberContextCache = (context: Context.Context<never>): Fiber.Fiber.Cache => {
   // The string-keyed lookups keep the Tracer key values (and the native
   // tracer behind Tracer.Tracer's default) out of every bundle
   const currentTracer = Context.getOrUndefinedUnsafe<Tracer.Tracer>(context, Tracer.TracerKey)
@@ -805,9 +765,9 @@ const fiberMiddleware = {
 }
 
 const fiberStackAnnotations = (fiber: Fiber.Fiber<any, any>) => {
-  if (!fiber.currentStackFrame) return undefined
+  if (!fiber.cache.stackFrame) return undefined
   const annotations = new Map<string, unknown>()
-  annotations.set(InterruptorStackTrace.key, fiber.currentStackFrame)
+  annotations.set(InterruptorStackTrace.key, fiber.cache.stackFrame)
   return Context.makeUnsafe(annotations)
 }
 
@@ -1165,7 +1125,7 @@ const callbackOptions: <A, E = never, R = never>(
   const Proto = makePrimitiveProto({
     op: "Async",
     [evaluate](this: any, fiber) {
-      const register = internalCall(() => this.register.bind(fiber.currentScheduler))
+      const register = internalCall(() => this.register.bind(fiber.cache.scheduler))
       let resumed = false
       let yielded: boolean | Primitive = false
       const controller = this.withSignal ? new AbortController() : undefined
@@ -1471,12 +1431,14 @@ export const as: {
   ): Effect.Effect<B, E, R> => new (AsImpl as any)(self, succeed(value))
 )
 
+const evaluateCont = function(this: any, fiber: FiberImpl): Primitive {
+  fiber._stack.push(this)
+  return this[args]
+}
+
 const AsProto = makePrimitiveProto({
   op: "As",
-  [evaluate](this: any, fiber: FiberImpl): Primitive {
-    fiber._stack.push(this)
-    return this[args]
-  },
+  [evaluate]: evaluateCont,
   [contA](this: any, _value, _fiber) {
     return this.exit
   }
@@ -1528,10 +1490,7 @@ export const andThen: {
 
 const AndThenProto = makePrimitiveProto({
   op: "AndThen",
-  [evaluate](this: any, fiber: FiberImpl): Primitive {
-    fiber._stack.push(this)
-    return this[args]
-  },
+  [evaluate]: evaluateCont,
   [contA](this: any, value, _fiber) {
     const f = this.f
     return internalCall(() => f(value))
@@ -1545,10 +1504,7 @@ AndThenImpl.prototype = AndThenProto
 
 const AndThenEffectProto = makePrimitiveProto({
   op: "AndThenEffect",
-  [evaluate](this: any, fiber: FiberImpl): Primitive {
-    fiber._stack.push(this)
-    return this[args]
-  },
+  [evaluate]: evaluateCont,
   [contA](this: any, _value, _fiber) {
     return this.f
   }
@@ -1586,10 +1542,7 @@ export const tap: {
 
 const TapProto = makePrimitiveProto({
   op: "Tap",
-  [evaluate](this: any, fiber: FiberImpl): Primitive {
-    fiber._stack.push(this)
-    return this[args]
-  },
+  [evaluate]: evaluateCont,
   [contA](this: any, value, _fiber) {
     const f = this.f
     return new (AsImpl as any)(internalCall(() => f(value)), exitSucceed(value))
@@ -1603,10 +1556,7 @@ TapImpl.prototype = TapProto
 
 const TapEffectProto = makePrimitiveProto({
   op: "TapEffect",
-  [evaluate](this: any, fiber: FiberImpl): Primitive {
-    fiber._stack.push(this)
-    return this[args]
-  },
+  [evaluate]: evaluateCont,
   [contA](this: any, value, _fiber) {
     return new (AsImpl as any)(this.f, exitSucceed(value))
   }
@@ -1831,10 +1781,7 @@ export const flatMap: {
 )
 const OnSuccessProto = makePrimitiveProto({
   op: "OnSuccess",
-  [evaluate](this: any, fiber: FiberImpl): Primitive {
-    fiber._stack.push(this)
-    return this[args]
-  }
+  [evaluate]: evaluateCont
 })
 function OnSuccessImpl(this: any, self: any, f: any) {
   this[args] = self
@@ -1928,10 +1875,7 @@ export const map: {
 
 const MapProto = makePrimitiveProto({
   op: "Map",
-  [evaluate](this: any, fiber: FiberImpl): Primitive {
-    fiber._stack.push(this)
-    return this[args]
-  },
+  [evaluate]: evaluateCont,
   [contA](this: any, value, _fiber) {
     return succeed(internalCall(() => this.f(value)))
   }
@@ -2660,10 +2604,7 @@ export const catchCause: {
 )
 const OnFailureProto = makePrimitiveProto({
   op: "OnFailure",
-  [evaluate](this: any, fiber: FiberImpl): Primitive {
-    fiber._stack.push(this as any)
-    return this[args]
-  }
+  [evaluate]: evaluateCont
 })
 function OnFailureImpl(this: any, self: any, f: any) {
   this[args] = self
@@ -3628,10 +3569,7 @@ export const matchCauseEffect: {
 )
 const OnSuccessAndFailureProto = makePrimitiveProto({
   op: "OnSuccessAndFailure",
-  [evaluate](this: any, fiber: FiberImpl): Primitive {
-    fiber._stack.push(this)
-    return this[args]
-  }
+  [evaluate]: evaluateCont
 })
 function OnSuccessAndFailureImpl(this: any, self: any, onSuccess: any, onFailure: any) {
   this[args] = self
@@ -5925,7 +5863,7 @@ export const makeSpanUnsafe = <XA, XE>(
     ? Option.some(options.parent)
     : options?.root
     ? Option.none<Tracer.AnySpan>()
-    : filterDisablePropagation(fiber.currentSpan)
+    : filterDisablePropagation(fiber.cache.span)
 
   let span: Tracer.Span
 
@@ -6573,8 +6511,8 @@ export const logWithLevel = (level?: LogLevel.Severity) =>
     cause = causeEmpty
   }
   return withFiber((fiber) => {
-    const logLevel = level ?? fiber.currentLogLevel
-    if (isLogLevelGreaterThan(fiber.minimumLogLevel, logLevel)) {
+    const logLevel = level ?? fiber.cache.logLevel
+    if (isLogLevelGreaterThan(fiber.cache.minimumLogLevel, logLevel)) {
       return void_
     }
     const clock = fiber.getRef(ClockRef)
@@ -6826,7 +6764,7 @@ export const defaultLogger = loggerMake<unknown, void>(({ cause, date, fiber, lo
 export const tracerLogger = loggerMake<unknown, void>(({ cause, fiber, logLevel, message }) => {
   const clock = fiber.getRef(ClockRef)
   const annotations = fiber.getRef(CurrentLogAnnotations)
-  const span = fiber.currentSpan
+  const span = fiber.cache.span
   if (span === undefined || span._tag === "ExternalSpan") return
   const attributes: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(annotations)) {

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -1673,12 +1673,8 @@ export const flatMap: {
   <A, E, R, B, E2, R2>(
     self: Effect.Effect<A, E, R>,
     f: (a: A) => Effect.Effect<B, E2, R2>
-  ): Effect.Effect<B, E | E2, R | R2> => {
-    const onSuccess = Object.create(OnSuccessProto)
-    onSuccess[args] = self
-    onSuccess[contA] = f.length !== 1 ? (a: A) => f(a) : f
-    return onSuccess
-  }
+  ): Effect.Effect<B, E | E2, R | R2> =>
+    new (OnSuccessImpl as any)(self, f.length !== 1 ? (a: A) => f(a) : f)
 )
 const OnSuccessProto = makePrimitiveProto({
   op: "OnSuccess",
@@ -1687,6 +1683,11 @@ const OnSuccessProto = makePrimitiveProto({
     return this[args]
   }
 })
+function OnSuccessImpl(this: any, self: any, f: any) {
+  this[args] = self
+  this[contA] = f
+}
+OnSuccessImpl.prototype = OnSuccessProto
 
 /** @internal */
 export const matchCauseEffectEager: {
@@ -2485,12 +2486,8 @@ export const catchCause: {
   <A, E, R, B, E2, R2>(
     self: Effect.Effect<A, E, R>,
     f: (cause: NoInfer<Cause.Cause<E>>) => Effect.Effect<B, E2, R2>
-  ): Effect.Effect<A | B, E2, R | R2> => {
-    const onFailure = Object.create(OnFailureProto)
-    onFailure[args] = self
-    onFailure[contE] = f.length !== 1 ? (cause: Cause.Cause<E>) => f(cause) : f
-    return onFailure
-  }
+  ): Effect.Effect<A | B, E2, R | R2> =>
+    new (OnFailureImpl as any)(self, f.length !== 1 ? (cause: Cause.Cause<E>) => f(cause) : f)
 )
 const OnFailureProto = makePrimitiveProto({
   op: "OnFailure",
@@ -2499,6 +2496,11 @@ const OnFailureProto = makePrimitiveProto({
     return this[args]
   }
 })
+function OnFailureImpl(this: any, self: any, f: any) {
+  this[args] = self
+  this[contE] = f
+}
+OnFailureImpl.prototype = OnFailureProto
 
 /** @internal */
 export const catchCauseIf: {
@@ -3446,15 +3448,14 @@ export const matchCauseEffect: {
       readonly onFailure: (cause: Cause.Cause<E>) => Effect.Effect<A2, E2, R2>
       readonly onSuccess: (a: A) => Effect.Effect<A3, E3, R3>
     }
-  ): Effect.Effect<A2 | A3, E2 | E3, R2 | R3 | R> => {
-    const primitive = Object.create(OnSuccessAndFailureProto)
-    primitive[args] = self
-    primitive[contA] = options.onSuccess.length !== 1 ? (a: A) => options.onSuccess(a) : options.onSuccess
-    primitive[contE] = options.onFailure.length !== 1
-      ? (cause: Cause.Cause<E>) => options.onFailure(cause)
-      : options.onFailure
-    return primitive
-  }
+  ): Effect.Effect<A2 | A3, E2 | E3, R2 | R3 | R> =>
+    new (OnSuccessAndFailureImpl as any)(
+      self,
+      options.onSuccess.length !== 1 ? (a: A) => options.onSuccess(a) : options.onSuccess,
+      options.onFailure.length !== 1
+        ? (cause: Cause.Cause<E>) => options.onFailure(cause)
+        : options.onFailure
+    )
 )
 const OnSuccessAndFailureProto = makePrimitiveProto({
   op: "OnSuccessAndFailure",
@@ -3463,6 +3464,12 @@ const OnSuccessAndFailureProto = makePrimitiveProto({
     return this[args]
   }
 })
+function OnSuccessAndFailureImpl(this: any, self: any, onSuccess: any, onFailure: any) {
+  this[args] = self
+  this[contA] = onSuccess
+  this[contE] = onFailure
+}
+OnSuccessAndFailureImpl.prototype = OnSuccessAndFailureProto
 
 /** @internal */
 export const matchCause: {

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -1106,14 +1106,14 @@ const callbackOptions: <A, E = never, R = never>(
     signal?: AbortSignal
   ) => void | Effect.Effect<void, never, R>,
   withSignal: boolean
-) => Effect.Effect<A, E, R> = makePrimitive({
-  op: "Async",
-  single: false,
-  [evaluate](fiber) {
-    const register = internalCall(() => this[args][0].bind(fiber.currentScheduler))
-    let resumed = false
-    let yielded: boolean | Primitive = false
-    const controller = this[args][1] ? new AbortController() : undefined
+) => Effect.Effect<A, E, R> = (function() {
+  const Proto = makePrimitiveProto({
+    op: "Async",
+    [evaluate](this: any, fiber) {
+      const register = internalCall(() => this.register.bind(fiber.currentScheduler))
+      let resumed = false
+      let yielded: boolean | Primitive = false
+      const controller = this.withSignal ? new AbortController() : undefined
     const onCancel = register((effect) => {
       if (resumed) return
       resumed = true
@@ -1131,16 +1131,25 @@ const callbackOptions: <A, E = never, R = never>(
     if (controller === undefined && onCancel === undefined) {
       return Yield
     }
-    fiber._stack.push(
-      asyncFinalizer(() => {
-        resumed = true
-        controller?.abort()
-        return onCancel ?? exitVoid
-      })
-    )
-    return Yield
+      fiber._stack.push(
+        asyncFinalizer(() => {
+          resumed = true
+          controller?.abort()
+          return onCancel ?? exitVoid
+        })
+      )
+      return Yield
+    }
+  })
+  function AsyncImpl(this: any, register: any, withSignal: boolean) {
+    this.register = register
+    this.withSignal = withSignal
   }
-})
+  AsyncImpl.prototype = Proto
+  return function(register: any, withSignal: boolean) {
+    return new (AsyncImpl as any)(register, withSignal)
+  } as any
+})()
 
 const asyncFinalizer: (
   onInterrupt: () => Effect.Effect<void, any, any>
@@ -1356,27 +1365,36 @@ const fromIteratorEagerUnsafe = (
 const fromIteratorUnsafe: (
   iterator: Iterator<Effect.Effect<any, any, any>>,
   initial?: undefined
-) => Effect.Effect<any, any, any> = makePrimitive({
-  op: "Iterator",
-  single: false,
-  [contA](value, fiber) {
-    const iter = this[args][0]
-    while (true) {
-      const state = iter.next(value)
-      if (state.done) return succeed(state.value)
-      if (!effectIsExit(state.value)) {
-        fiber._stack.push(this)
-        return state.value
-      } else if (state.value._tag === "Failure") {
-        return state.value
+) => Effect.Effect<any, any, any> = (function() {
+  const Proto = makePrimitiveProto({
+    op: "Iterator",
+    [contA](this: any, value, fiber) {
+      const iter = this.iterator
+      while (true) {
+        const state = iter.next(value)
+        if (state.done) return succeed(state.value)
+        if (!effectIsExit(state.value)) {
+          fiber._stack.push(this)
+          return state.value
+        } else if (state.value._tag === "Failure") {
+          return state.value
+        }
+        value = state.value.value
       }
-      value = state.value.value
+    },
+    [evaluate](this: any, fiber: FiberImpl) {
+      return this[contA](this.initial, fiber)
     }
-  },
-  [evaluate](this: any, fiber: FiberImpl) {
-    return this[contA](this[args][1], fiber)
+  })
+  function IteratorImpl(this: any, iterator: any, initial: any) {
+    this.iterator = iterator
+    this.initial = initial
   }
-})
+  IteratorImpl.prototype = Proto
+  return function(iterator: any, initial?: undefined) {
+    return new (IteratorImpl as any)(iterator, initial)
+  } as any
+})()
 
 // ----------------------------------------------------------------------------
 // mapping & sequencing
@@ -4016,30 +4034,40 @@ export const onExitPrimitive: <A, E, R, XE = never, XR = never>(
   self: Effect.Effect<A, E, R>,
   f: (exit: Exit.Exit<A, E>) => Effect.Effect<void, XE, XR> | undefined,
   interruptible?: boolean
-) => Effect.Effect<A, E | XE, R | XR> = makePrimitive({
-  op: "OnExit",
-  single: false,
-  [evaluate](fiber: FiberImpl) {
-    fiber._stack.push(this)
-    return this[args][0]
-  },
-  [contAll](fiber) {
-    if (fiber.interruptible && this[args][2] !== true) {
-      fiber._stack.push(setInterruptibleTrue)
-      fiber.interruptible = false
+) => Effect.Effect<A, E | XE, R | XR> = (function() {
+  const Proto = makePrimitiveProto({
+    op: "OnExit",
+    [evaluate](this: any, fiber: FiberImpl) {
+      fiber._stack.push(this)
+      return this.effect
+    },
+    [contAll](this: any, fiber) {
+      if (fiber.interruptible && this.interruptible !== true) {
+        fiber._stack.push(setInterruptibleTrue)
+        fiber.interruptible = false
+      }
+    },
+    [contA](this: any, value, _, exit) {
+      exit ??= exitSucceed(value)
+      const eff = this.onExit(exit)
+      return eff ? flatMap(eff, (_) => exit) : exit
+    },
+    [contE](this: any, cause, _, exit) {
+      exit ??= exitFailCause(cause)
+      const eff = this.onExit(exit)
+      return eff ? flatMap(combineFinalizerCause(exit, eff), (_) => exit) : exit
     }
-  },
-  [contA](value, _, exit) {
-    exit ??= exitSucceed(value)
-    const eff = this[args][1](exit)
-    return eff ? flatMap(eff, (_) => exit) : exit
-  },
-  [contE](cause, _, exit) {
-    exit ??= exitFailCause(cause)
-    const eff = this[args][1](exit)
-    return eff ? flatMap(combineFinalizerCause(exit, eff), (_) => exit) : exit
+  })
+  function OnExitImpl(this: any, effect: any, onExit: any, interruptible: any) {
+    this.effect = effect
+    this.onExit = onExit
+    this.interruptible = interruptible
   }
-})
+  OnExitImpl.prototype = Proto
+  return function(effect: any, onExit: any, interruptible?: boolean) {
+    return new (OnExitImpl as any)(effect, onExit, interruptible)
+  } as any
+})()
 
 /** @internal */
 export const onExit: {

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -539,15 +539,35 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
 
   // set in setContext
   context!: Context.Context<never>
-  currentScheduler!: Scheduler.Scheduler
-  currentTracerContext: Tracer.Tracer["context"]
-  currentSpan: Tracer.AnySpan | undefined
-  currentLogLevel!: LogLevel.LogLevel
-  minimumLogLevel!: LogLevel.LogLevel
-  currentStackFrame: StackFrame | undefined
-  runtimeMetrics: Metric.FiberRuntimeMetricsService | undefined
-  maxOpsBeforeYield!: number
-  currentPreventYield!: boolean
+  _ctxCache!: FiberContextCache
+
+  get currentScheduler(): Scheduler.Scheduler {
+    return this._ctxCache.scheduler
+  }
+  get currentTracerContext(): Tracer.Tracer["context"] {
+    return this._ctxCache.tracerContext
+  }
+  get currentSpan(): Tracer.AnySpan | undefined {
+    return this._ctxCache.span
+  }
+  get currentLogLevel(): LogLevel.LogLevel {
+    return this._ctxCache.logLevel
+  }
+  get minimumLogLevel(): LogLevel.LogLevel {
+    return this._ctxCache.minimumLogLevel
+  }
+  get currentStackFrame(): StackFrame | undefined {
+    return this._ctxCache.stackFrame
+  }
+  get runtimeMetrics(): Metric.FiberRuntimeMetricsService | undefined {
+    return this._ctxCache.runtimeMetrics
+  }
+  get maxOpsBeforeYield(): number {
+    return this._ctxCache.maxOpsBeforeYield
+  }
+  get currentPreventYield(): boolean {
+    return this._ctxCache.preventYield
+  }
 
   _dispatcher: Scheduler.SchedulerDispatcher | undefined = undefined
   get currentDispatcher(): Scheduler.SchedulerDispatcher {
@@ -712,25 +732,47 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     // Every key cached below opts in to Context caching, so contexts related
     // only by non-caching adds cannot have changed any of them
     if (previous !== undefined && Context.hasSameCache(previous, context)) return
-    const scheduler = this.getRef(Scheduler.Scheduler)
-    if (scheduler !== this.currentScheduler) {
-      this.currentScheduler = scheduler
+    // Contexts sharing a cacheRoot resolve every cached key identically, so
+    // the derived cache object is computed once per root and shared by all
+    // fibers running with that root (forked fibers reuse the parent's).
+    const root: any = (context as any).cacheRoot
+    const cache: FiberContextCache = root._fiberCache ??= makeFiberContextCache(context)
+    if (this._ctxCache !== undefined && this._ctxCache.scheduler !== cache.scheduler) {
       this._dispatcher = undefined
     }
-    // The string-keyed lookups keep the Tracer key values (and the native
-    // tracer behind Tracer.Tracer's default) out of every bundle
-    this.currentSpan = Context.getOrUndefinedUnsafe(context, Tracer.ParentSpanKey)
-    this.currentLogLevel = this.getRef(CurrentLogLevel)
-    this.minimumLogLevel = this.getRef(MinimumLogLevel)
-    this.currentStackFrame = this.getRef(CurrentStackFrame)
-    this.maxOpsBeforeYield = this.getRef(Scheduler.MaxOpsBeforeYield)
-    this.currentPreventYield = this.getRef(Scheduler.PreventSchedulerYield)
-    this.runtimeMetrics = Context.getOrUndefinedUnsafe(context, InternalMetric.FiberRuntimeMetricsKey)
-    const currentTracer = Context.getOrUndefinedUnsafe<Tracer.Tracer>(context, Tracer.TracerKey)
-    this.currentTracerContext = currentTracer ? currentTracer["context"] : undefined
+    this._ctxCache = cache
   }
   get currentSpanLocal(): Tracer.Span | undefined {
     return this.currentSpan?._tag === "Span" ? this.currentSpan : undefined
+  }
+}
+
+interface FiberContextCache {
+  readonly scheduler: Scheduler.Scheduler
+  readonly tracerContext: Tracer.Tracer["context"]
+  readonly span: Tracer.AnySpan | undefined
+  readonly logLevel: LogLevel.LogLevel
+  readonly minimumLogLevel: LogLevel.LogLevel
+  readonly stackFrame: StackFrame | undefined
+  readonly runtimeMetrics: Metric.FiberRuntimeMetricsService | undefined
+  readonly maxOpsBeforeYield: number
+  readonly preventYield: boolean
+}
+
+const makeFiberContextCache = (context: Context.Context<never>): FiberContextCache => {
+  // The string-keyed lookups keep the Tracer key values (and the native
+  // tracer behind Tracer.Tracer's default) out of every bundle
+  const currentTracer = Context.getOrUndefinedUnsafe<Tracer.Tracer>(context, Tracer.TracerKey)
+  return {
+    scheduler: Context.get(context, Scheduler.Scheduler),
+    tracerContext: currentTracer ? currentTracer["context"] : undefined,
+    span: Context.getOrUndefinedUnsafe(context, Tracer.ParentSpanKey),
+    logLevel: Context.get(context, CurrentLogLevel),
+    minimumLogLevel: Context.get(context, MinimumLogLevel),
+    stackFrame: Context.get(context, CurrentStackFrame),
+    runtimeMetrics: Context.getOrUndefinedUnsafe(context, InternalMetric.FiberRuntimeMetricsKey),
+    maxOpsBeforeYield: Context.get(context, Scheduler.MaxOpsBeforeYield),
+    preventYield: Context.get(context, Scheduler.PreventSchedulerYield)
   }
 }
 

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -1162,23 +1162,23 @@ const callbackOptions: <A, E = never, R = never>(
       let resumed = false
       let yielded: boolean | Primitive = false
       const controller = this.withSignal ? new AbortController() : undefined
-    const onCancel = register((effect) => {
-      if (resumed) return
-      resumed = true
-      if (yielded) {
-        fiber.evaluate(effect as any)
-      } else {
-        yielded = effect as any
+      const onCancel = register((effect: Effect.Effect<any, any, any>) => {
+        if (resumed) return
+        resumed = true
+        if (yielded) {
+          fiber.evaluate(effect as any)
+        } else {
+          yielded = effect as any
+        }
+      }, controller?.signal)
+      if (yielded !== false) return yielded
+      yielded = true
+      fiber._yielded = () => {
+        resumed = true
       }
-    }, controller?.signal)
-    if (yielded !== false) return yielded
-    yielded = true
-    fiber._yielded = () => {
-      resumed = true
-    }
-    if (controller === undefined && onCancel === undefined) {
-      return Yield
-    }
+      if (controller === undefined && onCancel === undefined) {
+        return Yield
+      }
       fiber._stack.push(
         asyncFinalizer(() => {
           resumed = true
@@ -1752,8 +1752,7 @@ export const flatMap: {
   <A, E, R, B, E2, R2>(
     self: Effect.Effect<A, E, R>,
     f: (a: A) => Effect.Effect<B, E2, R2>
-  ): Effect.Effect<B, E | E2, R | R2> =>
-    new (OnSuccessImpl as any)(self, f.length !== 1 ? (a: A) => f(a) : f)
+  ): Effect.Effect<B, E | E2, R | R2> => new (OnSuccessImpl as any)(self, f.length !== 1 ? (a: A) => f(a) : f)
 )
 const OnSuccessProto = makePrimitiveProto({
   op: "OnSuccess",

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -513,7 +513,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     this.currentOpCount = 0
     this.interruptible = interruptible
     this._stack = []
-    this._observers = []
+    this._observers = undefined
     this._exit = undefined
     this._children = undefined
     this._interruptedCause = undefined
@@ -530,7 +530,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   interruptible: boolean
   currentOpCount: number
   readonly _stack: Array<Primitive>
-  readonly _observers: Array<(exit: Exit.Exit<A, E>) => void>
+  _observers: Array<(exit: Exit.Exit<A, E>) => void> | undefined
   _exit: Exit.Exit<A, E> | undefined
   _children: Set<FiberImpl<any, any>> | undefined
   _interruptedCause: Cause.Cause<never> | undefined
@@ -584,9 +584,13 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
       cb(this._exit)
       return constVoid
     }
-    this._observers.push(cb)
+    if (this._observers === undefined) {
+      this._observers = [cb]
+    } else {
+      this._observers.push(cb)
+    }
     return () => {
-      if (this._exit) return
+      if (this._exit || this._observers === undefined) return
       const index = this._observers.indexOf(cb)
       if (index >= 0) {
         this._observers.splice(index, 1)
@@ -644,10 +648,13 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
       this._parent._children?.delete(this)
       this._parent = undefined
     }
-    for (let i = 0; i < this._observers.length; i++) {
-      this._observers[i](exit)
+    if (this._observers !== undefined) {
+      const observers = this._observers
+      this._observers = undefined
+      for (let i = 0; i < observers.length; i++) {
+        observers[i](exit)
+      }
     }
-    this._observers.length = 0
     this._stack.length = 0
     this._children = undefined
     this.context = Context.empty()
@@ -1245,12 +1252,14 @@ export const gen = <
   [Eff] extends [never] ? never
     : [Eff] extends [Effect.Effect<infer _A, infer _E, infer R>] ? R
     : never
-> =>
-  suspend(() =>
-    fromIteratorUnsafe(
-      args.length === 1 ? args[0]() : (args[1].call(args[0].self) as any)
-    )
-  )
+> => {
+  if (args.length === 1) {
+    const body = args[0]
+    return suspend(() => fromIteratorUnsafe(body()))
+  }
+  const [options, body] = args
+  return suspend(() => fromIteratorUnsafe(body.call(options.self) as any))
+}
 
 /** @internal */
 export const fnUntraced: Effect.fn.Untraced = (
@@ -1514,8 +1523,41 @@ export const andThen: {
     self: Effect.Effect<A, E, R>,
     f: ((a: A) => Effect.Effect<B, E2, R2>) | Effect.Effect<B, E2, R2>
   ): Effect.Effect<B, E | E2, R | R2> =>
-    flatMap(self, (a) => isEffect(f) ? f : internalCall(() => (f as (a: A) => Effect.Effect<B, E2, R2>)(a)))
+    isEffect(f) ? new (AndThenEffectImpl as any)(self, f) : new (AndThenImpl as any)(self, f)
 )
+
+const AndThenProto = makePrimitiveProto({
+  op: "AndThen",
+  [evaluate](this: any, fiber: FiberImpl): Primitive {
+    fiber._stack.push(this)
+    return this[args]
+  },
+  [contA](this: any, value, _fiber) {
+    const f = this.f
+    return internalCall(() => f(value))
+  }
+})
+function AndThenImpl(this: any, self: any, f: any) {
+  this[args] = self
+  this.f = f
+}
+AndThenImpl.prototype = AndThenProto
+
+const AndThenEffectProto = makePrimitiveProto({
+  op: "AndThenEffect",
+  [evaluate](this: any, fiber: FiberImpl): Primitive {
+    fiber._stack.push(this)
+    return this[args]
+  },
+  [contA](this: any, _value, _fiber) {
+    return this.f
+  }
+})
+function AndThenEffectImpl(this: any, self: any, f: any) {
+  this[args] = self
+  this.f = f
+}
+AndThenEffectImpl.prototype = AndThenEffectProto
 
 /** @internal */
 export const tap: {
@@ -1539,8 +1581,41 @@ export const tap: {
     self: Effect.Effect<A, E, R>,
     f: ((a: A) => Effect.Effect<B, E2, R2>) | Effect.Effect<B, E2, R2>
   ): Effect.Effect<A, E | E2, R | R2> =>
-    flatMap(self, (a) => as(isEffect(f) ? f : internalCall(() => (f as (a: A) => Effect.Effect<B, E2, R2>)(a)), a))
+    isEffect(f) ? new (TapEffectImpl as any)(self, f) : new (TapImpl as any)(self, f)
 )
+
+const TapProto = makePrimitiveProto({
+  op: "Tap",
+  [evaluate](this: any, fiber: FiberImpl): Primitive {
+    fiber._stack.push(this)
+    return this[args]
+  },
+  [contA](this: any, value, _fiber) {
+    const f = this.f
+    return new (AsImpl as any)(internalCall(() => f(value)), exitSucceed(value))
+  }
+})
+function TapImpl(this: any, self: any, f: any) {
+  this[args] = self
+  this.f = f
+}
+TapImpl.prototype = TapProto
+
+const TapEffectProto = makePrimitiveProto({
+  op: "TapEffect",
+  [evaluate](this: any, fiber: FiberImpl): Primitive {
+    fiber._stack.push(this)
+    return this[args]
+  },
+  [contA](this: any, value, _fiber) {
+    return new (AsImpl as any)(this.f, exitSucceed(value))
+  }
+})
+function TapEffectImpl(this: any, self: any, f: any) {
+  this[args] = self
+  this.f = f
+}
+TapEffectImpl.prototype = TapEffectProto
 
 /** @internal */
 export const asVoid = <A, E, R>(

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -1156,13 +1156,13 @@ const callbackOptions: <A, E = never, R = never>(
       return Yield
     }
   })
-  function AsyncImpl(this: any, register: any, withSignal: boolean) {
+  const AsyncImpl = function(this: any, register: any, withSignal: boolean) {
     this.register = register
     this.withSignal = withSignal
-  }
+  } as unknown as PrimitiveCtor<[register: any, withSignal: boolean]>
   AsyncImpl.prototype = Proto
   return function(register: any, withSignal: boolean) {
-    return new (AsyncImpl as any)(register, withSignal)
+    return new AsyncImpl(register, withSignal)
   } as any
 })()
 
@@ -1403,13 +1403,13 @@ const fromIteratorUnsafe: (
       return this[contA](this.initial, fiber)
     }
   })
-  function IteratorImpl(this: any, iterator: any, initial: any) {
+  const IteratorImpl = function(this: any, iterator: any, initial: any) {
     this.iterator = iterator
     this.initial = initial
-  }
+  } as unknown as PrimitiveCtor<[iterator: any, initial: any]>
   IteratorImpl.prototype = Proto
   return function(iterator: any, initial?: undefined) {
-    return new (IteratorImpl as any)(iterator, initial)
+    return new IteratorImpl(iterator, initial)
   } as any
 })()
 
@@ -1428,7 +1428,7 @@ export const as: {
   <A, E, R, B>(
     self: Effect.Effect<A, E, R>,
     value: B
-  ): Effect.Effect<B, E, R> => new (AsImpl as any)(self, succeed(value))
+  ): Effect.Effect<B, E, R> => new ContImpl(self, returnPayload, succeed(value))
 )
 
 const evaluateCont = function(this: any, fiber: FiberImpl): Primitive {
@@ -1436,18 +1436,62 @@ const evaluateCont = function(this: any, fiber: FiberImpl): Primitive {
   return this[args]
 }
 
-const AsProto = makePrimitiveProto({
-  op: "As",
-  [evaluate]: evaluateCont,
-  [contA](this: any, _value, _fiber) {
-    return this.exit
-  }
-})
-function AsImpl(this: any, self: any, exit: any) {
-  this[args] = self
-  this.exit = exit
+interface PrimitiveCtor<Args extends Array<any>> {
+  new(...args: Args): Primitive & Effect.Effect<any, any, any>
+  prototype: any
 }
-AsImpl.prototype = AsProto
+
+const OnSuccessProto = makePrimitiveProto({
+  op: "OnSuccess",
+  [evaluate]: evaluateCont
+})
+
+const OnSuccessImpl = function(this: any, self: Effect.Effect<any, any, any>, f: any) {
+  this[args] = self
+  this[contA] = f
+} as unknown as PrimitiveCtor<[self: Effect.Effect<any, any, any>, f: any]>
+OnSuccessImpl.prototype = OnSuccessProto
+
+// A success continuation with an extra payload slot. The stored continuation
+// receives the primitive as `this` and reads `this.payload`, so combinators
+// like map / as / tap / andThen can share module-level continuation functions
+// instead of allocating a closure per call.
+const ContImpl = function(
+  this: any,
+  self: Effect.Effect<any, any, any>,
+  cont: (this: { readonly payload: any }, value: any, fiber: FiberImpl) => unknown,
+  payload: unknown
+) {
+  this[args] = self
+  this[contA] = cont
+  this.payload = payload
+} as unknown as PrimitiveCtor<
+  [
+    self: Effect.Effect<any, any, any>,
+    cont: (this: { readonly payload: any }, value: any, fiber: FiberImpl) => unknown,
+    payload: unknown
+  ]
+>
+ContImpl.prototype = OnSuccessProto
+
+const returnPayload = function(this: { readonly payload: any }) {
+  return this.payload
+}
+const mapCont = function(this: { readonly payload: any }, value: any) {
+  const f = this.payload
+  return succeed(internalCall(() => f(value)))
+}
+const andThenCont = function(this: { readonly payload: any }, value: any) {
+  const f = this.payload
+  return internalCall(() => f(value))
+}
+const tapCont = function(this: { readonly payload: any }, value: any) {
+  const f = this.payload
+  return new ContImpl(internalCall(() => f(value)), returnPayload, exitSucceed(value))
+}
+const tapEffectCont = function(this: { readonly payload: any }, value: any) {
+  return new ContImpl(this.payload, returnPayload, exitSucceed(value))
+}
 
 /** @internal */
 export const asSome = <A, E, R>(
@@ -1484,36 +1528,8 @@ export const andThen: {
   <A, E, R, B, E2, R2>(
     self: Effect.Effect<A, E, R>,
     f: ((a: A) => Effect.Effect<B, E2, R2>) | Effect.Effect<B, E2, R2>
-  ): Effect.Effect<B, E | E2, R | R2> =>
-    isEffect(f) ? new (AndThenEffectImpl as any)(self, f) : new (AndThenImpl as any)(self, f)
+  ): Effect.Effect<B, E | E2, R | R2> => new ContImpl(self, isEffect(f) ? returnPayload : andThenCont, f)
 )
-
-const AndThenProto = makePrimitiveProto({
-  op: "AndThen",
-  [evaluate]: evaluateCont,
-  [contA](this: any, value, _fiber) {
-    const f = this.f
-    return internalCall(() => f(value))
-  }
-})
-function AndThenImpl(this: any, self: any, f: any) {
-  this[args] = self
-  this.f = f
-}
-AndThenImpl.prototype = AndThenProto
-
-const AndThenEffectProto = makePrimitiveProto({
-  op: "AndThenEffect",
-  [evaluate]: evaluateCont,
-  [contA](this: any, _value, _fiber) {
-    return this.f
-  }
-})
-function AndThenEffectImpl(this: any, self: any, f: any) {
-  this[args] = self
-  this.f = f
-}
-AndThenEffectImpl.prototype = AndThenEffectProto
 
 /** @internal */
 export const tap: {
@@ -1536,41 +1552,13 @@ export const tap: {
   <A, E, R, B, E2, R2>(
     self: Effect.Effect<A, E, R>,
     f: ((a: A) => Effect.Effect<B, E2, R2>) | Effect.Effect<B, E2, R2>
-  ): Effect.Effect<A, E | E2, R | R2> =>
-    isEffect(f) ? new (TapEffectImpl as any)(self, f) : new (TapImpl as any)(self, f)
+  ): Effect.Effect<A, E | E2, R | R2> => new ContImpl(self, isEffect(f) ? tapEffectCont : tapCont, f)
 )
-
-const TapProto = makePrimitiveProto({
-  op: "Tap",
-  [evaluate]: evaluateCont,
-  [contA](this: any, value, _fiber) {
-    const f = this.f
-    return new (AsImpl as any)(internalCall(() => f(value)), exitSucceed(value))
-  }
-})
-function TapImpl(this: any, self: any, f: any) {
-  this[args] = self
-  this.f = f
-}
-TapImpl.prototype = TapProto
-
-const TapEffectProto = makePrimitiveProto({
-  op: "TapEffect",
-  [evaluate]: evaluateCont,
-  [contA](this: any, value, _fiber) {
-    return new (AsImpl as any)(this.f, exitSucceed(value))
-  }
-})
-function TapEffectImpl(this: any, self: any, f: any) {
-  this[args] = self
-  this.f = f
-}
-TapEffectImpl.prototype = TapEffectProto
 
 /** @internal */
 export const asVoid = <A, E, R>(
   self: Effect.Effect<A, E, R>
-): Effect.Effect<void, E, R> => new (AsImpl as any)(self, exitVoid)
+): Effect.Effect<void, E, R> => new ContImpl(self, returnPayload, exitVoid)
 
 /** @internal */
 export const sandbox = <A, E, R>(
@@ -1777,17 +1765,8 @@ export const flatMap: {
   <A, E, R, B, E2, R2>(
     self: Effect.Effect<A, E, R>,
     f: (a: A) => Effect.Effect<B, E2, R2>
-  ): Effect.Effect<B, E | E2, R | R2> => new (OnSuccessImpl as any)(self, f.length !== 1 ? (a: A) => f(a) : f)
+  ): Effect.Effect<B, E | E2, R | R2> => new OnSuccessImpl(self, f.length !== 1 ? (a: A) => f(a) : f)
 )
-const OnSuccessProto = makePrimitiveProto({
-  op: "OnSuccess",
-  [evaluate]: evaluateCont
-})
-function OnSuccessImpl(this: any, self: any, f: any) {
-  this[args] = self
-  this[contA] = f
-}
-OnSuccessImpl.prototype = OnSuccessProto
 
 /** @internal */
 export const matchCauseEffectEager: {
@@ -1870,21 +1849,8 @@ export const map: {
   <A, E, R, B>(
     self: Effect.Effect<A, E, R>,
     f: (a: A) => B
-  ): Effect.Effect<B, E, R> => new (MapImpl as any)(self, f)
+  ): Effect.Effect<B, E, R> => new ContImpl(self, mapCont, f)
 )
-
-const MapProto = makePrimitiveProto({
-  op: "Map",
-  [evaluate]: evaluateCont,
-  [contA](this: any, value, _fiber) {
-    return succeed(internalCall(() => this.f(value)))
-  }
-})
-function MapImpl(this: any, self: any, f: any) {
-  this[args] = self
-  this.f = f
-}
-MapImpl.prototype = MapProto
 
 /** @internal */
 export const mapEager: {
@@ -2600,16 +2566,16 @@ export const catchCause: {
     self: Effect.Effect<A, E, R>,
     f: (cause: NoInfer<Cause.Cause<E>>) => Effect.Effect<B, E2, R2>
   ): Effect.Effect<A | B, E2, R | R2> =>
-    new (OnFailureImpl as any)(self, f.length !== 1 ? (cause: Cause.Cause<E>) => f(cause) : f)
+    new OnFailureImpl(self, f.length !== 1 ? (cause: Cause.Cause<E>) => f(cause) : f)
 )
 const OnFailureProto = makePrimitiveProto({
   op: "OnFailure",
   [evaluate]: evaluateCont
 })
-function OnFailureImpl(this: any, self: any, f: any) {
+const OnFailureImpl = function(this: any, self: Effect.Effect<any, any, any>, f: any) {
   this[args] = self
   this[contE] = f
-}
+} as unknown as PrimitiveCtor<[self: Effect.Effect<any, any, any>, f: any]>
 OnFailureImpl.prototype = OnFailureProto
 
 /** @internal */
@@ -3559,7 +3525,7 @@ export const matchCauseEffect: {
       readonly onSuccess: (a: A) => Effect.Effect<A3, E3, R3>
     }
   ): Effect.Effect<A2 | A3, E2 | E3, R2 | R3 | R> =>
-    new (OnSuccessAndFailureImpl as any)(
+    new OnSuccessAndFailureImpl(
       self,
       options.onSuccess.length !== 1 ? (a: A) => options.onSuccess(a) : options.onSuccess,
       options.onFailure.length !== 1
@@ -3571,11 +3537,16 @@ const OnSuccessAndFailureProto = makePrimitiveProto({
   op: "OnSuccessAndFailure",
   [evaluate]: evaluateCont
 })
-function OnSuccessAndFailureImpl(this: any, self: any, onSuccess: any, onFailure: any) {
+const OnSuccessAndFailureImpl = function(
+  this: any,
+  self: Effect.Effect<any, any, any>,
+  onSuccess: any,
+  onFailure: any
+) {
   this[args] = self
   this[contA] = onSuccess
   this[contE] = onFailure
-}
+} as unknown as PrimitiveCtor<[self: Effect.Effect<any, any, any>, onSuccess: any, onFailure: any]>
 OnSuccessAndFailureImpl.prototype = OnSuccessAndFailureProto
 
 /** @internal */
@@ -4147,14 +4118,14 @@ export const onExitPrimitive: <A, E, R, XE = never, XR = never>(
       return eff ? flatMap(combineFinalizerCause(exit, eff), (_) => exit) : exit
     }
   })
-  function OnExitImpl(this: any, effect: any, onExit: any, interruptible: any) {
+  const OnExitImpl = function(this: any, effect: any, onExit: any, interruptible: any) {
     this.effect = effect
     this.onExit = onExit
     this.interruptible = interruptible
-  }
+  } as unknown as PrimitiveCtor<[effect: any, onExit: any, interruptible: any]>
   OnExitImpl.prototype = Proto
   return function(effect: any, onExit: any, interruptible?: boolean) {
-    return new (OnExitImpl as any)(effect, onExit, interruptible)
+    return new OnExitImpl(effect, onExit, interruptible)
   } as any
 })()
 

--- a/packages/effect/src/internal/option.ts
+++ b/packages/effect/src/internal/option.ts
@@ -91,10 +91,10 @@ export const isSome = <A>(fa: Option.Option<A>): fa is Option.Some<A> => fa._tag
 export const none: Option.Option<never> = Object.create(NoneProto)
 
 /** @internal */
-function SomeImpl(this: any, value: unknown) {
+const SomeImpl = function(this: any, value: unknown) {
   this.value = value
-}
+} as unknown as { new<A>(value: A): Option.Option<A>; prototype: any }
 SomeImpl.prototype = SomeProto
 
 /** @internal */
-export const some = <A>(value: A): Option.Option<A> => new (SomeImpl as any)(value)
+export const some = <A>(value: A): Option.Option<A> => new SomeImpl(value)

--- a/packages/effect/src/internal/option.ts
+++ b/packages/effect/src/internal/option.ts
@@ -91,8 +91,10 @@ export const isSome = <A>(fa: Option.Option<A>): fa is Option.Some<A> => fa._tag
 export const none: Option.Option<never> = Object.create(NoneProto)
 
 /** @internal */
-export const some = <A>(value: A): Option.Option<A> => {
-  const a = Object.create(SomeProto)
-  a.value = value
-  return a
+function SomeImpl(this: any, value: unknown) {
+  this.value = value
 }
+SomeImpl.prototype = SomeProto
+
+/** @internal */
+export const some = <A>(value: A): Option.Option<A> => new (SomeImpl as any)(value)

--- a/packages/effect/src/internal/request.ts
+++ b/packages/effect/src/internal/request.ts
@@ -62,7 +62,7 @@ export const requestUnsafe = <A extends Request.Any>(
 ): () => void => {
   const entry = addEntry(options.resolver, self, options.onExit, {
     context: options.context,
-    currentScheduler: Context.get(options.context, Scheduler)
+    cache: { scheduler: Context.get(options.context, Scheduler) }
   })
   return () => removeEntryUnsafe(options.resolver, entry)
 }
@@ -87,7 +87,7 @@ const addEntry = <A extends Request.Any>(
   resume: (exit: Exit<any, any>) => void,
   fiber: {
     readonly context: Context.Context<never>
-    readonly currentScheduler: Scheduler
+    readonly cache: { readonly scheduler: Scheduler }
     readonly id?: number
   }
 ) => {
@@ -162,7 +162,7 @@ const addEntry = <A extends Request.Any>(
       batch = newBatch
     }
     batchMap.set(key, batch)
-    batch.fiber = effect.runForkWith(fiber.context)(batch.delayEffect, { scheduler: fiber.currentScheduler })
+    batch.fiber = effect.runForkWith(fiber.context)(batch.delayEffect, { scheduler: fiber.cache.scheduler })
   }
 
   batch.entrySet.add(entry)
@@ -170,7 +170,7 @@ const addEntry = <A extends Request.Any>(
   if (batch.resolver.collectWhile(batch.entries)) return entry
 
   batch.fiber!.interruptUnsafe(fiber.id)
-  batch.fiber = effect.runForkWith(fiber.context)(runBatch(batch), { scheduler: fiber.currentScheduler })
+  batch.fiber = effect.runForkWith(fiber.context)(runBatch(batch), { scheduler: fiber.cache.scheduler })
   return entry
 }
 

--- a/packages/effect/src/internal/result.ts
+++ b/packages/effect/src/internal/result.ts
@@ -80,18 +80,22 @@ export const isSuccess = <A, E>(result: Result.Result<A, E>): result is Result.S
   result._tag === "Success"
 
 /** @internal */
-export const fail = <E>(failure: E): Result.Result<never, E> => {
-  const a = Object.create(FailureProto)
-  a.failure = failure
-  return a
+function FailureImpl(this: any, failure: unknown) {
+  this.failure = failure
 }
+FailureImpl.prototype = FailureProto
 
 /** @internal */
-export const succeed = <A>(success: A): Result.Result<A> => {
-  const a = Object.create(SuccessProto)
-  a.success = success
-  return a
+export const fail = <E>(failure: E): Result.Result<never, E> => new (FailureImpl as any)(failure)
+
+/** @internal */
+function SuccessImpl(this: any, success: unknown) {
+  this.success = success
 }
+SuccessImpl.prototype = SuccessProto
+
+/** @internal */
+export const succeed = <A>(success: A): Result.Result<A> => new (SuccessImpl as any)(success)
 
 /** @internal */
 export const getFailure = <A, E>(self: Result.Result<A, E>): Option<E> =>

--- a/packages/effect/src/internal/result.ts
+++ b/packages/effect/src/internal/result.ts
@@ -80,22 +80,22 @@ export const isSuccess = <A, E>(result: Result.Result<A, E>): result is Result.S
   result._tag === "Success"
 
 /** @internal */
-function FailureImpl(this: any, failure: unknown) {
+const FailureImpl = function(this: any, failure: unknown) {
   this.failure = failure
-}
+} as unknown as { new<E>(failure: E): Result.Result<never, E>; prototype: any }
 FailureImpl.prototype = FailureProto
 
 /** @internal */
-export const fail = <E>(failure: E): Result.Result<never, E> => new (FailureImpl as any)(failure)
+export const fail = <E>(failure: E): Result.Result<never, E> => new FailureImpl(failure)
 
 /** @internal */
-function SuccessImpl(this: any, success: unknown) {
+const SuccessImpl = function(this: any, success: unknown) {
   this.success = success
-}
+} as unknown as { new<A>(success: A): Result.Result<A>; prototype: any }
 SuccessImpl.prototype = SuccessProto
 
 /** @internal */
-export const succeed = <A>(success: A): Result.Result<A> => new (SuccessImpl as any)(success)
+export const succeed = <A>(success: A): Result.Result<A> => new SuccessImpl(success)
 
 /** @internal */
 export const getFailure = <A, E>(self: Result.Result<A, E>): Option<E> =>

--- a/packages/effect/src/unstable/observability/OtlpLogger.ts
+++ b/packages/effect/src/unstable/observability/OtlpLogger.ts
@@ -227,9 +227,9 @@ const makeLogRecord = (options: Logger.Options<unknown>, opts: {
     droppedAttributesCount: 0
   }
 
-  if (options.fiber.currentSpan) {
-    logRecord.traceId = options.fiber.currentSpan.traceId
-    logRecord.spanId = options.fiber.currentSpan.spanId
+  if (options.fiber.cache.span) {
+    logRecord.traceId = options.fiber.cache.span.traceId
+    logRecord.spanId = options.fiber.cache.span.spanId
   }
 
   return logRecord

--- a/packages/effect/src/unstable/observability/OtlpTracer.ts
+++ b/packages/effect/src/unstable/observability/OtlpTracer.ts
@@ -108,10 +108,10 @@ export const make: (
     },
     context: options.context ?
       function(primitive, fiber) {
-        if (fiber.currentSpan === undefined) {
+        if (fiber.cache.span === undefined) {
           return primitive["~effect/Effect/evaluate"](fiber)
         }
-        return options.context!(primitive, fiber.currentSpan)
+        return options.context!(primitive, fiber.cache.span)
       } :
       undefined
   })

--- a/packages/opentelemetry/src/OtelTracer.ts
+++ b/packages/opentelemetry/src/OtelTracer.ts
@@ -104,7 +104,7 @@ export const make: Effect.Effect<Tracer.Tracer, never, OtelTracer> = Effect.map(
         )
       },
       context(primitive, fiber) {
-        const currentSpan = fiber.currentSpan
+        const currentSpan = fiber.cache.span
 
         if (currentSpan === undefined) {
           return primitive["~effect/Effect/evaluate"](fiber)


### PR DESCRIPTION
## Summary

- size Effect, Exit, Option, and Result primitives with constructor functions instead of `Object.create`
- replace retained `arguments` objects in Async, Iterator, and OnExit with named fields
- add dedicated Map and As primitives to remove closure and intermediate primitive allocations
- share context-derived fiber state per `cacheRoot`
- replace the supervised-child observer closure with a parent back-reference

The five commits are independent to make review and selective landing easier. This is an early-review PR, with the runtime and context changes called out for extra scrutiny.

## Measurements

On Node 26.7 without pointer compression:

- Effect and data primitives retain 30-65% less memory (`Effect.map`: 208 B to 72 B; exits and `Option.some` / `Result.succeed`: 56 B to 32 B)
- live supervised fibers retain 48% less memory (731 B to 379 B)
- fork/join is 15-25% faster in interleaved A/B runs
- the sequential flatMap run loop is unchanged within measurement noise

## Follow-ups worth considering

- make `_observers` lazy now that supervised children no longer allocate one; most fibers never gain an observer
- apply dedicated primitives selectively to hot combinators that still create closures through `flatMap`, especially `tap`, `mapError`, and `andThen`
- remove the now-unused `single: false` branch from `makePrimitive`
- keep the memory benchmark as a repeatable runtime benchmark so future representation changes can be checked against both retained bytes and CPU

The context cache and parent cleanup are the highest-risk parts of this PR. In particular, review should verify cache invalidation for every `fiberCached` context key and cleanup ordering for interrupted supervised children.

## Verification

- full Effect suite: 9,104 tests passed on the originating branch
- targeted Effect, Fiber, Context, Option, and Result tests: 368 passed locally
- `pnpm check`
- `pnpm lint`

Closes EFF-1036
