### PR TITLE
fix(platform): propagate upstream NodeStream duplex failures

### DIFF
--- a/.changeset/calm-ducks-fail.md
+++ b/.changeset/calm-ducks-fail.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+Wake `NodeStream.pipeThroughDuplex` readers when the upstream fails so the original error is propagated instead of hanging.

--- a/packages/platform/node-shared/src/NodeStream.ts
+++ b/packages/platform/node-shared/src/NodeStream.ts
@@ -86,6 +86,7 @@ export const fromDuplex = <IE, I = Uint8Array, O = Uint8Array, E = Cause.Unknown
   Channel.fromTransform((upstream, scope) => {
     const duplex = options.evaluate()
     const exit = MutableRef.make<Exit.Exit<never, IE | E | Cause.Done> | undefined>(undefined)
+    const latch = Latch.makeUnsafe(false)
 
     return pullIntoWritable({
       pull: upstream,
@@ -97,6 +98,7 @@ export const fromDuplex = <IE, I = Uint8Array, O = Uint8Array, E = Cause.Unknown
       Effect.catchCause((cause) => {
         if (Pull.isDoneCause(cause)) return Effect.void
         exit.current = Exit.failCause(cause as Cause.Cause<IE | E | Cause.Done>)
+        latch.openUnsafe()
         return Effect.void
       }),
       Effect.forkIn(scope),
@@ -104,6 +106,7 @@ export const fromDuplex = <IE, I = Uint8Array, O = Uint8Array, E = Cause.Unknown
         readableToPullUnsafe({
           scope,
           exit,
+          latch,
           readable: duplex,
           onError: options.onError ?? defaultOnError as any,
           chunkSize: options.chunkSize
@@ -330,6 +333,7 @@ export const toUint8Array = <E = Cause.UnknownError>(
 const readableToPullUnsafe = <A, E>(options: {
   readonly scope: Scope.Scope
   readonly exit?: MutableRef.MutableRef<Exit.Exit<never, E | Cause.Done> | undefined> | undefined
+  readonly latch?: Latch.Latch | undefined
   readonly readable: Readable | NodeJS.ReadableStream
   readonly onError: (error: unknown) => E
   readonly chunkSize: number | undefined
@@ -339,7 +343,7 @@ const readableToPullUnsafe = <A, E>(options: {
 
   const closeOnDone = options.closeOnDone ?? true
   const exit = options.exit ?? MutableRef.make(undefined)
-  const latch = Latch.makeUnsafe(false)
+  const latch = options.latch ?? Latch.makeUnsafe(false)
   function onReadable() {
     latch.openUnsafe()
   }

--- a/packages/platform/node-shared/test/NodeStream.test.ts
+++ b/packages/platform/node-shared/test/NodeStream.test.ts
@@ -89,7 +89,6 @@ describe("Stream", () => {
             })
         }),
         Stream.runDrain,
-        Effect.timeout(1000),
         Effect.flip
       )
 

--- a/packages/platform/node-shared/test/NodeStream.test.ts
+++ b/packages/platform/node-shared/test/NodeStream.test.ts
@@ -76,6 +76,26 @@ describe("Stream", () => {
       assert.strictEqual(result, "ABC")
     }))
 
+  it.effect("pipeThroughDuplex propagates upstream failure", () =>
+    Effect.gen(function*() {
+      const result = yield* Stream.fail("upstream error").pipe(
+        NodeStream.pipeThroughDuplex({
+          evaluate: () =>
+            new Duplex({
+              read() {},
+              write(_chunk, _encoding, callback) {
+                callback()
+              }
+            })
+        }),
+        Stream.runDrain,
+        Effect.timeout(1000),
+        Effect.flip
+      )
+
+      assert.strictEqual(result, "upstream error")
+    }))
+
   it.effect("pipeThroughDuplex write error", () =>
     Effect.gen(function*() {
       const result = yield* Stream.fromArray(["a", "b", "c"]).pipe(


### PR DESCRIPTION
Fixes #8069

## Root cause

`pipeThroughDuplex` runs the upstream writer and duplex reader independently. If the upstream fails before the duplex emits any data, the reader can enter this sequence:

- `read()` returns `null`, so the reader closes its latch and waits.
- The writer catches the upstream failure and stores it in the shared `exit` ref.
- Nothing opens the reader latch, and the duplex emits no `readable`, `error`, or `end` event.
- The reader never wakes up to inspect `exit`, so the original failure is lost and the stream hangs forever.

This is a lost wake-up, not a timeout problem. The timeout only makes the hang visible by replacing the missing upstream error with `TimeoutError`.

## Fix

Share the reader latch with the writer fiber and open it when the writer records a non-completion failure. The reader then resumes, sees the stored cause, and propagates the original error.

## Verification

- Reproduced the hang with `Stream.fail(new Boom())` before the duplex emits any data.
- Added a regression test for upstream failure propagation.
- `pnpm test --run packages/platform/node-shared/test/NodeStream.test.ts` (13 passed)
- `pnpm --dir packages/platform/node-shared check`
- Confirmed the original `Boom` failure now returns immediately.

Includes a patch changeset for `@effect/platform-node-shared`.