### PR TITLE
fix(HttpServerResponse): preserve Web response content lengths

### DIFF
--- a/.changeset/http-response-content-length.md
+++ b/.changeset/http-response-content-length.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Preserve valid Content-Length metadata when converting a Web Response with `HttpServerResponse.fromWeb`, including zero-length bodies.
+Preserve `Content-Length` headers in `HttpServerResponse.fromWeb`.

--- a/.changeset/http-response-content-length.md
+++ b/.changeset/http-response-content-length.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve valid Content-Length metadata when converting a Web Response with `HttpServerResponse.fromWeb`, including zero-length bodies.

--- a/packages/effect/src/unstable/http/HttpServerResponse.ts
+++ b/packages/effect/src/unstable/http/HttpServerResponse.ts
@@ -1384,7 +1384,8 @@ export const fromWeb = (response: Response): HttpServerResponse => {
           evaluate: () => response.body!,
           onError: (e) => e
         }),
-        contentType ?? undefined
+        contentType ?? undefined,
+        bodyInternal.parseContentLength(response.headers.get("content-length"))
       )
     )
   }

--- a/packages/effect/test/unstable/http/HttpServerResponse.test.ts
+++ b/packages/effect/test/unstable/http/HttpServerResponse.test.ts
@@ -15,87 +15,15 @@ describe("HttpServerResponse", () => {
     assert.strictEqual(response.headers["content-length"], "1")
   })
 
