### PR TITLE
fix(ai-docgen): resolve generated links from the output directory

### DIFF
--- a/.changeset/ai-docgen-output-links.md
+++ b/.changeset/ai-docgen-output-links.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-docgen": patch
+---
+
+Resolve generated example links relative to the output document.

--- a/packages/tools/ai-docgen/src/main.ts
+++ b/packages/tools/ai-docgen/src/main.ts
@@ -103,7 +103,8 @@ ${metadata.content}
           }
 
           const relativePath = pathService.relative(outputDirectory, filePath)
-          const link = `[${metadata.title}](./${relativePath})`
+          const href = relativePath.startsWith(".") ? relativePath : `./${relativePath}`
+          const link = `[${metadata.title}](${href})`
           let content = ""
 
           if (hasInlineFiles && metadata.fileNameWithoutExt.startsWith("10")) {

--- a/packages/tools/ai-docgen/src/main.ts
+++ b/packages/tools/ai-docgen/src/main.ts
@@ -32,7 +32,9 @@ const watch = Flag.boolean("watch").pipe(
 Command.make("effect-ai-docgen", { directory, output, watch }).pipe(
   Command.withHandler(Effect.fnUntraced(function*({ directory, output, watch }) {
     const fs = yield* FileSystem.FileSystem
-    const markdown = yield* directoryToMarkdown(directory)
+    const pathService = yield* Path.Path
+    const outputDirectory = pathService.dirname(pathService.resolve(output))
+    const markdown = yield* directoryToMarkdown(directory, outputDirectory)
     yield* fs.writeFileString(output, markdown)
 
     if (!watch) return
@@ -43,7 +45,7 @@ Command.make("effect-ai-docgen", { directory, output, watch }).pipe(
       Stream.debounce(1000),
       Stream.tap(() => Effect.logInfo("Changes detected, regenerating documentation...")),
       Stream.switchMap(() =>
-        directoryToMarkdown(directory).pipe(
+        directoryToMarkdown(directory, outputDirectory).pipe(
           Stream.fromEffect
         )
       ),
@@ -62,7 +64,8 @@ Command.make("effect-ai-docgen", { directory, output, watch }).pipe(
 
 const directoryToMarkdown = Effect.fn("directoryToMarkdown")(
   function*(
-    directory: string
+    directory: string,
+    outputDirectory: string
   ): Effect.fn.Return<string, PlatformError.PlatformError, FileSystem.FileSystem | Path.Path> {
     const pathService = yield* Path.Path
     const fs = yield* FileSystem.FileSystem
@@ -84,7 +87,7 @@ const directoryToMarkdown = Effect.fn("directoryToMarkdown")(
 
         if (stat.type === "Directory") {
           if (basename === "fixtures") return null
-          return `${yield* directoryToMarkdown(filePath)}\n`
+          return `${yield* directoryToMarkdown(filePath, outputDirectory)}\n`
         } else if (/\.tsx?$/.test(file)) {
           const metadata = yield* tsFileMetadata(filePath)
 
@@ -99,7 +102,7 @@ ${metadata.content}
 `
           }
 
-          const relativePath = pathService.relative(process.cwd(), filePath)
+          const relativePath = pathService.relative(outputDirectory, filePath)
           const link = `[${metadata.title}](./${relativePath})`
           let content = ""
 

--- a/packages/tools/ai-docgen/test/OutputLinks.test.ts
+++ b/packages/tools/ai-docgen/test/OutputLinks.test.ts
@@ -1,0 +1,36 @@
+import { assert, describe, it } from "@effect/vitest"
+import { spawnSync } from "node:child_process"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const cli = fileURLToPath(new URL("../src/main.ts", import.meta.url))
+
+describe("generated links", () => {
+  it("resolves links relative to a nested output document", () => {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "ai-docgen-output-links-"))
+
+    try {
+      const examples = path.join(fixture, "examples")
+      const source = path.join(examples, "10_example.ts")
+      const output = path.join(fixture, "docs", "guide.md")
+      fs.mkdirSync(path.dirname(output), { recursive: true })
+      fs.mkdirSync(examples)
+      fs.writeFileSync(source, "export const answer = 42\n")
+
+      const child = spawnSync(process.execPath, [cli, "examples", "--output", "docs/guide.md"], {
+        cwd: fixture,
+        encoding: "utf8"
+      })
+
+      assert.strictEqual(child.status, 0, child.stderr)
+      const markdown = fs.readFileSync(output, "utf8")
+      const href = markdown.match(/\]\(([^)]+)\)/)?.[1]
+      assert.isString(href)
+      assert.strictEqual(path.resolve(path.dirname(output), href), source)
+    } finally {
+      fs.rmSync(fixture, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/tools/ai-docgen/test/OutputLinks.test.ts
+++ b/packages/tools/ai-docgen/test/OutputLinks.test.ts
@@ -25,10 +25,10 @@ describe("generated links", () => {
       })
 
       assert.strictEqual(child.status, 0, child.stderr)
-      const markdown = fs.readFileSync(output, "utf8")
-      const href = markdown.match(/\]\(([^)]+)\)/)?.[1]
-      if (href === undefined) assert.fail("generated Markdown did not contain a link")
-      assert.strictEqual(path.resolve(path.dirname(output), href), source)
+      assert.strictEqual(
+        fs.readFileSync(output, "utf8").trim(),
+        "- **[Example](../examples/10_example.ts)**"
+      )
     } finally {
       fs.rmSync(fixture, { recursive: true, force: true })
     }

--- a/packages/tools/ai-docgen/test/OutputLinks.test.ts
+++ b/packages/tools/ai-docgen/test/OutputLinks.test.ts
@@ -27,7 +27,7 @@ describe("generated links", () => {
       assert.strictEqual(child.status, 0, child.stderr)
       const markdown = fs.readFileSync(output, "utf8")
       const href = markdown.match(/\]\(([^)]+)\)/)?.[1]
-      assert.isString(href)
+      if (href === undefined) assert.fail("generated Markdown did not contain a link")
       assert.strictEqual(path.resolve(path.dirname(output), href), source)
     } finally {
       fs.rmSync(fixture, { recursive: true, force: true })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -202,6 +202,7 @@ export default defineConfig({
       ...project("@effect/sql-sqlite-node", "packages/sql/sqlite-node", isNode),
       ...project("@effect/sql-sqlite-react-native", "packages/sql/sqlite-react-native"),
       ...project("@effect/sql-sqlite-wasm", "packages/sql/sqlite-wasm"),
+      ...project("@effect/ai-docgen", "packages/tools/ai-docgen", isNode),
       ...project("@effect/api-diff", "packages/tools/api-diff"),
       ...project("@effect/bundle", "packages/tools/bundle"),
       ...project("@effect/doctest", "packages/tools/doctest"),


### PR DESCRIPTION
## Why

AI docgen generated example links relative to the process working directory. When the output Markdown was written elsewhere, those links resolved beneath the output directory and were broken.

## What changed

- Resolve the output directory once and use it for generated links, including watch-mode regeneration.
- Add a Node regression test for a nested output document.
- Add a patch changeset for `@effect/ai-docgen`.

## Verification

```bash
pnpm test --run --project @effect/ai-docgen packages/tools/ai-docgen/test/OutputLinks.test.ts --maxWorkers=1 --maxConcurrency=1 --no-file-parallelism
pnpm check
pnpm lint
pnpm exec changeset status --since origin/main
git diff --check
```

Closes #7895
Closes EFF-1173
