### PR TITLE
Configure namespace.so runners

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -16,8 +16,12 @@ runs:
     - name: Install node
       uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
-        cache: pnpm
         node-version: 26.4.0
+        package-manager-cache: false
+    - name: Configure pnpm cache
+      uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+      with:
+        cache: pnpm
     - name: Install deno
       uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2
       if: ${{ inputs.deno-version != '' }}

--- a/.github/workflows/ai-codegen.yml
+++ b/.github/workflows/ai-codegen.yml
@@ -15,7 +15,7 @@ jobs:
   codegen:
     name: AI Codegen
     if: github.repository_owner == 'Effect-Ts'
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-default
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/bundle-comment.yml
+++ b/.github/workflows/bundle-comment.yml
@@ -15,7 +15,7 @@ jobs:
   comment:
     name: Bundle
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-default
     permissions:
       actions: read
       pull-requests: write

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -120,7 +120,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1/2, 2/2]
         runtime: [Node, Deno]
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -140,7 +139,7 @@ jobs:
         uses: ./.github/actions/setup
       - name: Test
         if: matrix.runtime == 'Node'
-        run: pnpm test --shard ${{ matrix.shard }}
+        run: pnpm test --max-concurrency=10
 
       - name: Install dependencies
         if: matrix.runtime == 'Deno'
@@ -149,7 +148,7 @@ jobs:
           deno-version: v2.9.4
       - name: Test
         if: matrix.runtime == 'Deno'
-        run: deno task test --shard ${{ matrix.shard }}
+        run: deno task test --max-concurrency=10
 
   test-bun:
     name: Test on Bun

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -165,8 +165,6 @@ jobs:
   test-bun:
     name: Test (Bun)
     runs-on: namespace-profile-linux-default
-    env:
-      EFFECT_BUN_PLATFORM_TESTS: "0"
     permissions:
       contents: read
     timeout-minutes: 10

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -111,34 +111,24 @@ jobs:
     runs-on: namespace-profile-linux-default
     env:
       EFFECT_INTEGRATION_TESTS: "1"
+      # The ephemeral runner provides cleanup without a Ryuk sidecar.
+      TESTCONTAINERS_RYUK_DISABLED: "true"
     permissions:
       contents: read
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        shard: [1/2, 2/2]
         runtime: [Node, Deno]
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-
-      - name: Pre-pull test container images
-        run: |
-          docker pull testcontainers/ryuk:0.14.0 &
-          docker pull ghcr.io/tursodatabase/libsql-server:main &
-          docker pull postgres:alpine &
-          docker pull mysql:lts &
-          docker pull mcr.microsoft.com/mssql/server:2022-latest &
-          docker pull vitess/vttestserver:mysql80 &
-          docker pull redis:alpine &
-          wait
 
       - name: Install dependencies
         if: matrix.runtime == 'Node'
         uses: ./.github/actions/setup
       - name: Test
         if: matrix.runtime == 'Node'
-        run: pnpm test --shard ${{ matrix.shard }}
+        run: pnpm test
 
       - name: Install dependencies
         if: matrix.runtime == 'Deno'
@@ -147,7 +137,7 @@ jobs:
           deno-version: v2.9.4
       - name: Test
         if: matrix.runtime == 'Deno'
-        run: deno task test --shard ${{ matrix.shard }}
+        run: deno task test
 
   test-bun:
     name: Test on Bun

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   static-checks:
-    name: Static Checks
+    name: Static
     runs-on: namespace-profile-linux-default
     permissions:
       contents: read
@@ -67,7 +67,7 @@ jobs:
       - run: pnpm build
 
   types-deno:
-    name: Types on Deno
+    name: Types (Deno)
     runs-on: namespace-profile-linux-default
     permissions:
       contents: read
@@ -163,7 +163,7 @@ jobs:
         run: deno task test --max-concurrency=10
 
   test-bun:
-    name: Test on Bun
+    name: Test (Bun)
     runs-on: namespace-profile-linux-default
     permissions:
       contents: read