-  for (const body of ["hello", ""]) {
-    const contentLength = String(body.length)
-
-    it.effect(`fromWeb preserves content-length ${contentLength} through a Web round trip`, () =>
-      Effect.gen(function*() {
-        const original = new Response(body, {
-          status: 201,
-          headers: { "content-length": contentLength, "content-type": "text/plain", "x-test": "kept" }
-        })
-        assert.isNotNull(original.body)
-        assert.strictEqual(original.headers.get("content-length"), contentLength)
-
-        const response = HttpServerResponse.fromWeb(original)
-        const roundTrip = HttpServerResponse.toWeb(response)
-
-        assert.strictEqual(yield* Effect.promise(() => roundTrip.text()), body)
-        assert.strictEqual(roundTrip.headers.get("content-length"), contentLength)
-        assert.strictEqual(response.headers["content-length"], contentLength)
-        assert.deepInclude(response.body, { _tag: "Stream", contentLength: body.length })
-      }))
-
-    it.effect(`fromClientResponse preserves content-length ${contentLength} through a Web round trip`, () =>
-      Effect.gen(function*() {
-        const clientResponse = HttpClientResponse.fromWeb(
-          HttpClientRequest.get("http://localhost:3000"),
-          new Response(body, {
-            status: 201,
-            headers: { "content-length": contentLength, "content-type": "text/plain", "x-test": "kept" }
-          })
-        )
-        const response = HttpServerResponse.fromClientResponse(clientResponse)
-        const roundTrip = HttpServerResponse.toWeb(response)
-
-        assert.strictEqual(yield* Effect.promise(() => roundTrip.text()), body)
-        assert.strictEqual(roundTrip.status, 201)
-        assert.strictEqual(roundTrip.headers.get("content-type"), "text/plain")
-        assert.strictEqual(roundTrip.headers.get("x-test"), "kept")
-        assert.strictEqual(roundTrip.headers.get("content-length"), contentLength)
-        assert.strictEqual(response.headers["content-length"], contentLength)
-        assert.deepInclude(response.body, { _tag: "Stream", contentLength: body.length })
-      }))
-  }
-
-  it.effect("fromWeb leaves an absent content-length absent through a Web round trip", () =>
-    Effect.gen(function*() {
-      const original = new Response("hello", { headers: { "content-type": "text/plain" } })
-      assert.isNull(original.headers.get("content-length"))
-
-      const response = HttpServerResponse.fromWeb(original)
-      const roundTrip = HttpServerResponse.toWeb(response)
-
-      assert.strictEqual(yield* Effect.promise(() => roundTrip.text()), "hello")
-      assert.isNull(roundTrip.headers.get("content-length"))
-      assert.notProperty(response.headers, "content-length")
-      assert.deepInclude(response.body, { _tag: "Stream", contentLength: undefined })
-    }))
-
-  it.effect("fromWeb preserves other metadata and body through a Web round trip", () =>
+  it.effect("fromWeb preserves content-length through a Web round trip", () =>
     Effect.gen(function*() {
       const response = HttpServerResponse.fromWeb(
-        new Response("hello", {
-          status: 201,
-          statusText: "Created",
-          headers: {
-            "content-length": "5",
-            "content-type": "text/plain",
-            "x-test": "kept",
-            "set-cookie": "session=123"
-          }
-        })
+        new Response("hello", { headers: { "content-length": "5" } })
       )
       const roundTrip = HttpServerResponse.toWeb(response)
 
-      assert.strictEqual(roundTrip.status, 201)
-      assert.strictEqual(roundTrip.statusText, "Created")
-      assert.strictEqual(roundTrip.headers.get("content-type"), "text/plain")
-      assert.strictEqual(roundTrip.headers.get("x-test"), "kept")
-      assert.deepStrictEqual(roundTrip.headers.getSetCookie(), ["session=123"])
-      assert.strictEqual(response.cookies.cookies.session?.value, "123")
-      assert.notProperty(response.headers, "set-cookie")
       assert.strictEqual(yield* Effect.promise(() => roundTrip.text()), "hello")
+      assert.strictEqual(roundTrip.headers.get("content-length"), "5")
     }))
 
   it.effect("fromClientResponse preserves status, headers, cookies, and json", () =>

--- a/packages/effect/test/unstable/http/HttpServerResponse.test.ts
+++ b/packages/effect/test/unstable/http/HttpServerResponse.test.ts
@@ -15,6 +15,89 @@ describe("HttpServerResponse", () => {
     assert.strictEqual(response.headers["content-length"], "1")
   })
 
+  for (const body of ["hello", ""]) {
+    const contentLength = String(body.length)
+
+    it.effect(`fromWeb preserves content-length ${contentLength} through a Web round trip`, () =>
+      Effect.gen(function*() {
+        const original = new Response(body, {
+          status: 201,
+          headers: { "content-length": contentLength, "content-type": "text/plain", "x-test": "kept" }
+        })
+        assert.isNotNull(original.body)
+        assert.strictEqual(original.headers.get("content-length"), contentLength)
+
+        const response = HttpServerResponse.fromWeb(original)
+        const roundTrip = HttpServerResponse.toWeb(response)
+
+        assert.strictEqual(yield* Effect.promise(() => roundTrip.text()), body)
+        assert.strictEqual(roundTrip.headers.get("content-length"), contentLength)
+        assert.strictEqual(response.headers["content-length"], contentLength)
+        assert.deepInclude(response.body, { _tag: "Stream", contentLength: body.length })
+      }))
+
+    it.effect(`fromClientResponse preserves content-length ${contentLength} through a Web round trip`, () =>
+      Effect.gen(function*() {
+        const clientResponse = HttpClientResponse.fromWeb(
+          HttpClientRequest.get("http://localhost:3000"),
+          new Response(body, {
+            status: 201,
+            headers: { "content-length": contentLength, "content-type": "text/plain", "x-test": "kept" }
+          })
+        )
+        const response = HttpServerResponse.fromClientResponse(clientResponse)
+        const roundTrip = HttpServerResponse.toWeb(response)
+
+        assert.strictEqual(yield* Effect.promise(() => roundTrip.text()), body)
+        assert.strictEqual(roundTrip.status, 201)
+        assert.strictEqual(roundTrip.headers.get("content-type"), "text/plain")
+        assert.strictEqual(roundTrip.headers.get("x-test"), "kept")
+        assert.strictEqual(roundTrip.headers.get("content-length"), contentLength)
+        assert.strictEqual(response.headers["content-length"], contentLength)
+        assert.deepInclude(response.body, { _tag: "Stream", contentLength: body.length })
+      }))
+  }
+
+  it.effect("fromWeb leaves an absent content-length absent through a Web round trip", () =>
+    Effect.gen(function*() {
+      const original = new Response("hello", { headers: { "content-type": "text/plain" } })
+      assert.isNull(original.headers.get("content-length"))
+
+      const response = HttpServerResponse.fromWeb(original)
+      const roundTrip = HttpServerResponse.toWeb(response)
+
+      assert.strictEqual(yield* Effect.promise(() => roundTrip.text()), "hello")
+      assert.isNull(roundTrip.headers.get("content-length"))
+      assert.notProperty(response.headers, "content-length")
+      assert.deepInclude(response.body, { _tag: "Stream", contentLength: undefined })
+    }))
+
+  it.effect("fromWeb preserves other metadata and body through a Web round trip", () =>
+    Effect.gen(function*() {
+      const response = HttpServerResponse.fromWeb(
+        new Response("hello", {
+          status: 201,
+          statusText: "Created",
+          headers: {
+            "content-length": "5",
+            "content-type": "text/plain",
+            "x-test": "kept",
+            "set-cookie": "session=123"
+          }
+        })
+      )
+      const roundTrip = HttpServerResponse.toWeb(response)
+
+      assert.strictEqual(roundTrip.status, 201)
+      assert.strictEqual(roundTrip.statusText, "Created")
+      assert.strictEqual(roundTrip.headers.get("content-type"), "text/plain")
+      assert.strictEqual(roundTrip.headers.get("x-test"), "kept")
+      assert.deepStrictEqual(roundTrip.headers.getSetCookie(), ["session=123"])
+      assert.strictEqual(response.cookies.cookies.session?.value, "123")
+      assert.notProperty(response.headers, "set-cookie")
+      assert.strictEqual(yield* Effect.promise(() => roundTrip.text()), "hello")
+    }))
+
   it.effect("fromClientResponse preserves status, headers, cookies, and json", () =>
     Effect.gen(function*() {
       const request = HttpClientRequest.get("http://localhost:3000/todos/1")


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`HttpServerResponse.fromWeb` attaches a Web body as a stream. `setBody` then derives the response's content headers from the stream metadata, which caused an existing `Content-Length` header to disappear.

Pass the header through the existing strict content-length parser and store the result in the stream metadata. Valid lengths survive the Web response round trip. Missing, malformed, and unsafe values remain omitted.

The regression test exercises the public `fromWeb` and `toWeb` conversion seam and checks both the body bytes and header.

## Verification

- `nix develop -c pnpm vitest run packages/effect/test/unstable/http/HttpServerResponse.test.ts`
- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`
- `git diff --check origin/main`

## Related

Closes #7680
Closes EFF-1057
