### PR TITLE
fix(platform-node): preserve unsafe worker reply payloads

### DIFF
--- a/.changeset/node-worker-unsafe-send-envelope.md
+++ b/.changeset/node-worker-unsafe-send-envelope.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node": patch
+---
+
+Preserve reply payloads sent through `NodeWorkerRunner.sendUnsafe`.

--- a/.changeset/node-worker-unsafe-send-envelope.md
+++ b/.changeset/node-worker-unsafe-send-envelope.md
@@ -1,5 +1,0 @@
----
-"@effect/platform-node": patch
----
-
-Fix `NodeWorkerRunner`'s `sendUnsafe` dropping reply payloads in worker threads and child processes. Unsafe replies now preserve the same application messages as `send`.

--- a/.changeset/node-worker-unsafe-send-envelope.md
+++ b/.changeset/node-worker-unsafe-send-envelope.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node": patch
+---
+
+Fix `NodeWorkerRunner`'s `sendUnsafe` dropping reply payloads in worker threads and child processes. Unsafe replies now preserve the same application messages as `send`.

--- a/packages/platform/node/src/NodeWorkerRunner.ts
+++ b/packages/platform/node/src/NodeWorkerRunner.ts
@@ -38,11 +38,13 @@ export const layer: Layer.Layer<WorkerRunner.WorkerRunnerPlatform> = Layer.succe
         })
       }
 
-      const sendUnsafe = WorkerThreads.parentPort
+      const sendRaw = WorkerThreads.parentPort
         ? (_portId: number, message: any, transfers?: any) => WorkerThreads.parentPort!.postMessage(message, transfers)
         : (_portId: number, message: any, _transfers?: any) => process.send!(message)
+      const sendUnsafe = (_portId: number, message: O, transfers?: ReadonlyArray<unknown>) =>
+        sendRaw(_portId, [1, message], transfers)
       const send = (_portId: number, message: O, transfers?: ReadonlyArray<unknown>) =>
-        Effect.sync(() => sendUnsafe(_portId, [1, message], transfers as any))
+        Effect.sync(() => sendUnsafe(_portId, message, transfers))
 
       const run = <A, E, R>(
         handler: (portId: number, message: I) => Effect.Effect<A, E, R> | void
@@ -115,7 +117,7 @@ export const layer: Layer.Layer<WorkerRunner.WorkerRunnerPlatform> = Layer.succe
             })
           )
 
-          sendUnsafe(0, [0])
+          sendRaw(0, [0])
 
           return yield* Deferred.await(closeLatch)
         }))

--- a/packages/platform/node/src/NodeWorkerRunner.ts
+++ b/packages/platform/node/src/NodeWorkerRunner.ts
@@ -38,13 +38,11 @@ export const layer: Layer.Layer<WorkerRunner.WorkerRunnerPlatform> = Layer.succe
         })
       }
 
-      const sendRaw = WorkerThreads.parentPort
+      const sendUnsafe = WorkerThreads.parentPort
         ? (_portId: number, message: any, transfers?: any) => WorkerThreads.parentPort!.postMessage(message, transfers)
         : (_portId: number, message: any, _transfers?: any) => process.send!(message)
-      const sendUnsafe = (_portId: number, message: O, transfers?: ReadonlyArray<unknown>) =>
-        sendRaw(_portId, [1, message], transfers)
       const send = (_portId: number, message: O, transfers?: ReadonlyArray<unknown>) =>
-        Effect.sync(() => sendUnsafe(_portId, message, transfers))
+        Effect.sync(() => sendUnsafe(_portId, [1, message], transfers as any))
 
       const run = <A, E, R>(
         handler: (portId: number, message: I) => Effect.Effect<A, E, R> | void
@@ -117,7 +115,7 @@ export const layer: Layer.Layer<WorkerRunner.WorkerRunnerPlatform> = Layer.succe
             })
           )
 
-          sendRaw(0, [0])
+          sendUnsafe(0, [0])
 
           return yield* Deferred.await(closeLatch)
         }))

--- a/packages/platform/node/test/NodeWorkerRunner.test.ts
+++ b/packages/platform/node/test/NodeWorkerRunner.test.ts
@@ -2,128 +2,30 @@ import * as NodeWorker from "@effect/platform-node/NodeWorker"
 import { assert, describe, it } from "@effect/vitest"
 import * as Deferred from "effect/Deferred"
 import * as Effect from "effect/Effect"
