### PR TITLE
fix(sql-pglite): preserve string values passed to sql.json

### DIFF
--- a/.changeset/pglite-json-string-values.md
+++ b/.changeset/pglite-json-string-values.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-pglite": patch
+---
+
+Preserve string values passed to `sql.json` when writing JSON or JSONB. Strings such as `"null"`, `"123"`, and `"hello"` now remain JSON strings instead of being interpreted as encoded JSON.

--- a/.changeset/pglite-json-string-values.md
+++ b/.changeset/pglite-json-string-values.md
@@ -2,4 +2,4 @@
 "@effect/sql-pglite": patch
 ---
 
-Preserve string values passed to `sql.json` when writing JSON or JSONB. Strings such as `"null"`, `"123"`, and `"hello"` now remain JSON strings instead of being interpreted as encoded JSON.
+Preserve string values passed to `sql.json` when using PGlite.

--- a/packages/sql/pglite/src/PgliteClient.ts
+++ b/packages/sql/pglite/src/PgliteClient.ts
@@ -429,13 +429,12 @@ export const makeCompiler = (
     onCustom(type, placeholder, withoutTransform) {
       switch (type.kind) {
         case "PgJson": {
+          const value = withoutTransform || transformValue === undefined
+            ? type.paramA
+            : transformValue(type.paramA)
           return [
             placeholder(undefined),
-            [
-              withoutTransform || transformValue === undefined
-                ? type.paramA
-                : transformValue(type.paramA)
-            ]
+            [typeof value === "string" ? JSON.stringify(value) : value]
           ]
         }
       }

--- a/packages/sql/pglite/test/Json.test.ts
+++ b/packages/sql/pglite/test/Json.test.ts
@@ -5,77 +5,15 @@ import { Effect } from "effect"
 describe("PgliteClient JSON values", () => {
   layer(PgliteClient.layer(), { timeout: "30 seconds" })((it) => {
     for (const type of ["json", "jsonb"]) {
-      describe(type, () => {
-        it.effect.each(["null", "123", "hello"])("preserves the string %j", (input) =>
+      it.effect.each(["null", "123", "hello", "", "\"quoted\"\\\n"])(
+        `${type} preserves the string %j`,
+        (input) =>
           Effect.gen(function*() {
             const sql = yield* PgliteClient.PgliteClient
             const rows = yield* sql<{ value: unknown }>`SELECT ${sql.json(input)}::${sql.literal(type)} AS value`
             assert.deepStrictEqual(rows, [{ value: input }])
-          }))
-
-        it.effect.each([
-          { input: { message: "hello" } },
-          { input: ["null", "123", "hello"] },
-          { input: 123 },
-          { input: true },
-          { input: false },
-          { input: null }
-        ])("preserves the non-string JSON value $input", ({ input }) =>
-          Effect.gen(function*() {
-            const sql = yield* PgliteClient.PgliteClient
-            const rows = yield* sql<{ value: unknown }>`SELECT ${sql.json(input)}::${sql.literal(type)} AS value`
-            assert.deepStrictEqual(rows, [{ value: input }])
-          }))
-
-        it.effect.each(["null", "123", "hello"])(
-          "accepts explicitly serialized string %j",
-          (input) =>
-            Effect.gen(function*() {
-              const sql = yield* PgliteClient.PgliteClient
-              const rows = yield* sql<{ value: unknown }>`SELECT ${JSON.stringify(input)}::${
-                sql.literal(type)
-              } AS value`
-              assert.deepStrictEqual(rows, [{ value: input }])
-            })
-        )
-
-        it.effect.each(["", "\"quoted\"\\\n"])("escapes the string %j", (input) =>
-          Effect.gen(function*() {
-            const sql = yield* PgliteClient.PgliteClient
-            const rows = yield* sql`SELECT ${sql.json(input)}::${sql.literal(type)} AS value`
-            assert.deepStrictEqual(rows, [{ value: input }])
-          }))
-
-        for (const transformJson of [true, false]) {
-          it.effect.each([true, false])(
-            `transformJson=${transformJson}, withoutTransform=%j`,
-            (withoutTransform) =>
-              Effect.gen(function*() {
-                const sql = yield* PgliteClient.PgliteClient
-                const compiler = PgliteClient.makeCompiler((name) => name.toUpperCase(), transformJson)
-                const input = { nested: [{ message: "hello" }] }
-                const expected = transformJson && !withoutTransform ? { NESTED: [{ MESSAGE: "hello" }] } : input
-                const [query, params] = compiler.compile(
-                  sql`SELECT ${sql.json("hello")}::${sql.literal(type)} AS text, ${sql.json(input)}::${
-                    sql.literal(type)
-                  } AS value`,
-                  withoutTransform
-                )
-                assert.deepStrictEqual(params, [JSON.stringify("hello"), expected])
-                assert.deepStrictEqual(yield* sql.unsafe(query, params), [{ text: "hello", value: expected }])
-                assert.deepStrictEqual(input, { nested: [{ message: "hello" }] })
-              })
-          )
-        }
-      })
+          })
+      )
     }
-
-    it.effect("leaves ordinary SQL parameters unchanged", () =>
-      Effect.gen(function*() {
-        const sql = yield* PgliteClient.PgliteClient
-        const statement = sql`SELECT ${"hello"}::text AS text, ${123}::integer AS number, ${true}::boolean AS boolean`
-        assert.deepStrictEqual(statement.compile()[1], ["hello", 123, true])
-        assert.deepStrictEqual(yield* statement, [{ text: "hello", number: 123, boolean: true }])
-      }))
   })
 })

