### PR TITLE
fix(HttpApiBuilder): honor status annotations on stream wrappers

### DIFF
--- a/.changeset/fix-stream-wrapper-status.md
+++ b/.changeset/fix-stream-wrapper-status.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Honor status annotations on WithHeaders stream responses in HttpApiBuilder, preserving wrapper precedence and preventing response-header encoding failures when the wrapper and inner stream statuses differ.
+Fix `HttpApiBuilder` ignoring the status annotation on a `HttpApiSchema.WithHeaders` wrapper around a streaming success, which defected when the wrapper and inner statuses differed.

--- a/.changeset/fix-stream-wrapper-status.md
+++ b/.changeset/fix-stream-wrapper-status.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Honor status annotations on WithHeaders stream responses in HttpApiBuilder, preserving wrapper precedence and preventing response-header encoding failures when the wrapper and inner stream statuses differ.

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -971,13 +971,16 @@ function makeWithHeadersEncoder(endpoint: HttpApiEndpoint.Top): WithHeadersEncod
 }
 
 function makeStreamEncoder(endpoint: HttpApiEndpoint.Top): StreamEncoder | undefined {
-  const streamSchema = getStreamSuccessSchema(endpoint)
-  if (streamSchema === undefined) {
+  const successSchema = getStreamSuccessSchema(endpoint)
+  if (successSchema === undefined) {
     return undefined
   }
 
+  const streamSchema = successSchema.body
   const hasBuffered = hasBufferedSuccess(endpoint)
-  const status = HttpApiSchema.getStatusStream(streamSchema)
+  const status = HttpApiSchema.isWithHeaders(successSchema.schema)
+    ? HttpApiSchema.getStatusSuccessSchema(successSchema.schema)
+    : HttpApiSchema.getStatusStream(streamSchema)
   const contentType = streamSchema.contentType
 
   if (HttpApiSchema.isStreamUint8Array(streamSchema)) {
@@ -1021,7 +1024,7 @@ function getStreamSuccessSchema(endpoint: HttpApiEndpoint.Top) {
   for (const schema of endpoint.success) {
     const body = HttpApiSchema.isWithHeaders(schema) ? schema.schema : schema
     if (HttpApiSchema.isStreamSchema(body)) {
-      return body
+      return { schema, body }
     }
   }
 }

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -978,9 +978,7 @@ function makeStreamEncoder(endpoint: HttpApiEndpoint.Top): StreamEncoder | undef
 
   const streamSchema = successSchema.body
   const hasBuffered = hasBufferedSuccess(endpoint)
-  const status = HttpApiSchema.isWithHeaders(successSchema.schema)
-    ? HttpApiSchema.getStatusSuccessSchema(successSchema.schema)
-    : HttpApiSchema.getStatusStream(streamSchema)
+  const status = HttpApiSchema.getStatusSuccessSchema(successSchema.schema)
   const contentType = streamSchema.contentType
 
   if (HttpApiSchema.isStreamUint8Array(streamSchema)) {

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -997,11 +997,6 @@ export function getResponseEncodingSchema(schema: Schema.Constraint): ResponseEn
 }
 
 /** @internal */
-export function getStatusStream(self: StreamSchema): number {
-  return getStatusSuccess(self.ast)
-}
-
-/** @internal */
 export function getStatusError(self: SchemaAST.AST): number {
   return resolveHttpApiStatus(self) ?? 500
 }

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -790,6 +790,53 @@ it.layer(TestServices)("HttpApiBuilder WithHeaders responses", (it) => {
 })
 
 it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
+  for (
+    const [name, innerStatus, wrapperStatus, expectedStatus] of [
+      ["wrapper status", undefined, 206, 206],
+      ["wrapper overrides inner status", 201, 206, 206],
+      ["inner status control", 206, undefined, 206],
+      ["matching statuses control", 206, 206, 206],
+      ["default status control", undefined, undefined, 200]
+    ] as const
+  ) {
+    it.effect(`preserves WithHeaders stream status: ${name}`, () =>
+      Effect.gen(function*() {
+        const stream = HttpApiSchema.StreamUint8Array()
+        const wrapped = HttpApiSchema.WithHeaders(
+          innerStatus === undefined ? stream : stream.pipe(HttpApiSchema.status(innerStatus)),
+          { "x-note": Schema.String }
+        )
+        const success = wrapperStatus === undefined ? wrapped : wrapped.pipe(HttpApiSchema.status(wrapperStatus))
+        const Api = HttpApi.make("Api").add(
+          HttpApiGroup.make("test").add(HttpApiEndpoint.get("download", "/test", { success }))
+        )
+        const GroupLayer = HttpApiBuilder.group(
+          Api,
+          "test",
+          (handlers) =>
+            handlers.handle("download", () =>
+              Effect.succeed(HttpApiSchema.withHeaders({
+                body: Stream.make(new Uint8Array([1, 2])),
+                headers: { "x-note": "test" }
+              })))
+        )
+
+        const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
+        const response = yield* client.test.download({ responseMode: "response-only" })
+        const chunks = yield* Stream.runCollect(response.stream)
+
+        assert.strictEqual(response.status, expectedStatus)
+        assert.strictEqual(response.headers["content-type"], "application/octet-stream")
+        assert.strictEqual(response.headers["x-note"], "test")
+        assert.deepStrictEqual(Array.from(chunks, (chunk) => Array.from(chunk)), [[1, 2]])
+
+        const decoded = yield* client.test.download({})
+        const decodedChunks = yield* Stream.runCollect(decoded.body)
+        assert.deepStrictEqual(decoded.headers, { "x-note": "test" })
+        assert.deepStrictEqual(Array.from(decodedChunks, (chunk) => Array.from(chunk)), [[1, 2]])
+      }))
+  }
+
   it.effect("emits StreamUint8Array handler responses as streamed bytes with the declared content type", () =>
     Effect.gen(function*() {
       const Api = HttpApi.make("Api").add(

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -794,8 +794,6 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
     const [name, innerStatus, wrapperStatus, expectedStatus] of [
       ["wrapper status", undefined, 206, 206],
       ["wrapper overrides inner status", 201, 206, 206],
-      ["inner status control", 206, undefined, 206],
-      ["matching statuses control", 206, 206, 206],
       ["default status control", undefined, undefined, 200]
     ] as const
   ) {


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

A streaming success wrapped in `HttpApiSchema.WithHeaders` could defect when the wrapper declared a different status from the inner stream. Header encoders used the wrapper-aware status, while the stream encoder looked up the inner status.

The stream encoder now resolves status from the original success schema with `getStatusSuccessSchema`, matching the client and endpoint validation paths. The obsolete `getStatusStream` helper has been removed.

The regression coverage keeps the three distinct cases: wrapper-only status, wrapper overriding an inner status, and the default status.

## Verification

```sh
nix develop -c pnpm lint-fix
nix develop -c pnpm test --run packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
nix develop -c pnpm check
```

Focused result: 41 tests passed.

## Related

Closes #7696
Closes EFF-1065

## Audit

Runtime correctness audit; intended label: `audit`.
