### PR TITLE
fix(HttpApiTest): run registered pre-response handlers

### DIFF
--- a/.changeset/fix-httpapi-test-pre-response-handlers.md
+++ b/.changeset/fix-httpapi-test-pre-response-handlers.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Run registered pre-response handlers in `HttpApiTest` before returning responses, so hook-added headers and cookies are visible to the test client. Handler defects continue to propagate rather than becoming HTTP 500 responses.
+Run registered pre-response handlers before `HttpApiTest` returns responses.

--- a/.changeset/fix-httpapi-test-pre-response-handlers.md
+++ b/.changeset/fix-httpapi-test-pre-response-handlers.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Run registered pre-response handlers in `HttpApiTest` before returning responses, so hook-added headers and cookies are visible to the test client. Handler defects continue to propagate rather than becoming HTTP 500 responses.

--- a/packages/effect/src/unstable/httpapi/HttpApiTest.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiTest.ts
@@ -20,6 +20,7 @@ import type { HttpPlatform } from "../http/HttpPlatform.ts"
 import * as HttpRouter from "../http/HttpRouter.ts"
 import * as HttpServerRequest from "../http/HttpServerRequest.ts"
 import * as HttpServerResponse from "../http/HttpServerResponse.ts"
+import * as preResponseHandler from "../http/internal/preResponseHandler.ts"
 import type * as HttpApi from "./HttpApi.ts"
 import type { HandlerRuntime } from "./HttpApiBuilder.ts"
 import * as HttpApiBuilder from "./HttpApiBuilder.ts"
