### PR TITLE
fix(sql-pg): honor explicit SSL overrides for URL modes

### DIFF
--- a/.changeset/pg-explicit-ssl-precedence.md
+++ b/.changeset/pg-explicit-ssl-precedence.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-pg": patch
+---
+
+Honor explicit `ssl` options when PostgreSQL URLs use `sslmode=prefer` or `sslmode=allow`.

--- a/packages/sql/pg/src/PgConnection.ts
+++ b/packages/sql/pg/src/PgConnection.ts
@@ -2136,7 +2136,7 @@ const configError = (message: string, cause?: unknown): SqlError =>
 const resolveConfig = (options: Config): Effect.Effect<ResolvedConfig, SqlError> =>
   Effect.suspend(() => {
     const parsed: EffectResult.Result<UrlConfig, SqlError> = options.url !== undefined
-      ? parseUrl(Redacted.value(options.url))
+      ? parseUrl(Redacted.value(options.url), options.ssl !== undefined)
       : EffectResult.succeed({})
     if (EffectResult.isFailure(parsed)) return Effect.fail(parsed.failure)
     const url = parsed.success
@@ -2187,7 +2187,7 @@ const parsePort = (value: string, what: string): EffectResult.Result<number, Sql
     : EffectResult.succeed(port)
 }
 
-const parseUrl = (raw: string): EffectResult.Result<UrlConfig, SqlError> => {
+const parseUrl = (raw: string, hasExplicitSsl: boolean): EffectResult.Result<UrlConfig, SqlError> => {
   let url: URL
   try {
     url = new URL(raw)
@@ -2270,6 +2270,7 @@ const parseUrl = (raw: string): EffectResult.Result<UrlConfig, SqlError> => {
             break
           case "prefer":
           case "allow":
+            if (hasExplicitSsl) break
             return EffectResult.fail(
               configError(`sslmode "${value}" is not supported: set ssl explicitly to true or false`)
             )

--- a/packages/sql/pg/test/PgConnection.test.ts
+++ b/packages/sql/pg/test/PgConnection.test.ts
@@ -21,6 +21,22 @@ describe("PgConnection config", () => {
       assert.include(error.reason.message, "sslmode")
     }))
 
+  it.effect("lets explicit ssl override sslmode=prefer in a URL", () =>
+    Effect.gen(function*() {
+      let connected = false
+      const error = yield* Effect.flip(PgConnection.make({
+        url: Redacted.make("postgres://user@localhost/db?sslmode=prefer"),
+        ssl: false,
+        stream: () => {
+          connected = true
+          throw new Error("test connection")
+        }
+      }))
+      assert.isTrue(connected)
+      assert.strictEqual(error.reason._tag, "ConnectionError")
+      assert.strictEqual(error.reason.message, "PgConnection: Failed to connect")
+    }))
+
   it.effect("rejects a non-postgres URL protocol", () =>
     Effect.gen(function*() {
       const error = yield* Effect.flip(PgConnection.make({


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

PostgreSQL URLs using `sslmode=prefer` or `sslmode=allow` require an explicit `ssl` option because automatic TLS fallback is unsupported. `PgConnection` rejected those URLs during parsing before the explicit option could take precedence.

The URL parser now accepts those two modes only when an explicit `ssl` option is present. Other URL validation and unsupported SSL modes are unchanged. The regression test is in `packages/sql/pg/test/PgConnection.test.ts`.

## Verification

```sh
nix develop -c pnpm lint-fix
nix develop -c pnpm test --run packages/sql/pg/test/PgConnection.test.ts
nix develop -c pnpm check
```

## Related

Closes EFF-1083
Closes #7733
