### PR TITLE
feat(atom-angular): add Angular bindings for Effect Atom

### DIFF
--- a/.changeset/angular-atom-bindings.md
+++ b/.changeset/angular-atom-bindings.md
@@ -1,0 +1,22 @@
+---
+"@effect/atom-angular": patch
+---
+
+Add `@effect/atom-angular`, Angular bindings for the Effect Atom modules.
+
+The package exposes the Atom registry through Angular dependency injection with `provideAtomRegistry`,
+`ATOM_REGISTRY`, `injectAtomRegistry`, and `REGISTRY_OPTIONS` / `injectRegistryOptions` for configuring the
+registry a scope creates.
+
+Injection functions surface atoms as Angular signals and operations on them: `injectAtomValue`,
+`injectAtomRef`, `injectAtomComputed`, `injectAtomMount`, `injectAtomSubscribe`, `injectAtomRefresh`,
+`injectAtomSet`, `injectAtomUpdate`, `injectAtomSetExit`, `injectAtomSetPromise`, and `injectDestroyRef`.
+`injectMakeAtom` bundles those operations into a single store whose surface is selected from the atom's
+type — reads for every atom, writes for writable ones, and `matchResult` for `Result`-shaped ones —
+and `atomMatchResult` flattens a `Result`-shaped store into one template-ready view tagged by
+`ATOM_RESULT_STATUS`.
+
+Every `inject*` function must be called from an injection context. Subscriptions and keepalives are created
+synchronously and released when the surrounding injector is destroyed; what those functions return — setters,
+refresh callbacks, and the store's methods — captures the registry at injection time and stays callable
+outside an injection context.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -19,6 +19,7 @@
       "@effect/ai-openai",
       "@effect/ai-openai-compat",
       "@effect/ai-openrouter",
