### PR TITLE
fix(HttpApiClient): decode form-urlencoded responses through UrlParams

### DIFF
--- a/.changeset/fix-httpapi-form-responses.md
+++ b/.changeset/fix-httpapi-form-responses.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `HttpApiClient` decoding form-urlencoded responses.

--- a/.changeset/fix-httpapi-form-responses.md
+++ b/.changeset/fix-httpapi-form-responses.md
@@ -1,5 +1,0 @@
----
-"effect": patch
----
-
-Fix generated HTTP API clients decoding form-urlencoded success and error responses, preserving escaped values and repeated fields.

--- a/.changeset/fix-httpapi-form-responses.md
+++ b/.changeset/fix-httpapi-form-responses.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix generated HTTP API clients decoding form-urlencoded success and error responses, preserving escaped values and repeated fields.

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -1023,13 +1023,7 @@ function fromArrayBuffer(schema: Schema.Constraint): Schema.Top {
         : UnknownFromArrayBuffer
     }
     case "FormUrlEncoded":
-      return StringFromArrayBuffer.pipe(Schema.decodeTo(
-        Schema.RecordFromUrlParams,
-        SchemaTransformation.transform({
-          decode: (text) => UrlParams.fromInput(new URLSearchParams(text)),
-          encode: UrlParams.toString
-        })
-      ))
+      return StringFromArrayBuffer.pipe(Schema.decodeTo(Schema.RecordFromUrlParams))
     case "Uint8Array":
       return Uint8ArrayFromArrayBuffer
     case "Text":

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -1023,7 +1023,13 @@ function fromArrayBuffer(schema: Schema.Constraint): Schema.Top {
         : UnknownFromArrayBuffer
     }
     case "FormUrlEncoded":
-      return StringFromArrayBuffer.pipe(Schema.decodeTo(Schema.RecordFromUrlParams))
+      return StringFromArrayBuffer.pipe(Schema.decodeTo(
+        Schema.RecordFromUrlParams,
+        SchemaTransformation.transform({
+          decode: (text) => UrlParams.fromInput(new URLSearchParams(text)),
+          encode: UrlParams.toString
+        })
+      ))
     case "Uint8Array":
       return Uint8ArrayFromArrayBuffer
     case "Text":

--- a/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
@@ -423,6 +423,117 @@ describe("HttpApiClient", () => {
       }))
   })
 
