### PR TITLE
Fix inconsistency between CookiesError name and tag

### DIFF
--- a/.changeset/cookies-error-tag.md
+++ b/.changeset/cookies-error-tag.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix the `CookiesError` tag in `effect/unstable/http` from `CookieError` to `CookiesError` to match the class name.

--- a/packages/effect/src/unstable/http/Cookies.ts
+++ b/packages/effect/src/unstable/http/Cookies.ts
@@ -106,7 +106,7 @@ export class CookiesErrorReason extends Data.Error<{
  * @category errors
  * @since 4.0.0
  */
-export class CookiesError extends Data.TaggedError("CookieError")<{
+export class CookiesError extends Data.TaggedError("CookiesError")<{
   readonly reason: CookiesErrorReason
 }> {
   /**


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The `CookiesError` is (presumably mistakenly) tagged `CookieError` (without the `s`). Had me confused when reading my error-handling type-errors.


