### PR TITLE
fix(ai-openai): preserve image strings in OpenAI and compatible requests

### DIFF
--- a/.changeset/openai-image-strings.md
+++ b/.changeset/openai-image-strings.md
@@ -3,4 +3,4 @@
 "@effect/ai-openai-compat": patch
 ---
 
-Preserve image data supplied as strings in OpenAI requests.
+Preserve image data supplied as strings in OpenAI Responses and OpenAI-compatible chat requests.

--- a/.changeset/openai-image-strings.md
+++ b/.changeset/openai-image-strings.md
@@ -1,0 +1,6 @@
+---
+"@effect/ai-openai": patch
+"@effect/ai-openai-compat": patch
+---
+
+Preserve image data supplied as strings in OpenAI requests.

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -787,6 +787,11 @@ const prepareMessages = Effect.fnUntraced(
 
                   if (typeof part.data === "string" && isFileId(part.data, config)) {
                     content.push({ type: "input_image", file_id: part.data, detail })
+                  } else if (typeof part.data === "string") {
+                    const imageUrl = part.data.startsWith("data:")
+                      ? part.data
+                      : `data:${mediaType};base64,${part.data}`
+                    content.push({ type: "input_image", image_url: imageUrl, detail })
                   }
 
                   if (part.data instanceof URL) {

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -787,20 +787,14 @@ const prepareMessages = Effect.fnUntraced(
 
                   if (typeof part.data === "string" && isFileId(part.data, config)) {
                     content.push({ type: "input_image", file_id: part.data, detail })
-                  } else if (typeof part.data === "string") {
-                    const imageUrl = part.data.startsWith("data:")
+                  } else {
+                    const imageUrl = part.data instanceof URL
+                      ? part.data.toString()
+                      : part.data instanceof Uint8Array
+                      ? `data:${mediaType};base64,${Encoding.encodeBase64(part.data)}`
+                      : /^(data:|https?:\/\/)/i.test(part.data)
                       ? part.data
                       : `data:${mediaType};base64,${part.data}`
-                    content.push({ type: "input_image", image_url: imageUrl, detail })
-                  }
-
-                  if (part.data instanceof URL) {
-                    content.push({ type: "input_image", image_url: part.data.toString(), detail })
-                  }
-
-                  if (part.data instanceof Uint8Array) {
-                    const base64 = Encoding.encodeBase64(part.data)
-                    const imageUrl = `data:${mediaType};base64,${base64}`
                     content.push({ type: "input_image", image_url: imageUrl, detail })
                   }
                 } else if (part.mediaType === "application/pdf") {

--- a/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
@@ -203,7 +203,7 @@ describe("OpenAiLanguageModel", () => {
         })
       }))
 
