### PR TITLE
Refine network address schemas, serialization, and URL handling

### DIFF
--- a/.changeset/net-address-values.md
+++ b/.changeset/net-address-values.md
@@ -7,16 +7,8 @@
 "@effect/platform-bun": patch
 ---
 
-Add platform-neutral network address modules under `effect/unstable/net`:
+Add `NetAddress` under `effect/unstable/net` for MAC, IP, internet socket, and Unix socket addresses, with checked parsing, schemas, equality, canonical string serialization, and URL formatting. Companion modules `IpInterface` and `IpNetwork` represent IP interfaces and CIDR networks.
 
-- `NetAddress` provides MAC, IP, internet, and Unix socket addresses.
-- `IpInterface` provides IP host addresses that preserve their prefix lengths and host bits.
-- `IpNetwork` provides canonical IPv4 and IPv6 CIDR networks, including containment, overlap, bounds, and address counts.
+HTTP and socket servers now expose `NetAddress.SocketAddress`. Replace TCP `hostname` access with `NetAddress.formatIp(address.address)` and use `UnixPathAddress.path` for Unix sockets. URL helpers bracket IPv6 addresses and reject scoped IPv6. Bun and Deno HTTP server layers can now fail with `ServeError` when listener address conversion fails.
 
-IP address constructors copy their input bytes, including Node.js Buffers, so mutating the input cannot change stored addresses, equality, or hashes.
-
-HTTP and socket servers now expose canonical `NetAddress.SocketAddress` values. TCP addresses use `NetAddress.InetAddress` with an `address` field instead of `hostname`, and Unix addresses use `NetAddress.UnixPathAddress`. IPv6 URL authorities are bracketed. A server bound to `::` now logs `http://[::]:3000` instead of `http://0.0.0.0:3000`, and HTTP test clients use IPv6 loopback for IPv6 unspecified listeners.
-
-Bun continues to resolve listener hostnames before binding. Bun and Deno HTTP server layers can now fail with `ServeError` when their native listener address cannot be converted to a `NetAddress`.
-
-PostgreSQL `inet` now uses `IpInterface`. The `cidr` codec rejects addresses with host bits set and still treats a bare address as a full-width network.
+PostgreSQL `inet` values now use `IpInterface`; `cidr` values use `IpNetwork` and reject addresses with host bits set.

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -11268,10 +11268,10 @@ export const DateTimeZonedFromString: DateTimeZonedFromString = DateTimeZonedStr
   decodeTo(DateTimeZoned, dateTimeZonedFromString)
 )
 
