### PR TITLE
ci: run Static and Build jobs on GitHub-hosted runners

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
   static-checks:
     name: Static
-    runs-on: namespace-profile-linux-small
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     timeout-minutes: 10
@@ -56,7 +56,7 @@ jobs:
   build:
     name: Build
     if: github.event_name == 'pull_request'
-    runs-on: namespace-profile-linux-small
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     timeout-minutes: 10


### PR DESCRIPTION
Moves the `Static` and `Build` jobs in `.github/workflows/check.yml` from `namespace-profile-linux-small` to `ubuntu-latest`.

Neither job uses Namespace-specific steps, so the runner swap is the whole change. `Types`, `Bundle`, `Test`, and `Doctest` stay on their current runners.

Closes EFF-1158
