### PR TITLE
fix(Effect): preserve causes for unmatched reasons

### DIFF
--- a/.changeset/effect-unmatched-reason-preservation.md
+++ b/.changeset/effect-unmatched-reason-preservation.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve the original cause in `Effect.catchReason` and `Effect.catchReasons` when no nested reason matches and no fallback is provided.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -3184,7 +3184,10 @@ export const catchReason: {
   > =>
     catchIf(
       self,
-      ((e: any) => isTagged(e, errorTag) && hasProperty(e, "reason")) as any,
+      ((e: any) =>
+        isTagged(e, errorTag) &&
+        hasProperty(e, "reason") &&
+        (orElse !== undefined || isTagged(e.reason, reasonTag))) as any,
       (e: any): Effect.Effect<A2 | A3, E | E2 | E3, R2 | R3> => {
         const reason = e.reason as any
         if (isTagged(reason, reasonTag)) return f(reason as any, e)
@@ -3284,7 +3287,8 @@ export const catchReasons: {
       isTagged(e, errorTag) &&
       hasProperty(e, "reason") &&
       hasProperty(e.reason, "_tag") &&
-      isString(e.reason._tag)) as any,
+      isString(e.reason._tag) &&
+      (orElse !== undefined || (keys ??= Object.keys(cases)).includes(e.reason._tag))) as any,
     (e: any) => {
       const reason = e.reason
       keys ??= Object.keys(cases)

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -3318,6 +3318,23 @@ describe("Effect", () => {
         assertExitFailure(exit, Cause.fail(new AiError({ reason })))
       }))
 
+    it.effect("preserves the cause for a non-matching reason", () =>
+      Effect.gen(function*() {
+        const error = new AiError({ reason: new QuotaExceededError({ limit: 100 }) })
+        const result = yield* Effect.gen(function*() {
+          yield* Effect.addFinalizer(() => Effect.die("finalizer failure"))
+          return yield* Effect.fail(error)
+        }).pipe(
+          Effect.scoped,
+          Effect.catchReason("AiError", "RateLimitError", () => Effect.succeed("no")),
+          Effect.exit
+        )
+        assert.deepStrictEqual(
+          result,
+          Exit.failCause(Cause.combine(Cause.fail(error), Cause.die("finalizer failure")))
+        )
+      }))
+
     it.effect("ignores non-matching parent tag", () =>
       Effect.gen(function*() {
         const error = new OtherError({ message: "test" })
@@ -3390,6 +3407,25 @@ describe("Effect", () => {
           Effect.exit
         )
         assertExitFailure(exit, Cause.fail(new AiError({ reason })))
+      }))
+
+    it.effect("preserves the cause for an unhandled reason", () =>
+      Effect.gen(function*() {
+        const error = new AiError({ reason: new QuotaExceededError({ limit: 100 }) })
+        const result = yield* Effect.gen(function*() {
+          yield* Effect.addFinalizer(() => Effect.die("finalizer failure"))
+          return yield* Effect.fail(error)
+        }).pipe(
+          Effect.scoped,
+          Effect.catchReasons("AiError", {
+            RateLimitError: () => Effect.succeed("handled")
+          }),
+          Effect.exit
+        )
+        assert.deepStrictEqual(
+          result,
+          Exit.failCause(Cause.combine(Cause.fail(error), Cause.die("finalizer failure")))
+        )
       }))
   })
 


### PR DESCRIPTION
## Why

When the parent error tag matches but no nested reason handler or fallback is selected, `catchReason` and `catchReasons` rebuild a singleton failure. This drops accompanying failure reasons, including finalizer defects, even though no recovery ran.

## What changed

Tightened the two selection predicates so an unmatched reason without a fallback leaves the original cause untouched. Matching handlers and explicit fallbacks keep their existing behavior.

Added focused scoped regressions for both APIs to the existing `Effect` test suite and included an `effect` patch changeset.

## Verification

```sh
pnpm lint-fix
pnpm test --run packages/effect/test/Effect.test.ts --project effect --maxWorkers 1 --no-file-parallelism
pnpm check
```

Closes EFF-1234
Closes #8006
