### PR TITLE
fix(platform-bun): preserve readable stream failures

### DIFF
--- a/.changeset/bun-stream-preserve-failure.md
+++ b/.changeset/bun-stream-preserve-failure.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-bun": patch
+---
+
+Preserve mapped errors from Bun readable streams.

--- a/packages/platform/bun/src/BunStream.ts
+++ b/packages/platform/bun/src/BunStream.ts
@@ -13,7 +13,7 @@ import * as Arr from "effect/Array"
 import * as Cause from "effect/Cause"
 import * as Channel from "effect/Channel"
 import * as Effect from "effect/Effect"
-import type { LazyArg } from "effect/Function"
+import { constVoid, type LazyArg } from "effect/Function"
 import type * as Pull from "effect/Pull"
 import * as Scope from "effect/Scope"
 import * as Stream from "effect/Stream"
@@ -41,10 +41,19 @@ export const fromReadableStream = <A, E>(
     const reader = options.evaluate().getReader()
     yield* Scope.addFinalizer(
       scope,
-      options.releaseLockOnEnd ? Effect.sync(() => reader.releaseLock()) : Effect.promise(() => reader.cancel())
+      options.releaseLockOnEnd
+        ? Effect.sync(() => reader.releaseLock())
+        : Effect.promise(() => reader.cancel().catch(constVoid))
     )
     function readMany(): Pull.Pull<Arr.NonEmptyReadonlyArray<A>, E> {
-      const result = reader.readMany()
+      let result:
+        | Bun.ReadableStreamDefaultReadManyResult<A>
+        | Promise<Bun.ReadableStreamDefaultReadManyResult<A>>
+      try {
+        result = reader.readMany()
+      } catch (error) {
+        return Effect.fail(options.onError(error))
+      }
       if ("then" in result) {
         return Effect.callback<Arr.NonEmptyReadonlyArray<A>, E | Cause.Done>((resume) => {
           result.then((_) => resume(handleResult(_)), (e) => resume(Effect.fail(options.onError(e))))

--- a/packages/platform/bun/test/BunStream.test.ts
+++ b/packages/platform/bun/test/BunStream.test.ts
@@ -1,0 +1,27 @@
+import * as BunStream from "@effect/platform-bun/BunStream"
+import { assert, describe, it } from "@effect/vitest"
+import * as Cause from "effect/Cause"
+import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
+import * as Stream from "effect/Stream"
+
+describe("BunStream", () => {
+  it.effect("preserves mapped failures from errored readable streams", () =>
+    Effect.gen(function*() {
+      const exit = yield* BunStream.fromReadableStream({
+        evaluate: () =>
+          new ReadableStream<number>({
+            start(controller) {
+              controller.error(new Error("boom"))
+            }
+          }),
+        onError: (error) => new Error(`mapped: ${(error as Error).message}`)
+      }).pipe(Stream.runDrain, Effect.exit)
+
+      assert.isTrue(Exit.isFailure(exit))
+      if (Exit.isFailure(exit)) {
+        assert.isTrue(exit.cause.reasons.every(Cause.isFailReason))
+        assert.deepStrictEqual(Cause.squash(exit.cause), new Error("mapped: boom"))
+      }
+    }))
+})


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Keep Bun readable stream errors in the mapped error channel and prevent cleanup from adding a defect. Adds regression coverage for errored streams.

## Related

- N/A
