### PR TITLE
Fix flaky browser RPC stream test

### DIFF
--- a/packages/platform/browser/test/fixtures/rpc-e2e.ts
+++ b/packages/platform/browser/test/fixtures/rpc-e2e.ts
@@ -65,7 +65,7 @@ export const e2eSuite = <E>(
       Effect.gen(function*() {
         const client = yield* UsersClient
         const users: Array<User> = []
-        yield* client.StreamUsers({ id: "1" }).pipe(
+        const fiber = yield* client.StreamUsers({ id: "1" }).pipe(
           Stream.take(5),
           Stream.runForEach((user) =>
             Effect.sync(() => {
@@ -75,7 +75,7 @@ export const e2eSuite = <E>(
           Effect.forkChild
         )
 
-        yield* Effect.sleep(2000)
+        yield* Fiber.join(fiber)
         assert.lengthOf(users, 5)
 
         // test interrupts


### PR DESCRIPTION
The browser RPC stream test forks its consumer and then waits for a fixed two seconds before asserting that five elements arrived. Under CI load, worker startup and scheduling can consume that budget, causing the assertion to observe only four elements.

Join the stream consumer fiber instead so the assertion runs after `Stream.take(5)` completes. This matches the existing Deno RPC fixture and removes the wall-clock race.

Failure: https://github.com/Effect-TS/effect/actions/runs/33756358405/job/100651616070?pr=7892

Validation:
- `pnpm lint-fix`
- `pnpm test --run packages/platform/browser/test/RpcWorker.test.ts`
- `pnpm check`
