### PR TITLE
add Effectable.Mixin

### DIFF
--- a/.changeset/effectable-mixin.md
+++ b/.changeset/effectable-mixin.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Effectable.Mixin` to insert the Effect prototype into an existing class inheritance chain. The returned abstract class requires an `override` Effect and derives its Effect type from that property through polymorphic `this`.

--- a/.changeset/effectable-mixin.md
+++ b/.changeset/effectable-mixin.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Add `Effectable.Mixin` to insert the Effect prototype into an existing class inheritance chain. The returned abstract class requires an `override` Effect and derives its Effect type from that property through polymorphic `this`.
+Add `Effectable.Mixin` to insert the Effect prototype into an existing class inheritance chain. The returned abstract class requires an `asEffect` method and derives its Effect type from that method through polymorphic `this`.

--- a/packages/effect/src/Effectable.ts
+++ b/packages/effect/src/Effectable.ts
@@ -43,10 +43,10 @@ export const Prototype = <A extends Effect.Effect<any, any, any>>(options: {
     [evaluate]: options.evaluate
   }) as any
 
-const proto = Prototype({
+const proto = Prototype<Class<any, any, any>>({
   label: "Effectable",
   evaluate(_) {
-    return (this as any).override
+    return this.override
   }
 })
 

--- a/packages/effect/src/Effectable.ts
+++ b/packages/effect/src/Effectable.ts
@@ -46,7 +46,7 @@ export const Prototype = <A extends Effect.Effect<any, any, any>>(options: {
 const proto = Prototype<Class<any, any, any>>({
   label: "Effectable",
   evaluate(_) {
-    return this.override
+    return this.asEffect()
   }
 })
 
@@ -73,14 +73,14 @@ export abstract class Class<A, E = never, R = never> extends Base<A, E, R> {
   abstract asEffect(): Effect.Effect<A, E, R>
 }
 
-type OverrideEffect<Self> = Self extends {
-  override: infer Override extends Effect.Effect<any, any, any>
-} ? Override
+type AsEffectReturn<Self> = Self extends {
+  asEffect(): infer A extends Effect.Effect<any, any, any>
+} ? A
   : never
 
-interface EffectableFromOverride extends Pipeable.Pipeable, Inspectable.Inspectable {
-  readonly [EffectTypeId]: OverrideEffect<this>[typeof EffectTypeId]
-  [Symbol.iterator](): Effect.EffectIterator<OverrideEffect<this>>
+interface EffectableFromAsEffect extends Pipeable.Pipeable, Inspectable.Inspectable {
+  readonly [EffectTypeId]: AsEffectReturn<this>[typeof EffectTypeId]
+  [Symbol.iterator](): Effect.EffectIterator<AsEffectReturn<this>>
 }
 
 /**
@@ -97,7 +97,7 @@ interface EffectableFromOverride extends Pipeable.Pipeable, Inspectable.Inspecta
  * @category models
  * @since 4.0.0
  */
-export type EffectableConstructor = abstract new(...args: ReadonlyArray<any>) => EffectableFromOverride
+export type EffectableConstructor = abstract new(...args: ReadonlyArray<any>) => EffectableFromAsEffect
 
 /**
  * Returns a subclass of the provided class that inserts the Effect prototype
@@ -110,10 +110,10 @@ export type EffectableConstructor = abstract new(...args: ReadonlyArray<any>) =>
  *
  * **Details**
  *
- * Pass the class to wrap, then define the `override` Effect on the final class.
- * The returned class is abstract, and the success, error, and service types are
- * inferred from the concrete `override` property. The original constructor and
- * instance members are preserved.
+ * Pass the class to wrap, then implement `asEffect` on the final class. The
+ * returned class is abstract, and the success, error, and service types are
+ * inferred from the concrete `asEffect` return type. The original constructor
+ * and instance members are preserved.
  *
  * **Example** (Evaluating a mixed-in class)
  *
@@ -125,7 +125,9 @@ export type EffectableConstructor = abstract new(...args: ReadonlyArray<any>) =>
  * }
  *
  * class EffectBox extends Effectable.Mixin(Box) {
- *   override = Effect.succeed(this.value)
+ *   asEffect() {
+ *     return Effect.succeed(this.value)
+ *   }
  * }
  *
  * const box = new EffectBox(2)
@@ -142,7 +144,7 @@ export const Mixin = <TBase extends new(...args: ReadonlyArray<any>) => any>(
   klass: TBase
 ) => {
   abstract class Mixed extends klass {
-    abstract override: Effect.Effect<any, any, any>
+    abstract asEffect(): Effect.Effect<any, any, any>
   }
   Object.setPrototypeOf(
     Mixed.prototype,

--- a/packages/effect/src/Effectable.ts
+++ b/packages/effect/src/Effectable.ts
@@ -1,6 +1,6 @@
 /**
  * Low-level helpers for making custom values behave like Effects. The module
- * exposes a prototype builder and an abstract base class that let
+ * exposes a prototype builder, an abstract base class, and a mixin that let
  * domain-specific values, such as service keys or configuration descriptions,
  * be evaluated by Effect and yielded inside `Effect.gen`.
  *
@@ -8,7 +8,9 @@
  */
 import type * as Effect from "./Effect.ts"
 import type * as Fiber from "./Fiber.ts"
-import { evaluate, makePrimitiveProto } from "./internal/core.ts"
+import type * as Inspectable from "./Inspectable.ts"
+import { type EffectTypeId, evaluate, makePrimitiveProto } from "./internal/core.ts"
+import type * as Pipeable from "./Pipeable.ts"
 
 /**
  * Create a low-level `Effect` prototype.
@@ -24,6 +26,7 @@ import { evaluate, makePrimitiveProto } from "./internal/core.ts"
  * When the effect is evaluated, it calls `evaluate` with the current fiber.
  *
  * @see {@link Class} for a class-based approach to defining custom Effect values
+ * @see {@link Mixin} for wrapping an existing class constructor
  *
  * @category prototypes
  * @since 4.0.0
@@ -40,14 +43,16 @@ export const Prototype = <A extends Effect.Effect<any, any, any>>(options: {
     [evaluate]: options.evaluate
   }) as any
 
+const proto = Prototype({
+  label: "Effectable",
+  evaluate(_) {
+    return (this as any).override
+  }
+})
+
 const Base: new<A, E, R>() => Effect.Effect<A, E, R> = (() => {
   const Base = function() {}
-  Base.prototype = Prototype<Class<any, any, any>>({
-    label: "Effectable",
-    evaluate(_) {
-      return this.asEffect()
-    }
-  })
+  Base.prototype = proto
   return Base as any
 })()
 
@@ -60,9 +65,88 @@ const Base: new<A, E, R>() => Effect.Effect<A, E, R> = (() => {
  * as `Effect` values.
  *
  * @see {@link Prototype} for a lower-level primitive approach to creating custom Effect-like values without a class
+ * @see {@link Mixin} for wrapping an existing class constructor
  * @category constructors
  * @since 2.0.0
  */
 export abstract class Class<A, E = never, R = never> extends Base<A, E, R> {
   abstract asEffect(): Effect.Effect<A, E, R>
+}
+
+type OverrideEffect<Self> = Self extends {
+  override: infer Override extends Effect.Effect<any, any, any>
+} ? Override
+  : never
+
+interface EffectableFromOverride extends Pipeable.Pipeable, Inspectable.Inspectable {
+  readonly [EffectTypeId]: OverrideEffect<this>[typeof EffectTypeId]
+  [Symbol.iterator](): Effect.EffectIterator<OverrideEffect<this>>
+}
+
+/**
+ * Constructor type for classes whose instances behave as `Effect` values.
+ *
+ * **When to use**
+ *
+ * Use as the constructor-side type when a class value should be known to create
+ * instances that can be evaluated by Effect.
+ *
+ * @see {@link Class} for the base constructor
+ * @see {@link Mixin} for wrapping an existing class constructor
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type EffectableConstructor = abstract new(...args: ReadonlyArray<any>) => EffectableFromOverride
+
+/**
+ * Returns a subclass of the provided class that inserts the Effect prototype
+ * into the inheritance chain.
+ *
+ * **When to use**
+ *
+ * Use to make instances of an existing class behave as `Effect` values without
+ * extending {@link Class} or modifying the original prototype.
+ *
+ * **Details**
+ *
+ * Pass the class to wrap, then define the `override` Effect on the final class.
+ * The returned class is abstract, and the success, error, and service types are
+ * inferred from the concrete `override` property. The original constructor and
+ * instance members are preserved.
+ *
+ * **Example** (Evaluating a mixed-in class)
+ *
+ * ```ts import.meta.vitest
+ * import { Effect, Effectable } from "effect"
+ *
+ * class Box {
+ *   constructor(readonly value: number) {}
+ * }
+ *
+ * class EffectBox extends Effectable.Mixin(Box) {
+ *   override = Effect.succeed(this.value)
+ * }
+ *
+ * const box = new EffectBox(2)
+ * Effect.isEffect(box) // => true
+ * await Effect.runPromise(box) // => 2
+ * ```
+ *
+ * @see {@link Prototype} for a lower-level primitive approach to creating custom Effect-like values without a class
+ * @see {@link Class} for a base constructor to extend
+ * @category constructors
+ * @since 4.0.0
+ */
+export const Mixin = <TBase extends new(...args: ReadonlyArray<any>) => any>(
+  klass: TBase
+) => {
+  abstract class Mixed extends klass {
+    abstract override: Effect.Effect<any, any, any>
+  }
+  Object.setPrototypeOf(
+    Mixed.prototype,
+    Object.create(klass.prototype, Object.getOwnPropertyDescriptors(proto))
+  )
+  return Mixed as typeof Mixed & EffectableConstructor
 }

--- a/packages/effect/src/Effectable.ts
+++ b/packages/effect/src/Effectable.ts
@@ -8,9 +8,7 @@
  */
 import type * as Effect from "./Effect.ts"
 import type * as Fiber from "./Fiber.ts"
-import type * as Inspectable from "./Inspectable.ts"
 import { type EffectTypeId, evaluate, makePrimitiveProto } from "./internal/core.ts"
-import type * as Pipeable from "./Pipeable.ts"
 
 /**
  * Create a low-level `Effect` prototype.
@@ -78,9 +76,10 @@ type AsEffectReturn<Self> = Self extends {
 } ? A
   : never
 
-interface EffectableFromAsEffect extends Pipeable.Pipeable, Inspectable.Inspectable {
-  readonly [EffectTypeId]: AsEffectReturn<this>[typeof EffectTypeId]
-  [Symbol.iterator](): Effect.EffectIterator<AsEffectReturn<this>>
+declare abstract class MixinBase extends Class<any, any, any> {
+  constructor(...args: ReadonlyArray<any>)
+  override readonly [EffectTypeId]: AsEffectReturn<this>[typeof EffectTypeId]
+  override [Symbol.iterator](): Effect.EffectIterator<AsEffectReturn<this>>
 }
 
 /**
@@ -129,10 +128,10 @@ interface EffectableFromAsEffect extends Pipeable.Pipeable, Inspectable.Inspecta
  */
 export const Mixin = <TBase extends abstract new(...args: ReadonlyArray<any>) => object>(
   klass: TBase
-) => {
+): TBase & typeof MixinBase => {
   abstract class Mixed extends klass {
     abstract asEffect(): Effect.Effect<any, any, any>
   }
   Object.defineProperties(Mixed.prototype, Object.getOwnPropertyDescriptors(proto))
-  return Mixed as typeof Mixed & (abstract new(...args: ReadonlyArray<any>) => EffectableFromAsEffect)
+  return Mixed as TBase & typeof MixinBase
 }

--- a/packages/effect/src/Effectable.ts
+++ b/packages/effect/src/Effectable.ts
@@ -84,22 +84,6 @@ interface EffectableFromAsEffect extends Pipeable.Pipeable, Inspectable.Inspecta
 }
 
 /**
- * Constructor type for classes whose instances behave as `Effect` values.
- *
- * **When to use**
- *
- * Use as the constructor-side type when a class value should be known to create
- * instances that can be evaluated by Effect.
- *
- * @see {@link Class} for the base constructor
- * @see {@link Mixin} for wrapping an existing class constructor
- *
- * @category models
- * @since 4.0.0
- */
-export type EffectableConstructor = abstract new(...args: ReadonlyArray<any>) => EffectableFromAsEffect
-
-/**
  * Returns a subclass of the provided class that inserts the Effect prototype
  * into the inheritance chain.
  *
@@ -112,8 +96,11 @@ export type EffectableConstructor = abstract new(...args: ReadonlyArray<any>) =>
  *
  * Pass the class to wrap, then implement `asEffect` on the final class. The
  * returned class is abstract, and the success, error, and service types are
- * inferred from the concrete `asEffect` return type. The original constructor
- * and instance members are preserved.
+ * inferred from the concrete `asEffect` return type. Concrete and abstract base
+ * classes are supported. Constructor parameters and instance members are
+ * preserved, except that Effect's prototype members shadow base prototype
+ * members with the same name: `pipe`, `toString`, `toJSON`, `[Symbol.iterator]`,
+ * and `[Symbol.for("nodejs.util.inspect.custom")]`.
  *
  * **Example** (Evaluating a mixed-in class)
  *
@@ -140,15 +127,12 @@ export type EffectableConstructor = abstract new(...args: ReadonlyArray<any>) =>
  * @category constructors
  * @since 4.0.0
  */
-export const Mixin = <TBase extends new(...args: ReadonlyArray<any>) => any>(
+export const Mixin = <TBase extends abstract new(...args: ReadonlyArray<any>) => object>(
   klass: TBase
 ) => {
   abstract class Mixed extends klass {
     abstract asEffect(): Effect.Effect<any, any, any>
   }
-  Object.setPrototypeOf(
-    Mixed.prototype,
-    Object.create(klass.prototype, Object.getOwnPropertyDescriptors(proto))
-  )
-  return Mixed as typeof Mixed & EffectableConstructor
+  Object.defineProperties(Mixed.prototype, Object.getOwnPropertyDescriptors(proto))
+  return Mixed as typeof Mixed & (abstract new(...args: ReadonlyArray<any>) => EffectableFromAsEffect)
 }

--- a/packages/effect/test/Effectable.test.ts
+++ b/packages/effect/test/Effectable.test.ts
@@ -1,0 +1,55 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Effectable } from "effect"
+
+describe("Effectable", () => {
+  describe("Mixin", () => {
+    class Box {
+      constructor(readonly value: number) {}
+      double() {
+        return this.value * 2
+      }
+    }
+
+    class EffectBox extends Effectable.Mixin(Box) {
+      override = Effect.succeed(this.value)
+    }
+
+    it.effect("evaluates override", () =>
+      Effect.gen(function*() {
+        const effectValue = yield* new EffectBox(1)
+        assert.strictEqual(effectValue, 2)
+      }))
+
+    it("inserts the Effect prototype between the subclass and original class", () => {
+      const box = new EffectBox(1)
+      const protos: Array<object> = []
+      let current: object | null = Object.getPrototypeOf(box)
+      while (current !== null && current !== Box.prototype) {
+        protos.push(current)
+        current = Object.getPrototypeOf(current)
+      }
+      assert.strictEqual(current, Box.prototype)
+      assert.isTrue(protos.some((proto) => Effect.TypeId in proto))
+    })
+
+    it("preserves the original constructor and instance members", () => {
+      const box = new EffectBox(2)
+      assert.isTrue(box instanceof EffectBox)
+      assert.isTrue(box instanceof Box)
+      assert.strictEqual(box.constructor, EffectBox)
+      assert.strictEqual(box.value, 2)
+      assert.strictEqual(box.double(), 4)
+    })
+
+    it("makes instances behave as Effects", () => {
+      const box = new EffectBox(3)
+      assert.isTrue(Effect.isEffect(box))
+      assert.strictEqual(box.pipe((b) => b.value), 3)
+    })
+
+    it("does not modify the original class prototype", () => {
+      assert.isFalse(Effect.TypeId in Box.prototype)
+      assert.isFalse(Effect.isEffect(new Box(1)))
+    })
+  })
+})

--- a/packages/effect/test/Effectable.test.ts
+++ b/packages/effect/test/Effectable.test.ts
@@ -11,7 +11,7 @@ describe("Effectable", () => {
     }
 
     class EffectBox extends Effectable.Mixin(Box) {
-      override = Effect.succeed(this.value)
+      override override = Effect.succeed(this.value)
     }
 
     it.effect("evaluates override", () =>

--- a/packages/effect/test/Effectable.test.ts
+++ b/packages/effect/test/Effectable.test.ts
@@ -17,7 +17,7 @@ describe("Effectable", () => {
     it.effect("evaluates override", () =>
       Effect.gen(function*() {
         const effectValue = yield* new EffectBox(1)
-        assert.strictEqual(effectValue, 2)
+        assert.strictEqual(effectValue, 1)
       }))
 
     it("inserts the Effect prototype between the subclass and original class", () => {

--- a/packages/effect/test/Effectable.test.ts
+++ b/packages/effect/test/Effectable.test.ts
@@ -11,10 +11,12 @@ describe("Effectable", () => {
     }
 
     class EffectBox extends Effectable.Mixin(Box) {
-      override override = Effect.succeed(this.value)
+      override asEffect() {
+        return Effect.succeed(this.value)
+      }
     }
 
-    it.effect("evaluates override", () =>
+    it.effect("evaluates asEffect", () =>
       Effect.gen(function*() {
         const effectValue = yield* new EffectBox(1)
         assert.strictEqual(effectValue, 1)

--- a/packages/effect/test/Effectable.test.ts
+++ b/packages/effect/test/Effectable.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Effectable } from "effect"
+import { Context, Effect, Effectable, Exit } from "effect"
 
 describe("Effectable", () => {
   describe("Mixin", () => {
@@ -21,6 +21,52 @@ describe("Effectable", () => {
         const effectValue = yield* new EffectBox(1)
         assert.strictEqual(effectValue, 1)
       }))
+
+    it.effect("propagates failures", () =>
+      Effect.gen(function*() {
+        class FailingBox extends Effectable.Mixin(Box) {
+          override asEffect() {
+            return Effect.fail(this.value)
+          }
+        }
+
+        assert.deepStrictEqual(yield* Effect.exit(new FailingBox(1)), Exit.fail(1))
+      }))
+
+    it.effect("uses provided services", () =>
+      Effect.gen(function*() {
+        class Multiplier extends Context.Service<Multiplier, number>()("Multiplier") {}
+        class ServiceBox extends Effectable.Mixin(Box) {
+          override asEffect() {
+            return Effect.map(Multiplier, (multiplier) => this.value * multiplier)
+          }
+        }
+
+        const value = yield* new ServiceBox(2).pipe(Effect.provideService(Multiplier, 3))
+        assert.strictEqual(value, 6)
+      }))
+
+    it("shadows base prototype methods without modifying them", () => {
+      class PrintableBox extends Box {
+        override toString() {
+          return "Box"
+        }
+        toJSON(): unknown {
+          return { _id: "Box" }
+        }
+      }
+      class PrintableEffectBox extends Effectable.Mixin(PrintableBox) {
+        override asEffect() {
+          return Effect.succeed(this.value)
+        }
+      }
+
+      const box = new PrintableEffectBox(1)
+      assert.deepStrictEqual(box.toJSON(), { _id: "Effect", op: "Effectable" })
+      assert.deepStrictEqual(JSON.parse(box.toString()), box.toJSON())
+      assert.strictEqual(new PrintableBox(1).toString(), "Box")
+      assert.deepStrictEqual(new PrintableBox(1).toJSON(), { _id: "Box" })
+    })
 
     it("inserts the Effect prototype between the subclass and original class", () => {
       const box = new EffectBox(1)

--- a/packages/effect/typetest/Effectable.tst.ts
+++ b/packages/effect/typetest/Effectable.tst.ts
@@ -1,0 +1,38 @@
+import { Effect, Effectable } from "effect"
+import { describe, expect, it } from "tstyche"
+
+describe("Effectable.Mixin", () => {
+  class Box {
+    constructor(readonly value: number) {}
+  }
+
+  class EffectBox extends Effectable.Mixin(Box) {
+    override = Effect.succeed(this.value.toString())
+  }
+
+  class FullEffectBox extends Effectable.Mixin(Box) {
+    override = undefined as unknown as Effect.Effect<"success", "error", "service">
+  }
+
+  it("preserves constructor parameters", () => {
+    expect<ConstructorParameters<typeof EffectBox>>().type.toBe<[value: number]>()
+  })
+
+  it("instances are Effects of the override success type and original class instances", () => {
+    expect<Effect.Success<EffectBox>>().type.toBe<string>()
+    expect(new EffectBox(1)).type.toBeAssignableTo<Effect.Effect<string>>()
+    expect(new EffectBox(1)).type.toBeAssignableTo<Box>()
+  })
+
+  it("propagates success, error, and services through yield*", () => {
+    const effect = Effect.gen(function*() {
+      return yield* new FullEffectBox(1)
+    })
+    expect(effect).type.toBe<Effect.Effect<"success", "error", "service">>()
+  })
+
+  it("requires override", () => {
+    // @ts-expect-error does not implement inherited abstract member override
+    class MissingOverride extends Effectable.Mixin(Box) {}
+  })
+})

--- a/packages/effect/typetest/Effectable.tst.ts
+++ b/packages/effect/typetest/Effectable.tst.ts
@@ -7,11 +7,11 @@ describe("Effectable.Mixin", () => {
   }
 
   class EffectBox extends Effectable.Mixin(Box) {
-    override = Effect.succeed(this.value.toString())
+    override override = Effect.succeed(this.value.toString())
   }
 
   class FullEffectBox extends Effectable.Mixin(Box) {
-    override = undefined as unknown as Effect.Effect<"success", "error", "service">
+    override override = undefined as unknown as Effect.Effect<"success", "error", "service">
   }
 
   it("preserves constructor parameters", () => {

--- a/packages/effect/typetest/Effectable.tst.ts
+++ b/packages/effect/typetest/Effectable.tst.ts
@@ -22,6 +22,36 @@ describe("Effectable.Mixin", () => {
     expect<ConstructorParameters<typeof EffectBox>>().type.toBe<[value: number]>()
   })
 
+  it("rejects unknown properties", () => {
+    expect(new EffectBox(1)).type.not.toHaveProperty("typo")
+  })
+
+  it("supports abstract base classes", () => {
+    abstract class AbstractBox {
+      constructor(readonly value: number) {}
+      abstract double(): number
+    }
+
+    class ConcreteBox extends Effectable.Mixin(AbstractBox) {
+      double() {
+        return this.value * 2
+      }
+      override asEffect() {
+        return Effect.succeed(this.double())
+      }
+    }
+
+    expect<ConstructorParameters<typeof ConcreteBox>>().type.toBe<[value: number]>()
+    expect(new ConcreteBox(1)).type.toBeAssignableTo<AbstractBox>()
+    expect(new ConcreteBox(1)).type.toBeAssignableTo<Effect.Effect<number>>()
+    // @ts-expect-error does not implement inherited abstract member double
+    class MissingDouble extends Effectable.Mixin(AbstractBox) {
+      override asEffect() {
+        return Effect.succeed(this.value)
+      }
+    }
+  })
+
   it("instances are Effects of the asEffect success type and original class instances", () => {
     expect<Effect.Success<EffectBox>>().type.toBe<string>()
     expect(new EffectBox(1)).type.toBeAssignableTo<Effect.Effect<string>>()

--- a/packages/effect/typetest/Effectable.tst.ts
+++ b/packages/effect/typetest/Effectable.tst.ts
@@ -7,18 +7,22 @@ describe("Effectable.Mixin", () => {
   }
 
   class EffectBox extends Effectable.Mixin(Box) {
-    override override = Effect.succeed(this.value.toString())
+    override asEffect() {
+      return Effect.succeed(this.value.toString())
+    }
   }
 
   class FullEffectBox extends Effectable.Mixin(Box) {
-    override override = undefined as unknown as Effect.Effect<"success", "error", "service">
+    override asEffect() {
+      return undefined as unknown as Effect.Effect<"success", "error", "service">
+    }
   }
 
   it("preserves constructor parameters", () => {
     expect<ConstructorParameters<typeof EffectBox>>().type.toBe<[value: number]>()
   })
 
-  it("instances are Effects of the override success type and original class instances", () => {
+  it("instances are Effects of the asEffect success type and original class instances", () => {
     expect<Effect.Success<EffectBox>>().type.toBe<string>()
     expect(new EffectBox(1)).type.toBeAssignableTo<Effect.Effect<string>>()
     expect(new EffectBox(1)).type.toBeAssignableTo<Box>()
@@ -31,8 +35,8 @@ describe("Effectable.Mixin", () => {
     expect(effect).type.toBe<Effect.Effect<"success", "error", "service">>()
   })
 
-  it("requires override", () => {
-    // @ts-expect-error does not implement inherited abstract member override
-    class MissingOverride extends Effectable.Mixin(Box) {}
+  it("requires asEffect", () => {
+    // @ts-expect-error does not implement inherited abstract member asEffect
+    class MissingAsEffect extends Effectable.Mixin(Box) {}
   })
 })


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds `Effectable.Mixin` to extend an existing concrete or abstract class with Effect behavior. Implement `asEffect()` on the subclass; its return type determines the success, error, and service types.

```ts
import { Effect, Effectable } from "effect"

class Box {
  constructor(readonly value: number) {}
  double() {
    return this.value * 2
  }
}

class EffectBox extends Effectable.Mixin(Box) {
  override asEffect() {
    return Effect.succeed(this.value)
  }
}

const program = Effect.gen(function*() {
  const effectValue = yield* new EffectBox(1)
  //    ^? number
  return effectValue
})
```

Constructor parameters and base members are preserved. Effect's prototype methods shadow matching base prototype methods, including `pipe`, `toString`, `toJSON`, the iterator, and Node's inspect method.

## Validation

Effectable runtime tests, type tests (TypeScript 5.9 and 6.0), doctest, full typecheck, and lint pass. The JSDoc check reports existing errors in the unchanged `Multipart.ts` and `ChildProcess.ts` files.

## Related

[Discord question](https://discord.com/channels/795981131316985866/1544760617255313438)

Closes EFF-1299
