### PR TITLE
fix(SynchronizedRef): correct callback-only modifySomeEffect currying

### DIFF
--- a/.changeset/synchronized-ref-modify-some-effect-currying.md
+++ b/.changeset/synchronized-ref-modify-some-effect-currying.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix the curried `SynchronizedRef.modifySomeEffect` overload to accept only the callback, matching its existing runtime behavior. Replace `modifySomeEffect(fallback, pf)(ref)` with `modifySomeEffect(pf)(ref)`; the callback's tuple supplies the result whether or not the ref is updated. The obsolete fallback form is now rejected by TypeScript instead of being accepted and crashing at runtime.
+Fix the curried `SynchronizedRef.modifySomeEffect` overload to accept only the callback, matching its runtime behavior.

--- a/.changeset/synchronized-ref-modify-some-effect-currying.md
+++ b/.changeset/synchronized-ref-modify-some-effect-currying.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix the curried `SynchronizedRef.modifySomeEffect` overload to accept only the callback, matching its existing runtime behavior. Replace `modifySomeEffect(fallback, pf)(ref)` with `modifySomeEffect(pf)(ref)`; the callback's tuple supplies the result whether or not the ref is updated. The obsolete fallback form is now rejected by TypeScript instead of being accepted and crashing at runtime.

