### PR TITLE
fix(platform): preserve multipart limit failures

### DIFF
--- a/.changeset/old-trees-worry.md
+++ b/.changeset/old-trees-worry.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Fix multipart limit failures being silently ignored.

--- a/packages/platform/src/Multipart.ts
+++ b/packages/platform/src/Multipart.ts
@@ -336,7 +336,9 @@ export const makeChannel = <IE>(
           exit = Option.some(Exit.fail(convertError(error_)))
         },
         onDone() {
-          exit = Option.some(Exit.void)
+          if (Option.isNone(exit)) {
+            exit = Option.some(Exit.void)
+          }
         }
       })
 

--- a/packages/platform/test/Multipart.test.ts
+++ b/packages/platform/test/Multipart.test.ts
@@ -1,9 +1,63 @@
 import * as Multipart from "@effect/platform/Multipart"
 import { describe, test } from "@effect/vitest"
-import { deepStrictEqual } from "@effect/vitest/utils"
-import { Chunk, Effect, identity, pipe, Stream, Unify } from "effect"
+import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
+import { Chunk, Effect, identity, Option, pipe, Stream, Unify } from "effect"
 
 describe("Multipart", () => {
+  test("fails when maxFileSize is exceeded, including when the terminator follows in the same chunk", () =>
+    Effect.gen(function*() {
+      const boundary = "X"
+      const body = `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="file"; filename="big.bin"\r\n` +
+        `Content-Type: application/octet-stream\r\n\r\n` +
+        "A".repeat(100) +
+        `\r\n--${boundary}--\r\n`
+      const encoder = new TextEncoder()
+      const terminatorIndex = body.indexOf(`\r\n--${boundary}--`)
+
+      for (
+        const chunks of [
+          Chunk.of(encoder.encode(body)),
+          Chunk.make(encoder.encode(body.slice(0, terminatorIndex)), encoder.encode(body.slice(terminatorIndex)))
+        ]
+      ) {
+        const error = yield* pipe(
+          Stream.fromChunk(chunks),
+          Stream.pipeThroughChannel(
+            Multipart.makeChannel({ "content-type": `multipart/form-data; boundary=${boundary}` })
+          ),
+          Stream.runCollect,
+          Multipart.withLimits({ maxFileSize: Option.some(10) }),
+          Effect.flip
+        )
+
+        strictEqual(error.reason, "FileTooLarge")
+      }
+    }).pipe(Effect.runPromise))
+
+  test("fails when maxParts is exceeded", () =>
+    Effect.gen(function*() {
+      const boundary = "X"
+      const part = (name: string) =>
+        `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="${name}"; filename="${name}.bin"\r\n` +
+        `Content-Type: application/octet-stream\r\n\r\n` +
+        "A\r\n"
+      const body = part("a") + part("b") + part("c") + `--${boundary}--\r\n`
+
+      const error = yield* pipe(
+        Stream.fromChunk(Chunk.of(new TextEncoder().encode(body))),
+        Stream.pipeThroughChannel(
+          Multipart.makeChannel({ "content-type": `multipart/form-data; boundary=${boundary}` })
+        ),
+        Stream.runCollect,
+        Multipart.withLimits({ maxParts: Option.some(2) }),
+        Effect.flip
+      )
+
+      strictEqual(error.reason, "TooManyParts")
+    }).pipe(Effect.runPromise))
+
   test("it parses", () =>
     Effect.gen(function*() {
       const data = new globalThis.FormData()


### PR DESCRIPTION
Fixes #7996.

`multipasta` invokes `onDone` after reporting a limit violation through `onError`. In the v3 multipart channel, `onDone` unconditionally replaced the captured `MultipartError` with successful completion, so `maxFileSize` and `maxParts` could be silently ignored.

Record normal completion only when no parser failure has already been captured.

Tests cover:
- `maxFileSize` with both a single input chunk and a boundary split after the violation
- `maxParts` with a three-part body and a limit of two

Verified with:
- `pnpm vitest run packages/platform/test/Multipart.test.ts`
- `pnpm --filter @effect/platform check`