### PR TITLE
Skip optional stack capture when stackTraceLimit is zero

### DIFF
--- a/.changeset/skip-disabled-stack-capture.md
+++ b/.changeset/skip-disabled-stack-capture.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Skip optional stack capture when `Error.stackTraceLimit` is zero in `Effect.fn`, spans, layer and middleware service definitions, and atom labels. Preserve named spans and explicit stack callbacks, and avoid raising a zero limit when formatting causes.

--- a/.changeset/skip-disabled-stack-capture.md
+++ b/.changeset/skip-disabled-stack-capture.md
@@ -2,4 +2,6 @@
 "effect": patch
 ---
 
-Skip optional stack capture when `Error.stackTraceLimit` is zero in `Effect.fn`, spans, layer and middleware service definitions, and atom labels. Preserve named spans and explicit stack callbacks, and avoid raising a zero limit when formatting causes.
+Skip optional stack capture when `Error.stackTraceLimit` is zero in `Effect.fn`, spans, layer and middleware service definitions, and atom labels. Preserve named spans and enabled stack locations, and leave a zero limit unchanged when formatting causes.
+
+Explicit span options remain supported at a zero global limit: `captureStackTrace: true` opts into capture, and a supplied stack callback is preserved. The `stack` property on `LayerMap.Service`, `LayerRef.Service`, `HttpApiMiddleware.Service`, and `RpcMiddleware.Service` definitions is `undefined` when defined at limit zero; positive limits retain the definition location.

--- a/.changeset/skip-disabled-stack-capture.md
+++ b/.changeset/skip-disabled-stack-capture.md
@@ -2,6 +2,4 @@
 "effect": patch
 ---
 
-Skip optional stack capture when `Error.stackTraceLimit` is zero in `Effect.fn`, spans, layer and middleware service definitions, and atom labels. Preserve named spans and enabled stack locations, and leave a zero limit unchanged when formatting causes.
-
-Explicit span options remain supported at a zero global limit: `captureStackTrace: true` opts into capture, and a supplied stack callback is preserved. The `stack` property on `LayerMap.Service`, `LayerRef.Service`, `HttpApiMiddleware.Service`, and `RpcMiddleware.Service` definitions is `undefined` when defined at limit zero; positive limits retain the definition location.
+Skip optional stack capture when `Error.stackTraceLimit` is zero.

