### PR TITLE
Refine network address serialization and error handling

### DIFF
--- a/.changeset/net-address-values.md
+++ b/.changeset/net-address-values.md
@@ -13,10 +13,10 @@ Add platform-neutral network address modules under `effect/unstable/net`:
 - `IpInterface` provides IP host addresses that preserve their prefix lengths and host bits.
 - `IpNetwork` provides canonical IPv4 and IPv6 CIDR networks, including containment, overlap, bounds, and address counts.
 
-IP address constructors copy their input bytes, including Node.js Buffers, so mutating the input cannot change stored addresses, equality, or hashes.
+IP address constructors copy their input bytes, including Node.js Buffers, so mutating the input cannot change stored addresses, equality, or hashes. Network address values serialize to canonical strings through `toJSON`, keeping private bytes out of JSON output. `NetAddressError.input` retains the original failing input, including complete socket and CIDR strings. The new network schemas in `Schema` are marked unstable, and their string codecs expose named interfaces.
 
-HTTP and socket servers now expose canonical `NetAddress.SocketAddress` values. TCP addresses use `NetAddress.InetAddress` with an `address` field instead of `hostname`, and Unix addresses use `NetAddress.UnixPathAddress`. IPv6 URL authorities are bracketed. A server bound to `::` now logs `http://[::]:3000` instead of `http://0.0.0.0:3000`, and HTTP test clients use IPv6 loopback for IPv6 unspecified listeners.
+HTTP and socket servers now expose canonical `NetAddress.SocketAddress` values. TCP addresses use `NetAddress.InetAddress` with an `address` field instead of `hostname`, and Unix addresses use `NetAddress.UnixPathAddress`. IPv6 URL authorities are bracketed. A server bound to `::` now logs `http://[::]:3000` instead of `http://0.0.0.0:3000`, and HTTP test clients retain the IPv4 loopback fallback for unspecified listeners, including dual-stack IPv6. `HttpServer.formatAddress` and `HttpServer.makeTestClient` reject scoped IPv6 addresses because WHATWG URLs cannot preserve their interface scope.
 
-Bun continues to resolve listener hostnames before binding. Bun and Deno HTTP server layers can now fail with `ServeError` when their native listener address cannot be converted to a `NetAddress`.
+Bun continues to resolve listener hostnames before binding and treats an explicitly undefined `unix` option as a TCP listener. Bun and Deno HTTP server layers can now fail with `ServeError` when their native listener address cannot be converted to a `NetAddress`.
 
