### PR TITLE
fix(Socket): resume paused WebSockets after reader handoff

### DIFF
--- a/.changeset/socket-paused-websocket-handoff.md
+++ b/.changeset/socket-paused-websocket-handoff.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Resume paused WebSockets after their readers take ownership.

--- a/packages/effect/src/unstable/socket/Socket.ts
+++ b/packages/effect/src/unstable/socket/Socket.ts
@@ -876,7 +876,7 @@ export const fromWebSocket = <RO, WS extends WebSocketLike>(
       ) => void
 
       let open = ws.readyState === 1
-      let paused = false
+      let paused = pausable && "isPaused" in ws && ws.isPaused === true
       let buffer: Array<Uint8Array | string> = []
       let bufferSize = 0
       let error: SocketError | undefined
@@ -1038,6 +1038,7 @@ export const fromWebSocket = <RO, WS extends WebSocketLike>(
         open = true
       }
 
+      if (error === undefined && bufferSize < highWaterMark!) resumeWebSocket()
       currentWS = ws
       latch.openUnsafe()
 

--- a/packages/platform/node/test/NodeSocket.test.ts
+++ b/packages/platform/node/test/NodeSocket.test.ts
@@ -1,6 +1,6 @@
 import { NodeSocket, NodeSocketServer } from "@effect/platform-node"
 import { assert, describe, it } from "@effect/vitest"
-import { Deferred, Effect, Queue, Redacted } from "effect"
+import { Deferred, Effect, Option, Queue, Redacted } from "effect"
 import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
 import * as Scope from "effect/Scope"
@@ -535,6 +535,54 @@ describe("Socket", () => {
           WS.clean()
         })
     )
+
+    it.live("receives messages after handing a paused WebSocket to the reader", () =>
+      Effect.gen(function*() {
+        const serverScope = yield* Scope.make()
+        const connections = new Set<NodeSocket.NodeWS.WebSocket>()
+        yield* Effect.addFinalizer(() =>
+          Effect.gen(function*() {
+            for (const connection of connections) connection.terminate()
+            yield* Scope.close(serverScope, Exit.void)
+          })
+        )
+        const received = yield* Deferred.make<ReadonlyArray<Uint8Array | string>>()
+        const server = yield* NodeSocketServer.makeWebSocket({ host: "127.0.0.1", port: 0 }).pipe(
+          Scope.provide(serverScope)
+        )
+        assert.strictEqual(server.address._tag, "TcpAddress")
+        if (server.address._tag !== "TcpAddress") return
+
+        yield* server.run((socket) =>
+          Effect.gen(function*() {
+            const native = Option.getOrThrow(yield* Effect.serviceOption(Socket.WebSocket))
+            if (native instanceof NodeSocket.NodeWS.WebSocket) connections.add(native)
+            const { pull } = yield* socket.reader
+            const writer = yield* socket.writer
+            yield* writer.write("reader-ready")
+            yield* Deferred.succeed(received, yield* pull)
+          }).pipe(Effect.scoped)
+        ).pipe(Effect.forkIn(serverScope))
+
+        const client = new NodeSocket.NodeWS.WebSocket(`ws://127.0.0.1:${server.address.port}`)
+        connections.add(client)
+        const open = new Promise<void>((resolve, reject) => {
+          client.once("open", resolve)
+          client.once("error", reject)
+        })
+        const ready = new Promise<string>((resolve) => {
+          client.once("message", (data) => resolve(data.toString()))
+        })
+
+        yield* Effect.promise(() => open).pipe(Effect.timeout("1 second"))
+        assert.strictEqual(yield* Effect.promise(() => ready).pipe(Effect.timeout("1 second")), "reader-ready")
+        client.send("after-ready")
+
+        assert.deepStrictEqual(
+          yield* Deferred.await(received).pipe(Effect.timeout("1 second")),
+          ["after-ready"]
+        )
+      }))
 
     it.effect("passes headers to the opening handshake", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Why

`NodeSocketServer.makeWebSocket` pauses accepted connections until a handler takes ownership. The socket adapter previously forgot that inherited pause state, so a frame sent after reader acquisition could remain stuck and scoped shutdown could wait for the native close timeout.

## What changed

The adapter now adopts a pausable WebSocket's public `isPaused` state. Once listeners are attached and open acquisition is complete, it resumes the connection when no error is recorded and the buffer is below the high-water mark.

The regression test uses a native Node WebSocket in `packages/platform/node/test/NodeSocket.test.ts`. It waits for a reader-ready greeting, sends one frame, and verifies that the reader receives it.

## Verification

```bash
pnpm lint-fix
pnpm test --run packages/platform/node/test/NodeSocket.test.ts packages/effect/test/unstable/socket/Socket.test.ts --maxWorkers=1 --no-file-parallelism --sequence.concurrent=false
pnpm check
git diff --check origin/main...HEAD
```

Closes #7824
Closes EFF-1136

## Audit

Runtime correctness audit.
