### PR TITLE
Refactor ByteSize exports to use explicit type annotations

### DIFF
--- a/packages/effect/src/ByteSize.ts
+++ b/packages/effect/src/ByteSize.ts
@@ -231,126 +231,126 @@ const unitConstructor = (symbol: Unit) => (value: number | bigint): ByteSize =>
  * @category constructors
  * @since 4.0.0
  */
-export const kilobytes = unitConstructor("kB")
+export const kilobytes: (value: number | bigint) => ByteSize = unitConstructor("kB")
 /**
  * Creates a decimal megabyte value.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const megabytes = unitConstructor("MB")
+export const megabytes: (value: number | bigint) => ByteSize = unitConstructor("MB")
 /**
  * Creates a decimal gigabyte value.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const gigabytes = unitConstructor("GB")
+export const gigabytes: (value: number | bigint) => ByteSize = unitConstructor("GB")
 /**
  * Creates a decimal terabyte value.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const terabytes = unitConstructor("TB")
+export const terabytes: (value: number | bigint) => ByteSize = unitConstructor("TB")
 /**
  * Creates a decimal petabyte value.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const petabytes = unitConstructor("PB")
+export const petabytes: (value: number | bigint) => ByteSize = unitConstructor("PB")
 /**
  * Creates a decimal exabyte value.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const exabytes = unitConstructor("EB")
+export const exabytes: (value: number | bigint) => ByteSize = unitConstructor("EB")
 /**
  * Creates a decimal zettabyte value.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const zettabytes = unitConstructor("ZB")
+export const zettabytes: (value: number | bigint) => ByteSize = unitConstructor("ZB")
 /**
  * Creates a decimal yottabyte value.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const yottabytes = unitConstructor("YB")
+export const yottabytes: (value: number | bigint) => ByteSize = unitConstructor("YB")
 /**
  * Creates a decimal ronnabyte value.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const ronnabytes = unitConstructor("RB")
+export const ronnabytes: (value: number | bigint) => ByteSize = unitConstructor("RB")
 /**
  * Creates a decimal quettabyte value.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const quettabytes = unitConstructor("QB")
+export const quettabytes: (value: number | bigint) => ByteSize = unitConstructor("QB")
 /**
  * Creates a binary kibibyte value.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const kibibytes = unitConstructor("KiB")
+export const kibibytes: (value: number | bigint) => ByteSize = unitConstructor("KiB")
 /**
  * Creates a binary mebibyte value.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const mebibytes = unitConstructor("MiB")
+export const mebibytes: (value: number | bigint) => ByteSize = unitConstructor("MiB")
 /**
  * Creates a binary gibibyte value.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const gibibytes = unitConstructor("GiB")
+export const gibibytes: (value: number | bigint) => ByteSize = unitConstructor("GiB")
 /**
  * Creates a binary tebibyte value.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const tebibytes = unitConstructor("TiB")
+export const tebibytes: (value: number | bigint) => ByteSize = unitConstructor("TiB")
 /**
  * Creates a binary pebibyte value.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const pebibytes = unitConstructor("PiB")
+export const pebibytes: (value: number | bigint) => ByteSize = unitConstructor("PiB")
 /**
  * Creates a binary exbibyte value.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const exbibytes = unitConstructor("EiB")
+export const exbibytes: (value: number | bigint) => ByteSize = unitConstructor("EiB")
 /**
  * Creates a binary zebibyte value.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const zebibytes = unitConstructor("ZiB")
+export const zebibytes: (value: number | bigint) => ByteSize = unitConstructor("ZiB")
 /**
  * Creates a binary yobibyte value.
  *
  * @category constructors
  * @since 4.0.0
  */
-export const yobibytes = unitConstructor("YiB")
+export const yobibytes: (value: number | bigint) => ByteSize = unitConstructor("YiB")
 
 /**
  * Checks whether a value is a byte size.
@@ -437,10 +437,10 @@ export const between: {
  * @category ordering
  * @since 4.0.0
  */
-export const min = BI.min as unknown as {
+export const min: {
   (that: ByteSize): (self: ByteSize) => ByteSize
   (self: ByteSize, that: ByteSize): ByteSize
-}
+} = BI.min as any
 
 /**
  * Returns the larger byte size.
@@ -448,10 +448,10 @@ export const min = BI.min as unknown as {
  * @category ordering
  * @since 4.0.0
  */
-export const max = BI.max as unknown as {
+export const max: {
   (that: ByteSize): (self: ByteSize) => ByteSize
   (self: ByteSize, that: ByteSize): ByteSize
-}
+} = BI.max as any
 
 /**
  * Constrains a byte size to an inclusive range.
@@ -459,10 +459,10 @@ export const max = BI.max as unknown as {
  * @category ordering
  * @since 4.0.0
  */
-export const clamp = BI.clamp as unknown as {
+export const clamp: {
   (options: { minimum: ByteSize; maximum: ByteSize }): (self: ByteSize) => ByteSize
   (self: ByteSize, options: { minimum: ByteSize; maximum: ByteSize }): ByteSize
-}
+} = BI.clamp as any
 
 /**
  * Checks whether the first byte size is less than the second.
@@ -525,10 +525,10 @@ export const equals: {
  * @category math
  * @since 4.0.0
  */
-export const sum = BI.sum as unknown as {
+export const sum: {
   (that: ByteSize): (self: ByteSize) => ByteSize
   (self: ByteSize, that: ByteSize): ByteSize
-}
+} = BI.sum as any
 
 /**
  * Subtracts byte sizes, returning `None` on underflow.
@@ -639,7 +639,7 @@ export const format = (self: ByteSize, options: FormatOptions = {}): string => {
  * @category math
  * @since 4.0.0
  */
-export const ReducerSum = BI.ReducerSum as unknown as Reducer.Reducer<ByteSize>
+export const ReducerSum: Reducer.Reducer<ByteSize> = BI.ReducerSum as any
 
 /**
  * Combiner that keeps the largest byte size.
@@ -647,7 +647,7 @@ export const ReducerSum = BI.ReducerSum as unknown as Reducer.Reducer<ByteSize>
  * @category math
  * @since 4.0.0
  */
-export const CombinerMax = BI.CombinerMax as unknown as Combiner.Combiner<ByteSize>
+export const CombinerMax: Combiner.Combiner<ByteSize> = BI.CombinerMax as any
 
 /**
  * Combiner that keeps the smallest byte size.
@@ -655,4 +655,4 @@ export const CombinerMax = BI.CombinerMax as unknown as Combiner.Combiner<ByteSi
  * @category math
  * @since 4.0.0
  */
-export const CombinerMin = BI.CombinerMin as unknown as Combiner.Combiner<ByteSize>
+export const CombinerMin: Combiner.Combiner<ByteSize> = BI.CombinerMin as any


### PR DESCRIPTION
ByteSize's unit constructors relied on inferred signatures, and several BigInt-backed exports placed their public types in assertions. Add explicit annotations to all 18 unit constructors and to `min`, `max`, `clamp`, `sum`, `ReducerSum`, `CombinerMax`, and `CombinerMin`, using the requested `as any` implementation casts.

Public signatures and runtime behavior are preserved, so no changeset is needed. No tests were added or changed.

Validation (all passed, run through `nix develop -c`):

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/ByteSize.test.ts` (11 tests)
- `pnpm test-types ByteSize` (TypeScript 5.9.3 and 6.0.3)
- `pnpm check`

Closes EFF-1304
