### PR TITLE
Add OtlpTracer runtime performance guard

### DIFF
--- a/packages/effect/runtimeperf/README.md
+++ b/packages/effect/runtimeperf/README.md
@@ -5,6 +5,7 @@ processes. It supports:
 
 - focused Effect Schema diagnostics;
 - native Arbitrary comparisons against equivalent fast-check v4 arbitraries;
+- OTLP tracer span creation and batched JSON export;
 - the upstream Effect, Valibot and Zod benchmark matrix;
 - paired comparisons between Git revisions or the current working tree.
 
@@ -38,6 +39,7 @@ Select a suite, fixture, shared scenario, tier, family or implementation:
 ```sh
 pnpm runtimeperf schema
 pnpm runtimeperf arbitrary
+pnpm runtimeperf otlp-tracer
 pnpm runtimeperf object-32-valid
 pnpm runtimeperf schema/object-32-valid-effect
 pnpm runtimeperf --family arrays
@@ -85,6 +87,10 @@ template literals, unions, records, transformations, optional properties,
 adapters, recursion and cold paths. The `schema-benchmarks` suite contains the
 complete timing matrices exposed by the upstream Effect, Valibot and Zod
 adapters.
+
+The `otlp-tracer` suite measures the public tracer seam without network I/O. It
+covers the create-and-end cost of an unsampled span and a sampled batch of 100
+spans through JSON serialization and a successful local HTTP client boundary.
 
 The `arbitrary` suite compares the native public API with direct fast-check v4 arbitraries in separate processes. It
 measures derivation through the first recursive sample, steady-state recursive

--- a/packages/effect/runtimeperf/config.json
+++ b/packages/effect/runtimeperf/config.json
@@ -1296,6 +1296,37 @@
       ]
     },
     {
+      "name": "otlp-tracer",
+      "fixtures": [
+        {
+          "file": "suites/otlp-tracer/fixtures/tracer.ts",
+          "defaults": {
+            "tier": 1,
+            "implementation": "effect",
+            "family": "observability",
+            "astTags": [],
+            "path": "hot"
+          },
+          "cases": [
+            {
+              "name": "unsampled-span",
+              "export": "unsampledSpan",
+              "scenario": "otlp-tracer-unsampled-span",
+              "operation": "create-and-end",
+              "size": 1
+            },
+            {
+              "name": "sampled-span-batch-100",
+              "export": "sampledSpanBatch",
+              "scenario": "otlp-tracer-sampled-span-batch-100",
+              "operation": "create-end-serialize-and-export",
+              "size": 100
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "schema-benchmarks",
       "fixtures": [
         {

--- a/packages/effect/runtimeperf/suites/otlp-tracer/fixtures/tracer.ts
+++ b/packages/effect/runtimeperf/suites/otlp-tracer/fixtures/tracer.ts
@@ -1,0 +1,93 @@
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
+import * as Option from "effect/Option"
+import type * as Tracer from "effect/Tracer"
+import * as HttpBody from "effect/unstable/http/HttpBody"
+import * as HttpClient from "effect/unstable/http/HttpClient"
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse"
+import * as OtlpExporter from "effect/unstable/observability/OtlpExporter"
+import * as OtlpSerialization from "effect/unstable/observability/OtlpSerialization"
+import * as OtlpTracer from "effect/unstable/observability/OtlpTracer"
+import assert from "node:assert/strict"
+
+const makeTracer = (onTraces: (data: OtlpTracer.TraceData) => void) => {
+  let exportEffect: Effect.Effect<void> = Effect.void
+  const httpClient = HttpClient.make((request) => Effect.succeed(HttpClientResponse.fromWeb(request, new Response())))
+  const tracer = Effect.runSync(
+    Effect.scoped(
+      OtlpTracer.make({
+        url: "http://localhost:4318/v1/traces",
+        resource: { serviceName: "runtimeperf" },
+        exportInterval: "1 day",
+        maxBatchSize: 101
+      }).pipe(
+        Effect.provideService(HttpClient.HttpClient, httpClient),
+        Effect.provideService(OtlpSerialization.OtlpSerialization, {
+          traces: (data) => {
+            onTraces(data)
+            return HttpBody.jsonUnsafe(data)
+          },
+          metrics: () => HttpBody.empty,
+          logs: () => HttpBody.empty
+        }),
+        Effect.provideService(OtlpExporter.Flusher, {
+          flush: Effect.suspend(() => exportEffect),
+          register: (effect) =>
+            Effect.sync(() => {
+              exportEffect = effect
+            })
+        })
+      )
+    )
+  )
+  return {
+    flush: () => Effect.runSync(exportEffect),
+    tracer
+  }
+}
+
+const spanOptions = {
+  name: "runtimeperf-span",
+  parent: Option.none<Tracer.AnySpan>(),
+  annotations: Context.empty(),
+  links: [] as Array<Tracer.SpanLink>,
+  startTime: BigInt(1),
+  kind: "internal" as const,
+  sampled: true
+}
+
+export const unsampledSpan = () => {
+  const { tracer } = makeTracer(() => {})
+  const options = { ...spanOptions, sampled: false }
+  return {
+    run: () => {
+      const span = tracer.span(options)
+      span.end(BigInt(2), Exit.void)
+      return span
+    },
+    validate: (span: Tracer.Span) => {
+      assert.equal(span.sampled, false)
+      assert.equal(span.status._tag, "Ended")
+    }
+  }
+}
+
+export const sampledSpanBatch = () => {
+  let exportedSpans = 0
+  const { flush, tracer } = makeTracer((data) => {
+    exportedSpans = data.resourceSpans[0]?.scopeSpans[0]?.spans.length ?? 0
+  })
+  return {
+    run: () => {
+      for (let index = 0; index < 100; index++) {
+        tracer.span(spanOptions).end(BigInt(2), Exit.void)
+      }
+      flush()
+      return exportedSpans
+    },
+    validate: (count: number) => {
+      assert.equal(count, 100)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add paired runtime-performance fixtures for unsampled OTLP span creation and sampled 100-span JSON export
- register and document the focused `otlp-tracer` suite
- leave `OtlpTracer` source unchanged so this PR establishes the guard before optimization

The initial profile measured about 231 ns per unsampled OTLP span and 82 microseconds per sampled 100-span export batch on this host. V8 attributed 28.6% of samples to GC, with `makeOtlpSpan`, object copying, eager maps, and eager identifier generation on the hot path.

## Validation

- `nix develop -c pnpm lint-fix`
- `nix develop -c node --test packages/effect/runtimeperf/test/registry.test.mts`
- `nix develop -c pnpm check`
- `nix develop -c pnpm runtimeperf otlp-tracer --rounds 3 --time 100 --warmup-time 50`
- `nix develop -c pnpm runtimeperf-compare otlp-tracer --rounds 5 --time 200 --warmup-time 75 --fail-on-regression`

Closes EFF-1157
