### PR TITLE
fix(Toml): allow child tables in distinct array entries

### DIFF
--- a/.changeset/fix-toml-array-subtables.md
+++ b/.changeset/fix-toml-array-subtables.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Toml.parse` rejecting child tables in separate array-of-tables entries.

--- a/packages/effect/src/unstable/encoding/Toml.ts
+++ b/packages/effect/src/unstable/encoding/Toml.ts
@@ -45,7 +45,7 @@ class TomlParser {
   private index = 0
   private line = 1
   private column = 1
-  private readonly explicitTables = new Set<string>()
+  private readonly explicitTables = new Set<Table>()
 
   constructor(input: string) {
     this.input = input
@@ -85,14 +85,14 @@ class TomlParser {
     }
     this.finishStatement()
 
-    const pathKey = JSON.stringify(path)
-    if (!array && this.explicitTables.has(pathKey)) {
+    const table = this.resolveTable(path, array)
+    if (!array && this.explicitTables.has(table)) {
       this.fail(`Cannot redefine table '${path.join(".")}'`)
     }
     if (!array) {
-      this.explicitTables.add(pathKey)
+      this.explicitTables.add(table)
     }
-    this.current = this.resolveTable(path, array)
+    this.current = table
   }
 
   private resolveTable(path: ReadonlyArray<string>, array: boolean): Table {

--- a/packages/effect/test/unstable/encoding/Toml.test.ts
+++ b/packages/effect/test/unstable/encoding/Toml.test.ts
@@ -45,6 +45,19 @@ started = 2026-08-05
     )
   })
 
+  it("parses child tables under distinct array entries", () => {
+    assert.deepStrictEqual(
+      Toml.parse(`
+[[servers]]
+[servers.tls]
+
+[[servers]]
+[servers.tls]
+`),
+      { servers: [{ tls: {} }, { tls: {} }] }
+    )
+  })
+
   it("parses multiline strings and numeric formats", () => {
     assert.deepStrictEqual(
       Toml.parse(`


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`Toml.parse` tracked explicit table declarations by textual path, so the same child-table path collided across distinct array-of-tables entries. It now tracks the resolved table identity, allowing each array entry to declare its own child table while preserving duplicate-table errors within one entry.

The regression test covers the public parser behavior with two `[[servers]]` entries that each declare `[servers.tls]`.

## Verification

```sh
pnpm lint-fix
pnpm test --run packages/effect/test/unstable/encoding/Toml.test.ts --reporter=verbose
pnpm check
git diff --check
```

## Related

Closes #7666
Closes EFF-1050

## Audit

Runtime correctness audit; intended label: `audit`.
