### PR TITLE
Fix disabled OTLP batch flushing

### DIFF
--- a/.changeset/otlp-disabled-batch-flush.md
+++ b/.changeset/otlp-disabled-batch-flush.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix disabled OTLP batching to skip empty exports and avoid resending buffered items.

--- a/packages/effect/src/unstable/observability/OtlpExporter.ts
+++ b/packages/effect/src/unstable/observability/OtlpExporter.ts
@@ -167,6 +167,7 @@ export const make: (
     readonly label: string
     readonly exportInterval: Duration.Input
     readonly maxBatchSize: number | "disabled"
+    readonly exportEmpty?: boolean | undefined
     readonly body: (data: Array<any>) => readonly [body: HttpBody, onSuccess: Effect.Effect<void>]
     readonly shutdownTimeout: Duration.Input
   }
@@ -201,13 +202,11 @@ export const make: (
     } else if (disabledUntil !== undefined) {
       disabledUntil = undefined
     }
-    const items = buffer
-    if (options.maxBatchSize !== "disabled") {
-      if (buffer.length === 0) {
-        return Effect.void
-      }
-      buffer = []
+    if (buffer.length === 0 && (options.maxBatchSize !== "disabled" || options.exportEmpty !== true)) {
+      return Effect.void
     }
+    const items = buffer
+    buffer = []
     const [body, onSuccess] = options.body(items)
     return client.execute(
       HttpClientRequest.setBody(request, body)

--- a/packages/effect/src/unstable/observability/OtlpMetrics.ts
+++ b/packages/effect/src/unstable/observability/OtlpMetrics.ts
@@ -461,6 +461,7 @@ export const make: (options: {
     url: options.url,
     headers: options.headers,
     maxBatchSize: "disabled",
+    exportEmpty: true,
     exportInterval: options.exportInterval ?? Duration.seconds(10),
     body: snapshot,
     shutdownTimeout: options.shutdownTimeout ?? Duration.seconds(3)

--- a/packages/effect/test/unstable/observability/OtlpExporter.test.ts
+++ b/packages/effect/test/unstable/observability/OtlpExporter.test.ts
@@ -50,14 +50,17 @@ const makeExporter = (
     Effect.provide(OtlpExporter.layerFlusher)
   )
 
-const makeExporterRaw = (maxBatchSize: number | "disabled" = 1) =>
+const makeExporterRaw = (
+  maxBatchSize: number | "disabled" = 1,
+  body: (data: Array<any>) => HttpBody.HttpBody = () => HttpBody.empty
+) =>
   OtlpExporter.make({
     label: "OtlpExporterTest",
     url: "http://localhost:4318/v1/logs",
     headers: undefined,
     exportInterval: "1 hour",
     maxBatchSize,
-    body: () => [HttpBody.empty, Effect.void],
+    body: (data) => [body(data), Effect.void],
     shutdownTimeout: "1 second"
   })
 
@@ -345,6 +348,53 @@ describe("OtlpExporter", () => {
             Effect.provide(OtlpExporter.layerFlusher)
           )
         )
+      }))
+
+    it.effect("does not export empty payloads when batching is disabled", () =>
+      Effect.gen(function*() {
+        const { httpClient } = yield* makeStatusHttpClient(200)
+        const payloads: Array<ReadonlyArray<unknown>> = []
+
+        yield* Effect.scoped(
+          Effect.gen(function*() {
+            yield* makeExporterRaw("disabled", (items) => {
+              payloads.push(items)
+              return HttpBody.empty
+            })
+            const flusher = yield* OtlpExporter.Flusher
+            yield* flusher.flush
+          }).pipe(
+            Effect.provideService(HttpClient.HttpClient, httpClient),
+            Effect.provide(OtlpExporter.layerFlusher)
+          )
+        )
+
+        assert.deepStrictEqual(payloads, [])
+      }))
+
+    it.effect("exports buffered items once when batching is disabled", () =>
+      Effect.gen(function*() {
+        const { httpClient } = yield* makeStatusHttpClient(200)
+        const payloads: Array<ReadonlyArray<unknown>> = []
+
+        yield* Effect.scoped(
+          Effect.gen(function*() {
+            const exporter = yield* makeExporterRaw("disabled", (items) => {
+              payloads.push(items)
+              return HttpBody.empty
+            })
+            const flusher = yield* OtlpExporter.Flusher
+
+            exporter.push({ value: 1 })
+            yield* flusher.flush
+            yield* flusher.flush
+          }).pipe(
+            Effect.provideService(HttpClient.HttpClient, httpClient),
+            Effect.provide(OtlpExporter.layerFlusher)
+          )
+        )
+
+        assert.deepStrictEqual(payloads, [[{ value: 1 }]])
       }))
 
     it.effect("shares one registry across traces, logs and metrics", () =>

--- a/packages/effect/test/unstable/observability/OtlpExporter.test.ts
+++ b/packages/effect/test/unstable/observability/OtlpExporter.test.ts
@@ -145,12 +145,14 @@ describe("OtlpExporter", () => {
       assert.isFalse(yield* Deferred.isDone(started[1]))
 
       yield* Deferred.succeed(releases[0], undefined)
+      exporter.push({ value: 2 })
       yield* TestClock.adjust("1 second")
       yield* Deferred.await(started[1])
 
+      exporter.push({ value: 3 })
       const closeFiber = yield* Effect.forkChild(Scope.close(scope, Exit.void))
-      yield* Deferred.await(started[2])
       yield* Deferred.succeed(releases[1], undefined)
+      yield* Deferred.await(started[2])
       yield* Deferred.succeed(releases[2], undefined)
       yield* Fiber.join(closeFiber)
     }))
@@ -471,10 +473,11 @@ describe("OtlpExporter", () => {
         const flusher = yield* OtlpExporter.Flusher
         const scope = yield* Scope.make()
 
-        yield* makeExporterRaw("disabled").pipe(
+        const exporter = yield* makeExporterRaw("disabled").pipe(
           Effect.provideService(HttpClient.HttpClient, httpClient),
           Effect.provideService(Scope.Scope, scope)
         )
+        exporter.push({ value: 1 })
 
         yield* Scope.close(scope, Exit.void)
         assert.strictEqual(yield* Ref.get(attempts), 1)


### PR DESCRIPTION
## Summary

- skip empty exports when batching is disabled
- drain disabled-batch buffers before export so repeated flushes and shutdown do not resend spans
- preserve metrics snapshot exports through an explicit empty-export option

## Tests

- `pnpm test --run packages/effect/test/unstable/observability/OtlpExporter.test.ts`
- `pnpm test --run packages/effect/test/unstable/observability/OtlpMetrics.test.ts`
- `pnpm check`

Closes EFF-1157
