### PR TITLE
Port HttpApiBuilder.handler from v3

### DIFF
--- a/.changeset/port-http-api-builder-handler.md
+++ b/.changeset/port-http-api-builder-handler.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Port `HttpApiBuilder.handler` from v3 to define reusable endpoint callbacks with inferred request, response, error, and service types.

--- a/migration/annotations/effect__platform__HttpApiBuilder.yaml
+++ b/migration/annotations/effect__platform__HttpApiBuilder.yaml
@@ -8,8 +8,8 @@
   replacement: "effect/unstable/httpapi/HttpApiBuilder#group"
   note: "The group layer remains; names are now identifiers and API/group global error channels are gone."
 "@effect/platform/HttpApiBuilder#handler":
-  replacement: "effect/unstable/httpapi/HttpApiBuilder#endpoint"
-  note: "Use endpoint for a standalone typed endpoint implementation; inside a group pass callbacks to handlers.handle."
+  replacement: "effect/unstable/httpapi/HttpApiBuilder#handler"
+  note: "The typed callback helper remains; names are now identifiers and API/group global error channels are gone. Pass the returned callback to handlers.handle."
 "@effect/platform/HttpApiBuilder#Handlers":
   replacement: "effect/unstable/httpapi/HttpApiBuilder#Handlers"
   note: "Handlers now tracks an endpoint map and handled identifiers. Prefer Handlers.FromGroup<Group>."

--- a/migration/v3-to-v4.md
+++ b/migration/v3-to-v4.md
@@ -6570,7 +6570,7 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `HttpApiBuilder.group` -> `effect/unstable/httpapi/HttpApiBuilder#group`: The group layer remains; names are now identifiers and API/group global error channels are gone.
 
-- `HttpApiBuilder.handler` -> `effect/unstable/httpapi/HttpApiBuilder#endpoint`: Use endpoint for a standalone typed endpoint implementation; inside a group pass callbacks to handlers.handle.
+- `HttpApiBuilder.handler` -> `effect/unstable/httpapi/HttpApiBuilder#handler`: The typed callback helper remains; names are now identifiers and API/group global error channels are gone. Pass the returned callback to handlers.handle.
 
 - `HttpApiBuilder.httpApp` -> `effect/unstable/http/HttpRouter#toHttpEffect`: Build the application from the assembled API route layer; HTTP apps are Effects in v4.
 

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -160,6 +160,49 @@ export const group = <
     )
   })) as any
 
