### PR TITLE
Fix extra arguments in Effect.flatMap callbacks

### DIFF
--- a/.changeset/fix-flatmap-callback-arguments.md
+++ b/.changeset/fix-flatmap-callback-arguments.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Effect.flatMap` and the deferred path of `Effect.flatMapEager` passing internal runtime arguments to callbacks with default or rest parameters. Callbacks now receive only the success value regardless of their declared arity.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -1772,7 +1772,7 @@ export const flatMap: {
   <A, E, R, B, E2, R2>(
     self: Effect.Effect<A, E, R>,
     f: (a: A) => Effect.Effect<B, E2, R2>
-  ): Effect.Effect<B, E | E2, R | R2> => new OnSuccessImpl(self, f.length !== 1 ? (a: A) => f(a) : f)
+  ): Effect.Effect<B, E | E2, R | R2> => new ContImpl(self, andThenCont, f)
 )
 
 /** @internal */

--- a/packages/effect/test/Effect.flatMap.test.ts
+++ b/packages/effect/test/Effect.flatMap.test.ts
@@ -1,0 +1,39 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+
+for (const flatMap of [Effect.flatMap, Effect.flatMapEager]) {
+  describe(flatMap === Effect.flatMap ? "flatMap" : "flatMapEager", () => {
+    for (
+      const [name, source] of [
+        ["succeed", Effect.succeed(42)],
+        ["sync", Effect.sync(() => 42)]
+      ] as const
+    ) {
+      describe(name, () => {
+        it("preserves callback default parameters", () => {
+          const result = Effect.runSync(
+            flatMap(source, (value, extra = "default") => Effect.succeed([value, extra === "default"]))
+          )
+
+          assert.deepEqual(result, [42, true])
+        })
+
+        it("passes no extra rest arguments to the callback", () => {
+          const result = Effect.runSync(
+            source.pipe(flatMap((value, ...extra: Array<unknown>) => Effect.succeed([value, extra.length])))
+          )
+
+          assert.deepEqual(result, [42, 0])
+        })
+
+        it("passes exactly one argument to a unary callback", () => {
+          const result = Effect.runSync(flatMap(source, function(value) {
+            return Effect.succeed([value, arguments.length])
+          }))
+
+          assert.deepEqual(result, [42, 1])
+        })
+      })
+    }
+  })
+}


### PR DESCRIPTION
`Effect.flatMap` still checks `f.length`, but a callback such as `(value, extra = "default") => ...` has length one and bypasses its wrapper. The runtime then supplies the fiber and, on the success-exit path, the exit as extra arguments. Rest parameters and `arguments` expose the same problem. The deferred path of `flatMapEager` is also affected.

Reuse the existing `andThen` continuation so callbacks always receive only the success value. The arity guard dates to July 2025; this fixes a gap in that guard rather than restoring a removed check. Includes a patch changeset.

Regression tests and implementation are separate commits. Before the fix, 9 of the 12 new cases failed; the eager success cases already passed. Coverage includes default parameters, rest parameters, and `arguments.length`, with `succeed` and `sync` sources and both calling styles.

Validation (all through `nix develop -c`):

- `pnpm test --run packages/effect/test/Effect.flatMap.test.ts packages/effect/test/Effect.test.ts packages/effect/test/EffectEager.test.ts`: 310 tests passed.
- `pnpm lint-fix`: passed.
- `pnpm check`: passed.

Closes EFF-1269
