### PR TITLE
fix(sql-d1): preserve native raw result envelopes

### DIFF
--- a/.changeset/d1-raw-native-results.md
+++ b/.changeset/d1-raw-native-results.md
@@ -2,8 +2,6 @@
 "@effect/sql-d1": patch
 ---
 
-Fix D1 statement `.raw` to return the native `D1Result` object with `success`, `meta`, and `results`, instead of discarding metadata and returning only the row array.
+Return the complete native `D1Result` from D1 statement `.raw`, preserving `success`, `meta`, and `results` instead of returning only the row array.
 
-This changes the observable result shape even though the public raw result type remains `unknown`. Callers casting the previous result to an array must use the native result's `.results` property, or use the ordinary statement or `.unprepared` API when only rows are needed.
-
-Normal row results, positional results (`.values` and `.valuesUnprepared`), and their query/result transform behavior are unchanged. `.raw` continues to bypass query and result name transforms.
+Callers that treated `.raw` as an array should read `.results` or use an ordinary or `.unprepared` statement when only rows are needed.

--- a/.changeset/d1-raw-native-results.md
+++ b/.changeset/d1-raw-native-results.md
@@ -1,0 +1,9 @@
+---
+"@effect/sql-d1": patch
+---
+
+Fix D1 statement `.raw` to return the native `D1Result` object with `success`, `meta`, and `results`, instead of discarding metadata and returning only the row array.
+
+This changes the observable result shape even though the public raw result type remains `unknown`. Callers casting the previous result to an array must use the native result's `.results` property, or use the ordinary statement or `.unprepared` API when only rows are needed.
+
+Normal row results, positional results (`.values` and `.valuesUnprepared`), and their query/result transform behavior are unchanged. `.raw` continues to bypass query and result name transforms.

--- a/packages/sql/d1/src/D1Client.ts
+++ b/packages/sql/d1/src/D1Client.ts
@@ -10,7 +10,7 @@
  *
  * @since 4.0.0
  */
-import type { D1Database, D1PreparedStatement } from "@cloudflare/workers-types"
+import type { D1Database, D1PreparedStatement, D1Result } from "@cloudflare/workers-types"
 import * as Cache from "effect/Cache"
 import * as Config from "effect/Config"
 import * as Context from "effect/Context"
@@ -221,25 +221,31 @@ export const make = (
           })
       })
 
-      const runStatement = (
+      const runStatementRaw = (
         statement: D1PreparedStatement,
         params: ReadonlyArray<unknown> = []
-      ): Effect.Effect<ReadonlyArray<any>, SqlError, never> =>
+      ): Effect.Effect<D1Result, SqlError, never> =>
         Effect.tryPromise({
           try: async () => {
             const response = await statement.bind(...params).all()
             if (response.error) {
               throw response.error
             }
-            return response.results || []
+            return response
           },
           catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
         })
 
