### PR TITLE
fix(effect): clear stale dynamic tool schemas when replacing parameters

### DIFF
--- a/.changeset/dynamic-tool-parameter-schema.md
+++ b/.changeset/dynamic-tool-parameter-schema.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Update the JSON Schema advertised by dynamic tools after `setParameters` replaces a raw JSON Schema with an Effect Schema, without changing the original tool.
+Update dynamic tools to advertise replacement parameter schemas after `setParameters`.

--- a/.changeset/dynamic-tool-parameter-schema.md
+++ b/.changeset/dynamic-tool-parameter-schema.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Update the JSON Schema advertised by dynamic tools after `setParameters` replaces a raw JSON Schema with an Effect Schema, without changing the original tool.

--- a/packages/effect/src/unstable/ai/Tool.ts
+++ b/packages/effect/src/unstable/ai/Tool.ts
@@ -1064,7 +1064,7 @@ const Proto = {
     return clone(this)
   },
   setParameters(this: Any, parametersSchema: Schema.Constraint) {
-    return clone(this, { parametersSchema })
+    return clone(this, { parametersSchema, jsonSchema: undefined })
   },
   setSuccess(this: Any, successSchema: Schema.Constraint) {
     return clone(this, { successSchema })

--- a/packages/effect/test/unstable/ai/Tool.test.ts
+++ b/packages/effect/test/unstable/ai/Tool.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effect/vitest"
+import { assert, describe, it } from "@effect/vitest"
 import { assertFalse, assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import { Context, DateTime, Effect, Fiber, identity, Latch, Schema, Stream } from "effect"
 import { TestClock } from "effect/testing"
@@ -1181,6 +1181,111 @@ describe("setNeedsApproval", () => {
 })
 
 describe("Dynamic", () => {
+  describe("setParameters", () => {
+    const rawParameters = {
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+      additionalProperties: false
+    } as const
+    const parameters = Schema.Struct({ count: Schema.Finite })
+
+    it("preserves raw parameters in unrelated clones and derived parameters in later clones", () => {
+      const original = Tool.dynamic("TestTool", {
+        description: "Test tool",
+        parameters: rawParameters,
+        failureMode: "return"
+      }).annotate(Tool.Strict, true)
+      const sibling = original.setSuccess(Schema.Number).setFailure(Schema.String).setNeedsApproval(true)
+      const updated = original.setParameters(parameters)
+      const cloned = updated.setSuccess(Schema.Number).setFailure(Schema.String).setNeedsApproval(true)
+      const replaced = cloned.setParameters(Schema.Struct({ enabled: Schema.Boolean }))
+
+      assert.strictEqual(Tool.getJsonSchema(sibling), rawParameters)
+      assert.strictEqual(Tool.getJsonSchema(original), rawParameters)
+      assert.deepStrictEqual(Tool.getJsonSchema(cloned), Tool.getJsonSchemaFromSchema(parameters))
+      assert.deepStrictEqual(Tool.getJsonSchema(updated), Tool.getJsonSchemaFromSchema(parameters))
+      assert.deepStrictEqual(Tool.getJsonSchema(replaced).required, ["enabled"])
+      for (const tool of [sibling, updated, cloned, replaced]) {
+        assert.isFalse(Object.is(tool, original))
+        assert.isTrue(Tool.isDynamic(tool))
+        assert.strictEqual(tool.id, original.id)
+        assert.strictEqual(tool.description, "Test tool")
+        assert.strictEqual(tool.failureMode, "return")
+        assert.strictEqual(Tool.getStrictMode(tool), true)
+      }
+    })
+
+    it("advertises the replacement schema for a raw JSON Schema tool", () => {
+      const original = Tool.dynamic("TestTool", { parameters: rawParameters })
+      const updated = original.setParameters(parameters)
+
+      assert.isTrue(Tool.isDynamic(updated))
+      assert.strictEqual(updated.parametersSchema, parameters)
+      assert.deepStrictEqual(Tool.getJsonSchema(updated), Tool.getJsonSchemaFromSchema(parameters))
+    })
+
+    it.effect("validates replacement parameters before executing a raw JSON Schema tool", () =>
+      Effect.gen(function*() {
+        const tool = Tool.dynamic("TestTool", {
+          parameters: rawParameters,
+          success: Schema.Number
+        }).setParameters(parameters)
+        const toolkit = Toolkit.make(tool)
+        let calls = 0
+        const handlers = yield* toolkit.pipe(Effect.provide(toolkit.toLayer({
+          TestTool: ({ count }) =>
+            Effect.sync(() => {
+              calls++
+              return count
+            })
+        })))
+        const results = yield* handlers.handle("TestTool", { count: 2 }).pipe(Effect.flatMap(Stream.runCollect))
+        assert.deepStrictEqual(results, [{
+          isFailure: false,
+          preliminary: false,
+          result: 2,
+          encodedResult: 2
+        }])
+
+        const error = yield* handlers.handle("TestTool", { count: Infinity }).pipe(Effect.flip)
+        assert.strictEqual(error.reason._tag, "ToolParameterValidationError")
+        assert.strictEqual(calls, 1)
+        const oldParameters = yield* Schema.decodeUnknownEffect(tool.parametersSchema)({ query: "search" }).pipe(
+          Effect.flip
+        )
+        assert.isTrue(Schema.isSchemaError(oldParameters))
+      }))
+
+    it("does not mutate the original raw JSON Schema tool", () => {
+      const original = Tool.dynamic("TestTool", { parameters: rawParameters })
+      original.setParameters(parameters)
+
+      assert.strictEqual(original.parametersSchema, Schema.Unknown)
+      assert.deepStrictEqual(Tool.getJsonSchema(original), rawParameters)
+    })
+
+    it("updates schema-backed dynamic tools", () => {
+      const original = Tool.dynamic("TestTool", { parameters: Schema.Struct({ query: Schema.String }) })
+      const updated = original.setParameters(parameters)
+
+      assert.isTrue(Tool.isDynamic(updated))
+      assert.strictEqual(updated.parametersSchema, parameters)
+      assert.deepStrictEqual(Tool.getJsonSchema(updated), Tool.getJsonSchemaFromSchema(parameters))
+      assert.deepStrictEqual(Tool.getJsonSchema(original).required, ["query"])
+    })
+
+    it("updates user-defined tools", () => {
+      const original = Tool.make("TestTool", { parameters: Schema.Struct({ query: Schema.String }) })
+      const updated = original.setParameters(parameters)
+
+      assert.isTrue(Tool.isUserDefined(updated))
+      assert.strictEqual(updated.parametersSchema, parameters)
+      assert.deepStrictEqual(Tool.getJsonSchema(updated), Tool.getJsonSchemaFromSchema(parameters))
+      assert.deepStrictEqual(Tool.getJsonSchema(original).required, ["query"])
+    })
+  })
+
   describe("isDynamic", () => {
     it.effect("returns true for dynamic tools with Effect Schema", () =>
       Effect.gen(function*() {

--- a/packages/effect/test/unstable/ai/Tool.test.ts
+++ b/packages/effect/test/unstable/ai/Tool.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, it } from "@effect/vitest"
+import { describe, it } from "@effect/vitest"
 import { assertFalse, assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import { Context, DateTime, Effect, Fiber, identity, Latch, Schema, Stream } from "effect"
 import { TestClock } from "effect/testing"
@@ -1181,109 +1181,16 @@ describe("setNeedsApproval", () => {
 })
 
 describe("Dynamic", () => {
-  describe("setParameters", () => {
-    const rawParameters = {
-      type: "object",
-      properties: { query: { type: "string" } },
-      required: ["query"],
-      additionalProperties: false
-    } as const
-    const parameters = Schema.Struct({ count: Schema.Finite })
-
-    it("preserves raw parameters in unrelated clones and derived parameters in later clones", () => {
-      const original = Tool.dynamic("TestTool", {
-        description: "Test tool",
-        parameters: rawParameters,
-        failureMode: "return"
-      }).annotate(Tool.Strict, true)
-      const sibling = original.setSuccess(Schema.Number).setFailure(Schema.String).setNeedsApproval(true)
-      const updated = original.setParameters(parameters)
-      const cloned = updated.setSuccess(Schema.Number).setFailure(Schema.String).setNeedsApproval(true)
-      const replaced = cloned.setParameters(Schema.Struct({ enabled: Schema.Boolean }))
-
-      assert.strictEqual(Tool.getJsonSchema(sibling), rawParameters)
-      assert.strictEqual(Tool.getJsonSchema(original), rawParameters)
-      assert.deepStrictEqual(Tool.getJsonSchema(cloned), Tool.getJsonSchemaFromSchema(parameters))
-      assert.deepStrictEqual(Tool.getJsonSchema(updated), Tool.getJsonSchemaFromSchema(parameters))
-      assert.deepStrictEqual(Tool.getJsonSchema(replaced).required, ["enabled"])
-      for (const tool of [sibling, updated, cloned, replaced]) {
-        assert.isFalse(Object.is(tool, original))
-        assert.isTrue(Tool.isDynamic(tool))
-        assert.strictEqual(tool.id, original.id)
-        assert.strictEqual(tool.description, "Test tool")
-        assert.strictEqual(tool.failureMode, "return")
-        assert.strictEqual(Tool.getStrictMode(tool), true)
+  it("setParameters replaces a raw JSON Schema", () => {
+    const tool = Tool.dynamic("TestTool", {
+      parameters: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"]
       }
-    })
+    }).setParameters(Schema.Struct({ count: Schema.Number }))
 
-    it("advertises the replacement schema for a raw JSON Schema tool", () => {
-      const original = Tool.dynamic("TestTool", { parameters: rawParameters })
-      const updated = original.setParameters(parameters)
-
-      assert.isTrue(Tool.isDynamic(updated))
-      assert.strictEqual(updated.parametersSchema, parameters)
-      assert.deepStrictEqual(Tool.getJsonSchema(updated), Tool.getJsonSchemaFromSchema(parameters))
-    })
-
-    it.effect("validates replacement parameters before executing a raw JSON Schema tool", () =>
-      Effect.gen(function*() {
-        const tool = Tool.dynamic("TestTool", {
-          parameters: rawParameters,
-          success: Schema.Number
-        }).setParameters(parameters)
-        const toolkit = Toolkit.make(tool)
-        let calls = 0
-        const handlers = yield* toolkit.pipe(Effect.provide(toolkit.toLayer({
-          TestTool: ({ count }) =>
-            Effect.sync(() => {
-              calls++
-              return count
-            })
-        })))
-        const results = yield* handlers.handle("TestTool", { count: 2 }).pipe(Effect.flatMap(Stream.runCollect))
-        assert.deepStrictEqual(results, [{
-          isFailure: false,
-          preliminary: false,
-          result: 2,
-          encodedResult: 2
-        }])
-
-        const error = yield* handlers.handle("TestTool", { count: Infinity }).pipe(Effect.flip)
-        assert.strictEqual(error.reason._tag, "ToolParameterValidationError")
-        assert.strictEqual(calls, 1)
-        const oldParameters = yield* Schema.decodeUnknownEffect(tool.parametersSchema)({ query: "search" }).pipe(
-          Effect.flip
-        )
-        assert.isTrue(Schema.isSchemaError(oldParameters))
-      }))
-
-    it("does not mutate the original raw JSON Schema tool", () => {
-      const original = Tool.dynamic("TestTool", { parameters: rawParameters })
-      original.setParameters(parameters)
-
-      assert.strictEqual(original.parametersSchema, Schema.Unknown)
-      assert.deepStrictEqual(Tool.getJsonSchema(original), rawParameters)
-    })
-
-    it("updates schema-backed dynamic tools", () => {
-      const original = Tool.dynamic("TestTool", { parameters: Schema.Struct({ query: Schema.String }) })
-      const updated = original.setParameters(parameters)
-
-      assert.isTrue(Tool.isDynamic(updated))
-      assert.strictEqual(updated.parametersSchema, parameters)
-      assert.deepStrictEqual(Tool.getJsonSchema(updated), Tool.getJsonSchemaFromSchema(parameters))
-      assert.deepStrictEqual(Tool.getJsonSchema(original).required, ["query"])
-    })
-
-    it("updates user-defined tools", () => {
-      const original = Tool.make("TestTool", { parameters: Schema.Struct({ query: Schema.String }) })
-      const updated = original.setParameters(parameters)
-
-      assert.isTrue(Tool.isUserDefined(updated))
-      assert.strictEqual(updated.parametersSchema, parameters)
-      assert.deepStrictEqual(Tool.getJsonSchema(updated), Tool.getJsonSchemaFromSchema(parameters))
-      assert.deepStrictEqual(Tool.getJsonSchema(original).required, ["query"])
-    })
+    deepStrictEqual(Tool.getJsonSchema(tool).required, ["count"], "expected the replacement schema")
   })
 
   describe("isDynamic", () => {


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Dynamic tools created from raw JSON Schema kept advertising that schema after `setParameters` supplied a replacement Effect Schema. Clear the raw-schema override on the cloned tool so `Tool.getJsonSchema` derives the advertised parameters from the replacement schema.

The regression test replaces a required `query` with a required `count` and checks the public JSON Schema output.

## Verification

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/unstable/ai/Tool.test.ts`
- `pnpm check`

## Related

Closes #7749
Closes EFF-1091

## Audit

Runtime correctness audit; intended label: `audit`.
