### PR TITLE
fix(Layer): require error taps to accept the source error

### DIFF
--- a/.changeset/layer-error-observer-types.md
+++ b/.changeset/layer-error-observer-types.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Layer.tapError` and `Layer.tapCause` to require observers that accept the source layer's complete error type.

--- a/packages/effect/src/Layer.ts
+++ b/packages/effect/src/Layer.ts
@@ -1737,21 +1737,24 @@ export const tap: {
  * @since 2.0.0
  */
 export const tapError: {
-  <E, XE extends E, RIn2, E2, X>(
-    f: (e: XE) => Effect<X, E2, RIn2>
+  <E, _XE extends E, RIn2, E2, X>(
+    f: (e: Types.NoInfer<E>) => Effect<X, E2, RIn2>
   ): <RIn, ROut>(self: Layer<ROut, E, RIn>) => Layer<ROut, E | E2, RIn | Exclude<RIn2, Scope.Scope>>
-  <RIn, E, XE extends E, ROut, RIn2, E2, X>(
+  <E, RIn2, E2, X>(
+    f: (e: E) => Effect<X, E2, RIn2>
+  ): <RIn, ROut, E1 extends E = E>(self: Layer<ROut, E1, RIn>) => Layer<ROut, E1 | E2, RIn | Exclude<RIn2, Scope.Scope>>
+  <RIn, E, _XE extends E, ROut, RIn2, E2, X>(
     self: Layer<ROut, E, RIn>,
-    f: (e: XE) => Effect<X, E2, RIn2>
+    f: (e: Types.NoInfer<E>) => Effect<X, E2, RIn2>
   ): Layer<ROut, E | E2, RIn | Exclude<RIn2, Scope.Scope>>
-} = dual(2, <RIn, E, XE extends E, ROut, RIn2, E2, X>(
+} = dual(2, <RIn, E, ROut, RIn2, E2, X>(
   self: Layer<ROut, E, RIn>,
-  f: (e: XE) => Effect<X, E2, RIn2>
+  f: (e: E) => Effect<X, E2, RIn2>
 ): Layer<ROut, E | E2, RIn | Exclude<RIn2, Scope.Scope>> =>
   fromBuild((memoMap, scope) =>
     internalEffect.catch_(
       self.build(memoMap, scope),
-      (error) => Scope.provide(internalEffect.andThen(f(error as XE), internalEffect.fail(error)), scope)
+      (error) => Scope.provide(internalEffect.andThen(f(error), internalEffect.fail(error)), scope)
     )
   ))
 
@@ -1777,22 +1780,24 @@ export const tapError: {
  * @since 4.0.0
  */
 export const tapCause: {
-  <E, XE extends E, RIn2, E2, X>(
-    f: (cause: Cause.Cause<XE>) => Effect<X, E2, RIn2>
+  <E, _XE extends E, RIn2, E2, X>(
+    f: (cause: Cause.Cause<Types.NoInfer<E>>) => Effect<X, E2, RIn2>
   ): <RIn, ROut>(self: Layer<ROut, E, RIn>) => Layer<ROut, E | E2, RIn | Exclude<RIn2, Scope.Scope>>
-  <RIn, E, XE extends E, ROut, RIn2, E2, X>(
+  <E, RIn2, E2, X>(
+    f: (cause: Cause.Cause<E>) => Effect<X, E2, RIn2>
+  ): <RIn, ROut, E1 extends E = E>(self: Layer<ROut, E1, RIn>) => Layer<ROut, E1 | E2, RIn | Exclude<RIn2, Scope.Scope>>
+  <RIn, E, _XE extends E, ROut, RIn2, E2, X>(
     self: Layer<ROut, E, RIn>,
-    f: (cause: Cause.Cause<XE>) => Effect<X, E2, RIn2>
+    f: (cause: Cause.Cause<Types.NoInfer<E>>) => Effect<X, E2, RIn2>
   ): Layer<ROut, E | E2, RIn | Exclude<RIn2, Scope.Scope>>
-} = dual(2, <RIn, E, XE extends E, ROut, RIn2, E2, X>(
+} = dual(2, <RIn, E, ROut, RIn2, E2, X>(
   self: Layer<ROut, E, RIn>,
-  f: (cause: Cause.Cause<XE>) => Effect<X, E2, RIn2>
+  f: (cause: Cause.Cause<E>) => Effect<X, E2, RIn2>
 ): Layer<ROut, E | E2, RIn | Exclude<RIn2, Scope.Scope>> =>
   fromBuild((memoMap, scope) =>
     internalEffect.catchCause(
       self.build(memoMap, scope),
-      (cause) =>
-        Scope.provide(internalEffect.andThen(f(cause as Cause.Cause<XE>), internalEffect.failCause(cause)), scope)
+      (cause) => Scope.provide(internalEffect.andThen(f(cause), internalEffect.failCause(cause)), scope)
     )
   ))
 

--- a/packages/effect/typetest/Layer.tst.ts
+++ b/packages/effect/typetest/Layer.tst.ts
@@ -1,0 +1,23 @@
+/** @effect-diagnostics missingEffectError:skip-file */
+import { type Cause, Effect, Layer } from "effect"
+import { it } from "tstyche"
+
+const source = Layer.effectDiscard(Effect.fail<string | number>(123))
+
+it("tapError rejects an observer that cannot handle every source error", () => {
+  const observer = (error: string) => Effect.succeed(error.toUpperCase())
+
+  // @ts-expect-error is not assignable
+  Layer.tapError(source, observer)
+  // @ts-expect-error is not assignable
+  source.pipe(Layer.tapError(observer))
+})
+
+it("tapCause rejects an observer that cannot handle every source error", () => {
+  const observer = (cause: Cause.Cause<string>) => Effect.succeed(cause.reasons)
+
+  // @ts-expect-error is not assignable
+  Layer.tapCause(source, observer)
+  // @ts-expect-error is not assignable
+  source.pipe(Layer.tapCause(observer))
+})


### PR DESCRIPTION
## Why

`Layer.tapError` and `Layer.tapCause` accepted observers that handled only part of the source layer's error type. A `Layer<_, string | number, _>` could therefore pass a number to a callback typed to accept only strings.

## What changed

- Require both observers to accept the source layer's complete error type.
- Remove the erased casts that hid the mismatch from the implementation.
- Preserve saved observer inference and the existing explicit generic arities.
- Add focused type regressions for data-first and data-last calls.

## Verification

```bash
nix develop -c pnpm test-types Layer.tst.ts
nix develop -c pnpm test --run packages/effect/test/Layer.test.ts
nix develop -c pnpm check
nix develop -c pnpm lint-fix
git diff --check origin/main...HEAD
```

The focused type test passes with TypeScript 5.9.3 and 6.0.3. The existing `Layer` runtime suite passes all 33 tests.

Closes EFF-1195
Closes #7934
