### PR TITLE
fix(doctest): preserve statement boundaries after generated assertions

### DIFF
--- a/.changeset/doctest-statement-boundary.md
+++ b/.changeset/doctest-statement-boundary.md
@@ -1,0 +1,5 @@
+---
+"@effect/doctest": patch
+---
+
+Terminate generated assertion statements with semicolons so following array expressions and immediately invoked functions remain separate statements.

--- a/.changeset/doctest-statement-boundary.md
+++ b/.changeset/doctest-statement-boundary.md
@@ -2,4 +2,4 @@
 "@effect/doctest": patch
 ---
 
-Terminate generated assertion statements with semicolons so following array expressions and immediately invoked functions remain separate statements.
+Preserve statement boundaries after generated doctest assertions.

--- a/packages/tools/doctest/src/Transform.ts
+++ b/packages/tools/doctest/src/Transform.ts
@@ -175,7 +175,7 @@ export const transform = (source: string, file: string, line: number): string =>
       output.overwrite(
         expression.start,
         comment.end,
-        `${alias}(${source.slice(expression.start, expression.end)}, ${expected})`
+        `${alias}(${source.slice(expression.start, expression.end)}, ${expected});`
       )
       continue
     }
@@ -189,7 +189,7 @@ export const transform = (source: string, file: string, line: number): string =>
         id?.type === "Identifier" && typeof id.name === "string"
       ) {
         const indentation = source.slice(source.lastIndexOf("\n", node.start - 1) + 1, node.start)
-        output.overwrite(node.end, comment.end, `\n${indentation}${alias}(${id.name}, ${expected})`)
+        output.overwrite(node.end, comment.end, `\n${indentation}${alias}(${id.name}, ${expected});`)
         continue
       }
     }

