### PR TITLE
fix(ai-openai): tolerate missing response sequence numbers

### DIFF
--- a/.changeset/openai-optional-sequence-number.md
+++ b/.changeset/openai-optional-sequence-number.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai": patch
+---
+
+Allow OpenAI-compatible Responses API stream events to omit `sequence_number`.

--- a/packages/ai/openai/src/OpenAiSchema.ts
+++ b/packages/ai/openai/src/OpenAiSchema.ts
@@ -905,38 +905,38 @@ export type Response = typeof Response.Type
 const ResponseCreatedEvent = Schema.Struct({
   type: Schema.Literal("response.created"),
   response: Response,
-  sequence_number: Schema.Int
+  sequence_number: Schema.optionalKey(Schema.Int)
 })
 
 const ResponseCompletedEvent = Schema.Struct({
   type: Schema.Literal("response.completed"),
   response: Response,
-  sequence_number: Schema.Int
+  sequence_number: Schema.optionalKey(Schema.Int)
 })
 
 const ResponseIncompleteEvent = Schema.Struct({
   type: Schema.Literal("response.incomplete"),
   response: Response,
-  sequence_number: Schema.Int
+  sequence_number: Schema.optionalKey(Schema.Int)
 })
 
 const ResponseFailedEvent = Schema.Struct({
   type: Schema.Literal("response.failed"),
   response: Response,
-  sequence_number: Schema.Int
+  sequence_number: Schema.optionalKey(Schema.Int)
 })
 
 const ResponseOutputItemAddedEvent = Schema.Struct({
   type: Schema.Literal("response.output_item.added"),
   output_index: Schema.Int,
-  sequence_number: Schema.Int,
+  sequence_number: Schema.optionalKey(Schema.Int),
   item: OutputItem
 })
 
 const ResponseOutputItemDoneEvent = Schema.Struct({
   type: Schema.Literal("response.output_item.done"),
   output_index: Schema.Int,
-  sequence_number: Schema.Int,
+  sequence_number: Schema.optionalKey(Schema.Int),
   item: OutputItem
 })
 
@@ -946,7 +946,7 @@ const ResponseOutputTextDeltaEvent = Schema.Struct({
   output_index: Schema.Int,
   content_index: Schema.Int,
   delta: Schema.String,
-  sequence_number: Schema.Int,
+  sequence_number: Schema.optionalKey(Schema.Int),
   logprobs: Schema.optionalKey(Schema.Array(Schema.Unknown))
 })
 
@@ -956,7 +956,7 @@ const ResponseOutputTextAnnotationAddedEvent = Schema.Struct({
   output_index: Schema.Int,
   content_index: Schema.Int,
   annotation_index: Schema.Int,
-  sequence_number: Schema.Int,
+  sequence_number: Schema.optionalKey(Schema.Int),
   annotation: Annotation
 })
 
@@ -965,7 +965,7 @@ const ResponseReasoningSummaryPartAddedEvent = Schema.Struct({
   item_id: Schema.String,
   output_index: Schema.Int,
   summary_index: Schema.Int,
-  sequence_number: Schema.Int,
+  sequence_number: Schema.optionalKey(Schema.Int),
   part: SummaryTextContent
 })
 
@@ -974,7 +974,7 @@ const ResponseReasoningSummaryPartDoneEvent = Schema.Struct({
   item_id: Schema.String,
   output_index: Schema.Int,
   summary_index: Schema.Int,
-  sequence_number: Schema.Int,
+  sequence_number: Schema.optionalKey(Schema.Int),
   part: SummaryTextContent
 })
 
@@ -984,14 +984,14 @@ const ResponseReasoningSummaryTextDeltaEvent = Schema.Struct({
   output_index: Schema.Int,
   summary_index: Schema.Int,
   delta: Schema.String,
-  sequence_number: Schema.Int
+  sequence_number: Schema.optionalKey(Schema.Int)
 })
 
 const ResponseFunctionCallArgumentsDeltaEvent = Schema.Struct({
   type: Schema.Literal("response.function_call_arguments.delta"),
   item_id: Schema.String,
   output_index: Schema.Int,
-  sequence_number: Schema.Int,
+  sequence_number: Schema.optionalKey(Schema.Int),
   delta: Schema.String
 })
 
@@ -999,7 +999,7 @@ const ResponseFunctionCallArgumentsDoneEvent = Schema.Struct({
   type: Schema.Literal("response.function_call_arguments.done"),
   item_id: Schema.String,
   output_index: Schema.Int,
-  sequence_number: Schema.Int,
+  sequence_number: Schema.optionalKey(Schema.Int),
   arguments: Schema.String
 })
 
