### PR TITLE
fix: skip stack capture when Error.stackTraceLimit is 0

### DIFF
--- a/.changeset/skip-stack-capture-at-zero-limit.md
+++ b/.changeset/skip-stack-capture-at-zero-limit.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Skip the stack captures when `Error.stackTraceLimit` is 0. A limit of 0 cannot carry a frame, so `Effect.fn`, `LayerMap.Service`, `LayerRef.Service`, `RpcMiddleware.Service`, `HttpApiMiddleware.Service`, `Atom.withLabel` and `addSpanStackTrace` no longer construct an `Error` at that limit, which removes a large amount of startup work on runtimes where the construction is costly.

--- a/packages/effect/src/LayerMap.ts
+++ b/packages/effect/src/LayerMap.ts
@@ -432,10 +432,16 @@ export const Service = <Self>() =>
     : never
 > => {
   const Err = globalThis.Error as any
+  // A limit of 0 cannot carry a frame, so the capture is skipped. Constructing
+  // the Error is costly on some runtimes regardless of the limit, and this runs
+  // once for every definition.
   const limit = getStackTraceLimit()
-  setStackTraceLimit(2)
-  const creationError = new Err()
-  setStackTraceLimit(limit)
+  let creationError: globalThis.Error | undefined
+  if (limit !== 0) {
+    setStackTraceLimit(2)
+    creationError = new Err()
+    setStackTraceLimit(limit)
+  }
 
   function TagClass() {}
   const TagClass_ = TagClass as any as Mutable<TagClass<Self, Id, string, any, any, any, any, any>>
@@ -443,7 +449,7 @@ export const Service = <Self>() =>
   TagClass.key = id
   Object.defineProperty(TagClass, "stack", {
     get() {
-      return creationError.stack
+      return creationError?.stack
     }
   })
 

--- a/packages/effect/src/LayerRef.ts
+++ b/packages/effect/src/LayerRef.ts
@@ -350,10 +350,16 @@ export const Service = <Self>() =>
   Deps[number]
 > => {
   const Err = globalThis.Error as any
+  // A limit of 0 cannot carry a frame, so the capture is skipped. Constructing
+  // the Error is costly on some runtimes regardless of the limit, and this runs
+  // once for every definition.
   const limit = getStackTraceLimit()
-  setStackTraceLimit(2)
-  const creationError = new Err()
-  setStackTraceLimit(limit)
+  let creationError: globalThis.Error | undefined
+  if (limit !== 0) {
+    setStackTraceLimit(2)
+    creationError = new Err()
+    setStackTraceLimit(limit)
+  }
 
   function TagClass() {}
   const TagClass_ = TagClass as any as Mutable<TagClass<Self, Id, any, any, any, any, any>>
@@ -361,7 +367,7 @@ export const Service = <Self>() =>
   TagClass.key = id
   Object.defineProperty(TagClass, "stack", {
     get() {
-      return creationError.stack
+      return creationError?.stack
     }
   })
 

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -1261,10 +1261,16 @@ export const fn: typeof Effect.fn = function() {
   const name = nameFirst ? arguments[0] : "Effect.fn"
   const spanOptions = nameFirst ? arguments[1] : undefined
 
+  // A limit of 0 cannot carry a frame, so the capture is skipped. Constructing
+  // the Error is costly on some runtimes regardless of the limit, and this runs
+  // once for every definition.
   const prevLimit = getStackTraceLimit()
-  setStackTraceLimit(2)
-  const defError = new globalThis.Error()
-  setStackTraceLimit(prevLimit)
+  let defError: Error | undefined
+  if (prevLimit !== 0) {
+    setStackTraceLimit(2)
+    defError = new globalThis.Error()
+    setStackTraceLimit(prevLimit)
+  }
 
   if (nameFirst) {
     return (body: Function | { readonly self: any }, ...pipeables: Array<Function>) =>
@@ -1284,7 +1290,7 @@ export const fn: typeof Effect.fn = function() {
 const makeFn = (
   name: string,
   bodyOrOptions: Function | { readonly self: any },
-  defError: Error,
+  defError: Error | undefined,
   pipeables: Array<Function>,
   addSpan: boolean,
   spanOptions: Tracer.SpanOptionsNoTrace | undefined
@@ -1304,10 +1310,14 @@ const makeFn = (
     if (!isEffect(result)) {
       return result
     }
+    // A limit of 0 cannot carry a frame, so the capture is skipped.
     const prevLimit = getStackTraceLimit()
-    setStackTraceLimit(2)
-    const callError = new globalThis.Error()
-    setStackTraceLimit(prevLimit)
+    let callError: Error | undefined
+    if (prevLimit !== 0) {
+      setStackTraceLimit(2)
+      callError = new globalThis.Error()
+      setStackTraceLimit(prevLimit)
+    }
     return updateService(
       addSpan ?
         useSpan(name, spanOptions!, (span) => provideParentSpan(result, span)) :
@@ -1315,10 +1325,10 @@ const makeFn = (
       CurrentStackFrame,
       (prev) => ({
         name,
-        stack: fnStackCleaner(() => callError.stack),
+        stack: fnStackCleaner(() => callError?.stack),
         parent: {
           name: `${name} (definition)`,
-          stack: fnStackCleaner(() => defError.stack),
+          stack: fnStackCleaner(() => defError?.stack),
           parent: prev
         }
       })

--- a/packages/effect/src/internal/tracer.ts
+++ b/packages/effect/src/internal/tracer.ts
@@ -16,6 +16,10 @@ export const addSpanStackTrace = <A extends Tracer.TraceOptions>(
     return options
   }
   const limit = getStackTraceLimit()
+  // A limit of 0 cannot carry a frame, so the capture is skipped.
+  if (limit === 0) {
+    return options as A
+  }
   setStackTraceLimit(3)
   const traceError = new Error()
   setStackTraceLimit(limit)

--- a/packages/effect/src/unstable/httpapi/HttpApiMiddleware.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiMiddleware.ts
@@ -353,16 +353,22 @@ export const Service = <
   } | undefined
 ) => {
   const Err = globalThis.Error as any
+  // A limit of 0 cannot carry a frame, so the capture is skipped. Constructing
+  // the Error is costly on some runtimes regardless of the limit, and this runs
+  // once for every definition.
   const limit = getStackTraceLimit()
-  setStackTraceLimit(2)
-  const creationError = new Err()
-  setStackTraceLimit(limit)
+  let creationError: globalThis.Error | undefined
+  if (limit !== 0) {
+    setStackTraceLimit(2)
+    creationError = new Err()
+    setStackTraceLimit(limit)
+  }
 
   class Service extends Context.Service<Self, any>()(id) {}
   const self = Service as any
   Object.defineProperty(Service, "stack", {
     get() {
-      return creationError.stack
+      return creationError?.stack
     }
   })
   self[TypeId] = TypeId

--- a/packages/effect/src/unstable/reactivity/Atom.ts
+++ b/packages/effect/src/unstable/reactivity/Atom.ts
@@ -22,6 +22,7 @@ import type { LazyArg } from "../../Function.ts"
 import { constant, constTrue, constVoid, dual, pipe } from "../../Function.ts"
 import type * as Inspectable from "../../Inspectable.ts"
 import { PipeInspectableProto } from "../../internal/core.ts"
+import { getStackTraceLimit } from "../../internal/stackTraceLimit.ts"
 import * as Layer from "../../Layer.ts"
 import * as MutableHashMap from "../../MutableHashMap.ts"
 import * as Option from "../../Option.ts"
@@ -1587,7 +1588,9 @@ export const withLabel: {
 >(2, (self, name) =>
   Object.assign(Object.create(Object.getPrototypeOf(self)), {
     ...self,
-    label: [name, new Error().stack?.split("\n")[5] ?? ""]
+    // A limit of 0 cannot carry a frame, so the capture is skipped. The Error
+    // stays inline so the frame index keeps counting from this caller.
+    label: [name, getStackTraceLimit() === 0 ? "" : (new Error().stack?.split("\n")[5] ?? "")]
   }))
 
 /**
@@ -2517,7 +2520,9 @@ export const serializable: {
   const codecJson = Schema.toCodecJson(options.schema)
   return Object.assign(Object.create(Object.getPrototypeOf(self)), {
     ...self,
-    label: self.label ?? [options.key, new Error().stack?.split("\n")[5] ?? ""],
+    // A limit of 0 cannot carry a frame, so the capture is skipped. The Error
+    // stays inline so the frame index keeps counting from this caller.
+    label: self.label ?? [options.key, getStackTraceLimit() === 0 ? "" : (new Error().stack?.split("\n")[5] ?? "")],
     [SerializableTypeId]: {
       key: options.key,
       encode: Schema.encodeSync(codecJson),

--- a/packages/effect/src/unstable/rpc/RpcMiddleware.ts
+++ b/packages/effect/src/unstable/rpc/RpcMiddleware.ts
@@ -293,10 +293,16 @@ export const Service = <
   }
 ) => {
   const Err = globalThis.Error as any
+  // A limit of 0 cannot carry a frame, so the capture is skipped. Constructing
+  // the Error is costly on some runtimes regardless of the limit, and this runs
+  // once for every definition.
   const limit = getStackTraceLimit()
-  setStackTraceLimit(2)
-  const creationError = new Err()
-  setStackTraceLimit(limit)
+  let creationError: globalThis.Error | undefined
+  if (limit !== 0) {
+    setStackTraceLimit(2)
+    creationError = new Err()
+    setStackTraceLimit(limit)
+  }
 
   function ServiceClass() {}
   const ServiceClass_ = ServiceClass as any as Mutable<AnyService>
@@ -304,7 +310,7 @@ export const Service = <
   ServiceClass.key = id
   Object.defineProperty(ServiceClass, "stack", {
     get() {
-      return creationError.stack
+      return creationError?.stack
     }
   })
   ServiceClass_[TypeId] = TypeId

--- a/packages/effect/test/StackTraceLimit.test.ts
+++ b/packages/effect/test/StackTraceLimit.test.ts
@@ -1,8 +1,25 @@
 import { describe, it, vi } from "@effect/vitest"
+import { Effect, Layer, LayerMap, LayerRef, References, Schema, type Tracer } from "effect"
 import * as StackTraceLimit from "effect/internal/stackTraceLimit"
-import { assertFalse, assertTrue, strictEqual } from "./utils/assert.ts"
+import { addSpanStackTrace } from "effect/internal/tracer"
+import { HttpApiMiddleware } from "effect/unstable/httpapi"
+import { Atom } from "effect/unstable/reactivity"
+import { RpcMiddleware } from "effect/unstable/rpc"
+import { assertFalse, assertInclude, assertTrue, deepStrictEqual, strictEqual } from "./utils/assert.ts"
 
 const getLimit = (): number | undefined => (Error as { stackTraceLimit?: number | undefined }).stackTraceLimit
+
+const withLimit = <A>(limit: number, f: () => A): A => {
+  const prev = getLimit()
+  StackTraceLimit.setStackTraceLimit(limit)
+  try {
+    return f()
+  } finally {
+    StackTraceLimit.setStackTraceLimit(prev)
+  }
+}
+
+const stackOf = (self: unknown): string | undefined => (self as { readonly stack?: string | undefined }).stack
 
 describe("stackTraceLimit", () => {
   describe("writable environment", () => {
@@ -55,6 +72,177 @@ describe("stackTraceLimit", () => {
         }
         vi.resetModules()
       }
+    })
+  })
+
+  describe("a limit of 0 skips the capture", () => {
+    const runFn = () => {
+      const double = Effect.fn("double")(function*(n: number) {
+        return [n * 2, yield* References.CurrentStackFrame] as const
+      })
+      return Effect.runSync(double(21))
+    }
+
+    it("Effect.fn runs and reports neither a call nor a definition frame", () => {
+      const [value, frame] = withLimit(0, runFn)
+      strictEqual(value, 42)
+      strictEqual(frame?.name, "double")
+      strictEqual(frame?.stack(), undefined)
+      strictEqual(frame?.parent?.name, "double (definition)")
+      strictEqual(frame?.parent?.stack(), undefined)
+    })
+
+    it("Effect.fn keeps both frames at a non-zero limit", () => {
+      const [value, frame] = withLimit(10, runFn)
+      strictEqual(value, 42)
+      assertInclude(frame?.stack(), "StackTraceLimit.test.ts")
+      assertInclude(frame?.parent?.stack(), "StackTraceLimit.test.ts")
+    })
+
+    it.effect("LayerMap.Service exposes no stack and is otherwise unchanged", () =>
+      Effect.gen(function*() {
+        const looked: Array<string> = []
+        const makeService = (id: string) => {
+          class TestMap extends LayerMap.Service<TestMap>()(id, {
+            lookup: (key: string) => Layer.effectDiscard(Effect.sync(() => looked.push(key))) as Layer.Layer<any>
+          }) {}
+          return TestMap
+        }
+
+        const ZeroMap = withLimit(0, () => makeService("StackTraceLimitTest/LayerMapZero"))
+        strictEqual(stackOf(ZeroMap), undefined)
+        strictEqual(ZeroMap.key, "StackTraceLimitTest/LayerMapZero")
+        yield* Effect.provide(Effect.scoped(ZeroMap.contextEffect("a")), ZeroMap.layer)
+        deepStrictEqual(looked, ["a"])
+
+        const TenMap = withLimit(10, () => makeService("StackTraceLimitTest/LayerMapTen"))
+        assertInclude(stackOf(TenMap), "StackTraceLimit.test.ts")
+      }))
+
+    it.effect("LayerRef.Service exposes no stack and is otherwise unchanged", () =>
+      Effect.gen(function*() {
+        const acquired: Array<string> = []
+        const makeService = (id: string) => {
+          class TestRef extends LayerRef.Service<TestRef>()(id, {
+            layer: Layer.effectDiscard(Effect.sync(() => acquired.push(id))) as Layer.Layer<any>
+          }) {}
+          return TestRef
+        }
+
+        const ZeroRef = withLimit(0, () => makeService("StackTraceLimitTest/LayerRefZero"))
+        strictEqual(stackOf(ZeroRef), undefined)
+        strictEqual(ZeroRef.key, "StackTraceLimitTest/LayerRefZero")
+        yield* Effect.provide(Effect.scoped(ZeroRef.contextEffect), ZeroRef.layer)
+        deepStrictEqual(acquired, ["StackTraceLimitTest/LayerRefZero"])
+
+        const TenRef = withLimit(10, () => makeService("StackTraceLimitTest/LayerRefTen"))
+        assertInclude(stackOf(TenRef), "StackTraceLimit.test.ts")
+      }))
+
+    it("RpcMiddleware.Service exposes no stack and is otherwise unchanged", () => {
+      const Zero = withLimit(0, () => {
+        class ZeroRpc extends RpcMiddleware.Service<ZeroRpc>()("StackTraceLimitTest/RpcZero") {}
+        return ZeroRpc
+      })
+      strictEqual(stackOf(Zero), undefined)
+      strictEqual(Zero.key, "StackTraceLimitTest/RpcZero")
+      strictEqual(Zero.requiredForClient, false)
+
+      const Ten = withLimit(10, () => {
+        class TenRpc extends RpcMiddleware.Service<TenRpc>()("StackTraceLimitTest/RpcTen") {}
+        return TenRpc
+      })
+      assertInclude(stackOf(Ten), "StackTraceLimit.test.ts")
+    })
+
+    it("HttpApiMiddleware.Service exposes no stack and is otherwise unchanged", () => {
+      const Zero = withLimit(0, () => {
+        class ZeroHttp extends HttpApiMiddleware.Service<ZeroHttp>()("StackTraceLimitTest/HttpZero") {}
+        return ZeroHttp
+      })
+      strictEqual(stackOf(Zero), undefined)
+      strictEqual(Zero.key, "StackTraceLimitTest/HttpZero")
+      strictEqual(Zero.requiredForClient, false)
+
+      const Ten = withLimit(10, () => {
+        class TenHttp extends HttpApiMiddleware.Service<TenHttp>()("StackTraceLimitTest/HttpTen") {}
+        return TenHttp
+      })
+      assertInclude(stackOf(Ten), "StackTraceLimit.test.ts")
+    })
+
+    it("Atom.withLabel keeps the name and drops the caller location", () => {
+      const zero = withLimit(0, () => Atom.make(0).pipe(Atom.withLabel("counter")).label)
+      deepStrictEqual(zero, ["counter", ""])
+
+      const ten = withLimit(10, () => Atom.make(0).pipe(Atom.withLabel("counter")).label)
+      strictEqual(ten?.[0], "counter")
+      assertInclude(ten?.[1], "StackTraceLimit.test.ts")
+    })
+
+    it("Atom.serializable keeps the key and drops the caller location", () => {
+      const zero = withLimit(0, () => Atom.make(0).pipe(Atom.serializable({ key: "count", schema: Schema.Number })))
+      deepStrictEqual(zero.label, ["count", ""])
+
+      const ten = withLimit(10, () => Atom.make(0).pipe(Atom.serializable({ key: "count", schema: Schema.Number })))
+      strictEqual(ten.label?.[0], "count")
+      assertInclude(ten.label?.[1], "StackTraceLimit.test.ts")
+    })
+
+    it("constructs no Error at a limit of 0, and one per site otherwise", () => {
+      const RealError = globalThis.Error
+      let constructed = 0
+      class CountingError extends RealError {
+        constructor(message?: string, options?: ErrorOptions) {
+          super(message, options)
+          constructed++
+        }
+      }
+
+      // Exercises all nine capture sites once each.
+      const touchEverySite = (suffix: string) => {
+        const counted = Effect.fn("counted")(function*(n: number) {
+          return n
+        })
+        Effect.runSync(counted(1))
+        class CountedMap extends LayerMap.Service<CountedMap>()(`StackTraceLimitTest/Counted${suffix}Map`, {
+          lookup: () => Layer.effectDiscard(Effect.void) as Layer.Layer<any>
+        }) {}
+        class CountedRef extends LayerRef.Service<CountedRef>()(`StackTraceLimitTest/Counted${suffix}Ref`, {
+          layer: Layer.effectDiscard(Effect.void) as Layer.Layer<any>
+        }) {}
+        class CountedRpc extends RpcMiddleware.Service<CountedRpc>()(`StackTraceLimitTest/Counted${suffix}Rpc`) {}
+        class CountedHttp
+          extends HttpApiMiddleware.Service<CountedHttp>()(`StackTraceLimitTest/Counted${suffix}Http`)
+        {}
+        Atom.make(0).pipe(Atom.withLabel("counted"))
+        Atom.make(0).pipe(Atom.serializable({ key: "counted", schema: Schema.Number }))
+        addSpanStackTrace(undefined)
+        return [CountedMap, CountedRef, CountedRpc, CountedHttp]
+      }
+      ;(globalThis as { Error: ErrorConstructor }).Error = CountingError as unknown as ErrorConstructor
+      try {
+        withLimit(0, () => touchEverySite("Zero"))
+        strictEqual(constructed, 0)
+
+        constructed = 0
+        withLimit(10, () => touchEverySite("Ten"))
+        strictEqual(constructed, 9)
+      } finally {
+        ;(globalThis as { Error: ErrorConstructor }).Error = RealError
+      }
+    })
+
+    it("addSpanStackTrace returns the options unchanged", () => {
+      const options: Tracer.TraceOptions = {}
+      const zero = withLimit(0, () => addSpanStackTrace(options))
+      strictEqual(zero, options)
+      strictEqual(zero.captureStackTrace, undefined)
+      strictEqual(withLimit(0, () => addSpanStackTrace(undefined)) as unknown, undefined)
+
+      const ten = withLimit(10, () => addSpanStackTrace(options))
+      assertTrue(typeof ten.captureStackTrace === "function")
+      assertInclude((ten.captureStackTrace as () => string | undefined)(), "StackTraceLimit.test.ts")
     })
   })
 })


### PR DESCRIPTION
## The problem

`Effect.fn` constructs a `globalThis.Error` at every definition site so it can
record where the function was defined. `Effect.fn` does the same again at every
call site, `LayerMap.Service`, `LayerRef.Service`, `RpcMiddleware.Service` and
`HttpApiMiddleware.Service` do it once at creation, `Atom.withLabel` and
`Atom.serializable` do it to label an atom, and `addSpanStackTrace` does it when
a span is created. Most of these set `Error.stackTraceLimit` to a small value
first, so they are already asking for a cheap trace. None of them keep the
Error. They only ever read its `stack`.

On Cloudflare's workerd runtime that construction is not cheap, and its cost
does not fall when the limit is lowered. Constructing the Error costs between
19 and 256 microseconds per site whatever the limit is set to, including 0. The
definition-site captures all run during module evaluation, so a Worker pays for
every `Effect.fn` in its dependency graph before it can serve its first
request.

Measured on a real Worker built on Effect:

| Measurement | Value |
| --- | --- |
| Definition sites evaluated before the first request | about 1900 |
| Total startup CPU, profiled | 222 ms |
| Of that, spent constructing these Errors | 176 ms |
| Startup CPU with module evaluation run at limit 0 | 132 ms, from 218 ms |

The last row comes from a separate timed run, which is why its baseline differs
slightly from the profiled one.

Reproduction: https://github.com/agcty/effect-fn-startup-repro

Related reports: Effect-TS/effect#8038 and cloudflare/workerd#7245.

## The rule

A limit of 0 cannot carry a frame, so the capture is skipped.

When the limit is 0, the Error a site is about to build could not hold a single
frame, so building it can only cost time. Most sites already read the limit
before lowering it, and the change simply constructs nothing when that read
returns 0. The two `Atom` sites did not read the limit at all, so they now do.

The rest follows from code that already exists. The stack thunks return
`undefined`, and `makeStackCleaner` already treats `undefined` as no trace.
`addSpanStackTrace` returns its options unchanged rather than attaching a
`captureStackTrace` thunk, and every caller already reads that field
optionally.

## What changes for users

At any non-zero limit, nothing changes. The same Errors are constructed at the
same sites with the same limits, and the same frames appear.

At a limit of 0, the definition frame and the call frame are absent from the
stack information, which is what a limit of 0 asks for. Frame names are still
present, so a pretty-printed cause still names the function and its definition,
it just carries no source location. Services created at limit 0 return
`undefined` from their `stack` getter. Atom labels are unaffected either way:
they already carried an empty caller location at limit 0, because the frame the
label reads was not in the stack.

Applications that want the startup saving opt in by setting
`Error.stackTraceLimit = 0` for the duration of module evaluation and restoring
it before serving traffic. Nothing changes for applications that leave the
limit alone.

## The changed sites

This is every place in the library that builds an Error solely to read its
stack. Seven files, nine captures, all changed the same way.

- `packages/effect/src/internal/effect.ts`, the `Effect.fn` definition capture
- `packages/effect/src/internal/effect.ts`, the `Effect.fn` call capture in `makeFn`
- `packages/effect/src/LayerMap.ts`, `Service`
- `packages/effect/src/LayerRef.ts`, `Service`
- `packages/effect/src/unstable/rpc/RpcMiddleware.ts`, `Service`
- `packages/effect/src/unstable/httpapi/HttpApiMiddleware.ts`, `Service`
- `packages/effect/src/internal/tracer.ts`, `addSpanStackTrace`
- `packages/effect/src/unstable/reactivity/Atom.ts`, `withLabel`
- `packages/effect/src/unstable/reactivity/Atom.ts`, `serializable`

Each Error is still constructed inline at its own call site rather than moved
into a shared helper, so the frames it captures keep pointing at the real
caller. That is the property `src/internal/stackTraceLimit.ts` documents. The
two `Atom.ts` sites read a fixed frame index, so keeping the construction
inline also keeps that index correct.

## Sites deliberately left out

Four other places touch `Error.stackTraceLimit` or build an Error, and the rule
does not apply to any of them.

- `Layer.ts`, the unimplemented-method error in `mockImpl`. The Error is a real
  error handed to the user through `die`, not a stack probe.
- `internal/effect.ts`, `causePrettyErrors`. It lowers the limit while it builds
  the Error objects it returns for rendering. Those Errors are the return value.
- `Schema.ts`, the `SchemaError` constructor. It already sets the limit to 0 to
  make construction cheap, and the error itself is returned to the user.
- `unstable/ai/Tool.ts`, `unsafeSecureJsonParse`. It already sets the limit to 0
  around `JSON.parse` for the same reason and constructs no Error of its own.

One further site, `Utils.ts`, builds an Error to read its stack, but it uses the
result to decide whether generators are being optimized away. Skipping the
construction would change which implementation is selected, so it is untouched.

## Tests

Added to `packages/effect/test/StackTraceLimit.test.ts`, each restoring the
limit afterwards:

- `Effect.fn` at limit 0 still returns its value, and both the call frame and
  the definition frame report `undefined` for their stack.
- `Effect.fn` at limit 10 keeps both frames and both point at the test file.
- `LayerMap.Service` and `LayerRef.Service` created at limit 0 expose
  `undefined` from `stack`, keep their key, and still build and run their
  layer. Created at limit 10 they expose a stack naming the test file.
- `RpcMiddleware.Service` and `HttpApiMiddleware.Service` behave the same way.
- `Atom.withLabel` and `Atom.serializable` at limit 0 keep the name and give an
  empty caller location, which is what they already produced at that limit, and
  at limit 10 they still record the caller.
- A counting test replaces `globalThis.Error` with a subclass and exercises all
  nine sites. At limit 0 it counts zero constructions. At limit 10 it counts
  exactly nine, one per site.
- `addSpanStackTrace` at limit 0 returns the very same options object with no
  `captureStackTrace`, and at limit 10 attaches a working capture thunk.

Seven of these tests fail on unpatched sources and pass with the change. The two
`Atom` label tests pass either way by design, because that behaviour was already
identical at limit 0; the counting test is what proves the construction is now
skipped there.

## Not run locally

`deno check .` and the container-backed integration tests were not run on the
contributor's machine, since neither Deno nor the test images were available. CI
covers both. Everything else in the Check workflow was run and passed.