+  describe("form responses", () => {
+    const Body = Schema.Struct({ name: Schema.String })
+    const Form = Body.pipe(HttpApiSchema.asFormUrlEncoded())
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("test").add(
+        HttpApiEndpoint.get("form", "/form", {
+          success: Form,
+          error: Form.pipe(HttpApiSchema.status(400))
+        }),
+        HttpApiEndpoint.get("json", "/json", {
+          success: Body,
+          error: Body.pipe(HttpApiSchema.status(400))
+        })
+      )
+    )
+
+    for (const status of [200, 400]) {
+      it.effect(`preserves escaping and repeated fields in a ${status} form response`, () =>
+        Effect.gen(function*() {
+          const Form = Schema.Struct({ name: Schema.String, tags: Schema.Array(Schema.String) }).pipe(
+            HttpApiSchema.asFormUrlEncoded()
+          )
+          const Api = HttpApi.make("Api").add(
+            HttpApiGroup.make("test").add(
+              HttpApiEndpoint.get("form", "/form", {
+                success: Form,
+                error: Form.pipe(HttpApiSchema.status(400))
+              })
+            )
+          )
+          const client = yield* HttpApiClient.makeWith(Api, {
+            baseUrl: "https://example.test",
+            httpClient: clientFromResponse(() =>
+              new Response("name=Ada+Lovelace&tags=a%2Fb&tags=100%25%2B", {
+                status,
+                headers: { "content-type": "application/x-www-form-urlencoded" }
+              })
+            )
+          })
+          const request = client.test.form({})
+          const value = yield* status === 200 ? request : Effect.flip(request)
+          assert.deepStrictEqual(value, { name: "Ada Lovelace", tags: ["a/b", "100%+"] })
+        }))
+
+      it.effect(`decodes a declared ${status} form response`, () =>
+        Effect.gen(function*() {
+          const client = yield* HttpApiClient.makeWith(Api, {
+            baseUrl: "https://example.test",
+            httpClient: clientFromResponse(() =>
+              new Response("name=Ada", {
+                status,
+                headers: { "content-type": "application/x-www-form-urlencoded" }
+              })
+            )
+          })
+
+          const request = client.test.form({})
+          const value = yield* status === 200 ? request : Effect.flip(request)
+          assert.deepStrictEqual(value, { name: "Ada" })
+        }))
+
+      it.effect(`decodes a declared ${status} JSON response`, () =>
+        Effect.gen(function*() {
+          const client = yield* HttpApiClient.makeWith(Api, {
+            baseUrl: "https://example.test",
+            httpClient: clientFromResponse(() =>
+              new Response(JSON.stringify({ name: "Ada" }), {
+                status,
+                headers: { "content-type": "application/json" }
+              })
+            )
+          })
+
+          const request = client.test.json({})
+          const value = yield* status === 200 ? request : Effect.flip(request)
+          assert.deepStrictEqual(value, { name: "Ada" })
+        }))
+
+      it.effect(`preserves a ${status} form response in response-only mode`, () =>
+        Effect.gen(function*() {
+          const client = yield* HttpApiClient.makeWith(Api, {
+            baseUrl: "https://example.test",
+            httpClient: clientFromResponse(() =>
+              new Response("name=Ada", {
+                status,
+                headers: { "content-type": "application/x-www-form-urlencoded" }
+              })
+            )
+          })
+
+          const response = yield* client.test.form({ responseMode: "response-only" })
+          assert.strictEqual(response.status, status)
+          assert.strictEqual(yield* response.text, "name=Ada")
+        }))
+    }
+
+    it.effect("decodes the same form body with schemaBodyUrlParams", () =>
+      Effect.gen(function*() {
+        const response = HttpClientResponse.fromWeb(
+          HttpClientRequest.get("https://example.test/form"),
+          new Response("name=Ada", {
+            status: 200,
+            headers: { "content-type": "application/x-www-form-urlencoded" }
+          })
+        )
+
+        const value = yield* HttpClientResponse.schemaBodyUrlParams(Body)(response)
+        assert.deepStrictEqual(value, { name: "Ada" })
+      }))
+  })
+
   describe("response headers", () => {
     it.effect("fails response decoding when a declared header is invalid", () =>
       Effect.gen(function*() {

--- a/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
@@ -423,116 +423,29 @@ describe("HttpApiClient", () => {
       }))
   })
 
-  describe("form responses", () => {
-    const Body = Schema.Struct({ name: Schema.String })
-    const Form = Body.pipe(HttpApiSchema.asFormUrlEncoded())
-    const Api = HttpApi.make("Api").add(
-      HttpApiGroup.make("test").add(
-        HttpApiEndpoint.get("form", "/form", {
-          success: Form,
-          error: Form.pipe(HttpApiSchema.status(400))
-        }),
-        HttpApiEndpoint.get("json", "/json", {
-          success: Body,
-          error: Body.pipe(HttpApiSchema.status(400))
-        })
+  it.effect("decodes form-urlencoded responses", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("form", "/form", {
+            success: Schema.Struct({ name: Schema.String }).pipe(HttpApiSchema.asFormUrlEncoded())
+          })
+        )
       )
-    )
-
-    for (const status of [200, 400]) {
-      it.effect(`preserves escaping and repeated fields in a ${status} form response`, () =>
-        Effect.gen(function*() {
-          const Form = Schema.Struct({ name: Schema.String, tags: Schema.Array(Schema.String) }).pipe(
-            HttpApiSchema.asFormUrlEncoded()
-          )
-          const Api = HttpApi.make("Api").add(
-            HttpApiGroup.make("test").add(
-              HttpApiEndpoint.get("form", "/form", {
-                success: Form,
-                error: Form.pipe(HttpApiSchema.status(400))
-              })
-            )
-          )
-          const client = yield* HttpApiClient.makeWith(Api, {
-            baseUrl: "https://example.test",
-            httpClient: clientFromResponse(() =>
-              new Response("name=Ada+Lovelace&tags=a%2Fb&tags=100%25%2B", {
-                status,
-                headers: { "content-type": "application/x-www-form-urlencoded" }
-              })
-            )
-          })
-          const request = client.test.form({})
-          const value = yield* status === 200 ? request : Effect.flip(request)
-          assert.deepStrictEqual(value, { name: "Ada Lovelace", tags: ["a/b", "100%+"] })
-        }))
-
-      it.effect(`decodes a declared ${status} form response`, () =>
-        Effect.gen(function*() {
-          const client = yield* HttpApiClient.makeWith(Api, {
-            baseUrl: "https://example.test",
-            httpClient: clientFromResponse(() =>
-              new Response("name=Ada", {
-                status,
-                headers: { "content-type": "application/x-www-form-urlencoded" }
-              })
-            )
-          })
-
-          const request = client.test.form({})
-          const value = yield* status === 200 ? request : Effect.flip(request)
-          assert.deepStrictEqual(value, { name: "Ada" })
-        }))
-
-      it.effect(`decodes a declared ${status} JSON response`, () =>
-        Effect.gen(function*() {
-          const client = yield* HttpApiClient.makeWith(Api, {
-            baseUrl: "https://example.test",
-            httpClient: clientFromResponse(() =>
-              new Response(JSON.stringify({ name: "Ada" }), {
-                status,
-                headers: { "content-type": "application/json" }
-              })
-            )
-          })
-
-          const request = client.test.json({})
-          const value = yield* status === 200 ? request : Effect.flip(request)
-          assert.deepStrictEqual(value, { name: "Ada" })
-        }))
-
-      it.effect(`preserves a ${status} form response in response-only mode`, () =>
-        Effect.gen(function*() {
-          const client = yield* HttpApiClient.makeWith(Api, {
-            baseUrl: "https://example.test",
-            httpClient: clientFromResponse(() =>
-              new Response("name=Ada", {
-                status,
-                headers: { "content-type": "application/x-www-form-urlencoded" }
-              })
-            )
-          })
-
-          const response = yield* client.test.form({ responseMode: "response-only" })
-          assert.strictEqual(response.status, status)
-          assert.strictEqual(yield* response.text, "name=Ada")
-        }))
-    }
-
-    it.effect("decodes the same form body with schemaBodyUrlParams", () =>
-      Effect.gen(function*() {
-        const response = HttpClientResponse.fromWeb(
-          HttpClientRequest.get("https://example.test/form"),
+      const client = yield* HttpApiClient.makeWith(Api, {
+        baseUrl: "https://example.test",
+        httpClient: clientFromResponse(() =>
           new Response("name=Ada", {
             status: 200,
             headers: { "content-type": "application/x-www-form-urlencoded" }
           })
         )
+      })
 
-        const value = yield* HttpClientResponse.schemaBodyUrlParams(Body)(response)
-        assert.deepStrictEqual(value, { name: "Ada" })
-      }))
-  })
+      const value = yield* client.test.form({})
+
+      assert.deepStrictEqual(value, { name: "Ada" })
+    }))
 
   describe("response headers", () => {
     it.effect("fails response decoding when a declared header is invalid", () =>


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Generated HTTP API clients passed form-urlencoded response text directly to `Schema.RecordFromUrlParams`, which expects `UrlParams`. The response codec now parses the text with `URLSearchParams` and `UrlParams.fromInput` first, matching the existing HTTP body parsing path.

The regression test exercises a generated client against a valid `application/x-www-form-urlencoded` response.

## Verification

```sh
nix develop -c pnpm lint-fix
nix develop -c pnpm test --run packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
nix develop -c pnpm check
```

## Related

Closes #7698
Closes EFF-1066

## Audit

Runtime correctness audit; intended label: `audit`.
