### PR TITLE
fix(Equal): preserve NaN equality in floating-point typed arrays

### DIFF
--- a/.changeset/equal-typed-array-nan.md
+++ b/.changeset/equal-typed-array-nan.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Equal.equals` to treat matching `NaN` elements in floating-point typed arrays as equal, consistent with ordinary arrays. This also allows `HashSet` lookups using equivalent copies of these typed arrays.

--- a/.changeset/equal-typed-array-nan.md
+++ b/.changeset/equal-typed-array-nan.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix `Equal.equals` to treat matching `NaN` elements in floating-point typed arrays as equal, consistent with ordinary arrays. This also allows `HashSet` lookups using equivalent copies of these typed arrays.
+Preserve `NaN` equality when comparing floating-point typed arrays.

--- a/packages/effect/src/Equal.ts
+++ b/packages/effect/src/Equal.ts
@@ -330,7 +330,7 @@ function compareTypedArrays(self: Uint8Array, that: Uint8Array): boolean {
     return false
   }
   for (let i = 0; i < self.length; i++) {
-    if (self[i] !== that[i]) {
+    if (self[i] !== that[i] && !(Number.isNaN(self[i]) && Number.isNaN(that[i]))) {
       return false
     }
   }

--- a/packages/effect/src/Equal.ts
+++ b/packages/effect/src/Equal.ts
@@ -330,7 +330,7 @@ function compareTypedArrays(self: Uint8Array, that: Uint8Array): boolean {
     return false
   }
   for (let i = 0; i < self.length; i++) {
-    if (self[i] !== that[i] && !(Number.isNaN(self[i]) && Number.isNaN(that[i]))) {
+    if (!compareBoth(self[i], that[i])) {
       return false
     }
   }

--- a/packages/effect/test/Equal.test.ts
+++ b/packages/effect/test/Equal.test.ts
@@ -2,7 +2,6 @@ import { assert } from "@effect/vitest"
 import * as Equal from "effect/Equal"
 import * as Hash from "effect/Hash"
 import * as HashMap from "effect/HashMap"
-import * as HashSet from "effect/HashSet"
 import * as Option from "effect/Option"
 import { describe, expect, it } from "vitest"
 
@@ -311,72 +310,11 @@ describe("Equal.equals", () => {
 
   describe("typed arrays", () => {
     for (const TypedArray of [Float32Array, Float64Array]) {
-      describe(TypedArray.name, () => {
-        it.each([false, true])("compares NaN copies (reversed: %s)", (reversed) => {
-          const original = new TypedArray([1, NaN, 3])
-          const copy = new TypedArray(original)
-          assert.isTrue(reversed ? Equal.equals(copy, original) : Equal.equals(original, copy))
-        })
-
-        it("compares NaN in a copied offset view", () => {
-          const view = new TypedArray([99, 1, NaN, 42]).subarray(1, 3)
-          const copy = new TypedArray(view)
-          assert.isAbove(view.byteOffset, 0)
-          assert.isTrue(Equal.equals(view, copy))
-        })
-
-        it("compares NaN copies nested in records and arrays", () => {
-          const original = new TypedArray([1, NaN])
-          const copy = new TypedArray(original)
-          assert.isTrue(Equal.equals({ values: [original] }, { values: [copy] }))
-        })
-
-        it("finds a NaN copy in a HashSet", () => {
-          const original = new TypedArray([1, NaN])
-          const copy = new TypedArray(original)
-          assert.isTrue(HashSet.has(HashSet.make(original), copy))
-        })
-
-        it("preserves NaN hashes, reflexivity, and ordinary-array equality", () => {
-          const original = new TypedArray([1, NaN])
-          const copy = new TypedArray(original)
-          assert.strictEqual(Hash.hash(original), Hash.hash(copy))
-          assert.isTrue(Equal.equals(original, original))
-          assert.isTrue(Equal.equals(Array.from(original), Array.from(copy)))
-        })
-
-        it.each([
-          { name: "finite", left: [1, 2], right: [1, 2], equal: true },
-          { name: "signed zero", left: [-0], right: [0], equal: true },
-          { name: "infinities", left: [Infinity, -Infinity], right: [Infinity, -Infinity], equal: true },
-          { name: "empty", left: [], right: [], equal: true },
-          { name: "unequal finite", left: [1], right: [2], equal: false },
-          { name: "opposite infinities", left: [Infinity], right: [-Infinity], equal: false },
-          { name: "NaN versus zero", left: [NaN], right: [0], equal: false },
-          { name: "NaN versus infinity", left: [NaN], right: [Infinity], equal: false },
-          { name: "length", left: [1], right: [1, 2], equal: false },
-          { name: "order", left: [1, 2], right: [2, 1], equal: false }
-        ])("preserves $name comparisons", ({ equal, left, right }) => {
-          assert.strictEqual(Equal.equals(new TypedArray(left), new TypedArray(right)), equal)
-          assert.strictEqual(Equal.equals(new TypedArray(right), new TypedArray(left)), equal)
-        })
+      it(`compares NaN values in ${TypedArray.name} copies`, () => {
+        const original = new TypedArray([NaN])
+        expect(Equal.equals(original, new TypedArray(original))).toBe(true)
       })
     }
-
-    for (const TypedArray of [BigInt64Array, BigUint64Array]) {
-      it(`preserves ${TypedArray.name} comparisons`, () => {
-        assert.isTrue(Equal.equals(new TypedArray([1n, 2n]), new TypedArray([1n, 2n])))
-        assert.isFalse(Equal.equals(new TypedArray([1n, 2n]), new TypedArray([2n, 1n])))
-      })
-    }
-
-    it("preserves byte-array and DataView comparisons", () => {
-      const original = new Uint8Array([1, 2])
-      const copy = new Uint8Array(original)
-      assert.isTrue(Equal.equals(original, copy))
-      assert.isTrue(Equal.equals(new DataView(original.buffer), new DataView(copy.buffer)))
-      assert.isFalse(Equal.equals(original, new Uint8Array([2, 1])))
-    })
   })
 
   describe("DataView objects", () => {

--- a/packages/effect/test/Equal.test.ts
+++ b/packages/effect/test/Equal.test.ts
@@ -2,6 +2,7 @@ import { assert } from "@effect/vitest"
 import * as Equal from "effect/Equal"
 import * as Hash from "effect/Hash"
 import * as HashMap from "effect/HashMap"
+import * as HashSet from "effect/HashSet"
 import * as Option from "effect/Option"
 import { describe, expect, it } from "vitest"
 
@@ -305,6 +306,76 @@ describe("Equal.equals", () => {
 
     it("should compare invalid dates without throwing", () => {
       expect(Equal.equals(new Date(NaN), new Date(NaN))).toBe(true)
+    })
+  })
+
+  describe("typed arrays", () => {
+    for (const TypedArray of [Float32Array, Float64Array]) {
+      describe(TypedArray.name, () => {
+        it.each([false, true])("compares NaN copies (reversed: %s)", (reversed) => {
+          const original = new TypedArray([1, NaN, 3])
+          const copy = new TypedArray(original)
+          assert.isTrue(reversed ? Equal.equals(copy, original) : Equal.equals(original, copy))
+        })
+
+        it("compares NaN in a copied offset view", () => {
+          const view = new TypedArray([99, 1, NaN, 42]).subarray(1, 3)
+          const copy = new TypedArray(view)
+          assert.isAbove(view.byteOffset, 0)
+          assert.isTrue(Equal.equals(view, copy))
+        })
+
+        it("compares NaN copies nested in records and arrays", () => {
+          const original = new TypedArray([1, NaN])
+          const copy = new TypedArray(original)
+          assert.isTrue(Equal.equals({ values: [original] }, { values: [copy] }))
+        })
+
+        it("finds a NaN copy in a HashSet", () => {
+          const original = new TypedArray([1, NaN])
+          const copy = new TypedArray(original)
+          assert.isTrue(HashSet.has(HashSet.make(original), copy))
+        })
+
+        it("preserves NaN hashes, reflexivity, and ordinary-array equality", () => {
+          const original = new TypedArray([1, NaN])
+          const copy = new TypedArray(original)
+          assert.strictEqual(Hash.hash(original), Hash.hash(copy))
+          assert.isTrue(Equal.equals(original, original))
+          assert.isTrue(Equal.equals(Array.from(original), Array.from(copy)))
+        })
+
+        it.each([
+          { name: "finite", left: [1, 2], right: [1, 2], equal: true },
+          { name: "signed zero", left: [-0], right: [0], equal: true },
+          { name: "infinities", left: [Infinity, -Infinity], right: [Infinity, -Infinity], equal: true },
+          { name: "empty", left: [], right: [], equal: true },
+          { name: "unequal finite", left: [1], right: [2], equal: false },
+          { name: "opposite infinities", left: [Infinity], right: [-Infinity], equal: false },
+          { name: "NaN versus zero", left: [NaN], right: [0], equal: false },
+          { name: "NaN versus infinity", left: [NaN], right: [Infinity], equal: false },
+          { name: "length", left: [1], right: [1, 2], equal: false },
+          { name: "order", left: [1, 2], right: [2, 1], equal: false }
+        ])("preserves $name comparisons", ({ equal, left, right }) => {
+          assert.strictEqual(Equal.equals(new TypedArray(left), new TypedArray(right)), equal)
+          assert.strictEqual(Equal.equals(new TypedArray(right), new TypedArray(left)), equal)
+        })
+      })
+    }
+
+    for (const TypedArray of [BigInt64Array, BigUint64Array]) {
+      it(`preserves ${TypedArray.name} comparisons`, () => {
+        assert.isTrue(Equal.equals(new TypedArray([1n, 2n]), new TypedArray([1n, 2n])))
+        assert.isFalse(Equal.equals(new TypedArray([1n, 2n]), new TypedArray([2n, 1n])))
+      })
+    }
+
+    it("preserves byte-array and DataView comparisons", () => {
+      const original = new Uint8Array([1, 2])
+      const copy = new Uint8Array(original)
+      assert.isTrue(Equal.equals(original, copy))
+      assert.isTrue(Equal.equals(new DataView(original.buffer), new DataView(copy.buffer)))
+      assert.isFalse(Equal.equals(original, new Uint8Array([2, 1])))
     })
   })
 


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Copies of `Float32Array` and `Float64Array` values containing `NaN` compared unequal. Typed-array elements now use Effect's existing equality rules, which already treat `NaN` as equal to `NaN`.

The regression coverage is in `packages/effect/test/Equal.test.ts` and covers both floating-point typed-array constructors.

## Verification

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/Equal.test.ts` (129 passed)
- `pnpm check`

Closes #7785
Closes EFF-1112
