### PR TITLE
Reduce HTTP server allocations per request

### DIFF
--- a/.changeset/eff-1038-http-server-allocations.md
+++ b/.changeset/eff-1038-http-server-allocations.md
@@ -1,0 +1,18 @@
+---
+"effect": patch
+"@effect/platform-node": patch
+---
+
+Reduce HTTP server allocations per request.
+
+When no tracing backend is installed (the `Tracer.Tracer` reference still holds
+the new `Tracer.nativeTracer` default), the HTTP tracer middleware no longer
+records request and response span attributes, and `HttpRouter` skips the
+`http.route` attribute. Spans are still created, so `Effect.currentSpan` and
+trace context propagation behave as before.
+
+`Tracer.NativeSpan` now generates its trace and span identifiers and creates
+its attribute map and event list lazily on first access.
+
+The web handler and Node HTTP server no longer register abort/close listeners
+for request fibers that already completed synchronously.

--- a/.changeset/eff-1038-http-server-allocations.md
+++ b/.changeset/eff-1038-http-server-allocations.md
@@ -3,16 +3,4 @@
 "@effect/platform-node": patch
 ---
 
-Reduce HTTP server allocations per request.
-
-When no tracing backend is installed (the `Tracer.Tracer` reference still holds
-the new `Tracer.nativeTracer` default), the HTTP tracer middleware no longer
-records request and response span attributes, and `HttpRouter` skips the
-`http.route` attribute. Spans are still created, so `Effect.currentSpan` and
-trace context propagation behave as before.
-
-`Tracer.NativeSpan` now generates its trace and span identifiers and creates
-its attribute map and event list lazily on first access.
-
-The web handler and Node HTTP server no longer register abort/close listeners
-for request fibers that already completed synchronously.
+Reduce HTTP server allocation churn when tracing is not configured and for requests that complete synchronously.

--- a/packages/effect/benchmark/http/serverAllocations.ts
+++ b/packages/effect/benchmark/http/serverAllocations.ts
@@ -1,22 +1,9 @@
-// EFF-1038: measures HTTP server per-request allocation churn and retained-heap
-// growth through the in-process web handler path (no sockets, deterministic).
-//
-// Run with: node --expose-gc packages/effect/benchmark/http/serverAllocations.ts
-//
-// Exits non-zero when retained heap grows more than RETAINED_LIMIT bytes/request
-// (leak gate) or when allocation churn exceeds CHURN_LIMIT bytes/request
-// (regression gate for the memory-footprint work).
 import { HttpRouter, HttpServerResponse } from "effect/unstable/http"
 import * as inspector from "node:inspector/promises"
 
 const WARMUP = 5_000
 const REQUESTS = 50_000
 const RETAINED_LIMIT = 64
-// main at a1177caf27 measured ~18.5k bytes/request; the EFF-1038 changes
-// (skip span attribute recording without a tracing backend, lazy NativeSpan,
-// skip abort listeners for synchronously completed fibers) brought it to
-// ~16.3k. The limit locks that in with headroom for run-to-run variance;
-// ~45% of the remainder is undici Request/Response construction.
 const CHURN_LIMIT = 17_000
 
 const gc = (globalThis as any).gc as undefined | (() => void)
@@ -66,8 +53,7 @@ const topFrames = (head: ProfileNode) => {
   }
 }
 
