### PR TITLE
fix(effect): encode tool results using their known result branch

### DIFF
--- a/.changeset/tool-result-branch-encoding.md
+++ b/.changeset/tool-result-branch-encoding.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Encode tool results with the schema for their known success or failure branch.

--- a/packages/effect/src/unstable/ai/Toolkit.ts
+++ b/packages/effect/src/unstable/ai/Toolkit.ts
@@ -243,7 +243,6 @@ const Proto = {
         readonly context: Context.Context<never>
         readonly handler: Tool.Handler<any>["handler"]
         readonly decodeParameters: (u: unknown) => Effect.Effect<unknown, Schema.SchemaError>
-        readonly decodeResult: (u: unknown) => Effect.Effect<unknown, Schema.SchemaError>
         readonly encodeResult: (u: unknown, isFailure: boolean) => Effect.Effect<unknown, Schema.SchemaError>
       }>()
 
@@ -251,13 +250,9 @@ const Proto = {
         let schemas = schemasCache.get(tool)
         if (Predicate.isUndefined(schemas)) {
           const handler = services.mapUnsafe.get(tool.id)! as Tool.Handler<any>
-          const resultSchema = tool.failureMode === "return"
-            ? Schema.Union([tool.successSchema, tool.failureSchema, AiError.AiError])
-            : tool.successSchema
           const decodeParameters = Schema.isSchema(tool.parametersSchema)
             ? Schema.decodeUnknownEffect(tool.parametersSchema) as any
             : (u: unknown) => Effect.succeed(u)
-          const decodeResult = Schema.decodeUnknownEffect(resultSchema) as any
           const encodeSuccess = Schema.encodeUnknownEffect(tool.successSchema) as any
           const encodeFailure = Schema.encodeUnknownEffect(tool.failureSchema) as any
           const encodeAiError = Schema.encodeUnknownEffect(AiError.AiError)
@@ -267,7 +262,6 @@ const Proto = {
             context: handler.context,
             handler: handler.handler,
             decodeParameters,
-            decodeResult,
             encodeResult
           }
           schemasCache.set(tool, schemas)

--- a/packages/effect/src/unstable/ai/Toolkit.ts
+++ b/packages/effect/src/unstable/ai/Toolkit.ts
@@ -244,7 +244,7 @@ const Proto = {
         readonly handler: Tool.Handler<any>["handler"]
         readonly decodeParameters: (u: unknown) => Effect.Effect<unknown, Schema.SchemaError>
         readonly decodeResult: (u: unknown) => Effect.Effect<unknown, Schema.SchemaError>
-        readonly encodeResult: (u: unknown) => Effect.Effect<unknown, Schema.SchemaError>
+        readonly encodeResult: (u: unknown, isFailure: boolean) => Effect.Effect<unknown, Schema.SchemaError>
       }>()
 
       const getSchemas = (tool: Tool.Any) => {
@@ -258,7 +258,11 @@ const Proto = {
             ? Schema.decodeUnknownEffect(tool.parametersSchema) as any
             : (u: unknown) => Effect.succeed(u)
           const decodeResult = Schema.decodeUnknownEffect(resultSchema) as any
-          const encodeResult = Schema.encodeUnknownEffect(resultSchema) as any
+          const encodeSuccess = Schema.encodeUnknownEffect(tool.successSchema) as any
+          const encodeFailure = Schema.encodeUnknownEffect(tool.failureSchema) as any
+          const encodeAiError = Schema.encodeUnknownEffect(AiError.AiError)
+          const encodeResult = (u: unknown, isFailure: boolean) =>
+            !isFailure ? encodeSuccess(u) : AiError.isAiError(u) ? encodeAiError(u) : encodeFailure(u)
           schemas = {
             context: handler.context,
             handler: handler.handler,
@@ -294,8 +298,8 @@ const Proto = {
         // Fetch cached schemas / handlers for the tool
         const schemas = getSchemas(tool)
 
-        const encodeResult = (result: any) =>
-          schemas.encodeResult(result).pipe(
+        const encodeResult = (result: any, isFailure: boolean) =>
+          schemas.encodeResult(result, isFailure).pipe(
             Effect.mapError((cause) =>
               AiError.make({
                 module: "Toolkit",
@@ -323,7 +327,7 @@ const Proto = {
             return yield* error
           }
           return Stream.fromEffect(
-            Effect.map(encodeResult(error), (encodedResult) => ({
+            Effect.map(encodeResult(error, true), (encodedResult) => ({
               result: error,
               isFailure: true,
               preliminary: false,
@@ -390,7 +394,7 @@ const Proto = {
               : Stream.succeed({ result: normalizedError, isFailure: true, preliminary: false })
           }),
           Stream.mapEffect(Effect.fnUntraced(function*(output) {
-            const encodedResult = yield* encodeResult(output.result)
+            const encodedResult = yield* encodeResult(output.result, output.isFailure)
             return { ...output, encodedResult }
           })),
           Stream.onEnd(Fiber.interrupt(fiber))

--- a/packages/effect/test/unstable/ai/Tool.test.ts
+++ b/packages/effect/test/unstable/ai/Tool.test.ts
@@ -87,6 +87,21 @@ describe("Tool", () => {
         ])
       }))
 
+    it.effect("should encode returned failures with the failure schema", () =>
+      Effect.gen(function*() {
+        const toolkit = Toolkit.make(Tool.make("FailureEncoding", {
+          success: Schema.Number,
+          failure: Schema.NumberFromString,
+          failureMode: "return"
+        }))
+        const handlers = yield* toolkit.pipe(Effect.provide(toolkit.toLayer({
+          FailureEncoding: () => Effect.fail(404)
+        })))
+        const results = yield* handlers.handle("FailureEncoding", {}).pipe(Effect.flatMap(Stream.runCollect))
+
+        strictEqual(results[0].encodedResult, "404")
+      }))
+
     it.effect("should return tool call handler failures with failure mode return using OpenAI transformer", () =>
       Effect.gen(function*() {
         const toolkit = Toolkit.make(FailureModeReturn)


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

With `failureMode: "return"`, toolkit results were encoded through a success-first schema union even though each result was already marked as a success or failure. Overlapping schemas could therefore encode a failure with the success schema.

Cache the success, declared failure, and `AiError` encoders separately, then select the encoder from the known result branch. This preserves failure-schema transformations without changing result decoding.

## Verification

- `pnpm test --run packages/effect/test/unstable/ai/Tool.test.ts --maxWorkers=1 --no-file-parallelism --reporter=verbose` (46 passed)
- `pnpm lint-fix`
- `pnpm check`

## Related

Closes #7747
Closes EFF-1090
