### PR TITLE
Update v3-to-v4 guidance for recent API changes

### DIFF
--- a/migration/annotations/effect__Graph.yaml
+++ b/migration/annotations/effect__Graph.yaml
@@ -6,10 +6,10 @@
   note: "The immutable type remains, but storage is opaque; replace field access with Graph nodes, edges, count, lookup, neighbor, and acyclicity APIs."
 "effect/Graph#MutableGraph":
   replacement: "Graph.MutableGraph"
-  note: "The mutable type remains but no longer extends Graph.Proto; obtain it through Graph.mutate or Graph.beginMutation and use public mutation/query functions."
+  note: "The mutable type remains but no longer shares a public base interface with immutable Graph; obtain it through Graph.mutate or Graph.beginMutation and use public mutation/query functions."
 "effect/Graph#Proto":
-  replacement: "Graph.Proto"
-  note: "The name remains as the opaque immutable graph protocol; it no longer exposes storage and is no longer the base of MutableGraph."
+  replacement: "none"
+  note: "The common graph protocol was removed. Use Graph.Graph or Graph.MutableGraph as appropriate and replace storage-field access with public graph query and mutation functions."
 "effect/Graph#SearchConfig":
   replacement: "Graph.SearchConfig"
   note: "The type remains; direction is now Graph.TraversalDirection and also accepts undirected, while radius limits traversal depth."

--- a/migration/annotations/effect__ParseResult.yaml
+++ b/migration/annotations/effect__ParseResult.yaml
@@ -8,6 +8,9 @@
 "effect/ParseResult#ArrayFormatterIssue":
   replacement: "StandardSchemaV1.FailureResult[\"issues\"][number]"
   note: "Use the Standard Schema issue shape returned by makeFormatterStandardSchemaV1."
+"effect/ParseResult#Composite":
+  replacement: "SchemaIssue.Composite"
+  note: "Composite parse failures moved to SchemaIssue. The v4 constructor takes the failing AST and an array of nested issues; input is retained only when reportInput is enabled."
 "effect/ParseResult#DeclarationDecodeUnknown":
   replacement: "SchemaGetter.Getter"
   note: "Custom declaration decoding now uses SchemaGetter values and Schema.declare annotations."
@@ -68,6 +71,9 @@
 "effect/ParseResult#orElse":
   replacement: "Effect.orElse"
   note: "Schema transformations now use Effect combinators."
+"effect/ParseResult#Pointer":
+  replacement: "SchemaIssue.Pointer"
+  note: "Path-qualified failures moved to SchemaIssue. Construct them with the property path and nested issue; rejected input belongs to the nested issue when reportInput is enabled."
 "effect/ParseResult#parseError":
   replacement: "Schema.SchemaError"
   note: "Construct a SchemaError from a SchemaIssue.Issue."
@@ -94,6 +100,9 @@
   replacement: "SchemaIssue.defaultFormatter"
   note: "Use the default SchemaIssue string formatter."
   example: "SchemaIssue.defaultFormatter(issue)"
+"effect/ParseResult#Transformation":
+  replacement: "SchemaIssue.Encoding"
+  note: "Transformation-stage failures are Encoding issues in v4. They retain the failing AST and nested issue; the old Encoded, Transformation, and Type kind discriminator was removed."
 "effect/ParseResult#try":
   replacement: "Effect.try"
   note: "Schema transformations now use Effect and map thrown errors to SchemaIssue values."

--- a/migration/annotations/effect__SchemaAST.yaml
+++ b/migration/annotations/effect__SchemaAST.yaml
@@ -1,6 +1,6 @@
 "effect/SchemaAST#Annotated":
-  replacement: "SchemaAST.Base"
-  note: "All v4 AST nodes extend Base, which owns annotations, checks, encoding, and context."
+  replacement: "SchemaAST.AST"
+  note: "The public base type was removed. Use the AST union; every variant still exposes annotations, checks, encoding, and context."
 "effect/SchemaAST#annotations":
   replacement: "SchemaAST.annotate"
   note: "Use the v4 annotation helper and string-keyed Schema.Annotations."
