### PR TITLE
HTTP server performance spike (needs substantial cleanup)

### DIFF
--- a/.changeset/faster-http-runtime.md
+++ b/.changeset/faster-http-runtime.md
@@ -1,0 +1,9 @@
+---
+"effect": patch
+"@effect/platform-node-shared": patch
+"@effect/platform-node": patch
+"@effect/platform-bun": patch
+"@effect/platform-deno": patch
+---
+
+Improve asynchronous HTTP server throughput while preserving request cancellation, routing, middleware, tracing, and resource-lifetime behavior. Route callbacks now also receive matched path parameters, `Context.addUnsafe2` can install two trusted services without an intermediate context, `Effect.runForkWith` supports an uncurried call form, `Effect.runForkInWith` starts a fiber owned by an existing scope, and `HttpEffect.toHandledNoTracer` lets adapters skip tracing setup after determining tracing is disabled.

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -808,6 +808,45 @@ export const addUnsafe = <Services, I, S>(
 }
 
 /**
+ * Adds two services by string key to a context in one operation.
+ *
+ * **When to use**
+ *
+ * Use when low-level infrastructure needs to extend a context with two trusted
+ * services while avoiding an intermediate context allocation.
+ *
+ * @category combining
+ * @since 4.0.0
+ */
+export const addUnsafe2 = <Services, I1, S1, I2, S2>(
+  self: Context<Services>,
+  key1: string,
+  service1: Types.NoInfer<S1>,
+  key2: string,
+  service2: Types.NoInfer<S2>
+): Context<Services | I1 | I2> => {
+  const impl = self as ContextImpl<Services>
+  const cacheRoot = cacheKeys.has(key1) || cacheKeys.has(key2) ? undefined : impl.cacheRoot
+  if (impl.depth + 2 > MaxDepth) {
+    const map = new Map(impl.mapUnsafe)
+    map.set(key1, service1)
+    map.set(key2, service2)
+    return makeImpl(cacheRoot, map, undefined, 0)
+  }
+
+  return makeImpl(
+    cacheRoot,
+    impl.base,
+    {
+      key: key2,
+      value: service2,
+      parent: { key: key1, value: service1, parent: impl.overlay }
+    },
+    impl.depth + 2
+  )
+}
+
+/**
  * Adds or removes a service depending on an `Option`.
  *
  * **When to use**

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -8835,9 +8835,28 @@ export const runFork: <A, E>(effect: Effect<A, E, never>, options?: RunOptions |
  * @category running
  * @since 4.0.0
  */
-export const runForkWith: <R>(
-  context: Context.Context<R>
-) => <A, E>(effect: Effect<A, E, R>, options?: RunOptions | undefined) => Fiber<A, E> = internal.runForkWith
+export const runForkWith: {
+  <R>(context: Context.Context<R>): <A, E>(effect: Effect<A, E, R>, options?: RunOptions | undefined) => Fiber<A, E>
+  <A, E, R>(context: Context.Context<R>, effect: Effect<A, E, R>, options?: RunOptions | undefined): Fiber<A, E>
+} = internal.runForkWith
+
+/**
+ * Runs an effect with the provided services and attaches the resulting fiber to
+ * a scope.
+ *
+ * **When to use**
+ *
+ * Use when an integration starts a background fiber that should be interrupted
+ * and awaited as part of an existing scope's shutdown.
+ *
+ * @category running
+ * @since 4.0.0
+ */
+export const runForkInWith: <A, E, R>(
+  context: Context.Context<R>,
+  effect: Effect<A, E, R>,
+  scope: Scope
+) => Fiber<A, E> = internal.runForkInWith
 
 /**
  * Forks an effect with the provided services, registers `onExit` as a fiber observer, and returns an interruptor.

--- a/packages/effect/src/Utils.ts
+++ b/packages/effect/src/Utils.ts
@@ -200,7 +200,7 @@ export type Gen<F extends TypeLambda> = <
 // the probe is wrapped in a single function call (rather than module-level
 // statements) so the whole selection is pure-annotated by the build and
 // tree-shakable when `internalCall` is unused.
-const pickInternalCall = (): <A>(body: () => A) => A => {
+const pickInternalCall = () => {
   const InternalTypeId = "~effect/Utils/internal"
 
   const standard = {
@@ -219,10 +219,33 @@ const pickInternalCall = (): <A>(body: () => A) => A => {
     }
   }
 
+  const standard1 = {
+    [InternalTypeId]: <A, B>(body: (a: A) => B, a: A) => {
+      return body(a)
+    }
+  }
+
+  const forced1 = {
+    [InternalTypeId]: <A, B>(body: (a: A) => B, a: A) => {
+      try {
+        return body(a)
+      } finally {
+        //
+      }
+    }
+  }
+
   const isNotOptimizedAway = standard[InternalTypeId](() => new Error().stack)?.includes(InternalTypeId) === true
 
-  return isNotOptimizedAway ? standard[InternalTypeId] : forced[InternalTypeId]
+  return isNotOptimizedAway
+    ? [standard[InternalTypeId], standard1[InternalTypeId]] as const
+    : [forced[InternalTypeId], forced1[InternalTypeId]] as const
 }
 
+const internalCalls = pickInternalCall()
+
 /** @internal */
-export const internalCall = pickInternalCall()
+export const internalCall = internalCalls[0]
+
+/** @internal */
+export const internalCall1 = internalCalls[1]

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -45,7 +45,7 @@ import type {
   Tags,
   unassigned
 } from "../Types.ts"
