### PR TITLE
fix(Yaml): preserve folded scalar paragraph and indentation breaks

### DIFF
--- a/.changeset/fix-yaml-folded-scalars.md
+++ b/.changeset/fix-yaml-folded-scalars.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix folded YAML scalars to preserve paragraph and indentation breaks.

--- a/packages/effect/src/unstable/encoding/Yaml.ts
+++ b/packages/effect/src/unstable/encoding/Yaml.ts
@@ -480,26 +480,25 @@ class YamlParser {
     if (style === "|") {
       output = content.join("\n")
     } else {
-      let separator = ""
-      let previousMoreIndented = false
+      let blankLines = 0
+      let previousMoreIndented: boolean | undefined
       for (const line of content) {
-        if (line.startsWith(" ")) {
-          if (separator === " ") separator = "\n"
-          else if (!previousMoreIndented && separator === "\n") separator = "\n\n"
-          output += separator + line
-          separator = "\n"
-          previousMoreIndented = true
-        } else if (line.length === 0) {
-          if (separator === "\n") output += "\n"
-          else separator = "\n"
+        if (line.length === 0) {
+          blankLines++
         } else {
-          output += separator + line
-          separator = " "
-          previousMoreIndented = false
+          const moreIndented = line.startsWith(" ")
+          const hardBreak = moreIndented || previousMoreIndented === true
+          if (previousMoreIndented === undefined) output += "\n".repeat(blankLines)
+          else if (blankLines === 0) output += hardBreak ? "\n" : " "
+          else output += "\n".repeat(blankLines + (hardBreak ? 1 : 0))
+          output += line
+          blankLines = 0
+          previousMoreIndented = moreIndented
         }
       }
+      output += "\n".repeat(blankLines)
     }
-    if (chomp === "keep") return `${output}\n`
+    if (chomp === "keep") return output.endsWith("\n") ? output : `${output}\n`
     output = output.replace(/\n+$/, "")
     return chomp === "strip" ? output : `${output}\n`
   }

--- a/packages/effect/src/unstable/encoding/Yaml.ts
+++ b/packages/effect/src/unstable/encoding/Yaml.ts
@@ -480,10 +480,22 @@ class YamlParser {
     if (style === "|") {
       output = content.join("\n")
     } else {
-      for (let index = 0; index < content.length; index++) {
-        output += content[index]
-        if (index < content.length - 1) {
-          output += content[index].length === 0 || content[index + 1].length === 0 ? "\n" : " "
+      let separator = ""
+      let previousMoreIndented = false
+      for (const line of content) {
+        if (line.startsWith(" ")) {
+          if (separator === " ") separator = "\n"
+          else if (!previousMoreIndented && separator === "\n") separator = "\n\n"
+          output += separator + line
+          separator = "\n"
+          previousMoreIndented = true
+        } else if (line.length === 0) {
+          if (separator === "\n") output += "\n"
+          else separator = "\n"
+        } else {
+          output += separator + line
+          separator = " "
+          previousMoreIndented = false
         }
       }
     }

--- a/packages/effect/test/unstable/encoding/Yaml.test.ts
+++ b/packages/effect/test/unstable/encoding/Yaml.test.ts
@@ -50,6 +50,25 @@ folded: >-
     )
   })
 
+  it("preserves paragraph and indentation breaks in folded block scalars", () => {
+    assert.deepStrictEqual(
+      Yaml.parse(`
+paragraph: >-
+  first
+
+  second
+indented: >-
+  first
+    second
+  third
+`),
+      {
+        paragraph: "first\nsecond",
+        indented: "first\n  second\nthird"
+      }
+    )
+  })
+
   it("resolves aliases", () => {
     assert.deepStrictEqual(
       Yaml.parse(`

--- a/packages/effect/test/unstable/encoding/Yaml.test.ts
+++ b/packages/effect/test/unstable/encoding/Yaml.test.ts
@@ -69,6 +69,26 @@ indented: >-
     )
   })
 
+  it.each([
+    [
+      "leading blanks before a more-indented first line",
+      "message: >-2\n\n    first\n  second\n",
+      "\n  first\nsecond"
+    ],
+    [
+      "keep chomping after a more-indented final line",
+      "message: >+2\n  first\n    second\n",
+      "first\n  second\n"
+    ],
+    [
+      "multiple blank paragraph lines",
+      "message: >-\n  first\n\n\n  second\n",
+      "first\n\nsecond"
+    ]
+  ])("preserves %s", (_, source, expected) => {
+    assert.deepStrictEqual(Yaml.parse(source), { message: expected })
+  })
+
   it("resolves aliases", () => {
     assert.deepStrictEqual(
       Yaml.parse(`


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`Yaml.parse` added an extra newline for folded-scalar paragraphs and replaced line breaks around more-indented passages with spaces.

Use the YAML folding separator rules so adjacent ordinary lines still fold to a space, paragraph breaks have the correct size, and breaks touching more-indented content remain newlines.

## Verification

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/unstable/encoding/Yaml.test.ts --reporter=verbose`
- `pnpm check`
- `git diff --check`

## Related

Closes EFF-1051
Closes #7668

## Audit

Runtime correctness audit; intended label: `audit`.
