### PR TITLE
fix(NodeSink): invalidate drain callbacks on interruption

### DIFF
--- a/.changeset/node-sink-cancel-drain.md
+++ b/.changeset/node-sink-cancel-drain.md
@@ -2,4 +2,4 @@
 "@effect/platform-node-shared": patch
 ---
 
-Fix NodeSink writable adapters submitting more writes after interruption while waiting for backpressure to clear. Interrupted sinks now remove the pending drain listener without cancelling writes already submitted to the writable.
+Prevent Node sinks from submitting buffered writes after interruption while waiting for writable backpressure.

--- a/.changeset/node-sink-cancel-drain.md
+++ b/.changeset/node-sink-cancel-drain.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+Fix NodeSink writable adapters submitting more writes after interruption while waiting for backpressure to clear. Interrupted sinks now remove the pending drain listener without cancelling writes already submitted to the writable.

--- a/packages/platform/node-shared/src/NodeSink.ts
+++ b/packages/platform/node-shared/src/NodeSink.ts
@@ -83,29 +83,26 @@ export const pullIntoWritable = <A, IE, E>(options: {
   options.pull.pipe(
     Effect.flatMap((chunk) => {
       let i = 0
-      return Effect.callback<void, E>((resume) => {
-        let cancelled = false
+      return Effect.callback<void, E>((resume, signal) => {
         const loop = () => {
           for (; i < chunk.length;) {
-            if (cancelled) {
+            if (signal.aborted) {
               return
             }
             const success = options.writable.write(chunk[i++], options.encoding as any)
             if (!success) {
-              if (!cancelled) {
+              if (!signal.aborted) {
                 options.writable.once("drain", loop)
               }
               return
             }
           }
-          if (!cancelled) {
+          if (!signal.aborted) {
             resume(Effect.void)
           }
         }
         loop()
         return Effect.sync(() => {
-          // Removing a listener does not invalidate an in-progress drain dispatch.
-          cancelled = true
           options.writable.off("drain", loop)
         })
       })

--- a/packages/platform/node-shared/src/NodeSink.ts
+++ b/packages/platform/node-shared/src/NodeSink.ts
@@ -83,15 +83,31 @@ export const pullIntoWritable = <A, IE, E>(options: {
   options.pull.pipe(
     Effect.flatMap((chunk) => {
       let i = 0
-      return Effect.callback<void, E>(function loop(resume) {
-        for (; i < chunk.length;) {
-          const success = options.writable.write(chunk[i++], options.encoding as any)
-          if (!success) {
-            options.writable.once("drain", () => (loop as any)(resume))
-            return
+      return Effect.callback<void, E>((resume) => {
+        let cancelled = false
+        const loop = () => {
+          for (; i < chunk.length;) {
+            if (cancelled) {
+              return
+            }
+            const success = options.writable.write(chunk[i++], options.encoding as any)
+            if (!success) {
+              if (!cancelled) {
+                options.writable.once("drain", loop)
+              }
+              return
+            }
+          }
+          if (!cancelled) {
+            resume(Effect.void)
           }
         }
-        resume(Effect.void)
+        loop()
+        return Effect.sync(() => {
+          // Removing a listener does not invalidate an in-progress drain dispatch.
+          cancelled = true
+          options.writable.off("drain", loop)
+        })
       })
     }),
     Effect.forever({ disableYield: true }),

--- a/packages/platform/node-shared/src/NodeSink.ts
+++ b/packages/platform/node-shared/src/NodeSink.ts
@@ -83,26 +83,28 @@ export const pullIntoWritable = <A, IE, E>(options: {
   options.pull.pipe(
     Effect.flatMap((chunk) => {
       let i = 0
-      return Effect.callback<void, E>((resume, signal) => {
+      return Effect.callback<void, E>((resume) => {
+        let cancelled = false
         const loop = () => {
           for (; i < chunk.length;) {
-            if (signal.aborted) {
+            if (cancelled) {
               return
             }
             const success = options.writable.write(chunk[i++], options.encoding as any)
             if (!success) {
-              if (!signal.aborted) {
+              if (!cancelled) {
                 options.writable.once("drain", loop)
               }
               return
             }
           }
-          if (!signal.aborted) {
+          if (!cancelled) {
             resume(Effect.void)
           }
         }
         loop()
         return Effect.sync(() => {
+          cancelled = true
           options.writable.off("drain", loop)
         })
       })

--- a/packages/platform/node-shared/test/NodeSink.test.ts
+++ b/packages/platform/node-shared/test/NodeSink.test.ts
@@ -1,7 +1,7 @@
 import * as NodeSink from "@effect/platform-node-shared/NodeSink"
 import * as NodeStream from "@effect/platform-node-shared/NodeStream"
 import { assert, describe, it } from "@effect/vitest"
-import { Effect } from "effect"
+import { Deferred, Effect, type Exit, Fiber } from "effect"
 import * as Data from "effect/Data"
 import * as Latch from "effect/Latch"
 import * as Queue from "effect/Queue"
@@ -14,6 +14,226 @@ import * as Tar from "tar"
 const TEST_TARBALL = join(__dirname, "fixtures", "helloworld.tar.gz")
 
 describe("Sink", () => {
+  it.effect.each([
+    { endOnDone: true, interrupted: true },
+    { endOnDone: false, interrupted: true },
+    { endOnDone: true, interrupted: false },
+    { endOnDone: false, interrupted: false }
+  ])(
+    "backpressure: endOnDone=$endOnDone, interrupted=$interrupted",
+    ({ endOnDone, interrupted }) =>
+      Effect.gen(function*() {
+        const items: Array<string> = []
+        const entered = yield* Deferred.make<() => void>()
+        const drained = yield* Deferred.make<void>()
+        const writable = new Writable({
+          highWaterMark: 1,
+          write(chunk, _encoding, callback) {
+            items.push(chunk.toString())
+            if (chunk.toString() === "a") {
+              // Let write() return and establish backpressure before notifying the test.
+              queueMicrotask(() => Deferred.doneUnsafe(entered, Effect.succeed(callback)))
+            } else {
+              callback()
+            }
+          }
+        })
+        yield* Effect.addFinalizer(() => Effect.sync(() => writable.destroy()))
+        const fiber = yield* Stream.make("a", "b").pipe(
+          Stream.run(NodeSink.fromWritable({
+            evaluate: () => writable,
+            onError: (error) => error,
+            endOnDone
+          })),
+          Effect.forkScoped
+        )
+        const release = yield* Deferred.await(entered)
+        assert.deepEqual(items, ["a"])
+        // Only "a" has been submitted to Node; "b" is still owned by the sink.
+        assert.strictEqual(writable.writableLength, 1)
+        assert.isTrue(writable.writableNeedDrain)
+        if (interrupted) {
+          yield* Fiber.interrupt(fiber)
+        }
+        writable.once("drain", () => Deferred.doneUnsafe(drained, Effect.void))
+        yield* Effect.sync(release)
+        yield* Deferred.await(drained)
+        if (!interrupted) {
+          yield* Fiber.join(fiber)
+          assert.strictEqual(writable.writableFinished, endOnDone)
+        }
+        assert.deepEqual(items, interrupted ? ["a"] : ["a", "b"])
+      })
+  )
+
+  it.effect.each([false, true])("repeated backpressure: interrupted=%s", (interrupted) =>
+    Effect.gen(function*() {
+      const items: Array<string> = []
+      const writes = yield* Queue.make<() => void>()
+      const writable = new Writable({
+        highWaterMark: 1,
+        write(chunk, _encoding, callback) {
+          items.push(chunk.toString())
+          queueMicrotask(() => Queue.offerUnsafe(writes, callback))
+        }
+      })
+      yield* Effect.addFinalizer(() => Effect.sync(() => writable.destroy()))
+      const fiber = yield* Stream.make("a", "b", "c", "d").pipe(
+        Stream.run(NodeSink.fromWritable({ evaluate: () => writable, onError: (error) => error })),
+        Effect.forkScoped
+      )
+      for (const count of [1, 2, 3, 4]) {
+        const release = yield* Queue.take(writes)
+        assert.deepEqual(items, ["a", "b", "c", "d"].slice(0, count))
+        assert.isTrue(writable.writableNeedDrain)
+        assert.strictEqual(writable.listenerCount("drain"), 1)
+        if (interrupted && count === 3) {
+          yield* Fiber.interrupt(fiber)
+          assert.strictEqual(writable.listenerCount("drain"), 0)
+          const drained = yield* Deferred.make<void>()
+          writable.once("drain", () => Deferred.doneUnsafe(drained, Effect.void))
+          yield* Effect.sync(release)
+          yield* Deferred.await(drained)
+          assert.deepEqual(items, ["a", "b", "c"])
+          break
+        }
+        yield* Effect.sync(release)
+      }
+      if (!interrupted) {
+        yield* Fiber.join(fiber)
+        assert.isTrue(writable.writableFinished)
+        assert.strictEqual(writable.listenerCount("drain"), 0)
+      }
+    }))
+
+  it.effect.each([true, false])(
+    "cancellation during drain dispatch: endOnDone=%s",
+    (endOnDone) =>
+      Effect.gen(function*() {
+        const events: Array<string> = []
+        const entered = yield* Deferred.make<() => void>()
+        const drained = yield* Deferred.make<void>()
+        const controller = new AbortController()
+        let exit: Exit.Exit<void, unknown> | undefined
+        const writable = new Writable({
+          highWaterMark: 1,
+          write(chunk, _encoding, callback) {
+            events.push(`write(${chunk.toString()})`)
+            if (chunk.toString() === "a") {
+              queueMicrotask(() => Deferred.doneUnsafe(entered, Effect.succeed(callback)))
+            } else {
+              callback()
+            }
+          }
+        })
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            controller.abort()
+            writable.destroy()
+          })
+        )
+        // Node selects both listeners before this earlier listener cancels the sink.
+        writable.once("drain", () => {
+          controller.abort()
+          events.push("abort returned")
+        })
+        Effect.runCallback(
+          Stream.run(
+            Stream.make("a", "b"),
+            NodeSink.fromWritable({
+              evaluate: () => writable,
+              onError: (error) => error,
+              endOnDone
+            })
+          ),
+          {
+            signal: controller.signal,
+            onExit: (result) => {
+              exit = result
+              events.push(result._tag)
+            }
+          }
+        )
+        const release = yield* Deferred.await(entered)
+        assert.deepEqual(events, ["write(a)"])
+        assert.strictEqual(writable.writableLength, 1)
+        assert.isTrue(writable.writableNeedDrain)
+        assert.strictEqual(writable.listenerCount("drain"), 2)
+        writable.once("drain", () => {
+          queueMicrotask(() => Deferred.doneUnsafe(drained, Effect.void))
+        })
+        yield* Effect.sync(release)
+        yield* Deferred.await(drained)
+        assert.strictEqual(exit?._tag, "Failure")
+        assert.strictEqual(writable.listenerCount("drain"), 0)
+        assert.deepEqual(events, ["write(a)", "Failure", "abort returned"])
+      })
+  )
+
+  it.effect.each([
+    { endOnDone: true, backpressure: true },
+    { endOnDone: false, backpressure: true },
+    { endOnDone: true, backpressure: false },
+    { endOnDone: false, backpressure: false }
+  ])(
+    "cancellation during resumed write: endOnDone=$endOnDone, backpressure=$backpressure",
+    ({ endOnDone, backpressure }) =>
+      Effect.gen(function*() {
+        const items: Array<string> = []
+        const writes = yield* Queue.make<() => void>()
+        const controller = new AbortController()
+        let exit: Exit.Exit<void, unknown> | undefined
+        const writable = new Writable({
+          highWaterMark: 1,
+          write(chunk, _encoding, callback) {
+            items.push(chunk.toString())
+            if (chunk.toString() === "b") {
+              controller.abort()
+            }
+            if (chunk.toString() === "a" || backpressure) {
+              queueMicrotask(() => Queue.offerUnsafe(writes, callback))
+            } else {
+              callback()
+            }
+          }
+        })
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            controller.abort()
+            writable.destroy()
+          })
+        )
+        Effect.runCallback(
+          Stream.run(
+            Stream.make("a", "b", "c"),
+            NodeSink.fromWritable({
+              evaluate: () => writable,
+              onError: (error) => error,
+              endOnDone
+            })
+          ),
+          {
+            signal: controller.signal,
+            onExit: (result) => {
+              exit = result
+            }
+          }
+        )
+        const release = yield* Queue.take(writes)
+        assert.deepEqual(items, ["a"])
+        assert.isTrue(writable.writableNeedDrain)
+        yield* Effect.sync(release)
+        assert.strictEqual(exit?._tag, "Failure")
+        assert.deepEqual(items, ["a", "b"])
+        assert.strictEqual(writable.listenerCount("drain"), 0)
+        if (backpressure) {
+          const releaseB = yield* Queue.take(writes)
+          yield* Effect.sync(releaseB)
+          assert.deepEqual(items, ["a", "b"])
+        }
+      })
+  )
+
   it.effect("should write to a stream", () =>
     Effect.gen(function*() {
       const items: Array<string> = []

--- a/packages/platform/node-shared/test/NodeSink.test.ts
+++ b/packages/platform/node-shared/test/NodeSink.test.ts
@@ -1,7 +1,7 @@
 import * as NodeSink from "@effect/platform-node-shared/NodeSink"
 import * as NodeStream from "@effect/platform-node-shared/NodeStream"
 import { assert, describe, it } from "@effect/vitest"
-import { Deferred, Effect, type Exit, Fiber } from "effect"
+import { Deferred, Effect } from "effect"
 import * as Data from "effect/Data"
 import * as Latch from "effect/Latch"
 import * as Queue from "effect/Queue"
@@ -14,225 +14,45 @@ import * as Tar from "tar"
 const TEST_TARBALL = join(__dirname, "fixtures", "helloworld.tar.gz")
 
 describe("Sink", () => {
-  it.effect.each([
-    { endOnDone: true, interrupted: true },
-    { endOnDone: false, interrupted: true },
-    { endOnDone: true, interrupted: false },
-    { endOnDone: false, interrupted: false }
-  ])(
-    "backpressure: endOnDone=$endOnDone, interrupted=$interrupted",
-    ({ endOnDone, interrupted }) =>
-      Effect.gen(function*() {
-        const items: Array<string> = []
-        const entered = yield* Deferred.make<() => void>()
-        const drained = yield* Deferred.make<void>()
-        const writable = new Writable({
-          highWaterMark: 1,
-          write(chunk, _encoding, callback) {
-            items.push(chunk.toString())
-            if (chunk.toString() === "a") {
-              // Let write() return and establish backpressure before notifying the test.
-              queueMicrotask(() => Deferred.doneUnsafe(entered, Effect.succeed(callback)))
-            } else {
-              callback()
-            }
-          }
-        })
-        yield* Effect.addFinalizer(() => Effect.sync(() => writable.destroy()))
-        const fiber = yield* Stream.make("a", "b").pipe(
-          Stream.run(NodeSink.fromWritable({
-            evaluate: () => writable,
-            onError: (error) => error,
-            endOnDone
-          })),
-          Effect.forkScoped
-        )
-        const release = yield* Deferred.await(entered)
-        assert.deepEqual(items, ["a"])
-        // Only "a" has been submitted to Node; "b" is still owned by the sink.
-        assert.strictEqual(writable.writableLength, 1)
-        assert.isTrue(writable.writableNeedDrain)
-        if (interrupted) {
-          yield* Fiber.interrupt(fiber)
-        }
-        writable.once("drain", () => Deferred.doneUnsafe(drained, Effect.void))
-        yield* Effect.sync(release)
-        yield* Deferred.await(drained)
-        if (!interrupted) {
-          yield* Fiber.join(fiber)
-          assert.strictEqual(writable.writableFinished, endOnDone)
-        }
-        assert.deepEqual(items, interrupted ? ["a"] : ["a", "b"])
-      })
-  )
-
-  it.effect.each([false, true])("repeated backpressure: interrupted=%s", (interrupted) =>
+  it.effect("does not resume a selected drain callback after interruption", () =>
     Effect.gen(function*() {
       const items: Array<string> = []
-      const writes = yield* Queue.make<() => void>()
+      const entered = yield* Deferred.make<() => void>()
+      const drained = yield* Deferred.make<void>()
+      const controller = new AbortController()
       const writable = new Writable({
         highWaterMark: 1,
         write(chunk, _encoding, callback) {
           items.push(chunk.toString())
-          queueMicrotask(() => Queue.offerUnsafe(writes, callback))
+          if (chunk.toString() === "a") {
+            queueMicrotask(() => Deferred.doneUnsafe(entered, Effect.succeed(callback)))
+          } else {
+            callback()
+          }
         }
       })
-      yield* Effect.addFinalizer(() => Effect.sync(() => writable.destroy()))
-      const fiber = yield* Stream.make("a", "b", "c", "d").pipe(
-        Stream.run(NodeSink.fromWritable({ evaluate: () => writable, onError: (error) => error })),
-        Effect.forkScoped
-      )
-      for (const count of [1, 2, 3, 4]) {
-        const release = yield* Queue.take(writes)
-        assert.deepEqual(items, ["a", "b", "c", "d"].slice(0, count))
-        assert.isTrue(writable.writableNeedDrain)
-        assert.strictEqual(writable.listenerCount("drain"), 1)
-        if (interrupted && count === 3) {
-          yield* Fiber.interrupt(fiber)
-          assert.strictEqual(writable.listenerCount("drain"), 0)
-          const drained = yield* Deferred.make<void>()
-          writable.once("drain", () => Deferred.doneUnsafe(drained, Effect.void))
-          yield* Effect.sync(release)
-          yield* Deferred.await(drained)
-          assert.deepEqual(items, ["a", "b", "c"])
-          break
-        }
-        yield* Effect.sync(release)
-      }
-      if (!interrupted) {
-        yield* Fiber.join(fiber)
-        assert.isTrue(writable.writableFinished)
-        assert.strictEqual(writable.listenerCount("drain"), 0)
-      }
-    }))
-
-  it.effect.each([true, false])(
-    "cancellation during drain dispatch: endOnDone=%s",
-    (endOnDone) =>
-      Effect.gen(function*() {
-        const events: Array<string> = []
-        const entered = yield* Deferred.make<() => void>()
-        const drained = yield* Deferred.make<void>()
-        const controller = new AbortController()
-        let exit: Exit.Exit<void, unknown> | undefined
-        const writable = new Writable({
-          highWaterMark: 1,
-          write(chunk, _encoding, callback) {
-            events.push(`write(${chunk.toString()})`)
-            if (chunk.toString() === "a") {
-              queueMicrotask(() => Deferred.doneUnsafe(entered, Effect.succeed(callback)))
-            } else {
-              callback()
-            }
-          }
-        })
-        yield* Effect.addFinalizer(() =>
-          Effect.sync(() => {
-            controller.abort()
-            writable.destroy()
-          })
-        )
-        // Node selects both listeners before this earlier listener cancels the sink.
-        writable.once("drain", () => {
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
           controller.abort()
-          events.push("abort returned")
+          writable.destroy()
         })
-        Effect.runCallback(
-          Stream.run(
-            Stream.make("a", "b"),
-            NodeSink.fromWritable({
-              evaluate: () => writable,
-              onError: (error) => error,
-              endOnDone
-            })
-          ),
-          {
-            signal: controller.signal,
-            onExit: (result) => {
-              exit = result
-              events.push(result._tag)
-            }
-          }
-        )
-        const release = yield* Deferred.await(entered)
-        assert.deepEqual(events, ["write(a)"])
-        assert.strictEqual(writable.writableLength, 1)
-        assert.isTrue(writable.writableNeedDrain)
-        assert.strictEqual(writable.listenerCount("drain"), 2)
-        writable.once("drain", () => {
-          queueMicrotask(() => Deferred.doneUnsafe(drained, Effect.void))
-        })
-        yield* Effect.sync(release)
-        yield* Deferred.await(drained)
-        assert.strictEqual(exit?._tag, "Failure")
-        assert.strictEqual(writable.listenerCount("drain"), 0)
-        assert.deepEqual(events, ["write(a)", "Failure", "abort returned"])
+      )
+      writable.once("drain", () => controller.abort())
+      Effect.runCallback(
+        Stream.make("a", "b").pipe(
+          Stream.run(NodeSink.fromWritable({ evaluate: () => writable, onError: (error) => error }))
+        ),
+        { signal: controller.signal, onExit: () => {} }
+      )
+      const release = yield* Deferred.await(entered)
+      assert.deepEqual(items, ["a"])
+      writable.once("drain", () => {
+        queueMicrotask(() => Deferred.doneUnsafe(drained, Effect.void))
       })
-  )
-
-  it.effect.each([
-    { endOnDone: true, backpressure: true },
-    { endOnDone: false, backpressure: true },
-    { endOnDone: true, backpressure: false },
-    { endOnDone: false, backpressure: false }
-  ])(
-    "cancellation during resumed write: endOnDone=$endOnDone, backpressure=$backpressure",
-    ({ endOnDone, backpressure }) =>
-      Effect.gen(function*() {
-        const items: Array<string> = []
-        const writes = yield* Queue.make<() => void>()
-        const controller = new AbortController()
-        let exit: Exit.Exit<void, unknown> | undefined
-        const writable = new Writable({
-          highWaterMark: 1,
-          write(chunk, _encoding, callback) {
-            items.push(chunk.toString())
-            if (chunk.toString() === "b") {
-              controller.abort()
-            }
-            if (chunk.toString() === "a" || backpressure) {
-              queueMicrotask(() => Queue.offerUnsafe(writes, callback))
-            } else {
-              callback()
-            }
-          }
-        })
-        yield* Effect.addFinalizer(() =>
-          Effect.sync(() => {
-            controller.abort()
-            writable.destroy()
-          })
-        )
-        Effect.runCallback(
-          Stream.run(
-            Stream.make("a", "b", "c"),
-            NodeSink.fromWritable({
-              evaluate: () => writable,
-              onError: (error) => error,
-              endOnDone
-            })
-          ),
-          {
-            signal: controller.signal,
-            onExit: (result) => {
-              exit = result
-            }
-          }
-        )
-        const release = yield* Queue.take(writes)
-        assert.deepEqual(items, ["a"])
-        assert.isTrue(writable.writableNeedDrain)
-        yield* Effect.sync(release)
-        assert.strictEqual(exit?._tag, "Failure")
-        assert.deepEqual(items, ["a", "b"])
-        assert.strictEqual(writable.listenerCount("drain"), 0)
-        if (backpressure) {
-          const releaseB = yield* Queue.take(writes)
-          yield* Effect.sync(releaseB)
-          assert.deepEqual(items, ["a", "b"])
-        }
-      })
-  )
+      yield* Effect.sync(release)
+      yield* Deferred.await(drained)
+      assert.deepEqual(items, ["a"])
+    }))
 
   it.effect("should write to a stream", () =>
     Effect.gen(function*() {


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Interrupting a Node sink while it waits for writable backpressure could still submit the next buffered value. Node may already have selected the sink's `drain` callback when interruption removes that listener.

The write loop now keeps a local cancellation flag. Cleanup sets the flag before removing the pending `drain` listener, so an already-selected callback returns before writing, registering another listener, or completing.

The regression uses `Stream.run(NodeSink.fromWritable(...))`, a real writable `drain` event, and public cancellation through an `AbortSignal`.

## Verification

```sh
nix develop -c pnpm lint-fix
nix develop -c pnpm test --run packages/platform/node-shared/test/NodeSink.test.ts
nix develop -c pnpm check
```

## Related

Closes EFF-1073
Closes #7713
