### PR TITLE
fix(schema): render finite numbers as Schema.Finite and reference generated aliases directly

### DIFF
--- a/.changeset/direct-lanterns.md
+++ b/.changeset/direct-lanterns.md
@@ -1,0 +1,5 @@
+---
+"@effect/openapi-generator": patch
+---
+
+Reference generated type aliases directly instead of `typeof X.Type` in client signatures.

--- a/.changeset/gentle-orbits.md
+++ b/.changeset/gentle-orbits.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Render JSON-derived finite numbers as `Schema.Finite` in `SchemaRepresentation.toCodeDocument`.

--- a/packages/effect/src/internal/schema/toCodeDocument.ts
+++ b/packages/effect/src/internal/schema/toCodeDocument.ts
@@ -1,6 +1,7 @@
 import * as Arr from "../../Array.ts"
 import { format, formatPropertyKey } from "../../Formatter.ts"
 import type * as Schema from "../../Schema.ts"
+import * as SchemaAST from "../../SchemaAST.ts"
 import type * as SchemaRepresentation from "../../SchemaRepresentation.ts"
 import { errorWithPath } from "../errors.ts"
 import * as InternalRecord from "../record.ts"
@@ -10,6 +11,14 @@ type Path = ReadonlyArray<string | number>
 type CheckRepresentationAnnotation = SchemaRepresentation.CheckRepresentationAnnotation<
   SchemaRepresentation.Representation
 >
