### PR TITLE
Fix Deno forceKillAfter under TestClock

### DIFF
--- a/packages/effect/test/unstable/process/ChildProcessSpawnerTest.ts
+++ b/packages/effect/test/unstable/process/ChildProcessSpawnerTest.ts
@@ -1,6 +1,4 @@
 import { assert, describe, it } from "@effect/vitest"
-import * as Clock from "effect/Clock"
-import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as FileSystem from "effect/FileSystem"
@@ -34,9 +32,6 @@ const decodeByteStream = Effect.fnUntraced(
     return new TextDecoder().decode(result).trim()
   }
 )
-
-const nativeClock = Clock.Clock.defaultValue()
-const liveSleep = (millis: number) => nativeClock.sleep(Duration.millis(millis))
 
 export const suite = (
   name: string,
@@ -501,7 +496,7 @@ export const suite = (
                   killSignal: "SIGTERM",
                   forceKillAfter: "50 millis"
                 }).pipe(Effect.as(true)),
-                liveSleep(1_000).pipe(Effect.as(false))
+                Effect.sleep("1 second").pipe(TestClock.withLive, Effect.as(false))
               )
 
               assert.isTrue(completed)

--- a/packages/effect/test/unstable/process/ChildProcessSpawnerTest.ts
+++ b/packages/effect/test/unstable/process/ChildProcessSpawnerTest.ts
@@ -33,6 +33,12 @@ const decodeByteStream = Effect.fnUntraced(
   }
 )
 
+const liveSleep = (millis: number) =>
+  Effect.callback<void>((resume) => {
+    const timer = setTimeout(() => resume(Effect.void), millis)
+    return Effect.sync(() => clearTimeout(timer))
+  })
+
 export const suite = (
   name: string,
   layer: Layer.Layer<ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path>,
@@ -491,16 +497,12 @@ export const suite = (
                 TestClock.withLive
               )
 
-              const completed = yield* handle.kill({
-                killSignal: "SIGTERM",
-                forceKillAfter: "50 millis"
-              }).pipe(
-                Effect.as(true),
-                Effect.timeoutOrElse({
-                  duration: "1 second",
-                  orElse: () => Effect.succeed(false)
-                }),
-                TestClock.withLive
+              const completed = yield* Effect.raceFirst(
+                handle.kill({
+                  killSignal: "SIGTERM",
+                  forceKillAfter: "50 millis"
+                }).pipe(Effect.as(true)),
+                liveSleep(1_000).pipe(Effect.as(false))
               )
 
               assert.isTrue(completed)

--- a/packages/effect/test/unstable/process/ChildProcessSpawnerTest.ts
+++ b/packages/effect/test/unstable/process/ChildProcessSpawnerTest.ts
@@ -1,4 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
+import * as Clock from "effect/Clock"
+import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as FileSystem from "effect/FileSystem"
@@ -33,11 +35,8 @@ const decodeByteStream = Effect.fnUntraced(
   }
 )
 
-const liveSleep = (millis: number) =>
-  Effect.callback<void>((resume) => {
-    const timer = setTimeout(() => resume(Effect.void), millis)
-    return Effect.sync(() => clearTimeout(timer))
-  })
+const nativeClock = Clock.Clock.defaultValue()
+const liveSleep = (millis: number) => nativeClock.sleep(Duration.millis(millis))
 
 export const suite = (
   name: string,

--- a/packages/platform/deno/src/DenoChildProcessSpawner.ts
+++ b/packages/platform/deno/src/DenoChildProcessSpawner.ts
@@ -8,6 +8,7 @@
  * @since 4.0.0
  */
 import type * as Arr from "effect/Array"
+import * as Clock from "effect/Clock"
 import * as Deferred from "effect/Deferred"
 import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
@@ -28,6 +29,8 @@ import {
   makeHandle,
   ProcessId
 } from "effect/unstable/process/ChildProcessSpawner"
+
+const nativeClock = Clock.Clock.defaultValue()
 
 const commandString = (command: ChildProcess.Command): string => {
   const { commands } = flattenCommand(command)
@@ -198,16 +201,6 @@ const make = Effect.gen(function*() {
       catch: (cause) => toPlatformError("kill", cause, command)
     })
 
-  const nativeSleep = (duration: Duration.Input): Effect.Effect<void> => {
-    const millis = Duration.toMillis(duration)
-    if (millis === Infinity) return Effect.never
-    if (millis <= 0) return Effect.void
-    return Effect.callback<void>((resume) => {
-      const timer = setTimeout(() => resume(Effect.void), millis)
-      return Effect.sync(() => clearTimeout(timer))
-    })
-  }
-
   const withTimeout = (
     childProcess: Deno.ChildProcess,
     command: ChildProcess.StandardCommand,
@@ -225,7 +218,9 @@ const make = Effect.gen(function*() {
       ? kill(command, childProcess, killSignal)
       : Effect.raceFirst(
         kill(command, childProcess, killSignal),
-        nativeSleep(options.forceKillAfter).pipe(Effect.andThen(kill(command, childProcess, "SIGKILL")))
+        nativeClock.sleep(Duration.fromInputUnsafe(options.forceKillAfter)).pipe(
+          Effect.andThen(kill(command, childProcess, "SIGKILL"))
+        )
       )
   }
 

--- a/packages/platform/deno/src/DenoChildProcessSpawner.ts
+++ b/packages/platform/deno/src/DenoChildProcessSpawner.ts
@@ -9,6 +9,7 @@
  */
 import type * as Arr from "effect/Array"
 import * as Deferred from "effect/Deferred"
+import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as Layer from "effect/Layer"
@@ -197,6 +198,16 @@ const make = Effect.gen(function*() {
       catch: (cause) => toPlatformError("kill", cause, command)
     })
 
+  const nativeSleep = (duration: Duration.Input): Effect.Effect<void> => {
+    const millis = Duration.toMillis(duration)
+    if (millis === Infinity) return Effect.never
+    if (millis <= 0) return Effect.void
+    return Effect.callback<void>((resume) => {
+      const timer = setTimeout(() => resume(Effect.void), millis)
+      return Effect.sync(() => clearTimeout(timer))
+    })
+  }
+
   const withTimeout = (
     childProcess: Deno.ChildProcess,
     command: ChildProcess.StandardCommand,
@@ -212,10 +223,10 @@ const make = Effect.gen(function*() {
     const killSignal = options?.killSignal ?? "SIGTERM"
     return options?.forceKillAfter === undefined
       ? kill(command, childProcess, killSignal)
-      : Effect.timeoutOrElse(kill(command, childProcess, killSignal), {
-        duration: options.forceKillAfter,
-        orElse: () => kill(command, childProcess, "SIGKILL")
-      })
+      : Effect.raceFirst(
+        kill(command, childProcess, killSignal),
+        nativeSleep(options.forceKillAfter).pipe(Effect.andThen(kill(command, childProcess, "SIGKILL")))
+      )
   }
 
   const getSourceStream = (


### PR DESCRIPTION
## Summary

- add a shared regression that runs the `forceKillAfter` assertion under `TestClock` while bounding the test with an interruptible native timer
- make the Deno spawner's escalation timer use native time, so `SIGKILL` is sent even when the Effect clock does not advance

## Verification

- `nix develop -c deno task test --run packages/platform/deno/test/DenoChildProcessSpawner.test.ts` (62 passed, 10 skipped)
- `nix develop -c pnpm test --run packages/platform/node-shared/test/NodeChildProcessSpawner.test.ts` (75 passed)
- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`

Closes EFF-1228
