### PR TITLE
fix(NodeHttpClient): parse Undici response forms from cached bytes

### DIFF
--- a/.changeset/undici-response-form-data.md
+++ b/.changeset/undici-response-form-data.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node": patch
+---
+
+Parse URL-encoded and multipart response bodies in the Undici HTTP client.

--- a/packages/platform/node/src/NodeHttpClient.ts
+++ b/packages/platform/node/src/NodeHttpClient.ts
@@ -296,17 +296,18 @@ class UndiciResponse extends Inspectable.Class implements HttpClientResponse, Pi
 
   private formDataBody?: Effect.Effect<FormData, Error.HttpClientError>
   get formData(): Effect.Effect<FormData, Error.HttpClientError> {
-    return this.formDataBody ??= Effect.tryPromise({
-      try: () => this.source.body.formData() as Promise<FormData>,
-      catch: (cause) =>
-        new Error.HttpClientError({
-          reason: new Error.DecodeError({
-            request: this.request,
-            response: this,
-            cause
+    return this.formDataBody ??= Effect.flatMap(this.arrayBuffer, (body) =>
+      Effect.tryPromise({
+        try: () => new globalThis.Response(body, { headers: this.headers }).formData(),
+        catch: (cause) =>
+          new Error.HttpClientError({
+            reason: new Error.DecodeError({
+              request: this.request,
+              response: this,
+              cause
+            })
           })
-        })
-    }).pipe(Effect.cached, Effect.runSync)
+      })).pipe(Effect.cached, Effect.runSync)
   }
 
   private arrayBufferBody?: Effect.Effect<ArrayBuffer, Error.HttpClientError>

--- a/packages/platform/node/test/NodeHttpClient.test.ts
+++ b/packages/platform/node/test/NodeHttpClient.test.ts
@@ -30,6 +30,31 @@ const TodoWithoutId = Schema.Struct({
 })
 const largeResponseBody = "a".repeat(10 * 1024 * 1024)
 const responseBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
+const formDataResponses = [
+  {
+    name: "URL-encoded",
+    path: "/form/url-encoded",
+    contentType: "application/x-www-form-urlencoded",
+    body: "tag=one&tag=two"
+  },
+  {
+    name: "multipart",
+    path: "/form/multipart",
+    contentType: "multipart/form-data; boundary=effect-test",
+    body: [
+      "--effect-test",
+      "Content-Disposition: form-data; name=\"tag\"",
+      "",
+      "one",
+      "--effect-test",
+      "Content-Disposition: form-data; name=\"tag\"",
+      "",
+      "two",
+      "--effect-test--",
+      ""
+    ].join("\r\n")
+  }
+] as const
 
 const makeLocalServerClient = Effect.gen(function*() {
   const client = yield* HttpClient.HttpClient
@@ -68,6 +93,9 @@ const LocalServerRoutes = HttpRouter.serve(HttpRouter.addAll([
   ),
   HttpRouter.route("GET", "/text", Effect.succeed(HttpServerResponse.text("test"))),
   HttpRouter.route("GET", "/bytes", Effect.succeed(HttpServerResponse.uint8Array(responseBytes))),
+  ...formDataResponses.map(({ body, contentType, path }) =>
+    HttpRouter.route("GET", path, Effect.succeed(HttpServerResponse.text(body, { contentType })))
+  ),
   HttpRouter.route("GET", "/large", Effect.succeed(HttpServerResponse.text(largeResponseBody))),
   HttpRouter.route("GET", "/hang", Effect.never),
   HttpRouter.route("GET", "/redirect", Effect.succeed(HttpServerResponse.redirect("/redirected"))),
@@ -111,6 +139,15 @@ const LocalServerRoutes = HttpRouter.serve(HttpRouter.addAll([
         void response.text
         assert.deepStrictEqual(new Uint8Array(yield* response.arrayBuffer), responseBytes)
       }).pipe(Effect.provide(localServerTestLayer)))
+
+    if (name === "undici") {
+      it.effect.each(formDataResponses)("parses $name response form data", ({ path }) =>
+        Effect.gen(function*() {
+          const response = yield* HttpClient.get(path)
+          const form = yield* response.formData
+          assert.deepStrictEqual(form.getAll("tag"), ["one", "two"])
+        }).pipe(Effect.provide(localServerTestLayer)))
+    }
 
     it.effect("local server followRedirects", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

### Why

The Undici client's `response.formData` fails for valid URL-encoded and multipart bodies with `UND_ERR_NOT_SUPPORTED`. The installed Undici `BodyReadable` does not implement `formData()`.

### What changed

Parse the response's cached bytes with native `Response.formData()` and forward the original headers for content-type and multipart boundary handling. The focused cases now live in `packages/platform/node/test/NodeHttpClient.test.ts`.

This also adds an `@effect/platform-node` patch changeset, resolving the changeset-bot notice.

### Verification

```sh
nix develop -c pnpm test --run packages/platform/node/test/NodeHttpClient.test.ts --reporter=verbose --maxWorkers=1 --no-file-parallelism --sequence.concurrent=false
nix develop -c pnpm lint-fix
nix develop -c pnpm check
git diff --check origin/main...HEAD
```

The targeted test file passes all 27 tests.

## Related

Closes #7717
Closes EFF-1075

## Audit

Runtime correctness audit; intended label: `audit`.
