### PR TITLE
fix(VariantSchema): preserve classes in default extraction

### DIFF
--- a/.changeset/preserve-default-variant-class.md
+++ b/.changeset/preserve-default-variant-class.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve schema classes when extracting their default `VariantSchema` variant.

--- a/.changeset/preserve-default-variant-class.md
+++ b/.changeset/preserve-default-variant-class.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix default variant extraction for `VariantSchema` classes so decoding preserves class instances and their methods. For example, `Model.extract(Person, "select")` now decodes to a `Person` rather than a plain object. Nondefault variants and named schemas such as `Person.select` remain plain field projections.

--- a/.changeset/preserve-default-variant-class.md
+++ b/.changeset/preserve-default-variant-class.md
@@ -1,5 +1,0 @@
----
-"effect": patch
----
-
-Fix default variant extraction for `VariantSchema` classes so decoding preserves class instances and their methods. For example, `Model.extract(Person, "select")` now decodes to a `Person` rather than a plain object. Nondefault variants and named schemas such as `Person.select` remain plain field projections.

--- a/packages/effect/src/unstable/schema/VariantSchema.ts
+++ b/packages/effect/src/unstable/schema/VariantSchema.ts
@@ -217,6 +217,9 @@ const extract: {
       readonly isDefault?: boolean | undefined
     }
   ): Extract<V, A> => {
+    if (options?.isDefault === true && Schema.isSchema(self)) {
+      return self as any
+    }
     const cache = options?.isDefault === true
       ? self[defaultCacheSymbol] ?? (self[defaultCacheSymbol] = Object.create(null))
       : self[cacheSymbol] ?? (self[cacheSymbol] = Object.create(null))

--- a/packages/effect/src/unstable/schema/VariantSchema.ts
+++ b/packages/effect/src/unstable/schema/VariantSchema.ts
@@ -217,9 +217,6 @@ const extract: {
       readonly isDefault?: boolean | undefined
     }
   ): Extract<V, A> => {
-    if (options?.isDefault === true && Schema.isSchema(self)) {
-      return self as any
-    }
     const cache = options?.isDefault === true
       ? self[defaultCacheSymbol] ?? (self[defaultCacheSymbol] = Object.create(null))
       : self[cacheSymbol] ?? (self[cacheSymbol] = Object.create(null))

--- a/packages/effect/test/unstable/schema/VariantSchema.test.ts
+++ b/packages/effect/test/unstable/schema/VariantSchema.test.ts
@@ -84,64 +84,14 @@ describe("VariantSchema", () => {
 })
 
 describe("Model", () => {
-  describe("extract", () => {
+  it("preserves classes when extracting the default variant", () => {
     class Person extends Model.Class<Person>("Person")({
-      name: Schema.String,
-      internalId: Model.FieldOnly(["select"])(Schema.Number)
-    }) {
-      greet() {
-        return `Hello ${this.name}`
-      }
-    }
-    const input = { name: "Alex", internalId: 1 }
+      name: Schema.String
+    }) {}
 
-    it("preserves instance methods when decoding the class directly", () => {
-      const person = Schema.decodeSync(Person)(input)
+    const person = Schema.decodeSync(Model.extract(Person, "select"))({ name: "Alex" })
 
-      assert.strictEqual(person.greet(), "Hello Alex")
-      assert.isTrue(person instanceof Person)
-    })
-
-    it("preserves instance methods in the default union", () => {
-      const person = Schema.decodeSync(Model.Union([Person]))(input)
-
-      assert.strictEqual(person.greet(), "Hello Alex")
-      assert.isTrue(person instanceof Person)
-    })
-
-    it("preserves instance methods when extracting the default variant data-first", () => {
-      const person = Schema.decodeSync(Model.extract(Person, "select"))(input)
-
-      assert.strictEqual(person.greet(), "Hello Alex")
-      assert.isTrue(person instanceof Person)
-    })
-
-    it("preserves instance methods when extracting the default variant data-last", () => {
-      const person = Schema.decodeSync(Person.pipe(Model.extract("select")))(input)
-
-      assert.strictEqual(person.greet(), "Hello Alex")
-      assert.isTrue(person instanceof Person)
-    })
-
-    it("keeps nondefault extraction as a plain field projection", () => {
-      const json = Model.extract(Person, "json")
-      const person = Schema.decodeSync(json)({ name: "Alex" })
-
-      assert.deepStrictEqual(person, { name: "Alex" })
-      assert.isFalse(person instanceof Person)
-      assert.isFalse("greet" in person)
-      assert.deepStrictEqual(Object.keys(json.fields), ["name"])
-    })
-
-    it("keeps named select schemas as plain field projections", () => {
-      const person = Schema.decodeSync(Person.select)(input)
-      const unionPerson = Schema.decodeSync(Model.Union([Person]).select)(input)
-
-      assert.deepStrictEqual(person, input)
-      assert.deepStrictEqual(unionPerson, input)
-      assert.isFalse(person instanceof Person)
-      assert.isFalse(unionPerson instanceof Person)
-    })
+    assert.isTrue(person instanceof Person)
   })
 
   it("FieldOnly includes fields only in listed variants", () => {

--- a/packages/effect/test/unstable/schema/VariantSchema.test.ts
+++ b/packages/effect/test/unstable/schema/VariantSchema.test.ts
@@ -84,6 +84,66 @@ describe("VariantSchema", () => {
 })
 
 describe("Model", () => {
+  describe("extract", () => {
+    class Person extends Model.Class<Person>("Person")({
+      name: Schema.String,
+      internalId: Model.FieldOnly(["select"])(Schema.Number)
+    }) {
+      greet() {
+        return `Hello ${this.name}`
+      }
+    }
+    const input = { name: "Alex", internalId: 1 }
+
+    it("preserves instance methods when decoding the class directly", () => {
+      const person = Schema.decodeSync(Person)(input)
+
+      assert.strictEqual(person.greet(), "Hello Alex")
+      assert.isTrue(person instanceof Person)
+    })
+
+    it("preserves instance methods in the default union", () => {
+      const person = Schema.decodeSync(Model.Union([Person]))(input)
+
+      assert.strictEqual(person.greet(), "Hello Alex")
+      assert.isTrue(person instanceof Person)
+    })
+
+    it("preserves instance methods when extracting the default variant data-first", () => {
+      const person = Schema.decodeSync(Model.extract(Person, "select"))(input)
+
+      assert.strictEqual(person.greet(), "Hello Alex")
+      assert.isTrue(person instanceof Person)
+    })
+
+    it("preserves instance methods when extracting the default variant data-last", () => {
+      const person = Schema.decodeSync(Person.pipe(Model.extract("select")))(input)
+
+      assert.strictEqual(person.greet(), "Hello Alex")
+      assert.isTrue(person instanceof Person)
+    })
+
+    it("keeps nondefault extraction as a plain field projection", () => {
+      const json = Model.extract(Person, "json")
+      const person = Schema.decodeSync(json)({ name: "Alex" })
+
+      assert.deepStrictEqual(person, { name: "Alex" })
+      assert.isFalse(person instanceof Person)
+      assert.isFalse("greet" in person)
+      assert.deepStrictEqual(Object.keys(json.fields), ["name"])
+    })
+
+    it("keeps named select schemas as plain field projections", () => {
+      const person = Schema.decodeSync(Person.select)(input)
+      const unionPerson = Schema.decodeSync(Model.Union([Person]).select)(input)
+
+      assert.deepStrictEqual(person, input)
+      assert.deepStrictEqual(unionPerson, input)
+      assert.isFalse(person instanceof Person)
+      assert.isFalse(unionPerson instanceof Person)
+    })
+  })
+
   it("FieldOnly includes fields only in listed variants", () => {
     const InsertOnly = Model.Struct({
       value: Model.FieldOnly(["insert"])(Schema.String)


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`Model.extract(Person, "select")` was typed as returning `Person`, but decoding produced a plain object because default extraction rebuilt the schema as a `Schema.Struct`.

Return a schema class unchanged when extracting its default variant. Non-default variants still use field projection.

## Testing

- `pnpm test --run packages/effect/test/unstable/schema/VariantSchema.test.ts --reporter=verbose`
- `pnpm lint-fix`
- `pnpm check`

## Related

Closes EFF-1048
Closes #7662
