### PR TITLE
fix(platform-bun): preserve routes across handler reloads

### DIFF
--- a/.changeset/quiet-buns-route.md
+++ b/.changeset/quiet-buns-route.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-bun": patch
+---
+
+Preserve configured Bun routes when Effect HTTP handlers are installed or restored.

--- a/packages/platform/bun/src/BunHttpServer.ts
+++ b/packages/platform/bun/src/BunHttpServer.ts
@@ -186,11 +186,17 @@ export const make = Effect.fnUntraced(
         yield* Scope.addFinalizerExit(serveScope, () => {
           const index = handlerStack.indexOf(handler)
           if (index !== -1) handlerStack.splice(index, 1)
-          server.reload({ fetch: handlerStack[handlerStack.length - 1] })
+          server.reload({
+            fetch: handlerStack[handlerStack.length - 1],
+            ...(options.routes === undefined ? undefined : { routes: options.routes })
+          })
           return handlerStack.length === 1 ? preemptiveShutdown : Effect.void
         })
         handlerStack.push(handler)
-        server.reload({ fetch: handler })
+        server.reload({
+          fetch: handler,
+          ...(options.routes === undefined ? undefined : { routes: options.routes })
+        })
       })
     })
   }

--- a/packages/platform/bun/test/BunHttpServer.test.ts
+++ b/packages/platform/bun/test/BunHttpServer.test.ts
@@ -161,6 +161,31 @@ describe("BunHttpServer", () => {
       assert.strictEqual(yield* fetchText(url), "first")
     }))
 
+  it.effect("preserves configured routes while changing handlers", () =>
+    Effect.gen(function*() {
+      const ownerScope = yield* Effect.scope
+      const server = yield* BunHttpServer.make({
+        hostname: "127.0.0.1",
+        port: 0,
+        routes: { "/static": new Response("static") }
+      })
+      const firstScope = yield* Scope.fork(ownerScope)
+      const secondScope = yield* Scope.fork(ownerScope)
+      const url = HttpServer.formatAddress(server.address)
+
+      yield* server.serve(Effect.succeed(HttpServerResponse.text("first"))).pipe(Scope.provide(firstScope))
+      assert.strictEqual(yield* fetchText(`${url}/static`), "static")
+      assert.strictEqual(yield* fetchText(`${url}/fallback`), "first")
+
+      yield* server.serve(Effect.succeed(HttpServerResponse.text("second"))).pipe(Scope.provide(secondScope))
+      assert.strictEqual(yield* fetchText(`${url}/static`), "static")
+      assert.strictEqual(yield* fetchText(`${url}/fallback`), "second")
+
+      yield* Scope.close(secondScope, Exit.void)
+      assert.strictEqual(yield* fetchText(`${url}/static`), "static")
+      assert.strictEqual(yield* fetchText(`${url}/fallback`), "first")
+    }))
+
   it.effect("compresses outgoing WebSocket messages when per-message deflate is negotiated", () =>
     Effect.gen(function*() {
       const payload = "a".repeat(4_096)


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Keep configured Bun routes active when HTTP handlers are changed or restored. Adds regression coverage for both paths.

## Related

- N/A