### PR TITLE
Fix persisted queue retry delay precision

### DIFF
--- a/.changeset/fix-mysql-queue-retry-precision.md
+++ b/.changeset/fix-mysql-queue-retry-precision.md
@@ -4,6 +4,8 @@
 
 Preserve sub-second retry delays in the SQL persisted queue store. Retry deadlines were rounded up to whole seconds, and MySQL and SQLite compared them against whole-second clocks, so a 500 ms retry could be redelivered within a few milliseconds of failing.
 
-MySQL now stores queue timestamps as `DATETIME(6)`. Existing tables are altered at store startup, which can rebuild the table and block writes for the duration on large queues.
+Retry delays round up to whole milliseconds on MySQL, PostgreSQL, and SQLite; MSSQL retains whole-second rounding.
+
+MySQL now stores queue timestamps as `DATETIME(6)`. Existing tables are altered at store startup, which can rebuild the table and block writes for the duration on large queues. Concurrent startups coordinate the upgrade with a connection-scoped lock and recheck the schema before altering it. Waiting for that lock times out after 30 seconds and fails startup safely; failed upgrades can be retried on the next startup.
 
 SQLite now stores `visible_at`, `acquired_at`, `created_at` and `updated_at` as `YYYY-MM-DD HH:MM:SS.mmm`. Existing whole-second rows keep working without a migration. Rolling back to an older version reads the new rows up to one second late, never early.

--- a/.changeset/fix-mysql-queue-retry-precision.md
+++ b/.changeset/fix-mysql-queue-retry-precision.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve sub-second MySQL persisted queue retry delays using microsecond timestamps and intervals. Migrate existing queue timestamp columns to retain fractional precision.

--- a/.changeset/fix-mysql-queue-retry-precision.md
+++ b/.changeset/fix-mysql-queue-retry-precision.md
@@ -4,4 +4,6 @@
 
 Preserve sub-second MySQL and SQLite persisted queue retry delays. MySQL uses microsecond timestamps and intervals; SQLite uses millisecond timestamps and rounds delays up to its clock precision while retaining compatibility with existing rows.
 
+SQLite now stores `visible_at`, `acquired_at`, `created_at`, and `updated_at` as `YYYY-MM-DD HH:MM:SS.mmm` instead of `YYYY-MM-DD HH:MM:SS`. Existing whole-second rows remain compatible and require no migration. Older versions can also read the new rows, but rolling back can defer their eligibility to the next whole-second boundary, adding up to one second of delay before normal polling. This delays delivery rather than making it early.
+
 Existing MySQL queue timestamp columns are migrated to DATETIME(6) at store startup. This can rebuild the table and hold locks that block writes for the duration, so plan startup accordingly for large queues. Startup now fails with a diagnostic if a previously recorded migration left timestamp columns without the required precision; repair those columns before restarting the store.

--- a/.changeset/fix-mysql-queue-retry-precision.md
+++ b/.changeset/fix-mysql-queue-retry-precision.md
@@ -2,4 +2,6 @@
 "effect": patch
 ---
 
-Preserve sub-second MySQL persisted queue retry delays using microsecond timestamps and intervals. Migrate existing queue timestamp columns to retain fractional precision.
+Preserve sub-second MySQL and SQLite persisted queue retry delays. MySQL uses microsecond timestamps and intervals; SQLite uses millisecond timestamps and rounds delays up to its clock precision while retaining compatibility with existing rows.
+
+Existing MySQL queue timestamp columns are migrated to DATETIME(6) at store startup. This can rebuild the table and hold locks that block writes for the duration, so plan startup accordingly for large queues. Startup now fails with a diagnostic if a previously recorded migration left timestamp columns without the required precision; repair those columns before restarting the store.

--- a/.changeset/fix-mysql-queue-retry-precision.md
+++ b/.changeset/fix-mysql-queue-retry-precision.md
@@ -2,8 +2,8 @@
 "effect": patch
 ---
 
-Preserve sub-second MySQL and SQLite persisted queue retry delays. MySQL uses microsecond timestamps and intervals; SQLite uses millisecond timestamps and rounds delays up to its clock precision while retaining compatibility with existing rows.
+Preserve sub-second retry delays in the SQL persisted queue store. Retry deadlines were rounded up to whole seconds, and MySQL and SQLite compared them against whole-second clocks, so a 500 ms retry could be redelivered within a few milliseconds of failing.
 
-SQLite now stores `visible_at`, `acquired_at`, `created_at`, and `updated_at` as `YYYY-MM-DD HH:MM:SS.mmm` instead of `YYYY-MM-DD HH:MM:SS`. Existing whole-second rows remain compatible and require no migration. Older versions can also read the new rows, but rolling back can defer their eligibility to the next whole-second boundary, adding up to one second of delay before normal polling. This delays delivery rather than making it early.
+MySQL now stores queue timestamps as `DATETIME(6)`. Existing tables are altered at store startup, which can rebuild the table and block writes for the duration on large queues.
 
-Existing MySQL queue timestamp columns are migrated to DATETIME(6) at store startup. This can rebuild the table and hold locks that block writes for the duration, so plan startup accordingly for large queues. Startup now fails with a diagnostic if a previously recorded migration left timestamp columns without the required precision; repair those columns before restarting the store.
+SQLite now stores `visible_at`, `acquired_at`, `created_at` and `updated_at` as `YYYY-MM-DD HH:MM:SS.mmm`. Existing whole-second rows keep working without a migration. Rolling back to an older version reads the new rows up to one second late, never early.

