### PR TITLE
fix(Sse): preserve events with mixed line endings

### DIFF
--- a/.changeset/fix-sse-mixed-line-endings.md
+++ b/.changeset/fix-sse-mixed-line-endings.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix SSE parsing dropping events when CRLF and LF line endings occur in the same input chunk.

--- a/.changeset/fix-sse-mixed-line-endings.md
+++ b/.changeset/fix-sse-mixed-line-endings.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix SSE parsing dropping events when CRLF and LF line endings occur in the same input chunk.
+Preserve SSE events with mixed line endings.

--- a/packages/effect/src/unstable/encoding/Sse.ts
+++ b/packages/effect/src/unstable/encoding/Sse.ts
@@ -311,7 +311,7 @@ export function makeParser(onParse: (event: AnyEvent) => void, options?: DecodeO
       let fieldLength = startingFieldLength
       let character: string
 
-      for (let index = startingPosition; lineLength < 0 && index < length; ++index) {
+      for (let index = position + startingPosition; lineLength < 0 && index < length; ++index) {
         character = buffer[index]
         if (character === ":" && fieldLength < 0) {
           fieldLength = index - position

--- a/packages/effect/test/unstable/encoding/Sse.test.ts
+++ b/packages/effect/test/unstable/encoding/Sse.test.ts
@@ -4,19 +4,11 @@ import * as Schema from "effect/Schema"
 import * as Sse from "effect/unstable/encoding/Sse"
 
 describe("Sse", () => {
-  it.each([
-    { name: "uniform LF endings", chunks: ["data: first\ndata: second\n\n"] },
-    { name: "uniform CRLF endings", chunks: ["data: first\r\ndata: second\r\n\r\n"] },
-    { name: "uniform CR endings", chunks: ["data: first\rdata: second\r\r"] },
-    { name: "mixed CRLF/LF endings in one feed", chunks: ["data: first\r\ndata: second\n\n"] },
-    { name: "mixed CRLF/LF endings split after CRLF", chunks: ["data: first\r\n", "data: second\n\n"] }
-  ])("parses $name", ({ chunks }) => {
+  it("parses mixed CRLF and LF line endings", () => {
     const events: Array<Sse.AnyEvent> = []
     const parser = Sse.makeParser((event) => events.push(event))
 
-    for (const chunk of chunks) {
-      assert.strictEqual(parser.feed(chunk), undefined)
-    }
+    parser.feed("data: first\r\ndata: second\n\n")
 
     assert.deepStrictEqual(events, [{
       _tag: "Event",
@@ -25,24 +17,6 @@ describe("Sse", () => {
       data: "first\nsecond"
     }])
   })
-
-  it.effect.each([
-    { name: "one chunk", chunks: ["data: first\r\ndata: second\n\n"] },
-    { name: "chunks split after CRLF", chunks: ["data: first\r\n", "data: second\n\n"] }
-  ])("decode parses mixed CRLF/LF endings in $name", ({ chunks }) =>
-    Effect.gen(function*() {
-      const events = yield* Stream.fromArray(chunks).pipe(
-        Stream.pipeThroughChannel(Sse.decode()),
-        Stream.runCollect
-      )
-
-      assert.deepStrictEqual([...events], [{
-        _tag: "Event",
-        event: "message",
-        id: undefined,
-        data: "first\nsecond"
-      }])
-    }))
 
   it("treats CRLF split across chunks as one line ending", () => {
     const events: Array<Sse.AnyEvent> = []

--- a/packages/effect/test/unstable/encoding/Sse.test.ts
+++ b/packages/effect/test/unstable/encoding/Sse.test.ts
@@ -4,6 +4,46 @@ import * as Schema from "effect/Schema"
 import * as Sse from "effect/unstable/encoding/Sse"
 
 describe("Sse", () => {
+  it.each([
+    { name: "uniform LF endings", chunks: ["data: first\ndata: second\n\n"] },
+    { name: "uniform CRLF endings", chunks: ["data: first\r\ndata: second\r\n\r\n"] },
+    { name: "uniform CR endings", chunks: ["data: first\rdata: second\r\r"] },
+    { name: "mixed CRLF/LF endings in one feed", chunks: ["data: first\r\ndata: second\n\n"] },
+    { name: "mixed CRLF/LF endings split after CRLF", chunks: ["data: first\r\n", "data: second\n\n"] }
+  ])("parses $name", ({ chunks }) => {
+    const events: Array<Sse.AnyEvent> = []
+    const parser = Sse.makeParser((event) => events.push(event))
+
+    for (const chunk of chunks) {
+      assert.strictEqual(parser.feed(chunk), undefined)
+    }
+
+    assert.deepStrictEqual(events, [{
+      _tag: "Event",
+      event: "message",
+      id: undefined,
+      data: "first\nsecond"
+    }])
+  })
+
+  it.effect.each([
+    { name: "one chunk", chunks: ["data: first\r\ndata: second\n\n"] },
+    { name: "chunks split after CRLF", chunks: ["data: first\r\n", "data: second\n\n"] }
+  ])("decode parses mixed CRLF/LF endings in $name", ({ chunks }) =>
+    Effect.gen(function*() {
+      const events = yield* Stream.fromArray(chunks).pipe(
+        Stream.pipeThroughChannel(Sse.decode()),
+        Stream.runCollect
+      )
+
+      assert.deepStrictEqual([...events], [{
+        _tag: "Event",
+        event: "message",
+        id: undefined,
+        data: "first\nsecond"
+      }])
+    }))
+
   it("treats CRLF split across chunks as one line ending", () => {
     const events: Array<Sse.AnyEvent> = []
     const parser = Sse.makeParser((event) => events.push(event))


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

The SSE parser could drop a complete event when CRLF and LF line endings occurred in the same input chunk. Start each line scan at the current buffer position plus the retained offset for an incomplete line.

The regression test covers a single mixed-ending feed through `Sse.makeParser`.

## Verification

```sh
pnpm lint-fix
pnpm test --run packages/effect/test/unstable/encoding/Sse.test.ts
pnpm check
git diff --check
```

Closes #7670
Closes EFF-1052