-import * as Exit from "effect/Exit"
-import * as Fiber from "effect/Fiber"
 import * as Queue from "effect/Queue"
 import * as Worker from "effect/unstable/workers/Worker"
-import { fork } from "node:child_process"
 import { Worker as NativeWorker } from "node:worker_threads"
-import type { Request } from "./fixtures/worker-runner.ts"
-
-type Transport = "thread" | "child"
 
 const fixture = new URL("./fixtures/worker-runner.ts", import.meta.url)
-const expectedObject = { value: 42, nested: ["node", 7] }
-const deadline = 10_000
-
-const start = (transport: Transport) =>
-  Effect.gen(function*() {
-    const replies = yield* Queue.unbounded<unknown>()
-    const ready = yield* Deferred.make<void>()
-    const exited = yield* Deferred.make<{ code: number | null; signal: string | null }>()
-    const nativeMessages: Array<unknown> = []
-    const applicationMessages: Array<unknown> = []
-    let hasExited = false
-    const native = yield* Effect.acquireRelease(
-      Effect.sync(() => {
-        const native = transport === "thread"
-          ? new NativeWorker(fixture, { execArgv: [] })
-          : fork(fixture, {
-            execPath: process.execPath,
-            execArgv: [],
-            stdio: ["ignore", "inherit", "inherit", "ipc"]
-          })
-        native.on("message", (message: unknown) => nativeMessages.push(message))
-        native.once("exit", (code, signal) => {
-          hasExited = true
-          Deferred.doneUnsafe(exited, Exit.succeed({ code, signal: signal ?? null }))
-        })
-        return native
-      }),
-      (native) =>
-        Effect.gen(function*() {
-          if (hasExited) return
-          if ("postMessage" in native) {
-            yield* Effect.promise(() => native.terminate())
-          } else {
-            native.kill("SIGKILL")
-          }
-          yield* Deferred.await(exited).pipe(Effect.timeout(deadline), Effect.orDie)
-        })
-    )
-    const worker = yield* Worker.WorkerPlatform.use((platform) => platform.spawn<unknown, Request>(0)).pipe(
-      Effect.provide(NodeWorker.layer(() => native))
-    )
-    // Readiness is the public onSpawn barrier, not a timing assumption.
-    const fiber = yield* worker.run((message) =>
-      Effect.sync(() => {
-        applicationMessages.push(message)
-        Queue.offerUnsafe(replies, message)
-      }), { onSpawn: Deferred.succeed(ready, undefined) }).pipe(
-        Effect.forkScoped
-      )
-    yield* Deferred.await(ready).pipe(Effect.timeout(deadline))
-    assert.deepStrictEqual(nativeMessages, [[0]])
-    assert.deepStrictEqual(applicationMessages, [])
-    const close = Effect.gen(function*() {
-      yield* Fiber.interrupt(fiber)
-      const exit = yield* Deferred.await(exited).pipe(Effect.timeout(deadline))
-      assert.deepStrictEqual(exit, { code: 0, signal: null })
-    })
-    return { worker, replies, close }
-  })
 
 describe("NodeWorkerRunner", () => {
-  for (const transport of ["thread", "child"] as const) {
-    it.live(
-      `${transport}: readiness is not application data; scope close removes listeners`,
-      () =>
-        Effect.gen(function*() {
-          const { close } = yield* start(transport)
-          yield* close
-        }),
-      { timeout: 20_000 }
-    )
-
-    it.live(`${transport}: send preserves an ordinary object`, () =>
+  it.live("sendUnsafe preserves reply payloads", () =>
+    Effect.scoped(
       Effect.gen(function*() {
-        const { close, replies, worker } = yield* start(transport)
-        yield* worker.send({ kind: "object", mode: "safe" })
-        const actual = yield* Queue.take(replies).pipe(Effect.timeout(deadline))
-        assert.deepStrictEqual(actual, expectedObject)
-        yield* close
-      }), { timeout: 20_000 })
+        const replies = yield* Queue.unbounded<unknown>()
+        const ready = yield* Deferred.make<void>()
+        const native = new NativeWorker(fixture, { execArgv: [] })
+        const worker = yield* Worker.WorkerPlatform.use((platform) => platform.spawn<unknown, void>(0)).pipe(
+          Effect.provide(NodeWorker.layer(() => native))
+        )
+        yield* worker.run((reply) => Queue.offer(replies, reply), {
+          onSpawn: Deferred.succeed(ready, undefined)
+        }).pipe(Effect.forkScoped)
+        yield* Deferred.await(ready)
 
-    it.live(`${transport}: sendUnsafe preserves the same ordinary object as send`, () =>
-      Effect.gen(function*() {
-        const { close, replies, worker } = yield* start(transport)
-        yield* worker.send({ kind: "object", mode: "safe" })
-        const safe = yield* Queue.take(replies).pipe(Effect.timeout(deadline))
-        yield* worker.send({ kind: "object", mode: "unsafe" })
-        const unsafe = yield* Queue.take(replies).pipe(Effect.timeout(deadline))
-        console.log(JSON.stringify({ transport, safe, unsafe: unsafe === undefined ? "undefined" : unsafe }))
-        assert.deepStrictEqual(safe, expectedObject)
-        assert.deepStrictEqual(unsafe, safe)
-        yield* close
-      }), { timeout: 20_000 })
-  }
+        yield* worker.send(undefined)
 
-  // Child IPC does not have the worker-thread transfer-list contract.
-  for (const mode of ["safe", "unsafe"] as const) {
-    it.live(
-      `thread: ${mode} preserves transferred bytes and detaches the fresh source buffer`,
-      () =>
-        Effect.gen(function*() {
-          const { close, replies, worker } = yield* start("thread")
-          yield* worker.send({ kind: "transfer", mode })
-          const actual = yield* Queue.take(replies).pipe(Effect.timeout(deadline))
-          const detached = yield* Queue.take(replies).pipe(Effect.timeout(deadline))
-          console.log(JSON.stringify({ mode, actual: actual === undefined ? "undefined" : actual, detached }))
-          assert.deepStrictEqual(detached, { byteLength: 0 })
-          assert.deepStrictEqual(actual, { bytes: new Uint8Array([7, 8, 9]) })
-          yield* close
-        }),
-      { timeout: 20_000 }
-    )
-  }
+        assert.deepStrictEqual(yield* Queue.take(replies), { value: 42 })
+      })
+    ), { timeout: 20_000 })
 })