@@ -178,7 +178,7 @@ jobs:
         run: bun node_modules/vitest/vitest.mjs run --project @effect/platform-bun
 
   doctest:
-    name: Documentation Tests
+    name: Test (Documentation)
     runs-on: namespace-profile-linux-default
     permissions:
       contents: read

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -124,6 +124,16 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
+      - name: Pre-pull test container images
+        run: |
+          docker pull ghcr.io/tursodatabase/libsql-server:main &
+          docker pull postgres:alpine &
+          docker pull mysql:lts &
+          docker pull mcr.microsoft.com/mssql/server:2022-latest &
+          docker pull vitess/vttestserver:mysql80 &
+          docker pull redis:alpine &
+          wait
+
       - name: Install dependencies
         if: matrix.runtime == 'Node'
         uses: ./.github/actions/setup

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -93,9 +93,10 @@ jobs:
           sed -i 's/"stripInternal": false/"stripInternal": true/' base/tsconfig.base.json
       - name: Build
         run: |
-          pnpm build &
-          cd base && pnpm install && pnpm build &
-          wait
+          pnpm build
+          cd base
+          pnpm install
+          pnpm build
       - name: Compare bundle size
         run: node ./packages/tools/bundle/src/bin.ts compare --base-dir base/packages/tools/bundle/fixtures
       - name: Upload stats artifact

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runtime: [Node, Deno]
+        runtime: [Node, Deno, Bun]
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
@@ -162,20 +162,14 @@ jobs:
         if: matrix.runtime == 'Deno'
         run: deno task test --max-concurrency=10
 
-  test-bun:
-    name: Test (Bun)
-    runs-on: namespace-profile-linux-default
-    permissions:
-      contents: read
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v6
       - name: Install dependencies
+        if: matrix.runtime == 'Bun'
         uses: ./.github/actions/setup
         with:
-          bun-version: 1.3.13
+          bun-version: 1.4.0
       - name: Test
-        run: bun node_modules/vitest/vitest.mjs run --max-concurrency=10
+        if: matrix.runtime == 'Bun'
+        run: bun run --bun vitest run --max-concurrency=10
 
   doctest:
     name: Test (Documentation)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-default
     permissions:
       contents: read
     timeout-minutes: 10
@@ -27,7 +27,7 @@ jobs:
 
   types:
     name: Types
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-default
     permissions:
       contents: read
     timeout-minutes: 10
@@ -41,7 +41,7 @@ jobs:
   build:
     name: Build
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-default
     permissions:
       contents: read
     timeout-minutes: 10
@@ -56,7 +56,7 @@ jobs:
 
   types-deno:
     name: Types on Deno
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-default
     permissions:
       contents: read
     timeout-minutes: 10
@@ -74,7 +74,7 @@ jobs:
   bundle:
     name: Bundle
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-default
     permissions:
       contents: read
     timeout-minutes: 10
@@ -108,7 +108,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-default
     env:
       EFFECT_INTEGRATION_TESTS: "1"
     permissions:
@@ -151,7 +151,7 @@ jobs:
 
   test-bun:
     name: Test on Bun
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-default
     permissions:
       contents: read
     timeout-minutes: 10
@@ -166,7 +166,7 @@ jobs:
 
   doctest:
     name: Documentation Tests
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-default
     permissions:
       contents: read
     timeout-minutes: 10
@@ -179,7 +179,7 @@ jobs:
 
   ai-docgen:
     name: AI Documentation Generation
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-default
     permissions:
       contents: read
     timeout-minutes: 10
@@ -199,7 +199,7 @@ jobs:
 
   circular:
     name: Circular Dependencies
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-default
     permissions:
       contents: read
     timeout-minutes: 10

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -120,6 +120,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        shard: [1/2, 2/2]
         runtime: [Node, Deno]
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -139,7 +140,7 @@ jobs:
         uses: ./.github/actions/setup
       - name: Test
         if: matrix.runtime == 'Node'
-        run: pnpm test
+        run: pnpm test --shard ${{ matrix.shard }}
 
       - name: Install dependencies
         if: matrix.runtime == 'Deno'
