### PR TITLE
Add manual Queue taker flushing APIs

### DIFF
--- a/.changeset/queue-manual-flush.md
+++ b/.changeset/queue-manual-flush.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Queue.flush` and `Queue.flushUnsafe` for manually resuming fibers waiting on `Queue.await` without completing the queue.

--- a/.changeset/queue-manual-flush.md
+++ b/.changeset/queue-manual-flush.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Add `Queue.flush` and `Queue.flushUnsafe` for manually resuming fibers waiting on `Queue.await` without completing the queue.
+Add `Queue.flush` and `Queue.flushUnsafe` for manually releasing pending takers, including after synchronous offers.

--- a/packages/effect/src/Queue.ts
+++ b/packages/effect/src/Queue.ts
@@ -1574,13 +1574,37 @@ export const takeUnsafe = <A, E>(self: Dequeue<A, E>): Exit<A, E> | undefined =>
 /**
  * Manually releases current queue takers synchronously.
  *
+ * **When to use**
+ *
+ * Use when synchronous offers should release waiting consumers immediately
+ * instead of waiting for the scheduled release task.
+ *
  * **Details**
  *
  * This immediately runs the queue's taker-release pass instead of waiting for
  * its scheduled task. It does not complete the queue or resume fibers waiting
  * on `Queue.await`.
  *
- * @category completion
+ * **Example** (Releasing a waiting taker synchronously)
+ *
+ * ```ts import.meta.vitest
+ * import { Effect, Fiber, Queue } from "effect"
+ *
+ * const program = Effect.gen(function*() {
+ *   const queue = yield* Queue.unbounded<number>()
+ *   const taker = yield* Queue.take(queue).pipe(Effect.forkChild)
+ *   yield* Effect.yieldNow
+ *
+ *   Queue.offerUnsafe(queue, 1)
+ *   Queue.flushUnsafe(queue)
+ *
+ *   return yield* Fiber.join(taker)
+ * })
+ *
+ * await Effect.runPromise(program) // => 1
+ * ```
+ *
+ * @category offering
  * @since 4.0.0
  */
 export const flushUnsafe = <A, E>(self: Enqueue<A, E>): void => releaseTakers(self)
@@ -1588,13 +1612,37 @@ export const flushUnsafe = <A, E>(self: Enqueue<A, E>): void => releaseTakers(se
 /**
  * Manually releases current queue takers.
  *
+ * **When to use**
+ *
+ * Use when synchronous offers should release waiting consumers through an
+ * `Effect` instead of waiting for the scheduled release task.
+ *
  * **Details**
  *
  * This immediately runs the queue's taker-release pass instead of waiting for
  * its scheduled task. It does not complete the queue or resume fibers waiting
  * on `Queue.await`.
  *
- * @category completion
+ * **Example** (Releasing a waiting taker)
+ *
+ * ```ts import.meta.vitest
+ * import { Effect, Fiber, Queue } from "effect"
+ *
+ * const program = Effect.gen(function*() {
+ *   const queue = yield* Queue.unbounded<number>()
+ *   const taker = yield* Queue.take(queue).pipe(Effect.forkChild)
+ *   yield* Effect.yieldNow
+ *
+ *   Queue.offerUnsafe(queue, 1)
+ *   yield* Queue.flush(queue)
+ *
+ *   return yield* Fiber.join(taker)
+ * })
+ *
+ * await Effect.runPromise(program) // => 1
+ * ```
+ *
+ * @category offering
  * @since 4.0.0
  */
 export const flush = <A, E>(self: Enqueue<A, E>): Effect<void> => internalEffect.sync(() => flushUnsafe(self))
@@ -1867,7 +1915,6 @@ const exitFailDone = core.exitFail(core.Done()) as Failure<never, Done>
 const exitInterrupt = internalEffect.exitInterrupt() as Failure<never, never>
 
 const releaseTakers = <A, E>(self: Enqueue<A, E>) => {
-  self.scheduleRunning = false
   if (self.state._tag === "Done" || self.state.takers.size === 0) {
     return
   }
@@ -1885,7 +1932,10 @@ const scheduleReleaseTaker = <A, E>(self: Enqueue<A, E>) => {
     return
   }
   self.scheduleRunning = true
-  self.dispatcher.scheduleTask(() => releaseTakers(self), 0)
+  self.dispatcher.scheduleTask(() => {
+    self.scheduleRunning = false
+    releaseTakers(self)
+  }, 0)
 }
 
 const takeBetweenUnsafe = <A, E>(

--- a/packages/effect/src/Queue.ts
+++ b/packages/effect/src/Queue.ts
@@ -1572,40 +1572,32 @@ export const takeUnsafe = <A, E>(self: Dequeue<A, E>): Exit<A, E> | undefined =>
 }
 
 /**
- * Manually triggers all current queue awaiters synchronously.
+ * Manually releases current queue takers synchronously.
  *
  * **Details**
  *
- * This resumes all fibers currently waiting for the queue to complete. The queue
- * remains open, and fibers that call `Queue.await` afterward wait for a later
- * flush or for the queue to complete.
+ * This immediately runs the queue's taker-release pass instead of waiting for
+ * its scheduled task. It does not complete the queue or resume fibers waiting
+ * on `Queue.await`.
  *
  * @category completion
  * @since 4.0.0
  */
-export const flushUnsafe = <A, E>(self: Dequeue<A, E>): void => {
-  if (self.state._tag === "Done") {
-    return
-  }
-  for (const awaiter of self.state.awaiters) {
-    awaiter(internalEffect.exitVoid)
-  }
-  self.state.awaiters.clear()
-}
+export const flushUnsafe = <A, E>(self: Enqueue<A, E>): void => releaseTakers(self)
 
 /**
- * Manually triggers all current queue awaiters.
+ * Manually releases current queue takers.
  *
  * **Details**
  *
- * This resumes all fibers currently waiting for the queue to complete. The queue
- * remains open, and fibers that call `Queue.await` afterward wait for a later
- * flush or for the queue to complete.
+ * This immediately runs the queue's taker-release pass instead of waiting for
+ * its scheduled task. It does not complete the queue or resume fibers waiting
+ * on `Queue.await`.
  *
  * @category completion
  * @since 4.0.0
  */
-export const flush = <A, E>(self: Dequeue<A, E>): Effect<void> => internalEffect.sync(() => flushUnsafe(self))
+export const flush = <A, E>(self: Enqueue<A, E>): Effect<void> => internalEffect.sync(() => flushUnsafe(self))
 
 const await_ = <A, E>(self: Dequeue<A, E>): Effect<void, Exclude<E, Done>> =>
   internalEffect.callback<void, Exclude<E, Done>>((resume) => {

--- a/packages/effect/src/Queue.ts
+++ b/packages/effect/src/Queue.ts
@@ -1571,6 +1571,42 @@ export const takeUnsafe = <A, E>(self: Dequeue<A, E>): Exit<A, E> | undefined =>
   return undefined
 }
 
+/**
+ * Manually triggers all current queue awaiters synchronously.
+ *
+ * **Details**
+ *
+ * This resumes all fibers currently waiting for the queue to complete. The queue
+ * remains open, and fibers that call `Queue.await` afterward wait for a later
+ * flush or for the queue to complete.
+ *
+ * @category completion
+ * @since 4.0.0
+ */
+export const flushUnsafe = <A, E>(self: Dequeue<A, E>): void => {
+  if (self.state._tag === "Done") {
+    return
+  }
+  for (const awaiter of self.state.awaiters) {
+    awaiter(internalEffect.exitVoid)
+  }
+  self.state.awaiters.clear()
+}
+
+/**
+ * Manually triggers all current queue awaiters.
+ *
+ * **Details**
+ *
+ * This resumes all fibers currently waiting for the queue to complete. The queue
+ * remains open, and fibers that call `Queue.await` afterward wait for a later
+ * flush or for the queue to complete.
+ *
+ * @category completion
+ * @since 4.0.0
+ */
+export const flush = <A, E>(self: Dequeue<A, E>): Effect<void> => internalEffect.sync(() => flushUnsafe(self))
+
 const await_ = <A, E>(self: Dequeue<A, E>): Effect<void, Exclude<E, Done>> =>
   internalEffect.callback<void, Exclude<E, Done>>((resume) => {
     const awaiter = (effect: Effect<void, E>) => resume(Pull.catchDone(effect, () => internalEffect.exitVoid))

--- a/packages/effect/test/Queue.test.ts
+++ b/packages/effect/test/Queue.test.ts
@@ -446,7 +446,7 @@ describe("Queue", () => {
       assert.deepStrictEqual(yield* Fiber.join(fiber), Exit.fail("boom"))
     }))
 
-  it.effect("flushUnsafe releases current takers, not awaiters", () =>
+  it.effect("flushUnsafe releases a waiting taker after offerUnsafe without completing the queue", () =>
     Effect.gen(function*() {
       const queue = yield* Queue.unbounded<number>()
       const taker = yield* Queue.take(queue).pipe(Effect.forkChild)
@@ -463,7 +463,7 @@ describe("Queue", () => {
       yield* Queue.shutdown(queue)
     }))
 
-  it.effect("flush releases current takers, not awaiters", () =>
+  it.effect("flush releases a waiting taker after offerUnsafe without completing the queue", () =>
     Effect.gen(function*() {
       const queue = yield* Queue.unbounded<number>()
       const taker = yield* Queue.take(queue).pipe(Effect.forkChild)

--- a/packages/effect/test/Queue.test.ts
+++ b/packages/effect/test/Queue.test.ts
@@ -446,6 +446,34 @@ describe("Queue", () => {
       assert.deepStrictEqual(yield* Fiber.join(fiber), Exit.fail("boom"))
     }))
 
+  it.effect("flushUnsafe triggers current awaiters without closing the queue", () =>
+    Effect.gen(function*() {
+      const queue = yield* Queue.unbounded<number>()
+      const fiber = yield* Queue.await(queue).pipe(Effect.forkChild)
+      yield* Effect.yieldNow
+
+      Queue.flushUnsafe(queue)
+
+      assert.strictEqual(yield* Fiber.join(fiber), void 0)
+      assert.isTrue(yield* Queue.offer(queue, 1))
+      assert.strictEqual(yield* Queue.take(queue), 1)
+    }))
+
+  it.effect("flush triggers current awaiters but not future awaiters", () =>
+    Effect.gen(function*() {
+      const queue = yield* Queue.unbounded<number>()
+      const current = yield* Queue.await(queue).pipe(Effect.forkChild)
+      yield* Effect.yieldNow
+
+      yield* Queue.flush(queue)
+
+      assert.strictEqual(yield* Fiber.join(current), void 0)
+      const future = yield* Queue.await(queue).pipe(Effect.forkChild)
+      yield* Effect.yieldNow
+      assert.isUndefined(future.pollUnsafe())
+      yield* Queue.shutdown(queue)
+    }))
+
   it.effect("bounded 0 capacity", () =>
     Effect.gen(function*() {
       const queue = yield* Queue.bounded<number>(0)

--- a/packages/effect/test/Queue.test.ts
+++ b/packages/effect/test/Queue.test.ts
@@ -514,6 +514,42 @@ describe("Queue", () => {
       yield* Queue.shutdown(queue)
     }))
 
+  it.effect("flush is a no-op after shutdown", () =>
+    Effect.gen(function*() {
+      const queue = yield* Queue.unbounded<number>()
+      yield* Queue.shutdown(queue)
+
+      Queue.flushUnsafe(queue)
+      yield* Queue.flush(queue)
+
+      assert.isFalse(yield* Queue.offer(queue, 1))
+    }))
+
+  it.effect("flush keeps a buffered message when no taker is waiting", () =>
+    Effect.gen(function*() {
+      const queue = yield* Queue.unbounded<number>()
+      Queue.offerUnsafe(queue, 1)
+
+      yield* Queue.flush(queue)
+
+      assert.strictEqual(yield* Queue.take(queue), 1)
+    }))
+
+  it.effect("flushUnsafe preserves later offers when the queue is empty", () =>
+    Effect.gen(function*() {
+      const queue = yield* Queue.unbounded<number>()
+      const first = yield* Queue.take(queue).pipe(Effect.forkChild)
+      const second = yield* Queue.take(queue).pipe(Effect.forkChild)
+      yield* Effect.yieldNow
+
+      Queue.flushUnsafe(queue)
+      yield* Queue.offerAll(queue, [1, 2])
+
+      const values = yield* Effect.all([Fiber.join(first), Fiber.join(second)])
+      assert.deepStrictEqual(new Set(values), new Set([1, 2]))
+      yield* Queue.shutdown(queue)
+    }))
+
   it.effect("bounded 0 capacity", () =>
     Effect.gen(function*() {
       const queue = yield* Queue.bounded<number>(0)

--- a/packages/effect/test/Queue.test.ts
+++ b/packages/effect/test/Queue.test.ts
@@ -449,36 +449,34 @@ describe("Queue", () => {
   it.effect("flushUnsafe releases current takers, not awaiters", () =>
     Effect.gen(function*() {
       const queue = yield* Queue.unbounded<number>()
-      yield* Queue.take(queue).pipe(Effect.forkChild)
-      yield* Queue.await(queue).pipe(Effect.forkChild)
+      const taker = yield* Queue.take(queue).pipe(Effect.forkChild)
+      const awaiter = yield* Queue.await(queue).pipe(Effect.forkChild)
       yield* Effect.yieldNow
-      const state = queue.state
-      if (state._tag === "Done") return assert.fail("Expected an open queue")
-      assert.strictEqual(state.takers.size, 1)
-      assert.strictEqual(state.awaiters.size, 1)
+
+      Queue.offerUnsafe(queue, 1)
+      assert.isUndefined(taker.pollUnsafe())
 
       Queue.flushUnsafe(queue)
 
-      assert.strictEqual(state.takers.size, 0)
-      assert.strictEqual(state.awaiters.size, 1)
+      assert.deepStrictEqual(taker.pollUnsafe(), Exit.succeed(1))
+      assert.isUndefined(awaiter.pollUnsafe())
       yield* Queue.shutdown(queue)
     }))
 
   it.effect("flush releases current takers, not awaiters", () =>
     Effect.gen(function*() {
       const queue = yield* Queue.unbounded<number>()
-      yield* Queue.take(queue).pipe(Effect.forkChild)
-      yield* Queue.await(queue).pipe(Effect.forkChild)
+      const taker = yield* Queue.take(queue).pipe(Effect.forkChild)
+      const awaiter = yield* Queue.await(queue).pipe(Effect.forkChild)
       yield* Effect.yieldNow
-      const state = queue.state
-      if (state._tag === "Done") return assert.fail("Expected an open queue")
-      assert.strictEqual(state.takers.size, 1)
-      assert.strictEqual(state.awaiters.size, 1)
+
+      Queue.offerUnsafe(queue, 1)
+      assert.isUndefined(taker.pollUnsafe())
 
       yield* Queue.flush(queue)
 
-      assert.strictEqual(state.takers.size, 0)
-      assert.strictEqual(state.awaiters.size, 1)
+      assert.deepStrictEqual(taker.pollUnsafe(), Exit.succeed(1))
+      assert.isUndefined(awaiter.pollUnsafe())
       yield* Queue.shutdown(queue)
     }))
 

--- a/packages/effect/test/Queue.test.ts
+++ b/packages/effect/test/Queue.test.ts
@@ -446,31 +446,39 @@ describe("Queue", () => {
       assert.deepStrictEqual(yield* Fiber.join(fiber), Exit.fail("boom"))
     }))
 
-  it.effect("flushUnsafe triggers current awaiters without closing the queue", () =>
+  it.effect("flushUnsafe releases current takers, not awaiters", () =>
     Effect.gen(function*() {
       const queue = yield* Queue.unbounded<number>()
-      const fiber = yield* Queue.await(queue).pipe(Effect.forkChild)
+      yield* Queue.take(queue).pipe(Effect.forkChild)
+      yield* Queue.await(queue).pipe(Effect.forkChild)
       yield* Effect.yieldNow
+      const state = queue.state
+      if (state._tag === "Done") return assert.fail("Expected an open queue")
+      assert.strictEqual(state.takers.size, 1)
+      assert.strictEqual(state.awaiters.size, 1)
 
       Queue.flushUnsafe(queue)
 
-      assert.strictEqual(yield* Fiber.join(fiber), void 0)
-      assert.isTrue(yield* Queue.offer(queue, 1))
-      assert.strictEqual(yield* Queue.take(queue), 1)
+      assert.strictEqual(state.takers.size, 0)
+      assert.strictEqual(state.awaiters.size, 1)
+      yield* Queue.shutdown(queue)
     }))
 
-  it.effect("flush triggers current awaiters but not future awaiters", () =>
+  it.effect("flush releases current takers, not awaiters", () =>
     Effect.gen(function*() {
       const queue = yield* Queue.unbounded<number>()
-      const current = yield* Queue.await(queue).pipe(Effect.forkChild)
+      yield* Queue.take(queue).pipe(Effect.forkChild)
+      yield* Queue.await(queue).pipe(Effect.forkChild)
       yield* Effect.yieldNow
+      const state = queue.state
+      if (state._tag === "Done") return assert.fail("Expected an open queue")
+      assert.strictEqual(state.takers.size, 1)
+      assert.strictEqual(state.awaiters.size, 1)
 
       yield* Queue.flush(queue)
 
-      assert.strictEqual(yield* Fiber.join(current), void 0)
-      const future = yield* Queue.await(queue).pipe(Effect.forkChild)
-      yield* Effect.yieldNow
-      assert.isUndefined(future.pollUnsafe())
+      assert.strictEqual(state.takers.size, 0)
+      assert.strictEqual(state.awaiters.size, 1)
       yield* Queue.shutdown(queue)
     }))
 

--- a/packages/effect/test/Queue.test.ts
+++ b/packages/effect/test/Queue.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Cause, Effect, Exit, Fiber, Option, Queue, Stream } from "effect"
+import * as Scheduler from "effect/Scheduler"
 
 describe("Queue", () => {
   it.effect("isEnqueue type guard", () =>
@@ -477,6 +478,39 @@ describe("Queue", () => {
 
       assert.deepStrictEqual(taker.pollUnsafe(), Exit.succeed(1))
       assert.isUndefined(awaiter.pollUnsafe())
+      yield* Queue.shutdown(queue)
+    }))
+
+  it.effect("flushUnsafe coalesces scheduled releases across repeated offers", () =>
+    Effect.gen(function*() {
+      const tasks: Array<() => void> = []
+      const scheduler: Scheduler.Scheduler = {
+        executionMode: "async",
+        makeDispatcher() {
+          return {
+            scheduleTask(task, _priority) {
+              tasks.push(task)
+            },
+            flush() {
+            }
+          }
+        },
+        shouldYield: () => false
+      }
+      const queue = yield* Queue.unbounded<number>().pipe(
+        Effect.provideService(Scheduler.Scheduler, scheduler)
+      )
+      for (let i = 0; i < 10; i++) {
+        yield* Queue.take(queue).pipe(Effect.forkChild)
+      }
+      yield* Effect.yieldNow
+
+      for (let i = 0; i < 8; i++) {
+        Queue.offerUnsafe(queue, i)
+        Queue.flushUnsafe(queue)
+      }
+
+      assert.lengthOf(tasks, 1)
       yield* Queue.shutdown(queue)
     }))
 


### PR DESCRIPTION
Add `Queue.flushUnsafe` and `Queue.flush` so producers can release current takers immediately, including after synchronous offers. Both APIs use the queue's existing taker-release pass and leave `Queue.await` listeners untouched.

The scheduled-release flag now stays set until its dispatcher task runs, so direct flushes do not orphan pending work or queue duplicate releases. Coverage exercises both APIs, scheduler coalescing, shutdown, buffered messages with no taker, and later offers after an empty flush. The PR includes the required `effect` changeset.

Validation:

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm lint`
- `nix develop -c pnpm test --run packages/effect/test/Queue.test.ts`
- `nix develop -c pnpm check`
- `nix develop -c pnpm jsdocs --check`
- `nix develop -c pnpm doctest --run packages/effect/src/Queue.ts`

Closes EFF-1123
