### PR TITLE
Fix oversized byte ranges in HttpStaticServer

### DIFF
--- a/.changeset/fix-static-oversized-ranges.md
+++ b/.changeset/fix-static-oversized-ranges.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Parse HttpStaticServer byte range integers exactly, including values above Number.MAX_SAFE_INTEGER. Oversized starts now return 416 with Content-Range instead of falling back to 200. Oversized ends clamp to the last byte, and oversized suffixes return the whole file as 206.

--- a/packages/effect/src/unstable/http/HttpStaticServer.ts
+++ b/packages/effect/src/unstable/http/HttpStaticServer.ts
@@ -305,12 +305,11 @@ const resolveMimeType = (path: Path.Path, filePath: string, mimeTypes: Record<st
   return mimeTypes[extension.slice(1)] ?? "application/octet-stream"
 }
 
-const parseInteger = (value: string): number | undefined => {
+const parseInteger = (value: string): bigint | undefined => {
   if (!/^\d+$/.test(value)) {
     return undefined
   }
-  const parsed = Number(value)
-  return Number.isSafeInteger(parsed) ? parsed : undefined
+  return BigInt(value)
 }
 
 const parseRange = (
@@ -338,16 +337,17 @@ const parseRange = (
   if (startPart === "" && endPart === "") {
     return undefined
   }
+  const size = BigInt(fileSize)
   if (startPart === "") {
     const suffixLength = parseInteger(endPart)
     if (suffixLength === undefined) {
       return undefined
     }
-    if (suffixLength === 0 || fileSize === 0) {
+    if (suffixLength === BigInt(0) || fileSize === 0) {
       return "unsatisfiable"
     }
     return {
-      start: Math.max(fileSize - suffixLength, 0),
+      start: suffixLength >= size ? 0 : Number(size - suffixLength),
       end: fileSize - 1
     }
   }
@@ -356,11 +356,11 @@ const parseRange = (
     return undefined
   }
   if (endPart === "") {
-    if (start >= fileSize) {
+    if (start >= size) {
       return "unsatisfiable"
     }
     return {
-      start,
+      start: Number(start),
       end: fileSize - 1
     }
   }
@@ -368,12 +368,12 @@ const parseRange = (
   if (end === undefined) {
     return undefined
   }
-  if (start > end || start >= fileSize) {
+  if (start > end || start >= size) {
     return "unsatisfiable"
   }
   return {
-    start,
-    end: Math.min(end, fileSize - 1)
+    start: Number(start),
+    end: end >= size ? fileSize - 1 : Number(end)
   }
 }
 

--- a/packages/platform/node/test/HttpStaticServer.test.ts
+++ b/packages/platform/node/test/HttpStaticServer.test.ts
@@ -181,11 +181,14 @@ describe("HttpStaticServer", () => {
 
   const unsafeRangeInteger = (BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1)).toString()
 
-  it("returns 416 for a range start above Number.MAX_SAFE_INTEGER", async () => {
+  it.each([
+    `bytes=${unsafeRangeInteger}-`,
+    `bytes=${unsafeRangeInteger}-${unsafeRangeInteger}`
+  ])("returns 416 for a range start above Number.MAX_SAFE_INTEGER: %s", async (range) => {
     await withStaticFiles(async ({ handler }) => {
       const fullBody = await handler(new Request("http://localhost/range.txt")).then((response) => response.text())
       const response = await handler(
-        new Request("http://localhost/range.txt", { headers: { Range: `bytes=${unsafeRangeInteger}-` } })
+        new Request("http://localhost/range.txt", { headers: { Range: range } })
       )
 
       assert.strictEqual(response.status, 416)
@@ -206,6 +209,20 @@ describe("HttpStaticServer", () => {
       assert.strictEqual(response.headers.get("content-range"), `bytes 0-${fullBody.length - 1}/${fullBody.length}`)
       assert.strictEqual(response.headers.get("content-length"), String(fullBody.length))
       assert.strictEqual(await response.text(), fullBody)
+    })
+  })
+
+  it("clamps a range end above Number.MAX_SAFE_INTEGER while preserving a nonzero start", async () => {
+    await withStaticFiles(async ({ handler }) => {
+      const fullBody = await handler(new Request("http://localhost/range.txt")).then((response) => response.text())
+      const response = await handler(
+        new Request("http://localhost/range.txt", { headers: { Range: `bytes=5-${unsafeRangeInteger}` } })
+      )
+
+      assert.strictEqual(response.status, 206)
+      assert.strictEqual(response.headers.get("content-range"), `bytes 5-${fullBody.length - 1}/${fullBody.length}`)
+      assert.strictEqual(response.headers.get("content-length"), String(fullBody.length - 5))
+      assert.strictEqual(await response.text(), fullBody.slice(5))
     })
   })
 

--- a/packages/platform/node/test/HttpStaticServer.test.ts
+++ b/packages/platform/node/test/HttpStaticServer.test.ts
@@ -180,17 +180,30 @@ describe("HttpStaticServer", () => {
   })
 
   const unsafeRangeInteger = (BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1)).toString()
+
+  it("returns 416 for a range start above Number.MAX_SAFE_INTEGER", async () => {
+    await withStaticFiles(async ({ handler }) => {
+      const fullBody = await handler(new Request("http://localhost/range.txt")).then((response) => response.text())
+      const response = await handler(
+        new Request("http://localhost/range.txt", { headers: { Range: `bytes=${unsafeRangeInteger}-` } })
+      )
+
+      assert.strictEqual(response.status, 416)
+      assert.strictEqual(response.headers.get("content-range"), `bytes */${fullBody.length}`)
+      assert.strictEqual(await response.text(), "")
+    })
+  })
+
   it.each([
-    `bytes=${unsafeRangeInteger}-`,
     `bytes=0-${unsafeRangeInteger}`,
     `bytes=-${unsafeRangeInteger}`
-  ])("ignores range integers above Number.MAX_SAFE_INTEGER: %s", async (range) => {
+  ])("returns the whole file as 206 for range ends and suffixes above Number.MAX_SAFE_INTEGER: %s", async (range) => {
     await withStaticFiles(async ({ handler }) => {
       const fullBody = await handler(new Request("http://localhost/range.txt")).then((response) => response.text())
       const response = await handler(new Request("http://localhost/range.txt", { headers: { Range: range } }))
 
-      assert.strictEqual(response.status, 200)
-      assert.strictEqual(response.headers.get("content-range"), null)
+      assert.strictEqual(response.status, 206)
+      assert.strictEqual(response.headers.get("content-range"), `bytes 0-${fullBody.length - 1}/${fullBody.length}`)
       assert.strictEqual(response.headers.get("content-length"), String(fullBody.length))
       assert.strictEqual(await response.text(), fullBody)
     })


### PR DESCRIPTION
HttpStaticServer currently falls back to a full `200` response when a Range integer exceeds `Number.MAX_SAFE_INTEGER`. Parse these integers as `bigint` and check them against the file size before converting to numeric offsets. Oversized starts return `416` with `Content-Range`; oversized ends clamp to the last byte, and oversized suffixes return the whole file as `206`.

Replaces the three pinned `200` expectations with regression coverage and adds an `effect` patch changeset. Those three regressions were verified to fail before the implementation. Coverage also checks oversized starts with explicit ends and oversized ends with nonzero starts.

Validation passed:

- `nix develop -c pnpm test --run packages/platform/node/test/HttpStaticServer.test.ts` (16 tests)
- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`

Closes EFF-1307
