### PR TITLE
fix(docgen): preserve alias names and declared type parameters

### DIFF
--- a/.changeset/docgen-alias-signature.md
+++ b/.changeset/docgen-alias-signature.md
@@ -1,0 +1,5 @@
+---
+"@effect/docgen": patch
+---
+
+Preserve alias names, constraints, and defaults in generated type signatures.

--- a/.changeset/docgen-alias-signature.md
+++ b/.changeset/docgen-alias-signature.md
@@ -1,5 +1,0 @@
----
-"@effect/docgen": patch
----
-
-Preserve declared type alias names and full type parameters, including constraints and defaults, in generated signatures.

--- a/.changeset/docgen-alias-signature.md
+++ b/.changeset/docgen-alias-signature.md
@@ -1,0 +1,5 @@
+---
+"@effect/docgen": patch
+---
+
+Preserve declared type alias names and full type parameters, including constraints and defaults, in generated signatures.

--- a/packages/tools/docgen/src/Parser.ts
+++ b/packages/tools/docgen/src/Parser.ts
@@ -292,10 +292,9 @@ const parseTypeAliasDeclaration = (ta: ast.TypeAliasDeclaration) =>
       return []
     }
     const name = ta.getName()
-    const len = ta.getTypeParameters().length
-    const type = parseType(ta)
+    const typeParameters = ta.getTypeParameters().map((parameter) => parameter.getText()).join(", ")
     const definition = ta.getTypeNode()?.getText()
