### PR TITLE
Fix strictJsonSchema leaking into OpenRouter requests

### DIFF
--- a/.changeset/openrouter-strict-json-schema.md
+++ b/.changeset/openrouter-strict-json-schema.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openrouter": patch
+---
+
+Exclude the provider-only `strictJsonSchema` option from outgoing OpenRouter request bodies while preserving structured-output and tool strictness settings.

--- a/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
+++ b/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
@@ -557,8 +557,9 @@ export const make = Effect.fnUntraced(function*({ model, config: providerConfig 
       const messages = yield* prepareMessages({ options })
       const { tools, toolChoice } = yield* prepareTools({ options, transformer: codecTransformer })
       const responseFormat = yield* getResponseFormat({ config, options, transformer: codecTransformer })
+      const { strictJsonSchema: _sjs, ...apiConfig } = config
       const request: typeof Generated.ChatRequest.Encoded = {
-        ...config,
+        ...apiConfig,
         messages,
         ...(Predicate.isNotUndefined(responseFormat) ? { response_format: responseFormat } : undefined),
         ...(Predicate.isNotUndefined(tools) ? { tools } : undefined),

--- a/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
+++ b/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
@@ -7,79 +7,46 @@ import { HttpClient, type HttpClientError, type HttpClientRequest, HttpClientRes
 
 describe("OpenRouterLanguageModel", () => {
   describe("strictJsonSchema", () => {
-    for (const strictJsonSchema of [true, false, undefined]) {
-      const config = {
-        temperature: 0.25,
-        ...(strictJsonSchema === undefined ? {} : { strictJsonSchema })
-      }
+    it.effect("omits false from requests while preserving response strictness", () =>
+      Effect.gen(function*() {
+        yield* LanguageModel.generateObject({
+          prompt: "Give me a name",
+          schema: Schema.Struct({ name: Schema.String })
+        }).pipe(Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini", { strictJsonSchema: false })))
 
-      for (const method of ["generateText", "streamText"] as const) {
-        it.effect(`${method} omits strictJsonSchema=${strictJsonSchema} and preserves tool strictness`, () =>
-          Effect.gen(function*() {
-            const toolkit = Toolkit.make(
-              Tool.make("StrictTool", { parameters: Schema.Struct({ query: Schema.String }) })
-                .annotate(Tool.Strict, true),
-              Tool.make("FlexibleTool", { parameters: Schema.Struct({ query: Schema.String }) })
-                .annotate(Tool.Strict, false)
-            )
-            const options = {
-              prompt: "Use a tool",
-              toolkit,
-              disableToolCallResolution: true
-            } as const
+        const requests = yield* MockHttpClient.requests
+        const body = yield* getRequestBody(requests[0])
+        strictEqual(body.response_format.json_schema.strict, false)
+        assert.notProperty(body, "strictJsonSchema")
+      }).pipe(Effect.provide(makeTestLayer({
+        body: {
+          choices: [{
+            finish_reason: "stop",
+            index: 0,
+            message: { role: "assistant", content: JSON.stringify({ name: "Alice" }) }
+          }]
+        }
+      }))))
 
-            yield* (method === "streamText"
-              ? LanguageModel.streamText(options).pipe(Stream.runDrain)
-              : LanguageModel.generateText(options).pipe(Effect.asVoid)).pipe(
-                Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini", config))
-              )
+    it.effect("omits true from streaming requests while preserving tool strictness", () =>
+      Effect.gen(function*() {
+        const tool = Tool.make("FlexibleTool", { parameters: Schema.Struct({ query: Schema.String }) })
+          .annotate(Tool.Strict, false)
+        yield* LanguageModel.streamText({
+          prompt: "Use a tool",
+          toolkit: Toolkit.make(tool),
+          disableToolCallResolution: true
+        }).pipe(
+          Stream.runDrain,
+          Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini", { strictJsonSchema: true }))
+        )
 
-            const requests = yield* MockHttpClient.requests
-            strictEqual(requests.length, 1)
-            const body = yield* getRequestBody(requests[0])
-
-            strictEqual(body.model, "openai/gpt-4o-mini")
-            strictEqual(body.temperature, 0.25)
-            deepStrictEqual(body.messages, [{ role: "user", content: "Use a tool" }])
-            deepStrictEqual(
-              body.tools.map((tool: any) => ({ name: tool.function.name, strict: tool.function.strict })),
-              [{ name: "StrictTool", strict: true }, { name: "FlexibleTool", strict: false }]
-            )
-            if (method === "streamText") {
-              strictEqual(body.stream, true)
-            }
-            assert.notProperty(body, "strictJsonSchema")
-          }).pipe(Effect.provide(method === "streamText" ? makeStreamTestLayer([]) : makeTestLayer())))
-      }
-
-      it.effect(`generateObject omits strictJsonSchema=${strictJsonSchema} and preserves response strictness`, () =>
-        Effect.gen(function*() {
-          const result = yield* LanguageModel.generateObject({
-            prompt: "Give me a name",
-            schema: Schema.Struct({ name: Schema.String })
-          }).pipe(Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini", config)))
-
-          deepStrictEqual(result.value, { name: "Alice" })
-          const requests = yield* MockHttpClient.requests
-          strictEqual(requests.length, 1)
-          const body = yield* getRequestBody(requests[0])
-
-          strictEqual(body.model, "openai/gpt-4o-mini")
-          strictEqual(body.temperature, 0.25)
-          strictEqual(body.response_format.type, "json_schema")
-          strictEqual(body.response_format.json_schema.strict, strictJsonSchema ?? null)
-          deepStrictEqual(body.response_format.json_schema.schema.required, ["name"])
-          assert.notProperty(body, "strictJsonSchema")
-        }).pipe(Effect.provide(makeTestLayer({
-          body: {
-            choices: [{
-              finish_reason: "stop",
-              index: 0,
-              message: { role: "assistant", content: JSON.stringify({ name: "Alice" }) }
-            }]
-          }
-        }))))
-    }
+        const requests = yield* MockHttpClient.requests
+        const body = yield* getRequestBody(requests[0])
+        strictEqual(body.stream, true)
+        strictEqual(body.tools[0].function.strict, false)
+        assert.notProperty(body, "strictJsonSchema")
+      }).pipe(Effect.provide(makeStreamTestLayer([]))))
   })
 
   describe("generateText", () => {

--- a/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
+++ b/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
@@ -6,6 +6,82 @@ import { LanguageModel, Prompt, Tool, Toolkit } from "effect/unstable/ai"
 import { HttpClient, type HttpClientError, type HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
 describe("OpenRouterLanguageModel", () => {
+  describe("strictJsonSchema", () => {
+    for (const strictJsonSchema of [true, false, undefined]) {
+      const config = {
+        temperature: 0.25,
+        ...(strictJsonSchema === undefined ? {} : { strictJsonSchema })
+      }
+
+      for (const method of ["generateText", "streamText"] as const) {
+        it.effect(`${method} omits strictJsonSchema=${strictJsonSchema} and preserves tool strictness`, () =>
+          Effect.gen(function*() {
+            const toolkit = Toolkit.make(
+              Tool.make("StrictTool", { parameters: Schema.Struct({ query: Schema.String }) })
+                .annotate(Tool.Strict, true),
+              Tool.make("FlexibleTool", { parameters: Schema.Struct({ query: Schema.String }) })
+                .annotate(Tool.Strict, false)
+            )
+            const options = {
+              prompt: "Use a tool",
+              toolkit,
+              disableToolCallResolution: true
+            } as const
+
+            yield* (method === "streamText"
+              ? LanguageModel.streamText(options).pipe(Stream.runDrain)
+              : LanguageModel.generateText(options).pipe(Effect.asVoid)).pipe(
+                Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini", config))
+              )
+
+            const requests = yield* MockHttpClient.requests
+            strictEqual(requests.length, 1)
+            const body = yield* getRequestBody(requests[0])
+
+            strictEqual(body.model, "openai/gpt-4o-mini")
+            strictEqual(body.temperature, 0.25)
+            deepStrictEqual(body.messages, [{ role: "user", content: "Use a tool" }])
+            deepStrictEqual(
+              body.tools.map((tool: any) => ({ name: tool.function.name, strict: tool.function.strict })),
+              [{ name: "StrictTool", strict: true }, { name: "FlexibleTool", strict: false }]
+            )
+            if (method === "streamText") {
+              strictEqual(body.stream, true)
+            }
+            assert.notProperty(body, "strictJsonSchema")
+          }).pipe(Effect.provide(method === "streamText" ? makeStreamTestLayer([]) : makeTestLayer())))
+      }
+
+      it.effect(`generateObject omits strictJsonSchema=${strictJsonSchema} and preserves response strictness`, () =>
+        Effect.gen(function*() {
+          const result = yield* LanguageModel.generateObject({
+            prompt: "Give me a name",
+            schema: Schema.Struct({ name: Schema.String })
+          }).pipe(Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini", config)))
+
+          deepStrictEqual(result.value, { name: "Alice" })
+          const requests = yield* MockHttpClient.requests
+          strictEqual(requests.length, 1)
+          const body = yield* getRequestBody(requests[0])
+
+          strictEqual(body.model, "openai/gpt-4o-mini")
+          strictEqual(body.temperature, 0.25)
+          strictEqual(body.response_format.type, "json_schema")
+          strictEqual(body.response_format.json_schema.strict, strictJsonSchema ?? null)
+          deepStrictEqual(body.response_format.json_schema.schema.required, ["name"])
+          assert.notProperty(body, "strictJsonSchema")
+        }).pipe(Effect.provide(makeTestLayer({
+          body: {
+            choices: [{
+              finish_reason: "stop",
+              index: 0,
+              message: { role: "assistant", content: JSON.stringify({ name: "Alice" }) }
+            }]
+          }
+        }))))
+    }
+  })
+
   describe("generateText", () => {
     describe("message preparation", () => {
       describe("audio file parts", () => {
@@ -475,20 +551,27 @@ const getRequestBody = (request: HttpClientRequest.HttpClientRequest) =>
 
 const makeStreamTestLayer = (events: ReadonlyArray<typeof Generated.ChatStreamChunk.Encoded>) => {
   const body = events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("") + "data: [DONE]\n\n"
-  const httpClient = HttpClient.makeWith(
-    Effect.fnUntraced(function*(requestEffect) {
-      const request = yield* requestEffect
-      return HttpClientResponse.fromWeb(
-        request,
-        new Response(body, {
-          status: 200,
-          headers: { "content-type": "text/event-stream" }
-        })
-      )
-    }),
-    Effect.succeed as HttpClient.HttpClient.Preprocess<HttpClientError.HttpClientError, never>
-  )
+  const httpClientLayer = Layer.effectContext(Effect.gen(function*() {
+    const capturedRequests = yield* Ref.make<ReadonlyArray<HttpClientRequest.HttpClientRequest>>([])
+    const httpClient = HttpClient.makeWith(
+      Effect.fnUntraced(function*(requestEffect) {
+        const request = yield* requestEffect
+        yield* Ref.update(capturedRequests, Array.append(request))
+        return HttpClientResponse.fromWeb(
+          request,
+          new Response(body, {
+            status: 200,
+            headers: { "content-type": "text/event-stream" }
+          })
+        )
+      }),
+      Effect.succeed as HttpClient.HttpClient.Preprocess<HttpClientError.HttpClientError, never>
+    )
+    return Context.make(HttpClient.HttpClient, httpClient).pipe(
+      Context.add(MockHttpClient, MockHttpClient.of({ requests: Ref.get(capturedRequests) }))
+    )
+  }))
   return OpenRouterClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
-    Layer.provide(Layer.succeed(HttpClient.HttpClient, httpClient))
+    Layer.provideMerge(httpClientLayer)
   )
 }


### PR DESCRIPTION
Explicit `strictJsonSchema: true` or `false` was serialized as a top-level field in OpenRouter chat requests. Exclude this provider-only setting from the API config while retaining it for structured-output strictness. Per-tool `Tool.Strict` settings remain intact.

Two focused regressions cover explicit false with structured output and explicit true with streaming, retaining response-format and tool strictness assertions. Includes a patch changeset for `@effect/ai-openrouter`.

Validation:

- Temporarily removing the fix produces exactly two failures at the assertions that the serialized body must omit `strictJsonSchema`; the 11 existing tests pass.
- With the fix restored, all 13 tests pass with `nix develop -c pnpm test --run packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts`.
- `nix develop -c pnpm lint-fix` and `nix develop -c pnpm check` pass.

Closes EFF-1296
