### PR TITLE
fix(ai): preserve string tool results

### DIFF
--- a/.changeset/plain-tool-results.md
+++ b/.changeset/plain-tool-results.md
@@ -1,0 +1,7 @@
+---
+"@effect/ai-openai": patch
+"@effect/ai-anthropic": patch
+"@effect/ai-openrouter": patch
+---
+
+Preserve plain-text client tool results when encoding provider requests.

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -962,7 +962,7 @@ const prepareMessages = Effect.fnUntraced(
                   content.push({
                     type: "tool_result",
                     tool_use_id: part.id,
-                    content: JSON.stringify(part.result),
+                    content: Predicate.isString(part.result) ? part.result : JSON.stringify(part.result),
                     is_error: part.isFailure,
                     cache_control: cacheControl
                   })

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -962,7 +962,7 @@ const prepareMessages = Effect.fnUntraced(
                   content.push({
                     type: "tool_result",
                     tool_use_id: part.id,
-                    content: Predicate.isString(part.result) ? part.result : JSON.stringify(part.result),
+                    content: typeof part.result === "string" ? part.result : JSON.stringify(part.result),
                     is_error: part.isFailure,
                     cache_control: cacheControl
                   })

--- a/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
+++ b/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
@@ -437,6 +437,79 @@ describe("AnthropicLanguageModel", () => {
   })
 
   describe("generateText", () => {
+    it.effect("preserves string tool results", () =>
+      Effect.gen(function*() {
+        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined = undefined
+        const layer = AnthropicClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) => {
+              capturedRequest = request
+              return Effect.succeed(jsonResponse(request, {
+                id: "msg_test_1",
+                type: "message",
+                role: "assistant",
+                model: "claude-sonnet-4-20250514",
+                content: [{ type: "text", text: "Done" }],
+                stop_reason: "end_turn",
+                stop_sequence: null,
+                usage: {
+                  cache_creation: null,
+                  cache_creation_input_tokens: null,
+                  cache_read_input_tokens: null,
+                  inference_geo: null,
+                  input_tokens: 10,
+                  output_tokens: 5,
+                  service_tier: null
+                }
+              }))
+            })
+          ))
+        )
+
+        yield* LanguageModel.generateText({
+          prompt: Prompt.make([
+            { role: "user", content: "Use the tool" },
+            {
+              role: "assistant",
+              content: [Prompt.toolCallPart({
+                id: "call_text",
+                name: "text_tool",
+                params: {},
+                providerExecuted: false
+              })]
+            },
+            {
+              role: "tool",
+              content: [Prompt.toolResultPart({
+                id: "call_text",
+                name: "text_tool",
+                result: "PLAIN_TEXT_SENTINEL\n",
+                isFailure: false,
+                providerExecuted: false
+              })]
+            }
+          ]),
+          disableToolCallResolution: true
+        }).pipe(
+          Effect.provide(AnthropicLanguageModel.model("claude-sonnet-4-20250514")),
+          Effect.provide(layer)
+        )
+
+        assert.isDefined(capturedRequest)
+        if (capturedRequest === undefined) {
+          return
+        }
+
+        const body = yield* getRequestBody(capturedRequest)
+        const toolResult = body.messages
+          .flatMap((message: any) => Array.isArray(message.content) ? message.content : [])
+          .find((block: any) => block.type === "tool_result")
+
+        assert.isDefined(toolResult)
+        assert.strictEqual(toolResult.content, "PLAIN_TEXT_SENTINEL\n")
+      }))
+
     it.effect("encodes dynamic tools", () =>
       Effect.gen(function*() {
         let capturedRequest: HttpClientRequest.HttpClientRequest | undefined = undefined

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -1193,7 +1193,7 @@ const prepareMessages = Effect.fnUntraced(
             messages.push({
               type: "function_call_output",
               call_id: part.id,
-              output: JSON.stringify(part.result),
+              output: Predicate.isString(part.result) ? part.result : JSON.stringify(part.result),
               ...(Predicate.isNotNull(status) ? { status } : {})
             })
           }

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -1193,7 +1193,7 @@ const prepareMessages = Effect.fnUntraced(
             messages.push({
               type: "function_call_output",
               call_id: part.id,
-              output: Predicate.isString(part.result) ? part.result : JSON.stringify(part.result),
+              output: typeof part.result === "string" ? part.result : JSON.stringify(part.result),
               ...(Predicate.isNotNull(status) ? { status } : {})
             })
           }

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -534,6 +534,46 @@ describe("OpenAiLanguageModel", () => {
             strictEqual(toolOutput.output, JSON.stringify({ output: "result" }))
           }).pipe(Effect.provide([makeTestLayer(), TestToolkitLayer])))
 
+        it.effect("preserves string tool results", () =>
+          Effect.gen(function*() {
+            yield* LanguageModel.generateText({
+              prompt: Prompt.make([
+                { role: "user", content: "Use the tool" },
+                {
+                  role: "assistant",
+                  content: [
+                    Prompt.toolCallPart({
+                      id: "call_text",
+                      name: "TestTool",
+                      params: { input: "test" },
+                      providerExecuted: false
+                    })
+                  ]
+                },
+                {
+                  role: "tool",
+                  content: [
+                    Prompt.toolResultPart({
+                      id: "call_text",
+                      name: "TestTool",
+                      isFailure: false,
+                      result: "PLAIN_TEXT_SENTINEL\n",
+                      providerExecuted: false
+                    })
+                  ]
+                }
+              ]),
+              toolkit: TestToolkit
+            }).pipe(Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")))
+
+            const requests = yield* MockHttpClient.requests
+            const body = yield* getRequestBody(requests[0])
+            const toolOutput = body.input.find((item: any) => item.type === "function_call_output")
+
+            assert.isDefined(toolOutput)
+            strictEqual(toolOutput.output, "PLAIN_TEXT_SENTINEL\n")
+          }).pipe(Effect.provide([makeTestLayer(), TestToolkitLayer])))
+
         it.effect("emits only the specialized output for apply_patch results", () =>
           Effect.gen(function*() {
             const toolkit = Toolkit.make(OpenAiTool.ApplyPatch({}))

--- a/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
+++ b/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
@@ -899,7 +899,7 @@ const prepareMessages = Effect.fnUntraced(
             messages.push({
               role: "tool",
               tool_call_id: part.id,
-              content: Predicate.isString(part.result) ? part.result : JSON.stringify(part.result)
+              content: typeof part.result === "string" ? part.result : JSON.stringify(part.result)
             })
           }
 

--- a/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
+++ b/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
@@ -899,7 +899,7 @@ const prepareMessages = Effect.fnUntraced(
             messages.push({
               role: "tool",
               tool_call_id: part.id,
-              content: JSON.stringify(part.result)
+              content: Predicate.isString(part.result) ? part.result : JSON.stringify(part.result)
             })
           }
 

--- a/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
+++ b/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
@@ -171,6 +171,42 @@ describe("OpenRouterLanguageModel", () => {
             }])
           }).pipe(Effect.provide(makeTestLayer())))
       })
