### PR TITLE
Fix Schema.Class annotations in generated JSON Schema

### DIFF
--- a/.changeset/tidy-classes-annotate.md
+++ b/.changeset/tidy-classes-annotate.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve class annotations on encoded JSON Schema definitions.

--- a/packages/effect/src/internal/schema/toCodec.ts
+++ b/packages/effect/src/internal/schema/toCodec.ts
@@ -22,8 +22,10 @@ export const toCodecJsonAST = memoizeIdempotent((ast: SchemaAST.AST): SchemaAST.
   }
   // Class metadata lives on the declaration, while JSON Schema uses its encoding.
   // Carry JSON annotations across without changing encoded identifiers or callbacks.
+  // Checks and later annotations override the class's own annotations.
+  const source = ast.checks ? { ...ast.annotations, ...InternalAnnotations.resolve(ast) } : ast.annotations
   const annotations = Object.fromEntries(
-    Object.entries(InternalAnnotations.resolve(ast) ?? {}).filter(([key, value]) =>
+    Object.entries(source).filter(([key, value]) =>
       key !== "identifier" &&
       key !== InternalAnnotations.IDENTIFIER_FALLBACK_KEY &&
       !InternalAnnotations.annotationExcludedKeys.has(key) &&

--- a/packages/effect/src/internal/schema/toCodec.ts
+++ b/packages/effect/src/internal/schema/toCodec.ts
@@ -1,9 +1,10 @@
-import { memoize } from "../../Function.ts"
+import { memoize, memoizeIdempotent } from "../../Function.ts"
 import * as Predicate from "../../Predicate.ts"
 import type * as PublicSchema from "../../Schema.ts"
 import * as SchemaAST from "../../SchemaAST.ts"
 import * as SchemaGetter from "../../SchemaGetter.ts"
 import * as InternalTransformation from "../../SchemaTransformation.ts"
+import * as InternalAnnotations from "./annotations.ts"
 import * as InternalMake from "./make.ts"
 
 /** @internal */
@@ -12,7 +13,30 @@ export function toCodecJson<S extends PublicSchema.Constraint>(schema: S): Publi
 }
 
 /** @internal */
-export const toCodecJsonAST = SchemaAST.applyToSelfOrLastLinkEncodingIdempotent((ast) => {
+export const toCodecJsonAST = memoizeIdempotent((ast: SchemaAST.AST): SchemaAST.AST => {
+  const out = toCodecJsonASTBase(ast)
+  if (
+    !SchemaAST.isDeclaration(ast) || ast.annotations?.[InternalAnnotations.CONSTRUCTOR_ANNOTATION_KEY] === undefined
+  ) {
+    return out
+  }
+  // Class metadata lives on the declaration, while JSON Schema uses its encoding.
+  // Carry JSON annotations across without changing encoded identifiers or callbacks.
+  const annotations = Object.fromEntries(
+    Object.entries(InternalAnnotations.resolve(ast) ?? {}).filter(([key, value]) =>
+      key !== "identifier" &&
+      key !== InternalAnnotations.IDENTIFIER_FALLBACK_KEY &&
+      !InternalAnnotations.annotationExcludedKeys.has(key) &&
+      SchemaAST.isJson(value)
+    )
+  )
+  if (Object.keys(annotations).length === 0) return out
+  return SchemaAST.applyToSelfOrLastLinkEncoding((encoded) =>
+    SchemaAST.annotate(encoded, { ...annotations, ...InternalAnnotations.resolve(encoded) })
+  )(out)
+})
+
+const toCodecJsonASTBase = SchemaAST.applyToSelfOrLastLinkEncodingIdempotent((ast) => {
   const out = toCodecJsonASTStep(ast, toCodecJsonAST)
   const context = ast.context
   if (out === ast || context === undefined) return out

--- a/packages/effect/src/internal/schema/toCodec.ts
+++ b/packages/effect/src/internal/schema/toCodec.ts
@@ -22,10 +22,9 @@ export const toCodecJsonAST = memoizeIdempotent((ast: SchemaAST.AST): SchemaAST.
   }
   // Class metadata lives on the declaration, while JSON Schema uses its encoding.
   // Carry JSON annotations across without changing encoded identifiers or callbacks.
-  // Checks and later annotations override the class's own annotations.
-  const source = ast.checks ? { ...ast.annotations, ...InternalAnnotations.resolve(ast) } : ast.annotations
+  // Leave check annotations to the normal JSON Schema handling for checks.
   const annotations = Object.fromEntries(
-    Object.entries(source).filter(([key, value]) =>
+    Object.entries(ast.annotations).filter(([key, value]) =>
       key !== "identifier" &&
       key !== InternalAnnotations.IDENTIFIER_FALLBACK_KEY &&
       !InternalAnnotations.annotationExcludedKeys.has(key) &&

--- a/packages/effect/test/schema/toCodec.test.ts
+++ b/packages/effect/test/schema/toCodec.test.ts
@@ -47,6 +47,12 @@ describe("Serializers", () => {
       strictEqual(Schema.toCodecJson(once).ast, once.ast)
     })
 
+    it("is idempotent for annotated classes", () => {
+      class A extends Schema.Class<A>("A")({ a: Schema.String }, { title: "A title" }) {}
+      const once = Schema.toCodecJson(A)
+      strictEqual(Schema.toCodecJson(once).ast, once.ast)
+    })
+
     it("should reorder the types in the Union based on the encoded side", async () => {
       const schema = Schema.Union([
         Schema.String,

--- a/packages/effect/test/schema/toJsonSchemaDocument.test.ts
+++ b/packages/effect/test/schema/toJsonSchemaDocument.test.ts
@@ -3627,6 +3627,26 @@ describe("toJsonSchemaDocument", () => {
         }
       })
     })
+
+    it("preserves annotations on recursive class definitions", () => {
+      class A extends Schema.Class<A>("A")({
+        children: Schema.Array(Schema.suspend((): Schema.Codec<A> => A))
+      }, { title: "Recursive class" }) {}
+      assertJsonSchemaDocument(A, {
+        schema: { $ref: "#/$defs/AEncoded" },
+        definitions: {
+          AEncoded: {
+            type: "object",
+            properties: {
+              children: { type: "array", items: { $ref: "#/$defs/AEncoded" } }
+            },
+            required: ["children"],
+            additionalProperties: false,
+            title: "Recursive class"
+          }
+        }
+      }, { includeAnnotationKey: () => true })
+    })
   })
 
   it("Error preserves its identifier as a canonical reference", () => {

--- a/packages/effect/test/schema/toJsonSchemaDocument.test.ts
+++ b/packages/effect/test/schema/toJsonSchemaDocument.test.ts
@@ -3567,6 +3567,68 @@ describe("toJsonSchemaDocument", () => {
     )
   })
 
+  describe("Class annotations", () => {
+    const annotations = {
+      title: "Class title",
+      description: "Class description",
+      "x-taplo": { hidden: true }
+    }
+    const definition = {
+      type: "object",
+      properties: { a: { type: "string" } },
+      required: ["a"],
+      additionalProperties: false,
+      ...annotations
+    }
+
+    it.each([false, true])("preserves annotations added with annotate: %s", (annotate) => {
+      class A extends Schema.Class<A>("A")({ a: Schema.String }, annotate ? undefined : annotations) {}
+      const schema = annotate ? A.annotate(annotations) : A
+      const options = { includeAnnotationKey: (key: string) => key === "x-taplo" }
+      assertJsonSchemaDocument(schema, {
+        schema: { $ref: "#/$defs/AEncoded" },
+        definitions: { AEncoded: definition }
+      }, options)
+      deepStrictEqual(JsonSchema.toDocumentDraft07(Schema.toJsonSchemaDocument(schema, options)), {
+        dialect: "draft-07",
+        schema: { $ref: "#/definitions/AEncoded" },
+        definitions: { AEncoded: definition }
+      })
+      const { "x-taplo": _, ...withoutCustom } = definition
+      assertJsonSchemaDocument(schema, {
+        schema: { $ref: "#/$defs/AEncoded" },
+        definitions: { AEncoded: withoutCustom }
+      })
+    })
+
+    it("keeps explicit encoded annotations authoritative", () => {
+      const encoded = Schema.Struct({ a: Schema.String }).annotate({
+        identifier: "WireA",
+        title: "Encoded title",
+        "x-taplo": { hidden: false }
+      })
+      class A extends Schema.Class<A>("A")(encoded, annotations) {}
+      assertJsonSchemaDocument(A, {
+        schema: { $ref: "#/$defs/WireA" },
+        definitions: {
+          WireA: { ...definition, title: "Encoded title", "x-taplo": { hidden: false } }
+        }
+      }, { includeAnnotationKey: (key) => key === "x-taplo" })
+      assertJsonSchemaDocument(encoded, {
+        schema: { $ref: "#/$defs/WireA" },
+        definitions: {
+          WireA: {
+            type: "object",
+            properties: { a: { type: "string" } },
+            required: ["a"],
+            additionalProperties: false,
+            title: "Encoded title"
+          }
+        }
+      })
+    })
+  })
+
   it("Error preserves its identifier as a canonical reference", () => {
     class E extends Schema.Error<E>("E")({
       a: Schema.String

--- a/packages/effect/test/schema/toJsonSchemaDocument.test.ts
+++ b/packages/effect/test/schema/toJsonSchemaDocument.test.ts
@@ -3637,24 +3637,17 @@ describe("toJsonSchemaDocument", () => {
         assertJsonSchemaDocument(schema, { schema: definition }, options)
       })
 
-      it("merges check annotations over constructor annotations", () => {
+      it("preserves constructor annotations without emitting custom-check annotations", () => {
         class A extends Schema.Class<A>("A")({ a: Schema.String }, annotations) {}
         const schema = A.check(Schema.makeFilter(() => true, {
           title: "Check title",
           "x-taplo": { hidden: false },
           "x-check": true
         }))
-        assertJsonSchemaDocument(schema, {
-          schema: {
-            ...definition,
-            title: "Check title",
-            "x-taplo": { hidden: false },
-            "x-check": true
-          }
-        }, options)
+        assertJsonSchemaDocument(schema, { schema: definition }, options)
       })
 
-      it("merges later annotations over check and constructor annotations", () => {
+      it("does not emit later annotations stored on custom checks", () => {
         class A extends Schema.Class<A>("A")({ a: Schema.String }, annotations) {}
         const schema = A.check(Schema.makeFilter(() => true, {
           title: "Check title",
@@ -3664,15 +3657,7 @@ describe("toJsonSchemaDocument", () => {
           "x-taplo": { hidden: false },
           "x-late": true
         })
-        assertJsonSchemaDocument(schema, {
-          schema: {
-            ...definition,
-            title: "Late title",
-            "x-taplo": { hidden: false },
-            "x-check": true,
-            "x-late": true
-          }
-        }, options)
+        assertJsonSchemaDocument(schema, { schema: definition }, options)
       })
 
       it("keeps encoded annotations ahead of checked-class annotations", () => {
@@ -3692,11 +3677,30 @@ describe("toJsonSchemaDocument", () => {
             WireA: {
               ...definition,
               title: "Encoded title",
-              "x-taplo": { hidden: false },
-              "x-check": true
+              "x-taplo": { hidden: false }
             }
           }
         }, options)
+      })
+
+      it("matches structs in suppressing custom-check annotations and later annotations", () => {
+        const checked = Schema.Struct({ a: Schema.String }).annotate(annotations).check(
+          Schema.makeFilter(() => true, {
+            title: "Check title",
+            "x-taplo": { hidden: false },
+            "x-check": true
+          })
+        )
+        assertJsonSchemaDocument(checked, { schema: definition }, options)
+        assertJsonSchemaDocument(
+          checked.annotate({
+            title: "Late title",
+            "x-taplo": { hidden: false },
+            "x-late": true
+          }),
+          { schema: definition },
+          options
+        )
       })
     })
 

--- a/packages/effect/test/schema/toJsonSchemaDocument.test.ts
+++ b/packages/effect/test/schema/toJsonSchemaDocument.test.ts
@@ -3628,6 +3628,78 @@ describe("toJsonSchemaDocument", () => {
       })
     })
 
+    describe("checked classes", () => {
+      const options = { includeAnnotationKey: (key: string) => key.startsWith("x-") }
+
+      it("preserves constructor annotations through an unannotated check", () => {
+        class A extends Schema.Class<A>("A")({ a: Schema.String }, annotations) {}
+        const schema = A.check(Schema.makeFilter(() => true))
+        assertJsonSchemaDocument(schema, { schema: definition }, options)
+      })
+
+      it("merges check annotations over constructor annotations", () => {
+        class A extends Schema.Class<A>("A")({ a: Schema.String }, annotations) {}
+        const schema = A.check(Schema.makeFilter(() => true, {
+          title: "Check title",
+          "x-taplo": { hidden: false },
+          "x-check": true
+        }))
+        assertJsonSchemaDocument(schema, {
+          schema: {
+            ...definition,
+            title: "Check title",
+            "x-taplo": { hidden: false },
+            "x-check": true
+          }
+        }, options)
+      })
+
+      it("merges later annotations over check and constructor annotations", () => {
+        class A extends Schema.Class<A>("A")({ a: Schema.String }, annotations) {}
+        const schema = A.check(Schema.makeFilter(() => true, {
+          title: "Check title",
+          "x-check": true
+        })).annotate({
+          title: "Late title",
+          "x-taplo": { hidden: false },
+          "x-late": true
+        })
+        assertJsonSchemaDocument(schema, {
+          schema: {
+            ...definition,
+            title: "Late title",
+            "x-taplo": { hidden: false },
+            "x-check": true,
+            "x-late": true
+          }
+        }, options)
+      })
+
+      it("keeps encoded annotations ahead of checked-class annotations", () => {
+        const encoded = Schema.Struct({ a: Schema.String }).annotate({
+          identifier: "WireA",
+          title: "Encoded title",
+          "x-taplo": { hidden: false }
+        })
+        class A extends Schema.Class<A>("A")(encoded, annotations) {}
+        const schema = A.check(Schema.makeFilter(() => true, {
+          title: "Check title",
+          "x-check": true
+        })).annotate({ title: "Late title", "x-taplo": { hidden: true } })
+        assertJsonSchemaDocument(schema, {
+          schema: { $ref: "#/$defs/WireA" },
+          definitions: {
+            WireA: {
+              ...definition,
+              title: "Encoded title",
+              "x-taplo": { hidden: false },
+              "x-check": true
+            }
+          }
+        }, options)
+      })
+    })
+
     it("preserves annotations on recursive class definitions", () => {
       class A extends Schema.Class<A>("A")({
         children: Schema.Array(Schema.suspend((): Schema.Codec<A> => A))

--- a/packages/effect/test/schema/toJsonSchemaDocument.test.ts
+++ b/packages/effect/test/schema/toJsonSchemaDocument.test.ts
@@ -3542,36 +3542,12 @@ describe("toJsonSchemaDocument", () => {
     })
   })
 
-  it("Class preserves its identifier as a canonical reference", () => {
-    class A extends Schema.Class<A>("A")({
-      a: Schema.String
-    }) {}
-    assertJsonSchemaDocument(
-      A,
-      {
-        schema: {
-          "$ref": "#/$defs/AEncoded"
-        },
-        definitions: {
-          "AEncoded": {
-            "type": "object",
-            "properties": {
-              "a": { "type": "string" }
-            },
-            "required": ["a"],
-            "additionalProperties": false
-          }
-        }
-      },
-      { includeAnnotationKey: () => true }
-    )
-  })
-
   describe("Class annotations", () => {
+    const fields = { a: Schema.String }
     const annotations = {
       title: "Class title",
       description: "Class description",
-      "x-taplo": { hidden: true }
+      "x-custom": 1
     }
     const definition = {
       type: "object",
@@ -3580,148 +3556,39 @@ describe("toJsonSchemaDocument", () => {
       additionalProperties: false,
       ...annotations
     }
+    const options = { includeAnnotationKey: (key: string) => key.startsWith("x-") }
 
-    it.each([false, true])("preserves annotations added with annotate: %s", (annotate) => {
-      class A extends Schema.Class<A>("A")({ a: Schema.String }, annotate ? undefined : annotations) {}
-      const schema = annotate ? A.annotate(annotations) : A
-      const options = { includeAnnotationKey: (key: string) => key === "x-taplo" }
+    it("preserves its identifier and annotations on the encoded definition", () => {
+      class A extends Schema.Class<A>("A")(fields, { title: "Class title" }) {}
+      const schema = A.annotate({ description: "Class description", "x-custom": 1 })
       assertJsonSchemaDocument(schema, {
         schema: { $ref: "#/$defs/AEncoded" },
         definitions: { AEncoded: definition }
       }, options)
-      deepStrictEqual(JsonSchema.toDocumentDraft07(Schema.toJsonSchemaDocument(schema, options)), {
-        dialect: "draft-07",
-        schema: { $ref: "#/definitions/AEncoded" },
-        definitions: { AEncoded: definition }
-      })
-      const { "x-taplo": _, ...withoutCustom } = definition
-      assertJsonSchemaDocument(schema, {
-        schema: { $ref: "#/$defs/AEncoded" },
-        definitions: { AEncoded: withoutCustom }
-      })
     })
 
     it("keeps explicit encoded annotations authoritative", () => {
-      const encoded = Schema.Struct({ a: Schema.String }).annotate({
+      const encoded = Schema.Struct(fields).annotate({
         identifier: "WireA",
         title: "Encoded title",
-        "x-taplo": { hidden: false }
+        "x-custom": 2
       })
       class A extends Schema.Class<A>("A")(encoded, annotations) {}
       assertJsonSchemaDocument(A, {
         schema: { $ref: "#/$defs/WireA" },
         definitions: {
-          WireA: { ...definition, title: "Encoded title", "x-taplo": { hidden: false } }
+          WireA: { ...definition, title: "Encoded title", "x-custom": 2 }
         }
-      }, { includeAnnotationKey: (key) => key === "x-taplo" })
-      assertJsonSchemaDocument(encoded, {
-        schema: { $ref: "#/$defs/WireA" },
-        definitions: {
-          WireA: {
-            type: "object",
-            properties: { a: { type: "string" } },
-            required: ["a"],
-            additionalProperties: false,
-            title: "Encoded title"
-          }
-        }
-      })
+      }, options)
     })
 
-    describe("checked classes", () => {
-      const options = { includeAnnotationKey: (key: string) => key.startsWith("x-") }
-
-      it("preserves constructor annotations through an unannotated check", () => {
-        class A extends Schema.Class<A>("A")({ a: Schema.String }, annotations) {}
-        const schema = A.check(Schema.makeFilter(() => true))
-        assertJsonSchemaDocument(schema, { schema: definition }, options)
-      })
-
-      it("preserves constructor annotations without emitting custom-check annotations", () => {
-        class A extends Schema.Class<A>("A")({ a: Schema.String }, annotations) {}
-        const schema = A.check(Schema.makeFilter(() => true, {
-          title: "Check title",
-          "x-taplo": { hidden: false },
-          "x-check": true
-        }))
-        assertJsonSchemaDocument(schema, { schema: definition }, options)
-      })
-
-      it("does not emit later annotations stored on custom checks", () => {
-        class A extends Schema.Class<A>("A")({ a: Schema.String }, annotations) {}
-        const schema = A.check(Schema.makeFilter(() => true, {
-          title: "Check title",
-          "x-check": true
-        })).annotate({
-          title: "Late title",
-          "x-taplo": { hidden: false },
-          "x-late": true
-        })
-        assertJsonSchemaDocument(schema, { schema: definition }, options)
-      })
-
-      it("keeps encoded annotations ahead of checked-class annotations", () => {
-        const encoded = Schema.Struct({ a: Schema.String }).annotate({
-          identifier: "WireA",
-          title: "Encoded title",
-          "x-taplo": { hidden: false }
-        })
-        class A extends Schema.Class<A>("A")(encoded, annotations) {}
-        const schema = A.check(Schema.makeFilter(() => true, {
-          title: "Check title",
-          "x-check": true
-        })).annotate({ title: "Late title", "x-taplo": { hidden: true } })
-        assertJsonSchemaDocument(schema, {
-          schema: { $ref: "#/$defs/WireA" },
-          definitions: {
-            WireA: {
-              ...definition,
-              title: "Encoded title",
-              "x-taplo": { hidden: false }
-            }
-          }
-        }, options)
-      })
-
-      it("matches structs in suppressing custom-check annotations and later annotations", () => {
-        const checked = Schema.Struct({ a: Schema.String }).annotate(annotations).check(
-          Schema.makeFilter(() => true, {
-            title: "Check title",
-            "x-taplo": { hidden: false },
-            "x-check": true
-          })
-        )
+    it("preserves own annotations and ignores custom-check annotations like a struct", () => {
+      class A extends Schema.Class<A>("A")(fields, annotations) {}
+      const check = Schema.makeFilter(() => true, { title: "Check title", "x-check": true })
+      for (const schema of [A, Schema.Struct(fields).annotate(annotations)]) {
+        const checked = schema.check(check).annotate({ description: "Late description", "x-late": true })
         assertJsonSchemaDocument(checked, { schema: definition }, options)
-        assertJsonSchemaDocument(
-          checked.annotate({
-            title: "Late title",
-            "x-taplo": { hidden: false },
-            "x-late": true
-          }),
-          { schema: definition },
-          options
-        )
-      })
-    })
-
-    it("preserves annotations on recursive class definitions", () => {
-      class A extends Schema.Class<A>("A")({
-        children: Schema.Array(Schema.suspend((): Schema.Codec<A> => A))
-      }, { title: "Recursive class" }) {}
-      assertJsonSchemaDocument(A, {
-        schema: { $ref: "#/$defs/AEncoded" },
-        definitions: {
-          AEncoded: {
-            type: "object",
-            properties: {
-              children: { type: "array", items: { $ref: "#/$defs/AEncoded" } }
-            },
-            required: ["children"],
-            additionalProperties: false,
-            title: "Recursive class"
-          }
-        }
-      }, { includeAnnotationKey: () => true })
+      }
     })
   })
 

--- a/packages/platform/node/test/__snapshots__/HttpApi.test.ts.snap
+++ b/packages/platform/node/test/__snapshots__/HttpApi.test.ts.snap
@@ -53,6 +53,7 @@ exports[`HttpApi > original tests > OpenAPI spec > fixture 1`] = `
       },
       "UserEncoded": {
         "additionalProperties": false,
+        "description": "Some description for User",
         "properties": {
           "createdAt": {
             "type": "string",


### PR DESCRIPTION
`Schema.toJsonSchemaDocument` loses class annotations when it follows the class's encoding link. Carry the class's own serializable annotations from `ast.annotations` onto the encoded definition, including custom keys selected by `includeAnnotationKey`. Explicit encoded annotations and identifiers retain precedence.

Preserve existing custom-filter behavior: constructor annotations survive, while custom-check annotations and later `.annotate()` values stored on those checks are omitted, matching structs. Annotations applied directly to an unchecked class still propagate. Keep JSON codec conversion idempotent and refresh the OpenAPI snapshot to include the propagated class description.

Credit to Xia Chao (`javascript-unsafe`) for the original class-annotation propagation contribution in [#8085](https://github.com/Effect-TS/effect/pull/8085). This PR uses that approach and adds idempotent caching and focused regression coverage. #8085 remains open for the maintainer's decision.

Validation:

- `nix develop -c pnpm test --run packages/effect/test/schema/toJsonSchemaDocument.test.ts packages/effect/test/schema/toCodec.test.ts packages/platform/node/test/HttpApi.test.ts`: all 428 tests pass, including the OpenAPI snapshot.
- `nix develop -c pnpm lint-fix` and `nix develop -c pnpm check` pass.
- Four focused regressions cover propagation through constructor annotations and `.annotate()`, encoded-side precedence, custom-check behavior compared with structs, and codec idempotence. This strengthens one existing test and adds three cases.

Closes EFF-1293
Closes #8084
