### PR TITLE
Fix token bucket refill timing and fractional costs

### DIFF
--- a/.changeset/token-bucket-elapsed-refill.md
+++ b/.changeset/token-bucket-elapsed-refill.md
@@ -5,3 +5,5 @@
 Fix token-bucket retry and delay timing in memory and Redis by accounting for elapsed refill time. `resetAfter` also accounts for elapsed time and reserved debt.
 
 `RateLimiterStore.tokenBucket` now returns `[remaining, elapsedMillis]` instead of a number. Custom stores must return both values atomically; `elapsedMillis` is the time since the last refill boundary in milliseconds, preserving fractional values.
+
+Returning `[remaining, 0]` retains the timing bug. Restart the refill interval for new or full buckets, but preserve it on reads of partially filled buckets.

--- a/.changeset/token-bucket-elapsed-refill.md
+++ b/.changeset/token-bucket-elapsed-refill.md
@@ -2,8 +2,6 @@
 "effect": patch
 ---
 
-Fix token-bucket retry and delay timing in memory and Redis by accounting for elapsed refill time. `resetAfter` also accounts for elapsed time and reserved debt.
+Fix token-bucket `retryAfter`, `delay` and `resetAfter` in the memory and Redis stores. They now subtract the time already elapsed in the current refill interval instead of always reporting whole intervals.
 
-`RateLimiterStore.tokenBucket` now returns `[remaining, elapsedMillis]` instead of a number. Custom stores must return both values atomically; `elapsedMillis` is the time since the last refill boundary in milliseconds, preserving fractional values.
-
-Returning `[remaining, 0]` retains the timing bug. Restart the refill interval for new buckets or buckets at capacity after refill and before consumption; preserve partial intervals on reads.
+`RateLimiterStore.tokenBucket` now returns `[remaining, elapsedMillis]` instead of `remaining`. Custom stores must return both values from the same atomic operation; see the `tokenBucket` docs for the contract. Returning `[remaining, 0]` keeps the old timing bug.

--- a/.changeset/token-bucket-elapsed-refill.md
+++ b/.changeset/token-bucket-elapsed-refill.md
@@ -1,0 +1,9 @@
+---
+"effect": patch
+---
+
+Fix token-bucket retry and delay timing in the memory and Redis rate limiter stores. After consuming five tokens in a five-minute window, a one-token request 59 seconds later now waits one second instead of 60 seconds.
+
+`RateLimiterStore.tokenBucket` now returns `readonly [remaining: number, elapsedMillis: number]` instead of a number. Custom stores must return the signed count after attempted consumption plus the elapsed portion of the current refill interval, in milliseconds, from the same atomic operation. Advance the refill boundary by whole intervals before computing elapsed time, preserve fractional milliseconds, and use zero elapsed time for a new bucket. Failed requests must not persist a negative count; delay reservations must persist their debt. Simply wrapping the old count as `[remaining, 0]` retains the timing bug.
+
+For token buckets, `ConsumeResult.resetAfter` now reports the time until the bucket returns to full capacity if no further tokens are consumed. It subtracts the elapsed portion of the current refill interval, includes reserved debt in delay mode, and is clamped to zero. Fixed-window reset semantics are unchanged.

--- a/.changeset/token-bucket-elapsed-refill.md
+++ b/.changeset/token-bucket-elapsed-refill.md
@@ -2,8 +2,6 @@
 "effect": patch
 ---
 
-Fix token-bucket retry and delay timing in the memory and Redis rate limiter stores. After consuming five tokens in a five-minute window, a one-token request 59 seconds later now waits one second instead of 60 seconds.
+Fix token-bucket retry and delay timing in memory and Redis by accounting for elapsed refill time. `resetAfter` also accounts for elapsed time and reserved debt.
 
-`RateLimiterStore.tokenBucket` now returns `readonly [remaining: number, elapsedMillis: number]` instead of a number. Custom stores must return the signed count after attempted consumption plus the elapsed portion of the current refill interval, in milliseconds, from the same atomic operation. Advance the refill boundary by whole intervals before computing elapsed time, preserve fractional milliseconds, and use zero elapsed time for a new bucket. Failed requests must not persist a negative count; delay reservations must persist their debt. Simply wrapping the old count as `[remaining, 0]` retains the timing bug.
-
-For token buckets, `ConsumeResult.resetAfter` now reports the time until the bucket returns to full capacity if no further tokens are consumed. It subtracts the elapsed portion of the current refill interval, includes reserved debt in delay mode, and is clamped to zero. Fixed-window reset semantics are unchanged.
+`RateLimiterStore.tokenBucket` now returns `[remaining, elapsedMillis]` instead of a number. Custom stores must return both values atomically; `elapsedMillis` is the time since the last refill boundary in milliseconds, preserving fractional values.

--- a/.changeset/token-bucket-elapsed-refill.md
+++ b/.changeset/token-bucket-elapsed-refill.md
@@ -6,4 +6,4 @@ Fix token-bucket retry and delay timing in memory and Redis by accounting for el
 
 `RateLimiterStore.tokenBucket` now returns `[remaining, elapsedMillis]` instead of a number. Custom stores must return both values atomically; `elapsedMillis` is the time since the last refill boundary in milliseconds, preserving fractional values.
 
-Returning `[remaining, 0]` retains the timing bug. Restart the refill interval for new or full buckets, but preserve it on reads of partially filled buckets.
+Returning `[remaining, 0]` retains the timing bug. Restart the refill interval for new buckets or buckets at capacity after refill and before consumption; preserve partial intervals on reads.

--- a/.changeset/token-bucket-elapsed-refill.md
+++ b/.changeset/token-bucket-elapsed-refill.md
@@ -2,6 +2,6 @@
 "effect": patch
 ---
 
-Fix token-bucket `retryAfter`, `delay` and `resetAfter` in the memory and Redis stores. They now subtract the time already elapsed in the current refill interval instead of always reporting whole intervals.
+Fix token-bucket `retryAfter`, `delay` and `resetAfter` in the memory and Redis stores. Timing now follows whole-token refill boundaries and accounts for elapsed time, including fractional token costs. Redis preserves signed fractional counts and keeps keys until capacity actually refills.
 
 `RateLimiterStore.tokenBucket` now returns `[remaining, elapsedMillis]` instead of `remaining`. Custom stores must return both values from the same atomic operation; see the `tokenBucket` docs for the contract. Returning `[remaining, 0]` keeps the old timing bug.

--- a/packages/effect/src/unstable/persistence/RateLimiter.ts
+++ b/packages/effect/src/unstable/persistence/RateLimiter.ts
@@ -629,8 +629,9 @@ export class RateLimiterStore extends Context.Service<
      * Refills the bucket for `key`, attempts to consume `tokens`, and returns
      * `[remaining, elapsedMillis]` from that single atomic operation.
      *
-     * `remaining` is the token count after subtracting `tokens`. A negative
-     * count is only persisted when `allowOverflow` is true.
+     * `remaining` is the token count after subtracting `tokens`. Fractional counts
+     * must retain their numeric precision. A negative count is only persisted
+     * when `allowOverflow` is true.
      *
      * `elapsedMillis` is the time since the current refill interval started, in
      * milliseconds (fractions preserved), always at least `0` and less than
@@ -1093,8 +1094,8 @@ local ttl = math.ceil(math.ceil(limit - stored) * refill_ms - elapsed)
 if ttl < 1 then ttl = 1 end
 redis.call("SET", key, stored, "PX", ttl)
 redis.call("SET", last_refill_key, last_refill, "PX", ttl)
--- Return strings to preserve fractions in Redis replies.
-return { tostring(next), tostring(elapsed) }
+-- Use 17 significant digits to round-trip both numbers.
+return { string.format("%.17g", next), string.format("%.17g", elapsed) }
 `
   }
 ).withReturnType<readonly [remaining: string, elapsedMillis: string]>()

--- a/packages/effect/src/unstable/persistence/RateLimiter.ts
+++ b/packages/effect/src/unstable/persistence/RateLimiter.ts
@@ -177,9 +177,9 @@ export const make: Effect.Effect<
           allowOverflow: onExceeded === "delay"
         }),
         ([remaining, elapsedMillis]) => {
-          const delay = Duration.millis(Math.max(0, -remaining * refillRateMillis - elapsedMillis))
+          const delay = Duration.millis(Math.max(0, Math.ceil(-remaining) * refillRateMillis - elapsedMillis))
           const resetAfter = Duration.millis(
-            Math.max(0, (options.limit - remaining) * refillRateMillis - elapsedMillis)
+            Math.max(0, Math.ceil(options.limit - remaining) * refillRateMillis - elapsedMillis)
           )
           if (onExceeded === "fail" && remaining < 0) {
             return Effect.fail(
@@ -952,7 +952,7 @@ export const makeStoreRedis = Effect.fnUntraced(function*(
               clock.currentTimeMillisUnsafe(),
               options.allowOverflow ? 1 : 0
             ),
-            ([remaining, elapsedMillis]) => [remaining, Number(elapsedMillis)] as const
+            ([remaining, elapsedMillis]) => [Number(remaining), Number(elapsedMillis)] as const
           ),
           (cause) =>
             new RateLimiterError({
@@ -1088,15 +1088,16 @@ if next >= 0 or overflow then
   stored = next
 end
 
-local ttl = math.floor((limit - stored) * refill_ms)
+elapsed = math.max(0, now - last_refill)
+local ttl = math.ceil(math.ceil(limit - stored) * refill_ms - elapsed)
 if ttl < 1 then ttl = 1 end
 redis.call("SET", key, stored, "PX", ttl)
 redis.call("SET", last_refill_key, last_refill, "PX", ttl)
--- Use a string to preserve fractional milliseconds in Redis replies.
-return { next, tostring(math.max(0, now - last_refill)) }
+-- Return strings to preserve fractions in Redis replies.
+return { tostring(next), tostring(elapsed) }
 `
   }
