### PR TITLE
feat(http): reduce web handler cold start on Cloudflare

### DIFF
--- a/.changeset/http-web-handler-cold-start.md
+++ b/.changeset/http-web-handler-cold-start.md
@@ -1,0 +1,8 @@
+---
+"effect": patch
+---
+
+Reduce cold start cost of `HttpRouter` and `HttpEffect` web handlers.
+
+- `HttpServerRespondable` no longer imports `Schema` to detect schema errors, which removes the Schema modules from bundles that do not otherwise use them (about 23% of a minimal `HttpRouter` bundle).
+- `HttpRouter.toWebHandler`, `HttpEffect.toWebHandlerLayer` and `HttpEffect.toWebHandlerLayerWith` accept an `eager` option that builds the layer immediately instead of on the first request. It defaults to `false`.

--- a/.changeset/http-web-handler-cold-start.md
+++ b/.changeset/http-web-handler-cold-start.md
@@ -5,4 +5,5 @@
 Reduce cold start cost of `HttpRouter` and `HttpEffect` web handlers.
 
 - `HttpServerRespondable` no longer imports `Schema` to detect schema errors, which removes the Schema modules from bundles that do not otherwise use them (about 23% of a minimal `HttpRouter` bundle).
-- `HttpRouter.toWebHandler`, `HttpEffect.toWebHandlerLayer` and `HttpEffect.toWebHandlerLayerWith` accept an `eager` option that builds the layer immediately instead of on the first request. It defaults to `false`.
+- `HttpRouter.toWebHandler`, `HttpEffect.toWebHandlerLayer` and `HttpEffect.toWebHandlerLayerWith` now build the layer immediately instead of on the first request. A failed build never surfaces as an unhandled rejection; every request rejects with the build error instead.
+- The default scheduler falls back to a microtask when setting a timer throws, so effects that yield while running in the global scope of a Cloudflare Worker no longer fail.

--- a/.changeset/http-web-handler-cold-start.md
+++ b/.changeset/http-web-handler-cold-start.md
@@ -6,4 +6,3 @@ Reduce cold start cost of `HttpRouter` and `HttpEffect` web handlers.
 
 - `HttpServerRespondable` no longer imports `Schema` to detect schema errors, which removes the Schema modules from bundles that do not otherwise use them (about 23% of a minimal `HttpRouter` bundle).
 - `HttpRouter.toWebHandler`, `HttpEffect.toWebHandlerLayer` and `HttpEffect.toWebHandlerLayerWith` now build the layer immediately instead of on the first request. A failed build never surfaces as an unhandled rejection; every request rejects with the build error instead.
-- The default scheduler falls back to a microtask when setting a timer throws, so effects that yield while running in the global scope of a Cloudflare Worker no longer fail.

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -80,16 +80,26 @@ export const Scheduler: Context.Reference<Scheduler> = Context.Reference<Schedul
   defaultValue: () => new MixedScheduler()
 })
 
+// Some runtimes (e.g. Cloudflare Workers) throw when a timer is set in global
+// scope. Fall back to a microtask so effects can still run at module load.
 const setImmediate = "setImmediate" in globalThis
   ? (f: () => void) => {
-    // @ts-ignore
-    const timer = globalThis.setImmediate(f)
-    // @ts-ignore
-    return (): void => globalThis.clearImmediate(timer)
+    try {
+      // @ts-ignore
+      const timer = globalThis.setImmediate(f)
+      // @ts-ignore
+      return (): void => globalThis.clearImmediate(timer)
+    } catch {
+      return setMicrotask(f)
+    }
   }
   : (f: () => void) => {
-    const timer = setTimeout(f, 0)
-    return (): void => clearTimeout(timer)
+    try {
+      const timer = setTimeout(f, 0)
+      return (): void => clearTimeout(timer)
+    } catch {
+      return setMicrotask(f)
+    }
   }
 
 const setMicrotask = (f: () => void) => {

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -80,26 +80,16 @@ export const Scheduler: Context.Reference<Scheduler> = Context.Reference<Schedul
   defaultValue: () => new MixedScheduler()
 })
 
