### PR TITLE
Skip unencodable atoms during dehydration

### DIFF
--- a/.changeset/isolate-unencodable-hydration.md
+++ b/.changeset/isolate-unencodable-hydration.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Prevent unencodable atom values from aborting dehydration of the rest of an atom registry.

--- a/packages/effect/src/unstable/reactivity/Hydration.ts
+++ b/packages/effect/src/unstable/reactivity/Hydration.ts
@@ -44,6 +44,20 @@ export interface DehydratedAtomValue extends DehydratedAtom {
   readonly resultPromise?: Promise<unknown> | undefined
 }
 
+const Skipped = Symbol.for("effect/reactivity/Hydration/Skipped")
+
+const encodeOrSkip = (
+  atom: Atom.Atom<any> & Atom.Serializable<any>,
+  value: unknown
+): unknown => {
+  try {
+    return atom[Atom.SerializableTypeId].encode(value)
+  } catch (error) {
+    if (Schema.isSchemaError(error)) return Skipped
+    throw error
+  }
+}
+
 /**
  * Encodes the serializable atoms currently stored in a registry into dehydrated
  * state.
@@ -51,9 +65,10 @@ export interface DehydratedAtomValue extends DehydratedAtom {
  * **Details**
  *
  * Only atoms marked with `Atom.serializable` whose current values can be encoded
- * are included. `encodeInitialAs` controls whether `AsyncResult.Initial` values
- * are ignored, encoded as values, or represented by promises that resolve when
- * the atom leaves the initial state.
+ * are included. Atoms that fail schema encoding are skipped without throwing.
+ * `encodeInitialAs` controls whether `AsyncResult.Initial` values are ignored,
+ * encoded as values, or represented by promises that resolve when the atom
+ * leaves the initial state.
  *
  * @category dehydration
  * @since 4.0.0
@@ -76,13 +91,8 @@ export const dehydrate = (
     const value = node.value()
     const isInitial = AsyncResult.isAsyncResult(value) && AsyncResult.isInitial(value)
     if (encodeInitialResultMode === "ignore" && isInitial) return
-    let encodedValue: unknown
-    try {
-      encodedValue = atom[Atom.SerializableTypeId].encode(value)
-    } catch (error) {
-      if (Schema.isSchemaError(error)) return
-      throw error
-    }
+    const encodedValue = encodeOrSkip(atom, value)
+    if (encodedValue === Skipped) return
 
     // Create a promise that resolves when the atom moves out of Initial state
     let resultPromise: Promise<unknown> | undefined
@@ -90,8 +100,8 @@ export const dehydrate = (
       resultPromise = new Promise((resolve) => {
         const unsubscribe = registry.subscribe(atom, (newValue) => {
           if (AsyncResult.isAsyncResult(newValue) && !AsyncResult.isInitial(newValue)) {
-            resolve(atom[Atom.SerializableTypeId].encode(newValue))
             unsubscribe()
+            resolve(encodeOrSkip(atom, newValue))
           }
         })
       })
@@ -144,6 +154,7 @@ export const hydrate = (
     // and we should wait for it to resolve to a non-Initial state, then update the registry
     if (!datom.resultPromise) continue
     datom.resultPromise.then((resolvedValue) => {
+      if (resolvedValue === Skipped) return
       // Try to update the existing node directly instead of using setSerializable
       const nodes = registry.getNodes()
       const node = nodes.get(datom.key)

--- a/packages/effect/src/unstable/reactivity/Hydration.ts
+++ b/packages/effect/src/unstable/reactivity/Hydration.ts
@@ -10,6 +10,7 @@
  *
  * @since 4.0.0
  */
+import * as Schema from "../../Schema.ts"
 import * as AsyncResult from "./AsyncResult.ts"
 import * as Atom from "./Atom.ts"
 import type * as AtomRegistry from "./AtomRegistry.ts"
