### PR TITLE
Fix durable suspension for child workflow fan-out inside activities

### DIFF
--- a/.changeset/fair-workflows-suspend.md
+++ b/.changeset/fair-workflows-suspend.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix parallel child workflows inside activities to dispatch before suspending, release activity resources during durable waits, and resume reliably when children complete during cleanup.

--- a/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
+++ b/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
@@ -88,7 +88,7 @@ export const make = Effect.gen(function*() {
         >,
         Schema.declare<Workflow.Result<any, any>>
       >
-      | Rpc.Rpc<"resume", Schema.Struct<{}>>
+      | typeof ResumeRpc
     >
   >()
   const partialEntities = new Map<
@@ -101,7 +101,7 @@ export const make = Effect.gen(function*() {
         Schema.Struct<{ name: typeof Schema.String; attempt: typeof Schema.Int }>,
         Schema.declare<Workflow.Result<any, any>>
       >
-      | Rpc.Rpc<"resume">
+      | typeof ResumeRpc
     >
   >()
   const ensureEntity = (workflow: Workflow.Any) => {
@@ -293,17 +293,17 @@ export const make = Effect.gen(function*() {
   const sendResumeParent = Effect.fnUntraced(function*(options: {
     readonly workflowName: string
     readonly executionId: string
-  }) {
+  }, childExecutionId: string) {
     const requestId = yield* requestIdFor({
       workflow: workflows.get(options.workflowName)!,
       entityType: `Workflow/${options.workflowName}`,
       executionId: options.executionId,
       tag: "resume",
-      id: ""
+      id: childExecutionId
     })
     if (Option.isNone(requestId)) {
       const client = (yield* RcMap.get(clientsPartial, options.workflowName))(options.executionId)
-      return yield* client.resume({} as any, { discard: true })
+      return yield* client.resume({ childExecutionId }, { discard: true })
     }
     const reply = yield* replyForRequestId(requestId.value)
     if (Option.isNone(reply)) return
@@ -358,8 +358,10 @@ export const make = Effect.gen(function*() {
           Effect.gen(function*() {
             const address = yield* Entity.CurrentAddress
             const executionId = address.entityId
+            let currentRun: Entity.Request<any> | undefined
             return {
               run: (request: Entity.Request<any>) => {
+                currentRun = request
                 const instance = WorkflowEngine.WorkflowInstance.initial(workflow, executionId)
                 const parent = (request.payload as any)[payloadParentKey] as
                   | { workflowName: string; executionId: string }
@@ -379,7 +381,7 @@ export const make = Effect.gen(function*() {
                       !instance.abandoned &&
                       !(suspendOnFailure && exit._tag === "Failure")
                     ) {
-                      return parent ? ensureSuccess(sendResumeParent(parent)) : Effect.void
+                      return parent ? ensureSuccess(sendResumeParent(parent, executionId)) : Effect.void
                     }
                     return engine.deferredResult(InterruptSignal).pipe(
                       Effect.flatMap((maybeExit) => {
@@ -451,7 +453,37 @@ export const make = Effect.gen(function*() {
                 return payload.exit
               }),
 
-              resume: () => ensureSuccess(resume(workflow, executionId))
+              resume: () =>
+                ensureSuccess(
+                  Effect.gen(function*() {
+                    if (currentRun) {
+                      // A child may complete while its parent is still unwinding.
+                      // Subscribe before checking storage so the wake cannot fall
+                      // between the parent's last read and its suspended reply.
+                      const request = currentRun
+                      const waiter = yield* storage.registerReplyHandler(
+                        new Message.OutgoingRequest<any>({
+                          envelope: request,
+                          context: Context.empty() as Context.Context<any>,
+                          rpc: ensureEntity(workflow).protocol.requests.get("run")!,
+                          lastReceivedReply: Option.none(),
+                          respond: () => Effect.void,
+                          annotations: Context.empty()
+                        })
+                      ).pipe(Effect.interruptible, Effect.forkScoped({ startImmediately: true }))
+                      const reply = yield* replyForRequestId(request.requestId)
+                      if (Option.isNone(reply)) {
+                        yield* Fiber.join(waiter).pipe(
+                          Effect.catchTag("EntityNotAssignedToRunner", () => ClusterAbandon.interrupt),
+                          Effect.catchCause((cause) =>
+                            ClusterAbandon.isCause(cause) ? ClusterAbandon.interrupt : Effect.failCause(cause)
+                          )
+                        )
+                      }
+                    }
+                    yield* resume(workflow, executionId)
+                  }).pipe(Effect.scoped)
+                ).pipe(Rpc.wrap({ fork: true, uninterruptible: true }))
             }
           }),
           // Reserve a slot for deferred completions to wake the active run.
@@ -705,8 +737,10 @@ const DeferredRpc = Rpc.make("deferred", {
 const decodeDeferredWithExit = Schema.decodeSync(Schema.toCodecJson(Reply.WithExit.schema(DeferredRpc)))
 
 const ResumeRpc = Rpc.make("resume", {
-  payload: {},
-  primaryKey: () => ""
+  payload: { childExecutionId: Schema.optional(Schema.String) },
+  // Different children must not share an in-flight wake: the parent may have
+  // already started another run when the next child finishes.
+  primaryKey: ({ childExecutionId }) => childExecutionId ?? ""
 })
   .annotate(ClusterSchema.Persisted, true)
   .annotate(ClusterSchema.Uninterruptible, "server")

--- a/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
+++ b/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
@@ -358,7 +358,11 @@ export const make = Effect.gen(function*() {
           Effect.gen(function*() {
             const address = yield* Entity.CurrentAddress
             const executionId = address.entityId
+            // Assigned when the handler is called, before RPC concurrency scheduling.
+            // Replays reuse the request id. Before the first run is delivered,
+            // resume reads its stored reply; a queued run will read child results.
             let currentRun: Entity.Request<any> | undefined
+            let waitingResume: object | undefined
             return {
               run: (request: Entity.Request<any>) => {
                 currentRun = request
@@ -456,32 +460,46 @@ export const make = Effect.gen(function*() {
               resume: () =>
                 ensureSuccess(
                   Effect.gen(function*() {
-                    if (currentRun) {
-                      // A child may complete while its parent is still unwinding.
-                      // Subscribe before checking storage so the wake cannot fall
-                      // between the parent's last read and its suspended reply.
-                      const request = currentRun
-                      const waiter = yield* storage.registerReplyHandler(
-                        new Message.OutgoingRequest<any>({
-                          envelope: request,
-                          context: Context.empty() as Context.Context<any>,
-                          rpc: ensureEntity(workflow).protocol.requests.get("run")!,
-                          lastReceivedReply: Option.none(),
-                          respond: () => Effect.void,
-                          annotations: Context.empty()
-                        })
-                      ).pipe(Effect.interruptible, Effect.forkScoped({ startImmediately: true }))
-                      const reply = yield* replyForRequestId(request.requestId)
-                      if (Option.isNone(reply)) {
-                        yield* Fiber.join(waiter).pipe(
-                          Effect.catchTag("EntityNotAssignedToRunner", () => ClusterAbandon.interrupt),
-                          Effect.catchCause((cause) =>
-                            ClusterAbandon.isCause(cause) ? ClusterAbandon.interrupt : Effect.failCause(cause)
+                    // The waiting request remains unacknowledged and durable, so
+                    // it also carries wakes acknowledged during this phase.
+                    if (waitingResume) return
+                    const token = {}
+                    waitingResume = token
+                    return yield* Effect.gen(function*() {
+                      if (currentRun) {
+                        // A child may complete while its parent is still unwinding.
+                        // Subscribe before checking storage so the wake cannot fall
+                        // between the parent's last read and its suspended reply.
+                        const request = currentRun
+                        const waiter = yield* storage.registerReplyHandler(
+                          new Message.OutgoingRequest<any>({
+                            envelope: request,
+                            context: Context.empty() as Context.Context<any>,
+                            rpc: ensureEntity(workflow).protocol.requests.get("run")!,
+                            lastReceivedReply: Option.none(),
+                            respond: () => Effect.void,
+                            annotations: Context.empty()
+                          })
+                        ).pipe(Effect.interruptible, Effect.forkScoped({ startImmediately: true }))
+                        const reply = yield* replyForRequestId(request.requestId)
+                        if (Option.isNone(reply)) {
+                          yield* Fiber.join(waiter).pipe(
+                            Effect.catchTag("EntityNotAssignedToRunner", () => ClusterAbandon.interrupt),
+                            Effect.catchCause((cause) =>
+                              ClusterAbandon.isCause(cause) ? ClusterAbandon.interrupt : Effect.failCause(cause)
+                            )
                           )
-                        )
+                        } else {
+                          yield* Fiber.interrupt(waiter)
+                        }
                       }
-                    }
-                    yield* resume(workflow, executionId)
+                      // Stop coalescing before reset can start another parent run.
+                      // Later child completions must be able to wake that replay.
+                      waitingResume = undefined
+                      yield* resume(workflow, executionId)
+                    }).pipe(Effect.ensuring(Effect.sync(() => {
+                      if (waitingResume === token) waitingResume = undefined
+                    })))
                   }).pipe(Effect.scoped)
                 ).pipe(Rpc.wrap({ fork: true, uninterruptible: true }))
             }
@@ -737,6 +755,7 @@ const DeferredRpc = Rpc.make("deferred", {
 const decodeDeferredWithExit = Schema.decodeSync(Schema.toCodecJson(Reply.WithExit.schema(DeferredRpc)))
 
 const ResumeRpc = Rpc.make("resume", {
+  // Older persisted resume envelopes have an empty payload and use the empty key.
   payload: { childExecutionId: Schema.optional(Schema.String) },
   // Different children must not share an in-flight wake: the parent may have
   // already started another run when the next child finishes.

--- a/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
+++ b/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
@@ -21,6 +21,7 @@ import type * as Record from "../../Record.ts"
 import * as Schedule from "../../Schedule.ts"
 import * as Schema from "../../Schema.ts"
 import type * as Scope from "../../Scope.ts"
+import * as Semaphore from "../../Semaphore.ts"
 import * as Headers from "../http/Headers.ts"
 import * as Rpc from "../rpc/Rpc.ts"
 import { ClientAbort } from "../rpc/RpcSchema.ts"
@@ -310,6 +311,28 @@ export const make = Effect.gen(function*() {
     yield* sharding.reset(requestId.value)
   }, Effect.scoped)
 
+  // A child may complete while its parent run is still unwinding. Subscribe to
+  // the run's reply before reading storage so the wake cannot fall between the
+  // parent's last read and its suspended reply.
+  const waitForRunReply = Effect.fnUntraced(function*(workflow: Workflow.Any, request: Entity.Request<any>) {
+    const waiter = yield* storage.registerReplyHandler(
+      new Message.OutgoingRequest<any>({
+        envelope: request,
+        context: Context.empty() as Context.Context<any>,
+        rpc: ensureEntity(workflow).protocol.requests.get("run")!,
+        lastReceivedReply: Option.none(),
+        respond: () => Effect.void,
+        annotations: Context.empty()
+      })
+    ).pipe(Effect.interruptible, Effect.forkScoped({ startImmediately: true }))
+    const reply = yield* replyForRequestId(request.requestId)
+    if (Option.isSome(reply)) return
+    yield* Fiber.join(waiter).pipe(
+      Effect.catchTag("EntityNotAssignedToRunner", () => ClusterAbandon.interrupt),
+      Effect.catchCause((cause) => ClusterAbandon.isCause(cause) ? ClusterAbandon.interrupt : Effect.failCause(cause))
+    )
+  }, Effect.scoped)
+
   const interrupt = Effect.fnUntraced(
     function*(workflow: Workflow.Any, executionId: string) {
       ensureEntity(workflow)
@@ -358,11 +381,10 @@ export const make = Effect.gen(function*() {
           Effect.gen(function*() {
             const address = yield* Entity.CurrentAddress
             const executionId = address.entityId
-            // Assigned when the handler is called, before RPC concurrency scheduling.
-            // Replays reuse the request id. Before the first run is delivered,
-            // resume reads its stored reply; a queued run will read child results.
+            // Latest run request for this entity; replays reuse its request id.
             let currentRun: Entity.Request<any> | undefined
-            let waitingResume: object | undefined
+            // Concurrent wakes share one wait for the current run to publish its reply.
+            const resumeGate = Semaphore.makeUnsafe(1)
             return {
               run: (request: Entity.Request<any>) => {
                 currentRun = request
@@ -458,50 +480,15 @@ export const make = Effect.gen(function*() {
               }),
 
               resume: () =>
-                ensureSuccess(
-                  Effect.gen(function*() {
-                    // The waiting request remains unacknowledged and durable, so
-                    // it also carries wakes acknowledged during this phase.
-                    if (waitingResume) return
-                    const token = {}
-                    waitingResume = token
-                    return yield* Effect.gen(function*() {
-                      if (currentRun) {
-                        // A child may complete while its parent is still unwinding.
-                        // Subscribe before checking storage so the wake cannot fall
-                        // between the parent's last read and its suspended reply.
-                        const request = currentRun
-                        const waiter = yield* storage.registerReplyHandler(
-                          new Message.OutgoingRequest<any>({
-                            envelope: request,
-                            context: Context.empty() as Context.Context<any>,
-                            rpc: ensureEntity(workflow).protocol.requests.get("run")!,
-                            lastReceivedReply: Option.none(),
-                            respond: () => Effect.void,
-                            annotations: Context.empty()
-                          })
-                        ).pipe(Effect.interruptible, Effect.forkScoped({ startImmediately: true }))
-                        const reply = yield* replyForRequestId(request.requestId)
-                        if (Option.isNone(reply)) {
-                          yield* Fiber.join(waiter).pipe(
-                            Effect.catchTag("EntityNotAssignedToRunner", () => ClusterAbandon.interrupt),
-                            Effect.catchCause((cause) =>
-                              ClusterAbandon.isCause(cause) ? ClusterAbandon.interrupt : Effect.failCause(cause)
-                            )
-                          )
-                        } else {
-                          yield* Fiber.interrupt(waiter)
-                        }
-                      }
-                      // Stop coalescing before reset can start another parent run.
-                      // Later child completions must be able to wake that replay.
-                      waitingResume = undefined
-                      yield* resume(workflow, executionId)
-                    }).pipe(Effect.ensuring(Effect.sync(() => {
-                      if (waitingResume === token) waitingResume = undefined
-                    })))
-                  }).pipe(Effect.scoped)
-                ).pipe(Rpc.wrap({ fork: true, uninterruptible: true }))
+                resumeGate.withPermitsIfAvailable(1)(
+                  currentRun ? waitForRunReply(workflow, currentRun) : Effect.void
+                ).pipe(
+                  // Release the gate before reset can start another parent run, so
+                  // later child completions can wake that replay.
+                  Effect.flatMap((waited) => Option.isSome(waited) ? resume(workflow, executionId) : Effect.void),
+                  ensureSuccess,
+                  Rpc.wrap({ fork: true, uninterruptible: true })
+                )
             }
           }),
           // Reserve a slot for deferred completions to wake the active run.

--- a/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
+++ b/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
@@ -324,7 +324,7 @@ export const make = Effect.gen(function*() {
         respond: () => Effect.void,
         annotations: Context.empty()
       })
-    ).pipe(Effect.interruptible, Effect.forkScoped({ startImmediately: true }))
+    ).pipe(Effect.forkScoped({ startImmediately: true }))
     const reply = yield* replyForRequestId(request.requestId)
     if (Option.isSome(reply)) return
     yield* Fiber.join(waiter).pipe(

--- a/packages/effect/src/unstable/workflow/Activity.ts
+++ b/packages/effect/src/unstable/workflow/Activity.ts
@@ -190,15 +190,21 @@ const retryOnInterrupt = (
   name: string,
   policy: Schedule.Schedule<any, Cause.Cause<unknown>> = interruptRetryPolicy
 ) =>
-<A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
-  effect.pipe(
-    Effect.sandbox,
-    Effect.retry(policy),
-    Effect.catch((cause) => {
-      if (!Cause.hasInterrupts(cause)) return Effect.failCause(cause)
-      return Effect.die(`Activity "${name}" interrupted and retry attempts exhausted`)
-    })
-  )
+<A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R | WorkflowInstance> =>
+  Effect.contextWith((context: Context.Context<WorkflowInstance>) => {
+    const instance = Context.get(context, InstanceTag)
+    return effect.pipe(
+      Effect.sandbox,
+      // A suspension interrupts the activity body on purpose and must surface
+      // as a suspended result instead of being retried.
+      Effect.retry({ schedule: policy, while: () => !instance.suspended }),
+      Effect.catch((cause) => {
+        if (!Cause.hasInterrupts(cause)) return Effect.failCause(cause)
+        if (instance.suspended) return Effect.failCause(cause)
+        return Effect.die(`Activity "${name}" interrupted and retry attempts exhausted`)
+      })
+    )
+  })
 
 /**
  * Retries an effect with `Effect.retry` while updating `CurrentAttempt` for

--- a/packages/effect/src/unstable/workflow/Activity.ts
+++ b/packages/effect/src/unstable/workflow/Activity.ts
@@ -198,20 +198,18 @@ const retryOnInterrupt = (
   policy: Schedule.Schedule<any, Cause.Cause<unknown>> = interruptRetryPolicy
 ) =>
 <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R | WorkflowInstance> =>
-  Effect.contextWith((context: Context.Context<WorkflowInstance>) => {
-    const instance = Context.get(context, InstanceTag)
-    return effect.pipe(
+  Effect.flatMap(InstanceTag, (instance) =>
+    effect.pipe(
       Effect.sandbox,
       // A suspension interrupts the activity body on purpose and must surface
       // as a suspended result instead of being retried.
       Effect.retry({ schedule: policy, while: () => !instance.suspended }),
-      Effect.catch((cause) => {
-        if (!Cause.hasInterrupts(cause)) return Effect.failCause(cause)
-        if (instance.suspended) return Effect.failCause(cause)
-        return Effect.die(`Activity "${name}" interrupted and retry attempts exhausted`)
-      })
-    )
-  })
+      Effect.catch((cause) =>
+        Cause.hasInterrupts(cause) && !instance.suspended
+          ? Effect.die(`Activity "${name}" interrupted and retry attempts exhausted`)
+          : Effect.failCause(cause)
+      )
+    ))
 
 /**
  * Retries an effect with `Effect.retry` while updating `CurrentAttempt` for

--- a/packages/effect/src/unstable/workflow/Activity.ts
+++ b/packages/effect/src/unstable/workflow/Activity.ts
@@ -117,6 +117,13 @@ export interface AnyWithProps {
  * Creates a workflow activity from an effect, using the provided schemas to
  * encode successes and failures for durable execution.
  *
+ * **Gotchas**
+ *
+ * Only completed activity results are memoized. If the activity suspends while
+ * awaiting child workflows or a durable clock, its body runs again when the
+ * parent workflow replays. Side effects before the suspension can repeat;
+ * make those side effects idempotent.
+ *
  * @category constructors
  * @since 4.0.0
  */

--- a/packages/effect/src/unstable/workflow/Workflow.ts
+++ b/packages/effect/src/unstable/workflow/Workflow.ts
@@ -759,8 +759,7 @@ export const wrapActivityResult = <A, E, R>(
 
 interface ActivityRegistration {
   readonly instance: WorkflowInstance["Service"]
-  adopted: boolean
-  released: boolean
+  state: "pending" | "adopted" | "released"
 }
 
 const PendingActivityRegistration = Context.Service<ActivityRegistration>(
@@ -771,27 +770,27 @@ const registerActivityUnsafe = (instance: WorkflowInstance["Service"]): Activity
   const state = instance.activityState
   if (state.count === 0) state.latch.closeUnsafe()
   state.count++
-  return { instance, adopted: false, released: false }
+  return { instance, state: "pending" }
 }
 
 const adoptActivityUnsafe = (
   context: Context.Context<never>,
   instance: WorkflowInstance["Service"]
 ): ActivityRegistration | undefined => {
-  const pending = Context.getOrElse(context, PendingActivityRegistration, () => undefined)
+  const pending = Context.getOrUndefined(context, PendingActivityRegistration)
   if (!pending || pending.instance !== instance) {
     return undefined
   }
-  if (pending.adopted || pending.released) {
+  if (pending.state !== "pending") {
     throw new Error("Workflow.wrapActivityResult: pending child registration has already been consumed")
   }
-  pending.adopted = true
+  pending.state = "adopted"
   return pending
 }
 
 const releaseActivityUnsafe = (registration: ActivityRegistration) => {
-  if (registration.released) return
-  registration.released = true
+  if (registration.state === "released") return
+  registration.state = "released"
   const state = registration.instance.activityState
   state.count--
   if (state.count === 0) state.latch.openUnsafe()
@@ -804,15 +803,12 @@ const releaseActivityUnsafe = (registration: ActivityRegistration) => {
  */
 const withPendingActivity = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
   Effect.contextWith((context: Context.Context<never>) => {
-    const instance = Context.getOrElse(context, InstanceTag, () => undefined)
+    const instance = Context.getOrUndefined(context, InstanceTag)
     if (!instance) return effect
     return Effect.acquireUseRelease(
       Effect.sync(() => registerActivityUnsafe(instance)),
       (registration) => Effect.provideService(effect, PendingActivityRegistration, registration),
-      (registration) =>
-        Effect.sync(() => {
-          releaseActivityUnsafe(registration)
-        })
+      (registration) => Effect.sync(() => releaseActivityUnsafe(registration))
     )
   })
 

--- a/packages/effect/src/unstable/workflow/Workflow.ts
+++ b/packages/effect/src/unstable/workflow/Workflow.ts
@@ -347,7 +347,7 @@ const Proto = {
   ) {
     return Effect.suspend(() => {
       const payload = this.payloadSchema.make(fields)
-      return Effect.flatMap(
+      const run = Effect.flatMap(
         EngineTag,
         (engine) =>
           Effect.flatMap(makeExecutionIdFromPayload(this, payload), (executionId) =>
@@ -361,6 +361,9 @@ const Proto = {
               })
             ))
       )
+      // Register with the parent before the execution id is computed, so a
+      // sibling that suspends first waits for this child to be dispatched.
+      return opts?.discard ? run : withPendingActivity(run)
     }).pipe(
       Effect.withSpan(
         `${this._tag}.execute`,
@@ -734,11 +737,9 @@ export const wrapActivityResult = <A, E, R>(
 ): Effect.Effect<A, E, R | WorkflowInstance> =>
   Effect.contextWith((context: Context.Context<WorkflowInstance>) => {
     const instance = Context.get(context, InstanceTag)
-    const state = instance.activityState
-    if (state.count === 0) state.latch.closeUnsafe()
-    state.count++
+    const registration = adoptActivityUnsafe(context, instance) ?? registerActivityUnsafe(instance)
     return Effect.onExit(effect, (exit) => {
-      state.count--
+      releaseActivityUnsafe(registration)
       const isSuspended = Exit.isSuccess(exit) && isSuspend(exit.value)
       if (
         Exit.isSuccess(exit) &&
@@ -750,12 +751,66 @@ export const wrapActivityResult = <A, E, R>(
           ? Cause.combine(instance.cause, exit.value.cause)
           : exit.value.cause
       }
-      return state.count === 0
-        ? state.latch.open
-        : isSuspended
+      return isSuspended && instance.activityState.count > 0
         ? waitForZero(instance)
         : Effect.void
     })
+  })
+
+interface ActivityRegistration {
+  readonly instance: WorkflowInstance["Service"]
+  adopted: boolean
+  released: boolean
+}
+
+const PendingActivityRegistration = Context.Service<ActivityRegistration>(
+  "effect/workflow/Workflow/PendingActivityRegistration"
+)
+
+const registerActivityUnsafe = (instance: WorkflowInstance["Service"]): ActivityRegistration => {
+  const state = instance.activityState
+  if (state.count === 0) state.latch.closeUnsafe()
+  state.count++
+  return { instance, adopted: false, released: false }
+}
+
+const adoptActivityUnsafe = (
+  context: Context.Context<never>,
+  instance: WorkflowInstance["Service"]
+): ActivityRegistration | undefined => {
+  const pending = Context.getOrElse(context, PendingActivityRegistration, () => undefined)
+  if (!pending || pending.instance !== instance || pending.adopted || pending.released) {
+    return undefined
+  }
+  pending.adopted = true
+  return pending
+}
+
+const releaseActivityUnsafe = (registration: ActivityRegistration) => {
+  if (registration.released) return
+  registration.released = true
+  const state = registration.instance.activityState
+  state.count--
+  if (state.count === 0) state.latch.openUnsafe()
+}
+
+/**
+ * Registers a pending child workflow execution with the current workflow
+ * instance before any asynchronous work runs. `wrapActivityResult` adopts the
+ * registration once the execution is dispatched.
+ */
+const withPendingActivity = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+  Effect.contextWith((context: Context.Context<never>) => {
+    const instance = Context.getOrElse(context, InstanceTag, () => undefined)
+    if (!instance) return effect
+    return Effect.acquireUseRelease(
+      Effect.sync(() => registerActivityUnsafe(instance)),
+      (registration) => Effect.provideService(effect, PendingActivityRegistration, registration),
+      (registration) =>
+        Effect.sync(() => {
+          releaseActivityUnsafe(registration)
+        })
+    )
   })
 
 const waitForZero = Effect.fnUntraced(function*(instance: WorkflowInstance["Service"]) {

--- a/packages/effect/src/unstable/workflow/Workflow.ts
+++ b/packages/effect/src/unstable/workflow/Workflow.ts
@@ -779,8 +779,11 @@ const adoptActivityUnsafe = (
   instance: WorkflowInstance["Service"]
 ): ActivityRegistration | undefined => {
   const pending = Context.getOrElse(context, PendingActivityRegistration, () => undefined)
-  if (!pending || pending.instance !== instance || pending.adopted || pending.released) {
+  if (!pending || pending.instance !== instance) {
     return undefined
+  }
+  if (pending.adopted || pending.released) {
+    throw new Error("Workflow.wrapActivityResult: pending child registration has already been consumed")
   }
   pending.adopted = true
   return pending

--- a/packages/effect/src/unstable/workflow/WorkflowEngine.ts
+++ b/packages/effect/src/unstable/workflow/WorkflowEngine.ts
@@ -690,6 +690,7 @@ export const layerMemory: Layer.Layer<WorkflowEngine> = Layer.effect(WorkflowEng
       readonly parent: string | undefined
       instance: WorkflowInstance["Service"]
       interrupted: boolean
+      resumeRequested: boolean
       fiber: Fiber.Fiber<Workflow.Result<unknown, unknown>> | undefined
     }
     const executions = new Map<string, ExecutionState>()
@@ -708,6 +709,18 @@ export const layerMemory: Layer.Layer<WorkflowEngine> = Layer.effect(WorkflowEng
       if (exit && exit._tag === "Success" && exit.value._tag === "Complete") {
         return
       } else if (state.fiber && !exit) {
+        // A child can finish while the parent is still releasing its activity.
+        // Preserve the wake until that run has published its suspended result.
+        if (!state.resumeRequested) {
+          state.resumeRequested = true
+          yield* Fiber.await(state.fiber).pipe(
+            Effect.andThen(() => {
+              state.resumeRequested = false
+              return resume(executionId)
+            }),
+            Effect.forkIn(scope)
+          )
+        }
         return
       }
 
@@ -765,6 +778,7 @@ export const layerMemory: Layer.Layer<WorkflowEngine> = Layer.effect(WorkflowEng
             execute: entry.execute,
             instance: WorkflowInstance.initial(workflow, options.executionId),
             interrupted: false,
+            resumeRequested: false,
             fiber: undefined,
             parent: options.parent?.executionId
           }

--- a/packages/effect/src/unstable/workflow/WorkflowEngine.ts
+++ b/packages/effect/src/unstable/workflow/WorkflowEngine.ts
@@ -714,7 +714,7 @@ export const layerMemory: Layer.Layer<WorkflowEngine> = Layer.effect(WorkflowEng
         if (!state.resumeRequested) {
           state.resumeRequested = true
           yield* Fiber.await(state.fiber).pipe(
-            Effect.andThen(() => {
+            Effect.flatMap(() => {
               state.resumeRequested = false
               return resume(executionId)
             }),

--- a/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
+++ b/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
@@ -588,13 +588,12 @@ describe.concurrent("ClusterWorkflowEngine", () => {
 
       // the parent suspends durably once every child has been dispatched
       let suspended = false
-      for (let i = 0; i < 50 && !suspended; i++) {
-        yield* TestClock.adjust(1)
+      while (!suspended) {
+        yield* Effect.yieldNow
         yield* sharding.pollStorage
         const result = yield* ParallelParentWorkflow.poll(executionId)
         suspended = Option.isSome(result) && result.value._tag === "Suspended"
       }
-      assert.isTrue(suspended, "parent run was not durably suspended")
       assert.strictEqual(flags.get("parallel-runs-parallel-activity"), 1)
       assert.isTrue(flags.get("parallel-child-start-parallel-activity-child-0"))
       assert.isTrue(flags.get("parallel-child-start-parallel-activity-child-1"))
@@ -605,8 +604,9 @@ describe.concurrent("ClusterWorkflowEngine", () => {
       // the children complete after a single sleep window and wake the parent
       yield* TestClock.adjust(Duration.seconds(2))
       yield* sharding.pollStorage
-      for (let i = 0; i < 4; i++) {
-        yield* TestClock.adjust(Duration.seconds(1))
+      while (fiber.pollUnsafe() === undefined) {
+        yield* Effect.yieldNow
+        yield* TestClock.adjust(1)
         yield* sharding.pollStorage
       }
       assert.deepStrictEqual(fiber.pollUnsafe(), Exit.succeed(["done-0", "done-1", "done-2"]))
@@ -629,14 +629,21 @@ describe.concurrent("ClusterWorkflowEngine", () => {
 
       for (const started of [2, 4, 5]) {
         let suspended = false
-        for (let i = 0; i < 50 && !suspended; i++) {
-          yield* TestClock.adjust(10)
+        while (!suspended) {
+          yield* Effect.yieldNow
+          // Drive cluster retries between runs without advancing child clocks
+          // while the activity is computing execution IDs.
+          if (
+            flags.get("parallel-activity-runs-parallel-bounded") ===
+              flags.get("parallel-activity-releases-parallel-bounded")
+          ) {
+            yield* TestClock.adjust(1)
+          }
           yield* sharding.pollStorage
           const result = yield* ParallelParentWorkflow.poll(executionId)
           suspended = Option.isSome(result) && result.value._tag === "Suspended" &&
             flags.get(`parallel-child-start-parallel-bounded-child-${started - 1}`) === true
         }
-        assert.isTrue(suspended, `parent did not suspend after dispatching ${started} children`)
         for (let index = 0; index < 5; index++) {
           assert.strictEqual(
             flags.get(`parallel-child-start-parallel-bounded-child-${index}`),
@@ -650,13 +657,16 @@ describe.concurrent("ClusterWorkflowEngine", () => {
         yield* TestClock.adjust(Duration.seconds(2))
         yield* sharding.pollStorage
       }
-      for (let i = 0; i < 50; i++) {
-        yield* TestClock.adjust(10)
+      let result = yield* ParallelParentWorkflow.poll(executionId)
+      while (Option.isNone(result) || result.value._tag !== "Complete") {
+        yield* Effect.yieldNow
+        yield* TestClock.adjust(1)
         yield* sharding.pollStorage
+        result = yield* ParallelParentWorkflow.poll(executionId)
       }
       assert.deepStrictEqual(
-        yield* ParallelParentWorkflow.poll(executionId),
-        Option.some(new Workflow.Complete({ exit: Exit.succeed(["done-0", "done-1", "done-2", "done-3", "done-4"]) }))
+        result.value,
+        new Workflow.Complete({ exit: Exit.succeed(["done-0", "done-1", "done-2", "done-3", "done-4"]) })
       )
       assert.isAtMost(
         Number(flags.get("parallel-activity-runs-parallel-bounded")),
@@ -696,30 +706,34 @@ describe.concurrent("ClusterWorkflowEngine", () => {
         const sharding = yield* Sharding.Sharding
         yield* TestClock.adjust(1)
         const executionId = yield* Parent.execute({}, { discard: true })
-        yield* TestClock.adjust(1)
-        yield* sharding.pollStorage
         yield* cleaningUp.await
         yield* TestClock.adjust("2 seconds")
         yield* sharding.pollStorage
-        for (let i = 0; i < 10; i++) {
-          yield* TestClock.adjust(10)
-          yield* sharding.pollStorage
-        }
         for (const index of [0, 1]) {
           const childId = yield* Child.executionId({ index })
+          let childResult = yield* Child.poll(childId)
+          while (Option.isNone(childResult) || childResult.value._tag !== "Complete") {
+            yield* Effect.yieldNow
+            yield* TestClock.adjust(1)
+            yield* sharding.pollStorage
+            childResult = yield* Child.poll(childId)
+          }
           assert.deepStrictEqual(
-            yield* Child.poll(childId),
-            Option.some(new Workflow.Complete({ exit: Exit.succeed(index) }))
+            childResult.value,
+            new Workflow.Complete({ exit: Exit.succeed(index) })
           )
         }
         yield* release.open
-        for (let i = 0; i < 50; i++) {
-          yield* TestClock.adjust(10)
+        let result = yield* Parent.poll(executionId)
+        while (Option.isNone(result) || result.value._tag !== "Complete") {
+          yield* Effect.yieldNow
+          yield* TestClock.adjust(1)
           yield* sharding.pollStorage
+          result = yield* Parent.poll(executionId)
         }
         assert.deepStrictEqual(
-          yield* Parent.poll(executionId),
-          Option.some(new Workflow.Complete({ exit: Exit.succeed([0, 1]) }))
+          result.value,
+          new Workflow.Complete({ exit: Exit.succeed([0, 1]) })
         )
       }).pipe(Effect.provide(Layer.mergeAll(ParentLayer, ChildLayer).pipe(Layer.provideMerge(TestWorkflowLayer))))
     }))
@@ -785,29 +799,39 @@ describe.concurrent("ClusterWorkflowEngine", () => {
         const driver = yield* MessageStorage.MemoryDriver
         yield* TestClock.adjust(1)
         const executionId = yield* Parent.execute({}, { discard: true })
-        for (let i = 0; i < 100; i++) {
-          yield* TestClock.adjust(10)
-          yield* sharding.pollStorage
-        }
         yield* cleaningUp.await
         yield* TestClock.adjust("2 seconds")
-        for (let i = 0; i < 100; i++) {
-          yield* TestClock.adjust(10)
+        const wakeRequests = () =>
+          driver.journal.filter((message) =>
+            message._tag === "Request" &&
+            message.address.entityType === "Workflow/ManyChildrenParent" && message.tag === "resume"
+          )
+        const allWakesHandled = () => {
+          const wakes = wakeRequests()
+          const replied = wakes.filter((message) =>
+            message._tag === "Request" && (driver.requests.get(message.requestId)?.replies.length ?? 0) > 0
+          ).length
+          // Every wake must have replied or parked before releasing the parent.
+          return wakes.length === indices.length && replied + parked === indices.length
+        }
+        while (!allWakesHandled()) {
+          yield* Effect.yieldNow
+          yield* TestClock.adjust(1)
           yield* sharding.pollStorage
         }
-        const wakes = driver.journal.filter((message) =>
-          message._tag === "Request" &&
-          message.address.entityType === "Workflow/ManyChildrenParent" && message.tag === "resume"
-        )
+        const wakes = wakeRequests()
         const parkedBeforeRelease = parked
         yield* release.open
-        for (let i = 0; i < 100; i++) {
-          yield* TestClock.adjust(10)
+        let result = yield* Parent.poll(executionId)
+        while (Option.isNone(result) || result.value._tag !== "Complete" || parked !== 0) { // oxlint-disable-line no-unmodified-loop-condition
+          yield* Effect.yieldNow
+          yield* TestClock.adjust(1)
           yield* sharding.pollStorage
+          result = yield* Parent.poll(executionId)
         }
         assert.deepStrictEqual(
-          yield* Parent.poll(executionId),
-          Option.some(new Workflow.Complete({ exit: Exit.succeed(indices) }))
+          result.value,
+          new Workflow.Complete({ exit: Exit.succeed(indices) })
         )
         assert.strictEqual(parked, 0)
         assert.strictEqual(wakes.length, indices.length)
@@ -852,14 +876,13 @@ describe.concurrent("ClusterWorkflowEngine", () => {
           const engine = yield* WorkflowEngine
           yield* TestClock.adjust(1)
           const executionId = yield* Parent.execute({}, { discard: true })
-          for (let i = 0; i < 50; i++) {
-            yield* TestClock.adjust(10)
+          let result = yield* Parent.poll(executionId)
+          while (Option.isNone(result) || result.value._tag !== "Suspended") {
+            yield* Effect.yieldNow
+            yield* TestClock.adjust(1)
             yield* sharding.pollStorage
+            result = yield* Parent.poll(executionId)
           }
-          assert.deepStrictEqual(
-            Option.map(yield* Parent.poll(executionId), (result) => result._tag),
-            Option.some("Suspended")
-          )
           for (let i = 0; i < 12 && (yield* sharding.activeEntityCount) > 0; i++) {
             yield* TestClock.adjust(5000)
           }
@@ -884,13 +907,16 @@ describe.concurrent("ClusterWorkflowEngine", () => {
               exit: Exit.void
             })
           }
-          for (let i = 0; i < 100; i++) {
-            yield* TestClock.adjust(10)
+          result = yield* Parent.poll(executionId)
+          while (Option.isNone(result) || result.value._tag !== "Complete" || legacyResume.pollUnsafe() === undefined) {
+            yield* Effect.yieldNow
+            yield* TestClock.adjust(1)
             yield* sharding.pollStorage
+            result = yield* Parent.poll(executionId)
           }
           assert.deepStrictEqual(
-            yield* Parent.poll(executionId),
-            Option.some(new Workflow.Complete({ exit: Exit.succeed([0, 1]) }))
+            result.value,
+            new Workflow.Complete({ exit: Exit.succeed([0, 1]) })
           )
           assert.deepStrictEqual(legacyResume.pollUnsafe(), Exit.void)
         }).pipe(Effect.provide(
@@ -914,13 +940,12 @@ describe.concurrent("ClusterWorkflowEngine", () => {
       )
 
       let suspended = false
-      for (let i = 0; i < 50 && !suspended; i++) {
-        yield* TestClock.adjust(1)
+      while (!suspended) {
+        yield* Effect.yieldNow
         yield* sharding.pollStorage
         const result = yield* ParallelParentWorkflow.poll(executionId)
         suspended = Option.isSome(result) && result.value._tag === "Suspended"
       }
-      assert.isTrue(suspended, "parent run was not durably suspended")
 
       // well past the activity interrupt retry budget the run is still suspended
       // and the activity body has not been re-executed
@@ -934,8 +959,9 @@ describe.concurrent("ClusterWorkflowEngine", () => {
 
       yield* TestClock.adjust(Duration.seconds(10))
       yield* sharding.pollStorage
-      for (let i = 0; i < 6; i++) {
-        yield* TestClock.adjust(Duration.seconds(5))
+      while (fiber.pollUnsafe() === undefined) {
+        yield* Effect.yieldNow
+        yield* TestClock.adjust(1)
         yield* sharding.pollStorage
       }
       assert.deepStrictEqual(fiber.pollUnsafe(), Exit.succeed(["done-0", "done-1"]))
@@ -954,13 +980,12 @@ describe.concurrent("ClusterWorkflowEngine", () => {
       )
 
       let suspended = false
-      for (let i = 0; i < 50 && !suspended; i++) {
-        yield* TestClock.adjust(1)
+      while (!suspended) {
+        yield* Effect.yieldNow
         yield* sharding.pollStorage
         const result = yield* ParallelDirectWorkflow.poll(executionId)
         suspended = Option.isSome(result) && result.value._tag === "Suspended"
       }
-      assert.isTrue(suspended, "parent run was not durably suspended")
       assert.strictEqual(flags.get("parallel-runs-parallel-direct"), 1)
       assert.isTrue(flags.get("parallel-child-start-parallel-direct-child-0"))
       assert.isTrue(flags.get("parallel-child-start-parallel-direct-child-1"))
@@ -968,8 +993,9 @@ describe.concurrent("ClusterWorkflowEngine", () => {
 
       yield* TestClock.adjust(Duration.seconds(2))
       yield* sharding.pollStorage
-      for (let i = 0; i < 4; i++) {
-        yield* TestClock.adjust(Duration.seconds(1))
+      while (fiber.pollUnsafe() === undefined) {
+        yield* Effect.yieldNow
+        yield* TestClock.adjust(1)
         yield* sharding.pollStorage
       }
       assert.deepStrictEqual(fiber.pollUnsafe(), Exit.succeed(["done-0", "done-1", "done-2"]))

--- a/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
+++ b/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
@@ -24,7 +24,8 @@ import {
   Runners,
   RunnerStorage,
   Sharding,
-  ShardingConfig
+  ShardingConfig,
+  Snowflake
 } from "effect/unstable/cluster"
 import { Rpc } from "effect/unstable/rpc"
 import { Activity, DurableClock, DurableDeferred, Workflow } from "effect/unstable/workflow"
@@ -812,6 +813,7 @@ describe.concurrent("ClusterWorkflowEngine", () => {
         assert.strictEqual(wakes.length, indices.length)
         // Each wake remains durable, but only one waits on this parent run.
         assert.strictEqual(parkedBeforeRelease, 1, `peak parked reply handlers: ${peak}`)
+        assert.strictEqual(peak, 1)
       }).pipe(Effect.provide(
         Layer.mergeAll(ParentLayer, ChildLayer).pipe(
           Layer.provideMerge(makeTestWorkflowEngine({ entityMailboxCapacity: 1000 }, storageLayer))
@@ -868,7 +870,8 @@ describe.concurrent("ClusterWorkflowEngine", () => {
               message.address.entityType === "Workflow/ColdParent" && message.tag === "run"
             )!
             assert(run._tag === "Request")
-            yield* sharding.reset(run.requestId)
+            assert.isTrue(yield* sharding.reset(Snowflake.Snowflake(run.requestId)))
+            assert.isTrue(Option.isNone(yield* Parent.poll(executionId)))
           }
           const client = yield* LegacyResume.client
           // The empty payload is the format of resume messages persisted before this fix.

--- a/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
+++ b/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
@@ -18,6 +18,7 @@ import { TestClock } from "effect/testing"
 import {
   ClusterSchema,
   ClusterWorkflowEngine,
+  Entity,
   MessageStorage,
   RunnerHealth,
   Runners,
@@ -25,6 +26,7 @@ import {
   Sharding,
   ShardingConfig
 } from "effect/unstable/cluster"
+import { Rpc } from "effect/unstable/rpc"
 import { Activity, DurableClock, DurableDeferred, Workflow } from "effect/unstable/workflow"
 import {
   makeUnsafe as makeWorkflowEngineUnsafe,
@@ -721,6 +723,181 @@ describe.concurrent("ClusterWorkflowEngine", () => {
       }).pipe(Effect.provide(Layer.mergeAll(ParentLayer, ChildLayer).pipe(Layer.provideMerge(TestWorkflowLayer))))
     }))
 
+  it.effect("coalesces parked child wakeups while parent cleanup is pending", () =>
+    Effect.gen(function*() {
+      const cleaningUp = yield* Latch.make()
+      const release = yield* Latch.make()
+      const indices = Array.from({ length: 64 }, (_, index) => index)
+      let parked = 0
+      let peak = 0
+      const storageLayer = Layer.effect(
+        MessageStorage.MessageStorage,
+        Effect.map(
+          MessageStorage.MessageStorage,
+          (storage) =>
+            MessageStorage.MessageStorage.of({
+              ...storage,
+              registerReplyHandler: (message) => {
+                if (
+                  message.envelope.address.entityType !== "Workflow/ManyChildrenParent" ||
+                  message.envelope.tag !== "run"
+                ) {
+                  return storage.registerReplyHandler(message)
+                }
+                return Effect.suspend(() => {
+                  parked++
+                  peak = Math.max(peak, parked)
+                  return storage.registerReplyHandler(message)
+                }).pipe(Effect.ensuring(Effect.sync(() => {
+                  parked--
+                })))
+              }
+            })
+        )
+      ).pipe(Layer.provideMerge(MessageStorage.layerMemory))
+      const Parent = Workflow.make("ManyChildrenParent", {
+        payload: {},
+        success: Schema.Array(Schema.Number),
+        idempotencyKey: () => "parent"
+      })
+      const Child = Workflow.make("ManyChildrenChild", {
+        payload: { index: Schema.Number },
+        success: Schema.Number,
+        idempotencyKey: ({ index }) => String(index)
+      })
+      const ParentLayer = Parent.toLayer(() =>
+        Activity.make({
+          name: "children",
+          success: Schema.Array(Schema.Number),
+          execute: Effect.forEach(indices, (index) => Child.execute({ index }), { concurrency: "unbounded" }).pipe(
+            Effect.ensuring(Effect.andThen(cleaningUp.open, release.await))
+          )
+        })
+      )
+      const ChildLayer = Child.toLayer(({ index }) =>
+        DurableClock.sleep({ name: "wait", duration: "2 seconds", inMemoryThreshold: Duration.zero }).pipe(
+          Effect.as(index)
+        )
+      )
+      yield* Effect.gen(function*() {
+        const sharding = yield* Sharding.Sharding
+        const driver = yield* MessageStorage.MemoryDriver
+        yield* TestClock.adjust(1)
+        const executionId = yield* Parent.execute({}, { discard: true })
+        for (let i = 0; i < 100; i++) {
+          yield* TestClock.adjust(10)
+          yield* sharding.pollStorage
+        }
+        yield* cleaningUp.await
+        yield* TestClock.adjust("2 seconds")
+        for (let i = 0; i < 100; i++) {
+          yield* TestClock.adjust(10)
+          yield* sharding.pollStorage
+        }
+        const wakes = driver.journal.filter((message) =>
+          message._tag === "Request" &&
+          message.address.entityType === "Workflow/ManyChildrenParent" && message.tag === "resume"
+        )
+        const parkedBeforeRelease = parked
+        yield* release.open
+        for (let i = 0; i < 100; i++) {
+          yield* TestClock.adjust(10)
+          yield* sharding.pollStorage
+        }
+        assert.deepStrictEqual(
+          yield* Parent.poll(executionId),
+          Option.some(new Workflow.Complete({ exit: Exit.succeed(indices) }))
+        )
+        assert.strictEqual(parked, 0)
+        assert.strictEqual(wakes.length, indices.length)
+        // Each wake remains durable, but only one waits on this parent run.
+        assert.strictEqual(parkedBeforeRelease, 1, `peak parked reply handlers: ${peak}`)
+      }).pipe(Effect.provide(
+        Layer.mergeAll(ParentLayer, ChildLayer).pipe(
+          Layer.provideMerge(makeTestWorkflowEngine({ entityMailboxCapacity: 1000 }, storageLayer))
+        )
+      ))
+    }))
+
+  for (const queuedReplay of [false, true]) {
+    it.effect(`resumes a fresh entity from a legacy envelope with queued replay ${queuedReplay}`, () =>
+      Effect.gen(function*() {
+        const Parent = Workflow.make("ColdParent", {
+          payload: {},
+          success: Schema.Array(Schema.Number),
+          idempotencyKey: () => "parent"
+        })
+        const Child = Workflow.make("ColdChild", {
+          payload: { index: Schema.Number },
+          success: Schema.Number,
+          idempotencyKey: ({ index }) => String(index)
+        })
+        const gate = DurableDeferred.make("cold-child")
+        const ParentLayer = Parent.toLayer(() =>
+          Activity.make({
+            name: "children",
+            success: Schema.Array(Schema.Number),
+            execute: Effect.forEach([0, 1], (index) => Child.execute({ index }), { concurrency: "unbounded" })
+          })
+        )
+        const ChildLayer = Child.toLayer(({ index }) => DurableDeferred.await(gate).pipe(Effect.as(index)))
+        const LegacyResume = Entity.make("Workflow/ColdParent", [
+          Rpc.make("resume", { payload: {}, primaryKey: () => "" }).annotate(ClusterSchema.Persisted, true)
+        ])
+        yield* Effect.gen(function*() {
+          const sharding = yield* Sharding.Sharding
+          const driver = yield* MessageStorage.MemoryDriver
+          const engine = yield* WorkflowEngine
+          yield* TestClock.adjust(1)
+          const executionId = yield* Parent.execute({}, { discard: true })
+          for (let i = 0; i < 50; i++) {
+            yield* TestClock.adjust(10)
+            yield* sharding.pollStorage
+          }
+          assert.deepStrictEqual(
+            Option.map(yield* Parent.poll(executionId), (result) => result._tag),
+            Option.some("Suspended")
+          )
+          for (let i = 0; i < 12 && (yield* sharding.activeEntityCount) > 0; i++) {
+            yield* TestClock.adjust(5000)
+          }
+          assert.strictEqual(yield* sharding.activeEntityCount, 0)
+          if (queuedReplay) {
+            const run = driver.journal.find((message) =>
+              message._tag === "Request" &&
+              message.address.entityType === "Workflow/ColdParent" && message.tag === "run"
+            )!
+            assert(run._tag === "Request")
+            yield* sharding.reset(run.requestId)
+          }
+          const client = yield* LegacyResume.client
+          // The empty payload is the format of resume messages persisted before this fix.
+          const legacyResume = yield* client(executionId).resume({}).pipe(Effect.forkChild({ startImmediately: true }))
+          for (const index of [0, 1]) {
+            yield* engine.deferredDone(gate, {
+              workflowName: Child._tag,
+              executionId: yield* Child.executionId({ index }),
+              deferredName: gate.name,
+              exit: Exit.void
+            })
+          }
+          for (let i = 0; i < 100; i++) {
+            yield* TestClock.adjust(10)
+            yield* sharding.pollStorage
+          }
+          assert.deepStrictEqual(
+            yield* Parent.poll(executionId),
+            Option.some(new Workflow.Complete({ exit: Exit.succeed([0, 1]) }))
+          )
+          assert.deepStrictEqual(legacyResume.pollUnsafe(), Exit.void)
+        }).pipe(Effect.provide(
+          Layer.mergeAll(ParentLayer, ChildLayer).pipe(
+            Layer.provideMerge(makeTestWorkflowEngine({ entityMessagePollInterval: "1 hour" }))
+          )
+        ))
+      }))
+  }
+
   it.effect("a parent stays suspended past the activity interrupt retry budget", () =>
     Effect.gen(function*() {
       const sharding = yield* Sharding.Sharding
@@ -987,11 +1164,14 @@ describe.concurrent("ClusterWorkflowEngine", () => {
     }).pipe(Effect.provide(TestWorkflowLayer)))
 })
 
-const makeTestWorkflowEngine = (config?: Partial<ShardingConfig.ShardingConfig["Service"]>) =>
+const makeTestWorkflowEngine = (
+  config?: Partial<ShardingConfig.ShardingConfig["Service"]>,
+  storageLayer = MessageStorage.layerMemory
+) =>
   ClusterWorkflowEngine.layer.pipe(
     Layer.provideMerge(Sharding.layer),
     Layer.provide(Runners.layerNoop),
-    Layer.provideMerge(MessageStorage.layerMemory),
+    Layer.provideMerge(storageLayer),
     Layer.provide(RunnerStorage.layerMemory),
     Layer.provide(RunnerHealth.layerNoop),
     Layer.provide(ShardingConfig.layer({

--- a/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
+++ b/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
@@ -627,7 +627,7 @@ describe.concurrent("ClusterWorkflowEngine", () => {
       for (const started of [2, 4, 5]) {
         let suspended = false
         for (let i = 0; i < 50 && !suspended; i++) {
-          yield* TestClock.adjust(1)
+          yield* TestClock.adjust(10)
           yield* sharding.pollStorage
           const result = yield* ParallelParentWorkflow.poll(executionId)
           suspended = Option.isSome(result) && result.value._tag === "Suspended" &&
@@ -647,8 +647,8 @@ describe.concurrent("ClusterWorkflowEngine", () => {
         yield* TestClock.adjust(Duration.seconds(2))
         yield* sharding.pollStorage
       }
-      for (let i = 0; i < 10; i++) {
-        yield* TestClock.adjust(1)
+      for (let i = 0; i < 50; i++) {
+        yield* TestClock.adjust(10)
         yield* sharding.pollStorage
       }
       assert.deepStrictEqual(
@@ -660,6 +660,66 @@ describe.concurrent("ClusterWorkflowEngine", () => {
         Number(flags.get("parallel-runs-parallel-bounded"))
       )
     }).pipe(Effect.provide(TestWorkflowLayer)))
+
+  it.effect("resumes when children complete during activity cleanup", () =>
+    Effect.gen(function*() {
+      const cleaningUp = yield* Latch.make()
+      const release = yield* Latch.make()
+      const Parent = Workflow.make("CleanupParent", {
+        payload: {},
+        success: Schema.Array(Schema.Number),
+        idempotencyKey: () => "parent"
+      })
+      const Child = Workflow.make("CleanupChild", {
+        payload: { index: Schema.Number },
+        success: Schema.Number,
+        idempotencyKey: ({ index }) => String(index)
+      })
+      const ParentLayer = Parent.toLayer(() =>
+        Activity.make({
+          name: "children",
+          success: Schema.Array(Schema.Number),
+          execute: Effect.forEach([0, 1], (index) => Child.execute({ index }), { concurrency: "unbounded" }).pipe(
+            Effect.ensuring(Effect.andThen(cleaningUp.open, release.await))
+          )
+        })
+      )
+      const ChildLayer = Child.toLayer(({ index }) =>
+        DurableClock.sleep({ name: "wait", duration: "2 seconds", inMemoryThreshold: Duration.zero }).pipe(
+          Effect.as(index)
+        )
+      )
+      yield* Effect.gen(function*() {
+        const sharding = yield* Sharding.Sharding
+        yield* TestClock.adjust(1)
+        const executionId = yield* Parent.execute({}, { discard: true })
+        yield* TestClock.adjust(1)
+        yield* sharding.pollStorage
+        yield* cleaningUp.await
+        yield* TestClock.adjust("2 seconds")
+        yield* sharding.pollStorage
+        for (let i = 0; i < 10; i++) {
+          yield* TestClock.adjust(10)
+          yield* sharding.pollStorage
+        }
+        for (const index of [0, 1]) {
+          const childId = yield* Child.executionId({ index })
+          assert.deepStrictEqual(
+            yield* Child.poll(childId),
+            Option.some(new Workflow.Complete({ exit: Exit.succeed(index) }))
+          )
+        }
+        yield* release.open
+        for (let i = 0; i < 50; i++) {
+          yield* TestClock.adjust(10)
+          yield* sharding.pollStorage
+        }
+        assert.deepStrictEqual(
+          yield* Parent.poll(executionId),
+          Option.some(new Workflow.Complete({ exit: Exit.succeed([0, 1]) }))
+        )
+      }).pipe(Effect.provide(Layer.mergeAll(ParentLayer, ChildLayer).pipe(Layer.provideMerge(TestWorkflowLayer))))
+    }))
 
   it.effect("a parent stays suspended past the activity interrupt retry budget", () =>
     Effect.gen(function*() {

--- a/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
+++ b/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
@@ -571,6 +571,170 @@ describe.concurrent("ClusterWorkflowEngine", () => {
     it.effect(`DurableClock.sleep preserves an explicit ${id} zero threshold`, () => verifyZeroThreshold(id, threshold))
   }
 
+  it.effect("parallel child workflows inside an activity suspend the parent durably", () =>
+    Effect.gen(function*() {
+      const sharding = yield* Sharding.Sharding
+      const flags = yield* Flags
+      yield* TestClock.adjust(1)
+
+      const payload = { id: "parallel-activity", childCount: 3, concurrency: 3, sleep: 2000 }
+      const executionId = yield* ParallelParentWorkflow.executionId(payload)
+      const fiber = yield* ParallelParentWorkflow.execute(payload).pipe(
+        Effect.forkChild({ startImmediately: true })
+      )
+
+      // the parent suspends durably once every child has been dispatched
+      let suspended = false
+      for (let i = 0; i < 50 && !suspended; i++) {
+        yield* TestClock.adjust(1)
+        yield* sharding.pollStorage
+        const result = yield* ParallelParentWorkflow.poll(executionId)
+        suspended = Option.isSome(result) && result.value._tag === "Suspended"
+      }
+      assert.isTrue(suspended, "parent run was not durably suspended")
+      assert.strictEqual(flags.get("parallel-runs-parallel-activity"), 1)
+      assert.isTrue(flags.get("parallel-child-start-parallel-activity-child-0"))
+      assert.isTrue(flags.get("parallel-child-start-parallel-activity-child-1"))
+      assert.isTrue(flags.get("parallel-child-start-parallel-activity-child-2"))
+      assert.strictEqual(flags.get("parallel-activity-runs-parallel-activity"), 1)
+      assert.strictEqual(flags.get("parallel-activity-releases-parallel-activity"), 1)
+
+      // the children complete after a single sleep window and wake the parent
+      yield* TestClock.adjust(Duration.seconds(2))
+      yield* sharding.pollStorage
+      for (let i = 0; i < 4; i++) {
+        yield* TestClock.adjust(Duration.seconds(1))
+        yield* sharding.pollStorage
+      }
+      assert.deepStrictEqual(fiber.pollUnsafe(), Exit.succeed(["done-0", "done-1", "done-2"]))
+
+      // the parent replayed after suspending, and no run retried the activity body
+      const parentRuns = Number(flags.get("parallel-runs-parallel-activity"))
+      const activityRuns = Number(flags.get("parallel-activity-runs-parallel-activity"))
+      assert.isAtLeast(parentRuns, 2)
+      assert.isAtMost(activityRuns, parentRuns)
+    }).pipe(Effect.provide(TestWorkflowLayer)))
+
+  it.effect("bounded child concurrency progresses across suspended activity replays", () =>
+    Effect.gen(function*() {
+      const sharding = yield* Sharding.Sharding
+      const flags = yield* Flags
+      yield* TestClock.adjust(1)
+      const payload = { id: "parallel-bounded", childCount: 5, concurrency: 2, sleep: 2000 }
+      const executionId = yield* ParallelParentWorkflow.executionId(payload)
+      yield* ParallelParentWorkflow.execute(payload, { discard: true })
+
+      for (const started of [2, 4, 5]) {
+        let suspended = false
+        for (let i = 0; i < 50 && !suspended; i++) {
+          yield* TestClock.adjust(1)
+          yield* sharding.pollStorage
+          const result = yield* ParallelParentWorkflow.poll(executionId)
+          suspended = Option.isSome(result) && result.value._tag === "Suspended" &&
+            flags.get(`parallel-child-start-parallel-bounded-child-${started - 1}`) === true
+        }
+        assert.isTrue(suspended, `parent did not suspend after dispatching ${started} children`)
+        for (let index = 0; index < 5; index++) {
+          assert.strictEqual(
+            flags.get(`parallel-child-start-parallel-bounded-child-${index}`),
+            index < started ? true : undefined
+          )
+        }
+        assert.strictEqual(
+          flags.get("parallel-activity-releases-parallel-bounded"),
+          flags.get("parallel-activity-runs-parallel-bounded")
+        )
+        yield* TestClock.adjust(Duration.seconds(2))
+        yield* sharding.pollStorage
+      }
+      for (let i = 0; i < 10; i++) {
+        yield* TestClock.adjust(1)
+        yield* sharding.pollStorage
+      }
+      assert.deepStrictEqual(
+        yield* ParallelParentWorkflow.poll(executionId),
+        Option.some(new Workflow.Complete({ exit: Exit.succeed(["done-0", "done-1", "done-2", "done-3", "done-4"]) }))
+      )
+      assert.isAtMost(
+        Number(flags.get("parallel-activity-runs-parallel-bounded")),
+        Number(flags.get("parallel-runs-parallel-bounded"))
+      )
+    }).pipe(Effect.provide(TestWorkflowLayer)))
+
+  it.effect("a parent stays suspended past the activity interrupt retry budget", () =>
+    Effect.gen(function*() {
+      const sharding = yield* Sharding.Sharding
+      const flags = yield* Flags
+      yield* TestClock.adjust(1)
+
+      const payload = { id: "parallel-long", childCount: 2, concurrency: 2, sleep: 60_000 }
+      const executionId = yield* ParallelParentWorkflow.executionId(payload)
+      const fiber = yield* ParallelParentWorkflow.execute(payload).pipe(
+        Effect.forkChild({ startImmediately: true })
+      )
+
+      let suspended = false
+      for (let i = 0; i < 50 && !suspended; i++) {
+        yield* TestClock.adjust(1)
+        yield* sharding.pollStorage
+        const result = yield* ParallelParentWorkflow.poll(executionId)
+        suspended = Option.isSome(result) && result.value._tag === "Suspended"
+      }
+      assert.isTrue(suspended, "parent run was not durably suspended")
+
+      // well past the activity interrupt retry budget the run is still suspended
+      // and the activity body has not been re-executed
+      yield* TestClock.adjust(Duration.seconds(50))
+      yield* sharding.pollStorage
+      const still = yield* ParallelParentWorkflow.poll(executionId)
+      assert.isTrue(Option.isSome(still) && still.value._tag === "Suspended")
+      assert.strictEqual(flags.get("parallel-activity-runs-parallel-long"), 1)
+      assert.strictEqual(flags.get("parallel-activity-releases-parallel-long"), 1)
+      assert.isUndefined(fiber.pollUnsafe())
+
+      yield* TestClock.adjust(Duration.seconds(10))
+      yield* sharding.pollStorage
+      for (let i = 0; i < 6; i++) {
+        yield* TestClock.adjust(Duration.seconds(5))
+        yield* sharding.pollStorage
+      }
+      assert.deepStrictEqual(fiber.pollUnsafe(), Exit.succeed(["done-0", "done-1"]))
+    }).pipe(Effect.provide(TestWorkflowLayer)))
+
+  it.effect("parallel child workflows in the workflow body all dispatch before suspending", () =>
+    Effect.gen(function*() {
+      const sharding = yield* Sharding.Sharding
+      const flags = yield* Flags
+      yield* TestClock.adjust(1)
+
+      const payload = { id: "parallel-direct", childCount: 3 }
+      const executionId = yield* ParallelDirectWorkflow.executionId(payload)
+      const fiber = yield* ParallelDirectWorkflow.execute(payload).pipe(
+        Effect.forkChild({ startImmediately: true })
+      )
+
+      let suspended = false
+      for (let i = 0; i < 50 && !suspended; i++) {
+        yield* TestClock.adjust(1)
+        yield* sharding.pollStorage
+        const result = yield* ParallelDirectWorkflow.poll(executionId)
+        suspended = Option.isSome(result) && result.value._tag === "Suspended"
+      }
+      assert.isTrue(suspended, "parent run was not durably suspended")
+      assert.strictEqual(flags.get("parallel-runs-parallel-direct"), 1)
+      assert.isTrue(flags.get("parallel-child-start-parallel-direct-child-0"))
+      assert.isTrue(flags.get("parallel-child-start-parallel-direct-child-1"))
+      assert.isTrue(flags.get("parallel-child-start-parallel-direct-child-2"))
+
+      yield* TestClock.adjust(Duration.seconds(2))
+      yield* sharding.pollStorage
+      for (let i = 0; i < 4; i++) {
+        yield* TestClock.adjust(Duration.seconds(1))
+        yield* sharding.pollStorage
+      }
+      assert.deepStrictEqual(fiber.pollUnsafe(), Exit.succeed(["done-0", "done-1", "done-2"]))
+    }).pipe(Effect.provide(TestWorkflowLayer)))
+
   it.effect("routes fractional millisecond durable clock wakeups to the workflow shard group", () =>
     Effect.gen(function*() {
       const driver = yield* MessageStorage.MemoryDriver
@@ -1389,6 +1553,87 @@ const ChildWorkflowLayer = ChildWorkflow.toLayer(Effect.fnUntraced(function*() {
   flags.set("child-end", true)
 }))
 
+const ParallelParentWorkflow = Workflow.make("ParallelParentWorkflow", {
+  payload: {
+    id: Schema.String,
+    childCount: Schema.Number,
+    concurrency: Schema.Number,
+    sleep: Schema.Number
+  },
+  success: Schema.Array(Schema.String),
+  idempotencyKey(payload) {
+    return payload.id
+  }
+})
+
+const ParallelDirectWorkflow = Workflow.make("ParallelDirectWorkflow", {
+  payload: {
+    id: Schema.String,
+    childCount: Schema.Number
+  },
+  success: Schema.Array(Schema.String),
+  idempotencyKey(payload) {
+    return payload.id
+  }
+})
+
+const ParallelChildWorkflow = Workflow.make("ParallelChildWorkflow", {
+  payload: {
+    id: Schema.String,
+    index: Schema.Number,
+    sleep: Schema.Number
+  },
+  success: Schema.String,
+  idempotencyKey(payload) {
+    return payload.id
+  }
+})
+
+const increment = (flags: Map<string, boolean | number | string>, key: string) => {
+  flags.set(key, Number(flags.get(key) ?? 0) + 1)
+}
+
+const ParallelParentWorkflowLayer = ParallelParentWorkflow.toLayer(Effect.fnUntraced(function*(payload) {
+  const flags = yield* Flags
+  increment(flags, `parallel-runs-${payload.id}`)
+  const indices = Array.from({ length: payload.childCount }, (_, i) => i)
+  return yield* Activity.make({
+    name: "parallel-children",
+    success: Schema.Array(Schema.String),
+    error: Schema.Never,
+    execute: Effect.suspend(() => {
+      increment(flags, `parallel-activity-runs-${payload.id}`)
+      return Effect.forEach(
+        indices,
+        (index) => ParallelChildWorkflow.execute({ id: `${payload.id}-child-${index}`, index, sleep: payload.sleep }),
+        { concurrency: payload.concurrency }
+      )
+    }).pipe(Effect.ensuring(Effect.sync(() => increment(flags, `parallel-activity-releases-${payload.id}`))))
+  })
+}))
+
+const ParallelDirectWorkflowLayer = ParallelDirectWorkflow.toLayer(Effect.fnUntraced(function*(payload) {
+  const flags = yield* Flags
+  increment(flags, `parallel-runs-${payload.id}`)
+  const indices = Array.from({ length: payload.childCount }, (_, i) => i)
+  return yield* Effect.forEach(
+    indices,
+    (index) => ParallelChildWorkflow.execute({ id: `${payload.id}-child-${index}`, index, sleep: 2000 }),
+    { concurrency: "unbounded" }
+  )
+}))
+
+const ParallelChildWorkflowLayer = ParallelChildWorkflow.toLayer(Effect.fnUntraced(function*(payload) {
+  const flags = yield* Flags
+  flags.set(`parallel-child-start-${payload.id}`, true)
+  yield* DurableClock.sleep({
+    name: "parallel-child",
+    duration: payload.sleep,
+    inMemoryThreshold: Duration.zero
+  })
+  return `done-${payload.index}`
+}))
+
 const ZeroThresholdWorkflow = Workflow.make("DurableClock/ZeroThreshold", {
   payload: { id: Schema.String },
   idempotencyKey: ({ id }) => id
@@ -1566,6 +1811,9 @@ const TestWorkflowLayer = EmailWorkflowLayer.pipe(
   Layer.merge(RaceWorkflowLayers),
   Layer.merge(ParentWorkflowLayer),
   Layer.merge(ChildWorkflowLayer),
+  Layer.merge(ParallelParentWorkflowLayer),
+  Layer.merge(ParallelDirectWorkflowLayer),
+  Layer.merge(ParallelChildWorkflowLayer),
   Layer.merge(ShardedClockWorkflowLayer),
   Layer.merge(SuspendOnFailureWorkflowLayer),
   Layer.merge(CatchWorkflowLayer),

--- a/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
+++ b/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
@@ -1,7 +1,7 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Exit, Fiber, Latch, Layer, Option, Ref, Schema, Scope } from "effect"
+import { Duration, Effect, Exit, Fiber, Latch, Layer, Option, Ref, Schema, Scope } from "effect"
 import { TestClock } from "effect/testing"
-import { DurableDeferred, Workflow, WorkflowEngine } from "effect/unstable/workflow"
+import { Activity, DurableClock, DurableDeferred, Workflow, WorkflowEngine } from "effect/unstable/workflow"
 
 describe("WorkflowEngine", () => {
   const IncrementWorkflow = Workflow.make("WorkflowEngine/IncrementWorkflow", {
@@ -46,6 +46,50 @@ describe("WorkflowEngine", () => {
     })
   )
 
+  const FanOutParentWorkflow = Workflow.make("WorkflowEngine/FanOutParentWorkflow", {
+    payload: { id: Schema.String, childCount: Schema.Number },
+    success: Schema.Array(Schema.String),
+    idempotencyKey: ({ id }) => id
+  })
+
+  const FanOutChildWorkflow = Workflow.make("WorkflowEngine/FanOutChildWorkflow", {
+    payload: { id: Schema.String, index: Schema.Number },
+    success: Schema.String,
+    idempotencyKey: ({ id }) => id
+  })
+
+  const fanOutStarted = new Set<number>()
+  let fanOutParentRuns = 0
+  let fanOutActivityRuns = 0
+
+  const FanOutParentWorkflowLayer = FanOutParentWorkflow.toLayer(({ childCount, id }) =>
+    Effect.suspend(() => {
+      fanOutParentRuns++
+      return Activity.make({
+        name: "fan-out",
+        success: Schema.Array(Schema.String),
+        execute: Effect.suspend(() => {
+          fanOutActivityRuns++
+          return Effect.forEach(
+            Array.from({ length: childCount }, (_, index) => index),
+            (index) => FanOutChildWorkflow.execute({ id: `${id}-child-${index}`, index }),
+            { concurrency: "unbounded" }
+          )
+        })
+      })
+    })
+  )
+
+  const FanOutChildWorkflowLayer = FanOutChildWorkflow.toLayer(Effect.fnUntraced(function*({ index }) {
+    fanOutStarted.add(index)
+    yield* DurableClock.sleep({
+      name: "fan-out-child",
+      duration: "2 seconds",
+      inMemoryThreshold: Duration.zero
+    })
+    return `done-${index}`
+  }))
+
   it.effect("layer executes and polls workflows", () =>
     Effect.gen(function*() {
       const executionId = yield* IncrementWorkflow.execute({ value: 1 }, { discard: true })
@@ -60,6 +104,86 @@ describe("WorkflowEngine", () => {
         Layer.provideMerge(WorkflowEngine.layerMemory)
       ))
     ))
+
+  it.effect("layerMemory suspends the parent durably while parallel child workflows run inside an activity", () =>
+    Effect.gen(function*() {
+      const payload = { id: "fan-out-1", childCount: 3 }
+      const executionId = yield* FanOutParentWorkflow.executionId(payload)
+      const fiber = yield* FanOutParentWorkflow.execute(payload).pipe(
+        Effect.forkChild({ startImmediately: true })
+      )
+
+      // the parent suspends once every child has been dispatched
+      let suspended = false
+      for (let i = 0; i < 50 && !suspended; i++) {
+        yield* TestClock.adjust(1)
+        const result = yield* FanOutParentWorkflow.poll(executionId)
+        suspended = Option.isSome(result) && result.value._tag === "Suspended"
+      }
+      assert.isTrue(suspended, "parent run was not suspended")
+      assert.strictEqual(fanOutParentRuns, 1)
+      assert.deepStrictEqual([...fanOutStarted].sort(), [0, 1, 2])
+      assert.strictEqual(fanOutActivityRuns, 1)
+
+      // the children complete after a single sleep window and wake the parent
+      yield* TestClock.adjust(Duration.seconds(2))
+      for (let i = 0; i < 4; i++) {
+        yield* TestClock.adjust(Duration.seconds(1))
+      }
+      assert.deepStrictEqual(fiber.pollUnsafe(), Exit.succeed(["done-0", "done-1", "done-2"]))
+      assert.isAtLeast(fanOutParentRuns, 2)
+      assert.isAtMost(fanOutActivityRuns, fanOutParentRuns)
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(FanOutParentWorkflowLayer, FanOutChildWorkflowLayer).pipe(
+          Layer.provideMerge(WorkflowEngine.layerMemory)
+        )
+      )
+    ))
+
+  it.effect("layerMemory resumes when children complete during activity cleanup", () =>
+    Effect.gen(function*() {
+      const cleaningUp = yield* Latch.make()
+      const release = yield* Latch.make()
+      const Parent = Workflow.make("WorkflowEngine/CleanupParent", {
+        payload: {},
+        success: Schema.Array(Schema.Number),
+        idempotencyKey: () => "parent"
+      })
+      const Child = Workflow.make("WorkflowEngine/CleanupChild", {
+        payload: { index: Schema.Number },
+        success: Schema.Number,
+        idempotencyKey: ({ index }) => String(index)
+      })
+      const ParentLayer = Parent.toLayer(() =>
+        Activity.make({
+          name: "children",
+          success: Schema.Array(Schema.Number),
+          execute: Effect.forEach([0, 1], (index) => Child.execute({ index }), { concurrency: "unbounded" }).pipe(
+            Effect.ensuring(Effect.andThen(cleaningUp.open, release.await))
+          )
+        })
+      )
+      const ChildLayer = Child.toLayer(({ index }) =>
+        DurableClock.sleep({ name: "wait", duration: "2 seconds", inMemoryThreshold: Duration.zero }).pipe(
+          Effect.as(index)
+        )
+      )
+      yield* Effect.gen(function*() {
+        const executionId = yield* Parent.execute({}, { discard: true })
+        yield* TestClock.adjust(1)
+        yield* cleaningUp.await
+        yield* TestClock.adjust("2 seconds")
+        yield* release.open
+        yield* TestClock.adjust(1)
+        assert.deepStrictEqual(
+          yield* Parent.poll(executionId),
+          Option.some(new Workflow.Complete({ exit: Exit.succeed([0, 1]) }))
+        )
+      }).pipe(
+        Effect.provide(Layer.mergeAll(ParentLayer, ChildLayer).pipe(Layer.provideMerge(WorkflowEngine.layerMemory)))
+      )
+    }))
 
   it.effect("discard returns the deterministic execution ID", () =>
     Effect.gen(function*() {

--- a/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
+++ b/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
@@ -108,10 +108,7 @@ describe("WorkflowEngine", () => {
   it.effect("layerMemory suspends the parent durably while parallel child workflows run inside an activity", () =>
     Effect.gen(function*() {
       const payload = { id: "fan-out-1", childCount: 3 }
-      const executionId = yield* FanOutParentWorkflow.executionId(payload)
-      const fiber = yield* FanOutParentWorkflow.execute(payload).pipe(
-        Effect.forkChild({ startImmediately: true })
-      )
+      const executionId = yield* FanOutParentWorkflow.execute(payload, { discard: true })
 
       // the parent suspends once every child has been dispatched
       let suspended = false
@@ -127,10 +124,13 @@ describe("WorkflowEngine", () => {
 
       // the children complete after a single sleep window and wake the parent
       yield* TestClock.adjust(Duration.seconds(2))
-      for (let i = 0; i < 4; i++) {
-        yield* TestClock.adjust(Duration.seconds(1))
+      for (let i = 0; i < 50; i++) {
+        yield* TestClock.adjust(1)
       }
-      assert.deepStrictEqual(fiber.pollUnsafe(), Exit.succeed(["done-0", "done-1", "done-2"]))
+      assert.deepStrictEqual(
+        yield* FanOutParentWorkflow.poll(executionId),
+        Option.some(new Workflow.Complete({ exit: Exit.succeed(["done-0", "done-1", "done-2"]) }))
+      )
       assert.isAtLeast(fanOutParentRuns, 2)
       assert.isAtMost(fanOutActivityRuns, fanOutParentRuns)
     }).pipe(
@@ -175,7 +175,9 @@ describe("WorkflowEngine", () => {
         yield* cleaningUp.await
         yield* TestClock.adjust("2 seconds")
         yield* release.open
-        yield* TestClock.adjust(1)
+        for (let i = 0; i < 50; i++) {
+          yield* TestClock.adjust(1)
+        }
         assert.deepStrictEqual(
           yield* Parent.poll(executionId),
           Option.some(new Workflow.Complete({ exit: Exit.succeed([0, 1]) }))
@@ -184,6 +186,69 @@ describe("WorkflowEngine", () => {
         Effect.provide(Layer.mergeAll(ParentLayer, ChildLayer).pipe(Layer.provideMerge(WorkflowEngine.layerMemory)))
       )
     }))
+
+  for (const mode of ["failure", "interruption"] as const) {
+    it.effect(`layerMemory releases a pending child registration on ${mode}`, () =>
+      Effect.gen(function*() {
+        const computingId = yield* Latch.make()
+        const started = new Set<number>()
+        const Parent = Workflow.make(`WorkflowEngine/PendingParent/${mode}`, {
+          payload: {},
+          success: Schema.Array(Schema.Number),
+          idempotencyKey: () => "parent"
+        })
+        const Child = Workflow.make(`WorkflowEngine/PendingChild/${mode}`, {
+          payload: { index: Schema.Number },
+          success: Schema.Number,
+          idempotencyKey: ({ index }) => {
+            if (index === 1) {
+              if (mode === "failure") throw new Error("cannot compute the execution id")
+              computingId.openUnsafe()
+            }
+            return String(index)
+          }
+        })
+        const ParentLayer = Parent.toLayer(() =>
+          Activity.make({
+            name: "children",
+            success: Schema.Array(Schema.Number),
+            execute: Effect.forEach([0, 1], (index) => {
+              const execute = Child.execute({ index })
+              if (index === 0) return execute
+              return mode === "failure"
+                ? Effect.catchDefect(execute, () => Effect.succeed(-1))
+                : Effect.raceFirst(execute, Effect.as(computingId.await, -1))
+            }, { concurrency: "unbounded" })
+          })
+        )
+        const ChildLayer = Child.toLayer(Effect.fnUntraced(function*({ index }) {
+          started.add(index)
+          yield* DurableClock.sleep({ name: "wait", duration: "2 seconds", inMemoryThreshold: Duration.zero })
+          return index
+        }))
+        yield* Effect.gen(function*() {
+          const executionId = yield* Parent.execute({}, { discard: true })
+          for (let i = 0; i < 50; i++) {
+            yield* TestClock.adjust(1)
+          }
+          assert.deepStrictEqual(
+            Option.map(yield* Parent.poll(executionId), (result) => result._tag),
+            Option.some("Suspended")
+          )
+          assert.deepStrictEqual([...started], [0])
+          yield* TestClock.adjust("2 seconds")
+          for (let i = 0; i < 50; i++) {
+            yield* TestClock.adjust(1)
+          }
+          assert.deepStrictEqual(
+            yield* Parent.poll(executionId),
+            Option.some(new Workflow.Complete({ exit: Exit.succeed([0, -1]) }))
+          )
+        }).pipe(
+          Effect.provide(Layer.mergeAll(ParentLayer, ChildLayer).pipe(Layer.provideMerge(WorkflowEngine.layerMemory)))
+        )
+      }))
+  }
 
   it.effect("discard returns the deterministic execution ID", () =>
     Effect.gen(function*() {

--- a/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
+++ b/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
@@ -46,50 +46,6 @@ describe("WorkflowEngine", () => {
     })
   )
 
-  const FanOutParentWorkflow = Workflow.make("WorkflowEngine/FanOutParentWorkflow", {
-    payload: { id: Schema.String, childCount: Schema.Number },
-    success: Schema.Array(Schema.String),
-    idempotencyKey: ({ id }) => id
-  })
-
-  const FanOutChildWorkflow = Workflow.make("WorkflowEngine/FanOutChildWorkflow", {
-    payload: { id: Schema.String, index: Schema.Number },
-    success: Schema.String,
-    idempotencyKey: ({ id }) => id
-  })
-
-  const fanOutStarted = new Set<number>()
-  let fanOutParentRuns = 0
-  let fanOutActivityRuns = 0
-
-  const FanOutParentWorkflowLayer = FanOutParentWorkflow.toLayer(({ childCount, id }) =>
-    Effect.suspend(() => {
-      fanOutParentRuns++
-      return Activity.make({
-        name: "fan-out",
-        success: Schema.Array(Schema.String),
-        execute: Effect.suspend(() => {
-          fanOutActivityRuns++
-          return Effect.forEach(
-            Array.from({ length: childCount }, (_, index) => index),
-            (index) => FanOutChildWorkflow.execute({ id: `${id}-child-${index}`, index }),
-            { concurrency: "unbounded" }
-          )
-        })
-      })
-    })
-  )
-
-  const FanOutChildWorkflowLayer = FanOutChildWorkflow.toLayer(Effect.fnUntraced(function*({ index }) {
-    fanOutStarted.add(index)
-    yield* DurableClock.sleep({
-      name: "fan-out-child",
-      duration: "2 seconds",
-      inMemoryThreshold: Duration.zero
-    })
-    return `done-${index}`
-  }))
-
   it.effect("layer executes and polls workflows", () =>
     Effect.gen(function*() {
       const executionId = yield* IncrementWorkflow.execute({ value: 1 }, { discard: true })
@@ -105,41 +61,82 @@ describe("WorkflowEngine", () => {
       ))
     ))
 
-  it.effect("layerMemory suspends the parent durably while parallel child workflows run inside an activity", () =>
-    Effect.gen(function*() {
-      const payload = { id: "fan-out-1", childCount: 3 }
-      const executionId = yield* FanOutParentWorkflow.execute(payload, { discard: true })
-
-      // the parent suspends once every child has been dispatched
-      let suspended = false
-      for (let i = 0; i < 50 && !suspended; i++) {
-        yield* TestClock.adjust(1)
-        const result = yield* FanOutParentWorkflow.poll(executionId)
-        suspended = Option.isSome(result) && result.value._tag === "Suspended"
-      }
-      assert.isTrue(suspended, "parent run was not suspended")
-      assert.strictEqual(fanOutParentRuns, 1)
-      assert.deepStrictEqual([...fanOutStarted].sort(), [0, 1, 2])
-      assert.strictEqual(fanOutActivityRuns, 1)
-
-      // the children complete after a single sleep window and wake the parent
-      yield* TestClock.adjust(Duration.seconds(2))
-      for (let i = 0; i < 50; i++) {
-        yield* TestClock.adjust(1)
-      }
-      assert.deepStrictEqual(
-        yield* FanOutParentWorkflow.poll(executionId),
-        Option.some(new Workflow.Complete({ exit: Exit.succeed(["done-0", "done-1", "done-2"]) }))
-      )
-      assert.isAtLeast(fanOutParentRuns, 2)
-      assert.isAtMost(fanOutActivityRuns, fanOutParentRuns)
-    }).pipe(
-      Effect.provide(
-        Layer.mergeAll(FanOutParentWorkflowLayer, FanOutChildWorkflowLayer).pipe(
-          Layer.provideMerge(WorkflowEngine.layerMemory)
+  for (
+    const { childCount, concurrency, waves } of [
+      { childCount: 3, concurrency: "unbounded" as const, waves: [3] },
+      { childCount: 5, concurrency: 2, waves: [2, 4, 5] }
+    ]
+  ) {
+    it.effect(`layerMemory replays suspended activity fan-out with concurrency ${concurrency}`, () =>
+      Effect.gen(function*() {
+        const Parent = Workflow.make("WorkflowEngine/FanOutParent", {
+          payload: {},
+          success: Schema.Array(Schema.Number),
+          idempotencyKey: () => "parent"
+        })
+        const Child = Workflow.make("WorkflowEngine/FanOutChild", {
+          payload: { index: Schema.Number },
+          success: Schema.Number,
+          idempotencyKey: ({ index }) => String(index)
+        })
+        const started = new Set<number>()
+        let parentRuns = 0
+        let activityRuns = 0
+        let released = 0
+        const ParentLayer = Parent.toLayer(() =>
+          Effect.suspend(() => {
+            parentRuns++
+            return Activity.make({
+              name: "fan-out",
+              success: Schema.Array(Schema.Number),
+              execute: Effect.suspend(() => {
+                activityRuns++
+                return Effect.forEach(
+                  Array.from({ length: childCount }, (_, index) => index),
+                  (index) => Child.execute({ index }),
+                  { concurrency }
+                )
+              }).pipe(Effect.ensuring(Effect.sync(() => {
+                released++
+              })))
+            })
+          })
         )
-      )
-    ))
+        const ChildLayer = Child.toLayer(Effect.fnUntraced(function*({ index }) {
+          started.add(index)
+          yield* DurableClock.sleep({ name: "child", duration: "2 seconds", inMemoryThreshold: Duration.zero })
+          return index
+        }))
+        yield* Effect.gen(function*() {
+          const executionId = yield* Parent.execute({}, { discard: true })
+          for (const expected of waves) {
+            let suspended = false
+            for (let i = 0; i < 50 && !suspended; i++) {
+              yield* TestClock.adjust(1)
+              const result = yield* Parent.poll(executionId)
+              suspended = Option.isSome(result) && result.value._tag === "Suspended" && started.size === expected
+            }
+            assert.isTrue(suspended, `parent did not suspend after ${expected} children`)
+            assert.deepStrictEqual([...started].sort(), Array.from({ length: expected }, (_, index) => index))
+            assert.strictEqual(released, activityRuns)
+            assert.isAtMost(activityRuns, parentRuns)
+            if (expected === waves[0]) assert.strictEqual(parentRuns, 1)
+            yield* TestClock.adjust("2 seconds")
+          }
+          for (let i = 0; i < 50; i++) yield* TestClock.adjust(1)
+          assert.deepStrictEqual(
+            yield* Parent.poll(executionId),
+            Option.some(
+              new Workflow.Complete({ exit: Exit.succeed(Array.from({ length: childCount }, (_, index) => index)) })
+            )
+          )
+          assert.isAtLeast(parentRuns, waves.length + 1)
+          assert.isAtMost(activityRuns, parentRuns)
+        }).pipe(
+          Effect.provide(Layer.mergeAll(ParentLayer, ChildLayer).pipe(Layer.provideMerge(WorkflowEngine.layerMemory)))
+        )
+      }))
+  }
 
   it.effect("layerMemory resumes when children complete during activity cleanup", () =>
     Effect.gen(function*() {

--- a/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
+++ b/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
@@ -109,26 +109,27 @@ describe("WorkflowEngine", () => {
         }))
         yield* Effect.gen(function*() {
           const executionId = yield* Parent.execute({}, { discard: true })
+          // Execution-ID digests use real promises, so wait for state rather than clock ticks.
           for (const expected of waves) {
-            let suspended = false
-            for (let i = 0; i < 50 && !suspended; i++) {
-              yield* TestClock.adjust(1)
-              const result = yield* Parent.poll(executionId)
-              suspended = Option.isSome(result) && result.value._tag === "Suspended" && started.size === expected
+            let result = yield* Parent.poll(executionId)
+            while (Option.isNone(result) || result.value._tag !== "Suspended" || started.size !== expected) {
+              yield* Effect.yieldNow
+              result = yield* Parent.poll(executionId)
             }
-            assert.isTrue(suspended, `parent did not suspend after ${expected} children`)
             assert.deepStrictEqual([...started].sort(), Array.from({ length: expected }, (_, index) => index))
             assert.strictEqual(released, activityRuns)
             assert.isAtMost(activityRuns, parentRuns)
             if (expected === waves[0]) assert.strictEqual(parentRuns, 1)
             yield* TestClock.adjust("2 seconds")
           }
-          for (let i = 0; i < 50; i++) yield* TestClock.adjust(1)
+          let result = yield* Parent.poll(executionId)
+          while (Option.isNone(result) || result.value._tag !== "Complete") {
+            yield* Effect.yieldNow
+            result = yield* Parent.poll(executionId)
+          }
           assert.deepStrictEqual(
-            yield* Parent.poll(executionId),
-            Option.some(
-              new Workflow.Complete({ exit: Exit.succeed(Array.from({ length: childCount }, (_, index) => index)) })
-            )
+            result.value,
+            new Workflow.Complete({ exit: Exit.succeed(Array.from({ length: childCount }, (_, index) => index)) })
           )
           assert.isAtLeast(parentRuns, waves.length + 1)
           assert.isAtMost(activityRuns, parentRuns)
@@ -168,16 +169,17 @@ describe("WorkflowEngine", () => {
       )
       yield* Effect.gen(function*() {
         const executionId = yield* Parent.execute({}, { discard: true })
-        yield* TestClock.adjust(1)
         yield* cleaningUp.await
         yield* TestClock.adjust("2 seconds")
         yield* release.open
-        for (let i = 0; i < 50; i++) {
-          yield* TestClock.adjust(1)
+        let result = yield* Parent.poll(executionId)
+        while (Option.isNone(result) || result.value._tag !== "Complete") {
+          yield* Effect.yieldNow
+          result = yield* Parent.poll(executionId)
         }
         assert.deepStrictEqual(
-          yield* Parent.poll(executionId),
-          Option.some(new Workflow.Complete({ exit: Exit.succeed([0, 1]) }))
+          result.value,
+          new Workflow.Complete({ exit: Exit.succeed([0, 1]) })
         )
       }).pipe(
         Effect.provide(Layer.mergeAll(ParentLayer, ChildLayer).pipe(Layer.provideMerge(WorkflowEngine.layerMemory)))
@@ -225,21 +227,21 @@ describe("WorkflowEngine", () => {
         }))
         yield* Effect.gen(function*() {
           const executionId = yield* Parent.execute({}, { discard: true })
-          for (let i = 0; i < 50; i++) {
-            yield* TestClock.adjust(1)
+          let result = yield* Parent.poll(executionId)
+          while (Option.isNone(result) || result.value._tag !== "Suspended") {
+            yield* Effect.yieldNow
+            result = yield* Parent.poll(executionId)
           }
-          assert.deepStrictEqual(
-            Option.map(yield* Parent.poll(executionId), (result) => result._tag),
-            Option.some("Suspended")
-          )
           assert.deepStrictEqual([...started], [0])
           yield* TestClock.adjust("2 seconds")
-          for (let i = 0; i < 50; i++) {
-            yield* TestClock.adjust(1)
+          result = yield* Parent.poll(executionId)
+          while (Option.isNone(result) || result.value._tag !== "Complete") {
+            yield* Effect.yieldNow
+            result = yield* Parent.poll(executionId)
           }
           assert.deepStrictEqual(
-            yield* Parent.poll(executionId),
-            Option.some(new Workflow.Complete({ exit: Exit.succeed([0, -1]) }))
+            result.value,
+            new Workflow.Complete({ exit: Exit.succeed([0, -1]) })
           )
         }).pipe(
           Effect.provide(Layer.mergeAll(ParentLayer, ChildLayer).pipe(Layer.provideMerge(WorkflowEngine.layerMemory)))


### PR DESCRIPTION
Parallel child workflows inside an activity could interrupt sibling dispatch, repeatedly retry the activity, and eventually exhaust its interrupt retry budget. Register children before execution-ID calculation and let intentional suspension return a durable `Suspended` result, releasing activity resources while children wait.

Preserve child wakeups that arrive during parent cleanup in both engines. Cluster resume messages use a separate key per child, and concurrent wakes share one pending wait for the parent's persisted reply. Coalescing stops before the parent is reset so later completions can wake the next replay. Empty resume envelopes persisted by older runners remain valid. Resume handlers do not occupy the slot reserved for deferred completions.

Pending child registrations are released on failure or cancellation and adopted once by the matching workflow instance. Attempting to consume a registration twice fails with a defect instead of silently adding a slot that could deadlock suspension.

Activities retain normal replay semantics: their bodies can execute again when the parent resumes. Bounded concurrency dispatches the next batch on replay. No child-wait polling loop is added.

Validation:

- Regression pass reproduced activity suspension failures and incomplete sibling dispatch before implementation.
- 164 workflow and cluster tests pass, including bounded replay in both engines, long suspension, resource release, cancellation during ID calculation, ID calculation failure, and child completion during cleanup. Existing durable race and clock-in-activity tests also pass.
- The 64-child cleanup regression reduces peak parked reply handlers from 64 to 1 while retaining each durable wake. Fresh-entity tests cover legacy resume envelopes against both suspended and queued parent runs.
- Repository-wide `pnpm check` and `pnpm lint` pass (all toolchain commands run through `nix develop -c`).
- `pnpm jsdocs --check` reports existing errors in unchanged `Multipart.ts` and `ChildProcess.ts`; the updated Activity documentation has no diagnostics.
- Includes an `effect` patch changeset.

Closes EFF-1268
