### PR TITLE
fix(Random, Crypto): prevent rounding to exclusive upper bounds

### DIFF
--- a/.changeset/random-exclusive-upper-endpoint.md
+++ b/.changeset/random-exclusive-upper-endpoint.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Fix `Random.nextBetween(min, max)` returning the excluded `max` due to floating-point rounding when `min < max`, both bounds are finite, and `max - min` is finite. These results now return the nearest representable number below `max`, still using exactly one random draw.
+
+Degenerate or unsupported inputs retain the existing formula behavior. This correction does not introduce a general invalid-input or overflow policy.

--- a/.changeset/random-exclusive-upper-endpoint.md
+++ b/.changeset/random-exclusive-upper-endpoint.md
@@ -2,6 +2,4 @@
 "effect": patch
 ---
 
-Fix `Random.nextBetween(min, max)` returning the excluded `max` due to floating-point rounding when `min < max`, both bounds are finite, and `max - min` is finite. These results now return the nearest representable number below `max`, still using exactly one random draw.
-
-Degenerate or unsupported inputs retain the existing formula behavior. This correction does not introduce a general invalid-input or overflow policy.
+Fix `Random.nextBetween` returning its exclusive upper bound when floating-point arithmetic rounds up.

--- a/.changeset/random-exclusive-upper-endpoint.md
+++ b/.changeset/random-exclusive-upper-endpoint.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix `Random.nextBetween` returning its exclusive upper bound when floating-point arithmetic rounds up.
+Fix `Random.nextBetween` and `Crypto.randomBetween` returning their exclusive upper bound when floating-point arithmetic rounds up.