+
+      it.effect("preserves string tool results", () =>
+        Effect.gen(function*() {
+          yield* LanguageModel.generateText({
+            prompt: Prompt.make([
+              { role: "user", content: "Use the tool" },
+              {
+                role: "assistant",
+                content: [Prompt.toolCallPart({
+                  id: "call_text",
+                  name: "text_tool",
+                  params: {},
+                  providerExecuted: false
+                })]
+              },
+              {
+                role: "tool",
+                content: [Prompt.toolResultPart({
+                  id: "call_text",
+                  name: "text_tool",
+                  result: "PLAIN_TEXT_SENTINEL\n",
+                  isFailure: false,
+                  providerExecuted: false
+                })]
+              }
+            ]),
+            disableToolCallResolution: true
+          }).pipe(Effect.provide(OpenRouterLanguageModel.model("google/gemini-2.5-flash")))
+
+          const requests = yield* MockHttpClient.requests
+          const body = yield* getRequestBody(requests[0])
+          const toolResult = body.messages.find((message: any) => message.role === "tool")
+
+          assert.isDefined(toolResult)
+          strictEqual(toolResult.content, "PLAIN_TEXT_SENTINEL\n")
+        }).pipe(Effect.provide(makeTestLayer())))
     })
 
     describe("tool preparation", () => {


### PR DESCRIPTION
## Summary

- Preserve plain-string client tool results in OpenAI, Anthropic, and OpenRouter request payloads.
- Standardize the relevant provider encoder branches on `typeof part.result === "string"`, matching the existing OpenAI Compat behavior.
- Keep JSON serialization as the fallback for structured results.
- Add request-capture regressions and a patch changeset for all three affected provider packages.

## Verification

- `nix develop -c pnpm test --run packages/ai/openai/test/OpenAiLanguageModel.test.ts packages/ai/anthropic/test/AnthropicLanguageModel.test.ts packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts` (105 passed)
- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`

Closes EFF-1105