@@ -43,6 +43,9 @@
 "effect/SchemaAST#Compiler":
   replacement: "none"
   note: "The generic AST compiler abstraction was removed; traverse the discriminated SchemaAST.AST union directly or use a higher-level Schema derivation API."
+"effect/SchemaAST#pick":
+  replacement: "none"
+  note: "The low-level AST picker was removed. Keep field selection at the Schema.Struct level with mapFields and Struct.pick, or discriminate and rebuild custom AST nodes explicitly."
 "effect/SchemaAST#composeTransformation":
   replacement: "SchemaAST.Encoding"
   note: "V4 transformations are SchemaAST.Link values in an encoding chain; compose by adding links with SchemaAST.decodeTo."

--- a/migration/annotations/effect__SynchronizedRef.yaml
+++ b/migration/annotations/effect__SynchronizedRef.yaml
@@ -1,9 +1,9 @@
 effect/SynchronizedRef#SynchronizedRef:
   replacement: "SynchronizedRef.SynchronizedRef"
-  note: "The model remains, now extends the v4 Ref model, and is read or updated through explicit SynchronizedRef operations."
+  note: "The model remains but no longer extends Ref; read and update it through explicit SynchronizedRef operations. The curried v4 modifySomeEffect takes only the callback, which returns an Effect of [result, Option<newValue>]; remove the v3 fallback and outer Option."
 effect/SynchronizedRef#SynchronizedRef.Variance:
-  replacement: "Ref.Ref.Variance"
-  note: "SynchronizedRef now inherits Ref variance instead of declaring a separate public variance marker."
+  replacement: "none"
+  note: "The public nested variance marker was removed. SynchronizedRef uses an internal brand in v4, so do not refer to a variance interface directly."
 effect/SynchronizedRef#SynchronizedRefTypeId:
   replacement: "none"
   note: "The SynchronizedRef type id is internal in v4; do not inspect or construct the brand directly."

--- a/migration/annotations/effect__platform-bun__BunStream.yaml
+++ b/migration/annotations/effect__platform-bun__BunStream.yaml
@@ -1,6 +1,6 @@
 "@effect/platform-bun/BunStream#FromReadableOptions":
   replacement: "Pick<Parameters<typeof BunStream.fromReadable>[0], \"chunkSize\" | \"closeOnDone\">"
-  note: "The named interface was inlined into the constructor options; chunkSize is now a number and the full options also contain evaluate, onError, and bufferSize."
+  note: "The named interface was inlined into the constructor options; chunkSize is now a number and the full options also contain evaluate and onError. The ignored bufferSize option was removed."
 "@effect/platform-bun/BunStream#FromWritableOptions":
   replacement: "Pick<Parameters<typeof BunSink.fromWritable>[0], \"endOnDone\" | \"encoding\">"
   note: "The named interface was inlined into BunSink.fromWritable and duplex constructor options."

--- a/migration/annotations/effect__platform__Headers.yaml
+++ b/migration/annotations/effect__platform__Headers.yaml
@@ -29,11 +29,11 @@
   replacement: "Headers.remove / Headers.removeMany"
   note: "Use remove for one name or removeMany for an iterable; RegExp removal requires enumerating matching names."
 "@effect/platform/Headers#schema":
-  replacement: "Headers.HeadersSchema"
-  note: "The encoded-record and self schemas were consolidated into HeadersSchema."
+  replacement: "Schema.Headers"
+  note: "The encoded-record and self schemas were consolidated and moved to effect/Schema as Schema.Headers."
 "@effect/platform/Headers#schemaFromSelf":
-  replacement: "Headers.HeadersSchema"
-  note: "The encoded-record and self schemas were consolidated into HeadersSchema."
+  replacement: "Schema.Headers"
+  note: "The encoded-record and self schemas were consolidated and moved to effect/Schema as Schema.Headers."
 "@effect/platform/Headers#set":
   replacement: "Headers.set"
   note: "Retained with the same dual signature and lowercase key normalization."