--- a/packages/effect/src/LayerMap.ts
+++ b/packages/effect/src/LayerMap.ts
@@ -431,11 +431,13 @@ export const Service = <Self>() =>
   Options extends { readonly dependencies: ReadonlyArray<Layer.Layer<any, any, any>> } ? Options["dependencies"][number]
     : never
 > => {
-  const Err = globalThis.Error as any
   const limit = getStackTraceLimit()
-  setStackTraceLimit(2)
-  const creationError = new Err()
-  setStackTraceLimit(limit)
+  let creationError: Error | undefined
+  if (limit !== 0) {
+    setStackTraceLimit(2)
+    creationError = new globalThis.Error()
+    setStackTraceLimit(limit)
+  }
 
   function TagClass() {}
   const TagClass_ = TagClass as any as Mutable<TagClass<Self, Id, string, any, any, any, any, any>>
@@ -443,7 +445,7 @@ export const Service = <Self>() =>
   TagClass.key = id
   Object.defineProperty(TagClass, "stack", {
     get() {
-      return creationError.stack
+      return creationError?.stack
     }
   })
 

--- a/packages/effect/src/LayerRef.ts
+++ b/packages/effect/src/LayerRef.ts
@@ -349,11 +349,13 @@ export const Service = <Self>() =>
   [Preload] extends [true] ? E : never,
   Deps[number]
 > => {
-  const Err = globalThis.Error as any
   const limit = getStackTraceLimit()
-  setStackTraceLimit(2)
-  const creationError = new Err()
-  setStackTraceLimit(limit)
+  let creationError: Error | undefined
+  if (limit !== 0) {
+    setStackTraceLimit(2)
+    creationError = new globalThis.Error()
+    setStackTraceLimit(limit)
+  }
 
   function TagClass() {}
   const TagClass_ = TagClass as any as Mutable<TagClass<Self, Id, any, any, any, any, any>>
@@ -361,7 +363,7 @@ export const Service = <Self>() =>
   TagClass.key = id
   Object.defineProperty(TagClass, "stack", {
     get() {
-      return creationError.stack
+      return creationError?.stack
     }
   })
 

--- a/packages/effect/src/Utils.ts
+++ b/packages/effect/src/Utils.ts
@@ -11,6 +11,7 @@
  * @since 2.0.0
  */
 import type { Kind, TypeLambda } from "./HKT.ts"
+import { getStackTraceLimit } from "./internal/stackTraceLimit.ts"
 import type * as Types from "./Types.ts"
 
 /**
@@ -219,7 +220,8 @@ const pickInternalCall = (): <A>(body: () => A) => A => {
     }
   }
 
-  const isNotOptimizedAway = standard[InternalTypeId](() => new Error().stack)?.includes(InternalTypeId) === true
+  const isNotOptimizedAway = getStackTraceLimit() !== 0 &&
+    standard[InternalTypeId](() => new Error().stack)?.includes(InternalTypeId) === true
 
   return isNotOptimizedAway ? standard[InternalTypeId] : forced[InternalTypeId]
 }

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -364,7 +364,7 @@ export const causePrettyErrors = <E>(self: Cause.Cause<E>, options?: {
     errors.push(causePrettyError(error, interrupts[0].annotations, options))
   }
 
-  setStackTraceLimit(prevStackLimit)
+  if (prevStackLimit !== 0) setStackTraceLimit(prevStackLimit)
   return errors
 }
 

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -339,7 +339,7 @@ export const causePrettyErrors = <E>(self: Cause.Cause<E>, options?: {
   if (self.reasons.length === 0) return errors
 
   const prevStackLimit = getStackTraceLimit()
-  setStackTraceLimit(1)
+  if (prevStackLimit !== 0) setStackTraceLimit(1)
 
   for (const failure of self.reasons) {
     if (failure._tag === "Interrupt") {
@@ -1285,9 +1285,12 @@ export const fn: typeof Effect.fn = function() {
   const spanOptions = nameFirst ? arguments[1] : undefined
 
   const prevLimit = getStackTraceLimit()
-  setStackTraceLimit(2)
-  const defError = new globalThis.Error()
-  setStackTraceLimit(prevLimit)
+  let defError: Error | undefined
+  if (prevLimit !== 0) {
+    setStackTraceLimit(2)
+    defError = new globalThis.Error()
+    setStackTraceLimit(prevLimit)
+  }
 
   if (nameFirst) {
     return (body: Function | { readonly self: any }, ...pipeables: Array<Function>) =>
@@ -1307,7 +1310,7 @@ export const fn: typeof Effect.fn = function() {
 const makeFn = (
   name: string,
   bodyOrOptions: Function | { readonly self: any },
-  defError: Error,
+  defError: Error | undefined,
   pipeables: Array<Function>,
   addSpan: boolean,
   spanOptions: Tracer.SpanOptionsNoTrace | undefined
@@ -1328,9 +1331,12 @@ const makeFn = (
       return result
     }
     const prevLimit = getStackTraceLimit()
-    setStackTraceLimit(2)
-    const callError = new globalThis.Error()
-    setStackTraceLimit(prevLimit)
+    let callError: Error | undefined
+    if (prevLimit !== 0) {
+      setStackTraceLimit(2)
+      callError = new globalThis.Error()
+      setStackTraceLimit(prevLimit)
+    }
     return updateService(
       addSpan ?
         useSpan(name, spanOptions!, (span) => provideParentSpan(result, span)) :
@@ -1338,10 +1344,10 @@ const makeFn = (
       CurrentStackFrame,
       (prev) => ({
         name,
-        stack: fnStackCleaner(() => callError.stack),
+        stack: callError ? fnStackCleaner(() => callError.stack) : constUndefined,
         parent: {
           name: `${name} (definition)`,
-          stack: fnStackCleaner(() => defError.stack),
+          stack: defError ? fnStackCleaner(() => defError.stack) : constUndefined,
           parent: prev
         }
       })

--- a/packages/effect/src/internal/tracer.ts
+++ b/packages/effect/src/internal/tracer.ts
@@ -16,7 +16,7 @@ export const addSpanStackTrace = <A extends Tracer.TraceOptions>(
     return options
   }
   const limit = getStackTraceLimit()
-  if (limit === 0) {
+  if (limit === 0 && options?.captureStackTrace !== true) {
     return { ...options, captureStackTrace: false } as A
   }
   setStackTraceLimit(3)

--- a/packages/effect/src/internal/tracer.ts
+++ b/packages/effect/src/internal/tracer.ts
@@ -16,6 +16,9 @@ export const addSpanStackTrace = <A extends Tracer.TraceOptions>(
     return options
   }
   const limit = getStackTraceLimit()
+  if (limit === 0) {
+    return { ...options, captureStackTrace: false } as A
+  }
   setStackTraceLimit(3)
   const traceError = new Error()
   setStackTraceLimit(limit)

--- a/packages/effect/src/unstable/httpapi/HttpApiMiddleware.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiMiddleware.ts
@@ -352,17 +352,19 @@ export const Service = <
     readonly requiredForClient?: boolean | undefined
   } | undefined
 ) => {
-  const Err = globalThis.Error as any
   const limit = getStackTraceLimit()
-  setStackTraceLimit(2)
-  const creationError = new Err()
-  setStackTraceLimit(limit)
+  let creationError: globalThis.Error | undefined
+  if (limit !== 0) {
+    setStackTraceLimit(2)
+    creationError = new globalThis.Error()
+    setStackTraceLimit(limit)
+  }
 
   class Service extends Context.Service<Self, any>()(id) {}
   const self = Service as any
   Object.defineProperty(Service, "stack", {
     get() {
-      return creationError.stack
+      return creationError?.stack
     }
   })
   self[TypeId] = TypeId

--- a/packages/effect/src/unstable/reactivity/Atom.ts
+++ b/packages/effect/src/unstable/reactivity/Atom.ts
@@ -22,6 +22,7 @@ import type { LazyArg } from "../../Function.ts"
 import { constant, constTrue, constVoid, dual, pipe } from "../../Function.ts"
 import type * as Inspectable from "../../Inspectable.ts"
 import { PipeInspectableProto } from "../../internal/core.ts"
+import { getStackTraceLimit } from "../../internal/stackTraceLimit.ts"
 import * as Layer from "../../Layer.ts"
 import * as MutableHashMap from "../../MutableHashMap.ts"
 import * as Option from "../../Option.ts"
@@ -1587,7 +1588,7 @@ export const withLabel: {
 >(2, (self, name) =>
   Object.assign(Object.create(Object.getPrototypeOf(self)), {
     ...self,
-    label: [name, new Error().stack?.split("\n")[5] ?? ""]
+    label: [name, getStackTraceLimit() === 0 ? "" : new Error().stack?.split("\n")[5] ?? ""]
   }))
 
 /**
@@ -2517,7 +2518,7 @@ export const serializable: {
   const codecJson = Schema.toCodecJson(options.schema)
   return Object.assign(Object.create(Object.getPrototypeOf(self)), {
     ...self,
-    label: self.label ?? [options.key, new Error().stack?.split("\n")[5] ?? ""],
+    label: self.label ?? [options.key, getStackTraceLimit() === 0 ? "" : new Error().stack?.split("\n")[5] ?? ""],
     [SerializableTypeId]: {
       key: options.key,
       encode: Schema.encodeSync(codecJson),

--- a/packages/effect/src/unstable/rpc/RpcMiddleware.ts
+++ b/packages/effect/src/unstable/rpc/RpcMiddleware.ts
@@ -292,11 +292,13 @@ export const Service = <
     readonly requiredForClient?: boolean | undefined
   }
 ) => {
-  const Err = globalThis.Error as any
   const limit = getStackTraceLimit()
-  setStackTraceLimit(2)
-  const creationError = new Err()
-  setStackTraceLimit(limit)
+  let creationError: globalThis.Error | undefined
+  if (limit !== 0) {
+    setStackTraceLimit(2)
+    creationError = new globalThis.Error()
+    setStackTraceLimit(limit)
+  }
 
   function ServiceClass() {}
   const ServiceClass_ = ServiceClass as any as Mutable<AnyService>
@@ -304,7 +306,7 @@ export const Service = <
   ServiceClass.key = id
   Object.defineProperty(ServiceClass, "stack", {
     get() {
-      return creationError.stack
+      return creationError?.stack
     }
   })
   ServiceClass_[TypeId] = TypeId

--- a/packages/effect/test/StackCapture.test.ts
+++ b/packages/effect/test/StackCapture.test.ts
@@ -1,0 +1,175 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Cause, Context, Effect, Exit, References } from "effect"
+
+const withStackTraceLimit = <A>(limit: number, run: () => A): A => {
+  const original = Object.getOwnPropertyDescriptor(Error, "stackTraceLimit")
+  Object.defineProperty(Error, "stackTraceLimit", { value: limit, writable: true, configurable: true })
+  try {
+    return run()
+  } finally {
+    if (original) {
+      Object.defineProperty(Error, "stackTraceLimit", original)
+    } else {
+      Reflect.deleteProperty(Error, "stackTraceLimit")
+    }
+  }
+}
+
+// A zero-length stack still costs a capture in workerd, so inspect construction
+// rather than only checking the resulting stack string.
+const observeErrors = <A>(run: () => A) => {
+  const original = globalThis.Error
+  let constructions = 0
+  const limits: Array<unknown> = []
+  globalThis.Error = new Proxy(original, {
+    construct(target, args, newTarget) {
+      constructions++
+      return Reflect.construct(target, args, newTarget)
+    },
+    set(target, key, value) {
+      if (key === "stackTraceLimit") limits.push(value)
+      return Reflect.set(target, key, value)
+    }
+  })
+  try {
+    return { value: run(), constructions, limits }
+  } finally {
+    globalThis.Error = original
+  }
+}
+
+// These tests mutate Error globally and must not overlap with each other.
+describe("stack capture", { concurrent: false }, () => {
+  for (const named of [false, true]) {
+    describe(named ? "named Effect.fn" : "unnamed Effect.fn", () => {
+      const define = () => {
+        const body = function*(value: number) {
+          return yield* Effect.succeed(value + 1)
+        }
+        return named ? Effect.fn("increment")(body) : Effect.fn(body)
+      }
+
+      it("does not construct an Error at definition when stackTraceLimit is zero", () => {
+        const observed = withStackTraceLimit(0, () => observeErrors(define))
+        assert.strictEqual(observed.constructions, 0)
+        assert.isTrue(observed.limits.every((limit) => limit === 0))
+        assert.strictEqual(Effect.runSync(observed.value(1)), 2)
+      })
+
+      it("does not construct an Error at invocation when stackTraceLimit is zero", () => {
+        const fn = withStackTraceLimit(10, define)
+        const observed = withStackTraceLimit(0, () => observeErrors(() => Effect.runSync(fn(1))))
+        assert.strictEqual(observed.value, 2)
+        assert.strictEqual(observed.constructions, 0)
+        assert.isTrue(observed.limits.every((limit) => limit === 0))
+      })
+
+      it("preserves failures when stack capture is disabled", () => {
+        const exit = withStackTraceLimit(0, () => {
+          const body = function*() {
+            return yield* Effect.fail("boom")
+          }
+          const fn = named ? Effect.fn("failure")(body) : Effect.fn(body)
+          return Effect.runSyncExit(fn())
+        })
+        assert.isTrue(Exit.isFailure(exit))
+        if (Exit.isFailure(exit)) {
+          assert.include(Cause.pretty(exit.cause), "boom")
+        }
+      })
+
+      it("preserves definition and invocation locations when stack capture is enabled", () => {
+        const frame = withStackTraceLimit(10, () => {
+          const body = function*() {
+            return yield* References.CurrentStackFrame
+          }
+          const fn = named ? Effect.fn("traced")(body) : Effect.fn(body)
+          const effect = fn()
+          assert.strictEqual(Error.stackTraceLimit, 10)
+          return Effect.runSync(effect)
+        })
+        assert.isDefined(frame)
+        assert.strictEqual(frame!.name, named ? "traced" : "Effect.fn")
+        assert.match(frame!.stack()!, /StackCapture\.test\.ts:\d+:\d+/)
+        assert.strictEqual(frame!.parent!.name, `${named ? "traced" : "Effect.fn"} (definition)`)
+        assert.match(frame!.parent!.stack()!, /StackCapture\.test\.ts:\d+:\d+/)
+        assert.notStrictEqual(frame!.stack(), frame!.parent!.stack())
+      })
+    })
+  }
+
+  for (const limit of [0, 10]) {
+    it(`named Effect.fn preserves spans and attributes with stackTraceLimit ${limit}`, () => {
+      const span = withStackTraceLimit(limit, () => {
+        const fn = Effect.fn("named span", { attributes: { operation: "regression" } })(function*() {
+          return yield* Effect.currentSpan
+        })
+        return Effect.runSync(fn())
+      })
+      assert.strictEqual(span.name, "named span")
+      assert.strictEqual(span.attributes.get("operation"), "regression")
+    })
+  }
+
+  for (
+    const [name, wrap] of [
+      ["withSpan data-first", (effect: Effect.Effect<string>) => Effect.withSpan(effect, "span")],
+      ["withSpan data-last", (effect: Effect.Effect<string>) => effect.pipe(Effect.withSpan("span"))],
+      ["withSpanScoped", (effect: Effect.Effect<string>) => Effect.scoped(Effect.withSpanScoped(effect, "span"))]
+    ] as const
+  ) {
+    it(`${name} does not construct an Error when stackTraceLimit is zero`, () => {
+      const observed = withStackTraceLimit(
+        0,
+        () =>
+          observeErrors(() => Effect.runSync(wrap(Effect.map(Effect.orDie(Effect.currentSpan), (span) => span.name))))
+      )
+      assert.strictEqual(observed.value, "span")
+      assert.strictEqual(observed.constructions, 0)
+      assert.isTrue(observed.limits.every((limit) => limit === 0))
+    })
+  }
+
+  it("withSpan preserves failure locations when stack capture is enabled", () => {
+    const exit = withStackTraceLimit(10, () => {
+      const effect = Effect.withSpan(Effect.fail("boom"), "traced span")
+      assert.strictEqual(Error.stackTraceLimit, 10)
+      return Effect.runSyncExit(effect)
+    })
+    assert.isTrue(Exit.isFailure(exit))
+    if (Exit.isFailure(exit)) {
+      const frame = Context.getUnsafe(Cause.annotations(exit.cause), Cause.StackTrace)
+      assert.strictEqual(frame.name, "traced span")
+      assert.match(frame.stack()!, /StackCapture\.test\.ts:\d+:\d+/)
+      assert.include(Cause.pretty(exit.cause), "boom")
+    }
+  })
+
+  it("withSpan honors captureStackTrace false when the global limit is positive", () => {
+    const observed = withStackTraceLimit(
+      10,
+      () =>
+        observeErrors(() =>
+          Effect.runSync(Effect.withSpan(References.CurrentStackFrame, "span", { captureStackTrace: false }))
+        )
+    )
+    assert.strictEqual(observed.constructions, 0)
+    assert.strictEqual(observed.value!.name, "span")
+    assert.isUndefined(observed.value!.stack())
+  })
+
+  it("withSpan preserves a supplied stack callback when the global limit is zero", () => {
+    const observed = withStackTraceLimit(
+      0,
+      () =>
+        observeErrors(() =>
+          Effect.runSync(Effect.withSpan(References.CurrentStackFrame, "span", {
+            captureStackTrace: () => "custom location"
+          }))
+        )
+    )
+    assert.strictEqual(observed.constructions, 0)
+    assert.strictEqual(observed.value!.name, "span")
+    assert.strictEqual(observed.value!.stack(), "custom location")
+  })
+})

--- a/packages/effect/test/StackCapture.test.ts
+++ b/packages/effect/test/StackCapture.test.ts
@@ -1,353 +1,57 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Cause, Context, Effect, Exit, Layer, LayerMap, LayerRef, References, Schema } from "effect"
-import { HttpApiMiddleware } from "effect/unstable/httpapi"
-import { Atom, AtomRegistry } from "effect/unstable/reactivity"
-import { RpcMiddleware } from "effect/unstable/rpc"
+import { Effect, References } from "effect"
 
-const withStackTraceLimit = <A>(limit: number, run: () => A): A => {
-  const original = Object.getOwnPropertyDescriptor(Error, "stackTraceLimit")
-  Object.defineProperty(Error, "stackTraceLimit", { value: limit, writable: true, configurable: true })
+const withCaptureDisabled = <A>(run: () => A): A => {
+  const limit = Error.stackTraceLimit
+  Error.stackTraceLimit = 0
   try {
     return run()
   } finally {
-    if (original) {
-      Object.defineProperty(Error, "stackTraceLimit", original)
-    } else {
-      Reflect.deleteProperty(Error, "stackTraceLimit")
-    }
+    Error.stackTraceLimit = limit
   }
 }
 
-// A zero-length stack still costs a capture in workerd, so inspect construction
-// rather than only checking the resulting stack string.
-const observeErrors = <A>(run: () => A) => {
+// Even an empty stack costs a capture in workerd, so count Error allocations.
+const countErrors = (run: () => void): number => {
   const original = globalThis.Error
-  let constructions = 0
-  const limits: Array<unknown> = []
+  let count = 0
   globalThis.Error = new Proxy(original, {
     construct(target, args, newTarget) {
-      constructions++
+      count++
       return Reflect.construct(target, args, newTarget)
-    },
-    set(target, key, value) {
-      if (key === "stackTraceLimit") limits.push(value)
-      return Reflect.set(target, key, value)
     }
   })
   try {
-    return { value: run(), constructions, limits }
+    run()
+    return count
   } finally {
     globalThis.Error = original
   }
 }
 
-// These tests mutate Error globally and must not overlap with each other.
 describe("stack capture", { concurrent: false }, () => {
-  for (const named of [false, true]) {
-    describe(named ? "named Effect.fn" : "unnamed Effect.fn", () => {
-      const define = () => {
-        const body = function*(value: number) {
-          return yield* Effect.succeed(value + 1)
-        }
-        return named ? Effect.fn("increment")(body) : Effect.fn(body)
-      }
-
-      it("does not construct an Error at definition when stackTraceLimit is zero", () => {
-        const observed = withStackTraceLimit(0, () => observeErrors(define))
-        assert.strictEqual(observed.constructions, 0)
-        assert.isTrue(observed.limits.every((limit) => limit === 0))
-        assert.strictEqual(Effect.runSync(observed.value(1)), 2)
-      })
-
-      it("does not construct an Error at invocation when stackTraceLimit is zero", () => {
-        const fn = withStackTraceLimit(10, define)
-        const observed = withStackTraceLimit(0, () => observeErrors(() => Effect.runSync(fn(1))))
-        assert.strictEqual(observed.value, 2)
-        assert.strictEqual(observed.constructions, 0)
-        assert.isTrue(observed.limits.every((limit) => limit === 0))
-      })
-
-      it("preserves failures when stack capture is disabled", () => {
-        const exit = withStackTraceLimit(0, () => {
-          const body = function*() {
-            return yield* Effect.fail("boom")
-          }
-          const fn = named ? Effect.fn("failure")(body) : Effect.fn(body)
-          return Effect.runSyncExit(fn())
-        })
-        assert.isTrue(Exit.isFailure(exit))
-        if (Exit.isFailure(exit)) {
-          assert.include(Cause.pretty(exit.cause), "boom")
-        }
-      })
-
-      it("preserves definition and invocation locations when stack capture is enabled", () => {
-        const frame = withStackTraceLimit(10, () => {
-          const body = function*() {
-            return yield* References.CurrentStackFrame
-          }
-          const fn = named ? Effect.fn("traced")(body) : Effect.fn(body)
-          const effect = fn()
-          assert.strictEqual(Error.stackTraceLimit, 10)
-          return Effect.runSync(effect)
-        })
-        assert.isDefined(frame)
-        assert.strictEqual(frame!.name, named ? "traced" : "Effect.fn")
-        assert.match(frame!.stack()!, /StackCapture\.test\.ts:\d+:\d+/)
-        assert.strictEqual(frame!.parent!.name, `${named ? "traced" : "Effect.fn"} (definition)`)
-        assert.match(frame!.parent!.stack()!, /StackCapture\.test\.ts:\d+:\d+/)
-        assert.notStrictEqual(frame!.stack(), frame!.parent!.stack())
-      })
-
-      it("captures an invocation after a definition with stack capture disabled", () => {
-        const fn = withStackTraceLimit(0, () => {
-          const body = function*() {
-            return yield* References.CurrentStackFrame
-          }
-          return named ? Effect.fn("traced")(body) : Effect.fn(body)
-        })
-        const frame = withStackTraceLimit(10, () => {
-          const effect = fn()
-          assert.strictEqual(Error.stackTraceLimit, 10)
-          return Effect.runSync(effect)
-        })
-        assert.isDefined(frame)
-        assert.strictEqual(frame!.name, named ? "traced" : "Effect.fn")
-        assert.match(frame!.stack()!, /StackCapture\.test\.ts:\d+:\d+/)
-        assert.strictEqual(frame!.parent!.name, `${named ? "traced" : "Effect.fn"} (definition)`)
-        assert.isUndefined(frame!.parent!.stack())
-      })
-    })
-  }
-
-  for (const limit of [0, 10]) {
-    it(`named Effect.fn preserves spans and attributes with stackTraceLimit ${limit}`, () => {
-      const span = withStackTraceLimit(limit, () => {
-        const fn = Effect.fn("named span", { attributes: { operation: "regression" } })(function*() {
-          return yield* Effect.currentSpan
-        })
-        return Effect.runSync(fn())
-      })
-      assert.strictEqual(span.name, "named span")
-      assert.strictEqual(span.attributes.get("operation"), "regression")
-    })
-  }
-
-  for (
-    const [name, wrap] of [
-      ["withSpan data-first", (effect: Effect.Effect<string>) => Effect.withSpan(effect, "span")],
-      ["withSpan data-last", (effect: Effect.Effect<string>) => effect.pipe(Effect.withSpan("span"))],
-      ["withSpanScoped", (effect: Effect.Effect<string>) => Effect.scoped(Effect.withSpanScoped(effect, "span"))]
-    ] as const
-  ) {
-    it(`${name} does not construct an Error when stackTraceLimit is zero`, () => {
-      const observed = withStackTraceLimit(
-        0,
-        () =>
-          observeErrors(() => Effect.runSync(wrap(Effect.map(Effect.orDie(Effect.currentSpan), (span) => span.name))))
-      )
-      assert.strictEqual(observed.value, "span")
-      assert.strictEqual(observed.constructions, 0)
-      assert.isTrue(observed.limits.every((limit) => limit === 0))
-    })
-  }
-
-  it("withSpan preserves failure locations when stack capture is enabled", () => {
-    const exit = withStackTraceLimit(10, () => {
-      const effect = Effect.withSpan(Effect.fail("boom"), "traced span")
-      assert.strictEqual(Error.stackTraceLimit, 10)
-      return Effect.runSyncExit(effect)
-    })
-    assert.isTrue(Exit.isFailure(exit))
-    if (Exit.isFailure(exit)) {
-      const frame = Context.getUnsafe(Cause.annotations(exit.cause), Cause.StackTrace)
-      assert.strictEqual(frame.name, "traced span")
-      assert.match(frame.stack()!, /StackCapture\.test\.ts:\d+:\d+/)
-      assert.include(Cause.pretty(exit.cause), "boom")
-    }
+  it("Effect.fn skips definition capture at limit zero", () => {
+    const count = withCaptureDisabled(() => countErrors(() => Effect.fn("test")(() => Effect.void)))
+    assert.strictEqual(count, 0)
   })
 
-  it("withSpan honors captureStackTrace false when the global limit is positive", () => {
-    const observed = withStackTraceLimit(
-      10,
-      () =>
-        observeErrors(() =>
-          Effect.runSync(Effect.withSpan(References.CurrentStackFrame, "span", { captureStackTrace: false }))
-        )
-    )
-    assert.strictEqual(observed.constructions, 0)
-    assert.strictEqual(observed.value!.name, "span")
-    assert.isUndefined(observed.value!.stack())
+  it("Effect.fn skips invocation capture at limit zero", () => {
+    const fn = Effect.fn("test")(() => Effect.void)
+    const count = withCaptureDisabled(() => countErrors(() => Effect.runSync(fn())))
+    assert.strictEqual(count, 0)
   })
 
-  it("withSpan preserves a supplied stack callback when the global limit is zero", () => {
-    const observed = withStackTraceLimit(
-      0,
-      () =>
-        observeErrors(() =>
-          Effect.runSync(Effect.withSpan(References.CurrentStackFrame, "span", {
-            captureStackTrace: () => "custom location"
-          }))
-        )
-    )
-    assert.strictEqual(observed.constructions, 0)
-    assert.strictEqual(observed.value!.name, "span")
-    assert.strictEqual(observed.value!.stack(), "custom location")
+  it("default spans skip capture at limit zero", () => {
+    const count = withCaptureDisabled(() => countErrors(() => Effect.runSync(Effect.withSpan(Effect.void, "test"))))
+    assert.strictEqual(count, 0)
   })
 
-  for (
-    const [name, wrap] of [
-      [
-        "withSpan data-first",
-        (effect: Effect.Effect<References.StackFrame | undefined>) =>
-          Effect.withSpan(effect, "explicit span", { captureStackTrace: true })
-      ],
-      [
-        "withSpan data-last",
-        (effect: Effect.Effect<References.StackFrame | undefined>) =>
-          effect.pipe(Effect.withSpan("explicit span", {}, { captureStackTrace: true }))
-      ],
-      [
-        "withSpanScoped",
-        (effect: Effect.Effect<References.StackFrame | undefined>) =>
-          Effect.scoped(Effect.withSpanScoped(effect, "explicit span", { captureStackTrace: true }))
-      ]
-    ] as const
-  ) {
-    it(`${name} honors captureStackTrace true when the global limit is zero`, () => {
-      const frame = withStackTraceLimit(0, () => {
-        const effect = wrap(References.CurrentStackFrame)
-        const frame = Effect.runSync(effect)
-        assert.strictEqual(Error.stackTraceLimit, 0)
-        return frame
-      })
-      assert.isDefined(frame)
-      assert.strictEqual(frame!.name, "explicit span")
-      assert.match(frame!.stack()!, /StackCapture\.test\.ts:\d+:\d+/)
+  it("explicit span capture works at limit zero", () => {
+    const frame = withCaptureDisabled(() => {
+      const frame = Effect.runSync(Effect.withSpan(References.CurrentStackFrame, "test", { captureStackTrace: true }))
+      assert.strictEqual(Error.stackTraceLimit, 0)
+      return frame
     })
-  }
-
-  describe("service definitions", () => {
-    for (
-      const [name, define] of [
-        ["LayerMap", () => {
-          class Value extends Context.Service<Value, { readonly value: number }>()("StackCapture/Value") {}
-          class Service extends LayerMap.Service<Service>()("LayerMap", {
-            lookup: (_key: string) => Layer.succeed(Value, { value: 42 })
-          }) {}
-          return Service
-        }],
-        ["LayerRef", () => {
-          class Service extends LayerRef.Service<Service>()("LayerRef", { layer: Layer.empty }) {}
-          return Service
-        }],
-        ["HttpApiMiddleware", () => {
-          class Service extends HttpApiMiddleware.Service<Service>()("HttpApiMiddleware") {}
-          return Service
-        }],
-        ["RpcMiddleware", () => {
-          class Service extends RpcMiddleware.Service<Service>()("RpcMiddleware") {}
-          return Service
-        }]
-      ] as const
-    ) {
-      it(`${name}.Service skips Error allocation and has no stack at limit zero`, () => {
-        const observed = withStackTraceLimit(0, () => observeErrors(() => define()))
-        assert.strictEqual(observed.constructions, 0)
-        assert.deepStrictEqual(observed.limits, [])
-        assert.strictEqual(observed.value.key, name)
-        assert.isUndefined(Reflect.get(observed.value, "stack"))
-      })
-
-      it(`${name}.Service captures its definition location at a positive limit`, () => {
-        const service = withStackTraceLimit(10, () => {
-          const service = define()
-          assert.strictEqual(Error.stackTraceLimit, 10)
-          return service
-        })
-        assert.strictEqual(service.key, name)
-        const stack = Reflect.get(service, "stack") as string | undefined
-        assert.isString(stack)
-        assert.match(stack!.split("\n").at(-1)!, /StackCapture\.test\.ts:\d+:\d+/)
-      })
-    }
-  })
-
-  describe("cause formatting", () => {
-    for (const [name, cause] of [["failure", Cause.fail("boom")], ["defect", Cause.die("boom")]] as const) {
-      for (const limit of [0, 10]) {
-        it(`formats a ${name} while stackTraceLimit is ${limit}`, () => {
-          const observed = withStackTraceLimit(limit, () =>
-            observeErrors(() => {
-              const rendered = Cause.pretty(cause)
-              const errors = Cause.prettyErrors(cause)
-              return { rendered, errors, limit: Error.stackTraceLimit }
-            }))
-          assert.strictEqual(observed.value.limit, limit)
-          assert.strictEqual(observed.value.errors.length, 1)
-          assert.instanceOf(observed.value.errors[0], Error)
-          assert.strictEqual(observed.value.errors[0].message, "boom")
-          if (limit === 0) {
-            assert.strictEqual(observed.value.rendered, "Error: boom")
-            assert.strictEqual(observed.value.errors[0].stack, "Error: boom")
-            assert.isTrue(observed.limits.every((value) => value === 0))
-          } else {
-            assert.include(observed.value.rendered, "Error: boom")
-            assert.match(observed.value.errors[0].stack!, /\n\s+at /)
-          }
-        })
-      }
-    }
-
-    it("preserves an existing error stack while formatting at limit zero", () => {
-      const error = new Error("boom")
-      error.stack = "Error: boom\n    at original.ts:1:1"
-      const observed = withStackTraceLimit(0, () => observeErrors(() => Cause.pretty(Cause.fail(error))))
-      assert.include(observed.value, "Error: boom")
-      assert.include(observed.value, "at original.ts:1:1")
-      assert.isTrue(observed.limits.every((value) => value === 0))
-    })
-
-    it("formats interruption details while the limit is zero", () => {
-      const observed = withStackTraceLimit(0, () => observeErrors(() => Cause.pretty(Cause.interrupt(42))))
-      assert.include(observed.value, "All fibers interrupted without error")
-      assert.include(observed.value, "at fiber (#42)")
-      assert.isTrue(observed.limits.every((value) => value === 0))
-    })
-  })
-
-  describe("Atom labels", () => {
-    for (
-      const [name, label] of [
-        ["withLabel", (atom: Atom.Atom<number>) => Atom.withLabel(atom, "counter")],
-        [
-          "serializable",
-          (atom: Atom.Atom<number>) => Atom.serializable(atom, { key: "counter", schema: Schema.Number })
-        ]
-      ] as const
-    ) {
-      it(`${name} skips Error allocation at limit zero and preserves the atom value`, () => {
-        const atom = Atom.make(42)
-        const observed = withStackTraceLimit(0, () => observeErrors(() => label(atom)))
-        assert.strictEqual(observed.constructions, 0)
-        assert.deepStrictEqual(observed.value.label, ["counter", ""])
-        const registry = AtomRegistry.make()
-        try {
-          assert.strictEqual(registry.get(observed.value), 42)
-        } finally {
-          registry.dispose()
-        }
-      })
-    }
-
-    it("serializable preserves an existing label without allocating another Error", () => {
-      const atom = withStackTraceLimit(10, () => Atom.withLabel(Atom.make(42), "original"))
-      const observed = withStackTraceLimit(
-        0,
-        () => observeErrors(() => Atom.serializable(atom, { key: "counter", schema: Schema.Number }))
-      )
-      assert.strictEqual(observed.constructions, 0)
-      assert.strictEqual(observed.value.label, atom.label)
-    })
+    assert.match(frame!.stack()!, /StackCapture\.test\.ts:\d+:\d+/)
   })
 })

--- a/packages/effect/test/StackCapture.test.ts
+++ b/packages/effect/test/StackCapture.test.ts
@@ -1,5 +1,8 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Cause, Context, Effect, Exit, References } from "effect"
+import { Cause, Context, Effect, Exit, Layer, LayerMap, LayerRef, References, Schema } from "effect"
+import { HttpApiMiddleware } from "effect/unstable/httpapi"
+import { Atom, AtomRegistry } from "effect/unstable/reactivity"
+import { RpcMiddleware } from "effect/unstable/rpc"
 
 const withStackTraceLimit = <A>(limit: number, run: () => A): A => {
   const original = Object.getOwnPropertyDescriptor(Error, "stackTraceLimit")
@@ -95,6 +98,25 @@ describe("stack capture", { concurrent: false }, () => {
         assert.match(frame!.parent!.stack()!, /StackCapture\.test\.ts:\d+:\d+/)
         assert.notStrictEqual(frame!.stack(), frame!.parent!.stack())
       })
+
+      it("captures an invocation after a definition with stack capture disabled", () => {
+        const fn = withStackTraceLimit(0, () => {
+          const body = function*() {
+            return yield* References.CurrentStackFrame
+          }
+          return named ? Effect.fn("traced")(body) : Effect.fn(body)
+        })
+        const frame = withStackTraceLimit(10, () => {
+          const effect = fn()
+          assert.strictEqual(Error.stackTraceLimit, 10)
+          return Effect.runSync(effect)
+        })
+        assert.isDefined(frame)
+        assert.strictEqual(frame!.name, named ? "traced" : "Effect.fn")
+        assert.match(frame!.stack()!, /StackCapture\.test\.ts:\d+:\d+/)
+        assert.strictEqual(frame!.parent!.name, `${named ? "traced" : "Effect.fn"} (definition)`)
+        assert.isUndefined(frame!.parent!.stack())
+      })
     })
   }
 
@@ -171,5 +193,161 @@ describe("stack capture", { concurrent: false }, () => {
     assert.strictEqual(observed.constructions, 0)
     assert.strictEqual(observed.value!.name, "span")
     assert.strictEqual(observed.value!.stack(), "custom location")
+  })
+
+  for (
+    const [name, wrap] of [
+      [
+        "withSpan data-first",
+        (effect: Effect.Effect<References.StackFrame | undefined>) =>
+          Effect.withSpan(effect, "explicit span", { captureStackTrace: true })
+      ],
+      [
+        "withSpan data-last",
+        (effect: Effect.Effect<References.StackFrame | undefined>) =>
+          effect.pipe(Effect.withSpan("explicit span", {}, { captureStackTrace: true }))
+      ],
+      [
+        "withSpanScoped",
+        (effect: Effect.Effect<References.StackFrame | undefined>) =>
+          Effect.scoped(Effect.withSpanScoped(effect, "explicit span", { captureStackTrace: true }))
+      ]
+    ] as const
+  ) {
+    it(`${name} honors captureStackTrace true when the global limit is zero`, () => {
+      const frame = withStackTraceLimit(0, () => {
+        const effect = wrap(References.CurrentStackFrame)
+        const frame = Effect.runSync(effect)
+        assert.strictEqual(Error.stackTraceLimit, 0)
+        return frame
+      })
+      assert.isDefined(frame)
+      assert.strictEqual(frame!.name, "explicit span")
+      assert.match(frame!.stack()!, /StackCapture\.test\.ts:\d+:\d+/)
+    })
+  }
+
+  describe("service definitions", () => {
+    for (
+      const [name, define] of [
+        ["LayerMap", () => {
+          class Value extends Context.Service<Value, { readonly value: number }>()("StackCapture/Value") {}
+          class Service extends LayerMap.Service<Service>()("LayerMap", {
+            lookup: (_key: string) => Layer.succeed(Value, { value: 42 })
+          }) {}
+          return Service
+        }],
+        ["LayerRef", () => {
+          class Service extends LayerRef.Service<Service>()("LayerRef", { layer: Layer.empty }) {}
+          return Service
+        }],
+        ["HttpApiMiddleware", () => {
+          class Service extends HttpApiMiddleware.Service<Service>()("HttpApiMiddleware") {}
+          return Service
+        }],
+        ["RpcMiddleware", () => {
+          class Service extends RpcMiddleware.Service<Service>()("RpcMiddleware") {}
+          return Service
+        }]
+      ] as const
+    ) {
+      it(`${name}.Service skips Error allocation and has no stack at limit zero`, () => {
+        const observed = withStackTraceLimit(0, () => observeErrors(() => define()))
+        assert.strictEqual(observed.constructions, 0)
+        assert.deepStrictEqual(observed.limits, [])
+        assert.strictEqual(observed.value.key, name)
+        assert.isUndefined(Reflect.get(observed.value, "stack"))
+      })
+
+      it(`${name}.Service captures its definition location at a positive limit`, () => {
+        const service = withStackTraceLimit(10, () => {
+          const service = define()
+          assert.strictEqual(Error.stackTraceLimit, 10)
+          return service
+        })
+        assert.strictEqual(service.key, name)
+        const stack = Reflect.get(service, "stack") as string | undefined
+        assert.isString(stack)
+        assert.match(stack!.split("\n").at(-1)!, /StackCapture\.test\.ts:\d+:\d+/)
+      })
+    }
+  })
+
+  describe("cause formatting", () => {
+    for (const [name, cause] of [["failure", Cause.fail("boom")], ["defect", Cause.die("boom")]] as const) {
+      for (const limit of [0, 10]) {
+        it(`formats a ${name} while stackTraceLimit is ${limit}`, () => {
+          const observed = withStackTraceLimit(limit, () =>
+            observeErrors(() => {
+              const rendered = Cause.pretty(cause)
+              const errors = Cause.prettyErrors(cause)
+              return { rendered, errors, limit: Error.stackTraceLimit }
+            }))
+          assert.strictEqual(observed.value.limit, limit)
+          assert.strictEqual(observed.value.errors.length, 1)
+          assert.instanceOf(observed.value.errors[0], Error)
+          assert.strictEqual(observed.value.errors[0].message, "boom")
+          if (limit === 0) {
+            assert.strictEqual(observed.value.rendered, "Error: boom")
+            assert.strictEqual(observed.value.errors[0].stack, "Error: boom")
+            assert.isTrue(observed.limits.every((value) => value === 0))
+          } else {
+            assert.include(observed.value.rendered, "Error: boom")
+            assert.match(observed.value.errors[0].stack!, /\n\s+at /)
+          }
+        })
+      }
+    }
+
+    it("preserves an existing error stack while formatting at limit zero", () => {
+      const error = new Error("boom")
+      error.stack = "Error: boom\n    at original.ts:1:1"
+      const observed = withStackTraceLimit(0, () => observeErrors(() => Cause.pretty(Cause.fail(error))))
+      assert.include(observed.value, "Error: boom")
+      assert.include(observed.value, "at original.ts:1:1")
+      assert.isTrue(observed.limits.every((value) => value === 0))
+    })
+
+    it("formats interruption details while the limit is zero", () => {
+      const observed = withStackTraceLimit(0, () => observeErrors(() => Cause.pretty(Cause.interrupt(42))))
+      assert.include(observed.value, "All fibers interrupted without error")
+      assert.include(observed.value, "at fiber (#42)")
+      assert.isTrue(observed.limits.every((value) => value === 0))
+    })
+  })
+
+  describe("Atom labels", () => {
+    for (
+      const [name, label] of [
+        ["withLabel", (atom: Atom.Atom<number>) => Atom.withLabel(atom, "counter")],
+        [
+          "serializable",
+          (atom: Atom.Atom<number>) => Atom.serializable(atom, { key: "counter", schema: Schema.Number })
+        ]
+      ] as const
+    ) {
+      it(`${name} skips Error allocation at limit zero and preserves the atom value`, () => {
+        const atom = Atom.make(42)
+        const observed = withStackTraceLimit(0, () => observeErrors(() => label(atom)))
+        assert.strictEqual(observed.constructions, 0)
+        assert.deepStrictEqual(observed.value.label, ["counter", ""])
+        const registry = AtomRegistry.make()
+        try {
+          assert.strictEqual(registry.get(observed.value), 42)
+        } finally {
+          registry.dispose()
+        }
+      })
+    }
+
+    it("serializable preserves an existing label without allocating another Error", () => {
+      const atom = withStackTraceLimit(10, () => Atom.withLabel(Atom.make(42), "original"))
+      const observed = withStackTraceLimit(
+        0,
+        () => observeErrors(() => Atom.serializable(atom, { key: "counter", schema: Schema.Number }))
+      )
+      assert.strictEqual(observed.constructions, 0)
+      assert.strictEqual(observed.value.label, atom.label)
+    })
   })
 })


### PR DESCRIPTION
`Effect.fn` overrides `Error.stackTraceLimit = 0` and constructs errors to capture definition and invocation sites. These captures can be expensive during Cloudflare Workers startup even with a zero-length stack.

Skip optional error construction when the limit is zero in functions, spans, layer and middleware service definitions, atom labels, and the internal stack probe. Leave a zero limit unchanged when formatting causes. Named spans, function frames, and enabled stack locations are preserved. Explicit `captureStackTrace: true` still opts into span capture at limit zero, and supplied stack callbacks remain supported.

Service definitions expose an undefined `stack` at limit zero and retain their definition location at positive limits. Includes an Effect patch changeset documenting these behaviors.

Adds four focused regressions for zero-limit function definition/invocation capture, default span capture, and explicit span opt-in. Existing tests cover the surrounding tracing behavior.

Validation:

- All 783 tests in 21 related files pass under Node, including the four focused regressions.
- `nix develop -c bun run --bun vitest run packages/effect/test/StackCapture.test.ts`: all four pass.
- `nix develop -c pnpm lint-fix`: passed.
- `nix develop -c pnpm check`: passed.

Closes EFF-1312
Closes #8038