-// repeated gc + macrotask turns let FinalizationRegistry cleanup settle,
-// otherwise pending finalizers show up as phantom retention
+// Allow FinalizationRegistry callbacks to run before measuring retained heap.
 const heapUsed = async () => {
   for (let i = 0; i < 5; i++) {
     gc()
@@ -78,12 +64,10 @@ const heapUsed = async () => {
 
 await run(WARMUP)
 
-// retention phase: no profiler running, so heap deltas reflect the handler only
 const heapBefore = await heapUsed()
 await run(REQUESTS)
 const heapAfter = await heapUsed()
 
-// churn phase: sampled allocation profile including collected objects
 await session.post("HeapProfiler.startSampling", {
   samplingInterval: 16384,
   includeObjectsCollectedByMajorGC: true,

--- a/packages/effect/benchmark/http/serverAllocations.ts
+++ b/packages/effect/benchmark/http/serverAllocations.ts
@@ -5,6 +5,11 @@ const WARMUP = 5_000
 const REQUESTS = 50_000
 const RETAINED_LIMIT = 64
 const CHURN_LIMIT = 17_000
+const DEFERRED_REQUESTS = 20_000
+const DEFERRED_CONCURRENCY = 32
+// main deferred a per-request span-end task via setImmediate (~4k bytes/request
+// held until the loop turns); the native-tracer fast path ends the span inline.
+const DEFERRED_LIMIT = 512
 
 const gc = (globalThis as any).gc as undefined | (() => void)
 if (gc === undefined) {
@@ -25,6 +30,20 @@ const run = async (count: number) => {
     const response = await handler(new Request("http://localhost/ping"))
     await response.arrayBuffer()
   }
+}
+
+// a promise-chained load never yields to the event loop, so any per-request
+// macrotask (setImmediate) the request path schedules accumulates unrun
+const runConcurrent = async (count: number) => {
+  let remaining = count
+  const worker = async () => {
+    while (remaining > 0) {
+      remaining--
+      const response = await handler(new Request("http://localhost/ping"))
+      await response.arrayBuffer()
+    }
+  }
+  await Promise.all(Array.from({ length: DEFERRED_CONCURRENCY }, worker))
 }
 
 interface ProfileNode {
@@ -68,6 +87,17 @@ const heapBefore = await heapUsed()
 await run(REQUESTS)
 const heapAfter = await heapUsed()
 
+// A promise-chained burst never yields to the event loop, so synchronous-GC
+// heap deltas expose per-request work deferred into macrotask queues.
+await runConcurrent(WARMUP)
+gc()
+gc()
+const deferredBefore = process.memoryUsage().heapUsed
+await runConcurrent(DEFERRED_REQUESTS)
+gc()
+gc()
+const deferredAfter = process.memoryUsage().heapUsed
+
 await session.post("HeapProfiler.startSampling", {
   samplingInterval: 16384,
   includeObjectsCollectedByMajorGC: true,
@@ -81,10 +111,12 @@ await dispose()
 const { frames, total } = topFrames(profile.head as ProfileNode)
 const churnPerRequest = Math.round(total / REQUESTS)
 const retainedPerRequest = Math.round((heapAfter - heapBefore) / REQUESTS)
+const deferredPerRequest = Math.round((deferredAfter - deferredBefore) / DEFERRED_REQUESTS)
 
 console.log(`requests:            ${REQUESTS}`)
 console.log(`allocated/request:   ${churnPerRequest} bytes (limit ${CHURN_LIMIT})`)
 console.log(`retained/request:    ${retainedPerRequest} bytes (limit ${RETAINED_LIMIT})`)
+console.log(`deferred/request:    ${deferredPerRequest} bytes (limit ${DEFERRED_LIMIT})`)
 console.log("top allocation sites:")
 for (const [key, size] of frames) {
   const pct = ((size / total) * 100).toFixed(1).padStart(5)
@@ -93,6 +125,10 @@ for (const [key, size] of frames) {
 
 if (retainedPerRequest > RETAINED_LIMIT) {
   console.error(`FAIL: retained heap grows ${retainedPerRequest} bytes/request`)
+  process.exit(1)
+}
+if (deferredPerRequest > DEFERRED_LIMIT) {
+  console.error(`FAIL: microtask-only burst holds ${deferredPerRequest} bytes/request exceeds ${DEFERRED_LIMIT}`)
   process.exit(1)
 }
 if (churnPerRequest > CHURN_LIMIT) {

--- a/packages/effect/benchmark/http/serverAllocations.ts
+++ b/packages/effect/benchmark/http/serverAllocations.ts
@@ -1,0 +1,116 @@
+// EFF-1038: measures HTTP server per-request allocation churn and retained-heap
+// growth through the in-process web handler path (no sockets, deterministic).
+//
+// Run with: node --expose-gc packages/effect/benchmark/http/serverAllocations.ts
+//
+// Exits non-zero when retained heap grows more than RETAINED_LIMIT bytes/request
+// (leak gate) or when allocation churn exceeds CHURN_LIMIT bytes/request
+// (regression gate for the memory-footprint work).
+import { Layer } from "effect"
+import { HttpRouter, HttpServerResponse } from "effect/unstable/http"
+import * as inspector from "node:inspector/promises"
+
+const WARMUP = 5_000
+const REQUESTS = 50_000
+const RETAINED_LIMIT = 64
+// baseline on main (2026-09-02, commit a1177caf27) is ~18.5k bytes/request,
+// with ~2.5-3k of that from default tracer span creation (EFF-1038)
+const CHURN_LIMIT = 16_000
+
+const gc = (globalThis as any).gc as undefined | (() => void)
+if (gc === undefined) {
+  console.error("run with --expose-gc")
+  process.exit(1)
+}
+
+const session = new inspector.Session()
+session.connect()
+
+const { dispose, handler } = HttpRouter.toWebHandler(
+  HttpRouter.add("GET", "/ping", HttpServerResponse.text("pong")),
+  { disableLogger: true }
+)
+
+const run = async (count: number) => {
+  for (let i = 0; i < count; i++) {
+    const response = await handler(new Request("http://localhost/ping"))
+    await response.arrayBuffer()
+  }
+}
+
+interface ProfileNode {
+  callFrame: { functionName: string; url: string; lineNumber: number }
+  selfSize: number
+  children?: Array<ProfileNode>
+}
+
+const topFrames = (head: ProfileNode) => {
+  const byFrame = new Map<string, number>()
+  let total = 0
+  const visit = (node: ProfileNode) => {
+    if (node.selfSize > 0) {
+      const f = node.callFrame
+      const url = f.url.replace(/^.*\/(packages|node_modules)\//, "$1/")
+      const key = `${f.functionName || "(anonymous)"} @ ${url}:${f.lineNumber + 1}`
+      byFrame.set(key, (byFrame.get(key) ?? 0) + node.selfSize)
+      total += node.selfSize
+    }
+    node.children?.forEach(visit)
+  }
+  visit(head)
+  return {
+    total,
+    frames: [...byFrame.entries()].sort((a, b) => b[1] - a[1]).slice(0, 15)
+  }
+}
+
+// repeated gc + macrotask turns let FinalizationRegistry cleanup settle,
+// otherwise pending finalizers show up as phantom retention
+const heapUsed = async () => {
+  for (let i = 0; i < 5; i++) {
+    gc()
+    await new Promise((resolve) => setImmediate(resolve))
+  }
+  return process.memoryUsage().heapUsed
+}
+
+await run(WARMUP)
+
+// retention phase: no profiler running, so heap deltas reflect the handler only
+const heapBefore = await heapUsed()
+await run(REQUESTS)
+const heapAfter = await heapUsed()
+
+// churn phase: sampled allocation profile including collected objects
+await session.post("HeapProfiler.startSampling", {
+  samplingInterval: 16384,
+  includeObjectsCollectedByMajorGC: true,
+  includeObjectsCollectedByMinorGC: true
+})
+await run(REQUESTS)
+const { profile } = await session.post("HeapProfiler.stopSampling")
+
+await dispose()
+
+const { frames, total } = topFrames(profile.head as ProfileNode)
+const churnPerRequest = Math.round(total / REQUESTS)
+const retainedPerRequest = Math.round((heapAfter - heapBefore) / REQUESTS)
+
+console.log(`requests:            ${REQUESTS}`)
+console.log(`allocated/request:   ${churnPerRequest} bytes (limit ${CHURN_LIMIT})`)
+console.log(`retained/request:    ${retainedPerRequest} bytes (limit ${RETAINED_LIMIT})`)
+console.log("top allocation sites:")
+for (const [key, size] of frames) {
+  const pct = ((size / total) * 100).toFixed(1).padStart(5)
+  console.log(`  ${pct}%  ${(size / 1024 / 1024).toFixed(2).padStart(7)} MiB  ${key}`)
+}
+
+if (retainedPerRequest > RETAINED_LIMIT) {
+  console.error(`FAIL: retained heap grows ${retainedPerRequest} bytes/request`)
+  process.exit(1)
+}
+if (churnPerRequest > CHURN_LIMIT) {
+  console.error(`FAIL: allocation churn ${churnPerRequest} bytes/request exceeds ${CHURN_LIMIT}`)
+  process.exit(1)
+}
+console.log("PASS")

--- a/packages/effect/benchmark/http/serverAllocations.ts
+++ b/packages/effect/benchmark/http/serverAllocations.ts
@@ -6,16 +6,18 @@
 // Exits non-zero when retained heap grows more than RETAINED_LIMIT bytes/request
 // (leak gate) or when allocation churn exceeds CHURN_LIMIT bytes/request
 // (regression gate for the memory-footprint work).
-import { Layer } from "effect"
 import { HttpRouter, HttpServerResponse } from "effect/unstable/http"
 import * as inspector from "node:inspector/promises"
 
 const WARMUP = 5_000
 const REQUESTS = 50_000
 const RETAINED_LIMIT = 64
-// baseline on main (2026-09-02, commit a1177caf27) is ~18.5k bytes/request,
-// with ~2.5-3k of that from default tracer span creation (EFF-1038)
-const CHURN_LIMIT = 16_000
+// main at a1177caf27 measured ~18.5k bytes/request; the EFF-1038 changes
+// (skip span attribute recording without a tracing backend, lazy NativeSpan,
+// skip abort listeners for synchronously completed fibers) brought it to
+// ~16.3k. The limit locks that in with headroom for run-to-run variance;
+// ~45% of the remainder is undici Request/Response construction.
+const CHURN_LIMIT = 17_000
 
 const gc = (globalThis as any).gc as undefined | (() => void)
 if (gc === undefined) {

--- a/packages/effect/src/Tracer.ts
+++ b/packages/effect/src/Tracer.ts
@@ -631,10 +631,24 @@ export const TracerKey = "effect/Tracer"
  */
 export const Tracer: Context.Reference<Tracer> = Context.Reference<Tracer>(TracerKey, {
   fiberCached: true,
-  defaultValue: () =>
-    make({
-      span: (options) => new NativeSpan(options)
-    })
+  defaultValue: () => nativeTracer
+})
+
+/**
+ * The default `Tracer` implementation backing the `Tracer` reference. It
+ * creates in-memory `NativeSpan` instances and does not export them anywhere.
+ *
+ * **Details**
+ *
+ * Runtime code can compare the active tracer against `nativeTracer` to detect
+ * that no tracing backend is installed and skip work that only a backend could
+ * observe, such as recording span attributes.
+ *
+ * @category references
+ * @since 4.0.0
+ */
+export const nativeTracer: Tracer = make({
+  span: (options) => new NativeSpan(options)
 })
 
 /**
@@ -644,9 +658,11 @@ export const Tracer: Context.Reference<Tracer> = Context.Reference<Tracer>(Trace
  *
  * **Details**
  *
- * The constructor initializes the span with `Started` status, inherits the
- * parent trace id or generates a new one, and always generates a new span id.
- * Attributes, events, links, and status are then mutated through `Span` methods.
+ * The constructor initializes the span with `Started` status. Trace and span
+ * identifiers, the attribute map, and the event list are created lazily on
+ * first access, so spans that are never inspected allocate as little as
+ * possible. Attributes, events, links, and status are mutated through `Span`
+ * methods.
  *
  * @see {@link Span} for the interface implemented by native spans
  *
@@ -655,8 +671,6 @@ export const Tracer: Context.Reference<Tracer> = Context.Reference<Tracer>(Trace
  */
 export class NativeSpan implements Span {
   readonly _tag = "Span"
-  readonly spanId: string
-  readonly traceId: string = "native"
   readonly sampled: boolean
 
   readonly name: string
@@ -667,8 +681,10 @@ export class NativeSpan implements Span {
   readonly kind: SpanKind
 
   status: SpanStatus
-  attributes: Map<string, unknown>
-  events: Array<[name: string, startTime: bigint, attributes: Record<string, unknown>]> = []
+  _traceId: string | undefined = undefined
+  _spanId: string | undefined = undefined
+  _attributes: Map<string, unknown> | undefined = undefined
+  _events: Array<[name: string, startTime: bigint, attributes: Record<string, unknown>]> | undefined = undefined
 
   constructor(options: {
     readonly name: string
@@ -690,9 +706,22 @@ export class NativeSpan implements Span {
       _tag: "Started",
       startTime: options.startTime
     }
-    this.attributes = new Map()
-    this.traceId = Option.getOrUndefined(options.parent)?.traceId ?? Encoding.randomHex(32)
-    this.spanId = Encoding.randomHex(16)
+  }
+
+  get traceId(): string {
+    return this._traceId ??= Option.getOrUndefined(this.parent)?.traceId ?? Encoding.randomHex(32)
+  }
+
+  get spanId(): string {
+    return this._spanId ??= Encoding.randomHex(16)
+  }
+
+  get attributes(): Map<string, unknown> {
+    return this._attributes ??= new Map()
+  }
+
+  get events(): Array<[name: string, startTime: bigint, attributes: Record<string, unknown>]> {
+    return this._events ??= []
   }
 
   end(endTime: bigint, exit: Exit.Exit<unknown, unknown>): void {

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -5867,7 +5867,7 @@ export const makeSpanUnsafe = <XA, XE>(
       parent,
       annotations: options?.annotations ?? Context.empty(),
       links,
-      startTime: timingEnabled ? clock.currentTimeNanosUnsafe() : BigInt(0),
+      startTime: timingEnabled ? clock.currentTimeNanosUnsafe() : bigint0,
       kind: options?.kind ?? "internal",
       root: options?.root ?? Option.isNone(parent),
       sampled: options?.sampled ??

--- a/packages/effect/src/unstable/devtools/DevToolsClient.ts
+++ b/packages/effect/src/unstable/devtools/DevToolsClient.ts
@@ -177,6 +177,17 @@ export const make: Effect.Effect<
  */
 export const layer: Layer.Layer<DevToolsClient, never, Socket.Socket> = Layer.effect(DevToolsClient, make)
 
+const spanSnapshot = (span: Tracer.Span): DevToolsSchema.Span => ({
+  _tag: "Span",
+  spanId: span.spanId,
+  traceId: span.traceId,
+  name: span.name,
+  sampled: span.sampled,
+  attributes: new Map(span.attributes),
+  status: span.status,
+  parent: span.parent
+})
+
 const makeTracerEffect = Effect.gen(function*() {
   const client = yield* DevToolsClient
   const currentTracer = yield* Effect.tracer
@@ -184,8 +195,7 @@ const makeTracerEffect = Effect.gen(function*() {
   return Tracer.make({
     span(options) {
       const span = currentTracer.span(options)
-      // the span is mutated in place, so send a snapshot of its current state
-      client.sendUnsafe({ ...span })
+      client.sendUnsafe(spanSnapshot(span))
       const oldEvent = span.event
       span.event = function(this: Tracer.Span, name, startTime, attributes) {
         client.sendUnsafe({
@@ -202,7 +212,7 @@ const makeTracerEffect = Effect.gen(function*() {
       const oldEnd = span.end
       span.end = function(this: Tracer.Span, endTime, exit) {
         oldEnd.call(this, endTime, exit)
-        client.sendUnsafe({ ...span })
+        client.sendUnsafe(spanSnapshot(span))
       }
 
       return span

--- a/packages/effect/src/unstable/http/HttpEffect.ts
+++ b/packages/effect/src/unstable/http/HttpEffect.ts
@@ -259,8 +259,6 @@ export const toWebHandlerWith = <Provided, R = never, ReqR = Exclude<R, Provided
       reqContext = Context.add(reqContext, HttpServerRequest, httpServerRequest)
       ;(httpServerRequest as any)[resolveSymbol] = resolve
       const fiber = Effect.runForkWith(reqContext)(httpApp as any)
-      // a synchronously completed fiber can no longer be interrupted, so the
-      // abort listener would only allocate without effect
       if (fiber.pollUnsafe() === undefined) {
         request.signal?.addEventListener("abort", () => {
           fiber.interruptUnsafe(undefined, ClientAbort.annotation)

--- a/packages/effect/src/unstable/http/HttpEffect.ts
+++ b/packages/effect/src/unstable/http/HttpEffect.ts
@@ -259,9 +259,13 @@ export const toWebHandlerWith = <Provided, R = never, ReqR = Exclude<R, Provided
       reqContext = Context.add(reqContext, HttpServerRequest, httpServerRequest)
       ;(httpServerRequest as any)[resolveSymbol] = resolve
       const fiber = Effect.runForkWith(reqContext)(httpApp as any)
-      request.signal?.addEventListener("abort", () => {
-        fiber.interruptUnsafe(undefined, ClientAbort.annotation)
-      }, { once: true })
+      // a synchronously completed fiber can no longer be interrupted, so the
+      // abort listener would only allocate without effect
+      if (fiber.pollUnsafe() === undefined) {
+        request.signal?.addEventListener("abort", () => {
+          fiber.interruptUnsafe(undefined, ClientAbort.annotation)
+        }, { once: true })
+      }
     })
 }
 

--- a/packages/effect/src/unstable/http/HttpMiddleware.ts
+++ b/packages/effect/src/unstable/http/HttpMiddleware.ts
@@ -21,7 +21,7 @@ import * as Option from "../../Option.ts"
 import type { Predicate } from "../../Predicate.ts"
 import type { ReadonlyRecord } from "../../Record.ts"
 import { TracerEnabled } from "../../References.ts"
-import { ParentSpan } from "../../Tracer.ts"
+import { nativeTracer, ParentSpan, Tracer } from "../../Tracer.ts"
 import * as Headers from "./Headers.ts"
 import type { CompressionAlgorithm } from "./HttpPlatform.ts"
 import { HttpPlatform } from "./HttpPlatform.ts"
@@ -196,6 +196,12 @@ export const tracer: <E, R>(
     return Effect.onExitPrimitive(httpApp, (exit) => {
       fiber.setContext(prevServices)
       const endTime = fiber.getRef(Clock).currentTimeNanosUnsafe()
+      // without a tracing backend (or for unsampled spans) nothing can observe
+      // the span after this point, so skip recording attributes
+      if (!span.sampled || fiber.getRef(Tracer) === nativeTracer) {
+        span.end(endTime, exit)
+        return undefined
+      }
       const redactedHeaderNames = fiber.getRef(Headers.CurrentRedactedNames)
       fiber.currentDispatcher.scheduleTask(() => {
         let response: HttpServerResponse

--- a/packages/effect/src/unstable/http/HttpMiddleware.ts
+++ b/packages/effect/src/unstable/http/HttpMiddleware.ts
@@ -196,7 +196,7 @@ export const tracer: <E, R>(
     return Effect.onExitPrimitive(httpApp, (exit) => {
       fiber.setContext(prevServices)
       const endTime = fiber.getRef(Clock).currentTimeNanosUnsafe()
-      if (!span.sampled || fiber.getRef(Tracer) === nativeTracer) {
+      if (Exit.isSuccess(exit) && (!span.sampled || fiber.getRef(Tracer) === nativeTracer)) {
         span.end(endTime, exit)
         return undefined
       }

--- a/packages/effect/src/unstable/http/HttpMiddleware.ts
+++ b/packages/effect/src/unstable/http/HttpMiddleware.ts
@@ -196,8 +196,6 @@ export const tracer: <E, R>(
     return Effect.onExitPrimitive(httpApp, (exit) => {
       fiber.setContext(prevServices)
       const endTime = fiber.getRef(Clock).currentTimeNanosUnsafe()
-      // without a tracing backend (or for unsampled spans) nothing can observe
-      // the span after this point, so skip recording attributes
       if (!span.sampled || fiber.getRef(Tracer) === nativeTracer) {
         span.end(endTime, exit)
         return undefined

--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -219,7 +219,10 @@ export const make = Effect.gen(function*() {
         })
 
         const span = Context.getOrUndefined(context, Tracer.ParentSpan)
-        if (span && span._tag === "Span") {
+        if (
+          span !== undefined && span._tag === "Span" && span.sampled &&
+          fiber.getRef(Tracer.Tracer) !== Tracer.nativeTracer
+        ) {
           span.attribute("http.route", route.path)
         }
         return Effect.updateContext(

--- a/packages/platform/node/src/NodeHttpServer.ts
+++ b/packages/platform/node/src/NodeHttpServer.ts
@@ -208,11 +208,15 @@ export const makeHandler = <
     ) {
       const context = Context.add(services, HttpServerRequest, new ServerRequestImpl(nodeRequest, nodeResponse))
       const fiber = Fiber.runIn(Effect.runForkWith(context as Context.Context<any>)(handled), options.scope)
-      nodeResponse.on("close", () => {
-        if (!nodeResponse.writableEnded) {
-          fiber.interruptUnsafe(parent.id, ClientAbort.annotation)
-        }
-      })
+      // a synchronously completed fiber can no longer be interrupted, so the
+      // close listener would only allocate without effect
+      if (fiber.pollUnsafe() === undefined) {
+        nodeResponse.on("close", () => {
+          if (!nodeResponse.writableEnded) {
+            fiber.interruptUnsafe(parent.id, ClientAbort.annotation)
+          }
+        })
+      }
     })
   })
 }

--- a/packages/platform/node/src/NodeHttpServer.ts
+++ b/packages/platform/node/src/NodeHttpServer.ts
@@ -208,8 +208,6 @@ export const makeHandler = <
     ) {
       const context = Context.add(services, HttpServerRequest, new ServerRequestImpl(nodeRequest, nodeResponse))
       const fiber = Fiber.runIn(Effect.runForkWith(context as Context.Context<any>)(handled), options.scope)
-      // a synchronously completed fiber can no longer be interrupted, so the
-      // close listener would only allocate without effect
       if (fiber.pollUnsafe() === undefined) {
         nodeResponse.on("close", () => {
           if (!nodeResponse.writableEnded) {


### PR DESCRIPTION
Reduces HTTP server allocation churn per request without regressing throughput.

Closes EFF-1038

## Changes

- `Tracer.nativeTracer` is now a named export and the memoized default of the `Tracer.Tracer` reference, so runtime code can detect that no tracing backend is installed.
- `HttpMiddleware.tracer` ends the span inline and skips recording request/response attributes (per-header attribute keys, url strings, the scheduled end task) when the span is unsampled or the tracer is the native default. Spans are still created, so `Effect.currentSpan`, log span events, and trace context propagation are unchanged.
- `HttpRouter` only records the `http.route` attribute when a tracing backend can observe it.
- `Tracer.NativeSpan` generates trace/span ids and creates its attribute map and event list lazily on first access.
- `HttpEffect.toWebHandlerWith` and `NodeHttpServer` skip registering abort/close listeners when the request fiber already completed synchronously (interrupting an exited fiber is a no-op).
- New regression benchmark `packages/effect/benchmark/http/serverAllocations.ts` (run with `node --expose-gc`) gates allocation churn and retained heap per request through the in-process web handler path.

## Measurements

Node 26.7.0, `GET /ping` text route, logger disabled, sampled allocation profiles including collected objects.

| path | before | after |
| --- | --- | --- |
| socket server, bytes allocated/request | ~14.6k | ~10.1k (-31%) |
| in-process web handler, bytes allocated/request | ~18.5k | ~16.3k (-12%) |
| socket throughput (3 x 10s, 100 keep-alive connections) | 53.1-55.0k req/s | 52.2-54.5k req/s (within noise) |
| retained heap per request after GC | ~0 | ~0 |

Fully disabling the tracer measures ~9.5k on the socket path, so this captures most of the available win while keeping span semantics. Most of the remaining in-process churn is undici `Request`/`Response` construction.