--- a/migration/annotations/effect__platform__HttpApiBuilder.yaml
+++ b/migration/annotations/effect__platform__HttpApiBuilder.yaml
@@ -25,6 +25,9 @@
 "@effect/platform/HttpApiBuilder#HandlersTypeId":
   replacement: "none"
   note: "The exported symbol was removed; do not inspect or construct the private Handlers marker."
+"@effect/platform/HttpApiBuilder#Middleware":
+  replacement: "none"
+  note: "The API-specific middleware service tag was removed. Declared HttpApiMiddleware services are applied while routes are built; use HttpRouter.middleware for additional global middleware."
 "@effect/platform/HttpApiBuilder#httpApp":
   replacement: "effect/unstable/http/HttpRouter#toHttpEffect"
   note: "Build the application from the assembled API route layer; HTTP apps are Effects in v4."

--- a/migration/annotations/effect__platform__OpenApiJsonSchema.yaml
+++ b/migration/annotations/effect__platform__OpenApiJsonSchema.yaml
@@ -10,6 +10,9 @@
 "@effect/platform/OpenApiJsonSchema#Array":
   replacement: "effect/JsonSchema#JsonSchema"
   note: "The narrow node interfaces were consolidated into the general object model."
+"@effect/platform/OpenApiJsonSchema#Boolean":
+  replacement: "effect/JsonSchema#JsonSchema"
+  note: "The narrow boolean interface was consolidated into the open, dialect-neutral JSON Schema object model."
 "@effect/platform/OpenApiJsonSchema#Empty":
   replacement: "effect/JsonSchema#JsonSchema"
   note: "The narrow node interfaces and special id shapes were removed."
@@ -31,6 +34,12 @@
 "@effect/platform/OpenApiJsonSchema#makeWithDefs":
   replacement: "effect/SchemaRepresentation#toJsonSchemaMultiDocument + effect/JsonSchema#toMultiDocumentOpenApi3_1"
   note: "Definitions are returned separately; build a multi-document representation and convert it to OpenAPI 3.1."
+"@effect/platform/OpenApiJsonSchema#Never":
+  replacement: "effect/JsonSchema#JsonSchema"
+  note: "The special never-schema interface was consolidated into the open JSON Schema object model; represent it with a not constraint."
+"@effect/platform/OpenApiJsonSchema#Number":
+  replacement: "effect/JsonSchema#JsonSchema"
+  note: "The narrow number interface was consolidated into the open, dialect-neutral JSON Schema object model."
 "@effect/platform/OpenApiJsonSchema#Numeric":
   replacement: "effect/JsonSchema#JsonSchema"
   note: "The narrow numeric interfaces were consolidated into the general object model."
@@ -43,3 +52,9 @@
 "@effect/platform/OpenApiJsonSchema#Root":
   replacement: "effect/JsonSchema#MultiDocument"
   note: "OpenAPI generation keeps roots in schemas and shared components in definitions; the inline-definitions root model is gone."
+"@effect/platform/OpenApiJsonSchema#String":
+  replacement: "effect/JsonSchema#JsonSchema"
+  note: "The narrow string interface was consolidated into the open, dialect-neutral JSON Schema object model."
+"@effect/platform/OpenApiJsonSchema#Void":
+  replacement: "effect/JsonSchema#JsonSchema"
+  note: "The special void-schema interface was consolidated into the open JSON Schema object model."

--- a/migration/annotations/effect__platform__UrlParams.yaml
+++ b/migration/annotations/effect__platform__UrlParams.yaml
@@ -23,23 +23,23 @@
   replacement: "UrlParams.remove"
   note: "Retained and removes every value for the key."
 "@effect/platform/UrlParams#schemaFromSelf":
-  replacement: "UrlParams.UrlParamsSchema"
-  note: "Renamed to the declaration schema for the v4 wrapper."
+  replacement: "Schema.UrlParams"
+  note: "The declaration schema for the v4 wrapper moved to effect/Schema."
 "@effect/platform/UrlParams#schemaFromString":
