### PR TITLE
Optimize OtlpTracer span creation and export

### DIFF
--- a/.changeset/otlp-tracer-span-performance.md
+++ b/.changeset/otlp-tracer-span-performance.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Speed up `OtlpTracer` span creation and export. Spans now allocate identifiers, attributes, and events lazily, and `Encoding.randomHex` produces flat strings for 16 and 32 character identifiers so serialization no longer flattens ropes.

--- a/packages/effect/src/Encoding.ts
+++ b/packages/effect/src/Encoding.ts
@@ -424,13 +424,107 @@ export const encodeHex: (input: Uint8Array | string) => string = (input) =>
  * @since 4.0.0
  */
 export const randomHex = (length: number): string => {
-  let result = ""
-  for (let i = length >>> 3; i > 0; i--) {
-    const word = (Math.random() * 0x100000000) >>> 0
-    result += byteToHex[word >>> 24] + byteToHex[(word >>> 16) & 0xff] + byteToHex[(word >>> 8) & 0xff] +
-      byteToHex[word & 0xff]
+  switch (length) {
+    case 16:
+      return randomHex16()
+    case 32:
+      return randomHex32()
+    default: {
+      let result = ""
+      for (let i = length >>> 3; i > 0; i--) {
+        result += randomHex8()
+      }
+      return result
+    }
   }
-  return result
+}
+
+const hexCharCodes = new Uint8Array(16)
+for (let i = 0; i < 16; i++) {
+  hexCharCodes[i] = "0123456789abcdef".charCodeAt(i)
+}
+
+const randomWord = (): number => (Math.random() * 0x100000000) >>> 0
+
+// Trace and span identifiers are the common lengths. A single
+// String.fromCharCode call produces a flat string, which avoids rope
+// flattening when the identifier is later serialized.
+const randomHex8 = (): string => {
+  const a = randomWord()
+  return String.fromCharCode(
+    hexCharCodes[a >>> 28],
+    hexCharCodes[(a >>> 24) & 15],
+    hexCharCodes[(a >>> 20) & 15],
+    hexCharCodes[(a >>> 16) & 15],
+    hexCharCodes[(a >>> 12) & 15],
+    hexCharCodes[(a >>> 8) & 15],
+    hexCharCodes[(a >>> 4) & 15],
+    hexCharCodes[a & 15]
+  )
+}
+
+const randomHex16 = (): string => {
+  const a = randomWord()
+  const b = randomWord()
+  return String.fromCharCode(
+    hexCharCodes[a >>> 28],
+    hexCharCodes[(a >>> 24) & 15],
+    hexCharCodes[(a >>> 20) & 15],
+    hexCharCodes[(a >>> 16) & 15],
+    hexCharCodes[(a >>> 12) & 15],
+    hexCharCodes[(a >>> 8) & 15],
+    hexCharCodes[(a >>> 4) & 15],
+    hexCharCodes[a & 15],
+    hexCharCodes[b >>> 28],
+    hexCharCodes[(b >>> 24) & 15],
+    hexCharCodes[(b >>> 20) & 15],
+    hexCharCodes[(b >>> 16) & 15],
+    hexCharCodes[(b >>> 12) & 15],
+    hexCharCodes[(b >>> 8) & 15],
+    hexCharCodes[(b >>> 4) & 15],
+    hexCharCodes[b & 15]
+  )
+}
+
+const randomHex32 = (): string => {
+  const a = randomWord()
+  const b = randomWord()
+  const c = randomWord()
+  const d = randomWord()
+  return String.fromCharCode(
+    hexCharCodes[a >>> 28],
+    hexCharCodes[(a >>> 24) & 15],
+    hexCharCodes[(a >>> 20) & 15],
+    hexCharCodes[(a >>> 16) & 15],
+    hexCharCodes[(a >>> 12) & 15],
+    hexCharCodes[(a >>> 8) & 15],
+    hexCharCodes[(a >>> 4) & 15],
+    hexCharCodes[a & 15],
+    hexCharCodes[b >>> 28],
+    hexCharCodes[(b >>> 24) & 15],
+    hexCharCodes[(b >>> 20) & 15],
+    hexCharCodes[(b >>> 16) & 15],
+    hexCharCodes[(b >>> 12) & 15],
+    hexCharCodes[(b >>> 8) & 15],
+    hexCharCodes[(b >>> 4) & 15],
+    hexCharCodes[b & 15],
+    hexCharCodes[c >>> 28],
+    hexCharCodes[(c >>> 24) & 15],
+    hexCharCodes[(c >>> 20) & 15],
+    hexCharCodes[(c >>> 16) & 15],
+    hexCharCodes[(c >>> 12) & 15],
+    hexCharCodes[(c >>> 8) & 15],
+    hexCharCodes[(c >>> 4) & 15],
+    hexCharCodes[c & 15],
+    hexCharCodes[d >>> 28],
+    hexCharCodes[(d >>> 24) & 15],
+    hexCharCodes[(d >>> 20) & 15],
+    hexCharCodes[(d >>> 16) & 15],
+    hexCharCodes[(d >>> 12) & 15],
+    hexCharCodes[(d >>> 8) & 15],
+    hexCharCodes[(d >>> 4) & 15],
+    hexCharCodes[d & 15]
+  )
 }
 
 /**

--- a/packages/effect/src/unstable/observability/OtlpTracer.ts
+++ b/packages/effect/src/unstable/observability/OtlpTracer.ts
@@ -22,7 +22,7 @@ import * as Layer from "../../Layer.ts"
 import * as Option from "../../Option.ts"
 import type * as Scope from "../../Scope.ts"
 import * as Tracer from "../../Tracer.ts"
-import type { ExtractTag, Mutable } from "../../Types.ts"
+import type { ExtractTag } from "../../Types.ts"
 import type * as Headers from "../http/Headers.ts"
 import type * as HttpClient from "../http/HttpClient.ts"
 import * as OtlpEnv from "./internal/otlpEnv.ts"
@@ -96,15 +96,7 @@ export const make: (
 
   return Tracer.make({
     span(options) {
-      return makeSpan({
-        ...options,
-        status: {
-          _tag: "Started",
-          startTime: options.startTime
-        },
-        attributes: new Map(),
-        export: exportFn
-      })
+      return new SpanImpl(options, exportFn)
     },
     context: options.context ?
       function(primitive, fiber) {
@@ -196,17 +188,64 @@ export const layerFromConfig = (options?: {
 
 // internal
 
-interface SpanImpl extends Tracer.Span {
-  readonly export: (span: SpanImpl) => void
-  readonly attributes: Map<string, unknown>
+class SpanImpl implements Tracer.Span {
+  readonly _tag = "Span"
+  readonly name: string
+  readonly parent: Option.Option<Tracer.AnySpan>
+  readonly annotations: Context.Context<never>
   readonly links: Array<Tracer.SpanLink>
-  readonly events: Array<[name: string, startTime: bigint, attributes: Record<string, unknown> | undefined]>
+  readonly kind: Tracer.SpanKind
+  readonly sampled: boolean
+  readonly export: (span: SpanImpl) => void
   status: Tracer.SpanStatus
-}
+  _traceId: string | undefined = undefined
+  _spanId: string | undefined = undefined
+  _attributes: Map<string, unknown> | undefined = undefined
+  _events: Array<[name: string, startTime: bigint, attributes: Record<string, unknown> | undefined]> | undefined =
+    undefined
 
-const SpanProto = {
-  _tag: "Span",
-  end(this: SpanImpl, endTime: bigint, exit: Exit.Exit<unknown, unknown>) {
+  constructor(
+    options: {
+      readonly name: string
+      readonly parent: Option.Option<Tracer.AnySpan>
+      readonly annotations: Context.Context<never>
+      readonly links: Array<Tracer.SpanLink>
+      readonly startTime: bigint
+      readonly kind: Tracer.SpanKind
+      readonly sampled: boolean
+    },
+    exportFn: (span: SpanImpl) => void
+  ) {
+    this.name = options.name
+    this.parent = options.parent
+    this.annotations = options.annotations
+    this.links = options.links
+    this.kind = options.kind
+    this.sampled = options.sampled
+    this.export = exportFn
+    this.status = {
+      _tag: "Started",
+      startTime: options.startTime
+    }
+  }
+
+  get traceId(): string {
+    return this._traceId ??= Option.isSome(this.parent) ? this.parent.value.traceId : Encoding.randomHex(32)
+  }
+
+  get spanId(): string {
+    return this._spanId ??= Encoding.randomHex(16)
+  }
+
+  get attributes(): Map<string, unknown> {
+    return this._attributes ??= new Map()
+  }
+
+  get events(): Array<[name: string, startTime: bigint, attributes: Record<string, unknown> | undefined]> {
+    return this._events ??= []
+  }
+
+  end(endTime: bigint, exit: Exit.Exit<unknown, unknown>): void {
     this.status = {
       _tag: "Ended",
       startTime: this.status.startTime,
@@ -214,59 +253,43 @@ const SpanProto = {
       exit
     }
     this.export(this)
-  },
-  attribute(this: SpanImpl, key: string, value: unknown) {
+  }
+
+  attribute(key: string, value: unknown): void {
     this.attributes.set(key, value)
-  },
-  event(this: SpanImpl, name: string, startTime: bigint, attributes?: Record<string, unknown>) {
+  }
+
+  event(name: string, startTime: bigint, attributes?: Record<string, unknown>): void {
     this.events.push([name, startTime, attributes])
-  },
-  addLinks(this: SpanImpl, links: ReadonlyArray<Tracer.SpanLink>) {
+  }
+
+  addLinks(links: ReadonlyArray<Tracer.SpanLink>): void {
+    // oxlint-disable-next-line no-restricted-syntax
     this.links.push(...links)
   }
-}
-type RemainingSpanImpl = Omit<Tracer.Span, (keyof typeof SpanProto) | "traceId" | "spanId" | "events">
-
-const makeSpan = (options: {
-  readonly name: string
-  readonly parent: Option.Option<Tracer.AnySpan>
-  readonly annotations: Context.Context<never>
-  readonly status: Tracer.SpanStatus
-  readonly attributes: ReadonlyMap<string, unknown>
-  readonly links: ReadonlyArray<Tracer.SpanLink>
-  readonly kind: Tracer.SpanKind
-  readonly sampled: boolean
-  readonly export: (span: SpanImpl) => void
-}): SpanImpl => {
-  const self: Mutable<SpanImpl> = Object.assign(
-    Object.create(SpanProto),
-    options satisfies RemainingSpanImpl
-  )
-  if (Option.isSome(self.parent)) {
-    self.traceId = self.parent.value.traceId
-  } else {
-    self.traceId = Encoding.randomHex(32)
-  }
-  self.spanId = Encoding.randomHex(16)
-  self.events = []
-  return self
 }
 
 const makeOtlpSpan = (self: SpanImpl): OtlpSpan => {
   const status = self.status as ExtractTag<Tracer.SpanStatus, "Ended">
-  const attributes = entriesToAttributes(self.attributes.entries())
-  const events = self.events.map(([name, startTime, attributes]) => ({
-    name,
-    timeUnixNano: String(startTime),
-    attributes: attributes
-      ? entriesToAttributes(Object.entries(attributes))
-      : [],
-    droppedAttributesCount: 0
-  }))
+  const attributes = self._attributes === undefined ? [] : entriesToAttributes(self._attributes)
+  const events: Array<Event> = []
+  if (self._events !== undefined) {
+    for (let i = 0; i < self._events.length; i++) {
+      const [name, startTime, attributes] = self._events[i]
+      events.push({
+        name,
+        timeUnixNano: String(startTime),
+        attributes: attributes
+          ? entriesToAttributes(Object.entries(attributes))
+          : [],
+        droppedAttributesCount: 0
+      })
+    }
+  }
   let otelStatus: Status
 
   if (status.exit._tag === "Success") {
-    otelStatus = constOtelStatusSuccess
+    otelStatus = { code: StatusCode.Ok }
   } else if (Cause.hasInterruptsOnly(status.exit.cause)) {
     otelStatus = {
       code: StatusCode.Ok,
@@ -318,13 +341,21 @@ const makeOtlpSpan = (self: SpanImpl): OtlpSpan => {
     }
   }
 
+  const links: Array<Link> = []
+  for (let i = 0; i < self.links.length; i++) {
+    const link = self.links[i]
+    links.push({
+      traceId: link.span.traceId,
+      spanId: link.span.spanId,
+      attributes: entriesToAttributes(Object.entries(link.attributes)),
+      droppedAttributesCount: 0
+    })
+  }
+
   return {
     traceId: self.traceId,
     spanId: self.spanId,
-    parentSpanId: Option.match(self.parent, {
-      onNone: () => undefined,
-      onSome: (parent) => parent.spanId
-    }),
+    parentSpanId: Option.isSome(self.parent) ? self.parent.value.spanId : undefined,
     name: self.name,
     kind: SpanKind[self.kind],
     startTimeUnixNano: String(status.startTime),
@@ -334,12 +365,7 @@ const makeOtlpSpan = (self: SpanImpl): OtlpSpan => {
     events,
     droppedEventsCount: 0,
     status: otelStatus,
-    links: self.links.map((link) => ({
-      traceId: link.span.traceId,
-      spanId: link.span.spanId,
-      attributes: entriesToAttributes(Object.entries(link.attributes)),
-      droppedAttributesCount: 0
-    })),
+    links,
     droppedLinksCount: 0
   }
 }
@@ -434,7 +460,3 @@ const SpanKind = {
   producer: 4,
   consumer: 5
 } as const
-
-const constOtelStatusSuccess: Status = {
-  code: StatusCode.Ok
-}


### PR DESCRIPTION
Closes EFF-1157

## Changes

- `OtlpTracer` spans are now a class with lazy `traceId`, `spanId`, `attributes`, and `events`, matching `Tracer.NativeSpan`. Unsampled spans no longer generate identifiers or allocate a `Map` and event array.
- `makeOtlpSpan` avoids the `Option.match` closure allocation and the `.map` calls on empty event and link arrays.
- `Encoding.randomHex` builds 16 and 32 character identifiers with a single `String.fromCharCode` call. This roughly halves generation cost and produces flat strings, so `JSON.stringify` no longer flattens rope strings for every span.

## Measurements

`pnpm runtimeperf-compare otlp-tracer` with the benchmark guard from #7918 applied locally (base = `main`, head = this branch):

| fixture | base | head | delta |
| --- | --- | --- | --- |
| otlp-tracer/unsampled-span | 232 ns | 6.5 ns | -97% |
| otlp-tracer/sampled-span-batch-100 | 81.65 µs | 46.91 µs | -43% |

Remaining cost in the sampled batch is roughly 20 µs `JSON.stringify`, 16 µs span creation and conversion, and 8 µs per-flush HTTP client overhead.

## Validation

- `pnpm lint-fix`
- `pnpm test --run` for `Tracer`, `OtlpExporter`, `OtlpSerialization`, and `Encoding` tests
- `pnpm check`
