### PR TITLE
refactor(Channel): remove runDone

### DIFF
--- a/.changeset/channel-rundone-completion.md
+++ b/.changeset/channel-rundone-completion.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Channel.runDone` to consume all output and return the channel's completion value instead of its first emitted element, ensuring later effects run and later failures propagate.

--- a/.changeset/channel-rundone-completion.md
+++ b/.changeset/channel-rundone-completion.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix `Channel.runDone` to consume all output and return the channel's completion value instead of its first emitted element, ensuring later effects run and later failures propagate.
+Fix `Channel.runDone` to consume all output and return the channel's completion value.

--- a/.changeset/channel-rundone-completion.md
+++ b/.changeset/channel-rundone-completion.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix `Channel.runDone` to consume all output and return the channel's completion value.
+Remove `Channel.runDone`; use `Channel.runDrain` to consume all output and return the completion value.

--- a/migration/annotations/effect__Channel.yaml
+++ b/migration/annotations/effect__Channel.yaml
@@ -173,11 +173,11 @@
   replacement: "Channel.forever"
   note: "Use forever for infinite repetition. Channel.repeat takes a Schedule and may terminate, so it is not equivalent."
 "effect/Channel#run":
-  replacement: "Channel.runDone"
-  note: "Renamed to runDone for an inputless, outputless channel. Use runDrain if emitted elements should be discarded."
+  replacement: "Channel.runDrain"
+  note: "Use runDrain to consume all emitted elements and return the channel's done value."
 "effect/Channel#runScoped":
   replacement: "Channel.toPull"
-  note: "No direct scoped runner remains. Use toPull in the caller scope and recover Cause.Done; use runDone or runDrain when an internally managed scope is acceptable."
+  note: "No direct scoped runner remains. Use toPull in the caller scope and recover Cause.Done; use runDrain when an internally managed scope is acceptable."
 "effect/Channel#scopedWith":
   replacement: "Channel.unwrap"
   note: "Use Channel.unwrap(Effect.map(Effect.scope, (scope) => Channel.fromEffect(f(scope)))) so the effect uses the active channel scope."

--- a/migration/v3-to-v4.md
+++ b/migration/v3-to-v4.md
@@ -8998,9 +8998,9 @@ Arbitrary.schema(schema)
 
 - `Channel.repeated` -> `Channel.forever`: Use forever for infinite repetition. Channel.repeat takes a Schedule and may terminate, so it is not equivalent.
 
-- `Channel.run` -> `Channel.runDone`: Renamed to runDone for an inputless, outputless channel. Use runDrain if emitted elements should be discarded.
+- `Channel.run` -> `Channel.runDrain`: Use runDrain to consume all emitted elements and return the channel's done value.
 
-- `Channel.runScoped` -> `Channel.toPull`: No direct scoped runner remains. Use toPull in the caller scope and recover Cause.Done; use runDone or runDrain when an internally managed scope is acceptable.
+- `Channel.runScoped` -> `Channel.toPull`: No direct scoped runner remains. Use toPull in the caller scope and recover Cause.Done; use runDrain when an internally managed scope is acceptable.
 
 - `Channel.scopedWith` -> `Channel.unwrap`: Use Channel.unwrap(Effect.map(Effect.scope, (scope) =\> Channel.fromEffect(f(scope)))) so the effect uses the active channel scope.
 

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -8076,7 +8076,7 @@ export const runCollect = <OutElem, OutErr, OutDone, Env>(
  */
 export const runDone = <OutElem, OutErr, OutDone, Env>(
   self: Channel<OutElem, OutErr, OutDone, unknown, unknown, unknown, Env>
-): Effect.Effect<OutDone, OutErr, Env> => runWith(self, identity_, Effect.succeed)
+): Effect.Effect<OutDone, OutErr, Env> => runDrain(self)
 
 /**
  * Runs a channel until the first output element is available, returning it in

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -8069,16 +8069,6 @@ export const runCollect = <OutElem, OutErr, OutDone, Env>(
   })
 
 /**
- * Runs a channel and outputs the done value.
- *
- * @category running
- * @since 4.0.0
- */
-export const runDone = <OutElem, OutErr, OutDone, Env>(
-  self: Channel<OutElem, OutErr, OutDone, unknown, unknown, unknown, Env>
-): Effect.Effect<OutDone, OutErr, Env> => runDrain(self)
-
-/**
  * Runs a channel until the first output element is available, returning it in
  * an `Option`.
  *

--- a/packages/effect/src/Sink.ts
+++ b/packages/effect/src/Sink.ts
@@ -323,7 +323,7 @@ export const fromTransform = <In, A, E, R, L = never>(
  *   Channel.pipeTo(Sink.toChannel(Sink.sum))
  * )
  *
- * await Effect.runPromise(Channel.runDone(channel)) // => [6]
+ * await Effect.runPromise(Channel.runDrain(channel)) // => [6]
  * ```
  *
  * @category constructors