-  replacement: "Schema.String.pipe(Schema.decodeTo(UrlParams.UrlParamsSchema, { decode: SchemaGetter.transform((s) => UrlParams.fromInput(new URLSearchParams(s))), encode: SchemaGetter.transform(UrlParams.toString) }))"
+  replacement: "Schema.String.pipe(Schema.decodeTo(Schema.UrlParams, { decode: SchemaGetter.transform((s) => UrlParams.fromInput(new URLSearchParams(s))), encode: SchemaGetter.transform(UrlParams.toString) }))"
   note: "No prebuilt string codec remains; recreate it by transforming between a query string and UrlParams."
 "@effect/platform/UrlParams#schemaJson":
-  replacement: "UrlParams.schemaJsonField(field).pipe(Schema.decodeTo(schema), Schema.decodeEffect)"
-  note: "Compose the field codec with the target schema, then decode it."
+  replacement: "Schema.JsonFromUrlParamsField(field).pipe(Schema.decodeTo(schema), Schema.decodeEffect)"
+  note: "The field codec moved to effect/Schema. Compose it with the target schema, then decode it."
 "@effect/platform/UrlParams#schemaParse":
-  replacement: "UrlParamsFromString.pipe(Schema.decodeTo(UrlParams.schemaRecord.pipe(Schema.decodeTo(schema))))"
+  replacement: "UrlParamsFromString.pipe(Schema.decodeTo(Schema.RecordFromUrlParams.pipe(Schema.decodeTo(schema))))"
   note: "Recreate the removed helper by composing the string, record, and target codecs."
 "@effect/platform/UrlParams#schemaRecord":
-  replacement: "UrlParams.schemaRecord.pipe(Schema.decodeTo(schema))"
-  note: "schemaRecord is now a base codec value; compose it with the target schema."
+  replacement: "Schema.RecordFromUrlParams.pipe(Schema.decodeTo(schema))"
+  note: "RecordFromUrlParams is a base codec in effect/Schema; compose it with the target schema."
 "@effect/platform/UrlParams#schemaStruct":
-  replacement: "UrlParams.schemaRecord.pipe(Schema.decodeTo(schema), Schema.decodeEffect)"
-  note: "Compose the record codec with the target schema and decode it."
+  replacement: "Schema.RecordFromUrlParams.pipe(Schema.decodeTo(schema), Schema.decodeEffect)"
+  note: "Compose the record codec from effect/Schema with the target schema and decode it."
 "@effect/platform/UrlParams#set":
   replacement: "UrlParams.set"
   note: "Retained and replaces all existing values for the key."
@@ -49,3 +49,6 @@
 "@effect/platform/UrlParams#toString":
   replacement: "UrlParams.toString"
   note: "Retained and broadened to accept any UrlParams.Input."
+"@effect/platform/UrlParams#UrlParams":
+  replacement: "UrlParams.UrlParams"
+  note: "Import UrlParams from effect/unstable/http. It is now a branded iterable object with a params field rather than a ReadonlyArray; construct it with UrlParams.make or UrlParams.fromInput."

--- a/migration/v3-to-v4.md
+++ b/migration/v3-to-v4.md
@@ -4,7 +4,7 @@
 
 Base: `origin/v3` (`7c6e1e5d2ac9dfe00649a65fa80a61dcc14d55ae`)
 
-Head: `origin/main` (`53843f6490f4eebaf1eeb91fdcc5f1c542b0e132`)
+Head: `origin/main` (`a9d1ee3d4d51e97ea33440fe6100935d5fd5aada`)
 
 This file is generated from the API diff and `migration/annotations/*.yaml`.
 
@@ -6192,7 +6192,7 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 ### `@effect/platform-bun/BunStream`
 