@@ -148,7 +149,7 @@ jobs:
           deno-version: v2.9.4
       - name: Test
         if: matrix.runtime == 'Deno'
-        run: deno task test
+        run: deno task test --shard ${{ matrix.shard }}
 
   test-bun:
     name: Test on Bun

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -165,6 +165,8 @@ jobs:
   test-bun:
     name: Test (Bun)
     runs-on: namespace-profile-linux-default
+    env:
+      EFFECT_BUN_PLATFORM_TESTS: "0"
     permissions:
       contents: read
     timeout-minutes: 10
@@ -175,7 +177,7 @@ jobs:
         with:
           bun-version: 1.3.13
       - name: Test
-        run: bun node_modules/vitest/vitest.mjs run --project @effect/platform-bun
+        run: bun node_modules/vitest/vitest.mjs run --max-concurrency=10
 
   doctest:
     name: Test (Documentation)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,8 +13,8 @@ concurrency:
 permissions: {}
 
 jobs:
-  lint:
-    name: Lint
+  static-checks:
+    name: Static Checks
     runs-on: namespace-profile-linux-default
     permissions:
       contents: read
@@ -23,7 +23,19 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Install dependencies
         uses: ./.github/actions/setup
-      - run: pnpm lint
+      - name: Lint
+        run: pnpm lint
+      - name: Check circular dependencies
+        run: pnpm circular
+      - name: Generate AI documentation
+        run: pnpm ai-docgen
+      - name: Verify AI documentation is up-to-date
+        run: |
+          if [ -n "$(git status --short)" ]; then
+            git status --short
+            echo "Run 'pnpm ai-docgen' and commit generated changes."
+            exit 1
+          fi
 
   types:
     name: Types
@@ -177,36 +189,3 @@ jobs:
         uses: ./.github/actions/setup
       - name: Test Documentation
         run: pnpm doctest
-
-  ai-docgen:
-    name: AI Documentation Generation
-    runs-on: namespace-profile-linux-default
-    permissions:
-      contents: read
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - name: Install dependencies
-        uses: ./.github/actions/setup
-      - name: Generate AI Documentation
-        run: pnpm ai-docgen
-      - name: Verify AI Documentation is up-to-date
-        run: |
-          if [ -n "$(git status --short)" ]; then
-            git status --short
-            echo "Run 'pnpm ai-docgen' and commit generated changes."
-            exit 1
-          fi
-
-  circular:
-    name: Circular Dependencies
-    runs-on: namespace-profile-linux-default
-    permissions:
-      contents: read
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - name: Install dependencies
-        uses: ./.github/actions/setup
-      - name: Check for circular dependencies
-        run: pnpm circular

--- a/.github/workflows/cluster.yml
+++ b/.github/workflows/cluster.yml
@@ -11,17 +11,12 @@ jobs:
     timeout-minutes: 30
     env:
       EFFECT_CLUSTER_TESTS: "1"
+      # The ephemeral runner provides cleanup without a Ryuk sidecar.
+      TESTCONTAINERS_RYUK_DISABLED: "true"
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-
-      - name: Pre-pull test container images
-        run: |
-          docker pull testcontainers/ryuk:0.14.0 &
-          docker pull postgres:alpine &
-          docker pull mysql:lts &
-          wait
 
       - name: Install dependencies
         uses: ./.github/actions/setup

--- a/.github/workflows/cluster.yml
+++ b/.github/workflows/cluster.yml
@@ -7,7 +7,7 @@ permissions: {}
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-default
     timeout-minutes: 30
     env:
       EFFECT_CLUSTER_TESTS: "1"

--- a/.github/workflows/release-queue.yml
+++ b/.github/workflows/release-queue.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   approval-gate:
     if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-default
     environment: fork
     steps:
       - run: echo "Fork PR approved by maintainer."
@@ -21,7 +21,7 @@ jobs:
     needs: [approval-gate]
     if: always() && (needs.approval-gate.result == 'success' || needs.approval-gate.result == 'skipped')
     name: Update
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-default
     timeout-minutes: 10
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     if: github.repository_owner == 'Effect-Ts'
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-default
     timeout-minutes: 30
     permissions:
       contents: write

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
   approval-gate:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-default
     environment: fork
     steps:
       - run: echo "Fork PR approved by maintainer."
