### PR TITLE
fix(HttpStaticServer): ignore Range on non-GET requests

### DIFF
--- a/.changeset/fix-static-head-range.md
+++ b/.changeset/fix-static-head-range.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Ignore Range headers on non-GET requests in HttpStaticServer.

--- a/packages/effect/src/unstable/http/HttpStaticServer.ts
+++ b/packages/effect/src/unstable/http/HttpStaticServer.ts
@@ -114,7 +114,7 @@ export const make: (options: {
     fileSize?: number
   ) => Effect.Effect<HttpServerResponse.HttpServerResponse, HttpServerError.HttpServerError> = Effect.fnUntraced(
     function*(request, filePath, fileSize) {
-      const rangeHeader = request.headers["range"]
+      const rangeHeader = request.method === "GET" ? request.headers["range"] : undefined
       const shouldEvaluateConditionals = request.headers["if-none-match"] !== undefined ||
         request.headers["if-modified-since"] !== undefined
 

--- a/packages/effect/test/unstable/http/HttpStaticServer.test.ts
+++ b/packages/effect/test/unstable/http/HttpStaticServer.test.ts
@@ -1,0 +1,41 @@
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as FileSystem from "effect/FileSystem"
+import * as Layer from "effect/Layer"
+import * as Path from "effect/Path"
+import { HttpEffect, HttpPlatform, HttpServerResponse, HttpStaticServer } from "effect/unstable/http"
+
+const services = Layer.mergeAll(
+  Path.layer,
+  FileSystem.layerNoop({
+    stat: () => Effect.succeed({ type: "File", size: FileSystem.Size(10) } as FileSystem.File.Info)
+  }),
+  Layer.succeed(
+    HttpPlatform.HttpPlatform,
+    HttpPlatform.HttpPlatform.of({
+      platform: "web",
+      compression: { algorithms: new Set(), compressResponse: Effect.succeed },
+      fileResponse: () => Effect.succeed(HttpServerResponse.text("0123456789")),
+      fileWebResponse: () => Effect.die("unused")
+    })
+  )
+)
+
+describe("HttpStaticServer", () => {
+  it.effect("ignores Range on HEAD requests", () =>
+    Effect.gen(function*() {
+      const app = yield* HttpStaticServer.make({ root: "/root" })
+      const response = yield* Effect.promise(() =>
+        HttpEffect.toWebHandler(app)(
+          new Request("http://localhost/file.txt", {
+            method: "HEAD",
+            headers: { Range: "bytes=20-24" }
+          })
+        )
+      )
+
+      assert.strictEqual(response.status, 200)
+      assert.strictEqual(response.headers.get("content-length"), "10")
+      assert.strictEqual(response.headers.get("content-range"), null)
+    }).pipe(Effect.provide(services)))
+})


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`HttpStaticServer` now reads `Range` only for GET requests. A HEAD request with a Range header returns the full representation's metadata without a body instead of returning 206 or 416.

The regression test covers an unsatisfiable HEAD range, which previously returned 416, and verifies the 200 response with the full content length and no content range.

## Verification

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/unstable/http/HttpStaticServer.test.ts`
- `pnpm check`
- `git diff --check`

## Related

Closes #7690
Closes EFF-1062
