### PR TITLE
fix(ai-anthropic): inject JSON fallback tool and resolve structured output from tool calls

### DIFF
--- a/.changeset/issue-8075-anthropic-json-fallback.md
+++ b/.changeset/issue-8075-anthropic-json-fallback.md
@@ -1,0 +1,9 @@
+---
+"effect": patch
+"@effect/ai-anthropic": patch
+---
+
+Fix non-native structured output fallback (`structuredOutputs: false`) for the Anthropic provider (#8075).
+
+- `AnthropicLanguageModel.prepareTools` no longer short-circuits when `generateObject` sends no tools / `toolChoice: "none"`: the JSON response tool is now injected and `tool_choice` is forced to that tool with parallel tool use disabled.
+- `LanguageModel.resolveStructuredOutput` now resolves the structured output from the forced tool call (or a JSON text segment) instead of concatenating it with incidental text.

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -1293,31 +1293,43 @@ const prepareTools = Effect.fnUntraced(
     readonly tools: ReadonlyArray<AnthropicUserDefinedTool | AnthropicProviderDefinedTool> | undefined
     readonly toolChoice: typeof Generated.BetaToolChoice.Encoded | undefined
   }, AiError.AiError> {
-    if (options.tools.length === 0 || options.toolChoice === "none") {
-      return { tools: undefined, toolChoice: undefined }
-    }
+    const userTools: Array<AnthropicUserDefinedTool> = []
+    const providerTools: Array<AnthropicProviderDefinedTool> = []
 
-    // Return a JSON response tool when using non-native structured outputs
+    // Return a JSON response tool when using non-native structured outputs.
+    // The tool is appended to any user tools, and the tool choice is forced so
+    // the model must answer with the structured JSON object (#8075). This must
+    // take precedence over `toolChoice: "none"`, which `generateObject` sets.
+    let jsonToolName: string | undefined = undefined
     if (options.responseFormat.type === "json" && !capabilities.supportsStructuredOutput) {
+      jsonToolName = options.responseFormat.objectName
       const input_schema = yield* tryJsonSchema(options.responseFormat.schema, "prepareTools")
       const userDescription = SchemaAST.resolveDescription(options.responseFormat.schema.ast)
       const description = Predicate.isNotUndefined(userDescription) ? `${userDescription} - ` : ""
+      userTools.push({
+        name: jsonToolName,
+        description: `${description}You MUST respond with a JSON object.`,
+        input_schema: input_schema as any
+      })
+    }
+
+    if (options.toolChoice === "none" && jsonToolName === undefined) {
+      return { tools: undefined, toolChoice: undefined }
+    }
+
+    if (options.tools.length === 0) {
+      if (jsonToolName === undefined) {
+        return { tools: undefined, toolChoice: undefined }
+      }
       return {
-        tools: [{
-          name: options.responseFormat.objectName,
-          description: `${description}You MUST respond with a JSON object.`,
-          input_schema: input_schema as any
-        }],
+        tools: userTools,
         toolChoice: {
           type: "tool",
-          name: options.responseFormat.objectName,
+          name: jsonToolName,
           disable_parallel_tool_use: true
         }
       }
     }
-
-    const userTools: Array<AnthropicUserDefinedTool> = []
-    const providerTools: Array<AnthropicProviderDefinedTool> = []
 
     for (const tool of options.tools) {
       if (Tool.isUserDefined(tool) || Tool.isDynamic(tool)) {
@@ -1498,6 +1510,13 @@ const prepareTools = Effect.fnUntraced(
     let tools = [...userTools, ...providerTools]
     let toolChoice: Mutable<typeof Generated.BetaToolChoice.Encoded> | undefined = undefined
 
+    if (options.toolChoice === "none") {
+      return {
+        tools,
+        toolChoice: { type: "none" as const }
+      }
+    }
+
     if (options.toolChoice === "auto") {
       toolChoice = { type: "auto" }
     } else if (options.toolChoice === "required") {
@@ -1508,6 +1527,16 @@ const prepareTools = Effect.fnUntraced(
       const allowedTools = new Set(options.toolChoice.oneOf)
       tools = tools.filter((tool) => allowedTools.has(tool.name))
       toolChoice = { type: options.toolChoice.mode === "required" ? "any" : "auto" }
+    }
+
+    // When the JSON response tool is injected, the model must be forced to
+    // call it, otherwise the structured output cannot be resolved (#8075)
+    if (jsonToolName !== undefined) {
+      toolChoice = {
+        type: "tool",
+        name: jsonToolName,
+        disable_parallel_tool_use: true
+      }
     }
 
     if (

--- a/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
+++ b/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
@@ -870,6 +870,111 @@ describe("AnthropicLanguageModel", () => {
         assert.strictEqual(body.output_config?.format?.type, "json_schema")
         assert.notProperty(body, "structuredOutputs")
       }))
+
+    // #8075: with `structuredOutputs: false`, generateObject must still
+    // succeed by injecting a JSON response tool and forcing `tool_choice`,
+    // then resolving the structured output from the tool call.
+    describe("json fallback (structuredOutputs: false)", () => {
+      const toolUseResponse = (request: HttpClientRequest.HttpClientRequest, content: ReadonlyArray<any>) =>
+        jsonResponse(request, {
+          id: "msg_test_1",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content,
+          stop_reason: "tool_use",
+          stop_sequence: null,
+          usage: {
+            cache_creation: null,
+            cache_creation_input_tokens: null,
+            cache_read_input_tokens: null,
+            inference_geo: null,
+            input_tokens: 10,
+            output_tokens: 5,
+            service_tier: null
+          }
+        })
+
+      it.effect("injects the JSON tool and forces tool_choice", () =>
+        Effect.gen(function*() {
+          let capturedRequest: HttpClientRequest.HttpClientRequest | undefined = undefined
+          const layer = AnthropicClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+            Layer.provide(Layer.succeed(
+              HttpClient.HttpClient,
+              makeHttpClient((request) => {
+                capturedRequest = request
+                return Effect.succeed(toolUseResponse(request, [
+                  { type: "tool_use", id: "toolu_1", name: "generateObject", input: { name: "John", age: 30 } }
+                ]))
+              })
+            ))
+          )
+
+          yield* LanguageModel.generateObject({
+            prompt: "Give me a person",
+            schema: Schema.Struct({ name: Schema.String, age: Schema.Number })
+          }).pipe(
+            Effect.provide(AnthropicLanguageModel.model("claude-sonnet-4-6", { structuredOutputs: false })),
+            Effect.provide(layer),
+            Effect.ignore
+          )
+
+          assert.isDefined(capturedRequest)
+          const body = yield* getRequestBody(capturedRequest!)
+          const tool = body.tools?.find((tool: any) => tool.name === "generateObject")
+          assert.isDefined(tool)
+          assert.deepStrictEqual(body.tool_choice, {
+            type: "tool",
+            name: "generateObject",
+            disable_parallel_tool_use: true
+          })
+        }))
+
+      it.effect("resolves the output from the forced tool call", () =>
+        Effect.gen(function*() {
+          const layer = AnthropicClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+            Layer.provide(Layer.succeed(
+              HttpClient.HttpClient,
+              makeHttpClient((request) => Effect.succeed(toolUseResponse(request, [
+                { type: "tool_use", id: "toolu_1", name: "generateObject", input: { name: "John", age: 30 } }
+              ])))
+            ))
+          )
+
+          const response = yield* LanguageModel.generateObject({
+            prompt: "Give me a person",
+            schema: Schema.Struct({ name: Schema.String, age: Schema.Number })
+          }).pipe(
+            Effect.provide(AnthropicLanguageModel.model("claude-sonnet-4-6", { structuredOutputs: false })),
+            Effect.provide(layer)
+          )
+
+          assert.deepStrictEqual(response.value, { name: "John", age: 30 })
+        }))
+
+      it.effect("prefers the JSON tool call over incidental text", () =>
+        Effect.gen(function*() {
+          const layer = AnthropicClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+            Layer.provide(Layer.succeed(
+              HttpClient.HttpClient,
+              makeHttpClient((request) => Effect.succeed(toolUseResponse(request, [
+                { type: "text", text: "Here is the result:" },
+                { type: "tool_use", id: "toolu_1", name: "generateObject", input: { name: "John", age: 30 } }
+              ])))
+            ))
+          )
+
+          const response = yield* LanguageModel.generateObject({
+            prompt: "Give me a person",
+            schema: Schema.Struct({ name: Schema.String, age: Schema.Number })
+          }).pipe(
+            Effect.provide(AnthropicLanguageModel.model("claude-sonnet-4-6", { structuredOutputs: false })),
+            Effect.provide(layer)
+          )
+
+          assert.deepStrictEqual(response.value, { name: "John", age: 30 })
+        }))
+    })
   })
 
   // The packaged `Memory_20250818` tool ships `customName: "AnthropicMemory"` /

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -929,7 +929,7 @@ export const make: (params: {
               })
           })
 
