### PR TITLE
fix(logger): Removed unused stderr option from consolePretty signature

### DIFF
--- a/.changeset/five-spoons-visit.md
+++ b/.changeset/five-spoons-visit.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Removed unused stderr option from Logger.consolePretty signature

--- a/packages/effect/src/Logger.ts
+++ b/packages/effect/src/Logger.ts
@@ -777,6 +777,22 @@ export const batched = dual<
  * )
  * ```
  *
+ * **Example** (Logging with console.error, when the environment has TTY)
+ *
+ * ```ts import.meta.vitest
+ * import { Effect, Layer, Logger } from "effect"
+ *
+ * const prettyLoggerLayer = Layer.merge(
+ *   Logger.layer([Logger.consolePretty()]),
+ *   Layer.succeed(Logger.LogToStderr, true)
+ * )
+ *
+ * Effect.log('hello').pipe(
+ *   Effect.provide(prettyLoggerLayer),
+ *   Effect.runSync
+ * )
+ * ```
+ *
  * @category constructors
  * @see {@link consolePrettyBrowser} for browser-specific implementation
  * @see {@link consolePrettyTty} for the TTY-mode implementation
@@ -785,7 +801,6 @@ export const batched = dual<
 export const consolePretty: (
   options?: {
     readonly colors?: "auto" | boolean | undefined
-    readonly stderr?: boolean | undefined
     readonly formatDate?: ((date: Date) => string) | undefined
     readonly mode?: "browser" | "tty" | "auto" | undefined
   }
@@ -848,6 +863,22 @@ export const consolePrettyBrowser: (
  *   Effect.withLogSpan('label'),
  *   Effect.annotateLogs('key', 'value'),
  *   Effect.provide(prettyLogger),
+ *   Effect.runSync
+ * )
+ * ```
+ *
+ * **Example** (Logging with console.error)
+ *
+ * ```ts import.meta.vitest
+ * import { Effect, Layer, Logger } from "effect"
+ *
+ * const prettyLoggerLayer = Layer.merge(
+ *   Logger.layer([Logger.consolePrettyTty()]),
+ *   Layer.succeed(Logger.LogToStderr, true)
+ * )
+ *
+ * Effect.log('hello').pipe(
+ *   Effect.provide(prettyLoggerLayer),
  *   Effect.runSync
  * )
  * ```


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
The `stderr` option is not needed because the behavior is controlled by this:

```ts
export const LogToStderr: Context.Reference<boolean> = effect.LogToStderr
```

## Related

- #8079 removes the last and only reference to the `stderr` param

UPD: Added `Logger.LogToStderr` example to `Logger.consolePrettyTty` after #8083 was merged