@@ -49,9 +50,10 @@ export interface DehydratedAtomValue extends DehydratedAtom {
  *
  * **Details**
  *
- * Only atoms marked with `Atom.serializable` are included. `encodeInitialAs`
- * controls whether `AsyncResult.Initial` values are ignored, encoded as values, or
- * represented by promises that resolve when the atom leaves the initial state.
+ * Only atoms marked with `Atom.serializable` whose current values can be encoded
+ * are included. `encodeInitialAs` controls whether `AsyncResult.Initial` values
+ * are ignored, encoded as values, or represented by promises that resolve when
+ * the atom leaves the initial state.
  *
  * @category dehydration
  * @since 4.0.0
@@ -74,7 +76,13 @@ export const dehydrate = (
     const value = node.value()
     const isInitial = AsyncResult.isAsyncResult(value) && AsyncResult.isInitial(value)
     if (encodeInitialResultMode === "ignore" && isInitial) return
-    const encodedValue = atom[Atom.SerializableTypeId].encode(value)
+    let encodedValue: unknown
+    try {
+      encodedValue = atom[Atom.SerializableTypeId].encode(value)
+    } catch (error) {
+      if (Schema.isSchemaError(error)) return
+      throw error
+    }
 
     // Create a promise that resolves when the atom moves out of Initial state
     let resultPromise: Promise<unknown> | undefined

--- a/packages/effect/test/reactivity/AtomRpc.test.ts
+++ b/packages/effect/test/reactivity/AtomRpc.test.ts
@@ -1,7 +1,7 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Effect, Layer, Schema } from "effect"
-import { Atom, AtomRegistry, AtomRpc, Hydration } from "effect/unstable/reactivity"
-import { Rpc, RpcGroup } from "effect/unstable/rpc"
+import { AsyncResult, Atom, AtomRegistry, AtomRpc, Hydration } from "effect/unstable/reactivity"
+import { Rpc, RpcClient, RpcGroup, RpcMiddleware, type RpcSerialization } from "effect/unstable/rpc"
 
 const Group = RpcGroup.make(
   Rpc.make("getUser", {
@@ -95,5 +95,66 @@ describe("AtomRpc", () => {
       assert.strictEqual(dehydrated[0]!.key, key)
 
       unmount()
+    }))
+
+  it.effect("dehydrates the rest of the registry when client middleware fails", () =>
+    Effect.gen(function*() {
+      class ClientFailure extends Schema.Error<ClientFailure>("ClientFailure")({
+        _tag: Schema.tag("ClientFailure")
+      }) {}
+
+      class ClientMiddleware extends RpcMiddleware.Service<ClientMiddleware, {
+        clientError: ClientFailure
+      }>()("ClientMiddleware", {
+        requiredForClient: true
+      }) {}
+
+      const group = RpcGroup.make(
+        Rpc.make("getUser", {
+          success: Schema.String
+        }).middleware(ClientMiddleware)
+      )
+      const protocol = Layer.mergeAll(
+        Layer.effect(
+          RpcClient.Protocol,
+          RpcClient.Protocol.make(() =>
+            Effect.succeed({
+              send: () => Effect.die("unexpected request"),
+              supportsAck: false,
+              supportsTransferables: false,
+              codecFor: Schema.toCodecJson as RpcSerialization.CodecFor
+            })
+          )
+        ),
+        RpcMiddleware.layerClient(
+          ClientMiddleware,
+          () => Effect.fail(new ClientFailure({}))
+        )
+      )
+      const Client = AtomRpc.Service()("ClientWithMiddleware", {
+        group,
+        protocol
+      })
+      const failedAtom = Client.query("getUser", undefined, {
+        serializationKey: "failed"
+      })
+      const unaffectedAtom = Atom.make(42).pipe(
+        Atom.serializable({
+          key: "unaffected",
+          schema: Schema.Number
+        })
+      )
+      const registry = AtomRegistry.make()
+      const unmountFailed = registry.mount(failedAtom)
+      const unmountUnaffected = registry.mount(unaffectedAtom)
+      yield* Effect.yieldNow
+      yield* Effect.yieldNow
+
+      assert(AsyncResult.isFailure(registry.get(failedAtom)))
+      const dehydrated = Hydration.toValues(Hydration.dehydrate(registry))
+      assert.strictEqual(dehydrated.find((entry) => entry.key === "unaffected")?.value, 42)
+
+      unmountUnaffected()
+      unmountFailed()
     }))
 })

--- a/packages/effect/test/reactivity/AtomRpc.test.ts
+++ b/packages/effect/test/reactivity/AtomRpc.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Layer, Schema } from "effect"
+import { Deferred, Effect, Layer, Schema } from "effect"
 import { AsyncResult, Atom, AtomRegistry, AtomRpc, Hydration } from "effect/unstable/reactivity"
 import { Rpc, RpcClient, RpcGroup, RpcMiddleware, type RpcSerialization } from "effect/unstable/rpc"
 
@@ -14,6 +14,40 @@ const Group = RpcGroup.make(
     })
   })
 )
