### PR TITLE
fix(Mime): normalize parameters in all-extension lookups

### DIFF
--- a/.changeset/fix-mime-parameter-normalization.md
+++ b/.changeset/fix-mime-parameter-normalization.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Normalize MIME type parameters and whitespace in `Mime.getAllExtensions`.

--- a/packages/effect/src/unstable/http/Mime.ts
+++ b/packages/effect/src/unstable/http/Mime.ts
@@ -72,5 +72,5 @@ export const getAllExtensions = (type: string): Option.Option<ReadonlySet<string
   if (typeof type !== "string") {
     return Option.none()
   }
-  return Option.fromUndefinedOr(typeToExtensions.get(type.toLowerCase()))
+  return Option.fromUndefinedOr(typeToExtensions.get(type.split(";")[0].trim().toLowerCase()))
 }

--- a/packages/effect/test/unstable/http/Mime.test.ts
+++ b/packages/effect/test/unstable/http/Mime.test.ts
@@ -32,5 +32,9 @@ describe("Mime", () => {
   it("exposes reverse lookups at the module level", () => {
     assert.deepStrictEqual(Mime.getExtension("text/html; charset=utf-8"), Option.some("html"))
     assert.deepStrictEqual(Mime.getAllExtensions("text/html"), Option.some(new Set(["html", "htm", "shtml"])))
+    assert.deepStrictEqual(
+      Mime.getAllExtensions("text/html; charset=utf-8"),
+      Option.some(new Set(["html", "htm", "shtml"]))
+    )
   })
 })


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`Mime.getAllExtensions` now normalizes media types the same way as `Mime.getExtension`: it removes parameters, trims whitespace, and lowercases the lookup key. Parameterized values such as `text/html; charset=utf-8` return all known HTML extensions instead of `None`.

The regression test is in the existing `packages/effect/test/unstable/http/Mime.test.ts` suite.

## Verification

```sh
pnpm lint-fix
pnpm test --run packages/effect/test/unstable/http/Mime.test.ts --reporter=verbose
pnpm check
```

Closes #7674
Closes EFF-1054
