### PR TITLE
fix(cli): buffer Prompt.custom clear and next-frame render (#8088)

### DIFF
--- a/.changeset/issue-8088-prompt-custom-frame-flash.md
+++ b/.changeset/issue-8088-prompt-custom-frame-flash.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Buffer `Prompt.custom` clear and next-frame render so the previous frame stays visible while the next frame is being computed (#8088)
+
+`runLoop` in `Prompt.ts` displayed the `clear` output as its own `display` call *before* the next frame was rendered. During a slow render this left a blank gap (flash) between the old and new frames. The clear output is now buffered and emitted together with the next frame's render in a single `display` call for both the `NextFrame` and `Submit` paths.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -1483,9 +1483,14 @@ const runLoop = Effect.fnUntraced(
   ) {
     let state = Effect.isEffect(loop.initialState) ? yield* loop.initialState : loop.initialState
     let action: Action<unknown, unknown> = Action.NextFrame({ state })
+    // Clear output is buffered and displayed together with the next frame's
+    // render, so the previous frame stays visible while the next frame is being
+    // computed (avoiding a blank flash during slow renders).
+    let pendingClear = ""
     while (true) {
       const msg = yield* loop.render(state, action)
-      yield* Effect.orDie(terminal.display(msg))
+      yield* Effect.orDie(terminal.display(pendingClear + msg))
+      pendingClear = ""
       if (loop.events) {
         const takeInput = Queue.take(input).pipe(
           Effect.map((input) => ({ _tag: "Input" as const, input }))
@@ -1503,14 +1508,14 @@ const runLoop = Effect.fnUntraced(
         case "Beep":
           continue
         case "NextFrame": {
-          yield* Effect.orDie(terminal.display(yield* loop.clear(state, action)))
+          pendingClear = yield* loop.clear(state, action)
           state = action.state
           continue
         }
         case "Submit": {
-          yield* Effect.orDie(terminal.display(yield* loop.clear(state, action)))
+          const clearOutput = yield* loop.clear(state, action)
           const msg = yield* loop.render(state, action)
-          yield* Effect.orDie(terminal.display(msg))
+          yield* Effect.orDie(terminal.display(clearOutput + msg))
           return action.value
         }
       }

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -1266,4 +1266,65 @@ describe("Prompt.custom", () => {
       const result = yield* Prompt.run(prompt)
       assert.strictEqual(result, "xy")
     }).pipe(Effect.provide(TestLayer)))
+
+  // Regression test for https://github.com/Effect-TS/effect/issues/8088
+  // `Prompt.custom` previously displayed the `clear` output as its own `display`
+  // call *before* the next frame was rendered. During a slow render this left a
+  // blank gap (flash) between the old and new frames. The clear output and the
+  // next frame's render must be buffered and displayed together in one call.
+  it.effect("buffers clear and the next frame render into a single display call", () =>
+    Effect.gen(function*() {
+      const eventQueue = yield* Queue.make<string>()
+      const rendered = yield* Queue.make<string>()
+
+      const prompt = Prompt.custom(
+        { count: 0 },
+        Queue.asDequeue(eventQueue),
+        {
+          render: (state) =>
+            Effect.gen(function*() {
+              yield* Queue.offer(rendered, `render:${state.count}`)
+              return `Frame ${state.count}`
+            }),
+          process: (input, state) =>
+            Match.value(input).pipe(
+              Match.tag("Input", () => Effect.succeed(Action.Submit({ value: state.count }))),
+              Match.tag("Event", ({ value }) =>
+                Effect.succeed(
+                  Action.NextFrame({ state: { count: state.count + (value === "tick" ? 1 : 0) } })
+                )),
+              Match.exhaustive
+            ),
+          clear: () => Effect.succeed("CLEAR")
+        }
+      )
+
+      const fiber = yield* Prompt.run(prompt).pipe(Effect.forkChild)
+      yield* Effect.yieldNow
+
+      // Trigger a NextFrame transition, then submit to finish the loop.
+      yield* Queue.offer(eventQueue, "tick")
+      yield* Effect.yieldNow
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Fiber.join(fiber)
+      assert.strictEqual(result, 1)
+
+      const lines = yield* MockTerminal.displayLines
+      // The final cursor-show sequence is emitted after the loop exits and is
+      // unrelated to the frame rendering under test, so filter it out.
+      const frames = lines.filter((line) => line !== escape + "[?25h")
+      // The initial frame, then the buffered clear+frame render, then the
+      // buffered clear+submission render.
+      assert.strictEqual(frames.length, 3)
+      assert.strictEqual(frames[0], "Frame 0")
+      // The NextFrame clear output must be prepended to the next frame's render
+      // in the *same* display call (no separate, intermediate blank display).
+      assert.strictEqual(frames[1], "CLEARFrame 1")
+      // The submission keeps the same state, so the render is still "Frame 1".
+      assert.strictEqual(frames[2], "CLEARFrame 1")
+
+      const renders = yield* Queue.takeAll(rendered)
+      assert.deepStrictEqual(Array.from(renders), ["render:0", "render:1", "render:1"])
+    }).pipe(Effect.provide(TestLayer)))
 })


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`Prompt.custom` flashes / shows a blank line when rendering the next frame. This is #8088.

**What happens:** in `runLoop` (`packages/effect/src/unstable/cli/Prompt.ts`), the `NextFrame` case displayed the `clear` output as its own `terminal.display` call *before* the next frame was rendered. When the render is slow, the old frame gets wiped out first, leaving the screen blank until the next frame is ready. The same ordering exists for `Submit`.

**The fix:** buffer the `clear` output and emit it together with the next frame's render in a single `display` call, so the previous frame stays visible while the next frame is being computed.

- For `NextFrame`: store the clear output in a `pendingClear` variable, then prepend it to the next render when the loop displays the new frame.
- For `Submit`: concatenate `clear(...)` + `render(...)` into one `display` call before returning.
- `Beep` and the initial frame are unchanged.

This keeps the `clear` before `render` (so it can still use the previous frame's layout), exactly as suggested in the issue.

**Tests:** added a regression test in `packages/effect/test/unstable/cli/Prompt.test.ts` that asserts the clear output and the next frame's render land in the *same* `display` call (before the fix they were two separate calls with an intermediate blank).

## Verification

`pnpm vitest run packages/effect/test/unstable/cli/Prompt.test.ts` gives 58 passed (including the new regression test).

`packages/effect` `tsc -b tsconfig.json` exits 0.

An instrumented reproduction (mock `Terminal` with a 750ms render delay) shows the clear and next frame now display together instead of leaving a ~750ms blank window.

Changeset included for `effect` (patch).

## Related

- Fixes #8088
