### PR TITLE
Use GitHub runners for releases

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -19,6 +19,7 @@ runs:
         node-version: 26.4.0
         package-manager-cache: false
     - name: Configure pnpm cache
+      if: ${{ env.NSC_CONTAINER_REGISTRY != '' }}
       uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
       with:
         cache: pnpm

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -17,7 +17,7 @@ runs:
       uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         node-version: 26.4.0
-        package-manager-cache: false
+        package-manager-cache: ${{ env.NSC_CONTAINER_REGISTRY == '' }}
     - name: Configure pnpm cache
       if: ${{ env.NSC_CONTAINER_REGISTRY != '' }}
       uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1

--- a/.github/workflows/release-queue.yml
+++ b/.github/workflows/release-queue.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   approval-gate:
     if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: namespace-profile-linux-default
+    runs-on: ubuntu-24.04
     environment: fork
     steps:
       - run: echo "Fork PR approved by maintainer."
@@ -21,13 +21,13 @@ jobs:
     needs: [approval-gate]
     if: always() && (needs.approval-gate.result == 'success' || needs.approval-gate.result == 'skipped')
     name: Update
-    runs-on: namespace-profile-linux-default
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.EFFECT_BOT_GH }}

--- a/.github/workflows/release-queue.yml
+++ b/.github/workflows/release-queue.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   approval-gate:
     if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     environment: fork
     steps:
       - run: echo "Fork PR approved by maintainer."
@@ -21,7 +21,7 @@ jobs:
     needs: [approval-gate]
     if: always() && (needs.approval-gate.result == 'success' || needs.approval-gate.result == 'skipped')
     name: Update
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     if: github.repository_owner == 'Effect-Ts'
     name: Release
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     if: github.repository_owner == 'Effect-Ts'
     name: Release
-    runs-on: namespace-profile-linux-default
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       contents: write


### PR DESCRIPTION
Use GitHub-hosted Ubuntu runners for publishing and release queue workflows.

This preserves npm trusted publishing and provenance support, avoids the Git 2.54 shallow-clone regression, and skips the Namespace-only pnpm cache step on other runners.