### PR TITLE
fix(Stream): preserve large source chunks when rechunking

### DIFF
--- a/.changeset/stream-rechunk-large-source.md
+++ b/.changeset/stream-rechunk-large-source.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix `Stream.rechunk` throwing for large source chunks when the target chunk size is larger, preserving all elements in order.
+Fix `Stream.rechunk` failing on large source chunks.

--- a/.changeset/stream-rechunk-large-source.md
+++ b/.changeset/stream-rechunk-large-source.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Stream.rechunk` throwing for large source chunks when the target chunk size is larger, preserving all elements in order.

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -6905,8 +6905,8 @@ export const rechunk: {
             if (chunk.length === 0 && arr.length === target) {
               return Effect.succeed(arr)
             } else if (chunk.length + arr.length < target) {
-              for (const value of arr) {
-                chunk.push(value)
+              for (let i = 0; i < arr.length; i++) {
+                chunk.push(arr[i])
               }
               return loop()
             }

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -6905,7 +6905,9 @@ export const rechunk: {
             if (chunk.length === 0 && arr.length === target) {
               return Effect.succeed(arr)
             } else if (chunk.length + arr.length < target) {
-              chunk.push(...arr)
+              for (const value of arr) {
+                chunk.push(value)
+              }
               return loop()
             }
             current = arr

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -1569,6 +1569,34 @@ describe("Stream", () => {
     })
   )
 
+  it.effect.each([
+    { size: 200001, lengths: [200000] },
+    { size: 200000, lengths: [200000] },
+    { size: 199999, lengths: [199999, 1] }
+  ])("rechunk preserves a large source chunk with target $size", ({ lengths, size }) =>
+    Effect.gen(function*() {
+      const values = Array.makeBy(200000, (i) => i)
+      const actual = yield* Stream.fromArray(values).pipe(
+        Stream.rechunk(size),
+        Stream.chunks,
+        Stream.runCollect
+      )
+      assert.deepStrictEqual(actual.map((chunk) => chunk.length), lengths)
+      assert.deepStrictEqual(actual.flat(), values)
+    }))
+
+  it.effect("rechunk preserves large input split across source chunks", () =>
+    Effect.gen(function*() {
+      const values = Array.makeBy(200000, (i) => i)
+      const actual = yield* Stream.fromArrays(values.slice(0, 100000), values.slice(100000)).pipe(
+        Stream.rechunk(200001),
+        Stream.chunks,
+        Stream.runCollect
+      )
+      assert.deepStrictEqual(actual.map((chunk) => chunk.length), [200000])
+      assert.deepStrictEqual(actual.flat(), values)
+    }))
+
   it.effect("rechunk and grouped normalize their chunk size", () =>
     Effect.gen(function*() {
       const counts = [Number.NaN, 0.5, 1.9, 2.9]

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -1587,13 +1587,13 @@ describe("Stream", () => {
 
   it.effect("rechunk preserves large input split across source chunks", () =>
     Effect.gen(function*() {
-      const values = Array.makeBy(200000, (i) => i)
-      const actual = yield* Stream.fromArrays(values.slice(0, 100000), values.slice(100000)).pipe(
-        Stream.rechunk(200001),
+      const values = Array.makeBy(200001, (i) => i)
+      const actual = yield* Stream.fromArrays(values.slice(0, 1), values.slice(1)).pipe(
+        Stream.rechunk(200002),
         Stream.chunks,
         Stream.runCollect
       )
-      assert.deepStrictEqual(actual.map((chunk) => chunk.length), [200000])
+      assert.deepStrictEqual(actual.map((chunk) => chunk.length), [200001])
       assert.deepStrictEqual(actual.flat(), values)
     }))
 


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`Stream.rechunk` used an array spread when buffering a source chunk. Large chunks can exceed the JavaScript engine's call-argument limit, causing a `RangeError` instead of preserving the stream elements.

The buffering branch now appends values individually. Regression coverage includes larger, equal, and smaller target sizes, plus input split across source chunks. The split case buffers one value before appending a 200,000-element chunk, so it exercises the same known failing size as the primary regression.

This PR also includes a patch changeset for `effect`.

## Verification

- `nix develop -c pnpm test --run --project effect packages/effect/test/Stream.test.ts -t rechunk` (6 passed)
- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`
- `git diff --check`

Closes #7654
Closes EFF-1044
