### PR TITLE
fix(AtomHttpApi): dispatch top-level group endpoints

### DIFF
--- a/.changeset/fix-atom-http-top-level-dispatch.md
+++ b/.changeset/fix-atom-http-top-level-dispatch.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `AtomHttpApi` query and mutation dispatch for top-level API groups.

--- a/packages/effect/src/unstable/reactivity/AtomHttpApi.ts
+++ b/packages/effect/src/unstable/reactivity/AtomHttpApi.ts
@@ -227,7 +227,8 @@ export const Service =
       }>()(
         Effect.fnUntraced(function*(opts) {
           const client = (yield* self) as any
-          const effect = catchErrors(client[group][endpoint]({
+          const groupClient = groups[group].topLevel ? client : client[group]
+          const effect = catchErrors(groupClient[endpoint]({
             ...opts,
             responseMode
           }) as Effect.Effect<any>)
@@ -261,7 +262,8 @@ export const Service =
     const queryFamily = Atom.family((opts: QueryKey) => {
       let atom = self.runtime.atom(self.use((client_) => {
         const client = client_ as any
-        return catchErrors(client[opts.group][opts.endpoint](opts) as Effect.Effect<
+        const groupClient = groups[opts.group].topLevel ? client : client[opts.group]
+        return catchErrors(groupClient[opts.endpoint](opts) as Effect.Effect<
           any,
           HttpClientError.HttpClientError | SchemaError
         >)

--- a/packages/effect/test/reactivity/AtomHttpApi.test.ts
+++ b/packages/effect/test/reactivity/AtomHttpApi.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Layer, Ref, Schema } from "effect"
+import { Effect, Exit, Layer, Ref, Schema } from "effect"
 import { HttpClient, HttpClientResponse } from "effect/unstable/http"
 import type * as HttpClientError from "effect/unstable/http/HttpClientError"
 import { HttpApi, HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi"
@@ -18,7 +18,46 @@ const Api = HttpApi.make("api").add(
   )
 )
 
+const TopLevelApi = HttpApi.make("top-level-api").add(
+  HttpApiGroup.make("group", { topLevel: true }).add(
+    HttpApiEndpoint.get("query", "/query"),
+    HttpApiEndpoint.post("mutation", "/mutation")
+  )
+)
+
 describe("AtomHttpApi", () => {
+  it.effect("dispatches queries and mutations for top-level groups", () =>
+    Effect.gen(function*() {
+      const requests: Array<string> = []
+      const httpClient = HttpClient.makeWith(
+        Effect.fnUntraced(function*(requestEffect) {
+          const request = yield* requestEffect
+          requests.push(request.url)
+          return HttpClientResponse.fromWeb(request, new Response(null, { status: 204 }))
+        }),
+        Effect.succeed as HttpClient.HttpClient.Preprocess<HttpClientError.HttpClientError, never>
+      )
+      const Client = AtomHttpApi.Service()("TopLevelClient", {
+        api: TopLevelApi,
+        httpClient: Layer.succeed(HttpClient.HttpClient, httpClient)
+      })
+      const registry = AtomRegistry.make()
+      const query = Client.query("group", "query", {})
+      const mutation = Client.mutation("group", "mutation")
+
+      yield* AtomRegistry.mount(registry, query)
+      yield* AtomRegistry.mount(registry, mutation)
+      registry.set(mutation, {})
+
+      const queryExit = yield* Effect.exit(AtomRegistry.getResult(registry, query, { suspendOnWaiting: true }))
+      const mutationExit = yield* Effect.exit(AtomRegistry.getResult(registry, mutation, { suspendOnWaiting: true }))
+
+      assert.deepStrictEqual(
+        { mutation: mutationExit, query: queryExit, requests },
+        { mutation: Exit.succeed(undefined), query: Exit.succeed(undefined), requests: ["/query", "/mutation"] }
+      )
+    }).pipe(Effect.scoped))
+
   it.effect("query creates a serializable atom with reactivity and retention that encodes the request", () =>
     Effect.gen(function*() {
       const requestRef = yield* Ref.make<


### PR DESCRIPTION
## Why

`AtomHttpApi.query` and `mutation` always looked up endpoints under `client[group]`. Generated clients expose endpoints from groups configured with `{ topLevel: true }` directly on `client`, so both operations failed before issuing an HTTP request.

## What changed

- Select the root client for top-level groups and the nested client for ordinary groups at both dispatch sites.
- Add a regression covering query and mutation dispatch through the public `AtomHttpApi` API.
- Add an `effect` patch changeset.

No HTTP client-core, encoding, response handling, or serialization behavior changed.

## Verification

Before the implementation change, the regression failed for both operations with `TypeError` and recorded no HTTP requests. After the change:

```sh
nix develop -c pnpm test --run packages/effect/test/reactivity/AtomHttpApi.test.ts
nix develop -c pnpm lint
nix develop -c pnpm check
git diff --check
```

All pass. The focused suite reports 2 passed tests.

Closes #7958
Closes EFF-1205
