### PR TITLE
fix(SchemaBinary): preserve leading U+FEFF in strings

### DIFF
--- a/.changeset/schema-binary-preserve-bom.md
+++ b/.changeset/schema-binary-preserve-bom.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve leading U+FEFF characters in SchemaBinary string values when decoding, including dictionary-backed streams in both default and fingerprint modes. Strings beginning with a byte order mark now round-trip without losing content.

--- a/.changeset/schema-binary-preserve-bom.md
+++ b/.changeset/schema-binary-preserve-bom.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Preserve leading U+FEFF characters in SchemaBinary string values when decoding, including dictionary-backed streams in both default and fingerprint modes. Strings beginning with a byte order mark now round-trip without losing content.
+Preserve leading U+FEFF characters in SchemaBinary string values when decoding.

--- a/packages/effect/src/unstable/encoding/SchemaBinary.ts
+++ b/packages/effect/src/unstable/encoding/SchemaBinary.ts
@@ -921,7 +921,7 @@ const BIGINT_U32_MASK = BigInt(0xFFFFFFFF)
 const BIGINT_THIRTY_TWO = BigInt(32)
 
 const utf8Encode = new TextEncoder()
-const utf8DecodeFatal = new TextDecoder("utf-8", { fatal: true })
+const utf8DecodeFatal = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true })
 
 // General numbers use up to seven varint bytes, a varint mantissa with a
 // decimal scale byte, or an eight-byte f64.

--- a/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
+++ b/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
@@ -255,6 +255,46 @@ describe("SchemaBinary", () => {
     })
   })
 
+  describe("string content", () => {
+    for (const fingerprint of [false, true]) {
+      for (
+        const { label, values } of [
+          {
+            label: "leading U+FEFF",
+            values: ["\uFEFFreport", "\uFEFF", "\uFEFF\uFEFFreport", `\uFEFF${"report".repeat(8)}`, "\uFEFFreport"]
+          },
+          {
+            label: "ordinary Unicode and non-leading U+FEFF",
+            values: ["", "report", "caf\u00E9", "report\uFEFF", "re\uFEFFport", "report".repeat(8), "report\uFEFF"]
+          }
+        ]
+      ) {
+        it(`preserves ${label} through the codec (fingerprint=${fingerprint})`, () => {
+          const codec = SchemaBinary.toCodec(Schema.String, { fingerprint })
+          const encode = Schema.encodeSync(codec)
+          const decode = Schema.decodeUnknownSync(codec)
+
+          assert.deepStrictEqual(values.map((value) => decode(encode(value))), values)
+        })
+
+        it(`preserves ${label} through fragmented dictionary frames (fingerprint=${fingerprint})`, () => {
+          const options = { dictionary: true, fingerprint }
+          const encoder = SchemaBinary.encoder(Schema.String, options)
+          const parser = SchemaBinary.parser(Schema.String, options)
+          const decoded: Array<string> = []
+          for (const value of values) {
+            for (const byte of encoder.encode(value)) {
+              decoded.push(...parser.feedSync(Uint8Array.of(byte)))
+            }
+          }
+          parser.endSync()
+
+          assert.deepStrictEqual(decoded, values)
+        })
+      }
+    }
+  })
+
   describe("output arena", () => {
     it("keeps an earlier result stable through later encodes and arena rollover", () => {
       const codec = SchemaBinary.toCodec(Schema.String)

--- a/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
+++ b/packages/effect/test/unstable/encoding/SchemaBinary.test.ts
@@ -256,43 +256,9 @@ describe("SchemaBinary", () => {
   })
 
   describe("string content", () => {
-    for (const fingerprint of [false, true]) {
-      for (
-        const { label, values } of [
-          {
-            label: "leading U+FEFF",
-            values: ["\uFEFFreport", "\uFEFF", "\uFEFF\uFEFFreport", `\uFEFF${"report".repeat(8)}`, "\uFEFFreport"]
-          },
-          {
-            label: "ordinary Unicode and non-leading U+FEFF",
-            values: ["", "report", "caf\u00E9", "report\uFEFF", "re\uFEFFport", "report".repeat(8), "report\uFEFF"]
-          }
-        ]
-      ) {
-        it(`preserves ${label} through the codec (fingerprint=${fingerprint})`, () => {
-          const codec = SchemaBinary.toCodec(Schema.String, { fingerprint })
-          const encode = Schema.encodeSync(codec)
-          const decode = Schema.decodeUnknownSync(codec)
-
-          assert.deepStrictEqual(values.map((value) => decode(encode(value))), values)
-        })
-
-        it(`preserves ${label} through fragmented dictionary frames (fingerprint=${fingerprint})`, () => {
-          const options = { dictionary: true, fingerprint }
-          const encoder = SchemaBinary.encoder(Schema.String, options)
-          const parser = SchemaBinary.parser(Schema.String, options)
-          const decoded: Array<string> = []
-          for (const value of values) {
-            for (const byte of encoder.encode(value)) {
-              decoded.push(...parser.feedSync(Uint8Array.of(byte)))
-            }
-          }
-          parser.endSync()
-
-          assert.deepStrictEqual(decoded, values)
-        })
-      }
-    }
+    it("preserves a leading U+FEFF in strings", () => {
+      assert.strictEqual(roundtrip(Schema.String, "\uFEFFreport"), "\uFEFFreport")
+    })
   })
 
   describe("output arena", () => {


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`SchemaBinary.toCodec(Schema.String)` consumed a leading U+FEFF during decoding, so strings such as `"\uFEFFreport"` did not round-trip.

Configure the shared fatal UTF-8 decoder with `ignoreBOM: true`. Despite the option name, this makes `TextDecoder` preserve U+FEFF as string content. A focused regression test covers the public codec round trip.

## Validation

- `nix develop -c pnpm test --run packages/effect/test/unstable/encoding/SchemaBinary.test.ts` (193 passed)
- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`
- `git diff --check 243c72f001dd87385839c057af48f346abcf480b`
- `git diff --check`

## Related

Closes EFF-1053

Closes #7672