+/**
+ * Creates a reusable handler for a single endpoint in an API group.
+ *
+ * Returns the supplied callback unchanged, with its request, success, and error
+ * types inferred from the endpoint. Pass the result to `handlers.handle` when
+ * implementing the group.
+ *
+ * @category handlers
+ * @since 4.0.0
+ */
+export const handler = <
+  ApiId extends string,
+  Groups extends HttpApiGroup.Constraint,
+  const GroupIdentifier extends HttpApiGroup.Identifier<Groups>,
+  const EndpointIdentifier extends HttpApiGroup.EndpointsWithIdentifier<Groups, GroupIdentifier>["identifier"],
+  R
+>(
+  _api: HttpApi.HttpApi<ApiId, Groups>,
+  _groupIdentifier: GroupIdentifier,
+  _endpointIdentifier: EndpointIdentifier,
+  f: HttpApiEndpoint.HandlerWithIdentifier<
+    HttpApiGroup.EndpointsWithIdentifier<Groups, GroupIdentifier>,
+    EndpointIdentifier,
+    HttpApiEndpoint.MiddlewareError<
+      HttpApiEndpoint.WithIdentifier<
+        HttpApiGroup.EndpointsWithIdentifier<Groups, GroupIdentifier>,
+        EndpointIdentifier
+      >
+    >,
+    R
+  >
+): HttpApiEndpoint.HandlerWithIdentifier<
+  HttpApiGroup.EndpointsWithIdentifier<Groups, GroupIdentifier>,
+  EndpointIdentifier,
+  HttpApiEndpoint.MiddlewareError<
+    HttpApiEndpoint.WithIdentifier<
+      HttpApiGroup.EndpointsWithIdentifier<Groups, GroupIdentifier>,
+      EndpointIdentifier
+    >
+  >,
+  R
+> => f
+
 const HandlersTypeId = "~effect/httpapi/HttpApiBuilder/Handlers"
 
 type EndpointMap<Endpoints extends HttpApiEndpoint.Constraint> = {

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -166,8 +166,8 @@ export const group = <
  * **Details**
  *
  * Returns the supplied callback unchanged, with its request, success, and error
- * types inferred from the endpoint. Pass the result to `handlers.handle` when
- * implementing the group.
+ * types inferred from the endpoint, preserving the callback's service
+ * requirements. Pass the result to `handlers.handle` when implementing the group.
  *
  * @category handlers
  * @since 4.0.0

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -163,6 +163,8 @@ export const group = <
 /**
  * Creates a reusable handler for a single endpoint in an API group.
  *
+ * **Details**
+ *
  * Returns the supplied callback unchanged, with its request, success, and error
  * types inferred from the endpoint. Pass the result to `handlers.handle` when
  * implementing the group.

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -33,6 +33,36 @@ const TestServices = Layer.mergeAll(
   HttpPlatform.layer
 ).pipe(Layer.provideMerge(FileSystem.layerNoop({})))
 
+it.layer(TestServices)("HttpApiBuilder.handler", (it) => {
+  it.effect("returns the callback unchanged and supports registration in a group", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("users").add(
+          HttpApiEndpoint.post("create", "/users/:id", {
+            params: { id: Schema.FiniteFromString },
+            payload: Schema.Struct({ name: Schema.String }),
+            success: Schema.Struct({ id: Schema.Number, name: Schema.String })
+          })
+        )
+      )
+      const callback = vi.fn(({ params, payload }: {
+        readonly params: { readonly id: number }
+        readonly payload: { readonly name: string }
+      }) => Effect.succeed({ id: params.id, name: payload.name }))
+      const handler = HttpApiBuilder.handler(Api, "users", "create", callback)
+
+      assert.strictEqual(handler, callback)
+      assert.strictEqual(callback.mock.calls.length, 0)
+
+      const GroupLayer = HttpApiBuilder.group(Api, "users", (handlers) => handlers.handle("create", handler))
+      const client = yield* HttpApiTest.groups(Api, ["users"]).pipe(Effect.provide(GroupLayer))
+      const result = yield* client.users.create({ params: { id: 42 }, payload: { name: "Ada" } })
+
+      assert.deepStrictEqual(result, { id: 42, name: "Ada" })
+      assert.strictEqual(callback.mock.calls.length, 1)
+    }))
+})
+
 it.layer(TestServices)("HttpApiTest pre-response handlers", (it) => {
   it.effect("runs registered pre-response handlers", () =>
     Effect.gen(function*() {

--- a/packages/effect/typetest/unstable/httpapi/HttpApiBuilder.tst.ts
+++ b/packages/effect/typetest/unstable/httpapi/HttpApiBuilder.tst.ts
@@ -19,6 +19,98 @@ import {
 import { describe, expect, it } from "tstyche"
 
 describe("HttpApiBuilder", () => {
+  describe("handler", () => {
+    it("infers the selected endpoint's decoded request and preserves service requirements", () => {
+      class Repository extends Context.Service<Repository, {}>()("Repository") {}
+      class Lookup extends HttpApiEndpoint.post("lookup", "/users/:id", {
+        params: { id: Schema.FiniteFromString },
+        query: { page: Schema.FiniteFromString },
+        payload: Schema.Struct({ name: Schema.String }),
+        headers: { "x-token": Schema.String },
+        success: Schema.String
+      }) {}
+      const api = HttpApi.make("api").add(
+        HttpApiGroup.make("users").add(Lookup),
+        HttpApiGroup.make("admins").add(
+          HttpApiEndpoint.get("lookup", "/admins", { success: Schema.Number })
+        )
+      )
+      const handler = HttpApiBuilder.handler(api, "users", "lookup", ({ params, query, payload, headers }) => {
+        expect(params).type.toBe<{ readonly id: number }>()
+        expect(query).type.toBe<{ readonly page: number }>()
+        expect(payload).type.toBe<{ readonly name: string }>()
+        expect(headers).type.toBe<{ readonly "x-token": string }>()
+        return Effect.as(Repository, payload.name)
+      })
+
+      expect(handler).type.toBe<HttpApiEndpoint.Handler<typeof Lookup, never, Repository>>()
+      const group = HttpApiBuilder.group(api, "users", (handlers) => handlers.handle("lookup", handler))
+      expect(group).type.toBe<
+        Layer.Layer<HttpApiGroup.Service<"api", "users">, never, HttpRouterRequest<"Requires", Repository>>
+      >()
+
+      const adminHandler = HttpApiBuilder.handler(api, "admins", "lookup", () => Effect.succeed(42))
+      expect<Effect.Success<ReturnType<typeof adminHandler>>>().type.toBe<number | HttpServerResponse>()
+      expect<Effect.Services<ReturnType<typeof adminHandler>>>().type.toBe<never>()
+    })
+
+    it("accepts endpoint and middleware errors while preserving middleware-provided services", () => {
+      class NotFound extends Schema.TaggedError<NotFound>()("NotFound", {}) {}
+      class Unauthorized extends Schema.TaggedError<Unauthorized>()("Unauthorized", {}) {}
+      class Auth extends HttpApiMiddleware.Service<Auth, { provides: CurrentUser }>()("Auth", {
+        error: Unauthorized
+      }) {}
+      const endpoint = HttpApiEndpoint.get("get", "/users", {
+        success: Schema.String,
+        error: NotFound
+      }).middleware(Auth)
+      const api = HttpApi.make("api").add(HttpApiGroup.make("users").add(endpoint))
+      const handler = HttpApiBuilder.handler(
+        api,
+        "users",
+        "get",
+        Effect.fnUntraced(function*() {
+          const { userId } = yield* CurrentUser
+          if (userId === "missing") return yield* Effect.fail(new NotFound())
+          if (userId === "unauthorized") return yield* Effect.fail(new Unauthorized())
+          return userId
+        })
+      )
+
+      expect(handler).type.toBe<HttpApiEndpoint.Handler<typeof endpoint, Unauthorized, CurrentUser>>()
+      const group = HttpApiBuilder.group(api, "users", (handlers) => handlers.handle("get", handler))
+      expect(group).type.toBe<Layer.Layer<HttpApiGroup.Service<"api", "users">, never, Auth>>()
+    })
+
+    it("rejects unknown groups and endpoints outside the selected group", () => {
+      const api = HttpApi.make("api").add(
+        HttpApiGroup.make("users").add(HttpApiEndpoint.get("getUser", "/users")),
+        HttpApiGroup.make("admins").add(HttpApiEndpoint.get("getAdmin", "/admins"))
+      )
+
+      expect(HttpApiBuilder.handler).type.not.toBeCallableWith(api, "missing", "getUser", () => Effect.void)
+      expect(HttpApiBuilder.handler).type.not.toBeCallableWith(api, "users", "missing", () => Effect.void)
+      expect(HttpApiBuilder.handler).type.not.toBeCallableWith(api, "users", "getAdmin", () => Effect.void)
+    })
+
+    it("rejects invalid successes and errors from other endpoints", () => {
+      class OtherError extends Schema.TaggedError<OtherError>()("OtherError", {}) {}
+      class OtherMiddleware extends HttpApiMiddleware.Service<OtherMiddleware>()("OtherMiddleware", {
+        error: OtherError
+      }) {}
+      const api = HttpApi.make("api").add(
+        HttpApiGroup.make("users").add(
+          HttpApiEndpoint.get("get", "/users", { success: Schema.String }),
+          HttpApiEndpoint.get("other", "/other", { success: Schema.Number }).middleware(OtherMiddleware)
+        )
+      )
+
+      expect(HttpApiBuilder.handler).type.not.toBeCallableWith(api, "users", "get", () => Effect.succeed(42))
+      expect(HttpApiBuilder.handler).type.not.toBeCallableWith(api, "users", "get", () => Effect.fail(new OtherError()))
+      expect(HttpApiBuilder.handler).type.not.toBeCallableWith(api, "users", "get", () => Effect.fail("undeclared"))
+    })
+  })
+
   describe("group", () => {
     it("does not require unknown services for status annotations piped onto errors", () => {
       class NotFound extends Schema.TaggedError<NotFound>()("NotFound", {}) {}


### PR DESCRIPTION
Port `HttpApiBuilder.handler` from v3 so endpoint callbacks can be defined separately and passed to `handlers.handle`. The helper returns the original callback and infers the selected endpoint's decoded request, success, declared errors, and service requirements using v4 identifiers and middleware types.

Includes a changeset, corrected migration guidance, and runtime/type coverage. Implementation and tests were added in separate passes and commits.

Validation (all commands run with `nix develop -c`):

- `pnpm test --run packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts`: 43 tests passed.
- `pnpm test-types packages/effect/typetest/unstable/httpapi/HttpApiBuilder.tst.ts`: passed on TypeScript 5.9.3 and 6.0.3, 120 assertions total.
- `pnpm check`: passed.
- `pnpm lint-fix` and `pnpm lint`: passed.
- `pnpm jsdocs --check`: fails on existing formatting errors in untouched `Multipart.ts` and `ChildProcess.ts`; no errors reported for `HttpApiBuilder.ts`.

Closes EFF-1274