+      const runStatement = (
+        statement: D1PreparedStatement,
+        params: ReadonlyArray<unknown> = []
+      ): Effect.Effect<ReadonlyArray<any>, SqlError, never> =>
+        Effect.map(runStatementRaw(statement, params), (response) => response.results || [])
+
       const runRaw = (
         sql: string,
         params: ReadonlyArray<unknown> = []
-      ) => runStatement(db.prepare(sql), params)
+      ) => runStatementRaw(db.prepare(sql), params)
 
       const runCached = (
         sql: string,
@@ -249,7 +255,7 @@ export const make = (
       const runUncached = (
         sql: string,
         params: ReadonlyArray<unknown> = []
-      ) => runRaw(sql, params)
+      ) => runStatement(db.prepare(sql), params)
 
       const runValues = (
         sql: string,

--- a/packages/sql/d1/test/Client.test.ts
+++ b/packages/sql/d1/test/Client.test.ts
@@ -1,11 +1,136 @@
+import type { D1Result } from "@cloudflare/workers-types"
 import { D1Client } from "@effect/sql-d1"
 import { assert, describe, it } from "@effect/vitest"
 import { Cause, Effect } from "effect"
 import * as Reactivity from "effect/unstable/reactivity/Reactivity"
 import { Statement } from "effect/unstable/sql"
+import { isSqlError } from "effect/unstable/sql/SqlError"
 import { D1Miniflare } from "./utils.ts"
 
+const assertD1Result = (value: unknown): D1Result => {
+  assert.isNotArray(value)
+  assert.isObject(value)
+  const result = value as D1Result
+  assert.strictEqual(result.success, true)
+  assert.isObject(result.meta)
+  assert.isArray(result.results)
+  return result
+}
+
 describe("Client", () => {
+  it.effect("raw preserves the native SELECT result envelope", () =>
+    Effect.gen(function*() {
+      const sql = yield* D1Client.D1Client
+      // Anchor last_row_id after native D1's first-query initialization.
+      yield* sql`CREATE TABLE select_control (id INTEGER PRIMARY KEY)`
+      yield* sql`INSERT INTO select_control (id) VALUES (${7})`
+      const native = assertD1Result(
+        yield* Effect.promise(() => sql.config.db.prepare("SELECT ? AS answer").bind(42).all())
+      )
+      assert.deepStrictEqual(native.results, [{ answer: 42 }])
+      assert.strictEqual(native.meta.last_row_id, 7)
+      const raw = assertD1Result(yield* sql`SELECT ${42} AS answer`.raw)
+      assert.deepStrictEqual(raw.results, native.results)
+      assert.strictEqual(raw.meta.changes, native.meta.changes)
+      assert.strictEqual(raw.meta.last_row_id, native.meta.last_row_id)
+      assert.strictEqual(raw.meta.rows_written, native.meta.rows_written)
+      assert.strictEqual(raw.meta.rows_read, native.meta.rows_read)
+    }).pipe(Effect.provide(D1Miniflare.layerClient)))
+
+  it.effect("raw preserves native INSERT metadata without RETURNING", () =>
+    Effect.gen(function*() {
+      const sql = yield* D1Client.D1Client
+      yield* sql`CREATE TABLE raw_test (id INTEGER PRIMARY KEY, name TEXT)`
+      const native = assertD1Result(
+        yield* Effect.promise(() =>
+          sql.config.db.prepare("INSERT INTO raw_test (name) VALUES (?)").bind("native").all()
+        )
+      )
+      assert.deepStrictEqual(native.results, [])
+      assert.strictEqual(native.meta.changes, 1)
+      assert.strictEqual(native.meta.last_row_id, 1)
+      const result = yield* sql`INSERT INTO raw_test (name) VALUES (${"effect"})`.raw
+      assert.deepStrictEqual(yield* sql`SELECT * FROM raw_test ORDER BY id`, [
+        { id: 1, name: "native" },
+        { id: 2, name: "effect" }
+      ])
+      const raw = assertD1Result(result)
+      assert.deepStrictEqual(raw.results, [])
+      assert.strictEqual(raw.meta.changes, native.meta.changes)
+      assert.strictEqual(raw.meta.last_row_id, 2)
+      assert.strictEqual(raw.meta.rows_written, native.meta.rows_written)
+      assert.strictEqual(raw.meta.rows_read, native.meta.rows_read)
+    }).pipe(Effect.provide(D1Miniflare.layerClient)))
+
+  it.effect("keeps prepared and unprepared row and positional results", () =>
+    Effect.gen(function*() {
+      const sql = yield* D1Client.D1Client
+      const query = sql`SELECT ${42} AS answer, ${"hello"} AS greeting`
+      assert.deepStrictEqual(yield* query, [{ answer: 42, greeting: "hello" }])
+      assert.deepStrictEqual(yield* query.unprepared, [{ answer: 42, greeting: "hello" }])
+      assert.deepStrictEqual(yield* query.withoutTransform, [{ answer: 42, greeting: "hello" }])
+      assert.deepStrictEqual(yield* query.values, [[42, "hello"]])
+      assert.deepStrictEqual(yield* query.valuesUnprepared, [[42, "hello"]])
+      yield* sql`CREATE TABLE row_test (id INTEGER PRIMARY KEY, name TEXT)`
+      assert.deepStrictEqual(yield* sql`INSERT INTO row_test (name) VALUES (${"prepared"})`, [])
+      assert.deepStrictEqual(yield* sql`INSERT INTO row_test (name) VALUES (${"unprepared"})`.unprepared, [])
+      assert.deepStrictEqual(yield* sql`SELECT * FROM row_test ORDER BY id`, [
+        { id: 1, name: "prepared" },
+        { id: 2, name: "unprepared" }
+      ])
+    }).pipe(Effect.provide(D1Miniflare.layerClient)))
+
+  it.effect("keeps query and result transforms on row paths", () =>
+    Effect.gen(function*() {
+      const sql = yield* D1Client.D1Client
+      yield* sql`CREATE TABLE transform_test (first_name TEXT, "firstName" TEXT)`
+      yield* sql`INSERT INTO transform_test (first_name, "firstName") VALUES ('John', 'Jane')`
+      const transformed = yield* D1Client.make({
+        db: sql.config.db,
+        transformQueryNames: (name) => name === "firstName" ? "first_name" : name,
+        transformResultNames: (name) => name === "first_name" ? "firstName" : name
+      }).pipe(Effect.provide(Reactivity.layer))
+      const query = transformed`SELECT ${transformed("firstName")} FROM transform_test`
+      assert.deepStrictEqual(yield* query, [{ firstName: "John" }])
+      assert.deepStrictEqual(yield* query.unprepared, [{ firstName: "John" }])
+      assert.deepStrictEqual(yield* query.withoutTransform, [{ firstName: "Jane" }])
+      assert.deepStrictEqual(yield* query.values, [["John"]])
+      assert.deepStrictEqual(yield* query.valuesUnprepared, [["John"]])
+      const withoutTransforms = transformed.withoutTransforms()
+      assert.deepStrictEqual(
+        yield* withoutTransforms`SELECT ${withoutTransforms("firstName")} FROM transform_test`,
+        [{ firstName: "Jane" }]
+      )
+    }).pipe(Effect.provide(D1Miniflare.layerClient)))
+
+  it.effect("raw bypasses query and result name transforms", () =>
+    Effect.gen(function*() {
+      const sql = yield* D1Client.D1Client
+      yield* sql`CREATE TABLE transform_raw_test (first_name TEXT, "firstName" TEXT)`
+      yield* sql`INSERT INTO transform_raw_test (first_name, "firstName") VALUES ('John', 'Jane')`
+      const transformed = yield* D1Client.make({
+        db: sql.config.db,
+        transformQueryNames: (name) => name === "firstName" ? "first_name" : name,
+        transformResultNames: (name) => name === "first_name" ? "firstName" : name
+      }).pipe(Effect.provide(Reactivity.layer))
+      const raw = assertD1Result(
+        yield* transformed`SELECT ${transformed("firstName")}, first_name FROM transform_raw_test`.raw
+      )
+      assert.deepStrictEqual(raw.results, [{ firstName: "Jane", first_name: "John" }])
+    }).pipe(Effect.provide(D1Miniflare.layerClient)))
+
+  it.effect("keeps real statement errors in the SqlError channel", () =>
+    Effect.gen(function*() {
+      const sql = yield* D1Client.D1Client
+      const query = sql`SELEC 42 AS answer`
+      for (const operation of [query, query.raw, query.unprepared, query.values, query.valuesUnprepared]) {
+        const error = yield* Effect.flip(operation)
+        assert.isTrue(isSqlError(error))
+        assert.strictEqual(error.reason._tag, "UnknownError")
+        assert.strictEqual(error.reason.operation, "execute")
+      }
+    }).pipe(Effect.provide(D1Miniflare.layerClient)))
+
   it.effect("classifies native errors without stable sqlite codes as UnknownError", () =>
     Effect.gen(function*() {
       const failingDb = {

--- a/packages/sql/d1/test/Client.test.ts
+++ b/packages/sql/d1/test/Client.test.ts
@@ -62,6 +62,18 @@ describe("Client", () => {
       assert.strictEqual(raw.meta.rows_read, native.meta.rows_read)
     }).pipe(Effect.provide(D1Miniflare.layerClient)))
 
+  it.effect("raw preserves returned rows and metadata for INSERT RETURNING", () =>
+    Effect.gen(function*() {
+      const sql = yield* D1Client.D1Client
+      yield* sql`CREATE TABLE raw_returning_test (id INTEGER PRIMARY KEY, name TEXT)`
+      const raw = assertD1Result(
+        yield* sql`INSERT INTO raw_returning_test (name) VALUES (${"effect"}) RETURNING *`.raw
+      )
+      assert.deepStrictEqual(raw.results, [{ id: 1, name: "effect" }])
+      assert.strictEqual(raw.meta.changes, 1)
+      assert.strictEqual(raw.meta.last_row_id, 1)
+    }).pipe(Effect.provide(D1Miniflare.layerClient)))
+
   it.effect("keeps prepared and unprepared row and positional results", () =>
     Effect.gen(function*() {
       const sql = yield* D1Client.D1Client

--- a/packages/sql/d1/test/Client.test.ts
+++ b/packages/sql/d1/test/Client.test.ts
@@ -4,143 +4,18 @@ import { assert, describe, it } from "@effect/vitest"
 import { Cause, Effect } from "effect"
 import * as Reactivity from "effect/unstable/reactivity/Reactivity"
 import { Statement } from "effect/unstable/sql"
-import { isSqlError } from "effect/unstable/sql/SqlError"
 import { D1Miniflare } from "./utils.ts"
 
-const assertD1Result = (value: unknown): D1Result => {
-  assert.isNotArray(value)
-  assert.isObject(value)
-  const result = value as D1Result
-  assert.strictEqual(result.success, true)
-  assert.isObject(result.meta)
-  assert.isArray(result.results)
-  return result
-}
-
 describe("Client", () => {
-  it.effect("raw preserves the native SELECT result envelope", () =>
-    Effect.gen(function*() {
-      const sql = yield* D1Client.D1Client
-      // Anchor last_row_id after native D1's first-query initialization.
-      yield* sql`CREATE TABLE select_control (id INTEGER PRIMARY KEY)`
-      yield* sql`INSERT INTO select_control (id) VALUES (${7})`
-      const native = assertD1Result(
-        yield* Effect.promise(() => sql.config.db.prepare("SELECT ? AS answer").bind(42).all())
-      )
-      assert.deepStrictEqual(native.results, [{ answer: 42 }])
-      assert.strictEqual(native.meta.last_row_id, 7)
-      const raw = assertD1Result(yield* sql`SELECT ${42} AS answer`.raw)
-      assert.deepStrictEqual(raw.results, native.results)
-      assert.strictEqual(raw.meta.changes, native.meta.changes)
-      assert.strictEqual(raw.meta.last_row_id, native.meta.last_row_id)
-      assert.strictEqual(raw.meta.rows_written, native.meta.rows_written)
-      assert.strictEqual(raw.meta.rows_read, native.meta.rows_read)
-    }).pipe(Effect.provide(D1Miniflare.layerClient)))
-
-  it.effect("raw preserves native INSERT metadata without RETURNING", () =>
+  it.effect("raw preserves the native result envelope", () =>
     Effect.gen(function*() {
       const sql = yield* D1Client.D1Client
       yield* sql`CREATE TABLE raw_test (id INTEGER PRIMARY KEY, name TEXT)`
-      const native = assertD1Result(
-        yield* Effect.promise(() =>
-          sql.config.db.prepare("INSERT INTO raw_test (name) VALUES (?)").bind("native").all()
-        )
-      )
-      assert.deepStrictEqual(native.results, [])
-      assert.strictEqual(native.meta.changes, 1)
-      assert.strictEqual(native.meta.last_row_id, 1)
-      const result = yield* sql`INSERT INTO raw_test (name) VALUES (${"effect"})`.raw
-      assert.deepStrictEqual(yield* sql`SELECT * FROM raw_test ORDER BY id`, [
-        { id: 1, name: "native" },
-        { id: 2, name: "effect" }
-      ])
-      const raw = assertD1Result(result)
+      const raw = (yield* sql`INSERT INTO raw_test (name) VALUES (${"effect"})`.raw) as D1Result
+      assert.strictEqual(raw.success, true)
       assert.deepStrictEqual(raw.results, [])
-      assert.strictEqual(raw.meta.changes, native.meta.changes)
-      assert.strictEqual(raw.meta.last_row_id, 2)
-      assert.strictEqual(raw.meta.rows_written, native.meta.rows_written)
-      assert.strictEqual(raw.meta.rows_read, native.meta.rows_read)
-    }).pipe(Effect.provide(D1Miniflare.layerClient)))
-
-  it.effect("raw preserves returned rows and metadata for INSERT RETURNING", () =>
-    Effect.gen(function*() {
-      const sql = yield* D1Client.D1Client
-      yield* sql`CREATE TABLE raw_returning_test (id INTEGER PRIMARY KEY, name TEXT)`
-      const raw = assertD1Result(
-        yield* sql`INSERT INTO raw_returning_test (name) VALUES (${"effect"}) RETURNING *`.raw
-      )
-      assert.deepStrictEqual(raw.results, [{ id: 1, name: "effect" }])
       assert.strictEqual(raw.meta.changes, 1)
       assert.strictEqual(raw.meta.last_row_id, 1)
-    }).pipe(Effect.provide(D1Miniflare.layerClient)))
-
-  it.effect("keeps prepared and unprepared row and positional results", () =>
-    Effect.gen(function*() {
-      const sql = yield* D1Client.D1Client
-      const query = sql`SELECT ${42} AS answer, ${"hello"} AS greeting`
-      assert.deepStrictEqual(yield* query, [{ answer: 42, greeting: "hello" }])
-      assert.deepStrictEqual(yield* query.unprepared, [{ answer: 42, greeting: "hello" }])
-      assert.deepStrictEqual(yield* query.withoutTransform, [{ answer: 42, greeting: "hello" }])
-      assert.deepStrictEqual(yield* query.values, [[42, "hello"]])
-      assert.deepStrictEqual(yield* query.valuesUnprepared, [[42, "hello"]])
-      yield* sql`CREATE TABLE row_test (id INTEGER PRIMARY KEY, name TEXT)`
-      assert.deepStrictEqual(yield* sql`INSERT INTO row_test (name) VALUES (${"prepared"})`, [])
-      assert.deepStrictEqual(yield* sql`INSERT INTO row_test (name) VALUES (${"unprepared"})`.unprepared, [])
-      assert.deepStrictEqual(yield* sql`SELECT * FROM row_test ORDER BY id`, [
-        { id: 1, name: "prepared" },
-        { id: 2, name: "unprepared" }
-      ])
-    }).pipe(Effect.provide(D1Miniflare.layerClient)))
-
-  it.effect("keeps query and result transforms on row paths", () =>
-    Effect.gen(function*() {
-      const sql = yield* D1Client.D1Client
-      yield* sql`CREATE TABLE transform_test (first_name TEXT, "firstName" TEXT)`
-      yield* sql`INSERT INTO transform_test (first_name, "firstName") VALUES ('John', 'Jane')`
-      const transformed = yield* D1Client.make({
-        db: sql.config.db,
-        transformQueryNames: (name) => name === "firstName" ? "first_name" : name,
-        transformResultNames: (name) => name === "first_name" ? "firstName" : name
-      }).pipe(Effect.provide(Reactivity.layer))
-      const query = transformed`SELECT ${transformed("firstName")} FROM transform_test`
-      assert.deepStrictEqual(yield* query, [{ firstName: "John" }])
-      assert.deepStrictEqual(yield* query.unprepared, [{ firstName: "John" }])
-      assert.deepStrictEqual(yield* query.withoutTransform, [{ firstName: "Jane" }])
-      assert.deepStrictEqual(yield* query.values, [["John"]])
-      assert.deepStrictEqual(yield* query.valuesUnprepared, [["John"]])
-      const withoutTransforms = transformed.withoutTransforms()
-      assert.deepStrictEqual(
-        yield* withoutTransforms`SELECT ${withoutTransforms("firstName")} FROM transform_test`,
-        [{ firstName: "Jane" }]
-      )
-    }).pipe(Effect.provide(D1Miniflare.layerClient)))
-
-  it.effect("raw bypasses query and result name transforms", () =>
-    Effect.gen(function*() {
-      const sql = yield* D1Client.D1Client
-      yield* sql`CREATE TABLE transform_raw_test (first_name TEXT, "firstName" TEXT)`
-      yield* sql`INSERT INTO transform_raw_test (first_name, "firstName") VALUES ('John', 'Jane')`
-      const transformed = yield* D1Client.make({
-        db: sql.config.db,
-        transformQueryNames: (name) => name === "firstName" ? "first_name" : name,
-        transformResultNames: (name) => name === "first_name" ? "firstName" : name
-      }).pipe(Effect.provide(Reactivity.layer))
-      const raw = assertD1Result(
-        yield* transformed`SELECT ${transformed("firstName")}, first_name FROM transform_raw_test`.raw
-      )
-      assert.deepStrictEqual(raw.results, [{ firstName: "Jane", first_name: "John" }])
-    }).pipe(Effect.provide(D1Miniflare.layerClient)))
-
-  it.effect("keeps real statement errors in the SqlError channel", () =>
-    Effect.gen(function*() {
-      const sql = yield* D1Client.D1Client
-      const query = sql`SELEC 42 AS answer`
-      for (const operation of [query, query.raw, query.unprepared, query.values, query.valuesUnprepared]) {
-        const error = yield* Effect.flip(operation)
-        assert.isTrue(isSqlError(error))
-        assert.strictEqual(error.reason._tag, "UnknownError")
-        assert.strictEqual(error.reason.operation, "execute")
-      }
     }).pipe(Effect.provide(D1Miniflare.layerClient)))
 
   it.effect("classifies native errors without stable sqlite codes as UnknownError", () =>


### PR DESCRIPTION
## Why

D1 statement `.raw` discarded the native result envelope, including `success` and metadata such as affected-row counts and the last inserted ID. For example, a successful INSERT without RETURNING became only `[]`.

## What changed

Native execution is separate from row projection. The raw path returns the complete `D1Result`; ordinary cached and unprepared paths continue returning rows, and positional APIs still use D1's positional operation.

One focused Miniflare regression checks that a successful INSERT through `.raw` retains `success`, empty `results`, and mutation metadata.

## Compatibility

Public `.raw` remains typed as `unknown`, but callers that cast its previous array shape should read `.results` or use an ordinary or `.unprepared` statement when only rows are needed.

## Verification

On current `main` at `d7c66d0349`, the focused regression fails because `.raw` returns the row array and `success` is missing. On this branch, the D1 client suite passes all 12 tests.

```bash
nix develop -c pnpm lint-fix
nix develop -c pnpm test --run packages/sql/d1/test/Client.test.ts --maxWorkers=1 --maxConcurrency=1 --no-file-parallelism
nix develop -c pnpm check
git diff --check
```

Closes EFF-1183
Closes #7881

## Audit

Runtime correctness audit; intended label: `audit`.
