### PR TITLE
Wait for inherited stdio close in NodeChildProcessSpawner release and kill

### DIFF
--- a/.changeset/childprocess-close-wait.md
+++ b/.changeset/childprocess-close-wait.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+Wait for the spawned process `close` event (inherited stdio released) in scoped release and `kill`, so a non-exec'ing shell leader cannot abandon descendants.

--- a/packages/platform/node-shared/src/NodeChildProcessSpawner.ts
+++ b/packages/platform/node-shared/src/NodeChildProcessSpawner.ts
@@ -65,6 +65,7 @@ const toPlatformError = (
 
 type ExitCodeWithSignal = readonly [code: number | null, signal: NodeJS.Signals | null]
 type ExitSignal = Deferred.Deferred<ExitCodeWithSignal>
+type CloseSignal = Deferred.Deferred<ExitCodeWithSignal>
 
 const taskkill = (
   childProcess: NodeChildProcess.ChildProcess,
@@ -336,10 +337,11 @@ const make = Effect.gen(function*() {
     spawnOptions: NodeChildProcess.SpawnOptions
   ) =>
     Effect.callback<
-      readonly [NodeChildProcess.ChildProcess, ExitSignal],
+      readonly [NodeChildProcess.ChildProcess, ExitSignal, CloseSignal],
       PlatformError.PlatformError
     >((resume) => {
-      const deferred = Deferred.makeUnsafe<ExitCodeWithSignal>()
+      const exitSignal = Deferred.makeUnsafe<ExitCodeWithSignal>()
+      const closeSignal = Deferred.makeUnsafe<ExitCodeWithSignal>()
       const handle = NodeChildProcess.spawn(
         command.command,
         command.args,
@@ -349,10 +351,13 @@ const make = Effect.gen(function*() {
         resume(Effect.fail(toPlatformError("spawn", error, command)))
       })
       handle.on("exit", (...args) => {
-        Deferred.doneUnsafe(deferred, Exit.succeed(args))
+        Deferred.doneUnsafe(exitSignal, Exit.succeed(args))
+      })
+      handle.on("close", (...args) => {
+        Deferred.doneUnsafe(closeSignal, Exit.succeed(args))
       })
       handle.on("spawn", () => {
-        resume(Effect.succeed([handle, deferred]))
+        resume(Effect.succeed([handle, exitSignal, closeSignal]))
       })
       return Effect.sync(() => {
         handle.kill("SIGTERM")
@@ -481,14 +486,14 @@ const make = Effect.gen(function*() {
         const env = resolveEnvironment(cmd.options)
         const stdio = buildStdioArray(stdinConfig, stdoutConfig, stderrConfig, resolvedAdditionalFds)
 
-        const [childProcess, exitSignal] = yield* Effect.acquireRelease(
+        const [childProcess, exitSignal, closeSignal] = yield* Effect.acquireRelease(
           spawn(cmd, buildSpawnOptions(cmd.options, { cwd, env, stdio }, process.platform)),
-          Effect.fnUntraced(function*([childProcess, exitSignal]) {
-            const exited = yield* Deferred.isDone(exitSignal)
+          Effect.fnUntraced(function*([childProcess, , closeSignal]) {
+            const closed = yield* Deferred.isDone(closeSignal)
             const killWithTimeout = withTimeout(childProcess, cmd, cmd.options)
-            if (exited) {
-              // Process already exited, check if children need cleanup
-              const [code] = yield* Deferred.await(exitSignal)
+            if (closed) {
+              // Process and inherited stdio already closed; check whether the process group needs cleanup
+              const [code] = yield* Deferred.await(closeSignal)
               if (code !== 0 && Predicate.isNotNull(code)) {
                 // Non-zero exit code ,attempt to clean up process group
                 return yield* Effect.ignore(killWithTimeout(killProcessGroup))
@@ -498,11 +503,11 @@ const make = Effect.gen(function*() {
             if (!isReferenced) {
               return yield* Effect.void
             }
-            // Process is still running, kill it
+            // Process or inherited stdio is still open; terminate the process group
             return yield* killWithTimeout((command, childProcess, signal) =>
               killProcessGroup(command, childProcess, signal).pipe(
                 Effect.catch(() => killProcess(command, childProcess, signal)),
-                Effect.andThen(Deferred.await(exitSignal))
+                Effect.andThen(Deferred.await(closeSignal))
               )
             ).pipe(
               Effect.ignore
@@ -548,7 +553,7 @@ const make = Effect.gen(function*() {
           return killWithTimeout((command, childProcess, signal) =>
             killProcessGroup(command, childProcess, signal).pipe(
               Effect.catch(() => killProcess(command, childProcess, signal)),
-              Effect.andThen(Deferred.await(exitSignal))
+              Effect.andThen(Deferred.await(closeSignal))
             )
           ).pipe(
             Effect.asVoid

--- a/packages/platform/node-shared/test/NodeChildProcessSpawner.test.ts
+++ b/packages/platform/node-shared/test/NodeChildProcessSpawner.test.ts
@@ -5,8 +5,12 @@ import * as NodePath from "@effect/platform-node-shared/NodePath"
 import { assert, describe, it } from "@effect/vitest"
 import * as ChildProcessSpawnerTest from "effect-test/unstable/process/ChildProcessSpawnerTest"
 import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
 import * as FileSystem from "effect/FileSystem"
 import * as Layer from "effect/Layer"
+import * as Schedule from "effect/Schedule"
+import * as Scope from "effect/Scope"
+import * as Stream from "effect/Stream"
 import * as ChildProcess from "effect/unstable/process/ChildProcess"
 
 const NodeServices = NodeChildProcessSpawner.layer.pipe(
@@ -90,3 +94,61 @@ it.live("kills every process in a pipeline", () =>
     assert.strictEqual(rootFinalSize, rootSizeAfterKill)
     assert.strictEqual(childFinalSize, childSizeAfterKill)
   }).pipe(Effect.scoped, Effect.provide(NodeServices)))
+
+const shellLeaderWrapper = `import { spawn } from "node:child_process"
+const child = spawn(process.execPath, ["-e", \`
+  process.once("SIGTERM", () => { console.log("child:SIGTERM"); process.exit(0) })
+  setTimeout(() => process.exit(0), 4000)
+\`], { detached: true, stdio: ["ignore", "inherit", "inherit"] })
+process.once("SIGTERM", () => {
+  console.log("wrapper:SIGTERM")
+  setTimeout(() => process.kill(-child.pid, "SIGTERM"), 150)
+})
+child.once("exit", () => process.exit(0))
+console.log("READY")
+`
+
+it.live.skipIf(process.platform === "win32")(
+  "scoped release waits for inherited stdio after a shell leader exits",
+  () =>
+    Effect.gen(function*() {
+      const fs = yield* FileSystem.FileSystem
+      const directory = yield* fs.makeTempDirectoryScoped()
+      const wrapperPath = `${directory}/wrapper.mjs`
+      yield* fs.writeFileString(wrapperPath, shellLeaderWrapper)
+      const scope = yield* Scope.make()
+      const handle = yield* Scope.provide(scope)(ChildProcess.make(
+        `"${process.execPath}" "${wrapperPath}"`,
+        [],
+        {
+          shell: true,
+          stdin: "ignore",
+          stdout: "pipe",
+          stderr: "pipe",
+          killSignal: "SIGTERM",
+          forceKillAfter: "15 seconds"
+        }
+      ))
+      const lines: Array<string> = []
+      yield* handle.stdout.pipe(
+        Stream.decodeText,
+        Stream.splitLines,
+        Stream.runForEach((line) =>
+          Effect.sync(() => {
+            lines.push(line)
+          })
+        ),
+        Effect.forkScoped
+      )
+      yield* Effect.sync(() => lines.includes("READY")).pipe(
+        Effect.repeat({
+          while: (ready) => !ready,
+          schedule: Schedule.spaced("10 millis")
+        }),
+        Effect.timeout("2 seconds")
+      )
+      yield* Scope.close(scope, Exit.void)
+      assert.isTrue(lines.includes("wrapper:SIGTERM"))
+      assert.isTrue(lines.includes("child:SIGTERM"))
+    }).pipe(Effect.scoped, Effect.provide(NodeServices))
+)


### PR DESCRIPTION
## Summary

`NodeChildProcessSpawner` already signals the process group on scoped release and `kill`, but it waited on the leader's `exit`. On Linux, `shell: true` uses dash (`sh -c`), which does not `exec` the command. SIGTERM kills the shell immediately, `exit` fires, `forceKillAfter` is dropped, and descendants keep running.

Release and `kill` now wait for the Node `close` event (inherited stdio released). Public `exitCode` / `isRunning` still use `exit`.

Fixes #7821

## Test plan

- [x] `vitest --run packages/platform/node-shared/test/NodeChildProcessSpawner.test.ts`
- [x] Linux `shell: true` scope close does not return until the wrapper and its inherited-stdio child have printed `*:SIGTERM`
- [x] macOS (bash execs) still completes the same wait
- [x] `exitCode` / `isRunning` remain bound to the leader `exit` event
