### PR TITLE
fix(oxc): escape rewritten import specifiers

### DIFF
--- a/packages/tools/oxc/src/oxlint/rules/no-js-extension-imports.ts
+++ b/packages/tools/oxc/src/oxlint/rules/no-js-extension-imports.ts
@@ -44,7 +44,7 @@ const rule: CreateRule = {
       context.report({
         node: source,
         message: `Use "${tsExt}" extension instead of "${ext}" for relative imports`,
-        fix: (fixer: Fixer) => fixer.replaceTextRange(source.range, `"${fixedSource}"`)
+        fix: (fixer: Fixer) => fixer.replaceTextRange(source.range, JSON.stringify(fixedSource))
       })
     }
 

--- a/packages/tools/oxc/test/no-js-extension-imports.test.ts
+++ b/packages/tools/oxc/test/no-js-extension-imports.test.ts
@@ -1,4 +1,6 @@
 import rule from "@effect/oxc/oxlint/rules/no-js-extension-imports"
+import { assert } from "@effect/vitest"
+import type { Fix, Fixer, Visitor } from "@oxlint/plugins"
 import { describe, expect, it } from "vitest"
 import { runRule } from "./utils.ts"
 
@@ -19,6 +21,43 @@ describe("no-js-extension-imports", () => {
     type: "ExportNamedDeclaration",
     source: { value: source, range: [9, 9 + source.length + 2] as [number, number] },
     range: [0, 50] as [number, number]
+  })
+
+  describe("fixes", () => {
+    const declarations = [
+      ["ImportDeclaration", "import "],
+      ["ExportAllDeclaration", "export * from "],
+      ["ExportNamedDeclaration", "export { value } from "]
+    ] as const
+
+    it.each(declarations)("escapes the replacement in %s", (visitor, prefix) => {
+      const value = "./say\"hello.js"
+      const source = `${prefix}'${value}'`
+      const node = { source: { value, range: [prefix.length, source.length] } }
+      const errors = runRule(rule, visitor, node)
+      assert.strictEqual(errors.length, 1)
+      const report = errors[0] as typeof errors[number] & { fix: (fixer: Pick<Fixer, "replaceTextRange">) => Fix }
+      const fix = report.fix({ replaceTextRange: (range, text) => ({ range, text }) })
+      assert.deepStrictEqual(fix.range, [prefix.length, source.length])
+      assert.strictEqual(fix.text, JSON.stringify("./say\"hello.ts"))
+      assert.strictEqual(Function(`return ${fix.text}`)(), "./say\"hello.ts")
+    })
+
+    it.each([
+      ["./back\\file.js", "./back\\file.ts"],
+      ["./plain.js", "./plain.ts"],
+      ["./plain.jsx", "./plain.tsx"],
+      ["./plain.mjs", "./plain.mts"],
+      ["./plain.cjs", "./plain.cts"],
+      ["./say'hello.js", "./say'hello.ts"]
+    ])("preserves the decoded specifier for %s", (value, expected) => {
+      const errors = runRule(rule, "ImportDeclaration" satisfies keyof Visitor, createImportDeclaration(value))
+      assert.strictEqual(errors.length, 1)
+      const report = errors[0] as typeof errors[number] & { fix: (fixer: Pick<Fixer, "replaceTextRange">) => Fix }
+      const fix = report.fix({ replaceTextRange: (range, text) => ({ range, text }) })
+      assert.strictEqual(fix.text, JSON.stringify(expected))
+      assert.strictEqual(Function(`return ${fix.text}`)(), expected)
+    })
   })
 
   describe("ImportDeclaration", () => {

--- a/packages/tools/oxc/test/no-js-extension-imports.test.ts
+++ b/packages/tools/oxc/test/no-js-extension-imports.test.ts
@@ -1,6 +1,5 @@
 import rule from "@effect/oxc/oxlint/rules/no-js-extension-imports"
-import { assert } from "@effect/vitest"
-import type { Fix, Fixer, Visitor } from "@oxlint/plugins"
+import type { Fix, Visitor } from "@oxlint/plugins"
 import { describe, expect, it } from "vitest"
 import { runRule } from "./utils.ts"
 
@@ -23,6 +22,12 @@ describe("no-js-extension-imports", () => {
     range: [0, 50] as [number, number]
   })
 
+  const applyFix = (visitor: keyof Visitor, node: unknown): Fix => {
+    const errors = runRule(rule, visitor, node)
+    expect(errors).toHaveLength(1)
+    return errors[0].fix!({ replaceTextRange: (range, text) => ({ range, text }) })
+  }
+
   describe("fixes", () => {
     const declarations = [
       ["ImportDeclaration", "import "],
@@ -34,29 +39,22 @@ describe("no-js-extension-imports", () => {
       const value = "./say\"hello.js"
       const source = `${prefix}'${value}'`
       const node = { source: { value, range: [prefix.length, source.length] } }
-      const errors = runRule(rule, visitor, node)
-      assert.strictEqual(errors.length, 1)
-      const report = errors[0] as typeof errors[number] & { fix: (fixer: Pick<Fixer, "replaceTextRange">) => Fix }
-      const fix = report.fix({ replaceTextRange: (range, text) => ({ range, text }) })
-      assert.deepStrictEqual(fix.range, [prefix.length, source.length])
-      assert.strictEqual(fix.text, JSON.stringify("./say\"hello.ts"))
-      assert.strictEqual(Function(`return ${fix.text}`)(), "./say\"hello.ts")
+      const fix = applyFix(visitor, node)
+      expect(fix.range).toEqual([prefix.length, source.length])
+      expect(Function(`return ${fix.text}`)()).toBe("./say\"hello.ts")
     })
 
     it.each([
       ["./back\\file.js", "./back\\file.ts"],
+      ["./a\nb.js", "./a\nb.ts"],
       ["./plain.js", "./plain.ts"],
       ["./plain.jsx", "./plain.tsx"],
       ["./plain.mjs", "./plain.mts"],
       ["./plain.cjs", "./plain.cts"],
       ["./say'hello.js", "./say'hello.ts"]
     ])("preserves the decoded specifier for %s", (value, expected) => {
-      const errors = runRule(rule, "ImportDeclaration" satisfies keyof Visitor, createImportDeclaration(value))
-      assert.strictEqual(errors.length, 1)
-      const report = errors[0] as typeof errors[number] & { fix: (fixer: Pick<Fixer, "replaceTextRange">) => Fix }
-      const fix = report.fix({ replaceTextRange: (range, text) => ({ range, text }) })
-      assert.strictEqual(fix.text, JSON.stringify(expected))
-      assert.strictEqual(Function(`return ${fix.text}`)(), expected)
+      const fix = applyFix("ImportDeclaration", createImportDeclaration(value))
+      expect(Function(`return ${fix.text}`)()).toBe(expected)
     })
   })
 

--- a/packages/tools/oxc/test/utils.ts
+++ b/packages/tools/oxc/test/utils.ts
@@ -1,8 +1,9 @@
-import type { CreateRule, Visitor } from "@oxlint/plugins"
+import type { CreateRule, Fix, Fixer, Visitor } from "@oxlint/plugins"
 
 export interface ReportedError {
   node: unknown
   message: string
+  fix?: (fixer: Pick<Fixer, "replaceTextRange">) => Fix
 }
 
 export interface TestContextOptions {


### PR DESCRIPTION
## Why

A valid relative import such as `import './say"hello.js'` is rewritten as invalid `import "./say"hello.ts"`. The fixer inserts a decoded module name between double quotes without escaping it. Backslashes can silently change the decoded path, and control characters such as newlines can produce invalid source.

## What changed

Encode the replacement as a JavaScript string literal with `JSON.stringify`. Keep the existing extension mapping, diagnostics, replacement ranges, and shared handling of imports and re-exports.

## Scope

One fixer expression and behavior-level callback tests, preserving all 14 existing tests. The regression coverage checks quotes, backslashes, newlines, ordinary suffix mappings, and both import and re-export visitors. No changeset because `@effect/oxc` is private.

## Verification

```sh
pnpm lint-fix
pnpm test --run packages/tools/oxc/test/no-js-extension-imports.test.ts
pnpm test --run packages/tools/oxc/test
pnpm check
git diff --check
```

The targeted file passes 24/24 tests, and the full `packages/tools/oxc/test` suite passes 57/57 tests.

Closes #7974
Closes EFF-1213

## Audit

Runtime correctness audit; intended label: `audit`.