--- a/packages/tools/doctest/test/Plugin.test.ts
+++ b/packages/tools/doctest/test/Plugin.test.ts
@@ -4,6 +4,7 @@ import { assert, describe, it } from "@effect/vitest"
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { compileFunction } from "node:vm"
 
 describe("Plugin", () => {
   it("configures the doctest runner by default", () => {
@@ -22,7 +23,7 @@ describe("Plugin", () => {
     assert.isUndefined(config.call({} as never, { test: { runner: "./custom-runner.ts" } }, {} as never))
   })
 
-  it("transforms inline assertions in snippet modules", async () => {
+  it("preserves statement boundaries after inline assertions", async () => {
     const root = mkdtempSync(join(tmpdir(), "effect-doctest-plugin-"))
     const file = join(root, "example.ts")
     writeFileSync(
@@ -30,7 +31,8 @@ describe("Plugin", () => {
       [
         "/**",
         " * ```ts import.meta.vitest name=asserted",
-        " * const result = 1 // => 1",
+        " * const result = 1; // => 1",
+        " * [1, 2].forEach(record)",
         " * ```",
         " */"
       ].join("\n")
@@ -58,8 +60,15 @@ describe("Plugin", () => {
       if (typeof resolvedSnippet !== "string") return assert.fail("expected resolved snippet ID")
       const snippet = await load.call(context, resolvedSnippet, {} as never)
       if (typeof snippet !== "string") return assert.fail("expected snippet source")
-      assert.match(snippet, /const result = 1\n__effect_doctest_assert_0\(result, 1\)/)
+      assert.match(snippet, /const result = 1;\n__effect_doctest_assert_0\(result, 1\)/)
       assert.match(snippet, /assertEquals as __effect_doctest_assert_0/)
+
+      const values: Array<number> = []
+      compileFunction(snippet.slice(0, snippet.lastIndexOf("\n\nimport ")), ["__effect_doctest_assert_0", "record"])(
+        (actual: unknown, expected: unknown) => assert.deepStrictEqual(actual, expected),
+        (value: number) => values.push(value)
+      )
+      assert.deepStrictEqual(values, [1, 2])
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/packages/tools/doctest/test/Transform.test.ts
+++ b/packages/tools/doctest/test/Transform.test.ts
@@ -1,48 +1,9 @@
-import { assertEquals } from "@effect/doctest/Runtime"
 import { transform } from "@effect/doctest/Transform"
 import { assert, describe, it } from "@effect/vitest"
-import { compileFunction } from "node:vm"
 
 const imported = `import { assertEquals as __effect_doctest_assert_0 } from "@effect/doctest/Runtime"`
 
 describe("Transform", () => {
-  for (
-    const [form, statement] of [
-      ["expression", "1 + 1; // => 2"],
-      ["const", "const result = 1 + 1; // => 2"]
-    ]
-  ) {
-    for (
-      const [boundary, continuation] of [
-        ["array", "[1, 2].forEach(record)"],
-        ["IIFE", "(() => { record(1); record(2) })()"],
-        ["void-array control", "void [1, 2].forEach(record)"]
-      ]
-    ) {
-      it(`preserves the ${boundary} statement after a ${form} assertion`, () => {
-        const source = `${statement}\n${continuation}`
-        const original: Array<number> = []
-        compileFunction(source, ["record"])((value: number) => original.push(value))
-        assert.deepStrictEqual(original, [1, 2])
-
-        const transformed = transform(source, "example.ts", 0)
-        assert.ok(transformed.endsWith(imported))
-        const actual: Array<number> = []
-        const assertions: Array<ReadonlyArray<number>> = []
-        // Bind the generated import to the real void-returning assertion utility.
-        compileFunction(transformed.slice(0, -imported.length), ["__effect_doctest_assert_0", "record"])(
-          (actual: number, expected: number): void => {
-            assertions.push([actual, expected])
-            assertEquals(actual, expected)
-          },
-          (value: number) => actual.push(value)
-        )
-        assert.deepStrictEqual(assertions, [[2, 2]])
-        assert.deepStrictEqual(actual, original)
-      })
-    }
-  }
-
   it("transforms expression assertions", () => {
     assert.strictEqual(
       transform("Option.some(1) // => Option.some(1)", "example.ts", 10),

--- a/packages/tools/doctest/test/Transform.test.ts
+++ b/packages/tools/doctest/test/Transform.test.ts
@@ -1,27 +1,66 @@
+import { assertEquals } from "@effect/doctest/Runtime"
 import { transform } from "@effect/doctest/Transform"
 import { assert, describe, it } from "@effect/vitest"
+import { compileFunction } from "node:vm"
 
 const imported = `import { assertEquals as __effect_doctest_assert_0 } from "@effect/doctest/Runtime"`
 
 describe("Transform", () => {
+  for (
+    const [form, statement] of [
+      ["expression", "1 + 1; // => 2"],
+      ["const", "const result = 1 + 1; // => 2"]
+    ]
+  ) {
+    for (
+      const [boundary, continuation] of [
+        ["array", "[1, 2].forEach(record)"],
+        ["IIFE", "(() => { record(1); record(2) })()"],
+        ["void-array control", "void [1, 2].forEach(record)"]
+      ]
+    ) {
+      it(`preserves the ${boundary} statement after a ${form} assertion`, () => {
+        const source = `${statement}\n${continuation}`
+        const original: Array<number> = []
+        compileFunction(source, ["record"])((value: number) => original.push(value))
+        assert.deepStrictEqual(original, [1, 2])
+
+        const transformed = transform(source, "example.ts", 0)
+        assert.ok(transformed.endsWith(imported))
+        const actual: Array<number> = []
+        const assertions: Array<ReadonlyArray<number>> = []
+        // Bind the generated import to the real void-returning assertion utility.
+        compileFunction(transformed.slice(0, -imported.length), ["__effect_doctest_assert_0", "record"])(
+          (actual: number, expected: number): void => {
+            assertions.push([actual, expected])
+            assertEquals(actual, expected)
+          },
+          (value: number) => actual.push(value)
+        )
+        assert.deepStrictEqual(assertions, [[2, 2]])
+        assert.deepStrictEqual(actual, original)
+      })
+    }
+  }
+
   it("transforms expression assertions", () => {
     assert.strictEqual(
       transform("Option.some(1) // => Option.some(1)", "example.ts", 10),
-      `__effect_doctest_assert_0(Option.some(1), Option.some(1))\n\n${imported}`
+      `__effect_doctest_assert_0(Option.some(1), Option.some(1));\n\n${imported}`
     )
   })
 
   it("transforms const declaration assertions without evaluating the initializer twice", () => {
     assert.strictEqual(
       transform("const result = makeValue() // => Option.some(1)\nuse(result)", "example.ts", 10),
-      `const result = makeValue()\n__effect_doctest_assert_0(result, Option.some(1))\nuse(result)\n\n${imported}`
+      `const result = makeValue()\n__effect_doctest_assert_0(result, Option.some(1));\nuse(result)\n\n${imported}`
     )
   })
 
   it("preserves indentation in nested blocks", () => {
     assert.strictEqual(
       transform("if (enabled) {\n  const result = makeValue() // => 1\n}", "example.ts", 10),
-      `if (enabled) {\n  const result = makeValue()\n  __effect_doctest_assert_0(result, 1)\n}\n\n${imported}`
+      `if (enabled) {\n  const result = makeValue()\n  __effect_doctest_assert_0(result, 1);\n}\n\n${imported}`
     )
   })
 


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Generated doctest assertion calls had no statement terminator. A valid snippet followed by an array expression or IIFE could continue the assertion call and fail at runtime.

Terminate generated assertions in both supported transformation paths. The regression loads a snippet through the plugin and executes the emitted code to confirm the following array expression remains a separate statement.

## Verification

```sh
pnpm lint-fix
pnpm test --run packages/tools/doctest/test/Transform.test.ts packages/tools/doctest/test/Runtime.test.ts packages/tools/doctest/test/Plugin.test.ts --maxWorkers=1 --no-file-parallelism --sequence.concurrent=false --reporter=verbose
pnpm check
git diff --check 243c72f001dd87385839c057af48f346abcf480b HEAD
```

The targeted run passes all 15 tests.

## Related

Closes #7753
Closes EFF-1093
