### PR TITLE
Reject file seeks before the start of the file

### DIFF
--- a/.changeset/fix-negative-file-seek.md
+++ b/.changeset/fix-negative-file-seek.md
@@ -1,0 +1,9 @@
+---
+"effect": patch
+"@effect/platform-node-shared": patch
+"@effect/platform-deno": patch
+---
+
+Reject file seeks before the start of the file on Node and Deno with a `PlatformError` whose reason is `BadArgument`, module is `FileSystem`, and method is `seek`. Failed seeks leave the cursor unchanged. Negative offsets remain valid when the resulting position is nonnegative.
+
+`FileSystem.File.seek` now returns `Effect<bigint, PlatformError>` instead of `Effect<bigint>`, so callers must account for the new error channel.

--- a/.changeset/fix-negative-file-seek.md
+++ b/.changeset/fix-negative-file-seek.md
@@ -4,6 +4,4 @@
 "@effect/platform-deno": patch
 ---
 
-Reject file seeks before the start of the file on Node and Deno with a `PlatformError` whose reason is `BadArgument`, module is `FileSystem`, and method is `seek`. Failed seeks leave the cursor unchanged. Negative offsets remain valid when the resulting position is nonnegative.
-
-`FileSystem.File.seek` now returns `Effect<bigint, PlatformError>` instead of `Effect<bigint>`, so callers must account for the new error channel.
+On Node and Deno, `FileSystem.File.seek` now rejects negative resulting positions with a `BadArgument` platform error, leaving the cursor unchanged. Its return type is now `Effect<bigint, PlatformError>`.

--- a/packages/effect/src/FileSystem.ts
+++ b/packages/effect/src/FileSystem.ts
@@ -854,7 +854,11 @@ export const isFile = (u: unknown): u is File => hasProperty(u, FileTypeId)
 export interface File {
   readonly [FileTypeId]: typeof FileTypeId
   readonly stat: Effect.Effect<File.Info, PlatformError>
-  readonly seek: (offset: bigint, from: SeekMode) => Effect.Effect<bigint>
+  /**
+   * Moves the cursor and returns its new position. Fails with `BadArgument`
+   * without moving the cursor if the resulting position would be negative.
+   */
+  readonly seek: (offset: bigint, from: SeekMode) => Effect.Effect<bigint, PlatformError>
   readonly sync: Effect.Effect<void, PlatformError>
   readonly read: (buffer: Uint8Array) => Effect.Effect<number, PlatformError>
   readonly readAlloc: (size: number) => Effect.Effect<Option.Option<Uint8Array>, PlatformError>

--- a/packages/effect/src/FileSystem.ts
+++ b/packages/effect/src/FileSystem.ts
@@ -855,8 +855,7 @@ export interface File {
   readonly [FileTypeId]: typeof FileTypeId
   readonly stat: Effect.Effect<File.Info, PlatformError>
   /**
-   * Moves the cursor and returns its new position. Fails with `BadArgument`
-   * without moving the cursor if the resulting position would be negative.
+   * Seeks before the start fail with `BadArgument` and leave the cursor unchanged.
    */
   readonly seek: (offset: bigint, from: SeekMode) => Effect.Effect<bigint, PlatformError>
   readonly sync: Effect.Effect<void, PlatformError>

--- a/packages/effect/test/FileSystem.test-utils.ts
+++ b/packages/effect/test/FileSystem.test-utils.ts
@@ -305,22 +305,42 @@ export const testLayer = <E>(layer: Layer.Layer<Fs.FileSystem, E>, options: Test
       )
     })))
 
