### PR TITLE
fix(cli): reset date input buffer on Tab navigation

### DIFF
--- a/.changeset/fix-prompt-date-tab-buffer.md
+++ b/.changeset/fix-prompt-date-tab-buffer.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Reset the typed input buffer when Tab moves between fields in `Prompt.date`, including when navigation wraps. Digits entered in the newly selected field no longer include input from the previous field.
+Fix `Prompt.date` carrying typed digits into the next field when pressing Tab, including when navigation wraps.

--- a/.changeset/fix-prompt-date-tab-buffer.md
+++ b/.changeset/fix-prompt-date-tab-buffer.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Reset the typed input buffer when Tab moves between fields in `Prompt.date`, including when navigation wraps. Digits entered in the newly selected field no longer include input from the previous field.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -1777,7 +1777,7 @@ const processDateNext = (state: DateState) => {
     onSome: (next) => state.dateParts.indexOf(next)
   })
   return Action.NextFrame({
-    state: { ...state, cursor }
+    state: { ...state, typed: "", cursor }
   })
 }
 

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -50,6 +50,16 @@ const toRawFrames = (lines: ReadonlyArray<unknown>) =>
 const findFrame = (frames: ReadonlyArray<string>, text: string) => frames.find((frame) => frame.includes(text))
 
 describe("Prompt.date", () => {
+  const dateComponents = (value: Date) => [
+    value.getFullYear(),
+    value.getMonth(),
+    value.getDate(),
+    value.getHours(),
+    value.getMinutes(),
+    value.getSeconds(),
+    value.getMilliseconds()
+  ]
+
   it.effect("renders two-digit years, teen ordinals, and noon meridiem correctly", () =>
     Effect.gen(function*() {
       const initial = DateTime.toDateUtc(DateTime.makeZonedUnsafe(
@@ -62,6 +72,158 @@ describe("Prompt.date", () => {
       const output = (yield* MockTerminal.displayLines).map(String).join("\n")
 
       assert.include(output, "24 11th PM")
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("starts a fresh typed buffer when Tab advances to the next field", () =>
+    Effect.gen(function*() {
+      const initial = new Date(2024, 0, 1, 12, 0, 0, 0)
+      assert.deepStrictEqual(yield* MockTerminal.displayLines, [])
+      yield* MockTerminal.inputText("1")
+      yield* MockTerminal.inputKey("tab")
+      yield* MockTerminal.inputText("5")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(Prompt.date({ message: "When", initial, dateMask: "MM-DD" }))
+
+      assert.deepStrictEqual(dateComponents(result), [2024, 0, 5, 12, 0, 0, 0])
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("starts a fresh typed buffer when Tab wraps to the first field", () =>
+    Effect.gen(function*() {
+      const initial = new Date(2024, 0, 1, 12, 0, 0, 0)
+      assert.deepStrictEqual(yield* MockTerminal.displayLines, [])
+      yield* MockTerminal.inputKey("tab")
+      yield* MockTerminal.inputText("1")
+      yield* MockTerminal.inputKey("tab")
+      yield* MockTerminal.inputText("5")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(Prompt.date({ message: "When", initial, dateMask: "DD-MM" }))
+
+      assert.deepStrictEqual(dateComponents(result), [2024, 0, 5, 12, 0, 0, 0])
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("starts a fresh typed buffer when Right advances to the next field", () =>
+    Effect.gen(function*() {
+      const initial = new Date(2024, 0, 1, 12, 0, 0, 0)
+      assert.deepStrictEqual(yield* MockTerminal.displayLines, [])
+      yield* MockTerminal.inputText("1")
+      yield* MockTerminal.inputKey("right")
+      yield* MockTerminal.inputText("5")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(Prompt.date({ message: "When", initial, dateMask: "MM-DD" }))
+
+      assert.deepStrictEqual(dateComponents(result), [2024, 0, 5, 12, 0, 0, 0])
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("starts a fresh typed buffer when Left returns to the previous field", () =>
+    Effect.gen(function*() {
+      const initial = new Date(2024, 0, 1, 12, 0, 0, 0)
+      assert.deepStrictEqual(yield* MockTerminal.displayLines, [])
+      yield* MockTerminal.inputKey("right")
+      yield* MockTerminal.inputText("1")
+      yield* MockTerminal.inputKey("left")
+      yield* MockTerminal.inputText("5")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(Prompt.date({ message: "When", initial, dateMask: "DD-MM" }))
+
+      assert.deepStrictEqual(dateComponents(result), [2024, 0, 5, 12, 0, 0, 0])
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("accepts input after Tab moves with an empty typed buffer", () =>
+    Effect.gen(function*() {
+      const initial = new Date(2024, 0, 1, 12, 0, 0, 0)
+      assert.deepStrictEqual(yield* MockTerminal.displayLines, [])
+      yield* MockTerminal.inputKey("tab")
+      yield* MockTerminal.inputText("5")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(Prompt.date({ message: "When", initial, dateMask: "MM-DD" }))
+
+      assert.deepStrictEqual(dateComponents(result), [2024, 0, 5, 12, 0, 0, 0])
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("accumulates multiple digits while staying in the same field", () =>
+    Effect.gen(function*() {
+      const initial = new Date(2024, 0, 1, 12, 0, 0, 0)
+      assert.deepStrictEqual(yield* MockTerminal.displayLines, [])
+      yield* MockTerminal.inputText("15")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(Prompt.date({ message: "When", initial, dateMask: "DD" }))
+
+      assert.deepStrictEqual(dateComponents(result), [2024, 0, 15, 12, 0, 0, 0])
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("keeps an empty typed buffer across repeated Tab navigation", () =>
+    Effect.gen(function*() {
+      const initial = new Date(2024, 0, 1, 12, 0, 0, 0)
+      assert.deepStrictEqual(yield* MockTerminal.displayLines, [])
+      yield* MockTerminal.inputKey("tab")
+      yield* MockTerminal.inputKey("tab")
+      yield* MockTerminal.inputKey("tab")
+      yield* MockTerminal.inputText("5")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(Prompt.date({ message: "When", initial, dateMask: "MM-DD" }))
+
+      assert.deepStrictEqual(dateComponents(result), [2024, 0, 5, 12, 0, 0, 0])
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("resets the next field after Tab on a validation retry", () =>
+    Effect.gen(function*() {
+      const initial = new Date(2024, 0, 1, 12, 0, 0, 0)
+      const attempts: Array<Array<number>> = []
+      assert.deepStrictEqual(yield* MockTerminal.displayLines, [])
+      yield* MockTerminal.inputText("1")
+      yield* MockTerminal.inputKey("enter")
+      yield* MockTerminal.inputKey("tab")
+      yield* MockTerminal.inputText("5")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(Prompt.date({
+        message: "When",
+        initial,
+        dateMask: "MM-DD",
+        validate: (value) => {
+          attempts.push(dateComponents(value))
+          return attempts.length === 1 ? Effect.fail("Try again") : Effect.succeed(value)
+        }
+      }))
+
+      assert.deepStrictEqual(dateComponents(result), [2024, 0, 5, 12, 0, 0, 0])
+      assert.deepStrictEqual(attempts, [[2024, 0, 1, 12, 0, 0, 0], [2024, 0, 5, 12, 0, 0, 0]])
+      assert.include((yield* MockTerminal.displayLines).join("\n"), "Try again")
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("starts a fresh typed buffer when Tab wraps a single editable field", () =>
+    Effect.gen(function*() {
+      const initial = new Date(2024, 0, 1, 12, 0, 0, 0)
+      assert.deepStrictEqual(yield* MockTerminal.displayLines, [])
+      yield* MockTerminal.inputText("1")
+      yield* MockTerminal.inputKey("tab")
+      yield* MockTerminal.inputText("5")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(Prompt.date({ message: "When", initial, dateMask: "DD" }))
+
+      assert.deepStrictEqual(dateComponents(result), [2024, 0, 5, 12, 0, 0, 0])
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("starts seconds independently after Tab from minutes", () =>
+    Effect.gen(function*() {
+      const initial = new Date(2024, 0, 1, 12, 0, 0, 0)
+      assert.deepStrictEqual(yield* MockTerminal.displayLines, [])
+      yield* MockTerminal.inputText("1")
+      yield* MockTerminal.inputKey("tab")
+      yield* MockTerminal.inputText("5")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(Prompt.date({ message: "When", initial, dateMask: "mm:ss" }))
+
+      assert.deepStrictEqual(dateComponents(result), [2024, 0, 1, 12, 1, 5, 0])
     }).pipe(Effect.provide(TestLayer)))
 })
 

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -50,16 +50,6 @@ const toRawFrames = (lines: ReadonlyArray<unknown>) =>
 const findFrame = (frames: ReadonlyArray<string>, text: string) => frames.find((frame) => frame.includes(text))
 
 describe("Prompt.date", () => {
-  const dateComponents = (value: Date) => [
-    value.getFullYear(),
-    value.getMonth(),
-    value.getDate(),
-    value.getHours(),
-    value.getMinutes(),
-    value.getSeconds(),
-    value.getMilliseconds()
-  ]
-
   it.effect("renders two-digit years, teen ordinals, and noon meridiem correctly", () =>
     Effect.gen(function*() {
       const initial = DateTime.toDateUtc(DateTime.makeZonedUnsafe(
@@ -76,8 +66,7 @@ describe("Prompt.date", () => {
 
   it.effect("starts a fresh typed buffer when Tab advances to the next field", () =>
     Effect.gen(function*() {
-      const initial = new Date(2024, 0, 1, 12, 0, 0, 0)
-      assert.deepStrictEqual(yield* MockTerminal.displayLines, [])
+      const initial = new Date(2024, 0, 1, 12)
       yield* MockTerminal.inputText("1")
       yield* MockTerminal.inputKey("tab")
       yield* MockTerminal.inputText("5")
@@ -85,13 +74,12 @@ describe("Prompt.date", () => {
 
       const result = yield* Prompt.run(Prompt.date({ message: "When", initial, dateMask: "MM-DD" }))
 
-      assert.deepStrictEqual(dateComponents(result), [2024, 0, 5, 12, 0, 0, 0])
+      assert.deepStrictEqual(result, new Date(2024, 0, 5, 12))
     }).pipe(Effect.provide(TestLayer)))
 
   it.effect("starts a fresh typed buffer when Tab wraps to the first field", () =>
     Effect.gen(function*() {
-      const initial = new Date(2024, 0, 1, 12, 0, 0, 0)
-      assert.deepStrictEqual(yield* MockTerminal.displayLines, [])
+      const initial = new Date(2024, 0, 1, 12)
       yield* MockTerminal.inputKey("tab")
       yield* MockTerminal.inputText("1")
       yield* MockTerminal.inputKey("tab")
@@ -100,108 +88,23 @@ describe("Prompt.date", () => {
 
       const result = yield* Prompt.run(Prompt.date({ message: "When", initial, dateMask: "DD-MM" }))
 
-      assert.deepStrictEqual(dateComponents(result), [2024, 0, 5, 12, 0, 0, 0])
-    }).pipe(Effect.provide(TestLayer)))
-
-  it.effect("starts a fresh typed buffer when Right advances to the next field", () =>
-    Effect.gen(function*() {
-      const initial = new Date(2024, 0, 1, 12, 0, 0, 0)
-      assert.deepStrictEqual(yield* MockTerminal.displayLines, [])
-      yield* MockTerminal.inputText("1")
-      yield* MockTerminal.inputKey("right")
-      yield* MockTerminal.inputText("5")
-      yield* MockTerminal.inputKey("enter")
-
-      const result = yield* Prompt.run(Prompt.date({ message: "When", initial, dateMask: "MM-DD" }))
-
-      assert.deepStrictEqual(dateComponents(result), [2024, 0, 5, 12, 0, 0, 0])
-    }).pipe(Effect.provide(TestLayer)))
-
-  it.effect("starts a fresh typed buffer when Left returns to the previous field", () =>
-    Effect.gen(function*() {
-      const initial = new Date(2024, 0, 1, 12, 0, 0, 0)
-      assert.deepStrictEqual(yield* MockTerminal.displayLines, [])
-      yield* MockTerminal.inputKey("right")
-      yield* MockTerminal.inputText("1")
-      yield* MockTerminal.inputKey("left")
-      yield* MockTerminal.inputText("5")
-      yield* MockTerminal.inputKey("enter")
-
-      const result = yield* Prompt.run(Prompt.date({ message: "When", initial, dateMask: "DD-MM" }))
-
-      assert.deepStrictEqual(dateComponents(result), [2024, 0, 5, 12, 0, 0, 0])
-    }).pipe(Effect.provide(TestLayer)))
-
-  it.effect("accepts input after Tab moves with an empty typed buffer", () =>
-    Effect.gen(function*() {
-      const initial = new Date(2024, 0, 1, 12, 0, 0, 0)
-      assert.deepStrictEqual(yield* MockTerminal.displayLines, [])
-      yield* MockTerminal.inputKey("tab")
-      yield* MockTerminal.inputText("5")
-      yield* MockTerminal.inputKey("enter")
-
-      const result = yield* Prompt.run(Prompt.date({ message: "When", initial, dateMask: "MM-DD" }))
-
-      assert.deepStrictEqual(dateComponents(result), [2024, 0, 5, 12, 0, 0, 0])
+      assert.deepStrictEqual(result, new Date(2024, 0, 5, 12))
     }).pipe(Effect.provide(TestLayer)))
 
   it.effect("accumulates multiple digits while staying in the same field", () =>
     Effect.gen(function*() {
-      const initial = new Date(2024, 0, 1, 12, 0, 0, 0)
-      assert.deepStrictEqual(yield* MockTerminal.displayLines, [])
+      const initial = new Date(2024, 0, 1, 12)
       yield* MockTerminal.inputText("15")
       yield* MockTerminal.inputKey("enter")
 
       const result = yield* Prompt.run(Prompt.date({ message: "When", initial, dateMask: "DD" }))
 
-      assert.deepStrictEqual(dateComponents(result), [2024, 0, 15, 12, 0, 0, 0])
-    }).pipe(Effect.provide(TestLayer)))
-
-  it.effect("keeps an empty typed buffer across repeated Tab navigation", () =>
-    Effect.gen(function*() {
-      const initial = new Date(2024, 0, 1, 12, 0, 0, 0)
-      assert.deepStrictEqual(yield* MockTerminal.displayLines, [])
-      yield* MockTerminal.inputKey("tab")
-      yield* MockTerminal.inputKey("tab")
-      yield* MockTerminal.inputKey("tab")
-      yield* MockTerminal.inputText("5")
-      yield* MockTerminal.inputKey("enter")
-
-      const result = yield* Prompt.run(Prompt.date({ message: "When", initial, dateMask: "MM-DD" }))
-
-      assert.deepStrictEqual(dateComponents(result), [2024, 0, 5, 12, 0, 0, 0])
-    }).pipe(Effect.provide(TestLayer)))
-
-  it.effect("resets the next field after Tab on a validation retry", () =>
-    Effect.gen(function*() {
-      const initial = new Date(2024, 0, 1, 12, 0, 0, 0)
-      const attempts: Array<Array<number>> = []
-      assert.deepStrictEqual(yield* MockTerminal.displayLines, [])
-      yield* MockTerminal.inputText("1")
-      yield* MockTerminal.inputKey("enter")
-      yield* MockTerminal.inputKey("tab")
-      yield* MockTerminal.inputText("5")
-      yield* MockTerminal.inputKey("enter")
-
-      const result = yield* Prompt.run(Prompt.date({
-        message: "When",
-        initial,
-        dateMask: "MM-DD",
-        validate: (value) => {
-          attempts.push(dateComponents(value))
-          return attempts.length === 1 ? Effect.fail("Try again") : Effect.succeed(value)
-        }
-      }))
-
-      assert.deepStrictEqual(dateComponents(result), [2024, 0, 5, 12, 0, 0, 0])
-      assert.deepStrictEqual(attempts, [[2024, 0, 1, 12, 0, 0, 0], [2024, 0, 5, 12, 0, 0, 0]])
-      assert.include((yield* MockTerminal.displayLines).join("\n"), "Try again")
+      assert.deepStrictEqual(result, new Date(2024, 0, 15, 12))
     }).pipe(Effect.provide(TestLayer)))
 
   it.effect("starts a fresh typed buffer when Tab wraps a single editable field", () =>
     Effect.gen(function*() {
-      const initial = new Date(2024, 0, 1, 12, 0, 0, 0)
-      assert.deepStrictEqual(yield* MockTerminal.displayLines, [])
+      const initial = new Date(2024, 0, 1, 12)
       yield* MockTerminal.inputText("1")
       yield* MockTerminal.inputKey("tab")
       yield* MockTerminal.inputText("5")
@@ -209,21 +112,7 @@ describe("Prompt.date", () => {
 
       const result = yield* Prompt.run(Prompt.date({ message: "When", initial, dateMask: "DD" }))
 
-      assert.deepStrictEqual(dateComponents(result), [2024, 0, 5, 12, 0, 0, 0])
-    }).pipe(Effect.provide(TestLayer)))
-
-  it.effect("starts seconds independently after Tab from minutes", () =>
-    Effect.gen(function*() {
-      const initial = new Date(2024, 0, 1, 12, 0, 0, 0)
-      assert.deepStrictEqual(yield* MockTerminal.displayLines, [])
-      yield* MockTerminal.inputText("1")
-      yield* MockTerminal.inputKey("tab")
-      yield* MockTerminal.inputText("5")
-      yield* MockTerminal.inputKey("enter")
-
-      const result = yield* Prompt.run(Prompt.date({ message: "When", initial, dateMask: "mm:ss" }))
-
-      assert.deepStrictEqual(dateComponents(result), [2024, 0, 1, 12, 1, 5, 0])
+      assert.deepStrictEqual(result, new Date(2024, 0, 5, 12))
     }).pipe(Effect.provide(TestLayer)))
 })
 


### PR DESCRIPTION
With an `MM-DD` date prompt, entering `1`, Tab, `5`, Enter returned January 15 instead of January 5 because Tab retained the previous field's digits.

Clear the typed input buffer whenever Tab advances or wraps, matching Left/Right navigation. Digits typed without navigating still accumulate normally. Includes an `effect` patch changeset and four focused cases in `packages/effect/test/unstable/cli/Prompt.test.ts`: Tab advancement, wraparound, single-field wrapping, and same-field digit accumulation.

Validation:

- With the reset removed, all three retained Tab regressions fail (January 15 instead of January 5), while the same-field control passes: 3 failures / 58 passes.
- With the fix restored, all 61 prompt tests pass.
- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/effect/test/unstable/cli/Prompt.test.ts --maxWorkers=1`
- `nix develop -c pnpm check`

Closes #8056
Closes EFF-1278