-          const value = yield* resolveStructuredOutput(content as any, codec)
+          const value = yield* resolveStructuredOutput(content as any, codec, objectName)
 
           return new GenerateObjectResponse(value, content)
         },
@@ -2427,15 +2427,43 @@ export const getObjectName = <StructuredOutputSchema extends Schema.Constraint>(
 
 const resolveStructuredOutput = Effect.fnUntraced(function*<
   StructuredOutputSchema extends Schema.Constraint
->(response: ReadonlyArray<Response.AllParts<any>>, schema: StructuredOutputSchema) {
+>(
+  response: ReadonlyArray<Response.AllParts<any>>,
+  schema: StructuredOutputSchema,
+  objectName: string
+) {
   const texts: Array<string> = []
+  let toolCallJson: string | undefined = undefined
+  // Some providers return the structured output as a tool call for the forced
+  // JSON response tool instead of text content (#8075). Such a tool call (or a
+  // text part carrying JSON) takes precedence over incidental prose emitted
+  // alongside it.
   for (const part of response) {
     if (part.type === "text") {
       texts.push(part.text)
+    } else if (part.type === "tool-call" && part.name === objectName) {
+      toolCallJson = typeof part.params === "string" ? part.params : JSON.stringify(part.params)
     }
   }
 
-  const text = texts.join("")
+  let text = toolCallJson ?? texts.join("")
+
+  // A provider may emit prose alongside the forced JSON tool call, which the
+  // provider layer flattens into concatenated text (#8075). Prefer a segment
+  // that parses as JSON over the concatenation.
+  if (toolCallJson === undefined && texts.length > 1) {
+    const jsonSegment = texts.find((segment) => {
+      try {
+        JSON.parse(segment)
+        return true
+      } catch {
+        return false
+      }
+    })
+    if (jsonSegment !== undefined) {
+      text = jsonSegment
+    }
+  }
 
   if (text.length === 0) {
     return yield* AiError.make({


### PR DESCRIPTION
## Summary

Fixes non-native structured output fallback (`structuredOutputs: false`) for the Anthropic provider, where `LanguageModel.generateObject` always failed with `StructuredOutputError` ("No text content in response" or "Expected a valid JSON string").

Two root causes:

1. `AnthropicLanguageModel.prepareTools` early-returns on `tools.length === 0 || toolChoice === "none"` **before** the JSON fallback tool injection. `generateObject` sends exactly `tools: []` + `toolChoice: "none"`, so the JSON response tool was never injected.
2. `LanguageModel.resolveStructuredOutput` concatenated all `text` parts. When the model emits incidental prose alongside the structured output (or the provider flattens the `tool_use` into text), the concatenation (`"hi" + '{"title":"Rain"}'`) is not valid JSON.

## What changes

- `AnthropicLanguageModel.prepareTools`: inject the JSON response tool before the empty-tools / `"none"` tool-choice early returns, and force `tool_choice: { type: "tool", name, disable_parallel_tool_use: true }` so the model must answer through the tool (this also overrides a user-supplied `auto`/`required` tool choice when the JSON fallback is active).
- `LanguageModel.resolveStructuredOutput`: resolve the structured output with the priority — the `tool-call` part matching `objectName` > a standalone JSON-parsable text segment > concatenation of all text parts.
- Add a changeset (`effect` + `@effect/ai-anthropic`, patch).

## Validation

```sh
pnpm test --run packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
# 30 passed (3 new regression tests)

pnpm vitest run packages/effect/test/unstable/ai
# 1071 passed, 44 skipped

npx tsc --noEmit -p packages/effect/tsconfig.json
npx tsc --noEmit -p packages/ai/anthropic/tsconfig.json
```

New regression tests cover:
- the JSON tool is injected and `tool_choice` is forced (request-shape assertion)
- `generateObject` resolves the value from the forced `tool_use` response
- incidental text alongside the tool call is ignored in favor of the JSON segment

Reproduced before the fix: `generateObject` with `structuredOutputs: false` fails with `Expected a valid JSON string`; after the fix it succeeds.

Closes #8075