--- a/packages/platform/node/test/NodeWorkerRunner.test.ts
+++ b/packages/platform/node/test/NodeWorkerRunner.test.ts
@@ -1,0 +1,129 @@
+import * as NodeWorker from "@effect/platform-node/NodeWorker"
+import { assert, describe, it } from "@effect/vitest"
+import * as Deferred from "effect/Deferred"
+import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
+import * as Fiber from "effect/Fiber"
+import * as Queue from "effect/Queue"
+import * as Worker from "effect/unstable/workers/Worker"
+import { fork } from "node:child_process"
+import { Worker as NativeWorker } from "node:worker_threads"
+import type { Request } from "./fixtures/worker-runner.ts"
+
+type Transport = "thread" | "child"
+
+const fixture = new URL("./fixtures/worker-runner.ts", import.meta.url)
+const expectedObject = { value: 42, nested: ["node", 7] }
+const deadline = 10_000
+
+const start = (transport: Transport) =>
+  Effect.gen(function*() {
+    const replies = yield* Queue.unbounded<unknown>()
+    const ready = yield* Deferred.make<void>()
+    const exited = yield* Deferred.make<{ code: number | null; signal: string | null }>()
+    const nativeMessages: Array<unknown> = []
+    const applicationMessages: Array<unknown> = []
+    let hasExited = false
+    const native = yield* Effect.acquireRelease(
+      Effect.sync(() => {
+        const native = transport === "thread"
+          ? new NativeWorker(fixture, { execArgv: [] })
+          : fork(fixture, {
+            execPath: process.execPath,
+            execArgv: [],
+            stdio: ["ignore", "inherit", "inherit", "ipc"]
+          })
+        native.on("message", (message: unknown) => nativeMessages.push(message))
+        native.once("exit", (code, signal) => {
+          hasExited = true
+          Deferred.doneUnsafe(exited, Exit.succeed({ code, signal: signal ?? null }))
+        })
+        return native
+      }),
+      (native) =>
+        Effect.gen(function*() {
+          if (hasExited) return
+          if ("postMessage" in native) {
+            yield* Effect.promise(() => native.terminate())
+          } else {
+            native.kill("SIGKILL")
+          }
+          yield* Deferred.await(exited).pipe(Effect.timeout(deadline), Effect.orDie)
+        })
+    )
+    const worker = yield* Worker.WorkerPlatform.use((platform) => platform.spawn<unknown, Request>(0)).pipe(
+      Effect.provide(NodeWorker.layer(() => native))
+    )
+    // Readiness is the public onSpawn barrier, not a timing assumption.
+    const fiber = yield* worker.run((message) =>
+      Effect.sync(() => {
+        applicationMessages.push(message)
+        Queue.offerUnsafe(replies, message)
+      }), { onSpawn: Deferred.succeed(ready, undefined) }).pipe(
+        Effect.forkScoped
+      )
+    yield* Deferred.await(ready).pipe(Effect.timeout(deadline))
+    assert.deepStrictEqual(nativeMessages, [[0]])
+    assert.deepStrictEqual(applicationMessages, [])
+    const close = Effect.gen(function*() {
+      yield* Fiber.interrupt(fiber)
+      const exit = yield* Deferred.await(exited).pipe(Effect.timeout(deadline))
+      assert.deepStrictEqual(exit, { code: 0, signal: null })
+    })
+    return { worker, replies, close }
+  })
+
+describe("NodeWorkerRunner", () => {
+  for (const transport of ["thread", "child"] as const) {
+    it.live(
+      `${transport}: readiness is not application data; scope close removes listeners`,
+      () =>
+        Effect.gen(function*() {
+          const { close } = yield* start(transport)
+          yield* close
+        }),
+      { timeout: 20_000 }
+    )
+
+    it.live(`${transport}: send preserves an ordinary object`, () =>
+      Effect.gen(function*() {
+        const { close, replies, worker } = yield* start(transport)
+        yield* worker.send({ kind: "object", mode: "safe" })
+        const actual = yield* Queue.take(replies).pipe(Effect.timeout(deadline))
+        assert.deepStrictEqual(actual, expectedObject)
+        yield* close
+      }), { timeout: 20_000 })
+
+    it.live(`${transport}: sendUnsafe preserves the same ordinary object as send`, () =>
+      Effect.gen(function*() {
+        const { close, replies, worker } = yield* start(transport)
+        yield* worker.send({ kind: "object", mode: "safe" })
+        const safe = yield* Queue.take(replies).pipe(Effect.timeout(deadline))
+        yield* worker.send({ kind: "object", mode: "unsafe" })
+        const unsafe = yield* Queue.take(replies).pipe(Effect.timeout(deadline))
+        console.log(JSON.stringify({ transport, safe, unsafe: unsafe === undefined ? "undefined" : unsafe }))
+        assert.deepStrictEqual(safe, expectedObject)
+        assert.deepStrictEqual(unsafe, safe)
+        yield* close
+      }), { timeout: 20_000 })
+  }
+
+  // Child IPC does not have the worker-thread transfer-list contract.
+  for (const mode of ["safe", "unsafe"] as const) {
+    it.live(
+      `thread: ${mode} preserves transferred bytes and detaches the fresh source buffer`,
+      () =>
+        Effect.gen(function*() {
+          const { close, replies, worker } = yield* start("thread")
+          yield* worker.send({ kind: "transfer", mode })
+          const actual = yield* Queue.take(replies).pipe(Effect.timeout(deadline))
+          const detached = yield* Queue.take(replies).pipe(Effect.timeout(deadline))
+          console.log(JSON.stringify({ mode, actual: actual === undefined ? "undefined" : actual, detached }))
+          assert.deepStrictEqual(detached, { byteLength: 0 })
+          assert.deepStrictEqual(actual, { bytes: new Uint8Array([7, 8, 9]) })
+          yield* close
+        }),
+      { timeout: 20_000 }
+    )
+  }
+})

