### PR TITLE
fix(platform-browser): recognize IndexedDB keys containing bytes

### DIFF
--- a/.changeset/browser-indexeddb-binary-key-existence.md
+++ b/.changeset/browser-indexeddb-binary-key-existence.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-browser": patch
+---
+
+Fix `has` in `BrowserKeyValueStore.layerIndexedDb` to recognize existing keys whose values are `Uint8Array`, including empty arrays and strings overwritten with bytes. String and binary reads retain their existing no-coercion behavior.

--- a/.changeset/browser-indexeddb-binary-key-existence.md
+++ b/.changeset/browser-indexeddb-binary-key-existence.md
@@ -2,4 +2,4 @@
 "@effect/platform-browser": patch
 ---
 
-Fix `has` in `BrowserKeyValueStore.layerIndexedDb` to recognize existing keys whose values are `Uint8Array`, including empty arrays and strings overwritten with bytes. String and binary reads retain their existing no-coercion behavior.
+Fix `BrowserKeyValueStore.layerIndexedDb` to report keys containing `Uint8Array` values from `has`.

--- a/packages/platform/browser/src/BrowserKeyValueStore.ts
+++ b/packages/platform/browser/src/BrowserKeyValueStore.ts
@@ -104,6 +104,18 @@ export const layerIndexedDb = (options?: {
             }),
             (found) => found?.value && found.value instanceof Uint8Array ? found.value : undefined
           ),
