### PR TITLE
fix(Schema): preserve ArrayEnsure element branches and encoding cardinality

### DIFF
--- a/.changeset/array-ensure-array-elements.md
+++ b/.changeset/array-ensure-array-elements.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Schema.ArrayEnsure` to preserve array-valued element branches and outer-array encoding cardinality.

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -4530,14 +4530,7 @@ export function ArrayEnsure<S extends Constraint>(schema: S): ArrayEnsure<S> {
       encode: ([value]) => value
     })
   )(schema)
-  const nonSingleton = many.pipe(decodeTo(ArraySchema(Unknown), {
-    decode: SchemaGetter.passthrough(),
-    encode: SchemaGetter.checkEffect((array) =>
-      Effect.succeed(array.length !== 1 || "Expected an array with a length other than 1")
-    )
-  }))
-  const normalized = Union([one, nonSingleton]).pipe(decodeTo(to))
-  return make(normalized.ast, { from: Union([schema, many]), to })
+  return make(Union([one, many]).pipe(decodeTo(to)).ast, { from: Union([schema, many]), to })
 }
 /**
  * Type-level representation returned by {@link UniqueArray}.

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -4521,13 +4521,23 @@ export interface ArrayEnsure<S extends Constraint> extends decodeTo<$Array<toTyp
  * @since 3.10.0
  */
 export function ArrayEnsure<S extends Constraint>(schema: S): ArrayEnsure<S> {
-  return Union([schema, ArraySchema(schema)]).pipe(decodeTo(
-    ArraySchema(toType(schema)),
+  const many = ArraySchema(schema)
+  const to = ArraySchema(toType(schema))
+  const one = decodeTo(
+    Tuple([Unknown]),
     SchemaTransformation.transform({
-      decode: Arr.ensure,
-      encode: (array) => array.length === 1 ? array[0] : array
+      decode: (value) => [value] as const,
+      encode: ([value]) => value
     })
-  ))
+  )(schema)
+  const nonSingleton = many.pipe(decodeTo(ArraySchema(Unknown), {
+    decode: SchemaGetter.passthrough(),
+    encode: SchemaGetter.checkEffect((array) =>
+      Effect.succeed(array.length !== 1 || "Expected an array with a length other than 1")
+    )
+  }))
+  const normalized = Union([one, nonSingleton]).pipe(decodeTo(to))
+  return make(normalized.ast, { from: Union([schema, many]), to })
 }
 /**
  * Type-level representation returned by {@link UniqueArray}.

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -1166,6 +1166,11 @@ Expected no excess property
     deepStrictEqual(Schema.decodeSync(schema)(encoded), [[1, 2]])
   })
 
+  it("ArrayEnsure preserves outer-array encoding", () => {
+    const schema = Schema.ArrayEnsure(Schema.fromJsonString(Schema.Unknown))
+    deepStrictEqual(Schema.encodeSync(schema)([1, 2]), ["1", "2"])
+  })
+
   describe("NonEmptyArray", () => {
     it("should expose the element schema via .value", () => {
       const schema = Schema.NonEmptyArray(Schema.String)

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -1159,6 +1159,13 @@ Expected no excess property
     await encoding.succeed([1, 2], ["1", "2"])
   })
 
+  it("ArrayEnsure roundtrips array-valued elements", () => {
+    const schema = Schema.ArrayEnsure(Schema.Tuple([Schema.Number, Schema.Number]))
+    const encoded = Schema.encodeSync(schema)([[1, 2]])
+    deepStrictEqual(encoded, [1, 2])
+    deepStrictEqual(Schema.decodeSync(schema)(encoded), [[1, 2]])
+  })
+
   describe("NonEmptyArray", () => {
     it("should expose the element schema via .value", () => {
       const schema = Schema.NonEmptyArray(Schema.String)


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

`Schema.ArrayEnsure` now preserves whether decoding selected the single-element branch or the outer-array branch before normalization. Singleton array-valued elements therefore encode and decode consistently.

Encoding also selects branches by outer cardinality. Multi-element and empty arrays use the array branch even when a broad element transformation could encode the whole array.

The regression coverage is consolidated in `packages/effect/test/schema/Schema.test.ts`.

## Verification

```sh
pnpm lint-fix
pnpm test --run packages/effect/test/schema/Schema.test.ts --maxWorkers=1 --no-file-parallelism
pnpm check
```

Closes #7795
Closes EFF-1117