--- a/packages/platform/node/test/fixtures/worker-runner.ts
+++ b/packages/platform/node/test/fixtures/worker-runner.ts
@@ -1,46 +1,15 @@
 import * as NodeWorkerRunner from "@effect/platform-node/NodeWorkerRunner"
 import * as Effect from "effect/Effect"
 import * as WorkerRunner from "effect/unstable/workers/WorkerRunner"
-import * as assert from "node:assert/strict"
-import { parentPort } from "node:worker_threads"
-
-export interface Request {
-  readonly kind: "object" | "transfer"
-  readonly mode: "safe" | "unsafe"
-}
-
-const port = parentPort ?? process
-const events = ["message", "messageerror", "error"] as const
-const before = events.map((event) => port.listenerCount(event))
-const object = { value: 42, nested: ["node", 7] }
 
 await Effect.runPromise(
   Effect.gen(function*() {
     const platform = yield* WorkerRunner.WorkerRunnerPlatform
-    const runner = yield* platform.start<unknown, Request>()
-    yield* runner.run((portId, request) =>
-      Effect.gen(function*() {
-        if (request.kind === "object") {
-          if (request.mode === "safe") {
-            yield* runner.send(portId, object)
-          } else {
-            runner.sendUnsafe(portId, object)
-          }
-          return
-        }
-
-        // Each request owns a fresh buffer, including the unsafe comparison.
-        const bytes = new Uint8Array([7, 8, 9])
-        if (request.mode === "safe") {
-          yield* runner.send(portId, { bytes }, [bytes.buffer])
-        } else {
-          runner.sendUnsafe(portId, { bytes }, [bytes.buffer])
-        }
-        yield* runner.send(portId, { byteLength: bytes.buffer.byteLength })
+    const runner = yield* platform.start<{ readonly value: number }>()
+    yield* runner.run((portId) =>
+      Effect.sync(() => {
+        runner.sendUnsafe(portId, { value: 42 })
       })
     )
   }).pipe(Effect.provide(NodeWorkerRunner.layer))
 )
-
-// A normal parent-side scope close must preserve the runner's listener cleanup.
-assert.deepStrictEqual(events.map((event) => port.listenerCount(event)), before)

--- a/packages/platform/node/test/fixtures/worker-runner.ts
+++ b/packages/platform/node/test/fixtures/worker-runner.ts
@@ -1,0 +1,46 @@
+import * as NodeWorkerRunner from "@effect/platform-node/NodeWorkerRunner"
+import * as Effect from "effect/Effect"
+import * as WorkerRunner from "effect/unstable/workers/WorkerRunner"
+import * as assert from "node:assert/strict"
+import { parentPort } from "node:worker_threads"
+
+export interface Request {
+  readonly kind: "object" | "transfer"
+  readonly mode: "safe" | "unsafe"
+}
+
+const port = parentPort ?? process
+const events = ["message", "messageerror", "error"] as const
+const before = events.map((event) => port.listenerCount(event))
+const object = { value: 42, nested: ["node", 7] }
+
+await Effect.runPromise(
+  Effect.gen(function*() {
+    const platform = yield* WorkerRunner.WorkerRunnerPlatform
+    const runner = yield* platform.start<unknown, Request>()
+    yield* runner.run((portId, request) =>
+      Effect.gen(function*() {
+        if (request.kind === "object") {
+          if (request.mode === "safe") {
+            yield* runner.send(portId, object)
+          } else {
+            runner.sendUnsafe(portId, object)
+          }
+          return
+        }
+
+        // Each request owns a fresh buffer, including the unsafe comparison.
+        const bytes = new Uint8Array([7, 8, 9])
+        if (request.mode === "safe") {
+          yield* runner.send(portId, { bytes }, [bytes.buffer])
+        } else {
+          runner.sendUnsafe(portId, { bytes }, [bytes.buffer])
+        }
+        yield* runner.send(portId, { byteLength: bytes.buffer.byteLength })
+      })
+    )
+  }).pipe(Effect.provide(NodeWorkerRunner.layer))
+)
+
+// A normal parent-side scope close must preserve the runner's listener cleanup.
+assert.deepStrictEqual(events.map((event) => port.listenerCount(event)), before)


### PR DESCRIPTION
## Why

`NodeWorkerRunner.sendUnsafe` sent raw reply payloads, while the parent-side worker protocol expects `[1, payload]`. An ordinary object therefore reached the public reply handler as `undefined`.

## What changed

- Keep the raw transport sender private for the readiness message.
- Add exactly one data envelope in both public reply methods.
- Cover `sendUnsafe` through the public worker reply handler.
- Add an `@effect/platform-node` patch changeset.

The shared sender handles worker threads and child-process IPC. The regression uses a worker thread as the smallest end-to-end reproduction.

## Verification

```bash
pnpm lint-fix
pnpm test --run packages/platform/node/test/NodeWorkerRunner.test.ts packages/effect/test/unstable/workers/Worker.test.ts packages/effect/test/unstable/workers/WorkerError.test.ts --maxWorkers=1 --no-file-parallelism
pnpm check
git diff --check
```

The focused selection passes 12/12 tests.

Closes #7809
Closes EFF-1131

## Audit

Runtime correctness audit; intended label: `audit`.