-const netAddressFromString = <A, E extends { readonly message: string }>(
-  declaration: declare<A>,
-  parse: (input: string) => Result_.Result<A, E>,
-  encode: (value: A) => string,
+const netAddressFromString = <S extends declare<any>, E extends { readonly message: string }>(
+  declaration: S,
+  parse: (input: string) => Result_.Result<S["Type"], E>,
+  encode: (value: S["Type"]) => string,
   identifier: string
 ) =>
   String.pipe(decodeTo(
@@ -11288,22 +11288,46 @@ const netAddressFromString = <A, E extends { readonly message: string }>(
   )).annotate({ identifier })
 
 /**
+ * Type-level representation of {@link MacAddress}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface MacAddress extends declare<NetAddress_.MacAddress> {
+  readonly "Rebuild": MacAddress
+}
+
+/**
  * Schema for already-constructed MAC address values.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const MacAddress: declare<NetAddress_.MacAddress> = declare(NetAddress_.isMacAddress, {
+export const MacAddress: MacAddress = declare(NetAddress_.isMacAddress, {
   identifier: "MacAddress"
 })
 
 /**
+ * Type-level representation of {@link MacAddressFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface MacAddressFromString extends decodeTo<MacAddress, String> {
+  readonly "Rebuild": MacAddressFromString
+}
+
+/**
  * Schema for MAC addresses encoded as canonical colon-separated hexadecimal strings.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const MacAddressFromString = netAddressFromString(
+export const MacAddressFromString: MacAddressFromString = netAddressFromString(
   MacAddress,
   NetAddress_.macAddressFromString,
   NetAddress_.formatMacAddress,
@@ -11311,22 +11335,46 @@ export const MacAddressFromString = netAddressFromString(
 )
 
 /**
+ * Type-level representation of {@link Ipv4Address}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface Ipv4Address extends declare<NetAddress_.Ipv4Address> {
+  readonly "Rebuild": Ipv4Address
+}
+
+/**
  * Schema for already-constructed IPv4 address values.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const Ipv4Address: declare<NetAddress_.Ipv4Address> = declare(NetAddress_.isIpv4Address, {
+export const Ipv4Address: Ipv4Address = declare(NetAddress_.isIpv4Address, {
   identifier: "Ipv4Address"
 })
 
 /**
+ * Type-level representation of {@link Ipv4AddressFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface Ipv4AddressFromString extends decodeTo<Ipv4Address, String> {
+  readonly "Rebuild": Ipv4AddressFromString
+}
+
+/**
  * Schema for IPv4 addresses encoded as canonical dotted-decimal strings.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const Ipv4AddressFromString = netAddressFromString(
+export const Ipv4AddressFromString: Ipv4AddressFromString = netAddressFromString(
   Ipv4Address,
   NetAddress_.ipv4FromString,
   NetAddress_.formatIp,
@@ -11334,22 +11382,46 @@ export const Ipv4AddressFromString = netAddressFromString(
 )
 
 /**
+ * Type-level representation of {@link Ipv6Address}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface Ipv6Address extends declare<NetAddress_.Ipv6Address> {
+  readonly "Rebuild": Ipv6Address
+}
+
+/**
  * Schema for already-constructed IPv6 address values.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const Ipv6Address: declare<NetAddress_.Ipv6Address> = declare(NetAddress_.isIpv6Address, {
+export const Ipv6Address: Ipv6Address = declare(NetAddress_.isIpv6Address, {
   identifier: "Ipv6Address"
 })
 
 /**
+ * Type-level representation of {@link Ipv6AddressFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface Ipv6AddressFromString extends decodeTo<Ipv6Address, String> {
+  readonly "Rebuild": Ipv6AddressFromString
+}
+
+/**
  * Schema for IPv6 addresses encoded as canonical strings.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const Ipv6AddressFromString = netAddressFromString(
+export const Ipv6AddressFromString: Ipv6AddressFromString = netAddressFromString(
   Ipv6Address,
   NetAddress_.ipv6FromString,
   NetAddress_.formatIp,
@@ -11357,22 +11429,46 @@ export const Ipv6AddressFromString = netAddressFromString(
 )
 
 /**
+ * Type-level representation of {@link IpAddress}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface IpAddress extends declare<NetAddress_.IpAddress> {
+  readonly "Rebuild": IpAddress
+}
+
+/**
  * Schema for already-constructed IPv4 or IPv6 address values.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const IpAddress: declare<NetAddress_.IpAddress> = declare(NetAddress_.isIpAddress, {
+export const IpAddress: IpAddress = declare(NetAddress_.isIpAddress, {
   identifier: "IpAddress"
 })
 
 /**
+ * Type-level representation of {@link IpAddressFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface IpAddressFromString extends decodeTo<IpAddress, String> {
+  readonly "Rebuild": IpAddressFromString
+}
+
+/**
  * Schema for IP addresses encoded as canonical numeric strings.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const IpAddressFromString = netAddressFromString(
+export const IpAddressFromString: IpAddressFromString = netAddressFromString(
   IpAddress,
   NetAddress_.ipFromString,
   NetAddress_.formatIp,
@@ -11380,22 +11476,46 @@ export const IpAddressFromString = netAddressFromString(
 )
 
 /**
+ * Type-level representation of {@link Ipv4Interface}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface Ipv4Interface extends declare<IpInterface_.Ipv4Interface> {
+  readonly "Rebuild": Ipv4Interface
+}
+
+/**
  * Schema for already-constructed IPv4 interface address values.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const Ipv4Interface: declare<IpInterface_.Ipv4Interface> = declare(IpInterface_.isIpv4Interface, {
+export const Ipv4Interface: Ipv4Interface = declare(IpInterface_.isIpv4Interface, {
   identifier: "Ipv4Interface"
 })
 
 /**
+ * Type-level representation of {@link Ipv4InterfaceFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface Ipv4InterfaceFromString extends decodeTo<Ipv4Interface, String> {
+  readonly "Rebuild": Ipv4InterfaceFromString
+}
+
+/**
  * Schema for IPv4 interface addresses encoded as an address and prefix length.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const Ipv4InterfaceFromString = netAddressFromString(
+export const Ipv4InterfaceFromString: Ipv4InterfaceFromString = netAddressFromString(
   Ipv4Interface,
   IpInterface_.ipv4FromString,
   IpInterface_.format,
@@ -11403,22 +11523,46 @@ export const Ipv4InterfaceFromString = netAddressFromString(
 )
 
 /**
+ * Type-level representation of {@link Ipv6Interface}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface Ipv6Interface extends declare<IpInterface_.Ipv6Interface> {
+  readonly "Rebuild": Ipv6Interface
+}
+
+/**
  * Schema for already-constructed IPv6 interface address values.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const Ipv6Interface: declare<IpInterface_.Ipv6Interface> = declare(IpInterface_.isIpv6Interface, {
+export const Ipv6Interface: Ipv6Interface = declare(IpInterface_.isIpv6Interface, {
   identifier: "Ipv6Interface"
 })
 
 /**
+ * Type-level representation of {@link Ipv6InterfaceFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface Ipv6InterfaceFromString extends decodeTo<Ipv6Interface, String> {
+  readonly "Rebuild": Ipv6InterfaceFromString
+}
+
+/**
  * Schema for IPv6 interface addresses encoded as an address and prefix length.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const Ipv6InterfaceFromString = netAddressFromString(
+export const Ipv6InterfaceFromString: Ipv6InterfaceFromString = netAddressFromString(
   Ipv6Interface,
   IpInterface_.ipv6FromString,
   IpInterface_.format,
@@ -11426,22 +11570,46 @@ export const Ipv6InterfaceFromString = netAddressFromString(
 )
 
 /**
+ * Type-level representation of {@link IpInterface}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface IpInterface extends declare<IpInterface_.IpInterface> {
+  readonly "Rebuild": IpInterface
+}
+
+/**
  * Schema for already-constructed IPv4 or IPv6 interface address values.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const IpInterface: declare<IpInterface_.IpInterface> = declare(IpInterface_.isIpInterface, {
+export const IpInterface: IpInterface = declare(IpInterface_.isIpInterface, {
   identifier: "IpInterface"
 })
 
 /**
+ * Type-level representation of {@link IpInterfaceFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface IpInterfaceFromString extends decodeTo<IpInterface, String> {
+  readonly "Rebuild": IpInterfaceFromString
+}
+
+/**
  * Schema for IPv4 or IPv6 interface addresses encoded as an address and prefix length.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const IpInterfaceFromString = netAddressFromString(
+export const IpInterfaceFromString: IpInterfaceFromString = netAddressFromString(
   IpInterface,
   IpInterface_.fromString,
   IpInterface_.format,
@@ -11449,22 +11617,46 @@ export const IpInterfaceFromString = netAddressFromString(
 )
 
 /**
+ * Type-level representation of {@link Ipv4Network}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface Ipv4Network extends declare<IpNetwork_.Ipv4Network> {
+  readonly "Rebuild": Ipv4Network
+}
+
+/**
  * Schema for already-constructed canonical IPv4 network prefixes.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const Ipv4Network: declare<IpNetwork_.Ipv4Network> = declare(IpNetwork_.isIpv4Network, {
+export const Ipv4Network: Ipv4Network = declare(IpNetwork_.isIpv4Network, {
   identifier: "Ipv4Network"
 })
 
 /**
+ * Type-level representation of {@link Ipv4NetworkFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface Ipv4NetworkFromString extends decodeTo<Ipv4Network, String> {
+  readonly "Rebuild": Ipv4NetworkFromString
+}
+
+/**
  * Schema for canonical IPv4 network prefixes encoded in CIDR notation.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const Ipv4NetworkFromString = netAddressFromString(
+export const Ipv4NetworkFromString: Ipv4NetworkFromString = netAddressFromString(
   Ipv4Network,
   IpNetwork_.ipv4FromString,
   IpNetwork_.format,
@@ -11472,22 +11664,46 @@ export const Ipv4NetworkFromString = netAddressFromString(
 )
 
 /**
+ * Type-level representation of {@link Ipv6Network}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface Ipv6Network extends declare<IpNetwork_.Ipv6Network> {
+  readonly "Rebuild": Ipv6Network
+}
+
+/**
  * Schema for already-constructed canonical IPv6 network prefixes.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const Ipv6Network: declare<IpNetwork_.Ipv6Network> = declare(IpNetwork_.isIpv6Network, {
+export const Ipv6Network: Ipv6Network = declare(IpNetwork_.isIpv6Network, {
   identifier: "Ipv6Network"
 })
 
 /**
+ * Type-level representation of {@link Ipv6NetworkFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface Ipv6NetworkFromString extends decodeTo<Ipv6Network, String> {
+  readonly "Rebuild": Ipv6NetworkFromString
+}
+
+/**
  * Schema for canonical IPv6 network prefixes encoded in CIDR notation.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const Ipv6NetworkFromString = netAddressFromString(
+export const Ipv6NetworkFromString: Ipv6NetworkFromString = netAddressFromString(
   Ipv6Network,
   IpNetwork_.ipv6FromString,
   IpNetwork_.format,
@@ -11495,22 +11711,46 @@ export const Ipv6NetworkFromString = netAddressFromString(
 )
 
 /**
+ * Type-level representation of {@link IpNetwork}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface IpNetwork extends declare<IpNetwork_.IpNetwork> {
+  readonly "Rebuild": IpNetwork
+}
+
+/**
  * Schema for already-constructed canonical IPv4 or IPv6 network prefixes.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const IpNetwork: declare<IpNetwork_.IpNetwork> = declare(IpNetwork_.isIpNetwork, {
+export const IpNetwork: IpNetwork = declare(IpNetwork_.isIpNetwork, {
   identifier: "IpNetwork"
 })
 
 /**
+ * Type-level representation of {@link IpNetworkFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface IpNetworkFromString extends decodeTo<IpNetwork, String> {
+  readonly "Rebuild": IpNetworkFromString
+}
+
+/**
  * Schema for canonical IPv4 or IPv6 network prefixes encoded in CIDR notation.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const IpNetworkFromString = netAddressFromString(
+export const IpNetworkFromString: IpNetworkFromString = netAddressFromString(
   IpNetwork,
   IpNetwork_.fromString,
   IpNetwork_.format,
@@ -11518,42 +11758,90 @@ export const IpNetworkFromString = netAddressFromString(
 )
 
 /**
+ * Type-level representation of {@link InetAddressV4}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface InetAddressV4 extends declare<NetAddress_.InetAddressV4> {
+  readonly "Rebuild": InetAddressV4
+}
+
+/**
  * Schema for already-constructed resolved IPv4 internet addresses.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const InetAddressV4: declare<NetAddress_.InetAddressV4> = declare(NetAddress_.isInetAddressV4, {
+export const InetAddressV4: InetAddressV4 = declare(NetAddress_.isInetAddressV4, {
   identifier: "InetAddressV4"
 })
 
 /**
+ * Type-level representation of {@link InetAddressV6}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface InetAddressV6 extends declare<NetAddress_.InetAddressV6> {
+  readonly "Rebuild": InetAddressV6
+}
+
+/**
  * Schema for already-constructed resolved IPv6 internet addresses.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const InetAddressV6: declare<NetAddress_.InetAddressV6> = declare(NetAddress_.isInetAddressV6, {
+export const InetAddressV6: InetAddressV6 = declare(NetAddress_.isInetAddressV6, {
   identifier: "InetAddressV6"
 })
 
 /**
+ * Type-level representation of {@link InetAddress}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface InetAddress extends declare<NetAddress_.InetAddress> {
+  readonly "Rebuild": InetAddress
+}
+
+/**
  * Schema for already-constructed resolved internet addresses.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const InetAddress: declare<NetAddress_.InetAddress> = declare(NetAddress_.isInetAddress, {
+export const InetAddress: InetAddress = declare(NetAddress_.isInetAddress, {
   identifier: "InetAddress"
 })
 
 /**
+ * Type-level representation of {@link InetAddressFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface InetAddressFromString extends decodeTo<InetAddress, String> {
+  readonly "Rebuild": InetAddressFromString
+}
+
+/**
  * Schema for resolved internet addresses encoded as numeric socket strings.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const InetAddressFromString = netAddressFromString(
+export const InetAddressFromString: InetAddressFromString = netAddressFromString(
   InetAddress,
   NetAddress_.inetAddressFromString,
   NetAddress_.formatInet,
@@ -11561,23 +11849,47 @@ export const InetAddressFromString = netAddressFromString(
 )
 
 /**
+ * Type-level representation of {@link UnixPathAddress}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface UnixPathAddress extends declare<NetAddress_.UnixPathAddress> {
+  readonly "Rebuild": UnixPathAddress
+}
+
+/**
  * Schema for already-constructed Unix-domain filesystem addresses.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const UnixPathAddress: declare<NetAddress_.UnixPathAddress> = declare(
+export const UnixPathAddress: UnixPathAddress = declare(
   NetAddress_.isUnixPathAddress,
   { identifier: "UnixPathAddress" }
 )
 
 /**
+ * Type-level representation of {@link UnixPathAddressFromString}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface UnixPathAddressFromString extends decodeTo<UnixPathAddress, String> {
+  readonly "Rebuild": UnixPathAddressFromString
+}
+
+/**
  * Schema for Unix-domain filesystem addresses encoded as opaque path strings.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const UnixPathAddressFromString = String.pipe(decodeTo(
+export const UnixPathAddressFromString: UnixPathAddressFromString = String.pipe(decodeTo(
   UnixPathAddress,
   SchemaTransformation.transform({
     decode: NetAddress_.unixPathAddress,
@@ -11586,12 +11898,24 @@ export const UnixPathAddressFromString = String.pipe(decodeTo(
 )).annotate({ identifier: "UnixPathAddressFromString" })
 
 /**
+ * Type-level representation of {@link SocketAddress}.
+ *
+ * @unstable
+ * @category models
+ * @since 4.0.0
+ */
+export interface SocketAddress extends declare<NetAddress_.SocketAddress> {
+  readonly "Rebuild": SocketAddress
+}
+
+/**
  * Schema for already-constructed portable concrete socket addresses.
  *
+ * @unstable
  * @category schemas
  * @since 4.0.0
  */
-export const SocketAddress: declare<NetAddress_.SocketAddress> = declare(NetAddress_.isSocketAddress, {
+export const SocketAddress: SocketAddress = declare(NetAddress_.isSocketAddress, {
   identifier: "SocketAddress"
 })
 

--- a/packages/effect/src/unstable/http/HttpServer.ts
+++ b/packages/effect/src/unstable/http/HttpServer.ts
@@ -169,30 +169,17 @@ export const serveEffect: {
 > => HttpServer.use((server) => server.serve(effect, middleware!)) as any)
 
 /**
- * Formats a server address as a display string.
- *
- * **Details**
- *
- * Internet addresses are formatted as `http://host:port`, with IPv6 hosts
- * bracketed; Unix socket addresses are formatted as `unix://path`.
+ * Formats a server address as a display string using {@link NetAddress.formatUrlUnsafe}.
  *
  * **Gotchas**
  *
- * IPv6 scope identifiers are omitted because WHATWG URLs do not support scoped
- * IPv6 hosts.
+ * Throws a `NetAddressError` when URL conversion fails, including for scoped
+ * IPv6 addresses. Unix socket paths are displayed with a `unix://` prefix.
  *
  * @category converting
  * @since 4.0.0
  */
-export const formatAddress = (address: NetAddress.SocketAddress): string => {
-  switch (address._tag) {
-    case "UnixPathAddress":
-      return `unix://${address.path}`
-    case "InetAddressV4":
-    case "InetAddressV6":
-      return `http://${NetAddress.formatUrlHost(address.address)}:${address.port}`
-  }
-}
+export const formatAddress: (address: NetAddress.SocketAddress) => string = NetAddress.formatUrlUnsafe
 
 /**
  * Reads the current server address, formats it with `formatAddress`, and passes
@@ -238,7 +225,7 @@ export const withLogAddress = <A, E, R>(
  * **Details**
  *
  * For internet servers, requests are prefixed with the server URL and unspecified
- * addresses are replaced by the loopback address of the same IP family.
+ * addresses are replaced by IPv4 loopback, including dual-stack `::` listeners.
  *
  * **Gotchas**
  *
@@ -255,14 +242,14 @@ export const makeTestClient: Effect.Effect<
   const server = yield* HttpServer
   const client = yield* HttpClient.HttpClient
   const address = server.address
-  if (address._tag === "UnixPathAddress") {
+  if (NetAddress.isUnixPathAddress(address)) {
     return yield* Effect.die(new Error("HttpServer.layerTestClient: UnixPathAddress not supported"))
   }
-  const host = NetAddress.isUnspecified(address.address)
-    ? NetAddress.isIpv4Address(address.address) ? NetAddress.ipv4Loopback : NetAddress.ipv6Loopback
-    : address.address
-  const url = `http://${NetAddress.formatUrlHost(host)}:${address.port}`
-  return HttpClient.mapRequest(client, ClientRequest.prependUrl(url))
+  const url = yield* Effect.fromResult(NetAddress.toUrl(address)).pipe(Effect.orDie)
+  if (NetAddress.isUnspecified(address.address)) {
+    url.hostname = NetAddress.formatIp(NetAddress.ipv4Loopback)
+  }
+  return HttpClient.mapRequest(client, ClientRequest.prependUrl(url.origin))
 })
 
 /**

--- a/packages/effect/src/unstable/net/IpInterface.ts
+++ b/packages/effect/src/unstable/net/IpInterface.ts
@@ -24,6 +24,7 @@ export interface IpInterface<out A extends NetAddress.IpAddress = NetAddress.IpA
   readonly prefixLength: number
   readonly [TypeId]: typeof TypeId
   toString(): string
+  toJSON(): string
 }
 
 /**
@@ -100,13 +101,16 @@ const IpInterfaceProto = {
   toString(this: IpInterface): string {
     return format(this)
   },
-  [NodeInspectSymbol](this: IpInterface): string {
+  toJSON(this: IpInterface): string {
     return this.toString()
+  },
+  [NodeInspectSymbol](this: IpInterface): string {
+    return this.toJSON()
   }
 }
 
-const interfaceError = (message: string): Result.Result<never, NetAddress.NetAddressError> =>
-  Result.fail(new NetAddress.NetAddressError({ message }))
+const interfaceError = (input: unknown, message: string): Result.Result<never, NetAddress.NetAddressError> =>
+  Result.fail(new NetAddress.NetAddressError({ input, message }))
 
 /**
  * Creates an interface address while preserving all address bits.
@@ -120,7 +124,7 @@ export const make = <A extends NetAddress.IpAddress>(
 ): Result.Result<IpInterface<A>, NetAddress.NetAddressError> => {
   const max = NetAddress.width(address)
   if (!Number.isInteger(prefixLength) || prefixLength < 0 || prefixLength > max) {
-    return interfaceError(`prefix length must be an integer from 0 through ${max}`)
+    return interfaceError(address, `prefix length must be an integer from 0 through ${max}`)
   }
   const self = Object.assign(Object.create(IpInterfaceProto), { address, prefixLength })
   return Result.succeed(Object.freeze(self))
@@ -138,11 +142,11 @@ const parseAddressWithPrefix = (
     return Result.succeed({ address: input, prefixLength: undefined })
   }
   if (slash <= 0 || slash !== input.lastIndexOf("/") || slash === input.length - 1) {
-    return interfaceError("expected an address and prefix length separated by one slash")
+    return interfaceError(input, "expected an address and prefix length separated by one slash")
   }
   const prefix = input.slice(slash + 1)
   if (!/^(0|[1-9][0-9]*)$/.test(prefix)) {
-    return interfaceError("prefix length must be an unpadded ASCII decimal integer")
+    return interfaceError(input, "prefix length must be an unpadded ASCII decimal integer")
   }
   return Result.succeed({ address: input.slice(0, slash), prefixLength: Number(prefix) })
 }

--- a/packages/effect/src/unstable/net/IpNetwork.ts
+++ b/packages/effect/src/unstable/net/IpNetwork.ts
@@ -26,6 +26,7 @@ export interface IpNetwork<out A extends NetAddress.IpAddress = NetAddress.IpAdd
   readonly prefixLength: number
   readonly [TypeId]: typeof TypeId
   toString(): string
+  toJSON(): string
 }
 
 /**
@@ -75,13 +76,16 @@ const IpNetworkProto = {
     return isIpNetwork(that) && this.prefixLength === that.prefixLength && Equal.equals(this.address, that.address)
   },
   [Hash.symbol](this: IpNetwork): number {
-    return Hash.combine(Hash.hash(this.address))(Hash.number(this.prefixLength))
+    return Hash.combine(Hash.hash(this.address), Hash.number(this.prefixLength))
   },
   toString(this: IpNetwork): string {
     return format(this)
   },
-  [NodeInspectSymbol](this: IpNetwork): string {
+  toJSON(this: IpNetwork): string {
     return this.toString()
+  },
+  [NodeInspectSymbol](this: IpNetwork): string {
+    return this.toJSON()
   }
 }
 
@@ -131,7 +135,9 @@ export const make = <A extends NetAddress.IpAddress>(
     const bytes = toBytes(address)
     const masked = maskBytes(bytes, prefixLength)
     if (bytes.some((byte, index) => byte !== masked[index])) {
-      return Result.fail(new NetAddress.NetAddressError({ message: "address has non-zero host bits" }))
+      return Result.fail(
+        new NetAddress.NetAddressError({ input: address, message: "address has non-zero host bits" })
+      )
     }
     return Result.succeed(fromInterfaceValue(value))
   })

--- a/packages/effect/src/unstable/net/NetAddress.ts
+++ b/packages/effect/src/unstable/net/NetAddress.ts
@@ -24,6 +24,7 @@ export interface Ipv4Address extends Equal.Equal, Hash.Hash {
   readonly _tag: "Ipv4Address"
   readonly [TypeId]: typeof TypeId
   toString(): string
+  toJSON(): string
 }
 
 /**
@@ -36,6 +37,7 @@ export interface Ipv6Address extends Equal.Equal, Hash.Hash {
   readonly _tag: "Ipv6Address"
   readonly [TypeId]: typeof TypeId
   toString(): string
+  toJSON(): string
 }
 
 /**
@@ -56,6 +58,7 @@ export interface MacAddress extends Equal.Equal, Hash.Hash {
   readonly _tag: "MacAddress"
   readonly [TypeId]: typeof TypeId
   toString(): string
+  toJSON(): string
 }
 
 const getBytes = (self: IpAddress | MacAddress): Uint8Array => (self as any).bytes
@@ -72,6 +75,7 @@ export interface InetAddressV4 extends Equal.Equal, Hash.Hash {
   readonly port: number
   readonly [TypeId]: typeof TypeId
   toString(): string
+  toJSON(): string
 }
 
 /**
@@ -87,6 +91,7 @@ export interface InetAddressV6 extends Equal.Equal, Hash.Hash {
   readonly scopeId: number
   readonly [TypeId]: typeof TypeId
   toString(): string
+  toJSON(): string
 }
 
 /**
@@ -108,6 +113,7 @@ export interface UnixPathAddress extends Equal.Equal, Hash.Hash {
   readonly path: string
   readonly [TypeId]: typeof TypeId
   toString(): string
+  toJSON(): string
 }
 
 /**
@@ -144,13 +150,22 @@ export declare namespace SocketAddress {
 }
 
 /**
- * A checked network-address operation failure.
+ * A checked network-address operation failure retaining the address or supplied input.
+ *
+ * **Details**
+ *
+ * Address-based operations retain the address value. Parsing and numeric
+ * construction retain the supplied string or array. Composed operations forward
+ * errors from the failing operation unchanged. Failures from external operations
+ * retain the original exception in `cause` when available.
  *
  * @category errors
  * @since 4.0.0
  */
 export class NetAddressError extends Data.TaggedError("NetAddressError")<{
   readonly message: string
+  readonly input: unknown
+  readonly cause?: unknown
 }> {}
 
 const isAddress = (u: unknown): u is IpAddress | MacAddress | SocketAddress => hasProperty(u, TypeId)
@@ -247,8 +262,11 @@ const Ipv4Proto = {
   toString(this: Ipv4Address): string {
     return formatIp(this)
   },
-  [NodeInspectSymbol](this: Ipv4Address): string {
+  toJSON(this: Ipv4Address): string {
     return this.toString()
+  },
+  [NodeInspectSymbol](this: Ipv4Address): string {
+    return this.toJSON()
   }
 }
 
@@ -264,8 +282,11 @@ const Ipv6Proto = {
   toString(this: Ipv6Address): string {
     return formatIp(this)
   },
-  [NodeInspectSymbol](this: Ipv6Address): string {
+  toJSON(this: Ipv6Address): string {
     return this.toString()
+  },
+  [NodeInspectSymbol](this: Ipv6Address): string {
+    return this.toJSON()
   }
 }
 
@@ -281,8 +302,11 @@ const MacProto = {
   toString(this: MacAddress): string {
     return formatMacAddress(this)
   },
-  [NodeInspectSymbol](this: MacAddress): string {
+  toJSON(this: MacAddress): string {
     return this.toString()
+  },
+  [NodeInspectSymbol](this: MacAddress): string {
+    return this.toJSON()
   }
 }
 
@@ -309,7 +333,7 @@ const makeIpv6 = (bytes: Uint8Array): Ipv6Address => {
 }
 
 const makeMac = (bytes: Uint8Array): MacAddress => {
-  const self = Object.assign(Object.create(MacProto), { bytes: bytes.slice() })
+  const self = Object.assign(Object.create(MacProto), { bytes: new Uint8Array(bytes) })
   return Object.freeze(self)
 }
 
@@ -369,8 +393,8 @@ export const ipv6Unspecified: Ipv6Address = makeIpv6(new Uint8Array(16))
  */
 export const ipv4Broadcast: Ipv4Address = makeIpv4(new Uint8Array([255, 255, 255, 255]))
 
-const addressError = (message: string): Result.Result<never, NetAddressError> =>
-  Result.fail(new NetAddressError({ message }))
+const addressError = (input: unknown, message: string): Result.Result<never, NetAddressError> =>
+  Result.fail(new NetAddressError({ input, message }))
 
 /**
  * Creates an IPv4 address from four checked octets.
@@ -382,7 +406,7 @@ export const ipv4FromOctets = (
   octets: readonly [number, number, number, number]
 ): Result.Result<Ipv4Address, NetAddressError> => {
   if (!octets.every((n) => Number.isInteger(n) && n >= 0 && n <= 255)) {
-    return addressError("octets must be integers from 0 through 255")
+    return addressError(octets, "octets must be integers from 0 through 255")
   }
   return Result.succeed(makeIpv4(new Uint8Array(octets)))
 }
@@ -397,7 +421,7 @@ export const ipv6FromSegments = (
   segments: readonly [number, number, number, number, number, number, number, number]
 ): Result.Result<Ipv6Address, NetAddressError> => {
   if (!segments.every((n) => Number.isInteger(n) && n >= 0 && n <= 0xffff)) {
-    return addressError("segments must be integers from 0 through 65535")
+    return addressError(segments, "segments must be integers from 0 through 65535")
   }
   const bytes = new Uint8Array(16)
   for (let index = 0; index < 8; index++) {
@@ -417,7 +441,7 @@ export const macAddressFromOctets = (
   octets: readonly [number, number, number, number, number, number]
 ): Result.Result<MacAddress, NetAddressError> => {
   if (!octets.every((n) => Number.isInteger(n) && n >= 0 && n <= 255)) {
-    return addressError("octets must be integers from 0 through 255")
+    return addressError(octets, "octets must be integers from 0 through 255")
   }
   return Result.succeed(makeMac(new Uint8Array(octets)))
 }
@@ -430,7 +454,7 @@ export const macAddressFromOctets = (
  */
 export const macAddressFromString = (input: string): Result.Result<MacAddress, NetAddressError> => {
   if (!/^(?:[0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$/.test(input)) {
-    return addressError("expected six two-digit hexadecimal octets separated by colons")
+    return addressError(input, "expected six two-digit hexadecimal octets separated by colons")
   }
   return Result.succeed(makeMac(new Uint8Array(input.split(":").map((part) => Number.parseInt(part, 16)))))
 }
@@ -456,34 +480,34 @@ export const macAddressFromStringUnsafe = (input: string): MacAddress => Result.
 export const ipv4FromString = (input: string): Result.Result<Ipv4Address, NetAddressError> => {
   const parts = input.split(".")
   if (parts.length !== 4 || parts.some((part) => !/^\d{1,3}$/.test(part))) {
-    return addressError("expected exactly four decimal octets")
+    return addressError(input, "expected exactly four decimal octets")
   }
   if (parts.some((part) => part.length > 1 && part[0] === "0")) {
-    return addressError("leading zeroes are not allowed")
+    return addressError(input, "leading zeroes are not allowed")
   }
   const octets = parts.map(Number)
   if (octets.some((part) => part > 255)) {
-    return addressError("octets must be at most 255")
+    return addressError(input, "octets must be at most 255")
   }
   return ipv4FromOctets([octets[0], octets[1], octets[2], octets[3]])
 }
 
 const parseIpv6Segments = (input: string): Result.Result<ReadonlyArray<number>, NetAddressError> => {
   if (input.includes("[") || input.includes("]") || input.includes("%")) {
-    return addressError("brackets and zone identifiers are not valid in a bare IPv6 address")
+    return addressError(input, "brackets and zone identifiers are not valid in a bare IPv6 address")
   }
   const halves = input.split("::")
-  if (halves.length > 2) return addressError("only one compression marker is allowed")
+  if (halves.length > 2) return addressError(input, "only one compression marker is allowed")
   const head = halves[0] === "" ? [] : halves[0].split(":")
   const tail = halves.length === 2 && halves[1] !== "" ? halves[1].split(":") : []
   if (head.some((part) => part === "") || tail.some((part) => part === "")) {
-    return addressError("empty segments are only valid in the compression marker")
+    return addressError(input, "empty segments are only valid in the compression marker")
   }
   const trailing = tail.length > 0 ? tail[tail.length - 1] : head.length > 0 ? head[head.length - 1] : ""
   let embedded: ReadonlyArray<number> | undefined
   if (trailing.includes(".")) {
     if (halves.length === 2 && tail.length === 0) {
-      return addressError("embedded IPv4 syntax must be trailing")
+      return addressError(input, "embedded IPv4 syntax must be trailing")
     }
     const parsed = Result.map(ipv4FromString(trailing), (address) => {
       const octets = ipv4ToOctets(address)
@@ -497,6 +521,7 @@ const parseIpv6Segments = (input: string): Result.Result<ReadonlyArray<number>, 
   const explicit = head.length + tail.length + (embedded ? 2 : 0)
   if (halves.length === 1 ? explicit !== 8 : explicit >= 8) {
     return addressError(
+      input,
       halves.length === 1 ? "expected eight segments" : "compression must replace at least one segment"
     )
   }
@@ -505,7 +530,7 @@ const parseIpv6Segments = (input: string): Result.Result<ReadonlyArray<number>, 
   const parsedHead = head.map(parse)
   const parsedTail = tail.map(parse)
   if (parsedHead.some((part) => part === undefined) || parsedTail.some((part) => part === undefined)) {
-    return addressError("segments must contain one through four hexadecimal digits")
+    return addressError(input, "segments must contain one through four hexadecimal digits")
   }
   return Result.succeed([
     ...parsedHead as ReadonlyArray<number>,
@@ -848,8 +873,11 @@ const InetV4Proto = {
   toString(this: InetAddressV4): string {
     return formatInet(this)
   },
-  [NodeInspectSymbol](this: InetAddressV4): string {
+  toJSON(this: InetAddressV4): string {
     return this.toString()
+  },
+  [NodeInspectSymbol](this: InetAddressV4): string {
+    return this.toJSON()
   }
 }
 
@@ -869,15 +897,15 @@ const InetV6Proto = {
   toString(this: InetAddressV6): string {
     return formatInet(this)
   },
-  [NodeInspectSymbol](this: InetAddressV6): string {
+  toJSON(this: InetAddressV6): string {
     return this.toString()
+  },
+  [NodeInspectSymbol](this: InetAddressV6): string {
+    return this.toJSON()
   }
 }
 
-const checkPort = (port: number): Result.Result<number, NetAddressError> =>
-  Number.isInteger(port) && port >= 0 && port <= 0xffff
-    ? Result.succeed(port)
-    : addressError("port must be an integer from 0 through 65535")
+const checkPort = (port: number): boolean => Number.isInteger(port) && port >= 0 && port <= 0xffff
 
 /**
  * Creates a checked IPv4 internet address.
@@ -886,12 +914,13 @@ const checkPort = (port: number): Result.Result<number, NetAddressError> =>
  * @since 4.0.0
  */
 export const inetAddressV4 = (address: Ipv4Address, port: number): Result.Result<InetAddressV4, NetAddressError> => {
-  return Result.map(checkPort(port), () => {
-    const self = Object.create(InetV4Proto)
-    self.address = address
-    self.port = port
-    return Object.freeze(self)
-  })
+  if (!checkPort(port)) {
+    return addressError(address, "port must be an integer from 0 through 65535")
+  }
+  const self = Object.create(InetV4Proto)
+  self.address = address
+  self.port = port
+  return Result.succeed(Object.freeze(self))
 }
 
 /**
@@ -905,17 +934,18 @@ export const inetAddressV6 = (
   port: number,
   options?: { readonly scopeId?: number | undefined }
 ): Result.Result<InetAddressV6, NetAddressError> => {
-  return Result.flatMap(checkPort(port), () => {
-    const scopeId = options?.scopeId ?? 0
-    if (!Number.isInteger(scopeId) || scopeId < 0 || scopeId > 0xffffffff) {
-      return addressError("scopeId must be an unsigned 32-bit integer")
-    }
-    const self = Object.create(InetV6Proto)
-    self.address = address
-    self.port = port
-    self.scopeId = scopeId
-    return Result.succeed(Object.freeze(self))
-  })
+  if (!checkPort(port)) {
+    return addressError(address, "port must be an integer from 0 through 65535")
+  }
+  const scopeId = options?.scopeId ?? 0
+  if (!Number.isInteger(scopeId) || scopeId < 0 || scopeId > 0xffffffff) {
+    return addressError(address, "scopeId must be an unsigned 32-bit integer")
+  }
+  const self = Object.create(InetV6Proto)
+  self.address = address
+  self.port = port
+  self.scopeId = scopeId
+  return Result.succeed(Object.freeze(self))
 }
 
 /**
@@ -982,7 +1012,7 @@ export const inetAddressFromString = (input: string): Result.Result<InetAddress,
   if (bracketed) {
     const end = input.indexOf("]")
     if (end < 0 || input[end + 1] !== ":" || input.indexOf("]", end + 1) !== -1) {
-      return addressError("expected [IPv6]:port")
+      return addressError(input, "expected [IPv6]:port")
     }
     host = input.slice(1, end)
     portText = input.slice(end + 2)
@@ -990,31 +1020,31 @@ export const inetAddressFromString = (input: string): Result.Result<InetAddress,
     if (scopeSeparator !== -1) {
       const scopeText = host.slice(scopeSeparator + 1)
       if (host.indexOf("%", scopeSeparator + 1) !== -1 || !/^\d+$/.test(scopeText)) {
-        return addressError("scope identifier must be decimal")
+        return addressError(input, "scope identifier must be decimal")
       }
       scopeId = Number(scopeText)
       if (!Number.isInteger(scopeId) || scopeId > 0xffffffff) {
-        return addressError("scope identifier must be an unsigned 32-bit integer")
+        return addressError(input, "scope identifier must be an unsigned 32-bit integer")
       }
       host = host.slice(0, scopeSeparator)
     }
   } else {
     const separator = input.lastIndexOf(":")
     if (separator < 0) {
-      return addressError("expected host:port or [IPv6]:port")
+      return addressError(input, "expected host:port or [IPv6]:port")
     }
     if (input.indexOf(":") !== separator) {
-      return addressError("IPv6 addresses must be bracketed")
+      return addressError(input, "IPv6 addresses must be bracketed")
     }
     host = input.slice(0, separator)
     portText = input.slice(separator + 1)
   }
   if (!/^(0|[1-9]\d*)$/.test(portText)) {
-    return addressError("port must be an unpadded decimal integer")
+    return addressError(input, "port must be an unpadded decimal integer")
   }
   return Result.flatMap(ipFromString(host), (address): Result.Result<InetAddress, NetAddressError> => {
     if (bracketed !== isIpv6Address(address)) {
-      return addressError("only IPv6 addresses use brackets")
+      return addressError(input, "only IPv6 addresses use brackets")
     }
     return isIpv6Address(address)
       ? inetAddressV6(address, Number(portText), { scopeId })
@@ -1052,6 +1082,73 @@ export const formatInet = (self: InetAddress): string => {
 export const formatUrlHost = (self: IpAddress): string => isIpv4Address(self) ? formatIp(self) : `[${formatIp(self)}]`
 
 /**
+ * Converts an IP address or internet socket address to a WHATWG `URL`.
+ *
+ * **Details**
+ *
+ * Defaults to the HTTP scheme and uses standard URL normalization, including
+ * IPv6 brackets and omission of default ports. Bare IP addresses have no
+ * explicit port; internet socket addresses retain their port, including zero.
+ * Unspecified addresses are preserved.
+ *
+ * **Gotchas**
+ *
+ * Returns a `NetAddressError` for scoped IPv6 addresses or inputs that the URL
+ * constructor rejects. Supply the scheme without a trailing colon, for example
+ * `"https"`.
+ *
+ * @category conversions
+ * @since 4.0.0
+ */
+export const toUrl = (self: IpAddress | InetAddress, scheme: string = "http"): Result.Result<URL, NetAddressError> => {
+  if (self._tag === "InetAddressV6" && self.scopeId !== 0) {
+    return addressError(self, "scoped IPv6 addresses are not supported by WHATWG URLs")
+  }
+  return Result.try({
+    try: () => new URL(`${scheme}://${isInetAddress(self) ? formatInet(self) : formatUrlHost(self)}`),
+    catch: (cause) => new NetAddressError({ input: self, message: "failed to construct URL", cause })
+  })
+}
+
+/**
+ * Formats an IP or socket address as a URL display string.
+ *
+ * **Details**
+ *
+ * Defaults to HTTP, brackets IPv6 addresses, and omits default ports and the
+ * trailing slash. Custom schemes such as `"tcp"` retain their scheme and host.
+ * Unix socket addresses use {@link formatUnixPath}, preserving the raw path
+ * with a `unix://` prefix regardless of the supplied scheme.
+ *
+ * **Gotchas**
+ *
+ * Returns a `NetAddressError` when URL conversion fails, including for scoped
+ * IPv6 addresses.
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export const formatUrl = (
+  self: IpAddress | SocketAddress,
+  scheme: string = "http"
+): Result.Result<string, NetAddressError> =>
+  isUnixPathAddress(self)
+    ? Result.succeed(formatUnixPath(self))
+    : Result.map(toUrl(self, scheme), (url) => `${url.protocol}//${url.host}`)
+
+/**
+ * Formats an IP or socket address as a URL display string,
+ * throwing a `NetAddressError` when conversion fails.
+ *
+ * @see {@link formatUrl} for the checked version and formatting behavior.
+ *
+ * @category unsafe
+ * @since 4.0.0
+ */
+export const formatUrlUnsafe = (self: IpAddress | SocketAddress, scheme: string = "http"): string =>
+  Result.getOrThrow(formatUrl(self, scheme))
+
+/**
  * Formats a hostname or numeric IP address for use as a URL authority host.
  *
  * @category encoding
@@ -1067,13 +1164,16 @@ const UnixPathProto = {
     return isUnixPathAddress(that) && this.path === that.path
   },
   [Hash.symbol](this: UnixPathAddress): number {
-    return Hash.combine(Hash.string("UnixPathAddress"))(Hash.string(this.path))
+    return Hash.combine(Hash.string("UnixPathAddress"), Hash.string(this.path))
   },
   toString(this: UnixPathAddress): string {
     return this.path
   },
-  [NodeInspectSymbol](this: UnixPathAddress): string {
+  toJSON(this: UnixPathAddress): string {
     return this.toString()
+  },
+  [NodeInspectSymbol](this: UnixPathAddress): string {
+    return this.toJSON()
   }
 }
 
@@ -1088,6 +1188,19 @@ export const unixPathAddress = (path: string): UnixPathAddress => {
   self.path = path
   return Object.freeze(self)
 }
+
+/**
+ * Formats a Unix-domain socket path as a readable `unix://path` display string.
+ *
+ * **Details**
+ *
+ * Preserves the raw path without URL encoding or normalization. The resulting
+ * string is intended for display.
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export const formatUnixPath = (self: UnixPathAddress): string => `unix://${self.path}`
 
 /**
  * Converts a `SocketAddress.Input` to a concrete socket address.
@@ -1108,16 +1221,16 @@ export const socketAddressFromInput = (
   if (hasProperty(input, "path")) {
     return typeof input.path === "string"
       ? Result.succeed(unixPathAddress(input.path))
-      : addressError("path must be a string")
+      : addressError(input, "path must be a string")
   }
   if (!hasProperty(input, "address") || !hasProperty(input, "port")) {
-    return addressError("expected an address and port or a Unix path")
+    return addressError(input, "expected an address and port or a Unix path")
   }
   const address = typeof input.address === "string"
     ? ipFromString(input.address)
     : isIpAddress(input.address)
     ? Result.succeed(input.address)
-    : addressError("address must be an IP address or numeric IP string")
+    : addressError(input, "address must be an IP address or numeric IP string")
   return Result.flatMap(address, (address) => inetAddress(address, input.port as number))
 }
 

--- a/packages/effect/test/unstable/http/HttpServer.test.ts
+++ b/packages/effect/test/unstable/http/HttpServer.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect } from "effect"
+import { Cause, Effect, Exit } from "effect"
 import * as HttpClient from "effect/unstable/http/HttpClient"
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse"
 import * as HttpServer from "effect/unstable/http/HttpServer"
@@ -16,29 +16,84 @@ describe("HttpServer", () => {
     assert.strictEqual(server.address, address)
   })
 
-  it("formats scoped IPv6 addresses as valid URLs", () => {
-    const address = NetAddress.inetAddressFromStringUnsafe("[fe80::1%2]:3000")
-    const formatted = HttpServer.formatAddress(address)
-    assert.strictEqual(formatted, "http://[fe80::1]:3000")
-    assert.doesNotThrow(() => new URL(formatted))
-  })
+  it.effect("passes formatted server addresses to the callback", () =>
+    Effect.gen(function*() {
+      for (
+        const [input, expected] of [
+          ["127.0.0.1:3000", "http://127.0.0.1:3000"],
+          ["127.0.0.1:80", "http://127.0.0.1"],
+          ["[::]:3000", "http://[::]:3000"],
+          ["[::1]:3000", "http://[::1]:3000"],
+          ["[fe80::1%0]:3000", "http://[fe80::1]:3000"]
+        ]
+      ) {
+        const server = HttpServer.make({
+          address: NetAddress.inetAddressFromStringUnsafe(input),
+          serve: () => Effect.void
+        })
+        const formatted = yield* HttpServer.addressFormattedWith(Effect.succeed).pipe(
+          Effect.provideService(HttpServer.HttpServer, server)
+        )
+        assert.strictEqual(formatted, expected)
+        assert.doesNotThrow(() => new URL(formatted))
+      }
+      for (
+        const [path, expected] of [
+          ["server.sock", "unix://server.sock"],
+          ["/tmp/server.sock", "unix:///tmp/server.sock"],
+          ["./run/../socket?#", "unix://./run/../socket?#"]
+        ]
+      ) {
+        const server = HttpServer.make({ address: NetAddress.unixPathAddress(path), serve: () => Effect.void })
+        const formatted = yield* HttpServer.addressFormattedWith(Effect.succeed).pipe(
+          Effect.provideService(HttpServer.HttpServer, server)
+        )
+        assert.strictEqual(formatted, expected)
+      }
+    }))
 
-  it.effect("preserves the address family for unspecified test server addresses", () => {
-    const server = HttpServer.make({
-      address: NetAddress.inetAddressUnsafe(NetAddress.ipv6Unspecified, 3000),
-      serve: () => Effect.void
-    })
-    const client = HttpClient.make((request, url) => {
-      assert.strictEqual(url.origin, "http://[::1]:3000")
-      return Effect.succeed(HttpClientResponse.fromWeb(request, new Response()))
-    })
+  it.effect("rejects scoped IPv6 test server addresses before dropping their scope", () =>
+    Effect.gen(function*() {
+      for (const input of ["[fe80::1%2]:3000", "[::%2]:3000"]) {
+        const address = NetAddress.inetAddressFromStringUnsafe(input)
+        const server = HttpServer.make({ address, serve: () => Effect.void })
+        const client = HttpClient.make(() => Effect.die("unexpected request"))
+        const exit = yield* HttpServer.makeTestClient.pipe(
+          Effect.provideService(HttpServer.HttpServer, server),
+          Effect.provideService(HttpClient.HttpClient, client),
+          Effect.exit
+        )
+        if (Exit.isSuccess(exit)) assert.fail("expected Failure")
+        const error = Cause.squash(exit.cause)
+        assert.instanceOf(error, NetAddress.NetAddressError)
+        assert.strictEqual((error as NetAddress.NetAddressError).input, address)
+      }
+    }))
 
-    return Effect.gen(function*() {
-      const testClient = yield* HttpServer.makeTestClient
-      yield* testClient.get("/")
-    }).pipe(
-      Effect.provideService(HttpServer.HttpServer, server),
-      Effect.provideService(HttpClient.HttpClient, client)
-    )
-  })
+  it.effect("uses IPv4 loopback for unspecified listeners and preserves explicit hosts", () =>
+    Effect.gen(function*() {
+      for (
+        const [input, origin] of [
+          ["0.0.0.0:3000", "http://127.0.0.1:3000"],
+          ["[::]:3000", "http://127.0.0.1:3000"],
+          ["127.0.0.1:3000", "http://127.0.0.1:3000"],
+          ["[::1]:3000", "http://[::1]:3000"],
+          ["[2001:db8::1]:3000", "http://[2001:db8::1]:3000"]
+        ]
+      ) {
+        const server = HttpServer.make({
+          address: NetAddress.inetAddressFromStringUnsafe(input),
+          serve: () => Effect.void
+        })
+        const client = HttpClient.make((request, url) => {
+          assert.strictEqual(url.origin, origin)
+          return Effect.succeed(HttpClientResponse.fromWeb(request, new Response()))
+        })
+        const testClient = yield* HttpServer.makeTestClient.pipe(
+          Effect.provideService(HttpServer.HttpServer, server),
+          Effect.provideService(HttpClient.HttpClient, client)
+        )
+        yield* testClient.get("/")
+      }
+    }))
 })

--- a/packages/effect/test/unstable/net/IpInterface.test.ts
+++ b/packages/effect/test/unstable/net/IpInterface.test.ts
@@ -1,16 +1,18 @@
 import { assert, describe, it } from "@effect/vitest"
+import { assertTrue } from "@effect/vitest/utils"
 import { Equal, Hash, Result, Schema } from "effect"
 import * as IpInterface from "effect/unstable/net/IpInterface"
 import * as IpNetwork from "effect/unstable/net/IpNetwork"
 import * as NetAddress from "effect/unstable/net/NetAddress"
+import { inspect } from "node:util"
 
 const success = <A>(result: Result.Result<A, unknown>): A => {
-  if (Result.isFailure(result)) assert.fail("expected Success")
+  assertTrue(Result.isSuccess(result), "expected Success")
   return result.success
 }
 
 const failure = <E>(result: Result.Result<unknown, E>): E => {
-  if (Result.isSuccess(result)) assert.fail("expected Failure")
+  assertTrue(Result.isFailure(result), "expected Failure")
   return result.failure
 }
 
@@ -18,6 +20,31 @@ const ip = (input: string): NetAddress.IpAddress => success(NetAddress.ipFromStr
 const interfaceAddress = (input: string): IpInterface.IpInterface => success(IpInterface.fromString(input))
 
 describe("IpInterface", () => {
+  it("serializes and inspects canonical strings", () => {
+    for (const expected of ["192.0.2.1/24", "2001:db8::1/64"]) {
+      const address = IpInterface.fromStringUnsafe(expected)
+      assert.strictEqual(address.toJSON(), expected)
+      assert.strictEqual(JSON.stringify(address), JSON.stringify(expected))
+      assert.strictEqual(inspect(address), expected)
+    }
+  })
+
+  it("retains the address supplied to checked constructors", () => {
+    const address = NetAddress.ipv4Loopback
+    assert.strictEqual(failure(IpInterface.make(address, 33)).input, address)
+  })
+
+  it("forwards errors from address and prefix validation", () => {
+    for (const parse of [IpInterface.fromString, IpInterface.ipv4FromString]) {
+      assert.strictEqual(failure(parse("1.2.3.4/+24")).input, "1.2.3.4/+24")
+      assert.strictEqual(failure(parse("010.2.3.4/24")).input, "010.2.3.4")
+      assert.deepStrictEqual(failure(parse("1.2.3.4/33")).input, ip("1.2.3.4"))
+    }
+    for (const parse of [IpInterface.fromString, IpInterface.ipv6FromString]) {
+      assert.strictEqual(failure(parse("::ffff:192.000.2.1/128")).input, "192.000.2.1")
+    }
+  })
+
   it("constructs one generic runtime representation", () => {
     const ipv4 = IpInterface.makeUnsafe(NetAddress.ipv4Unspecified, 0)
     const ipv6 = IpInterface.makeUnsafe(NetAddress.ipv6Unspecified, 0)

--- a/packages/effect/test/unstable/net/IpNetwork.test.ts
+++ b/packages/effect/test/unstable/net/IpNetwork.test.ts
@@ -1,16 +1,18 @@
 import { assert, describe, it } from "@effect/vitest"
+import { assertTrue } from "@effect/vitest/utils"
 import { Equal, Hash, Result, Schema } from "effect"
 import * as IpNetwork from "effect/unstable/net/IpNetwork"
 import * as NetAddress from "effect/unstable/net/NetAddress"
 import * as fc from "fast-check"
+import { inspect } from "node:util"
 
 const success = <A>(result: Result.Result<A, unknown>): A => {
-  if (Result.isFailure(result)) assert.fail("expected Success")
+  assertTrue(Result.isSuccess(result), "expected Success")
   return result.success
 }
 
 const failure = <E>(result: Result.Result<unknown, E>): E => {
-  if (Result.isSuccess(result)) assert.fail("expected Failure")
+  assertTrue(Result.isFailure(result), "expected Failure")
   return result.failure
 }
 
@@ -18,6 +20,33 @@ const ip = (input: string): NetAddress.IpAddress => success(NetAddress.ipFromStr
 const network = (input: string): IpNetwork.IpNetwork => success(IpNetwork.fromString(input))
 
 describe("IpNetwork", () => {
+  it("serializes and inspects canonical strings", () => {
+    for (const expected of ["192.0.2.0/24", "2001:db8::/32"]) {
+      const address = IpNetwork.fromStringUnsafe(expected)
+      assert.strictEqual(address.toJSON(), expected)
+      assert.strictEqual(JSON.stringify(address), JSON.stringify(expected))
+      assert.strictEqual(inspect(address), expected)
+    }
+  })
+
+  it("retains the address supplied to checked constructors", () => {
+    const address = NetAddress.ipv4Loopback
+    assert.strictEqual(failure(IpNetwork.make(address, 33)).input, address)
+    assert.strictEqual(failure(IpNetwork.make(address, 8)).input, address)
+    assert.strictEqual(failure(IpNetwork.fromAddress(address, 33)).input, address)
+  })
+
+  it("forwards errors from address and prefix validation", () => {
+    for (const parse of [IpNetwork.fromString, IpNetwork.ipv4FromString]) {
+      assert.strictEqual(failure(parse("1.2.3.4/+24")).input, "1.2.3.4/+24")
+      assert.strictEqual(failure(parse("010.2.3.4/24")).input, "010.2.3.4")
+      assert.deepStrictEqual(failure(parse("1.2.3.4/33")).input, ip("1.2.3.4"))
+    }
+    for (const parse of [IpNetwork.fromString, IpNetwork.ipv6FromString]) {
+      assert.strictEqual(failure(parse("::ffff:192.000.2.1/128")).input, "192.000.2.1")
+    }
+  })
+
   it("constructs immutable canonical networks and preserves family identity", () => {
     const ipv4 = IpNetwork.makeUnsafe(NetAddress.ipv4Unspecified, 0)
     const ipv6 = IpNetwork.makeUnsafe(NetAddress.ipv6Unspecified, 0)
@@ -43,6 +72,7 @@ describe("IpNetwork", () => {
       failure(IpNetwork.fromAddress(ipv4, prefix))
     }
     failure(IpNetwork.make(ipv6, 129))
+    assert.deepStrictEqual(failure(IpNetwork.fromString("10.1.2.3/8")).input, ipv4)
     failure(IpNetwork.make(ipv4, 8))
     failure(IpNetwork.make(ipv6, 32))
 

--- a/packages/effect/test/unstable/net/NetAddress.test.ts
+++ b/packages/effect/test/unstable/net/NetAddress.test.ts
@@ -1,15 +1,18 @@
 import { assert, describe, it } from "@effect/vitest"
+import { assertTrue } from "@effect/vitest/utils"
 import { Equal, Hash, Option, Result, Schema } from "effect"
 import * as NetAddress from "effect/unstable/net/NetAddress"
 import { Buffer } from "node:buffer"
+import { inspect } from "node:util"
 
 const success = <A>(result: Result.Result<A, unknown>): A => {
-  if (Result.isFailure(result)) assert.fail("expected Success")
+  assertTrue(Result.isSuccess(result), "expected Success")
   return result.success
 }
 
-const failure = (result: Result.Result<unknown, unknown>): void => {
-  assert.isTrue(Result.isFailure(result))
+const failure = <E>(result: Result.Result<unknown, E>): E => {
+  assertTrue(Result.isFailure(result), "expected Failure")
+  return result.failure
 }
 
 describe("NetAddress", () => {
@@ -230,6 +233,157 @@ describe("NetAddress", () => {
     assert.isTrue(Equal.equals(NetAddress.ipv6Unspecified, ip("::")))
   })
 
+  it("serializes and inspects canonical strings without private bytes", () => {
+    const cases = [
+      [NetAddress.ipv4Loopback, "127.0.0.1"],
+      [NetAddress.ipv6Loopback, "::1"],
+      [NetAddress.macAddressFromStringUnsafe("02:0A:0B:0C:0D:0E"), "02:0a:0b:0c:0d:0e"],
+      [NetAddress.inetAddressFromStringUnsafe("127.0.0.1:80"), "127.0.0.1:80"],
+      [NetAddress.inetAddressFromStringUnsafe("[fe80::1%2]:80"), "[fe80::1%2]:80"],
+      [NetAddress.unixPathAddress("./run/../server.sock"), "./run/../server.sock"]
+    ] as const
+    for (const [address, expected] of cases) {
+      assert.strictEqual(address.toJSON(), expected)
+      assert.strictEqual(JSON.stringify(address), JSON.stringify(expected))
+      assert.strictEqual(JSON.stringify({ address }), JSON.stringify({ address: expected }))
+      assert.strictEqual(inspect(address), expected)
+    }
+  })
+
+  it("preserves the input rejected by the failing operation", () => {
+    const cases = [
+      [NetAddress.ipv4FromString, "01.2.3.4", "01.2.3.4"],
+      [NetAddress.ipv6FromString, "::ffff:192.000.2.1", "192.000.2.1"],
+      [NetAddress.macAddressFromString, "00-11-22-33-44-55", "00-11-22-33-44-55"],
+      [NetAddress.inetAddressFromString, "localhost:80", "localhost"],
+      [NetAddress.inetAddressFromString, "[::ffff:999.0.0.1]:80", "999.0.0.1"],
+      [NetAddress.inetAddressFromString, "[fe80::1%bad]:80", "[fe80::1%bad]:80"]
+    ] as const
+    for (const [parse, input, rejected] of cases) {
+      assert.strictEqual(failure(parse(input)).input, rejected)
+    }
+    assert.deepStrictEqual(failure(NetAddress.inetAddressFromString("127.0.0.1:65536")).input, NetAddress.ipv4Loopback)
+    assert.strictEqual(
+      failure(NetAddress.socketAddressFromInput({ address: "localhost", port: 80 })).input,
+      "localhost"
+    )
+    assert.strictEqual(failure(NetAddress.inetAddressFromIpString("localhost", 80)).input, "localhost")
+    const octets = [256, 0, 0, 1] as const
+    assert.strictEqual(failure(NetAddress.ipv4FromOctets(octets)).input, octets)
+  })
+
+  it("retains the address supplied to checked socket constructors", () => {
+    const ipv4 = NetAddress.ipv4Loopback
+    const ipv6 = NetAddress.ipv6Loopback
+    assert.strictEqual(failure(NetAddress.inetAddressV4(ipv4, -1)).input, ipv4)
+    assert.strictEqual(failure(NetAddress.inetAddressV6(ipv6, -1)).input, ipv6)
+    assert.strictEqual(failure(NetAddress.inetAddressV6(ipv6, 80, { scopeId: -1 })).input, ipv6)
+  })
+
+  it("converts internet addresses to normalized URL values", () => {
+    for (
+      const [input, scheme, expected] of [
+        ["[::]:3000", "https", "https://[::]:3000/"],
+        ["0.0.0.0:3000", "http", "http://0.0.0.0:3000/"],
+        ["[::1]:3000", "ws", "ws://[::1]:3000/"],
+        ["192.0.2.1:80", "http", "http://192.0.2.1/"],
+        ["[::1]:443", "HTTPS", "https://[::1]/"],
+        ["[::1]:0", "http", "http://[::1]:0/"],
+        ["192.0.2.1:65535", "http", "http://192.0.2.1:65535/"]
+      ]
+    ) {
+      const address = NetAddress.inetAddressFromStringUnsafe(input)
+      const url = success(NetAddress.toUrl(address, scheme))
+      assert.instanceOf(url, URL)
+      assert.strictEqual(url.href, expected)
+    }
+    const address = NetAddress.inetAddressFromStringUnsafe("[::]:3000")
+    const url = success(NetAddress.toUrl(address))
+    assert.strictEqual(url.href, "http://[::]:3000/")
+    url.hostname = "127.0.0.1"
+    assert.strictEqual(url.origin, "http://127.0.0.1:3000")
+    assert.strictEqual(success(NetAddress.toUrl(address, undefined)).hostname, "[::]")
+  })
+
+  it("converts bare IP addresses without adding an explicit port", () => {
+    for (
+      const [input, expected] of [
+        ["127.0.0.1", "http://127.0.0.1/"],
+        ["::1", "http://[::1]/"],
+        ["0.0.0.0", "http://0.0.0.0/"],
+        ["::", "http://[::]/"]
+      ]
+    ) {
+      const url = success(NetAddress.toUrl(NetAddress.ipFromStringUnsafe(input)))
+      assert.strictEqual(url.href, expected)
+      assert.strictEqual(url.port, "")
+    }
+    assert.strictEqual(success(NetAddress.toUrl(NetAddress.ipv6Loopback, "https")).href, "https://[::1]/")
+  })
+
+  it("formats URL strings without trailing slashes or default ports", () => {
+    assert.strictEqual(success(NetAddress.formatUrl(NetAddress.ipv4Loopback)), "http://127.0.0.1")
+    assert.strictEqual(success(NetAddress.formatUrl(NetAddress.ipv6Loopback, "https")), "https://[::1]")
+    assert.strictEqual(NetAddress.formatUrlUnsafe(NetAddress.ipv4Loopback), "http://127.0.0.1")
+    assert.strictEqual(NetAddress.formatUrlUnsafe(NetAddress.ipv6Loopback, "https"), "https://[::1]")
+    for (
+      const [input, scheme, expected] of [
+        ["192.0.2.1:80", "http", "http://192.0.2.1"],
+        ["[::1]:443", "HTTPS", "https://[::1]"],
+        ["[::]:3000", "http", "http://[::]:3000"],
+        ["[::1]:0", "http", "http://[::1]:0"],
+        ["127.0.0.1:80", "tcp", "tcp://127.0.0.1:80"]
+      ]
+    ) {
+      assert.strictEqual(success(NetAddress.formatUrl(NetAddress.inetAddressFromStringUnsafe(input), scheme)), expected)
+    }
+    const scoped = NetAddress.inetAddressFromStringUnsafe("[fe80::1%2]:3000")
+    const scopedError = failure(NetAddress.formatUrl(scoped))
+    assert.strictEqual(scopedError.input, scoped)
+    assert.include(scopedError.message, "scoped IPv6")
+    const schemeError = failure(NetAddress.formatUrl(NetAddress.ipv4Loopback, "1http"))
+    assert.strictEqual(schemeError.input, NetAddress.ipv4Loopback)
+    assert.instanceOf(schemeError.cause, TypeError)
+    assert.throws(() => NetAddress.formatUrlUnsafe(scoped), NetAddress.NetAddressError, "scoped IPv6")
+    assert.throws(() => NetAddress.formatUrlUnsafe(NetAddress.ipv4Loopback, "1http"), NetAddress.NetAddressError)
+  })
+
+  it("formats Unix socket paths without encoding or normalizing them", () => {
+    for (
+      const [path, expected] of [
+        ["/tmp/server.sock", "unix:///tmp/server.sock"],
+        ["./run/../server.sock", "unix://./run/../server.sock"],
+        ["/tmp/socket?#%20", "unix:///tmp/socket?#%20"],
+        ["/tmp/socket with spaces.sock", "unix:///tmp/socket with spaces.sock"],
+        ["", "unix://"]
+      ]
+    ) {
+      const address = NetAddress.unixPathAddress(path)
+      assert.strictEqual(NetAddress.formatUnixPath(address), expected)
+      assert.strictEqual(success(NetAddress.formatUrl(address)), expected)
+      assert.strictEqual(NetAddress.formatUrlUnsafe(address, "https"), expected)
+    }
+  })
+
+  it("returns URL conversion errors for scopes and rejected URLs", () => {
+    for (const input of ["[fe80::1%2]:3000", "[::%2]:3000"]) {
+      const scoped = NetAddress.inetAddressFromStringUnsafe(input)
+      const error = failure(NetAddress.toUrl(scoped, "http"))
+      assert.instanceOf(error, NetAddress.NetAddressError)
+      assert.strictEqual(error.input, scoped)
+      assert.include(error.message, "scoped IPv6")
+      assert.isUndefined(error.cause)
+    }
+    const address = NetAddress.inetAddressFromStringUnsafe("127.0.0.1:80")
+    for (const scheme of ["", "1http", "file"]) {
+      const error = failure(NetAddress.toUrl(address, scheme))
+      assert.instanceOf(error, NetAddress.NetAddressError)
+      assert.strictEqual(error.input, address)
+      assert.strictEqual(error.message, "failed to construct URL")
+      assert.instanceOf(error.cause, TypeError)
+    }
+  })
+
   it("constructs immutable address values", () => {
     const ipv4 = success(NetAddress.ipv4FromString("127.0.0.1"))
     const ipv6 = success(NetAddress.ipv6FromString("::1"))
@@ -289,9 +443,10 @@ describe("NetAddress", () => {
 
   it("returns NetAddressError from checked operations", () => {
     const result = NetAddress.ipFromString("localhost")
-    if (Result.isSuccess(result)) assert.fail("expected Failure")
+    assertTrue(Result.isFailure(result), "expected Failure")
     assert.instanceOf(result.failure, NetAddress.NetAddressError)
     assert.strictEqual(result.failure.message, "expected exactly four decimal octets")
+    assert.strictEqual(result.failure.input, "localhost")
   })
 
   describe("socket addresses", () => {
@@ -382,11 +537,11 @@ describe("NetAddress", () => {
         failure(NetAddress.inetAddressFromString(input))
       }
       const invalidPort = NetAddress.inetAddressFromString("127.0.0.1:65536")
-      if (Result.isSuccess(invalidPort)) assert.fail("expected Failure")
+      assertTrue(Result.isFailure(invalidPort), "expected Failure")
       assert.strictEqual(invalidPort.failure.message, "port must be an integer from 0 through 65535")
 
       const missingPort = NetAddress.inetAddressFromString("127.0.0.1")
-      if (Result.isSuccess(missingPort)) assert.fail("expected Failure")
+      assertTrue(Result.isFailure(missingPort), "expected Failure")
       assert.strictEqual(missingPort.failure.message, "expected host:port or [IPv6]:port")
     })
 

--- a/packages/effect/typetest/unstable/net/NetAddress.tst.ts
+++ b/packages/effect/typetest/unstable/net/NetAddress.tst.ts
@@ -52,6 +52,30 @@ describe("NetAddress", () => {
     })
   })
 
+  it("converts internet addresses to URLs and exposes rejected inputs", () => {
+    const address = NetAddress.inetAddressUnsafe(NetAddress.ipv6Unspecified, 80)
+    expect(NetAddress.toUrl(address)).type.toBe<Result.Result<URL, NetAddress.NetAddressError>>()
+    expect(NetAddress.toUrl(address, undefined)).type.toBe<Result.Result<URL, NetAddress.NetAddressError>>()
+    expect(NetAddress.toUrl(address, "https")).type.toBe<Result.Result<URL, NetAddress.NetAddressError>>()
+    const unix = NetAddress.unixPathAddress("server.sock")
+    expect(NetAddress.toUrl(NetAddress.ipv4Loopback)).type.toBe<Result.Result<URL, NetAddress.NetAddressError>>()
+    expect(NetAddress.toUrl(NetAddress.ipv6Loopback, "https")).type.toBe<
+      Result.Result<URL, NetAddress.NetAddressError>
+    >()
+    expect(NetAddress.toUrl).type.not.toBeCallableWith(unix)
+    expect(NetAddress.toUrl).type.not.toBeCallableWith(unix, "http")
+    expect(NetAddress.formatUrl(address)).type.toBe<Result.Result<string, NetAddress.NetAddressError>>()
+    expect(NetAddress.formatUrl(NetAddress.ipv4Loopback, "https")).type.toBe<
+      Result.Result<string, NetAddress.NetAddressError>
+    >()
+    expect(NetAddress.formatUrl(unix)).type.toBe<Result.Result<string, NetAddress.NetAddressError>>()
+    expect(NetAddress.formatUrlUnsafe(address)).type.toBe<string>()
+    expect(NetAddress.formatUrlUnsafe(NetAddress.ipv4Loopback, "https")).type.toBe<string>()
+    expect(NetAddress.formatUrlUnsafe(unix)).type.toBe<string>()
+    expect(NetAddress.formatUnixPath(unix)).type.toBe<string>()
+    expect(new NetAddress.NetAddressError({ input: address, message: "invalid" }).input).type.toBe<unknown>()
+  })
+
   it("narrows address unions", () => {
     const address = null as unknown as NetAddress.SocketAddress
     if (NetAddress.isUnixPathAddress(address)) {
@@ -61,6 +85,27 @@ describe("NetAddress", () => {
     } else {
       expect(address.address).type.toBe<NetAddress.Ipv6Address>()
     }
+  })
+
+  it("preserves named schema types when annotating codecs", () => {
+    expect(Schema.MacAddressFromString.annotate({ identifier: "custom" })).type.toBe<Schema.MacAddressFromString>()
+    expect(Schema.Ipv4AddressFromString.annotate({ identifier: "custom" })).type.toBe<Schema.Ipv4AddressFromString>()
+    expect(Schema.Ipv6AddressFromString.annotate({ identifier: "custom" })).type.toBe<Schema.Ipv6AddressFromString>()
+    expect(Schema.IpAddressFromString.annotate({ identifier: "custom" })).type.toBe<Schema.IpAddressFromString>()
+    expect(Schema.Ipv4InterfaceFromString.annotate({ identifier: "custom" })).type.toBe<
+      Schema.Ipv4InterfaceFromString
+    >()
+    expect(Schema.Ipv6InterfaceFromString.annotate({ identifier: "custom" })).type.toBe<
+      Schema.Ipv6InterfaceFromString
+    >()
+    expect(Schema.IpInterfaceFromString.annotate({ identifier: "custom" })).type.toBe<Schema.IpInterfaceFromString>()
+    expect(Schema.Ipv4NetworkFromString.annotate({ identifier: "custom" })).type.toBe<Schema.Ipv4NetworkFromString>()
+    expect(Schema.Ipv6NetworkFromString.annotate({ identifier: "custom" })).type.toBe<Schema.Ipv6NetworkFromString>()
+    expect(Schema.IpNetworkFromString.annotate({ identifier: "custom" })).type.toBe<Schema.IpNetworkFromString>()
+    expect(Schema.InetAddressFromString.annotate({ identifier: "custom" })).type.toBe<Schema.InetAddressFromString>()
+    expect(Schema.UnixPathAddressFromString.annotate({ identifier: "custom" })).type.toBe<
+      Schema.UnixPathAddressFromString
+    >()
   })
 
   it("exposes string transformation schemas", () => {

--- a/packages/platform/bun/src/BunHttpServer.ts
+++ b/packages/platform/bun/src/BunHttpServer.ts
@@ -118,7 +118,7 @@ export const make = Effect.fnUntraced(
   ) {
     const scope = yield* Effect.scope
     let listenOptions = options
-    if (!("unix" in options)) {
+    if (!("unix" in options) || options.unix === undefined) {
       const internetOptions = options as Bun.Serve.HostnamePortServeOptions<WebSocketContext>
       const hostname = internetOptions.hostname ?? "0.0.0.0"
       if (Result.isFailure(NetAddress.ipFromString(hostname))) {
@@ -172,7 +172,7 @@ export const make = Effect.fnUntraced(
 
     yield* Scope.addFinalizer(scope, shutdown)
 
-    const address = "unix" in options
+    const address = "unix" in options && options.unix !== undefined
       ? NetAddress.unixPathAddress(options.unix)
       : yield* Effect.fromResult(NetAddress.inetAddressFromIpString(server.hostname!, server.port!)).pipe(
         Effect.mapError((cause) => new Error.ServeError({ cause }))

--- a/packages/platform/bun/test/BunHttpServer.test.ts
+++ b/packages/platform/bun/test/BunHttpServer.test.ts
@@ -5,10 +5,11 @@ import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
 import * as Scope from "effect/Scope"
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient"
 import * as HttpServer from "effect/unstable/http/HttpServer"
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest"
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse"
-import type * as NetAddress from "effect/unstable/net/NetAddress"
+import * as NetAddress from "effect/unstable/net/NetAddress"
 import { mkdtemp, rm } from "node:fs/promises"
 import * as Net from "node:net"
 import { tmpdir } from "node:os"
@@ -112,6 +113,21 @@ const makeWebSocketServer = Effect.fnUntraced(function*(payload: string, compres
 })
 
 describe("BunHttpServer", () => {
+  it.effect("treats an undefined Unix path as a TCP listener", () =>
+    Effect.gen(function*() {
+      for (const hostname of ["localhost", "127.0.0.1"]) {
+        const server = yield* BunHttpServer.make({ unix: undefined, hostname, port: 0 })
+        assert.isTrue(server.address._tag === "InetAddressV4" || server.address._tag === "InetAddressV6")
+        yield* server.serve(Effect.succeed(HttpServerResponse.text("tcp")))
+        const client = yield* HttpServer.makeTestClient.pipe(
+          Effect.provideService(HttpServer.HttpServer, server),
+          Effect.provide(FetchHttpClient.layer)
+        )
+        const response = yield* client.get("/")
+        assert.strictEqual(yield* response.text, "tcp")
+      }
+    }))
+
   it.effect("resolves hostnames and formats Unix socket addresses", () =>
     Effect.gen(function*() {
       const server = yield* BunHttpServer.make({ hostname: "localhost", port: 0 })
@@ -126,7 +142,7 @@ describe("BunHttpServer", () => {
 
       assert.strictEqual(unixServer.address._tag, "UnixPathAddress")
       assert.strictEqual(unixServer.address._tag === "UnixPathAddress" ? unixServer.address.path : undefined, path)
-      assert.strictEqual(HttpServer.formatAddress(unixServer.address), `unix://${path}`)
+      assert.strictEqual(NetAddress.formatUrlUnsafe(unixServer.address), `unix://${path}`)
     }))
 
   it.effect("closing an older serve scope keeps the newer handler active", () =>
@@ -141,7 +157,7 @@ describe("BunHttpServer", () => {
 
       yield* server.serve(Effect.succeed(HttpServerResponse.text("first"))).pipe(Scope.provide(firstScope))
       yield* server.serve(Effect.succeed(HttpServerResponse.text("second"))).pipe(Scope.provide(secondScope))
-      const url = HttpServer.formatAddress(server.address)
+      const url = NetAddress.formatUrlUnsafe(server.address)
 
       assert.strictEqual(yield* fetchText(url), "second")
       yield* Scope.close(firstScope, Exit.void)
@@ -160,7 +176,7 @@ describe("BunHttpServer", () => {
 
       yield* server.serve(Effect.succeed(HttpServerResponse.text("first"))).pipe(Scope.provide(firstScope))
       yield* server.serve(Effect.succeed(HttpServerResponse.text("second"))).pipe(Scope.provide(secondScope))
-      const url = HttpServer.formatAddress(server.address)
+      const url = NetAddress.formatUrlUnsafe(server.address)
 
       assert.strictEqual(yield* fetchText(url), "second")
       yield* Scope.close(secondScope, Exit.void)
@@ -177,7 +193,7 @@ describe("BunHttpServer", () => {
       })
       const firstScope = yield* Scope.fork(ownerScope)
       const secondScope = yield* Scope.fork(ownerScope)
-      const url = HttpServer.formatAddress(server.address)
+      const url = NetAddress.formatUrlUnsafe(server.address)
 
       yield* server.serve(Effect.succeed(HttpServerResponse.text("first"))).pipe(Scope.provide(firstScope))
       assert.strictEqual(yield* fetchText(`${url}/static`), "static")

--- a/packages/sql/pg/src/PgTypes.ts
+++ b/packages/sql/pg/src/PgTypes.ts
@@ -659,14 +659,17 @@ const PGSQL_AF_INET = 2
 const PGSQL_AF_INET6 = 3
 
 const encodeInet = (value: unknown, isCidr: boolean): Uint8Array => {
-  const text = requireString(value, isCidr ? "cidr" : "inet")
+  const type = isCidr ? "cidr" : "inet"
+  const text = requireString(value, type)
   const parsed = IpInterface.fromString(text)
-  if (Result.isFailure(parsed)) return fail(parsed.failure.message)
+  if (Result.isFailure(parsed)) return fail(`Invalid ${type} value ${JSON.stringify(text)}: ${parsed.failure.message}`)
   const address = parsed.success.address
   const bits = parsed.success.prefixLength
   if (isCidr) {
     const network = IpNetwork.make(address, bits)
-    if (Result.isFailure(network)) return fail(network.failure.message)
+    if (Result.isFailure(network)) {
+      return fail(`Invalid ${type} value ${JSON.stringify(text)}: ${network.failure.message}`)
+    }
   }
   const octets = NetAddress.isIpv4Address(address)
     ? NetAddress.ipv4ToOctets(address)
@@ -698,16 +701,14 @@ const decodeInet = (bytes: Uint8Array, offset: number, size: number): string => 
   const address = family === PGSQL_AF_INET
     ? NetAddress.ipv4FromBytesUnsafe(addressBytes)
     : NetAddress.ipv6FromBytesUnsafe(addressBytes)
-  const interfaceAddress = IpInterface.make(address, bits)
-  if (Result.isFailure(interfaceAddress)) return fail(interfaceAddress.failure.message)
   if (isCidr) {
-    const network = IpNetwork.make(interfaceAddress.success.address, interfaceAddress.success.prefixLength)
+    const network = IpNetwork.make(address, bits)
     if (Result.isFailure(network)) return fail(network.failure.message)
     return IpNetwork.format(network.success)
   }
   return bits === addressSize * 8
     ? NetAddress.formatIp(address)
-    : IpInterface.format(interfaceAddress.success)
+    : IpInterface.format(IpInterface.makeUnsafe(address, bits))
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/sql/pg/test/PgTypes.test.ts
+++ b/packages/sql/pg/test/PgTypes.test.ts
@@ -287,6 +287,23 @@ describe("PgTypes", () => {
     assert.strictEqual(PgTypes.decode(expected, PgTypes.OID.cidr, 1), "2001:db8::/32")
   })
 
+  it("includes the input and column type in network encoding errors", () => {
+    for (
+      const [type, input, reason] of [
+        ["inet", "010.1.2.3/24", "leading zeroes are not allowed"],
+        ["cidr", "010.1.2.3/24", "leading zeroes are not allowed"],
+        ["inet", "192.0.2.1/33", "prefix length must be an integer from 0 through 32"],
+        ["cidr", "10.1.2.3/8", "address has non-zero host bits"],
+        ["cidr", "2001:db8::1/32", "address has non-zero host bits"]
+      ] as const
+    ) {
+      const result = PgTypesResult.encode(input, PgTypes.OID[type])
+      if (Result.isSuccess(result)) assert.fail("expected Failure")
+      assert.strictEqual(result.failure._tag, "PgTypesCodecError")
+      assert.strictEqual(result.failure.message, `Invalid ${type} value ${JSON.stringify(input)}: ${reason}`)
+    }
+  })
+
   it("uses shared canonical parsing for inet and cidr", () => {
     assert.deepStrictEqual(
       PgTypes.encode("10.1.2.3", PgTypes.OID.cidr),


### PR DESCRIPTION
## Summary

- Add named network schema interfaces with rebuild support and unstable annotations.
- Serialize network addresses, interfaces, and networks as canonical JSON strings.
- Preserve input and optional causes in network address errors.
- Centralize HTTP server URL formatting, reject scoped IPv6 URLs, and use IPv4 loopback for unspecified test listeners.
- Extend runtime and type coverage for network addresses, HTTP servers, and PostgreSQL codecs.

## Testing

- Not run: targeted runtime tests and network address type tests.
- Not run: lint, TypeScript checks, and JSDoc validation.