### PR TITLE
fix(cli): preserve prompt frames while rendering

### DIFF
--- a/.changeset/prompt-buffer-render.md
+++ b/.changeset/prompt-buffer-render.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Keep the previous prompt frame visible until the next frame or submission is ready to display.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -1483,9 +1483,11 @@ const runLoop = Effect.fnUntraced(
   ) {
     let state = Effect.isEffect(loop.initialState) ? yield* loop.initialState : loop.initialState
     let action: Action<unknown, unknown> = Action.NextFrame({ state })
+    let clear = ""
     while (true) {
       const msg = yield* loop.render(state, action)
-      yield* Effect.orDie(terminal.display(msg))
+      yield* Effect.orDie(terminal.display(clear + msg))
+      clear = ""
       if (loop.events) {
         const takeInput = Queue.take(input).pipe(
           Effect.map((input) => ({ _tag: "Input" as const, input }))
@@ -1503,14 +1505,14 @@ const runLoop = Effect.fnUntraced(
         case "Beep":
           continue
         case "NextFrame": {
-          yield* Effect.orDie(terminal.display(yield* loop.clear(state, action)))
+          clear = yield* loop.clear(state, action)
           state = action.state
           continue
         }
         case "Submit": {
-          yield* Effect.orDie(terminal.display(yield* loop.clear(state, action)))
+          clear = yield* loop.clear(state, action)
           const msg = yield* loop.render(state, action)
-          yield* Effect.orDie(terminal.display(msg))
+          yield* Effect.orDie(terminal.display(clear + msg))
           return action.value
         }
       }

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Data, DateTime, Effect, Fiber, FileSystem, Layer, Match, Path, Queue, Redacted } from "effect"
+import { Data, DateTime, Deferred, Effect, Fiber, FileSystem, Layer, Match, Path, Queue, Redacted } from "effect"
 import { Prompt } from "effect/unstable/cli"
 import * as MockTerminal from "./services/MockTerminal.ts"
 
@@ -1161,6 +1161,64 @@ describe("Prompt.multiSelect", () => {
 })
 
 describe("Prompt.custom", () => {
+  for (const transition of ["NextFrame", "Submit"] as const) {
+    it.effect(`keeps the previous frame visible while rendering ${transition}`, () =>
+      Effect.gen(function*() {
+        const rendering = yield* Deferred.make<void>()
+        const resume = yield* Deferred.make<void>()
+        const calls: Array<string> = []
+        const clear = `${escape}[2K\r`
+        const prompt = Prompt.custom<number, number>(0, {
+          render: (state, action) =>
+            Effect.gen(function*() {
+              calls.push(`render ${state} ${action._tag}`)
+              if (action._tag === transition && (state > 0 || action._tag === "Submit")) {
+                yield* Deferred.succeed(rendering, undefined)
+                yield* Deferred.await(resume)
+              }
+              return action._tag === "Submit" ? `Done ${state}` : action._tag === "Beep" ? bell : `Frame ${state}`
+            }),
+          clear: (state, action) =>
+            Effect.sync(() => {
+              calls.push(`clear ${state} ${action._tag}`)
+              return clear
+            }),
+          process: (input, state) =>
+            Effect.succeed(
+              input.key.name === "q"
+                ? Action.Submit({ value: 42 })
+                : input.key.name === "b"
+                ? Action.Beep()
+                : Action.NextFrame({ state: state + 1 })
+            )
+        })
+
+        if (transition === "NextFrame") {
+          yield* MockTerminal.inputKey("enter")
+          yield* MockTerminal.inputKey("b")
+        }
+        yield* MockTerminal.inputKey("q")
+        const fiber = yield* Prompt.run(prompt).pipe(Effect.forkChild)
+        yield* Deferred.await(rendering)
+
+        assert.deepStrictEqual(yield* MockTerminal.displayLines, ["Frame 0"])
+        assert.deepStrictEqual(calls, [
+          "render 0 NextFrame",
+          `clear 0 ${transition}`,
+          `render ${transition === "NextFrame" ? 1 : 0} ${transition}`
+        ])
+
+        yield* Deferred.succeed(resume, undefined)
+        assert.strictEqual(yield* Fiber.join(fiber), 42)
+        assert.deepStrictEqual(
+          yield* MockTerminal.displayLines,
+          transition === "NextFrame"
+            ? ["Frame 0", `${clear}Frame 1`, bell, `${clear}Done 1`, `${escape}[?25h`]
+            : ["Frame 0", `${clear}Done 0`, `${escape}[?25h`]
+        )
+      }).pipe(Effect.provide(TestLayer)))
+  }
+
   it.effect("receive handles events from external dequeue", () =>
     Effect.gen(function*() {
       const eventQueue = yield* Queue.make<string>()


### PR DESCRIPTION
Slow `Prompt.custom` renders clear the previous frame before the replacement is ready, leaving the terminal blank. Buffer the clear output and display it together with the next frame or submission. Clearing still uses the previous state and runs before rendering; submission keeps the current state.

The first commit adds gated regression tests for `NextFrame` and `Submit`. Both failed against the original implementation while the other 61 prompt tests passed. The second commit fixes the ordering and adds a patch changeset. Coverage also checks that a subsequent beep does not replay the clear output.

Validation passed (all through `nix develop -c`):

- `pnpm test --run packages/effect/test/unstable/cli/Prompt.test.ts` (63 tests)
- `pnpm lint-fix`
- `pnpm check`

Overlaps the existing fix in #8091; this PR includes tests that explicitly pause rendering and inspect terminal output before releasing it.

Closes EFF-1292
Closes #8088