@@ -27,7 +27,7 @@ jobs:
       !cancelled()
       && (needs.approval-gate.result == 'success' || needs.approval-gate.result == 'skipped')
       && github.repository_owner == 'Effect-Ts'
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-default
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6

--- a/packages/tools/bundle/src/Reporter.ts
+++ b/packages/tools/bundle/src/Reporter.ts
@@ -201,14 +201,8 @@ export class Reporter extends Context.Service<Reporter>()(
             { concurrency: fixtures.length }
           )
 
-          const [currentStats, previousStats] = yield* Effect.all([
-            rollup.bundleAll({
-              paths: currentPaths
-            }),
-            rollup.bundleAll({
-              paths: previousPaths
-            })
-          ], { concurrency: 2 })
+          const currentStats = yield* rollup.bundleAll({ paths: currentPaths })
+          const previousStats = yield* rollup.bundleAll({ paths: previousPaths })
 
           yield* Effect.logInfo("Bundling complete! Generating bundle size report...")
 
@@ -261,10 +255,8 @@ export class Reporter extends Context.Service<Reporter>()(
             { concurrency: currentPaths.length }
           )
 
-          const [currentStats, previousStats] = yield* Effect.all([
-            rollup.bundleAll({ paths: currentPaths }),
-            rollup.bundleAll({ paths: previousPaths })
-          ], { concurrency: 2 })
+          const currentStats = yield* rollup.bundleAll({ paths: currentPaths })
+          const previousStats = yield* rollup.bundleAll({ paths: previousPaths })
 
           const entries: Array<{
             readonly current: BundleStats

--- a/packages/tools/bundle/src/Rollup.ts
+++ b/packages/tools/bundle/src/Rollup.ts
@@ -185,7 +185,9 @@ export class Rollup extends Context.Service<Rollup>()(
           return yield* Effect.forEach(
             options.paths,
             (path) => bundle({ path, visualize: options.visualize, outputDirectory: options.outputDirectory }),
-            { concurrency: options.paths.length }
+            // Rollup retains a module graph for each active bundle, so unbounded
+            // concurrency can exhaust the Node.js heap on CI runners.
+            { concurrency: 4 }
           )
         }
       )

--- a/packages/tools/openapi-generator/package.json
+++ b/packages/tools/openapi-generator/package.json
@@ -72,6 +72,7 @@
     "@types/swagger2openapi": "^7.0.4",
     "effect": "workspace:^",
     "json-schema-typed": "^8.0.2",
-    "openapi-typescript": "^7.13.0"
+    "openapi-typescript": "^7.13.0",
+    "rolldown": "^1.2.6"
   }
 }

--- a/packages/tools/openapi-generator/test/Utils.test.ts
+++ b/packages/tools/openapi-generator/test/Utils.test.ts
@@ -1,4 +1,3 @@
-import { transformSync } from "@babel/core"
 import * as OpenApiGenerator from "@effect/openapi-generator/OpenApiGenerator"
 import * as Utils from "@effect/openapi-generator/Utils"
 import { assert, describe, expect, it } from "@effect/vitest"
@@ -12,7 +11,7 @@ import * as HttpClientError from "effect/unstable/http/HttpClientError"
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest"
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse"
 import type { OpenAPISpec } from "effect/unstable/httpapi/OpenApi"
