### PR TITLE
fix(HttpApiClient): preserve base paths in URL builders

### DIFF
--- a/.changeset/fix-httpapi-url-builder-base-path.md
+++ b/.changeset/fix-httpapi-url-builder-base-path.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `HttpApiClient.urlBuilder` dropping base URL pathnames.

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -687,9 +687,20 @@ export const urlBuilder = <Api extends HttpApi.Constraint>(api: Api, options?: {
         const queryInput = request?.query === undefined
           ? undefined
           : (encodeQuery === undefined ? request.query : encodeQuery(request.query)) as UrlParams.Input
-        const query = queryInput === undefined ? "" : UrlParams.toString(UrlParams.fromInput(queryInput))
-        const url = query === "" ? path : `${path}?${query}`
-        return options?.baseUrl === undefined ? url : new URL(url, options.baseUrl.toString()).toString()
+        const urlParams = queryInput === undefined ? UrlParams.empty : UrlParams.fromInput(queryInput)
+        if (options?.baseUrl === undefined) {
+          const query = UrlParams.toString(urlParams)
+          return query === "" ? path : `${path}?${query}`
+        }
+        const url = new URL(
+          HttpClientRequest.prependUrl(HttpClientRequest.get(path), options.baseUrl.toString()).url
+        )
+        for (const [key, value] of urlParams.params) {
+          if (value !== undefined) {
+            url.searchParams.append(key, value)
+          }
+        }
+        return url.toString()
       }
       InternalRecord.assignProperty(
         group.topLevel ? builder : builder[group.identifier],

--- a/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
@@ -502,6 +502,14 @@ describe("HttpApiClient", () => {
       )
     })
 
+    it("preserves a base URL pathname", () => {
+      const builder = HttpApiClient.urlBuilder(Api, {
+        baseUrl: "https://api.example.com/v1"
+      })
+
+      strictEqual(builder.users.health(), "https://api.example.com/v1/health")
+    })
+
     it("encodes path parameters", () => {
       const Api = HttpApi.make("Api")
         .add(


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`HttpApiClient.urlBuilder` dropped the pathname from `baseUrl` because endpoint paths begin with `/`. It now uses the same URL-prefix joining as generated clients before appending encoded query parameters.

With base `https://example.test/v1`, endpoint `/items` now builds as `https://example.test/v1/items`.

## Verification

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/effect/test/unstable/httpapi/HttpApiClient.test.ts`
- `nix develop -c pnpm check`

Closes EFF-1067
Closes #7700
