### PR TITLE
fix(ai-anthropic): strip strictJsonSchema from Messages request body

### DIFF
--- a/.changeset/issue-8076-strictjsonschema-leak.md
+++ b/.changeset/issue-8076-strictjsonschema-leak.md
@@ -1,0 +1,7 @@
+---
+"@effect/ai-anthropic": patch
+---
+
+Strip `strictJsonSchema` from the Messages request body (#8076)
+
+`strictJsonSchema` is a provider-only config key consumed by `prepareTools` to decide the per-tool `strict` flag. It was missing from the destructuring list in `makeRequest`, so it leaked into the request payload as a top-level field, which the Anthropic API (and Bedrock's Anthropic runtime) reject with `Extra inputs are not permitted`.

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -710,8 +710,13 @@ export const make = Effect.fnUntraced(function*({ model, config: providerConfig 
       if (betas.size > 0) {
         params["anthropic-beta"] = Array.from(betas).join(",")
       }
-      const { disableParallelToolCalls: _, output_config, structuredOutputs: _structuredOutputs, ...requestConfig } =
-        config
+      const {
+        disableParallelToolCalls: _disableParallelToolCalls,
+        output_config,
+        structuredOutputs: _structuredOutputs,
+        strictJsonSchema: _strictJsonSchema,
+        ...requestConfig
+      } = config
       const payload: Mutable<typeof Generated.BetaCreateMessageParams.Encoded> = {
         ...requestConfig,
         max_tokens: requestConfig.max_tokens ?? capabilities.maxOutputTokens,

--- a/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
+++ b/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
@@ -870,6 +870,15 @@ describe("AnthropicLanguageModel", () => {
         assert.strictEqual(body.output_config?.format?.type, "json_schema")
         assert.notProperty(body, "structuredOutputs")
       }))
+
+    // #8076: `strictJsonSchema` is a provider-only config key (consumed by
+    // `prepareTools`); it must never leak into the Messages request body.
+    it.effect("does not leak strictJsonSchema into the request body", () =>
+      Effect.gen(function*() {
+        const body = yield* getRequest("claude-sonnet-4-6", { strictJsonSchema: false })
+
+        assert.notProperty(body, "strictJsonSchema")
+      }))
   })
 
   // The packaged `Memory_20250818` tool ships `customName: "AnthropicMemory"` /


### PR DESCRIPTION
## Summary

`AnthropicLanguageModel.Config` accepts `strictJsonSchema` as a provider-only key (consumed by `prepareTools` to set the per-tool `strict` flag), but `makeRequest` strips provider-only keys by destructuring a hand-written list — and `strictJsonSchema` was missing from it. The key leaked into the Messages request payload as a top-level field, which the Anthropic API (and Amazon Bedrock's Anthropic runtime) reject with `strictJsonSchema: Extra inputs are not permitted`, breaking every request once the option is set.

## What changes

- Add `strictJsonSchema` to the destructuring list in `makeRequest` so it is consumed and never serialized.

## Validation

```sh
pnpm test --run packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
# 28 passed, including the new regression test

npx tsc --noEmit -p packages/ai/anthropic/tsconfig.json
```

Reproduced with a capturing `HttpClient`: with `config: { strictJsonSchema: false }` the request body contained `strictJsonSchema` next to `model` / `max_tokens` / `messages`; after the fix the body contains only Messages API fields.

Closes #8076
