### PR TITLE
fix(openapi-generator): apply transformClient to streamed requests

### DIFF
--- a/.changeset/swift-streams-transform.md
+++ b/.changeset/swift-streams-transform.md
@@ -1,0 +1,5 @@
+---
+"@effect/openapi-generator": patch
+---
+
+Apply `transformClient` to generated streamed requests.

--- a/packages/tools/openapi-generator/src/OpenApiTransformer.ts
+++ b/packages/tools/openapi-generator/src/OpenApiTransformer.ts
@@ -261,6 +261,9 @@ ${clientErrorSource(name)}`
     }
 
     const helpers: Array<string> = [commonSource]
+    if (requiresStreaming(requirements)) {
+      helpers.push(executeStreamRequestSource)
+    }
     if (requirements.eventStreamData) {
       helpers.push(sseRequestSource(importName))
     }
@@ -686,6 +689,9 @@ ${clientErrorSource(name)}`
     }
 
     const helpers: Array<string> = [commonSource]
+    if (requiresStreaming(requirements)) {
+      helpers.push(executeStreamRequestSource)
+    }
     if (requirements.eventStream) {
       helpers.push(sseRequestSourceTs)
     }
@@ -973,6 +979,16 @@ const commonSource = `const unexpectedStatus = (response: HttpClientResponse.Htt
 const decodeBinarySource = `const decodeBinary = (response: HttpClientResponse.HttpClientResponse) =>
     Effect.map(response.arrayBuffer, (buffer) => new Uint8Array(buffer))`
 
+const executeStreamRequestSource = `const executeStreamRequest = (request: HttpClientRequest.HttpClientRequest) =>
+    Effect.suspend(() =>
+      options?.transformClient
+        ? Effect.flatMap(
+            options.transformClient(httpClient),
+            (client) => HttpClient.filterStatusOk(client).execute(request)
+          )
+        : HttpClient.filterStatusOk(httpClient).execute(request)
+    )`
+
 const decodeVoidErrorSource = (name: string) =>
   `const decodeVoidError = <const Tag extends string>(tag: Tag) =>
     (response: HttpClientResponse.HttpClientResponse) =>
@@ -1036,7 +1052,7 @@ const sseRequestSource = (_importName: string) =>
       HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError,
       DecodingServices
     > =>
-      HttpClient.filterStatusOk(httpClient).execute(request).pipe(
+      executeStreamRequest(request).pipe(
         Effect.map((response) => response.stream),
         Stream.unwrap,
         Stream.decodeText(),
@@ -1051,7 +1067,7 @@ const sseEventRequestSource = `const sseEventRequest = <S extends Sse.EventCodec
       HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError,
       S["DecodingServices"]
     > =>
-      HttpClient.filterStatusOk(httpClient).execute(request).pipe(
+      executeStreamRequest(request).pipe(
         Effect.map((response) => response.stream),
         Stream.unwrap,
         Stream.decodeText(),
@@ -1060,7 +1076,7 @@ const sseEventRequestSource = `const sseEventRequest = <S extends Sse.EventCodec
 
 const binaryRequestSource =
   `const binaryRequest = (request: HttpClientRequest.HttpClientRequest): Stream.Stream<Uint8Array, HttpClientError.HttpClientError> =>
-    HttpClient.filterStatusOk(httpClient).execute(request).pipe(
+    executeStreamRequest(request).pipe(
       Effect.map((response) => response.stream),
       Stream.unwrap
     )`
@@ -1068,7 +1084,7 @@ const binaryRequestSource =
 // Type-only mode helpers (no schema decoding)
 const sseRequestSourceTs =
   `const sseRequest = (request: HttpClientRequest.HttpClientRequest): Stream.Stream<unknown, HttpClientError.HttpClientError> =>
-    HttpClient.filterStatusOk(httpClient).execute(request).pipe(
+    executeStreamRequest(request).pipe(
       Effect.map((response) => response.stream),
       Stream.unwrap,
       Stream.decodeText(),
@@ -1079,7 +1095,7 @@ const sseRequestSourceTs =
 
 const binaryRequestSourceTs =
   `const binaryRequest = (request: HttpClientRequest.HttpClientRequest): Stream.Stream<Uint8Array, HttpClientError.HttpClientError> =>
-    HttpClient.filterStatusOk(httpClient).execute(request).pipe(
+    executeStreamRequest(request).pipe(
       Effect.map((response) => response.stream),
       Stream.unwrap
     )`

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -898,6 +898,7 @@ export const TestClientError = <Tag extends string, E>(
           `readonly "streamEventsSse": () => Stream.Stream<{ readonly event: string; readonly id: string | undefined; readonly data: typeof StreamEvents200Sse.Type }, HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError, typeof StreamEvents200Sse.DecodingServices>`,
           `"streamEventsSse": () => HttpClientRequest.get(\`/events\`).pipe(`,
           `sseRequest(StreamEvents200Sse)`,
+          `executeStreamRequest(request).pipe(`,
           `schema: Schema.ConstraintDecoder<Type, DecodingServices>`
         ]
       ))
@@ -959,6 +960,7 @@ export const TestClientError = <Tag extends string, E>(
           `"id": Schema.optionalKey(Schema.String), "event": Schema.Literal("effect/httpapi/stream/failure"), "data": Schema.String`,
           `readonly "streamEventsSse": () => Stream.Stream<typeof StreamEvents200Sse.Type, HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError, typeof StreamEvents200Sse.DecodingServices>`,
           `sseEventRequest(StreamEvents200Sse)`,
+          `executeStreamRequest(request).pipe(`,
           `Stream.pipeThroughChannel(Sse.decodeSchema(schema))`
         ]
       ))

