### PR TITLE
Clamp HttpPlatform file responses to the available bytes

### DIFF
--- a/.changeset/fix-http-platform-file-ranges.md
+++ b/.changeset/fix-http-platform-file-ranges.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Clamp HttpPlatform file response ranges to the file size so Content-Length matches the bytes available. Oversized reads stop at EOF, and offsets at or past EOF return an empty body with Content-Length 0. Apply the same clamping to the default Web file response implementation.

--- a/packages/effect/src/unstable/http/HttpPlatform.ts
+++ b/packages/effect/src/unstable/http/HttpPlatform.ts
@@ -94,10 +94,13 @@ export const make: (impl: {
     fileResponse: Effect.fnUntraced(function*(path, options) {
       const info = yield* fs.stat(path)
       const etag = yield* etagGen.fromFileInfo(info)
-      const start = options?.offset === undefined ? 0 : Number(ByteSize.fromInputUnsafe(options.offset))
-      const end = options?.bytesToRead !== undefined
-        ? start + Number(ByteSize.fromInputUnsafe(options.bytesToRead))
-        : undefined
+      const size = Number(info.size)
+      const start = Math.min(options?.offset === undefined ? 0 : Number(ByteSize.fromInputUnsafe(options.offset)), size)
+      const available = size - start
+      const contentLength = options?.bytesToRead === undefined
+        ? available
+        : Math.min(Number(ByteSize.fromInputUnsafe(options.bytesToRead)), available)
+      const end = options?.bytesToRead === undefined ? undefined : start + contentLength
       const headers = Headers.set(
         options?.headers ? Headers.fromInput(options.headers) : Headers.empty,
         "etag",
@@ -106,7 +109,6 @@ export const make: (impl: {
       if (Option.isSome(info.mtime)) {
         ;(headers as any)["last-modified"] = info.mtime.value.toUTCString()
       }
-      const contentLength = end !== undefined ? end - start : Number(info.size) - start
       return impl.fileResponse(
         path,
         options?.status ?? 200,
@@ -165,10 +167,13 @@ export const layer = Layer.effect(HttpPlatform)(
         )
       },
       fileWebResponse(file, status, statusText, headers, options) {
-        const offset = options?.offset ?? 0
-        const bytesToRead = options?.bytesToRead
+        const offset = Math.min(Math.max(options?.offset ?? 0, 0), file.size)
+        const available = file.size - offset
+        const contentLength = options?.bytesToRead === undefined
+          ? available
+          : Math.min(Math.max(options.bytesToRead, 0), available)
         const chunkSize = options?.chunkSize !== undefined ? Math.max(1, options.chunkSize) : Infinity
-        const end = offset + (bytesToRead ?? Infinity)
+        const end = offset + contentLength
         const stream = end <= offset
           ? Stream.empty
           : Stream.fromReadableStream({
@@ -195,7 +200,7 @@ export const layer = Layer.effect(HttpPlatform)(
             Stream.map((chunk) => chunk.bytes)
           )
         return Response.stream(stream, {
-          contentLength: bytesToRead ?? file.size - offset,
+          contentLength,
           headers,
           status,
           statusText

--- a/packages/effect/test/unstable/http/HttpPlatform.test.ts
+++ b/packages/effect/test/unstable/http/HttpPlatform.test.ts
@@ -26,20 +26,36 @@ describe("HttpPlatform", () => {
       Effect.provideService(FileSystem.FileSystem, {} as any)
     ))
 
-  it.effect("retains the requested Web file content length beyond EOF", () =>
-    Effect.gen(function*() {
-      const platform = yield* HttpPlatform.HttpPlatform
-      const response = yield* platform.fileWebResponse(file, { offset: 1, bytesToRead: 10 })
-      assert.strictEqual(response.body._tag, "Stream")
-      if (response.body._tag === "Stream") {
-        assert.strictEqual(response.body.contentLength, 10)
-        const bytes = yield* Stream.mkUint8Array(response.body.stream)
-        assert.deepStrictEqual(Array.from(bytes), [2, 3, 4])
-      }
-    }).pipe(
-      Effect.provide(HttpPlatform.layer),
-      Effect.provideService(FileSystem.FileSystem, {} as any)
-    ))
+  for (
+    const { name, offset, bytesToRead, expected } of [
+      { name: "clamps bytesToRead beyond EOF", offset: 1, bytesToRead: 10, expected: [2, 3, 4] },
+      { name: "returns an empty body at EOF", offset: 4, bytesToRead: undefined, expected: [] },
+      { name: "returns an empty body past EOF", offset: 9, bytesToRead: undefined, expected: [] },
+      { name: "clamps bytesToRead at EOF", offset: 4, bytesToRead: 10, expected: [] },
+      { name: "clamps bytesToRead past EOF", offset: 9, bytesToRead: 10, expected: [] }
+    ]
+  ) {
+    it.effect(`fileWebResponse ${name}`, () =>
+      Effect.gen(function*() {
+        const platform = yield* HttpPlatform.HttpPlatform
+        const response = yield* platform.fileWebResponse(file, { offset, bytesToRead })
+        assert.strictEqual(response.body._tag, "Stream")
+        if (response.body._tag === "Stream") {
+          const bytes = yield* Stream.mkUint8Array(response.body.stream)
+          assert.deepStrictEqual(
+            {
+              contentLength: response.body.contentLength,
+              header: response.headers["content-length"],
+              body: Array.from(bytes)
+            },
+            { contentLength: expected.length, header: String(expected.length), body: expected }
+          )
+        }
+      }).pipe(
+        Effect.provide(HttpPlatform.layer),
+        Effect.provideService(FileSystem.FileSystem, {} as any)
+      ))
+  }
 
   it.effect("honors Web file chunk size", () =>
     Effect.gen(function*() {

--- a/packages/platform/bun/test/BunHttpPlatform.test.ts
+++ b/packages/platform/bun/test/BunHttpPlatform.test.ts
@@ -4,13 +4,82 @@ import * as ByteSize from "effect/ByteSize"
 import * as Effect from "effect/Effect"
 import type * as HttpBody from "effect/unstable/http/HttpBody"
 import * as HttpPlatform from "effect/unstable/http/HttpPlatform"
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse"
 
 const readBody = (body: HttpBody.HttpBody) => {
   assert.strictEqual(body._tag, "Raw")
   return Effect.promise(() => new Response((body as HttpBody.Raw).body as BodyInit).text())
 }
 
+// Bun sets Content-Length when sending the raw file, so inspect the HTTP response.
+const readResponse = (response: HttpServerResponse.HttpServerResponse) =>
+  Effect.acquireUseRelease(
+    Effect.sync(() =>
+      Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        fetch: () => HttpServerResponse.toWeb(response)
+      })
+    ),
+    (server) =>
+      Effect.promise(async (signal) => {
+        const response = await fetch(server.url, { signal })
+        return { contentLength: response.headers.get("content-length"), body: await response.text() }
+      }),
+    (server) =>
+      Effect.promise(async () => {
+        await server.stop(true)
+      })
+  )
+
 describe("BunHttpPlatform", () => {
+  for (
+    const { name, offset, bytesToRead, expected } of [
+      { name: "clamps bytesToRead beyond EOF", offset: 1, bytesToRead: 10, expected: "bcd" },
+      { name: "returns an empty body at EOF", offset: 4, bytesToRead: undefined, expected: "" },
+      { name: "returns an empty body past EOF", offset: 9, bytesToRead: undefined, expected: "" },
+      { name: "clamps bytesToRead at EOF", offset: 4, bytesToRead: 10, expected: "" },
+      { name: "clamps bytesToRead past EOF", offset: 9, bytesToRead: 10, expected: "" }
+    ]
+  ) {
+    it.effect(`fileWebResponse ${name}`, () =>
+      Effect.gen(function*() {
+        const platform = yield* HttpPlatform.HttpPlatform
+        const file = new File(["abcd"], "file.txt", { type: "text/plain", lastModified: 0 })
+        const response = yield* platform.fileWebResponse(file, { offset, bytesToRead })
+        assert.deepStrictEqual(
+          yield* readResponse(response),
+          { contentLength: String(expected.length), body: expected }
+        )
+      }).pipe(Effect.provide(BunHttpPlatform.layer)))
+  }
+
+  for (
+    const { name, offsetFromEnd, bytesToRead } of [
+      { name: "clamps bytesToRead beyond EOF", offsetFromEnd: -5, bytesToRead: 100 },
+      { name: "returns an empty body at EOF", offsetFromEnd: 0, bytesToRead: undefined },
+      { name: "returns an empty body past EOF", offsetFromEnd: 5, bytesToRead: undefined },
+      { name: "clamps bytesToRead at EOF", offsetFromEnd: 0, bytesToRead: 100 },
+      { name: "clamps bytesToRead past EOF", offsetFromEnd: 5, bytesToRead: 100 }
+    ]
+  ) {
+    it.effect(`fileResponse ${name}`, () =>
+      Effect.gen(function*() {
+        const platform = yield* HttpPlatform.HttpPlatform
+        const file = Bun.file(import.meta.filename)
+        const contents = yield* Effect.promise(() => file.text())
+        const expected = offsetFromEnd < 0 ? contents.slice(offsetFromEnd) : ""
+        const response = yield* platform.fileResponse(import.meta.filename, {
+          offset: ByteSize.bytes(file.size + offsetFromEnd),
+          bytesToRead: bytesToRead === undefined ? undefined : ByteSize.bytes(bytesToRead)
+        })
+        assert.deepStrictEqual(
+          yield* readResponse(response),
+          { contentLength: String(expected.length), body: expected }
+        )
+      }).pipe(Effect.provide(BunHttpPlatform.layer)))
+  }
+
   it.effect("fileWebResponse honors offset and bytesToRead including zero", () =>
     Effect.gen(function*() {
       const platform = yield* HttpPlatform.HttpPlatform

--- a/packages/platform/deno/test/DenoHttpPlatform.test.ts
+++ b/packages/platform/deno/test/DenoHttpPlatform.test.ts
@@ -19,6 +19,29 @@ const readBody = (body: HttpBody.HttpBody) => {
 }
 
 describe("DenoHttpPlatform", () => {
+  for (
+    const { name, offset, bytesToRead, expected } of [
+      { name: "clamps bytesToRead beyond EOF", offset: 1, bytesToRead: 10, expected: "bcd" },
+      { name: "returns an empty body at EOF", offset: 4, bytesToRead: undefined, expected: "" },
+      { name: "returns an empty body past EOF", offset: 9, bytesToRead: undefined, expected: "" },
+      { name: "clamps bytesToRead at EOF", offset: 4, bytesToRead: 10, expected: "" },
+      { name: "clamps bytesToRead past EOF", offset: 9, bytesToRead: 10, expected: "" }
+    ]
+  ) {
+    it.effect(`fileWebResponse ${name}`, () =>
+      Effect.gen(function*() {
+        const platform = yield* HttpPlatform.HttpPlatform
+        const file = new File(["abcd"], "file.txt", { type: "text/plain", lastModified: 0 })
+        const response = yield* platform.fileWebResponse(file, { offset, bytesToRead })
+        const text = yield* readBody(response.body)
+
+        assert.deepStrictEqual(
+          { contentLength: response.headers["content-length"], body: text },
+          { contentLength: String(expected.length), body: expected }
+        )
+      }).pipe(Effect.provide(DenoHttpPlatform.layer)))
+  }
+
   it.effect("fileResponse preserves open failures as defects after stat succeeds", () =>
     Effect.gen(function*() {
       const fs = yield* FileSystem.FileSystem
@@ -77,19 +100,31 @@ describe("DenoHttpPlatform", () => {
       assert.strictEqual(text, "ipsum")
     }).pipe(Effect.provide(DenoHttpPlatform.layer)))
 
-  it.effect("fileResponse retains the requested content length beyond EOF", () =>
-    Effect.gen(function*() {
-      const platform = yield* HttpPlatform.HttpPlatform
-      const response = yield* platform.fileResponse(fixture, {
-        offset: ByteSize.bytes(6),
-        bytesToRead: ByteSize.bytes(100)
-      })
+  for (
+    const { name, offset, bytesToRead, expected } of [
+      { name: "clamps bytesToRead beyond EOF", offset: 22, bytesToRead: 100, expected: "amet\n" },
+      { name: "returns an empty body at EOF", offset: 27, bytesToRead: undefined, expected: "" },
+      { name: "returns an empty body past EOF", offset: 50, bytesToRead: undefined, expected: "" },
+      { name: "clamps bytesToRead at EOF", offset: 27, bytesToRead: 100, expected: "" },
+      { name: "clamps bytesToRead past EOF", offset: 50, bytesToRead: 100, expected: "" }
+    ]
+  ) {
+    it.effect(`fileResponse ${name}`, () =>
+      Effect.gen(function*() {
+        const platform = yield* HttpPlatform.HttpPlatform
+        const response = yield* platform.fileResponse(fixture, {
+          offset: ByteSize.bytes(offset),
+          bytesToRead: bytesToRead === undefined ? undefined : ByteSize.bytes(bytesToRead)
+        })
 
-      assert.strictEqual(response.headers["content-length"], "100")
-      assert.strictEqual(response.body._tag, "Raw")
-      const text = yield* readStream((response.body as HttpBody.Raw).body as ReadableStream<Uint8Array>)
-      assert.strictEqual(text, "ipsum dolar sit amet\n")
-    }).pipe(Effect.provide(DenoHttpPlatform.layer)))
+        assert.strictEqual(response.body._tag, "Raw")
+        const text = yield* readStream((response.body as HttpBody.Raw).body as ReadableStream<Uint8Array>)
+        assert.deepStrictEqual(
+          { contentLength: response.headers["content-length"], body: text },
+          { contentLength: String(expected.length), body: expected }
+        )
+      }).pipe(Effect.provide(DenoHttpPlatform.layer)))
+  }
 
   it.effect("fileResponse supports zero bytesToRead", () =>
     Effect.gen(function*() {

--- a/packages/platform/node/test/NodeHttpPlatform.test.ts
+++ b/packages/platform/node/test/NodeHttpPlatform.test.ts
@@ -34,19 +34,31 @@ describe("NodeHttpPlatform", () => {
       assert.strictEqual(text, "ipsum")
     }).pipe(Effect.provide(NodeHttpPlatform.layer)))
 
-  it.effect("fileResponse retains the requested content length beyond EOF", () =>
-    Effect.gen(function*() {
-      const platform = yield* HttpPlatform.HttpPlatform
-      const response = yield* platform.fileResponse(`${__dirname}/fixtures/text.txt`, {
-        offset: ByteSize.bytes(6),
-        bytesToRead: ByteSize.bytes(100)
-      })
+  for (
+    const { name, offset, bytesToRead, expected } of [
+      { name: "clamps bytesToRead beyond EOF", offset: 22, bytesToRead: 100, expected: "amet\n" },
+      { name: "returns an empty body at EOF", offset: 27, bytesToRead: undefined, expected: "" },
+      { name: "returns an empty body past EOF", offset: 50, bytesToRead: undefined, expected: "" },
+      { name: "clamps bytesToRead at EOF", offset: 27, bytesToRead: 100, expected: "" },
+      { name: "clamps bytesToRead past EOF", offset: 50, bytesToRead: 100, expected: "" }
+    ]
+  ) {
+    it.effect(`fileResponse ${name}`, () =>
+      Effect.gen(function*() {
+        const platform = yield* HttpPlatform.HttpPlatform
+        const response = yield* platform.fileResponse(`${__dirname}/fixtures/text.txt`, {
+          offset: ByteSize.bytes(offset),
+          bytesToRead: bytesToRead === undefined ? undefined : ByteSize.bytes(bytesToRead)
+        })
 
-      assert.strictEqual(response.headers["content-length"], "100")
-      assert.strictEqual(response.body._tag, "Raw")
-      const text = yield* readStream((response.body as HttpBody.Raw).body as Readable)
-      assert.strictEqual(text, "ipsum dolar sit amet\n")
-    }).pipe(Effect.provide(NodeHttpPlatform.layer)))
+        assert.strictEqual(response.body._tag, "Raw")
+        const text = yield* readStream((response.body as HttpBody.Raw).body as Readable)
+        assert.deepStrictEqual(
+          { contentLength: response.headers["content-length"], body: text },
+          { contentLength: String(expected.length), body: expected }
+        )
+      }).pipe(Effect.provide(NodeHttpPlatform.layer)))
+  }
 
   it.effect("fileResponse supports zero bytesToRead", () =>
     Effect.gen(function*() {


### PR DESCRIPTION
File responses could advertise more bytes than their bodies contain, including negative Content-Length values for offsets past EOF. Clamp the start and requested length to the file size in `HttpPlatform.make` and the default Web layer. A 100-byte read with only 5 bytes available now advertises 5; offsets at or past EOF return an empty body with Content-Length 0.

Includes regression coverage for Node, Deno, Bun, and the default Web layer, plus an `effect` patch changeset. The tests were committed separately and reproduced 12 failures before this fix.

Validation passed:

- Node/default Web, HttpBody, and HttpStaticServer: 22 tests.
- DenoHttpPlatform: 14 tests.
- BunHttpPlatform: 12 tests, including HTTP header checks.
- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`

Closes EFF-1306