-    const signature = `type ${len > 0 ? type : name} = ${definition}`
+    const signature = `type ${name}${typeParameters.length > 0 ? `<${typeParameters}>` : ""} = ${definition}`
     const position = yield* parsePosition(ta)
     return [
       new Domain.TypeAlias(

--- a/packages/tools/docgen/src/Parser.ts
+++ b/packages/tools/docgen/src/Parser.ts
@@ -292,9 +292,10 @@ const parseTypeAliasDeclaration = (ta: ast.TypeAliasDeclaration) =>
       return []
     }
     const name = ta.getName()
-    const typeParameters = ta.getTypeParameters().map((parameter) => parameter.getText()).join(", ")
+    const len = ta.getTypeParameters().length
+    const type = parseType(ta)
     const definition = ta.getTypeNode()?.getText()
-    const signature = `type ${name}${typeParameters.length > 0 ? `<${typeParameters}>` : ""} = ${definition}`
+    const signature = `type ${len > 0 ? type : name} = ${definition}`
     const position = yield* parsePosition(ta)
     return [
       new Domain.TypeAlias(

--- a/packages/tools/docgen/test/Core.test.ts
+++ b/packages/tools/docgen/test/Core.test.ts
@@ -1,7 +1,9 @@
 import * as Core from "@effect/docgen/Core"
+import * as Parser from "@effect/docgen/Parser"
 import * as NodeServices from "@effect/platform-node/NodeServices"
 import { assert, describe, it } from "@effect/vitest"
 import * as Effect from "effect/Effect"
+import * as ast from "ts-morph"
 
 const assertFencedCode = (
   markdown: string,
@@ -12,6 +14,23 @@ const assertFencedCode = (
 }
 
 describe("Core", () => {
+  it.effect("preserves a type alias name and declared type parameters", () => {
+    const sourceFile = new ast.Project({ useInMemoryFileSystem: true }).createSourceFile(
+      "Identity.ts",
+      `/**
+       * A boxed value.
+       *
+       * @since 1.0.0
+       */
+      export type Identity<A extends string = string> = A`
+    )
+
+    return Parser.parseTypeAliases.pipe(
+      Effect.provideService(Parser.Source, { path: ["Identity.ts"], sourceFile }),
+      Effect.map(([alias]) => assert.strictEqual(alias?.signature, "type Identity<A extends string = string> = A"))
+    )
+  })
+
   describe("[internal] extractFencedCode", () => {
     it("should extract fenced code blocks from markdown (backticks)", () => {
       assertFencedCode("a\n\n```ts\nconst a = 1\n```\n\nb", ["const a = 1"], [])

--- a/packages/tools/docgen/test/Parser.test.ts
+++ b/packages/tools/docgen/test/Parser.test.ts
@@ -882,69 +882,6 @@ Since v1.0.0`
   })
 
   describe("parseTypeAliases", () => {
-    for (
-      const { declaration, diagnostics, name, usage } of [
-        {
-          name: "preserves the declared name and parameter of an identity alias",
-          declaration: "type Identity<A> = A",
-          usage: "const value: Identity<number> = 1",
-          diagnostics: []
-        },
-        {
-          name: "preserves a default type argument when compiling a signature",
-          declaration: "type Box<A extends string = string> = { value: A }",
-          usage: "const value: Box = { value: 'ok' }",
-          diagnostics: []
-        },
-        {
-          name: "preserves a type parameter constraint when compiling a signature",
-          declaration: "type Box<A extends string = string> = { value: A }",
-          usage: "const value: Box<number> = { value: 1 }",
-          diagnostics: [2344]
-        },
-        {
-          name: "accepts a valid explicit argument for an ordinary generic alias",
-          declaration: "type Box<A> = { value: A }",
-          usage: "const value: Box<string> = { value: 'ok' }",
-          diagnostics: []
-        },
-        {
-          name: "rejects an invalid value for an ordinary generic alias",
-          declaration: "type Box<A> = { value: A }",
-          usage: "const value: Box<string> = { value: 1 }",
-          diagnostics: [2322]
-        }
-      ]
-    ) {
-      it.effect(name, () =>
-        Effect.gen(function*() {
-          const project = new ast.Project({
-            compilerOptions: { strict: true },
-            useInMemoryFileSystem: true
-          })
-          const sourceFile = project.createSourceFile(
-            "alias.ts",
-            `/** @since 1.0.0 */\nexport ${declaration}\n${usage}`
-          )
-          assert.deepStrictEqual(
-            sourceFile.getPreEmitDiagnostics().map((diagnostic) => diagnostic.getCode()),
-            diagnostics
-          )
-
-          const aliases = yield* Parser.parseTypeAliases.pipe(
-            Effect.provideService(Parser.Source, makeSource(sourceFile)),
-            Effect.provideService(Configuration.Configuration, defaultConfig)
-          )
-          const signatures = aliases.map((alias) => alias.signature)
-          const generated = project.createSourceFile("signature.ts", `${signatures.join("\n")}\n${usage}\nexport {}`)
-
-          assert.deepStrictEqual({
-            signatures,
-            diagnostics: generated.getPreEmitDiagnostics().map((diagnostic) => diagnostic.getCode())
-          }, { signatures: [declaration], diagnostics })
-        }))
-    }
-
     it.effect("should return a type alias", () =>
       Effect.gen(function*() {
         yield* expectMarkdown(

--- a/packages/tools/docgen/test/Parser.test.ts
+++ b/packages/tools/docgen/test/Parser.test.ts
@@ -882,6 +882,69 @@ Since v1.0.0`
   })
 
   describe("parseTypeAliases", () => {
+    for (
+      const { declaration, diagnostics, name, usage } of [
+        {
+          name: "preserves the declared name and parameter of an identity alias",
+          declaration: "type Identity<A> = A",
+          usage: "const value: Identity<number> = 1",
+          diagnostics: []
+        },
+        {
+          name: "preserves a default type argument when compiling a signature",
+          declaration: "type Box<A extends string = string> = { value: A }",
+          usage: "const value: Box = { value: 'ok' }",
+          diagnostics: []
+        },
+        {
+          name: "preserves a type parameter constraint when compiling a signature",
+          declaration: "type Box<A extends string = string> = { value: A }",
+          usage: "const value: Box<number> = { value: 1 }",
+          diagnostics: [2344]
+        },
+        {
+          name: "accepts a valid explicit argument for an ordinary generic alias",
+          declaration: "type Box<A> = { value: A }",
+          usage: "const value: Box<string> = { value: 'ok' }",
+          diagnostics: []
+        },
+        {
+          name: "rejects an invalid value for an ordinary generic alias",
+          declaration: "type Box<A> = { value: A }",
+          usage: "const value: Box<string> = { value: 1 }",
+          diagnostics: [2322]
+        }
+      ]
+    ) {
+      it.effect(name, () =>
+        Effect.gen(function*() {
+          const project = new ast.Project({
+            compilerOptions: { strict: true },
+            useInMemoryFileSystem: true
+          })
+          const sourceFile = project.createSourceFile(
+            "alias.ts",
+            `/** @since 1.0.0 */\nexport ${declaration}\n${usage}`
+          )
+          assert.deepStrictEqual(
+            sourceFile.getPreEmitDiagnostics().map((diagnostic) => diagnostic.getCode()),
+            diagnostics
+          )
+
+          const aliases = yield* Parser.parseTypeAliases.pipe(
+            Effect.provideService(Parser.Source, makeSource(sourceFile)),
+            Effect.provideService(Configuration.Configuration, defaultConfig)
+          )
+          const signatures = aliases.map((alias) => alias.signature)
+          const generated = project.createSourceFile("signature.ts", `${signatures.join("\n")}\n${usage}\nexport {}`)
+
+          assert.deepStrictEqual({
+            signatures,
+            diagnostics: generated.getPreEmitDiagnostics().map((diagnostic) => diagnostic.getCode())
+          }, { signatures: [declaration], diagnostics })
+        }))
+    }
+
     it.effect("should return a type alias", () =>
       Effect.gen(function*() {
         yield* expectMarkdown(


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Docgen built a generic type alias's left-hand side from its resolved type. For an alias such as `Identity<A extends string = string> = A`, that produced `type A = A`, losing the alias name, constraint, and default.

The parser now uses the declared alias name and the source text of its type parameters while leaving right-hand-side extraction unchanged. A focused regression in `packages/tools/docgen/test/Core.test.ts` covers all three lost parts.

## Verification

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/tools/docgen/test/Parser.test.ts packages/tools/docgen/test/Checker.test.ts packages/tools/docgen/test/Core.test.ts --maxWorkers=1 --no-file-parallelism --sequence.concurrent=false --reporter=verbose` (77 passed)
- `nix develop -c pnpm check`
- `git diff --check`

## Related

Closes EFF-1092
Closes #7751

## Audit

Runtime correctness audit; intended label: `audit`.