-    it.effect("preserves multimodal user content order in chat payload", () =>
+    it.effect("preserves URL and base64 images in multimodal content order", () =>
       Effect.gen(function*() {
         const base64 = "iVBORw0KGgo="
         let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
@@ -239,6 +239,7 @@ describe("OpenAiLanguageModel", () => {
                 mediaType: "image/png",
                 data: new URL("https://example.com/image.png")
               }),
+              Prompt.filePart({ mediaType: "image/png", data: "https://example.com/string-image.png" }),
               Prompt.filePart({ mediaType: "image/png", data: base64 }),
               Prompt.textPart({ text: "second text" })
             ]
@@ -265,6 +266,13 @@ describe("OpenAiLanguageModel", () => {
             type: "image_url",
             image_url: {
               url: "https://example.com/image.png",
+              detail: "auto"
+            }
+          },
+          {
+            type: "image_url",
+            image_url: {
+              url: "https://example.com/string-image.png",
               detail: "auto"
             }
           },

--- a/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
@@ -205,6 +205,7 @@ describe("OpenAiLanguageModel", () => {
 
     it.effect("preserves multimodal user content order in chat payload", () =>
       Effect.gen(function*() {
+        const base64 = "iVBORw0KGgo="
         let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
 
         const layer = OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
@@ -238,6 +239,7 @@ describe("OpenAiLanguageModel", () => {
                 mediaType: "image/png",
                 data: new URL("https://example.com/image.png")
               }),
+              Prompt.filePart({ mediaType: "image/png", data: base64 }),
               Prompt.textPart({ text: "second text" })
             ]
           }])
@@ -263,6 +265,13 @@ describe("OpenAiLanguageModel", () => {
             type: "image_url",
             image_url: {
               url: "https://example.com/image.png",
+              detail: "auto"
+            }
+          },
+          {
+            type: "image_url",
+            image_url: {
+              url: `data:image/png;base64,${base64}`,
               detail: "auto"
             }
           },

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -878,6 +878,11 @@ const prepareMessages = Effect.fnUntraced(
 
                   if (typeof part.data === "string" && isFileId(part.data, config)) {
                     content.push({ type: "input_image", file_id: part.data, detail })
+                  } else if (typeof part.data === "string") {
+                    const imageUrl = part.data.startsWith("data:")
+                      ? part.data
+                      : `data:${mediaType};base64,${part.data}`
+                    content.push({ type: "input_image", image_url: imageUrl, detail })
                   }
 
                   if (part.data instanceof URL) {

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -878,20 +878,14 @@ const prepareMessages = Effect.fnUntraced(
 
                   if (typeof part.data === "string" && isFileId(part.data, config)) {
                     content.push({ type: "input_image", file_id: part.data, detail })
-                  } else if (typeof part.data === "string") {
-                    const imageUrl = part.data.startsWith("data:")
+                  } else {
+                    const imageUrl = part.data instanceof URL
+                      ? part.data.toString()
+                      : part.data instanceof Uint8Array
+                      ? `data:${mediaType};base64,${Encoding.encodeBase64(part.data)}`
+                      : /^(data:|https?:\/\/)/i.test(part.data)
                       ? part.data
                       : `data:${mediaType};base64,${part.data}`
-                    content.push({ type: "input_image", image_url: imageUrl, detail })
-                  }
-
-                  if (part.data instanceof URL) {
-                    content.push({ type: "input_image", image_url: part.data.toString(), detail })
-                  }
-
-                  if (part.data instanceof Uint8Array) {
-                    const base64 = Encoding.encodeBase64(part.data)
-                    const imageUrl = `data:${mediaType};base64,${base64}`
                     content.push({ type: "input_image", image_url: imageUrl, detail })
                   }
                 } else if (part.mediaType === "application/pdf") {

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -169,28 +169,6 @@ describe("OpenAiLanguageModel", () => {
       })
 
       describe("user messages", () => {
-        it.effect("handles image data URLs", () =>
-          Effect.gen(function*() {
-            const dataUrl = "data:image/png;base64,iVBORw0KGgo="
-            yield* LanguageModel.generateText({
-              prompt: Prompt.make([Prompt.userMessage({
-                content: [Prompt.filePart({ mediaType: "image/png", data: dataUrl })]
-              })])
-            }).pipe(Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")))
-
-            const requests = yield* MockHttpClient.requests
-            const body = yield* getRequestBody(requests[0])
-
-            assert.deepStrictEqual(body.input, [{
-              role: "user",
-              content: [{
-                type: "input_image",
-                image_url: dataUrl,
-                detail: "auto"
-              }]
-            }])
-          }).pipe(Effect.provide(makeTestLayer())))
-
         it.effect("converts text parts to input_text", () =>
           Effect.gen(function*() {
             yield* LanguageModel.generateText({
@@ -227,6 +205,35 @@ describe("OpenAiLanguageModel", () => {
               type: "input_image",
               image_url: "https://example.com/image.png",
               detail: "auto"
+            }])
+          }).pipe(Effect.provide(makeTestLayer())))
+
+        it.effect("handles image strings", () =>
+          Effect.gen(function*() {
+            const base64 = "iVBORw0KGgo="
+            const dataUrl = `data:image/png;base64,${base64}`
+            const upperCaseDataUrl = `DATA:image/png;base64,${base64}`
+            const url = "https://example.com/image.png"
+
+            yield* LanguageModel.generateText({
+              prompt: Prompt.make([Prompt.userMessage({
+                content: [base64, dataUrl, upperCaseDataUrl, url].map((data) =>
+                  Prompt.filePart({ mediaType: "image/png", data })
+                )
+              })])
+            }).pipe(Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")))
+
+            const requests = yield* MockHttpClient.requests
+            const body = yield* getRequestBody(requests[0])
+
+            assert.deepStrictEqual(body.input, [{
+              role: "user",
+              content: [
+                { type: "input_image", image_url: `data:image/png;base64,${base64}`, detail: "auto" },
+                { type: "input_image", image_url: dataUrl, detail: "auto" },
+                { type: "input_image", image_url: upperCaseDataUrl, detail: "auto" },
+                { type: "input_image", image_url: url, detail: "auto" }
+              ]
             }])
           }).pipe(Effect.provide(makeTestLayer())))
 

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -169,6 +169,28 @@ describe("OpenAiLanguageModel", () => {
       })
 
       describe("user messages", () => {
+        it.effect("handles image data URLs", () =>
+          Effect.gen(function*() {
+            const dataUrl = "data:image/png;base64,iVBORw0KGgo="
+            yield* LanguageModel.generateText({
+              prompt: Prompt.make([Prompt.userMessage({
+                content: [Prompt.filePart({ mediaType: "image/png", data: dataUrl })]
+              })])
+            }).pipe(Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")))
+
+            const requests = yield* MockHttpClient.requests
+            const body = yield* getRequestBody(requests[0])
+
+            assert.deepStrictEqual(body.input, [{
+              role: "user",
+              content: [{
+                type: "input_image",
+                image_url: dataUrl,
+                detail: "auto"
+              }]
+            }])
+          }).pipe(Effect.provide(makeTestLayer())))
+
         it.effect("converts text parts to input_text", () =>
           Effect.gen(function*() {
             yield* LanguageModel.generateText({


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Preserve image file parts supplied as strings in OpenAI Responses requests and OpenAI-compatible chat requests. Data URLs and HTTP(S) URL strings pass through unchanged; raw base64 is wrapped in a data URL using the declared media type. Configured file IDs retain their current behavior.

Coverage stays in the two adapters' main language-model test files. PDF handling is unchanged.

## Verification

- `pnpm test --run packages/ai/openai/test/OpenAiLanguageModel.test.ts packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts --maxWorkers=1 --no-file-parallelism --reporter=verbose`
- `pnpm lint-fix`
- `pnpm check`

## Related

Closes #7755
Closes EFF-1094
