### PR TITLE
fix(effect): forward fallback atom writes to the primary atom

### DIFF
--- a/.changeset/fix-atom-writable-fallback.md
+++ b/.changeset/fix-atom-writable-fallback.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix writes through `Atom.withFallback` updating the wrapper instead of the primary atom. Writes now preserve the primary atom's custom write behavior and continue to show the waiting fallback when the primary returns to its initial state.
+Forward `Atom.withFallback` writes to the primary atom.

--- a/.changeset/fix-atom-writable-fallback.md
+++ b/.changeset/fix-atom-writable-fallback.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix writes through `Atom.withFallback` updating the wrapper instead of the primary atom. Writes now preserve the primary atom's custom write behavior and continue to show the waiting fallback when the primary returns to its initial state.

--- a/packages/effect/src/unstable/reactivity/Atom.ts
+++ b/packages/effect/src/unstable/reactivity/Atom.ts
@@ -1465,7 +1465,9 @@ export const withFallback: {
   return isWritable(self)
     ? writable(
       withFallback,
-      self.write,
+      function(ctx, value) {
+        ctx.set(self, value)
+      },
       self.refresh ?? function(refresh) {
         refresh(self)
       }

--- a/packages/effect/test/reactivity/Atom.test.ts
+++ b/packages/effect/test/reactivity/Atom.test.ts
@@ -1251,6 +1251,68 @@ describe.sequential("Atom", () => {
     assert.deepEqual(r.get(count), AsyncResult.success(1))
   })
 
+  for (const target of ["primary", "withFallback", "map"] as const) {
+    it.effect(`withFallback preserves writes through ${target}`, () =>
+      Effect.gen(function*() {
+        const r = yield* Effect.acquireRelease(
+          Effect.sync(() => AtomRegistry.make()),
+          (registry) => Effect.sync(() => registry.dispose())
+        )
+        const success = AsyncResult.success(1, { timestamp: 0 })
+        const fallback = AsyncResult.success(10, { timestamp: 0 })
+        const primary = Atom.make<AsyncResult.AsyncResult<number>>(success)
+        const wrapped = Atom.withFallback(primary, Atom.make(fallback))
+        const writable = target === "primary" ? primary : target === "withFallback" ?
+          wrapped :
+          Atom.map(primary, (result) => result)
+
+        assert.deepEqual(r.get(wrapped), success)
+        r.set(writable, AsyncResult.initial())
+
+        assert.deepEqual({ primary: r.get(primary), wrapped: r.get(wrapped) }, {
+          primary: AsyncResult.initial(),
+          wrapped: AsyncResult.waiting(fallback)
+        })
+      }))
+  }
+
+  it.effect("withFallback preserves custom writes, tracking, and failures", () =>
+    Effect.gen(function*() {
+      const r = yield* Effect.acquireRelease(
+        Effect.sync(() => AtomRegistry.make()),
+        (registry) => Effect.sync(() => registry.dispose())
+      )
+      const failure = AsyncResult.fail("failed")
+      const writes: Array<number | "fail" | "reset"> = []
+      const primary = Atom.writable<AsyncResult.AsyncResult<number, string>, number | "fail" | "reset">(
+        () => AsyncResult.initial(),
+        (ctx, value) => {
+          writes.push(value)
+          if (value === "reset") {
+            ctx.refreshSelf()
+          } else {
+            ctx.setSelf(value === "fail" ? failure : AsyncResult.success(value * 2, { timestamp: 0 }))
+          }
+        }
+      )
+      const fallback = Atom.make(AsyncResult.success(10, { timestamp: 0 }))
+      const wrapped = Atom.withFallback(primary, fallback)
+      assert.deepEqual(r.get(wrapped), AsyncResult.waiting(r.get(fallback)))
+
+      r.set(fallback, AsyncResult.success(20, { timestamp: 0 }))
+      assert.deepEqual(r.get(wrapped), AsyncResult.waiting(r.get(fallback)))
+      r.set(wrapped, 2)
+      assert.deepEqual(r.get(primary), AsyncResult.success(4, { timestamp: 0 }))
+      assert.strictEqual(r.get(wrapped), r.get(primary))
+      r.set(wrapped, "fail")
+      assert.strictEqual(r.get(primary), failure)
+      assert.strictEqual(r.get(wrapped), failure)
+      r.set(wrapped, "reset")
+      assert.deepEqual(r.get(primary), AsyncResult.initial())
+      assert.deepEqual(r.get(wrapped), AsyncResult.waiting(r.get(fallback)))
+      assert.deepEqual(writes, [2, "fail", "reset"])
+    }))
+
   it("failure with previousSuccess", async () => {
     const count = Atom.fn((i: number) => i === 1 ? Effect.fail("fail") : Effect.succeed(i))
     const r = AtomRegistry.make()

--- a/packages/effect/test/reactivity/Atom.test.ts
+++ b/packages/effect/test/reactivity/Atom.test.ts
@@ -1251,67 +1251,19 @@ describe.sequential("Atom", () => {
     assert.deepEqual(r.get(count), AsyncResult.success(1))
   })
 
-  for (const target of ["primary", "withFallback", "map"] as const) {
-    it.effect(`withFallback preserves writes through ${target}`, () =>
-      Effect.gen(function*() {
-        const r = yield* Effect.acquireRelease(
-          Effect.sync(() => AtomRegistry.make()),
-          (registry) => Effect.sync(() => registry.dispose())
-        )
-        const success = AsyncResult.success(1, { timestamp: 0 })
-        const fallback = AsyncResult.success(10, { timestamp: 0 })
-        const primary = Atom.make<AsyncResult.AsyncResult<number>>(success)
-        const wrapped = Atom.withFallback(primary, Atom.make(fallback))
-        const writable = target === "primary" ? primary : target === "withFallback" ?
-          wrapped :
-          Atom.map(primary, (result) => result)
+  it("withFallback forwards writes to the primary atom", () => {
+    const primary = Atom.make<AsyncResult.AsyncResult<number>>(AsyncResult.success(1))
+    const fallback = AsyncResult.success(2)
+    const atom = Atom.withFallback(primary, Atom.make(fallback))
+    const r = AtomRegistry.make()
 
-        assert.deepEqual(r.get(wrapped), success)
-        r.set(writable, AsyncResult.initial())
+    r.set(atom, AsyncResult.initial())
 
-        assert.deepEqual({ primary: r.get(primary), wrapped: r.get(wrapped) }, {
-          primary: AsyncResult.initial(),
-          wrapped: AsyncResult.waiting(fallback)
-        })
-      }))
-  }
-
-  it.effect("withFallback preserves custom writes, tracking, and failures", () =>
-    Effect.gen(function*() {
-      const r = yield* Effect.acquireRelease(
-        Effect.sync(() => AtomRegistry.make()),
-        (registry) => Effect.sync(() => registry.dispose())
-      )
-      const failure = AsyncResult.fail("failed")
-      const writes: Array<number | "fail" | "reset"> = []
-      const primary = Atom.writable<AsyncResult.AsyncResult<number, string>, number | "fail" | "reset">(
-        () => AsyncResult.initial(),
-        (ctx, value) => {
-          writes.push(value)
-          if (value === "reset") {
-            ctx.refreshSelf()
-          } else {
-            ctx.setSelf(value === "fail" ? failure : AsyncResult.success(value * 2, { timestamp: 0 }))
-          }
-        }
-      )
-      const fallback = Atom.make(AsyncResult.success(10, { timestamp: 0 }))
-      const wrapped = Atom.withFallback(primary, fallback)
-      assert.deepEqual(r.get(wrapped), AsyncResult.waiting(r.get(fallback)))
-
-      r.set(fallback, AsyncResult.success(20, { timestamp: 0 }))
-      assert.deepEqual(r.get(wrapped), AsyncResult.waiting(r.get(fallback)))
-      r.set(wrapped, 2)
-      assert.deepEqual(r.get(primary), AsyncResult.success(4, { timestamp: 0 }))
-      assert.strictEqual(r.get(wrapped), r.get(primary))
-      r.set(wrapped, "fail")
-      assert.strictEqual(r.get(primary), failure)
-      assert.strictEqual(r.get(wrapped), failure)
-      r.set(wrapped, "reset")
-      assert.deepEqual(r.get(primary), AsyncResult.initial())
-      assert.deepEqual(r.get(wrapped), AsyncResult.waiting(r.get(fallback)))
-      assert.deepEqual(writes, [2, "fail", "reset"])
-    }))
+    assert.deepEqual([r.get(primary), r.get(atom)], [
+      AsyncResult.initial(),
+      AsyncResult.waiting(fallback)
+    ])
+  })
 
   it("failure with previousSuccess", async () => {
     const count = Atom.fn((i: number) => i === 1 ? Effect.fail("fail") : Effect.succeed(i))


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`Atom.withFallback` reused the primary atom's write function with the wrapper's write context. Writers using `setSelf` or `refreshSelf` therefore updated the wrapper instead of the primary atom.

Writes now go through `ctx.set(self, value)`, which lets the registry invoke the writer with the primary atom's context. Resetting the primary to `Initial` also makes the wrapper read as the waiting fallback again.

## Verification

- `nix develop -c pnpm test packages/effect/test/reactivity/Atom.test.ts --run --project effect --maxWorkers=1 --no-file-parallelism` (109 passed)
- `nix develop -c pnpm --dir packages/effect check`
- `dprint check`, `oxlint`, and `git diff --check` on the changed files

## Related

Closes #7739
Closes EFF-1086
