### PR TITLE
fix(Scheduler): fall back to a microtask when timers cannot be set

### DIFF
--- a/.changeset/scheduler-global-scope-timers.md
+++ b/.changeset/scheduler-global-scope-timers.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+The default scheduler falls back to a microtask when setting a timer throws. Cloudflare Workers disallow timers in global scope, so an effect that yielded while running at module load failed with "Disallowed operation called within global scope".

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -80,16 +80,26 @@ export const Scheduler: Context.Reference<Scheduler> = Context.Reference<Schedul
   defaultValue: () => new MixedScheduler()
 })
 
+// Some runtimes (e.g. Cloudflare Workers) throw when a timer is set in global
+// scope. Fall back to a microtask so effects can still yield at module load.
 const setImmediate = "setImmediate" in globalThis
   ? (f: () => void) => {
-    // @ts-ignore
-    const timer = globalThis.setImmediate(f)
-    // @ts-ignore
-    return (): void => globalThis.clearImmediate(timer)
+    try {
+      // @ts-ignore
+      const timer = globalThis.setImmediate(f)
+      // @ts-ignore
+      return (): void => globalThis.clearImmediate(timer)
+    } catch {
+      return setMicrotask(f)
+    }
   }
   : (f: () => void) => {
-    const timer = setTimeout(f, 0)
-    return (): void => clearTimeout(timer)
+    try {
+      const timer = setTimeout(f, 0)
+      return (): void => clearTimeout(timer)
+    } catch {
+      return setMicrotask(f)
+    }
   }
 
 const setMicrotask = (f: () => void) => {

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -80,28 +80,6 @@ export const Scheduler: Context.Reference<Scheduler> = Context.Reference<Schedul
   defaultValue: () => new MixedScheduler()
 })
 
-// Some runtimes (e.g. Cloudflare Workers) throw when a timer is set in global
-// scope. Fall back to a microtask so effects can still yield at module load.
-const setImmediate = "setImmediate" in globalThis
-  ? (f: () => void) => {
-    try {
-      // @ts-ignore
-      const timer = globalThis.setImmediate(f)
-      // @ts-ignore
-      return (): void => globalThis.clearImmediate(timer)
-    } catch {
-      return setMicrotask(f)
-    }
-  }
-  : (f: () => void) => {
-    try {
-      const timer = setTimeout(f, 0)
-      return (): void => clearTimeout(timer)
-    } catch {
-      return setMicrotask(f)
-    }
-  }
-
 const setMicrotask = (f: () => void) => {
   let cancelled = false
   Promise.resolve().then(() => {
@@ -109,6 +87,28 @@ const setMicrotask = (f: () => void) => {
   })
   return (): void => {
     cancelled = true
+  }
+}
+
+const setTimer: (f: () => void) => () => void = "setImmediate" in globalThis
+  ? (f) => {
+    // @ts-ignore
+    const timer = globalThis.setImmediate(f)
+    // @ts-ignore
+    return (): void => globalThis.clearImmediate(timer)
+  }
+  : (f) => {
+    const timer = setTimeout(f, 0)
+    return (): void => clearTimeout(timer)
+  }
+
+// Some runtimes (e.g. Cloudflare Workers) throw when a timer is set in global
+// scope. Fall back to a microtask so effects can still yield at module load.
+const setImmediate = (f: () => void) => {
+  try {
+    return setTimer(f)
+  } catch {
+    return setMicrotask(f)
   }
 }
 

--- a/packages/effect/test/Scheduler.test.ts
+++ b/packages/effect/test/Scheduler.test.ts
@@ -103,4 +103,21 @@ describe("Scheduler", () => {
       )
       assert.strictEqual(calls, 0)
     }))
+
+  it("MixedScheduler falls back to a microtask when timers cannot be set", async () => {
+    // Cloudflare Workers throw for timers set in global scope
+    const setImmediate = vi.spyOn(globalThis, "setImmediate").mockImplementation(() => {
+      throw new Error("Disallowed operation called within global scope")
+    })
+    try {
+      const count = Scheduler.MaxOpsBeforeYield.defaultValue() * 3
+      const result = await Effect.runPromise(
+        Effect.forEach(Array.from({ length: count }, (_, i) => i), (i) => Effect.succeed(i))
+      )
+      assert.strictEqual(result.length, count)
+      assert.isAbove(setImmediate.mock.calls.length, 0)
+    } finally {
+      setImmediate.mockRestore()
+    }
+  })
 })


### PR DESCRIPTION
Split out of #7927 at review time.

Cloudflare Workers throw `Disallowed operation called within global scope` for `setTimeout` and `setImmediate` in global scope. The default `MixedScheduler` yields through those, so any effect that runs at module load and exceeds `MaxOpsBeforeYield` (2048 ops) dies. With #7927 the web handler layer is built at module load; realistic router and HttpApi builds never yield (measured 0 timer yields for a 200 route router and a 30 endpoint HttpApi), so that PR does not need this. A layer that does real CPU work while building, or any other module-scope `Effect.runPromise`, still hits it.

Reproduction in `workerd` 1.20260828.1: a worker whose module scope runs `Effect.forEach` over 200k elements. Before this change every request returns the "Disallowed operation" error; after it the effect completes. The added test reproduces the same thing in Node by making `globalThis.setImmediate` throw, and fails on `main`.

The `catch` only wraps the timer registration call, never the scheduled task, so a task that throws is unaffected.

Closes EFF-1156

