### PR TITLE
fix(AtomRpc): match RPC requirements in query return type

### DIFF
--- a/.changeset/atom-rpc-query-requires.md
+++ b/.changeset/atom-rpc-query-requires.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `AtomRpc.query` returning `never` for RPCs whose middleware declares service `requires`. The return-type conditional now infers all six `Rpc` type parameters, matching `mutation` and every utility in `Rpc`.

--- a/packages/effect/src/unstable/reactivity/AtomRpc.ts
+++ b/packages/effect/src/unstable/reactivity/AtomRpc.ts
@@ -94,7 +94,8 @@ export interface AtomRpcClient<Self, Id extends string, Rpcs extends Rpc.Any> ex
     infer _Payload,
     infer _Success,
     infer _Error,
-    infer _Middleware
+    infer _Middleware,
+    infer _Requires
   > ? [_Success] extends [RpcSchema.Stream<infer _A, infer _E>] ? Atom.Writable<
         Atom.PullResult<
           _A["Type"],

--- a/packages/effect/typetest/unstable/reactivity/AtomRpc.tst.ts
+++ b/packages/effect/typetest/unstable/reactivity/AtomRpc.tst.ts
@@ -1,0 +1,39 @@
+import { Context, Effect, Layer, Schema } from "effect"
+import { Atom, AtomRpc } from "effect/unstable/reactivity"
+import { Rpc, RpcGroup, RpcMiddleware } from "effect/unstable/rpc"
+import { describe, expect, it } from "tstyche"
+
+describe("AtomRpc", () => {
+  class ServerDependency extends Context.Service<
+    ServerDependency,
+    {}
+  >()("ServerDependency") {}
+
+  class RequiringMiddleware extends RpcMiddleware.Service<RequiringMiddleware, {
+    requires: ServerDependency
+  }>()("RequiringMiddleware", {}) {}
+
+  const RequiringGroup = RpcGroup.make(
+    Rpc.make("getUser", {
+      success: Schema.Struct({
+        id: Schema.Number,
+        name: Schema.String
+      })
+    }).middleware(RequiringMiddleware)
+  )
+
+  it("query supports RPCs whose middleware declares service requirements", () => {
+    const Client = AtomRpc.Service()("RequiringClient", {
+      group: RequiringGroup,
+      protocol: Layer.empty,
+      makeEffect: Effect.die("unused")
+    })
+
+    const query = Client.query("getUser", undefined)
+
+    expect<Atom.Success<typeof query>>().type.toBe<{
+      readonly id: number
+      readonly name: string
+    }>()
+  })
+})

--- a/packages/effect/typetest/unstable/reactivity/AtomRpc.tst.ts
+++ b/packages/effect/typetest/unstable/reactivity/AtomRpc.tst.ts
@@ -1,5 +1,5 @@
 import { Context, Effect, Layer, Schema } from "effect"
-import { Atom, AtomRpc } from "effect/unstable/reactivity"
+import { type Atom, AtomRpc } from "effect/unstable/reactivity"
 import { Rpc, RpcGroup, RpcMiddleware } from "effect/unstable/rpc"
 import { describe, expect, it } from "tstyche"
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
<!--
Please add a brief summary/description of the pull request here.
-->
`AtomRpc.query` returning `never` for RPCs whose middleware declares service `requires`. Different from `mutation`, `query` has not six `Rpc` type parameters, so i think it's bug

## Testing

`pnpm test-types packages/effect/typetest/unstable/reactivity/AtomRpc.tst.ts`