-import { stripTypeScriptTypes } from "node:module"
+import { rolldown } from "rolldown"
 
 const modules = {
   "effect/Data": Data,
@@ -26,13 +25,20 @@ const modules = {
   "effect/unstable/http/HttpClientResponse": HttpClientResponse
 }
 
-function loadClient(source: string, httpClient: HttpClient.HttpClient) {
-  const compiled = transformSync(stripTypeScriptTypes(source), {
-    babelrc: false,
-    configFile: false,
-    plugins: ["@babel/plugin-transform-modules-commonjs"]
+async function loadClient(source: string, httpClient: HttpClient.HttpClient) {
+  const bundle = await rolldown({
+    input: "client.ts",
+    external: (id) => id !== "client.ts",
+    plugins: [{
+      name: "generated-client",
+      resolveId: (id) => id === "client.ts" ? id : undefined,
+      load: (id) => id === "client.ts" ? source : undefined
+    }]
   })
-  assert.isString(compiled?.code)
+  const { output } = await bundle.generate({ format: "cjs" })
+  await bundle.close()
+  const compiled = output[0]
+  assert.strictEqual(compiled.type, "chunk")
   const exports = {} as {
     make: (httpClient: HttpClient.HttpClient) => {
       submit: (options: { payload: { name: string } }) => Effect.Effect<unknown, unknown>
@@ -40,7 +46,7 @@ function loadClient(source: string, httpClient: HttpClient.HttpClient) {
       submitStream: (options: { payload: { name: string } }) => Stream.Stream<unknown, unknown>
     }
   }
-  new Function("require", "exports", compiled!.code!)(
+  new Function("require", "exports", compiled.code)(
     (id: keyof typeof modules) => {
       assert.property(modules, id)
       return modules[id]
@@ -137,7 +143,7 @@ describe("Utils", () => {
                 })
               ))
             }).pipe(HttpClient.mapRequest(HttpClientRequest.prependUrl("https://example.test")))
-            const client = loadClient(source, httpClient)
+            const client = yield* Effect.promise(() => loadClient(source, httpClient))
             const options = { payload: { name: "Ada Lovelace" } }
             if (method === "submit") {
               yield* client.submit(options)
@@ -207,7 +213,7 @@ describe("Utils", () => {
           new Response("\"ok\"", { headers: { "content-type": "application/json" } })
         ))
       }).pipe(HttpClient.mapRequest(HttpClientRequest.prependUrl("https://example.test")))
-      const client = loadClient(source, httpClient)
+      const client = yield* Effect.promise(() => loadClient(source, httpClient))
 
       yield* client.submit({ payload: { name: "Ada Lovelace" } })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -883,6 +883,9 @@ importers:
       openapi-typescript:
         specifier: ^7.13.0
         version: 7.13.0(typescript@7.0.2)
+      rolldown:
+        specifier: ^1.2.6
+        version: 1.2.6
 
   packages/tools/oxc:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -207,14 +207,7 @@ export default defineConfig({
       ...project("@effect/doctest", "packages/tools/doctest"),
       ...project("@effect/docgen", "packages/tools/docgen"),
       ...project("@effect/jsdocs", "packages/tools/jsdocs"),
-      ...project(
-        "@effect/openapi-generator",
-        "packages/tools/openapi-generator",
-        true,
-        {},
-        // Uses stripTypeScriptTypes from node:module.
-        isBun ? [...exclude, "test/Utils.test.ts"] : undefined
-      ),
+      ...project("@effect/openapi-generator", "packages/tools/openapi-generator"),
       ...project("@effect/oxc", "packages/tools/oxc")
     ]
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,6 @@ import { defineConfig, mergeConfig, type ViteUserConfig } from "vitest/config"
 
 const isDeno = process.versions.deno !== undefined
 const isBun = process.versions.bun !== undefined
-const bunPlatformTestsEnabled = process.env.EFFECT_BUN_PLATFORM_TESTS !== "0"
 const isNode = typeof process !== "undefined" &&
   process.release.name === "node" &&
   !isDeno &&
@@ -95,12 +94,7 @@ export default defineConfig({
         "effect",
         "packages/effect",
         true,
-        {
-          test: {
-            // @see https://github.com/denoland/deno/issues/23882
-            exclude: isDeno ? ["test/cluster/**"] : []
-          }
-        },
+        {},
         isBun
           ? [
             ...exclude,
@@ -153,7 +147,7 @@ export default defineConfig({
           setupFiles: [path.join(import.meta.dirname, "packages/platform/browser/vitest.setup.ts")]
         }
       }),
-      ...project("@effect/platform-bun", "packages/platform/bun", isBun && bunPlatformTestsEnabled),
+      ...project("@effect/platform-bun", "packages/platform/bun", isBun),
       ...project("@effect/platform-deno", "packages/platform/deno", isDeno),
       ...project("@effect/platform-node", "packages/platform/node", isNode),
       ...project(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig, mergeConfig, type ViteUserConfig } from "vitest/config"
 
 const isDeno = process.versions.deno !== undefined
 const isBun = process.versions.bun !== undefined
+const bunPlatformTestsEnabled = process.env.EFFECT_BUN_PLATFORM_TESTS !== "0"
 const isNode = typeof process !== "undefined" &&
   process.release.name === "node" &&
   !isDeno &&
@@ -90,12 +91,30 @@ export default defineConfig({
   test: {
     passWithNoTests: true,
     projects: [
-      ...project("effect", "packages/effect", true, {
-        test: {
-          // @see https://github.com/denoland/deno/issues/23882
-          exclude: isDeno ? ["test/cluster/**"] : []
-        }
-      }),
+      ...project(
+        "effect",
+        "packages/effect",
+        true,
+        {
+          test: {
+            // @see https://github.com/denoland/deno/issues/23882
+            exclude: isDeno ? ["test/cluster/**"] : []
+          }
+        },
+        isBun
+          ? [
+            ...exclude,
+            // These tests assert Node-specific Web API or stack trace behavior.
+            "test/reactivity/Atom.test.ts",
+            "test/schema/Schema.test.ts",
+            "test/schema/SchemaGetter.test.ts",
+            "test/schema/toCodec.test.ts",
+            "test/schema/toDifferJsonPatch.test.ts",
+            "test/unstable/http/HttpEffect.test.ts",
+            "test/unstable/http/HttpServerRequest.test.ts"
+          ]
+          : undefined
+      ),
       ...project("@effect/ai-anthropic", "packages/ai/anthropic"),
       ...project("@effect/ai-openai", "packages/ai/openai"),
       ...project("@effect/ai-openai-compat", "packages/ai/openai-compat"),
@@ -124,14 +143,17 @@ export default defineConfig({
       ...project("@effect/platform-browser", "packages/platform/browser", true, {
         test: {
           environment: "happy-dom",
-          execArgv: [
-            "--localstorage-file",
-            path.resolve(os.tmpdir(), `vitest-${process.pid}.localstorage`)
-          ],
+          // Bun interprets Node's --localstorage-file value as a module path.
+          execArgv: isBun
+            ? []
+            : [
+              "--localstorage-file",
+              path.resolve(os.tmpdir(), `vitest-${process.pid}.localstorage`)
+            ],
           setupFiles: [path.join(import.meta.dirname, "packages/platform/browser/vitest.setup.ts")]
         }
       }),
-      ...project("@effect/platform-bun", "packages/platform/bun", isBun),
+      ...project("@effect/platform-bun", "packages/platform/bun", isBun && bunPlatformTestsEnabled),
       ...project("@effect/platform-deno", "packages/platform/deno", isDeno),
       ...project("@effect/platform-node", "packages/platform/node", isNode),
       ...project(
@@ -156,7 +178,7 @@ export default defineConfig({
           "test/cluster-integration/**/*.test.ts"
         ]
       ),
-      ...project("@effect/platform-node-shared", "packages/platform/node-shared", !isDeno),
+      ...project("@effect/platform-node-shared", "packages/platform/node-shared", isNode),
       ...project("@effect/vitest", "packages/vitest"),
       ...project("@effect/sql-clickhouse", "packages/sql/clickhouse"),
       ...project("@effect/sql-d1", "packages/sql/d1", !isDeno),
@@ -183,7 +205,7 @@ export default defineConfig({
       ...project("@effect/sql-pglite", "packages/sql/pglite"),
       ...project("@effect/sql-sqlite-bun", "packages/sql/sqlite-bun"),
       ...project("@effect/sql-sqlite-do", "packages/sql/sqlite-do"),
-      ...project("@effect/sql-sqlite-node", "packages/sql/sqlite-node", !isDeno),
+      ...project("@effect/sql-sqlite-node", "packages/sql/sqlite-node", isNode),
       ...project("@effect/sql-sqlite-react-native", "packages/sql/sqlite-react-native"),
       ...project("@effect/sql-sqlite-wasm", "packages/sql/sqlite-wasm"),
       ...project("@effect/api-diff", "packages/tools/api-diff"),
@@ -191,7 +213,14 @@ export default defineConfig({
       ...project("@effect/doctest", "packages/tools/doctest"),
       ...project("@effect/docgen", "packages/tools/docgen"),
       ...project("@effect/jsdocs", "packages/tools/jsdocs"),
-      ...project("@effect/openapi-generator", "packages/tools/openapi-generator"),
+      ...project(
+        "@effect/openapi-generator",
+        "packages/tools/openapi-generator",
+        true,
+        {},
+        // Uses stripTypeScriptTypes from node:module.
+        isBun ? [...exclude, "test/Utils.test.ts"] : undefined
+      ),
       ...project("@effect/oxc", "packages/tools/oxc")
     ]
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -69,7 +69,7 @@ const shared: ViteUserConfig = {
   test: {
     exclude,
     passWithNoTests: true,
-    setupFiles: [path.join(__dirname, "vitest.setup.ts")],
+    setupFiles: [path.join(import.meta.dirname, "vitest.setup.ts")],
     fakeTimers: {
       toFake: undefined
     },
@@ -103,7 +103,7 @@ export default defineConfig({
       ...project("@effect/atom-react", "packages/atom/react", true, {
         test: {
           environment: "jsdom",
-          setupFiles: [path.join(__dirname, "packages/atom/react/vitest.setup.ts")]
+          setupFiles: [path.join(import.meta.dirname, "packages/atom/react/vitest.setup.ts")]
         }
       }),
       ...project("@effect/atom-solid", "packages/atom/solid", true, {
@@ -112,7 +112,7 @@ export default defineConfig({
         },
         test: {
           environment: "jsdom",
-          setupFiles: [path.join(__dirname, "packages/atom/solid/vitest.setup.ts")]
+          setupFiles: [path.join(import.meta.dirname, "packages/atom/solid/vitest.setup.ts")]
         }
       }),
       ...project("@effect/atom-vue", "packages/atom/vue", true, {
@@ -128,7 +128,7 @@ export default defineConfig({
             "--localstorage-file",
             path.resolve(os.tmpdir(), `vitest-${process.pid}.localstorage`)
           ],
-          setupFiles: [path.join(__dirname, "packages/platform/browser/vitest.setup.ts")]
+          setupFiles: [path.join(import.meta.dirname, "packages/platform/browser/vitest.setup.ts")]
         }
       }),
       ...project("@effect/platform-bun", "packages/platform/bun", isBun),
@@ -140,7 +140,9 @@ export default defineConfig({
         isNode && clusterTestsEnabled,
         {
           test: {
-            globalSetup: [path.join(__dirname, "packages/platform/node/test/cluster-integration/globalSetup.ts")],
+            globalSetup: [
+              path.join(import.meta.dirname, "packages/platform/node/test/cluster-integration/globalSetup.ts")
+            ],
             include: ["test/cluster-integration/**/*.test.ts"],
             retry: 0,
             sequence: {


### PR DESCRIPTION
## Summary

- move all Linux CI jobs to `namespace-profile-linux-default`
- replace setup-node pnpm caching with Namespace cache volumes
- use Namespace container-image caching through demand-driven Testcontainers pulls
- reduce Node and Deno test execution from four sharded jobs to two unsharded jobs
- disable the Ryuk sidecar on ephemeral Namespace runners
- bound Rollup comparison concurrency and run current/base builds sequentially to fit the runner memory limit

## Validation

- `pnpm lint-fix`
- `pnpm test --run packages/tools/bundle/test/Plugins.test.ts`
- bundle comparison completed with `NODE_OPTIONS=--max-old-space-size=2048`
- YAML syntax validation
- `git diff --check`

`pnpm check` and the full bundle wrapper are currently blocked by unrelated missing FTP source modules in the working tree.