-).withReturnType<readonly [remaining: number, elapsedMillis: string]>()
+).withReturnType<readonly [remaining: string, elapsedMillis: string]>()
 
 const adaptiveConsumeScript = Redis.script(
   (key: string, tokens: number, fallbackWindowMillis: number, ttlGraceMillis: number) => [

--- a/packages/effect/src/unstable/persistence/RateLimiter.ts
+++ b/packages/effect/src/unstable/persistence/RateLimiter.ts
@@ -632,10 +632,11 @@ export class RateLimiterStore extends Context.Service<
      * `remaining` is the token count after subtracting `tokens`. A negative
      * count is only persisted when `allowOverflow` is true.
      *
-     * `elapsedMillis` is the time since the current refill interval started,
-     * in milliseconds (fractions preserved). It is `0` when the bucket is at
-     * capacity after refilling and before consuming; otherwise it is carried
-     * over from previous calls rather than restarted.
+     * `elapsedMillis` is the time since the current refill interval started, in
+     * milliseconds (fractions preserved), always at least `0` and less than
+     * `Duration.toMillis(refillRate)`. It is `0` when the bucket is at capacity
+     * after refilling and before consuming. Otherwise the boundary advances by
+     * whole refill intervals and the interval never restarts.
      */
     readonly tokenBucket: (options: {
       readonly key: string

--- a/packages/effect/src/unstable/persistence/RateLimiter.ts
+++ b/packages/effect/src/unstable/persistence/RateLimiter.ts
@@ -626,17 +626,16 @@ export class RateLimiterStore extends Context.Service<
     }) => Effect.Effect<readonly [count: number, ttl: number], RateLimiterError>
 
     /**
-     * Returns `[remaining, elapsedMillis]` atomically after refilling and
-     * attempting consumption.
+     * Refills the bucket for `key`, attempts to consume `tokens`, and returns
+     * `[remaining, elapsedMillis]` from that single atomic operation.
      *
-     * `remaining` is the count after subtracting the requested tokens. Negative
-     * counts are persisted only when `allowOverflow` is true.
+     * `remaining` is the token count after subtracting `tokens`. A negative
+     * count is only persisted when `allowOverflow` is true.
      *
-     * `elapsedMillis` is the time since the last whole-token refill boundary,
-     * in milliseconds (possibly fractional). It must be nonnegative and less
-     * than `Duration.toMillis(refillRate)`. Restart the interval for new buckets
-     * or buckets at capacity after refill and before consumption. Reads of
-     * partially filled buckets must preserve it.
+     * `elapsedMillis` is the time since the current refill interval started,
+     * in milliseconds (fractions preserved). It is `0` when the bucket is at
+     * capacity after refilling and before consuming; otherwise it is carried
+     * over from previous calls rather than restarted.
      */
     readonly tokenBucket: (options: {
       readonly key: string
@@ -741,16 +740,14 @@ export const layerStoreMemory: Layer.Layer<
           if (!bucket) {
             bucket = { tokens: options.limit, lastRefill: now }
             tokenBuckets.set(options.key, bucket)
-          } else {
-            const elapsed = now - bucket.lastRefill
-            const tokensToAdd = Math.floor(elapsed / refillRateMillis)
-            if (tokensToAdd > 0) {
-              bucket.tokens = Math.min(options.limit, bucket.tokens + tokensToAdd)
-              bucket.lastRefill += tokensToAdd * refillRateMillis
-            }
-            if (bucket.tokens >= options.limit) {
-              bucket.lastRefill = now
-            }
+          }
+          const tokensToAdd = Math.floor((now - bucket.lastRefill) / refillRateMillis)
+          if (tokensToAdd > 0) {
+            bucket.tokens = Math.min(options.limit, bucket.tokens + tokensToAdd)
+            bucket.lastRefill += tokensToAdd * refillRateMillis
+          }
+          if (bucket.tokens >= options.limit) {
+            bucket.lastRefill = now
           }
 
           const newTokenCount = bucket.tokens - options.tokens

--- a/packages/effect/src/unstable/persistence/RateLimiter.ts
+++ b/packages/effect/src/unstable/persistence/RateLimiter.ts
@@ -181,33 +181,17 @@ export const make: Effect.Effect<
           const resetAfter = Duration.millis(
             Math.max(0, (options.limit - remaining) * refillRateMillis - elapsedMillis)
           )
-          if (onExceeded === "fail") {
-            if (remaining < 0) {
-              return Effect.fail(
-                new RateLimiterError({
-                  reason: new RateLimitExceeded({
-                    key: options.key,
-                    retryAfter: delay,
-                    limit: options.limit,
-                    remaining: 0
-                  })
+          if (onExceeded === "fail" && remaining < 0) {
+            return Effect.fail(
+              new RateLimiterError({
+                reason: new RateLimitExceeded({
+                  key: options.key,
+                  retryAfter: delay,
+                  limit: options.limit,
+                  remaining: 0
                 })
-              )
-            }
-            return Effect.succeed<ConsumeResult>({
-              delay: Duration.zero,
-              limit: options.limit,
-              remaining,
-              resetAfter
-            })
-          }
-          if (remaining >= 0) {
-            return Effect.succeed<ConsumeResult>({
-              delay: Duration.zero,
-              limit: options.limit,
-              remaining,
-              resetAfter
-            })
+              })
+            )
           }
           return Effect.succeed<ConsumeResult>({
             delay,
@@ -649,8 +633,9 @@ export class RateLimiterStore extends Context.Service<
      * counts are persisted only when `allowOverflow` is true.
      *
      * `elapsedMillis` is the time since the last whole-token refill boundary,
-     * in milliseconds (possibly fractional). It is zero for new buckets and
-     * must be nonnegative and less than `Duration.toMillis(refillRate)`.
+     * in milliseconds (possibly fractional). It must be nonnegative and less
+     * than `Duration.toMillis(refillRate)`. Restart the interval for new or full
+     * buckets; reads of partially filled buckets must preserve it.
      */
     readonly tokenBucket: (options: {
       readonly key: string
@@ -761,6 +746,9 @@ export const layerStoreMemory: Layer.Layer<
             if (tokensToAdd > 0) {
               bucket.tokens = Math.min(options.limit, bucket.tokens + tokensToAdd)
               bucket.lastRefill += tokensToAdd * refillRateMillis
+            }
+            if (bucket.tokens >= options.limit) {
+              bucket.lastRefill = now
             }
           }
 
@@ -1090,6 +1078,9 @@ local refill_amount = math.floor(elapsed / refill_ms)
 if refill_amount > 0 then
   current = math.min(current + refill_amount, limit)
   last_refill = last_refill + (refill_amount * refill_ms)
+end
+if current >= limit then
+  last_refill = now
 end
 
 local next = current - tokens

--- a/packages/effect/src/unstable/persistence/RateLimiter.ts
+++ b/packages/effect/src/unstable/persistence/RateLimiter.ts
@@ -176,14 +176,18 @@ export const make: Effect.Effect<
           refillRate,
           allowOverflow: onExceeded === "delay"
         }),
-        (remaining) => {
+        ([remaining, elapsedMillis]) => {
+          const delay = Duration.millis(Math.max(0, -remaining * refillRateMillis - elapsedMillis))
+          const resetAfter = Duration.millis(
+            Math.max(0, (options.limit - remaining) * refillRateMillis - elapsedMillis)
+          )
           if (onExceeded === "fail") {
             if (remaining < 0) {
               return Effect.fail(
                 new RateLimiterError({
                   reason: new RateLimitExceeded({
                     key: options.key,
-                    retryAfter: Duration.times(refillRate, -remaining),
+                    retryAfter: delay,
                     limit: options.limit,
                     remaining: 0
                   })
@@ -194,7 +198,7 @@ export const make: Effect.Effect<
               delay: Duration.zero,
               limit: options.limit,
               remaining,
-              resetAfter: Duration.times(refillRate, options.limit - remaining)
+              resetAfter
             })
           }
           if (remaining >= 0) {
@@ -202,14 +206,14 @@ export const make: Effect.Effect<
               delay: Duration.zero,
               limit: options.limit,
               remaining,
-              resetAfter: Duration.times(refillRate, options.limit - remaining)
+              resetAfter
             })
           }
           return Effect.succeed<ConsumeResult>({
-            delay: Duration.times(refillRate, -remaining),
+            delay,
             limit: options.limit,
             remaining,
-            resetAfter: Duration.times(refillRate, options.limit - remaining)
+            resetAfter
           })
         }
       )
@@ -505,6 +509,13 @@ export interface ConsumeResult {
 
   /**
    * The time until the rate limit fully resets.
+   *
+   * **Details**
+   *
+   * For token buckets, this is the time from this consumption until the bucket
+   * reaches its full capacity, assuming no further consumption. It accounts for
+   * the elapsed portion of the current refill interval and includes any debt
+   * reserved by the "delay" strategy. It is zero when the bucket is already full.
    */
   readonly resetAfter: Duration.Duration
 }
@@ -633,14 +644,25 @@ export class RateLimiterStore extends Context.Service<
     }) => Effect.Effect<readonly [count: number, ttl: number], RateLimiterError>
 
     /**
-     * Returns the current remaining tokens for the `key` after consuming the
-     * specified amount of tokens.
+     * Returns `[remaining, elapsedMillis]` for the `key` from a single atomic
+     * operation. `remaining` is the token count after applying whole-token
+     * refills and subtracting the requested tokens. `elapsedMillis` is the
+     * elapsed portion of the current refill interval, in milliseconds (including
+     * fractional milliseconds), measured after advancing the last-refill time
+     * by the whole refill intervals. It is zero for a new bucket and must be
+     * nonnegative and less than `Duration.toMillis(refillRate)`.
      *
      * If `allowOverflow` is true, the number of tokens can drop below zero.
      *
      * In the case of no overflow, the returned token count will only be
      * negative if the requested tokens exceed the available tokens, but the
      * real token count will not be persisted below zero.
+     *
+     * Custom stores migrating from the previous numeric return value must
+     * return the existing count together with the elapsed time since the last
+     * refill boundary. Compute both from the same clock reading and state
+     * update; returning `[remaining, 0]` preserves the old timing bug. Reads
+     * between refill boundaries must not restart the refill interval.
      */
     readonly tokenBucket: (options: {
       readonly key: string
@@ -648,7 +670,7 @@ export class RateLimiterStore extends Context.Service<
       readonly limit: number
       readonly refillRate: Duration.Duration
       readonly allowOverflow: boolean
-    }) => Effect.Effect<number, RateLimiterError>
+    }) => Effect.Effect<readonly [remaining: number, elapsedMillis: number], RateLimiterError>
 
     /**
      * Consumes tokens from the adaptive rate-limit state for the `key`.
@@ -758,7 +780,7 @@ export const layerStoreMemory: Layer.Layer<
           if (options.allowOverflow || newTokenCount >= 0) {
             bucket.tokens = newTokenCount
           }
-          return newTokenCount
+          return [newTokenCount, Math.max(0, now - bucket.lastRefill)] as const
         })
       ),
     adaptiveConsume: (options) =>
@@ -945,14 +967,17 @@ export const makeStoreRedis = Effect.fnUntraced(function*(
       const refillMillis = Duration.toMillis(options.refillRate)
       return Effect.clockWith((clock) =>
         Effect.mapError(
-          tokenBucket(
-            key,
-            lastRefillKey,
-            options.tokens,
-            refillMillis,
-            options.limit,
-            clock.currentTimeMillisUnsafe(),
-            options.allowOverflow ? 1 : 0
+          Effect.map(
+            tokenBucket(
+              key,
+              lastRefillKey,
+              options.tokens,
+              refillMillis,
+              options.limit,
+              clock.currentTimeMillisUnsafe(),
+              options.allowOverflow ? 1 : 0
+            ),
+            ([remaining, elapsedMillis]) => [remaining, Number(elapsedMillis)] as const
           ),
           (cause) =>
             new RateLimiterError({
@@ -1089,10 +1114,11 @@ local ttl = math.floor((limit - stored) * refill_ms)
 if ttl < 1 then ttl = 1 end
 redis.call("SET", key, stored, "PX", ttl)
 redis.call("SET", last_refill_key, last_refill, "PX", ttl)
-return next
+-- Redis truncates Lua numeric replies to integers; preserve fractional milliseconds.
+return { next, tostring(math.max(0, now - last_refill)) }
 `
   }
-).withReturnType<number>()
+).withReturnType<readonly [remaining: number, elapsedMillis: string]>()
 
 const adaptiveConsumeScript = Redis.script(
   (key: string, tokens: number, fallbackWindowMillis: number, ttlGraceMillis: number) => [

--- a/packages/effect/src/unstable/persistence/RateLimiter.ts
+++ b/packages/effect/src/unstable/persistence/RateLimiter.ts
@@ -634,8 +634,9 @@ export class RateLimiterStore extends Context.Service<
      *
      * `elapsedMillis` is the time since the last whole-token refill boundary,
      * in milliseconds (possibly fractional). It must be nonnegative and less
-     * than `Duration.toMillis(refillRate)`. Restart the interval for new or full
-     * buckets; reads of partially filled buckets must preserve it.
+     * than `Duration.toMillis(refillRate)`. Restart the interval for new buckets
+     * or buckets at capacity after refill and before consumption. Reads of
+     * partially filled buckets must preserve it.
      */
     readonly tokenBucket: (options: {
       readonly key: string

--- a/packages/effect/src/unstable/persistence/RateLimiter.ts
+++ b/packages/effect/src/unstable/persistence/RateLimiter.ts
@@ -512,10 +512,8 @@ export interface ConsumeResult {
    *
    * **Details**
    *
-   * For token buckets, this is the time from this consumption until the bucket
-   * reaches its full capacity, assuming no further consumption. It accounts for
-   * the elapsed portion of the current refill interval and includes any debt
-   * reserved by the "delay" strategy. It is zero when the bucket is already full.
+   * For token buckets, accounts for elapsed refill time and reserved debt,
+   * assuming no further consumption.
    */
   readonly resetAfter: Duration.Duration
 }
@@ -644,25 +642,15 @@ export class RateLimiterStore extends Context.Service<
     }) => Effect.Effect<readonly [count: number, ttl: number], RateLimiterError>
 
     /**
-     * Returns `[remaining, elapsedMillis]` for the `key` from a single atomic
-     * operation. `remaining` is the token count after applying whole-token
-     * refills and subtracting the requested tokens. `elapsedMillis` is the
-     * elapsed portion of the current refill interval, in milliseconds (including
-     * fractional milliseconds), measured after advancing the last-refill time
-     * by the whole refill intervals. It is zero for a new bucket and must be
-     * nonnegative and less than `Duration.toMillis(refillRate)`.
+     * Returns `[remaining, elapsedMillis]` atomically after refilling and
+     * attempting consumption.
      *
-     * If `allowOverflow` is true, the number of tokens can drop below zero.
+     * `remaining` is the count after subtracting the requested tokens. Negative
+     * counts are persisted only when `allowOverflow` is true.
      *
-     * In the case of no overflow, the returned token count will only be
-     * negative if the requested tokens exceed the available tokens, but the
-     * real token count will not be persisted below zero.
-     *
-     * Custom stores migrating from the previous numeric return value must
-     * return the existing count together with the elapsed time since the last
-     * refill boundary. Compute both from the same clock reading and state
-     * update; returning `[remaining, 0]` preserves the old timing bug. Reads
-     * between refill boundaries must not restart the refill interval.
+     * `elapsedMillis` is the time since the last whole-token refill boundary,
+     * in milliseconds (possibly fractional). It is zero for new buckets and
+     * must be nonnegative and less than `Duration.toMillis(refillRate)`.
      */
     readonly tokenBucket: (options: {
       readonly key: string
@@ -1114,7 +1102,7 @@ local ttl = math.floor((limit - stored) * refill_ms)
 if ttl < 1 then ttl = 1 end
 redis.call("SET", key, stored, "PX", ttl)
 redis.call("SET", last_refill_key, last_refill, "PX", ttl)
--- Redis truncates Lua numeric replies to integers; preserve fractional milliseconds.
+-- Use a string to preserve fractional milliseconds in Redis replies.
 return { next, tostring(math.max(0, now - last_refill)) }
 `
   }

--- a/packages/effect/test/unstable/persistence/RateLimiter.test.ts
+++ b/packages/effect/test/unstable/persistence/RateLimiter.test.ts
@@ -2,9 +2,9 @@ import { assert, describe, it } from "@effect/vitest"
 import { Duration, Effect } from "effect"
 import { TestClock } from "effect/testing"
 import { RateLimiter } from "effect/unstable/persistence"
-import { tokenBucketTimingSuite } from "./RateLimiterTest.ts"
+import * as RateLimiterTest from "./RateLimiterTest.ts"
 
-tokenBucketTimingSuite("memory", RateLimiter.layerStoreMemory)
+RateLimiterTest.suite("memory", RateLimiter.layerStoreMemory)
 
 describe(`RateLimiter`, () => {
   it.effect("supports partially applied sleep", () =>

--- a/packages/effect/test/unstable/persistence/RateLimiter.test.ts
+++ b/packages/effect/test/unstable/persistence/RateLimiter.test.ts
@@ -2,6 +2,9 @@ import { assert, describe, it } from "@effect/vitest"
 import { Duration, Effect } from "effect"
 import { TestClock } from "effect/testing"
 import { RateLimiter } from "effect/unstable/persistence"
+import { tokenBucketTimingSuite } from "./RateLimiterTest.ts"
+
+tokenBucketTimingSuite("memory", RateLimiter.layerStoreMemory)
 
 describe(`RateLimiter`, () => {
   it.effect("supports partially applied sleep", () =>

--- a/packages/effect/test/unstable/persistence/RateLimiterTest.ts
+++ b/packages/effect/test/unstable/persistence/RateLimiterTest.ts
@@ -3,18 +3,18 @@ import { Duration, Effect, type Layer } from "effect"
 import { TestClock } from "effect/testing"
 import { RateLimiter } from "effect/unstable/persistence"
 
-export const tokenBucketTimingSuite = (
+export const suite = (
   name: string,
   layer: Layer.Layer<RateLimiter.RateLimiterStore, unknown>
 ) => {
   it.layer(layer, { timeout: "30 seconds" })(`RateLimiter token-bucket timing (${name})`, (it) => {
     for (const onExceeded of ["fail", "delay"] as const) {
       for (
-        const [elapsed, tokens, expected] of [
-          [59_000, 1, 1_000],
-          [59_500, 1, 500],
-          [59_000, 2, 61_000],
-          [119_000, 2, 1_000]
+        const [elapsed, tokens, expected, resetAfter] of [
+          [59_000, 1, 1_000, 301_000],
+          [59_500, 1, 500, 300_500],
+          [59_000, 2, 61_000, 361_000],
+          [119_000, 2, 1_000, 301_000]
         ] as const
       ) {
         it.effect(`${onExceeded}: ${tokens} tokens after ${elapsed}ms waits ${expected}ms`, () =>
@@ -41,10 +41,101 @@ export const tokenBucketTimingSuite = (
               const result = yield* limiter.consume({ ...options, tokens })
               assert.strictEqual(Duration.toMillis(result.delay), expected)
               assert.strictEqual(result.remaining, Math.floor(elapsed / 60_000) - tokens)
+              assert.strictEqual(Duration.toMillis(result.resetAfter), resetAfter)
+            }
+          }))
+      }
+
+      it.effect(`${onExceeded}: resetAfter accounts for elapsed time on an allowed request`, () =>
+        Effect.gen(function*() {
+          const limiter = yield* RateLimiter.make
+          const options = {
+            algorithm: "token-bucket",
+            onExceeded,
+            window: "5 minutes",
+            limit: 5,
+            key: `timing-allowed-${onExceeded}`
+          } as const
+          const initial = yield* limiter.consume({ ...options, tokens: 4 })
+          assert.strictEqual(Duration.toMillis(initial.resetAfter), 240_000)
+          yield* TestClock.adjust("59 seconds")
+          const result = yield* limiter.consume(options)
+
+          assert.deepStrictEqual(result.delay, Duration.zero)
+          assert.strictEqual(result.remaining, 0)
+          assert.strictEqual(Duration.toMillis(result.resetAfter), 241_000)
+
+          yield* TestClock.adjust("241 seconds")
+          const full = yield* limiter.consume({ ...options, tokens: 0 })
+          assert.strictEqual(full.remaining, 5)
+          assert.deepStrictEqual(full.resetAfter, Duration.zero)
+        }))
+
+      for (const [tokens, elapsed, resetAfter] of [[1, 61_000, 60_000], [5, 359_000, 300_000]] as const) {
+        it.effect(`${onExceeded}: restarts the refill interval after ${elapsed}ms idle`, () =>
+          Effect.gen(function*() {
+            const limiter = yield* RateLimiter.make
+            const options = {
+              algorithm: "token-bucket",
+              onExceeded,
+              window: "5 minutes",
+              limit: 5,
+              key: `timing-idle-${onExceeded}-${tokens}`
+            } as const
+            yield* limiter.consume({ ...options, tokens })
+            yield* TestClock.adjust(elapsed)
+            const result = yield* limiter.consume({ ...options, tokens })
+
+            assert.strictEqual(result.remaining, 5 - tokens)
+            assert.deepStrictEqual(result.delay, Duration.zero)
+            assert.strictEqual(Duration.toMillis(result.resetAfter), resetAfter)
+
+            const excess = limiter.consume({ ...options, tokens: 6 - tokens })
+            if (onExceeded === "fail") {
+              const error = yield* Effect.flip(excess)
+              if (error.reason._tag !== "RateLimitExceeded") {
+                throw new Error("Expected RateLimitExceeded")
+              }
+              assert.strictEqual(Duration.toMillis(error.reason.retryAfter), 60_000)
+            } else {
+              const delayed = yield* excess
+              assert.strictEqual(delayed.remaining, -1)
+              assert.strictEqual(Duration.toMillis(delayed.delay), 60_000)
+              assert.strictEqual(Duration.toMillis(delayed.resetAfter), 360_000)
             }
           }))
       }
     }
+
+    it.effect("preserves fractional elapsed milliseconds in the store tuple and timing metadata", () =>
+      Effect.gen(function*() {
+        const store = yield* RateLimiter.RateLimiterStore
+        const options = {
+          key: "timing-fractional",
+          limit: 3,
+          refillRate: Duration.millis(1_000 / 3),
+          allowOverflow: true
+        }
+        const initial = yield* store.tokenBucket({ ...options, tokens: 3 })
+        assert.deepStrictEqual(initial, [0, 0])
+        yield* TestClock.adjust(500)
+        const [remaining, elapsedMillis] = yield* store.tokenBucket({ ...options, tokens: 1 })
+
+        assert.strictEqual(remaining, 0)
+        assert.closeTo(elapsedMillis, 1_000 / 6, 0.000_001)
+
+        const limiter = yield* RateLimiter.make
+        const result = yield* limiter.consume({
+          algorithm: "token-bucket",
+          onExceeded: "delay",
+          window: "1 second",
+          limit: 3,
+          key: options.key
+        })
+        assert.strictEqual(result.remaining, -1)
+        assert.closeTo(Duration.toMillis(result.delay), 1_000 / 6, 0.000_01)
+        assert.closeTo(Duration.toMillis(result.resetAfter), 7_000 / 6, 0.000_01)
+      }))
 
     it.effect("failed retries do not reserve tokens or move the refill boundary", () =>
       Effect.gen(function*() {
@@ -66,6 +157,7 @@ export const tokenBucketTimingSuite = (
         const result = yield* limiter.consume(options)
         assert.deepStrictEqual(result.delay, Duration.zero)
         assert.strictEqual(result.remaining, 0)
+        assert.strictEqual(Duration.toMillis(result.resetAfter), 300_000)
       }))
 
     it.effect("accumulated delay reservations retain the partial refill interval", () =>
@@ -85,6 +177,7 @@ export const tokenBucketTimingSuite = (
 
         assert.strictEqual(Duration.toMillis(result.delay), 61_000)
         assert.strictEqual(result.remaining, -2)
+        assert.strictEqual(Duration.toMillis(result.resetAfter), 361_000)
       }))
   })
 }

--- a/packages/effect/test/unstable/persistence/RateLimiterTest.ts
+++ b/packages/effect/test/unstable/persistence/RateLimiterTest.ts
@@ -1,0 +1,90 @@
+import { assert, it } from "@effect/vitest"
+import { Duration, Effect, type Layer } from "effect"
+import { TestClock } from "effect/testing"
+import { RateLimiter } from "effect/unstable/persistence"
+
+export const tokenBucketTimingSuite = (
+  name: string,
+  layer: Layer.Layer<RateLimiter.RateLimiterStore, unknown>
+) => {
+  it.layer(layer, { timeout: "30 seconds" })(`RateLimiter token-bucket timing (${name})`, (it) => {
+    for (const onExceeded of ["fail", "delay"] as const) {
+      for (
+        const [elapsed, tokens, expected] of [
+          [59_000, 1, 1_000],
+          [59_500, 1, 500],
+          [59_000, 2, 61_000],
+          [119_000, 2, 1_000]
+        ] as const
+      ) {
+        it.effect(`${onExceeded}: ${tokens} tokens after ${elapsed}ms waits ${expected}ms`, () =>
+          Effect.gen(function*() {
+            const limiter = yield* RateLimiter.make
+            const options = {
+              algorithm: "token-bucket",
+              onExceeded,
+              window: "5 minutes",
+              limit: 5,
+              key: `timing-${onExceeded}-${elapsed}-${tokens}`
+            } as const
+            yield* limiter.consume({ ...options, tokens: 5 })
+            yield* TestClock.adjust(elapsed)
+
+            if (onExceeded === "fail") {
+              const error = yield* Effect.flip(limiter.consume({ ...options, tokens }))
+              if (error.reason._tag !== "RateLimitExceeded") {
+                throw new Error("Expected RateLimitExceeded")
+              }
+              assert.strictEqual(Duration.toMillis(error.reason.retryAfter), expected)
+              assert.strictEqual(error.reason.remaining, 0)
+            } else {
+              const result = yield* limiter.consume({ ...options, tokens })
+              assert.strictEqual(Duration.toMillis(result.delay), expected)
+              assert.strictEqual(result.remaining, Math.floor(elapsed / 60_000) - tokens)
+            }
+          }))
+      }
+    }
+
+    it.effect("failed retries do not reserve tokens or move the refill boundary", () =>
+      Effect.gen(function*() {
+        const limiter = yield* RateLimiter.make
+        const options = {
+          algorithm: "token-bucket",
+          onExceeded: "fail",
+          window: "5 minutes",
+          limit: 5,
+          key: "timing-fail-boundary"
+        } as const
+        yield* limiter.consume({ ...options, tokens: 5 })
+        yield* Effect.flip(limiter.consume(options))
+        yield* TestClock.adjust("59 seconds")
+        yield* Effect.flip(limiter.consume(options))
+        yield* Effect.flip(limiter.consume(options))
+        yield* TestClock.adjust("1 second")
+
+        const result = yield* limiter.consume(options)
+        assert.deepStrictEqual(result.delay, Duration.zero)
+        assert.strictEqual(result.remaining, 0)
+      }))
+
+    it.effect("accumulated delay reservations retain the partial refill interval", () =>
+      Effect.gen(function*() {
+        const limiter = yield* RateLimiter.make
+        const options = {
+          algorithm: "token-bucket",
+          onExceeded: "delay",
+          window: "5 minutes",
+          limit: 5,
+          key: "timing-delay-reservations"
+        } as const
+        yield* limiter.consume({ ...options, tokens: 5 })
+        yield* TestClock.adjust("59 seconds")
+        yield* limiter.consume(options)
+        const result = yield* limiter.consume(options)
+
+        assert.strictEqual(Duration.toMillis(result.delay), 61_000)
+        assert.strictEqual(result.remaining, -2)
+      }))
+  })
+}

--- a/packages/effect/test/unstable/persistence/RateLimiterTest.ts
+++ b/packages/effect/test/unstable/persistence/RateLimiterTest.ts
@@ -107,6 +107,27 @@ export const suite = (
       }
     }
 
+    it.effect("restarts the interval after a zero-token call without a whole-token refill", () =>
+      Effect.gen(function*() {
+        const limiter = yield* RateLimiter.make
+        const options = {
+          algorithm: "token-bucket",
+          window: "5 minutes",
+          limit: 5,
+          key: "timing-zero-tokens"
+        } as const
+        const initial = yield* limiter.consume({ ...options, tokens: 0 })
+        assert.strictEqual(initial.remaining, 5)
+        assert.deepStrictEqual(initial.resetAfter, Duration.zero)
+
+        yield* TestClock.adjust("30 seconds")
+        const result = yield* limiter.consume(options)
+
+        assert.strictEqual(result.remaining, 4)
+        assert.deepStrictEqual(result.delay, Duration.zero)
+        assert.strictEqual(Duration.toMillis(result.resetAfter), 60_000)
+      }))
+
     it.effect("preserves fractional elapsed milliseconds in the store tuple and timing metadata", () =>
       Effect.gen(function*() {
         const store = yield* RateLimiter.RateLimiterStore

--- a/packages/effect/test/unstable/persistence/RateLimiterTest.ts
+++ b/packages/effect/test/unstable/persistence/RateLimiterTest.ts
@@ -118,6 +118,39 @@ export const suite = (
         assert.strictEqual(Duration.toMillis(result.resetAfter), 60_000)
       }))
 
+    for (const allowOverflow of [false, true]) {
+      it.effect(`preserves signed fractional token counts with allowOverflow=${allowOverflow}`, () =>
+        Effect.gen(function*() {
+          const store = yield* RateLimiter.RateLimiterStore
+          const opts = {
+            key: `fractional-count-${allowOverflow}`,
+            limit: 5,
+            refillRate: Duration.minutes(1),
+            allowOverflow
+          }
+          const initial = yield* store.tokenBucket({ ...opts, tokens: 4.5 })
+          const excess = yield* store.tokenBucket({ ...opts, tokens: 1 })
+          const stored = yield* store.tokenBucket({ ...opts, tokens: 0 })
+
+          assert.deepStrictEqual([initial, excess, stored], [
+            [0.5, 0],
+            [-0.5, 0],
+            [allowOverflow ? -0.5 : 0.5, 0]
+          ])
+        }))
+    }
+
+    it.effect("rejects a request with a fractional token deficit", () =>
+      Effect.gen(function*() {
+        const limiter = yield* RateLimiter.make
+        const opts = options("fractional-deficit", "fail")
+        yield* limiter.consume({ ...opts, tokens: 4.5 })
+
+        const error = exceeded(yield* Effect.flip(limiter.consume(opts)))
+        assert.strictEqual(error.remaining, 0)
+        assert.strictEqual(error.limit, 5)
+      }))
+
     it.effect("preserves fractional elapsed milliseconds in the store tuple and timing metadata", () =>
       Effect.gen(function*() {
         const store = yield* RateLimiter.RateLimiterStore

--- a/packages/effect/test/unstable/persistence/RateLimiterTest.ts
+++ b/packages/effect/test/unstable/persistence/RateLimiterTest.ts
@@ -43,6 +43,14 @@ export const restartsInterval = Effect.fnUntraced(function*<E, R>(
   }
 })
 
+export const consumeFractionalCosts = Effect.fnUntraced(function*(key: string) {
+  const limiter = yield* RateLimiter.make
+  return yield* Effect.forEach(
+    [0.1, 0.1, 0.4, 0.15, 0.15, 0.1],
+    (tokens) => limiter.consume({ ...options(key), tokens })
+  )
+})
+
 export const suite = (
   name: string,
   layer: Layer.Layer<RateLimiter.RateLimiterStore, unknown>
@@ -139,6 +147,27 @@ export const suite = (
           ])
         }))
     }
+
+    it.effect("preserves accumulated fractional balances and their reset timing", () =>
+      Effect.gen(function*() {
+        const results = yield* consumeFractionalCosts("fractional-accumulation")
+
+        assert.deepStrictEqual(
+          results.map((result) => ({
+            remaining: result.remaining,
+            delay: Duration.toMillis(result.delay),
+            resetAfter: Duration.toMillis(result.resetAfter)
+          })),
+          [
+            { remaining: 4.9, delay: 0, resetAfter: 60_000 },
+            { remaining: 4.800000000000001, delay: 0, resetAfter: 60_000 },
+            { remaining: 4.4, delay: 0, resetAfter: 60_000 },
+            { remaining: 4.25, delay: 0, resetAfter: 60_000 },
+            { remaining: 4.1, delay: 0, resetAfter: 60_000 },
+            { remaining: 3.9999999999999996, delay: 0, resetAfter: 120_000 }
+          ]
+        )
+      }))
 
     it.effect("rejects a request with a fractional token deficit", () =>
       Effect.gen(function*() {

--- a/packages/effect/test/unstable/persistence/RateLimiterTest.ts
+++ b/packages/effect/test/unstable/persistence/RateLimiterTest.ts
@@ -15,34 +15,33 @@ const exceeded = (error: RateLimiter.RateLimiterError) =>
  * Consumes `tokens`, runs `idle`, and asserts the bucket is back at capacity
  * with a fresh refill interval.
  */
-export const restartsInterval = <E, R>(
+export const restartsInterval = Effect.fnUntraced(function*<E, R>(
   key: string,
   onExceeded: OnExceeded,
   tokens: number,
   idle: Effect.Effect<void, E, R>
-) =>
-  Effect.gen(function*() {
-    const limiter = yield* RateLimiter.make
-    const opts = options(key, onExceeded)
-    yield* limiter.consume({ ...opts, tokens })
-    yield* idle
-    const result = yield* limiter.consume({ ...opts, tokens })
+) {
+  const limiter = yield* RateLimiter.make
+  const opts = options(key, onExceeded)
+  yield* limiter.consume({ ...opts, tokens })
+  yield* idle
+  const result = yield* limiter.consume({ ...opts, tokens })
 
-    assert.strictEqual(result.remaining, 5 - tokens)
-    assert.deepStrictEqual(result.delay, Duration.zero)
-    assert.strictEqual(Duration.toMillis(result.resetAfter), tokens * 60_000)
+  assert.strictEqual(result.remaining, 5 - tokens)
+  assert.deepStrictEqual(result.delay, Duration.zero)
+  assert.strictEqual(Duration.toMillis(result.resetAfter), tokens * 60_000)
 
-    const excess = limiter.consume({ ...opts, tokens: 6 - tokens })
-    if (onExceeded === "fail") {
-      const error = exceeded(yield* Effect.flip(excess))
-      assert.strictEqual(Duration.toMillis(error.retryAfter), 60_000)
-    } else {
-      const delayed = yield* excess
-      assert.strictEqual(delayed.remaining, -1)
-      assert.strictEqual(Duration.toMillis(delayed.delay), 60_000)
-      assert.strictEqual(Duration.toMillis(delayed.resetAfter), 360_000)
-    }
-  })
+  const excess = limiter.consume({ ...opts, tokens: 6 - tokens })
+  if (onExceeded === "fail") {
+    const error = exceeded(yield* Effect.flip(excess))
+    assert.strictEqual(Duration.toMillis(error.retryAfter), 60_000)
+  } else {
+    const delayed = yield* excess
+    assert.strictEqual(delayed.remaining, -1)
+    assert.strictEqual(Duration.toMillis(delayed.delay), 60_000)
+    assert.strictEqual(Duration.toMillis(delayed.resetAfter), 360_000)
+  }
+})
 
 export const suite = (
   name: string,

--- a/packages/effect/test/unstable/persistence/RateLimiterTest.ts
+++ b/packages/effect/test/unstable/persistence/RateLimiterTest.ts
@@ -3,6 +3,47 @@ import { Duration, Effect, type Layer } from "effect"
 import { TestClock } from "effect/testing"
 import { RateLimiter } from "effect/unstable/persistence"
 
+type OnExceeded = "fail" | "delay"
+
+const options = (key: string, onExceeded?: OnExceeded) =>
+  ({ algorithm: "token-bucket", window: "5 minutes", limit: 5, key, onExceeded }) as const
+
+const exceeded = (error: RateLimiter.RateLimiterError) =>
+  error.reason._tag === "RateLimitExceeded" ? error.reason : assert.fail("Expected RateLimitExceeded")
+
+/**
+ * Consumes `tokens`, runs `idle`, and asserts the bucket is back at capacity
+ * with a fresh refill interval.
+ */
+export const restartsInterval = <E, R>(
+  key: string,
+  onExceeded: OnExceeded,
+  tokens: number,
+  idle: Effect.Effect<void, E, R>
+) =>
+  Effect.gen(function*() {
+    const limiter = yield* RateLimiter.make
+    const opts = options(key, onExceeded)
+    yield* limiter.consume({ ...opts, tokens })
+    yield* idle
+    const result = yield* limiter.consume({ ...opts, tokens })
+
+    assert.strictEqual(result.remaining, 5 - tokens)
+    assert.deepStrictEqual(result.delay, Duration.zero)
+    assert.strictEqual(Duration.toMillis(result.resetAfter), tokens * 60_000)
+
+    const excess = limiter.consume({ ...opts, tokens: 6 - tokens })
+    if (onExceeded === "fail") {
+      const error = exceeded(yield* Effect.flip(excess))
+      assert.strictEqual(Duration.toMillis(error.retryAfter), 60_000)
+    } else {
+      const delayed = yield* excess
+      assert.strictEqual(delayed.remaining, -1)
+      assert.strictEqual(Duration.toMillis(delayed.delay), 60_000)
+      assert.strictEqual(Duration.toMillis(delayed.resetAfter), 360_000)
+    }
+  })
+
 export const suite = (
   name: string,
   layer: Layer.Layer<RateLimiter.RateLimiterStore, unknown>
@@ -20,25 +61,16 @@ export const suite = (
         it.effect(`${onExceeded}: ${tokens} tokens after ${elapsed}ms waits ${expected}ms`, () =>
           Effect.gen(function*() {
             const limiter = yield* RateLimiter.make
-            const options = {
-              algorithm: "token-bucket",
-              onExceeded,
-              window: "5 minutes",
-              limit: 5,
-              key: `timing-${onExceeded}-${elapsed}-${tokens}`
-            } as const
-            yield* limiter.consume({ ...options, tokens: 5 })
+            const opts = options(`timing-${onExceeded}-${elapsed}-${tokens}`, onExceeded)
+            yield* limiter.consume({ ...opts, tokens: 5 })
             yield* TestClock.adjust(elapsed)
 
             if (onExceeded === "fail") {
-              const error = yield* Effect.flip(limiter.consume({ ...options, tokens }))
-              if (error.reason._tag !== "RateLimitExceeded") {
-                throw new Error("Expected RateLimitExceeded")
-              }
-              assert.strictEqual(Duration.toMillis(error.reason.retryAfter), expected)
-              assert.strictEqual(error.reason.remaining, 0)
+              const error = exceeded(yield* Effect.flip(limiter.consume({ ...opts, tokens })))
+              assert.strictEqual(Duration.toMillis(error.retryAfter), expected)
+              assert.strictEqual(error.remaining, 0)
             } else {
-              const result = yield* limiter.consume({ ...options, tokens })
+              const result = yield* limiter.consume({ ...opts, tokens })
               assert.strictEqual(Duration.toMillis(result.delay), expected)
               assert.strictEqual(result.remaining, Math.floor(elapsed / 60_000) - tokens)
               assert.strictEqual(Duration.toMillis(result.resetAfter), resetAfter)
@@ -49,79 +81,38 @@ export const suite = (
       it.effect(`${onExceeded}: resetAfter accounts for elapsed time on an allowed request`, () =>
         Effect.gen(function*() {
           const limiter = yield* RateLimiter.make
-          const options = {
-            algorithm: "token-bucket",
-            onExceeded,
-            window: "5 minutes",
-            limit: 5,
-            key: `timing-allowed-${onExceeded}`
-          } as const
-          const initial = yield* limiter.consume({ ...options, tokens: 4 })
+          const opts = options(`timing-allowed-${onExceeded}`, onExceeded)
+          const initial = yield* limiter.consume({ ...opts, tokens: 4 })
           assert.strictEqual(Duration.toMillis(initial.resetAfter), 240_000)
           yield* TestClock.adjust("59 seconds")
-          const result = yield* limiter.consume(options)
+          const result = yield* limiter.consume(opts)
 
           assert.deepStrictEqual(result.delay, Duration.zero)
           assert.strictEqual(result.remaining, 0)
           assert.strictEqual(Duration.toMillis(result.resetAfter), 241_000)
 
           yield* TestClock.adjust("241 seconds")
-          const full = yield* limiter.consume({ ...options, tokens: 0 })
+          const full = yield* limiter.consume({ ...opts, tokens: 0 })
           assert.strictEqual(full.remaining, 5)
           assert.deepStrictEqual(full.resetAfter, Duration.zero)
         }))
 
-      for (const [tokens, elapsed, resetAfter] of [[1, 61_000, 60_000], [5, 359_000, 300_000]] as const) {
-        it.effect(`${onExceeded}: restarts the refill interval after ${elapsed}ms idle`, () =>
-          Effect.gen(function*() {
-            const limiter = yield* RateLimiter.make
-            const options = {
-              algorithm: "token-bucket",
-              onExceeded,
-              window: "5 minutes",
-              limit: 5,
-              key: `timing-idle-${onExceeded}-${tokens}`
-            } as const
-            yield* limiter.consume({ ...options, tokens })
-            yield* TestClock.adjust(elapsed)
-            const result = yield* limiter.consume({ ...options, tokens })
-
-            assert.strictEqual(result.remaining, 5 - tokens)
-            assert.deepStrictEqual(result.delay, Duration.zero)
-            assert.strictEqual(Duration.toMillis(result.resetAfter), resetAfter)
-
-            const excess = limiter.consume({ ...options, tokens: 6 - tokens })
-            if (onExceeded === "fail") {
-              const error = yield* Effect.flip(excess)
-              if (error.reason._tag !== "RateLimitExceeded") {
-                throw new Error("Expected RateLimitExceeded")
-              }
-              assert.strictEqual(Duration.toMillis(error.reason.retryAfter), 60_000)
-            } else {
-              const delayed = yield* excess
-              assert.strictEqual(delayed.remaining, -1)
-              assert.strictEqual(Duration.toMillis(delayed.delay), 60_000)
-              assert.strictEqual(Duration.toMillis(delayed.resetAfter), 360_000)
-            }
-          }))
+      for (const [tokens, idle] of [[1, "61 seconds"], [5, "359 seconds"]] as const) {
+        it.effect(`${onExceeded}: restarts the refill interval after ${idle} idle`, () =>
+          restartsInterval(`timing-idle-${onExceeded}-${tokens}`, onExceeded, tokens, TestClock.adjust(idle)))
       }
     }
 
     it.effect("restarts the interval after a zero-token call without a whole-token refill", () =>
       Effect.gen(function*() {
         const limiter = yield* RateLimiter.make
-        const options = {
-          algorithm: "token-bucket",
-          window: "5 minutes",
-          limit: 5,
-          key: "timing-zero-tokens"
-        } as const
-        const initial = yield* limiter.consume({ ...options, tokens: 0 })
+        const opts = options("timing-zero-tokens")
+        const initial = yield* limiter.consume({ ...opts, tokens: 0 })
         assert.strictEqual(initial.remaining, 5)
         assert.deepStrictEqual(initial.resetAfter, Duration.zero)
 
         yield* TestClock.adjust("30 seconds")
-        const result = yield* limiter.consume(options)
+        const result = yield* limiter.consume(opts)
 
         assert.strictEqual(result.remaining, 4)
         assert.deepStrictEqual(result.delay, Duration.zero)
@@ -131,16 +122,16 @@ export const suite = (
     it.effect("preserves fractional elapsed milliseconds in the store tuple and timing metadata", () =>
       Effect.gen(function*() {
         const store = yield* RateLimiter.RateLimiterStore
-        const options = {
+        const opts = {
           key: "timing-fractional",
           limit: 3,
           refillRate: Duration.millis(1_000 / 3),
           allowOverflow: true
         }
-        const initial = yield* store.tokenBucket({ ...options, tokens: 3 })
+        const initial = yield* store.tokenBucket({ ...opts, tokens: 3 })
         assert.deepStrictEqual(initial, [0, 0])
         yield* TestClock.adjust(500)
-        const [remaining, elapsedMillis] = yield* store.tokenBucket({ ...options, tokens: 1 })
+        const [remaining, elapsedMillis] = yield* store.tokenBucket({ ...opts, tokens: 1 })
 
         assert.strictEqual(remaining, 0)
         assert.closeTo(elapsedMillis, 1_000 / 6, 0.000_001)
@@ -151,7 +142,7 @@ export const suite = (
           onExceeded: "delay",
           window: "1 second",
           limit: 3,
-          key: options.key
+          key: opts.key
         })
         assert.strictEqual(result.remaining, -1)
         assert.closeTo(Duration.toMillis(result.delay), 1_000 / 6, 0.000_01)
@@ -161,21 +152,15 @@ export const suite = (
     it.effect("failed retries do not reserve tokens or move the refill boundary", () =>
       Effect.gen(function*() {
         const limiter = yield* RateLimiter.make
-        const options = {
-          algorithm: "token-bucket",
-          onExceeded: "fail",
-          window: "5 minutes",
-          limit: 5,
-          key: "timing-fail-boundary"
-        } as const
-        yield* limiter.consume({ ...options, tokens: 5 })
-        yield* Effect.flip(limiter.consume(options))
+        const opts = options("timing-fail-boundary", "fail")
+        yield* limiter.consume({ ...opts, tokens: 5 })
+        yield* Effect.flip(limiter.consume(opts))
         yield* TestClock.adjust("59 seconds")
-        yield* Effect.flip(limiter.consume(options))
-        yield* Effect.flip(limiter.consume(options))
+        yield* Effect.flip(limiter.consume(opts))
+        yield* Effect.flip(limiter.consume(opts))
         yield* TestClock.adjust("1 second")
 
-        const result = yield* limiter.consume(options)
+        const result = yield* limiter.consume(opts)
         assert.deepStrictEqual(result.delay, Duration.zero)
         assert.strictEqual(result.remaining, 0)
         assert.strictEqual(Duration.toMillis(result.resetAfter), 300_000)
@@ -184,17 +169,11 @@ export const suite = (
     it.effect("accumulated delay reservations retain the partial refill interval", () =>
       Effect.gen(function*() {
         const limiter = yield* RateLimiter.make
-        const options = {
-          algorithm: "token-bucket",
-          onExceeded: "delay",
-          window: "5 minutes",
-          limit: 5,
-          key: "timing-delay-reservations"
-        } as const
-        yield* limiter.consume({ ...options, tokens: 5 })
+        const opts = options("timing-delay-reservations", "delay")
+        yield* limiter.consume({ ...opts, tokens: 5 })
         yield* TestClock.adjust("59 seconds")
-        yield* limiter.consume(options)
-        const result = yield* limiter.consume(options)
+        yield* limiter.consume(opts)
+        const result = yield* limiter.consume(opts)
 
         assert.strictEqual(Duration.toMillis(result.delay), 61_000)
         assert.strictEqual(result.remaining, -2)

--- a/packages/effect/test/unstable/persistence/RateLimiterTest.ts
+++ b/packages/effect/test/unstable/persistence/RateLimiterTest.ts
@@ -151,6 +151,73 @@ export const suite = (
         assert.strictEqual(error.limit, 5)
       }))
 
+    for (const onExceeded of ["fail", "delay"] as const) {
+      it.effect(`${onExceeded}: fractional costs reset at the next whole-token refill`, () =>
+        Effect.gen(function*() {
+          const limiter = yield* RateLimiter.make
+          const opts = options(`fractional-reset-${onExceeded}`, onExceeded)
+          const initial = yield* limiter.consume({ ...opts, tokens: 0.5 })
+          yield* TestClock.adjust("45 seconds")
+          const partial = yield* limiter.consume({ ...opts, tokens: 0 })
+          yield* TestClock.adjust("15 seconds")
+          const full = yield* limiter.consume({ ...opts, tokens: 0 })
+
+          assert.strictEqual(full.remaining, 5)
+          assert.deepStrictEqual(
+            [initial, partial, full].map((result) => Duration.toMillis(result.resetAfter)),
+            [60_000, 15_000, 0]
+          )
+        }))
+    }
+
+    it.effect("fractional deficits remain rejected until the whole-token refill", () =>
+      Effect.gen(function*() {
+        const limiter = yield* RateLimiter.make
+        const opts = options("fractional-retry-boundary", "fail")
+        yield* limiter.consume({ ...opts, tokens: 4.5 })
+        yield* TestClock.adjust("45 seconds")
+        const first = exceeded(yield* Effect.flip(limiter.consume(opts)))
+        yield* TestClock.adjust(14_999)
+        const beforeRefill = exceeded(yield* Effect.flip(limiter.consume(opts)))
+        yield* TestClock.adjust(1)
+        const allowed = yield* limiter.consume(opts)
+
+        assert.deepStrictEqual(
+          [first, beforeRefill].map((error) => Duration.toMillis(error.retryAfter)),
+          [15_000, 1]
+        )
+        assert.strictEqual(allowed.remaining, 0.5)
+        assert.deepStrictEqual(allowed.delay, Duration.zero)
+      }))
+
+    it.effect("fractional delay reservations wait for enough whole-token refills", () =>
+      Effect.gen(function*() {
+        const limiter = yield* RateLimiter.make
+        const opts = options("fractional-reservation-boundary", "delay")
+        yield* limiter.consume({ ...opts, tokens: 4.5 })
+        yield* TestClock.adjust("45 seconds")
+        const first = yield* limiter.consume(opts)
+        const second = yield* limiter.consume({ ...opts, tokens: 1.25 })
+        yield* TestClock.adjust(74_999)
+        const beforeRefill = yield* limiter.consume({ ...opts, tokens: 0 })
+        yield* TestClock.adjust(1)
+        const available = yield* limiter.consume({ ...opts, tokens: 0 })
+
+        assert.deepStrictEqual(
+          [first, second, beforeRefill, available].map((result) => ({
+            remaining: result.remaining,
+            delay: Duration.toMillis(result.delay),
+            resetAfter: Duration.toMillis(result.resetAfter)
+          })),
+          [
+            { remaining: -0.5, delay: 15_000, resetAfter: 315_000 },
+            { remaining: -1.75, delay: 75_000, resetAfter: 375_000 },
+            { remaining: -0.75, delay: 1, resetAfter: 300_001 },
+            { remaining: 0.25, delay: 0, resetAfter: 300_000 }
+          ]
+        )
+      }))
+
     it.effect("preserves fractional elapsed milliseconds in the store tuple and timing metadata", () =>
       Effect.gen(function*() {
         const store = yield* RateLimiter.RateLimiterStore

--- a/packages/platform/node/test/NodeRedis.integration.test.ts
+++ b/packages/platform/node/test/NodeRedis.integration.test.ts
@@ -1,10 +1,10 @@
 import { NodeRedis } from "@effect/platform-node"
 import { assert, it } from "@effect/vitest"
 import { RedisContainer } from "@testcontainers/redis"
-import { Effect, Layer, Queue, Schema } from "effect"
+import { Duration, Effect, Layer, Queue, Schema } from "effect"
 import * as PersistedCacheTest from "effect-test/unstable/persistence/PersistedCacheTest"
 import * as PersistedQueueTest from "effect-test/unstable/persistence/PersistedQueueTest"
-import { tokenBucketTimingSuite } from "effect-test/unstable/persistence/RateLimiterTest"
+import * as RateLimiterTest from "effect-test/unstable/persistence/RateLimiterTest"
 import { TestClock } from "effect/testing"
 import { PersistedQueue, Persistence, RateLimiter, Redis } from "effect/unstable/persistence"
 import { createServer } from "node:net"
@@ -41,9 +41,57 @@ PersistedQueueTest.suite(
   }).pipe(Layer.provide(RedisLayer))
 )
 
-tokenBucketTimingSuite(
+RateLimiterTest.suite(
   "NodeRedis",
   RateLimiter.layerStoreRedis().pipe(Layer.provide(RedisLayer))
+)
+
+it.layer(RateLimiter.layerStoreRedis().pipe(Layer.provideMerge(RedisLayer)), { timeout: "30 seconds" })(
+  "RateLimiter token-bucket expiry (NodeRedis)",
+  (it) => {
+    for (const onExceeded of ["fail", "delay"] as const) {
+      it.effect(`${onExceeded}: restarts the refill interval after both Redis keys expire`, () =>
+        Effect.gen(function*() {
+          const redis = yield* Redis.Redis
+          const limiter = yield* RateLimiter.make
+          const options = {
+            algorithm: "token-bucket",
+            onExceeded,
+            window: "5 minutes",
+            limit: 5,
+            key: `timing-expired-${onExceeded}`
+          } as const
+          const key = `ratelimiter:${options.key}`
+          const refillKey = `${key}:refill`
+          yield* limiter.consume({ ...options, tokens: 5 })
+          yield* TestClock.adjust("359 seconds")
+
+          // TestClock does not advance Redis's expiry clock.
+          assert.strictEqual(yield* redis.send<number>("EXISTS", key, refillKey), 2)
+          assert.strictEqual(yield* redis.send<number>("PEXPIRE", key, "0"), 1)
+          assert.strictEqual(yield* redis.send<number>("PEXPIRE", refillKey, "0"), 1)
+          assert.strictEqual(yield* redis.send<number>("EXISTS", key, refillKey), 0)
+
+          const result = yield* limiter.consume({ ...options, tokens: 5 })
+          assert.strictEqual(result.remaining, 0)
+          assert.deepStrictEqual(result.delay, Duration.zero)
+          assert.strictEqual(Duration.toMillis(result.resetAfter), 300_000)
+
+          if (onExceeded === "fail") {
+            const error = yield* Effect.flip(limiter.consume(options))
+            if (error.reason._tag !== "RateLimitExceeded") {
+              throw new Error("Expected RateLimitExceeded")
+            }
+            assert.strictEqual(Duration.toMillis(error.reason.retryAfter), 60_000)
+          } else {
+            const delayed = yield* limiter.consume(options)
+            assert.strictEqual(delayed.remaining, -1)
+            assert.strictEqual(Duration.toMillis(delayed.delay), 60_000)
+            assert.strictEqual(Duration.toMillis(delayed.resetAfter), 360_000)
+          }
+        }))
+    }
+  }
 )
 
 const PersistedQueueRedisLayer = Layer.mergeAll(

--- a/packages/platform/node/test/NodeRedis.integration.test.ts
+++ b/packages/platform/node/test/NodeRedis.integration.test.ts
@@ -1,7 +1,7 @@
 import { NodeRedis } from "@effect/platform-node"
 import { assert, it } from "@effect/vitest"
 import { RedisContainer } from "@testcontainers/redis"
-import { Effect, Layer, Queue, Schema } from "effect"
+import { Clock, Duration, Effect, Layer, Queue, Schema } from "effect"
 import * as PersistedCacheTest from "effect-test/unstable/persistence/PersistedCacheTest"
 import * as PersistedQueueTest from "effect-test/unstable/persistence/PersistedQueueTest"
 import * as RateLimiterTest from "effect-test/unstable/persistence/RateLimiterTest"
@@ -49,6 +49,46 @@ RateLimiterTest.suite(
 it.layer(RateLimiter.layerStoreRedis().pipe(Layer.provideMerge(RedisLayer)), { timeout: "30 seconds" })(
   "RateLimiter token-bucket expiry (NodeRedis)",
   (it) => {
+    it.effect(
+      "does not restore capacity early after a fractional token cost",
+      () =>
+        Effect.gen(function*() {
+          const redis = yield* Redis.Redis
+          const store = yield* RateLimiter.RateLimiterStore
+          const memory = yield* RateLimiter.RateLimiterStore.pipe(Effect.provide(RateLimiter.layerStoreMemory))
+          const opts = {
+            key: "fractional-cost-expiry",
+            limit: 5,
+            refillRate: Duration.seconds(4),
+            allowOverflow: false
+          }
+          const key = `ratelimiter:${opts.key}`
+          const refillKey = `${key}:refill`
+          yield* memory.tokenBucket({ ...opts, tokens: 0.5 })
+          yield* store.tokenBucket({ ...opts, tokens: 0.5 })
+          const refillAt = Number(yield* redis.send<string>("GET", refillKey))
+          assert.isAbove(yield* redis.send<number>("PTTL", key), 0)
+
+          // Use wall time: the reported bug expires these keys after 2s, before the 4s refill.
+          yield* Effect.sleep("2500 millis")
+          const beforeRefill = {
+            keys: yield* redis.send<number>("EXISTS", key, refillKey),
+            tokens: yield* redis.send<string | null>("GET", key),
+            memoryRemaining: (yield* memory.tokenBucket({ ...opts, tokens: 0 }))[0],
+            redisRemaining: (yield* store.tokenBucket({ ...opts, tokens: 0 }))[0]
+          }
+          const elapsed = (yield* Clock.currentTimeMillis) - refillAt
+          assert.isAtLeast(elapsed, 2_500)
+          assert.isBelow(elapsed, 4_000)
+
+          yield* Effect.sleep(4_100 - elapsed)
+          assert.strictEqual((yield* memory.tokenBucket({ ...opts, tokens: 0 }))[0], 5)
+          assert.strictEqual((yield* store.tokenBucket({ ...opts, tokens: 0 }))[0], 5)
+          assert.deepStrictEqual(beforeRefill, { keys: 2, tokens: "4.5", memoryRemaining: 4.5, redisRemaining: 4.5 })
+        }).pipe(TestClock.withLive),
+      10_000
+    )
+
     for (const onExceeded of ["fail", "delay"] as const) {
       it.effect(`${onExceeded}: restarts the refill interval after both Redis keys expire`, () => {
         const key = `timing-expired-${onExceeded}`

--- a/packages/platform/node/test/NodeRedis.integration.test.ts
+++ b/packages/platform/node/test/NodeRedis.integration.test.ts
@@ -47,8 +47,19 @@ RateLimiterTest.suite(
 )
 
 it.layer(RateLimiter.layerStoreRedis().pipe(Layer.provideMerge(RedisLayer)), { timeout: "30 seconds" })(
-  "RateLimiter token-bucket expiry (NodeRedis)",
+  "RateLimiter token-bucket storage (NodeRedis)",
   (it) => {
+    it.effect("returns the persisted balance after accumulating fractional costs", () =>
+      Effect.gen(function*() {
+        const redis = yield* Redis.Redis
+        const key = "fractional-persisted-balance"
+        const results = yield* RateLimiterTest.consumeFractionalCosts(key)
+        const stored = Number(yield* redis.send<string>("GET", `ratelimiter:${key}`))
+
+        assert.strictEqual(stored, 3.9999999999999996)
+        assert.strictEqual(results[results.length - 1].remaining, stored)
+      }))
+
     it.effect(
       "does not restore capacity early after a fractional token cost",
       () =>

--- a/packages/platform/node/test/NodeRedis.integration.test.ts
+++ b/packages/platform/node/test/NodeRedis.integration.test.ts
@@ -1,7 +1,7 @@
 import { NodeRedis } from "@effect/platform-node"
 import { assert, it } from "@effect/vitest"
 import { RedisContainer } from "@testcontainers/redis"
-import { Duration, Effect, Layer, Queue, Schema } from "effect"
+import { Effect, Layer, Queue, Schema } from "effect"
 import * as PersistedCacheTest from "effect-test/unstable/persistence/PersistedCacheTest"
 import * as PersistedQueueTest from "effect-test/unstable/persistence/PersistedQueueTest"
 import * as RateLimiterTest from "effect-test/unstable/persistence/RateLimiterTest"
@@ -50,46 +50,21 @@ it.layer(RateLimiter.layerStoreRedis().pipe(Layer.provideMerge(RedisLayer)), { t
   "RateLimiter token-bucket expiry (NodeRedis)",
   (it) => {
     for (const onExceeded of ["fail", "delay"] as const) {
-      it.effect(`${onExceeded}: restarts the refill interval after both Redis keys expire`, () =>
-        Effect.gen(function*() {
+      it.effect(`${onExceeded}: restarts the refill interval after both Redis keys expire`, () => {
+        const key = `timing-expired-${onExceeded}`
+        const redisKey = `ratelimiter:${key}`
+        const refillKey = `${redisKey}:refill`
+        // TestClock does not advance Redis's expiry clock, so expire the keys by hand.
+        const idle = Effect.gen(function*() {
           const redis = yield* Redis.Redis
-          const limiter = yield* RateLimiter.make
-          const options = {
-            algorithm: "token-bucket",
-            onExceeded,
-            window: "5 minutes",
-            limit: 5,
-            key: `timing-expired-${onExceeded}`
-          } as const
-          const key = `ratelimiter:${options.key}`
-          const refillKey = `${key}:refill`
-          yield* limiter.consume({ ...options, tokens: 5 })
           yield* TestClock.adjust("359 seconds")
-
-          // TestClock does not advance Redis's expiry clock.
-          assert.strictEqual(yield* redis.send<number>("EXISTS", key, refillKey), 2)
-          assert.strictEqual(yield* redis.send<number>("PEXPIRE", key, "0"), 1)
+          assert.strictEqual(yield* redis.send<number>("EXISTS", redisKey, refillKey), 2)
+          assert.strictEqual(yield* redis.send<number>("PEXPIRE", redisKey, "0"), 1)
           assert.strictEqual(yield* redis.send<number>("PEXPIRE", refillKey, "0"), 1)
-          assert.strictEqual(yield* redis.send<number>("EXISTS", key, refillKey), 0)
-
-          const result = yield* limiter.consume({ ...options, tokens: 5 })
-          assert.strictEqual(result.remaining, 0)
-          assert.deepStrictEqual(result.delay, Duration.zero)
-          assert.strictEqual(Duration.toMillis(result.resetAfter), 300_000)
-
-          if (onExceeded === "fail") {
-            const error = yield* Effect.flip(limiter.consume(options))
-            if (error.reason._tag !== "RateLimitExceeded") {
-              throw new Error("Expected RateLimitExceeded")
-            }
-            assert.strictEqual(Duration.toMillis(error.reason.retryAfter), 60_000)
-          } else {
-            const delayed = yield* limiter.consume(options)
-            assert.strictEqual(delayed.remaining, -1)
-            assert.strictEqual(Duration.toMillis(delayed.delay), 60_000)
-            assert.strictEqual(Duration.toMillis(delayed.resetAfter), 360_000)
-          }
-        }))
+          assert.strictEqual(yield* redis.send<number>("EXISTS", redisKey, refillKey), 0)
+        })
+        return RateLimiterTest.restartsInterval(key, onExceeded, 5, idle)
+      })
     }
   }
 )

--- a/packages/platform/node/test/NodeRedis.integration.test.ts
+++ b/packages/platform/node/test/NodeRedis.integration.test.ts
@@ -4,8 +4,9 @@ import { RedisContainer } from "@testcontainers/redis"
 import { Effect, Layer, Queue, Schema } from "effect"
 import * as PersistedCacheTest from "effect-test/unstable/persistence/PersistedCacheTest"
 import * as PersistedQueueTest from "effect-test/unstable/persistence/PersistedQueueTest"
+import { tokenBucketTimingSuite } from "effect-test/unstable/persistence/RateLimiterTest"
 import { TestClock } from "effect/testing"
-import { PersistedQueue, Persistence, Redis } from "effect/unstable/persistence"
+import { PersistedQueue, Persistence, RateLimiter, Redis } from "effect/unstable/persistence"
 import { createServer } from "node:net"
 
 const RedisLayer = Layer.unwrap(
@@ -38,6 +39,11 @@ PersistedQueueTest.suite(
     pollInterval: "50 millis",
     lockRefreshInterval: "100 millis"
   }).pipe(Layer.provide(RedisLayer))
+)
+
+tokenBucketTimingSuite(
+  "NodeRedis",
+  RateLimiter.layerStoreRedis().pipe(Layer.provide(RedisLayer))
 )
 
 const PersistedQueueRedisLayer = Layer.mergeAll(


### PR DESCRIPTION
After exhausting five tokens in a five-minute window, retrying 59 seconds later now reports `retryAfter: 1s` instead of `60s`. Memory and Redis use whole-token refill boundaries for retry, delay, and reset timing, including fractional token costs.

Redis preserves signed fractional balances, so a remaining count of `-0.5` rejects instead of becoming `0`. Both tuple values use round-trip precision, keeping accumulated fractional balances and timing consistent with memory. Both keys expire when capacity actually refills, with the TTL rounded up to a millisecond. A 0.5-token cost with a 4s refill interval therefore keeps the bucket until the 4s boundary.

`RateLimiterStore.tokenBucket` now returns `readonly [remaining: number, elapsedMillis: number]` atomically. Custom stores must retain numeric precision in both values and provide elapsed time in milliseconds; returning `[remaining, 0]` retains the timing bug. Restart the interval only at full capacity after refill and before consumption. Otherwise, advance the boundary by whole refill intervals without restarting it on reads.

`resetAfter` measures time until full capacity with no further consumption, including reserved debt. Failed requests do not reserve debt.

Validation:

- Memory suite: 50 passed.
- Real Redis timing/expiry coverage: 30 passed; 21 unrelated tests excluded. Includes actual wall-clock expiry and accumulated fractional balances compared with persisted values.
- `pnpm check`, `pnpm lint-fix`, `pnpm lint`, and `git diff --check` passed.
- JSDoc checks report existing errors in unchanged `Multipart.ts` and `ChildProcess.ts`.
- Tests are unchanged from regression commit `eddbf84`.

Closes EFF-1297
