### PR TITLE
test: serialize MySQL integration suites on Node

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -161,12 +161,12 @@ export default defineConfig({
       ...project("@effect/sql-libsql", "packages/sql/libsql"),
       ...project("@effect/sql-mssql", "packages/sql/mssql"),
       // MySQL starts a fresh container per integration test suite, so avoid competing
-      // with the other container-backed projects on Deno CI runners.
+      // with the other container-backed projects on integration-test runners.
       ...project(
         "@effect/sql-mysql2",
         "packages/sql/mysql2",
         true,
-        isDeno && integrationTestsEnabled
+        integrationTestsEnabled
           ? {
             test: {
               fileParallelism: false,


### PR DESCRIPTION
## Summary

- serialize `@effect/sql-mysql2` integration test files on Node as well as Deno
- schedule the MySQL project after the other container-backed projects
- keep the existing test and hook timeouts unchanged

## Root cause

Each MySQL integration file starts a fresh `mysql:lts` container. The failed Node shard ran those files alongside other container-backed projects, which stretched normally short container setup and query work into 30 to 60 second timeouts. The repository already isolates this project for Deno integration runs, but the guard excluded Node.

Applying the same scheduling to every integration runtime removes the startup contention instead of increasing timeouts.

## Validation

- `pnpm lint-fix`
- `EFFECT_INTEGRATION_TESTS=1 pnpm test --run packages/sql/mysql2/test/MysqlClient.integration.test.ts packages/sql/mysql2/test/Persistence.integration.test.ts packages/sql/mysql2/test/SqlEventLogServerUnencrypted.integration.test.ts packages/platform/node/test/cluster/SqlRunnerStorage.integration.test.ts` (48 tests passed)
- `pnpm check`

Closes EFF-1124