+      "@effect/atom-angular",
       "@effect/atom-react",
       "@effect/atom-solid",
       "@effect/atom-vue",

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This monorepo contains the core `effect` package alongside integration packages 
 | [`@effect/ai-openai`](packages/ai/openai)                             | OpenAI provider for the Effect AI modules                | [docs](https://effect.website/docs/v4/api/ai-openai)               |
 | [`@effect/ai-openai-compat`](packages/ai/openai-compat)               | OpenAI-compatible API provider for the Effect AI modules | [docs](https://effect.website/docs/v4/api/ai-openai-compat)        |
 | [`@effect/ai-openrouter`](packages/ai/openrouter)                     | OpenRouter provider for the Effect AI modules            | [docs](https://effect.website/docs/v4/api/ai-openrouter)           |
+| [`@effect/atom-angular`](packages/atom/angular)                       | Angular bindings for Effect Atom                         | [docs](https://effect.website/docs/v4/api/atom-angular)            |
 | [`@effect/atom-react`](packages/atom/react)                           | React bindings for Effect Atom                           | [docs](https://effect.website/docs/v4/api/atom-react)              |
 | [`@effect/atom-solid`](packages/atom/solid)                           | SolidJS bindings for Effect Atom                         | [docs](https://effect.website/docs/v4/api/atom-solid)              |
 | [`@effect/atom-vue`](packages/atom/vue)                               | Vue bindings for Effect Atom                             | [docs](https://effect.website/docs/v4/api/atom-vue)                |

--- a/ai-docs/package.json
+++ b/ai-docs/package.json
@@ -8,6 +8,7 @@
     "@effect/ai-openai": "workspace:*",
     "@effect/ai-openai-compat": "workspace:*",
     "@effect/ai-openrouter": "workspace:*",
+    "@effect/atom-angular": "workspace:*",
     "@effect/atom-react": "workspace:*",
     "@effect/atom-solid": "workspace:*",
     "@effect/atom-vue": "workspace:*",

--- a/packages/atom/angular/CHANGELOG.md
+++ b/packages/atom/angular/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @effect/atom-angular

--- a/packages/atom/angular/LICENSE
+++ b/packages/atom/angular/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-present The Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/atom/angular/README.md
+++ b/packages/atom/angular/README.md
@@ -1,0 +1,14 @@
+# @effect/atom-angular
+
+[Angular](https://angular.dev) bindings for Atom, the reactive state management modules for Effect.
+
+## Installation
+
+```sh
+npm install effect@rc @effect/atom-angular@rc
+```
+
+## Documentation
+
+- [Effect website](https://effect.website)
+- [API reference](https://effect.website/docs/v4/api/atom-angular)

--- a/packages/atom/angular/package.json
+++ b/packages/atom/angular/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@effect/atom-angular",
+  "version": "4.0.0-rc.112",
+  "type": "module",
+  "license": "MIT",
+  "description": "Angular bindings for the Effect Atom modules",
+  "homepage": "https://effect.website",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Effect-TS/effect.git",
+    "directory": "packages/atom/angular"
+  },
+  "bugs": {
+    "url": "https://github.com/Effect-TS/effect/issues"
+  },
+  "tags": [
+    "typescript",
+    "angular",
+    "database"
+  ],
+  "keywords": [
+    "typescript",
+    "angular",
+    "database"
+  ],
+  "sideEffects": [],
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts",
+    "./internal/*": null,
+    "./index": null,
+    "./*/index": null
+  },
+  "files": [
+    "src/**/*.ts",
+    "dist/**/*.js",
+    "dist/**/*.js.map",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.ts.map",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "ai-docs/**/*"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "exports": {
+      "./package.json": "./package.json",
+      ".": "./dist/index.js",
+      "./*": "./dist/*.js",
+      "./internal/*": null,
+      "./index": null,
+      "./*/index": null
+    }
+  },
+  "scripts": {
+    "build": "tsc -b tsconfig.json && pnpm babel",
+    "babel": "babel dist --plugins annotate-pure-calls --out-dir dist --source-maps",
+    "check": "tsc -b tsconfig.json"
+  },
+  "peerDependencies": {
+    "@angular/core": ">=20.0.0 <23.0.0",
+    "effect": "workspace:^"
+  },
+  "devDependencies": {
+    "@angular/common": "^22.1.4",
+    "@angular/compiler": "^22.1.4",
+    "@angular/core": "^22.1.4",
+    "@angular/platform-browser": "^22.1.4",
+    "effect": "workspace:^",
+    "jsdom": "^30.0.1",
+    "rxjs": "^7.8.2"
+  }
+}

--- a/packages/atom/angular/src/Constants.ts
+++ b/packages/atom/angular/src/Constants.ts
@@ -1,0 +1,35 @@
+/**
+ * The status tags used by the Angular Result view. `ATOM_RESULT_STATUS` is the
+ * single source of truth for the tag set: `AtomResultStatus` is derived from it
+ * and `AtomResultView` is discriminated by its members, so a tag cannot be added
+ * to the type without a value to compare against, nor removed from here while
+ * the view still names it.
+ *
+ * @since 4.0.0
+ */
+
+/**
+ * Status tags for the flattened `Result` view, as runtime values.
+ *
+ * **When to use**
+ *
+ * Use to compare against `status` in a component or a template, so a tag is
+ * written once here instead of being spelled as a string literal at each
+ * comparison site.
+ *
+ * **Details**
+ *
+ * The three members are the `AsyncResult` tags `Initial`, `Failure`, and
+ * `Success`, lowercased. `as const` keeps each member its own string literal
+ * type instead of widening to `string`, which is what lets `AtomResultStatus`
+ * be derived from this object and what lets `AtomResultView` discriminate on
+ * it.
+ *
+ * @category constants
+ * @since 4.0.0
+ */
+export const ATOM_RESULT_STATUS = {
+  INITIAL: "initial",
+  SUCCESS: "success",
+  FAILURE: "failure"
+} as const

--- a/packages/atom/angular/src/Injects.ts
+++ b/packages/atom/angular/src/Injects.ts
@@ -1,0 +1,651 @@
+/**
+ * Angular injection functions for using Effect Atoms from components,
+ * directives, and services. They read atoms and refs as Angular signals, derive
+ * projections inside the atom graph, mount and refresh atoms, subscribe
+ * callbacks, write atoms synchronously or awaitably, and build a store that
+ * bundles all of that for a single atom.
+ *
+ * Every function whose name starts with `inject` must be called from an
+ * injection context, such as a field initializer or a constructor, and every
+ * subscription and keepalive it creates is released when the surrounding
+ * injector is destroyed. What those functions return does not carry that
+ * restriction: the registry and the destroy hook are captured at creation time,
+ * so the setters, the refresh callbacks, the store's methods, and
+ * `atomMatchResult` stay callable afterwards.
+ *
+ * @since 4.0.0
+ */
+import type { Signal } from "@angular/core"
+import { DestroyRef, inject, signal } from "@angular/core"
+import * as Cause from "effect/Cause"
+import * as Effect from "effect/Effect"
+import * as Equal from "effect/Equal"
+import * as Exit from "effect/Exit"
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
+import * as Atom from "effect/unstable/reactivity/Atom"
+import type * as AtomRef from "effect/unstable/reactivity/AtomRef"
+import * as AtomRegistry from "effect/unstable/reactivity/AtomRegistry"
+
+import { ATOM_RESULT_STATUS } from "./Constants.ts"
+import { injectAtomRegistry } from "./Providers.ts"
+import type {
+  AtomComputedOptions,
+  AtomExit,
+  AtomRegistryOptions,
+  AtomResultView,
+  AtomResultViewOptions,
+  AtomStore,
+  AtomSubscribeOptions,
+  AtomSuccess,
+  AtomValue,
+  AtomWriteValue,
+  ReadableAtomStore
+} from "./Types.ts"
+
+const flattenExit = <A, E>(exit: Exit.Exit<A, E>): A => {
+  if (Exit.isSuccess(exit)) return exit.value
+  throw Cause.squash(exit.cause)
+}
+
+// A private registry is owned here, and therefore disposed with the injector
+const injectScopedRegistry = (options?: AtomRegistryOptions): AtomRegistry.AtomRegistry => {
+  if (options?.registry === undefined) return injectAtomRegistry()
+
+  const registry = AtomRegistry.make(options.registry)
+  injectDestroyRef().onDestroy(() => registry.dispose())
+  return registry
+}
+
+// The single bridge from the atom graph to Angular's reactivity
+const atomSignal = <A>(
+  registry: AtomRegistry.AtomRegistry,
+  destroyRef: DestroyRef,
+  atom: Atom.Atom<A>,
+  options?: AtomComputedOptions<A>
+): Signal<A> => {
+  const out = signal(registry.get(atom), options)
+
+  destroyRef.onDestroy(registry.subscribe(atom, (next) => out.set(next)))
+
+  return out.asReadonly()
+}
+
+const setExit = <R, W>(
+  registry: AtomRegistry.AtomRegistry,
+  atom: Atom.Writable<R, W>,
+  value: W
+): Promise<Exit.Exit<unknown, unknown>> => {
+  registry.set(atom, value)
+
+  // Free to check: `getResult` is about to read the value anyway
+  const current: unknown = registry.get(atom)
+  if (!AsyncResult.isAsyncResult(current)) {
+    throw new Error(
+      "[@effect/atom-angular] setExit/setPromise require a Result-shaped atom; " +
+        "this atom is not Result-shaped"
+    )
+  }
+
+  return Effect.runPromiseExit(
+    AtomRegistry.getResult(registry, atom as unknown as Atom.Atom<AsyncResult.AsyncResult<any, any>>, {
+      suspendOnWaiting: true
+    })
+  )
+}
+
+// `exactOptionalPropertyTypes` leaves a typed caller two choices per transform:
+// omit it, or pass a function. This is for the untyped one.
+const requireTransform = (name: string, f: unknown): void => {
+  if (f !== undefined && typeof f !== "function") {
+    throw new TypeError(`[@effect/atom-angular] ${name} must be a function`)
+  }
+}
+
+// Checked in the match rather than once up front, because that is where the
+// value first exists
+const requireResult = <R extends AsyncResult.AsyncResult<any, any>>(value: R): R => {
+  if (!AsyncResult.isAsyncResult(value)) {
+    throw new TypeError(
+      "[@effect/atom-angular] matchResult requires a Result-shaped atom; " +
+        "this atom is not Result-shaped"
+    )
+  }
+
+  return value
+}
+
+// The branches are disjoint, so comparing `value` and `error` unconditionally is
+// safe: whichever is not the branch's own field is `null` on both sides
+const sameResultView = (
+  a: AtomResultView<unknown, unknown>,
+  b: AtomResultView<unknown, unknown>
+): boolean =>
+  a.status === b.status &&
+  a.waiting === b.waiting &&
+  Equal.equals(a.value, b.value) &&
+  Equal.equals(a.error, b.error)
+
+/**
+ * Returns the `DestroyRef` of the current Angular injector.
+ *
+ * **When to use**
+ *
+ * Use to tie a subscription or a keepalive created outside these functions to
+ * the same lifetime they use.
+ *
+ * **Gotchas**
+ *
+ * Must be called from an injection context, such as a constructor or a field
+ * initializer.
+ *
+ * @category injection
+ * @since 4.0.0
+ */
+export const injectDestroyRef = (): DestroyRef => inject(DestroyRef)
+
+/**
+ * Subscribes to an atom and exposes its value as an Angular signal.
+ *
+ * **When to use**
+ *
+ * Use when a template or a computation should re-render as an atom changes.
+ *
+ * **Details**
+ *
+ * The signal is seeded with the atom's current value before the subscription is
+ * created, so it already holds a value the first time it is read. Reading it
+ * also mounts the atom for the injector's lifetime.
+ *
+ * **Gotchas**
+ *
+ * Must be called from an injection context; the subscription is torn down when
+ * that injector is destroyed. The signal notifies on reference inequality, so
+ * reach for {@link injectAtomComputed} and its comparator when a projection
+ * rebuilds its value on every run.
+ *
+ * @see {@link injectAtomComputed} for deriving a projection instead of the whole value
+ * @see {@link injectMakeAtom} for reading and writing the same atom through one store
+ *
+ * @category injection
+ * @since 4.0.0
+ */
+export const injectAtomValue = <A>(atom: Atom.Atom<A>): Signal<A> =>
+  atomSignal(injectAtomRegistry(), injectDestroyRef(), atom)
+
+/**
+ * Subscribes to an `AtomRef` and exposes its value as an Angular signal.
+ *
+ * **When to use**
+ *
+ * Use to render a reactive reference that is not part of the atom graph, such as
+ * one handed out by a service.
+ *
+ * **Details**
+ *
+ * Refs live outside the registry, so this takes no atom and touches no registry
+ * node. `ReadonlyRef.map` returns another `ReadonlyRef` and `AtomRef.prop`
+ * returns a nested `AtomRef`; either can be passed here, and each notifies only
+ * when its own view changes.
+ *
+ * **Gotchas**
+ *
+ * Must be called from an injection context; the subscription is torn down when
+ * that injector is destroyed.
+ *
+ * @see {@link injectAtomValue} for reading an `Atom` from the registry
+ *
+ * @category injection
+ * @since 4.0.0
+ */
+export const injectAtomRef = <A>(ref: AtomRef.ReadonlyRef<A>): Signal<A> => {
+  const out = signal(ref.value)
+
+  injectDestroyRef().onDestroy(ref.subscribe((next) => out.set(next)))
+
+  return out.asReadonly()
+}
+
+/**
+ * Subscribes to a projection of an atom and exposes it as an Angular signal.
+ *
+ * **When to use**
+ *
+ * Use when a component needs only part of an atom's value and should not
+ * re-render when the rest of it changes.
+ *
+ * **Details**
+ *
+ * The projection is derived inside the atom graph with `Atom.map`, not over the
+ * value signal, so the intermediate value is never subscribed to and the derived
+ * node is shared with anything else in the registry that reads it.
+ *
+ * **Gotchas**
+ *
+ * Each call builds a new derived atom, so this is meant to be called once from
+ * an injection context and stored, not called from a template expression.
+ * Without `equal`, a transform that returns a fresh object or array notifies on
+ * every recompute, because Angular compares with `Object.is`.
+ *
+ * @see {@link AtomComputedOptions} for the comparator this accepts
+ * @see {@link injectAtomValue} for reading the whole value
+ *
+ * @category injection
+ * @since 4.0.0
+ */
+export const injectAtomComputed = <A, B>(
+  atom: Atom.Atom<A>,
+  transform: (current: A) => B,
+  options?: AtomComputedOptions<B>
+): Signal<B> =>
+  atomSignal(
+    injectAtomRegistry(),
+    injectDestroyRef(),
+    // Left to infer, `Atom.map` binds its first type parameter to the argument
+    // type and rejects the widened source
+    Atom.map<Atom.Atom<A>, B>(atom, transform),
+    options
+  )
+
+/**
+ * Mounts an atom for the lifetime of the current Angular injector.
+ *
+ * **When to use**
+ *
+ * Use to keep an atom alive without reading, writing, or refreshing it, for
+ * example to start a subscription-backed atom while a route is active.
+ *
+ * **Details**
+ *
+ * A mounted atom holds its state and keeps recomputing instead of being swept
+ * when it goes idle. The keepalive is released when the injector is destroyed.
+ *
+ * **Gotchas**
+ *
+ * Must be called from an injection context. Reading the atom with
+ * {@link injectAtomValue} mounts it as well, so both are rarely needed.
+ *
+ * @category injection
+ * @since 4.0.0
+ */
+export const injectAtomMount = <A>(atom: Atom.Atom<A>): void => {
+  injectDestroyRef().onDestroy(injectAtomRegistry().mount(atom))
+}
+
+/**
+ * Observes an atom with a callback, without materialising a signal for it.
+ *
+ * **When to use**
+ *
+ * Use to run a side effect on every atom change, such as logging a value or
+ * persisting it.
+ *
+ * **Details**
+ *
+ * The subscription runs until the current injector is destroyed. It does not
+ * fire with the current value unless `immediate` is set in the options.
+ *
+ * **Gotchas**
+ *
+ * Must be called from an injection context, and there is no unsubscribe handle.
+ * Use the registry's own `subscribe` for a subscription that must end earlier
+ * than the injector.
+ *
+ * @see {@link AtomSubscribeOptions} for the options this accepts
+ * @see {@link injectAtomValue} for observing the atom as a signal instead
+ *
+ * @category injection
+ * @since 4.0.0
+ */
+export const injectAtomSubscribe = <A>(
+  atom: Atom.Atom<A>,
+  f: (value: A) => void,
+  options?: AtomSubscribeOptions
+): void => {
+  injectDestroyRef().onDestroy(injectAtomRegistry().subscribe(atom, f, options))
+}
+
+/**
+ * Returns a callback that re-runs an atom's read.
+ *
+ * **When to use**
+ *
+ * Use to reload an atom on demand, for example behind a refresh button.
+ *
+ * **Details**
+ *
+ * The registry is resolved once, at injection time, so the returned callback
+ * stays usable from an event handler outside any injection context.
+ *
+ * **Gotchas**
+ *
+ * Must be called from an injection context. Refreshing discards whatever a write
+ * had put in the atom, so a state atom is re-seeded with its initial value. The
+ * atom is not mounted here, so pair this with {@link injectAtomValue} or
+ * {@link injectAtomMount} to keep the refreshed value alive.
+ *
+ * @see {@link injectAtomValue} for reading the refreshed value
+ *
+ * @category injection
+ * @since 4.0.0
+ */
+export const injectAtomRefresh = <A>(atom: Atom.Atom<A>): () => void => {
+  const registry = injectAtomRegistry()
+  return () => registry.refresh(atom)
+}
+
+/**
+ * Returns a function that writes a value to a writable atom.
+ *
+ * **When to use**
+ *
+ * Use when a component only needs to update an atom, for example from an event
+ * handler, and should not re-render when the atom changes.
+ *
+ * **Details**
+ *
+ * The registry is resolved once, at injection time, so the returned function
+ * stays usable outside any injection context.
+ *
+ * **Gotchas**
+ *
+ * Must be called from an injection context. The atom is not mounted here, so a
+ * write to an otherwise unread atom may be swept once it goes idle.
+ *
+ * @see {@link injectAtomUpdate} for writing a value derived from the current one
+ *
+ * @category injection
+ * @since 4.0.0
+ */
+export const injectAtomSet = <R, W>(atom: Atom.Writable<R, W>): (value: W) => void => {
+  const registry = injectAtomRegistry()
+  return (value) => registry.set(atom, value)
+}
+
+/**
+ * Returns a function that writes a value derived from the atom's current one.
+ *
+ * **When to use**
+ *
+ * Use to write increments, toggles, and anything else that must read the
+ * current value before it writes.
+ *
+ * **Details**
+ *
+ * The transform runs inside the registry's `update`, so the read and the write
+ * happen in a single registry pass rather than as a separate get and set.
+ *
+ * **Gotchas**
+ *
+ * Must be called from an injection context.
+ *
+ * @see {@link injectAtomSet} for writing a value directly
+ *
+ * @category injection
+ * @since 4.0.0
+ */
+export const injectAtomUpdate = <R, W>(
+  atom: Atom.Writable<R, W>
+): (transform: (current: R) => W) => void => {
+  const registry = injectAtomRegistry()
+  return (transform) => registry.update(atom, transform)
+}
+
+/**
+ * Returns a function that writes a `Result`-shaped atom and resolves with the
+ * `Exit` of the run that write started.
+ *
+ * **When to use**
+ *
+ * Use when the caller must branch on the typed error of a mutation, for example
+ * to map a validation failure onto form controls.
+ *
+ * **Details**
+ *
+ * The promise settles on the first `Success` or `Failure` that is not itself
+ * waiting on another run, so an intermediate waiting state does not resolve it.
+ *
+ * **Gotchas**
+ *
+ * Must be called from an injection context. The `Result` constraint is
+ * bypassable through the `any` in the atom's type parameters, so the value is
+ * re-read after the write and a non-`Result` atom throws with a named error
+ * instead of hanging forever.
+ *
+ * @see {@link injectAtomSetPromise} for the variant that rejects with the squashed cause
+ * @see {@link AtomExit} for the type this resolves with
+ *
+ * @category injection
+ * @since 4.0.0
+ */
+export const injectAtomSetExit = <R extends AsyncResult.AsyncResult<any, any>, W>(
+  atom: Atom.Writable<R, W>
+): (value: W) => Promise<AtomExit<R>> => {
+  const registry = injectAtomRegistry()
+  return (value) => setExit(registry, atom, value) as Promise<AtomExit<R>>
+}
+
+/**
+ * Returns a function that writes a `Result`-shaped atom and resolves with the
+ * success value of the run that write started.
+ *
+ * **When to use**
+ *
+ * Use when a mutation should read like an ordinary promise, for example to await
+ * it in a component method and let a global handler deal with failures.
+ *
+ * **Gotchas**
+ *
+ * Must be called from an injection context. Rejects with the cause squashed by
+ * `Cause.squash`, which loses the typed error channel; use
+ * {@link injectAtomSetExit} to keep it.
+ *
+ * @see {@link injectAtomSetExit} for the variant that keeps the typed error
+ *
+ * @category injection
+ * @since 4.0.0
+ */
+export const injectAtomSetPromise = <R extends AsyncResult.AsyncResult<any, any>, W>(
+  atom: Atom.Writable<R, W>
+): (value: W) => Promise<AtomSuccess<R>> => {
+  const setter = injectAtomSetExit(atom)
+  return (value) => setter(value).then(flattenExit)
+}
+
+/**
+ * Flattens a `Result`-shaped store into one template-ready signal.
+ *
+ * **When to use**
+ *
+ * Use to render loading, success, and failure from a query atom in a single
+ * template switch over `status`, instead of reading the `Result` tags directly.
+ *
+ * **Details**
+ *
+ * `S` and `F` are inferred from the transforms when they are given, and fall
+ * back to the atom's own success type and a `Cause.pretty` string when they are
+ * not, so an untransformed call stays fully typed instead of collapsing to
+ * `unknown`. The name is unprefixed because it injects nothing: the store
+ * already captured its registry and destroy hook, so this is callable wherever
+ * the store is. `store.matchResult()` reaches the same view through the store.
+ *
+ * **Gotchas**
+ *
+ * The default comparator holds when `status` and `waiting` match and `value` and
+ * `error` are equal under `Equal.equals` — structural for plain objects and
+ * arrays as well as for Effect data types, and cached per object pair, so a
+ * payload mutated in place after its first comparison can stop notifying. The
+ * transforms are validated once, when the view is bound, and a non-function
+ * throws rather than being silently dropped. The `Result` constraint is
+ * bypassable, so the value is re-checked on every emission and a non-`Result`
+ * store throws when the view is first read.
+ *
+ * @see {@link AtomResultViewOptions} for the transforms and the comparator
+ * @see {@link AtomResultView} for the shape this produces
+ *
+ * @category combinators
+ * @since 4.0.0
+ */
+export const atomMatchResult = <R extends AsyncResult.AsyncResult<any, any>, S = AtomSuccess<R>, F = string>(
+  source: ReadableAtomStore<R>,
+  { equal = sameResultView, transformFailure, transformSuccess }: AtomResultViewOptions<R, S, F> = {}
+): Signal<AtomResultView<S, F>> => {
+  requireTransform("transformSuccess", transformSuccess)
+  requireTransform("transformFailure", transformFailure)
+  requireTransform("equal", equal)
+
+  return source.computed<AtomResultView<S, F>>(
+    (result) =>
+      AsyncResult.match(requireResult(result), {
+        onInitial: ({ waiting }) => ({
+          status: ATOM_RESULT_STATUS.INITIAL,
+          waiting,
+          value: null,
+          error: null
+        }),
+        onFailure: ({ cause, waiting }) => ({
+          status: ATOM_RESULT_STATUS.FAILURE,
+          waiting,
+          value: null,
+          // Only the caller's transform can produce an `F`, and the fallback is
+          // a string by construction. Same shape on the success side.
+          error: (transformFailure ? transformFailure(cause) : Cause.pretty(cause)) as F
+        }),
+        onSuccess: ({ value, waiting }) => ({
+          status: ATOM_RESULT_STATUS.SUCCESS,
+          waiting,
+          error: null,
+          value: (transformSuccess ? transformSuccess(value) : value) as S
+        })
+      }),
+    { equal }
+  )
+}
+
+/**
+ * Binds an atom to the current Angular injector and returns a store over it.
+ *
+ * **When to use**
+ *
+ * Use when one component or service needs several operations on the same atom —
+ * read, write, derive, refresh — and a separate injection function for each
+ * would be repetitive.
+ *
+ * **Details**
+ *
+ * The returned surface is selected from the atom's type: reads for every atom,
+ * writes for writable ones, `matchResult` for `Result`-shaped ones, and the
+ * awaitable write pair when it is both. Everything the store needs from the
+ * injector — the registry and the destroy hook — is captured here, so the
+ * store's methods stay callable afterwards, outside any injection context.
+ * `value()` and a bare `matchResult()` are memoised, so repeated calls share one
+ * subscription.
+ *
+ * **Gotchas**
+ *
+ * Must be called from an injection context. Each caller gets its own store over
+ * the same atom; it is the shared registry, not the store, that keeps them in
+ * step. Pass `registry` in the options only to opt out of that sharing, which
+ * gives the store a private registry that it also disposes.
+ *
+ * **Example** (Sharing one store through an injection token)
+ *
+ * ```ts
+ * import { InjectionToken } from "@angular/core"
+ * import { injectMakeAtom } from "@effect/atom-angular"
+ * import { Atom } from "effect/unstable/reactivity"
+ *
+ * const countAtom = Atom.make(0)
+ *
+ * export const COUNT_STORE = new InjectionToken("COUNT_STORE", {
+ *   providedIn: "root",
+ *   factory: () => injectMakeAtom(countAtom)
+ * })
+ * ```
+ *
+ * @see {@link AtomStore} for how the surface is selected from the atom type
+ * @see {@link AtomRegistryOptions} for the private-registry option
+ *
+ * @category injection
+ * @since 4.0.0
+ */
+export const injectMakeAtom = <T extends Atom.Atom<any>>(
+  source: T,
+  options?: AtomRegistryOptions
+): AtomStore<T> => {
+  type R = AtomValue<T>
+  type W = AtomWriteValue<T>
+
+  const atom = source as Atom.Atom<R>
+  const registry = injectScopedRegistry(options)
+  const destroyRef = injectDestroyRef()
+
+  // Resolved once, when the store is bound. `Atom.isWritable` is a real guard,
+  // so this narrowing is sound; what it cannot infer is W, which the explicit
+  // type arguments pin.
+  const writable = Atom.isWritable<R, W>(atom) ? atom : undefined
+
+  const requireWritable = (): Atom.Writable<R, W> => {
+    if (!writable) {
+      throw new Error("[@effect/atom-angular] cannot write to a read-only atom")
+    }
+
+    return writable
+  }
+
+  // One signal per store, so repeated `value()` calls share a subscription
+  let valueSignal: Signal<R> | undefined
+
+  // The same, for the bare Result view — see `matchResult` for why only the bare one
+  let resultView: Signal<AtomResultView<unknown, unknown>> | undefined
+
+  // One keepalive per store, for the same reason
+  let mounted = false
+
+  const store = {
+    registry,
+
+    value: (): Signal<R> => (valueSignal ??= atomSignal(registry, destroyRef, atom)),
+
+    mount: (): void => {
+      if (mounted) return
+
+      mounted = true
+      destroyRef.onDestroy(registry.mount(atom))
+    },
+
+    computed: <B>(transform: (current: R) => B, options?: AtomComputedOptions<B>): Signal<B> =>
+      atomSignal(registry, destroyRef, Atom.map<Atom.Atom<R>, B>(atom, transform), options),
+
+    subscribe: (f: (value: R) => void, options?: AtomSubscribeOptions): void => {
+      destroyRef.onDestroy(registry.subscribe(atom, f, options))
+    },
+
+    refresh: (): void => registry.refresh(atom),
+
+    set: (value: W): void => registry.set(requireWritable(), value),
+
+    update: (transform: (current: R) => W): void => registry.update(requireWritable(), transform),
+
+    setExit: (value: W): Promise<Exit.Exit<unknown, unknown>> => setExit(registry, requireWritable(), value),
+
+    setPromise: (value: W): Promise<unknown> => setExit(registry, requireWritable(), value).then(flattenExit),
+
+    // Memoised only when called bare. With transforms there is no sound key —
+    // two callers passing different closures want different views.
+    matchResult: (options?: AtomResultViewOptions<R, unknown, unknown>) => {
+      const source = store as unknown as ReadableAtomStore<AsyncResult.AsyncResult<any, any>>
+
+      if (options === undefined) return (resultView ??= atomMatchResult(source))
+
+      return atomMatchResult(
+        source,
+        options as AtomResultViewOptions<AsyncResult.AsyncResult<any, any>, unknown, unknown>
+      )
+    }
+  }
+
+  // The object is structurally wider than the derived store type: it always
+  // carries the write members, and the conditional type is what removes them
+  // from view. This cast narrows — it does not paper over a mismatch.
+  return store as unknown as AtomStore<T>
+}

--- a/packages/atom/angular/src/Providers.ts
+++ b/packages/atom/angular/src/Providers.ts
@@ -1,0 +1,158 @@
+/**
+ * Angular dependency-injection wiring for the `AtomRegistry` that the stores and
+ * injection functions read from. The registry holds atom values, schedules
+ * update work, and cleans up unused atoms; sharing one through Angular DI is
+ * what lets components, directives, and services in the same injector tree read
+ * and write the same atom state.
+ *
+ * The registry token is `providedIn: "root"`, so a registry exists without any
+ * setup. `provideAtomRegistry` replaces it for an injector scope, and
+ * `REGISTRY_OPTIONS` configures the one that is created by default.
+ *
+ * @since 4.0.0
+ */
+import type { Provider } from "@angular/core"
+import { DestroyRef, inject, InjectionToken } from "@angular/core"
+import * as AtomRegistry from "effect/unstable/reactivity/AtomRegistry"
+
+import type { RegistryOptions } from "./Types.ts"
+
+/**
+ * Injection token carrying the options a default registry is created with.
+ *
+ * **When to use**
+ *
+ * Use to configure the registry that {@link ATOM_REGISTRY} creates on first use
+ * without replacing the token itself: provide it in
+ * `ApplicationConfig.providers` and the root registry picks it up.
+ *
+ * **Details**
+ *
+ * The token is optional. When nothing provides it, the registry is created with
+ * `AtomRegistry.make` defaults. {@link provideAtomRegistry} provides it too, so
+ * the options a scope was configured with stay readable through
+ * {@link injectRegistryOptions}.
+ *
+ * @see {@link ATOM_REGISTRY} for the registry these options configure
+ *
+ * @category context
+ * @since 4.0.0
+ */
+export const REGISTRY_OPTIONS: InjectionToken<RegistryOptions> = new InjectionToken<RegistryOptions>(
+  "@effect/atom-angular:REGISTRY_OPTIONS"
+)
+
+/**
+ * Returns the registry options provided for the current Angular injector, or
+ * `null` when none were provided.
+ *
+ * **When to use**
+ *
+ * Use when building a registry by hand and the surrounding scope's configured
+ * options should be honoured.
+ *
+ * **Gotchas**
+ *
+ * Must be called from an injection context, such as a constructor or a field
+ * initializer.
+ *
+ * @see {@link REGISTRY_OPTIONS} for the token this reads
+ *
+ * @category context
+ * @since 4.0.0
+ */
+export const injectRegistryOptions = (): RegistryOptions | null => inject(REGISTRY_OPTIONS, { optional: true })
+
+// Creates a registry bound to the current injector; needs an injection context
+const makeScopedRegistry = (options?: RegistryOptions): AtomRegistry.AtomRegistry => {
+  const registry = AtomRegistry.make(options ?? injectRegistryOptions() ?? undefined)
+  inject(DestroyRef).onDestroy(() => registry.dispose())
+  return registry
+}
+
+/**
+ * Injection token carrying the `AtomRegistry` every store shares by default.
+ *
+ * **When to use**
+ *
+ * Use when you need to read or provide the registry through lower-level Angular
+ * DI APIs instead of {@link injectAtomRegistry} or {@link provideAtomRegistry}.
+ *
+ * **Details**
+ *
+ * The token is tree-shakable and `providedIn: "root"`. When no explicit provider
+ * is present, a registry is created on first use from {@link REGISTRY_OPTIONS}
+ * and disposed when the injector that created it is destroyed. Atoms form a
+ * dependency graph and that graph lives in a registry, so one registry per
+ * injector scope is the intended model: two registries mean two independent
+ * copies of the same atoms, and stores built over related atoms would not see
+ * each other's writes.
+ *
+ * @see {@link provideAtomRegistry} for scoping a registry to an injector
+ *
+ * @category context
+ * @since 4.0.0
+ */
+export const ATOM_REGISTRY: InjectionToken<AtomRegistry.AtomRegistry> = new InjectionToken<
+  AtomRegistry.AtomRegistry
+>("@effect/atom-angular:ATOM_REGISTRY", {
+  providedIn: "root",
+  factory: () => makeScopedRegistry()
+})
+
+/**
+ * Returns the `AtomRegistry` visible to the current Angular injector.
+ *
+ * **When to use**
+ *
+ * Use when a component or service needs the registry directly, for example to
+ * read, set, or refresh an atom outside the store and the injection functions,
+ * or to end a subscription earlier than the injector does.
+ *
+ * **Gotchas**
+ *
+ * Must be called from an injection context, such as a constructor or a field
+ * initializer.
+ *
+ * @see {@link ATOM_REGISTRY} for the token this reads
+ *
+ * @category context
+ * @since 4.0.0
+ */
+export const injectAtomRegistry = (): AtomRegistry.AtomRegistry => inject(ATOM_REGISTRY)
+
+/**
+ * Provides an `AtomRegistry` for an Angular injector, configured with the given
+ * registry options.
+ *
+ * **When to use**
+ *
+ * Use to scope atom state, scheduling, and idle cleanup to an application, a
+ * lazily loaded route, or a single component subtree.
+ *
+ * **Details**
+ *
+ * Returns providers for both {@link REGISTRY_OPTIONS} and {@link ATOM_REGISTRY},
+ * so the options stay readable from the same scope. In
+ * `ApplicationConfig.providers` this configures the application-wide registry;
+ * in a component's or a route's `providers` it creates a child registry for that
+ * injector, disposed when that injector is destroyed.
+ *
+ * **Gotchas**
+ *
+ * Options are read once, when the registry is created; changing them afterwards
+ * has no effect. A component-level provider creates one registry per component
+ * instance, which isolates that component from atom state held elsewhere.
+ * Leaving `defaultIdleTTL` unset means unused atoms are never swept, which is the
+ * `AtomRegistry.make` default.
+ *
+ * @see {@link ATOM_REGISTRY} for the token this provides
+ * @see {@link injectAtomRegistry} for reading the resulting registry
+ *
+ * @category context
+ * @since 4.0.0
+ */
+export const provideAtomRegistry = (options: RegistryOptions = {}): Array<Provider> => [
+  { provide: REGISTRY_OPTIONS, useValue: options },
+  { provide: ATOM_REGISTRY, useFactory: () => makeScopedRegistry(options) }
+]

--- a/packages/atom/angular/src/Types.ts
+++ b/packages/atom/angular/src/Types.ts
@@ -1,0 +1,507 @@
+/**
+ * The type-level surface of the Angular Atom bindings: the option bags the
+ * injection functions accept, the helpers that read an atom's value, write, and
+ * error types back out of its type, the flattened `Result` view a template can
+ * render, and the store interfaces `injectMakeAtom` returns.
+ *
+ * The store interfaces are layered so a store exposes only what its atom
+ * supports. Reading and deriving are always available, writing is added for a
+ * writable atom, and `matchResult` is added for a `Result`-shaped one, with
+ * `AtomStore` selecting the right combination from the atom type alone.
+ *
+ * @since 4.0.0
+ */
+import type { Signal, ValueEqualityFn } from "@angular/core"
+import type * as Cause from "effect/Cause"
+import type * as Exit from "effect/Exit"
+import type * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
+import type * as Atom from "effect/unstable/reactivity/Atom"
+import type * as AtomRegistry from "effect/unstable/reactivity/AtomRegistry"
+// `typeof` needs the binding, not the value, so this stays type-only and cannot
+// form a runtime cycle with `Constants.ts`
+import type { ATOM_RESULT_STATUS } from "./Constants.ts"
+
+// One shape for all three branches, so `waiting` and `readonly` live in one place
+type ResultBranch<Status extends AtomResultStatus, V, E> = {
+  readonly status: Status
+  // Orthogonal to the tag: any branch can be waiting on the next run
+  readonly waiting: boolean
+  readonly value: V
+  readonly error: E
+}
+
+/**
+ * Options accepted when creating an `AtomRegistry`.
+ *
+ * **Details**
+ *
+ * Derived from the parameter of `AtomRegistry.make` rather than restated, so the
+ * option set tracks the installed version of `effect` automatically. It carries
+ * `initialValues`, `scheduleTask`, `timeoutResolution`, and `defaultIdleTTL`.
+ *
+ * @see {@link AtomRegistryOptions} for the per-store option that opts into a private registry
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type RegistryOptions = NonNullable<Parameters<typeof AtomRegistry.make>[0]>
+
+/**
+ * Options accepted by an atom subscription.
+ *
+ * **Details**
+ *
+ * Derived from the third parameter of `AtomRegistry.subscribe` rather than
+ * restated, because every caller forwards this bag to the registry unchanged. It
+ * carries a single `immediate` flag: when `true` the callback is invoked once
+ * with the current value before the first change. It defaults to `false`.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type AtomSubscribeOptions = NonNullable<Parameters<AtomRegistry.AtomRegistry["subscribe"]>[2]>
+
+/**
+ * Options controlling how a derived signal decides that its value has not
+ * changed.
+ *
+ * **When to use**
+ *
+ * Use when a transform returns a freshly built object or array on every run and
+ * the consumer should only be notified when the projected value actually
+ * differs.
+ *
+ * **Details**
+ *
+ * `equal` is Angular's `ValueEqualityFn`, narrowed to the one field the bindings
+ * forward; Angular's own `debugName` is not accepted. When `equal` is omitted
+ * Angular falls back to `Object.is`, which is reference equality and so never
+ * holds for a fresh object — a projection that collapses distinct values then
+ * notifies on every recompute.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type AtomComputedOptions<B> = {
+  readonly equal?: ValueEqualityFn<B>
+}
+
+/**
+ * The value an atom reads, extracted from the atom's type.
+ *
+ * **Details**
+ *
+ * An alias for `Atom.Type`, kept here so the store types name their read type
+ * with the same vocabulary as their write type.
+ *
+ * @see {@link AtomWriteValue} for the value an atom accepts on write
+ *
+ * @category utility types
+ * @since 4.0.0
+ */
+export type AtomValue<T extends Atom.Atom<any>> = Atom.Type<T>
+
+/**
+ * The value an atom accepts on write, extracted from the atom's type, or `never`
+ * when the atom is read-only.
+ *
+ * **Details**
+ *
+ * The conditional is written in guarded form, `[T] extends [...]`, so a union of
+ * atom types is treated as one type instead of being distributed over, which
+ * would otherwise produce a union of write types for a source that is only
+ * sometimes writable.
+ *
+ * @see {@link AtomValue} for the value an atom reads
+ *
+ * @category utility types
+ * @since 4.0.0
+ */
+export type AtomWriteValue<T extends Atom.Atom<any>> = [T] extends [Atom.Writable<any, infer W>] ? W
+  : never
+
+/**
+ * The success value carried by a `Result`-shaped atom value, or `never` when the
+ * value is not `Result`-shaped.
+ *
+ * **Details**
+ *
+ * The conditional is written in guarded form, `[R] extends [...]`, so a union of
+ * atom value types is not distributed over.
+ *
+ * @see {@link AtomFailure} for the matching error type
+ *
+ * @category utility types
+ * @since 4.0.0
+ */
+export type AtomSuccess<R> = [R] extends [AsyncResult.AsyncResult<infer A, any>] ? A : never
+
+/**
+ * The error type carried by a `Result`-shaped atom value, or `never` when the
+ * value is not `Result`-shaped.
+ *
+ * **Details**
+ *
+ * The conditional is written in guarded form, `[R] extends [...]`, so a union of
+ * atom value types is not distributed over. This is the error type, not the
+ * `Cause` — a failure transform receives `Cause<AtomFailure<R>>`.
+ *
+ * @see {@link AtomSuccess} for the matching success type
+ *
+ * @category utility types
+ * @since 4.0.0
+ */
+export type AtomFailure<R> = [R] extends [AsyncResult.AsyncResult<any, infer E>] ? E : never
+
+/**
+ * The `Exit` a write against a `Result`-shaped atom settles into.
+ *
+ * **Details**
+ *
+ * Pairs {@link AtomSuccess} with {@link AtomFailure}, so an `Exit` produced by an
+ * awaitable write stays typed on both channels instead of collapsing to
+ * `Exit<unknown, unknown>`.
+ *
+ * @category utility types
+ * @since 4.0.0
+ */
+export type AtomExit<R> = Exit.Exit<AtomSuccess<R>, AtomFailure<R>>
+
+/**
+ * The part of an `AtomRegistry` a store exposes to its consumers.
+ *
+ * **Details**
+ *
+ * Picks `get`, `subscribe`, `mount`, `refresh`, and `getNodes`. Writes are left
+ * out so they go through the store and stay typed against the atom's own write
+ * type.
+ *
+ * **Gotchas**
+ *
+ * `reset`, `dispose`, and `setSerializable` are also left out: lifetime belongs
+ * to whoever created the registry, and a store that joined the injector's shared
+ * registry must not be able to dispose it out from under the other stores. Reach
+ * for `injectAtomRegistry` when those operations are genuinely needed.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type AtomRegistryView = Pick<
+  AtomRegistry.AtomRegistry,
+  "get" | "subscribe" | "mount" | "refresh" | "getNodes"
+>
+
+/**
+ * Options selecting which `AtomRegistry` a store binds to.
+ *
+ * **When to use**
+ *
+ * Use when a store must not share state with the rest of the injector scope, for
+ * example a wizard or a modal whose atoms should start clean each time it opens.
+ *
+ * **Gotchas**
+ *
+ * Omitting `registry` is the common case, and it is what lets related atoms in
+ * the same injector scope see each other's writes. Passing it — even as `{}` —
+ * creates a second, independent copy of the atom graph.
+ *
+ * @see {@link RegistryOptions} for the options the private registry is built with
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type AtomRegistryOptions = {
+  /**
+   * Opts the store out of the shared registry and gives it a private one, owned
+   * and disposed by the store.
+   *
+   * **Details**
+   *
+   * Omit it to join the registry of the injector scope, which is what lets
+   * related atoms see each other's writes.
+   */
+  readonly registry?: RegistryOptions
+}
+
+/**
+ * The set of status tags a flattened `Result` view can carry.
+ *
+ * **Details**
+ *
+ * Derived from `ATOM_RESULT_STATUS` with an indexed access rather than written
+ * out, so the union and the constant cannot name different tag sets.
+ *
+ * @see {@link ATOM_RESULT_STATUS} for the runtime values these tags are compared against
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type AtomResultStatus = (typeof ATOM_RESULT_STATUS)[keyof typeof ATOM_RESULT_STATUS]
+
+/**
+ * The three states of a `Result`, flattened into one object a template can read.
+ *
+ * **Details**
+ *
+ * A discriminated union over `status`, so a template guard on
+ * `view().status === 'success'` narrows `value` to `S` and `error` to `null`.
+ * Every branch also carries `waiting`, which is orthogonal to the tag: any branch
+ * can be waiting on the next run.
+ *
+ * **Gotchas**
+ *
+ * The tag is what makes narrowing work. A flat `value: S | null` narrows nothing
+ * when `S` is itself nullable, and forces a non-null assertion in the template.
+ * The failure branch keeps only the transformed error, so the `previousSuccess`
+ * carried by the underlying `AsyncResult.Failure` is not reachable through this
+ * view.
+ *
+ * @see {@link AtomResultViewOptions} for the transforms and comparator that produce it
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type AtomResultView<S, F> =
+  | ResultBranch<typeof ATOM_RESULT_STATUS.INITIAL, null, null>
+  | ResultBranch<typeof ATOM_RESULT_STATUS.SUCCESS, S, null>
+  | ResultBranch<typeof ATOM_RESULT_STATUS.FAILURE, null, F>
+
+/**
+ * Per-branch transforms that decide what the flattened `Result` view carries.
+ *
+ * **Details**
+ *
+ * Omit a transform and that branch falls back to its default: `S` becomes the
+ * atom's own success type, and `F` becomes the string produced by `Cause.pretty`.
+ * Supply one and it fixes `S` or `F` by inference. `transformFailure` receives
+ * the whole `Cause`, not the bare error.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type AtomResultTransforms<R, S, F> = {
+  readonly transformSuccess?: (value: AtomSuccess<R>) => S
+  readonly transformFailure?: (cause: Cause.Cause<AtomFailure<R>>) => F
+}
+
+/**
+ * Everything the flattened `Result` view accepts: the per-branch transforms plus
+ * the comparator the derived signal notifies by.
+ *
+ * **Details**
+ *
+ * The default comparator holds when `status` and `waiting` are identical and
+ * `value` and `error` are equal under `Equal.equals`, which is a structural
+ * comparison for plain objects and arrays as well as for Effect data types.
+ * Supply `equal` to widen or narrow that, for example to compare only an `id`
+ * when the payload is large.
+ *
+ * **Gotchas**
+ *
+ * The default comparator runs on every emission, over the whole payload.
+ * `Equal.equals` also caches each object pair, so a payload mutated in place
+ * after its first comparison can keep comparing equal and stop notifying.
+ *
+ * @see {@link AtomResultTransforms} for the transform half of these options
+ * @see {@link AtomComputedOptions} for the comparator half
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type AtomResultViewOptions<R, S, F> =
+  & AtomResultTransforms<R, S, F>
+  & AtomComputedOptions<AtomResultView<S, F>>
+
+/**
+ * The store surface available for every atom: reading it as a signal, deriving
+ * from it, mounting it, subscribing to it, and refreshing it.
+ *
+ * **Details**
+ *
+ * Reading and deriving never require writability, so this is the base every
+ * other store interface extends. Every method captured its registry and its
+ * destroy hook when the store was created, so they stay callable outside an
+ * injection context.
+ *
+ * @see {@link AtomStore} for the interface selected from a given atom type
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ReadableAtomStore<R> {
+  /**
+   * The registry this store is bound to, narrowed to reads and subscriptions.
+   */
+  readonly registry: AtomRegistryView
+  /**
+   * Returns the atom's value as an Angular signal.
+   *
+   * **Details**
+   *
+   * The signal is built on first call and shared from then on, so repeated calls
+   * share one subscription. Reading it mounts the atom.
+   */
+  value(): Signal<R>
+  /**
+   * Derives a projection inside the atom graph and returns it as a signal.
+   *
+   * **Gotchas**
+   *
+   * Each call builds a new derived atom and a new subscription, so this is meant
+   * to be called once and stored, not called from a template expression.
+   */
+  computed<B>(transform: (current: R) => B, options?: AtomComputedOptions<B>): Signal<B>
+  /**
+   * Re-runs the atom's read, discarding whatever a write had put there.
+   *
+   * **Gotchas**
+   *
+   * A state atom is re-seeded with its initial value.
+   */
+  refresh(): void
+  /**
+   * Keeps the atom alive for the store's lifetime without reading it as a
+   * signal.
+   *
+   * **Details**
+   *
+   * A mounted atom holds its state between reads instead of being recomputed.
+   * The keepalive is released when the injector that built the store is
+   * destroyed.
+   *
+   * **Gotchas**
+   *
+   * Calling this more than once is a no-op. Reading `value()` mounts the atom
+   * too, so a store that reads its atom does not need this.
+   */
+  mount(): void
+  /**
+   * Observes the atom without materialising a signal for it.
+   *
+   * **Details**
+   *
+   * The subscription runs until the injector that built the store is destroyed.
+   * It does not fire with the current value unless `immediate` is set.
+   *
+   * **Gotchas**
+   *
+   * There is no unsubscribe handle. Use `registry.subscribe` directly for a
+   * subscription that must end earlier than the injector.
+   */
+  subscribe(f: (value: R) => void, options?: AtomSubscribeOptions): void
+}
+
+/**
+ * The store surface added when the atom's value is `Result`-shaped.
+ *
+ * **Details**
+ *
+ * Reachable whenever the atom is `Result`-shaped, independently of writability,
+ * because the query atoms this exists for are usually read-only.
+ *
+ * @see {@link AtomResultView} for the shape `matchResult` produces
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ResultAtomStore<R> extends ReadableAtomStore<R> {
+  /**
+   * Flattens the three `Result` states into one template-ready signal.
+   *
+   * **Details**
+   *
+   * `S` and `F` are inferred from the transforms, and default to the atom's own
+   * success type and to a `Cause.pretty` string when the transforms are absent.
+   * The bare call is memoised per store; a call with options builds a fresh
+   * derived signal each time.
+   */
+  matchResult<S = AtomSuccess<R>, F = string>(
+    options?: AtomResultViewOptions<R, S, F>
+  ): Signal<AtomResultView<S, F>>
+}
+
+/**
+ * The store surface added when the atom is writable.
+ *
+ * **Details**
+ *
+ * Reachable only when the atom type is `Atom.Writable`, so `set` and `update` do
+ * not appear on a store built over a read-only atom.
+ *
+ * @see {@link AsyncAtomStore} for the surface when the atom is also `Result`-shaped
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface WritableAtomStore<R, W> extends ReadableAtomStore<R> {
+  /**
+   * Writes a value to the atom.
+   */
+  set(value: W): void
+  /**
+   * Writes a value derived from the atom's current one, in a single registry
+   * pass.
+   */
+  update(transform: (current: R) => W): void
+}
+
+/**
+ * The store surface for an atom that is both writable and `Result`-shaped: the
+ * synchronous writes, the `Result` view, and the two awaitable writes.
+ *
+ * **Details**
+ *
+ * Reachable only when both axes hold, because only then does a write start a run
+ * whose outcome can be awaited.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface AsyncAtomStore<R, W> extends WritableAtomStore<R, W>, ResultAtomStore<R> {
+  /**
+   * Writes the atom and resolves with the success value of the run that write
+   * started.
+   *
+   * **Gotchas**
+   *
+   * Rejects with the squashed cause, which loses the typed error channel. Use
+   * `setExit` to keep it.
+   */
+  setPromise(value: W): Promise<AtomSuccess<R>>
+  /**
+   * Writes the atom and resolves with the `Exit` of the run that write started.
+   *
+   * **Details**
+   *
+   * The promise settles on the first `Success` or `Failure` that is not itself
+   * waiting on another run.
+   */
+  setExit(value: W): Promise<AtomExit<R>>
+}
+
+/**
+ * The store interface selected from an atom's type.
+ *
+ * **Details**
+ *
+ * Writability and `Result`-shape are independent axes. A read-only atom gets no
+ * write members on the type at all, while `matchResult` follows the other axis,
+ * so a read-only query atom keeps it and a writable non-`Result` atom does not.
+ *
+ * **Gotchas**
+ *
+ * This only removes members from view. The object the store constructor returns
+ * always carries every member at runtime, so a store reached through an `any` can
+ * still call a write or `matchResult`, and fails at the point of use rather than
+ * at the call site.
+ *
+ * @see {@link ReadableAtomStore} for the members every store has
+ *
+ * @category utility types
+ * @since 4.0.0
+ */
+export type AtomStore<T extends Atom.Atom<any>> = [T] extends [Atom.Writable<infer R, infer W>]
+  ? [R] extends [AsyncResult.AsyncResult<any, any>] ? AsyncAtomStore<R, W>
+  : WritableAtomStore<R, W>
+  : [AtomValue<T>] extends [AsyncResult.AsyncResult<any, any>] ? ResultAtomStore<AtomValue<T>>
+  : ReadableAtomStore<AtomValue<T>>

--- a/packages/atom/angular/src/index.ts
+++ b/packages/atom/angular/src/index.ts
@@ -1,0 +1,19 @@
+/**
+ * @since 4.0.0
+ */
+export * from "./Constants.ts"
+
+/**
+ * @since 4.0.0
+ */
+export * from "./Injects.ts"
+
+/**
+ * @since 4.0.0
+ */
+export * from "./Providers.ts"
+
+/**
+ * @since 4.0.0
+ */
+export * from "./Types.ts"

--- a/packages/atom/angular/test/index.test.ts
+++ b/packages/atom/angular/test/index.test.ts
@@ -1,0 +1,1239 @@
+import type { DestroyRef, Signal, ValueEqualityFn } from "@angular/core"
+import { createEnvironmentInjector, EnvironmentInjector, runInInjectionContext } from "@angular/core"
+import { TestBed } from "@angular/core/testing"
+import type {
+  AsyncAtomStore,
+  AtomComputedOptions,
+  AtomExit,
+  AtomFailure,
+  AtomRegistryOptions,
+  AtomResultStatus,
+  AtomResultView,
+  AtomResultViewOptions,
+  AtomSubscribeOptions,
+  AtomSuccess,
+  AtomValue,
+  AtomWriteValue,
+  ReadableAtomStore,
+  RegistryOptions,
+  ResultAtomStore,
+  WritableAtomStore
+} from "@effect/atom-angular"
+import {
+  ATOM_REGISTRY,
+  ATOM_RESULT_STATUS,
+  atomMatchResult,
+  injectAtomComputed,
+  injectAtomMount,
+  injectAtomRef,
+  injectAtomRefresh,
+  injectAtomRegistry,
+  injectAtomSet,
+  injectAtomSetExit,
+  injectAtomSetPromise,
+  injectAtomSubscribe,
+  injectAtomUpdate,
+  injectAtomValue,
+  injectDestroyRef,
+  injectMakeAtom,
+  injectRegistryOptions,
+  provideAtomRegistry,
+  REGISTRY_OPTIONS
+} from "@effect/atom-angular"
+import * as Cause from "effect/Cause"
+import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
+import * as Option from "effect/Option"
+import { Atom, AtomRef } from "effect/unstable/reactivity"
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
+import { describe, expect, expectTypeOf, it, vi } from "vitest"
+
+/** Runs `f` in a child injection context that can be destroyed independently. */
+const scoped = <A>(f: () => A): readonly [value: A, destroy: () => void] => {
+  const injector = createEnvironmentInjector([], TestBed.inject(EnvironmentInjector))
+  return [runInInjectionContext(injector, f), () => injector.destroy()] as const
+}
+
+/**
+ * Compile-time contract for the store type derived by `injectMakeAtom`.
+ *
+ * `tsc` is the assertion engine here, not the runner: a regression surfaces as
+ * a build failure. Negative cases use `@ts-expect-error`, which fails the build
+ * if the line it guards ever stops erroring. Every assertion therefore lives in
+ * a function that is declared but never invoked — the guarded lines must be
+ * type-checked without ever executing.
+ */
+
+const readOnlyAtom = Atom.make(() => 1)
+const valueAtom = Atom.make(2)
+const resultAtom = Atom.fn((n: number) => Effect.succeed(n > 0))
+const failingAtom = Atom.fn((n: number) => n > 0 ? Effect.succeed(n) : Effect.fail("negative" as const))
+const readOnlyResultAtom = Atom.make(Effect.succeed(1))
+const readWriteAtom = Atom.writable<number, string>(
+  () => 0,
+  () => {}
+)
+
+type StoreOf<A extends Atom.Atom<any>> = ReturnType<typeof injectMakeAtom<A>>
+
+// A read-only atom exposes the readable surface and nothing else
+const _readOnlyContract = (store: StoreOf<typeof readOnlyAtom>) => {
+  expectTypeOf<StoreOf<typeof readOnlyAtom>>().toEqualTypeOf<ReadableAtomStore<number>>()
+  expectTypeOf(store.value()).toEqualTypeOf<Signal<number>>()
+  expectTypeOf(store.computed((n) => `${n}`)).toEqualTypeOf<Signal<string>>()
+  // Refreshing and mounting are read concerns, so they are readable-surface too
+  expectTypeOf(store.refresh()).toBeVoid()
+  expectTypeOf(store.mount()).toBeVoid()
+  expectTypeOf(store.subscribe).parameter(0).toEqualTypeOf<(value: number) => void>()
+  expectTypeOf(store.subscribe((n) => void n)).toBeVoid()
+
+  // @ts-expect-error a read-only atom has no `set`
+  store.set(1)
+  // @ts-expect-error a read-only atom has no `update`
+  store.update((n: number) => n + 1)
+  // @ts-expect-error a read-only atom has no `setPromise`
+  store.setPromise(1)
+  // @ts-expect-error a read-only atom has no `setExit`
+  store.setExit(1)
+}
+
+// The exposed registry allows reads and subscriptions but no writes or disposal
+const _registryViewContract = (store: StoreOf<typeof valueAtom>) => {
+  expectTypeOf(store.registry.get(valueAtom)).toEqualTypeOf<number>()
+  expectTypeOf(store.registry.subscribe).toBeFunction()
+  expectTypeOf(store.registry.refresh).toBeFunction()
+
+  // @ts-expect-error lifetime belongs to the registry owner
+  store.registry.dispose()
+  // @ts-expect-error lifetime belongs to the registry owner
+  store.registry.reset()
+  // @ts-expect-error writes go through the store so they stay typed
+  store.registry.set(valueAtom, 1)
+  // @ts-expect-error writes go through the store so they stay typed
+  store.registry.update(valueAtom, (n: number) => n + 1)
+  // @ts-expect-error writes go through the store so they stay typed
+  store.registry.modify(valueAtom, (n: number) => [n, n + 1])
+}
+
+// A writable non-Result atom gains the write surface but no async surface
+const _writableValueContract = (store: StoreOf<typeof valueAtom>) => {
+  expectTypeOf<StoreOf<typeof valueAtom>>().toEqualTypeOf<WritableAtomStore<number, number>>()
+  expectTypeOf(store.value()).toEqualTypeOf<Signal<number>>()
+  expectTypeOf(store.set).parameter(0).toEqualTypeOf<number>()
+  expectTypeOf(store.update).parameter(0).toEqualTypeOf<(current: number) => number>()
+
+  // @ts-expect-error a non-Result atom has no `setPromise`
+  store.setPromise(1)
+  // @ts-expect-error a non-Result atom has no `setExit`
+  store.setExit(1)
+  // @ts-expect-error the written value must match W
+  store.set("nope")
+}
+
+// A writable Result atom gains the async surface with both channels typed
+const _asyncContract = (store: StoreOf<typeof resultAtom>) => {
+  expectTypeOf<StoreOf<typeof resultAtom>>().toExtend<
+    AsyncAtomStore<AsyncResult.AsyncResult<boolean, never>, number>
+  >()
+  expectTypeOf(store.value()).toEqualTypeOf<Signal<AsyncResult.AsyncResult<boolean, never>>>()
+  expectTypeOf(store.setPromise(1)).toEqualTypeOf<Promise<boolean>>()
+  expectTypeOf(store.setExit(1)).toEqualTypeOf<Promise<Exit.Exit<boolean, never>>>()
+}
+
+// The failure channel survives into `setExit` and is flattened away by `setPromise`
+const _errorChannelContract = (store: StoreOf<typeof failingAtom>) => {
+  expectTypeOf(store.setPromise(1)).toEqualTypeOf<Promise<number>>()
+  expectTypeOf(store.setExit(1)).toEqualTypeOf<Promise<Exit.Exit<number, "negative">>>()
+}
+
+// Read and write types stay distinct when the atom separates them
+const _readWriteContract = (store: StoreOf<typeof readWriteAtom>) => {
+  expectTypeOf(store.value()).toEqualTypeOf<Signal<number>>()
+  expectTypeOf(store.set).parameter(0).toEqualTypeOf<string>()
+  expectTypeOf(store.update).parameter(0).toEqualTypeOf<(current: number) => string>()
+
+  // @ts-expect-error `set` takes W, not R
+  store.set(1)
+}
+
+// `computed` widens to any type the transform returns
+const _computedContract = (store: StoreOf<typeof valueAtom>) => {
+  expectTypeOf(store.computed((n) => n > 1)).toEqualTypeOf<Signal<boolean>>()
+  expectTypeOf(store.computed((n) => ({ n }))).toEqualTypeOf<Signal<{ n: number }>>()
+  expectTypeOf(store.computed).parameter(0).parameter(0).toEqualTypeOf<number>()
+}
+
+/**
+ * The equality bag is typed by what the transform returns, not by the atom's
+ * own value — the comparator never sees the upstream type.
+ */
+const _computedEqualContract = (store: StoreOf<typeof valueAtom>) => {
+  expectTypeOf<AtomComputedOptions<string>>().toEqualTypeOf<{
+    readonly equal?: ValueEqualityFn<string>
+  }>()
+
+  expectTypeOf(store.computed((n) => ({ n }), { equal: (a, b) => a.n === b.n })).toEqualTypeOf<
+    Signal<{ n: number }>
+  >()
+
+  expectTypeOf(
+    injectAtomComputed(valueAtom, (n) => `${n}`, { equal: (a, b) => a === b })
+  ).toEqualTypeOf<Signal<string>>()
+
+  // @ts-expect-error the comparator takes the projection, not the atom's value
+  store.computed((n) => `${n}`, { equal: (a: number, b: number) => a === b })
+  // @ts-expect-error the only option is `equal`
+  store.computed((n) => `${n}`, { equals: (a: string, b: string) => a === b })
+}
+
+// The exported value helpers resolve independently of the store type
+const _helperContract = () => {
+  expectTypeOf<AtomValue<Atom.Atom<number>>>().toEqualTypeOf<number>()
+  expectTypeOf<AtomValue<Atom.Writable<number, string>>>().toEqualTypeOf<number>()
+  expectTypeOf<AtomWriteValue<Atom.Writable<number, string>>>().toEqualTypeOf<string>()
+  expectTypeOf<AtomWriteValue<Atom.Atom<number>>>().toEqualTypeOf<never>()
+}
+
+/**
+ * The Result-channel aliases, asserted by name. `setExit`/`setPromise` cover
+ * them structurally, but only here does a rename or a dropped export fail with
+ * a message that names the type.
+ */
+const _channelAliasContract = () => {
+  expectTypeOf<AtomSuccess<AsyncResult.AsyncResult<number, "negative">>>().toEqualTypeOf<number>()
+  expectTypeOf<AtomFailure<AsyncResult.AsyncResult<number, "negative">>>().toEqualTypeOf<"negative">()
+  expectTypeOf<AtomExit<AsyncResult.AsyncResult<number, "negative">>>().toEqualTypeOf<
+    Exit.Exit<number, "negative">
+  >()
+
+  // Off the Result path they collapse rather than leaking `unknown`
+  expectTypeOf<AtomSuccess<number>>().toEqualTypeOf<never>()
+  expectTypeOf<AtomFailure<number>>().toEqualTypeOf<never>()
+
+  /**
+   * Guarded, so a union of Results is matched once as a whole and `infer`
+   * collects both channels — not distributed into a union of two aliases.
+   */
+  expectTypeOf<
+    AtomSuccess<AsyncResult.AsyncResult<number, never> | AsyncResult.AsyncResult<string, never>>
+  >().toEqualTypeOf<number | string>()
+}
+
+/**
+ * `ATOM_RESULT_STATUS` must stay the exact set of tags `AtomResultView` is
+ * discriminated by — a tag added to one and not the other is the failure the
+ * constant exists to prevent.
+ */
+const _statusConstantContract = () => {
+  // Each member is its own literal, not the widened union
+  expectTypeOf(ATOM_RESULT_STATUS.INITIAL).toEqualTypeOf<"initial">()
+  expectTypeOf(ATOM_RESULT_STATUS.SUCCESS).toEqualTypeOf<"success">()
+  expectTypeOf(ATOM_RESULT_STATUS.FAILURE).toEqualTypeOf<"failure">()
+
+  /**
+   * Spelled out rather than derived. `AtomResultStatus` *is*
+   * `(typeof ATOM_RESULT_STATUS)[keyof typeof ATOM_RESULT_STATUS]`, and
+   * `AtomResultView` is tagged from the same constant, so asserting either
+   * against the other compares a type to itself and holds for any tag set.
+   * Only an independent spelling fails when a tag is renamed, added or dropped.
+   */
+  expectTypeOf<AtomResultStatus>().toEqualTypeOf<"initial" | "success" | "failure">()
+  expectTypeOf<AtomResultView<number, string>["status"]>().toEqualTypeOf<
+    "initial" | "success" | "failure"
+  >()
+
+  // @ts-expect-error the table is closed
+  expectTypeOf(ATOM_RESULT_STATUS.PENDING)
+}
+
+/**
+ * Both options aliases are derived from upstream, so this pins the shape they
+ * currently resolve to — an upstream change surfaces here rather than silently
+ * widening the store surface.
+ */
+const _registryOptionsContract = () => {
+  expectTypeOf<AtomSubscribeOptions>().toEqualTypeOf<{ readonly immediate?: boolean }>()
+  expectTypeOf<Parameters<ReadableAtomStore<number>["subscribe"]>[1]>().toEqualTypeOf<
+    AtomSubscribeOptions | undefined
+  >()
+  expectTypeOf<AtomRegistryOptions>().toEqualTypeOf<{ readonly registry?: RegistryOptions }>()
+  expectTypeOf<Parameters<typeof injectMakeAtom<typeof valueAtom>>[1]>().toEqualTypeOf<
+    AtomRegistryOptions | undefined
+  >()
+}
+
+// Options cover the registry only — there is no injectable to scope any more
+const _optionsContract = () => {
+  expectTypeOf(injectMakeAtom(valueAtom, { registry: {} })).toEqualTypeOf<
+    WritableAtomStore<number, number>
+  >()
+
+  // @ts-expect-error the functional form has no `providedIn`
+  injectMakeAtom(valueAtom, { providedIn: "root" })
+}
+
+// The granular helpers each constrain the atom to what they can do with it
+const _granularContract = () => {
+  expectTypeOf(injectAtomValue(readOnlyAtom)).toEqualTypeOf<Signal<number>>()
+  expectTypeOf(injectAtomComputed(valueAtom, (n) => `${n}`)).toEqualTypeOf<Signal<string>>()
+  expectTypeOf(injectAtomSet(readWriteAtom)).parameter(0).toEqualTypeOf<string>()
+  expectTypeOf(injectAtomUpdate(readWriteAtom))
+    .parameter(0)
+    .toEqualTypeOf<(current: number) => string>()
+  expectTypeOf(injectAtomSetPromise(failingAtom)).returns.toEqualTypeOf<Promise<number>>()
+  expectTypeOf(injectAtomSetExit(failingAtom)).returns.toEqualTypeOf<
+    Promise<Exit.Exit<number, "negative">>
+  >()
+
+  // @ts-expect-error a read-only atom cannot be written
+  injectAtomSet(readOnlyAtom)
+  // @ts-expect-error the async setters need a Result-shaped atom
+  injectAtomSetPromise(valueAtom)
+  // @ts-expect-error the async setters need a Result-shaped atom
+  injectAtomSetExit(valueAtom)
+}
+
+// The helpers that return nothing, and the ref reader that touches no registry
+const _voidHelperContract = () => {
+  expectTypeOf(injectDestroyRef()).toEqualTypeOf<DestroyRef>()
+  expectTypeOf(injectAtomMount(readOnlyAtom)).toBeVoid()
+  expectTypeOf(injectAtomSubscribe(readOnlyAtom, (n) => void n)).toBeVoid()
+  expectTypeOf(injectAtomSubscribe<number>)
+    .parameter(1)
+    .toEqualTypeOf<(value: number) => void>()
+  expectTypeOf(injectAtomRefresh(readOnlyAtom)).toEqualTypeOf<() => void>()
+
+  // A ref is read off the ref itself, so it takes no atom and no registry
+  expectTypeOf(injectAtomRef(AtomRef.make(1))).toEqualTypeOf<Signal<number>>()
+
+  // @ts-expect-error a ref is not an atom
+  injectAtomRef(readOnlyAtom)
+  // @ts-expect-error an atom is not a ref
+  injectAtomValue(AtomRef.make(1))
+}
+
+/**
+ * The view keeps the atom's own success and failure types when no transform is
+ * given, and takes them from the transforms when they are.
+ */
+const _matchResultContract = (store: StoreOf<typeof failingAtom>) => {
+  expectTypeOf(atomMatchResult(store)).toEqualTypeOf<Signal<AtomResultView<number, string>>>()
+
+  expectTypeOf(
+    atomMatchResult(store, {
+      transformSuccess: (value) => `#${value}`,
+      transformFailure: (cause) => Cause.squash(cause)
+    })
+  ).toEqualTypeOf<Signal<AtomResultView<string, unknown>>>()
+
+  // Each transform sees the atom's own channel, not `unknown`
+  expectTypeOf(atomMatchResult<AsyncResult.AsyncResult<number, "negative">>)
+    .parameter(1)
+    .toExtend<{ transformSuccess?: (value: number) => unknown } | undefined>()
+
+  /**
+   * The generic branch alias must stay a plain literal union: an intersection
+   * would still assign, but would narrow and print worse.
+   */
+  expectTypeOf<Extract<AtomResultView<number, string>, { status: "success" }>>().toEqualTypeOf<{
+    readonly status: "success"
+    readonly waiting: boolean
+    readonly value: number
+    readonly error: null
+  }>()
+
+  // The tag is what narrows: no non-null assertion needed to read `value`
+  const view = atomMatchResult(store)()
+  if (view.status === "success") expectTypeOf(view.value).toEqualTypeOf<number>()
+  if (view.status === "failure") expectTypeOf(view.error).toEqualTypeOf<string>()
+  if (view.status === "initial") expectTypeOf(view.value).toEqualTypeOf<null>()
+
+  // @ts-expect-error the view needs a Result-shaped store
+  atomMatchResult(_nonResultStore)
+  // @ts-expect-error the transform must accept the atom's success type
+  atomMatchResult(store, { transformSuccess: (value: string) => value })
+
+  /**
+   * The comparator sees the finished view, with `S` and `F` already decided by
+   * the transforms in the same bag — not the atom's own channels.
+   */
+  expectTypeOf<AtomResultViewOptions<AsyncResult.AsyncResult<number, "negative">, boolean, string>>()
+    .toHaveProperty("equal")
+    .toEqualTypeOf<ValueEqualityFn<AtomResultView<boolean, string>> | undefined>()
+
+  expectTypeOf(
+    atomMatchResult(store, {
+      transformSuccess: (value) => value > 1,
+      equal: (a, b) => a.value === b.value
+    })
+  ).toEqualTypeOf<Signal<AtomResultView<boolean, string>>>()
+
+  // @ts-expect-error the comparator takes the view, not the success payload
+  atomMatchResult(store, { equal: (a: number, b: number) => a === b })
+}
+
+/**
+ * `matchResult` follows Result-shapedness, not writability: a read-only query
+ * atom keeps it, a writable non-Result atom never had it.
+ */
+const _storeMatchResultContract = (store: StoreOf<typeof failingAtom>) => {
+  expectTypeOf(store.matchResult()).toEqualTypeOf<Signal<AtomResultView<number, string>>>()
+  expectTypeOf(store.matchResult({ transformSuccess: (value) => value > 1 })).toEqualTypeOf<
+    Signal<AtomResultView<boolean, string>>
+  >()
+
+  // The comparator rides in the same bag, and does not disturb the inference
+  expectTypeOf(
+    store.matchResult({
+      transformSuccess: (value) => value > 1,
+      equal: (a, b) => a.status === b.status
+    })
+  ).toEqualTypeOf<Signal<AtomResultView<boolean, string>>>()
+
+  // The same member on a read-only Result atom
+  expectTypeOf<StoreOf<typeof readOnlyResultAtom>>().toExtend<
+    ResultAtomStore<AsyncResult.AsyncResult<number, never>>
+  >()
+
+  // @ts-expect-error a writable non-Result atom has no `matchResult`
+  _nonResultStore.matchResult()
+  // @ts-expect-error a plain read-only atom has no `matchResult` either
+  _plainReadOnlyStore.matchResult()
+}
+
+declare const _plainReadOnlyStore: StoreOf<typeof readOnlyAtom>
+
+declare const _nonResultStore: StoreOf<typeof valueAtom>
+
+describe("atom-angular", () => {
+  describe("registry wiring", () => {
+    it("hands every injection in the scope the same registry", () => {
+      const registry = TestBed.inject(ATOM_REGISTRY)
+
+      expect(TestBed.runInInjectionContext(() => injectAtomRegistry())).toBe(registry)
+    })
+
+    it("gives a child injector a registry of its own", () => {
+      const countAtom = Atom.make(0)
+      const parent = TestBed.inject(ATOM_REGISTRY)
+
+      const injector = createEnvironmentInjector(
+        [provideAtomRegistry()],
+        TestBed.inject(EnvironmentInjector)
+      )
+      const child = injector.get(ATOM_REGISTRY)
+
+      expect(child).not.toBe(parent)
+
+      // Two registries are two copies of the same atom, so the write stays put
+      child.set(countAtom, 1)
+      expect(parent.get(countAtom)).toBe(0)
+
+      injector.destroy()
+    })
+
+    it("seeds the scope registry from the options it was provided with", () => {
+      const countAtom = Atom.make(0)
+
+      TestBed.configureTestingModule({
+        providers: [provideAtomRegistry({ initialValues: [[countAtom, 10]] })]
+      })
+
+      expect(TestBed.runInInjectionContext(() => injectAtomValue(countAtom))()).toBe(10)
+    })
+
+    it("reads back the options of the scope, and null when none were provided", () => {
+      expect(TestBed.runInInjectionContext(() => injectRegistryOptions())).toBeNull()
+
+      const options: RegistryOptions = { defaultIdleTTL: 500 }
+      const injector = createEnvironmentInjector(
+        [provideAtomRegistry(options)],
+        TestBed.inject(EnvironmentInjector)
+      )
+
+      expect(runInInjectionContext(injector, () => injectRegistryOptions())).toEqual(options)
+
+      injector.destroy()
+    })
+
+    it("resolves without setup, and reaches a child that provides no registry", () => {
+      const countAtom = Atom.make(0)
+      const root = TestBed.inject(ATOM_REGISTRY)
+
+      const injector = createEnvironmentInjector([], TestBed.inject(EnvironmentInjector))
+
+      // The token is tree-shakable and providedIn root, so it resolves at the
+      // root injector and both scopes read one atom graph
+      expect(injector.get(ATOM_REGISTRY)).toBe(root)
+
+      runInInjectionContext(injector, () => injectAtomRegistry()).set(countAtom, 1)
+      expect(root.get(countAtom)).toBe(1)
+
+      injector.destroy()
+    })
+
+    it("builds the default registry from the REGISTRY_OPTIONS it finds", () => {
+      const countAtom = Atom.make(0)
+
+      TestBed.configureTestingModule({
+        providers: [{ provide: REGISTRY_OPTIONS, useValue: { initialValues: [[countAtom, 10]] } }]
+      })
+
+      expect(TestBed.inject(ATOM_REGISTRY).get(countAtom)).toBe(10)
+    })
+
+    it("creates the scope registry once, however often it is injected", () => {
+      const injector = createEnvironmentInjector(
+        [provideAtomRegistry()],
+        TestBed.inject(EnvironmentInjector)
+      )
+
+      const registry = injector.get(ATOM_REGISTRY)
+      expect(injector.get(ATOM_REGISTRY)).toBe(registry)
+      expect(runInInjectionContext(injector, () => injectAtomRegistry())).toBe(registry)
+
+      injector.destroy()
+    })
+
+    it("provides the options alongside the registry, and defaults them to empty", () => {
+      const options: RegistryOptions = { defaultIdleTTL: 500 }
+      const configured = createEnvironmentInjector(
+        [provideAtomRegistry(options)],
+        TestBed.inject(EnvironmentInjector)
+      )
+      const bare = createEnvironmentInjector(
+        [provideAtomRegistry()],
+        TestBed.inject(EnvironmentInjector)
+      )
+
+      expect(configured.get(REGISTRY_OPTIONS)).toBe(options)
+      expect(bare.get(REGISTRY_OPTIONS)).toEqual({})
+
+      configured.destroy()
+      bare.destroy()
+    })
+
+    it("ignores the options of the parent scope, even when given none of its own", () => {
+      const countAtom = Atom.make(0)
+
+      TestBed.configureTestingModule({
+        providers: [{ provide: REGISTRY_OPTIONS, useValue: { initialValues: [[countAtom, 10]] } }]
+      })
+      const injector = createEnvironmentInjector(
+        [provideAtomRegistry()],
+        TestBed.inject(EnvironmentInjector)
+      )
+
+      // The scope was configured with `{}`, which is an answer, not an absence
+      expect(injector.get(ATOM_REGISTRY).get(countAtom)).toBe(0)
+      expect(TestBed.inject(ATOM_REGISTRY).get(countAtom)).toBe(10)
+
+      injector.destroy()
+    })
+
+    it("prefers its own options over the ones the parent scope was configured with", () => {
+      const countAtom = Atom.make(0)
+
+      TestBed.configureTestingModule({
+        providers: [{ provide: REGISTRY_OPTIONS, useValue: { initialValues: [[countAtom, 10]] } }]
+      })
+      const injector = createEnvironmentInjector(
+        [provideAtomRegistry({ initialValues: [[countAtom, 20]] })],
+        TestBed.inject(EnvironmentInjector)
+      )
+
+      expect(injector.get(ATOM_REGISTRY).get(countAtom)).toBe(20)
+
+      injector.destroy()
+    })
+
+    it("reads its options once, when the registry is created", () => {
+      const countAtom = Atom.make(0)
+      const lateAtom = Atom.make(0)
+      const initialValues: Array<readonly [Atom.Atom<any>, any]> = [[countAtom, 10]]
+
+      const injector = createEnvironmentInjector(
+        [provideAtomRegistry({ initialValues })],
+        TestBed.inject(EnvironmentInjector)
+      )
+      const registry = injector.get(ATOM_REGISTRY)
+      initialValues.push([lateAtom, 20])
+
+      expect(injector.get(ATOM_REGISTRY)).toBe(registry)
+      expect(registry.get(countAtom)).toBe(10)
+      expect(registry.get(lateAtom)).toBe(0)
+
+      injector.destroy()
+    })
+
+    it("disposes the scope registry when its injector is destroyed", () => {
+      const injector = createEnvironmentInjector(
+        [provideAtomRegistry()],
+        TestBed.inject(EnvironmentInjector)
+      )
+      const registry = injector.get(ATOM_REGISTRY)
+
+      injector.destroy()
+
+      expect(() => registry.get(Atom.make(0))).toThrow(/registry is disposed/)
+      // The parent owns its own lifetime, and the child's destruction is not it
+      expect(TestBed.inject(ATOM_REGISTRY).get(Atom.make(1))).toBe(1)
+    })
+
+    it("reads the registry and the options only from an injection context", () => {
+      expect(() => injectAtomRegistry()).toThrow()
+      expect(() => injectRegistryOptions()).toThrow()
+    })
+  })
+
+  describe("injectMakeAtom", () => {
+    it("joins the registry of its injector scope", () => {
+      const countAtom = Atom.make(1)
+      const doubledAtom = Atom.make((get) => get(countAtom) * 2)
+
+      const { count, doubled, registry } = TestBed.runInInjectionContext(() => ({
+        count: injectMakeAtom(countAtom),
+        doubled: injectMakeAtom(doubledAtom),
+        registry: injectAtomRegistry()
+      }))
+
+      expect(count.registry).toBe(registry)
+      expect(doubled.registry).toBe(registry)
+
+      const doubledSignal = doubled.value()
+      expect(doubledSignal()).toBe(2)
+
+      count.set(5)
+      expect(doubledSignal()).toBe(10)
+    })
+
+    it("isolates a store that opts into its own registry", () => {
+      const countAtom = Atom.make(1)
+
+      const { isolated, shared } = TestBed.runInInjectionContext(() => ({
+        shared: injectMakeAtom(countAtom),
+        isolated: injectMakeAtom(countAtom, { registry: {} })
+      }))
+
+      expect(shared.registry).not.toBe(isolated.registry)
+
+      isolated.set(9)
+      expect(isolated.value()()).toBe(9)
+      expect(shared.value()()).toBe(1)
+    })
+
+    it("keeps everything it needs from the injector, so methods outlive the context", () => {
+      const countAtom = Atom.make(0)
+
+      const store = TestBed.runInInjectionContext(() => injectMakeAtom(countAtom))
+
+      // Neither call is inside an injection context any more
+      const value = store.value()
+      store.update((n) => n + 3)
+
+      expect(value()).toBe(3)
+    })
+
+    it("returns one signal per store, however often value() is called", () => {
+      const store = TestBed.runInInjectionContext(() => injectMakeAtom(Atom.make(0)))
+
+      expect(store.value()).toBe(store.value())
+    })
+
+    it("derives a projection through the atom graph", () => {
+      const store = TestBed.runInInjectionContext(() => injectMakeAtom(Atom.make(2)))
+
+      const label = store.computed((n) => `n=${n}`)
+      expect(label()).toBe("n=2")
+
+      store.set(4)
+      expect(label()).toBe("n=4")
+    })
+
+    it("re-runs the atom read on refresh", () => {
+      let reads = 0
+      const store = TestBed.runInInjectionContext(() => injectMakeAtom(Atom.make(() => ++reads)))
+
+      const value = store.value()
+      expect(value()).toBe(1)
+
+      store.refresh()
+      expect(value()).toBe(2)
+    })
+
+    it("drops a write on refresh, because the read is what runs again", () => {
+      const store = TestBed.runInInjectionContext(() => injectMakeAtom(Atom.make(0)))
+
+      const value = store.value()
+      store.set(7)
+      expect(value()).toBe(7)
+
+      store.refresh()
+      expect(value()).toBe(0)
+    })
+
+    it("observes writes, and stops when its injector is destroyed", () => {
+      const countAtom = Atom.make(0)
+      const seen: Array<number> = []
+
+      const [store, destroy] = scoped(() => injectMakeAtom(countAtom))
+
+      store.subscribe((n) => seen.push(n))
+
+      store.set(1)
+      store.set(2)
+      expect(seen).toEqual([1, 2])
+
+      /**
+       * The registry outlives the child injector, so the writes below still land
+       * — what has gone is this store's subscription to them.
+       */
+      destroy()
+      store.set(3)
+      expect(seen).toEqual([1, 2])
+      expect(TestBed.inject(ATOM_REGISTRY).get(countAtom)).toBe(3)
+    })
+
+    it("delivers the current value first when asked to", () => {
+      const seen: Array<number> = []
+      const store = TestBed.runInInjectionContext(() => injectMakeAtom(Atom.make(7)))
+
+      store.subscribe((n) => seen.push(n), { immediate: true })
+      expect(seen).toEqual([7])
+
+      store.set(8)
+      expect(seen).toEqual([7, 8])
+    })
+
+    it("computes the atom on mount, with no value signal in play", () => {
+      let reads = 0
+      const store = TestBed.runInInjectionContext(() => injectMakeAtom(Atom.make(() => ++reads)))
+
+      expect(reads).toBe(0)
+
+      store.mount()
+      expect(reads).toBe(1)
+    })
+
+    it("makes refresh eager, where an unmounted atom waits to be read", () => {
+      let mountedReads = 0
+      let lazyReads = 0
+
+      const lazyAtom = Atom.make(() => ++lazyReads)
+
+      const { lazy, mounted } = TestBed.runInInjectionContext(() => ({
+        mounted: injectMakeAtom(Atom.make(() => ++mountedReads)),
+        lazy: injectMakeAtom(lazyAtom)
+      }))
+
+      mounted.mount()
+      mounted.refresh()
+      expect(mountedReads).toBe(2)
+
+      /**
+       * Nothing holds the unmounted atom — `value()` would mount it too, so the
+       * read goes through the registry — and a refresh only marks it stale, with
+       * the recomputation deferred to whoever reads it next.
+       */
+      expect(lazy.registry.get(lazyAtom)).toBe(1)
+      lazy.refresh()
+      expect(lazyReads).toBe(1)
+      expect(lazy.registry.get(lazyAtom)).toBe(2)
+    })
+
+    it("lets computed decide for itself what counts as a change", () => {
+      const store = TestBed.runInInjectionContext(() => injectMakeAtom(Atom.make(2)))
+
+      const parity = store.computed((n) => ({ even: n % 2 === 0 }), {
+        equal: (a, b) => a.even === b.even
+      })
+
+      const first = parity()
+
+      // Same parity: the projection is a new object, but nothing downstream changed
+      store.set(4)
+      expect(parity()).toBe(first)
+
+      store.set(5)
+      expect(parity()).not.toBe(first)
+      expect(parity()).toEqual({ even: false })
+    })
+
+    // Without an `equal`, every recompute is a new object and so a new notification
+    it("defaults computed to reference identity", () => {
+      const store = TestBed.runInInjectionContext(() => injectMakeAtom(Atom.make(2)))
+      const boxed = store.computed((n) => ({ n }))
+
+      const first = boxed()
+      store.set(3)
+      expect(boxed()).not.toBe(first)
+    })
+
+    it("mounts once, however often mount() is called", () => {
+      let reads = 0
+      const store = TestBed.runInInjectionContext(() => injectMakeAtom(Atom.make(() => ++reads)))
+
+      store.mount()
+      store.mount()
+      store.mount()
+
+      expect(reads).toBe(1)
+    })
+
+    it("resolves each async write against its own run", async () => {
+      const slowDouble = Atom.fn((n: number) => Effect.succeed(n * 2).pipe(Effect.delay("10 millis")))
+
+      const store = TestBed.runInInjectionContext(() => injectMakeAtom(slowDouble))
+
+      // Mount the atom the way a component would, so writes go Waiting-over-Success
+      store.value()
+
+      await expect(store.setPromise(1)).resolves.toBe(2)
+      await expect(store.setPromise(5)).resolves.toBe(10)
+    })
+
+    it("keeps the failure in the Exit channel and rejects from setPromise", async () => {
+      const mayFail = Atom.fn((n: number) => n > 0 ? Effect.succeed(n) : Effect.fail("negative" as const))
+
+      const store = TestBed.runInInjectionContext(() => injectMakeAtom(mayFail))
+
+      expect(Exit.isFailure(await store.setExit(-1))).toBe(true)
+      await expect(store.setPromise(-1)).rejects.toBe("negative")
+    })
+
+    it("rejects writes the store type already hides", () => {
+      const readOnly = TestBed.runInInjectionContext(() => injectMakeAtom(Atom.make(() => 1)))
+      const plain = TestBed.runInInjectionContext(() => injectMakeAtom(Atom.make(1)))
+
+      /**
+       * Both are hidden from the public type and only reachable through an `any`
+       * leak — the guards are what turn a silent misbehaviour into a precise
+       * error.
+       */
+      const unsafeReadOnly = readOnly as unknown as { set: (value: number) => void }
+      expect(() => unsafeReadOnly.set(2)).toThrow(/read-only atom/)
+
+      const unsafePlain = plain as unknown as { setExit: (value: number) => Promise<unknown> }
+      expect(() => unsafePlain.setExit(2)).toThrow(/not Result-shaped/)
+    })
+
+    it("applies provideAtomRegistry options to the scope registry", () => {
+      // The registry expects a cancel handle back; the task itself runs eagerly here
+      const scheduleTask = vi.fn((f: () => void) => {
+        f()
+        return () => {}
+      })
+
+      TestBed.configureTestingModule({ providers: [provideAtomRegistry({ scheduleTask })] })
+
+      const store = TestBed.runInInjectionContext(() => injectMakeAtom(Atom.make(0)))
+      const value = store.value()
+
+      store.set(1)
+      expect(value()).toBe(1)
+      expect(scheduleTask).toHaveBeenCalled()
+    })
+  })
+
+  describe("granular atom injects", () => {
+    it("read, derive, write and refresh over the shared registry", () => {
+      const countAtom = Atom.make(1)
+
+      const bound = TestBed.runInInjectionContext(() => ({
+        value: injectAtomValue(countAtom),
+        doubled: injectAtomComputed(countAtom, (n) => n * 2),
+        set: injectAtomSet(countAtom),
+        update: injectAtomUpdate(countAtom),
+        refresh: injectAtomRefresh(countAtom)
+      }))
+
+      expect(bound.value()).toBe(1)
+      expect(bound.doubled()).toBe(2)
+
+      bound.set(4)
+      expect(bound.value()).toBe(4)
+      expect(bound.doubled()).toBe(8)
+
+      bound.update((n) => n + 1)
+      expect(bound.value()).toBe(5)
+
+      // A refresh re-runs the atom's read, which for a state atom re-seeds it
+      bound.refresh()
+      expect(bound.value()).toBe(1)
+      expect(bound.doubled()).toBe(2)
+    })
+
+    it("stops reading the atom once its injector is destroyed", () => {
+      const countAtom = Atom.make(1)
+
+      const [value, destroy] = scoped(() => injectAtomValue(countAtom))
+      const registry = TestBed.inject(ATOM_REGISTRY)
+
+      registry.set(countAtom, 2)
+      expect(value()).toBe(2)
+
+      destroy()
+      registry.set(countAtom, 3)
+      expect(value()).toBe(2)
+    })
+
+    it("subscribes without materialising a signal", () => {
+      const countAtom = Atom.make(0)
+      const seen: Array<number> = []
+
+      const set = TestBed.runInInjectionContext(() => {
+        injectAtomSubscribe(countAtom, (n) => seen.push(n))
+        return injectAtomSet(countAtom)
+      })
+
+      set(1)
+      set(2)
+
+      expect(seen).toEqual([1, 2])
+    })
+
+    it("keeps an atom computing for the lifetime of the injector", () => {
+      let reads = 0
+      const countAtom = Atom.make(() => ++reads)
+
+      const [, destroy] = scoped(() => injectAtomMount(countAtom))
+      const registry = TestBed.inject(ATOM_REGISTRY)
+
+      // Mounting alone computes the atom, with nothing reading it
+      expect(reads).toBe(1)
+
+      // A mounted atom recomputes eagerly; once released, it waits to be read
+      registry.refresh(countAtom)
+      expect(reads).toBe(2)
+
+      destroy()
+      registry.refresh(countAtom)
+      expect(reads).toBe(2)
+    })
+
+    it("reads an AtomRef, and its props, as signals", () => {
+      const userRef = AtomRef.make({ name: "ada", age: 36 })
+      const nameRef = userRef.prop("name")
+
+      const { name, upper, user } = TestBed.runInInjectionContext(() => ({
+        user: injectAtomRef(userRef),
+        name: injectAtomRef(nameRef),
+        upper: injectAtomRef(nameRef.map((n) => n.toUpperCase()))
+      }))
+
+      expect(user()).toEqual({ name: "ada", age: 36 })
+      expect(name()).toBe("ada")
+      expect(upper()).toBe("ADA")
+
+      userRef.update((u) => ({ ...u, name: "grace" }))
+      expect(name()).toBe("grace")
+      expect(upper()).toBe("GRACE")
+    })
+
+    it("stops following a ref once its injector is destroyed", () => {
+      const userRef = AtomRef.make({ name: "ada" })
+
+      const [name, destroy] = scoped(() => injectAtomRef(userRef.prop("name")))
+
+      userRef.update(() => ({ name: "grace" }))
+      expect(name()).toBe("grace")
+
+      // The ref keeps changing; the signal is no longer listening
+      destroy()
+      userRef.update(() => ({ name: "ada" }))
+      expect(userRef.value.name).toBe("ada")
+      expect(name()).toBe("grace")
+    })
+
+    it("awaits a Result-shaped write", async () => {
+      const double = Atom.fn((n: number) => Effect.succeed(n * 2))
+
+      const { setPromise } = TestBed.runInInjectionContext(() => {
+        injectAtomValue(double)
+        return { setPromise: injectAtomSetPromise(double) }
+      })
+
+      await expect(setPromise(3)).resolves.toBe(6)
+    })
+
+    it("keeps the typed failure when the write is awaited as an Exit", async () => {
+      const mayFail = Atom.fn((n: number) => n > 0 ? Effect.succeed(n) : Effect.fail("negative" as const))
+
+      const { setExit } = TestBed.runInInjectionContext(() => {
+        injectAtomValue(mayFail)
+        return { setExit: injectAtomSetExit(mayFail) }
+      })
+
+      expect(await setExit(3)).toStrictEqual(Exit.succeed(3))
+
+      const failed = await setExit(-1)
+      expect(Exit.isFailure(failed)).toBe(true)
+      expect(Exit.isFailure(failed) && Cause.findErrorOption(failed.cause)).toEqual(Option.some("negative"))
+    })
+
+    it("hands back the DestroyRef of the current injector", () => {
+      const seen: Array<string> = []
+
+      const [, destroy] = scoped(() => injectDestroyRef().onDestroy(() => seen.push("destroyed")))
+
+      expect(seen).toEqual([])
+      destroy()
+      expect(seen).toEqual(["destroyed"])
+    })
+  })
+
+  describe("atomMatchResult", () => {
+    const failing = Atom.fn((n: number) => n > 0 ? Effect.succeed(n * 2) : Effect.fail("negative" as const))
+
+    it("tags each Result state and defaults to a pretty-printed cause", async () => {
+      const { store, view } = TestBed.runInInjectionContext(() => {
+        const store = injectMakeAtom(failing)
+        return { store, view: atomMatchResult(store) }
+      })
+
+      expect(view()).toEqual({ status: "initial", waiting: false, value: null, error: null })
+
+      await store.setPromise(3)
+      expect(view()).toMatchObject({ status: "success", value: 6, error: null })
+
+      await store.setExit(-1)
+      const failed = view()
+      expect(failed.status).toBe("failure")
+      expect(failed.value).toBeNull()
+      expect(typeof failed.error).toBe("string")
+      expect(failed.error).toContain("negative")
+    })
+
+    it("routes each branch through its transform", async () => {
+      const { store, view } = TestBed.runInInjectionContext(() => {
+        const store = injectMakeAtom(failing)
+        return {
+          store,
+          view: atomMatchResult(store, {
+            transformSuccess: (value) => `#${value}`,
+            transformFailure: (cause) => Cause.findErrorOption(cause)
+          })
+        }
+      })
+
+      await store.setPromise(4)
+      expect(view()).toMatchObject({ status: "success", value: "#8" })
+
+      await store.setExit(-1)
+      expect(view().error).toEqual(Option.some("negative"))
+    })
+
+    it("is reachable from the store itself, on read-only Result atoms too", async () => {
+      const readOnlyResult = Atom.make(Effect.succeed(7))
+
+      const { fromStore, writable } = TestBed.runInInjectionContext(() => ({
+        fromStore: injectMakeAtom(readOnlyResult).matchResult(),
+        writable: injectMakeAtom(failing)
+      }))
+
+      expect(fromStore()).toMatchObject({ status: "success", value: 7 })
+
+      const view = writable.matchResult({ transformSuccess: (value) => `#${value}` })
+      await writable.setPromise(3)
+      expect(view()).toMatchObject({ status: "success", value: "#6" })
+    })
+
+    it("rejects a store over a non-Result atom when the view is bound", () => {
+      const plain = TestBed.runInInjectionContext(() => injectMakeAtom(Atom.make(1)))
+
+      // Both routes in: the free function, and the member the store type hides
+      expect(() => atomMatchResult(plain as unknown as ReadableAtomStore<AsyncResult.AsyncResult<number, never>>))
+        .toThrow(/not Result-shaped/)
+
+      expect(() => (plain as unknown as ResultAtomStore<AsyncResult.AsyncResult<number, never>>).matchResult())
+        .toThrow(/not Result-shaped/)
+    })
+
+    /**
+     * A writable atom holding a `Result` directly, so a write lands in one step
+     * with no `waiting` round-trip to churn the view in between. Driving these
+     * through `Atom.fn` would emit an intermediate waiting view and make the
+     * identity assertions below untestable.
+     */
+    const resultState = () => Atom.make(AsyncResult.success(1) as AsyncResult.AsyncResult<number, never>)
+
+    const store_equalNotAFunction = () =>
+      atomMatchResult(injectMakeAtom(resultState()), {
+        equal: "nope" as unknown as (a: unknown, b: unknown) => boolean
+      } as never)
+
+    it("keeps the view object when a transform collapses two distinct values", () => {
+      const { store, view } = TestBed.runInInjectionContext(() => {
+        const store = injectMakeAtom(resultState())
+        return { store, view: store.matchResult({ transformSuccess: (value) => value > 0 }) }
+      })
+
+      const first = view()
+      expect(first).toMatchObject({ status: "success", value: true })
+
+      // A different Result, but the same rendered view — no new object, no notification
+      store.set(AsyncResult.success(2))
+      expect(view()).toBe(first)
+    })
+
+    it("still emits when the collapsed view actually changes", () => {
+      const { store, view } = TestBed.runInInjectionContext(() => {
+        const store = injectMakeAtom(resultState())
+        return { store, view: store.matchResult({ transformSuccess: (value) => value > 0 }) }
+      })
+
+      const first = view()
+
+      store.set(AsyncResult.success(-1))
+      expect(view()).not.toBe(first)
+      expect(view()).toMatchObject({ status: "success", value: false })
+
+      // ...and a change of branch is a change of view, whatever the payload
+      const second = view()
+      store.set(AsyncResult.initial())
+      expect(view()).not.toBe(second)
+      expect(view()).toMatchObject({ status: "initial", value: null })
+    })
+
+    /**
+     * The default comparator is `Equal.equals`, so a transform returning a
+     * trait-bearing value dedupes without the caller supplying one.
+     *
+     * It has to be a *transform* to isolate the comparator: with no transform the
+     * view's value is the payload itself, so an `Equal`-equal payload makes the
+     * whole `Result` equal and the registry drops it upstream — `Object.is` here
+     * would look just as good while proving nothing.
+     */
+    it("dedupes a projection that carries its own equality", () => {
+      const { store, view } = TestBed.runInInjectionContext(() => {
+        const store = injectMakeAtom(resultState())
+        return { store, view: store.matchResult({ transformSuccess: (n) => Option.some(n % 2) }) }
+      })
+
+      const first = view()
+      expect(first).toMatchObject({ status: "success", value: Option.some(1) })
+
+      // A different Result, a different Option instance, the same structure
+      store.set(AsyncResult.success(3))
+      expect(view()).toBe(first)
+
+      store.set(AsyncResult.success(4))
+      expect(view()).not.toBe(first)
+      expect(view()).toMatchObject({ value: Option.some(0) })
+    })
+
+    /**
+     * The default comparator is structural, not referential, so a fresh-but-equal
+     * payload already dedupes without any help. What a caller comparator adds is
+     * the freedom to ignore part of the payload — here a timestamp that changes on
+     * every refetch while the rows themselves do not.
+     */
+    it("lets the caller decide equality, for payloads that differ where it does not matter", () => {
+      type Row = { readonly id: number; readonly fetchedAt: number }
+
+      const listState = Atom.make(
+        AsyncResult.success([{ id: 1, fetchedAt: 0 }]) as AsyncResult.AsyncResult<ReadonlyArray<Row>, never>
+      )
+
+      // A stand-in for the case this exists for: a refetch returning the same rows
+      const sameIds = (a: { readonly value: unknown }, b: { readonly value: unknown }): boolean => {
+        // Hoisted: narrowing a property access does not survive into the callback
+        const left = a.value
+        const right = b.value
+
+        if (!Array.isArray(left) || !Array.isArray(right)) return false
+
+        return left.length === right.length && left.every((row, index) => row.id === right[index].id)
+      }
+
+      const { byDefault, byIds, store } = TestBed.runInInjectionContext(() => {
+        const store = injectMakeAtom(listState)
+        return { store, byDefault: store.matchResult(), byIds: store.matchResult({ equal: sameIds }) }
+      })
+
+      const defaultFirst = byDefault()
+      const idsFirst = byIds()
+
+      // Same rows, a new timestamp — the default sees a change, the comparator does not
+      store.set(AsyncResult.success([{ id: 1, fetchedAt: 1 }]))
+      expect(byDefault()).not.toBe(defaultFirst)
+      expect(byIds()).toBe(idsFirst)
+
+      // A real change still lands on both
+      store.set(AsyncResult.success([{ id: 1, fetchedAt: 1 }, { id: 2, fetchedAt: 1 }]))
+      expect(byIds()).not.toBe(idsFirst)
+      expect(byIds()).toMatchObject({
+        status: "success",
+        value: [{ id: 1 }, { id: 2 }]
+      })
+    })
+
+    it("takes the same comparator through the free function", () => {
+      const view = TestBed.runInInjectionContext(() =>
+        atomMatchResult(injectMakeAtom(resultState()), {
+          transformSuccess: (value) => ({ boxed: value }),
+          equal: (a, b) => a.value?.boxed === b.value?.boxed
+        })
+      )
+
+      expect(view()).toMatchObject({ status: "success", value: { boxed: 1 } })
+    })
+
+    it("rejects a non-function comparator when the view is bound", () => {
+      expect(() =>
+        TestBed.runInInjectionContext(() =>
+          // Only reachable from an untyped caller, like the transforms
+          store_equalNotAFunction()
+        )
+      ).toThrow(/equal must be a function/)
+    })
+
+    it("shares one view between bare calls, and builds a fresh one per transform", () => {
+      const store = TestBed.runInInjectionContext(() => injectMakeAtom(resultState()))
+
+      expect(store.matchResult()).toBe(store.matchResult())
+
+      /**
+       * Two callers passing different closures want different views, so there is
+       * no sound key to memoise on — each call subscribes for itself.
+       */
+      const transform = { transformSuccess: (value: number) => value }
+      expect(store.matchResult(transform)).not.toBe(store.matchResult(transform))
+    })
+
+    it("rejects a non-function transform when the view is bound, not on emission", () => {
+      expect(() =>
+        TestBed.runInInjectionContext(() =>
+          atomMatchResult(injectMakeAtom(failing), {
+            // Only reachable from an untyped caller
+            transformSuccess: "nope" as unknown as (value: number) => string
+          })
+        )
+      ).toThrow(/transformSuccess must be a function/)
+    })
+  })
+
+  describe("type contract", () => {
+    it("is enforced by the compiler, not the runner", () => {
+      expect([
+        _readOnlyContract,
+        _registryViewContract,
+        _writableValueContract,
+        _asyncContract,
+        _errorChannelContract,
+        _readWriteContract,
+        _computedContract,
+        _helperContract,
+        _optionsContract,
+        _granularContract,
+        _matchResultContract,
+        _storeMatchResultContract,
+        _channelAliasContract,
+        _statusConstantContract,
+        _registryOptionsContract,
+        _voidHelperContract,
+        _computedEqualContract
+      ]).toHaveLength(17)
+    })
+  })
+})

--- a/packages/atom/angular/tsconfig.json
+++ b/packages/atom/angular/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src"],
+  "references": [
+    { "path": "../../effect" }
+  ]
+}

