### PR TITLE
fix(ConfigProvider): substitute dotenv references as literal data

### DIFF
--- a/.changeset/dotenv-literal-substitution.md
+++ b/.changeset/dotenv-literal-substitution.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `ConfigProvider.fromDotEnvContents` variable expansion to preserve replacement tokens such as `$&` in referenced values.

--- a/packages/effect/src/ConfigProvider.ts
+++ b/packages/effect/src/ConfigProvider.ts
@@ -1135,7 +1135,7 @@ function interpolate(envValue: string, parsed: Record<string, string>): string {
       : defaultValue ?? ""
 
     return interpolate(
-      envValue.replace(group, value),
+      envValue.replace(group, () => value),
       parsed
     )
   }

--- a/packages/effect/test/ConfigProvider.test.ts
+++ b/packages/effect/test/ConfigProvider.test.ts
@@ -846,6 +846,17 @@ DB_PASS=\${PASSWORD}
       await assertSuccess(provider, ["DB_PASS"], ConfigProvider.makeValue("value"))
     })
 
+    it("expands referenced values as literal data", async () => {
+      const provider = ConfigProvider.fromDotEnvContents(
+        `
+SOURCE=$&
+TARGET=\${SOURCE}
+`,
+        { expandVariables: true }
+      )
+      await assertSuccess(provider, ["TARGET"], ConfigProvider.makeValue("$&"))
+    })
+
     it("expansion defaults are used only for empty or unset variables", async () => {
       const provider = ConfigProvider.fromDotEnvContents(
         `

--- a/packages/effect/test/ConfigProvider.test.ts
+++ b/packages/effect/test/ConfigProvider.test.ts
@@ -849,12 +849,12 @@ DB_PASS=\${PASSWORD}
     it("expands referenced values as literal data", async () => {
       const provider = ConfigProvider.fromDotEnvContents(
         `
-SOURCE=$&
+SOURCE=a$&b$'c$\`d
 TARGET=\${SOURCE}
 `,
         { expandVariables: true }
       )
-      await assertSuccess(provider, ["TARGET"], ConfigProvider.makeValue("$&"))
+      await assertSuccess(provider, ["TARGET"], ConfigProvider.makeValue("a$&b$'c$`d"))
     })
 
     it("expansion defaults are used only for empty or unset variables", async () => {


### PR DESCRIPTION
## Why

Dotenv expansion passed referenced values directly to `String.replace`. Values such as `$&` were treated as replacement templates, causing incorrect substitution and, in this case, unbounded recursion.

## What changed

Insert referenced values through a replacement callback so they remain literal data. The existing ConfigProvider suite now covers `$&`, `$'`, and ``$` `` in one referenced value.

## Verification

- `pnpm test --run packages/effect/test/ConfigProvider.test.ts --maxWorkers=1 --no-file-parallelism` (101 passed)
- `pnpm lint`
- `pnpm check`

Closes #7883
Closes EFF-1181
