### PR TITLE
Fix invalid File.readAlloc sizes on Node and Deno

### DIFF
--- a/.changeset/fix-read-alloc-invalid-sizes.md
+++ b/.changeset/fix-read-alloc-invalid-sizes.md
@@ -1,0 +1,6 @@
+---
+"@effect/platform-node-shared": patch
+"@effect/platform-deno": patch
+---
+
+Fix `File.readAlloc` on Node and Deno to fail with `PlatformError` (`BadArgument`) for negative, fractional, non-finite, or unallocatable sizes without moving the cursor. Zero-size reads continue to return `Option.none()` without moving the cursor.

--- a/packages/effect/test/FileSystem.test-utils.ts
+++ b/packages/effect/test/FileSystem.test-utils.ts
@@ -1,5 +1,5 @@
 import { assert, expect, it } from "@effect/vitest"
-import { Array, ByteSize, Cause, Result } from "effect"
+import { Array, ByteSize, Cause, Option, Result } from "effect"
 import * as Effect from "effect/Effect"
 import * as Fs from "effect/FileSystem"
 import type * as Layer from "effect/Layer"
@@ -322,19 +322,49 @@ export const testLayer = <E>(layer: Layer.Layer<Fs.FileSystem, E>, options: Test
       }).pipe(Effect.scoped)
     })))
 