--- a/packages/effect/src/SynchronizedRef.ts
+++ b/packages/effect/src/SynchronizedRef.ts
@@ -368,7 +368,6 @@ export const modifySome: {
  */
 export const modifySomeEffect: {
   <A, B, R, E>(
-    fallback: B,
     pf: (a: A) => Effect.Effect<readonly [B, Option.Option<A>], E, R>
   ): (self: SynchronizedRef<A>) => Effect.Effect<B, E, R>
   <A, B, R, E>(

--- a/packages/effect/test/SynchronizedRef.modifySomeEffect.test.ts
+++ b/packages/effect/test/SynchronizedRef.modifySomeEffect.test.ts
@@ -1,65 +1,26 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Exit, Option, SubscriptionRef, SynchronizedRef } from "effect"
+import { Effect, Option, SynchronizedRef } from "effect"
 
-describe("SynchronizedRef.modifySomeEffect runtime controls", () => {
-  for (const update of [false, true]) {
-    const branch = update ? "Some" : "None"
-    const tuple = (value: number): readonly [string, Option.Option<number>] => [
-      `callback-${branch}`,
-      update ? Option.some(value + 1) : Option.none()
-    ]
-    const pf = (value: number) => Effect.succeed(tuple(value))
+describe("SynchronizedRef.modifySomeEffect", () => {
+  it.effect("supports callback-only currying", () =>
+    Effect.gen(function*() {
+      const ref = yield* SynchronizedRef.make(1)
+      const result = yield* SynchronizedRef.modifySomeEffect((value: number) =>
+        Effect.succeed(["updated", Option.some(value + 1)] as const)
+      )(ref)
 
-    for (const curried of [false, true]) {
-      it.effect(`control: SynchronizedRef ${curried ? "callback-only runtime" : "data-first"} ${branch}`, () =>
-        Effect.gen(function*() {
-          const ref = yield* SynchronizedRef.make(10)
-          let calls = 0
-          const counted = (value: number) => {
-            calls++
-            assert.strictEqual(value, 10)
-            return pf(value)
-          }
-          const effect = curried
-            ? SynchronizedRef.modifySomeEffect(counted)(ref)
-            : SynchronizedRef.modifySomeEffect(ref, counted)
-          assert.strictEqual(calls, 0)
-          assert.strictEqual(yield* effect, `callback-${branch}`)
-          assert.strictEqual(calls, 1)
-          assert.strictEqual(yield* SynchronizedRef.get(ref), update ? 11 : 10)
-        }))
+      assert.strictEqual(result, "updated")
+      assert.strictEqual(yield* SynchronizedRef.get(ref), 2)
+    }))
 
-      it.effect(`control: pure modifySome ${curried ? "curried" : "data-first"} ${branch}`, () =>
-        Effect.gen(function*() {
-          const ref = yield* SynchronizedRef.make(10)
-          const effect = curried ? ref.pipe(SynchronizedRef.modifySome(tuple)) : SynchronizedRef.modifySome(ref, tuple)
-          assert.strictEqual(yield* effect, `callback-${branch}`)
-          assert.strictEqual(yield* SynchronizedRef.get(ref), update ? 11 : 10)
-        }))
+  it.effect("preserves the value for Option.none", () =>
+    Effect.gen(function*() {
+      const ref = yield* SynchronizedRef.make(1)
+      const result = yield* SynchronizedRef.modifySomeEffect((_: number) =>
+        Effect.succeed(["unchanged", Option.none<number>()] as const)
+      )(ref)
 
-      it.effect(`control: SubscriptionRef ${curried ? "curried" : "data-first"} ${branch}`, () =>
-        Effect.gen(function*() {
-          const ref = yield* SubscriptionRef.make(10)
-          const effect = curried
-            ? ref.pipe(SubscriptionRef.modifySomeEffect(pf))
-            : SubscriptionRef.modifySomeEffect(ref, pf)
-          assert.strictEqual(yield* effect, `callback-${branch}`)
-          assert.strictEqual(yield* SubscriptionRef.get(ref), update ? 11 : 10)
-        }))
-    }
-  }
-
-  for (const curried of [false, true]) {
-    it.effect(`control: ${curried ? "callback-only runtime" : "data-first"} failure preserves state and releases permit`, () =>
-      Effect.gen(function*() {
-        const ref = yield* SynchronizedRef.make(10)
-        const pf = (_: number): Effect.Effect<readonly [string, Option.Option<number>], string> =>
-          Effect.fail("failure")
-        const effect = curried ? SynchronizedRef.modifySomeEffect(pf)(ref) : SynchronizedRef.modifySomeEffect(ref, pf)
-        assert.deepStrictEqual(yield* Effect.exit(effect), Exit.fail("failure"))
-        assert.strictEqual(yield* SynchronizedRef.get(ref), 10)
-        yield* SynchronizedRef.update(ref, (value) => value + 1)
-        assert.strictEqual(yield* SynchronizedRef.get(ref), 11)
-      }))
-  }
+      assert.strictEqual(result, "unchanged")
+      assert.strictEqual(yield* SynchronizedRef.get(ref), 1)
+    }))
 })

--- a/packages/effect/test/SynchronizedRef.modifySomeEffect.test.ts
+++ b/packages/effect/test/SynchronizedRef.modifySomeEffect.test.ts
@@ -1,0 +1,65 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Exit, Option, SubscriptionRef, SynchronizedRef } from "effect"
+
+describe("SynchronizedRef.modifySomeEffect runtime controls", () => {
+  for (const update of [false, true]) {
+    const branch = update ? "Some" : "None"
+    const tuple = (value: number): readonly [string, Option.Option<number>] => [
+      `callback-${branch}`,
+      update ? Option.some(value + 1) : Option.none()
+    ]
+    const pf = (value: number) => Effect.succeed(tuple(value))
+
+    for (const curried of [false, true]) {
+      it.effect(`control: SynchronizedRef ${curried ? "callback-only runtime" : "data-first"} ${branch}`, () =>
+        Effect.gen(function*() {
+          const ref = yield* SynchronizedRef.make(10)
+          let calls = 0
+          const counted = (value: number) => {
+            calls++
+            assert.strictEqual(value, 10)
+            return pf(value)
+          }
+          const effect = curried
+            ? SynchronizedRef.modifySomeEffect(counted)(ref)
+            : SynchronizedRef.modifySomeEffect(ref, counted)
+          assert.strictEqual(calls, 0)
+          assert.strictEqual(yield* effect, `callback-${branch}`)
+          assert.strictEqual(calls, 1)
+          assert.strictEqual(yield* SynchronizedRef.get(ref), update ? 11 : 10)
+        }))
+
+      it.effect(`control: pure modifySome ${curried ? "curried" : "data-first"} ${branch}`, () =>
+        Effect.gen(function*() {
+          const ref = yield* SynchronizedRef.make(10)
+          const effect = curried ? ref.pipe(SynchronizedRef.modifySome(tuple)) : SynchronizedRef.modifySome(ref, tuple)
+          assert.strictEqual(yield* effect, `callback-${branch}`)
+          assert.strictEqual(yield* SynchronizedRef.get(ref), update ? 11 : 10)
+        }))
+
+      it.effect(`control: SubscriptionRef ${curried ? "curried" : "data-first"} ${branch}`, () =>
+        Effect.gen(function*() {
+          const ref = yield* SubscriptionRef.make(10)
+          const effect = curried
+            ? ref.pipe(SubscriptionRef.modifySomeEffect(pf))
+            : SubscriptionRef.modifySomeEffect(ref, pf)
+          assert.strictEqual(yield* effect, `callback-${branch}`)
+          assert.strictEqual(yield* SubscriptionRef.get(ref), update ? 11 : 10)
+        }))
+    }
+  }
+
+  for (const curried of [false, true]) {
+    it.effect(`control: ${curried ? "callback-only runtime" : "data-first"} failure preserves state and releases permit`, () =>
+      Effect.gen(function*() {
+        const ref = yield* SynchronizedRef.make(10)
+        const pf = (_: number): Effect.Effect<readonly [string, Option.Option<number>], string> =>
+          Effect.fail("failure")
+        const effect = curried ? SynchronizedRef.modifySomeEffect(pf)(ref) : SynchronizedRef.modifySomeEffect(ref, pf)
+        assert.deepStrictEqual(yield* Effect.exit(effect), Exit.fail("failure"))
+        assert.strictEqual(yield* SynchronizedRef.get(ref), 10)
+        yield* SynchronizedRef.update(ref, (value) => value + 1)
+        assert.strictEqual(yield* SynchronizedRef.get(ref), 11)
+      }))
+  }
+})

--- a/packages/effect/typetest/SynchronizedRef.tst.ts
+++ b/packages/effect/typetest/SynchronizedRef.tst.ts
@@ -1,0 +1,46 @@
+import { Effect, Option, SubscriptionRef, SynchronizedRef } from "effect"
+import { describe, expect, it } from "tstyche"
+
+declare const ref: SynchronizedRef.SynchronizedRef<number>
+declare const subscription: SubscriptionRef.SubscriptionRef<number>
+declare const pf: (value: number) => Effect.Effect<readonly [string, Option.Option<number>], "failure", "dependency">
+declare const pure: (value: number) => readonly [string, Option.Option<number>]
+
+describe("SynchronizedRef.modifySomeEffect", () => {
+  it("regression: callback-only currying preserves result, error, and environment", () => {
+    const operation = SynchronizedRef.modifySomeEffect(pf)
+    expect(operation).type.toBe<
+      (self: SynchronizedRef.SynchronizedRef<number>) => Effect.Effect<string, "failure", "dependency">
+    >()
+    expect(ref.pipe(operation)).type.toBe<Effect.Effect<string, "failure", "dependency">>()
+  })
+
+  it("regression: infers the callback tuple without a fallback", () => {
+    const result = ref.pipe(
+      SynchronizedRef.modifySomeEffect((value: number) => Effect.succeed(["result", Option.some(value + 1)] as const))
+    )
+    expect(result).type.toBe<Effect.Effect<"result">>()
+  })
+
+  it("regression: rejects the obsolete fallback call", () => {
+    expect(SynchronizedRef.modifySomeEffect).type.not.toBeCallableWith("fallback", pf)
+  })
+
+  it("control: data-first preserves result, error, and environment", () => {
+    expect(SynchronizedRef.modifySomeEffect(ref, pf)).type.toBe<Effect.Effect<string, "failure", "dependency">>()
+  })
+
+  it("control: SubscriptionRef accepts callback-only currying", () => {
+    expect(subscription.pipe(SubscriptionRef.modifySomeEffect(pf))).type.toBe<
+      Effect.Effect<string, "failure", "dependency">
+    >()
+    expect(SubscriptionRef.modifySomeEffect(subscription, pf)).type.toBe<
+      Effect.Effect<string, "failure", "dependency">
+    >()
+  })
+
+  it("control: pure modifySome accepts callback-only currying", () => {
+    expect(ref.pipe(SynchronizedRef.modifySome(pure))).type.toBe<Effect.Effect<string>>()
+    expect(SynchronizedRef.modifySome(ref, pure)).type.toBe<Effect.Effect<string>>()
+  })
+})

--- a/packages/effect/typetest/SynchronizedRef.tst.ts
+++ b/packages/effect/typetest/SynchronizedRef.tst.ts
@@ -1,10 +1,8 @@
-import { Effect, Option, SubscriptionRef, SynchronizedRef } from "effect"
+import { Effect, Option, SynchronizedRef } from "effect"
 import { describe, expect, it } from "tstyche"
 
 declare const ref: SynchronizedRef.SynchronizedRef<number>
-declare const subscription: SubscriptionRef.SubscriptionRef<number>
 declare const pf: (value: number) => Effect.Effect<readonly [string, Option.Option<number>], "failure", "dependency">
-declare const pure: (value: number) => readonly [string, Option.Option<number>]
 
 describe("SynchronizedRef.modifySomeEffect", () => {
   it("regression: callback-only currying preserves result, error, and environment", () => {
@@ -28,19 +26,5 @@ describe("SynchronizedRef.modifySomeEffect", () => {
 
   it("control: data-first preserves result, error, and environment", () => {
     expect(SynchronizedRef.modifySomeEffect(ref, pf)).type.toBe<Effect.Effect<string, "failure", "dependency">>()
-  })
-
-  it("control: SubscriptionRef accepts callback-only currying", () => {
-    expect(subscription.pipe(SubscriptionRef.modifySomeEffect(pf))).type.toBe<
-      Effect.Effect<string, "failure", "dependency">
-    >()
-    expect(SubscriptionRef.modifySomeEffect(subscription, pf)).type.toBe<
-      Effect.Effect<string, "failure", "dependency">
-    >()
-  })
-
-  it("control: pure modifySome accepts callback-only currying", () => {
-    expect(ref.pipe(SynchronizedRef.modifySome(pure))).type.toBe<Effect.Effect<string>>()
-    expect(SynchronizedRef.modifySome(ref, pure)).type.toBe<Effect.Effect<string>>()
   })
 })


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`SynchronizedRef.modifySomeEffect` declared its curried form as `(fallback, pf)`, but its `dual(2)` runtime accepts the callback alone. Remove the obsolete fallback parameter so `modifySomeEffect(pf)(ref)` is both type-safe and consistent with the runtime.

The focused type tests cover result, error, and environment inference as well as rejection of the old fallback form. Runtime tests cover the `Some` and `None` branches.

## Verification

- `pnpm test-types SynchronizedRef.tst.ts`
- `pnpm test --run packages/effect/test/SynchronizedRef.modifySomeEffect.test.ts --maxWorkers=1 --no-file-parallelism`
- `pnpm lint-fix`
- `pnpm check`

## Related

Closes #7789

Closes EFF-1114
