### PR TITLE
Fix workflow activity counter leak on interruption

### DIFF
--- a/.changeset/workflow-activity-acquisition.md
+++ b/.changeset/workflow-activity-acquisition.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix interruption during workflow activity acquisition leaking the activity count and blocking later durable deferred suspension.

--- a/packages/effect/src/unstable/workflow/Workflow.ts
+++ b/packages/effect/src/unstable/workflow/Workflow.ts
@@ -735,27 +735,29 @@ export const wrapActivityResult = <A, E, R>(
   effect: Effect.Effect<A, E, R>,
   isSuspend: (value: A) => boolean
 ): Effect.Effect<A, E, R | WorkflowInstance> =>
-  Effect.contextWith((context: Context.Context<WorkflowInstance>) => {
-    const instance = Context.get(context, InstanceTag)
-    const registration = adoptActivityUnsafe(context, instance) ?? registerActivityUnsafe(instance)
-    return Effect.onExit(effect, (exit) => {
-      releaseActivityUnsafe(registration)
-      const isSuspended = Exit.isSuccess(exit) && isSuspend(exit.value)
-      if (
-        Exit.isSuccess(exit) &&
-        isResult(exit.value) &&
-        exit.value._tag === "Suspended" &&
-        exit.value.cause
-      ) {
-        instance.cause = instance.cause
-          ? Cause.combine(instance.cause, exit.value.cause)
-          : exit.value.cause
-      }
-      return isSuspended && instance.activityState.count > 0
-        ? waitForZero(instance)
-        : Effect.void
+  Effect.uninterruptibleMask((restore) =>
+    Effect.contextWith((context: Context.Context<WorkflowInstance>) => {
+      const instance = Context.get(context, InstanceTag)
+      const registration = adoptActivityUnsafe(context, instance) ?? registerActivityUnsafe(instance)
+      return Effect.onExit(restore(effect), (exit) => {
+        releaseActivityUnsafe(registration)
+        const isSuspended = Exit.isSuccess(exit) && isSuspend(exit.value)
+        if (
+          Exit.isSuccess(exit) &&
+          isResult(exit.value) &&
+          exit.value._tag === "Suspended" &&
+          exit.value.cause
+        ) {
+          instance.cause = instance.cause
+            ? Cause.combine(instance.cause, exit.value.cause)
+            : exit.value.cause
+        }
+        return isSuspended && instance.activityState.count > 0
+          ? waitForZero(instance)
+          : Effect.void
+      })
     })
-  })
+  )
 
 interface ActivityRegistration {
   readonly instance: WorkflowInstance["Service"]

--- a/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
+++ b/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
@@ -1,9 +1,87 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Duration, Effect, Exit, Fiber, Latch, Layer, Option, Ref, Schema, Scope } from "effect"
+import { Duration, Effect, Exit, Fiber, Latch, Layer, Option, Ref, Scheduler, Schema, Scope } from "effect"
 import { TestClock } from "effect/testing"
 import { Activity, DurableClock, DurableDeferred, Workflow, WorkflowEngine } from "effect/unstable/workflow"
 
 describe("WorkflowEngine", () => {
+  it.effect("interrupted activity acquisition does not block a later durable deferred", () =>
+    Effect.gen(function*() {
+      const observations: Array<{
+        yieldedAfterAcquisition: boolean
+        bodyEntered: boolean
+        childInterrupted: boolean
+        countAfterInterrupt: number
+        waiterSettled: boolean
+        waiterSettledAfterCancellation: boolean
+      }> = []
+      const Repro = Workflow.make("WorkflowEngine/InterruptedActivityAcquisition", {
+        payload: {},
+        idempotencyKey: () => "repro"
+      })
+      const layer = Repro.toLayer(() =>
+        Effect.gen(function*() {
+          const instance = yield* WorkflowEngine.WorkflowInstance
+          let yieldedAfterAcquisition = false
+          let bodyEntered = false
+          class AcquisitionScheduler extends Scheduler.MixedScheduler {
+            override shouldYield(fiber: Fiber.Fiber<unknown, unknown>): boolean {
+              // Yield at the first runtime boundary after acquisition, before the
+              // returned onExit has installed its release. No counter mutation.
+              if (!yieldedAfterAcquisition && instance.activityState.count > 0) {
+                yieldedAfterAcquisition = true
+                return true
+              }
+              return super.shouldYield(fiber)
+            }
+          }
+          const child = yield* Activity.make({
+            name: "candidate",
+            execute: Effect.sync(() => {
+              bodyEntered = true
+            }).pipe(Effect.andThen(Effect.never))
+          }).pipe(
+            Effect.provideService(Scheduler.Scheduler, new AcquisitionScheduler()),
+            Effect.forkChild({ startImmediately: true })
+          )
+          yield* Fiber.interrupt(child)
+          const childInterrupted = Exit.hasInterrupts(yield* Fiber.await(child))
+          const countAfterInterrupt = instance.activityState.count
+          const waiter = yield* DurableDeferred.await(DurableDeferred.make("unresolved")).pipe(
+            Effect.forkChild({ startImmediately: true })
+          )
+          for (let turn = 0; turn < 100; turn++) yield* Effect.yieldNow
+          const waiterSettled = waiter.pollUnsafe() !== undefined
+          const cancellation = yield* Fiber.interrupt(waiter).pipe(
+            Effect.forkChild({ startImmediately: true })
+          )
+          for (let turn = 0; turn < 100; turn++) yield* Effect.yieldNow
+          observations.push({
+            yieldedAfterAcquisition,
+            bodyEntered,
+            childInterrupted,
+            countAfterInterrupt,
+            waiterSettled,
+            waiterSettledAfterCancellation: waiter.pollUnsafe() !== undefined
+          })
+          // Repair only after observing the failure, so the leaked count cannot
+          // strand the waiter's uninterruptible finalizer during test teardown.
+          instance.activityState.count = 0
+          instance.activityState.latch.openUnsafe()
+          yield* Fiber.join(cancellation)
+        })
+      ).pipe(Layer.provideMerge(WorkflowEngine.layerMemory))
+
+      yield* Repro.execute({}).pipe(Effect.provide(layer))
+      assert.deepStrictEqual(observations, [{
+        yieldedAfterAcquisition: true,
+        bodyEntered: false,
+        childInterrupted: true,
+        countAfterInterrupt: 0,
+        waiterSettled: true,
+        waiterSettledAfterCancellation: true
+      }])
+    }))
+
   const IncrementWorkflow = Workflow.make("WorkflowEngine/IncrementWorkflow", {
     payload: { value: Schema.Number },
     success: Schema.Number,


### PR DESCRIPTION
Interrupting an activity between count acquisition and finalizer installation could leak the count, leaving a later durable deferred blocked during suspension cleanup in the same workflow run.

Wrap activity registration and finalizer installation in `Effect.uninterruptibleMask`, restoring the wrapped effect's original interruptibility. The regression uses a registered memory workflow and a scheduler that yields immediately after acquisition; it verifies that interruption releases the count and the later deferred can settle. Includes an Effect patch changeset.

Validation:

- The regression failed before the fix and passes unchanged afterward.
- `nix develop -c pnpm test --run packages/effect/test/unstable/workflow/WorkflowEngine.test.ts packages/effect/test/unstable/workflow/DurableQueue.test.ts packages/effect/test/cluster/ClusterWorkflowEngine.test.ts` passed (54 tests).
- `nix develop -c pnpm lint-fix` passed.
- `nix develop -c pnpm check` passed.

Closes EFF-1321
Closes #8130