--- a/packages/effect/src/Crypto.ts
+++ b/packages/effect/src/Crypto.ts
@@ -252,7 +252,7 @@ export const make = (
     random: Effect.sync(() => nextDoubleUnsafe()),
     randomBoolean: Effect.sync(() => nextDoubleUnsafe() > 0.5),
     randomInt: Effect.sync(() => nextIntUnsafe()),
-    randomBetween: (min, max) => Effect.sync(() => random.nextBetween(nextDoubleUnsafe(), min, max)),
+    randomBetween: (min, max) => Effect.sync(() => random.nextBetween(min, max, nextDoubleUnsafe())),
     randomIntBetween(min, max, options) {
       const extra = options?.halfOpen === true ? 0 : 1
       return Effect.sync(() => {

--- a/packages/effect/src/Crypto.ts
+++ b/packages/effect/src/Crypto.ts
@@ -11,6 +11,7 @@
  */
 import * as Context from "./Context.ts"
 import * as Effect from "./Effect.ts"
+import * as random from "./internal/random.ts"
 import * as Uuid from "./internal/uuid.ts"
 import * as PlatformError from "./PlatformError.ts"
 
@@ -251,7 +252,7 @@ export const make = (
     random: Effect.sync(() => nextDoubleUnsafe()),
     randomBoolean: Effect.sync(() => nextDoubleUnsafe() > 0.5),
     randomInt: Effect.sync(() => nextIntUnsafe()),
-    randomBetween: (min, max) => Effect.sync(() => nextDoubleUnsafe() * (max - min) + min),
+    randomBetween: (min, max) => Effect.sync(() => random.nextBetween(nextDoubleUnsafe(), min, max)),
     randomIntBetween(min, max, options) {
       const extra = options?.halfOpen === true ? 0 : 1
       return Effect.sync(() => {

--- a/packages/effect/src/Random.ts
+++ b/packages/effect/src/Random.ts
@@ -155,7 +155,7 @@ export const nextInt: Effect.Effect<number> = randomWith((r) => r.nextIntUnsafe(
 export const nextBetween = (min: number, max: number): Effect.Effect<number> =>
   randomWith((r) => {
     const value = r.nextDoubleUnsafe() * (max - min) + min
-    if (value !== max || min >= max || !Number.isFinite(max) || !Number.isFinite(max - min)) {
+    if (value !== max || min >= max || !Number.isFinite(max)) {
       return value
     }
     // Rounding can reach the excluded endpoint even for a draw below 1.
@@ -165,7 +165,8 @@ export const nextBetween = (min: number, max: number): Effect.Effect<number> =>
     }
     const view = new DataView(new ArrayBuffer(8))
     view.setFloat64(0, max)
-    view.setBigUint64(0, view.getBigUint64(0) + BigInt(max > 0 ? -1 : 1))
+    const bits = view.getBigUint64(0)
+    view.setBigUint64(0, max > 0 ? bits - BigInt(1) : bits + BigInt(1))
     return view.getFloat64(0)
   })
 

--- a/packages/effect/src/Random.ts
+++ b/packages/effect/src/Random.ts
@@ -153,7 +153,7 @@ export const nextInt: Effect.Effect<number> = randomWith((r) => r.nextIntUnsafe(
  * @since 4.0.0
  */
 export const nextBetween = (min: number, max: number): Effect.Effect<number> =>
-  randomWith((r) => random.nextBetween(r.nextDoubleUnsafe(), min, max))
+  randomWith((r) => random.nextBetween(min, max, r.nextDoubleUnsafe()))
 
 /**
  * Generates a random integer between `min` and `max`.

--- a/packages/effect/src/Random.ts
+++ b/packages/effect/src/Random.ts
@@ -153,7 +153,21 @@ export const nextInt: Effect.Effect<number> = randomWith((r) => r.nextIntUnsafe(
  * @since 4.0.0
  */
 export const nextBetween = (min: number, max: number): Effect.Effect<number> =>
-  randomWith((r) => r.nextDoubleUnsafe() * (max - min) + min)
+  randomWith((r) => {
+    const value = r.nextDoubleUnsafe() * (max - min) + min
+    if (value !== max || min >= max || !Number.isFinite(max) || !Number.isFinite(max - min)) {
+      return value
+    }
+    // Rounding can reach the excluded endpoint even for a draw below 1.
+    // Return its immediate predecessor, which is at least min for finite min < max.
+    if (max === 0) {
+      return -Number.MIN_VALUE
+    }
+    const view = new DataView(new ArrayBuffer(8))
+    view.setFloat64(0, max)
+    view.setBigUint64(0, view.getBigUint64(0) + BigInt(max > 0 ? -1 : 1))
+    return view.getFloat64(0)
+  })
 
 /**
  * Generates a random integer between `min` and `max`.

--- a/packages/effect/src/Random.ts
+++ b/packages/effect/src/Random.ts
@@ -153,22 +153,7 @@ export const nextInt: Effect.Effect<number> = randomWith((r) => r.nextIntUnsafe(
  * @since 4.0.0
  */
 export const nextBetween = (min: number, max: number): Effect.Effect<number> =>
-  randomWith((r) => {
-    const value = r.nextDoubleUnsafe() * (max - min) + min
-    if (value !== max || min >= max || !Number.isFinite(max)) {
-      return value
-    }
-    // Rounding can reach the excluded endpoint even for a draw below 1.
-    // Return its immediate predecessor, which is at least min for finite min < max.
-    if (max === 0) {
-      return -Number.MIN_VALUE
-    }
-    const view = new DataView(new ArrayBuffer(8))
-    view.setFloat64(0, max)
-    const bits = view.getBigUint64(0)
-    view.setBigUint64(0, max > 0 ? bits - BigInt(1) : bits + BigInt(1))
-    return view.getFloat64(0)
-  })
+  randomWith((r) => random.nextBetween(r.nextDoubleUnsafe(), min, max))
 
 /**
  * Generates a random integer between `min` and `max`.

--- a/packages/effect/src/internal/random.ts
+++ b/packages/effect/src/internal/random.ts
@@ -13,3 +13,21 @@ export const Random: Context.Reference<RandomService> = Context.Reference<Random
     }
   })
 })
+
+/** @internal */
+export const nextBetween = (draw: number, min: number, max: number): number => {
+  const value = draw * (max - min) + min
+  if (value !== max || min >= max || !Number.isFinite(max)) {
+    return value
+  }
+  // Rounding can reach the excluded endpoint even for a draw below 1.
+  // Return its immediate predecessor, which is at least min for finite min < max.
+  if (max === 0) {
+    return -Number.MIN_VALUE
+  }
+  const view = new DataView(new ArrayBuffer(8))
+  view.setFloat64(0, max)
+  const bits = view.getBigUint64(0)
+  view.setBigUint64(0, max > 0 ? bits - BigInt(1) : bits + BigInt(1))
+  return view.getFloat64(0)
+}

--- a/packages/effect/src/internal/random.ts
+++ b/packages/effect/src/internal/random.ts
@@ -15,7 +15,7 @@ export const Random: Context.Reference<RandomService> = Context.Reference<Random
 })
 
 /** @internal */
-export const nextBetween = (draw: number, min: number, max: number): number => {
+export const nextBetween = (min: number, max: number, draw: number): number => {
   const value = draw * (max - min) + min
   if (value !== max || min >= max || !Number.isFinite(max)) {
     return value

--- a/packages/effect/test/Crypto.test.ts
+++ b/packages/effect/test/Crypto.test.ts
@@ -64,6 +64,13 @@ describe("Crypto", () => {
       assert.deepStrictEqual(randomShuffle, [1, 2, 3])
     }).pipe(Effect.provideService(Crypto.Crypto, testCrypto)))
 
+  it.effect("randomBetween excludes the upper bound when the result rounds up", () =>
+    Effect.gen(function*() {
+      const value = yield* makeCrypto((1n << 53n) - 2n).randomBetween(10, 20)
+
+      assert.isBelow(value, 20)
+    }))
+
   it("maps adjacent random values to adjacent safe integers", () => {
     assert.strictEqual(makeCrypto(0n).nextIntUnsafe(), Number.MIN_SAFE_INTEGER)
     assert.strictEqual(makeCrypto(1n).nextIntUnsafe(), Number.MIN_SAFE_INTEGER + 1)

--- a/packages/effect/test/Crypto.test.ts
+++ b/packages/effect/test/Crypto.test.ts
@@ -68,7 +68,9 @@ describe("Crypto", () => {
     Effect.gen(function*() {
       const value = yield* makeCrypto((1n << 53n) - 2n).randomBetween(10, 20)
 
+      assert.isAtLeast(value, 10)
       assert.isBelow(value, 20)
+      assert.strictEqual(value, 20 - 2 ** -48)
     }))
 
   it("maps adjacent random values to adjacent safe integers", () => {

--- a/packages/effect/test/Random.test.ts
+++ b/packages/effect/test/Random.test.ts
@@ -81,17 +81,28 @@ describe("Random", () => {
         assert.strictEqual(value, expected)
       }))
 
-    it.effect("preserves unsupported bounds", () =>
+    it.effect("preserves degenerate bounds", () =>
       Effect.gen(function*() {
-        const program = Effect.all([Random.nextBetween(10, 10), Random.nextBetween(10, Infinity)])
-        const values = yield* program.pipe(
+        const value = yield* Random.nextBetween(10, 10).pipe(
           Effect.provideService(Random.Random, {
             nextIntUnsafe: () => 0,
             nextDoubleUnsafe: () => 0.75
           })
         )
 
-        assert.deepStrictEqual(values, [10, Infinity])
+        assert.strictEqual(value, 10)
+      }))
+
+    it.effect("documents current behavior for unsupported bounds", () =>
+      Effect.gen(function*() {
+        const value = yield* Random.nextBetween(10, Infinity).pipe(
+          Effect.provideService(Random.Random, {
+            nextIntUnsafe: () => 0,
+            nextDoubleUnsafe: () => 0.75
+          })
+        )
+
+        assert.strictEqual(value, Infinity)
       }))
 
     it.effect("generates number in half-open range", () =>

--- a/packages/effect/test/Random.test.ts
+++ b/packages/effect/test/Random.test.ts
@@ -62,129 +62,36 @@ describe("Random", () => {
   describe("nextBetween", () => {
     it.effect.each(
       [
-        ["unit high control", 0, 1, 1 - Number.EPSILON, 1 - Number.EPSILON],
-        ["ordinary interior control", 10, 20, 0.75, 17.5],
-        ["inclusive lower control", 10, 20, 0, 10],
-        ["negative interior control", -20, -10, 0.75, -12.5],
-        ["cross-zero interior control", -10, 10, 0.75, 5],
-        ["positive zero lower control", 0, 1, 0, 0],
-        ["negative zero lower control", -0, 1, 0, 0],
-        ["ordinary upper rounding", 10, 20, 1 - Number.EPSILON, 20 - 2 ** -48],
-        ["adjacent positive integers", 1e16, 1e16 + 2, 0.75, 1e16],
-        ["adjacent negative integers", -1e16 - 2, -1e16, 0.75, -1e16 - 2],
-        ["positive unit endpoint", 1 - 2 ** -53, 1, 0.75, 1 - 2 ** -53],
-        ["positive power-of-two endpoint", 2 - 2 ** -52, 2, 0.75, 2 - 2 ** -52],
-        ["negative unit endpoint", -1 - 2 ** -52, -1, 0.75, -1 - 2 ** -52],
-        ["negative power-of-two endpoint", -2 - 2 ** -51, -2, 0.75, -2 - 2 ** -51],
-        ["positive zero upper", -Number.MIN_VALUE, 0, 0.75, -Number.MIN_VALUE],
-        ["negative zero upper", -Number.MIN_VALUE, -0, 0.75, -Number.MIN_VALUE],
-        ["smallest positive upper", 0, Number.MIN_VALUE, 0.75, 0],
-        ["smallest positive upper from negative zero", -0, Number.MIN_VALUE, 0.75, 0],
-        ["cross-zero subnormal", -Number.MIN_VALUE, Number.MIN_VALUE, 0.75, 0],
-        ["positive subnormal", Number.MIN_VALUE, 2 * Number.MIN_VALUE, 0.75, Number.MIN_VALUE],
-        ["negative subnormal", -2 * Number.MIN_VALUE, -Number.MIN_VALUE, 0.75, -2 * Number.MIN_VALUE],
-        ["smallest positive normal", 2 ** -1022 - Number.MIN_VALUE, 2 ** -1022, 0.75, 2 ** -1022 - Number.MIN_VALUE],
-        ["negative normal-subnormal boundary", -(2 ** -1022), -(2 ** -1022) + Number.MIN_VALUE, 0.75, -(2 ** -1022)],
-        ["largest finite upper", Number.MAX_VALUE - 2 ** 971, Number.MAX_VALUE, 0.75, Number.MAX_VALUE - 2 ** 971],
-        ["smallest finite lower", -Number.MAX_VALUE, -Number.MAX_VALUE + 2 ** 971, 0.75, -Number.MAX_VALUE]
+        ["positive", 10, 20, 1 - Number.EPSILON, 20 - 2 ** -48],
+        ["adjacent", 1e16, 1e16 + 2, 0.75, 1e16],
+        ["negative", -1e16 - 2, -1e16, 0.75, -1e16 - 2],
+        ["zero", -Number.MIN_VALUE, 0, 0.75, -Number.MIN_VALUE]
       ] as const
-    )("excludes the upper endpoint with one draw: %s", ([_name, min, max, draw, expected]) =>
+    )("excludes a rounded upper bound: %s", ([_name, min, max, draw, expected]) =>
       Effect.gen(function*() {
-        assert.isTrue(Number.isFinite(min) && Number.isFinite(max) && Number.isFinite(max - min))
-        assert.isBelow(min, max)
-        assert.isAtLeast(draw, 0)
-        assert.isBelow(draw, 1)
-        let doubleCalls = 0
-        let intCalls = 0
         const value = yield* Random.nextBetween(min, max).pipe(
           Effect.provideService(Random.Random, {
-            nextIntUnsafe: () => {
-              intCalls++
-              return 0
-            },
-            nextDoubleUnsafe: () => {
-              doubleCalls++
-              return draw
-            }
+            nextIntUnsafe: () => 0,
+            nextDoubleUnsafe: () => draw
           })
         )
-        assert.strictEqual(doubleCalls, 1)
-        assert.strictEqual(intCalls, 0)
+
         assert.isAtLeast(value, min)
         assert.isBelow(value, max)
-        assert.isTrue(Object.is(value, expected))
+        assert.strictEqual(value, expected)
       }))
 
-    it.effect("does not retry a constant provider", () =>
+    it.effect("preserves unsupported bounds", () =>
       Effect.gen(function*() {
-        let calls = 0
-        const values = yield* Effect.all([
-          Random.nextBetween(10, 20),
-          Random.nextBetween(10, 20),
-          Random.nextBetween(10, 20)
-        ]).pipe(Effect.provideService(Random.Random, {
-          nextIntUnsafe: () => 0,
-          nextDoubleUnsafe: () => {
-            calls++
-            return 1 - Number.EPSILON
-          }
-        }))
-        assert.strictEqual(calls, 3)
-        assert.deepStrictEqual(values, [20 - 2 ** -48, 20 - 2 ** -48, 20 - 2 ** -48])
-      }))
-
-    it.effect("preserves the in-range seeded formula and following draw", () =>
-      Effect.gen(function*() {
-        const bounds = [[0, 1], [10, 20], [-20, -10], [-10, 10], [10.5, 20.5]] as const
-        const draws = yield* Effect.all(bounds.map(() => Random.next)).pipe(Random.withSeed("next-between-formula"))
-        const expected = bounds.map(([min, max], i) => draws[i] * (max - min) + min)
-        for (let i = 0; i < bounds.length; i++) {
-          assert.isAtLeast(expected[i], bounds[i][0])
-          assert.isBelow(expected[i], bounds[i][1])
-        }
-        const actual = yield* Effect.all(bounds.map(([min, max]) => Random.nextBetween(min, max))).pipe(
-          Random.withSeed("next-between-formula")
+        const program = Effect.all([Random.nextBetween(10, 10), Random.nextBetween(10, Infinity)])
+        const values = yield* program.pipe(
+          Effect.provideService(Random.Random, {
+            nextIntUnsafe: () => 0,
+            nextDoubleUnsafe: () => 0.75
+          })
         )
-        assert.deepStrictEqual(actual, expected)
 
-        const withBounded = yield* Effect.all([Random.nextBetween(10, 20), Random.next]).pipe(
-          Random.withSeed("next-between-formula")
-        )
-        const raw = yield* Effect.all([Random.next, Random.next]).pipe(Random.withSeed("next-between-formula"))
-        assert.deepStrictEqual(withBounded, [raw[0] * 10 + 10, raw[1]])
-      }))
-
-    it.effect("leaves degenerate and unsupported bounds on the existing formula", () =>
-      Effect.gen(function*() {
-        // Compatibility guards only: these cases do not establish a new bounds policy.
-        const bounds = [
-          [10, 10],
-          [0, -0],
-          [-0, 0],
-          [20, 10],
-          [NaN, 20],
-          [10, NaN],
-          [10, Infinity],
-          [-Infinity, 20],
-          [-Infinity, Infinity],
-          [-Number.MAX_VALUE, Number.MAX_VALUE]
-        ] as const
-        for (const [min, max] of bounds) {
-          for (const draw of [0, 0.75, 1 - Number.EPSILON]) {
-            let calls = 0
-            const value = yield* Random.nextBetween(min, max).pipe(
-              Effect.provideService(Random.Random, {
-                nextIntUnsafe: () => 0,
-                nextDoubleUnsafe: () => {
-                  calls++
-                  return draw
-                }
-              })
-            )
-            assert.strictEqual(calls, 1)
-            assert.isTrue(Object.is(value, draw * (max - min) + min))
-          }
-        }
+        assert.deepStrictEqual(values, [10, Infinity])
       }))
 
     it.effect("generates number in half-open range", () =>

--- a/packages/effect/test/Random.test.ts
+++ b/packages/effect/test/Random.test.ts
@@ -60,6 +60,133 @@ describe("Random", () => {
   })
 
   describe("nextBetween", () => {
+    it.effect.each(
+      [
+        ["unit high control", 0, 1, 1 - Number.EPSILON, 1 - Number.EPSILON],
+        ["ordinary interior control", 10, 20, 0.75, 17.5],
+        ["inclusive lower control", 10, 20, 0, 10],
+        ["negative interior control", -20, -10, 0.75, -12.5],
+        ["cross-zero interior control", -10, 10, 0.75, 5],
+        ["positive zero lower control", 0, 1, 0, 0],
+        ["negative zero lower control", -0, 1, 0, 0],
+        ["ordinary upper rounding", 10, 20, 1 - Number.EPSILON, 20 - 2 ** -48],
+        ["adjacent positive integers", 1e16, 1e16 + 2, 0.75, 1e16],
+        ["adjacent negative integers", -1e16 - 2, -1e16, 0.75, -1e16 - 2],
+        ["positive unit endpoint", 1 - 2 ** -53, 1, 0.75, 1 - 2 ** -53],
+        ["positive power-of-two endpoint", 2 - 2 ** -52, 2, 0.75, 2 - 2 ** -52],
+        ["negative unit endpoint", -1 - 2 ** -52, -1, 0.75, -1 - 2 ** -52],
+        ["negative power-of-two endpoint", -2 - 2 ** -51, -2, 0.75, -2 - 2 ** -51],
+        ["positive zero upper", -Number.MIN_VALUE, 0, 0.75, -Number.MIN_VALUE],
+        ["negative zero upper", -Number.MIN_VALUE, -0, 0.75, -Number.MIN_VALUE],
+        ["smallest positive upper", 0, Number.MIN_VALUE, 0.75, 0],
+        ["smallest positive upper from negative zero", -0, Number.MIN_VALUE, 0.75, 0],
+        ["cross-zero subnormal", -Number.MIN_VALUE, Number.MIN_VALUE, 0.75, 0],
+        ["positive subnormal", Number.MIN_VALUE, 2 * Number.MIN_VALUE, 0.75, Number.MIN_VALUE],
+        ["negative subnormal", -2 * Number.MIN_VALUE, -Number.MIN_VALUE, 0.75, -2 * Number.MIN_VALUE],
+        ["smallest positive normal", 2 ** -1022 - Number.MIN_VALUE, 2 ** -1022, 0.75, 2 ** -1022 - Number.MIN_VALUE],
+        ["negative normal-subnormal boundary", -(2 ** -1022), -(2 ** -1022) + Number.MIN_VALUE, 0.75, -(2 ** -1022)],
+        ["largest finite upper", Number.MAX_VALUE - 2 ** 971, Number.MAX_VALUE, 0.75, Number.MAX_VALUE - 2 ** 971],
+        ["smallest finite lower", -Number.MAX_VALUE, -Number.MAX_VALUE + 2 ** 971, 0.75, -Number.MAX_VALUE]
+      ] as const
+    )("excludes the upper endpoint with one draw: %s", ([_name, min, max, draw, expected]) =>
+      Effect.gen(function*() {
+        assert.isTrue(Number.isFinite(min) && Number.isFinite(max) && Number.isFinite(max - min))
+        assert.isBelow(min, max)
+        assert.isAtLeast(draw, 0)
+        assert.isBelow(draw, 1)
+        let doubleCalls = 0
+        let intCalls = 0
+        const value = yield* Random.nextBetween(min, max).pipe(
+          Effect.provideService(Random.Random, {
+            nextIntUnsafe: () => {
+              intCalls++
+              return 0
+            },
+            nextDoubleUnsafe: () => {
+              doubleCalls++
+              return draw
+            }
+          })
+        )
+        assert.strictEqual(doubleCalls, 1)
+        assert.strictEqual(intCalls, 0)
+        assert.isAtLeast(value, min)
+        assert.isBelow(value, max)
+        assert.isTrue(Object.is(value, expected))
+      }))
+
+    it.effect("does not retry a constant provider", () =>
+      Effect.gen(function*() {
+        let calls = 0
+        const values = yield* Effect.all([
+          Random.nextBetween(10, 20),
+          Random.nextBetween(10, 20),
+          Random.nextBetween(10, 20)
+        ]).pipe(Effect.provideService(Random.Random, {
+          nextIntUnsafe: () => 0,
+          nextDoubleUnsafe: () => {
+            calls++
+            return 1 - Number.EPSILON
+          }
+        }))
+        assert.strictEqual(calls, 3)
+        assert.deepStrictEqual(values, [20 - 2 ** -48, 20 - 2 ** -48, 20 - 2 ** -48])
+      }))
+
+    it.effect("preserves the in-range seeded formula and following draw", () =>
+      Effect.gen(function*() {
+        const bounds = [[0, 1], [10, 20], [-20, -10], [-10, 10], [10.5, 20.5]] as const
+        const draws = yield* Effect.all(bounds.map(() => Random.next)).pipe(Random.withSeed("next-between-formula"))
+        const expected = bounds.map(([min, max], i) => draws[i] * (max - min) + min)
+        for (let i = 0; i < bounds.length; i++) {
+          assert.isAtLeast(expected[i], bounds[i][0])
+          assert.isBelow(expected[i], bounds[i][1])
+        }
+        const actual = yield* Effect.all(bounds.map(([min, max]) => Random.nextBetween(min, max))).pipe(
+          Random.withSeed("next-between-formula")
+        )
+        assert.deepStrictEqual(actual, expected)
+
+        const withBounded = yield* Effect.all([Random.nextBetween(10, 20), Random.next]).pipe(
+          Random.withSeed("next-between-formula")
+        )
+        const raw = yield* Effect.all([Random.next, Random.next]).pipe(Random.withSeed("next-between-formula"))
+        assert.deepStrictEqual(withBounded, [raw[0] * 10 + 10, raw[1]])
+      }))
+
+    it.effect("leaves degenerate and unsupported bounds on the existing formula", () =>
+      Effect.gen(function*() {
+        // Compatibility guards only: these cases do not establish a new bounds policy.
+        const bounds = [
+          [10, 10],
+          [0, -0],
+          [-0, 0],
+          [20, 10],
+          [NaN, 20],
+          [10, NaN],
+          [10, Infinity],
+          [-Infinity, 20],
+          [-Infinity, Infinity],
+          [-Number.MAX_VALUE, Number.MAX_VALUE]
+        ] as const
+        for (const [min, max] of bounds) {
+          for (const draw of [0, 0.75, 1 - Number.EPSILON]) {
+            let calls = 0
+            const value = yield* Random.nextBetween(min, max).pipe(
+              Effect.provideService(Random.Random, {
+                nextIntUnsafe: () => 0,
+                nextDoubleUnsafe: () => {
+                  calls++
+                  return draw
+                }
+              })
+            )
+            assert.strictEqual(calls, 1)
+            assert.isTrue(Object.is(value, draw * (max - min) + min))
+          }
+        }
+      }))
+
     it.effect("generates number in half-open range", () =>
       Effect.gen(function*() {
         for (let i = 0; i < 100; i++) {


### PR DESCRIPTION
## Why

`Random.nextBetween` and `Crypto.randomBetween` promise half-open ranges, but floating-point rounding can produce the excluded upper bound. For `(10, 20)`, the valid draw `1 - Number.EPSILON` returns `20` on `main`.

## What changed

Both APIs now use one shared calculation in `internal/random.ts`. When the existing formula rounds to a finite upper bound in an ordered range, it returns that bound's immediate binary64 predecessor. Other results and unsupported bounds keep their existing behavior.

The regression tests cover positive, adjacent, negative, and zero upper bounds for `Random.nextBetween`, plus the same ordinary rounding case for `Crypto.randomBetween`.

## Verification

- Reproduced the Random bug on `main`: 1 failed, 22 passed
- Reproduced the Crypto bug before implementation: 1 failed, 38 passed
- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/Crypto.test.ts packages/effect/test/Random.test.ts --maxWorkers=1 --no-file-parallelism`: 39 passed
- `pnpm check`

Closes EFF-1182
Closes #7863