--- a/packages/atom/angular/vitest.setup.ts
+++ b/packages/atom/angular/vitest.setup.ts
@@ -1,0 +1,11 @@
+// oxlint-disable-next-line no-unassigned-import
+import "@angular/compiler"
+import { TestBed } from "@angular/core/testing"
+import { BrowserTestingModule, platformBrowserTesting } from "@angular/platform-browser/testing"
+import { afterEach } from "vitest"
+
+TestBed.initTestEnvironment(BrowserTestingModule, platformBrowserTesting())
+
+afterEach(() => {
+  TestBed.resetTestingModule()
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ importers:
         version: 26.4.0
       '@vitest/browser':
         specifier: ^4.1.11
-        version: 4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)
+        version: 4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)
       '@vitest/coverage-v8':
         specifier: ^4.1.11
         version: 4.1.11(@vitest/browser@4.1.11)(vitest@4.1.11)
@@ -127,7 +127,7 @@ importers:
         version: 4.63.1
       rollup-plugin-bundle-stats:
         specifier: ^4.22.3
-        version: 4.22.3(core-js@3.47.0)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.22.3(core-js@3.47.0)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
       rollup-plugin-esbuild:
         specifier: ^6.2.1
         version: 6.2.1(esbuild@0.28.2)(rollup@4.63.1)(supports-color@10.2.2)
