### PR TITLE
fix(platform-deno): apply writeFile modes only during creation

### DIFF
--- a/.changeset/deno-writefile-existing-mode.md
+++ b/.changeset/deno-writefile-existing-mode.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-deno": patch
+---
+
+Fix `FileSystem.writeFile` on Deno to preserve permissions when writing an existing file with an explicit mode.

--- a/packages/platform/deno/src/DenoFileSystem.ts
+++ b/packages/platform/deno/src/DenoFileSystem.ts
@@ -441,12 +441,11 @@ const watch = (
 
 const writeFile: FileSystem.FileSystem["writeFile"] = (path, data, options) => {
   const flag = options?.flag ?? "w"
-  if (flag === "w" || flag === "wx" || flag === "a" || flag === "ax") {
+  if (options?.mode === undefined && (flag === "w" || flag === "wx" || flag === "a" || flag === "ax")) {
     return tryPromise("writeFile", path, (signal) =>
       Deno.writeFile(path, data, {
         append: flag.startsWith("a"),
         createNew: flag.includes("x"),
-        ...(options?.mode === undefined ? {} : { mode: options.mode }),
         signal
       }))
   }

--- a/packages/platform/deno/test/DenoFileSystem.test.ts
+++ b/packages/platform/deno/test/DenoFileSystem.test.ts
@@ -11,6 +11,17 @@ describe("FileSystem", () =>
   }))
 
 describe.skipIf(Deno.build.os === "windows")("writeFile", () => {
+  it.effect("applies the mode when creating a file", () =>
+    Effect.gen(function*() {
+      const fs = yield* FileSystem.FileSystem
+      const directory = yield* fs.makeTempDirectoryScoped()
+      const path = `${directory}/created`
+
+      yield* fs.writeFileString(path, "content", { mode: 0o600 })
+
+      assert.strictEqual((yield* fs.stat(path)).mode & 0o777, 0o600)
+    }).pipe(Effect.provide(DenoFileSystem.layer)))
+
   it.effect("preserves the mode of an existing file", () =>
     Effect.gen(function*() {
       const fs = yield* FileSystem.FileSystem

--- a/packages/platform/deno/test/DenoFileSystem.test.ts
+++ b/packages/platform/deno/test/DenoFileSystem.test.ts
@@ -1,5 +1,7 @@
 import * as DenoFileSystem from "@effect/platform-deno/DenoFileSystem"
-import { describe } from "@effect/vitest"
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as FileSystem from "effect/FileSystem"
 import { testLayer } from "../../../effect/test/FileSystem.test-utils.ts"
 
 describe("FileSystem", () =>
@@ -7,3 +9,16 @@ describe("FileSystem", () =>
     accessOnDirectory: false,
     tempFileScopedRemovesDirectory: false
   }))
+
+describe.skipIf(Deno.build.os === "windows")("writeFile", () => {
+  it.effect("preserves the mode of an existing file", () =>
+    Effect.gen(function*() {
+      const fs = yield* FileSystem.FileSystem
+      const path = yield* fs.makeTempFileScoped()
+      yield* fs.chmod(path, 0o640)
+
+      yield* fs.writeFileString(path, "content", { mode: 0o600 })
+
+      assert.strictEqual((yield* fs.stat(path)).mode & 0o777, 0o640)
+    }).pipe(Effect.provide(DenoFileSystem.layer)))
+})


### PR DESCRIPTION
## Why

The Deno adapter forwarded an explicit mode to `Deno.writeFile`, which changes the permissions of an existing file. The Node adapter forwards mode to Node's `fs.writeFile`, where it is used when creating a file and existing permissions are preserved. The platform adapters should agree on that behavior.

## What changed

- Route Deno writes with an explicit mode through the existing open/write path, which applies the mode during creation without changing existing permissions.
- Cover both sides of the behavior: a new file receives the requested mode, while an existing file keeps its current mode.
- Add an `@effect/platform-deno` patch changeset.

## Verification

- Focused native Deno test: 22 passed, 1 pre-existing skip.
- `pnpm --filter @effect/platform-deno check`
- `pnpm lint-fix`
- `pnpm check`

Closes #7942

Closes EFF-1193
