### PR TITLE
fix(MessageStorage): clear queued control envelopes with their address

### DIFF
--- a/.changeset/memory-message-storage-clear-controls.md
+++ b/.changeset/memory-message-storage-clear-controls.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix in-memory `MessageStorage.clearAddress` leaving unread interrupt and chunk acknowledgement messages behind after clearing an entity's requests and replies.

--- a/packages/effect/src/unstable/cluster/MessageStorage.ts
+++ b/packages/effect/src/unstable/cluster/MessageStorage.ts
@@ -1105,12 +1105,14 @@ export class MemoryDriver extends Context.Service<MemoryDriver>()("effect/cluste
             const envelope = journal[i]
             const sameAddress = address.entityType === envelope.address.entityType &&
               address.entityId === envelope.address.entityId
-            if (!sameAddress || envelope._tag !== "Request") {
+            if (!sameAddress) {
               continue
             }
             unprocessed.delete(envelope)
             lastRead.delete(envelope)
-            requests.delete(envelope.requestId)
+            if (envelope._tag === "Request") {
+              requests.delete(envelope.requestId)
+            }
             journal.splice(i, 1)
           }
         }),

--- a/packages/effect/test/cluster/MessageStorage.test.ts
+++ b/packages/effect/test/cluster/MessageStorage.test.ts
@@ -51,6 +51,24 @@ describe("MessageStorage", () => {
         expect(result._tag).toEqual("Success")
       }).pipe(Effect.provide(MessageStorage.MemoryDriver.layer)))
 