-- `BunStream.FromReadableOptions` -> `Pick<Parameters<typeof BunStream.fromReadable>[0], "chunkSize" | "closeOnDone">`: The named interface was inlined into the constructor options; chunkSize is now a number and the full options also contain evaluate, onError, and bufferSize.
+- `BunStream.FromReadableOptions` -> `Pick<Parameters<typeof BunStream.fromReadable>[0], "chunkSize" | "closeOnDone">`: The named interface was inlined into the constructor options; chunkSize is now a number and the full options also contain evaluate and onError. The ignored bufferSize option was removed.
 
 - `BunStream.FromWritableOptions` -> `Pick<Parameters<typeof BunSink.fromWritable>[0], "endOnDone" | "encoding">`: The named interface was inlined into BunSink.fromWritable and duplex constructor options.
 
@@ -6528,9 +6528,9 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `Headers.remove` -> `Headers.remove / Headers.removeMany`: Use remove for one name or removeMany for an iterable; RegExp removal requires enumerating matching names.
 
-- `Headers.schema` -> `Headers.HeadersSchema`: The encoded-record and self schemas were consolidated into HeadersSchema.
+- `Headers.schema` -> `Schema.Headers`: The encoded-record and self schemas were consolidated and moved to effect/Schema as Schema.Headers.
 
-- `Headers.schemaFromSelf` -> `Headers.HeadersSchema`: The encoded-record and self schemas were consolidated into HeadersSchema.
+- `Headers.schemaFromSelf` -> `Schema.Headers`: The encoded-record and self schemas were consolidated and moved to effect/Schema as Schema.Headers.
 
 - `Headers.unsafeFromRecord` -> `Headers.fromRecordUnsafe`: Renamed to put Unsafe last; it still skips name normalization.
 
@@ -6557,6 +6557,8 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 - `HttpApiBuilder.Handlers.ValidateReturn` -> `effect/unstable/httpapi/HttpApiBuilder#Handlers.ValidateReturn`: The validator remains and now checks the endpoint map against handled identifiers.
 
 - `HttpApiBuilder.HandlersTypeId` -> `none`: The exported symbol was removed; do not inspect or construct the private Handlers marker.
+
+- `HttpApiBuilder.Middleware` -> `none`: The API-specific middleware service tag was removed. Declared HttpApiMiddleware services are applied while routes are built; use HttpRouter.middleware for additional global middleware.
 
 - `HttpApiBuilder.MiddlewareFn` -> `effect/unstable/http/HttpRouter#middleware.Fn`: HTTP apps are Effects in v4; use the router middleware function type or infer it through HttpRouter.middleware.
 
@@ -7318,6 +7320,8 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `OpenApiJsonSchema.Array` -> `effect/JsonSchema#JsonSchema`: The narrow node interfaces were consolidated into the general object model.
 
+- `OpenApiJsonSchema.Boolean` -> `effect/JsonSchema#JsonSchema`: The narrow boolean interface was consolidated into the open, dialect-neutral JSON Schema object model.
+
 - `OpenApiJsonSchema.Empty` -> `effect/JsonSchema#JsonSchema`: The narrow node interfaces and special id shapes were removed.
 
 - `OpenApiJsonSchema.Enum` -> `effect/JsonSchema#JsonSchema`: The narrow node interfaces were consolidated into the general object model.
@@ -7328,6 +7332,10 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `OpenApiJsonSchema.JsonSchema` -> `effect/JsonSchema#JsonSchema`: Use the dialect-neutral open JSON Schema object model.
 
+- `OpenApiJsonSchema.Never` -> `effect/JsonSchema#JsonSchema`: The special never-schema interface was consolidated into the open JSON Schema object model; represent it with a not constraint.
+
+- `OpenApiJsonSchema.Number` -> `effect/JsonSchema#JsonSchema`: The narrow number interface was consolidated into the open, dialect-neutral JSON Schema object model.
+
 - `OpenApiJsonSchema.Numeric` -> `effect/JsonSchema#JsonSchema`: The narrow numeric interfaces were consolidated into the general object model.
 
 - `OpenApiJsonSchema.Object` -> `effect/JsonSchema#JsonSchema`: The narrow node interfaces were consolidated into the general object model.
