### PR TITLE
Fix JSDoc section formatting in multipart and process APIs

### DIFF
--- a/packages/effect/src/unstable/http/Multipart.ts
+++ b/packages/effect/src/unstable/http/Multipart.ts
@@ -100,6 +100,8 @@ export interface Field extends Part.Proto {
 /**
  * Returns `true` when a value has the multipart part type identifier.
  *
+ * **Details**
+ *
  * This includes `Field`, `File`, and `PersistedFile` values. Use
  * `isStreamPart` to identify only parsed, streamed parts.
  *

--- a/packages/effect/src/unstable/process/ChildProcess.ts
+++ b/packages/effect/src/unstable/process/ChildProcess.ts
@@ -249,6 +249,8 @@ export interface KillOptions {
    * before forcefully killing the child process by sending it the `"SIGKILL"`
    * signal. Defaults to `undefined`, so `"SIGKILL"` is never sent.
    *
+   * **Details**
+   *
    * The spawner decides whether to terminate descendants and how long to wait.
    * See its platform module documentation, such as `NodeChildProcessSpawner`.
    */


### PR DESCRIPTION
`pnpm jsdocs --check` failed with six diagnostics in `Multipart.isPart` and `ChildProcess.KillOptions.forceKillAfter`: multiple description paragraphs, content outside a standard section, and invalid section spacing.

Add `**Details**` headings above the existing explanatory paragraphs so both blocks follow the JSDoc format.

Validation passed:

- `nix develop -c pnpm jsdocs --check` (full extraction, zero diagnostics)
- `nix develop -c pnpm lint`
- `git diff --check`

No test changes are needed for this documentation formatting fix. No changeset is required for JSDoc maintenance.

Closes EFF-1302
