### PR TITLE
fix(sql-sqlite-node): capture unprepared statement preparation errors

### DIFF
--- a/.changeset/sqlite-node-unprepared-errors.md
+++ b/.changeset/sqlite-node-unprepared-errors.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-sqlite-node": patch
+---
+
+Capture unprepared statement preparation failures as typed `SqlError`s.

--- a/packages/sql/sqlite-node/src/SqliteClient.ts
+++ b/packages/sql/sqlite-node/src/SqliteClient.ts
@@ -151,14 +151,16 @@ export const make = (
         db.exec("PRAGMA journal_mode = WAL")
       }
 
+      const prepare = (sql: string) =>
+        Effect.try({
+          try: () => db.prepare(sql),
+          catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to prepare statement", "prepare") })
+        })
+
       const prepareCache = yield* Cache.make({
         capacity: options.prepareCacheSize ?? 200,
         timeToLive: options.prepareCacheTTL ?? Duration.minutes(10),
-        lookup: (sql: string) =>
-          Effect.try({
-            try: () => db.prepare(sql),
-            catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to prepare statement", "prepare") })
-          })
+        lookup: prepare
       })
 
       const runStatement = (
@@ -246,7 +248,7 @@ export const make = (
       const runValuesUnprepared = (
         sql: string,
         params: ReadonlyArray<unknown>
-      ) => runStatementValuesUnprepared(db.prepare(sql), params)
+      ) => Effect.flatMap(prepare(sql), (statement) => runStatementValuesUnprepared(statement, params))
 
       return identity<SqliteConnection>({
         execute(sql, params, transformRows) {
@@ -264,7 +266,7 @@ export const make = (
           return runValuesUnprepared(sql, params)
         },
         executeUnprepared(sql, params, transformRows) {
-          const effect = runStatement(db.prepare(sql), params ?? [], false)
+          const effect = Effect.flatMap(prepare(sql), (statement) => runStatement(statement, params ?? [], false))
           return transformRows ? Effect.map(effect, transformRows) : effect
         },
         executeStream(_sql, _params) {

--- a/packages/sql/sqlite-node/test/Client.test.ts
+++ b/packages/sql/sqlite-node/test/Client.test.ts
@@ -63,6 +63,22 @@ describe("Client", () => {
       ])
     }))
 
+  for (const mode of ["unprepared", "valuesUnprepared"] as const) {
+    it.effect(`captures ${mode} preparation errors`, () =>
+      Effect.gen(function*() {
+        const sql = yield* makeClient
+        yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY)`
+
+        const statement = sql`CREATE TABLE test (id INTEGER PRIMARY KEY)`
+        const execution = mode === "unprepared"
+          ? Effect.as(statement.unprepared, false)
+          : Effect.as(statement.valuesUnprepared, false)
+        const recovered = yield* execution.pipe(Effect.catchTag("SqlError", () => Effect.succeed(true)))
+
+        assert.isTrue(recovered)
+      }))
+  }
+
   it.effect("withTransaction", () =>
     Effect.gen(function*() {
       const sql = yield* makeClient


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

SQLite's `.unprepared` and `.valuesUnprepared` paths called `db.prepare` outside Effect error capture. Preparation failures therefore escaped as defects and could not be recovered with `Effect.catchTag("SqlError", ...)`.

Route cached and uncached preparation through the same effectful helper. Uncached execution still bypasses the statement cache, and the regression coverage lives in `packages/sql/sqlite-node/test/Client.test.ts`.

## Verification

- `pnpm lint-fix`
- `pnpm test --run packages/sql/sqlite-node/test --maxWorkers=1 --no-file-parallelism` (8 files, 76 tests)
- `pnpm check`

## Related

Closes #7721
Closes EFF-1077
