### PR TITLE
fix(cluster): distinguish entity teardown keys unambiguously

### DIFF
--- a/.changeset/cluster-teardown-distinct-entity-keys.md
+++ b/.changeset/cluster-teardown-distinct-entity-keys.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Keep teardown tracking separate for distinct cluster entity addresses whose types or IDs contain delimiters. Closing one entity no longer suppresses persisted cancellations from an unrelated live entity. Persisted and wire identities are unchanged.

--- a/packages/effect/src/unstable/cluster/internal/interruptors.ts
+++ b/packages/effect/src/unstable/cluster/internal/interruptors.ts
@@ -22,7 +22,7 @@ const around = <A, E, R>(key: string, effect: Effect.Effect<A, E, R>): Effect.Ef
   })
 
 const entityKey = (address: EntityAddress): string =>
-  `entity:${address.entityType}:${address.entityId}:${address.shardId.toString()}`
+  `entity:${JSON.stringify([address.entityType, address.entityId, address.shardId.group, address.shardId.id])}`
 
 const shardKey = (shardId: ShardId): string => `shard:${shardId.toString()}`
 

--- a/packages/effect/test/cluster/EntityTeardownVerification.test.ts
+++ b/packages/effect/test/cluster/EntityTeardownVerification.test.ts
@@ -130,7 +130,6 @@ const observe = (label: string, colliding: boolean, closeBeforeCancel: boolean) 
         interrupts: interrupts.length,
         journal: driver.journal.slice()
       }
-      console.log(JSON.stringify(result))
       yield* Deferred.succeed(releaseAFinalizer, undefined)
       yield* Deferred.succeed(releaseReceiver, undefined)
       yield* Fiber.join(closingA)

--- a/packages/effect/test/cluster/EntityTeardownVerification.test.ts
+++ b/packages/effect/test/cluster/EntityTeardownVerification.test.ts
@@ -1,0 +1,160 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Deferred, Effect, Equal, Exit, Fiber, Layer, Schema, Scope } from "effect"
+import {
+  ClusterSchema,
+  Entity,
+  type EntityAddress,
+  MessageStorage,
+  RunnerHealth,
+  Runners,
+  RunnerStorage,
+  Sharding,
+  ShardingConfig
+} from "effect/unstable/cluster"
+import { Rpc } from "effect/unstable/rpc"
+
+const Runtime = Sharding.layer.pipe(
+  Layer.provide(Runners.layerNoop),
+  Layer.provide([RunnerStorage.layerMemory, RunnerHealth.layerNoop]),
+  Layer.provideMerge(MessageStorage.layerMemory),
+  Layer.provide(ShardingConfig.layer({
+    shardsPerGroup: 1,
+    preemptiveShutdown: false,
+    entityMaxIdleTime: Infinity,
+    entityTerminationTimeout: 0,
+    refreshAssignmentsInterval: 1000,
+    entityMessagePollInterval: 5000,
+    sendRetryInterval: 10
+  }))
+)
+
+// Deadlines are harness-failure guards, never scheduling oracles.
+const gate = <A>(deferred: Deferred.Deferred<A>) =>
+  Deferred.await(deferred).pipe(Effect.timeout("5 seconds"), Effect.orDie)
+
+const observe = (label: string, colliding: boolean, closeBeforeCancel: boolean) =>
+  Effect.gen(function*() {
+    const sharding = yield* Sharding.Sharding
+    const driver = yield* MessageStorage.MemoryDriver
+    const outerScope = yield* Effect.scope
+    const aScope = yield* Scope.fork(outerScope)
+    const aFinalizerStarted = yield* Deferred.make<void>()
+    const releaseAFinalizer = yield* Deferred.make<void>()
+    const releaseReceiver = yield* Deferred.make<void>()
+    const receiverStarted = yield* Deferred.make<string>()
+    const aAddress = yield* Deferred.make<EntityAddress.EntityAddress>()
+    const bAddress = yield* Deferred.make<EntityAddress.EntityAddress>()
+    const aType = `R4Orders-${label}${colliding ? ":" : "-"}Shard`
+    const bType = `R4Orders-${label}`
+    const A = Entity.make(aType, [Rpc.make("Ping")])
+    const B = Entity.make(bType, [
+      Rpc.make("Start"),
+      Rpc.make("Cancel", { success: Schema.Number })
+    ])
+    const Receiver = Entity.make(`R4Receiver-${label}`, [
+      Rpc.make("Work", { success: Schema.Number }).annotate(ClusterSchema.Persisted, true)
+    ])
+
+    // Release blockers before the surrounding runtime scope closes, on success or failure.
+    return yield* Effect.gen(function*() {
+      yield* Layer.build(Receiver.toLayer({
+        Work: ({ requestId }) =>
+          Effect.gen(function*() {
+            yield* Deferred.succeed(receiverStarted, String(requestId))
+            yield* gate(releaseReceiver)
+            return 7
+          })
+      }))
+      yield* Layer.build(A.toLayer(Effect.gen(function*() {
+        yield* Deferred.succeed(aAddress, yield* Entity.CurrentAddress)
+        yield* Effect.acquireRelease(Effect.void, () =>
+          Deferred.succeed(aFinalizerStarted, undefined).pipe(
+            Effect.andThen(gate(releaseAFinalizer))
+          ))
+        return { Ping: () => Effect.void }
+      }))).pipe(Scope.provide(aScope))
+      yield* Layer.build(B.toLayer(
+        Effect.gen(function*() {
+          yield* Deferred.succeed(bAddress, yield* Entity.CurrentAddress)
+          const scope = yield* Effect.scope
+          const receiver = (yield* Receiver.client)("receiver")
+          let child: Fiber.Fiber<unknown, unknown> | undefined
+          return {
+            Start: () =>
+              Effect.gen(function*() {
+                child = yield* receiver.Work().pipe(Effect.forkIn(scope))
+              }),
+            Cancel: () =>
+              Effect.suspend(() =>
+                child
+                  ? Fiber.interrupt(child).pipe(Effect.as(42))
+                  : Effect.die("HARNESS: Cancel before Start")
+              )
+          }
+        }),
+        { concurrency: "unbounded" }
+      ))
+
+      yield* (yield* A.client)("123").Ping()
+      const b = (yield* B.client)("Shard:123")
+      yield* b.Start()
+      const requestId = yield* gate(receiverStarted)
+      const addressA = yield* gate(aAddress)
+      const addressB = yield* gate(bAddress)
+      assert.isFalse(Equal.equals(addressA, addressB), "distinct valid entity addresses")
+      const oldKey = (address: EntityAddress.EntityAddress) =>
+        `${address.entityType}:${address.entityId}:${address.shardId.toString()}`
+      assert.strictEqual(oldKey(addressA) === oldKey(addressB), colliding)
+
+      const closingA = yield* Scope.close(aScope, Exit.void).pipe(Effect.forkIn(outerScope))
+      yield* gate(aFinalizerStarted)
+      if (closeBeforeCancel) {
+        yield* Deferred.succeed(releaseAFinalizer, undefined)
+        yield* Fiber.join(closingA)
+      }
+      assert.isFalse(yield* sharding.isShutdown, "only A registration is closing")
+      assert.strictEqual(yield* b.Cancel(), 42, "live B completed explicit cancellation")
+      assert.isFalse(yield* sharding.isShutdown, "runner remains live after Cancel")
+      const requests = driver.journal.filter((envelope) =>
+        envelope._tag === "Request" && envelope.requestId === requestId
+      )
+      const interrupts = driver.journal.filter((envelope) =>
+        envelope._tag === "Interrupt" && envelope.requestId === requestId
+      )
+      const result = {
+        assertionId: label,
+        requestId,
+        addressA,
+        addressB,
+        requests: requests.length,
+        interrupts: interrupts.length,
+        journal: driver.journal.slice()
+      }
+      console.log(JSON.stringify(result))
+      yield* Deferred.succeed(releaseAFinalizer, undefined)
+      yield* Deferred.succeed(releaseReceiver, undefined)
+      yield* Fiber.join(closingA)
+      return result
+    }).pipe(Effect.ensuring(Effect.gen(function*() {
+      yield* Deferred.succeed(releaseAFinalizer, undefined)
+      yield* Deferred.succeed(releaseReceiver, undefined)
+      yield* Scope.close(aScope, Exit.void)
+    })))
+  }).pipe(Effect.provide(Runtime), Effect.timeout("15 seconds"))
+
+describe.sequential("R4 entity teardown identity", () => {
+  for (
+    const [label, colliding, closeBeforeCancel] of [
+      ["TEARDOWN-COLLIDING-LIVE", true, false],
+      ["TEARDOWN-NONCOLLIDING-LIVE", false, false],
+      ["TEARDOWN-COLLIDING-CLOSED", true, true]
+    ] as const
+  ) {
+    it.live(label, () =>
+      Effect.gen(function*() {
+        const result = yield* observe(label, colliding, closeBeforeCancel)
+        assert.strictEqual(result.requests, 1, "one exact Receiver request")
+        assert.strictEqual(result.interrupts, 1, "live B cancellation must persist one exact Interrupt")
+      }), { timeout: 20000 })
+  }
+})


