### PR TITLE
fix(Scope): retain cleanup after finalizer callback defects

### DIFF
--- a/.changeset/scope-finalizer-callback-defects.md
+++ b/.changeset/scope-finalizer-callback-defects.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Scope` finalization so all registered finalizers run when a finalizer callback throws.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -3913,10 +3913,11 @@ const scopeCloseFinalizers = fnUntraced(function*<A, E>(
   const parent = getCurrentFiber()!
   for (let i = arr.length - 1; i >= 0; i--) {
     const finalizer = arr[i]
+    const finalizerEffect = suspend(() => finalizer(exit_))
     if (self.strategy === "sequential") {
-      exits.push(yield* exit(finalizer(exit_)))
+      exits.push(yield* exit(finalizerEffect))
     } else {
-      fibers.push(forkUnsafe(parent, finalizer(exit_), true, true, "inherit"))
+      fibers.push(forkUnsafe(parent, finalizerEffect, true, true, "inherit"))
     }
   }
   if (fibers.length > 0) {

--- a/packages/effect/test/Scope.test.ts
+++ b/packages/effect/test/Scope.test.ts
@@ -3,24 +3,31 @@ import { Duration, Effect, Exit, Scope } from "effect"
 import { TestClock } from "effect/testing"
 
 describe("Scope", () => {
-  for (const strategy of ["sequential", "parallel"] as const) {
-    it.effect(`runs remaining ${strategy} finalizers when a finalizer callback throws`, () =>
-      Effect.gen(function*() {
-        const scope = yield* Scope.make(strategy)
-        const finalized: Array<string> = []
-        const defect = new Error("boom")
-        yield* Scope.addFinalizer(scope, Effect.sync(() => finalized.push("remaining")))
-        yield* Scope.addFinalizerExit(scope, () => {
-          finalized.push("throwing")
-          throw defect
-        })
+  describe("finalizer defects", () => {
+    for (const strategy of ["sequential", "parallel"] as const) {
+      it.effect(`runs remaining ${strategy} finalizers when a finalizer callback throws`, () =>
+        Effect.gen(function*() {
+          const scope = yield* Scope.make(strategy)
+          const finalized: Array<string> = []
+          const defect = new Error("boom")
+          yield* Scope.addFinalizer(scope, Effect.sync(() => finalized.push("remaining-1")))
+          yield* Scope.addFinalizerExit(scope, () => {
+            finalized.push("throwing")
+            throw defect
+          })
+          yield* Scope.addFinalizer(scope, Effect.sync(() => finalized.push("remaining-2")))
 
-        const closeExit = yield* Effect.exit(Scope.close(scope, Exit.void))
+          const closeExit = yield* Effect.exit(Scope.close(scope, Exit.void))
 
-        expect(closeExit).toEqual(Exit.die(defect))
-        expect([...finalized].sort()).toEqual(["remaining", "throwing"])
-      }))
-  }
+          expect(closeExit).toEqual(Exit.die(defect))
+          if (strategy === "sequential") {
+            expect(finalized).toEqual(["remaining-2", "throwing", "remaining-1"])
+          } else {
+            expect(finalized.sort()).toEqual(["remaining-1", "remaining-2", "throwing"])
+          }
+        }))
+    }
+  })
 
   describe("parallel finalization", () => {
     it.effect("executes finalizers in parallel", () =>

--- a/packages/effect/test/Scope.test.ts
+++ b/packages/effect/test/Scope.test.ts
@@ -3,6 +3,25 @@ import { Duration, Effect, Exit, Scope } from "effect"
 import { TestClock } from "effect/testing"
 
 describe("Scope", () => {
+  for (const strategy of ["sequential", "parallel"] as const) {
+    it.effect(`runs remaining ${strategy} finalizers when a finalizer callback throws`, () =>
+      Effect.gen(function*() {
+        const scope = yield* Scope.make(strategy)
+        const finalized: Array<string> = []
+        const defect = new Error("boom")
+        yield* Scope.addFinalizer(scope, Effect.sync(() => finalized.push("remaining")))
+        yield* Scope.addFinalizerExit(scope, () => {
+          finalized.push("throwing")
+          throw defect
+        })
+
+        const closeExit = yield* Effect.exit(Scope.close(scope, Exit.void))
+
+        expect(closeExit).toEqual(Exit.die(defect))
+        expect([...finalized].sort()).toEqual(["remaining", "throwing"])
+      }))
+  }
+
   describe("parallel finalization", () => {
     it.effect("executes finalizers in parallel", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Summary

A synchronous throw from an exit-aware finalizer callback stopped `Scope` from reaching the remaining finalizers. Callback invocation is now suspended so the existing finalization machinery records the defect and continues cleanup.

Regression coverage exercises both sequential and parallel scopes through the public `Scope` API. It also verifies that closing the scope still reports the original defect.

## Verification

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/effect/test/Scope.test.ts`
- `nix develop -c pnpm check`

Closes #7916
Closes EFF-1166
