### PR TITLE
fix(Trie): preserve valued nodes during removal

### DIFF
--- a/.changeset/trie-remove-valued-prefix.md
+++ b/.changeset/trie-remove-valued-prefix.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve valued prefix nodes when removing a longer key from a `Trie`.

--- a/.changeset/trie-remove-valued-prefix.md
+++ b/.changeset/trie-remove-valued-prefix.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Trie.remove` and `Trie.removeMany` to preserve other stored entries, including prefixes and sibling keys, when removing their last child. Stored `undefined` values are preserved as well.

--- a/.changeset/trie-remove-valued-prefix.md
+++ b/.changeset/trie-remove-valued-prefix.md
@@ -1,5 +1,0 @@
----
-"effect": patch
----
-
-Fix `Trie.remove` and `Trie.removeMany` to preserve other stored entries, including prefixes and sibling keys, when removing their last child. Stored `undefined` values are preserved as well.

--- a/packages/effect/src/internal/trie.ts
+++ b/packages/effect/src/internal/trie.ts
@@ -516,7 +516,10 @@ export const remove = dual<
       const n2 = nStack[s]
       const d = dStack[s]
       const child = nStack[s + 1]
-      const nc = child.left === undefined && child.mid === undefined && child.right === undefined ? undefined : child
+      const nc =
+        child.value === undefined && child.left === undefined && child.mid === undefined && child.right === undefined
+          ? undefined
+          : child
       if (d === -1) {
         // left
         nStack[s] = {

--- a/packages/effect/src/internal/trie.ts
+++ b/packages/effect/src/internal/trie.ts
@@ -516,10 +516,7 @@ export const remove = dual<
       const n2 = nStack[s]
       const d = dStack[s]
       const child = nStack[s + 1]
-      const nc =
-        child.value === undefined && child.left === undefined && child.mid === undefined && child.right === undefined
-          ? undefined
-          : child
+      const nc = child.left === undefined && child.mid === undefined && child.right === undefined ? undefined : child
       if (d === -1) {
         // left
         nStack[s] = {

--- a/packages/effect/test/Trie.test.ts
+++ b/packages/effect/test/Trie.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, it } from "@effect/vitest"
+import { describe, it } from "@effect/vitest"
 import { assertNone, assertSome, deepStrictEqual, strictEqual, throws } from "@effect/vitest/utils"
 import * as Equal from "effect/Equal"
 import { pipe } from "effect/Function"
@@ -233,67 +233,10 @@ describe("Trie", () => {
     deepStrictEqual(Array.from(trie2), [["me", 1], ["mid", 3], ["mind", 2]])
   })
 
-  describe("remove preserves other stored entries", () => {
-    const cases: Array<[
-      name: string,
-      entries: Array<readonly [string, number | undefined]>,
-      keys: Array<string>,
-      many?: boolean
-    ]> = [
-      ["prefix", [["ab", 1], ["abc", 2]], ["abc"]],
-      ["reverse insertion prefix", [["abc", 2], ["ab", 1]], ["abc"]],
-      ["prefix chain", [["a", 1], ["ab", 2], ["abc", 3], ["abcd", 4]], ["abcd"]],
-      ["right sibling", [["ab", 1], ["ac", 2]], ["ac"]],
-      ["left sibling", [["ac", 1], ["ab", 2]], ["ab"]],
-      ["prefix with unrelated branch", [["ab", 1], ["abc", 2], ["z", 3]], ["abc"]],
-      ["remaining extension", [["ab", 1], ["abc", 2], ["abd", 3]], ["abc"]],
-      ["remaining left sibling", [["ab", 1], ["abc", 2], ["aa", 3]], ["abc"]],
-      ["root-valued prefix", [["a", 1], ["ab", 2]], ["ab"]],
-      ["undefined-valued prefix", [["ab", undefined], ["abc", 2]], ["abc"]],
-      ["undefined-valued removed leaf", [["ab", 1], ["abc", undefined]], ["abc"]],
-      ["removeMany extension", [["ab", 1], ["abc", 2]], ["abc"], true],
-      ["removeMany last extensions", [["ab", 1], ["abc", 2], ["abd", 3]], ["abc", "abd"], true],
-      ["removeMany repeated extension", [["ab", 1], ["abc", 2]], ["abc", "abc"], true],
-      ["remove prefix", [["ab", 1], ["abc", 2]], ["ab"]],
-      ["remove unrelated branch", [["ab", 1], ["z", 2]], ["z"]],
-      ["missing branch", [["ab", 1], ["abc", 2]], ["z"]],
-      ["missing terminal value", [["abc", 2]], ["ab"]],
-      ["missing extension", [["ab", 1]], ["abc"]],
-      ["sole entry", [["abc", 1]], ["abc"]],
-      ["sole undefined entry", [["abc", undefined]], ["abc"]],
-      ["empty trie", [], ["abc"]],
-      ["removeMany missing", [["ab", 1], ["abc", 2]], ["z", "abcd"], true],
-      ["removeMany empty", [["ab", 1], ["abc", 2]], [], true],
-      ["removeMany repeated sole entry", [["abc", 1]], ["abc", "abc"], true]
-    ]
+  it("remove preserves a valued prefix", () => {
+    const trie = Trie.make(["ab", 1], ["abc", 2]).pipe(Trie.remove("abc"))
 
-    for (const [name, entries, keys, many] of cases) {
-      it(name, () => {
-        const before = Trie.make(...entries)
-        const original = entries.slice().sort(([a], [b]) => a < b ? -1 : a > b ? 1 : 0)
-        const expected = original.filter(([key]) => !keys.includes(key))
-        const after = many ? Trie.removeMany(before, keys) : Trie.remove(before, keys[0])
-
-        assert.deepStrictEqual(Trie.toEntries(before), original)
-        assert.strictEqual(Trie.size(before), original.length)
-        for (const [key, value] of original) {
-          assert.deepStrictEqual(Trie.get(before, key), Option.some(value))
-        }
-
-        assert.strictEqual(Trie.size(after), expected.length)
-        assert.deepStrictEqual(Trie.toEntries(after), expected)
-        assert.deepStrictEqual(Array.from(after), expected)
-        assert.strictEqual(Trie.size(after), Array.from(after).length)
-        for (const [key, value] of expected) {
-          assert.strictEqual(Trie.has(after, key), true)
-          assert.deepStrictEqual(Trie.get(after, key), Option.some(value))
-        }
-        for (const key of keys) {
-          assert.strictEqual(Trie.has(after, key), false)
-          assert.deepStrictEqual(Trie.get(after, key), Option.none())
-        }
-      })
-    }
+    deepStrictEqual(Array.from(trie), [["ab", 1]], "valued prefix should remain after removing its extension")
   })
 
   it("keys returns keys in sorted order", () => {

--- a/packages/effect/test/Trie.test.ts
+++ b/packages/effect/test/Trie.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effect/vitest"
+import { assert, describe, it } from "@effect/vitest"
 import { assertNone, assertSome, deepStrictEqual, strictEqual, throws } from "@effect/vitest/utils"
 import * as Equal from "effect/Equal"
 import { pipe } from "effect/Function"
@@ -231,6 +231,69 @@ describe("Trie", () => {
     deepStrictEqual(Array.from(trie), [["call", 0], ["me", 1], ["mid", 3], ["mind", 2]])
     deepStrictEqual(Array.from(trie1), [["me", 1], ["mid", 3], ["mind", 2]])
     deepStrictEqual(Array.from(trie2), [["me", 1], ["mid", 3], ["mind", 2]])
+  })
+
+  describe("remove preserves other stored entries", () => {
+    const cases: Array<[
+      name: string,
+      entries: Array<readonly [string, number | undefined]>,
+      keys: Array<string>,
+      many?: boolean
+    ]> = [
+      ["prefix", [["ab", 1], ["abc", 2]], ["abc"]],
+      ["reverse insertion prefix", [["abc", 2], ["ab", 1]], ["abc"]],
+      ["prefix chain", [["a", 1], ["ab", 2], ["abc", 3], ["abcd", 4]], ["abcd"]],
+      ["right sibling", [["ab", 1], ["ac", 2]], ["ac"]],
+      ["left sibling", [["ac", 1], ["ab", 2]], ["ab"]],
+      ["prefix with unrelated branch", [["ab", 1], ["abc", 2], ["z", 3]], ["abc"]],
+      ["remaining extension", [["ab", 1], ["abc", 2], ["abd", 3]], ["abc"]],
+      ["remaining left sibling", [["ab", 1], ["abc", 2], ["aa", 3]], ["abc"]],
+      ["root-valued prefix", [["a", 1], ["ab", 2]], ["ab"]],
+      ["undefined-valued prefix", [["ab", undefined], ["abc", 2]], ["abc"]],
+      ["undefined-valued removed leaf", [["ab", 1], ["abc", undefined]], ["abc"]],
+      ["removeMany extension", [["ab", 1], ["abc", 2]], ["abc"], true],
+      ["removeMany last extensions", [["ab", 1], ["abc", 2], ["abd", 3]], ["abc", "abd"], true],
+      ["removeMany repeated extension", [["ab", 1], ["abc", 2]], ["abc", "abc"], true],
+      ["remove prefix", [["ab", 1], ["abc", 2]], ["ab"]],
+      ["remove unrelated branch", [["ab", 1], ["z", 2]], ["z"]],
+      ["missing branch", [["ab", 1], ["abc", 2]], ["z"]],
+      ["missing terminal value", [["abc", 2]], ["ab"]],
+      ["missing extension", [["ab", 1]], ["abc"]],
+      ["sole entry", [["abc", 1]], ["abc"]],
+      ["sole undefined entry", [["abc", undefined]], ["abc"]],
+      ["empty trie", [], ["abc"]],
+      ["removeMany missing", [["ab", 1], ["abc", 2]], ["z", "abcd"], true],
+      ["removeMany empty", [["ab", 1], ["abc", 2]], [], true],
+      ["removeMany repeated sole entry", [["abc", 1]], ["abc", "abc"], true]
+    ]
+
+    for (const [name, entries, keys, many] of cases) {
+      it(name, () => {
+        const before = Trie.make(...entries)
+        const original = entries.slice().sort(([a], [b]) => a < b ? -1 : a > b ? 1 : 0)
+        const expected = original.filter(([key]) => !keys.includes(key))
+        const after = many ? Trie.removeMany(before, keys) : Trie.remove(before, keys[0])
+
+        assert.deepStrictEqual(Trie.toEntries(before), original)
+        assert.strictEqual(Trie.size(before), original.length)
+        for (const [key, value] of original) {
+          assert.deepStrictEqual(Trie.get(before, key), Option.some(value))
+        }
+
+        assert.strictEqual(Trie.size(after), expected.length)
+        assert.deepStrictEqual(Trie.toEntries(after), expected)
+        assert.deepStrictEqual(Array.from(after), expected)
+        assert.strictEqual(Trie.size(after), Array.from(after).length)
+        for (const [key, value] of expected) {
+          assert.strictEqual(Trie.has(after, key), true)
+          assert.deepStrictEqual(Trie.get(after, key), Option.some(value))
+        }
+        for (const key of keys) {
+          assert.strictEqual(Trie.has(after, key), false)
+          assert.deepStrictEqual(Trie.get(after, key), Option.none())
+        }
+      })
+    }
   })
 
   it("keys returns keys in sorted order", () => {


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`Trie.remove` could prune a prefix node that still held a value when its last child was removed. Removing `"abc"` from a trie containing `"ab"` and `"abc"` therefore left the trie with a reported size of one but no iterable entries.

The removal path now prunes a child only when it has no stored value and no children. The regression test covers the public iteration behavior with the minimal failing example.

## Verification

```sh
nix develop -c pnpm vitest run packages/effect/test/Trie.test.ts
nix develop -c pnpm lint
nix develop -c pnpm check
git diff --check
```

## Related

Closes #7773
Closes EFF-1106