@@ -1007,7 +1007,7 @@ const ResponseCodeInterpreterCallCodeDeltaEvent = Schema.Struct({
   type: Schema.Literal("response.code_interpreter_call_code.delta"),
   item_id: Schema.String,
   output_index: Schema.Int,
-  sequence_number: Schema.Int,
+  sequence_number: Schema.optionalKey(Schema.Int),
   delta: Schema.String
 })
 
@@ -1015,7 +1015,7 @@ const ResponseCodeInterpreterCallCodeDoneEvent = Schema.Struct({
   type: Schema.Literal("response.code_interpreter_call_code.done"),
   item_id: Schema.String,
   output_index: Schema.Int,
-  sequence_number: Schema.Int,
+  sequence_number: Schema.optionalKey(Schema.Int),
   code: Schema.String
 })
 
@@ -1023,7 +1023,7 @@ const ResponseApplyPatchCallOperationDiffDeltaEvent = Schema.Struct({
   type: Schema.Literal("response.apply_patch_call_operation_diff.delta"),
   item_id: Schema.String,
   output_index: Schema.Int,
-  sequence_number: Schema.Int,
+  sequence_number: Schema.optionalKey(Schema.Int),
   delta: Schema.String
 })
 
@@ -1031,7 +1031,7 @@ const ResponseApplyPatchCallOperationDiffDoneEvent = Schema.Struct({
   type: Schema.Literal("response.apply_patch_call_operation_diff.done"),
   item_id: Schema.String,
   output_index: Schema.Int,
-  sequence_number: Schema.Int,
+  sequence_number: Schema.optionalKey(Schema.Int),
   delta: Schema.optionalKey(Schema.String)
 })
 
@@ -1039,7 +1039,7 @@ const ResponseImageGenerationCallPartialImageEvent = Schema.Struct({
   type: Schema.Literal("response.image_generation_call.partial_image"),
   item_id: Schema.String,
   output_index: Schema.Int,
-  sequence_number: Schema.Int,
+  sequence_number: Schema.optionalKey(Schema.Int),
   partial_image_b64: Schema.String
 })
 
@@ -1048,7 +1048,7 @@ const ResponseErrorEvent = Schema.Struct({
   code: Schema.NullOr(Schema.String),
   message: Schema.String,
   param: Schema.NullOr(Schema.String),
-  sequence_number: Schema.Int,
+  sequence_number: Schema.optionalKey(Schema.Int),
   status: Schema.optionalKey(Schema.Int)
 })
 
@@ -1060,7 +1060,7 @@ const NestedResponseErrorEvent = Schema.Struct({
     message: Schema.String,
     param: Schema.NullOr(Schema.String)
   }),
-  sequence_number: Schema.Int,
+  sequence_number: Schema.optionalKey(Schema.Int),
   status: Schema.optionalKey(Schema.Int)
 }).pipe(
   Schema.decodeTo(

--- a/packages/ai/openai/test/OpenAiClient.test.ts
+++ b/packages/ai/openai/test/OpenAiClient.test.ts
@@ -611,6 +611,124 @@ describe("OpenAiClient", () => {
         ]
       }))))
 