--- a/packages/sql/pglite/test/Json.test.ts
+++ b/packages/sql/pglite/test/Json.test.ts
@@ -1,0 +1,81 @@
+import { PgliteClient } from "@effect/sql-pglite"
+import { assert, describe, layer } from "@effect/vitest"
+import { Effect } from "effect"
+
+describe("PgliteClient JSON values", () => {
+  layer(PgliteClient.layer(), { timeout: "30 seconds" })((it) => {
+    for (const type of ["json", "jsonb"]) {
+      describe(type, () => {
+        it.effect.each(["null", "123", "hello"])("preserves the string %j", (input) =>
+          Effect.gen(function*() {
+            const sql = yield* PgliteClient.PgliteClient
+            const rows = yield* sql<{ value: unknown }>`SELECT ${sql.json(input)}::${sql.literal(type)} AS value`
+            assert.deepStrictEqual(rows, [{ value: input }])
+          }))
+
+        it.effect.each([
+          { input: { message: "hello" } },
+          { input: ["null", "123", "hello"] },
+          { input: 123 },
+          { input: true },
+          { input: false },
+          { input: null }
+        ])("preserves the non-string JSON value $input", ({ input }) =>
+          Effect.gen(function*() {
+            const sql = yield* PgliteClient.PgliteClient
+            const rows = yield* sql<{ value: unknown }>`SELECT ${sql.json(input)}::${sql.literal(type)} AS value`
+            assert.deepStrictEqual(rows, [{ value: input }])
+          }))
+
+        it.effect.each(["null", "123", "hello"])(
+          "accepts explicitly serialized string %j",
+          (input) =>
+            Effect.gen(function*() {
+              const sql = yield* PgliteClient.PgliteClient
+              const rows = yield* sql<{ value: unknown }>`SELECT ${JSON.stringify(input)}::${
+                sql.literal(type)
+              } AS value`
+              assert.deepStrictEqual(rows, [{ value: input }])
+            })
+        )
+
+        it.effect.each(["", "\"quoted\"\\\n"])("escapes the string %j", (input) =>
+          Effect.gen(function*() {
+            const sql = yield* PgliteClient.PgliteClient
+            const rows = yield* sql`SELECT ${sql.json(input)}::${sql.literal(type)} AS value`
+            assert.deepStrictEqual(rows, [{ value: input }])
+          }))
+
+        for (const transformJson of [true, false]) {
+          it.effect.each([true, false])(
+            `transformJson=${transformJson}, withoutTransform=%j`,
+            (withoutTransform) =>
+              Effect.gen(function*() {
+                const sql = yield* PgliteClient.PgliteClient
+                const compiler = PgliteClient.makeCompiler((name) => name.toUpperCase(), transformJson)
+                const input = { nested: [{ message: "hello" }] }
+                const expected = transformJson && !withoutTransform ? { NESTED: [{ MESSAGE: "hello" }] } : input
+                const [query, params] = compiler.compile(
+                  sql`SELECT ${sql.json("hello")}::${sql.literal(type)} AS text, ${sql.json(input)}::${
+                    sql.literal(type)
+                  } AS value`,
+                  withoutTransform
+                )
+                assert.deepStrictEqual(params, [JSON.stringify("hello"), expected])
+                assert.deepStrictEqual(yield* sql.unsafe(query, params), [{ text: "hello", value: expected }])
+                assert.deepStrictEqual(input, { nested: [{ message: "hello" }] })
+              })
+          )
+        }
+      })
+    }
+
+    it.effect("leaves ordinary SQL parameters unchanged", () =>
+      Effect.gen(function*() {
+        const sql = yield* PgliteClient.PgliteClient
+        const statement = sql`SELECT ${"hello"}::text AS text, ${123}::integer AS number, ${true}::boolean AS boolean`
+        assert.deepStrictEqual(statement.compile()[1], ["hello", 123, true])
+        assert.deepStrictEqual(yield* statement, [{ text: "hello", number: 123, boolean: true }])
+      }))
+  })
+})


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

PGlite treats unencoded string parameters as JSON source text. As a result, `sql.json("null")` and `sql.json("123")` return non-string values, while `sql.json("hello")` fails to parse.

This change JSON-encodes string values after the existing optional key transform. Non-string JSON values keep their current parameter representation. Focused coverage checks JSON and JSONB round trips, including empty and escaped strings.

## Verification

- `pnpm lint-fix`
- `pnpm test --run packages/sql/pglite/test/Json.test.ts packages/sql/pglite/test/Client.test.ts` (23 passed)
- `pnpm check`
- The focused JSON test fails 10/10 when only the implementation fix is reverted.

## Related

Closes #7719
Closes EFF-1076