+        has: (key: string) =>
+          Effect.map(
+            Effect.suspend(() => {
+              const store = getKvsEntriesStore(db, "readonly")
+              return idbRequest<number>({
+                method: "has",
+                message: "Failed to check key in backing store",
+                key
+              }, () => store.count(key))
+            }),
+            (count) => count > 0
+          ),
         set: (key: string, value: string | Uint8Array) =>
           Effect.asVoid(Effect.suspend(() => {
             return idbWriteRequest(

--- a/packages/platform/browser/test/BrowserKeyValueStore.test.ts
+++ b/packages/platform/browser/test/BrowserKeyValueStore.test.ts
@@ -24,6 +24,129 @@ describe("KeyValueStore / layerIndexedDb", () => {
     )
   )
 
+  for (const scenario of ["bytes", "empty bytes", "string overwritten with bytes"] as const) {
+    it.effect(`has recognizes ${scenario} without coercing text reads`, () => {
+      const database = `kvs_binary_${crypto.randomUUID()}`
+      const layer = BrowserKeyValueStore.layerIndexedDb({ database }).pipe(Layer.provide(layerFakeIndexedDb))
+      const removeDatabase = Effect.callback<void>((resume) => {
+        const request = indexedDB.deleteDatabase(database)
+        request.onsuccess = () => resume(Effect.void)
+        request.onerror = () => resume(Effect.die(request.error))
+        request.onblocked = () => resume(Effect.die(new Error("test database deletion blocked")))
+      })
+      return Effect.gen(function*() {
+        const store = yield* KeyValueStore.KeyValueStore
+        assert.isFalse(yield* store.has("missing"))
+        if (scenario === "string overwritten with bytes") {
+          yield* store.set("key", "original")
+          assert.isTrue(yield* store.has("key"))
+          assert.strictEqual(yield* store.get("key"), "original")
+          assert.isUndefined(yield* store.getUint8Array("key"))
+        }
+        const value = scenario === "empty bytes" ? new Uint8Array() : new Uint8Array([1, 2, 255])
+        yield* store.set("key", value)
+        assert.deepStrictEqual(yield* store.getUint8Array("key"), value)
+        assert.strictEqual(yield* store.size, 1)
+        assert.isFalse(yield* store.isEmpty)
+        assert.isUndefined(yield* store.get("key"))
+        assert.isTrue(yield* store.has("key"))
+        yield* store.remove("key")
+        assert.isFalse(yield* store.has("key"))
+        assert.isUndefined(yield* store.getUint8Array("key"))
+        assert.strictEqual(yield* store.size, 0)
+        assert.isTrue(yield* store.isEmpty)
+      }).pipe(Effect.provide(layer), Effect.ensuring(removeDatabase))
+    })
+  }
+
+  for (const failRequest of [true, false]) {
+    it.effect(
+      failRequest
+        ? "has maps request errors with its method and key"
+        : "has retains read-request rather than transaction-commit completion",
+      () => {
+        const cause = new DOMException("Request failed", "AbortError")
+        const events: Array<string> = []
+        const db = {
+          objectStoreNames: { contains: () => true },
+          close() {
+            events.push("close")
+          },
+          transaction(_name: string, mode: string) {
+            events.push(mode)
+            const transaction = {
+              error: null as unknown,
+              onabort: null as null | (() => void),
+              objectStore() {
+                const request = (key: string, result: unknown) => {
+                  events.push(key)
+                  const request = {
+                    readyState: "pending",
+                    result,
+                    error: cause,
+                    onsuccess: null as null | (() => void),
+                    onerror: null as null | (() => void)
+                  }
+                  queueMicrotask(() => {
+                    request.readyState = "done"
+                    if (failRequest) request.onerror?.()
+                    else request.onsuccess?.()
+                    transaction.error = cause
+                    events.push("abort-after-request")
+                    transaction.onabort?.()
+                  })
+                  return request
+                }
+                return {
+                  count: (key: string) => request(key, 1),
+                  get: (key: string) => request(key, { key, value: "value" })
+                }
+              }
+            }
+            return transaction
+          }
+        }
+        const fixture = {
+          open() {
+            const request = {
+              readyState: "pending",
+              result: db,
+              error: null,
+              onsuccess: null as null | (() => void)
+            }
+            queueMicrotask(() => {
+              request.readyState = "done"
+              request.onsuccess?.()
+            })
+            return request
+          }
+        }
+        const layer = BrowserKeyValueStore.layerIndexedDb({ database: "owned_request_fixture" }).pipe(
+          Layer.provide(Layer.succeed(
+            IndexedDb.IndexedDb,
+            IndexedDb.make({ indexedDB: fixture as unknown as IDBFactory, IDBKeyRange })
+          ))
+        )
+        return Effect.gen(function*() {
+          const store = yield* KeyValueStore.KeyValueStore
+          const result = yield* Effect.result(store.has("request-key"))
+          yield* Effect.yieldNow
+          assert.deepStrictEqual(events, ["readonly", "request-key", "abort-after-request"])
+          if (failRequest) {
+            assert.isTrue(Result.isFailure(result))
+            if (Result.isFailure(result)) {
+              assert.strictEqual(result.failure.method, "has")
+              assert.strictEqual(result.failure.key, "request-key")
+              assert.strictEqual(result.failure.cause, cause)
+            }
+          } else {
+            assert.deepStrictEqual(result, Result.succeed(true))
+          }
+        }).pipe(Effect.provide(layer))
+      }
+    )
+  }
+
   it.effect("does not report a write before its transaction commits", () => {
     const db = {
       objectStoreNames: { contains: () => true },

--- a/packages/platform/browser/test/BrowserKeyValueStore.test.ts
+++ b/packages/platform/browser/test/BrowserKeyValueStore.test.ts
@@ -24,128 +24,17 @@ describe("KeyValueStore / layerIndexedDb", () => {
     )
   )
 
-  for (const scenario of ["bytes", "empty bytes", "string overwritten with bytes"] as const) {
-    it.effect(`has recognizes ${scenario} without coercing text reads`, () => {
-      const database = `kvs_binary_${crypto.randomUUID()}`
-      const layer = BrowserKeyValueStore.layerIndexedDb({ database }).pipe(Layer.provide(layerFakeIndexedDb))
-      const removeDatabase = Effect.callback<void>((resume) => {
-        const request = indexedDB.deleteDatabase(database)
-        request.onsuccess = () => resume(Effect.void)
-        request.onerror = () => resume(Effect.die(request.error))
-        request.onblocked = () => resume(Effect.die(new Error("test database deletion blocked")))
-      })
-      return Effect.gen(function*() {
-        const store = yield* KeyValueStore.KeyValueStore
-        assert.isFalse(yield* store.has("missing"))
-        if (scenario === "string overwritten with bytes") {
-          yield* store.set("key", "original")
-          assert.isTrue(yield* store.has("key"))
-          assert.strictEqual(yield* store.get("key"), "original")
-          assert.isUndefined(yield* store.getUint8Array("key"))
-        }
-        const value = scenario === "empty bytes" ? new Uint8Array() : new Uint8Array([1, 2, 255])
-        yield* store.set("key", value)
-        assert.deepStrictEqual(yield* store.getUint8Array("key"), value)
-        assert.strictEqual(yield* store.size, 1)
-        assert.isFalse(yield* store.isEmpty)
-        assert.isUndefined(yield* store.get("key"))
-        assert.isTrue(yield* store.has("key"))
-        yield* store.remove("key")
-        assert.isFalse(yield* store.has("key"))
-        assert.isUndefined(yield* store.getUint8Array("key"))
-        assert.strictEqual(yield* store.size, 0)
-        assert.isTrue(yield* store.isEmpty)
-      }).pipe(Effect.provide(layer), Effect.ensuring(removeDatabase))
-    })
-  }
+  it.effect("reports a key containing bytes as present", () => {
+    const layer = BrowserKeyValueStore.layerIndexedDb({
+      database: `kvs_binary_has_${crypto.randomUUID()}`
+    }).pipe(Layer.provide(layerFakeIndexedDb))
 
-  for (const failRequest of [true, false]) {
-    it.effect(
-      failRequest
-        ? "has maps request errors with its method and key"
-        : "has retains read-request rather than transaction-commit completion",
-      () => {
-        const cause = new DOMException("Request failed", "AbortError")
-        const events: Array<string> = []
-        const db = {
-          objectStoreNames: { contains: () => true },
-          close() {
-            events.push("close")
-          },
-          transaction(_name: string, mode: string) {
-            events.push(mode)
-            const transaction = {
-              error: null as unknown,
-              onabort: null as null | (() => void),
-              objectStore() {
-                const request = (key: string, result: unknown) => {
-                  events.push(key)
-                  const request = {
-                    readyState: "pending",
-                    result,
-                    error: cause,
-                    onsuccess: null as null | (() => void),
-                    onerror: null as null | (() => void)
-                  }
-                  queueMicrotask(() => {
-                    request.readyState = "done"
-                    if (failRequest) request.onerror?.()
-                    else request.onsuccess?.()
-                    transaction.error = cause
-                    events.push("abort-after-request")
-                    transaction.onabort?.()
-                  })
-                  return request
-                }
-                return {
-                  count: (key: string) => request(key, 1),
-                  get: (key: string) => request(key, { key, value: "value" })
-                }
-              }
-            }
-            return transaction
-          }
-        }
-        const fixture = {
-          open() {
-            const request = {
-              readyState: "pending",
-              result: db,
-              error: null,
-              onsuccess: null as null | (() => void)
-            }
-            queueMicrotask(() => {
-              request.readyState = "done"
-              request.onsuccess?.()
-            })
-            return request
-          }
-        }
-        const layer = BrowserKeyValueStore.layerIndexedDb({ database: "owned_request_fixture" }).pipe(
-          Layer.provide(Layer.succeed(
-            IndexedDb.IndexedDb,
-            IndexedDb.make({ indexedDB: fixture as unknown as IDBFactory, IDBKeyRange })
-          ))
-        )
-        return Effect.gen(function*() {
-          const store = yield* KeyValueStore.KeyValueStore
-          const result = yield* Effect.result(store.has("request-key"))
-          yield* Effect.yieldNow
-          assert.deepStrictEqual(events, ["readonly", "request-key", "abort-after-request"])
-          if (failRequest) {
-            assert.isTrue(Result.isFailure(result))
-            if (Result.isFailure(result)) {
-              assert.strictEqual(result.failure.method, "has")
-              assert.strictEqual(result.failure.key, "request-key")
-              assert.strictEqual(result.failure.cause, cause)
-            }
-          } else {
-            assert.deepStrictEqual(result, Result.succeed(true))
-          }
-        }).pipe(Effect.provide(layer))
-      }
-    )
-  }
+    return Effect.gen(function*() {
+      const store = yield* KeyValueStore.KeyValueStore
+      yield* store.set("binary", new Uint8Array([0, 127, 255]))
+      assert.isTrue(yield* store.has("binary"))
+    }).pipe(Effect.provide(layer))
+  })
 
   it.effect("does not report a write before its transaction commits", () => {
     const db = {


### PR DESCRIPTION
## Why

The IndexedDB key-value adapter reports byte-valued keys as absent. Its inherited `has` checks the string-only getter even though the adapter supports storing bytes.

## What changes

Supply a representation-independent `has` using the existing readonly request helper and `count(key) > 0`. Preserve the intentional no-coercion behavior of the text and byte getters.

## Scope

The browser IndexedDB wrapper, a regression test in the existing module suite, and an `@effect/platform-browser` patch changeset. No core `KeyValueStore` behavior changes.

## Verification

```bash
pnpm lint-fix
pnpm test --run packages/platform/browser/test/BrowserKeyValueStore.test.ts --maxWorkers=1 --no-file-parallelism
pnpm check
git diff --check
```

The independent regression test fails against the stock implementation with `has` returning `false` after storing a `Uint8Array`. The focused suite passes with the override: 34 tests passed.

Closes #7867
Closes EFF-1185

## Audit

Runtime correctness audit; intended label: `audit`.
