### PR TITLE
fix(HttpMiddleware): preserve existing CORS Vary dimensions

### DIFF
--- a/.changeset/fix-cors-vary.md
+++ b/.changeset/fix-cors-vary.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve existing Vary dimensions when CORS adds Origin, including wildcard variation and case-insensitive Origin membership, so caches retain the response's original selection constraints.

--- a/.changeset/fix-cors-vary.md
+++ b/.changeset/fix-cors-vary.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Preserve existing `Vary` values when CORS adds `Origin`.
+Fix `HttpMiddleware.cors` to preserve `Origin` and other required `Vary` dimensions.

--- a/.changeset/fix-cors-vary.md
+++ b/.changeset/fix-cors-vary.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Preserve existing Vary dimensions when CORS adds Origin, including wildcard variation and case-insensitive Origin membership, so caches retain the response's original selection constraints.
+Preserve existing `Vary` values when CORS adds `Origin`.

--- a/packages/effect/src/unstable/http/HttpMiddleware.ts
+++ b/packages/effect/src/unstable/http/HttpMiddleware.ts
@@ -341,7 +341,7 @@ export const cors = (options?: {
 
   const allowOrigin = typeof opts.allowedOrigins === "function" || opts.allowedOrigins.length > 1
     ? ((originHeader: string) => {
-      if (!isAllowedOrigin(originHeader)) return undefined
+      if (!isAllowedOrigin(originHeader)) return { vary: "Origin" }
       return {
         "access-control-allow-origin": originHeader,
         vary: "Origin"
@@ -403,28 +403,35 @@ export const cors = (options?: {
   const headersFromRequestOptions = (request: HttpServerRequest) => {
     const origin = request.headers["origin"]
     const accessControlRequestHeaders = request.headers["access-control-request-headers"]
-    return Headers.fromRecordUnsafe({
+    const headers = Headers.fromRecordUnsafe({
       ...allowOrigin(origin),
       ...allowCredentials,
       ...exposeHeaders,
       ...allowMethods,
-      ...allowHeaders(accessControlRequestHeaders),
       ...maxAge
     })
+    const accessControlHeaders = allowHeaders(accessControlRequestHeaders)
+    if (accessControlHeaders === undefined) return headers
+    const vary = accessControlHeaders["vary"]
+    return Headers.setAll(
+      headers,
+      vary === undefined
+        ? accessControlHeaders
+        : {
+          ...accessControlHeaders,
+          vary: compressionInternal.varyWith(headers, vary)
+        }
+    )
   }
 
   const preResponseHandler = (request: HttpServerRequest, response: HttpServerResponse) => {
-    let headers = headersFromRequest(request)
-    const vary = response.headers["vary"]
-    if (headers["vary"] !== undefined && vary !== undefined) {
-      const members = vary.split(",").map((member) => member.trim().toLowerCase())
-      headers = Headers.set(
-        headers,
-        "vary",
-        members.includes("*") || members.includes("origin") ? vary : `${vary}, Origin`
-      )
-    }
-    return Effect.succeed(Response.setHeaders(response, headers))
+    const headers = headersFromRequest(request)
+    return Effect.succeed(Response.setHeaders(
+      response,
+      headers["vary"] === undefined
+        ? headers
+        : Headers.set(headers, "vary", compressionInternal.varyWith(response.headers, "Origin"))
+    ))
   }
 
   return <E, R>(
@@ -577,8 +584,8 @@ export const compression = (
 }
 
 const withVary = (response: HttpServerResponse): HttpServerResponse => {
-  const vary = compressionInternal.varyAcceptEncoding(response.headers)
-  return vary === undefined ? response : Response.setHeader(response, "vary", vary)
+  const vary = compressionInternal.varyWith(response.headers, "Accept-Encoding")
+  return Response.setHeader(response, "vary", vary)
 }
 
 const defaultAlgorithms: ReadonlyArray<CompressionAlgorithm> = ["br", "gzip", "deflate"]

--- a/packages/effect/src/unstable/http/HttpMiddleware.ts
+++ b/packages/effect/src/unstable/http/HttpMiddleware.ts
@@ -340,7 +340,7 @@ export const cors = (options?: {
     : (origin: string) => (opts.allowedOrigins as ReadonlyArray<string>).includes(origin)
 
   const allowOrigin = typeof opts.allowedOrigins === "function" || opts.allowedOrigins.length > 1
-    ? ((originHeader: string) => {
+    ? ((originHeader: string): ReadonlyRecord<string, string> => {
       if (!isAllowedOrigin(originHeader)) return { vary: "Origin" }
       return {
         "access-control-allow-origin": originHeader,

--- a/packages/effect/src/unstable/http/HttpMiddleware.ts
+++ b/packages/effect/src/unstable/http/HttpMiddleware.ts
@@ -413,8 +413,19 @@ export const cors = (options?: {
     })
   }
 
-  const preResponseHandler = (request: HttpServerRequest, response: HttpServerResponse) =>
-    Effect.succeed(Response.setHeaders(response, headersFromRequest(request)))
+  const preResponseHandler = (request: HttpServerRequest, response: HttpServerResponse) => {
+    let headers = headersFromRequest(request)
+    const vary = response.headers["vary"]
+    if (headers["vary"] !== undefined && vary !== undefined) {
+      const members = vary.split(",").map((member) => member.trim().toLowerCase())
+      headers = Headers.set(
+        headers,
+        "vary",
+        members.includes("*") || members.includes("origin") ? vary : `${vary}, Origin`
+      )
+    }
+    return Effect.succeed(Response.setHeaders(response, headers))
+  }
 
   return <E, R>(
     httpApp: Effect.Effect<HttpServerResponse, E, R>

--- a/packages/effect/src/unstable/http/internal/compression.ts
+++ b/packages/effect/src/unstable/http/internal/compression.ts
@@ -7,15 +7,13 @@ import type { Compression, CompressionAlgorithm, CompressionOptions } from "../H
 import * as Response from "../HttpServerResponse.ts"
 
 /** @internal */
-export const varyAcceptEncoding = (headers: Headers.Headers): string | undefined => {
+export const varyWith = (headers: Headers.Headers, dimension: string): string => {
   const vary = headers["vary"]
   if (vary === undefined) {
-    return "Accept-Encoding"
+    return dimension
   }
   const members = vary.split(",").map((member) => member.trim().toLowerCase())
-  return members.includes("*") || members.includes("accept-encoding")
-    ? undefined
-    : `${vary}, Accept-Encoding`
+  return members.includes("*") || members.includes(dimension.toLowerCase()) ? vary : `${vary}, ${dimension}`
 }
 
 /** @internal */
@@ -26,10 +24,9 @@ export const wrapCompression = (impl: Compression): Compression => ({
       if (compressed === response) {
         return response
       }
-      const headers: Record<string, string> = { "content-encoding": algorithm }
-      const vary = varyAcceptEncoding(compressed.headers)
-      if (vary !== undefined) {
-        headers["vary"] = vary
+      const headers: Record<string, string> = {
+        "content-encoding": algorithm,
+        vary: varyWith(compressed.headers, "Accept-Encoding")
       }
       const etag = compressed.headers["etag"]
       if (etag !== undefined && !etag.startsWith("W/")) {

--- a/packages/effect/test/unstable/http/HttpMiddleware.test.ts
+++ b/packages/effect/test/unstable/http/HttpMiddleware.test.ts
@@ -55,6 +55,45 @@ describe("HttpMiddleware", () => {
         assert.strictEqual(response.headers.get("vary"), expected)
       }))
 
+    it.effect("preserves both Vary dimensions for preflight requests", () =>
+      Effect.gen(function*() {
+        const handler = HttpEffect.toWebHandler(
+          Effect.succeed(HttpServerResponse.empty()).pipe(HttpMiddleware.cors({
+            allowedOrigins: ["https://client.example", "https://other.example"]
+          }))
+        )
+        const response = yield* Effect.promise(() =>
+          handler(
+            new Request("http://localhost/", {
+              method: "OPTIONS",
+              headers: {
+                Origin: "https://client.example",
+                "Access-Control-Request-Headers": "X-Test"
+              }
+            })
+          )
+        )
+        const vary = response.headers.get("vary")?.split(",").map((member) => member.trim().toLowerCase()).sort()
+        assert.deepStrictEqual(vary, ["access-control-request-headers", "origin"])
+      }))
+
+    it.effect("varies by Origin when the request origin is rejected", () =>
+      Effect.gen(function*() {
+        const handler = HttpEffect.toWebHandler(
+          Effect.succeed(HttpServerResponse.empty()).pipe(HttpMiddleware.cors({
+            allowedOrigins: ["https://client.example", "https://other.example"]
+          }))
+        )
+        const response = yield* Effect.promise(() =>
+          handler(
+            new Request("http://localhost/", {
+              headers: { Origin: "https://rejected.example" }
+            })
+          )
+        )
+        assert.strictEqual(response.headers.get("vary"), "Origin")
+      }))
+
     it.effect("preserves Vary when allowing all origins", () =>
       Effect.gen(function*() {
         const handler = HttpEffect.toWebHandler(

--- a/packages/effect/test/unstable/http/HttpMiddleware.test.ts
+++ b/packages/effect/test/unstable/http/HttpMiddleware.test.ts
@@ -18,27 +18,22 @@ describe("HttpMiddleware", () => {
       {
         name: "adds Origin when Vary is absent",
         vary: undefined,
-        expected: ["origin"]
+        expected: "Origin"
       },
       {
         name: "preserves existing Vary dimensions when adding Origin",
         vary: "Accept-Language",
-        expected: ["accept-language", "origin"]
+        expected: "Accept-Language, Origin"
       },
       {
         name: "preserves other dimensions without duplicating a mixed-case Origin",
         vary: "Accept-Language, oRiGiN",
-        expected: ["accept-language", "origin"]
-      },
-      {
-        name: "does not duplicate an existing mixed-case Origin",
-        vary: "oRiGiN",
-        expected: ["origin"]
+        expected: "Accept-Language, oRiGiN"
       },
       {
         name: "preserves wildcard Vary",
         vary: "*",
-        expected: ["*"]
+        expected: "*"
       }
     ])("$name", ({ expected, vary }) =>
       Effect.gen(function*() {
@@ -56,16 +51,8 @@ describe("HttpMiddleware", () => {
             })
           )
         )
-        assert.strictEqual(response.status, 200)
         assert.strictEqual(response.headers.get("access-control-allow-origin"), "https://client.example")
-        assert.strictEqual(response.headers.get("content-length"), "5")
-        assert.strictEqual(yield* Effect.promise(() => response.text()), "hello")
-        const members = response.headers.get("vary")?.split(",").map((member) => member.trim().toLowerCase()) ?? []
-        if (vary === "*") {
-          assert.include(members, "*")
-        } else {
-          assert.deepStrictEqual(members.sort(), expected)
-        }
+        assert.strictEqual(response.headers.get("vary"), expected)
       }))
 
     it.effect("preserves Vary when allowing all origins", () =>
@@ -82,11 +69,8 @@ describe("HttpMiddleware", () => {
             })
           )
         )
-        assert.strictEqual(response.status, 200)
         assert.strictEqual(response.headers.get("access-control-allow-origin"), "*")
         assert.strictEqual(response.headers.get("vary"), "Accept-Language")
-        assert.strictEqual(response.headers.get("content-length"), "5")
-        assert.strictEqual(yield* Effect.promise(() => response.text()), "hello")
       }))
   })
 

--- a/packages/effect/test/unstable/http/HttpMiddleware.test.ts
+++ b/packages/effect/test/unstable/http/HttpMiddleware.test.ts
@@ -7,11 +7,89 @@ import * as Logger from "effect/Logger"
 import * as References from "effect/References"
 import * as Tracer from "effect/Tracer"
 import * as Headers from "effect/unstable/http/Headers"
+import * as HttpEffect from "effect/unstable/http/HttpEffect"
 import * as HttpMiddleware from "effect/unstable/http/HttpMiddleware"
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest"
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse"
 
 describe("HttpMiddleware", () => {
+  describe("cors", () => {
+    it.effect.each([
+      {
+        name: "adds Origin when Vary is absent",
+        vary: undefined,
+        expected: ["origin"]
+      },
+      {
+        name: "preserves existing Vary dimensions when adding Origin",
+        vary: "Accept-Language",
+        expected: ["accept-language", "origin"]
+      },
+      {
+        name: "preserves other dimensions without duplicating a mixed-case Origin",
+        vary: "Accept-Language, oRiGiN",
+        expected: ["accept-language", "origin"]
+      },
+      {
+        name: "does not duplicate an existing mixed-case Origin",
+        vary: "oRiGiN",
+        expected: ["origin"]
+      },
+      {
+        name: "preserves wildcard Vary",
+        vary: "*",
+        expected: ["*"]
+      }
+    ])("$name", ({ expected, vary }) =>
+      Effect.gen(function*() {
+        const handler = HttpEffect.toWebHandler(
+          Effect.succeed(HttpServerResponse.text("hello", {
+            headers: vary === undefined ? {} : { Vary: vary }
+          })).pipe(HttpMiddleware.cors({
+            allowedOrigins: ["https://client.example", "https://other.example"]
+          }))
+        )
+        const response = yield* Effect.promise(() =>
+          handler(
+            new Request("http://localhost/", {
+              headers: { Origin: "https://client.example" }
+            })
+          )
+        )
+        assert.strictEqual(response.status, 200)
+        assert.strictEqual(response.headers.get("access-control-allow-origin"), "https://client.example")
+        assert.strictEqual(response.headers.get("content-length"), "5")
+        assert.strictEqual(yield* Effect.promise(() => response.text()), "hello")
+        const members = response.headers.get("vary")?.split(",").map((member) => member.trim().toLowerCase()) ?? []
+        if (vary === "*") {
+          assert.include(members, "*")
+        } else {
+          assert.deepStrictEqual(members.sort(), expected)
+        }
+      }))
+
+    it.effect("preserves Vary when allowing all origins", () =>
+      Effect.gen(function*() {
+        const handler = HttpEffect.toWebHandler(
+          Effect.succeed(HttpServerResponse.text("hello", {
+            headers: { Vary: "Accept-Language" }
+          })).pipe(HttpMiddleware.cors())
+        )
+        const response = yield* Effect.promise(() =>
+          handler(
+            new Request("http://localhost/", {
+              headers: { Origin: "https://client.example" }
+            })
+          )
+        )
+        assert.strictEqual(response.status, 200)
+        assert.strictEqual(response.headers.get("access-control-allow-origin"), "*")
+        assert.strictEqual(response.headers.get("vary"), "Accept-Language")
+        assert.strictEqual(response.headers.get("content-length"), "5")
+        assert.strictEqual(yield* Effect.promise(() => response.text()), "hello")
+      }))
+  })
+
   describe("logger", () => {
     it.effect("annotates method, path, and status without query or hash", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

When CORS adds `Vary: Origin`, it currently replaces an existing `Vary` header. This loses cache-selection constraints such as `Accept-Language` and weakens `Vary: *` to `Vary: Origin`.

`HttpMiddleware.cors` now preserves the response's existing `Vary` dimensions, retains both `Origin` and `Access-Control-Request-Headers` on preflight responses, and emits `Vary: Origin` when an origin-dependent configuration rejects the request origin.

The shared `varyWith` helper handles case-insensitive membership and wildcard variation for both CORS and compression without duplicating the header-token logic.

Regression coverage lives in `packages/effect/test/unstable/http/HttpMiddleware.test.ts` and exercises the public web-handler path.

## Verification

- `nix develop -c deno check .`
- `nix develop -c pnpm vitest run packages/effect/test/unstable/http/HttpMiddleware.test.ts --project effect` (13 passed)
- `nix develop -c pnpm vitest run packages/effect/test/unstable/http --project effect` (461 passed)
- `nix develop -c pnpm lint`
- `nix develop -c pnpm check`
- `git diff --check`

## Related

Closes #7692
Closes EFF-1063