+    it.effect("accepts response stream events without sequence numbers", () =>
+      Effect.gen(function*() {
+        const client = yield* OpenAiClient.OpenAiClient
+        const [, stream] = yield* client.createResponseStream({
+          model: "gpt-4o",
+          input: "test"
+        })
+
+        const events = yield* Stream.runCollect(stream)
+        const decoded = globalThis.Array.from(events)
+
+        assert.deepStrictEqual(decoded.map((event) => event.type), [
+          "response.created",
+          "response.output_item.added",
+          "response.content_part.added",
+          "response.output_text.delta",
+          "response.reasoning_text.delta",
+          "response.reasoning_text.done",
+          "response.content_part.done",
+          "response.completed"
+        ])
+        assert.deepStrictEqual(decoded.slice(2, 7), [
+          {
+            type: "response.content_part.added",
+            output_index: 0,
+            item_id: "rs_tmp_123",
+            content_index: 0,
+            part: { type: "reasoning_text", text: "" }
+          },
+          {
+            type: "response.output_text.delta",
+            output_index: 0,
+            item_id: "msg_123",
+            content_index: 0,
+            delta: "hello"
+          },
+          {
+            type: "response.reasoning_text.delta",
+            output_index: 0,
+            item_id: "rs_tmp_123",
+            content_index: 0,
+            delta: "thinking..."
+          },
+          {
+            type: "response.reasoning_text.done",
+            output_index: 0,
+            item_id: "rs_tmp_123",
+            content_index: 0,
+            text: "thinking..."
+          },
+          {
+            type: "response.content_part.done",
+            output_index: 0,
+            item_id: "rs_tmp_123",
+            content_index: 0,
+            part: { type: "reasoning_text", text: "thinking..." }
+          }
+        ])
+      }).pipe(Effect.provide(makeTestLayer(undefined, {
+        _tag: "Sse",
+        events: [
+          {
+            type: "response.created",
+            response: makeResponseBody({ status: "in_progress" })
+          },
+          {
+            type: "response.output_item.added",
+            output_index: 0,
+            item: {
+              id: "msg_123",
+              type: "message",
+              role: "assistant",
+              status: "in_progress",
+              content: []
+            }
+          },
+          {
+            type: "response.content_part.added",
+            output_index: 0,
+            item_id: "rs_tmp_123",
+            content_index: 0,
+            part: { type: "reasoning_text", text: "" }
+          },
+          {
+            type: "response.output_text.delta",
+            output_index: 0,
+            item_id: "msg_123",
+            content_index: 0,
+            delta: "hello"
+          },
+          {
+            type: "response.reasoning_text.delta",
+            output_index: 0,
+            item_id: "rs_tmp_123",
+            content_index: 0,
+            delta: "thinking..."
+          },
+          {
+            type: "response.reasoning_text.done",
+            output_index: 0,
+            item_id: "rs_tmp_123",
+            content_index: 0,
+            text: "thinking..."
+          },
+          {
+            type: "response.content_part.done",
+            output_index: 0,
+            item_id: "rs_tmp_123",
+            content_index: 0,
+            part: { type: "reasoning_text", text: "thinking..." }
+          },
+          {
+            type: "response.completed",
+            response: makeResponseBody()
+          }
+        ]
+      }))))
+
     it.effect("maps HTTP error before stream starts", () =>
       Effect.gen(function*() {
         const client = yield* OpenAiClient.OpenAiClient

--- a/packages/ai/openai/test/OpenAiClient.test.ts
+++ b/packages/ai/openai/test/OpenAiClient.test.ts
@@ -632,20 +632,33 @@ describe("OpenAiClient", () => {
           "response.content_part.done",
           "response.completed"
         ])
-        assert.deepStrictEqual(decoded.slice(2, 7), [
+        assert.deepStrictEqual(decoded[0], {
+          type: "response.created",
+          response: {
+            id: "resp_test123",
+            object: "response",
+            model: "gpt-4o-mini",
+            created_at: 1,
+            output: [],
+            error: null,
+            incomplete_details: null
+          }
+        })
+        assert.deepStrictEqual(decoded[3], {
+          type: "response.output_text.delta",
+          output_index: 0,
+          item_id: "msg_123",
+          content_index: 0,
+          delta: "hello",
+          sequence_number: 4
+        })
+        assert.deepStrictEqual([decoded[2], decoded[4], decoded[5], decoded[6]], [
           {
             type: "response.content_part.added",
             output_index: 0,
             item_id: "rs_tmp_123",
             content_index: 0,
             part: { type: "reasoning_text", text: "" }
-          },
-          {
-            type: "response.output_text.delta",
-            output_index: 0,
-            item_id: "msg_123",
-            content_index: 0,
-            delta: "hello"
           },
           {
             type: "response.reasoning_text.delta",
@@ -699,7 +712,8 @@ describe("OpenAiClient", () => {
             output_index: 0,
             item_id: "msg_123",
             content_index: 0,
-            delta: "hello"
+            delta: "hello",
+            sequence_number: 4
           },
           {
             type: "response.reasoning_text.delta",


### PR DESCRIPTION
## Summary

- allow Responses API stream schemas to decode known events without `sequence_number`
- preserve strict validation for the remaining fields on known event types
- cover a mixed OpenAI-compatible SSE stream with absent and present sequence numbers while preserving schema-less events unchanged

## Scope

This fixes the stream-decoding failure reproduced with gproxy and `@effect/ai-openai@4.0.0-rc.112`. The existing unknown-event fallback already passes through the reported `content_part` and `reasoning_text` events. This change does not add typed schemas or language-model handling for those events.

## Validation

- `nix develop -c pnpm vitest run packages/ai/openai/test/OpenAiClient.test.ts packages/ai/openai/test/OpenAiSchema.test.ts`
- `nix develop -c pnpm lint-fix packages/ai/openai/src/OpenAiSchema.ts packages/ai/openai/test/OpenAiClient.test.ts .changeset/openai-optional-sequence-number.md`
- `nix develop -c pnpm check`

Closes EFF-1249
Closes EFF-1251
Closes #8017