--- a/packages/effect/test/Channel.test.ts
+++ b/packages/effect/test/Channel.test.ts
@@ -220,11 +220,11 @@ describe("Channel", () => {
   })
 
   describe("destructors", () => {
-    it.effect("runDone returns the done value after emitted elements", () =>
+    it.effect("runDrain returns the done value after emitted elements", () =>
       Effect.gen(function*() {
         const result = yield* Channel.fromArray([1]).pipe(
           Channel.concat(Channel.end("done")),
-          Channel.runDone
+          Channel.runDrain
         )
 
         assert.strictEqual(result, "done")

--- a/packages/effect/test/Channel.test.ts
+++ b/packages/effect/test/Channel.test.ts
@@ -220,55 +220,15 @@ describe("Channel", () => {
   })
 
   describe("destructors", () => {
-    for (const [name, run] of [["runDone", Channel.runDone], ["runDrain", Channel.runDrain]] as const) {
-      describe(name, () => {
-        it.effect("returns the done value after emitted elements", () =>
-          Effect.gen(function*() {
-            const result = yield* Channel.fromArray([1, 2]).pipe(
-              Channel.concat(Channel.end("finished")),
-              (channel) => run(channel)
-            )
-            assert.strictEqual(result, "finished")
-          }))
+    it.effect("runDone returns the done value after emitted elements", () =>
+      Effect.gen(function*() {
+        const result = yield* Channel.fromArray([1]).pipe(
+          Channel.concat(Channel.end("done")),
+          Channel.runDone
+        )
 
-        it.effect("executes effects after the first emitted element", () =>
-          Effect.gen(function*() {
-            const seen: Array<number> = []
-            yield* Channel.fromArray([1, 2]).pipe(
-              Channel.mapEffect((n) =>
-                Effect.sync(() => {
-                  seen.push(n)
-                  return n
-                })
-              ),
-              (channel) => run(channel)
-            )
-            assert.deepStrictEqual(seen, [1, 2])
-          }))
-
-        it.effect("propagates failure after emitted elements", () =>
-          Effect.gen(function*() {
-            const exit = yield* Channel.fromArray([1, 2]).pipe(
-              Channel.concat(Channel.fail("later failure")),
-              (channel) => run(channel),
-              Effect.exit
-            )
-            assert.deepStrictEqual(exit, Exit.fail("later failure"))
-          }))
-
-        it.effect("returns the done value without emitted elements", () =>
-          Effect.gen(function*() {
-            const result = yield* run(Channel.end("finished"))
-            assert.strictEqual(result, "finished")
-          }))
-
-        it.effect("propagates failure without emitted elements", () =>
-          Effect.gen(function*() {
-            const exit = yield* run(Channel.fail("immediate failure")).pipe(Effect.exit)
-            assert.deepStrictEqual(exit, Exit.fail("immediate failure"))
-          }))
-      })
-    }
+        assert.strictEqual(result, "done")
+      }))
 
     it.effect("mkUint8Array", () =>
       Effect.gen(function*() {

--- a/packages/effect/test/Channel.test.ts
+++ b/packages/effect/test/Channel.test.ts
@@ -220,6 +220,56 @@ describe("Channel", () => {
   })
 
   describe("destructors", () => {
+    for (const [name, run] of [["runDone", Channel.runDone], ["runDrain", Channel.runDrain]] as const) {
+      describe(name, () => {
+        it.effect("returns the done value after emitted elements", () =>
+          Effect.gen(function*() {
+            const result = yield* Channel.fromArray([1, 2]).pipe(
+              Channel.concat(Channel.end("finished")),
+              (channel) => run(channel)
+            )
+            assert.strictEqual(result, "finished")
+          }))
+
+        it.effect("executes effects after the first emitted element", () =>
+          Effect.gen(function*() {
+            const seen: Array<number> = []
+            yield* Channel.fromArray([1, 2]).pipe(
+              Channel.mapEffect((n) =>
+                Effect.sync(() => {
+                  seen.push(n)
+                  return n
+                })
+              ),
+              (channel) => run(channel)
+            )
+            assert.deepStrictEqual(seen, [1, 2])
+          }))
+
+        it.effect("propagates failure after emitted elements", () =>
+          Effect.gen(function*() {
+            const exit = yield* Channel.fromArray([1, 2]).pipe(
+              Channel.concat(Channel.fail("later failure")),
+              (channel) => run(channel),
+              Effect.exit
+            )
+            assert.deepStrictEqual(exit, Exit.fail("later failure"))
+          }))
+
+        it.effect("returns the done value without emitted elements", () =>
+          Effect.gen(function*() {
+            const result = yield* run(Channel.end("finished"))
+            assert.strictEqual(result, "finished")
+          }))
+
+        it.effect("propagates failure without emitted elements", () =>
+          Effect.gen(function*() {
+            const exit = yield* run(Channel.fail("immediate failure")).pipe(Effect.exit)
+            assert.deepStrictEqual(exit, Exit.fail("immediate failure"))
+          }))
+      })
+    }
+
     it.effect("mkUint8Array", () =>
       Effect.gen(function*() {
         const bytes = yield* Channel.fromArray(


### PR DESCRIPTION
## Type

- [x] Refactor

## Description

Remove `Channel.runDone`, which duplicates `Channel.runDrain`. Callers should use `runDrain` to consume emitted elements and return the channel's done value.

The `Sink.toChannel` example and v3-to-v4 migration guidance now point to `runDrain`. The Channel test covers that replacement behavior with an emitted value followed by a distinct done value.

## Verification

```sh
pnpm lint-fix
pnpm test --run packages/effect/test/Channel.test.ts
pnpm doctest --run packages/effect/src/Sink.ts
pnpm jsdocs --check
pnpm check
```

## Related

Closes #7656
Closes EFF-1045
