### PR TITLE
Reduce HTTP server overhead in response headers, routing, HttpApi errors, and Effect.cached

### DIFF
--- a/.changeset/eff-1201-http-overhead.md
+++ b/.changeset/eff-1201-http-overhead.md
@@ -1,0 +1,9 @@
+---
+"effect": patch
+---
+
+Reduce HTTP server overhead: complete freshly created header maps in place in
+`HttpServerResponse.setHeader` and `setHeaders`, compare static route prefixes
+with a prepared `startsWith`, map `HttpApi` schema errors eagerly for completed
+decoder results, and implement `Effect.cached` as a dedicated one-time memo
+without time-to-live machinery.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -4398,7 +4398,22 @@ export const cachedWithTTL: {
 
 /** @internal */
 export const cached = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<Effect.Effect<A, E, R>> =>
-  cachedWithTTL(self, Duration.infinity)
+  sync(() => {
+    const latch = makeLatchUnsafe(false)
+    let started = false
+    let exit: Exit.Exit<A, E> | undefined
+    const wait = flatMap(latch.await, () => exit!)
+    return suspend(() => {
+      if (exit !== undefined) return exit
+      if (started) return wait
+      started = true
+      return onExit(self, (result) =>
+        sync(() => {
+          exit = result
+          latch.openUnsafe()
+        }))
+    })
+  })
 
 // ----------------------------------------------------------------------------
 // interruption

--- a/packages/effect/src/unstable/http/FindMyWay/internal/router.ts
+++ b/packages/effect/src/unstable/http/FindMyWay/internal/router.ts
@@ -667,18 +667,12 @@ class StaticNode extends ParentNode {
   private setPrefix(prefix: string) {
     this.prefix = prefix
 
+    // Child selection already matched the first character.
     if (prefix.length === 1) {
       this.matchPrefix = (_path, _pathIndex) => true
     } else {
-      const len = prefix.length
-      this.matchPrefix = function(path, pathIndex) {
-        for (let i = 1; i < len; i++) {
-          if (path.charCodeAt(pathIndex + i) !== this.prefix.charCodeAt(i)) {
-            return false
-          }
-        }
-        return true
-      }
+      const tail = prefix.slice(1)
+      this.matchPrefix = (path, pathIndex) => path.startsWith(tail, pathIndex + 1)
     }
   }
 

--- a/packages/effect/src/unstable/http/HttpServerResponse.ts
+++ b/packages/effect/src/unstable/http/HttpServerResponse.ts
@@ -928,7 +928,7 @@ export const setBody: {
 } = dual(
   2,
   (self: HttpServerResponse, body: Body.HttpBody): HttpServerResponse =>
-    makeResponse({ ...self, headers: bodyInternal.updateHeaders(self.headers, body), body })
+    makeResponse({ ...self, body }, bodyInternal.updateHeaders(self.headers, body))
 )
 
 /**
@@ -1337,8 +1337,8 @@ const makeResponse = (options: {
   readonly body?: Body.HttpBody | undefined
 }, ownedHeaders?: Headers.Headers) => {
   // ownedHeaders is a freshly created map that nothing else references, so it
-  // can be completed in place instead of copied. Explicit content headers in it
-  // take precedence over body-derived ones.
+  // can be completed in place instead of copied. It supersedes options.headers,
+  // and explicit content headers in it take precedence over body-derived ones.
   const self = Object.create(Proto) as Mutable<HttpServerResponse>
   self.status = options.status
   self.statusText = options.statusText

--- a/packages/effect/src/unstable/http/HttpServerResponse.ts
+++ b/packages/effect/src/unstable/http/HttpServerResponse.ts
@@ -532,10 +532,7 @@ export const setHeader: {
 } = dual(
   3,
   (self: HttpServerResponse, key: string, value: string): HttpServerResponse =>
-    makeResponse({
-      ...self,
-      headers: Headers.set(self.headers, key, value)
-    }, true)
+    makeResponse(self, Headers.set(self.headers, key, value))
 )
 
 /**
@@ -568,10 +565,7 @@ export const setHeaders: {
 } = dual(
   2,
   (self: HttpServerResponse, input: Headers.Input): HttpServerResponse =>
-    makeResponse({
-      ...self,
-      headers: Headers.setAll(self.headers, input)
-    }, true)
+    makeResponse(self, Headers.setAll(self.headers, input))
 )
 
 /**
@@ -1341,7 +1335,10 @@ const makeResponse = (options: {
   readonly headers?: Headers.Headers | undefined
   readonly cookies?: Cookies.Cookies | undefined
   readonly body?: Body.HttpBody | undefined
-}, preferHeaders = false) => {
+}, ownedHeaders?: Headers.Headers) => {
+  // ownedHeaders is a freshly created map that nothing else references, so it
+  // can be completed in place instead of copied. Explicit content headers in it
+  // take precedence over body-derived ones.
   const self = Object.create(Proto) as Mutable<HttpServerResponse>
   self.status = options.status
   self.statusText = options.statusText
@@ -1351,18 +1348,21 @@ const makeResponse = (options: {
     self.body._tag !== "Empty" &&
     (self.body.contentType || self.body.contentLength !== undefined)
   ) {
-    const newHeaders = options.headers === undefined || options.headers === Headers.empty
+    const owned = ownedHeaders !== undefined
+    const newHeaders = owned
+      ? ownedHeaders as any
+      : options.headers === undefined || options.headers === Headers.empty
       ? headersInternal.emptyMutableUnsafe() as any
       : Headers.fromRecordUnsafe({ ...options.headers }) as any
-    if (self.body.contentType && (!preferHeaders || newHeaders["content-type"] === undefined)) {
+    if (self.body.contentType && (!owned || newHeaders["content-type"] === undefined)) {
       newHeaders["content-type"] = self.body.contentType
     }
-    if (self.body.contentLength !== undefined && (!preferHeaders || newHeaders["content-length"] === undefined)) {
+    if (self.body.contentLength !== undefined && (!owned || newHeaders["content-length"] === undefined)) {
       newHeaders["content-length"] = self.body.contentLength.toString()
     }
     self.headers = newHeaders
   } else {
-    self.headers = options.headers ?? Headers.empty
+    self.headers = ownedHeaders ?? options.headers ?? Headers.empty
   }
   return self
 }

--- a/packages/effect/src/unstable/httpapi/HttpApiError.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiError.ts
@@ -458,7 +458,9 @@ export class HttpApiSchemaError extends Data.TaggedClass("HttpApiSchemaError")<{
     kind: HttpApiSchemaError["kind"],
     effect: Effect.Effect<A, Schema.SchemaError, R>
   ): Effect.Effect<A, HttpApiSchemaError, R> {
-    return Effect.mapError(effect, (error) => new HttpApiSchemaError({ kind, cause: error }))
+    // Decoders return completed Exit values for synchronous results, so map
+    // eagerly and skip the error wrapper when nothing remains to run.
+    return Effect.mapErrorEager(effect, (error) => new HttpApiSchemaError({ kind, cause: error }))
   }
 
   readonly name = "HttpApiSchemaError"

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -3411,6 +3411,78 @@ describe("Effect", () => {
       }))
   })
 
+  describe("cached", () => {
+    it.effect("runs the effect once for concurrent callers", () =>
+      Effect.gen(function*() {
+        const release = yield* Deferred.make<void>()
+        let count = 0
+        const cached = yield* Effect.cached(
+          Effect.gen(function*() {
+            count++
+            yield* Deferred.await(release)
+            return count
+          })
+        )
+
+        const fibers = yield* Effect.forEach([1, 2, 3], () => cached.pipe(Effect.forkChild({ startImmediately: true })))
+        assert.strictEqual(count, 1)
+
+        yield* Deferred.succeed(release, void 0)
+        assert.deepStrictEqual(yield* Fiber.awaitAll(fibers), [Exit.succeed(1), Exit.succeed(1), Exit.succeed(1)])
+      }))
+
+    it.effect("replays failures", () =>
+      Effect.gen(function*() {
+        let count = 0
+        const cached = yield* Effect.cached(
+          Effect.sync(() => count++).pipe(Effect.andThen(Effect.fail("boom")))
+        )
+
+        assert.deepStrictEqual(yield* Effect.exit(cached), Exit.fail("boom"))
+        assert.deepStrictEqual(yield* Effect.exit(cached), Exit.fail("boom"))
+        assert.strictEqual(count, 1)
+      }))
+
+    it.effect("interrupting a waiter leaves the owner running", () =>
+      Effect.gen(function*() {
+        const started = yield* Deferred.make<void>()
+        const release = yield* Deferred.make<void>()
+        const cached = yield* Effect.cached(
+          Deferred.succeed(started, void 0).pipe(
+            Effect.andThen(Deferred.await(release)),
+            Effect.as(42)
+          )
+        )
+
+        const owner = yield* cached.pipe(Effect.forkChild({ startImmediately: true }))
+        yield* Deferred.await(started)
+        const waiter = yield* cached.pipe(Effect.forkChild({ startImmediately: true }))
+        yield* Fiber.interrupt(waiter)
+        assert.isTrue(Exit.hasInterrupts(yield* Fiber.await(waiter)))
+
+        yield* Deferred.succeed(release, void 0)
+        assert.strictEqual(yield* Fiber.join(owner), 42)
+        assert.strictEqual(yield* cached, 42)
+      }))
+
+    it.effect("replays the owner's interrupted exit", () =>
+      Effect.gen(function*() {
+        const started = yield* Deferred.make<void>()
+        const cached = yield* Effect.cached(
+          Deferred.succeed(started, void 0).pipe(Effect.andThen(Effect.never))
+        )
+
+        const owner = yield* cached.pipe(Effect.forkChild({ startImmediately: true }))
+        yield* Deferred.await(started)
+        yield* Fiber.interrupt(owner)
+        const ownerExit = yield* Fiber.await(owner)
+        const replayedExit = yield* Effect.exit(cached)
+
+        assert.isTrue(Exit.hasInterrupts(ownerExit))
+        assert.deepStrictEqual(replayedExit, ownerExit)
+      }))
+  })
+
   describe("cachedWithTTL", () => {
     it.effect("starts ttl from value creation", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
Evaluates the six techniques from [Reducing HTTP Overhead in Effect](https://behold.kitlangton.com/published/reducing-http-overhead-in-effect) against current `main` and applies the ones that still hold.

## Applied

- **Header maps are completed in place** in `HttpServerResponse.setHeader` and `setHeaders`. `Headers.set` / `setAll` already return an independent map, so `makeResponse` now takes that owned map instead of cloning it again while filling in body-derived `content-type` / `content-length`. The `preferHeaders` flag is folded into "owned headers win".
- **Static prefix comparison** in `StaticNode.setPrefix` uses a prepared `prefix.slice(1)` and `String.prototype.startsWith` instead of a per-request char loop. Equivalent semantics on UTF-16 code units, less code.
- **`HttpApiSchemaError.wrap`** uses `Effect.mapErrorEager`. Schema decoders already return completed `Exit` values for synchronous results, so completed successes pass through untouched and completed failures are mapped without allocating an `OnFailure` wrapper.
- **`Effect.cached`** is a dedicated one-time memo (started flag, saved `Exit`, latch) instead of `cachedWithTTL(self, Duration.infinity)`. No clock read or expiry computation. Behaviour verified with a scratch probe: one shared execution across concurrent callers, failure replay, waiter interruption leaves the owner running, owner interruption is recorded for later callers, services read at first use. Node's HTTP adapter calls `Effect.cached` for every buffered request body, so this is on the request path.

## Not applied

- **Skipping URL normalization for plain paths** (`RouterImpl.find`): already covered by #7772, which added a `clean` fast path that bypasses duplicate-slash removal, decoding, and trailing-slash handling for canonical paths. The article's guards are a subset of that.
- **Using the `FileSystem` service in file-heavy handlers**: a usage recommendation for application code. No library code in the HTTP path uses `node:fs/promises`, so there is nothing to change here.

## Local micro-benchmark (Linux, Node 26.7.0, median ns/op)

| Case | Before | After |
| --- | ---: | ---: |
| `setHeader` x1 on a JSON response | 232.5 | 28.2 |
| `setHeader` x4 | 1255.4 | 211.3 |
| `Effect.cached` construct | 366.0 | 263.8 |
| `Effect.cached` construct + first run | 735.2 | 548.2 |
| `Effect.cached` replay | 215.2 | 190.0 |
| `HttpApiSchemaError.wrap` completed success | 496.5 | 120.9 |
| `HttpApiSchemaError.wrap` completed failure | 1527.0 | 1078.7 |

Whole-router `find` timings did not move with the prefix change (matches the article's own whole-router result). It is kept as a simplification with equal performance.

`pnpm lint-fix`, `pnpm check`, and the http / httpapi / FindMyWay / Effect test files pass locally.

Closes EFF-1201