+    it.effect("removes a queued Interrupt when clearing an address", () =>
+      Effect.gen(function*() {
+        const storage = yield* MessageStorage.MessageStorage
+        const snowflake = yield* Snowflake.Generator
+        const request = yield* makeRequest()
+        yield* storage.saveRequest(request)
+        yield* storage.saveEnvelope(Message.OutgoingEnvelope.interrupt({
+          id: snowflake.nextUnsafe(),
+          requestId: request.envelope.requestId,
+          address: request.envelope.address
+        }))
+
+        yield* storage.clearAddress(request.envelope.address)
+
+        const messages = yield* storage.unprocessedMessages([request.envelope.address.shardId])
+        expect(messages.map(({ envelope }) => envelope._tag)).toEqual([])
+      }).pipe(Effect.provide(MemoryLayer)))
+
     it.effect("encoded unprocessedMessages fails closed for an empty address filter", () =>
       Effect.gen(function*() {
         const driver = yield* MessageStorage.MemoryDriver

--- a/packages/effect/test/cluster/MessageStorage.test.ts
+++ b/packages/effect/test/cluster/MessageStorage.test.ts
@@ -400,3 +400,98 @@ export const makeEmptyReply = (request: Message.OutgoingRequest<any>) => {
     rpc: request.rpc
   })
 }
+
+describe("clearAddress control envelopes", () => {
+  it.effect.each([1, 2])("removes an unread Interrupt after %i clears", (clears) =>
+    Effect.gen(function*() {
+      const storage = yield* MessageStorage.MessageStorage
+      const snowflake = yield* Snowflake.Generator
+      const target = yield* makeRequest({ entityId: "target" })
+      const keep = yield* makeRequest({ entityId: "keep" })
+      yield* storage.saveRequest(target)
+      yield* storage.saveRequest(keep)
+      yield* storage.saveEnvelope(Message.OutgoingEnvelope.interrupt({
+        address: target.envelope.address,
+        requestId: target.envelope.requestId,
+        id: snowflake.nextUnsafe()
+      }))
+      for (let i = 0; i < clears; i++) {
+        yield* storage.clearAddress(target.envelope.address)
+      }
+      const messages = yield* storage.unprocessedMessages([target.envelope.address.shardId])
+      const actual = messages.map(({ envelope }) => [envelope._tag, String(envelope.requestId)])
+      const expected = [["Request", String(keep.envelope.requestId)]]
+      console.log(JSON.stringify({ witness: "memory-interrupt", clears, actual, expected }))
+      assert.deepStrictEqual(
+        messages.filter(({ envelope }) => envelope._tag === "Request").map(({ envelope }) => envelope.requestId),
+        [keep.envelope.requestId]
+      )
+      assert.deepStrictEqual(actual, expected)
+    }).pipe(Effect.provide(MemoryLayer)))
+
+  it.effect("clears requests without controls and remains idempotent", () =>
+    Effect.gen(function*() {
+      const storage = yield* MessageStorage.MessageStorage
+      const target = yield* makeRequest({ entityId: "target" })
+      const keep = yield* makeRequest({ entityId: "keep" })
+      yield* storage.saveRequest(target)
+      yield* storage.saveRequest(keep)
+      yield* storage.clearAddress(target.envelope.address)
+      yield* storage.clearAddress(target.envelope.address)
+      const messages = yield* storage.unprocessedMessages([target.envelope.address.shardId])
+      assert.deepStrictEqual(messages.map(({ envelope }) => envelope.requestId), [keep.envelope.requestId])
+    }).pipe(Effect.provide(MemoryLayer)))
+
+  it.effect("removes AckChunk while preserving unrelated requests controls and replies", () =>
+    Effect.gen(function*() {
+      const storage = yield* MessageStorage.MessageStorage
+      const snowflake = yield* Snowflake.Generator
+      const target = yield* makeRequest({
+        rpc: StreamRpc,
+        entityId: "target",
+        payload: StreamRpc.payloadSchema.make({ id: 123 })
+      })
+      const keep = yield* makeRequest({
+        rpc: StreamRpc,
+        entityId: "keep",
+        payload: StreamRpc.payloadSchema.make({ id: 123 })
+      })
+      yield* storage.saveRequest(target)
+      yield* storage.saveRequest(keep)
+      const targetChunk = yield* makeChunkReply(target, 0)
+      const keepChunk = yield* makeChunkReply(keep, 0)
+      yield* storage.saveReply(targetChunk)
+      yield* storage.saveReply(keepChunk)
+      const targetAck = yield* makeAckChunk(target, targetChunk)
+      const keepAck = yield* makeAckChunk(keep, keepChunk)
+      const keepInterrupt = Message.OutgoingEnvelope.interrupt({
+        address: keep.envelope.address,
+        requestId: keep.envelope.requestId,
+        id: snowflake.nextUnsafe()
+      })
+      yield* storage.saveEnvelope(targetAck)
+      yield* storage.saveEnvelope(keepAck)
+      yield* storage.saveEnvelope(keepInterrupt)
+      const keepReplies = yield* storage.repliesForUnfiltered([keep.envelope.requestId])
+      assert.strictEqual(keepReplies.length, 1)
+      assert.strictEqual((yield* storage.repliesForUnfiltered([target.envelope.requestId])).length, 1)
+      yield* storage.clearAddress(target.envelope.address)
+      yield* storage.clearAddress(target.envelope.address)
+      assert.deepStrictEqual(yield* storage.repliesForUnfiltered([target.envelope.requestId]), [])
+      assert.deepStrictEqual(yield* storage.repliesForUnfiltered([keep.envelope.requestId]), keepReplies)
+      const messages = yield* storage.unprocessedMessages([target.envelope.address.shardId])
+      const actual = messages.map(({ envelope }) => [envelope._tag, String(envelope.requestId)])
+      const expected = ["Request", "AckChunk", "Interrupt"].map((tag) => [tag, String(keep.envelope.requestId)])
+      console.log(JSON.stringify({ witness: "memory-ack", actual, expected }))
+      assert.deepStrictEqual(
+        actual.filter(([, requestId]) => requestId === String(keep.envelope.requestId)),
+        expected
+      )
+      assert.deepStrictEqual(actual, expected)
+      yield* storage.resetShards([target.envelope.address.shardId])
+      const reread = yield* storage.unprocessedMessages([target.envelope.address.shardId])
+      assert.deepStrictEqual(reread.map(({ envelope }) => [envelope._tag, envelope.requestId]), [
+        ["Request", keep.envelope.requestId]
+      ])
+    }).pipe(Effect.provide(MemoryLayer)))
+})


### PR DESCRIPTION
## Why

Memory `MessageStorage.clearAddress` removes an entity's requests but leaves unread control envelopes queued. A later mailbox read can return controls for an address that was already cleared.

## What changed

- Remove every matching envelope from the journal, unprocessed set, and last-read tracking.
- Keep request-map deletion conditional on request envelopes.
- Add a focused regression for a queued `Interrupt` through the public `MessageStorage` API.

## Verification

```bash
nix develop -c pnpm lint-fix
nix develop -c pnpm test --run packages/effect/test/cluster/MessageStorage.test.ts --maxWorkers=1 --no-file-parallelism
nix develop -c pnpm check
git diff --check
```

The regression failed before the implementation with `received ["Interrupt"]` and now passes. The focused file has 15 passing tests.

Closes #7834
Closes EFF-1144

## Audit

Runtime correctness audit; intended label: `audit`.
