### PR TITLE
fix(cli): include inherited shared flags in descendant completions

### DIFF
--- a/.changeset/cli-completion-shared-flags.md
+++ b/.changeset/cli-completion-shared-flags.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Include inherited shared flags in descendant CLI completions.

--- a/packages/effect/src/unstable/cli/internal/completions/descriptor.ts
+++ b/packages/effect/src/unstable/cli/internal/completions/descriptor.ts
@@ -70,18 +70,25 @@ const toArgumentType = (single: Param.Single<"argument", unknown>): Completions.
 // ---------------------------------------------------------------------------
 
 /** @internal */
-export const fromCommand = (cmd: Command.Any): Completions.CommandDescriptor => {
+export const fromCommand = (
+  cmd: Command.Any,
+  inheritedFlags: ReadonlyArray<Param.AnyFlag> = []
+): Completions.CommandDescriptor => {
   const impl = toImpl(cmd)
   const config = impl.config
 
   const flags: Array<Completions.FlagDescriptor> = []
-  for (const flag of config.flags) {
+  const seen = new Set<string>()
+  // Match help's precedence: local flags first, then ancestors root to leaf.
+  for (const [index, flag] of [...config.flags, ...inheritedFlags].entries()) {
     const singles = Param.extractSingleParams(flag)
     for (const single of singles) {
       if (single.kind !== "flag") continue
       // Omit hidden flags from completion scripts so tab-completion in the
       // shell does not advertise flags that are absent from --help.
       if (single.hidden) continue
+      if (index >= config.flags.length && seen.has(single.name)) continue
+      seen.add(single.name)
       flags.push({
         name: single.name,
         aliases: single.aliases,
@@ -108,12 +115,13 @@ export const fromCommand = (cmd: Command.Any): Completions.CommandDescriptor => 
   }
 
   const subcommands: Array<Completions.CommandDescriptor> = []
+  const sharedFlags = [...inheritedFlags, ...impl.contextConfig.flags]
   for (const group of cmd.subcommands) {
     for (const subcommand of group.commands) {
       // Omit unlisted subcommands from completion scripts so tab-completion in
       // the shell does not advertise commands that are absent from --help.
       if (subcommand.unlisted) continue
-      subcommands.push(fromCommand(subcommand))
+      subcommands.push(fromCommand(subcommand, sharedFlags))
     }
   }
 

--- a/packages/effect/test/unstable/cli/Help.test.ts
+++ b/packages/effect/test/unstable/cli/Help.test.ts
@@ -575,6 +575,28 @@ describe("Command help output", () => {
       expect(chatHelp.some((line) => String(line).includes("--topic"))).toBe(true)
     }).pipe(Effect.provide(TestLayer)))
 
+  it.effect("includes inherited shared flags in subcommand completions", () =>
+    Effect.gen(function*() {
+      const root = Command.make("tool").pipe(
+        Command.withSharedFlags({
+          workspace: Flag.string("workspace").pipe(Flag.withAlias("w"))
+        }),
+        Command.withSubcommands([
+          Command.make("chat", {
+            topic: Flag.string("topic").pipe(Flag.withAlias("t"))
+          })
+        ])
+      )
+      const runRoot = Command.runWith(root, { version: "1.0.0" })
+
+      yield* runRoot(["--completions", "bash"])
+
+      const completionScript = (yield* TestConsole.logLines).join("\n")
+      const chatCompletions = completionScript.slice(completionScript.indexOf("_tool_chat()"))
+      expect(chatCompletions).toContain(`_filtered_flags+=" --topic -t"`)
+      expect(chatCompletions).toContain(`_filtered_flags+=" --workspace -w"`)
+    }).pipe(Effect.provide(TestLayer)))
+
   it.effect("renders grouped subcommands", () =>
     Effect.gen(function*() {
       const ungrouped = Command.make("ungrouped").pipe(


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Descendant shell-completion contexts omitted ancestor shared flags even though parsing and help accepted them. This change carries shared flags through descriptor extraction while keeping local flags first and excluding hidden or non-shared parent flags.

The regression test exercises generated Bash completions through `Command.runWith` and checks that a child command offers both its local flag and the root `--workspace`/`-w` shared flag.

## Verification

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/effect/test/unstable/cli/Help.test.ts packages/effect/test/unstable/cli/completions/descriptor.test.ts packages/effect/test/unstable/cli/completions/completions.test.ts packages/effect/test/unstable/cli/Command.test.ts`
- `nix develop -c pnpm check`
- `git diff --check`

Closes #7803
Closes EFF-1121
