### PR TITLE
fix(RpcSerialization): retain falsy control IDs when decoding JSON-RPC

### DIFF
--- a/.changeset/rpc-falsy-control-ids.md
+++ b/.changeset/rpc-falsy-control-ids.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve zero and empty-string request IDs when decoding JSON-RPC acknowledgement and interruption messages, so valid correlation IDs are not discarded.

--- a/.changeset/rpc-falsy-control-ids.md
+++ b/.changeset/rpc-falsy-control-ids.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Preserve zero and empty-string request IDs when decoding JSON-RPC acknowledgement and interruption messages, so valid correlation IDs are not discarded.
+Preserve zero and empty-string request IDs in JSON-RPC control messages.

--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -306,7 +306,7 @@ function decodeJsonRpcMessage(decoded: JsonRpcMessage): RpcMessage.FromClientEnc
         | RpcMessage.FromServerEncoded["_tag"]
         | Exclude<RpcMessage.FromClientEncoded["_tag"], "Request">
       const requestId = (request as any).params?.requestId
-      return requestId ?
+      return requestId !== undefined ?
         {
           _tag: tag,
           requestId

--- a/packages/effect/test/rpc/RpcSerialization.test.ts
+++ b/packages/effect/test/rpc/RpcSerialization.test.ts
@@ -160,37 +160,23 @@ const uvarint = (value: number): Uint8Array => {
 }
 
 describe("RpcSerialization", () => {
-  for (
-    const [name, serialization] of Object.entries({
-      json: RpcSerialization.json,
-      ndjson: RpcSerialization.ndjson,
-      jsonRpc: RpcSerialization.jsonRpc(),
-      ndJsonRpc: RpcSerialization.ndJsonRpc()
+  it.each(
+    [
+      ["Ack", 0],
+      ["Ack", ""],
+      ["Interrupt", 0],
+      ["Interrupt", ""]
+    ] as const
+  )("jsonRpc preserves %s requestId %j", (_tag, requestId) => {
+    const parser = RpcSerialization.jsonRpc().makeUnsafe()
+    const encoded = JSON.stringify({
+      jsonrpc: "2.0",
+      method: `@effect/rpc/${_tag}`,
+      params: { requestId }
     })
-  ) {
-    describe(`${name} control messages`, () => {
-      for (const _tag of ["Ack", "Interrupt"] as const) {
-        it.each([0, "", 1, "0"])(`roundtrips ${_tag} with requestId %j`, (requestId) => {
-          const message: RpcMessage.AckEncoded | RpcMessage.InterruptEncoded = { _tag, requestId }
-          const parser = serialization.makeUnsafe()
-          const encoded = parser.encode(message)
 
-          assert(typeof encoded === "string")
-          assert.include(encoded, `"requestId":${JSON.stringify(requestId)}`)
-          assert.deepStrictEqual(parser.decode(encoded), [message])
-        })
-      }
-
-      it.each(["Ping", "Pong", "Eof"] as const)("roundtrips %s without a requestId", (_tag) => {
-        const message: RpcMessage.Ping | RpcMessage.Pong | RpcMessage.Eof = { _tag }
-        const parser = serialization.makeUnsafe()
-        const encoded = parser.encode(message)
-
-        assert(typeof encoded === "string")
-        assert.deepStrictEqual(parser.decode(encoded), [message])
-      })
-    })
-  }
+    assert.deepStrictEqual(parser.decode(encoded), [{ _tag, requestId }])
+  })
 
   describe.sequential("jsonRpc inherited properties", () => {
     afterEach(() => {

--- a/packages/effect/test/rpc/RpcSerialization.test.ts
+++ b/packages/effect/test/rpc/RpcSerialization.test.ts
@@ -160,6 +160,38 @@ const uvarint = (value: number): Uint8Array => {
 }
 
 describe("RpcSerialization", () => {
+  for (
+    const [name, serialization] of Object.entries({
+      json: RpcSerialization.json,
+      ndjson: RpcSerialization.ndjson,
+      jsonRpc: RpcSerialization.jsonRpc(),
+      ndJsonRpc: RpcSerialization.ndJsonRpc()
+    })
+  ) {
+    describe(`${name} control messages`, () => {
+      for (const _tag of ["Ack", "Interrupt"] as const) {
+        it.each([0, "", 1, "0"])(`roundtrips ${_tag} with requestId %j`, (requestId) => {
+          const message: RpcMessage.AckEncoded | RpcMessage.InterruptEncoded = { _tag, requestId }
+          const parser = serialization.makeUnsafe()
+          const encoded = parser.encode(message)
+
+          assert(typeof encoded === "string")
+          assert.include(encoded, `"requestId":${JSON.stringify(requestId)}`)
+          assert.deepStrictEqual(parser.decode(encoded), [message])
+        })
+      }
+
+      it.each(["Ping", "Pong", "Eof"] as const)("roundtrips %s without a requestId", (_tag) => {
+        const message: RpcMessage.Ping | RpcMessage.Pong | RpcMessage.Eof = { _tag }
+        const parser = serialization.makeUnsafe()
+        const encoded = parser.encode(message)
+
+        assert(typeof encoded === "string")
+        assert.deepStrictEqual(parser.decode(encoded), [message])
+      })
+    })
+  }
+
   describe.sequential("jsonRpc inherited properties", () => {
     afterEach(() => {
       delete objectPrototype["method"]


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

JSON-RPC decoding used a truthiness check for control-message request IDs. This dropped valid `0` and `""` IDs from Ack and Interrupt messages, breaking request correlation.

The decoder now checks for `undefined`, preserving both valid falsy values. A focused regression in `packages/effect/test/rpc/RpcSerialization.test.ts` covers both message tags and both IDs through the public JSON-RPC decoder.

## Verification

- `pnpm test --run packages/effect/test/rpc/RpcSerialization.test.ts` (37 passed)
- `pnpm lint-fix`
- `pnpm check`
- `git diff --check`

## Related

Closes #7682
Closes EFF-1058
