### PR TITLE
fix(sql-mssql): adapt byte arrays for automatic VarBinary binding

### DIFF
--- a/.changeset/mssql-binary-parameters.md
+++ b/.changeset/mssql-binary-parameters.md
@@ -2,4 +2,4 @@
 "@effect/sql-mssql": patch
 ---
 
-Fix automatic VarBinary binding for Uint8Array and Int8Array SQL parameters, preserving signed bytes, subarray bounds, and empty values. Custom parameter types and explicit parameters retain their existing behavior.
+Fix automatic binary parameter binding in `@effect/sql-mssql`.

--- a/.changeset/mssql-binary-parameters.md
+++ b/.changeset/mssql-binary-parameters.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-mssql": patch
+---
+
+Fix automatic VarBinary binding for Uint8Array and Int8Array SQL parameters, preserving signed bytes, subarray bounds, and empty values. Custom parameter types and explicit parameters retain their existing behavior.

--- a/packages/sql/mssql/src/MssqlClient.ts
+++ b/packages/sql/mssql/src/MssqlClient.ts
@@ -367,14 +367,7 @@ export const make = (
               } else {
                 const kind = Statement.primitiveKind(value)
                 const type = parameterTypes[kind]
-                req.addParameter(
-                  name,
-                  type,
-                  type === Tedious.TYPES.VarBinary && (kind === "Uint8Array" || kind === "Int8Array") &&
-                    !Buffer.isBuffer(value)
-                    ? Buffer.from(value.buffer, value.byteOffset, value.byteLength)
-                    : value
-                )
+                req.addParameter(name, type, value)
               }
             }
           }
@@ -714,6 +707,17 @@ function numberToParamName(n: number) {
   return `${Math.ceil(n + 1)}`
 }
 
