### PR TITLE
fix(effect): retain completed non-streaming tool approval results

### DIFF
--- a/.changeset/ai-approved-tool-results.md
+++ b/.changeset/ai-approved-tool-results.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Retain completed tool approval results in non-streaming responses so Chat records them and does not replay approved tools on later turns.

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -1139,6 +1139,7 @@ export const make: (params: {
     }
 
     // Pre-resolve pending tool approvals before calling the LLM
+    let preResolvedResults: Array<Response.ToolResultPart<string, unknown, unknown>> = []
     if (hasPendingApprovals) {
       for (const approval of approved) {
         if (approval.toolCall && !toolkit.tools[approval.toolCall.name]) {
@@ -1159,12 +1160,12 @@ export const make: (params: {
         concurrency
       )
       const deniedResults = createDenialResults(denied)
-      const preResolvedResults = [...approvedResults, ...deniedResults]
+      preResolvedResults = [...approvedResults, ...deniedResults]
 
       if (preResolvedResults.length > 0) {
         providerOptions.prompt = Prompt.fromMessages([
           ...providerOptions.prompt.content,
-          Prompt.makeMessage("tool", { content: preResolvedResults })
+          ...Prompt.fromResponseParts(preResolvedResults).content
         ])
       }
     }
@@ -1215,7 +1216,7 @@ export const make: (params: {
           tracker.markParts(providerOptions.prompt.content, responseMetadata.id)
         }
       }
-      return content as Array<Response.Part<Tools>>
+      return [...preResolvedResults, ...content] as Array<Response.Part<Tools>>
     }
 
     const rawContent = yield* generateWithNonIncrementalFallback()
@@ -1257,8 +1258,8 @@ export const make: (params: {
       }
     }
 
-    // Return the content merged with the tool call results
-    return [...content, ...toolResults] as Array<Response.Part<Tools>>
+    // Retain pre-resolved results so Chat can recognize completed approvals on later turns.
+    return [...preResolvedResults, ...content, ...toolResults] as Array<Response.Part<Tools>>
   })
 
   const streamContent: <
@@ -1450,15 +1451,14 @@ export const make: (params: {
       if (preResolvedResults.length > 0) {
         providerOptions.prompt = Prompt.fromMessages([
           ...providerOptions.prompt.content,
-          Prompt.makeMessage("tool", { content: preResolvedResults })
+          ...Prompt.fromResponseParts(preResolvedResults).content
         ])
       }
 
       // Emit pre-resolved tool-results as stream parts so Chat.streamText
       // persists them to history. This lets collectToolApprovals find them
       // on subsequent rounds and skip the now-resolved approvals.
-      // Note: r.result is already encoded (from executeApprovedToolCalls /
-      // createDenialResults), so it goes into both result and encodedResult.
+      // Preserve the existing encoded result representation for streaming approvals.
       for (const r of preResolvedResults) {
         preResolvedStreamParts.push(
           Response.makePart("tool-result", {
@@ -1466,8 +1466,8 @@ export const make: (params: {
             name: r.name,
             providerExecuted: false,
             preliminary: false,
-            result: r.result,
-            encodedResult: r.result,
+            result: r.encodedResult,
+            encodedResult: r.encodedResult,
             isFailure: r.isFailure
           }) as Response.StreamPart<Tools>
         )
@@ -2134,7 +2134,7 @@ const executeApprovedToolCalls = <Tools extends Record<string, Tool.Any>>(
   toolkit: Toolkit.WithHandler<Tools>,
   concurrency: Concurrency
 ): Effect.Effect<
-  Array<Prompt.ToolResultPart>,
+  Array<Response.ToolResultPart<string, unknown, unknown>>,
   Tool.HandlerError<Tools[keyof Tools]> | AiError.AiError,
   Tool.HandlerServices<Tools[keyof Tools]>
 > => {
@@ -2175,11 +2175,10 @@ const executeApprovedToolCalls = <Tools extends Record<string, Tool.Any>>(
       )
     )
 
-    return Prompt.makePart("tool-result", {
+    return Response.makePart("tool-result", {
       id: approval.toolCallId,
       name: toolCall.name,
-      isFailure: terminalResult.isFailure,
-      result: terminalResult.encodedResult,
+      ...terminalResult,
       providerExecuted: false
     })
   })
@@ -2191,16 +2190,18 @@ const executeApprovedToolCalls = <Tools extends Record<string, Tool.Any>>(
 
 const createDenialResults = (
   denials: ReadonlyArray<ApprovalResult>
-): ReadonlyArray<Prompt.ToolResultPart> => {
-  const results: Array<Prompt.ToolResultPart> = []
+): ReadonlyArray<Response.ToolResultPart<string, unknown, unknown>> => {
+  const results: Array<Response.ToolResultPart<string, unknown, unknown>> = []
   for (const denial of denials) {
     if (Predicate.isNotUndefined(denial.toolCall)) {
       results.push(
-        Prompt.makePart("tool-result", {
+        Response.makePart("tool-result", {
           id: denial.toolCallId,
           name: denial.toolCall.name,
           isFailure: true,
           result: { type: "execution-denied", reason: denial.reason },
+          encodedResult: { type: "execution-denied", reason: denial.reason },
+          preliminary: false,
           providerExecuted: false
         })
       )

--- a/packages/effect/test/unstable/ai/Chat.test.ts
+++ b/packages/effect/test/unstable/ai/Chat.test.ts
@@ -1,7 +1,7 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Effect, Layer, Predicate, Ref, Schema } from "effect"
 import { TestClock } from "effect/testing"
-import { Chat, IdGenerator, Prompt } from "effect/unstable/ai"
+import { Chat, IdGenerator, Prompt, Tool, Toolkit } from "effect/unstable/ai"
 import { Persistence } from "effect/unstable/persistence"
 import * as TestUtils from "./utils.ts"
 
@@ -16,6 +16,43 @@ const PersistenceLayer = Layer.provideMerge(
 )
 
 describe("Chat", () => {
+  it.effect("does not replay a completed approved tool", () => {
+    let executions = 0
+    const toolkit = Toolkit.make(Tool.make("Counter", {
+      parameters: Schema.Struct({}),
+      success: Schema.Number,
+      needsApproval: true
+    }))
+
+    return Effect.gen(function*() {
+      const chat = yield* Chat.empty
+      const initial = yield* chat.generateText({ prompt: "Run the counter", toolkit }).pipe(
+        TestUtils.withLanguageModel({
+          generateText: [{ type: "tool-call", id: "counter-call", name: "Counter", params: {} }]
+        })
+      )
+      const approval = initial.content.find((part) => part.type === "tool-approval-request")
+      assert.isDefined(approval)
+
+      yield* chat.generateText({
+        toolkit,
+        prompt: [Prompt.toolMessage({
+          content: [Prompt.toolApprovalResponsePart({ approvalId: approval.approvalId, approved: true })]
+        })]
+      }).pipe(
+        TestUtils.withLanguageModel({ generateText: [{ type: "text", text: "Complete" }] })
+      )
+
+      yield* chat.generateText({ prompt: "Continue", toolkit }).pipe(
+        TestUtils.withLanguageModel({ generateText: [{ type: "text", text: "Continued" }] })
+      )
+
+      assert.strictEqual(executions, 1)
+    }).pipe(
+      Effect.provide(toolkit.toLayer({ Counter: () => Effect.sync(() => ++executions) }))
+    )
+  })
+
   it.effect("should persist chat history to the backing persistence store", () =>
     Effect.gen(function*() {
       const storeId = "chat"


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

After an approved tool finished during a non-streaming Chat turn, its result was sent to the provider but omitted from the returned response. Chat could not record the completion, so a later turn executed the same approved call again.

This retains pre-resolved approval results as response parts and prepends them to both non-streaming response paths. Provider prompts and Chat history still receive encoded results, while the response keeps the decoded result. Streaming behavior is unchanged.

The Chat regression uses one approval-gated counter tool and verifies that a follow-up turn does not execute it twice.

## Verification

```sh
pnpm lint-fix
pnpm test --run packages/effect/test/unstable/ai/Chat.test.ts packages/effect/test/unstable/ai/LanguageModel.test.ts packages/effect/test/unstable/ai/Prompt.test.ts packages/effect/test/unstable/ai/Response.test.ts packages/effect/test/unstable/ai/LanguageModelRepresentation.test.ts packages/effect/test/unstable/ai/LanguageModelTrackerLifecycle.test.ts packages/effect/test/unstable/ai/ResponseIdTracker.test.ts packages/effect/test/unstable/ai/Tool.test.ts --maxWorkers=1 --no-file-parallelism --reporter=verbose
pnpm check
```

## Related

Closes #7737
Closes EFF-1085
