### PR TITLE
Add changeset for CookiesError tag fix

### DIFF
--- a/.changeset/cookies-error-tag.md
+++ b/.changeset/cookies-error-tag.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix the `CookiesError` tag in `effect/unstable/http` from `CookieError` to `CookiesError` to match the class name.


### PR DESCRIPTION
Adds an `effect` patch changeset for #8064, documenting the correction of the `CookiesError` tag from `CookieError` to `CookiesError` in `effect/unstable/http`.

Depends on #8064, which is still open. Merge this changeset with or after that fix.

Validation: `nix develop -c pnpm lint-fix`, `nix develop -c pnpm exec changeset status --since origin/main`, and `git diff --check` passed. Changesets reports patch releases for the configured fixed version group. No runtime code changed.

Closes EFF-1311