@@ -145,10 +145,10 @@ importers:
         version: 7.0.2
       vite:
         specifier: ^8.2.2
-        version: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)
+        version: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
       vitest-websocket-mock:
         specifier: ^0.7.0
         version: 0.7.0(vitest@4.1.11)
@@ -170,6 +170,9 @@ importers:
       '@effect/ai-openrouter':
         specifier: workspace:*
         version: link:../packages/ai/openrouter
+      '@effect/atom-angular':
+        specifier: workspace:*
+        version: link:../packages/atom/angular
       '@effect/atom-react':
         specifier: workspace:*
         version: link:../packages/atom/react
@@ -261,6 +264,30 @@ importers:
       effect:
         specifier: workspace:^
         version: link:../../effect
+
+  packages/atom/angular:
+    devDependencies:
+      '@angular/common':
+        specifier: ^22.1.4
+        version: 22.1.4(@angular/core@22.1.4(@angular/compiler@22.1.4)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
+      '@angular/compiler':
+        specifier: ^22.1.4
+        version: 22.1.4
+      '@angular/core':
+        specifier: ^22.1.4
+        version: 22.1.4(@angular/compiler@22.1.4)(rxjs@7.8.2)(zone.js@0.16.2)
+      '@angular/platform-browser':
+        specifier: ^22.1.4
+        version: 22.1.4(@angular/common@22.1.4(@angular/core@22.1.4(@angular/compiler@22.1.4)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.1.4(@angular/compiler@22.1.4)(rxjs@7.8.2)(zone.js@0.16.2))
+      effect:
+        specifier: workspace:^
+        version: link:../../effect
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1
+      rxjs:
+        specifier: ^7.8.2
+        version: 7.8.2
 
   packages/atom/react:
     devDependencies:
@@ -727,7 +754,7 @@ importers:
         version: typescript@6.0.3
       vitest:
         specifier: 4.1.11
-        version: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/tools/bundle:
     dependencies:
@@ -825,7 +852,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/tools/doctest:
     dependencies:
@@ -844,10 +871,10 @@ importers:
         version: link:../../effect
       vite:
         specifier: ^8.2.2
-        version: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)
+        version: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/tools/jsdocs:
     dependencies:
@@ -869,7 +896,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/tools/openapi-generator:
     dependencies:
@@ -910,7 +937,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/tools/utils:
     dependencies:
@@ -938,7 +965,7 @@ importers:
         version: link:../effect
       vitest:
         specifier: 4.1.11
-        version: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
 
   scratchpad:
     dependencies:
@@ -1049,6 +1076,41 @@ packages:
 
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@angular/common@22.1.4':
+    resolution: {integrity: sha512-UtWCloA/d0I5twV9Lu/Fcc7T6uQb40f/k0Hj5HLohIsiLTyvXVxWINBfa7LWWLtcq/0UOIY/yCs9Zq9Sj4dWqA==}
+    engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      '@angular/core': 22.1.4
+      rxjs: ^6.5.3 || ^7.4.0
+
+  '@angular/compiler@22.1.4':
+    resolution: {integrity: sha512-o+W0shjR5KmPPWchFmqN9bLINYAy14zIW//g9T5WqKDMOqjt4IbeY6AKOoE1db/dXffprLEH9nyPOmi19iKNxg==}
+    engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0}
+
+  '@angular/core@22.1.4':
+    resolution: {integrity: sha512-0dW+lw8nHo6RGBUOXtjs02vjHIPJ8rEbw4fd0NH3Dii4p+gIB4ZaTw+o7Se3Nf4m1oZ8+2qAYmWVHXlfhKcCDg==}
+    engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      '@angular/compiler': 22.1.4
+      rxjs: ^6.5.3 || ^7.4.0
+      zone.js: ~0.15.0 || ~0.16.0
+    peerDependenciesMeta:
+      '@angular/compiler':
+        optional: true
+      zone.js:
+        optional: true
+
+  '@angular/platform-browser@22.1.4':
+    resolution: {integrity: sha512-zhEWnRShG6GjnEvCVROD68XfnrV6+HJ9bPjwZx4LsAz7spX823Nhiml8Uqpvijsa1w7UdWLU7nK/magr9IEMOQ==}
+    engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      '@angular/animations': 22.1.4
+      '@angular/common': 22.1.4
+      '@angular/core': 22.1.4
+    peerDependenciesMeta:
+      '@angular/animations':
+        optional: true
 
   '@asamuzakjp/css-color@6.0.5':
     resolution: {integrity: sha512-mbhpPMmnw/kwW19aRNmSUl1QzLbdGo1SCuE49BT98MNwqF6zaHb3o2owssFc/PEO/4t2UjqtCNwocuDtJornzA==}
@@ -2602,6 +2664,88 @@ packages:
   '@oxlint/plugins@1.80.0':
     resolution: {integrity: sha512-QRgH1XqQEYNHa4f1vvPQ5fAdNdncHGIUG1ZWLlGIZHky3qwCEeAKYitZNbZMtaXtAQAAFFTOwqUfzESvimqZNA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@parcel/watcher-android-arm64@2.6.0':
+    resolution: {integrity: sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@parcel/watcher-darwin-arm64@2.6.0':
+    resolution: {integrity: sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@parcel/watcher-darwin-x64@2.6.0':
+    resolution: {integrity: sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@parcel/watcher-freebsd-x64@2.6.0':
+    resolution: {integrity: sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@parcel/watcher-linux-arm-glibc@2.6.0':
+    resolution: {integrity: sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm-musl@2.6.0':
+    resolution: {integrity: sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-arm64-glibc@2.6.0':
+    resolution: {integrity: sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm64-musl@2.6.0':
+    resolution: {integrity: sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-x64-glibc@2.6.0':
+    resolution: {integrity: sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-x64-musl@2.6.0':
+    resolution: {integrity: sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-win32-arm64@2.6.0':
+    resolution: {integrity: sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@parcel/watcher-win32-x64@2.6.0':
+    resolution: {integrity: sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@parcel/watcher@2.6.0':
+    resolution: {integrity: sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==}
+    engines: {node: '>= 10.0.0'}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -4511,6 +4655,9 @@ packages:
   immer@11.1.18:
     resolution: {integrity: sha512-EQyQtLiYW029lyoczMl/Hh4Xu7cDecSc58JRYpHyL4tIAu3eqd1yJzQX04d2BZHDkzFFvm6qJEJWOtfDSWAXbQ==}
 
+  immutable@5.1.9:
+    resolution: {integrity: sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==}
+
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
@@ -4564,9 +4711,17 @@ packages:
     resolution: {integrity: sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==}
     engines: {node: '>=0.10.0'}
 
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
 
   is-in-ssh@1.0.0:
     resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
@@ -4702,6 +4857,10 @@ packages:
   jest-worker@29.7.0:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
 
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
@@ -5216,6 +5375,9 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-addon-api@8.9.2:
     resolution: {integrity: sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==}
     engines: {node: ^18 || ^20 || >= 21}
@@ -5470,6 +5632,10 @@ packages:
 
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.28:
+    resolution: {integrity: sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres@3.4.9:
@@ -5778,6 +5944,9 @@ packages:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -5790,6 +5959,11 @@ packages:
   sass-lookup@6.1.2:
     resolution: {integrity: sha512-GjmndmKQBtlPil79RK72L7yc5kDXZPCQeH97bP8R8DcxtXQJO6vECExb3WP/m6+cxaV9h4ZxrSRvCkPG2v/VSw==}
     engines: {node: '>=18'}
+    hasBin: true
+
+  sass@1.101.0:
+    resolution: {integrity: sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==}
+    engines: {node: '>=20.19.0'}
     hasBin: true
 
   saxes@6.0.0:
@@ -6628,9 +6802,36 @@ packages:
   zod@4.5.4:
     resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
 
+  zone.js@0.16.2:
+    resolution: {integrity: sha512-Eky7p2Z1Ig3NnbfodSPoARCjKBSTFMnE/ACsP1L/XJEfY4SdOFce19BsUCWVwL6K5ABZFy5J3bjcMWffX+YM3Q==}
+
 snapshots:
 
   '@adobe/css-tools@4.5.0': {}
+
+  '@angular/common@22.1.4(@angular/core@22.1.4(@angular/compiler@22.1.4)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)':
+    dependencies:
+      '@angular/core': 22.1.4(@angular/compiler@22.1.4)(rxjs@7.8.2)(zone.js@0.16.2)
+      rxjs: 7.8.2
+      tslib: 2.8.1
+
+  '@angular/compiler@22.1.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@angular/core@22.1.4(@angular/compiler@22.1.4)(rxjs@7.8.2)(zone.js@0.16.2)':
+    dependencies:
+      rxjs: 7.8.2
+      tslib: 2.8.1
+    optionalDependencies:
+      '@angular/compiler': 22.1.4
+      zone.js: 0.16.2
+
+  '@angular/platform-browser@22.1.4(@angular/common@22.1.4(@angular/core@22.1.4(@angular/compiler@22.1.4)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.1.4(@angular/compiler@22.1.4)(rxjs@7.8.2)(zone.js@0.16.2))':
+    dependencies:
+      '@angular/common': 22.1.4(@angular/core@22.1.4(@angular/compiler@22.1.4)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
+      '@angular/core': 22.1.4(@angular/compiler@22.1.4)(rxjs@7.8.2)(zone.js@0.16.2)
+      tslib: 2.8.1
 
   '@asamuzakjp/css-color@6.0.5':
     dependencies:
@@ -8177,6 +8378,63 @@ snapshots:
 
   '@oxlint/plugins@1.80.0': {}
 
+  '@parcel/watcher-android-arm64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-darwin-x64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-arm-glibc@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-arm-musl@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-glibc@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-x64-glibc@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.6.0':
+    optional: true
+
+  '@parcel/watcher-win32-arm64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-win32-x64@2.6.0':
+    optional: true
+
+  '@parcel/watcher@2.6.0':
+    dependencies:
+      detect-libc: 2.1.2
+      is-glob: 4.0.3
+      node-addon-api: 7.1.1
+      picomatch: 4.0.7
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.6.0
+      '@parcel/watcher-darwin-arm64': 2.6.0
+      '@parcel/watcher-darwin-x64': 2.6.0
+      '@parcel/watcher-freebsd-x64': 2.6.0
+      '@parcel/watcher-linux-arm-glibc': 2.6.0
+      '@parcel/watcher-linux-arm-musl': 2.6.0
+      '@parcel/watcher-linux-arm64-glibc': 2.6.0
+      '@parcel/watcher-linux-arm64-musl': 2.6.0
+      '@parcel/watcher-linux-x64-glibc': 2.6.0
+      '@parcel/watcher-linux-x64-musl': 2.6.0
+      '@parcel/watcher-win32-arm64': 2.6.0
+      '@parcel/watcher-win32-x64': 2.6.0
+    optional: true
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -8582,7 +8840,7 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
     optionalDependencies:
-      vitest: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
 
   '@testing-library/react@16.3.3(@testing-library/dom@10.4.1)(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -8854,16 +9112,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)':
+  '@vitest/browser@4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
       '@vitest/utils': 4.1.11
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -8883,9 +9141,9 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)
+      '@vitest/browser': 4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)
 
   '@vitest/expect@4.1.11':
     dependencies:
@@ -8896,13 +9154,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.11':
     dependencies:
@@ -8931,7 +9189,7 @@ snapshots:
   '@vitest/web-worker@4.1.11(vitest@4.1.11)':
     dependencies:
       obug: 2.1.4
-      vitest: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
 
   '@vue/compiler-core@3.5.42':
     dependencies:
@@ -10029,6 +10287,9 @@ snapshots:
 
   immer@11.1.18: {}
 
+  immutable@5.1.9:
+    optional: true
+
   import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
@@ -10066,7 +10327,15 @@ snapshots:
     dependencies:
       is-plain-object: 2.0.4
 
+  is-extglob@2.1.1:
+    optional: true
+
   is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+    optional: true
 
   is-in-ssh@1.0.0: {}
 
@@ -10222,6 +10491,9 @@ snapshots:
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
+
+  jiti@2.7.0:
+    optional: true
 
   jju@1.4.0: {}
 
@@ -10852,6 +11124,9 @@ snapshots:
 
   neo-async@2.6.2: {}
 
+  node-addon-api@7.1.1:
+    optional: true
+
   node-addon-api@8.9.2: {}
 
   node-fetch-h2@2.3.0:
@@ -11102,6 +11377,12 @@ snapshots:
       quote-unquote: 1.0.0
 
   postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.28:
     dependencies:
       nanoid: 3.3.18
       picocolors: 1.1.1
@@ -11420,16 +11701,16 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.6
       '@rolldown/binding-win32-x64-msvc': 1.2.6
 
-  rollup-plugin-bundle-stats@4.22.3(core-js@3.47.0)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)):
+  rollup-plugin-bundle-stats@4.22.3(core-js@3.47.0)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       '@bundle-stats/cli-utils': 4.22.3(core-js@3.47.0)
-      rollup-plugin-stats: 2.1.3(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
-      rollup-plugin-webpack-stats: 3.1.3(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+      rollup-plugin-stats: 2.1.3(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+      rollup-plugin-webpack-stats: 3.1.3(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
       tslib: 2.8.1
     optionalDependencies:
       rolldown: 1.2.6
       rollup: 4.63.1
-      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)
     transitivePeerDependencies:
       - core-js
 
@@ -11444,11 +11725,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rollup-plugin-stats@2.1.3(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)):
+  rollup-plugin-stats@2.1.3(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)):
     optionalDependencies:
       rolldown: 1.2.6
       rollup: 4.63.1
-      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)
 
   rollup-plugin-visualizer@7.1.1(rolldown@1.2.6)(rollup@4.63.1):
     dependencies:
@@ -11460,13 +11741,13 @@ snapshots:
       rolldown: 1.2.6
       rollup: 4.63.1
 
-  rollup-plugin-webpack-stats@3.1.3(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)):
+  rollup-plugin-webpack-stats@3.1.3(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
-      rollup-plugin-stats: 2.1.3(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+      rollup-plugin-stats: 2.1.3(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
     optionalDependencies:
       rolldown: 1.2.6
       rollup: 4.63.1
-      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)
 
   rollup@4.63.1:
     dependencies:
@@ -11502,6 +11783,10 @@ snapshots:
 
   run-applescript@7.1.0: {}
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
@@ -11512,6 +11797,15 @@ snapshots:
     dependencies:
       commander: 12.1.0
       enhanced-resolve: 5.24.5
+
+  sass@1.101.0:
+    dependencies:
+      chokidar: 5.0.0
+      immutable: 5.1.9
+      source-map-js: 1.2.1
+    optionalDependencies:
+      '@parcel/watcher': 2.6.0
+    optional: true
 
   saxes@6.0.0:
     dependencies:
@@ -12124,17 +12418,19 @@ snapshots:
     optionalDependencies:
       typescript: 7.0.2
 
-  vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0):
+  vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.7
-      postcss: 8.5.26
+      postcss: 8.5.28
       rolldown: 1.2.6
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 26.4.0
       esbuild: 0.28.2
       fsevents: 2.3.3
+      jiti: 2.7.0
+      sass: 1.101.0
       terser: 5.51.2
       tsx: 4.23.12
       yaml: 2.9.0
@@ -12142,12 +12438,12 @@ snapshots:
   vitest-websocket-mock@0.7.0(vitest@4.1.11):
     dependencies:
       mock-socket: 9.3.1
-      vitest: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
 
-  vitest@4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)):
+  vitest@4.1.11(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(happy-dom@20.12.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.11
       '@vitest/runner': 4.1.11
       '@vitest/snapshot': 4.1.11
@@ -12164,7 +12460,7 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.101.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@edge-runtime/vm': 5.0.0
@@ -12356,3 +12652,6 @@ snapshots:
       readable-stream: 4.7.0
 
   zod@4.5.4: {}
+
+  zone.js@0.16.2:
+    optional: true

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -9,6 +9,7 @@
     { "path": "packages/ai/openai-compat" },
     { "path": "packages/ai/openai" },
     { "path": "packages/ai/openrouter" },
+    { "path": "packages/atom/angular" },
     { "path": "packages/atom/react" },
     { "path": "packages/atom/vue" },
     { "path": "packages/atom/solid" },

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -35,6 +35,8 @@
       "@effect/ai-openai/*": ["./packages/ai/openai/src/*.ts"],
       "@effect/ai-openrouter": ["./packages/ai/openrouter/src/index.ts"],
       "@effect/ai-openrouter/*": ["./packages/ai/openrouter/src/*.ts"],
+      "@effect/atom-angular": ["./packages/atom/angular/src/index.ts"],
+      "@effect/atom-angular/*": ["./packages/atom/angular/src/*.ts"],
       "@effect/atom-react": ["./packages/atom/react/src/index.ts"],
       "@effect/atom-react/*": ["./packages/atom/react/src/*.ts"],
       "@effect/atom-vue": ["./packages/atom/vue/src/index.ts"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -113,6 +113,12 @@ export default defineConfig({
       ...project("@effect/ai-openai", "packages/ai/openai"),
       ...project("@effect/ai-openai-compat", "packages/ai/openai-compat"),
       ...project("@effect/ai-openrouter", "packages/ai/openrouter"),
+      ...project("@effect/atom-angular", "packages/atom/angular", true, {
+        test: {
+          environment: "jsdom",
+          setupFiles: [path.join(import.meta.dirname, "packages/atom/angular/vitest.setup.ts")]
+        }
+      }),
       ...project("@effect/atom-react", "packages/atom/react", true, {
         test: {
           environment: "jsdom",


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

**Suggested Labels:** `4.0`

Adds `@effect/atom-angular`, Angular bindings for the Effect Atom modules. It joins
`@effect/atom-react`, `@effect/atom-solid`, and `@effect/atom-vue` under `packages/atom`.

The package shares one `AtomRegistry` through Angular's dependency injection and surfaces atoms as
Angular signals, so a component reads atom state the same way it reads any other signal and writes
it through functions that resolve the registry at injection time.

```ts
import { Component } from "@angular/core"
import { injectMakeAtom, provideAtomRegistry } from "@effect/atom-angular"

@Component({
  selector: "app-users",
  providers: [provideAtomRegistry()],
  template: `
    @switch (result().status) {
      @case ("initial") { <p>Loading…</p> }
      @case ("success") { <ul>@for (u of result().value; track u.id) { <li>{{ u.name }}</li> }</ul> }
      @case ("failure") { <p>{{ result().error }}</p> }
    }
    <button (click)="handleRefresh()">Reload</button>
  `
})
export class UsersComponent {
  readonly #store = injectMakeAtom(usersAtom)
  readonly result = this.#store.matchResult()

  handleRefresh() {
    this.#store.refresh()
  }
}
```

### API surface

`src/Providers.ts` — dependency-injection wiring:

- `provideAtomRegistry(options?)` — the provider array an application or route supplies
- `ATOM_REGISTRY` / `injectAtomRegistry()` — the registry token and its accessor
- `REGISTRY_OPTIONS` / `injectRegistryOptions()` — configures the registry a scope creates

`src/Injects.ts` — signal-based injection functions:

- Read: `injectAtomValue`, `injectAtomRef`, `injectAtomComputed`, `injectAtomMount`,
  `injectAtomSubscribe`
- Write: `injectAtomSet`, `injectAtomUpdate`, `injectAtomSetExit`, `injectAtomSetPromise`,
  `injectAtomRefresh`
- Composition: `injectMakeAtom` bundles the above into a single store whose surface is selected from
  the atom's type — reads for every atom, writes for writable ones, `matchResult` for
  `Result`-shaped ones; `atomMatchResult` flattens a `Result`-shaped store into one template-ready
  view tagged by `ATOM_RESULT_STATUS`
- Lifecycle: `injectDestroyRef`

`src/Constants.ts` — `ATOM_RESULT_STATUS`, the `initial` / `success` / `failure` tag set.

`src/Types.ts` — the type-level surface: option bags, the helpers that read an atom's value/write/
error types back out of its type, `AtomResultView`, and the layered store interfaces
(`ReadableAtomStore`, `WritableAtomStore`, `ResultAtomStore`, `AsyncAtomStore`).

Each branch of the flattened view also carries `waiting`, which is orthogonal to the tag: a success
branch can be waiting on the next run. Success and failure payloads default to the atom's own
success type and to a `Cause.pretty` string; `transformSuccess` / `transformFailure` fix them by
inference, and `transformFailure` receives the whole `Cause`, not the bare error.

### Design notes

**DI instead of a provider component.** React and Solid ship a `RegistryProvider` component.
Angular's equivalent is a provider array, so this package exposes `provideAtomRegistry()` plus
injection tokens rather than a component. `ATOM_REGISTRY` is `providedIn: "root"`, so a registry
exists without any explicit wiring; calling `provideAtomRegistry()` at application or route level
creates a scoped one.

**`inject*` instead of `use*`.** The siblings name their entry points `useAtom*`. Angular's
convention for functions that must run inside an injection context is the `inject` prefix, and
following it makes the constraint legible at the call site — so the equivalents here are
`injectAtomValue`, `injectAtomSet`, and so on.

**Injection-context contract.** Every `inject*` function must be called from an injection context.
Subscriptions and keepalives are created synchronously and released when the surrounding injector is
destroyed. What those functions _return_ — setters, refresh callbacks, and the store's methods —
captures the registry at injection time and stays callable outside an injection context, so a store
can be handed to a callback or a service method without losing its binding.

**Signal identity.** `value()` builds its signal on first call and shares it from then on, so
repeated calls share one subscription. `computed()` builds a new derived atom and subscription per
call and is meant to be stored on the component, not called from a template expression.

**Divergence from the sibling packages, stated up front.** The API is not a one-to-one port, and
I would rather surface that here than have a reviewer discover it:

- No equivalent of React's `useAtom` read+write tuple. The closest is `injectMakeAtom`, which
  returns a store object instead of a tuple — a tuple destructure reads poorly in an Angular
  component field, and the store lets the type system add or withhold `set` / `matchResult` based on
  the atom.
- No equivalent of `useAtomInitialValues`, `useAtomRefProp`, `useAtomRefPropValue`,
  `useAtomSuspense`, `ScopedAtom`, or `HydrationBoundary` (React), or `useAtomResource` (Solid).
  Suspense and hydration have no Angular counterpart; the others were left out until there is a
  concrete use for them rather than ported speculatively.
- Adds `injectAtomComputed`, `injectAtomUpdate`, `injectAtomSetExit`, `injectAtomSetPromise`,
  `atomMatchResult`, and `injectDestroyRef`, which have no sibling equivalent.

**Dedicated `Types.ts` / `Constants.ts`.** The siblings colocate types with implementations. The
store interfaces here are layered so that a store exposes only what its atom supports, and that
conditional surface is large enough that keeping it beside the injection functions made both harder
to read. `ATOM_RESULT_STATUS` is split out for the same reason: it is the single source of truth for
the tag set, with `AtomResultStatus` derived from it and `AtomResultView` discriminated by it.

### Testing

`packages/atom/angular/test/index.test.ts` — (53) cases covering the registry providers, each
injection function, the store surfaces, and the `Result` view. `vitest.setup.ts` bootstraps `TestBed`
with `platformBrowserTesting` and resets it per test; the vitest project runs under `jsdom`, matching
`atom-react` and `atom-solid`. Type-level expectations are asserted inline with `expectTypeOf`, as in
the sibling bindings.

Validated with `pnpm lint-fix`, `pnpm test --run packages/atom/angular/test/index.test.ts`,
`pnpm check`, `pnpm circular`, and `pnpm ai-docgen` (tree clean), plus a build and dry `pnpm pack` to
confirm the packed surface resolves `publishConfig.exports` to `dist` and keeps the internal and
legacy paths blocked. `pnpm jsdocs --check` reports no findings for this package.

### Monorepo registration

Following `.agents/skills/package-development/registration.md`:

- `.changeset/config.json` — added to the `fixed` version group alongside the other atom packages
- `tsconfig.packages.json` — project reference
- `tsconfig.tests.json` — `@effect/atom-angular` and `@effect/atom-angular/*` path mappings
- `vitest.config.ts` — project entry with the `jsdom` environment and setup file
- `README.md` — catalog table row
- `ai-docs/package.json` — workspace dependency, matching the other three atom packages
- `exports` / `publishConfig.exports` / `files` mirror the sibling packages
- Covered without change: `pnpm-workspace.yaml` (`packages/atom/*` glob), `snapshot.yml`
  (`./packages/atom/*` glob), `jsdocs.config.json` and lint configs (glob-based), `deno.json`
  (`packages/atom` is excluded), `tstyche.json` (no `typetest` directory)

### Changeset

`.changeset/angular-atom-bindings.md`, `patch` for `@effect/atom-angular`. The repository is in
`rc` pre-mode, where new surface is recorded as `patch`.

### Peer range

`@angular/core: ">=20.0.0 <23.0.0"`, developed and tested against 22.1.x. Please confirm that floor
matches the Angular support window you want to commit to.

### Follow-up

A sample application demonstrating the bindings is ready and will follow in a separate PR once this
lands, so the toolchain and lockfile cost of an Angular CLI app can be reviewed on its own.

Sample Demo: `https://github.com/Effect-TS/effect/commit/55fa911c40f9e513f8421e72fa76ca5f1a5d0709`

