### PR TITLE
fix(cli): allow optional wrappers around alternative flags

### DIFF
--- a/.changeset/cli-optional-alternative-flags.md
+++ b/.changeset/cli-optional-alternative-flags.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Allow optional alternative CLI flags.

--- a/packages/effect/src/unstable/cli/Param.ts
+++ b/packages/effect/src/unstable/cli/Param.ts
@@ -1273,8 +1273,6 @@ export const optional = <Kind extends ParamKind, A>(
   param: Param<Kind, A>
 ): Param<Kind, Option.Option<A>> => {
   const parse: Parse<Option.Option<A>> = Effect.fnUntraced(function*(args) {
-    getUnderlyingSingleOrThrow(param)
-
     return yield* param.parse(args).pipe(
       Effect.map(([leftover, value]) => [leftover, Option.some(value)] as const),
       // Catch both MissingOption (for flags) and MissingArgument (for positional arguments)

--- a/packages/effect/src/unstable/cli/Param.ts
+++ b/packages/effect/src/unstable/cli/Param.ts
@@ -1272,8 +1272,8 @@ export const mapTryCatch: {
 export const optional = <Kind extends ParamKind, A>(
   param: Param<Kind, A>
 ): Param<Kind, Option.Option<A>> => {
-  const parse: Parse<Option.Option<A>> = Effect.fnUntraced(function*(args) {
-    return yield* param.parse(args).pipe(
+  const parse: Parse<Option.Option<A>> = (args) =>
+    param.parse(args).pipe(
       Effect.map(([leftover, value]) => [leftover, Option.some(value)] as const),
       // Catch both MissingOption (for flags) and MissingArgument (for positional arguments)
       Effect.catchTags({
@@ -1281,7 +1281,6 @@ export const optional = <Kind extends ParamKind, A>(
         MissingArgument: () => Effect.succeed([args.arguments, Option.none()] as const)
       })
     )
-  })
   return Object.assign(Object.create(Proto), {
     _tag: "Optional",
     kind: param.kind,

--- a/packages/effect/test/unstable/cli/Param.test.ts
+++ b/packages/effect/test/unstable/cli/Param.test.ts
@@ -133,6 +133,18 @@ describe("Param", () => {
 
         assert.deepStrictEqual(value, Option.some(false))
       }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("supports alternative flags", () =>
+      Effect.gen(function*() {
+        const flag = Flag.string("config").pipe(
+          Flag.orElse(() => Flag.string("config-url")),
+          Flag.optional
+        )
+
+        const [, value] = yield* flag.parse({ flags: { config: ["config.json"] }, arguments: [] })
+
+        assert.deepStrictEqual(value, Option.some("config.json"))
+      }).pipe(Effect.provide(TestLayer)))
   })
 
   describe("withFallbackPrompt", () => {


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`Flag.optional` no longer rejects `Flag.orElse` parameter trees before parsing. `Flag.withDefault`, which delegates to `optional`, now supports alternative flags as well.

The fix removes a stale single-leaf assertion whose result was unused.

## Verification

- `pnpm test --run packages/effect/test/unstable/cli/Param.test.ts`
- `pnpm lint-fix`
- `pnpm check`

## Related

Closes #7686
Closes EFF-1060
