### PR TITLE
fix(cli): classify absent required variadic arguments as missing

### DIFF
--- a/.changeset/cli-variadic-absence-defaults.md
+++ b/.changeset/cli-variadic-absence-defaults.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix defaulted variadic arguments when omitted.

--- a/.changeset/cli-variadic-absence-defaults.md
+++ b/.changeset/cli-variadic-absence-defaults.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Report absent required variadic positional arguments as missing so optional and default combinators can handle them. Partially supplied lists below their minimum remain invalid.

--- a/.changeset/cli-variadic-absence-defaults.md
+++ b/.changeset/cli-variadic-absence-defaults.md
@@ -1,5 +1,0 @@
----
-"effect": patch
----
-
-Report absent required variadic positional arguments as missing so optional and default combinators can handle them. Partially supplied lists below their minimum remain invalid.

--- a/packages/effect/src/unstable/cli/Param.ts
+++ b/packages/effect/src/unstable/cli/Param.ts
@@ -2008,9 +2008,6 @@ const parsePositionalVariadic: <Kind extends ParamKind, A>(
   }
 
   if (count < minValue) {
-    if (count === 0) {
-      return yield* new CliError.MissingArgument({ argument: single.name })
-    }
     return yield* new CliError.InvalidValue({
       option: single.name,
       value: `${count} values`,

--- a/packages/effect/src/unstable/cli/Param.ts
+++ b/packages/effect/src/unstable/cli/Param.ts
@@ -2008,6 +2008,9 @@ const parsePositionalVariadic: <Kind extends ParamKind, A>(
   }
 
   if (count < minValue) {
+    if (count === 0) {
+      return yield* new CliError.MissingArgument({ argument: single.name })
+    }
     return yield* new CliError.InvalidValue({
       option: single.name,
       value: `${count} values`,

--- a/packages/effect/src/unstable/cli/Param.ts
+++ b/packages/effect/src/unstable/cli/Param.ts
@@ -2008,12 +2008,14 @@ const parsePositionalVariadic: <Kind extends ParamKind, A>(
   }
 
   if (count < minValue) {
-    return yield* new CliError.InvalidValue({
-      option: single.name,
-      value: `${count} values`,
-      expected: `at least ${minValue} value${minValue === 1 ? "" : "s"}`,
-      kind: single.kind
-    })
+    return yield* count === 0
+      ? new CliError.MissingArgument({ argument: single.name })
+      : new CliError.InvalidValue({
+        option: single.name,
+        value: `${count} values`,
+        expected: `at least ${minValue} value${minValue === 1 ? "" : "s"}`,
+        kind: single.kind
+      })
   }
 
   return [currentArgs, results] as const

--- a/packages/effect/test/unstable/cli/Param.test.ts
+++ b/packages/effect/test/unstable/cli/Param.test.ts
@@ -135,6 +135,109 @@ describe("Param", () => {
       }).pipe(Effect.provide(TestLayer)))
   })
 
+  describe("variadic defaults", () => {
+    it.effect("uses the default when a required variadic argument is omitted", () =>
+      Effect.gen(function*() {
+        const argument = Argument.string("files").pipe(
+          Argument.atLeast(1),
+          Argument.withDefault(["README.md"])
+        )
+
+        const result = yield* argument.parse({ flags: {}, arguments: [] })
+
+        assert.deepStrictEqual(result, [[], ["README.md"]])
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("returns MissingArgument when a required variadic argument is omitted", () =>
+      Effect.gen(function*() {
+        const argument = Argument.string("files").pipe(Argument.atLeast(1))
+
+        const error = yield* Effect.flip(argument.parse({ flags: {}, arguments: [] }))
+
+        assert.instanceOf(error, CliError.MissingArgument)
+        assert.strictEqual(error.argument, "files")
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("preserves provided variadic argument values instead of using the default", () =>
+      Effect.gen(function*() {
+        const argument = Argument.string("files").pipe(
+          Argument.atLeast(1),
+          Argument.withDefault(["README.md"])
+        )
+
+        const result = yield* argument.parse({ flags: {}, arguments: ["src.ts", "test.ts"] })
+
+        assert.deepStrictEqual(result, [[], ["src.ts", "test.ts"]])
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("uses the default when a required variadic flag is omitted", () =>
+      Effect.gen(function*() {
+        const flag = Flag.string("files").pipe(
+          Flag.atLeast(1),
+          Flag.withDefault(["README.md"])
+        )
+
+        const result = yield* flag.parse({ flags: {}, arguments: ["tail"] })
+
+        assert.deepStrictEqual(result, [["tail"], ["README.md"]])
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("preserves provided variadic flag values instead of using the default", () =>
+      Effect.gen(function*() {
+        const flag = Flag.string("files").pipe(
+          Flag.atLeast(1),
+          Flag.withDefault(["README.md"])
+        )
+
+        const result = yield* flag.parse({
+          flags: { files: ["src.ts", "test.ts"] },
+          arguments: ["tail"]
+        })
+
+        assert.deepStrictEqual(result, [["tail"], ["src.ts", "test.ts"]])
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("does not default a nonempty variadic argument below its minimum", () =>
+      Effect.gen(function*() {
+        const argument = Argument.string("files").pipe(
+          Argument.atLeast(2),
+          Argument.withDefault(["README.md", "LICENSE"])
+        )
+
+        const error = yield* Effect.flip(argument.parse({ flags: {}, arguments: ["src.ts"] }))
+
+        assert.instanceOf(error, CliError.InvalidValue)
+        assert.strictEqual(error.option, "files")
+        assert.strictEqual(error.value, "1 values")
+        assert.strictEqual(error.expected, "at least 2 values")
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("does not default a nonempty variadic flag below its minimum", () =>
+      Effect.gen(function*() {
+        const flag = Flag.string("files").pipe(
+          Flag.atLeast(2),
+          Flag.withDefault(["README.md", "LICENSE"])
+        )
+
+        const error = yield* Effect.flip(flag.parse({ flags: { files: ["src.ts"] }, arguments: [] }))
+
+        assert.instanceOf(error, CliError.InvalidValue)
+        assert.strictEqual(error.expected, "at least 2 values")
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("preserves the empty result when the variadic argument minimum is zero", () =>
+      Effect.gen(function*() {
+        const argument = Argument.string("files").pipe(
+          Argument.atLeast(0),
+          Argument.withDefault(["README.md"])
+        )
+
+        const result = yield* argument.parse({ flags: {}, arguments: [] })
+
+        assert.deepStrictEqual(result, [[], []])
+      }).pipe(Effect.provide(TestLayer)))
+  })
+
   describe("withFallbackPrompt", () => {
     it.effect("prompts for missing flag values and preserves remaining args", () =>
       Effect.gen(function*() {

--- a/packages/effect/test/unstable/cli/Param.test.ts
+++ b/packages/effect/test/unstable/cli/Param.test.ts
@@ -135,108 +135,17 @@ describe("Param", () => {
       }).pipe(Effect.provide(TestLayer)))
   })
 
-  describe("variadic defaults", () => {
-    it.effect("uses the default when a required variadic argument is omitted", () =>
-      Effect.gen(function*() {
-        const argument = Argument.string("files").pipe(
-          Argument.atLeast(1),
-          Argument.withDefault(["README.md"])
-        )
+  it.effect("uses the default when a required variadic argument is omitted", () =>
+    Effect.gen(function*() {
+      const argument = Argument.string("files").pipe(
+        Argument.atLeast(1),
+        Argument.withDefault(["README.md"])
+      )
 
-        const result = yield* argument.parse({ flags: {}, arguments: [] })
+      const result = yield* argument.parse({ flags: {}, arguments: [] })
 
-        assert.deepStrictEqual(result, [[], ["README.md"]])
-      }).pipe(Effect.provide(TestLayer)))
-
-    it.effect("returns MissingArgument when a required variadic argument is omitted", () =>
-      Effect.gen(function*() {
-        const argument = Argument.string("files").pipe(Argument.atLeast(1))
-
-        const error = yield* Effect.flip(argument.parse({ flags: {}, arguments: [] }))
-
-        assert.instanceOf(error, CliError.MissingArgument)
-        assert.strictEqual(error.argument, "files")
-      }).pipe(Effect.provide(TestLayer)))
-
-    it.effect("preserves provided variadic argument values instead of using the default", () =>
-      Effect.gen(function*() {
-        const argument = Argument.string("files").pipe(
-          Argument.atLeast(1),
-          Argument.withDefault(["README.md"])
-        )
-
-        const result = yield* argument.parse({ flags: {}, arguments: ["src.ts", "test.ts"] })
-
-        assert.deepStrictEqual(result, [[], ["src.ts", "test.ts"]])
-      }).pipe(Effect.provide(TestLayer)))
-
-    it.effect("uses the default when a required variadic flag is omitted", () =>
-      Effect.gen(function*() {
-        const flag = Flag.string("files").pipe(
-          Flag.atLeast(1),
-          Flag.withDefault(["README.md"])
-        )
-
-        const result = yield* flag.parse({ flags: {}, arguments: ["tail"] })
-
-        assert.deepStrictEqual(result, [["tail"], ["README.md"]])
-      }).pipe(Effect.provide(TestLayer)))
-
-    it.effect("preserves provided variadic flag values instead of using the default", () =>
-      Effect.gen(function*() {
-        const flag = Flag.string("files").pipe(
-          Flag.atLeast(1),
-          Flag.withDefault(["README.md"])
-        )
-
-        const result = yield* flag.parse({
-          flags: { files: ["src.ts", "test.ts"] },
-          arguments: ["tail"]
-        })
-
-        assert.deepStrictEqual(result, [["tail"], ["src.ts", "test.ts"]])
-      }).pipe(Effect.provide(TestLayer)))
-
-    it.effect("does not default a nonempty variadic argument below its minimum", () =>
-      Effect.gen(function*() {
-        const argument = Argument.string("files").pipe(
-          Argument.atLeast(2),
-          Argument.withDefault(["README.md", "LICENSE"])
-        )
-
-        const error = yield* Effect.flip(argument.parse({ flags: {}, arguments: ["src.ts"] }))
-
-        assert.instanceOf(error, CliError.InvalidValue)
-        assert.strictEqual(error.option, "files")
-        assert.strictEqual(error.value, "1 values")
-        assert.strictEqual(error.expected, "at least 2 values")
-      }).pipe(Effect.provide(TestLayer)))
-
-    it.effect("does not default a nonempty variadic flag below its minimum", () =>
-      Effect.gen(function*() {
-        const flag = Flag.string("files").pipe(
-          Flag.atLeast(2),
-          Flag.withDefault(["README.md", "LICENSE"])
-        )
-
-        const error = yield* Effect.flip(flag.parse({ flags: { files: ["src.ts"] }, arguments: [] }))
-
-        assert.instanceOf(error, CliError.InvalidValue)
-        assert.strictEqual(error.expected, "at least 2 values")
-      }).pipe(Effect.provide(TestLayer)))
-
-    it.effect("preserves the empty result when the variadic argument minimum is zero", () =>
-      Effect.gen(function*() {
-        const argument = Argument.string("files").pipe(
-          Argument.atLeast(0),
-          Argument.withDefault(["README.md"])
-        )
-
-        const result = yield* argument.parse({ flags: {}, arguments: [] })
-
-        assert.deepStrictEqual(result, [[], []])
-      }).pipe(Effect.provide(TestLayer)))
-  })
+      assert.deepStrictEqual(result, [[], ["README.md"]])
+    }).pipe(Effect.provide(TestLayer)))
 
   describe("withFallbackPrompt", () => {
     it.effect("prompts for missing flag values and preserves remaining args", () =>


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Treat an omitted required variadic positional argument as missing. This lets `Argument.withDefault` supply its default while keeping partially supplied lists below their minimum invalid.

## Verification

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/unstable/cli/Param.test.ts` (29 passed)
- `pnpm check`

## Related

Closes #7684
Closes EFF-1059
