### PR TITLE
Remove changesets for private tool packages

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -18,8 +18,10 @@ Do not add changesets for packages whose `package.json` has `"private": true`, i
 `packages/tools`. Check the package manifest rather than assuming every tool package is private. For changes spanning
 private and published packages, list only the published packages in the changeset.
 
-The Changesets config sets `"privatePackages": false`. Changesets for private packages are not consumed during versioning;
-leftover root changesets keep the release workflow on the version-PR path and prevent publishing.
+The Changesets config sets `"privatePackages": false`. Any changeset naming a private package remains in the root during
+versioning, even when it also names published packages. A mixed changeset still bumps the published packages and updates
+their changelogs, but can be reapplied on later version runs, duplicating changelog entries. Leftover root changesets keep
+the release workflow on the version-PR path and prevent publishing.
 
 ## Validation
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -12,6 +12,15 @@ This is the Effect TypeScript monorepo. The git base branch is `main`; use `pnpm
 - Migration sources (v3-to-v4) are in `migration/annotations`.
 - Inspect nearby code before editing.
 
+## Changesets
+
+Do not add changesets for packages whose `package.json` has `"private": true`, including private packages under
+`packages/tools`. Check the package manifest rather than assuming every tool package is private. For changes spanning
+private and published packages, list only the published packages in the changeset.
+
+The Changesets config sets `"privatePackages": false`. Changesets for private packages are not consumed during versioning;
+leftover root changesets keep the release workflow on the version-PR path and prevent publishing.
+
 ## Validation
 
 Use the narrowest validation that covers the change:

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -12,17 +12,6 @@ This is the Effect TypeScript monorepo. The git base branch is `main`; use `pnpm
 - Migration sources (v3-to-v4) are in `migration/annotations`.
 - Inspect nearby code before editing.
 
-## Changesets
-
-Do not add changesets for packages whose `package.json` has `"private": true`, including private packages under
-`packages/tools`. Check the package manifest rather than assuming every tool package is private. For changes spanning
-private and published packages, list only the published packages in the changeset.
-
-The Changesets config sets `"privatePackages": false`. Any changeset naming a private package remains in the root during
-versioning, even when it also names published packages. A mixed changeset still bumps the published packages and updates
-their changelogs, but can be reapplied on later version runs, duplicating changelog entries. Leftover root changesets keep
-the release workflow on the version-PR path and prevent publishing.
-
 ## Validation
 
 Use the narrowest validation that covers the change:

--- a/.changeset/api-diff-literal-categories.md
+++ b/.changeset/api-diff-literal-categories.md
@@ -1,5 +1,0 @@
----
-"@effect/api-diff": patch
----
-
-Preserve literal type categories in API snapshots.

--- a/.changeset/codegen-absolute-discovery.md
+++ b/.changeset/codegen-absolute-discovery.md
@@ -1,5 +1,0 @@
----
-"@effect/utils": patch
----
-
-Preserve absolute paths when discovering codegen barrel files.

--- a/.changeset/eff-1149-jsdocs-cache-refresh.md
+++ b/.changeset/eff-1149-jsdocs-cache-refresh.md
@@ -1,5 +1,0 @@
----
-"@effect/jsdocs": patch
----
-
-Refresh cached extraction inputs between JSDoc runs.

--- a/.changeset/fix-bundle-fixture-paths.md
+++ b/.changeset/fix-bundle-fixture-paths.md
@@ -1,5 +1,0 @@
----
-"@effect/bundle": patch
----
-
-Decode module URLs before using them as fixture directory paths.

--- a/.changeset/migration-example-fences.md
+++ b/.changeset/migration-example-fences.md
@@ -1,5 +1,0 @@
----
-"@effect/api-diff": patch
----
-
-Preserve migration example fences and avoid stack overflows when examples or replacements contain many backtick runs.

--- a/.changeset/retain-class-optionality.md
+++ b/.changeset/retain-class-optionality.md
@@ -1,5 +1,0 @@
----
-"@effect/api-diff": patch
----
-
-Retain optional class members in API snapshots.


### PR DESCRIPTION
Six root changesets target private packages excluded by `privatePackages: false`. They survive versioning and keep the release action on the version-PR path instead of publishing. This PR removes those six changesets.

Verified `main` at `54adcab052`: these were the only root changesets, and all four target packages have `private: true`. After cleanup, no root changesets remain. The diff contains only the six deletions.

Validation: `git diff --check` passed, and the final diff was verified to contain only the intended changeset deletions. No tests added or run for this metadata cleanup. The automated guard remains deferred.

Closes EFF-1318