-PostgreSQL `inet` now uses `IpInterface`. The `cidr` codec rejects addresses with host bits set and still treats a bare address as a full-width network.
+PostgreSQL `inet` now uses `IpInterface`. The `cidr` codec rejects addresses with host bits set and still treats a bare address as a full-width network. Network encoding errors include the original value, PostgreSQL type, and validation failure.

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -11290,6 +11290,7 @@ const netAddressFromString = <A, E extends { readonly message: string }>(
 /**
  * Schema for already-constructed MAC address values.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
@@ -11298,12 +11299,24 @@ export const MacAddress: declare<NetAddress_.MacAddress> = declare(NetAddress_.i
 })
 
 /**
+ * Type-level representation of {@link MacAddressFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface MacAddressFromString extends decodeTo<typeof MacAddress, String> {
+  readonly "Rebuild": MacAddressFromString
+}
+
+/**
  * Schema for MAC addresses encoded as canonical colon-separated hexadecimal strings.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const MacAddressFromString = netAddressFromString(
+export const MacAddressFromString: MacAddressFromString = netAddressFromString(
   MacAddress,
   NetAddress_.macAddressFromString,
   NetAddress_.formatMacAddress,
@@ -11313,6 +11326,7 @@ export const MacAddressFromString = netAddressFromString(
 /**
  * Schema for already-constructed IPv4 address values.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
@@ -11321,12 +11335,24 @@ export const Ipv4Address: declare<NetAddress_.Ipv4Address> = declare(NetAddress_
 })
 
 /**
+ * Type-level representation of {@link Ipv4AddressFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface Ipv4AddressFromString extends decodeTo<typeof Ipv4Address, String> {
+  readonly "Rebuild": Ipv4AddressFromString
+}
+
+/**
  * Schema for IPv4 addresses encoded as canonical dotted-decimal strings.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const Ipv4AddressFromString = netAddressFromString(
+export const Ipv4AddressFromString: Ipv4AddressFromString = netAddressFromString(
   Ipv4Address,
   NetAddress_.ipv4FromString,
   NetAddress_.formatIp,
@@ -11336,6 +11362,7 @@ export const Ipv4AddressFromString = netAddressFromString(
 /**
  * Schema for already-constructed IPv6 address values.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
@@ -11344,12 +11371,24 @@ export const Ipv6Address: declare<NetAddress_.Ipv6Address> = declare(NetAddress_
 })
 
 /**
+ * Type-level representation of {@link Ipv6AddressFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface Ipv6AddressFromString extends decodeTo<typeof Ipv6Address, String> {
+  readonly "Rebuild": Ipv6AddressFromString
+}
+
+/**
  * Schema for IPv6 addresses encoded as canonical strings.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const Ipv6AddressFromString = netAddressFromString(
+export const Ipv6AddressFromString: Ipv6AddressFromString = netAddressFromString(
   Ipv6Address,
   NetAddress_.ipv6FromString,
   NetAddress_.formatIp,
@@ -11359,6 +11398,7 @@ export const Ipv6AddressFromString = netAddressFromString(
 /**
  * Schema for already-constructed IPv4 or IPv6 address values.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
@@ -11367,12 +11407,24 @@ export const IpAddress: declare<NetAddress_.IpAddress> = declare(NetAddress_.isI
 })
 
 /**
+ * Type-level representation of {@link IpAddressFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface IpAddressFromString extends decodeTo<typeof IpAddress, String> {
+  readonly "Rebuild": IpAddressFromString
+}
+
+/**
  * Schema for IP addresses encoded as canonical numeric strings.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const IpAddressFromString = netAddressFromString(
+export const IpAddressFromString: IpAddressFromString = netAddressFromString(
   IpAddress,
   NetAddress_.ipFromString,
   NetAddress_.formatIp,
@@ -11382,6 +11434,7 @@ export const IpAddressFromString = netAddressFromString(
 /**
  * Schema for already-constructed IPv4 interface address values.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
@@ -11390,12 +11443,24 @@ export const Ipv4Interface: declare<IpInterface_.Ipv4Interface> = declare(IpInte
 })
 
 /**
+ * Type-level representation of {@link Ipv4InterfaceFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface Ipv4InterfaceFromString extends decodeTo<typeof Ipv4Interface, String> {
+  readonly "Rebuild": Ipv4InterfaceFromString
+}
+
+/**
  * Schema for IPv4 interface addresses encoded as an address and prefix length.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const Ipv4InterfaceFromString = netAddressFromString(
+export const Ipv4InterfaceFromString: Ipv4InterfaceFromString = netAddressFromString(
   Ipv4Interface,
   IpInterface_.ipv4FromString,
   IpInterface_.format,
@@ -11405,6 +11470,7 @@ export const Ipv4InterfaceFromString = netAddressFromString(
 /**
  * Schema for already-constructed IPv6 interface address values.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
@@ -11413,12 +11479,24 @@ export const Ipv6Interface: declare<IpInterface_.Ipv6Interface> = declare(IpInte
 })
 
 /**
+ * Type-level representation of {@link Ipv6InterfaceFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface Ipv6InterfaceFromString extends decodeTo<typeof Ipv6Interface, String> {
+  readonly "Rebuild": Ipv6InterfaceFromString
+}
+
+/**
  * Schema for IPv6 interface addresses encoded as an address and prefix length.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const Ipv6InterfaceFromString = netAddressFromString(
+export const Ipv6InterfaceFromString: Ipv6InterfaceFromString = netAddressFromString(
   Ipv6Interface,
   IpInterface_.ipv6FromString,
   IpInterface_.format,
@@ -11428,6 +11506,7 @@ export const Ipv6InterfaceFromString = netAddressFromString(
 /**
  * Schema for already-constructed IPv4 or IPv6 interface address values.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
@@ -11436,12 +11515,24 @@ export const IpInterface: declare<IpInterface_.IpInterface> = declare(IpInterfac
 })
 
 /**
+ * Type-level representation of {@link IpInterfaceFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface IpInterfaceFromString extends decodeTo<typeof IpInterface, String> {
+  readonly "Rebuild": IpInterfaceFromString
+}
+
+/**
  * Schema for IPv4 or IPv6 interface addresses encoded as an address and prefix length.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const IpInterfaceFromString = netAddressFromString(
+export const IpInterfaceFromString: IpInterfaceFromString = netAddressFromString(
   IpInterface,
   IpInterface_.fromString,
   IpInterface_.format,
@@ -11451,6 +11542,7 @@ export const IpInterfaceFromString = netAddressFromString(
 /**
  * Schema for already-constructed canonical IPv4 network prefixes.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
@@ -11459,12 +11551,24 @@ export const Ipv4Network: declare<IpNetwork_.Ipv4Network> = declare(IpNetwork_.i
 })
 
 /**
+ * Type-level representation of {@link Ipv4NetworkFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface Ipv4NetworkFromString extends decodeTo<typeof Ipv4Network, String> {
+  readonly "Rebuild": Ipv4NetworkFromString
+}
+
+/**
  * Schema for canonical IPv4 network prefixes encoded in CIDR notation.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const Ipv4NetworkFromString = netAddressFromString(
+export const Ipv4NetworkFromString: Ipv4NetworkFromString = netAddressFromString(
   Ipv4Network,
   IpNetwork_.ipv4FromString,
   IpNetwork_.format,
@@ -11474,6 +11578,7 @@ export const Ipv4NetworkFromString = netAddressFromString(
 /**
  * Schema for already-constructed canonical IPv6 network prefixes.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
@@ -11482,12 +11587,24 @@ export const Ipv6Network: declare<IpNetwork_.Ipv6Network> = declare(IpNetwork_.i
 })
 
 /**
+ * Type-level representation of {@link Ipv6NetworkFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface Ipv6NetworkFromString extends decodeTo<typeof Ipv6Network, String> {
+  readonly "Rebuild": Ipv6NetworkFromString
+}
+
+/**
  * Schema for canonical IPv6 network prefixes encoded in CIDR notation.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const Ipv6NetworkFromString = netAddressFromString(
+export const Ipv6NetworkFromString: Ipv6NetworkFromString = netAddressFromString(
   Ipv6Network,
   IpNetwork_.ipv6FromString,
   IpNetwork_.format,
@@ -11497,6 +11614,7 @@ export const Ipv6NetworkFromString = netAddressFromString(
 /**
  * Schema for already-constructed canonical IPv4 or IPv6 network prefixes.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
@@ -11505,12 +11623,24 @@ export const IpNetwork: declare<IpNetwork_.IpNetwork> = declare(IpNetwork_.isIpN
 })
 
 /**
+ * Type-level representation of {@link IpNetworkFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface IpNetworkFromString extends decodeTo<typeof IpNetwork, String> {
+  readonly "Rebuild": IpNetworkFromString
+}
+
+/**
  * Schema for canonical IPv4 or IPv6 network prefixes encoded in CIDR notation.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const IpNetworkFromString = netAddressFromString(
+export const IpNetworkFromString: IpNetworkFromString = netAddressFromString(
   IpNetwork,
   IpNetwork_.fromString,
   IpNetwork_.format,
@@ -11520,6 +11650,7 @@ export const IpNetworkFromString = netAddressFromString(
 /**
  * Schema for already-constructed resolved IPv4 internet addresses.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
@@ -11530,6 +11661,7 @@ export const InetAddressV4: declare<NetAddress_.InetAddressV4> = declare(NetAddr
 /**
  * Schema for already-constructed resolved IPv6 internet addresses.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
@@ -11540,6 +11672,7 @@ export const InetAddressV6: declare<NetAddress_.InetAddressV6> = declare(NetAddr
 /**
  * Schema for already-constructed resolved internet addresses.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
@@ -11548,12 +11681,24 @@ export const InetAddress: declare<NetAddress_.InetAddress> = declare(NetAddress_
 })
 
 /**
+ * Type-level representation of {@link InetAddressFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface InetAddressFromString extends decodeTo<typeof InetAddress, String> {
+  readonly "Rebuild": InetAddressFromString
+}
+
+/**
  * Schema for resolved internet addresses encoded as numeric socket strings.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const InetAddressFromString = netAddressFromString(
+export const InetAddressFromString: InetAddressFromString = netAddressFromString(
   InetAddress,
   NetAddress_.inetAddressFromString,
   NetAddress_.formatInet,
@@ -11563,6 +11708,7 @@ export const InetAddressFromString = netAddressFromString(
 /**
  * Schema for already-constructed Unix-domain filesystem addresses.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
@@ -11572,12 +11718,24 @@ export const UnixPathAddress: declare<NetAddress_.UnixPathAddress> = declare(
 )
 
 /**
+ * Type-level representation of {@link UnixPathAddressFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface UnixPathAddressFromString extends decodeTo<typeof UnixPathAddress, String> {
+  readonly "Rebuild": UnixPathAddressFromString
+}
+
+/**
  * Schema for Unix-domain filesystem addresses encoded as opaque path strings.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const UnixPathAddressFromString = String.pipe(decodeTo(
+export const UnixPathAddressFromString: UnixPathAddressFromString = String.pipe(decodeTo(
   UnixPathAddress,
   SchemaTransformation.transform({
     decode: NetAddress_.unixPathAddress,
@@ -11588,6 +11746,7 @@ export const UnixPathAddressFromString = String.pipe(decodeTo(
 /**
  * Schema for already-constructed portable concrete socket addresses.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */

--- a/packages/effect/src/unstable/http/HttpServer.ts
+++ b/packages/effect/src/unstable/http/HttpServer.ts
@@ -178,13 +178,16 @@ export const serveEffect: {
  *
  * **Gotchas**
  *
- * IPv6 scope identifiers are omitted because WHATWG URLs do not support scoped
+ * Throws for scoped IPv6 addresses because WHATWG URLs do not support scoped
  * IPv6 hosts.
  *
  * @category converting
  * @since 4.0.0
  */
 export const formatAddress = (address: NetAddress.SocketAddress): string => {
+  if (address._tag === "InetAddressV6" && address.scopeId !== 0) {
+    throw new Error("HttpServer.formatAddress: scoped IPv6 addresses are not supported")
+  }
   switch (address._tag) {
     case "UnixPathAddress":
       return `unix://${address.path}`
@@ -238,7 +241,7 @@ export const withLogAddress = <A, E, R>(
  * **Details**
  *
  * For internet servers, requests are prefixed with the server URL and unspecified
- * addresses are replaced by the loopback address of the same IP family.
+ * addresses are replaced by IPv4 loopback, including dual-stack IPv6 listeners.
  *
  * **Gotchas**
  *
@@ -258,9 +261,10 @@ export const makeTestClient: Effect.Effect<
   if (address._tag === "UnixPathAddress") {
     return yield* Effect.die(new Error("HttpServer.layerTestClient: UnixPathAddress not supported"))
   }
-  const host = NetAddress.isUnspecified(address.address)
-    ? NetAddress.isIpv4Address(address.address) ? NetAddress.ipv4Loopback : NetAddress.ipv6Loopback
-    : address.address
+  if (address._tag === "InetAddressV6" && address.scopeId !== 0) {
+    return yield* Effect.die(new Error("HttpServer.makeTestClient: scoped IPv6 addresses are not supported"))
+  }
+  const host = NetAddress.isUnspecified(address.address) ? NetAddress.ipv4Loopback : address.address
   const url = `http://${NetAddress.formatUrlHost(host)}:${address.port}`
   return HttpClient.mapRequest(client, ClientRequest.prependUrl(url))
 })

--- a/packages/effect/src/unstable/net/IpInterface.ts
+++ b/packages/effect/src/unstable/net/IpInterface.ts
@@ -24,6 +24,7 @@ export interface IpInterface<out A extends NetAddress.IpAddress = NetAddress.IpA
   readonly prefixLength: number
   readonly [TypeId]: typeof TypeId
   toString(): string
+  toJSON(): string
 }
 
 /**
@@ -100,13 +101,16 @@ const IpInterfaceProto = {
   toString(this: IpInterface): string {
     return format(this)
   },
-  [NodeInspectSymbol](this: IpInterface): string {
+  toJSON(this: IpInterface): string {
     return this.toString()
+  },
+  [NodeInspectSymbol](this: IpInterface): string {
+    return this.toJSON()
   }
 }
 
-const interfaceError = (message: string): Result.Result<never, NetAddress.NetAddressError> =>
-  Result.fail(new NetAddress.NetAddressError({ message }))
+const interfaceError = (message: string, input: unknown): Result.Result<never, NetAddress.NetAddressError> =>
+  Result.fail(new NetAddress.NetAddressError({ message, input }))
 
 /**
  * Creates an interface address while preserving all address bits.
@@ -120,7 +124,7 @@ export const make = <A extends NetAddress.IpAddress>(
 ): Result.Result<IpInterface<A>, NetAddress.NetAddressError> => {
   const max = NetAddress.width(address)
   if (!Number.isInteger(prefixLength) || prefixLength < 0 || prefixLength > max) {
-    return interfaceError(`prefix length must be an integer from 0 through ${max}`)
+    return interfaceError(`prefix length must be an integer from 0 through ${max}`, { address, prefixLength })
   }
   const self = Object.assign(Object.create(IpInterfaceProto), { address, prefixLength })
   return Result.succeed(Object.freeze(self))
@@ -138,11 +142,11 @@ const parseAddressWithPrefix = (
     return Result.succeed({ address: input, prefixLength: undefined })
   }
   if (slash <= 0 || slash !== input.lastIndexOf("/") || slash === input.length - 1) {
-    return interfaceError("expected an address and prefix length separated by one slash")
+    return interfaceError("expected an address and prefix length separated by one slash", input)
   }
   const prefix = input.slice(slash + 1)
   if (!/^(0|[1-9][0-9]*)$/.test(prefix)) {
-    return interfaceError("prefix length must be an unpadded ASCII decimal integer")
+    return interfaceError("prefix length must be an unpadded ASCII decimal integer", input)
   }
   return Result.succeed({ address: input.slice(0, slash), prefixLength: Number(prefix) })
 }
@@ -161,11 +165,16 @@ export const ipv4FromString = (
   input: string,
   options?: IpInterface.ParseOptions
 ): Result.Result<Ipv4Interface, NetAddress.NetAddressError> =>
-  Result.flatMap(
-    parseAddressWithPrefix(input, options),
-    (parts) =>
-      Result.flatMap(NetAddress.ipv4FromString(parts.address), (address) =>
-        make(address, parts.prefixLength ?? NetAddress.width(address)))
+  Result.mapError(
+    Result.flatMap(
+      parseAddressWithPrefix(input, options),
+      (parts) =>
+        Result.flatMap(
+          NetAddress.ipv4FromString(parts.address),
+          (address) => make(address, parts.prefixLength ?? NetAddress.width(address))
+        )
+    ),
+    (error) => new NetAddress.NetAddressError({ message: error.message, input })
   )
 
 /**
@@ -182,11 +191,16 @@ export const ipv6FromString = (
   input: string,
   options?: IpInterface.ParseOptions
 ): Result.Result<Ipv6Interface, NetAddress.NetAddressError> =>
-  Result.flatMap(
-    parseAddressWithPrefix(input, options),
-    (parts) =>
-      Result.flatMap(NetAddress.ipv6FromString(parts.address), (address) =>
-        make(address, parts.prefixLength ?? NetAddress.width(address)))
+  Result.mapError(
+    Result.flatMap(
+      parseAddressWithPrefix(input, options),
+      (parts) =>
+        Result.flatMap(
+          NetAddress.ipv6FromString(parts.address),
+          (address) => make(address, parts.prefixLength ?? NetAddress.width(address))
+        )
+    ),
+    (error) => new NetAddress.NetAddressError({ message: error.message, input })
   )
 
 /**
@@ -204,11 +218,16 @@ export const fromString = (
   input: string,
   options?: IpInterface.ParseOptions
 ): Result.Result<IpInterface, NetAddress.NetAddressError> =>
-  Result.flatMap(
-    parseAddressWithPrefix(input, options),
-    (parts) =>
-      Result.flatMap(NetAddress.ipFromString(parts.address), (address) =>
-        make(address, parts.prefixLength ?? NetAddress.width(address)))
+  Result.mapError(
+    Result.flatMap(
+      parseAddressWithPrefix(input, options),
+      (parts) =>
+        Result.flatMap(
+          NetAddress.ipFromString(parts.address),
+          (address) => make(address, parts.prefixLength ?? NetAddress.width(address))
+        )
+    ),
+    (error) => new NetAddress.NetAddressError({ message: error.message, input })
   )
 
 /**

--- a/packages/effect/src/unstable/net/IpNetwork.ts
+++ b/packages/effect/src/unstable/net/IpNetwork.ts
@@ -26,6 +26,7 @@ export interface IpNetwork<out A extends NetAddress.IpAddress = NetAddress.IpAdd
   readonly prefixLength: number
   readonly [TypeId]: typeof TypeId
   toString(): string
+  toJSON(): string
 }
 
 /**
@@ -75,13 +76,16 @@ const IpNetworkProto = {
     return isIpNetwork(that) && this.prefixLength === that.prefixLength && Equal.equals(this.address, that.address)
   },
   [Hash.symbol](this: IpNetwork): number {
-    return Hash.combine(Hash.hash(this.address))(Hash.number(this.prefixLength))
+    return Hash.combine(Hash.number(this.prefixLength), Hash.hash(this.address))
   },
   toString(this: IpNetwork): string {
     return format(this)
   },
-  [NodeInspectSymbol](this: IpNetwork): string {
+  toJSON(this: IpNetwork): string {
     return this.toString()
+  },
+  [NodeInspectSymbol](this: IpNetwork): string {
+    return this.toJSON()
   }
 }
 
@@ -131,7 +135,9 @@ export const make = <A extends NetAddress.IpAddress>(
     const bytes = toBytes(address)
     const masked = maskBytes(bytes, prefixLength)
     if (bytes.some((byte, index) => byte !== masked[index])) {
-      return Result.fail(new NetAddress.NetAddressError({ message: "address has non-zero host bits" }))
+      return Result.fail(
+        new NetAddress.NetAddressError({ message: "address has non-zero host bits", input: { address, prefixLength } })
+      )
     }
     return Result.succeed(fromInterfaceValue(value))
   })
@@ -173,9 +179,12 @@ export const fromInterface = <A extends NetAddress.IpAddress>(self: IpInterface.
  * @since 4.0.0
  */
 export const ipv4FromString = (input: string): Result.Result<Ipv4Network, NetAddress.NetAddressError> => {
-  return Result.flatMap(
-    IpInterface.ipv4FromString(input, { prefix: "required" }),
-    (value) => make(value.address, value.prefixLength)
+  return Result.mapError(
+    Result.flatMap(
+      IpInterface.ipv4FromString(input, { prefix: "required" }),
+      (value) => make(value.address, value.prefixLength)
+    ),
+    (error) => new NetAddress.NetAddressError({ message: error.message, input })
   )
 }
 
@@ -186,9 +195,12 @@ export const ipv4FromString = (input: string): Result.Result<Ipv4Network, NetAdd
  * @since 4.0.0
  */
 export const ipv6FromString = (input: string): Result.Result<Ipv6Network, NetAddress.NetAddressError> => {
-  return Result.flatMap(
-    IpInterface.ipv6FromString(input, { prefix: "required" }),
-    (value) => make(value.address, value.prefixLength)
+  return Result.mapError(
+    Result.flatMap(
+      IpInterface.ipv6FromString(input, { prefix: "required" }),
+      (value) => make(value.address, value.prefixLength)
+    ),
+    (error) => new NetAddress.NetAddressError({ message: error.message, input })
   )
 }
 
@@ -199,9 +211,12 @@ export const ipv6FromString = (input: string): Result.Result<Ipv6Network, NetAdd
  * @since 4.0.0
  */
 export const fromString = (input: string): Result.Result<IpNetwork, NetAddress.NetAddressError> => {
-  return Result.flatMap(
-    IpInterface.fromString(input, { prefix: "required" }),
-    (value) => make(value.address, value.prefixLength)
+  return Result.mapError(
+    Result.flatMap(
+      IpInterface.fromString(input, { prefix: "required" }),
+      (value) => make(value.address, value.prefixLength)
+    ),
+    (error) => new NetAddress.NetAddressError({ message: error.message, input })
   )
 }
 

--- a/packages/effect/src/unstable/net/NetAddress.ts
+++ b/packages/effect/src/unstable/net/NetAddress.ts
@@ -24,6 +24,7 @@ export interface Ipv4Address extends Equal.Equal, Hash.Hash {
   readonly _tag: "Ipv4Address"
   readonly [TypeId]: typeof TypeId
   toString(): string
+  toJSON(): string
 }
 
 /**
@@ -36,6 +37,7 @@ export interface Ipv6Address extends Equal.Equal, Hash.Hash {
   readonly _tag: "Ipv6Address"
   readonly [TypeId]: typeof TypeId
   toString(): string
+  toJSON(): string
 }
 
 /**
@@ -56,6 +58,7 @@ export interface MacAddress extends Equal.Equal, Hash.Hash {
   readonly _tag: "MacAddress"
   readonly [TypeId]: typeof TypeId
   toString(): string
+  toJSON(): string
 }
 
 const getBytes = (self: IpAddress | MacAddress): Uint8Array => (self as any).bytes
@@ -72,6 +75,7 @@ export interface InetAddressV4 extends Equal.Equal, Hash.Hash {
   readonly port: number
   readonly [TypeId]: typeof TypeId
   toString(): string
+  toJSON(): string
 }
 
 /**
@@ -87,6 +91,7 @@ export interface InetAddressV6 extends Equal.Equal, Hash.Hash {
   readonly scopeId: number
   readonly [TypeId]: typeof TypeId
   toString(): string
+  toJSON(): string
 }
 
 /**
@@ -108,6 +113,7 @@ export interface UnixPathAddress extends Equal.Equal, Hash.Hash {
   readonly path: string
   readonly [TypeId]: typeof TypeId
   toString(): string
+  toJSON(): string
 }
 
 /**
@@ -144,13 +150,14 @@ export declare namespace SocketAddress {
 }
 
 /**
- * A checked network-address operation failure.
+ * A checked network-address operation failure that retains the original input.
  *
  * @category errors
  * @since 4.0.0
  */
 export class NetAddressError extends Data.TaggedError("NetAddressError")<{
   readonly message: string
+  readonly input: unknown
 }> {}
 
 const isAddress = (u: unknown): u is IpAddress | MacAddress | SocketAddress => hasProperty(u, TypeId)
@@ -247,8 +254,11 @@ const Ipv4Proto = {
   toString(this: Ipv4Address): string {
     return formatIp(this)
   },
-  [NodeInspectSymbol](this: Ipv4Address): string {
+  toJSON(this: Ipv4Address): string {
     return this.toString()
+  },
+  [NodeInspectSymbol](this: Ipv4Address): string {
+    return this.toJSON()
   }
 }
 
@@ -264,8 +274,11 @@ const Ipv6Proto = {
   toString(this: Ipv6Address): string {
     return formatIp(this)
   },
-  [NodeInspectSymbol](this: Ipv6Address): string {
+  toJSON(this: Ipv6Address): string {
     return this.toString()
+  },
+  [NodeInspectSymbol](this: Ipv6Address): string {
+    return this.toJSON()
   }
 }
 
@@ -281,8 +294,11 @@ const MacProto = {
   toString(this: MacAddress): string {
     return formatMacAddress(this)
   },
-  [NodeInspectSymbol](this: MacAddress): string {
+  toJSON(this: MacAddress): string {
     return this.toString()
+  },
+  [NodeInspectSymbol](this: MacAddress): string {
+    return this.toJSON()
   }
 }
 
@@ -309,7 +325,7 @@ const makeIpv6 = (bytes: Uint8Array): Ipv6Address => {
 }
 
 const makeMac = (bytes: Uint8Array): MacAddress => {
-  const self = Object.assign(Object.create(MacProto), { bytes: bytes.slice() })
+  const self = Object.assign(Object.create(MacProto), { bytes: new Uint8Array(bytes) })
   return Object.freeze(self)
 }
 
@@ -369,8 +385,8 @@ export const ipv6Unspecified: Ipv6Address = makeIpv6(new Uint8Array(16))
  */
 export const ipv4Broadcast: Ipv4Address = makeIpv4(new Uint8Array([255, 255, 255, 255]))
 
-const addressError = (message: string): Result.Result<never, NetAddressError> =>
-  Result.fail(new NetAddressError({ message }))
+const addressError = (message: string, input: unknown): Result.Result<never, NetAddressError> =>
+  Result.fail(new NetAddressError({ message, input }))
 
 /**
  * Creates an IPv4 address from four checked octets.
@@ -382,7 +398,7 @@ export const ipv4FromOctets = (
   octets: readonly [number, number, number, number]
 ): Result.Result<Ipv4Address, NetAddressError> => {
   if (!octets.every((n) => Number.isInteger(n) && n >= 0 && n <= 255)) {
-    return addressError("octets must be integers from 0 through 255")
+    return addressError("octets must be integers from 0 through 255", octets)
   }
   return Result.succeed(makeIpv4(new Uint8Array(octets)))
 }
@@ -397,7 +413,7 @@ export const ipv6FromSegments = (
   segments: readonly [number, number, number, number, number, number, number, number]
 ): Result.Result<Ipv6Address, NetAddressError> => {
   if (!segments.every((n) => Number.isInteger(n) && n >= 0 && n <= 0xffff)) {
-    return addressError("segments must be integers from 0 through 65535")
+    return addressError("segments must be integers from 0 through 65535", segments)
   }
   const bytes = new Uint8Array(16)
   for (let index = 0; index < 8; index++) {
@@ -417,7 +433,7 @@ export const macAddressFromOctets = (
   octets: readonly [number, number, number, number, number, number]
 ): Result.Result<MacAddress, NetAddressError> => {
   if (!octets.every((n) => Number.isInteger(n) && n >= 0 && n <= 255)) {
-    return addressError("octets must be integers from 0 through 255")
+    return addressError("octets must be integers from 0 through 255", octets)
   }
   return Result.succeed(makeMac(new Uint8Array(octets)))
 }
@@ -430,7 +446,7 @@ export const macAddressFromOctets = (
  */
 export const macAddressFromString = (input: string): Result.Result<MacAddress, NetAddressError> => {
   if (!/^(?:[0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$/.test(input)) {
-    return addressError("expected six two-digit hexadecimal octets separated by colons")
+    return addressError("expected six two-digit hexadecimal octets separated by colons", input)
   }
   return Result.succeed(makeMac(new Uint8Array(input.split(":").map((part) => Number.parseInt(part, 16)))))
 }
@@ -456,40 +472,40 @@ export const macAddressFromStringUnsafe = (input: string): MacAddress => Result.
 export const ipv4FromString = (input: string): Result.Result<Ipv4Address, NetAddressError> => {
   const parts = input.split(".")
   if (parts.length !== 4 || parts.some((part) => !/^\d{1,3}$/.test(part))) {
-    return addressError("expected exactly four decimal octets")
+    return addressError("expected exactly four decimal octets", input)
   }
   if (parts.some((part) => part.length > 1 && part[0] === "0")) {
-    return addressError("leading zeroes are not allowed")
+    return addressError("leading zeroes are not allowed", input)
   }
   const octets = parts.map(Number)
   if (octets.some((part) => part > 255)) {
-    return addressError("octets must be at most 255")
+    return addressError("octets must be at most 255", input)
   }
   return ipv4FromOctets([octets[0], octets[1], octets[2], octets[3]])
 }
 
 const parseIpv6Segments = (input: string): Result.Result<ReadonlyArray<number>, NetAddressError> => {
   if (input.includes("[") || input.includes("]") || input.includes("%")) {
-    return addressError("brackets and zone identifiers are not valid in a bare IPv6 address")
+    return addressError("brackets and zone identifiers are not valid in a bare IPv6 address", input)
   }
   const halves = input.split("::")
-  if (halves.length > 2) return addressError("only one compression marker is allowed")
+  if (halves.length > 2) return addressError("only one compression marker is allowed", input)
   const head = halves[0] === "" ? [] : halves[0].split(":")
   const tail = halves.length === 2 && halves[1] !== "" ? halves[1].split(":") : []
   if (head.some((part) => part === "") || tail.some((part) => part === "")) {
-    return addressError("empty segments are only valid in the compression marker")
+    return addressError("empty segments are only valid in the compression marker", input)
   }
   const trailing = tail.length > 0 ? tail[tail.length - 1] : head.length > 0 ? head[head.length - 1] : ""
   let embedded: ReadonlyArray<number> | undefined
   if (trailing.includes(".")) {
     if (halves.length === 2 && tail.length === 0) {
-      return addressError("embedded IPv4 syntax must be trailing")
+      return addressError("embedded IPv4 syntax must be trailing", input)
     }
     const parsed = Result.map(ipv4FromString(trailing), (address) => {
       const octets = ipv4ToOctets(address)
       return [octets[0] * 256 + octets[1], octets[2] * 256 + octets[3]]
     })
-    if (Result.isFailure(parsed)) return parsed
+    if (Result.isFailure(parsed)) return addressError(parsed.failure.message, input)
     embedded = parsed.success
     if (tail.length > 0) tail.pop()
     else head.pop()
@@ -497,7 +513,8 @@ const parseIpv6Segments = (input: string): Result.Result<ReadonlyArray<number>, 
   const explicit = head.length + tail.length + (embedded ? 2 : 0)
   if (halves.length === 1 ? explicit !== 8 : explicit >= 8) {
     return addressError(
-      halves.length === 1 ? "expected eight segments" : "compression must replace at least one segment"
+      halves.length === 1 ? "expected eight segments" : "compression must replace at least one segment",
+      input
     )
   }
   const parse = (part: string): number | undefined =>
@@ -505,7 +522,7 @@ const parseIpv6Segments = (input: string): Result.Result<ReadonlyArray<number>, 
   const parsedHead = head.map(parse)
   const parsedTail = tail.map(parse)
   if (parsedHead.some((part) => part === undefined) || parsedTail.some((part) => part === undefined)) {
-    return addressError("segments must contain one through four hexadecimal digits")
+    return addressError("segments must contain one through four hexadecimal digits", input)
   }
   return Result.succeed([
     ...parsedHead as ReadonlyArray<number>,
@@ -848,8 +865,11 @@ const InetV4Proto = {
   toString(this: InetAddressV4): string {
     return formatInet(this)
   },
-  [NodeInspectSymbol](this: InetAddressV4): string {
+  toJSON(this: InetAddressV4): string {
     return this.toString()
+  },
+  [NodeInspectSymbol](this: InetAddressV4): string {
+    return this.toJSON()
   }
 }
 
@@ -869,15 +889,18 @@ const InetV6Proto = {
   toString(this: InetAddressV6): string {
     return formatInet(this)
   },
-  [NodeInspectSymbol](this: InetAddressV6): string {
+  toJSON(this: InetAddressV6): string {
     return this.toString()
+  },
+  [NodeInspectSymbol](this: InetAddressV6): string {
+    return this.toJSON()
   }
 }
 
 const checkPort = (port: number): Result.Result<number, NetAddressError> =>
   Number.isInteger(port) && port >= 0 && port <= 0xffff
     ? Result.succeed(port)
-    : addressError("port must be an integer from 0 through 65535")
+    : addressError("port must be an integer from 0 through 65535", port)
 
 /**
  * Creates a checked IPv4 internet address.
@@ -908,7 +931,7 @@ export const inetAddressV6 = (
   return Result.flatMap(checkPort(port), () => {
     const scopeId = options?.scopeId ?? 0
     if (!Number.isInteger(scopeId) || scopeId < 0 || scopeId > 0xffffffff) {
-      return addressError("scopeId must be an unsigned 32-bit integer")
+      return addressError("scopeId must be an unsigned 32-bit integer", scopeId)
     }
     const self = Object.create(InetV6Proto)
     self.address = address
@@ -982,7 +1005,7 @@ export const inetAddressFromString = (input: string): Result.Result<InetAddress,
   if (bracketed) {
     const end = input.indexOf("]")
     if (end < 0 || input[end + 1] !== ":" || input.indexOf("]", end + 1) !== -1) {
-      return addressError("expected [IPv6]:port")
+      return addressError("expected [IPv6]:port", input)
     }
     host = input.slice(1, end)
     portText = input.slice(end + 2)
@@ -990,36 +1013,39 @@ export const inetAddressFromString = (input: string): Result.Result<InetAddress,
     if (scopeSeparator !== -1) {
       const scopeText = host.slice(scopeSeparator + 1)
       if (host.indexOf("%", scopeSeparator + 1) !== -1 || !/^\d+$/.test(scopeText)) {
-        return addressError("scope identifier must be decimal")
+        return addressError("scope identifier must be decimal", input)
       }
       scopeId = Number(scopeText)
       if (!Number.isInteger(scopeId) || scopeId > 0xffffffff) {
-        return addressError("scope identifier must be an unsigned 32-bit integer")
+        return addressError("scope identifier must be an unsigned 32-bit integer", input)
       }
       host = host.slice(0, scopeSeparator)
     }
   } else {
     const separator = input.lastIndexOf(":")
     if (separator < 0) {
-      return addressError("expected host:port or [IPv6]:port")
+      return addressError("expected host:port or [IPv6]:port", input)
     }
     if (input.indexOf(":") !== separator) {
-      return addressError("IPv6 addresses must be bracketed")
+      return addressError("IPv6 addresses must be bracketed", input)
     }
     host = input.slice(0, separator)
     portText = input.slice(separator + 1)
   }
   if (!/^(0|[1-9]\d*)$/.test(portText)) {
-    return addressError("port must be an unpadded decimal integer")
+    return addressError("port must be an unpadded decimal integer", input)
   }
-  return Result.flatMap(ipFromString(host), (address): Result.Result<InetAddress, NetAddressError> => {
-    if (bracketed !== isIpv6Address(address)) {
-      return addressError("only IPv6 addresses use brackets")
-    }
-    return isIpv6Address(address)
-      ? inetAddressV6(address, Number(portText), { scopeId })
-      : inetAddressV4(address, Number(portText))
-  })
+  return Result.mapError(
+    Result.flatMap(ipFromString(host), (address): Result.Result<InetAddress, NetAddressError> => {
+      if (bracketed !== isIpv6Address(address)) {
+        return addressError("only IPv6 addresses use brackets", input)
+      }
+      return isIpv6Address(address)
+        ? inetAddressV6(address, Number(portText), { scopeId })
+        : inetAddressV4(address, Number(portText))
+    }),
+    (error) => new NetAddressError({ message: error.message, input })
+  )
 }
 
 /**
@@ -1067,13 +1093,16 @@ const UnixPathProto = {
     return isUnixPathAddress(that) && this.path === that.path
   },
   [Hash.symbol](this: UnixPathAddress): number {
-    return Hash.combine(Hash.string("UnixPathAddress"))(Hash.string(this.path))
+    return Hash.combine(Hash.string(this.path), Hash.string("UnixPathAddress"))
   },
   toString(this: UnixPathAddress): string {
     return this.path
   },
-  [NodeInspectSymbol](this: UnixPathAddress): string {
+  toJSON(this: UnixPathAddress): string {
     return this.toString()
+  },
+  [NodeInspectSymbol](this: UnixPathAddress): string {
+    return this.toJSON()
   }
 }
 
@@ -1108,17 +1137,20 @@ export const socketAddressFromInput = (
   if (hasProperty(input, "path")) {
     return typeof input.path === "string"
       ? Result.succeed(unixPathAddress(input.path))
-      : addressError("path must be a string")
+      : addressError("path must be a string", input)
   }
   if (!hasProperty(input, "address") || !hasProperty(input, "port")) {
-    return addressError("expected an address and port or a Unix path")
+    return addressError("expected an address and port or a Unix path", input)
   }
   const address = typeof input.address === "string"
     ? ipFromString(input.address)
     : isIpAddress(input.address)
     ? Result.succeed(input.address)
-    : addressError("address must be an IP address or numeric IP string")
-  return Result.flatMap(address, (address) => inetAddress(address, input.port as number))
+    : addressError("address must be an IP address or numeric IP string", input)
+  return Result.mapError(
+    Result.flatMap(address, (address) => inetAddress(address, input.port as number)),
+    (error) => new NetAddressError({ message: error.message, input })
+  )
 }
 
 /**

--- a/packages/effect/test/unstable/http/HttpServer.test.ts
+++ b/packages/effect/test/unstable/http/HttpServer.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect } from "effect"
+import { Cause, Effect, Exit } from "effect"
 import * as HttpClient from "effect/unstable/http/HttpClient"
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse"
 import * as HttpServer from "effect/unstable/http/HttpServer"
@@ -16,29 +16,67 @@ describe("HttpServer", () => {
     assert.strictEqual(server.address, address)
   })
 
-  it("formats scoped IPv6 addresses as valid URLs", () => {
-    const address = NetAddress.inetAddressFromStringUnsafe("[fe80::1%2]:3000")
-    const formatted = HttpServer.formatAddress(address)
-    assert.strictEqual(formatted, "http://[fe80::1]:3000")
-    assert.doesNotThrow(() => new URL(formatted))
-  })
-
-  it.effect("preserves the address family for unspecified test server addresses", () => {
-    const server = HttpServer.make({
-      address: NetAddress.inetAddressUnsafe(NetAddress.ipv6Unspecified, 3000),
-      serve: () => Effect.void
-    })
-    const client = HttpClient.make((request, url) => {
-      assert.strictEqual(url.origin, "http://[::1]:3000")
-      return Effect.succeed(HttpClientResponse.fromWeb(request, new Response()))
-    })
-
-    return Effect.gen(function*() {
-      const testClient = yield* HttpServer.makeTestClient
-      yield* testClient.get("/")
-    }).pipe(
-      Effect.provideService(HttpServer.HttpServer, server),
-      Effect.provideService(HttpClient.HttpClient, client)
+  it("formats unscoped addresses and rejects scoped IPv6 addresses", () => {
+    for (
+      const [input, expected] of [
+        ["127.0.0.1:3000", "http://127.0.0.1:3000"],
+        ["[::1]:3000", "http://[::1]:3000"],
+        ["[fe80::1%0]:3000", "http://[fe80::1]:3000"]
+      ]
+    ) {
+      const formatted = HttpServer.formatAddress(NetAddress.inetAddressFromStringUnsafe(input))
+      assert.strictEqual(formatted, expected)
+      assert.doesNotThrow(() => new URL(formatted))
+    }
+    assert.throws(
+      () => HttpServer.formatAddress(NetAddress.inetAddressFromStringUnsafe("[fe80::1%2]:3000")),
+      /scoped IPv6 addresses are not supported/
     )
   })
+
+  it.effect("uses IPv4 fallback for unspecified listeners and preserves concrete IPv6 hosts", () =>
+    Effect.gen(function*() {
+      for (
+        const [input, expected] of [
+          ["0.0.0.0:3000", "http://127.0.0.1:3000"],
+          ["[::]:3000", "http://127.0.0.1:3000"],
+          ["[::1]:3000", "http://[::1]:3000"],
+          ["[2001:db8::1]:3000", "http://[2001:db8::1]:3000"]
+        ]
+      ) {
+        const server = HttpServer.make({
+          address: NetAddress.inetAddressFromStringUnsafe(input),
+          serve: () => Effect.void
+        })
+        const client = HttpClient.make((request, url) => {
+          assert.strictEqual(url.origin, expected)
+          return Effect.succeed(HttpClientResponse.fromWeb(request, new Response()))
+        })
+        const testClient = yield* HttpServer.makeTestClient.pipe(
+          Effect.provideService(HttpServer.HttpServer, server),
+          Effect.provideService(HttpClient.HttpClient, client)
+        )
+        yield* testClient.get("/")
+      }
+    }))
+
+  it.effect("rejects scoped IPv6 test server addresses before making requests", () =>
+    Effect.gen(function*() {
+      for (const input of ["[fe80::1%2]:3000", "[::%2]:3000"]) {
+        const server = HttpServer.make({
+          address: NetAddress.inetAddressFromStringUnsafe(input),
+          serve: () => Effect.void
+        })
+        const client = HttpClient.make(() => Effect.die("unexpected request"))
+        const exit = yield* HttpServer.makeTestClient.pipe(
+          Effect.provideService(HttpServer.HttpServer, server),
+          Effect.provideService(HttpClient.HttpClient, client),
+          Effect.exit
+        )
+        if (Exit.isSuccess(exit)) assert.fail("expected scoped address rejection")
+        const error = Cause.squash(exit.cause)
+        assert.instanceOf(error, Error)
+        assert.strictEqual(error.message, "HttpServer.makeTestClient: scoped IPv6 addresses are not supported")
+      }
+    }))
 })

--- a/packages/effect/test/unstable/net/IpInterface.test.ts
+++ b/packages/effect/test/unstable/net/IpInterface.test.ts
@@ -3,6 +3,7 @@ import { Equal, Hash, Result, Schema } from "effect"
 import * as IpInterface from "effect/unstable/net/IpInterface"
 import * as IpNetwork from "effect/unstable/net/IpNetwork"
 import * as NetAddress from "effect/unstable/net/NetAddress"
+import { inspect } from "node:util"
 
 const success = <A>(result: Result.Result<A, unknown>): A => {
   if (Result.isFailure(result)) assert.fail("expected Success")
@@ -18,6 +19,23 @@ const ip = (input: string): NetAddress.IpAddress => success(NetAddress.ipFromStr
 const interfaceAddress = (input: string): IpInterface.IpInterface => success(IpInterface.fromString(input))
 
 describe("IpInterface", () => {
+  it("serializes and inspects canonical address and prefix strings", () => {
+    for (const input of ["192.0.2.1/24", "2001:db8::1/64"]) {
+      const value = IpInterface.fromStringUnsafe(input)
+      assert.strictEqual(value.toJSON(), input)
+      assert.strictEqual(JSON.stringify(value), JSON.stringify(input))
+      assert.strictEqual(inspect(value), input)
+    }
+  })
+
+  it("retains the original input for invalid addresses and prefixes", () => {
+    for (const input of ["localhost/24", "1.2.3.4/+24", "1.2.3.4/33", "::ffff:192.00.2.1/128", "2001:db8::/129"]) {
+      assert.strictEqual(failure(IpInterface.fromString(input)).input, input)
+    }
+    assert.strictEqual(failure(IpInterface.ipv4FromString("localhost/24")).input, "localhost/24")
+    assert.strictEqual(failure(IpInterface.ipv6FromString("2001:db8::/129")).input, "2001:db8::/129")
+  })
+
   it("constructs one generic runtime representation", () => {
     const ipv4 = IpInterface.makeUnsafe(NetAddress.ipv4Unspecified, 0)
     const ipv6 = IpInterface.makeUnsafe(NetAddress.ipv6Unspecified, 0)

--- a/packages/effect/test/unstable/net/IpNetwork.test.ts
+++ b/packages/effect/test/unstable/net/IpNetwork.test.ts
@@ -3,6 +3,7 @@ import { Equal, Hash, Result, Schema } from "effect"
 import * as IpNetwork from "effect/unstable/net/IpNetwork"
 import * as NetAddress from "effect/unstable/net/NetAddress"
 import * as fc from "fast-check"
+import { inspect } from "node:util"
 
 const success = <A>(result: Result.Result<A, unknown>): A => {
   if (Result.isFailure(result)) assert.fail("expected Success")
@@ -18,6 +19,23 @@ const ip = (input: string): NetAddress.IpAddress => success(NetAddress.ipFromStr
 const network = (input: string): IpNetwork.IpNetwork => success(IpNetwork.fromString(input))
 
 describe("IpNetwork", () => {
+  it("serializes and inspects canonical address and prefix strings", () => {
+    for (const input of ["192.0.2.0/24", "2001:db8::/64"]) {
+      const value = IpNetwork.fromStringUnsafe(input)
+      assert.strictEqual(value.toJSON(), input)
+      assert.strictEqual(JSON.stringify(value), JSON.stringify(input))
+      assert.strictEqual(inspect(value), input)
+    }
+  })
+
+  it("retains the original input for invalid addresses and prefixes", () => {
+    for (const input of ["localhost/24", "1.2.3.4/+24", "1.2.3.4/33", "::ffff:192.00.2.1/128", "2001:db8::/129"]) {
+      assert.strictEqual(failure(IpNetwork.fromString(input)).input, input)
+    }
+    assert.strictEqual(failure(IpNetwork.ipv4FromString("localhost/24")).input, "localhost/24")
+    assert.strictEqual(failure(IpNetwork.ipv6FromString("2001:db8::/129")).input, "2001:db8::/129")
+  })
+
   it("constructs immutable canonical networks and preserves family identity", () => {
     const ipv4 = IpNetwork.makeUnsafe(NetAddress.ipv4Unspecified, 0)
     const ipv6 = IpNetwork.makeUnsafe(NetAddress.ipv6Unspecified, 0)
@@ -43,8 +61,9 @@ describe("IpNetwork", () => {
       failure(IpNetwork.fromAddress(ipv4, prefix))
     }
     failure(IpNetwork.make(ipv6, 129))
-    failure(IpNetwork.make(ipv4, 8))
+    assert.deepStrictEqual(failure(IpNetwork.make(ipv4, 8)).input, { address: ipv4, prefixLength: 8 })
     failure(IpNetwork.make(ipv6, 32))
+    assert.strictEqual(failure(IpNetwork.fromString("10.1.2.3/8")).input, "10.1.2.3/8")
 
     const error = failure(IpNetwork.make(ipv4, -1))
     assert.strictEqual(error._tag, "NetAddressError")

--- a/packages/effect/test/unstable/net/NetAddress.test.ts
+++ b/packages/effect/test/unstable/net/NetAddress.test.ts
@@ -2,6 +2,7 @@ import { assert, describe, it } from "@effect/vitest"
 import { Equal, Hash, Option, Result, Schema } from "effect"
 import * as NetAddress from "effect/unstable/net/NetAddress"
 import { Buffer } from "node:buffer"
+import { inspect } from "node:util"
 
 const success = <A>(result: Result.Result<A, unknown>): A => {
   if (Result.isFailure(result)) assert.fail("expected Success")
@@ -243,6 +244,46 @@ describe("NetAddress", () => {
     }
   })
 
+  it("serializes and inspects canonical strings without exposing private bytes", () => {
+    const values = [
+      NetAddress.ipv4Loopback,
+      NetAddress.ipv6Loopback,
+      NetAddress.macAddressFromStringUnsafe("00:00:5E:00:53:01"),
+      NetAddress.inetAddressFromStringUnsafe("127.0.0.1:80"),
+      NetAddress.inetAddressFromStringUnsafe("[fe80::1%2]:80"),
+      NetAddress.unixPathAddress("./run/../server.sock")
+    ]
+    const expected = ["127.0.0.1", "::1", "00:00:5e:00:53:01", "127.0.0.1:80", "[fe80::1%2]:80", "./run/../server.sock"]
+    assert.deepStrictEqual(JSON.parse(JSON.stringify(values)), expected)
+    for (let i = 0; i < values.length; i++) {
+      assert.strictEqual(values[i].toJSON(), expected[i])
+      assert.strictEqual(inspect(values[i]), expected[i])
+    }
+  })
+
+  it("retains complete inputs when parsing fails inside nested address parsers", () => {
+    const cases: ReadonlyArray<readonly [unknown, Result.Result<unknown, NetAddress.NetAddressError>]> = [
+      ["invalid", NetAddress.macAddressFromString("invalid")],
+      ["::ffff:192.00.2.1", NetAddress.ipv6FromString("::ffff:192.00.2.1")],
+      ["localhost:80", NetAddress.inetAddressFromString("localhost:80")],
+      ["127.0.0.1:65536", NetAddress.inetAddressFromString("127.0.0.1:65536")],
+      ["[fe80::1%eth0]:80", NetAddress.inetAddressFromString("[fe80::1%eth0]:80")]
+    ]
+    for (const [input, result] of cases) {
+      if (Result.isSuccess(result)) assert.fail("expected Failure")
+      assert.strictEqual(result.failure.input, input)
+    }
+    for (const input of [{ address: "localhost", port: 80 }, { address: "127.0.0.1", port: -1 }]) {
+      const result = NetAddress.socketAddressFromInput(input)
+      if (Result.isSuccess(result)) assert.fail("expected Failure")
+      assert.strictEqual(result.failure.input, input)
+    }
+    const octets = [256, 0, 0, 1] as const
+    const result = NetAddress.ipv4FromOctets(octets)
+    if (Result.isSuccess(result)) assert.fail("expected Failure")
+    assert.strictEqual(result.failure.input, octets)
+  })
+
   it("copies byte constructor inputs", () => {
     const ipv4Bytes = new Uint8Array([127, 0, 0, 1])
     const ipv6Bytes = new Uint8Array(16)
@@ -291,6 +332,7 @@ describe("NetAddress", () => {
     const result = NetAddress.ipFromString("localhost")
     if (Result.isSuccess(result)) assert.fail("expected Failure")
     assert.instanceOf(result.failure, NetAddress.NetAddressError)
+    assert.strictEqual(result.failure.input, "localhost")
     assert.strictEqual(result.failure.message, "expected exactly four decimal octets")
   })
 

--- a/packages/effect/typetest/unstable/net/NetAddress.tst.ts
+++ b/packages/effect/typetest/unstable/net/NetAddress.tst.ts
@@ -63,6 +63,35 @@ describe("NetAddress", () => {
     }
   })
 
+  it("preserves named codec types when rebuilding schemas", () => {
+    expect(Schema.MacAddressFromString).type.toBe<Schema.MacAddressFromString>()
+    expect(Schema.MacAddressFromString.annotate({ title: "Address" })).type.toBe<Schema.MacAddressFromString>()
+    expect(Schema.Ipv4AddressFromString).type.toBe<Schema.Ipv4AddressFromString>()
+    expect(Schema.Ipv4AddressFromString.annotate({ title: "Address" })).type.toBe<Schema.Ipv4AddressFromString>()
+    expect(Schema.Ipv6AddressFromString).type.toBe<Schema.Ipv6AddressFromString>()
+    expect(Schema.Ipv6AddressFromString.annotate({ title: "Address" })).type.toBe<Schema.Ipv6AddressFromString>()
+    expect(Schema.IpAddressFromString).type.toBe<Schema.IpAddressFromString>()
+    expect(Schema.IpAddressFromString.annotate({ title: "Address" })).type.toBe<Schema.IpAddressFromString>()
+    expect(Schema.Ipv4InterfaceFromString).type.toBe<Schema.Ipv4InterfaceFromString>()
+    expect(Schema.Ipv4InterfaceFromString.annotate({ title: "Address" })).type.toBe<Schema.Ipv4InterfaceFromString>()
+    expect(Schema.Ipv6InterfaceFromString).type.toBe<Schema.Ipv6InterfaceFromString>()
+    expect(Schema.Ipv6InterfaceFromString.annotate({ title: "Address" })).type.toBe<Schema.Ipv6InterfaceFromString>()
+    expect(Schema.IpInterfaceFromString).type.toBe<Schema.IpInterfaceFromString>()
+    expect(Schema.IpInterfaceFromString.annotate({ title: "Address" })).type.toBe<Schema.IpInterfaceFromString>()
+    expect(Schema.Ipv4NetworkFromString).type.toBe<Schema.Ipv4NetworkFromString>()
+    expect(Schema.Ipv4NetworkFromString.annotate({ title: "Address" })).type.toBe<Schema.Ipv4NetworkFromString>()
+    expect(Schema.Ipv6NetworkFromString).type.toBe<Schema.Ipv6NetworkFromString>()
+    expect(Schema.Ipv6NetworkFromString.annotate({ title: "Address" })).type.toBe<Schema.Ipv6NetworkFromString>()
+    expect(Schema.IpNetworkFromString).type.toBe<Schema.IpNetworkFromString>()
+    expect(Schema.IpNetworkFromString.annotate({ title: "Address" })).type.toBe<Schema.IpNetworkFromString>()
+    expect(Schema.InetAddressFromString).type.toBe<Schema.InetAddressFromString>()
+    expect(Schema.InetAddressFromString.annotate({ title: "Address" })).type.toBe<Schema.InetAddressFromString>()
+    expect(Schema.UnixPathAddressFromString).type.toBe<Schema.UnixPathAddressFromString>()
+    expect(Schema.UnixPathAddressFromString.annotate({ title: "Address" })).type.toBe<
+      Schema.UnixPathAddressFromString
+    >()
+  })
+
   it("exposes string transformation schemas", () => {
     expect(Schema.MacAddressFromString).type.toBeAssignableTo<Schema.Codec<NetAddress.MacAddress, string>>()
     expect(Schema.IpAddressFromString).type.toBeAssignableTo<Schema.Codec<NetAddress.IpAddress, string>>()

--- a/packages/platform/bun/src/BunHttpServer.ts
+++ b/packages/platform/bun/src/BunHttpServer.ts
@@ -118,7 +118,7 @@ export const make = Effect.fnUntraced(
   ) {
     const scope = yield* Effect.scope
     let listenOptions = options
-    if (!("unix" in options)) {
+    if (!("unix" in options) || options.unix === undefined) {
       const internetOptions = options as Bun.Serve.HostnamePortServeOptions<WebSocketContext>
       const hostname = internetOptions.hostname ?? "0.0.0.0"
       if (Result.isFailure(NetAddress.ipFromString(hostname))) {
@@ -172,7 +172,7 @@ export const make = Effect.fnUntraced(
 
     yield* Scope.addFinalizer(scope, shutdown)
 
-    const address = "unix" in options
+    const address = "unix" in options && options.unix !== undefined
       ? NetAddress.unixPathAddress(options.unix)
       : yield* Effect.fromResult(NetAddress.inetAddressFromIpString(server.hostname!, server.port!)).pipe(
         Effect.mapError((cause) => new Error.ServeError({ cause }))

--- a/packages/platform/bun/test/BunHttpServer.test.ts
+++ b/packages/platform/bun/test/BunHttpServer.test.ts
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
 import * as Scope from "effect/Scope"
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient"
 import * as HttpServer from "effect/unstable/http/HttpServer"
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest"
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse"
@@ -127,6 +128,19 @@ describe("BunHttpServer", () => {
       assert.strictEqual(unixServer.address._tag, "UnixPathAddress")
       assert.strictEqual(unixServer.address._tag === "UnixPathAddress" ? unixServer.address.path : undefined, path)
       assert.strictEqual(HttpServer.formatAddress(unixServer.address), `unix://${path}`)
+    }))
+
+  it.effect("treats an undefined Unix option as TCP and supports the test client", () =>
+    Effect.gen(function*() {
+      const server = yield* BunHttpServer.make({ unix: undefined, hostname: "localhost", port: 0 })
+      assert.isTrue(server.address._tag === "InetAddressV4" || server.address._tag === "InetAddressV6")
+      yield* server.serve(Effect.succeed(HttpServerResponse.text("tcp")))
+      const client = yield* HttpServer.makeTestClient.pipe(
+        Effect.provideService(HttpServer.HttpServer, server),
+        Effect.provide(FetchHttpClient.layer)
+      )
+      const response = yield* client.get("/")
+      assert.strictEqual(yield* response.text, "tcp")
     }))
 
   it.effect("closing an older serve scope keeps the newer handler active", () =>

--- a/packages/sql/pg/src/PgTypes.ts
+++ b/packages/sql/pg/src/PgTypes.ts
@@ -661,12 +661,16 @@ const PGSQL_AF_INET6 = 3
 const encodeInet = (value: unknown, isCidr: boolean): Uint8Array => {
   const text = requireString(value, isCidr ? "cidr" : "inet")
   const parsed = IpInterface.fromString(text)
-  if (Result.isFailure(parsed)) return fail(parsed.failure.message)
+  if (Result.isFailure(parsed)) {
+    return fail(
+      `Invalid ${isCidr ? "cidr" : "inet"} value ${JSON.stringify(parsed.failure.input)}: ${parsed.failure.message}`
+    )
+  }
   const address = parsed.success.address
   const bits = parsed.success.prefixLength
   if (isCidr) {
     const network = IpNetwork.make(address, bits)
-    if (Result.isFailure(network)) return fail(network.failure.message)
+    if (Result.isFailure(network)) return fail(`Invalid cidr value ${JSON.stringify(text)}: ${network.failure.message}`)
   }
   const octets = NetAddress.isIpv4Address(address)
     ? NetAddress.ipv4ToOctets(address)
@@ -698,16 +702,14 @@ const decodeInet = (bytes: Uint8Array, offset: number, size: number): string => 
   const address = family === PGSQL_AF_INET
     ? NetAddress.ipv4FromBytesUnsafe(addressBytes)
     : NetAddress.ipv6FromBytesUnsafe(addressBytes)
-  const interfaceAddress = IpInterface.make(address, bits)
-  if (Result.isFailure(interfaceAddress)) return fail(interfaceAddress.failure.message)
   if (isCidr) {
-    const network = IpNetwork.make(interfaceAddress.success.address, interfaceAddress.success.prefixLength)
+    const network = IpNetwork.make(address, bits)
     if (Result.isFailure(network)) return fail(network.failure.message)
     return IpNetwork.format(network.success)
   }
   return bits === addressSize * 8
     ? NetAddress.formatIp(address)
-    : IpInterface.format(interfaceAddress.success)
+    : IpInterface.format(IpInterface.makeUnsafe(address, bits))
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/sql/pg/test/PgTypes.test.ts
+++ b/packages/sql/pg/test/PgTypes.test.ts
@@ -301,6 +301,21 @@ describe("PgTypes", () => {
     assertThrowsTagged("PgTypesCodecError", () => PgTypes.encode("010.1.2.3", PgTypes.OID.inet))
   })
 
+  it("includes the original value and column type in network encoding errors", () => {
+    for (
+      const [type, value, reason] of [
+        ["inet", "010.1.2.3/24", "leading zeroes are not allowed"],
+        ["inet", "1.2.3.4/33", "prefix length must be an integer from 0 through 32"],
+        ["cidr", "localhost/24", "expected exactly four decimal octets"],
+        ["cidr", "10.1.2.3/8", "address has non-zero host bits"]
+      ] as const
+    ) {
+      const result = PgTypesResult.encode(value, PgTypes.OID[type])
+      if (Result.isSuccess(result)) assert.fail("expected Failure")
+      assert.strictEqual(result.failure.message, `Invalid ${type} value ${JSON.stringify(value)}: ${reason}`)
+    }
+  })
+
   it("preserves inet host bits alongside the prefix", () => {
     for (const value of ["10.1.2.3/8", "2001:db8::1/32"]) {
       assert.strictEqual(PgTypes.decode(PgTypes.encode(value, PgTypes.OID.inet), PgTypes.OID.inet, 1), value)


### PR DESCRIPTION
## Summary

- Serialize network address values as canonical JSON strings and preserve original inputs in validation errors.
- Mark network schemas unstable and expose named string codec interfaces.
- Reject scoped IPv6 HTTP addresses and restore IPv4 loopback fallback for unspecified listeners.
- Handle explicitly undefined Bun Unix options as TCP listeners and improve PostgreSQL network encoding errors.
- Add runtime and type regression coverage.

## Testing

- Not run: targeted network, HTTP server, Bun, and PostgreSQL tests.
- Not run: network address type tests, `pnpm check`, lint, and JSDoc checks.