### PR TITLE
Stabilize durable clock routing test

### DIFF
--- a/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
+++ b/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
@@ -556,12 +556,15 @@ describe.concurrent("ClusterWorkflowEngine", () => {
         id: "sharded-clock"
       }).pipe(Effect.forkChild({ startImmediately: true }))
 
-      yield* TestClock.adjust(1)
-
-      const envelope = driver.journal.find((envelope) =>
+      let envelope = driver.journal.find((envelope) =>
         envelope._tag === "Request" && envelope.address.entityType === "Workflow/-/DurableClock"
       )
-      assert(envelope)
+      while (envelope === undefined) {
+        yield* Effect.yieldNow
+        envelope = driver.journal.find((envelope) =>
+          envelope._tag === "Request" && envelope.address.entityType === "Workflow/-/DurableClock"
+        )
+      }
       assert.strictEqual(envelope.address.shardId.group, "workflow")
       const deliverAt = driver.requests.get(envelope.requestId)?.deliverAt
       assert.isNumber(deliverAt)

--- a/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
+++ b/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
@@ -1,5 +1,19 @@
 import { assert, describe, expect, it } from "@effect/vitest"
-import { Cause, Context, DateTime, Duration, Effect, Exit, Fiber, Layer, Option, Result, Schema, Tracer } from "effect"
+import {
+  Cause,
+  Context,
+  DateTime,
+  Duration,
+  Effect,
+  Exit,
+  Fiber,
+  Latch,
+  Layer,
+  Option,
+  Result,
+  Schema,
+  Tracer
+} from "effect"
 import { TestClock } from "effect/testing"
 import {
   ClusterSchema,
@@ -550,21 +564,19 @@ describe.concurrent("ClusterWorkflowEngine", () => {
     Effect.gen(function*() {
       const driver = yield* MessageStorage.MemoryDriver
       const sharding = yield* Sharding.Sharding
+      const scheduled = yield* ShardedClockScheduled
       const startedAt = yield* DateTime.now
 
       const fiber = yield* ShardedClockWorkflow.execute({
         id: "sharded-clock"
       }).pipe(Effect.forkChild({ startImmediately: true }))
 
-      let envelope = driver.journal.find((envelope) =>
+      yield* scheduled.await
+
+      const envelope = driver.journal.find((envelope) =>
         envelope._tag === "Request" && envelope.address.entityType === "Workflow/-/DurableClock"
       )
-      while (envelope === undefined) {
-        yield* Effect.yieldNow
-        envelope = driver.journal.find((envelope) =>
-          envelope._tag === "Request" && envelope.address.entityType === "Workflow/-/DurableClock"
-        )
-      }
+      assert(envelope)
       assert.strictEqual(envelope.address.shardId.group, "workflow")
       const deliverAt = driver.requests.get(envelope.requestId)?.deliverAt
       assert.isNumber(deliverAt)
@@ -1361,12 +1373,26 @@ const ShardedClockWorkflow = Workflow.make("ShardedClockWorkflow", {
   }
 }).annotate(ClusterSchema.ShardGroup, () => "workflow")
 
+class ShardedClockScheduled extends Context.Service<ShardedClockScheduled>()("ShardedClockScheduled", {
+  make: Latch.make()
+}) {
+  static readonly layer = Layer.effect(ShardedClockScheduled, this.make)
+}
+
 const ShardedClockWorkflowLayer = ShardedClockWorkflow.toLayer(Effect.fnUntraced(function*() {
-  yield* DurableClock.sleep({
+  const engine = yield* WorkflowEngine
+  const instance = yield* WorkflowInstance
+  const scheduled = yield* ShardedClockScheduled
+  const clock = DurableClock.make({
     name: "ShardedClock",
-    duration: 10000.5,
-    inMemoryThreshold: Duration.zero
+    duration: 10000.5
   })
+  yield* engine.scheduleClock(instance.workflow, {
+    executionId: instance.executionId,
+    clock
+  })
+  yield* scheduled.open
+  yield* DurableDeferred.await(clock.deferred)
 }))
 
 const ShardedDeferred = DurableDeferred.make("ShardedDeferred")
@@ -1481,5 +1507,6 @@ const TestWorkflowLayer = EmailWorkflowLayer.pipe(
   Layer.merge(CatchWorkflowLayer),
   Layer.merge(ErrorDefectWorkflowLayer),
   Layer.provideMerge(Flags.layer),
+  Layer.provideMerge(ShardedClockScheduled.layer),
   Layer.provideMerge(TestWorkflowEngine)
 )


### PR DESCRIPTION
## Summary

- synchronize the durable clock routing test with a latch opened after `scheduleClock` completes
- keep `TestClock` fixed until the durable request is persisted
- preserve the fractional-millisecond `deliverAt` assertion without scheduler polling

Fixes the flaky Deno failure observed in https://github.com/Effect-TS/effect/actions/runs/33740674209/job/100601572234.

## Validation

- `pnpm lint-fix`
- 30 focused Deno test iterations
- `deno task test --run packages/effect/test/cluster/ClusterWorkflowEngine.test.ts`
- `pnpm test --run packages/effect/test/cluster/ClusterWorkflowEngine.test.ts`
- `pnpm check`