### PR TITLE
Fix file body content-length precision and range errors

### DIFF
--- a/.changeset/exact-http-file-body-length.md
+++ b/.changeset/exact-http-file-body-length.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Calculate `HttpBody.file`, `HttpBody.fileFromInfo`, and `HttpClientRequest.bodyFile` content lengths with exact bigint arithmetic and EOF clamping. Fail with typed `PlatformError` / `BadArgument` when the final length exceeds `Number.MAX_SAFE_INTEGER`, while allowing larger sizes and range inputs when the resulting length is representable. Invalid range inputs now fail through the typed error channel during effect evaluation instead of causing defects.
+Calculate `HttpBody.file`, `HttpBody.fileFromInfo`, and `HttpClientRequest.bodyFile` content lengths with exact bigint arithmetic and EOF clamping.

--- a/.changeset/exact-http-file-body-length.md
+++ b/.changeset/exact-http-file-body-length.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Calculate `HttpBody.file`, `HttpBody.fileFromInfo`, and `HttpClientRequest.bodyFile` content lengths with exact bigint arithmetic and EOF clamping. Fail with typed `PlatformError` / `BadArgument` when the final length exceeds `Number.MAX_SAFE_INTEGER`, while allowing larger sizes and range inputs when the resulting length is representable. Invalid range inputs now fail through the typed error channel during effect evaluation instead of causing defects.

--- a/packages/effect/src/unstable/http/HttpBody.ts
+++ b/packages/effect/src/unstable/http/HttpBody.ts
@@ -17,7 +17,8 @@ import * as Effect from "../../Effect.ts"
 import * as FileSystem from "../../FileSystem.ts"
 import { format } from "../../Formatter.ts"
 import * as Inspectable from "../../Inspectable.ts"
-import type * as PlatformError from "../../PlatformError.ts"
+import * as Option from "../../Option.ts"
+import * as PlatformError from "../../PlatformError.ts"
 import * as Predicate from "../../Predicate.ts"
 import * as Schema from "../../Schema.ts"
 import type { ParseOptions } from "../../SchemaAST.ts"
@@ -512,19 +513,44 @@ export const stream = (
   contentLength?: number
 ): Stream => new Stream(body, contentType ?? "application/octet-stream", contentLength)
 
-const fileContentLength = (
+const fileRangeSize = (
+  input: ByteSize.Input,
+  field: string,
+  method: string
+): Effect.Effect<ByteSize.ByteSize, PlatformError.PlatformError> => {
+  const size = ByteSize.fromInput(input)
+  return Option.isSome(size)
+    ? Effect.succeed(size.value)
+    : Effect.fail(PlatformError.badArgument({
+      module: "HttpBody",
+      method,
+      description: `Invalid ${field}: ${input}`
+    }))
+}
+
+const fileContentLength = Effect.fnUntraced(function*(
   size: ByteSize.ByteSize,
+  method: string,
   options?: {
     readonly bytesToRead?: ByteSize.Input | undefined
     readonly offset?: ByteSize.Input | undefined
   }
-): number => {
-  const offset = options?.offset === undefined ? 0 : Number(ByteSize.fromInputUnsafe(options.offset))
-  const available = Math.max(0, Number(size) - offset)
-  return options?.bytesToRead === undefined
-    ? available
-    : Math.min(available, Number(ByteSize.fromInputUnsafe(options.bytesToRead)))
-}
+): Effect.fn.Return<number, PlatformError.PlatformError> {
+  const offset = options?.offset === undefined ? ByteSize.zero : yield* fileRangeSize(options.offset, "offset", method)
+  const bytesToRead = options?.bytesToRead === undefined
+    ? undefined
+    : yield* fileRangeSize(options.bytesToRead, "bytesToRead", method)
+  const available = offset >= size ? BigInt("0") : size - offset
+  const length = bytesToRead === undefined || bytesToRead > available ? available : bytesToRead
+  if (length > BigInt(Number.MAX_SAFE_INTEGER)) {
+    return yield* Effect.fail(PlatformError.badArgument({
+      module: "HttpBody",
+      method,
+      description: `Content length exceeds Number.MAX_SAFE_INTEGER: ${length}`
+    }))
+  }
+  return Number(length)
+})
 
 /**
  * Creates a streaming HTTP body for a file path.
@@ -533,6 +559,15 @@ const fileContentLength = (
  *
  * The effect requires `FileSystem`, stats the file to set the selected content length, and can fail with
  * `PlatformError`.
+ *
+ * Range validation and file access are deferred until the effect runs. Numeric range inputs must be
+ * non-negative safe integers; bigint and byte-size strings can represent larger values. Malformed strings,
+ * negative values, and non-finite, fractional, or unsafe numbers fail with `PlatformError` / `BadArgument`.
+ *
+ * The selected length is calculated exactly with bigint arithmetic and clamped to the bytes available after
+ * `offset` (zero at or past EOF). Since `Stream.contentLength` is a number, a final length above
+ * `Number.MAX_SAFE_INTEGER` fails with `BadArgument`. Larger sizes, offsets, and byte counts are valid when
+ * the final clamped length is representable; the resulting Content-Length header preserves that exact length.
  *
  * @category constructors
  * @since 4.0.0
@@ -549,12 +584,13 @@ export const file = (
   Effect.flatMap(
     FileSystem.FileSystem,
     (fs) =>
-      Effect.map(fs.stat(path), (info) =>
-        stream(
-          fs.stream(path, options),
-          options?.contentType,
-          fileContentLength(info.size, options)
-        ))
+      Effect.flatMap(fs.stat(path), (info) =>
+        Effect.map(fileContentLength(info.size, "file", options), (contentLength) =>
+          stream(
+            fs.stream(path, options),
+            options?.contentType,
+            contentLength
+          )))
   )
 
 /**
@@ -564,6 +600,11 @@ export const file = (
  *
  * The effect requires `FileSystem`, uses the provided file size to determine the selected content length, and can
  * fail with `PlatformError`.
+ *
+ * Like {@link file}, this constructor validates ranges lazily and calculates the EOF-clamped length with exact
+ * bigint arithmetic. Invalid range inputs and final lengths above `Number.MAX_SAFE_INTEGER` fail with
+ * `PlatformError` / `BadArgument`. Larger sizes, offsets, and byte counts remain valid when the final length
+ * is representable as a safe integer, preserving the exact Content-Length header.
  *
  * @category constructors
  * @since 4.0.0
@@ -578,12 +619,13 @@ export const fileFromInfo = (
     readonly contentType?: string | undefined
   }
 ): Effect.Effect<Stream, PlatformError.PlatformError, FileSystem.FileSystem> =>
-  Effect.map(
+  Effect.flatMap(
     FileSystem.FileSystem,
     (fs) =>
-      stream(
-        fs.stream(path, options),
-        options?.contentType,
-        fileContentLength(info.size, options)
-      )
+      Effect.map(fileContentLength(info.size, "fileFromInfo", options), (contentLength) =>
+        stream(
+          fs.stream(path, options),
+          options?.contentType,
+          contentLength
+        ))
   )

--- a/packages/effect/src/unstable/http/HttpClientRequest.ts
+++ b/packages/effect/src/unstable/http/HttpClientRequest.ts
@@ -830,6 +830,13 @@ export const bodyStream: {
 /**
  * Creates a file-backed request body from a filesystem path and sets it on the request.
  *
+ * **Details**
+ *
+ * Uses {@link HttpBody.file} to validate ranges lazily and calculate the EOF-clamped content length with exact
+ * bigint arithmetic. Invalid range inputs or a final length above `Number.MAX_SAFE_INTEGER` fail with
+ * `PlatformError` / `BadArgument`. Larger sizes, offsets, and byte counts are valid when the final length is
+ * representable as a safe integer. The request's Content-Length header contains that exact length.
+ *
  * @category combinators
  * @since 4.0.0
  */

