### PR TITLE
fix(HashRing): include the final exclusion search radius

### DIFF
--- a/.changeset/hashring-exclusion-endpoint.md
+++ b/.changeset/hashring-exclusion-endpoint.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `HashRing.getShards` skipping an eligible node at the first ring position when other nodes have reached their allocation quota.

--- a/packages/effect/src/HashRing.ts
+++ b/packages/effect/src/HashRing.ts
@@ -420,7 +420,7 @@ function getIndexForInput<A extends PrimaryKey.PrimaryKey>(
     return [a, distA]
   }
   const range = Math.max(lo, len - lo)
-  for (let i = 1; i < range; i++) {
+  for (let i = 1; i <= range; i++) {
     let index = lo - i
     if (index >= 0 && index < len && !exclude.has(ring[index][1])) {
       return [index, Math.abs(ring[index][0] - hash)]

--- a/packages/effect/test/HashRing.test.ts
+++ b/packages/effect/test/HashRing.test.ts
@@ -61,6 +61,8 @@ describe("HashRing", () => {
   })
 
   it("getShards considers the first ring entry when excluding allocated nodes", () => {
+    // With one ring entry per node, these keys make every shard nearest to
+    // `second`, so `first` at index 0 is reached only by the exclusion scan.
     const first = {
       [PrimaryKey.symbol]() {
         return "node-10"
@@ -75,6 +77,6 @@ describe("HashRing", () => {
     HashRing.add(ring, first)
     HashRing.add(ring, second)
 
-    assert.strictEqual(HashRing.getShards(ring, 3)?.includes(first), true)
+    assert.deepStrictEqual(HashRing.getShards(ring, 3)?.map(PrimaryKey.value), ["node-10", "node-29", "node-29"])
   })
 })

--- a/packages/effect/test/HashRing.test.ts
+++ b/packages/effect/test/HashRing.test.ts
@@ -59,4 +59,22 @@ describe("HashRing", () => {
 
     assert.deepStrictEqual(shards, [[], [], [], [], [node], [node, node]])
   })
+
+  it("getShards considers the first ring entry when excluding allocated nodes", () => {
+    const first = {
+      [PrimaryKey.symbol]() {
+        return "node-10"
+      }
+    }
+    const second = {
+      [PrimaryKey.symbol]() {
+        return "node-29"
+      }
+    }
+    const ring = HashRing.make<typeof first>({ baseWeight: 1 })
+    HashRing.add(ring, first)
+    HashRing.add(ring, second)
+
+    assert.strictEqual(HashRing.getShards(ring, 3)?.includes(first), true)
+  })
 })


### PR DESCRIPTION
## Why

`HashRing.getShards` can skip the first virtual entry when the nearest node has reached its allocation quota. With two equally weighted nodes at `baseWeight: 1`, this can leave the first node unused while the second node receives every shard.

## What changed

- Include the final search radius so the exclusion scan reaches ring index `0`.
- Add a minimal public-API regression test for the confirmed two-node, three-shard case.
- Add an `effect` patch changeset.

## Verification

```bash
nix develop -c pnpm test --run packages/effect/test/HashRing.test.ts
nix develop -c pnpm lint-fix
nix develop -c pnpm check
git diff --check origin/main...HEAD
```

The focused suite passes all 4 tests. Lint, typecheck, and the whitespace check pass.

Closes #7885
Closes EFF-1175
