### PR TITLE
Add defect recovery operators to Stream and Channel

### DIFF
--- a/.changeset/catch-stream-channel-defects.md
+++ b/.changeset/catch-stream-channel-defects.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Stream.catchDefect` and `Channel.catchDefect` for recovering from defects without catching typed failures or interruptions.

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -4144,6 +4144,97 @@ export const catchCause: {
   }))
 
 /**
+ * Recovers from defects using the provided function.
+ *
+ * **Details**
+ *
+ * Typed failures and interruptions are not caught.
+ *
+ * **Example** (Recovering from a defect)
+ *
+ * ```ts import.meta.vitest
+ * import { Channel, Effect } from "effect"
+ *
+ * const channel = Channel.fromEffect(Effect.die("boom")).pipe(
+ *   Channel.catchDefect((defect) => Channel.succeed(`recovered: ${defect}`))
+ * )
+ *
+ * Effect.runSync(Channel.runCollect(channel)) // => ["recovered: boom"]
+ * ```
+ *
+ * @category error handling
+ * @since 4.0.0
+ */
+export const catchDefect: {
+  <OutElem1, OutErr1, OutDone1, InElem1, InErr1, InDone1, Env1>(
+    f: (defect: unknown) => Channel<OutElem1, OutErr1, OutDone1, InElem1, InErr1, InDone1, Env1>
+  ): <OutElem, OutErr, OutDone, InElem, InErr, InDone, Env>(
+    self: Channel<OutElem, OutErr, OutDone, InElem, InErr, InDone, Env>
+  ) => Channel<
+    OutElem | OutElem1,
+    OutErr | OutErr1,
+    OutDone | OutDone1,
+    InElem & InElem1,
+    InErr & InErr1,
+    InDone & InDone1,
+    Env | Env1
+  >
+  <
+    OutElem,
+    OutErr,
+    OutDone,
+    InElem,
+    InErr,
+    InDone,
+    Env,
+    OutElem1,
+    OutErr1,
+    OutDone1,
+    InElem1,
+    InErr1,
+    InDone1,
+    Env1
+  >(
+    self: Channel<OutElem, OutErr, OutDone, InElem, InErr, InDone, Env>,
+    f: (defect: unknown) => Channel<OutElem1, OutErr1, OutDone1, InElem1, InErr1, InDone1, Env1>
+  ): Channel<
+    OutElem | OutElem1,
+    OutErr | OutErr1,
+    OutDone | OutDone1,
+    InElem & InElem1,
+    InErr & InErr1,
+    InDone & InDone1,
+    Env | Env1
+  >
+} = dual(2, <
+  OutElem,
+  OutErr,
+  OutDone,
+  InElem,
+  InErr,
+  InDone,
+  Env,
+  OutElem1,
+  OutErr1,
+  OutDone1,
+  InElem1,
+  InErr1,
+  InDone1,
+  Env1
+>(
+  self: Channel<OutElem, OutErr, OutDone, InElem, InErr, InDone, Env>,
+  f: (defect: unknown) => Channel<OutElem1, OutErr1, OutDone1, InElem1, InErr1, InDone1, Env1>
+): Channel<
+  OutElem | OutElem1,
+  OutErr | OutErr1,
+  OutDone | OutDone1,
+  InElem & InElem1,
+  InErr & InErr1,
+  InDone & InDone1,
+  Env | Env1
+> => catchCauseFilter(self, Cause.findDefect, f))
+
+/**
  * Runs an effect with the full failure `Cause` when the channel fails, then
  * fails the returned channel with the original cause.
  *

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -4698,6 +4698,46 @@ export const catchCause: {
   ))
 
 /**
+ * Recovers from defects using the provided function.
+ *
+ * **Details**
+ *
+ * Typed failures and interruptions are not caught.
+ *
+ * **Example** (Recovering from a defect)
+ *
+ * ```ts import.meta.vitest
+ * import { Effect, Stream } from "effect"
+ *
+ * const stream = Stream.die("boom").pipe(
+ *   Stream.catchDefect((defect) => Stream.succeed(`recovered: ${defect}`))
+ * )
+ *
+ * const result = Effect.runSync(Stream.runCollect(stream))
+ * result // => ["recovered: boom"]
+ * ```
+ *
+ * @category error handling
+ * @since 4.0.0
+ */
+export const catchDefect: {
+  <A2, E2, R2>(
+    f: (defect: unknown) => Stream<A2, E2, R2>
+  ): <A, E, R>(self: Stream<A, E, R>) => Stream<A | A2, E | E2, R | R2>
+  <A, E, R, A2, E2, R2>(
+    self: Stream<A, E, R>,
+    f: (defect: unknown) => Stream<A2, E2, R2>
+  ): Stream<A | A2, E | E2, R | R2>
+} = dual(2, <A, E, R, A2, E2, R2>(
+  self: Stream<A, E, R>,
+  f: (defect: unknown) => Stream<A2, E2, R2>
+): Stream<A | A2, E | E2, R | R2> =>
+  self.channel.pipe(
+    Channel.catchDefect((defect) => f(defect).channel),
+    fromChannel
+  ))
+
+/**
  * Runs an effect when the stream fails without changing its values or error,
  * unless the tap effect itself fails.
  *

--- a/packages/effect/test/Channel.test.ts
+++ b/packages/effect/test/Channel.test.ts
@@ -496,6 +496,22 @@ describe("Channel", () => {
       readonly message: string
     }> {}
 
+    it.effect("catchDefect", () =>
+      Effect.gen(function*() {
+        const defect = new Error("boom")
+        const recovered = yield* Channel.fromEffect(Effect.die(defect)).pipe(
+          Channel.catchDefect((caught) => Channel.succeed(caught)),
+          Channel.runCollect
+        )
+        const failed = yield* Channel.fail("failure").pipe(
+          Channel.catchDefect(() => Channel.succeed("recovered")),
+          Channel.runCollect,
+          Effect.exit
+        )
+        assert.deepStrictEqual(recovered, [defect])
+        assertExitFailure(failed, Cause.fail("failure"))
+      }))
+
     it.effect("catchIf with refinement", () =>
       Effect.gen(function*() {
         const exit = yield* (Channel.fail(new ValidationError({ field: "email" })) as Channel.Channel<

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -947,6 +947,22 @@ describe("Stream", () => {
         assertExitFailure(exit, Cause.die(defect))
       }))
 
+    it.effect("catchDefect", () =>
+      Effect.gen(function*() {
+        const defect = new Error("boom")
+        const recovered = yield* Stream.die(defect).pipe(
+          Stream.catchDefect((caught) => Stream.succeed(caught)),
+          Stream.runCollect
+        )
+        const failed = yield* Stream.fail("failure").pipe(
+          Stream.catchDefect(() => Stream.succeed("recovered")),
+          Stream.runCollect,
+          Effect.exit
+        )
+        assert.deepStrictEqual(recovered, [defect])
+        assertExitFailure(failed, Cause.fail("failure"))
+      }))
+
     it.effect("catchIf with refinement", () =>
       Effect.gen(function*() {
         interface ErrorA {

--- a/packages/effect/typetest/Channel.tst.ts
+++ b/packages/effect/typetest/Channel.tst.ts
@@ -12,6 +12,18 @@ class AiError extends Data.TaggedError("AiError")<{ readonly reason: RateLimit |
 
 declare const aiChannel: Channel.Channel<number, AiError | ErrorB>
 
+describe("Channel.catchDefect", () => {
+  it("supports data-last usage", () => {
+    const result = pipe(channel, Channel.catchDefect(() => Channel.fail("recovery" as const)))
+    expect(result).type.toBe<Channel.Channel<number, ErrorA | ErrorB | "recovery">>()
+  })
+
+  it("supports data-first usage", () => {
+    const result = Channel.catchDefect(channel, () => Channel.succeed("recovered"))
+    expect(result).type.toBe<Channel.Channel<number | string, ErrorA | ErrorB>>()
+  })
+})
+
 describe("Channel.catchTag", () => {
   it("removes the handled error when orElse is omitted", () => {
     const result = pipe(channel, Channel.catchTag("ErrorA", () => Channel.succeed(1)))

--- a/packages/effect/typetest/Stream.tst.ts
+++ b/packages/effect/typetest/Stream.tst.ts
@@ -18,6 +18,18 @@ class AiError extends Data.TaggedError("AiError")<{ readonly reason: RateLimit |
 
 declare const aiStream: Stream.Stream<string, AiError | ErrorB, "dep-1">
 
+describe("Stream.catchDefect", () => {
+  it("supports data-last usage", () => {
+    const result = pipe(stream, Stream.catchDefect(() => Stream.fail("recovery" as const)))
+    expect(result).type.toBe<Stream.Stream<string, ErrorA | ErrorB | "recovery", "dep-1">>()
+  })
+
+  it("supports data-first usage", () => {
+    const result = Stream.catchDefect(stream, () => Stream.succeed(1))
+    expect(result).type.toBe<Stream.Stream<string | number, ErrorA | ErrorB, "dep-1">>()
+  })
+})
+
 describe("Stream.catchIf", () => {
   it("supports refinement in data-last usage", () => {
     const result = pipe(


### PR DESCRIPTION
## Description

Add `Stream.catchDefect` and `Channel.catchDefect`. Both operators recover the first defect through the existing cause-filtering path while preserving typed failures and interruptions.

Runtime tests cover defect recovery and typed-failure passthrough. Type tests cover data-first and data-last inference for both APIs.

## Verification

- `pnpm test --run packages/effect/test/Channel.test.ts packages/effect/test/Stream.test.ts`
- `pnpm test-types Channel.tst.ts Stream.tst.ts`
- `pnpm check`
- `pnpm jsdocs --check`
- `pnpm doctest --run packages/effect/src/Channel.ts packages/effect/src/Stream.ts`

Closes EFF-1127