@@ -100,6 +101,10 @@ export const groups = Effect.fnUntraced(function*<
   const httpClient = HttpClient.make(Effect.fnUntraced(function*(request) {
     const serverRequest = HttpServerRequest.fromClientRequest(request)
     const response = yield* handler.pipe(
+      Effect.flatMap((response) => {
+        const preResponse = preResponseHandler.requestPreResponseHandlers.get(serverRequest.source)
+        return preResponse === undefined ? Effect.succeed(response) : preResponse(serverRequest, response)
+      }),
       Effect.provideService(HttpServerRequest.HttpServerRequest, serverRequest),
       Effect.orDie
     )

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -11,7 +11,7 @@ import {
   SchemaTransformation,
   Stream
 } from "effect"
-import { Etag, HttpPlatform } from "effect/unstable/http"
+import { Etag, HttpEffect, HttpPlatform, HttpRouter, HttpServerResponse } from "effect/unstable/http"
 import {
   HttpApi,
   HttpApiBuilder,
@@ -32,6 +32,145 @@ const TestServices = Layer.mergeAll(
   Etag.layerWeak,
   HttpPlatform.layer
 ).pipe(Layer.provideMerge(FileSystem.layerNoop({})))
+
+it.layer(TestServices)("HttpApiTest pre-response handlers", (it) => {
+  for (const transport of ["test client", "Web handler"] as const) {
+    it.effect(`runs registered pre-response handlers through the ${transport}`, () =>
+      Effect.gen(function*() {
+        const Api = HttpApi.make("Api").add(
+          HttpApiGroup.make("test").add(
+            HttpApiEndpoint.get("get", "/fixture", { success: Schema.String.pipe(HttpApiSchema.asText()) })
+          )
+        )
+        let calls = 0
+        const GroupLayer = HttpApiBuilder.group(Api, "test", (handlers) =>
+          handlers.handle("get", () =>
+            Effect.gen(function*() {
+              yield* HttpEffect.appendPreResponseHandler((_request, response) =>
+                Effect.sync(() => {
+                  calls++
+                  return HttpServerResponse.setHeader(response, "x-fixture", "present")
+                })
+              )
+              return "ok"
+            })))
+
+        let header: string | null | undefined
+        if (transport === "test client") {
+          const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
+          const response = yield* client.test.get({ responseMode: "response-only" })
+          assert.strictEqual(response.status, 200)
+          assert.strictEqual(yield* response.text, "ok")
+          header = response.headers["x-fixture"]
+        } else {
+          const { handler } = yield* Effect.acquireRelease(
+            Effect.sync(() =>
+              HttpRouter.toWebHandler(
+                HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer), Layer.provide(TestServices)),
+                { disableLogger: true }
+              )
+            ),
+            ({ dispose }) =>
+              Effect.promise(dispose)
+          )
+          const response = yield* Effect.promise(() =>
+            handler(new Request("http://localhost/fixture"))
+          )
+          assert.strictEqual(response.status, 200)
+          assert.strictEqual(yield* Effect.promise(() => response.text()), "ok")
+          header = response.headers.get("x-fixture")
+        }
+
+        assert.deepStrictEqual({ header, calls }, { header: "present", calls: 1 })
+      }))
+  }
+
+  it.effect("preserves headers set directly on the response", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("get", "/fixture", { success: Schema.String.pipe(HttpApiSchema.asText()) })
+        )
+      )
+      const GroupLayer = HttpApiBuilder.group(Api, "test", (handlers) =>
+        handlers.handle("get", () =>
+          Effect.succeed(HttpServerResponse.text("ok", { headers: { "x-fixture": "present" } }))))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
+      const response = yield* client.test.get({ responseMode: "response-only" })
+
+      assert.strictEqual(response.status, 200)
+      assert.strictEqual(response.headers["x-fixture"], "present")
+      assert.strictEqual(yield* response.text, "ok")
+    }))
+
+  it.effect("preserves handler defects rather than converting them to HTTP responses", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(HttpApiEndpoint.get("get", "/fixture"))
+      )
+      const defect = new Error("fixture defect")
+      const GroupLayer = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) => handlers.handle("get", () => Effect.die(defect))
+      )
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
+      const exit = yield* Effect.exit(client.test.get({ responseMode: "response-only" }))
+
+      assert.strictEqual(exit._tag, "Failure")
+      if (exit._tag === "Failure") {
+        assert.strictEqual(Cause.squash(exit.cause), defect)
+      }
+    }))
+
+  it.effect("composes pre-response handlers in order without leaking across requests", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(HttpApiEndpoint.get("get", "/fixture"))
+      )
+      const calls: Array<string> = []
+      const GroupLayer = HttpApiBuilder.group(Api, "test", (handlers) =>
+        handlers.handle("get", () =>
+          Effect.gen(function*() {
+            for (const name of ["first", "second"]) {
+              yield* HttpEffect.appendPreResponseHandler((_request, response) =>
+                Effect.sync(() => {
+                  calls.push(name)
+                  return HttpServerResponse.setHeader(
+                    response,
+                    "x-order",
+                    `${response.headers["x-order"] ?? ""}${name}`
+                  )
+                })
+              )
+            }
+          })))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
+      for (let i = 0; i < 2; i++) {
+        const response = yield* client.test.get({ responseMode: "response-only" })
+        assert.strictEqual(response.headers["x-order"], "firstsecond")
+      }
+      assert.deepStrictEqual(calls, ["first", "second", "first", "second"])
+    }))
+
+  it.effect("preserves pre-response handler defects", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(HttpApiEndpoint.get("get", "/fixture"))
+      )
+      const defect = new Error("pre-response fixture defect")
+      const GroupLayer = HttpApiBuilder.group(Api, "test", (handlers) =>
+        handlers.handle("get", () =>
+          HttpEffect.appendPreResponseHandler(() => Effect.die(defect))))
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
+      const exit = yield* Effect.exit(client.test.get({ responseMode: "response-only" }))
+
+      assert.strictEqual(exit._tag, "Failure")
+      if (exit._tag === "Failure") {
+        assert.strictEqual(Cause.squash(exit.cause), defect)
+      }
+    }))
+})
 
 it.layer(TestServices)("HttpApiBuilder query parameters", (it) => {
   it.effect("round trips array query parameters with one or more values", () =>

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -1,17 +1,6 @@
 import { assert, it, vi } from "@effect/vitest"
-import {
-  Cause,
-  DateTime,
-  Effect,
-  FileSystem,
-  Layer,
-  Path,
-  Redacted,
-  Schema,
-  SchemaTransformation,
-  Stream
-} from "effect"
-import { Etag, HttpEffect, HttpPlatform, HttpRouter, HttpServerResponse } from "effect/unstable/http"
+import { Cause, DateTime, Effect, FileSystem, Layer, Path, Redacted, Schema, SchemaTransformation, Stream } from "effect"
+import { Etag, HttpEffect, HttpPlatform, HttpServerResponse } from "effect/unstable/http"
 import {
   HttpApi,
   HttpApiBuilder,
@@ -34,58 +23,7 @@ const TestServices = Layer.mergeAll(
 ).pipe(Layer.provideMerge(FileSystem.layerNoop({})))
 
 it.layer(TestServices)("HttpApiTest pre-response handlers", (it) => {
-  for (const transport of ["test client", "Web handler"] as const) {
-    it.effect(`runs registered pre-response handlers through the ${transport}`, () =>
-      Effect.gen(function*() {
-        const Api = HttpApi.make("Api").add(
-          HttpApiGroup.make("test").add(
-            HttpApiEndpoint.get("get", "/fixture", { success: Schema.String.pipe(HttpApiSchema.asText()) })
-          )
-        )
-        let calls = 0
-        const GroupLayer = HttpApiBuilder.group(Api, "test", (handlers) =>
-          handlers.handle("get", () =>
-            Effect.gen(function*() {
-              yield* HttpEffect.appendPreResponseHandler((_request, response) =>
-                Effect.sync(() => {
-                  calls++
-                  return HttpServerResponse.setHeader(response, "x-fixture", "present")
-                })
-              )
-              return "ok"
-            })))
-
-        let header: string | null | undefined
-        if (transport === "test client") {
-          const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
-          const response = yield* client.test.get({ responseMode: "response-only" })
-          assert.strictEqual(response.status, 200)
-          assert.strictEqual(yield* response.text, "ok")
-          header = response.headers["x-fixture"]
-        } else {
-          const { handler } = yield* Effect.acquireRelease(
-            Effect.sync(() =>
-              HttpRouter.toWebHandler(
-                HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLayer), Layer.provide(TestServices)),
-                { disableLogger: true }
-              )
-            ),
-            ({ dispose }) =>
-              Effect.promise(dispose)
-          )
-          const response = yield* Effect.promise(() =>
-            handler(new Request("http://localhost/fixture"))
-          )
-          assert.strictEqual(response.status, 200)
-          assert.strictEqual(yield* Effect.promise(() => response.text()), "ok")
-          header = response.headers.get("x-fixture")
-        }
-
-        assert.deepStrictEqual({ header, calls }, { header: "present", calls: 1 })
-      }))
-  }
-
-  it.effect("preserves headers set directly on the response", () =>
+  it.effect("runs registered pre-response handlers", () =>
     Effect.gen(function*() {
       const Api = HttpApi.make("Api").add(
         HttpApiGroup.make("test").add(
@@ -94,81 +32,18 @@ it.layer(TestServices)("HttpApiTest pre-response handlers", (it) => {
       )
       const GroupLayer = HttpApiBuilder.group(Api, "test", (handlers) =>
         handlers.handle("get", () =>
-          Effect.succeed(HttpServerResponse.text("ok", { headers: { "x-fixture": "present" } }))))
+          Effect.as(
+            HttpEffect.appendPreResponseHandler((_request, response) =>
+              Effect.succeed(HttpServerResponse.setHeader(response, "x-fixture", "present"))
+            ),
+            "ok"
+          )))
       const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
       const response = yield* client.test.get({ responseMode: "response-only" })
 
       assert.strictEqual(response.status, 200)
       assert.strictEqual(response.headers["x-fixture"], "present")
       assert.strictEqual(yield* response.text, "ok")
-    }))
-
-  it.effect("preserves handler defects rather than converting them to HTTP responses", () =>
-    Effect.gen(function*() {
-      const Api = HttpApi.make("Api").add(
-        HttpApiGroup.make("test").add(HttpApiEndpoint.get("get", "/fixture"))
-      )
-      const defect = new Error("fixture defect")
-      const GroupLayer = HttpApiBuilder.group(
-        Api,
-        "test",
-        (handlers) => handlers.handle("get", () => Effect.die(defect))
-      )
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
-      const exit = yield* Effect.exit(client.test.get({ responseMode: "response-only" }))
-
-      assert.strictEqual(exit._tag, "Failure")
-      if (exit._tag === "Failure") {
-        assert.strictEqual(Cause.squash(exit.cause), defect)
-      }
-    }))
-
-  it.effect("composes pre-response handlers in order without leaking across requests", () =>
-    Effect.gen(function*() {
-      const Api = HttpApi.make("Api").add(
-        HttpApiGroup.make("test").add(HttpApiEndpoint.get("get", "/fixture"))
-      )
-      const calls: Array<string> = []
-      const GroupLayer = HttpApiBuilder.group(Api, "test", (handlers) =>
-        handlers.handle("get", () =>
-          Effect.gen(function*() {
-            for (const name of ["first", "second"]) {
-              yield* HttpEffect.appendPreResponseHandler((_request, response) =>
-                Effect.sync(() => {
-                  calls.push(name)
-                  return HttpServerResponse.setHeader(
-                    response,
-                    "x-order",
-                    `${response.headers["x-order"] ?? ""}${name}`
-                  )
-                })
-              )
-            }
-          })))
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
-      for (let i = 0; i < 2; i++) {
-        const response = yield* client.test.get({ responseMode: "response-only" })
-        assert.strictEqual(response.headers["x-order"], "firstsecond")
-      }
-      assert.deepStrictEqual(calls, ["first", "second", "first", "second"])
-    }))
-
-  it.effect("preserves pre-response handler defects", () =>
-    Effect.gen(function*() {
-      const Api = HttpApi.make("Api").add(
-        HttpApiGroup.make("test").add(HttpApiEndpoint.get("get", "/fixture"))
-      )
-      const defect = new Error("pre-response fixture defect")
-      const GroupLayer = HttpApiBuilder.group(Api, "test", (handlers) =>
-        handlers.handle("get", () =>
-          HttpEffect.appendPreResponseHandler(() => Effect.die(defect))))
-      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLayer))
-      const exit = yield* Effect.exit(client.test.get({ responseMode: "response-only" }))
-
-      assert.strictEqual(exit._tag, "Failure")
-      if (exit._tag === "Failure") {
-        assert.strictEqual(Cause.squash(exit.cause), defect)
-      }
     }))
 })
 

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -1,5 +1,16 @@
 import { assert, it, vi } from "@effect/vitest"
-import { Cause, DateTime, Effect, FileSystem, Layer, Path, Redacted, Schema, SchemaTransformation, Stream } from "effect"
+import {
+  Cause,
+  DateTime,
+  Effect,
+  FileSystem,
+  Layer,
+  Path,
+  Redacted,
+  Schema,
+  SchemaTransformation,
+  Stream
+} from "effect"
 import { Etag, HttpEffect, HttpPlatform, HttpServerResponse } from "effect/unstable/http"
 import {
   HttpApi,


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`HttpApiTest.groups` converted routed responses without running the request's registered pre-response handlers. Run that handler chain before converting the response so hook-added headers and cookies reach the in-memory client.

The test helper still propagates handler and pre-response defects. It does not adopt the Web transport's platform-boundary failure conversion.

## Verification

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts` (39 passed)
- `nix develop -c pnpm check`

The regression test fails on the base implementation because the hook-added header is absent.

## Related

Closes #7704
Closes EFF-1069