@@ -7336,7 +7344,11 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `OpenApiJsonSchema.Root` -> `effect/JsonSchema#MultiDocument`: OpenAPI generation keeps roots in schemas and shared components in definitions; the inline-definitions root model is gone.
 
+- `OpenApiJsonSchema.String` -> `effect/JsonSchema#JsonSchema`: The narrow string interface was consolidated into the open, dialect-neutral JSON Schema object model.
+
 - `OpenApiJsonSchema.Unknown`: TODO: needs guidance
+
+- `OpenApiJsonSchema.Void` -> `effect/JsonSchema#JsonSchema`: The special void-schema interface was consolidated into the open JSON Schema object model.
 
 - `OpenApiJsonSchema.make` -> `effect/Schema#toJsonSchemaDocument + effect/JsonSchema#toMultiDocumentOpenApi3_1`: Generate Draft 2020-12, wrap the root in a multi-document, then convert references and definitions to OpenAPI 3.1.
 
@@ -7424,19 +7436,21 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `UrlParams.Input` -> `UrlParams.Input`: Retained and broadened to include UrlParams itself.
 
+- `UrlParams.UrlParams` -> `UrlParams.UrlParams`: Import UrlParams from effect/unstable/http. It is now a branded iterable object with a params field rather than a ReadonlyArray; construct it with UrlParams.make or UrlParams.fromInput.
+
 - `UrlParams.makeUrl` -> `Url.make`: Moved to Url, returns Result, and takes string | undefined for the hash.
 
-- `UrlParams.schemaFromSelf` -> `UrlParams.UrlParamsSchema`: Renamed to the declaration schema for the v4 wrapper.
+- `UrlParams.schemaFromSelf` -> `Schema.UrlParams`: The declaration schema for the v4 wrapper moved to effect/Schema.
 
-- `UrlParams.schemaFromString` -> `Schema.String.pipe(Schema.decodeTo(UrlParams.UrlParamsSchema, { decode: SchemaGetter.transform((s) => UrlParams.fromInput(new URLSearchParams(s))), encode: SchemaGetter.transform(UrlParams.toString) }))`: No prebuilt string codec remains; recreate it by transforming between a query string and UrlParams.
+- `UrlParams.schemaFromString` -> `Schema.String.pipe(Schema.decodeTo(Schema.UrlParams, { decode: SchemaGetter.transform((s) => UrlParams.fromInput(new URLSearchParams(s))), encode: SchemaGetter.transform(UrlParams.toString) }))`: No prebuilt string codec remains; recreate it by transforming between a query string and UrlParams.
 
-- `UrlParams.schemaJson` -> `UrlParams.schemaJsonField(field).pipe(Schema.decodeTo(schema), Schema.decodeEffect)`: Compose the field codec with the target schema, then decode it.
+- `UrlParams.schemaJson` -> `Schema.JsonFromUrlParamsField(field).pipe(Schema.decodeTo(schema), Schema.decodeEffect)`: The field codec moved to effect/Schema. Compose it with the target schema, then decode it.
 
-- `UrlParams.schemaParse` -> `UrlParamsFromString.pipe(Schema.decodeTo(UrlParams.schemaRecord.pipe(Schema.decodeTo(schema))))`: Recreate the removed helper by composing the string, record, and target codecs.
+- `UrlParams.schemaParse` -> `UrlParamsFromString.pipe(Schema.decodeTo(Schema.RecordFromUrlParams.pipe(Schema.decodeTo(schema))))`: Recreate the removed helper by composing the string, record, and target codecs.
 
-- `UrlParams.schemaRecord` -> `UrlParams.schemaRecord.pipe(Schema.decodeTo(schema))`: schemaRecord is now a base codec value; compose it with the target schema.
+- `UrlParams.schemaRecord` -> `Schema.RecordFromUrlParams.pipe(Schema.decodeTo(schema))`: RecordFromUrlParams is a base codec in effect/Schema; compose it with the target schema.
 
