### PR TITLE
fix(NodeHttpServer): forward custom and empty status text

### DIFF
--- a/.changeset/node-http-status-text.md
+++ b/.changeset/node-http-status-text.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node": patch
+---
+
+Forward custom and empty status text from NodeHttpServer responses.

--- a/packages/platform/node/src/NodeHttpServer.ts
+++ b/packages/platform/node/src/NodeHttpServer.ts
@@ -537,7 +537,7 @@ const handleResponse = (
   }
 
   if (request.method === "HEAD") {
-    nodeResponse.writeHead(response.status, headers)
+    nodeResponse.writeHead(response.status, response.statusText, headers)
     return Effect.andThen(
       cancelResponseBody(response.body),
       Effect.callback<void>((resume) => {
@@ -556,12 +556,12 @@ const handleResponse = (
   const body = response.body
   switch (body._tag) {
     case "Empty": {
-      nodeResponse.writeHead(response.status, headers)
+      nodeResponse.writeHead(response.status, response.statusText, headers)
       nodeResponse.end()
       return Effect.void
     }
     case "Raw": {
-      nodeResponse.writeHead(response.status, headers)
+      nodeResponse.writeHead(response.status, response.statusText, headers)
       if (
         typeof body.body === "object" && body.body !== null && "pipe" in body.body &&
         typeof body.body.pipe === "function"
@@ -587,7 +587,7 @@ const handleResponse = (
       })
     }
     case "Uint8Array": {
-      nodeResponse.writeHead(response.status, headers)
+      nodeResponse.writeHead(response.status, response.statusText, headers)
       // If the body is less than 1MB, we skip the callback
       if (body.body.length < 1024 * 1024) {
         nodeResponse.end(body.body)
@@ -600,7 +600,7 @@ const handleResponse = (
     case "FormData": {
       return Effect.suspend(() => {
         const r = new globalThis.Response(body.formData)
-        nodeResponse.writeHead(response.status, {
+        nodeResponse.writeHead(response.status, response.statusText, {
           ...headers,
           ...Object.fromEntries(r.headers)
         })
@@ -629,7 +629,7 @@ const handleResponse = (
       })
     }
     case "Stream": {
-      nodeResponse.writeHead(response.status, headers)
+      nodeResponse.writeHead(response.status, response.statusText, headers)
       const drainLatch = Latch.makeUnsafe()
       nodeResponse.on("drain", () => drainLatch.openUnsafe())
       return body.stream.pipe(
@@ -666,7 +666,7 @@ const handleCause = (
   Effect.flatMap(causeResponse(originalCause), ([response, cause]) => {
     const headersSent = nodeResponse.headersSent
     if (!headersSent) {
-      nodeResponse.writeHead(response.status)
+      nodeResponse.writeHead(response.status, response.statusText)
     }
     if (!nodeResponse.writableEnded) {
       nodeResponse.end()

--- a/packages/platform/node/test/NodeHttpServer.test.ts
+++ b/packages/platform/node/test/NodeHttpServer.test.ts
@@ -86,6 +86,22 @@ describe("HttpServer", () => {
       assert.strictEqual(response.status, 204)
     }).pipe(Effect.provide(NodeHttpServer.layerTest)))
 
+  it.effect.each(["Uploaded", ""] as const)("forwards status text %j", (statusText) =>
+    Effect.gen(function*() {
+      yield* HttpRouter.add(
+        "GET",
+        "/",
+        HttpServerResponse.empty({ status: 201, statusText })
+      ).pipe(
+        HttpRouter.serve,
+        Layer.build
+      )
+      const server = yield* HttpServer.HttpServer
+      const port = (server.address as HttpServer.TcpAddress).port
+
+      assert.strictEqual(yield* getStatusText(port), statusText)
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)))
+
   it.effect("formData", () =>
     Effect.gen(function*() {
       yield* HttpRouter.add(
@@ -997,6 +1013,16 @@ const layerTestWebsocket = HttpServer.layerTestClient.pipe(
     websocket: { perMessageDeflate: true }
   }))
 )
+
+const getStatusText = (port: number) =>
+  Effect.callback<string | undefined, Error>((resume) => {
+    const request = Http.get({ hostname: "127.0.0.1", port, agent: false }, (response) => {
+      response.resume()
+      response.on("end", () => resume(Effect.succeed(response.statusMessage)))
+    })
+    request.on("error", (error) => resume(Effect.fail(error)))
+    return Effect.sync(() => request.destroy())
+  })
 
 const tcpPort = (server: Http.Server): number => {
   const address = server.address()


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`NodeHttpServer` discarded `HttpServerResponse.statusText`, so Node replaced custom and explicitly empty reason phrases with its default text. Pass the response status text through every `writeHead` path, including HEAD and error responses.

The regression cases live in `packages/platform/node/test/NodeHttpServer.test.ts` and check `"Uploaded"` and `""` over a real Node HTTP connection.

## Verification

- `pnpm test --run packages/platform/node/test/NodeHttpServer.test.ts --maxWorkers=1 --no-file-parallelism` (33 passed)
- `pnpm lint-fix`
- `pnpm check`
- `git diff --check`

## Related

Closes EFF-1081
Closes #7729

## Audit

Runtime correctness audit; intended label: `audit`.