-  it("should report invalid read allocations as defects", () =>
+  it.each([-1, 1.5, NaN, Infinity, Number.MAX_VALUE])(
+    "readAlloc(%s) fails with BadArgument without moving the cursor",
+    (size) =>
+      runPromise(Effect.gen(function*() {
+        const fs = yield* Fs.FileSystem
+
+        yield* Effect.gen(function*() {
+          const file = yield* fs.open(`${__dirname}/fixtures/text.txt`)
+          const first = yield* file.readAlloc(6).pipe(Effect.flatMap(Effect.fromOption))
+          assert.strictEqual(new TextDecoder().decode(first), "lorem ")
+
+          const exit = yield* Effect.exit(file.readAlloc(size))
+          const position = yield* file.seek(BigInt(0), "current")
+          const next = yield* file.readAlloc(5).pipe(Effect.flatMap(Effect.fromOption))
+
+          assert.strictEqual(position, BigInt(6))
+          assert.strictEqual(new TextDecoder().decode(next), "ipsum")
+          assert(exit._tag === "Failure")
+          assert.isFalse(Cause.hasDies(exit.cause))
+          const error = Cause.findErrorOption(exit.cause)
+          assert(Option.isSome(error))
+          assert.strictEqual(error.value._tag, "PlatformError")
+          assert.strictEqual(error.value.reason._tag, "BadArgument")
+          assert.strictEqual(error.value.reason.module, "FileSystem")
+          assert.strictEqual(error.value.reason.method, "readAlloc")
+        }).pipe(Effect.scoped)
+      }))
+  )
+
+  it("readAlloc(0) returns None without moving the cursor", () =>
     runPromise(Effect.gen(function*() {
       const fs = yield* Fs.FileSystem
 
       yield* Effect.gen(function*() {
         const file = yield* fs.open(`${__dirname}/fixtures/text.txt`)
-        const exit = yield* Effect.exit(file.readAlloc(-1))
-        assert.strictEqual(exit._tag, "Failure")
-        if (exit._tag === "Failure") {
-          assert.isTrue(Cause.hasDies(exit.cause))
-          assert.isFalse(Cause.hasFails(exit.cause))
-        }
-        assert.strictEqual(yield* file.seek(BigInt(0), "current"), BigInt(0))
+        const first = yield* file.readAlloc(6).pipe(Effect.flatMap(Effect.fromOption))
+        assert.strictEqual(new TextDecoder().decode(first), "lorem ")
+
+        assert.deepStrictEqual(yield* file.readAlloc(0), Option.none())
+        assert.strictEqual(yield* file.seek(BigInt(0), "current"), BigInt(6))
+
+        const next = yield* file.readAlloc(5).pipe(Effect.flatMap(Effect.fromOption))
+        assert.strictEqual(new TextDecoder().decode(next), "ipsum")
       }).pipe(Effect.scoped)
     })))
 

--- a/packages/platform/deno/src/DenoFileSystem.ts
+++ b/packages/platform/deno/src/DenoFileSystem.ts
@@ -247,31 +247,27 @@ class FileImpl implements FileSystem.File {
   }
 
   readAlloc(size: number) {
-    return Effect.flatMap(
-      Effect.try({
-        try: () => {
-          if (!Number.isInteger(size) || size < 0) {
-            throw new RangeError("size must be a non-negative integer")
-          }
-          return new Uint8Array(size)
-        },
-        catch: (cause) =>
-          PlatformError.badArgument({
-            module: "FileSystem",
-            method: "readAlloc",
-            description: `Could not allocate a buffer of size ${size}`,
-            cause
-          })
-      }),
-      (buffer) => {
+    return Effect.suspend(() => {
+      try {
+        if (!Number.isInteger(size) || size < 0) {
+          throw new RangeError("size must be a non-negative integer")
+        }
+        const buffer = new Uint8Array(size)
         return Effect.map(this.readChunk("readAlloc", buffer), (bytesRead) => {
           if (bytesRead === 0) {
             return Option.none()
           }
           return Option.some(bytesRead === size ? buffer : buffer.subarray(0, bytesRead))
         })
+      } catch (cause) {
+        return Effect.fail(PlatformError.badArgument({
+          module: "FileSystem",
+          method: "readAlloc",
+          description: `Could not allocate a buffer of size ${size}`,
+          cause
+        }))
       }
-    )
+    })
   }
 
   truncate(length?: number) {

--- a/packages/platform/deno/src/DenoFileSystem.ts
+++ b/packages/platform/deno/src/DenoFileSystem.ts
@@ -247,15 +247,31 @@ class FileImpl implements FileSystem.File {
   }
 
   readAlloc(size: number) {
-    return Effect.suspend(() => {
-      const buffer = new Uint8Array(size)
-      return Effect.map(this.readChunk("readAlloc", buffer), (bytesRead) => {
-        if (bytesRead === 0) {
-          return Option.none()
-        }
-        return Option.some(bytesRead === size ? buffer : buffer.subarray(0, bytesRead))
-      })
-    })
+    return Effect.flatMap(
+      Effect.try({
+        try: () => {
+          if (!Number.isInteger(size) || size < 0) {
+            throw new RangeError("size must be a non-negative integer")
+          }
+          return new Uint8Array(size)
+        },
+        catch: (cause) =>
+          PlatformError.badArgument({
+            module: "FileSystem",
+            method: "readAlloc",
+            description: `Could not allocate a buffer of size ${size}`,
+            cause
+          })
+      }),
+      (buffer) => {
+        return Effect.map(this.readChunk("readAlloc", buffer), (bytesRead) => {
+          if (bytesRead === 0) {
+            return Option.none()
+          }
+          return Option.some(bytesRead === size ? buffer : buffer.subarray(0, bytesRead))
+        })
+      }
+    )
   }
 
   truncate(length?: number) {

--- a/packages/platform/node-shared/src/NodeFileSystem.ts
+++ b/packages/platform/node-shared/src/NodeFileSystem.ts
@@ -301,17 +301,12 @@ const makeFile = (() => {
     }
 
     readAlloc(size: number) {
-      return Effect.flatMap(
-        Effect.try({
-          try: () => {
-            if (!Number.isInteger(size) || size < 0) {
-              throw new RangeError("size must be a non-negative integer")
-            }
-            return Buffer.allocUnsafeSlow(size)
-          },
-          catch: handleBadArgument("readAlloc")
-        }),
-        (buffer) => {
+      return Effect.suspend(() => {
+        try {
+          if (!Number.isInteger(size) || size < 0) {
+            throw new RangeError("size must be a non-negative integer")
+          }
+          const buffer = Buffer.allocUnsafeSlow(size)
           const position = this.position
           return Effect.map(
             nodeReadAlloc(this.fd, { buffer, position }),
@@ -330,8 +325,10 @@ const makeFile = (() => {
               return Option.some(dst)
             }
           )
+        } catch (cause) {
+          return Effect.fail(handleBadArgument("readAlloc")(cause))
         }
-      )
+      })
     }
 
     truncate(length?: number) {

--- a/packages/platform/node-shared/src/NodeFileSystem.ts
+++ b/packages/platform/node-shared/src/NodeFileSystem.ts
@@ -301,27 +301,37 @@ const makeFile = (() => {
     }
 
     readAlloc(size: number) {
-      return Effect.suspend(() => {
-        const buffer = Buffer.allocUnsafeSlow(size)
-        const position = this.position
-        return Effect.map(
-          nodeReadAlloc(this.fd, { buffer, position }),
-          (bytesRead): Option.Option<Buffer> => {
-            if (bytesRead === 0) {
-              return Option.none()
+      return Effect.flatMap(
+        Effect.try({
+          try: () => {
+            if (!Number.isInteger(size) || size < 0) {
+              throw new RangeError("size must be a non-negative integer")
             }
+            return Buffer.allocUnsafeSlow(size)
+          },
+          catch: handleBadArgument("readAlloc")
+        }),
+        (buffer) => {
+          const position = this.position
+          return Effect.map(
+            nodeReadAlloc(this.fd, { buffer, position }),
+            (bytesRead): Option.Option<Buffer> => {
+              if (bytesRead === 0) {
+                return Option.none()
+              }
 
-            this.position = position + BigInt(bytesRead)
-            if (bytesRead === size) {
-              return Option.some(buffer)
+              this.position = position + BigInt(bytesRead)
+              if (bytesRead === size) {
+                return Option.some(buffer)
+              }
+
+              const dst = Buffer.allocUnsafeSlow(bytesRead)
+              buffer.copy(dst, 0, 0, bytesRead)
+              return Option.some(dst)
             }
-
-            const dst = Buffer.allocUnsafeSlow(bytesRead)
-            buffer.copy(dst, 0, 0, bytesRead)
-            return Option.some(dst)
-          }
-        )
-      })
+          )
+        }
+      )
     }
 
     truncate(length?: number) {


### PR DESCRIPTION
`File.readAlloc` now fails with `PlatformError` (`BadArgument`, `FileSystem.readAlloc`) for negative, fractional, non-finite, and unallocatable sizes on Node and Deno. Previously, `1.5` consumed one byte, Deno accepted `NaN` as an empty read, and other invalid allocations surfaced as defects.

Validate and allocate before reading so rejected sizes preserve the cursor. `readAlloc(0)` continues to return `Option.none()` without moving the cursor. Includes shared regression coverage and a patch changeset for both platform packages.

Validation passed:

- Node file-system suite: 38 tests.
- Deno file-system suite: 36 tests, 1 existing skip.
- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm check`
- `nix develop -c deno check packages/platform/deno/src/DenoFileSystem.ts`

Closes EFF-1308