--- a/packages/effect/src/unstable/persistence/PersistedQueue.ts
+++ b/packages/effect/src/unstable/persistence/PersistedQueue.ts
@@ -1315,30 +1315,28 @@ export const makeStoreSql: (
 
   yield* Effect.orDie(
     Migrator.make({})({
-      loader: sqlMigrations(tableName, sql),
+      loader: sqlMigrations(tableName),
       table: `${tableName}_migrations`
     })
   )
 
+  // Tables created before DATETIME(6) round sub-second deadlines to whole
+  // seconds, so upgrade them at startup.
   yield* sql.onDialectOrElse({
     mysql: () =>
       Effect.gen(function*() {
-        // MySQL DDL implicitly commits the migration marker before ALTER TABLE
-        // runs. A failed ALTER can therefore leave an applied but unsafe schema.
-        const columns = yield* sql<{ name: string; fractional_digits: number }>`
-          SELECT COLUMN_NAME AS name, DATETIME_PRECISION AS fractional_digits
-          FROM information_schema.columns
+        const [{ count }] = yield* sql<{ count: number }>`
+          SELECT COUNT(*) AS count FROM information_schema.columns
           WHERE table_schema = DATABASE() AND table_name = ${tableName}
           AND column_name IN ('visible_at', 'acquired_at', 'created_at', 'updated_at')
+          AND DATETIME_PRECISION = 6
         `
-        if (columns.length !== 4 || columns.some((column) => Number(column.fractional_digits) !== 6)) {
-          return yield* Effect.die(
-            new Error(
-              `PersistedQueue: MySQL table ${tableName} requires DATETIME(6) for visible_at, acquired_at, created_at and updated_at. ` +
-                "The timestamp precision migration may have failed after being recorded as applied. " +
-                "Repair these columns before restarting the queue store."
-            )
-          )
+        if (Number(count) < 4) {
+          yield* sql`ALTER TABLE ${tableNameSql}
+            MODIFY COLUMN visible_at DATETIME(6) NOT NULL,
+            MODIFY COLUMN acquired_at DATETIME(6) NULL,
+            MODIFY COLUMN created_at DATETIME(6) NOT NULL,
+            MODIFY COLUMN updated_at DATETIME(6) NOT NULL`
         }
       }),
     orElse: () => Effect.void
@@ -1350,38 +1348,24 @@ export const makeStoreSql: (
     mssql: () => sql.literal("SYSDATETIME()"),
     mysql: () => sql.literal("NOW(6)"),
     pg: () => sql.literal("NOW()"),
-    // sqlite
-    // Keep the same sortable format as legacy rows, adding milliseconds.
+    // sqlite, in the same sortable format as rows written before milliseconds
     orElse: () => sql.literal("strftime('%Y-%m-%d %H:%M:%f', 'now')")
   })
 
-  // `seconds` is a whole number, possibly negative
-  const secondsOffset = (seconds: number) => {
-    const s = sql.literal(seconds.toString())
-    return sql.onDialectOrElse({
-      pg: () => sql`${sqlNow} + INTERVAL '${s} seconds'`,
-      mysql: () => sql`DATE_ADD(${sqlNow}, INTERVAL ${s} SECOND)`,
-      mssql: () => sql`DATEADD(SECOND, ${s}, ${sqlNow})`,
-      orElse: () => sql`strftime('%Y-%m-%d %H:%M:%f', ${sqlNow}, '${s} seconds')`
-    })
-  }
-  const secondsAgo = (seconds: number) => secondsOffset(-Math.max(Math.ceil(seconds), 0))
-  const secondsFromNow = (seconds: number) =>
+  // `millis` is a whole number, possibly negative. MSSQL rounds to whole
+  // seconds away from zero because DATEADD only accepts a 32-bit count.
+  const millisOffset = (millis: number) =>
     sql.onDialectOrElse({
-      // Preserve sub-second delays without rounding the deadline down.
-      mysql: () =>
-        sql`DATE_ADD(${sqlNow}, INTERVAL ${
-          sql.literal(String(Math.max(Math.ceil(seconds * 1_000_000), 0)))
-        } MICROSECOND)`,
-      // SQLite's clock and timestamp formatter have millisecond precision.
-      // Round up so a fractional-millisecond delay never becomes zero.
-      sqlite: () =>
-        sql`strftime('%Y-%m-%d %H:%M:%f', ${sqlNow}, ${
-          String(Math.max(Math.ceil(seconds * 1000), 0) / 1000) + " seconds"
-        })`,
-      orElse: () => secondsOffset(Math.max(Math.ceil(seconds), 0))
+      pg: () => sql`${sqlNow} + INTERVAL '${sql.literal(String(millis))} milliseconds'`,
+      mysql: () => sql`DATE_ADD(${sqlNow}, INTERVAL ${sql.literal(String(millis * 1000))} MICROSECOND)`,
+      mssql: () =>
+        sql`DATEADD(SECOND, ${sql.literal(String(Math.sign(millis) * Math.ceil(Math.abs(millis) / 1000)))}, ${sqlNow})`,
+      orElse: () => sql`strftime('%Y-%m-%d %H:%M:%f', ${sqlNow}, '${sql.literal(String(millis / 1000))} seconds')`
     })
-  const expiresAt = secondsAgo(Duration.toSeconds(lockExpiration))
+  const wholeMillis = (duration: Duration.Duration) => Math.ceil(Duration.toMillis(duration))
+  const fromNow = (duration: Duration.Duration) => millisOffset(wholeMillis(duration))
+  const ago = (duration: Duration.Duration) => millisOffset(-wholeMillis(duration))
+  const expiresAt = ago(lockExpiration)
 
   const offer = sql.onDialectOrElse({
     pg: () => (id: string, name: string, element: string) =>
@@ -1471,7 +1455,7 @@ export const makeStoreSql: (
       sql`
         UPDATE ${tableNameSql}
         SET acquired_at = NULL, acquired_by = NULL, updated_at = ${sqlNow}, visible_at = ${
-        secondsFromNow(Duration.toSeconds(delay))
+        fromNow(delay)
       }, last_failure = ${Cause.pretty(cause)}
         WHERE sequence = ${sequence}
         AND acquired_by = ${workerIdSql}
@@ -1661,13 +1645,13 @@ export const makeStoreSql: (
   })
 
   const cleanupBatch = sql.onDialectOrElse({
-    pg: () => (state: string, seconds: number) =>
+    pg: () => (state: string, timeToLive: Duration.Duration) =>
       sql<{ readonly count: number }>`
         WITH deleted_entries AS (
           DELETE FROM ${tableNameSql}
           WHERE sequence IN (
             SELECT sequence FROM ${tableNameSql}
-            WHERE state = ${state} AND updated_at <= ${secondsAgo(seconds)}
+            WHERE state = ${state} AND updated_at <= ${ago(timeToLive)}
             LIMIT ${sql.literal(String(sqlCleanupBatchSize))}
           )
           RETURNING 1
@@ -1676,11 +1660,11 @@ export const makeStoreSql: (
       `.pipe(Effect.map((rows) => rows[0].count)),
     mysql: () =>
       Effect.fnUntraced(
-        function*(state: string, seconds: number) {
+        function*(state: string, timeToLive: Duration.Duration) {
           const connection = yield* sql.reserve
           const [statement, parameters] = sql`
             DELETE FROM ${tableNameSql}
-            WHERE state = ${state} AND updated_at <= ${secondsAgo(seconds)}
+            WHERE state = ${state} AND updated_at <= ${ago(timeToLive)}
             LIMIT ${sql.literal(String(sqlCleanupBatchSize))}
           `.compile()
           yield* connection.execute(statement, parameters, undefined)
@@ -1689,19 +1673,19 @@ export const makeStoreSql: (
         },
         Effect.scoped
       ),
-    mssql: () => (state: string, seconds: number) =>
+    mssql: () => (state: string, timeToLive: Duration.Duration) =>
       sql<{ readonly sequence: number }>`
         DELETE TOP (${sql.literal(String(sqlCleanupBatchSize))}) FROM ${tableNameSql}
         OUTPUT DELETED.sequence
-        WHERE state = ${state} AND updated_at <= ${secondsAgo(seconds)}
+        WHERE state = ${state} AND updated_at <= ${ago(timeToLive)}
       `.pipe(Effect.map((rows) => rows.length)),
     // sqlite
-    orElse: () => (state: string, seconds: number) =>
+    orElse: () => (state: string, timeToLive: Duration.Duration) =>
       sql<{ readonly deleted: number }>`
         DELETE FROM ${tableNameSql}
         WHERE sequence IN (
           SELECT sequence FROM ${tableNameSql}
-          WHERE state = ${state} AND updated_at <= ${secondsAgo(seconds)}
+          WHERE state = ${state} AND updated_at <= ${ago(timeToLive)}
           LIMIT ${sql.literal(String(sqlCleanupBatchSize))}
         )
         RETURNING 1 AS deleted
@@ -1709,7 +1693,7 @@ export const makeStoreSql: (
   })
 
   const cleanupState = (state: string, timeToLive: Duration.Duration) =>
-    cleanupBatch(state, Duration.toSeconds(timeToLive)).pipe(
+    cleanupBatch(state, timeToLive).pipe(
       Effect.repeat({
         while: (deletedCount) => deletedCount === sqlCleanupBatchSize,
         schedule: Schedule.spaced(Duration.millis(10))
@@ -1819,7 +1803,7 @@ export const makeStoreSql: (
   })
 })
 
-const sqlMigrations = (tableName: string, client: SqlClient.SqlClient) =>
+const sqlMigrations = (tableName: string) =>
   Migrator.fromRecord({
     "0001_create_table": Effect.gen(function*() {
       const sql = (yield* SqlClient.SqlClient).withoutTransforms()
@@ -1835,10 +1819,10 @@ const sqlMigrations = (tableName: string, client: SqlClient.SqlClient) =>
             completed BOOLEAN NOT NULL,
             attempts INT NOT NULL DEFAULT 0,
             last_failure TEXT NULL,
-            acquired_at DATETIME NULL,
+            acquired_at DATETIME(6) NULL,
             acquired_by VARCHAR(36) NULL,
-            created_at DATETIME NOT NULL,
-            updated_at DATETIME NOT NULL
+            created_at DATETIME(6) NOT NULL,
+            updated_at DATETIME(6) NOT NULL
           )`,
         pg: () =>
           sql`CREATE TABLE IF NOT EXISTS ${tableNameSql} (
@@ -1959,13 +1943,13 @@ const sqlMigrations = (tableName: string, client: SqlClient.SqlClient) =>
               MODIFY COLUMN element MEDIUMTEXT NOT NULL,
               MODIFY COLUMN last_failure MEDIUMTEXT NULL,
               ADD COLUMN state VARCHAR(10) NULL,
-              ADD COLUMN visible_at DATETIME NULL`
+              ADD COLUMN visible_at DATETIME(6) NULL`
             yield* sql`UPDATE ${tableNameSql}
               SET state = CASE WHEN completed THEN 'completed' ELSE 'pending' END,
                   visible_at = updated_at`
             yield* sql`ALTER TABLE ${tableNameSql}
               MODIFY COLUMN state VARCHAR(10) NOT NULL,
-              MODIFY COLUMN visible_at DATETIME NOT NULL,
+              MODIFY COLUMN visible_at DATETIME(6) NOT NULL,
               DROP COLUMN completed`
           }),
         mssql: () =>
@@ -2048,21 +2032,6 @@ const sqlMigrations = (tableName: string, client: SqlClient.SqlClient) =>
           sql`CREATE INDEX ${takeIndex} ON ${tableNameSql} (queue_name, visible_at)
             WHERE state = 'pending'`
       })
-    }),
-    ...client.onDialectOrElse({
-      mysql: () => ({
-        "0003_mysql_timestamp_precision": Effect.gen(function*() {
-          const sql = (yield* SqlClient.SqlClient).withoutTransforms()
-          // Apply to existing tables too. All timestamps written with NOW(6) must
-          // retain their precision, including acquisition and cleanup timestamps.
-          yield* sql`ALTER TABLE ${sql(tableName)}
-            MODIFY COLUMN visible_at DATETIME(6) NOT NULL,
-            MODIFY COLUMN acquired_at DATETIME(6) NULL,
-            MODIFY COLUMN created_at DATETIME(6) NOT NULL,
-            MODIFY COLUMN updated_at DATETIME(6) NOT NULL`
-        })
-      }),
-      orElse: () => ({})
     })
   })
 

--- a/packages/effect/src/unstable/persistence/PersistedQueue.ts
+++ b/packages/effect/src/unstable/persistence/PersistedQueue.ts
@@ -1320,6 +1320,30 @@ export const makeStoreSql: (
     })
   )
 
+  yield* sql.onDialectOrElse({
+    mysql: () =>
+      Effect.gen(function*() {
+        // MySQL DDL implicitly commits the migration marker before ALTER TABLE
+        // runs. A failed ALTER can therefore leave an applied but unsafe schema.
+        const columns = yield* sql<{ name: string; fractional_digits: number }>`
+          SELECT COLUMN_NAME AS name, DATETIME_PRECISION AS fractional_digits
+          FROM information_schema.columns
+          WHERE table_schema = DATABASE() AND table_name = ${tableName}
+          AND column_name IN ('visible_at', 'acquired_at', 'created_at', 'updated_at')
+        `
+        if (columns.length !== 4 || columns.some((column) => Number(column.fractional_digits) !== 6)) {
+          return yield* Effect.die(
+            new Error(
+              `PersistedQueue: MySQL table ${tableName} requires DATETIME(6) for visible_at, acquired_at, created_at and updated_at. ` +
+                "The timestamp precision migration may have failed after being recorded as applied. " +
+                "Repair these columns before restarting the queue store."
+            )
+          )
+        }
+      }),
+    orElse: () => Effect.void
+  })
+
   const sqlNow = sql.onDialectOrElse({
     // GETDATE() rounds to 1/300s and can land in the future, hiding freshly
     // written visible_at values from the poll query
@@ -1327,7 +1351,8 @@ export const makeStoreSql: (
     mysql: () => sql.literal("NOW(6)"),
     pg: () => sql.literal("NOW()"),
     // sqlite
-    orElse: () => sql.literal("CURRENT_TIMESTAMP")
+    // Keep the same sortable format as legacy rows, adding milliseconds.
+    orElse: () => sql.literal("strftime('%Y-%m-%d %H:%M:%f', 'now')")
   })
 
   // `seconds` is a whole number, possibly negative
@@ -1337,7 +1362,7 @@ export const makeStoreSql: (
       pg: () => sql`${sqlNow} + INTERVAL '${s} seconds'`,
       mysql: () => sql`DATE_ADD(${sqlNow}, INTERVAL ${s} SECOND)`,
       mssql: () => sql`DATEADD(SECOND, ${s}, ${sqlNow})`,
-      orElse: () => sql`datetime(${sqlNow}, '${s} seconds')`
+      orElse: () => sql`strftime('%Y-%m-%d %H:%M:%f', ${sqlNow}, '${s} seconds')`
     })
   }
   const secondsAgo = (seconds: number) => secondsOffset(-Math.max(Math.ceil(seconds), 0))
@@ -1348,6 +1373,12 @@ export const makeStoreSql: (
         sql`DATE_ADD(${sqlNow}, INTERVAL ${
           sql.literal(String(Math.max(Math.ceil(seconds * 1_000_000), 0)))
         } MICROSECOND)`,
+      // SQLite's clock and timestamp formatter have millisecond precision.
+      // Round up so a fractional-millisecond delay never becomes zero.
+      sqlite: () =>
+        sql`strftime('%Y-%m-%d %H:%M:%f', ${sqlNow}, ${
+          String(Math.max(Math.ceil(seconds * 1000), 0) / 1000) + " seconds"
+        })`,
       orElse: () => secondsOffset(Math.max(Math.ceil(seconds), 0))
     })
   const expiresAt = secondsAgo(Duration.toSeconds(lockExpiration))

--- a/packages/effect/src/unstable/persistence/PersistedQueue.ts
+++ b/packages/effect/src/unstable/persistence/PersistedQueue.ts
@@ -1315,7 +1315,7 @@ export const makeStoreSql: (
 
   yield* Effect.orDie(
     Migrator.make({})({
-      loader: sqlMigrations(tableName),
+      loader: sqlMigrations(tableName, sql),
       table: `${tableName}_migrations`
     })
   )
@@ -1324,7 +1324,7 @@ export const makeStoreSql: (
     // GETDATE() rounds to 1/300s and can land in the future, hiding freshly
     // written visible_at values from the poll query
     mssql: () => sql.literal("SYSDATETIME()"),
-    mysql: () => sql.literal("NOW()"),
+    mysql: () => sql.literal("NOW(6)"),
     pg: () => sql.literal("NOW()"),
     // sqlite
     orElse: () => sql.literal("CURRENT_TIMESTAMP")
@@ -1341,7 +1341,15 @@ export const makeStoreSql: (
     })
   }
   const secondsAgo = (seconds: number) => secondsOffset(-Math.max(Math.ceil(seconds), 0))
-  const secondsFromNow = (seconds: number) => secondsOffset(Math.max(Math.ceil(seconds), 0))
+  const secondsFromNow = (seconds: number) =>
+    sql.onDialectOrElse({
+      // Preserve sub-second delays without rounding the deadline down.
+      mysql: () =>
+        sql`DATE_ADD(${sqlNow}, INTERVAL ${
+          sql.literal(String(Math.max(Math.ceil(seconds * 1_000_000), 0)))
+        } MICROSECOND)`,
+      orElse: () => secondsOffset(Math.max(Math.ceil(seconds), 0))
+    })
   const expiresAt = secondsAgo(Duration.toSeconds(lockExpiration))
 
   const offer = sql.onDialectOrElse({
@@ -1780,7 +1788,7 @@ export const makeStoreSql: (
   })
 })
 
-const sqlMigrations = (tableName: string) =>
+const sqlMigrations = (tableName: string, client: SqlClient.SqlClient) =>
   Migrator.fromRecord({
     "0001_create_table": Effect.gen(function*() {
       const sql = (yield* SqlClient.SqlClient).withoutTransforms()
@@ -2009,6 +2017,21 @@ const sqlMigrations = (tableName: string) =>
           sql`CREATE INDEX ${takeIndex} ON ${tableNameSql} (queue_name, visible_at)
             WHERE state = 'pending'`
       })
+    }),
+    ...client.onDialectOrElse({
+      mysql: () => ({
+        "0003_mysql_timestamp_precision": Effect.gen(function*() {
+          const sql = (yield* SqlClient.SqlClient).withoutTransforms()
+          // Apply to existing tables too. All timestamps written with NOW(6) must
+          // retain their precision, including acquisition and cleanup timestamps.
+          yield* sql`ALTER TABLE ${sql(tableName)}
+            MODIFY COLUMN visible_at DATETIME(6) NOT NULL,
+            MODIFY COLUMN acquired_at DATETIME(6) NULL,
+            MODIFY COLUMN created_at DATETIME(6) NOT NULL,
+            MODIFY COLUMN updated_at DATETIME(6) NOT NULL`
+        })
+      }),
+      orElse: () => ({})
     })
   })
 

--- a/packages/effect/src/unstable/persistence/PersistedQueue.ts
+++ b/packages/effect/src/unstable/persistence/PersistedQueue.ts
@@ -32,7 +32,7 @@ import * as Schema from "../../Schema.ts"
 import * as Scope from "../../Scope.ts"
 import * as Migrator from "../sql/Migrator.ts"
 import * as SqlClient from "../sql/SqlClient.ts"
-import type { SqlError } from "../sql/SqlError.ts"
+import { LockTimeoutError, SqlError, UnknownError } from "../sql/SqlError.ts"
 import * as Redis from "./Redis.ts"
 
 /**
@@ -1325,19 +1325,75 @@ export const makeStoreSql: (
   yield* sql.onDialectOrElse({
     mysql: () =>
       Effect.gen(function*() {
-        const [{ count }] = yield* sql<{ count: number }>`
+        const needsUpgrade = sql<{ count: number }>`
           SELECT COUNT(*) AS count FROM information_schema.columns
           WHERE table_schema = DATABASE() AND table_name = ${tableName}
           AND column_name IN ('visible_at', 'acquired_at', 'created_at', 'updated_at')
           AND DATETIME_PRECISION = 6
-        `
-        if (Number(count) < 4) {
-          yield* sql`ALTER TABLE ${tableNameSql}
-            MODIFY COLUMN visible_at DATETIME(6) NOT NULL,
-            MODIFY COLUMN acquired_at DATETIME(6) NULL,
-            MODIFY COLUMN created_at DATETIME(6) NOT NULL,
-            MODIFY COLUMN updated_at DATETIME(6) NOT NULL`
-        }
+        `.pipe(Effect.map(([{ count }]) => Number(count) < 4))
+        if (!(yield* needsUpgrade)) return
+
+        yield* Effect.scoped(Effect.gen(function*() {
+          const connection = yield* sql.reserve
+          yield* Effect.gen(function*() {
+            // Named locks are connection-scoped, survive DDL's implicit commit,
+            // and have a 64-character limit. Include the database in their key.
+            const [{ name }] = yield* sql<{ name: string }>`SELECT
+              SHA2(CONCAT('effect/PersistedQueue/precision:', DATABASE(), ':', ${tableName}), 256) AS name`
+            yield* Effect.acquireRelease(
+              Effect.gen(function*() {
+                const [{ acquired }] = yield* connection.execute(
+                  "SELECT GET_LOCK(?, 30) AS acquired",
+                  [name],
+                  undefined
+                )
+                if (Number(acquired) !== 1) {
+                  return yield* Effect.fail(
+                    new SqlError({
+                      reason: acquired === 0
+                        ? new LockTimeoutError({
+                          cause: acquired,
+                          message:
+                            `Timed out waiting to upgrade MySQL persisted queue table ${tableName} to DATETIME(6); retry store startup.`,
+                          operation: "GET_LOCK"
+                        })
+                        : new UnknownError({
+                          cause: acquired,
+                          message:
+                            `Could not acquire the precision upgrade lock for MySQL persisted queue table ${tableName}.`,
+                          operation: "GET_LOCK"
+                        })
+                    })
+                  )
+                }
+              }),
+              // acquireRelease masks interruption while GET_LOCK is pending:
+              // ownership is known before release is registered. Release runs
+              // before the reserved connection returns to its pool on any exit.
+              () => connection.execute("SELECT RELEASE_LOCK(?)", [name], undefined).pipe(Effect.orDie)
+            )
+            // A different process may have repaired the table while we waited.
+            if (!(yield* needsUpgrade)) return
+            yield* sql`ALTER TABLE ${tableNameSql}
+              MODIFY COLUMN visible_at DATETIME(6) NOT NULL,
+              MODIFY COLUMN acquired_at DATETIME(6) NULL,
+              MODIFY COLUMN created_at DATETIME(6) NOT NULL,
+              MODIFY COLUMN updated_at DATETIME(6) NOT NULL`.pipe(
+              Effect.mapError((cause) =>
+                new SqlError({
+                  reason: new UnknownError({
+                    message:
+                      `Failed to upgrade MySQL persisted queue table ${tableName} to DATETIME(6); check ALTER permissions and table locks, then retry store startup.`,
+                    operation: "ALTER TABLE",
+                    cause
+                  })
+                })
+              )
+            )
+            // Pin statements to the reservation without beginning a transaction:
+            // ALTER TABLE commits implicitly, but must keep named-lock ownership.
+          }).pipe(Effect.provideService(sql.transactionService, [connection, 0]))
+        }))
       }),
     orElse: () => Effect.void
   })

--- a/packages/sql/mysql2/test/PersistedQueue.integration.test.ts
+++ b/packages/sql/mysql2/test/PersistedQueue.integration.test.ts
@@ -1,0 +1,57 @@
+import { MysqlClient } from "@effect/sql-mysql2"
+import { assert, it } from "@effect/vitest"
+import { Effect, Layer, Redacted, Schedule, Schema } from "effect"
+import { PersistedQueue } from "effect/unstable/persistence"
+import { MysqlContainer } from "./utils.ts"
+
+// SET timestamp is session-local. One connection ensures the queue's SQL and
+// the assertions use the same frozen database clock, including background polls.
+const client = Layer.unwrap(Effect.gen(function*() {
+  const container = yield* MysqlContainer
+  return MysqlClient.layer({
+    url: Redacted.make(container.getConnectionUri()),
+    maxConnections: 1
+  })
+})).pipe(Layer.provide(MysqlContainer.layer))
+
+const layer = PersistedQueue.layer.pipe(
+  Layer.provideMerge(PersistedQueue.layerStoreSql({ tableName: "retry_precision" })),
+  Layer.provideMerge(client)
+)
+
+it.layer(layer, { timeout: "60 seconds", concurrent: false })("PersistedQueue MySQL retry precision", (it) => {
+  for (const phase of [0, 250, 750, 950]) {
+    it.effect(`preserves the 500 ms retry minimum at second phase ${phase} ms`, () =>
+      Effect.gen(function*() {
+        const sql = yield* MysqlClient.MysqlClient
+        const timestamp = 1_800_000_000 + phase / 1000
+        yield* sql`SET timestamp = ${timestamp}`
+        yield* Effect.addFinalizer(() => sql`SET timestamp = DEFAULT`.pipe(Effect.orDie))
+        const clock = yield* sql<{ phase: number }>`SELECT MICROSECOND(NOW(6)) AS phase`
+        assert.strictEqual(clock[0].phase, phase * 1000)
+
+        const queue = yield* PersistedQueue.make({
+          name: `retry-precision-${phase}`,
+          schema: Schema.Number,
+          retrySchedule: Schedule.spaced(500)
+        })
+        yield* queue.offer(42)
+        assert.strictEqual(yield* queue.take(() => Effect.fail("boom")).pipe(Effect.flip), "boom")
+
+        // Measure the persisted deadline against NOW(6), not updated_at: both
+        // NOW() and the existing DATETIME columns lack fractional precision.
+        // Freezing MySQL time avoids TestClock/live-clock scheduling races.
+        const rows = yield* sql<{ delay_us: number; attempts: number; state: string }>`
+          SELECT TIMESTAMPDIFF(MICROSECOND, NOW(6), visible_at) AS delay_us, attempts, state
+          FROM retry_precision WHERE queue_name = ${`retry-precision-${phase}`}
+        `
+        assert.strictEqual(rows.length, 1)
+        assert.strictEqual(rows[0].attempts, 1)
+        assert.strictEqual(rows[0].state, "pending")
+        assert.isAtLeast(Number(rows[0].delay_us), 500_000)
+
+        yield* sql`SET timestamp = ${timestamp + 2}`
+        assert.strictEqual(yield* queue.take((_, { attempts }) => Effect.succeed(attempts)), 2)
+      }), { timeout: 10_000 })
+  }
+})

--- a/packages/sql/mysql2/test/PersistedQueue.integration.test.ts
+++ b/packages/sql/mysql2/test/PersistedQueue.integration.test.ts
@@ -1,7 +1,10 @@
 import { MysqlClient } from "@effect/sql-mysql2"
 import { assert, it } from "@effect/vitest"
-import { Effect, Layer, Redacted, Schedule, Schema } from "effect"
+import { Effect, Latch, Layer, Redacted, Schedule, Schema } from "effect"
+import { TestClock } from "effect/testing"
 import { PersistedQueue } from "effect/unstable/persistence"
+import { Reactivity } from "effect/unstable/reactivity"
+import { SqlClient, Statement } from "effect/unstable/sql"
 import { MysqlContainer } from "./utils.ts"
 
 // SET timestamp is session-local. One connection ensures the queue's SQL and
@@ -20,6 +23,85 @@ const layer = PersistedQueue.layer.pipe(
 )
 
 it.layer(layer, { timeout: "60 seconds", concurrent: false })("PersistedQueue MySQL retry precision", (it) => {
+  for (const legacy of [false, true]) {
+    it.effect(
+      legacy ? "concurrent startups perform only one precision ALTER" : "correct tables skip precision ALTER",
+      () =>
+        Effect.gen(function*() {
+          const sql = yield* MysqlClient.MysqlClient
+          const tableName = legacy ? "concurrent_precision" : "correct_precision"
+          yield* sql`CREATE TABLE ${sql(tableName)} LIKE retry_precision`
+          yield* sql`CREATE TABLE ${sql(`${tableName}_migrations`)} LIKE retry_precision_migrations`
+          yield* sql`INSERT INTO ${sql(`${tableName}_migrations`)} SELECT * FROM retry_precision_migrations`
+          if (legacy) {
+            yield* sql`ALTER TABLE ${sql(tableName)} MODIFY visible_at DATETIME NOT NULL`
+          }
+          const clients = yield* Effect.forEach(
+            [0, 1],
+            () => MysqlClient.make(sql.config).pipe(Effect.provide(Reactivity.layer))
+          )
+          const attempts: Array<string> = []
+          const observe: Statement.Transformer = (statement) => {
+            const [query] = statement.compile()
+            if (!/^\s*ALTER TABLE\b/i.test(query) || !query.includes(tableName)) return Effect.succeed(statement)
+            attempts.push(query)
+            // Hold the first ALTER before execution to let the other independent
+            // startup read the old schema. A coordinated implementation may block
+            // that startup before its check, so this delay must not await it.
+            return Effect.as(Effect.sleep(250), statement)
+          }
+          yield* Effect.forEach(clients, (client) =>
+            PersistedQueue.makeStoreSql({ tableName }).pipe(
+              Effect.provideService(SqlClient.SqlClient, client),
+              Effect.provideService(Statement.CurrentTransformer, observe),
+              Effect.scoped
+            ), { concurrency: 2 })
+          const columns = yield* sql<{ count: number }>`SELECT COUNT(*) AS count FROM information_schema.columns
+          WHERE table_schema = DATABASE() AND table_name = ${tableName}
+          AND column_name IN ('visible_at', 'acquired_at', 'created_at', 'updated_at') AND datetime_precision = 6`
+          assert.strictEqual(Number(columns[0].count), 4)
+          assert.strictEqual(attempts.length, legacy ? 1 : 0, JSON.stringify(attempts))
+        }).pipe(TestClock.withLive),
+      { timeout: 10_000 }
+    )
+  }
+
+  it.effect("cleanup uses the default 30-day TTL without deleting newer or pending rows", () =>
+    Effect.gen(function*() {
+      const sql = yield* MysqlClient.MysqlClient
+      const store = yield* PersistedQueue.makeStoreSql({ tableName: "cleanup_month" })
+      yield* sql`SET timestamp = 1800000000.95`
+      yield* Effect.addFinalizer(() => sql`SET timestamp = DEFAULT`.pipe(Effect.orDie))
+      for (
+        const [id, state, days] of [
+          ["old", "completed", 31],
+          ["boundary", "completed", 30],
+          ["new", "completed", 29],
+          ["pending", "pending", 31],
+          ["failed", "failed", 31]
+        ] as const
+      ) {
+        yield* sql`INSERT INTO cleanup_month
+          (id, queue_name, element, state, attempts, visible_at, created_at, updated_at)
+          VALUES (${id}, 'cleanup', '42', ${state}, 1, NOW(6), NOW(6), DATE_SUB(NOW(6), INTERVAL ${days} DAY))`
+      }
+      const completed = Latch.makeUnsafe()
+      // Observe successful completion so layerCleanup's warning handler cannot
+      // hide a rejected large negative MICROSECOND interval from this test.
+      yield* Layer.build(PersistedQueue.layerCleanup()).pipe(
+        Effect.provideService(PersistedQueue.PersistedQueueStore, {
+          ...store,
+          cleanup: (options) => store.cleanup(options).pipe(Effect.tap(() => completed.open))
+        })
+      )
+      yield* completed.await.pipe(Effect.timeout("5 seconds"))
+      assert.deepStrictEqual(yield* sql`SELECT id FROM cleanup_month ORDER BY id`, [
+        { id: "failed" },
+        { id: "new" },
+        { id: "pending" }
+      ])
+    }).pipe(TestClock.withLive), { timeout: 10_000 })
+
   for (const column of ["visible_at", "acquired_at", "created_at", "updated_at"]) {
     it.effect(`upgrades ${column} when it was left below microsecond precision`, () =>
       Effect.gen(function*() {

--- a/packages/sql/mysql2/test/PersistedQueue.integration.test.ts
+++ b/packages/sql/mysql2/test/PersistedQueue.integration.test.ts
@@ -1,6 +1,6 @@
 import { MysqlClient } from "@effect/sql-mysql2"
 import { assert, it } from "@effect/vitest"
-import { Effect, Exit, Fiber, Layer, Redacted, Schedule, Schema } from "effect"
+import { Cause, Effect, Exit, Fiber, Layer, Redacted, Schedule, Schema } from "effect"
 import { TestClock } from "effect/testing"
 import { PersistedQueue } from "effect/unstable/persistence"
 import { MysqlContainer } from "./utils.ts"
@@ -20,7 +20,37 @@ const layer = PersistedQueue.layer.pipe(
   Layer.provideMerge(client)
 )
 
+const assertPrecisionDiagnostic = (cause: Cause.Cause<unknown>, tableName: string) => {
+  const error = Cause.squash(cause)
+  assert.instanceOf(error, Error)
+  assert.strictEqual(
+    (error as Error).message,
+    `PersistedQueue: MySQL table ${tableName} requires DATETIME(6) for visible_at, acquired_at, created_at and updated_at. ` +
+      "The timestamp precision migration may have failed after being recorded as applied. " +
+      "Repair these columns before restarting the queue store."
+  )
+}
+
 it.layer(layer, { timeout: "60 seconds", concurrent: false })("PersistedQueue MySQL retry precision", (it) => {
+  for (const column of ["visible_at", "acquired_at", "created_at", "updated_at"]) {
+    for (const precision of [0, 3]) {
+      it.effect(`rejects a partial upgrade with ${column} at precision ${precision}`, () =>
+        Effect.gen(function*() {
+          const sql = yield* MysqlClient.MysqlClient
+          const tableName = `partial_${column}_${precision}`
+          yield* sql`CREATE TABLE ${sql(tableName)} LIKE retry_precision`
+          yield* sql`ALTER TABLE ${sql(tableName)} MODIFY ${sql(column)} DATETIME(${sql.literal(String(precision))}) ${
+            sql.literal(column === "acquired_at" ? "NULL" : "NOT NULL")
+          }`
+          yield* sql`CREATE TABLE ${sql(`${tableName}_migrations`)} LIKE retry_precision_migrations`
+          yield* sql`INSERT INTO ${sql(`${tableName}_migrations`)} SELECT * FROM retry_precision_migrations`
+          const startup = yield* PersistedQueue.makeStoreSql({ tableName }).pipe(Effect.exit)
+          assert.isTrue(Exit.isFailure(startup))
+          if (Exit.isFailure(startup)) assertPrecisionDiagnostic(startup.cause, tableName)
+        }))
+    }
+  }
+
   it.effect(
     "rejects or repairs an applied precision migration with old columns before delivering retries",
     () =>
@@ -54,7 +84,10 @@ it.layer(layer, { timeout: "60 seconds", concurrent: false })("PersistedQueue My
           pollInterval: "10 millis"
         }).pipe(Effect.exit)
         // Refusing unsafe startup is valid; a repaired store must honor the delay.
-        if (Exit.isFailure(startup)) return
+        if (Exit.isFailure(startup)) {
+          assertPrecisionDiagnostic(startup.cause, "interrupted_upgrade")
+          return
+        }
         const factory = yield* PersistedQueue.makeFactory.pipe(
           Effect.provideService(PersistedQueue.PersistedQueueStore, startup.value)
         )

--- a/packages/sql/mysql2/test/PersistedQueue.integration.test.ts
+++ b/packages/sql/mysql2/test/PersistedQueue.integration.test.ts
@@ -1,6 +1,7 @@
 import { MysqlClient } from "@effect/sql-mysql2"
 import { assert, it } from "@effect/vitest"
-import { Effect, Layer, Redacted, Schedule, Schema } from "effect"
+import { Effect, Exit, Fiber, Layer, Redacted, Schedule, Schema } from "effect"
+import { TestClock } from "effect/testing"
 import { PersistedQueue } from "effect/unstable/persistence"
 import { MysqlContainer } from "./utils.ts"
 
@@ -20,6 +21,69 @@ const layer = PersistedQueue.layer.pipe(
 )
 
 it.layer(layer, { timeout: "60 seconds", concurrent: false })("PersistedQueue MySQL retry precision", (it) => {
+  it.effect(
+    "rejects or repairs an applied precision migration with old columns before delivering retries",
+    () =>
+      Effect.gen(function*() {
+        const sql = yield* MysqlClient.MysqlClient
+        yield* sql`CREATE TABLE interrupted_upgrade LIKE retry_precision`
+        yield* sql`ALTER TABLE interrupted_upgrade
+        MODIFY visible_at DATETIME NOT NULL, MODIFY acquired_at DATETIME NULL,
+        MODIFY created_at DATETIME NOT NULL, MODIFY updated_at DATETIME NOT NULL`
+        yield* sql`CREATE TABLE interrupted_upgrade_migrations LIKE retry_precision_migrations`
+        yield* sql`INSERT INTO interrupted_upgrade_migrations
+        SELECT * FROM retry_precision_migrations WHERE migration_id < 3`
+
+        // Independently reproduce MySQL's implicit commit before failing DDL:
+        // the marker survives rollback while the timestamp columns stay unchanged.
+        const ddl = yield* Effect.gen(function*() {
+          yield* sql`INSERT INTO interrupted_upgrade_migrations (migration_id, name)
+          VALUES (3, 'mysql_timestamp_precision')`
+          yield* sql`ALTER TABLE interrupted_upgrade MODIFY missing_column DATETIME(6)`
+        }).pipe(sql.withTransaction, Effect.exit)
+        assert.isTrue(Exit.isFailure(ddl))
+        const markers = yield* sql`SELECT migration_id FROM interrupted_upgrade_migrations WHERE migration_id = 3`
+        assert.strictEqual(markers.length, 1)
+        const columns = yield* sql<{ fractional_digits: number }>`SELECT DATETIME_PRECISION AS fractional_digits
+        FROM information_schema.columns WHERE table_schema = DATABASE()
+        AND table_name = 'interrupted_upgrade' AND column_name = 'visible_at'`
+        assert.strictEqual(columns[0].fractional_digits, 0)
+
+        const startup = yield* PersistedQueue.makeStoreSql({
+          tableName: "interrupted_upgrade",
+          pollInterval: "10 millis"
+        }).pipe(Effect.exit)
+        // Refusing unsafe startup is valid; a repaired store must honor the delay.
+        if (Exit.isFailure(startup)) return
+        const factory = yield* PersistedQueue.makeFactory.pipe(
+          Effect.provideService(PersistedQueue.PersistedQueueStore, startup.value)
+        )
+        const queue = yield* factory.make({
+          name: "interrupted",
+          schema: Schema.Number,
+          retrySchedule: Schedule.spaced(500)
+        })
+        yield* sql`SET timestamp = 1800000000`
+        yield* Effect.addFinalizer(() => sql`SET timestamp = DEFAULT`.pipe(Effect.orDie))
+        yield* queue.offer(42)
+        assert.strictEqual(
+          yield* queue.take(() => sql`SET timestamp = 1800000000.9`.pipe(Effect.andThen(Effect.fail("boom")))).pipe(
+            Effect.flip
+          ),
+          "boom"
+        )
+        // Only 100 ms after failure. DATETIME(0) rounds the intended .4 deadline
+        // down to the whole second, allowing the queue to redeliver here.
+        yield* sql`SET timestamp = 1800000001`
+        const fiber = yield* queue.take((_, { attempts }) => Effect.succeed(attempts)).pipe(Effect.forkScoped)
+        yield* Effect.sleep(100)
+        assert.isUndefined(fiber.pollUnsafe())
+        yield* sql`SET timestamp = 1800000002`
+        assert.strictEqual(yield* Fiber.join(fiber), 2)
+      }).pipe(TestClock.withLive),
+    { timeout: 10_000 }
+  )
+
   it.effect("upgrades an existing queue once and preserves its rows and indexes", () =>
     Effect.gen(function*() {
       const sql = yield* MysqlClient.MysqlClient
@@ -141,6 +205,23 @@ it.layer(layer, { timeout: "60 seconds", concurrent: false })("PersistedQueue My
           assert.strictEqual(rows[0].attempts, 1)
           assert.strictEqual(rows[0].state, "pending")
           assert.strictEqual(Number(rows[0].delay_us), delay * 1000)
+
+          if (delay > 0) {
+            // Let MySQL compute the boundary from its stored deadline, avoiding
+            // floating-point conversion of epoch seconds in JavaScript.
+            const boundary = yield* sql<{ timestamp: string }>`SELECT
+              CAST(UNIX_TIMESTAMP(visible_at) - 0.000001 AS CHAR) AS timestamp
+              FROM retry_precision WHERE queue_name = ${`retry-precision-${delay}-${phase}`}`
+            yield* sql`SET timestamp = ${boundary[0].timestamp}`
+            const remaining = yield* sql<{ microseconds: number }>`SELECT
+              TIMESTAMPDIFF(MICROSECOND, NOW(6), visible_at) AS microseconds
+              FROM retry_precision WHERE queue_name = ${`retry-precision-${delay}-${phase}`}`
+            assert.strictEqual(Number(remaining[0].microseconds), 1)
+            const eligible = yield* sql`SELECT sequence FROM retry_precision
+              WHERE queue_name = ${`retry-precision-${delay}-${phase}`}
+              AND state = 'pending' AND visible_at <= NOW(6)`
+            assert.deepStrictEqual(eligible, [])
+          }
 
           yield* sql`SET timestamp = ${timestamp + Math.ceil(delay / 1000)}`
           assert.strictEqual(yield* queue.take((_, { attempts }) => Effect.succeed(attempts)), 2)

--- a/packages/sql/mysql2/test/PersistedQueue.integration.test.ts
+++ b/packages/sql/mysql2/test/PersistedQueue.integration.test.ts
@@ -20,38 +20,131 @@ const layer = PersistedQueue.layer.pipe(
 )
 
 it.layer(layer, { timeout: "60 seconds", concurrent: false })("PersistedQueue MySQL retry precision", (it) => {
-  for (const phase of [0, 250, 750, 950]) {
-    it.effect(`preserves the 500 ms retry minimum at second phase ${phase} ms`, () =>
-      Effect.gen(function*() {
-        const sql = yield* MysqlClient.MysqlClient
-        const timestamp = 1_800_000_000 + phase / 1000
-        yield* sql`SET timestamp = ${timestamp}`
-        yield* Effect.addFinalizer(() => sql`SET timestamp = DEFAULT`.pipe(Effect.orDie))
-        const clock = yield* sql<{ phase: number }>`SELECT MICROSECOND(NOW(6)) AS phase`
-        assert.strictEqual(clock[0].phase, phase * 1000)
+  it.effect("upgrades an existing queue once and preserves its rows and indexes", () =>
+    Effect.gen(function*() {
+      const sql = yield* MysqlClient.MysqlClient
+      const tableName = "existing_queue"
+      // Schema and migration history from before the precision migration.
+      // Build the fixture independently of the current migration implementation.
+      yield* sql`CREATE TABLE existing_queue (
+        sequence BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+        id VARCHAR(255) NOT NULL,
+        queue_name VARCHAR(255) NOT NULL,
+        element MEDIUMTEXT NOT NULL,
+        state VARCHAR(10) NOT NULL,
+        attempts INT NOT NULL DEFAULT 0,
+        last_failure MEDIUMTEXT NULL,
+        visible_at DATETIME NOT NULL,
+        acquired_at DATETIME NULL,
+        acquired_by VARCHAR(36) NULL,
+        created_at DATETIME NOT NULL,
+        updated_at DATETIME NOT NULL,
+        UNIQUE INDEX idx_existing_queue_id (id, queue_name),
+        INDEX idx_existing_queue_take (queue_name, state, visible_at),
+        INDEX idx_existing_queue_update (sequence, acquired_by)
+      )`
+      yield* sql`CREATE TABLE existing_queue_migrations (
+        migration_id INTEGER UNSIGNED NOT NULL PRIMARY KEY,
+        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        name VARCHAR(255) NOT NULL
+      )`
+      yield* sql`INSERT INTO existing_queue_migrations (migration_id, name)
+        VALUES (1, 'create_table'), (2, 'upgrade_schema')`
+      yield* sql`INSERT INTO existing_queue
+        (id, queue_name, element, state, attempts, last_failure, visible_at, acquired_at, acquired_by, created_at, updated_at)
+        VALUES
+        ('pending', 'upgrade', '42', 'pending', 0, NULL, '2026-01-01', NULL, NULL, '2026-01-01', '2026-01-01'),
+        ('completed', 'upgrade', '43', 'completed', 1, NULL, '2026-01-01', NULL, NULL, '2026-01-01', '2026-01-01'),
+        ('failed', 'upgrade', '44', 'failed', 3, 'boom', '2026-01-01', NULL, NULL, '2026-01-01', '2026-01-01'),
+        ('acquired', 'other', '45', 'pending', 1, NULL, '2026-01-01', '2026-01-01', 'worker', '2026-01-01', '2026-01-01')`
+      const before = yield* sql`SELECT * FROM existing_queue ORDER BY sequence`
+      const indexes = sql`SELECT index_name, column_name, seq_in_index, non_unique
+        FROM information_schema.statistics
+        WHERE table_schema = DATABASE() AND table_name = 'existing_queue'
+        ORDER BY index_name, seq_in_index`
+      const indexesBefore = yield* indexes
 
-        const queue = yield* PersistedQueue.make({
-          name: `retry-precision-${phase}`,
-          schema: Schema.Number,
-          retrySchedule: Schedule.spaced(500)
-        })
-        yield* queue.offer(42)
-        assert.strictEqual(yield* queue.take(() => Effect.fail("boom")).pipe(Effect.flip), "boom")
+      yield* PersistedQueue.makeStoreSql({ tableName }).pipe(Effect.scoped)
+      const migrations = sql`SELECT * FROM existing_queue_migrations ORDER BY migration_id`
+      const migrated = yield* migrations
+      assert.deepStrictEqual(migrated.map((row) => [row.migration_id, row.name]), [
+        [1, "create_table"],
+        [2, "upgrade_schema"],
+        [3, "mysql_timestamp_precision"]
+      ])
+      const columns = yield* sql<{ column_name: string; datetime_precision: number; is_nullable: string }>`
+        SELECT COLUMN_NAME AS column_name, DATETIME_PRECISION AS datetime_precision, IS_NULLABLE AS is_nullable
+        FROM information_schema.columns
+        WHERE table_schema = DATABASE() AND table_name = 'existing_queue' AND data_type = 'datetime'
+        ORDER BY column_name`
+      assert.deepStrictEqual(columns, [
+        { column_name: "acquired_at", datetime_precision: 6, is_nullable: "YES" },
+        { column_name: "created_at", datetime_precision: 6, is_nullable: "NO" },
+        { column_name: "updated_at", datetime_precision: 6, is_nullable: "NO" },
+        { column_name: "visible_at", datetime_precision: 6, is_nullable: "NO" }
+      ])
 
-        // Measure the persisted deadline against NOW(6), not updated_at: both
-        // NOW() and the existing DATETIME columns lack fractional precision.
-        // Freezing MySQL time avoids TestClock/live-clock scheduling races.
-        const rows = yield* sql<{ delay_us: number; attempts: number; state: string }>`
-          SELECT TIMESTAMPDIFF(MICROSECOND, NOW(6), visible_at) AS delay_us, attempts, state
-          FROM retry_precision WHERE queue_name = ${`retry-precision-${phase}`}
-        `
-        assert.strictEqual(rows.length, 1)
-        assert.strictEqual(rows[0].attempts, 1)
-        assert.strictEqual(rows[0].state, "pending")
-        assert.isAtLeast(Number(rows[0].delay_us), 500_000)
+      // Reopening must keep the migration history, data, and indexes intact.
+      const store = yield* PersistedQueue.makeStoreSql({ tableName })
+      assert.deepStrictEqual(yield* migrations, migrated)
+      assert.deepStrictEqual(yield* sql`SELECT * FROM existing_queue ORDER BY sequence`, before)
+      assert.deepStrictEqual(yield* indexes, indexesBefore)
 
-        yield* sql`SET timestamp = ${timestamp + 2}`
-        assert.strictEqual(yield* queue.take((_, { attempts }) => Effect.succeed(attempts)), 2)
-      }), { timeout: 10_000 })
+      const factory = yield* PersistedQueue.makeFactory.pipe(
+        Effect.provideService(PersistedQueue.PersistedQueueStore, store)
+      )
+      const queue = yield* factory.make({ name: "upgrade", schema: Schema.Number, retrySchedule: Schedule.spaced(500) })
+      yield* sql`SET timestamp = 1800000000.95`
+      yield* Effect.addFinalizer(() => sql`SET timestamp = DEFAULT`.pipe(Effect.orDie))
+      assert.strictEqual(
+        yield* queue.take((value) => {
+          assert.strictEqual(value, 42)
+          return Effect.fail("retry")
+        }).pipe(Effect.flip),
+        "retry"
+      )
+      const rows = yield* sql<{ delay_us: number }>`
+        SELECT TIMESTAMPDIFF(MICROSECOND, NOW(6), visible_at) AS delay_us
+        FROM existing_queue WHERE id = 'pending'`
+      assert.strictEqual(Number(rows[0].delay_us), 500_000)
+      yield* sql`SET timestamp = 1800000002`
+      assert.strictEqual(yield* queue.take((_, { attempts }) => Effect.succeed(attempts)), 2)
+    }), { timeout: 10_000 })
+
+  for (const delay of [0, 0.5, 500, 2500]) {
+    for (const phase of [0, 250, 750, 950]) {
+      it.effect(`preserves a ${delay} ms retry at second phase ${phase} ms`, () =>
+        Effect.gen(function*() {
+          const sql = yield* MysqlClient.MysqlClient
+          const timestamp = 1_800_000_000 + phase / 1000
+          yield* sql`SET timestamp = ${timestamp}`
+          yield* Effect.addFinalizer(() => sql`SET timestamp = DEFAULT`.pipe(Effect.orDie))
+          const clock = yield* sql<{ phase: number }>`SELECT MICROSECOND(NOW(6)) AS phase`
+          assert.strictEqual(clock[0].phase, phase * 1000)
+
+          const queue = yield* PersistedQueue.make({
+            name: `retry-precision-${delay}-${phase}`,
+            schema: Schema.Number,
+            retrySchedule: Schedule.spaced(delay)
+          })
+          yield* queue.offer(42)
+          assert.strictEqual(yield* queue.take(() => Effect.fail("boom")).pipe(Effect.flip), "boom")
+
+          // Measure the persisted deadline against the frozen database clock.
+          // Exact equality also catches unnecessary rounding up to whole seconds.
+          // Freezing MySQL time avoids TestClock/live-clock scheduling races.
+          const rows = yield* sql<{ delay_us: number; attempts: number; state: string }>`
+            SELECT TIMESTAMPDIFF(MICROSECOND, NOW(6), visible_at) AS delay_us, attempts, state
+            FROM retry_precision WHERE queue_name = ${`retry-precision-${delay}-${phase}`}
+          `
+          assert.strictEqual(rows.length, 1)
+          assert.strictEqual(rows[0].attempts, 1)
+          assert.strictEqual(rows[0].state, "pending")
+          assert.strictEqual(Number(rows[0].delay_us), delay * 1000)
+
+          yield* sql`SET timestamp = ${timestamp + Math.ceil(delay / 1000)}`
+          assert.strictEqual(yield* queue.take((_, { attempts }) => Effect.succeed(attempts)), 2)
+        }), { timeout: 10_000 })
+    }
   }
 })

--- a/packages/sql/mysql2/test/PersistedQueue.integration.test.ts
+++ b/packages/sql/mysql2/test/PersistedQueue.integration.test.ts
@@ -1,6 +1,6 @@
 import { MysqlClient } from "@effect/sql-mysql2"
 import { assert, it } from "@effect/vitest"
-import { Effect, Latch, Layer, Redacted, Schedule, Schema } from "effect"
+import { Cause, Effect, Exit, Fiber, Latch, Layer, Redacted, Schedule, Schema } from "effect"
 import { TestClock } from "effect/testing"
 import { PersistedQueue } from "effect/unstable/persistence"
 import { Reactivity } from "effect/unstable/reactivity"
@@ -23,6 +23,154 @@ const layer = PersistedQueue.layer.pipe(
 )
 
 it.layer(layer, { timeout: "60 seconds", concurrent: false })("PersistedQueue MySQL retry precision", (it) => {
+  for (const scenario of ["failed_alter", "interrupt_owner", "interrupt_waiter", "timeout"] as const) {
+    it.effect(`releases upgrade ownership before pool reuse after ${scenario}`, () =>
+      Effect.gen(function*() {
+        const sql = yield* MysqlClient.MysqlClient
+        const observer = yield* MysqlClient.make(sql.config).pipe(Effect.provide(Reactivity.layer))
+        const tableName = `lock_${scenario}`
+        yield* sql`CREATE TABLE ${sql(tableName)} LIKE retry_precision`
+        yield* sql`ALTER TABLE ${sql(tableName)} MODIFY visible_at DATETIME NOT NULL`
+        yield* sql`CREATE TABLE ${sql(`${tableName}_migrations`)} LIKE retry_precision_migrations`
+        yield* sql`INSERT INTO ${sql(`${tableName}_migrations`)} SELECT * FROM retry_precision_migrations`
+        yield* sql`INSERT INTO ${sql(tableName)}
+          (id, queue_name, element, state, attempts, visible_at, created_at, updated_at)
+          VALUES ('retained', 'lifecycle', '42', 'pending', 0, '2026-01-01', '2026-01-01', '2026-01-01')`
+        const [{ name }] = yield* observer<{ name: string }>`SELECT
+          SHA2(CONCAT('effect/PersistedQueue/precision:', DATABASE(), ':', ${tableName}), 256) AS name`
+        const [{ id }] = yield* sql<{ id: number }>`SELECT CONNECTION_ID() AS id`
+        const waiting = Latch.makeUnsafe()
+        const owning = Latch.makeUnsafe()
+        let reservationReleased = false
+        let workStarted = false
+        // The extra finalizer runs immediately before the underlying reservation
+        // returns its connection to the pool, after the inner lock scope closes.
+        const reserve = sql.reserve.pipe(Effect.flatMap((connection) =>
+          Effect.gen(function*() {
+            yield* Effect.addFinalizer(() =>
+              observer<{ owner: number | null }>`SELECT IS_USED_LOCK(${name}) AS owner`.pipe(
+                Effect.orDie,
+                Effect.tap(([{ owner }]) =>
+                  Effect.sync(() => {
+                    assert.notStrictEqual(owner, id)
+                    reservationReleased = true
+                  })
+                )
+              )
+            )
+            return new Proxy(connection, {
+              get(target, key, receiver) {
+                if (key === "execute") {
+                  return (
+                    query: string,
+                    params: ReadonlyArray<unknown>,
+                    transform: Parameters<typeof connection.execute>[2]
+                  ) =>
+                    /GET_LOCK/.test(query)
+                      ? Effect.andThen(waiting.open, connection.execute(query, params, transform))
+                      : connection.execute(query, params, transform)
+                }
+                return Reflect.get(target, key, receiver)
+              }
+            })
+          })
+        ))
+        const tracked: SqlClient.SqlClient = new Proxy(sql, {
+          get(target, key, receiver) {
+            if (key === "reserve") return reserve
+            if (key === "withoutTransforms") return () => tracked
+            return Reflect.get(target, key, receiver)
+          }
+        })
+        const start = Effect.gen(function*() {
+          const store = yield* PersistedQueue.makeStoreSql({ tableName, pollInterval: 5 })
+          workStarted = true
+          const factory = yield* PersistedQueue.makeFactory.pipe(
+            Effect.provideService(PersistedQueue.PersistedQueueStore, store)
+          )
+          const queue = yield* factory.make({ name: "lifecycle", schema: Schema.Number })
+          return yield* queue.take(Effect.succeed)
+        }).pipe(Effect.provideService(SqlClient.SqlClient, tracked), Effect.scoped)
+        const intercept: Statement.Transformer = (statement, constructor) => {
+          const [query] = statement.compile()
+          if (!/^\s*ALTER TABLE/.test(query)) return Effect.succeed(statement)
+          if (scenario === "failed_alter") {
+            return Effect.succeed(constructor`ALTER TABLE ${constructor(tableName)} MODIFY missing_column DATETIME(6)`)
+          }
+          return Effect.andThen(owning.open, Effect.never)
+        }
+
+        if (scenario === "failed_alter") {
+          const exit = yield* start.pipe(Effect.provideService(Statement.CurrentTransformer, intercept), Effect.exit)
+          assert.isTrue(Exit.isFailure(exit))
+          if (Exit.isFailure(exit)) {
+            assert.include(
+              String(Cause.squash(exit.cause)),
+              `Failed to upgrade MySQL persisted queue table ${tableName}`
+            )
+          }
+        } else if (scenario === "interrupt_owner") {
+          const fiber = yield* start.pipe(
+            Effect.provideService(Statement.CurrentTransformer, intercept),
+            Effect.forkScoped
+          )
+          yield* owning.await
+          const [{ owner }] = yield* observer<{ owner: number }>`SELECT IS_USED_LOCK(${name}) AS owner`
+          assert.strictEqual(owner, id)
+          yield* Fiber.interrupt(fiber)
+          const exit = yield* Fiber.await(fiber)
+          assert.isTrue(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause))
+        } else {
+          yield* Effect.scoped(Effect.gen(function*() {
+            yield* Effect.acquireRelease(
+              observer<{ acquired: number }>`SELECT GET_LOCK(${name}, 0) AS acquired`.pipe(
+                Effect.tap(([{ acquired }]) => Effect.sync(() => assert.strictEqual(acquired, 1)))
+              ),
+              () => observer`SELECT RELEASE_LOCK(${name})`.pipe(Effect.orDie)
+            )
+            if (scenario === "timeout") {
+              const exit = yield* start.pipe(Effect.exit)
+              assert.isTrue(Exit.isFailure(exit))
+              if (Exit.isFailure(exit)) {
+                assert.include(
+                  String(Cause.squash(exit.cause)),
+                  `Timed out waiting to upgrade MySQL persisted queue table ${tableName}`
+                )
+              }
+            } else {
+              const fiber = yield* start.pipe(Effect.forkScoped)
+              yield* waiting.await
+              const interrupter = yield* Fiber.interrupt(fiber).pipe(Effect.forkScoped)
+              // GET_LOCK is uninterruptible until ownership is known. Releasing
+              // the blocker lets cancellation finalize any newly acquired lock.
+              yield* Effect.sleep(50)
+              assert.isUndefined(interrupter.pollUnsafe())
+              yield* observer`SELECT RELEASE_LOCK(${name})`
+              yield* Fiber.join(interrupter)
+              const exit = yield* Fiber.await(fiber)
+              assert.isTrue(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause))
+            }
+          }))
+        }
+
+        assert.isTrue(reservationReleased)
+        assert.isFalse(workStarted)
+        const [{ free }] = yield* observer<{ free: number }>`SELECT IS_FREE_LOCK(${name}) AS free`
+        assert.strictEqual(free, 1)
+        // Reuse the same physical connection, rather than hiding a leaked lock
+        // by closing its pool and opening a new connection.
+        const [{ reused }] = yield* sql<{ reused: number }>`SELECT CONNECTION_ID() AS reused`
+        assert.strictEqual(reused, id)
+        assert.deepStrictEqual(yield* sql`SELECT state, attempts FROM ${sql(tableName)} WHERE id = 'retained'`, [
+          { state: "pending", attempts: 0 }
+        ])
+        assert.strictEqual(yield* start, 42)
+        assert.isTrue(workStarted)
+        const [{ free: afterRestart }] = yield* observer<{ free: number }>`SELECT IS_FREE_LOCK(${name}) AS free`
+        assert.strictEqual(afterRestart, 1)
+      }).pipe(TestClock.withLive), { timeout: scenario === "timeout" ? 45_000 : 10_000 })
+  }
+
   for (const legacy of [false, true]) {
     it.effect(
       legacy ? "concurrent startups perform only one precision ALTER" : "correct tables skip precision ALTER",

--- a/packages/sql/mysql2/test/PersistedQueue.integration.test.ts
+++ b/packages/sql/mysql2/test/PersistedQueue.integration.test.ts
@@ -1,7 +1,6 @@
 import { MysqlClient } from "@effect/sql-mysql2"
 import { assert, it } from "@effect/vitest"
-import { Cause, Effect, Exit, Fiber, Layer, Redacted, Schedule, Schema } from "effect"
-import { TestClock } from "effect/testing"
+import { Effect, Layer, Redacted, Schedule, Schema } from "effect"
 import { PersistedQueue } from "effect/unstable/persistence"
 import { MysqlContainer } from "./utils.ts"
 
@@ -20,109 +19,32 @@ const layer = PersistedQueue.layer.pipe(
   Layer.provideMerge(client)
 )
 
-const assertPrecisionDiagnostic = (cause: Cause.Cause<unknown>, tableName: string) => {
-  const error = Cause.squash(cause)
-  assert.instanceOf(error, Error)
-  assert.strictEqual(
-    (error as Error).message,
-    `PersistedQueue: MySQL table ${tableName} requires DATETIME(6) for visible_at, acquired_at, created_at and updated_at. ` +
-      "The timestamp precision migration may have failed after being recorded as applied. " +
-      "Repair these columns before restarting the queue store."
-  )
-}
-
 it.layer(layer, { timeout: "60 seconds", concurrent: false })("PersistedQueue MySQL retry precision", (it) => {
   for (const column of ["visible_at", "acquired_at", "created_at", "updated_at"]) {
-    for (const precision of [0, 3]) {
-      it.effect(`rejects a partial upgrade with ${column} at precision ${precision}`, () =>
-        Effect.gen(function*() {
-          const sql = yield* MysqlClient.MysqlClient
-          const tableName = `partial_${column}_${precision}`
-          yield* sql`CREATE TABLE ${sql(tableName)} LIKE retry_precision`
-          yield* sql`ALTER TABLE ${sql(tableName)} MODIFY ${sql(column)} DATETIME(${sql.literal(String(precision))}) ${
-            sql.literal(column === "acquired_at" ? "NULL" : "NOT NULL")
-          }`
-          yield* sql`CREATE TABLE ${sql(`${tableName}_migrations`)} LIKE retry_precision_migrations`
-          yield* sql`INSERT INTO ${sql(`${tableName}_migrations`)} SELECT * FROM retry_precision_migrations`
-          const startup = yield* PersistedQueue.makeStoreSql({ tableName }).pipe(Effect.exit)
-          assert.isTrue(Exit.isFailure(startup))
-          if (Exit.isFailure(startup)) assertPrecisionDiagnostic(startup.cause, tableName)
-        }))
-    }
-  }
-
-  it.effect(
-    "rejects or repairs an applied precision migration with old columns before delivering retries",
-    () =>
+    it.effect(`upgrades ${column} when it was left below microsecond precision`, () =>
       Effect.gen(function*() {
         const sql = yield* MysqlClient.MysqlClient
-        yield* sql`CREATE TABLE interrupted_upgrade LIKE retry_precision`
-        yield* sql`ALTER TABLE interrupted_upgrade
-        MODIFY visible_at DATETIME NOT NULL, MODIFY acquired_at DATETIME NULL,
-        MODIFY created_at DATETIME NOT NULL, MODIFY updated_at DATETIME NOT NULL`
-        yield* sql`CREATE TABLE interrupted_upgrade_migrations LIKE retry_precision_migrations`
-        yield* sql`INSERT INTO interrupted_upgrade_migrations
-        SELECT * FROM retry_precision_migrations WHERE migration_id < 3`
-
-        // Independently reproduce MySQL's implicit commit before failing DDL:
-        // the marker survives rollback while the timestamp columns stay unchanged.
-        const ddl = yield* Effect.gen(function*() {
-          yield* sql`INSERT INTO interrupted_upgrade_migrations (migration_id, name)
-          VALUES (3, 'mysql_timestamp_precision')`
-          yield* sql`ALTER TABLE interrupted_upgrade MODIFY missing_column DATETIME(6)`
-        }).pipe(sql.withTransaction, Effect.exit)
-        assert.isTrue(Exit.isFailure(ddl))
-        const markers = yield* sql`SELECT migration_id FROM interrupted_upgrade_migrations WHERE migration_id = 3`
-        assert.strictEqual(markers.length, 1)
+        const tableName = `partial_${column}`
+        yield* sql`CREATE TABLE ${sql(tableName)} LIKE retry_precision`
+        yield* sql`ALTER TABLE ${sql(tableName)} MODIFY ${sql(column)} DATETIME(3) ${
+          sql.literal(column === "acquired_at" ? "NULL" : "NOT NULL")
+        }`
+        yield* sql`CREATE TABLE ${sql(`${tableName}_migrations`)} LIKE retry_precision_migrations`
+        yield* sql`INSERT INTO ${sql(`${tableName}_migrations`)} SELECT * FROM retry_precision_migrations`
+        yield* PersistedQueue.makeStoreSql({ tableName })
         const columns = yield* sql<{ fractional_digits: number }>`SELECT DATETIME_PRECISION AS fractional_digits
-        FROM information_schema.columns WHERE table_schema = DATABASE()
-        AND table_name = 'interrupted_upgrade' AND column_name = 'visible_at'`
-        assert.strictEqual(columns[0].fractional_digits, 0)
-
-        const startup = yield* PersistedQueue.makeStoreSql({
-          tableName: "interrupted_upgrade",
-          pollInterval: "10 millis"
-        }).pipe(Effect.exit)
-        // Refusing unsafe startup is valid; a repaired store must honor the delay.
-        if (Exit.isFailure(startup)) {
-          assertPrecisionDiagnostic(startup.cause, "interrupted_upgrade")
-          return
-        }
-        const factory = yield* PersistedQueue.makeFactory.pipe(
-          Effect.provideService(PersistedQueue.PersistedQueueStore, startup.value)
-        )
-        const queue = yield* factory.make({
-          name: "interrupted",
-          schema: Schema.Number,
-          retrySchedule: Schedule.spaced(500)
-        })
-        yield* sql`SET timestamp = 1800000000`
-        yield* Effect.addFinalizer(() => sql`SET timestamp = DEFAULT`.pipe(Effect.orDie))
-        yield* queue.offer(42)
-        assert.strictEqual(
-          yield* queue.take(() => sql`SET timestamp = 1800000000.9`.pipe(Effect.andThen(Effect.fail("boom")))).pipe(
-            Effect.flip
-          ),
-          "boom"
-        )
-        // Only 100 ms after failure. DATETIME(0) rounds the intended .4 deadline
-        // down to the whole second, allowing the queue to redeliver here.
-        yield* sql`SET timestamp = 1800000001`
-        const fiber = yield* queue.take((_, { attempts }) => Effect.succeed(attempts)).pipe(Effect.forkScoped)
-        yield* Effect.sleep(100)
-        assert.isUndefined(fiber.pollUnsafe())
-        yield* sql`SET timestamp = 1800000002`
-        assert.strictEqual(yield* Fiber.join(fiber), 2)
-      }).pipe(TestClock.withLive),
-    { timeout: 10_000 }
-  )
+          FROM information_schema.columns WHERE table_schema = DATABASE()
+          AND table_name = ${tableName} AND column_name = ${column}`
+        assert.strictEqual(Number(columns[0].fractional_digits), 6)
+      }))
+  }
 
   it.effect("upgrades an existing queue once and preserves its rows and indexes", () =>
     Effect.gen(function*() {
       const sql = yield* MysqlClient.MysqlClient
       const tableName = "existing_queue"
-      // Schema and migration history from before the precision migration.
-      // Build the fixture independently of the current migration implementation.
+      // Schema and migration history from before DATETIME(6), built
+      // independently of the current migration implementation.
       yield* sql`CREATE TABLE existing_queue (
         sequence BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
         id VARCHAR(255) NOT NULL,
@@ -166,8 +88,7 @@ it.layer(layer, { timeout: "60 seconds", concurrent: false })("PersistedQueue My
       const migrated = yield* migrations
       assert.deepStrictEqual(migrated.map((row) => [row.migration_id, row.name]), [
         [1, "create_table"],
-        [2, "upgrade_schema"],
-        [3, "mysql_timestamp_precision"]
+        [2, "upgrade_schema"]
       ])
       const columns = yield* sql<{ column_name: string; datetime_precision: number; is_nullable: string }>`
         SELECT COLUMN_NAME AS column_name, DATETIME_PRECISION AS datetime_precision, IS_NULLABLE AS is_nullable
@@ -228,7 +149,7 @@ it.layer(layer, { timeout: "60 seconds", concurrent: false })("PersistedQueue My
           assert.strictEqual(yield* queue.take(() => Effect.fail("boom")).pipe(Effect.flip), "boom")
 
           // Measure the persisted deadline against the frozen database clock.
-          // Exact equality also catches unnecessary rounding up to whole seconds.
+          // Delays round up to whole milliseconds, never to whole seconds.
           // Freezing MySQL time avoids TestClock/live-clock scheduling races.
           const rows = yield* sql<{ delay_us: number; attempts: number; state: string }>`
             SELECT TIMESTAMPDIFF(MICROSECOND, NOW(6), visible_at) AS delay_us, attempts, state
@@ -237,7 +158,7 @@ it.layer(layer, { timeout: "60 seconds", concurrent: false })("PersistedQueue My
           assert.strictEqual(rows.length, 1)
           assert.strictEqual(rows[0].attempts, 1)
           assert.strictEqual(rows[0].state, "pending")
-          assert.strictEqual(Number(rows[0].delay_us), delay * 1000)
+          assert.strictEqual(Number(rows[0].delay_us), Math.ceil(delay) * 1000)
 
           if (delay > 0) {
             // Let MySQL compute the boundary from its stored deadline, avoiding

--- a/packages/sql/pglite/test/PersistedQueue.test.ts
+++ b/packages/sql/pglite/test/PersistedQueue.test.ts
@@ -1,6 +1,7 @@
 import { PgliteClient } from "@effect/sql-pglite"
 import { assert, describe, layer } from "@effect/vitest"
-import { Effect } from "effect"
+import { Effect, Schedule, Schema } from "effect"
+import { TestClock } from "effect/testing"
 import { PersistedQueue } from "effect/unstable/persistence"
 import { SqlClient } from "effect/unstable/sql"
 
@@ -8,6 +9,31 @@ const ClientLayer = PgliteClient.layer({})
 
 describe("PersistedQueue SQL migrations", () => {
   layer(ClientLayer, { timeout: "30 seconds" })((it) => {
+    it.effect("preserves a sub-second retry through the PostgreSQL interval branch", () =>
+      Effect.gen(function*() {
+        const sql = yield* SqlClient.SqlClient
+        const store = yield* PersistedQueue.makeStoreSql({ tableName: "pg_retry", pollInterval: 10 })
+        const factory = yield* PersistedQueue.makeFactory.pipe(
+          Effect.provideService(PersistedQueue.PersistedQueueStore, store)
+        )
+        const queue = yield* factory.make({ name: "retry", schema: Schema.Number, retrySchedule: Schedule.spaced(500) })
+        yield* queue.offer(42)
+        let failedAt = 0
+        assert.strictEqual(
+          yield* queue.take(() => {
+            failedAt = Date.now()
+            return Effect.fail("boom")
+          }).pipe(Effect.flip),
+          "boom"
+        )
+        const rows = yield* sql<{ delay_ms: string }>`SELECT
+          EXTRACT(EPOCH FROM (visible_at - updated_at)) * 1000 AS delay_ms FROM pg_retry WHERE queue_name = 'retry'`
+        assert.strictEqual(Number(rows[0].delay_ms), 500)
+        const result = yield* queue.take((value, { attempts }) => Effect.succeed({ value, attempts }))
+        assert.deepStrictEqual(result, { value: 42, attempts: 2 })
+        assert.isAtLeast(Date.now() - failedAt, 500)
+      }).pipe(TestClock.withLive), { timeout: 10_000 })
+
     it.effect("runs fresh-install migrations once", () =>
       Effect.gen(function*() {
         const sql = (yield* SqlClient.SqlClient).withoutTransforms()

--- a/packages/sql/sqlite-node/test/PersistedQueue.test.ts
+++ b/packages/sql/sqlite-node/test/PersistedQueue.test.ts
@@ -79,13 +79,10 @@ it.layer(layer, { concurrent: false })("PersistedQueue SQLite retry precision", 
         yield* queue.take(() =>
           Effect.gen(function*() {
             // Use SQLite's real clock. TestClock cannot advance SQLite's 'now'.
-            // A short poll interval exposes early eligibility hidden by 1s polling.
-            while (true) {
-              const rows = yield* sql<{ phase: number }>`SELECT
-            CAST(substr(strftime('%f', 'now'), 4) AS INTEGER) AS phase`
-              if (rows[0].phase >= 850 && rows[0].phase < 900) break
-              yield* Effect.sleep(5)
-            }
+            // Fail late in the second, where whole-second rounding redelivered early.
+            const rows = yield* sql<{ phase: number }>`SELECT
+              CAST(substr(strftime('%f', 'now'), 4) AS INTEGER) AS phase`
+            yield* Effect.sleep((1880 - rows[0].phase) % 1000)
             failedAt = Date.now()
             return yield* Effect.fail("boom")
           })

--- a/packages/sql/sqlite-node/test/PersistedQueue.test.ts
+++ b/packages/sql/sqlite-node/test/PersistedQueue.test.ts
@@ -1,0 +1,51 @@
+import { SqliteClient } from "@effect/sql-sqlite-node"
+import { assert, it } from "@effect/vitest"
+import { Effect, Layer, Schedule, Schema } from "effect"
+import { TestClock } from "effect/testing"
+import { PersistedQueue } from "effect/unstable/persistence"
+
+const layer = PersistedQueue.layer.pipe(
+  Layer.provideMerge(PersistedQueue.layerStoreSql({ pollInterval: "5 millis" })),
+  Layer.provideMerge(SqliteClient.layer({ filename: ":memory:" }))
+)
+
+it.layer(layer)("PersistedQueue SQLite retry precision", (it) => {
+  it.effect("does not redeliver a 500 ms retry early near a second boundary", () =>
+    Effect.gen(function*() {
+      const sql = yield* SqliteClient.SqliteClient
+      const queue = yield* PersistedQueue.make({
+        name: "boundary",
+        schema: Schema.Number,
+        retrySchedule: Schedule.spaced(500)
+      })
+      yield* queue.offer(42)
+      let failedAt = 0
+      assert.strictEqual(
+        yield* queue.take(() =>
+          Effect.gen(function*() {
+            // Use SQLite's real clock. TestClock cannot advance SQLite's 'now'.
+            // A short poll interval exposes early eligibility hidden by 1s polling.
+            while (true) {
+              const rows = yield* sql<{ phase: number }>`SELECT
+            CAST(substr(strftime('%f', 'now'), 4) AS INTEGER) AS phase`
+              if (rows[0].phase >= 850 && rows[0].phase < 900) break
+              yield* Effect.sleep(5)
+            }
+            failedAt = Date.now()
+            return yield* Effect.fail("boom")
+          })
+        ).pipe(Effect.flip),
+        "boom"
+      )
+      const result = yield* queue.take((value, { attempts }) =>
+        Effect.succeed({
+          value,
+          attempts,
+          elapsed: Date.now() - failedAt
+        })
+      )
+      assert.strictEqual(result.value, 42)
+      assert.strictEqual(result.attempts, 2)
+      assert.isAtLeast(result.elapsed, 500)
+    }).pipe(TestClock.withLive), { timeout: 10_000 })
+})

--- a/packages/sql/sqlite-node/test/PersistedQueue.test.ts
+++ b/packages/sql/sqlite-node/test/PersistedQueue.test.ts
@@ -1,6 +1,6 @@
 import { SqliteClient } from "@effect/sql-sqlite-node"
 import { assert, it } from "@effect/vitest"
-import { Effect, Layer, Schedule, Schema } from "effect"
+import { Duration, Effect, Fiber, Layer, Schedule, Schema } from "effect"
 import { TestClock } from "effect/testing"
 import { PersistedQueue } from "effect/unstable/persistence"
 
@@ -9,7 +9,62 @@ const layer = PersistedQueue.layer.pipe(
   Layer.provideMerge(SqliteClient.layer({ filename: ":memory:" }))
 )
 
-it.layer(layer)("PersistedQueue SQLite retry precision", (it) => {
+it.layer(layer, { concurrent: false })("PersistedQueue SQLite retry precision", (it) => {
+  for (const delay of [0, 0.001, 0.5, 1, 500, 2500]) {
+    it.effect(`preserves a ${delay} ms retry rounded up to SQLite clock precision`, () =>
+      Effect.gen(function*() {
+        const sql = yield* SqliteClient.SqliteClient
+        const name = `duration-${delay}`
+        const queue = yield* PersistedQueue.make({ name, schema: Schema.Number, retrySchedule: Schedule.spaced(delay) })
+        yield* queue.offer(42)
+        const failedAt = Date.now()
+        assert.strictEqual(yield* queue.take(() => Effect.fail("boom")).pipe(Effect.flip), "boom")
+        // Both timestamps are written in the retry UPDATE, so database latency
+        // cannot change the measured interval. Round away julianday float error.
+        const rows = yield* sql<{ delay_ms: number }>`SELECT
+          ROUND((julianday(visible_at) - julianday(updated_at)) * 86400000) AS delay_ms
+          FROM effect_queue WHERE queue_name = ${name}`
+        assert.strictEqual(rows[0].delay_ms, Math.ceil(delay))
+        assert.strictEqual(yield* queue.take((_, { attempts }) => Effect.succeed(attempts)), 2)
+        assert.isAtLeast(Date.now() - failedAt, Math.ceil(delay))
+      }).pipe(TestClock.withLive), { timeout: 10_000 })
+  }
+
+  it.effect(
+    "delivers and cleans up legacy whole-second rows without exposing future rows",
+    () =>
+      Effect.gen(function*() {
+        const sql = yield* SqliteClient.SqliteClient
+        const store = yield* PersistedQueue.makeStoreSql({ tableName: "legacy_queue", pollInterval: 5 })
+        const factory = yield* PersistedQueue.makeFactory.pipe(
+          Effect.provideService(PersistedQueue.PersistedQueueStore, store)
+        )
+        yield* sql`INSERT INTO legacy_queue
+        (id, queue_name, element, state, attempts, visible_at, acquired_at, acquired_by, created_at, updated_at)
+        VALUES
+        ('old', 'legacy', '42', 'pending', 1, '2026-01-01 00:00:00', '2026-01-01 00:00:00', 'old-worker',
+          '2026-01-01 00:00:00', '2026-01-01 00:00:00'),
+        ('future', 'legacy', '43', 'pending', 0, '2099-01-01 00:00:00', NULL, NULL,
+          '2026-01-01 00:00:00', '2026-01-01 00:00:00'),
+        ('done', 'legacy', '44', 'completed', 1, '2026-01-01 00:00:00', NULL, NULL,
+          '2026-01-01 00:00:00', '2026-01-01 00:00:00'),
+        ('failed', 'legacy', '45', 'failed', 3, '2026-01-01 00:00:00', NULL, NULL,
+          '2026-01-01 00:00:00', '2026-01-01 00:00:00')`
+        yield* store.cleanup({ timeToLive: Duration.seconds(1), failedTimeToLive: Duration.seconds(1) })
+        assert.deepStrictEqual(yield* sql`SELECT id FROM legacy_queue ORDER BY id`, [{ id: "future" }, { id: "old" }])
+        const queue = yield* factory.make({ name: "legacy", schema: Schema.Number })
+        const result = yield* queue.take((value, { attempts }) => Effect.succeed({ value, attempts }))
+        assert.deepStrictEqual(result, { value: 42, attempts: 2 })
+        const fiber = yield* queue.take(Effect.succeed).pipe(Effect.forkScoped)
+        yield* Effect.sleep(50)
+        assert.isUndefined(fiber.pollUnsafe())
+        yield* Fiber.interrupt(fiber)
+        const future = yield* sql`SELECT visible_at, attempts FROM legacy_queue WHERE id = 'future'`
+        assert.deepStrictEqual(future, [{ visible_at: "2099-01-01 00:00:00", attempts: 0 }])
+      }).pipe(TestClock.withLive),
+    { timeout: 10_000 }
+  )
+
   it.effect("does not redeliver a 500 ms retry early near a second boundary", () =>
     Effect.gen(function*() {
       const sql = yield* SqliteClient.SqliteClient


### PR DESCRIPTION
A persisted queue retry scheduled for 500 ms could become eligible near the next whole second, only a few milliseconds after failure. Preserve fractional timestamp precision and round retry delays up to whole milliseconds on MySQL, PostgreSQL, and SQLite. MSSQL retains whole-second rounding.

MySQL uses `NOW(6)` and creates queue timestamp columns as `DATETIME(6)`. Legacy tables are repaired outside the migrator, so failed ALTERs can be retried on the next startup. Concurrent repairs now acquire a database/table-specific named lock on a reserved connection and recheck precision before altering. The check and ALTER use that same connection. The lock is released before the connection returns to its pool, including on failure or interruption. A 30-second lock timeout fails startup; ALTER errors include table-specific repair context and preserve the original error as their cause.

The changeset documents millisecond rounding and the MySQL rebuild/locking cost. SQLite keeps legacy whole-second rows compatible with its millisecond format, including the possible late delivery on rollback.

Coverage includes MySQL duration/phase deadlines, eligibility one microsecond before the deadline, existing-table repair, concurrent startup and zero ALTERs for correct tables, default 30-day cleanup, PGlite retries, and SQLite durations/boundary/legacy compatibility.

Validation:

- Lint and root type check pass.
- 53 tests passed across MySQL persistence, MySQL regressions, PGlite, and SQLite regressions.
- The MySQL/PGlite regression set passed twice more (26 tests each); the concurrent-upgrade regression passes in all three runs.
- A temporary probe verified lock release after failed ALTER, restart repair, interruption while holding/waiting for ownership, and a real 30-second timeout followed by successful restart.

Permanent lock lifecycle tests now cover failed ALTER followed by restart, interruption while owning and waiting for the lock, and a real 30-second timeout followed by recovery. They inspect ownership immediately before reservation return, verify reuse of the same physical connection, and assert failed startup leaves the queue item untouched before successful consumption on restart. All 28 MySQL regression tests, lint, and root type check pass on the latest test-only commit.

Closes EFF-1319
