### PR TITLE
fix(HttpRouter): normalize prefix-removal metadata

### DIFF
--- a/.changeset/http-router-normalized-prefix.md
+++ b/.changeset/http-router-normalized-prefix.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Keep router prefix-removal metadata consistent with registered paths. Trailing-slash and root prefixes no longer remove an extra character from the URL seen by route handlers.

--- a/.changeset/http-router-normalized-prefix.md
+++ b/.changeset/http-router-normalized-prefix.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Keep router prefix-removal metadata consistent with registered paths. Trailing-slash and root prefixes no longer remove an extra character from the URL seen by route handlers.
+Normalize router prefixes before removing them from handler request URLs.

--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -163,6 +163,7 @@ export const make = Effect.gen(function*() {
   return HttpRouter.of({
     [TypeId]: TypeId,
     prefixed(this: HttpRouter, prefix: string) {
+      prefix = removeTrailingSlash(prefix as PathInput)
       return HttpRouter.of({
         ...this,
         prefixed: (newPrefix: string) => this.prefixed(prefixPath(prefix, newPrefix)),
@@ -748,7 +749,7 @@ export const prefixRoute: {
     ...self,
     path: prefixPath(self.path, prefix) as PathInput,
     prefix: Option.match(self.prefix, {
-      onNone: () => prefix as string,
+      onNone: () => removeTrailingSlash(prefix as PathInput),
       onSome: (existingPrefix) => prefixPath(existingPrefix, prefix) as string
     })
   }))

--- a/packages/effect/test/unstable/http/HttpRouter.test.ts
+++ b/packages/effect/test/unstable/http/HttpRouter.test.ts
@@ -1,69 +1,42 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Effect, Option } from "effect"
-import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpRouter, type HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 
 describe("HttpRouter", () => {
-  it.each(["/api", "/api/"])("prefixRoute stores the matched prefix for %s", (prefix) => {
+  it("normalizes the prefix stored by prefixRoute", () => {
     const route = HttpRouter.prefixRoute(
       HttpRouter.route("GET", "/users", HttpServerResponse.text("ok")),
-      prefix
+      "/api/"
     )
-    assert.strictEqual(route.path, "/api/users")
+
     assert.deepStrictEqual(route.prefix, Option.some("/api"))
   })
 
-  for (const registration of ["add", "addAll"] as const) {
-    describe(registration, () => {
-      for (
-        const { name, prefix, prefixes } of [
-          { name: "unprefixed root", prefixes: [], prefix: "" },
-          { name: "root prefix", prefixes: ["/"], prefix: "" },
-          { name: "normalized prefix", prefixes: ["/api"], prefix: "/api" },
-          { name: "trailing-slash prefix", prefixes: ["/api/"], prefix: "/api" },
-          { name: "normalized nested prefix", prefixes: ["/v1", "/api"], prefix: "/api/v1" },
-          { name: "trailing-slash nested prefix", prefixes: ["/v1/", "/api"], prefix: "/api/v1" }
-        ]
-      ) {
-        for (
-          const { params, path, searchParams, url } of [
-            { path: "/users", url: "/users?x=1", params: {}, searchParams: { x: "1" } },
-            {
-              path: "/users/:id",
-              url: "/users/alice%20smith?x=1&x=2&name=hello%20world",
-              params: { id: "alice smith" },
-              searchParams: { x: ["1", "2"], name: "hello world" }
-            }
-          ] as const
-        ) {
-          it.effect(`${name} preserves the local URL for ${path}`, () =>
-            Effect.gen(function*() {
-              const routes = HttpRouter.use((router) => {
-                for (const value of prefixes) {
-                  router = router.prefixed(value)
-                }
-                const respond = (request: HttpServerRequest.HttpServerRequest) =>
-                  Effect.gen(function*() {
-                    const params = yield* HttpRouter.params
-                    const searchParams = yield* HttpServerRequest.ParsedSearchParams
-                    return HttpServerResponse.jsonUnsafe({ url: request.url, params, searchParams })
-                  })
-                return registration === "add"
-                  ? router.add("GET", path, respond)
-                  : router.addAll([HttpRouter.route("GET", path, respond)])
-              })
-              const { handler } = yield* Effect.acquireRelease(
-                Effect.sync(() => HttpRouter.toWebHandler(routes, { disableLogger: true })),
-                ({ dispose }) => Effect.promise(dispose)
-              )
-              const response = yield* Effect.promise(() => handler(new Request(`http://localhost${prefix}${url}`)))
-              assert.strictEqual(response.status, 200)
-              const body = yield* Effect.promise(() => response.json())
-              assert.deepStrictEqual(body.params, params)
-              assert.deepStrictEqual(body.searchParams, searchParams)
-              assert.strictEqual(body.url, url)
-            }))
-        }
-      }
-    })
+  for (
+    const { prefix, requestUrl } of [
+      { prefix: "/", requestUrl: "/users" },
+      { prefix: "/api/", requestUrl: "/api/users" }
+    ]
+  ) {
+    it.effect(`preserves the local URL for the ${prefix} prefix`, () =>
+      Effect.gen(function*() {
+        const routes = HttpRouter.use((router) =>
+          router.prefixed(prefix).add("GET", "/users", (request: HttpServerRequest.HttpServerRequest) =>
+            Effect.succeed(HttpServerResponse.text(request.url)))
+        )
+        const body = yield* Effect.acquireUseRelease(
+          Effect.sync(() =>
+            HttpRouter.toWebHandler(routes, { disableLogger: true })
+          ),
+          ({ handler }) =>
+            Effect.flatMap(
+              Effect.promise(() => handler(new Request(`http://localhost${requestUrl}`))),
+              (response) => Effect.promise(() => response.text())
+            ),
+          ({ dispose }) => Effect.promise(dispose)
+        )
+
+        assert.strictEqual(body, "/users")
+      }))
   }
 })

--- a/packages/effect/test/unstable/http/HttpRouter.test.ts
+++ b/packages/effect/test/unstable/http/HttpRouter.test.ts
@@ -1,0 +1,69 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Option } from "effect"
+import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+
+describe("HttpRouter", () => {
+  it.each(["/api", "/api/"])("prefixRoute stores the matched prefix for %s", (prefix) => {
+    const route = HttpRouter.prefixRoute(
+      HttpRouter.route("GET", "/users", HttpServerResponse.text("ok")),
+      prefix
+    )
+    assert.strictEqual(route.path, "/api/users")
+    assert.deepStrictEqual(route.prefix, Option.some("/api"))
+  })
+
+  for (const registration of ["add", "addAll"] as const) {
+    describe(registration, () => {
+      for (
+        const { name, prefix, prefixes } of [
+          { name: "unprefixed root", prefixes: [], prefix: "" },
+          { name: "root prefix", prefixes: ["/"], prefix: "" },
+          { name: "normalized prefix", prefixes: ["/api"], prefix: "/api" },
+          { name: "trailing-slash prefix", prefixes: ["/api/"], prefix: "/api" },
+          { name: "normalized nested prefix", prefixes: ["/v1", "/api"], prefix: "/api/v1" },
+          { name: "trailing-slash nested prefix", prefixes: ["/v1/", "/api"], prefix: "/api/v1" }
+        ]
+      ) {
+        for (
+          const { params, path, searchParams, url } of [
+            { path: "/users", url: "/users?x=1", params: {}, searchParams: { x: "1" } },
+            {
+              path: "/users/:id",
+              url: "/users/alice%20smith?x=1&x=2&name=hello%20world",
+              params: { id: "alice smith" },
+              searchParams: { x: ["1", "2"], name: "hello world" }
+            }
+          ] as const
+        ) {
+          it.effect(`${name} preserves the local URL for ${path}`, () =>
+            Effect.gen(function*() {
+              const routes = HttpRouter.use((router) => {
+                for (const value of prefixes) {
+                  router = router.prefixed(value)
+                }
+                const respond = (request: HttpServerRequest.HttpServerRequest) =>
+                  Effect.gen(function*() {
+                    const params = yield* HttpRouter.params
+                    const searchParams = yield* HttpServerRequest.ParsedSearchParams
+                    return HttpServerResponse.jsonUnsafe({ url: request.url, params, searchParams })
+                  })
+                return registration === "add"
+                  ? router.add("GET", path, respond)
+                  : router.addAll([HttpRouter.route("GET", path, respond)])
+              })
+              const { handler } = yield* Effect.acquireRelease(
+                Effect.sync(() => HttpRouter.toWebHandler(routes, { disableLogger: true })),
+                ({ dispose }) => Effect.promise(dispose)
+              )
+              const response = yield* Effect.promise(() => handler(new Request(`http://localhost${prefix}${url}`)))
+              assert.strictEqual(response.status, 200)
+              const body = yield* Effect.promise(() => response.json())
+              assert.deepStrictEqual(body.params, params)
+              assert.deepStrictEqual(body.searchParams, searchParams)
+              assert.strictEqual(body.url, url)
+            }))
+        }
+      }
+    })
+  }
+})


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

### Why

A router prefixed with `/api/` registers `/api/users` correctly but removes one extra character from the handler's local URL. A root prefix `/` has the same problem: `/users` becomes `users` even though route matching succeeds.

### What changes

Normalize the stored removal prefix using the same trailing-slash rule as the registered path, in both `prefixed` and `prefixRoute`. `/api/` stores `/api`, while `/` stores an empty prefix. Nested prefix composition keeps its existing order.

### Scope

Two prefix-metadata corrections, three focused regression tests in the main `HttpRouter` test file, and an `effect` patch changeset. Matcher behavior is unchanged.

### Verification

Before the implementation, the focused suite failed all three regression tests with the expected prefix and local-URL mismatches. After the implementation, these commands pass:

```sh
pnpm lint-fix
pnpm test --run packages/effect/test/unstable/http/HttpRouter.test.ts
pnpm check
git diff --check
```

## Related

Closes #7688
Closes EFF-1061

## Audit

Runtime correctness audit; intended label: `audit`.
