### PR TITLE
Fix Content-Type preservation during HTTP compression

### DIFF
--- a/.changeset/fix-node-compression-content-type.md
+++ b/.changeset/fix-node-compression-content-type.md
@@ -1,5 +1,9 @@
 ---
+"effect": patch
 "@effect/platform-node": patch
+"@effect/platform-node-shared": patch
+"@effect/platform-bun": patch
+"@effect/platform-deno": patch
 ---
 
-Preserve the response Content-Type when compressing Node file, raw, and stream responses.
+Preserve the response Content-Type when compressing file, raw, stream, and byte-array responses on Node, Bun, Deno, and the web platform, including headers overridden after body construction.

--- a/.changeset/fix-node-compression-content-type.md
+++ b/.changeset/fix-node-compression-content-type.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node": patch
+---
+
+Preserve the response Content-Type when compressing Node file, raw, and stream responses.

--- a/packages/effect/src/unstable/http/internal/compression.ts
+++ b/packages/effect/src/unstable/http/internal/compression.ts
@@ -67,7 +67,7 @@ export const makeCompressionWeb = (options: {
         return Effect.succeed(streamBody(
           response,
           () => options.transform(algorithm, opts)(singleChunkStream(data)),
-          body.contentType
+          response.headers["content-type"] ?? body.contentType
         ))
       }
       case "Stream": {
@@ -75,7 +75,7 @@ export const makeCompressionWeb = (options: {
         return Effect.succeed(streamBody(
           response,
           () => options.transform(algorithm, opts)(Stream.toReadableStream(stream)),
-          body.contentType
+          response.headers["content-type"] ?? body.contentType
         ))
       }
       case "Raw": {
@@ -85,7 +85,9 @@ export const makeCompressionWeb = (options: {
         }
         return Effect.succeed(setBodyWithoutLength(
           response,
-          HttpBody.raw(options.transform(algorithm, opts)(readable), { contentType: body.contentType })
+          HttpBody.raw(options.transform(algorithm, opts)(readable), {
+            contentType: response.headers["content-type"] ?? body.contentType
+          })
         ))
       }
       default: {

--- a/packages/effect/test/unstable/http/HttpCompression.test.ts
+++ b/packages/effect/test/unstable/http/HttpCompression.test.ts
@@ -90,6 +90,41 @@ const randomBytes = (length: number): Uint8Array => {
 }
 
 describe("HttpCompression", () => {
+  for (
+    const [name, makeResponse] of [
+      ["Stream", () => HttpServerResponse.stream(Stream.succeed(new TextEncoder().encode(bigJson)))],
+      ["Uint8Array", () => HttpServerResponse.uint8Array(new TextEncoder().encode(bigJson))],
+      ["Raw", () => HttpServerResponse.raw(new Response(bigJson).body, { contentType: "text/plain" })]
+    ] as const
+  ) {
+    it(`preserves a Content-Type header override when compressing web ${name} responses`, async () => {
+      const original = HttpServerResponse.setHeader(makeResponse(), "content-type", "application/json")
+      assert.strictEqual(original.headers["content-type"], "application/json")
+      const handler = makeHandler(Effect.succeed(original))
+
+      const compressed = await get(handler, { "accept-encoding": "gzip" })
+      assert.strictEqual(compressed.headers.get("content-encoding"), "gzip")
+      assert.strictEqual(await decompress(await compressed.arrayBuffer(), "gzip"), bigJson)
+      assert.strictEqual(compressed.headers.get("content-type"), original.headers["content-type"])
+    })
+  }
+
+  it("preserves a header-only Content-Type when compressing web Raw responses", async () => {
+    const handler = makeHandler(
+      Effect.sync(() =>
+        HttpServerResponse.raw(new Response(bigJson).body, { headers: { "content-type": "application/json" } })
+      )
+    )
+    const uncompressed = await get(handler, { "accept-encoding": "identity" })
+    assert.strictEqual(uncompressed.headers.get("content-type"), "application/json")
+    assert.strictEqual(await uncompressed.text(), bigJson)
+
+    const compressed = await get(handler, { "accept-encoding": "gzip" })
+    assert.strictEqual(compressed.headers.get("content-encoding"), "gzip")
+    assert.strictEqual(await decompress(await compressed.arrayBuffer(), "gzip"), bigJson)
+    assert.strictEqual(compressed.headers.get("content-type"), uncompressed.headers.get("content-type"))
+  })
+
   it("compresses a compressible response with gzip", async () => {
     const response = await get(makeHandler(bigJsonApp), { "accept-encoding": "gzip" })
     assert.strictEqual(response.status, 200)

--- a/packages/platform/node-shared/src/NodeHttpCompression.ts
+++ b/packages/platform/node-shared/src/NodeHttpCompression.ts
@@ -93,7 +93,7 @@ export const make = (fallback: Platform.Compression): Platform.Compression => ({
     }
     return Effect.map(compress(body.body, algorithm, options), (result) =>
       Response.setHeader(
-        Response.setBody(response, HttpBody.uint8Array(result, body.contentType)),
+        Response.setBody(response, HttpBody.uint8Array(result, response.headers["content-type"] ?? body.contentType)),
         "content-length",
         result.byteLength.toString()
       ))

--- a/packages/platform/node/src/NodeHttpPlatform.ts
+++ b/packages/platform/node/src/NodeHttpPlatform.ts
@@ -44,7 +44,7 @@ const compression = NodeHttpCompression.make({
             NodeStream.pipeThroughDuplex(body.stream, {
               evaluate: () => NodeHttpCompression.compressTransform(algorithm, options)
             }),
-            body.contentType
+            response.headers["content-type"] ?? body.contentType
           )
         ))
       }
@@ -57,7 +57,12 @@ const compression = NodeHttpCompression.make({
         transform.on("error", (cause) => readable.destroy(cause))
         transform.on("close", () => readable.destroy())
         return Effect.succeed(
-          compressedBody(response, HttpBody.raw(readable.pipe(transform), { contentType: body.contentType }))
+          compressedBody(
+            response,
+            HttpBody.raw(readable.pipe(transform), {
+              contentType: response.headers["content-type"] ?? body.contentType
+            })
+          )
         )
       }
       default: {

--- a/packages/platform/node/test/NodeHttpCompression.test.ts
+++ b/packages/platform/node/test/NodeHttpCompression.test.ts
@@ -50,6 +50,28 @@ const get = (
 ) => handler(new Request("http://localhost/", headers === undefined ? {} : { headers }))
 
 describe("NodeHttpCompression", () => {
+  for (
+    const [name, makeResponse] of [
+      ["Stream", () => HttpServerResponse.stream(Stream.succeed(new TextEncoder().encode(bigJson)))],
+      ["Uint8Array", () => HttpServerResponse.uint8Array(new TextEncoder().encode(bigJson))]
+    ] as const
+  ) {
+    it(`preserves a Content-Type header override when compressing ${name} responses`, () => {
+      const original = HttpServerResponse.setHeader(makeResponse(), "content-type", "application/json")
+      assert.strictEqual(original.headers["content-type"], "application/json")
+      return withHandler(
+        Effect.succeed(original),
+        undefined,
+        async (handler) => {
+          const compressed = await get(handler, { "accept-encoding": "gzip" })
+          assert.strictEqual(compressed.headers.get("content-encoding"), "gzip")
+          assert.strictEqual(Zlib.gunzipSync(new Uint8Array(await compressed.arrayBuffer())).toString(), bigJson)
+          assert.strictEqual(compressed.headers.get("content-type"), original.headers["content-type"])
+        }
+      )
+    })
+  }
+
   it.effect("advertises supported algorithms", () =>
     Effect.gen(function*() {
       const platform = yield* HttpPlatform.HttpPlatform

--- a/packages/platform/node/test/NodeHttpCompression.test.ts
+++ b/packages/platform/node/test/NodeHttpCompression.test.ts
@@ -136,6 +136,32 @@ describe("NodeHttpCompression", () => {
     )
   })
 
+  it.effect("preserves the Content-Type of file responses when compressed with Brotli", () =>
+    Effect.gen(function*() {
+      const directory = Fs.mkdtempSync(Path.join(Os.tmpdir(), "effect-http-compression-"))
+      yield* Effect.addFinalizer(() => Effect.sync(() => Fs.rmSync(directory, { recursive: true })))
+      const path = Path.join(directory, "index.html")
+      const contents = `<!doctype html><html><body>${"<p>Hello world</p>".repeat(100)}</body></html>`
+      Fs.writeFileSync(path, contents)
+
+      yield* HttpRouter.add("GET", "/file", HttpServerResponse.file(path)).pipe(
+        (self) => HttpRouter.serve(self, { middleware: HttpMiddleware.compression() }),
+        Layer.build
+      )
+
+      const uncompressed = yield* HttpClient.get("/file", { headers: { "accept-encoding": "identity" } })
+      assert.strictEqual(uncompressed.status, 200)
+      assert.strictEqual(uncompressed.headers["content-encoding"], undefined)
+      assert.strictEqual(uncompressed.headers["content-type"], "text/html")
+      assert.strictEqual(yield* uncompressed.text, contents)
+
+      const compressed = yield* HttpClient.get("/file", { headers: { "accept-encoding": "br" } })
+      assert.strictEqual(compressed.status, 200)
+      assert.strictEqual(compressed.headers["content-encoding"], "br")
+      assert.strictEqual(yield* compressed.text, contents)
+      assert.strictEqual(compressed.headers["content-type"], uncompressed.headers["content-type"])
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)))
+
   it.effect("closes compressed file bodies for HEAD requests", () =>
     Effect.gen(function*() {
       const directory = Fs.mkdtempSync(Path.join(Os.tmpdir(), "effect-http-compression-"))


### PR DESCRIPTION
Compression could drop the Content-Type of file responses or replace an explicit header override with the body's original type. Preserve the response header when constructing compressed raw, stream, and byte-array bodies, falling back to the body's type when no header is present. This covers Node and the shared compression paths used by the web platform, Bun, and Deno.

Includes regressions for inferred HTML file types and header overrides, plus a patch changeset. Uncompressed Stream serialization is outside this change.

Validation: 81 focused Node/web tests, lint, and typecheck pass. Reviewer verification also passed the Bun suite (35 tests), Deno suite (235 passed, 11 skipped), and web compression tests under both runtimes (35 each).

Closes EFF-1328
Closes #8146