--- a/packages/effect/test/unstable/http/HttpBody.test.ts
+++ b/packages/effect/test/unstable/http/HttpBody.test.ts
@@ -1,47 +1,228 @@
-import { assert, it } from "@effect/vitest"
-import { ByteSize, Cause, Effect, FileSystem, Stream } from "effect"
+import { assert, describe, it } from "@effect/vitest"
+import { ByteSize, Effect, FileSystem, Stream } from "effect"
 import { HttpBody } from "effect/unstable/http"
 
-for (const constructor of ["file", "fileFromInfo"] as const) {
-  it.each([
-    { name: "negative offset", options: { offset: -1 } },
-    { name: "malformed byte count", options: { bytesToRead: "nope" } }
-  ])(`${constructor} defers an invalid $name to an effect defect`, async ({ options }) => {
-    const info = { size: ByteSize.bytes(6) } as FileSystem.File.Info
-    // Construct outside Effect.gen so a synchronous throw fails the test.
-    const body = constructor === "file"
-      ? HttpBody.file("x", options)
-      : HttpBody.fileFromInfo("x", info, options)
+const maxSafe = BigInt(Number.MAX_SAFE_INTEGER)
+const oversized = 9007199254740993n
+const fileInfo = (size: bigint): FileSystem.File.Info => ({ size: ByteSize.bytes(size) }) as FileSystem.File.Info
+const fileSystem = (info: FileSystem.File.Info) =>
+  FileSystem.makeNoop({
+    stat: () => Effect.succeed(info),
+    stream: () => Stream.empty
+  })
 
-    const exit = await Effect.runPromiseExit(body.pipe(
-      Effect.provideService(
+for (const constructor of ["file", "fileFromInfo"] as const) {
+  describe(constructor, () => {
+    const make = (info: FileSystem.File.Info, options?: Parameters<typeof HttpBody.file>[1]) =>
+      constructor === "file" ? HttpBody.file("x", options) : HttpBody.fileFromInfo("x", info, options)
+
+    it.each([
+      { name: "maximum safe length", size: maxSafe, options: {}, expected: Number.MAX_SAFE_INTEGER },
+      { name: "oversized file capped by a safe byte count", size: oversized, options: { bytesToRead: 2 }, expected: 2 },
+      {
+        name: "safe offset leaving the maximum safe length",
+        size: oversized,
+        options: { offset: 2 },
+        expected: Number.MAX_SAFE_INTEGER
+      },
+      { name: "safe offset leaving two bytes", size: oversized, options: { offset: maxSafe }, expected: 2 },
+      {
+        name: "unsafe bigint offset leaving one byte",
+        size: oversized,
+        options: { offset: maxSafe + 1n },
+        expected: 1
+      },
+      {
+        name: "unsafe bigint size and offset leaving three bytes",
+        size: oversized + 3n,
+        options: { offset: oversized },
+        expected: 3
+      },
+      {
+        name: "unsafe string offset leaving three bytes",
+        size: oversized + 3n,
+        options: { offset: "9007199254740993 B" },
+        expected: 3
+      },
+      {
+        name: "byte count clamped after exact subtraction",
+        size: oversized + 3n,
+        options: { offset: oversized, bytesToRead: 4 },
+        expected: 3
+      },
+      {
+        name: "unsafe bigint byte count clamped to a small file",
+        size: 6n,
+        options: { bytesToRead: oversized },
+        expected: 6
+      },
+      {
+        name: "unsafe string byte count clamped to a small file",
+        size: 6n,
+        options: { bytesToRead: "9007199254740993 B" },
+        expected: 6
+      },
+      {
+        name: "unsafe byte count clamped to the maximum safe length",
+        size: maxSafe,
+        options: { bytesToRead: oversized },
+        expected: Number.MAX_SAFE_INTEGER
+      },
+      { name: "unsafe offset at EOF", size: oversized, options: { offset: oversized }, expected: 0 },
+      {
+        name: "unsafe offset past EOF",
+        size: oversized,
+        options: { offset: oversized + 1n, bytesToRead: oversized },
+        expected: 0
+      },
+      { name: "zero byte count on an oversized file", size: oversized, options: { bytesToRead: 0 }, expected: 0 },
+      {
+        name: "bigints beyond the finite number range",
+        size: 10n ** 400n + 3n,
+        options: { offset: 10n ** 400n },
+        expected: 3
+      }
+    ])("calculates $name exactly", async ({ expected, options, size }) => {
+      const info = fileInfo(size)
+      const body = await Effect.runPromise(
+        make(info, options).pipe(
+          Effect.provideService(FileSystem.FileSystem, fileSystem(info))
+        )
+      )
+      assert.strictEqual(body.contentLength, expected)
+    })
+
+    it.each([
+      { name: "first unsafe length", size: maxSafe + 1n, options: {} },
+      { name: "length that would round down", size: oversized, options: {} },
+      { name: "length that would round up", size: oversized + 2n, options: {} },
+      { name: "unsafe length after applying an offset", size: oversized, options: { offset: 1 } },
+      {
+        name: "unsafe length after applying both bounds",
+        size: oversized + 3n,
+        options: { offset: 1, bytesToRead: oversized }
+      },
+      { name: "length beyond the finite number range", size: 10n ** 400n, options: {} }
+    ])("rejects $name with typed BadArgument", async ({ options, size }) => {
+      const info = fileInfo(size)
+      const error = await Effect.runPromise(
+        make(info, options).pipe(
+          Effect.flip,
+          Effect.provideService(FileSystem.FileSystem, fileSystem(info))
+        )
+      )
+      assert.strictEqual(error._tag, "PlatformError")
+      assert.strictEqual(error.reason._tag, "BadArgument")
+    })
+
+    for (const field of ["offset", "bytesToRead"] as const) {
+      it.each([
+        { name: "malformed string", value: "garbage" },
+        { name: "fractional byte string", value: "1.5 B" },
+        { name: "negative string", value: "-1 B" },
+        { name: "negative bigint", value: -1n },
+        { name: "negative number", value: -1 },
+        { name: "fractional number", value: 1.5 },
+        { name: "NaN", value: NaN },
+        { name: "positive infinity", value: Infinity },
+        { name: "negative infinity", value: -Infinity },
+        { name: "unsafe integer number", value: Number.MAX_SAFE_INTEGER + 1 }
+      ])(`rejects ${field} containing $name with typed BadArgument`, async ({ value }) => {
+        const info = fileInfo(6n)
+        // Construction outside Effect.gen must not throw, even for invalid inputs.
+        const body = make(info, { [field]: value })
+        const error = await Effect.runPromise(body.pipe(
+          Effect.flip,
+          Effect.provideService(FileSystem.FileSystem, fileSystem(info))
+        ))
+        assert.strictEqual(error._tag, "PlatformError")
+        assert.strictEqual(error.reason._tag, "BadArgument")
+      })
+    }
+
+    it.each([
+      { name: "invalid offset with zero bytes requested", options: { offset: -1, bytesToRead: 0 } },
+      { name: "invalid byte count at EOF", options: { offset: 6, bytesToRead: -1 } },
+      { name: "unsafe numeric byte count past EOF", options: { offset: 7, bytesToRead: Number.MAX_SAFE_INTEGER + 1 } }
+    ])("validates $name before accepting an empty body", async ({ options }) => {
+      const info = fileInfo(6n)
+      const error = await Effect.runPromise(
+        make(info, options).pipe(
+          Effect.flip,
+          Effect.provideService(FileSystem.FileSystem, fileSystem(info))
+        )
+      )
+      assert.strictEqual(error.reason._tag, "BadArgument")
+    })
+
+    it("defers reading range inputs and accessing the filesystem until evaluation", async () => {
+      const info = fileInfo(6n)
+      let reads = 0
+      let statCalls = 0
+      let streamCalls = 0
+      const body = make(info, {
+        get offset() {
+          reads++
+          return 2
+        }
+      }).pipe(Effect.provideService(
         FileSystem.FileSystem,
         FileSystem.makeNoop({
-          stat: () => Effect.succeed(info),
-          stream: () => Stream.empty
+          stat: () => {
+            statCalls++
+            return Effect.succeed(info)
+          },
+          stream: () => {
+            streamCalls++
+            return Stream.empty
+          }
         })
-      )
-    ))
+      ))
+      assert.strictEqual(reads, 0)
+      assert.strictEqual(statCalls, 0)
+      assert.strictEqual(streamCalls, 0)
+      assert.strictEqual((await Effect.runPromise(body)).contentLength, 4)
+      assert.isAbove(reads, 0)
+      assert.strictEqual(statCalls, constructor === "file" ? 1 : 0)
+      assert.strictEqual(streamCalls, 1)
+    })
 
-    assert.strictEqual(exit._tag, "Failure")
-    if (exit._tag === "Failure") {
-      assert.isTrue(Cause.hasDies(exit.cause))
-      assert.isFalse(Cause.hasFails(exit.cause))
-    }
+    it.each([
+      { name: "whole file", options: {}, expected: [1, 2, 3, 4, 5, 6] },
+      { name: "offset only", options: { offset: 2 }, expected: [3, 4, 5, 6] },
+      {
+        name: "selected ByteSize range",
+        options: { offset: ByteSize.bytes(2), bytesToRead: ByteSize.bytes(2) },
+        expected: [3, 4]
+      },
+      { name: "selected string range", options: { offset: "2 B", bytesToRead: "2 B" }, expected: [3, 4] },
+      { name: "byte count past EOF", options: { offset: 2, bytesToRead: 10 }, expected: [3, 4, 5, 6] },
+      { name: "offset at EOF", options: { offset: 6 }, expected: [] },
+      { name: "offset past EOF", options: { offset: 7, bytesToRead: 2 }, expected: [] },
+      { name: "zero byte count", options: { bytesToRead: 0 }, expected: [] }
+    ])("preserves the bytes and content length for $name", async ({ expected, options }) => {
+      const info = fileInfo(6n)
+      const body = await Effect.runPromise(
+        make(info, { ...options, contentType: "text/plain", chunkSize: 2 }).pipe(
+          Effect.provideService(
+            FileSystem.FileSystem,
+            FileSystem.makeNoop({
+              stat: () => Effect.succeed(info),
+              stream: (path, range) => {
+                assert.strictEqual(path, "x")
+                assert.strictEqual(range?.chunkSize, 2)
+                const offset = Number(ByteSize.fromInputUnsafe(range?.offset ?? 0))
+                const count = Number(ByteSize.fromInputUnsafe(range?.bytesToRead ?? 6))
+                return Stream.succeed(new Uint8Array([1, 2, 3, 4, 5, 6]).slice(offset, offset + count))
+              }
+            })
+          )
+        )
+      )
+      const bytes = await Effect.runPromise(Stream.mkUint8Array(body.stream))
+      assert.deepStrictEqual(Array.from(bytes), expected)
+      assert.strictEqual(body.contentLength, bytes.length)
+      assert.strictEqual(body.contentType, "text/plain")
+    })
   })
 }
-
-it.effect("uses the selected byte count as partial file content length", () =>
-  Effect.gen(function*() {
-    const body = yield* HttpBody.fileFromInfo(
-      "x",
-      { size: ByteSize.bytes(6) } as any,
-      { offset: ByteSize.bytes(2), bytesToRead: ByteSize.bytes(2) }
-    ).pipe(
-      Effect.provideService(FileSystem.FileSystem, {
-        stream: () => Stream.succeed(new Uint8Array([3, 4]))
-      } as any)
-    )
-    const bytes = yield* Stream.mkUint8Array(body.stream)
-    assert.strictEqual(body.contentLength, bytes.length)
-  }))

--- a/packages/effect/test/unstable/http/HttpBody.test.ts
+++ b/packages/effect/test/unstable/http/HttpBody.test.ts
@@ -1,228 +1,108 @@
-import { assert, describe, it } from "@effect/vitest"
+import { assert, it } from "@effect/vitest"
 import { ByteSize, Effect, FileSystem, Stream } from "effect"
 import { HttpBody } from "effect/unstable/http"
 
 const maxSafe = BigInt(Number.MAX_SAFE_INTEGER)
 const oversized = 9007199254740993n
 const fileInfo = (size: bigint): FileSystem.File.Info => ({ size: ByteSize.bytes(size) }) as FileSystem.File.Info
-const fileSystem = (info: FileSystem.File.Info) =>
-  FileSystem.makeNoop({
-    stat: () => Effect.succeed(info),
-    stream: () => Stream.empty
-  })
+const fromInfo = (size: bigint, options?: Parameters<typeof HttpBody.fileFromInfo>[2]) =>
+  HttpBody.fileFromInfo("x", fileInfo(size), options).pipe(
+    Effect.provideService(FileSystem.FileSystem, FileSystem.makeNoop({ stream: () => Stream.empty }))
+  )
+
+it.each([
+  { name: "maximum safe final length", size: oversized, options: { offset: 2 }, expected: Number.MAX_SAFE_INTEGER },
+  {
+    name: "exact subtraction before clamping",
+    size: oversized + 3n,
+    options: { offset: oversized, bytesToRead: 4 },
+    expected: 3
+  },
+  { name: "safe byte count on an oversized file", size: oversized, options: { bytesToRead: 2 }, expected: 2 },
+  { name: "oversized byte count clamped to a small file", size: 6n, options: { bytesToRead: oversized }, expected: 6 },
+  { name: "offset at EOF", size: 6n, options: { offset: 6 }, expected: 0 },
+  { name: "offset past EOF", size: 6n, options: { offset: 7, bytesToRead: 2 }, expected: 0 },
+  { name: "zero byte count", size: oversized, options: { bytesToRead: 0 }, expected: 0 }
+])("fileFromInfo handles $name", async ({ expected, options, size }) => {
+  const body = await Effect.runPromise(fromInfo(size, options))
+  assert.strictEqual(body.contentLength, expected)
+})
+
+it.each([
+  { name: "first unsafe final length", size: maxSafe + 1n, options: {} },
+  {
+    name: "unsafe length after applying both bounds",
+    size: oversized + 3n,
+    options: { offset: 1, bytesToRead: oversized }
+  },
+  { name: "malformed byte count", size: 6n, options: { bytesToRead: "garbage" } },
+  { name: "negative offset with zero bytes requested", size: 6n, options: { offset: -1n, bytesToRead: 0 } },
+  { name: "negative byte count at EOF", size: 6n, options: { offset: 6, bytesToRead: -1 } },
+  { name: "fractional offset", size: 6n, options: { offset: 1.5 } },
+  { name: "non-finite byte count", size: 6n, options: { bytesToRead: Infinity } },
+  { name: "unsafe numeric offset", size: 6n, options: { offset: Number.MAX_SAFE_INTEGER + 1 } },
+  { name: "unsafe numeric byte count", size: 6n, options: { bytesToRead: Number.MAX_SAFE_INTEGER + 1 } }
+])("fileFromInfo rejects $name with typed BadArgument", async ({ options, size }) => {
+  const error = await Effect.runPromise(fromInfo(size, options).pipe(Effect.flip))
+  assert.strictEqual(error._tag, "PlatformError")
+  assert.strictEqual(error.reason._tag, "BadArgument")
+  assert.strictEqual(error.reason.method, "fileFromInfo")
+})
 
 for (const constructor of ["file", "fileFromInfo"] as const) {
-  describe(constructor, () => {
-    const make = (info: FileSystem.File.Info, options?: Parameters<typeof HttpBody.file>[1]) =>
-      constructor === "file" ? HttpBody.file("x", options) : HttpBody.fileFromInfo("x", info, options)
-
-    it.each([
-      { name: "maximum safe length", size: maxSafe, options: {}, expected: Number.MAX_SAFE_INTEGER },
-      { name: "oversized file capped by a safe byte count", size: oversized, options: { bytesToRead: 2 }, expected: 2 },
-      {
-        name: "safe offset leaving the maximum safe length",
-        size: oversized,
-        options: { offset: 2 },
-        expected: Number.MAX_SAFE_INTEGER
-      },
-      { name: "safe offset leaving two bytes", size: oversized, options: { offset: maxSafe }, expected: 2 },
-      {
-        name: "unsafe bigint offset leaving one byte",
-        size: oversized,
-        options: { offset: maxSafe + 1n },
-        expected: 1
-      },
-      {
-        name: "unsafe bigint size and offset leaving three bytes",
-        size: oversized + 3n,
-        options: { offset: oversized },
-        expected: 3
-      },
-      {
-        name: "unsafe string offset leaving three bytes",
-        size: oversized + 3n,
-        options: { offset: "9007199254740993 B" },
-        expected: 3
-      },
-      {
-        name: "byte count clamped after exact subtraction",
-        size: oversized + 3n,
-        options: { offset: oversized, bytesToRead: 4 },
-        expected: 3
-      },
-      {
-        name: "unsafe bigint byte count clamped to a small file",
-        size: 6n,
-        options: { bytesToRead: oversized },
-        expected: 6
-      },
-      {
-        name: "unsafe string byte count clamped to a small file",
-        size: 6n,
-        options: { bytesToRead: "9007199254740993 B" },
-        expected: 6
-      },
-      {
-        name: "unsafe byte count clamped to the maximum safe length",
-        size: maxSafe,
-        options: { bytesToRead: oversized },
-        expected: Number.MAX_SAFE_INTEGER
-      },
-      { name: "unsafe offset at EOF", size: oversized, options: { offset: oversized }, expected: 0 },
-      {
-        name: "unsafe offset past EOF",
-        size: oversized,
-        options: { offset: oversized + 1n, bytesToRead: oversized },
-        expected: 0
-      },
-      { name: "zero byte count on an oversized file", size: oversized, options: { bytesToRead: 0 }, expected: 0 },
-      {
-        name: "bigints beyond the finite number range",
-        size: 10n ** 400n + 3n,
-        options: { offset: 10n ** 400n },
-        expected: 3
+  it(`${constructor} defers range validation and filesystem access until evaluation`, async () => {
+    let reads = 0
+    let statCalls = 0
+    const options = {
+      get offset() {
+        reads++
+        return "garbage"
       }
-    ])("calculates $name exactly", async ({ expected, options, size }) => {
-      const info = fileInfo(size)
-      const body = await Effect.runPromise(
-        make(info, options).pipe(
-          Effect.provideService(FileSystem.FileSystem, fileSystem(info))
-        )
-      )
-      assert.strictEqual(body.contentLength, expected)
-    })
-
-    it.each([
-      { name: "first unsafe length", size: maxSafe + 1n, options: {} },
-      { name: "length that would round down", size: oversized, options: {} },
-      { name: "length that would round up", size: oversized + 2n, options: {} },
-      { name: "unsafe length after applying an offset", size: oversized, options: { offset: 1 } },
-      {
-        name: "unsafe length after applying both bounds",
-        size: oversized + 3n,
-        options: { offset: 1, bytesToRead: oversized }
-      },
-      { name: "length beyond the finite number range", size: 10n ** 400n, options: {} }
-    ])("rejects $name with typed BadArgument", async ({ options, size }) => {
-      const info = fileInfo(size)
-      const error = await Effect.runPromise(
-        make(info, options).pipe(
-          Effect.flip,
-          Effect.provideService(FileSystem.FileSystem, fileSystem(info))
-        )
-      )
-      assert.strictEqual(error._tag, "PlatformError")
-      assert.strictEqual(error.reason._tag, "BadArgument")
-    })
-
-    for (const field of ["offset", "bytesToRead"] as const) {
-      it.each([
-        { name: "malformed string", value: "garbage" },
-        { name: "fractional byte string", value: "1.5 B" },
-        { name: "negative string", value: "-1 B" },
-        { name: "negative bigint", value: -1n },
-        { name: "negative number", value: -1 },
-        { name: "fractional number", value: 1.5 },
-        { name: "NaN", value: NaN },
-        { name: "positive infinity", value: Infinity },
-        { name: "negative infinity", value: -Infinity },
-        { name: "unsafe integer number", value: Number.MAX_SAFE_INTEGER + 1 }
-      ])(`rejects ${field} containing $name with typed BadArgument`, async ({ value }) => {
-        const info = fileInfo(6n)
-        // Construction outside Effect.gen must not throw, even for invalid inputs.
-        const body = make(info, { [field]: value })
-        const error = await Effect.runPromise(body.pipe(
-          Effect.flip,
-          Effect.provideService(FileSystem.FileSystem, fileSystem(info))
-        ))
-        assert.strictEqual(error._tag, "PlatformError")
-        assert.strictEqual(error.reason._tag, "BadArgument")
-      })
     }
-
-    it.each([
-      { name: "invalid offset with zero bytes requested", options: { offset: -1, bytesToRead: 0 } },
-      { name: "invalid byte count at EOF", options: { offset: 6, bytesToRead: -1 } },
-      { name: "unsafe numeric byte count past EOF", options: { offset: 7, bytesToRead: Number.MAX_SAFE_INTEGER + 1 } }
-    ])("validates $name before accepting an empty body", async ({ options }) => {
-      const info = fileInfo(6n)
-      const error = await Effect.runPromise(
-        make(info, options).pipe(
-          Effect.flip,
-          Effect.provideService(FileSystem.FileSystem, fileSystem(info))
+    // Construct outside Effect.gen so eager validation fails the test.
+    const info = fileInfo(6n)
+    const body = (constructor === "file" ? HttpBody.file("x", options) : HttpBody.fileFromInfo("x", info, options))
+      .pipe(
+        Effect.provideService(
+          FileSystem.FileSystem,
+          FileSystem.makeNoop({
+            stat: () => {
+              statCalls++
+              return Effect.succeed(info)
+            },
+            stream: () => assert.fail("invalid ranges must fail before creating a stream")
+          })
         )
       )
-      assert.strictEqual(error.reason._tag, "BadArgument")
-    })
-
-    it("defers reading range inputs and accessing the filesystem until evaluation", async () => {
-      const info = fileInfo(6n)
-      let reads = 0
-      let statCalls = 0
-      let streamCalls = 0
-      const body = make(info, {
-        get offset() {
-          reads++
-          return 2
-        }
-      }).pipe(Effect.provideService(
-        FileSystem.FileSystem,
-        FileSystem.makeNoop({
-          stat: () => {
-            statCalls++
-            return Effect.succeed(info)
-          },
-          stream: () => {
-            streamCalls++
-            return Stream.empty
-          }
-        })
-      ))
-      assert.strictEqual(reads, 0)
-      assert.strictEqual(statCalls, 0)
-      assert.strictEqual(streamCalls, 0)
-      assert.strictEqual((await Effect.runPromise(body)).contentLength, 4)
-      assert.isAbove(reads, 0)
-      assert.strictEqual(statCalls, constructor === "file" ? 1 : 0)
-      assert.strictEqual(streamCalls, 1)
-    })
-
-    it.each([
-      { name: "whole file", options: {}, expected: [1, 2, 3, 4, 5, 6] },
-      { name: "offset only", options: { offset: 2 }, expected: [3, 4, 5, 6] },
-      {
-        name: "selected ByteSize range",
-        options: { offset: ByteSize.bytes(2), bytesToRead: ByteSize.bytes(2) },
-        expected: [3, 4]
-      },
-      { name: "selected string range", options: { offset: "2 B", bytesToRead: "2 B" }, expected: [3, 4] },
-      { name: "byte count past EOF", options: { offset: 2, bytesToRead: 10 }, expected: [3, 4, 5, 6] },
-      { name: "offset at EOF", options: { offset: 6 }, expected: [] },
-      { name: "offset past EOF", options: { offset: 7, bytesToRead: 2 }, expected: [] },
-      { name: "zero byte count", options: { bytesToRead: 0 }, expected: [] }
-    ])("preserves the bytes and content length for $name", async ({ expected, options }) => {
-      const info = fileInfo(6n)
-      const body = await Effect.runPromise(
-        make(info, { ...options, contentType: "text/plain", chunkSize: 2 }).pipe(
-          Effect.provideService(
-            FileSystem.FileSystem,
-            FileSystem.makeNoop({
-              stat: () => Effect.succeed(info),
-              stream: (path, range) => {
-                assert.strictEqual(path, "x")
-                assert.strictEqual(range?.chunkSize, 2)
-                const offset = Number(ByteSize.fromInputUnsafe(range?.offset ?? 0))
-                const count = Number(ByteSize.fromInputUnsafe(range?.bytesToRead ?? 6))
-                return Stream.succeed(new Uint8Array([1, 2, 3, 4, 5, 6]).slice(offset, offset + count))
-              }
-            })
-          )
-        )
-      )
-      const bytes = await Effect.runPromise(Stream.mkUint8Array(body.stream))
-      assert.deepStrictEqual(Array.from(bytes), expected)
-      assert.strictEqual(body.contentLength, bytes.length)
-      assert.strictEqual(body.contentType, "text/plain")
-    })
+    assert.strictEqual(reads, 0)
+    assert.strictEqual(statCalls, 0)
+    const error = await Effect.runPromise(body.pipe(Effect.flip))
+    assert.strictEqual(error._tag, "PlatformError")
+    assert.strictEqual(error.reason._tag, "BadArgument")
+    assert.strictEqual(error.reason.method, constructor)
+    assert.isAbove(reads, 0)
+    assert.strictEqual(statCalls, constructor === "file" ? 1 : 0)
   })
 }
+
+it("fileFromInfo preserves a small selected range and stream options", async () => {
+  const options = { offset: "2 B", bytesToRead: ByteSize.bytes(2), contentType: "text/plain", chunkSize: 2 }
+  const body = await Effect.runPromise(
+    HttpBody.fileFromInfo("x", fileInfo(6n), options).pipe(
+      Effect.provideService(
+        FileSystem.FileSystem,
+        FileSystem.makeNoop({
+          stream: (path, range) => {
+            assert.strictEqual(path, "x")
+            assert.deepStrictEqual(range, options)
+            return Stream.succeed(new Uint8Array([3, 4]))
+          }
+        })
+      )
+    )
+  )
+  const bytes = await Effect.runPromise(Stream.mkUint8Array(body.stream))
+  assert.deepStrictEqual(Array.from(bytes), [3, 4])
+  assert.strictEqual(body.contentLength, bytes.length)
+  assert.strictEqual(body.contentType, "text/plain")
+})

--- a/packages/effect/test/unstable/http/HttpClientRequest.test.ts
+++ b/packages/effect/test/unstable/http/HttpClientRequest.test.ts
@@ -1,10 +1,75 @@
 import { describe, it } from "@effect/vitest"
 import { assertNone, assertSome, assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
-import { Effect, Stream } from "effect"
+import { ByteSize, Effect, FileSystem, Stream } from "effect"
 import * as Option from "effect/Option"
 import { Headers, HttpBody, HttpClientRequest } from "effect/unstable/http"
 
 describe("HttpClientRequest", () => {
+  describe("bodyFile", () => {
+    const oversized = 9007199254740993n
+    const fileSystem = (size: bigint) =>
+      FileSystem.makeNoop({
+        stat: () => Effect.succeed({ size: ByteSize.bytes(size) } as FileSystem.File.Info),
+        stream: () => Stream.empty
+      })
+
+    it.each([
+      { name: "whole small file", size: 6n, options: {}, expected: 6 },
+      { name: "range clamped to EOF", size: 6n, options: { offset: 2, bytesToRead: 10 }, expected: 4 },
+      { name: "range past EOF", size: 6n, options: { offset: 7 }, expected: 0 },
+      {
+        name: "maximum safe length",
+        size: BigInt(Number.MAX_SAFE_INTEGER),
+        options: {},
+        expected: Number.MAX_SAFE_INTEGER
+      },
+      { name: "small range of an oversized file", size: oversized, options: { bytesToRead: 2 }, expected: 2 },
+      { name: "unsafe bigint offset", size: oversized + 3n, options: { offset: oversized }, expected: 3 },
+      { name: "unsafe string offset", size: oversized + 3n, options: { offset: "9007199254740993 B" }, expected: 3 },
+      { name: "unsafe byte count clamped to EOF", size: 6n, options: { bytesToRead: oversized }, expected: 6 }
+    ])("sets the exact outgoing Content-Length for $name", async ({ expected, options, size }) => {
+      const request = await Effect.runPromise(
+        HttpClientRequest.post("https://example.com").pipe(
+          HttpClientRequest.bodyText("stale"),
+          HttpClientRequest.bodyFile("x", { ...options, contentType: "application/octet-stream" }),
+          Effect.provideService(FileSystem.FileSystem, fileSystem(size))
+        )
+      )
+      strictEqual(request.body._tag, "Stream")
+      if (request.body._tag === "Stream") {
+        strictEqual(request.body.contentLength, expected)
+      }
+      strictEqual(request.headers["content-length"], String(expected))
+      strictEqual(request.headers["content-type"], "application/octet-stream")
+      const web = await Effect.runPromise(HttpClientRequest.toWeb(request))
+      strictEqual(web.headers.get("content-length"), String(expected))
+    })
+
+    it.each([
+      { name: "unrepresentable whole file", size: oversized, options: {} },
+      { name: "unrepresentable clamped length", size: oversized + 3n, options: { offset: 1, bytesToRead: oversized } },
+      { name: "malformed offset", size: 6n, options: { offset: "garbage" } },
+      { name: "malformed byte count", size: 6n, options: { bytesToRead: "garbage" } },
+      { name: "unsafe numeric offset", size: 6n, options: { offset: Number.MAX_SAFE_INTEGER + 1 } },
+      { name: "unsafe numeric byte count", size: 6n, options: { bytesToRead: Number.MAX_SAFE_INTEGER + 1 } },
+      { name: "negative offset", size: 6n, options: { offset: -1n } },
+      { name: "negative byte count", size: 6n, options: { bytesToRead: -1 } },
+      { name: "fractional offset", size: 6n, options: { offset: 1.5 } },
+      { name: "fractional byte count", size: 6n, options: { bytesToRead: 1.5 } },
+      { name: "non-finite offset", size: 6n, options: { offset: Infinity } },
+      { name: "non-finite byte count", size: 6n, options: { bytesToRead: NaN } }
+    ])("propagates typed BadArgument for $name", async ({ options, size }) => {
+      // Invalid inputs must remain lazy through the request combinator too.
+      const request = HttpClientRequest.bodyFile(HttpClientRequest.post("https://example.com"), "x", options)
+      const error = await Effect.runPromise(request.pipe(
+        Effect.flip,
+        Effect.provideService(FileSystem.FileSystem, fileSystem(size))
+      ))
+      strictEqual(error._tag, "PlatformError")
+      strictEqual(error.reason._tag, "BadArgument")
+    })
+  })
+
   describe("appendUrl", () => {
     it("joins segments without slashes", () => {
       const request = HttpClientRequest.get("base").pipe(

--- a/packages/effect/test/unstable/http/HttpClientRequest.test.ts
+++ b/packages/effect/test/unstable/http/HttpClientRequest.test.ts
@@ -14,19 +14,8 @@ describe("HttpClientRequest", () => {
       })
 
     it.each([
-      { name: "whole small file", size: 6n, options: {}, expected: 6 },
-      { name: "range clamped to EOF", size: 6n, options: { offset: 2, bytesToRead: 10 }, expected: 4 },
-      { name: "range past EOF", size: 6n, options: { offset: 7 }, expected: 0 },
-      {
-        name: "maximum safe length",
-        size: BigInt(Number.MAX_SAFE_INTEGER),
-        options: {},
-        expected: Number.MAX_SAFE_INTEGER
-      },
-      { name: "small range of an oversized file", size: oversized, options: { bytesToRead: 2 }, expected: 2 },
       { name: "unsafe bigint offset", size: oversized + 3n, options: { offset: oversized }, expected: 3 },
-      { name: "unsafe string offset", size: oversized + 3n, options: { offset: "9007199254740993 B" }, expected: 3 },
-      { name: "unsafe byte count clamped to EOF", size: 6n, options: { bytesToRead: oversized }, expected: 6 }
+      { name: "range past EOF", size: 6n, options: { offset: 7 }, expected: 0 }
     ])("sets the exact outgoing Content-Length for $name", async ({ expected, options, size }) => {
       const request = await Effect.runPromise(
         HttpClientRequest.post("https://example.com").pipe(
@@ -45,25 +34,13 @@ describe("HttpClientRequest", () => {
       strictEqual(web.headers.get("content-length"), String(expected))
     })
 
-    it.each([
-      { name: "unrepresentable whole file", size: oversized, options: {} },
-      { name: "unrepresentable clamped length", size: oversized + 3n, options: { offset: 1, bytesToRead: oversized } },
-      { name: "malformed offset", size: 6n, options: { offset: "garbage" } },
-      { name: "malformed byte count", size: 6n, options: { bytesToRead: "garbage" } },
-      { name: "unsafe numeric offset", size: 6n, options: { offset: Number.MAX_SAFE_INTEGER + 1 } },
-      { name: "unsafe numeric byte count", size: 6n, options: { bytesToRead: Number.MAX_SAFE_INTEGER + 1 } },
-      { name: "negative offset", size: 6n, options: { offset: -1n } },
-      { name: "negative byte count", size: 6n, options: { bytesToRead: -1 } },
-      { name: "fractional offset", size: 6n, options: { offset: 1.5 } },
-      { name: "fractional byte count", size: 6n, options: { bytesToRead: 1.5 } },
-      { name: "non-finite offset", size: 6n, options: { offset: Infinity } },
-      { name: "non-finite byte count", size: 6n, options: { bytesToRead: NaN } }
-    ])("propagates typed BadArgument for $name", async ({ options, size }) => {
-      // Invalid inputs must remain lazy through the request combinator too.
-      const request = HttpClientRequest.bodyFile(HttpClientRequest.post("https://example.com"), "x", options)
+    it("propagates typed BadArgument from file range validation", async () => {
+      const request = HttpClientRequest.bodyFile(HttpClientRequest.post("https://example.com"), "x", {
+        bytesToRead: "garbage"
+      })
       const error = await Effect.runPromise(request.pipe(
         Effect.flip,
-        Effect.provideService(FileSystem.FileSystem, fileSystem(size))
+        Effect.provideService(FileSystem.FileSystem, fileSystem(6n))
       ))
       strictEqual(error._tag, "PlatformError")
       strictEqual(error.reason._tag, "BadArgument")


### PR DESCRIPTION
File body constructors can round Content-Length when sizes or offsets exceed the safe integer range, and invalid ranges currently cause defects. Calculate ranges with exact bigint arithmetic, clamp to EOF, and convert only the final safe length to a number. Invalid inputs and final lengths above `Number.MAX_SAFE_INTEGER` now fail with typed `PlatformError` / `BadArgument`; larger sizes and ranges remain valid when their resulting length is representable.

The change covers `HttpBody.file`, `HttpBody.fileFromInfo`, and propagation through `HttpClientRequest.bodyFile`, with public policy documentation and a changeset. Regression tests use stat/stream doubles and cover lazy evaluation, small-file bytes, EOF clamping, oversized ranges, invalid inputs, and outgoing headers.

Validation:

- All 43 tests pass in `HttpBody.test.ts` and `HttpClientRequest.test.ts` (previously 147). File-body cases were reduced from 126 to 22 by removing redundant permutations and repeated entry-point coverage; the 21 unrelated request tests are unchanged.
- `nix develop -c pnpm lint-fix`, `nix develop -c pnpm lint`, and `nix develop -c pnpm check` pass.
- `nix develop -c pnpm jsdocs --check` reports two existing errors in unchanged `packages/effect/src/Logger.ts`: an out-of-order `@see` and an unresolved `consolePretty` link. No diagnostics concern the modified HTTP docs.

Closes EFF-1310
