### PR TITLE
fix(Schema): preserve percent-encoded JSON Schema references

### DIFF
--- a/.changeset/fix-json-schema-percent-references.md
+++ b/.changeset/fix-json-schema-percent-references.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix JSON Schema export for definition names containing percent signs so local references remain resolvable after round trips and alias deduplication, while preserving JSON Pointer escaping.
+Fix JSON Schema reference encoding for definition names containing percent signs.

--- a/.changeset/fix-json-schema-percent-references.md
+++ b/.changeset/fix-json-schema-percent-references.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix JSON Schema export for definition names containing percent signs so local references remain resolvable after round trips and alias deduplication, while preserving JSON Pointer escaping.

--- a/packages/effect/src/internal/schema/toJsonSchemaDocument.ts
+++ b/packages/effect/src/internal/schema/toJsonSchemaDocument.ts
@@ -220,10 +220,18 @@ function compileJsonSchema(
 
   function finalizeJsonSchema(schema: JsonSchema.JsonSchema): JsonSchema.JsonSchema {
     if (!hasAliases) return schema
+    // URI-encoded slashes separate pointer tokens; only ~1 represents a slash within a token.
     return rewriteRefs(schema, ($ref) =>
-      $ref.replace(/^#\/\$defs\/([^/]*)/, (match, token) => {
+      $ref.replace(/^#\/\$defs\/((?:(?!%2[fF])[^/])*)/, (match, token) => {
+        try {
+          token = decodeURIComponent(token)
+        } catch {
+          return match
+        }
         const canonical = definitionStates.get(unescapeToken(token))
-        return typeof canonical === "string" ? `#/$defs/${escapeToken(canonical)}` : match
+        return typeof canonical === "string"
+          ? `#/$defs/${encodeURI(escapeToken(canonical)).replace(/#/g, "%23")}`
+          : match
       }))
   }
 
@@ -283,7 +291,7 @@ function compileJsonSchema(
   ): JsonSchema.JsonSchema {
     if (representation._tag === "Reference") {
       const canonical = compileDefinition(representation.$ref, path)
-      return { $ref: `#/$defs/${escapeToken(canonical)}` }
+      return { $ref: `#/$defs/${encodeURI(escapeToken(canonical)).replace(/#/g, "%23")}` }
     }
     const cached = compiledRepresentations.get(representation)
     if (cached !== undefined) return cached

--- a/packages/effect/src/internal/schema/toJsonSchemaDocument.ts
+++ b/packages/effect/src/internal/schema/toJsonSchemaDocument.ts
@@ -16,6 +16,10 @@ type CheckRepresentationAnnotation = SchemaRepresentation.CheckRepresentationAnn
   SchemaRepresentation.Representation
 >
 
+function formatReferenceToken(token: string): string {
+  return encodeURI(escapeToken(token)).replace(/#/g, "%23")
+}
+
 const jsonSchemaAnnotationExcludedKeys = new Set([
   ...InternalAnnotations.annotationExcludedKeys,
   InternalAnnotations.IDENTIFIER_FALLBACK_KEY,
@@ -226,12 +230,10 @@ function compileJsonSchema(
         try {
           token = decodeURIComponent(token)
         } catch {
-          return match
+          // Keep the raw token so malformed callback references can still be canonicalized.
         }
         const canonical = definitionStates.get(unescapeToken(token))
-        return typeof canonical === "string"
-          ? `#/$defs/${encodeURI(escapeToken(canonical)).replace(/#/g, "%23")}`
-          : match
+        return typeof canonical === "string" ? `#/$defs/${formatReferenceToken(canonical)}` : match
       }))
   }
 
@@ -291,7 +293,7 @@ function compileJsonSchema(
   ): JsonSchema.JsonSchema {
     if (representation._tag === "Reference") {
       const canonical = compileDefinition(representation.$ref, path)
-      return { $ref: `#/$defs/${encodeURI(escapeToken(canonical)).replace(/#/g, "%23")}` }
+      return { $ref: `#/$defs/${formatReferenceToken(canonical)}` }
     }
     const cached = compiledRepresentations.get(representation)
     if (cached !== undefined) return cached

--- a/packages/effect/test/schema/representation/toJsonSchemaDocument.test.ts
+++ b/packages/effect/test/schema/representation/toJsonSchemaDocument.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { type JsonSchema, Schema, SchemaAST, SchemaRepresentation } from "effect"
+import { JsonSchema, Schema, SchemaAST, SchemaRepresentation } from "effect"
 import { throws } from "../../utils/assert.ts"
 
 function expectError(thunk: () => void, expected: string | Error): void {
@@ -36,6 +36,36 @@ describe("SchemaRepresentation.toJsonSchemaDocument", () => {
   function compile(representation: SchemaRepresentation.Representation) {
     return SchemaRepresentation.toJsonSchemaDocument({ representation, references: {} }).schema
   }
+
+  describe("local reference round trips", () => {
+    for (
+      const [key, token] of [
+        ["Rate", "Rate"],
+        ["id~a/b", "id~0a~1b"],
+        ["Rate%", "Rate%25"],
+        ["id~a/b%25", "id~0a~1b%2525"]
+      ]
+    ) {
+      it(`preserves the definition named ${key}`, () => {
+        const input = JsonSchema.fromSchemaDraft2020_12({
+          $ref: `#/$defs/${token}`,
+          $defs: { [key]: { type: "string" } }
+        })
+        const imported = SchemaRepresentation.fromJsonSchemaDocument(input)
+        assert.strictEqual(Schema.is(imported)("value"), true)
+        assert.strictEqual(Schema.is(imported)(1), false)
+
+        const output = SchemaRepresentation.toJsonSchemaDocument(
+          SchemaRepresentation.toRepresentation(imported.ast)
+        )
+        assert.deepStrictEqual(Object.keys(output.definitions), [key])
+        const restored = SchemaRepresentation.fromJsonSchemaDocument(output)
+        assert.strictEqual(Schema.is(restored)("value"), true)
+        assert.strictEqual(Schema.is(restored)(1), false)
+        assert.strictEqual(output.schema.$ref, input.schema.$ref)
+      })
+    }
+  })
 
   describe("representation nodes", () => {
     const keywords = [

--- a/packages/effect/test/schema/representation/toJsonSchemaMultiDocument.test.ts
+++ b/packages/effect/test/schema/representation/toJsonSchemaMultiDocument.test.ts
@@ -196,6 +196,25 @@ describe("SchemaRepresentation.toJsonSchemaMultiDocument", () => {
       })
     }
 
+    it("rewrites callback references containing a bare percent sign", () => {
+      const Content = Schema.String.annotate({ identifier: "Rate%" })
+      const make = () =>
+        Schema.toCodecJson(
+          Schema.String.check(Schema.isMinLength(1)).pipe(
+            Schema.decodeTo(Content, stringIdentityTransformation)
+          )
+        )
+      const callback = Schema.Unknown.check(Schema.makeFilter(() => true, {
+        toJsonSchema: () => ({ $ref: "#/$defs/Rate%Encoded_1" })
+      }))
+      const output = SchemaRepresentation.toJsonSchemaMultiDocument(
+        SchemaRepresentation.toRepresentations([make().ast, make().ast, callback.ast])
+      )
+
+      assert.deepStrictEqual(Object.keys(output.definitions), ["Rate%Encoded"])
+      assert.deepStrictEqual(output.schemas[2], { $ref: "#/$defs/Rate%25Encoded" })
+    })
+
     for (const separator of ["/", "%2F", "%2f", "~1", "%7E1"]) {
       it(`distinguishes pointer separators from escaped slashes in ${separator} callback references`, () => {
         const Content = Schema.String.annotate({ identifier: "Box/properties/value" })

--- a/packages/effect/test/schema/representation/toJsonSchemaMultiDocument.test.ts
+++ b/packages/effect/test/schema/representation/toJsonSchemaMultiDocument.test.ts
@@ -1,6 +1,9 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Schema, SchemaRepresentation, SchemaTransformation } from "effect"
+import { JsonSchema, Schema, SchemaRepresentation, SchemaTransformation } from "effect"
 import { throws } from "../../utils/assert.ts"
+
+// oxlint-disable-next-line @typescript-eslint/no-require-imports
+const AjvDraft07 = require("ajv")
 
 function expectError(thunk: () => void, expected: string | Error): void {
   if (typeof expected === "string") {
@@ -156,6 +159,114 @@ describe("SchemaRepresentation.toJsonSchemaMultiDocument", () => {
           contentMediaType: "application/json"
         }
       })
+    })
+
+    for (
+      const [identifier, token] of [
+        ["Rate", "Rate"],
+        ["id~a/b", "id~0a~1b"],
+        ["Rate%", "Rate%25"],
+        ["Rate%2F", "Rate%252F"],
+        ["Rate%25", "Rate%2525"]
+      ]
+    ) {
+      it(`rewrites callback references to the canonical ${identifier} definition`, () => {
+        const Content = Schema.String.annotate({ identifier })
+        const make = () =>
+          Schema.toCodecJson(
+            Schema.String.check(Schema.isMinLength(1)).pipe(
+              Schema.decodeTo(Content, stringIdentityTransformation)
+            )
+          )
+        const first = make()
+        const second = make()
+        const callback = Schema.Unknown.check(Schema.makeFilter(() => true, {
+          toJsonSchema: () => ({ $ref: `#/$defs/${token}Encoded_1` })
+        }))
+        const document = SchemaRepresentation.toRepresentations([first.ast, second.ast, callback.ast])
+        assert.deepStrictEqual(Object.keys(document.references), [`${identifier}Encoded`, `${identifier}Encoded_1`])
+        const output = SchemaRepresentation.toJsonSchemaMultiDocument(document)
+
+        assert.deepStrictEqual(Object.keys(output.definitions), [`${identifier}Encoded`])
+        assert.deepStrictEqual(output.schemas[2], { $ref: `#/$defs/${token}Encoded` })
+        for (const restored of SchemaRepresentation.fromJsonSchemaMultiDocument(output)) {
+          assert.strictEqual(Schema.is(restored)("value"), true)
+          assert.strictEqual(Schema.is(restored)(1), false)
+        }
+      })
+    }
+
+    for (const separator of ["/", "%2F", "%2f", "~1", "%7E1"]) {
+      it(`distinguishes pointer separators from escaped slashes in ${separator} callback references`, () => {
+        const Content = Schema.String.annotate({ identifier: "Box/properties/value" })
+        const make = () =>
+          Schema.toCodecJson(
+            Schema.String.check(Schema.isMinLength(1)).pipe(
+              Schema.decodeTo(Content, stringIdentityTransformation)
+            )
+          )
+        const Box = Schema.Struct({ valueEncoded_1: Schema.Boolean }).annotate({ identifier: "Box" })
+        const $ref = `#/$defs/Box${separator}properties${separator}valueEncoded_1`
+        const callback = Schema.Unknown.check(Schema.makeFilter(() => true, {
+          toJsonSchema: () => ({ $ref })
+        }))
+        const output = SchemaRepresentation.toJsonSchemaMultiDocument(
+          SchemaRepresentation.toRepresentations([make().ast, make().ast, Box.ast, callback.ast])
+        )
+        // Normalize URI fragments before validation: Ajv alone treats %2F as token contents.
+        const document = JsonSchema.toDocumentDraft07({
+          dialect: output.dialect,
+          schema: output.schemas[3],
+          definitions: output.definitions
+        })
+        const validate = new AjvDraft07.default({ strict: false }).compile({
+          ...document.schema,
+          definitions: document.definitions
+        })
+        const isName = separator === "~1" || separator === "%7E1"
+        assert.strictEqual(validate(true), !isName)
+        assert.strictEqual(validate("value"), isName)
+        assert.strictEqual(output.schemas[3].$ref, isName ? "#/$defs/Box~1properties~1valueEncoded" : $ref)
+      })
+    }
+
+    it("preserves an encoded pointer suffix when rewriting a percent-named alias", () => {
+      const representation = SchemaRepresentation.toRepresentation(
+        Schema.Struct({ "value%2F": Schema.Boolean }).ast
+      ).representation
+      if (representation._tag !== "Objects") throw new Error("Expected an object representation")
+      const definition: SchemaRepresentation.Representation = {
+        ...representation,
+        annotations: { "~identifier": "Box%" }
+      }
+      const $ref = "#/$defs/Box%25_1%2Fproperties%2Fvalue%252F"
+      const reference = Object.freeze({ $ref, default: Object.freeze({ $ref }) })
+      const output = SchemaRepresentation.toJsonSchemaMultiDocument({
+        representations: [{
+          _tag: "Unknown",
+          checks: [{
+            _tag: "Filter",
+            aborted: false,
+            annotations: { toJsonSchema: () => reference }
+          }]
+        }],
+        references: { "Box%": definition, "Box%_1": definition }
+      })
+
+      assert.strictEqual(output.schemas[0].$ref, "#/$defs/Box%25%2Fproperties%2Fvalue%252F")
+      assert.deepStrictEqual(output.schemas[0].default, { $ref })
+      assert.strictEqual(reference.$ref, $ref)
+      const document = JsonSchema.toDocumentDraft07({
+        dialect: output.dialect,
+        schema: output.schemas[0],
+        definitions: output.definitions
+      })
+      const validate = new AjvDraft07.default({ strict: false }).compile({
+        ...document.schema,
+        definitions: document.definitions
+      })
+      assert.strictEqual(validate(true), true)
+      assert.strictEqual(validate("value"), false)
     })
 
     // JSON Schema callbacks are user-provided and may have effects, so invocation count is observable.


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

### Why

Exporting a JSON Schema definition named `Rate%` emits `#/$defs/Rate%` instead of `#/$defs/Rate%25`, so a valid local reference no longer resolves after a round trip. Callback references to percent-encoded definition aliases can also remain pointed at aliases removed during deduplication.

### What Changes

Apply URI-fragment escaping after JSON Pointer token escaping when emitting definition references. Decode the definition token before alias lookup, then re-encode the canonical name while preserving the pointer suffix.

The alias rewrite distinguishes `/` and `%2F`/`%2f` path separators from `~1` or `%7E1`, which represent a slash inside a definition name. For example, `#/$defs/Box%2Fproperties%2Fvalue` stays a property path rather than matching a definition named `Box/properties/value`.

[Round-trip regressions](https://github.com/kitlangton/effect/blob/audit/i2-jsonschema-percent/packages/effect/test/schema/representation/toJsonSchemaDocument.test.ts) and [alias/pointer regressions](https://github.com/kitlangton/effect/blob/audit/i2-jsonschema-percent/packages/effect/test/schema/representation/toJsonSchemaMultiDocument.test.ts) cover percent names, repeated encoding, escaped slashes, encoded pointer suffixes, and malformed callback references.

### Scope

Local definition-reference emission and alias rewriting in the JSON Schema exporter, tests, and an `effect` patch changeset. This does not expand the importer's supported reference forms or add external-reference resolution.

### Verification

Validation commands from the repository root:

```sh
nix develop -c pnpm test --run packages/effect/test/schema/representation/toJsonSchemaDocument.test.ts packages/effect/test/schema/representation/toJsonSchemaMultiDocument.test.ts
nix develop -c pnpm lint
nix develop -c pnpm check
git diff --check
```

The focused suites pass 98 tests. Lint, type checking, and whitespace checks pass.

## Related

Closes #7660
Closes EFF-1047

## Audit

Runtime correctness audit; intended label: `audit`.