-// Some runtimes (e.g. Cloudflare Workers) throw when a timer is set in global
-// scope. Fall back to a microtask so effects can still run at module load.
 const setImmediate = "setImmediate" in globalThis
   ? (f: () => void) => {
-    try {
-      // @ts-ignore
-      const timer = globalThis.setImmediate(f)
-      // @ts-ignore
-      return (): void => globalThis.clearImmediate(timer)
-    } catch {
-      return setMicrotask(f)
-    }
+    // @ts-ignore
+    const timer = globalThis.setImmediate(f)
+    // @ts-ignore
+    return (): void => globalThis.clearImmediate(timer)
   }
   : (f: () => void) => {
-    try {
-      const timer = setTimeout(f, 0)
-      return (): void => clearTimeout(timer)
-    } catch {
-      return setMicrotask(f)
-    }
+    const timer = setTimeout(f, 0)
+    return (): void => clearTimeout(timer)
   }
 
 const setMicrotask = (f: () => void) => {

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -48,6 +48,7 @@ import * as InternalToFormatter from "./internal/schema/toFormatter.ts"
 import * as InternalToIso from "./internal/schema/toIso.ts"
 import * as InternalToJsonSchemaDocument from "./internal/schema/toJsonSchemaDocument.ts"
 import * as InternalToRepresentation from "./internal/schema/toRepresentation.ts"
+import { isSchemaError as isSchemaErrorInternal, SchemaErrorTypeId } from "./internal/schemaError.ts"
 import { getStackTraceLimit, setStackTraceLimit } from "./internal/stackTraceLimit.ts"
 import type * as JsonPatch from "./JsonPatch.ts"
 import type * as JsonSchema from "./JsonSchema.ts"
@@ -1125,7 +1126,6 @@ export interface Optic<out T, out Iso> extends Schema<T> {
   readonly "EncodingServices": never
   readonly "Rebuild": Optic<T, Iso>
 }
-const SchemaErrorTypeId = "~effect/Schema/SchemaError"
 /**
  * Error thrown or returned when schema decoding or encoding fails.
  *
@@ -1197,7 +1197,7 @@ export class SchemaError extends Data.TaggedError("SchemaError")<{
  * @since 4.0.0
  */
 export function isSchemaError(u: unknown): u is SchemaError {
-  return Predicate.hasProperty(u, SchemaErrorTypeId) && u[SchemaErrorTypeId] === SchemaErrorTypeId
+  return isSchemaErrorInternal(u)
 }
 
 function fromIssueEffect<A, R>(

--- a/packages/effect/src/internal/schemaError.ts
+++ b/packages/effect/src/internal/schemaError.ts
@@ -1,0 +1,8 @@
+import * as Predicate from "../Predicate.ts"
+import type { SchemaError } from "../Schema.ts"
+
+export const SchemaErrorTypeId = "~effect/Schema/SchemaError"
+
+export function isSchemaError(u: unknown): u is SchemaError {
+  return Predicate.hasProperty(u, SchemaErrorTypeId) && u[SchemaErrorTypeId] === SchemaErrorTypeId
+}

--- a/packages/effect/src/unstable/http/HttpEffect.ts
+++ b/packages/effect/src/unstable/http/HttpEffect.ts
@@ -336,6 +336,12 @@ export const toWebHandler: <E>(
 /**
  * Builds a Web `Request` handler from a layer and handler factory, returning the handler with a `dispose` function for the layer scope.
  *
+ * **Details**
+ *
+ * The layer is built immediately, so the cost is paid when the handler is
+ * created rather than on the first request. If the build fails, every request
+ * rejects with the build error.
+ *
  * @category converting
  * @since 4.0.0
  */
@@ -353,16 +359,6 @@ export const toWebHandlerLayerWith = <
     ) => Effect.Effect<Effect.Effect<HttpServerResponse, E, R>, LE>
     readonly middleware?: HttpMiddleware | undefined
     readonly memoMap?: Layer.MemoMap | undefined
-    /**
-     * Build the layer immediately instead of on the first request.
-     *
-     * Useful on platforms that evaluate the module before the first request
-     * arrives (e.g. Cloudflare Workers), so the layer cost is paid at startup
-     * rather than on the request path.
-     *
-     * Defaults to `false`.
-     */
-    readonly eager?: boolean | undefined
   }
 ): {
   readonly dispose: () => Promise<void>
@@ -381,19 +377,18 @@ export const toWebHandlerLayerWith = <
   let handlerCache:
     | ((request: Request, context?: Context.Context<ReqR> | undefined) => Promise<globalThis.Response>)
     | undefined
-  let handlerPromise:
-    | Promise<(request: Request, context?: Context.Context<ReqR> | undefined) => Promise<globalThis.Response>>
-    | undefined
-  const build = () =>
-    handlerPromise ??= Effect.runPromise(Effect.gen(function*() {
-      const context = yield* (options.memoMap
-        ? Layer.buildWithMemoMap(layer, options.memoMap, scope)
-        : Layer.buildWithScope(layer, scope))
-      return handlerCache = toWebHandlerWith<Provided, R>(context)(
-        yield* options.toHandler(context),
-        options.middleware
-      ) as any
-    }))
+  const handlerPromise = Effect.runPromise(Effect.gen(function*() {
+    const context = yield* (options.memoMap
+      ? Layer.buildWithMemoMap(layer, options.memoMap, scope)
+      : Layer.buildWithScope(layer, scope))
+    return handlerCache = toWebHandlerWith<Provided, R>(context)(
+      yield* options.toHandler(context),
+      options.middleware
+    ) as any
+  }))
+  // A failed build must not become an unhandled rejection at startup. Every
+  // request still rejects with the build error below.
+  handlerPromise.catch(constVoid)
   function handler(
     request: Request,
     context?: Context.Context<ReqR> | undefined
@@ -401,18 +396,19 @@ export const toWebHandlerLayerWith = <
     if (handlerCache) {
       return handlerCache(request, context)
     }
-    return build().then((f) => f(request, context))
-  }
-  if (options.eager === true) {
-    // Failures are still surfaced by each request, so avoid an unhandled
-    // rejection at startup.
-    build().catch(constVoid)
+    return handlerPromise.then((f) => f(request, context))
   }
   return { dispose, handler: handler as any } as const
 }
 
 /**
  * Builds a Web `Request` handler for an HTTP server effect using a layer to provide its services, returning the handler with a `dispose` function.
+ *
+ * **Details**
+ *
+ * The layer is built immediately, so the cost is paid when the handler is
+ * created rather than on the first request. If the build fails, every request
+ * rejects with the build error.
  *
  * @category converting
  * @since 4.0.0
@@ -423,12 +419,6 @@ export const toWebHandlerLayer = <E, R, Provided, LE, ReqR = Exclude<R, Provided
   options?: {
     readonly middleware?: HttpMiddleware | undefined
     readonly memoMap?: Layer.MemoMap | undefined
-    /**
-     * Build the layer immediately instead of on the first request.
-     *
-     * Defaults to `false`.
-     */
-    readonly eager?: boolean | undefined
   } | undefined
 ): {
   readonly dispose: () => Promise<void>

--- a/packages/effect/src/unstable/http/HttpEffect.ts
+++ b/packages/effect/src/unstable/http/HttpEffect.ts
@@ -339,8 +339,10 @@ export const toWebHandler: <E>(
  * **Details**
  *
  * The layer is built immediately, so the cost is paid when the handler is
- * created rather than on the first request. If the build fails, every request
- * rejects with the build error.
+ * created rather than on the first request. A layer that performs asynchronous
+ * work while building may still be in progress when the first request arrives,
+ * in which case that request waits for the build to finish. If the build fails,
+ * every request rejects with the build error.
  *
  * @category converting
  * @since 4.0.0
@@ -407,8 +409,10 @@ export const toWebHandlerLayerWith = <
  * **Details**
  *
  * The layer is built immediately, so the cost is paid when the handler is
- * created rather than on the first request. If the build fails, every request
- * rejects with the build error.
+ * created rather than on the first request. A layer that performs asynchronous
+ * work while building may still be in progress when the first request arrives,
+ * in which case that request waits for the build to finish. If the build fails,
+ * every request rejects with the build error.
  *
  * @category converting
  * @since 4.0.0

--- a/packages/effect/src/unstable/http/HttpEffect.ts
+++ b/packages/effect/src/unstable/http/HttpEffect.ts
@@ -13,7 +13,7 @@ import * as Context from "../../Context.ts"
 import * as Effect from "../../Effect.ts"
 import * as Exit from "../../Exit.ts"
 import * as Fiber from "../../Fiber.ts"
-import { dual } from "../../Function.ts"
+import { constVoid, dual } from "../../Function.ts"
 import { contA, contE } from "../../internal/core.ts"
 import { effectIsExit, fiberEnterUninterruptibleUnsafe, reportCauseUnsafe } from "../../internal/effect.ts"
 import * as Layer from "../../Layer.ts"
@@ -353,6 +353,16 @@ export const toWebHandlerLayerWith = <
     ) => Effect.Effect<Effect.Effect<HttpServerResponse, E, R>, LE>
     readonly middleware?: HttpMiddleware | undefined
     readonly memoMap?: Layer.MemoMap | undefined
+    /**
+     * Build the layer immediately instead of on the first request.
+     *
+     * Useful on platforms that evaluate the module before the first request
+     * arrives (e.g. Cloudflare Workers), so the layer cost is paid at startup
+     * rather than on the request path.
+     *
+     * Defaults to `false`.
+     */
+    readonly eager?: boolean | undefined
   }
 ): {
   readonly dispose: () => Promise<void>
@@ -374,13 +384,7 @@ export const toWebHandlerLayerWith = <
   let handlerPromise:
     | Promise<(request: Request, context?: Context.Context<ReqR> | undefined) => Promise<globalThis.Response>>
     | undefined
-  function handler(
-    request: Request,
-    context?: Context.Context<ReqR> | undefined
-  ): Promise<globalThis.Response> {
-    if (handlerCache) {
-      return handlerCache(request, context)
-    }
+  const build = () =>
     handlerPromise ??= Effect.runPromise(Effect.gen(function*() {
       const context = yield* (options.memoMap
         ? Layer.buildWithMemoMap(layer, options.memoMap, scope)
@@ -390,7 +394,19 @@ export const toWebHandlerLayerWith = <
         options.middleware
       ) as any
     }))
-    return handlerPromise.then((f) => f(request, context))
+  function handler(
+    request: Request,
+    context?: Context.Context<ReqR> | undefined
+  ): Promise<globalThis.Response> {
+    if (handlerCache) {
+      return handlerCache(request, context)
+    }
+    return build().then((f) => f(request, context))
+  }
+  if (options.eager === true) {
+    // Failures are still surfaced by each request, so avoid an unhandled
+    // rejection at startup.
+    build().catch(constVoid)
   }
   return { dispose, handler: handler as any } as const
 }
@@ -407,6 +423,12 @@ export const toWebHandlerLayer = <E, R, Provided, LE, ReqR = Exclude<R, Provided
   options?: {
     readonly middleware?: HttpMiddleware | undefined
     readonly memoMap?: Layer.MemoMap | undefined
+    /**
+     * Build the layer immediately instead of on the first request.
+     *
+     * Defaults to `false`.
+     */
+    readonly eager?: boolean | undefined
   } | undefined
 ): {
   readonly dispose: () => Promise<void>

--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -1288,7 +1288,9 @@ export const serve = <A, E, R, HE, HR = Request.Only<"Requires", R> | Request.On
  *
  * The result contains a `handler` function that converts Web `Request` values to
  * Web `Response` values and a `dispose` function for releasing the layer
- * resources.
+ * resources. The layer is built immediately, so the cost is paid when the
+ * handler is created rather than on the first request. If the build fails,
+ * every request rejects with the build error.
  *
  * @category converting
  * @since 4.0.0
@@ -1311,16 +1313,6 @@ export const toWebHandler = <
     readonly memoMap?: Layer.MemoMap | undefined
     readonly routerConfig?: Partial<FindMyWay.RouterConfig> | undefined
     readonly disableLogger?: boolean | undefined
-    /**
-     * Build the router layer immediately instead of on the first request.
-     *
-     * Useful on platforms that evaluate the module before the first request
-     * arrives (e.g. Cloudflare Workers), so the layer cost is paid at startup
-     * rather than on the request path.
-     *
-     * Defaults to `false`.
-     */
-    readonly eager?: boolean | undefined
     /**
      * Middleware to apply to the HTTP server.
      *
@@ -1361,7 +1353,6 @@ export const toWebHandler = <
   return HttpEffect.toWebHandlerLayerWith(Layer.provideMerge(appLayer, RouterLayer) as Layer.Layer<A | HttpRouter, E>, {
     toHandler: (s) => Effect.succeed(Context.get(s, HttpRouter).asHttpEffect()),
     middleware,
-    memoMap: options?.memoMap,
-    eager: options?.eager
+    memoMap: options?.memoMap
   })
 }

--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -1312,6 +1312,16 @@ export const toWebHandler = <
     readonly routerConfig?: Partial<FindMyWay.RouterConfig> | undefined
     readonly disableLogger?: boolean | undefined
     /**
+     * Build the router layer immediately instead of on the first request.
+     *
+     * Useful on platforms that evaluate the module before the first request
+     * arrives (e.g. Cloudflare Workers), so the layer cost is paid at startup
+     * rather than on the request path.
+     *
+     * Defaults to `false`.
+     */
+    readonly eager?: boolean | undefined
+    /**
      * Middleware to apply to the HTTP server.
      *
      * **Gotchas**
@@ -1351,6 +1361,7 @@ export const toWebHandler = <
   return HttpEffect.toWebHandlerLayerWith(Layer.provideMerge(appLayer, RouterLayer) as Layer.Layer<A | HttpRouter, E>, {
     toHandler: (s) => Effect.succeed(Context.get(s, HttpRouter).asHttpEffect()),
     middleware,
-    memoMap: options?.memoMap
+    memoMap: options?.memoMap,
+    eager: options?.eager
   })
 }

--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -1289,8 +1289,10 @@ export const serve = <A, E, R, HE, HR = Request.Only<"Requires", R> | Request.On
  * The result contains a `handler` function that converts Web `Request` values to
  * Web `Response` values and a `dispose` function for releasing the layer
  * resources. The layer is built immediately, so the cost is paid when the
- * handler is created rather than on the first request. If the build fails,
- * every request rejects with the build error.
+ * handler is created rather than on the first request. A layer that performs
+ * asynchronous work while building may still be in progress when the first
+ * request arrives, in which case that request waits for the build to finish.
+ * If the build fails, every request rejects with the build error.
  *
  * @category converting
  * @since 4.0.0

--- a/packages/effect/src/unstable/http/HttpServerRespondable.ts
+++ b/packages/effect/src/unstable/http/HttpServerRespondable.ts
@@ -11,7 +11,6 @@
 import * as Cause from "../../Cause.ts"
 import * as Effect from "../../Effect.ts"
 import { hasProperty } from "../../Predicate.ts"
-import * as Schema from "../../Schema.ts"
 import type { HttpServerResponse } from "./HttpServerResponse.ts"
 import * as Response from "./HttpServerResponse.ts"
 
@@ -50,6 +49,12 @@ export const isRespondable = (u: unknown): u is Respondable => hasProperty(u, sy
 const badRequest = Response.empty({ status: 400 })
 const notFound = Response.empty({ status: 404 })
 
+// Checked by type id instead of `Schema.isSchemaError` so that this module does
+// not pull the Schema modules into bundles that never use them.
+const SchemaErrorTypeId = "~effect/Schema/SchemaError"
+const isSchemaError = (u: unknown): boolean =>
+  hasProperty(u, SchemaErrorTypeId) && u[SchemaErrorTypeId] === SchemaErrorTypeId
+
 /**
  * Converts a `Respondable` value into an `HttpServerResponse`.
  *
@@ -86,7 +91,7 @@ export const toResponseOrElse = (u: unknown, orElse: HttpServerResponse): Effect
   } else if (isRespondable(u)) {
     return Effect.catchCause(u[symbol](), () => Effect.succeed(orElse))
     // add support for some commmon types
-  } else if (Schema.isSchemaError(u)) {
+  } else if (isSchemaError(u)) {
     return Effect.succeed(badRequest)
   } else if (Cause.isNoSuchElementError(u)) {
     return Effect.succeed(notFound)

--- a/packages/effect/src/unstable/http/HttpServerRespondable.ts
+++ b/packages/effect/src/unstable/http/HttpServerRespondable.ts
@@ -10,6 +10,7 @@
  */
 import * as Cause from "../../Cause.ts"
 import * as Effect from "../../Effect.ts"
+import * as Schema from "../../internal/schemaError.ts"
 import { hasProperty } from "../../Predicate.ts"
 import type { HttpServerResponse } from "./HttpServerResponse.ts"
 import * as Response from "./HttpServerResponse.ts"
@@ -49,12 +50,6 @@ export const isRespondable = (u: unknown): u is Respondable => hasProperty(u, sy
 const badRequest = Response.empty({ status: 400 })
 const notFound = Response.empty({ status: 404 })
 
-// Checked by type id instead of `Schema.isSchemaError` so that this module does
-// not pull the Schema modules into bundles that never use them.
-const SchemaErrorTypeId = "~effect/Schema/SchemaError"
-const isSchemaError = (u: unknown): boolean =>
-  hasProperty(u, SchemaErrorTypeId) && u[SchemaErrorTypeId] === SchemaErrorTypeId
-
 /**
  * Converts a `Respondable` value into an `HttpServerResponse`.
  *
@@ -91,7 +86,7 @@ export const toResponseOrElse = (u: unknown, orElse: HttpServerResponse): Effect
   } else if (isRespondable(u)) {
     return Effect.catchCause(u[symbol](), () => Effect.succeed(orElse))
     // add support for some commmon types
-  } else if (isSchemaError(u)) {
+  } else if (Schema.isSchemaError(u)) {
     return Effect.succeed(badRequest)
   } else if (Cause.isNoSuchElementError(u)) {
     return Effect.succeed(notFound)

--- a/packages/effect/test/unstable/http/HttpEffect.test.ts
+++ b/packages/effect/test/unstable/http/HttpEffect.test.ts
@@ -204,6 +204,54 @@ describe("HttpEffect", () => {
     })
   })
 
+  describe("toWebHandlerLayer", () => {
+    test("builds the layer when the handler is created", async () => {
+      let builds = 0
+      const { dispose, handler } = HttpEffect.toWebHandlerLayer(
+        Effect.map(TestValue, (value) => HttpServerResponse.text(String(value))),
+        Layer.effect(
+          TestValue,
+          Effect.sync(() => {
+            builds++
+            return 420
+          })
+        )
+      )
+      strictEqual(builds, 1)
+      const response = await handler(new Request("http://localhost:3000/"))
+      strictEqual(await response.text(), "420")
+      strictEqual(builds, 1)
+      await dispose()
+    })
+
+    test("a failing layer rejects every request without an unhandled rejection", async () => {
+      const unhandled: Array<unknown> = []
+      const onUnhandled = (reason: unknown) => {
+        unhandled.push(reason)
+      }
+      process.on("unhandledRejection", onUnhandled)
+      try {
+        const error = new Error("boom")
+        const { handler } = HttpEffect.toWebHandlerLayer(
+          Effect.succeed(HttpServerResponse.empty()),
+          Layer.effectDiscard(Effect.fail(error))
+        )
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        for (let i = 0; i < 2; i++) {
+          const rejected = await handler(new Request("http://localhost:3000/")).then(
+            () => undefined,
+            (cause) => cause
+          )
+          strictEqual(rejected, error)
+        }
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        deepStrictEqual(unhandled, [])
+      } finally {
+        process.off("unhandledRejection", onUnhandled)
+      }
+    })
+  })
+
   describe("fromWebHandler", () => {
     test("basic GET request", async () => {
       const webHandler = async (request: Request) => {

--- a/packages/effect/test/unstable/http/HttpServerRespondable.test.ts
+++ b/packages/effect/test/unstable/http/HttpServerRespondable.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from "@effect/vitest"
+import { strictEqual } from "@effect/vitest/utils"
+import { Effect, Schema } from "effect"
+import { HttpServerRespondable, HttpServerResponse } from "effect/unstable/http"
+
+describe("HttpServerRespondable", () => {
+  it.effect("maps SchemaError to a 400 response", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(Schema.decodeUnknownEffect(Schema.String)(123))
+      strictEqual(Schema.isSchemaError(error), true)
+      const fallback = HttpServerResponse.empty({ status: 500 })
+      const response = yield* HttpServerRespondable.toResponseOrElse(error, fallback)
+      strictEqual(response.status, 400)
+    }))
+
+  it.effect("falls back for other errors", () =>
+    Effect.gen(function*() {
+      const fallback = HttpServerResponse.empty({ status: 500 })
+      const response = yield* HttpServerRespondable.toResponseOrElse(new Error("boom"), fallback)
+      strictEqual(response, fallback)
+    }))
+})

--- a/packages/tools/bundle/fixtures/http-router.ts
+++ b/packages/tools/bundle/fixtures/http-router.ts
@@ -1,0 +1,17 @@
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import * as HttpRouter from "effect/unstable/http/HttpRouter"
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse"
+
+const Routes = Layer.mergeAll(
+  HttpRouter.add("GET", "/hello", HttpServerResponse.text("Hello")),
+  HttpRouter.add(
+    "GET",
+    "/users/:id",
+    Effect.map(HttpRouter.params, (params) => HttpServerResponse.jsonUnsafe({ id: params.id }))
+  )
+)
+
+const { handler } = HttpRouter.toWebHandler(Routes, { disableLogger: true })
+
+handler(new Request("http://localhost/hello")).then((response) => response.text())

--- a/packages/tools/bundle/package.json
+++ b/packages/tools/bundle/package.json
@@ -46,6 +46,9 @@
     "rollup-plugin-visualizer": "^7.1.1"
   },
   "devDependencies": {
-    "@types/node": "^26.4.0"
+    "@babel/core": "^8.0.1",
+    "@types/node": "^26.4.0",
+    "babel-plugin-annotate-pure-calls": "^0.5.0",
+    "esbuild": "^0.28.2"
   }
 }

--- a/packages/tools/bundle/test/HttpRouterEsbuild.test.ts
+++ b/packages/tools/bundle/test/HttpRouterEsbuild.test.ts
@@ -1,0 +1,76 @@
+import * as babel from "@babel/core"
+import { assert, describe, it } from "@effect/vitest"
+import * as esbuild from "esbuild"
+import * as fs from "node:fs/promises"
+import * as path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const packageDir = fileURLToPath(new URL("..", import.meta.url))
+const effectSrcDir = fileURLToPath(new URL("../../../effect/src/", import.meta.url))
+
+// The published build runs babel with annotate-pure-calls over the compiler
+// output. Bundlers rely on those annotations to drop unused module-scope
+// calls, so the same step is reproduced here for every effect source module.
+// Without it esbuild shakes source differently from the published package.
+const annotatePureCalls: esbuild.Plugin = {
+  name: "annotate-pure-calls",
+  setup(build) {
+    build.onLoad({ filter: /\.ts$/ }, async (args) => {
+      if (!args.path.startsWith(effectSrcDir)) {
+        return undefined
+      }
+      const source = await fs.readFile(args.path, "utf8")
+      const transpiled = await esbuild.transform(source, {
+        loader: "ts",
+        format: "esm",
+        target: "es2022",
+        sourcefile: args.path,
+        tsconfigRaw: { compilerOptions: { verbatimModuleSyntax: true } }
+      })
+      const annotated = await babel.transformAsync(transpiled.code, {
+        babelrc: false,
+        configFile: false,
+        compact: false,
+        cwd: packageDir,
+        filename: args.path,
+        plugins: ["annotate-pure-calls"]
+      })
+      return { contents: annotated!.code!, loader: "js" }
+    })
+  }
+}
+
+// Bundles a fixture the way wrangler does (esbuild, worker conditions) and
+// returns the effect source modules that made it into the output. Only the
+// output entry of the metafile lists retained modules; `metafile.inputs` is
+// the whole import graph, tree-shaken or not.
+const bundledEffectModules = async (fixture: string): Promise<ReadonlyArray<string>> => {
+  const result = await esbuild.build({
+    entryPoints: [path.join(packageDir, "fixtures", fixture)],
+    bundle: true,
+    write: false,
+    metafile: true,
+    format: "esm",
+    platform: "browser",
+    target: "es2022",
+    conditions: ["workerd", "worker", "browser"],
+    logLevel: "silent",
+    absWorkingDir: packageDir,
+    plugins: [annotatePureCalls]
+  })
+  const [output] = Object.values(result.metafile.outputs)
+  return Object.keys(output.inputs)
+    .map((input) => path.relative(effectSrcDir, path.resolve(packageDir, input)))
+    .filter((module) => !module.startsWith(".."))
+    .sort()
+}
+
+describe("http-router fixture bundled with esbuild", () => {
+  it("does not include any Schema module", async () => {
+    const modules = await bundledEffectModules("http-router.ts")
+    assert.include(modules, "unstable/http/HttpRouter.ts")
+    assert.include(modules, "unstable/http/HttpServerRespondable.ts")
+    const schemaModules = modules.filter((module) => /^Schema[A-Za-z]*\.ts$|^internal\/schema\//.test(module))
+    assert.deepStrictEqual(schemaModules, [], `Schema modules reached the router bundle: ${schemaModules.join(", ")}`)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -759,9 +759,18 @@ importers:
         specifier: ^7.1.1
         version: 7.1.1(rolldown@1.2.6)(rollup@4.63.1)
     devDependencies:
+      '@babel/core':
+        specifier: ^8.0.1
+        version: 8.0.1
       '@types/node':
         specifier: ^26.4.0
         version: 26.4.0
+      babel-plugin-annotate-pure-calls:
+        specifier: ^0.5.0
+        version: 0.5.0(@babel/core@8.0.1)
+      esbuild:
+        specifier: ^0.28.2
+        version: 0.28.2
 
   packages/tools/docgen:
     dependencies:


### PR DESCRIPTION
Two of the cold-start improvements from the Cloudflare investigation.

## Changes

- `HttpServerRespondable` still calls `Schema.isSchemaError`. The predicate and type id now live in a small internal leaf shared with the public `Schema.isSchemaError` API, so the HTTP path does not retain the main Schema module graph. A minimal `HttpRouter` worker bundled from the published output stays at 283 KB (41 KB min+gzip), with no `Schema*` or `internal/schema/*` modules retained, and keeps the roughly 3 ms workerd cold-start improvement.
- `HttpRouter.toWebHandler`, `HttpEffect.toWebHandlerLayer` and `HttpEffect.toWebHandlerLayerWith` build the layer when the handler is created instead of on the first request. On Cloudflare the module is evaluated before the first request, so the layer and router construction (about 2.5 ms) move off the request path. A failed build never surfaces as an unhandled rejection at startup; every request rejects with the build error, which Workers turns into a 500 and logs. A layer doing async work while building may still be in progress on the first request, which then waits; the docs say so.
- Guard for the Schema removal: `packages/tools/bundle/test/HttpRouterEsbuild.test.ts` bundles `fixtures/http-router.ts` with esbuild using worker conditions and asserts that no `Schema*` or `internal/schema/*` module is retained. The rollup based Bundle job cannot see this regression because rollup lifts single exports out of `Schema.js` (21 bytes of movement), while wrangler's esbuild drags the whole graph in. The test reproduces the `annotate-pure-calls` build step per Effect module so it shakes like the published package. Proven on demand: importing the full `Schema.ts` module for the same `Schema.isSchemaError` call makes the guard fail with `Schema.ts`, `SchemaAST.ts`, `SchemaParser.ts`, `SchemaIssue.ts` and six more retained modules; using the shared leaf passes.
- `packages/tools/bundle/fixtures/http-router.ts` stays as a size trend for the router and catches Schema regressions that reach the parser (about +10 % in the Bundle job).
- Tests cover a `SchemaError` mapping to 400 through `toResponseOrElse`, eager layer construction without rebuilding on the first request, and repeated request failures without an unhandled rejection when layer construction fails.

Layers that do I/O during construction (fetch, sleep, random values) still cannot be built in the global scope of a Worker; they need to be turned into a handler inside `fetch`, which is also where bindings become available.

## Validation

- `pnpm lint-fix`
- `pnpm check`
- `pnpm jsdocs --check`
- `pnpm test --run packages/tools/bundle/test/HttpRouterEsbuild.test.ts packages/effect/test/unstable/http/HttpServerRespondable.test.ts packages/effect/test/schema/Schema.test.ts` (590 tests passed)
- Rebuilt `dist` and ran the router in `workerd`: the layer is observed to be built before the first request, and a layer that fails on purpose gives a 500 on every request with the error logged, with no unhandled rejection at startup under `node --unhandled-rejections=strict`

Closes EFF-1156
