### PR TITLE
Right-size Namespace CI runners

### DIFF
--- a/.github/workflows/ai-codegen.yml
+++ b/.github/workflows/ai-codegen.yml
@@ -15,7 +15,7 @@ jobs:
   codegen:
     name: AI Codegen
     if: github.repository_owner == 'Effect-Ts'
-    runs-on: namespace-profile-linux-default
+    runs-on: namespace-profile-linux-small
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/bundle-comment.yml
+++ b/.github/workflows/bundle-comment.yml
@@ -15,7 +15,7 @@ jobs:
   comment:
     name: Bundle
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
-    runs-on: namespace-profile-linux-default
+    runs-on: namespace-profile-linux-small
     permissions:
       actions: read
       pull-requests: write

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
   static-checks:
     name: Static
-    runs-on: namespace-profile-linux-default
+    runs-on: namespace-profile-linux-small
     permissions:
       contents: read
     timeout-minutes: 10
@@ -39,7 +39,7 @@ jobs:
 
   types:
     name: Types
-    runs-on: namespace-profile-linux-default
+    runs-on: namespace-profile-linux-small
     permissions:
       contents: read
     timeout-minutes: 10
@@ -53,7 +53,7 @@ jobs:
   build:
     name: Build
     if: github.event_name == 'pull_request'
-    runs-on: namespace-profile-linux-default
+    runs-on: namespace-profile-linux-small
     permissions:
       contents: read
     timeout-minutes: 10
@@ -68,7 +68,7 @@ jobs:
 
   types-deno:
     name: Types (Deno)
-    runs-on: namespace-profile-linux-default
+    runs-on: namespace-profile-linux-small
     permissions:
       contents: read
     timeout-minutes: 10
@@ -86,7 +86,7 @@ jobs:
   bundle:
     name: Bundle
     if: github.event_name == 'pull_request'
-    runs-on: namespace-profile-linux-default
+    runs-on: namespace-profile-linux-small
     permissions:
       contents: read
     timeout-minutes: 10
@@ -173,7 +173,7 @@ jobs:
 
   doctest:
     name: Test (Documentation)
-    runs-on: namespace-profile-linux-default
+    runs-on: namespace-profile-linux-small
     permissions:
       contents: read
     timeout-minutes: 10

--- a/.github/workflows/cluster.yml
+++ b/.github/workflows/cluster.yml
@@ -7,7 +7,7 @@ permissions: {}
 jobs:
   test:
     name: Test
-    runs-on: namespace-profile-linux-default
+    runs-on: namespace-profile-linux-small
     timeout-minutes: 30
     env:
       EFFECT_CLUSTER_TESTS: "1"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
   approval-gate:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: namespace-profile-linux-default
+    runs-on: namespace-profile-linux-small
     environment: fork
     steps:
       - run: echo "Fork PR approved by maintainer."
@@ -27,7 +27,7 @@ jobs:
       !cancelled()
       && (needs.approval-gate.result == 'success' || needs.approval-gate.result == 'skipped')
       && github.repository_owner == 'Effect-Ts'
-    runs-on: namespace-profile-linux-default
+    runs-on: namespace-profile-linux-small
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6


### PR DESCRIPTION
## Summary

- run static, type, documentation, build, bundle, snapshot, and codegen jobs on `namespace-profile-linux-small`
- keep the parallel Node, Deno, and Bun test matrix on `namespace-profile-linux-default`
- run the explicitly sequential cluster integration workflow on the small profile

This reduces peak Namespace vCPU allocation during CI bursts while retaining the larger profile for the regular test suite, which runs with concurrency 10.

## Validation

- `pnpm lint-fix`
- parsed all workflow YAML files
- `git diff --check`

`actionlint` is not installed locally.