### PR TITLE
fix(Order): retain finite criteria across comparisons

### DIFF
--- a/.changeset/order-consumed-criteria.md
+++ b/.changeset/order-consumed-criteria.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Order.combineAll` consuming one-shot iterables after the first comparison.

--- a/packages/effect/src/Order.ts
+++ b/packages/effect/src/Order.ts
@@ -368,6 +368,7 @@ export function alwaysEqual<A>(): Order<A> {
  *
  * Applies orders in iteration order and short-circuits on the first non-zero
  * result. It returns `0` only if all orders return `0`.
+ * The collection is materialized when the order is created, so it must be finite.
  *
  * **Example** (Combining multiple Orders)
  *
@@ -397,9 +398,10 @@ export function alwaysEqual<A>(): Order<A> {
  * @since 2.0.0
  */
 export function combineAll<A>(collection: Iterable<Order<A>>): Order<A> {
+  const orders = Array.from(collection)
   return make((a1, a2) => {
     let out: Ordering = 0
-    for (const O of collection) {
+    for (const O of orders) {
       out = O(a1, a2)
       if (out !== 0) {
         return out

--- a/packages/effect/test/Order.test.ts
+++ b/packages/effect/test/Order.test.ts
@@ -131,6 +131,12 @@ describe("Order", () => {
     deepStrictEqual(max(first, second), first)
   })
 
+  it("combineAll reuses finite criteria across comparisons", () => {
+    const O = Order.combineAll([Order.Number].values())
+    strictEqual(O(1, 2), -1)
+    strictEqual(O(1, 2), -1)
+  })
+
   it("combine", () => {
     type T = [number, string]
     const tuples: Array<T> = [


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`Order.combineAll` reused its input `Iterable` for every comparison. One-shot iterators were exhausted after the first call, so later comparisons incorrectly returned equality.

Materialize the finite criteria once when constructing the combined order, then reuse that snapshot. `Order.makeReducer().combineAll` delegates to the same implementation.

Includes a focused regression test for repeated comparisons with an array iterator.

## Verification

- `nix develop -c pnpm vitest run packages/effect/test/Order.test.ts`
- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm jsdocs --check`
- `nix develop -c pnpm lint`
- `nix develop -c pnpm check`
- `git diff --check`

## Related

Closes EFF-1110
Closes #7781