+
+class ClientFailure extends Schema.Error<ClientFailure>("ClientFailure")({
+  _tag: Schema.tag("ClientFailure")
+}) {}
+
+class ClientMiddleware extends RpcMiddleware.Service<ClientMiddleware, {
+  clientError: ClientFailure
+}>()("ClientMiddleware", {
+  requiredForClient: true
+}) {}
+
+const ClientMiddlewareGroup = RpcGroup.make(
+  Rpc.make("getUser", {
+    success: Schema.String
+  }).middleware(ClientMiddleware)
+)
+
+const makeClientMiddlewareProtocol = (
+  middleware: RpcMiddleware.RpcMiddlewareClient<never, ClientFailure, never>
+) =>
+  Layer.mergeAll(
+    Layer.effect(
+      RpcClient.Protocol,
+      RpcClient.Protocol.make(() =>
+        Effect.succeed({
+          send: () => Effect.die("unexpected request"),
+          supportsAck: false,
+          supportsTransferables: false,
+          codecFor: Schema.toCodecJson as RpcSerialization.CodecFor
+        })
+      )
+    ),
+    RpcMiddleware.layerClient(ClientMiddleware, middleware)
+  )
 
 describe("AtomRpc", () => {
   it.effect("query creates a serializable atom with reactivity and retention", () =>
@@ -99,41 +133,9 @@ describe("AtomRpc", () => {
 
   it.effect("dehydrates the rest of the registry when client middleware fails", () =>
     Effect.gen(function*() {
-      class ClientFailure extends Schema.Error<ClientFailure>("ClientFailure")({
-        _tag: Schema.tag("ClientFailure")
-      }) {}
-
-      class ClientMiddleware extends RpcMiddleware.Service<ClientMiddleware, {
-        clientError: ClientFailure
-      }>()("ClientMiddleware", {
-        requiredForClient: true
-      }) {}
-
-      const group = RpcGroup.make(
-        Rpc.make("getUser", {
-          success: Schema.String
-        }).middleware(ClientMiddleware)
-      )
-      const protocol = Layer.mergeAll(
-        Layer.effect(
-          RpcClient.Protocol,
-          RpcClient.Protocol.make(() =>
-            Effect.succeed({
-              send: () => Effect.die("unexpected request"),
-              supportsAck: false,
-              supportsTransferables: false,
-              codecFor: Schema.toCodecJson as RpcSerialization.CodecFor
-            })
-          )
-        ),
-        RpcMiddleware.layerClient(
-          ClientMiddleware,
-          () => Effect.fail(new ClientFailure({}))
-        )
-      )
       const Client = AtomRpc.Service()("ClientWithMiddleware", {
-        group,
-        protocol
+        group: ClientMiddlewareGroup,
+        protocol: makeClientMiddlewareProtocol(() => Effect.fail(new ClientFailure({})))
       })
       const failedAtom = Client.query("getUser", undefined, {
         serializationKey: "failed"
@@ -152,9 +154,51 @@ describe("AtomRpc", () => {
 
       assert(AsyncResult.isFailure(registry.get(failedAtom)))
       const dehydrated = Hydration.toValues(Hydration.dehydrate(registry))
+      assert.isUndefined(dehydrated.find((entry) => entry.key === "AtomRpc:getUser:failed"))
       assert.strictEqual(dehydrated.find((entry) => entry.key === "unaffected")?.value, 42)
 
       unmountUnaffected()
+      unmountFailed()
+    }))
+
+  it.effect("settles promise dehydration when client middleware later fails", () =>
+    Effect.gen(function*() {
+      const failMiddleware = yield* Deferred.make<void>()
+      const Client = AtomRpc.Service()("ClientWithDeferredMiddleware", {
+        group: ClientMiddlewareGroup,
+        protocol: makeClientMiddlewareProtocol(() =>
+          Deferred.await(failMiddleware).pipe(
+            Effect.andThen(Effect.fail(new ClientFailure({})))
+          )
+        )
+      })
+      const failedAtom = Client.query("getUser", undefined, {
+        serializationKey: "deferred-failure"
+      })
+      const registry = AtomRegistry.make()
+      const unmountFailed = registry.mount(failedAtom)
+
+      assert(AsyncResult.isInitial(registry.get(failedAtom)))
+      const dehydrated = Hydration.toValues(Hydration.dehydrate(registry, {
+        encodeInitialAs: "promise"
+      }))
+      const resultPromise = dehydrated.find((entry) => entry.key === "AtomRpc:getUser:deferred-failure")
+        ?.resultPromise
+      assert.isDefined(resultPromise)
+
+      let notifications = 0
+      const unsubscribe = registry.subscribe(failedAtom, () => notifications++)
+      const hydratedRegistry = AtomRegistry.make()
+      Hydration.hydrate(hydratedRegistry, dehydrated)
+
+      yield* Deferred.succeed(failMiddleware, undefined)
+      yield* Effect.promise(() => resultPromise).pipe(Effect.timeout("1 second"))
+
+      assert.strictEqual(notifications, 1)
+      const unmountHydrated = hydratedRegistry.mount(failedAtom)
+
+      unmountHydrated()
+      unsubscribe()
       unmountFailed()
     }))
 })


### PR DESCRIPTION
Prevents a schema-unencodable atom value from aborting dehydration of the entire registry. `Hydration.dehydrate` now skips that entry and continues, while non-schema exceptions still surface.

Client middleware errors are type-only and have no runtime schema, so isolation is the focused fix. Both the immediate path and `encodeInitialAs: "promise"` use the same encode-or-skip helper. Deferred failures settle the result promise without poisoning hydration state or blocking later registry subscribers.

Includes regression coverage for immediate and deferred client-middleware failures, an explicit assertion that the failed atom is omitted, and a patch changeset.

Validation:

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`
- `nix develop -c pnpm jsdocs --check`
- `nix develop -c pnpm test --run packages/effect/test/reactivity/AtomRpc.test.ts` (3 tests passed)

Closes EFF-1222