+const byteArrayParameterType: DataType = {
+  ...Tedious.TYPES.VarBinary,
+  validate(value, collation, options) {
+    return Tedious.TYPES.VarBinary.validate(
+      Buffer.isBuffer(value) ? value : Buffer.from(value.buffer, value.byteOffset, value.byteLength),
+      collation,
+      options
+    )
+  }
+}
+
 /**
  * Default mapping from Effect SQL primitive value kinds to Tedious SQL Server parameter data types.
  *
@@ -726,8 +730,8 @@ export const defaultParameterTypes: Record<Statement.PrimitiveKind, DataType> = 
   bigint: Tedious.TYPES.BigInt,
   boolean: Tedious.TYPES.Bit,
   Date: Tedious.TYPES.DateTime,
-  Uint8Array: Tedious.TYPES.VarBinary,
-  Int8Array: Tedious.TYPES.VarBinary,
+  Uint8Array: byteArrayParameterType,
+  Int8Array: byteArrayParameterType,
   null: Tedious.TYPES.Bit
 }
 

--- a/packages/sql/mssql/src/MssqlClient.ts
+++ b/packages/sql/mssql/src/MssqlClient.ts
@@ -40,6 +40,7 @@ import {
   UnknownError
 } from "effect/unstable/sql/SqlError"
 import * as Statement from "effect/unstable/sql/Statement"
+import { Buffer } from "node:buffer"
 import * as Tedious from "tedious"
 import type { ConnectionOptions } from "tedious/lib/connection.ts"
 import type { DataType } from "tedious/lib/data-type.ts"
@@ -366,7 +367,14 @@ export const make = (
               } else {
                 const kind = Statement.primitiveKind(value)
                 const type = parameterTypes[kind]
-                req.addParameter(name, type, value)
+                req.addParameter(
+                  name,
+                  type,
+                  type === Tedious.TYPES.VarBinary && (kind === "Uint8Array" || kind === "Int8Array") &&
+                    !Buffer.isBuffer(value)
+                    ? Buffer.from(value.buffer, value.byteOffset, value.byteLength)
+                    : value
+                )
               }
             }
           }

--- a/packages/sql/mssql/test/Binary.test.ts
+++ b/packages/sql/mssql/test/Binary.test.ts
@@ -1,15 +1,13 @@
 import { MssqlClient } from "@effect/sql-mssql"
-import { assert, describe, it } from "@effect/vitest"
+import { assert, it } from "@effect/vitest"
 import { Effect } from "effect"
 import * as Reactivity from "effect/unstable/reactivity/Reactivity"
-import { Buffer } from "node:buffer"
-import * as Tedious from "tedious"
+import type * as Tedious from "tedious"
 import { vi } from "vitest"
 
 vi.mock("tedious", async (importOriginal) => {
   const original = await importOriginal<typeof Tedious>()
 
-  // Keep real execSql / Request validation; replace only connection and transport.
   class MockConnection extends original.Connection {
     override connect(callback?: (error?: Error) => void) {
       callback?.()
@@ -22,7 +20,6 @@ vi.mock("tedious", async (importOriginal) => {
       if (!(request instanceof original.Request)) {
         throw new Error("Unexpected bulk load")
       }
-      // Echo validated bindings as rows so assertions use the public client result.
       const rows = request.parameters.map((parameter) => [
         { metadata: { colName: "value" }, value: parameter.value }
       ])
@@ -33,96 +30,14 @@ vi.mock("tedious", async (importOriginal) => {
   return { ...original, Connection: MockConnection }
 })
 
-const config = { server: "mock.invalid", minConnections: 0, maxConnections: 1 }
+it.effect("binds an interpolated Uint8Array as VarBinary", () =>
+  Effect.gen(function*() {
+    const client = yield* MssqlClient.make({
+      server: "mock.invalid",
+      minConnections: 0,
+      maxConnections: 1
+    })
+    const rows = yield* client<{ value: Uint8Array }>`SELECT ${new Uint8Array([0, 128, 255])} AS value`
 
-describe("MssqlClient binary parameters", () => {
-  for (
-    const [name, input, expected] of [
-      ["Uint8Array", new Uint8Array([0, 127, 128, 255]), [0, 127, 128, 255]],
-      ["signed Int8Array", new Int8Array([-128, -1, 0, 127]), [128, 255, 0, 127]],
-      ["Uint8Array subarray", new Uint8Array([99, 0, 128, 255, 88]).subarray(1, 4), [0, 128, 255]],
-      ["Int8Array subarray", new Int8Array([99, -128, -1, 0, 88]).subarray(1, 4), [128, 255, 0]],
-      ["empty Uint8Array", new Uint8Array(0), []],
-      ["empty Int8Array", new Int8Array(0), []],
-      ["Buffer", Buffer.from([0, 127, 128, 255]), [0, 127, 128, 255]],
-      ["Buffer subarray", Buffer.from([99, 0, 128, 255, 88]).subarray(1, 4), [0, 128, 255]],
-      ["empty Buffer", Buffer.alloc(0), []]
-    ] as const
-  ) {
-    it.effect(`preserves ${name} bytes through interpolation`, () =>
-      Effect.gen(function*() {
-        const client = yield* MssqlClient.make(config)
-        const rows = yield* client<{ value: Buffer }>`SELECT ${input} AS value`
-
-        assert.lengthOf(rows, 1)
-        assert.isTrue(Buffer.isBuffer(rows[0].value))
-        assert.deepStrictEqual<ReadonlyArray<number>>(Array.from(rows[0].value), expected)
-      }).pipe(Effect.provide(Reactivity.layer)))
-  }
-
-  for (const value of ["lambda: \u03bb", 1.5]) {
-    it.effect(`preserves non-binary parameter ${value}`, () =>
-      Effect.gen(function*() {
-        const client = yield* MssqlClient.make(config)
-        const rows = yield* client`SELECT ${value} AS value`
-
-        assert.deepStrictEqual(rows, [{ value }])
-      }).pipe(Effect.provide(Reactivity.layer)))
-  }
-
-  for (const input of [new Uint8Array([0, 128, 255]), new Int8Array([0, -128, -1])]) {
-    it.effect(`uses a configured binary validator for ${input.constructor.name}`, () =>
-      Effect.gen(function*() {
-        const validate = vi.fn((value: unknown) => {
-          if (!(value instanceof Uint8Array || value instanceof Int8Array)) {
-            throw new TypeError("Expected a byte array")
-          }
-          return Tedious.TYPES.VarBinary.validate(
-            Buffer.from(value.buffer, value.byteOffset, value.byteLength),
-            undefined
-          )
-        })
-        const binaryType = { ...Tedious.TYPES.VarBinary, validate }
-        const client = yield* MssqlClient.make({
-          ...config,
-          parameterTypes: {
-            ...MssqlClient.defaultParameterTypes,
-            Uint8Array: binaryType,
-            Int8Array: binaryType
-          }
-        })
-        const rows = yield* client`SELECT ${input} AS value`
-
-        assert.strictEqual(validate.mock.calls.length, 1)
-        assert.strictEqual(validate.mock.calls[0][0], input)
-        assert.deepStrictEqual(rows, [{ value: Buffer.from([0, 128, 255]) }])
-      }).pipe(Effect.provide(Reactivity.layer)))
-  }
-
-  it.effect("preserves an explicit VarBinary Buffer parameter", () =>
-    Effect.gen(function*() {
-      const client = yield* MssqlClient.make(config)
-      const value = Buffer.from([0, 128, 255])
-      const rows = yield* client`SELECT ${client.param(Tedious.TYPES.VarBinary, value)} AS value`
-
-      assert.deepStrictEqual(rows, [{ value }])
-    }).pipe(Effect.provide(Reactivity.layer)))
-
-  it.effect("preserves an explicit custom binary parameter", () =>
-    Effect.gen(function*() {
-      const client = yield* MssqlClient.make(config)
-      const input = new Int8Array([0, -128, -1])
-      const validate = vi.fn((value: unknown) => {
-        assert.strictEqual(value, input)
-        return Tedious.TYPES.VarBinary.validate(
-          Buffer.from(input.buffer, input.byteOffset, input.byteLength),
-          undefined
-        )
-      })
-      const type = { ...Tedious.TYPES.VarBinary, validate }
-      const rows = yield* client`SELECT ${client.param(type, input)} AS value`
-
-      assert.strictEqual(validate.mock.calls.length, 1)
-      assert.deepStrictEqual(rows, [{ value: Buffer.from([0, 128, 255]) }])
-    }).pipe(Effect.provide(Reactivity.layer)))
-})
+    assert.deepStrictEqual(Array.from(rows[0].value), [0, 128, 255])
+  }).pipe(Effect.provide(Reactivity.layer)))

--- a/packages/sql/mssql/test/Binary.test.ts
+++ b/packages/sql/mssql/test/Binary.test.ts
@@ -1,0 +1,128 @@
+import { MssqlClient } from "@effect/sql-mssql"
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import * as Reactivity from "effect/unstable/reactivity/Reactivity"
+import { Buffer } from "node:buffer"
+import * as Tedious from "tedious"
+import { vi } from "vitest"
+
+vi.mock("tedious", async (importOriginal) => {
+  const original = await importOriginal<typeof Tedious>()
+
+  // Keep real execSql / Request validation; replace only connection and transport.
+  class MockConnection extends original.Connection {
+    override connect(callback?: (error?: Error) => void) {
+      callback?.()
+    }
+    override close() {}
+    override cancel() {
+      return false
+    }
+    override makeRequest(request: Tedious.Request | Tedious.BulkLoad) {
+      if (!(request instanceof original.Request)) {
+        throw new Error("Unexpected bulk load")
+      }
+      // Echo validated bindings as rows so assertions use the public client result.
+      const rows = request.parameters.map((parameter) => [
+        { metadata: { colName: "value" }, value: parameter.value }
+      ])
+      request.callback(null, rows.length, rows)
+    }
+  }
+
+  return { ...original, Connection: MockConnection }
+})
+
+const config = { server: "mock.invalid", minConnections: 0, maxConnections: 1 }
+
+describe("MssqlClient binary parameters", () => {
+  for (
+    const [name, input, expected] of [
+      ["Uint8Array", new Uint8Array([0, 127, 128, 255]), [0, 127, 128, 255]],
+      ["signed Int8Array", new Int8Array([-128, -1, 0, 127]), [128, 255, 0, 127]],
+      ["Uint8Array subarray", new Uint8Array([99, 0, 128, 255, 88]).subarray(1, 4), [0, 128, 255]],
+      ["Int8Array subarray", new Int8Array([99, -128, -1, 0, 88]).subarray(1, 4), [128, 255, 0]],
+      ["empty Uint8Array", new Uint8Array(0), []],
+      ["empty Int8Array", new Int8Array(0), []],
+      ["Buffer", Buffer.from([0, 127, 128, 255]), [0, 127, 128, 255]],
+      ["Buffer subarray", Buffer.from([99, 0, 128, 255, 88]).subarray(1, 4), [0, 128, 255]],
+      ["empty Buffer", Buffer.alloc(0), []]
+    ] as const
+  ) {
+    it.effect(`preserves ${name} bytes through interpolation`, () =>
+      Effect.gen(function*() {
+        const client = yield* MssqlClient.make(config)
+        const rows = yield* client<{ value: Buffer }>`SELECT ${input} AS value`
+
+        assert.lengthOf(rows, 1)
+        assert.isTrue(Buffer.isBuffer(rows[0].value))
+        assert.deepStrictEqual<ReadonlyArray<number>>(Array.from(rows[0].value), expected)
+      }).pipe(Effect.provide(Reactivity.layer)))
+  }
+
+  for (const value of ["lambda: \u03bb", 1.5]) {
+    it.effect(`preserves non-binary parameter ${value}`, () =>
+      Effect.gen(function*() {
+        const client = yield* MssqlClient.make(config)
+        const rows = yield* client`SELECT ${value} AS value`
+
+        assert.deepStrictEqual(rows, [{ value }])
+      }).pipe(Effect.provide(Reactivity.layer)))
+  }
+
+  for (const input of [new Uint8Array([0, 128, 255]), new Int8Array([0, -128, -1])]) {
+    it.effect(`uses a configured binary validator for ${input.constructor.name}`, () =>
+      Effect.gen(function*() {
+        const validate = vi.fn((value: unknown) => {
+          if (!(value instanceof Uint8Array || value instanceof Int8Array)) {
+            throw new TypeError("Expected a byte array")
+          }
+          return Tedious.TYPES.VarBinary.validate(
+            Buffer.from(value.buffer, value.byteOffset, value.byteLength),
+            undefined
+          )
+        })
+        const binaryType = { ...Tedious.TYPES.VarBinary, validate }
+        const client = yield* MssqlClient.make({
+          ...config,
+          parameterTypes: {
+            ...MssqlClient.defaultParameterTypes,
+            Uint8Array: binaryType,
+            Int8Array: binaryType
+          }
+        })
+        const rows = yield* client`SELECT ${input} AS value`
+
+        assert.strictEqual(validate.mock.calls.length, 1)
+        assert.strictEqual(validate.mock.calls[0][0], input)
+        assert.deepStrictEqual(rows, [{ value: Buffer.from([0, 128, 255]) }])
+      }).pipe(Effect.provide(Reactivity.layer)))
+  }
+
+  it.effect("preserves an explicit VarBinary Buffer parameter", () =>
+    Effect.gen(function*() {
+      const client = yield* MssqlClient.make(config)
+      const value = Buffer.from([0, 128, 255])
+      const rows = yield* client`SELECT ${client.param(Tedious.TYPES.VarBinary, value)} AS value`
+
+      assert.deepStrictEqual(rows, [{ value }])
+    }).pipe(Effect.provide(Reactivity.layer)))
+
+  it.effect("preserves an explicit custom binary parameter", () =>
+    Effect.gen(function*() {
+      const client = yield* MssqlClient.make(config)
+      const input = new Int8Array([0, -128, -1])
+      const validate = vi.fn((value: unknown) => {
+        assert.strictEqual(value, input)
+        return Tedious.TYPES.VarBinary.validate(
+          Buffer.from(input.buffer, input.byteOffset, input.byteLength),
+          undefined
+        )
+      })
+      const type = { ...Tedious.TYPES.VarBinary, validate }
+      const rows = yield* client`SELECT ${client.param(type, input)} AS value`
+
+      assert.strictEqual(validate.mock.calls.length, 1)
+      assert.deepStrictEqual(rows, [{ value: Buffer.from([0, 128, 255]) }])
+    }).pipe(Effect.provide(Reactivity.layer)))
+})

--- a/packages/sql/mssql/tsconfig.json
+++ b/packages/sql/mssql/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
   "include": ["src"],
   "references": [
     { "path": "../../effect" }


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Convert automatically bound `Uint8Array` and `Int8Array` values to buffers in the default MSSQL binary parameter validator before Tedious validates them. Configured custom parameter types and explicit parameters keep their existing behavior.

The regression test exercises interpolation through the public client with real Tedious request validation and a stubbed transport.

## Verification

- `pnpm test --run packages/sql/mssql/test/Binary.test.ts packages/sql/mssql/test/Client.test.ts packages/sql/mssql/test/SqlErrorClassification.test.ts --maxWorkers 1 --no-file-parallelism`
- `pnpm lint-fix`
- `pnpm check`

## Related

Closes #7725
Closes EFF-1079
