### PR TITLE
fix(NodeFileSystem): accept empty writeAll buffers

### DIFF
--- a/.changeset/node-writeall-empty.md
+++ b/.changeset/node-writeall-empty.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+Allow `File.writeAll` and filesystem sinks to accept empty byte buffers without failing with `WriteZero` or changing file contents or the cursor.

--- a/.changeset/node-writeall-empty.md
+++ b/.changeset/node-writeall-empty.md
@@ -2,4 +2,4 @@
 "@effect/platform-node-shared": patch
 ---
 
-Allow `File.writeAll` and filesystem sinks to accept empty byte buffers without failing with `WriteZero` or changing file contents or the cursor.
+Allow `File.writeAll` to accept empty buffers.

--- a/packages/platform/node-shared/src/NodeFileSystem.ts
+++ b/packages/platform/node-shared/src/NodeFileSystem.ts
@@ -382,7 +382,7 @@ const makeFile = (() => {
     }
 
     writeAll(buffer: Uint8Array) {
-      return this.writeAllChunk(buffer)
+      return buffer.length === 0 ? Effect.void : this.writeAllChunk(buffer)
     }
   }
 

--- a/packages/platform/node-shared/test/NodeFileSystem.test.ts
+++ b/packages/platform/node-shared/test/NodeFileSystem.test.ts
@@ -44,74 +44,16 @@ const startWatch = <E, R>(
 describe("FileSystem", () => {
   testLayer(NodeFileSystem.layer)
 
-  describe("file writes", () => {
-    it.effect("write accepts an empty buffer without changing the cursor or contents", () =>
-      Effect.gen(function*() {
-        const fs = yield* FileSystem.FileSystem
-        const path = yield* fs.makeTempFileScoped()
-        yield* fs.writeFileString(path, "abc")
-        const file = yield* fs.open(path, { flag: "r+" })
-        yield* file.seek(1, "start")
+  it.effect("writeAll accepts an empty buffer", () =>
+    Effect.gen(function*() {
+      const fs = yield* FileSystem.FileSystem
+      const path = yield* fs.makeTempFileScoped()
+      const file = yield* fs.open(path, { flag: "r+" })
 
-        assert.strictEqual(yield* file.write(new Uint8Array(0)), 0n)
-        assert.strictEqual(yield* file.seek(0, "current"), 1n)
-        assert.strictEqual(yield* fs.readFileString(path), "abc")
-      }).pipe(
-        Effect.provide(NodeFileSystem.layer)
-      ))
-
-    it.effect("writeAll accepts an empty buffer without changing the cursor or contents", () =>
-      Effect.gen(function*() {
-        const fs = yield* FileSystem.FileSystem
-        const path = yield* fs.makeTempFileScoped()
-        yield* fs.writeFileString(path, "abc")
-        const file = yield* fs.open(path, { flag: "r+" })
-        yield* file.seek(1, "start")
-
-        yield* file.writeAll(new Uint8Array(0))
-        assert.strictEqual(yield* file.seek(0, "current"), 1n)
-        assert.strictEqual(yield* fs.readFileString(path), "abc")
-      }).pipe(
-        Effect.provide(NodeFileSystem.layer)
-      ))
-
-    it.effect.each([
-      { name: "non-empty buffers", chunks: ["xy", "z"] },
-      { name: "empty buffers before, between and after writes", chunks: ["", "xy", "", "z", ""] }
-    ])("writeAll preserves surrounding contents with $name", ({ chunks }) =>
-      Effect.gen(function*() {
-        const fs = yield* FileSystem.FileSystem
-        const path = yield* fs.makeTempFileScoped()
-        yield* fs.writeFileString(path, "abcdef")
-        const file = yield* fs.open(path, { flag: "r+" })
-        yield* file.seek(1, "start")
-
-        for (const chunk of chunks) {
-          yield* file.writeAll(new TextEncoder().encode(chunk))
-        }
-        assert.strictEqual(yield* file.seek(0, "current"), 4n)
-        assert.strictEqual(yield* fs.readFileString(path), "axyzef")
-      }).pipe(
-        Effect.provide(NodeFileSystem.layer)
-      ))
-
-    it.effect.each([
-      { name: "non-empty buffers", chunks: ["abc", "def"] },
-      { name: "empty buffers before, between and after writes", chunks: ["", "abc", "", "def", ""] }
-    ])("sink preserves contents with $name", ({ chunks }) =>
-      Effect.gen(function*() {
-        const fs = yield* FileSystem.FileSystem
-        const path = yield* fs.makeTempFileScoped()
-
-        yield* Stream.fromIterable(chunks).pipe(
-          Stream.map((chunk) => new TextEncoder().encode(chunk)),
-          Stream.run(fs.sink(path))
-        )
-        assert.strictEqual(yield* fs.readFileString(path), "abcdef")
-      }).pipe(
-        Effect.provide(NodeFileSystem.layer)
-      ))
-  })
+      yield* file.writeAll(new Uint8Array(0))
+    }).pipe(
+      Effect.provide(NodeFileSystem.layer)
+    ))
 
   it.effect("watch does not report nested changes when recursive is false", () =>
     Effect.gen(function*() {

--- a/packages/platform/node-shared/test/NodeFileSystem.test.ts
+++ b/packages/platform/node-shared/test/NodeFileSystem.test.ts
@@ -44,6 +44,75 @@ const startWatch = <E, R>(
 describe("FileSystem", () => {
   testLayer(NodeFileSystem.layer)
 
+  describe("file writes", () => {
+    it.effect("write accepts an empty buffer without changing the cursor or contents", () =>
+      Effect.gen(function*() {
+        const fs = yield* FileSystem.FileSystem
+        const path = yield* fs.makeTempFileScoped()
+        yield* fs.writeFileString(path, "abc")
+        const file = yield* fs.open(path, { flag: "r+" })
+        yield* file.seek(1, "start")
+
+        assert.strictEqual(yield* file.write(new Uint8Array(0)), 0n)
+        assert.strictEqual(yield* file.seek(0, "current"), 1n)
+        assert.strictEqual(yield* fs.readFileString(path), "abc")
+      }).pipe(
+        Effect.provide(NodeFileSystem.layer)
+      ))
+
+    it.effect("writeAll accepts an empty buffer without changing the cursor or contents", () =>
+      Effect.gen(function*() {
+        const fs = yield* FileSystem.FileSystem
+        const path = yield* fs.makeTempFileScoped()
+        yield* fs.writeFileString(path, "abc")
+        const file = yield* fs.open(path, { flag: "r+" })
+        yield* file.seek(1, "start")
+
+        yield* file.writeAll(new Uint8Array(0))
+        assert.strictEqual(yield* file.seek(0, "current"), 1n)
+        assert.strictEqual(yield* fs.readFileString(path), "abc")
+      }).pipe(
+        Effect.provide(NodeFileSystem.layer)
+      ))
+
+    it.effect.each([
+      { name: "non-empty buffers", chunks: ["xy", "z"] },
+      { name: "empty buffers before, between and after writes", chunks: ["", "xy", "", "z", ""] }
+    ])("writeAll preserves surrounding contents with $name", ({ chunks }) =>
+      Effect.gen(function*() {
+        const fs = yield* FileSystem.FileSystem
+        const path = yield* fs.makeTempFileScoped()
+        yield* fs.writeFileString(path, "abcdef")
+        const file = yield* fs.open(path, { flag: "r+" })
+        yield* file.seek(1, "start")
+
+        for (const chunk of chunks) {
+          yield* file.writeAll(new TextEncoder().encode(chunk))
+        }
+        assert.strictEqual(yield* file.seek(0, "current"), 4n)
+        assert.strictEqual(yield* fs.readFileString(path), "axyzef")
+      }).pipe(
+        Effect.provide(NodeFileSystem.layer)
+      ))
+
+    it.effect.each([
+      { name: "non-empty buffers", chunks: ["abc", "def"] },
+      { name: "empty buffers before, between and after writes", chunks: ["", "abc", "", "def", ""] }
+    ])("sink preserves contents with $name", ({ chunks }) =>
+      Effect.gen(function*() {
+        const fs = yield* FileSystem.FileSystem
+        const path = yield* fs.makeTempFileScoped()
+
+        yield* Stream.fromIterable(chunks).pipe(
+          Stream.map((chunk) => new TextEncoder().encode(chunk)),
+          Stream.run(fs.sink(path))
+        )
+        assert.strictEqual(yield* fs.readFileString(path), "abcdef")
+      }).pipe(
+        Effect.provide(NodeFileSystem.layer)
+      ))
+  })
+
   it.effect("watch does not report nested changes when recursive is false", () =>
     Effect.gen(function*() {
       const fs = yield* FileSystem.FileSystem


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`File.writeAll` treated Node's zero-byte result for an empty buffer as a stalled write and failed with `WriteZero`.

Empty buffers now return successfully before entering the partial-write loop. Non-empty writes retain the existing retry behavior and zero-progress protection.

## Verification

- `pnpm test --run packages/platform/node-shared/test/NodeFileSystem.test.ts --reporter=verbose` (25 passed)
- `pnpm lint-fix`
- `pnpm check`
- `git diff --check origin/main...HEAD`

## Related

Closes #7707

Closes EFF-1070