+
+function hasFiniteNumberCheck(checks: ReadonlyArray<SchemaRepresentation.Check>): boolean {
+  return checks.some((check) =>
+    check._tag === "Filter"
+      ? check.representation?.id === "effect/schema/isFinite" || check.representation?.id === "effect/schema/isInt"
+      : hasFiniteNumberCheck(check.checks)
+  )
+}
 
 /** @internal */
 export function makeCode(runtime: string, Type: string): SchemaRepresentation.Code {
@@ -330,6 +339,10 @@ export function toCodeDocument(
     return rendered === undefined ? "" : `.${method}(${rendered})`
   }
 
+  function defaultFiniteAnnotations(): string {
+    return runtimeAnnotate(SchemaAST.isFinite().annotations)
+  }
+
   function compileCheck(
     check: SchemaRepresentation.Check,
     path: Path
@@ -365,6 +378,18 @@ export function toCodeDocument(
     for (let index = 0; index < representation.checks.length; index++) {
       const check = representation.checks[index]
       const brands = checkBrands(check)
+      // `Schema.Finite` already carries this check, so an unannotated or
+      // default-annotated `isFinite` filter adds nothing to the rendered code.
+      if (
+        base.runtime === "Schema.Finite" &&
+        check._tag === "Filter" &&
+        check.representation?.id === "effect/schema/isFinite" &&
+        !check.aborted &&
+        brands.length === 0
+      ) {
+        const rendered = runtimeAnnotate(check.annotations)
+        if (rendered === "" || rendered === defaultFiniteAnnotations()) continue
+      }
       runtime += `.check(${compileCheck(check, [...path, "checks", index])})${runtimeBrands(brands)}`
       if (includeTypeBrands) Type += typeBrands(brands)
     }
@@ -434,7 +459,7 @@ export function toCodeDocument(
       case "String":
         return makeCode("Schema.String", "string")
       case "Number":
-        return makeCode("Schema.Number", "number")
+        return makeCode(hasFiniteNumberCheck(representation.checks) ? "Schema.Finite" : "Schema.Number", "number")
       case "Boolean":
         return makeCode("Schema.Boolean", "boolean")
       case "BigInt":

--- a/packages/effect/test/schema/representation/toCodeDocument.test.ts
+++ b/packages/effect/test/schema/representation/toCodeDocument.test.ts
@@ -452,6 +452,42 @@ describe("toCodeDocument", () => {
         }
       )
     })
+
+    it("Number & unannotated isFinite", () => {
+      assertSchema(
+        { schema: Schema.Number.check(Schema.isFinite({ expected: undefined })) },
+        {
+          codes: makeCode("Schema.Finite", "number")
+        }
+      )
+    })
+
+    it("Number & default isFinite", () => {
+      assertSchema(
+        { schema: Schema.Number.check(Schema.isFinite()) },
+        {
+          codes: makeCode("Schema.Finite", "number")
+        }
+      )
+    })
+
+    it("Number & annotated isFinite", () => {
+      assertSchema(
+        { schema: Schema.Number.check(Schema.isFinite({ expected: undefined, description: "finite" })) },
+        {
+          codes: makeCode(`Schema.Finite.check(Schema.isFinite().annotate({ "description": "finite" }))`, "number")
+        }
+      )
+    })
+
+    it("Number & isInt", () => {
+      assertSchema(
+        { schema: Schema.Number.check(Schema.isInt({ expected: undefined })) },
+        {
+          codes: makeCode("Schema.Finite.check(Schema.isInt())", "number")
+        }
+      )
+    })
   })
 
   it("Boolean", () => {
@@ -1850,7 +1886,7 @@ describe("toCodeDocument", () => {
             {
               $ref: "A",
               code: makeCode(
-                `Schema.Struct({ "b": Schema.Number.check(Schema.isFinite()), "a": Schema.String }).annotate({ "identifier": "A" })`,
+                `Schema.Struct({ "b": Schema.Finite, "a": Schema.String }).annotate({ "identifier": "A" })`,
                 `{ readonly "b": number, readonly "a": string }`
               )
             }

--- a/packages/tools/openapi-generator/src/OpenApiTransformer.ts
+++ b/packages/tools/openapi-generator/src/OpenApiTransformer.ts
@@ -149,7 +149,7 @@ ${clientErrorSource(name)}`
       args.push(`options: { ${options.join("; ")} } | undefined`)
     }
 
-    const successTypes = new Set(Array.from(responses.successSchemas.values(), (schema) => `typeof ${schema}.Type`))
+    const successTypes = new Set(responses.successSchemas.values())
     if (responses.binarySuccessStatuses.size > 0) {
       successTypes.add("Uint8Array")
     }
@@ -161,7 +161,7 @@ ${clientErrorSource(name)}`
     if (responses.errorSchemas.size > 0) {
       Utils.spreadElementsInto(
         Array.from(responses.errorSchemas.values()).map(
-          (schema) => `${name}Error<"${schema}", typeof ${schema}.Type>`
+          (schema) => `${name}Error<"${schema}", ${schema}>`
         ),
         errors
       )
@@ -206,8 +206,8 @@ ${clientErrorSource(name)}`
     const methodKey = `readonly "${operation.id}Sse"`
     const parameters = args.join(", ")
     const value = responses.sseSchemaMode === "event"
-      ? `typeof ${responses.sseSchema}.Type`
-      : `{ readonly event: string; readonly id: string | undefined; readonly data: typeof ${responses.sseSchema}.Type }`
+      ? responses.sseSchema
+      : `{ readonly event: string; readonly id: string | undefined; readonly data: ${responses.sseSchema} }`
     const returnType =
       `Stream.Stream<${value}, HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError, typeof ${responses.sseSchema}.DecodingServices>`
     return `${jsdoc}${methodKey}: (${parameters}) => ${returnType}`

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -763,7 +763,7 @@ export const make = (
 
 export interface TestClient {
   readonly httpClient: HttpClient.HttpClient
-  readonly "getUser": <Config extends OperationConfig>(id: string, options: { readonly config?: Config | undefined } | undefined) => Effect.Effect<WithOptionalResponse<typeof GetUser200.Type, Config>, HttpClientError.HttpClientError | SchemaError>
+  readonly "getUser": <Config extends OperationConfig>(id: string, options: { readonly config?: Config | undefined } | undefined) => Effect.Effect<WithOptionalResponse<GetUser200, Config>, HttpClientError.HttpClientError | SchemaError>
 }
 
 export interface TestClientError<Tag extends string, E> {
@@ -895,7 +895,7 @@ export const TestClientError = <Tag extends string, E>(
         },
         [
           `import * as Sse from "effect/unstable/encoding/Sse"`,
-          `readonly "streamEventsSse": () => Stream.Stream<{ readonly event: string; readonly id: string | undefined; readonly data: typeof StreamEvents200Sse.Type }, HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError, typeof StreamEvents200Sse.DecodingServices>`,
+          `readonly "streamEventsSse": () => Stream.Stream<{ readonly event: string; readonly id: string | undefined; readonly data: StreamEvents200Sse }, HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError, typeof StreamEvents200Sse.DecodingServices>`,
           `"streamEventsSse": () => HttpClientRequest.get(\`/events\`).pipe(`,
           `sseRequest(StreamEvents200Sse)`,
           `schema: Schema.ConstraintDecoder<Type, DecodingServices>`
@@ -957,7 +957,7 @@ export const TestClientError = <Tag extends string, E>(
         [
           `"id": Schema.optionalKey(Schema.String), "event": Schema.Literal("message"), "data": Schema.String`,
           `"id": Schema.optionalKey(Schema.String), "event": Schema.Literal("effect/httpapi/stream/failure"), "data": Schema.String`,
-          `readonly "streamEventsSse": () => Stream.Stream<typeof StreamEvents200Sse.Type, HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError, typeof StreamEvents200Sse.DecodingServices>`,
+          `readonly "streamEventsSse": () => Stream.Stream<StreamEvents200Sse, HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError, typeof StreamEvents200Sse.DecodingServices>`,
           `sseEventRequest(StreamEvents200Sse)`,
           `Stream.pipeThroughChannel(Sse.decodeSchema(schema))`
         ]
@@ -1054,7 +1054,7 @@ export const TestClientError = <Tag extends string, E>(
         `TestClientError<"500", undefined>`
       ], [
         `"200": decodeSuccess(DownloadMixedContent200)`,
-        `typeof DownloadMixedContent200.Type | Uint8Array`
+        `DownloadMixedContent200 | Uint8Array`
       ]))
 
     it.effect("routes mixed and non-2xx bodiless success responses", () =>
@@ -1062,7 +1062,7 @@ export const TestClientError = <Tag extends string, E>(
         `"200": decodeSuccess(MixedSuccess200)`,
         `"204": () => Effect.void`,
         `"304": () => Effect.void`,
-        `WithOptionalResponse<typeof MixedSuccess200.Type | void, Config>`
+        `WithOptionalResponse<MixedSuccess200 | void, Config>`
       ]))
   })
 


### PR DESCRIPTION
Closes #7646.

`@effect/openapi-generator` output triggered two `@effect/language-service` diagnostics that the generator can avoid by construction.

## `effect`: `SchemaRepresentation.toCodeDocument`

The JSON Schema importer already attaches `effect/schema/isFinite` (for `type: number`) and `effect/schema/isInt` (for `type: integer`) checks to number nodes. The renderer now emits such nodes from `Schema.Finite` instead of `Schema.Number`, and drops an `isFinite` check when it carries nothing beyond the defaults of `Schema.isFinite()` (a custom-annotated, aborted, or branded check is kept on top of the `Schema.Finite` base). Plain `Schema.Number` without those checks renders unchanged.

Before / after for `{ "type": "number" }` and `{ "type": "integer" }`:

```ts
Schema.Number.check(Schema.isFinite().annotate({ "expected": "a finite number" }))  // before
Schema.Finite                                                                       // after

Schema.Number.check(Schema.isInt().annotate({ "expected": "an integer" }))          // before
Schema.Finite.check(Schema.isInt().annotate({ "expected": "an integer" }))          // after
```

## `@effect/openapi-generator`: client signatures

Operation signatures referenced `typeof X.Type` for success, error, and SSE schemas even though the generator emits `export type X = ...` for the same name in the same file. They now reference `X` directly (`typeof X.Encoded` and `typeof X.DecodingServices` are unchanged, as no alias exists for those).

```ts
// before
Effect.Effect<WithOptionalResponse<typeof GetAddon200.Type, Config>, ...>
// after
Effect.Effect<WithOptionalResponse<GetAddon200, Config>, ...>
```

## Verification

- `pnpm vitest run packages/effect/test/schema/representation packages/tools/openapi-generator/test`: 25 files, 807 tests passed (new cases cover unannotated, default-annotated, custom-annotated `isFinite`, `isInt`, and plain `Number`).
- `pnpm lint`, and `pnpm check` in both packages: clean.
- The minimal spec from the issue now renders `"downloads": Schema.Finite`, `"id": Schema.Finite.check(Schema.isInt()...)` and `WithOptionalResponse<GetAddon200, Config>`, with no `schemaNumber` or `unnecessaryTypeofType` diagnostics.

Two changesets are included (`effect` patch, `@effect/openapi-generator` patch).
