### PR TITLE
fix(TestSchema): compare every own struct field by AST

### DIFF
--- a/.changeset/testschema-own-field-asts.md
+++ b/.changeset/testschema-own-field-asts.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `TestSchema.Asserts.ast.fields.equals` to compare ASTs for all own struct fields, including symbol and non-enumerable keys. Equivalent field schemas now compare equally regardless of schema instance identity, while differing ASTs and distinct symbol keys remain unequal.

--- a/packages/effect/src/testing/TestSchema.ts
+++ b/packages/effect/src/testing/TestSchema.ts
@@ -14,7 +14,6 @@ import { isDeepStrictEqual } from "node:util"
 import type * as Context from "../Context.ts"
 import * as Effect from "../Effect.ts"
 import { pipe } from "../Function.ts"
-import * as Record from "../Record.ts"
 import * as Result from "../Result.ts"
 import * as Schema from "../Schema.ts"
 import * as SchemaAST from "../SchemaAST.ts"
@@ -82,7 +81,10 @@ export class Asserts<S extends Schema.Constraint> {
   static ast = {
     fields: {
       equals: (a: Schema.Struct.Fields, b: Schema.Struct.Fields) => {
-        assert.deepStrictEqual(Record.map(a, SchemaAST.getAST), Record.map(b, SchemaAST.getAST))
+        assert.deepStrictEqual(
+          Object.fromEntries(Reflect.ownKeys(a).map((key) => [key, SchemaAST.getAST(a[key])])),
+          Object.fromEntries(Reflect.ownKeys(b).map((key) => [key, SchemaAST.getAST(b[key])]))
+        )
       }
     },
     elements: {

--- a/packages/effect/test/testing/TestSchema.test.ts
+++ b/packages/effect/test/testing/TestSchema.test.ts
@@ -5,6 +5,98 @@ import * as SchemaTransformation from "effect/SchemaTransformation"
 import { TestSchema } from "effect/testing"
 
 describe("TestSchema", () => {
+  describe("ast.fields.equals", () => {
+    const equals = TestSchema.Asserts.ast.fields.equals
+
+    it("compares fresh string fields and tuple elements by AST", () => {
+      const left = Schema.Literal("value")
+      const right = Schema.Literal("value")
+      assert.notStrictEqual(left, right)
+      assert.deepStrictEqual(left.ast, right.ast)
+      equals({ field: left }, { field: right })
+      TestSchema.Asserts.ast.elements.equals([left], [right])
+    })
+
+    it("compares fresh symbol fields by AST", () => {
+      const key = Symbol("field")
+      const left = Schema.Literal("value")
+      const right = Schema.Literal("value")
+      assert.notStrictEqual(left, right)
+      assert.deepStrictEqual(left.ast, right.ast)
+      equals({ [key]: left }, { [key]: right })
+    })
+
+    it("accepts a reused schema at the same symbol", () => {
+      const key = Symbol("field")
+      const schema = Schema.Literal("value")
+      equals({ [key]: schema }, { [key]: schema })
+    })
+
+    it("rejects unequal ASTs and missing fields", () => {
+      const key = Symbol("field")
+      assert.throws(() => equals({ [key]: Schema.Literal("left") }, { [key]: Schema.Literal("right") }))
+      assert.throws(() => equals({ [key]: Schema.Literal("value") }, {}))
+      assert.throws(() => equals({}, { [key]: Schema.Literal("value") }))
+      assert.throws(() => equals({ field: Schema.Literal("left") }, { field: Schema.Literal("right") }))
+    })
+
+    it("preserves symbol identity even with equal descriptions", () => {
+      const left: symbol = Symbol("field")
+      const right: symbol = Symbol("field")
+      const schema = Schema.Literal("value")
+      assert.notStrictEqual(left, right)
+      assert.throws(() => equals({ [left]: schema }, { [right]: schema }))
+    })
+
+    it("compares mixed string, numeric, and symbol fields", () => {
+      const key = Symbol("field")
+      const fields = () => ({ field: Schema.Literal("text"), 1: Schema.Literal(1), [key]: Schema.Literal(true) })
+      equals(fields(), fields())
+      equals({ 1: Schema.Literal(1) }, { "1": Schema.Literal(1) })
+      assert.throws(() => equals({ 1: Schema.Literal(1) }, { 1: Schema.Literal(2) }))
+    })
+
+    it("preserves annotations and optionality at symbol fields", () => {
+      const key = Symbol("field")
+      const annotated = () => Schema.Literal("value").annotate({ title: "Field" })
+      const optional = () => Schema.optionalKey(Schema.Literal("value"))
+      equals({ [key]: annotated() }, { [key]: annotated() })
+      equals({ [key]: optional() }, { [key]: optional() })
+      assert.throws(() => equals({ [key]: annotated() }, { [key]: Schema.Literal("value") }))
+      assert.throws(() => equals({ [key]: optional() }, { [key]: Schema.Literal("value") }))
+    })
+
+    it("preserves own __proto__ and constructor fields", () => {
+      const fields = () => ({ ["__proto__"]: Schema.Literal("proto"), constructor: Schema.Literal("ctor") })
+      const left = fields()
+      assert.isTrue(Object.hasOwn(left, "__proto__"))
+      assert.isTrue(Object.hasOwn(left, "constructor"))
+      equals(left, fields())
+      assert.throws(() => equals(left, { constructor: Schema.Literal("ctor") }))
+      assert.throws(() => equals(left, { ["__proto__"]: Schema.Literal("other"), constructor: Schema.Literal("ctor") }))
+      assert.strictEqual(Object.getPrototypeOf(left), Object.prototype)
+    })
+
+    it("uses the Struct own-key contract for non-enumerable fields", () => {
+      const key = Symbol("hidden")
+      const fields = (value: string): Schema.Struct.Fields =>
+        Object.defineProperties({}, {
+          hidden: { value: Schema.Literal(value) },
+          [key]: { value: Schema.Literal(value) }
+        })
+      const left = fields("value")
+      const right = fields("value")
+      assert.deepStrictEqual(Object.keys(left), [])
+      assert.deepStrictEqual(Reflect.ownKeys(left), ["hidden", key])
+      assert.deepStrictEqual(Schema.Struct(left).ast.propertySignatures.map((field) => field.name), ["hidden", key])
+      assert.deepStrictEqual(Schema.Struct(left).ast, Schema.Struct(right).ast)
+      equals(left, right)
+      equals(left, { hidden: Schema.Literal("value"), [key]: Schema.Literal("value") })
+      assert.throws(() => equals(left, fields("other")))
+      assert.throws(() => equals(left, {}))
+    })
+  })
+
   it("decoding", async () => {
     const schema = Schema.FiniteFromString.check(Schema.isGreaterThan(0))
     const asserts = new TestSchema.Asserts(schema)

--- a/packages/effect/test/testing/TestSchema.test.ts
+++ b/packages/effect/test/testing/TestSchema.test.ts
@@ -8,36 +8,28 @@ describe("TestSchema", () => {
   describe("ast.fields.equals", () => {
     const equals = TestSchema.Asserts.ast.fields.equals
 
-    it("compares fresh string fields and tuple elements by AST", () => {
-      const left = Schema.Literal("value")
-      const right = Schema.Literal("value")
-      assert.notStrictEqual(left, right)
-      assert.deepStrictEqual(left.ast, right.ast)
-      equals({ field: left }, { field: right })
-      TestSchema.Asserts.ast.elements.equals([left], [right])
-    })
-
-    it("compares fresh symbol fields by AST", () => {
+    it("compares string and symbol fields by AST", () => {
       const key = Symbol("field")
-      const left = Schema.Literal("value")
-      const right = Schema.Literal("value")
-      assert.notStrictEqual(left, right)
-      assert.deepStrictEqual(left.ast, right.ast)
-      equals({ [key]: left }, { [key]: right })
+      const fields = () => ({ field: Schema.Literal("value"), [key]: Schema.Literal("value") })
+      const left = fields()
+      const right = fields()
+      assert.notStrictEqual(left[key], right[key])
+      equals(left, right)
     })
 
-    it("accepts a reused schema at the same symbol", () => {
-      const key = Symbol("field")
-      const schema = Schema.Literal("value")
-      equals({ [key]: schema }, { [key]: schema })
-    })
-
-    it("rejects unequal ASTs and missing fields", () => {
+    it("rejects missing or structurally different symbol fields", () => {
       const key = Symbol("field")
       assert.throws(() => equals({ [key]: Schema.Literal("left") }, { [key]: Schema.Literal("right") }))
       assert.throws(() => equals({ [key]: Schema.Literal("value") }, {}))
-      assert.throws(() => equals({}, { [key]: Schema.Literal("value") }))
-      assert.throws(() => equals({ field: Schema.Literal("left") }, { field: Schema.Literal("right") }))
+      assert.throws(() =>
+        equals(
+          { [key]: Schema.Literal("value").annotate({ title: "Field" }) },
+          { [key]: Schema.Literal("value") }
+        )
+      )
+      assert.throws(() =>
+        equals({ [key]: Schema.optionalKey(Schema.Literal("value")) }, { [key]: Schema.Literal("value") })
+      )
     })
 
     it("preserves symbol identity even with equal descriptions", () => {
@@ -48,24 +40,6 @@ describe("TestSchema", () => {
       assert.throws(() => equals({ [left]: schema }, { [right]: schema }))
     })
 
-    it("compares mixed string, numeric, and symbol fields", () => {
-      const key = Symbol("field")
-      const fields = () => ({ field: Schema.Literal("text"), 1: Schema.Literal(1), [key]: Schema.Literal(true) })
-      equals(fields(), fields())
-      equals({ 1: Schema.Literal(1) }, { "1": Schema.Literal(1) })
-      assert.throws(() => equals({ 1: Schema.Literal(1) }, { 1: Schema.Literal(2) }))
-    })
-
-    it("preserves annotations and optionality at symbol fields", () => {
-      const key = Symbol("field")
-      const annotated = () => Schema.Literal("value").annotate({ title: "Field" })
-      const optional = () => Schema.optionalKey(Schema.Literal("value"))
-      equals({ [key]: annotated() }, { [key]: annotated() })
-      equals({ [key]: optional() }, { [key]: optional() })
-      assert.throws(() => equals({ [key]: annotated() }, { [key]: Schema.Literal("value") }))
-      assert.throws(() => equals({ [key]: optional() }, { [key]: Schema.Literal("value") }))
-    })
-
     it("preserves own __proto__ and constructor fields", () => {
       const fields = () => ({ ["__proto__"]: Schema.Literal("proto"), constructor: Schema.Literal("ctor") })
       const left = fields()
@@ -74,7 +48,6 @@ describe("TestSchema", () => {
       equals(left, fields())
       assert.throws(() => equals(left, { constructor: Schema.Literal("ctor") }))
       assert.throws(() => equals(left, { ["__proto__"]: Schema.Literal("other"), constructor: Schema.Literal("ctor") }))
-      assert.strictEqual(Object.getPrototypeOf(left), Object.prototype)
     })
 
     it("uses the Struct own-key contract for non-enumerable fields", () => {
@@ -87,13 +60,10 @@ describe("TestSchema", () => {
       const left = fields("value")
       const right = fields("value")
       assert.deepStrictEqual(Object.keys(left), [])
-      assert.deepStrictEqual(Reflect.ownKeys(left), ["hidden", key])
       assert.deepStrictEqual(Schema.Struct(left).ast.propertySignatures.map((field) => field.name), ["hidden", key])
-      assert.deepStrictEqual(Schema.Struct(left).ast, Schema.Struct(right).ast)
       equals(left, right)
       equals(left, { hidden: Schema.Literal("value"), [key]: Schema.Literal("value") })
       assert.throws(() => equals(left, fields("other")))
-      assert.throws(() => equals(left, {}))
     })
   })
 


### PR DESCRIPTION
## Why

`TestSchema.Asserts.ast.fields.equals` leaves Schema functions under symbol keys instead of projecting their ASTs. Fresh equivalent schemas can therefore fail the helper's documented structural comparison.

## What Changes

Project every own field key with `Reflect.ownKeys` and a safe `Object.fromEntries` construction, retaining the existing deep-strict AST comparison.

## Scope

The TestSchema helper, regression coverage and an `effect` patch changeset. No Record or Schema implementation change. Symbol identity, missing/unequal-field failures, special keys, annotations and Struct's own-key contract remain intact.

## Verification

```bash
pnpm lint-fix
pnpm test --run packages/effect/test/testing/TestSchema.test.ts packages/effect/test/schema/Schema.test.ts packages/effect/test/schema/toEquivalence.test.ts --maxWorkers=1 --no-file-parallelism
pnpm check
git diff --check 9cc3e6218ab3a92a31ca907721f51867abf943f9 HEAD
git diff --check
```

On publication base `9cc3e6218ab3a92a31ca907721f51867abf943f9`, the identical focused selection has **644 passed / 4 failed** without this fix and **648 passed** with it, with no skipped tests or changed identities. Post-commit lint, root typecheck, and whitespace checks passed on `edbc16a1af45606be9a61eeaf862553e2c8494b2`.

Tests distinguish fresh Schema identity from equal AST structure and retain negative comparisons for distinct symbols, missing fields, changed annotations/optionality and special keys. Non-enumerable cases are checked against actual Struct AST construction, not an invented record-enumeration policy.

Closes #7869

## Audit

Runtime correctness audit; intended label: `audit`.
