### PR TITLE
fix(openapi-generator): encode declared form-urlencoded requests

### DIFF
--- a/.changeset/fix-openapi-client-form-url-encoding.md
+++ b/.changeset/fix-openapi-client-form-url-encoding.md
@@ -1,0 +1,5 @@
+---
+"@effect/openapi-generator": patch
+---
+
+Encode form-urlencoded request bodies in generated HTTP clients.

--- a/packages/tools/openapi-generator/src/OpenApiTransformer.ts
+++ b/packages/tools/openapi-generator/src/OpenApiTransformer.ts
@@ -413,6 +413,8 @@ export const make = (
 
     if (operation.payloadFormData) {
       pipeline.push(`HttpClientRequest.bodyFormData(options.payload as any)`)
+    } else if (operation.payloadFormUrlEncoded) {
+      pipeline.push(`HttpClientRequest.bodyUrlParams(options.payload as any)`)
     } else if (operation.payload) {
       pipeline.push(`HttpClientRequest.bodyJsonUnsafe(options.payload)`)
     }
@@ -454,6 +456,8 @@ export const make = (
 
     if (operation.payloadFormData) {
       pipeline.push(`HttpClientRequest.bodyFormData(options.payload as any)`)
+    } else if (operation.payloadFormUrlEncoded) {
+      pipeline.push(`HttpClientRequest.bodyUrlParams(options.payload as any)`)
     } else if (operation.payload) {
       pipeline.push(`HttpClientRequest.bodyJsonUnsafe(options.payload)`)
     }
@@ -778,6 +782,8 @@ export const make = (
     const payloadAccessor = "options.payload"
     if (operation.payloadFormData) {
       pipeline.push(`HttpClientRequest.bodyFormDataRecord(${payloadAccessor} as any)`)
+    } else if (operation.payloadFormUrlEncoded) {
+      pipeline.push(`HttpClientRequest.bodyUrlParams(${payloadAccessor} as any)`)
     } else if (operation.payload) {
       pipeline.push(`HttpClientRequest.bodyJsonUnsafe(${payloadAccessor})`)
     }
@@ -840,6 +846,8 @@ export const make = (
 
     if (operation.payloadFormData) {
       pipeline.push(`HttpClientRequest.bodyFormDataRecord(options.payload as any)`)
+    } else if (operation.payloadFormUrlEncoded) {
+      pipeline.push(`HttpClientRequest.bodyUrlParams(options.payload as any)`)
     } else if (operation.payload) {
       pipeline.push(`HttpClientRequest.bodyJsonUnsafe(options.payload)`)
     }
@@ -881,6 +889,8 @@ export const make = (
 
     if (operation.payloadFormData) {
       pipeline.push(`HttpClientRequest.bodyFormDataRecord(options.payload as any)`)
+    } else if (operation.payloadFormUrlEncoded) {
+      pipeline.push(`HttpClientRequest.bodyUrlParams(options.payload as any)`)
     } else if (operation.payload) {
       pipeline.push(`HttpClientRequest.bodyJsonUnsafe(options.payload)`)
     }

--- a/packages/tools/openapi-generator/test/Utils.test.ts
+++ b/packages/tools/openapi-generator/test/Utils.test.ts
@@ -1,5 +1,54 @@
+import { transformSync } from "@babel/core"
+import * as OpenApiGenerator from "@effect/openapi-generator/OpenApiGenerator"
 import * as Utils from "@effect/openapi-generator/Utils"
-import { describe, expect, it } from "vitest"
+import { assert, describe, expect, it } from "@effect/vitest"
+import * as Data from "effect/Data"
+import * as Effect from "effect/Effect"
+import * as Schema from "effect/Schema"
+import * as Stream from "effect/Stream"
+import * as Sse from "effect/unstable/encoding/Sse"
+import * as HttpClient from "effect/unstable/http/HttpClient"
+import * as HttpClientError from "effect/unstable/http/HttpClientError"
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest"
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse"
+import type { OpenAPISpec } from "effect/unstable/httpapi/OpenApi"
+import { stripTypeScriptTypes } from "node:module"
+
+const modules = {
+  "effect/Data": Data,
+  "effect/Effect": Effect,
+  "effect/Schema": Schema,
+  "effect/Stream": Stream,
+  "effect/unstable/encoding/Sse": Sse,
+  "effect/unstable/http/HttpClient": HttpClient,
+  "effect/unstable/http/HttpClientError": HttpClientError,
+  "effect/unstable/http/HttpClientRequest": HttpClientRequest,
+  "effect/unstable/http/HttpClientResponse": HttpClientResponse
+}
+
+function loadClient(source: string, httpClient: HttpClient.HttpClient) {
+  const compiled = transformSync(stripTypeScriptTypes(source), {
+    babelrc: false,
+    configFile: false,
+    plugins: ["@babel/plugin-transform-modules-commonjs"]
+  })
+  assert.isString(compiled?.code)
+  const exports = {} as {
+    make: (httpClient: HttpClient.HttpClient) => {
+      submit: (options: { payload: { name: string } }) => Effect.Effect<unknown, unknown>
+      submitSse: (options: { payload: { name: string } }) => Stream.Stream<unknown, unknown>
+      submitStream: (options: { payload: { name: string } }) => Stream.Stream<unknown, unknown>
+    }
+  }
+  new Function("require", "exports", compiled!.code!)(
+    (id: keyof typeof modules) => {
+      assert.property(modules, id)
+      return modules[id]
+    },
+    exports
+  )
+  return exports.make(httpClient)
+}
 
 describe("Utils", () => {
   describe("camelize", () => {
@@ -29,5 +78,85 @@ describe("Utils", () => {
       expect(Utils.identifier("my-operation")).toBe("MyOperation")
       expect(Utils.identifier("operation-2")).toBe("Operation2")
     })
+  })
+
+  describe("generated request encoding", () => {
+    for (const format of ["httpclient", "httpclient-type-only"] as const) {
+      for (const method of ["submit", "submitSse", "submitStream"] as const) {
+        it.effect(`${format} ${method} sends form-urlencoded payloads`, () =>
+          Effect.gen(function*() {
+            const responseContentType = method === "submitSse"
+              ? "text/event-stream"
+              : method === "submitStream"
+              ? "application/octet-stream"
+              : "application/json"
+            const spec: OpenAPISpec = {
+              openapi: "3.1.0",
+              info: { title: "Form API", version: "1.0.0" },
+              components: { schemas: {}, securitySchemes: {} },
+              security: [],
+              tags: [],
+              paths: {
+                "/submit": {
+                  post: {
+                    operationId: "submit",
+                    parameters: [],
+                    tags: ["Forms"],
+                    security: [],
+                    requestBody: {
+                      required: true,
+                      content: {
+                        "application/x-www-form-urlencoded": {
+                          schema: {
+                            type: "object",
+                            properties: { name: { type: "string" } },
+                            required: ["name"]
+                          }
+                        }
+                      }
+                    },
+                    responses: {
+                      "200": {
+                        description: "Success",
+                        content: { [responseContentType]: { schema: { type: "string" } } }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            const generator = yield* OpenApiGenerator.OpenApiGenerator
+            const source = yield* generator.generate(spec, { name: "TestClient", format })
+            const requests: Array<HttpClientRequest.HttpClientRequest> = []
+            const httpClient = HttpClient.make((request) => {
+              requests.push(request)
+              return Effect.succeed(HttpClientResponse.fromWeb(
+                request,
+                new Response(method === "submitSse" ? "data: \"ok\"\n\n" : "\"ok\"", {
+                  headers: { "content-type": responseContentType }
+                })
+              ))
+            }).pipe(HttpClient.mapRequest(HttpClientRequest.prependUrl("https://example.test")))
+            const client = loadClient(source, httpClient)
+            const options = { payload: { name: "Ada Lovelace" } }
+            if (method === "submit") {
+              yield* client.submit(options)
+            } else {
+              yield* Stream.runDrain(client[method](options))
+            }
+            assert.strictEqual(requests.length, 1)
+            const request = yield* HttpClientRequest.toWeb(requests[0])
+            assert.deepStrictEqual({
+              contentType: request.headers.get("content-type"),
+              body: yield* Effect.promise(() => request.text())
+            }, {
+              contentType: "application/x-www-form-urlencoded",
+              body: "name=Ada+Lovelace"
+            })
+          }).pipe(Effect.provide(
+            format === "httpclient" ? OpenApiGenerator.layerTransformerSchema : OpenApiGenerator.layerTransformerTs
+          )))
+      }
+    }
   })
 })


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Generated schema-backed SSE and binary methods, plus all type-only HTTP client methods, encoded declared `application/x-www-form-urlencoded` payloads as JSON. These paths now use `HttpClientRequest.bodyUrlParams`, matching the existing schema-backed request path.

The regression matrix in `packages/tools/openapi-generator/test/Utils.test.ts` executes all six generated-client variants and checks the request content type and wire body.

## Verification

```sh
pnpm lint-fix
pnpm test --run packages/tools/openapi-generator/test/OpenApiGenerator.test.ts packages/tools/openapi-generator/test/OpenApiGeneratorCli.test.ts packages/tools/openapi-generator/test/JsonSchemaGenerator.test.ts packages/tools/openapi-generator/test/JsonSchemaGeneratorRepresentation.test.ts packages/tools/openapi-generator/test/OpenApiPatch.test.ts packages/tools/openapi-generator/test/Utils.test.ts --maxWorkers 1
pnpm check
```

## Related

Closes #7767
Closes EFF-1100

## Audit

Runtime correctness audit; intended label: `audit`.
