### PR TITLE
fix(NodeFileSystem): classify watch events relative to their target

### DIFF
--- a/.changeset/node-watch-relative.md
+++ b/.changeset/node-watch-relative.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+Fix watch event classification for targets outside the current working directory.

--- a/.changeset/node-watch-relative.md
+++ b/.changeset/node-watch-relative.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+Fix filesystem watch event classification by resolving filenames against the watched directory or file's parent instead of the current working directory. Newly created files are now reported as `Create` rather than `Remove`, while event paths remain relative.

--- a/.changeset/node-watch-relative.md
+++ b/.changeset/node-watch-relative.md
@@ -1,5 +1,0 @@
----
-"@effect/platform-node-shared": patch
----
-
-Fix filesystem watch event classification by resolving filenames against the watched directory or file's parent instead of the current working directory. Newly created files are now reported as `Create` rather than `Remove`, while event paths remain relative.

--- a/packages/platform/node-shared/src/NodeFileSystem.ts
+++ b/packages/platform/node-shared/src/NodeFileSystem.ts
@@ -550,18 +550,17 @@ const utimes = (() => {
 
 // == watch
 
-const watchNode = (path: string, info: FileSystem.File.Info, options?: FileSystem.WatchOptions) =>
+const watchNode = (path: string, options?: FileSystem.WatchOptions) =>
   Stream.callback<FileSystem.WatchEvent, Error.PlatformError>((queue) =>
     Effect.acquireRelease(
       Effect.sync(() => {
-        const directory = Path.resolve(info.type === "Directory" ? path : Path.dirname(path))
         const watcher = NFS.watch(path, {
           recursive: options?.recursive ?? false
         }, (event, path) => {
           if (!path) return
           switch (event) {
             case "rename": {
-              Effect.runFork(Effect.matchEffect(stat(Path.join(directory, path)), {
+              Effect.runFork(Effect.matchEffect(stat(path), {
                 onSuccess: (_) => Queue.offer(queue, { _tag: "Create", path }),
                 onFailure: (_) => Queue.offer(queue, { _tag: "Remove", path })
               }))
@@ -605,7 +604,7 @@ const watch = (
     Effect.map((stat) =>
       backend.pipe(
         Option.flatMap((_) => _.register(path, stat, options)),
-        Option.getOrElse(() => watchNode(path, stat, options))
+        Option.getOrElse(() => watchNode(path, options))
       )
     ),
     Stream.unwrap

--- a/packages/platform/node-shared/src/NodeFileSystem.ts
+++ b/packages/platform/node-shared/src/NodeFileSystem.ts
@@ -550,17 +550,18 @@ const utimes = (() => {
 
 // == watch
 
-const watchNode = (path: string, options?: FileSystem.WatchOptions) =>
+const watchNode = (path: string, info: FileSystem.File.Info, options?: FileSystem.WatchOptions) =>
   Stream.callback<FileSystem.WatchEvent, Error.PlatformError>((queue) =>
     Effect.acquireRelease(
       Effect.sync(() => {
+        const directory = info.type === "Directory" ? path : Path.dirname(path)
         const watcher = NFS.watch(path, {
           recursive: options?.recursive ?? false
         }, (event, path) => {
           if (!path) return
           switch (event) {
             case "rename": {
-              Effect.runFork(Effect.matchEffect(stat(path), {
+              Effect.runFork(Effect.matchEffect(stat(Path.resolve(directory, path)), {
                 onSuccess: (_) => Queue.offer(queue, { _tag: "Create", path }),
                 onFailure: (_) => Queue.offer(queue, { _tag: "Remove", path })
               }))
@@ -604,7 +605,7 @@ const watch = (
     Effect.map((stat) =>
       backend.pipe(
         Option.flatMap((_) => _.register(path, stat, options)),
-        Option.getOrElse(() => watchNode(path, options))
+        Option.getOrElse(() => watchNode(path, stat, options))
       )
     ),
     Stream.unwrap

--- a/packages/platform/node-shared/src/NodeFileSystem.ts
+++ b/packages/platform/node-shared/src/NodeFileSystem.ts
@@ -550,17 +550,18 @@ const utimes = (() => {
 
 // == watch
 
-const watchNode = (path: string, options?: FileSystem.WatchOptions) =>
+const watchNode = (path: string, info: FileSystem.File.Info, options?: FileSystem.WatchOptions) =>
   Stream.callback<FileSystem.WatchEvent, Error.PlatformError>((queue) =>
     Effect.acquireRelease(
       Effect.sync(() => {
+        const directory = Path.resolve(info.type === "Directory" ? path : Path.dirname(path))
         const watcher = NFS.watch(path, {
           recursive: options?.recursive ?? false
         }, (event, path) => {
           if (!path) return
           switch (event) {
             case "rename": {
-              Effect.runFork(Effect.matchEffect(stat(path), {
+              Effect.runFork(Effect.matchEffect(stat(Path.join(directory, path)), {
                 onSuccess: (_) => Queue.offer(queue, { _tag: "Create", path }),
                 onFailure: (_) => Queue.offer(queue, { _tag: "Remove", path })
               }))
@@ -604,7 +605,7 @@ const watch = (
     Effect.map((stat) =>
       backend.pipe(
         Option.flatMap((_) => _.register(path, stat, options)),
-        Option.getOrElse(() => watchNode(path, options))
+        Option.getOrElse(() => watchNode(path, stat, options))
       )
     ),
     Stream.unwrap

--- a/packages/platform/node-shared/test/NodeFileSystem.test.ts
+++ b/packages/platform/node-shared/test/NodeFileSystem.test.ts
@@ -6,15 +6,7 @@ import * as Fiber from "effect/Fiber"
 import * as FileSystem from "effect/FileSystem"
 import * as Stream from "effect/Stream"
 import * as TestClock from "effect/testing/TestClock"
-import { EventEmitter } from "node:events"
-import * as NFS from "node:fs"
-import * as Path from "node:path"
-import { vi } from "vitest"
 import { testLayer } from "../../../effect/test/FileSystem.test-utils.ts"
-
-vi.mock("node:fs", async (importOriginal) => ({
-  ...await importOriginal<typeof NFS>()
-}))
 
 const startWatch = <E, R>(
   fs: FileSystem.FileSystem,
@@ -80,85 +72,6 @@ describe("FileSystem", () => {
     }).pipe(
       Effect.provide(NodeFileSystem.layer)
     ))
-
-  it.effect("watch reports Remove for a deleted file outside the current directory", () =>
-    Effect.gen(function*() {
-      const fs = yield* FileSystem.FileSystem
-      const root = yield* fs.makeTempDirectoryScoped()
-      const name = "removed.txt"
-      const path = `${root}/${name}`
-      yield* fs.writeFileString(path, "")
-
-      const fiber = yield* startWatch(fs, root, () => fs.watch(root))
-      yield* fs.remove(path)
-
-      const event = yield* Fiber.join(fiber)
-      assert.strictEqual(yield* fs.exists(path), false)
-      assert.deepStrictEqual(event, { _tag: "Remove", path: name })
-    }).pipe(
-      Effect.provide(NodeFileSystem.layer)
-    ))
-
-  it.effect.each([false, true])(
-    "watch resolves a relative directory with recursive %s",
-    (recursive) =>
-      Effect.gen(function*() {
-        const fs = yield* FileSystem.FileSystem
-        const root = yield* fs.makeTempDirectoryScoped()
-        yield* fs.makeDirectory(`${root}/nested`)
-        const name = recursive ? Path.join("nested", "created.txt") : "created.txt"
-        const path = Path.join(root, name)
-
-        const fiber = yield* startWatch(fs, root, () => fs.watch(Path.relative(process.cwd(), root), { recursive }))
-        yield* fs.writeFileString(path, "")
-
-        const event = yield* Fiber.join(fiber)
-        assert.strictEqual(yield* fs.exists(path), true)
-        assert.deepStrictEqual(event, { _tag: "Create", path: name })
-      }).pipe(
-        Effect.provide(NodeFileSystem.layer)
-      )
-  )
-
-  it.effect.each([false, true])(
-    "watch resolves file events with a relative target %s",
-    (relative) =>
-      Effect.gen(function*() {
-        const fs = yield* FileSystem.FileSystem
-        const path = yield* fs.makeTempFileScoped()
-        const name = Path.basename(path)
-        const target = relative ? Path.relative(process.cwd(), path) : path
-        const watcher = new class extends EventEmitter implements NFS.FSWatcher {
-          close() {}
-          ref() {
-            return this
-          }
-          unref() {
-            return this
-          }
-        }()
-        const watch = yield* Effect.acquireRelease(
-          Effect.sync(() => vi.spyOn(NFS, "watch")),
-          (watch) => Effect.sync(() => watch.mockRestore())
-        )
-        // Inject a rename notification while the file exists, without a native rename race.
-        watch.mockImplementationOnce((
-          filename: NFS.PathLike,
-          options: NFS.WatchOptions | NFS.WatchListener<string>,
-          listener?: NFS.WatchListener<string>
-        ) => {
-          assert.strictEqual(filename, target)
-          assert.deepStrictEqual(options, { recursive: false })
-          listener?.("rename", name)
-          return watcher
-        })
-
-        const event = yield* fs.watch(target).pipe(Stream.runHead, Effect.flatMap(Effect.fromOption))
-        assert.deepStrictEqual(event, { _tag: "Create", path: name })
-      }).pipe(
-        Effect.provide(NodeFileSystem.layer)
-      )
-  )
 
   it.effect("watch does not report nested changes when recursive is false", () =>
     Effect.gen(function*() {

--- a/packages/platform/node-shared/test/NodeFileSystem.test.ts
+++ b/packages/platform/node-shared/test/NodeFileSystem.test.ts
@@ -6,7 +6,15 @@ import * as Fiber from "effect/Fiber"
 import * as FileSystem from "effect/FileSystem"
 import * as Stream from "effect/Stream"
 import * as TestClock from "effect/testing/TestClock"
+import { EventEmitter } from "node:events"
+import * as NFS from "node:fs"
+import * as Path from "node:path"
+import { vi } from "vitest"
 import { testLayer } from "../../../effect/test/FileSystem.test-utils.ts"
+
+vi.mock("node:fs", async (importOriginal) => ({
+  ...await importOriginal<typeof NFS>()
+}))
 
 const startWatch = <E, R>(
   fs: FileSystem.FileSystem,
@@ -54,6 +62,103 @@ describe("FileSystem", () => {
     }).pipe(
       Effect.provide(NodeFileSystem.layer)
     ))
+
+  it.effect("watch reports Create for a new file outside the current directory", () =>
+    Effect.gen(function*() {
+      const fs = yield* FileSystem.FileSystem
+      const root = yield* fs.makeTempDirectoryScoped()
+      const name = "created.txt"
+      const path = `${root}/${name}`
+      assert.strictEqual(yield* fs.exists(name), false)
+
+      const fiber = yield* startWatch(fs, root, () => fs.watch(root))
+      yield* fs.writeFileString(path, "")
+
+      const event = yield* Fiber.join(fiber)
+      assert.strictEqual(yield* fs.exists(path), true)
+      assert.deepStrictEqual(event, { _tag: "Create", path: name })
+    }).pipe(
+      Effect.provide(NodeFileSystem.layer)
+    ))
+
+  it.effect("watch reports Remove for a deleted file outside the current directory", () =>
+    Effect.gen(function*() {
+      const fs = yield* FileSystem.FileSystem
+      const root = yield* fs.makeTempDirectoryScoped()
+      const name = "removed.txt"
+      const path = `${root}/${name}`
+      yield* fs.writeFileString(path, "")
+
+      const fiber = yield* startWatch(fs, root, () => fs.watch(root))
+      yield* fs.remove(path)
+
+      const event = yield* Fiber.join(fiber)
+      assert.strictEqual(yield* fs.exists(path), false)
+      assert.deepStrictEqual(event, { _tag: "Remove", path: name })
+    }).pipe(
+      Effect.provide(NodeFileSystem.layer)
+    ))
+
+  it.effect.each([false, true])(
+    "watch resolves a relative directory with recursive %s",
+    (recursive) =>
+      Effect.gen(function*() {
+        const fs = yield* FileSystem.FileSystem
+        const root = yield* fs.makeTempDirectoryScoped()
+        yield* fs.makeDirectory(`${root}/nested`)
+        const name = recursive ? Path.join("nested", "created.txt") : "created.txt"
+        const path = Path.join(root, name)
+
+        const fiber = yield* startWatch(fs, root, () => fs.watch(Path.relative(process.cwd(), root), { recursive }))
+        yield* fs.writeFileString(path, "")
+
+        const event = yield* Fiber.join(fiber)
+        assert.strictEqual(yield* fs.exists(path), true)
+        assert.deepStrictEqual(event, { _tag: "Create", path: name })
+      }).pipe(
+        Effect.provide(NodeFileSystem.layer)
+      )
+  )
+
+  it.effect.each([false, true])(
+    "watch resolves file events with a relative target %s",
+    (relative) =>
+      Effect.gen(function*() {
+        const fs = yield* FileSystem.FileSystem
+        const path = yield* fs.makeTempFileScoped()
+        const name = Path.basename(path)
+        const target = relative ? Path.relative(process.cwd(), path) : path
+        const watcher = new class extends EventEmitter implements NFS.FSWatcher {
+          close() {}
+          ref() {
+            return this
+          }
+          unref() {
+            return this
+          }
+        }()
+        const watch = yield* Effect.acquireRelease(
+          Effect.sync(() => vi.spyOn(NFS, "watch")),
+          (watch) => Effect.sync(() => watch.mockRestore())
+        )
+        // Inject a rename notification while the file exists, without a native rename race.
+        watch.mockImplementationOnce((
+          filename: NFS.PathLike,
+          options: NFS.WatchOptions | NFS.WatchListener<string>,
+          listener?: NFS.WatchListener<string>
+        ) => {
+          assert.strictEqual(filename, target)
+          assert.deepStrictEqual(options, { recursive: false })
+          listener?.("rename", name)
+          return watcher
+        })
+
+        const event = yield* fs.watch(target).pipe(Stream.runHead, Effect.flatMap(Effect.fromOption))
+        assert.deepStrictEqual(event, { _tag: "Create", path: name })
+      }).pipe(
+        Effect.provide(NodeFileSystem.layer)
+      )
+  )
 
   it.effect("watch does not report nested changes when recursive is false", () =>
     Effect.gen(function*() {


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Node reports native watch filenames relative to the watched target. `NodeFileSystem` classified those events by checking the relative filename against the process working directory, so creating a file under a watched directory elsewhere could be reported as `Remove`.

Resolve the classification lookup against the watched directory, or the parent of a watched file, while preserving the relative path in the emitted event. This includes one regression test and a patch changeset for `@effect/platform-node-shared`.

## Verification

- `pnpm test --run packages/platform/node-shared/test/NodeFileSystem.test.ts --reporter=verbose`
- `pnpm lint-fix`
- `pnpm check`
- `git diff --check`

## Related

Closes #7709
Closes EFF-1071

## Audit

Runtime correctness audit; intended label: `audit`.
