### PR TITLE
fix(Schema): preserve Class JSON Schema annotations

### DIFF
--- a/.changeset/calm-owls-share.md
+++ b/.changeset/calm-owls-share.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve `Schema.Class` annotations on generated JSON Schema definitions.

--- a/packages/effect/src/internal/schema/toCodec.ts
+++ b/packages/effect/src/internal/schema/toCodec.ts
@@ -4,6 +4,7 @@ import type * as PublicSchema from "../../Schema.ts"
 import * as SchemaAST from "../../SchemaAST.ts"
 import * as SchemaGetter from "../../SchemaGetter.ts"
 import * as InternalTransformation from "../../SchemaTransformation.ts"
+import * as InternalAnnotations from "./annotations.ts"
 import * as InternalMake from "./make.ts"
 
 /** @internal */
@@ -12,7 +13,17 @@ export function toCodecJson<S extends PublicSchema.Constraint>(schema: S): Publi
 }
 
 /** @internal */
-export const toCodecJsonAST = SchemaAST.applyToSelfOrLastLinkEncodingIdempotent((ast) => {
+export const toCodecJsonAST = memoize((ast: SchemaAST.AST): SchemaAST.AST => {
+  const out = toCodecJsonASTBase(ast)
+  const annotations = SchemaAST.isDeclaration(ast) ? getClassJsonAnnotations(ast) : undefined
+  return annotations === undefined
+    ? out
+    : SchemaAST.applyToSelfOrLastLinkEncoding((encoded) =>
+      SchemaAST.annotate(encoded, { ...annotations, ...InternalAnnotations.resolve(encoded) })
+    )(out)
+})
+
+const toCodecJsonASTBase = SchemaAST.applyToSelfOrLastLinkEncodingIdempotent((ast) => {
   const out = toCodecJsonASTStep(ast, toCodecJsonAST)
   const context = ast.context
   if (out === ast || context === undefined) return out
@@ -118,6 +129,23 @@ function toCodecJsonASTStep(ast: SchemaAST.AST, recur: (ast: SchemaAST.AST) => S
   }
   // `Schema.Any` is used as an escape hatch
   return ast
+}
+
+function getClassJsonAnnotations(ast: SchemaAST.Declaration): PublicSchema.Annotations.Annotations | undefined {
+  const annotations = ast.annotations
+  if (annotations?.[InternalAnnotations.CONSTRUCTOR_ANNOTATION_KEY] === undefined) return undefined
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(annotations)) {
+    if (
+      key !== "identifier" &&
+      key !== InternalAnnotations.IDENTIFIER_FALLBACK_KEY &&
+      !InternalAnnotations.annotationExcludedKeys.has(key) &&
+      SchemaAST.isJson(value)
+    ) {
+      out[key] = value
+    }
+  }
+  return Object.keys(out).length === 0 ? undefined : out
 }
 
 /** @internal */

--- a/packages/effect/test/schema/toJsonSchemaDocument.test.ts
+++ b/packages/effect/test/schema/toJsonSchemaDocument.test.ts
@@ -3542,12 +3542,18 @@ describe("toJsonSchemaDocument", () => {
     })
   })
 
-  it("Class preserves its identifier as a canonical reference", () => {
+  it("Class preserves its identifier and annotations on the encoded definition", () => {
     class A extends Schema.Class<A>("A")({
       a: Schema.String
+    }, {
+      title: "A title"
     }) {}
+    const schema = A.annotate({
+      description: "A description",
+      "x-custom": { hidden: true }
+    })
     assertJsonSchemaDocument(
-      A,
+      schema,
       {
         schema: {
           "$ref": "#/$defs/AEncoded"
@@ -3559,7 +3565,10 @@ describe("toJsonSchemaDocument", () => {
               "a": { "type": "string" }
             },
             "required": ["a"],
-            "additionalProperties": false
+            "additionalProperties": false,
+            "title": "A title",
+            "description": "A description",
+            "x-custom": { "hidden": true }
           }
         }
       },


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`Schema.toJsonSchemaDocument` follows a class’s encoding link to the underlying object schema. The class annotations stayed on the outer class node, so the generated `$defs` entry lost `title`, `description`, and custom JSON annotations.

This change carries serializable class annotations to the encoded schema used for JSON Schema generation. If the encoded side already has the same annotation, the encoded-side value still wins. Internal class metadata and callbacks are not copied.

The regression test covers an annotation passed to `Schema.Class`, annotations added later with `.annotate()`, and a custom key enabled through `includeAnnotationKey`.

Validation:

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/schema/toJsonSchemaDocument.test.ts packages/effect/test/schema/representation/toRepresentation.test.ts packages/effect/test/schema/jsonSchemaRoundTrip.test.ts packages/effect/test/schema/toCodec.test.ts packages/effect/test/schema/Schema.test.ts` (1038 tests)
- `pnpm check`

## Related

- Closes #8084