### PR TITLE
fix(Tokenizer): measure complete candidate prompts when truncating

### DIFF
--- a/.changeset/tokenizer-whole-prompt-truncation.md
+++ b/.changeset/tokenizer-whole-prompt-truncation.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Tokenizer.truncate` to account for token costs between messages.

--- a/packages/effect/src/unstable/ai/Tokenizer.ts
+++ b/packages/effect/src/unstable/ai/Tokenizer.ts
@@ -165,7 +165,6 @@ const truncate = (
   maxTokens: number
 ): Effect.Effect<Prompt.Prompt, AiError.AiError> =>
   Effect.suspend(() => {
-    let count = 0
     let inputMessages = self.content
     let outputMessages: Array<Prompt.Message> = []
     const loop: Effect.Effect<Prompt.Prompt, AiError.AiError> = Effect.suspend(() => {
@@ -174,12 +173,12 @@ const truncate = (
         return Effect.succeed(Prompt.fromMessages(outputMessages))
       }
       inputMessages = inputMessages.slice(0, inputMessages.length - 1)
-      return Effect.flatMap(tokenize(Prompt.fromMessages([message])), (tokens) => {
-        count += tokens.length
-        if (count > maxTokens) {
+      const candidate = [message, ...outputMessages]
+      return Effect.flatMap(tokenize(Prompt.fromMessages(candidate)), (tokens) => {
+        if (tokens.length > maxTokens) {
           return Effect.succeed(Prompt.fromMessages(outputMessages))
         }
-        outputMessages = [message, ...outputMessages]
+        outputMessages = candidate
         return loop
       })
     })

--- a/packages/effect/test/unstable/ai/Tokenizer.test.ts
+++ b/packages/effect/test/unstable/ai/Tokenizer.test.ts
@@ -1,0 +1,24 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import { Prompt, Tokenizer } from "effect/unstable/ai"
+
+describe("Tokenizer", () => {
+  it.effect("truncate accounts for costs between messages", () =>
+    Effect.gen(function*() {
+      const tokenizer = Tokenizer.make({
+        tokenize: (prompt) =>
+          Effect.succeed(
+            Array.from({ length: Math.max(0, prompt.content.length * 2 - 1) }, (_, index) => index)
+          )
+      })
+      const input = Prompt.make([
+        { role: "user", content: "a" },
+        { role: "assistant", content: "b" }
+      ])
+
+      const output = yield* tokenizer.truncate(input, 2)
+
+      assert.deepStrictEqual(output.content, [input.content[1]])
+      assert.isAtMost((yield* tokenizer.tokenize(output)).length, 2)
+    }))
+})


### PR DESCRIPTION
## Why

`Tokenizer.truncate` sums token counts from isolated messages, but tokenizers receive complete prompts. Costs between messages can therefore make the returned prompt exceed its token limit.

## What changed

Each candidate suffix is now tokenized as a complete prompt before it is accepted. A focused regression test covers a two-message prompt whose individual messages fit but whose combined cost does not.

## Verification

- `pnpm test --run packages/effect/test/unstable/ai/Tokenizer.test.ts --maxWorkers=1 --no-file-parallelism`
- `pnpm lint-fix`
- `pnpm check`
- `git diff --check`

Closes #7911
Closes EFF-1160

## Audit

Runtime correctness audit; intended label: `audit`.
