### PR TITLE
Stabilize PGlite client tests under CPU contention

### DIFF
--- a/packages/sql/pglite/test/Client.test.ts
+++ b/packages/sql/pglite/test/Client.test.ts
@@ -14,7 +14,8 @@ const Migrations = Layer.effectDiscard(
   })
 )
 
-describe("PgliteClient", () => {
+// Avoid overlapping PGlite startup with SQL assertions in other tests.
+describe("PgliteClient", { concurrent: false }, () => {
   layer(ClientLayer, { timeout: "30 seconds" })((it) => {
     it.effect("basic insert/select", () =>
       Effect.gen(function*() {
@@ -123,7 +124,12 @@ describe("PgliteClient", () => {
   describe("fromClient", () => {
     layer(
       PgliteClient.layerFrom(Effect.gen(function*() {
-        const pg = new Pglite.PGlite()
+        const pg = yield* Effect.acquireRelease(
+          Effect.sync(() => new Pglite.PGlite()),
+          (pg) => Effect.promise(() => pg.close())
+        )
+        // Charge startup to the layer hook timeout, not the first query's test timeout.
+        yield* Effect.promise(() => pg.waitReady)
         return yield* PgliteClient.fromClient({ liveClient: pg })
       })),
       { timeout: "30 seconds" }


### PR DESCRIPTION
Concurrent PGlite fixture startup can delay the basic SQL test beyond its five-second budget under CPU contention. The `fromClient` test also includes database startup in its first query and leaves its caller-owned instance open.

Run this test file sequentially, await `fromClient` readiness in the existing 30-second setup hook, and close its instance through the fixture scope. SQL assertions and test timeouts are unchanged. No production code changes.

On base `addeaea0b0abe0dc24ca1d4d0fd194a0e458be70`, temporary timing probes reproduced both failures in all four Bun 1.4.0 processes pinned to CPU 0. Initial readiness took 7.3–7.8 seconds, migrations took 37–64 milliseconds, and the basic query body remained pending while later fixtures initialized. The `fromClient` first query took 5.0–5.4 seconds, ending with readiness.

Validation:
- Four concurrent Bun 1.4.0 client runs pinned to CPU 0: 13/13 passed each.
- Bun 1.4.0 PGlite package suite: 33/33 passed.
- `nix develop -c pnpm test --run packages/sql/pglite/test/Client.test.ts`: 13/13 passed.
- `nix develop -c pnpm lint-fix` and `nix develop -c pnpm check`: passed.

Closes EFF-1322
