### PR TITLE
fix(OpenApi): populate schemas before endpoint transforms

### DIFF
--- a/.changeset/fix-openapi-endpoint-transform-order.md
+++ b/.changeset/fix-openapi-endpoint-transform-order.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Apply endpoint OpenAPI overrides and transforms after schemas are generated, so reordering or removing parameters preserves their schemas and customizations. Endpoint transforms still run after endpoint overrides and before API-level transforms.
+Apply endpoint OpenAPI overrides and transforms after schema generation.

--- a/.changeset/fix-openapi-endpoint-transform-order.md
+++ b/.changeset/fix-openapi-endpoint-transform-order.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Apply endpoint OpenAPI overrides and transforms after schemas are generated, so reordering or removing parameters preserves their schemas and customizations. Endpoint transforms still run after endpoint overrides and before API-level transforms.

--- a/packages/effect/src/unstable/httpapi/OpenApi.ts
+++ b/packages/effect/src/unstable/httpapi/OpenApi.ts
@@ -329,6 +329,7 @@ function makeOpenApi<Id extends string, Groups extends HttpApiGroup.Constraint>(
   > = []
   const pathOperations = new Set<string>()
   const operationIds = new Set<string>()
+  const finalizeOperations: Array<() => void> = []
 
   processAnnotation(api.annotations, Title, (title) => {
     spec.info.title = title
@@ -379,7 +380,7 @@ function makeOpenApi<Id extends string, Groups extends HttpApiGroup.Constraint>(
       if (Context.get(mergedAnnotations, Exclude)) {
         return
       }
-      let op: OpenAPISpecOperation = {
+      const op: OpenAPISpecOperation = {
         tags: [Context.getOrElse(group.annotations, Title, () => group.identifier)],
         operationId: Context.getOrElse(
           endpoint.annotations,
@@ -619,32 +620,35 @@ function makeOpenApi<Id extends string, Groups extends HttpApiGroup.Constraint>(
         () => "Error"
       )
 
-      processAnnotation(endpoint.annotations, Override, (override) => {
-        // OpenAPI documents are JSON, so symbol keys are intentionally ignored.
-        for (const [key, value] of Object.entries(override)) {
-          InternalRecord.assignProperty(op as any, key, value)
-        }
-      })
-      processAnnotation(endpoint.annotations, Transform, (transformFn) => {
-        op = transformFn(op) as OpenAPISpecOperation
-      })
-
       const pathOperation = `${method} ${path.replace(/\{[^}]+\}/g, "{}")}`
       if (pathOperations.has(pathOperation)) {
         throw new globalThis.Error(`Duplicate OpenAPI operation for ${endpoint.method} ${path}`)
-      }
-      const operationId = op.operationId
-      if (operationId !== undefined) {
-        if (operationIds.has(operationId)) {
-          throw new globalThis.Error(`Duplicate OpenAPI operationId: ${operationId}`)
-        }
-        operationIds.add(operationId)
       }
       pathOperations.add(pathOperation)
       if (!Object.hasOwn(spec.paths, path)) {
         InternalRecord.assignProperty(spec.paths, path, {})
       }
       spec.paths[path][method] = op
+      finalizeOperations.push(() => {
+        let op = spec.paths[path][method]!
+        processAnnotation(endpoint.annotations, Override, (override) => {
+          // OpenAPI documents are JSON, so symbol keys are intentionally ignored.
+          for (const [key, value] of Object.entries(override)) {
+            InternalRecord.assignProperty(op as any, key, value)
+          }
+        })
+        processAnnotation(endpoint.annotations, Transform, (transformFn) => {
+          op = transformFn(op) as OpenAPISpecOperation
+        })
+        const operationId = op.operationId
+        if (operationId !== undefined) {
+          if (operationIds.has(operationId)) {
+            throw new globalThis.Error(`Duplicate OpenAPI operationId: ${operationId}`)
+          }
+          operationIds.add(operationId)
+        }
+        spec.paths[path][method] = op
+      })
     }
   })
 
@@ -697,6 +701,10 @@ function makeOpenApi<Id extends string, Groups extends HttpApiGroup.Constraint>(
     })
 
     spec = JsonPatch.apply(patchOps, spec as any) as any
+  }
+
+  for (const finalize of finalizeOperations) {
+    finalize()
   }
 
   Object.keys(spec.components.schemas).forEach((key) => {

--- a/packages/effect/test/unstable/httpapi/OpenApi.test.ts
+++ b/packages/effect/test/unstable/httpapi/OpenApi.test.ts
@@ -70,6 +70,110 @@ const makeSecurityApi = (
   )
 
 describe("OpenApi", () => {
+  describe("parameter transforms", () => {
+    const endpoint = HttpApiEndpoint.get("list", "/list", {
+      query: { first: Schema.Literal("first"), second: Schema.Literal("second") }
+    })
+    const reverseParameters = (operation: Record<string, any>) => ({
+      ...operation,
+      parameters: [...operation.parameters].reverse()
+    })
+    const expected: Array<OpenApi.OpenAPISpecParameter> = [
+      { name: "first", in: "query", required: true, schema: { type: "string", enum: ["first"] } },
+      { name: "second", in: "query", required: true, schema: { type: "string", enum: ["second"] } }
+    ]
+
+    it("preserves parameter schemas without a transform", () => {
+      const Api = HttpApi.make("Api").add(HttpApiGroup.make("test").add(endpoint))
+
+      assert.deepStrictEqual(OpenApi.fromApi(Api).paths["/list"]?.get?.parameters, expected)
+    })
+
+    it("preserves parameter schemas when an endpoint transform reverses parameters", () => {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(endpoint.annotate(OpenApi.Transform, reverseParameters))
+      )
+
+      assert.deepStrictEqual(OpenApi.fromApi(Api).paths["/list"]?.get?.parameters, [...expected].reverse())
+    })
+
+    it("preserves parameter schemas when an API transform reverses parameters", () => {
+      const Api = HttpApi.make("Api").add(HttpApiGroup.make("test").add(endpoint)).annotate(
+        OpenApi.Transform,
+        (spec) => ({
+          ...spec,
+          paths: { ...spec.paths, "/list": { get: reverseParameters(spec.paths["/list"].get) } }
+        })
+      )
+
+      assert.deepStrictEqual(OpenApi.fromApi(Api).paths["/list"]?.get?.parameters, [...expected].reverse())
+    })
+
+    it("applies endpoint overrides before the transform", () => {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          endpoint.annotate(OpenApi.Override, { operationId: "overridden", summary: "fixture" }).annotate(
+            OpenApi.Transform,
+            (operation) => ({ ...operation, operationId: `${operation.operationId}.transformed` })
+          )
+        )
+      )
+      const operation = OpenApi.fromApi(Api).paths["/list"]?.get
+
+      assert.strictEqual(operation?.operationId, "overridden.transformed")
+      assert.strictEqual(operation?.summary, "fixture")
+      assert.deepStrictEqual(operation?.parameters, expected)
+    })
+
+    it("rejects duplicate operation identifiers introduced by endpoint transforms", () => {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          endpoint.annotate(OpenApi.Transform, (operation) => ({ ...operation, operationId: "shared" })),
+          HttpApiEndpoint.get("other", "/other").annotate(OpenApi.Identifier, "shared")
+        )
+      )
+
+      assert.throws(() => OpenApi.fromApi(Api), /Duplicate OpenAPI operationId: shared/)
+    })
+
+    it("allows endpoint overrides to remove generated parameters", () => {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          endpoint.annotate(OpenApi.Override, { parameters: [] }).annotate(OpenApi.Transform, (operation) => {
+            assert.deepStrictEqual(operation.parameters, [])
+            return operation
+          })
+        )
+      )
+
+      assert.deepStrictEqual(OpenApi.fromApi(Api).paths["/list"]?.get?.parameters, [])
+    })
+
+    it("finalizes endpoint transforms in declaration order before the API transform", () => {
+      const calls: Array<string> = []
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          endpoint.annotate(OpenApi.Transform, (operation) => {
+            calls.push("list")
+            assert.deepStrictEqual(operation.parameters, expected)
+            return reverseParameters(operation)
+          }),
+          HttpApiEndpoint.get("other", "/other").annotate(OpenApi.Transform, (operation) => {
+            calls.push("other")
+            return operation
+          })
+        )
+      ).annotate(OpenApi.Transform, (spec) => {
+        calls.push("api")
+        assert.deepStrictEqual(spec.paths["/list"].get.parameters, [...expected].reverse())
+        return spec
+      })
+
+      OpenApi.fromApi(Api)
+      assert.deepStrictEqual(calls, ["list", "other", "api"])
+    })
+  })
+
   it("returns fresh spec instances when using the cache", () => {
     const Api = HttpApi.make("Api").add(
       HttpApiGroup.make("test").add(

--- a/packages/effect/test/unstable/httpapi/OpenApi.test.ts
+++ b/packages/effect/test/unstable/httpapi/OpenApi.test.ts
@@ -70,108 +70,22 @@ const makeSecurityApi = (
   )
 
 describe("OpenApi", () => {
-  describe("parameter transforms", () => {
-    const endpoint = HttpApiEndpoint.get("list", "/list", {
-      query: { first: Schema.Literal("first"), second: Schema.Literal("second") }
-    })
-    const reverseParameters = (operation: Record<string, any>) => ({
-      ...operation,
-      parameters: [...operation.parameters].reverse()
-    })
-    const expected: Array<OpenApi.OpenAPISpecParameter> = [
-      { name: "first", in: "query", required: true, schema: { type: "string", enum: ["first"] } },
-      { name: "second", in: "query", required: true, schema: { type: "string", enum: ["second"] } }
-    ]
-
-    it("preserves parameter schemas without a transform", () => {
-      const Api = HttpApi.make("Api").add(HttpApiGroup.make("test").add(endpoint))
-
-      assert.deepStrictEqual(OpenApi.fromApi(Api).paths["/list"]?.get?.parameters, expected)
-    })
-
-    it("preserves parameter schemas when an endpoint transform reverses parameters", () => {
-      const Api = HttpApi.make("Api").add(
-        HttpApiGroup.make("test").add(endpoint.annotate(OpenApi.Transform, reverseParameters))
+  it("preserves parameter schemas when an endpoint transform reorders parameters", () => {
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("test").add(
+        HttpApiEndpoint.get("list", "/list", {
+          query: { first: Schema.Literal("first"), second: Schema.Literal("second") }
+        }).annotate(OpenApi.Transform, (operation: Record<string, any>) => ({
+          ...operation,
+          parameters: [...operation.parameters].reverse()
+        }))
       )
+    )
 
-      assert.deepStrictEqual(OpenApi.fromApi(Api).paths["/list"]?.get?.parameters, [...expected].reverse())
-    })
-
-    it("preserves parameter schemas when an API transform reverses parameters", () => {
-      const Api = HttpApi.make("Api").add(HttpApiGroup.make("test").add(endpoint)).annotate(
-        OpenApi.Transform,
-        (spec) => ({
-          ...spec,
-          paths: { ...spec.paths, "/list": { get: reverseParameters(spec.paths["/list"].get) } }
-        })
-      )
-
-      assert.deepStrictEqual(OpenApi.fromApi(Api).paths["/list"]?.get?.parameters, [...expected].reverse())
-    })
-
-    it("applies endpoint overrides before the transform", () => {
-      const Api = HttpApi.make("Api").add(
-        HttpApiGroup.make("test").add(
-          endpoint.annotate(OpenApi.Override, { operationId: "overridden", summary: "fixture" }).annotate(
-            OpenApi.Transform,
-            (operation) => ({ ...operation, operationId: `${operation.operationId}.transformed` })
-          )
-        )
-      )
-      const operation = OpenApi.fromApi(Api).paths["/list"]?.get
-
-      assert.strictEqual(operation?.operationId, "overridden.transformed")
-      assert.strictEqual(operation?.summary, "fixture")
-      assert.deepStrictEqual(operation?.parameters, expected)
-    })
-
-    it("rejects duplicate operation identifiers introduced by endpoint transforms", () => {
-      const Api = HttpApi.make("Api").add(
-        HttpApiGroup.make("test").add(
-          endpoint.annotate(OpenApi.Transform, (operation) => ({ ...operation, operationId: "shared" })),
-          HttpApiEndpoint.get("other", "/other").annotate(OpenApi.Identifier, "shared")
-        )
-      )
-
-      assert.throws(() => OpenApi.fromApi(Api), /Duplicate OpenAPI operationId: shared/)
-    })
-
-    it("allows endpoint overrides to remove generated parameters", () => {
-      const Api = HttpApi.make("Api").add(
-        HttpApiGroup.make("test").add(
-          endpoint.annotate(OpenApi.Override, { parameters: [] }).annotate(OpenApi.Transform, (operation) => {
-            assert.deepStrictEqual(operation.parameters, [])
-            return operation
-          })
-        )
-      )
-
-      assert.deepStrictEqual(OpenApi.fromApi(Api).paths["/list"]?.get?.parameters, [])
-    })
-
-    it("finalizes endpoint transforms in declaration order before the API transform", () => {
-      const calls: Array<string> = []
-      const Api = HttpApi.make("Api").add(
-        HttpApiGroup.make("test").add(
-          endpoint.annotate(OpenApi.Transform, (operation) => {
-            calls.push("list")
-            assert.deepStrictEqual(operation.parameters, expected)
-            return reverseParameters(operation)
-          }),
-          HttpApiEndpoint.get("other", "/other").annotate(OpenApi.Transform, (operation) => {
-            calls.push("other")
-            return operation
-          })
-        )
-      ).annotate(OpenApi.Transform, (spec) => {
-        calls.push("api")
-        assert.deepStrictEqual(spec.paths["/list"].get.parameters, [...expected].reverse())
-        return spec
-      })
-
-      OpenApi.fromApi(Api)
-      assert.deepStrictEqual(calls, ["list", "other", "api"])
-    })
+    assert.deepStrictEqual(OpenApi.fromApi(Api).paths["/list"]?.get?.parameters, [
+      { name: "second", in: "query", required: true, schema: { type: "string", enum: ["second"] } },
+      { name: "first", in: "query", required: true, schema: { type: "string", enum: ["first"] } }
+    ])
   })
 
   it("returns fresh spec instances when using the cache", () => {


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Endpoint `OpenApi.Transform` annotations previously ran before deferred schema patches. Reordering two query parameters therefore left each parameter name paired with the other parameter's schema.

Generate and patch schemas first, then apply endpoint overrides and transforms. Overrides still precede endpoint transforms, and API-level transforms still run last.

The regression test reverses two query parameters through the public `OpenApi.fromApi` interface and verifies that each transformed parameter retains its own literal schema.

## Verification

```sh
pnpm lint-fix
pnpm test --run packages/effect/test/unstable/httpapi/OpenApi.test.ts
pnpm check
git diff --check origin/main...HEAD
```

The focused suite passes 27 tests.

## Related

Closes #7702
Closes EFF-1068
