### PR TITLE
Stabilize shard release active-teardown test

### DIFF
--- a/packages/effect/test/cluster/Sharding.test.ts
+++ b/packages/effect/test/cluster/Sharding.test.ts
@@ -1126,6 +1126,8 @@ describe.concurrent("Sharding active teardowns", () => {
       assert.strictEqual(journalInterrupts(driver), 0)
     }).pipe(Effect.provide(ActiveTeardownSharding({ entityMaxIdleTime: 1 }))))
 
+  // TestClock-driven reassignment can exhaust the wall-clock timeout when
+  // this test competes with the rest of this file in CI.
   it.effect("swallows persisted interrupts when the caller's shard is released", () =>
     Effect.gen(function*() {
       const storageState = makeFailoverStorageState()
@@ -1175,7 +1177,7 @@ describe.concurrent("Sharding active teardowns", () => {
 
         assert.strictEqual(journalInterrupts(driver), 0)
       }).pipe(Effect.provide(layer), Effect.scoped)
-    }))
+    }), { concurrent: false })
 
   it.effect("treats node shutdown interrupts as transient via isShutdown", () =>
     Effect.gen(function*() {


### PR DESCRIPTION
The active-teardown shard-release test can consume Vitest's five-second wall-clock timeout when it competes with the rest of the file under Node CI load. Run that timing-sensitive case non-concurrently while preserving its TestClock-driven shard reassignment and persisted-interrupt assertions.

Local verification:

- 18/18 focused runs passed across three concurrent Vitest processes
- all 53 tests in `packages/effect/test/cluster/Sharding.test.ts` passed
- `pnpm lint-fix`
- `pnpm check`

Closes EFF-1203