### PR DESCRIPTION
## Why

Distinct entity addresses containing colons can share the same private teardown key. A still-live entity's explicit cancellation can then be suppressed while an unrelated entity finalizes.

## What Changes

Encode the entity type, ID and shard components as an unambiguous tuple. Preserve the existing namespace, type/shard-wide keys and reference counts.

## Scope

One private in-memory key expression, public lifecycle regression coverage and an `effect` patch changeset. No persisted identifiers, wire formats, address hashing or cancellation policy change. Same-entity transient teardown suppression remains intact.

## Verification

```bash
pnpm lint-fix
pnpm test --run packages/effect/test/cluster/EntityTeardownVerification.test.ts --maxWorkers=1 --no-file-parallelism
pnpm test --run packages/effect/test/cluster/Sharding.test.ts packages/effect/test/cluster/interruptors.test.ts --maxWorkers=1 --no-file-parallelism --passWithNoTests=false -t 'swallows.persisted.interrupts.from.an.idle-reaped.nested.proxy.call|forwards.interrupts.from.an.external.same-node.caller$|releases.entity.keys|refcounts.overlapping|aroundEntityType.restores'
pnpm check
git diff --check af0ccdd13aa8917bce7161b8bc257fbe51c6a6a5 HEAD
git diff --check
```

On publication base `af0ccdd13aa8917bce7161b8bc257fbe51c6a6a5`, the identical focused selection has **2 passed / 1 failed** without this fix and **3 passed** with it, with no skipped tests or changed identities. Post-commit lint, root typecheck, and whitespace checks passed on `2eccd9c90310415ccd05195d2826d35ddff28e49`. The separate existing-control selection passed all five intended tests; 51 unrelated Sharding tests were intentionally filtered, not counted as passes. The exact control identities and filtered inventory were checked separately.

Deferred handshakes keep one resource finalizer active while another entity's cancellation completes. The journal snapshot is taken before fixture cleanup, for the exact receiver request ID, with node shutdown still false. Existing transient-suppression, external-cancellation and reference-count controls are checked separately; filtered tests are not counted as passes. No partition, storage failure or timing window is used as the oracle.

Closes #7890
Closes EFF-1161

## Audit

Runtime correctness audit; intended label: `audit`.
