### PR TITLE
Isolate MySQL single-table persistence tests

### DIFF
--- a/packages/sql/mysql2/test/Persistence.integration.test.ts
+++ b/packages/sql/mysql2/test/Persistence.integration.test.ts
@@ -1,4 +1,4 @@
-import { assert, it } from "@effect/vitest"
+import { assert, describe, it } from "@effect/vitest"
 import { Effect, Layer, Schema } from "effect"
 import * as PersistedCacheTest from "effect-test/unstable/persistence/PersistedCacheTest"
 import * as PersistedQueueTest from "effect-test/unstable/persistence/PersistedQueueTest"
@@ -10,8 +10,6 @@ import { MysqlContainer } from "./utils.ts"
 
 it.layer(MysqlContainer.layerClient, { timeout: "90 seconds" })("Persistence", (it) => {
   PersistedCacheTest.suiteWith("sql-mysql2-multi", Persistence.layerSqlMultiTable, it)
-
-  PersistedCacheTest.suiteWith("sql-mysql2-single", Persistence.layerSql, it)
 
   PersistedQueueTest.suiteWith("sql-mysql2", PersistedQueue.layerStoreSql(), it)
 
@@ -34,52 +32,56 @@ it.layer(MysqlContainer.layerClient, { timeout: "90 seconds" })("Persistence", (
       assert.strictEqual(value, payload)
     }).pipe(TestClock.withLive), { timeout: 30000 })
 
-  it.effect("deletes expired entries in batches", () =>
-    Effect.gen(function*() {
-      const sql = (yield* SqlClient.SqlClient).withoutTransforms()
-      const table = sql("effect_persistence")
-      const expiredCount = sql<{ readonly count: number }>`
-        SELECT COUNT(*) AS count FROM ${table} WHERE store_id = 'expired'
-      `.pipe(Effect.map((rows) => Number(rows[0].count)))
-      // Reset the table left by the single-table cache suite so cleanup builds its own schema and index.
-      yield* sql`DROP TABLE IF EXISTS ${table}`
-      yield* sql`
-        CREATE TABLE ${table} (
-          store_id VARCHAR(191) NOT NULL,
-          id VARCHAR(191) NOT NULL,
-          value TEXT NOT NULL,
-          expires BIGINT,
-          PRIMARY KEY (store_id, id)
-        )
-      `
+  describe.sequential("single-table persistence", () => {
+    PersistedCacheTest.suiteWith("sql-mysql2-single", Persistence.layerSql, it)
 
-      const entries = Array.from({ length: SqlCleanupTest.expiredEntryCount }, (_, i) => ({
-        store_id: "expired",
-        id: String(i),
-        value: "{}",
-        expires: SqlCleanupTest.expiredAtEpoch
-      }))
-      yield* sql`INSERT INTO ${table} ${sql.insert(entries)}`.unprepared
-      yield* sql`
-        INSERT INTO ${table} (store_id, id, value, expires)
-        VALUES ('live', 'live', '{}', NULL), ('live', 'future', '{}', ${SqlCleanupTest.futureExpiresAt})
-      `
+    it.effect("deletes expired entries in batches", () =>
+      Effect.gen(function*() {
+        const sql = (yield* SqlClient.SqlClient).withoutTransforms()
+        const table = sql("effect_persistence")
+        const expiredCount = sql<{ readonly count: number }>`
+          SELECT COUNT(*) AS count FROM ${table} WHERE store_id = 'expired'
+        `.pipe(Effect.map((rows) => Number(rows[0].count)))
+        // Reset the table left by the single-table cache suite so cleanup builds its own schema and index.
+        yield* sql`DROP TABLE IF EXISTS ${table}`
+        yield* sql`
+          CREATE TABLE ${table} (
+            store_id VARCHAR(191) NOT NULL,
+            id VARCHAR(191) NOT NULL,
+            value TEXT NOT NULL,
+            expires BIGINT,
+            PRIMARY KEY (store_id, id)
+          )
+        `
 
-      yield* Layer.build(Persistence.layerBackingSql).pipe(TestClock.withLive)
+        const entries = Array.from({ length: SqlCleanupTest.expiredEntryCount }, (_, i) => ({
+          store_id: "expired",
+          id: String(i),
+          value: "{}",
+          expires: SqlCleanupTest.expiredAtEpoch
+        }))
+        yield* sql`INSERT INTO ${table} ${sql.insert(entries)}`.unprepared
+        yield* sql`
+          INSERT INTO ${table} (store_id, id, value, expires)
+          VALUES ('live', 'live', '{}', NULL), ('live', 'future', '{}', ${SqlCleanupTest.futureExpiresAt})
+        `
 
-      const expired = yield* SqlCleanupTest.waitForCount(expiredCount, (count) => count === 0)
-      assert.strictEqual(expired, 0)
-      const live = yield* sql<{ readonly count: number }>`
-        SELECT COUNT(*) AS count FROM ${table} WHERE store_id = 'live'
-      `
-      assert.strictEqual(Number(live[0].count), 2)
+        yield* Layer.build(Persistence.layerBackingSql).pipe(TestClock.withLive)
 
-      const indexes = yield* sql<{ readonly count: number }>`
-        SELECT COUNT(*) AS count FROM information_schema.statistics
-        WHERE table_schema = DATABASE()
-          AND table_name = 'effect_persistence'
-          AND index_name = 'effect_persistence_expires_idx'
-      `
-      assert.strictEqual(Number(indexes[0].count), 1)
-    }), { timeout: SqlCleanupTest.testTimeout })
+        const expired = yield* SqlCleanupTest.waitForCount(expiredCount, (count) => count === 0)
+        assert.strictEqual(expired, 0)
+        const live = yield* sql<{ readonly count: number }>`
+          SELECT COUNT(*) AS count FROM ${table} WHERE store_id = 'live'
+        `
+        assert.strictEqual(Number(live[0].count), 2)
+
+        const indexes = yield* sql<{ readonly count: number }>`
+          SELECT COUNT(*) AS count FROM information_schema.statistics
+          WHERE table_schema = DATABASE()
+            AND table_name = 'effect_persistence'
+            AND index_name = 'effect_persistence_expires_idx'
+        `
+        assert.strictEqual(Number(indexes[0].count), 1)
+      }), { timeout: SqlCleanupTest.testTimeout })
+  })
 })


### PR DESCRIPTION
## Summary

- Run the single-table cache tests and SQL cleanup test sequentially because they share `effect_persistence`.
- Keep the multi-table cache and queue tests concurrent.

## Cause

Vitest schedules tests concurrently. The cleanup test drops and rebuilds `effect_persistence`, inserts a batch of expired rows, and starts deleting them while the single-table cache smoke test upserts the same table. That race produced MySQL error 1213 in CI. The cases pass independently, so the failure belongs to test isolation rather than persistence retry behavior.

## Validation

- `EFFECT_INTEGRATION_TESTS=1 pnpm test --run packages/sql/mysql2/test/Persistence.integration.test.ts`
- `pnpm lint-fix`
- `pnpm check`

Closes EFF-1125
