### PR TITLE
fix(Model): preserve omitted variants in FieldOption

### DIFF
--- a/.changeset/model-field-option-undefined.md
+++ b/.changeset/model-field-option-undefined.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Model.FieldOption` to preserve omitted variants.

--- a/.changeset/model-field-option-undefined.md
+++ b/.changeset/model-field-option-undefined.md
@@ -1,5 +1,0 @@
----
-"effect": patch
----
-
-Fix `Model.FieldOption` throwing when a field explicitly uses `undefined` to omit a variant. Omitted variants now remain omitted while defined variants retain their optional encoding behavior.

--- a/.changeset/model-field-option-undefined.md
+++ b/.changeset/model-field-option-undefined.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Model.FieldOption` throwing when a field explicitly uses `undefined` to omit a variant. Omitted variants now remain omitted while defined variants retain their optional encoding behavior.

--- a/packages/effect/src/unstable/schema/Model.ts
+++ b/packages/effect/src/unstable/schema/Model.ts
@@ -20,6 +20,7 @@ import * as Predicate from "../../Predicate.ts"
 import * as Schema from "../../Schema.ts"
 import * as SchemaGetter from "../../SchemaGetter.ts"
 import * as SchemaTransformation from "../../SchemaTransformation.ts"
+import * as UndefinedOr from "../../UndefinedOr.ts"
 import * as VariantSchema from "./VariantSchema.ts"
 
 const {
@@ -366,13 +367,13 @@ export const FieldOption: <Field extends VariantSchema.Field<any> | Schema.Top>(
       }
     > :
   never = fieldEvolve({
-    select: Schema.OptionFromNullOr,
-    insert: Schema.OptionFromNullOr,
-    update: Schema.OptionFromNullOr,
-    json: optionalOption,
-    jsonCreate: optionalOption,
-    jsonUpdate: optionalOption
-  }) as any
+    select: UndefinedOr.map(Schema.OptionFromNullOr),
+    insert: UndefinedOr.map(Schema.OptionFromNullOr),
+    update: UndefinedOr.map(Schema.OptionFromNullOr),
+    json: UndefinedOr.map(optionalOption),
+    jsonCreate: UndefinedOr.map(optionalOption),
+    jsonUpdate: UndefinedOr.map(optionalOption)
+  } as any) as any
 
 /**
  * Variant field type for SQLite booleans stored as `0 | 1` in database variants

--- a/packages/effect/src/unstable/schema/Model.ts
+++ b/packages/effect/src/unstable/schema/Model.ts
@@ -366,12 +366,12 @@ export const FieldOption: <Field extends VariantSchema.Field<any> | Schema.Top>(
       }
     > :
   never = fieldEvolve({
-    select: Schema.OptionFromNullOr,
-    insert: Schema.OptionFromNullOr,
-    update: Schema.OptionFromNullOr,
-    json: optionalOption,
-    jsonCreate: optionalOption,
-    jsonUpdate: optionalOption
+    select: (schema: any) => schema === undefined ? schema : Schema.OptionFromNullOr(schema),
+    insert: (schema: any) => schema === undefined ? schema : Schema.OptionFromNullOr(schema),
+    update: (schema: any) => schema === undefined ? schema : Schema.OptionFromNullOr(schema),
+    json: (schema: any) => schema === undefined ? schema : optionalOption(schema),
+    jsonCreate: (schema: any) => schema === undefined ? schema : optionalOption(schema),
+    jsonUpdate: (schema: any) => schema === undefined ? schema : optionalOption(schema)
   }) as any
 
 /**

--- a/packages/effect/src/unstable/schema/Model.ts
+++ b/packages/effect/src/unstable/schema/Model.ts
@@ -366,12 +366,12 @@ export const FieldOption: <Field extends VariantSchema.Field<any> | Schema.Top>(
       }
     > :
   never = fieldEvolve({
-    select: (schema: any) => schema === undefined ? schema : Schema.OptionFromNullOr(schema),
-    insert: (schema: any) => schema === undefined ? schema : Schema.OptionFromNullOr(schema),
-    update: (schema: any) => schema === undefined ? schema : Schema.OptionFromNullOr(schema),
-    json: (schema: any) => schema === undefined ? schema : optionalOption(schema),
-    jsonCreate: (schema: any) => schema === undefined ? schema : optionalOption(schema),
-    jsonUpdate: (schema: any) => schema === undefined ? schema : optionalOption(schema)
+    select: Schema.OptionFromNullOr,
+    insert: Schema.OptionFromNullOr,
+    update: Schema.OptionFromNullOr,
+    json: optionalOption,
+    jsonCreate: optionalOption,
+    jsonUpdate: optionalOption
   }) as any
 
 /**

--- a/packages/effect/test/unstable/schema/VariantSchema.test.ts
+++ b/packages/effect/test/unstable/schema/VariantSchema.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { DateTime, Effect, Option, Schema } from "effect"
+import { DateTime, Effect, Schema } from "effect"
 import { Model, VariantSchema } from "effect/unstable/schema"
 
 describe("VariantSchema", () => {
@@ -94,94 +94,9 @@ describe("Model", () => {
     assert.isTrue(person instanceof Person)
   })
 
-  describe("FieldOption", () => {
-    const variants = ["select", "insert", "update", "json", "jsonCreate", "jsonUpdate"] as const
-    const schemas = {
-      select: Schema.String,
-      insert: Schema.String,
-      update: Schema.String,
-      json: Schema.String,
-      jsonCreate: Schema.String,
-      jsonUpdate: Schema.String
-    }
-
-    it.each(variants)("preserves an explicitly undefined %s variant", (variant) => {
-      const field = Model.Field({ ...schemas, [variant]: undefined })
-      const optional = Model.FieldOption(field)
-      const model = Model.Struct({ value: optional })
-      const omitted = Model.extract(model, variant)
-
-      assert.isTrue(Object.hasOwn(optional.schemas, variant))
-      assert.strictEqual(optional.schemas[variant], undefined)
-      assert.deepStrictEqual(Object.keys(omitted.fields), [])
-      assert.deepStrictEqual<unknown>(Schema.decodeUnknownSync(omitted)({}), {})
-      assert.deepStrictEqual<unknown>(Schema.encodeUnknownSync(omitted)({}), {})
-
-      for (const retained of variants) {
-        if (retained === variant) continue
-        const schema = Model.extract(model, retained)
-        assert.deepStrictEqual(Schema.decodeUnknownSync(schema)({ value: null }), { value: Option.none() })
-        assert.deepStrictEqual(Schema.decodeUnknownSync(schema)({ value: "sample" }), { value: Option.some("sample") })
-        assert.deepStrictEqual(Schema.encodeUnknownSync(schema)({ value: Option.some("sample") }), { value: "sample" })
-        assert.strictEqual(field.schemas[retained], Schema.String)
-      }
-    })
-
-    it("omits explicitly undefined variants before optionalization", () => {
-      for (const variant of variants) {
-        const model = Model.Struct({ value: Model.Field({ ...schemas, [variant]: undefined }) })
-        const schema = Model.extract(model, variant)
-        assert.deepStrictEqual(Object.keys(schema.fields), [])
-        assert.deepStrictEqual<unknown>(Schema.decodeUnknownSync(schema)({}), {})
-        assert.deepStrictEqual<unknown>(Schema.encodeUnknownSync(schema)({}), {})
-      }
-    })
-
-    it.each(variants)("round-trips defined schemas in the %s variant", (variant) => {
-      for (const field of [Schema.String, Model.Field(schemas)]) {
-        const model = Model.Struct({ value: Model.FieldOption(field) })
-        const schema = Model.extract(model, variant)
-        const isJson = variant === "json" || variant === "jsonCreate" || variant === "jsonUpdate"
-
-        assert.deepStrictEqual(Schema.decodeUnknownSync(schema)({ value: null }), { value: Option.none() })
-        assert.deepStrictEqual(Schema.decodeUnknownSync(schema)({ value: "sample" }), { value: Option.some("sample") })
-        assert.deepStrictEqual(Schema.encodeUnknownSync(schema)({ value: Option.some("sample") }), { value: "sample" })
-        assert.deepStrictEqual<unknown>(
-          Schema.encodeUnknownSync(schema)({ value: Option.none() }),
-          isJson ? {} : { value: null }
-        )
-        if (isJson) {
-          assert.deepStrictEqual(Schema.decodeUnknownSync(schema)({}), { value: Option.none() })
-        } else {
-          assert.throws(() => Schema.decodeUnknownSync(schema)({}))
-        }
-      }
-    })
-
-    it("keeps absent variants omitted", () => {
-      const model = Model.Struct({ value: Model.FieldOption(Model.Field({ select: Schema.String })) })
-      assert.deepStrictEqual(Schema.decodeUnknownSync(Model.extract(model, "select"))({ value: null }), {
-        value: Option.none()
-      })
-      for (const variant of variants) {
-        if (variant === "select") continue
-        const schema = Model.extract(model, variant)
-        assert.deepStrictEqual(Object.keys(schema.fields), [])
-        assert.deepStrictEqual(Schema.decodeUnknownSync(schema)({}), {})
-      }
-    })
-  })
-
-  it("fieldEvolve passes explicitly undefined variants to the callback", () => {
-    const field = Model.fieldEvolve(Model.Field({ select: Schema.String, json: undefined }), {
-      json: (schema) => {
-        assert.strictEqual(schema, undefined)
-        return Schema.String
-      }
-    })
-    const json = Model.extract(Model.Struct({ value: field }), "json")
-
-    assert.deepStrictEqual(Schema.decodeSync(json)({ value: "sample" }), { value: "sample" })
+  it("FieldOption preserves omitted variants", () => {
+    const field = Model.FieldOption(Model.Field({ select: Schema.String, json: undefined }))
+    assert.strictEqual(field.schemas.json, undefined)
   })
 
   it("FieldOnly includes fields only in listed variants", () => {

--- a/packages/effect/test/unstable/schema/VariantSchema.test.ts
+++ b/packages/effect/test/unstable/schema/VariantSchema.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { DateTime, Effect, Schema } from "effect"
+import { DateTime, Effect, Option, Schema } from "effect"
 import { Model, VariantSchema } from "effect/unstable/schema"
 
 describe("VariantSchema", () => {
@@ -92,6 +92,96 @@ describe("Model", () => {
     const person = Schema.decodeSync(Model.extract(Person, "select"))({ name: "Alex" })
 
     assert.isTrue(person instanceof Person)
+  })
+
+  describe("FieldOption", () => {
+    const variants = ["select", "insert", "update", "json", "jsonCreate", "jsonUpdate"] as const
+    const schemas = {
+      select: Schema.String,
+      insert: Schema.String,
+      update: Schema.String,
+      json: Schema.String,
+      jsonCreate: Schema.String,
+      jsonUpdate: Schema.String
+    }
+
+    it.each(variants)("preserves an explicitly undefined %s variant", (variant) => {
+      const field = Model.Field({ ...schemas, [variant]: undefined })
+      const optional = Model.FieldOption(field)
+      const model = Model.Struct({ value: optional })
+      const omitted = Model.extract(model, variant)
+
+      assert.isTrue(Object.hasOwn(optional.schemas, variant))
+      assert.strictEqual(optional.schemas[variant], undefined)
+      assert.deepStrictEqual(Object.keys(omitted.fields), [])
+      assert.deepStrictEqual<unknown>(Schema.decodeUnknownSync(omitted)({}), {})
+      assert.deepStrictEqual<unknown>(Schema.encodeUnknownSync(omitted)({}), {})
+
+      for (const retained of variants) {
+        if (retained === variant) continue
+        const schema = Model.extract(model, retained)
+        assert.deepStrictEqual(Schema.decodeUnknownSync(schema)({ value: null }), { value: Option.none() })
+        assert.deepStrictEqual(Schema.decodeUnknownSync(schema)({ value: "sample" }), { value: Option.some("sample") })
+        assert.deepStrictEqual(Schema.encodeUnknownSync(schema)({ value: Option.some("sample") }), { value: "sample" })
+        assert.strictEqual(field.schemas[retained], Schema.String)
+      }
+    })
+
+    it("omits explicitly undefined variants before optionalization", () => {
+      for (const variant of variants) {
+        const model = Model.Struct({ value: Model.Field({ ...schemas, [variant]: undefined }) })
+        const schema = Model.extract(model, variant)
+        assert.deepStrictEqual(Object.keys(schema.fields), [])
+        assert.deepStrictEqual<unknown>(Schema.decodeUnknownSync(schema)({}), {})
+        assert.deepStrictEqual<unknown>(Schema.encodeUnknownSync(schema)({}), {})
+      }
+    })
+
+    it.each(variants)("round-trips defined schemas in the %s variant", (variant) => {
+      for (const field of [Schema.String, Model.Field(schemas)]) {
+        const model = Model.Struct({ value: Model.FieldOption(field) })
+        const schema = Model.extract(model, variant)
+        const isJson = variant === "json" || variant === "jsonCreate" || variant === "jsonUpdate"
+
+        assert.deepStrictEqual(Schema.decodeUnknownSync(schema)({ value: null }), { value: Option.none() })
+        assert.deepStrictEqual(Schema.decodeUnknownSync(schema)({ value: "sample" }), { value: Option.some("sample") })
+        assert.deepStrictEqual(Schema.encodeUnknownSync(schema)({ value: Option.some("sample") }), { value: "sample" })
+        assert.deepStrictEqual<unknown>(
+          Schema.encodeUnknownSync(schema)({ value: Option.none() }),
+          isJson ? {} : { value: null }
+        )
+        if (isJson) {
+          assert.deepStrictEqual(Schema.decodeUnknownSync(schema)({}), { value: Option.none() })
+        } else {
+          assert.throws(() => Schema.decodeUnknownSync(schema)({}))
+        }
+      }
+    })
+
+    it("keeps absent variants omitted", () => {
+      const model = Model.Struct({ value: Model.FieldOption(Model.Field({ select: Schema.String })) })
+      assert.deepStrictEqual(Schema.decodeUnknownSync(Model.extract(model, "select"))({ value: null }), {
+        value: Option.none()
+      })
+      for (const variant of variants) {
+        if (variant === "select") continue
+        const schema = Model.extract(model, variant)
+        assert.deepStrictEqual(Object.keys(schema.fields), [])
+        assert.deepStrictEqual(Schema.decodeUnknownSync(schema)({}), {})
+      }
+    })
+  })
+
+  it("fieldEvolve passes explicitly undefined variants to the callback", () => {
+    const field = Model.fieldEvolve(Model.Field({ select: Schema.String, json: undefined }), {
+      json: (schema) => {
+        assert.strictEqual(schema, undefined)
+        return Schema.String
+      }
+    })
+    const json = Model.extract(Model.Struct({ value: field }), "json")
+
+    assert.deepStrictEqual(Schema.decodeSync(json)({ value: "sample" }), { value: "sample" })
   })
 
   it("FieldOnly includes fields only in listed variants", () => {


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`Model.FieldOption` now preserves explicitly omitted variants instead of passing `undefined` to a schema constructor. Defined database and JSON variants keep their existing optional encoding behavior.

The regression test covers the public `FieldOption` constructor with an omitted JSON variant.

## Verification

```sh
pnpm lint-fix
pnpm test --run packages/effect/test/unstable/schema/VariantSchema.test.ts
pnpm check
```

## Related

Closes EFF-1049
Closes #7664
