### PR TITLE
fix(HttpApiSchema): clear stale metadata in encodeToWithHeaders

### DIFF
--- a/.changeset/fix-encoded-header-metadata.md
+++ b/.changeset/fix-encoded-header-metadata.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Use body status and encoding defaults in `HttpApiSchema.encodeToWithHeaders`.

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -735,8 +735,8 @@ export function encodeToWithHeaders<
       )
     ).annotate({
       "~httpApiWithHeaders": { body, headers, headersCodec: Schema.toEncoded(headers) },
-      ...(status !== undefined ? { httpApiStatus: status } : undefined),
-      ...(encoding !== undefined ? { "~httpApiEncoding": encoding } : undefined)
+      httpApiStatus: status,
+      "~httpApiEncoding": encoding
     })
   }
 }

--- a/packages/effect/test/unstable/httpapi/HttpApiSchema.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiSchema.test.ts
@@ -268,6 +268,28 @@ describe("HttpApiSchema", () => {
     it("defaults the response encoding to Json", () => {
       assert.strictEqual(HttpApiSchema.getResponseEncoding(WrappedUserNotFound.ast)._tag, "Json")
     })
+
+    it("uses the body defaults instead of source response metadata", () => {
+      const schema = Schema.String.pipe(
+        HttpApiSchema.status(429),
+        HttpApiSchema.asText(),
+        HttpApiSchema.encodeToWithHeaders({
+          body: Schema.String,
+          headers: { "x-note": Schema.String }
+        }, {
+          decode: ({ body }) => body,
+          encode: (body) => ({ body, headers: { "x-note": "test" } })
+        })
+      )
+
+      assert.deepStrictEqual({
+        status: HttpApiSchema.getStatusError(schema.ast),
+        encoding: HttpApiSchema.getResponseEncoding(schema.ast)
+      }, {
+        status: 500,
+        encoding: { _tag: "Json", contentType: "application/json" }
+      })
+    })
   })
 
   it("does not identify buffered schemas as stream schemas", () => {


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`encodeToWithHeaders` retained status and encoding annotations from its source schema when the body used defaults. This could make generated-client and OpenAPI metadata disagree with the server response.

The wrapper now writes the body's resolved annotations even when they are `undefined`, which clears stale source metadata and lets the existing response defaults apply. A regression test covers an error source annotated as 429/text with an unannotated string body; it now resolves to 500/JSON.

## Validation

```sh
pnpm lint-fix
pnpm check
pnpm test --run packages/effect/test/unstable/httpapi/HttpApiSchema.test.ts
```

Closes EFF-1064
Closes #7694
