### PR TITLE
fix(ai-anthropic): preserve base64 image string payloads

### DIFF
--- a/.changeset/anthropic-image-strings.md
+++ b/.changeset/anthropic-image-strings.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-anthropic": patch
+---
+
+Preserve base64 image strings in Anthropic requests.

--- a/.changeset/anthropic-image-strings.md
+++ b/.changeset/anthropic-image-strings.md
@@ -1,5 +1,0 @@
----
-"@effect/ai-anthropic": patch
----
-
-Preserve already-base64 image strings and remove the base64 data-URL prefix in Anthropic model requests instead of encoding the string contents again.

--- a/.changeset/anthropic-image-strings.md
+++ b/.changeset/anthropic-image-strings.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-anthropic": patch
+---
+
+Preserve already-base64 image strings and remove the base64 data-URL prefix in Anthropic model requests instead of encoding the string contents again.

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -889,13 +889,7 @@ const prepareMessages = Effect.fnUntraced(
 
                         const source = isUrlData(part.data)
                           ? { type: "url", url: getUrlString(part.data) } as const
-                          : {
-                            type: "base64",
-                            media_type: mediaType,
-                            data: typeof part.data === "string"
-                              ? part.data.replace(/^data:[^;]+;base64,/, "")
-                              : Encoding.encodeBase64(part.data)
-                          } as const
+                          : { type: "base64", media_type: mediaType, data: Encoding.encodeBase64(part.data) } as const
 
                         content.push({ type: "image", source, cache_control: cacheControl })
                       } else if (part.mediaType === "application/pdf" || part.mediaType === "text/plain") {

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -889,7 +889,13 @@ const prepareMessages = Effect.fnUntraced(
 
                         const source = isUrlData(part.data)
                           ? { type: "url", url: getUrlString(part.data) } as const
-                          : { type: "base64", media_type: mediaType, data: Encoding.encodeBase64(part.data) } as const
+                          : {
+                            type: "base64",
+                            media_type: mediaType,
+                            data: typeof part.data === "string"
+                              ? part.data.replace(/^data:[^;]+;base64,/, "")
+                              : Encoding.encodeBase64(part.data)
+                          } as const
 
                         content.push({ type: "image", source, cache_control: cacheControl })
                       } else if (part.mediaType === "application/pdf" || part.mediaType === "text/plain") {

--- a/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
+++ b/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
@@ -1,4 +1,4 @@
-import { AnthropicClient, AnthropicLanguageModel, AnthropicTool } from "@effect/ai-anthropic"
+import { AnthropicClient, AnthropicLanguageModel, AnthropicTool, Generated } from "@effect/ai-anthropic"
 import { assert, describe, it } from "@effect/vitest"
 import { Effect, Layer, Redacted, Schema, Stream } from "effect"
 import {
@@ -13,6 +13,70 @@ import {
 import { HttpClient, type HttpClientError, type HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
 describe("AnthropicLanguageModel", () => {
+  describe("image file data representations", () => {
+    const base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGP4DwQACfsD/fteaysAAAAASUVORK5CYII="
+    const source = { type: "base64", media_type: "image/png", data: base64 }
+    const url = "https://example.com/pixel.png"
+    const cases: ReadonlyArray<readonly [string, Prompt.FilePart["data"], object]> = [
+      ["base64 string", base64, source],
+      ["data-URL string", `data:image/png;base64,${base64}`, source],
+      ["bytes", Uint8Array.from(atob(base64), (char) => char.charCodeAt(0)), source],
+      ["HTTPS URL object", new URL(url), { type: "url", url }],
+      ["HTTPS URL string", url, { type: "url", url }]
+    ]
+
+    for (const [name, data, expected] of cases) {
+      it.effect(`preserves image from ${name}`, () =>
+        Effect.gen(function*() {
+          const response = yield* Schema.decodeUnknownEffect(Generated.BetaMessage)({
+            id: "msg_fixture",
+            type: "message",
+            role: "assistant",
+            model: "fixture-model",
+            content: [],
+            stop_reason: "end_turn",
+            stop_sequence: null,
+            usage: {
+              cache_creation: null,
+              cache_creation_input_tokens: null,
+              cache_read_input_tokens: null,
+              inference_geo: null,
+              input_tokens: 1,
+              output_tokens: 1,
+              service_tier: null
+            }
+          })
+          const requests: Array<HttpClientRequest.HttpClientRequest> = []
+          const layer = AnthropicClient.layer({}).pipe(
+            Layer.provide(Layer.succeed(
+              HttpClient.HttpClient,
+              makeHttpClient((request) => {
+                requests.push(request)
+                return Effect.succeed(jsonResponse(request, response))
+              })
+            ))
+          )
+
+          yield* LanguageModel.generateText({
+            prompt: Prompt.make([Prompt.userMessage({
+              content: [Prompt.filePart({ mediaType: "image/png", data })]
+            })])
+          }).pipe(
+            Effect.provide(AnthropicLanguageModel.model("fixture-model")),
+            Effect.provide(layer)
+          )
+
+          assert.strictEqual(requests.length, 1)
+          const body = yield* getRequestBody(requests[0])
+          yield* Schema.decodeUnknownEffect(Generated.BetaCreateMessageParams)(body)
+          assert.deepStrictEqual(body.messages, [{
+            role: "user",
+            content: [{ type: "image", source: expected, cache_control: null }]
+          }])
+        }))
+    }
+  })
+
   describe("streamText", () => {
     it.effect("decodes tool call params in content_block_stop", () =>
       Effect.gen(function*() {

--- a/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
+++ b/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
@@ -1,4 +1,4 @@
-import { AnthropicClient, AnthropicLanguageModel, AnthropicTool, Generated } from "@effect/ai-anthropic"
+import { AnthropicClient, AnthropicLanguageModel, AnthropicTool } from "@effect/ai-anthropic"
 import { assert, describe, it } from "@effect/vitest"
 import { Effect, Layer, Redacted, Schema, Stream } from "effect"
 import {
@@ -13,70 +13,6 @@ import {
 import { HttpClient, type HttpClientError, type HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
 describe("AnthropicLanguageModel", () => {
-  describe("image file data representations", () => {
-    const base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGP4DwQACfsD/fteaysAAAAASUVORK5CYII="
-    const source = { type: "base64", media_type: "image/png", data: base64 }
-    const url = "https://example.com/pixel.png"
-    const cases: ReadonlyArray<readonly [string, Prompt.FilePart["data"], object]> = [
-      ["base64 string", base64, source],
-      ["data-URL string", `data:image/png;base64,${base64}`, source],
-      ["bytes", Uint8Array.from(atob(base64), (char) => char.charCodeAt(0)), source],
-      ["HTTPS URL object", new URL(url), { type: "url", url }],
-      ["HTTPS URL string", url, { type: "url", url }]
-    ]
-
-    for (const [name, data, expected] of cases) {
-      it.effect(`preserves image from ${name}`, () =>
-        Effect.gen(function*() {
-          const response = yield* Schema.decodeUnknownEffect(Generated.BetaMessage)({
-            id: "msg_fixture",
-            type: "message",
-            role: "assistant",
-            model: "fixture-model",
-            content: [],
-            stop_reason: "end_turn",
-            stop_sequence: null,
-            usage: {
-              cache_creation: null,
-              cache_creation_input_tokens: null,
-              cache_read_input_tokens: null,
-              inference_geo: null,
-              input_tokens: 1,
-              output_tokens: 1,
-              service_tier: null
-            }
-          })
-          const requests: Array<HttpClientRequest.HttpClientRequest> = []
-          const layer = AnthropicClient.layer({}).pipe(
-            Layer.provide(Layer.succeed(
-              HttpClient.HttpClient,
-              makeHttpClient((request) => {
-                requests.push(request)
-                return Effect.succeed(jsonResponse(request, response))
-              })
-            ))
-          )
-
-          yield* LanguageModel.generateText({
-            prompt: Prompt.make([Prompt.userMessage({
-              content: [Prompt.filePart({ mediaType: "image/png", data })]
-            })])
-          }).pipe(
-            Effect.provide(AnthropicLanguageModel.model("fixture-model")),
-            Effect.provide(layer)
-          )
-
-          assert.strictEqual(requests.length, 1)
-          const body = yield* getRequestBody(requests[0])
-          yield* Schema.decodeUnknownEffect(Generated.BetaCreateMessageParams)(body)
-          assert.deepStrictEqual(body.messages, [{
-            role: "user",
-            content: [{ type: "image", source: expected, cache_control: null }]
-          }])
-        }))
-    }
-  })
-
   describe("streamText", () => {
     it.effect("decodes tool call params in content_block_stop", () =>
       Effect.gen(function*() {
@@ -572,6 +508,51 @@ describe("AnthropicLanguageModel", () => {
 
         assert.isDefined(toolResult)
         assert.strictEqual(toolResult.content, "PLAIN_TEXT_SENTINEL\n")
+      }))
+
+    it.effect("preserves base64 image string payloads", () =>
+      Effect.gen(function*() {
+        const base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGP4DwQACfsD/fteaysAAAAASUVORK5CYII="
+        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined = undefined
+        const layer = AnthropicClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) => {
+              capturedRequest = request
+              return Effect.succeed(jsonResponse(request, {
+                id: "msg_test_1",
+                type: "message",
+                role: "assistant",
+                model: "claude-sonnet-4-20250514",
+                content: [{ type: "text", text: "Done" }],
+                stop_reason: "end_turn",
+                stop_sequence: null,
+                usage: {
+                  cache_creation: null,
+                  cache_creation_input_tokens: null,
+                  cache_read_input_tokens: null,
+                  inference_geo: null,
+                  input_tokens: 1,
+                  output_tokens: 1,
+                  service_tier: null
+                }
+              }))
+            })
+          ))
+        )
+
+        yield* LanguageModel.generateText({
+          prompt: Prompt.make([Prompt.userMessage({
+            content: [Prompt.filePart({ mediaType: "image/png", data: base64 })]
+          })])
+        }).pipe(
+          Effect.provide(AnthropicLanguageModel.model("claude-sonnet-4-20250514")),
+          Effect.provide(layer)
+        )
+
+        assert.isDefined(capturedRequest)
+        const body = yield* getRequestBody(capturedRequest)
+        assert.strictEqual(body.messages[0].content[0].source.data, base64)
       }))
 
     it.effect("encodes dynamic tools", () =>


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Anthropic image translation encoded base64 string payloads a second time. String payloads are now preserved after removing a standard `data:<media-type>;base64,` prefix. Byte arrays are still encoded, and HTTP(S) URLs keep their URL source.

The regression test captures the outgoing Anthropic request through the public `LanguageModel.generateText` interface.

## Verification

```sh
pnpm test --run packages/ai/anthropic/test/AnthropicLanguageModel.test.ts --maxWorkers=1 --no-file-parallelism --reporter=verbose
pnpm lint-fix
pnpm check
```

## Related

Closes #7757
Closes EFF-1095
