### PR TITLE
fix(HttpEffect): close request scopes for streaming HEAD responses

### DIFF
--- a/.changeset/http-head-stream-scope.md
+++ b/.changeset/http-head-stream-scope.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Close request scopes for streaming HEAD responses.

--- a/packages/effect/src/unstable/http/HttpEffect.ts
+++ b/packages/effect/src/unstable/http/HttpEffect.ts
@@ -241,7 +241,7 @@ export const toWebHandlerWith = <Provided, R = never, ReqR = Exclude<R, Provided
 {
   const resolveSymbol = Symbol.for("@effect/platform/HttpApp/resolve")
   const httpApp = toHandled(self, (request, response) => {
-    response = scopeTransferToStream(response)
+    if (request.method !== "HEAD") response = scopeTransferToStream(response)
     ;(request as any)[resolveSymbol](
       Response.toWeb(response, { withoutBody: request.method === "HEAD", context })
     )

--- a/packages/effect/test/unstable/http/HttpEffect.test.ts
+++ b/packages/effect/test/unstable/http/HttpEffect.test.ts
@@ -108,6 +108,22 @@ describe("HttpEffect", () => {
       strictEqual(streamFinalized < handlerFinalized, true)
     })
 
+    test("streaming HEAD closes the request scope", async () => {
+      let finalized = false
+      const handler = HttpEffect.toWebHandler(Effect.gen(function*() {
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            finalized = true
+          })
+        )
+        return HttpServerResponse.stream(Stream.make("body").pipe(Stream.encodeText))
+      }))
+
+      await handler(new Request("http://localhost:3000/", { method: "HEAD" }))
+
+      strictEqual(finalized, true)
+    })
+
     test("stream runtime", async () => {
       const handler = Effect.succeed(HttpServerResponse.stream(
         Stream.fromEffect(TestValue).pipe(Stream.map(String), Stream.encodeText)


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`HttpEffect.toWebHandler` transferred request-scope ownership to streaming response bodies. For HEAD requests, the Web response omits that body, so nothing closed the scope.

Keep streaming HEAD responses on the normal request-scope cleanup path. Streaming responses for other methods still transfer ownership to the body stream.

The regression checks that a request finalizer runs when a streaming HEAD handler completes.

## Verification

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/unstable/http/HttpEffect.test.ts` (19 passed)
- `pnpm check`
- `git diff --check`

## Related

Closes #7678

Closes EFF-1056