-  it("should retain signed cursor positions before the start of the file", () =>
-    runPromise(Effect.gen(function*() {
-      const fs = yield* Fs.FileSystem
+  it.each([
+    { offset: BigInt(-1), from: "start" as const },
+    { offset: BigInt(-3), from: "start" as const },
+    { offset: BigInt(-6), from: "current" as const },
+    { offset: BigInt(-8), from: "current" as const }
+  ])(
+    "should reject seeks before the start of the file ($offset from $from)",
+    ({ from, offset }) =>
+      runPromise(Effect.gen(function*() {
+        const fs = yield* Fs.FileSystem
 
-      yield* Effect.gen(function*() {
-        const file = yield* fs.open(`${__dirname}/fixtures/text.txt`)
-        assert.strictEqual(yield* file.seek(BigInt(-1), "start"), BigInt(-1))
-        assert.strictEqual(yield* file.seek(BigInt(-2), "current"), BigInt(-3))
-        assert.strictEqual(yield* file.seek(BigInt(0), "current"), BigInt(-3))
-        assert.strictEqual(yield* file.seek(BigInt(3), "current"), BigInt(0))
+        yield* Effect.gen(function*() {
+          const file = yield* fs.open(`${__dirname}/fixtures/text.txt`)
+          const buffer = new Uint8Array(5)
+          assert.strictEqual(yield* file.read(buffer), 5)
+          assert.strictEqual(new TextDecoder().decode(buffer), "lorem")
 
-        const buffer = new Uint8Array(5)
-        assert.strictEqual(yield* file.read(buffer), 5)
-        assert.strictEqual(new TextDecoder().decode(buffer), "lorem")
-      }).pipe(Effect.scoped)
-    })))
+          const result = yield* Effect.result(file.seek(offset, from))
+          expect(result).toMatchObject({
+            _tag: "Failure",
+            failure: {
+              _tag: "PlatformError",
+              reason: { _tag: "BadArgument", module: "FileSystem", method: "seek" }
+            }
+          })
+          assert.strictEqual(yield* file.seek(BigInt(0), "current"), BigInt(5))
+          assert.strictEqual(yield* file.read(buffer), 5)
+          assert.strictEqual(new TextDecoder().decode(buffer), " ipsu")
+          assert.strictEqual(yield* file.seek(BigInt(0), "current"), BigInt(10))
+
+          assert.strictEqual(yield* file.seek(BigInt(-10), "current"), BigInt(0))
+          assert.strictEqual(yield* file.read(buffer), 5)
+          assert.strictEqual(new TextDecoder().decode(buffer), "lorem")
+        }).pipe(Effect.scoped)
+      }))
+  )
 
   it("should report invalid read allocations as defects", () =>
     runPromise(Effect.gen(function*() {

--- a/packages/effect/typetest/FileSystem.tst.ts
+++ b/packages/effect/typetest/FileSystem.tst.ts
@@ -1,4 +1,4 @@
-import type { ByteSize, Effect, FileSystem } from "effect"
+import type { ByteSize, Effect, FileSystem, PlatformError } from "effect"
 import { describe, expect, it } from "tstyche"
 
 describe("FileSystem", () => {
@@ -10,7 +10,7 @@ describe("FileSystem", () => {
     >()
     expect<Parameters<FileSystem.File["truncate"]>[0]>().type.toBe<number | undefined>()
     expect<Parameters<FileSystem.File["seek"]>[0]>().type.toBe<bigint>()
-    expect<ReturnType<FileSystem.File["seek"]>>().type.toBe<Effect.Effect<bigint>>()
+    expect<ReturnType<FileSystem.File["seek"]>>().type.toBe<Effect.Effect<bigint, PlatformError.PlatformError>>()
     expect<Effect.Success<ReturnType<FileSystem.File["read"]>>>().type.toBe<number>()
     expect<Effect.Success<ReturnType<FileSystem.File["write"]>>>().type.toBe<number>()
   })

--- a/packages/platform/deno/src/DenoFileSystem.ts
+++ b/packages/platform/deno/src/DenoFileSystem.ts
@@ -209,13 +209,17 @@ class FileImpl implements FileSystem.File {
   }
 
   seek(offset: bigint, from: FileSystem.SeekMode) {
-    return Effect.sync(() => {
-      if (from === "start") {
-        this.position = offset
-      } else {
-        this.position += offset
+    return Effect.suspend(() => {
+      const position = from === "start" ? offset : this.position + offset
+      if (position < BigInt(0)) {
+        return Effect.fail(PlatformError.badArgument({
+          module: "FileSystem",
+          method: "seek",
+          description: "Cannot seek before the start of the file"
+        }))
       }
-      return this.position
+      this.position = position
+      return Effect.succeed(position)
     })
   }
 

--- a/packages/platform/node-shared/src/NodeFileSystem.ts
+++ b/packages/platform/node-shared/src/NodeFileSystem.ts
@@ -276,14 +276,17 @@ const makeFile = (() => {
     }
 
     seek(offset: bigint, from: FileSystem.SeekMode) {
-      return Effect.sync(() => {
-        if (from === "start") {
-          this.position = offset
-        } else if (from === "current") {
-          this.position = this.position + offset
+      return Effect.suspend(() => {
+        const position = from === "start" ? offset : this.position + offset
+        if (position < BigInt(0)) {
+          return Effect.fail(Error.badArgument({
+            module: "FileSystem",
+            method: "seek",
+            description: "Cannot seek before the start of the file"
+          }))
         }
-
-        return this.position
+        this.position = position
+        return Effect.succeed(position)
       })
     }
 


### PR DESCRIPTION
File seeks before the start currently succeed and leave a negative cursor, causing later I/O to fail or, for Node's `-1` sentinel, read from the wrong position. Node and Deno now reject negative resulting positions with `PlatformError` (`BadArgument`, module `FileSystem`, method `seek`) before changing the cursor. Backward seeks to nonnegative positions remain valid.

`FileSystem.File.seek` now exposes `PlatformError` in its error channel. Includes a changeset and regression coverage for both seek modes, cursor preservation, subsequent reads, and the updated return type. The implementation commit leaves the tests from the preceding tests commit unchanged.

Validation:

- Node filesystem suite: 36 passed.
- Deno filesystem suite: 34 passed, 1 skipped.
- FileSystem type tests: all 16 assertions passed across TypeScript 5.9.3 and 6.0.3.
- `nix develop -c pnpm check`, `nix develop -c pnpm lint-fix`, `nix develop -c pnpm lint`, and `git diff --check` passed.
- `nix develop -c pnpm jsdocs --check` reports two errors in unchanged `packages/effect/src/Logger.ts`: an out-of-order `@see` and an unresolved `consolePretty` link.

Runtime commands: `nix develop -c pnpm test --run packages/platform/node-shared/test/NodeFileSystem.test.ts` and `nix develop -c deno task test --run packages/platform/deno/test/DenoFileSystem.test.ts`. Type-test command: `nix develop -c pnpm test-types FileSystem.tst.ts`.

Closes EFF-1305
