### PR TITLE
Migrate Context.Service declarations and examples to class syntax

### DIFF
--- a/.changeset/class-service-declarations.md
+++ b/.changeset/class-service-declarations.md
@@ -1,0 +1,32 @@
+---
+"@effect/ai-anthropic": patch
+"@effect/ai-openai": patch
+"@effect/ai-openai-compat": patch
+"@effect/ai-openrouter": patch
+"@effect/atom-react": patch
+"@effect/atom-solid": patch
+"@effect/atom-vue": patch
+"@effect/openapi-generator": patch
+"@effect/platform-browser": patch
+"@effect/platform-bun": patch
+"@effect/platform-deno": patch
+"@effect/platform-node": patch
+"@effect/platform-node-shared": patch
+"@effect/sql-clickhouse": patch
+"@effect/sql-d1": patch
+"@effect/sql-libsql": patch
+"@effect/sql-mssql": patch
+"@effect/sql-mysql2": patch
+"@effect/sql-pg": patch
+"@effect/sql-pglite": patch
+"@effect/sql-sqlite-bun": patch
+"@effect/sql-sqlite-do": patch
+"@effect/sql-sqlite-node": patch
+"@effect/sql-sqlite-react-native": patch
+"@effect/sql-sqlite-wasm": patch
+"effect": patch
+---
+
+Use class syntax for Context.Service declarations throughout the core, unstable modules, platform services, SQL drivers, and examples. Service keys and runtime behavior are preserved, and the direct const form of Context.Service remains supported.
+
+This is a breaking type cleanup for the Effect 4 release candidate. Service class types now identify environment requirements; use `ServiceClass["Service"]` (or the accompanying `Service` namespace member) to annotate implementation values. Update interface inheritance to extend the service shape rather than the identifier.

--- a/packages/ai/anthropic/src/AnthropicClient.ts
+++ b/packages/ai/anthropic/src/AnthropicClient.ts
@@ -183,7 +183,9 @@ export type Options = {
    * Optional transformer for the underlying HTTP client, such as middleware, logging, or custom request/response
    * handling.
    */
-  readonly transformClient?: ((client: HttpClient.HttpClient) => HttpClient.HttpClient) | undefined
+  readonly transformClient?:
+    | ((client: HttpClient.HttpClient["Service"]) => HttpClient.HttpClient["Service"])
+    | undefined
 }
 
 // =============================================================================
@@ -413,7 +415,9 @@ export const layerConfig = (options?: {
    * Optional transformer for the underlying HTTP client, such as middleware, logging, or custom request/response
    * handling.
    */
-  readonly transformClient?: ((client: HttpClient.HttpClient) => HttpClient.HttpClient) | undefined
+  readonly transformClient?:
+    | ((client: HttpClient.HttpClient["Service"]) => HttpClient.HttpClient["Service"])
+    | undefined
 }): Layer.Layer<AnthropicClient, Config.ConfigError, HttpClient.HttpClient> =>
   Layer.effect(
     AnthropicClient,

--- a/packages/ai/anthropic/src/AnthropicConfig.ts
+++ b/packages/ai/anthropic/src/AnthropicConfig.ts
@@ -56,7 +56,7 @@ export declare namespace AnthropicConfig {
    * @since 4.0.0
    */
   export interface Service {
-    readonly transformClient?: ((client: HttpClient) => HttpClient) | undefined
+    readonly transformClient?: ((client: HttpClient["Service"]) => HttpClient["Service"]) | undefined
   }
 }
 
@@ -72,11 +72,16 @@ export declare namespace AnthropicConfig {
  * @since 4.0.0
  */
 export const withClientTransform: {
-  (transform: (client: HttpClient) => HttpClient): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
-  <A, E, R>(self: Effect.Effect<A, E, R>, transform: (client: HttpClient) => HttpClient): Effect.Effect<A, E, R>
+  (
+    transform: (client: HttpClient["Service"]) => HttpClient["Service"]
+  ): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
+  <A, E, R>(
+    self: Effect.Effect<A, E, R>,
+    transform: (client: HttpClient["Service"]) => HttpClient["Service"]
+  ): Effect.Effect<A, E, R>
 } = dual(2, <A, E, R>(
   self: Effect.Effect<A, E, R>,
-  transformClient: (client: HttpClient) => HttpClient
+  transformClient: (client: HttpClient["Service"]) => HttpClient["Service"]
 ) =>
   Effect.flatMap(
     AnthropicConfig.getOrUndefined,

--- a/packages/ai/anthropic/src/Generated.ts
+++ b/packages/ai/anthropic/src/Generated.ts
@@ -11036,9 +11036,11 @@ export type WithOptionalResponse<A, Config extends OperationConfig> = Config ext
   A
 
 export const make = (
-  httpClient: HttpClient.HttpClient,
+  httpClient: HttpClient.HttpClient["Service"],
   options: {
-    readonly transformClient?: ((client: HttpClient.HttpClient) => Effect.Effect<HttpClient.HttpClient>) | undefined
+    readonly transformClient?:
+      | ((client: HttpClient.HttpClient["Service"]) => Effect.Effect<HttpClient.HttpClient["Service"]>)
+      | undefined
   } = {}
 ): AnthropicClient => {
   const unexpectedStatus = (response: HttpClientResponse.HttpClientResponse) =>
@@ -11772,7 +11774,7 @@ export const make = (
 }
 
 export interface AnthropicClient {
-  readonly httpClient: HttpClient.HttpClient
+  readonly httpClient: HttpClient.HttpClient["Service"]
   /**
    * Send a structured list of input messages with text and/or image content, and the model will generate the next message in the conversation.
    *

--- a/packages/ai/openai-compat/src/OpenAiClient.ts
+++ b/packages/ai/openai-compat/src/OpenAiClient.ts
@@ -38,7 +38,7 @@ import { OpenAiConfig } from "./OpenAiConfig.ts"
  * @since 4.0.0
  */
 export interface Service {
-  readonly client: HttpClient.HttpClient
+  readonly client: HttpClient.HttpClient["Service"]
   readonly createResponse: (
     options: CreateResponseRequestJson
   ) => Effect.Effect<
@@ -95,7 +95,9 @@ export type Options = {
   readonly apiUrl?: string | undefined
   readonly organizationId?: Redacted.Redacted<string> | undefined
   readonly projectId?: Redacted.Redacted<string> | undefined
-  readonly transformClient?: ((client: HttpClient.HttpClient) => HttpClient.HttpClient) | undefined
+  readonly transformClient?:
+    | ((client: HttpClient.HttpClient["Service"]) => HttpClient.HttpClient["Service"])
+    | undefined
 }
 
 const RedactedOpenAiHeaders = {
@@ -320,7 +322,9 @@ export const layerConfig = (options?: {
   readonly apiUrl?: Config.Config<string> | undefined
   readonly organizationId?: Config.Config<Redacted.Redacted<string> | undefined> | undefined
   readonly projectId?: Config.Config<Redacted.Redacted<string> | undefined> | undefined
-  readonly transformClient?: ((client: HttpClient.HttpClient) => HttpClient.HttpClient) | undefined
+  readonly transformClient?:
+    | ((client: HttpClient.HttpClient["Service"]) => HttpClient.HttpClient["Service"])
+    | undefined
 }): Layer.Layer<OpenAiClient, Config.ConfigError, HttpClient.HttpClient> =>
   Layer.effect(
     OpenAiClient,

--- a/packages/ai/openai-compat/src/OpenAiConfig.ts
+++ b/packages/ai/openai-compat/src/OpenAiConfig.ts
@@ -54,7 +54,7 @@ export declare namespace OpenAiConfig {
    * @since 4.0.0
    */
   export interface Service {
-    readonly transformClient?: ((client: HttpClient) => HttpClient) | undefined
+    readonly transformClient?: ((client: HttpClient["Service"]) => HttpClient["Service"]) | undefined
   }
 }
 
@@ -75,11 +75,16 @@ export declare namespace OpenAiConfig {
  * @since 4.0.0
  */
 export const withClientTransform: {
-  (transform: (client: HttpClient) => HttpClient): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
-  <A, E, R>(self: Effect.Effect<A, E, R>, transform: (client: HttpClient) => HttpClient): Effect.Effect<A, E, R>
+  (
+    transform: (client: HttpClient["Service"]) => HttpClient["Service"]
+  ): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
+  <A, E, R>(
+    self: Effect.Effect<A, E, R>,
+    transform: (client: HttpClient["Service"]) => HttpClient["Service"]
+  ): Effect.Effect<A, E, R>
 } = dual(2, <A, E, R>(
   self: Effect.Effect<A, E, R>,
-  transformClient: (client: HttpClient) => HttpClient
+  transformClient: (client: HttpClient["Service"]) => HttpClient["Service"]
 ) =>
   Effect.flatMap(
     OpenAiConfig.getOrUndefined,

--- a/packages/ai/openai/src/Generated.ts
+++ b/packages/ai/openai/src/Generated.ts
@@ -30395,9 +30395,11 @@ export type WithOptionalResponse<A, Config extends OperationConfig> = Config ext
   A
 
 export const make = (
-  httpClient: HttpClient.HttpClient,
+  httpClient: HttpClient.HttpClient["Service"],
   options: {
-    readonly transformClient?: ((client: HttpClient.HttpClient) => Effect.Effect<HttpClient.HttpClient>) | undefined
+    readonly transformClient?:
+      | ((client: HttpClient.HttpClient["Service"]) => Effect.Effect<HttpClient.HttpClient["Service"]>)
+      | undefined
   } = {}
 ): OpenAiClient => {
   const unexpectedStatus = (response: HttpClientResponse.HttpClientResponse) =>
@@ -32764,7 +32766,7 @@ export const make = (
 }
 
 export interface OpenAiClient {
-  readonly httpClient: HttpClient.HttpClient
+  readonly httpClient: HttpClient.HttpClient["Service"]
   /**
    * Returns a list of assistants.
    */

--- a/packages/ai/openai/src/OpenAiClient.ts
+++ b/packages/ai/openai/src/OpenAiClient.ts
@@ -54,7 +54,7 @@ export interface Service {
   /**
    * The transformed HTTP client used by this service.
    */
-  readonly client: HttpClient.HttpClient
+  readonly client: HttpClient.HttpClient["Service"]
 
   /**
    * Create a response using the OpenAI responses endpoint.
@@ -146,7 +146,9 @@ export type Options = {
   /**
    * Optional transformer for the HTTP client.
    */
-  readonly transformClient?: ((client: HttpClient.HttpClient) => HttpClient.HttpClient) | undefined
+  readonly transformClient?:
+    | ((client: HttpClient.HttpClient["Service"]) => HttpClient.HttpClient["Service"])
+    | undefined
 }
 
 // =============================================================================
@@ -400,7 +402,9 @@ export const layerConfig = (options?: {
   /**
    * Optional transformer for the HTTP client.
    */
-  readonly transformClient?: ((client: HttpClient.HttpClient) => HttpClient.HttpClient) | undefined
+  readonly transformClient?:
+    | ((client: HttpClient.HttpClient["Service"]) => HttpClient.HttpClient["Service"])
+    | undefined
 }): Layer.Layer<OpenAiClient, Config.ConfigError, HttpClient.HttpClient> =>
   Layer.effect(
     OpenAiClient,

--- a/packages/ai/openai/src/OpenAiClientGenerated.ts
+++ b/packages/ai/openai/src/OpenAiClientGenerated.ts
@@ -66,7 +66,9 @@ export type Options = {
   /**
    * Optional transformer for the HTTP client.
    */
-  readonly transformClient?: ((client: HttpClient.HttpClient) => HttpClient.HttpClient) | undefined
+  readonly transformClient?:
+    | ((client: HttpClient.HttpClient["Service"]) => HttpClient.HttpClient["Service"])
+    | undefined
 }
 
 const RedactedOpenAiHeaders = {
@@ -176,7 +178,9 @@ export const layerConfig = (options?: {
   /**
    * Optional transformer for the HTTP client.
    */
-  readonly transformClient?: ((client: HttpClient.HttpClient) => HttpClient.HttpClient) | undefined
+  readonly transformClient?:
+    | ((client: HttpClient.HttpClient["Service"]) => HttpClient.HttpClient["Service"])
+    | undefined
 }): Layer.Layer<OpenAiClientGenerated, Config.ConfigError, HttpClient.HttpClient> =>
   Layer.effect(
     OpenAiClientGenerated,

--- a/packages/ai/openai/src/OpenAiConfig.ts
+++ b/packages/ai/openai/src/OpenAiConfig.ts
@@ -53,7 +53,7 @@ export declare namespace OpenAiConfig {
    * @since 4.0.0
    */
   export interface Service {
-    readonly transformClient?: ((client: HttpClient) => HttpClient) | undefined
+    readonly transformClient?: ((client: HttpClient["Service"]) => HttpClient["Service"]) | undefined
   }
 }
 
@@ -81,11 +81,16 @@ export declare namespace OpenAiConfig {
  * @since 4.0.0
  */
 export const withClientTransform: {
-  (transform: (client: HttpClient) => HttpClient): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
-  <A, E, R>(self: Effect.Effect<A, E, R>, transform: (client: HttpClient) => HttpClient): Effect.Effect<A, E, R>
+  (
+    transform: (client: HttpClient["Service"]) => HttpClient["Service"]
+  ): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
+  <A, E, R>(
+    self: Effect.Effect<A, E, R>,
+    transform: (client: HttpClient["Service"]) => HttpClient["Service"]
+  ): Effect.Effect<A, E, R>
 } = dual(2, <A, E, R>(
   self: Effect.Effect<A, E, R>,
-  transformClient: (client: HttpClient) => HttpClient
+  transformClient: (client: HttpClient["Service"]) => HttpClient["Service"]
 ) =>
   Effect.flatMap(
     OpenAiConfig.getOrUndefined,

--- a/packages/ai/openrouter/src/Generated.ts
+++ b/packages/ai/openrouter/src/Generated.ts
@@ -32757,9 +32757,11 @@ export type WithOptionalResponse<A, Config extends OperationConfig> = Config ext
   A
 
 export const make = (
-  httpClient: HttpClient.HttpClient,
+  httpClient: HttpClient.HttpClient["Service"],
   options: {
-    readonly transformClient?: ((client: HttpClient.HttpClient) => Effect.Effect<HttpClient.HttpClient>) | undefined
+    readonly transformClient?:
+      | ((client: HttpClient.HttpClient["Service"]) => Effect.Effect<HttpClient.HttpClient["Service"]>)
+      | undefined
   } = {}
 ): OpenRouterClient => {
   const unexpectedStatus = (response: HttpClientResponse.HttpClientResponse) =>
@@ -34544,7 +34546,7 @@ export const make = (
 }
 
 export interface OpenRouterClient {
-  readonly httpClient: HttpClient.HttpClient
+  readonly httpClient: HttpClient.HttpClient["Service"]
   /**
    * Returns user activity data grouped by endpoint for the last 30 (completed) UTC days. [Management key](/docs/guides/overview/auth/management-api-keys) required.
    */

--- a/packages/ai/openrouter/src/OpenRouterClient.ts
+++ b/packages/ai/openrouter/src/OpenRouterClient.ts
@@ -130,7 +130,9 @@ export type Options = {
    *
    * Use to add middleware, logging, or custom request/response handling.
    */
-  readonly transformClient?: ((client: HttpClient.HttpClient) => HttpClient.HttpClient) | undefined
+  readonly transformClient?:
+    | ((client: HttpClient.HttpClient["Service"]) => HttpClient.HttpClient["Service"])
+    | undefined
 }
 
 // =============================================================================
@@ -326,7 +328,9 @@ export const layerConfig = (options?: {
   /**
    * Optional transformer for the HTTP client.
    */
-  readonly transformClient?: ((client: HttpClient.HttpClient) => HttpClient.HttpClient) | undefined
+  readonly transformClient?:
+    | ((client: HttpClient.HttpClient["Service"]) => HttpClient.HttpClient["Service"])
+    | undefined
 }): Layer.Layer<OpenRouterClient, Config.ConfigError, HttpClient.HttpClient> =>
   Layer.effect(
     OpenRouterClient,

--- a/packages/ai/openrouter/src/OpenRouterConfig.ts
+++ b/packages/ai/openrouter/src/OpenRouterConfig.ts
@@ -54,7 +54,7 @@ export declare namespace OpenRouterConfig {
    * @since 4.0.0
    */
   export interface Service {
-    readonly transformClient?: ((client: HttpClient) => HttpClient) | undefined
+    readonly transformClient?: ((client: HttpClient["Service"]) => HttpClient["Service"]) | undefined
   }
 }
 
@@ -84,11 +84,21 @@ export declare namespace OpenRouterConfig {
  * @since 4.0.0
  */
 export const withClientTransform: {
-  (transform: (client: HttpClient) => HttpClient): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
-  <A, E, R>(self: Effect.Effect<A, E, R>, transform: (client: HttpClient) => HttpClient): Effect.Effect<A, E, R>
+  (
+    transform: (client: HttpClient["Service"]) => HttpClient["Service"]
+  ): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
+  <A, E, R>(
+    self: Effect.Effect<A, E, R>,
+    transform: (client: HttpClient["Service"]) => HttpClient["Service"]
+  ): Effect.Effect<A, E, R>
 } = dual<
-  (transform: (client: HttpClient) => HttpClient) => <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>,
-  <A, E, R>(self: Effect.Effect<A, E, R>, transform: (client: HttpClient) => HttpClient) => Effect.Effect<A, E, R>
+  (
+    transform: (client: HttpClient["Service"]) => HttpClient["Service"]
+  ) => <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>,
+  <A, E, R>(
+    self: Effect.Effect<A, E, R>,
+    transform: (client: HttpClient["Service"]) => HttpClient["Service"]
+  ) => Effect.Effect<A, E, R>
 >(
   2,
   (self, transformClient) =>

--- a/packages/atom/react/src/Hooks.ts
+++ b/packages/atom/react/src/Hooks.ts
@@ -24,9 +24,9 @@ interface AtomStore<A> {
   readonly getServerSnapshot: () => A
 }
 
-const storeRegistry = new WeakMap<AtomRegistry.AtomRegistry, WeakMap<Atom.Atom<any>, AtomStore<any>>>()
+const storeRegistry = new WeakMap<AtomRegistry.AtomRegistry["Service"], WeakMap<Atom.Atom<any>, AtomStore<any>>>()
 
-function makeStore<A>(registry: AtomRegistry.AtomRegistry, atom: Atom.Atom<A>): AtomStore<A> {
+function makeStore<A>(registry: AtomRegistry.AtomRegistry["Service"], atom: Atom.Atom<A>): AtomStore<A> {
   let stores = storeRegistry.get(registry)
   if (stores === undefined) {
     stores = new WeakMap()
@@ -51,13 +51,13 @@ function makeStore<A>(registry: AtomRegistry.AtomRegistry, atom: Atom.Atom<A>): 
   return newStore
 }
 
-function useStore<A>(registry: AtomRegistry.AtomRegistry, atom: Atom.Atom<A>): A {
+function useStore<A>(registry: AtomRegistry.AtomRegistry["Service"], atom: Atom.Atom<A>): A {
   const store = makeStore(registry, atom)
 
   return React.useSyncExternalStore(store.subscribe, store.snapshot, store.getServerSnapshot)
 }
 
-const initialValuesSet = new WeakMap<AtomRegistry.AtomRegistry, WeakSet<Atom.Atom<any>>>()
+const initialValuesSet = new WeakMap<AtomRegistry.AtomRegistry["Service"], WeakSet<Atom.Atom<any>>>()
 
 /**
  * Seeds initial atom values in the current React atom registry.
@@ -122,12 +122,12 @@ export const useAtomValue: {
   return useStore(registry, atom)
 }
 
-function mountAtom<A>(registry: AtomRegistry.AtomRegistry, atom: Atom.Atom<A>): void {
+function mountAtom<A>(registry: AtomRegistry.AtomRegistry["Service"], atom: Atom.Atom<A>): void {
   React.useEffect(() => registry.mount(atom), [atom, registry])
 }
 
 function setAtom<R, W, Mode extends "value" | "promise" | "promiseExit" = never>(
-  registry: AtomRegistry.AtomRegistry,
+  registry: AtomRegistry.AtomRegistry["Service"],
   atom: Atom.Writable<R, W>,
   options?: {
     readonly mode?: ([R] extends [AsyncResult.AsyncResult<any, any>] ? Mode : "value") | undefined
@@ -294,17 +294,17 @@ export const useAtom = <R, W, const Mode extends "value" | "promise" | "promiseE
 
 const atomPromiseMap = {
   suspendOnWaiting: new WeakMap<
-    AtomRegistry.AtomRegistry,
+    AtomRegistry.AtomRegistry["Service"],
     WeakMap<Atom.Atom<any>, Promise<void>>
   >(),
   default: new WeakMap<
-    AtomRegistry.AtomRegistry,
+    AtomRegistry.AtomRegistry["Service"],
     WeakMap<Atom.Atom<any>, Promise<void>>
   >()
 }
 
 function atomToPromise<A, E>(
-  registry: AtomRegistry.AtomRegistry,
+  registry: AtomRegistry.AtomRegistry["Service"],
   atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>,
   suspendOnWaiting: boolean
 ) {
@@ -333,7 +333,7 @@ function atomToPromise<A, E>(
 }
 
 function atomResultOrSuspend<A, E>(
-  registry: AtomRegistry.AtomRegistry,
+  registry: AtomRegistry.AtomRegistry["Service"],
   atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>,
   suspendOnWaiting: boolean
 ) {

--- a/packages/atom/react/src/RegistryContext.ts
+++ b/packages/atom/react/src/RegistryContext.ts
@@ -41,7 +41,7 @@ export function scheduleTask(f: () => void): () => void {
  * @category context
  * @since 4.0.0
  */
-export const RegistryContext = React.createContext<AtomRegistry.AtomRegistry>(AtomRegistry.make({
+export const RegistryContext = React.createContext<AtomRegistry.AtomRegistry["Service"]>(AtomRegistry.make({
   scheduleTask,
   defaultIdleTTL: 400
 }))
@@ -80,7 +80,7 @@ export const RegistryProvider = (options: {
   readonly defaultIdleTTL?: number | undefined
 }) => {
   const ref = React.useRef<{
-    readonly registry: AtomRegistry.AtomRegistry
+    readonly registry: AtomRegistry.AtomRegistry["Service"]
     timeout?: number | undefined
   }>(null)
   if (ref.current === null) {

--- a/packages/atom/solid/src/Hooks.ts
+++ b/packages/atom/solid/src/Hooks.ts
@@ -17,7 +17,7 @@ import type { Accessor, ResourceOptions, ResourceReturn } from "solid-js"
 import { createComputed, createEffect, createMemo, createResource, createSignal, onCleanup, useContext } from "solid-js"
 import { RegistryContext } from "./RegistryContext.ts"
 
-const initialValuesSet = new WeakMap<AtomRegistry.AtomRegistry, WeakSet<Atom.Atom<any>>>()
+const initialValuesSet = new WeakMap<AtomRegistry.AtomRegistry["Service"], WeakSet<Atom.Atom<any>>>()
 
 /**
  * Seeds initial atom values in the current Solid atom registry.
@@ -66,7 +66,7 @@ export const useAtomValue: {
   return createAtomAccessor(registry, f ? () => Atom.map(atom(), f) : atom)
 }
 
-function createAtomAccessor<A>(registry: AtomRegistry.AtomRegistry, atom: () => Atom.Atom<A>): Accessor<A> {
+function createAtomAccessor<A>(registry: AtomRegistry.AtomRegistry["Service"], atom: () => Atom.Atom<A>): Accessor<A> {
   const [value, setValue] = createSignal<A>(null as any)
   createComputed(() => {
     onCleanup(registry.subscribe(atom(), setValue as any, constImmediate))
@@ -76,14 +76,14 @@ function createAtomAccessor<A>(registry: AtomRegistry.AtomRegistry, atom: () => 
 
 const constImmediate = { immediate: true }
 
-function mountAtom<A>(registry: AtomRegistry.AtomRegistry, atom: () => Atom.Atom<A>): void {
+function mountAtom<A>(registry: AtomRegistry.AtomRegistry["Service"], atom: () => Atom.Atom<A>): void {
   createComputed(() => {
     onCleanup(registry.mount(atom()))
   })
 }
 
 function setAtom<R, W, Mode extends "value" | "promise" | "promiseExit" = never>(
-  registry: AtomRegistry.AtomRegistry,
+  registry: AtomRegistry.AtomRegistry["Service"],
   atom: () => Atom.Writable<R, W>,
   options?: {
     readonly mode?: ([R] extends [AsyncResult.AsyncResult<any, any>] ? Mode : "value") | undefined

--- a/packages/atom/solid/src/RegistryContext.ts
+++ b/packages/atom/solid/src/RegistryContext.ts
@@ -29,7 +29,7 @@ import { createComponent, createContext, onCleanup } from "solid-js"
  * @category context
  * @since 4.0.0
  */
-export const RegistryContext = createContext<AtomRegistry.AtomRegistry>(AtomRegistry.make())
+export const RegistryContext = createContext<AtomRegistry.AtomRegistry["Service"]>(AtomRegistry.make())
 
 /**
  * Creates an `AtomRegistry` for a Solid subtree, optionally seeding initial atom

--- a/packages/atom/vue/src/index.ts
+++ b/packages/atom/vue/src/index.ts
@@ -50,19 +50,21 @@ export * as AtomRpc from "effect/unstable/reactivity/AtomRpc"
  * @since 4.0.0
  * @category symbols
  */
-export const registryKey = Symbol.for("@effect/atom-vue/registryKey") as InjectionKey<AtomRegistry.AtomRegistry>
+export const registryKey = Symbol.for("@effect/atom-vue/registryKey") as InjectionKey<
+  AtomRegistry.AtomRegistry["Service"]
+>
 
 /**
  * @since 4.0.0
  * @category constants
  */
-export const defaultRegistry: AtomRegistry.AtomRegistry = AtomRegistry.make()
+export const defaultRegistry: AtomRegistry.AtomRegistry["Service"] = AtomRegistry.make()
 
 /**
  * @since 4.0.0
  * @category accessors
  */
-export const injectRegistry = (): AtomRegistry.AtomRegistry => {
+export const injectRegistry = (): AtomRegistry.AtomRegistry["Service"] => {
   return inject(registryKey, defaultRegistry)
 }
 
@@ -113,7 +115,7 @@ const flattenExit = <A, E>(exit: Exit.Exit<A, E>): A => {
 }
 
 function setAtom<R, W, Mode extends "value" | "promise" | "promiseExit" = never>(
-  registry: AtomRegistry.AtomRegistry,
+  registry: AtomRegistry.AtomRegistry["Service"],
   atomRef: ComputedRef<Atom.Writable<R, W>>,
   options?: {
     readonly mode?: ([R] extends [AsyncResult.AsyncResult<any, any>] ? Mode : "value") | undefined

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -284,7 +284,7 @@ const ChannelProto = {
 export const fromTransform = <OutElem, OutErr, OutDone, InElem, InErr, InDone, EX, EnvX, Env>(
   transform: (
     upstream: Pull.Pull<InElem, InErr, InDone>,
-    scope: Scope.Scope
+    scope: Scope.Scope["Service"]
   ) => Effect.Effect<Pull.Pull<OutElem, OutErr, OutDone, EnvX>, EX, Env>
 ): Channel<
   OutElem,
@@ -296,7 +296,7 @@ export const fromTransform = <OutElem, OutErr, OutDone, InElem, InErr, InDone, E
   Env | EnvX
 > => {
   const self = Object.create(ChannelProto)
-  self.transform = (upstream: any, scope: Scope.Scope) =>
+  self.transform = (upstream: any, scope: Scope.Scope["Service"]) =>
     Effect.catchCause(transform(upstream, scope), (cause) => Effect.succeed(Effect.failCause(cause)))
   return self
 }
@@ -343,7 +343,7 @@ export const transformPull = <
   self: Channel<OutElem, OutErr, OutDone, InElem, InErr, InDone, Env>,
   f: (
     pull: Pull.Pull<OutElem, OutErr, OutDone>,
-    scope: Scope.Scope
+    scope: Scope.Scope["Service"]
   ) => Effect.Effect<Pull.Pull<OutElem2, OutErr2, OutDone2, Env2>, OutErrX, EnvX>
 ): Channel<
   OutElem2,
@@ -400,8 +400,8 @@ export const fromPull = <OutElem, OutErr, OutDone, EX, EnvX, Env>(
 export const fromTransformBracket = <OutElem, OutErr, OutDone, InElem, InErr, InDone, EX, EnvX, Env>(
   f: (
     upstream: Pull.Pull<InElem, InErr, InDone>,
-    scope: Scope.Scope,
-    forkedScope: Scope.Scope
+    scope: Scope.Scope["Service"],
+    forkedScope: Scope.Scope["Service"]
   ) => Effect.Effect<Pull.Pull<OutElem, OutErr, OutDone, EnvX>, EX, Env>
 ): Channel<OutElem, Pull.ExcludeDone<OutErr> | EX, OutDone, InElem, InErr, InDone, Env | EnvX> =>
   fromTransform(
@@ -438,7 +438,7 @@ export const toTransform = <OutElem, OutErr, OutDone, InElem, InErr, InDone, Env
   channel: Channel<OutElem, OutErr, OutDone, InElem, InErr, InDone, Env>
 ): (
   upstream: Pull.Pull<InElem, InErr, InDone>,
-  scope: Scope.Scope
+  scope: Scope.Scope["Service"]
 ) => Effect.Effect<Pull.Pull<OutElem, OutErr, OutDone>, never, Env> => (channel as any).transform
 
 /**
@@ -458,7 +458,7 @@ export const toTransform = <OutElem, OutErr, OutDone, InElem, InErr, InDone, Env
 export const DefaultChunkSize: number = 4096
 
 const asyncQueue = <A, E = never, R = never>(
-  scope: Scope.Scope,
+  scope: Scope.Scope["Service"],
   f: (queue: Queue.Queue<A, E | Cause.Done>) => Effect.Effect<unknown, E, R | Scope.Scope>,
   options?: {
     readonly bufferSize?: number | undefined
@@ -1829,7 +1829,7 @@ export const fromTransformStream = <IE, I, O, E>(options: {
   })
 
 const readableStreamToPullUnsafe = <A, E, E2 = never>(options: {
-  readonly scope: Scope.Scope
+  readonly scope: Scope.Scope["Service"]
   readonly exit?: MutableRef.MutableRef<Exit.Exit<never, E | E2 | Cause.Done> | undefined> | undefined
   readonly readable: ReadableStream<A>
   readonly onError: (error: unknown) => E
@@ -8408,7 +8408,7 @@ export const toPull: <OutElem, OutErr, OutDone, Env>(
  */
 export const toPullScoped = <OutElem, OutErr, OutDone, Env>(
   self: Channel<OutElem, OutErr, OutDone, unknown, unknown, unknown, Env>,
-  scope: Scope.Scope
+  scope: Scope.Scope["Service"]
 ): Effect.Effect<Pull.Pull<OutElem, OutErr, OutDone, Env>, never, Env> => toTransform(self)(Cause.done(), scope)
 
 /**

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -83,9 +83,7 @@ export interface Key<out Identifier, out Shape> extends Effect<Shape, never, Ide
  * import { Context } from "effect"
  *
  * // Define an identifier for a database service
- * const Database = Context.Service<{ query: (sql: string) => string }>(
- *   "Database"
- * )
+ * class Database extends Context.Service<Database, { query: (sql: string) => string }>()("Database") {}
  *
  * // The key can be used to store and retrieve services
  * const context = Context.make(Database, { query: (sql) => `Result: ${sql}` })
@@ -347,9 +345,9 @@ export interface Reference<in out Shape> extends Service<never, Shape> {
  * ```ts import.meta.vitest
  * import { Context } from "effect"
  *
- * const Database = Context.Service<{
+ * class Database extends Context.Service<Database, {
  *   query: (sql: string) => string
- * }>("Database")
+ * }>()("Database") {}
  *
  * // Extract service type from a key
  * type DatabaseService = Context.Service.Shape<typeof Database>
@@ -373,10 +371,9 @@ export declare namespace Service {
    * import { Context } from "effect"
    *
    * // Any represents any possible service type
-   * const services: Array<Context.Service.Any> = [
-   *   Context.Service<{ log: (msg: string) => void }>("Logger"),
-   *   Context.Service<{ query: (sql: string) => string }>("Database")
-   * ]
+   * class Logger extends Context.Service<Logger, { log: (msg: string) => void }>()("Logger") {}
+   * class Database extends Context.Service<Database, { query: (sql: string) => string }>()("Database") {}
+   * const services: Array<Context.Service.Any> = [Logger, Database]
    * services.map((service) => service.key) // => ["Logger", "Database"]
    * ```
    *
@@ -394,9 +391,7 @@ export declare namespace Service {
    * ```ts import.meta.vitest
    * import { Context } from "effect"
    *
-   * const Database = Context.Service<{ query: (sql: string) => string }>(
-   *   "Database"
-   * )
+   * class Database extends Context.Service<Database, { query: (sql: string) => string }>()("Database") {}
    *
    * // Extract the service shape from the service
    * type DatabaseService = Context.Service.Shape<typeof Database>
@@ -418,9 +413,7 @@ export declare namespace Service {
    * ```ts import.meta.vitest
    * import { Context } from "effect"
    *
-   * const Database = Context.Service<{ query: (sql: string) => string }>(
-   *   "Database"
-   * )
+   * class Database extends Context.Service<Database, { query: (sql: string) => string }>()("Database") {}
    *
    * // Extract the identifier type from a key
    * type DatabaseId = Context.Service.Identifier<typeof Database>
@@ -451,10 +444,8 @@ const TypeId = "~effect/Context" as const
  * import { Context } from "effect"
  *
  * // Create a context with multiple services
- * const Logger = Context.Service<{ log: (msg: string) => void }>("Logger")
- * const Database = Context.Service<{ query: (sql: string) => string }>(
- *   "Database"
- * )
+ * class Logger extends Context.Service<Logger, { log: (msg: string) => void }>()("Logger") {}
+ * class Database extends Context.Service<Database, { query: (sql: string) => string }>()("Database") {}
  *
  * const context = Context.make(Logger, { log: (_msg: string) => {} })
  *   .pipe(Context.add(Database, { query: (sql) => `Result: ${sql}` }))
@@ -711,7 +702,7 @@ const emptyContext = makeUnsafe(new Map())
  * ```ts import.meta.vitest
  * import { Context } from "effect"
  *
- * const Port = Context.Service<{ PORT: number }>("Port")
+ * class Port extends Context.Service<Port, { PORT: number }>()("Port") {}
  *
  * const context = Context.make(Port, { PORT: 8080 })
  *
@@ -743,8 +734,8 @@ export const make = <I, S>(
  * ```ts import.meta.vitest
  * import { Context, pipe } from "effect"
  *
- * const Port = Context.Service<{ PORT: number }>("Port")
- * const Timeout = Context.Service<{ TIMEOUT: number }>("Timeout")
+ * class Port extends Context.Service<Port, { PORT: number }>()("Port") {}
+ * class Timeout extends Context.Service<Timeout, { TIMEOUT: number }>()("Timeout") {}
  *
  * const someContext = Context.make(Port, { PORT: 8080 })
  *
@@ -824,7 +815,7 @@ export const addUnsafe = <Services, I, S>(
  * ```ts import.meta.vitest
  * import { Context, Option } from "effect"
  *
- * const Port = Context.Service<{ PORT: number }>("Port")
+ * class Port extends Context.Service<Port, { PORT: number }>()("Port") {}
  *
  * const withPort = Context.empty().pipe(
  *   Context.addOrOmit(Port, Option.some({ PORT: 8080 }))
@@ -885,10 +876,8 @@ export const addOrOmit: {
  * ```ts import.meta.vitest
  * import { Context } from "effect"
  *
- * const Logger = Context.Service<{ log: (msg: string) => void }>("Logger")
- * const Database = Context.Service<{ query: (sql: string) => string }>(
- *   "Database"
- * )
+ * class Logger extends Context.Service<Logger, { log: (msg: string) => void }>()("Logger") {}
+ * class Database extends Context.Service<Database, { query: (sql: string) => string }>()("Database") {}
  *
  * const context = Context.make(Logger, { log: (_msg: string) => {} })
  *
@@ -970,8 +959,8 @@ export const getOrUndefinedUnsafe = <A, Services = never>(self: Context<Services
  * ```ts import.meta.vitest
  * import { Context, Option } from "effect"
  *
- * const Port = Context.Service<{ PORT: number }>("Port")
- * const Timeout = Context.Service<{ TIMEOUT: number }>("Timeout")
+ * class Port extends Context.Service<Port, { PORT: number }>()("Port") {}
+ * class Timeout extends Context.Service<Timeout, { TIMEOUT: number }>()("Timeout") {}
  *
  * const context = Context.make(Port, { PORT: 8080 })
  *
@@ -1013,8 +1002,8 @@ export const getUnsafe: {
  * ```ts import.meta.vitest
  * import { Context, pipe } from "effect"
  *
- * const Port = Context.Service<{ PORT: number }>("Port")
- * const Timeout = Context.Service<{ TIMEOUT: number }>("Timeout")
+ * class Port extends Context.Service<Port, { PORT: number }>()("Port") {}
+ * class Timeout extends Context.Service<Timeout, { TIMEOUT: number }>()("Timeout") {}
  *
  * const context = pipe(
  *   Context.make(Port, { PORT: 8080 }),
@@ -1076,8 +1065,8 @@ const serviceNotFoundError = (service: Key<any, any>) => {
  * ```ts import.meta.vitest
  * import { Context, Option } from "effect"
  *
- * const Port = Context.Service<{ PORT: number }>("Port")
- * const Timeout = Context.Service<{ TIMEOUT: number }>("Timeout")
+ * class Port extends Context.Service<Port, { PORT: number }>()("Port") {}
+ * class Timeout extends Context.Service<Timeout, { TIMEOUT: number }>()("Timeout") {}
  *
  * const context = Context.make(Port, { PORT: 8080 })
  *
@@ -1116,8 +1105,8 @@ export const getOption: {
  * ```ts import.meta.vitest
  * import { Context } from "effect"
  *
- * const Port = Context.Service<{ PORT: number }>("Port")
- * const Timeout = Context.Service<{ TIMEOUT: number }>("Timeout")
+ * class Port extends Context.Service<Port, { PORT: number }>()("Port") {}
+ * class Timeout extends Context.Service<Timeout, { TIMEOUT: number }>()("Timeout") {}
  *
  * const firstContext = Context.make(Port, { PORT: 8080 })
  * const secondContext = Context.make(Timeout, { TIMEOUT: 5000 })
@@ -1159,9 +1148,9 @@ export const merge: {
  * ```ts import.meta.vitest
  * import { Context } from "effect"
  *
- * const Port = Context.Service<{ PORT: number }>("Port")
- * const Timeout = Context.Service<{ TIMEOUT: number }>("Timeout")
- * const Host = Context.Service<{ HOST: string }>("Host")
+ * class Port extends Context.Service<Port, { PORT: number }>()("Port") {}
+ * class Timeout extends Context.Service<Timeout, { TIMEOUT: number }>()("Timeout") {}
+ * class Host extends Context.Service<Host, { HOST: string }>()("Host") {}
  *
  * const firstContext = Context.make(Port, { PORT: 8080 })
  * const secondContext = Context.make(Timeout, { TIMEOUT: 5000 })
@@ -1205,8 +1194,8 @@ export const mergeAll = <T extends Array<unknown>>(
  * ```ts import.meta.vitest
  * import { Context, Option, pipe } from "effect"
  *
- * const Port = Context.Service<{ PORT: number }>("Port")
- * const Timeout = Context.Service<{ TIMEOUT: number }>("Timeout")
+ * class Port extends Context.Service<Port, { PORT: number }>()("Port") {}
+ * class Timeout extends Context.Service<Timeout, { TIMEOUT: number }>()("Timeout") {}
  *
  * const someContext = pipe(
  *   Context.make(Port, { PORT: 8080 }),
@@ -1247,8 +1236,8 @@ export const pick = <S extends ReadonlyArray<Key<any, any>>>(
  * ```ts import.meta.vitest
  * import { Context, Option, pipe } from "effect"
  *
- * const Port = Context.Service<{ PORT: number }>("Port")
- * const Timeout = Context.Service<{ TIMEOUT: number }>("Timeout")
+ * class Port extends Context.Service<Port, { PORT: number }>()("Port") {}
+ * class Timeout extends Context.Service<Timeout, { TIMEOUT: number }>()("Timeout") {}
  *
  * const someContext = pipe(
  *   Context.make(Port, { PORT: 8080 }),

--- a/packages/effect/src/Crypto.ts
+++ b/packages/effect/src/Crypto.ts
@@ -74,84 +74,92 @@ export type DigestAlgorithm = "SHA-1" | "SHA-256" | "SHA-384" | "SHA-512"
  * @category services
  * @since 4.0.0
  */
-export interface Crypto {
-  readonly [TypeId]: typeof TypeId
-
+export declare namespace Crypto {
   /**
-   * Generates a random integer in the range Number.MIN_SAFE_INTEGER to
-   * Number.MAX_SAFE_INTEGER (both inclusive).
-   */
-  nextIntUnsafe(): number
-
-  /**
-   * Generates a random number in the range 0 (inclusive) to 1 (exclusive).
-   */
-  nextDoubleUnsafe(): number
-
-  /**
-   * Generates cryptographically secure random bytes.
-   */
-  randomBytes(size: number): Effect.Effect<Uint8Array, PlatformError.PlatformError>
-
-  /**
-   * Computes a cryptographic digest for the supplied data.
-   */
-  digest(
-    algorithm: DigestAlgorithm,
-    data: Uint8Array
-  ): Effect.Effect<Uint8Array, PlatformError.PlatformError>
-
-  /**
-   * Generates a cryptographically secure random number between 0 (inclusive)
-   * and 1 (exclusive).
-   */
-  readonly random: Effect.Effect<number>
-
-  /**
-   * Generates a cryptographically secure random boolean.
-   */
-  readonly randomBoolean: Effect.Effect<boolean>
-
-  /**
-   * Generates a cryptographically secure random integer between
-   * `Number.MIN_SAFE_INTEGER` and `Number.MAX_SAFE_INTEGER` (both inclusive).
-   */
-  readonly randomInt: Effect.Effect<number>
-
-  /**
-   * Generates a cryptographically secure random number between `min`
-   * (inclusive) and `max` (exclusive).
-   */
-  randomBetween(min: number, max: number): Effect.Effect<number>
-
-  /**
-   * Generates a cryptographically secure random integer between `min` and `max`.
+   * Implementation of the Crypto service.
    *
-   * **Details**
-   *
-   * The lower bound is rounded up with `Math.ceil` and the upper bound is
-   * rounded down with `Math.floor`. By default the range is inclusive; set
-   * `options.halfOpen: true` to exclude the upper bound.
+   * @category models
+   * @since 4.0.0
    */
-  randomIntBetween(min: number, max: number, options?: {
-    readonly halfOpen?: boolean | undefined
-  }): Effect.Effect<number>
+  export interface Service {
+    readonly [TypeId]: typeof TypeId
 
-  /**
-   * Uses the cryptographically secure random generator to shuffle the supplied
-   * iterable.
-   */
-  randomShuffle<A>(elements: Iterable<A>): Effect.Effect<Array<A>>
+    /**
+     * Generates a random integer in the range Number.MIN_SAFE_INTEGER to
+     * Number.MAX_SAFE_INTEGER (both inclusive).
+     */
+    nextIntUnsafe(): number
 
-  /**
-   * Generates a cryptographically secure UUIDv4 string.
-   */
-  readonly randomUUIDv4: Effect.Effect<string, PlatformError.PlatformError>
+    /**
+     * Generates a random number in the range 0 (inclusive) to 1 (exclusive).
+     */
+    nextDoubleUnsafe(): number
 
-  /**
-   * Generates a cryptographically secure UUIDv7 string.
-   */
-  readonly randomUUIDv7: Effect.Effect<string, PlatformError.PlatformError>
+    /**
+     * Generates cryptographically secure random bytes.
+     */
+    randomBytes(size: number): Effect.Effect<Uint8Array, PlatformError.PlatformError>
+
+    /**
+     * Computes a cryptographic digest for the supplied data.
+     */
+    digest(
+      algorithm: DigestAlgorithm,
+      data: Uint8Array
+    ): Effect.Effect<Uint8Array, PlatformError.PlatformError>
+
+    /**
+     * Generates a cryptographically secure random number between 0 (inclusive)
+     * and 1 (exclusive).
+     */
+    readonly random: Effect.Effect<number>
+
+    /**
+     * Generates a cryptographically secure random boolean.
+     */
+    readonly randomBoolean: Effect.Effect<boolean>
+
+    /**
+     * Generates a cryptographically secure random integer between
+     * `Number.MIN_SAFE_INTEGER` and `Number.MAX_SAFE_INTEGER` (both inclusive).
+     */
+    readonly randomInt: Effect.Effect<number>
+
+    /**
+     * Generates a cryptographically secure random number between `min`
+     * (inclusive) and `max` (exclusive).
+     */
+    randomBetween(min: number, max: number): Effect.Effect<number>
+
+    /**
+     * Generates a cryptographically secure random integer between `min` and `max`.
+     *
+     * **Details**
+     *
+     * The lower bound is rounded up with `Math.ceil` and the upper bound is
+     * rounded down with `Math.floor`. By default the range is inclusive; set
+     * `options.halfOpen: true` to exclude the upper bound.
+     */
+    randomIntBetween(min: number, max: number, options?: {
+      readonly halfOpen?: boolean | undefined
+    }): Effect.Effect<number>
+
+    /**
+     * Uses the cryptographically secure random generator to shuffle the supplied
+     * iterable.
+     */
+    randomShuffle<A>(elements: Iterable<A>): Effect.Effect<Array<A>>
+
+    /**
+     * Generates a cryptographically secure UUIDv4 string.
+     */
+    readonly randomUUIDv4: Effect.Effect<string, PlatformError.PlatformError>
+
+    /**
+     * Generates a cryptographically secure UUIDv7 string.
+     */
+    readonly randomUUIDv7: Effect.Effect<string, PlatformError.PlatformError>
+  }
 }
 
 /**
@@ -172,7 +180,7 @@ export interface Crypto {
  * @category services
  * @since 4.0.0
  */
-export const Crypto: Context.Service<Crypto, Crypto> = Context.Service("effect/Crypto")
+export class Crypto extends Context.Service<Crypto, Crypto.Service>()("effect/Crypto") {}
 
 /**
  * Creates a `Crypto` service from the primitive implementation, deriving the
@@ -219,10 +227,11 @@ export const make = (
       data: Uint8Array
     ) => Effect.Effect<Uint8Array, PlatformError.PlatformError>
   }
-): Crypto => {
+): Crypto["Service"] => {
   const randomBytesUnsafe = impl.randomBytes
 
-  const randomBytes: Crypto["randomBytes"] = (size) => Effect.map(validateSize("randomBytes", size), randomBytesUnsafe)
+  const randomBytes: Crypto["Service"]["randomBytes"] = (size) =>
+    Effect.map(validateSize("randomBytes", size), randomBytesUnsafe)
 
   const readUint53 = (bytes: Uint8Array): number =>
     ((bytes[0] & 0x1f) * 2 ** 48) + (bytes[1] * 2 ** 40) + (bytes[2] * 2 ** 32) +

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -4330,7 +4330,7 @@ export const ignoreCause: <
  * ```ts import.meta.vitest
  * import { Context, Effect, ExecutionPlan, Layer } from "effect"
  *
- * const Endpoint = Context.Service<{ url: string }>("Endpoint")
+ * class Endpoint extends Context.Service<Endpoint, { url: string }>()("Endpoint") {}
  *
  * const fetchUrl = Effect.gen(function*() {
  *   const endpoint = yield* Effect.service(Endpoint)
@@ -4354,7 +4354,7 @@ export const ignoreCause: <
  * ```ts import.meta.vitest
  * import { Context, Effect, ExecutionPlan, Layer } from "effect"
  *
- * const Endpoint = Context.Service<{ url: string }>("Endpoint")
+ * class Endpoint extends Context.Service<Endpoint, { url: string }>()("Endpoint") {}
  *
  * const fetchUrl = Effect.gen(function*() {
  *   const endpoint = yield* Effect.service(Endpoint)
@@ -5747,12 +5747,12 @@ export const isSuccess: <A, E, R>(self: Effect<A, E, R>) => Effect<boolean, neve
  * import { Context, Effect, Option } from "effect"
  * const output: Array<unknown> = []
  *
- * const Logger = Context.Service<{
+ * class Logger extends Context.Service<Logger, {
  *   log: (msg: string) => void
- * }>("Logger")
- * const Database = Context.Service<{
+ * }>()("Logger") {}
+ * class Database extends Context.Service<Database, {
  *   query: (sql: string) => string
- * }>("Database")
+ * }>()("Database") {}
  *
  * const program = Effect.gen(function*() {
  *   const allServices = yield* Effect.context()
@@ -5800,12 +5800,12 @@ export const context: <R = never>() => Effect<Context.Context<R>, never, R> = in
  * import { Context, Effect, Option } from "effect"
  * const output: Array<unknown> = []
  *
- * const Logger = Context.Service<{
+ * class Logger extends Context.Service<Logger, {
  *   log: (msg: string) => void
- * }>("Logger")
- * const Cache = Context.Service<{
+ * }>()("Logger") {}
+ * class Cache extends Context.Service<Cache, {
  *   get: (key: string) => string | null
- * }>("Cache")
+ * }>()("Cache") {}
  *
  * const program = Effect.contextWith((services: Context.Context<Context.Service.Identifier<typeof Cache>>) => {
  *   const cacheOption = Context.getOption(services, Cache)
@@ -5852,11 +5852,11 @@ export const contextWith: <R, A, E, R2>(
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * interface Database {
+ * interface DatabaseShape {
  *   readonly query: (sql: string) => Effect.Effect<string>
  * }
  *
- * const Database = Context.Service<Database>("Database")
+ * class Database extends Context.Service<Database, DatabaseShape>()("Database") {}
  *
  * const DatabaseLayer = Layer.succeed(Database)({
  *   query: Effect.fn("Database.query")((sql: string) => Effect.succeed(`Result for: ${sql}`))
@@ -5939,12 +5939,12 @@ export const provide: {
  * const output: Array<unknown> = []
  *
  * // Define service keys
- * const Logger = Context.Service<{
+ * class Logger extends Context.Service<Logger, {
  *   log: (msg: string) => void
- * }>("Logger")
- * const Database = Context.Service<{
+ * }>()("Logger") {}
+ * class Database extends Context.Service<Database, {
  *   query: (sql: string) => string
- * }>("Database")
+ * }>()("Database") {}
  *
  * // Create a context with multiple services
  * const context = Context.make(Logger, { log: (message) => { output.push(message) } })
@@ -6030,11 +6030,11 @@ export const setContext: {
  * ```ts import.meta.vitest
  * import { Context, Effect } from "effect"
  *
- * interface Database {
+ * interface DatabaseShape {
  *   readonly query: (sql: string) => Effect.Effect<string>
  * }
  *
- * const Database = Context.Service<Database>("Database")
+ * class Database extends Context.Service<Database, DatabaseShape>()("Database") {}
  *
  * const program = Effect.gen(function*() {
  *   const db = yield* Effect.service(Database)
@@ -6074,9 +6074,9 @@ export const service: <I, S>(service: Context.Key<I, S>) => Effect<S, never, I> 
  * const output: Array<unknown> = []
  *
  * // Define a service key
- * const Logger = Context.Service<{
+ * class Logger extends Context.Service<Logger, {
  *   log: (msg: string) => void
- * }>("Logger")
+ * }>()("Logger") {}
  *
  * // Use serviceOption to optionally access the logger
  * const program = Effect.gen(function*() {
@@ -6112,12 +6112,12 @@ export const serviceOption: <I, S>(key: Context.Key<I, S>) => Effect<Option<S>> 
  * import { Context, Effect } from "effect"
  *
  * // Define services
- * const Logger = Context.Service<{
+ * class Logger extends Context.Service<Logger, {
  *   log: (msg: string) => void
- * }>("Logger")
- * const Config = Context.Service<{
+ * }>()("Logger") {}
+ * class Config extends Context.Service<Config, {
  *   name: string
- * }>("Config")
+ * }>()("Config") {}
  *
  * const program = Effect.service(Config).pipe(
  *   Effect.map((config) => `Hello ${config.name}!`)
@@ -6166,7 +6166,7 @@ export const updateContext: {
  * const output: Array<unknown> = []
  *
  * // Define a counter service
- * const Counter = Context.Service<{ count: number }>("Counter")
+ * class Counter extends Context.Service<Counter, { count: number }>()("Counter") {}
  *
  * const program = Effect.gen(function*() {
  *   const updatedCounter = yield* Effect.service(Counter)
@@ -6283,10 +6283,10 @@ export const updateServiceScoped: <I, A>(
  * const output: Array<unknown> = []
  *
  * // Define a service for configuration
- * const Config = Context.Service<{
+ * class Config extends Context.Service<Config, {
  *   apiUrl: string
  *   timeout: number
- * }>("Config")
+ * }>()("Config") {}
  *
  * const fetchData = Effect.gen(function*() {
  *   const config = yield* Effect.service(Config)
@@ -6354,7 +6354,7 @@ export const provideService: {
  * interface DatabaseConnection {
  *   readonly query: (sql: string) => Effect.Effect<string>
  * }
- * const Database = Context.Service<DatabaseConnection>("Database")
+ * class Database extends Context.Service<Database, DatabaseConnection>()("Database") {}
  *
  * // Effect that creates a database connection
  * const createConnection = Effect.gen(function*() {
@@ -6429,7 +6429,7 @@ export const provideServiceEffect: {
  * @category resource management
  * @since 2.0.0
  */
-export const scope: Effect<Scope, never, Scope> = internal.scope
+export const scope: Effect<Scope["Service"], never, Scope> = internal.scope
 
 /**
  * Runs an effect with a scope that closes when the effect completes.
@@ -6514,7 +6514,7 @@ export const scoped: <A, E, R>(
  * @since 3.11.0
  */
 export const scopedWith: <A, E, R>(
-  f: (scope: Scope) => Effect<A, E, R>
+  f: (scope: Scope["Service"]) => Effect<A, E, R>
 ) => Effect<A, E, R> = internal.scopedWith
 
 /**
@@ -8575,7 +8575,7 @@ export const forkChild: <
  */
 export const forkIn: {
   (
-    scope: Scope,
+    scope: Scope["Service"],
     options?: {
       readonly startImmediately?: boolean | undefined
       readonly uninterruptible?: boolean | "inherit" | undefined
@@ -8583,7 +8583,7 @@ export const forkIn: {
   ): <A, E, R>(self: Effect<A, E, R>) => Effect<Fiber<A, E>, never, R>
   <A, E, R>(
     self: Effect<A, E, R>,
-    scope: Scope,
+    scope: Scope["Service"],
     options?: {
       readonly startImmediately?: boolean | undefined
       readonly uninterruptible?: boolean | "inherit" | undefined
@@ -8817,11 +8817,11 @@ export const runFork: <A, E>(effect: Effect<A, E, never>, options?: RunOptions |
  * import { Context, Effect, Fiber } from "effect"
  * const output: Array<unknown> = []
  *
- * interface Logger {
+ * interface LoggerShape {
  *   log: (message: string) => void
  * }
  *
- * const Logger = Context.Service<Logger>("Logger")
+ * class Logger extends Context.Service<Logger, LoggerShape>()("Logger") {}
  *
  * const services = Context.make(Logger, {
  *   log: (message) => void output.push(message)
@@ -8863,11 +8863,11 @@ export const runForkWith: <R>(
  * import { Context, Effect } from "effect"
  * const output: Array<unknown> = []
  *
- * interface Logger {
+ * interface LoggerShape {
  *   log: (message: string) => Effect.Effect<void>
  * }
  *
- * const Logger = Context.Service<Logger>("Logger")
+ * class Logger extends Context.Service<Logger, LoggerShape>()("Logger") {}
  *
  * const services = Context.make(Logger, {
  *   log: (message) => Effect.sync(() => { output.push(message) })
@@ -9000,11 +9000,11 @@ export const runPromise: <A, E>(
  * ```ts import.meta.vitest
  * import { Context, Effect } from "effect"
  *
- * interface Config {
+ * interface ConfigShape {
  *   apiUrl: string
  * }
  *
- * const Config = Context.Service<Config>("Config")
+ * class Config extends Context.Service<Config, ConfigShape>()("Config") {}
  *
  * const context = Context.make(Config, {
  *   apiUrl: "https://api.example.com"
@@ -9076,11 +9076,11 @@ export const runPromiseExit: <A, E>(
  * import { Context, Effect, Exit } from "effect"
  * const output: Array<unknown> = []
  *
- * interface Database {
+ * interface DatabaseShape {
  *   query: (sql: string) => string
  * }
  *
- * const Database = Context.Service<Database>("Database")
+ * class Database extends Context.Service<Database, DatabaseShape>()("Database") {}
  *
  * const services = Context.make(Database, {
  *   query: (sql) => `Result for: ${sql}`
@@ -9177,11 +9177,11 @@ export const runSync: <A, E>(effect: Effect<A, E>) => A = internal.runSync
  * ```ts import.meta.vitest
  * import { Context, Effect } from "effect"
  *
- * interface MathService {
+ * interface MathServiceShape {
  *   add: (a: number, b: number) => number
  * }
  *
- * const MathService = Context.Service<MathService>("MathService")
+ * class MathService extends Context.Service<MathService, MathServiceShape>()("MathService") {}
  *
  * const context = Context.make(MathService, {
  *   add: (a, b) => a + b
@@ -9267,9 +9267,9 @@ export const runSyncExit: <A, E>(effect: Effect<A, E>) => Exit.Exit<A, E> = inte
  * const output: Array<unknown> = []
  *
  * // Define a logger service
- * const Logger = Context.Service<{
+ * class Logger extends Context.Service<Logger, {
  *   log: (msg: string) => void
- * }>("Logger")
+ * }>()("Logger") {}
  *
  * const program = Effect.gen(function*() {
  *   const logger = yield* Effect.service(Logger)

--- a/packages/effect/src/Fiber.ts
+++ b/packages/effect/src/Fiber.ts
@@ -615,6 +615,6 @@ export const getCurrent: () => Fiber<any, any> | undefined = effect.getCurrentFi
  * @since 4.0.0
  */
 export const runIn: {
-  (scope: Scope): <A, E>(self: Fiber<A, E>) => Fiber<A, E>
-  <A, E>(self: Fiber<A, E>, scope: Scope): Fiber<A, E>
+  (scope: Scope["Service"]): <A, E>(self: Fiber<A, E>) => Fiber<A, E>
+  <A, E>(self: Fiber<A, E>, scope: Scope["Service"]): Fiber<A, E>
 } = effect.fiberRunIn

--- a/packages/effect/src/FileSystem.ts
+++ b/packages/effect/src/FileSystem.ts
@@ -75,312 +75,320 @@ const TypeId = "~effect/FileSystem"
  * @category services
  * @since 4.0.0
  */
-export interface FileSystem {
-  readonly [TypeId]: typeof TypeId
+export declare namespace FileSystem {
+  /**
+   * Implementation of the FileSystem service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service {
+    readonly [TypeId]: typeof TypeId
 
-  /**
-   * Checks whether a file can be accessed.
-   * You can optionally specify the level of access to check for.
-   */
-  readonly access: (
-    path: string,
-    options?: {
-      readonly ok?: boolean | undefined
-      readonly readable?: boolean | undefined
-      readonly writable?: boolean | undefined
-    }
-  ) => Effect.Effect<void, PlatformError>
-  /**
-   * Copy a file or directory from `fromPath` to `toPath`.
-   *
-   * **Details**
-   *
-   * Equivalent to `cp -r`.
-   */
-  readonly copy: (
-    fromPath: string,
-    toPath: string,
-    options?: {
-      readonly overwrite?: boolean | undefined
-      readonly preserveTimestamps?: boolean | undefined
-    }
-  ) => Effect.Effect<void, PlatformError>
-  /**
-   * Copy a file from `fromPath` to `toPath`.
-   */
-  readonly copyFile: (
-    fromPath: string,
-    toPath: string
-  ) => Effect.Effect<void, PlatformError>
-  /**
-   * Change the permissions of a file.
-   */
-  readonly chmod: (
-    path: string,
-    mode: number
-  ) => Effect.Effect<void, PlatformError>
-  /**
-   * Change the owner and group of a file.
-   */
-  readonly chown: (
-    path: string,
-    uid: number,
-    gid: number
-  ) => Effect.Effect<void, PlatformError>
-  /**
-   * Glob a directory.
-   */
-  readonly glob: (
-    pattern: string,
-    options?: {
-      readonly root?: string | undefined
-      readonly exclude?: ReadonlyArray<string> | undefined
-    }
-  ) => Effect.Effect<Array<string>, PlatformError>
-  /**
-   * Checks whether a path exists.
-   */
-  readonly exists: (
-    path: string
-  ) => Effect.Effect<boolean, PlatformError>
-  /**
-   * Create a hard link from `fromPath` to `toPath`.
-   */
-  readonly link: (
-    fromPath: string,
-    toPath: string
-  ) => Effect.Effect<void, PlatformError>
-  /**
-   * Create a directory at `path`. You can optionally specify the mode and
-   * whether to recursively create nested directories.
-   */
-  readonly makeDirectory: (
-    path: string,
-    options?: {
-      readonly recursive?: boolean | undefined
-      readonly mode?: number | undefined
-    }
-  ) => Effect.Effect<void, PlatformError>
-  /**
-   * Create a temporary directory.
-   *
-   * **Details**
-   *
-   * By default the directory will be created inside the system's default
-   * temporary directory, but you can specify a different location by setting
-   * the `directory` option.
-   *
-   * You can also specify a prefix for the directory name by setting the
-   * `prefix` option.
-   */
-  readonly makeTempDirectory: (options?: {
-    readonly directory?: string | undefined
-    readonly prefix?: string | undefined
-  }) => Effect.Effect<string, PlatformError>
-  /**
-   * Create a temporary directory inside a scope.
-   *
-   * **Details**
-   *
-   * Functionally equivalent to `makeTempDirectory`, but the directory will be
-   * automatically deleted when the scope is closed.
-   */
-  readonly makeTempDirectoryScoped: (options?: {
-    readonly directory?: string | undefined
-    readonly prefix?: string | undefined
-  }) => Effect.Effect<string, PlatformError, Scope>
-  /**
-   * Create a temporary file.
-   * The directory creation is functionally equivalent to `makeTempDirectory`.
-   * The file name will be a randomly generated string.
-   */
-  readonly makeTempFile: (options?: {
-    readonly directory?: string | undefined
-    readonly prefix?: string | undefined
-    readonly suffix?: string | undefined
-  }) => Effect.Effect<string, PlatformError>
-  /**
-   * Create a temporary file inside a scope.
-   *
-   * **Details**
-   *
-   * Functionally equivalent to `makeTempFile`, but the file will be
-   * automatically deleted when the scope is closed.
-   */
-  readonly makeTempFileScoped: (options?: {
-    readonly directory?: string | undefined
-    readonly prefix?: string | undefined
-    readonly suffix?: string | undefined
-  }) => Effect.Effect<string, PlatformError, Scope>
-  /**
-   * Open a file at `path` with the specified `options`.
-   *
-   * **Details**
-   *
-   * The file handle will be automatically closed when the scope is closed.
-   */
-  readonly open: (
-    path: string,
-    options?: {
-      readonly flag?: OpenFlag | undefined
-      readonly mode?: number | undefined
-    }
-  ) => Effect.Effect<File, PlatformError, Scope>
-  /**
-   * List the contents of a directory.
-   *
-   * **Details**
-   *
-   * You can recursively list the contents of nested directories by setting the
-   * `recursive` option.
-   */
-  readonly readDirectory: (
-    path: string,
-    options?: {
-      readonly recursive?: boolean | undefined
-    }
-  ) => Effect.Effect<Array<string>, PlatformError>
-  /**
-   * Read the contents of a file.
-   */
-  readonly readFile: (
-    path: string
-  ) => Effect.Effect<Uint8Array, PlatformError>
-  /**
-   * Read the contents of a file.
-   */
-  readonly readFileString: (
-    path: string,
-    encoding?: string
-  ) => Effect.Effect<string, PlatformError>
-  /**
-   * Read the destination of a symbolic link.
-   */
-  readonly readLink: (
-    path: string
-  ) => Effect.Effect<string, PlatformError>
-  /**
-   * Resolve a path to its canonicalized absolute pathname.
-   */
-  readonly realPath: (
-    path: string
-  ) => Effect.Effect<string, PlatformError>
-  /**
-   * Remove a file or directory.
-   */
-  readonly remove: (
-    path: string,
-    options?: {
-      /**
-       * When `true`, you can recursively remove nested directories.
-       */
-      readonly recursive?: boolean | undefined
-      /**
-       * When `true`, exceptions will be ignored if `path` does not exist.
-       */
-      readonly force?: boolean | undefined
-    }
-  ) => Effect.Effect<void, PlatformError>
-  /**
-   * Rename a file or directory.
-   */
-  readonly rename: (
-    oldPath: string,
-    newPath: string
-  ) => Effect.Effect<void, PlatformError>
-  /**
-   * Create a writable `Sink` for the specified `path`.
-   */
-  readonly sink: (
-    path: string,
-    options?: {
-      readonly flag?: OpenFlag | undefined
-      readonly mode?: number | undefined
-    }
-  ) => Sink.Sink<void, Uint8Array, never, PlatformError>
-  /**
-   * Get information about a file at `path`. See `File.Info` for metadata limits.
-   */
-  readonly stat: (
-    path: string
-  ) => Effect.Effect<File.Info, PlatformError>
-  /**
-   * Create a readable `Stream` for the specified `path`.
-   *
-   * **Details**
-   *
-   * Changing the `bufferSize` option will change the internal buffer size of
-   * the stream. It defaults to `4`.
-   *
-   * The `chunkSize` option will change the size of the chunks emitted by the
-   * stream. It defaults to 64kb.
-   *
-   * Changing `offset` and `bytesToRead` will change the offset and the number
-   * of bytes to read from the file.
-   */
-  readonly stream: (
-    path: string,
-    options?: {
-      readonly bytesToRead?: ByteSize.Input | undefined
-      readonly chunkSize?: number | undefined
-      readonly offset?: ByteSize.Input | undefined
-    }
-  ) => Stream.Stream<Uint8Array, PlatformError>
-  /**
-   * Create a symbolic link from `fromPath` to `toPath`.
-   */
-  readonly symlink: (
-    fromPath: string,
-    toPath: string
-  ) => Effect.Effect<void, PlatformError>
-  /**
-   * Truncate a file to a specified length. If the `length` is not specified,
-   * the file will be truncated to length `0`.
-   */
-  readonly truncate: (
-    path: string,
-    length?: number
-  ) => Effect.Effect<void, PlatformError>
-  /**
-   * Change the file system timestamps of the file at `path`.
-   */
-  readonly utimes: (
-    path: string,
-    atime: Date | number,
-    mtime: Date | number
-  ) => Effect.Effect<void, PlatformError>
-  /**
-   * Watch a directory or file for changes.
-   *
-   * **Details**
-   *
-   * By default, only changes to the direct children of the directory are
-   * reported. Set the `recursive` option to `true` to watch for changes in
-   * subdirectories as well.
-   */
-  readonly watch: (path: string, options?: WatchOptions) => Stream.Stream<WatchEvent, PlatformError>
-  /**
-   * Write data to a file at `path`.
-   */
-  readonly writeFile: (
-    path: string,
-    data: Uint8Array,
-    options?: {
-      readonly flag?: OpenFlag | undefined
-      readonly mode?: number | undefined
-    }
-  ) => Effect.Effect<void, PlatformError>
-  /**
-   * Write a string to a file at `path`.
-   */
-  readonly writeFileString: (
-    path: string,
-    data: string,
-    options?: {
-      readonly flag?: OpenFlag | undefined
-      readonly mode?: number | undefined
-    }
-  ) => Effect.Effect<void, PlatformError>
+    /**
+     * Checks whether a file can be accessed.
+     * You can optionally specify the level of access to check for.
+     */
+    readonly access: (
+      path: string,
+      options?: {
+        readonly ok?: boolean | undefined
+        readonly readable?: boolean | undefined
+        readonly writable?: boolean | undefined
+      }
+    ) => Effect.Effect<void, PlatformError>
+    /**
+     * Copy a file or directory from `fromPath` to `toPath`.
+     *
+     * **Details**
+     *
+     * Equivalent to `cp -r`.
+     */
+    readonly copy: (
+      fromPath: string,
+      toPath: string,
+      options?: {
+        readonly overwrite?: boolean | undefined
+        readonly preserveTimestamps?: boolean | undefined
+      }
+    ) => Effect.Effect<void, PlatformError>
+    /**
+     * Copy a file from `fromPath` to `toPath`.
+     */
+    readonly copyFile: (
+      fromPath: string,
+      toPath: string
+    ) => Effect.Effect<void, PlatformError>
+    /**
+     * Change the permissions of a file.
+     */
+    readonly chmod: (
+      path: string,
+      mode: number
+    ) => Effect.Effect<void, PlatformError>
+    /**
+     * Change the owner and group of a file.
+     */
+    readonly chown: (
+      path: string,
+      uid: number,
+      gid: number
+    ) => Effect.Effect<void, PlatformError>
+    /**
+     * Glob a directory.
+     */
+    readonly glob: (
+      pattern: string,
+      options?: {
+        readonly root?: string | undefined
+        readonly exclude?: ReadonlyArray<string> | undefined
+      }
+    ) => Effect.Effect<Array<string>, PlatformError>
+    /**
+     * Checks whether a path exists.
+     */
+    readonly exists: (
+      path: string
+    ) => Effect.Effect<boolean, PlatformError>
+    /**
+     * Create a hard link from `fromPath` to `toPath`.
+     */
+    readonly link: (
+      fromPath: string,
+      toPath: string
+    ) => Effect.Effect<void, PlatformError>
+    /**
+     * Create a directory at `path`. You can optionally specify the mode and
+     * whether to recursively create nested directories.
+     */
+    readonly makeDirectory: (
+      path: string,
+      options?: {
+        readonly recursive?: boolean | undefined
+        readonly mode?: number | undefined
+      }
+    ) => Effect.Effect<void, PlatformError>
+    /**
+     * Create a temporary directory.
+     *
+     * **Details**
+     *
+     * By default the directory will be created inside the system's default
+     * temporary directory, but you can specify a different location by setting
+     * the `directory` option.
+     *
+     * You can also specify a prefix for the directory name by setting the
+     * `prefix` option.
+     */
+    readonly makeTempDirectory: (options?: {
+      readonly directory?: string | undefined
+      readonly prefix?: string | undefined
+    }) => Effect.Effect<string, PlatformError>
+    /**
+     * Create a temporary directory inside a scope.
+     *
+     * **Details**
+     *
+     * Functionally equivalent to `makeTempDirectory`, but the directory will be
+     * automatically deleted when the scope is closed.
+     */
+    readonly makeTempDirectoryScoped: (options?: {
+      readonly directory?: string | undefined
+      readonly prefix?: string | undefined
+    }) => Effect.Effect<string, PlatformError, Scope>
+    /**
+     * Create a temporary file.
+     * The directory creation is functionally equivalent to `makeTempDirectory`.
+     * The file name will be a randomly generated string.
+     */
+    readonly makeTempFile: (options?: {
+      readonly directory?: string | undefined
+      readonly prefix?: string | undefined
+      readonly suffix?: string | undefined
+    }) => Effect.Effect<string, PlatformError>
+    /**
+     * Create a temporary file inside a scope.
+     *
+     * **Details**
+     *
+     * Functionally equivalent to `makeTempFile`, but the file will be
+     * automatically deleted when the scope is closed.
+     */
+    readonly makeTempFileScoped: (options?: {
+      readonly directory?: string | undefined
+      readonly prefix?: string | undefined
+      readonly suffix?: string | undefined
+    }) => Effect.Effect<string, PlatformError, Scope>
+    /**
+     * Open a file at `path` with the specified `options`.
+     *
+     * **Details**
+     *
+     * The file handle will be automatically closed when the scope is closed.
+     */
+    readonly open: (
+      path: string,
+      options?: {
+        readonly flag?: OpenFlag | undefined
+        readonly mode?: number | undefined
+      }
+    ) => Effect.Effect<File, PlatformError, Scope>
+    /**
+     * List the contents of a directory.
+     *
+     * **Details**
+     *
+     * You can recursively list the contents of nested directories by setting the
+     * `recursive` option.
+     */
+    readonly readDirectory: (
+      path: string,
+      options?: {
+        readonly recursive?: boolean | undefined
+      }
+    ) => Effect.Effect<Array<string>, PlatformError>
+    /**
+     * Read the contents of a file.
+     */
+    readonly readFile: (
+      path: string
+    ) => Effect.Effect<Uint8Array, PlatformError>
+    /**
+     * Read the contents of a file.
+     */
+    readonly readFileString: (
+      path: string,
+      encoding?: string
+    ) => Effect.Effect<string, PlatformError>
+    /**
+     * Read the destination of a symbolic link.
+     */
+    readonly readLink: (
+      path: string
+    ) => Effect.Effect<string, PlatformError>
+    /**
+     * Resolve a path to its canonicalized absolute pathname.
+     */
+    readonly realPath: (
+      path: string
+    ) => Effect.Effect<string, PlatformError>
+    /**
+     * Remove a file or directory.
+     */
+    readonly remove: (
+      path: string,
+      options?: {
+        /**
+         * When `true`, you can recursively remove nested directories.
+         */
+        readonly recursive?: boolean | undefined
+        /**
+         * When `true`, exceptions will be ignored if `path` does not exist.
+         */
+        readonly force?: boolean | undefined
+      }
+    ) => Effect.Effect<void, PlatformError>
+    /**
+     * Rename a file or directory.
+     */
+    readonly rename: (
+      oldPath: string,
+      newPath: string
+    ) => Effect.Effect<void, PlatformError>
+    /**
+     * Create a writable `Sink` for the specified `path`.
+     */
+    readonly sink: (
+      path: string,
+      options?: {
+        readonly flag?: OpenFlag | undefined
+        readonly mode?: number | undefined
+      }
+    ) => Sink.Sink<void, Uint8Array, never, PlatformError>
+    /**
+     * Get information about a file at `path`. See `File.Info` for metadata limits.
+     */
+    readonly stat: (
+      path: string
+    ) => Effect.Effect<File.Info, PlatformError>
+    /**
+     * Create a readable `Stream` for the specified `path`.
+     *
+     * **Details**
+     *
+     * Changing the `bufferSize` option will change the internal buffer size of
+     * the stream. It defaults to `4`.
+     *
+     * The `chunkSize` option will change the size of the chunks emitted by the
+     * stream. It defaults to 64kb.
+     *
+     * Changing `offset` and `bytesToRead` will change the offset and the number
+     * of bytes to read from the file.
+     */
+    readonly stream: (
+      path: string,
+      options?: {
+        readonly bytesToRead?: ByteSize.Input | undefined
+        readonly chunkSize?: number | undefined
+        readonly offset?: ByteSize.Input | undefined
+      }
+    ) => Stream.Stream<Uint8Array, PlatformError>
+    /**
+     * Create a symbolic link from `fromPath` to `toPath`.
+     */
+    readonly symlink: (
+      fromPath: string,
+      toPath: string
+    ) => Effect.Effect<void, PlatformError>
+    /**
+     * Truncate a file to a specified length. If the `length` is not specified,
+     * the file will be truncated to length `0`.
+     */
+    readonly truncate: (
+      path: string,
+      length?: number
+    ) => Effect.Effect<void, PlatformError>
+    /**
+     * Change the file system timestamps of the file at `path`.
+     */
+    readonly utimes: (
+      path: string,
+      atime: Date | number,
+      mtime: Date | number
+    ) => Effect.Effect<void, PlatformError>
+    /**
+     * Watch a directory or file for changes.
+     *
+     * **Details**
+     *
+     * By default, only changes to the direct children of the directory are
+     * reported. Set the `recursive` option to `true` to watch for changes in
+     * subdirectories as well.
+     */
+    readonly watch: (path: string, options?: WatchOptions) => Stream.Stream<WatchEvent, PlatformError>
+    /**
+     * Write data to a file at `path`.
+     */
+    readonly writeFile: (
+      path: string,
+      data: Uint8Array,
+      options?: {
+        readonly flag?: OpenFlag | undefined
+        readonly mode?: number | undefined
+      }
+    ) => Effect.Effect<void, PlatformError>
+    /**
+     * Write a string to a file at `path`.
+     */
+    readonly writeFileString: (
+      path: string,
+      data: string,
+      options?: {
+        readonly flag?: OpenFlag | undefined
+        readonly mode?: number | undefined
+      }
+    ) => Effect.Effect<void, PlatformError>
+  }
 }
 
 /**
@@ -467,7 +475,7 @@ export type OpenFlag =
  * @category services
  * @since 4.0.0
  */
-export const FileSystem: Context.Service<FileSystem, FileSystem> = Context.Service("effect/FileSystem")
+export class FileSystem extends Context.Service<FileSystem, FileSystem.Service>()("effect/FileSystem") {}
 
 /**
  * Creates a FileSystem implementation from a partial implementation.
@@ -491,8 +499,8 @@ export const FileSystem: Context.Service<FileSystem, FileSystem> = Context.Servi
  * @since 4.0.0
  */
 export const make = (
-  impl: Omit<FileSystem, typeof TypeId | "exists" | "readFileString" | "stream" | "sink" | "writeFileString">
-): FileSystem =>
+  impl: Omit<FileSystem["Service"], typeof TypeId | "exists" | "readFileString" | "stream" | "sink" | "writeFileString">
+): FileSystem["Service"] =>
   FileSystem.of({
     ...impl,
     [TypeId]: TypeId,
@@ -633,7 +641,7 @@ const notFound = (method: string, path: string) =>
  * @category constructors
  * @since 4.0.0
  */
-export const makeNoop = (fileSystem: Partial<FileSystem>): FileSystem =>
+export const makeNoop = (fileSystem: Partial<FileSystem["Service"]>): FileSystem["Service"] =>
   FileSystem.of({
     [TypeId]: TypeId,
     access(path) {
@@ -762,7 +770,7 @@ export const makeNoop = (fileSystem: Partial<FileSystem>): FileSystem =>
  * @category layers
  * @since 4.0.0
  */
-export const layerNoop = (fileSystem: Partial<FileSystem>): Layer.Layer<FileSystem> =>
+export const layerNoop = (fileSystem: Partial<FileSystem["Service"]>): Layer.Layer<FileSystem> =>
   Layer.succeed(FileSystem)(makeNoop(fileSystem))
 
 /**

--- a/packages/effect/src/Layer.ts
+++ b/packages/effect/src/Layer.ts
@@ -53,7 +53,7 @@ const TypeId = "~effect/Layer"
  */
 export interface Layer<in ROut, out E = never, out RIn = never> extends Variance<ROut, E, RIn>, Pipeable {
   /** @internal */
-  build(memoMap: MemoMap, scope: Scope.Scope): Effect<Context.Context<ROut>, E, RIn>
+  build(memoMap: MemoMap, scope: Scope.Scope["Service"]): Effect<Context.Context<ROut>, E, RIn>
   [Unify.typeSymbol]?: unknown
   [Unify.unifySymbol]?: LayerUnify<this>
   [Unify.ignoreSymbol]?: LayerUnifyIgnore
@@ -223,12 +223,12 @@ export interface MemoMap {
   readonly [MemoMapTypeId]: typeof MemoMapTypeId
   readonly get: <RIn, E, ROut>(
     layer: Layer<ROut, E, RIn>,
-    scope: Scope.Scope
+    scope: Scope.Scope["Service"]
   ) => Effect<Context.Context<ROut>, E, RIn> | undefined
   readonly getOrElseMemoize: <RIn, E, ROut>(
     layer: Layer<ROut, E, RIn>,
-    scope: Scope.Scope,
-    build: (memoMap: MemoMap, scope: Scope.Scope) => Effect<Context.Context<ROut>, E, RIn>
+    scope: Scope.Scope["Service"],
+    build: (memoMap: MemoMap, scope: Scope.Scope["Service"]) => Effect<Context.Context<ROut>, E, RIn>
   ) => Effect<Context.Context<ROut>, E, RIn>
 }
 
@@ -240,7 +240,7 @@ type MemoMapEntry = {
 
 const memoMapReuse = <RIn, E, ROut>(
   entry: MemoMapEntry,
-  scope: Scope.Scope
+  scope: Scope.Scope["Service"]
 ): Effect<Context.Context<ROut>, E, RIn> => {
   entry.observers++
   return internalEffect.andThen(
@@ -289,7 +289,7 @@ const LayerProto = {
 const fromBuildUnsafe = <ROut, E, RIn>(
   build: (
     memoMap: MemoMap,
-    scope: Scope.Scope
+    scope: Scope.Scope["Service"]
   ) => Effect<Context.Context<ROut>, E, RIn>
 ): Layer<ROut, E, RIn> => {
   const self = Object.create(LayerProto)
@@ -333,10 +333,10 @@ const fromBuildUnsafe = <ROut, E, RIn>(
 export const fromBuild = <ROut, E, RIn>(
   build: (
     memoMap: MemoMap,
-    scope: Scope.Scope
+    scope: Scope.Scope["Service"]
   ) => Effect<Context.Context<ROut>, E, RIn>
 ): Layer<ROut, E, RIn> =>
-  fromBuildUnsafe((memoMap: MemoMap, scope: Scope.Scope) => {
+  fromBuildUnsafe((memoMap: MemoMap, scope: Scope.Scope["Service"]) => {
     const layerScope = Scope.forkUnsafe(scope)
     return internalEffect.onExit(
       build(memoMap, layerScope),
@@ -380,7 +380,7 @@ export const fromBuild = <ROut, E, RIn>(
 export const fromBuildMemo = <ROut, E, RIn>(
   build: (
     memoMap: MemoMap,
-    scope: Scope.Scope
+    scope: Scope.Scope["Service"]
   ) => Effect<Context.Context<ROut>, E, RIn>
 ): Layer<ROut, E, RIn> => {
   const self: Layer<ROut, E, RIn> = fromBuild((memoMap, scope) => memoMap.getOrElseMemoize(self, scope, build))
@@ -390,8 +390,8 @@ export const fromBuildMemo = <ROut, E, RIn>(
 const memoMapBuild = <RIn, E, ROut>(
   memoMap: MemoMapImpl,
   layer: Layer<ROut, E, RIn>,
-  scope: Scope.Scope,
-  build: (memoMap: MemoMap, scope: Scope.Scope) => Effect<Context.Context<ROut>, E, RIn>
+  scope: Scope.Scope["Service"],
+  build: (memoMap: MemoMap, scope: Scope.Scope["Service"]) => Effect<Context.Context<ROut>, E, RIn>
 ): Effect<Context.Context<ROut>, E, RIn> => {
   const layerScope = Scope.makeUnsafe()
   const deferred = Deferred.makeUnsafe<Context.Context<ROut>, E>()
@@ -433,7 +433,7 @@ class MemoMapImpl implements MemoMap {
 
   get<RIn, E, ROut>(
     layer: Layer<ROut, E, RIn>,
-    scope: Scope.Scope
+    scope: Scope.Scope["Service"]
   ): Effect<Context.Context<ROut>, E, RIn> | undefined {
     const local = this.map.get(layer)
     if (local) {
@@ -444,8 +444,8 @@ class MemoMapImpl implements MemoMap {
 
   getOrElseMemoize<RIn, E, ROut>(
     layer: Layer<ROut, E, RIn>,
-    scope: Scope.Scope,
-    build: (memoMap: MemoMap, scope: Scope.Scope) => Effect<Context.Context<ROut>, E, RIn>
+    scope: Scope.Scope["Service"],
+    build: (memoMap: MemoMap, scope: Scope.Scope["Service"]) => Effect<Context.Context<ROut>, E, RIn>
   ): Effect<Context.Context<ROut>, E, RIn> {
     return internalEffect.suspend(() => {
       const existing = this.get(layer, scope)
@@ -645,17 +645,17 @@ export class CurrentMemoMap extends Context.Service<CurrentMemoMap, MemoMap>()("
 export const buildWithMemoMap: {
   (
     memoMap: MemoMap,
-    scope: Scope.Scope
+    scope: Scope.Scope["Service"]
   ): <RIn, E, ROut>(self: Layer<ROut, E, RIn>) => Effect<Context.Context<ROut>, E, RIn>
   <RIn, E, ROut>(
     self: Layer<ROut, E, RIn>,
     memoMap: MemoMap,
-    scope: Scope.Scope
+    scope: Scope.Scope["Service"]
   ): Effect<Context.Context<ROut>, E, RIn>
 } = dual(3, <RIn, E, ROut>(
   self: Layer<ROut, E, RIn>,
   memoMap: MemoMap,
-  scope: Scope.Scope
+  scope: Scope.Scope["Service"]
 ): Effect<Context.Context<ROut>, E, RIn> =>
   internalEffect.provideService(
     internalEffect.map(self.build(memoMap, scope), Context.add(CurrentMemoMap, memoMap)),
@@ -760,11 +760,11 @@ export const build = <RIn, E, ROut>(
  * @since 2.0.0
  */
 export const buildWithScope: {
-  (scope: Scope.Scope): <RIn, E, ROut>(self: Layer<ROut, E, RIn>) => Effect<Context.Context<ROut>, E, RIn>
-  <RIn, E, ROut>(self: Layer<ROut, E, RIn>, scope: Scope.Scope): Effect<Context.Context<ROut>, E, RIn>
+  (scope: Scope.Scope["Service"]): <RIn, E, ROut>(self: Layer<ROut, E, RIn>) => Effect<Context.Context<ROut>, E, RIn>
+  <RIn, E, ROut>(self: Layer<ROut, E, RIn>, scope: Scope.Scope["Service"]): Effect<Context.Context<ROut>, E, RIn>
 } = dual(2, <RIn, E, ROut>(
   self: Layer<ROut, E, RIn>,
-  scope: Scope.Scope
+  scope: Scope.Scope["Service"]
 ): Effect<Context.Context<ROut>, E, RIn> =>
   core.withFiber((fiber) =>
     buildWithMemoMap(
@@ -877,7 +877,7 @@ export const succeedContext = <A>(context: Context.Context<A>): Layer<A> =>
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer, Option } from "effect"
  *
- * const Service = Context.Service<string>("Service")
+ * class Service extends Context.Service<Service, string>()("Service") {}
  * const context = Effect.runSync(Effect.scoped(Layer.build(Layer.empty)))
  * Context.getOption(context, Service) // => Option.none()
  * ```
@@ -1137,7 +1137,7 @@ export const effectDiscard = <X, E, R>(effect: Effect<X, E, R>): Layer<never, E,
 export const suspend = <A, E, R>(evaluate: LazyArg<Layer<A, E, R>>): Layer<A, E, R> =>
   fromBuildMemo((memoMap, scope) => internalEffect.suspend(() => evaluate().build(memoMap, scope)))
 
-const unwrapKey = Context.Service<Layer<any, any, any>>("effect/Layer/unwrap")
+class UnwrapKey extends Context.Service<UnwrapKey, Layer<any, any, any>>()("effect/Layer/unwrap") {}
 
 /**
  * Unwraps a `Layer` from an `Effect`, flattening the nested structure.
@@ -1175,12 +1175,12 @@ const unwrapKey = Context.Service<Layer<any, any, any>>("effect/Layer/unwrap")
  */
 export const unwrap = <A, E1, R1, E, R>(
   self: Effect<Layer<A, E1, R1>, E, R>
-): Layer<A, E | E1, R1 | Exclude<R, Scope.Scope>> => flatMap(effect(unwrapKey)(self), Context.get(unwrapKey))
+): Layer<A, E | E1, R1 | Exclude<R, Scope.Scope>> => flatMap(effect(UnwrapKey)(self), Context.get(UnwrapKey))
 
 const mergeAllEffect = <Layers extends [Layer<never, any, any>, ...Array<Layer<never, any, any>>]>(
   layers: Layers,
   memoMap: MemoMap,
-  scope: Scope.Scope
+  scope: Scope.Scope["Service"]
 ): Effect<
   Context.Context<{ [k in keyof Layers]: Success<Layers[k]> }[number]>,
   { [k in keyof Layers]: Error<Layers[k]> }[number],
@@ -2375,13 +2375,13 @@ const ChannelTypeId: Channel.TypeId = "~effect/Channel"
  * ```ts import.meta.vitest
  * import { Context, Layer } from "effect"
  *
- * const NumberService = Context.Service<number>("Number")
+ * class NumberService extends Context.Service<NumberService, number>()("Number") {}
  * const numberLayer = Layer.succeed(NumberService, 42)
  *
- * // Define a constraint that the success type must be a number
- * const satisfiesNumber = Layer.satisfiesSuccessType<number>()
+ * // Require the layer to provide the NumberService identifier
+ * const satisfiesNumber = Layer.satisfiesSuccessType<NumberService>()
  *
- * // This works - Layer<42, never, never> extends Layer<number, never, never>
+ * // The layer provides NumberService with a number implementation
  * const validLayer = satisfiesNumber(numberLayer)
  * ```
  *
@@ -2432,13 +2432,13 @@ export const satisfiesErrorType =
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * const NumberService = Context.Service<number>("Number")
+ * class NumberService extends Context.Service<NumberService, number>()("Number") {}
  * const numberLayer = Layer.effectDiscard(Effect.asVoid(NumberService))
  *
- * // Define a constraint that the service requirements must be numbers
- * const satisfiesNumber = Layer.satisfiesServicesType<number>()
+ * // Require the layer dependencies to use the NumberService identifier
+ * const satisfiesNumber = Layer.satisfiesServicesType<NumberService>()
  *
- * // This works - Layer<never, never, 42> extends Layer<never, never, number>
+ * // The layer requires NumberService
  * const validLayer = satisfiesNumber(numberLayer)
  * ```
  *

--- a/packages/effect/src/LayerMap.ts
+++ b/packages/effect/src/LayerMap.ts
@@ -38,9 +38,9 @@ type IdleTimeToLiveInput<K> = Duration.Input | ((key: K) => Duration.Input)
  * import { Context, Effect, Layer, LayerMap } from "effect"
  *
  * // Define a service key
- * const DatabaseService = Context.Service<{
+ * class DatabaseService extends Context.Service<DatabaseService, {
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>("Database")
+ * }>()("Database") {}
  *
  * // Create a LayerMap that provides different database configurations
  * const createDatabaseLayerMap = LayerMap.make((env: string) =>
@@ -120,9 +120,9 @@ export interface LayerMap<in out K, in out I, in out E = never> {
  * import { Context, Effect, Layer, LayerMap } from "effect"
  *
  * // Define a service key
- * const DatabaseService = Context.Service<{
+ * class DatabaseService extends Context.Service<DatabaseService, {
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>("Database")
+ * }>()("Database") {}
  *
  * // Create a LayerMap that provides different database configurations
  * const program = Effect.gen(function*() {
@@ -215,9 +215,9 @@ export const make: <
  * import { Context, Effect, Layer, LayerMap } from "effect"
  *
  * // Define a service key
- * const Database = Context.Service<{
+ * class Database extends Context.Service<Database, {
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>("Database")
+ * }>()("Database") {}
  *
  * // Create predefined layers
  * const layers = {
@@ -360,9 +360,9 @@ export interface TagClass<
  * import { Context, Effect, Layer, LayerMap } from "effect"
  *
  * // Define a service key
- * const Greeter = Context.Service<{
+ * class Greeter extends Context.Service<Greeter, {
  *   readonly greet: Effect.Effect<string>
- * }>("Greeter")
+ * }>()("Greeter") {}
  *
  * // Create a service that wraps a LayerMap
  * class GreeterMap extends LayerMap.Service<GreeterMap>()("GreeterMap", {

--- a/packages/effect/src/Path.ts
+++ b/packages/effect/src/Path.ts
@@ -81,22 +81,30 @@ export const TypeId = "~effect/Path"
  * @category services
  * @since 4.0.0
  */
-export interface Path {
-  readonly [TypeId]: typeof TypeId
-  readonly sep: string
-  readonly basename: (path: string, suffix?: string) => string
-  readonly dirname: (path: string) => string
-  readonly extname: (path: string) => string
-  readonly format: (pathObject: Partial<Path.Parsed>) => string
-  readonly fromFileUrl: (url: URL) => Effect.Effect<string, BadArgument>
-  readonly isAbsolute: (path: string) => boolean
-  readonly join: (...paths: ReadonlyArray<string>) => string
-  readonly normalize: (path: string) => string
-  readonly parse: (path: string) => Path.Parsed
-  readonly relative: (from: string, to: string) => string
-  readonly resolve: (...pathSegments: ReadonlyArray<string>) => string
-  readonly toFileUrl: (path: string) => Effect.Effect<URL, BadArgument>
-  readonly toNamespacedPath: (path: string) => string
+export declare namespace Path {
+  /**
+   * Implementation of the Path service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service {
+    readonly [TypeId]: typeof TypeId
+    readonly sep: string
+    readonly basename: (path: string, suffix?: string) => string
+    readonly dirname: (path: string) => string
+    readonly extname: (path: string) => string
+    readonly format: (pathObject: Partial<Path.Parsed>) => string
+    readonly fromFileUrl: (url: URL) => Effect.Effect<string, BadArgument>
+    readonly isAbsolute: (path: string) => boolean
+    readonly join: (...paths: ReadonlyArray<string>) => string
+    readonly normalize: (path: string) => string
+    readonly parse: (path: string) => Path.Parsed
+    readonly relative: (from: string, to: string) => string
+    readonly resolve: (...pathSegments: ReadonlyArray<string>) => string
+    readonly toFileUrl: (path: string) => Effect.Effect<URL, BadArgument>
+    readonly toNamespacedPath: (path: string) => string
+  }
 }
 
 /**
@@ -200,7 +208,7 @@ export declare namespace Path {
  * import { Effect, Layer, Path } from "effect"
  *
  * // Create a custom path implementation
- * const customPath: Path.Path = {
+ * const customPath: Path.Path["Service"] = {
  *   [Path.TypeId]: Path.TypeId,
  *   sep: "/",
  *   basename: (path: string, suffix?: string) => {
@@ -252,7 +260,7 @@ export declare namespace Path {
  * @category services
  * @since 4.0.0
  */
-export const Path: Context.Service<Path, Path> = Context.Service("effect/Path")
+export class Path extends Context.Service<Path, Path.Service>()("effect/Path") {}
 
 /**
  * The following functions are adapted from the Node.js source code:
@@ -382,7 +390,7 @@ function fromFileUrl(url: URL): Effect.Effect<string, BadArgument> {
   return Effect.succeed(decodeURIComponent(pathname))
 }
 
-const resolve: Path["resolve"] = function resolve() {
+const resolve: Path["Service"]["resolve"] = function resolve() {
   let resolvedPath = ""
   let resolvedAbsolute = false
   let cwd: string | undefined = undefined

--- a/packages/effect/src/Pool.ts
+++ b/packages/effect/src/Pool.ts
@@ -115,7 +115,7 @@ export interface Config<A, E> {
  * @since 4.0.0
  */
 export interface State<A, E> {
-  readonly scope: Scope.Scope
+  readonly scope: Scope.Scope["Service"]
   isShuttingDown: boolean
   usage: number
   readonly resizeSemaphore: Semaphore.Semaphore

--- a/packages/effect/src/RcMap.ts
+++ b/packages/effect/src/RcMap.ts
@@ -74,7 +74,7 @@ export interface RcMap<in out K, in out A, in out E = never> extends Pipeable {
   readonly [TypeId]: typeof TypeId
   readonly lookup: (key: K) => Effect.Effect<A, E, Scope.Scope>
   readonly context: Context.Context<never>
-  readonly scope: Scope.Scope
+  readonly scope: Scope.Scope["Service"]
   readonly idleTimeToLive: (key: K) => Duration.Duration
   readonly capacity: number
   state: State<K, A, E>
@@ -167,7 +167,7 @@ export declare namespace State {
 const makeUnsafe = <K, A, E>(options: {
   readonly lookup: (key: K) => Effect.Effect<A, E, Scope.Scope>
   readonly context: Context.Context<never>
-  readonly scope: Scope.Scope
+  readonly scope: Scope.Scope["Service"]
   readonly idleTimeToLive: (key: K) => Duration.Duration
   readonly capacity: number
 }): RcMap<K, A, E> => ({

--- a/packages/effect/src/Scope.ts
+++ b/packages/effect/src/Scope.ts
@@ -42,10 +42,18 @@ const CloseableTypeId = effect.ScopeCloseableTypeId
  * @category services
  * @since 2.0.0
  */
-export interface Scope {
-  readonly [TypeId]: typeof TypeId
-  readonly strategy: "sequential" | "parallel"
-  state: State.Open | State.Closed | State.Empty
+export declare namespace Scope {
+  /**
+   * Implementation of the Scope service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service {
+    readonly [TypeId]: typeof TypeId
+    readonly strategy: "sequential" | "parallel"
+    state: State.Open | State.Closed | State.Empty
+  }
 }
 /**
  * A `Closeable` scope extends the base `Scope` interface with the ability
@@ -70,7 +78,7 @@ export interface Scope {
  * @category models
  * @since 2.0.0
  */
-export interface Closeable extends Scope {
+export interface Closeable extends Scope.Service {
   readonly [CloseableTypeId]: typeof CloseableTypeId
 }
 
@@ -212,7 +220,15 @@ export declare namespace State {
  * @category services
  * @since 2.0.0
  */
-export const Scope: Context.Service<Scope, Scope> = effect.scopeTag
+export const Scope: Context.ServiceClass<Scope, "effect/Scope", Scope.Service> = effect.Scope
+
+/**
+ * Identifier for the current scope.
+ *
+ * @category services
+ * @since 2.0.0
+ */
+export interface Scope extends Context.ServiceClass.Shape<"effect/Scope", Scope.Service> {}
 
 /**
  * Creates a new `Scope` with the specified finalizer strategy.
@@ -308,8 +324,8 @@ export const makeUnsafe: (finalizerStrategy?: "sequential" | "parallel") => Clos
  * @since 4.0.0
  */
 export const provide: {
-  (value: Scope): <A, E, R>(self: Effect<A, E, R>) => Effect<A, E, Exclude<R, Scope>>
-  <A, E, R>(self: Effect<A, E, R>, value: Scope): Effect<A, E, Exclude<R, Scope>>
+  (value: Scope["Service"]): <A, E, R>(self: Effect<A, E, R>) => Effect<A, E, Exclude<R, Scope>>
+  <A, E, R>(self: Effect<A, E, R>, value: Scope["Service"]): Effect<A, E, Exclude<R, Scope>>
 } = effect.provideScope
 
 /**
@@ -345,8 +361,10 @@ export const provide: {
  * @category combinators
  * @since 2.0.0
  */
-export const addFinalizerExit: (scope: Scope, finalizer: (exit: Exit<any, any>) => Effect<unknown>) => Effect<void> =
-  effect.scopeAddFinalizerExit
+export const addFinalizerExit: (
+  scope: Scope["Service"],
+  finalizer: (exit: Exit<any, any>) => Effect<unknown>
+) => Effect<void> = effect.scopeAddFinalizerExit
 
 /**
  * Registers a finalizer effect on a scope.
@@ -379,7 +397,8 @@ export const addFinalizerExit: (scope: Scope, finalizer: (exit: Exit<any, any>) 
  * @category combinators
  * @since 2.0.0
  */
-export const addFinalizer: (scope: Scope, finalizer: Effect<unknown>) => Effect<void> = effect.scopeAddFinalizer
+export const addFinalizer: (scope: Scope["Service"], finalizer: Effect<unknown>) => Effect<void> =
+  effect.scopeAddFinalizer
 
 /**
  * Creates a closeable child scope registered with a parent scope.
@@ -413,7 +432,7 @@ export const addFinalizer: (scope: Scope, finalizer: Effect<unknown>) => Effect<
  * @since 2.0.0
  */
 export const fork: (
-  scope: Scope,
+  scope: Scope["Service"],
   finalizerStrategy?: "sequential" | "parallel"
 ) => Effect<Closeable> = effect.scopeFork
 
@@ -453,7 +472,7 @@ export const fork: (
  * @category combinators
  * @since 4.0.0
  */
-export const forkUnsafe: (scope: Scope, finalizerStrategy?: "sequential" | "parallel") => Closeable =
+export const forkUnsafe: (scope: Scope["Service"], finalizerStrategy?: "sequential" | "parallel") => Closeable =
   effect.scopeForkUnsafe
 
 /**
@@ -490,7 +509,7 @@ export const forkUnsafe: (scope: Scope, finalizerStrategy?: "sequential" | "para
  * @category combinators
  * @since 2.0.0
  */
-export const close: <A, E>(self: Scope, exit: Exit<A, E>) => Effect<void> = effect.scopeClose
+export const close: <A, E>(self: Scope["Service"], exit: Exit<A, E>) => Effect<void> = effect.scopeClose
 
 /**
  * Closes a scope unsafely with the provided exit value.
@@ -515,7 +534,7 @@ export const close: <A, E>(self: Scope, exit: Exit<A, E>) => Effect<void> = effe
  * @category unsafe
  * @since 4.0.0
  */
-export const closeUnsafe: <A, E>(self: Scope, exit_: Exit<A, E>) => Effect<void, never, never> | undefined =
+export const closeUnsafe: <A, E>(self: Scope["Service"], exit_: Exit<A, E>) => Effect<void, never, never> | undefined =
   effect.scopeCloseUnsafe
 
 /**

--- a/packages/effect/src/Sink.ts
+++ b/packages/effect/src/Sink.ts
@@ -66,7 +66,7 @@ export interface Sink<out A, in In = unknown, out L = never, out E = never, out 
 {
   readonly transform: (
     upstream: Pull.Pull<NonEmptyReadonlyArray<In>, never, void>,
-    scope: Scope.Scope
+    scope: Scope.Scope["Service"]
   ) => Effect.Effect<End<A, L>, E, R>
   [Unify.typeSymbol]?: unknown
   [Unify.unifySymbol]?: SinkUnify<this>
@@ -303,7 +303,7 @@ export const fromWritableStream = <A, E>(options: {
 export const fromTransform = <In, A, E, R, L = never>(
   transform: (
     upstream: Pull.Pull<NonEmptyReadonlyArray<In>, never, void>,
-    scope: Scope.Scope
+    scope: Scope.Scope["Service"]
   ) => Effect.Effect<End<A, L>, E, R>
 ): Sink<A, In, L, E, R> => {
   const self = Object.create(SinkProto)

--- a/packages/effect/src/Stdio.ts
+++ b/packages/effect/src/Stdio.ts
@@ -60,28 +60,36 @@ export const TypeId: TypeId = "~effect/Stdio"
  * @category services
  * @since 4.0.0
  */
-export interface Stdio {
-  readonly [TypeId]: TypeId
-  readonly args: Effect.Effect<ReadonlyArray<string>>
+export declare namespace Stdio {
   /**
-   * Whether standard input is attached to a terminal.
+   * Implementation of the Stdio service.
    *
+   * @category models
    * @since 4.0.0
    */
-  readonly stdinIsTerminal: Effect.Effect<boolean>
-  /**
-   * Whether standard output is attached to a terminal.
-   *
-   * @since 4.0.0
-   */
-  readonly stdoutIsTerminal: Effect.Effect<boolean>
-  stdout(options?: {
-    readonly endOnDone?: boolean | undefined
-  }): Sink.Sink<void, string | Uint8Array, never, PlatformError>
-  stderr(options?: {
-    readonly endOnDone?: boolean | undefined
-  }): Sink.Sink<void, string | Uint8Array, never, PlatformError>
-  readonly stdin: Stream.Stream<Uint8Array, PlatformError>
+  export interface Service {
+    readonly [TypeId]: TypeId
+    readonly args: Effect.Effect<ReadonlyArray<string>>
+    /**
+     * Whether standard input is attached to a terminal.
+     *
+     * @since 4.0.0
+     */
+    readonly stdinIsTerminal: Effect.Effect<boolean>
+    /**
+     * Whether standard output is attached to a terminal.
+     *
+     * @since 4.0.0
+     */
+    readonly stdoutIsTerminal: Effect.Effect<boolean>
+    stdout(options?: {
+      readonly endOnDone?: boolean | undefined
+    }): Sink.Sink<void, string | Uint8Array, never, PlatformError>
+    stderr(options?: {
+      readonly endOnDone?: boolean | undefined
+    }): Sink.Sink<void, string | Uint8Array, never, PlatformError>
+    readonly stdin: Stream.Stream<Uint8Array, PlatformError>
+  }
 }
 /**
  * Service tag for process standard I/O.
@@ -97,7 +105,7 @@ export interface Stdio {
  * @category services
  * @since 4.0.0
  */
-export const Stdio: Context.Service<Stdio, Stdio> = Context.Service<Stdio>(TypeId)
+export class Stdio extends Context.Service<Stdio, Stdio.Service>()(TypeId) {}
 
 /**
  * Creates a `Stdio` service implementation from the provided fields and
@@ -121,9 +129,9 @@ export const Stdio: Context.Service<Stdio, Stdio> = Context.Service<Stdio>(TypeI
  */
 export const make = (
   options:
-    & Omit<Stdio, TypeId | "stdinIsTerminal" | "stdoutIsTerminal">
-    & Partial<Pick<Stdio, "stdinIsTerminal" | "stdoutIsTerminal">>
-): Stdio => ({
+    & Omit<Stdio["Service"], TypeId | "stdinIsTerminal" | "stdoutIsTerminal">
+    & Partial<Pick<Stdio["Service"], "stdinIsTerminal" | "stdoutIsTerminal">>
+): Stdio["Service"] => ({
   [TypeId]: TypeId,
   stdinIsTerminal: Effect.succeed(false),
   stdoutIsTerminal: Effect.succeed(false),
@@ -149,7 +157,7 @@ export const make = (
  * @category layers
  * @since 4.0.0
  */
-export const layerTest = (impl: Partial<Stdio>): Layer.Layer<Stdio> =>
+export const layerTest = (impl: Partial<Stdio["Service"]>): Layer.Layer<Stdio> =>
   Layer.succeed(
     Stdio,
     make({

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -576,7 +576,7 @@ export const fromPull = <A, E, R, EX, RX>(
  */
 export const transformPull = <A, E, R, B, E2, R2, EX, RX>(
   self: Stream<A, E, R>,
-  f: (pull: Pull.Pull<Arr.NonEmptyReadonlyArray<A>, E, void>, scope: Scope.Scope) => Effect.Effect<
+  f: (pull: Pull.Pull<Arr.NonEmptyReadonlyArray<A>, E, void>, scope: Scope.Scope["Service"]) => Effect.Effect<
     Pull.Pull<Arr.NonEmptyReadonlyArray<B>, E2, void, R2>,
     EX,
     RX
@@ -624,8 +624,8 @@ export const transformPullBracket = <A, E, R, B, E2, R2, EX, RX>(
   self: Stream<A, E, R>,
   f: (
     pull: Pull.Pull<Arr.NonEmptyReadonlyArray<A>, E, void, R>,
-    scope: Scope.Scope,
-    forkedScope: Scope.Scope
+    scope: Scope.Scope["Service"],
+    forkedScope: Scope.Scope["Service"]
   ) => Effect.Effect<
     Pull.Pull<Arr.NonEmptyReadonlyArray<B>, E2, void, R2>,
     EX,

--- a/packages/effect/src/Terminal.ts
+++ b/packages/effect/src/Terminal.ts
@@ -28,30 +28,38 @@ const TypeId = "~effect/Terminal"
  * @category services
  * @since 4.0.0
  */
-export interface Terminal {
-  readonly [TypeId]: typeof TypeId
+export declare namespace Terminal {
+  /**
+   * Implementation of the Terminal service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service {
+    readonly [TypeId]: typeof TypeId
 
-  /**
-   * The number of columns available on the platform's terminal interface.
-   */
-  readonly columns: Effect.Effect<number>
-  /**
-   * The number of rows available on the platform's terminal interface.
-   */
+    /**
+     * The number of columns available on the platform's terminal interface.
+     */
+    readonly columns: Effect.Effect<number>
+    /**
+     * The number of rows available on the platform's terminal interface.
+     */
 
-  readonly rows: Effect.Effect<number>
-  /**
-   * Reads input events from the default standard input.
-   */
-  readonly readInput: Effect.Effect<Queue.Dequeue<UserInput, Cause.Done>, never, Scope.Scope>
-  /**
-   * Reads a single line from the default standard input.
-   */
-  readonly readLine: Effect.Effect<string, QuitError>
-  /**
-   * Displays text to the default standard output.
-   */
-  readonly display: (text: string) => Effect.Effect<void, PlatformError>
+    readonly rows: Effect.Effect<number>
+    /**
+     * Reads input events from the default standard input.
+     */
+    readonly readInput: Effect.Effect<Queue.Dequeue<UserInput, Cause.Done>, never, Scope.Scope>
+    /**
+     * Reads a single line from the default standard input.
+     */
+    readonly readLine: Effect.Effect<string, QuitError>
+    /**
+     * Displays text to the default standard output.
+     */
+    readonly display: (text: string) => Effect.Effect<void, PlatformError>
+  }
 }
 
 /**
@@ -163,7 +171,7 @@ export const isQuitError = (u: unknown): u is QuitError => Predicate.hasProperty
  * @category services
  * @since 4.0.0
  */
-export const Terminal: Context.Service<Terminal, Terminal> = Context.Service("effect/Terminal")
+export class Terminal extends Context.Service<Terminal, Terminal.Service>()("effect/Terminal") {}
 
 /**
  * Creates a `Terminal` service implementation.
@@ -184,5 +192,5 @@ export const Terminal: Context.Service<Terminal, Terminal> = Context.Service("ef
  * @since 4.0.0
  */
 export const make = (
-  impl: Omit<Terminal, typeof TypeId>
-): Terminal => Terminal.of({ ...impl, [TypeId]: TypeId })
+  impl: Omit<Terminal["Service"], typeof TypeId>
+): Terminal["Service"] => Terminal.of({ ...impl, [TypeId]: TypeId })

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -27,7 +27,7 @@ import { currentFiberTypeId, redact } from "../Redactable.ts"
 import type { StackFrame } from "../References.ts"
 import * as Result from "../Result.ts"
 import * as Scheduler from "../Scheduler.ts"
-import type * as Scope from "../Scope.ts"
+import type * as ScopeModule from "../Scope.ts"
 import * as Tracer from "../Tracer.ts"
 import type {
   Concurrency,
@@ -2246,7 +2246,7 @@ export const updateServiceScoped = <I, A>(
   options?: {
     readonly reset?: ((original: A, updated: A, current: A) => A) | undefined
   } | undefined
-): Effect.Effect<void, never, I | Scope.Scope> =>
+): Effect.Effect<void, never, I | ScopeModule.Scope> =>
   uninterruptible(withFiber((fiber) => {
     const original = Context.getUnsafe(fiber.context, service)
     const updated = update(original)
@@ -3903,16 +3903,19 @@ export const ScopeTypeId = "~effect/Scope"
 export const ScopeCloseableTypeId = "~effect/Scope/Closeable"
 
 /** @internal */
-export const scopeTag: Context.Service<Scope.Scope, Scope.Scope> = Context.Service<Scope.Scope>("effect/Scope")
+export class Scope extends Context.Service<Scope, ScopeModule.Scope.Service>()("effect/Scope") {}
 
 /** @internal */
-export const scopeClose = <A, E>(self: Scope.Scope, exit_: Exit.Exit<A, E>) =>
+export const scopeTag = Scope
+
+/** @internal */
+export const scopeClose = <A, E>(self: ScopeModule.Scope["Service"], exit_: Exit.Exit<A, E>) =>
   suspend(() => scopeCloseUnsafe(self, exit_) ?? void_)
 
 /** @internal */
-export const scopeCloseUnsafe = <A, E>(self: Scope.Scope, exit_: Exit.Exit<A, E>) => {
+export const scopeCloseUnsafe = <A, E>(self: ScopeModule.Scope["Service"], exit_: Exit.Exit<A, E>) => {
   if (self.state._tag === "Closed") return
-  const closed: Scope.State.Closed = { _tag: "Closed", exit: exit_ }
+  const closed: ScopeModule.State.Closed = { _tag: "Closed", exit: exit_ }
   if (self.state._tag === "Empty") {
     self.state = closed
     return
@@ -3938,8 +3941,8 @@ const combineFinalizerCause = <A, E, XE, XR>(
   exitIsSuccess(exit_) ? finalizer : catchCause(finalizer, (cause) => failCause(causeCombine(exit_.cause, cause)))
 
 const scopeCloseFinalizers = fnUntraced(function*<A, E>(
-  self: Scope.Scope,
-  finalizers: NonNullable<Scope.State.Open["finalizers"]>,
+  self: ScopeModule.Scope["Service"],
+  finalizers: NonNullable<ScopeModule.State.Open["finalizers"]>,
   exit_: Exit.Exit<A, E>
 ) {
   let exits: Array<Exit.Exit<any, never>> = []
@@ -3961,11 +3964,11 @@ const scopeCloseFinalizers = fnUntraced(function*<A, E>(
 })
 
 /** @internal */
-export const scopeFork = (scope: Scope.Scope, finalizerStrategy?: "sequential" | "parallel") =>
+export const scopeFork = (scope: ScopeModule.Scope["Service"], finalizerStrategy?: "sequential" | "parallel") =>
   sync(() => scopeForkUnsafe(scope, finalizerStrategy))
 
 /** @internal */
-export const scopeForkUnsafe = (scope: Scope.Scope, finalizerStrategy?: "sequential" | "parallel") => {
+export const scopeForkUnsafe = (scope: ScopeModule.Scope["Service"], finalizerStrategy?: "sequential" | "parallel") => {
   const newScope = scopeMakeUnsafe(finalizerStrategy)
   if (scope.state._tag === "Closed") {
     newScope.state = scope.state
@@ -3979,7 +3982,7 @@ export const scopeForkUnsafe = (scope: Scope.Scope, finalizerStrategy?: "sequent
 
 /** @internal */
 export const scopeAddFinalizerExit = (
-  scope: Scope.Scope,
+  scope: ScopeModule.Scope["Service"],
   finalizer: (exit: Exit.Exit<any, any>) => Effect.Effect<unknown>
 ): Effect.Effect<void> => {
   return suspend(() => {
@@ -3993,13 +3996,13 @@ export const scopeAddFinalizerExit = (
 
 /** @internal */
 export const scopeAddFinalizer = (
-  scope: Scope.Scope,
+  scope: ScopeModule.Scope["Service"],
   finalizer: Effect.Effect<unknown>
 ): Effect.Effect<void> => scopeAddFinalizerExit(scope, constant(finalizer))
 
 /** @internal */
 export const scopeAddFinalizerUnsafe = (
-  scope: Scope.Scope,
+  scope: ScopeModule.Scope["Service"],
   key: {},
   finalizer: (exit: Exit.Exit<any, any>) => Effect.Effect<unknown>
 ): void => {
@@ -4023,7 +4026,7 @@ export const scopeAddFinalizerUnsafe = (
 
 /** @internal */
 export const scopeRemoveFinalizerUnsafe = (
-  scope: Scope.Scope,
+  scope: ScopeModule.Scope["Service"],
   key: {}
 ): void => {
   if (scope.state._tag === "Open") {
@@ -4038,7 +4041,7 @@ export const scopeRemoveFinalizerUnsafe = (
 }
 
 /** @internal */
-export const scopeFinalizerCountUnsafe = (scope: Scope.Scope): number =>
+export const scopeFinalizerCountUnsafe = (scope: ScopeModule.Scope["Service"]): number =>
   scope.state._tag !== "Open"
     ? 0
     : scope.state.finalizer !== undefined
@@ -4046,7 +4049,9 @@ export const scopeFinalizerCountUnsafe = (scope: Scope.Scope): number =>
     : (scope.state.finalizers?.size ?? 0)
 
 /** @internal */
-export const scopeMakeUnsafe = (finalizerStrategy: "sequential" | "parallel" = "sequential"): Scope.Closeable => ({
+export const scopeMakeUnsafe = (
+  finalizerStrategy: "sequential" | "parallel" = "sequential"
+): ScopeModule.Closeable => ({
   [ScopeCloseableTypeId]: ScopeCloseableTypeId,
   [ScopeTypeId]: ScopeTypeId,
   strategy: finalizerStrategy,
@@ -4056,20 +4061,25 @@ export const scopeMakeUnsafe = (finalizerStrategy: "sequential" | "parallel" = "
 const constScopeEmpty = { _tag: "Empty" } as const
 
 /** @internal */
-export const scopeMake = (finalizerStrategy?: "sequential" | "parallel"): Effect.Effect<Scope.Closeable> =>
+export const scopeMake = (finalizerStrategy?: "sequential" | "parallel"): Effect.Effect<ScopeModule.Closeable> =>
   sync(() => scopeMakeUnsafe(finalizerStrategy))
 
 /** @internal */
-export const scope: Effect.Effect<Scope.Scope, never, Scope.Scope> = scopeTag
+export const scope: Effect.Effect<ScopeModule.Scope["Service"], never, ScopeModule.Scope> = scopeTag
 
 /** @internal */
 export const provideScope: {
-  (value: Scope.Scope): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Scope.Scope>>
-  <A, E, R>(self: Effect.Effect<A, E, R>, value: Scope.Scope): Effect.Effect<A, E, Exclude<R, Scope.Scope>>
+  (
+    value: ScopeModule.Scope["Service"]
+  ): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, ScopeModule.Scope>>
+  <A, E, R>(
+    self: Effect.Effect<A, E, R>,
+    value: ScopeModule.Scope["Service"]
+  ): Effect.Effect<A, E, Exclude<R, ScopeModule.Scope>>
 } = provideService(scopeTag)
 
 /** @internal */
-export const scoped = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, Exclude<R, Scope.Scope>> =>
+export const scoped = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, Exclude<R, ScopeModule.Scope>> =>
   withFiber((fiber) => {
     const prev = fiber.context
     const scope = scopeMakeUnsafe()
@@ -4083,18 +4093,24 @@ export const scoped = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, 
 /** @internal */
 export const scopeUse: {
   (
-    scope: Scope.Closeable
-  ): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Scope.Scope>>
-  <A, E, R>(self: Effect.Effect<A, E, R>, scope: Scope.Closeable): Effect.Effect<A, E, Exclude<R, Scope.Scope>>
+    scope: ScopeModule.Closeable
+  ): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, ScopeModule.Scope>>
+  <A, E, R>(
+    self: Effect.Effect<A, E, R>,
+    scope: ScopeModule.Closeable
+  ): Effect.Effect<A, E, Exclude<R, ScopeModule.Scope>>
 } = dual(
   2,
-  <A, E, R>(self: Effect.Effect<A, E, R>, scope: Scope.Closeable): Effect.Effect<A, E, Exclude<R, Scope.Scope>> =>
+  <A, E, R>(
+    self: Effect.Effect<A, E, R>,
+    scope: ScopeModule.Closeable
+  ): Effect.Effect<A, E, Exclude<R, ScopeModule.Scope>> =>
     onExit(provideScope(self, scope), (exit) => suspend(() => scopeCloseUnsafe(scope, exit) ?? void_))
 )
 
 /** @internal */
 export const scopedWith = <A, E, R>(
-  f: (scope: Scope.Scope) => Effect.Effect<A, E, R>
+  f: (scope: ScopeModule.Scope["Service"]) => Effect.Effect<A, E, R>
 ): Effect.Effect<A, E, R> =>
   suspend(() => {
     const scope = scopeMakeUnsafe()
@@ -4106,7 +4122,7 @@ export const acquireRelease = <A, E, R, R2>(
   acquire: Effect.Effect<A, E, R>,
   release: (a: A, exit: Exit.Exit<unknown, unknown>) => Effect.Effect<unknown, never, R2>,
   options?: { readonly interruptible?: boolean }
-): Effect.Effect<A, E, R | R2 | Scope.Scope> =>
+): Effect.Effect<A, E, R | R2 | ScopeModule.Scope> =>
   contextWith((context: Context.Context<R2>) =>
     uninterruptibleMask((restore) =>
       flatMap(
@@ -4123,7 +4139,7 @@ export const acquireRelease = <A, E, R, R2>(
 /** @internal */
 export const addFinalizer = <R>(
   finalizer: (exit: Exit.Exit<unknown, unknown>) => Effect.Effect<void, never, R>
-): Effect.Effect<void, never, R | Scope.Scope> =>
+): Effect.Effect<void, never, R | ScopeModule.Scope> =>
   flatMap(
     scope,
     (scope) =>
@@ -4359,7 +4375,7 @@ export const acquireUseRelease = <Resource, E, R, A, E2, R2, E3, R3>(
 /** @internal */
 export const acquireDisposable = <A extends AsyncDisposable | Disposable, E, R>(
   acquire: Effect.Effect<A, E, R>
-): Effect.Effect<A, E, R | Scope.Scope> =>
+): Effect.Effect<A, E, R | ScopeModule.Scope> =>
   acquireRelease(acquire, (resource) =>
     hasProperty(resource, Symbol.asyncDispose)
       ? promise(() => resource[Symbol.asyncDispose]())
@@ -4554,7 +4570,7 @@ export const interruptibleMask = <A, E, R>(
   })
 
 /** @internal */
-export const abortSignal: Effect.Effect<AbortSignal, never, Scope.Scope> = map(
+export const abortSignal: Effect.Effect<AbortSignal, never, ScopeModule.Scope> = map(
   acquireRelease(
     sync(() => new AbortController()),
     (controller) => sync(() => controller.abort())
@@ -5503,7 +5519,7 @@ export const awaitAllChildren = <A, E, R>(
 /** @internal */
 export const forkIn: {
   (
-    scope: Scope.Scope,
+    scope: ScopeModule.Scope["Service"],
     options?: {
       readonly startImmediately?: boolean | undefined
       readonly uninterruptible?: boolean | "inherit" | undefined
@@ -5513,7 +5529,7 @@ export const forkIn: {
   ) => Effect.Effect<Fiber.Fiber<A, E>, never, R>
   <A, E, R>(
     self: Effect.Effect<A, E, R>,
-    scope: Scope.Scope,
+    scope: ScopeModule.Scope["Service"],
     options?: {
       readonly startImmediately?: boolean | undefined
       readonly uninterruptible?: boolean | "inherit" | undefined
@@ -5523,7 +5539,7 @@ export const forkIn: {
   (args) => isEffect(args[0]),
   <A, E, R>(
     self: Effect.Effect<A, E, R>,
-    scope: Scope.Scope,
+    scope: ScopeModule.Scope["Service"],
     options?: {
       readonly startImmediately?: boolean | undefined
       readonly uninterruptible?: boolean | "inherit" | undefined
@@ -5562,15 +5578,16 @@ export const forkScoped: {
       readonly uninterruptible?: boolean | "inherit" | undefined
     } | undefined
   ): [Arg] extends [Effect.Effect<infer _A, infer _E, infer _R>] ?
-    Effect.Effect<Fiber.Fiber<_A, _E>, never, _R | Scope.Scope>
-    : <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<Fiber.Fiber<A, E>, never, R | Scope.Scope>
+    Effect.Effect<Fiber.Fiber<_A, _E>, never, _R | ScopeModule.Scope>
+    : <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<Fiber.Fiber<A, E>, never, R | ScopeModule.Scope>
 } = dual((args) => isEffect(args[0]), <A, E, R>(
   self: Effect.Effect<A, E, R>,
   options?: {
     readonly startImmediately?: boolean
     readonly uninterruptible?: boolean | "inherit"
   }
-): Effect.Effect<Fiber.Fiber<A, E>, never, R | Scope.Scope> => flatMap(scope, (scope) => forkIn(self, scope, options)))
+): Effect.Effect<Fiber.Fiber<A, E>, never, R | ScopeModule.Scope> =>
+  flatMap(scope, (scope) => forkIn(self, scope, options)))
 
 // ----------------------------------------------------------------------------
 // execution
@@ -5606,14 +5623,14 @@ export const runForkWith = <R>(context: Context.Context<R>) =>
 
 /** @internal */
 export const fiberRunIn: {
-  (scope: Scope.Scope): <A, E>(self: Fiber.Fiber<A, E>) => Fiber.Fiber<A, E>
+  (scope: ScopeModule.Scope["Service"]): <A, E>(self: Fiber.Fiber<A, E>) => Fiber.Fiber<A, E>
   <A, E>(
     self: Fiber.Fiber<A, E>,
-    scope: Scope.Scope
+    scope: ScopeModule.Scope["Service"]
   ): Fiber.Fiber<A, E>
 } = dual(2, <A, E>(
   self: FiberImpl<A, E>,
-  scope: Scope.Scope
+  scope: ScopeModule.Scope["Service"]
 ): Fiber.Fiber<A, E> => {
   if (self._exit) {
     return self
@@ -5965,7 +5982,7 @@ export const makeSpan = (
 export const makeSpanScoped = (
   name: string,
   options?: Tracer.SpanOptionsNoTrace | undefined
-): Effect.Effect<Tracer.Span, never, Scope.Scope> =>
+): Effect.Effect<Tracer.Span, never, ScopeModule.Scope> =>
   uninterruptible(
     withFiber((fiber) => {
       const scope = Context.getUnsafe(fiber.context, scopeTag)
@@ -5984,12 +6001,12 @@ export const withSpanScoped: {
   (
     name: string,
     options?: Tracer.SpanOptions
-  ): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Tracer.ParentSpan> | Scope.Scope>
+  ): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Tracer.ParentSpan> | ScopeModule.Scope>
   <A, E, R>(
     self: Effect.Effect<A, E, R>,
     name: string,
     options?: Tracer.SpanOptions
-  ): Effect.Effect<A, E, Exclude<R, Tracer.ParentSpan> | Scope.Scope>
+  ): Effect.Effect<A, E, Exclude<R, Tracer.ParentSpan> | ScopeModule.Scope>
 } = function() {
   const dataFirst = typeof arguments[0] !== "string"
   const name = dataFirst ? arguments[1] : arguments[0]
@@ -6444,8 +6461,8 @@ export const LogToStderr = Context.Reference<boolean>("effect/Logger/LogToStderr
 
 /** @internal */
 export const annotateLogsScoped: {
-  (key: string, value: unknown): Effect.Effect<void, never, Scope.Scope>
-  (values: Record<string, unknown>): Effect.Effect<void, never, Scope.Scope>
+  (key: string, value: unknown): Effect.Effect<void, never, ScopeModule.Scope>
+  (values: Record<string, unknown>): Effect.Effect<void, never, ScopeModule.Scope>
 } = function() {
   const entries = typeof arguments[0] === "string" ?
     [[arguments[0], arguments[1]]] :

--- a/packages/effect/src/internal/rcRef.ts
+++ b/packages/effect/src/internal/rcRef.ts
@@ -51,13 +51,13 @@ class RcRefImpl<A, E> implements RcRef.RcRef<A, E> {
   readonly semaphore = Semaphore.makeUnsafe(1)
   readonly acquire: Effect.Effect<A, E>
   readonly context: Context.Context<never>
-  readonly scope: Scope.Scope
+  readonly scope: Scope.Scope["Service"]
   readonly idleTimeToLive: Duration.Duration | undefined
 
   constructor(
     acquire: Effect.Effect<A, E>,
     context: Context.Context<never>,
-    scope: Scope.Scope,
+    scope: Scope.Scope["Service"],
     idleTimeToLive: Duration.Duration | undefined
   ) {
     this.acquire = acquire

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -1340,7 +1340,7 @@ export const layerHttp = (options: {
     status: 405,
     headers: { allow: "POST" }
   })
-  const methodNotAllowed = (request: HttpServerRequest.HttpServerRequest) =>
+  const methodNotAllowed = (request: HttpServerRequest.HttpServerRequest["Service"]) =>
     isAllowedMcpOrigin(request, options.allowedOrigins)
       ? Effect.succeed(methodNotAllowedResponse)
       : Effect.succeed(HttpServerResponse.empty({ status: 403 }))
@@ -1466,7 +1466,7 @@ const layerMcpProtocolHttp = (options: {
   }))
 
 const isAllowedMcpOrigin = (
-  request: HttpServerRequest.HttpServerRequest,
+  request: HttpServerRequest.HttpServerRequest["Service"],
   allowedOrigins: ReadonlyArray<string> | undefined
 ): boolean => {
   const origin = request.headers["origin"]

--- a/packages/effect/src/unstable/cli/GlobalFlag.ts
+++ b/packages/effect/src/unstable/cli/GlobalFlag.ts
@@ -126,9 +126,10 @@ export const Setting = <const Id extends string>(
   readonly flag: Flag.Flag<A>
 }): Setting<Id, A> => {
   settingIdCounter += 1
-  const ref = Context.Service<Setting.Identifier<Id>, A>(
+  // This factory preserves its public string identifier independently of the parsed value type.
+  const ref: Context.Service<Setting.Identifier<Id>, A> = class extends Context.Service<Setting.Identifier<Id>, A>()(
     `effect/unstable/cli/GlobalFlag/${id}/${settingIdCounter}`
-  )
+  ) {}
   return Object.assign(ref, {
     _tag: "Setting" as const,
     id,

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -1449,7 +1449,7 @@ const allTupled = <const T extends ArrayLike<Prompt<any>>>(arg: T): Prompt<
 
 const runWithInput = <Output>(
   prompt: Prompt<Output>,
-  terminal: Terminal.Terminal,
+  terminal: Terminal.Terminal["Service"],
   input: Queue.Dequeue<Terminal.UserInput, Cause.Done>
 ): Effect.Effect<Output, NoSuchElementError, Environment> =>
   Effect.suspend(() => {
@@ -1473,7 +1473,7 @@ const runWithInput = <Output>(
 const runLoop = Effect.fnUntraced(
   function*(
     loop: Loop,
-    terminal: Terminal.Terminal,
+    terminal: Terminal.Terminal["Service"],
     input: Queue.Dequeue<Terminal.UserInput, Cause.Done>
   ) {
     let state = Effect.isEffect(loop.initialState) ? yield* loop.initialState : loop.initialState

--- a/packages/effect/src/unstable/cli/internal/command.ts
+++ b/packages/effect/src/unstable/cli/internal/command.ts
@@ -111,7 +111,9 @@ export const makeCommand = <const Name extends string, Input, E, R, ContextInput
 }): Command<Name, Input, ContextInput, E, R> => {
   const config = options.config
   const contextConfig = options.contextConfig ?? emptyConfig
-  const service = options.service ?? Context.Service<CommandContext<Name>, ContextInput>(`${TypeId}/${options.name}`)
+  // Command keys use CommandContext<Name>, independently of their parsed input shape.
+  const service = options.service ??
+    class extends Context.Service<CommandContext<Name>, ContextInput>()(`${TypeId}/${options.name}`) {}
   const annotations = options.annotations ?? Context.empty()
   const globalFlags = options.globalFlags ?? []
   const subcommands = options.subcommands ?? []

--- a/packages/effect/src/unstable/cluster/Entity.ts
+++ b/packages/effect/src/unstable/cluster/Entity.ts
@@ -263,10 +263,10 @@ const Proto = {
     return fromRpcGroup(this.type, this.protocol.annotateRpcsMerge(annotations))
   },
   getShardId(this: Entity<string, any>, entityId: EntityId) {
-    return Effect.map(shardingTag, (sharding) => sharding.getShardId(entityId, this.getShardGroup(entityId)))
+    return Effect.map(ShardingTag, (sharding) => sharding.getShardId(entityId, this.getShardGroup(entityId)))
   },
   get client() {
-    return shardingTag.pipe(
+    return ShardingTag.pipe(
       Effect.flatMap((sharding) => sharding.makeClient(this as any))
     )
   },
@@ -295,7 +295,7 @@ const Proto = {
     | Rpc.Middleware<Rpcs>
     | Sharding
   > {
-    return shardingTag.pipe(
+    return ShardingTag.pipe(
       Effect.flatMap((sharding) =>
         sharding.registerEntity(
           this,
@@ -586,7 +586,7 @@ export class Request<Rpc extends Rpc.Any> extends Data.Class<
   }
 }
 
-const shardingTag = Context.Service<Sharding, Sharding["Service"]>("effect/cluster/Sharding")
+class ShardingTag extends Context.Service<ShardingTag, Sharding["Service"]>()("effect/cluster/Sharding") {}
 
 /**
  * Builds an in-memory test client for an entity layer.
@@ -626,7 +626,7 @@ export const makeTestClient: <Type extends string, Rpcs extends Rpc.Any, LA, LE,
     readonly disableFatalDefects: boolean | undefined
     readonly build: Effect.Effect<Context.Context<Rpc.ToHandler<Rpcs>>>
   }>()
-  const sharding = shardingTag.of({
+  const sharding = ShardingTag.of({
     ...({} as Sharding["Service"]),
     registerEntity: (entity, handlers, options) =>
       Effect.contextWith((context) => {
@@ -639,7 +639,7 @@ export const makeTestClient: <Type extends string, Rpcs extends Rpc.Any, LA, LE,
         return Effect.void
       })
   })
-  yield* Layer.build(Layer.provide(layer, Layer.succeed(shardingTag)(sharding)))
+  yield* Layer.build(Layer.provide(layer, Layer.succeed(ShardingTag)(sharding)))
   const entityEntry = entityMap.get(entity.type)
   if (!entityEntry) {
     return yield* Effect.die(`Entity.makeTestClient: ${entity.type} was not registered by layer`)
@@ -722,7 +722,7 @@ export const keepAlive: (
     yield* olatch.value.open
     return
   }
-  const sharding = yield* shardingTag
+  const sharding = yield* ShardingTag
   const address = yield* CurrentAddress
   const requestId = yield* sharding.getSnowflake
   const span = yield* Effect.orDie(Effect.currentSpan)

--- a/packages/effect/src/unstable/cluster/EntityResource.ts
+++ b/packages/effect/src/unstable/cluster/EntityResource.ts
@@ -71,7 +71,7 @@ export interface EntityResource<out A, out E = never> {
  */
 export class CloseScope extends Context.Service<
   CloseScope,
-  Scope.Scope
+  Scope.Scope["Service"]
 >()("effect/cluster/EntityResource/CloseScope") {}
 
 /**

--- a/packages/effect/src/unstable/cluster/K8sHttpClient.ts
+++ b/packages/effect/src/unstable/cluster/K8sHttpClient.ts
@@ -29,7 +29,7 @@ import type { Pod as K8sPod } from "./K8sTypes.ts"
  */
 export class K8sHttpClient extends Context.Service<
   K8sHttpClient,
-  HttpClient.HttpClient
+  HttpClient.HttpClient["Service"]
 >()("effect/cluster/K8sHttpClient") {}
 
 /**

--- a/packages/effect/src/unstable/cluster/Sharding.ts
+++ b/packages/effect/src/unstable/cluster/Sharding.ts
@@ -1808,4 +1808,6 @@ export const layer: Layer.Layer<
 
 // Utilities
 
-const ClientAddressTag = Context.Service<EntityAddress>("effect/cluster/Sharding/ClientAddress")
+class ClientAddressTag
+  extends Context.Service<ClientAddressTag, EntityAddress>()("effect/cluster/Sharding/ClientAddress")
+{}

--- a/packages/effect/src/unstable/cluster/SqlRunnerStorage.ts
+++ b/packages/effect/src/unstable/cluster/SqlRunnerStorage.ts
@@ -87,7 +87,7 @@ export const make = Effect.fnUntraced(function*(options: {
   // reserved connection, including when advisory locks are disabled.
   const acquireLockConn = sql.onDialectOrElse({
     pg: () =>
-      Effect.fnUntraced(function*(scope: Scope.Scope) {
+      Effect.fnUntraced(function*(scope: Scope.Scope["Service"]) {
         const conn = yield* Effect.orDie(sql.reserve).pipe(
           Scope.provide(scope)
         )
@@ -105,7 +105,7 @@ export const make = Effect.fnUntraced(function*(options: {
         return [conn, pid] as const
       }, Effect.orDie),
     mysql: () =>
-      Effect.fnUntraced(function*(scope: Scope.Scope) {
+      Effect.fnUntraced(function*(scope: Scope.Scope["Service"]) {
         const conn = yield* Effect.orDie(sql.reserve).pipe(
           Scope.provide(scope)
         )

--- a/packages/effect/src/unstable/cluster/internal/entityManager.ts
+++ b/packages/effect/src/unstable/cluster/internal/entityManager.ts
@@ -83,7 +83,7 @@ export interface Residency {
 /** @internal */
 export type EntityState = {
   readonly address: EntityAddress
-  readonly scope: Scope.Scope
+  readonly scope: Scope.Scope["Service"]
   readonly activeRequests: Map<Snowflake.Snowflake, {
     readonly rpc: Rpc.AnyWithProps
     readonly message: Message.IncomingRequestLocal<any>

--- a/packages/effect/src/unstable/cluster/internal/resourceMap.ts
+++ b/packages/effect/src/unstable/cluster/internal/resourceMap.ts
@@ -8,11 +8,11 @@ import * as Scope from "../../../Scope.ts"
 
 /** @internal */
 export class ResourceMap<K, A, E> {
-  readonly lookup: (key: K, scope: Scope.Scope) => Effect.Effect<A, E>
+  readonly lookup: (key: K, scope: Scope.Scope["Service"]) => Effect.Effect<A, E>
   readonly entries: BackingMap<K, A, E>
   readonly isClosed: MutableRef.MutableRef<boolean>
   constructor(
-    lookup: (key: K, scope: Scope.Scope) => Effect.Effect<A, E>,
+    lookup: (key: K, scope: Scope.Scope["Service"]) => Effect.Effect<A, E>,
     entries: BackingMap<K, A, E>,
     isClosed: MutableRef.MutableRef<boolean>
   ) {

--- a/packages/effect/src/unstable/cluster/internal/resourceRef.ts
+++ b/packages/effect/src/unstable/cluster/internal/resourceRef.ts
@@ -27,8 +27,8 @@ export type State<A, E> = {
 /** @internal */
 export class ResourceRef<A, E = never> {
   static from = Effect.fnUntraced(function*<A, E>(
-    parentScope: Scope.Scope,
-    acquire: (scope: Scope.Scope) => Effect.Effect<A, E>,
+    parentScope: Scope.Scope["Service"],
+    acquire: (scope: Scope.Scope["Service"]) => Effect.Effect<A, E>,
     teardownAddress?: EntityAddress
   ) {
     const state = MutableRef.make<State<A, E>>({ _tag: "Closed" })
@@ -52,11 +52,11 @@ export class ResourceRef<A, E = never> {
   })
 
   readonly state: MutableRef.MutableRef<State<A, E>>
-  readonly acquire: (scope: Scope.Scope) => Effect.Effect<A, E>
+  readonly acquire: (scope: Scope.Scope["Service"]) => Effect.Effect<A, E>
   readonly teardownAddress: EntityAddress | undefined
   constructor(
     state: MutableRef.MutableRef<State<A, E>>,
-    acquire: (scope: Scope.Scope) => Effect.Effect<A, E>,
+    acquire: (scope: Scope.Scope["Service"]) => Effect.Effect<A, E>,
     teardownAddress?: EntityAddress
   ) {
     this.state = state

--- a/packages/effect/src/unstable/http/FetchHttpClient.ts
+++ b/packages/effect/src/unstable/http/FetchHttpClient.ts
@@ -50,7 +50,7 @@ export class RequestInit extends Context.Service<RequestInit, globalThis.Request
   "effect/http/FetchHttpClient/RequestInit"
 ) {}
 
-const fetch: HttpClient.HttpClient = HttpClient.make((request, url, signal, fiber) => {
+const fetch: HttpClient.HttpClient["Service"] = HttpClient.make((request, url, signal, fiber) => {
   const fetch = fiber.getRef(Fetch)
   const options: globalThis.RequestInit = Context.getOrUndefined(fiber.context, RequestInit) ?? {}
   let headers = options.headers

--- a/packages/effect/src/unstable/http/HttpClient.ts
+++ b/packages/effect/src/unstable/http/HttpClient.ts
@@ -51,7 +51,7 @@ const TypeId = "~effect/http/HttpClient"
  * @category guards
  * @since 4.0.0
  */
-export const isHttpClient = (u: unknown): u is HttpClient => Predicate.hasProperty(u, TypeId)
+export const isHttpClient = (u: unknown): u is HttpClient["Service"] => Predicate.hasProperty(u, TypeId)
 
 /**
  * HTTP client whose requests produce `HttpClientResponse` values and can fail with `HttpClientError`.
@@ -59,7 +59,15 @@ export const isHttpClient = (u: unknown): u is HttpClient => Predicate.hasProper
  * @category models
  * @since 4.0.0
  */
-export interface HttpClient extends HttpClient.With<Error.HttpClientError> {}
+export declare namespace HttpClient {
+  /**
+   * Implementation of the HttpClient service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service extends HttpClient.With<Error.HttpClientError> {}
+}
 
 /**
  * Namespace containing type-level members associated with `HttpClient`.
@@ -147,11 +155,9 @@ export declare namespace HttpClient {
  * @category services
  * @since 4.0.0
  */
-export const HttpClient: Context.Service<HttpClient, HttpClient> = Context.Service<HttpClient, HttpClient>(
-  "effect/HttpClient"
-)
+export class HttpClient extends Context.Service<HttpClient, HttpClient.Service>()("effect/HttpClient") {}
 
-const accessor = (method: keyof HttpClient) => (...args: Array<any>): Effect.Effect<any, any, any> =>
+const accessor = (method: keyof HttpClient["Service"]) => (...args: Array<any>): Effect.Effect<any, any, any> =>
   Effect.flatMap(
     HttpClient,
     (client) => (client as any)[method](...args)
@@ -609,7 +615,7 @@ const Proto = {
   ...Object.fromEntries(
     HttpMethod.allShort.map((
       [fullMethod, method]
-    ) => [method, function(this: HttpClient, url: string | URL, options?: HttpClientRequest.Options.NoUrl) {
+    ) => [method, function(this: HttpClient["Service"], url: string | URL, options?: HttpClientRequest.Options.NoUrl) {
       return this.execute(HttpClientRequest.make(fullMethod)(url, options))
     }])
   )
@@ -632,7 +638,7 @@ export const make = (
     signal: AbortSignal,
     fiber: Fiber.Fiber<HttpClientResponse.HttpClientResponse, Error.HttpClientError>
   ) => Effect.Effect<HttpClientResponse.HttpClientResponse, Error.HttpClientError>
-): HttpClient =>
+): HttpClient["Service"] =>
   makeWith((effect) =>
     Effect.flatMap(effect, (request) =>
       Effect.withFiber((fiber) => {
@@ -1006,7 +1012,7 @@ export declare namespace WithRateLimiter {
     /**
      * The `RateLimiter` service to use for rate limiting.
      */
-    readonly limiter: RateLimiter.RateLimiter
+    readonly limiter: RateLimiter.RateLimiter["Service"]
     /**
      * The initial rate limit window duration.
      */
@@ -1642,7 +1648,7 @@ export const SpanNameGenerator = Context.Reference<
  * @since 4.0.0
  */
 export const layerMergedContext = <E, R>(
-  effect: Effect.Effect<HttpClient, E, R>
+  effect: Effect.Effect<HttpClient["Service"], E, R>
 ): Layer.Layer<HttpClient, E, R> =>
   Layer.effect(HttpClient)(
     Effect.contextWith((context: Context.Context<never>) =>

--- a/packages/effect/src/unstable/http/HttpEffect.ts
+++ b/packages/effect/src/unstable/http/HttpEffect.ts
@@ -38,12 +38,12 @@ import * as preResponseHandler from "./internal/preResponseHandler.ts"
 export const toHandled = <E, R, EH, RH>(
   self: Effect.Effect<HttpServerResponse, E, R>,
   handleResponse: (
-    request: HttpServerRequest,
+    request: HttpServerRequest["Service"],
     response: HttpServerResponse
   ) => Effect.Effect<unknown, EH, RH>,
   middleware?: HttpMiddleware | undefined
 ): Effect.Effect<void, never, Exclude<R | RH | HttpServerRequest, Scope.Scope>> => {
-  const handleCause = (request: HttpServerRequest, cause: Cause.Cause<E | EH | HttpServerError>) =>
+  const handleCause = (request: HttpServerRequest["Service"], cause: Cause.Cause<E | EH | HttpServerError>) =>
     Effect.flatMapEager(causeResponse(cause), ([response, cause]) => {
       const fiber = Fiber.getCurrent()!
       reportCauseUnsafe(fiber, cause)
@@ -69,7 +69,7 @@ export const toHandled = <E, R, EH, RH>(
   // Writes the response, applying any registered pre-response handler first.
   // Returns an `Exit` when the write completes synchronously.
   const sendResponse = (
-    request: HttpServerRequest,
+    request: HttpServerRequest["Service"],
     response: HttpServerResponse
   ): Effect.Effect<HttpServerResponse, EH | HttpServerError, RH> => {
     const handler = preResponseHandler.requestPreResponseHandlers.get(request.source)
@@ -83,7 +83,7 @@ export const toHandled = <E, R, EH, RH>(
     })
   }
 
-  const withMiddleware = (request: HttpServerRequest): Effect.Effect<
+  const withMiddleware = (request: HttpServerRequest["Service"]): Effect.Effect<
     unknown,
     E | EH | HttpServerError,
     HttpServerRequest | R | RH
@@ -114,7 +114,7 @@ export const toHandled = <E, R, EH, RH>(
   }
 
   // Apply tracing lazily so disabled requests can use the single-frame path.
-  const traced = (request: HttpServerRequest) =>
+  const traced = (request: HttpServerRequest["Service"]) =>
     tracer(
       withMiddleware(request) as Effect.Effect<
         HttpServerResponse,
@@ -139,8 +139,8 @@ export const toHandled = <E, R, EH, RH>(
   class RequestFrame {
     readonly scope: Scope.Closeable
     readonly prev: Context.Context<never>
-    readonly request: HttpServerRequest
-    constructor(scope: Scope.Closeable, prev: Context.Context<never>, request: HttpServerRequest) {
+    readonly request: HttpServerRequest["Service"]
+    constructor(scope: Scope.Closeable, prev: Context.Context<never>, request: HttpServerRequest["Service"]) {
       this.scope = scope
       this.prev = prev
       this.request = request
@@ -192,7 +192,7 @@ const handledSymbol = Symbol.for("effect/http/HttpEffect/handled")
  * @category resource management
  * @since 4.0.0
  */
-export const scopeDisableClose = (scope: Scope.Scope): void => {
+export const scopeDisableClose = (scope: Scope.Scope["Service"]): void => {
   ;(scope as any)[scopeEjected] = true
 }
 
@@ -230,7 +230,7 @@ const scopeEjected = Symbol.for("effect/http/HttpEffect/scopeEjected")
  * @since 4.0.0
  */
 export type PreResponseHandler = (
-  request: HttpServerRequest,
+  request: HttpServerRequest["Service"],
   response: HttpServerResponse
 ) => Effect.Effect<HttpServerResponse, HttpServerError>
 
@@ -253,7 +253,7 @@ export const appendPreResponseHandler = (handler: PreResponseHandler): Effect.Ef
  * @since 4.0.0
  */
 export const appendPreResponseHandlerUnsafe: (
-  request: HttpServerRequest,
+  request: HttpServerRequest["Service"],
   handler: PreResponseHandler
 ) => void = preResponseHandler.appendPreResponseHandlerUnsafe
 

--- a/packages/effect/src/unstable/http/HttpMiddleware.ts
+++ b/packages/effect/src/unstable/http/HttpMiddleware.ts
@@ -104,7 +104,7 @@ export const withLoggerDisabled = <A, E, R>(self: Effect.Effect<A, E, R>): Effec
  * @category services
  * @since 4.0.0
  */
-export const TracerDisabledWhen = Context.Reference<Predicate<HttpServerRequest>>(
+export const TracerDisabledWhen = Context.Reference<Predicate<HttpServerRequest["Service"]>>(
   "effect/http/HttpMiddleware/TracerDisabledWhen",
   { defaultValue: () => constFalse }
 )
@@ -125,7 +125,7 @@ export const layerTracerDisabledForUrls = (
  * @category services
  * @since 4.0.0
  */
-export const SpanNameGenerator = Context.Reference<(request: HttpServerRequest) => string>(
+export const SpanNameGenerator = Context.Reference<(request: HttpServerRequest["Service"]) => string>(
   "@effect/platform/HttpMiddleware/SpanNameGenerator",
   { defaultValue: () => (request) => `http.server ${request.method}` }
 )
@@ -174,7 +174,7 @@ export const logger: <E, R>(
 /** @internal */
 export const isTracerDisabledUnsafe = (
   fiber: Fiber.Fiber<unknown, unknown>,
-  request: HttpServerRequest
+  request: HttpServerRequest["Service"]
 ): boolean => !fiber.cache.tracerEnabled || fiber.getRef(TracerDisabledWhen)(request)
 
 /**
@@ -396,7 +396,7 @@ export const cors = (options?: {
     ? { "access-control-max-age": opts.maxAge.toString() }
     : undefined
 
-  const headersFromRequest = (request: HttpServerRequest) => {
+  const headersFromRequest = (request: HttpServerRequest["Service"]) => {
     const origin = request.headers["origin"]
     return Headers.fromRecordUnsafe({
       ...allowOrigin(origin),
@@ -405,7 +405,7 @@ export const cors = (options?: {
     })
   }
 
-  const headersFromRequestOptions = (request: HttpServerRequest) => {
+  const headersFromRequestOptions = (request: HttpServerRequest["Service"]) => {
     const origin = request.headers["origin"]
     const accessControlRequestHeaders = request.headers["access-control-request-headers"]
     const headers = Headers.fromRecordUnsafe({
@@ -429,7 +429,7 @@ export const cors = (options?: {
     )
   }
 
-  const preResponseHandler = (request: HttpServerRequest, response: HttpServerResponse) => {
+  const preResponseHandler = (request: HttpServerRequest["Service"], response: HttpServerResponse) => {
     const headers = headersFromRequest(request)
     return Effect.succeed(Response.setHeaders(
       response,

--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -46,52 +46,62 @@ const TypeId = "~effect/http/HttpRouter"
  * @category services
  * @since 4.0.0
  */
-export interface HttpRouter {
-  readonly [TypeId]: typeof TypeId
+export declare namespace HttpRouter {
+  /**
+   * Implementation of the HttpRouter service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service {
+    readonly [TypeId]: typeof TypeId
 
-  readonly prefixed: (prefix: string) => HttpRouter
+    readonly prefixed: (prefix: string) => HttpRouter["Service"]
 
-  readonly add: <E = never, R = never>(
-    method: "*" | "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS",
-    path: PathInput,
-    handler:
-      | HttpServerResponse.HttpServerResponse
-      | Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>
-      | ((request: HttpServerRequest.HttpServerRequest) => Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>),
-    options?: { readonly uninterruptible?: boolean | undefined } | undefined
-  ) => Effect.Effect<
-    void,
-    never,
-    Request.From<"Requires", Exclude<R, Provided>> | Request.From<"Error", E>
-  >
+    readonly add: <E = never, R = never>(
+      method: "*" | "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS",
+      path: PathInput,
+      handler:
+        | HttpServerResponse.HttpServerResponse
+        | Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>
+        | ((
+          request: HttpServerRequest.HttpServerRequest["Service"]
+        ) => Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>),
+      options?: { readonly uninterruptible?: boolean | undefined } | undefined
+    ) => Effect.Effect<
+      void,
+      never,
+      Request.From<"Requires", Exclude<R, Provided>> | Request.From<"Error", E>
+    >
 
-  readonly addAll: <const Routes extends ReadonlyArray<Route<any, any>>>(
-    routes: Routes
-  ) => Effect.Effect<
-    void,
-    never,
-    | Request.From<"Requires", Exclude<Route.Context<Routes[number]>, Provided>>
-    | Request.From<"Error", Route.Error<Routes[number]>>
-  >
+    readonly addAll: <const Routes extends ReadonlyArray<Route<any, any>>>(
+      routes: Routes
+    ) => Effect.Effect<
+      void,
+      never,
+      | Request.From<"Requires", Exclude<Route.Context<Routes[number]>, Provided>>
+      | Request.From<"Error", Route.Error<Routes[number]>>
+    >
 
-  readonly addGlobalMiddleware: <E, R>(
-    middleware:
-      & ((
-        effect: Effect.Effect<HttpServerResponse.HttpServerResponse, Types.unhandled>
-      ) => Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>)
-      & (Types.unhandled extends E ? unknown : "You cannot handle any errors")
-  ) => Effect.Effect<
-    void,
-    never,
-    | Request.From<"GlobalRequires", Exclude<R, GlobalProvided>>
-    | Request.From<"GlobalError", Exclude<E, Types.unhandled>>
-  >
+    readonly addGlobalMiddleware: <E, R>(
+      middleware:
+        & ((
+          effect: Effect.Effect<HttpServerResponse.HttpServerResponse, Types.unhandled>
+        ) => Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>)
+        & (Types.unhandled extends E ? unknown : "You cannot handle any errors")
+    ) => Effect.Effect<
+      void,
+      never,
+      | Request.From<"GlobalRequires", Exclude<R, GlobalProvided>>
+      | Request.From<"GlobalError", Exclude<E, Types.unhandled>>
+    >
 
-  readonly asHttpEffect: () => Effect.Effect<
-    HttpServerResponse.HttpServerResponse,
-    unknown,
-    HttpServerRequest.HttpServerRequest | Scope.Scope
-  >
+    readonly asHttpEffect: () => Effect.Effect<
+      HttpServerResponse.HttpServerResponse,
+      unknown,
+      HttpServerRequest.HttpServerRequest | Scope.Scope
+    >
+  }
 }
 
 /**
@@ -102,9 +112,7 @@ export interface HttpRouter {
  * @category services
  * @since 4.0.0
  */
-export const HttpRouter: Context.Service<HttpRouter, HttpRouter> = Context.Service<HttpRouter>(
-  "effect/http/HttpRouter"
-)
+export class HttpRouter extends Context.Service<HttpRouter, HttpRouter.Service>()("effect/http/HttpRouter") {}
 
 /**
  * Constructs an empty `HttpRouter` service.
@@ -163,7 +171,7 @@ export const make = Effect.gen(function*() {
 
   return HttpRouter.of({
     [TypeId]: TypeId,
-    prefixed(this: HttpRouter, prefix: string) {
+    prefixed(this: HttpRouter["Service"], prefix: string) {
       prefix = removeTrailingSlash(prefix as PathInput)
       return HttpRouter.of({
         ...this,
@@ -246,7 +254,7 @@ export const make = Effect.gen(function*() {
   })
 })
 
-function sliceRequestUrl(request: HttpServerRequest.HttpServerRequest, prefix: string) {
+function sliceRequestUrl(request: HttpServerRequest.HttpServerRequest["Service"], prefix: string) {
   const prefexLen = prefix.length
   return request.modify({ url: request.url.length <= prefexLen ? "/" : request.url.slice(prefexLen) })
 }
@@ -485,7 +493,7 @@ export const schemaPathParams = <A, I extends Readonly<Record<string, string | u
  * @since 4.0.0
  */
 export const use = <A, E, R>(
-  f: (router: HttpRouter) => Effect.Effect<A, E, R>
+  f: (router: HttpRouter["Service"]) => Effect.Effect<A, E, R>
 ): Layer.Layer<never, E, HttpRouter | Exclude<R, Scope.Scope>> => Layer.effectDiscard(Effect.flatMap(HttpRouter, f))
 
 /**
@@ -514,7 +522,9 @@ export const add = <E = never, R = never>(
   handler:
     | HttpServerResponse.HttpServerResponse
     | Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>
-    | ((request: HttpServerRequest.HttpServerRequest) => Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>),
+    | ((
+      request: HttpServerRequest.HttpServerRequest["Service"]
+    ) => Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>),
   options?: {
     readonly uninterruptible?: boolean | undefined
   }
@@ -681,7 +691,9 @@ export const route = <E = never, R = never>(
   handler:
     | HttpServerResponse.HttpServerResponse
     | Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>
-    | ((request: HttpServerRequest.HttpServerRequest) => Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>),
+    | ((
+      request: HttpServerRequest.HttpServerRequest["Service"]
+    ) => Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>),
   options?: {
     readonly uninterruptible?: boolean | undefined
   }

--- a/packages/effect/src/unstable/http/HttpServer.ts
+++ b/packages/effect/src/unstable/http/HttpServer.ts
@@ -235,7 +235,7 @@ export const withLogAddress = <A, E, R>(
  * @since 4.0.0
  */
 export const makeTestClient: Effect.Effect<
-  HttpClient.HttpClient,
+  HttpClient.HttpClient["Service"],
   never,
   HttpServer | HttpClient.HttpClient
 > = Effect.gen(function*() {

--- a/packages/effect/src/unstable/http/HttpServerError.ts
+++ b/packages/effect/src/unstable/http/HttpServerError.ts
@@ -57,7 +57,7 @@ export class HttpServerError extends Data.TaggedError("HttpServerError")<{
 
   override stack = `${this.name}: ${this.message}`
 
-  get request(): Request.HttpServerRequest {
+  get request(): Request.HttpServerRequest["Service"] {
     return this.reason.request
   }
 
@@ -89,7 +89,7 @@ export class HttpServerError extends Data.TaggedError("HttpServerError")<{
  * @since 4.0.0
  */
 export class RequestParseError extends Data.TaggedError("RequestParseError")<{
-  readonly request: Request.HttpServerRequest
+  readonly request: Request.HttpServerRequest["Service"]
   readonly description?: string
   readonly cause?: unknown
 }> implements Respondable.Respondable {
@@ -123,7 +123,7 @@ export class RequestParseError extends Data.TaggedError("RequestParseError")<{
  * @since 4.0.0
  */
 export class RouteNotFound extends Data.TaggedError("RouteNotFound")<{
-  readonly request: Request.HttpServerRequest
+  readonly request: Request.HttpServerRequest["Service"]
   readonly description?: string
   readonly cause?: unknown
 }> implements Respondable.Respondable {
@@ -153,7 +153,7 @@ export class RouteNotFound extends Data.TaggedError("RouteNotFound")<{
  * @since 4.0.0
  */
 export class InternalError extends Data.TaggedError("InternalError")<{
-  readonly request: Request.HttpServerRequest
+  readonly request: Request.HttpServerRequest["Service"]
   readonly description?: string
   readonly cause?: unknown
 }> implements Respondable.Respondable {
@@ -195,7 +195,7 @@ export const isHttpServerError = (u: unknown): u is HttpServerError => hasProper
  * @since 4.0.0
  */
 export class ResponseError extends Data.TaggedError("ResponseError")<{
-  readonly request: Request.HttpServerRequest
+  readonly request: Request.HttpServerRequest["Service"]
   readonly response: Response.HttpServerResponse
   readonly description?: string
   readonly cause?: unknown

--- a/packages/effect/src/unstable/http/HttpServerRequest.ts
+++ b/packages/effect/src/unstable/http/HttpServerRequest.ts
@@ -72,30 +72,38 @@ export const TypeId = "~effect/http/HttpServerRequest"
  * @category models
  * @since 4.0.0
  */
-export interface HttpServerRequest extends HttpIncomingMessage.HttpIncomingMessage<HttpServerError> {
-  readonly [TypeId]: typeof TypeId
-  readonly source: object
-  readonly url: string
-  readonly originalUrl: string
-  readonly method: HttpMethod
-  readonly cookies: ReadonlyRecord<string, string>
+export declare namespace HttpServerRequest {
+  /**
+   * Implementation of the HttpServerRequest service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service extends HttpIncomingMessage.HttpIncomingMessage<HttpServerError> {
+    readonly [TypeId]: typeof TypeId
+    readonly source: object
+    readonly url: string
+    readonly originalUrl: string
+    readonly method: HttpMethod
+    readonly cookies: ReadonlyRecord<string, string>
 
-  readonly multipart: Effect.Effect<
-    Multipart.Persisted,
-    Multipart.MultipartError,
-    Scope.Scope | FileSystem.FileSystem | Path.Path
-  >
-  readonly multipartStream: Stream.Stream<Multipart.Part, Multipart.MultipartError>
+    readonly multipart: Effect.Effect<
+      Multipart.Persisted,
+      Multipart.MultipartError,
+      Scope.Scope | FileSystem.FileSystem | Path.Path
+    >
+    readonly multipartStream: Stream.Stream<Multipart.Part, Multipart.MultipartError>
 
-  readonly upgrade: Effect.Effect<Socket.Socket, HttpServerError>
+    readonly upgrade: Effect.Effect<Socket.Socket["Service"], HttpServerError>
 
-  readonly modify: (
-    options: {
-      readonly url?: string
-      readonly headers?: Headers.Headers
-      readonly remoteAddress?: Option.Option<string>
-    }
-  ) => HttpServerRequest
+    readonly modify: (
+      options: {
+        readonly url?: string
+        readonly headers?: Headers.Headers
+        readonly remoteAddress?: Option.Option<string>
+      }
+    ) => HttpServerRequest["Service"]
+  }
 }
 
 /**
@@ -109,9 +117,9 @@ export interface HttpServerRequest extends HttpIncomingMessage.HttpIncomingMessa
  * @category services
  * @since 4.0.0
  */
-export const HttpServerRequest: Context.Service<HttpServerRequest, HttpServerRequest> = Context.Service(
-  "effect/http/HttpServerRequest"
-)
+export class HttpServerRequest
+  extends Context.Service<HttpServerRequest, HttpServerRequest.Service>()("effect/http/HttpServerRequest")
+{}
 
 /**
  * Service that contains decoded URL query parameters for the current request.
@@ -251,7 +259,7 @@ export const schemaBodyJson = <A, RD>(
   return Effect.flatMap(HttpServerRequest, parse)
 }
 
-const isMultipart = (request: HttpServerRequest) =>
+const isMultipart = (request: HttpServerRequest["Service"]) =>
   request.headers["content-type"]?.toLowerCase().includes("multipart/form-data") === true ||
   getFormDataBody(request) !== undefined
 
@@ -391,7 +399,7 @@ export const schemaBodyFormJson = <A, RD>(
  * @category converting
  * @since 4.0.0
  */
-export const fromClientRequest = (request: HttpClientRequest.HttpClientRequest): HttpServerRequest => {
+export const fromClientRequest = (request: HttpClientRequest.HttpClientRequest): HttpServerRequest["Service"] => {
   const url = Option.match(HttpClientRequest.toUrl(request), {
     onNone: () => request.url,
     onSome: (url) => url.toString()
@@ -410,7 +418,7 @@ export const fromClientRequest = (request: HttpClientRequest.HttpClientRequest):
  * @category converting
  * @since 4.0.0
  */
-export const fromWeb = (request: globalThis.Request): HttpServerRequest =>
+export const fromWeb = (request: globalThis.Request): HttpServerRequest["Service"] =>
   new ServerRequestImpl(request, removeHost(request.url))
 
 /**
@@ -424,7 +432,7 @@ export const fromWeb = (request: globalThis.Request): HttpServerRequest =>
  * @category converting
  * @since 4.0.0
  */
-export const toClientRequest = (request: HttpServerRequest): HttpClientRequest.HttpClientRequest => {
+export const toClientRequest = (request: HttpServerRequest["Service"]): HttpClientRequest.HttpClientRequest => {
   const body = toClientBody(request)
   const headers = body._tag !== "Empty" && body.contentLength === undefined
     ? Headers.remove(request.headers, "content-length")
@@ -442,7 +450,7 @@ export const toClientRequest = (request: HttpServerRequest): HttpClientRequest.H
   )
 }
 
-const toClientBody = (request: HttpServerRequest): HttpBody.HttpBody => {
+const toClientBody = (request: HttpServerRequest["Service"]): HttpBody.HttpBody => {
   if (!hasBody(request.method)) {
     return HttpBody.empty
   }
@@ -464,7 +472,7 @@ const removeHost = (url: string) => {
   return index === -1 ? "/" : url.slice(index)
 }
 
-class ServerRequestImpl extends Inspectable.Class implements HttpServerRequest {
+class ServerRequestImpl extends Inspectable.Class implements HttpServerRequest.Service {
   readonly [TypeId]: typeof TypeId
   readonly [HttpIncomingMessage.TypeId]: typeof HttpIncomingMessage.TypeId
   readonly source: Request
@@ -647,7 +655,7 @@ class ServerRequestImpl extends Inspectable.Class implements HttpServerRequest {
     return this.arrayBufferEffect
   }
 
-  get upgrade(): Effect.Effect<Socket.Socket, HttpServerError> {
+  get upgrade(): Effect.Effect<Socket.Socket["Service"], HttpServerError> {
     return Effect.fail(
       new HttpServerError({
         reason: new RequestParseError({
@@ -659,7 +667,7 @@ class ServerRequestImpl extends Inspectable.Class implements HttpServerRequest {
   }
 }
 
-class ClientRequestImpl extends Inspectable.Class implements HttpServerRequest {
+class ClientRequestImpl extends Inspectable.Class implements HttpServerRequest.Service {
   readonly [TypeId]: typeof TypeId
   readonly [HttpIncomingMessage.TypeId]: typeof HttpIncomingMessage.TypeId
   readonly source: HttpClientRequest.HttpClientRequest
@@ -847,12 +855,12 @@ class ClientRequestImpl extends Inspectable.Class implements HttpServerRequest {
     )
   }
 
-  get upgrade(): Effect.Effect<Socket.Socket, HttpServerError> {
+  get upgrade(): Effect.Effect<Socket.Socket["Service"], HttpServerError> {
     return Effect.fail(requestParseError(this, "Not an upgradeable ServerRequest"))
   }
 }
 
-const getFormDataBody = (request: HttpServerRequest): FormData | undefined => {
+const getFormDataBody = (request: HttpServerRequest["Service"]): FormData | undefined => {
   if (!HttpClientRequest.isHttpClientRequest(request.source)) {
     return undefined
   }
@@ -866,7 +874,10 @@ const getFormDataBody = (request: HttpServerRequest): FormData | undefined => {
   return undefined
 }
 
-const rawBodyStream = (request: HttpServerRequest, body: unknown): Stream.Stream<Uint8Array, HttpServerError> => {
+const rawBodyStream = (
+  request: HttpServerRequest["Service"],
+  body: unknown
+): Stream.Stream<Uint8Array, HttpServerError> => {
   if (body instanceof Request) {
     return streamFromReadable(request, body.body)
   }
@@ -879,7 +890,10 @@ const rawBodyStream = (request: HttpServerRequest, body: unknown): Stream.Stream
   return Stream.fail(requestParseError(request, "Unsupported body type"))
 }
 
-const rawBodyBytes = (request: HttpServerRequest, body: unknown): Effect.Effect<Uint8Array, HttpServerError> => {
+const rawBodyBytes = (
+  request: HttpServerRequest["Service"],
+  body: unknown
+): Effect.Effect<Uint8Array, HttpServerError> => {
   if (body instanceof Request) {
     return Effect.tryPromise({
       try: () => body.arrayBuffer().then((buffer) => new Uint8Array(buffer)),
@@ -892,14 +906,17 @@ const rawBodyBytes = (request: HttpServerRequest, body: unknown): Effect.Effect<
   return Effect.fail(requestParseError(request, "Unsupported body type"))
 }
 
-const bytesFromBodyInit = (request: HttpServerRequest, body: BodyInit): Effect.Effect<Uint8Array, HttpServerError> =>
+const bytesFromBodyInit = (
+  request: HttpServerRequest["Service"],
+  body: BodyInit
+): Effect.Effect<Uint8Array, HttpServerError> =>
   Effect.tryPromise({
     try: () => new Response(body).arrayBuffer().then((buffer) => new Uint8Array(buffer)),
     catch: (cause) => requestParseError(request, undefined, cause)
   })
 
 const streamFromReadable = (
-  request: HttpServerRequest,
+  request: HttpServerRequest["Service"],
   body: ReadableStream<Uint8Array> | null | undefined
 ): Stream.Stream<Uint8Array, HttpServerError> =>
   body
@@ -910,7 +927,7 @@ const streamFromReadable = (
     : Stream.empty
 
 const requestParseError = (
-  request: HttpServerRequest,
+  request: HttpServerRequest["Service"],
   description?: string,
   cause?: unknown
 ) =>
@@ -1024,7 +1041,7 @@ const textDecoder = new TextDecoder()
  * @category converting
  * @since 4.0.0
  */
-export const toURL = (self: HttpServerRequest): Option.Option<URL> => {
+export const toURL = (self: HttpServerRequest["Service"]): Option.Option<URL> => {
   const host = self.headers.host ?? "localhost"
   const protocol = self.headers["x-forwarded-proto"] === "https" ? "https" : "http"
   try {
@@ -1046,7 +1063,7 @@ export const toURL = (self: HttpServerRequest): Option.Option<URL> => {
  * @category converting
  * @since 4.0.0
  */
-export const toWebResult = (self: HttpServerRequest, options?: {
+export const toWebResult = (self: HttpServerRequest["Service"], options?: {
   readonly signal?: AbortSignal | undefined
   readonly context?: Context.Context<never> | undefined
 }): Result.Result<Request, RequestError> => {
@@ -1087,7 +1104,7 @@ export const toWebResult = (self: HttpServerRequest, options?: {
  * @category converting
  * @since 4.0.0
  */
-export const toWeb = (self: HttpServerRequest, options?: {
+export const toWeb = (self: HttpServerRequest["Service"], options?: {
   readonly signal?: AbortSignal | undefined
 }): Effect.Effect<Request, RequestError> =>
   Effect.contextWith((context) =>

--- a/packages/effect/src/unstable/http/HttpServerResponse.ts
+++ b/packages/effect/src/unstable/http/HttpServerResponse.ts
@@ -466,10 +466,9 @@ export const stream = <E>(
   })
 }
 
-const HttpPlatformKey = Context.Service<
-  HttpPlatform,
-  HttpPlatform["Service"]
->("effect/http/HttpPlatform" satisfies typeof HttpPlatform.key)
+class HttpPlatformKey extends Context.Service<HttpPlatformKey, HttpPlatform["Service"]>()(
+  "effect/http/HttpPlatform" satisfies typeof HttpPlatform.key
+) {}
 
 /**
  * Creates a streamed file response for a file system path.

--- a/packages/effect/src/unstable/http/HttpStaticServer.ts
+++ b/packages/effect/src/unstable/http/HttpStaticServer.ts
@@ -109,7 +109,7 @@ export const make: (options: {
   }
 
   const serveFile: (
-    request: HttpServerRequest.HttpServerRequest,
+    request: HttpServerRequest.HttpServerRequest["Service"],
     filePath: string,
     fileSize?: bigint
   ) => Effect.Effect<HttpServerResponse.HttpServerResponse, HttpServerError.HttpServerError> = Effect.fnUntraced(
@@ -297,7 +297,7 @@ const stripQueryString = (url: string): string => {
   return queryIndex === -1 ? url : url.slice(0, queryIndex)
 }
 
-const resolveMimeType = (path: Path.Path, filePath: string, mimeTypes: Record<string, string>): string => {
+const resolveMimeType = (path: Path.Path["Service"], filePath: string, mimeTypes: Record<string, string>): string => {
   const extension = path.extname(filePath).toLowerCase()
   if (extension.length <= 1) {
     return "application/octet-stream"
@@ -376,7 +376,7 @@ const parseRange = (
   }
 }
 
-const resolveFilePath = (path: Path.Path, root: string, url: string): string | undefined => {
+const resolveFilePath = (path: Path.Path["Service"], root: string, url: string): string | undefined => {
   const urlPath = stripQueryString(url)
   let decodedPath: string
   try {
@@ -399,14 +399,14 @@ const resolveFilePath = (path: Path.Path, root: string, url: string): string | u
   return resolvedPath
 }
 
-const toRouteNotFoundError = (request: HttpServerRequest.HttpServerRequest) =>
+const toRouteNotFoundError = (request: HttpServerRequest.HttpServerRequest["Service"]) =>
   new HttpServerError.HttpServerError({ reason: new HttpServerError.RouteNotFound({ request }) })
 
-const toInternalServerError = (request: HttpServerRequest.HttpServerRequest, cause: unknown) =>
+const toInternalServerError = (request: HttpServerRequest.HttpServerRequest["Service"], cause: unknown) =>
   new HttpServerError.HttpServerError({ reason: new HttpServerError.InternalError({ request, cause }) })
 
 const handlePlatformError = <A>(
-  request: HttpServerRequest.HttpServerRequest,
+  request: HttpServerRequest.HttpServerRequest["Service"],
   self: Effect.Effect<A, PlatformError>
 ): Effect.Effect<A, HttpServerError.HttpServerError> =>
   Effect.catchIf(
@@ -479,7 +479,7 @@ const notModifiedResponse = (
 }
 
 const evaluateConditionalRequest = (
-  request: HttpServerRequest.HttpServerRequest,
+  request: HttpServerRequest.HttpServerRequest["Service"],
   response: HttpServerResponse.HttpServerResponse
 ): HttpServerResponse.HttpServerResponse | undefined => {
   const ifNoneMatch = request.headers["if-none-match"]

--- a/packages/effect/src/unstable/http/internal/preResponseHandler.ts
+++ b/packages/effect/src/unstable/http/internal/preResponseHandler.ts
@@ -6,7 +6,10 @@ import type { HttpServerRequest } from "../HttpServerRequest.ts"
 export const requestPreResponseHandlers = new WeakMap<object, PreResponseHandler>()
 
 /** @internal */
-export const appendPreResponseHandlerUnsafe = (request: HttpServerRequest, handler: PreResponseHandler): void => {
+export const appendPreResponseHandlerUnsafe = (
+  request: HttpServerRequest["Service"],
+  handler: PreResponseHandler
+): void => {
   const prev = requestPreResponseHandlers.get(request.source)
   const next: PreResponseHandler = prev ?
     (request, response) => Effect.flatMap(prev(request, response), (response) => handler(request, response))

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -740,7 +740,7 @@ function buildPayloadDecoders(
 
 function decodePayload(
   payloadBy: Map<string, PayloadDecoder>,
-  httpRequest: HttpServerRequest,
+  httpRequest: HttpServerRequest["Service"],
   query: Record<string, string | Array<string>>
 ): Effect.Effect<unknown, Schema.SchemaError, unknown> | HttpServerResponse | undefined {
   const hasBody = HttpMethod.hasBody(httpRequest.method)

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -479,7 +479,9 @@ export const makeClient = <ApiId extends string, Groups extends HttpApiGroup.Con
 export const make = <ApiId extends string, Groups extends HttpApiGroup.Constraint>(
   api: HttpApi.HttpApi<ApiId, Groups>,
   options?: {
-    readonly transformClient?: ((client: HttpClient.HttpClient) => HttpClient.HttpClient) | undefined
+    readonly transformClient?:
+      | ((client: HttpClient.HttpClient["Service"]) => HttpClient.HttpClient["Service"])
+      | undefined
     readonly transformResponse?:
       | ((effect: Effect.Effect<unknown, unknown, unknown>) => Effect.Effect<unknown, unknown, unknown>)
       | undefined

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -117,7 +117,7 @@ type RequestFromParts<Endpoint, ParamsType, QueryType, PayloadType, HeadersType>
     : { readonly payload: Simplify<PayloadType> })
   & ([HeadersType] extends [never] ? {} : { readonly headers: Simplify<HeadersType> })
   & {
-    readonly request: HttpServerRequest
+    readonly request: HttpServerRequest["Service"]
     readonly endpoint: Endpoint
     readonly group: HttpApiGroup.Top
   }
@@ -127,7 +127,7 @@ type RequestRawFromParts<Endpoint, ParamsType, QueryType, HeadersType> =
   & ([QueryType] extends [never] ? {} : { readonly query: Simplify<QueryType> })
   & ([HeadersType] extends [never] ? {} : { readonly headers: Simplify<HeadersType> })
   & {
-    readonly request: HttpServerRequest
+    readonly request: HttpServerRequest["Service"]
     readonly endpoint: Endpoint
     readonly group: HttpApiGroup.Top
   }

--- a/packages/effect/src/unstable/persistence/KeyValueStore.ts
+++ b/packages/effect/src/unstable/persistence/KeyValueStore.ts
@@ -35,63 +35,71 @@ const TypeId = "~effect/persistence/KeyValueStore" as const
  * @category models
  * @since 4.0.0
  */
-export interface KeyValueStore {
-  readonly [TypeId]: typeof TypeId
+export declare namespace KeyValueStore {
   /**
-   * Returns the value of the specified key if it exists.
+   * Implementation of the KeyValueStore service.
+   *
+   * @category models
+   * @since 4.0.0
    */
-  readonly get: (key: string) => Effect.Effect<string | undefined, KeyValueStoreError>
+  export interface Service {
+    readonly [TypeId]: typeof TypeId
+    /**
+     * Returns the value of the specified key if it exists.
+     */
+    readonly get: (key: string) => Effect.Effect<string | undefined, KeyValueStoreError>
 
-  /**
-   * Returns the value of the specified key if it exists.
-   */
-  readonly getUint8Array: (key: string) => Effect.Effect<Uint8Array | undefined, KeyValueStoreError>
+    /**
+     * Returns the value of the specified key if it exists.
+     */
+    readonly getUint8Array: (key: string) => Effect.Effect<Uint8Array | undefined, KeyValueStoreError>
 
-  /**
-   * Sets the value of the specified key.
-   */
-  readonly set: (key: string, value: string | Uint8Array) => Effect.Effect<void, KeyValueStoreError>
+    /**
+     * Sets the value of the specified key.
+     */
+    readonly set: (key: string, value: string | Uint8Array) => Effect.Effect<void, KeyValueStoreError>
 
-  /**
-   * Removes the specified key.
-   */
-  readonly remove: (key: string) => Effect.Effect<void, KeyValueStoreError>
+    /**
+     * Removes the specified key.
+     */
+    readonly remove: (key: string) => Effect.Effect<void, KeyValueStoreError>
 
-  /**
-   * Removes all entries.
-   */
-  readonly clear: Effect.Effect<void, KeyValueStoreError>
+    /**
+     * Removes all entries.
+     */
+    readonly clear: Effect.Effect<void, KeyValueStoreError>
 
-  /**
-   * Returns the number of entries.
-   */
-  readonly size: Effect.Effect<number, KeyValueStoreError>
+    /**
+     * Returns the number of entries.
+     */
+    readonly size: Effect.Effect<number, KeyValueStoreError>
 
-  /**
-   * Updates the value of the specified key if it exists.
-   */
-  readonly modify: (
-    key: string,
-    f: (value: string) => string
-  ) => Effect.Effect<string | undefined, KeyValueStoreError>
+    /**
+     * Updates the value of the specified key if it exists.
+     */
+    readonly modify: (
+      key: string,
+      f: (value: string) => string
+    ) => Effect.Effect<string | undefined, KeyValueStoreError>
 
-  /**
-   * Updates the value of the specified key if it exists.
-   */
-  readonly modifyUint8Array: (
-    key: string,
-    f: (value: Uint8Array) => Uint8Array
-  ) => Effect.Effect<Uint8Array | undefined, KeyValueStoreError>
+    /**
+     * Updates the value of the specified key if it exists.
+     */
+    readonly modifyUint8Array: (
+      key: string,
+      f: (value: Uint8Array) => Uint8Array
+    ) => Effect.Effect<Uint8Array | undefined, KeyValueStoreError>
 
-  /**
-   * Returns true if the KeyValueStore contains the specified key.
-   */
-  readonly has: (key: string) => Effect.Effect<boolean, KeyValueStoreError>
+    /**
+     * Returns true if the KeyValueStore contains the specified key.
+     */
+    readonly has: (key: string) => Effect.Effect<boolean, KeyValueStoreError>
 
-  /**
-   * Checks whether the KeyValueStore contains any entries.
-   */
-  readonly isEmpty: Effect.Effect<boolean, KeyValueStoreError>
+    /**
+     * Checks whether the KeyValueStore contains any entries.
+     */
+    readonly isEmpty: Effect.Effect<boolean, KeyValueStoreError>
+  }
 }
 
 /**
@@ -105,7 +113,7 @@ export interface KeyValueStore {
  * @category options
  * @since 4.0.0
  */
-export type MakeOptions = Partial<KeyValueStore> & {
+export type MakeOptions = Partial<KeyValueStore["Service"]> & {
   /**
    * Returns the value of the specified key if it exists.
    */
@@ -144,7 +152,7 @@ export type MakeOptions = Partial<KeyValueStore> & {
  * @category options
  * @since 4.0.0
  */
-export type MakeStringOptions = Partial<Omit<KeyValueStore, "set">> & {
+export type MakeStringOptions = Partial<Omit<KeyValueStore["Service"], "set">> & {
   /**
    * Returns the value of the specified key if it exists.
    */
@@ -205,10 +213,9 @@ export class KeyValueStoreError extends Data.TaggedError("KeyValueStoreError")<{
  * @category services
  * @since 4.0.0
  */
-export const KeyValueStore: Context.Service<
-  KeyValueStore,
-  KeyValueStore
-> = Context.Service("effect/persistence/KeyValueStore")
+export class KeyValueStore
+  extends Context.Service<KeyValueStore, KeyValueStore.Service>()("effect/persistence/KeyValueStore")
+{}
 
 /**
  * Constructs a `KeyValueStore` from primitive store operations.
@@ -221,7 +228,7 @@ export const KeyValueStore: Context.Service<
  * @category constructors
  * @since 4.0.0
  */
-export const make = (options: MakeOptions): KeyValueStore =>
+export const make = (options: MakeOptions): KeyValueStore["Service"] =>
   KeyValueStore.of({
     [TypeId]: TypeId,
     has: (key) => Effect.map(options.get(key), Predicate.isNotUndefined),
@@ -267,7 +274,7 @@ export const make = (options: MakeOptions): KeyValueStore =>
  */
 export const makeStringOnly = (
   options: MakeStringOptions
-): KeyValueStore => {
+): KeyValueStore["Service"] => {
   const encoder = new TextEncoder()
   return make({
     ...options,
@@ -295,9 +302,9 @@ export const makeStringOnly = (
  * @since 4.0.0
  */
 export const prefix: {
-  (prefix: string): (self: KeyValueStore) => KeyValueStore
-  (self: KeyValueStore, prefix: string): KeyValueStore
-} = dual(2, (self: KeyValueStore, prefix: string): KeyValueStore => ({
+  (prefix: string): (self: KeyValueStore["Service"]) => KeyValueStore["Service"]
+  (self: KeyValueStore["Service"], prefix: string): KeyValueStore["Service"]
+} = dual(2, (self: KeyValueStore["Service"], prefix: string): KeyValueStore["Service"] => ({
   ...self,
   get: (key) => self.get(`${prefix}${key}`),
   getUint8Array: (key) => self.getUint8Array(`${prefix}${key}`),
@@ -765,7 +772,10 @@ export interface SchemaStore<S extends Schema.Constraint> {
  * @category converting
  * @since 4.0.0
  */
-export const toSchemaStore = <S extends Schema.Constraint>(self: KeyValueStore, schema: S): SchemaStore<S> => {
+export const toSchemaStore = <S extends Schema.Constraint>(
+  self: KeyValueStore["Service"],
+  schema: S
+): SchemaStore<S> => {
   const serializer = Schema.toCodecJson(schema)
   const jsonSchema = Schema.fromJsonString(serializer)
   const decode = Schema.decodeEffect(jsonSchema)

--- a/packages/effect/src/unstable/persistence/RateLimiter.ts
+++ b/packages/effect/src/unstable/persistence/RateLimiter.ts
@@ -42,21 +42,31 @@ export type TypeId = "~effect/persistence/RateLimiter"
  * @category models
  * @since 4.0.0
  */
-export interface RateLimiter {
-  readonly [TypeId]: TypeId
+export declare namespace RateLimiter {
+  /**
+   * Implementation of the RateLimiter service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service {
+    readonly [TypeId]: TypeId
 
-  readonly consume: (options: {
-    readonly algorithm?: "fixed-window" | "token-bucket" | undefined
-    readonly onExceeded?: "delay" | "fail" | undefined
-    readonly window: Duration.Input
-    readonly limit: number
-    readonly key: string
-    readonly tokens?: number | undefined
-  }) => Effect.Effect<ConsumeResult, RateLimiterError>
+    readonly consume: (options: {
+      readonly algorithm?: "fixed-window" | "token-bucket" | undefined
+      readonly onExceeded?: "delay" | "fail" | undefined
+      readonly window: Duration.Input
+      readonly limit: number
+      readonly key: string
+      readonly tokens?: number | undefined
+    }) => Effect.Effect<ConsumeResult, RateLimiterError>
 
-  readonly adaptiveConsume: (options: AdaptiveConsumeOptions) => Effect.Effect<AdaptiveConsumeResult, RateLimiterError>
+    readonly adaptiveConsume: (
+      options: AdaptiveConsumeOptions
+    ) => Effect.Effect<AdaptiveConsumeResult, RateLimiterError>
 
-  readonly adaptiveFeedback: (options: AdaptiveFeedbackOptions) => Effect.Effect<void, RateLimiterError>
+    readonly adaptiveFeedback: (options: AdaptiveFeedbackOptions) => Effect.Effect<void, RateLimiterError>
+  }
 }
 
 /**
@@ -70,7 +80,7 @@ export interface RateLimiter {
  * @category services
  * @since 4.0.0
  */
-export const RateLimiter: Context.Service<RateLimiter, RateLimiter> = Context.Service<RateLimiter>(TypeId)
+export class RateLimiter extends Context.Service<RateLimiter, RateLimiter.Service>()(TypeId) {}
 
 /**
  * Creates a `RateLimiter` from the current `RateLimiterStore`.
@@ -84,13 +94,13 @@ export const RateLimiter: Context.Service<RateLimiter, RateLimiter> = Context.Se
  * @since 4.0.0
  */
 export const make: Effect.Effect<
-  RateLimiter,
+  RateLimiter["Service"],
   never,
   RateLimiterStore
 > = Effect.gen(function*() {
   const store = yield* RateLimiterStore
 
-  return identity<RateLimiter>({
+  return identity<RateLimiter["Service"]>({
     [TypeId]: TypeId,
     adaptiveConsume: store.adaptiveConsume,
     adaptiveFeedback: store.adaptiveFeedback,
@@ -307,21 +317,21 @@ export const makeWithRateLimiter: Effect.Effect<
  * @category accessors
  * @since 4.0.0
  */
-export function sleep(self: RateLimiter): (options: {
+export function sleep(self: RateLimiter["Service"]): (options: {
   readonly algorithm?: "fixed-window" | "token-bucket" | undefined
   readonly window: Duration.Input
   readonly limit: number
   readonly key: string
   readonly tokens?: number | undefined
 }) => Effect.Effect<ConsumeResult, RateLimiterError>
-export function sleep(self: RateLimiter, options: {
+export function sleep(self: RateLimiter["Service"], options: {
   readonly algorithm?: "fixed-window" | "token-bucket" | undefined
   readonly window: Duration.Input
   readonly limit: number
   readonly key: string
   readonly tokens?: number | undefined
 }): Effect.Effect<ConsumeResult, RateLimiterError>
-export function sleep(self: RateLimiter, options?: {
+export function sleep(self: RateLimiter["Service"], options?: {
   readonly algorithm?: "fixed-window" | "token-bucket" | undefined
   readonly window: Duration.Input
   readonly limit: number

--- a/packages/effect/src/unstable/reactivity/Atom.ts
+++ b/packages/effect/src/unstable/reactivity/Atom.ts
@@ -189,7 +189,7 @@ export interface AtomContext {
   subscribe<A>(this: AtomContext, atom: Atom<A>, f: (_: A) => void, options?: {
     readonly immediate?: boolean
   }): void
-  readonly registry: Registry.AtomRegistry
+  readonly registry: Registry.AtomRegistry["Service"]
 }
 
 /**
@@ -1034,7 +1034,7 @@ export interface FnContext {
   subscribe<A>(this: FnContext, atom: Atom<A>, f: (_: A) => void, options?: {
     readonly immediate?: boolean
   }): void
-  readonly registry: Registry.AtomRegistry
+  readonly registry: Registry.AtomRegistry["Service"]
 }
 
 /**
@@ -2575,11 +2575,11 @@ export const withServerValueInitial = <A extends Atom<AsyncResult.AsyncResult<an
  * @since 4.0.0
  */
 export const getServerValue: {
-  (registry: Registry.AtomRegistry): <A>(self: Atom<A>) => A
-  <A>(self: Atom<A>, registry: Registry.AtomRegistry): A
+  (registry: Registry.AtomRegistry["Service"]): <A>(self: Atom<A>) => A
+  <A>(self: Atom<A>, registry: Registry.AtomRegistry["Service"]): A
 } = dual(
   2,
-  <A>(self: Atom<A>, registry: Registry.AtomRegistry): A =>
+  <A>(self: Atom<A>, registry: Registry.AtomRegistry["Service"]): A =>
     ServerValueTypeId in self
       ? (self as any)[ServerValueTypeId]((atom: Atom<any>) => registry.get(atom))
       : registry.get(self)

--- a/packages/effect/src/unstable/reactivity/AtomHttpApi.ts
+++ b/packages/effect/src/unstable/reactivity/AtomHttpApi.ts
@@ -181,7 +181,9 @@ export const Service =
           | HttpApiGroup.ClientServices<Groups>
           | HttpClient.HttpClient
         >)
-      readonly transformClient?: ((client: HttpClient.HttpClient) => HttpClient.HttpClient) | undefined
+      readonly transformClient?:
+        | ((client: HttpClient.HttpClient["Service"]) => HttpClient.HttpClient["Service"])
+        | undefined
       readonly transformResponse?:
         | ((effect: Effect.Effect<unknown, unknown, unknown>) => Effect.Effect<unknown, unknown, unknown>)
         | undefined
@@ -189,10 +191,11 @@ export const Service =
       readonly runtime?: Atom.RuntimeFactory | undefined
     }
   ): AtomHttpApiClient<Self, Id, Groups> => {
-    const self: Mutable<AtomHttpApiClient<Self, Id, Groups>> = Context.Service<
+    // This constructor must retain the caller-supplied Self identifier for service subclasses.
+    const self: Mutable<AtomHttpApiClient<Self, Id, Groups>> = class extends Context.Service<
       Self,
       HttpApiClient.Client<Groups, never, never>
-    >()(id) as any
+    >()(id) {} as any
 
     const layer = Layer.effect(
       self,

--- a/packages/effect/src/unstable/reactivity/AtomRegistry.ts
+++ b/packages/effect/src/unstable/reactivity/AtomRegistry.ts
@@ -47,7 +47,7 @@ export const TypeId: TypeId = "~effect/reactivity/AtomRegistry"
  * @category guards
  * @since 4.0.0
  */
-export const isAtomRegistry = (u: unknown): u is AtomRegistry => hasProperty(u, TypeId)
+export const isAtomRegistry = (u: unknown): u is AtomRegistry["Service"] => hasProperty(u, TypeId)
 
 /**
  * The runtime registry that stores atom nodes and coordinates reads, writes,
@@ -61,25 +61,33 @@ export const isAtomRegistry = (u: unknown): u is AtomRegistry => hasProperty(u, 
  * @category models
  * @since 4.0.0
  */
-export interface AtomRegistry {
-  readonly [TypeId]: TypeId
-  readonly scheduler: Scheduler
-  readonly schedulerAsync: Scheduler
-  readonly getNodes: () => ReadonlyMap<Atom.Atom<any> | string, Node<any>>
-  readonly get: <A>(atom: Atom.Atom<A>) => A
-  readonly mount: <A>(atom: Atom.Atom<A>) => () => void
-  readonly refresh: <A>(atom: Atom.Atom<A>) => void
-  readonly set: <R, W>(atom: Atom.Writable<R, W>, value: W) => void
-  readonly setSerializable: (key: string, encoded: unknown) => void
-  readonly modify: <R, W, A>(atom: Atom.Writable<R, W>, f: (_: R) => [returnValue: A, nextValue: W]) => A
-  readonly update: <R, W>(atom: Atom.Writable<R, W>, f: (_: R) => W) => void
-  readonly subscribe: <A>(atom: Atom.Atom<A>, f: (_: A) => void, options?: {
-    readonly immediate?: boolean
-  }) => () => void
-  readonly reset: () => void
-  readonly dispose: () => void
-  onNodeAdded?: ((node: Node<any>) => void) | undefined
-  onNodeRemoved?: ((node: Node<any>) => void) | undefined
+export declare namespace AtomRegistry {
+  /**
+   * Implementation of the AtomRegistry service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service {
+    readonly [TypeId]: TypeId
+    readonly scheduler: Scheduler
+    readonly schedulerAsync: Scheduler
+    readonly getNodes: () => ReadonlyMap<Atom.Atom<any> | string, Node<any>>
+    readonly get: <A>(atom: Atom.Atom<A>) => A
+    readonly mount: <A>(atom: Atom.Atom<A>) => () => void
+    readonly refresh: <A>(atom: Atom.Atom<A>) => void
+    readonly set: <R, W>(atom: Atom.Writable<R, W>, value: W) => void
+    readonly setSerializable: (key: string, encoded: unknown) => void
+    readonly modify: <R, W, A>(atom: Atom.Writable<R, W>, f: (_: R) => [returnValue: A, nextValue: W]) => A
+    readonly update: <R, W>(atom: Atom.Writable<R, W>, f: (_: R) => W) => void
+    readonly subscribe: <A>(atom: Atom.Atom<A>, f: (_: A) => void, options?: {
+      readonly immediate?: boolean
+    }) => () => void
+    readonly reset: () => void
+    readonly dispose: () => void
+    onNodeAdded?: ((node: Node<any>) => void) | undefined
+    onNodeRemoved?: ((node: Node<any>) => void) | undefined
+  }
 }
 
 /**
@@ -121,7 +129,7 @@ export const make = (
     readonly timeoutResolution?: number | undefined
     readonly defaultIdleTTL?: number | undefined
   } | undefined
-): AtomRegistry =>
+): AtomRegistry["Service"] =>
   new RegistryImpl(
     options?.initialValues,
     options?.scheduleTask,
@@ -140,7 +148,7 @@ export const make = (
  * @category services
  * @since 4.0.0
  */
-export const AtomRegistry = Context.Service<AtomRegistry>(TypeId)
+export class AtomRegistry extends Context.Service<AtomRegistry, AtomRegistry.Service>()(TypeId) {}
 
 /**
  * Creates a layer that provides an `AtomRegistry` configured with the supplied
@@ -196,11 +204,11 @@ export const layer: Layer.Layer<AtomRegistry> = layerOptions()
  * @since 4.0.0
  */
 export const toStream: {
-  <A>(atom: Atom.Atom<A>): (self: AtomRegistry) => Stream.Stream<A>
-  <A>(self: AtomRegistry, atom: Atom.Atom<A>): Stream.Stream<A>
+  <A>(atom: Atom.Atom<A>): (self: AtomRegistry["Service"]) => Stream.Stream<A>
+  <A>(self: AtomRegistry["Service"], atom: Atom.Atom<A>): Stream.Stream<A>
 } = dual(
   2,
-  <A>(self: AtomRegistry, atom: Atom.Atom<A>) =>
+  <A>(self: AtomRegistry["Service"], atom: Atom.Atom<A>) =>
     Stream.callback<A>((queue) =>
       Effect.suspend(() => {
         const fiber = Fiber.getCurrent()!
@@ -226,11 +234,11 @@ export const toStream: {
  * @since 4.0.0
  */
 export const toStreamResult: {
-  <A, E>(atom: Atom.Atom<Result.AsyncResult<A, E>>): (self: AtomRegistry) => Stream.Stream<A, E>
-  <A, E>(self: AtomRegistry, atom: Atom.Atom<Result.AsyncResult<A, E>>): Stream.Stream<A, E>
+  <A, E>(atom: Atom.Atom<Result.AsyncResult<A, E>>): (self: AtomRegistry["Service"]) => Stream.Stream<A, E>
+  <A, E>(self: AtomRegistry["Service"], atom: Atom.Atom<Result.AsyncResult<A, E>>): Stream.Stream<A, E>
 } = dual(
   2,
-  <A, E>(self: AtomRegistry, atom: Atom.Atom<Result.AsyncResult<A, E>>): Stream.Stream<A, E> =>
+  <A, E>(self: AtomRegistry["Service"], atom: Atom.Atom<Result.AsyncResult<A, E>>): Stream.Stream<A, E> =>
     toStream(self, atom).pipe(
       Stream.filter(Result.isNotInitial),
       Stream.mapEffect((result) =>
@@ -254,13 +262,13 @@ export const toStreamResult: {
 export const getResult: {
   <A, E>(atom: Atom.Atom<Result.AsyncResult<A, E>>, options?: {
     readonly suspendOnWaiting?: boolean | undefined
-  }): (self: AtomRegistry) => Effect.Effect<A, E>
-  <A, E>(self: AtomRegistry, atom: Atom.Atom<Result.AsyncResult<A, E>>, options?: {
+  }): (self: AtomRegistry["Service"]) => Effect.Effect<A, E>
+  <A, E>(self: AtomRegistry["Service"], atom: Atom.Atom<Result.AsyncResult<A, E>>, options?: {
     readonly suspendOnWaiting?: boolean | undefined
   }): Effect.Effect<A, E>
 } = dual(
   (args) => isAtomRegistry(args[0]),
-  <A, E>(self: AtomRegistry, atom: Atom.Atom<Result.AsyncResult<A, E>>, options?: {
+  <A, E>(self: AtomRegistry["Service"], atom: Atom.Atom<Result.AsyncResult<A, E>>, options?: {
     readonly suspendOnWaiting?: boolean | undefined
   }): Effect.Effect<A, E> => {
     const suspendOnWaiting = options?.suspendOnWaiting ?? false
@@ -292,11 +300,11 @@ export const getResult: {
  * @since 4.0.0
  */
 export const mount: {
-  <A>(atom: Atom.Atom<A>): (self: AtomRegistry) => Effect.Effect<void, never, Scope.Scope>
-  <A>(self: AtomRegistry, atom: Atom.Atom<A>): Effect.Effect<void, never, Scope.Scope>
+  <A>(atom: Atom.Atom<A>): (self: AtomRegistry["Service"]) => Effect.Effect<void, never, Scope.Scope>
+  <A>(self: AtomRegistry["Service"], atom: Atom.Atom<A>): Effect.Effect<void, never, Scope.Scope>
 } = dual(
   2,
-  <A>(self: AtomRegistry, atom: Atom.Atom<A>) =>
+  <A>(self: AtomRegistry["Service"], atom: Atom.Atom<A>) =>
     Effect.acquireRelease(
       Effect.sync(() => self.mount(atom)),
       (release) => Effect.sync(release)
@@ -317,7 +325,7 @@ const SerializableTypeId: Atom.SerializableTypeId = "~effect-atom/atom/Atom/Seri
 const atomKey = <A>(atom: Atom.Atom<A>): Atom.Atom<A> | string =>
   SerializableTypeId in atom ? (atom as Atom.Serializable<any>)[SerializableTypeId].key : atom
 
-class RegistryImpl implements AtomRegistry {
+class RegistryImpl implements AtomRegistry.Service {
   readonly [TypeId]: TypeId
   readonly timeoutResolution: number
   readonly defaultIdleTTL: number | undefined

--- a/packages/effect/src/unstable/reactivity/AtomRpc.ts
+++ b/packages/effect/src/unstable/reactivity/AtomRpc.ts
@@ -159,10 +159,11 @@ export const Service = <Self>() =>
     readonly runtime?: Atom.RuntimeFactory | undefined
   }
 ): AtomRpcClient<Self, Id, Rpcs> => {
-  const self: Mutable<AtomRpcClient<Self, Id, Rpcs>> = Context.Service<
+  // This constructor must retain the caller-supplied Self identifier for service subclasses.
+  const self: Mutable<AtomRpcClient<Self, Id, Rpcs>> = class extends Context.Service<
     Self,
     RpcClient.RpcClient.Flat<Rpcs, RpcClientError>
-  >()(id) as any
+  >()(id) {} as any
 
   const layer = Layer.effect(
     self,

--- a/packages/effect/src/unstable/reactivity/Hydration.ts
+++ b/packages/effect/src/unstable/reactivity/Hydration.ts
@@ -74,7 +74,7 @@ const encodeOrSkip = (
  * @since 4.0.0
  */
 export const dehydrate = (
-  registry: AtomRegistry.AtomRegistry,
+  registry: AtomRegistry.AtomRegistry["Service"],
   options?: {
     /**
      * How to encode `AsyncResult.Initial` values. Default is "ignore".
@@ -144,7 +144,7 @@ export const toValues = (state: ReadonlyArray<DehydratedAtom>): Array<Dehydrated
  * @since 4.0.0
  */
 export const hydrate = (
-  registry: AtomRegistry.AtomRegistry,
+  registry: AtomRegistry.AtomRegistry["Service"],
   dehydratedState: Iterable<DehydratedAtom>
 ): void => {
   for (const datom of (dehydratedState as Iterable<DehydratedAtomValue>)) {

--- a/packages/effect/src/unstable/rpc/RpcClient.ts
+++ b/packages/effect/src/unstable/rpc/RpcClient.ts
@@ -277,7 +277,7 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
     readonly _tag: "Queue"
     readonly rpc: Rpc.AnyWithProps
     readonly queue: Queue.Queue<any, any>
-    readonly scope: Scope.Scope
+    readonly scope: Scope.Scope["Service"]
     readonly context: Context.Context<never>
   }
   const entries = new Map<RequestId, ClientEntry>()
@@ -884,7 +884,7 @@ export class Protocol extends Context.Service<Protocol, {
  * @category protocols
  * @since 4.0.0
  */
-export const makeProtocolHttp = (client: HttpClient.HttpClient): Effect.Effect<
+export const makeProtocolHttp = (client: HttpClient.HttpClient["Service"]): Effect.Effect<
   Protocol["Service"],
   never,
   RpcSerialization.RpcSerialization

--- a/packages/effect/src/unstable/rpc/RpcServer.ts
+++ b/packages/effect/src/unstable/rpc/RpcServer.ts
@@ -1495,7 +1495,7 @@ const makeSocketProtocol: Effect.Effect<
   {
     readonly protocol: Protocol["Service"]
     readonly onSocket: (
-      socket: Socket.Socket,
+      socket: Socket.Socket["Service"],
       headers?: ReadonlyArray<[string, string]>
     ) => Effect.Effect<void, never, Scope.Scope>
   },
@@ -1514,70 +1514,72 @@ const makeSocketProtocol: Effect.Effect<
 
   let writeRequest!: (clientId: number, message: FromClientEncoded) => Effect.Effect<void>
 
-  const onSocket = Effect.fnUntraced(function*(socket: Socket.Socket, headers?: ReadonlyArray<[string, string]>) {
-    const scope = yield* Effect.scope
-    const parser = serialization.makeUnsafe()
-    const id = clientId++
-    yield* Scope.addFinalizerExit(scope, () => {
-      clients.delete(id)
-      clientIds.delete(id)
-      return Queue.offer(disconnects, id)
-    })
+  const onSocket = Effect.fnUntraced(
+    function*(socket: Socket.Socket["Service"], headers?: ReadonlyArray<[string, string]>) {
+      const scope = yield* Effect.scope
+      const parser = serialization.makeUnsafe()
+      const id = clientId++
+      yield* Scope.addFinalizerExit(scope, () => {
+        clients.delete(id)
+        clientIds.delete(id)
+        return Queue.offer(disconnects, id)
+      })
 
-    const writer = yield* socket.writer
-    const write = (response: FromServerEncoded) => {
-      try {
-        const encoded = parser.encode(response)
-        if (encoded === undefined) {
-          return Effect.void
+      const writer = yield* socket.writer
+      const write = (response: FromServerEncoded) => {
+        try {
+          const encoded = parser.encode(response)
+          if (encoded === undefined) {
+            return Effect.void
+          }
+          return Effect.orDie(writer.write(encoded))
+        } catch (cause) {
+          return Effect.orDie(
+            writer.write(parser.encode(ResponseDefectEncoded(encodeDefectUnsafe(cause)))!)
+          )
         }
-        return Effect.orDie(writer.write(encoded))
-      } catch (cause) {
-        return Effect.orDie(
-          writer.write(parser.encode(ResponseDefectEncoded(encodeDefectUnsafe(cause)))!)
-        )
       }
+      clients.set(id, { write })
+      clientIds.add(id)
+
+      const processData = (data: Uint8Array | string): Effect.Effect<void, Socket.SocketError> => {
+        try {
+          const decoded = parser.decode(data) as ReadonlyArray<FromClientEncoded>
+          if (decoded.length === 0) return Effect.void
+          let i = 0
+          return Effect.whileLoop({
+            while: () => i < decoded.length,
+            body() {
+              const message = decoded[i++]
+              if (message._tag === "Request" && headers) {
+                ;(message as Types.Mutable<RequestEncoded>).headers = headers.concat(message.headers)
+              }
+              return writeRequest(id, message)
+            },
+            step: constVoid
+          })
+        } catch (cause) {
+          if (Predicate.isTagged(cause, "MaxBufferSizeExceeded")) {
+            return writer.write(new Socket.CloseEvent(1009, String(cause)))
+          }
+          return writer.write(parser.encode(ResponseDefectEncoded(encodeDefectUnsafe(cause)))!)
+        }
+      }
+
+      yield* Effect.gen(function*() {
+        const { pull } = yield* socket.reader
+        while (true) {
+          const frames = yield* pull
+          for (let i = 0; i < frames.length; i++) {
+            yield* processData(frames[i])
+          }
+        }
+      }).pipe(
+        Effect.catchReason("SocketError", "SocketCloseError", (_) => Effect.void),
+        Effect.orDie
+      )
     }
-    clients.set(id, { write })
-    clientIds.add(id)
-
-    const processData = (data: Uint8Array | string): Effect.Effect<void, Socket.SocketError> => {
-      try {
-        const decoded = parser.decode(data) as ReadonlyArray<FromClientEncoded>
-        if (decoded.length === 0) return Effect.void
-        let i = 0
-        return Effect.whileLoop({
-          while: () => i < decoded.length,
-          body() {
-            const message = decoded[i++]
-            if (message._tag === "Request" && headers) {
-              ;(message as Types.Mutable<RequestEncoded>).headers = headers.concat(message.headers)
-            }
-            return writeRequest(id, message)
-          },
-          step: constVoid
-        })
-      } catch (cause) {
-        if (Predicate.isTagged(cause, "MaxBufferSizeExceeded")) {
-          return writer.write(new Socket.CloseEvent(1009, String(cause)))
-        }
-        return writer.write(parser.encode(ResponseDefectEncoded(encodeDefectUnsafe(cause)))!)
-      }
-    }
-
-    yield* Effect.gen(function*() {
-      const { pull } = yield* socket.reader
-      while (true) {
-        const frames = yield* pull
-        for (let i = 0; i < frames.length; i++) {
-          yield* processData(frames[i])
-        }
-      }
-    }).pipe(
-      Effect.catchReason("SocketError", "SocketCloseError", (_) => Effect.void),
-      Effect.orDie
-    )
-  })
+  )
 
   const protocol = yield* Protocol.make((writeRequest_) => {
     writeRequest = writeRequest_

--- a/packages/effect/src/unstable/rpc/RpcWorker.ts
+++ b/packages/effect/src/unstable/rpc/RpcWorker.ts
@@ -53,9 +53,9 @@ export declare namespace InitialMessage {
   }
 }
 
-const ProtocolTag = Context.Service<Protocol, Protocol["Service"]>(
-  "effect/rpc/RpcServer/Protocol" satisfies Protocol["key"]
-)
+class ProtocolTag
+  extends Context.Service<ProtocolTag, Protocol["Service"]>()("effect/rpc/RpcServer/Protocol" satisfies Protocol["key"])
+{}
 
 /**
  * Runs an effect, encodes its result with the schema's JSON codec, and returns

--- a/packages/effect/src/unstable/socket/Socket.ts
+++ b/packages/effect/src/unstable/socket/Socket.ts
@@ -41,7 +41,7 @@ export const TypeId = "~effect/socket/Socket"
  * @category guards
  * @since 4.0.0
  */
-export const isSocket = (u: unknown): u is Socket => Predicate.hasProperty(u, TypeId)
+export const isSocket = (u: unknown): u is Socket["Service"] => Predicate.hasProperty(u, TypeId)
 
 /**
  * Service tag for bidirectional socket transports.
@@ -54,7 +54,7 @@ export const isSocket = (u: unknown): u is Socket => Predicate.hasProperty(u, Ty
  * @category services
  * @since 4.0.0
  */
-export const Socket: Context.Service<Socket, Socket> = Context.Service<Socket>("effect/socket/Socket")
+export class Socket extends Context.Service<Socket, Socket.Service>()("effect/socket/Socket") {}
 
 /**
  * Effect-based socket abstraction exposing a pull-based read side and a
@@ -96,10 +96,18 @@ export const Socket: Context.Service<Socket, Socket> = Context.Service<Socket>("
  * @category models
  * @since 4.0.0
  */
-export interface Socket {
-  readonly [TypeId]: typeof TypeId
-  readonly reader: Effect.Effect<Reader, SocketError, Scope.Scope>
-  readonly writer: Effect.Effect<Writer, never, Scope.Scope>
+export declare namespace Socket {
+  /**
+   * Implementation of the Socket service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service {
+    readonly [TypeId]: typeof TypeId
+    readonly reader: Effect.Effect<Reader, SocketError, Scope.Scope>
+    readonly writer: Effect.Effect<Writer, never, Scope.Scope>
+  }
 }
 
 /**
@@ -178,9 +186,9 @@ export interface TlsUpgradeOptions {
  * @since 4.0.0
  */
 export const make = (options: {
-  readonly reader: Socket["reader"]
-  readonly writer: Socket["writer"]
-}): Socket =>
+  readonly reader: Socket["Service"]["reader"]
+  readonly writer: Socket["Service"]["writer"]
+}): Socket["Service"] =>
   Socket.of({
     [TypeId]: TypeId,
     reader: options.reader,
@@ -202,7 +210,7 @@ const encoder = new TextEncoder()
  * @since 4.0.0
  */
 export const readerBytes = (
-  self: Socket
+  self: Socket["Service"]
 ): Effect.Effect<
   Effect.Effect<NonEmptyReadonlyArray<Uint8Array>, SocketError>,
   SocketError,
@@ -235,7 +243,7 @@ export const readerBytes = (
  * @since 4.0.0
  */
 export const readerString = (
-  self: Socket,
+  self: Socket["Service"],
   encoding?: string | undefined
 ): Effect.Effect<
   Effect.Effect<NonEmptyReadonlyArray<string>, SocketError>,
@@ -525,7 +533,7 @@ const writeChunk = (
 }
 
 const toChannelWithReader = <A extends Uint8Array | string, IE>(
-  self: Socket,
+  self: Socket["Service"],
   reader: Effect.Effect<
     Effect.Effect<NonEmptyReadonlyArray<A>, SocketError>,
     SocketError,
@@ -590,7 +598,7 @@ const toChannelWithReader = <A extends Uint8Array | string, IE>(
  * @since 4.0.0
  */
 export const toChannel = <IE = never>(
-  self: Socket
+  self: Socket["Service"]
 ): Channel.Channel<
   NonEmptyReadonlyArray<Uint8Array>,
   SocketError | IE,
@@ -607,7 +615,7 @@ export const toChannel = <IE = never>(
  * @since 4.0.0
  */
 export const toChannelString: {
-  (encoding?: string | undefined): <IE>(self: Socket) => Channel.Channel<
+  (encoding?: string | undefined): <IE>(self: Socket["Service"]) => Channel.Channel<
     NonEmptyReadonlyArray<string>,
     SocketError | IE,
     void,
@@ -615,7 +623,7 @@ export const toChannelString: {
     IE
   >
   <IE>(
-    self: Socket,
+    self: Socket["Service"],
     encoding?: string | undefined
   ): Channel.Channel<
     NonEmptyReadonlyArray<string>,
@@ -625,7 +633,7 @@ export const toChannelString: {
     IE
   >
 } = dual((args) => isSocket(args[0]), <IE>(
-  self: Socket,
+  self: Socket["Service"],
   encoding?: string | undefined
 ): Channel.Channel<
   NonEmptyReadonlyArray<string>,
@@ -644,7 +652,7 @@ export const toChannelString: {
  */
 export const toChannelWith = <IE = never>() =>
 (
-  self: Socket
+  self: Socket["Service"]
 ): Channel.Channel<
   NonEmptyReadonlyArray<Uint8Array>,
   SocketError | IE,
@@ -660,7 +668,7 @@ export const toChannelWith = <IE = never>() =>
  * @category combinators
  * @since 4.0.0
  */
-export const toStream = (self: Socket): Stream.Stream<Uint8Array, SocketError> =>
+export const toStream = (self: Socket["Service"]): Stream.Stream<Uint8Array, SocketError> =>
   Stream.fromChannel(
     Channel.fromTransform((_, scope) => Scope.provide(readerBytes(self), scope))
   )
@@ -809,7 +817,7 @@ export const makeWebSocket = (url: string | Effect.Effect<string>, options?: {
   readonly openTimeout?: Duration.Input | undefined
   readonly protocols?: string | Array<string> | undefined
   readonly highWaterMark?: number | undefined
-}): Effect.Effect<Socket, never, WebSocketConstructor> =>
+}): Effect.Effect<Socket["Service"], never, WebSocketConstructor> =>
   WebSocketConstructor.use((makeWs) =>
     fromWebSocket(
       Effect.acquireRelease(
@@ -854,13 +862,13 @@ export const fromWebSocket = <RO, WS extends WebSocketLike>(
     readonly openTimeout?: Duration.Input | undefined
     readonly highWaterMark?: number | undefined
   } | undefined
-): Effect.Effect<Socket, never, Exclude<RO, Scope.Scope>> =>
+): Effect.Effect<Socket["Service"], never, Exclude<RO, Scope.Scope>> =>
   Effect.withFiber((fiber) => {
     let currentWS: WebSocketLike | undefined
     const latch = Latch.makeUnsafe(false)
     const acquireContext = fiber.context as Context.Context<RO>
 
-    const reader: Socket["reader"] = Effect.gen(function*() {
+    const reader: Socket["Service"]["reader"] = Effect.gen(function*() {
       const scope = yield* Effect.scope
       const ws = yield* Scope.provide(acquire, scope)
       if ("binaryType" in ws) {
@@ -1048,7 +1056,7 @@ export const fromWebSocket = <RO, WS extends WebSocketLike>(
       }
     }).pipe(
       Effect.updateContext((input: Context.Context<Scope.Scope>) => Context.merge(acquireContext, input))
-    ) as Socket["reader"]
+    ) as Socket["Service"]["reader"]
 
     const write = (chunk: Uint8Array | string | CloseEvent): Effect.Effect<void, SocketError> =>
       Effect.suspend(() => {
@@ -1080,7 +1088,7 @@ export const fromWebSocket = <RO, WS extends WebSocketLike>(
           return Effect.fail(new SocketError({ reason: new SocketWriteError({ cause }) }))
         }
       })
-    const writer: Socket["writer"] = Effect.succeed({ write, writeAll })
+    const writer: Socket["Service"]["writer"] = Effect.succeed({ write, writeAll })
 
     return Effect.succeed(make({ reader, writer }))
   })
@@ -1152,7 +1160,7 @@ export interface InputTransformStream {
  */
 export const fromTransformStream = <R>(
   acquire: Effect.Effect<InputTransformStream, SocketError, R>
-): Effect.Effect<Socket, never, Exclude<R, Scope.Scope>> =>
+): Effect.Effect<Socket["Service"], never, Exclude<R, Scope.Scope>> =>
   Effect.withFiber((fiber) => {
     const latch = Latch.makeUnsafe(false)
     let currentStream: {
@@ -1171,7 +1179,7 @@ export const fromTransformStream = <R>(
       return writer
     }
 
-    const reader: Socket["reader"] = Effect.gen(function*() {
+    const reader: Socket["Service"]["reader"] = Effect.gen(function*() {
       const scope = yield* Effect.scope
       const stream = yield* Scope.provide(acquire, scope)
       const readerHandle = (stream.readable as ReadableStream<Uint8Array | string>).getReader()
@@ -1212,7 +1220,7 @@ export const fromTransformStream = <R>(
       }
     }).pipe(
       Effect.updateContext((input: Context.Context<Scope.Scope>) => Context.merge(acquireContext, input))
-    ) as Socket["reader"]
+    ) as Socket["Service"]["reader"]
 
     const write = (chunk: Uint8Array | string | CloseEvent) =>
       latch.whenOpen(Effect.suspend(() => {
@@ -1238,7 +1246,7 @@ export const fromTransformStream = <R>(
         },
         catch: (cause) => new SocketError({ reason: new SocketWriteError({ cause }) })
       }))
-    const writer: Socket["writer"] = Effect.acquireRelease(
+    const writer: Socket["Service"]["writer"] = Effect.acquireRelease(
       Effect.succeed({ write, writeAll }),
       () =>
         Effect.promise(async () => {

--- a/packages/effect/src/unstable/socket/SocketServer.ts
+++ b/packages/effect/src/unstable/socket/SocketServer.ts
@@ -25,7 +25,7 @@ import type * as Socket from "./Socket.ts"
 export class SocketServer extends Context.Service<SocketServer, {
   readonly address: NetAddress.SocketAddress
   readonly run: <R, E, _>(
-    handler: (socket: Socket.Socket) => Effect.Effect<_, E, R>
+    handler: (socket: Socket.Socket["Service"]) => Effect.Effect<_, E, R>
   ) => Effect.Effect<never, SocketServerError, R>
 }>()("@effect/platform/SocketServer") {}
 

--- a/packages/effect/src/unstable/sql/SqlClient.ts
+++ b/packages/effect/src/unstable/sql/SqlClient.ts
@@ -36,49 +36,57 @@ const TypeId = "~effect/sql/SqlClient"
  * @category models
  * @since 4.0.0
  */
-export interface SqlClient extends Constructor {
-  readonly [TypeId]: typeof TypeId
-
+export declare namespace SqlClient {
   /**
-   * Copy of the client for safeql etc.
+   * Implementation of the SqlClient service.
+   *
+   * @category models
+   * @since 4.0.0
    */
-  readonly safe: this
+  export interface Service extends Constructor {
+    readonly [TypeId]: typeof TypeId
 
-  /**
-   * Copy of the client without transformations.
-   */
-  readonly withoutTransforms: () => this
+    /**
+     * Copy of the client for safeql etc.
+     */
+    readonly safe: this
 
-  readonly reserve: Effect.Effect<Connection.Connection, SqlError, Scope.Scope>
+    /**
+     * Copy of the client without transformations.
+     */
+    readonly withoutTransforms: () => this
 
-  /**
-   * With the given effect, ensure all sql queries are run in a transaction.
-   */
-  readonly withTransaction: <R, E, A>(
-    self: Effect.Effect<A, E, R>
-  ) => Effect.Effect<A, E | SqlError, R>
+    readonly reserve: Effect.Effect<Connection.Connection["Service"], SqlError, Scope.Scope>
 
-  /**
-   * The transaction service for this client.
-   */
-  readonly transactionService: Context.Service<TransactionConnection, TransactionConnection.Service>
+    /**
+     * With the given effect, ensure all sql queries are run in a transaction.
+     */
+    readonly withTransaction: <R, E, A>(
+      self: Effect.Effect<A, E, R>
+    ) => Effect.Effect<A, E | SqlError, R>
 
-  /**
-   * Use the Reactivity service to create a reactive query.
-   */
-  readonly reactive: <A, E, R>(
-    keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,
-    effect: Effect.Effect<A, E, R>
-  ) => Stream.Stream<A, E, R>
+    /**
+     * The transaction service for this client.
+     */
+    readonly transactionService: Context.Service<TransactionConnection, TransactionConnection.Service>
 
-  /**
-   * Use the Reactivity service to create a reactive
-   * query.
-   */
-  readonly reactiveMailbox: <A, E, R>(
-    keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,
-    effect: Effect.Effect<A, E, R>
-  ) => Effect.Effect<Queue.Dequeue<A, E>, never, R | Scope.Scope>
+    /**
+     * Use the Reactivity service to create a reactive query.
+     */
+    readonly reactive: <A, E, R>(
+      keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,
+      effect: Effect.Effect<A, E, R>
+    ) => Stream.Stream<A, E, R>
+
+    /**
+     * Use the Reactivity service to create a reactive
+     * query.
+     */
+    readonly reactiveMailbox: <A, E, R>(
+      keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,
+      effect: Effect.Effect<A, E, R>
+    ) => Effect.Effect<Queue.Dequeue<A, E>, never, R | Scope.Scope>
+  }
 }
 
 /**
@@ -92,7 +100,7 @@ export interface SqlClient extends Constructor {
  * @category services
  * @since 4.0.0
  */
-export const SqlClient = Context.Service<SqlClient>("effect/sql/SqlClient")
+export class SqlClient extends Context.Service<SqlClient, SqlClient.Service>()("effect/sql/SqlClient") {}
 
 /**
  * Namespace containing types associated with the `SqlClient` service.
@@ -175,8 +183,8 @@ export const make = Effect.fnUntraced(function*(options: SqlClient.MakeOptions) 
   const rollbackSavepoint = options.rollbackSavepoint ?? ((name: string) => `ROLLBACK TO SAVEPOINT ${name}`)
   const transactionAcquirer = options.transactionAcquirer ?? options.acquirer
   const control = options.prepareTransactionControls === true
-    ? (conn: Connection.Connection, sql: string) => conn.execute(sql, [], undefined)
-    : (conn: Connection.Connection, sql: string) => conn.executeUnprepared(sql, [], undefined)
+    ? (conn: Connection.Connection["Service"], sql: string) => conn.execute(sql, [], undefined)
+    : (conn: Connection.Connection["Service"], sql: string) => conn.executeUnprepared(sql, [], undefined)
   const withTransaction = makeWithTransaction({
     transactionService,
     spanAttributes: options.spanAttributes,
@@ -203,7 +211,7 @@ export const make = Effect.fnUntraced(function*(options: SqlClient.MakeOptions) 
       })
     )
 
-  const client: SqlClient = Object.assign(
+  const client: SqlClient["Service"] = Object.assign(
     Statement.make(getConnection, options.compiler, options.spanAttributes, options.transformRows, borrower),
     {
       [TypeId]: TypeId as typeof TypeId,
@@ -266,9 +274,9 @@ export const makeWithTransaction = <I, S>(options: {
   readonly rollback: (conn: NoInfer<S>) => Effect.Effect<void, SqlError>
   readonly rollbackSavepoint: (conn: NoInfer<S>, id: number) => Effect.Effect<void, SqlError>
 }) => {
-  const transactionSemaphore = Context.Service<Semaphore.Semaphore>(
+  class TransactionSemaphore extends Context.Service<TransactionSemaphore, Semaphore.Semaphore>()(
     `effect/sql/SqlClient/TransactionSemaphore/${transactionSemaphoreIdCounter++}`
-  )
+  ) {}
   return <R, E, A>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E | SqlError, R> =>
     Effect.uninterruptibleMask((restore) =>
       Effect.useSpan(
@@ -298,7 +306,7 @@ export const makeWithTransaction = <I, S>(options: {
                         restore(effect),
                         services.pipe(
                           Context.add(options.transactionService, [conn, id]),
-                          Context.add(transactionSemaphore, Semaphore.makeUnsafe(1)),
+                          Context.add(TransactionSemaphore, Semaphore.makeUnsafe(1)),
                           Context.add(Tracer.ParentSpan, span)
                         )
                       ),
@@ -330,7 +338,7 @@ export const makeWithTransaction = <I, S>(options: {
             )
             return id === 0
               ? transaction
-              : Context.getUnsafe(services, transactionSemaphore).withPermit(transaction)
+              : Context.getUnsafe(services, TransactionSemaphore).withPermit(transaction)
           })
       )
     )
@@ -343,9 +351,7 @@ export const makeWithTransaction = <I, S>(options: {
  * @category models
  * @since 4.0.0
  */
-export interface TransactionConnection {
-  readonly _: unique symbol
-}
+export interface TransactionConnection extends Context.ServiceClass.Shape<string, TransactionConnection.Service> {}
 
 /**
  * Namespace containing types associated with transaction connection services.
@@ -360,7 +366,7 @@ export declare namespace TransactionConnection {
    * @category services
    * @since 4.0.0
    */
-  export type Service = readonly [conn: Connection.Connection, depth: number]
+  export type Service = readonly [conn: Connection.Connection["Service"], depth: number]
 }
 
 /**
@@ -372,8 +378,11 @@ export declare namespace TransactionConnection {
  */
 export const TransactionConnection = (
   clientId: number
-): Context.Service<TransactionConnection, TransactionConnection.Service> =>
-  Context.Service(`effect/sql/SqlClient/TransactionConnection/${clientId}`)
+): Context.Service<TransactionConnection, TransactionConnection.Service> => {
+  const key: string = `effect/sql/SqlClient/TransactionConnection/${clientId}`
+  class Transaction extends Context.Service<Transaction, TransactionConnection.Service>()(key) {}
+  return Transaction
+}
 
 /**
  * Context reference used by SQL integrations to opt in to safe integer

--- a/packages/effect/src/unstable/sql/SqlConnection.ts
+++ b/packages/effect/src/unstable/sql/SqlConnection.ts
@@ -23,43 +23,51 @@ import type { SqlError } from "./SqlError.ts"
  * @category models
  * @since 4.0.0
  */
-export interface Connection {
-  readonly execute: (
-    sql: string,
-    params: ReadonlyArray<unknown>,
-    transformRows: (<A extends object>(row: ReadonlyArray<A>) => ReadonlyArray<A>) | undefined
-  ) => Effect<ReadonlyArray<any>, SqlError>
-
+export declare namespace Connection {
   /**
-   * Execute the specified SQL query and return the raw results directly from
-   * underlying SQL client.
+   * Implementation of the Connection service.
+   *
+   * @category models
+   * @since 4.0.0
    */
-  readonly executeRaw: (
-    sql: string,
-    params: ReadonlyArray<unknown>
-  ) => Effect<unknown, SqlError>
+  export interface Service {
+    readonly execute: (
+      sql: string,
+      params: ReadonlyArray<unknown>,
+      transformRows: (<A extends object>(row: ReadonlyArray<A>) => ReadonlyArray<A>) | undefined
+    ) => Effect<ReadonlyArray<any>, SqlError>
 
-  readonly executeStream: (
-    sql: string,
-    params: ReadonlyArray<unknown>,
-    transformRows: (<A extends object>(row: ReadonlyArray<A>) => ReadonlyArray<A>) | undefined
-  ) => Stream<any, SqlError>
+    /**
+     * Execute the specified SQL query and return the raw results directly from
+     * underlying SQL client.
+     */
+    readonly executeRaw: (
+      sql: string,
+      params: ReadonlyArray<unknown>
+    ) => Effect<unknown, SqlError>
 
-  readonly executeValues: (
-    sql: string,
-    params: ReadonlyArray<unknown>
-  ) => Effect<ReadonlyArray<ReadonlyArray<unknown>>, SqlError>
+    readonly executeStream: (
+      sql: string,
+      params: ReadonlyArray<unknown>,
+      transformRows: (<A extends object>(row: ReadonlyArray<A>) => ReadonlyArray<A>) | undefined
+    ) => Stream<any, SqlError>
 
-  readonly executeValuesUnprepared: (
-    sql: string,
-    params: ReadonlyArray<unknown>
-  ) => Effect<ReadonlyArray<ReadonlyArray<unknown>>, SqlError>
+    readonly executeValues: (
+      sql: string,
+      params: ReadonlyArray<unknown>
+    ) => Effect<ReadonlyArray<ReadonlyArray<unknown>>, SqlError>
 
-  readonly executeUnprepared: (
-    sql: string,
-    params: ReadonlyArray<unknown>,
-    transformRows: (<A extends object>(row: ReadonlyArray<A>) => ReadonlyArray<A>) | undefined
-  ) => Effect<ReadonlyArray<any>, SqlError>
+    readonly executeValuesUnprepared: (
+      sql: string,
+      params: ReadonlyArray<unknown>
+    ) => Effect<ReadonlyArray<ReadonlyArray<unknown>>, SqlError>
+
+    readonly executeUnprepared: (
+      sql: string,
+      params: ReadonlyArray<unknown>,
+      transformRows: (<A extends object>(row: ReadonlyArray<A>) => ReadonlyArray<A>) | undefined
+    ) => Effect<ReadonlyArray<any>, SqlError>
+  }
 }
 
 /**
@@ -69,7 +77,7 @@ export interface Connection {
  * @category models
  * @since 4.0.0
  */
-export type Acquirer = Effect<Connection, SqlError, Scope>
+export type Acquirer = Effect<Connection["Service"], SqlError, Scope>
 
 /**
  * Lends a connection for the duration of one effect and takes it back on any
@@ -86,7 +94,7 @@ export type Acquirer = Effect<Connection, SqlError, Scope>
  * @since 4.0.0
  */
 export type Borrower = <A, E, R>(
-  f: (connection: Connection) => Effect<A, E, R>
+  f: (connection: Connection["Service"]) => Effect<A, E, R>
 ) => Effect<A, E | SqlError, R>
 
 /**
@@ -95,7 +103,7 @@ export type Borrower = <A, E, R>(
  * @category services
  * @since 4.0.0
  */
-export const Connection = Context.Service<Connection>("effect/sql/SqlConnection")
+export class Connection extends Context.Service<Connection, Connection.Service>()("effect/sql/SqlConnection") {}
 
 /**
  * Generic SQL row shape mapping column names to unknown values.

--- a/packages/effect/src/unstable/sql/Statement.ts
+++ b/packages/effect/src/unstable/sql/Statement.ts
@@ -1236,7 +1236,7 @@ interface StatementImpl<A> extends Statement<A> {
   withConnection<XA, E>(
     operation: string,
     f: (
-      connection: Connection,
+      connection: Connection["Service"],
       sql: string,
       params: ReadonlyArray<unknown>
     ) => Effect.Effect<XA, E>,
@@ -1245,7 +1245,7 @@ interface StatementImpl<A> extends Statement<A> {
   withConnectionSpan<XA, E>(
     operation: string,
     f: (
-      connection: Connection,
+      connection: Connection["Service"],
       sql: string,
       params: ReadonlyArray<unknown>
     ) => Effect.Effect<XA, E>,
@@ -1282,7 +1282,7 @@ const StatementProto: Omit<
     this: StatementImpl<any>,
     operation: string,
     f: (
-      connection: Connection,
+      connection: Connection["Service"],
       sql: string,
       params: ReadonlyArray<unknown>
     ) => Effect.Effect<XA, E>,
@@ -1304,7 +1304,7 @@ const StatementProto: Omit<
     this: StatementImpl<any>,
     operation: string,
     f: (
-      connection: Connection,
+      connection: Connection["Service"],
       sql: string,
       params: ReadonlyArray<unknown>
     ) => Effect.Effect<XA, E>,
@@ -1320,7 +1320,7 @@ const StatementProto: Omit<
       span.attribute(ATTR_DB_QUERY_TEXT, sql)
       const execute = this.borrower === undefined
         ? Effect.scoped(Effect.flatMap(this.acquirer, (_) => f(_, sql, params)))
-        : this.borrower((connection: Connection) => f(connection, sql, params))
+        : this.borrower((connection: Connection["Service"]) => f(connection, sql, params))
       return fiber.cache.tracerEnabled && fiber.getRef(SpanPropagationEnabled)
         ? Effect.provideService(execute, Tracer.ParentSpan, span)
         : execute

--- a/packages/effect/src/unstable/workers/Worker.ts
+++ b/packages/effect/src/unstable/workers/Worker.ts
@@ -92,26 +92,12 @@ export const makeUnsafe = (options: {
 export type PlatformMessage = readonly [ready: 0] | readonly [data: 1, unknown]
 
 /**
- * Phantom identifier for the service that maps worker ids to platform-specific
- * worker instances.
- *
- * @category models
- * @since 4.0.0
- */
-export interface Spawner {
-  readonly _: unique symbol
-}
-
-/**
  * Service tag for the worker `SpawnerFn`.
  *
  * @category services
  * @since 4.0.0
  */
-export const Spawner: Context.Service<
-  Spawner,
-  SpawnerFn<unknown>
-> = Context.Service("effect/workers/Worker/Spawner")
+export class Spawner extends Context.Service<Spawner, SpawnerFn<unknown>>()("effect/workers/Worker/Spawner") {}
 
 /**
  * Function that creates or locates a platform-specific worker instance for a
@@ -150,13 +136,13 @@ export const makePlatform = <W>() =>
 >(options: {
   readonly setup: (options: {
     readonly worker: W
-    readonly scope: Scope.Scope
+    readonly scope: Scope.Scope["Service"]
   }) => Effect.Effect<P, WorkerError>
   readonly listen: (options: {
     readonly port: P
     readonly emit: (data: any) => void
     readonly deferred: Deferred.Deferred<never, WorkerError>
-    readonly scope: Scope.Scope
+    readonly scope: Scope.Scope["Service"]
   }) => Effect.Effect<void>
 }): WorkerPlatform["Service"] =>
   WorkerPlatform.of({

--- a/packages/effect/src/unstable/workflow/Activity.ts
+++ b/packages/effect/src/unstable/workflow/Activity.ts
@@ -306,12 +306,12 @@ export const raceAll = <const Activities extends NonEmptyReadonlyArray<Any>>(
 // internal
 // -----------------------------------------------------------------------------
 
-const EngineTag = Context.Service<WorkflowEngine, WorkflowEngine["Service"]>(
+class EngineTag extends Context.Service<EngineTag, WorkflowEngine["Service"]>()(
   "effect/workflow/WorkflowEngine" satisfies typeof WorkflowEngine.key
-)
-const InstanceTag = Context.Service<WorkflowInstance, WorkflowInstance["Service"]>(
+) {}
+class InstanceTag extends Context.Service<InstanceTag, WorkflowInstance["Service"]>()(
   "effect/workflow/WorkflowEngine/WorkflowInstance" satisfies typeof WorkflowInstance.key
-)
+) {}
 
 const makeExecute = Effect.fnUntraced(function*<
   R,

--- a/packages/effect/src/unstable/workflow/DurableClock.ts
+++ b/packages/effect/src/unstable/workflow/DurableClock.ts
@@ -49,16 +49,13 @@ export const make = (options: {
   deferred: DurableDeferred.make(`DurableClock/${options.name}`)
 })
 
-const EngineTag = Context.Service<WorkflowEngine, WorkflowEngine["Service"]>(
+class EngineTag extends Context.Service<EngineTag, WorkflowEngine["Service"]>()(
   "effect/workflow/WorkflowEngine" satisfies typeof WorkflowEngine.key
-)
+) {}
 
-const InstanceTag = Context.Service<
-  WorkflowInstance,
-  WorkflowInstance["Service"]
->(
+class InstanceTag extends Context.Service<InstanceTag, WorkflowInstance["Service"]>()(
   "effect/workflow/WorkflowEngine/WorkflowInstance" satisfies typeof WorkflowInstance.key
-)
+) {}
 
 /**
  * Waits inside a workflow, using an in-memory activity for durations at or

--- a/packages/effect/src/unstable/workflow/DurableDeferred.ts
+++ b/packages/effect/src/unstable/workflow/DurableDeferred.ts
@@ -113,16 +113,13 @@ export const make = <
   }
 }
 
-const EngineTag = Context.Service<WorkflowEngine, WorkflowEngine["Service"]>(
+class EngineTag extends Context.Service<EngineTag, WorkflowEngine["Service"]>()(
   "effect/workflow/WorkflowEngine" satisfies typeof WorkflowEngine.key
-)
+) {}
 
-const InstanceTag = Context.Service<
-  WorkflowInstance,
-  WorkflowInstance["Service"]
->(
+class InstanceTag extends Context.Service<InstanceTag, WorkflowInstance["Service"]>()(
   "effect/workflow/WorkflowEngine/WorkflowInstance" satisfies typeof WorkflowInstance.key
-)
+) {}
 
 const CurrentAttempt = Context.Reference<number>(
   "effect/workflow/Activity/CurrentAttempt" satisfies typeof Activity.CurrentAttempt.key,

--- a/packages/effect/src/unstable/workflow/Workflow.ts
+++ b/packages/effect/src/unstable/workflow/Workflow.ts
@@ -302,16 +302,13 @@ export type RequirementsHandler<Workflows extends Any> = Workflows extends Workf
     | _Error["EncodingServices"]
   : never
 
-const EngineTag = Context.Service<WorkflowEngine, WorkflowEngine["Service"]>(
+class EngineTag extends Context.Service<EngineTag, WorkflowEngine["Service"]>()(
   "effect/workflow/WorkflowEngine" satisfies typeof WorkflowEngine.key
-)
+) {}
 
-const InstanceTag = Context.Service<
-  WorkflowInstance,
-  WorkflowInstance["Service"]
->(
+class InstanceTag extends Context.Service<InstanceTag, WorkflowInstance["Service"]>()(
   "effect/workflow/WorkflowEngine/WorkflowInstance" satisfies typeof WorkflowInstance.key
-)
+) {}
 
 const makeExecutionIdFromPayload = (self: AnyWithProps, payload: unknown) =>
   makeHashDigest(`${self._tag}-${self.idempotencyKey(payload)}`)
@@ -765,9 +762,9 @@ interface ActivityRegistration {
   state: "pending" | "adopted" | "released"
 }
 
-const PendingActivityRegistration = Context.Service<ActivityRegistration>(
+class PendingActivityRegistration extends Context.Service<PendingActivityRegistration, ActivityRegistration>()(
   "effect/workflow/Workflow/PendingActivityRegistration"
-)
+) {}
 
 const registerActivityUnsafe = (instance: WorkflowInstance["Service"]): ActivityRegistration => {
   const state = instance.activityState
@@ -835,12 +832,12 @@ const waitForZero = Effect.fnUntraced(function*(instance: WorkflowInstance["Serv
  * @since 4.0.0
  */
 export const scope: Effect.Effect<
-  Scope.Scope,
+  Scope.Scope["Service"],
   never,
   WorkflowInstance
 > = Effect.map(
   InstanceTag,
-  (instance) => instance.scope as Scope.Scope
+  (instance) => instance.scope as Scope.Scope["Service"]
 )
 
 /**

--- a/packages/effect/src/unstable/workflow/WorkflowEngine.ts
+++ b/packages/effect/src/unstable/workflow/WorkflowEngine.ts
@@ -678,7 +678,7 @@ export const layerMemory: Layer.Layer<WorkflowEngine> = Layer.effect(WorkflowEng
         payload: object,
         executionId: string
       ) => Effect.Effect<unknown, unknown, WorkflowInstance | WorkflowEngine>
-      readonly scope: Scope.Scope
+      readonly scope: Scope.Scope["Service"]
     }>()
 
     type ExecutionState = {

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -6,9 +6,9 @@ import * as Redactable from "effect/Redactable"
 import { describe, it } from "vitest"
 
 describe("Context", () => {
-  const A = Context.Service<number>("ContextTest/A")
-  const B = Context.Service<number>("ContextTest/B")
-  const C = Context.Service<number>("ContextTest/C")
+  class A extends Context.Service<A, number>()("ContextTest/A") {}
+  class B extends Context.Service<B, number>()("ContextTest/B") {}
+  class C extends Context.Service<C, number>()("ContextTest/C") {}
 
   it("keeps the source immutable across additions", () => {
     const source = Context.make(A, 1)
@@ -43,6 +43,7 @@ describe("Context", () => {
   })
 
   it("invalidates the fiber cache only for opted-in keys", () => {
+    // Keep direct const-form coverage alongside the class form.
     const Cached = Context.Service<number>("ContextTest/Cached", { fiberCached: true })
     class CachedClass extends Context.Service<CachedClass, number>()("ContextTest/CachedClass", {
       fiberCached: true
@@ -82,7 +83,7 @@ describe("Context", () => {
   })
 
   it("supports the Redactable fallback context", () => {
-    const Cached = Context.Service<number>("ContextTest/RedactableCached", { fiberCached: true })
+    class Cached extends Context.Service<Cached, number>()("ContextTest/RedactableCached", { fiberCached: true }) {}
     const context = Redactable.getRedacted({
       [Redactable.symbolRedactable](context: Context.Context<never>) {
         return context
@@ -98,8 +99,8 @@ describe("Context", () => {
   })
 
   it("distinguishes an undefined service from an absent service", () => {
-    const Undefined = Context.Service<undefined>("ContextTest/Undefined", { fiberCached: true })
-    const Missing = Context.Service<undefined>("ContextTest/Missing")
+    class Undefined extends Context.Service<Undefined, undefined>()("ContextTest/Undefined", { fiberCached: true }) {}
+    class Missing extends Context.Service<Missing, undefined>()("ContextTest/Missing") {}
     const Ref = Context.Reference<string | undefined>("ContextTest/UndefinedRef", {
       defaultValue: () => "default",
       fiberCached: true
@@ -115,7 +116,10 @@ describe("Context", () => {
   })
 
   it("bounds deep overlay chains without changing values or order", () => {
-    const keys = Array.from({ length: 20 }, (_, i) => Context.Service<number>(`ContextTest/Deep${i}`))
+    const keys = Array.from(
+      { length: 20 },
+      (_, i) => class Deep extends Context.Service<Deep, number>()(`ContextTest/Deep${i}`) {}
+    )
     let context = Context.empty()
     for (let i = 0; i < keys.length; i++) {
       context = Context.add(context, keys[i], i)

--- a/packages/effect/test/Formatter.test.ts
+++ b/packages/effect/test/Formatter.test.ts
@@ -230,7 +230,7 @@ describe("Formatter", () => {
     })
 
     it("Context.Service", () => {
-      const MyService = Context.Service<{ readonly value: number }>("MyService")
+      class MyService extends Context.Service<MyService, { readonly value: number }>()("MyService") {}
       strictEqual(format(MyService).includes(`"key": "MyService"`), true)
     })
 

--- a/packages/effect/test/HttpClient.test.ts
+++ b/packages/effect/test/HttpClient.test.ts
@@ -35,8 +35,9 @@ const makeJsonPlaceholder = Effect.gen(function*() {
     createTodo
   } as const
 })
-interface JsonPlaceholder extends Effect.Success<typeof makeJsonPlaceholder> {}
-const JsonPlaceholder = Context.Service<JsonPlaceholder>("test/JsonPlaceholder")
+class JsonPlaceholder
+  extends Context.Service<JsonPlaceholder, Effect.Success<typeof makeJsonPlaceholder>>()("test/JsonPlaceholder")
+{}
 const JsonPlaceholderLayer = Layer.effect(JsonPlaceholder)(makeJsonPlaceholder)
 const TestRoutes = HttpRouter.serve(HttpRouter.use(Effect.fnUntraced(function*(router) {
   yield* router.addAll([

--- a/packages/effect/test/Layer.test.ts
+++ b/packages/effect/test/Layer.test.ts
@@ -11,7 +11,7 @@ import * as Scope from "effect/Scope"
 describe("Layer", () => {
   it.effect("layers can be acquired in parallel", () =>
     Effect.gen(function*() {
-      const BoolTag = Context.Service<boolean>("boolean")
+      class BoolTag extends Context.Service<BoolTag, boolean>()("boolean") {}
       const latch = Latch.makeUnsafe()
       const layer1 = Layer.effectContext<never, never, never>(Effect.never)
       const layer2 = Layer.effectContext(
@@ -555,7 +555,7 @@ describe("Layer", () => {
   describe("tracing", () => {
     it.effect("withSpan forwards captureStackTrace to the layer stack frame", () =>
       Effect.gen(function*() {
-        const Frame = Context.Service<References.StackFrame | undefined>("Frame")
+        class Frame extends Context.Service<Frame, References.StackFrame | undefined>()("Frame") {}
         const layer = Layer.effect(Frame, References.CurrentStackFrame)
 
         // By default the frame records this call site, not Layer's internals.
@@ -587,7 +587,7 @@ describe("Layer", () => {
       Effect.gen(function*() {
         // Edge case: the data-first overload has separate runtime branching, and onEnd
         // must run when the layer scope closes.
-        const SpanName = Context.Service<string>("SpanName")
+        class SpanName extends Context.Service<SpanName, string>()("SpanName") {}
         const exits: Array<Exit.Exit<unknown, unknown>> = []
         const scope = yield* Scope.make()
         const layer = Layer.effect(SpanName)(
@@ -610,7 +610,7 @@ describe("Layer", () => {
       Effect.gen(function*() {
         // Edge case: external spans do not get stack-frame wrapping, but they should
         // still be installed as the parent span for layer construction.
-        const SpanId = Context.Service<string>("SpanId")
+        class SpanId extends Context.Service<SpanId, string>()("SpanId") {}
         const parent = Tracer.externalSpan({
           spanId: "0000000000000001",
           traceId: "00000000000000000000000000000001",
@@ -641,8 +641,8 @@ export class Service1 {
     return Effect.succeed(1)
   }
 }
-const Service1Tag = Context.Service<Service1>("Service1")
-const makeLayer1 = (array: Array<string>): Layer.Layer<Service1> => {
+class Service1Tag extends Context.Service<Service1Tag, Service1>()("Service1") {}
+const makeLayer1 = (array: Array<string>): Layer.Layer<Service1Tag> => {
   return Layer.effect(Service1Tag)(
     Effect.acquireRelease(
       Effect.sync(() => {
@@ -658,8 +658,8 @@ class Service2 {
     return Effect.succeed(2)
   }
 }
-const Service2Tag = Context.Service<Service2>("Service2")
-const makeLayer2 = (array: Array<string>): Layer.Layer<Service2> => {
+class Service2Tag extends Context.Service<Service2Tag, Service2>()("Service2") {}
+const makeLayer2 = (array: Array<string>): Layer.Layer<Service2Tag> => {
   return Layer.effect(Service2Tag)(
     Effect.acquireRelease(
       Effect.sync(() => {
@@ -675,8 +675,8 @@ class Service3 {
     return Effect.succeed(3)
   }
 }
-const Service3Tag = Context.Service<Service3>("Service3")
-const makeLayer3 = (array: Array<string>): Layer.Layer<Service3> => {
+class Service3Tag extends Context.Service<Service3Tag, Service3>()("Service3") {}
+const makeLayer3 = (array: Array<string>): Layer.Layer<Service3Tag> => {
   return Layer.effect(Service3Tag)(
     Effect.acquireRelease(
       Effect.sync(() => {

--- a/packages/effect/test/ManagedRuntime.test.ts
+++ b/packages/effect/test/ManagedRuntime.test.ts
@@ -16,10 +16,10 @@ describe("ManagedRuntime", () => {
   })
 
   test("provides context", async () => {
-    const tag = Context.Service<string>("string")
-    const layer = Layer.succeed(tag)("test")
+    class Tag extends Context.Service<Tag, string>()("string") {}
+    const layer = Layer.succeed(Tag)("test")
     const runtime = ManagedRuntime.make(layer)
-    const result = await runtime.runPromise(tag)
+    const result = await runtime.runPromise(Tag)
     await runtime.dispose()
     strictEqual(result, "test")
   })
@@ -39,11 +39,11 @@ describe("ManagedRuntime", () => {
   })
 
   it("can be built synchronously", () => {
-    const tag = Context.Service<string>("string")
-    const layer = Layer.succeed(tag)("test")
+    class Tag extends Context.Service<Tag, string>()("string") {}
+    const layer = Layer.succeed(Tag)("test")
     const managedRuntime = ManagedRuntime.make(layer)
     const services = Effect.runSync(managedRuntime.contextEffect)
-    const result = Context.get(services, tag)
+    const result = Context.get(services, Tag)
     strictEqual(result, "test")
   })
 

--- a/packages/effect/test/cluster/TestEntity.ts
+++ b/packages/effect/test/cluster/TestEntity.ts
@@ -140,9 +140,9 @@ export const TestEntityNoState = TestEntity.toLayer(
 
 export const TestEntityLayer = TestEntityNoState.pipe(Layer.provideMerge(TestEntityState.layer))
 
-export const CallerId = Context.Service<never, string>(
+export class CallerId extends Context.Service<CallerId, string>()(
   "effect/test/cluster/CallerId"
-)
+) {}
 
 export const ContextBleedEntity = Entity.make("ContextBleedEntity", [
   Rpc.make("ReadCaller", { success: Schema.String }).annotate(ClusterSchema.Persisted, false),

--- a/packages/effect/test/reactivity/Atom.test.ts
+++ b/packages/effect/test/reactivity/Atom.test.ts
@@ -202,12 +202,11 @@ describe("Atom", { concurrent: false }, () => {
   })
 
   it("runtime layers are disposed with their registry", () => {
-    interface Service {
+    class Service extends Context.Service<Service, {
       readonly id: number
       readonly isAlive: () => boolean
       readonly finalize: () => void
-    }
-    const Service = Context.Service<Service>("Atom.test/RegistryScopedService")
+    }>()("Atom.test/RegistryScopedService") {}
     const finalized: Array<number> = []
     let builds = 0
     const layer = Layer.effect(
@@ -247,7 +246,7 @@ describe("Atom", { concurrent: false }, () => {
   })
 
   it("default runtime factories build layers once per registry", () => {
-    const Service = Context.Service<number>("Atom.test/DefaultRegistryScopedService")
+    class Service extends Context.Service<Service, number>()("Atom.test/DefaultRegistryScopedService") {}
     let builds = 0
     const runtime = Atom.runtime(Layer.sync(Service, () => ++builds))
     const service = runtime.atom(Service)
@@ -263,7 +262,7 @@ describe("Atom", { concurrent: false }, () => {
   })
 
   it("concrete runtime memo maps share layers across registries", () => {
-    const Service = Context.Service<number>("Atom.test/SharedRuntimeService")
+    class Service extends Context.Service<Service, number>()("Atom.test/SharedRuntimeService") {}
     let builds = 0
     const factory = Atom.context({ memoMap: Layer.makeMemoMapUnsafe() })
     const runtime = factory(Layer.sync(Service, () => ++builds))
@@ -280,7 +279,7 @@ describe("Atom", { concurrent: false }, () => {
   })
 
   it("shared memo map atoms share within a registry and isolate across registries", () => {
-    const Service = Context.Service<number>("Atom.test/SharedRegistryScopedService")
+    class Service extends Context.Service<Service, number>()("Atom.test/SharedRegistryScopedService") {}
     let builds = 0
     const layer = Layer.sync(Service, () => ++builds)
     const memoMap = Atom.make(() => Layer.makeMemoMapUnsafe())
@@ -2830,11 +2829,10 @@ describe("Atom", { concurrent: false }, () => {
   })
 })
 
-interface BuildCounter {
+class BuildCounter extends Context.Service<BuildCounter, {
   readonly get: Effect.Effect<number>
   readonly inc: Effect.Effect<void>
-}
-const BuildCounter = Context.Service<BuildCounter>("BuildCounter")
+}>()("BuildCounter") {}
 const BuildCounterLayer = Layer.sync(BuildCounter, () => {
   let count = 0
   return BuildCounter.of({
@@ -2845,11 +2843,10 @@ const BuildCounterLayer = Layer.sync(BuildCounter, () => {
   })
 })
 
-interface Counter {
+class Counter extends Context.Service<Counter, {
   readonly get: Effect.Effect<number>
   readonly inc: Effect.Effect<void>
-}
-const Counter = Context.Service<Counter>("Counter")
+}>()("Counter") {}
 const CounterLayer = Layer.effect(
   Counter,
   Effect.gen(function*() {
@@ -2884,10 +2881,9 @@ const CounterTest = Layer.effect(
   Layer.provide(BuildCounterLayer)
 )
 
-interface Multiplier {
+class Multiplier extends Context.Service<Multiplier, {
   readonly times: (n: number) => Effect.Effect<number>
-}
-const Multiplier = Context.Service<Multiplier>("Multiplier")
+}>()("Multiplier") {}
 const MultiplierLayer = Layer.effect(
   Multiplier,
   Effect.gen(function*() {

--- a/packages/effect/test/unstable/cli/Command.test.ts
+++ b/packages/effect/test/unstable/cli/Command.test.ts
@@ -50,8 +50,8 @@ describe("Command", () => {
   describe("annotations", () => {
     it.effect("should expose annotations in help docs", () =>
       Effect.gen(function*() {
-        const Team = Context.Service<never, string>("effect/test/unstable/cli/Team")
-        const Priority = Context.Service<never, number>("effect/test/unstable/cli/Priority")
+        class Team extends Context.Service<Team, string>()("effect/test/unstable/cli/Team") {}
+        class Priority extends Context.Service<Priority, number>()("effect/test/unstable/cli/Priority") {}
         const docs: Array<Parameters<CliOutput.Formatter["formatHelpDoc"]>[0]> = []
 
         const formatter: CliOutput.Formatter = {
@@ -74,13 +74,13 @@ describe("Command", () => {
 
         assert.strictEqual(docs.length, 1)
         const annotations = docs[0].annotations
-        assert.strictEqual(Context.get(annotations, Team), "runtime")
-        assert.strictEqual(Context.get(annotations, Priority), 2)
+        assert.strictEqual(Context.getUnsafe(annotations, Team), "runtime")
+        assert.strictEqual(Context.getUnsafe(annotations, Priority), 2)
       }))
 
     it.effect("should keep annotations when adding subcommands", () =>
       Effect.gen(function*() {
-        const Scope = Context.Service<never, string>("effect/test/unstable/cli/Scope")
+        class Scope extends Context.Service<Scope, string>()("effect/test/unstable/cli/Scope") {}
         const docs: Array<Parameters<CliOutput.Formatter["formatHelpDoc"]>[0]> = []
 
         const formatter: CliOutput.Formatter = {
@@ -110,8 +110,8 @@ describe("Command", () => {
         )
 
         assert.strictEqual(docs.length, 2)
-        assert.strictEqual(Context.get(docs[0].annotations, Scope), "root")
-        assert.strictEqual(Context.get(docs[1].annotations, Scope), "child")
+        assert.strictEqual(Context.getUnsafe(docs[0].annotations, Scope), "root")
+        assert.strictEqual(Context.getUnsafe(docs[1].annotations, Scope), "child")
       }))
   })
 
@@ -667,9 +667,9 @@ describe("Command", () => {
         const Region = GlobalFlag.Setting("region")({
           flag: Flag.String("region").pipe(Flag.optional)
         })
-        const RegionFromProvide = Context.Service<never, Option.Option<string>>(
+        class RegionFromProvide extends Context.Service<RegionFromProvide, Option.Option<string>>()(
           "effect/test/unstable/cli/RegionFromProvide"
-        )
+        ) {}
         const capturedFromProvide: Array<Option.Option<string>> = []
         const capturedFromProvideEffect: Array<Option.Option<string>> = []
 
@@ -1412,7 +1412,7 @@ describe("Command", () => {
       Effect.gen(function*() {
         const messages: Array<string> = []
 
-        const DbUrl = Context.Service<never, string>("effect/test/unstable/cli/DbUrl")
+        class DbUrl extends Context.Service<DbUrl, string>()("effect/test/unstable/cli/DbUrl") {}
 
         const root = Command.make("app", {
           dryRun: Flag.Boolean("dry-run")

--- a/packages/effect/test/unstable/cli/services/MockTerminal.ts
+++ b/packages/effect/test/unstable/cli/services/MockTerminal.ts
@@ -30,6 +30,8 @@ export declare namespace MockTerminal {
 // Service
 // =============================================================================
 
+// Keep the production Terminal identifier until Terminal is migrated to class syntax.
+// A MockTerminal self type would no longer satisfy the Terminal requirements below.
 export const MockTerminal = Context.Service<Terminal.Terminal, MockTerminal>()(
   Terminal.Terminal.key
 )

--- a/packages/effect/test/unstable/sql/SqlClient.test.ts
+++ b/packages/effect/test/unstable/sql/SqlClient.test.ts
@@ -6,10 +6,6 @@ interface StubConnection {
   readonly id: string
 }
 
-interface StubTransactionConnection {
-  readonly _: unique symbol
-}
-
 const sqlError = (message: string) =>
   new SqlError.SqlError({
     reason: new SqlError.UnknownError({ cause: new Error(message), message })
@@ -31,10 +27,10 @@ const makeHarness = (failures: {
 } = {}) => {
   const calls: Array<string> = []
   const conn: StubConnection = { id: "stub" }
-  const transactionService = Context.Service<
-    StubTransactionConnection,
+  class TransactionConnection extends Context.Service<
+    TransactionConnection,
     readonly [conn: StubConnection, counter: number]
-  >(`test/SqlClient/TransactionConnection/${harnessIdCounter++}`)
+  >()(`test/SqlClient/TransactionConnection/${harnessIdCounter++}`) {}
 
   let transactionActive = false
   const savepoints: Array<number> = []
@@ -42,7 +38,7 @@ const makeHarness = (failures: {
   const record = (name: string) => Effect.sync(() => calls.push(name))
 
   const withTransaction = SqlClient.makeWithTransaction({
-    transactionService,
+    transactionService: TransactionConnection,
     spanAttributes: [],
     acquireConnection: Effect.flatMap(Scope.make(), (scope) =>
       Effect.as(

--- a/packages/effect/typeperf/suites/httpapi/fixtures/client-endpoint-count-500.ts
+++ b/packages/effect/typeperf/suites/httpapi/fixtures/client-endpoint-count-500.ts
@@ -10,7 +10,7 @@ HttpApiGroup.make("users")
 HttpApiEndpoint.get("warmup", "/warmup")
 
 declare const api: Api<500>
-declare const httpClient: HttpClient.HttpClient
+declare const httpClient: HttpClient.HttpClient["Service"]
 
 const endpointClient = HttpApiClient.endpoint(api, {
   group: "users",

--- a/packages/effect/typetest/Context.tst.ts
+++ b/packages/effect/typetest/Context.tst.ts
@@ -1,7 +1,7 @@
 import { Context, Option } from "effect"
 import { expect, it } from "tstyche"
 
-it("does not type a service removed with addOrOmit as present", () => {
+it("does not type a const service removed with addOrOmit as present", () => {
   const Service = Context.Service<{ readonly value: number }>("TestService")
   const context = Context.make(Service, { value: 1 }).pipe(Context.addOrOmit(Service, Option.none()))
   const dataFirst = Context.addOrOmit(Context.make(Service, { value: 1 }), Service, Option.none())
@@ -10,7 +10,7 @@ it("does not type a service removed with addOrOmit as present", () => {
   expect(Context.get).type.not.toBeCallableWith(dataFirst, Service)
 })
 
-it("infers services for a saved curried getter", () => {
+it("infers const services for a saved curried getter", () => {
   const Service = Context.Service<{ readonly value: number }>("TestService")
   const getService = Context.get(Service)
 

--- a/packages/platform/browser/src/BrowserCrypto.ts
+++ b/packages/platform/browser/src/BrowserCrypto.ts
@@ -66,7 +66,7 @@ export const layer: Layer.Layer<EffectCrypto.Crypto> = Layer.effect(
       return bytes
     }
 
-    const digest: EffectCrypto.Crypto["digest"] = (algorithm, data) => {
+    const digest: EffectCrypto.Crypto["Service"]["digest"] = (algorithm, data) => {
       if (typeof crypto.subtle?.digest !== "function") {
         return Effect.fail(PlatformError.systemError({
           module: "Crypto",

--- a/packages/platform/browser/src/Clipboard.ts
+++ b/packages/platform/browser/src/Clipboard.ts
@@ -41,14 +41,22 @@ const ErrorTypeId = "~@effect/platform-browser/Clipboard/ClipboardError"
  * @category services
  * @since 4.0.0
  */
-export interface Clipboard {
-  readonly [TypeId]: typeof TypeId
-  readonly read: Effect.Effect<ClipboardItems, ClipboardError>
-  readonly readString: Effect.Effect<string, ClipboardError>
-  readonly write: (items: ClipboardItems) => Effect.Effect<void, ClipboardError>
-  readonly writeString: (text: string) => Effect.Effect<void, ClipboardError>
-  readonly writeBlob: (blob: Blob) => Effect.Effect<void, ClipboardError>
-  readonly clear: Effect.Effect<void, ClipboardError>
+export declare namespace Clipboard {
+  /**
+   * Implementation of the Clipboard service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service {
+    readonly [TypeId]: typeof TypeId
+    readonly read: Effect.Effect<ClipboardItems, ClipboardError>
+    readonly readString: Effect.Effect<string, ClipboardError>
+    readonly write: (items: ClipboardItems) => Effect.Effect<void, ClipboardError>
+    readonly writeString: (text: string) => Effect.Effect<void, ClipboardError>
+    readonly writeBlob: (blob: Blob) => Effect.Effect<void, ClipboardError>
+    readonly clear: Effect.Effect<void, ClipboardError>
+  }
 }
 
 /**
@@ -78,7 +86,7 @@ export class ClipboardError extends Data.TaggedError("ClipboardError")<{
  * @category services
  * @since 4.0.0
  */
-export const Clipboard: Context.Service<Clipboard, Clipboard> = Context.Service<Clipboard>(TypeId)
+export class Clipboard extends Context.Service<Clipboard, Clipboard.Service>()(TypeId) {}
 
 /**
  * Builds a `Clipboard` service from primitive read and write operations, deriving `clear` and `writeBlob` helpers.
@@ -87,8 +95,8 @@ export const Clipboard: Context.Service<Clipboard, Clipboard> = Context.Service<
  * @since 4.0.0
  */
 export const make = (
-  impl: Omit<Clipboard, "clear" | "writeBlob" | typeof TypeId>
-): Clipboard =>
+  impl: Omit<Clipboard["Service"], "clear" | "writeBlob" | typeof TypeId>
+): Clipboard["Service"] =>
   Clipboard.of({
     ...impl,
     [TypeId]: TypeId,

--- a/packages/platform/browser/src/Geolocation.ts
+++ b/packages/platform/browser/src/Geolocation.ts
@@ -47,18 +47,26 @@ const ErrorTypeId = "~@effect/platform-browser/Geolocation/GeolocationError"
  * @category services
  * @since 4.0.0
  */
-export interface Geolocation {
-  readonly [TypeId]: typeof TypeId
-  readonly getCurrentPosition: (
-    options?: PositionOptions | undefined
-  ) => Effect.Effect<GeolocationPosition, GeolocationError>
-  readonly watchPosition: (
-    options?:
-      | PositionOptions & {
-        readonly bufferSize?: number | undefined
-      }
-      | undefined
-  ) => Stream.Stream<GeolocationPosition, GeolocationError>
+export declare namespace Geolocation {
+  /**
+   * Implementation of the Geolocation service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service {
+    readonly [TypeId]: typeof TypeId
+    readonly getCurrentPosition: (
+      options?: PositionOptions | undefined
+    ) => Effect.Effect<GeolocationPosition, GeolocationError>
+    readonly watchPosition: (
+      options?:
+        | PositionOptions & {
+          readonly bufferSize?: number | undefined
+        }
+        | undefined
+    ) => Stream.Stream<GeolocationPosition, GeolocationError>
+  }
 }
 
 /**
@@ -74,7 +82,7 @@ export interface Geolocation {
  * @category services
  * @since 4.0.0
  */
-export const Geolocation: Context.Service<Geolocation, Geolocation> = Context.Service<Geolocation>(TypeId)
+export class Geolocation extends Context.Service<Geolocation, Geolocation.Service>()(TypeId) {}
 
 /**
  * Tagged error wrapping a browser geolocation failure reason.

--- a/packages/platform/browser/src/IndexedDb.ts
+++ b/packages/platform/browser/src/IndexedDb.ts
@@ -22,10 +22,18 @@ const TypeId = "~@effect/platform-browser/IndexedDb"
  * @category services
  * @since 4.0.0
  */
-export interface IndexedDb {
-  readonly [TypeId]: typeof TypeId
-  readonly indexedDB: globalThis.IDBFactory
-  readonly IDBKeyRange: typeof globalThis.IDBKeyRange
+export declare namespace IndexedDb {
+  /**
+   * Implementation of the IndexedDb service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service {
+    readonly [TypeId]: typeof TypeId
+    readonly indexedDB: globalThis.IDBFactory
+    readonly IDBKeyRange: typeof globalThis.IDBKeyRange
+  }
 }
 
 /**
@@ -34,7 +42,7 @@ export interface IndexedDb {
  * @category services
  * @since 4.0.0
  */
-export const IndexedDb: Context.Service<IndexedDb, IndexedDb> = Context.Service<IndexedDb, IndexedDb>(TypeId)
+export class IndexedDb extends Context.Service<IndexedDb, IndexedDb.Service>()(TypeId) {}
 
 /** @internal */
 const IDBFlatKey = Schema.Union([
@@ -88,7 +96,8 @@ export const AutoIncrement = Schema.Int.check(
  * @category constructors
  * @since 4.0.0
  */
-export const make = (impl: Omit<IndexedDb, typeof TypeId>): IndexedDb => IndexedDb.of({ [TypeId]: TypeId, ...impl })
+export const make = (impl: Omit<IndexedDb["Service"], typeof TypeId>): IndexedDb["Service"] =>
+  IndexedDb.of({ [TypeId]: TypeId, ...impl })
 
 /**
  * Layer that provides `IndexedDb` from `window.indexedDB` and `window.IDBKeyRange`, failing with a config error when they are unavailable.

--- a/packages/platform/browser/src/Permissions.ts
+++ b/packages/platform/browser/src/Permissions.ts
@@ -24,20 +24,28 @@ const ErrorTypeId = "~@effect/platform-browser/Permissions/PermissionsError"
  * @category services
  * @since 4.0.0
  */
-export interface Permissions {
-  readonly [TypeId]: typeof TypeId
-
+export declare namespace Permissions {
   /**
-   * Returns the state of a user permission on the global scope.
+   * Implementation of the Permissions service.
+   *
+   * @category models
+   * @since 4.0.0
    */
-  readonly query: <Name extends PermissionName>(
-    name: Name
-  ) => Effect.Effect<
-    // `name` is identical to the name passed to Permissions.query
-    // https://developer.mozilla.org/en-US/docs/Web/API/PermissionStatus
-    Omit<PermissionStatus, "name"> & { name: Name },
-    PermissionsError
-  >
+  export interface Service {
+    readonly [TypeId]: typeof TypeId
+
+    /**
+     * Returns the state of a user permission on the global scope.
+     */
+    readonly query: <Name extends PermissionName>(
+      name: Name
+    ) => Effect.Effect<
+      // `name` is identical to the name passed to Permissions.query
+      // https://developer.mozilla.org/en-US/docs/Web/API/PermissionStatus
+      Omit<PermissionStatus, "name"> & { name: Name },
+      PermissionsError
+    >
+  }
 }
 
 /**
@@ -110,7 +118,7 @@ export class PermissionsError extends Data.TaggedError("PermissionsError")<{
  * @category services
  * @since 4.0.0
  */
-export const Permissions: Context.Service<Permissions, Permissions> = Context.Service<Permissions>(TypeId)
+export class Permissions extends Context.Service<Permissions, Permissions.Service>()(TypeId) {}
 
 /**
  * Provides the `Permissions` service using the browser `navigator.permissions` API.

--- a/packages/platform/bun/src/BunHttpServer.ts
+++ b/packages/platform/bun/src/BunHttpServer.ts
@@ -227,10 +227,10 @@ export const make = Effect.fnUntraced(
 const MIN_COMPRESSIBLE_SIZE = 1024
 
 const makeResponse = (
-  request: ServerRequest.HttpServerRequest,
+  request: ServerRequest.HttpServerRequest["Service"],
   response: ServerResponse.HttpServerResponse,
   context: Context.Context<never>,
-  scope: Scope.Scope
+  scope: Scope.Scope["Service"]
 ): Response => {
   const fields: {
     headers: globalThis.Headers
@@ -394,7 +394,7 @@ function wsDefaultRun(this: WebSocketContext, _: Uint8Array | string) {
   this.buffer.push(_)
 }
 
-class BunServerRequest extends Inspectable.Class implements ServerRequest.HttpServerRequest {
+class BunServerRequest extends Inspectable.Class implements ServerRequest.HttpServerRequest.Service {
   readonly [ServerRequest.TypeId]: typeof ServerRequest.TypeId
   readonly [IncomingMessage.TypeId]: typeof IncomingMessage.TypeId
   readonly source: Request
@@ -587,8 +587,8 @@ class BunServerRequest extends Inspectable.Class implements ServerRequest.HttpSe
     return this.arrayBufferEffect
   }
 
-  get upgrade(): Effect.Effect<Socket.Socket, Error.HttpServerError> {
-    return Effect.callback<Socket.Socket, Error.HttpServerError>((resume) => {
+  get upgrade(): Effect.Effect<Socket.Socket["Service"], Error.HttpServerError> {
+    return Effect.callback<Socket.Socket["Service"], Error.HttpServerError>((resume) => {
       const deferred = Deferred.makeUnsafe<ServerWebSocket<WebSocketContext>>()
       const semaphore = Semaphore.makeUnsafe(1)
 
@@ -635,9 +635,9 @@ class BunServerRequest extends Inspectable.Class implements ServerRequest.HttpSe
               }
             }
           })
-        const writer: Socket.Socket["writer"] = Effect.succeed({ write, writeAll })
+        const writer: Socket.Socket["Service"]["writer"] = Effect.succeed({ write, writeAll })
 
-        const reader: Socket.Socket["reader"] = Effect.gen(function*() {
+        const reader: Socket.Socket["Service"]["reader"] = Effect.gen(function*() {
           const dispatcher = (yield* Scheduler.Scheduler).makeDispatcher()
           yield* Effect.acquireRelease(semaphore.take(1), () => semaphore.release(1))
           const closeError = ws.data.closeError ?? (ws.readyState >= 2

--- a/packages/platform/bun/src/BunHttpServerRequest.ts
+++ b/packages/platform/bun/src/BunHttpServerRequest.ts
@@ -15,5 +15,5 @@ import type { HttpServerRequest } from "effect/unstable/http/HttpServerRequest"
  * @category accessors
  * @since 4.0.0
  */
-export const toBunServerRequest = <T extends string = string>(self: HttpServerRequest): Bun.BunRequest<T> =>
+export const toBunServerRequest = <T extends string = string>(self: HttpServerRequest["Service"]): Bun.BunRequest<T> =>
   (self as any).source

--- a/packages/platform/bun/src/BunTerminal.ts
+++ b/packages/platform/bun/src/BunTerminal.ts
@@ -20,7 +20,8 @@ import type { Terminal, UserInput } from "effect/Terminal"
  * @category constructors
  * @since 4.0.0
  */
-export const make: (shouldQuit?: (input: UserInput) => boolean) => Effect<Terminal, never, Scope> = NodeTerminal.make
+export const make: (shouldQuit?: (input: UserInput) => boolean) => Effect<Terminal["Service"], never, Scope> =
+  NodeTerminal.make
 
 /**
  * Provides the default process-backed `Terminal` service, ending key input on

--- a/packages/platform/deno/src/DenoCrypto.ts
+++ b/packages/platform/deno/src/DenoCrypto.ts
@@ -39,7 +39,7 @@ export const layer: Layer.Layer<EffectCrypto.Crypto> = Layer.effect(
       return bytes
     }
 
-    const digest: EffectCrypto.Crypto["digest"] = (algorithm, data) =>
+    const digest: EffectCrypto.Crypto["Service"]["digest"] = (algorithm, data) =>
       Effect.map(
         Effect.tryPromise({
           try: () => crypto.subtle.digest(algorithm, new Uint8Array(data)),

--- a/packages/platform/deno/src/DenoFileSystem.ts
+++ b/packages/platform/deno/src/DenoFileSystem.ts
@@ -46,7 +46,7 @@ const collectAsyncIterable = <A>(
     catch: handleError("FileSystem", method, pathOrDescriptor)
   })
 
-const access: FileSystem.FileSystem["access"] = (path, options) => {
+const access: FileSystem.FileSystem["Service"]["access"] = (path, options) => {
   if (!options?.readable && !options?.writable) {
     return Effect.asVoid(tryPromise("access", path, () => Deno.stat(path)))
   }
@@ -61,22 +61,23 @@ const access: FileSystem.FileSystem["access"] = (path, options) => {
   )
 }
 
-const copy: FileSystem.FileSystem["copy"] = (fromPath, toPath, options) =>
+const copy: FileSystem.FileSystem["Service"]["copy"] = (fromPath, toPath, options) =>
   tryPromise("copy", fromPath, () =>
     denoCopy(fromPath, toPath, {
       overwrite: options?.overwrite ?? false,
       preserveTimestamps: options?.preserveTimestamps ?? false
     }))
 
-const copyFile: FileSystem.FileSystem["copyFile"] = (fromPath, toPath) =>
+const copyFile: FileSystem.FileSystem["Service"]["copyFile"] = (fromPath, toPath) =>
   tryPromise("copyFile", fromPath, () => Deno.copyFile(fromPath, toPath))
 
-const chmod: FileSystem.FileSystem["chmod"] = (path, mode) => tryPromise("chmod", path, () => Deno.chmod(path, mode))
+const chmod: FileSystem.FileSystem["Service"]["chmod"] = (path, mode) =>
+  tryPromise("chmod", path, () => Deno.chmod(path, mode))
 
-const chown: FileSystem.FileSystem["chown"] = (path, uid, gid) =>
+const chown: FileSystem.FileSystem["Service"]["chown"] = (path, uid, gid) =>
   tryPromise("chown", path, () => Deno.chown(path, uid, gid))
 
-const glob: FileSystem.FileSystem["glob"] = (pattern, options) =>
+const glob: FileSystem.FileSystem["Service"]["glob"] = (pattern, options) =>
   Effect.map(
     collectAsyncIterable("glob", pattern, () =>
       expandGlob(pattern, {
@@ -86,17 +87,17 @@ const glob: FileSystem.FileSystem["glob"] = (pattern, options) =>
     (entries) => entries.map((entry) => entry.path)
   )
 
-const link: FileSystem.FileSystem["link"] = (existingPath, newPath) =>
+const link: FileSystem.FileSystem["Service"]["link"] = (existingPath, newPath) =>
   tryPromise("link", existingPath, () => Deno.link(existingPath, newPath))
 
-const makeDirectory: FileSystem.FileSystem["makeDirectory"] = (path, options) =>
+const makeDirectory: FileSystem.FileSystem["Service"]["makeDirectory"] = (path, options) =>
   tryPromise("makeDirectory", path, () =>
     Deno.mkdir(path, {
       recursive: options?.recursive ?? false,
       ...(options?.mode === undefined ? {} : { mode: options.mode })
     }))
 
-const makeTempDirectoryFactory = (method: string): FileSystem.FileSystem["makeTempDirectory"] => (options) =>
+const makeTempDirectoryFactory = (method: string): FileSystem.FileSystem["Service"]["makeTempDirectory"] => (options) =>
   tryPromise(method, options?.directory, () =>
     Deno.makeTempDir({
       ...(options?.directory === undefined ? {} : { dir: options.directory }),
@@ -105,7 +106,7 @@ const makeTempDirectoryFactory = (method: string): FileSystem.FileSystem["makeTe
 
 const makeTempDirectory = makeTempDirectoryFactory("makeTempDirectory")
 
-const removeFactory = (method: string): FileSystem.FileSystem["remove"] => (path, options) => {
+const removeFactory = (method: string): FileSystem.FileSystem["Service"]["remove"] => (path, options) => {
   const effect = tryPromise(method, path, () => Deno.remove(path, { recursive: options?.recursive ?? false }))
   return options?.force
     ? Effect.catchTag(
@@ -118,7 +119,7 @@ const removeFactory = (method: string): FileSystem.FileSystem["remove"] => (path
 
 const remove = removeFactory("remove")
 
-const makeTempDirectoryScoped: FileSystem.FileSystem["makeTempDirectoryScoped"] = (options) =>
+const makeTempDirectoryScoped: FileSystem.FileSystem["Service"]["makeTempDirectoryScoped"] = (options) =>
   Effect.acquireRelease(
     makeTempDirectoryFactory("makeTempDirectoryScoped")(options),
     (directory) => Effect.orDie(removeFactory("makeTempDirectoryScoped")(directory, { recursive: true }))
@@ -338,7 +339,7 @@ class FileImpl implements FileSystem.File {
   }
 }
 
-const open: FileSystem.FileSystem["open"] = (path, options) => {
+const open: FileSystem.FileSystem["Service"]["open"] = (path, options) => {
   const append = options?.flag?.startsWith("a") ?? false
   return Effect.map(
     Effect.acquireRelease(
@@ -349,7 +350,7 @@ const open: FileSystem.FileSystem["open"] = (path, options) => {
   )
 }
 
-const makeTempFileFactory = (method: string): FileSystem.FileSystem["makeTempFile"] => (options) =>
+const makeTempFileFactory = (method: string): FileSystem.FileSystem["Service"]["makeTempFile"] => (options) =>
   tryPromise(method, options?.directory, () =>
     Deno.makeTempFile({
       ...(options?.directory === undefined ? {} : { dir: options.directory }),
@@ -359,13 +360,13 @@ const makeTempFileFactory = (method: string): FileSystem.FileSystem["makeTempFil
 
 const makeTempFile = makeTempFileFactory("makeTempFile")
 
-const makeTempFileScoped: FileSystem.FileSystem["makeTempFileScoped"] = (options) =>
+const makeTempFileScoped: FileSystem.FileSystem["Service"]["makeTempFileScoped"] = (options) =>
   Effect.acquireRelease(
     makeTempFileFactory("makeTempFileScoped")(options),
     (file) => Effect.orDie(removeFactory("makeTempFileScoped")(file, { force: true }))
   )
 
-const readDirectory: FileSystem.FileSystem["readDirectory"] = (path, options) => {
+const readDirectory: FileSystem.FileSystem["Service"]["readDirectory"] = (path, options) => {
   if (options?.recursive) {
     return Effect.map(
       collectAsyncIterable("readDirectory", path, () => walk(path)),
@@ -378,29 +379,31 @@ const readDirectory: FileSystem.FileSystem["readDirectory"] = (path, options) =>
   )
 }
 
-const readFile: FileSystem.FileSystem["readFile"] = (path) =>
+const readFile: FileSystem.FileSystem["Service"]["readFile"] = (path) =>
   tryPromise("readFile", path, (signal) => Deno.readFile(path, { signal }))
 
-const readLink: FileSystem.FileSystem["readLink"] = (path) => tryPromise("readLink", path, () => Deno.readLink(path))
+const readLink: FileSystem.FileSystem["Service"]["readLink"] = (path) =>
+  tryPromise("readLink", path, () => Deno.readLink(path))
 
-const realPath: FileSystem.FileSystem["realPath"] = (path) => tryPromise("realPath", path, () => Deno.realPath(path))
+const realPath: FileSystem.FileSystem["Service"]["realPath"] = (path) =>
+  tryPromise("realPath", path, () => Deno.realPath(path))
 
-const rename: FileSystem.FileSystem["rename"] = (oldPath, newPath) =>
+const rename: FileSystem.FileSystem["Service"]["rename"] = (oldPath, newPath) =>
   tryPromise("rename", oldPath, () => Deno.rename(oldPath, newPath))
 
-const stat: FileSystem.FileSystem["stat"] = (path) =>
+const stat: FileSystem.FileSystem["Service"]["stat"] = (path) =>
   Effect.map(
     tryPromise("stat", path, () => Deno.stat(path)),
     makeFileInfo
   )
 
-const symlink: FileSystem.FileSystem["symlink"] = (target, path) =>
+const symlink: FileSystem.FileSystem["Service"]["symlink"] = (target, path) =>
   tryPromise("symlink", target, () => Deno.symlink(target, path))
 
-const truncate: FileSystem.FileSystem["truncate"] = (path, length) =>
+const truncate: FileSystem.FileSystem["Service"]["truncate"] = (path, length) =>
   tryPromise("truncate", path, () => Deno.truncate(path, length))
 
-const utimes: FileSystem.FileSystem["utimes"] = (path, atime, mtime) =>
+const utimes: FileSystem.FileSystem["Service"]["utimes"] = (path, atime, mtime) =>
   tryPromise("utimes", path, () => Deno.utime(path, atime, mtime))
 
 const watchNative = (
@@ -452,7 +455,7 @@ const watch = (
     Stream.unwrap
   )
 
-const writeFile: FileSystem.FileSystem["writeFile"] = (path, data, options) => {
+const writeFile: FileSystem.FileSystem["Service"]["writeFile"] = (path, data, options) => {
   const flag = options?.flag ?? "w"
   if (options?.mode === undefined && (flag === "w" || flag === "wx" || flag === "a" || flag === "ax")) {
     return tryPromise("writeFile", path, (signal) =>

--- a/packages/platform/deno/src/DenoHttpServer.ts
+++ b/packages/platform/deno/src/DenoHttpServer.ts
@@ -150,10 +150,10 @@ export const make = Effect.fnUntraced(function*(
 })
 
 const makeResponse = Effect.fnUntraced(function*(
-  request: ServerRequest.HttpServerRequest,
+  request: ServerRequest.HttpServerRequest["Service"],
   response: ServerResponse.HttpServerResponse,
   context: Context.Context<never>,
-  scope: Scope.Scope
+  scope: Scope.Scope["Service"]
 ) {
   const fields: {
     headers: globalThis.Headers
@@ -286,7 +286,7 @@ export const layerConfig = (
     layerHttpServices
   )
 
-class DenoServerRequest extends Inspectable.Class implements ServerRequest.HttpServerRequest {
+class DenoServerRequest extends Inspectable.Class implements ServerRequest.HttpServerRequest.Service {
   readonly [ServerRequest.TypeId]: typeof ServerRequest.TypeId
   readonly [IncomingMessage.TypeId]: typeof IncomingMessage.TypeId
   readonly source: Request
@@ -443,7 +443,7 @@ class DenoServerRequest extends Inspectable.Class implements ServerRequest.HttpS
     return this.arrayBufferEffect
   }
 
-  get upgrade(): Effect.Effect<Socket.Socket, Error.HttpServerError> {
+  get upgrade(): Effect.Effect<Socket.Socket["Service"], Error.HttpServerError> {
     return Effect.flatMap(
       Effect.try({
         try: () => Deno.upgradeWebSocket(this.source, this.websocketOptions),

--- a/packages/platform/deno/src/DenoHttpServerRequest.ts
+++ b/packages/platform/deno/src/DenoHttpServerRequest.ts
@@ -15,4 +15,4 @@ import type { HttpServerRequest } from "effect/unstable/http/HttpServerRequest"
  * @category accessors
  * @since 4.0.0
  */
-export const toDenoServerRequest = (self: HttpServerRequest): Request => (self as any).source
+export const toDenoServerRequest = (self: HttpServerRequest["Service"]): Request => (self as any).source

--- a/packages/platform/deno/src/DenoSocket.ts
+++ b/packages/platform/deno/src/DenoSocket.ts
@@ -71,8 +71,8 @@ export class Conn extends Context.Service<Conn, Deno.Conn>()(
  */
 export const fromConn = <RO>(
   open: Effect.Effect<Deno.Conn, Socket.SocketError, RO>
-): Effect.Effect<Socket.Socket, never, Exclude<RO, Scope.Scope>> =>
-  Effect.withFiber<Socket.Socket, never, Exclude<RO, Scope.Scope>>((fiber) => {
+): Effect.Effect<Socket.Socket["Service"], never, Exclude<RO, Scope.Scope>> =>
+  Effect.withFiber<Socket.Socket["Service"], never, Exclude<RO, Scope.Scope>>((fiber) => {
     let current: {
       readonly conn: Deno.Conn
       readonly writer: WritableStreamDefaultWriter<Uint8Array>
@@ -83,7 +83,7 @@ export const fromConn = <RO>(
     const latch = Latch.makeUnsafe(false)
     const openServices = fiber.context as Context.Context<RO>
 
-    const reader: Socket.Socket["reader"] = Effect.gen(function*() {
+    const reader: Socket.Socket["Service"]["reader"] = Effect.gen(function*() {
       const scope = yield* Effect.scope
       let conn: Deno.Conn | undefined
       let upgradeAvailable = true
@@ -199,7 +199,7 @@ export const fromConn = <RO>(
       }
     }).pipe(
       Effect.updateContext((input: Context.Context<Scope.Scope>) => Context.merge(openServices, input))
-    ) as Socket.Socket["reader"]
+    ) as Socket.Socket["Service"]["reader"]
 
     const write = (chunk: Uint8Array | string | Socket.CloseEvent) =>
       latch.whenOpen(Effect.suspend(() => {
@@ -239,7 +239,7 @@ export const fromConn = <RO>(
           })
       }))
 
-    const writer: Socket.Socket["writer"] = Effect.acquireRelease(
+    const writer: Socket.Socket["Service"]["writer"] = Effect.acquireRelease(
       Effect.sync(() => {
         writeClosed = false
         return { write, writeAll }
@@ -271,7 +271,7 @@ export const fromConn = <RO>(
  * @category constructors
  * @since 4.0.0
  */
-export const makeTcp = (options: TcpOptions): Effect.Effect<Socket.Socket> => {
+export const makeTcp = (options: TcpOptions): Effect.Effect<Socket.Socket["Service"]> => {
   const { keepAlive, noDelay, openTimeout, ...connectOptions } = options
   const acquire = Effect.contextWith((context: Context.Context<Scope.Scope>) => {
     let conn: Deno.Conn | undefined

--- a/packages/platform/deno/src/DenoTerminal.ts
+++ b/packages/platform/deno/src/DenoTerminal.ts
@@ -20,7 +20,8 @@ import type { Terminal, UserInput } from "effect/Terminal"
  * @category constructors
  * @since 4.0.0
  */
-export const make: (shouldQuit?: (input: UserInput) => boolean) => Effect<Terminal, never, Scope> = NodeTerminal.make
+export const make: (shouldQuit?: (input: UserInput) => boolean) => Effect<Terminal["Service"], never, Scope> =
+  NodeTerminal.make
 
 /**
  * Provides the default process-backed `Terminal` service, ending key input on

--- a/packages/platform/node-shared/benchmark/Socket.ts
+++ b/packages/platform/node-shared/benchmark/Socket.ts
@@ -201,7 +201,7 @@ interface SocketClient {
   readonly read: (bytes: number) => Effect.Effect<void>
 }
 
-const socketClient = Effect.fnUntraced(function*(socket: Socket.Socket) {
+const socketClient = Effect.fnUntraced(function*(socket: Socket.Socket["Service"]) {
   const writer = yield* socket.writer
   const pull = yield* Socket.readerBytes(socket)
   const read = Effect.orDie(pull)

--- a/packages/platform/node-shared/src/NodeCrypto.ts
+++ b/packages/platform/node-shared/src/NodeCrypto.ts
@@ -27,7 +27,7 @@ const toHashAlgorithm = (algorithm: EffectCrypto.DigestAlgorithm): string => {
   }
 }
 
-const digest: EffectCrypto.Crypto["digest"] = (algorithm, data) =>
+const digest: EffectCrypto.Crypto["Service"]["digest"] = (algorithm, data) =>
   Effect.try({
     try: () => Uint8Array.from(NodeCrypto.createHash(toHashAlgorithm(algorithm)).update(data).digest()),
     catch: (cause) =>
@@ -46,7 +46,7 @@ const digest: EffectCrypto.Crypto["digest"] = (algorithm, data) =>
  * @category constructors
  * @since 1.0.0
  */
-export const make: EffectCrypto.Crypto = EffectCrypto.make({
+export const make: EffectCrypto.Crypto["Service"] = EffectCrypto.make({
   randomBytes: NodeCrypto.randomBytes,
   digest
 })

--- a/packages/platform/node-shared/src/NodeFileSystem.ts
+++ b/packages/platform/node-shared/src/NodeFileSystem.ts
@@ -53,7 +53,7 @@ const positionToNumber = (position: bigint, method: string) =>
 
 // == access
 
-const access = ((): FileSystem.FileSystem["access"] => {
+const access = ((): FileSystem.FileSystem["Service"]["access"] => {
   const nodeAccess = effectify(
     NFS.access,
     handleErrnoException("FileSystem", "access"),
@@ -73,7 +73,7 @@ const access = ((): FileSystem.FileSystem["access"] => {
 
 // == copy
 
-const copy = ((): FileSystem.FileSystem["copy"] => {
+const copy = ((): FileSystem.FileSystem["Service"]["copy"] => {
   const nodeCp = effectify(
     NFS.cp,
     handleErrnoException("FileSystem", "copy"),
@@ -122,7 +122,7 @@ const chown = (() => {
 
 // == glob
 
-const glob = ((): FileSystem.FileSystem["glob"] => {
+const glob = ((): FileSystem.FileSystem["Service"]["glob"] => {
   const nodeGlob = effectify(
     NFS.glob,
     handleErrnoException("FileSystem", "glob"),
@@ -148,7 +148,7 @@ const link = (() => {
 
 // == makeDirectory
 
-const makeDirectory = ((): FileSystem.FileSystem["makeDirectory"] => {
+const makeDirectory = ((): FileSystem.FileSystem["Service"]["makeDirectory"] => {
   const nodeMkdir = effectify(
     NFS.mkdir,
     handleErrnoException("FileSystem", "makeDirectory"),
@@ -163,7 +163,7 @@ const makeDirectory = ((): FileSystem.FileSystem["makeDirectory"] => {
 
 // == makeTempDirectory
 
-const makeTempDirectoryFactory = (method: string): FileSystem.FileSystem["makeTempDirectory"] => {
+const makeTempDirectoryFactory = (method: string): FileSystem.FileSystem["Service"]["makeTempDirectory"] => {
   const nodeMkdtemp = effectify(
     NFS.mkdtemp,
     handleErrnoException("FileSystem", method),
@@ -183,7 +183,7 @@ const makeTempDirectory = makeTempDirectoryFactory("makeTempDirectory")
 
 // == remove
 
-const removeFactory = (method: string): FileSystem.FileSystem["remove"] => {
+const removeFactory = (method: string): FileSystem.FileSystem["Service"]["remove"] => {
   const nodeRm = effectify(
     NFS.rm,
     handleErrnoException("FileSystem", method),
@@ -199,7 +199,7 @@ const remove = removeFactory("remove")
 
 // == makeTempDirectoryScoped
 
-const makeTempDirectoryScoped = ((): FileSystem.FileSystem["makeTempDirectoryScoped"] => {
+const makeTempDirectoryScoped = ((): FileSystem.FileSystem["Service"]["makeTempDirectoryScoped"] => {
   const makeDirectory = makeTempDirectoryFactory("makeTempDirectoryScoped")
   const removeDirectory = removeFactory("makeTempDirectoryScoped")
   return (options) =>
@@ -211,7 +211,7 @@ const makeTempDirectoryScoped = ((): FileSystem.FileSystem["makeTempDirectorySco
 
 // == open
 
-const openFactory = (method: string): FileSystem.FileSystem["open"] => {
+const openFactory = (method: string): FileSystem.FileSystem["Service"]["open"] => {
   const nodeOpen = effectify(
     NFS.open,
     handleErrnoException("FileSystem", method),
@@ -424,7 +424,7 @@ const makeFile = (() => {
 
 // == makeTempFile
 
-const makeTempFileFactory = (method: string): FileSystem.FileSystem["makeTempFile"] => {
+const makeTempFileFactory = (method: string): FileSystem.FileSystem["Service"]["makeTempFile"] => {
   const makeDirectory = makeTempDirectoryFactory(method)
   return Effect.fnUntraced(function*(options) {
     const directory = yield* makeDirectory(options)
@@ -438,7 +438,7 @@ const makeTempFile = makeTempFileFactory("makeTempFile")
 
 // == makeTempFileScoped
 
-const makeTempFileScoped = ((): FileSystem.FileSystem["makeTempFileScoped"] => {
+const makeTempFileScoped = ((): FileSystem.FileSystem["Service"]["makeTempFileScoped"] => {
   const makeFile = makeTempFileFactory("makeTempFileScoped")
   const removeDirectory = removeFactory("makeTempFileScoped")
   return (options) =>
@@ -450,7 +450,7 @@ const makeTempFileScoped = ((): FileSystem.FileSystem["makeTempFileScoped"] => {
 
 // == readDirectory
 
-const readDirectory: FileSystem.FileSystem["readDirectory"] = (path, options) =>
+const readDirectory: FileSystem.FileSystem["Service"]["readDirectory"] = (path, options) =>
   Effect.tryPromise({
     try: () => NFS.promises.readdir(path, options),
     catch: (err) => handleErrnoException("FileSystem", "readDirectory")(err as any, [path])
@@ -649,7 +649,7 @@ const watch = (
 
 // == writeFile
 
-const writeFile: FileSystem.FileSystem["writeFile"] = (path, data, options) =>
+const writeFile: FileSystem.FileSystem["Service"]["writeFile"] = (path, data, options) =>
   Effect.callback<void, Error.PlatformError>((resume, signal) => {
     try {
       NFS.writeFile(path, data, {

--- a/packages/platform/node-shared/src/NodeSocket.ts
+++ b/packages/platform/node-shared/src/NodeSocket.ts
@@ -91,7 +91,7 @@ export const makeNet = (
   options: Net.NetConnectOpts & {
     readonly openTimeout?: Duration.Input | undefined
   }
-): Effect.Effect<Socket.Socket> =>
+): Effect.Effect<Socket.Socket["Service"]> =>
   fromDuplex(
     Effect.contextWith((context: Context.Context<Scope.Scope>) => {
       let conn: Net.Socket | undefined
@@ -150,15 +150,15 @@ export const fromDuplex = <RO>(
     readonly openTimeout?: Duration.Input | undefined
     readonly tlsServer?: boolean | undefined
   }
-): Effect.Effect<Socket.Socket, never, Exclude<RO, Scope.Scope>> =>
-  Effect.withFiber<Socket.Socket, never, Exclude<RO, Scope.Scope>>((fiber) => {
+): Effect.Effect<Socket.Socket["Service"], never, Exclude<RO, Scope.Scope>> =>
+  Effect.withFiber<Socket.Socket["Service"], never, Exclude<RO, Scope.Scope>>((fiber) => {
     let currentSocket: Duplex | undefined
     const latch = Latch.makeUnsafe(false)
     const openServices = fiber.context as Context.Context<RO>
     const isServer = options?.tlsServer === true
     const secureEvent = isServer ? "secure" : "secureConnect"
 
-    const reader: Socket.Socket["reader"] = Effect.gen(function*() {
+    const reader: Socket.Socket["Service"]["reader"] = Effect.gen(function*() {
       const scope = yield* Effect.scope
       let conn = yield* Scope.provide(open, scope).pipe(
         options?.openTimeout !== undefined ?
@@ -377,7 +377,7 @@ export const fromDuplex = <RO>(
       return { pull, upgrade }
     }).pipe(
       Effect.updateContext((input: Context.Context<Scope.Scope>) => Context.merge(openServices, input))
-    ) as Socket.Socket["reader"]
+    ) as Socket.Socket["Service"]["reader"]
 
     const awaitDrain = (conn: Duplex) =>
       Effect.callback<void, Socket.SocketError>((resume) => {
@@ -463,7 +463,7 @@ export const fromDuplex = <RO>(
         return needsDrain ? awaitDrain(conn) : Effect.void
       })
 
-    const writer: Socket.Socket["writer"] = Effect.acquireRelease(
+    const writer: Socket.Socket["Service"]["writer"] = Effect.acquireRelease(
       Effect.succeed({ write, writeAll }),
       () =>
         Effect.sync(() => {
@@ -530,7 +530,7 @@ export const makeTls = (
   options: Tls.ConnectionOptions & {
     readonly openTimeout?: Duration.Input | undefined
   }
-): Effect.Effect<Socket.Socket> =>
+): Effect.Effect<Socket.Socket["Service"]> =>
   fromDuplex(
     Effect.contextWith((context: Context.Context<Scope.Scope>) => {
       let conn: Tls.TLSSocket | undefined

--- a/packages/platform/node-shared/src/NodeSocketServer.ts
+++ b/packages/platform/node-shared/src/NodeSocketServer.ts
@@ -204,43 +204,45 @@ export const makeWebSocket: (
     })
   })
 
-  const run = Effect.fnUntraced(function*<R, E, _>(handler: (socket: Socket.Socket) => Effect.Effect<_, E, R>) {
-    const scope = yield* Scope.make()
-    const services = Context.omit(Scope.Scope)(yield* Effect.context<R>()) as Context.Context<R>
-    const trackFiber = Fiber.runIn(scope)
-    const prevOnConnection = onConnection
-    onConnection = function(conn: NodeWS.WebSocket, req: Http.IncomingMessage) {
-      let context = services
-      context = Context.add(context, IncomingMessage, req)
-      context = Context.add(context, Socket.WebSocket, conn)
-      pipe(
-        Socket.fromWebSocket(
-          Effect.acquireRelease(
-            Effect.succeed(conn),
-            (conn) =>
-              Effect.sync(() => {
-                conn.close()
-              })
-          )
-        ),
-        Effect.flatMap(handler),
-        Effect.catchCause(reportUnhandledError),
-        Effect.runForkWith(context),
-        trackFiber
+  const run = Effect.fnUntraced(
+    function*<R, E, _>(handler: (socket: Socket.Socket["Service"]) => Effect.Effect<_, E, R>) {
+      const scope = yield* Scope.make()
+      const services = Context.omit(Scope.Scope)(yield* Effect.context<R>()) as Context.Context<R>
+      const trackFiber = Fiber.runIn(scope)
+      const prevOnConnection = onConnection
+      onConnection = function(conn: NodeWS.WebSocket, req: Http.IncomingMessage) {
+        let context = services
+        context = Context.add(context, IncomingMessage, req)
+        context = Context.add(context, Socket.WebSocket, conn)
+        pipe(
+          Socket.fromWebSocket(
+            Effect.acquireRelease(
+              Effect.succeed(conn),
+              (conn) =>
+                Effect.sync(() => {
+                  conn.close()
+                })
+            )
+          ),
+          Effect.flatMap(handler),
+          Effect.catchCause(reportUnhandledError),
+          Effect.runForkWith(context),
+          trackFiber
+        )
+      }
+      pendingConnections.forEach(([req, remove], conn) => {
+        remove()
+        onConnection(conn, req)
+      })
+      return yield* Effect.callback<never>((_resume) => {
+        return Effect.sync(() => {
+          onConnection = prevOnConnection
+        })
+      }).pipe(
+        Effect.ensuring(Scope.close(scope, Exit.void))
       )
     }
-    pendingConnections.forEach(([req, remove], conn) => {
-      remove()
-      onConnection(conn, req)
-    })
-    return yield* Effect.callback<never>((_resume) => {
-      return Effect.sync(() => {
-        onConnection = prevOnConnection
-      })
-    }).pipe(
-      Effect.ensuring(Scope.close(scope, Exit.void))
-    )
-  })
+  )
 
   const boundAddress = yield* socketAddressFromNode(server.address()!)
   return SocketServer.SocketServer.of({
@@ -322,64 +324,66 @@ const makeNetServer = Effect.fnUntraced(function*(options: {
       })))
   )
 
-  const run = Effect.fnUntraced(function*<R, E, _>(handler: (socket: Socket.Socket) => Effect.Effect<_, E, R>) {
-    const scope = yield* Scope.make()
-    const services = Context.omit(Scope.Scope)(yield* Effect.context<R>()) as Context.Context<R>
-    const trackFiber = Fiber.runIn(scope)
-    const prevOnConnection = onConnection
-    onConnection = function(conn: Net.Socket) {
-      let error: Error | undefined
-      conn.on("error", (err) => {
-        error = err
-      })
-      pipe(
-        NodeSocket.fromDuplex(
-          Effect.acquireRelease(
-            Effect.suspend((): Effect.Effect<Net.Socket, Socket.SocketError> => {
-              if (error) {
-                return Effect.fail(
-                  new Socket.SocketError({
-                    reason: new Socket.SocketOpenError({
-                      kind: "Unknown",
-                      cause: error
+  const run = Effect.fnUntraced(
+    function*<R, E, _>(handler: (socket: Socket.Socket["Service"]) => Effect.Effect<_, E, R>) {
+      const scope = yield* Scope.make()
+      const services = Context.omit(Scope.Scope)(yield* Effect.context<R>()) as Context.Context<R>
+      const trackFiber = Fiber.runIn(scope)
+      const prevOnConnection = onConnection
+      onConnection = function(conn: Net.Socket) {
+        let error: Error | undefined
+        conn.on("error", (err) => {
+          error = err
+        })
+        pipe(
+          NodeSocket.fromDuplex(
+            Effect.acquireRelease(
+              Effect.suspend((): Effect.Effect<Net.Socket, Socket.SocketError> => {
+                if (error) {
+                  return Effect.fail(
+                    new Socket.SocketError({
+                      reason: new Socket.SocketOpenError({
+                        kind: "Unknown",
+                        cause: error
+                      })
                     })
-                  })
-                )
-              } else if (conn.closed) {
-                return Effect.fail(
-                  new Socket.SocketError({
-                    reason: new Socket.SocketCloseError({ code: 1000 })
-                  })
-                )
-              }
-              return Effect.succeed(conn)
-            }),
-            (conn) =>
-              Effect.sync(() => {
-                if (conn.closed === false) {
-                  conn.destroySoon()
+                  )
+                } else if (conn.closed) {
+                  return Effect.fail(
+                    new Socket.SocketError({
+                      reason: new Socket.SocketCloseError({ code: 1000 })
+                    })
+                  )
                 }
-              })
+                return Effect.succeed(conn)
+              }),
+              (conn) =>
+                Effect.sync(() => {
+                  if (conn.closed === false) {
+                    conn.destroySoon()
+                  }
+                })
+            ),
+            { tlsServer: true }
           ),
-          { tlsServer: true }
-        ),
-        Effect.flatMap(handler),
-        Effect.catchCause(reportUnhandledError),
-        Effect.runForkWith(Context.add(services, NodeSocket.NetSocket, conn)),
-        trackFiber
-      )
-    }
-    pending.forEach((remove, conn) => {
-      remove()
-      onConnection(conn)
-    })
-    return yield* Effect.callback<never>((_resume) => {
-      return Effect.suspend(() => {
-        onConnection = prevOnConnection
-        return Scope.close(scope, Exit.void)
+          Effect.flatMap(handler),
+          Effect.catchCause(reportUnhandledError),
+          Effect.runForkWith(Context.add(services, NodeSocket.NetSocket, conn)),
+          trackFiber
+        )
+      }
+      pending.forEach((remove, conn) => {
+        remove()
+        onConnection(conn)
       })
-    })
-  })
+      return yield* Effect.callback<never>((_resume) => {
+        return Effect.suspend(() => {
+          onConnection = prevOnConnection
+          return Scope.close(scope, Exit.void)
+        })
+      })
+    }
+  )
 
   const boundAddress = yield* socketAddressFromNode(server.address()!)
   return SocketServer.SocketServer.of({

--- a/packages/platform/node-shared/src/NodeStream.ts
+++ b/packages/platform/node-shared/src/NodeStream.ts
@@ -331,7 +331,7 @@ export const toUint8Array = <E = Cause.UnknownError>(
 // ----------------------------------------------------------------------------
 
 const readableToPullUnsafe = <A, E>(options: {
-  readonly scope: Scope.Scope
+  readonly scope: Scope.Scope["Service"]
   readonly exit?: MutableRef.MutableRef<Exit.Exit<never, E | Cause.Done> | undefined> | undefined
   readonly latch?: Latch.Latch | undefined
   readonly readable: Readable | NodeJS.ReadableStream

--- a/packages/platform/node-shared/src/NodeTerminal.ts
+++ b/packages/platform/node-shared/src/NodeTerminal.ts
@@ -31,7 +31,7 @@ import * as readline from "node:readline"
  */
 export const make: (
   shouldQuit?: (input: Terminal.UserInput) => boolean
-) => Effect.Effect<Terminal.Terminal, never, Scope.Scope> = Effect.fnUntraced(
+) => Effect.Effect<Terminal.Terminal["Service"], never, Scope.Scope> = Effect.fnUntraced(
   function*(shouldQuit: (input: Terminal.UserInput) => boolean = defaultShouldQuit) {
     const stdin = process.stdin
     const stdout = process.stdout

--- a/packages/platform/node/src/NodeHttpServer.ts
+++ b/packages/platform/node/src/NodeHttpServer.ts
@@ -189,7 +189,7 @@ export const makeHandler = <
 >(
   httpEffect: Effect.Effect<HttpServerResponse, E, R>,
   options: {
-    readonly scope: Scope.Scope
+    readonly scope: Scope.Scope["Service"]
     readonly middleware?: Middleware.HttpMiddleware.Applied<App, E, R> | undefined
   }
 ): Effect.Effect<
@@ -233,7 +233,7 @@ export const makeUpgradeHandler = <
   lazyWss: Effect.Effect<NodeWS.WebSocketServer>,
   httpEffect: Effect.Effect<HttpServerResponse, E, R>,
   options: {
-    readonly scope: Scope.Scope
+    readonly scope: Scope.Scope["Service"]
     readonly middleware?: Middleware.HttpMiddleware.Applied<App, E, R> | undefined
   }
 ): Effect.Effect<
@@ -297,17 +297,17 @@ export const makeUpgradeHandler = <
   })
 }
 
-class ServerRequestImpl extends NodeHttpIncomingMessage<HttpServerError> implements HttpServerRequest {
+class ServerRequestImpl extends NodeHttpIncomingMessage<HttpServerError> implements HttpServerRequest.Service {
   readonly [Request.TypeId]: typeof Request.TypeId
   readonly response: Http.ServerResponse | LazyArg<Http.ServerResponse>
-  private upgradeEffect?: Effect.Effect<Socket.Socket, HttpServerError> | undefined
+  private upgradeEffect?: Effect.Effect<Socket.Socket["Service"], HttpServerError> | undefined
   readonly url: string
   private headersOverride?: Headers.Headers | undefined
 
   constructor(
     source: Http.IncomingMessage,
     response: Http.ServerResponse | LazyArg<Http.ServerResponse>,
-    upgradeEffect?: Effect.Effect<Socket.Socket, HttpServerError>,
+    upgradeEffect?: Effect.Effect<Socket.Socket["Service"], HttpServerError>,
     url = source.url!,
     headersOverride?: Headers.Headers,
     remoteAddressOverride?: Option.Option<string>
@@ -394,7 +394,7 @@ class ServerRequestImpl extends NodeHttpIncomingMessage<HttpServerError> impleme
     return NodeMultipart.stream(this.source, this.source.headers)
   }
 
-  get upgrade(): Effect.Effect<Socket.Socket, HttpServerError> {
+  get upgrade(): Effect.Effect<Socket.Socket["Service"], HttpServerError> {
     return this.upgradeEffect ?? Effect.fail(
       new HttpServerError({
         reason: new RequestParseError({
@@ -516,7 +516,7 @@ export const layerTest: Layer.Layer<
 // -----------------------------------------------------------------------------
 
 const handleResponse = (
-  request: HttpServerRequest,
+  request: HttpServerRequest["Service"],
   response: HttpServerResponse
 ): Effect.Effect<void, HttpServerError> => {
   const nodeResponse = (request as ServerRequestImpl).resolvedResponse

--- a/packages/platform/node/src/NodeHttpServerRequest.ts
+++ b/packages/platform/node/src/NodeHttpServerRequest.ts
@@ -17,7 +17,7 @@ import type * as Http from "node:http"
  * @category accessors
  * @since 4.0.0
  */
-export const toIncomingMessage = (self: HttpServerRequest): Http.IncomingMessage => self.source as any
+export const toIncomingMessage = (self: HttpServerRequest["Service"]): Http.IncomingMessage => self.source as any
 
 /**
  * Returns the underlying Node `ServerResponse` for a platform Node
@@ -27,7 +27,7 @@ export const toIncomingMessage = (self: HttpServerRequest): Http.IncomingMessage
  * @category accessors
  * @since 4.0.0
  */
-export const toServerResponse = (self: HttpServerRequest): Http.ServerResponse => {
+export const toServerResponse = (self: HttpServerRequest["Service"]): Http.ServerResponse => {
   const res = (self as any).response
   return typeof res === "function" ? res() : res
 }

--- a/packages/platform/node/src/NodeTerminal.ts
+++ b/packages/platform/node/src/NodeTerminal.ts
@@ -20,7 +20,8 @@ import type { Terminal, UserInput } from "effect/Terminal"
  * @category constructors
  * @since 4.0.0
  */
-export const make: (shouldQuit?: (input: UserInput) => boolean) => Effect<Terminal, never, Scope> = NodeTerminal.make
+export const make: (shouldQuit?: (input: UserInput) => boolean) => Effect<Terminal["Service"], never, Scope> =
+  NodeTerminal.make
 
 /**
  * Provides the default process-backed `Terminal` service, ending key input on

--- a/packages/platform/node/test/NodeHttpClient.test.ts
+++ b/packages/platform/node/test/NodeHttpClient.test.ts
@@ -69,8 +69,9 @@ const makeLocalServerClient = Effect.gen(function*() {
     createTodo
   } as const
 })
-interface LocalServerClient extends Effect.Success<typeof makeLocalServerClient> {}
-const LocalServerClient = Context.Service<LocalServerClient>("test/LocalServerClient")
+class LocalServerClient
+  extends Context.Service<LocalServerClient, Effect.Success<typeof makeLocalServerClient>>()("test/LocalServerClient")
+{}
 const LocalServerClientLayer = Layer.effect(LocalServerClient)(makeLocalServerClient)
 const LocalServerRoutes = HttpRouter.serve(HttpRouter.addAll([
   HttpRouter.route(

--- a/packages/sql/clickhouse/src/ClickhouseClient.ts
+++ b/packages/sql/clickhouse/src/ClickhouseClient.ts
@@ -107,28 +107,36 @@ export type TypeId = "~@effect/sql-clickhouse/ClickhouseClient"
  * @category services
  * @since 4.0.0
  */
-export interface ClickhouseClient extends Client.SqlClient {
-  readonly [TypeId]: TypeId
-  readonly config: ClickhouseClientConfig
-  readonly param: (dataType: string, value: unknown) => Statement.Fragment
-  readonly asCommand: <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
-  readonly insertQuery: <T = unknown>(options: {
-    readonly table: string
-    readonly values: Clickhouse.InsertValues<Readable, T>
-    readonly format?: Clickhouse.DataFormat
-  }) => Effect.Effect<Clickhouse.InsertResult, SqlError>
-  readonly withQueryId: {
-    (queryId: string): <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
-    <A, E, R>(effect: Effect.Effect<A, E, R>, queryId: string): Effect.Effect<A, E, R>
-  }
-  readonly withClickhouseSettings: {
-    (
-      settings: NonNullable<Clickhouse.BaseQueryParams["clickhouse_settings"]>
-    ): <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
-    <A, E, R>(
-      effect: Effect.Effect<A, E, R>,
-      settings: NonNullable<Clickhouse.BaseQueryParams["clickhouse_settings"]>
-    ): Effect.Effect<A, E, R>
+export declare namespace ClickhouseClient {
+  /**
+   * Implementation of the ClickhouseClient service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service extends Client.SqlClient.Service {
+    readonly [TypeId]: TypeId
+    readonly config: ClickhouseClientConfig
+    readonly param: (dataType: string, value: unknown) => Statement.Fragment
+    readonly asCommand: <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
+    readonly insertQuery: <T = unknown>(options: {
+      readonly table: string
+      readonly values: Clickhouse.InsertValues<Readable, T>
+      readonly format?: Clickhouse.DataFormat
+    }) => Effect.Effect<Clickhouse.InsertResult, SqlError>
+    readonly withQueryId: {
+      (queryId: string): <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
+      <A, E, R>(effect: Effect.Effect<A, E, R>, queryId: string): Effect.Effect<A, E, R>
+    }
+    readonly withClickhouseSettings: {
+      (
+        settings: NonNullable<Clickhouse.BaseQueryParams["clickhouse_settings"]>
+      ): <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
+      <A, E, R>(
+        effect: Effect.Effect<A, E, R>,
+        settings: NonNullable<Clickhouse.BaseQueryParams["clickhouse_settings"]>
+      ): Effect.Effect<A, E, R>
+    }
   }
 }
 
@@ -142,7 +150,9 @@ export interface ClickhouseClient extends Client.SqlClient {
  * @category services
  * @since 4.0.0
  */
-export const ClickhouseClient = Context.Service<ClickhouseClient>("@effect/sql-clickhouse/ClickhouseClient")
+export class ClickhouseClient
+  extends Context.Service<ClickhouseClient, ClickhouseClient.Service>()("@effect/sql-clickhouse/ClickhouseClient")
+{}
 
 /**
  * Configuration for creating a ClickHouse client, combining
@@ -168,7 +178,7 @@ export interface ClickhouseClientConfig extends Clickhouse.ClickHouseClientConfi
  */
 export const make = (
   options: ClickhouseClientConfig
-): Effect.Effect<ClickhouseClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
+): Effect.Effect<ClickhouseClient["Service"], SqlError, Scope.Scope | Reactivity.Reactivity> =>
   Effect.gen(function*() {
     const compiler = makeCompiler(options.transformQueryNames)
     const transformRows = options.transformResultNames
@@ -200,7 +210,7 @@ export const make = (
       })
     )
 
-    class ConnectionImpl implements Connection {
+    class ConnectionImpl implements Connection.Service {
       private conn: Clickhouse.ClickHouseClient
       constructor(conn: Clickhouse.ClickHouseClient) {
         this.conn = conn

--- a/packages/sql/d1/src/D1Client.ts
+++ b/packages/sql/d1/src/D1Client.ts
@@ -55,37 +55,45 @@ export type TypeId = "~@effect/sql-d1/D1Client"
  * @category services
  * @since 4.0.0
  */
-export interface D1Client extends Client.SqlClient {
-  readonly [TypeId]: TypeId
-  readonly config: D1ClientConfig
-
+export declare namespace D1Client {
   /**
-   * Executes SQL statements as a single atomic D1 batch and returns their row results in order.
+   * Implementation of the D1Client service.
    *
-   * **When to use**
-   *
-   * Use when you have a fixed collection of statements that should run in one
-   * request and roll back together if any statement fails.
-   *
-   * **Gotchas**
-   *
-   * Each statement uses the query and result name transformations from the
-   * client that created it. Mixing clients can produce differently shaped row
-   * results within the same batch.
-   *
+   * @category models
    * @since 4.0.0
    */
-  readonly batch: <const Statements extends ReadonlyArray<Statement.Statement<any>>>(
-    statements: Statements
-  ) => Effect.Effect<
-    {
-      readonly [K in keyof Statements]: Effect.Success<Statements[K]>
-    },
-    SqlError
-  >
+  export interface Service extends Client.SqlClient.Service {
+    readonly [TypeId]: TypeId
+    readonly config: D1ClientConfig
 
-  /** Not supported in d1 */
-  readonly updateValues: never
+    /**
+     * Executes SQL statements as a single atomic D1 batch and returns their row results in order.
+     *
+     * **When to use**
+     *
+     * Use when you have a fixed collection of statements that should run in one
+     * request and roll back together if any statement fails.
+     *
+     * **Gotchas**
+     *
+     * Each statement uses the query and result name transformations from the
+     * client that created it. Mixing clients can produce differently shaped row
+     * results within the same batch.
+     *
+     * @since 4.0.0
+     */
+    readonly batch: <const Statements extends ReadonlyArray<Statement.Statement<any>>>(
+      statements: Statements
+    ) => Effect.Effect<
+      {
+        readonly [K in keyof Statements]: Effect.Success<Statements[K]>
+      },
+      SqlError
+    >
+
+    /** Not supported in d1 */
+    readonly updateValues: never
+  }
 }
 
 /**
@@ -99,7 +107,7 @@ export interface D1Client extends Client.SqlClient {
  * @category services
  * @since 4.0.0
  */
-export const D1Client = Context.Service<D1Client>("@effect/sql-d1/D1Client")
+export class D1Client extends Context.Service<D1Client, D1Client.Service>()("@effect/sql-d1/D1Client") {}
 
 /**
  * Configuration for a Cloudflare D1 client, including the `D1Database`, prepared statement cache settings, span attributes, and query/result name transforms.
@@ -131,8 +139,8 @@ const makeBatch = (options: {
   readonly db: D1Database
   readonly prepareCache: Cache.Cache<string, D1PreparedStatement, SqlError>
   readonly spanAttributes: ReadonlyArray<readonly [string, unknown]>
-  readonly getClient: () => D1Client
-}): D1Client["batch"] =>
+  readonly getClient: () => D1Client["Service"]
+}): D1Client["Service"]["batch"] =>
 <const Statements extends ReadonlyArray<Statement.Statement<any>>>(
   statements: Statements
 ) => {
@@ -197,7 +205,7 @@ const makeBatch = (options: {
  */
 export const make = (
   options: D1ClientConfig
-): Effect.Effect<D1Client, never, Scope.Scope | Reactivity.Reactivity> =>
+): Effect.Effect<D1Client["Service"], never, Scope.Scope | Reactivity.Reactivity> =>
   Effect.gen(function*() {
     const compiler = Statement.makeCompilerSqlite(options.transformQueryNames)
     const transformRows = options.transformResultNames ?
@@ -291,7 +299,7 @@ export const make = (
           catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
         })
 
-      const connection = identity<Connection>({
+      const connection = identity<Connection["Service"]>({
         execute(sql, params, transformRows) {
           return transformRows
             ? Effect.map(runCached(sql, params), transformRows)
@@ -322,7 +330,7 @@ export const make = (
     const acquirer = Effect.succeed(connection)
     const transactionAcquirer = Effect.die("transactions are not supported in D1")
 
-    let client!: D1Client
+    let client!: D1Client["Service"]
     client = Object.assign(
       (yield* Client.make({
         acquirer,
@@ -330,7 +338,7 @@ export const make = (
         transactionAcquirer,
         spanAttributes,
         transformRows
-      })) as D1Client,
+      })) as D1Client["Service"],
       {
         [TypeId]: TypeId as TypeId,
         config: options,
@@ -351,8 +359,8 @@ export const make = (
         spanAttributes,
         transformRows: undefined
       })
-      let clientWithoutTransforms!: D1Client
-      clientWithoutTransforms = Object.assign(clientWithoutTransformsBase as D1Client, {
+      let clientWithoutTransforms!: D1Client["Service"]
+      clientWithoutTransforms = Object.assign(clientWithoutTransformsBase as D1Client["Service"], {
         [TypeId]: TypeId as TypeId,
         config: options,
         batch: makeBatch({

--- a/packages/sql/libsql/src/LibsqlClient.ts
+++ b/packages/sql/libsql/src/LibsqlClient.ts
@@ -53,9 +53,17 @@ export type TypeId = "~@effect/sql-libsql/LibsqlClient"
  * @category services
  * @since 4.0.0
  */
-export interface LibsqlClient extends Client.SqlClient {
-  readonly [TypeId]: TypeId
-  readonly config: LibsqlClientConfig
+export declare namespace LibsqlClient {
+  /**
+   * Implementation of the LibsqlClient service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service extends Client.SqlClient.Service {
+    readonly [TypeId]: TypeId
+    readonly config: LibsqlClientConfig
+  }
 }
 
 /**
@@ -68,7 +76,9 @@ export interface LibsqlClient extends Client.SqlClient {
  * @category services
  * @since 4.0.0
  */
-export const LibsqlClient = Context.Service<LibsqlClient>("@effect/sql-libsql/LibsqlClient")
+export class LibsqlClient
+  extends Context.Service<LibsqlClient, LibsqlClient.Service>()("@effect/sql-libsql/LibsqlClient")
+{}
 
 let clientIdCounter = 0
 
@@ -167,7 +177,7 @@ export declare namespace LibsqlClientConfig {
   }
 }
 
-interface LibsqlConnection extends Connection {
+interface LibsqlConnection extends Connection.Service {
   readonly beginTransaction: Effect.Effect<LibsqlConnection, SqlError>
   readonly commit: Effect.Effect<void, SqlError>
   readonly rollback: Effect.Effect<void, SqlError>
@@ -181,11 +191,11 @@ interface LibsqlConnection extends Connection {
  */
 export const make = (
   options: LibsqlClientConfig
-): Effect.Effect<LibsqlClient, never, Scope.Scope | Reactivity.Reactivity> =>
+): Effect.Effect<LibsqlClient["Service"], never, Scope.Scope | Reactivity.Reactivity> =>
   Effect.gen(function*() {
-    const LibsqlTransaction = Context.Service<readonly [LibsqlConnection, counter: number]>(
+    class LibsqlTransaction extends Context.Service<LibsqlTransaction, readonly [LibsqlConnection, counter: number]>()(
       `@effect/sql-libsql/LibsqlClient/LibsqlTransaction/${clientIdCounter++}`
-    )
+    ) {}
     const compiler = Statement.makeCompilerSqlite(options.transformQueryNames)
     const transformRows = options.transformResultNames ?
       Statement.defaultTransforms(

--- a/packages/sql/mssql/src/MssqlClient.ts
+++ b/packages/sql/mssql/src/MssqlClient.ts
@@ -164,24 +164,32 @@ export type TypeId = typeof TypeId
  * @category services
  * @since 4.0.0
  */
-export interface MssqlClient extends Client.SqlClient {
-  readonly [TypeId]: TypeId
+export declare namespace MssqlClient {
+  /**
+   * Implementation of the MssqlClient service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service extends Client.SqlClient.Service {
+    readonly [TypeId]: TypeId
 
-  readonly config: MssqlClientConfig
+    readonly config: MssqlClientConfig
 
-  readonly param: (
-    type: DataType,
-    value: unknown,
-    options?: ParameterOptions
-  ) => Statement.Fragment
+    readonly param: (
+      type: DataType,
+      value: unknown,
+      options?: ParameterOptions
+    ) => Statement.Fragment
 
-  readonly call: <
-    I extends Record<string, Parameter<any>>,
-    O extends Record<string, Parameter<any>>,
-    A extends object
-  >(
-    procedure: Procedure.ProcedureWithValues<I, O, A>
-  ) => Effect.Effect<Procedure.Procedure.Result<O, A>, SqlError>
+    readonly call: <
+      I extends Record<string, Parameter<any>>,
+      O extends Record<string, Parameter<any>>,
+      A extends object
+    >(
+      procedure: Procedure.ProcedureWithValues<I, O, A>
+    ) => Effect.Effect<Procedure.Procedure.Result<O, A>, SqlError>
+  }
 }
 
 /**
@@ -195,7 +203,7 @@ export interface MssqlClient extends Client.SqlClient {
  * @category services
  * @since 4.0.0
  */
-export const MssqlClient = Context.Service<MssqlClient>("@effect/sql-mssql/MssqlClient")
+export class MssqlClient extends Context.Service<MssqlClient, MssqlClient.Service>()("@effect/sql-mssql/MssqlClient") {}
 
 /**
  * Configuration for a Microsoft SQL Server client, including connection, authentication, pool, parameter type, span attribute, and query/result name transform options.
@@ -238,7 +246,7 @@ export interface MssqlClientConfig {
   readonly transformQueryNames?: ((str: string) => string) | undefined
 }
 
-interface MssqlConnection extends Connection {
+interface MssqlConnection extends Connection.Service {
   readonly call: (
     procedure: Procedure.ProcedureWithValues<any, any, any>,
     transformRows: ((rows: ReadonlyArray<any>) => ReadonlyArray<any>) | undefined
@@ -265,7 +273,7 @@ let clientIdCounter = 0
  */
 export const make = (
   options: MssqlClientConfig
-): Effect.Effect<MssqlClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
+): Effect.Effect<MssqlClient["Service"], SqlError, Scope.Scope | Reactivity.Reactivity> =>
   Effect.gen(function*() {
     const parameterTypes = options.parameterTypes ?? defaultParameterTypes
     const compiler = makeCompiler(options.transformQueryNames)
@@ -570,7 +578,7 @@ export const make = (
       rollbackSavepoint: (conn, id) => conn.rollback(`effect_sql_${id}`)
     })
 
-    return identity<MssqlClient>(Object.assign(
+    return identity<MssqlClient["Service"]>(Object.assign(
       yield* Client.make({
         acquirer: Pool.get(pool),
         compiler,

--- a/packages/sql/mysql2/src/MysqlClient.ts
+++ b/packages/sql/mysql2/src/MysqlClient.ts
@@ -156,9 +156,17 @@ export type TypeId = "~@effect/sql-mysql2/MysqlClient"
  * @category services
  * @since 4.0.0
  */
-export interface MysqlClient extends Client.SqlClient {
-  readonly [TypeId]: TypeId
-  readonly config: MysqlClientConfig
+export declare namespace MysqlClient {
+  /**
+   * Implementation of the MysqlClient service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service extends Client.SqlClient.Service {
+    readonly [TypeId]: TypeId
+    readonly config: MysqlClientConfig
+  }
 }
 
 /**
@@ -171,7 +179,9 @@ export interface MysqlClient extends Client.SqlClient {
  * @category services
  * @since 4.0.0
  */
-export const MysqlClient = Context.Service<MysqlClient>("@effect/sql-mysql2/MysqlClient")
+export class MysqlClient
+  extends Context.Service<MysqlClient, MysqlClient.Service>()("@effect/sql-mysql2/MysqlClient")
+{}
 
 /**
  * Configuration for a mysql2 client, including connection URI or connection fields, pool options, span attributes, and query/result name transforms.
@@ -216,7 +226,7 @@ export interface MysqlClientConfig {
  */
 export const make = (
   options: MysqlClientConfig
-): Effect.Effect<MysqlClient, SqlError, Scope | Reactivity.Reactivity> =>
+): Effect.Effect<MysqlClient["Service"], SqlError, Scope | Reactivity.Reactivity> =>
   Effect.gen(function*() {
     const compiler = makeCompiler(options.transformQueryNames)
     const transformRows = options.transformResultNames ?
@@ -226,7 +236,7 @@ export const make = (
       undefined
     const defaultMethod: "execute" | "query" = options.disablePreparedStatements === true ? "query" : "execute"
 
-    class ConnectionImpl implements Connection {
+    class ConnectionImpl implements Connection.Service {
       readonly conn: Mysql.PoolConnection | Mysql.Pool
       constructor(conn: Mysql.PoolConnection | Mysql.Pool) {
         this.conn = conn

--- a/packages/sql/pg/src/PgClient.ts
+++ b/packages/sql/pg/src/PgClient.ts
@@ -48,19 +48,27 @@ export type TypeId = "~@effect/sql-pg/PgClient"
  * @category services
  * @since 4.0.0
  */
-export interface PgClient extends Client.SqlClient {
-  readonly [TypeId]: TypeId
-  readonly config: PgClientConfig
-  readonly json: (_: unknown) => Fragment
+export declare namespace PgClient {
   /**
-   * Registers a channel listener and returns its non-empty payload queue after
-   * PostgreSQL confirms `LISTEN`. The listener holds a connection until the
-   * scope closes.
+   * Implementation of the PgClient service.
+   *
+   * @category models
+   * @since 4.0.0
    */
-  readonly listen: (
-    channel: string
-  ) => Effect.Effect<Queue.Dequeue<PgConnection.Notification>, SqlError, Scope.Scope>
-  readonly notify: (channel: string, payload: string) => Effect.Effect<void, SqlError>
+  export interface Service extends Client.SqlClient.Service {
+    readonly [TypeId]: TypeId
+    readonly config: PgClientConfig
+    readonly json: (_: unknown) => Fragment
+    /**
+     * Registers a channel listener and returns its non-empty payload queue after
+     * PostgreSQL confirms `LISTEN`. The listener holds a connection until the
+     * scope closes.
+     */
+    readonly listen: (
+      channel: string
+    ) => Effect.Effect<Queue.Dequeue<PgConnection.Notification>, SqlError, Scope.Scope>
+    readonly notify: (channel: string, payload: string) => Effect.Effect<void, SqlError>
+  }
 }
 
 /**
@@ -69,7 +77,7 @@ export interface PgClient extends Client.SqlClient {
  * @category services
  * @since 4.0.0
  */
-export const PgClient = Context.Service<PgClient>("@effect/sql-pg/PgClient")
+export class PgClient extends Context.Service<PgClient, PgClient.Service>()("@effect/sql-pg/PgClient") {}
 
 /**
  * Connection and query settings for a PostgreSQL client.
@@ -142,7 +150,9 @@ export interface PgPoolConfig extends PgClientConfig {
  * @category constructors
  * @since 4.0.0
  */
-export const make = (options: PgPoolConfig): Effect.Effect<PgClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
+export const make = (
+  options: PgPoolConfig
+): Effect.Effect<PgClient["Service"], SqlError, Scope.Scope | Reactivity.Reactivity> =>
   Effect.flatMap(PgPool.make(options), (pool) =>
     makeImpl({
       acquirer: Effect.map(pool.get, makeConnection),
@@ -165,7 +175,7 @@ export const makeClient = (
      */
     readonly acquireForStream?: boolean | undefined
   }
-): Effect.Effect<PgClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
+): Effect.Effect<PgClient["Service"], SqlError, Scope.Scope | Reactivity.Reactivity> =>
   Effect.flatMap(PgConnection.make(options), (connection) =>
     makeImpl({
       acquirer: Effect.succeed(makeConnection(
@@ -182,13 +192,13 @@ export const makeClient = (
  */
 const makeImpl = Effect.fnUntraced(function*(
   options: {
-    readonly acquirer: Effect.Effect<Connection, SqlError, Scope.Scope>
+    readonly acquirer: Effect.Effect<Connection["Service"], SqlError, Scope.Scope>
     readonly borrower?: Borrower | undefined
-    readonly transactionAcquirer: Effect.Effect<Connection, SqlError, Scope.Scope>
-    readonly listenAcquirer: Effect.Effect<PgConnection.PgConnection, SqlError, Scope.Scope>
+    readonly transactionAcquirer: Effect.Effect<Connection["Service"], SqlError, Scope.Scope>
+    readonly listenAcquirer: Effect.Effect<PgConnection.PgConnection["Service"], SqlError, Scope.Scope>
     readonly config: PgClientConfig
   }
-): Effect.fn.Return<PgClient, SqlError, Scope.Scope | Reactivity.Reactivity> {
+): Effect.fn.Return<PgClient["Service"], SqlError, Scope.Scope | Reactivity.Reactivity> {
   const config = options.config
   const compiler = makeCompiler(
     config.transformQueryNames,
@@ -242,13 +252,13 @@ const makeImpl = Effect.fnUntraced(function*(
   )
 })
 
-class ConnectionImpl implements Connection {
-  readonly connection: PgConnection.PgConnection
-  readonly streamAcquirer: Effect.Effect<PgConnection.PgConnection, SqlError, Scope.Scope> | undefined
+class ConnectionImpl implements Connection.Service {
+  readonly connection: PgConnection.PgConnection["Service"]
+  readonly streamAcquirer: Effect.Effect<PgConnection.PgConnection["Service"], SqlError, Scope.Scope> | undefined
 
   constructor(
-    connection: PgConnection.PgConnection,
-    streamAcquirer?: Effect.Effect<PgConnection.PgConnection, SqlError, Scope.Scope> | undefined
+    connection: PgConnection.PgConnection["Service"],
+    streamAcquirer?: Effect.Effect<PgConnection.PgConnection["Service"], SqlError, Scope.Scope> | undefined
   ) {
     this.connection = connection
     this.streamAcquirer = streamAcquirer
@@ -304,9 +314,9 @@ class ConnectionImpl implements Connection {
 }
 
 const makeConnection = (
-  connection: PgConnection.PgConnection,
-  streamAcquirer?: Effect.Effect<PgConnection.PgConnection, SqlError, Scope.Scope> | undefined
-): Connection => new ConnectionImpl(connection, streamAcquirer)
+  connection: PgConnection.PgConnection["Service"],
+  streamAcquirer?: Effect.Effect<PgConnection.PgConnection["Service"], SqlError, Scope.Scope> | undefined
+): Connection["Service"] => new ConnectionImpl(connection, streamAcquirer)
 
 /**
  * Provides both `PgClient` and `SqlClient` from an acquisition effect.
@@ -315,7 +325,7 @@ const makeConnection = (
  * @since 4.0.0
  */
 export const layerFrom = <E, R>(
-  acquire: Effect.Effect<PgClient, E, R>
+  acquire: Effect.Effect<PgClient["Service"], E, R>
 ): Layer.Layer<PgClient | Client.SqlClient, E, Exclude<R, Scope.Scope | Reactivity.Reactivity>> =>
   Layer.effectContext(
     Effect.map(acquire, (client) =>

--- a/packages/sql/pg/src/PgConnection.ts
+++ b/packages/sql/pg/src/PgConnection.ts
@@ -161,53 +161,61 @@ export interface Notification {
  * @category models
  * @since 4.0.0
  */
-export interface PgConnection {
-  readonly [TypeId]: TypeId
-  readonly config: Config
-  readonly processId: number
+export declare namespace PgConnection {
   /**
-   * Reserves the session for exclusive use until the scope closes. Pinning is
-   * reentrant. Calls through the returned connection skip the
-   * ownership queue, while calls through the original connection wait.
+   * Implementation of the PgConnection service.
+   *
+   * @category models
+   * @since 4.0.0
    */
-  readonly pin: Effect.Effect<PgConnection, never, Scope.Scope>
-  /** Runs a query and returns rows keyed by column name. Pass `false` to skip the prepared statement cache. */
-  readonly query: (
-    sql: string,
-    params?: ReadonlyArray<unknown>,
-    prepare?: boolean
-  ) => Effect.Effect<Result, SqlError>
-  /** Runs a query and returns positional rows. Pass `false` to skip the prepared statement cache. */
-  readonly queryValues: (
-    sql: string,
-    params?: ReadonlyArray<unknown>,
-    prepare?: boolean
-  ) => Effect.Effect<ReadonlyArray<ReadonlyArray<unknown>>, SqlError>
-  /**
-   * Streams rows without collecting the full result. The session is pinned for
-   * the lifetime of the stream. Aborting the stream
-   * before the result completes cancels the statement with a `CancelRequest`
-   * and drains the connection back to `ReadyForQuery`.
-   */
-  readonly stream: (
-    sql: string,
-    params?: ReadonlyArray<unknown>
-  ) => Stream.Stream<Row, SqlError>
-  /**
-   * Registers a channel listener and returns its notification queue after
-   * PostgreSQL confirms `LISTEN`. The session stays pinned until the scope
-   * closes, when it runs `UNLISTEN` and shuts down the queue. PostgreSQL
-   * registration errors fail the acquiring effect.
-   */
-  readonly listen: (
-    channel: string
-  ) => Effect.Effect<Queue.Dequeue<Notification>, SqlError, Scope.Scope>
-  /**
-   * Attempts to cancel the active query through a side connection. This is a
-   * no-op for an unpinned multiplexed connection because the active
-   * query may belong to another fiber. The effect never fails.
-   */
-  readonly interrupt: Effect.Effect<void>
+  export interface Service {
+    readonly [TypeId]: TypeId
+    readonly config: Config
+    readonly processId: number
+    /**
+     * Reserves the session for exclusive use until the scope closes. Pinning is
+     * reentrant. Calls through the returned connection skip the
+     * ownership queue, while calls through the original connection wait.
+     */
+    readonly pin: Effect.Effect<PgConnection["Service"], never, Scope.Scope>
+    /** Runs a query and returns rows keyed by column name. Pass `false` to skip the prepared statement cache. */
+    readonly query: (
+      sql: string,
+      params?: ReadonlyArray<unknown>,
+      prepare?: boolean
+    ) => Effect.Effect<Result, SqlError>
+    /** Runs a query and returns positional rows. Pass `false` to skip the prepared statement cache. */
+    readonly queryValues: (
+      sql: string,
+      params?: ReadonlyArray<unknown>,
+      prepare?: boolean
+    ) => Effect.Effect<ReadonlyArray<ReadonlyArray<unknown>>, SqlError>
+    /**
+     * Streams rows without collecting the full result. The session is pinned for
+     * the lifetime of the stream. Aborting the stream
+     * before the result completes cancels the statement with a `CancelRequest`
+     * and drains the connection back to `ReadyForQuery`.
+     */
+    readonly stream: (
+      sql: string,
+      params?: ReadonlyArray<unknown>
+    ) => Stream.Stream<Row, SqlError>
+    /**
+     * Registers a channel listener and returns its notification queue after
+     * PostgreSQL confirms `LISTEN`. The session stays pinned until the scope
+     * closes, when it runs `UNLISTEN` and shuts down the queue. PostgreSQL
+     * registration errors fail the acquiring effect.
+     */
+    readonly listen: (
+      channel: string
+    ) => Effect.Effect<Queue.Dequeue<Notification>, SqlError, Scope.Scope>
+    /**
+     * Attempts to cancel the active query through a side connection. This is a
+     * no-op for an unpinned multiplexed connection because the active
+     * query may belong to another fiber. The effect never fails.
+     */
+    readonly interrupt: Effect.Effect<void>
+  }
 }
 
 /**
@@ -216,7 +224,9 @@ export interface PgConnection {
  * @category services
  * @since 4.0.0
  */
-export const PgConnection = Context.Service<PgConnection>("@effect/sql-pg/PgConnection")
+export class PgConnection
+  extends Context.Service<PgConnection, PgConnection.Service>()("@effect/sql-pg/PgConnection")
+{}
 
 /**
  * Connects and authenticates a single PostgreSQL session.
@@ -235,7 +245,7 @@ export const PgConnection = Context.Service<PgConnection>("@effect/sql-pg/PgConn
  * @category constructors
  * @since 4.0.0
  */
-export const make = (options: Config): Effect.Effect<PgConnection, SqlError, Scope.Scope> =>
+export const make = (options: Config): Effect.Effect<PgConnection["Service"], SqlError, Scope.Scope> =>
   Effect.flatMap(resolveConfig(options), (config) =>
     Effect.acquireRelease(
       Effect.map(
@@ -291,7 +301,7 @@ const cancelRequestTimeoutMillis = 5000
 const maxPipelineDepth = 128
 const streamPauseThreshold = 512
 
-class PgConnectionImpl implements PgConnection {
+class PgConnectionImpl implements PgConnection.Service {
   readonly [TypeId]: TypeId = TypeId
   readonly config: Config
   readonly processId: number
@@ -320,7 +330,7 @@ class PgConnectionImpl implements PgConnection {
   pipelineHead = 0
   pipelineFlushScheduled = false
   readonly pipelineIdleWaiters = new Set<() => void>()
-  readonly pinnedView: PgConnection
+  readonly pinnedView: PgConnection["Service"]
   readonly [internalsKey]: ConnectionInternals
 
   constructor(config: Config, resolved: ResolvedConfig, session: Session, registry: PgTypes.Registry | undefined) {
@@ -666,12 +676,12 @@ class PgConnectionImpl implements PgConnection {
     return sendCancelRequest(this.resolved, this.session.processId, this.session.secretKey)
   })
 
-  readonly pin: Effect.Effect<PgConnection, never, Scope.Scope> = Effect.suspend(() => {
+  readonly pin: Effect.Effect<PgConnection["Service"], never, Scope.Scope> = Effect.suspend(() => {
     const reserve = this[internalsKey].reserve
     return reserve === undefined ? this.pinExclusive : Effect.andThen(reserve, this.pinExclusive)
   })
 
-  private readonly pinExclusive: Effect.Effect<PgConnection, never, Scope.Scope> = Effect.acquireRelease(
+  private readonly pinExclusive: Effect.Effect<PgConnection["Service"], never, Scope.Scope> = Effect.acquireRelease(
     Effect.flatMap(this.owner.take(1), () =>
       // Holding `owner` stops new submissions; a pipeline already on the wire
       // still has to drain before this fiber owns the connection.
@@ -731,11 +741,11 @@ class PgConnectionImpl implements PgConnection {
  * queue and re-pinning is a no-op, making `pin` reentrant for `stream` and
  * `listen` running inside a transaction.
  */
-class PinnedPgConnection implements PgConnection {
+class PinnedPgConnection implements PgConnection.Service {
   readonly [TypeId]: TypeId = TypeId
   readonly base: PgConnectionImpl
   readonly [internalsKey]: ConnectionInternals
-  readonly pin: Effect.Effect<PgConnection, never, Scope.Scope>
+  readonly pin: Effect.Effect<PgConnection["Service"], never, Scope.Scope>
   readonly interrupt: Effect.Effect<void>
 
   constructor(base: PgConnectionImpl) {
@@ -1546,7 +1556,7 @@ const makeRowBuilder = (fields: ReadonlyArray<PgProtocol.FieldDescription>): Row
 
 const streamRows = (
   conn: PgConnectionImpl,
-  pin: Effect.Effect<PgConnection, never, Scope.Scope>,
+  pin: Effect.Effect<PgConnection["Service"], never, Scope.Scope>,
   sql: string,
   params: ReadonlyArray<unknown>
 ): Stream.Stream<Row, SqlError> =>
@@ -1766,7 +1776,7 @@ const streamRows = (
 
 const listenChannel = (
   conn: PgConnectionImpl,
-  pin: Effect.Effect<PgConnection, never, Scope.Scope>,
+  pin: Effect.Effect<PgConnection["Service"], never, Scope.Scope>,
   channel: string
 ): Effect.Effect<Queue.Dequeue<Notification>, SqlError, Scope.Scope> =>
   Effect.uninterruptibleMask((restore) =>

--- a/packages/sql/pg/src/PgPool.ts
+++ b/packages/sql/pg/src/PgPool.ts
@@ -67,38 +67,46 @@ export interface Config extends PgConnection.Config {
  * @category models
  * @since 4.0.0
  */
-export interface PgPool {
-  readonly [TypeId]: TypeId
-  readonly config: Config
+export declare namespace PgPool {
   /**
-   * Checks out a session until the scope closes. Without multiplexing the
-   * checkout is exclusive. With multiplexing the
-   * session may be shared with other fibers, so multi-statement work should
-   * use `reserve` instead.
-   */
-  readonly get: Effect.Effect<PgConnection.PgConnection, SqlError, Scope.Scope>
-  /**
-   * Checks out a session for exclusive use until the scope closes. Use this for
-   * transactions and listeners on a multiplexed pool.
-   */
-  readonly reserve: Effect.Effect<PgConnection.PgConnection, SqlError, Scope.Scope>
-  /**
-   * Removes a session so the pool can replace it. Fatal protocol and socket
-   * errors invalidate sessions automatically.
-   */
-  /**
-   * Lends a session for the duration of one effect and takes it back on any
-   * exit, without opening a scope for it.
+   * Implementation of the PgPool service.
    *
-   * **Details**
-   *
-   * For work that finishes with the effect that runs it. A lease that has to
-   * outlive its effect - a stream, a transaction - takes `get` or `reserve`.
+   * @category models
+   * @since 4.0.0
    */
-  readonly use: <A, E, R>(
-    f: (connection: PgConnection.PgConnection) => Effect.Effect<A, E, R>
-  ) => Effect.Effect<A, E | SqlError, R>
-  readonly invalidate: (connection: PgConnection.PgConnection) => Effect.Effect<void>
+  export interface Service {
+    readonly [TypeId]: TypeId
+    readonly config: Config
+    /**
+     * Checks out a session until the scope closes. Without multiplexing the
+     * checkout is exclusive. With multiplexing the
+     * session may be shared with other fibers, so multi-statement work should
+     * use `reserve` instead.
+     */
+    readonly get: Effect.Effect<PgConnection.PgConnection["Service"], SqlError, Scope.Scope>
+    /**
+     * Checks out a session for exclusive use until the scope closes. Use this for
+     * transactions and listeners on a multiplexed pool.
+     */
+    readonly reserve: Effect.Effect<PgConnection.PgConnection["Service"], SqlError, Scope.Scope>
+    /**
+     * Removes a session so the pool can replace it. Fatal protocol and socket
+     * errors invalidate sessions automatically.
+     */
+    /**
+     * Lends a session for the duration of one effect and takes it back on any
+     * exit, without opening a scope for it.
+     *
+     * **Details**
+     *
+     * For work that finishes with the effect that runs it. A lease that has to
+     * outlive its effect - a stream, a transaction - takes `get` or `reserve`.
+     */
+    readonly use: <A, E, R>(
+      f: (connection: PgConnection.PgConnection["Service"]) => Effect.Effect<A, E, R>
+    ) => Effect.Effect<A, E | SqlError, R>
+    readonly invalidate: (connection: PgConnection.PgConnection["Service"]) => Effect.Effect<void>
+  }
 }
 
 /**
@@ -107,7 +115,7 @@ export interface PgPool {
  * @category services
  * @since 4.0.0
  */
-export const PgPool = Context.Service<PgPool>("@effect/sql-pg/PgPool")
+export class PgPool extends Context.Service<PgPool, PgPool.Service>()("@effect/sql-pg/PgPool") {}
 
 /**
  * Creates a scoped PostgreSQL session pool.
@@ -121,111 +129,114 @@ export const PgPool = Context.Service<PgPool>("@effect/sql-pg/PgPool")
  * @category constructors
  * @since 4.0.0
  */
-export const make = Effect.fnUntraced(function*(options: Config): Effect.fn.Return<PgPool, SqlError, Scope.Scope> {
-  const clock = yield* Clock.Clock
-  const runFork = Effect.runForkWith(yield* Effect.context())
+export const make = Effect.fnUntraced(
+  function*(options: Config): Effect.fn.Return<PgPool["Service"], SqlError, Scope.Scope> {
+    const clock = yield* Clock.Clock
+    const runFork = Effect.runForkWith(yield* Effect.context())
 
-  const multiplex = options.multiplex ?? false
-  const connectionTTL = options.connectionTTL !== undefined
-    ? Duration.toMillis(Duration.fromInputUnsafe(options.connectionTTL))
-    : undefined
-  const deadConnections = new Set<PgConnection.PgConnection>()
-  const createdAt = new WeakMap<PgConnection.PgConnection, number>()
-  const checkedOut = new WeakSet<PgConnection.PgConnection>()
+    const multiplex = options.multiplex ?? false
+    const connectionTTL = options.connectionTTL !== undefined
+      ? Duration.toMillis(Duration.fromInputUnsafe(options.connectionTTL))
+      : undefined
+    const deadConnections = new Set<PgConnection.PgConnection["Service"]>()
+    const createdAt = new WeakMap<PgConnection.PgConnection["Service"], number>()
+    const checkedOut = new WeakSet<PgConnection.PgConnection["Service"]>()
 
-  // Assigned below, once the pool exists. `acquire` only runs when the pool
-  // opens a connection, which is always after that.
-  let pool: Pool.Pool<PgConnection.PgConnection, SqlError>
-  const acquire = Effect.tap(PgConnection.make(options), (connection) =>
-    Effect.sync(() => {
-      createdAt.set(connection, clock.currentTimeMillisUnsafe())
-      const internals = connectionInternals(connection)
-      internals.fatalHooks.add(() => {
-        deadConnections.add(connection)
-        // `deadConnections` is only read by the next checkout, and a checkout
-        // already waiting for this connection would never get that far. Tell
-        // the pool now so it can replace the connection and admit them.
-        runFork(Pool.invalidate(pool, connection))
-      })
-      // Pinning a shared session has to take it out of circulation, or a
-      // second checkout lands on the connection its own stream is holding.
-      if (multiplex) internals.reserve = Pool.reserve(pool, connection)
-    }))
+    // Assigned below, once the pool exists. `acquire` only runs when the pool
+    // opens a connection, which is always after that.
+    let pool: Pool.Pool<PgConnection.PgConnection["Service"], SqlError>
+    const acquire = Effect.tap(PgConnection.make(options), (connection) =>
+      Effect.sync(() => {
+        createdAt.set(connection, clock.currentTimeMillisUnsafe())
+        const internals = connectionInternals(connection)
+        internals.fatalHooks.add(() => {
+          deadConnections.add(connection)
+          // `deadConnections` is only read by the next checkout, and a checkout
+          // already waiting for this connection would never get that far. Tell
+          // the pool now so it can replace the connection and admit them.
+          runFork(Pool.invalidate(pool, connection))
+        })
+        // Pinning a shared session has to take it out of circulation, or a
+        // second checkout lands on the connection its own stream is holding.
+        if (multiplex) internals.reserve = Pool.reserve(pool, connection)
+      }))
 
-  const maxConnections = options.maxConnections ?? 10
-  pool = yield* Pool.makeWithTTL({
-    acquire,
-    min: options.minConnections ?? 0,
-    max: maxConnections,
-    concurrency: multiplex
-      ? Math.max(1, options.multiplexConcurrency ?? defaultMultiplexConcurrency)
-      : 1,
-    timeToLive: options.idleTimeout ?? Duration.seconds(10),
-    timeToLiveStrategy: "usage"
-  })
+    const maxConnections = options.maxConnections ?? 10
+    pool = yield* Pool.makeWithTTL({
+      acquire,
+      min: options.minConnections ?? 0,
+      max: maxConnections,
+      concurrency: multiplex
+        ? Math.max(1, options.multiplexConcurrency ?? defaultMultiplexConcurrency)
+        : 1,
+      timeToLive: options.idleTimeout ?? Duration.seconds(10),
+      timeToLiveStrategy: "usage"
+    })
 
-  const expired = (connection: PgConnection.PgConnection): boolean => {
-    if (connectionInternals(connection).deadError() !== undefined) return true
-    if (connectionTTL === undefined) return false
-    if (!checkedOut.has(connection)) {
-      checkedOut.add(connection)
-      return false
-    }
-    const openedAt = createdAt.get(connection)
-    return openedAt !== undefined && clock.currentTimeMillisUnsafe() - openedAt >= connectionTTL
-  }
-
-  // A checkout runs per statement, so the case where nothing has died and the
-  // first connection is usable stays a plain flatMap; retrying is the
-  // exception and pays for the loop.
-  const retry: Effect.Effect<PgConnection.PgConnection, SqlError, Scope.Scope> = Effect.gen(function*() {
-    while (true) {
-      if (deadConnections.size > 0) {
-        const dead = Array.from(deadConnections)
-        deadConnections.clear()
-        yield* Effect.forEach(dead, (connection) => Pool.invalidate(pool, connection), { discard: true })
+    const expired = (connection: PgConnection.PgConnection["Service"]): boolean => {
+      if (connectionInternals(connection).deadError() !== undefined) return true
+      if (connectionTTL === undefined) return false
+      if (!checkedOut.has(connection)) {
+        checkedOut.add(connection)
+        return false
       }
-      const connection = yield* Pool.get(pool)
-      if (expired(connection)) {
-        yield* Pool.invalidate(pool, connection)
-        continue
-      }
-      return connection
+      const openedAt = createdAt.get(connection)
+      return openedAt !== undefined && clock.currentTimeMillisUnsafe() - openedAt >= connectionTTL
     }
-  })
 
-  const get: Effect.Effect<PgConnection.PgConnection, SqlError, Scope.Scope> = Effect.suspend(() =>
-    deadConnections.size > 0 ? retry : Effect.flatMap(Pool.get(pool), (connection) =>
-      expired(connection)
-        ? Effect.andThen(Pool.invalidate(pool, connection), retry)
-        : Effect.succeed(connection))
-  )
+    // A checkout runs per statement, so the case where nothing has died and the
+    // first connection is usable stays a plain flatMap; retrying is the
+    // exception and pays for the loop.
+    const retry: Effect.Effect<PgConnection.PgConnection["Service"], SqlError, Scope.Scope> = Effect.gen(function*() {
+      while (true) {
+        if (deadConnections.size > 0) {
+          const dead = Array.from(deadConnections)
+          deadConnections.clear()
+          yield* Effect.forEach(dead, (connection) => Pool.invalidate(pool, connection), { discard: true })
+        }
+        const connection = yield* Pool.get(pool)
+        if (expired(connection)) {
+          yield* Pool.invalidate(pool, connection)
+          continue
+        }
+        return connection
+      }
+    })
 
-  // `pin` reserves the pool item itself, so this needs no help.
-  const reserve = Effect.flatMap(get, (connection) => connection.pin)
-
-  // `Pool.use` cannot check the session it hands over before running the
-  // effect, so it is only taken when there is nothing to check: no session is
-  // known dead, and no lifetime can have run out. Otherwise the scoped
-  // checkout does its replacement pass first. Checking inside the callback
-  // instead would hold one lease while acquiring another, which deadlocks a
-  // pool of one.
-  const use = <A, E, R>(
-    f: (connection: PgConnection.PgConnection) => Effect.Effect<A, E, R>
-  ): Effect.Effect<A, E | SqlError, R> =>
-    Effect.suspend(() =>
-      connectionTTL === undefined && deadConnections.size === 0
-        ? Pool.use(pool, f)
-        : Effect.scoped(Effect.flatMap(get, f))
+    const get: Effect.Effect<PgConnection.PgConnection["Service"], SqlError, Scope.Scope> = Effect.suspend(() =>
+      deadConnections.size > 0 ? retry : Effect.flatMap(Pool.get(pool), (connection) =>
+        expired(connection)
+          ? Effect.andThen(Pool.invalidate(pool, connection), retry)
+          : Effect.succeed(connection))
     )
 
-  const pgPool: PgPool = {
-    [TypeId]: TypeId,
-    config: options,
-    get,
-    reserve,
-    use,
-    invalidate: (connection) => Pool.invalidate(pool, connectionInternals(connection).base as PgConnection.PgConnection)
+    // `pin` reserves the pool item itself, so this needs no help.
+    const reserve = Effect.flatMap(get, (connection) => connection.pin)
+
+    // `Pool.use` cannot check the session it hands over before running the
+    // effect, so it is only taken when there is nothing to check: no session is
+    // known dead, and no lifetime can have run out. Otherwise the scoped
+    // checkout does its replacement pass first. Checking inside the callback
+    // instead would hold one lease while acquiring another, which deadlocks a
+    // pool of one.
+    const use = <A, E, R>(
+      f: (connection: PgConnection.PgConnection["Service"]) => Effect.Effect<A, E, R>
+    ): Effect.Effect<A, E | SqlError, R> =>
+      Effect.suspend(() =>
+        connectionTTL === undefined && deadConnections.size === 0
+          ? Pool.use(pool, f)
+          : Effect.scoped(Effect.flatMap(get, f))
+      )
+
+    const pgPool: PgPool["Service"] = {
+      [TypeId]: TypeId,
+      config: options,
+      get,
+      reserve,
+      use,
+      invalidate: (connection) =>
+        Pool.invalidate(pool, connectionInternals(connection).base as PgConnection.PgConnection["Service"])
+    }
+    return pgPool
   }
-  return pgPool
-})
+)

--- a/packages/sql/pglite/src/PgliteClient.ts
+++ b/packages/sql/pglite/src/PgliteClient.ts
@@ -63,26 +63,34 @@ export type TypeId = "~@effect/sql-pglite/PgliteClient"
  * @category services
  * @since 4.0.0
  */
-export interface PgliteClient extends Client.SqlClient {
-  readonly [TypeId]: TypeId
-  readonly config: PgliteClientConfig
-  readonly pglite: PGliteInterface
-  readonly json: (_: unknown) => Fragment
+export declare namespace PgliteClient {
   /**
-   * Subscribes to a PGlite notification channel.
+   * Implementation of the PgliteClient service.
    *
-   * **Details**
-   *
-   * The effect completes after the listener is installed. Notifications are
-   * buffered in the returned dequeue, and the subscription remains active
-   * until the required scope closes.
+   * @category models
+   * @since 4.0.0
    */
-  readonly listen: (
-    channel: string
-  ) => Effect.Effect<Queue.Dequeue<string>, SqlError, Scope.Scope>
-  readonly notify: (channel: string, payload: string) => Effect.Effect<void, SqlError>
-  readonly dumpDataDir: (compression?: "none" | "gzip" | "auto") => Effect.Effect<File | Blob, SqlError>
-  readonly refreshArrayTypes: Effect.Effect<void, SqlError>
+  export interface Service extends Client.SqlClient.Service {
+    readonly [TypeId]: TypeId
+    readonly config: PgliteClientConfig
+    readonly pglite: PGliteInterface
+    readonly json: (_: unknown) => Fragment
+    /**
+     * Subscribes to a PGlite notification channel.
+     *
+     * **Details**
+     *
+     * The effect completes after the listener is installed. Notifications are
+     * buffered in the returned dequeue, and the subscription remains active
+     * until the required scope closes.
+     */
+    readonly listen: (
+      channel: string
+    ) => Effect.Effect<Queue.Dequeue<string>, SqlError, Scope.Scope>
+    readonly notify: (channel: string, payload: string) => Effect.Effect<void, SqlError>
+    readonly dumpDataDir: (compression?: "none" | "gzip" | "auto") => Effect.Effect<File | Blob, SqlError>
+    readonly refreshArrayTypes: Effect.Effect<void, SqlError>
+  }
 }
 
 /**
@@ -95,7 +103,9 @@ export interface PgliteClient extends Client.SqlClient {
  * @category services
  * @since 4.0.0
  */
-export const PgliteClient = Context.Service<PgliteClient>("@effect/sql-pglite/PgliteClient")
+export class PgliteClient
+  extends Context.Service<PgliteClient, PgliteClient.Service>()("@effect/sql-pglite/PgliteClient")
+{}
 
 /**
  * Configuration for a PGlite client, either by supplying PGlite creation options or an existing live PGlite client.
@@ -164,7 +174,7 @@ export declare namespace PgliteClientConfig {
  */
 export const make = (
   options: PgliteClientConfig = {}
-): Effect.Effect<PgliteClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
+): Effect.Effect<PgliteClient["Service"], SqlError, Scope.Scope | Reactivity.Reactivity> =>
   Effect.gen(function*() {
     const pglite = "liveClient" in options
       ? options.liveClient
@@ -196,7 +206,7 @@ export const fromClient = (
     & {
       readonly liveClient: PGliteInterface
     }
-): Effect.Effect<PgliteClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
+): Effect.Effect<PgliteClient["Service"], SqlError, Scope.Scope | Reactivity.Reactivity> =>
   Effect.gen(function*() {
     const pglite = options.liveClient
     const compiler = makeCompiler(options.transformQueryNames, options.transformJson)
@@ -282,7 +292,7 @@ export const fromClient = (
     )
   })
 
-class PgliteConnection implements Connection {
+class PgliteConnection implements Connection.Service {
   readonly pglite: PGliteInterface
   constructor(pglite: PGliteInterface) {
     this.pglite = pglite
@@ -359,7 +369,7 @@ class PgliteConnection implements Connection {
  * @since 4.0.0
  */
 export const layerFrom = <E, R>(
-  acquire: Effect.Effect<PgliteClient, E, R>
+  acquire: Effect.Effect<PgliteClient["Service"], E, R>
 ): Layer.Layer<PgliteClient | Client.SqlClient, E, Exclude<R, Scope.Scope | Reactivity.Reactivity>> =>
   Layer.effectContext(
     Effect.map(acquire, (client) =>

--- a/packages/sql/sqlite-bun/src/SqliteClient.ts
+++ b/packages/sql/sqlite-bun/src/SqliteClient.ts
@@ -58,14 +58,22 @@ export type TypeId = "~@effect/sql-sqlite-bun/SqliteClient"
  * @category services
  * @since 4.0.0
  */
-export interface SqliteClient extends Client.SqlClient {
-  readonly [TypeId]: TypeId
-  readonly config: SqliteClientConfig
-  readonly export: Effect.Effect<Uint8Array, SqlError>
-  readonly loadExtension: (path: string) => Effect.Effect<void, SqlError>
+export declare namespace SqliteClient {
+  /**
+   * Implementation of the SqliteClient service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service extends Client.SqlClient.Service {
+    readonly [TypeId]: TypeId
+    readonly config: SqliteClientConfig
+    readonly export: Effect.Effect<Uint8Array, SqlError>
+    readonly loadExtension: (path: string) => Effect.Effect<void, SqlError>
 
-  /** Not supported in sqlite */
-  readonly updateValues: never
+    /** Not supported in sqlite */
+    readonly updateValues: never
+  }
 }
 
 /**
@@ -78,7 +86,9 @@ export interface SqliteClient extends Client.SqlClient {
  * @category services
  * @since 4.0.0
  */
-export const SqliteClient = Context.Service<SqliteClient>("@effect/sql-sqlite-bun/Client")
+export class SqliteClient
+  extends Context.Service<SqliteClient, SqliteClient.Service>()("@effect/sql-sqlite-bun/Client")
+{}
 
 /**
  * Configuration for a Bun SQLite client, including filename, open mode flags, WAL and busy timeout behavior, span attributes, and query/result name transforms.
@@ -105,7 +115,7 @@ export interface SqliteClientConfig {
   readonly transformQueryNames?: ((str: string) => string) | undefined
 }
 
-interface SqliteConnection extends Connection {
+interface SqliteConnection extends Connection.Service {
   readonly export: Effect.Effect<Uint8Array, SqlError>
   readonly loadExtension: (path: string) => Effect.Effect<void, SqlError>
 }
@@ -118,7 +128,7 @@ interface SqliteConnection extends Connection {
  */
 export const make = (
   options: SqliteClientConfig
-): Effect.Effect<SqliteClient, never, Scope.Scope | Reactivity.Reactivity> =>
+): Effect.Effect<SqliteClient["Service"], never, Scope.Scope | Reactivity.Reactivity> =>
   Effect.gen(function*() {
     const compiler = Statement.makeCompilerSqlite(options.transformQueryNames)
     const transformRows = options.transformResultNames ?
@@ -230,7 +240,7 @@ export const make = (
       )
     })
 
-    const client: SqliteClient = Object.assign(
+    const client: SqliteClient["Service"] = Object.assign(
       (yield* Client.make({
         acquirer,
         compiler,
@@ -241,7 +251,7 @@ export const make = (
           [ATTR_DB_SYSTEM_NAME, "sqlite"]
         ],
         transformRows
-      })) as SqliteClient,
+      })) as SqliteClient["Service"],
       {
         [TypeId]: TypeId as TypeId,
         config: options,

--- a/packages/sql/sqlite-do/src/SqliteClient.ts
+++ b/packages/sql/sqlite-do/src/SqliteClient.ts
@@ -66,12 +66,20 @@ export type TypeId = "~@effect/sql-sqlite-do/SqliteClient"
  * @category services
  * @since 4.0.0
  */
-export interface SqliteClient extends Client.SqlClient {
-  readonly [TypeId]: TypeId
-  readonly config: SqliteClientConfig
+export declare namespace SqliteClient {
+  /**
+   * Implementation of the SqliteClient service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service extends Client.SqlClient.Service {
+    readonly [TypeId]: TypeId
+    readonly config: SqliteClientConfig
 
-  /** Not supported in sqlite */
-  readonly updateValues: never
+    /** Not supported in sqlite */
+    readonly updateValues: never
+  }
 }
 
 /**
@@ -85,11 +93,14 @@ export interface SqliteClient extends Client.SqlClient {
  * @category services
  * @since 4.0.0
  */
-export const SqliteClient = Context.Service<SqliteClient>("@effect/sql-sqlite-do/SqliteClient")
+export class SqliteClient
+  extends Context.Service<SqliteClient, SqliteClient.Service>()("@effect/sql-sqlite-do/SqliteClient")
+{}
 
-const SqliteTransaction = Context.Service<Client.TransactionConnection, Client.TransactionConnection.Service>(
-  "@effect/sql-sqlite-do/SqliteClient/SqliteTransaction"
-)
+const sqliteTransactionKey: string = "@effect/sql-sqlite-do/SqliteClient/SqliteTransaction"
+class SqliteTransaction
+  extends Context.Service<SqliteTransaction, Client.TransactionConnection.Service>()(sqliteTransactionKey)
+{}
 
 /**
  * Configuration for a Cloudflare Durable Object SQLite client, including either a `SqlStorage` handle or the full `DurableObjectStorage` for transaction support, span attributes, and query/result name transforms.
@@ -116,15 +127,15 @@ const unsupportedTransaction = (message: string, operation: string) =>
   })
 
 const makeUnsupportedWithTransaction =
-  (message: string): Client.SqlClient["withTransaction"] =>
+  (message: string): Client.SqlClient["Service"]["withTransaction"] =>
   <R, E, A>(_effect: Effect.Effect<A, E, R>): Effect.Effect<A, E | SqlError, R> =>
     Effect.fail(unsupportedTransaction(message, "transaction"))
 
 const makeStorageBackedWithTransaction = (
   storage: DurableObjectStorage,
-  connection: Connection,
+  connection: Connection["Service"],
   semaphore: Semaphore.Semaphore
-): Client.SqlClient["withTransaction"] =>
+): Client.SqlClient["Service"]["withTransaction"] =>
 <R, E, A>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E | SqlError, R> =>
   Effect.withFiber((fiber) => {
     const services = fiber.context
@@ -177,7 +188,7 @@ const makeStorageBackedWithTransaction = (
  */
 export const make = (
   options: SqliteClientConfig
-): Effect.Effect<SqliteClient, never, Scope.Scope | Reactivity.Reactivity> =>
+): Effect.Effect<SqliteClient["Service"], never, Scope.Scope | Reactivity.Reactivity> =>
   Effect.gen(function*() {
     const compiler = Statement.makeCompilerSqlite(options.transformQueryNames)
     const transformRows = options.transformResultNames
@@ -234,7 +245,7 @@ export const make = (
           catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
         })
 
-      return identity<Connection>({
+      return identity<Connection["Service"]>({
         execute(sql, params, transformRows) {
           return transformRows
             ? Effect.map(runStatement(sql, params), transformRows)
@@ -299,7 +310,7 @@ export const make = (
         [ATTR_DB_SYSTEM_NAME, "sqlite"]
       ],
       transformRows
-    })) as SqliteClient
+    })) as SqliteClient["Service"]
 
     return Object.assign(client, {
       [TypeId]: TypeId as TypeId,

--- a/packages/sql/sqlite-node/src/SqliteClient.ts
+++ b/packages/sql/sqlite-node/src/SqliteClient.ts
@@ -58,14 +58,22 @@ export type TypeId = "~@effect/sql-sqlite-node/SqliteClient"
  * @category services
  * @since 4.0.0
  */
-export interface SqliteClient extends Client.SqlClient {
-  readonly [TypeId]: TypeId
-  readonly config: SqliteClientConfig
-  readonly backup: (destination: string) => Effect.Effect<BackupMetadata, SqlError>
-  readonly loadExtension: (path: string) => Effect.Effect<void, SqlError>
+export declare namespace SqliteClient {
+  /**
+   * Implementation of the SqliteClient service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service extends Client.SqlClient.Service {
+    readonly [TypeId]: TypeId
+    readonly config: SqliteClientConfig
+    readonly backup: (destination: string) => Effect.Effect<BackupMetadata, SqlError>
+    readonly loadExtension: (path: string) => Effect.Effect<void, SqlError>
 
-  /** Not supported in sqlite */
-  readonly updateValues: never
+    /** Not supported in sqlite */
+    readonly updateValues: never
+  }
 }
 
 /**
@@ -85,7 +93,9 @@ export interface BackupMetadata {
  * @category services
  * @since 4.0.0
  */
-export const SqliteClient = Context.Service<SqliteClient>("@effect/sql-sqlite-node/SqliteClient")
+export class SqliteClient
+  extends Context.Service<SqliteClient, SqliteClient.Service>()("@effect/sql-sqlite-node/SqliteClient")
+{}
 
 /**
  * Configuration for a node SQLite client backed by `node:sqlite`, including the database filename, read-only mode, statement cache settings, WAL and busy timeout behavior, span attributes, and query/result name transforms.
@@ -111,7 +121,7 @@ export interface SqliteClientConfig {
   readonly transformQueryNames?: ((str: string) => string) | undefined
 }
 
-interface SqliteConnection extends Connection {
+interface SqliteConnection extends Connection.Service {
   readonly backup: (destination: string) => Effect.Effect<BackupMetadata, SqlError>
   readonly loadExtension: (path: string) => Effect.Effect<void, SqlError>
 }
@@ -124,7 +134,7 @@ interface SqliteConnection extends Connection {
  */
 export const make = (
   options: SqliteClientConfig
-): Effect.Effect<SqliteClient, never, Scope.Scope | Reactivity.Reactivity> =>
+): Effect.Effect<SqliteClient["Service"], never, Scope.Scope | Reactivity.Reactivity> =>
   Effect.gen(function*() {
     const compiler = Statement.makeCompilerSqlite(options.transformQueryNames)
     const transformRows = options.transformResultNames ?
@@ -328,7 +338,7 @@ export const make = (
           [ATTR_DB_SYSTEM_NAME, "sqlite"]
         ],
         transformRows
-      })) as SqliteClient,
+      })) as SqliteClient["Service"],
       {
         [TypeId]: TypeId as TypeId,
         config: options,

--- a/packages/sql/sqlite-react-native/src/SqliteClient.ts
+++ b/packages/sql/sqlite-react-native/src/SqliteClient.ts
@@ -66,12 +66,20 @@ export type TypeId = "~@effect/sql-sqlite-react-native/SqliteClient"
  * @category services
  * @since 4.0.0
  */
-export interface SqliteClient extends Client.SqlClient {
-  readonly [TypeId]: TypeId
-  readonly config: SqliteClientConfig
+export declare namespace SqliteClient {
+  /**
+   * Implementation of the SqliteClient service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service extends Client.SqlClient.Service {
+    readonly [TypeId]: TypeId
+    readonly config: SqliteClientConfig
 
-  /** Not supported in sqlite */
-  readonly updateValues: never
+    /** Not supported in sqlite */
+    readonly updateValues: never
+  }
 }
 
 /**
@@ -80,7 +88,9 @@ export interface SqliteClient extends Client.SqlClient {
  * @category services
  * @since 4.0.0
  */
-export const SqliteClient = Context.Service<SqliteClient>("@effect/sql-sqlite-react-native/SqliteClient")
+export class SqliteClient
+  extends Context.Service<SqliteClient, SqliteClient.Service>()("@effect/sql-sqlite-react-native/SqliteClient")
+{}
 
 /**
  * Configuration for a React Native SQLite client, including the database filename, optional location and encryption key, span attributes, and query/result name transforms.
@@ -122,7 +132,7 @@ export const AsyncQuery = Context.Reference<boolean>(
 export const withAsyncQuery = <R, E, A>(effect: Effect.Effect<A, E, R>) =>
   Effect.provideService(effect, AsyncQuery, true)
 
-interface SqliteConnection extends Connection {}
+interface SqliteConnection extends Connection.Service {}
 
 /**
  * Creates a scoped React Native SQLite client from the supplied configuration, using a single serialized connection and honoring `AsyncQuery` for query execution.
@@ -132,7 +142,7 @@ interface SqliteConnection extends Connection {}
  */
 export const make = (
   options: SqliteClientConfig
-): Effect.Effect<SqliteClient, never, Scope.Scope | Reactivity.Reactivity> =>
+): Effect.Effect<SqliteClient["Service"], never, Scope.Scope | Reactivity.Reactivity> =>
   Effect.gen(function*() {
     const clientOptions: Parameters<typeof open>[0] = {
       name: options.filename
@@ -245,7 +255,7 @@ export const make = (
           [ATTR_DB_SYSTEM_NAME, "sqlite"]
         ],
         transformRows
-      })) as SqliteClient,
+      })) as SqliteClient["Service"],
       {
         [TypeId]: TypeId,
         config: options

--- a/packages/sql/sqlite-wasm/src/SqliteClient.ts
+++ b/packages/sql/sqlite-wasm/src/SqliteClient.ts
@@ -63,14 +63,22 @@ export type TypeId = "~@effect/sql-sqlite-wasm/SqliteClient"
  * @category services
  * @since 4.0.0
  */
-export interface SqliteClient extends Client.SqlClient {
-  readonly [TypeId]: TypeId
-  readonly config: SqliteClientMemoryConfig
-  readonly export: Effect.Effect<Uint8Array, SqlError>
-  readonly import: (data: Uint8Array) => Effect.Effect<void, SqlError>
+export declare namespace SqliteClient {
+  /**
+   * Implementation of the SqliteClient service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service extends Client.SqlClient.Service {
+    readonly [TypeId]: TypeId
+    readonly config: SqliteClientMemoryConfig
+    readonly export: Effect.Effect<Uint8Array, SqlError>
+    readonly import: (data: Uint8Array) => Effect.Effect<void, SqlError>
 
-  /** Not supported in sqlite */
-  readonly updateValues: never
+    /** Not supported in sqlite */
+    readonly updateValues: never
+  }
 }
 
 /**
@@ -79,7 +87,9 @@ export interface SqliteClient extends Client.SqlClient {
  * @category services
  * @since 4.0.0
  */
-export const SqliteClient = Context.Service<SqliteClient>("@effect/sql-sqlite-wasm/SqliteClient")
+export class SqliteClient
+  extends Context.Service<SqliteClient, SqliteClient.Service>()("@effect/sql-sqlite-wasm/SqliteClient")
+{}
 
 /**
  * Configuration for an in-memory SQLite WASM client, including optional reactivity hooks, span attributes, and query/result name transforms.
@@ -108,7 +118,7 @@ export interface SqliteClientConfig {
   readonly transformQueryNames?: (str: string) => string
 }
 
-interface SqliteConnection extends Connection {
+interface SqliteConnection extends Connection.Service {
   readonly export: Effect.Effect<Uint8Array, SqlError>
   readonly import: (data: Uint8Array) => Effect.Effect<void, SqlError>
 }
@@ -131,7 +141,7 @@ const registered = new Set<string>()
  */
 export const makeMemory = (
   options: SqliteClientMemoryConfig
-): Effect.Effect<SqliteClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
+): Effect.Effect<SqliteClient["Service"], SqlError, Scope.Scope | Reactivity.Reactivity> =>
   Effect.gen(function*() {
     const reactivity = yield* Reactivity.Reactivity
     const compiler = Statement.makeCompilerSqlite(options.transformQueryNames)
@@ -279,7 +289,7 @@ export const makeMemory = (
           [ATTR_DB_SYSTEM_NAME, "sqlite"]
         ],
         transformRows
-      })) as SqliteClient,
+      })) as SqliteClient["Service"],
       {
         [TypeId]: TypeId as TypeId,
         config: options,
@@ -299,7 +309,7 @@ export const makeMemory = (
  */
 export const make = (
   options: SqliteClientConfig
-): Effect.Effect<SqliteClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
+): Effect.Effect<SqliteClient["Service"], SqlError, Scope.Scope | Reactivity.Reactivity> =>
   Effect.gen(function*() {
     const reactivity = yield* Reactivity.Reactivity
     const compiler = Statement.makeCompilerSqlite(options.transformQueryNames)
@@ -452,7 +462,7 @@ export const make = (
           [ATTR_DB_SYSTEM_NAME, "sqlite"]
         ],
         transformRows
-      })) as SqliteClient,
+      })) as SqliteClient["Service"],
       {
         [TypeId]: TypeId as TypeId,
         config: options,

--- a/packages/tools/ai-codegen/src/Config.ts
+++ b/packages/tools/ai-codegen/src/Config.ts
@@ -222,7 +222,7 @@ export const SpecSource = {
    *
    * @since 4.0.0
    */
-  fromString: (spec: string, packagePath: string, pathService: Path.Path): SpecSource => {
+  fromString: (spec: string, packagePath: string, pathService: Path.Path["Service"]): SpecSource => {
     if (spec.startsWith("http://") || spec.startsWith("https://")) {
       return SpecSource.Url(spec)
     }
@@ -237,7 +237,7 @@ export const SpecSource = {
   fromConfig: (
     spec: string | { readonly type: string; readonly statsUrl?: string },
     packagePath: string,
-    pathService: Path.Path
+    pathService: Path.Path["Service"]
   ): SpecSource => {
     if (typeof spec === "string") {
       return SpecSource.fromString(spec, packagePath, pathService)

--- a/packages/tools/ai-codegen/src/Discovery.ts
+++ b/packages/tools/ai-codegen/src/Discovery.ts
@@ -55,17 +55,25 @@ export interface DiscoveredProvider {
  * @category services
  * @since 4.0.0
  */
-export interface ProviderDiscovery {
-  readonly discover: () => Effect.Effect<
-    Array<DiscoveredProvider>,
-    DiscoveryError | Glob.GlobError
-  >
-  readonly discoverOne: (
-    name: string
-  ) => Effect.Effect<
-    DiscoveredProvider,
-    DiscoveryError | ProviderNotFoundError | Glob.GlobError
-  >
+export declare namespace ProviderDiscovery {
+  /**
+   * Implementation of the ProviderDiscovery service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service {
+    readonly discover: () => Effect.Effect<
+      Array<DiscoveredProvider>,
+      DiscoveryError | Glob.GlobError
+    >
+    readonly discoverOne: (
+      name: string
+    ) => Effect.Effect<
+      DiscoveredProvider,
+      DiscoveryError | ProviderNotFoundError | Glob.GlobError
+    >
+  }
 }
 
 /**
@@ -74,9 +82,9 @@ export interface ProviderDiscovery {
  * @category services
  * @since 4.0.0
  */
-export const ProviderDiscovery: Context.Service<ProviderDiscovery, ProviderDiscovery> = Context.Service(
-  "@effect/ai-codegen/ProviderDiscovery"
-)
+export class ProviderDiscovery
+  extends Context.Service<ProviderDiscovery, ProviderDiscovery.Service>()("@effect/ai-codegen/ProviderDiscovery")
+{}
 
 /**
  * Error during provider discovery.

--- a/packages/tools/ai-codegen/src/Generator.ts
+++ b/packages/tools/ai-codegen/src/Generator.ts
@@ -72,11 +72,19 @@ export class PatchError extends Data.TaggedError("PatchError")<{
  * @category services
  * @since 4.0.0
  */
-export interface CodeGenerator {
-  readonly generate: (
-    provider: DiscoveredProvider,
-    spec: unknown
-  ) => Effect.Effect<string, GenerationError | PatchError, FileSystem.FileSystem | Path_.Path>
+export declare namespace CodeGenerator {
+  /**
+   * Implementation of the CodeGenerator service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service {
+    readonly generate: (
+      provider: DiscoveredProvider,
+      spec: unknown
+    ) => Effect.Effect<string, GenerationError | PatchError, FileSystem.FileSystem | Path_.Path>
+  }
 }
 
 /**
@@ -85,9 +93,9 @@ export interface CodeGenerator {
  * @category services
  * @since 4.0.0
  */
-export const CodeGenerator: Context.Service<CodeGenerator, CodeGenerator> = Context.Service(
-  "@effect/ai-codegen/CodeGenerator"
-)
+export class CodeGenerator
+  extends Context.Service<CodeGenerator, CodeGenerator.Service>()("@effect/ai-codegen/CodeGenerator")
+{}
 
 const isRecord = (u: unknown): u is { readonly [x: string]: unknown } =>
   Predicate.isObjectOrArray(u) && !Array.isArray(u)

--- a/packages/tools/ai-codegen/src/Glob.ts
+++ b/packages/tools/ai-codegen/src/Glob.ts
@@ -26,11 +26,19 @@ export class GlobError extends Data.TaggedError("GlobError")<{
  * @category services
  * @since 4.0.0
  */
-export interface Glob {
-  readonly glob: (
-    pattern: string | ReadonlyArray<string>,
-    options?: GlobLib.GlobOptions
-  ) => Effect.Effect<Array<string>, GlobError>
+export declare namespace Glob {
+  /**
+   * Implementation of the Glob service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service {
+    readonly glob: (
+      pattern: string | ReadonlyArray<string>,
+      options?: GlobLib.GlobOptions
+    ) => Effect.Effect<Array<string>, GlobError>
+  }
 }
 
 /**
@@ -39,7 +47,7 @@ export interface Glob {
  * @category services
  * @since 4.0.0
  */
-export const Glob: Context.Service<Glob, Glob> = Context.Service("@effect/ai-codegen/Glob")
+export class Glob extends Context.Service<Glob, Glob.Service>()("@effect/ai-codegen/Glob") {}
 
 /**
  * Layer providing the Glob service.

--- a/packages/tools/ai-codegen/src/PostProcess.ts
+++ b/packages/tools/ai-codegen/src/PostProcess.ts
@@ -69,9 +69,17 @@ export class PostProcessError extends Data.TaggedError("PostProcessError")<{
  * @category services
  * @since 4.0.0
  */
-export interface PostProcessor {
-  readonly lint: (filePath: string) => Effect.Effect<void, PostProcessError>
-  readonly format: (filePath: string) => Effect.Effect<void, PostProcessError>
+export declare namespace PostProcessor {
+  /**
+   * Implementation of the PostProcessor service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service {
+    readonly lint: (filePath: string) => Effect.Effect<void, PostProcessError>
+    readonly format: (filePath: string) => Effect.Effect<void, PostProcessError>
+  }
 }
 
 /**
@@ -80,9 +88,9 @@ export interface PostProcessor {
  * @category services
  * @since 4.0.0
  */
-export const PostProcessor: Context.Service<PostProcessor, PostProcessor> = Context.Service(
-  "@effect/ai-codegen/PostProcessor"
-)
+export class PostProcessor
+  extends Context.Service<PostProcessor, PostProcessor.Service>()("@effect/ai-codegen/PostProcessor")
+{}
 
 /**
  * Layer providing the PostProcessor service.

--- a/packages/tools/ai-codegen/src/SpecFetcher.ts
+++ b/packages/tools/ai-codegen/src/SpecFetcher.ts
@@ -46,11 +46,19 @@ export class SpecFetchError extends Data.TaggedError("SpecFetchError")<{
  * @category services
  * @since 4.0.0
  */
-export interface SpecFetcher {
-  readonly fetch: (
-    source: SpecSource,
-    provider: string
-  ) => Effect.Effect<unknown, SpecFetchError>
+export declare namespace SpecFetcher {
+  /**
+   * Implementation of the SpecFetcher service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service {
+    readonly fetch: (
+      source: SpecSource,
+      provider: string
+    ) => Effect.Effect<unknown, SpecFetchError>
+  }
 }
 
 /**
@@ -59,9 +67,9 @@ export interface SpecFetcher {
  * @category services
  * @since 4.0.0
  */
-export const SpecFetcher: Context.Service<SpecFetcher, SpecFetcher> = Context.Service(
-  "@effect/ai-codegen/SpecFetcher"
-)
+export class SpecFetcher
+  extends Context.Service<SpecFetcher, SpecFetcher.Service>()("@effect/ai-codegen/SpecFetcher")
+{}
 
 /**
  * Layer providing the SpecFetcher service.

--- a/packages/tools/api-diff/src/Snapshot.ts
+++ b/packages/tools/api-diff/src/Snapshot.ts
@@ -26,16 +26,16 @@ import type {
 
 interface SerializationContext {
   readonly checker: ts.TypeChecker
-  readonly path: Path.Path
+  readonly path: Path.Path["Service"]
   readonly repoRoot: string
   readonly typeParameters: ReadonlyMap<string, string>
   readonly publicSymbols: ReadonlyMap<string, string>
 }
 
-const normalizedPath = (path: Path.Path, root: string, location: string): string =>
+const normalizedPath = (path: Path.Path["Service"], root: string, location: string): string =>
   path.relative(root, location).split(path.sep).join("/")
 
-const sourceLocation = (path: Path.Path, root: string, node: ts.Node): SourceLocation => {
+const sourceLocation = (path: Path.Path["Service"], root: string, node: ts.Node): SourceLocation => {
   const source = node.getSourceFile()
   const position = source.getLineAndCharacterOfPosition(node.getStart(source, false))
   return {
@@ -735,7 +735,7 @@ const snapshotExtractionError = (diagnostics: ReadonlyArray<SnapshotDiagnostic>)
 const extractSnapshot = (
   options: ExtractSnapshotOptions,
   discovered: DiscoveryResult,
-  path: Path.Path
+  path: Path.Path["Service"]
 ): ApiSnapshot => {
   const diagnostics: Array<SnapshotDiagnostic> = discovered.missing.map((module) => ({
     code: "missing-entrypoint",

--- a/packages/tools/bundle/src/Plugins.ts
+++ b/packages/tools/bundle/src/Plugins.ts
@@ -30,7 +30,7 @@ import { type PluginVisualizerOptions, visualizer } from "rollup-plugin-visualiz
 const EFFECT_PACKAGE_REGEX = /^(@effect\/[\w-]+|effect)(\/.*)?$/
 const TYPE_SCRIPT_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".cts"])
 
-const toLocalDistPath = (pathService: Path.Path, packageDir: string, resolvedId: string): string => {
+const toLocalDistPath = (pathService: Path.Path["Service"], packageDir: string, resolvedId: string): string => {
   const srcDir = pathService.join(packageDir, "src")
   const relative = pathService.relative(srcDir, resolvedId)
   if (relative === "" || relative.startsWith("..") || pathService.isAbsolute(relative)) {
@@ -103,7 +103,7 @@ const resolvePluginOptions = (options: PluginOptions): ResolvedPluginOptions => 
  * @category constructors
  * @since 4.0.0
  */
-export const createResolveLocalPackageImports = (pathService: Path.Path): Plugin => ({
+export const createResolveLocalPackageImports = (pathService: Path.Path["Service"]): Plugin => ({
   name: "rollup-plugin-resolve-imports",
   async resolveId(source, importer) {
     const match = source.match(EFFECT_PACKAGE_REGEX)
@@ -129,7 +129,7 @@ export const createResolveLocalPackageImports = (pathService: Path.Path): Plugin
  * @category constructors
  * @since 4.0.0
  */
-export const createPlugins = (pathService: Path.Path, options: PluginOptions = {}): Array<Plugin> => {
+export const createPlugins = (pathService: Path.Path["Service"], options: PluginOptions = {}): Array<Plugin> => {
   const resolved = resolvePluginOptions(options)
   const plugins: Array<Plugin> = [
     createResolveLocalPackageImports(pathService),

--- a/packages/tools/openapi-generator/src/OpenApiTransformer.ts
+++ b/packages/tools/openapi-generator/src/OpenApiTransformer.ts
@@ -114,7 +114,7 @@ export const makeTransformerSchema = () => {
       }
     }
     return `export interface ${name} {
-  readonly httpClient: HttpClient.HttpClient
+  readonly httpClient: HttpClient.HttpClient["Service"]
   ${methods.join("\n  ")}
 }
 
@@ -300,9 +300,9 @@ export type WithOptionalResponse<A, Config extends OperationConfig> = Config ext
 } ? [A, HttpClientResponse.HttpClientResponse] : A
 
 export const make = (
-  httpClient: HttpClient.HttpClient,
+  httpClient: HttpClient.HttpClient["Service"],
   options: {
-    readonly transformClient?: ((client: HttpClient.HttpClient) => Effect.Effect<HttpClient.HttpClient>) | undefined
+    readonly transformClient?: ((client: HttpClient.HttpClient["Service"]) => Effect.Effect<HttpClient.HttpClient["Service"]>) | undefined
   } = {}
 ): ${name} => {
   ${helpers.join("\n  ")}
@@ -554,7 +554,7 @@ export const makeTransformerTs = () => {
       }
     }
     return `export interface ${name} {
-  readonly httpClient: HttpClient.HttpClient
+  readonly httpClient: HttpClient.HttpClient["Service"]
   ${methods.join("\n  ")}
 }
 
@@ -731,9 +731,9 @@ export type WithOptionalResponse<A, Config extends OperationConfig> = Config ext
 } ? [A, HttpClientResponse.HttpClientResponse] : A
 
 export const make = (
-  httpClient: HttpClient.HttpClient,
+  httpClient: HttpClient.HttpClient["Service"],
   options: {
-    readonly transformClient?: ((client: HttpClient.HttpClient) => Effect.Effect<HttpClient.HttpClient>) | undefined
+    readonly transformClient?: ((client: HttpClient.HttpClient["Service"]) => Effect.Effect<HttpClient.HttpClient["Service"]>) | undefined
   } = {}
 ): ${name} => {
   ${helpers.join("\n  ")}

--- a/packages/tools/utils/src/Codegen.ts
+++ b/packages/tools/utils/src/Codegen.ts
@@ -121,12 +121,20 @@ export interface BarrelFile {
  * @category services
  * @since 4.0.0
  */
-export interface BarrelGenerator {
-  readonly discoverFiles: (
-    pattern: string,
-    cwd: string
-  ) => Effect.Effect<Array<BarrelFile>, PlatformError | Glob.GlobError>
-  readonly processFile: (file: BarrelFile) => Effect.Effect<void, PlatformError | Glob.GlobError | BarrelCodegenError>
+export declare namespace BarrelGenerator {
+  /**
+   * Implementation of the BarrelGenerator service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service {
+    readonly discoverFiles: (
+      pattern: string,
+      cwd: string
+    ) => Effect.Effect<Array<BarrelFile>, PlatformError | Glob.GlobError>
+    readonly processFile: (file: BarrelFile) => Effect.Effect<void, PlatformError | Glob.GlobError | BarrelCodegenError>
+  }
 }
 
 /**
@@ -135,9 +143,9 @@ export interface BarrelGenerator {
  * @category services
  * @since 4.0.0
  */
-export const BarrelGenerator: Context.Service<BarrelGenerator, BarrelGenerator> = Context.Service(
-  "@effect/utils/BarrelGenerator"
-)
+export class BarrelGenerator
+  extends Context.Service<BarrelGenerator, BarrelGenerator.Service>()("@effect/utils/BarrelGenerator")
+{}
 
 /**
  * Builds the `BarrelGenerator` service, discovering files with `@barrel` annotations and rewriting their generated export sections from matching modules.

--- a/packages/tools/utils/src/Glob.ts
+++ b/packages/tools/utils/src/Glob.ts
@@ -31,11 +31,19 @@ export class GlobError extends Data.TaggedError("GlobError")<{
  * @category services
  * @since 4.0.0
  */
-export interface Glob {
-  readonly glob: (
-    pattern: string | ReadonlyArray<string>,
-    options?: GlobLib.GlobOptions
-  ) => Effect.Effect<Array<string>, GlobError>
+export declare namespace Glob {
+  /**
+   * Implementation of the Glob service.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Service {
+    readonly glob: (
+      pattern: string | ReadonlyArray<string>,
+      options?: GlobLib.GlobOptions
+    ) => Effect.Effect<Array<string>, GlobError>
+  }
 }
 
 /**
@@ -44,7 +52,7 @@ export interface Glob {
  * @category services
  * @since 4.0.0
  */
-export const Glob: Context.Service<Glob, Glob> = Context.Service("@effect/utils/Glob")
+export class Glob extends Context.Service<Glob, Glob.Service>()("@effect/utils/Glob") {}
 
 /**
  * Layer that provides the `Glob` service using the `glob` package and maps matching failures to `GlobError`.


### PR DESCRIPTION
Effect services used a mixture of interface/const pairs and service classes. This change migrates production declarations and ordinary fixtures across packages, including unstable modules and examples, to Context.Service class syntax. It preserves service keys and runtime behavior while separating environment identifiers (`Foo`) from implementation shapes (`Foo["Service"]` or `Foo.Service`).

The OpenAPI generator now emits implementation projections in both schema and type-only clients. The shared service signatures in the Anthropic, OpenAI, and OpenRouter generated clients were regenerated from the transformer without refreshing provider schemas. A changeset documents the breaking type cleanup for the Effect 4 release candidate, using the repository's patch-release convention for these cleanups.

Ordinary declarations use named classes; generic CLI and Atom service factories use anonymous class expressions to retain their caller-defined identifiers. Local workflow/RPC/HTTP/cluster aliases preserve their keys and avoid new import cycles. Scope's public export aliases its single internal class. Context.Reference declarations are outside this migration. The Context.Service API retains both overloads, its explicit const constructor example, and const-support runtime/type tests.

The source migration commit deliberately contains no test edits. A final test-only follow-up is required before merge:

- Convert MockTerminal to a class over a `MockTerminalShape extends Terminal.Terminal.Service` interface; provide its implementation through `Layer.effect(Terminal.Terminal, make)` and update its shape-indexed helper annotations.
- Update old implementation-valued annotations and assertions in 23 test/typetest files to service-shape projections, retaining identifiers in environment requirements.
- Update the two OpenAPI generator `get operation` output expectations for the new HttpClient implementation signatures.

Validation (all through `nix develop -c`):

- `pnpm exec tsc -b tsconfig.packages.json`, `pnpm lint-fix`, and `pnpm jsdocs --check` pass.
- Broad targeted runtime run: 2,367 tests pass across 110 files. Final CLI/Atom factory rerun: 422 pass across 14 files.
- Additional generator/client run: 120 pass; 2 fail on the deferred generated-output expectations.
- Executable examples: 306 pass in Context/Effect/Layer/LayerMap; final Context/Layer/Path run: 66 pass. In-memory TypeScript review of all 43 changed executable example blocks passes.
- Context const-support type tests pass on TypeScript 5.9.3 and 6.0.3 (6 assertions).
- Existing Context/FileSystem/HttpClient/HttpApiClient/Socket type-test run: 106 pass, 16 fail across both compiler versions due to deferred annotation/assertion updates.
- `pnpm check` remains red in test/typetest files only; this PR is not ready to merge until that follow-up lands.

Closes EFF-995