-- `UrlParams.schemaStruct` -> `UrlParams.schemaRecord.pipe(Schema.decodeTo(schema), Schema.decodeEffect)`: Compose the record codec with the target schema and decode it.
+- `UrlParams.schemaStruct` -> `Schema.RecordFromUrlParams.pipe(Schema.decodeTo(schema), Schema.decodeEffect)`: Compose the record codec from effect/Schema with the target schema and decode it.
 
 - `UrlParams.toString` -> `UrlParams.toString`: Retained and broadened to accept any UrlParams.Input.
 
@@ -11148,9 +11162,9 @@ FastCheck.uuid({ version: 4 })
 
 - `Graph.Graph` -> `Graph.Graph`: The immutable type remains, but storage is opaque; replace field access with Graph nodes, edges, count, lookup, neighbor, and acyclicity APIs.
 
-- `Graph.MutableGraph` -> `Graph.MutableGraph`: The mutable type remains but no longer extends Graph.Proto; obtain it through Graph.mutate or Graph.beginMutation and use public mutation/query functions.
+- `Graph.MutableGraph` -> `Graph.MutableGraph`: The mutable type remains but no longer shares a public base interface with immutable Graph; obtain it through Graph.mutate or Graph.beginMutation and use public mutation/query functions.
 
-- `Graph.Proto` -> `Graph.Proto`: The name remains as the opaque immutable graph protocol; it no longer exposes storage and is no longer the base of MutableGraph.
+- `Graph.Proto` -> `none`: The common graph protocol was removed. Use Graph.Graph or Graph.MutableGraph as appropriate and replace storage-field access with public graph query and mutation functions.
 
 - `Graph.SearchConfig` -> `Graph.SearchConfig`: The type remains; direction is now Graph.TraversalDirection and also accepts undirected, while radius limits traversal depth.
 
@@ -11673,7 +11687,7 @@ JsonSchema.toDocumentDraft07(Schema.toJsonSchemaDocument(schema))
 
 - `Logger.withMinimumLogLevel` -> `Effect.provideService(effect, References.MinimumLogLevel, level)`: Replace the FiberRef-local helper with reference provisioning.
 
-- `Logger.withSpanAnnotations` -> `custom Logger.make wrapper using options.fiber.currentSpan`: No transparent generic equivalent remains. Read span identity from options.fiber.currentSpan and add it to custom output as needed.
+- `Logger.withSpanAnnotations` -> `custom Logger.make wrapper using options.fiber.cache.span`: No transparent generic equivalent remains. Read span identity from options.fiber.cache.span and add it to custom output as needed.
 
 - `Logger.zip` -> `Logger.make(options => [left.log(options), right.log(options)])`: No named combinator remains; invoke both loggers and return their output tuple.
 
@@ -12661,6 +12675,8 @@ SchemaIssue.makeFormatterStandardSchemaV1()(error.issue).issues
 
 - `ParseResult.ArrayFormatterIssue` -> `StandardSchemaV1.FailureResult["issues"][number]`: Use the Standard Schema issue shape returned by makeFormatterStandardSchemaV1.
 
+- `ParseResult.Composite` -> `SchemaIssue.Composite`: Composite parse failures moved to SchemaIssue. The v4 constructor takes the failing AST and an array of nested issues; input is retained only when reportInput is enabled.
+
 - `ParseResult.DeclarationDecodeUnknown` -> `SchemaGetter.Getter`: Custom declaration decoding now uses SchemaGetter values and Schema.declare annotations.
 
 - `ParseResult.DecodeUnknown` -> `Schema.decodeUnknownEffect`: Use the function type returned by Schema.decodeUnknownEffect.
@@ -12677,9 +12693,13 @@ SchemaIssue.makeFormatterStandardSchemaV1()(error.issue).issues
 
 - `ParseResult.ParseResultFormatter` -> `SchemaIssue.Formatter`: Issue formatter types moved to SchemaIssue.
 
+- `ParseResult.Pointer` -> `SchemaIssue.Pointer`: Path-qualified failures moved to SchemaIssue. Construct them with the property path and nested issue; rejected input belongs to the nested issue when reportInput is enabled.
+
 - `ParseResult.Refinement` -> `SchemaIssue.Filter`: Refinement failures are represented as filter issues in v4.
 
 - `ParseResult.SingleOrNonEmpty` -> `ReadonlyArray`: This ParseResult helper type was removed; use an explicit value-or-non-empty-array type when still needed.
