### PR TITLE
Fix strictJsonSchema leaking into Anthropic Messages requests

### DIFF
--- a/.changeset/anthropic-strict-json-schema.md
+++ b/.changeset/anthropic-strict-json-schema.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-anthropic": patch
+---
+
+Exclude the provider-only `strictJsonSchema` option from Anthropic Messages request bodies while preserving its control over tool strictness.

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -710,8 +710,13 @@ export const make = Effect.fnUntraced(function*({ model, config: providerConfig 
       if (betas.size > 0) {
         params["anthropic-beta"] = Array.from(betas).join(",")
       }
-      const { disableParallelToolCalls: _, output_config, structuredOutputs: _structuredOutputs, ...requestConfig } =
-        config
+      const {
+        disableParallelToolCalls: _,
+        output_config,
+        strictJsonSchema: _strictJsonSchema,
+        structuredOutputs: _structuredOutputs,
+        ...requestConfig
+      } = config
       const payload: Mutable<typeof Generated.BetaCreateMessageParams.Encoded> = {
         ...requestConfig,
         max_tokens: requestConfig.max_tokens ?? capabilities.maxOutputTokens,

--- a/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
+++ b/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
@@ -13,6 +13,78 @@ import {
 import { HttpClient, type HttpClientError, type HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
 describe("AnthropicLanguageModel", () => {
+  describe("strictJsonSchema", () => {
+    for (const stream of [false, true]) {
+      for (const withTools of [false, true]) {
+        for (const strictJsonSchema of [undefined, false, true]) {
+          it.effect(
+            `${stream ? "streamText" : "generateText"} with strictJsonSchema=${strictJsonSchema} ${
+              withTools ? "with" : "without"
+            } tools`,
+            () =>
+              Effect.gen(function*() {
+                let capturedRequest: HttpClientRequest.HttpClientRequest | undefined = undefined
+                const model = "claude-sonnet-4-6"
+                const layer = AnthropicClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+                  Layer.provide(Layer.succeed(
+                    HttpClient.HttpClient,
+                    makeHttpClient((request) => {
+                      capturedRequest = request
+                      return Effect.succeed(
+                        stream ? sseResponse(request, []) : jsonResponse(request, {
+                          id: "msg_test_1",
+                          type: "message",
+                          role: "assistant",
+                          model,
+                          content: [{ type: "text", text: "Hello" }],
+                          stop_reason: "end_turn",
+                          stop_sequence: null,
+                          usage: {
+                            cache_creation: null,
+                            cache_creation_input_tokens: null,
+                            cache_read_input_tokens: null,
+                            inference_geo: null,
+                            input_tokens: 1,
+                            output_tokens: 1,
+                            service_tier: null
+                          }
+                        })
+                      )
+                    })
+                  ))
+                )
+                const toolkit = Toolkit.make(Tool.make("Search", {
+                  parameters: Schema.Struct({ query: Schema.String }),
+                  success: Schema.String
+                }))
+                const options = {
+                  prompt: "Hello",
+                  toolkit: withTools ? toolkit : Toolkit.empty,
+                  disableToolCallResolution: true as const
+                }
+
+                yield* (stream
+                  ? LanguageModel.streamText(options).pipe(Stream.runDrain)
+                  : LanguageModel.generateText(options)).pipe(
+                    Effect.provide(AnthropicLanguageModel.model(model, { strictJsonSchema })),
+                    Effect.provide(layer)
+                  )
+
+                assert.isDefined(capturedRequest)
+                const body = yield* getRequestBody(capturedRequest)
+                assert.strictEqual(body.model, model)
+                if (withTools) {
+                  assert.strictEqual(body.tools[0].name, "Search")
+                  assert.strictEqual(body.tools[0].strict, strictJsonSchema ?? true)
+                }
+                assert.notProperty(body, "strictJsonSchema")
+              })
+          )
+        }
+      }
+    }
+  })
+
   describe("streamText", () => {
     it.effect("decodes tool call params in content_block_stop", () =>
       Effect.gen(function*() {

--- a/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
+++ b/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
@@ -13,129 +13,6 @@ import {
 import { HttpClient, type HttpClientError, type HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
 describe("AnthropicLanguageModel", () => {
-  describe("strictJsonSchema", () => {
-    for (const stream of [false, true]) {
-      for (const withTools of [false, true]) {
-        for (const strictJsonSchema of [undefined, false, true]) {
-          it.effect(
-            `${stream ? "streamText" : "generateText"} with strictJsonSchema=${strictJsonSchema} ${
-              withTools ? "with" : "without"
-            } tools`,
-            () =>
-              Effect.gen(function*() {
-                let capturedRequest: HttpClientRequest.HttpClientRequest | undefined = undefined
-                const model = "claude-sonnet-4-5"
-                const layer = AnthropicClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
-                  Layer.provide(Layer.succeed(
-                    HttpClient.HttpClient,
-                    makeHttpClient((request) => {
-                      capturedRequest = request
-                      return Effect.succeed(
-                        stream ? sseResponse(request, []) : jsonResponse(request, {
-                          id: "msg_test_1",
-                          type: "message",
-                          role: "assistant",
-                          model,
-                          content: [{ type: "text", text: "Hello" }],
-                          stop_reason: "end_turn",
-                          stop_sequence: null,
-                          usage: {
-                            cache_creation: null,
-                            cache_creation_input_tokens: null,
-                            cache_read_input_tokens: null,
-                            inference_geo: null,
-                            input_tokens: 1,
-                            output_tokens: 1,
-                            service_tier: null
-                          }
-                        })
-                      )
-                    })
-                  ))
-                )
-                const toolkit = Toolkit.make(Tool.make("Search", {
-                  parameters: Schema.Struct({ query: Schema.String }),
-                  success: Schema.String
-                }))
-                const options = {
-                  prompt: "Hello",
-                  toolkit: withTools ? toolkit : Toolkit.empty,
-                  disableToolCallResolution: true as const
-                }
-
-                yield* (stream
-                  ? LanguageModel.streamText(options).pipe(Stream.runDrain)
-                  : LanguageModel.generateText(options)).pipe(
-                    Effect.provide(AnthropicLanguageModel.model(model, { strictJsonSchema })),
-                    Effect.provide(layer)
-                  )
-
-                assert.isDefined(capturedRequest)
-                const body = yield* getRequestBody(capturedRequest)
-                assert.strictEqual(body.model, model)
-                if (withTools) {
-                  assert.strictEqual(body.tools[0].name, "Search")
-                  assert.strictEqual(body.tools[0].strict, strictJsonSchema ?? true)
-                }
-                assert.notProperty(body, "strictJsonSchema")
-              })
-          )
-        }
-      }
-    }
-
-    it.effect("omits tool strictness for a model without structured output support", () =>
-      Effect.gen(function*() {
-        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined = undefined
-        const model = "claude-sonnet-4-20250514"
-        const layer = AnthropicClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
-          Layer.provide(Layer.succeed(
-            HttpClient.HttpClient,
-            makeHttpClient((request) => {
-              capturedRequest = request
-              return Effect.succeed(jsonResponse(request, {
-                id: "msg_test_1",
-                type: "message",
-                role: "assistant",
-                model,
-                content: [{ type: "text", text: "Hello" }],
-                stop_reason: "end_turn",
-                stop_sequence: null,
-                usage: {
-                  cache_creation: null,
-                  cache_creation_input_tokens: null,
-                  cache_read_input_tokens: null,
-                  inference_geo: null,
-                  input_tokens: 1,
-                  output_tokens: 1,
-                  service_tier: null
-                }
-              }))
-            })
-          ))
-        )
-
-        yield* LanguageModel.generateText({
-          prompt: "Hello",
-          toolkit: Toolkit.make(Tool.make("Search", {
-            parameters: Schema.Struct({ query: Schema.String }),
-            success: Schema.String
-          })),
-          disableToolCallResolution: true
-        }).pipe(
-          Effect.provide(AnthropicLanguageModel.model(model, { strictJsonSchema: false })),
-          Effect.provide(layer)
-        )
-
-        assert.isDefined(capturedRequest)
-        const body = yield* getRequestBody(capturedRequest)
-        assert.strictEqual(body.model, model)
-        assert.strictEqual(body.tools[0].name, "Search")
-        assert.notProperty(body.tools[0], "strict")
-        assert.notProperty(body, "strictJsonSchema")
-      }))
-  })
-
   describe("streamText", () => {
     it.effect("decodes tool call params in content_block_stop", () =>
       Effect.gen(function*() {
@@ -560,6 +437,57 @@ describe("AnthropicLanguageModel", () => {
   })
 
   describe("generateText", () => {
+    it.effect("omits strictJsonSchema from the request while preserving tool strictness", () =>
+      Effect.gen(function*() {
+        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined = undefined
+        const model = "claude-sonnet-4-5"
+        const layer = AnthropicClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) => {
+              capturedRequest = request
+              return Effect.succeed(jsonResponse(request, {
+                id: "msg_test_1",
+                type: "message",
+                role: "assistant",
+                model,
+                content: [{ type: "text", text: "Hello" }],
+                stop_reason: "end_turn",
+                stop_sequence: null,
+                usage: {
+                  cache_creation: null,
+                  cache_creation_input_tokens: null,
+                  cache_read_input_tokens: null,
+                  inference_geo: null,
+                  input_tokens: 1,
+                  output_tokens: 1,
+                  service_tier: null
+                }
+              }))
+            })
+          ))
+        )
+
+        yield* LanguageModel.generateText({
+          prompt: "Hello",
+          toolkit: Toolkit.make(Tool.make("Search", {
+            parameters: Schema.Struct({ query: Schema.String }),
+            success: Schema.String
+          })),
+          disableToolCallResolution: true
+        }).pipe(
+          Effect.provide(AnthropicLanguageModel.model(model, { strictJsonSchema: false })),
+          Effect.provide(layer)
+        )
+
+        assert.isDefined(capturedRequest)
+        const body = yield* getRequestBody(capturedRequest)
+        assert.strictEqual(body.model, model)
+        assert.strictEqual(body.tools[0].name, "Search")
+        assert.strictEqual(body.tools[0].strict, false)
+        assert.notProperty(body, "strictJsonSchema")
+      }))
+
     it.effect("preserves string tool results", () =>
       Effect.gen(function*() {
         let capturedRequest: HttpClientRequest.HttpClientRequest | undefined = undefined

--- a/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
+++ b/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
@@ -24,7 +24,7 @@ describe("AnthropicLanguageModel", () => {
             () =>
               Effect.gen(function*() {
                 let capturedRequest: HttpClientRequest.HttpClientRequest | undefined = undefined
-                const model = "claude-sonnet-4-6"
+                const model = "claude-sonnet-4-5"
                 const layer = AnthropicClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
                   Layer.provide(Layer.succeed(
                     HttpClient.HttpClient,
@@ -83,6 +83,57 @@ describe("AnthropicLanguageModel", () => {
         }
       }
     }
+
+    it.effect("omits tool strictness for a model without structured output support", () =>
+      Effect.gen(function*() {
+        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined = undefined
+        const model = "claude-sonnet-4-20250514"
+        const layer = AnthropicClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) => {
+              capturedRequest = request
+              return Effect.succeed(jsonResponse(request, {
+                id: "msg_test_1",
+                type: "message",
+                role: "assistant",
+                model,
+                content: [{ type: "text", text: "Hello" }],
+                stop_reason: "end_turn",
+                stop_sequence: null,
+                usage: {
+                  cache_creation: null,
+                  cache_creation_input_tokens: null,
+                  cache_read_input_tokens: null,
+                  inference_geo: null,
+                  input_tokens: 1,
+                  output_tokens: 1,
+                  service_tier: null
+                }
+              }))
+            })
+          ))
+        )
+
+        yield* LanguageModel.generateText({
+          prompt: "Hello",
+          toolkit: Toolkit.make(Tool.make("Search", {
+            parameters: Schema.Struct({ query: Schema.String }),
+            success: Schema.String
+          })),
+          disableToolCallResolution: true
+        }).pipe(
+          Effect.provide(AnthropicLanguageModel.model(model, { strictJsonSchema: false })),
+          Effect.provide(layer)
+        )
+
+        assert.isDefined(capturedRequest)
+        const body = yield* getRequestBody(capturedRequest)
+        assert.strictEqual(body.model, model)
+        assert.strictEqual(body.tools[0].name, "Search")
+        assert.notProperty(body.tools[0], "strict")
+        assert.notProperty(body, "strictJsonSchema")
+      }))
   })
 
   describe("streamText", () => {


### PR DESCRIPTION
Explicitly setting `strictJsonSchema` currently serializes it as a top-level Anthropic Messages field, causing API rejection. Exclude it from the request config while preserving its use in `prepareTools` to set each tool's `strict` flag. Includes a patch changeset.

One focused regression uses tools and `strictJsonSchema: false`, asserting that the request omits `strictJsonSchema` while the tool retains `strict: false`. Removing the fix makes this test fail on the leaked request field; restoring it makes the test pass.

Validation passed:

- `nix develop -c pnpm test --run packages/ai/anthropic/test/AnthropicLanguageModel.test.ts` (28 tests)
- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`
- `git diff --check`

Closes EFF-1294
Closes #8076
