### PR TITLE
fix(NodeSink): capture writable finalization errors

### DIFF
--- a/.changeset/node-sink-finalization-errors.md
+++ b/.changeset/node-sink-finalization-errors.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+Fix NodeSink writable adapters hanging when a writable reports an error during finalization. These errors now fail the sink through the supplied `onError` mapper.

--- a/.changeset/node-sink-finalization-errors.md
+++ b/.changeset/node-sink-finalization-errors.md
@@ -2,4 +2,4 @@
 "@effect/platform-node-shared": patch
 ---
 
-Fix NodeSink writable adapters hanging when a writable reports an error during finalization. These errors now fail the sink through the supplied `onError` mapper.
+Fix `NodeSink` hanging when a writable reports an error during finalization.

--- a/packages/platform/node-shared/src/NodeSink.ts
+++ b/packages/platform/node-shared/src/NodeSink.ts
@@ -95,22 +95,26 @@ export const pullIntoWritable = <A, IE, E>(options: {
       })
     }),
     Effect.forever({ disableYield: true }),
-    Effect.raceFirst(Effect.callback<never, E>((resume) => {
-      const onError = (error: unknown) => resume(Effect.fail(options.onError(error)))
-      options.writable.once("error", onError)
-      return Effect.sync(() => {
-        options.writable.off("error", onError)
-      })
-    })),
     options.endOnDone !== false ?
       Pull.catchDone((_) => {
         if ("closed" in options.writable && options.writable.closed) {
           return Cause.done(_)
         }
         return Effect.callback<never, E | Cause.Done<unknown>>((resume) => {
-          options.writable.once("finish", () => resume(Cause.done(_)))
+          const onFinish = () => resume(Cause.done(_))
+          options.writable.once("finish", onFinish)
           options.writable.end()
+          return Effect.sync(() => {
+            options.writable.off("finish", onFinish)
+          })
         })
       }) :
-      identity
+      identity,
+    Effect.raceFirst(Effect.callback<never, E>((resume) => {
+      const onError = (error: unknown) => resume(Effect.fail(options.onError(error)))
+      options.writable.once("error", onError)
+      return Effect.sync(() => {
+        options.writable.off("error", onError)
+      })
+    }))
   )

--- a/packages/platform/node-shared/test/NodeSink.test.ts
+++ b/packages/platform/node-shared/test/NodeSink.test.ts
@@ -1,11 +1,12 @@
 import * as NodeSink from "@effect/platform-node-shared/NodeSink"
 import * as NodeStream from "@effect/platform-node-shared/NodeStream"
 import { assert, describe, it } from "@effect/vitest"
-import { Effect } from "effect"
+import { Deferred, Effect, Exit, Fiber, Option } from "effect"
 import * as Data from "effect/Data"
 import * as Latch from "effect/Latch"
 import * as Queue from "effect/Queue"
 import * as Stream from "effect/Stream"
+import { TestClock } from "effect/testing"
 import { createReadStream } from "fs"
 import { join } from "path"
 import { Writable } from "stream"
@@ -14,6 +15,94 @@ import * as Tar from "tar"
 const TEST_TARBALL = join(__dirname, "fixtures", "helloworld.tar.gz")
 
 describe("Sink", () => {
+  it.effect.each(["normal_final", "write_error", "final_error"] as const)(
+    "writable lifecycle: %s",
+    (mode) =>
+      Effect.gen(function*() {
+        const error = new Error(mode)
+        const mapped = { _tag: "WritableError", cause: error }
+        const observed: Array<unknown> = []
+        const mappedErrors: Array<unknown> = []
+        const closed = yield* Deferred.make<void>()
+        const items: Array<string> = []
+        let finalized = false
+        const writable = new Writable({
+          write(chunk, _encoding, callback) {
+            items.push(chunk.toString())
+            callback(mode === "write_error" ? error : null)
+          },
+          final(callback) {
+            finalized = true
+            callback(mode === "final_error" ? error : null)
+          }
+        })
+        // Observe Node errors without handling them on behalf of the sink.
+        writable.on("error", (error) => observed.push(error))
+        writable.once("close", () => Deferred.doneUnsafe(closed, Effect.void))
+        yield* Effect.addFinalizer(() => Effect.sync(() => writable.destroy()))
+        const fiber = yield* Stream.make("a", "b").pipe(
+          Stream.run(NodeSink.fromWritable({
+            evaluate: () => writable,
+            onError: (error) => {
+              mappedErrors.push(error)
+              return mapped
+            }
+          })),
+          Effect.exit,
+          Effect.timeoutOption("1 second"),
+          Effect.forkScoped
+        )
+        yield* Deferred.await(closed)
+        // The writable has settled; advance only the virtual non-completion guard.
+        yield* TestClock.adjust("1 second")
+        assert.deepEqual(observed, mode === "normal_final" ? [] : [error])
+        assert.strictEqual(finalized, mode !== "write_error")
+        assert.deepEqual(items, mode === "write_error" ? ["a"] : ["a", "b"])
+        assert.deepEqual({ result: yield* Fiber.join(fiber), mappedErrors }, {
+          result: Option.some(mode === "normal_final" ? Exit.void : Exit.fail(mapped)),
+          mappedErrors: mode === "normal_final" ? [] : [error]
+        })
+      })
+  )
+
+  it.effect.each(["error", "interrupt"] as const)(
+    "cleans up finalization listeners on %s",
+    (mode) =>
+      Effect.gen(function*() {
+        const finalizing = yield* Deferred.make<(error?: Error | null) => void>()
+        const error = new Error("finalization failed")
+        const writable = new Writable({
+          write(_chunk, _encoding, callback) {
+            callback()
+          },
+          final(callback) {
+            queueMicrotask(() => Deferred.doneUnsafe(finalizing, Effect.succeed(callback)))
+          }
+        })
+        const observed: Array<unknown> = []
+        writable.on("error", (error) => observed.push(error))
+        yield* Effect.addFinalizer(() => Effect.sync(() => writable.destroy()))
+        const fiber = yield* Stream.make("a").pipe(
+          Stream.run(NodeSink.fromWritable({ evaluate: () => writable, onError: (error) => error })),
+          Effect.forkScoped
+        )
+        const release = yield* Deferred.await(finalizing)
+        assert.strictEqual(writable.listenerCount("finish"), 1)
+        if (mode === "error") {
+          yield* Effect.sync(() => release(error))
+          assert.deepEqual(yield* Fiber.await(fiber), Exit.fail(error))
+        } else {
+          yield* Fiber.interrupt(fiber)
+        }
+        assert.strictEqual(writable.listenerCount("finish"), 0)
+        assert.strictEqual(writable.listenerCount("error"), 1)
+        assert.deepEqual(observed, mode === "error" ? [error] : [])
+        if (mode === "interrupt") {
+          yield* Effect.sync(() => release())
+        }
+      })
+  )
+
   it.effect("should write to a stream", () =>
     Effect.gen(function*() {
       const items: Array<string> = []


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Keep `NodeSink`'s writable error listener active through finalization so an `_final` error fails through the supplied `onError` mapper instead of leaving the sink suspended. Remove the owned `finish` listener when the finalization wait ends.

## Verification

- `pnpm lint-fix`
- `pnpm test --run packages/platform/node-shared/test/NodeSink.test.ts`
- `pnpm check`

## Related

Closes #7711
Closes EFF-1072