+
+- `ParseResult.Transformation` -> `SchemaIssue.Encoding`: Transformation-stage failures are Encoding issues in v4. They retain the failing AST and nested issue; the old Encoded, Transformation, and Type kind discriminator was removed.
 
 #### `ParseResult.TreeFormatter`
 
@@ -14783,7 +14803,7 @@ Schema.toFormatter(schema)
 
 - `SchemaAST.AST` -> `SchemaAST.AST`: The name remains, but its constructor and fields changed in the v4 Base/check/context/encoding model.
 
-- `SchemaAST.Annotated` -> `SchemaAST.Base`: All v4 AST nodes extend Base, which owns annotations, checks, encoding, and context.
+- `SchemaAST.Annotated` -> `SchemaAST.AST`: The public base type was removed. Use the AST union; every variant still exposes annotations, checks, encoding, and context.
 
 - `SchemaAST.AnyKeyword` -> `SchemaAST.Any`: The v4 SchemaAST redesign renamed this primitive, collection, or guard while preserving its role.
 
@@ -15060,6 +15080,8 @@ Schema.toFormatter(schema)
 - `SchemaAST.omit` -> `Schema.mapFields + Struct.omit`: Object projection moved to schema field transforms.
 
 - `SchemaAST.partial` -> `Schema.mapFields + Struct.map(Schema.optional)`: Partial object transforms moved to schema field transforms.
+
+- `SchemaAST.pick` -> `none`: The low-level AST picker was removed. Keep field selection at the Schema.Struct level with mapFields and Struct.pick, or discriminate and rebuild custom AST nodes explicitly.
 
 - `SchemaAST.required` -> `Schema.mapFields + Struct.map(Schema.requiredKey)`: Required object transforms moved to schema field transforms.
 
@@ -15828,9 +15850,9 @@ switch (strategy) {
 
 ### `effect/SynchronizedRef`
 
-- `SynchronizedRef.SynchronizedRef` -> `SynchronizedRef.SynchronizedRef`: The model remains, now extends the v4 Ref model, and is read or updated through explicit SynchronizedRef operations.
+- `SynchronizedRef.SynchronizedRef` -> `SynchronizedRef.SynchronizedRef`: The model remains but no longer extends Ref; read and update it through explicit SynchronizedRef operations. The curried v4 modifySomeEffect takes only the callback, which returns an Effect of [result, Option\<newValue\>]; remove the v3 fallback and outer Option.
 
-- `SynchronizedRef.SynchronizedRef.Variance` -> `Ref.Ref.Variance`: SynchronizedRef now inherits Ref variance instead of declaring a separate public variance marker.
+- `SynchronizedRef.SynchronizedRef.Variance` -> `none`: The public nested variance marker was removed. SynchronizedRef uses an internal brand in v4, so do not refer to a variance interface directly.
 
 - `SynchronizedRef.SynchronizedRefTypeId` -> `none`: The SynchronizedRef type id is internal in v4; do not inspect or construct the brand directly.
 


### PR DESCRIPTION
## Summary

- update migration guidance after recent Graph, SchemaAST, SchemaIssue, SynchronizedRef, and Node stream API changes
- point Headers and UrlParams schema migrations at their new `effect/Schema` exports
- add explicit guidance for 11 newly unmatched v3 API IDs and regenerate the reference at main SHA `a9d1ee3d4d51e97ea33440fe6100935d5fd5aada`

## Validation

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/tools/api-diff/test` (25 tests passed)
- `nix develop -c pnpm --dir packages/tools/api-diff check`
- repeated migration-document generation completed without further changes
- `git diff --check`
- full `api-diff --check` returned the same 12 known annotation groups as the recorded baseline; all 11 groups and IDs introduced by this commit range are covered

Closes EFF-1188
