### PR TITLE
Fix HTTP Router prefix order when nested

### DIFF
--- a/.changeset/shaky-terms-push.md
+++ b/.changeset/shaky-terms-push.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix HttpRouter nested prefixed application order

--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -167,7 +167,7 @@ export const make = Effect.gen(function*() {
       prefix = removeTrailingSlash(prefix as PathInput)
       return HttpRouter.of({
         ...this,
-        prefixed: (newPrefix: string) => this.prefixed(prefixPath(prefix, newPrefix)),
+        prefixed: (newPrefix: string) => this.prefixed(prefixPath(newPrefix, prefix)),
         addAll: (routes) => addAll(routes.map(prefixRoute(prefix))) as any,
         add: (method, path, handler, options) =>
           addAll([

--- a/packages/effect/test/unstable/http/HttpRouter.test.ts
+++ b/packages/effect/test/unstable/http/HttpRouter.test.ts
@@ -2,6 +2,25 @@ import { assert, describe, it } from "@effect/vitest"
 import { Effect, Layer, Option } from "effect"
 import { HttpRouter, type HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 
+const echoUrl = (request: HttpServerRequest.HttpServerRequest) => Effect.succeed(HttpServerResponse.text(request.url))
+
+const layerPrefixed = (prefix: string) =>
+  Layer.effect(
+    HttpRouter.HttpRouter,
+    Effect.map(HttpRouter.HttpRouter, (router) => router.prefixed(prefix))
+  )
+
+const fetchText = (app: Layer.Layer<never, never, HttpRouter.HttpRouter>, path: string) =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => HttpRouter.toWebHandler(app, { disableLogger: true })),
+    ({ handler }) =>
+      Effect.promise(async () => {
+        const response = await handler(new Request(`http://localhost${path}`))
+        return await response.text()
+      }),
+    ({ dispose }) => Effect.promise(dispose)
+  )
+
 describe("HttpRouter", () => {
   it("normalizes the prefix stored by prefixRoute", () => {
     const route = HttpRouter.prefixRoute(
@@ -37,23 +56,34 @@ describe("HttpRouter", () => {
   ) {
     it.effect(`preserves the local URL for the ${prefix} prefix`, () =>
       Effect.gen(function*() {
-        const routes = HttpRouter.use((router) =>
-          router.prefixed(prefix).add("GET", "/users", (request: HttpServerRequest.HttpServerRequest) =>
-            Effect.succeed(HttpServerResponse.text(request.url)))
-        )
-        const body = yield* Effect.acquireUseRelease(
-          Effect.sync(() =>
-            HttpRouter.toWebHandler(routes, { disableLogger: true })
-          ),
-          ({ handler }) =>
-            Effect.flatMap(
-              Effect.promise(() => handler(new Request(`http://localhost${requestUrl}`))),
-              (response) => Effect.promise(() => response.text())
-            ),
-          ({ dispose }) => Effect.promise(dispose)
-        )
+        const routes = HttpRouter.use((router) => router.prefixed(prefix).add("GET", "/users", echoUrl))
+
+        const body = yield* fetchText(routes, requestUrl)
 
         assert.strictEqual(body, "/users")
       }))
   }
+
+  it.effect("nests a prefixed sub-router beneath a prefixed parent router", () =>
+    Effect.gen(function*() {
+      const routes = HttpRouter.use((router) => router.prefixed("/app").add("GET", "/users", echoUrl)).pipe(
+        Layer.provide(layerPrefixed("/api"))
+      )
+
+      const body = yield* fetchText(routes, "/api/app/users")
+
+      assert.strictEqual(body, "/users")
+    }))
+
+  it.effect("nests a prefixRoute prefix beneath a prefixed parent router", () =>
+    Effect.gen(function*() {
+      const users = HttpRouter.prefixRoute(HttpRouter.route("GET", "/users", echoUrl), "/app")
+      const routes = HttpRouter.use((router) => router.addAll([users])).pipe(
+        Layer.provide(layerPrefixed("/api"))
+      )
+
+      const body = yield* fetchText(routes, "/api/app/users")
+
+      assert.strictEqual(body, "/users")
+    }))
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Nested `.prefixed` in HttpRouter currently applies paths in wrong order. From child route's point of view, parent router's prefix is the prefix.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