--- a/packages/tools/openapi-generator/test/OpenApiStreamTransform.repro.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiStreamTransform.repro.test.ts
@@ -63,7 +63,7 @@ describe("OpenAPI streamed transformClient reproduction", () => {
           )
         }).pipe(HttpClient.mapRequest(HttpClientRequest.prependUrl("https://example.test")))
         const client = ReproClient.make(recordingClient, {
-          transformClient: (httpClient) => {
+          transformClient: (httpClient: HttpClient.HttpClient) => {
             transformCount += 1
             return Effect.succeed(
               httpClient.pipe(HttpClient.mapRequest(HttpClientRequest.setHeader("x-transformed", "yes")))

--- a/packages/tools/openapi-generator/test/OpenApiStreamTransform.repro.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiStreamTransform.repro.test.ts
@@ -1,0 +1,83 @@
+import * as OpenApiGenerator from "@effect/openapi-generator/OpenApiGenerator"
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as Stream from "effect/Stream"
+import * as HttpClient from "effect/unstable/http/HttpClient"
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest"
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse"
+import type { OpenAPISpec } from "effect/unstable/httpapi/OpenApi"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+const spec: OpenAPISpec = {
+  openapi: "3.1.0",
+  info: { title: "Stream transform repro", version: "1.0.0" },
+  paths: {
+    "/download": {
+      get: {
+        operationId: "download",
+        parameters: [],
+        responses: {
+          "200": {
+            description: "bytes",
+            content: {
+              "application/octet-stream": {
+                schema: { type: "string", format: "binary" }
+              }
+            }
+          }
+        },
+        tags: ["Repro"],
+        security: []
+      }
+    }
+  },
+  components: { schemas: {}, securitySchemes: {} },
+  security: [],
+  tags: [{ name: "Repro" }]
+}
+
+describe("OpenAPI streamed transformClient reproduction", () => {
+  it.effect("applies transformClient lazily when a generated binary stream runs", () =>
+    Effect.gen(function*() {
+      const generator = yield* OpenApiGenerator.OpenApiGenerator
+      const source = yield* generator.generate(spec, {
+        name: "ReproClient",
+        format: "httpclient"
+      })
+      const directory = mkdtempSync(
+        join(dirname(fileURLToPath(import.meta.url)), ".stream-transform-repro-")
+      )
+      const path = join(directory, "ReproClient.ts")
+      writeFileSync(path, source)
+
+      try {
+        const ReproClient = yield* Effect.tryPromise(() => import(pathToFileURL(path).href))
+        let recordedRequest: HttpClientRequest.HttpClientRequest | undefined
+        let transformCount = 0
+        const recordingClient = HttpClient.make((request) => {
+          recordedRequest = request
+          return Effect.succeed(
+            HttpClientResponse.fromWeb(request, new Response(new Uint8Array([1, 2, 3])))
+          )
+        }).pipe(HttpClient.mapRequest(HttpClientRequest.prependUrl("https://example.test")))
+        const client = ReproClient.make(recordingClient, {
+          transformClient: (httpClient) => {
+            transformCount += 1
+            return Effect.succeed(
+              httpClient.pipe(HttpClient.mapRequest(HttpClientRequest.setHeader("x-transformed", "yes")))
+            )
+          }
+        })
+
+        const stream = client.downloadStream()
+        assert.strictEqual(transformCount, 0)
+        yield* Effect.promise(() => Effect.runPromise(stream.pipe(Stream.runCollect)))
+        assert.strictEqual(recordedRequest?.headers["x-transformed"], "yes")
+        assert.strictEqual(transformCount, 1)
+      } finally {
+        rmSync(directory, { recursive: true, force: true })
+      }
+    }).pipe(Effect.provide(OpenApiGenerator.layerTransformerSchema)))
+})

--- a/packages/tools/openapi-generator/test/OpenApiStreamTransform.repro.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiStreamTransform.repro.test.ts
@@ -1,6 +1,7 @@
 import * as OpenApiGenerator from "@effect/openapi-generator/OpenApiGenerator"
 import { assert, describe, it } from "@effect/vitest"
 import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
 import * as Stream from "effect/Stream"
 import * as HttpClient from "effect/unstable/http/HttpClient"
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest"
@@ -38,6 +39,30 @@ const spec: OpenAPISpec = {
   tags: [{ name: "Repro" }]
 }
 
+const sseSpec: OpenAPISpec = {
+  ...spec,
+  paths: {
+    "/events": {
+      get: {
+        operationId: "events",
+        parameters: [],
+        responses: {
+          "200": {
+            description: "events",
+            content: {
+              "text/event-stream": {
+                schema: { type: "string" }
+              }
+            }
+          }
+        },
+        tags: ["Repro"],
+        security: []
+      }
+    }
+  }
+}
+
 describe("OpenAPI streamed transformClient reproduction", () => {
   it.effect("applies transformClient lazily when a generated binary stream runs", () =>
     Effect.gen(function*() {
@@ -55,11 +80,14 @@ describe("OpenAPI streamed transformClient reproduction", () => {
       try {
         const ReproClient = yield* Effect.tryPromise(() => import(pathToFileURL(path).href))
         let recordedRequest: HttpClientRequest.HttpClientRequest | undefined
+        let executionCount = 0
+        let responseStatus = 200
         let transformCount = 0
         const recordingClient = HttpClient.make((request) => {
+          executionCount += 1
           recordedRequest = request
           return Effect.succeed(
-            HttpClientResponse.fromWeb(request, new Response(new Uint8Array([1, 2, 3])))
+            HttpClientResponse.fromWeb(request, new Response(new Uint8Array([1, 2, 3]), { status: responseStatus }))
           )
         }).pipe(HttpClient.mapRequest(HttpClientRequest.prependUrl("https://example.test")))
         const client = ReproClient.make(recordingClient, {
@@ -76,8 +104,43 @@ describe("OpenAPI streamed transformClient reproduction", () => {
         yield* Effect.promise(() => Effect.runPromise(stream.pipe(Stream.runCollect)))
         assert.strictEqual(recordedRequest?.headers["x-transformed"], "yes")
         assert.strictEqual(transformCount, 1)
+        yield* Effect.promise(() => Effect.runPromise(stream.pipe(Stream.runCollect)))
+        assert.strictEqual(transformCount, 2)
+
+        const untransformedClient = ReproClient.make(recordingClient)
+        yield* Effect.promise(() => Effect.runPromise(untransformedClient.downloadStream().pipe(Stream.runCollect)))
+        assert.strictEqual(executionCount, 3)
+        assert.strictEqual(recordedRequest?.headers["x-transformed"], undefined)
+
+        responseStatus = 500
+        const exit = yield* Effect.promise(() =>
+          Effect.runPromise(Effect.exit(untransformedClient.downloadStream().pipe(Stream.runCollect)))
+        )
+        assert.isTrue(Exit.isFailure(exit))
       } finally {
         rmSync(directory, { recursive: true, force: true })
       }
     }).pipe(Effect.provide(OpenApiGenerator.layerTransformerSchema)))
+
+  it.effect("routes type-only binary and SSE streams through the shared executor", () =>
+    Effect.gen(function*() {
+      const generator = yield* OpenApiGenerator.OpenApiGenerator
+      const binarySource = yield* generator.generate(spec, {
+        name: "ReproClient",
+        format: "httpclient-type-only"
+      })
+      const sseSource = yield* generator.generate(sseSpec, {
+        name: "ReproClient",
+        format: "httpclient-type-only"
+      })
+
+      assert.include(
+        binarySource,
+        `const binaryRequest = (request: HttpClientRequest.HttpClientRequest): Stream.Stream<Uint8Array, HttpClientError.HttpClientError> =>\n    executeStreamRequest(request).pipe(`
+      )
+      assert.include(
+        sseSource,
+        `const sseRequest = (request: HttpClientRequest.HttpClientRequest): Stream.Stream<unknown, HttpClientError.HttpClientError> =>\n    executeStreamRequest(request).pipe(`
+      )
+    }).pipe(Effect.provide(OpenApiGenerator.layerTransformerTs)))
 })


### PR DESCRIPTION
## What

Suggested source-level fix for generated binary and SSE requests that bypass `transformClient`.

## Why

`transformClient` applies to ordinary generated requests but not streamed requests, which can omit authorization, tracing, proxy, or other request middleware. Related to #7846.

This is a suggested implementation; maintainers can choose a different approach.

## Worth a close look

`executeStreamRequest` is emitted only for generated clients with streaming support. `Effect.suspend` keeps transform selection lazy, and `HttpClient.filterStatusOk` wraps the transformed client.

## Verified

- The public no-network binary repro fails on unpatched `main` and passes with this change.
- Transform invocation is lazy and happens once per stream subscription.
- Untransformed execution and non-2xx status failure remain covered.
- All five helper-template mutations fail a matching test.
- `pnpm lint-fix`, focused generator tests (36 passing), `pnpm check`, and the openapi-generator build pass.

### Diff size

**Docs** — 1 file · `+5 / -0`

Patch release metadata for `@effect/openapi-generator`.

**Implementation** — 1 file · `+21 / -5`

One generated lazy executor routes all streamed request paths through the transformed client.

**Tests** — 2 files · `+148 / -0`

One executable public reproduction plus helper-specific assertions protect binary and SSE output in both generator modes.