-import { internalCall } from "../Utils.ts"
+import { internalCall, internalCall1 } from "../Utils.ts"
 import type { Primitive } from "./core.ts"
 import {
   args,
@@ -497,6 +497,10 @@ const fiberVariance = {
 
 const fiberIdStore = { id: 0 }
 
+interface ScopeObserver {
+  readonly scope: Scope.Scope
+}
+
 /** @internal */
 export const getCurrentFiber = (): Fiber.Fiber<any, any> | undefined => (globalThis as any)[currentFiberTypeId]
 
@@ -520,6 +524,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     this._running = false
     this._deferredInterrupt = false
     this._parent = undefined
+    this._attachedScope = undefined
     this.cache.runtimeMetrics?.recordFiberStart(this.context)
   }
 
@@ -529,7 +534,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   interruptible: boolean
   currentOpCount: number
   readonly _stack: Array<Primitive>
-  _observers: Array<(exit: Exit.Exit<A, E>) => void> | undefined
+  _observers: Array<((exit: Exit.Exit<A, E>) => void) | ScopeObserver> | undefined
   _exit: Exit.Exit<A, E> | undefined
   _children: Set<FiberImpl<any, any>> | undefined
   _interruptedCause: Cause.Cause<never> | undefined
@@ -537,6 +542,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   _running: boolean
   _deferredInterrupt: boolean
   _parent: FiberImpl<any, any> | undefined
+  _attachedScope: Scope.Scope | undefined
 
   // set in setContext
   context!: Context.Context<never>
@@ -615,6 +621,10 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
 
     this._exit = exit
     this.cache.runtimeMetrics?.recordFiberEnd(this.context, this._exit)
+    if (this._attachedScope !== undefined) {
+      scopeRemoveFinalizerUnsafe(this._attachedScope, this)
+      this._attachedScope = undefined
+    }
     if (this._parent) {
       this._parent._children?.delete(this)
       this._parent = undefined
@@ -623,7 +633,12 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
       const observers = this._observers
       this._observers = undefined
       for (let i = 0; i < observers.length; i++) {
-        observers[i](exit)
+        const observer = observers[i]
+        if (typeof observer === "function") {
+          observer(exit)
+        } else {
+          scopeRemoveFinalizerUnsafe(observer.scope, observer)
+        }
       }
     }
     this._stack.length = 0
@@ -1087,13 +1102,13 @@ export const tryPromise = <A, E = Cause.UnknownError>(
   return callbackOptions<A, E>(function(resume, signal) {
     const failWithCatch = (cause: unknown) => {
       try {
-        resume(fail(internalCall(() => catcher(cause)) as E))
+        resume(fail(internalCall1(catcher as (cause: unknown) => E, cause)))
       } catch (err) {
         resume(die(err))
       }
     }
     try {
-      internalCall(() => f(signal!)).then(
+      internalCall1(f, signal!).then(
         (a) => resume(succeed(a)),
         failWithCatch
       )
@@ -1125,19 +1140,20 @@ const callbackOptions: <A, E = never, R = never>(
   const Proto = makePrimitiveProto({
     op: "Async",
     [evaluate](this: any, fiber) {
-      const register = internalCall(() => this.register.bind(fiber.cache.scheduler))
       let resumed = false
       let yielded: boolean | Primitive = false
       const controller = this.withSignal ? new AbortController() : undefined
-      const onCancel = register((effect: Effect.Effect<any, any, any>) => {
-        if (resumed) return
-        resumed = true
-        if (yielded) {
-          fiber.evaluate(effect as any)
-        } else {
-          yielded = effect as any
-        }
-      }, controller?.signal)
+      const onCancel = internalCall(() =>
+        this.register.call(fiber.cache.scheduler, (effect: Effect.Effect<any, any, any>) => {
+          if (resumed) return
+          resumed = true
+          if (yielded) {
+            fiber.evaluate(effect as any)
+          } else {
+            yielded = effect as any
+          }
+        }, controller?.signal)
+      )
       if (yielded !== false) return yielded
       yielded = true
       fiber._yielded = () => {
@@ -1479,15 +1495,15 @@ const returnPayload = function(this: { readonly payload: any }) {
 }
 const mapCont = function(this: { readonly payload: any }, value: any) {
   const f = this.payload
-  return succeed(internalCall(() => f(value)))
+  return succeed(internalCall1(f, value))
 }
 const andThenCont = function(this: { readonly payload: any }, value: any) {
   const f = this.payload
-  return internalCall(() => f(value))
+  return internalCall1(f, value)
 }
 const tapCont = function(this: { readonly payload: any }, value: any) {
   const f = this.payload
-  return new ContImpl(internalCall(() => f(value)), returnPayload, exitSucceed(value))
+  return new ContImpl(internalCall1(f, value), returnPayload, exitSucceed(value))
 }
 const tapEffectCont = function(this: { readonly payload: any }, value: any) {
   return new ContImpl(this.payload, returnPayload, exitSucceed(value))
@@ -2237,6 +2253,31 @@ export const contextWith = <R, A, E, R2>(
   f: (context: Context.Context<R>) => Effect.Effect<A, E, R2>
 ): Effect.Effect<A, E, R | R2> => withFiber((fiber) => f(fiber.context as Context.Context<R>))
 
+const restoreFiberContext = (context: Context.Context<never>): Primitive => restoreFiberContextPrimitive(context)
+const restoreFiberContextPrimitive = makePrimitive({
+  op: "RestoreFiberContext",
+  [contAll](this: any, fiber: FiberImpl) {
+    fiber.setContext(this[args])
+  }
+})
+
+/** @internal */
+export const fiberSetContext = (
+  fiber: Fiber.Fiber<any, any>,
+  context: Context.Context<never>
+): void => {
+  const impl = fiber as FiberImpl
+  const previous = impl.context
+  if (previous === context) return
+  impl.setContext(context)
+  const frame = impl._stack[impl._stack.length - 1] as any
+  if (frame !== undefined && frame[scopedMatchCauseFrame] === true) {
+    frame.appContext ??= previous
+    return
+  }
+  impl._stack.push(restoreFiberContext(previous))
+}
+
 /** @internal */
 export const setContext: {
   <R>(
@@ -2646,8 +2687,21 @@ export const catch_: {
   <A, E, R, B, E2, R2>(
     self: Effect.Effect<A, E, R>,
     f: (a: NoInfer<E>) => Effect.Effect<B, E2, R2>
-  ): Effect.Effect<A | B, E2, R | R2> => catchCauseFilter(self, findError as any, (e: any) => f(e)) as any
+  ): Effect.Effect<A | B, E2, R | R2> => new CatchImpl(self, f) as any
 )
+const CatchProto = makePrimitiveProto({
+  op: "Catch",
+  [evaluate]: evaluateCont,
+  [contE](this: any, cause: Cause.Cause<any>) {
+    const error = findError(cause)
+    return Result.isFailure(error) ? failCause(error.failure) : internalCall1(this.payload, error.success)
+  }
+})
+const CatchImpl = function(this: any, self: Effect.Effect<any, any, any>, f: any) {
+  this[args] = self
+  this.payload = f
+} as unknown as PrimitiveCtor<[self: Effect.Effect<any, any, any>, f: any]>
+CatchImpl.prototype = CatchProto
 
 /** @internal */
 export const catchNoSuchElement = <A, E, R>(
@@ -4038,6 +4092,139 @@ export const scoped = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, 
   }) as any
 
 /** @internal */
+export const scopedMatchCauseEffect = <A, E, R, A2, E2, R2, A3, E3, R3>(
+  self: Effect.Effect<A, E, R>,
+  options: {
+    readonly onFailure: (cause: Cause.Cause<E>, fiber: FiberImpl) => Effect.Effect<A2, E2, R2>
+    readonly onSuccess: (value: A, fiber: FiberImpl) => Effect.Effect<A3, E3, R3>
+    readonly onExit: (
+      scope: Scope.Closeable,
+      exit: Exit.Exit<A2 | A3, E2 | E3>,
+      appSuccess: Exit.Exit<A> | undefined
+    ) => Effect.Effect<void> | undefined
+    readonly uninterruptible?: boolean | undefined
+  }
+): Effect.Effect<A2 | A3, E2 | E3, Exclude<R | R2 | R3, Scope.Scope>> =>
+  new (ScopedMatchCauseEffectImpl as any)(self, options) as any
+
+const ScopedMatchCauseEffectProto = makePrimitiveProto({
+  op: "ScopedMatchCauseEffect",
+  [evaluate](this: any, fiber: FiberImpl) {
+    const scope = scopeMakeUnsafe()
+    const previousContext = fiber.context
+    const restoreInterruptible = this.uninterruptible && fiber.interruptible
+    if (restoreInterruptible) {
+      fiber.interruptible = false
+    }
+    fiber.setContext(Context.add(fiber.context, scopeTag, scope))
+    fiber._stack.push(new (ScopedMatchCauseFrame as any)(this, scope, previousContext, restoreInterruptible))
+    return this.effect
+  }
+})
+
+const ScopedMatchCauseEffectImpl = function(this: any, effect: Effect.Effect<any, any, any>, options: any) {
+  this.effect = effect
+  this.onFailure = options.onFailure
+  this.onSuccess = options.onSuccess
+  this.onExit = options.onExit
+  this.uninterruptible = options.uninterruptible === true
+}
+ScopedMatchCauseEffectImpl.prototype = ScopedMatchCauseEffectProto
+
+const scopedMatchCauseFrame = Symbol("effect/Effect/scopedMatchCauseFrame")
+
+const ScopedMatchCauseFrameProto = {
+  [scopedMatchCauseFrame]: true,
+  [contA](this: any, value: any, fiber: FiberImpl, exit: Exit.Exit<any, any> | undefined) {
+    if (this.stage === 0) {
+      scopedMatchCausePrepare(this, fiber)
+      this.stage = 1
+      this.appSuccess = exit ?? exitSucceed(value)
+      fiber._stack.push(this)
+      const handled = this.effect.onSuccess(value, fiber)
+      if (
+        ExitTypeId in handled &&
+        (handled as any)._tag === "Success" &&
+        fiber._stack[fiber._stack.length - 1] === this
+      ) {
+        fiber._stack.pop()
+        return scopedMatchCauseCompleteSuccess(this, fiber, handled as any)
+      }
+      return handled
+    }
+    exit ??= exitSucceed(value)
+    return scopedMatchCauseCompleteSuccess(this, fiber, exit)
+  },
+  [contE](this: any, cause: Cause.Cause<any>, fiber: FiberImpl, exit: Exit.Exit<any, any> | undefined) {
+    if (this.stage === 0) {
+      scopedMatchCausePrepare(this, fiber)
+      this.stage = 2
+      fiber._stack.push(this)
+      return this.effect.onFailure(cause, fiber)
+    }
+    exit ??= exitFailCause(cause)
+    fiber.setContext(this.previousContext)
+    if (this.restoreInterruptible) {
+      fiber._stack.push(setInterruptibleTrue)
+    }
+    const finalizer = this.effect.onExit(this.scope, exit, this.appSuccess)
+    return finalizer ? flatMap(combineFinalizerCause(exit, finalizer), () => exit) : exit
+  }
+}
+
+const ScopedMatchCauseFrame = function(
+  this: any,
+  effect: any,
+  scope: Scope.Closeable,
+  previousContext: Context.Context<never>,
+  restoreInterruptible: boolean
+) {
+  this.effect = effect
+  this.scope = scope
+  this.previousContext = previousContext
+  this.restoreInterruptible = restoreInterruptible
+  this.restoreHandlerInterruptible = false
+  this.appContext = undefined
+  this.stage = 0
+  this.appSuccess = undefined
+}
+ScopedMatchCauseFrame.prototype = ScopedMatchCauseFrameProto
+
+const scopedMatchCausePrepare = (frame: any, fiber: FiberImpl): void => {
+  if (frame.appContext !== undefined) {
+    fiber.setContext(frame.appContext)
+    frame.appContext = undefined
+  }
+  if (frame.restoreHandlerInterruptible) {
+    fiber.interruptible = false
+    frame.restoreHandlerInterruptible = false
+  }
+}
+
+const scopedMatchCauseCompleteSuccess = (
+  frame: any,
+  fiber: FiberImpl,
+  exit: Exit.Exit<any, any>
+): Effect.Effect<any, any, any> | Yield => {
+  fiber.setContext(frame.previousContext)
+  if (frame.restoreInterruptible) {
+    fiber._stack.push(setInterruptibleTrue)
+  }
+  const finalizer = frame.effect.onExit(frame.scope, exit, frame.appSuccess)
+  if (finalizer) {
+    return flatMap(finalizer, () => exit)
+  }
+  if (frame.restoreInterruptible && fiber._stack[fiber._stack.length - 1] === setInterruptibleTrue) {
+    fiber._stack.pop()
+    fiber.interruptible = true
+    if (fiber._interruptedCause) {
+      return failCause(fiber._interruptedCause)
+    }
+  }
+  return fiber._stack.length === 0 ? fiber.yieldWith(exit) : exit
+}
+
+/** @internal */
 export const scopeUse: {
   (
     scope: Scope.Closeable
@@ -4390,7 +4577,23 @@ export const cachedWithTTL: {
 
 /** @internal */
 export const cached = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<Effect.Effect<A, E, R>> =>
-  cachedWithTTL(self, Duration.infinity)
+  sync(() => {
+    const latch = makeLatchUnsafe(false)
+    let running = false
+    let exit: Exit.Exit<A, E> | undefined
+    const wait = flatMap(latch.await, () => exit!)
+    return suspend(() => {
+      if (exit !== undefined) return exit
+      if (running) return wait
+      running = true
+      return onExit(self, (exit_) =>
+        sync(() => {
+          running = false
+          exit = exit_
+          latch.openUnsafe()
+        }))
+    })
+  })
 
 // ----------------------------------------------------------------------------
 // interruption
@@ -4410,6 +4613,7 @@ export const uninterruptible = <A, E, R>(
     return self
   })
 
+/** @internal */
 const setInterruptible: (interruptible: boolean) => Primitive = makePrimitive({
   op: "SetInterruptible",
   [contAll](fiber) {
@@ -4426,6 +4630,27 @@ const setFiberInterruptible = (fiber: FiberImpl): Effect.Effect<never> | undefin
   fiber.interruptible = true
   fiber._stack.push(setInterruptibleFalse)
   if (fiber._interruptedCause) return failCause(fiber._interruptedCause)
+}
+
+/** @internal */
+export const fiberInterruptibleWith2 = <A, B, XA, E, R>(
+  fiber: Fiber.Fiber<any, any>,
+  f: (a: A, b: B) => Effect.Effect<XA, E, R>,
+  a: A,
+  b: B
+): Effect.Effect<XA, E, R> => {
+  const impl = fiber as FiberImpl
+  if (impl.interruptible) return f(a, b)
+  const frame = impl._stack[impl._stack.length - 1] as any
+  let interrupted: Effect.Effect<never> | undefined
+  if (frame !== undefined && frame[scopedMatchCauseFrame] === true) {
+    impl.interruptible = true
+    frame.restoreHandlerInterruptible = true
+    interrupted = impl._interruptedCause ? failCause(impl._interruptedCause) : undefined
+  } else {
+    interrupted = setFiberInterruptible(impl)
+  }
+  return interrupted ?? f(a, b)
 }
 
 /** @internal */
@@ -5511,11 +5736,28 @@ export const forkScoped: {
 // ----------------------------------------------------------------------------
 
 /** @internal */
-export const runForkWith = <R>(context: Context.Context<R>) =>
-<A, E>(
+export function runForkWith<R>(context: Context.Context<R>): <A, E>(
   effect: Effect.Effect<A, E, R>,
   options?: Effect.RunOptions | undefined
-): Fiber.Fiber<A, E> => {
+) => Fiber.Fiber<A, E>
+/** @internal */
+export function runForkWith<A, E, R>(
+  context: Context.Context<R>,
+  effect: Effect.Effect<A, E, R>,
+  options?: Effect.RunOptions | undefined
+): Fiber.Fiber<A, E>
+/** @internal */
+export function runForkWith<A, E, R>(
+  context: Context.Context<R>,
+  effect?: Effect.Effect<A, E, R>,
+  options?: Effect.RunOptions | undefined
+):
+  | Fiber.Fiber<A, E>
+  | ((effect: Effect.Effect<A, E, R>, options?: Effect.RunOptions | undefined) => Fiber.Fiber<A, E>)
+{
+  if (effect === undefined) {
+    return (effect, options) => runForkWith(context, effect, options)
+  }
   const fiber = new FiberImpl<A, E>(
     options?.scheduler ? Context.add(context, Scheduler.Scheduler, options.scheduler) : context,
     options?.uninterruptible !== true
@@ -5539,6 +5781,24 @@ export const runForkWith = <R>(context: Context.Context<R>) =>
 }
 
 /** @internal */
+export const runForkInWith = <A, E, R>(
+  context: Context.Context<R>,
+  effect: Effect.Effect<A, E, R>,
+  scope: Scope.Scope
+): Fiber.Fiber<A, E> => {
+  const fiber = new FiberImpl<A, E>(context)
+  fiber.evaluate(effect as any)
+  if (fiber._exit) return fiber
+  if (scope.state._tag === "Closed") {
+    fiber.interruptUnsafe(fiber.id)
+    return fiber
+  }
+  fiber._attachedScope = scope
+  scopeAddFinalizerUnsafe(scope, fiber, () => fiberInterrupt(fiber))
+  return fiber
+}
+
+/** @internal */
 export const fiberRunIn: {
   (scope: Scope.Scope): <A, E>(self: Fiber.Fiber<A, E>) => Fiber.Fiber<A, E>
   <A, E>(
@@ -5555,9 +5815,13 @@ export const fiberRunIn: {
     self.interruptUnsafe(self.id)
     return self
   }
-  const key = {}
-  scopeAddFinalizerUnsafe(scope, key, () => fiberInterrupt(self))
-  self.addObserver(() => scopeRemoveFinalizerUnsafe(scope, key))
+  const observer: ScopeObserver = { scope }
+  scopeAddFinalizerUnsafe(scope, observer, () => fiberInterrupt(self))
+  if (self._observers === undefined) {
+    self._observers = [observer]
+  } else {
+    self._observers.push(observer)
+  }
   return self
 })
 

--- a/packages/effect/src/unstable/http/FindMyWay/internal/router.ts
+++ b/packages/effect/src/unstable/http/FindMyWay/internal/router.ts
@@ -745,7 +745,7 @@ const assert: Assert = (condition, message) => {
 }
 
 function removeDuplicateSlashes(path: string): Router.PathInput {
-  return path.replace(/\/\/+/g, "/") as Router.PathInput
+  return path.indexOf("//") === -1 ? path as Router.PathInput : path.replace(/\/\/+/g, "/") as Router.PathInput
 }
 
 function trimLastSlash(path: string): Router.PathInput {
@@ -849,6 +849,15 @@ function decodeComponentChar(highCharCode: number, lowCharCode: number) {
 }
 
 function safeDecodeURI(path: string) {
+  if (
+    path.indexOf("%", 1) === -1 &&
+    path.indexOf("?", 1) === -1 &&
+    path.indexOf(";", 1) === -1 &&
+    path.indexOf("#", 1) === -1
+  ) {
+    return { path, querystring: "", shouldDecodeParam: false } as const
+  }
+
   let shouldDecode = false
   let shouldDecodeParam = false
 

--- a/packages/effect/src/unstable/http/HttpEffect.ts
+++ b/packages/effect/src/unstable/http/HttpEffect.ts
@@ -14,7 +14,7 @@ import * as Effect from "../../Effect.ts"
 import * as Exit from "../../Exit.ts"
 import * as Fiber from "../../Fiber.ts"
 import { dual } from "../../Function.ts"
-import { reportCauseUnsafe } from "../../internal/effect.ts"
+import { reportCauseUnsafe, scopedMatchCauseEffect } from "../../internal/effect.ts"
 import * as Layer from "../../Layer.ts"
 import * as Scope from "../../Scope.ts"
 import * as Stream from "../../Stream.ts"
@@ -27,29 +27,25 @@ import type { HttpServerResponse } from "./HttpServerResponse.ts"
 import * as Response from "./HttpServerResponse.ts"
 import * as preResponseHandler from "./internal/preResponseHandler.ts"
 
-/**
- * Runs an HTTP server effect, sends the produced response with the supplied handler, and converts failures into HTTP responses.
- *
- * @category combinators
- * @since 4.0.0
- */
-export const toHandled = <E, R, EH, RH>(
+const toHandledInternal = <E, R, EH, RH>(
   self: Effect.Effect<HttpServerResponse, E, R>,
   handleResponse: (
     request: HttpServerRequest,
     response: HttpServerResponse
   ) => Effect.Effect<unknown, EH, RH>,
-  middleware?: HttpMiddleware | undefined
+  middleware: HttpMiddleware | undefined,
+  tracingEnabled: boolean
 ): Effect.Effect<void, never, Exclude<R | RH | HttpServerRequest, Scope.Scope>> => {
-  const handleCause = (cause: Cause.Cause<E | EH | HttpServerError>) =>
+  const handleCause = (cause: Cause.Cause<E | EH | HttpServerError>, currentFiber = Fiber.getCurrent()!) =>
     Effect.flatMapEager(causeResponse(cause), ([response, cause]) => {
-      const fiber = Fiber.getCurrent()!
-      reportCauseUnsafe(fiber, cause)
-      const request = Context.getUnsafe(fiber.context, HttpServerRequest)
+      reportCauseUnsafe(currentFiber, cause)
+      const request = Context.getUnsafe(currentFiber.context, HttpServerRequest)
       const handler = preResponseHandler.requestPreResponseHandlers.get(request.source)
       const cont = cause.reasons.length === 0 ? Effect.succeed(response) : Effect.failCause(cause)
       if (handler === undefined) {
-        ;(request as any)[handledSymbol] = true
+        if (middleware !== undefined) {
+          ;(request as any)[handledSymbol] = true
+        }
         return Effect.flatMapEager(
           handleResponse(request, response),
           () => cont
@@ -58,37 +54,61 @@ export const toHandled = <E, R, EH, RH>(
 
       return Effect.flatMapEager(
         Effect.flatMapEager(handler(request, response), (response) => {
-          ;(request as any)[handledSymbol] = true
+          if (middleware !== undefined) {
+            ;(request as any)[handledSymbol] = true
+          }
           return handleResponse(request, response)
         }),
         () => cont
       )
     })
 
-  const responded = Effect.matchCauseEffect(self, {
-    onSuccess: (response) => {
-      const fiber = Fiber.getCurrent()!
-      const request = Context.getUnsafe(fiber.context, HttpServerRequest)
-      const handler = preResponseHandler.requestPreResponseHandlers.get(request.source)
-      if (handler === undefined) {
-        ;(request as any)[handledSymbol] = true
-        return Effect.mapEager(handleResponse(request, response), () => response)
+  if (middleware === undefined && !tracingEnabled) {
+    return scopedMatchCauseEffect(self, {
+      uninterruptible: true,
+      onSuccess(response, fiber) {
+        const request = Context.getUnsafe(fiber.context, HttpServerRequest)
+        const handler = preResponseHandler.requestPreResponseHandlers.get(request.source)
+        if (handler === undefined) {
+          return handleResponse(request, response)
+        }
+        return Effect.flatMapEager(handler(request, response), (sentResponse) => handleResponse(request, sentResponse))
+      },
+      onFailure: handleCause,
+      onExit(scope, exit, appSuccess) {
+        if (scopeEjected in scope) return undefined
+        return Scope.closeUnsafe(scope, exit._tag === "Success" && appSuccess !== undefined ? appSuccess : exit)
       }
-      return Effect.flatMapEager(handler(request, response), (sentResponse) => {
-        ;(request as any)[handledSymbol] = true
-        return Effect.mapEager(handleResponse(request, sentResponse), () => response)
-      })
-    },
+    }) as any
+  }
+
+  const onSuccess = (response: HttpServerResponse) => {
+    const fiber = Fiber.getCurrent()!
+    const request = Context.getUnsafe(fiber.context, HttpServerRequest)
+    const handler = preResponseHandler.requestPreResponseHandlers.get(request.source)
+    if (handler === undefined) {
+      ;(request as any)[handledSymbol] = true
+      return Effect.mapEager(handleResponse(request, response), () => response)
+    }
+    return Effect.flatMapEager(handler(request, response), (sentResponse) => {
+      ;(request as any)[handledSymbol] = true
+      return Effect.mapEager(handleResponse(request, sentResponse), () => response)
+    })
+  }
+
+  const responded = Effect.matchCauseEffect(self, {
+    onSuccess,
     onFailure: handleCause
   })
 
+  const applyTracer = tracingEnabled ? tracer : <A, E, R>(effect: Effect.Effect<A, E, R>) => effect
   const withMiddleware: Effect.Effect<
     unknown,
     E | EH | HttpServerError,
     HttpServerRequest | R | RH
   > = middleware === undefined ?
-    tracer(responded) :
-    Effect.matchCauseEffect(tracer(middleware(responded)), {
+    applyTracer(responded as any) :
+    Effect.matchCauseEffect(applyTracer(middleware(responded as any)), {
       onFailure(cause): Effect.Effect<void, EH, RH> {
         const fiber = Fiber.getCurrent()!
         reportCauseUnsafe(fiber, cause)
@@ -112,6 +132,43 @@ export const toHandled = <E, R, EH, RH>(
 
   return Effect.uninterruptible(scoped(withMiddleware)) as any
 }
+
+/**
+ * Runs an HTTP server effect, sends the produced response with the supplied handler, and converts failures into HTTP responses.
+ *
+ * @category combinators
+ * @since 4.0.0
+ */
+export const toHandled = <E, R, EH, RH>(
+  self: Effect.Effect<HttpServerResponse, E, R>,
+  handleResponse: (
+    request: HttpServerRequest,
+    response: HttpServerResponse
+  ) => Effect.Effect<unknown, EH, RH>,
+  middleware?: HttpMiddleware | undefined
+): Effect.Effect<void, never, Exclude<R | RH | HttpServerRequest, Scope.Scope>> =>
+  toHandledInternal(self, handleResponse, middleware, true)
+
+/**
+ * Runs an HTTP server effect without adding the HTTP tracing middleware.
+ *
+ * **When to use**
+ *
+ * Use when a server adapter has already determined tracing is disabled for the
+ * application.
+ *
+ * @category combinators
+ * @since 4.0.0
+ */
+export const toHandledNoTracer = <E, R, EH, RH>(
+  self: Effect.Effect<HttpServerResponse, E, R>,
+  handleResponse: (
+    request: HttpServerRequest,
+    response: HttpServerResponse
+  ) => Effect.Effect<unknown, EH, RH>,
+  middleware?: HttpMiddleware | undefined
+): Effect.Effect<void, never, Exclude<R | RH | HttpServerRequest, Scope.Scope>> =>
+  toHandledInternal(self, handleResponse, middleware, false)
 
 const handledSymbol = Symbol.for("effect/http/HttpEffect/handled")
 
@@ -258,7 +315,7 @@ export const toWebHandlerWith = <Provided, R = never, ReqR = Exclude<R, Provided
       const httpServerRequest = Request.fromWeb(request)
       reqContext = Context.add(reqContext, HttpServerRequest, httpServerRequest)
       ;(httpServerRequest as any)[resolveSymbol] = resolve
-      const fiber = Effect.runForkWith(reqContext)(httpApp as any)
+      const fiber = Effect.runForkWith(reqContext, httpApp as any)
       request.signal?.addEventListener("abort", () => {
         fiber.interruptUnsafe(undefined, ClientAbort.annotation)
       }, { once: true })

--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -13,13 +13,13 @@ import * as Arr from "../../Array.ts"
 import * as Context from "../../Context.ts"
 import * as Effect from "../../Effect.ts"
 import { compose, dual, identity } from "../../Function.ts"
+import * as internalEffect from "../../internal/effect.ts"
 import * as Layer from "../../Layer.ts"
 import * as Option from "../../Option.ts"
 import type { ReadonlyRecord } from "../../Record.ts"
 import * as Schema from "../../Schema.ts"
 import type { ParseOptions } from "../../SchemaAST.ts"
 import * as Scope from "../../Scope.ts"
-import * as Tracer from "../../Tracer.ts"
 import type * as Types from "../../Types.ts"
 import * as FindMyWay from "./FindMyWay.ts"
 import * as HttpEffect from "./HttpEffect.ts"
@@ -56,7 +56,10 @@ export interface HttpRouter {
     handler:
       | HttpServerResponse.HttpServerResponse
       | Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>
-      | ((request: HttpServerRequest.HttpServerRequest) => Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>),
+      | ((
+        request: HttpServerRequest.HttpServerRequest,
+        params: ReadonlyRecord<string, string | undefined>
+      ) => Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>),
     options?: { readonly uninterruptible?: boolean | undefined } | undefined
   ) => Effect.Effect<
     void,
@@ -117,7 +120,14 @@ export const HttpRouter: Context.Service<HttpRouter, HttpRouter> = Context.Servi
  * @since 4.0.0
  */
 export const make = Effect.gen(function*() {
-  const router = FindMyWay.make<Route<any, never>>(yield* RouterConfig)
+  interface RegisteredRoute {
+    readonly route: Route<any, any>
+    readonly handler: Effect.Effect<HttpServerResponse.HttpServerResponse, unknown>
+    readonly handlerFunction: RouteHandler<any, any> | undefined
+    readonly prefix: string | undefined
+  }
+
+  const router = FindMyWay.make<RegisteredRoute>(yield* RouterConfig)
   const middleware = new Set<middleware.Fn>()
 
   const addAll = <const Routes extends ReadonlyArray<Route<any, any>>>(
@@ -141,19 +151,30 @@ export const make = Effect.gen(function*() {
           ...routes[i],
           handler: applyMiddleware(routes[i].handler as Effect.Effect<HttpServerResponse.HttpServerResponse>)
         })
+        const registered: RegisteredRoute = {
+          route,
+          handler: (route.uninterruptible ? route.handler : Effect.interruptible(route.handler)) as Effect.Effect<
+            HttpServerResponse.HttpServerResponse,
+            unknown
+          >,
+          handlerFunction: middleware.length === 0
+            ? (route as any)[RouteHandlerTypeId]
+            : undefined,
+          prefix: Option.getOrUndefined(route.prefix)
+        }
         if (route.method === "*") {
           if (route.path.endsWith("/*")) {
-            router.all(route.path, route as any)
-            router.all(route.path.slice(0, -2) as any, route as any)
+            router.all(route.path, registered)
+            router.all(route.path.slice(0, -2) as any, registered)
           } else {
-            router.all(route.path, route as any)
+            router.all(route.path, registered)
           }
         } else {
           if (route.path.endsWith("/*")) {
-            router.on(route.method, route.path, route as any)
-            router.on(route.method, route.path.slice(0, -2) as any, route as any)
+            router.on(route.method, route.path, registered)
+            router.on(route.method, route.path.slice(0, -2) as any, registered)
           } else {
-            router.on(route.method, route.path, route as any)
+            router.on(route.method, route.path, registered)
           }
         }
       }
@@ -167,20 +188,7 @@ export const make = Effect.gen(function*() {
         ...this,
         prefixed: (newPrefix: string) => this.prefixed(prefixPath(prefix, newPrefix)),
         addAll: (routes) => addAll(routes.map(prefixRoute(prefix))) as any,
-        add: (method, path, handler, options) =>
-          addAll([
-            makeRoute({
-              method,
-              path: prefixPath(path, prefix) as PathInput,
-              handler: HttpServerResponse.isHttpServerResponse(handler) ?
-                Effect.succeed(handler) :
-                Effect.isEffect(handler)
-                ? handler
-                : Effect.flatMap(HttpServerRequest.HttpServerRequest, handler),
-              uninterruptible: options?.uninterruptible ?? false,
-              prefix
-            })
-          ])
+        add: (method, path, handler, options) => addAll([prefixRoute(route(method, path, handler, options), prefix)])
       })
     },
     addAll,
@@ -204,33 +212,37 @@ export const make = Effect.gen(function*() {
             })
           )
         }
-        const route = result.handler
-        if (Option.isSome(route.prefix)) {
-          context = Context.add(
+        const registered = result.handler
+        const route = registered.route
+        const span = fiber.cache.span
+        let routeRequest = request
+        if (registered.prefix !== undefined) {
+          routeRequest = sliceRequestUrl(request, registered.prefix)
+          context = Context.addUnsafe(
             context,
-            HttpServerRequest.HttpServerRequest,
-            sliceRequestUrl(request, route.prefix.value)
+            HttpServerRequest.HttpServerRequest.key,
+            routeRequest
           )
         }
-        context = Context.add(context, HttpServerRequest.ParsedSearchParams, result.searchParams)
-        context = Context.add(context, RouteContext, {
-          route,
-          params: result.params
-        })
+        context = Context.addUnsafe2(
+          context,
+          HttpServerRequest.ParsedSearchParams.key,
+          result.searchParams,
+          RouteContext.key,
+          { route, params: result.params }
+        )
 
-        const span = Context.getOrUndefined(context, Tracer.ParentSpan)
         if (span && span._tag === "Span") {
           span.attribute("http.route", route.path)
         }
-        return Effect.updateContext(
-          (route.uninterruptible ?
-            route.handler :
-            Effect.interruptible(route.handler)) as Effect.Effect<
-              HttpServerResponse.HttpServerResponse,
-              unknown
-            >,
-          () => context
-        )
+        internalEffect.fiberSetContext(fiber, context)
+        if (registered.handlerFunction === undefined) {
+          return registered.handler
+        }
+        const routeEffect = route.uninterruptible
+          ? registered.handlerFunction(routeRequest, result.params)
+          : internalEffect.fiberInterruptibleWith2(fiber, registered.handlerFunction, routeRequest, result.params)
+        return routeEffect as Effect.Effect<HttpServerResponse.HttpServerResponse, unknown>
       })
       if (middleware.size === 0) return handler
       for (const fn of Arr.reverse(middleware)) {
@@ -507,7 +519,10 @@ export const add = <E = never, R = never>(
   handler:
     | HttpServerResponse.HttpServerResponse
     | Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>
-    | ((request: HttpServerRequest.HttpServerRequest) => Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>),
+    | ((
+      request: HttpServerRequest.HttpServerRequest,
+      params: ReadonlyRecord<string, string | undefined>
+    ) => Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>),
   options?: {
     readonly uninterruptible?: boolean | undefined
   }
@@ -598,6 +613,12 @@ export const toHttpEffect = <A, E, R>(
   }) as any
 
 const RouteTypeId = "~effect/http/HttpRouter/Route"
+const RouteHandlerTypeId = Symbol.for("effect/http/HttpRouter/Route/handler")
+
+type RouteHandler<E, R> = (
+  request: HttpServerRequest.HttpServerRequest,
+  params: ReadonlyRecord<string, string | undefined>
+) => Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>
 
 /**
  * Description of a registered HTTP route.
@@ -662,8 +683,9 @@ const makeRoute = <E, R>(options: {
  * **Details**
  *
  * The handler may be a static response, an effect that produces a response, or a
- * function from the current request to a response effect. Set `uninterruptible` to
- * prevent the route handler from being made interruptible while it runs.
+ * function receiving the current request and matched path parameters. Set
+ * `uninterruptible` to prevent the route handler from being made interruptible
+ * while it runs.
  *
  * @category routes
  * @since 4.0.0
@@ -674,12 +696,15 @@ export const route = <E = never, R = never>(
   handler:
     | HttpServerResponse.HttpServerResponse
     | Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>
-    | ((request: HttpServerRequest.HttpServerRequest) => Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>),
+    | RouteHandler<E, R>,
   options?: {
     readonly uninterruptible?: boolean | undefined
   }
-): Route<E, Exclude<R, Provided>> =>
-  makeRoute({
+): Route<E, Exclude<R, Provided>> => {
+  const handlerFunction = HttpServerResponse.isHttpServerResponse(handler) || Effect.isEffect(handler)
+    ? undefined
+    : handler
+  const result = makeRoute({
     ...options,
     method,
     path,
@@ -687,9 +712,20 @@ export const route = <E = never, R = never>(
       Effect.succeed(handler) :
       Effect.isEffect(handler)
       ? handler
-      : Effect.flatMap(HttpServerRequest.HttpServerRequest, handler),
+      : Effect.withFiber((fiber) => {
+        const context = fiber.context
+        return handler(
+          Context.getUnsafe(context, HttpServerRequest.HttpServerRequest),
+          Context.getUnsafe(context, RouteContext).params
+        )
+      }),
     uninterruptible: options?.uninterruptible ?? false
   })
+  if (handlerFunction !== undefined) {
+    Object.defineProperty(result, RouteHandlerTypeId, { value: handlerFunction })
+  }
+  return result
+}
 
 /**
  * Path pattern accepted by the router. Routes must use an absolute path
@@ -740,15 +776,21 @@ export const prefixPath: {
 export const prefixRoute: {
   (prefix: string): <E, R>(self: Route<E, R>) => Route<E, R>
   <E, R>(self: Route<E, R>, prefix: string): Route<E, R>
-} = dual(2, <E, R>(self: Route<E, R>, prefix: string): Route<E, R> =>
-  makeRoute({
+} = dual(2, <E, R>(self: Route<E, R>, prefix: string): Route<E, R> => {
+  const result = makeRoute({
     ...self,
     path: prefixPath(self.path, prefix) as PathInput,
     prefix: Option.match(self.prefix, {
       onNone: () => prefix as string,
       onSome: (existingPrefix) => prefixPath(existingPrefix, prefix) as string
     })
-  }))
+  })
+  const handlerFunction = (self as any)[RouteHandlerTypeId]
+  if (handlerFunction !== undefined) {
+    Object.defineProperty(result, RouteHandlerTypeId, { value: handlerFunction })
+  }
+  return result
+})
 
 /**
  * Represents a request-level dependency, that needs to be provided by

--- a/packages/effect/src/unstable/http/HttpServerResponse.ts
+++ b/packages/effect/src/unstable/http/HttpServerResponse.ts
@@ -1324,6 +1324,8 @@ const Proto: Omit<
   }
 }
 
+const headersProto = Object.getPrototypeOf(Headers.empty)
+
 const makeResponse = (options: {
   readonly status: number
   readonly statusText?: string | undefined
@@ -1340,7 +1342,9 @@ const makeResponse = (options: {
     self.body._tag !== "Empty" &&
     (self.body.contentType || self.body.contentLength !== undefined)
   ) {
-    const newHeaders = Headers.fromRecordUnsafe({ ...options.headers }) as any
+    const newHeaders = options.headers === undefined || options.headers === Headers.empty
+      ? Object.create(headersProto)
+      : Headers.fromRecordUnsafe({ ...options.headers }) as any
     if (self.body.contentType && (!preferHeaders || newHeaders["content-type"] === undefined)) {
       newHeaders["content-type"] = self.body.contentType
     }

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -18,6 +18,16 @@ describe("Context", () => {
     deepStrictEqual([...result.mapUnsafe], [[A.key, 1], [B.key, 2]])
   })
 
+  it("adds two unsafe services with sequential-add semantics", () => {
+    const source = Context.make(A, 1)
+    const result = Context.addUnsafe2(source, B.key, 2, A.key, 3)
+
+    deepStrictEqual([...source.mapUnsafe], [[A.key, 1]])
+    deepStrictEqual([...result.mapUnsafe], [[A.key, 3], [B.key, 2]])
+    strictEqual(Context.get(result, A), 3)
+    strictEqual(Context.get(result, B), 2)
+  })
+
   it("removes a service with addOrOmit", () => {
     const context = Context.make(A, 1).pipe(Context.addOrOmit(A, Option.none()))
 

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -55,6 +55,83 @@ describe("Effect", () => {
     assert.isFalse(Effect.isEffect([0]))
   })
 
+  it("runForkWith supports the uncurried form", () => {
+    const fiber = Effect.runForkWith(Context.make(ATag, "A"), ATag)
+    assert.deepStrictEqual(fiber.pollUnsafe(), Exit.succeed("A"))
+  })
+
+  describe("runForkInWith", () => {
+    it("does not attach synchronously completed fibers", () => {
+      const scope = Scope.makeUnsafe()
+      const fiber = Effect.runForkInWith(Context.empty(), Effect.succeed("done"), scope)
+
+      assert.deepStrictEqual(fiber.pollUnsafe(), Exit.succeed("done"))
+      assert.strictEqual(scope.state._tag, "Empty")
+    })
+
+    it.effect("scope close interrupts and awaits the fiber", () =>
+      Effect.gen(function*() {
+        const scope = Scope.makeUnsafe()
+        const interruptStarted = yield* Deferred.make<void>()
+        const interruptFinished = yield* Deferred.make<void>()
+        const fiber = Effect.runForkInWith(
+          Context.empty(),
+          Effect.never.pipe(
+            Effect.onInterrupt(() =>
+              Deferred.succeed(interruptStarted, void 0).pipe(
+                Effect.andThen(Deferred.await(interruptFinished))
+              )
+            )
+          ),
+          scope
+        )
+        const closeFiber = yield* Scope.close(scope, Exit.void).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+
+        assert.isTrue(yield* Deferred.isDone(interruptStarted))
+        assert.isUndefined(closeFiber.pollUnsafe())
+        yield* Deferred.succeed(interruptFinished, void 0)
+        yield* Fiber.join(closeFiber)
+        assert.isTrue(Exit.hasInterrupts(yield* Fiber.await(fiber)))
+      }))
+
+    it.effect("interrupts a pending fiber when the scope is already closed", () =>
+      Effect.gen(function*() {
+        const scope = Scope.makeUnsafe()
+        yield* Scope.close(scope, Exit.void)
+
+        const fiber = Effect.runForkInWith(Context.empty(), Effect.never, scope)
+        assert.isTrue(Exit.hasInterrupts(yield* Fiber.await(fiber)))
+      }))
+
+    it.effect("interrupts and awaits all fibers attached to a parallel scope", () =>
+      Effect.gen(function*() {
+        const scope = Scope.makeUnsafe("parallel")
+        const release = yield* Deferred.make<void>()
+        let interrupted = 0
+        const effect = Effect.never.pipe(
+          Effect.onInterrupt(() =>
+            Effect.sync(() => {
+              interrupted++
+            }).pipe(Effect.andThen(Deferred.await(release)))
+          )
+        )
+        const first = Effect.runForkInWith(Context.empty(), effect, scope)
+        const second = Effect.runForkInWith(Context.empty(), effect, scope)
+        const closeFiber = yield* Scope.close(scope, Exit.void).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+
+        assert.strictEqual(interrupted, 2)
+        assert.isUndefined(closeFiber.pollUnsafe())
+        yield* Deferred.succeed(release, void 0)
+        yield* Fiber.join(closeFiber)
+        assert.isTrue(Exit.hasInterrupts(yield* Fiber.await(first)))
+        assert.isTrue(Exit.hasInterrupts(yield* Fiber.await(second)))
+      }))
+  })
+
   describe("structural compare", () => {
     it("should pass structural comparison", () => {
       assert.deepEqual(Effect.succeed(0), Effect.succeed(0))
@@ -2958,6 +3035,27 @@ describe("Effect", () => {
         const result = yield* Effect.flip(Effect.catch(Effect.fail("e1" as const), () => Effect.fail("e2" as const)))
         assert.deepStrictEqual(result, "e2")
       }))
+    it.effect("catches the typed failure in a mixed cause", () =>
+      Effect.gen(function*() {
+        const result = yield* Effect.catch(
+          Effect.failCause(Cause.combine(Cause.die("defect"), Cause.fail("failure"))),
+          Effect.succeed
+        )
+        assert.strictEqual(result, "failure")
+      }))
+    it.effect("preserves causes without a typed failure", () =>
+      Effect.gen(function*() {
+        const exit = yield* Effect.exit(Effect.catch(Effect.die("defect"), () => Effect.succeed("caught")))
+        assertExitDefect(exit, "defect")
+      }))
+    it.effect("turns a throwing handler into a defect", () =>
+      Effect.gen(function*() {
+        const defect = new Error("boom")
+        const exit = yield* Effect.exit(Effect.catch(Effect.fail("failure"), (): Effect.Effect<never> => {
+          throw defect
+        }))
+        assertExitDefect(exit, defect)
+      }))
   })
 
   describe("firstSuccessOf", () => {
@@ -3436,6 +3534,39 @@ describe("Effect", () => {
         yield* Effect.yieldNow
         yield* TestClock.adjust("2 seconds")
         assert.strictEqual(yield* Fiber.join(secondFiber), 1)
+        assert.strictEqual(count, 1)
+      }))
+  })
+
+  describe("cached", () => {
+    it.effect("runs once for concurrent and subsequent consumers", () =>
+      Effect.gen(function*() {
+        let count = 0
+        const latch = Latch.makeUnsafe()
+        const cached = yield* Effect.cached(
+          latch.await.pipe(
+            Effect.andThen(Effect.sync(() => ++count))
+          )
+        )
+
+        const fibers = yield* Effect.all([cached, cached], { concurrency: "unbounded" }).pipe(Effect.forkChild)
+        yield* Effect.yieldNow
+        latch.openUnsafe()
+
+        assert.deepStrictEqual(yield* Fiber.join(fibers), [1, 1])
+        assert.strictEqual(yield* cached, 1)
+        assert.strictEqual(count, 1)
+      }))
+
+    it.effect("caches failures", () =>
+      Effect.gen(function*() {
+        let count = 0
+        const cached = yield* Effect.cached(
+          Effect.sync(() => ++count).pipe(Effect.andThen(Effect.fail("error")))
+        )
+
+        assertExitFailure(yield* Effect.exit(cached), Cause.fail("error"))
+        assertExitFailure(yield* Effect.exit(cached), Cause.fail("error"))
         assert.strictEqual(count, 1)
       }))
   })

--- a/packages/effect/test/unstable/http/HttpEffect.test.ts
+++ b/packages/effect/test/unstable/http/HttpEffect.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, test } from "@effect/vitest"
 import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
-import { Context, Effect, References, Scope, Stream } from "effect"
+import { Context, Effect, Exit, References, Scope, Stream } from "effect"
 import * as Layer from "effect/Layer"
-import { HttpEffect, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpEffect, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import {
   appendPreResponseHandlerUnsafe,
   requestPreResponseHandlers
@@ -11,6 +11,27 @@ import {
 const TestValue = Context.Reference<number>("test/TestValue", { defaultValue: () => 0 })
 
 describe("HttpEffect", () => {
+  it.effect("passes the response exit to request scope finalizers without tracing", () => {
+    const request = HttpServerRequest.fromWeb(new Request("http://localhost:3000/"))
+    const response = HttpServerResponse.empty()
+    let finalizerExit: Exit.Exit<unknown, unknown> | undefined
+    return Effect.gen(function*() {
+      yield* HttpEffect.toHandledNoTracer(
+        Effect.gen(function*() {
+          yield* Effect.addFinalizer((exit) =>
+            Effect.sync(() => {
+              finalizerExit = exit
+            })
+          )
+          return response
+        }),
+        () => Effect.void
+      )
+
+      deepStrictEqual(finalizerExit, Exit.succeed(response))
+    }).pipe(Effect.provideService(HttpServerRequest.HttpServerRequest, request))
+  })
+
   it.effect("restores the request Scope context identity", () => {
     const request = HttpServerRequest.fromWeb(new Request("http://localhost:3000/"))
     return Effect.gen(function*() {
@@ -34,6 +55,35 @@ describe("HttpEffect", () => {
       Effect.provideService(References.TracerEnabled, false)
     )
   })
+
+  it.effect("restores route context and interruptibility before handling the response", () =>
+    Effect.gen(function*() {
+      const router = yield* HttpRouter.make
+      const request = HttpServerRequest.fromWeb(new Request("http://localhost/"))
+      let routeInterruptible = false
+      let responseInterruptible = true
+      let responseRouteContext: unknown
+
+      yield* router.add("GET", "/", () =>
+        Effect.withFiber((fiber) => {
+          routeInterruptible = (fiber as any).interruptible
+          return Effect.succeed(HttpServerResponse.empty())
+        }))
+
+      yield* HttpEffect.toHandledNoTracer(
+        router.asHttpEffect(),
+        () =>
+          Effect.withFiber((fiber) => {
+            responseInterruptible = (fiber as any).interruptible
+            responseRouteContext = Context.getOrUndefined(fiber.context, HttpRouter.RouteContext)
+            return Effect.void
+          })
+      ).pipe(Effect.provideService(HttpServerRequest.HttpServerRequest, request))
+
+      strictEqual(routeInterruptible, true)
+      strictEqual(responseInterruptible, false)
+      strictEqual(responseRouteContext, undefined)
+    }))
 
   describe("toWebHandler", () => {
     test("json", async () => {

--- a/packages/effect/test/unstable/http/HttpRouter.test.ts
+++ b/packages/effect/test/unstable/http/HttpRouter.test.ts
@@ -1,0 +1,97 @@
+import { assert, it } from "@effect/vitest"
+import { Context, Effect, Exit, Fiber } from "effect"
+import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+
+it("passes the request and matched params to callback routes", async () => {
+  let paramsPrototype: object | null | undefined
+  const { dispose, handler } = HttpRouter.toWebHandler(
+    HttpRouter.add("GET", "/users/:id", (request, params) => {
+      paramsPrototype = Object.getPrototypeOf(params)
+      return Effect.gen(function*() {
+        const contextParams = yield* HttpRouter.params
+        const searchParams = yield* HttpServerRequest.ParsedSearchParams
+        return HttpServerResponse.jsonUnsafe({
+          url: request.url,
+          id: params.id,
+          contextId: contextParams.id,
+          active: searchParams.active
+        })
+      })
+    }),
+    { disableLogger: true }
+  )
+
+  try {
+    const response = await handler(new Request("http://localhost/users/42?active=true"))
+    assert.deepStrictEqual(await response.json(), {
+      url: "/users/42?active=true",
+      id: "42",
+      contextId: "42",
+      active: "true"
+    })
+    assert.strictEqual(paramsPrototype, null)
+  } finally {
+    await dispose()
+  }
+})
+
+it("uses a replaced handler on a spread route", async () => {
+  const original = HttpRouter.route("GET", "/", () => Effect.succeed(HttpServerResponse.text("original")))
+  const replacement = {
+    ...original,
+    handler: Effect.succeed(HttpServerResponse.text("replacement"))
+  }
+  const { dispose, handler } = HttpRouter.toWebHandler(HttpRouter.addAll([replacement]), { disableLogger: true })
+
+  try {
+    const response = await handler(new Request("http://localhost/"))
+    assert.strictEqual(await response.text(), "replacement")
+  } finally {
+    await dispose()
+  }
+})
+
+it.effect("restores route context when a callback throws", () =>
+  Effect.gen(function*() {
+    const router = yield* HttpRouter.make
+    const defect = new Error("boom")
+    yield* router.add("GET", "/", (): Effect.Effect<never> => {
+      throw defect
+    })
+    const request = HttpServerRequest.fromWeb(new Request("http://localhost/"))
+
+    yield* Effect.gen(function*() {
+      const before = yield* Effect.withFiber((fiber) => Effect.succeed(fiber.context))
+      const exit = yield* Effect.exit(router.asHttpEffect())
+      const after = yield* Effect.withFiber((fiber) => Effect.succeed(fiber.context))
+
+      assert.isTrue(Exit.hasDies(exit))
+      assert.strictEqual(after, before)
+      assert.isUndefined(Context.getOrUndefined(after, HttpRouter.RouteContext))
+    }).pipe(Effect.provideService(HttpServerRequest.HttpServerRequest, request))
+  }))
+
+it.effect("observes pending interruption before invoking a route callback", () =>
+  Effect.gen(function*() {
+    const router = yield* HttpRouter.make
+    let invoked = false
+    yield* router.add("GET", "/", () => {
+      invoked = true
+      return Effect.succeed(HttpServerResponse.empty())
+    })
+    const request = HttpServerRequest.fromWeb(new Request("http://localhost/"))
+
+    const fiber = yield* Effect.uninterruptible(
+      Effect.withFiber((fiber) => {
+        fiber.interruptUnsafe(fiber.id)
+        return router.asHttpEffect()
+      })
+    ).pipe(
+      Effect.provideService(HttpServerRequest.HttpServerRequest, request),
+      Effect.forkChild
+    )
+    const exit = yield* Fiber.await(fiber)
+
+    assert.isTrue(Exit.hasInterrupts(exit))
+    assert.isFalse(invoked)
+  }))

--- a/packages/effect/typetest/Context.tst.ts
+++ b/packages/effect/typetest/Context.tst.ts
@@ -1,6 +1,20 @@
 import { Context, Option } from "effect"
 import { expect, it } from "tstyche"
 
+it("addUnsafe2 preserves explicitly supplied service identifiers", () => {
+  const ServiceA = Context.Service<{ readonly value: number }>("ServiceA")
+  const ServiceB = Context.Service<{ readonly value: string }>("ServiceB")
+  const context = Context.addUnsafe2<
+    never,
+    typeof ServiceA,
+    { readonly value: number },
+    typeof ServiceB,
+    { readonly value: string }
+  >(Context.empty(), ServiceA.key, { value: 1 }, ServiceB.key, { value: "value" })
+
+  expect(context).type.toBe<Context.Context<typeof ServiceA | typeof ServiceB>>()
+})
+
 it("does not type a service removed with addOrOmit as present", () => {
   const Service = Context.Service<{ readonly value: number }>("TestService")
   const context = Context.make(Service, { value: 1 }).pipe(Context.addOrOmit(Service, Option.none()))

--- a/packages/effect/typetest/Effect.tst.ts
+++ b/packages/effect/typetest/Effect.tst.ts
@@ -160,6 +160,28 @@ describe("Effect.tryPromise", () => {
   })
 })
 
+describe("Effect.runForkWith", () => {
+  const context = Context.make(AcquireReleaseDependency, "value")
+
+  it("supports the curried form", () => {
+    expect(Effect.runForkWith(context)(AcquireReleaseDependency)).type.toBe<Fiber.Fiber<string>>()
+  })
+
+  it("supports the uncurried form", () => {
+    expect(Effect.runForkWith(context, AcquireReleaseDependency)).type.toBe<Fiber.Fiber<string>>()
+  })
+})
+
+describe("Effect.runForkInWith", () => {
+  const context = Context.make(AcquireReleaseDependency, "value")
+  const scope = null as any as Scope.Scope
+
+  it("provides context services and preserves the error type", () => {
+    expect(Effect.runForkInWith(context, Effect.andThen(AcquireReleaseDependency, Effect.fail("error")), scope)).type
+      .toBe<Fiber.Fiber<never, string>>()
+  })
+})
+
 describe("Effect.catchReason", () => {
   it("handler receives reason type", () => {
     pipe(

--- a/packages/effect/typetest/unstable/http/HttpRouter.tst.ts
+++ b/packages/effect/typetest/unstable/http/HttpRouter.tst.ts
@@ -1,8 +1,18 @@
 import { Context, Effect, Layer } from "effect"
-import { HttpRouter, type HttpServerError, HttpServerResponse } from "effect/unstable/http"
+import { HttpRouter, type HttpServerError, type HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { describe, expect, it } from "tstyche"
 
 describe("HttpRouter", () => {
+  describe("route", () => {
+    it("types callback request and params", () => {
+      HttpRouter.route("GET", "/users/:id", (request, params) => {
+        expect(request).type.toBe<HttpServerRequest.HttpServerRequest>()
+        expect(params).type.toBe<Readonly<Record<string, string | undefined>>>()
+        return Effect.succeed(HttpServerResponse.text(params.id ?? "missing"))
+      })
+    })
+  })
+
   describe("middleware", () => {
     it("provides handled request errors", () => {
       class MyError {

--- a/packages/platform/bun/src/BunHttpServer.ts
+++ b/packages/platform/bun/src/BunHttpServer.ts
@@ -28,6 +28,7 @@ import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
 import type * as Path from "effect/Path"
 import type * as Record from "effect/Record"
+import * as References from "effect/References"
 import * as Scheduler from "effect/Scheduler"
 import type * as Schema from "effect/Schema"
 import * as Scope from "effect/Scope"
@@ -161,20 +162,24 @@ export const make = Effect.fnUntraced(
         const services = parent.context
         const serveScope = Context.getUnsafe(services, Scope.Scope)
         const scope = Scope.forkUnsafe(serveScope, "parallel")
+        const runInScope = Fiber.runIn(scope)
 
-        const httpEffect = HttpEffect.toHandled(httpApp, (request, response) =>
+        const toHandled = parent.getRef(References.TracerEnabled)
+          ? HttpEffect.toHandled
+          : HttpEffect.toHandledNoTracer
+        const httpEffect = toHandled(httpApp, (request, response) =>
           Effect.sync(() => {
             ;(request as BunServerRequest).resolve(makeResponse(request, response, services, scope))
           }), middleware)
 
         function handler(request: Request, server: BunServer<WebSocketContext>) {
           return new Promise<Response>((resolve, _reject) => {
-            const context = Context.add(
+            const context = Context.addUnsafe(
               services,
-              ServerRequest.HttpServerRequest,
+              ServerRequest.HttpServerRequest.key,
               new BunServerRequest(request, resolve, removeHost(request.url), server, compressionThreshold)
             )
-            const fiber = Fiber.runIn(Effect.runForkWith(context)(httpEffect), scope)
+            const fiber = runInScope(Effect.runForkWith(context, httpEffect))
             request.signal.addEventListener("abort", () => {
               fiber.interruptUnsafe(parent.id, Error.ClientAbort.annotation)
             }, { once: true })

--- a/packages/platform/deno/src/DenoHttpServer.ts
+++ b/packages/platform/deno/src/DenoHttpServer.ts
@@ -16,6 +16,7 @@ import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
 import type * as Path from "effect/Path"
 import type * as Record from "effect/Record"
+import * as References from "effect/References"
 import type * as Schema from "effect/Schema"
 import * as Scope from "effect/Scope"
 import * as Stream from "effect/Stream"
@@ -110,8 +111,12 @@ export const make = Effect.fnUntraced(function*(
       const services = parent.context
       const serveScope = Context.getUnsafe(services, Scope.Scope)
       const scope = Scope.forkUnsafe(serveScope, "parallel")
+      const runInScope = Fiber.runIn(scope)
 
-      const httpEffect = HttpEffect.toHandled(httpApp, (request, response) => {
+      const toHandled = parent.getRef(References.TracerEnabled)
+        ? HttpEffect.toHandled
+        : HttpEffect.toHandledNoTracer
+      const httpEffect = toHandled(httpApp, (request, response) => {
         const denoRequest = request as DenoServerRequest
         if (denoRequest.upgraded) return cancelResponseBody(response.body)
         return Effect.flatMap(
@@ -125,12 +130,12 @@ export const make = Effect.fnUntraced(function*(
         info: Deno.ServeHandlerInfo<Deno.NetAddr | Deno.UnixAddr>
       ): Promise<Response> {
         return new Promise<Response>((resolve) => {
-          const context = Context.add(
+          const context = Context.addUnsafe(
             services,
-            ServerRequest.HttpServerRequest,
+            ServerRequest.HttpServerRequest.key,
             new DenoServerRequest(request, info.remoteAddr, resolve, removeHost(request.url), websocket)
           )
-          const fiber = Fiber.runIn(Effect.runForkWith(context)(httpEffect), scope)
+          const fiber = runInScope(Effect.runForkWith(context, httpEffect))
           request.signal.addEventListener("abort", () => {
             fiber.interruptUnsafe(parent.id, Error.ClientAbort.annotation)
           }, { once: true })

--- a/packages/platform/node-shared/src/NodeStream.ts
+++ b/packages/platform/node-shared/src/NodeStream.ts
@@ -241,16 +241,22 @@ export const toString = <E = Cause.UnknownError>(
     stream.once("end", () => {
       resume(Effect.succeed(string))
     })
-    stream.on("data", (chunk) => {
-      string += chunk
-      bytes += Buffer.byteLength(chunk)
-      if (maxBytesNumber !== undefined && bytes > maxBytesNumber) {
-        if ("closed" in stream && !stream.closed) {
-          stream.destroy()
+    if (maxBytesNumber === undefined) {
+      stream.on("data", (chunk) => {
+        string += chunk
+      })
+    } else {
+      stream.on("data", (chunk) => {
+        string += chunk
+        bytes += Buffer.byteLength(chunk)
+        if (bytes > maxBytesNumber) {
+          if ("closed" in stream && !stream.closed) {
+            stream.destroy()
+          }
+          resume(Effect.fail(onError(new Error("maxBytes exceeded")) as E))
         }
-        resume(Effect.fail(onError(new Error("maxBytes exceeded")) as E))
-      }
-    })
+      })
+    }
     return Effect.sync(() => {
       if ("closed" in stream && !stream.closed) {
         stream.destroy()

--- a/packages/platform/node/src/NodeHttpIncomingMessage.ts
+++ b/packages/platform/node/src/NodeHttpIncomingMessage.ts
@@ -11,6 +11,7 @@
  *
  * @since 4.0.0
  */
+import * as Deferred from "effect/Deferred"
 import * as Effect from "effect/Effect"
 import * as Inspectable from "effect/Inspectable"
 import * as Option from "effect/Option"
@@ -21,6 +22,19 @@ import * as IncomingMessage from "effect/unstable/http/HttpIncomingMessage"
 import * as UrlParams from "effect/unstable/http/UrlParams"
 import type * as Http from "node:http"
 import * as NodeStream from "./NodeStream.ts"
+
+const cachedUnsafe = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> => {
+  const deferred = Deferred.makeUnsafe<A, E>()
+  let started = false
+  return Effect.suspend(() => {
+    if (started) return Deferred.await(deferred)
+    started = true
+    return Effect.onExitPrimitive(effect, (exit) => {
+      Deferred.doneUnsafe(deferred, exit)
+      return undefined
+    })
+  })
+}
 
 /**
  * Adapts a Node `IncomingMessage` to Effect HTTP incoming messages.
@@ -76,7 +90,7 @@ export abstract class NodeHttpIncomingMessage<E> extends Inspectable.Class
     if (this.textEffect) {
       return this.textEffect
     }
-    this.textEffect = Effect.runSync(Effect.cached(
+    this.textEffect = cachedUnsafe(
       Effect.flatMap(
         IncomingMessage.MaxBodySize,
         (maxBodySize) =>
@@ -85,7 +99,7 @@ export abstract class NodeHttpIncomingMessage<E> extends Inspectable.Class
             maxBytes: maxBodySize
           })
       )
-    ))
+    )
     this.arrayBufferEffect = Effect.map(this.textEffect, (_) => new TextEncoder().encode(_).buffer)
     return this.textEffect
   }
@@ -126,15 +140,12 @@ export abstract class NodeHttpIncomingMessage<E> extends Inspectable.Class
     if (this.arrayBufferEffect) {
       return this.arrayBufferEffect
     }
-    this.arrayBufferEffect = Effect.withFiber((fiber) =>
+    this.arrayBufferEffect = cachedUnsafe(Effect.withFiber((fiber) =>
       NodeStream.toArrayBuffer(() => this.source, {
         onError: this.onError,
         maxBytes: fiber.getRef(IncomingMessage.MaxBodySize)
       })
-    ).pipe(
-      Effect.cached,
-      Effect.runSync
-    )
+    ))
     this.textEffect = Effect.map(this.arrayBufferEffect, (_) => new TextDecoder().decode(_))
     return this.arrayBufferEffect
   }

--- a/packages/platform/node/src/NodeHttpServer.ts
+++ b/packages/platform/node/src/NodeHttpServer.ts
@@ -25,6 +25,7 @@ import * as Layer from "effect/Layer"
 import type * as Option from "effect/Option"
 import type * as Path from "effect/Path"
 import type * as Record from "effect/Record"
+import * as References from "effect/References"
 import * as Scope from "effect/Scope"
 import * as Stream from "effect/Stream"
 import * as Cookies from "effect/unstable/http/Cookies"
@@ -199,15 +200,21 @@ export const makeHandler = <
   never,
   Exclude<Effect.Services<App>, HttpServerRequest | Scope.Scope>
 > => {
-  const handled = HttpEffect.toHandled(httpEffect, handleResponse, options.middleware as any)
   return Effect.withFiber((parent) => {
+    const handled = parent.getRef(References.TracerEnabled)
+      ? HttpEffect.toHandled(httpEffect, handleResponse, options.middleware as any)
+      : HttpEffect.toHandledNoTracer(httpEffect, handleResponse, options.middleware as any)
     const services = parent.context
     return Effect.succeed(function handler(
       nodeRequest: Http.IncomingMessage,
       nodeResponse: Http.ServerResponse
     ) {
-      const context = Context.add(services, HttpServerRequest, new ServerRequestImpl(nodeRequest, nodeResponse))
-      const fiber = Fiber.runIn(Effect.runForkWith(context as Context.Context<any>)(handled), options.scope)
+      const context = Context.addUnsafe(
+        services,
+        HttpServerRequest.key,
+        new ServerRequestImpl(nodeRequest, nodeResponse)
+      )
+      const fiber = Effect.runForkInWith(context as Context.Context<any>, handled, options.scope)
       nodeResponse.on("close", () => {
         if (!nodeResponse.writableEnded) {
           fiber.interruptUnsafe(parent.id, ClientAbort.annotation)
@@ -241,9 +248,12 @@ export const makeUpgradeHandler = <
   never,
   Exclude<Effect.Services<App>, HttpServerRequest | Scope.Scope>
 > => {
-  const handledApp = HttpEffect.toHandled(httpEffect, handleResponse, options.middleware as any)
   return Effect.withFiber((parent) => {
+    const handledApp = parent.getRef(References.TracerEnabled)
+      ? HttpEffect.toHandled(httpEffect, handleResponse, options.middleware as any)
+      : HttpEffect.toHandledNoTracer(httpEffect, handleResponse, options.middleware as any)
     const services = parent.context
+    const runInScope = Fiber.runIn(options.scope)
     return Effect.succeed(function handler(
       nodeRequest: Http.IncomingMessage,
       socket: Duplex,
@@ -281,12 +291,12 @@ export const makeUpgradeHandler = <
             (ws) => Effect.sync(() => ws.close())
           )
       ))
-      const context = Context.add(
+      const context = Context.addUnsafe(
         services,
-        HttpServerRequest,
+        HttpServerRequest.key,
         new ServerRequestImpl(nodeRequest, nodeResponse, upgradeEffect)
       )
-      const fiber = Fiber.runIn(Effect.runForkWith(context as Context.Context<any>)(handledApp), options.scope)
+      const fiber = runInScope(Effect.runForkWith(context as Context.Context<any>, handledApp))
       socket.on("error", () => {})
       socket.on("close", () => {
         if (!socket.writableEnded) {

--- a/packages/platform/node/test/NodeHttpServer.test.ts
+++ b/packages/platform/node/test/NodeHttpServer.test.ts
@@ -46,6 +46,23 @@ const IdParams = Schema.Struct({
 const todoResponse = HttpServerResponse.schemaJson(Todo)
 
 describe("HttpServer", () => {
+  it.effect("caches concurrent and subsequent text body reads", () =>
+    Effect.gen(function*() {
+      yield* HttpRouter.add(
+        "POST",
+        "/body",
+        (request) =>
+          Effect.gen(function*() {
+            const [first, second] = yield* Effect.all([request.text, request.text], { concurrency: "unbounded" })
+            const third = yield* request.text
+            return HttpServerResponse.text(`${first}|${second}|${third}`)
+          })
+      ).pipe(HttpRouter.serve, Layer.build)
+
+      const response = yield* HttpClient.post("/body", { body: HttpBody.text("payload") })
+      assert.strictEqual(yield* response.text, "payload|payload|payload")
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)))
+
   it.effect("schema", () =>
     Effect.gen(function*() {
       yield* HttpRouter.add(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -987,6 +987,13 @@ importers:
       effect:
         specifier: workspace:*
         version: link:../packages/effect
+    devDependencies:
+      '@hono/node-server':
+        specifier: ^2.1.1
+        version: 2.1.1(hono@4.13.5)
+      hono:
+        specifier: ^4.13.5
+        version: 4.13.5
 
   scripts:
     dependencies:
@@ -2000,6 +2007,12 @@ packages:
     resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@hono/node-server@2.1.1':
+    resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -7644,6 +7657,10 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.6.6
       yargs: 17.7.3
+
+  '@hono/node-server@2.1.1(hono@4.13.5)':
+    dependencies:
+      hono: 4.13.5
 
   '@img/colour@1.1.0': {}
 

--- a/scratchpad/http-api-benchmark/README.md
+++ b/scratchpad/http-api-benchmark/README.md
@@ -1,0 +1,74 @@
+# Effect HttpServer vs Hono filesystem benchmark
+
+This exploratory benchmark compares Effect's plain `HttpRouter` server and Hono while serving the same small document
+API on Node.js.
+It deliberately avoids no-op or tiny synchronous handlers.
+
+Each measured request does all of the following:
+
+- routes and validates a document id
+- parses or serializes JSON
+- reads or writes a 16 KiB document with asynchronous `node:fs/promises`
+- transfers the complete response body over a keep-alive HTTP/1.1 connection
+
+The default workload is 80% `GET /documents/:id` and 20% `PUT /documents/:id` at 32 concurrent connections.
+Reads and writes use disjoint pre-seeded files so concurrent writes cannot make reads observe partially replaced content.
+
+## Run
+
+From the repository root:
+
+```sh
+node scratchpad/http-api-benchmark/run.ts
+```
+
+A quicker smoke run:
+
+```sh
+node scratchpad/http-api-benchmark/run.ts --rounds=1 --warmup=0.5 --duration=1
+```
+
+Record raw data for later comparison:
+
+```sh
+node scratchpad/http-api-benchmark/run.ts --json=scratchpad/http-api-benchmark/results.json
+```
+
+Run `node scratchpad/http-api-benchmark/run.ts --help` for all tuning options. Use `--read-percent=100` or
+`--read-percent=0` to isolate reads or writes. `BENCH_TMPDIR` can place the corpus on a specific filesystem.
+
+## Fairness controls
+
+- Both implementations use the same functions in `shared.ts`, including identical `readFile` and `writeFile` calls.
+- Both implementations use the same manually written id and payload validation predicates.
+- Both run in fresh child processes on Node's HTTP server stack and receive the same request bodies and concurrency.
+- Both enforce the same id, JSON object, non-empty content, and 64 KiB maximum-length rules.
+- Correctness probes verify reads, writes, persistence, invalid ids, and invalid payloads before each timed run.
+- Timed requests check status and response size, and the correctness probes run again after each measured interval. Any
+  invalid measured response aborts the comparison instead of contributing to the reported throughput.
+- Corpus creation, server startup, correctness checks, and warmup are outside the measured interval.
+- Each framework gets a fresh temporary corpus. The runner removes the corpus and closes the server after every run.
+- Paired rounds alternate Effect-first and Hono-first order to reduce systematic thermal and ordering bias.
+- Effect tracing and request logging are disabled; the Hono server has no telemetry configured.
+- The client consumes every response. Server CPU and event-loop utilization are measured in the child, independently
+  from the load-generator process.
+
+## Interpretation
+
+The benchmark measures an in-process development-style JSON API whose useful work is asynchronous filesystem I/O. It
+includes each framework's normal routing and request/response behavior. Both implementations parse JSON, apply the same
+explicit validation checks, and serialize plain response objects without schema decoding or encoding.
+
+`writeFile` completion does not imply durable media persistence because the benchmark does not call `fsync`. Reads are
+also likely to hit the operating-system page cache after warmup. This is intentional: the workload exercises realistic
+asynchronous boundaries without turning the comparison into a storage-device benchmark.
+
+Results remain sensitive to Node version, CPU scaling, filesystem, background activity, payload size, read/write mix,
+and concurrency. Use the same machine and settings, run all paired rounds, inspect variability, and do not use a single
+run as evidence of a general performance claim. For lower-noise publication-quality measurements, pin processes to
+dedicated cores where the operating system permits it and generate load from a separate machine.
+
+The built-in generator is closed-loop: each connection sends its next request only after receiving the previous
+response. Its latency percentiles therefore describe response time at fixed concurrency and do not correct for
+coordinated omission. Use an open-loop external load generator as an additional test when evaluating latency under a
+fixed arrival rate.

--- a/scratchpad/http-api-benchmark/effect.ts
+++ b/scratchpad/http-api-benchmark/effect.ts
@@ -1,0 +1,65 @@
+import { NodeHttpServer, NodeRuntime } from "@effect/platform-node"
+import { Effect, Layer } from "effect"
+import { HttpRouter, HttpServerResponse } from "effect/unstable/http"
+import { createServer } from "node:http"
+import {
+  HOST,
+  installServerMetrics,
+  isDocumentId,
+  isWritePayload,
+  parseServerEnvironment,
+  readDocument,
+  writeDocument
+} from "./shared.ts"
+
+const { port, root } = parseServerEnvironment()
+installServerMetrics()
+
+const badRequest = (error: string) => HttpServerResponse.jsonUnsafe({ error }, { status: 400 })
+
+const Routes = HttpRouter.use(Effect.fnUntraced(function*(router) {
+  yield* router.add(
+    "GET",
+    "/documents/:id",
+    (_request, { id }) => {
+      if (!isDocumentId(id)) {
+        return Effect.succeed(badRequest("invalid document id"))
+      }
+      return Effect.map(
+        Effect.tryPromise(() => readDocument(root, id)).pipe(Effect.orDie),
+        HttpServerResponse.jsonUnsafe
+      )
+    }
+  )
+
+  yield* router.add(
+    "PUT",
+    "/documents/:id",
+    (request, { id }) => {
+      if (!isDocumentId(id)) {
+        return Effect.succeed(badRequest("invalid document id"))
+      }
+      return Effect.flatMap(Effect.catch(request.json, () => Effect.succeed(undefined)), (payload) => {
+        if (!isWritePayload(payload)) {
+          return Effect.succeed(
+            badRequest(payload === undefined ? "invalid JSON payload" : "invalid document payload")
+          )
+        }
+        return Effect.map(
+          Effect.tryPromise(() => writeDocument(root, id, payload.content)).pipe(Effect.orDie),
+          HttpServerResponse.jsonUnsafe
+        )
+      })
+    }
+  )
+}))
+
+HttpRouter.serve(Routes, {
+  disableListenLog: true,
+  disableLogger: true
+}).pipe(
+  Layer.provide(NodeHttpServer.layer(createServer, { host: HOST, port })),
+  Layer.launch,
+  Effect.withTracerEnabled(false),
+  NodeRuntime.runMain
+)

--- a/scratchpad/http-api-benchmark/hono.ts
+++ b/scratchpad/http-api-benchmark/hono.ts
@@ -1,0 +1,51 @@
+import { serve } from "@hono/node-server"
+import { Hono } from "hono"
+import {
+  HOST,
+  installServerMetrics,
+  isDocumentId,
+  isWritePayload,
+  parseServerEnvironment,
+  readDocument,
+  writeDocument
+} from "./shared.ts"
+
+const { port, root } = parseServerEnvironment()
+installServerMetrics()
+
+const app = new Hono()
+
+app.get("/documents/:id", async (context) => {
+  const id = context.req.param("id")
+  if (!isDocumentId(id)) {
+    return context.json({ error: "invalid document id" }, 400)
+  }
+  return context.json(await readDocument(root, id))
+})
+
+app.put("/documents/:id", async (context) => {
+  const id = context.req.param("id")
+  if (!isDocumentId(id)) {
+    return context.json({ error: "invalid document id" }, 400)
+  }
+
+  let payload: unknown
+  try {
+    payload = await context.req.json()
+  } catch {
+    return context.json({ error: "invalid JSON payload" }, 400)
+  }
+  if (!isWritePayload(payload)) {
+    return context.json({ error: "invalid document payload" }, 400)
+  }
+
+  return context.json(await writeDocument(root, id, payload.content))
+})
+
+const server = serve({ fetch: app.fetch, hostname: HOST, port })
+
+const shutdown = () => {
+  server.close(() => process.exit(0))
+}
+process.once("SIGINT", shutdown)
+process.once("SIGTERM", shutdown)

--- a/scratchpad/http-api-benchmark/run.ts
+++ b/scratchpad/http-api-benchmark/run.ts
@@ -1,0 +1,642 @@
+import { type ChildProcess, execFileSync, spawn } from "node:child_process"
+import { createHash } from "node:crypto"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { Agent, createServer, request } from "node:http"
+import { cpus, tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { HOST, MAX_DOCUMENT_LENGTH, type MetricsResponse, type ServerMetrics } from "./shared.ts"
+
+type Framework = "Effect HttpServer" | "Hono"
+
+interface Config {
+  readonly connections: number
+  readonly documents: number
+  readonly durationMs: number
+  readonly jsonPath: string | undefined
+  readonly payloadBytes: number
+  readonly readPercent: number
+  readonly rounds: number
+  readonly warmupMs: number
+}
+
+interface HttpResult {
+  readonly body: string
+  readonly bytes: number
+  readonly status: number
+}
+
+interface LoadResult {
+  readonly errors: number
+  readonly elapsedMs: number
+  readonly firstError: string | undefined
+  readonly latencies: ReadonlyArray<number>
+  readonly readRequests: number
+  readonly responseBytes: number
+  readonly requests: number
+  readonly writeRequests: number
+}
+
+interface RoundResult {
+  readonly framework: Framework
+  readonly round: number
+  readonly order: number
+  readonly requests: number
+  readonly readRequests: number
+  readonly writeRequests: number
+  readonly errors: number
+  readonly requestsPerSecond: number
+  readonly responseMiBPerSecond: number
+  readonly p50Ms: number
+  readonly p95Ms: number
+  readonly p99Ms: number
+  readonly maxMs: number
+  readonly serverCpuMsPerRequest: number
+  readonly serverEventLoopUtilization: number
+  readonly serverRssMiB: number
+}
+
+interface RunningServer {
+  readonly child: ChildProcess
+  readonly port: number
+  readonly stderr: () => string
+  readonly stdout: () => string
+}
+
+const help = `Usage: node scratchpad/http-api-benchmark/run.ts [options]
+
+Options:
+  --connections=N       Concurrent keep-alive connections (default: 32)
+  --documents=N         Files per operation type, 1-1000 (default: 256)
+  --duration=N          Measured seconds per server per round (default: 10)
+  --json=PATH           Also write raw results as JSON
+  --payload-kib=N       ASCII document size in KiB, max 64 (default: 16)
+  --read-percent=N      Percentage of GET requests, 0-100 (default: 80)
+  --rounds=N            Paired rounds with alternating order (default: 5)
+  --warmup=N            Warmup seconds per server per round (default: 3)
+  --help                 Show this message
+`
+
+const argumentsMap = new Map<string, string>()
+for (const argument of process.argv.slice(2)) {
+  if (argument === "--help") {
+    console.log(help)
+    process.exit(0)
+  }
+  const match = /^(--[^=]+)=(.+)$/.exec(argument)
+  if (match === null) {
+    throw new Error(`Invalid argument: ${argument}\n\n${help}`)
+  }
+  argumentsMap.set(match[1], match[2])
+}
+
+const numberArgument = (name: string, fallback: number, minimum: number, maximum: number): number => {
+  const raw = argumentsMap.get(name)
+  if (raw === undefined) {
+    return fallback
+  }
+  const value = Number(raw)
+  if (!Number.isFinite(value) || value < minimum || value > maximum) {
+    throw new Error(`${name} must be between ${minimum} and ${maximum}`)
+  }
+  return value
+}
+
+const integerArgument = (name: string, fallback: number, minimum: number, maximum: number): number => {
+  const value = numberArgument(name, fallback, minimum, maximum)
+  if (!Number.isInteger(value)) {
+    throw new Error(`${name} must be an integer`)
+  }
+  return value
+}
+
+const knownArguments = new Set([
+  "--connections",
+  "--documents",
+  "--duration",
+  "--json",
+  "--payload-kib",
+  "--read-percent",
+  "--rounds",
+  "--warmup"
+])
+for (const argument of argumentsMap.keys()) {
+  if (!knownArguments.has(argument)) {
+    throw new Error(`Unknown argument: ${argument}\n\n${help}`)
+  }
+}
+
+const config: Config = {
+  connections: integerArgument("--connections", 32, 1, 512),
+  documents: integerArgument("--documents", 256, 1, 1_000),
+  durationMs: numberArgument("--duration", 10, 0.1, 3_600) * 1_000,
+  jsonPath: argumentsMap.get("--json"),
+  payloadBytes: integerArgument("--payload-kib", 16, 1, MAX_DOCUMENT_LENGTH / 1_024) * 1_024,
+  readPercent: integerArgument("--read-percent", 80, 0, 100),
+  rounds: integerArgument("--rounds", 5, 1, 100),
+  warmupMs: numberArgument("--warmup", 3, 0, 3_600) * 1_000
+}
+
+const makeContent = (label: string): string => {
+  const prefix = `${label}:`
+  return prefix + "x".repeat(config.payloadBytes - prefix.length)
+}
+
+const readContent = makeContent("read")
+const writeContent = makeContent("write")
+const writeBody = JSON.stringify({ content: writeContent })
+const readResponseBytes = Buffer.byteLength(JSON.stringify({
+  id: "read-000",
+  content: readContent,
+  bytes: config.payloadBytes
+}))
+const writeResponseBytes = Buffer.byteLength(JSON.stringify({ id: "write-000", bytes: config.payloadBytes }))
+
+const packageVersion = async (specifier: string): Promise<string> => {
+  const packageJsonUrl = new URL("../package.json", import.meta.resolve(specifier))
+  const packageJson = JSON.parse(await readFile(packageJsonUrl, "utf8")) as { readonly version?: unknown }
+  if (typeof packageJson.version !== "string") {
+    throw new Error(`Could not read the version for ${specifier}`)
+  }
+  return packageJson.version
+}
+
+const versions = {
+  effect: await packageVersion("effect"),
+  hono: await packageVersion("hono"),
+  honoNodeServer: await packageVersion("@hono/node-server")
+}
+const benchmarkSourceHash = createHash("sha256")
+for (const filename of ["effect.ts", "hono.ts", "run.ts", "shared.ts"]) {
+  benchmarkSourceHash.update(await readFile(new URL(filename, import.meta.url)))
+}
+const sourceHash = benchmarkSourceHash.digest("hex")
+const git = {
+  revision: execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
+  dirty: execFileSync("git", ["status", "--porcelain"], { encoding: "utf8" }).trim().length > 0
+}
+const corpusBaseDirectory = process.env.BENCH_TMPDIR ?? tmpdir()
+
+const documentId = (operation: "read" | "write", index: number): string =>
+  `${operation}-${index.toString().padStart(3, "0")}`
+
+const percentile = (sorted: ReadonlyArray<number>, quantile: number): number => {
+  if (sorted.length === 0) {
+    return Number.NaN
+  }
+  return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * quantile) - 1)]
+}
+
+const median = (values: ReadonlyArray<number>): number => {
+  const sorted = [...values].sort((left, right) => left - right)
+  const middle = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle]
+}
+
+const getFreePort = (): Promise<number> =>
+  new Promise((resolve, reject) => {
+    const server = createServer()
+    server.once("error", reject)
+    server.listen(0, HOST, () => {
+      const address = server.address()
+      if (address === null || typeof address === "string") {
+        server.close()
+        reject(new Error("Could not allocate a benchmark port"))
+        return
+      }
+      server.close((error) => error ? reject(error) : resolve(address.port))
+    })
+  })
+
+const sendRequest = (
+  port: number,
+  method: "GET" | "PUT",
+  path: string,
+  body?: string,
+  agent?: Agent,
+  collectBody = true,
+  timeoutMs = 30_000
+): Promise<HttpResult> =>
+  new Promise((resolve, reject) => {
+    const req = request({
+      agent,
+      hostname: HOST,
+      method,
+      path,
+      port,
+      headers: body === undefined ? { accept: "application/json" } : {
+        accept: "application/json",
+        "content-length": Buffer.byteLength(body),
+        "content-type": "application/json"
+      }
+    }, (response) => {
+      const chunks: Array<Buffer> | undefined = collectBody ? [] : undefined
+      let bytes = 0
+      response.on("data", (chunk: Buffer) => {
+        chunks?.push(chunk)
+        bytes += chunk.length
+      })
+      response.once("end", () => {
+        resolve({
+          body: chunks === undefined ? "" : Buffer.concat(chunks, bytes).toString("utf8"),
+          bytes,
+          status: response.statusCode ?? 0
+        })
+      })
+      response.once("error", reject)
+    })
+    req.setTimeout(timeoutMs, () => req.destroy(new Error("request timed out")))
+    req.once("error", reject)
+    req.end(body)
+  })
+
+const waitForServer = async (server: RunningServer): Promise<void> => {
+  const deadline = Date.now() + 15_000
+  while (Date.now() < deadline) {
+    if (server.child.exitCode !== null) {
+      throw new Error(
+        `Server exited during startup with code ${server.child.exitCode}\n${server.stderr()}${server.stdout()}`
+      )
+    }
+    try {
+      const response = await sendRequest(server.port, "GET", "/documents/read-000", undefined, undefined, true, 500)
+      if (response.status === 200) {
+        return
+      }
+    } catch {
+      // The child process has not started listening yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  throw new Error(`Server did not start within 15 seconds\n${server.stderr()}${server.stdout()}`)
+}
+
+const startServer = async (framework: Framework, root: string): Promise<RunningServer> => {
+  const port = await getFreePort()
+  const entrypoint = framework === "Effect HttpServer" ? "effect.ts" : "hono.ts"
+  const child = spawn(process.execPath, [fileURLToPath(new URL(entrypoint, import.meta.url))], {
+    env: { ...process.env, BENCH_ROOT: root, PORT: String(port) },
+    stdio: ["ignore", "pipe", "pipe", "ipc"]
+  })
+  let stdout = ""
+  let stderr = ""
+  child.stdout?.setEncoding("utf8")
+  child.stderr?.setEncoding("utf8")
+  child.stdout?.on("data", (chunk: string) => {
+    stdout += chunk
+  })
+  child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk
+  })
+  const running = { child, port, stderr: () => stderr, stdout: () => stdout }
+  try {
+    await waitForServer(running)
+    return running
+  } catch (error) {
+    await stopServer(running)
+    throw error
+  }
+}
+
+let metricsMessageId = 0
+const sendMetricsMessage = <Type extends MetricsResponse["type"]>(
+  child: ChildProcess,
+  type: Type extends "metrics:started" ? "metrics:start" : "metrics:stop",
+  responseType: Type
+): Promise<Extract<MetricsResponse, { readonly type: Type }>> =>
+  new Promise((resolve, reject) => {
+    const id = ++metricsMessageId
+    const timeout = setTimeout(() => {
+      child.off("message", onMessage)
+      reject(new Error(`Timed out waiting for ${responseType}`))
+    }, 5_000)
+    const onMessage = (message: MetricsResponse) => {
+      if (message.type === responseType && message.id === id) {
+        clearTimeout(timeout)
+        child.off("message", onMessage)
+        resolve(message as Extract<MetricsResponse, { readonly type: Type }>)
+      }
+    }
+    child.on("message", onMessage)
+    child.send({ type, id }, (error) => {
+      if (error) {
+        clearTimeout(timeout)
+        child.off("message", onMessage)
+        reject(error)
+      }
+    })
+  })
+
+const stopServer = async (server: RunningServer): Promise<void> => {
+  if (server.child.exitCode !== null) {
+    return
+  }
+  server.child.kill("SIGTERM")
+  await new Promise<void>((resolve) => {
+    const timeout = setTimeout(() => {
+      server.child.kill("SIGKILL")
+    }, 5_000)
+    server.child.once("exit", () => {
+      clearTimeout(timeout)
+      resolve()
+    })
+  })
+}
+
+const assertStatus = (result: HttpResult, expected: number, label: string): void => {
+  if (result.status !== expected) {
+    throw new Error(`${label}: expected HTTP ${expected}, received ${result.status}: ${result.body}`)
+  }
+}
+
+const verifyServer = async (port: number): Promise<void> => {
+  const read = await sendRequest(port, "GET", "/documents/read-000")
+  assertStatus(read, 200, "read probe")
+  const readJson = JSON.parse(read.body) as {
+    readonly id?: unknown
+    readonly content?: unknown
+    readonly bytes?: unknown
+  }
+  if (readJson.id !== "read-000" || readJson.content !== readContent || readJson.bytes !== config.payloadBytes) {
+    throw new Error("read probe returned an unexpected response")
+  }
+
+  const write = await sendRequest(port, "PUT", "/documents/write-000", writeBody)
+  assertStatus(write, 200, "write probe")
+  const writeJson = JSON.parse(write.body) as { readonly id?: unknown; readonly bytes?: unknown }
+  if (writeJson.id !== "write-000" || writeJson.bytes !== config.payloadBytes) {
+    throw new Error("write probe returned an unexpected response")
+  }
+
+  const written = await sendRequest(port, "GET", "/documents/write-000")
+  assertStatus(written, 200, "written document probe")
+  const writtenJson = JSON.parse(written.body) as { readonly content?: unknown }
+  if (writtenJson.content !== writeContent) {
+    throw new Error("write probe did not persist the expected content")
+  }
+
+  assertStatus(await sendRequest(port, "GET", "/documents/invalid"), 400, "invalid id probe")
+  assertStatus(await sendRequest(port, "PUT", "/documents/write-000", "{}"), 400, "invalid payload probe")
+}
+
+const runLoad = async (port: number, durationMs: number, agent: Agent): Promise<LoadResult> => {
+  if (durationMs === 0) {
+    return {
+      errors: 0,
+      elapsedMs: 0,
+      firstError: undefined,
+      latencies: [],
+      readRequests: 0,
+      requests: 0,
+      responseBytes: 0,
+      writeRequests: 0
+    }
+  }
+
+  const latencies: Array<number> = []
+  let errors = 0
+  let firstError: string | undefined
+  let nextRequest = 0
+  let nextRead = 0
+  let nextWrite = 0
+  let readRequests = 0
+  let responseBytes = 0
+  let writeRequests = 0
+  const startedAt = performance.now()
+  const deadline = startedAt + durationMs
+
+  const worker = async (): Promise<void> => {
+    while (performance.now() < deadline) {
+      const sequence = nextRequest++
+      const isRead = (sequence * 37) % 100 < config.readPercent
+      const index = isRead ? nextRead++ % config.documents : nextWrite++ % config.documents
+      const operation = isRead ? "read" : "write"
+      const started = performance.now()
+      try {
+        const result = await sendRequest(
+          port,
+          isRead ? "GET" : "PUT",
+          `/documents/${documentId(operation, index)}`,
+          isRead ? undefined : writeBody,
+          agent,
+          false
+        )
+        responseBytes += result.bytes
+        if (result.status < 200 || result.status >= 300) {
+          errors++
+          firstError ??= `received HTTP ${result.status}`
+        } else if (result.bytes !== (isRead ? readResponseBytes : writeResponseBytes)) {
+          errors++
+          firstError ??= `received ${result.bytes} response bytes, expected ${
+            isRead ? readResponseBytes : writeResponseBytes
+          }`
+        }
+      } catch (error) {
+        errors++
+        firstError ??= error instanceof Error ? error.message : String(error)
+      }
+      latencies.push(performance.now() - started)
+      if (isRead) {
+        readRequests++
+      } else {
+        writeRequests++
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: config.connections }, () => worker()))
+  const elapsedMs = performance.now() - startedAt
+  return {
+    elapsedMs,
+    errors,
+    firstError,
+    latencies,
+    readRequests,
+    requests: readRequests + writeRequests,
+    responseBytes,
+    writeRequests
+  }
+}
+
+const seedCorpus = async (root: string): Promise<void> => {
+  await mkdir(root, { recursive: true })
+  await Promise.all(Array.from({ length: config.documents }, async (_, index) => {
+    await Promise.all([
+      writeFile(join(root, `${documentId("read", index)}.txt`), readContent, "utf8"),
+      writeFile(join(root, `${documentId("write", index)}.txt`), writeContent, "utf8")
+    ])
+  }))
+}
+
+const runFramework = async (framework: Framework, round: number, order: number): Promise<RoundResult> => {
+  const root = await mkdtemp(join(corpusBaseDirectory, "effect-hono-http-api-"))
+  const agent = new Agent({
+    keepAlive: true,
+    maxFreeSockets: config.connections,
+    maxSockets: config.connections,
+    scheduling: "fifo"
+  })
+  let server: RunningServer | undefined
+  try {
+    await seedCorpus(root)
+    server = await startServer(framework, root)
+    await verifyServer(server.port)
+    if (config.warmupMs > 0) {
+      await runLoad(server.port, config.warmupMs, agent)
+    }
+
+    await sendMetricsMessage(server.child, "metrics:start", "metrics:started")
+    const load = await runLoad(server.port, config.durationMs, agent)
+    const metricsResponse = await sendMetricsMessage(server.child, "metrics:stop", "metrics:stopped")
+    if (load.errors > 0) {
+      throw new Error(
+        `${framework} returned ${load.errors} invalid measured responses: ${load.firstError ?? "unknown"}`
+      )
+    }
+    await verifyServer(server.port)
+    const metrics: ServerMetrics = metricsResponse.metrics
+    const sortedLatencies = [...load.latencies].sort((left, right) => left - right)
+    const elapsedSeconds = load.elapsedMs / 1_000
+    const cpuMs = (metrics.userCpuMicros + metrics.systemCpuMicros) / 1_000
+
+    return {
+      framework,
+      round,
+      order,
+      requests: load.requests,
+      readRequests: load.readRequests,
+      writeRequests: load.writeRequests,
+      errors: load.errors,
+      requestsPerSecond: load.requests / elapsedSeconds,
+      responseMiBPerSecond: load.responseBytes / 1_048_576 / elapsedSeconds,
+      p50Ms: percentile(sortedLatencies, 0.5),
+      p95Ms: percentile(sortedLatencies, 0.95),
+      p99Ms: percentile(sortedLatencies, 0.99),
+      maxMs: percentile(sortedLatencies, 1),
+      serverCpuMsPerRequest: cpuMs / load.requests,
+      serverEventLoopUtilization: metrics.eventLoopUtilization,
+      serverRssMiB: metrics.rssBytes / 1_048_576
+    }
+  } finally {
+    agent.destroy()
+    if (server !== undefined) {
+      await stopServer(server)
+    }
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+const formatRoundResult = (result: RoundResult) => ({
+  round: result.round,
+  order: result.order,
+  framework: result.framework,
+  "req/s": result.requestsPerSecond.toFixed(0),
+  "MiB/s": result.responseMiBPerSecond.toFixed(1),
+  "p50 ms": result.p50Ms.toFixed(2),
+  "p95 ms": result.p95Ms.toFixed(2),
+  "p99 ms": result.p99Ms.toFixed(2),
+  "max ms": result.maxMs.toFixed(2),
+  errors: result.errors,
+  "CPU ms/req": result.serverCpuMsPerRequest.toFixed(3),
+  "server ELU": `${(result.serverEventLoopUtilization * 100).toFixed(1)}%`,
+  "RSS MiB": result.serverRssMiB.toFixed(1)
+})
+
+const frameworks: ReadonlyArray<Framework> = ["Effect HttpServer", "Hono"]
+const results: Array<RoundResult> = []
+
+console.log("Effect HttpServer vs Hono: asynchronous filesystem HTTP API")
+console.log({
+  node: process.version,
+  versions,
+  git,
+  sourceHash: sourceHash.slice(0, 16),
+  cpu: cpus()[0]?.model ?? "unknown",
+  logicalCpus: cpus().length,
+  connections: config.connections,
+  documentsPerOperation: config.documents,
+  durationSeconds: config.durationMs / 1_000,
+  payloadKiB: config.payloadBytes / 1_024,
+  readPercent: config.readPercent,
+  rounds: config.rounds,
+  warmupSeconds: config.warmupMs / 1_000,
+  corpusBaseDirectory
+})
+
+for (let round = 1; round <= config.rounds; round++) {
+  const order = round % 2 === 1 ? frameworks : [...frameworks].reverse()
+  for (let index = 0; index < order.length; index++) {
+    const framework = order[index]
+    process.stdout.write(`Round ${round}/${config.rounds}, ${framework}... `)
+    const result = await runFramework(framework, round, index + 1)
+    results.push(result)
+    console.log(`${result.requestsPerSecond.toFixed(0)} req/s, p99 ${result.p99Ms.toFixed(2)} ms`)
+  }
+}
+
+console.log("\nPer-round results")
+console.table(results.map(formatRoundResult))
+
+const summary = frameworks.map((framework) => {
+  const selected = results.filter((result) => result.framework === framework)
+  return {
+    framework,
+    "median req/s": median(selected.map((result) => result.requestsPerSecond)).toFixed(0),
+    "median p50 ms": median(selected.map((result) => result.p50Ms)).toFixed(2),
+    "median p99 ms": median(selected.map((result) => result.p99Ms)).toFixed(2),
+    "median CPU ms/req": median(selected.map((result) => result.serverCpuMsPerRequest)).toFixed(3),
+    "median server ELU": `${(median(selected.map((result) => result.serverEventLoopUtilization)) * 100).toFixed(1)}%`,
+    errors: selected.reduce((total, result) => total + result.errors, 0)
+  }
+})
+console.log("\nMedian summary")
+console.table(summary)
+
+const pairedRatios = Array.from({ length: config.rounds }, (_, index) => {
+  const round = index + 1
+  const effect = results.find((result) => result.round === round && result.framework === "Effect HttpServer")!
+  const hono = results.find((result) => result.round === round && result.framework === "Hono")!
+  return {
+    round,
+    throughput: effect.requestsPerSecond / hono.requestsPerSecond,
+    p99: effect.p99Ms / hono.p99Ms
+  }
+})
+console.log("\nPaired Effect / Hono ratios (1.0 means equal)")
+console.table(pairedRatios.map((ratio) => ({
+  round: ratio.round,
+  throughput: ratio.throughput.toFixed(3),
+  "p99 latency": ratio.p99.toFixed(3)
+})))
+console.log({
+  medianThroughputRatio: median(pairedRatios.map((ratio) => ratio.throughput)).toFixed(3),
+  medianP99LatencyRatio: median(pairedRatios.map((ratio) => ratio.p99)).toFixed(3)
+})
+console.log(
+  "Results are exploratory. Inspect all paired rounds and variability; do not treat one run as a release claim."
+)
+
+if (config.jsonPath !== undefined) {
+  if (config.jsonPath.length === 0) {
+    throw new Error("--json requires a non-empty path")
+  }
+  const output = {
+    generatedAt: new Date().toISOString(),
+    system: {
+      node: process.version,
+      platform: process.platform,
+      architecture: process.arch,
+      cpu: cpus()[0]?.model ?? "unknown",
+      logicalCpus: cpus().length
+    },
+    versions,
+    git,
+    sourceHash,
+    corpusBaseDirectory,
+    config,
+    results,
+    pairedRatios
+  }
+  await writeFile(config.jsonPath, `${JSON.stringify(output, null, 2)}\n`, "utf8")
+  console.log(`Raw results written to ${config.jsonPath}`)
+}

--- a/scratchpad/http-api-benchmark/shared.ts
+++ b/scratchpad/http-api-benchmark/shared.ts
@@ -1,0 +1,108 @@
+import { readFile, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { performance } from "node:perf_hooks"
+
+export const HOST = "127.0.0.1"
+export const MAX_DOCUMENT_LENGTH = 64 * 1024
+export const DOCUMENT_ID_PATTERN = /^(?:read|write)-\d{3}$/
+
+export interface ReadResult {
+  readonly id: string
+  readonly content: string
+  readonly bytes: number
+}
+
+export interface WriteResult {
+  readonly id: string
+  readonly bytes: number
+}
+
+export interface WritePayload {
+  readonly content: string
+}
+
+export const isDocumentId = (value: unknown): value is string =>
+  typeof value === "string" && DOCUMENT_ID_PATTERN.test(value)
+
+export const isWritePayload = (value: unknown): value is WritePayload =>
+  value !== null &&
+  typeof value === "object" &&
+  "content" in value &&
+  typeof value.content === "string" &&
+  value.content.length >= 1 &&
+  value.content.length <= MAX_DOCUMENT_LENGTH
+
+const documentPath = (root: string, id: string) => join(root, `${id}.txt`)
+
+export const readDocument = async (root: string, id: string): Promise<ReadResult> => {
+  const content = await readFile(documentPath(root, id), "utf8")
+  return { id, content, bytes: Buffer.byteLength(content) }
+}
+
+export const writeDocument = async (root: string, id: string, content: string): Promise<WriteResult> => {
+  await writeFile(documentPath(root, id), content, "utf8")
+  return { id, bytes: Buffer.byteLength(content) }
+}
+
+export const parseServerEnvironment = (): { readonly port: number; readonly root: string } => {
+  const port = Number(process.env.PORT)
+  const root = process.env.BENCH_ROOT
+  if (!Number.isInteger(port) || port < 1 || port > 65_535 || root === undefined) {
+    throw new Error("PORT and BENCH_ROOT must be set by the benchmark runner")
+  }
+  return { port, root }
+}
+
+interface MetricsStartMessage {
+  readonly type: "metrics:start"
+  readonly id: number
+}
+
+interface MetricsStopMessage {
+  readonly type: "metrics:stop"
+  readonly id: number
+}
+
+export interface ServerMetrics {
+  readonly eventLoopUtilization: number
+  readonly userCpuMicros: number
+  readonly systemCpuMicros: number
+  readonly rssBytes: number
+}
+
+export type MetricsResponse =
+  | { readonly type: "metrics:started"; readonly id: number }
+  | { readonly type: "metrics:stopped"; readonly id: number; readonly metrics: ServerMetrics }
+
+export const installServerMetrics = (): void => {
+  let eventLoopStart: ReturnType<typeof performance.eventLoopUtilization> | undefined
+  let cpuStart: NodeJS.CpuUsage | undefined
+
+  process.on("message", (message: MetricsStartMessage | MetricsStopMessage) => {
+    if (message === null || typeof message !== "object" || !("type" in message) || !("id" in message)) {
+      return
+    }
+    if (message.type === "metrics:start") {
+      eventLoopStart = performance.eventLoopUtilization()
+      cpuStart = process.cpuUsage()
+      process.send?.({ type: "metrics:started", id: message.id } satisfies MetricsResponse)
+      return
+    }
+    if (message.type === "metrics:stop" && eventLoopStart !== undefined && cpuStart !== undefined) {
+      const eventLoop = performance.eventLoopUtilization(eventLoopStart)
+      const cpu = process.cpuUsage(cpuStart)
+      process.send?.(
+        {
+          type: "metrics:stopped",
+          id: message.id,
+          metrics: {
+            eventLoopUtilization: eventLoop.utilization,
+            userCpuMicros: cpu.user,
+            systemCpuMicros: cpu.system,
+            rssBytes: process.memoryUsage.rss()
+          }
+        } satisfies MetricsResponse
+      )
+    }
+  })
+}

--- a/scratchpad/package.json
+++ b/scratchpad/package.json
@@ -23,5 +23,9 @@
     "@effect/sql-sqlite-react-native": "workspace:*",
     "@effect/sql-sqlite-wasm": "workspace:*",
     "effect": "workspace:*"
+  },
+  "devDependencies": {
+    "@hono/node-server": "^2.1.1",
+    "hono": "^4.13.5"
   }
 }


### PR DESCRIPTION
## Status

This is a slop-heavy performance spike. It is not review-ready and must not be merged in its current form. The branch contains broad internal runtime coupling, mixed API and performance changes, experimental primitives, loose typing, and substantial cleanup debt.

The original goal was to make the fixed Effect HTTP benchmark consistently beat Hono. This spike does not achieve that goal.

## Included benchmark

The reproducible Effect-versus-Hono harness is included under `scratchpad/http-api-benchmark`. Run the fixed protocol from the repository root with:

```sh
node scratchpad/http-api-benchmark/run.ts
```

The committed `scratchpad/package.json` and lockfile entries provide its Hono dependencies.

## Current result

Fixed protocol: 5 paired alternating rounds, 3 second warmup, 10 second measurement, 32 connections, 16 KiB payloads, and an 80/20 read/write mix.

- Effect median: 27,312 req/s
- Hono median: 28,796 req/s
- Median paired Effect/Hono ratio: 0.974
- Errors: 0
- Previous paired ratio before the latest retained work: 0.947

## What the spike explores

- A fused no-tracer HTTP terminal path
- Eager synchronous transport completion
- Request-fiber ownership by the server scope
- Router/context/interruption restoration fusion
- Router callback path parameters and routing hot-path changes
- Node request-body, stream, response-header, and lifecycle allocation reductions
- New low-level runner and context APIs used by the spike

## Cleanup required

- Reduce or remove the custom runtime primitive and its HTTP-specific frame coupling.
- Audit every `any`, internal symbol, mutable frame field, and eager interpreter shortcut.
- Separate public API changes from internal performance work.
- Decide whether `Context.addUnsafe2`, `Effect.runForkInWith`, the `runForkWith` overload, callback route parameters, and `HttpEffect.toHandledNoTracer` should exist independently.
- Decide whether the benchmark harness and Hono dependencies should remain in the final PR or move to dedicated tooling.
- Split the change into reviewable commits or separate PRs.
- Re-profile each retained optimization after cleanup and remove noise-level changes.
- Re-run the fixed benchmark and require a repeatable win before claiming the original objective.
- Re-audit cancellation, shutdown awaiting, middleware, tracing, scheduler yielding, context restoration, scope finalizers, pre-response handlers, and finalizer exits.

## Validation completed

- `pnpm lint-fix`
- `pnpm check`
- `pnpm jsdocs --check`
- Targeted Effect, Fiber, Scope, routing, HTTP, Node, Bun, and Deno runtime tests
- Type tests for `Context`, `Effect`, and `HttpRouter`
- Changeset validation
- `git diff --check`

Again: this is intentionally a draft checkpoint for discussion and cleanup, not a merge candidate.