### PR TITLE
fix(cli): split key=value pairs at the first separator

### DIFF
--- a/.changeset/cli-key-value-pair-first-separator.md
+++ b/.changeset/cli-key-value-pair-first-separator.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Primitive.keyValuePair` in `effect/unstable/cli`, and the `Flag.keyValuePair` and `Param.keyValuePair` built on it, rejecting any pair whose value contains `=`. The pair is now split at the first `=`, so `--env DATABASE_URL=postgres://user:pass@host/db?sslmode=require` and `--env TOKEN=YWJjZA==` parse instead of failing with `Invalid key=value format`. Pairs with no `=`, an empty key, or an empty value are still rejected.

--- a/.changeset/cli-key-value-pair-first-separator.md
+++ b/.changeset/cli-key-value-pair-first-separator.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix `Primitive.keyValuePair` in `effect/unstable/cli`, and the `Flag.keyValuePair` and `Param.keyValuePair` built on it, rejecting any pair whose value contains `=`. The pair is now split at the first `=`, so `--env DATABASE_URL=postgres://user:pass@host/db?sslmode=require` and `--env TOKEN=YWJjZA==` parse instead of failing with `Invalid key=value format`. Pairs with no `=`, an empty key, or an empty value are still rejected.
+Allow `=` in values parsed by `Primitive.keyValuePair`, `Flag.keyValuePair`, and `Param.keyValuePair` in `effect/unstable/cli`.

--- a/packages/effect/src/unstable/cli/Primitive.ts
+++ b/packages/effect/src/unstable/cli/Primitive.ts
@@ -820,6 +820,11 @@ export const fileSchema = <A>(
 /**
  * Parses a single `key=value` pair into a record object.
  *
+ * **Details**
+ *
+ * The pair is split at the first `=`, so the value may itself contain `=`
+ * characters. Both the key and the value must be non-empty.
+ *
  * **Example** (Parsing key-value pairs)
  *
  * ```ts import.meta.vitest
@@ -860,13 +865,14 @@ export const fileSchema = <A>(
 export const keyValuePair: Primitive<Record<string, string>> = makePrimitive(
   "KeyValuePair",
   Effect.fnUntraced(function*(value) {
-    const parts = value.split("=")
-    if (parts.length !== 2) {
+    const separator = value.indexOf("=")
+    if (separator === -1) {
       return yield* Effect.fail(
         `Invalid key=value format. Expected format: key=value, got: ${value}`
       )
     }
-    const [key, val] = parts
+    const key = value.slice(0, separator)
+    const val = value.slice(separator + 1)
     if (!key || !val) {
       return yield* Effect.fail(
         `Invalid key=value format. Both key and value must be non-empty. Got: ${value}`

--- a/packages/effect/src/unstable/cli/Primitive.ts
+++ b/packages/effect/src/unstable/cli/Primitive.ts
@@ -822,8 +822,7 @@ export const fileSchema = <A>(
  *
  * **Details**
  *
- * The pair is split at the first `=`, so the value may itself contain `=`
- * characters. Both the key and the value must be non-empty.
+ * Splits at the first `=`. Keys and values must be non-empty; values may contain `=`.
  *
  * **Example** (Parsing key-value pairs)
  *

--- a/packages/effect/test/unstable/cli/Primitive.test.ts
+++ b/packages/effect/test/unstable/cli/Primitive.test.ts
@@ -335,18 +335,18 @@ describe("Primitive", () => {
 
   describe("keyValuePair", () => {
     it.layer(TestLayer)((it) => {
-      it.effect("should split at the first '='", () =>
+      it.effect("should preserve '=' in URL query parameters", () =>
         Effect.gen(function*() {
-          const simple = yield* Primitive.keyValuePair.parse("name=john")
-          assert.deepStrictEqual(simple, { name: "john" })
-
           const url = yield* Primitive.keyValuePair.parse(
             "DATABASE_URL=postgres://user:pass@host:5432/db?sslmode=require"
           )
           assert.deepStrictEqual(url, {
             DATABASE_URL: "postgres://user:pass@host:5432/db?sslmode=require"
           })
+        }))
 
+      it.effect("should preserve trailing '=' in padded values", () =>
+        Effect.gen(function*() {
           const padded = yield* Primitive.keyValuePair.parse("TOKEN=YWJjZA==")
           assert.deepStrictEqual(padded, { TOKEN: "YWJjZA==" })
         }))
@@ -361,10 +361,6 @@ describe("Primitive", () => {
             "Invalid key=value format. Both key and value must be non-empty. Got: key="
           ]
         ))
-
-      it("should have correct _tag", () => {
-        assert.strictEqual(Primitive.keyValuePair._tag, "KeyValuePair")
-      })
     })
   })
 })

--- a/packages/effect/test/unstable/cli/Primitive.test.ts
+++ b/packages/effect/test/unstable/cli/Primitive.test.ts
@@ -332,4 +332,39 @@ describe("Primitive", () => {
         }))
     })
   })
+
+  describe("keyValuePair", () => {
+    it.layer(TestLayer)((it) => {
+      it.effect("should split at the first '='", () =>
+        Effect.gen(function*() {
+          const simple = yield* Primitive.keyValuePair.parse("name=john")
+          assert.deepStrictEqual(simple, { name: "john" })
+
+          const url = yield* Primitive.keyValuePair.parse(
+            "DATABASE_URL=postgres://user:pass@host:5432/db?sslmode=require"
+          )
+          assert.deepStrictEqual(url, {
+            DATABASE_URL: "postgres://user:pass@host:5432/db?sslmode=require"
+          })
+
+          const padded = yield* Primitive.keyValuePair.parse("TOKEN=YWJjZA==")
+          assert.deepStrictEqual(padded, { TOKEN: "YWJjZA==" })
+        }))
+
+      it.effect("should fail when the input is malformed", () =>
+        expectInvalidValues(
+          Primitive.keyValuePair,
+          ["invalid", "=value", "key="],
+          [
+            "Invalid key=value format. Expected format: key=value, got: invalid",
+            "Invalid key=value format. Both key and value must be non-empty. Got: =value",
+            "Invalid key=value format. Both key and value must be non-empty. Got: key="
+          ]
+        ))
+
+      it("should have correct _tag", () => {
+        assert.strictEqual(Primitive.keyValuePair._tag, "KeyValuePair")
+      })
+    })
+  })
 })


### PR DESCRIPTION
`Primitive.keyValuePair` now splits at the first `=`, allowing values such as URL query parameters and padded base64 tokens. `Flag.keyValuePair` and `Param.keyValuePair` use the same primitive. Inputs without a separator, an empty key, or an empty value still fail with the existing messages.

Focused tests in `packages/effect/test/unstable/cli/Primitive.test.ts` cover embedded and trailing `=` characters and malformed inputs. Includes an `effect` patch changeset.

Validation (commands run through `nix develop -c`):

- `pnpm test --run packages/effect/test/unstable/cli/Primitive.test.ts packages/effect/test/unstable/cli/Command.test.ts`: 138 passed.
- Both regression cases fail against the original parser; the other 27 primitive tests pass.
- `pnpm lint-fix` and `pnpm check`: passed.

Closes EFF-1313
