### PR TITLE
Unify owned services with branded interfaces

### DIFF
--- a/.changeset/unified-service-interfaces.md
+++ b/.changeset/unified-service-interfaces.md
@@ -1,0 +1,32 @@
+---
+"@effect/ai-anthropic": patch
+"@effect/ai-openai": patch
+"@effect/ai-openai-compat": patch
+"@effect/ai-openrouter": patch
+"@effect/docgen": patch
+"@effect/openapi-generator": patch
+"@effect/platform-browser": patch
+"@effect/platform-bun": patch
+"@effect/platform-deno": patch
+"@effect/platform-node": patch
+"@effect/platform-node-shared": patch
+"@effect/sql-clickhouse": patch
+"@effect/sql-d1": patch
+"@effect/sql-libsql": patch
+"@effect/sql-mssql": patch
+"@effect/sql-mysql2": patch
+"@effect/sql-pg": patch
+"@effect/sql-pglite": patch
+"@effect/sql-sqlite-bun": patch
+"@effect/sql-sqlite-do": patch
+"@effect/sql-sqlite-node": patch
+"@effect/sql-sqlite-react-native": patch
+"@effect/sql-sqlite-wasm": patch
+"effect": patch
+---
+
+Use same-name interfaces and `Context.Service` values for owned object services across Effect, platform adapters, AI providers, and tooling. Each migrated service has a TypeId, and its interface names both the implementation and context requirement.
+
+Replace implementation annotations such as `Foo["Service"]` with `Foo`. Use module constructors where available; manually implemented services must include the interface's required TypeId. Migrated exports no longer have class constructor types. Define new service classes through `Context.Service` itself, which continues to support both class and const forms.
+
+Primitive annotations and services that retain borrowed object identities keep their existing declarations. Service key strings are unchanged, and AI configuration TypeIds are omitted from provider request options.

--- a/LLMS.md
+++ b/LLMS.md
@@ -127,48 +127,59 @@ code is modular, testable, and maintainable.
 
 ### Context.Service
 
-The default way to define a service is to extend `Context.Service`,
-passing in the service interface as a type parameter.
+Define services with an interface and a `Context.Service` value of the same
+name. Include a unique TypeId to distinguish the service structurally.
 
 ```ts
 // file: src/db/Database.ts
 import { Context, Effect, Layer, Schema } from "effect"
 
-// Pass in the service class name as the first type parameter, and the service
-// interface as the second type parameter.
-export class Database extends Context.Service<Database, {
-  query(sql: string): Effect.Effect<Array<unknown>, DatabaseError>
-}>()(
-  // The string identifier for the service, which should include the package
-  // name and the subdirectory path to the service file.
-  "myapp/db/Database"
-) {
-  // Attach a static layer to the service, which will be used to provide an
-  // implementation of the service.
-  static readonly layer = Layer.effect(
-    Database,
-    Effect.gen(function*() {
-      // Define the service methods using Effect.fn
-      const query = Effect.fn("Database.query")(function*(sql: string) {
-        yield* Effect.log("Executing SQL query:", sql)
-        return [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }]
-      })
+// The interface names the implementation type and the context requirement.
+const DatabaseTypeId = "~myapp/db/Database"
 
-      // Return an instance of the service using Database.of, passing in an
-      // object that implements the service interface.
-      return Database.of({
-        query
-      })
-    })
-  )
+export interface Database {
+  readonly [DatabaseTypeId]: typeof DatabaseTypeId
+
+  query(sql: string): Effect.Effect<Array<unknown>, DatabaseError>
 }
+
+/**
+ * Service key for `Database` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Database = (() => {
+  const service = Context.Service<Database>("myapp/db/Database")
+  return Object.assign(service, {
+    // Attach a static layer to the service, which will be used to provide an
+    // implementation of the service.
+    layer: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        // Define the service methods using Effect.fn
+        const query = Effect.fn("Database.query")(function*(sql: string) {
+          yield* Effect.log("Executing SQL query:", sql)
+          return [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }]
+        })
+
+        // Return an instance of the service using Database.of, passing in an
+        // object that implements the service interface.
+        return service.of({
+          [DatabaseTypeId]: DatabaseTypeId as typeof DatabaseTypeId,
+          query
+        })
+      })
+    )
+  })
+})()
 
 export class DatabaseError extends Schema.TaggedError<DatabaseError>()("DatabaseError", {
   cause: Schema.Defect()
 }) {}
 
-// If you ever need to access the service type, use `Database["Service"]`
-export type DatabaseService = Database["Service"]
+// The service interface is directly nameable as Database.
+export type DatabaseService = Database
 ```
 
 ### More examples

--- a/ai-docs/src/01_effect/03_services/01_service.ts
+++ b/ai-docs/src/01_effect/03_services/01_service.ts
@@ -1,45 +1,56 @@
 /**
  * @title Context.Service
  *
- * The default way to define a service is to extend `Context.Service`,
- * passing in the service interface as a type parameter.
+ * Define services with an interface and a `Context.Service` value of the same
+ * name. Include a unique TypeId to distinguish the service structurally.
  */
 
 // file: src/db/Database.ts
 import { Context, Effect, Layer, Schema } from "effect"
 
-// Pass in the service class name as the first type parameter, and the service
-// interface as the second type parameter.
-export class Database extends Context.Service<Database, {
-  query(sql: string): Effect.Effect<Array<unknown>, DatabaseError>
-}>()(
-  // The string identifier for the service, which should include the package
-  // name and the subdirectory path to the service file.
-  "myapp/db/Database"
-) {
-  // Attach a static layer to the service, which will be used to provide an
-  // implementation of the service.
-  static readonly layer = Layer.effect(
-    Database,
-    Effect.gen(function*() {
-      // Define the service methods using Effect.fn
-      const query = Effect.fn("Database.query")(function*(sql: string) {
-        yield* Effect.log("Executing SQL query:", sql)
-        return [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }]
-      })
+// The interface names the implementation type and the context requirement.
+const DatabaseTypeId = "~myapp/db/Database"
 
-      // Return an instance of the service using Database.of, passing in an
-      // object that implements the service interface.
-      return Database.of({
-        query
-      })
-    })
-  )
+export interface Database {
+  readonly [DatabaseTypeId]: typeof DatabaseTypeId
+
+  query(sql: string): Effect.Effect<Array<unknown>, DatabaseError>
 }
+
+/**
+ * Service key for `Database` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Database = (() => {
+  const service = Context.Service<Database>("myapp/db/Database")
+  return Object.assign(service, {
+    // Attach a static layer to the service, which will be used to provide an
+    // implementation of the service.
+    layer: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        // Define the service methods using Effect.fn
+        const query = Effect.fn("Database.query")(function*(sql: string) {
+          yield* Effect.log("Executing SQL query:", sql)
+          return [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }]
+        })
+
+        // Return an instance of the service using Database.of, passing in an
+        // object that implements the service interface.
+        return service.of({
+          [DatabaseTypeId]: DatabaseTypeId as typeof DatabaseTypeId,
+          query
+        })
+      })
+    )
+  })
+})()
 
 export class DatabaseError extends Schema.TaggedError<DatabaseError>()("DatabaseError", {
   cause: Schema.Defect()
 }) {}
 
-// If you ever need to access the service type, use `Database["Service"]`
-export type DatabaseService = Database["Service"]
+// The service interface is directly nameable as Database.
+export type DatabaseService = Database

--- a/ai-docs/src/01_effect/03_services/20_layer-composition.ts
+++ b/ai-docs/src/01_effect/03_services/20_layer-composition.ts
@@ -21,50 +21,61 @@ export class UserRespositoryError extends Schema.TaggedError<UserRespositoryErro
   reason: SqlError.SqlError
 }) {}
 
-export class UserRepository extends Context.Service<UserRepository, {
+const UserRepositoryTypeId = "~myapp/UserRepository"
+
+export interface UserRepository {
+  readonly [UserRepositoryTypeId]: typeof UserRepositoryTypeId
+
   findById(id: string): Effect.Effect<
     Option.Option<{ readonly id: string; readonly name: string }>,
     UserRespositoryError
   >
-}>()("myapp/UserRepository") {
-  // Implement the layer for the UserRepository service, which depends on the
-  // SqlClient service
-  static readonly layerNoDeps: Layer.Layer<
-    UserRepository,
-    never,
-    SqlClient.SqlClient
-  > = Layer.effect(
-    UserRepository,
-    Effect.gen(function*() {
-      const sql = yield* SqlClient.SqlClient
-
-      const findById = Effect.fn("UserRepository.findById")(function*(id: string) {
-        const results = yield* sql<{
-          readonly id: string
-          readonly name: string
-        }>`SELECT * FROM users WHERE id = '${id}'`
-        return Array.head(results)
-      }, Effect.mapError((reason) => new UserRespositoryError({ reason })))
-
-      return UserRepository.of({ findById })
-    })
-  )
-
-  // Use Layer.provide to compose the UserRepository layer with the SqlClient
-  // layer, exposing only the UserRepository service
-  static readonly layer: Layer.Layer<
-    UserRepository,
-    Config.ConfigError | SqlError.SqlError
-  > = this.layerNoDeps.pipe(
-    Layer.provide(SqlClientLayer)
-  )
-
-  // Use Layer.provideMerge to compose the UserRepository layer with the SqlClient
-  // layer, exposing both the UserRepository and SqlClient services
-  static readonly layerWithSqlClient: Layer.Layer<
-    UserRepository | SqlClient.SqlClient,
-    Config.ConfigError | SqlError.SqlError
-  > = this.layerNoDeps.pipe(
-    Layer.provideMerge(SqlClientLayer)
-  )
 }
+
+/**
+ * Service key for `UserRepository` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const UserRepository = (() => {
+  const service = Context.Service<UserRepository>("myapp/UserRepository")
+  const service1 = Object.assign(service, {
+    // Implement the layer for the UserRepository service, which depends on the
+    // SqlClient service
+    layerNoDeps: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        const sql = yield* SqlClient.SqlClient
+
+        const findById = Effect.fn("UserRepository.findById")(function*(id: string) {
+          const results = yield* sql<{
+            readonly id: string
+            readonly name: string
+          }>`SELECT * FROM users WHERE id = '${id}'`
+          return Array.head(results)
+        }, Effect.mapError((reason) => new UserRespositoryError({ reason })))
+
+        return service.of({
+          [UserRepositoryTypeId]: UserRepositoryTypeId as typeof UserRepositoryTypeId,
+          findById
+        })
+      })
+    )
+  })
+  const service2 = Object.assign(service1, {
+    // Use Layer.provide to compose the UserRepository layer with the SqlClient
+    // layer, exposing only the UserRepository service1
+    layer: service1.layerNoDeps.pipe(
+      Layer.provide(SqlClientLayer)
+    )
+  })
+  const service3 = Object.assign(service2, {
+    // Use Layer.provideMerge to compose the UserRepository layer with the SqlClient
+    // layer, exposing both the UserRepository and SqlClient services
+    layerWithSqlClient: service2.layerNoDeps.pipe(
+      Layer.provideMerge(SqlClientLayer)
+    )
+  })
+  return service3
+})()

--- a/ai-docs/src/01_effect/03_services/20_layer-unwrap.ts
+++ b/ai-docs/src/01_effect/03_services/20_layer-unwrap.ts
@@ -9,58 +9,78 @@ export class MessageStoreError extends Schema.TaggedError<MessageStoreError>()("
   cause: Schema.Defect()
 }) {}
 
-export class MessageStore extends Context.Service<MessageStore, {
+const MessageStoreTypeId = "~myapp/MessageStore"
+
+export interface MessageStore {
+  readonly [MessageStoreTypeId]: typeof MessageStoreTypeId
+
   append(message: string): Effect.Effect<void>
   readonly all: Effect.Effect<ReadonlyArray<string>>
-}>()("myapp/MessageStore") {
-  static readonly layerInMemory = Layer.effect(
-    MessageStore,
-    Effect.sync(() => {
-      const messages: Array<string> = []
+}
 
-      return MessageStore.of({
-        append: (message) =>
-          Effect.sync(() => {
-            messages.push(message)
-          }),
-        all: Effect.sync(() => [...messages])
-      })
-    })
-  )
+/**
+ * Service key for `MessageStore` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const MessageStore = (() => {
+  const service = Context.Service<MessageStore>("myapp/MessageStore")
+  const service1 = Object.assign(service, {
+    layerInMemory: Layer.effect(
+      service,
+      Effect.sync(() => {
+        const messages: Array<string> = []
 
-  static readonly layerRemote = (url: URL) =>
-    Layer.effect(
-      MessageStore,
-      Effect.try({
-        try: () => {
-          // In a real app this is where you would open a network connection.
-          const messages: Array<string> = []
-
-          return MessageStore.of({
-            append: (message) =>
-              Effect.sync(() => {
-                messages.push(`[${url.host}] ${message}`)
-              }),
-            all: Effect.sync(() => [...messages])
-          })
-        },
-        catch: (cause) => new MessageStoreError({ cause })
+        return service.of({
+          [MessageStoreTypeId]: MessageStoreTypeId as typeof MessageStoreTypeId,
+          append: (message) =>
+            Effect.sync(() => {
+              messages.push(message)
+            }),
+          all: Effect.sync(() => [...messages])
+        })
       })
     )
+  })
+  const service2 = Object.assign(service1, {
+    layerRemote: (url: URL) =>
+      Layer.effect(
+        service1,
+        Effect.try({
+          try: () => {
+            // In a real app service1 is where you would open a network connection.
+            const messages: Array<string> = []
 
-  static readonly layer = Layer.unwrap(
-    Effect.gen(function*() {
-      // Read config inside an Effect, then choose which concrete layer to use.
-      const useInMemory = yield* Config.Boolean("MESSAGE_STORE_IN_MEMORY").pipe(
-        Config.withDefault(false)
+            return service1.of({
+              [MessageStoreTypeId]: MessageStoreTypeId as typeof MessageStoreTypeId,
+              append: (message) =>
+                Effect.sync(() => {
+                  messages.push(`[${url.host}] ${message}`)
+                }),
+              all: Effect.sync(() => [...messages])
+            })
+          },
+          catch: (cause) => new MessageStoreError({ cause })
+        })
       )
+  })
+  const service3 = Object.assign(service2, {
+    layer: Layer.unwrap(
+      Effect.gen(function*() {
+        // Read config inside an Effect, then choose which concrete layer to use.
+        const useInMemory = yield* Config.Boolean("MESSAGE_STORE_IN_MEMORY").pipe(
+          Config.withDefault(false)
+        )
 
-      if (useInMemory) {
-        return MessageStore.layerInMemory
-      }
+        if (useInMemory) {
+          return service2.layerInMemory
+        }
 
-      const remoteUrl = yield* Config.URL("MESSAGE_STORE_URL")
-      return MessageStore.layerRemote(remoteUrl)
-    })
-  )
-}
+        const remoteUrl = yield* Config.URL("MESSAGE_STORE_URL")
+        return service2.layerRemote(remoteUrl)
+      })
+    )
+  })
+  return service3
+})()

--- a/ai-docs/src/01_effect/05_resources/10_acquire-release.ts
+++ b/ai-docs/src/01_effect/05_resources/10_acquire-release.ts
@@ -12,60 +12,78 @@ export class SmtpError extends Schema.Error<SmtpError>("SmtpError")({
   cause: Schema.Defect()
 }) {}
 
-export class Smtp extends Context.Service<Smtp, {
+const SmtpTypeId = "~app/Smtp"
+
+export interface Smtp {
+  readonly [SmtpTypeId]: typeof SmtpTypeId
+
   send(message: {
     readonly to: string
     readonly subject: string
     readonly body: string
   }): Effect.Effect<void, SmtpError>
-}>()("app/Smtp") {
-  static readonly layer = Layer.effect(
-    Smtp,
-    Effect.gen(function*() {
-      const user = yield* Config.String("SMTP_USER")
-      const pass = yield* Config.Redacted("SMTP_PASS")
-
-      // Use `Effect.acquireRelease` to manage the lifecycle of the SMTP
-      // transporter.
-      //
-      // When the Layer is built, the transporter will be created. When the
-      // Layer is torn down, the transporter will be closed, ensuring that
-      // resources are always cleaned up properly.
-      const transporter = yield* Effect.acquireRelease(
-        Effect.sync(() =>
-          NodeMailer.createTransport({
-            host: "smtp.example.com",
-            port: 587,
-            secure: false,
-            auth: { user, pass: Redacted.value(pass) }
-          })
-        ),
-        (transporter) => Effect.sync(() => transporter.close())
-      )
-
-      const send = Effect.fn("Smtp.send")((message: {
-        readonly to: string
-        readonly subject: string
-        readonly body: string
-      }) =>
-        Effect.tryPromise({
-          try: () =>
-            transporter.sendMail({
-              from: "Acme Cloud <cloud@acme.com>",
-              to: message.to,
-              subject: message.subject,
-              text: message.body
-            }),
-          catch: (cause) => new SmtpError({ cause })
-        }).pipe(
-          Effect.asVoid
-        )
-      )
-
-      return Smtp.of({ send })
-    })
-  )
 }
+
+/**
+ * Service key for `Smtp` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Smtp = (() => {
+  const service = Context.Service<Smtp>("app/Smtp")
+  return Object.assign(service, {
+    layer: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        const user = yield* Config.String("SMTP_USER")
+        const pass = yield* Config.Redacted("SMTP_PASS")
+
+        // Use `Effect.acquireRelease` to manage the lifecycle of the SMTP
+        // transporter.
+        //
+        // When the Layer is built, the transporter will be created. When the
+        // Layer is torn down, the transporter will be closed, ensuring that
+        // resources are always cleaned up properly.
+        const transporter = yield* Effect.acquireRelease(
+          Effect.sync(() =>
+            NodeMailer.createTransport({
+              host: "smtp.example.com",
+              port: 587,
+              secure: false,
+              auth: { user, pass: Redacted.value(pass) }
+            })
+          ),
+          (transporter) => Effect.sync(() => transporter.close())
+        )
+
+        const send = Effect.fn("Smtp.send")((message: {
+          readonly to: string
+          readonly subject: string
+          readonly body: string
+        }) =>
+          Effect.tryPromise({
+            try: () =>
+              transporter.sendMail({
+                from: "Acme Cloud <cloud@acme.com>",
+                to: message.to,
+                subject: message.subject,
+                text: message.body
+              }),
+            catch: (cause) => new SmtpError({ cause })
+          }).pipe(
+            Effect.asVoid
+          )
+        )
+
+        return service.of({
+          [SmtpTypeId]: SmtpTypeId as typeof SmtpTypeId,
+          send
+        })
+      })
+    )
+  })
+})()
 
 // We can then use the `Smtp` service in another service, and the transporter
 // will be properly managed by the Layer system.
@@ -74,32 +92,52 @@ export class MailerError extends Schema.TaggedError<MailerError>()("MailerError"
   reason: SmtpError
 }) {}
 
-export class Mailer extends Context.Service<Mailer, {
+const MailerTypeId = "~app/Mailer"
+
+export interface Mailer {
+  readonly [MailerTypeId]: typeof MailerTypeId
+
   sendWelcomeEmail(to: string): Effect.Effect<void, MailerError>
-}>()("app/Mailer") {
-  static readonly layerNoDeps = Layer.effect(
-    Mailer,
-    Effect.gen(function*() {
-      const smtp = yield* Smtp
-
-      const sendWelcomeEmail = Effect.fn("Mailer.sendWelcomeEmail")(function*(to: string) {
-        yield* smtp.send({
-          to,
-          subject: "Welcome to Acme Cloud!",
-          body: "Thanks for signing up for Acme Cloud. We're glad to have you!"
-        }).pipe(
-          Effect.mapError((reason) => new MailerError({ reason }))
-        )
-        yield* Effect.logInfo(`Sent welcome email to ${to}`)
-      })
-
-      return Mailer.of({ sendWelcomeEmail })
-    })
-  )
-
-  // Locally provide the Smtp layer to the Mailer layer, to eliminate all the
-  // requirements
-  static readonly layer = this.layerNoDeps.pipe(
-    Layer.provide(Smtp.layer)
-  )
 }
+
+/**
+ * Service key for `Mailer` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Mailer = (() => {
+  const service = Context.Service<Mailer>("app/Mailer")
+  const service1 = Object.assign(service, {
+    layerNoDeps: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        const smtp = yield* Smtp
+
+        const sendWelcomeEmail = Effect.fn("Mailer.sendWelcomeEmail")(function*(to: string) {
+          yield* smtp.send({
+            to,
+            subject: "Welcome to Acme Cloud!",
+            body: "Thanks for signing up for Acme Cloud. We're glad to have you!"
+          }).pipe(
+            Effect.mapError((reason) => new MailerError({ reason }))
+          )
+          yield* Effect.logInfo(`Sent welcome email to ${to}`)
+        })
+
+        return service.of({
+          [MailerTypeId]: MailerTypeId as typeof MailerTypeId,
+          sendWelcomeEmail
+        })
+      })
+    )
+  })
+  const service2 = Object.assign(service1, {
+    // Locally provide the Smtp layer to the Mailer layer, to eliminate all the
+    // requirements
+    layer: service1.layerNoDeps.pipe(
+      Layer.provide(Smtp.layer)
+    )
+  })
+  return service2
+})()

--- a/ai-docs/src/01_effect/05_resources/30_layer-map.ts
+++ b/ai-docs/src/01_effect/05_resources/30_layer-map.ts
@@ -18,34 +18,50 @@ type UserRecord = {
 
 let nextConnectionId = 0
 
-export class DatabasePool extends Context.Service<DatabasePool, {
+const DatabasePoolTypeId = "~app/DatabasePool"
+
+export interface DatabasePool {
+  readonly [DatabasePoolTypeId]: typeof DatabasePoolTypeId
+
   readonly tenantId: string
   readonly connectionId: number
   readonly query: (sql: string) => Effect.Effect<ReadonlyArray<UserRecord>, DatabaseQueryError>
-}>()("app/DatabasePool") {
-  // A layer factory that builds one pool per tenant.
-  static readonly layer = (tenantId: string) =>
-    Layer.effect(
-      DatabasePool,
-      Effect.acquireRelease(
-        Effect.sync(() => {
-          const connectionId = ++nextConnectionId
-
-          return DatabasePool.of({
-            tenantId,
-            connectionId,
-            query: Effect.fn("DatabasePool.query")((_sql: string) =>
-              Effect.succeed([
-                { id: 1, email: `admin@${tenantId}.example.com` },
-                { id: 2, email: `ops@${tenantId}.example.com` }
-              ])
-            )
-          })
-        }),
-        (pool) => Effect.logInfo(`Closing tenant pool ${pool.tenantId}#${pool.connectionId}`)
-      )
-    )
 }
+
+/**
+ * Service key for `DatabasePool` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const DatabasePool = (() => {
+  const service = Context.Service<DatabasePool>("app/DatabasePool")
+  return Object.assign(service, {
+    // A layer factory that builds one pool per tenant.
+    layer: (tenantId: string) =>
+      Layer.effect(
+        service,
+        Effect.acquireRelease(
+          Effect.sync(() => {
+            const connectionId = ++nextConnectionId
+
+            return service.of({
+              [DatabasePoolTypeId]: DatabasePoolTypeId as typeof DatabasePoolTypeId,
+              tenantId,
+              connectionId,
+              query: Effect.fn("DatabasePool.query")((_sql: string) =>
+                Effect.succeed([
+                  { id: 1, email: `admin@${tenantId}.example.com` },
+                  { id: 2, email: `ops@${tenantId}.example.com` }
+                ])
+              )
+            })
+          }),
+          (pool) => Effect.logInfo(`Closing tenant pool ${pool.tenantId}#${pool.connectionId}`)
+        )
+      )
+  })
+})()
 
 // extend `LayerMap.Service` to create a `LayerMap` service
 export class PoolMap extends LayerMap.Service<PoolMap>()("app/PoolMap", {

--- a/ai-docs/src/01_effect/07_pubsub/10_pubsub.ts
+++ b/ai-docs/src/01_effect/07_pubsub/10_pubsub.ts
@@ -10,47 +10,63 @@ export type OrderEvent =
   | { readonly _tag: "PaymentCaptured"; readonly orderId: string }
   | { readonly _tag: "OrderShipped"; readonly orderId: string }
 
-export class OrderEvents extends Context.Service<OrderEvents, {
+const OrderEventsTypeId = "~acme/OrderEvents"
+
+export interface OrderEvents {
+  readonly [OrderEventsTypeId]: typeof OrderEventsTypeId
+
   publish(event: OrderEvent): Effect.Effect<void>
   publishAll(events: ReadonlyArray<OrderEvent>): Effect.Effect<void>
   readonly subscribe: Stream.Stream<OrderEvent>
-}>()("acme/OrderEvents") {
-  static readonly layer = Layer.effect(
-    OrderEvents,
-    Effect.gen(function*() {
-      // Use PubSub.bounded to create a PubSub with backpressure support.
-      // You can also use PubSub.unbounded if you don't need backpressure.
-      const pubsub = yield* PubSub.bounded<OrderEvent>({
-        capacity: 256,
-        // Optionally add a replay buffer to let late subscribers catch up on
-        // recent events after restarts.
-        replay: 50
-      })
-
-      // Ensure the PubSub is properly shut down when the service is no longer
-      // needed.
-      yield* Effect.addFinalizer(() => PubSub.shutdown(pubsub))
-
-      const publish = Effect.fn("OrderEvents.publish")(function*(event: OrderEvent) {
-        yield* PubSub.publish(pubsub, event)
-      })
-
-      const publishAll = Effect.fn("OrderEvents.publishAll")(function*(events: ReadonlyArray<OrderEvent>) {
-        yield* PubSub.publishAll(pubsub, events)
-      })
-
-      // Create a Stream that emits events published to the PubSub.
-      //
-      // Each subscriber will receive all events published after they subscribe,
-      // and if a replay buffer is configured, they will also receive the most
-      // recent events that were published before they subscribed.
-      const subscribe = Stream.fromPubSub(pubsub)
-
-      return OrderEvents.of({
-        publish,
-        publishAll,
-        subscribe
-      })
-    })
-  )
 }
+
+/**
+ * Service key for `OrderEvents` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const OrderEvents = (() => {
+  const service = Context.Service<OrderEvents>("acme/OrderEvents")
+  return Object.assign(service, {
+    layer: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        // Use PubSub.bounded to create a PubSub with backpressure support.
+        // You can also use PubSub.unbounded if you don't need backpressure.
+        const pubsub = yield* PubSub.bounded<OrderEvent>({
+          capacity: 256,
+          // Optionally add a replay buffer to let late subscribers catch up on
+          // recent events after restarts.
+          replay: 50
+        })
+
+        // Ensure the PubSub is properly shut down when the service is no longer
+        // needed.
+        yield* Effect.addFinalizer(() => PubSub.shutdown(pubsub))
+
+        const publish = Effect.fn("OrderEvents.publish")(function*(event: OrderEvent) {
+          yield* PubSub.publish(pubsub, event)
+        })
+
+        const publishAll = Effect.fn("OrderEvents.publishAll")(function*(events: ReadonlyArray<OrderEvent>) {
+          yield* PubSub.publishAll(pubsub, events)
+        })
+
+        // Create a Stream that emits events published to the PubSub.
+        //
+        // Each subscriber will receive all events published after they subscribe,
+        // and if a replay buffer is configured, they will also receive the most
+        // recent events that were published before they subscribed.
+        const subscribe = Stream.fromPubSub(pubsub)
+
+        return service.of({
+          [OrderEventsTypeId]: OrderEventsTypeId as typeof OrderEventsTypeId,
+          publish,
+          publishAll,
+          subscribe
+        })
+      })
+    )
+  })
+})()

--- a/ai-docs/src/04_integration/10_managed-runtime.ts
+++ b/ai-docs/src/04_integration/10_managed-runtime.ts
@@ -20,42 +20,62 @@ class TodoNotFound extends Schema.TaggedError<TodoNotFound>()("TodoNotFound", {
   id: Schema.Int
 }) {}
 
-export class TodoRepo extends Context.Service<TodoRepo, {
+const TodoRepoTypeId = "~app/TodoRepo"
+
+export interface TodoRepo {
+  readonly [TodoRepoTypeId]: typeof TodoRepoTypeId
+
   readonly getAll: Effect.Effect<ReadonlyArray<Todo>>
   getById(id: number): Effect.Effect<Todo, TodoNotFound>
   create(payload: CreateTodoPayload): Effect.Effect<Todo>
-}>()("app/TodoRepo") {
-  static readonly layer = Layer.effect(
-    TodoRepo,
-    Effect.gen(function*() {
-      const store = new Map<number, Todo>()
-      const nextId = yield* Ref.make(1)
-
-      const getAll = Effect.gen(function*() {
-        return Array.from(store.values())
-      }).pipe(
-        Effect.withSpan("TodoRepo.getAll")
-      )
-
-      const getById = Effect.fn("TodoRepo.getById")(function*(id: number) {
-        const todo = store.get(id)
-        if (todo === undefined) {
-          return yield* new TodoNotFound({ id })
-        }
-        return todo
-      })
-
-      const create = Effect.fn("TodoRepo.create")(function*(payload: CreateTodoPayload) {
-        const id = yield* Ref.getAndUpdate(nextId, (current) => current + 1)
-        const todo = new Todo({ id, title: payload.title, completed: false })
-        store.set(id, todo)
-        return todo
-      })
-
-      return TodoRepo.of({ getAll, getById, create })
-    })
-  )
 }
+
+/**
+ * Service key for `TodoRepo` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const TodoRepo = (() => {
+  const service = Context.Service<TodoRepo>("app/TodoRepo")
+  return Object.assign(service, {
+    layer: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        const store = new Map<number, Todo>()
+        const nextId = yield* Ref.make(1)
+
+        const getAll = Effect.gen(function*() {
+          return Array.from(store.values())
+        }).pipe(
+          Effect.withSpan("TodoRepo.getAll")
+        )
+
+        const getById = Effect.fn("TodoRepo.getById")(function*(id: number) {
+          const todo = store.get(id)
+          if (todo === undefined) {
+            return yield* new TodoNotFound({ id })
+          }
+          return todo
+        })
+
+        const create = Effect.fn("TodoRepo.create")(function*(payload: CreateTodoPayload) {
+          const id = yield* Ref.getAndUpdate(nextId, (current) => current + 1)
+          const todo = new Todo({ id, title: payload.title, completed: false })
+          store.set(id, todo)
+          return todo
+        })
+
+        return service.of({
+          [TodoRepoTypeId]: TodoRepoTypeId as typeof TodoRepoTypeId,
+          getAll,
+          getById,
+          create
+        })
+      })
+    )
+  })
+})()
 
 // Create a global memo map that can be shared across the app. This is necessary
 // for memoization to work correctly across ManagedRuntime instances.

--- a/ai-docs/src/05_batching/10_request-resolver.ts
+++ b/ai-docs/src/05_batching/10_request-resolver.ts
@@ -15,67 +15,85 @@ export class UserNotFound extends Schema.TaggedError<UserNotFound>()("UserNotFou
   id: Schema.Int
 }) {}
 
-export class Users extends Context.Service<Users, {
+const UsersTypeId = "~app/Users"
+
+export interface Users {
+  readonly [UsersTypeId]: typeof UsersTypeId
+
   getUserById(id: number): Effect.Effect<User, UserNotFound>
-}>()("app/Users") {
-  static readonly layer = Layer.effect(
-    Users,
-    Effect.gen(function*() {
-      // Request classes model a single external lookup.
-      class GetUserById extends Request.Class<
-        { readonly id: number },
-        User, // The success type of the request
-        UserNotFound, // The error type of the request
-        never // The requirements type of the request, if any
-      > {}
+}
 
-      // Simulate an external data source that supports batched lookup.
-      const usersTable = new Map<number, User>([
-        [1, new User({ id: 1, name: "Ada Lovelace", email: "ada@acme.dev" })],
-        [2, new User({ id: 2, name: "Alan Turing", email: "alan@acme.dev" })],
-        [3, new User({ id: 3, name: "Grace Hopper", email: "grace@acme.dev" })]
-      ])
+/**
+ * Service key for `Users` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Users = (() => {
+  const service = Context.Service<Users>("app/Users")
+  return Object.assign(service, {
+    layer: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        // Request classes model a single external lookup.
+        class GetUserById extends Request.Class<
+          { readonly id: number },
+          User, // The success type of the request
+          UserNotFound, // The error type of the request
+          never // The requirements type of the request, if any
+        > {}
 
-      const resolver = yield* RequestResolver.make<GetUserById>(Effect.fn(function*(entries) {
-        for (const entry of entries) {
-          const user = usersTable.get(entry.request.id)
+        // Simulate an external data source that supports batched lookup.
+        const usersTable = new Map<number, User>([
+          [1, new User({ id: 1, name: "Ada Lovelace", email: "ada@acme.dev" })],
+          [2, new User({ id: 2, name: "Alan Turing", email: "alan@acme.dev" })],
+          [3, new User({ id: 3, name: "Grace Hopper", email: "grace@acme.dev" })]
+        ])
 
-          // If the request had requirements, you can access them with
-          // `entry.context`
-          const requestSpan = Context.getOption(entry.context, Tracer.ParentSpan)
-          console.log("Request span", requestSpan)
+        const resolver = yield* RequestResolver.make<GetUserById>(Effect.fn(function*(entries) {
+          for (const entry of entries) {
+            const user = usersTable.get(entry.request.id)
 
-          if (user) {
-            // Complete requests with .completeUnsafe and pass in an Exit value
-            entry.completeUnsafe(Exit.succeed(user))
-          } else {
-            entry.completeUnsafe(Exit.fail(new UserNotFound({ id: entry.request.id })))
+            // If the request had requirements, you can access them with
+            // `entry.context`
+            const requestSpan = Context.getOption(entry.context, Tracer.ParentSpan)
+            console.log("Request span", requestSpan)
+
+            if (user) {
+              // Complete requests with .completeUnsafe and pass in an Exit value
+              entry.completeUnsafe(Exit.succeed(user))
+            } else {
+              entry.completeUnsafe(Exit.fail(new UserNotFound({ id: entry.request.id })))
+            }
           }
-        }
-      })).pipe(
-        // Control the delay before the resolver is executed. This allows more
-        // requests to be batched together, but also adds latency to the first
-        // request.
-        RequestResolver.setDelay("10 millis"),
-        // RequestResolver.withSpan adds a span around the resolver execution,
-        // and also sets up span links for each request
-        RequestResolver.withSpan("Users.getUserById.resolver"),
-        // RequestResolver.withCache adds a simple LRU cache to avoid repeated
-        // lookups for the same ID.
-        RequestResolver.withCache({ capacity: 1024 })
-      )
-
-      // Wrap the resolver in a service method. The resolver batches calls to
-      // `getUserById` that occur within the delay window.
-      const getUserById = (id: number) =>
-        Effect.request(new GetUserById({ id }), resolver).pipe(
-          Effect.withSpan("Users.getUserById", { attributes: { userId: id } })
+        })).pipe(
+          // Control the delay before the resolver is executed. This allows more
+          // requests to be batched together, but also adds latency to the first
+          // request.
+          RequestResolver.setDelay("10 millis"),
+          // RequestResolver.withSpan adds a span around the resolver execution,
+          // and also sets up span links for each request
+          RequestResolver.withSpan("Users.getUserById.resolver"),
+          // RequestResolver.withCache adds a simple LRU cache to avoid repeated
+          // lookups for the same ID.
+          RequestResolver.withCache({ capacity: 1024 })
         )
 
-      return { getUserById } as const
-    })
-  )
-}
+        // Wrap the resolver in a service method. The resolver batches calls to
+        // `getUserById` that occur within the delay window.
+        const getUserById = (id: number) =>
+          Effect.request(new GetUserById({ id }), resolver).pipe(
+            Effect.withSpan("Users.getUserById", { attributes: { userId: id } })
+          )
+
+        return {
+          [UsersTypeId]: UsersTypeId as typeof UsersTypeId,
+          getUserById
+        } as const
+      })
+    )
+  })
+})()
 
 // Run multiple lookups concurrently. The resolver receives one batch and
 // internally deduplicates repeated IDs for the external call.

--- a/ai-docs/src/08_observability/20_otlp-tracing.ts
+++ b/ai-docs/src/08_observability/20_otlp-tracing.ts
@@ -38,36 +38,52 @@ export const ObservabilityLayer = Layer.merge(OtlpTracingLayer, OtlpLoggingLayer
   Layer.provide(FetchHttpClient.layer)
 )
 
-export class Checkout extends Context.Service<Checkout, {
+const CheckoutTypeId = "~acme/Checkout"
+
+export interface Checkout {
+  readonly [CheckoutTypeId]: typeof CheckoutTypeId
+
   processCheckout(orderId: string): Effect.Effect<void>
-}>()("acme/Checkout") {
-  static readonly layer = Layer.effect(
-    Checkout,
-    Effect.gen(function*() {
-      yield* Effect.logInfo("setting up checkout service")
+}
 
-      return Checkout.of({
-        processCheckout: Effect.fn("Checkout.processCheckout")(function*(orderId: string) {
-          yield* Effect.logInfo("starting checkout", { orderId })
+/**
+ * Service key for `Checkout` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Checkout = (() => {
+  const service = Context.Service<Checkout>("acme/Checkout")
+  return Object.assign(service, {
+    layer: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        yield* Effect.logInfo("setting up checkout service")
 
-          yield* Effect.sleep("50 millis").pipe(
-            Effect.withSpan("checkout.charge-card"),
-            Effect.annotateSpans({
-              "checkout.order_id": orderId,
-              "checkout.provider": "acme-pay"
-            })
-          )
+        return service.of({
+          [CheckoutTypeId]: CheckoutTypeId as typeof CheckoutTypeId,
+          processCheckout: Effect.fn("Checkout.processCheckout")(function*(orderId: string) {
+            yield* Effect.logInfo("starting checkout", { orderId })
 
-          yield* Effect.sleep("20 millis").pipe(
-            Effect.withSpan("checkout.persist-order")
-          )
+            yield* Effect.sleep("50 millis").pipe(
+              Effect.withSpan("checkout.charge-card"),
+              Effect.annotateSpans({
+                "checkout.order_id": orderId,
+                "checkout.provider": "acme-pay"
+              })
+            )
 
-          yield* Effect.logInfo("checkout completed", { orderId })
+            yield* Effect.sleep("20 millis").pipe(
+              Effect.withSpan("checkout.persist-order")
+            )
+
+            yield* Effect.logInfo("checkout completed", { orderId })
+          })
         })
       })
-    })
-  )
-}
+    )
+  })
+})()
 
 // Example usage of the Checkout service.
 const CheckoutTest = Layer.effectDiscard(

--- a/ai-docs/src/09_testing/20_layer-tests.ts
+++ b/ai-docs/src/09_testing/20_layer-tests.ts
@@ -13,81 +13,137 @@ export interface Todo {
 
 // Create a test ref service that can be used to store and manipulate test data
 // in layers.
-export class TodoRepoTestRef extends Context.Service<TodoRepoTestRef, Ref.Ref<Array<Todo>>>()("app/TodoRepoTestRef") {
-  static readonly layer = Layer.effect(TodoRepoTestRef, Ref.make(Array.empty()))
+const TodoRepoTestRefTypeId = "~app/TodoRepoTestRef"
+
+export interface TodoRepoTestRef extends Ref.Ref<Array<Todo>> {
+  readonly [TodoRepoTestRefTypeId]: typeof TodoRepoTestRefTypeId
 }
 
-class TodoRepo extends Context.Service<TodoRepo, {
+/**
+ * Service key for `TodoRepoTestRef` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const TodoRepoTestRef = (() => {
+  const service = Context.Service<TodoRepoTestRef>("app/TodoRepoTestRef")
+  return Object.assign(service, {
+    layer: Layer.effect(
+      service,
+      Ref.make(Array.empty<Todo>()).pipe(
+        Effect.map((ref) =>
+          Object.assign(ref, { [TodoRepoTestRefTypeId]: TodoRepoTestRefTypeId as typeof TodoRepoTestRefTypeId })
+        )
+      )
+    )
+  })
+})()
+
+const TodoRepoTypeId = "~app/testing/TodoRepo"
+
+interface TodoRepo {
+  readonly [TodoRepoTypeId]: typeof TodoRepoTypeId
+
   create(title: string): Effect.Effect<Todo>
   readonly list: Effect.Effect<ReadonlyArray<Todo>>
-}>()("app/TodoRepo") {
-  static readonly layerTest = Layer.effect(
-    TodoRepo,
-    Effect.gen(function*() {
-      const store = yield* TodoRepoTestRef
-
-      const create = Effect.fn("TodoRepo.create")(function*(title: string) {
-        const todos = yield* Ref.get(store)
-        const todo = { id: todos.length + 1, title }
-        yield* Ref.set(store, [...todos, todo])
-        return todo
-      })
-
-      const list = Ref.get(store)
-
-      return TodoRepo.of({
-        create,
-        list
-      })
-    })
-  ).pipe(
-    // Provide the test ref layer as a dependency for the test repo layer.
-    // Use Layer.provideMerge so the tests can also access the test ref directly
-    // if needed.
-    Layer.provideMerge(TodoRepoTestRef.layer)
-  )
 }
 
-class TodoService extends Context.Service<TodoService, {
+/**
+ * Service key for `TodoRepo` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+const TodoRepo = (() => {
+  const service = Context.Service<TodoRepo>("app/TodoRepo")
+  return Object.assign(service, {
+    layerTest: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        const store = yield* TodoRepoTestRef
+
+        const create = Effect.fn("TodoRepo.create")(function*(title: string) {
+          const todos = yield* Ref.get(store)
+          const todo = { id: todos.length + 1, title }
+          yield* Ref.set(store, [...todos, todo])
+          return todo
+        })
+
+        const list = Ref.get(store)
+
+        return service.of({
+          [TodoRepoTypeId]: TodoRepoTypeId as typeof TodoRepoTypeId,
+          create,
+          list
+        })
+      })
+    ).pipe(
+      // Provide the test ref layer as a dependency for the test repo layer.
+      // Use Layer.provideMerge so the tests can also access the test ref directly
+      // if needed.
+      Layer.provideMerge(TodoRepoTestRef.layer)
+    )
+  })
+})()
+
+const TodoServiceTypeId = "~app/TodoService"
+
+interface TodoService {
+  readonly [TodoServiceTypeId]: typeof TodoServiceTypeId
+
   addAndCount(title: string): Effect.Effect<number>
   readonly titles: Effect.Effect<ReadonlyArray<string>>
-}>()("app/TodoService") {
-  static readonly layerNoDeps = Layer.effect(
-    TodoService,
-    Effect.gen(function*() {
-      const repo = yield* TodoRepo
-
-      const addAndCount = Effect.fn("TodoService.addAndCount")(function*(title: string) {
-        yield* repo.create(title)
-        const todos = yield* repo.list
-        return todos.length
-      })
-
-      const titles = repo.list.pipe(
-        Effect.map((todos) => todos.map((todo) => todo.title))
-      )
-
-      return TodoService.of({
-        addAndCount,
-        titles
-      })
-    })
-  )
-
-  // You would also add a live layer here that provides real dependencies for
-  // production code.
-  //
-  // static readonly layer = Layer.effect(TodoService, ...).pipe(
-  //   Layer.provide(TodoRepo.layer)
-  // )
-
-  static readonly layerTest = this.layerNoDeps.pipe(
-    // Provide the test repo layer as a dependency for the test service layer.
-    // Use `Layer.provideMerge` so the tests can also access the test repo
-    // directly if needed, as well as the test ref through the repo layer.
-    Layer.provideMerge(TodoRepo.layerTest)
-  )
 }
+
+/**
+ * Service key for `TodoService` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+const TodoService = (() => {
+  const service = Context.Service<TodoService>("app/TodoService")
+  const service1 = Object.assign(service, {
+    layerNoDeps: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        const repo = yield* TodoRepo
+
+        const addAndCount = Effect.fn("TodoService.addAndCount")(function*(title: string) {
+          yield* repo.create(title)
+          const todos = yield* repo.list
+          return todos.length
+        })
+
+        const titles = repo.list.pipe(
+          Effect.map((todos) => todos.map((todo) => todo.title))
+        )
+
+        return service.of({
+          [TodoServiceTypeId]: TodoServiceTypeId as typeof TodoServiceTypeId,
+          addAndCount,
+          titles
+        })
+      })
+    )
+  })
+  const service2 = Object.assign(service1, {
+    // You would also add a live layer here that provides real dependencies for
+    // production code.
+    //
+    // static readonly layer = Layer.effect(TodoService, ...).pipe(
+    //   Layer.provide(TodoRepo.layer)
+    // )
+
+    layerTest: service1.layerNoDeps.pipe(
+      // Provide the test repo layer as a dependency for the test service1 layer.
+      // Use `Layer.provideMerge` so the tests can also access the test repo
+      // directly if needed, as well as the test ref through the repo layer.
+      Layer.provideMerge(TodoRepo.layerTest)
+    )
+  })
+  return service2
+})()
 
 // `layer(...)` creates one shared layer for the block and tears it down in
 // `afterAll`, so all tests inside can access the same service context.

--- a/ai-docs/src/40_sql/10_basics.ts
+++ b/ai-docs/src/40_sql/10_basics.ts
@@ -82,77 +82,98 @@ const SqlLive = MigratorLayer.pipe(Layer.provideMerge(SqlLayer))
 
 // Wrap data access in a service, so the rest of the application depends on
 // `Groups` instead of the database directly.
-export class Groups extends Context.Service<Groups, {
+const GroupsTypeId = "~app/Groups"
+
+export interface Groups {
+  readonly [GroupsTypeId]: typeof GroupsTypeId
+
   create(name: string, slug: string): Effect.Effect<Group>
   rename(id: GroupId, name: string): Effect.Effect<Group, GroupNotFound>
   findById(id: GroupId): Effect.Effect<Group, GroupNotFound>
   readonly list: Effect.Effect<Array<Group>>
-}>()("app/Groups") {
-  static readonly layer = Layer.effect(
-    Groups,
-    Effect.gen(function*() {
-      const sql = yield* SqlClient.SqlClient
-
-      // `SqlModel.makeRepository` derives insert / update / findById / delete
-      // operations from the model, using the matching variant schema for each
-      // operation.
-      const repo = yield* SqlModel.makeRepository(Group, {
-        tableName: "groups",
-        spanPrefix: "Groups",
-        idColumn: "id"
-      })
-
-      // For queries the repository does not cover, combine the `sql` tag with
-      // `SqlSchema` to decode the rows using the model schema.
-      const listAll = SqlSchema.findAll({
-        Request: Schema.Void,
-        Result: Group,
-        execute: () => sql`SELECT * FROM groups ORDER BY createdAt`
-      })
-
-      // Use `Effect.fn` to give each method a named span for observability.
-      const create = Effect.fn("Groups.create")((name: string, slug: string) =>
-        // `Group.insert.makeEffect` fills in the generated id and timestamps
-        // using the Effect clock, so tests can control them with `TestClock`.
-        Group.insert.makeEffect({ name, slug, notes: null }).pipe(
-          Effect.flatMap(repo.insert),
-          // Database and encoding failures are unexpected here, so treat
-          // them as defects to keep the service interface focused on domain
-          // errors.
-          Effect.orDie
-        )
-      )
-
-      const rename = Effect.fn("Groups.rename")((id: GroupId, name: string) =>
-        Group.update.makeEffect({ id, name }).pipe(
-          Effect.flatMap(repo.update),
-          Effect.orDie
-        )
-      )
-
-      const findById = Effect.fn("Groups.findById")((id: GroupId) =>
-        repo.findById(id).pipe(
-          Effect.catchTags({
-            NoSuchElementError: () => new GroupNotFound({ id }),
-            SchemaError: Effect.die,
-            SqlError: Effect.die
-          })
-        )
-      )
-
-      const list = listAll().pipe(
-        Effect.orDie,
-        Effect.withSpan("Groups.list")
-      )
-
-      return Groups.of({ create, rename, findById, list })
-    })
-  ).pipe(
-    // Provide the layers locally, so lots of messy wiring doesn't need to
-    // happen in the "main" entrypoint of the application.
-    Layer.provide(SqlLive)
-  )
 }
+
+/**
+ * Service key for `Groups` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Groups = (() => {
+  const service = Context.Service<Groups>("app/Groups")
+  return Object.assign(service, {
+    layer: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        const sql = yield* SqlClient.SqlClient
+
+        // `SqlModel.makeRepository` derives insert / update / findById / delete
+        // operations from the model, using the matching variant schema for each
+        // operation.
+        const repo = yield* SqlModel.makeRepository(Group, {
+          tableName: "groups",
+          spanPrefix: "Groups",
+          idColumn: "id"
+        })
+
+        // For queries the repository does not cover, combine the `sql` tag with
+        // `SqlSchema` to decode the rows using the model schema.
+        const listAll = SqlSchema.findAll({
+          Request: Schema.Void,
+          Result: Group,
+          execute: () => sql`SELECT * FROM groups ORDER BY createdAt`
+        })
+
+        // Use `Effect.fn` to give each method a named span for observability.
+        const create = Effect.fn("Groups.create")((name: string, slug: string) =>
+          // `Group.insert.makeEffect` fills in the generated id and timestamps
+          // using the Effect clock, so tests can control them with `TestClock`.
+          Group.insert.makeEffect({ name, slug, notes: null }).pipe(
+            Effect.flatMap(repo.insert),
+            // Database and encoding failures are unexpected here, so treat
+            // them as defects to keep the service interface focused on domain
+            // errors.
+            Effect.orDie
+          )
+        )
+
+        const rename = Effect.fn("Groups.rename")((id: GroupId, name: string) =>
+          Group.update.makeEffect({ id, name }).pipe(
+            Effect.flatMap(repo.update),
+            Effect.orDie
+          )
+        )
+
+        const findById = Effect.fn("Groups.findById")((id: GroupId) =>
+          repo.findById(id).pipe(
+            Effect.catchTags({
+              NoSuchElementError: () => new GroupNotFound({ id }),
+              SchemaError: Effect.die,
+              SqlError: Effect.die
+            })
+          )
+        )
+
+        const list = listAll().pipe(
+          Effect.orDie,
+          Effect.withSpan("Groups.list")
+        )
+
+        return service.of({
+          [GroupsTypeId]: GroupsTypeId as typeof GroupsTypeId,
+          create,
+          rename,
+          findById,
+          list
+        })
+      })
+    ).pipe(
+      // Provide the layers locally, so lots of messy wiring doesn't need to
+      // happen in the "main" entrypoint of the application.
+      Layer.provide(SqlLive)
+    )
+  })
+})()
 
 const program = Effect.gen(function*() {
   const groups = yield* Groups

--- a/ai-docs/src/50_http-client/10_basics.ts
+++ b/ai-docs/src/50_http-client/10_basics.ts
@@ -13,89 +13,105 @@ class Todo extends Schema.Class<Todo>("Todo")({
   completed: Schema.Boolean
 }) {}
 
-export class JsonPlaceholder extends Context.Service<JsonPlaceholder, {
+const JsonPlaceholderTypeId = "~app/JsonPlaceholder"
+
+export interface JsonPlaceholder {
+  readonly [JsonPlaceholderTypeId]: typeof JsonPlaceholderTypeId
+
   readonly allTodos: Effect.Effect<ReadonlyArray<Todo>, JsonPlaceholderError>
   getTodo(id: number): Effect.Effect<Todo, JsonPlaceholderError>
   createTodo(todo: Omit<Todo, "id">): Effect.Effect<Todo, JsonPlaceholderError>
-}>()("app/JsonPlaceholder") {
-  static readonly layer = Layer.effect(
-    JsonPlaceholder,
-    Effect.gen(function*() {
-      // Access the HttpClient service, and apply some common middleware to all
-      // requests:
-      const client = (yield* HttpClient.HttpClient).pipe(
-        // Add a base URL to all requests made with this client, and set the
-        // Accept header to expect JSON responses
-        HttpClient.mapRequest(flow(
-          HttpClientRequest.prependUrl("https://jsonplaceholder.typicode.com"),
-          HttpClientRequest.acceptJson
-        )),
-        // Fail if the response status is not 2xx
-        HttpClient.filterStatusOk,
-        // Retry transient errors (network issues, 5xx responses) with an
-        // exponential backoff.
-        //
-        // See the schedule documentation for more complex retry strategies.
-        HttpClient.retryTransient({
-          schedule: Schedule.exponential(100),
-          times: 3
-        })
-      )
-
-      const allTodos = client.get("/todos").pipe(
-        Effect.flatMap(HttpClientResponse.schemaBodyJson(Schema.Array(Todo))),
-        Effect.mapError((cause) => new JsonPlaceholderError({ cause })),
-        Effect.withSpan("JsonPlaceholder.allTodos")
-      )
-
-      // Use the HttpClient to fetch a todo item by id, and decode the response
-      // using the Todo schema.
-      const getTodo = Effect.fn("JsonPlaceholder.getTodo")(function*(id: number) {
-        // Annotate the current span with the id of the todo being fetched, so
-        // that it shows up in telemetry for this request.
-        yield* Effect.annotateCurrentSpan({ id })
-
-        const todo = yield* client.get(`/todos/${id}`, {
-          // You can pass additional options to individual requests.
-          // There are options for query parameters, request body, headers, and
-          // more.
-          urlParams: { format: "json" }
-        }).pipe(
-          Effect.flatMap(HttpClientResponse.schemaBodyJson(Todo)),
-          Effect.mapError((cause) => new JsonPlaceholderError({ cause }))
-        )
-
-        return todo
-      })
-
-      // You can use the HttpClientRequest module to build up more complex
-      // requests:
-      const createTodo = Effect.fn("JsonPlaceholder.createTodo")(function*(todo: Omit<Todo, "id">) {
-        yield* Effect.annotateCurrentSpan({ title: todo.title })
-
-        const createdTodo = yield* HttpClientRequest.post("/todos").pipe(
-          // The HttpClientRequest module has many helper functions for building requests.
-          HttpClientRequest.setUrlParams({ format: "json" }),
-          HttpClientRequest.bodyJsonUnsafe(todo),
-          client.execute,
-          Effect.flatMap(HttpClientResponse.schemaBodyJson(Todo)),
-          Effect.mapError((cause) => new JsonPlaceholderError({ cause }))
-        )
-
-        return createdTodo
-      })
-
-      return JsonPlaceholder.of({
-        allTodos,
-        getTodo,
-        createTodo
-      })
-    })
-  ).pipe(
-    // Provide the fetch-based HttpClient implementation
-    Layer.provide(FetchHttpClient.layer)
-  )
 }
+
+/**
+ * Service key for `JsonPlaceholder` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const JsonPlaceholder = (() => {
+  const service = Context.Service<JsonPlaceholder>("app/JsonPlaceholder")
+  return Object.assign(service, {
+    layer: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        // Access the HttpClient service, and apply some common middleware to all
+        // requests:
+        const client = (yield* HttpClient.HttpClient).pipe(
+          // Add a base URL to all requests made with service client, and set the
+          // Accept header to expect JSON responses
+          HttpClient.mapRequest(flow(
+            HttpClientRequest.prependUrl("https://jsonplaceholder.typicode.com"),
+            HttpClientRequest.acceptJson
+          )),
+          // Fail if the response status is not 2xx
+          HttpClient.filterStatusOk,
+          // Retry transient errors (network issues, 5xx responses) with an
+          // exponential backoff.
+          //
+          // See the schedule documentation for more complex retry strategies.
+          HttpClient.retryTransient({
+            schedule: Schedule.exponential(100),
+            times: 3
+          })
+        )
+
+        const allTodos = client.get("/todos").pipe(
+          Effect.flatMap(HttpClientResponse.schemaBodyJson(Schema.Array(Todo))),
+          Effect.mapError((cause) => new JsonPlaceholderError({ cause })),
+          Effect.withSpan("JsonPlaceholder.allTodos")
+        )
+
+        // Use the HttpClient to fetch a todo item by id, and decode the response
+        // using the Todo schema.
+        const getTodo = Effect.fn("JsonPlaceholder.getTodo")(function*(id: number) {
+          // Annotate the current span with the id of the todo being fetched, so
+          // that it shows up in telemetry for service request.
+          yield* Effect.annotateCurrentSpan({ id })
+
+          const todo = yield* client.get(`/todos/${id}`, {
+            // You can pass additional options to individual requests.
+            // There are options for query parameters, request body, headers, and
+            // more.
+            urlParams: { format: "json" }
+          }).pipe(
+            Effect.flatMap(HttpClientResponse.schemaBodyJson(Todo)),
+            Effect.mapError((cause) => new JsonPlaceholderError({ cause }))
+          )
+
+          return todo
+        })
+
+        // You can use the HttpClientRequest module to build up more complex
+        // requests:
+        const createTodo = Effect.fn("JsonPlaceholder.createTodo")(function*(todo: Omit<Todo, "id">) {
+          yield* Effect.annotateCurrentSpan({ title: todo.title })
+
+          const createdTodo = yield* HttpClientRequest.post("/todos").pipe(
+            // The HttpClientRequest module has many helper functions for building requests.
+            HttpClientRequest.setUrlParams({ format: "json" }),
+            HttpClientRequest.bodyJsonUnsafe(todo),
+            client.execute,
+            Effect.flatMap(HttpClientResponse.schemaBodyJson(Todo)),
+            Effect.mapError((cause) => new JsonPlaceholderError({ cause }))
+          )
+
+          return createdTodo
+        })
+
+        return service.of({
+          [JsonPlaceholderTypeId]: JsonPlaceholderTypeId as typeof JsonPlaceholderTypeId,
+          allTodos,
+          getTodo,
+          createTodo
+        })
+      })
+    ).pipe(
+      // Provide the fetch-based HttpClient implementation
+      Layer.provide(FetchHttpClient.layer)
+    )
+  })
+})()
 
 export class JsonPlaceholderError extends Schema.TaggedError<JsonPlaceholderError>()("JsonPlaceholderError", {
   cause: Schema.Defect()

--- a/ai-docs/src/51_http-server/10_basics.ts
+++ b/ai-docs/src/51_http-server/10_basics.ts
@@ -79,33 +79,50 @@ export const AuthorizationClient = HttpApiMiddleware.layerClient(
 
 // Define the HttpApiClient service, which will be used to make requests to the
 // API.
-export class ApiClient extends Context.Service<ApiClient, HttpApiClient.ForApi<typeof Api>>()("acme/ApiClient") {
-  static readonly layer = Layer.effect(
-    ApiClient,
-    HttpApiClient.make(Api, {
-      // Use transformClient to apply middleware to the generated client. This
-      // is useful for settings the base url and applying retry policies.
-      transformClient: (client) =>
-        client.pipe(
-          HttpClient.mapRequest(flow(
-            HttpClientRequest.prependUrl("http://localhost:3000")
-          )),
-          HttpClient.retryTransient({
-            schedule: Schedule.exponential(100),
-            times: 3
-          })
-        )
-    })
-  ).pipe(
-    // Provide the client implementation of the Authorization middleware, which
-    // is required.
-    Layer.provide(AuthorizationClient),
-    // Supply a HttpClient implementation to use for making requests. Here we
-    // use the FetchHttpClient, but you could also use the NodeHttpClient or
-    // BunHttpClient.
-    Layer.provide(FetchHttpClient.layer)
-  )
+const ApiClientTypeId = "~acme/ApiClient"
+
+export interface ApiClient extends HttpApiClient.ForApi<typeof Api> {
+  readonly [ApiClientTypeId]: typeof ApiClientTypeId
 }
+
+/**
+ * Service key for `ApiClient` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const ApiClient = (() => {
+  const service = Context.Service<ApiClient>("acme/ApiClient")
+  return Object.assign(service, {
+    layer: Layer.effect(
+      service,
+      HttpApiClient.make(Api, {
+        // Use transformClient to apply middleware to the generated client. This
+        // is useful for settings the base url and applying retry policies.
+        transformClient: (client) =>
+          client.pipe(
+            HttpClient.mapRequest(flow(
+              HttpClientRequest.prependUrl("http://localhost:3000")
+            )),
+            HttpClient.retryTransient({
+              schedule: Schedule.exponential(100),
+              times: 3
+            })
+          )
+      }).pipe(
+        Effect.map((client) => Object.assign(client, { [ApiClientTypeId]: ApiClientTypeId as typeof ApiClientTypeId }))
+      )
+    ).pipe(
+      // Provide the client implementation of the Authorization middleware, which
+      // is required.
+      Layer.provide(AuthorizationClient),
+      // Supply a HttpClient implementation to use for making requests. Here we
+      // use the FetchHttpClient, but you could also use the NodeHttpClient or
+      // BunHttpClient.
+      Layer.provide(FetchHttpClient.layer)
+    )
+  })
+})()
 
 // The generated client mirrors your API definition, so renames and schema
 // changes are checked end-to-end at compile time.

--- a/ai-docs/src/51_http-server/fixtures/server/Users.ts
+++ b/ai-docs/src/51_http-server/fixtures/server/Users.ts
@@ -29,155 +29,185 @@ const MigratorLayer = SqliteMigrator.layer({
   })
 })
 
-export class Users extends Context.Service<Users, {
+const UsersTypeId = "~acme/Users"
+
+export interface Users {
+  readonly [UsersTypeId]: typeof UsersTypeId
+
   list(search: string | undefined): Effect.Effect<Array<User>, UsersError>
   getById(id: UserId): Effect.Effect<User, UsersError>
   create(input: typeof User.jsonCreate.Type): Effect.Effect<User, UsersError>
   update(id: UserId, input: typeof User.jsonUpdate.Type): Effect.Effect<User, UsersError>
-}>()("acme/Users") {
-  // The SQL implementation only requires a `SqlClient`, so entrypoints and
-  // tests decide how the database is provided.
-  static readonly layerNoDeps = Layer.effect(
-    Users,
-    Effect.gen(function*() {
-      const sql = yield* SqlClient.SqlClient
-
-      // CRUD goes through a repository derived from the `User` model. Each
-      // operation uses the matching model variant to encode its input and
-      // decodes rows with the full model schema.
-      const repo = yield* SqlModel.makeRepository(User, {
-        tableName: "users",
-        spanPrefix: "Users",
-        idColumn: "id"
-      })
-
-      // Queries the repository does not cover are written with the `sql` tag
-      // and decoded with the model schema.
-      const listAll = SqlSchema.findAll({
-        Request: Schema.Void,
-        Result: User,
-        execute: () => sql`SELECT * FROM users ORDER BY createdAt`
-      })
-
-      const searchUsers = SqlSchema.findAll({
-        Request: Schema.String,
-        Result: User,
-        execute: (search) => {
-          const pattern = `%${search}%`
-          return sql`SELECT * FROM users WHERE name LIKE ${pattern} OR email LIKE ${pattern}`
-        }
-      })
-
-      const list = Effect.fn("Users.list")(function*(search: string | undefined) {
-        if (search === undefined || search.length === 0) {
-          return yield* Effect.orDie(listAll())
-        } else if (search.length < SearchQueryTooShort.minimumLength) {
-          return yield* new UsersError({
-            reason: new SearchQueryTooShort()
-          })
-        }
-        yield* Effect.annotateCurrentSpan({ search })
-        return yield* Effect.orDie(searchUsers(search))
-      })
-
-      const getById = Effect.fn("Users.getById")((id: UserId) =>
-        repo.findById(id).pipe(
-          Effect.catchTags({
-            NoSuchElementError: () => new UsersError({ reason: new UserNotFound() }),
-            // Database and encoding failures are unexpected, so treat them as
-            // defects to keep the service interface focused on domain errors.
-            SchemaError: Effect.die,
-            SqlError: Effect.die
-          })
-        )
-      )
-
-      const create = Effect.fn("Users.create")((input: typeof User.jsonCreate.Type) =>
-        // `User.insert.makeEffect` fills in the generated id and timestamps
-        // using the Effect clock, so tests can control them with `TestClock`.
-        User.insert.makeEffect(input).pipe(
-          Effect.flatMap(repo.insert),
-          Effect.orDie
-        )
-      )
-
-      const update = Effect.fn("Users.update")(function*(id: UserId, input: typeof User.jsonUpdate.Type) {
-        // Ensure the user exists first, so a missing id fails with the domain
-        // error instead of a defect.
-        yield* getById(id)
-        const update = yield* User.update.makeEffect({ id, ...input }).pipe(Effect.orDie)
-        return yield* repo.update(update).pipe(Effect.orDie)
-      })
-
-      return Users.of({ list, getById, create, update })
-    })
-  )
-
-  // The fully provided SQL implementation: the database client and migrations
-  // are implementation details, so this layer requires nothing.
-  static readonly layer: Layer.Layer<Users> = this.layerNoDeps.pipe(
-    Layer.provide(MigratorLayer.pipe(Layer.provideMerge(SqlLayer))),
-    Layer.orDie
-  )
-
-  // An in-memory implementation for tests, so the HTTP stack can be exercised
-  // without a database.
-  static readonly layerMemory = Layer.effect(
-    Users,
-    Effect.gen(function*() {
-      const users = new Map<UserId, User>()
-
-      const makeUser = (input: typeof User.jsonCreate.Type) =>
-        User.insert.makeEffect(input).pipe(
-          Effect.map((user) => new User(user)),
-          Effect.orDie
-        )
-
-      const admin = yield* makeUser({ name: "Admin", email: "admin@acme.dev" })
-      users.set(admin.id, admin)
-
-      const list = Effect.fn("Users.list")(function*(search: string | undefined) {
-        const allUsers = Array.from(users.values())
-        if (search === undefined || search.length === 0) {
-          return allUsers
-        } else if (search.length < SearchQueryTooShort.minimumLength) {
-          return yield* new UsersError({
-            reason: new SearchQueryTooShort()
-          })
-        }
-        yield* Effect.annotateCurrentSpan({ search })
-        const normalized = search.toLowerCase()
-        return allUsers.filter((user) =>
-          user.name.toLowerCase().includes(normalized) || user.email.toLowerCase().includes(normalized)
-        )
-      })
-
-      const getById = Effect.fn("Users.getById")(function*(id: UserId) {
-        yield* Effect.annotateCurrentSpan({ id })
-        const user = users.get(id)
-        if (user === undefined) {
-          return yield* new UsersError({
-            reason: new UserNotFound()
-          })
-        }
-        return user
-      })
-
-      const create = Effect.fn("Users.create")(function*(input: typeof User.jsonCreate.Type) {
-        const user = yield* makeUser(input)
-        users.set(user.id, user)
-        return user
-      })
-
-      const update = Effect.fn("Users.update")(function*(id: UserId, input: typeof User.jsonUpdate.Type) {
-        const existing = yield* getById(id)
-        const update = yield* User.update.makeEffect({ id, ...input }).pipe(Effect.orDie)
-        const updated = new User({ ...existing, ...update })
-        users.set(id, updated)
-        return updated
-      })
-
-      return Users.of({ list, getById, create, update })
-    })
-  )
 }
+
+/**
+ * Service key for `Users` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Users = (() => {
+  const service = Context.Service<Users>("acme/Users")
+  const service1 = Object.assign(service, {
+    // The SQL implementation only requires a `SqlClient`, so entrypoints and
+    // tests decide how the database is provided.
+    layerNoDeps: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        const sql = yield* SqlClient.SqlClient
+
+        // CRUD goes through a repository derived from the `User` model. Each
+        // operation uses the matching model variant to encode its input and
+        // decodes rows with the full model schema.
+        const repo = yield* SqlModel.makeRepository(User, {
+          tableName: "users",
+          spanPrefix: "Users",
+          idColumn: "id"
+        })
+
+        // Queries the repository does not cover are written with the `sql` tag
+        // and decoded with the model schema.
+        const listAll = SqlSchema.findAll({
+          Request: Schema.Void,
+          Result: User,
+          execute: () => sql`SELECT * FROM users ORDER BY createdAt`
+        })
+
+        const searchUsers = SqlSchema.findAll({
+          Request: Schema.String,
+          Result: User,
+          execute: (search) => {
+            const pattern = `%${search}%`
+            return sql`SELECT * FROM users WHERE name LIKE ${pattern} OR email LIKE ${pattern}`
+          }
+        })
+
+        const list = Effect.fn("Users.list")(function*(search: string | undefined) {
+          if (search === undefined || search.length === 0) {
+            return yield* Effect.orDie(listAll())
+          } else if (search.length < SearchQueryTooShort.minimumLength) {
+            return yield* new UsersError({
+              reason: new SearchQueryTooShort()
+            })
+          }
+          yield* Effect.annotateCurrentSpan({ search })
+          return yield* Effect.orDie(searchUsers(search))
+        })
+
+        const getById = Effect.fn("Users.getById")((id: UserId) =>
+          repo.findById(id).pipe(
+            Effect.catchTags({
+              NoSuchElementError: () => new UsersError({ reason: new UserNotFound() }),
+              // Database and encoding failures are unexpected, so treat them as
+              // defects to keep the service interface focused on domain errors.
+              SchemaError: Effect.die,
+              SqlError: Effect.die
+            })
+          )
+        )
+
+        const create = Effect.fn("Users.create")((input: typeof User.jsonCreate.Type) =>
+          // `User.insert.makeEffect` fills in the generated id and timestamps
+          // using the Effect clock, so tests can control them with `TestClock`.
+          User.insert.makeEffect(input).pipe(
+            Effect.flatMap(repo.insert),
+            Effect.orDie
+          )
+        )
+
+        const update = Effect.fn("Users.update")(function*(id: UserId, input: typeof User.jsonUpdate.Type) {
+          // Ensure the user exists first, so a missing id fails with the domain
+          // error instead of a defect.
+          yield* getById(id)
+          const update = yield* User.update.makeEffect({ id, ...input }).pipe(Effect.orDie)
+          return yield* repo.update(update).pipe(Effect.orDie)
+        })
+
+        return service.of({
+          [UsersTypeId]: UsersTypeId as typeof UsersTypeId,
+          list,
+          getById,
+          create,
+          update
+        })
+      })
+    )
+  })
+  const service2 = Object.assign(service1, {
+    // The fully provided SQL implementation: the database client and migrations
+    // are implementation details, so service1 layer requires nothing.
+    layer: service1.layerNoDeps.pipe(
+      Layer.provide(MigratorLayer.pipe(Layer.provideMerge(SqlLayer))),
+      Layer.orDie
+    )
+  })
+  const service3 = Object.assign(service2, {
+    // An in-memory implementation for tests, so the HTTP stack can be exercised
+    // without a database.
+    layerMemory: Layer.effect(
+      service2,
+      Effect.gen(function*() {
+        const users = new Map<UserId, User>()
+
+        const makeUser = (input: typeof User.jsonCreate.Type) =>
+          User.insert.makeEffect(input).pipe(
+            Effect.map((user) => new User(user)),
+            Effect.orDie
+          )
+
+        const admin = yield* makeUser({ name: "Admin", email: "admin@acme.dev" })
+        users.set(admin.id, admin)
+
+        const list = Effect.fn("Users.list")(function*(search: string | undefined) {
+          const allUsers = Array.from(users.values())
+          if (search === undefined || search.length === 0) {
+            return allUsers
+          } else if (search.length < SearchQueryTooShort.minimumLength) {
+            return yield* new UsersError({
+              reason: new SearchQueryTooShort()
+            })
+          }
+          yield* Effect.annotateCurrentSpan({ search })
+          const normalized = search.toLowerCase()
+          return allUsers.filter((user) =>
+            user.name.toLowerCase().includes(normalized) || user.email.toLowerCase().includes(normalized)
+          )
+        })
+
+        const getById = Effect.fn("Users.getById")(function*(id: UserId) {
+          yield* Effect.annotateCurrentSpan({ id })
+          const user = users.get(id)
+          if (user === undefined) {
+            return yield* new UsersError({
+              reason: new UserNotFound()
+            })
+          }
+          return user
+        })
+
+        const create = Effect.fn("Users.create")(function*(input: typeof User.jsonCreate.Type) {
+          const user = yield* makeUser(input)
+          users.set(user.id, user)
+          return user
+        })
+
+        const update = Effect.fn("Users.update")(function*(id: UserId, input: typeof User.jsonUpdate.Type) {
+          const existing = yield* getById(id)
+          const update = yield* User.update.makeEffect({ id, ...input }).pipe(Effect.orDie)
+          const updated = new User({ ...existing, ...update })
+          users.set(id, updated)
+          return updated
+        })
+
+        return service2.of({
+          [UsersTypeId]: UsersTypeId as typeof UsersTypeId,
+          list,
+          getById,
+          create,
+          update
+        })
+      })
+    )
+  })
+  return service3
+})()

--- a/ai-docs/src/60_child-process/10_working-with-child-processes.ts
+++ b/ai-docs/src/60_child-process/10_working-with-child-processes.ts
@@ -11,99 +11,115 @@ export class DevToolsError extends Schema.TaggedError<DevToolsError>()("DevTools
   cause: Schema.Defect()
 }) {}
 
-export class DevTools extends Context.Service<DevTools, {
+const DevToolsTypeId = "~docs/DevTools"
+
+export interface DevTools {
+  readonly [DevToolsTypeId]: typeof DevToolsTypeId
+
   readonly nodeVersion: Effect.Effect<string, DevToolsError>
   readonly recentCommitSubjects: Effect.Effect<ReadonlyArray<string>, DevToolsError>
   readonly runLintFix: Effect.Effect<void, DevToolsError>
   changedTypeScriptFiles(baseRef: string): Effect.Effect<ReadonlyArray<string>, DevToolsError>
-}>()("docs/DevTools") {
-  static readonly layer = Layer.effect(
-    DevTools,
-    Effect.gen(function*() {
-      // To run child processes, we need access to a `ChildProcessSpawner`.
-      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
-
-      // Use `spawner.string` when you want to collect the entire output of a
-      // command as a string. This runs `node --version` and collects the
-      // output.
-      const nodeVersion = spawner.string(
-        ChildProcess.make("node", ["--version"])
-      ).pipe(
-        Effect.map(String.trim),
-        Effect.mapError((cause) => new DevToolsError({ cause }))
-      )
-
-      const changedTypeScriptFiles = Effect.fn("DevTools.changedTypeScriptFiles")(function*(baseRef: string) {
-        yield* Effect.annotateCurrentSpan({ baseRef })
-
-        // `spawner.lines` is a convenience helper for line-oriented command
-        // output.
-        const files = yield* spawner.lines(
-          ChildProcess.make("git", ["diff", "--name-only", `${baseRef}...HEAD`])
-        ).pipe(
-          Effect.mapError((cause) => new DevToolsError({ cause }))
-        )
-
-        return files.filter((file) => file.endsWith(".ts"))
-      })
-
-      // Build a pipeline from two command values. This runs:
-      // `git log --pretty=format:%s -n 20 | head -n 5`
-      const recentCommitSubjects = spawner.lines(
-        ChildProcess.make("git", ["log", "--pretty=format:%s", "-n", "20"]).pipe(
-          ChildProcess.pipeTo(ChildProcess.make("head", ["-n", "5"]))
-        )
-      ).pipe(
-        Effect.mapError((cause) => new DevToolsError({ cause }))
-      )
-
-      const runLintFix = Effect.gen(function*() {
-        // Use `spawn` when you want the process handle and stream output while
-        // the process is still running.
-        const handle = yield* spawner.spawn(
-          ChildProcess.make("pnpm", ["lint-fix"], {
-            env: { FORCE_COLOR: "1" },
-            extendEnv: true
-          })
-        ).pipe(
-          Effect.mapError((cause) => new DevToolsError({ cause }))
-        )
-
-        yield* handle.all.pipe(
-          Stream.decodeText(),
-          Stream.splitLines,
-          Stream.runForEach((line) => Console.log(`[lint-fix] ${line}`)),
-          Effect.mapError((cause) => new DevToolsError({ cause }))
-        )
-
-        const exitCode = yield* handle.exitCode.pipe(
-          Effect.mapError((cause) => new DevToolsError({ cause }))
-        )
-
-        if (exitCode !== ChildProcessSpawner.ExitCode(0)) {
-          return yield* new DevToolsError({
-            cause: new Error(`pnpm lint-fix failed with exit code ${exitCode}`)
-          })
-        }
-      }).pipe(
-        // `spawner.spawn` adds a `Scope` requirement to manage the lifecycle of
-        // the child process. We can use `Effect.scoped` to provide a `Scope`
-        // and close it when the effect completes.
-        Effect.scoped
-      )
-
-      return DevTools.of({
-        nodeVersion,
-        changedTypeScriptFiles,
-        recentCommitSubjects,
-        runLintFix
-      })
-    })
-  ).pipe(
-    // Provide the `ChildProcessSpawner` dependency from `NodeServices.layer`.
-    Layer.provide(NodeServices.layer)
-  )
 }
+
+/**
+ * Service key for `DevTools` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const DevTools = (() => {
+  const service = Context.Service<DevTools>("docs/DevTools")
+  return Object.assign(service, {
+    layer: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        // To run child processes, we need access to a `ChildProcessSpawner`.
+        const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+
+        // Use `spawner.string` when you want to collect the entire output of a
+        // command as a string. This runs `node --version` and collects the
+        // output.
+        const nodeVersion = spawner.string(
+          ChildProcess.make("node", ["--version"])
+        ).pipe(
+          Effect.map(String.trim),
+          Effect.mapError((cause) => new DevToolsError({ cause }))
+        )
+
+        const changedTypeScriptFiles = Effect.fn("DevTools.changedTypeScriptFiles")(function*(baseRef: string) {
+          yield* Effect.annotateCurrentSpan({ baseRef })
+
+          // `spawner.lines` is a convenience helper for line-oriented command
+          // output.
+          const files = yield* spawner.lines(
+            ChildProcess.make("git", ["diff", "--name-only", `${baseRef}...HEAD`])
+          ).pipe(
+            Effect.mapError((cause) => new DevToolsError({ cause }))
+          )
+
+          return files.filter((file) => file.endsWith(".ts"))
+        })
+
+        // Build a pipeline from two command values. This runs:
+        // `git log --pretty=format:%s -n 20 | head -n 5`
+        const recentCommitSubjects = spawner.lines(
+          ChildProcess.make("git", ["log", "--pretty=format:%s", "-n", "20"]).pipe(
+            ChildProcess.pipeTo(ChildProcess.make("head", ["-n", "5"]))
+          )
+        ).pipe(
+          Effect.mapError((cause) => new DevToolsError({ cause }))
+        )
+
+        const runLintFix = Effect.gen(function*() {
+          // Use `spawn` when you want the process handle and stream output while
+          // the process is still running.
+          const handle = yield* spawner.spawn(
+            ChildProcess.make("pnpm", ["lint-fix"], {
+              env: { FORCE_COLOR: "1" },
+              extendEnv: true
+            })
+          ).pipe(
+            Effect.mapError((cause) => new DevToolsError({ cause }))
+          )
+
+          yield* handle.all.pipe(
+            Stream.decodeText(),
+            Stream.splitLines,
+            Stream.runForEach((line) => Console.log(`[lint-fix] ${line}`)),
+            Effect.mapError((cause) => new DevToolsError({ cause }))
+          )
+
+          const exitCode = yield* handle.exitCode.pipe(
+            Effect.mapError((cause) => new DevToolsError({ cause }))
+          )
+
+          if (exitCode !== ChildProcessSpawner.ExitCode(0)) {
+            return yield* new DevToolsError({
+              cause: new Error(`pnpm lint-fix failed with exit code ${exitCode}`)
+            })
+          }
+        }).pipe(
+          // `spawner.spawn` adds a `Scope` requirement to manage the lifecycle of
+          // the child process. We can use `Effect.scoped` to provide a `Scope`
+          // and close it when the effect completes.
+          Effect.scoped
+        )
+
+        return service.of({
+          [DevToolsTypeId]: DevToolsTypeId as typeof DevToolsTypeId,
+          nodeVersion,
+          changedTypeScriptFiles,
+          recentCommitSubjects,
+          runLintFix
+        })
+      })
+    ).pipe(
+      // Provide the `ChildProcessSpawner` dependency from `NodeServices.layer`.
+      Layer.provide(NodeServices.layer)
+    )
+  })
+})()
 
 export const program = Effect.gen(function*() {
   const tools = yield* DevTools

--- a/ai-docs/src/71_ai/10_language-model.ts
+++ b/ai-docs/src/71_ai/10_language-model.ts
@@ -55,95 +55,111 @@ const DraftPlan = ExecutionPlan.make(
   }
 )
 
-export class AiWriter extends Context.Service<AiWriter, {
+const AiWriterTypeId = "~docs/AiWriter"
+
+export interface AiWriter {
+  readonly [AiWriterTypeId]: typeof AiWriterTypeId
+
   draftAnnouncement(product: string): Effect.Effect<{
     readonly provider: string
     readonly text: string
   }, AiWriterError>
   extractLaunchPlan(notes: string): Effect.Effect<LaunchPlan, AiWriterError>
   streamReleaseHighlights(version: string): Stream.Stream<string, AiWriterError>
-}>()("docs/AiWriter") {
-  static readonly layer = Layer.effect(
-    AiWriter,
-    Effect.gen(function*() {
-      // Calling `captureRequirements` on an `ExecutionPlan` will move the
-      // requirements of the plan (in this case the ai clients) into the Layer
-      // requirements.
-      const draftsModel = yield* DraftPlan.captureRequirements
+}
 
-      // Use a different model for the launch plan extraction
-      const launchPlanModel = yield* OpenAiLanguageModel.model("gpt-4.1").captureRequirements
+/**
+ * Service key for `AiWriter` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const AiWriter = (() => {
+  const service = Context.Service<AiWriter>("docs/AiWriter")
+  return Object.assign(service, {
+    layer: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        // Calling `captureRequirements` on an `ExecutionPlan` will move the
+        // requirements of the plan (in service case the ai clients) into the Layer
+        // requirements.
+        const draftsModel = yield* DraftPlan.captureRequirements
 
-      const draftAnnouncement = Effect.fn("AiWriter.draftAnnouncement")(
-        function*(product: string) {
-          const model = yield* LanguageModel.LanguageModel
-          const provider = yield* Model.ProviderName
-          const response = yield* model.generateText({
-            prompt: `Write a short launch announcement for ${product}. ` +
-              "Keep it concise and include one concrete user benefit."
-          })
+        // Use a different model for the launch plan extraction
+        const launchPlanModel = yield* OpenAiLanguageModel.model("gpt-4.1").captureRequirements
 
-          // `LanguageModel.generateText` exposes convenience fields so you can
-          // inspect usage and finish reason without parsing content parts.
-          yield* Effect.logInfo(
-            `${provider} finished with ${response.finishReason}. outputTokens=${response.usage.outputTokens.total}`
-          )
+        const draftAnnouncement = Effect.fn("AiWriter.draftAnnouncement")(
+          function*(product: string) {
+            const model = yield* LanguageModel.LanguageModel
+            const provider = yield* Model.ProviderName
+            const response = yield* model.generateText({
+              prompt: `Write a short launch announcement for ${product}. ` +
+                "Keep it concise and include one concrete user benefit."
+            })
 
-          return {
-            provider,
-            text: response.text
-          }
-        },
-        // To apply an `ExecutionPlan`, we use `Effect.withExecutionPlan`
-        Effect.withExecutionPlan(draftsModel),
-        // Map AiError into our custom error type
-        Effect.mapError((error) => AiWriterError.fromAiError(error))
-      )
+            // `LanguageModel.generateText` exposes convenience fields so you can
+            // inspect usage and finish reason without parsing content parts.
+            yield* Effect.logInfo(
+              `${provider} finished with ${response.finishReason}. outputTokens=${response.usage.outputTokens.total}`
+            )
 
-      const extractLaunchPlan = Effect.fn("AiWriter.extractLaunchPlan")(
-        function*(notes: string) {
-          const model = yield* LanguageModel.LanguageModel
-          const response = yield* model.generateObject({
-            objectName: "launch_plan",
-            prompt:
-              "Convert these notes into a launch plan object with audience, channels, launchDate, summary, and keyRisks:\n" +
-              notes,
-            // The generated object is validated and decoded through this schema.
-            schema: LaunchPlan
-          })
-
-          return response.value
-        },
-        // The .model(...) apis return a Layer that can be used with
-        // Effect.provide
-        Effect.provide(launchPlanModel),
-        // Map AiError into our custom error type
-        Effect.mapError((error) => AiWriterError.fromAiError(error))
-      )
-
-      const streamReleaseHighlights = (version: string) =>
-        LanguageModel.streamText({
-          prompt: `Write release highlights for version ${version} as a short bulleted list.`
-        }).pipe(
-          Stream.filter((part): part is Response.TextDeltaPart => part.type === "text-delta"),
-          Stream.map((part) => part.delta),
-          Stream.provide(launchPlanModel),
+            return {
+              provider,
+              text: response.text
+            }
+          },
+          // To apply an `ExecutionPlan`, we use `Effect.withExecutionPlan`
+          Effect.withExecutionPlan(draftsModel),
           // Map AiError into our custom error type
-          Stream.mapError((error) => AiWriterError.fromAiError(error))
+          Effect.mapError((error) => AiWriterError.fromAiError(error))
         )
 
-      return AiWriter.of({
-        draftAnnouncement,
-        extractLaunchPlan,
-        streamReleaseHighlights
+        const extractLaunchPlan = Effect.fn("AiWriter.extractLaunchPlan")(
+          function*(notes: string) {
+            const model = yield* LanguageModel.LanguageModel
+            const response = yield* model.generateObject({
+              objectName: "launch_plan",
+              prompt:
+                "Convert these notes into a launch plan object with audience, channels, launchDate, summary, and keyRisks:\n" +
+                notes,
+              // The generated object is validated and decoded through service schema.
+              schema: LaunchPlan
+            })
+
+            return response.value
+          },
+          // The .model(...) apis return a Layer that can be used with
+          // Effect.provide
+          Effect.provide(launchPlanModel),
+          // Map AiError into our custom error type
+          Effect.mapError((error) => AiWriterError.fromAiError(error))
+        )
+
+        const streamReleaseHighlights = (version: string) =>
+          LanguageModel.streamText({
+            prompt: `Write release highlights for version ${version} as a short bulleted list.`
+          }).pipe(
+            Stream.filter((part): part is Response.TextDeltaPart => part.type === "text-delta"),
+            Stream.map((part) => part.delta),
+            Stream.provide(launchPlanModel),
+            // Map AiError into our custom error type
+            Stream.mapError((error) => AiWriterError.fromAiError(error))
+          )
+
+        return service.of({
+          [AiWriterTypeId]: AiWriterTypeId as typeof AiWriterTypeId,
+          draftAnnouncement,
+          extractLaunchPlan,
+          streamReleaseHighlights
+        })
       })
-    })
-  ).pipe(
-    // This Layer has requirements for both the OpenAI and Anthropic clients,
-    // since the ExecutionPlan includes models from both providers.
-    Layer.provide([OpenAiClientLayer, AnthropicClientLayer])
-  )
-}
+    ).pipe(
+      // This Layer has requirements for both the OpenAI and Anthropic clients,
+      // since the ExecutionPlan includes models from both providers.
+      Layer.provide([OpenAiClientLayer, AnthropicClientLayer])
+    )
+  })
+})()
 
 // We can now use `AiWriter` like any other Effect service.
 export const program: Effect.Effect<

--- a/ai-docs/src/71_ai/20_tools.ts
+++ b/ai-docs/src/71_ai/20_tools.ts
@@ -110,86 +110,104 @@ export class ProductAssistantError extends Schema.TaggedError<ProductAssistantEr
 ) {}
 
 // Wrap tool-enabled generation in a service
-export class ProductAssistant extends Context.Service<ProductAssistant, {
+const ProductAssistantTypeId = "~docs/ProductAssistant"
+
+export interface ProductAssistant {
+  readonly [ProductAssistantTypeId]: typeof ProductAssistantTypeId
+
   answer(question: string): Effect.Effect<{
     readonly text: string
     readonly toolCallCount: number
   }, ProductAssistantError>
-}>()("docs/ProductAssistant") {
-  static readonly layer = Layer.effect(
-    ProductAssistant,
-    Effect.gen(function*() {
-      // Access the toolkit's handlers by yielding the toolkit definition.
-      const toolkit = yield* ProductToolkit
-
-      // Choose a model to use
-      const model = yield* OpenAiLanguageModel.model("gpt-5.2").captureRequirements
-
-      const answer = Effect.fn("ProductAssistant.answer")(
-        function*(question: string) {
-          // Pass the toolkit to `generateText`. The model can call any tool in
-          // the toolkit; the framework resolves parameters, invokes handlers,
-          // and feeds results back automatically.
-          const response = yield* LanguageModel.generateText({
-            prompt: question,
-            toolkit,
-            // You can set `toolChoice` to "required" to force the model to call
-            // a tool before responding with text.
-            //
-            // By default it is set to "auto"
-            toolChoice: "required"
-          })
-
-          // -------------------------------------------------------------------
-          // 5. Inspecting tool calls and results
-          // -------------------------------------------------------------------
-
-          // `response.toolCalls` lists every tool the model invoked, each with
-          // the tool name, a unique id, and the decoded parameters.
-          for (const call of response.toolCalls) {
-            yield* Effect.log(`Tool call: ${call.name} id=${call.id}`)
-          }
-
-          // `response.toolResults` lists the resolved results, each with the
-          // tool name, id, decoded result, and an `isFailure` flag.
-          for (const result of response.toolResults) {
-            yield* Effect.log(
-              `Tool result: ${result.name} id=${result.id} isFailure=${result.isFailure}`
-            )
-          }
-
-          return {
-            text: response.text,
-            toolCallCount: response.toolCalls.length
-          }
-        },
-        // Provide the chosen model to use
-        Effect.provide(model),
-        (_) => _,
-        // Map AI errors into our domain error type
-        Effect.catchTag(
-          "AiError",
-          (error) =>
-            Effect.fail(
-              new ProductAssistantError({
-                reason: error.reason
-              })
-            ),
-          // For unexpected errors, die with the original error
-          (e) => Effect.die(e)
-        )
-      )
-
-      return ProductAssistant.of({ answer })
-    })
-  ).pipe(
-    // The toolkit handler layer must be provided so the framework can invoke
-    // the tool handlers when the model makes tool calls.
-    Layer.provide(ProductToolkitLayer),
-    // Also provide the openai client required by OpenAiLanguageModel.model
-    Layer.provide(OpenAiClientLayer)
-  )
 }
+
+/**
+ * Service key for `ProductAssistant` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const ProductAssistant = (() => {
+  const service = Context.Service<ProductAssistant>("docs/ProductAssistant")
+  return Object.assign(service, {
+    layer: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        // Access the toolkit's handlers by yielding the toolkit definition.
+        const toolkit = yield* ProductToolkit
+
+        // Choose a model to use
+        const model = yield* OpenAiLanguageModel.model("gpt-5.2").captureRequirements
+
+        const answer = Effect.fn("ProductAssistant.answer")(
+          function*(question: string) {
+            // Pass the toolkit to `generateText`. The model can call any tool in
+            // the toolkit; the framework resolves parameters, invokes handlers,
+            // and feeds results back automatically.
+            const response = yield* LanguageModel.generateText({
+              prompt: question,
+              toolkit,
+              // You can set `toolChoice` to "required" to force the model to call
+              // a tool before responding with text.
+              //
+              // By default it is set to "auto"
+              toolChoice: "required"
+            })
+
+            // -------------------------------------------------------------------
+            // 5. Inspecting tool calls and results
+            // -------------------------------------------------------------------
+
+            // `response.toolCalls` lists every tool the model invoked, each with
+            // the tool name, a unique id, and the decoded parameters.
+            for (const call of response.toolCalls) {
+              yield* Effect.log(`Tool call: ${call.name} id=${call.id}`)
+            }
+
+            // `response.toolResults` lists the resolved results, each with the
+            // tool name, id, decoded result, and an `isFailure` flag.
+            for (const result of response.toolResults) {
+              yield* Effect.log(
+                `Tool result: ${result.name} id=${result.id} isFailure=${result.isFailure}`
+              )
+            }
+
+            return {
+              text: response.text,
+              toolCallCount: response.toolCalls.length
+            }
+          },
+          // Provide the chosen model to use
+          Effect.provide(model),
+          (_) => _,
+          // Map AI errors into our domain error type
+          Effect.catchTag(
+            "AiError",
+            (error) =>
+              Effect.fail(
+                new ProductAssistantError({
+                  reason: error.reason
+                })
+              ),
+            // For unexpected errors, die with the original error
+            (e) => Effect.die(e)
+          )
+        )
+
+        return service.of({
+          [ProductAssistantTypeId]: ProductAssistantTypeId as typeof ProductAssistantTypeId,
+          answer
+        })
+      })
+    ).pipe(
+      // The toolkit handler layer must be provided so the framework can invoke
+      // the tool handlers when the model makes tool calls.
+      Layer.provide(ProductToolkitLayer),
+      // Also provide the openai client required by OpenAiLanguageModel.model
+      Layer.provide(OpenAiClientLayer)
+    )
+  })
+})()
 
 // ---------------------------------------------------------------------------
 // 6. Provider-defined tools

--- a/ai-docs/src/71_ai/30_chat.ts
+++ b/ai-docs/src/71_ai/30_chat.ts
@@ -51,108 +51,124 @@ export class AiAssistantError extends Schema.TaggedError<AiAssistantError>()("Ai
   }
 }
 
-export class AiAssistant extends Context.Service<AiAssistant, {
+const AiAssistantTypeId = "~acme/AiAssistant"
+
+export interface AiAssistant {
+  readonly [AiAssistantTypeId]: typeof AiAssistantTypeId
+
   // Send a message while maintaining conversation history across turns.
   chat(message: string): Effect.Effect<string, AiAssistantError>
   // Ask a question and use an agentic loop with tool calls to answer it.
   agent(question: string): Effect.Effect<string, AiAssistantError>
-}>()("acme/AiAssistant") {
-  static readonly layer = Layer.effect(
-    AiAssistant,
-    Effect.gen(function*() {
-      // Choose the model you want to use for the chat sessions.
-      const modelLayer = yield* OpenAiLanguageModel.model("gpt-5.2").captureRequirements
+}
 
-      // ---------------------------------------------------------------------------
-      // 1. Chat.empty — basic multi-turn conversation
-      // ---------------------------------------------------------------------------
+/**
+ * Service key for `AiAssistant` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const AiAssistant = (() => {
+  const service = Context.Service<AiAssistant>("acme/AiAssistant")
+  return Object.assign(service, {
+    layer: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        // Choose the model you want to use for the chat sessions.
+        const modelLayer = yield* OpenAiLanguageModel.model("gpt-5.2").captureRequirements
 
-      // Create a new chat session with `Chat.empty` or `Chat.fromPrompt`. The
-      // session maintains conversation history automatically, so you can focus on
-      // the current turn without having to manage context.
-      const newSession = yield* Chat.fromPrompt(Prompt.empty.pipe(
-        Prompt.setSystem("You are a helpful assistant that answers questions.")
-      ))
+        // ---------------------------------------------------------------------------
+        // 1. Chat.empty — basic multi-turn conversation
+        // ---------------------------------------------------------------------------
 
-      // You can also create a chat using a json export.
-      const json = yield* newSession.exportJson
-      const session = yield* Chat.fromJson(json)
+        // Create a new chat session with `Chat.empty` or `Chat.fromPrompt`. The
+        // session maintains conversation history automatically, so you can focus on
+        // the current turn without having to manage context.
+        const newSession = yield* Chat.fromPrompt(Prompt.empty.pipe(
+          Prompt.setSystem("You are a helpful assistant that answers questions.")
+        ))
 
-      const chat = Effect.fn("AiAssistant.chat")(
-        function*(message: string) {
-          // Create a new turn in the conversation by passing the user's message
-          // to `session.generateText`.
-          const response = yield* session.generateText({ prompt: message }).pipe(
-            // Provide the model layer to use.
-            // You could potentially use different models for different turns,
-            // or even switch models in the middle of a conversation.
-            Effect.provide(modelLayer)
-          )
+        // You can also create a chat using a json export.
+        const json = yield* newSession.exportJson
+        const session = yield* Chat.fromJson(json)
 
-          // You can inspect the accumulated history at any point through the
-          // `history` ref on the chat instance.
-          const history = yield* Ref.get(session.history)
-          yield* Effect.logInfo(
-            `Conversation has ${history.content.length} messages`
-          )
-
-          return response.text
-        },
-        Effect.mapError((error) => AiAssistantError.fromAiError(error))
-      )
-
-      // ---------------------------------------------------------------------------
-      // 2. Create agentic loops with tools
-      // ---------------------------------------------------------------------------
-
-      const tools = yield* Tools
-      const agent = Effect.fn("AiAssistant.agent")(
-        function*(question: string) {
-          // We start the agent with a system prompt and the user question. The
-          // agent can then call tools in a loop until it decides to return a
-          // final answer.
-          const session = yield* Chat.fromPrompt([
-            { role: "system", content: "You are an assistant that can use tools to answer questions." },
-            { role: "user", content: question }
-          ])
-
-          while (true) {
-            const response = yield* session.generateText({
-              prompt: [], // No additional prompt — the model has full access to the conversation history
-              toolkit: tools // Provide the tools to the model
-            }).pipe(
+        const chat = Effect.fn("AiAssistant.chat")(
+          function*(message: string) {
+            // Create a new turn in the conversation by passing the user's message
+            // to `session.generateText`.
+            const response = yield* session.generateText({ prompt: message }).pipe(
               // Provide the model layer to use.
               // You could potentially use different models for different turns,
               // or even switch models in the middle of a conversation.
               Effect.provide(modelLayer)
             )
-            if (response.toolCalls.length > 0) {
-              // If the model called any tools, execute them and the Chat module
-              // will automatically add the tool results to the conversation
-              // history before the next turn.
-              continue
-            }
-            // If there are no tool calls, the model has returned a final answer
-            // and we can exit the loop.
-            return response.text
-          }
-        },
-        // Remap AI errors to our domain-specific error type, but die on
-        // unexpected errors.
-        Effect.catchTag(
-          "AiError",
-          (error) => Effect.fail(AiAssistantError.fromAiError(error)),
-          (e) => Effect.die(e)
-        )
-      )
 
-      return AiAssistant.of({
-        chat,
-        agent
+            // You can inspect the accumulated history at any point through the
+            // `history` ref on the chat instance.
+            const history = yield* Ref.get(session.history)
+            yield* Effect.logInfo(
+              `Conversation has ${history.content.length} messages`
+            )
+
+            return response.text
+          },
+          Effect.mapError((error) => AiAssistantError.fromAiError(error))
+        )
+
+        // ---------------------------------------------------------------------------
+        // 2. Create agentic loops with tools
+        // ---------------------------------------------------------------------------
+
+        const tools = yield* Tools
+        const agent = Effect.fn("AiAssistant.agent")(
+          function*(question: string) {
+            // We start the agent with a system prompt and the user question. The
+            // agent can then call tools in a loop until it decides to return a
+            // final answer.
+            const session = yield* Chat.fromPrompt([
+              { role: "system", content: "You are an assistant that can use tools to answer questions." },
+              { role: "user", content: question }
+            ])
+
+            while (true) {
+              const response = yield* session.generateText({
+                prompt: [], // No additional prompt — the model has full access to the conversation history
+                toolkit: tools // Provide the tools to the model
+              }).pipe(
+                // Provide the model layer to use.
+                // You could potentially use different models for different turns,
+                // or even switch models in the middle of a conversation.
+                Effect.provide(modelLayer)
+              )
+              if (response.toolCalls.length > 0) {
+                // If the model called any tools, execute them and the Chat module
+                // will automatically add the tool results to the conversation
+                // history before the next turn.
+                continue
+              }
+              // If there are no tool calls, the model has returned a final answer
+              // and we can exit the loop.
+              return response.text
+            }
+          },
+          // Remap AI errors to our domain-specific error type, but die on
+          // unexpected errors.
+          Effect.catchTag(
+            "AiError",
+            (error) => Effect.fail(AiAssistantError.fromAiError(error)),
+            (e) => Effect.die(e)
+          )
+        )
+
+        return service.of({
+          [AiAssistantTypeId]: AiAssistantTypeId as typeof AiAssistantTypeId,
+          chat,
+          agent
+        })
       })
-    })
-  ).pipe(
-    // Provide the OpenAI client and tools layers to the AiAssistant service.
-    Layer.provide([OpenAiClientLayer, ToolsLayer])
-  )
-}
+    ).pipe(
+      // Provide the OpenAI client and tools layers to the AiAssistant service.
+      Layer.provide([OpenAiClientLayer, ToolsLayer])
+    )
+  })
+})()

--- a/migration/annotations/effect__ai-anthropic__AnthropicClient.yaml
+++ b/migration/annotations/effect__ai-anthropic__AnthropicClient.yaml
@@ -52,3 +52,6 @@
 "@effect/ai-anthropic/AnthropicClient#ThinkingContentBlockDelta":
   replacement: "Generated.BetaThinkingContentBlockDelta"
   note: "The client-local stream schema moved to the regenerated v4 Anthropic schema surface; re-check its Type/Encoded shape."
+"@effect/ai-anthropic/AnthropicClient#AnthropicClient":
+  replacement: "@effect/ai-anthropic/AnthropicClient#AnthropicClient"
+  note: "Use the same-name AnthropicClient interface for the service value and the Context.Service constant for the key. Implementations now include the ~@effect/ai-anthropic/AnthropicClient TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__ai-openai__OpenAiClient.yaml
+++ b/migration/annotations/effect__ai-openai__OpenAiClient.yaml
@@ -160,3 +160,6 @@
 "@effect/ai-openai/OpenAiClient#SummaryPart":
   replacement: "OpenAiSchema.SummaryTextContent"
   note: "The client-local reasoning summary schema moved to the focused v4 OpenAiSchema module."
+"@effect/ai-openai/OpenAiClient#OpenAiClient":
+  replacement: "@effect/ai-openai/OpenAiClient#OpenAiClient"
+  note: "Use the same-name OpenAiClient interface for the service value and the Context.Service constant for the key. Implementations now include the ~@effect/ai-openai/OpenAiClient TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__ai-openrouter__OpenRouterClient.yaml
+++ b/migration/annotations/effect__ai-openrouter__OpenRouterClient.yaml
@@ -13,3 +13,6 @@
 "@effect/ai-openrouter/OpenRouterClient#Service":
   replacement: "OpenRouterClient.Service"
   note: "Still exported in v4; adapt to the regenerated client, revised request and response schemas, and the new streaming result tuple."
+"@effect/ai-openrouter/OpenRouterClient#OpenRouterClient":
+  replacement: "@effect/ai-openrouter/OpenRouterClient#OpenRouterClient"
+  note: "Use the same-name OpenRouterClient interface for the service value and the Context.Service constant for the key. Implementations now include the ~@effect/ai-openrouter/OpenRouterClient TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__ai__Chat.yaml
+++ b/migration/annotations/effect__ai__Chat.yaml
@@ -1,0 +1,6 @@
+"@effect/ai/Chat#Chat":
+  replacement: "effect/unstable/ai/Chat#Chat"
+  note: "Use the same-name Chat interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/ai/Chat TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."
+"@effect/ai/Chat#Persistence":
+  replacement: "effect/unstable/ai/Chat#Persistence"
+  note: "Use the same-name Persistence interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/ai/Chat/Persisted TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__ai__EmbeddingModel.yaml
+++ b/migration/annotations/effect__ai__EmbeddingModel.yaml
@@ -1,3 +1,6 @@
 "@effect/ai/EmbeddingModel#makeDataLoader":
   replacement: "EmbeddingModel.make + RequestResolver.setDelay + RequestResolver.batchN"
   note: "The dedicated data-loader constructor was removed. EmbeddingModel.make batches concurrent embed requests through its resolver; compose the exposed resolver with setDelay and optional batchN for the old window and maximum-batch behavior."
+"@effect/ai/EmbeddingModel#EmbeddingModel":
+  replacement: "effect/unstable/ai/EmbeddingModel#EmbeddingModel"
+  note: "Use the same-name EmbeddingModel interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/unstable/ai/EmbeddingModel TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__ai__IdGenerator.yaml
+++ b/migration/annotations/effect__ai__IdGenerator.yaml
@@ -1,3 +1,6 @@
 "@effect/ai/IdGenerator#make":
   replacement: "IdGenerator.make"
   note: "Moved to effect/unstable/ai/IdGenerator with the same configurable alphabet, prefix, separator, and size behavior. Invalid configuration now fails with Cause.IllegalArgumentError."
+"@effect/ai/IdGenerator#IdGenerator":
+  replacement: "effect/unstable/ai/IdGenerator#IdGenerator"
+  note: "Use the same-name IdGenerator interface for the service value and the Context.Service constant for the key. Implementations now include the ~@effect/ai/IdGenerator TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__ai__LanguageModel.yaml
+++ b/migration/annotations/effect__ai__LanguageModel.yaml
@@ -4,3 +4,9 @@
 "@effect/ai/LanguageModel#ExtractContext":
   replacement: "LanguageModel.ExtractServices"
   note: "Renamed in effect/unstable/ai/LanguageModel. ExtractServices infers toolkit handler, result-decoding, and effectful-toolkit service requirements."
+"@effect/ai/LanguageModel#LanguageModel":
+  replacement: "effect/unstable/ai/LanguageModel#LanguageModel"
+  note: "Use the same-name LanguageModel interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/unstable/ai/LanguageModel TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."
+"@effect/ai/LanguageModel#Service":
+  replacement: "effect/unstable/ai/LanguageModel#Service"
+  note: "The retained Service interface now includes the ~effect/unstable/ai/LanguageModel TypeId. Prefer LanguageModel for service annotations and LanguageModel.make for provider implementations."

--- a/migration/annotations/effect__ai__McpSchema.yaml
+++ b/migration/annotations/effect__ai__McpSchema.yaml
@@ -25,3 +25,6 @@
 "@effect/ai/McpSchema#SuccessEncoded":
   replacement: "McpSchema.SuccessEncoded"
   note: "Moved to effect/unstable/ai/McpSchema and still derives an encoded JSON-RPC success union from an RpcGroup."
+"@effect/ai/McpSchema#McpServerClient":
+  replacement: "effect/unstable/ai/McpSchema#McpServerClient"
+  note: "Use the same-name McpServerClient interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/ai/McpSchema/McpServerClient TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__ai__McpServer.yaml
+++ b/migration/annotations/effect__ai__McpServer.yaml
@@ -13,3 +13,6 @@
 "@effect/ai/McpServer#run":
   replacement: "McpServer.run"
   note: "Moved to effect/unstable/ai/McpServer. Pass a non-empty protocols array of adapters, such as [McpProtocol.v2025_06_18], imported with McpProtocol from effect/unstable/ai; it remains the Effect-level runner over RpcServer.Protocol."
+"@effect/ai/McpServer#McpServer":
+  replacement: "effect/unstable/ai/McpServer#McpServer"
+  note: "Use the same-name McpServer interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/ai/McpServer TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__ai__Tokenizer.yaml
+++ b/migration/annotations/effect__ai__Tokenizer.yaml
@@ -1,0 +1,3 @@
+"@effect/ai/Tokenizer#Tokenizer":
+  replacement: "effect/unstable/ai/Tokenizer#Tokenizer"
+  note: "Use the same-name Tokenizer interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/ai/Tokenizer TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__cluster__MessageStorage.yaml
+++ b/migration/annotations/effect__cluster__MessageStorage.yaml
@@ -6,10 +6,16 @@
   note: "Moved into core Effect with the same dependency-free no-op implementation."
 "@effect/cluster/MessageStorage#make":
   replacement: "effect/unstable/cluster/MessageStorage#make"
-  note: "Moved into core Effect. Context service projections now use the Service property instead of Type. Custom service implementations must also provide resetAddresses for batched mailbox resets."
+  note: "Moved into core Effect. Use the same-name service interfaces instead of Context service type projections. Custom service implementations must also provide resetAddresses for batched mailbox resets."
 "@effect/cluster/MessageStorage#makeEncoded":
   replacement: "effect/unstable/cluster/MessageStorage#makeEncoded"
   note: "Moved into core Effect. Custom encoded drivers must replace resetAddress with resetAddresses and may use the new limit and addresses options passed to unprocessedMessages."
 "@effect/cluster/MessageStorage#Encoded":
   replacement: "effect/unstable/cluster/MessageStorage#Encoded"
   note: "Moved into core Effect; use the v4 Envelope.Encoded and Reply.Encoded aliases. Custom drivers now implement batched resetAddresses, and unprocessedMessages receives optional limit and address filters."
+"@effect/cluster/MessageStorage#MemoryDriver":
+  replacement: "effect/unstable/cluster/MessageStorage#MemoryDriver"
+  note: "Use the same-name MemoryDriver interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/cluster/MessageStorage/MemoryDriver TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."
+"@effect/cluster/MessageStorage#MessageStorage":
+  replacement: "effect/unstable/cluster/MessageStorage#MessageStorage"
+  note: "Use the same-name MessageStorage interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/cluster/MessageStorage TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__cluster__RunnerHealth.yaml
+++ b/migration/annotations/effect__cluster__RunnerHealth.yaml
@@ -1,3 +1,6 @@
 "@effect/cluster/RunnerHealth#layerNoop":
   replacement: "effect/unstable/cluster/RunnerHealth#layerNoop"
   note: "Moved into core Effect with the same dependency-free health implementation."
+"@effect/cluster/RunnerHealth#RunnerHealth":
+  replacement: "effect/unstable/cluster/RunnerHealth#RunnerHealth"
+  note: "Use the same-name RunnerHealth interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/cluster/RunnerHealth TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__cluster__RunnerStorage.yaml
+++ b/migration/annotations/effect__cluster__RunnerStorage.yaml
@@ -4,3 +4,6 @@
 "@effect/cluster/RunnerStorage#makeMemory":
   replacement: "effect/unstable/cluster/RunnerStorage#makeMemory"
   note: "Moved into core Effect; it still constructs the in-memory RunnerStorage service implementation."
+"@effect/cluster/RunnerStorage#RunnerStorage":
+  replacement: "effect/unstable/cluster/RunnerStorage#RunnerStorage"
+  note: "Use the same-name RunnerStorage interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/cluster/RunnerStorage TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__cluster__Runners.yaml
+++ b/migration/annotations/effect__cluster__Runners.yaml
@@ -3,7 +3,13 @@
   note: "Moved into core Effect with the same no-op runner communication layer."
 "@effect/cluster/Runners#make":
   replacement: "effect/unstable/cluster/Runners#make"
-  note: "Moved into core Effect. Its options now require codecFor; pass the codec used by the remote runner transport, such as RpcSerialization.json.codecFor for JSON. Context service projections now use Service instead of Type."
+  note: "Moved into core Effect. Its options now require codecFor; pass the codec used by the remote runner transport, such as RpcSerialization.json.codecFor for JSON. Use the same-name service interfaces instead of Context service type projections."
 "@effect/cluster/Runners#makeNoop":
   replacement: "effect/unstable/cluster/Runners#makeNoop"
   note: "Moved into core Effect; it returns the Context.Service implementation as a directly nameable interface instead of the old Type projection."
+"@effect/cluster/Runners#RpcClientProtocol":
+  replacement: "effect/unstable/cluster/Runners#RpcClientProtocol"
+  note: "Use the same-name RpcClientProtocol interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/cluster/Runners/RpcClientProtocol TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."
+"@effect/cluster/Runners#Runners":
+  replacement: "effect/unstable/cluster/Runners#Runners"
+  note: "Use the same-name Runners interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/cluster/Runners TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__cluster__Runners.yaml
+++ b/migration/annotations/effect__cluster__Runners.yaml
@@ -6,4 +6,4 @@
   note: "Moved into core Effect. Its options now require codecFor; pass the codec used by the remote runner transport, such as RpcSerialization.json.codecFor for JSON. Context service projections now use Service instead of Type."
 "@effect/cluster/Runners#makeNoop":
   replacement: "effect/unstable/cluster/Runners#makeNoop"
-  note: "Moved into core Effect; it returns the Context.Service implementation through the Service projection instead of Type."
+  note: "Moved into core Effect; it returns the Context.Service implementation as a directly nameable interface instead of the old Type projection."

--- a/migration/annotations/effect__cluster__Sharding.yaml
+++ b/migration/annotations/effect__cluster__Sharding.yaml
@@ -1,3 +1,6 @@
 "@effect/cluster/Sharding#layer":
   replacement: "effect/unstable/cluster/Sharding#layer"
   note: "Moved into core Effect with the same main sharding runtime composition and public service requirements."
+"@effect/cluster/Sharding#Sharding":
+  replacement: "effect/unstable/cluster/Sharding#Sharding"
+  note: "Use the same-name Sharding interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/cluster/Sharding TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__cluster__ShardingConfig.yaml
+++ b/migration/annotations/effect__cluster__ShardingConfig.yaml
@@ -1,9 +1,12 @@
 "@effect/cluster/ShardingConfig#config":
   replacement: "effect/unstable/cluster/ShardingConfig#config"
-  note: "Moved into core Effect; its Context service value type now uses the Service property instead of Type."
+  note: "Moved into core Effect; use the ShardingConfig interface for the service value type."
 "@effect/cluster/ShardingConfig#defaults":
   replacement: "effect/unstable/cluster/ShardingConfig#defaults"
-  note: "Moved into core Effect; service type projections now use Service instead of Type. V4 also defaults maxResidentEntities to 10,000 and unprocessedMessageBatchSize to 1,024."
+  note: "Moved into core Effect; use the ShardingConfig interface for service value types. V4 also defaults maxResidentEntities to 10,000 and unprocessedMessageBatchSize to 1,024."
 "@effect/cluster/ShardingConfig#layer":
   replacement: "effect/unstable/cluster/ShardingConfig#layer"
-  note: "Moved into core Effect with the same shallow default merge; service type projections now use Service instead of Type."
+  note: "Moved into core Effect with the same shallow default merge; use the ShardingConfig interface for service value types."
+"@effect/cluster/ShardingConfig#ShardingConfig":
+  replacement: "effect/unstable/cluster/ShardingConfig#ShardingConfig"
+  note: "Use the same-name ShardingConfig interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/cluster/ShardingConfig TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__cluster__Snowflake.yaml
+++ b/migration/annotations/effect__cluster__Snowflake.yaml
@@ -7,3 +7,6 @@
 "@effect/cluster/Snowflake#TypeId":
   replacement: "effect/unstable/cluster/Snowflake#TypeId"
   note: "Moved into core Effect; the public marker is now the string literal ~effect/cluster/Snowflake."
+"@effect/cluster/Snowflake#Snowflake.Generator":
+  replacement: "effect/unstable/cluster/Snowflake#Snowflake.Generator"
+  note: "The generator shape now includes the ~effect/cluster/Snowflake/Generator TypeId. Use the module make constructor and the top-level Generator interface and service key."

--- a/migration/annotations/effect__experimental__DevTools__Client.yaml
+++ b/migration/annotations/effect__experimental__DevTools__Client.yaml
@@ -1,8 +1,8 @@
 "@effect/experimental/DevTools/Client#Client":
   replacement: effect/unstable/devtools/DevToolsClient#DevToolsClient
-  note: Client was renamed to the DevToolsClient Context.Service class.
+  note: Client was renamed to the DevToolsClient Context.Service value and same-name interface.
 "@effect/experimental/DevTools/Client#ClientImpl":
-  replacement: effect/unstable/devtools/DevToolsClient#DevToolsClient["Service"]
+  replacement: effect/unstable/devtools/DevToolsClient#DevToolsClient
   note: Use the service shape from DevToolsClient; unsafeAddSpan was replaced by sendUnsafe.
 "@effect/experimental/DevTools/Client#layer":
   replacement: effect/unstable/devtools/DevToolsClient#layer

--- a/migration/annotations/effect__experimental__EventJournal.yaml
+++ b/migration/annotations/effect__experimental__EventJournal.yaml
@@ -15,4 +15,4 @@
   note: Import RemoteIdTypeId from the v4 EventJournal module; it is now a string brand.
 "@effect/experimental/EventJournal#makeMemory":
   replacement: effect/unstable/eventlog/EventJournal#makeMemory
-  note: The in-memory constructor moved into core Effect and now returns the Context.Service implementation through its Service projection.
+  note: The in-memory constructor moved into core Effect and now returns the Context.Service implementation as a directly nameable interface.

--- a/migration/annotations/effect__experimental__EventJournal.yaml
+++ b/migration/annotations/effect__experimental__EventJournal.yaml
@@ -16,3 +16,6 @@
 "@effect/experimental/EventJournal#makeMemory":
   replacement: effect/unstable/eventlog/EventJournal#makeMemory
   note: The in-memory constructor moved into core Effect and now returns the Context.Service implementation as a directly nameable interface.
+"@effect/experimental/EventJournal#EventJournal":
+  replacement: "effect/unstable/eventlog/EventJournal#EventJournal"
+  note: "Use the same-name EventJournal interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/eventlog/EventJournal TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__experimental__EventLog.yaml
+++ b/migration/annotations/effect__experimental__EventLog.yaml
@@ -25,3 +25,12 @@
 "@effect/experimental/EventLog#SchemaTypeId":
   replacement: effect/unstable/eventlog/EventLog#SchemaTypeId
   note: Import SchemaTypeId from the v4 EventLog module.
+"@effect/experimental/EventLog#EventLog":
+  replacement: "effect/unstable/eventlog/EventLog#EventLog"
+  note: "Use the same-name EventLog interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/eventlog/EventLog TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."
+"@effect/experimental/EventLog#Identity":
+  replacement: "effect/unstable/eventlog/EventLog#Identity"
+  note: "Use the same-name Identity interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/eventlog/EventLog/Identity TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."
+"@effect/experimental/EventLog#Registry":
+  replacement: "effect/unstable/eventlog/EventLog#Registry"
+  note: "Use the same-name Registry interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/unstable/eventlog/EventLog/Registry TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__experimental__EventLogEncryption.yaml
+++ b/migration/annotations/effect__experimental__EventLogEncryption.yaml
@@ -1,0 +1,3 @@
+"@effect/experimental/EventLogEncryption#EventLogEncryption":
+  replacement: "effect/unstable/eventlog/EventLogEncryption#EventLogEncryption"
+  note: "Use the same-name EventLogEncryption interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/eventlog/EventLogEncryption TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__experimental__PersistedQueue.yaml
+++ b/migration/annotations/effect__experimental__PersistedQueue.yaml
@@ -13,3 +13,9 @@
 "@effect/experimental/PersistedQueue#TypeId":
   replacement: effect/unstable/persistence/PersistedQueue#TypeId
   note: Import TypeId from the v4 unstable PersistedQueue module; it is now a string brand.
+"@effect/experimental/PersistedQueue#PersistedQueueFactory":
+  replacement: "effect/unstable/persistence/PersistedQueue#PersistedQueueFactory"
+  note: "Use the same-name PersistedQueueFactory interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/persistence/PersistedQueue/PersistedQueueFactory TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."
+"@effect/experimental/PersistedQueue#PersistedQueueStore":
+  replacement: "effect/unstable/persistence/PersistedQueue#PersistedQueueStore"
+  note: "Use the same-name PersistedQueueStore interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/persistence/PersistedQueue/PersistedQueueStore TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__experimental__Persistence.yaml
+++ b/migration/annotations/effect__experimental__Persistence.yaml
@@ -1,6 +1,6 @@
 "@effect/experimental/Persistence#BackingPersistence":
   replacement: effect/unstable/persistence/Persistence#BackingPersistence
-  note: Use the v4 BackingPersistence Context.Service class.
+  note: Use the v4 BackingPersistence Context.Service value and same-name interface.
 "@effect/experimental/Persistence#BackingPersistenceTypeId":
   replacement: none
   note: The BackingPersistence brand is no longer publicly exported in v4.
@@ -33,7 +33,7 @@
   note: Persistence parsing failures now use the core SchemaError type.
 "@effect/experimental/Persistence#ResultPersistence":
   replacement: effect/unstable/persistence/Persistence#Persistence
-  note: ResultPersistence was renamed to Persistence and is now a Context.Service class.
+  note: ResultPersistence was renamed to Persistence and is now a Context.Service value and same-name interface.
 "@effect/experimental/Persistence#ResultPersistence.Key":
   replacement: effect/unstable/persistence/Persistable#Persistable
   note: Persistable is the v4 schema-backed persistence key contract.

--- a/migration/annotations/effect__experimental__RateLimiter.yaml
+++ b/migration/annotations/effect__experimental__RateLimiter.yaml
@@ -18,4 +18,4 @@
   note: Import TypeId from the v4 unstable RateLimiter module; it is now a string brand.
 "@effect/experimental/RateLimiter#RateLimiterStore":
   replacement: RateLimiter.RateLimiterStore
-  note: "Use the Context.Service class from effect/unstable/persistence/RateLimiter. Custom tokenBucket implementations must return [remaining, elapsedMillis] instead of a number, preserving fractional counts and elapsed refill time."
+  note: "Use the Context.Service value and same-name interface from effect/unstable/persistence/RateLimiter. Custom tokenBucket implementations must return [remaining, elapsedMillis] instead of a number, preserving fractional counts and elapsed refill time."

--- a/migration/annotations/effect__experimental__Reactivity.yaml
+++ b/migration/annotations/effect__experimental__Reactivity.yaml
@@ -8,8 +8,8 @@
   replacement: effect/unstable/reactivity/Reactivity#Reactivity
   note: Use the v4 Reactivity Context.Service; unsafe methods were renamed with an Unsafe suffix.
 "@effect/experimental/Reactivity#Reactivity.Service":
-  replacement: effect/unstable/reactivity/Reactivity#Reactivity["Service"]
-  note: The named namespace member was removed; derive the service shape from the Context.Service class.
+  replacement: effect/unstable/reactivity/Reactivity#Reactivity
+  note: The named namespace member was removed; use the directly exported Reactivity interface.
 "@effect/experimental/Reactivity#stream":
   replacement: effect/unstable/reactivity/Reactivity#stream
   note: Import stream from the v4 unstable Reactivity module.

--- a/migration/annotations/effect__opentelemetry__OtlpSerialization.yaml
+++ b/migration/annotations/effect__opentelemetry__OtlpSerialization.yaml
@@ -1,0 +1,3 @@
+"@effect/opentelemetry/OtlpSerialization#OtlpSerialization":
+  replacement: "effect/unstable/observability/OtlpSerialization#OtlpSerialization"
+  note: "Use the same-name OtlpSerialization interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/observability/OtlpSerialization TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__platform-node__NodeHttpClient.yaml
+++ b/migration/annotations/effect__platform-node__NodeHttpClient.yaml
@@ -9,10 +9,10 @@
   note: "Direct rename; the layer owns and finalizes a scoped Undici Agent."
 "@effect/platform-node/NodeHttpClient#HttpAgent":
   replacement: "NodeHttpClient.HttpAgent"
-  note: "The identifier remains but is now a Context.Service class; use HttpAgent[\"Service\"] for the concrete http/https agent pair."
+  note: "Use the same-name HttpAgent interface and Context.Service value for the concrete http/https agent pair."
 "@effect/platform-node/NodeHttpClient#HttpAgentTypeId":
   replacement: "none"
-  note: "The public marker was removed; the HttpAgent Context.Service class supplies service identity."
+  note: "The public marker was removed; HttpAgent implementations now include a private TypeId."
 "@effect/platform-node/NodeHttpClient#layer":
   replacement: "NodeHttpClient.layerNodeHttp"
   note: "Use the renamed node:http/node:https backend layer; choose layerUndici only when intentionally changing backends."

--- a/migration/annotations/effect__platform__CommandExecutor.yaml
+++ b/migration/annotations/effect__platform__CommandExecutor.yaml
@@ -15,4 +15,4 @@
   note: "The ChildProcessHandle marker is internal in v4; use the ChildProcessHandle interface."
 "@effect/platform/CommandExecutor#TypeId":
   replacement: "none"
-  note: "The Context.Service class replaces the public executor type-id alias."
+  note: "The Context.Service value and same-name interface replaces the public executor type-id alias."

--- a/migration/annotations/effect__platform__Etag.yaml
+++ b/migration/annotations/effect__platform__Etag.yaml
@@ -1,6 +1,6 @@
 "@effect/platform/Etag#GeneratorTypeId":
   replacement: "Etag.Generator"
-  note: "The standalone generator brand was removed; Generator is now a Context.Service class."
+  note: "The standalone generator brand was removed; Generator is now a Context.Service value and same-name interface."
 "@effect/platform/Etag#layer":
   replacement: "Etag.layer"
   note: "Retained; it still provides the strong metadata-based ETag Generator service."

--- a/migration/annotations/effect__platform__Etag.yaml
+++ b/migration/annotations/effect__platform__Etag.yaml
@@ -7,3 +7,6 @@
 "@effect/platform/Etag#toString":
   replacement: "Etag.toString"
   note: "Retained with the same Etag-to-header-string behavior and signature."
+"@effect/platform/Etag#Generator":
+  replacement: "effect/unstable/http/Etag#Generator"
+  note: "Use the same-name Generator interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/http/Etag/Generator TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__platform__FileSystem.yaml
+++ b/migration/annotations/effect__platform__FileSystem.yaml
@@ -88,3 +88,6 @@
 "@effect/platform/FileSystem#WriteFileStringOptions":
   replacement: "NonNullable<Parameters<FileSystem.FileSystem[\"writeFileString\"]>[2]>"
   note: "Operation option interfaces are inline in the v4 FileSystem service."
+"@effect/platform/FileSystem#WatchBackend":
+  replacement: "effect/FileSystem#WatchBackend"
+  note: "Use the same-name WatchBackend interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/FileSystem/WatchBackend TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__platform__HttpPlatform.yaml
+++ b/migration/annotations/effect__platform__HttpPlatform.yaml
@@ -1,6 +1,6 @@
 "@effect/platform/HttpPlatform#HttpPlatform":
   replacement: "HttpPlatform.HttpPlatform"
-  note: "The service is now a Context.Service class; use its Service member for the implementation type. Path-backed offset and bytesToRead accept ByteSize.Input, while chunkSize and all Web File range options use number."
+  note: "The service is now a Context.Service value and same-name interface; use its Service member for the implementation type. Path-backed offset and bytesToRead accept ByteSize.Input, while chunkSize and all Web File range options use number."
 "@effect/platform/HttpPlatform#layer":
   replacement: "HttpPlatform.layer"
   note: "Retained as the default file-response layer."
@@ -9,4 +9,4 @@
   note: "Retained; v4 returns the service implementation. The fileResponse callback receives contentLength as bigint, while start and end remain numbers. Web File range options use number."
 "@effect/platform/HttpPlatform#TypeId":
   replacement: "none"
-  note: "The public type id was removed; use the HttpPlatform Context.Service class."
+  note: "The public type id was removed; use the HttpPlatform Context.Service value and same-name interface."

--- a/migration/annotations/effect__platform__HttpServer.yaml
+++ b/migration/annotations/effect__platform__HttpServer.yaml
@@ -6,7 +6,7 @@
   note: "The accessor was removed; read the service and pass its Address to the callback."
 "@effect/platform/HttpServer#HttpServer":
   replacement: "HttpServer.HttpServer"
-  note: "The interface and tag became one Context.Service class; use its Service member for implementations."
+  note: "The interface and tag became one Context.Service value and same-name interface; use the same-name interface for implementations."
 "@effect/platform/HttpServer#layerContext":
   replacement: "HttpServer.layerServices"
   note: "Renamed; it provides the standard HTTP platform services."
@@ -21,7 +21,7 @@
   note: "Replaced by the shared resolved internet-address model; use address and port instead of hostname and port."
 "@effect/platform/HttpServer#TypeId":
   replacement: "none"
-  note: "The public TypeId was removed; HttpServer is now a Context.Service class."
+  note: "The public TypeId was removed; HttpServer is now a Context.Service value and same-name interface."
 "@effect/platform/HttpServer#UnixAddress":
   replacement: "effect/unstable/net/NetAddress#UnixPathAddress"
   note: "Replaced by the shared Unix filesystem-path address model."

--- a/migration/annotations/effect__platform__SocketServer.yaml
+++ b/migration/annotations/effect__platform__SocketServer.yaml
@@ -10,3 +10,6 @@
 "@effect/platform/SocketServer#UnixAddress":
   replacement: "effect/unstable/net/NetAddress#UnixPathAddress"
   note: "Replaced by the shared Unix filesystem-path address model."
+"@effect/platform/SocketServer#SocketServer":
+  replacement: "effect/unstable/socket/SocketServer#SocketServer"
+  note: "Use the same-name SocketServer interface for the service value and the Context.Service constant for the key. Implementations now include the ~@effect/platform/SocketServer TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__platform__Transferable.yaml
+++ b/migration/annotations/effect__platform__Transferable.yaml
@@ -1,6 +1,6 @@
 "@effect/platform/Transferable#CollectorService":
   replacement: "Transferable.Collector[\"Service\"]"
-  note: "The collector interface is now the service type of the Transferable.Collector Context.Service class."
+  note: "The collector interface is now the service type of the Transferable.Collector Context.Service value and same-name interface."
 "@effect/platform/Transferable#schema":
   replacement: "Transferable.schema"
   note: "The schema wrapper moved to effect/unstable/workers/Transferable and uses the v4 Schema model."

--- a/migration/annotations/effect__platform__Transferable.yaml
+++ b/migration/annotations/effect__platform__Transferable.yaml
@@ -1,5 +1,5 @@
 "@effect/platform/Transferable#CollectorService":
-  replacement: "Transferable.Collector[\"Service\"]"
+  replacement: "Transferable.Collector"
   note: "The collector interface is now the service type of the Transferable.Collector Context.Service value and same-name interface."
 "@effect/platform/Transferable#schema":
   replacement: "Transferable.schema"
@@ -10,3 +10,6 @@
 "@effect/platform/Transferable#unsafeMakeCollector":
   replacement: "Transferable.makeCollectorUnsafe"
   note: "The unsafe collector constructor was renamed."
+"@effect/platform/Transferable#Collector":
+  replacement: "effect/unstable/workers/Transferable#Collector"
+  note: "Use the same-name Collector interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/workers/Transferable/Collector TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__platform__Worker.yaml
+++ b/migration/annotations/effect__platform__Worker.yaml
@@ -24,10 +24,10 @@
   note: "Serialized tagged-request execution moved to the v4 RPC model; define an RpcGroup and use the worker protocol."
 "@effect/platform/Worker#PlatformWorker":
   replacement: "Worker.WorkerPlatform"
-  note: "The platform service was renamed and is now a Context.Service class."
+  note: "The platform service was renamed and is now a Context.Service value and same-name interface."
 "@effect/platform/Worker#PlatformWorkerTypeId":
   replacement: "none"
-  note: "The Context.Service class replaces the public platform-worker type-id alias."
+  note: "The Context.Service value and same-name interface replaces the public platform-worker type-id alias."
 "@effect/platform/Worker#SerializedWorker":
   replacement: "RpcClient with RpcClient.layerProtocolWorker"
   note: "The serialized worker facade was removed; v4 routes schema-defined RPCs through the worker protocol."
@@ -57,7 +57,7 @@
   note: "WorkerPlatform now spawns low-level Worker values directly, replacing WorkerManager."
 "@effect/platform/Worker#WorkerManagerTypeId":
   replacement: "none"
-  note: "The removed WorkerManager has no v4 type-id; WorkerPlatform is a Context.Service class."
+  note: "The removed WorkerManager has no v4 type-id; WorkerPlatform is a Context.Service value and same-name interface."
 "@effect/platform/Worker#WorkerPool":
   replacement: "RpcClient.Protocol"
   note: "For serialized request/response workloads use the worker-backed RPC Protocol; for raw messages build a Pool around WorkerPlatform.spawn."

--- a/migration/annotations/effect__platform__WorkerRunner.yaml
+++ b/migration/annotations/effect__platform__WorkerRunner.yaml
@@ -27,10 +27,10 @@
   note: "Serialized tagged-request execution moved to RpcServer with an RpcGroup handler layer."
 "@effect/platform/WorkerRunner#PlatformRunner":
   replacement: "WorkerRunner.WorkerRunnerPlatform"
-  note: "The platform service was renamed and is now a Context.Service class."
+  note: "The platform service was renamed and is now a Context.Service value and same-name interface."
 "@effect/platform/WorkerRunner#PlatformRunnerTypeId":
   replacement: "none"
-  note: "The Context.Service class replaces the public platform-runner type-id alias."
+  note: "The Context.Service value and same-name interface replaces the public platform-runner type-id alias."
 "@effect/platform/WorkerRunner#Runner":
   replacement: "WorkerRunner.WorkerRunner"
   note: "The namespace-only runner API was replaced by the low-level WorkerRunner interface."

--- a/migration/annotations/effect__rpc__RpcSerialization.yaml
+++ b/migration/annotations/effect__rpc__RpcSerialization.yaml
@@ -13,3 +13,6 @@
 "@effect/rpc/RpcSerialization#msgPack":
   replacement: "effect/unstable/rpc/RpcSerialization#layerSchemaBinary"
   note: "The MessagePack RpcSerialization service value was removed. Provide layerSchemaBinary instead."
+"@effect/rpc/RpcSerialization#RpcSerialization":
+  replacement: "effect/unstable/rpc/RpcSerialization#RpcSerialization"
+  note: "Use the same-name RpcSerialization interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/rpc/RpcSerialization TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/annotations/effect__workflow__WorkflowEngine.yaml
+++ b/migration/annotations/effect__workflow__WorkflowEngine.yaml
@@ -3,4 +3,10 @@
   note: "Moved into core Effect and remains the non-durable engine for tests and local development."
 "@effect/workflow/WorkflowEngine#makeUnsafe":
   replacement: "effect/unstable/workflow/WorkflowEngine#makeUnsafe"
-  note: "Moved into core Effect. Context service projections now use Service instead of Type, and absent encoded results use Option."
+  note: "Moved into core Effect. Use the same-name service interfaces instead of Context service type projections, and absent encoded results use Option."
+"@effect/workflow/WorkflowEngine#WorkflowEngine":
+  replacement: "effect/unstable/workflow/WorkflowEngine#WorkflowEngine"
+  note: "Use the same-name WorkflowEngine interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/workflow/WorkflowEngine TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."
+"@effect/workflow/WorkflowEngine#WorkflowInstance":
+  replacement: "effect/unstable/workflow/WorkflowEngine#WorkflowInstance"
+  note: "Use the same-name WorkflowInstance interface for the service value and the Context.Service constant for the key. Implementations now include the ~effect/workflow/WorkflowEngine/WorkflowInstance TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration."

--- a/migration/layer-memoization.md
+++ b/migration/layer-memoization.md
@@ -15,13 +15,20 @@ deduplicated across `Effect.provide` calls.
 ```ts
 import { Console, Context, Effect, Layer } from "effect"
 
-const MyService = Context.Service<{ readonly value: string }>("MyService")
+interface MyService {
+  readonly ["~MyService"]: "~MyService"
+  readonly value: string
+}
+const MyService = Context.Service<MyService>("MyService")
 
 const MyServiceLayer = Layer.effect(
   MyService,
   Effect.gen(function*() {
     yield* Console.log("Building MyService")
-    return { value: "hello" }
+    return {
+      ["~MyService"]: "~MyService" as const,
+      value: "hello"
+    }
   })
 )
 

--- a/migration/runtime.md
+++ b/migration/runtime.md
@@ -56,9 +56,12 @@ In v4, use the same pattern with `Effect.context<R>()`, then run with
 ```ts
 import { Context, Effect } from "effect"
 
-class Logger extends Context.Service<Logger, {
+interface Logger {
+  readonly ["~Logger"]: "~Logger"
+
   readonly log: (message: string) => void
-}>()("Logger") {}
+}
+const Logger = Context.Service<Logger>("Logger")
 
 const program = Effect.gen(function*() {
   const logger = yield* Logger
@@ -70,6 +73,7 @@ const main = Effect.gen(function*() {
   return Effect.runForkWith(services)(program)
 }).pipe(
   Effect.provideContext(Context.make(Logger, {
+    ["~Logger"]: "~Logger" as const,
     log: (message) => console.log(message)
   }))
 )

--- a/migration/services.md
+++ b/migration/services.md
@@ -26,14 +26,19 @@ const Database = Context.GenericTag<Database>("Database")
 ```ts
 import { Context } from "effect"
 
-interface Database {
+export interface Database {
+  readonly ["~Database"]: "~Database"
   readonly query: (sql: string) => string
 }
 
-const Database = Context.Service<Database>("Database")
+export const Database = Context.Service<Database>("Database")
 ```
 
-## Class-Based Services
+Use the same name for the interface and service value. The interface names both
+the implementation and its context requirement; no `["Service"]` projection is
+needed. Implementations include the service-specific TypeId.
+
+## Supported class constructor syntax
 
 **v3: `Context.Tag` class syntax**
 
@@ -44,6 +49,8 @@ class Database extends Context.Tag("Database")<Database, {
   readonly query: (sql: string) => string
 }>() {}
 ```
+
+The class constructor remains supported, including tests that exercise this API.
 
 **v4: `Context.Service` class syntax**
 
@@ -99,9 +106,12 @@ const program = Notifications.notify("hello")
 ```ts
 import { Context, Effect } from "effect"
 
-class Notifications extends Context.Service<Notifications, {
+interface Notifications {
+  readonly ["~Notifications"]: "~Notifications"
+
   readonly notify: (message: string) => Effect.Effect<void>
-}>()("Notifications") {}
+}
+const Notifications = Context.Service<Notifications>("Notifications")
 
 // use: access the service and call a method in one step
 const program = Notifications.use((n) => n.notify("hello"))
@@ -170,25 +180,34 @@ const program = Effect.gen(function*() {
 
 **v4**
 
-In v4, `Context.Service` with `make` stores the constructor effect on the
-class but does **not** auto-generate a layer. Define layers explicitly using
-`Layer.effect`:
+In v4, define the service interface and value together, then export the constructor
+and layer explicitly:
 
 ```ts
 import { Context, Effect, Layer } from "effect"
 
-class Logger extends Context.Service<Logger>()("Logger", {
-  make: Effect.gen(function*() {
-    const config = yield* Config
-    return { log: (msg: string) => Effect.log(`[${config.prefix}] ${msg}`) }
-  })
-}) {
-  // Build the layer yourself from the make effect
-  static readonly layer = Layer.effect(this, this.make).pipe(
-    Layer.provide(Config.layer)
-  )
+export interface Logger {
+  readonly ["~Logger"]: "~Logger"
+  readonly log: (message: string) => Effect.Effect<void>
 }
+
+export const Logger = Context.Service<Logger>("Logger")
+
+export const make = Effect.gen(function*() {
+  const config = yield* Config
+  return Logger.of({
+    ["~Logger"]: "~Logger",
+    log: (message: string) => Effect.log(`[${config.prefix}] ${message}`)
+  })
+})
+
+export const layer = Layer.effect(Logger, make).pipe(
+  Layer.provide(Config.layer)
+)
 ```
+
+The supported class constructor also accepts a `make` option, but it does not
+automatically generate a layer.
 
 The `dependencies` option no longer exists. Wire dependencies via
 `Layer.provide` as shown above.

--- a/migration/v3-to-v4.md
+++ b/migration/v3-to-v4.md
@@ -4,7 +4,7 @@
 
 Base: `origin/v3` (`6985be0cf461f0997f28f6798f469d01a2b46ca3`)
 
-Head: `HEAD` (`f57836b4418ea7c7d399f51bc1adad3fc0c08e98`)
+Head: `64d1ca59563e1524f6dc8f33b8286f8ab2ce4030` (`64d1ca59563e1524f6dc8f33b8286f8ab2ce4030`)
 
 This file is generated from the API diff and `migration/annotations/*.yaml`.
 
@@ -767,6 +767,8 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 ## API Reference
 
 ### `@effect/ai-anthropic/AnthropicClient`
+
+- `AnthropicClient.AnthropicClient` -> `@effect/ai-anthropic/AnthropicClient#AnthropicClient`: Use the same-name AnthropicClient interface for the service value and the Context.Service constant for the key. Implementations now include the \~@effect/ai-anthropic/AnthropicClient TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
 
 - `AnthropicClient.CitationsDelta` -> `Generated.BetaCitationsDelta`: The client-local stream schema moved to the regenerated v4 Anthropic schema surface; re-check its Type/Encoded shape.
 
@@ -4004,6 +4006,8 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `OpenAiClient.LogProbs` -> `Generated.LogProb`: The client-local log-probability schema moved to the regenerated v4 OpenAI schema surface and changed shape.
 
+- `OpenAiClient.OpenAiClient` -> `@effect/ai-openai/OpenAiClient#OpenAiClient`: Use the same-name OpenAiClient interface for the service value and the Context.Service constant for the key. Implementations now include the \~@effect/ai-openai/OpenAiClient TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
+
 - `OpenAiClient.ResponseCodeInterpreterCallCodeDeltaEvent` -> `Generated.ResponseCodeInterpreterCallCodeDeltaEvent`: The event schema moved out of OpenAiClient into the regenerated OpenAI schema surface; re-check its v4 Type/Encoded shape.
 
 - `OpenAiClient.ResponseCodeInterpreterCallCodeDoneEvent` -> `Generated.ResponseCodeInterpreterCallCodeDoneEvent`: The event schema moved out of OpenAiClient into the regenerated OpenAI schema surface; re-check its v4 Type/Encoded shape.
@@ -4878,6 +4882,8 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `OpenRouterClient.ChatStreamingResponseChunk` -> `OpenRouterClient.ChatStreamingResponseChunkData`: The standalone streaming chunk schema was replaced by the decoded data type from Generated.ChatStreamingResponse.
 
+- `OpenRouterClient.OpenRouterClient` -> `@effect/ai-openrouter/OpenRouterClient#OpenRouterClient`: Use the same-name OpenRouterClient interface for the service value and the Context.Service constant for the key. Implementations now include the \~@effect/ai-openrouter/OpenRouterClient TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
+
 - `OpenRouterClient.Service` -> `OpenRouterClient.Service`: Still exported in v4; adapt to the regenerated client, revised request and response schemas, and the new streaming result tuple.
 
 ### `@effect/ai-openrouter/OpenRouterConfig`
@@ -4912,13 +4918,23 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `AiError.UnknownError` -> `AiError.make + AiError.UnknownError`: UnknownError is now a semantic reason rather than a top-level error. Put module and method on AiError.make and inspect reason.\_tag when handling the outer AiError.
 
+### `@effect/ai/Chat`
+
+- `Chat.Chat` -> `effect/unstable/ai/Chat#Chat`: Use the same-name Chat interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/ai/Chat TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
+
+- `Chat.Persistence` -> `effect/unstable/ai/Chat#Persistence`: Use the same-name Persistence interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/ai/Chat/Persisted TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
+
 ### `@effect/ai/EmbeddingModel`
+
+- `EmbeddingModel.EmbeddingModel` -> `effect/unstable/ai/EmbeddingModel#EmbeddingModel`: Use the same-name EmbeddingModel interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/unstable/ai/EmbeddingModel TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
 
 - `EmbeddingModel.Result`: TODO: needs guidance
 
 - `EmbeddingModel.makeDataLoader` -> `EmbeddingModel.make + RequestResolver.setDelay + RequestResolver.batchN`: The dedicated data-loader constructor was removed. EmbeddingModel.make batches concurrent embed requests through its resolver; compose the exposed resolver with setDelay and optional batchN for the old window and maximum-batch behavior.
 
 ### `@effect/ai/IdGenerator`
+
+- `IdGenerator.IdGenerator` -> `effect/unstable/ai/IdGenerator#IdGenerator`: Use the same-name IdGenerator interface for the service value and the Context.Service constant for the key. Implementations now include the \~@effect/ai/IdGenerator TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
 
 - `IdGenerator.make` -> `IdGenerator.make`: Moved to effect/unstable/ai/IdGenerator with the same configurable alphabet, prefix, separator, and size behavior. Invalid configuration now fails with Cause.IllegalArgumentError.
 
@@ -4928,6 +4944,10 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `LanguageModel.ExtractContext` -> `LanguageModel.ExtractServices`: Renamed in effect/unstable/ai/LanguageModel. ExtractServices infers toolkit handler, result-decoding, and effectful-toolkit service requirements.
 
+- `LanguageModel.LanguageModel` -> `effect/unstable/ai/LanguageModel#LanguageModel`: Use the same-name LanguageModel interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/unstable/ai/LanguageModel TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
+
+- `LanguageModel.Service` -> `effect/unstable/ai/LanguageModel#Service`: The retained Service interface now includes the \~effect/unstable/ai/LanguageModel TypeId. Prefer LanguageModel for service annotations and LanguageModel.make for provider implementations.
+
 ### `@effect/ai/McpSchema`
 
 - `McpSchema.ContentBlock` -> `McpSchema.ContentBlock`: Moved to effect/unstable/ai/McpSchema. It remains the MCP content-block union, but v4 exports it as a const schema rather than a Schema.Union subclass. Binary image, audio, and blob data still use Uint8Array values with base64 wire encoding.
@@ -4936,11 +4956,15 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `McpSchema.McpError` -> `McpSchema.McpError`: Moved, but changed from a constructable base class to a union schema of standard tagged protocol errors plus McpErrorBase. Use McpErrorBase to construct a generic MCP error.
 
+- `McpSchema.McpServerClient` -> `effect/unstable/ai/McpSchema#McpServerClient`: Use the same-name McpServerClient interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/ai/McpSchema/McpServerClient TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
+
 - `McpSchema.ParamAnnotation` -> `McpSchema.isParam / Param.name`: The public symbol annotation was removed. Detect parameter wrappers with McpSchema.isParam and read the narrowed Param.name instead of inspecting AST annotations.
 
 - `McpSchema.param` -> `McpSchema.param`: Moved to effect/unstable/ai/McpSchema. V4 wraps the schema and exposes Param.name and Param.schema instead of attaching a public symbol annotation.
 
 ### `@effect/ai/McpServer`
+
+- `McpServer.McpServer` -> `effect/unstable/ai/McpServer#McpServer`: Use the same-name McpServer interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/ai/McpServer TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
 
 - `McpServer.layer` -> `McpServer.layer`: Moved to effect/unstable/ai/McpServer. Pass a non-empty protocols array of adapters, such as [McpProtocol.v2025\_06\_18], imported with McpProtocol from effect/unstable/ai; it still runs over a caller-provided RpcServer.Protocol.
 
@@ -5029,6 +5053,10 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 - `Response.toolResultPart` -> `Response.toolResultPart`: Moved to effect/unstable/ai/Response; providerName was removed and decoded tool results now require preliminary, normally false.
 
 - `Response.urlSourcePart` -> `Response.makePart("source", { ...params, sourceType: "url" })`: The lowercase convenience constructor was removed. The UrlSourcePart model remains, and the generic constructor now requires the URL source discriminator.
+
+### `@effect/ai/Tokenizer`
+
+- `Tokenizer.Tokenizer` -> `effect/unstable/ai/Tokenizer#Tokenizer`: Use the same-name Tokenizer interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/ai/Tokenizer TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
 
 ### `@effect/ai/Tool`
 
@@ -5742,7 +5770,11 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `MessageStorage.Encoded` -> `effect/unstable/cluster/MessageStorage#Encoded`: Moved into core Effect; use the v4 Envelope.Encoded and Reply.Encoded aliases. Custom drivers now implement batched resetAddresses, and unprocessedMessages receives optional limit and address filters.
 
-- `MessageStorage.make` -> `effect/unstable/cluster/MessageStorage#make`: Moved into core Effect. Context service projections now use the Service property instead of Type. Custom service implementations must also provide resetAddresses for batched mailbox resets.
+- `MessageStorage.MemoryDriver` -> `effect/unstable/cluster/MessageStorage#MemoryDriver`: Use the same-name MemoryDriver interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/cluster/MessageStorage/MemoryDriver TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
+
+- `MessageStorage.MessageStorage` -> `effect/unstable/cluster/MessageStorage#MessageStorage`: Use the same-name MessageStorage interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/cluster/MessageStorage TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
+
+- `MessageStorage.make` -> `effect/unstable/cluster/MessageStorage#make`: Moved into core Effect. Use the same-name service interfaces instead of Context service type projections. Custom service implementations must also provide resetAddresses for batched mailbox resets.
 
 - `MessageStorage.makeEncoded` -> `effect/unstable/cluster/MessageStorage#makeEncoded`: Moved into core Effect. Custom encoded drivers must replace resetAddress with resetAddresses and may use the new limit and addresses options passed to unprocessedMessages.
 
@@ -5764,15 +5796,25 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `RunnerAddress.TypeId` -> `none`: The runner-address marker is private in v4. Use the exported RunnerAddress class and schema.
 
+### `@effect/cluster/RunnerHealth`
+
+- `RunnerHealth.RunnerHealth` -> `effect/unstable/cluster/RunnerHealth#RunnerHealth`: Use the same-name RunnerHealth interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/cluster/RunnerHealth TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
+
 ### `@effect/cluster/RunnerStorage`
+
+- `RunnerStorage.RunnerStorage` -> `effect/unstable/cluster/RunnerStorage#RunnerStorage`: Use the same-name RunnerStorage interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/cluster/RunnerStorage TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
 
 - `RunnerStorage.makeMemory` -> `effect/unstable/cluster/RunnerStorage#makeMemory`: Moved into core Effect; it still constructs the in-memory RunnerStorage service implementation.
 
 ### `@effect/cluster/Runners`
 
-- `Runners.make` -> `effect/unstable/cluster/Runners#make`: Moved into core Effect. Its options now require codecFor; pass the codec used by the remote runner transport, such as RpcSerialization.json.codecFor for JSON. Context service projections now use Service instead of Type.
+- `Runners.RpcClientProtocol` -> `effect/unstable/cluster/Runners#RpcClientProtocol`: Use the same-name RpcClientProtocol interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/cluster/Runners/RpcClientProtocol TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
 
-- `Runners.makeNoop` -> `effect/unstable/cluster/Runners#makeNoop`: Moved into core Effect; it returns the Context.Service implementation through the Service projection instead of Type.
+- `Runners.Runners` -> `effect/unstable/cluster/Runners#Runners`: Use the same-name Runners interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/cluster/Runners TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
+
+- `Runners.make` -> `effect/unstable/cluster/Runners#make`: Moved into core Effect. Its options now require codecFor; pass the codec used by the remote runner transport, such as RpcSerialization.json.codecFor for JSON. Use the same-name service interfaces instead of Context service type projections.
+
+- `Runners.makeNoop` -> `effect/unstable/cluster/Runners#makeNoop`: Moved into core Effect; it returns the Context.Service implementation as a directly nameable interface instead of the old Type projection.
 
 ### `@effect/cluster/ShardId`
 
@@ -5780,13 +5822,19 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `ShardId.TypeId` -> `none`: The shard marker is private in v4. Use ShardId.isShardId for runtime refinement.
 
+### `@effect/cluster/Sharding`
+
+- `Sharding.Sharding` -> `effect/unstable/cluster/Sharding#Sharding`: Use the same-name Sharding interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/cluster/Sharding TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
+
 ### `@effect/cluster/ShardingConfig`
 
-- `ShardingConfig.config` -> `effect/unstable/cluster/ShardingConfig#config`: Moved into core Effect; its Context service value type now uses the Service property instead of Type.
+- `ShardingConfig.ShardingConfig` -> `effect/unstable/cluster/ShardingConfig#ShardingConfig`: Use the same-name ShardingConfig interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/cluster/ShardingConfig TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
 
-- `ShardingConfig.defaults` -> `effect/unstable/cluster/ShardingConfig#defaults`: Moved into core Effect; service type projections now use Service instead of Type. V4 also defaults maxResidentEntities to 10,000 and unprocessedMessageBatchSize to 1,024.
+- `ShardingConfig.config` -> `effect/unstable/cluster/ShardingConfig#config`: Moved into core Effect; use the ShardingConfig interface for the service value type.
 
-- `ShardingConfig.layer` -> `effect/unstable/cluster/ShardingConfig#layer`: Moved into core Effect with the same shallow default merge; service type projections now use Service instead of Type.
+- `ShardingConfig.defaults` -> `effect/unstable/cluster/ShardingConfig#defaults`: Moved into core Effect; use the ShardingConfig interface for service value types. V4 also defaults maxResidentEntities to 10,000 and unprocessedMessageBatchSize to 1,024.
+
+- `ShardingConfig.layer` -> `effect/unstable/cluster/ShardingConfig#layer`: Moved into core Effect with the same shallow default merge; use the ShardingConfig interface for service value types.
 
 ### `@effect/cluster/ShardingRegistrationEvent`
 
@@ -5801,6 +5849,10 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 - `SingletonAddress.TypeId` -> `none`: The singleton-address marker is private in v4. Use the exported SingletonAddress class and schema.
 
 ### `@effect/cluster/Snowflake`
+
+- `Snowflake.Generator` -> `effect/unstable/cluster/Snowflake#Generator`: Moved into core Effect and changed to Context.Service; its unsafeNext method was renamed to nextUnsafe.
+
+- `Snowflake.Snowflake.Generator` -> `effect/unstable/cluster/Snowflake#Snowflake.Generator`: The generator shape now includes the \~effect/cluster/Snowflake/Generator TypeId. Use the module make constructor and the top-level Generator interface and service key.
 
 - `Snowflake.TypeId` -> `effect/unstable/cluster/Snowflake#TypeId`: Moved into core Effect; the public marker is now the string literal \~effect/cluster/Snowflake.
 
@@ -5818,9 +5870,9 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 ### `@effect/experimental/DevTools/Client`
 
-- `Client.Client` -> `effect/unstable/devtools/DevToolsClient#DevToolsClient`: Client was renamed to the DevToolsClient Context.Service class.
+- `Client.Client` -> `effect/unstable/devtools/DevToolsClient#DevToolsClient`: Client was renamed to the DevToolsClient Context.Service value and same-name interface.
 
-- `Client.ClientImpl` -> `effect/unstable/devtools/DevToolsClient#DevToolsClient["Service"]`: Use the service shape from DevToolsClient; unsafeAddSpan was replaced by sendUnsafe.
+- `Client.ClientImpl` -> `effect/unstable/devtools/DevToolsClient#DevToolsClient`: Use the service shape from DevToolsClient; unsafeAddSpan was replaced by sendUnsafe.
 
 - `Client.layer` -> `effect/unstable/devtools/DevToolsClient#layer`: Import layer from the v4 unstable DevToolsClient module.
 
@@ -5892,19 +5944,27 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `EventJournal.ErrorTypeId` -> `none`: The v4 error marker is private; narrow with EventJournalError instead.
 
+- `EventJournal.EventJournal` -> `effect/unstable/eventlog/EventJournal#EventJournal`: Use the same-name EventJournal interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/eventlog/EventJournal TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
+
 - `EventJournal.RemoteIdTypeId` -> `effect/unstable/eventlog/EventJournal#RemoteIdTypeId`: Import RemoteIdTypeId from the v4 EventJournal module; it is now a string brand.
 
 - `EventJournal.makeEntryId` -> `effect/unstable/eventlog/EventJournal#makeEntryIdUnsafe`: The unchecked EntryId constructor was renamed to makeEntryIdUnsafe.
 
-- `EventJournal.makeMemory` -> `effect/unstable/eventlog/EventJournal#makeMemory`: The in-memory constructor moved into core Effect and now returns the Context.Service implementation through its Service projection.
+- `EventJournal.makeMemory` -> `effect/unstable/eventlog/EventJournal#makeMemory`: The in-memory constructor moved into core Effect and now returns the Context.Service implementation as a directly nameable interface.
 
 - `EventJournal.makeRemoteId` -> `effect/unstable/eventlog/EventJournal#makeRemoteIdUnsafe`: The unchecked RemoteId constructor was renamed to makeRemoteIdUnsafe.
 
 ### `@effect/experimental/EventLog`
 
+- `EventLog.EventLog` -> `effect/unstable/eventlog/EventLog#EventLog`: Use the same-name EventLog interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/eventlog/EventLog TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
+
 - `EventLog.Handlers` -> `effect/unstable/eventlog/EventLog#Handlers`: Import Handlers from the v4 EventLog module; handlers now also receive storeId.
 
 - `EventLog.HandlersTypeId` -> `effect/unstable/eventlog/EventLog#HandlersTypeId`: Import HandlersTypeId from the v4 EventLog module.
+
+- `EventLog.Identity` -> `effect/unstable/eventlog/EventLog#Identity`: Use the same-name Identity interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/eventlog/EventLog/Identity TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
+
+- `EventLog.Registry` -> `effect/unstable/eventlog/EventLog#Registry`: Use the same-name Registry interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/unstable/eventlog/EventLog/Registry TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
 
 - `EventLog.SchemaTypeId` -> `effect/unstable/eventlog/EventLog#SchemaTypeId`: Import SchemaTypeId from the v4 EventLog module.
 
@@ -5913,6 +5973,10 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 - `EventLog.layer` -> `effect/unstable/eventlog/EventLog#layer`: The v4 layer takes both the schema and handler layer; use layerEventLog for runtime only.
 
 - `EventLog.layerIdentityKvs` -> `none`: Compose KeyValueStore.toSchemaStore, EventLog.IdentitySchema, EventLog.makeIdentity, and Layer.effect manually.
+
+### `@effect/experimental/EventLogEncryption`
+
+- `EventLogEncryption.EventLogEncryption` -> `effect/unstable/eventlog/EventLogEncryption#EventLogEncryption`: Use the same-name EventLogEncryption interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/eventlog/EventLogEncryption TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
 
 ### `@effect/experimental/EventLogRemote`
 
@@ -5958,6 +6022,8 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 ### `@effect/experimental/EventLogServer`
 
+- `EventLogServer.Storage` -> `effect/unstable/eventlog/EventLogServerEncrypted#Storage`: Use the encrypted server Storage service, which is storeId- and session-aware.
+
 - `EventLogServer.makeHandler` -> `effect/unstable/eventlog/EventLogServerEncrypted#layer + effect/unstable/rpc/RpcServer#layerProtocolSocketServer`: Compose the encrypted server layer with the generic RPC socket server; there is no per-socket handler factory.
 
 - `EventLogServer.makeHandlerHttp` -> `effect/unstable/eventlog/EventLogServerEncrypted#layer + effect/unstable/rpc/RpcServer#makeProtocolWithHttpEffectWebsocket`: Use the returned httpEffect for upgrades and provide its protocol to the encrypted server layer.
@@ -5971,6 +6037,10 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 ### `@effect/experimental/PersistedQueue`
 
 - `PersistedQueue.ErrorTypeId` -> `effect/unstable/persistence/PersistedQueue#ErrorTypeId`: Retained as a string brand; the runtime marker now uses the persistence module path.
+
+- `PersistedQueue.PersistedQueueFactory` -> `effect/unstable/persistence/PersistedQueue#PersistedQueueFactory`: Use the same-name PersistedQueueFactory interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/persistence/PersistedQueue/PersistedQueueFactory TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
+
+- `PersistedQueue.PersistedQueueStore` -> `effect/unstable/persistence/PersistedQueue#PersistedQueueStore`: Use the same-name PersistedQueueStore interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/persistence/PersistedQueue/PersistedQueueStore TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
 
 - `PersistedQueue.TypeId` -> `effect/unstable/persistence/PersistedQueue#TypeId`: Import TypeId from the v4 unstable PersistedQueue module; it is now a string brand.
 
@@ -5986,7 +6056,7 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 ### `@effect/experimental/Persistence`
 
-- `Persistence.BackingPersistence` -> `effect/unstable/persistence/Persistence#BackingPersistence`: Use the v4 BackingPersistence Context.Service class.
+- `Persistence.BackingPersistence` -> `effect/unstable/persistence/Persistence#BackingPersistence`: Use the v4 BackingPersistence Context.Service value and same-name interface.
 
 - `Persistence.BackingPersistenceTypeId` -> `none`: The BackingPersistence brand is no longer publicly exported in v4.
 
@@ -5998,7 +6068,7 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `Persistence.PersistenceParseError` -> `effect/Schema#SchemaError`: Persistence parsing failures now use the core SchemaError type.
 
-- `Persistence.ResultPersistence` -> `effect/unstable/persistence/Persistence#Persistence`: ResultPersistence was renamed to Persistence and is now a Context.Service class.
+- `Persistence.ResultPersistence` -> `effect/unstable/persistence/Persistence#Persistence`: ResultPersistence was renamed to Persistence and is now a Context.Service value and same-name interface.
 
 - `Persistence.ResultPersistence.Key` -> `effect/unstable/persistence/Persistable#Persistable`: Persistable is the v4 schema-backed persistence key contract.
 
@@ -6038,6 +6108,8 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `RateLimiter.RateLimiterError` -> `effect/unstable/persistence/RateLimiter#RateLimiterError`: The retained name is now a wrapper error class whose reason is RateLimitExceeded or RateLimitStoreError.
 
+- `RateLimiter.RateLimiterStore` -> `RateLimiter.RateLimiterStore`: Use the Context.Service value and same-name interface from effect/unstable/persistence/RateLimiter. Custom tokenBucket implementations must return [remaining, elapsedMillis] instead of a number, preserving fractional counts and elapsed refill time.
+
 - `RateLimiter.TypeId` -> `effect/unstable/persistence/RateLimiter#TypeId`: Import TypeId from the v4 unstable RateLimiter module; it is now a string brand.
 
 - `RateLimiter.makeSleep` -> `effect/unstable/persistence/RateLimiter#sleep`: The accessor Effect was replaced by sleep; obtain the RateLimiter service and pass it to sleep directly or with its curried overload.
@@ -6054,7 +6126,7 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `Reactivity.Reactivity` -> `effect/unstable/reactivity/Reactivity#Reactivity`: Use the v4 Reactivity Context.Service; unsafe methods were renamed with an Unsafe suffix.
 
-- `Reactivity.Reactivity.Service` -> `effect/unstable/reactivity/Reactivity#Reactivity["Service"]`: The named namespace member was removed; derive the service shape from the Context.Service class.
+- `Reactivity.Reactivity.Service` -> `effect/unstable/reactivity/Reactivity#Reactivity`: The named namespace member was removed; use the directly exported Reactivity interface.
 
 - `Reactivity.make` -> `effect/unstable/reactivity/Reactivity#make`: Import make from the v4 unstable Reactivity module.
 
@@ -6131,6 +6203,10 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 ### `@effect/opentelemetry/OtlpResource`
 
 - `OtlpResource.unsafeServiceName` -> `OtlpResource.serviceNameUnsafe`: Moved to effect/unstable/observability/OtlpResource and renamed to follow the v4 unsafe-suffix convention.
+
+### `@effect/opentelemetry/OtlpSerialization`
+
+- `OtlpSerialization.OtlpSerialization` -> `effect/unstable/observability/OtlpSerialization#OtlpSerialization`: Use the same-name OtlpSerialization interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/observability/OtlpSerialization TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
 
 ### `@effect/opentelemetry/OtlpTracer`
 
@@ -6322,9 +6398,7 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `NodeHttpClient.Dispatcher` -> `NodeHttpClient.Dispatcher`: The identifier remains but is now a Context.Service class; use Dispatcher["Service"] for the concrete Undici dispatcher type.
 
-- `NodeHttpClient.HttpAgent` -> `NodeHttpClient.HttpAgent`: The identifier remains but is now a Context.Service class; use HttpAgent["Service"] for the concrete http/https agent pair.
-
-- `NodeHttpClient.HttpAgentTypeId` -> `none`: The public marker was removed; the HttpAgent Context.Service class supplies service identity.
+- `NodeHttpClient.HttpAgentTypeId` -> `none`: The public marker was removed; HttpAgent implementations now include a private TypeId.
 
 - `NodeHttpClient.UndiciRequestOptions` -> `NodeHttpClient.UndiciOptions`: The required Context.Tag became a defaulted Context.Reference\<Partial\<Dispatcher.RequestOptions\>\>; override it with Effect.provideService.
 
@@ -6490,7 +6564,7 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `CommandExecutor.ProcessTypeId` -> `none`: The ChildProcessHandle marker is internal in v4; use the ChildProcessHandle interface.
 
-- `CommandExecutor.TypeId` -> `none`: The Context.Service class replaces the public executor type-id alias.
+- `CommandExecutor.TypeId` -> `none`: The Context.Service value and same-name interface replaces the public executor type-id alias.
 
 - `CommandExecutor.makeExecutor` -> `ChildProcessSpawner.make`: Use the renamed constructor; it derives output helpers from a spawn implementation.
 
@@ -6526,7 +6600,9 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 ### `@effect/platform/Etag`
 
-- `Etag.GeneratorTypeId` -> `Etag.Generator`: The standalone generator brand was removed; Generator is now a Context.Service class.
+- `Etag.Generator` -> `effect/unstable/http/Etag#Generator`: Use the same-name Generator interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/http/Etag/Generator TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
+
+- `Etag.GeneratorTypeId` -> `Etag.Generator`: The standalone generator brand was removed; Generator is now a Context.Service value and same-name interface.
 
 - `Etag.layer` -> `Etag.layer`: Retained; it still provides the strong metadata-based ETag Generator service.
 
@@ -6577,6 +6653,8 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 - `FileSystem.StreamOptions` -> `NonNullable<Parameters<FileSystem.FileSystem["stream"]>[1]>`: Stream options are inline; bufferSize was removed, bytesToRead and offset accept ByteSize inputs, and chunkSize uses number.
 
 - `FileSystem.TiB` -> `ByteSize.tebibytes`: Use the ByteSize binary unit constructor.
+
+- `FileSystem.WatchBackend` -> `effect/FileSystem#WatchBackend`: Use the same-name WatchBackend interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/FileSystem/WatchBackend TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
 
 - `FileSystem.WatchEventCreate` -> `FileSystem.WatchEvent.Create`: The constructor was removed; construct a tagged object with \_tag: "Create" and path.
 
@@ -7126,9 +7204,9 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 ### `@effect/platform/HttpPlatform`
 
-- `HttpPlatform.HttpPlatform` -> `HttpPlatform.HttpPlatform`: The service is now a Context.Service class; use its Service member for the implementation type. Path-backed offset and bytesToRead accept ByteSize.Input, while chunkSize and all Web File range options use number.
+- `HttpPlatform.HttpPlatform` -> `HttpPlatform.HttpPlatform`: The service is now a Context.Service value and same-name interface; use its Service member for the implementation type. Path-backed offset and bytesToRead accept ByteSize.Input, while chunkSize and all Web File range options use number.
 
-- `HttpPlatform.TypeId` -> `none`: The public type id was removed; use the HttpPlatform Context.Service class.
+- `HttpPlatform.TypeId` -> `none`: The public type id was removed; use the HttpPlatform Context.Service value and same-name interface.
 
 - `HttpPlatform.layer` -> `HttpPlatform.layer`: Retained as the default file-response layer.
 
@@ -7206,13 +7284,13 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `HttpServer.Address` -> `effect/unstable/net/NetAddress#SocketAddress`: Replaced by the shared concrete internet-or-Unix socket address union.
 
-- `HttpServer.HttpServer` -> `HttpServer.HttpServer`: The interface and tag became one Context.Service class; use its Service member for implementations.
+- `HttpServer.HttpServer` -> `HttpServer.HttpServer`: The interface and tag became one Context.Service value and same-name interface; use the same-name interface for implementations.
 
 - `HttpServer.ServeOptions` -> `none`: The unused respond option model was removed with no shared v4 counterpart.
 
 - `HttpServer.TcpAddress` -> `effect/unstable/net/NetAddress#InetAddress`: Replaced by the shared resolved internet-address model; use address and port instead of hostname and port.
 
-- `HttpServer.TypeId` -> `none`: The public TypeId was removed; HttpServer is now a Context.Service class.
+- `HttpServer.TypeId` -> `none`: The public TypeId was removed; HttpServer is now a Context.Service value and same-name interface.
 
 - `HttpServer.UnixAddress` -> `effect/unstable/net/NetAddress#UnixPathAddress`: Replaced by the shared Unix filesystem-path address model.
 
@@ -7492,6 +7570,8 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `SocketServer.ErrorTypeId` -> `SocketServer.ErrorTypeId`: The API moved to effect/unstable/socket/SocketServer and retains this name.
 
+- `SocketServer.SocketServer` -> `effect/unstable/socket/SocketServer#SocketServer`: Use the same-name SocketServer interface for the service value and the Context.Service constant for the key. Implementations now include the \~@effect/platform/SocketServer TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
+
 - `SocketServer.TcpAddress` -> `effect/unstable/net/NetAddress#InetAddress`: Replaced by the shared resolved internet-address model; use address and port instead of hostname and port.
 
 - `SocketServer.UnixAddress` -> `effect/unstable/net/NetAddress#UnixPathAddress`: Replaced by the shared Unix filesystem-path address model.
@@ -7510,7 +7590,9 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 ### `@effect/platform/Transferable`
 
-- `Transferable.CollectorService` -> `Transferable.Collector["Service"]`: The collector interface is now the service type of the Transferable.Collector Context.Service class.
+- `Transferable.Collector` -> `effect/unstable/workers/Transferable#Collector`: Use the same-name Collector interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/workers/Transferable/Collector TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
+
+- `Transferable.CollectorService` -> `Transferable.Collector`: The collector interface is now the service type of the Transferable.Collector Context.Service value and same-name interface.
 
 - `Transferable.Uint8Array` -> `Transferable.Uint8Array`: The transferable Uint8Array schema remains in the moved module.
 
@@ -7552,9 +7634,9 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `Worker.BackingWorker` -> `Worker.Worker`: The low-level backing worker became the primary Worker interface with send and run operations.
 
-- `Worker.PlatformWorker` -> `Worker.WorkerPlatform`: The platform service was renamed and is now a Context.Service class.
+- `Worker.PlatformWorker` -> `Worker.WorkerPlatform`: The platform service was renamed and is now a Context.Service value and same-name interface.
 
-- `Worker.PlatformWorkerTypeId` -> `none`: The Context.Service class replaces the public platform-worker type-id alias.
+- `Worker.PlatformWorkerTypeId` -> `none`: The Context.Service value and same-name interface replaces the public platform-worker type-id alias.
 
 - `Worker.SerializedWorker` -> `RpcClient with RpcClient.layerProtocolWorker`: The serialized worker facade was removed; v4 routes schema-defined RPCs through the worker protocol.
 
@@ -7574,7 +7656,7 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `Worker.WorkerManager` -> `Worker.WorkerPlatform`: WorkerPlatform now spawns low-level Worker values directly, replacing WorkerManager.
 
-- `Worker.WorkerManagerTypeId` -> `none`: The removed WorkerManager has no v4 type-id; WorkerPlatform is a Context.Service class.
+- `Worker.WorkerManagerTypeId` -> `none`: The removed WorkerManager has no v4 type-id; WorkerPlatform is a Context.Service value and same-name interface.
 
 - `Worker.WorkerPool` -> `RpcClient.Protocol`: For serialized request/response workloads use the worker-backed RPC Protocol; for raw messages build a Pool around WorkerPlatform.spawn.
 
@@ -7608,9 +7690,9 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `WorkerRunner.CloseLatch` -> `none`: The public close-latch service was removed; WorkerRunner implementations manage lifetime through their run effect and adapter scope.
 
-- `WorkerRunner.PlatformRunner` -> `WorkerRunner.WorkerRunnerPlatform`: The platform service was renamed and is now a Context.Service class.
+- `WorkerRunner.PlatformRunner` -> `WorkerRunner.WorkerRunnerPlatform`: The platform service was renamed and is now a Context.Service value and same-name interface.
 
-- `WorkerRunner.PlatformRunnerTypeId` -> `none`: The Context.Service class replaces the public platform-runner type-id alias.
+- `WorkerRunner.PlatformRunnerTypeId` -> `none`: The Context.Service value and same-name interface replaces the public platform-runner type-id alias.
 
 - `WorkerRunner.Runner` -> `WorkerRunner.WorkerRunner`: The namespace-only runner API was replaced by the low-level WorkerRunner interface.
 
@@ -7769,6 +7851,8 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 - `RpcSchema.isStreamSerializable` -> `RpcSchema.isStreamSchema(schema)`: The separate WithResult serializability predicate was removed; v4 RPC streaming is identified by its explicit Stream schema.
 
 ### `@effect/rpc/RpcSerialization`
+
+- `RpcSerialization.RpcSerialization` -> `effect/unstable/rpc/RpcSerialization#RpcSerialization`: Use the same-name RpcSerialization interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/rpc/RpcSerialization TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
 
 - `RpcSerialization.RpcSerializationError` -> `effect/unstable/rpc/RpcSerialization#MaxBufferSizeExceeded`: Buffer-limit failures now use MaxBufferSizeExceeded. MessagePack-specific decode errors have no counterpart.
 
@@ -8688,7 +8772,11 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 ### `@effect/workflow/WorkflowEngine`
 
-- `WorkflowEngine.makeUnsafe` -> `effect/unstable/workflow/WorkflowEngine#makeUnsafe`: Moved into core Effect. Context service projections now use Service instead of Type, and absent encoded results use Option.
+- `WorkflowEngine.WorkflowEngine` -> `effect/unstable/workflow/WorkflowEngine#WorkflowEngine`: Use the same-name WorkflowEngine interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/workflow/WorkflowEngine TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
+
+- `WorkflowEngine.WorkflowInstance` -> `effect/unstable/workflow/WorkflowEngine#WorkflowInstance`: Use the same-name WorkflowInstance interface for the service value and the Context.Service constant for the key. Implementations now include the \~effect/workflow/WorkflowEngine/WorkflowInstance TypeId; use the module constructor or layer where available, and include that field on manual implementations. The runtime service key is unchanged by the interface migration.
+
+- `WorkflowEngine.makeUnsafe` -> `effect/unstable/workflow/WorkflowEngine#makeUnsafe`: Moved into core Effect. Use the same-name service interfaces instead of Context service type projections, and absent encoded results use Option.
 
 ### `@effect/workflow/WorkflowProxy`
 

--- a/packages/ai/anthropic/src/AnthropicClient.ts
+++ b/packages/ai/anthropic/src/AnthropicClient.ts
@@ -40,6 +40,8 @@ import * as Errors from "./internal/errors.ts"
  * @since 4.0.0
  */
 export interface Service {
+  readonly [AnthropicClientTypeId]: typeof AnthropicClientTypeId
+
   /**
    * The underlying generated Anthropic client that exposes all API endpoints.
    */
@@ -114,6 +116,8 @@ export type MessageStreamEvent =
 // Service Identifier
 // =============================================================================
 
+const AnthropicClientTypeId = "~@effect/ai-anthropic/AnthropicClient"
+
 /**
  * Service tag for the Anthropic client.
  *
@@ -129,9 +133,17 @@ export type MessageStreamEvent =
  * @category services
  * @since 4.0.0
  */
-export class AnthropicClient extends Context.Service<AnthropicClient, Service>()(
-  "@effect/ai-anthropic/AnthropicClient"
-) {}
+export interface AnthropicClient extends Service {
+  readonly [AnthropicClientTypeId]: typeof AnthropicClientTypeId
+}
+
+/**
+ * Service key for `AnthropicClient` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const AnthropicClient = Context.Service<AnthropicClient>("@effect/ai-anthropic/AnthropicClient")
 
 // =============================================================================
 // Options
@@ -342,6 +354,7 @@ export const make = Effect.fnUntraced(
     }
 
     return AnthropicClient.of({
+      [AnthropicClientTypeId]: AnthropicClientTypeId as typeof AnthropicClientTypeId,
       client,
       streamRequest,
       createMessage,

--- a/packages/ai/anthropic/src/AnthropicConfig.ts
+++ b/packages/ai/anthropic/src/AnthropicConfig.ts
@@ -11,6 +11,8 @@ import * as Effect from "effect/Effect"
 import { dual } from "effect/Function"
 import type { HttpClient } from "effect/unstable/http/HttpClient"
 
+const AnthropicConfigTypeId = "~@effect/ai-anthropic/AnthropicConfig"
+
 /**
  * Service tag for Anthropic client configuration overrides, such as transformations applied to the generated HTTP client.
  *
@@ -24,20 +26,30 @@ import type { HttpClient } from "effect/unstable/http/HttpClient"
  * @category services
  * @since 4.0.0
  */
-export class AnthropicConfig extends Context.Service<
-  AnthropicConfig,
-  AnthropicConfig.Service
->()("@effect/ai-anthropic/AnthropicConfig") {
-  /**
-   * Gets the configured Anthropic service from the current context when present.
-   *
-   * @since 4.0.0
-   */
-  static readonly getOrUndefined: Effect.Effect<typeof AnthropicConfig.Service | undefined> = Effect.map(
-    Effect.context<never>(),
-    Context.getOrUndefined(AnthropicConfig)
-  )
+export interface AnthropicConfig extends AnthropicConfig.Service {
+  readonly [AnthropicConfigTypeId]: typeof AnthropicConfigTypeId
 }
+
+/**
+ * Service key for `AnthropicConfig` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const AnthropicConfig = (() => {
+  const service = Context.Service<AnthropicConfig>("@effect/ai-anthropic/AnthropicConfig")
+  return Object.assign(service, {
+    /**
+     * Gets the configured Anthropic service from the current context when present.
+     *
+     * @since 4.0.0
+     */
+    getOrUndefined: Effect.map(
+      Effect.context<never>(),
+      Context.getOrUndefined(service)
+    )
+  })
+})()
 
 /**
  * Namespace containing types associated with the `AnthropicConfig` service.
@@ -56,6 +68,8 @@ export declare namespace AnthropicConfig {
    * @since 4.0.0
    */
   export interface Service {
+    readonly [AnthropicConfigTypeId]: typeof AnthropicConfigTypeId
+
     readonly transformClient?: ((client: HttpClient) => HttpClient) | undefined
   }
 }
@@ -80,5 +94,10 @@ export const withClientTransform: {
 ) =>
   Effect.flatMap(
     AnthropicConfig.getOrUndefined,
-    (config) => Effect.provideService(self, AnthropicConfig, { ...config, transformClient })
+    (config) =>
+      Effect.provideService(self, AnthropicConfig, {
+        ...config,
+        [AnthropicConfigTypeId]: AnthropicConfigTypeId,
+        transformClient
+      })
   ))

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -51,6 +51,41 @@ export type Model = (typeof Generated.Model)["members"][1]["Encoded"]
 // Configuration
 // =============================================================================
 
+const ConfigTypeId = "~@effect/ai-anthropic/AnthropicLanguageModel/Config"
+
+type ConfigShape = Simplify<
+  & Partial<
+    Omit<
+      typeof Generated.BetaCreateMessageParams.Encoded,
+      "messages" | "output_config" | "tools" | "tool_choice" | "stream"
+    >
+  >
+  & {
+    readonly output_config?: {
+      readonly effort?: "low" | "medium" | "high" | null
+    }
+    /**
+     * Disables Claude's ability to use multiple tools to respond to a query.
+     */
+    readonly disableParallelToolCalls?: boolean | undefined
+    /**
+     * Whether the model supports native structured outputs.
+     *
+     * Overrides automatic capability detection based on the model identifier.
+     */
+    readonly structuredOutputs?: boolean | undefined
+    /**
+     * Whether to use strict JSON schema validation for tool calls.
+     *
+     * **Details**
+     *
+     * Only applies to models that support structured outputs. Defaults to
+     * `true` when structured outputs are supported.
+     */
+    readonly strictJsonSchema?: boolean | undefined
+  }
+>
+
 /**
  * Context service for Anthropic language model configuration.
  *
@@ -68,41 +103,17 @@ export type Model = (typeof Generated.Model)["members"][1]["Encoded"]
  * @category services
  * @since 4.0.0
  */
-export class Config extends Context.Service<
-  Config,
-  Simplify<
-    & Partial<
-      Omit<
-        typeof Generated.BetaCreateMessageParams.Encoded,
-        "messages" | "output_config" | "tools" | "tool_choice" | "stream"
-      >
-    >
-    & {
-      readonly output_config?: {
-        readonly effort?: "low" | "medium" | "high" | null
-      }
-      /**
-       * Disables Claude's ability to use multiple tools to respond to a query.
-       */
-      readonly disableParallelToolCalls?: boolean | undefined
-      /**
-       * Whether the model supports native structured outputs.
-       *
-       * Overrides automatic capability detection based on the model identifier.
-       */
-      readonly structuredOutputs?: boolean | undefined
-      /**
-       * Whether to use strict JSON schema validation for tool calls.
-       *
-       * **Details**
-       *
-       * Only applies to models that support structured outputs. Defaults to
-       * `true` when structured outputs are supported.
-       */
-      readonly strictJsonSchema?: boolean | undefined
-    }
-  >
->()("@effect/ai-anthropic/AnthropicLanguageModel/Config") {}
+export interface Config extends ConfigShape {
+  readonly [ConfigTypeId]: typeof ConfigTypeId
+}
+
+/**
+ * Service key for `Config` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Config = Context.Service<Config>("@effect/ai-anthropic/AnthropicLanguageModel/Config")
 
 // =============================================================================
 // Provider Options / Metadata
@@ -651,7 +662,7 @@ declare module "effect/unstable/ai/Response" {
  */
 export const model = (
   model: (string & {}) | Model,
-  config?: Omit<typeof Config.Service, "model">
+  config?: Omit<ConfigShape, "model">
 ): AiModel.Model<"anthropic", LanguageModel.LanguageModel, AnthropicClient> =>
   AiModel.make("anthropic", model, layer({ model, config }))
 
@@ -677,21 +688,23 @@ export const model = (
  */
 export const make = Effect.fnUntraced(function*({ model, config: providerConfig }: {
   readonly model: (string & {}) | Model
-  readonly config?: Omit<typeof Config.Service, "model"> | undefined
+  readonly config?: Omit<ConfigShape, "model"> | undefined
 }): Effect.fn.Return<LanguageModel.Service, never, AnthropicClient> {
   const client = yield* AnthropicClient
 
-  const makeConfig: Effect.Effect<typeof Config.Service & { readonly model: string }> = Effect.contextWith((services) =>
+  const makeConfig: Effect.Effect<ConfigShape & { readonly model: string }> = Effect.contextWith((
+    services: Context.Context<never>
+  ) =>
     Effect.succeed({
       model,
       ...providerConfig,
       ...Context.getOrUndefined(services, Config)
     })
-  )
+  ).pipe(Effect.map(({ [ConfigTypeId]: _typeId, ...config }) => config))
 
   const makeRequest = Effect.fnUntraced(
     function*<Tools extends ReadonlyArray<Tool.Any>>({ config, options, toolNameMapper }: {
-      readonly config: typeof Config.Service & { readonly model: string }
+      readonly config: ConfigShape & { readonly model: string }
       readonly options: LanguageModel.ProviderOptions
       readonly toolNameMapper: Tool.NameMapper<Tools>
     }): Effect.fn.Return<{
@@ -785,7 +798,7 @@ export const make = Effect.fnUntraced(function*({ model, config: providerConfig 
  */
 export const layer = (options: {
   readonly model: (string & {}) | Model
-  readonly config?: Omit<typeof Config.Service, "model"> | undefined
+  readonly config?: Omit<ConfigShape, "model"> | undefined
 }): Layer.Layer<LanguageModel.LanguageModel, never, AnthropicClient> =>
   Layer.effect(LanguageModel.LanguageModel, make(options))
 
@@ -810,19 +823,21 @@ export const layer = (options: {
  * @since 4.0.0
  */
 export const withConfigOverride: {
-  (overrides: typeof Config.Service): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Config>>
-  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: typeof Config.Service): Effect.Effect<A, E, Exclude<R, Config>>
+  (overrides: ConfigShape): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Config>>
+  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: ConfigShape): Effect.Effect<A, E, Exclude<R, Config>>
 } = dual<
   (
-    overrides: typeof Config.Service
+    overrides: ConfigShape
   ) => <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Config>>,
-  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: typeof Config.Service) => Effect.Effect<A, E, Exclude<R, Config>>
+  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: ConfigShape) => Effect.Effect<A, E, Exclude<R, Config>>
 >(2, (self, overrides) =>
   Effect.flatMap(
     Effect.serviceOption(Config),
     (config) =>
       Effect.provideService(self, Config, {
-        ...(config._tag === "Some" ? config.value : {}),
+        ...(config._tag === "Some" ? config.value : {
+          [ConfigTypeId]: ConfigTypeId as typeof ConfigTypeId
+        }),
         ...overrides
       })
   ))
@@ -1292,7 +1307,7 @@ const prepareTools = Effect.fnUntraced(
   function*({ betas, capabilities, config, options }: {
     readonly betas: Set<string>
     readonly capabilities: ModelCapabilities
-    readonly config: typeof Config.Service
+    readonly config: ConfigShape
     readonly options: LanguageModel.ProviderOptions
   }): Effect.fn.Return<{
     readonly tools: ReadonlyArray<AnthropicUserDefinedTool | AnthropicProviderDefinedTool> | undefined

--- a/packages/ai/openai-compat/src/OpenAiClient.ts
+++ b/packages/ai/openai-compat/src/OpenAiClient.ts
@@ -38,6 +38,8 @@ import { OpenAiConfig } from "./OpenAiConfig.ts"
  * @since 4.0.0
  */
 export interface Service {
+  readonly [OpenAiClientTypeId]: typeof OpenAiClientTypeId
+
   readonly client: HttpClient.HttpClient
   readonly createResponse: (
     options: CreateResponseRequestJson
@@ -58,6 +60,8 @@ export interface Service {
     options: CreateEmbeddingRequestJson
   ) => Effect.Effect<CreateEmbedding200, AiError.AiError>
 }
+
+const OpenAiClientTypeId = "~@effect/ai-openai-compat/OpenAiClient"
 
 /**
  * Service tag for the OpenAI-compatible chat completions and embeddings client.
@@ -80,9 +84,17 @@ export interface Service {
  * @category services
  * @since 4.0.0
  */
-export class OpenAiClient extends Context.Service<OpenAiClient, Service>()(
-  "@effect/ai-openai-compat/OpenAiClient"
-) {}
+export interface OpenAiClient extends Service {
+  readonly [OpenAiClientTypeId]: typeof OpenAiClientTypeId
+}
+
+/**
+ * Service key for `OpenAiClient` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const OpenAiClient = Context.Service<OpenAiClient>("@effect/ai-openai-compat/OpenAiClient")
 
 /**
  * Configuration options used to construct an OpenAI-compatible client.
@@ -268,6 +280,7 @@ export const make = Effect.fnUntraced(
       )
 
     return OpenAiClient.of({
+      [OpenAiClientTypeId]: OpenAiClientTypeId as typeof OpenAiClientTypeId,
       client: httpClient,
       createResponse,
       createResponseStream,

--- a/packages/ai/openai-compat/src/OpenAiConfig.ts
+++ b/packages/ai/openai-compat/src/OpenAiConfig.ts
@@ -11,6 +11,8 @@ import * as Effect from "effect/Effect"
 import { dual } from "effect/Function"
 import type { HttpClient } from "effect/unstable/http/HttpClient"
 
+const OpenAiConfigTypeId = "~@effect/ai-openai-compat/OpenAiConfig"
+
 /**
  * Context service for OpenAI-compatible client configuration in the current
  * Effect scope.
@@ -25,20 +27,30 @@ import type { HttpClient } from "effect/unstable/http/HttpClient"
  * @category services
  * @since 4.0.0
  */
-export class OpenAiConfig extends Context.Service<
-  OpenAiConfig,
-  OpenAiConfig.Service
->()("@effect/ai-openai-compat/OpenAiConfig") {
-  /**
-   * Gets the configured OpenAI-compatible service from the current context when present.
-   *
-   * @since 4.0.0
-   */
-  static readonly getOrUndefined: Effect.Effect<typeof OpenAiConfig.Service | undefined> = Effect.map(
-    Effect.context<never>(),
-    Context.getOrUndefined(OpenAiConfig)
-  )
+export interface OpenAiConfig extends OpenAiConfig.Service {
+  readonly [OpenAiConfigTypeId]: typeof OpenAiConfigTypeId
 }
+
+/**
+ * Service key for `OpenAiConfig` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const OpenAiConfig = (() => {
+  const service = Context.Service<OpenAiConfig>("@effect/ai-openai-compat/OpenAiConfig")
+  return Object.assign(service, {
+    /**
+     * Gets the configured OpenAI-compatible service from the current context when present.
+     *
+     * @since 4.0.0
+     */
+    getOrUndefined: Effect.map(
+      Effect.context<never>(),
+      Context.getOrUndefined(service)
+    )
+  })
+})()
 
 /**
  * Types associated with the `OpenAiConfig` context service.
@@ -54,6 +66,8 @@ export declare namespace OpenAiConfig {
    * @since 4.0.0
    */
   export interface Service {
+    readonly [OpenAiConfigTypeId]: typeof OpenAiConfigTypeId
+
     readonly transformClient?: ((client: HttpClient) => HttpClient) | undefined
   }
 }
@@ -83,5 +97,10 @@ export const withClientTransform: {
 ) =>
   Effect.flatMap(
     OpenAiConfig.getOrUndefined,
-    (config) => Effect.provideService(self, OpenAiConfig, { ...config, transformClient })
+    (config) =>
+      Effect.provideService(self, OpenAiConfig, {
+        ...config,
+        [OpenAiConfigTypeId]: OpenAiConfigTypeId,
+        transformClient
+      })
   ))

--- a/packages/ai/openai-compat/src/OpenAiEmbeddingModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiEmbeddingModel.ts
@@ -29,6 +29,10 @@ export type Model = string
 type ConfigOptions = Simplify<Partial<Omit<CreateEmbeddingRequestJson, "input">>>
 type ModelConfig = Omit<ConfigOptions, "model"> & { readonly [x: string]: unknown }
 
+const ConfigTypeId = "~@effect/ai-openai-compat/OpenAiEmbeddingModel/Config"
+
+type ConfigShape = ConfigOptions & { readonly [x: string]: unknown }
+
 /**
  * Context service for OpenAI embedding model configuration.
  *
@@ -49,10 +53,17 @@ type ModelConfig = Omit<ConfigOptions, "model"> & { readonly [x: string]: unknow
  * @category services
  * @since 4.0.0
  */
-export class Config extends Context.Service<
-  Config,
-  ConfigOptions & { readonly [x: string]: unknown }
->()("@effect/ai-openai-compat/OpenAiEmbeddingModel/Config") {}
+export interface Config extends ConfigShape {
+  readonly [ConfigTypeId]: typeof ConfigTypeId
+}
+
+/**
+ * Service key for `Config` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Config = Context.Service<Config>("@effect/ai-openai-compat/OpenAiEmbeddingModel/Config")
 
 /**
  * Creates an `AiModel` for an OpenAI-compatible embedding model with its configured vector dimensions.
@@ -123,7 +134,7 @@ export const make = Effect.fnUntraced(function*({ model, config: providerConfig 
 
   const makeConfig = Effect.contextWith((services: Context.Context<never>) =>
     Effect.succeed({ model, ...providerConfig, ...Context.getOrUndefined(services, Config) })
-  )
+  ).pipe(Effect.map(({ [ConfigTypeId]: _typeId, ...config }) => config))
 
   return yield* EmbeddingModel.make({
     embedMany: Effect.fnUntraced(function*({ inputs }) {
@@ -176,13 +187,13 @@ export const layer = (options: {
  * @since 4.0.0
  */
 export const withConfigOverride: {
-  (overrides: typeof Config.Service): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Config>>
-  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: typeof Config.Service): Effect.Effect<A, E, Exclude<R, Config>>
+  (overrides: ConfigShape): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Config>>
+  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: ConfigShape): Effect.Effect<A, E, Exclude<R, Config>>
 } = dual<
   (
-    overrides: typeof Config.Service
+    overrides: ConfigShape
   ) => <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Config>>,
-  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: typeof Config.Service) => Effect.Effect<A, E, Exclude<R, Config>>
+  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: ConfigShape) => Effect.Effect<A, E, Exclude<R, Config>>
 >(2, (self, overrides) =>
   Effect.flatMap(
     Effect.serviceOption(Config),

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -100,6 +100,10 @@ type ConfigOptions = Simplify<
 >
 type ModelConfig = Omit<ConfigOptions, "model"> & { readonly [x: string]: unknown }
 
+const ConfigTypeId = "~@effect/ai-openai-compat/OpenAiLanguageModel/Config"
+
+type ConfigShape = ConfigOptions & { readonly [x: string]: unknown }
+
 /**
  * Context service for OpenAI language model configuration.
  *
@@ -114,10 +118,17 @@ type ModelConfig = Omit<ConfigOptions, "model"> & { readonly [x: string]: unknow
  * @category services
  * @since 4.0.0
  */
-export class Config extends Context.Service<
-  Config,
-  ConfigOptions & { readonly [x: string]: unknown }
->()("@effect/ai-openai-compat/OpenAiLanguageModel/Config") {}
+export interface Config extends ConfigShape {
+  readonly [ConfigTypeId]: typeof ConfigTypeId
+}
+
+/**
+ * Service key for `Config` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Config = Context.Service<Config>("@effect/ai-openai-compat/OpenAiLanguageModel/Config")
 
 // =============================================================================
 // Provider Options / Metadata
@@ -577,11 +588,11 @@ export const make = Effect.fnUntraced(function*({ model, config: providerConfig 
 
   const makeConfig = Effect.contextWith((services: Context.Context<never>) =>
     Effect.succeed({ model, ...providerConfig, ...Context.getOrUndefined(services, Config) })
-  )
+  ).pipe(Effect.map(({ [ConfigTypeId]: _typeId, ...config }) => config))
 
   const makeRequest = Effect.fnUntraced(
     function*<Tools extends ReadonlyArray<Tool.Any>>({ config, options, toolNameMapper }: {
-      readonly config: typeof Config.Service
+      readonly config: ConfigShape
       readonly options: LanguageModel.ProviderOptions
       readonly toolNameMapper: Tool.NameMapper<Tools>
     }): Effect.fn.Return<CreateResponseRequestJson, AiError.AiError> {
@@ -703,13 +714,13 @@ export const layer = (options: {
  * @since 4.0.0
  */
 export const withConfigOverride: {
-  (overrides: typeof Config.Service): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Config>>
-  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: typeof Config.Service): Effect.Effect<A, E, Exclude<R, Config>>
+  (overrides: ConfigShape): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Config>>
+  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: ConfigShape): Effect.Effect<A, E, Exclude<R, Config>>
 } = dual<
   (
-    overrides: typeof Config.Service
+    overrides: ConfigShape
   ) => <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Config>>,
-  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: typeof Config.Service) => Effect.Effect<A, E, Exclude<R, Config>>
+  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: ConfigShape) => Effect.Effect<A, E, Exclude<R, Config>>
 >(2, (self, overrides) =>
   Effect.flatMap(
     Effect.serviceOption(Config),
@@ -740,7 +751,7 @@ const prepareMessages = Effect.fnUntraced(
     include,
     toolNameMapper
   }: {
-    readonly config: typeof Config.Service
+    readonly config: ConfigShape
     readonly options: LanguageModel.ProviderOptions
     readonly include: Set<IncludeEnum>
     readonly capabilities: ModelCapabilities
@@ -1463,7 +1474,7 @@ const prepareTools = Effect.fnUntraced(function*<Tools extends ReadonlyArray<Too
   options,
   toolNameMapper
 }: {
-  readonly config: typeof Config.Service
+  readonly config: ConfigShape
   readonly options: LanguageModel.ProviderOptions
   readonly toolNameMapper: Tool.NameMapper<Tools>
 }): Effect.fn.Return<{
@@ -1866,7 +1877,7 @@ const stringifyJson = (value: unknown): string =>
 // Utilities
 // =============================================================================
 
-const isFileId = (data: string, config: typeof Config.Service): boolean =>
+const isFileId = (data: string, config: ConfigShape): boolean =>
   config.fileIdPrefixes != null && config.fileIdPrefixes.some((prefix) => data.startsWith(prefix))
 
 const getItemId = (
@@ -1908,7 +1919,7 @@ const normalizeServiceTier = (
 }
 
 const prepareResponseFormat = Effect.fnUntraced(function*({ config, options }: {
-  readonly config: typeof Config.Service
+  readonly config: ConfigShape
   readonly options: LanguageModel.ProviderOptions
 }): Effect.fn.Return<TextResponseFormatConfiguration, AiError.AiError> {
   if (options.responseFormat.type === "json") {

--- a/packages/ai/openai-compat/test/OpenAiEmbeddingModel.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiEmbeddingModel.test.ts
@@ -209,6 +209,7 @@ const getRequestBody = (request: HttpClientRequest.HttpClientRequest) =>
   })
 
 const noopOpenAiClient: OpenAiClient.Service = {
+  ["~@effect/ai-openai-compat/OpenAiClient"]: "~@effect/ai-openai-compat/OpenAiClient" as const,
   client: undefined as unknown as OpenAiClient.Service["client"],
   createResponse: () => Effect.die(new Error("noop")),
   createResponseStream: () => Effect.die(new Error("noop")),

--- a/packages/ai/openai/src/OpenAiClient.ts
+++ b/packages/ai/openai/src/OpenAiClient.ts
@@ -51,6 +51,8 @@ import * as OpenAiSchema from "./OpenAiSchema.ts"
  * @since 4.0.0
  */
 export interface Service {
+  readonly [OpenAiClientTypeId]: typeof OpenAiClientTypeId
+
   /**
    * The transformed HTTP client used by this service.
    */
@@ -91,6 +93,8 @@ export interface Service {
 // Service Identifier
 // =============================================================================
 
+const OpenAiClientTypeId = "~@effect/ai-openai/OpenAiClient"
+
 /**
  * Service tag for the OpenAI client.
  *
@@ -106,9 +110,17 @@ export interface Service {
  * @category services
  * @since 4.0.0
  */
-export class OpenAiClient extends Context.Service<OpenAiClient, Service>()(
-  "@effect/ai-openai/OpenAiClient"
-) {}
+export interface OpenAiClient extends Service {
+  readonly [OpenAiClientTypeId]: typeof OpenAiClientTypeId
+}
+
+/**
+ * Service key for `OpenAiClient` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const OpenAiClient = Context.Service<OpenAiClient>("@effect/ai-openai/OpenAiClient")
 
 // =============================================================================
 // Options
@@ -326,6 +338,7 @@ export const make = Effect.fnUntraced(
       )
 
     return OpenAiClient.of({
+      [OpenAiClientTypeId]: OpenAiClientTypeId as typeof OpenAiClientTypeId,
       client: httpClient,
       createResponse,
       createResponseStream,
@@ -439,6 +452,8 @@ export const layerConfig = (options?: {
  */
 export type ResponseStreamEvent = typeof OpenAiSchema.ResponseStreamEvent.Type
 
+const OpenAiSocketTypeId = "~@effect/ai-openai/OpenAiClient/OpenAiSocket"
+
 /**
  * Service for creating OpenAI response streams over a WebSocket connection.
  *
@@ -464,7 +479,9 @@ export type ResponseStreamEvent = typeof OpenAiSchema.ResponseStreamEvent.Type
  * @category services
  * @since 4.0.0
  */
-export class OpenAiSocket extends Context.Service<OpenAiSocket, {
+export interface OpenAiSocket {
+  readonly [OpenAiSocketTypeId]: typeof OpenAiSocketTypeId
+
   /**
    * Create a streaming response using the OpenAI responses endpoint.
    */
@@ -477,7 +494,15 @@ export class OpenAiSocket extends Context.Service<OpenAiSocket, {
     ],
     AiError.AiError
   >
-}>()("@effect/ai-openai/OpenAiClient/OpenAiSocket") {}
+}
+
+/**
+ * Service key for `OpenAiSocket` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const OpenAiSocket = Context.Service<OpenAiSocket>("@effect/ai-openai/OpenAiClient/OpenAiSocket")
 
 const makeSocket = Effect.gen(function*() {
   const client = yield* OpenAiClient
@@ -631,6 +656,7 @@ const makeSocket = Effect.gen(function*() {
   const request = yield* makeRequest
 
   return OpenAiSocket.context({
+    [OpenAiSocketTypeId]: OpenAiSocketTypeId as typeof OpenAiSocketTypeId,
     createResponseStream(options) {
       const stream = Stream.unwrap(Effect.gen(function*() {
         const scope = yield* Effect.scope

--- a/packages/ai/openai/src/OpenAiClientGenerated.ts
+++ b/packages/ai/openai/src/OpenAiClientGenerated.ts
@@ -20,15 +20,25 @@ import { OpenAiConfig } from "./OpenAiConfig.ts"
 // Service Identifier
 // =============================================================================
 
+const OpenAiClientGeneratedTypeId = "~@effect/ai-openai/OpenAiClientGenerated"
+
 /**
  * Service identifier for the generated OpenAI client.
  *
  * @since 4.0.0
  * @category service
  */
-export class OpenAiClientGenerated extends Context.Service<OpenAiClientGenerated, Generated.OpenAiClient>()(
-  "@effect/ai-openai/OpenAiClientGenerated"
-) {}
+export interface OpenAiClientGenerated extends Generated.OpenAiClient {
+  readonly [OpenAiClientGeneratedTypeId]: typeof OpenAiClientGeneratedTypeId
+}
+
+/**
+ * Service key for `OpenAiClientGenerated` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const OpenAiClientGenerated = Context.Service<OpenAiClientGenerated>("@effect/ai-openai/OpenAiClientGenerated")
 
 // =============================================================================
 // Options
@@ -90,7 +100,7 @@ const withRedactedHeaders = Effect.updateService(
  * @category constructors
  */
 export const make = Effect.fnUntraced(
-  function*(options: Options): Effect.fn.Return<Generated.OpenAiClient, never, HttpClient.HttpClient> {
+  function*(options: Options): Effect.fn.Return<OpenAiClientGenerated, never, HttpClient.HttpClient> {
     const baseClient = yield* HttpClient.HttpClient
     const apiUrl = options.apiUrl ?? "https://api.openai.com/v1"
 
@@ -119,15 +129,18 @@ export const make = Effect.fnUntraced(
         : identity
     )
 
-    return Generated.make(httpClient, {
-      transformClient: Effect.fnUntraced(function*(client) {
-        const config = yield* OpenAiConfig.getOrUndefined
-        if (Predicate.isNotUndefined(config?.transformClient)) {
-          return config.transformClient(client)
-        }
-        return client
-      })
-    })
+    return Object.assign(
+      Generated.make(httpClient, {
+        transformClient: Effect.fnUntraced(function*(client) {
+          const config = yield* OpenAiConfig.getOrUndefined
+          if (Predicate.isNotUndefined(config?.transformClient)) {
+            return config.transformClient(client)
+          }
+          return client
+        })
+      }),
+      { [OpenAiClientGeneratedTypeId]: OpenAiClientGeneratedTypeId as typeof OpenAiClientGeneratedTypeId }
+    )
   },
   withRedactedHeaders
 )

--- a/packages/ai/openai/src/OpenAiConfig.ts
+++ b/packages/ai/openai/src/OpenAiConfig.ts
@@ -11,6 +11,8 @@ import * as Effect from "effect/Effect"
 import { dual } from "effect/Function"
 import type { HttpClient } from "effect/unstable/http/HttpClient"
 
+const OpenAiConfigTypeId = "~@effect/ai-openai/OpenAiConfig"
+
 /**
  * Context service for scoped OpenAI configuration used by provider operations.
  *
@@ -24,20 +26,30 @@ import type { HttpClient } from "effect/unstable/http/HttpClient"
  * @category services
  * @since 4.0.0
  */
-export class OpenAiConfig extends Context.Service<
-  OpenAiConfig,
-  OpenAiConfig.Service
->()("@effect/ai-openai/OpenAiConfig") {
-  /**
-   * Gets the configured OpenAI service from the current context when present.
-   *
-   * @since 4.0.0
-   */
-  static readonly getOrUndefined: Effect.Effect<typeof OpenAiConfig.Service | undefined> = Effect.map(
-    Effect.context<never>(),
-    Context.getOrUndefined(OpenAiConfig)
-  )
+export interface OpenAiConfig extends OpenAiConfig.Service {
+  readonly [OpenAiConfigTypeId]: typeof OpenAiConfigTypeId
 }
+
+/**
+ * Service key for `OpenAiConfig` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const OpenAiConfig = (() => {
+  const service = Context.Service<OpenAiConfig>("@effect/ai-openai/OpenAiConfig")
+  return Object.assign(service, {
+    /**
+     * Gets the configured OpenAI service from the current context when present.
+     *
+     * @since 4.0.0
+     */
+    getOrUndefined: Effect.map(
+      Effect.context<never>(),
+      Context.getOrUndefined(service)
+    )
+  })
+})()
 
 /**
  * Types used by the `OpenAiConfig` context service.
@@ -53,6 +65,8 @@ export declare namespace OpenAiConfig {
    * @since 4.0.0
    */
   export interface Service {
+    readonly [OpenAiConfigTypeId]: typeof OpenAiConfigTypeId
+
     readonly transformClient?: ((client: HttpClient) => HttpClient) | undefined
   }
 }
@@ -89,5 +103,10 @@ export const withClientTransform: {
 ) =>
   Effect.flatMap(
     OpenAiConfig.getOrUndefined,
-    (config) => Effect.provideService(self, OpenAiConfig, { ...config, transformClient })
+    (config) =>
+      Effect.provideService(self, OpenAiConfig, {
+        ...config,
+        [OpenAiConfigTypeId]: OpenAiConfigTypeId,
+        transformClient
+      })
   ))

--- a/packages/ai/openai/src/OpenAiEmbeddingModel.ts
+++ b/packages/ai/openai/src/OpenAiEmbeddingModel.ts
@@ -26,6 +26,20 @@ import type * as OpenAiSchema from "./OpenAiSchema.ts"
  */
 export type Model = "text-embedding-ada-002" | "text-embedding-3-small" | "text-embedding-3-large"
 
+const ConfigTypeId = "~@effect/ai-openai/OpenAiEmbeddingModel/Config"
+
+type ConfigShape = Simplify<
+  & Partial<
+    Omit<
+      typeof OpenAiSchema.CreateEmbeddingRequest.Encoded,
+      "input"
+    >
+  >
+  & {
+    readonly [x: string]: unknown
+  }
+>
+
 /**
  * Context service for OpenAI embedding model configuration.
  *
@@ -45,20 +59,17 @@ export type Model = "text-embedding-ada-002" | "text-embedding-3-small" | "text-
  * @category services
  * @since 4.0.0
  */
-export class Config extends Context.Service<
-  Config,
-  Simplify<
-    & Partial<
-      Omit<
-        typeof OpenAiSchema.CreateEmbeddingRequest.Encoded,
-        "input"
-      >
-    >
-    & {
-      readonly [x: string]: unknown
-    }
-  >
->()("@effect/ai-openai/OpenAiEmbeddingModel/Config") {}
+export interface Config extends ConfigShape {
+  readonly [ConfigTypeId]: typeof ConfigTypeId
+}
+
+/**
+ * Service key for `Config` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Config = Context.Service<Config>("@effect/ai-openai/OpenAiEmbeddingModel/Config")
 
 /**
  * Creates an `AiModel` for an OpenAI embedding model with its configured vector dimensions.
@@ -78,7 +89,7 @@ export const model = (
   model: (string & {}) | Model,
   options: {
     readonly dimensions: number
-    readonly config?: Omit<typeof Config.Service, "model" | "dimensions">
+    readonly config?: Omit<ConfigShape, "model" | "dimensions">
   }
 ): AiModel.Model<"openai", EmbeddingModel.EmbeddingModel | EmbeddingModel.Dimensions, OpenAiClient> =>
   AiModel.make(
@@ -126,13 +137,13 @@ export const model = (
  */
 export const make = Effect.fnUntraced(function*({ model, config: providerConfig }: {
   readonly model: (string & {}) | Model
-  readonly config?: Omit<typeof Config.Service, "model"> | undefined
+  readonly config?: Omit<ConfigShape, "model"> | undefined
 }): Effect.fn.Return<EmbeddingModel.Service, never, OpenAiClient> {
   const client = yield* OpenAiClient
 
   const makeConfig = Effect.contextWith((services: Context.Context<never>) =>
     Effect.succeed({ model, ...providerConfig, ...Context.getOrUndefined(services, Config) })
-  )
+  ).pipe(Effect.map(({ [ConfigTypeId]: _typeId, ...config }) => config))
 
   return yield* EmbeddingModel.make({
     embedMany: Effect.fnUntraced(function*({ inputs }) {
@@ -166,7 +177,7 @@ export const make = Effect.fnUntraced(function*({ model, config: providerConfig 
  */
 export const layer = (options: {
   readonly model: (string & {}) | Model
-  readonly config?: Omit<typeof Config.Service, "model"> | undefined
+  readonly config?: Omit<ConfigShape, "model"> | undefined
 }): Layer.Layer<EmbeddingModel.EmbeddingModel, never, OpenAiClient> =>
   Layer.effect(EmbeddingModel.EmbeddingModel, make(options))
 
@@ -190,19 +201,21 @@ export const layer = (options: {
  * @since 4.0.0
  */
 export const withConfigOverride: {
-  (overrides: typeof Config.Service): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Config>>
-  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: typeof Config.Service): Effect.Effect<A, E, Exclude<R, Config>>
+  (overrides: ConfigShape): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Config>>
+  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: ConfigShape): Effect.Effect<A, E, Exclude<R, Config>>
 } = dual<
   (
-    overrides: typeof Config.Service
+    overrides: ConfigShape
   ) => <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Config>>,
-  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: typeof Config.Service) => Effect.Effect<A, E, Exclude<R, Config>>
+  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: ConfigShape) => Effect.Effect<A, E, Exclude<R, Config>>
 >(2, (self, overrides) =>
   Effect.flatMap(
     Effect.serviceOption(Config),
     (config) =>
       Effect.provideService(self, Config, {
-        ...(config._tag === "Some" ? config.value : {}),
+        ...(config._tag === "Some" ? config.value : {
+          [ConfigTypeId]: ConfigTypeId as typeof ConfigTypeId
+        }),
         ...overrides
       })
   ))

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -61,6 +61,47 @@ type PromptCacheBreakpoint = { readonly mode: "explicit" }
 // Configuration
 // =============================================================================
 
+const ConfigTypeId = "~@effect/ai-openai/OpenAiLanguageModel/Config"
+
+type ConfigShape = Simplify<
+  & Partial<
+    Omit<
+      typeof OpenAiSchema.CreateResponse.Encoded,
+      "input" | "tools" | "tool_choice" | "stream" | "text"
+    >
+  >
+  & {
+    /**
+     * File ID prefixes used to identify file IDs in Responses API.
+     * When undefined, all file data is treated as base64 content.
+     *
+     * Examples:
+     * - OpenAI: ['file-'] for IDs like 'file-abc123'
+     * - Azure OpenAI: ['assistant-'] for IDs like 'assistant-abc123'
+     */
+    readonly fileIdPrefixes?: ReadonlyArray<string> | undefined
+    /**
+     * Configuration options for a text response from the model.
+     */
+    readonly text?: {
+      /**
+       * Constrains the verbosity of the model's response. Lower values will
+       * result in more concise responses, while higher values will result in
+       * more verbose responses.
+       *
+       * Defaults to `"medium"`.
+       */
+      readonly verbosity?: "low" | "medium" | "high" | undefined
+    } | undefined
+    /**
+     * Whether to use strict JSON schema validation.
+     *
+     * Defaults to `true`.
+     */
+    readonly strictJsonSchema?: boolean | undefined
+  }
+>
+
 /**
  * Context service for OpenAI language model configuration.
  *
@@ -79,47 +120,17 @@ type PromptCacheBreakpoint = { readonly mode: "explicit" }
  * @category services
  * @since 4.0.0
  */
-export class Config extends Context.Service<
-  Config,
-  Simplify<
-    & Partial<
-      Omit<
-        typeof OpenAiSchema.CreateResponse.Encoded,
-        "input" | "tools" | "tool_choice" | "stream" | "text"
-      >
-    >
-    & {
-      /**
-       * File ID prefixes used to identify file IDs in Responses API.
-       * When undefined, all file data is treated as base64 content.
-       *
-       * Examples:
-       * - OpenAI: ['file-'] for IDs like 'file-abc123'
-       * - Azure OpenAI: ['assistant-'] for IDs like 'assistant-abc123'
-       */
-      readonly fileIdPrefixes?: ReadonlyArray<string> | undefined
-      /**
-       * Configuration options for a text response from the model.
-       */
-      readonly text?: {
-        /**
-         * Constrains the verbosity of the model's response. Lower values will
-         * result in more concise responses, while higher values will result in
-         * more verbose responses.
-         *
-         * Defaults to `"medium"`.
-         */
-        readonly verbosity?: "low" | "medium" | "high" | undefined
-      } | undefined
-      /**
-       * Whether to use strict JSON schema validation.
-       *
-       * Defaults to `true`.
-       */
-      readonly strictJsonSchema?: boolean | undefined
-    }
-  >
->()("@effect/ai-openai/OpenAiLanguageModel/Config") {}
+export interface Config extends ConfigShape {
+  readonly [ConfigTypeId]: typeof ConfigTypeId
+}
+
+/**
+ * Service key for `Config` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Config = Context.Service<Config>("@effect/ai-openai/OpenAiLanguageModel/Config")
 
 // =============================================================================
 // Provider Options / Metadata
@@ -572,7 +583,7 @@ declare module "effect/unstable/ai/Response" {
  */
 export const model = (
   model: (string & {}) | Model,
-  config?: Omit<typeof Config.Service, "model">
+  config?: Omit<ConfigShape, "model">
 ): AiModel.Model<"openai", LanguageModel.LanguageModel, OpenAiClient> =>
   AiModel.make("openai", model, layer({ model, config }))
 
@@ -611,18 +622,18 @@ export const model = (
  */
 export const make = Effect.fnUntraced(function*({ model, config: providerConfig }: {
   readonly model: (string & {}) | Model
-  readonly config?: Omit<typeof Config.Service, "model"> | undefined
+  readonly config?: Omit<ConfigShape, "model"> | undefined
 }): Effect.fn.Return<LanguageModel.Service, never, OpenAiClient> {
   const client = yield* OpenAiClient
 
   const makeConfig = Effect.gen(function*() {
     const services = yield* Effect.context<never>()
     return { model, ...providerConfig, ...Context.getOrUndefined(services, Config) }
-  })
+  }).pipe(Effect.map(({ [ConfigTypeId]: _typeId, ...config }) => config))
 
   const makeRequest = Effect.fnUntraced(
     function*<Tools extends ReadonlyArray<Tool.Any>>({ config, options, toolNameMapper }: {
-      readonly config: typeof Config.Service
+      readonly config: ConfigShape
       readonly options: LanguageModel.ProviderOptions
       readonly toolNameMapper: Tool.NameMapper<Tools>
     }): Effect.fn.Return<typeof OpenAiSchema.CreateResponse.Encoded, AiError.AiError> {
@@ -731,7 +742,7 @@ export const make = Effect.fnUntraced(function*({ model, config: providerConfig 
  */
 export const layer = (options: {
   readonly model: (string & {}) | Model
-  readonly config?: Omit<typeof Config.Service, "model"> | undefined
+  readonly config?: Omit<ConfigShape, "model"> | undefined
 }): Layer.Layer<LanguageModel.LanguageModel, never, OpenAiClient> =>
   Layer.effect(LanguageModel.LanguageModel, make(options))
 
@@ -757,19 +768,21 @@ export const layer = (options: {
  * @since 4.0.0
  */
 export const withConfigOverride: {
-  (overrides: typeof Config.Service): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Config>>
-  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: typeof Config.Service): Effect.Effect<A, E, Exclude<R, Config>>
+  (overrides: ConfigShape): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Config>>
+  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: ConfigShape): Effect.Effect<A, E, Exclude<R, Config>>
 } = dual<
   (
-    overrides: typeof Config.Service
+    overrides: ConfigShape
   ) => <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Config>>,
-  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: typeof Config.Service) => Effect.Effect<A, E, Exclude<R, Config>>
+  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: ConfigShape) => Effect.Effect<A, E, Exclude<R, Config>>
 >(2, (self, overrides) =>
   Effect.flatMap(
     Effect.serviceOption(Config),
     (config) =>
       Effect.provideService(self, Config, {
-        ...(config._tag === "Some" ? config.value : {}),
+        ...(config._tag === "Some" ? config.value : {
+          [ConfigTypeId]: ConfigTypeId as typeof ConfigTypeId
+        }),
         ...overrides
       })
   ))
@@ -794,7 +807,7 @@ const prepareMessages = Effect.fnUntraced(
     include,
     toolNameMapper
   }: {
-    readonly config: typeof Config.Service
+    readonly config: ConfigShape
     readonly options: LanguageModel.ProviderOptions
     readonly include: Set<typeof OpenAiSchema.IncludeEnum.Encoded>
     readonly capabilities: ModelCapabilities
@@ -1695,7 +1708,7 @@ const makeStreamResponse = Effect.fnUntraced(
     options,
     toolNameMapper
   }: {
-    readonly config: typeof Config.Service
+    readonly config: ConfigShape
     readonly stream: Stream.Stream<ResponseStreamEvent, AiError.AiError>
     readonly response: HttpClientResponse.HttpClientResponse
     readonly options: LanguageModel.ProviderOptions
@@ -2713,7 +2726,7 @@ const prepareTools = Effect.fnUntraced(function*<Tools extends ReadonlyArray<Too
   options,
   toolNameMapper
 }: {
-  readonly config: typeof Config.Service
+  readonly config: ConfigShape
   readonly options: LanguageModel.ProviderOptions
   readonly toolNameMapper: Tool.NameMapper<Tools>
 }): Effect.fn.Return<{
@@ -2917,7 +2930,7 @@ const prepareTools = Effect.fnUntraced(function*<Tools extends ReadonlyArray<Too
 // Utilities
 // =============================================================================
 
-const isFileId = (data: string, config: typeof Config.Service): boolean =>
+const isFileId = (data: string, config: ConfigShape): boolean =>
   config.fileIdPrefixes != null && config.fileIdPrefixes.some((prefix) => data.startsWith(prefix))
 
 const getItemId = (
@@ -2979,7 +2992,7 @@ const tryToolJsonSchema = <T extends Tool.Any>(tool: T, method: string) =>
   })
 
 const prepareResponseFormat = Effect.fnUntraced(function*({ config, options }: {
-  readonly config: typeof Config.Service
+  readonly config: ConfigShape
   readonly options: LanguageModel.ProviderOptions
 }): Effect.fn.Return<typeof OpenAiSchema.TextResponseFormatConfiguration.Encoded, AiError.AiError> {
   if (options.responseFormat.type === "json") {

--- a/packages/ai/openai/test/OpenAiEmbeddingModel.test.ts
+++ b/packages/ai/openai/test/OpenAiEmbeddingModel.test.ts
@@ -282,6 +282,7 @@ const getRequestBody = (request: HttpClientRequest.HttpClientRequest) =>
   })
 
 const noopOpenAiClient: OpenAiClient.Service = {
+  ["~@effect/ai-openai/OpenAiClient"]: "~@effect/ai-openai/OpenAiClient" as const,
   client: undefined as unknown as OpenAiClient.Service["client"],
   createResponse: () => Effect.die(new Error("noop")),
   createResponseStream: () => Effect.die(new Error("noop")),

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -1992,6 +1992,7 @@ const makeStreamTestLayer = (events: ReadonlyArray<typeof Generated.ResponseStre
   return Layer.succeed(
     OpenAiClient.OpenAiClient,
     OpenAiClient.OpenAiClient.of({
+      ["~@effect/ai-openai/OpenAiClient"]: "~@effect/ai-openai/OpenAiClient" as const,
       client: undefined as any,
       createResponse: () => Effect.die(new Error("unexpected createResponse call")),
       createResponseStream: () => Effect.succeed([response, Stream.fromIterable(events)]),

--- a/packages/ai/openai/test/OpenAiSchema.test.ts
+++ b/packages/ai/openai/test/OpenAiSchema.test.ts
@@ -426,6 +426,7 @@ describe("OpenAiSchema", () => {
     const client = Layer.succeed(
       OpenAiClient.OpenAiClient,
       OpenAiClient.OpenAiClient.of({
+        ["~@effect/ai-openai/OpenAiClient"]: "~@effect/ai-openai/OpenAiClient" as const,
         client: undefined as any,
         createResponse: () => Effect.die("unexpected"),
         createResponseStream: () =>

--- a/packages/ai/openrouter/src/OpenRouterClient.ts
+++ b/packages/ai/openrouter/src/OpenRouterClient.ts
@@ -41,6 +41,8 @@ import { OpenRouterConfig } from "./OpenRouterConfig.ts"
  * @since 4.0.0
  */
 export interface Service {
+  readonly [OpenRouterClientTypeId]: typeof OpenRouterClientTypeId
+
   readonly client: Generated.OpenRouterClient
 
   readonly createChatCompletion: (
@@ -78,6 +80,8 @@ export type ChatStreamingResponseChunkData = typeof Generated.ChatStreamingRespo
 // Service Identifier
 // =============================================================================
 
+const OpenRouterClientTypeId = "~@effect/ai-openrouter/OpenRouterClient"
+
 /**
  * Service tag for the OpenRouter client.
  *
@@ -93,10 +97,17 @@ export type ChatStreamingResponseChunkData = typeof Generated.ChatStreamingRespo
  * @category services
  * @since 4.0.0
  */
-export class OpenRouterClient extends Context.Service<
-  OpenRouterClient,
-  Service
->()("@effect/ai-openrouter/OpenRouterClient") {}
+export interface OpenRouterClient extends Service {
+  readonly [OpenRouterClientTypeId]: typeof OpenRouterClientTypeId
+}
+
+/**
+ * Service key for `OpenRouterClient` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const OpenRouterClient = Context.Service<OpenRouterClient>("@effect/ai-openrouter/OpenRouterClient")
 
 // =============================================================================
 // Options
@@ -254,6 +265,7 @@ export const make = Effect.fnUntraced(
       )
 
     return OpenRouterClient.of({
+      [OpenRouterClientTypeId]: OpenRouterClientTypeId as typeof OpenRouterClientTypeId,
       client,
       createChatCompletion,
       createChatCompletionStream

--- a/packages/ai/openrouter/src/OpenRouterConfig.ts
+++ b/packages/ai/openrouter/src/OpenRouterConfig.ts
@@ -11,6 +11,8 @@ import * as Effect from "effect/Effect"
 import { dual } from "effect/Function"
 import type { HttpClient } from "effect/unstable/http/HttpClient"
 
+const OpenRouterConfigTypeId = "~@effect/ai-openrouter/OpenRouterConfig"
+
 /**
  * Context service for scoped OpenRouter provider configuration used by client
  * operations.
@@ -25,20 +27,30 @@ import type { HttpClient } from "effect/unstable/http/HttpClient"
  * @category services
  * @since 4.0.0
  */
-export class OpenRouterConfig extends Context.Service<
-  OpenRouterConfig,
-  OpenRouterConfig.Service
->()("@effect/ai-openrouter/OpenRouterConfig") {
-  /**
-   * Gets the configured OpenRouter service from the current context when present.
-   *
-   * @since 4.0.0
-   */
-  static readonly getOrUndefined: Effect.Effect<typeof OpenRouterConfig.Service | undefined> = Effect.map(
-    Effect.context<never>(),
-    Context.getOrUndefined(OpenRouterConfig)
-  )
+export interface OpenRouterConfig extends OpenRouterConfig.Service {
+  readonly [OpenRouterConfigTypeId]: typeof OpenRouterConfigTypeId
 }
+
+/**
+ * Service key for `OpenRouterConfig` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const OpenRouterConfig = (() => {
+  const service = Context.Service<OpenRouterConfig>("@effect/ai-openrouter/OpenRouterConfig")
+  return Object.assign(service, {
+    /**
+     * Gets the configured OpenRouter service from the current context when present.
+     *
+     * @since 4.0.0
+     */
+    getOrUndefined: Effect.map(
+      Effect.context<never>(),
+      Context.getOrUndefined(service)
+    )
+  })
+})()
 
 /**
  * Types associated with the `OpenRouterConfig` context service.
@@ -54,6 +66,8 @@ export declare namespace OpenRouterConfig {
    * @since 4.0.0
    */
   export interface Service {
+    readonly [OpenRouterConfigTypeId]: typeof OpenRouterConfigTypeId
+
     readonly transformClient?: ((client: HttpClient) => HttpClient) | undefined
   }
 }
@@ -94,6 +108,11 @@ export const withClientTransform: {
   (self, transformClient) =>
     Effect.flatMap(
       OpenRouterConfig.getOrUndefined,
-      (config) => Effect.provideService(self, OpenRouterConfig, { ...config, transformClient })
+      (config) =>
+        Effect.provideService(self, OpenRouterConfig, {
+          ...config,
+          [OpenRouterConfigTypeId]: OpenRouterConfigTypeId,
+          transformClient
+        })
     )
 )

--- a/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
+++ b/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
@@ -44,6 +44,26 @@ import { type ChatStreamingResponseChunkData, OpenRouterClient } from "./OpenRou
 // Configuration
 // =============================================================================
 
+const ConfigTypeId = "~@effect/ai-openrouter/OpenRouterLanguageModel/Config"
+
+type ConfigShape = Simplify<
+  & Partial<
+    Omit<
+      typeof Generated.ChatRequest.Encoded,
+      "messages" | "response_format" | "tools" | "tool_choice" | "stream" | "stream_options"
+    >
+  >
+  & {
+    /**
+     * Whether to use strict JSON schema validation for structured outputs.
+     *
+     * Only applies to models that support structured outputs. Defaults to
+     * `true` when structured outputs are supported.
+     */
+    readonly strictJsonSchema?: boolean | undefined
+  }
+>
+
 /**
  * Context service for OpenRouter language model configuration.
  *
@@ -57,26 +77,17 @@ import { type ChatStreamingResponseChunkData, OpenRouterClient } from "./OpenRou
  * @category services
  * @since 4.0.0
  */
-export class Config extends Context.Service<
-  Config,
-  Simplify<
-    & Partial<
-      Omit<
-        typeof Generated.ChatRequest.Encoded,
-        "messages" | "response_format" | "tools" | "tool_choice" | "stream" | "stream_options"
-      >
-    >
-    & {
-      /**
-       * Whether to use strict JSON schema validation for structured outputs.
-       *
-       * Only applies to models that support structured outputs. Defaults to
-       * `true` when structured outputs are supported.
-       */
-      readonly strictJsonSchema?: boolean | undefined
-    }
-  >
->()("@effect/ai-openrouter/OpenRouterLanguageModel/Config") {}
+export interface Config extends ConfigShape {
+  readonly [ConfigTypeId]: typeof ConfigTypeId
+}
+
+/**
+ * Service key for `Config` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Config = Context.Service<Config>("@effect/ai-openrouter/OpenRouterLanguageModel/Config")
 
 // =============================================================================
 // Provider Options / Metadata
@@ -506,7 +517,7 @@ declare module "effect/unstable/ai/Response" {
  */
 export const model = (
   model: string,
-  config?: Omit<typeof Config.Service, "model">
+  config?: Omit<ConfigShape, "model">
 ): AiModel.Model<"openai", LanguageModel.LanguageModel, OpenRouterClient> =>
   AiModel.make("openai", model, layer({ model, config }))
 
@@ -540,18 +551,18 @@ export const model = (
  */
 export const make = Effect.fnUntraced(function*({ model, config: providerConfig }: {
   readonly model: string
-  readonly config?: Omit<typeof Config.Service, "model"> | undefined
+  readonly config?: Omit<ConfigShape, "model"> | undefined
 }): Effect.fn.Return<LanguageModel.Service, never, OpenRouterClient> {
   const client = yield* OpenRouterClient
   const codecTransformer = getCodecTransformer(model)
 
   const makeConfig = Effect.contextWith((services: Context.Context<never>) =>
     Effect.succeed({ model, ...providerConfig, ...Context.getOrUndefined(services, Config) })
-  )
+  ).pipe(Effect.map(({ [ConfigTypeId]: _typeId, ...config }) => config))
 
   const makeRequest = Effect.fnUntraced(
     function*({ config, options }: {
-      readonly config: typeof Config.Service
+      readonly config: ConfigShape
       readonly options: LanguageModel.ProviderOptions
     }): Effect.fn.Return<typeof Generated.ChatRequest.Encoded, AiError.AiError> {
       const messages = yield* prepareMessages({ options })
@@ -618,7 +629,7 @@ export const make = Effect.fnUntraced(function*({ model, config: providerConfig 
  */
 export const layer = (options: {
   readonly model: string
-  readonly config?: Omit<typeof Config.Service, "model"> | undefined
+  readonly config?: Omit<ConfigShape, "model"> | undefined
 }): Layer.Layer<LanguageModel.LanguageModel, never, OpenRouterClient> =>
   Layer.effect(LanguageModel.LanguageModel, make(options))
 
@@ -643,19 +654,21 @@ export const layer = (options: {
  * @since 4.0.0
  */
 export const withConfigOverride: {
-  (overrides: typeof Config.Service): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Config>>
-  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: typeof Config.Service): Effect.Effect<A, E, Exclude<R, Config>>
+  (overrides: ConfigShape): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Config>>
+  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: ConfigShape): Effect.Effect<A, E, Exclude<R, Config>>
 } = dual<
   (
-    overrides: typeof Config.Service
+    overrides: ConfigShape
   ) => <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Config>>,
-  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: typeof Config.Service) => Effect.Effect<A, E, Exclude<R, Config>>
+  <A, E, R>(self: Effect.Effect<A, E, R>, overrides: ConfigShape) => Effect.Effect<A, E, Exclude<R, Config>>
 >(2, (self, overrides) =>
   Effect.flatMap(
     Effect.serviceOption(Config),
     (config) =>
       Effect.provideService(self, Config, {
-        ...(config._tag === "Some" ? config.value : {}),
+        ...(config._tag === "Some" ? config.value : {
+          [ConfigTypeId]: ConfigTypeId as typeof ConfigTypeId
+        }),
         ...overrides
       })
   ))
@@ -1776,7 +1789,7 @@ const tryToolJsonSchema = <T extends Tool.Any>(tool: T, method: string, transfor
   })
 
 const getResponseFormat = Effect.fnUntraced(function*({ config, options, transformer }: {
-  readonly config: typeof Config.Service
+  readonly config: ConfigShape
   readonly options: LanguageModel.ProviderOptions
   readonly transformer: LanguageModel.CodecTransformer
 }): Effect.fn.Return<typeof Generated.ChatFormatJsonSchemaConfig.Encoded | undefined, AiError.AiError> {

--- a/packages/ai/openrouter/test/Generated.test.ts
+++ b/packages/ai/openrouter/test/Generated.test.ts
@@ -131,6 +131,7 @@ describe("Generated", () => {
           success: Schema.String
         }))
         const client = OpenRouterClient.OpenRouterClient.of({
+          ["~@effect/ai-openrouter/OpenRouterClient"]: "~@effect/ai-openrouter/OpenRouterClient" as const,
           client: Generated.make(HttpClient.make(() => Effect.die("Unexpected HTTP request"))),
           createChatCompletion: () => Effect.succeed([body, response]),
           createChatCompletionStream: () => Effect.succeed([response, Stream.fromIterable(chunks)])

--- a/packages/effect/HTTPAPI.md
+++ b/packages/effect/HTTPAPI.md
@@ -1259,9 +1259,12 @@ import {
 import { createServer } from "node:http"
 
 // Define the service providing the current user
-class CurrentUser
-  extends Context.Service<CurrentUser, { readonly id: number; readonly name: string }>()("CurrentUser")
-{}
+interface CurrentUser {
+  readonly ["~CurrentUser"]: "~CurrentUser"
+  readonly id: number
+  readonly name: string
+}
+const CurrentUser = Context.Service<CurrentUser>("CurrentUser")
 
 // Define the security scheme: read the "session" cookie
 const sessionCookie = HttpApiSecurity.apiKey({ in: "cookie", key: "session" })
@@ -1298,7 +1301,11 @@ const AuthLayer = Layer.succeed(
           if (value !== "valid-session") {
             return yield* Effect.fail("Invalid session")
           }
-          return { id: 1, name: "John Doe" }
+          return {
+            ["~CurrentUser"]: "~CurrentUser" as const,
+            id: 1,
+            name: "John Doe"
+          }
         })
       )
   }
@@ -2478,9 +2485,12 @@ When you attach interdependent middleware to an endpoint, group, or API, the mid
 import { Context, Effect, Layer, Schema } from "effect"
 import { HttpApi, HttpApiEndpoint, HttpApiGroup, HttpApiMiddleware } from "effect/unstable/httpapi"
 
-class AuthInfo extends Context.Service<AuthInfo, {
+interface AuthInfo {
+  readonly ["~AuthInfo"]: "~AuthInfo"
+
   readonly userId: string
-}>()("AuthInfo") {}
+}
+const AuthInfo = Context.Service<AuthInfo>("AuthInfo")
 
 class LoadAuth extends HttpApiMiddleware.Service<LoadAuth, {
   readonly provides: AuthInfo
@@ -2506,6 +2516,7 @@ const LoadAuthLayer = Layer.effect(
   LoadAuth,
   Effect.succeed((effect) =>
     Effect.provideService(effect, AuthInfo, {
+      ["~AuthInfo"]: "~AuthInfo" as const,
       userId: "user-1"
     })
   )
@@ -2742,9 +2753,12 @@ const User = Schema.Struct({
 })
 
 // Define the UsersRepository service
-class UsersRepository extends Context.Service<UsersRepository, {
+interface UsersRepository {
+  readonly ["~UsersRepository"]: "~UsersRepository"
+
   readonly findById: (id: number) => Effect.Effect<typeof User.Type>
-}>()("UsersRepository") {}
+}
+const UsersRepository = Context.Service<UsersRepository>("UsersRepository")
 
 const Api = HttpApi.make("MyApi")
   .add(
@@ -2779,6 +2793,7 @@ const ApiLayer = HttpApiBuilder.layer(Api).pipe(
   Layer.provide(HttpApiScalar.layer(Api)),
   Layer.provide(
     Layer.succeed(UsersRepository, {
+      ["~UsersRepository"]: "~UsersRepository" as const,
       findById: (id) => Effect.succeed({ id, name: `User ${id}` })
     })
   ),

--- a/packages/effect/SCHEMA.md
+++ b/packages/effect/SCHEMA.md
@@ -2991,9 +2991,11 @@ SchemaParser.makeEffect(schema)({}).pipe(Effect.runPromise).then(console.log)
 import { Context, Effect, Option, Schema, SchemaParser } from "effect"
 
 // Define a service that may provide a default value
-class ConstructorService extends Context.Service<ConstructorService, { defaultValue: Effect.Effect<number> }>()(
-  "ConstructorService"
-) {}
+interface ConstructorService {
+  readonly ["~ConstructorService"]: "~ConstructorService"
+  defaultValue: Effect.Effect<number>
+}
+const ConstructorService = Context.Service<ConstructorService>("ConstructorService")
 
 const schema = Schema.Struct({
   a: Schema.Number.pipe(
@@ -3012,7 +3014,13 @@ const schema = Schema.Struct({
 
 SchemaParser.makeEffect(schema)({})
   .pipe(
-    Effect.provideService(ConstructorService, ConstructorService.of({ defaultValue: Effect.succeed(0) })),
+    Effect.provideService(
+      ConstructorService,
+      ConstructorService.of({
+        ["~ConstructorService"]: "~ConstructorService" as const,
+        defaultValue: Effect.succeed(0)
+      })
+    ),
     Effect.runPromise
   )
   .then(console.log, console.error)
@@ -6568,7 +6576,11 @@ You can use `Schema.catchDecodingWithContext` to get a fallback value from a ser
 import { Context, Effect, Option, Schema } from "effect"
 
 // Define a service that provides a fallback value
-class Service extends Context.Service<Service, { fallback: Effect.Effect<string> }>()("Service") {}
+interface Service {
+  readonly ["~Service"]: "~Service"
+  fallback: Effect.Effect<string>
+}
+const Service = Context.Service<Service>("Service")
 
 //      ┌─── Codec<string, string, Service, never>
 //      ▼
@@ -6589,7 +6601,10 @@ const schema = Schema.revealCodec(
 //      ┌─── Codec<string, string, never, never>
 //      ▼
 const provided = Schema.revealCodec(
-  schema.pipe(Schema.middlewareDecoding(Effect.provideService(Service, { fallback: Effect.succeed("b") })))
+  schema.pipe(Schema.middlewareDecoding(Effect.provideService(Service, {
+    ["~Service"]: "~Service" as const,
+    fallback: Effect.succeed("b")
+  })))
 )
 
 console.log(String(Schema.decodeUnknownExit(provided)(null)))
@@ -6856,12 +6871,12 @@ import type { Effect } from "effect"
 import { Context, Schema } from "effect"
 
 // A service that retrieves full user info from an ID
-class UserDatabase extends Context.Service<
-  UserDatabase,
-  {
-    getUserById: (id: string) => Effect.Effect<{ readonly id: string; readonly name: string }>
-  }
->()("UserDatabase") {}
+interface UserDatabase {
+  readonly ["~UserDatabase"]: "~UserDatabase"
+
+  getUserById: (id: string) => Effect.Effect<{ readonly id: string; readonly name: string }>
+}
+const UserDatabase = Context.Service<UserDatabase>("UserDatabase")
 
 // Schema that decodes from an ID to a user object using the database,
 // but encodes just the ID

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -83,12 +83,17 @@ export interface Key<out Identifier, out Shape> extends Effect<Shape, never, Ide
  * import { Context } from "effect"
  *
  * // Define an identifier for a database service
- * const Database = Context.Service<{ query: (sql: string) => string }>(
- *   "Database"
- * )
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *   query: (sql: string) => string
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * // The key can be used to store and retrieve services
- * const context = Context.make(Database, { query: (sql) => `Result: ${sql}` })
+ * const context = Context.make(Database, {
+ *   ["~Database"]: "~Database" as const,
+ *   query: (sql) => `Result: ${sql}`
+ * })
  * Context.get(context, Database).query("SELECT 1") // => "Result: SELECT 1"
  * ```
  *
@@ -347,9 +352,12 @@ export interface Reference<in out Shape> extends Service<never, Shape> {
  * ```ts import.meta.vitest
  * import { Context } from "effect"
  *
- * const Database = Context.Service<{
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   query: (sql: string) => string
- * }>("Database")
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * // Extract service type from a key
  * type DatabaseService = Context.Service.Shape<typeof Database>
@@ -394,9 +402,11 @@ export declare namespace Service {
    * ```ts import.meta.vitest
    * import { Context } from "effect"
    *
-   * const Database = Context.Service<{ query: (sql: string) => string }>(
-   *   "Database"
-   * )
+   * interface Database {
+   *   readonly ["~Database"]: "~Database"
+   *   query: (sql: string) => string
+   * }
+   * const Database = Context.Service<Database>("Database")
    *
    * // Extract the service shape from the service
    * type DatabaseService = Context.Service.Shape<typeof Database>
@@ -418,9 +428,11 @@ export declare namespace Service {
    * ```ts import.meta.vitest
    * import { Context } from "effect"
    *
-   * const Database = Context.Service<{ query: (sql: string) => string }>(
-   *   "Database"
-   * )
+   * interface Database {
+   *   readonly ["~Database"]: "~Database"
+   *   query: (sql: string) => string
+   * }
+   * const Database = Context.Service<Database>("Database")
    *
    * // Extract the identifier type from a key
    * type DatabaseId = Context.Service.Identifier<typeof Database>
@@ -451,13 +463,25 @@ const TypeId = "~effect/Context" as const
  * import { Context } from "effect"
  *
  * // Create a context with multiple services
- * const Logger = Context.Service<{ log: (msg: string) => void }>("Logger")
- * const Database = Context.Service<{ query: (sql: string) => string }>(
- *   "Database"
- * )
+ * interface Logger {
+ *   readonly ["~Logger"]: "~Logger"
+ *   log: (msg: string) => void
+ * }
+ * const Logger = Context.Service<Logger>("Logger")
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *   query: (sql: string) => string
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
- * const context = Context.make(Logger, { log: (_msg: string) => {} })
- *   .pipe(Context.add(Database, { query: (sql) => `Result: ${sql}` }))
+ * const context = Context.make(Logger, {
+ *   ["~Logger"]: "~Logger" as const,
+ *   log: (_msg: string) => {}
+ * })
+ *   .pipe(Context.add(Database, {
+ *     ["~Database"]: "~Database" as const,
+ *     query: (sql) => `Result: ${sql}`
+ *   }))
  * Context.get(context, Database).query("SELECT 1") // => "Result: SELECT 1"
  * ```
  *
@@ -711,9 +735,16 @@ const emptyContext = makeUnsafe(new Map())
  * ```ts import.meta.vitest
  * import { Context } from "effect"
  *
- * const Port = Context.Service<{ PORT: number }>("Port")
+ * interface Port {
+ *   readonly ["~Port"]: "~Port"
+ *   PORT: number
+ * }
+ * const Port = Context.Service<Port>("Port")
  *
- * const context = Context.make(Port, { PORT: 8080 })
+ * const context = Context.make(Port, {
+ *   ["~Port"]: "~Port" as const,
+ *   PORT: 8080
+ * })
  *
  * Context.get(context, Port).PORT // => 8080
  * ```
@@ -743,14 +774,28 @@ export const make = <I, S>(
  * ```ts import.meta.vitest
  * import { Context, pipe } from "effect"
  *
- * const Port = Context.Service<{ PORT: number }>("Port")
- * const Timeout = Context.Service<{ TIMEOUT: number }>("Timeout")
+ * interface Port {
+ *   readonly ["~Port"]: "~Port"
+ *   PORT: number
+ * }
+ * const Port = Context.Service<Port>("Port")
+ * interface Timeout {
+ *   readonly ["~Timeout"]: "~Timeout"
+ *   TIMEOUT: number
+ * }
+ * const Timeout = Context.Service<Timeout>("Timeout")
  *
- * const someContext = Context.make(Port, { PORT: 8080 })
+ * const someContext = Context.make(Port, {
+ *   ["~Port"]: "~Port" as const,
+ *   PORT: 8080
+ * })
  *
  * const context = pipe(
  *   someContext,
- *   Context.add(Timeout, { TIMEOUT: 5000 })
+ *   Context.add(Timeout, {
+ *     ["~Timeout"]: "~Timeout" as const,
+ *     TIMEOUT: 5000
+ *   })
  * )
  *
  * const values = [Context.get(context, Port).PORT, Context.get(context, Timeout).TIMEOUT]
@@ -824,16 +869,26 @@ export const addUnsafe = <Services, I, S>(
  * ```ts import.meta.vitest
  * import { Context, Option } from "effect"
  *
- * const Port = Context.Service<{ PORT: number }>("Port")
+ * interface Port {
+ *   readonly ["~Port"]: "~Port"
+ *   PORT: number
+ * }
+ * const Port = Context.Service<Port>("Port")
  *
  * const withPort = Context.empty().pipe(
- *   Context.addOrOmit(Port, Option.some({ PORT: 8080 }))
+ *   Context.addOrOmit(
+ *     Port,
+ *     Option.some({
+ *       ["~Port"]: "~Port" as const,
+ *       PORT: 8080
+ *     })
+ *   )
  * )
  *
  * const withoutPort = withPort.pipe(
  *   Context.addOrOmit(Port, Option.none())
  * )
- * Context.getOption(withPort, Port) // => Option.some({ PORT: 8080 })
+ * Context.getOption(withPort, Port).pipe(Option.map((port) => port.PORT)) // => Option.some(8080)
  * Context.getOption(withoutPort, Port) // => Option.none()
  * ```
  *
@@ -885,18 +940,33 @@ export const addOrOmit: {
  * ```ts import.meta.vitest
  * import { Context } from "effect"
  *
- * const Logger = Context.Service<{ log: (msg: string) => void }>("Logger")
- * const Database = Context.Service<{ query: (sql: string) => string }>(
- *   "Database"
- * )
+ * interface Logger {
+ *   readonly ["~Logger"]: "~Logger"
+ *   log: (msg: string) => void
+ * }
+ * const Logger = Context.Service<Logger>("Logger")
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *   query: (sql: string) => string
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
- * const context = Context.make(Logger, { log: (_msg: string) => {} })
+ * const context = Context.make(Logger, {
+ *   ["~Logger"]: "~Logger" as const,
+ *   log: (_msg: string) => {}
+ * })
  *
- * const logger = Context.getOrElse(context, Logger, () => ({ log: () => {} }))
+ * const logger = Context.getOrElse(context, Logger, () => ({
+ *   ["~Logger"]: "~Logger" as const,
+ *   log: () => {}
+ * }))
  * const database = Context.getOrElse(
  *   context,
  *   Database,
- *   () => ({ query: () => "fallback" })
+ *   () => ({
+ *     ["~Database"]: "~Database" as const,
+ *     query: () => "fallback"
+ *   })
  * )
  *
  * logger === Context.get(context, Logger) // => true
@@ -970,10 +1040,21 @@ export const getOrUndefinedUnsafe = <A, Services = never>(self: Context<Services
  * ```ts import.meta.vitest
  * import { Context, Option } from "effect"
  *
- * const Port = Context.Service<{ PORT: number }>("Port")
- * const Timeout = Context.Service<{ TIMEOUT: number }>("Timeout")
+ * interface Port {
+ *   readonly ["~Port"]: "~Port"
+ *   PORT: number
+ * }
+ * const Port = Context.Service<Port>("Port")
+ * interface Timeout {
+ *   readonly ["~Timeout"]: "~Timeout"
+ *   TIMEOUT: number
+ * }
+ * const Timeout = Context.Service<Timeout>("Timeout")
  *
- * const context = Context.make(Port, { PORT: 8080 })
+ * const context = Context.make(Port, {
+ *   ["~Port"]: "~Port" as const,
+ *   PORT: 8080
+ * })
  *
  * Context.getUnsafe(context, Port).PORT // => 8080
  * Context.getOption(context, Timeout) // => Option.none()
@@ -1013,12 +1094,26 @@ export const getUnsafe: {
  * ```ts import.meta.vitest
  * import { Context, pipe } from "effect"
  *
- * const Port = Context.Service<{ PORT: number }>("Port")
- * const Timeout = Context.Service<{ TIMEOUT: number }>("Timeout")
+ * interface Port {
+ *   readonly ["~Port"]: "~Port"
+ *   PORT: number
+ * }
+ * const Port = Context.Service<Port>("Port")
+ * interface Timeout {
+ *   readonly ["~Timeout"]: "~Timeout"
+ *   TIMEOUT: number
+ * }
+ * const Timeout = Context.Service<Timeout>("Timeout")
  *
  * const context = pipe(
- *   Context.make(Port, { PORT: 8080 }),
- *   Context.add(Timeout, { TIMEOUT: 5000 })
+ *   Context.make(Port, {
+ *     ["~Port"]: "~Port" as const,
+ *     PORT: 8080
+ *   }),
+ *   Context.add(Timeout, {
+ *     ["~Timeout"]: "~Timeout" as const,
+ *     TIMEOUT: 5000
+ *   })
  * )
  *
  * Context.get(context, Timeout).TIMEOUT // => 5000
@@ -1076,12 +1171,23 @@ const serviceNotFoundError = (service: Key<any, any>) => {
  * ```ts import.meta.vitest
  * import { Context, Option } from "effect"
  *
- * const Port = Context.Service<{ PORT: number }>("Port")
- * const Timeout = Context.Service<{ TIMEOUT: number }>("Timeout")
+ * interface Port {
+ *   readonly ["~Port"]: "~Port"
+ *   PORT: number
+ * }
+ * const Port = Context.Service<Port>("Port")
+ * interface Timeout {
+ *   readonly ["~Timeout"]: "~Timeout"
+ *   TIMEOUT: number
+ * }
+ * const Timeout = Context.Service<Timeout>("Timeout")
  *
- * const context = Context.make(Port, { PORT: 8080 })
+ * const context = Context.make(Port, {
+ *   ["~Port"]: "~Port" as const,
+ *   PORT: 8080
+ * })
  *
- * Context.getOption(context, Port) // => Option.some({ PORT: 8080 })
+ * Context.getOption(context, Port).pipe(Option.map((port) => port.PORT)) // => Option.some(8080)
  * Context.getOption(context, Timeout) // => Option.none()
  * ```
  *
@@ -1116,11 +1222,25 @@ export const getOption: {
  * ```ts import.meta.vitest
  * import { Context } from "effect"
  *
- * const Port = Context.Service<{ PORT: number }>("Port")
- * const Timeout = Context.Service<{ TIMEOUT: number }>("Timeout")
+ * interface Port {
+ *   readonly ["~Port"]: "~Port"
+ *   PORT: number
+ * }
+ * const Port = Context.Service<Port>("Port")
+ * interface Timeout {
+ *   readonly ["~Timeout"]: "~Timeout"
+ *   TIMEOUT: number
+ * }
+ * const Timeout = Context.Service<Timeout>("Timeout")
  *
- * const firstContext = Context.make(Port, { PORT: 8080 })
- * const secondContext = Context.make(Timeout, { TIMEOUT: 5000 })
+ * const firstContext = Context.make(Port, {
+ *   ["~Port"]: "~Port" as const,
+ *   PORT: 8080
+ * })
+ * const secondContext = Context.make(Timeout, {
+ *   ["~Timeout"]: "~Timeout" as const,
+ *   TIMEOUT: 5000
+ * })
  *
  * const context = Context.merge(firstContext, secondContext)
  *
@@ -1159,13 +1279,34 @@ export const merge: {
  * ```ts import.meta.vitest
  * import { Context } from "effect"
  *
- * const Port = Context.Service<{ PORT: number }>("Port")
- * const Timeout = Context.Service<{ TIMEOUT: number }>("Timeout")
- * const Host = Context.Service<{ HOST: string }>("Host")
+ * interface Port {
+ *   readonly ["~Port"]: "~Port"
+ *   PORT: number
+ * }
+ * const Port = Context.Service<Port>("Port")
+ * interface Timeout {
+ *   readonly ["~Timeout"]: "~Timeout"
+ *   TIMEOUT: number
+ * }
+ * const Timeout = Context.Service<Timeout>("Timeout")
+ * interface Host {
+ *   readonly ["~Host"]: "~Host"
+ *   HOST: string
+ * }
+ * const Host = Context.Service<Host>("Host")
  *
- * const firstContext = Context.make(Port, { PORT: 8080 })
- * const secondContext = Context.make(Timeout, { TIMEOUT: 5000 })
- * const thirdContext = Context.make(Host, { HOST: "localhost" })
+ * const firstContext = Context.make(Port, {
+ *   ["~Port"]: "~Port" as const,
+ *   PORT: 8080
+ * })
+ * const secondContext = Context.make(Timeout, {
+ *   ["~Timeout"]: "~Timeout" as const,
+ *   TIMEOUT: 5000
+ * })
+ * const thirdContext = Context.make(Host, {
+ *   ["~Host"]: "~Host" as const,
+ *   HOST: "localhost"
+ * })
  *
  * const context = Context.mergeAll(
  *   firstContext,
@@ -1205,17 +1346,31 @@ export const mergeAll = <T extends Array<unknown>>(
  * ```ts import.meta.vitest
  * import { Context, Option, pipe } from "effect"
  *
- * const Port = Context.Service<{ PORT: number }>("Port")
- * const Timeout = Context.Service<{ TIMEOUT: number }>("Timeout")
+ * interface Port {
+ *   readonly ["~Port"]: "~Port"
+ *   PORT: number
+ * }
+ * const Port = Context.Service<Port>("Port")
+ * interface Timeout {
+ *   readonly ["~Timeout"]: "~Timeout"
+ *   TIMEOUT: number
+ * }
+ * const Timeout = Context.Service<Timeout>("Timeout")
  *
  * const someContext = pipe(
- *   Context.make(Port, { PORT: 8080 }),
- *   Context.add(Timeout, { TIMEOUT: 5000 })
+ *   Context.make(Port, {
+ *     ["~Port"]: "~Port" as const,
+ *     PORT: 8080
+ *   }),
+ *   Context.add(Timeout, {
+ *     ["~Timeout"]: "~Timeout" as const,
+ *     TIMEOUT: 5000
+ *   })
  * )
  *
  * const context = pipe(someContext, Context.pick(Port))
  *
- * Context.getOption(context, Port) // => Option.some({ PORT: 8080 })
+ * Context.getOption(context, Port).pipe(Option.map((port) => port.PORT)) // => Option.some(8080)
  * Context.getOption(context, Timeout) // => Option.none()
  * ```
  *
@@ -1247,17 +1402,31 @@ export const pick = <S extends ReadonlyArray<Key<any, any>>>(
  * ```ts import.meta.vitest
  * import { Context, Option, pipe } from "effect"
  *
- * const Port = Context.Service<{ PORT: number }>("Port")
- * const Timeout = Context.Service<{ TIMEOUT: number }>("Timeout")
+ * interface Port {
+ *   readonly ["~Port"]: "~Port"
+ *   PORT: number
+ * }
+ * const Port = Context.Service<Port>("Port")
+ * interface Timeout {
+ *   readonly ["~Timeout"]: "~Timeout"
+ *   TIMEOUT: number
+ * }
+ * const Timeout = Context.Service<Timeout>("Timeout")
  *
  * const someContext = pipe(
- *   Context.make(Port, { PORT: 8080 }),
- *   Context.add(Timeout, { TIMEOUT: 5000 })
+ *   Context.make(Port, {
+ *     ["~Port"]: "~Port" as const,
+ *     PORT: 8080
+ *   }),
+ *   Context.add(Timeout, {
+ *     ["~Timeout"]: "~Timeout" as const,
+ *     TIMEOUT: 5000
+ *   })
  * )
  *
  * const context = pipe(someContext, Context.omit(Timeout))
  *
- * Context.getOption(context, Port) // => Option.some({ PORT: 8080 })
+ * Context.getOption(context, Port).pipe(Option.map((port) => port.PORT)) // => Option.some(8080)
  * Context.getOption(context, Timeout) // => Option.none()
  * ```
  *

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -4330,7 +4330,11 @@ export const ignoreCause: <
  * ```ts import.meta.vitest
  * import { Context, Effect, ExecutionPlan, Layer } from "effect"
  *
- * const Endpoint = Context.Service<{ url: string }>("Endpoint")
+ * interface Endpoint {
+ *   readonly ["~Endpoint"]: "~Endpoint"
+ *   url: string
+ * }
+ * const Endpoint = Context.Service<Endpoint>("Endpoint")
  *
  * const fetchUrl = Effect.gen(function*() {
  *   const endpoint = yield* Effect.service(Endpoint)
@@ -4341,8 +4345,19 @@ export const ignoreCause: <
  * })
  *
  * const plan = ExecutionPlan.make(
- *   { provide: Layer.succeed(Endpoint, { url: "bad" }), attempts: 2 },
- *   { provide: Layer.succeed(Endpoint, { url: "good" }) }
+ *   {
+ *     provide: Layer.succeed(Endpoint, {
+ *       ["~Endpoint"]: "~Endpoint" as const,
+ *       url: "bad"
+ *     }),
+ *     attempts: 2
+ *   },
+ *   {
+ *     provide: Layer.succeed(Endpoint, {
+ *       ["~Endpoint"]: "~Endpoint" as const,
+ *       url: "good"
+ *     })
+ *   }
  * )
  *
  * const program = Effect.withExecutionPlan(fetchUrl, plan)
@@ -4354,7 +4369,11 @@ export const ignoreCause: <
  * ```ts import.meta.vitest
  * import { Context, Effect, ExecutionPlan, Layer } from "effect"
  *
- * const Endpoint = Context.Service<{ url: string }>("Endpoint")
+ * interface Endpoint {
+ *   readonly ["~Endpoint"]: "~Endpoint"
+ *   url: string
+ * }
+ * const Endpoint = Context.Service<Endpoint>("Endpoint")
  *
  * const fetchUrl = Effect.gen(function*() {
  *   const endpoint = yield* Effect.service(Endpoint)
@@ -4365,8 +4384,18 @@ export const ignoreCause: <
  * })
  *
  * const plan = ExecutionPlan.make(
- *   { provide: Layer.succeed(Endpoint, { url: "bad" }) },
- *   { provide: Layer.succeed(Endpoint, { url: "good" }) }
+ *   {
+ *     provide: Layer.succeed(Endpoint, {
+ *       ["~Endpoint"]: "~Endpoint" as const,
+ *       url: "bad"
+ *     })
+ *   },
+ *   {
+ *     provide: Layer.succeed(Endpoint, {
+ *       ["~Endpoint"]: "~Endpoint" as const,
+ *       url: "good"
+ *     })
+ *   }
  * )
  *
  * const events: Array<string> = []
@@ -5747,12 +5776,18 @@ export const isSuccess: <A, E, R>(self: Effect<A, E, R>) => Effect<boolean, neve
  * import { Context, Effect, Option } from "effect"
  * const output: Array<unknown> = []
  *
- * const Logger = Context.Service<{
+ * interface Logger {
+ *   readonly ["~Logger"]: "~Logger"
+ *
  *   log: (msg: string) => void
- * }>("Logger")
- * const Database = Context.Service<{
+ * }
+ * const Logger = Context.Service<Logger>("Logger")
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   query: (sql: string) => string
- * }>("Database")
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * const program = Effect.gen(function*() {
  *   const allServices = yield* Effect.context()
@@ -5761,12 +5796,22 @@ export const isSuccess: <A, E, R>(self: Effect<A, E, R>) => Effect<boolean, neve
  *   const loggerOption = Context.getOption(allServices, Logger)
  *   const databaseOption = Context.getOption(allServices, Database)
  *
- *   yield* Effect.sync(() => { output.push(`Logger available: ${Option.isSome(loggerOption)}`) })
- *   yield* Effect.sync(() => { output.push(`Database available: ${Option.isSome(databaseOption)}`) })
+ *   yield* Effect.sync(() => {
+ *     output.push(`Logger available: ${Option.isSome(loggerOption)}`)
+ *   })
+ *   yield* Effect.sync(() => {
+ *     output.push(`Database available: ${Option.isSome(databaseOption)}`)
+ *   })
  * })
  *
- * const context = Context.make(Logger, { log: () => {} })
- *   .pipe(Context.add(Database, { query: () => "result" }))
+ * const context = Context.make(Logger, {
+ *   ["~Logger"]: "~Logger" as const,
+ *   log: () => {}
+ * })
+ *   .pipe(Context.add(Database, {
+ *     ["~Database"]: "~Database" as const,
+ *     query: () => "result"
+ *   }))
  *
  * const provided = Effect.provideContext(program, context)
  * Effect.runSync(provided)
@@ -5800,12 +5845,18 @@ export const context: <R = never>() => Effect<Context.Context<R>, never, R> = in
  * import { Context, Effect, Option } from "effect"
  * const output: Array<unknown> = []
  *
- * const Logger = Context.Service<{
+ * interface Logger {
+ *   readonly ["~Logger"]: "~Logger"
+ *
  *   log: (msg: string) => void
- * }>("Logger")
- * const Cache = Context.Service<{
+ * }
+ * const Logger = Context.Service<Logger>("Logger")
+ * interface Cache {
+ *   readonly ["~Cache"]: "~Cache"
+ *
  *   get: (key: string) => string | null
- * }>("Cache")
+ * }
+ * const Cache = Context.Service<Cache>("Cache")
  *
  * const program = Effect.contextWith((services: Context.Context<Context.Service.Identifier<typeof Cache>>) => {
  *   const cacheOption = Context.getOption(services, Cache)
@@ -5814,18 +5865,23 @@ export const context: <R = never>() => Effect<Context.Context<R>, never, R> = in
  *   if (hasCache) {
  *     return Effect.gen(function*() {
  *       const cache = yield* Effect.service(Cache)
- *       yield* Effect.sync(() => { output.push("Using cached data") })
+ *       yield* Effect.sync(() => {
+ *         output.push("Using cached data")
+ *       })
  *       return cache.get("user:123") || "default"
  *     })
  *   } else {
  *     return Effect.gen(function*() {
- *       yield* Effect.sync(() => { output.push("No cache available, using fallback") })
+ *       yield* Effect.sync(() => {
+ *         output.push("No cache available, using fallback")
+ *       })
  *       return "fallback data"
  *     })
  *   }
  * })
  *
  * const withCache = Effect.provideService(program, Cache, {
+ *   ["~Cache"]: "~Cache" as const,
  *   get: () => "cached_value"
  * })
  * void output.push(Effect.runSync(withCache))
@@ -5939,16 +5995,30 @@ export const provide: {
  * const output: Array<unknown> = []
  *
  * // Define service keys
- * const Logger = Context.Service<{
+ * interface Logger {
+ *   readonly ["~Logger"]: "~Logger"
+ *
  *   log: (msg: string) => void
- * }>("Logger")
- * const Database = Context.Service<{
+ * }
+ * const Logger = Context.Service<Logger>("Logger")
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   query: (sql: string) => string
- * }>("Database")
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * // Create a context with multiple services
- * const context = Context.make(Logger, { log: (message) => { output.push(message) } })
- *   .pipe(Context.add(Database, { query: () => "result" }))
+ * const context = Context.make(Logger, {
+ *   ["~Logger"]: "~Logger" as const,
+ *   log: (message) => {
+ *     output.push(message)
+ *   }
+ * })
+ *   .pipe(Context.add(Database, {
+ *     ["~Database"]: "~Database" as const,
+ *     query: () => "result"
+ *   }))
  *
  * // An effect that requires both services
  * const program = Effect.gen(function*() {
@@ -5995,16 +6065,22 @@ export const provideContext: {
  * ```ts import.meta.vitest
  * import { Context, Effect } from "effect"
  *
- * class Config extends Context.Service<Config, {
+ * interface Config {
+ *   readonly ["~Config"]: "~Config"
+ *
  *   readonly greeting: string
- * }>()("Config") {}
+ * }
+ * const Config = Context.Service<Config>("Config")
  *
  * const program = Effect.gen(function*() {
  *   const config = yield* Effect.service(Config)
  *   return `${config.greeting}, World!`
  * })
  *
- * const context = Context.make(Config, { greeting: "Hello" })
+ * const context = Context.make(Config, {
+ *   ["~Config"]: "~Config" as const,
+ *   greeting: "Hello"
+ * })
  *
  * const runnable = Effect.setContext(program, context)
  *
@@ -6074,9 +6150,12 @@ export const service: <I, S>(service: Context.Key<I, S>) => Effect<S, never, I> 
  * const output: Array<unknown> = []
  *
  * // Define a service key
- * const Logger = Context.Service<{
+ * interface Logger {
+ *   readonly ["~Logger"]: "~Logger"
+ *
  *   log: (msg: string) => void
- * }>("Logger")
+ * }
+ * const Logger = Context.Service<Logger>("Logger")
  *
  * // Use serviceOption to optionally access the logger
  * const program = Effect.gen(function*() {
@@ -6112,12 +6191,18 @@ export const serviceOption: <I, S>(key: Context.Key<I, S>) => Effect<Option<S>> 
  * import { Context, Effect } from "effect"
  *
  * // Define services
- * const Logger = Context.Service<{
+ * interface Logger {
+ *   readonly ["~Logger"]: "~Logger"
+ *
  *   log: (msg: string) => void
- * }>("Logger")
- * const Config = Context.Service<{
+ * }
+ * const Logger = Context.Service<Logger>("Logger")
+ * interface Config {
+ *   readonly ["~Config"]: "~Config"
+ *
  *   name: string
- * }>("Config")
+ * }
+ * const Config = Context.Service<Config>("Config")
  *
  * const program = Effect.service(Config).pipe(
  *   Effect.map((config) => `Hello ${config.name}!`)
@@ -6126,12 +6211,16 @@ export const serviceOption: <I, S>(key: Context.Key<I, S>) => Effect<Option<S>> 
  * // Transform services by providing Config while keeping Logger requirement
  * const configured = program.pipe(
  *   Effect.updateContext((context: Context.Context<Context.Service.Identifier<typeof Logger>>) =>
- *     Context.add(context, Config, { name: "World" })
+ *     Context.add(context, Config, {
+ *       ["~Config"]: "~Config" as const,
+ *       name: "World"
+ *     })
  *   )
  * )
  *
  * // The effect now requires only Logger service
  * const result = Effect.provideService(configured, Logger, {
+ *   ["~Logger"]: "~Logger" as const,
  *   log: () => {}
  * })
  * Effect.runSync(result) // => "Hello World!"
@@ -6166,18 +6255,30 @@ export const updateContext: {
  * const output: Array<unknown> = []
  *
  * // Define a counter service
- * const Counter = Context.Service<{ count: number }>("Counter")
+ * interface Counter {
+ *   readonly ["~Counter"]: "~Counter"
+ *   count: number
+ * }
+ * const Counter = Context.Service<Counter>("Counter")
  *
  * const program = Effect.gen(function*() {
  *   const updatedCounter = yield* Effect.service(Counter)
- *   yield* Effect.sync(() => { output.push(`Updated count: ${updatedCounter.count}`) })
+ *   yield* Effect.sync(() => {
+ *     output.push(`Updated count: ${updatedCounter.count}`)
+ *   })
  *   return updatedCounter.count
  * }).pipe(
- *   Effect.updateService(Counter, (counter) => ({ count: counter.count + 1 }))
+ *   Effect.updateService(Counter, (counter) => ({
+ *     ["~Counter"]: "~Counter" as const,
+ *     count: counter.count + 1
+ *   }))
  * )
  *
  * // Provide initial service and run
- * const result = Effect.provideService(program, Counter, { count: 0 })
+ * const result = Effect.provideService(program, Counter, {
+ *   ["~Counter"]: "~Counter" as const,
+ *   count: 0
+ * })
  * void output.push(Effect.runSync(result))
  * output // => ["Updated count: 1", 1]
  * ```
@@ -6283,20 +6384,28 @@ export const updateServiceScoped: <I, A>(
  * const output: Array<unknown> = []
  *
  * // Define a service for configuration
- * const Config = Context.Service<{
+ * interface Config {
+ *   readonly ["~Config"]: "~Config"
+ *
  *   apiUrl: string
  *   timeout: number
- * }>("Config")
+ * }
+ * const Config = Context.Service<Config>("Config")
  *
  * const fetchData = Effect.gen(function*() {
  *   const config = yield* Effect.service(Config)
- *   yield* Effect.sync(() => { output.push(`Fetching from: ${config.apiUrl}`) })
- *   yield* Effect.sync(() => { output.push(`Timeout: ${config.timeout}ms`) })
+ *   yield* Effect.sync(() => {
+ *     output.push(`Fetching from: ${config.apiUrl}`)
+ *   })
+ *   yield* Effect.sync(() => {
+ *     output.push(`Timeout: ${config.timeout}ms`)
+ *   })
  *   return "data"
  * })
  *
  * // Provide the service implementation
  * const program = Effect.provideService(fetchData, Config, {
+ *   ["~Config"]: "~Config" as const,
  *   apiUrl: "https://api.example.com",
  *   timeout: 5000
  * })
@@ -9267,9 +9376,12 @@ export const runSyncExit: <A, E>(effect: Effect<A, E>) => Exit.Exit<A, E> = inte
  * const output: Array<unknown> = []
  *
  * // Define a logger service
- * const Logger = Context.Service<{
+ * interface Logger {
+ *   readonly ["~Logger"]: "~Logger"
+ *
  *   log: (msg: string) => void
- * }>("Logger")
+ * }
+ * const Logger = Context.Service<Logger>("Logger")
  *
  * const program = Effect.gen(function*() {
  *   const logger = yield* Effect.service(Logger)
@@ -9279,6 +9391,7 @@ export const runSyncExit: <A, E>(effect: Effect<A, E>) => Exit.Exit<A, E> = inte
  *
  * // Prepare context
  * const context = Context.make(Logger, {
+ *   ["~Logger"]: "~Logger" as const,
  *   log: (msg) => void output.push(`[LOG] ${msg}`)
  * })
  *
@@ -14471,6 +14584,8 @@ export const trackDuration: {
 // Transactions
 // -----------------------------------------------------------------------------
 
+const TransactionTypeId = "~effect/Effect/Transaction"
+
 /**
  * Service that holds the current transaction state.
  *
@@ -14492,6 +14607,7 @@ export const trackDuration: {
  * })
  *
  * const runnable = Effect.provideService(txEffect, Effect.Transaction, {
+ *   ["~effect/Effect/Transaction"]: "~effect/Effect/Transaction",
  *   retry: false,
  *   journal: new Map()
  * })
@@ -14501,19 +14617,26 @@ export const trackDuration: {
  * @category services
  * @since 4.0.0
  */
-export class Transaction extends Context.Service<
-  Transaction,
-  {
-    retry: boolean
-    readonly journal: Map<
-      TxRef<any>,
-      {
-        readonly version: number
-        value: any
-      }
-    >
-  }
->()("effect/Effect/Transaction") {}
+export interface Transaction {
+  readonly [TransactionTypeId]: typeof TransactionTypeId
+
+  retry: boolean
+  readonly journal: Map<
+    TxRef<any>,
+    {
+      readonly version: number
+      value: any
+    }
+  >
+}
+
+/**
+ * Service key for `Transaction` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Transaction = Context.Service<Transaction>("effect/Effect/Transaction")
 
 /**
  * Defines a transaction boundary. Transactions are "all or nothing" with respect to changes
@@ -14570,7 +14693,11 @@ export const tx = <A, E, R>(
       return effect as Effect<A, E, Exclude<R, Transaction>>
     }
     // Create transaction state only at the outermost boundary
-    state = { journal: new Map(), retry: false }
+    state = {
+      [TransactionTypeId]: TransactionTypeId as typeof TransactionTypeId,
+      journal: new Map(),
+      retry: false
+    }
     let result: Exit.Exit<A, E> | undefined
     return uninterruptibleMask((restore) =>
       flatMap(
@@ -14603,7 +14730,7 @@ export const tx = <A, E, R>(
     )
   })
 
-const isTransactionConsistent = (state: Transaction["Service"]) => {
+const isTransactionConsistent = (state: Transaction) => {
   for (const [ref, { version }] of state.journal) {
     if (ref.version !== version) {
       return false
@@ -14612,7 +14739,7 @@ const isTransactionConsistent = (state: Transaction["Service"]) => {
   return true
 }
 
-const awaitPendingTransaction = (state: Transaction["Service"]) =>
+const awaitPendingTransaction = (state: Transaction) =>
   suspend(() => {
     const key = {}
     const refs = Array.from(state.journal.keys())
@@ -14633,7 +14760,7 @@ const awaitPendingTransaction = (state: Transaction["Service"]) =>
     })
   })
 
-function commitTransaction(fiber: Fiber<unknown, unknown>, state: Transaction["Service"]) {
+function commitTransaction(fiber: Fiber<unknown, unknown>, state: Transaction) {
   for (const [ref, { value }] of state.journal) {
     if (value !== ref.value) {
       ref.version = ref.version + 1
@@ -14646,7 +14773,7 @@ function commitTransaction(fiber: Fiber<unknown, unknown>, state: Transaction["S
   }
 }
 
-function clearTransaction(state: Transaction["Service"]) {
+function clearTransaction(state: Transaction) {
   state.retry = false
   state.journal.clear()
 }

--- a/packages/effect/src/FiberHandle.ts
+++ b/packages/effect/src/FiberHandle.ts
@@ -639,9 +639,12 @@ const runImpl = <A, E, R, XE extends E, XA extends A>(
  * ```ts import.meta.vitest
  * import { Context, Effect, Fiber, FiberHandle } from "effect"
  *
- * class Users extends Context.Service<Users, {
+ * interface Users {
+ *   readonly ["~Users"]: "~Users"
+ *
  *   readonly getAll: Effect.Effect<Array<unknown>>
- * }>()("Users") {}
+ * }
+ * const Users = Context.Service<Users>("Users")
  *
  * const program = Effect.gen(function*() {
  *   const handle = yield* FiberHandle.make()
@@ -659,6 +662,7 @@ const runImpl = <A, E, R, XE extends E, XA extends A>(
  * )
  *
  * const actual = await Effect.runPromise(Effect.provideService(program, Users, {
+ *   ["~Users"]: "~Users" as const,
  *   getAll: Effect.succeed([])
  * }))
  * actual // => 0

--- a/packages/effect/src/FiberMap.ts
+++ b/packages/effect/src/FiberMap.ts
@@ -825,9 +825,12 @@ const runImpl = <K, A, E, R, XE extends E, XA extends A>(
  * ```ts import.meta.vitest
  * import { Context, Effect, Fiber, FiberMap } from "effect"
  *
- * class Users extends Context.Service<Users, {
+ * interface Users {
+ *   readonly ["~Users"]: "~Users"
+ *
  *   readonly getAll: Effect.Effect<Array<unknown>>
- * }>()("Users") {}
+ * }
+ * const Users = Context.Service<Users>("Users")
  *
  * const program = Effect.gen(function*() {
  *   const map = yield* FiberMap.make<string>()
@@ -842,6 +845,7 @@ const runImpl = <K, A, E, R, XE extends E, XA extends A>(
  * )
  *
  * const actual = await Effect.runPromise(Effect.provideService(program, Users, {
+ *   ["~Users"]: "~Users" as const,
  *   getAll: Effect.succeed([])
  * }))
  * actual // => [0, 0]

--- a/packages/effect/src/FiberSet.ts
+++ b/packages/effect/src/FiberSet.ts
@@ -526,9 +526,12 @@ const runImpl = <A, E, R, XE extends E, XA extends A>(
  * ```ts import.meta.vitest
  * import { Context, Effect, Fiber, FiberSet } from "effect"
  *
- * class Users extends Context.Service<Users, {
+ * interface Users {
+ *   readonly ["~Users"]: "~Users"
+ *
  *   readonly getAll: Effect.Effect<Array<unknown>>
- * }>()("Users") {}
+ * }
+ * const Users = Context.Service<Users>("Users")
  *
  * const program = Effect.gen(function*() {
  *   const set = yield* FiberSet.make()
@@ -542,6 +545,7 @@ const runImpl = <A, E, R, XE extends E, XA extends A>(
  * )
  *
  * const actual = await Effect.runPromise(Effect.provideService(program, Users, {
+ *   ["~Users"]: "~Users" as const,
  *   getAll: Effect.succeed([])
  * }))
  * actual // => 0

--- a/packages/effect/src/FileSystem.ts
+++ b/packages/effect/src/FileSystem.ts
@@ -1075,6 +1075,8 @@ export declare namespace WatchEvent {
   }
 }
 
+const WatchBackendTypeId = "~effect/FileSystem/WatchBackend"
+
 /**
  * Service key for file system watch backend implementations.
  *
@@ -1090,7 +1092,8 @@ export declare namespace WatchEvent {
  * import { Effect, FileSystem, Option, Stream } from "effect"
  *
  * // Custom watch backend implementation
- * const customWatchBackend = {
+ * const customWatchBackend: FileSystem.WatchBackend = {
+ *   ["~effect/FileSystem/WatchBackend"]: "~effect/FileSystem/WatchBackend",
  *   register: (path: string, stat: FileSystem.File.Info) => {
  *     // Implementation would depend on platform
  *     return Option.some(Stream.empty) // Placeholder implementation
@@ -1115,10 +1118,20 @@ export declare namespace WatchEvent {
  * @category services
  * @since 4.0.0
  */
-export class WatchBackend extends Context.Service<WatchBackend, {
+export interface WatchBackend {
+  readonly [WatchBackendTypeId]: typeof WatchBackendTypeId
+
   readonly register: (
     path: string,
     stat: File.Info,
     options?: WatchOptions
   ) => Option.Option<Stream.Stream<WatchEvent, PlatformError>>
-}>()("effect/FileSystem/WatchBackend") {}
+}
+
+/**
+ * Service key for `WatchBackend` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const WatchBackend = Context.Service<WatchBackend>("effect/FileSystem/WatchBackend")

--- a/packages/effect/src/Layer.ts
+++ b/packages/effect/src/Layer.ts
@@ -195,9 +195,12 @@ const MemoMapTypeId = "~effect/Layer/MemoMap"
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Database extends Context.Service<Database, {
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * // Create a custom MemoMap for manual layer building
  * const program = Effect.gen(function*() {
@@ -205,6 +208,7 @@ const MemoMapTypeId = "~effect/Layer/MemoMap"
  *   const scope = yield* Effect.scope
  *
  *   const dbLayer = Layer.succeed(Database, {
+ *     ["~Database"]: "~Database" as const,
  *     query: Effect.fn("Database.query")((sql: string) => Effect.succeed("result"))
  *   })
  *   const context = yield* Layer.buildWithMemoMap(dbLayer, memoMap, scope)
@@ -257,11 +261,15 @@ const memoMapReuse = <RIn, E, ROut>(
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Database extends Context.Service<Database, {
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * const dbLayer = Layer.succeed(Database, {
+ *   ["~Database"]: "~Database" as const,
  *   query: Effect.fn("Database.query")((sql: string) => Effect.succeed("result"))
  * })
  * const notALayer = { someProperty: "value" }
@@ -311,13 +319,17 @@ const fromBuildUnsafe = <ROut, E, RIn>(
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Database extends Context.Service<Database, {
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * const databaseLayer = Layer.fromBuild(() =>
  *   Effect.sync(() =>
  *     Context.make(Database, {
+ *       ["~Database"]: "~Database" as const,
  *       query: (sql: string) => Effect.succeed("result")
  *     })
  *   )
@@ -358,13 +370,17 @@ export const fromBuild = <ROut, E, RIn>(
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Database extends Context.Service<Database, {
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * const databaseLayer = Layer.fromBuildMemo(() =>
  *   Effect.sync(() =>
  *     Context.make(Database, {
+ *       ["~Database"]: "~Database" as const,
  *       query: (sql: string) => Effect.succeed("result")
  *     })
  *   )
@@ -465,9 +481,12 @@ class MemoMapImpl implements MemoMap {
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Database extends Context.Service<Database, {
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * // Create a memo map for manual layer building
  * const program = Effect.gen(function*() {
@@ -475,6 +494,7 @@ class MemoMapImpl implements MemoMap {
  *   const scope = yield* Effect.scope
  *
  *   const dbLayer = Layer.succeed(Database, {
+ *     ["~Database"]: "~Database" as const,
  *     query: Effect.fn("Database.query")((sql: string) => Effect.succeed("result"))
  *   })
  *   const context = yield* Layer.buildWithMemoMap(dbLayer, memoMap, scope)
@@ -518,9 +538,12 @@ export const forkMemoMapUnsafe = (parent: MemoMap): MemoMap => new MemoMapImpl(p
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Database extends Context.Service<Database, {
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * // Create a memo map safely within an Effect
  * const program = Effect.gen(function*() {
@@ -528,6 +551,7 @@ export const forkMemoMapUnsafe = (parent: MemoMap): MemoMap => new MemoMapImpl(p
  *   const scope = yield* Effect.scope
  *
  *   const dbLayer = Layer.succeed(Database, {
+ *     ["~Database"]: "~Database" as const,
  *     query: Effect.fn("Database.query")((sql: string) => Effect.succeed("result"))
  *   })
  *   const context = yield* Layer.buildWithMemoMap(dbLayer, memoMap, scope)
@@ -597,13 +621,19 @@ export class CurrentMemoMap extends Context.Service<CurrentMemoMap, MemoMap>()("
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Database extends Context.Service<Database, {
- *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
  *
- * class Logger extends Context.Service<Logger, {
+ *   readonly query: (sql: string) => Effect.Effect<string>
+ * }
+ * const Database = Context.Service<Database>("Database")
+ *
+ * interface Logger {
+ *   readonly ["~Logger"]: "~Logger"
+ *
  *   readonly log: (msg: string) => Effect.Effect<void>
- * }>()("Logger") {}
+ * }
+ * const Logger = Context.Service<Logger>("Logger")
  *
  * const logs: Array<string> = []
  *
@@ -614,12 +644,14 @@ export class CurrentMemoMap extends Context.Service<CurrentMemoMap, MemoMap>()("
  *
  *   // Build database layer with memoization
  *   const dbLayer = Layer.succeed(Database, {
+ *     ["~Database"]: "~Database" as const,
  *     query: Effect.fn("Database.query")((sql: string) => Effect.succeed("result"))
  *   })
  *   const dbContext = yield* Layer.buildWithMemoMap(dbLayer, memoMap, scope)
  *
  *   // Build logger layer with same memoization (reuses memo if same layer)
  *   const loggerLayer = Layer.succeed(Logger, {
+ *     ["~Logger"]: "~Logger" as const,
  *     log: Effect.fn("Logger.log")((msg: string) => Effect.sync(() => logs.push(msg)))
  *   })
  *   const loggerContext = yield* Layer.buildWithMemoMap(
@@ -671,13 +703,17 @@ export const buildWithMemoMap: {
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Database extends Context.Service<Database, {
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * // Build a layer to get its services
  * const program = Effect.gen(function*() {
  *   const dbLayer = Layer.succeed(Database, {
+ *     ["~Database"]: "~Database" as const,
  *     query: Effect.fn("Database.query")((sql: string) => Effect.succeed("result"))
  *   })
  *
@@ -725,9 +761,12 @@ export const build = <RIn, E, ROut>(
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer, Scope } from "effect"
  *
- * class Database extends Context.Service<Database, {
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * const logs: Array<string> = []
  *
@@ -735,14 +774,20 @@ export const build = <RIn, E, ROut>(
  * const program = Effect.gen(function*() {
  *   const scope = yield* Effect.scope
  *
- *   const dbLayer = Layer.effect(Database, Effect.gen(function*() {
- *     logs.push("Initializing database...")
- *     yield* Scope.addFinalizer(
- *       scope,
- *       Effect.sync(() => logs.push("Database closed"))
- *     )
- *     return { query: Effect.fn("Database.query")((sql: string) => Effect.succeed(`Result: ${sql}`)) }
- *   }))
+ *   const dbLayer = Layer.effect(
+ *     Database,
+ *     Effect.gen(function*() {
+ *       logs.push("Initializing database...")
+ *       yield* Scope.addFinalizer(
+ *         scope,
+ *         Effect.sync(() => logs.push("Database closed"))
+ *       )
+ *       return {
+ *         ["~Database"]: "~Database" as const,
+ *         query: Effect.fn("Database.query")((sql: string) => Effect.succeed(`Result: ${sql}`))
+ *       }
+ *     })
+ *   )
  *
  *   // Build with specific scope - resources tied to this scope
  *   const context = yield* Layer.buildWithScope(dbLayer, scope)
@@ -788,11 +833,15 @@ export const buildWithScope: {
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Database extends Context.Service<Database, {
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * const DatabaseLayer = Layer.succeed(Database, {
+ *   ["~Database"]: "~Database" as const,
  *   query: Effect.fn("Database.query")((sql: string) => Effect.succeed(`Query result: ${sql}`))
  * })
  * const program = Database.use((database) => database.query("SELECT 1"))
@@ -833,19 +882,27 @@ export const succeed: {
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Database extends Context.Service<Database, {
- *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
  *
- * class Logger extends Context.Service<Logger, {
+ *   readonly query: (sql: string) => Effect.Effect<string>
+ * }
+ * const Database = Context.Service<Database>("Database")
+ *
+ * interface Logger {
+ *   readonly ["~Logger"]: "~Logger"
+ *
  *   readonly log: (msg: string) => Effect.Effect<void>
- * }>()("Logger") {}
+ * }
+ * const Logger = Context.Service<Logger>("Logger")
  *
  * const logs: Array<string> = []
  * const context = Context.make(Database, {
+ *   ["~Database"]: "~Database" as const,
  *   query: Effect.fn("Database.query")((sql: string) => Effect.succeed("result"))
  * }).pipe(
  *   Context.add(Logger, {
+ *     ["~Logger"]: "~Logger" as const,
  *     log: (msg: string) => Effect.sync(() => logs.push(msg))
  *   })
  * )
@@ -907,11 +964,15 @@ export const empty: Layer<never> = succeedContext(Context.empty())
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Database extends Context.Service<Database, {
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * const layer = Layer.sync(Database, () => ({
+ *   ["~Database"]: "~Database" as const,
  *   query: (sql: string) => Effect.succeed(`Query: ${sql}`)
  * }))
  * const program = Database.use((database) => database.query("SELECT 1"))
@@ -951,12 +1012,16 @@ export const sync: {
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Database extends Context.Service<Database, {
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * const layer = Layer.syncContext(() =>
  *   Context.make(Database, {
+ *     ["~Database"]: "~Database" as const,
  *     query: (sql: string) => Effect.succeed(`Query: ${sql}`)
  *   })
  * )
@@ -992,12 +1057,17 @@ export const syncContext = <A>(evaluate: LazyArg<Context.Context<A>>): Layer<A> 
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Database extends Context.Service<Database, {
- *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
  *
- * const layer = Layer.effect(Database,
+ *   readonly query: (sql: string) => Effect.Effect<string>
+ * }
+ * const Database = Context.Service<Database>("Database")
+ *
+ * const layer = Layer.effect(
+ *   Database,
  *   Effect.sync(() => ({
+ *     ["~Database"]: "~Database" as const,
  *     query: (sql: string) => Effect.succeed(`Query: ${sql}`)
  *   }))
  * )
@@ -1051,13 +1121,15 @@ const effectImpl = <I, S, E, R>(
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Database extends Context.Service<
- *   Database,
- *   { readonly query: (sql: string) => Effect.Effect<string> }
- * >()("Database") {}
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *   readonly query: (sql: string) => Effect.Effect<string>
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * const layer = Layer.effectContext(
  *   Effect.succeed(Context.make(Database, {
+ *     ["~Database"]: "~Database" as const,
  *     query: (sql: string) => Effect.succeed(`Query: ${sql}`)
  *   }))
  * )
@@ -1157,12 +1229,18 @@ const unwrapKey = Context.Service<Layer<any, any, any>>("effect/Layer/unwrap")
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Database extends Context.Service<Database, {
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * const layerEffect = Effect.succeed(
- *   Layer.succeed(Database, { query: Effect.fn("Database.query")((sql: string) => Effect.succeed("result")) })
+ *   Layer.succeed(Database, {
+ *     ["~Database"]: "~Database" as const,
+ *     query: Effect.fn("Database.query")((sql: string) => Effect.succeed("result"))
+ *   })
  * )
  *
  * const unwrappedLayer = Layer.unwrap(layerEffect)
@@ -1215,19 +1293,27 @@ const mergeAllEffect = <Layers extends [Layer<never, any, any>, ...Array<Layer<n
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Database extends Context.Service<Database, {
- *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
  *
- * class Logger extends Context.Service<Logger, {
+ *   readonly query: (sql: string) => Effect.Effect<string>
+ * }
+ * const Database = Context.Service<Database>("Database")
+ *
+ * interface Logger {
+ *   readonly ["~Logger"]: "~Logger"
+ *
  *   readonly log: (msg: string) => Effect.Effect<void>
- * }>()("Logger") {}
+ * }
+ * const Logger = Context.Service<Logger>("Logger")
  *
  * const dbLayer = Layer.succeed(Database, {
+ *   ["~Database"]: "~Database" as const,
  *   query: Effect.fn("Database.query")((sql: string) => Effect.succeed("result"))
  * })
  * const logs: Array<string> = []
  * const loggerLayer = Layer.succeed(Logger, {
+ *   ["~Logger"]: "~Logger" as const,
  *   log: Effect.fn("Logger.log")((msg: string) => Effect.sync(() => logs.push(msg)))
  * })
  *
@@ -1270,18 +1356,26 @@ export const mergeAll = <Layers extends [Layer<never, any, any>, ...Array<Layer<
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Database extends Context.Service<Database, {
- *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
  *
- * class Logger extends Context.Service<Logger, {
+ *   readonly query: (sql: string) => Effect.Effect<string>
+ * }
+ * const Database = Context.Service<Database>("Database")
+ *
+ * interface Logger {
+ *   readonly ["~Logger"]: "~Logger"
+ *
  *   readonly log: (msg: string) => Effect.Effect<void>
- * }>()("Logger") {}
+ * }
+ * const Logger = Context.Service<Logger>("Logger")
  *
  * const dbLayer = Layer.succeed(Database, {
+ *   ["~Database"]: "~Database" as const,
  *   query: Effect.fn("Database.query")((sql: string) => Effect.succeed("result"))
  * })
  * const loggerLayer = Layer.succeed(Logger, {
+ *   ["~Logger"]: "~Logger" as const,
  *   log: Effect.fn("Logger.log")((_msg: string) => Effect.void)
  * })
  *
@@ -1366,46 +1460,61 @@ const provideWith = (
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Database extends Context.Service<Database, {
- *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
  *
- * class UserService extends Context.Service<UserService, {
+ *   readonly query: (sql: string) => Effect.Effect<string>
+ * }
+ * const Database = Context.Service<Database>("Database")
+ *
+ * interface UserService {
+ *   readonly ["~UserService"]: "~UserService"
+ *
  *   readonly getUser: (id: string) => Effect.Effect<{
  *     id: string
  *     name: string
  *   }>
- * }>()("UserService") {}
+ * }
+ * const UserService = Context.Service<UserService>("UserService")
  *
- * class Logger extends Context.Service<Logger, {
+ * interface Logger {
+ *   readonly ["~Logger"]: "~Logger"
+ *
  *   readonly log: (msg: string) => Effect.Effect<void>
- * }>()("Logger") {}
+ * }
+ * const Logger = Context.Service<Logger>("Logger")
  *
  * // Create dependency layers
  * const databaseLayer = Layer.succeed(Database, {
+ *   ["~Database"]: "~Database" as const,
  *   query: Effect.fn("Database.query")((sql: string) => Effect.succeed(`DB: ${sql}`))
  * })
  *
  * const logs: Array<string> = []
  * const loggerLayer = Layer.succeed(Logger, {
+ *   ["~Logger"]: "~Logger" as const,
  *   log: Effect.fn("Logger.log")((msg: string) => Effect.sync(() => logs.push(`[LOG] ${msg}`)))
  * })
  *
  * // UserService depends on Database and Logger
- * const userServiceLayer = Layer.effect(UserService, Effect.gen(function*() {
- *   const database = yield* Database
- *   const logger = yield* Logger
+ * const userServiceLayer = Layer.effect(
+ *   UserService,
+ *   Effect.gen(function*() {
+ *     const database = yield* Database
+ *     const logger = yield* Logger
  *
- *   return {
- *     getUser: Effect.fn("UserService.getUser")(function*(id: string) {
+ *     return {
+ *       ["~UserService"]: "~UserService" as const,
+ *       getUser: Effect.fn("UserService.getUser")(function*(id: string) {
  *         yield* logger.log(`Looking up user ${id}`)
  *         const result = yield* database.query(
  *           `SELECT * FROM users WHERE id = ${id}`
  *         )
  *         return { id, name: result }
  *       })
- *   }
- * }))
+ *     }
+ *   })
+ * )
  *
  * // Provide dependencies to UserService layer
  * const userServiceWithDependencies = userServiceLayer.pipe(
@@ -1478,46 +1587,61 @@ export const provide: {
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Database extends Context.Service<Database, {
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
- * class Logger extends Context.Service<Logger, {
+ * interface Logger {
+ *   readonly ["~Logger"]: "~Logger"
+ *
  *   readonly log: (msg: string) => Effect.Effect<void>
- * }>()("Logger") {}
+ * }
+ * const Logger = Context.Service<Logger>("Logger")
  *
- * class UserService extends Context.Service<UserService, {
+ * interface UserService {
+ *   readonly ["~UserService"]: "~UserService"
+ *
  *   readonly getUser: (id: string) => Effect.Effect<{
  *     id: string
  *     name: string
  *   }>
- * }>()("UserService") {}
+ * }
+ * const UserService = Context.Service<UserService>("UserService")
  *
  * // Create dependency layers
  * const databaseLayer = Layer.succeed(Database, {
+ *   ["~Database"]: "~Database" as const,
  *   query: Effect.fn("Database.query")((sql: string) => Effect.succeed(`DB: ${sql}`))
  * })
  *
  * const logs: Array<string> = []
  * const loggerLayer = Layer.succeed(Logger, {
+ *   ["~Logger"]: "~Logger" as const,
  *   log: Effect.fn("Logger.log")((msg: string) => Effect.sync(() => logs.push(`[LOG] ${msg}`)))
  * })
  *
  * // UserService depends on Database and Logger
- * const userServiceLayer = Layer.effect(UserService, Effect.gen(function*() {
- *   const database = yield* Database
- *   const logger = yield* Logger
+ * const userServiceLayer = Layer.effect(
+ *   UserService,
+ *   Effect.gen(function*() {
+ *     const database = yield* Database
+ *     const logger = yield* Logger
  *
- *   return {
- *     getUser: Effect.fn("UserService.getUser")(function*(id: string) {
+ *     return {
+ *       ["~UserService"]: "~UserService" as const,
+ *       getUser: Effect.fn("UserService.getUser")(function*(id: string) {
  *         yield* logger.log(`Looking up user ${id}`)
  *         const result = yield* database.query(
  *           `SELECT * FROM users WHERE id = ${id}`
  *         )
  *         return { id, name: result }
  *       })
- *   }
- * }))
+ *     }
+ *   })
+ * )
  *
  * // Provide dependencies and merge all services together
  * const allServicesLayer = userServiceLayer.pipe(
@@ -1591,23 +1715,33 @@ export const provideMerge: {
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Config extends Context.Service<Config, {
+ * interface Config {
+ *   readonly ["~Config"]: "~Config"
+ *
  *   readonly dbUrl: string
  *   readonly logLevel: string
- * }>()("Config") {}
+ * }
+ * const Config = Context.Service<Config>("Config")
  *
- * class Database extends Context.Service<Database, {
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
- * class Logger extends Context.Service<Logger, {
+ * interface Logger {
+ *   readonly ["~Logger"]: "~Logger"
+ *
  *   readonly log: (msg: string) => Effect.Effect<void>
- * }>()("Logger") {}
+ * }
+ * const Logger = Context.Service<Logger>("Logger")
  *
  * const logs: Array<string> = []
  *
  * // Base config layer
  * const configLayer = Layer.succeed(Config, {
+ *   ["~Config"]: "~Config" as const,
  *   dbUrl: "postgres://localhost:5432/mydb",
  *   logLevel: "debug"
  * })
@@ -1619,14 +1753,17 @@ export const provideMerge: {
  *
  *     // Create database layer based on config
  *     const dbLayer = Layer.succeed(Database, {
+ *       ["~Database"]: "~Database" as const,
  *       query: Effect.fn("Database.query")((sql: string) =>
  *         Effect.succeed(
  *           `Querying ${config.dbUrl}: ${sql}`
- *         ))
+ *         )
+ *       )
  *     })
  *
  *     // Create logger layer based on config
  *     const loggerLayer = Layer.succeed(Logger, {
+ *       ["~Logger"]: "~Logger" as const,
  *       log: Effect.fn("Logger.log")((msg: string) =>
  *         config.logLevel === "debug"
  *           ? Effect.sync(() => logs.push(`[DEBUG] ${msg}`))
@@ -1819,9 +1956,12 @@ export const tapCause: {
  *   message: string
  * }> {}
  *
- * class Database extends Context.Service<Database, {
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * // Layer that can fail during construction
  * const error = new DatabaseError({ message: "Connection failed" })
@@ -1901,13 +2041,19 @@ export {
  *
  * class ConfigError extends Data.TaggedError("ConfigError") {}
  *
- * class Config extends Context.Service<Config, {
+ * interface Config {
+ *   readonly ["~Config"]: "~Config"
+ *
  *   readonly apiUrl: string
- * }>()("Config") {}
+ * }
+ * const Config = Context.Service<Config>("Config")
  *
  * const configLayer = Layer.effect(Config, Effect.fail(new ConfigError()))
  *
- * const fallbackLayer = Layer.succeed(Config, { apiUrl: "http://localhost" })
+ * const fallbackLayer = Layer.succeed(Config, {
+ *   ["~Config"]: "~Config" as const,
+ *   apiUrl: "http://localhost"
+ * })
  *
  * const recovered = configLayer.pipe(
  *   Layer.catchTag("ConfigError", () => fallbackLayer)
@@ -1996,17 +2142,22 @@ export const catchTag: {
  *   message: string
  * }> {}
  *
- * class Database extends Context.Service<Database, {
- *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
  *
- * const primaryDatabaseLayer = Layer.effect(Database,
+ *   readonly query: (sql: string) => Effect.Effect<string>
+ * }
+ * const Database = Context.Service<Database>("Database")
+ *
+ * const primaryDatabaseLayer = Layer.effect(
+ *   Database,
  *   Effect.fail(new DatabaseError({ message: "Primary DB unreachable" }))
  * )
  *
  * const databaseWithFallback = primaryDatabaseLayer.pipe(
  *   Layer.catchCause(() => {
  *     return Layer.succeed(Database, {
+ *       ["~Database"]: "~Database" as const,
  *       query: Effect.fn("Database.query")((sql: string) => Effect.succeed(`Memory: ${sql}`))
  *     })
  *   })
@@ -2101,27 +2252,42 @@ export const updateService: {
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer, Ref } from "effect"
  *
- * class Counter extends Context.Service<Counter, {
+ * interface Counter {
+ *   readonly ["~Counter"]: "~Counter"
+ *
  *   readonly id: number
- * }>()("Counter") {}
+ * }
+ * const Counter = Context.Service<Counter>("Counter")
  *
- * class Left extends Context.Service<Left, {
+ * interface Left {
+ *   readonly ["~Left"]: "~Left"
+ *
  *   readonly counterId: number
- * }>()("Left") {}
+ * }
+ * const Left = Context.Service<Left>("Left")
  *
- * class Right extends Context.Service<Right, {
+ * interface Right {
+ *   readonly ["~Right"]: "~Right"
+ *
  *   readonly counterId: number
- * }>()("Right") {}
+ * }
+ * const Right = Context.Service<Right>("Right")
  *
- * const leftLayer = Layer.effect(Left, Effect.gen(function*() {
- *   const counter = yield* Counter
- *   return { counterId: counter.id }
- * }))
+ * const leftLayer = Layer.effect(
+ *   Left,
+ *   Effect.gen(function*() {
+ *     const counter = yield* Counter
+ *     return Left.of({ ["~Left"]: "~Left", counterId: counter.id })
+ *   })
+ * )
  *
- * const rightLayer = Layer.effect(Right, Effect.gen(function*() {
- *   const counter = yield* Counter
- *   return { counterId: counter.id }
- * }))
+ * const rightLayer = Layer.effect(
+ *   Right,
+ *   Effect.gen(function*() {
+ *     const counter = yield* Counter
+ *     return Right.of({ ["~Right"]: "~Right", counterId: counter.id })
+ *   })
+ * )
  *
  * const compareIds = Effect.gen(function*() {
  *   const left = yield* Left
@@ -2132,10 +2298,16 @@ export const updateService: {
  * const program = Effect.gen(function*() {
  *   const nextId = yield* Ref.make(0)
  *
- *   const counterLayer = Layer.effect(Counter, Effect.gen(function*() {
- *     const id = yield* Ref.updateAndGet(nextId, (n) => n + 1)
- *     return { id }
- *   }))
+ *   const counterLayer = Layer.effect(
+ *     Counter,
+ *     Effect.gen(function*() {
+ *       const id = yield* Ref.updateAndGet(nextId, (n) => n + 1)
+ *       return {
+ *         ["~Counter"]: "~Counter" as const,
+ *         id
+ *       }
+ *     })
+ *   )
  *
  *   const shared = Layer.merge(
  *     Layer.provide(leftLayer, counterLayer),
@@ -2182,19 +2354,28 @@ export const fresh = <A, E, R>(self: Layer<A, E, R>): Layer<A, E, R> =>
  * ```ts import.meta.vitest
  * import { Context, Deferred, Effect, Fiber, Layer, Ref } from "effect"
  *
- * class HttpServer extends Context.Service<HttpServer, {
+ * interface HttpServer {
+ *   readonly ["~HttpServer"]: "~HttpServer"
+ *
  *   readonly port: number
- * }>()("HttpServer") {}
+ * }
+ * const HttpServer = Context.Service<HttpServer>("HttpServer")
  *
  * const program = Effect.gen(function*() {
  *   const events = yield* Ref.make<Array<string>>([])
  *   const started = yield* Deferred.make<void>()
  *
- *   const serverLayer = Layer.effect(HttpServer, Effect.gen(function*() {
- *     yield* Ref.update(events, (events) => [...events, "Starting HTTP server..."])
- *     yield* Deferred.succeed(started, undefined)
- *     return { port: 3000 }
- *   }))
+ *   const serverLayer = Layer.effect(
+ *     HttpServer,
+ *     Effect.gen(function*() {
+ *       yield* Ref.update(events, (events) => [...events, "Starting HTTP server..."])
+ *       yield* Deferred.succeed(started, undefined)
+ *       return {
+ *         ["~HttpServer"]: "~HttpServer" as const,
+ *         port: 3000
+ *       }
+ *     })
+ *   )
  *
  *   const fiber = yield* Effect.forkChild(Layer.launch(serverLayer))
  *   yield* Deferred.await(started)
@@ -2266,7 +2447,9 @@ type AnyEffectOrStream =
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class UserService extends Context.Service<UserService, {
+ * interface UserService {
+ *   readonly ["~UserService"]: "~UserService"
+ *
  *   readonly config: { apiUrl: string }
  *   readonly getUser: (
  *     id: string
@@ -2276,10 +2459,12 @@ type AnyEffectOrStream =
  *     id: string,
  *     data: object
  *   ) => Effect.Effect<{ id: string; name: string }, Error>
- * }>()("UserService") {}
+ * }
+ * const UserService = Context.Service<UserService>("UserService")
  *
  * // Create a partial mock - only implement what you need for testing
  * const testUserLayer = Layer.mock(UserService, {
+ *   ["~UserService"]: "~UserService",
  *   config: { apiUrl: "https://test-api.com" }, // Required - non-Effect property
  *   getUser: (id: string) => Effect.succeed({ id, name: "Test User" }) // Mock implementation
  *   // deleteUser and updateUser are omitted - will throw UnimplementedError if called
@@ -2501,28 +2686,34 @@ export interface SpanOptions extends Tracer.SpanOptions {
  * import { Context, Effect, Layer } from "effect"
  * import type { Tracer } from "effect"
  *
- * class Database extends Context.Service<Database, {
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * const logs: Array<string> = []
  *
  * // Create a traced layer - all operations performed during construction of
  * // the `Database` service are part of the "database-init" span
- * const databaseLayer = Layer.effect(Database, Effect.gen(function*() {
- *   // These operations are traced under "database-init" span
- *   logs.push("Connecting to database")
- *   logs.push("Database connected")
+ * const databaseLayer = Layer.effect(
+ *   Database,
+ *   Effect.gen(function*() {
+ *     // These operations are traced under "database-init" span
+ *     logs.push("Connecting to database")
+ *     logs.push("Database connected")
  *
- *   const parentSpan = yield* Effect.currentParentSpan
- *   logs.push((parentSpan as Tracer.Span).name)
+ *     const parentSpan = yield* Effect.currentParentSpan
+ *     logs.push((parentSpan as Tracer.Span).name)
  *
- *   return {
- *     query: Effect.fn("Database.query")((sql: string) => Effect.succeed(`Result: ${sql}`))
- *   }
- * })).pipe(Layer.provide(Layer.span("database-init", {
- *   onEnd: (span, exit) =>
- *     Effect.sync(() => logs.push(`Span ${span.name} ended with: ${exit._tag}`))
+ *     return {
+ *       ["~Database"]: "~Database" as const,
+ *       query: Effect.fn("Database.query")((sql: string) => Effect.succeed(`Result: ${sql}`))
+ *     }
+ *   })
+ * ).pipe(Layer.provide(Layer.span("database-init", {
+ *   onEnd: (span, exit) => Effect.sync(() => logs.push(`Span ${span.name} ended with: ${exit._tag}`))
  * })))
  *
  * const program = Database.use((database) => database.query("SELECT 1"))
@@ -2563,10 +2754,13 @@ export const span = (
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer, Tracer } from "effect"
  *
- * class Database extends Context.Service<Database, {
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly spanId: string
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * // Create a layer that uses an existing span as parent
  * const databaseLayer = Layer.effect(
@@ -2575,6 +2769,7 @@ export const span = (
  *     const parentSpan = yield* Effect.currentParentSpan
  *
  *     return {
+ *       ["~Database"]: "~Database" as const,
  *       spanId: parentSpan.spanId,
  *       query: Effect.fn("Database.query")((sql: string) => Effect.succeed(`Result: ${sql}`))
  *     }
@@ -2584,7 +2779,8 @@ export const span = (
  *   traceId: "000"
  * }))))
  * const program = Database.use((database) =>
- *   Effect.map(database.query("SELECT 1"), (result) => ({ spanId: database.spanId, result })))
+ *   Effect.map(database.query("SELECT 1"), (result) => ({ spanId: database.spanId, result }))
+ * )
  * Effect.runSync(Effect.provide(program, databaseLayer)) // => { spanId: "42", result: "Result: SELECT 1" }
  * ```
  *
@@ -2609,34 +2805,44 @@ export const parentSpan = (span: Tracer.AnySpan): Layer<Tracer.ParentSpan> =>
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer } from "effect"
  *
- * class Database extends Context.Service<Database, {
- *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
  *
- * class Logger extends Context.Service<Logger, {
+ *   readonly query: (sql: string) => Effect.Effect<string>
+ * }
+ * const Database = Context.Service<Database>("Database")
+ *
+ * interface Logger {
+ *   readonly ["~Logger"]: "~Logger"
+ *
  *   readonly log: (msg: string) => Effect.Effect<void>
- * }>()("Logger") {}
+ * }
+ * const Logger = Context.Service<Logger>("Logger")
  *
  * const logs: Array<string> = []
  *
  * // Create layers with tracing
- * const databaseLayer = Layer.effect(Database, Effect.gen(function*() {
- *   return {
- *     query: Effect.fn("Database.query")((sql: string) => Effect.succeed(`Result: ${sql}`))
- *   }
- * })).pipe(Layer.withSpan("database-initialization", {
+ * const databaseLayer = Layer.effect(
+ *   Database,
+ *   Effect.gen(function*() {
+ *     return {
+ *       ["~Database"]: "~Database" as const,
+ *       query: Effect.fn("Database.query")((sql: string) => Effect.succeed(`Result: ${sql}`))
+ *     }
+ *   })
+ * ).pipe(Layer.withSpan("database-initialization", {
  *   attributes: { dbType: "postgres" }
  * }))
  *
  * const loggerLayer = Layer.succeed(Logger, {
+ *   ["~Logger"]: "~Logger" as const,
  *   log: Effect.fn("Logger.log")((msg: string) => Effect.sync(() => logs.push(msg)))
  * }).pipe(Layer.withSpan("logger-initialization"))
  *
  * // Combine traced layers
  * const appLayer = Layer.mergeAll(databaseLayer, loggerLayer).pipe(
  *   Layer.withSpan("app-initialization", {
- *     onEnd: (span, exit) =>
- *       Effect.sync(() => logs.push(`Application initialization completed: ${exit._tag}`))
+ *     onEnd: (span, exit) => Effect.sync(() => logs.push(`Application initialization completed: ${exit._tag}`))
  *   })
  * )
  *
@@ -2717,26 +2923,40 @@ export const withSpan: {
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer, Tracer } from "effect"
  *
- * class Database extends Context.Service<Database, {
- *   readonly query: (sql: string) => Effect.Effect<string>
- * }>()("Database") {}
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
  *
- * class Cache extends Context.Service<Cache, {
+ *   readonly query: (sql: string) => Effect.Effect<string>
+ * }
+ * const Database = Context.Service<Database>("Database")
+ *
+ * interface Cache {
+ *   readonly ["~Cache"]: "~Cache"
+ *
  *   readonly get: (key: string) => Effect.Effect<string | null>
- * }>()("Cache") {}
+ * }
+ * const Cache = Context.Service<Cache>("Cache")
  *
  * // Create layers
- * const DatabaseLayer = Layer.effect(Database, Effect.gen(function*() {
- *   return {
- *     query: Effect.fn("Database.query")((sql: string) => Effect.succeed(`DB: ${sql}`))
- *   }
- * }))
+ * const DatabaseLayer = Layer.effect(
+ *   Database,
+ *   Effect.gen(function*() {
+ *     return {
+ *       ["~Database"]: "~Database" as const,
+ *       query: Effect.fn("Database.query")((sql: string) => Effect.succeed(`DB: ${sql}`))
+ *     }
+ *   })
+ * )
  *
- * const CacheLayer = Layer.effect(Cache, Effect.gen(function*() {
- *   return {
- *     get: Effect.fn("Cache.get")((key: string) => Effect.succeed(`Cache: ${key}`))
- *   }
- * }))
+ * const CacheLayer = Layer.effect(
+ *   Cache,
+ *   Effect.gen(function*() {
+ *     return {
+ *       ["~Cache"]: "~Cache" as const,
+ *       get: Effect.fn("Cache.get")((key: string) => Effect.succeed(`Cache: ${key}`))
+ *     }
+ *   })
+ * )
  *
  * // Use with an existing parent span from Effect.withSpan
  * const program = Effect.withSpan("application-startup")(

--- a/packages/effect/src/LayerMap.ts
+++ b/packages/effect/src/LayerMap.ts
@@ -38,13 +38,17 @@ type IdleTimeToLiveInput<K> = Duration.Input | ((key: K) => Duration.Input)
  * import { Context, Effect, Layer, LayerMap } from "effect"
  *
  * // Define a service key
- * const DatabaseService = Context.Service<{
+ * interface DatabaseService {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>("Database")
+ * }
+ * const DatabaseService = Context.Service<DatabaseService>("Database")
  *
  * // Create a LayerMap that provides different database configurations
  * const createDatabaseLayerMap = LayerMap.make((env: string) =>
  *   Layer.succeed(DatabaseService)({
+ *     ["~Database"]: "~Database" as const,
  *     query: Effect.fn("DatabaseService.query")((sql) => Effect.succeed(`${env}: ${sql}`))
  *   })
  * )
@@ -120,15 +124,19 @@ export interface LayerMap<in out K, in out I, in out E = never> {
  * import { Context, Effect, Layer, LayerMap } from "effect"
  *
  * // Define a service key
- * const DatabaseService = Context.Service<{
+ * interface DatabaseService {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>("Database")
+ * }
+ * const DatabaseService = Context.Service<DatabaseService>("Database")
  *
  * // Create a LayerMap that provides different database configurations
  * const program = Effect.gen(function*() {
  *   const layerMap = yield* LayerMap.make(
  *     (env: string) =>
  *       Layer.succeed(DatabaseService)({
+ *         ["~Database"]: "~Database" as const,
  *         query: Effect.fn("DatabaseService.query")((sql) => Effect.succeed(`${env}: ${sql}`))
  *       }),
  *     { idleTimeToLive: "5 seconds" }
@@ -215,16 +223,21 @@ export const make: <
  * import { Context, Effect, Layer, LayerMap } from "effect"
  *
  * // Define a service key
- * const Database = Context.Service<{
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: (sql: string) => Effect.Effect<string>
- * }>("Database")
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * // Create predefined layers
  * const layers = {
  *   development: Layer.succeed(Database)({
+ *     ["~Database"]: "~Database" as const,
  *     query: Effect.fn("DevDatabase.query")((sql) => Effect.succeed(`DEV: ${sql}`))
  *   }),
  *   production: Layer.succeed(Database)({
+ *     ["~Database"]: "~Database" as const,
  *     query: Effect.fn("ProdDatabase.query")((sql) => Effect.succeed(`PROD: ${sql}`))
  *   })
  * } as const
@@ -360,15 +373,19 @@ export interface TagClass<
  * import { Context, Effect, Layer, LayerMap } from "effect"
  *
  * // Define a service key
- * const Greeter = Context.Service<{
+ * interface Greeter {
+ *   readonly ["~Greeter"]: "~Greeter"
+ *
  *   readonly greet: Effect.Effect<string>
- * }>("Greeter")
+ * }
+ * const Greeter = Context.Service<Greeter>("Greeter")
  *
  * // Create a service that wraps a LayerMap
  * class GreeterMap extends LayerMap.Service<GreeterMap>()("GreeterMap", {
  *   // Define the lookup function for the layer map
  *   lookup: (name: string) =>
  *     Layer.succeed(Greeter)({
+ *       ["~Greeter"]: "~Greeter" as const,
  *       greet: Effect.succeed(`Hello, ${name}!`)
  *     }),
  *

--- a/packages/effect/src/LayerRef.ts
+++ b/packages/effect/src/LayerRef.ts
@@ -95,11 +95,15 @@ export interface LayerRef<in out I, in out E = never> {
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer, LayerRef } from "effect"
  *
- * class Database extends Context.Service<Database, {
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: Effect.Effect<string>
- * }>()("Database") {}
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * const databaseLayer = Layer.succeed(Database, {
+ *   ["~Database"]: "~Database" as const,
  *   query: Effect.succeed("result")
  * })
  *
@@ -275,11 +279,15 @@ export interface TagClass<
  * ```ts import.meta.vitest
  * import { Context, Effect, Layer, LayerRef } from "effect"
  *
- * class Database extends Context.Service<Database, {
+ * interface Database {
+ *   readonly ["~Database"]: "~Database"
+ *
  *   readonly query: Effect.Effect<string>
- * }>()("Database") {}
+ * }
+ * const Database = Context.Service<Database>("Database")
  *
  * const databaseLayer = Layer.succeed(Database, {
+ *   ["~Database"]: "~Database" as const,
  *   query: Effect.succeed("result")
  * })
  *

--- a/packages/effect/src/ManagedRuntime.ts
+++ b/packages/effect/src/ManagedRuntime.ts
@@ -254,17 +254,17 @@ export interface ManagedRuntime<in R, out ER> {
  *
  * const notifications: Array<string> = []
  *
- * class Notifications extends Context.Service<Notifications, {
+ * interface Notifications {
+ *   readonly ["~Notifications"]: "~Notifications"
  *   readonly notify: (message: string) => Effect.Effect<void>
- * }>()("Notifications") {
- *   static readonly layer = Layer.succeed(this)({
- *     notify: Effect.fn("Notifications.notify")((message) =>
- *       Effect.sync(() => notifications.push(message))
- *     )
- *   })
  * }
+ * const Notifications = Context.Service<Notifications>("Notifications")
+ * const notificationsLayer = Layer.succeed(Notifications)({
+ *   ["~Notifications"]: "~Notifications",
+ *   notify: Effect.fn("Notifications.notify")((message) => Effect.sync(() => notifications.push(message)))
+ * })
  *
- * const runtime = ManagedRuntime.make(Notifications.layer)
+ * const runtime = ManagedRuntime.make(notificationsLayer)
  *
  * const program = Effect.flatMap(
  *   Notifications,

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -347,9 +347,12 @@ export const fromEffect = <A, E, R>(effect: Effect.Effect<A, E, R>): Stream<A, E
  * ```ts import.meta.vitest
  * import { Context, Effect, Stream } from "effect"
  *
- * class Greeter extends Context.Service<Greeter, {
+ * interface Greeter {
+ *   readonly ["~Greeter"]: "~Greeter"
+ *
  *   readonly greet: (name: string) => string
- * }>()("Greeter") {}
+ * }
+ * const Greeter = Context.Service<Greeter>("Greeter")
  *
  * const stream = Stream.service(Greeter).pipe(
  *   Stream.map((greeter) => greeter.greet("World"))
@@ -358,6 +361,7 @@ export const fromEffect = <A, E, R>(effect: Effect.Effect<A, E, R>): Stream<A, E
  * await Effect.runPromise(
  *   stream.pipe(
  *     Stream.provideService(Greeter, {
+ *       ["~Greeter"]: "~Greeter" as const,
  *       greet: (name) => `Hello, ${name}!`
  *     }),
  *     Stream.runCollect
@@ -384,9 +388,12 @@ export const service = <I, S>(service: Context.Key<I, S>): Stream<S, never, I> =
  * ```ts import.meta.vitest
  * import { Context, Effect, Option, Stream } from "effect"
  *
- * class Greeter extends Context.Service<Greeter, {
+ * interface Greeter {
+ *   readonly ["~Greeter"]: "~Greeter"
+ *
  *   readonly greet: (name: string) => string
- * }>()("Greeter") {}
+ * }
+ * const Greeter = Context.Service<Greeter>("Greeter")
  *
  * const stream = Stream.serviceOption(Greeter).pipe(
  *   Stream.map((maybeGreeter) =>
@@ -400,6 +407,7 @@ export const service = <I, S>(service: Context.Key<I, S>): Stream<S, never, I> =
  * await Effect.runPromise(
  *   stream.pipe(
  *     Stream.provideService(Greeter, {
+ *       ["~Greeter"]: "~Greeter" as const,
  *       greet: (name) => `Hello, ${name}!`
  *     }),
  *     Stream.runCollect
@@ -972,9 +980,12 @@ export const fromIterable = <A>(
  * ```ts import.meta.vitest
  * import { Context, Effect, Stream } from "effect"
  *
- * class UserRepo extends Context.Service<UserRepo, {
+ * interface UserRepo {
+ *   readonly ["~UserRepo"]: "~UserRepo"
+ *
  *   readonly list: Effect.Effect<ReadonlyArray<string>>
- * }>()("UserRepo") {}
+ * }
+ * const UserRepo = Context.Service<UserRepo>("UserRepo")
  *
  * const listUsers = Effect.service(UserRepo).pipe(
  *   Effect.andThen((repo) => repo.list)
@@ -985,6 +996,7 @@ export const fromIterable = <A>(
  * const program = Effect.gen(function*() {
  *   const users = yield* stream.pipe(
  *     Stream.provideService(UserRepo, {
+ *       ["~UserRepo"]: "~UserRepo" as const,
  *       list: Effect.succeed(["user1", "user2"])
  *     }),
  *     Stream.runCollect
@@ -5981,18 +5993,17 @@ const retryWithoutReset = <A, E, R, X, E2, R2>(
  * ```ts import.meta.vitest
  * import { Context, Effect, ExecutionPlan, Layer, Stream } from "effect"
  *
- * class Service extends Context.Service<Service>()("Service", {
- *   make: Effect.succeed({
- *     stream: Stream.fail("A") as Stream.Stream<number, string>
- *   })
- * }) {
- *   static Bad = Layer.succeed(Service, Service.of({ stream: Stream.fail("A") }))
- *   static Good = Layer.succeed(Service, Service.of({ stream: Stream.make(1, 2, 3) }))
+ * interface Service {
+ *   readonly ["~Service"]: "~Service"
+ *   readonly stream: Stream.Stream<number, string>
  * }
+ * const Service = Context.Service<Service>("Service")
+ * const bad = Layer.succeed(Service, { ["~Service"]: "~Service", stream: Stream.fail("A") })
+ * const good = Layer.succeed(Service, { ["~Service"]: "~Service", stream: Stream.make(1, 2, 3) })
  *
  * const plan = ExecutionPlan.make(
- *   { provide: Service.Bad },
- *   { provide: Service.Good }
+ *   { provide: bad },
+ *   { provide: good }
  * )
  *
  * const stream = Stream.unwrap(Effect.map(Service, (_) => _.stream))
@@ -9902,9 +9913,16 @@ export const ensuring: {
  * ```ts import.meta.vitest
  * import { Console, Context, Effect, Layer, Stream } from "effect"
  *
- * class Env extends Context.Service<Env, { readonly name: string }>()("Env") {}
+ * interface Env {
+ *   readonly ["~Env"]: "~Env"
+ *   readonly name: string
+ * }
+ * const Env = Context.Service<Env>("Env")
  *
- * const layer = Layer.succeed(Env)({ name: "Ada" })
+ * const layer = Layer.succeed(Env)({
+ *   ["~Env"]: "~Env" as const,
+ *   name: "Ada"
+ * })
  *
  * const stream = Stream.fromEffect(
  *   Effect.gen(function*() {
@@ -9953,11 +9971,25 @@ export const provide: {
  * ```ts import.meta.vitest
  * import { Context, Effect, Stream } from "effect"
  *
- * class Config extends Context.Service<Config, { readonly prefix: string }>()("Config") {}
- * class Greeter extends Context.Service<Greeter, { greet: (name: string) => string }>()("Greeter") {}
+ * interface Config {
+ *   readonly ["~Config"]: "~Config"
+ *   readonly prefix: string
+ * }
+ * const Config = Context.Service<Config>("Config")
+ * interface Greeter {
+ *   readonly ["~Greeter"]: "~Greeter"
+ *   greet: (name: string) => string
+ * }
+ * const Greeter = Context.Service<Greeter>("Greeter")
  *
- * const context = Context.make(Config, { prefix: "Hello" }).pipe(
- *   Context.add(Greeter, { greet: (name: string) => `${name}!` })
+ * const context = Context.make(Config, {
+ *   ["~Config"]: "~Config" as const,
+ *   prefix: "Hello"
+ * }).pipe(
+ *   Context.add(Greeter, {
+ *     ["~Greeter"]: "~Greeter" as const,
+ *     greet: (name: string) => `${name}!`
+ *   })
  * )
  *
  * const stream = Stream.fromEffect(
@@ -9997,9 +10029,12 @@ export const provideContext: {
  * ```ts import.meta.vitest
  * import { Context, Effect, Stream } from "effect"
  *
- * class Greeter extends Context.Service<Greeter, {
+ * interface Greeter {
+ *   readonly ["~Greeter"]: "~Greeter"
+ *
  *   greet: (name: string) => string
- * }>()("Greeter") {}
+ * }
+ * const Greeter = Context.Service<Greeter>("Greeter")
  *
  * const stream = Stream.fromEffect(
  *   Effect.service(Greeter).pipe(
@@ -10011,6 +10046,7 @@ export const provideContext: {
  *   const collected = yield* Stream.runCollect(
  *     stream.pipe(
  *       Stream.provideService(Greeter, {
+ *         ["~Greeter"]: "~Greeter" as const,
  *         greet: (name) => `Hello, ${name}`
  *       })
  *     )
@@ -10050,7 +10086,11 @@ export const provideService: {
  * ```ts import.meta.vitest
  * import { Context, Effect, Stream } from "effect"
  *
- * class ApiConfig extends Context.Service<ApiConfig, { readonly baseUrl: string }>()("ApiConfig") {}
+ * interface ApiConfig {
+ *   readonly ["~ApiConfig"]: "~ApiConfig"
+ *   readonly baseUrl: string
+ * }
+ * const ApiConfig = Context.Service<ApiConfig>("ApiConfig")
  *
  * const stream = Stream.fromEffect(
  *   Effect.gen(function*() {
@@ -10063,7 +10103,10 @@ export const provideService: {
  * const withConfig = stream.pipe(
  *   Stream.provideServiceEffect(
  *     ApiConfig,
- *     Effect.succeed({ baseUrl: "https://example.com" }).pipe(
+ *     Effect.succeed({
+ *       ["~ApiConfig"]: "~ApiConfig" as const,
+ *       baseUrl: "https://example.com"
+ *     }).pipe(
  *       Effect.tap(() => Effect.sync(() => events.push("loading")))
  *     )
  *   )
@@ -10103,8 +10146,16 @@ export const provideServiceEffect: {
  * ```ts import.meta.vitest
  * import { Context, Effect, Stream } from "effect"
  *
- * class Logger extends Context.Service<Logger, { prefix: string }>()("Logger") {}
- * class Config extends Context.Service<Config, { name: string }>()("Config") {}
+ * interface Logger {
+ *   readonly ["~Logger"]: "~Logger"
+ *   prefix: string
+ * }
+ * const Logger = Context.Service<Logger>("Logger")
+ * interface Config {
+ *   readonly ["~Config"]: "~Config"
+ *   name: string
+ * }
+ * const Config = Context.Service<Config>("Config")
  *
  * const stream = Stream.fromEffect(
  *   Effect.gen(function*() {
@@ -10116,7 +10167,10 @@ export const provideServiceEffect: {
  *
  * const updated = stream.pipe(
  *   Stream.updateContext((context: Context.Context<Logger>) =>
- *     Context.add(context, Config, { name: "World" })
+ *     Context.add(context, Config, {
+ *       ["~Config"]: "~Config" as const,
+ *       name: "World"
+ *     })
  *   )
  * )
  *
@@ -10126,7 +10180,10 @@ export const provideServiceEffect: {
  * })
  *
  * await Effect.runPromise(
- *   Effect.provideService(program, Logger, { prefix: "Hello " })
+ *   Effect.provideService(program, Logger, {
+ *     ["~Logger"]: "~Logger" as const,
+ *     prefix: "Hello "
+ *   })
  * )
  * ```
  *
@@ -10156,10 +10213,17 @@ export const updateContext: {
  * ```ts import.meta.vitest
  * import { Context, Effect, Stream } from "effect"
  *
- * class Counter extends Context.Service<Counter, { count: number }>()("Counter") {}
+ * interface Counter {
+ *   readonly ["~Counter"]: "~Counter"
+ *   count: number
+ * }
+ * const Counter = Context.Service<Counter>("Counter")
  *
  * const stream = Stream.fromEffect(Effect.service(Counter)).pipe(
- *   Stream.updateService(Counter, (counter) => ({ count: counter.count + 1 }))
+ *   Stream.updateService(Counter, (counter) => ({
+ *     ["~Counter"]: "~Counter" as const,
+ *     count: counter.count + 1
+ *   }))
  * )
  *
  * const program = Effect.gen(function*() {
@@ -10167,7 +10231,10 @@ export const updateContext: {
  *   const message = `Updated count: ${counters[0].count}` // => "Updated count: 1"
  * })
  *
- * await Effect.runPromise(Effect.provideService(program, Counter, { count: 0 }))
+ * await Effect.runPromise(Effect.provideService(program, Counter, {
+ *   ["~Counter"]: "~Counter" as const,
+ *   count: 0
+ * }))
  * ```
  *
  * @category providing services

--- a/packages/effect/src/unstable/ai/Chat.ts
+++ b/packages/effect/src/unstable/ai/Chat.ts
@@ -32,6 +32,8 @@ import * as Prompt from "./Prompt.ts"
 import type * as Response from "./Response.ts"
 import type * as Tool from "./Tool.ts"
 
+const ChatTypeId = "~effect/ai/Chat"
+
 /**
  * Service tag for stateful AI conversation sessions.
  *
@@ -82,9 +84,17 @@ import type * as Tool from "./Tool.ts"
  * @category services
  * @since 4.0.0
  */
-export class Chat extends Context.Service<Chat, Service>()(
-  "effect/ai/Chat"
-) {}
+export interface Chat extends Service {
+  readonly [ChatTypeId]: typeof ChatTypeId
+}
+
+/**
+ * Service key for `Chat` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Chat = Context.Service<Chat>("effect/ai/Chat")
 
 /**
  * Represents the interface that the `Chat` service provides.
@@ -102,6 +112,7 @@ export class Chat extends Context.Service<Chat, Service>()(
  * @since 4.0.0
  */
 export interface Service {
+  readonly [ChatTypeId]: typeof ChatTypeId
   /**
    * Reference to the chat history.
    *
@@ -419,6 +430,7 @@ const makeUnsafe = (history: Ref.Ref<Prompt.Prompt>) => {
   const semaphore = Semaphore.makeUnsafe(1)
 
   return Chat.of({
+    [ChatTypeId]: ChatTypeId as typeof ChatTypeId,
     history,
     export: Ref.get(history).pipe(
       Effect.flatMap(encodeHistory),
@@ -716,6 +728,9 @@ export class ChatNotFoundError extends Schema.Error<ChatNotFoundError>(
   chatId: Schema.String
 }) {}
 
+// @effect-diagnostics effect/leakingRequirements:off
+const PersistenceTypeId = "~effect/ai/Chat/Persisted"
+
 /**
  * Service tag for persistence-backed AI conversation storage.
  *
@@ -727,10 +742,17 @@ export class ChatNotFoundError extends Schema.Error<ChatNotFoundError>(
  * @category services
  * @since 4.0.0
  */
-// @effect-diagnostics effect/leakingRequirements:off
-export class Persistence extends Context.Service<Persistence, Persistence.Service>()(
-  "effect/ai/Chat/Persisted"
-) {}
+export interface Persistence extends Persistence.Service {
+  readonly [PersistenceTypeId]: typeof PersistenceTypeId
+}
+
+/**
+ * Service key for `Persistence` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Persistence = Context.Service<Persistence>("effect/ai/Chat/Persisted")
 
 /**
  * Namespace containing the service contract for chat persistence.
@@ -746,6 +768,8 @@ export declare namespace Persistence {
    * @since 4.0.0
    */
   export interface Service {
+    readonly [PersistenceTypeId]: typeof PersistenceTypeId
+
     /**
      * Attempts to retrieve the persisted chat from the backing persistence
      * store with the specified chat identifer. If the chat does not exist in
@@ -948,6 +972,7 @@ export const makePersisted = Effect.fnUntraced(function*(options: {
   )
 
   return Persistence.of({
+    [PersistenceTypeId]: PersistenceTypeId as typeof PersistenceTypeId,
     get,
     getOrCreate
   })

--- a/packages/effect/src/unstable/ai/EmbeddingModel.ts
+++ b/packages/effect/src/unstable/ai/EmbeddingModel.ts
@@ -18,6 +18,8 @@ import * as RequestResolver from "../../RequestResolver.ts"
 import * as Schema from "../../Schema.ts"
 import * as AiError from "./AiError.ts"
 
+const EmbeddingModelTypeId = "~effect/unstable/ai/EmbeddingModel"
+
 /**
  * Service tag for embedding model operations.
  *
@@ -33,9 +35,17 @@ import * as AiError from "./AiError.ts"
  * @category services
  * @since 4.0.0
  */
-export class EmbeddingModel extends Context.Service<EmbeddingModel, Service>()(
-  "effect/unstable/ai/EmbeddingModel"
-) {}
+export interface EmbeddingModel extends Service {
+  readonly [EmbeddingModelTypeId]: typeof EmbeddingModelTypeId
+}
+
+/**
+ * Service key for `EmbeddingModel` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const EmbeddingModel = Context.Service<EmbeddingModel>("effect/unstable/ai/EmbeddingModel")
 
 /**
  * Service tag that provides the current embedding dimensions.
@@ -157,6 +167,8 @@ export class EmbeddingRequest extends Request.TaggedClass("EmbeddingRequest")<
  * @since 4.0.0
  */
 export interface Service {
+  readonly [EmbeddingModelTypeId]: typeof EmbeddingModelTypeId
+
   readonly resolver: RequestResolver.RequestResolver<EmbeddingRequest>
   readonly embed: (input: string) => Effect.Effect<EmbedResponse, AiError.AiError>
   readonly embedMany: (input: ReadonlyArray<string>) => Effect.Effect<EmbedManyResponse, AiError.AiError>
@@ -219,6 +231,7 @@ export const make: (params: {
   )
 
   return EmbeddingModel.of({
+    [EmbeddingModelTypeId]: EmbeddingModelTypeId as typeof EmbeddingModelTypeId,
     resolver,
     embed: (input) =>
       Effect.request(new EmbeddingRequest({ input }), resolver).pipe(

--- a/packages/effect/src/unstable/ai/IdGenerator.ts
+++ b/packages/effect/src/unstable/ai/IdGenerator.ts
@@ -16,6 +16,8 @@ import * as Layer from "../../Layer.ts"
 import * as Predicate from "../../Predicate.ts"
 import * as Random from "../../Random.ts"
 
+const IdGeneratorTypeId = "~@effect/ai/IdGenerator"
+
 /**
  * Service tag for AI identifier generation services.
  *
@@ -44,6 +46,7 @@ import * as Random from "../../Random.ts"
  *
  * const program = useIdGenerator.pipe(
  *   Effect.provideService(IdGenerator.IdGenerator, {
+ *     ["~@effect/ai/IdGenerator"]: "~@effect/ai/IdGenerator",
  *     generateId: () => Effect.succeed("id-1")
  *   })
  * )
@@ -53,9 +56,17 @@ import * as Random from "../../Random.ts"
  * @category services
  * @since 4.0.0
  */
-export class IdGenerator extends Context.Service<IdGenerator, Service>()(
-  "@effect/ai/IdGenerator"
-) {}
+export interface IdGenerator extends Service {
+  readonly [IdGeneratorTypeId]: typeof IdGeneratorTypeId
+}
+
+/**
+ * Service key for `IdGenerator` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const IdGenerator = Context.Service<IdGenerator>("@effect/ai/IdGenerator")
 
 /**
  * The service interface for ID generation.
@@ -74,7 +85,8 @@ export class IdGenerator extends Context.Service<IdGenerator, Service>()(
  *
  * // Custom deterministic implementation
  * let nextId = 0
- * const customService: IdGenerator.Service = {
+ * const customService: IdGenerator.IdGenerator = {
+ *   ["~@effect/ai/IdGenerator"]: "~@effect/ai/IdGenerator",
  *   generateId: () => Effect.sync(() => `custom_${++nextId}`)
  * }
  *
@@ -87,6 +99,8 @@ export class IdGenerator extends Context.Service<IdGenerator, Service>()(
  * @since 4.0.0
  */
 export interface Service {
+  readonly [IdGeneratorTypeId]: typeof IdGeneratorTypeId
+
   readonly generateId: () => Effect.Effect<string>
 }
 
@@ -193,6 +207,7 @@ const makeGenerator = ({
  * @since 4.0.0
  */
 export const defaultIdGenerator: Service = {
+  [IdGeneratorTypeId]: IdGeneratorTypeId as typeof IdGeneratorTypeId,
   generateId: makeGenerator({ prefix: "id" })
 }
 
@@ -261,6 +276,7 @@ export const make = Effect.fnUntraced(function*({
   const generateId = makeGenerator({ alphabet, prefix, separator, size })
 
   return {
+    [IdGeneratorTypeId]: IdGeneratorTypeId as typeof IdGeneratorTypeId,
     generateId
   } as const
 })

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -42,6 +42,8 @@ import * as Toolkit from "./Toolkit.ts"
 // Service Definition
 // =============================================================================
 
+const LanguageModelTypeId = "~effect/unstable/ai/LanguageModel"
+
 /**
  * Service tag for AI model services.
  *
@@ -82,9 +84,17 @@ import * as Toolkit from "./Toolkit.ts"
  * @category services
  * @since 4.0.0
  */
-export class LanguageModel extends Context.Service<LanguageModel, Service>()(
-  "effect/unstable/ai/LanguageModel"
-) {}
+export interface LanguageModel extends Service {
+  readonly [LanguageModelTypeId]: typeof LanguageModelTypeId
+}
+
+/**
+ * Service key for `LanguageModel` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const LanguageModel = Context.Service<LanguageModel>("effect/unstable/ai/LanguageModel")
 
 /**
  * The service interface for language model operations, defining the contract that all language model implementations must fulfill.
@@ -93,6 +103,8 @@ export class LanguageModel extends Context.Service<LanguageModel, Service>()(
  * @since 4.0.0
  */
 export interface Service {
+  readonly [LanguageModelTypeId]: typeof LanguageModelTypeId
+
   /**
    * Generate text using the language model.
    */
@@ -1708,6 +1720,7 @@ export const make: (params: {
   }) as any
 
   return {
+    [LanguageModelTypeId]: LanguageModelTypeId as typeof LanguageModelTypeId,
     generateText: generateText as Service["generateText"],
     generateObject: generateObject as Service["generateObject"],
     streamText: streamText as Service["streamText"]

--- a/packages/effect/src/unstable/ai/McpSchema.ts
+++ b/packages/effect/src/unstable/ai/McpSchema.ts
@@ -2647,6 +2647,8 @@ export interface McpReverseClient {
   ) => Effect.Effect<typeof ElicitResult.Type, McpReverseOperationError | McpReverseOperationUnsupported>
 }
 
+const McpServerClientTypeId = "~effect/ai/McpSchema/McpServerClient"
+
 /**
  * Service available while handling an MCP client request.
  *
@@ -2658,7 +2660,9 @@ export interface McpReverseClient {
  * @category services
  * @since 4.0.0
  */
-export class McpServerClient extends Context.Service<McpServerClient, {
+export interface McpServerClient {
+  readonly [McpServerClientTypeId]: typeof McpServerClientTypeId
+
   readonly clientId: number
   readonly protocolVersion: ProtocolVersion
   readonly clientCapabilities: ClientCapabilities
@@ -2669,7 +2673,15 @@ export class McpServerClient extends Context.Service<McpServerClient, {
     never,
     Scope.Scope
   >
-}>()("effect/ai/McpSchema/McpServerClient") {}
+}
+
+/**
+ * Service key for `McpServerClient` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const McpServerClient = Context.Service<McpServerClient>("effect/ai/McpSchema/McpServerClient")
 
 /**
  * RPC middleware that provides `McpServerClient` to handlers for initialized

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -168,6 +168,8 @@ const toInternalServerNotification = (
   }
 }
 
+const McpServerTypeId = "~effect/ai/McpServer"
+
 /**
  * Service that stores and serves an MCP server's registered tools, resources,
  * prompts, completions, and outgoing notifications.
@@ -180,7 +182,9 @@ const toInternalServerNotification = (
  * @category services
  * @since 4.0.0
  */
-export class McpServer extends Context.Service<McpServer, {
+export interface McpServer {
+  readonly [McpServerTypeId]: typeof McpServerTypeId
+
   readonly notifications: RpcClient.RpcClient<RpcGroup.Rpcs<typeof BroadcastServerNotificationRpcs>>
   readonly notifyElicitationComplete: (options: {
     readonly clientId: number
@@ -266,343 +270,357 @@ export class McpServer extends Context.Service<McpServer, {
   readonly completion: (
     complete: typeof Complete.payloadSchema.Type
   ) => Effect.Effect<CompleteResult, InvalidParams | InternalError, McpServerClient>
-}>()("effect/ai/McpServer") {
-  /**
-   * Builds an MCP server service from registered tools, prompts, resources, and completions.
-   *
-   * @since 4.0.0
-   */
-  static readonly make = Effect.gen(function*() {
-    const internalCore = yield* McpCore.make
-    const tools = Arr.empty<{
-      readonly tool: McpTool
-      readonly annotations: Context.Context<never>
-    }>()
-    const resources: Array<{
-      readonly resource: Resource
-      readonly annotations: Context.Context<never>
-    }> = []
-    const resourceTemplates: Array<{
-      readonly template: ResourceTemplate
-      readonly annotations: Context.Context<never>
-    }> = []
-    const prompts: Array<{
-      readonly prompt: Prompt
-      readonly annotations: Context.Context<never>
-    }> = []
-    const notificationsQueue = yield* Queue.make<QueuedServerNotification>()
-    const listChangedHandles = new Map<string, any>()
-    const notifications = yield* RpcClient.makeNoSerialization(BroadcastServerNotificationRpcs, {
-      spanPrefix: "McpServer/Notifications",
-      onFromClient: (options) =>
-        Effect.suspend((): Effect.Effect<void> => {
-          const message = options.message
-          if (message._tag !== "Request") {
-            return Effect.void
-          }
-          const notification = toInternalServerNotification(message)
-          if (notification === undefined) {
-            return Effect.void
-          }
-          if (message.tag.includes("list_changed")) {
-            if (!listChangedHandles.has(message.tag)) {
-              listChangedHandles.set(
-                message.tag,
-                setTimeout(() => {
-                  Queue.offerUnsafe(notificationsQueue, { notification })
-                  listChangedHandles.delete(message.tag)
-                }, 0)
-              )
-            }
-          } else {
-            Queue.offerUnsafe(notificationsQueue, { notification })
-          }
-          return notifications.write({
-            clientId: 0,
-            requestId: message.id,
-            _tag: "Exit",
-            exit: Exit.void
-          })
-        })
-    })
+}
 
-    const service = McpServer.of({
-      notifications: notifications.client,
-      notifyElicitationComplete: ({ clientId, elicitationId }) =>
-        Queue.offer(notificationsQueue, {
-          notification: McpCore.ServerNotification.ElicitationComplete({ elicitationId }),
-          targetClientId: clientId
-        }),
-      initializedClients: new Set(),
-      get tools() {
-        return tools
-      },
-      addTool: (options) =>
-        Effect.gen(function*() {
-          const existingIndex = tools.findIndex(({ tool }) => tool.name === options.tool.name)
-          if (existingIndex === -1) {
-            tools.push(options)
-          } else {
-            tools[existingIndex] = options
-          }
-          const enabledWhen = Context.getOrUndefined(options.annotations, EnabledWhen)
-          yield* internalCore.tools.register({
-            descriptor: new McpTool({
-              ...options.tool,
-              title: options.tool.title ?? options.tool.annotations?.title
-            }),
-            isVisible: (profile) =>
-              enabledWhen === undefined || enabledWhen(
-                {
-                  protocolVersion: profile.protocolVersion,
-                  capabilities: profile.clientCapabilities,
-                  clientInfo: profile.clientInfo
-                }
-              ),
-            handle: (call, invocation) =>
-              options.handle(call.arguments).pipe(
-                Effect.provideService(
-                  McpServerClient,
-                  invocation.requestContext
+/**
+ * Service key for `McpServer` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const McpServer = (() => {
+  const service = Context.Service<McpServer>("effect/ai/McpServer")
+  const service1 = Object.assign(service, {
+    /**
+     * Builds an MCP server service from registered tools, prompts, resources, and completions.
+     *
+     * @since 4.0.0
+     */
+    make: Effect.gen(function*() {
+      const internalCore = yield* McpCore.make
+      const tools = Arr.empty<{
+        readonly tool: McpTool
+        readonly annotations: Context.Context<never>
+      }>()
+      const resources: Array<{
+        readonly resource: Resource
+        readonly annotations: Context.Context<never>
+      }> = []
+      const resourceTemplates: Array<{
+        readonly template: ResourceTemplate
+        readonly annotations: Context.Context<never>
+      }> = []
+      const prompts: Array<{
+        readonly prompt: Prompt
+        readonly annotations: Context.Context<never>
+      }> = []
+      const notificationsQueue = yield* Queue.make<QueuedServerNotification>()
+      const listChangedHandles = new Map<string, any>()
+      const notifications = yield* RpcClient.makeNoSerialization(BroadcastServerNotificationRpcs, {
+        spanPrefix: "McpServer/Notifications",
+        onFromClient: (options) =>
+          Effect.suspend((): Effect.Effect<void> => {
+            const message = options.message
+            if (message._tag !== "Request") {
+              return Effect.void
+            }
+            const notification = toInternalServerNotification(message)
+            if (notification === undefined) {
+              return Effect.void
+            }
+            if (message.tag.includes("list_changed")) {
+              if (!listChangedHandles.has(message.tag)) {
+                listChangedHandles.set(
+                  message.tag,
+                  setTimeout(() => {
+                    Queue.offerUnsafe(notificationsQueue, { notification })
+                    listChangedHandles.delete(message.tag)
+                  }, 0)
+                )
+              }
+            } else {
+              Queue.offerUnsafe(notificationsQueue, { notification })
+            }
+            return notifications.write({
+              clientId: 0,
+              requestId: message.id,
+              _tag: "Exit",
+              exit: Exit.void
+            })
+          })
+      })
+
+      const service: McpServer = {
+        [McpServerTypeId]: McpServerTypeId as typeof McpServerTypeId,
+        notifications: notifications.client,
+        notifyElicitationComplete: ({ clientId, elicitationId }) =>
+          Queue.offer(notificationsQueue, {
+            notification: McpCore.ServerNotification.ElicitationComplete({ elicitationId }),
+            targetClientId: clientId
+          }),
+        initializedClients: new Set(),
+        get tools() {
+          return tools
+        },
+        addTool: (options) =>
+          Effect.gen(function*() {
+            const existingIndex = tools.findIndex(({ tool }) => tool.name === options.tool.name)
+            if (existingIndex === -1) {
+              tools.push(options)
+            } else {
+              tools[existingIndex] = options
+            }
+            const enabledWhen = Context.getOrUndefined(options.annotations, EnabledWhen)
+            yield* internalCore.tools.register({
+              descriptor: new McpTool({
+                ...options.tool,
+                title: options.tool.title ?? options.tool.annotations?.title
+              }),
+              isVisible: (profile) =>
+                enabledWhen === undefined || enabledWhen(
+                  {
+                    protocolVersion: profile.protocolVersion,
+                    capabilities: profile.clientCapabilities,
+                    clientInfo: profile.clientInfo
+                  }
                 ),
-                Effect.catchTags({
-                  InternalError: (error) =>
-                    Effect.fail(
-                      new McpCore.ToolExecutionError({
-                        name: options.tool.name,
-                        message: error.message
-                      })
-                    ),
-                  InvalidParams: (error) =>
-                    Effect.fail(
-                      new McpCore.InvalidToolInput({
-                        name: options.tool.name,
-                        message: error.message
-                      })
-                    )
-                }),
-                Effect.flatMap((result) =>
-                  result.structuredContent === undefined
-                    ? Effect.succeed(result)
-                    : validateStructuredContent(options.tool.name, result.structuredContent).pipe(
-                      Effect.as(result)
-                    )
-                )
-              )
-          })
-          yield* notifications.client["notifications/tools/list_changed"]({})
-        }),
-      callTool: (request) =>
-        Effect.gen(function*() {
-          const client = yield* McpServerClient
-          const result = yield* internalCore.tools.call(request, {
-            clientId: client.clientId,
-            protocol: {
-              protocolVersion: client.protocolVersion,
-              clientCapabilities: client.initializePayload.capabilities,
-              clientInfo: client.initializePayload.clientInfo
-            },
-            requestContext: client
-          }).pipe(
-            Effect.mapError((error) =>
-              new InvalidParams({
-                message: error._tag === "ToolNotFound"
-                  ? `Tool '${error.name}' not found`
-                  : error.message
-              })
-            )
-          )
-          return result
-        }),
-      get resources() {
-        return resources
-      },
-      get resourceTemplates() {
-        return resourceTemplates
-      },
-      addResource: (options) =>
-        Effect.gen(function*() {
-          const existingIndex = resources.findIndex(({ resource }) => resource.uri === options.resource.uri)
-          if (existingIndex === -1) {
-            resources.push(options)
-          } else {
-            resources[existingIndex] = options
-          }
-          yield* internalCore.resources.register({
-            descriptor: options.resource,
-            isVisible: (profile) => {
-              const enabledWhen = Context.getOrUndefined(options.annotations, EnabledWhen)
-              return enabledWhen === undefined || enabledWhen({
-                protocolVersion: profile.protocolVersion,
-                capabilities: profile.clientCapabilities,
-                clientInfo: profile.clientInfo
-              })
-            },
-            read: (invocation) =>
-              options.handle.pipe(
-                Effect.provideService(McpServerClient, invocation.requestContext)
-              )
-          })
-          yield* notifications.client["notifications/resources/list_changed"]({})
-        }),
-      addResourceTemplate: ({ annotations, completions, handle, routerPath, template }) =>
-        Effect.gen(function*() {
-          const existingIndex = resourceTemplates.findIndex(({ template: current }) =>
-            current.uriTemplate === template.uriTemplate
-          )
-          if (existingIndex === -1) {
-            resourceTemplates.push({ template, annotations })
-          } else {
-            resourceTemplates[existingIndex] = { template, annotations }
-          }
-          const templateMatcher = makeUriMatcher<true>()
-          templateMatcher.add(routerPath, true)
-          yield* internalCore.resources.registerTemplate({
-            descriptor: template,
-            isVisible: (profile) => {
-              const enabledWhen = Context.getOrUndefined(annotations, EnabledWhen)
-              return enabledWhen === undefined || enabledWhen({
-                protocolVersion: profile.protocolVersion,
-                capabilities: profile.clientCapabilities,
-                clientInfo: profile.clientInfo
-              })
-            },
-            match: (uri) => {
-              const match = templateMatcher.find(uri)
-              if (match === undefined) {
-                return undefined
-              }
-              const params: Array<string> = []
-              for (const key of Object.keys(match.params)) {
-                params[Number(key)] = match.params[key]!
-              }
-              return params
-            },
-            read: (uri, params, invocation) =>
-              handle(uri, Array.from(params)).pipe(
-                Effect.provideService(McpServerClient, invocation.requestContext)
-              )
-          })
-          for (const [param, handle] of Object.entries(completions)) {
-            yield* internalCore.completions.register(
-              `resource/${template.uriTemplate}/${param}`,
-              (request) =>
-                handle(request.argument.value, request.context).pipe(
-                  Effect.map((result) => ({
-                    values: result.completion.values,
-                    total: result.completion.total,
-                    hasMore: result.completion.hasMore,
-                    metadata: result._meta
-                  }))
-                )
-            )
-          }
-          yield* notifications.client["notifications/resources/list_changed"]({})
-        }),
-      findResource: (uri) =>
-        Effect.gen(function*() {
-          const client = yield* McpServerClient
-          return yield* internalCore.resources.read(uri, {
-            clientId: client.clientId,
-            protocol: {
-              protocolVersion: client.protocolVersion,
-              clientCapabilities: client.clientCapabilities,
-              clientInfo: client.clientInfo,
-              requestMetadata: client.initializePayload._meta
-            },
-            requestContext: client
-          }).pipe(
-            Effect.catchTag("ResourceNotFound", (error) =>
-              Effect.fail(new InvalidParams({ message: `Resource '${error.uri}' not found` })))
-          )
-        }),
-      get prompts() {
-        return prompts
-      },
-      addPrompt: (options) =>
-        Effect.gen(function*() {
-          const existingIndex = prompts.findIndex(({ prompt }) => prompt.name === options.prompt.name)
-          if (existingIndex === -1) {
-            prompts.push(options)
-          } else {
-            prompts[existingIndex] = options
-          }
-          yield* internalCore.prompts.register({
-            descriptor: options.prompt,
-            isVisible: (profile) => {
-              const enabledWhen = Context.getOrUndefined(options.annotations, EnabledWhen)
-              return enabledWhen === undefined || enabledWhen({
-                protocolVersion: profile.protocolVersion,
-                capabilities: profile.clientCapabilities,
-                clientInfo: profile.clientInfo
-              })
-            },
-            get: (params, invocation) =>
-              options.handle(params).pipe(
-                Effect.provideService(McpServerClient, invocation.requestContext)
-              )
-          })
-          for (const [param, handle] of Object.entries(options.completions)) {
-            yield* internalCore.completions.register(
-              `prompt/${options.prompt.name}/${param}`,
-              (request, invocation) =>
-                handle(request.argument.value, request.context).pipe(
+              handle: (call, invocation) =>
+                options.handle(call.arguments).pipe(
                   Effect.provideService(
                     McpServerClient,
                     invocation.requestContext
                   ),
-                  Effect.map((result) => ({
-                    values: result.completion.values,
-                    total: result.completion.total,
-                    hasMore: result.completion.hasMore,
-                    metadata: result._meta
-                  }))
+                  Effect.catchTags({
+                    InternalError: (error) =>
+                      Effect.fail(
+                        new McpCore.ToolExecutionError({
+                          name: options.tool.name,
+                          message: error.message
+                        })
+                      ),
+                    InvalidParams: (error) =>
+                      Effect.fail(
+                        new McpCore.InvalidToolInput({
+                          name: options.tool.name,
+                          message: error.message
+                        })
+                      )
+                  }),
+                  Effect.flatMap((result) =>
+                    result.structuredContent === undefined
+                      ? Effect.succeed(result)
+                      : validateStructuredContent(options.tool.name, result.structuredContent).pipe(
+                        Effect.as(result)
+                      )
+                  )
                 )
+            })
+            yield* notifications.client["notifications/tools/list_changed"]({})
+          }),
+        callTool: (request) =>
+          Effect.gen(function*() {
+            const client = yield* McpServerClient
+            const result = yield* internalCore.tools.call(request, {
+              clientId: client.clientId,
+              protocol: {
+                protocolVersion: client.protocolVersion,
+                clientCapabilities: client.initializePayload.capabilities,
+                clientInfo: client.initializePayload.clientInfo
+              },
+              requestContext: client
+            }).pipe(
+              Effect.mapError((error) =>
+                new InvalidParams({
+                  message: error._tag === "ToolNotFound"
+                    ? `Tool '${error.name}' not found`
+                    : error.message
+                })
+              )
             )
-          }
-          yield* notifications.client["notifications/prompts/list_changed"]({})
+            return result
+          }),
+        get resources() {
+          return resources
+        },
+        get resourceTemplates() {
+          return resourceTemplates
+        },
+        addResource: (options) =>
+          Effect.gen(function*() {
+            const existingIndex = resources.findIndex(({ resource }) => resource.uri === options.resource.uri)
+            if (existingIndex === -1) {
+              resources.push(options)
+            } else {
+              resources[existingIndex] = options
+            }
+            yield* internalCore.resources.register({
+              descriptor: options.resource,
+              isVisible: (profile) => {
+                const enabledWhen = Context.getOrUndefined(options.annotations, EnabledWhen)
+                return enabledWhen === undefined || enabledWhen({
+                  protocolVersion: profile.protocolVersion,
+                  capabilities: profile.clientCapabilities,
+                  clientInfo: profile.clientInfo
+                })
+              },
+              read: (invocation) =>
+                options.handle.pipe(
+                  Effect.provideService(McpServerClient, invocation.requestContext)
+                )
+            })
+            yield* notifications.client["notifications/resources/list_changed"]({})
+          }),
+        addResourceTemplate: ({ annotations, completions, handle, routerPath, template }) =>
+          Effect.gen(function*() {
+            const existingIndex = resourceTemplates.findIndex(({ template: current }) =>
+              current.uriTemplate === template.uriTemplate
+            )
+            if (existingIndex === -1) {
+              resourceTemplates.push({ template, annotations })
+            } else {
+              resourceTemplates[existingIndex] = { template, annotations }
+            }
+            const templateMatcher = makeUriMatcher<true>()
+            templateMatcher.add(routerPath, true)
+            yield* internalCore.resources.registerTemplate({
+              descriptor: template,
+              isVisible: (profile) => {
+                const enabledWhen = Context.getOrUndefined(annotations, EnabledWhen)
+                return enabledWhen === undefined || enabledWhen({
+                  protocolVersion: profile.protocolVersion,
+                  capabilities: profile.clientCapabilities,
+                  clientInfo: profile.clientInfo
+                })
+              },
+              match: (uri) => {
+                const match = templateMatcher.find(uri)
+                if (match === undefined) {
+                  return undefined
+                }
+                const params: Array<string> = []
+                for (const key of Object.keys(match.params)) {
+                  params[Number(key)] = match.params[key]!
+                }
+                return params
+              },
+              read: (uri, params, invocation) =>
+                handle(uri, Array.from(params)).pipe(
+                  Effect.provideService(McpServerClient, invocation.requestContext)
+                )
+            })
+            for (const [param, handle] of Object.entries(completions)) {
+              yield* internalCore.completions.register(
+                `resource/${template.uriTemplate}/${param}`,
+                (request) =>
+                  handle(request.argument.value, request.context).pipe(
+                    Effect.map((result) => ({
+                      values: result.completion.values,
+                      total: result.completion.total,
+                      hasMore: result.completion.hasMore,
+                      metadata: result._meta
+                    }))
+                  )
+              )
+            }
+            yield* notifications.client["notifications/resources/list_changed"]({})
+          }),
+        findResource: (uri) =>
+          Effect.gen(function*() {
+            const client = yield* McpServerClient
+            return yield* internalCore.resources.read(uri, {
+              clientId: client.clientId,
+              protocol: {
+                protocolVersion: client.protocolVersion,
+                clientCapabilities: client.clientCapabilities,
+                clientInfo: client.clientInfo,
+                requestMetadata: client.initializePayload._meta
+              },
+              requestContext: client
+            }).pipe(
+              Effect.catchTag("ResourceNotFound", (error) =>
+                Effect.fail(new InvalidParams({ message: `Resource '${error.uri}' not found` })))
+            )
+          }),
+        get prompts() {
+          return prompts
+        },
+        addPrompt: (options) =>
+          Effect.gen(function*() {
+            const existingIndex = prompts.findIndex(({ prompt }) => prompt.name === options.prompt.name)
+            if (existingIndex === -1) {
+              prompts.push(options)
+            } else {
+              prompts[existingIndex] = options
+            }
+            yield* internalCore.prompts.register({
+              descriptor: options.prompt,
+              isVisible: (profile) => {
+                const enabledWhen = Context.getOrUndefined(options.annotations, EnabledWhen)
+                return enabledWhen === undefined || enabledWhen({
+                  protocolVersion: profile.protocolVersion,
+                  capabilities: profile.clientCapabilities,
+                  clientInfo: profile.clientInfo
+                })
+              },
+              get: (params, invocation) =>
+                options.handle(params).pipe(
+                  Effect.provideService(McpServerClient, invocation.requestContext)
+                )
+            })
+            for (const [param, handle] of Object.entries(options.completions)) {
+              yield* internalCore.completions.register(
+                `prompt/${options.prompt.name}/${param}`,
+                (request, invocation) =>
+                  handle(request.argument.value, request.context).pipe(
+                    Effect.provideService(
+                      McpServerClient,
+                      invocation.requestContext
+                    ),
+                    Effect.map((result) => ({
+                      values: result.completion.values,
+                      total: result.completion.total,
+                      hasMore: result.completion.hasMore,
+                      metadata: result._meta
+                    }))
+                  )
+              )
+            }
+            yield* notifications.client["notifications/prompts/list_changed"]({})
+          }),
+        getPromptResult: Effect.fnUntraced(function*({ arguments: params, name }) {
+          const client = yield* McpServerClient
+          return yield* internalCore.prompts.get(
+            name,
+            params ?? {},
+            McpProtocolInternal.invocationFromClient(client)
+          ).pipe(
+            Effect.catchTag("PromptNotFound", () => new InvalidParams({ message: `Prompt '${name}' not found` }))
+          )
         }),
-      getPromptResult: Effect.fnUntraced(function*({ arguments: params, name }) {
-        const client = yield* McpServerClient
-        return yield* internalCore.prompts.get(
-          name,
-          params ?? {},
-          McpProtocolInternal.invocationFromClient(client)
-        ).pipe(
-          Effect.catchTag("PromptNotFound", () => new InvalidParams({ message: `Prompt '${name}' not found` }))
-        )
-      }),
-      completion: Effect.fnUntraced(function*(complete) {
-        const client = yield* McpServerClient
-        const ref = complete.ref
-        const result = yield* internalCore.completions.complete({
-          reference: ref.type === "ref/resource"
-            ? { type: "resourceTemplate", uriTemplate: ref.uri }
-            : { type: "prompt", name: ref.name },
-          argument: complete.argument,
-          context: complete.context
-        }, McpProtocolInternal.invocationFromClient(client))
-        return {
-          _meta: result.metadata,
-          completion: {
-            values: result.values,
-            total: result.total,
-            hasMore: result.hasMore
+        completion: Effect.fnUntraced(function*(complete) {
+          const client = yield* McpServerClient
+          const ref = complete.ref
+          const result = yield* internalCore.completions.complete({
+            reference: ref.type === "ref/resource"
+              ? { type: "resourceTemplate", uriTemplate: ref.uri }
+              : { type: "prompt", name: ref.name },
+            argument: complete.argument,
+            context: complete.context
+          }, McpProtocolInternal.invocationFromClient(client))
+          return {
+            _meta: result.metadata,
+            completion: {
+              values: result.values,
+              total: result.total,
+              hasMore: result.hasMore
+            }
           }
-        }
-      })
+        })
+      }
+      internalState.set(service, { core: internalCore, notifications: notificationsQueue })
+      return service
     })
-    internalState.set(service, { core: internalCore, notifications: notificationsQueue })
-    return service
   })
-
-  /**
-   * Layer that provides the MCP server and client services.
-   *
-   * @since 4.0.0
-   */
-  static readonly layer: Layer.Layer<McpServer | McpServerClient> = Layer.effect(McpServer)(McpServer.make) as any
-}
+  const service2 = Object.assign(service1, {
+    /**
+     * Layer that provides the MCP server and client services.
+     *
+     * @since 4.0.0
+     */
+    layer: Layer.effect(service1)(service1.make) as Layer.Layer<McpServer | McpServerClient>
+  })
+  return service2
+})()
 
 const MCP_SESSION_ID_HEADER = "mcp-session-id"
 const MCP_PROTOCOL_VERSION_HEADER = "mcp-protocol-version"
@@ -631,10 +649,22 @@ class McpClientKey extends Data.Class<{
   readonly profile: McpCore.NegotiatedProtocolProfile
 }> {}
 
-class McpProtocolState extends Context.Service<McpProtocolState, {
+const McpProtocolStateTypeId = "~effect/ai/McpServer/McpProtocolState"
+
+interface McpProtocolState {
+  readonly [McpProtocolStateTypeId]: typeof McpProtocolStateTypeId
+
   readonly sessions: Sessions
   readonly protocolRegistry: McpProtocolRegistry.ProtocolRegistry<McpProtocol.ProtocolAdapter>
-}>()("effect/ai/McpServer/McpProtocolState") {}
+}
+
+/**
+ * Service key for `McpProtocolState` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+const McpProtocolState = Context.Service<McpProtocolState>("effect/ai/McpServer/McpProtocolState")
 
 const makeMcpProtocolState = Effect.fnUntraced(function*(
   protocols: Arr.NonEmptyReadonlyArray<McpProtocol.ProtocolAdapter>
@@ -643,6 +673,7 @@ const makeMcpProtocolState = Effect.fnUntraced(function*(
   // before v2026-07-28. The strategy must let sessionful revisions pin a profile
   // after initialize while stateless revisions select and derive it per request.
   return McpProtocolState.of({
+    [McpProtocolStateTypeId]: McpProtocolStateTypeId as typeof McpProtocolStateTypeId,
     sessions: {
       bySessionId: new Map(),
       byClientId: new Map()
@@ -703,7 +734,7 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
   readonly websiteUrl?: string | undefined
   readonly icons?: ReadonlyArray<McpSchema.Icon> | undefined
   readonly extensions?: ServerExtensions | undefined
-}, protocolState: McpProtocolState["Service"]) {
+}, protocolState: McpProtocolState) {
   const protocolRegistry = protocolState.protocolRegistry
   const serverScope = yield* Effect.scope
   const protocol = yield* RpcServer.Protocol
@@ -792,6 +823,7 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
         effect,
         McpServerClient,
         McpServerClient.of({
+          ["~effect/ai/McpSchema/McpServerClient"]: "~effect/ai/McpSchema/McpServerClient" as const,
           clientId: client.id,
           protocolVersion: session?.negotiatedProfile.protocolVersion ?? selectedProtocol.protocolVersion,
           clientCapabilities: profile.clientCapabilities,
@@ -1233,11 +1265,12 @@ export const layerStdio = (options: {
 
 const mcpStdioSerialization = (
   protocols: Arr.NonEmptyReadonlyArray<McpProtocol.ProtocolAdapter>
-): RpcSerialization.RpcSerialization["Service"] => {
+): RpcSerialization.RpcSerialization => {
   const serialization = RpcSerialization.jsonRpc({
     contentType: "application/json-rpc"
   })
   return RpcSerialization.RpcSerialization.of({
+    ["~effect/rpc/RpcSerialization"]: "~effect/rpc/RpcSerialization" as const,
     contentType: serialization.contentType,
     includesFraming: true,
     codecFor: serialization.codecFor,

--- a/packages/effect/src/unstable/ai/ResponseIdTracker.ts
+++ b/packages/effect/src/unstable/ai/ResponseIdTracker.ts
@@ -46,10 +46,14 @@ export interface PrepareResult {
  * @since 4.0.0
  */
 export interface Service {
+  readonly [ResponseIdTrackerTypeId]: typeof ResponseIdTrackerTypeId
+
   clearUnsafe(): void
   markParts(parts: ReadonlyArray<object>, responseId: string): void
   prepareUnsafe(prompt: Prompt.Prompt): Option.Option<PrepareResult>
 }
+
+const ResponseIdTrackerTypeId = "~effect/ai/ResponseIdTracker"
 
 /**
  * Service tag for enabling provider previous-response ID reuse across language
@@ -64,7 +68,17 @@ export interface Service {
  * @category services
  * @since 4.0.0
  */
-export class ResponseIdTracker extends Context.Service<ResponseIdTracker, Service>()("effect/ai/ResponseIdTracker") {}
+export interface ResponseIdTracker extends Service {
+  readonly [ResponseIdTrackerTypeId]: typeof ResponseIdTrackerTypeId
+}
+
+/**
+ * Service key for `ResponseIdTracker` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const ResponseIdTracker = Context.Service<ResponseIdTracker>("effect/ai/ResponseIdTracker")
 
 /**
  * Creates an in-memory `ResponseIdTracker` service.
@@ -88,6 +102,7 @@ export const make: Effect.Effect<Service> = Effect.sync(() => {
   }
 
   return {
+    [ResponseIdTrackerTypeId]: ResponseIdTrackerTypeId as typeof ResponseIdTrackerTypeId,
     clearUnsafe() {
       sentParts.clear()
     },

--- a/packages/effect/src/unstable/ai/Tokenizer.ts
+++ b/packages/effect/src/unstable/ai/Tokenizer.ts
@@ -16,6 +16,8 @@ import * as Predicate from "../../Predicate.ts"
 import type * as AiError from "./AiError.ts"
 import * as Prompt from "./Prompt.ts"
 
+const TokenizerTypeId = "~effect/ai/Tokenizer"
+
 /**
  * Service tag for model tokenization services.
  *
@@ -51,9 +53,17 @@ import * as Prompt from "./Prompt.ts"
  * @category services
  * @since 4.0.0
  */
-export class Tokenizer extends Context.Service<Tokenizer, Service>()(
-  "effect/ai/Tokenizer"
-) {}
+export interface Tokenizer extends Service {
+  readonly [TokenizerTypeId]: typeof TokenizerTypeId
+}
+
+/**
+ * Service key for `Tokenizer` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Tokenizer = Context.Service<Tokenizer>("effect/ai/Tokenizer")
 
 /**
  * Tokenizer service interface providing text tokenization and truncation
@@ -71,11 +81,10 @@ export class Tokenizer extends Context.Service<Tokenizer, Service>()(
  * import { Prompt } from "effect/unstable/ai"
  * import type { Tokenizer } from "effect/unstable/ai"
  *
- * const customTokenizer: Tokenizer.Service = {
- *   tokenize: (input) =>
- *     Effect.succeed(input.toString().split(" ").map((_, i) => i)),
- *   truncate: (input, maxTokens) =>
- *     Effect.succeed(Prompt.make(input.toString().slice(0, maxTokens * 5)))
+ * const customTokenizer: Tokenizer.Tokenizer = {
+ *   ["~effect/ai/Tokenizer"]: "~effect/ai/Tokenizer",
+ *   tokenize: (input) => Effect.succeed(input.toString().split(" ").map((_, i) => i)),
+ *   truncate: (input, maxTokens) => Effect.succeed(Prompt.make(input.toString().slice(0, maxTokens * 5)))
  * }
  *
  * const tokenCount = (await Effect.runPromise(customTokenizer.tokenize("one two three"))).length // => 3
@@ -86,6 +95,8 @@ export class Tokenizer extends Context.Service<Tokenizer, Service>()(
  * @since 4.0.0
  */
 export interface Service {
+  readonly [TokenizerTypeId]: typeof TokenizerTypeId
+
   /**
    * Converts text input into an array of token numbers.
    */
@@ -151,6 +162,7 @@ export const make = (options: {
   readonly tokenize: (content: Prompt.Prompt) => Effect.Effect<Array<number>, AiError.AiError>
 }): Service =>
   Tokenizer.of({
+    [TokenizerTypeId]: TokenizerTypeId as typeof TokenizerTypeId,
     tokenize(input) {
       return options.tokenize(Prompt.make(input))
     },

--- a/packages/effect/src/unstable/ai/internal/mcpCore.ts
+++ b/packages/effect/src/unstable/ai/internal/mcpCore.ts
@@ -56,7 +56,7 @@ export interface CanonicalInitializeResult {
 export interface McpInvocation {
   readonly clientId: number
   readonly protocol: NegotiatedProtocolProfile
-  readonly requestContext: McpSchema.McpServerClient["Service"]
+  readonly requestContext: McpSchema.McpServerClient
 }
 
 // NOTE: McpInvocation is runtime context, not a wire DTO. It combines the

--- a/packages/effect/src/unstable/ai/internal/mcpProtocol.ts
+++ b/packages/effect/src/unstable/ai/internal/mcpProtocol.ts
@@ -15,7 +15,7 @@ import * as McpCore from "./mcpCore.ts"
 
 /** @internal */
 export const profileFromClient = (
-  request: PublicMcpSchema.McpServerClient["Service"]
+  request: PublicMcpSchema.McpServerClient
 ): McpCore.NegotiatedProtocolProfile => ({
   protocolVersion: request.protocolVersion,
   clientCapabilities: request.clientCapabilities,
@@ -25,7 +25,7 @@ export const profileFromClient = (
 
 /** @internal */
 export const invocationFromClient = (
-  request: PublicMcpSchema.McpServerClient["Service"]
+  request: PublicMcpSchema.McpServerClient
 ): McpCore.McpInvocation => ({
   clientId: request.clientId,
   protocol: profileFromClient(request),

--- a/packages/effect/src/unstable/cluster/Entity.ts
+++ b/packages/effect/src/unstable/cluster/Entity.ts
@@ -586,7 +586,7 @@ export class Request<Rpc extends Rpc.Any> extends Data.Class<
   }
 }
 
-const shardingTag = Context.Service<Sharding, Sharding["Service"]>("effect/cluster/Sharding")
+const shardingTag = Context.Service<Sharding, Sharding>("effect/cluster/Sharding")
 
 /**
  * Builds an in-memory test client for an entity layer.
@@ -627,7 +627,7 @@ export const makeTestClient: <Type extends string, Rpcs extends Rpc.Any, LA, LE,
     readonly build: Effect.Effect<Context.Context<Rpc.ToHandler<Rpcs>>>
   }>()
   const sharding = shardingTag.of({
-    ...({} as Sharding["Service"]),
+    ...({} as Sharding),
     registerEntity: (entity, handlers, options) =>
       Effect.contextWith((context) => {
         entityMap.set(entity.type, {

--- a/packages/effect/src/unstable/cluster/HttpRunner.ts
+++ b/packages/effect/src/unstable/cluster/HttpRunner.ts
@@ -59,6 +59,7 @@ export const layerClientProtocolHttp = (options: {
       const https = options.https ?? false
       const path = options.path.startsWith("/") ? options.path : `/${options.path}`
       return {
+        ["~effect/cluster/Runners/RpcClientProtocol"]: "~effect/cluster/Runners/RpcClientProtocol" as const,
         codecFor: serialization.codecFor,
         make: (address) => {
           const clientWithUrl = HttpClient.mapRequest(
@@ -114,6 +115,7 @@ export const layerClientProtocolWebsocket = (options: {
       const path = options.path.startsWith("/") ? options.path : `/${options.path}`
       const constructor = yield* Socket.WebSocketConstructor
       return {
+        ["~effect/cluster/Runners/RpcClientProtocol"]: "~effect/cluster/Runners/RpcClientProtocol" as const,
         codecFor: serialization.codecFor,
         make: Effect.fnUntraced(function*(address) {
           const socket = yield* Socket.makeWebSocket(

--- a/packages/effect/src/unstable/cluster/MessageStorage.ts
+++ b/packages/effect/src/unstable/cluster/MessageStorage.ts
@@ -37,6 +37,8 @@ import * as Snowflake from "./Snowflake.ts"
 
 const codecForJson = Schema.toCodecJson as RpcSerialization.CodecFor
 
+const MessageStorageTypeId = "~effect/cluster/MessageStorage"
+
 /**
  * Service for cluster mailbox persistence and reply delivery.
  *
@@ -49,7 +51,9 @@ const codecForJson = Schema.toCodecJson as RpcSerialization.CodecFor
  * @category services
  * @since 4.0.0
  */
-export class MessageStorage extends Context.Service<MessageStorage, {
+export interface MessageStorage {
+  readonly [MessageStorageTypeId]: typeof MessageStorageTypeId
+
   /**
    * Save the provided message and its associated metadata.
    */
@@ -122,6 +126,8 @@ export class MessageStorage extends Context.Service<MessageStorage, {
 
   /**
    * Unregister the reply handlers for the specified ShardId.
+   *
+   * **Details**
    *
    * By default the waiters are resumed with `EntityNotAssignedToRunner`, so
    * they can re-route the wait. With `interrupt: true` the waiters are
@@ -198,7 +204,15 @@ export class MessageStorage extends Context.Service<MessageStorage, {
   readonly withTransaction: <A, E, R>(
     effect: Effect.Effect<A, E, R>
   ) => Effect.Effect<A, E, R>
-}>()("effect/cluster/MessageStorage") {}
+}
+
+/**
+ * Service key for `MessageStorage` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const MessageStorage = Context.Service<MessageStorage>("effect/cluster/MessageStorage")
 
 /**
  * Result of saving a request or envelope into message storage.
@@ -489,8 +503,12 @@ export type EncodedRepliesOptions<A> = {
 export const make = (
   storage:
     & Omit<
-      MessageStorage["Service"],
-      "saveReply" | "registerReplyHandler" | "unregisterReplyHandler" | "unregisterShardReplyHandlers"
+      MessageStorage,
+      | typeof MessageStorageTypeId
+      | "saveReply"
+      | "registerReplyHandler"
+      | "unregisterReplyHandler"
+      | "unregisterShardReplyHandlers"
     >
     & {
       /**
@@ -504,7 +522,7 @@ export const make = (
         reply: Reply.ReplyWithContext<R>
       ) => Effect.Effect<Reply.ReplyWithContext<R>, PersistenceError | MalformedMessage>
     }
-): Effect.Effect<MessageStorage["Service"]> =>
+): Effect.Effect<MessageStorage> =>
   Effect.sync(() => {
     type ReplyHandler = {
       readonly message: Message.OutgoingRequest<any> | Message.IncomingRequest<any>
@@ -515,6 +533,7 @@ export const make = (
     const replyHandlers = new Map<Snowflake.Snowflake, Array<ReplyHandler>>()
     const replyHandlersShard = new Map<string, Set<ReplyHandler>>()
     return MessageStorage.of({
+      [MessageStorageTypeId]: MessageStorageTypeId as typeof MessageStorageTypeId,
       ...storage,
       registerReplyHandler: (message) => {
         const requestId = message.envelope.requestId
@@ -612,14 +631,14 @@ export const make = (
  * @since 4.0.0
  */
 export const makeEncoded: (encoded: Encoded) => Effect.Effect<
-  MessageStorage["Service"],
+  MessageStorage,
   never,
   Snowflake.Generator
 > = Effect.fnUntraced(function*(encoded: Encoded) {
   const snowflakeGen = yield* Snowflake.Generator
   const clock = yield* Clock
 
-  const storage: MessageStorage["Service"] = yield* make({
+  const storage: MessageStorage = yield* make({
     saveRequest: (message) =>
       Message.serializeEnvelope(message).pipe(
         Effect.flatMap((envelope) =>
@@ -697,7 +716,7 @@ export const makeEncoded: (encoded: Encoded) => Effect.Effect<
       return encoded.requestIdForPrimaryKey(primaryKey)
     },
     unprocessedMessages(shardIds, options) {
-      const storage = this as unknown as MessageStorage["Service"]
+      const storage = this as unknown as MessageStorage
       const shards = Array.from(shardIds, (id) => id.toString())
       if (!Arr.isArrayNonEmpty(shards)) return Effect.succeed([])
       if (options?.addresses !== undefined && options.addresses.length === 0) return Effect.succeed([])
@@ -707,7 +726,7 @@ export const makeEncoded: (encoded: Encoded) => Effect.Effect<
       )
     },
     unprocessedMessagesById(messageIds) {
-      const storage = this as unknown as MessageStorage["Service"]
+      const storage = this as unknown as MessageStorage
       const ids = Array.from(messageIds)
       if (!Arr.isArrayNonEmpty(ids)) return Effect.succeed([])
       return Effect.flatMap(
@@ -727,7 +746,7 @@ export const makeEncoded: (encoded: Encoded) => Effect.Effect<
   })
 
   const decodeMessages = (
-    storage: MessageStorage["Service"],
+    storage: MessageStorage,
     envelopes: Array<{
       readonly envelope: Envelope.Encoded
       readonly lastSentReply: Option.Option<Reply.Encoded>
@@ -835,7 +854,7 @@ export const makeEncoded: (encoded: Encoded) => Effect.Effect<
  * @category constructors
  * @since 4.0.0
  */
-export const noop: MessageStorage["Service"] = Effect.runSync(make({
+export const noop: MessageStorage = Effect.runSync(make({
   saveRequest: () => Effect.succeed(SaveResult.Success()),
   saveEnvelope: () => Effect.void,
   saveReply: (reply) => Effect.succeed(reply),
@@ -883,6 +902,256 @@ export const MemoryTransaction = Context.Reference<boolean>("effect/cluster/Mess
 // the same claim window the SQL driver uses (`last_read < ten minutes ago`)
 const claimExpirationMillis = 10 * 60 * 1000
 
+const MemoryDriverTypeId = "~effect/cluster/MessageStorage/MemoryDriver"
+const MemoryDriverMake = Effect.gen(function*() {
+  const clock = yield* Clock
+  const requests = new Map<string, MemoryEntry>()
+  const requestsByPrimaryKey = new Map<string, MemoryEntry>()
+  const unprocessed = new Set<Envelope.Encoded>()
+  const replyIds = new Set<string>()
+  const lastRead = new Map<Envelope.Encoded, number>()
+
+  const journal: Array<Envelope.Encoded> = []
+
+  const addressKey = (address: Envelope.Encoded["address"] | EntityAddress) =>
+    `${address.shardId.group}/${address.shardId.id}/${address.entityType}/${address.entityId}`
+
+  const resetAddresses = (addresses: ReadonlyArray<EntityAddress>) =>
+    addresses.length === 0
+      ? Effect.void
+      : Effect.sync(() => {
+        const keys = new Set(addresses.map(addressKey))
+        for (const envelope of journal) {
+          if (keys.has(addressKey(envelope.address))) {
+            lastRead.delete(envelope)
+          }
+        }
+      })
+
+  const cursors = new WeakMap<{}, number>()
+
+  const unprocessedWith = (predicate: Predicate<Envelope.Encoded>) => {
+    const messages: Array<{
+      readonly envelope: Envelope.Encoded
+      readonly lastSentReply: Option.Option<Reply.Encoded>
+    }> = []
+    const now = clock.currentTimeMillisUnsafe()
+    for (const envelope of unprocessed) {
+      if (!predicate(envelope)) {
+        continue
+      }
+      if (envelope._tag === "Request") {
+        const entry = requests.get(envelope.requestId)
+        if (entry?.deliverAt && entry.deliverAt > now) {
+          continue
+        }
+        messages.push({
+          envelope,
+          lastSentReply: Option.fromNullishOr(entry?.replies[entry.replies.length - 1])
+        })
+      } else {
+        messages.push({
+          envelope,
+          lastSentReply: Option.none()
+        })
+      }
+    }
+    return messages
+  }
+
+  const replyLatch = yield* Latch.make()
+
+  function repliesFor(requestIds: Array<string>) {
+    const replies = Arr.empty<Reply.Encoded>()
+    for (const requestId of requestIds) {
+      const request = requests.get(requestId)
+      if (!request) continue
+      else if (request.lastReceivedChunk === undefined) {
+        replies.push(...request.replies)
+        continue
+      }
+      const sequence = request.lastReceivedChunk.sequence
+      for (const reply of request.replies) {
+        if (reply._tag === "Chunk" && reply.sequence <= sequence) {
+          continue
+        }
+        replies.push(reply)
+      }
+    }
+    return replies
+  }
+
+  const encoded: Encoded = {
+    saveEnvelope: ({ deliverAt, envelope: envelope_, primaryKey }) =>
+      Effect.sync(() => {
+        const envelope = JSON.parse(JSON.stringify(envelope_)) as Envelope.Encoded
+        const existing = primaryKey
+          ? requestsByPrimaryKey.get(primaryKey)
+          : envelope._tag === "Request" && requests.get(envelope.requestId)
+        if (existing) {
+          return SaveResultEncoded.Duplicate({
+            originalId: Snowflake.Snowflake(existing.envelope.requestId),
+            lastReceivedReply: Option.fromNullishOr(
+              existing.replies.length === 1 && existing.replies[0]._tag === "WithExit"
+                ? existing.replies[0]
+                : existing.lastReceivedChunk
+            )
+          })
+        }
+        if (envelope._tag === "Request") {
+          const entry: MemoryEntry = { envelope, replies: [], lastReceivedChunk: undefined, deliverAt }
+          requests.set(envelope.requestId, entry)
+          if (primaryKey) {
+            requestsByPrimaryKey.set(primaryKey, entry)
+          }
+        } else if (envelope._tag === "AckChunk") {
+          const entry = requests.get(envelope.requestId)
+          if (entry) {
+            entry.lastReceivedChunk = entry.replies.find((r): r is Reply.ChunkEncoded =>
+              r._tag === "Chunk" && r.id === envelope.replyId
+            ) ?? entry.lastReceivedChunk
+          }
+        }
+        unprocessed.add(envelope)
+        journal.push(envelope)
+        return SaveResultEncoded.Success()
+      }),
+    saveReply: (reply_) =>
+      Effect.sync(() => {
+        const reply = JSON.parse(JSON.stringify(reply_)) as Reply.Encoded
+        const entry = requests.get(reply.requestId)
+        if (!entry || replyIds.has(reply.id)) return
+        if (reply._tag === "WithExit") {
+          unprocessed.delete(entry.envelope)
+          lastRead.delete(entry.envelope)
+        }
+        entry.replies.push(reply)
+        replyIds.add(reply.id)
+        replyLatch.openUnsafe()
+      }),
+    clearReplies: (id) =>
+      Effect.sync(() => {
+        const entry = requests.get(String(id))
+        if (!entry) return
+        entry.replies = []
+        entry.lastReceivedChunk = undefined
+        unprocessed.add(entry.envelope)
+        lastRead.delete(entry.envelope)
+      }),
+    requestIdForPrimaryKey: (primaryKey) =>
+      Effect.sync(() => {
+        const entry = requestsByPrimaryKey.get(primaryKey)
+        return Option.map(Option.fromNullishOr(entry?.envelope.requestId), Snowflake.Snowflake)
+      }),
+    repliesFor: (requestIds) => Effect.sync(() => repliesFor(requestIds)),
+    repliesForUnfiltered: (requestIds) =>
+      Effect.sync(() => requestIds.flatMap((id) => requests.get(String(id))?.replies ?? [])),
+    unprocessedMessages: (shardIds, now, options) =>
+      options?.addresses?.length === 0 ? Effect.succeed([]) : Effect.sync(() => {
+        if (unprocessed.size === 0) return []
+        const limit = options?.limit ?? Infinity
+        const addressFilter = options?.addresses && new Set(options.addresses.map(addressKey))
+        const messages = Arr.empty<{
+          envelope: Envelope.Encoded
+          lastSentReply: Option.Option<Reply.Encoded>
+        }>()
+        for (let index = 0; index < journal.length; index++) {
+          if (messages.length >= limit) break
+          const envelope = journal[index]
+          const shardId = ShardId.make(envelope.address.shardId.group, envelope.address.shardId.id)
+          if (!unprocessed.has(envelope as any) || !shardIds.includes(shardId.toString())) {
+            continue
+          }
+          if (addressFilter && !addressFilter.has(addressKey(envelope.address))) {
+            continue
+          }
+          if (envelope._tag === "Request") {
+            const entry = requests.get(envelope.requestId)!
+            if (entry.deliverAt && entry.deliverAt > now) {
+              continue
+            }
+            const claimedAt = lastRead.get(envelope)
+            if (claimedAt !== undefined && claimedAt > now - claimExpirationMillis) {
+              continue
+            }
+            messages.push({
+              envelope,
+              lastSentReply: Option.fromNullishOr(entry.replies[entry.replies.length - 1])
+            })
+            lastRead.set(envelope, now)
+          } else {
+            messages.push({
+              envelope,
+              lastSentReply: Option.none()
+            })
+            unprocessed.delete(envelope)
+          }
+        }
+        return messages
+      }),
+    unprocessedMessagesById: (ids) =>
+      Effect.sync(() => {
+        const envelopeIds = new Set<string>()
+        for (const id of ids) {
+          envelopeIds.add(String(id))
+        }
+        return unprocessedWith((envelope) => envelopeIds.has(envelope.requestId))
+      }),
+    resetAddresses,
+    clearAddress: (address) =>
+      Effect.sync(() => {
+        for (const [primaryKey, entry] of requestsByPrimaryKey) {
+          const envelope = entry.envelope
+          const sameAddress = address.entityType === envelope.address.entityType &&
+            address.entityId === envelope.address.entityId
+          if (sameAddress) {
+            requestsByPrimaryKey.delete(primaryKey)
+          }
+        }
+        for (let i = journal.length - 1; i >= 0; i--) {
+          const envelope = journal[i]
+          const sameAddress = address.entityType === envelope.address.entityType &&
+            address.entityId === envelope.address.entityId
+          if (!sameAddress) {
+            continue
+          }
+          unprocessed.delete(envelope)
+          lastRead.delete(envelope)
+          if (envelope._tag === "Request") {
+            requests.delete(envelope.requestId)
+          }
+          journal.splice(i, 1)
+        }
+      }),
+    resetShards: (shardIds) =>
+      Effect.sync(() => {
+        const shards = new Set(shardIds)
+        for (const envelope of journal) {
+          const shardId = ShardId.make(envelope.address.shardId.group, envelope.address.shardId.id)
+          if (shards.has(shardId.toString())) {
+            lastRead.delete(envelope)
+          }
+        }
+      }),
+    withTransaction: Effect.provideService(MemoryTransaction, true)
+  }
+
+  const storage = yield* makeEncoded(encoded)
+
+  return {
+    [MemoryDriverTypeId]: MemoryDriverTypeId as typeof MemoryDriverTypeId,
+    storage,
+    encoded,
+    requests,
+    requestsByPrimaryKey,
+    unprocessed,
+    replyIds,
+    journal,
+    cursors
+  } as const
+})
+type MemoryDriverShape = Effect.Success<typeof MemoryDriverMake>
+
 /**
  * Service that provides an in-memory message storage driver with inspectable backing state.
  *
@@ -895,263 +1164,26 @@ const claimExpirationMillis = 10 * 60 * 1000
  * @category services
  * @since 4.0.0
  */
-export class MemoryDriver extends Context.Service<MemoryDriver>()("effect/cluster/MessageStorage/MemoryDriver", {
-  make: Effect.gen(function*() {
-    const clock = yield* Clock
-    const requests = new Map<string, MemoryEntry>()
-    const requestsByPrimaryKey = new Map<string, MemoryEntry>()
-    const unprocessed = new Set<Envelope.Encoded>()
-    const replyIds = new Set<string>()
-    const lastRead = new Map<Envelope.Encoded, number>()
-
-    const journal: Array<Envelope.Encoded> = []
-
-    const addressKey = (address: Envelope.Encoded["address"] | EntityAddress) =>
-      `${address.shardId.group}/${address.shardId.id}/${address.entityType}/${address.entityId}`
-
-    const resetAddresses = (addresses: ReadonlyArray<EntityAddress>) =>
-      addresses.length === 0
-        ? Effect.void
-        : Effect.sync(() => {
-          const keys = new Set(addresses.map(addressKey))
-          for (const envelope of journal) {
-            if (keys.has(addressKey(envelope.address))) {
-              lastRead.delete(envelope)
-            }
-          }
-        })
-
-    const cursors = new WeakMap<{}, number>()
-
-    const unprocessedWith = (predicate: Predicate<Envelope.Encoded>) => {
-      const messages: Array<{
-        readonly envelope: Envelope.Encoded
-        readonly lastSentReply: Option.Option<Reply.Encoded>
-      }> = []
-      const now = clock.currentTimeMillisUnsafe()
-      for (const envelope of unprocessed) {
-        if (!predicate(envelope)) {
-          continue
-        }
-        if (envelope._tag === "Request") {
-          const entry = requests.get(envelope.requestId)
-          if (entry?.deliverAt && entry.deliverAt > now) {
-            continue
-          }
-          messages.push({
-            envelope,
-            lastSentReply: Option.fromNullishOr(entry?.replies[entry.replies.length - 1])
-          })
-        } else {
-          messages.push({
-            envelope,
-            lastSentReply: Option.none()
-          })
-        }
-      }
-      return messages
-    }
-
-    const replyLatch = yield* Latch.make()
-
-    function repliesFor(requestIds: Array<string>) {
-      const replies = Arr.empty<Reply.Encoded>()
-      for (const requestId of requestIds) {
-        const request = requests.get(requestId)
-        if (!request) continue
-        else if (request.lastReceivedChunk === undefined) {
-          replies.push(...request.replies)
-          continue
-        }
-        const sequence = request.lastReceivedChunk.sequence
-        for (const reply of request.replies) {
-          if (reply._tag === "Chunk" && reply.sequence <= sequence) {
-            continue
-          }
-          replies.push(reply)
-        }
-      }
-      return replies
-    }
-
-    const encoded: Encoded = {
-      saveEnvelope: ({ deliverAt, envelope: envelope_, primaryKey }) =>
-        Effect.sync(() => {
-          const envelope = JSON.parse(JSON.stringify(envelope_)) as Envelope.Encoded
-          const existing = primaryKey
-            ? requestsByPrimaryKey.get(primaryKey)
-            : envelope._tag === "Request" && requests.get(envelope.requestId)
-          if (existing) {
-            return SaveResultEncoded.Duplicate({
-              originalId: Snowflake.Snowflake(existing.envelope.requestId),
-              lastReceivedReply: Option.fromNullishOr(
-                existing.replies.length === 1 && existing.replies[0]._tag === "WithExit"
-                  ? existing.replies[0]
-                  : existing.lastReceivedChunk
-              )
-            })
-          }
-          if (envelope._tag === "Request") {
-            const entry: MemoryEntry = { envelope, replies: [], lastReceivedChunk: undefined, deliverAt }
-            requests.set(envelope.requestId, entry)
-            if (primaryKey) {
-              requestsByPrimaryKey.set(primaryKey, entry)
-            }
-          } else if (envelope._tag === "AckChunk") {
-            const entry = requests.get(envelope.requestId)
-            if (entry) {
-              entry.lastReceivedChunk = entry.replies.find((r): r is Reply.ChunkEncoded =>
-                r._tag === "Chunk" && r.id === envelope.replyId
-              ) ?? entry.lastReceivedChunk
-            }
-          }
-          unprocessed.add(envelope)
-          journal.push(envelope)
-          return SaveResultEncoded.Success()
-        }),
-      saveReply: (reply_) =>
-        Effect.sync(() => {
-          const reply = JSON.parse(JSON.stringify(reply_)) as Reply.Encoded
-          const entry = requests.get(reply.requestId)
-          if (!entry || replyIds.has(reply.id)) return
-          if (reply._tag === "WithExit") {
-            unprocessed.delete(entry.envelope)
-            lastRead.delete(entry.envelope)
-          }
-          entry.replies.push(reply)
-          replyIds.add(reply.id)
-          replyLatch.openUnsafe()
-        }),
-      clearReplies: (id) =>
-        Effect.sync(() => {
-          const entry = requests.get(String(id))
-          if (!entry) return
-          entry.replies = []
-          entry.lastReceivedChunk = undefined
-          unprocessed.add(entry.envelope)
-          lastRead.delete(entry.envelope)
-        }),
-      requestIdForPrimaryKey: (primaryKey) =>
-        Effect.sync(() => {
-          const entry = requestsByPrimaryKey.get(primaryKey)
-          return Option.map(Option.fromNullishOr(entry?.envelope.requestId), Snowflake.Snowflake)
-        }),
-      repliesFor: (requestIds) => Effect.sync(() => repliesFor(requestIds)),
-      repliesForUnfiltered: (requestIds) =>
-        Effect.sync(() => requestIds.flatMap((id) => requests.get(String(id))?.replies ?? [])),
-      unprocessedMessages: (shardIds, now, options) =>
-        options?.addresses?.length === 0 ? Effect.succeed([]) : Effect.sync(() => {
-          if (unprocessed.size === 0) return []
-          const limit = options?.limit ?? Infinity
-          const addressFilter = options?.addresses && new Set(options.addresses.map(addressKey))
-          const messages = Arr.empty<{
-            envelope: Envelope.Encoded
-            lastSentReply: Option.Option<Reply.Encoded>
-          }>()
-          for (let index = 0; index < journal.length; index++) {
-            if (messages.length >= limit) break
-            const envelope = journal[index]
-            const shardId = ShardId.make(envelope.address.shardId.group, envelope.address.shardId.id)
-            if (!unprocessed.has(envelope as any) || !shardIds.includes(shardId.toString())) {
-              continue
-            }
-            if (addressFilter && !addressFilter.has(addressKey(envelope.address))) {
-              continue
-            }
-            if (envelope._tag === "Request") {
-              const entry = requests.get(envelope.requestId)!
-              if (entry.deliverAt && entry.deliverAt > now) {
-                continue
-              }
-              const claimedAt = lastRead.get(envelope)
-              if (claimedAt !== undefined && claimedAt > now - claimExpirationMillis) {
-                continue
-              }
-              messages.push({
-                envelope,
-                lastSentReply: Option.fromNullishOr(entry.replies[entry.replies.length - 1])
-              })
-              lastRead.set(envelope, now)
-            } else {
-              messages.push({
-                envelope,
-                lastSentReply: Option.none()
-              })
-              unprocessed.delete(envelope)
-            }
-          }
-          return messages
-        }),
-      unprocessedMessagesById: (ids) =>
-        Effect.sync(() => {
-          const envelopeIds = new Set<string>()
-          for (const id of ids) {
-            envelopeIds.add(String(id))
-          }
-          return unprocessedWith((envelope) => envelopeIds.has(envelope.requestId))
-        }),
-      resetAddresses,
-      clearAddress: (address) =>
-        Effect.sync(() => {
-          for (const [primaryKey, entry] of requestsByPrimaryKey) {
-            const envelope = entry.envelope
-            const sameAddress = address.entityType === envelope.address.entityType &&
-              address.entityId === envelope.address.entityId
-            if (sameAddress) {
-              requestsByPrimaryKey.delete(primaryKey)
-            }
-          }
-          for (let i = journal.length - 1; i >= 0; i--) {
-            const envelope = journal[i]
-            const sameAddress = address.entityType === envelope.address.entityType &&
-              address.entityId === envelope.address.entityId
-            if (!sameAddress) {
-              continue
-            }
-            unprocessed.delete(envelope)
-            lastRead.delete(envelope)
-            if (envelope._tag === "Request") {
-              requests.delete(envelope.requestId)
-            }
-            journal.splice(i, 1)
-          }
-        }),
-      resetShards: (shardIds) =>
-        Effect.sync(() => {
-          const shards = new Set(shardIds)
-          for (const envelope of journal) {
-            const shardId = ShardId.make(envelope.address.shardId.group, envelope.address.shardId.id)
-            if (shards.has(shardId.toString())) {
-              lastRead.delete(envelope)
-            }
-          }
-        }),
-      withTransaction: Effect.provideService(MemoryTransaction, true)
-    }
-
-    const storage = yield* makeEncoded(encoded)
-
-    return {
-      storage,
-      encoded,
-      requests,
-      requestsByPrimaryKey,
-      unprocessed,
-      replyIds,
-      journal,
-      cursors
-    } as const
-  })
-}) {
-  /**
-   * Layer that provides the in-memory message storage driver.
-   *
-   * @since 4.0.0
-   */
-  static readonly layer: Layer.Layer<MemoryDriver> = Layer.effect(this)(this.make).pipe(
-    Layer.provide(Snowflake.layerGenerator)
-  )
+export interface MemoryDriver extends MemoryDriverShape {
+  readonly [MemoryDriverTypeId]: typeof MemoryDriverTypeId
 }
+
+/**
+ * Service key for `MemoryDriver` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const MemoryDriver = (() => {
+  const service = Object.assign(Context.Service<MemoryDriver>("effect/cluster/MessageStorage/MemoryDriver"), {
+    make: MemoryDriverMake
+  })
+  return Object.assign(service, {
+    layer: Layer.effect(service)(service.make).pipe(
+      Layer.provide(Snowflake.layerGenerator)
+    )
+  })
+})()
 
 /**
  * Layer that provides the no-op `MessageStorage` service.

--- a/packages/effect/src/unstable/cluster/RunnerHealth.ts
+++ b/packages/effect/src/unstable/cluster/RunnerHealth.ts
@@ -18,6 +18,8 @@ import * as K8s from "./K8sHttpClient.ts"
 import type { RunnerAddress } from "./RunnerAddress.ts"
 import * as Runners from "./Runners.ts"
 
+const RunnerHealthTypeId = "~effect/cluster/RunnerHealth"
+
 /**
  * Represents the service used to check if a Runner is healthy.
  *
@@ -30,12 +32,19 @@ import * as Runners from "./Runners.ts"
  * @category services
  * @since 4.0.0
  */
-export class RunnerHealth extends Context.Service<
-  RunnerHealth,
-  {
-    readonly isAlive: (address: RunnerAddress) => Effect.Effect<boolean>
-  }
->()("effect/cluster/RunnerHealth") {}
+export interface RunnerHealth {
+  readonly [RunnerHealthTypeId]: typeof RunnerHealthTypeId
+
+  readonly isAlive: (address: RunnerAddress) => Effect.Effect<boolean>
+}
+
+/**
+ * Service key for `RunnerHealth` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const RunnerHealth = Context.Service<RunnerHealth>("effect/cluster/RunnerHealth")
 
 /**
  * Layer that always considers a runner healthy.
@@ -49,6 +58,7 @@ export class RunnerHealth extends Context.Service<
  * @since 4.0.0
  */
 export const layerNoop = Layer.succeed(RunnerHealth, {
+  [RunnerHealthTypeId]: RunnerHealthTypeId as typeof RunnerHealthTypeId,
   isAlive: () => Effect.succeed(true)
 })
 
@@ -61,7 +71,7 @@ export const layerNoop = Layer.succeed(RunnerHealth, {
  * @since 4.0.0
  */
 export const makePing: Effect.Effect<
-  RunnerHealth["Service"],
+  RunnerHealth,
   never,
   Runners.Runners | Scope.Scope
 > = Effect.gen(function*() {
@@ -76,7 +86,10 @@ export const makePing: Effect.Effect<
     )
   }
 
-  return RunnerHealth.of({ isAlive })
+  return RunnerHealth.of({
+    [RunnerHealthTypeId]: RunnerHealthTypeId as typeof RunnerHealthTypeId,
+    isAlive
+  })
 })
 
 /**
@@ -109,6 +122,7 @@ export const makeK8s = Effect.fnUntraced(function*(options?: {
   const allPods = yield* K8s.makeGetPods(options)
 
   return RunnerHealth.of({
+    [RunnerHealthTypeId]: RunnerHealthTypeId as typeof RunnerHealthTypeId,
     isAlive: (address) =>
       allPods.pipe(
         Effect.map((pods) => pods.get(address.host)?.isReadyOrInitializing ?? false),

--- a/packages/effect/src/unstable/cluster/RunnerServer.ts
+++ b/packages/effect/src/unstable/cluster/RunnerServer.ts
@@ -35,7 +35,7 @@ const constVoid = constant(Effect.void)
 const serializeDefectReply = <R extends Rpc.Any>(
   reply: Reply.ReplyWithContext<R>,
   defect: unknown,
-  codecFor: RpcServer.Protocol["Service"]["codecFor"]
+  codecFor: RpcServer.Protocol["codecFor"]
 ): Effect.Effect<Reply.Encoded> =>
   Effect.orDie(Reply.serialize(
     Reply.ReplyWithContext.fromDefect({

--- a/packages/effect/src/unstable/cluster/RunnerStorage.ts
+++ b/packages/effect/src/unstable/cluster/RunnerStorage.ts
@@ -20,6 +20,8 @@ import { Runner } from "./Runner.ts"
 import type { RunnerAddress } from "./RunnerAddress.ts"
 import * as ShardId from "./ShardId.ts"
 
+const RunnerStorageTypeId = "~effect/cluster/RunnerStorage"
+
 /**
  * Represents a generic interface to the persistent storage required by the
  * cluster.
@@ -27,7 +29,9 @@ import * as ShardId from "./ShardId.ts"
  * @category services
  * @since 4.0.0
  */
-export class RunnerStorage extends Context.Service<RunnerStorage, {
+export interface RunnerStorage {
+  readonly [RunnerStorageTypeId]: typeof RunnerStorageTypeId
+
   /**
    * Register a new runner with the cluster.
    */
@@ -50,6 +54,8 @@ export class RunnerStorage extends Context.Service<RunnerStorage, {
 
   /**
    * Try to acquire the given shard ids for processing.
+   *
+   * **Details**
    *
    * It returns an array of shards it was able to acquire.
    */
@@ -78,7 +84,15 @@ export class RunnerStorage extends Context.Service<RunnerStorage, {
    * Release all the shards assigned to the given runner.
    */
   readonly releaseAll: (address: RunnerAddress) => Effect.Effect<void, PersistenceError>
-}>()("effect/cluster/RunnerStorage") {}
+}
+
+/**
+ * Service key for `RunnerStorage` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const RunnerStorage = Context.Service<RunnerStorage>("effect/cluster/RunnerStorage")
 
 /**
  * String-encoded runner storage interface used by adapters that persist runner
@@ -150,6 +164,7 @@ export interface Encoded {
  */
 export const makeEncoded = (encoded: Encoded) =>
   RunnerStorage.of({
+    [RunnerStorageTypeId]: RunnerStorageTypeId as typeof RunnerStorageTypeId,
     getRunners: Effect.gen(function*() {
       const runners = yield* encoded.getRunners
       const results: Array<[Runner, boolean]> = []
@@ -206,6 +221,7 @@ export const makeMemory = Effect.gen(function*() {
   let id = 0
 
   return RunnerStorage.of({
+    [RunnerStorageTypeId]: RunnerStorageTypeId as typeof RunnerStorageTypeId,
     getRunners: Effect.sync(() => Array.from(MutableHashMap.values(runners))),
     register: (runner, healthy) =>
       Effect.sync(() => {

--- a/packages/effect/src/unstable/cluster/Runners.ts
+++ b/packages/effect/src/unstable/cluster/Runners.ts
@@ -37,6 +37,8 @@ import type { RunnerAddress } from "./RunnerAddress.ts"
 import { ShardingConfig } from "./ShardingConfig.ts"
 import * as Snowflake from "./Snowflake.ts"
 
+const RunnersTypeId = "~effect/cluster/Runners"
+
 /**
  * Service for communicating with cluster runners, including pinging runners,
  * sending and notifying messages, coordinating persisted replies, and marking
@@ -45,7 +47,9 @@ import * as Snowflake from "./Snowflake.ts"
  * @category services
  * @since 4.0.0
  */
-export class Runners extends Context.Service<Runners, {
+export interface Runners {
+  readonly [RunnersTypeId]: typeof RunnersTypeId
+
   /**
    * Checks whether a Runner is responsive.
    */
@@ -53,6 +57,8 @@ export class Runners extends Context.Service<Runners, {
 
   /**
    * Send a message locally.
+   *
+   * **Details**
    *
    * This ensures that the message hits storage before being sent to the local
    * entity.
@@ -113,6 +119,8 @@ export class Runners extends Context.Service<Runners, {
    * Notify the current Runner that a message is available, then read replies from
    * storage.
    *
+   * **Details**
+   *
    * This ensures that the message hits storage before being sent to the local
    * entity.
    */
@@ -131,7 +139,15 @@ export class Runners extends Context.Service<Runners, {
    * Mark a Runner as unavailable.
    */
   readonly onRunnerUnavailable: (address: RunnerAddress) => Effect.Effect<void>
-}>()("effect/cluster/Runners") {}
+}
+
+/**
+ * Service key for `Runners` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Runners = Context.Service<Runners>("effect/cluster/Runners")
 
 /**
  * Builds the `Runners` service from remote runner callbacks and adds local
@@ -160,11 +176,11 @@ export class Runners extends Context.Service<Runners, {
  * @since 4.0.0
  */
 export const make: (
-  options: Omit<Runners["Service"], "sendLocal" | "notifyLocal"> & {
+  options: Omit<Runners, typeof RunnersTypeId | "sendLocal" | "notifyLocal"> & {
     readonly codecFor: RpcSerialization.CodecFor
   }
 ) => Effect.Effect<
-  Runners["Service"],
+  Runners,
   never,
   MessageStorage.MessageStorage | Snowflake.Generator | ShardingConfig | Scope
 > = Effect.fnUntraced(function*(options) {
@@ -363,6 +379,7 @@ export const make: (
   }
 
   return Runners.of({
+    [RunnersTypeId]: RunnersTypeId as typeof RunnersTypeId,
     ...serviceOptions,
     sendLocal(options) {
       const message = options.message
@@ -437,7 +454,7 @@ export const make: (
  * @since 4.0.0
  */
 export const makeNoop: Effect.Effect<
-  Runners["Service"],
+  Runners,
   never,
   MessageStorage.MessageStorage | Snowflake.Generator | ShardingConfig | Scope
 > = make({
@@ -544,7 +561,7 @@ export const makeRpcClient: Effect.Effect<
  * @since 4.0.0
  */
 export const makeRpc: Effect.Effect<
-  Runners["Service"],
+  Runners,
   never,
   Scope | RpcClientProtocol | MessageStorage.MessageStorage | Snowflake.Generator | ShardingConfig
 > = Effect.gen(function*() {
@@ -709,6 +726,8 @@ export const layerRpc: Layer.Layer<
   Layer.provide(Snowflake.layerGenerator)
 )
 
+const RpcClientProtocolTypeId = "~effect/cluster/Runners/RpcClientProtocol"
+
 /**
  * Service that creates RPC client protocols for runner addresses and exposes
  * the codec shared by those protocols.
@@ -716,10 +735,17 @@ export const layerRpc: Layer.Layer<
  * @category services
  * @since 4.0.0
  */
-export class RpcClientProtocol extends Context.Service<
-  RpcClientProtocol,
-  {
-    readonly make: (address: RunnerAddress) => Effect.Effect<RpcClient_.Protocol["Service"], never, Scope>
-    readonly codecFor: RpcSerialization.CodecFor
-  }
->()("effect/cluster/Runners/RpcClientProtocol") {}
+export interface RpcClientProtocol {
+  readonly [RpcClientProtocolTypeId]: typeof RpcClientProtocolTypeId
+
+  readonly make: (address: RunnerAddress) => Effect.Effect<RpcClient_.Protocol, never, Scope>
+  readonly codecFor: RpcSerialization.CodecFor
+}
+
+/**
+ * Service key for `RpcClientProtocol` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const RpcClientProtocol = Context.Service<RpcClientProtocol>("effect/cluster/Runners/RpcClientProtocol")

--- a/packages/effect/src/unstable/cluster/Sharding.ts
+++ b/packages/effect/src/unstable/cluster/Sharding.ts
@@ -73,6 +73,8 @@ import { EntityRegistered, type ShardingRegistrationEvent, SingletonRegistered }
 import { SingletonAddress } from "./SingletonAddress.ts"
 import * as Snowflake from "./Snowflake.ts"
 
+const ShardingTypeId = "~effect/cluster/Sharding"
+
 /**
  * Service that registers entities and singletons, routes messages to owned
  * shards, generates runner-local snowflake ids, and polls
@@ -86,7 +88,9 @@ import * as Snowflake from "./Snowflake.ts"
  * @category services
  * @since 4.0.0
  */
-export class Sharding extends Context.Service<Sharding, {
+export interface Sharding {
+  readonly [ShardingTypeId]: typeof ShardingTypeId
+
   /**
    * Returns a stream of events that occur when the runner registers entities or
    * singletons.
@@ -206,7 +210,15 @@ export class Sharding extends Context.Service<Sharding, {
    * Retrieves the active entity count for the current runner.
    */
   readonly activeEntityCount: Effect.Effect<number>
-}>()("effect/cluster/Sharding") {}
+}
+
+/**
+ * Service key for `Sharding` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Sharding = Context.Service<Sharding>("effect/cluster/Sharding")
 
 // -----------------------------------------------------------------------------
 // Implementation
@@ -1177,7 +1189,7 @@ const make = Effect.gen(function*() {
     )
   }
 
-  const reset: Sharding["Service"]["reset"] = (requestId) =>
+  const reset: Sharding["reset"] = (requestId) =>
     Effect.matchCause(storage.clearReplies(requestId), {
       onSuccess: () => true,
       onFailure: () => false
@@ -1535,7 +1547,7 @@ const make = Effect.gen(function*() {
   const singletonFibers = yield* FiberMap.make<SingletonAddress>()
   const withSingletonLock = Semaphore.makeUnsafe(1).withPermits(1)
 
-  const registerSingleton: Sharding["Service"]["registerSingleton"] = Effect.fnUntraced(
+  const registerSingleton: Sharding["registerSingleton"] = Effect.fnUntraced(
     function*(name, run, options) {
       const shardGroup = options?.shardGroup ?? "default"
       const address = new SingletonAddress({
@@ -1608,7 +1620,7 @@ const make = Effect.gen(function*() {
   const reaper = yield* EntityReaper
   const entityManagerLatches = new Map<string, Latch.Latch>()
 
-  const registerEntity: Sharding["Service"]["registerEntity"] = Effect.fnUntraced(
+  const registerEntity: Sharding["registerEntity"] = Effect.fnUntraced(
     function*(entity, build, options) {
       const runnerAddress = getRunnerAddress()
       if (!runnerAddress || entityManagers.has(entity.type)) return
@@ -1749,6 +1761,7 @@ const make = Effect.gen(function*() {
   })
 
   const sharding = Sharding.of({
+    [ShardingTypeId]: ShardingTypeId as typeof ShardingTypeId,
     getRegistrationEvents,
     getShardId,
     hasShardId(shardId: ShardId) {

--- a/packages/effect/src/unstable/cluster/ShardingConfig.ts
+++ b/packages/effect/src/unstable/cluster/ShardingConfig.ts
@@ -20,16 +20,22 @@ import * as Option from "../../Option.ts"
 import * as Schema from "../../Schema.ts"
 import { RunnerAddress } from "./RunnerAddress.ts"
 
+const ShardingConfigTypeId = "~effect/cluster/ShardingConfig"
+
 /**
  * Represents the configuration for the `Sharding` service on a given runner.
  *
  * @category services
  * @since 4.0.0
  */
-export class ShardingConfig extends Context.Service<ShardingConfig, {
+export interface ShardingConfig {
+  readonly [ShardingConfigTypeId]: typeof ShardingConfigTypeId
+
   /**
    * The address for the current runner that other runners can use to
    * communicate with it.
+   *
+   * **Details**
    *
    * If `None`, the runner is not part of the cluster and will be in a client-only
    * mode.
@@ -38,12 +44,16 @@ export class ShardingConfig extends Context.Service<ShardingConfig, {
   /**
    * The listen address for the current runner.
    *
+   * **Details**
+   *
    * Defaults to the `runnerAddress`.
    */
   readonly runnerListenAddress: Option.Option<RunnerAddress>
   /**
    * A number that determines how many shards this runner will be assigned
    * relative to other runners.
+   *
+   * **Details**
    *
    * Defaults to `1`.
    *
@@ -54,11 +64,15 @@ export class ShardingConfig extends Context.Service<ShardingConfig, {
   /**
    * The shard groups available across all runners.
    *
+   * **Details**
+   *
    * Defaults to `["default"]`.
    */
   readonly availableShardGroups: ReadonlyArray<string>
   /**
    * The shard groups that are assigned to this runner.
+   *
+   * **Details**
    *
    * Defaults to `["default"]`.
    */
@@ -66,11 +80,15 @@ export class ShardingConfig extends Context.Service<ShardingConfig, {
   /**
    * The number of shards to allocate per shard group.
    *
+   * **Details**
+   *
    * **Note**: this value should be consistent across all runners.
    */
   readonly shardsPerGroup: number
   /**
    * The maximum interval between shard lock refreshes.
+   *
+   * **Details**
    *
    * The runner may shorten this interval to one third of
    * `shardLockExpiration` to preserve enough time to stop entities safely if
@@ -88,6 +106,8 @@ export class ShardingConfig extends Context.Service<ShardingConfig, {
   /**
    * Start shutting down as soon as an Entity has started shutting down.
    *
+   * **Details**
+   *
    * Defaults to `true`.
    */
   readonly preemptiveShutdown: boolean
@@ -98,6 +118,8 @@ export class ShardingConfig extends Context.Service<ShardingConfig, {
   /**
    * The maximum number of entities that can be resident on this runner at the
    * same time.
+   *
+   * **Details**
    *
    * When the limit is reached, no new entities are spawned: the storage read
    * loop stops admitting messages for new entity addresses (they stay in
@@ -114,6 +136,8 @@ export class ShardingConfig extends Context.Service<ShardingConfig, {
    * The maximum number of unprocessed messages read from storage in a single
    * poll.
    *
+   * **Details**
+   *
    * Defaults to `1024`.
    */
   readonly unprocessedMessageBatchSize: number
@@ -126,11 +150,15 @@ export class ShardingConfig extends Context.Service<ShardingConfig, {
    * If an entity does not register itself within this time after a message is
    * sent to it, the message will be marked as failed.
    *
+   * **Details**
+   *
    * Defaults to 1 minute.
    */
   readonly entityRegistrationTimeout: Duration.Input
   /**
    * The maximum duration of time to wait for an entity to terminate.
+   *
+   * **Details**
    *
    * By default this is set to 15 seconds to stay within kubernetes defaults.
    */
@@ -161,7 +189,15 @@ export class ShardingConfig extends Context.Service<ShardingConfig, {
    * entities.
    */
   readonly simulateRemoteSerialization: boolean
-}>()("effect/cluster/ShardingConfig") {}
+}
+
+/**
+ * Service key for `ShardingConfig` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const ShardingConfig = Context.Service<ShardingConfig>("effect/cluster/ShardingConfig")
 
 const defaultRunnerAddress = RunnerAddress.make({ host: "localhost", port: 34431 })
 
@@ -173,7 +209,8 @@ const defaultRunnerAddress = RunnerAddress.make({ host: "localhost", port: 34431
  * @category defaults
  * @since 4.0.0
  */
-export const defaults: ShardingConfig["Service"] = {
+export const defaults: ShardingConfig = {
+  [ShardingConfigTypeId]: ShardingConfigTypeId as typeof ShardingConfigTypeId,
   runnerAddress: Option.some(defaultRunnerAddress),
   runnerListenAddress: Option.none(),
   runnerShardWeight: 1,
@@ -228,7 +265,7 @@ export const defaults: ShardingConfig["Service"] = {
  * @category layers
  * @since 4.0.0
  */
-export const layer = (options?: Partial<ShardingConfig["Service"]>): Layer.Layer<ShardingConfig> =>
+export const layer = (options?: Partial<ShardingConfig>): Layer.Layer<ShardingConfig> =>
   Layer.succeed(ShardingConfig)({ ...defaults, ...options })
 
 /**
@@ -246,7 +283,8 @@ export const layerDefaults: Layer.Layer<ShardingConfig> = layer()
  * @category configuration
  * @since 4.0.0
  */
-export const config: Config.Config<ShardingConfig["Service"]> = Config.all({
+export const config: Config.Config<ShardingConfig> = Config.all({
+  [ShardingConfigTypeId]: Config.succeed(ShardingConfigTypeId as typeof ShardingConfigTypeId),
   runnerAddress: Config.all({
     host: Config.String("host").pipe(
       Config.withDefault(defaultRunnerAddress.host)
@@ -379,7 +417,7 @@ export const configFromEnv = config.pipe(
  * @category layers
  * @since 4.0.0
  */
-export const layerFromEnv = (options?: Partial<ShardingConfig["Service"]> | undefined): Layer.Layer<
+export const layerFromEnv = (options?: Partial<ShardingConfig> | undefined): Layer.Layer<
   ShardingConfig,
   Config.ConfigError
 > =>
@@ -394,7 +432,7 @@ export const layerFromEnv = (options?: Partial<ShardingConfig["Service"]> | unde
  * @category converting
  * @since 4.0.0
  */
-export const shardGroupConfig = (config: ShardingConfig["Service"]): {
+export const shardGroupConfig = (config: ShardingConfig): {
   readonly available: ReadonlySet<string>
   readonly assigned: ReadonlySet<string>
 } => {

--- a/packages/effect/src/unstable/cluster/SingleRunner.ts
+++ b/packages/effect/src/unstable/cluster/SingleRunner.ts
@@ -57,7 +57,7 @@ import * as SqlRunnerStorage from "./SqlRunnerStorage.ts"
  * @since 4.0.0
  */
 export const layer = (options?: {
-  readonly shardingConfig?: Partial<ShardingConfig.ShardingConfig["Service"]> | undefined
+  readonly shardingConfig?: Partial<ShardingConfig.ShardingConfig> | undefined
   readonly runnerStorage?: "memory" | "sql" | undefined
 }): Layer.Layer<
   | Sharding.Sharding

--- a/packages/effect/src/unstable/cluster/Snowflake.ts
+++ b/packages/effect/src/unstable/cluster/Snowflake.ts
@@ -83,6 +83,7 @@ export declare namespace Snowflake {
    * @since 4.0.0
    */
   export interface Generator {
+    readonly [GeneratorTypeId]: typeof GeneratorTypeId
     readonly nextUnsafe: () => Snowflake
     readonly setMachineId: (machineId: MachineId) => Effect.Effect<void>
   }
@@ -232,6 +233,7 @@ export const makeGenerator: Effect.Effect<Snowflake.Generator> = Effect.gen(func
   let sequenceAt = Math.floor(clock.currentTimeMillisUnsafe())
 
   return identity<Snowflake.Generator>({
+    [GeneratorTypeId]: GeneratorTypeId,
     setMachineId: (newMachineId) =>
       Effect.sync(() => {
         machineId = newMachineId
@@ -262,16 +264,25 @@ export const makeGenerator: Effect.Effect<Snowflake.Generator> = Effect.gen(func
   })
 })
 
+const GeneratorTypeId = "~effect/cluster/Snowflake/Generator"
+
 /**
  * Context service for a stateful snowflake id generator.
  *
  * @category services
  * @since 4.0.0
  */
-export class Generator extends Context.Service<
-  Generator,
-  Snowflake.Generator
->()("effect/cluster/Snowflake/Generator") {}
+export interface Generator extends Snowflake.Generator {
+  readonly [GeneratorTypeId]: typeof GeneratorTypeId
+}
+
+/**
+ * Service key for `Generator` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Generator = Context.Service<Generator>("effect/cluster/Snowflake/Generator")
 
 /**
  * Layer that provides the default snowflake `Generator` service.

--- a/packages/effect/src/unstable/cluster/SqlMessageStorage.ts
+++ b/packages/effect/src/unstable/cluster/SqlMessageStorage.ts
@@ -763,7 +763,7 @@ export const makeEncoded: (options?: {
 export const make: (options?: {
   readonly prefix?: string | undefined
 }) => Effect.Effect<
-  MessageStorage.MessageStorage["Service"],
+  MessageStorage.MessageStorage,
   never,
   SqlClient.SqlClient | Snowflake.Generator | Crypto.Crypto
 > = (options) => Effect.flatMap(makeEncoded(options), MessageStorage.makeEncoded)

--- a/packages/effect/src/unstable/cluster/internal/entityManager.ts
+++ b/packages/effect/src/unstable/cluster/internal/entityManager.ts
@@ -107,8 +107,8 @@ export const make = Effect.fnUntraced(function*<
   entity: Entity<Type, Rpcs>,
   buildHandlers: Effect.Effect<Handlers, never, RX>,
   options: {
-    readonly sharding: Sharding["Service"]
-    readonly storage: MessageStorage.MessageStorage["Service"]
+    readonly sharding: Sharding
+    readonly storage: MessageStorage.MessageStorage
     readonly runnerAddress: RunnerAddress
     readonly residency: Residency
     readonly maxIdleTime?: Input | undefined

--- a/packages/effect/src/unstable/cluster/internal/entityReaper.ts
+++ b/packages/effect/src/unstable/cluster/internal/entityReaper.ts
@@ -8,50 +8,68 @@ import type { EntityId } from "../EntityId.ts"
 import type { EntityState } from "./entityManager.ts"
 import type { ResourceMap } from "./resourceMap.ts"
 
-/** @internal */
-export class EntityReaper extends Context.Service<EntityReaper>()("effect/cluster/EntityReaper", {
-  make: Effect.gen(function*() {
-    let currentResolution = 30_000
-    const registered: Array<{
-      readonly maxIdleTime: number
-      readonly servers: Map<EntityId, EntityState>
-      readonly entities: ResourceMap<EntityAddress, EntityState, any>
-    }> = []
-    const latch = yield* Latch.make()
+const EntityReaperTypeId = "~effect/cluster/EntityReaper"
+const EntityReaperMake = Effect.gen(function*() {
+  let currentResolution = 30_000
+  const registered: Array<{
+    readonly maxIdleTime: number
+    readonly servers: Map<EntityId, EntityState>
+    readonly entities: ResourceMap<EntityAddress, EntityState, any>
+  }> = []
+  const latch = yield* Latch.make()
 
-    const register = (options: {
-      readonly maxIdleTime: number
-      readonly servers: Map<EntityId, EntityState>
-      readonly entities: ResourceMap<EntityAddress, EntityState, any>
-    }) =>
-      Effect.suspend(() => {
-        currentResolution = Math.max(Math.min(currentResolution, options.maxIdleTime), 5000)
-        registered.push(options)
-        return latch.open
-      })
+  const register = (options: {
+    readonly maxIdleTime: number
+    readonly servers: Map<EntityId, EntityState>
+    readonly entities: ResourceMap<EntityAddress, EntityState, any>
+  }) =>
+    Effect.suspend(() => {
+      currentResolution = Math.max(Math.min(currentResolution, options.maxIdleTime), 5000)
+      registered.push(options)
+      return latch.open
+    })
 
-    const clock = yield* Clock
-    yield* Effect.gen(function*() {
-      while (true) {
-        yield* Effect.sleep(currentResolution)
-        const now = clock.currentTimeMillisUnsafe()
-        for (const { entities, maxIdleTime, servers } of registered) {
-          for (const state of servers.values()) {
-            const duration = now - state.lastActiveCheck
-            if (state.keepAliveEnabled || state.activeRequests.size > 0 || duration < maxIdleTime) {
-              continue
-            }
-            yield* Effect.forkChild(entities.removeIgnore(state.address))
+  const clock = yield* Clock
+  yield* Effect.gen(function*() {
+    while (true) {
+      yield* Effect.sleep(currentResolution)
+      const now = clock.currentTimeMillisUnsafe()
+      for (const { entities, maxIdleTime, servers } of registered) {
+        for (const state of servers.values()) {
+          const duration = now - state.lastActiveCheck
+          if (state.keepAliveEnabled || state.activeRequests.size > 0 || duration < maxIdleTime) {
+            continue
           }
+          yield* Effect.forkChild(entities.removeIgnore(state.address))
         }
       }
-    }).pipe(
-      latch.whenOpen,
-      Effect.forkScoped
-    )
+    }
+  }).pipe(
+    latch.whenOpen,
+    Effect.forkScoped
+  )
 
-    return { register } as const
-  })
-}) {
-  static readonly layer: Layer.Layer<EntityReaper> = Layer.effect(this)(this.make)
+  return {
+    [EntityReaperTypeId]: EntityReaperTypeId as typeof EntityReaperTypeId,
+    register
+  } as const
+})
+type EntityReaperShape = Effect.Success<typeof EntityReaperMake>
+
+/** @internal */
+export interface EntityReaper extends EntityReaperShape {
+  readonly [EntityReaperTypeId]: typeof EntityReaperTypeId
 }
+
+/**
+ * Service key for `EntityReaper` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const EntityReaper = (() => {
+  const service = Object.assign(Context.Service<EntityReaper>("effect/cluster/EntityReaper"), {
+    make: EntityReaperMake
+  })
+  return Object.assign(service, { layer: Layer.effect(service)(service.make) })
+})()

--- a/packages/effect/src/unstable/cluster/internal/shardLock.ts
+++ b/packages/effect/src/unstable/cluster/internal/shardLock.ts
@@ -2,7 +2,7 @@ import * as Duration from "../../../Duration.ts"
 import type { ShardingConfig } from "../ShardingConfig.ts"
 
 /** @internal */
-export const effectiveInterval = (config: ShardingConfig["Service"]): Duration.Duration =>
+export const effectiveInterval = (config: ShardingConfig): Duration.Duration =>
   Duration.min(
     Duration.fromInputUnsafe(config.shardLockRefreshInterval),
     Duration.divideUnsafe(Duration.fromInputUnsafe(config.shardLockExpiration), 3)

--- a/packages/effect/src/unstable/devtools/DevToolsClient.ts
+++ b/packages/effect/src/unstable/devtools/DevToolsClient.ts
@@ -27,6 +27,8 @@ import * as DevToolsSchema from "./DevToolsSchema.ts"
 const RequestSchema = Schema.toCodecJson(DevToolsSchema.Request)
 const ResponseSchema = Schema.toCodecJson(DevToolsSchema.Response)
 
+const DevToolsClientTypeId = "~effect/devtools/DevToolsClient"
+
 /**
  * Service for sending span and span-event telemetry to the Effect devtools
  * connection.
@@ -34,14 +36,21 @@ const ResponseSchema = Schema.toCodecJson(DevToolsSchema.Response)
  * @category services
  * @since 4.0.0
  */
-export class DevToolsClient extends Context.Service<
-  DevToolsClient,
-  {
-    readonly sendUnsafe: (
-      _: DevToolsSchema.Span | DevToolsSchema.SpanEvent
-    ) => void
-  }
->()("effect/devtools/DevToolsClient") {}
+export interface DevToolsClient {
+  readonly [DevToolsClientTypeId]: typeof DevToolsClientTypeId
+
+  readonly sendUnsafe: (
+    _: DevToolsSchema.Span | DevToolsSchema.SpanEvent
+  ) => void
+}
+
+/**
+ * Service key for `DevToolsClient` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const DevToolsClient = Context.Service<DevToolsClient>("effect/devtools/DevToolsClient")
 
 const makeEffect = Effect.gen(function*() {
   const socket = yield* Socket.Socket
@@ -99,6 +108,7 @@ const makeEffect = Effect.gen(function*() {
   )
 
   return DevToolsClient.of({
+    [DevToolsClientTypeId]: DevToolsClientTypeId as typeof DevToolsClientTypeId,
     sendUnsafe(request: DevToolsSchema.Span | DevToolsSchema.SpanEvent) {
       Queue.offerUnsafe(requests, request)
     }
@@ -139,7 +149,7 @@ const toMetricsSnapshot = (
  * @since 4.0.0
  */
 export const make: Effect.Effect<
-  DevToolsClient["Service"],
+  DevToolsClient,
   never,
   Scope.Scope | Socket.Socket
 > = makeEffect.pipe(

--- a/packages/effect/src/unstable/eventlog/EventJournal.ts
+++ b/packages/effect/src/unstable/eventlog/EventJournal.ts
@@ -28,6 +28,8 @@ import * as Semaphore from "../../Semaphore.ts"
 import * as SchemaBinary from "../encoding/SchemaBinary.ts"
 import type { StoreId } from "./EventLogMessage.ts"
 
+const EventJournalTypeId = "~effect/eventlog/EventJournal"
+
 /**
  * Context service for storing and replaying event journal entries.
  *
@@ -39,7 +41,9 @@ import type { StoreId } from "./EventLogMessage.ts"
  * @category services
  * @since 4.0.0
  */
-export class EventJournal extends Context.Service<EventJournal, {
+export interface EventJournal {
+  readonly [EventJournalTypeId]: typeof EventJournalTypeId
+
   /**
    * Read all the entries in the journal.
    */
@@ -82,6 +86,8 @@ export class EventJournal extends Context.Service<EventJournal, {
   /**
    * Run an effect with the uncommitted entries for a remote source.
    *
+   * **Details**
+   *
    * The effect is not run when there are no uncommitted entries, in which case
    * `Option.none()` is returned. Otherwise, its result is wrapped in
    * `Option.some()`.
@@ -110,7 +116,15 @@ export class EventJournal extends Context.Service<EventJournal, {
    * Run an effect with a lock on the journal.
    */
   readonly withLock: (storeId: StoreId) => <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
-}>()("effect/eventlog/EventJournal") {}
+}
+
+/**
+ * Service key for `EventJournal` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const EventJournal = Context.Service<EventJournal>("effect/eventlog/EventJournal")
 
 const TypeId = "effect/eventlog/EventJournal/EventJournalError" as const
 
@@ -366,7 +380,7 @@ export class RemoteEntry extends Schema.Class<RemoteEntry>("effect/eventlog/Even
  * @category constructors
  * @since 4.0.0
  */
-export const makeMemory: Effect.Effect<EventJournal["Service"]> = Effect.gen(function*() {
+export const makeMemory: Effect.Effect<EventJournal> = Effect.gen(function*() {
   const journal: Array<Entry> = []
   const byId = new Map<string, Entry>()
   const remotes = new Map<string, { sequence: number; missing: Array<Entry> }>()
@@ -391,6 +405,7 @@ export const makeMemory: Effect.Effect<EventJournal["Service"]> = Effect.gen(fun
   }
 
   return EventJournal.of({
+    [EventJournalTypeId]: EventJournalTypeId as typeof EventJournalTypeId,
     entries: Effect.sync(() => journal.slice()),
     write({ effect, event, payload, primaryKey }) {
       return Effect.acquireUseRelease(
@@ -530,7 +545,7 @@ export const layerMemory: Layer.Layer<EventJournal> = Layer.effect(EventJournal,
  */
 export const makeIndexedDb = (options?: {
   readonly database?: string
-}): Effect.Effect<EventJournal["Service"], EventJournalError, Scope> =>
+}): Effect.Effect<EventJournal, EventJournalError, Scope> =>
   Effect.gen(function*() {
     const database = options?.database ?? "effect_event_journal"
     const openRequest = indexedDB.open(database, 1)
@@ -557,6 +572,7 @@ export const makeIndexedDb = (options?: {
     const pubsub = yield* PubSub.unbounded<Entry>()
 
     return EventJournal.of({
+      [EventJournalTypeId]: EventJournalTypeId as typeof EventJournalTypeId,
       entries: idbReq("entries", () =>
         db.transaction("entries", "readonly")
           .objectStore("entries")

--- a/packages/effect/src/unstable/eventlog/EventLog.ts
+++ b/packages/effect/src/unstable/eventlog/EventLog.ts
@@ -36,6 +36,8 @@ import * as EventLogEncryption from "./EventLogEncryption.ts"
 import { StoreId } from "./EventLogMessage.ts"
 import type { EventLogRemote } from "./EventLogRemote.ts"
 
+const EventLogTypeId = "~effect/eventlog/EventLog"
+
 /**
  * Service for writing typed event-log events through registered handlers.
  *
@@ -48,7 +50,9 @@ import type { EventLogRemote } from "./EventLogRemote.ts"
  * @category services
  * @since 4.0.0
  */
-export class EventLog extends Context.Service<EventLog, {
+export interface EventLog {
+  readonly [EventLogTypeId]: typeof EventLogTypeId
+
   readonly write: <Groups extends EventGroup.Any, Tag extends Event.Tag<EventGroup.Events<Groups>>>(options: {
     readonly schema: EventLogSchema<Groups>
     readonly event: Tag
@@ -59,7 +63,17 @@ export class EventLog extends Context.Service<EventLog, {
   >
   readonly entries: Effect.Effect<ReadonlyArray<Entry>, EventJournalError>
   readonly destroy: Effect.Effect<void, EventJournalError>
-}>()("effect/eventlog/EventLog") {}
+}
+
+/**
+ * Event log service contract.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const EventLog = Context.Service<EventLog>("effect/eventlog/EventLog")
+
+const RegistryTypeId = "~effect/unstable/eventlog/EventLog/Registry"
 
 /**
  * Service that collects event handlers, compaction handlers, remote replicas,
@@ -68,7 +82,9 @@ export class EventLog extends Context.Service<EventLog, {
  * @category services
  * @since 4.0.0
  */
-export class Registry extends Context.Service<Registry, {
+export interface Registry {
+  readonly [RegistryTypeId]: typeof RegistryTypeId
+
   readonly registerHandlerUnsafe: (options: {
     readonly event: string
     readonly handler: Handlers.Item<any>
@@ -92,13 +108,21 @@ export class Registry extends Context.Service<Registry, {
     }) => Effect.Effect<void>
   }>
 
-  readonly registerRemote: (remote: EventLogRemote["Service"]) => Effect.Effect<void, never, Scope.Scope>
-  readonly handleRemote: (handler: (remote: EventLogRemote["Service"]) => Effect.Effect<void>) => Effect.Effect<void>
+  readonly registerRemote: (remote: EventLogRemote) => Effect.Effect<void, never, Scope.Scope>
+  readonly handleRemote: (handler: (remote: EventLogRemote) => Effect.Effect<void>) => Effect.Effect<void>
 
   readonly registerReactivity: (keys: Record<string, ReadonlyArray<string>>) => Effect.Effect<void, never, Scope.Scope>
 
   readonly reactivityKeys: Record<string, ReadonlyArray<string>>
-}>()("effect/unstable/eventlog/EventLog/Registry") {}
+}
+
+/**
+ * Service key for `Registry` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Registry = Context.Service<Registry>("effect/unstable/eventlog/EventLog/Registry")
 
 /**
  * Provides an in-memory `Registry` for event handlers, compactors, remote
@@ -120,11 +144,12 @@ export const layerRegistry = Layer.effect(
     }>()
 
     const remoteFiberMap = yield* FiberMap.make<RemoteId>()
-    const remotes = new Map<RemoteId, EventLogRemote["Service"]>()
-    let remoteHandler: (remote: EventLogRemote["Service"]) => Effect.Effect<void> = (_) => Effect.void
+    const remotes = new Map<RemoteId, EventLogRemote>()
+    let remoteHandler: (remote: EventLogRemote) => Effect.Effect<void> = (_) => Effect.void
 
     const reactivityKeys: Record<string, ReadonlyArray<string>> = {}
     return Registry.of({
+      [RegistryTypeId]: RegistryTypeId as typeof RegistryTypeId,
       registerHandlerUnsafe(options) {
         handlers.set(options.event, options.handler)
       },
@@ -169,6 +194,8 @@ export const layerRegistry = Layer.effect(
   })
 )
 
+const IdentityTypeId = "~effect/eventlog/EventLog/Identity"
+
 /**
  * Context service for an event-log identity containing a public key and redacted
  * private key material.
@@ -181,10 +208,20 @@ export const layerRegistry = Layer.effect(
  * @category services
  * @since 4.0.0
  */
-export class Identity extends Context.Service<Identity, {
+export interface Identity {
+  readonly [IdentityTypeId]: typeof IdentityTypeId
+
   readonly publicKey: string
   readonly privateKey: Redacted.Redacted<Uint8Array<ArrayBuffer>>
-}>()("effect/eventlog/EventLog/Identity") {}
+}
+
+/**
+ * Service key for `Identity` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Identity = Context.Service<Identity>("effect/eventlog/EventLog/Identity")
 
 /**
  * Type-level identifier used to brand `EventLogSchema` values.
@@ -455,9 +492,10 @@ const IdentityStringSchema = Schema.StringFromBase64Url.pipe(
  * @category constructors
  * @since 4.0.0
  */
-export const decodeIdentityString = (value: string): Identity["Service"] => {
+export const decodeIdentityString = (value: string): Identity => {
   const decoded = Schema.decodeUnknownSync(IdentityStringSchema)(value)
   return {
+    [IdentityTypeId]: IdentityTypeId as typeof IdentityTypeId,
     publicKey: decoded.publicKey,
     privateKey: Redacted.make(decoded.privateKey as Uint8Array<ArrayBuffer>)
   }
@@ -470,7 +508,7 @@ export const decodeIdentityString = (value: string): Identity["Service"] => {
  * @category constructors
  * @since 4.0.0
  */
-export const encodeIdentityString = (identity: Identity["Service"]): string =>
+export const encodeIdentityString = (identity: Identity): string =>
   Schema.encodeSync(IdentityStringSchema)({
     publicKey: identity.publicKey,
     privateKey: Redacted.value(identity.privateKey)
@@ -483,8 +521,8 @@ export const encodeIdentityString = (identity: Identity["Service"]): string =>
  * @category constructors
  * @since 4.0.0
  */
-export const makeIdentity: Effect.Effect<Identity["Service"], never, EventLogEncryption.EventLogEncryption> =
-  EventLogEncryption.EventLogEncryption.use((_) => _.generateIdentity)
+export const makeIdentity: Effect.Effect<Identity, never, EventLogEncryption.EventLogEncryption> = EventLogEncryption
+  .EventLogEncryption.use((_) => _.generateIdentity)
 
 const handlersProto = {
   [HandlersTypeId]: {
@@ -701,8 +739,8 @@ export const groupReactivity = <Events extends Event.Any>(
 export const makeReplayFromRemote = (options: {
   readonly handlers: ReadonlyMap<string, Handlers.Item<any>>
   readonly storeId: StoreId
-  readonly identity: Identity["Service"]
-  readonly reactivity: Reactivity["Service"]
+  readonly identity: Identity
+  readonly reactivity: Reactivity
   readonly reactivityKeys: Record<string, ReadonlyArray<string>>
   readonly logAnnotations: {
     readonly service: string
@@ -805,7 +843,7 @@ const make = Effect.gen(function*() {
     })
 
   const runRemote = Effect.fnUntraced(
-    function*(remote: EventLogRemote["Service"]) {
+    function*(remote: EventLogRemote) {
       const startSequence = yield* journal.nextRemoteSequence(remote.id)
 
       yield* Effect.gen(function*() {
@@ -951,7 +989,8 @@ const make = Effect.gen(function*() {
   yield* registry.handleRemote(runRemote)
 
   return EventLog.of({
-    write: eventLogWrite as EventLog["Service"]["write"],
+    [EventLogTypeId]: EventLogTypeId as typeof EventLogTypeId,
+    write: eventLogWrite as EventLog["write"],
     entries: journal.entries,
     destroy: journal.destroy
   })

--- a/packages/effect/src/unstable/eventlog/EventLogEncryption.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogEncryption.ts
@@ -61,6 +61,8 @@ const toArrayBuffer = (data: Uint8Array): ArrayBuffer => {
 
 const toBufferSource = (data: Uint8Array): ArrayBufferView<ArrayBuffer> => new Uint8Array(toArrayBuffer(data))
 
+const EventLogEncryptionTypeId = "~effect/eventlog/EventLogEncryption"
+
 /**
  * Service that provides identity generation, entry
  * encryption and decryption, and SHA-256 hashing for event-log replication.
@@ -73,9 +75,11 @@ const toBufferSource = (data: Uint8Array): ArrayBufferView<ArrayBuffer> => new U
  * @category services
  * @since 4.0.0
  */
-export class EventLogEncryption extends Context.Service<EventLogEncryption, {
+export interface EventLogEncryption {
+  readonly [EventLogEncryptionTypeId]: typeof EventLogEncryptionTypeId
+
   readonly encrypt: (
-    identity: Identity["Service"],
+    identity: Identity,
     entries: ReadonlyArray<Entry>
   ) => Effect.Effect<
     ReadonlyArray<{
@@ -84,13 +88,21 @@ export class EventLogEncryption extends Context.Service<EventLogEncryption, {
     }>
   >
   readonly decrypt: (
-    identity: Identity["Service"],
+    identity: Identity,
     entries: ReadonlyArray<EncryptedRemoteEntry>
   ) => Effect.Effect<Array<RemoteEntry>>
   readonly sha256String: (data: Uint8Array) => Effect.Effect<string>
   readonly sha256: (data: Uint8Array) => Effect.Effect<Uint8Array>
-  readonly generateIdentity: Effect.Effect<Identity["Service"]>
-}>()("effect/eventlog/EventLogEncryption") {}
+  readonly generateIdentity: Effect.Effect<Identity>
+}
+
+/**
+ * Service key for `EventLogEncryption` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const EventLogEncryption = Context.Service<EventLogEncryption>("effect/eventlog/EventLogEncryption")
 
 /**
  * Creates an `EventLogEncryption` service backed by the Web Crypto `SubtleCrypto`
@@ -99,11 +111,12 @@ export class EventLogEncryption extends Context.Service<EventLogEncryption, {
  * @category encryption
  * @since 4.0.0
  */
-export const makeEncryptionSubtle = (crypto: Crypto): Effect.Effect<EventLogEncryption["Service"]> =>
+export const makeEncryptionSubtle = (crypto: Crypto): Effect.Effect<EventLogEncryption> =>
   Effect.sync(() => {
     const getIdentityRootSecretMaterial = makeGetIdentityRootSecretMaterial(crypto)
 
     return EventLogEncryption.of({
+      [EventLogEncryptionTypeId]: EventLogEncryptionTypeId as typeof EventLogEncryptionTypeId,
       encrypt: Effect.fnUntraced(function*(identity, entries) {
         const data = yield* Effect.orDie(Entry.encodeArray(entries))
         const key = (yield* getIdentityRootSecretMaterial(identity)).encryptionKey
@@ -150,6 +163,7 @@ export const makeEncryptionSubtle = (crypto: Crypto): Effect.Effect<EventLogEncr
           }
         ),
       generateIdentity: Effect.sync(() => ({
+        ["~effect/eventlog/EventLog/Identity"]: "~effect/eventlog/EventLog/Identity" as const,
         publicKey: crypto.randomUUID(),
         privateKey: Redacted.make(crypto.getRandomValues(new Uint8Array(32)))
       }))

--- a/packages/effect/src/unstable/eventlog/EventLogRemote.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogRemote.ts
@@ -40,6 +40,8 @@ import {
 import { encodeSessionAuthPayload, signSessionAuthPayloadBytes } from "./EventLogSessionAuth.ts"
 import { makeGetIdentityRootSecretMaterial } from "./internal/identityRootSecretDerivation.ts"
 
+const EventLogRemoteTypeId = "~effect/eventlog/EventLogRemote"
+
 /**
  * Service that represents a remote event-log replica.
  *
@@ -56,22 +58,32 @@ import { makeGetIdentityRootSecretMaterial } from "./internal/identityRootSecret
  * @category services
  * @since 4.0.0
  */
-export class EventLogRemote extends Context.Service<EventLogRemote, {
+export interface EventLogRemote {
+  readonly [EventLogRemoteTypeId]: typeof EventLogRemoteTypeId
+
   readonly id: RemoteId
   readonly changes: (options: {
-    readonly identity: Identity["Service"]
+    readonly identity: Identity
     readonly storeId: StoreId
     readonly startSequence: number
   }) => Effect.Effect<Queue.Dequeue<RemoteEntry, EventLogRemoteError>, never, Scope.Scope>
   readonly write: (options: {
-    readonly identity: Identity["Service"]
+    readonly identity: Identity
     readonly storeId: StoreId
     readonly entries: ReadonlyArray<Entry>
   }) => Effect.Effect<void, EventLogRemoteError>
   readonly whenAuthenticated: <A, E, R>(
     effect: Effect.Effect<A, E, R>
   ) => Effect.Effect<A, E | EventLogRemoteError, R | Identity>
-}>()("effect/eventlog/EventLogRemote") {}
+}
+
+/**
+ * Service key for `EventLogRemote` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const EventLogRemote = Context.Service<EventLogRemote>("effect/eventlog/EventLogRemote")
 
 /**
  * Error raised by `EventLogRemote` operations, recording the failed method and
@@ -97,7 +109,7 @@ export class EventLogRemoteError extends Data.TaggedError("EventLogRemoteError")
 const getIdentityRootSecretMaterial = makeGetIdentityRootSecretMaterial(globalThis.crypto)
 
 const makeAuthenticate = Effect.fnUntraced(function*(options: {
-  readonly identity: Identity["Service"]
+  readonly identity: Identity
   readonly hello: HelloResponse
 }) {
   const rootSecretMaterial = yield* getIdentityRootSecretMaterial(options.identity)
@@ -120,6 +132,8 @@ const makeAuthenticate = Effect.fnUntraced(function*(options: {
   })
 })
 
+const EventLogRemoteClientTypeId = "~effect/unstable/eventlog/EventLogRemote/EventLogRemoteClient"
+
 /**
  * Service that provides a typed RPC client for the `EventLogRemoteRpcs` protocol.
  *
@@ -131,19 +145,35 @@ const makeAuthenticate = Effect.fnUntraced(function*(options: {
  * @category services
  * @since 4.0.0
  */
-export class EventLogRemoteClient extends Context.Service<
-  EventLogRemoteClient,
-  RpcClient.RpcClient<RpcGroup.Rpcs<typeof EventLogRemoteRpcs>, RpcClientError>
->()(
-  "effect/unstable/eventlog/EventLogRemote/EventLogRemoteClient"
-) {
-  static readonly layer = Layer.effect(
-    EventLogRemoteClient,
-    RpcClient.make(EventLogRemoteRpcs, {
-      disableTracing: true
-    })
-  )
+export interface EventLogRemoteClient
+  extends RpcClient.RpcClient<RpcGroup.Rpcs<typeof EventLogRemoteRpcs>, RpcClientError>
+{
+  readonly [EventLogRemoteClientTypeId]: typeof EventLogRemoteClientTypeId
 }
+
+/**
+ * Service key for `EventLogRemoteClient` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const EventLogRemoteClient = (() => {
+  const service = Context.Service<EventLogRemoteClient>("effect/unstable/eventlog/EventLogRemote/EventLogRemoteClient")
+  return Object.assign(service, {
+    layer: Layer.effect(
+      service,
+      RpcClient.make(EventLogRemoteRpcs, {
+        disableTracing: true
+      }).pipe(
+        Effect.map((client) =>
+          Object.assign(client, {
+            [EventLogRemoteClientTypeId]: EventLogRemoteClientTypeId as typeof EventLogRemoteClientTypeId
+          })
+        )
+      )
+    )
+  })
+})()
 
 /**
  * Creates an `EventLogRemote` from custom write encoding and change decoding
@@ -160,15 +190,15 @@ export class EventLogRemoteClient extends Context.Service<
  */
 export const makeWith = Effect.fnUntraced(function*({ encodeWrite, decodeChanges }: {
   readonly encodeWrite: (options: {
-    readonly identity: Identity["Service"]
+    readonly identity: Identity
     readonly entries: ReadonlyArray<Entry>
     readonly storeId: StoreId
   }) => Effect.Effect<Uint8Array<ArrayBuffer>, Schema.SchemaError>
   readonly decodeChanges: (
-    identity: Identity["Service"],
+    identity: Identity,
     data: Uint8Array<ArrayBuffer>
   ) => Effect.Effect<ReadonlyArray<RemoteEntry>, Schema.SchemaError>
-}): Effect.fn.Return<EventLogRemote["Service"], EventLogRemoteError, Scope.Scope | EventLogRemoteClient | Registry> {
+}): Effect.fn.Return<EventLogRemote, EventLogRemoteError, Scope.Scope | EventLogRemoteClient | Registry> {
   const client = yield* EventLogRemoteClient
   const registry = yield* Registry
 
@@ -176,8 +206,8 @@ export const makeWith = Effect.fnUntraced(function*({ encodeWrite, decodeChanges
     Effect.mapError((cause) => new EventLogRemoteError({ method: "hello", cause }))
   )
 
-  const identities = new Map<string, Identity["Service"]>()
-  const ensureIdentity = (identity: Identity["Service"]) => {
+  const identities = new Map<string, Identity>()
+  const ensureIdentity = (identity: Identity) => {
     let entry = identities.get(identity.publicKey)
     if (!entry) {
       entry = identity
@@ -201,7 +231,7 @@ export const makeWith = Effect.fnUntraced(function*({ encodeWrite, decodeChanges
     capacity: Number.MAX_SAFE_INTEGER
   })
 
-  const ensureAuthenticated = (identity: Identity["Service"]) => {
+  const ensureAuthenticated = (identity: Identity) => {
     ensureIdentity(identity)
     return Cache.get(authCache, identity.publicKey)
   }
@@ -209,7 +239,7 @@ export const makeWith = Effect.fnUntraced(function*({ encodeWrite, decodeChanges
   const retryForbidden = <A, E, R>(
     effect: Effect.Effect<A, E, R>,
     options: {
-      readonly identity: Identity["Service"]
+      readonly identity: Identity
     }
   ) =>
     Effect.retry(effect, {
@@ -229,6 +259,7 @@ export const makeWith = Effect.fnUntraced(function*({ encodeWrite, decodeChanges
   let chunkedIdCounter = 0
 
   const remote = EventLogRemote.of({
+    [EventLogRemoteTypeId]: EventLogRemoteTypeId as typeof EventLogRemoteTypeId,
     id: hello.remoteId,
     write: Effect.fnUntraced(
       function*(options) {
@@ -296,10 +327,9 @@ export const makeWith = Effect.fnUntraced(function*({ encodeWrite, decodeChanges
   return remote
 })
 
-/** @effect-diagnostics-next-line classSelfMismatch:off */
-class IdentityService extends Context.Service<Identity, Identity["Service"]>()(
-  "effect/eventlog/EventLog/Identity" satisfies Identity["key"]
-) {}
+const IdentityService = Context.Service<Identity>(
+  "effect/eventlog/EventLog/Identity" satisfies typeof Identity.key
+)
 
 /**
  * Creates an `EventLogRemote` that encrypts outgoing entries and decrypts
@@ -309,7 +339,7 @@ class IdentityService extends Context.Service<Identity, Identity["Service"]>()(
  * @since 4.0.0
  */
 export const makeEncrypted = Effect.gen(function*(): Effect.fn.Return<
-  EventLogRemote["Service"],
+  EventLogRemote,
   EventLogRemoteError,
   Scope.Scope | EventLogRemoteClient | EventLogEncryption | Registry
 > {
@@ -344,7 +374,7 @@ export const makeEncrypted = Effect.gen(function*(): Effect.fn.Return<
  * @since 4.0.0
  */
 export const makeUnencrypted: Effect.Effect<
-  EventLogRemote["Service"],
+  EventLogRemote,
   EventLogRemoteError,
   Scope.Scope | EventLogRemoteClient | Registry
 > = makeWith({

--- a/packages/effect/src/unstable/eventlog/EventLogServer.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogServer.ts
@@ -162,12 +162,16 @@ export const layerRpcHandlers = (options: {
           })
         }
 
-        const authenticatedIdentities = new Set(
-          Context.getOrUndefined(client.annotations, AuthenticatedIdentities)
+        const authenticatedIdentities = Object.assign(
+          new Set(
+            Context.getOrUndefined(client.annotations, AuthenticatedIdentities)
+          ),
+          { [AuthenticatedIdentitiesTypeId]: AuthenticatedIdentitiesTypeId as typeof AuthenticatedIdentitiesTypeId }
         )
         authenticatedIdentities.add(request.publicKey)
         void client
           .annotate(EventLog.Identity, {
+            ["~effect/eventlog/EventLog/Identity"]: "~effect/eventlog/EventLog/Identity" as const,
             publicKey: request.publicKey,
             privateKey: constEmptyPrivateKey
           })
@@ -251,15 +255,27 @@ export class ChunkedMessageState extends Context.Reference<
   defaultValue: () => new Map()
 }) {}
 
+const AuthenticatedIdentitiesTypeId = "~effect/eventlog/EventLogServer/AuthenticatedIdentities"
+
 /**
  * Annotation containing the public keys authenticated on an RPC connection.
  *
  * @category services
  * @since 4.0.0
  */
-export class AuthenticatedIdentities extends Context.Service<AuthenticatedIdentities, Set<string>>()(
+export interface AuthenticatedIdentities extends Set<string> {
+  readonly [AuthenticatedIdentitiesTypeId]: typeof AuthenticatedIdentitiesTypeId
+}
+
+/**
+ * Service key for `AuthenticatedIdentities` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const AuthenticatedIdentities = Context.Service<AuthenticatedIdentities>(
   "effect/eventlog/EventLogServer/AuthenticatedIdentities"
-) {}
+)
 
 class SessionAuthCacheKey extends Data.Class<{
   readonly publicKey: string

--- a/packages/effect/src/unstable/eventlog/EventLogServerEncrypted.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogServerEncrypted.ts
@@ -144,6 +144,8 @@ export class PersistedEntry extends Schema.Class<PersistedEntry>(
   }
 }
 
+const StorageTypeId = "~effect/eventlog/EventLogServer/Storage"
+
 /**
  * Defines the backing store service used by the encrypted event-log server.
  *
@@ -161,7 +163,9 @@ export class PersistedEntry extends Schema.Class<PersistedEntry>(
  * @category services
  * @since 4.0.0
  */
-export class Storage extends Context.Service<Storage, {
+export interface Storage {
+  readonly [StorageTypeId]: typeof StorageTypeId
+
   readonly getId: Effect.Effect<RemoteId>
   readonly getOrCreateSessionAuthBinding: (
     publicKey: string,
@@ -177,7 +181,15 @@ export class Storage extends Context.Service<Storage, {
     storeId: StoreId,
     startSequence: number
   ) => Stream.Stream<EncryptedRemoteEntry>
-}>()("effect/eventlog/EventLogServer/Storage") {}
+}
+
+/**
+ * Service key for `Storage` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Storage = Context.Service<Storage>("effect/eventlog/EventLogServer/Storage")
 
 /**
  * Creates an in-memory encrypted server `Storage`.
@@ -190,7 +202,7 @@ export class Storage extends Context.Service<Storage, {
  * @category constructors
  * @since 4.0.0
  */
-export const makeStorageMemory: Effect.Effect<Storage["Service"], never, Scope.Scope> = Effect.gen(function*() {
+export const makeStorageMemory: Effect.Effect<Storage, never, Scope.Scope> = Effect.gen(function*() {
   const knownIds = new Map<string, Map<string, number>>()
   const journals = new Map<string, Array<EncryptedRemoteEntry>>()
   const sessionAuthBindings = new Map<string, Uint8Array<ArrayBuffer>>()
@@ -219,6 +231,7 @@ export const makeStorageMemory: Effect.Effect<Storage["Service"], never, Scope.S
   })
 
   return Storage.of({
+    [StorageTypeId]: StorageTypeId as typeof StorageTypeId,
     getId: Effect.succeed(remoteId),
     getOrCreateSessionAuthBinding: (publicKey, signingPublicKey) =>
       Effect.sync(() => {

--- a/packages/effect/src/unstable/eventlog/EventLogServerUnencrypted.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogServerUnencrypted.ts
@@ -42,6 +42,8 @@ import {
 } from "./EventLogMessage.ts"
 import * as EventLogServer from "./EventLogServer.ts"
 
+const EventLogServerUnencryptedTypeId = "~effect/eventlog/EventLogServerUnencrypted"
+
 /**
  * Service that writes plaintext event-log entries directly to
  * unencrypted storage through registered event handlers.
@@ -54,7 +56,9 @@ import * as EventLogServer from "./EventLogServer.ts"
  * @category services
  * @since 4.0.0
  */
-export class EventLogServerUnencrypted extends Context.Service<EventLogServerUnencrypted, {
+export interface EventLogServerUnencrypted {
+  readonly [EventLogServerUnencryptedTypeId]: typeof EventLogServerUnencryptedTypeId
+
   readonly makeWrite: <Groups extends EventGroup.Any>(
     schema: EventLog.EventLogSchema<Groups>
   ) => <
@@ -68,7 +72,17 @@ export class EventLogServerUnencrypted extends Context.Service<EventLogServerUne
     Event.Success<Event>,
     EventLogServerStoreError | Event.Error<Event>
   >
-}>()("effect/eventlog/EventLogServerUnencrypted") {}
+}
+
+/**
+ * Service key for `EventLogServerUnencrypted` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const EventLogServerUnencrypted = Context.Service<EventLogServerUnencrypted>(
+  "effect/eventlog/EventLogServerUnencrypted"
+)
 
 /**
  * Creates a typed server-side write function for events in the supplied
@@ -261,6 +275,8 @@ export class EventLogServerAuthError extends Data.TaggedError("EventLogServerAut
   readonly message?: string | undefined
 }> {}
 
+const EventLogServerAuthorizationTypeId = "~effect/eventlog/EventLogServerUnencrypted/EventLogServerAuthorization"
+
 /**
  * Service that validates unencrypted event-log server
  * write access, read access, and identities.
@@ -273,7 +289,9 @@ export class EventLogServerAuthError extends Data.TaggedError("EventLogServerAut
  * @category services
  * @since 4.0.0
  */
-export class EventLogServerAuthorization extends Context.Service<EventLogServerAuthorization, {
+export interface EventLogServerAuthorization {
+  readonly [EventLogServerAuthorizationTypeId]: typeof EventLogServerAuthorizationTypeId
+
   readonly authorizeWrite: (options: {
     readonly publicKey: string
     readonly storeId: StoreId
@@ -286,7 +304,19 @@ export class EventLogServerAuthorization extends Context.Service<EventLogServerA
   readonly authorizeIdentity: (options: {
     readonly publicKey: string
   }) => Effect.Effect<void, EventLogServerAuthError>
-}>()("effect/eventlog/EventLogServerUnencrypted/EventLogServerAuthorization") {}
+}
+
+/**
+ * Service key for `EventLogServerAuthorization` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const EventLogServerAuthorization = Context.Service<EventLogServerAuthorization>(
+  "effect/eventlog/EventLogServerUnencrypted/EventLogServerAuthorization"
+)
+
+const StoreMappingTypeId = "~effect/eventlog/EventLogServerUnencrypted/StoreMapping"
 
 /**
  * Service that resolves client-requested store ids to server store ids and checks
@@ -300,7 +330,9 @@ export class EventLogServerAuthorization extends Context.Service<EventLogServerA
  * @category services
  * @since 4.0.0
  */
-export class StoreMapping extends Context.Service<StoreMapping, {
+export interface StoreMapping {
+  readonly [StoreMappingTypeId]: typeof StoreMappingTypeId
+
   readonly resolve: (
     options: {
       readonly publicKey: string
@@ -311,7 +343,15 @@ export class StoreMapping extends Context.Service<StoreMapping, {
     readonly publicKey: string
     readonly storeId: StoreId
   }) => Effect.Effect<boolean, EventLogServerStoreError>
-}>()("effect/eventlog/EventLogServerUnencrypted/StoreMapping") {}
+}
+
+/**
+ * Service key for `StoreMapping` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const StoreMapping = Context.Service<StoreMapping>("effect/eventlog/EventLogServerUnencrypted/StoreMapping")
 
 const toStoreNotFoundError = (options: {
   readonly storeId: StoreId
@@ -337,6 +377,7 @@ export const layerStoreMappingStatic = (options: {
   readonly storeId: StoreId
 }): Layer.Layer<StoreMapping> =>
   Layer.succeed(StoreMapping, {
+    [StoreMappingTypeId]: StoreMappingTypeId as typeof StoreMappingTypeId,
     resolve(request) {
       if (request.storeId === options.storeId) {
         return Effect.succeed(options.storeId)
@@ -345,6 +386,8 @@ export const layerStoreMappingStatic = (options: {
     },
     hasStore: ({ storeId }) => Effect.succeed(storeId === options.storeId)
   })
+
+const StorageTypeId = "~effect/eventlog/EventLogServerUnencrypted/Storage"
 
 /**
  * Defines the backing store service used by the unencrypted event-log server.
@@ -363,7 +406,9 @@ export const layerStoreMappingStatic = (options: {
  * @category services
  * @since 4.0.0
  */
-export class Storage extends Context.Service<Storage, {
+export interface Storage {
+  readonly [StorageTypeId]: typeof StorageTypeId
+
   readonly getId: Effect.Effect<RemoteId>
   readonly getOrCreateSessionAuthBinding: (
     publicKey: string,
@@ -380,9 +425,18 @@ export class Storage extends Context.Service<Storage, {
     readonly compactors: ReadonlyMap<string, RegisteredCompactor>
   }) => Stream.Stream<RemoteEntry>
   readonly withTransaction: <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
-}>()("effect/eventlog/EventLogServerUnencrypted/Storage") {}
+}
 
-const makeClientIdentity = (publicKey: string): EventLog.Identity["Service"] => ({
+/**
+ * Service key for `Storage` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Storage = Context.Service<Storage>("effect/eventlog/EventLogServerUnencrypted/Storage")
+
+const makeClientIdentity = (publicKey: string): EventLog.Identity => ({
+  ["~effect/eventlog/EventLog/Identity"]: "~effect/eventlog/EventLog/Identity" as const,
   publicKey,
   privateKey: constEmptyPrivateKey
 })
@@ -567,7 +621,7 @@ export const compactBacklog = Effect.fnUntraced(function*(options: {
  * @category constructors
  * @since 4.0.0
  */
-export const makeStorageMemory: Effect.Effect<Storage["Service"], never, Scope.Scope> = Effect.gen(function*() {
+export const makeStorageMemory: Effect.Effect<Storage, never, Scope.Scope> = Effect.gen(function*() {
   const knownIds = new Map<string, Map<string, number>>()
   const journals = new Map<string, Array<RemoteEntry>>()
   const sessionAuthBindings = new Map<string, Uint8Array<ArrayBuffer>>()
@@ -632,6 +686,7 @@ export const makeStorageMemory: Effect.Effect<Storage["Service"], never, Scope.S
   const transactionSemaphore = yield* Semaphore.make(1)
 
   return Storage.of({
+    [StorageTypeId]: StorageTypeId as typeof StorageTypeId,
     getId: Effect.succeed(remoteId),
     getOrCreateSessionAuthBinding: (publicKey, signingPublicKey) =>
       Effect.sync(() => {
@@ -708,6 +763,7 @@ export const make = Effect.gen(function*() {
   const handler = yield* makeServerHandler
 
   return EventLogServerUnencrypted.of({
+    [EventLogServerUnencryptedTypeId]: EventLogServerUnencryptedTypeId as typeof EventLogServerUnencryptedTypeId,
     makeWrite<Groups extends EventGroup.Any>(schema: EventLog.EventLogSchema<Groups>) {
       const events = new Map<string, Event.AnyWithProps>()
       for (const group of schema.groups as unknown as ReadonlyArray<EventGroup.EventGroup<Event.Any>>) {

--- a/packages/effect/src/unstable/eventlog/SqlEventJournal.ts
+++ b/packages/effect/src/unstable/eventlog/SqlEventJournal.ts
@@ -20,7 +20,7 @@ import * as SqlError from "../sql/SqlError.ts"
 import * as SqlSchema from "../sql/SqlSchema.ts"
 import * as EventJournal from "./EventJournal.ts"
 
-type WriteFromRemoteOptions = Parameters<EventJournal.EventJournal["Service"]["writeFromRemote"]>[0]
+type WriteFromRemoteOptions = Parameters<EventJournal.EventJournal["writeFromRemote"]>[0]
 
 /**
  * Creates an `EventJournal` backed by a SQL database.
@@ -37,7 +37,7 @@ export const make = (options?: {
   readonly entryTable?: string
   readonly remotesTable?: string
 }): Effect.Effect<
-  EventJournal.EventJournal["Service"],
+  EventJournal.EventJournal,
   SqlError.SqlError,
   SqlClient.SqlClient
 > =>
@@ -210,6 +210,7 @@ export const make = (options?: {
     })
 
     return EventJournal.EventJournal.of({
+      ["~effect/eventlog/EventJournal"]: "~effect/eventlog/EventJournal" as const,
       entries: sql`SELECT * FROM ${entryTableSql} ORDER BY timestamp ASC`.pipe(
         withTracerDisabled,
         Effect.flatMap(decodeEntryRows),

--- a/packages/effect/src/unstable/eventlog/SqlEventLogServerEncrypted.ts
+++ b/packages/effect/src/unstable/eventlog/SqlEventLogServerEncrypted.ts
@@ -40,7 +40,7 @@ export const makeStorage = (options?: {
   readonly remoteIdTable?: string
   readonly insertBatchSize?: number
 }): Effect.Effect<
-  EventLogServerEncrypted.Storage["Service"],
+  EventLogServerEncrypted.Storage,
   SqlError.SqlError,
   SqlClient.SqlClient | EventLogEncryption.EventLogEncryption | Scope.Scope
 > =>
@@ -184,6 +184,7 @@ export const makeStorage = (options?: {
       )
 
     return EventLogServerEncrypted.Storage.of({
+      ["~effect/eventlog/EventLogServer/Storage"]: "~effect/eventlog/EventLogServer/Storage" as const,
       getId: Effect.succeed(remoteId),
       getOrCreateSessionAuthBinding: Effect.fnUntraced(
         function*(publicKey, signingPublicKey) {

--- a/packages/effect/src/unstable/eventlog/SqlEventLogServerUnencrypted.ts
+++ b/packages/effect/src/unstable/eventlog/SqlEventLogServerUnencrypted.ts
@@ -40,7 +40,7 @@ export const makeStorage = (options?: {
   readonly remoteIdTable?: string
   readonly insertBatchSize?: number
 }): Effect.Effect<
-  EventLogServerUnencrypted.Storage["Service"],
+  EventLogServerUnencrypted.Storage,
   SqlError.SqlError,
   SqlClient.SqlClient | Scope.Scope
 > =>
@@ -324,6 +324,8 @@ export const makeStorage = (options?: {
       )
 
     return EventLogServerUnencrypted.Storage.of({
+      ["~effect/eventlog/EventLogServerUnencrypted/Storage"]:
+        "~effect/eventlog/EventLogServerUnencrypted/Storage" as const,
       getId: Effect.succeed(remoteId),
       getOrCreateSessionAuthBinding: Effect.fnUntraced(
         function*(publicKey, signingPublicKey) {

--- a/packages/effect/src/unstable/eventlog/internal/identityRootSecretDerivation.ts
+++ b/packages/effect/src/unstable/eventlog/internal/identityRootSecretDerivation.ts
@@ -131,9 +131,9 @@ export const deriveIdentityRootSecretMaterial = Effect.fnUntraced(function*(opti
 
 /** @internal */
 export const makeGetIdentityRootSecretMaterial = (crypto: Crypto) => {
-  const cache = new WeakMap<Identity["Service"], IdentityRootSecretMaterial>()
+  const cache = new WeakMap<Identity, IdentityRootSecretMaterial>()
 
-  return Effect.fnUntraced(function*(identity: Identity["Service"]) {
+  return Effect.fnUntraced(function*(identity: Identity) {
     const cached = cache.get(identity)
     if (cached !== undefined) {
       return cached

--- a/packages/effect/src/unstable/http/Etag.ts
+++ b/packages/effect/src/unstable/http/Etag.ts
@@ -68,16 +68,28 @@ export const toString = (self: Etag): string => {
   }
 }
 
+const GeneratorTypeId = "~effect/http/Etag/Generator"
+
 /**
  * Service for generating ETags from filesystem file information or Web `File`-like metadata.
  *
  * @category services
  * @since 4.0.0
  */
-export class Generator extends Context.Service<Generator, {
+export interface Generator {
+  readonly [GeneratorTypeId]: typeof GeneratorTypeId
+
   readonly fromFileInfo: (info: FileSystem.File.Info) => Effect.Effect<Etag>
   readonly fromFileWeb: (file: Body.HttpBody.FileLike) => Effect.Effect<Etag>
-}>()("effect/http/Etag/Generator") {}
+}
+
+/**
+ * Service key for `Generator` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Generator = Context.Service<Generator>("effect/http/Etag/Generator")
 
 const fromFileInfo = (info: FileSystem.File.Info) => {
   const mtime = Option.match(info.mtime, {
@@ -115,6 +127,7 @@ const fromFileWeb = (file: Body.HttpBody.FileLike) => {
 export const layer: Layer.Layer<Generator> = Layer.succeed(
   Generator
 )({
+  [GeneratorTypeId]: GeneratorTypeId as typeof GeneratorTypeId,
   fromFileInfo(info) {
     return Effect.sync(() => ({ _tag: "Strong", value: fromFileInfo(info) }))
   },
@@ -132,6 +145,7 @@ export const layer: Layer.Layer<Generator> = Layer.succeed(
 export const layerWeak: Layer.Layer<Generator> = Layer.succeed(
   Generator
 )({
+  [GeneratorTypeId]: GeneratorTypeId as typeof GeneratorTypeId,
   fromFileInfo(info) {
     return Effect.sync(() => ({ _tag: "Weak", value: fromFileInfo(info) }))
   },

--- a/packages/effect/src/unstable/http/HttpMiddleware.ts
+++ b/packages/effect/src/unstable/http/HttpMiddleware.ts
@@ -534,7 +534,7 @@ export const compression = (
     zstd: { level: levels.zstd }
   }
   const transform = (
-    compression: HttpPlatform["Service"]["compression"],
+    compression: HttpPlatform["compression"],
     acceptEncoding: string | undefined,
     response: HttpServerResponse
   ): Effect.Effect<HttpServerResponse> => {

--- a/packages/effect/src/unstable/http/HttpPlatform.ts
+++ b/packages/effect/src/unstable/http/HttpPlatform.ts
@@ -24,13 +24,17 @@ import type * as Body from "./HttpBody.ts"
 import * as Response from "./HttpServerResponse.ts"
 import * as internal from "./internal/compression.ts"
 
+const HttpPlatformTypeId = "~effect/http/HttpPlatform"
+
 /**
  * Service for platform-specific HTTP response helpers, including file-backed server responses.
  *
  * @category services
  * @since 4.0.0
  */
-export class HttpPlatform extends Context.Service<HttpPlatform, {
+export interface HttpPlatform {
+  readonly [HttpPlatformTypeId]: typeof HttpPlatformTypeId
+
   readonly platform: "deno" | "node" | "bun" | "web"
   readonly compression: Compression
   readonly fileResponse: (
@@ -49,7 +53,15 @@ export class HttpPlatform extends Context.Service<HttpPlatform, {
       readonly offset?: number | undefined
     }
   ) => Effect.Effect<Response.HttpServerResponse>
-}>()("effect/http/HttpPlatform") {}
+}
+
+/**
+ * Service key for `HttpPlatform` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const HttpPlatform = Context.Service<HttpPlatform>("effect/http/HttpPlatform")
 
 /**
  * Creates an `HttpPlatform` service from platform-specific file response constructors, using `FileSystem` and `Etag.Generator`.
@@ -81,7 +93,7 @@ export const make: (impl: {
     }
   ) => Response.HttpServerResponse
 }) => Effect.Effect<
-  HttpPlatform["Service"],
+  HttpPlatform,
   never,
   Etag.Generator | FileSystem.FileSystem
 > = Effect.fnUntraced(function*(impl) {
@@ -89,6 +101,7 @@ export const make: (impl: {
   const etagGen = yield* Etag.Generator
 
   return HttpPlatform.of({
+    [HttpPlatformTypeId]: HttpPlatformTypeId as typeof HttpPlatformTypeId,
     platform: impl.platform,
     compression: internal.wrapCompression(impl.compression),
     fileResponse: Effect.fnUntraced(function*(path, options) {

--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -216,6 +216,7 @@ export const make = Effect.gen(function*() {
         }
         context = Context.add(context, HttpServerRequest.ParsedSearchParams, result.searchParams)
         context = Context.add(context, RouteContext, {
+          [RouteContextTypeId]: RouteContextTypeId as typeof RouteContextTypeId,
           route,
           params: result.params
         })
@@ -267,6 +268,8 @@ export const RouterConfig = Context.Reference<Partial<FindMyWay.RouterConfig>>(
   { defaultValue: () => ({}) }
 )
 
+const RouteContextTypeId = "~effect/http/HttpRouter/RouteContext"
+
 /**
  * Service for the matched HTTP route in the current request.
  *
@@ -283,10 +286,20 @@ export const RouterConfig = Context.Reference<Partial<FindMyWay.RouterConfig>>(
  * @category services
  * @since 4.0.0
  */
-export class RouteContext extends Context.Service<RouteContext, {
+export interface RouteContext {
+  readonly [RouteContextTypeId]: typeof RouteContextTypeId
+
   readonly params: Readonly<Record<string, string | undefined>>
   readonly route: Route<unknown, unknown>
-}>()("effect/http/HttpRouter/RouteContext") {}
+}
+
+/**
+ * Service key for `RouteContext` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const RouteContext = Context.Service<RouteContext>("effect/http/HttpRouter/RouteContext")
 
 /**
  * Effect that returns the path parameters captured for the current matched route.

--- a/packages/effect/src/unstable/http/HttpServer.ts
+++ b/packages/effect/src/unstable/http/HttpServer.ts
@@ -25,6 +25,8 @@ import * as HttpPlatform from "./HttpPlatform.ts"
 import type { HttpServerRequest } from "./HttpServerRequest.ts"
 import type { HttpServerResponse } from "./HttpServerResponse.ts"
 
+const HttpServerTypeId = "~effect/http/HttpServer"
+
 /**
  * Service tag for an HTTP server runtime.
  *
@@ -36,7 +38,9 @@ import type { HttpServerResponse } from "./HttpServerResponse.ts"
  * @category services
  * @since 4.0.0
  */
-export class HttpServer extends Context.Service<HttpServer, {
+export interface HttpServer {
+  readonly [HttpServerTypeId]: typeof HttpServerTypeId
+
   readonly serve: {
     <E, R>(effect: Effect.Effect<HttpServerResponse, E, R>): Effect.Effect<
       void,
@@ -54,7 +58,15 @@ export class HttpServer extends Context.Service<HttpServer, {
   }
 
   readonly address: NetAddress.SocketAddress
-}>()("effect/http/HttpServer") {}
+}
+
+/**
+ * Service key for `HttpServer` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const HttpServer = Context.Service<HttpServer>("effect/http/HttpServer")
 
 /**
  * Constructs an `HttpServer` service from a serving implementation and listening
@@ -71,7 +83,7 @@ export const make = (
     ) => Effect.Effect<void, never, Scope.Scope>
     readonly address: NetAddress.SocketAddress
   }
-): HttpServer["Service"] => options
+): HttpServer => Object.assign(options, { [HttpServerTypeId]: HttpServerTypeId as typeof HttpServerTypeId })
 
 /**
  * Creates a layer that starts serving an HTTP response effect with the current

--- a/packages/effect/src/unstable/http/HttpServerResponse.ts
+++ b/packages/effect/src/unstable/http/HttpServerResponse.ts
@@ -468,7 +468,7 @@ export const stream = <E>(
 
 const HttpPlatformKey = Context.Service<
   HttpPlatform,
-  HttpPlatform["Service"]
+  HttpPlatform
 >("effect/http/HttpPlatform" satisfies typeof HttpPlatform.key)
 
 /**

--- a/packages/effect/src/unstable/observability/OtlpExporter.ts
+++ b/packages/effect/src/unstable/observability/OtlpExporter.ts
@@ -58,6 +58,8 @@ const policy = Schedule.forever.pipe(
   })
 )
 
+const FlusherTypeId = "~effect/observability/OtlpExporter/Flusher"
+
 /**
  * Registry of exporter flush operations, used to manually drain buffered
  * telemetry before the surrounding scope closes.
@@ -73,7 +75,9 @@ const policy = Schedule.forever.pipe(
  * @category services
  * @since 4.0.0
  */
-export class Flusher extends Context.Service<Flusher, {
+export interface Flusher {
+  readonly [FlusherTypeId]: typeof FlusherTypeId
+
   /**
    * Drains all registered exporters concurrently and cannot fail.
    *
@@ -99,9 +103,15 @@ export class Flusher extends Context.Service<Flusher, {
    */
   readonly flush: Effect.Effect<void>
   readonly register: (run: Effect.Effect<void>) => Effect.Effect<void, never, Scope.Scope>
-}>()(
-  "effect/observability/OtlpExporter/Flusher"
-) {}
+}
+
+/**
+ * Service key for `Flusher` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Flusher = Context.Service<Flusher>("effect/observability/OtlpExporter/Flusher")
 
 /**
  * Provides a `Flusher` backed by a fresh registry.
@@ -127,6 +137,7 @@ export class Flusher extends Context.Service<Flusher, {
 export const layerFlusher: Layer.Layer<Flusher> = Layer.sync(Flusher, () => {
   const registry = new Set<Effect.Effect<void>>()
   return {
+    [FlusherTypeId]: FlusherTypeId as typeof FlusherTypeId,
     flush: Effect.suspend(() => {
       if (registry.size === 0) {
         return Effect.void

--- a/packages/effect/src/unstable/observability/OtlpSerialization.ts
+++ b/packages/effect/src/unstable/observability/OtlpSerialization.ts
@@ -15,6 +15,8 @@ import type { LogsData } from "./OtlpLogger.ts"
 import type { MetricsData } from "./OtlpMetrics.ts"
 import type { TraceData } from "./OtlpTracer.ts"
 
+const OtlpSerializationTypeId = "~effect/observability/OtlpSerialization"
+
 /**
  * Service for serializing OTLP traces, metrics, and logs into HTTP request
  * bodies.
@@ -22,11 +24,21 @@ import type { TraceData } from "./OtlpTracer.ts"
  * @category services
  * @since 4.0.0
  */
-export class OtlpSerialization extends Context.Service<OtlpSerialization, {
+export interface OtlpSerialization {
+  readonly [OtlpSerializationTypeId]: typeof OtlpSerializationTypeId
+
   readonly traces: (data: TraceData) => HttpBody.HttpBody
   readonly metrics: (data: MetricsData) => HttpBody.HttpBody
   readonly logs: (data: LogsData) => HttpBody.HttpBody
-}>()("effect/observability/OtlpSerialization") {}
+}
+
+/**
+ * Service key for `OtlpSerialization` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const OtlpSerialization = Context.Service<OtlpSerialization>("effect/observability/OtlpSerialization")
 
 /**
  * Provides `OtlpSerialization` using OTLP/HTTP JSON bodies.
@@ -35,6 +47,7 @@ export class OtlpSerialization extends Context.Service<OtlpSerialization, {
  * @since 4.0.0
  */
 export const layerJson = Layer.succeed(OtlpSerialization, {
+  [OtlpSerializationTypeId]: OtlpSerializationTypeId as typeof OtlpSerializationTypeId,
   traces: (spans) => HttpBody.jsonUnsafe(spans),
   metrics: (metrics) => HttpBody.jsonUnsafe(metrics),
   logs: (logs) => HttpBody.jsonUnsafe(logs)
@@ -48,6 +61,7 @@ export const layerJson = Layer.succeed(OtlpSerialization, {
  * @since 4.0.0
  */
 export const layerProtobuf = Layer.succeed(OtlpSerialization, {
+  [OtlpSerializationTypeId]: OtlpSerializationTypeId as typeof OtlpSerializationTypeId,
   traces: (spans) =>
     HttpBody.uint8Array(
       otlpProtobuf.encodeTracesData(spans as any),

--- a/packages/effect/src/unstable/persistence/PersistedQueue.ts
+++ b/packages/effect/src/unstable/persistence/PersistedQueue.ts
@@ -109,23 +109,34 @@ export interface PersistedQueue<in out A, out R = never> {
   ) => Effect.Effect<XA, XE | PersistedQueueError, R | XR>
 }
 
+const PersistedQueueFactoryTypeId = "~effect/persistence/PersistedQueue/PersistedQueueFactory"
+
 /**
  * Service for constructing named `PersistedQueue` instances from schemas.
  *
  * @category services
  * @since 4.0.0
  */
-export class PersistedQueueFactory extends Context.Service<
-  PersistedQueueFactory,
-  {
-    readonly make: <S extends Schema.Constraint>(options: {
-      readonly name: string
-      readonly schema: S
-      readonly maxAttempts?: number | undefined
-      readonly retrySchedule?: Schedule.Schedule<any, number> | undefined
-    }) => Effect.Effect<PersistedQueue<S["Type"], S["EncodingServices"] | S["DecodingServices"]>>
-  }
->()("effect/persistence/PersistedQueue/PersistedQueueFactory") {}
+export interface PersistedQueueFactory {
+  readonly [PersistedQueueFactoryTypeId]: typeof PersistedQueueFactoryTypeId
+
+  readonly make: <S extends Schema.Constraint>(options: {
+    readonly name: string
+    readonly schema: S
+    readonly maxAttempts?: number | undefined
+    readonly retrySchedule?: Schedule.Schedule<any, number> | undefined
+  }) => Effect.Effect<PersistedQueue<S["Type"], S["EncodingServices"] | S["DecodingServices"]>>
+}
+
+/**
+ * Service key for `PersistedQueueFactory` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const PersistedQueueFactory = Context.Service<PersistedQueueFactory>(
+  "effect/persistence/PersistedQueue/PersistedQueueFactory"
+)
 
 /**
  * Accesses `PersistedQueueFactory` to create a named persisted queue for a
@@ -206,6 +217,7 @@ export const makeFactory = Effect.gen(function*() {
   const store = yield* PersistedQueueStore
 
   return PersistedQueueFactory.of({
+    [PersistedQueueFactoryTypeId]: PersistedQueueFactoryTypeId as typeof PersistedQueueFactoryTypeId,
     make<S extends Schema.Constraint>(options: {
       readonly name: string
       readonly schema: S
@@ -426,6 +438,8 @@ const deadLetterFromCause = (cause: Cause.Cause<unknown>): DeadLetter | undefine
   return undefined
 }
 
+const PersistedQueueStoreTypeId = "~effect/persistence/PersistedQueue/PersistedQueueStore"
+
 /**
  * Defines the low-level backing store service used by `PersistedQueue`.
  *
@@ -448,43 +462,52 @@ const deadLetterFromCause = (cause: Cause.Cause<unknown>): DeadLetter | undefine
  * @category services
  * @since 4.0.0
  */
-export class PersistedQueueStore extends Context.Service<
-  PersistedQueueStore,
-  {
-    readonly offer: (
-      options: {
-        readonly name: string
-        readonly id: string
-        readonly element: unknown
-        readonly isCustomId: boolean
-      }
-    ) => Effect.Effect<void, PersistedQueueError>
+export interface PersistedQueueStore {
+  readonly [PersistedQueueStoreTypeId]: typeof PersistedQueueStoreTypeId
 
-    readonly take: (options: {
+  readonly offer: (
+    options: {
       readonly name: string
-      readonly maxAttempts: number
-      readonly retryDelay: (attempts: number) => Effect.Effect<Duration.Duration>
-    }) => Effect.Effect<
-      {
-        readonly id: string
-        readonly attempts: number
-        readonly element: unknown
-      },
-      PersistedQueueError,
-      Scope.Scope
-    >
+      readonly id: string
+      readonly element: unknown
+      readonly isCustomId: boolean
+    }
+  ) => Effect.Effect<void, PersistedQueueError>
 
-    /**
-     * Removes completed elements older than `timeToLive`, together with their
-     * de-duplication records. Failed elements are removed only when
-     * `failedTimeToLive` is provided.
-     */
-    readonly cleanup: (options: {
-      readonly timeToLive: Duration.Duration
-      readonly failedTimeToLive: Duration.Duration | undefined
-    }) => Effect.Effect<void, PersistedQueueError>
-  }
->()("effect/persistence/PersistedQueue/PersistedQueueStore") {}
+  readonly take: (options: {
+    readonly name: string
+    readonly maxAttempts: number
+    readonly retryDelay: (attempts: number) => Effect.Effect<Duration.Duration>
+  }) => Effect.Effect<
+    {
+      readonly id: string
+      readonly attempts: number
+      readonly element: unknown
+    },
+    PersistedQueueError,
+    Scope.Scope
+  >
+
+  /**
+   * Removes completed elements older than `timeToLive`, together with their
+   * de-duplication records. Failed elements are removed only when
+   * `failedTimeToLive` is provided.
+   */
+  readonly cleanup: (options: {
+    readonly timeToLive: Duration.Duration
+    readonly failedTimeToLive: Duration.Duration | undefined
+  }) => Effect.Effect<void, PersistedQueueError>
+}
+
+/**
+ * Service key for `PersistedQueueStore` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const PersistedQueueStore = Context.Service<PersistedQueueStore>(
+  "effect/persistence/PersistedQueue/PersistedQueueStore"
+)
 
 /**
  * Provides an in-memory `PersistedQueueStore`.
@@ -533,6 +556,7 @@ export const layerStoreMemory: Layer.Layer<
     }
 
     return PersistedQueueStore.of({
+      [PersistedQueueStoreTypeId]: PersistedQueueStoreTypeId as typeof PersistedQueueStoreTypeId,
       offer: (options) =>
         Effect.sync(() => {
           const now = clock.currentTimeMillisUnsafe()
@@ -840,6 +864,7 @@ export const makeStoreRedis = Effect.fnUntraced(function*(
     })
 
   return PersistedQueueStore.of({
+    [PersistedQueueStoreTypeId]: PersistedQueueStoreTypeId as typeof PersistedQueueStoreTypeId,
     offer: ({ element, id, isCustomId, name }) => {
       const keys = keysFor(name)
       const payload = JSON.stringify({ id, element })
@@ -1290,7 +1315,7 @@ export const makeStoreSql: (
     readonly lockExpiration?: Duration.Input | undefined
   } | undefined
 ) => Effect.Effect<
-  PersistedQueueStore["Service"],
+  PersistedQueueStore,
   SqlError,
   SqlClient.SqlClient | Scope.Scope
 > = Effect.fnUntraced(function*(options) {
@@ -1678,6 +1703,7 @@ export const makeStoreSql: (
     )
 
   return PersistedQueueStore.of({
+    [PersistedQueueStoreTypeId]: PersistedQueueStoreTypeId as typeof PersistedQueueStoreTypeId,
     offer: ({ element, id, name }) =>
       Effect.catchCause(Effect.suspend(() => offer(id, name, JSON.stringify(element))), (cause) =>
         Effect.fail(

--- a/packages/effect/src/unstable/persistence/Persistence.ts
+++ b/packages/effect/src/unstable/persistence/Persistence.ts
@@ -48,6 +48,8 @@ export class PersistenceError extends Schema.Error<PersistenceError>(ErrorTypeId
   readonly [ErrorTypeId]: typeof ErrorTypeId = ErrorTypeId
 }
 
+const PersistenceTypeId = "~effect/persistence/Persistence"
+
 /**
  * Service for creating scoped stores of persisted `Persistable` request
  * results.
@@ -55,12 +57,22 @@ export class PersistenceError extends Schema.Error<PersistenceError>(ErrorTypeId
  * @category services
  * @since 4.0.0
  */
-export class Persistence extends Context.Service<Persistence, {
+export interface Persistence {
+  readonly [PersistenceTypeId]: typeof PersistenceTypeId
+
   readonly make: (options: {
     readonly storeId: string
     readonly timeToLive?: (exit: Exit.Exit<unknown, unknown>, key: Persistable.Any) => Duration.Input
   }) => Effect.Effect<PersistenceStore, never, Scope.Scope>
-}>()("effect/persistence/Persistence") {}
+}
+
+/**
+ * Service key for `Persistence` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Persistence = Context.Service<Persistence>("effect/persistence/Persistence")
 
 /**
  * Typed store for persisted `Exit` values keyed by `Persistable` requests.
@@ -96,15 +108,27 @@ export interface PersistenceStore {
   readonly clear: Effect.Effect<void, PersistenceError>
 }
 
+const BackingPersistenceTypeId = "~effect/persistence/BackingPersistence"
+
 /**
  * Service for creating raw backing stores for persistence store ids.
  *
  * @category services
  * @since 4.0.0
  */
-export class BackingPersistence extends Context.Service<BackingPersistence, {
+export interface BackingPersistence {
+  readonly [BackingPersistenceTypeId]: typeof BackingPersistenceTypeId
+
   readonly make: (storeId: string) => Effect.Effect<BackingPersistenceStore, never, Scope.Scope>
-}>()("effect/persistence/BackingPersistence") {}
+}
+
+/**
+ * Service key for `BackingPersistence` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const BackingPersistence = Context.Service<BackingPersistence>("effect/persistence/BackingPersistence")
 
 /**
  * Raw persistence backing store for JSON-compatible objects with optional
@@ -145,6 +169,7 @@ export const layer = Layer.effect(Persistence)(Effect.gen(function*() {
   const backing = yield* BackingPersistence
   const scope = yield* Effect.scope
   return Persistence.of({
+    [PersistenceTypeId]: PersistenceTypeId as typeof PersistenceTypeId,
     make: Effect.fnUntraced(function*(options) {
       const storage = yield* backing.make(options.storeId)
       const timeToLive = options.timeToLive ?? (() => Duration.infinity)
@@ -253,6 +278,7 @@ export const layerBackingMemory: Layer.Layer<BackingPersistence> = Layer.sync(Ba
       return store
     }
     return BackingPersistence.of({
+      [BackingPersistenceTypeId]: BackingPersistenceTypeId as typeof BackingPersistenceTypeId,
       make: (storeId) =>
         Effect.clockWith((clock) => {
           const map = getStore(storeId)
@@ -302,6 +328,7 @@ export const layerBackingSqlMultiTable: Layer.Layer<
 > = Layer.effect(BackingPersistence)(Effect.gen(function*() {
   const sql = (yield* SqlClient.SqlClient).withoutTransforms()
   return BackingPersistence.of({
+    [BackingPersistenceTypeId]: BackingPersistenceTypeId as typeof BackingPersistenceTypeId,
     make: Effect.fnUntraced(function*(storeId) {
       const clock = yield* Clock.Clock
       const tableName = `effect_persistence_${storeId}`
@@ -732,6 +759,7 @@ export const layerBackingSql: Layer.Layer<
   })
 
   return BackingPersistence.of({
+    [BackingPersistenceTypeId]: BackingPersistenceTypeId as typeof BackingPersistenceTypeId,
     make: Effect.fnUntraced(function*(storeId) {
       const clock = yield* Clock.Clock
 
@@ -884,6 +912,7 @@ export const layerBackingRedis: Layer.Layer<
   const setMany = redis.eval(setManyRedis)
 
   return BackingPersistence.of({
+    [BackingPersistenceTypeId]: BackingPersistenceTypeId as typeof BackingPersistenceTypeId,
     make: (prefix) =>
       Effect.sync(() => {
         const prefixed = (key: string) => `${prefix}:${key}`
@@ -1050,6 +1079,7 @@ export const layerBackingKvs: Layer.Layer<
   const backing = yield* KeyValueStore.KeyValueStore
   const clock = yield* Clock.Clock
   return BackingPersistence.of({
+    [BackingPersistenceTypeId]: BackingPersistenceTypeId as typeof BackingPersistenceTypeId,
     make: (storeId) =>
       Effect.sync(() => {
         const store = KeyValueStore.prefix(backing, storeId)

--- a/packages/effect/src/unstable/persistence/RateLimiter.ts
+++ b/packages/effect/src/unstable/persistence/RateLimiter.ts
@@ -594,6 +594,8 @@ export interface AdaptiveFeedbackOptions {
   readonly retryAfter: Duration.Duration | undefined
 }
 
+const RateLimiterStoreTypeId = "~effect/persistence/RateLimiter/RateLimiterStore"
+
 /**
  * Defines the low-level backing store for rate-limit state.
  *
@@ -605,64 +607,76 @@ export interface AdaptiveFeedbackOptions {
  * @category services
  * @since 4.0.0
  */
-export class RateLimiterStore extends Context.Service<
-  RateLimiterStore,
-  {
-    /**
-     * Returns the token count *after* taking the specified `tokens` and time to
-     * live for the `key`.
-     *
-     * If `limit` is provided, the number of taken tokens will be capped at the
-     * limit.
-     *
-     * In the case the limit is exceeded, the returned count will be greater
-     * than the limit, but the TTL will not be updated.
-     */
-    readonly fixedWindow: (options: {
-      readonly key: string
-      readonly tokens: number
-      readonly refillRate: Duration.Duration
-      readonly limit: number | undefined
-    }) => Effect.Effect<readonly [count: number, ttl: number], RateLimiterError>
+export interface RateLimiterStore {
+  readonly [RateLimiterStoreTypeId]: typeof RateLimiterStoreTypeId
 
-    /**
-     * Refills the bucket for `key`, attempts to consume `tokens`, and returns
-     * `[remaining, elapsedMillis]` from that single atomic operation.
-     *
-     * `remaining` is the token count after subtracting `tokens`. Fractional counts
-     * must retain their numeric precision. A negative count is only persisted
-     * when `allowOverflow` is true.
-     *
-     * `elapsedMillis` is the time since the current refill interval started, in
-     * milliseconds (fractions preserved), always at least `0` and less than
-     * `Duration.toMillis(refillRate)`. It is `0` when the bucket is at capacity
-     * after refilling and before consuming. Otherwise the boundary advances by
-     * whole refill intervals and the interval never restarts.
-     */
-    readonly tokenBucket: (options: {
-      readonly key: string
-      readonly tokens: number
-      readonly limit: number
-      readonly refillRate: Duration.Duration
-      readonly allowOverflow: boolean
-    }) => Effect.Effect<readonly [remaining: number, elapsedMillis: number], RateLimiterError>
+  /**
+   * Returns the token count *after* taking the specified `tokens` and time to
+   * live for the `key`.
+   *
+   * **Details**
+   *
+   * If `limit` is provided, the number of taken tokens will be capped at the
+   * limit.
+   * In the case the limit is exceeded, the returned count will be greater
+   * than the limit, but the TTL will not be updated.
+   */
+  readonly fixedWindow: (options: {
+    readonly key: string
+    readonly tokens: number
+    readonly refillRate: Duration.Duration
+    readonly limit: number | undefined
+  }) => Effect.Effect<readonly [count: number, ttl: number], RateLimiterError>
 
-    /**
-     * Consumes tokens from the adaptive rate-limit state for the `key`.
-     *
-     * When the store has no adaptive state for the `key`, implementations
-     * should return a zero delay with the inactive phase.
-     */
-    readonly adaptiveConsume: (
-      options: AdaptiveConsumeOptions
-    ) => Effect.Effect<AdaptiveConsumeResult, RateLimiterError>
+  /**
+   * Refills the bucket for `key`, attempts to consume `tokens`, and returns
+   * `[remaining, elapsedMillis]` from that single atomic operation.
+   *
+   * **Details**
+   *
+   * `remaining` is the token count after subtracting `tokens`. Fractional counts
+   * must retain their numeric precision. A negative count is only persisted
+   * when `allowOverflow` is true.
+   *
+   * `elapsedMillis` is the time since the current refill interval started, in
+   * milliseconds (fractions preserved), always at least `0` and less than
+   * `Duration.toMillis(refillRate)`. It is `0` when the bucket is at capacity
+   * after refilling and before consuming. Otherwise the boundary advances by
+   * whole refill intervals and the interval never restarts.
+   */
+  readonly tokenBucket: (options: {
+    readonly key: string
+    readonly tokens: number
+    readonly limit: number
+    readonly refillRate: Duration.Duration
+    readonly allowOverflow: boolean
+  }) => Effect.Effect<readonly [remaining: number, elapsedMillis: number], RateLimiterError>
 
-    /**
-     * Records response feedback for the adaptive rate-limit state.
-     */
-    readonly adaptiveFeedback: (options: AdaptiveFeedbackOptions) => Effect.Effect<void, RateLimiterError>
-  }
->()("effect/persistence/RateLimiter/RateLimiterStore") {}
+  /**
+   * Consumes tokens from the adaptive rate-limit state for the `key`.
+   *
+   * **Details**
+   *
+   * When the store has no adaptive state for the `key`, implementations
+   * should return a zero delay with the inactive phase.
+   */
+  readonly adaptiveConsume: (
+    options: AdaptiveConsumeOptions
+  ) => Effect.Effect<AdaptiveConsumeResult, RateLimiterError>
+
+  /**
+   * Records response feedback for the adaptive rate-limit state.
+   */
+  readonly adaptiveFeedback: (options: AdaptiveFeedbackOptions) => Effect.Effect<void, RateLimiterError>
+}
+
+/**
+ * Service key for `RateLimiterStore` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const RateLimiterStore = Context.Service<RateLimiterStore>("effect/persistence/RateLimiter/RateLimiterStore")
 
 const adaptiveStateTtlGraceMillis = 60_000
 const adaptiveStateMaxWindowMillis = 60 * 60 * 1_000
@@ -715,6 +729,7 @@ export const layerStoreMemory: Layer.Layer<
     now + learnedWindowMillis + adaptiveStateTtlGraceMillis
 
   return RateLimiterStore.of({
+    [RateLimiterStoreTypeId]: RateLimiterStoreTypeId as typeof RateLimiterStoreTypeId,
     fixedWindow: (options) =>
       Effect.clockWith((clock) =>
         Effect.sync(() => {
@@ -923,6 +938,7 @@ export const makeStoreRedis = Effect.fnUntraced(function*(
   const adaptiveFeedback = redis.eval(adaptiveFeedbackScript)
 
   return RateLimiterStore.of({
+    [RateLimiterStoreTypeId]: RateLimiterStoreTypeId as typeof RateLimiterStoreTypeId,
     fixedWindow(options) {
       const key = `${prefix}${options.key}`
       const refillMillis = Duration.toMillis(options.refillRate)

--- a/packages/effect/src/unstable/persistence/Redis.ts
+++ b/packages/effect/src/unstable/persistence/Redis.ts
@@ -33,6 +33,8 @@ export interface RedisMessage {
   readonly message: string
 }
 
+const RedisTypeId = "~effect/persistence/Redis"
+
 /**
  * Service for sending Redis commands, subscribing to channels, and evaluating
  * cached Lua scripts.
@@ -40,7 +42,9 @@ export interface RedisMessage {
  * @category services
  * @since 4.0.0
  */
-export class Redis extends Context.Service<Redis, {
+export interface Redis {
+  readonly [RedisTypeId]: typeof RedisTypeId
+
   readonly send: <A = unknown>(command: string, ...args: ReadonlyArray<string>) => Effect.Effect<A, RedisError>
 
   /**
@@ -60,7 +64,15 @@ export class Redis extends Context.Service<Redis, {
       readonly result: unknown
     }
   >(script: Script<Config>) => (...params: Config["params"]) => Effect.Effect<Config["result"], RedisError>
-}>()("effect/persistence/Redis") {}
+}
+
+/**
+ * Service key for `Redis` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Redis = Context.Service<Redis>("effect/persistence/Redis")
 
 /**
  * Creates a `Redis` service from raw command and subscription operations.
@@ -128,7 +140,8 @@ export const make = Effect.fnUntraced(function*(
     return queue
   })
 
-  return identity<Redis["Service"]>({
+  return identity<Redis>({
+    [RedisTypeId]: RedisTypeId as typeof RedisTypeId,
     send: options.send,
     subscribe,
     eval: eval_

--- a/packages/effect/src/unstable/process/ChildProcessSpawner.ts
+++ b/packages/effect/src/unstable/process/ChildProcessSpawner.ts
@@ -220,8 +220,8 @@ export const makeHandle = (params: Omit<ChildProcessHandle, typeof HandleTypeId>
  * @category constructors
  * @since 4.0.0
  */
-export const make = (spawn: ChildProcessSpawner["Service"]["spawn"]): ChildProcessSpawner["Service"] => {
-  const streamString: ChildProcessSpawner["Service"]["streamLines"] = (command, options) =>
+export const make = (spawn: ChildProcessSpawner["spawn"]): ChildProcessSpawner => {
+  const streamString: ChildProcessSpawner["streamLines"] = (command, options) =>
     spawn(command).pipe(
       Effect.map((handle) =>
         Stream.decodeText(
@@ -230,10 +230,11 @@ export const make = (spawn: ChildProcessSpawner["Service"]["spawn"]): ChildProce
       ),
       Stream.unwrap
     )
-  const streamLines: ChildProcessSpawner["Service"]["streamLines"] = (command, options) =>
+  const streamLines: ChildProcessSpawner["streamLines"] = (command, options) =>
     Stream.splitLines(streamString(command, options))
 
   return ChildProcessSpawner.of({
+    [ChildProcessSpawnerTypeId]: ChildProcessSpawnerTypeId as typeof ChildProcessSpawnerTypeId,
     spawn,
     exitCode: (command) => Effect.scoped(Effect.flatMap(spawn(command), (handle) => handle.exitCode)),
     streamString,
@@ -243,13 +244,17 @@ export const make = (spawn: ChildProcessSpawner["Service"]["spawn"]): ChildProce
   })
 }
 
+const ChildProcessSpawnerTypeId = "~effect/process/ChildProcessSpawner"
+
 /**
  * Service tag for child process spawning.
  *
  * @category services
  * @since 4.0.0
  */
-export class ChildProcessSpawner extends Context.Service<ChildProcessSpawner, {
+export interface ChildProcessSpawner {
+  readonly [ChildProcessSpawnerTypeId]: typeof ChildProcessSpawnerTypeId
+
   /**
    * Spawn a command and return a handle for interaction.
    */
@@ -293,4 +298,12 @@ export class ChildProcessSpawner extends Context.Service<ChildProcessSpawner, {
   string(command: Command, options?: {
     readonly includeStderr?: boolean | undefined
   }): Effect.Effect<string, PlatformError.PlatformError>
-}>()("effect/process/ChildProcessSpawner") {}
+}
+
+/**
+ * Service key for `ChildProcessSpawner` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const ChildProcessSpawner = Context.Service<ChildProcessSpawner>("effect/process/ChildProcessSpawner")

--- a/packages/effect/src/unstable/reactivity/Reactivity.ts
+++ b/packages/effect/src/unstable/reactivity/Reactivity.ts
@@ -21,6 +21,8 @@ import type { ReadonlyRecord } from "../../Record.ts"
 import * as Scope from "../../Scope.ts"
 import * as Stream from "../../Stream.ts"
 
+const ReactivityTypeId = "~effect/reactivity/Reactivity"
+
 /**
  * Service for key-based reactive invalidation.
  *
@@ -38,32 +40,39 @@ import * as Stream from "../../Stream.ts"
  * @category services
  * @since 4.0.0
  */
-export class Reactivity extends Context.Service<
-  Reactivity,
-  {
-    readonly invalidateUnsafe: (keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>) => void
-    readonly registerUnsafe: (
-      keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,
-      handler: () => void
-    ) => () => void
-    readonly invalidate: (
-      keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>
-    ) => Effect.Effect<void>
-    readonly mutation: <A, E, R>(
-      keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,
-      effect: Effect.Effect<A, E, R>
-    ) => Effect.Effect<A, E, R>
-    readonly query: <A, E, R>(
-      keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,
-      effect: Effect.Effect<A, E, R>
-    ) => Effect.Effect<Queue.Dequeue<A, E>, never, R | Scope.Scope>
-    readonly stream: <A, E, R>(
-      keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,
-      effect: Effect.Effect<A, E, R>
-    ) => Stream.Stream<A, E, Exclude<R, Scope.Scope>>
-    readonly withBatch: <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
-  }
->()("effect/reactivity/Reactivity") {}
+export interface Reactivity {
+  readonly [ReactivityTypeId]: typeof ReactivityTypeId
+
+  readonly invalidateUnsafe: (keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>) => void
+  readonly registerUnsafe: (
+    keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,
+    handler: () => void
+  ) => () => void
+  readonly invalidate: (
+    keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>
+  ) => Effect.Effect<void>
+  readonly mutation: <A, E, R>(
+    keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,
+    effect: Effect.Effect<A, E, R>
+  ) => Effect.Effect<A, E, R>
+  readonly query: <A, E, R>(
+    keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,
+    effect: Effect.Effect<A, E, R>
+  ) => Effect.Effect<Queue.Dequeue<A, E>, never, R | Scope.Scope>
+  readonly stream: <A, E, R>(
+    keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,
+    effect: Effect.Effect<A, E, R>
+  ) => Stream.Stream<A, E, Exclude<R, Scope.Scope>>
+  readonly withBatch: <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
+}
+
+/**
+ * Service key for `Reactivity` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Reactivity = Context.Service<Reactivity>("effect/reactivity/Reactivity")
 
 /**
  * Creates an in-memory `Reactivity` service.
@@ -186,7 +195,9 @@ export const make = Effect.sync(() => {
 
   const withBatch = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
     Effect.suspend(() => {
-      const pending = new Set<string | number>()
+      const pending = Object.assign(new Set<string | number>(), {
+        [PendingInvalidationTypeId]: PendingInvalidationTypeId as typeof PendingInvalidationTypeId
+      })
       return effect.pipe(
         Effect.provideService(PendingInvalidation, pending),
         Effect.onExit((_) =>
@@ -202,6 +213,7 @@ export const make = Effect.sync(() => {
     })
 
   return Reactivity.of({
+    [ReactivityTypeId]: ReactivityTypeId as typeof ReactivityTypeId,
     mutation,
     query,
     stream,
@@ -212,9 +224,19 @@ export const make = Effect.sync(() => {
   })
 })
 
-class PendingInvalidation extends Context.Service<PendingInvalidation, Set<string | number>>()(
-  "effect/reactivity/Reactivity/PendingInvalidation"
-) {}
+const PendingInvalidationTypeId = "~effect/reactivity/Reactivity/PendingInvalidation"
+
+interface PendingInvalidation extends Set<string | number> {
+  readonly [PendingInvalidationTypeId]: typeof PendingInvalidationTypeId
+}
+
+/**
+ * Service key for `PendingInvalidation` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+const PendingInvalidation = Context.Service<PendingInvalidation>("effect/reactivity/Reactivity/PendingInvalidation")
 
 /**
  * Wraps an effect so the supplied keys are invalidated after the effect succeeds.

--- a/packages/effect/src/unstable/rpc/RpcClient.ts
+++ b/packages/effect/src/unstable/rpc/RpcClient.ts
@@ -839,6 +839,8 @@ export const withHeaders: {
     Effect.updateService(effect, CurrentHeaders, Headers.merge(Headers.fromInput(headers)))
 )
 
+const ProtocolTypeId = "~effect/rpc/RpcClient/Protocol"
+
 /**
  * Defines the service interface for an RPC client transport, responsible for running the
  * receive loop and sending encoded client messages.
@@ -851,7 +853,9 @@ export const withHeaders: {
  * @category services
  * @since 4.0.0
  */
-export class Protocol extends Context.Service<Protocol, {
+export interface Protocol {
+  readonly [ProtocolTypeId]: typeof ProtocolTypeId
+
   readonly run: (
     clientId: number,
     f: (data: FromServerEncoded) => Effect.Effect<void>
@@ -868,14 +872,25 @@ export class Protocol extends Context.Service<Protocol, {
    * re-passed from the `RpcSerialization` backing this transport.
    */
   readonly codecFor: RpcSerialization.CodecFor
-}>()("effect/rpc/RpcClient/Protocol") {
-  /**
-   * Creates a client protocol service from the supplied RPC request runner.
-   *
-   * @since 4.0.0
-   */
-  static make = withRunClient
 }
+
+/**
+ * Service key for `Protocol` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Protocol = (() => {
+  const service = Context.Service<Protocol>("effect/rpc/RpcClient/Protocol")
+  return Object.assign(service, {
+    /**
+     * Creates a client protocol service from the supplied RPC request runner.
+     *
+     * @since 4.0.0
+     */
+    make: withRunClient
+  })
+})()
 
 /**
  * Creates a client `Protocol` that sends each RPC request through the supplied
@@ -885,7 +900,7 @@ export class Protocol extends Context.Service<Protocol, {
  * @since 4.0.0
  */
 export const makeProtocolHttp = (client: HttpClient.HttpClient): Effect.Effect<
-  Protocol["Service"],
+  Protocol,
   never,
   RpcSerialization.RpcSerialization
 > =>
@@ -1026,7 +1041,7 @@ export const makeProtocolSocket = (options?: {
    */
   readonly onTransientError?: ((error: RpcClientError) => Effect.Effect<void>) | undefined
 }): Effect.Effect<
-  Protocol["Service"],
+  Protocol,
   never,
   Scope.Scope | RpcSerialization.RpcSerialization | Socket.Socket
 > =>
@@ -1250,7 +1265,7 @@ export const makeProtocolWorker = (
     readonly timeToLive: Duration.Input
   }
 ): Effect.Effect<
-  Protocol["Service"],
+  Protocol,
   WorkerError,
   Scope.Scope | Worker.WorkerPlatform | Worker.Spawner
 > =>
@@ -1429,6 +1444,8 @@ export const layerProtocolWorker: (
   Worker.WorkerPlatform | Worker.Spawner
 > = flow(makeProtocolWorker, Layer.effect(Protocol))
 
+const ConnectionHooksTypeId = "~effect/rpc/RpcClient/ConnectionHooks"
+
 /**
  * Represents optional client protocol hooks that run when a transport connects
  * and disconnects.
@@ -1441,7 +1458,17 @@ export const layerProtocolWorker: (
  * @category services
  * @since 4.0.0
  */
-export class ConnectionHooks extends Context.Service<ConnectionHooks, {
+export interface ConnectionHooks {
+  readonly [ConnectionHooksTypeId]: typeof ConnectionHooksTypeId
+
   readonly onConnect: Effect.Effect<void>
   readonly onDisconnect: Effect.Effect<void>
-}>()("effect/rpc/RpcClient/ConnectionHooks") {}
+}
+
+/**
+ * Service key for `ConnectionHooks` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const ConnectionHooks = Context.Service<ConnectionHooks>("effect/rpc/RpcClient/ConnectionHooks")

--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -43,6 +43,8 @@ const codecForJson = Schema.toCodecJson as CodecFor
 let sharedTextDecoder: TextDecoder | undefined
 const decodeText = (bytes: Uint8Array): string => (sharedTextDecoder ??= new TextDecoder()).decode(bytes)
 
+const RpcSerializationTypeId = "~effect/rpc/RpcSerialization"
+
 /**
  * Service that describes how RPC protocol messages are encoded and decoded,
  * including the content type and whether the serialization format provides
@@ -56,12 +58,22 @@ const decodeText = (bytes: Uint8Array): string => (sharedTextDecoder ??= new Tex
  * @category services
  * @since 4.0.0
  */
-export class RpcSerialization extends Context.Service<RpcSerialization, {
+export interface RpcSerialization {
+  readonly [RpcSerializationTypeId]: typeof RpcSerializationTypeId
+
   makeUnsafe(): Parser
   readonly contentType: string
   readonly includesFraming: boolean
   readonly codecFor: CodecFor
-}>()("effect/rpc/RpcSerialization") {}
+}
+
+/**
+ * Service key for `RpcSerialization` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const RpcSerialization = Context.Service<RpcSerialization>("effect/rpc/RpcSerialization")
 
 /**
  * A stateful parser for an RPC serialization format, able to decode input
@@ -119,7 +131,8 @@ const isBufferSizeExceeded = (
  * @category serialization
  * @since 4.0.0
  */
-export const json: RpcSerialization["Service"] = RpcSerialization.of({
+export const json: RpcSerialization = RpcSerialization.of({
+  [RpcSerializationTypeId]: RpcSerializationTypeId as typeof RpcSerializationTypeId,
   contentType: "application/json",
   includesFraming: false,
   codecFor: codecForJson,
@@ -139,9 +152,10 @@ export const json: RpcSerialization["Service"] = RpcSerialization.of({
  * @category serialization
  * @since 4.0.0
  */
-export const makeNdjson = (options?: StreamOptions): RpcSerialization["Service"] => {
+export const makeNdjson = (options?: StreamOptions): RpcSerialization => {
   const maxBufferSize = options?.maxBufferSize ?? defaultMaxBufferSize
   return RpcSerialization.of({
+    [RpcSerializationTypeId]: RpcSerializationTypeId as typeof RpcSerializationTypeId,
     contentType: "application/ndjson",
     includesFraming: true,
     codecFor: codecForJson,
@@ -196,7 +210,7 @@ export const makeNdjson = (options?: StreamOptions): RpcSerialization["Service"]
  * @category serialization
  * @since 4.0.0
  */
-export const ndjson: RpcSerialization["Service"] = makeNdjson()
+export const ndjson: RpcSerialization = makeNdjson()
 
 /**
  * Creates a JSON-RPC 2.0 serialization for RPC protocol messages without
@@ -207,8 +221,9 @@ export const ndjson: RpcSerialization["Service"] = makeNdjson()
  */
 export const jsonRpc = (options?: {
   readonly contentType?: string | undefined
-}): RpcSerialization["Service"] =>
+}): RpcSerialization =>
   RpcSerialization.of({
+    [RpcSerializationTypeId]: RpcSerializationTypeId as typeof RpcSerializationTypeId,
     contentType: options?.contentType ?? "application/json",
     includesFraming: false,
     codecFor: codecForJson,
@@ -242,8 +257,9 @@ export const jsonRpc = (options?: {
 export const ndJsonRpc = (options?: {
   readonly contentType?: string | undefined
   readonly maxBufferSize?: number | "unbounded" | undefined
-}): RpcSerialization["Service"] =>
+}): RpcSerialization =>
   RpcSerialization.of({
+    [RpcSerializationTypeId]: RpcSerializationTypeId as typeof RpcSerializationTypeId,
     contentType: options?.contentType ?? "application/json-rpc",
     includesFraming: true,
     codecFor: codecForJson,
@@ -533,7 +549,7 @@ const schemaBinaryTextEncoder = new TextEncoder()
 const makeSchemaBinary = (options?: {
   readonly maxFrameSize?: number | "unbounded" | undefined
   readonly fingerprintPayloads?: boolean | undefined
-}): RpcSerialization["Service"] => {
+}): RpcSerialization => {
   const maxFrameSize = options?.maxFrameSize === "unbounded"
     ? undefined
     : options?.maxFrameSize ?? defaultSchemaBinaryMaxFrameSize
@@ -542,6 +558,7 @@ const makeSchemaBinary = (options?: {
     : SchemaBinary.toCodecDirect
   const envelopeOptions = { fingerprint: true } as const
   return RpcSerialization.of({
+    [RpcSerializationTypeId]: RpcSerializationTypeId as typeof RpcSerializationTypeId,
     contentType: "application/vnd.effect.rpc+schema-binary",
     includesFraming: true,
     codecFor,

--- a/packages/effect/src/unstable/rpc/RpcServer.ts
+++ b/packages/effect/src/unstable/rpc/RpcServer.ts
@@ -624,7 +624,7 @@ export const make: <Rpcs extends Rpc.Any>(
     readonly encodeExit: (u: unknown) => Effect.Effect<ResponseExitEncoded["exit"], Schema.SchemaError>
     readonly encodeDefect: (u: unknown) => Effect.Effect<unknown, Schema.SchemaError>
     readonly context: Context.Context<never>
-    readonly collector?: Transferable.Collector["Service"] | undefined
+    readonly collector?: Transferable.Collector | undefined
   }
 
   const schemasCache = new WeakMap<any, Schemas>()
@@ -887,6 +887,8 @@ export const layerHttp = <Rpcs extends Rpc.Any>(options: {
     )
   )
 
+const ProtocolTypeId = "~effect/rpc/RpcServer/Protocol"
+
 /**
  * Defines the service interface for an RPC server transport, responsible for receiving
  * encoded client messages, sending encoded responses, tracking clients, and
@@ -900,39 +902,55 @@ export const layerHttp = <Rpcs extends Rpc.Any>(options: {
  * @category services
  * @since 4.0.0
  */
-export class Protocol extends Context.Service<
-  Protocol,
-  {
-    readonly run: (
-      f: (clientId: number, data: FromClientEncoded) => Effect.Effect<void>
-    ) => Effect.Effect<never>
-    readonly disconnects: Queue.Dequeue<number>
-    readonly send: (
-      clientId: number,
-      response: FromServerEncoded,
-      transferables?: ReadonlyArray<globalThis.Transferable>
-    ) => Effect.Effect<void>
-    readonly end: (clientId: number) => Effect.Effect<void>
-    readonly clientIds: Effect.Effect<ReadonlySet<number>>
-    readonly initialMessage: Effect.Effect<Option.Option<unknown>>
-    readonly supportsAck: boolean
-    readonly supportsTransferables: boolean
-    readonly supportsSpanPropagation: boolean
-    readonly supportsNotifications: boolean
-    /**
-     * Builds the codec that fills the `unknown` holes of the protocol messages,
-     * re-passed from the `RpcSerialization` backing this transport.
-     */
-    readonly codecFor: RpcSerialization.CodecFor
-  }
->()("effect/rpc/RpcServer/Protocol") {
+export interface Protocol {
+  readonly [ProtocolTypeId]: typeof ProtocolTypeId
+
+  readonly run: (
+    f: (clientId: number, data: FromClientEncoded) => Effect.Effect<void>
+  ) => Effect.Effect<never>
+  readonly disconnects: Queue.Dequeue<number>
+  readonly send: (
+    clientId: number,
+    response: FromServerEncoded,
+    transferables?: ReadonlyArray<globalThis.Transferable>
+  ) => Effect.Effect<void>
+  readonly end: (clientId: number) => Effect.Effect<void>
+  readonly clientIds: Effect.Effect<ReadonlySet<number>>
+  readonly initialMessage: Effect.Effect<Option.Option<unknown>>
+  readonly supportsAck: boolean
+  readonly supportsTransferables: boolean
+  readonly supportsSpanPropagation: boolean
+  readonly supportsNotifications: boolean
   /**
-   * Creates a server protocol service from the supplied RPC implementation.
-   *
-   * @since 4.0.0
+   * Builds the codec that fills the `unknown` holes of the protocol messages,
+   * re-passed from the `RpcSerialization` backing this transport.
    */
-  static make = withRun<Protocol["Service"]>()
+  readonly codecFor: RpcSerialization.CodecFor
 }
+
+/**
+ * Service key for `Protocol` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Protocol = (() => {
+  const service = Context.Service<Protocol>("effect/rpc/RpcServer/Protocol")
+  return Object.assign(service, {
+    /**
+     * Creates a server protocol service from the supplied RPC implementation.
+     *
+     * @since 4.0.0
+     */
+    make: <E, R>(
+      f: (write: Parameters<Protocol["run"]>[0]) => Effect.Effect<Omit<Protocol, "run" | typeof ProtocolTypeId>, E, R>
+    ): Effect.Effect<Protocol, E, R> =>
+      Effect.map(
+        withRun<Omit<Protocol, typeof ProtocolTypeId>>()(f),
+        (protocol) => ({ ...protocol, [ProtocolTypeId]: ProtocolTypeId })
+      )
+  })
+})()
 
 /**
  * Creates a server `Protocol` backed by the current `SocketServer`, accepting
@@ -971,7 +989,7 @@ export const layerProtocolSocketServer: Layer.Layer<
  */
 export const makeProtocolWithHttpEffectWebsocket: Effect.Effect<
   {
-    readonly protocol: Protocol["Service"]
+    readonly protocol: Protocol
     readonly httpEffect: Effect.Effect<
       HttpServerResponse.HttpServerResponse,
       never,
@@ -1007,7 +1025,7 @@ export const makeProtocolWithHttpEffectWebsocket: Effect.Effect<
 export const makeProtocolWebsocket: (options: {
   readonly path: HttpRouter.PathInput
 }) => Effect.Effect<
-  Protocol["Service"],
+  Protocol,
   never,
   RpcSerialization.RpcSerialization | HttpRouter.HttpRouter
 > = Effect.fnUntraced(function*(options) {
@@ -1047,7 +1065,7 @@ export const makeProtocolWithHttpEffect: (
   } | undefined
 ) => Effect.Effect<
   {
-    readonly protocol: Protocol["Service"]
+    readonly protocol: Protocol
     readonly httpEffect: Effect.Effect<
       HttpServerResponse.HttpServerResponse,
       never,
@@ -1181,6 +1199,7 @@ export const makeProtocolWithHttpEffect: (
   const protocol = yield* Protocol.make((writeRequest_) => {
     writeRequest = writeRequest_
     return Effect.succeed({
+      [ProtocolTypeId]: ProtocolTypeId as typeof ProtocolTypeId,
       disconnects,
       send(clientId, response) {
         const client = clients.get(clientId)
@@ -1229,7 +1248,7 @@ export const makeProtocolHttp: (options: {
   readonly path: HttpRouter.PathInput
   readonly streamBufferSize?: number | "unbounded" | undefined
 }) => Effect.Effect<
-  Protocol["Service"],
+  Protocol,
   never,
   RpcSerialization.RpcSerialization | HttpRouter.HttpRouter
 > = Effect.fnUntraced(function*(options) {
@@ -1421,7 +1440,7 @@ export const layerProtocolStdio: Layer.Layer<
  * @since 4.0.0
  */
 export const makeProtocolWorkerRunner: Effect.Effect<
-  Protocol["Service"],
+  Protocol,
   WorkerError,
   WorkerRunner.WorkerRunnerPlatform | Scope.Scope
 > = Protocol.make(Effect.fnUntraced(function*(writeRequest) {
@@ -1493,7 +1512,7 @@ export const layerProtocolWorkerRunner: Layer.Layer<
 
 const makeSocketProtocol: Effect.Effect<
   {
-    readonly protocol: Protocol["Service"]
+    readonly protocol: Protocol
     readonly onSocket: (
       socket: Socket.Socket,
       headers?: ReadonlyArray<[string, string]>
@@ -1582,6 +1601,7 @@ const makeSocketProtocol: Effect.Effect<
   const protocol = yield* Protocol.make((writeRequest_) => {
     writeRequest = writeRequest_
     return Effect.succeed({
+      [ProtocolTypeId]: ProtocolTypeId as typeof ProtocolTypeId,
       disconnects,
       send: (clientId, response) => {
         const client = clients.get(clientId)

--- a/packages/effect/src/unstable/rpc/RpcWorker.ts
+++ b/packages/effect/src/unstable/rpc/RpcWorker.ts
@@ -53,8 +53,8 @@ export declare namespace InitialMessage {
   }
 }
 
-const ProtocolTag = Context.Service<Protocol, Protocol["Service"]>(
-  "effect/rpc/RpcServer/Protocol" satisfies Protocol["key"]
+const ProtocolTag = Context.Service<Protocol, Protocol>(
+  "effect/rpc/RpcServer/Protocol" satisfies typeof Protocol.key
 )
 
 /**

--- a/packages/effect/src/unstable/rpc/Utils.ts
+++ b/packages/effect/src/unstable/rpc/Utils.ts
@@ -69,8 +69,8 @@ export const withRunClient = <EX, RX>(
   f: (
     write: (clientId: number, response: FromServerEncoded) => Effect.Effect<void>,
     clientIds: ReadonlySet<number>
-  ) => Effect.Effect<Omit<Protocol["Service"], "run">, EX, RX>
-): Effect.Effect<Protocol["Service"], EX, RX> =>
+  ) => Effect.Effect<Omit<Protocol, "run" | "~effect/rpc/RpcClient/Protocol">, EX, RX>
+): Effect.Effect<Protocol, EX, RX> =>
   Effect.suspend(() => {
     const clientIds = new Set<number>()
     const clientBuffers = new Map<number, Array<[FromServerEncoded, Context.Context<never>]>>()
@@ -94,6 +94,7 @@ export const withRunClient = <EX, RX>(
         return write(clientId, data)
       }, clientIds),
       (a) => ({
+        ["~effect/rpc/RpcClient/Protocol"]: "~effect/rpc/RpcClient/Protocol" as const,
         ...a,
         run(clientId, f) {
           return Effect.gen(function*() {
@@ -115,6 +116,6 @@ export const withRunClient = <EX, RX>(
             })
           })
         }
-      } satisfies Protocol["Service"])
+      } satisfies Protocol)
     )
   })

--- a/packages/effect/src/unstable/socket/SocketServer.ts
+++ b/packages/effect/src/unstable/socket/SocketServer.ts
@@ -15,6 +15,8 @@ import type * as Effect from "../../Effect.ts"
 import type * as NetAddress from "../net/NetAddress.ts"
 import type * as Socket from "./Socket.ts"
 
+const SocketServerTypeId = "~@effect/platform/SocketServer"
+
 /**
  * Context service for a socket server, exposing its bound address and a run
  * loop that handles each accepted `Socket`.
@@ -22,12 +24,22 @@ import type * as Socket from "./Socket.ts"
  * @category services
  * @since 4.0.0
  */
-export class SocketServer extends Context.Service<SocketServer, {
+export interface SocketServer {
+  readonly [SocketServerTypeId]: typeof SocketServerTypeId
+
   readonly address: NetAddress.SocketAddress
   readonly run: <R, E, _>(
     handler: (socket: Socket.Socket) => Effect.Effect<_, E, R>
   ) => Effect.Effect<never, SocketServerError, R>
-}>()("@effect/platform/SocketServer") {}
+}
+
+/**
+ * Service key for `SocketServer` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const SocketServer = Context.Service<SocketServer>("@effect/platform/SocketServer")
 
 /**
  * Runtime type identifier attached to `SocketServerError` values.

--- a/packages/effect/src/unstable/sql/SqlConnection.ts
+++ b/packages/effect/src/unstable/sql/SqlConnection.ts
@@ -14,6 +14,7 @@ import type { Effect } from "../../Effect.ts"
 import type { Scope } from "../../Scope.ts"
 import type { Stream } from "../../Stream.ts"
 import type { SqlError } from "./SqlError.ts"
+const ConnectionTypeId = "~effect/sql/SqlConnection"
 
 /**
  * Low-level SQL driver connection capable of executing compiled SQL as
@@ -24,6 +25,8 @@ import type { SqlError } from "./SqlError.ts"
  * @since 4.0.0
  */
 export interface Connection {
+  readonly [ConnectionTypeId]: typeof ConnectionTypeId
+
   readonly execute: (
     sql: string,
     params: ReadonlyArray<unknown>,

--- a/packages/effect/src/unstable/workers/Transferable.ts
+++ b/packages/effect/src/unstable/workers/Transferable.ts
@@ -16,6 +16,8 @@ import { dual } from "../../Function.ts"
 import * as Schema from "../../Schema.ts"
 import * as SchemaGetter from "../../SchemaGetter.ts"
 
+const CollectorTypeId = "~effect/workers/Transferable/Collector"
+
 /**
  * Service for collecting `Transferable` objects while encoding worker messages
  * so they can be passed to `postMessage` transfer lists.
@@ -23,7 +25,9 @@ import * as SchemaGetter from "../../SchemaGetter.ts"
  * @category services
  * @since 4.0.0
  */
-export class Collector extends Context.Service<Collector, {
+export interface Collector {
+  readonly [CollectorTypeId]: typeof CollectorTypeId
+
   readonly addAll: (
     _: Iterable<globalThis.Transferable>
   ) => Effect.Effect<void>
@@ -32,7 +36,15 @@ export class Collector extends Context.Service<Collector, {
   readonly readUnsafe: () => Array<globalThis.Transferable>
   readonly clearUnsafe: () => Array<globalThis.Transferable>
   readonly clear: Effect.Effect<Array<globalThis.Transferable>>
-}>()("effect/workers/Transferable/Collector") {}
+}
+
+/**
+ * Service key for `Collector` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Collector = Context.Service<Collector>("effect/workers/Transferable/Collector")
 
 /**
  * Creates a mutable `Collector` service directly, exposing unsafe synchronous
@@ -41,7 +53,7 @@ export class Collector extends Context.Service<Collector, {
  * @category constructors
  * @since 4.0.0
  */
-export const makeCollectorUnsafe = (): Collector["Service"] => {
+export const makeCollectorUnsafe = (): Collector => {
   let tranferables: Array<globalThis.Transferable> = []
   const unsafeAddAll = (transfers: Iterable<globalThis.Transferable>): void => {
     tranferables.push(...transfers)
@@ -53,6 +65,7 @@ export const makeCollectorUnsafe = (): Collector["Service"] => {
     return prev
   }
   return Collector.of({
+    [CollectorTypeId]: CollectorTypeId as typeof CollectorTypeId,
     addAllUnsafe: unsafeAddAll,
     addAll: (transferables) => Effect.sync(() => unsafeAddAll(transferables)),
     readUnsafe: unsafeRead,
@@ -69,7 +82,7 @@ export const makeCollectorUnsafe = (): Collector["Service"] => {
  * @category constructors
  * @since 4.0.0
  */
-export const makeCollector: Effect.Effect<Collector["Service"]> = Effect.sync(makeCollectorUnsafe)
+export const makeCollector: Effect.Effect<Collector> = Effect.sync(makeCollectorUnsafe)
 
 /**
  * Adds transferables to the current `Collector` when one is present in the

--- a/packages/effect/src/unstable/workers/Worker.ts
+++ b/packages/effect/src/unstable/workers/Worker.ts
@@ -19,6 +19,8 @@ import * as Layer from "../../Layer.ts"
 import * as Scope from "../../Scope.ts"
 import { WorkerError, WorkerSendError } from "./WorkerError.ts"
 
+const WorkerPlatformTypeId = "~effect/workers/Worker/WorkerPlatform"
+
 /**
  * Service that spawns effect `Worker` instances for numeric worker ids using
  * the configured `Spawner`.
@@ -26,11 +28,21 @@ import { WorkerError, WorkerSendError } from "./WorkerError.ts"
  * @category services
  * @since 4.0.0
  */
-export class WorkerPlatform extends Context.Service<WorkerPlatform, {
+export interface WorkerPlatform {
+  readonly [WorkerPlatformTypeId]: typeof WorkerPlatformTypeId
+
   readonly spawn: <O = unknown, I = unknown>(
     id: number
   ) => Effect.Effect<Worker<O, I>, WorkerError, Spawner>
-}>()("effect/workers/Worker/WorkerPlatform") {}
+}
+
+/**
+ * Service key for `WorkerPlatform` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const WorkerPlatform = Context.Service<WorkerPlatform>("effect/workers/Worker/WorkerPlatform")
 
 /**
  * Effect-based worker abstraction that can send input messages and run a
@@ -158,8 +170,9 @@ export const makePlatform = <W>() =>
     readonly deferred: Deferred.Deferred<never, WorkerError>
     readonly scope: Scope.Scope
   }) => Effect.Effect<void>
-}): WorkerPlatform["Service"] =>
+}): WorkerPlatform =>
   WorkerPlatform.of({
+    [WorkerPlatformTypeId]: WorkerPlatformTypeId as typeof WorkerPlatformTypeId,
     spawn<O, I>(id: number) {
       return Effect.gen(function*() {
         const spawn = (yield* Spawner) as SpawnerFn<W>

--- a/packages/effect/src/unstable/workers/WorkerRunner.ts
+++ b/packages/effect/src/unstable/workers/WorkerRunner.ts
@@ -46,12 +46,26 @@ export interface WorkerRunner<O = unknown, I = unknown> {
  */
 export type PlatformMessage<I> = readonly [request: 0, I] | readonly [close: 1]
 
+const WorkerRunnerPlatformTypeId = "~effect/workers/WorkerRunner/WorkerRunnerPlatform"
+
 /**
  * Context service that starts a platform-specific `WorkerRunner`.
  *
  * @category services
  * @since 4.0.0
  */
-export class WorkerRunnerPlatform extends Context.Service<WorkerRunnerPlatform, {
+export interface WorkerRunnerPlatform {
+  readonly [WorkerRunnerPlatformTypeId]: typeof WorkerRunnerPlatformTypeId
+
   readonly start: <O = unknown, I = unknown>() => Effect.Effect<WorkerRunner<O, I>, WorkerError>
-}>()("effect/workers/WorkerRunner/WorkerRunnerPlatform") {}
+}
+
+/**
+ * Service key for `WorkerRunnerPlatform` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const WorkerRunnerPlatform = Context.Service<WorkerRunnerPlatform>(
+  "effect/workers/WorkerRunner/WorkerRunnerPlatform"
+)

--- a/packages/effect/src/unstable/workflow/Activity.ts
+++ b/packages/effect/src/unstable/workflow/Activity.ts
@@ -306,10 +306,10 @@ export const raceAll = <const Activities extends NonEmptyReadonlyArray<Any>>(
 // internal
 // -----------------------------------------------------------------------------
 
-const EngineTag = Context.Service<WorkflowEngine, WorkflowEngine["Service"]>(
+const EngineTag = Context.Service<WorkflowEngine, WorkflowEngine>(
   "effect/workflow/WorkflowEngine" satisfies typeof WorkflowEngine.key
 )
-const InstanceTag = Context.Service<WorkflowInstance, WorkflowInstance["Service"]>(
+const InstanceTag = Context.Service<WorkflowInstance, WorkflowInstance>(
   "effect/workflow/WorkflowEngine/WorkflowInstance" satisfies typeof WorkflowInstance.key
 )
 

--- a/packages/effect/src/unstable/workflow/DurableClock.ts
+++ b/packages/effect/src/unstable/workflow/DurableClock.ts
@@ -49,13 +49,13 @@ export const make = (options: {
   deferred: DurableDeferred.make(`DurableClock/${options.name}`)
 })
 
-const EngineTag = Context.Service<WorkflowEngine, WorkflowEngine["Service"]>(
+const EngineTag = Context.Service<WorkflowEngine, WorkflowEngine>(
   "effect/workflow/WorkflowEngine" satisfies typeof WorkflowEngine.key
 )
 
 const InstanceTag = Context.Service<
   WorkflowInstance,
-  WorkflowInstance["Service"]
+  WorkflowInstance
 >(
   "effect/workflow/WorkflowEngine/WorkflowInstance" satisfies typeof WorkflowInstance.key
 )

--- a/packages/effect/src/unstable/workflow/DurableDeferred.ts
+++ b/packages/effect/src/unstable/workflow/DurableDeferred.ts
@@ -113,13 +113,13 @@ export const make = <
   }
 }
 
-const EngineTag = Context.Service<WorkflowEngine, WorkflowEngine["Service"]>(
+const EngineTag = Context.Service<WorkflowEngine, WorkflowEngine>(
   "effect/workflow/WorkflowEngine" satisfies typeof WorkflowEngine.key
 )
 
 const InstanceTag = Context.Service<
   WorkflowInstance,
-  WorkflowInstance["Service"]
+  WorkflowInstance
 >(
   "effect/workflow/WorkflowEngine/WorkflowInstance" satisfies typeof WorkflowInstance.key
 )

--- a/packages/effect/src/unstable/workflow/Workflow.ts
+++ b/packages/effect/src/unstable/workflow/Workflow.ts
@@ -302,13 +302,13 @@ export type RequirementsHandler<Workflows extends Any> = Workflows extends Workf
     | _Error["EncodingServices"]
   : never
 
-const EngineTag = Context.Service<WorkflowEngine, WorkflowEngine["Service"]>(
+const EngineTag = Context.Service<WorkflowEngine, WorkflowEngine>(
   "effect/workflow/WorkflowEngine" satisfies typeof WorkflowEngine.key
 )
 
 const InstanceTag = Context.Service<
   WorkflowInstance,
-  WorkflowInstance["Service"]
+  WorkflowInstance
 >(
   "effect/workflow/WorkflowEngine/WorkflowInstance" satisfies typeof WorkflowInstance.key
 )
@@ -761,7 +761,7 @@ export const wrapActivityResult = <A, E, R>(
   })
 
 interface ActivityRegistration {
-  readonly instance: WorkflowInstance["Service"]
+  readonly instance: WorkflowInstance
   state: "pending" | "adopted" | "released"
 }
 
@@ -769,7 +769,7 @@ const PendingActivityRegistration = Context.Service<ActivityRegistration>(
   "effect/workflow/Workflow/PendingActivityRegistration"
 )
 
-const registerActivityUnsafe = (instance: WorkflowInstance["Service"]): ActivityRegistration => {
+const registerActivityUnsafe = (instance: WorkflowInstance): ActivityRegistration => {
   const state = instance.activityState
   if (state.count === 0) state.latch.closeUnsafe()
   state.count++
@@ -778,7 +778,7 @@ const registerActivityUnsafe = (instance: WorkflowInstance["Service"]): Activity
 
 const adoptActivityUnsafe = (
   context: Context.Context<never>,
-  instance: WorkflowInstance["Service"]
+  instance: WorkflowInstance
 ): ActivityRegistration | undefined => {
   const pending = Context.getOrUndefined(context, PendingActivityRegistration)
   if (!pending || pending.instance !== instance) {
@@ -815,7 +815,7 @@ const withPendingActivity = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Ef
     )
   })
 
-const waitForZero = Effect.fnUntraced(function*(instance: WorkflowInstance["Service"]) {
+const waitForZero = Effect.fnUntraced(function*(instance: WorkflowInstance) {
   const state = instance.activityState
   while (true) {
     if (state.count > 0) {
@@ -933,7 +933,7 @@ export const withCompensation: {
  * @category interruption
  * @since 4.0.0
  */
-export const suspend = (instance: WorkflowInstance["Service"]): Effect.Effect<never> =>
+export const suspend = (instance: WorkflowInstance): Effect.Effect<never> =>
   Effect.interruptible(Effect.callback<never>(() => {
     instance.suspended = true
     const fiber = Fiber.getCurrent()!

--- a/packages/effect/src/unstable/workflow/WorkflowEngine.ts
+++ b/packages/effect/src/unstable/workflow/WorkflowEngine.ts
@@ -26,6 +26,8 @@ import type { DurableClock } from "./DurableClock.ts"
 import type * as DurableDeferred from "./DurableDeferred.ts"
 import * as Workflow from "./Workflow.ts"
 
+const WorkflowEngineTypeId = "~effect/workflow/WorkflowEngine"
+
 /**
  * Service that represents workflow runtimes, responsible for registering and
  * executing workflows and coordinating activities, durable deferreds,
@@ -34,178 +36,187 @@ import * as Workflow from "./Workflow.ts"
  * @category services
  * @since 4.0.0
  */
-export class WorkflowEngine extends Context.Service<
-  WorkflowEngine,
-  {
-    /**
-     * Register a workflow with the engine.
-     */
-    readonly register: <
-      Name extends string,
-      Payload extends Workflow.AnyStructSchema,
-      Success extends Schema.Top,
-      Error extends Schema.Top,
-      R
-    >(
-      workflow: Workflow.Workflow<Name, Payload, Success, Error>,
-      execute: (
-        payload: Payload["Type"],
-        executionId: string
-      ) => Effect.Effect<Success["Type"], Error["Type"], R>
-    ) => Effect.Effect<
-      void,
-      never,
-      | Scope.Scope
-      | Exclude<
-        R,
-        | WorkflowEngine
-        | WorkflowInstance
-        | Workflow.Execution<Name>
-        | Scope.Scope
-      >
-      | Payload["DecodingServices"]
-      | Payload["EncodingServices"]
-      | Success["DecodingServices"]
-      | Success["EncodingServices"]
-      | Error["DecodingServices"]
-      | Error["EncodingServices"]
-    >
+export interface WorkflowEngine {
+  readonly [WorkflowEngineTypeId]: typeof WorkflowEngineTypeId
 
-    /**
-     * Execute a registered workflow.
-     */
-    readonly execute: <
-      Name extends string,
-      Payload extends Workflow.AnyStructSchema,
-      Success extends Schema.Top,
-      Error extends Schema.Top,
-      const Discard extends boolean = false
-    >(
-      workflow: Workflow.Workflow<Name, Payload, Success, Error>,
-      options: {
-        readonly executionId: string
-        readonly payload: Payload["Type"]
-        readonly discard?: Discard | undefined
-        readonly suspendedRetrySchedule?:
-          | Schedule.Schedule<any, unknown>
-          | undefined
-      }
-    ) => Effect.Effect<
-      Discard extends true ? string : Success["Type"],
-      Error["Type"],
-      | Payload["EncodingServices"]
-      | Success["DecodingServices"]
-      | Error["DecodingServices"]
-    >
-
-    /**
-     * Poll the current status of a registered workflow execution.
-     */
-    readonly poll: <
-      Name extends string,
-      Payload extends Workflow.AnyStructSchema,
-      Success extends Schema.Top,
-      Error extends Schema.Top
-    >(
-      workflow: Workflow.Workflow<Name, Payload, Success, Error>,
+  /**
+   * Register a workflow with the engine.
+   */
+  readonly register: <
+    Name extends string,
+    Payload extends Workflow.AnyStructSchema,
+    Success extends Schema.Top,
+    Error extends Schema.Top,
+    R
+  >(
+    workflow: Workflow.Workflow<Name, Payload, Success, Error>,
+    execute: (
+      payload: Payload["Type"],
       executionId: string
-    ) => Effect.Effect<
-      Option.Option<Workflow.Result<Success["Type"], Error["Type"]>>,
-      never,
-      Success["DecodingServices"] | Error["DecodingServices"]
-    >
-
-    /**
-     * Interrupt a registered workflow.
-     */
-    readonly interrupt: (
-      workflow: Workflow.Any,
-      executionId: string
-    ) => Effect.Effect<void>
-
-    /**
-     * Interrupts a registered workflow unsafely, potentially ignoring
-     * compensation finalizers and orphaning child workflows.
-     */
-    readonly interruptUnsafe: (
-      workflow: Workflow.Any,
-      executionId: string
-    ) => Effect.Effect<void>
-
-    /**
-     * Resume a registered workflow.
-     */
-    readonly resume: (
-      workflow: Workflow.Any,
-      executionId: string
-    ) => Effect.Effect<void>
-
-    /**
-     * Execute an activity from a workflow.
-     */
-    readonly activityExecute: <
-      Success extends Schema.Constraint,
-      Error extends Schema.Constraint,
-      R
-    >(
-      activity: Activity.Activity<Success, Error, R>,
-      attempt: number
-    ) => Effect.Effect<
-      Workflow.Result<Success["Type"], Error["Type"]>,
-      never,
-      | Success["DecodingServices"]
-      | Error["DecodingServices"]
-      | R
+    ) => Effect.Effect<Success["Type"], Error["Type"], R>
+  ) => Effect.Effect<
+    void,
+    never,
+    | Scope.Scope
+    | Exclude<
+      R,
+      | WorkflowEngine
       | WorkflowInstance
+      | Workflow.Execution<Name>
+      | Scope.Scope
     >
+    | Payload["DecodingServices"]
+    | Payload["EncodingServices"]
+    | Success["DecodingServices"]
+    | Success["EncodingServices"]
+    | Error["DecodingServices"]
+    | Error["EncodingServices"]
+  >
 
-    /**
-     * Try to retrieve the result of an DurableDeferred
-     */
-    readonly deferredResult: <
-      Success extends Schema.Constraint,
-      Error extends Schema.Constraint
-    >(
-      deferred: DurableDeferred.DurableDeferred<Success, Error>
-    ) => Effect.Effect<
-      Option.Option<Exit.Exit<Success["Type"], Error["Type"]>>,
-      never,
-      WorkflowInstance
-    >
+  /**
+   * Execute a registered workflow.
+   */
+  readonly execute: <
+    Name extends string,
+    Payload extends Workflow.AnyStructSchema,
+    Success extends Schema.Top,
+    Error extends Schema.Top,
+    const Discard extends boolean = false
+  >(
+    workflow: Workflow.Workflow<Name, Payload, Success, Error>,
+    options: {
+      readonly executionId: string
+      readonly payload: Payload["Type"]
+      readonly discard?: Discard | undefined
+      readonly suspendedRetrySchedule?:
+        | Schedule.Schedule<any, unknown>
+        | undefined
+    }
+  ) => Effect.Effect<
+    Discard extends true ? string : Success["Type"],
+    Error["Type"],
+    | Payload["EncodingServices"]
+    | Success["DecodingServices"]
+    | Error["DecodingServices"]
+  >
 
-    /**
-     * Set the result of a DurableDeferred, and then resume any waiting
-     * workflows.
-     */
-    readonly deferredDone: <
-      Success extends Schema.Constraint,
-      Error extends Schema.Constraint
-    >(
-      deferred: DurableDeferred.DurableDeferred<Success, Error>,
-      options: {
-        readonly workflowName: string
-        readonly executionId: string
-        readonly deferredName: string
-        readonly exit: Exit.Exit<Success["Type"], Error["Type"]>
-      }
-    ) => Effect.Effect<
-      void,
-      never,
-      Success["EncodingServices"] | Error["EncodingServices"]
-    >
+  /**
+   * Poll the current status of a registered workflow execution.
+   */
+  readonly poll: <
+    Name extends string,
+    Payload extends Workflow.AnyStructSchema,
+    Success extends Schema.Top,
+    Error extends Schema.Top
+  >(
+    workflow: Workflow.Workflow<Name, Payload, Success, Error>,
+    executionId: string
+  ) => Effect.Effect<
+    Option.Option<Workflow.Result<Success["Type"], Error["Type"]>>,
+    never,
+    Success["DecodingServices"] | Error["DecodingServices"]
+  >
 
-    /**
-     * Schedule a wake up for a DurableClock
-     */
-    readonly scheduleClock: (
-      workflow: Workflow.Any,
-      options: {
-        readonly executionId: string
-        readonly clock: DurableClock
-      }
-    ) => Effect.Effect<void>
-  }
->()("effect/workflow/WorkflowEngine") {}
+  /**
+   * Interrupt a registered workflow.
+   */
+  readonly interrupt: (
+    workflow: Workflow.Any,
+    executionId: string
+  ) => Effect.Effect<void>
+
+  /**
+   * Interrupts a registered workflow unsafely, potentially ignoring
+   * compensation finalizers and orphaning child workflows.
+   */
+  readonly interruptUnsafe: (
+    workflow: Workflow.Any,
+    executionId: string
+  ) => Effect.Effect<void>
+
+  /**
+   * Resume a registered workflow.
+   */
+  readonly resume: (
+    workflow: Workflow.Any,
+    executionId: string
+  ) => Effect.Effect<void>
+
+  /**
+   * Execute an activity from a workflow.
+   */
+  readonly activityExecute: <
+    Success extends Schema.Constraint,
+    Error extends Schema.Constraint,
+    R
+  >(
+    activity: Activity.Activity<Success, Error, R>,
+    attempt: number
+  ) => Effect.Effect<
+    Workflow.Result<Success["Type"], Error["Type"]>,
+    never,
+    | Success["DecodingServices"]
+    | Error["DecodingServices"]
+    | R
+    | WorkflowInstance
+  >
+
+  /**
+   * Try to retrieve the result of an DurableDeferred
+   */
+  readonly deferredResult: <
+    Success extends Schema.Constraint,
+    Error extends Schema.Constraint
+  >(
+    deferred: DurableDeferred.DurableDeferred<Success, Error>
+  ) => Effect.Effect<
+    Option.Option<Exit.Exit<Success["Type"], Error["Type"]>>,
+    never,
+    WorkflowInstance
+  >
+
+  /**
+   * Set the result of a DurableDeferred, and then resume any waiting
+   * workflows.
+   */
+  readonly deferredDone: <
+    Success extends Schema.Constraint,
+    Error extends Schema.Constraint
+  >(
+    deferred: DurableDeferred.DurableDeferred<Success, Error>,
+    options: {
+      readonly workflowName: string
+      readonly executionId: string
+      readonly deferredName: string
+      readonly exit: Exit.Exit<Success["Type"], Error["Type"]>
+    }
+  ) => Effect.Effect<
+    void,
+    never,
+    Success["EncodingServices"] | Error["EncodingServices"]
+  >
+
+  /**
+   * Schedule a wake up for a DurableClock
+   */
+  readonly scheduleClock: (
+    workflow: Workflow.Any,
+    options: {
+      readonly executionId: string
+      readonly clock: DurableClock
+    }
+  ) => Effect.Effect<void>
+}
+
+/**
+ * Service key for `WorkflowEngine` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const WorkflowEngine = Context.Service<WorkflowEngine>("effect/workflow/WorkflowEngine")
+
+const WorkflowInstanceTypeId = "~effect/workflow/WorkflowEngine/WorkflowInstance"
 
 /**
  * Service that contains workflow runtime state for one execution.
@@ -225,79 +236,93 @@ export class WorkflowEngine extends Context.Service<
  * @category services
  * @since 4.0.0
  */
-export class WorkflowInstance extends Context.Service<
-  WorkflowInstance,
-  {
-    /**
-     * The workflow execution ID.
-     */
-    readonly executionId: string
+export interface WorkflowInstance {
+  readonly [WorkflowInstanceTypeId]: typeof WorkflowInstanceTypeId
 
-    /**
-     * The workflow definition.
-     */
-    readonly workflow: Workflow.Any
+  /**
+   * The workflow execution ID.
+   */
+  readonly executionId: string
 
-    /**
-     * A scope that represents the lifetime of the workflow.
-     *
-     * It is only closed when the workflow is completed.
-     */
-    readonly scope: Scope.Closeable
+  /**
+   * The workflow definition.
+   */
+  readonly workflow: Workflow.Any
 
-    /**
-     * Whether the workflow has requested to be suspended.
-     */
-    suspended: boolean
+  /**
+   * A scope that represents the lifetime of the workflow.
+   *
+   * **Details**
+   *
+   * It is only closed when the workflow is completed.
+   */
+  readonly scope: Scope.Closeable
 
-    /**
-     * Whether the workflow has requested to be interrupted.
-     */
-    interrupted: boolean
+  /**
+   * Whether the workflow has requested to be suspended.
+   */
+  suspended: boolean
 
-    /**
-     * Whether the current workflow run has been abandoned for replay. When
-     * `true`, callbacks registered with `Workflow.addFinalizer` are skipped as
-     * the owner-local scope closes.
-     */
-    abandoned: boolean
+  /**
+   * Whether the workflow has requested to be interrupted.
+   */
+  interrupted: boolean
 
-    /**
-     * When SuspendOnFailure is triggered, the cause of the failure is stored
-     * here.
-     */
-    cause: Cause.Cause<never> | undefined
+  /**
+   * Whether the current workflow run has been abandoned for replay. When
+   * `true`, callbacks registered with `Workflow.addFinalizer` are skipped as
+   * the owner-local scope closes.
+   */
+  abandoned: boolean
 
-    /** Deferred names this run parked on; their completions preempt the run. */
-    readonly awaitedDeferreds: Set<string>
+  /**
+   * When SuspendOnFailure is triggered, the cause of the failure is stored
+   * here.
+   */
+  cause: Cause.Cause<never> | undefined
 
-    readonly activityState: {
-      count: number
-      readonly latch: Latch.Latch
-    }
-  }
->()("effect/workflow/WorkflowEngine/WorkflowInstance") {
-  static initial(
-    workflow: Workflow.Any,
-    executionId: string,
-    scope = Scope.makeUnsafe()
-  ): WorkflowInstance["Service"] {
-    return WorkflowInstance.of({
-      executionId,
-      workflow,
-      scope,
-      suspended: false,
-      interrupted: false,
-      abandoned: false,
-      cause: undefined,
-      awaitedDeferreds: new Set(),
-      activityState: {
-        count: 0,
-        latch: Latch.makeUnsafe()
-      }
-    })
+  /** Deferred names this run parked on; their completions preempt the run. */
+  readonly awaitedDeferreds: Set<string>
+
+  readonly activityState: {
+    count: number
+    readonly latch: Latch.Latch
   }
 }
+
+/**
+ * Service key for `WorkflowInstance` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const WorkflowInstance = (() => {
+  const service = Context.Service<WorkflowInstance>("effect/workflow/WorkflowEngine/WorkflowInstance")
+  const withInitial = Object.assign(service, {
+    initial(
+      workflow: Workflow.Any,
+      executionId: string,
+      scope = Scope.makeUnsafe()
+    ): WorkflowInstance {
+      return service.of({
+        [WorkflowInstanceTypeId]: WorkflowInstanceTypeId as typeof WorkflowInstanceTypeId,
+        executionId,
+        workflow,
+        scope,
+        suspended: false,
+        interrupted: false,
+        abandoned: false,
+        cause: undefined,
+        awaitedDeferreds: new Set(),
+        activityState: {
+          count: 0,
+          latch: Latch.makeUnsafe()
+        }
+      })
+    }
+  })
+  return Object.defineProperty(withInitial, "initial", { enumerable: false })
+})()
 
 /**
  * In-process deferred state for live workflow executions.
@@ -314,7 +339,7 @@ export interface DeferredState {
 
   /** Tracks and provides a run, retaining pending results across suspension. */
   readonly trackRun: <A, E, R>(
-    instance: WorkflowInstance["Service"],
+    instance: WorkflowInstance,
     effect: Effect.Effect<A, E, R>
   ) => Effect.Effect<A, E, Exclude<R, WorkflowInstance>>
 
@@ -335,7 +360,7 @@ export interface DeferredState {
 export const makeDeferredState = (): DeferredState => {
   const pending = new Map<string, Map<string, Exit.Exit<unknown, unknown>>>()
   const running = new Map<string, {
-    readonly instance: WorkflowInstance["Service"]
+    readonly instance: WorkflowInstance
     readonly fiber: Fiber.Fiber<unknown, unknown>
   }>()
   return {
@@ -402,7 +427,7 @@ export interface Encoded {
       readonly executionId: string
       readonly payload: object
       readonly discard: Discard
-      readonly parent?: WorkflowInstance["Service"] | undefined
+      readonly parent?: WorkflowInstance | undefined
     }
   ) => Effect.Effect<
     Discard extends true ? void : Workflow.Result<unknown, unknown>
@@ -469,8 +494,9 @@ export interface Encoded {
  * @category constructors
  * @since 4.0.0
  */
-export const makeUnsafe = (options: Encoded): WorkflowEngine["Service"] =>
+export const makeUnsafe = (options: Encoded): WorkflowEngine =>
   WorkflowEngine.of({
+    [WorkflowEngineTypeId]: WorkflowEngineTypeId as typeof WorkflowEngineTypeId,
     register: Effect.fnUntraced(function*(workflow, execute) {
       const services = yield* Effect.context<WorkflowEngine>()
       yield* options.register(workflow, (payload, executionId) =>
@@ -688,7 +714,7 @@ export const layerMemory: Layer.Layer<WorkflowEngine> = Layer.effect(WorkflowEng
         executionId: string
       ) => Effect.Effect<unknown, unknown, WorkflowInstance | WorkflowEngine>
       readonly parent: string | undefined
-      instance: WorkflowInstance["Service"]
+      instance: WorkflowInstance
       interrupted: boolean
       resumeRequested: boolean
       fiber: Fiber.Fiber<Workflow.Result<unknown, unknown>> | undefined

--- a/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
+++ b/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
@@ -1194,7 +1194,7 @@ describe.concurrent("ClusterWorkflowEngine", () => {
 })
 
 const makeTestWorkflowEngine = (
-  config?: Partial<ShardingConfig.ShardingConfig["Service"]>,
+  config?: Partial<ShardingConfig.ShardingConfig>,
   storageLayer = MessageStorage.layerMemory
 ) =>
   ClusterWorkflowEngine.layer.pipe(

--- a/packages/effect/test/cluster/RunnerServer.test.ts
+++ b/packages/effect/test/cluster/RunnerServer.test.ts
@@ -38,6 +38,7 @@ const layerProtocol = (codecFor: RpcSerialization.CodecFor) =>
   Layer.effect(RpcServer.Protocol)(
     Effect.map(Queue.unbounded<number>(), (disconnects) =>
       RpcServer.Protocol.of({
+        ["~effect/rpc/RpcServer/Protocol"]: "~effect/rpc/RpcServer/Protocol" as const,
         run: () => Effect.never,
         disconnects,
         send: () => Effect.void,

--- a/packages/effect/test/cluster/Runners.test.ts
+++ b/packages/effect/test/cluster/Runners.test.ts
@@ -61,6 +61,7 @@ const layerServerProtocol = (codecFor: RpcSerialization.CodecFor) =>
   Layer.effect(RpcServer.Protocol)(
     Effect.map(Queue.unbounded<number>(), (disconnects) =>
       RpcServer.Protocol.of({
+        "~effect/rpc/RpcServer/Protocol": "~effect/rpc/RpcServer/Protocol",
         run: () => Effect.never,
         disconnects,
         send: () => Effect.void,
@@ -144,6 +145,7 @@ describe.concurrent("HttpRunner", () => {
         Effect.provide(RpcSerialization.layerJson),
         Effect.provideService(Socket.WebSocketConstructor, constructor),
         Effect.provideService(RpcClient.ConnectionHooks, {
+          ["~effect/rpc/RpcClient/ConnectionHooks"]: "~effect/rpc/RpcClient/ConnectionHooks" as const,
           onConnect: Deferred.succeed(connected, undefined).pipe(Effect.asVoid),
           onDisconnect: Effect.void
         }),
@@ -285,11 +287,13 @@ describe.concurrent("Runners.makeRpc", () => {
     codecFor: RpcSerialization.CodecFor = Schema.toCodecJson as RpcSerialization.CodecFor
   ) =>
     Layer.succeed(Runners.RpcClientProtocol)({
+      ["~effect/cluster/Runners/RpcClientProtocol"]: "~effect/cluster/Runners/RpcClientProtocol" as const,
       codecFor,
       make: () =>
         Effect.sync(() => {
           let write!: (data: FromServerEncoded) => Effect.Effect<void>
           return RpcClient.Protocol.of({
+            "~effect/rpc/RpcClient/Protocol": "~effect/rpc/RpcClient/Protocol",
             run(_clientId, f) {
               write = f
               return Effect.never

--- a/packages/effect/test/cluster/Sharding.test.ts
+++ b/packages/effect/test/cluster/Sharding.test.ts
@@ -143,7 +143,7 @@ describe.concurrent("Sharding", () => {
 
   it.effect("interrupts aren't sent for durable messages on shutdown", () =>
     Effect.gen(function*() {
-      let driver!: MessageStorage.MemoryDriver["Service"]
+      let driver!: MessageStorage.MemoryDriver
       yield* Effect.gen(function*() {
         driver = yield* MessageStorage.MemoryDriver
         const makeClient = yield* TestEntity.client
@@ -208,7 +208,7 @@ describe.concurrent("Sharding", () => {
 
             const shardAcquired = Latch.makeUnsafe()
             const armed = Latch.makeUnsafe()
-            let driver!: MessageStorage.MemoryDriver["Service"]
+            let driver!: MessageStorage.MemoryDriver
             const runFiber = yield* Effect.gen(function*() {
               driver = yield* MessageStorage.MemoryDriver
               const sharding = yield* Sharding.Sharding
@@ -288,7 +288,7 @@ describe.concurrent("Sharding", () => {
 
           const shardAcquired = Latch.makeUnsafe()
           const armed = Latch.makeUnsafe()
-          let driver!: MessageStorage.MemoryDriver["Service"]
+          let driver!: MessageStorage.MemoryDriver
           const runFiber = yield* Effect.gen(function*() {
             driver = yield* MessageStorage.MemoryDriver
             const sharding = yield* Sharding.Sharding
@@ -385,7 +385,7 @@ describe.concurrent("Sharding", () => {
 
       const shardAcquired = Latch.makeUnsafe()
       const armed = Latch.makeUnsafe()
-      let driver!: MessageStorage.MemoryDriver["Service"]
+      let driver!: MessageStorage.MemoryDriver
       const runFiber = yield* Effect.gen(function*() {
         driver = yield* MessageStorage.MemoryDriver
         const sharding = yield* Sharding.Sharding
@@ -1109,7 +1109,7 @@ const ActiveTeardownCallerLayer = ActiveTeardownCaller.toLayer(Effect.gen(functi
   return { Arm: () => Effect.void }
 }))
 
-const journalInterrupts = (driver: MessageStorage.MemoryDriver["Service"]) =>
+const journalInterrupts = (driver: MessageStorage.MemoryDriver) =>
   driver.journal.filter((envelope) => envelope._tag === "Interrupt").length
 
 const waitForIdleReap = Effect.fnUntraced(function*(
@@ -1197,7 +1197,7 @@ describe.concurrent("Sharding active teardowns", () => {
 
   it.effect("treats node shutdown interrupts as transient via isShutdown", () =>
     Effect.gen(function*() {
-      let driver!: MessageStorage.MemoryDriver["Service"]
+      let driver!: MessageStorage.MemoryDriver
       let state!: TestEntityState["Service"]
       yield* Effect.gen(function*() {
         driver = yield* MessageStorage.MemoryDriver
@@ -1932,6 +1932,7 @@ const makeFailoverStorageState = (
 
 const makeFailoverStorage = (state: FailoverStorageState, clock: Clock.Clock) =>
   RunnerStorage.RunnerStorage.of({
+    ["~effect/cluster/RunnerStorage"]: "~effect/cluster/RunnerStorage" as const,
     getRunners: Effect.sync(() => {
       if (!state.runner) return []
       if (!state.assignSelf) return [[state.runner, false], [otherRunner, true]]
@@ -2000,7 +2001,7 @@ const RegistrationContextHandlers = Effect.map(
   (value) => RegistrationContextEntity.of({ Read: () => Effect.succeed(value) })
 )
 
-const testConfigDefaults: Partial<ShardingConfig.ShardingConfig["Service"]> = {
+const testConfigDefaults: Partial<ShardingConfig.ShardingConfig> = {
   entityMailboxCapacity: 10,
   entityTerminationTimeout: 0,
   entityMessagePollInterval: 5000,
@@ -2033,10 +2034,10 @@ const TestSharding = TestShardingWithoutStorage.pipe(
 )
 
 const CappedSharding = (
-  config: Partial<ShardingConfig.ShardingConfig["Service"]>,
+  config: Partial<ShardingConfig.ShardingConfig>,
   transformStorage?: (
-    storage: MessageStorage.MessageStorage["Service"]
-  ) => MessageStorage.MessageStorage["Service"]
+    storage: MessageStorage.MessageStorage
+  ) => MessageStorage.MessageStorage
 ) => {
   const configLayer = ShardingConfig.layer({ ...testConfigDefaults, ...config })
   let layer = TestShardingWithoutRunners.pipe(
@@ -2055,7 +2056,7 @@ const CappedSharding = (
 const ContextBleedSharding = ContextBleedLayer.pipe(Layer.provideMerge(TestSharding))
 
 const ActiveTeardownSharding = (
-  config?: Partial<ShardingConfig.ShardingConfig["Service"]>
+  config?: Partial<ShardingConfig.ShardingConfig>
 ) =>
   ActiveTeardownCallerLayer.pipe(
     Layer.merge(TestEntityNoState),

--- a/packages/effect/test/rpc/RpcClient.test.ts
+++ b/packages/effect/test/rpc/RpcClient.test.ts
@@ -90,6 +90,7 @@ describe("RpcClient", () => {
         }
       }
       const workerPlatform = Worker.WorkerPlatform.of({
+        ["~effect/workers/Worker/WorkerPlatform"]: "~effect/workers/Worker/WorkerPlatform" as const,
         spawn: () => Effect.succeed(backing)
       })
       const protocol = yield* RpcClient.makeProtocolWorker({ size: 1, concurrency: 1 }).pipe(

--- a/packages/effect/test/rpc/RpcSerialization.test.ts
+++ b/packages/effect/test/rpc/RpcSerialization.test.ts
@@ -53,7 +53,7 @@ const codecForJsonString =
   (<S extends Schema.Top>(schema: S) =>
     Schema.fromJsonString(Schema.toCodecJson(schema as any))) as RpcSerialization.CodecFor
 
-const serialization: RpcSerialization.RpcSerialization["Service"] = RpcSerialization.RpcSerialization.of({
+const serialization: RpcSerialization.RpcSerialization = RpcSerialization.RpcSerialization.of({
   ...RpcSerialization.ndjson,
   codecFor: codecForJsonString
 })

--- a/packages/effect/test/rpc/RpcServer.test.ts
+++ b/packages/effect/test/rpc/RpcServer.test.ts
@@ -153,6 +153,7 @@ describe("RpcServer", () => {
         })
       })
       const socketServer = SocketServer.SocketServer.of({
+        ["~@effect/platform/SocketServer"]: "~@effect/platform/SocketServer" as const,
         address: NetAddress.inetAddressFromStringUnsafe("127.0.0.1:0"),
         run: (handler) => handler(socket).pipe(Effect.orDie, Effect.andThen(Effect.never))
       })

--- a/packages/effect/test/unstable/ai/Chat.test.ts
+++ b/packages/effect/test/unstable/ai/Chat.test.ts
@@ -7,6 +7,7 @@ import * as TestUtils from "./utils.ts"
 
 const withConstantIdGenerator = (id: string) =>
   Effect.provideService(IdGenerator.IdGenerator, {
+    ["~@effect/ai/IdGenerator"]: "~@effect/ai/IdGenerator" as const,
     generateId: () => Effect.succeed(id)
   })
 

--- a/packages/effect/test/unstable/ai/LanguageModel.test.ts
+++ b/packages/effect/test/unstable/ai/LanguageModel.test.ts
@@ -1358,6 +1358,7 @@ describe("LanguageModel", () => {
             })
           ),
           Effect.provideService(ResponseIdTracker.ResponseIdTracker, {
+            ["~effect/ai/ResponseIdTracker"]: "~effect/ai/ResponseIdTracker" as const,
             clearUnsafe() {},
             markParts() {},
             prepareUnsafe: () =>
@@ -1416,6 +1417,7 @@ describe("LanguageModel", () => {
             })
           ),
           Effect.provideService(ResponseIdTracker.ResponseIdTracker, {
+            ["~effect/ai/ResponseIdTracker"]: "~effect/ai/ResponseIdTracker" as const,
             clearUnsafe() {},
             markParts() {},
             prepareUnsafe: () =>
@@ -1470,6 +1472,7 @@ describe("LanguageModel", () => {
             }
           }),
           Effect.provideService(ResponseIdTracker.ResponseIdTracker, {
+            ["~effect/ai/ResponseIdTracker"]: "~effect/ai/ResponseIdTracker" as const,
             clearUnsafe() {},
             markParts() {},
             prepareUnsafe: () =>
@@ -1520,6 +1523,7 @@ describe("LanguageModel", () => {
             })
           ),
           Effect.provideService(ResponseIdTracker.ResponseIdTracker, {
+            ["~effect/ai/ResponseIdTracker"]: "~effect/ai/ResponseIdTracker" as const,
             clearUnsafe() {},
             markParts: (parts, responseId) => {
               markedParts = parts
@@ -1575,6 +1579,7 @@ describe("LanguageModel", () => {
             })
           ),
           Effect.provideService(ResponseIdTracker.ResponseIdTracker, {
+            ["~effect/ai/ResponseIdTracker"]: "~effect/ai/ResponseIdTracker" as const,
             clearUnsafe() {},
             markParts: () => {
               markCalls++
@@ -1658,6 +1663,7 @@ describe("LanguageModel", () => {
             })
           ),
           Effect.provideService(ResponseIdTracker.ResponseIdTracker, {
+            ["~effect/ai/ResponseIdTracker"]: "~effect/ai/ResponseIdTracker" as const,
             clearUnsafe() {},
             markParts(parts) {
               markedParts = parts
@@ -1718,6 +1724,7 @@ describe("LanguageModel", () => {
             })
           ),
           Effect.provideService(ResponseIdTracker.ResponseIdTracker, {
+            ["~effect/ai/ResponseIdTracker"]: "~effect/ai/ResponseIdTracker" as const,
             clearUnsafe() {},
             markParts: (parts, responseId) => {
               markedParts = parts
@@ -1779,6 +1786,7 @@ describe("LanguageModel", () => {
             })
           ),
           Effect.provideService(ResponseIdTracker.ResponseIdTracker, {
+            ["~effect/ai/ResponseIdTracker"]: "~effect/ai/ResponseIdTracker" as const,
             clearUnsafe() {},
             markParts: (parts, responseId) => {
               markedParts = parts
@@ -1868,6 +1876,7 @@ describe("LanguageModel", () => {
             })
           ),
           Effect.provideService(ResponseIdTracker.ResponseIdTracker, {
+            ["~effect/ai/ResponseIdTracker"]: "~effect/ai/ResponseIdTracker" as const,
             clearUnsafe() {},
             markParts: (parts) => {
               markedParts = parts
@@ -1966,6 +1975,7 @@ describe("LanguageModel", () => {
             })
           ),
           Effect.provideService(ResponseIdTracker.ResponseIdTracker, {
+            ["~effect/ai/ResponseIdTracker"]: "~effect/ai/ResponseIdTracker" as const,
             markParts: (parts, responseId) => {
               markedParts = parts
               markedResponseId = responseId

--- a/packages/effect/test/unstable/ai/McpServer/McpConformance/ElicitationTest.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpConformance/ElicitationTest.ts
@@ -50,6 +50,7 @@ const runElicitation = <S extends Schema.ConstraintEncoder<Record<string, unknow
     Effect.provideService(
       McpSchema.McpServerClient,
       McpSchema.McpServerClient.of({
+        ["~effect/ai/McpSchema/McpServerClient"]: "~effect/ai/McpSchema/McpServerClient" as const,
         clientId: 1,
         protocolVersion,
         clientCapabilities: { elicitation: {} },

--- a/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
@@ -127,6 +127,7 @@ const pingBody = {
 }
 
 const directClient = McpSchema.McpServerClient.of({
+  ["~effect/ai/McpSchema/McpServerClient"]: "~effect/ai/McpSchema/McpServerClient" as const,
   clientId: 1,
   protocolVersion: "2025-06-18",
   clientCapabilities: {},
@@ -843,7 +844,7 @@ describe("McpServer", () => {
             })
           )
         )
-        const ready = yield* Deferred.make<McpServer.McpServer["Service"]>()
+        const ready = yield* Deferred.make<McpServer.McpServer>()
         yield* Effect.gen(function*() {
           const context = yield* Layer.build(
             McpServer.resource({

--- a/packages/effect/test/unstable/ai/McpServer/ProtocolAdapters.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/ProtocolAdapters.test.ts
@@ -1230,6 +1230,7 @@ describe("McpServer protocol adapters", () => {
         Effect.provideService(
           McpSchema.McpServerClient,
           McpSchema.McpServerClient.of({
+            ["~effect/ai/McpSchema/McpServerClient"]: "~effect/ai/McpSchema/McpServerClient" as const,
             clientId: 1,
             protocolVersion: "2025-06-18",
             clientCapabilities: {},

--- a/packages/effect/test/unstable/ai/McpServer/TestUtils/McpStdioHarness.ts
+++ b/packages/effect/test/unstable/ai/McpServer/TestUtils/McpStdioHarness.ts
@@ -22,7 +22,7 @@ export interface JsonRpcMessage {
 }
 
 export interface McpStdioHarness {
-  readonly server: McpServer.McpServer["Service"]
+  readonly server: McpServer.McpServer
   readonly serverFiber: Fiber.Fiber<never, Cause.IllegalArgumentError>
   readonly close: Effect.Effect<void>
   readonly sendRaw: (message: unknown) => Effect.Effect<void>
@@ -78,7 +78,7 @@ export const makeMcpStdioHarness = Effect.fnUntraced(function*(
     stdout: () => Sink.forEach((chunk) => Queue.offer(stdout, chunk)),
     stderr: () => Sink.forEach((chunk) => Queue.offer(stderr, chunk))
   })
-  const ready = yield* Deferred.make<McpServer.McpServer["Service"]>()
+  const ready = yield* Deferred.make<McpServer.McpServer>()
   const serverFiber = yield* Effect.gen(function*() {
     const context = yield* Layer.build(
       McpServer.layerStdio({

--- a/packages/effect/test/unstable/eventlog/EventLog.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventLog.test.ts
@@ -83,6 +83,7 @@ describe("EventLog", () => {
         let attempt = 0
         let failedChangeWrite = false
         const remote = EventLogRemote.EventLogRemote.of({
+          ["~effect/eventlog/EventLogRemote"]: "~effect/eventlog/EventLogRemote" as const,
           id: EventJournal.makeRemoteIdUnsafe(),
           changes: () => Queue.unbounded<EventJournal.RemoteEntry, EventLogRemote.EventLogRemoteError>(),
           write: ({ entries }) =>

--- a/packages/effect/test/unstable/eventlog/EventLogIdentityDerivation.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventLogIdentityDerivation.test.ts
@@ -10,7 +10,8 @@ import {
 const makeIdentity = (options: {
   readonly publicKey: string
   readonly rootSecret: Uint8Array
-}): EventLog.Identity["Service"] => ({
+}): EventLog.Identity => ({
+  ["~effect/eventlog/EventLog/Identity"]: "~effect/eventlog/EventLog/Identity" as const,
   publicKey: options.publicKey,
   privateKey: Redacted.make(options.rootSecret.slice())
 })

--- a/packages/effect/test/unstable/eventlog/EventLogRemote.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventLogRemote.test.ts
@@ -104,7 +104,7 @@ describe("EventLogRemote", () => {
 })
 
 class RemoteHarness extends Context.Service<RemoteHarness, {
-  readonly remote: EventLogRemote.EventLogRemote["Service"]
+  readonly remote: EventLogRemote.EventLogRemote
   readonly take: Effect.Effect<{
     readonly _tag: Rpc.Tag<RpcGroup.Rpcs<typeof EventLogMessage.EventLogRemoteRpcs>>
     readonly request: Rpc.Payload<RpcGroup.Rpcs<typeof EventLogMessage.EventLogRemoteRpcs>>
@@ -114,7 +114,7 @@ class RemoteHarness extends Context.Service<RemoteHarness, {
 
 const makeHarness = Effect.fn(function*(
   makeClient: Effect.Effect<
-    EventLogRemote.EventLogRemote["Service"],
+    EventLogRemote.EventLogRemote,
     EventLogRemote.EventLogRemoteError,
     EventLogEncryption.EventLogEncryption | EventLogRemote.EventLogRemoteClient | EventLog.Registry | Scope.Scope
   >
@@ -152,7 +152,11 @@ const makeHarness = Effect.fn(function*(
     )
   )
   const remote = yield* makeClient.pipe(
-    Effect.provideService(EventLogRemote.EventLogRemoteClient, client),
+    Effect.provideService(EventLogRemote.EventLogRemoteClient, {
+      ...client,
+      "~effect/unstable/eventlog/EventLogRemote/EventLogRemoteClient":
+        "~effect/unstable/eventlog/EventLogRemote/EventLogRemoteClient"
+    }),
     Effect.provide([EventLogEncryption.layerSubtle, EventLog.layerRegistry]),
     Effect.forkChild
   )
@@ -190,7 +194,7 @@ const getIdentityRootSecretMaterial = makeGetIdentityRootSecretMaterial(globalTh
 
 const authenticate = Effect.fnUntraced(function*(options: {
   readonly harness: RemoteHarness["Service"]
-  readonly identity: EventLog.Identity["Service"]
+  readonly identity: EventLog.Identity
 }) {
   const auth = yield* options.harness.take
   assert(auth._tag === "EventLog.Authenticate")

--- a/packages/effect/test/unstable/eventlog/EventLogServerUnencrypted.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventLogServerUnencrypted.test.ts
@@ -20,7 +20,7 @@ const storeId = EventLogMessage.StoreId.make("repro-store")
 const getIdentityRootSecretMaterial = makeGetIdentityRootSecretMaterial(globalThis.crypto)
 
 const authenticate = Effect.fnUntraced(function*(options: {
-  readonly identity: EventLog.Identity["Service"]
+  readonly identity: EventLog.Identity
   readonly challenge: Uint8Array
   readonly remoteId: EventJournal.RemoteId
 }) {
@@ -83,10 +83,14 @@ it.effect("indexes conflicts from the sliced history", () =>
         Layer.provide(Layer.succeed(EventLogServerUnencrypted.Storage, storage)),
         Layer.provide(Layer.succeed(EventLog.Registry, registry)),
         Layer.provide(Layer.succeed(EventLogServerUnencrypted.StoreMapping, {
+          ["~effect/eventlog/EventLogServerUnencrypted/StoreMapping"]:
+            "~effect/eventlog/EventLogServerUnencrypted/StoreMapping" as const,
           resolve: ({ storeId }) => Effect.succeed(storeId),
           hasStore: () => Effect.succeed(true)
         })),
         Layer.provide(Layer.succeed(EventLogServerUnencrypted.EventLogServerAuthorization, {
+          ["~effect/eventlog/EventLogServerUnencrypted/EventLogServerAuthorization"]:
+            "~effect/eventlog/EventLogServerUnencrypted/EventLogServerAuthorization" as const,
           authorizeWrite: () => Effect.void,
           authorizeRead: () => Effect.void,
           authorizeIdentity: () => Effect.void

--- a/packages/effect/test/unstable/http/HttpCompression.test.ts
+++ b/packages/effect/test/unstable/http/HttpCompression.test.ts
@@ -39,6 +39,7 @@ const platformContext = (compression: HttpPlatform.Compression): Context.Context
   Context.make(
     HttpPlatform.HttpPlatform,
     HttpPlatform.HttpPlatform.of({
+      ["~effect/http/HttpPlatform"]: "~effect/http/HttpPlatform" as const,
       platform: "web",
       compression,
       fileResponse: () => Effect.die("not implemented"),

--- a/packages/effect/test/unstable/http/HttpStaticServer.test.ts
+++ b/packages/effect/test/unstable/http/HttpStaticServer.test.ts
@@ -14,6 +14,7 @@ const services = Layer.mergeAll(
   Layer.succeed(
     HttpPlatform.HttpPlatform,
     HttpPlatform.HttpPlatform.of({
+      ["~effect/http/HttpPlatform"]: "~effect/http/HttpPlatform" as const,
       platform: "web",
       compression: { algorithms: new Set(), compressResponse: Effect.succeed },
       fileResponse: () => Effect.succeed(HttpServerResponse.text("0123456789")),
@@ -41,7 +42,7 @@ describe("HttpStaticServer", () => {
     }).pipe(Effect.provide(services)))
 })
 
-type FileOptions = Parameters<HttpPlatform.HttpPlatform["Service"]["fileResponse"]>[1]
+type FileOptions = Parameters<HttpPlatform.HttpPlatform["fileResponse"]>[1]
 
 const precisionServices = (size: bigint, calls: Array<{ path: string; options: FileOptions }>) =>
   Layer.mergeAll(
@@ -56,6 +57,7 @@ const precisionServices = (size: bigint, calls: Array<{ path: string; options: F
     Layer.succeed(
       HttpPlatform.HttpPlatform,
       HttpPlatform.HttpPlatform.of({
+        ["~effect/http/HttpPlatform"]: "~effect/http/HttpPlatform" as const,
         platform: "web",
         compression: { algorithms: new Set(), compressResponse: Effect.succeed },
         fileResponse: (path, options) => {

--- a/packages/effect/test/unstable/persistence/Redis.test.ts
+++ b/packages/effect/test/unstable/persistence/Redis.test.ts
@@ -17,6 +17,7 @@ describe("Redis", () => {
 
   it.effect("clearing an empty persistence store succeeds", () => {
     const redis = Redis.Redis.of({
+      ["~effect/persistence/Redis"]: "~effect/persistence/Redis" as const,
       send: <A>(command: string, ...args: ReadonlyArray<string>) => {
         if (command.toUpperCase() === "KEYS") return Effect.succeed([] as unknown as A)
         if (command.toUpperCase() === "DEL" && args.length === 0) {
@@ -40,6 +41,7 @@ describe("Redis", () => {
     const commands: Array<readonly [command: string, args: ReadonlyArray<string>]> = []
     const scripts: Array<unknown> = []
     const redis = Redis.Redis.of({
+      ["~effect/persistence/Redis"]: "~effect/persistence/Redis" as const,
       send: <A>(command: string, ...args: ReadonlyArray<string>) => {
         commands.push([command, args])
         return Effect.succeed(undefined as unknown as A)

--- a/packages/effect/test/unstable/sql/Statement.test.ts
+++ b/packages/effect/test/unstable/sql/Statement.test.ts
@@ -110,6 +110,7 @@ describe("Statement", () => {
 const makeClient = (observe: Effect.Effect<void>, borrow = false) => {
   const execute = Effect.as(observe, [])
   const connection: Connection = {
+    ["~effect/sql/SqlConnection"]: "~effect/sql/SqlConnection" as const,
     execute: () => execute,
     executeRaw: () => execute,
     executeValues: () => execute,

--- a/packages/platform/browser/src/BrowserPersistence.ts
+++ b/packages/platform/browser/src/BrowserPersistence.ts
@@ -51,6 +51,7 @@ export const layerBackingIndexedDb = (options?: {
     ).pipe(Effect.orDie)
 
     return Persistence.BackingPersistence.of({
+      ["~effect/persistence/BackingPersistence"]: "~effect/persistence/BackingPersistence" as const,
       make: Effect.fnUntraced(function*(storeId) {
         const clock = yield* Clock.Clock
         return {

--- a/packages/platform/browser/src/BrowserWorkerRunner.ts
+++ b/packages/platform/browser/src/BrowserWorkerRunner.ts
@@ -35,7 +35,8 @@ if (typeof self !== "undefined" && "onconnect" in self) {
  * @category constructors
  * @since 4.0.0
  */
-export const make = (self: MessagePort | Window): WorkerRunner.WorkerRunnerPlatform["Service"] => ({
+export const make = (self: MessagePort | Window): WorkerRunner.WorkerRunnerPlatform => ({
+  ["~effect/workers/WorkerRunner/WorkerRunnerPlatform"]: "~effect/workers/WorkerRunner/WorkerRunnerPlatform" as const,
   start: Effect.fnUntraced(function*<O = unknown, I = unknown>() {
     const disconnects = yield* Queue.make<number>()
     let currentPortId = 0

--- a/packages/platform/browser/src/IndexedDbDatabase.ts
+++ b/packages/platform/browser/src/IndexedDbDatabase.ts
@@ -104,6 +104,8 @@ export class IndexedDbDatabaseError extends Data.TaggedError(
   override readonly message = this.reason
 }
 
+const IndexedDbDatabaseTypeId = "~@effect/platform-browser/IndexedDbDatabase"
+
 /**
  * Service tag for an open IndexedDB database, its `IDBKeyRange` constructor, reactivity service, and rebuild effect.
  *
@@ -129,15 +131,22 @@ export class IndexedDbDatabaseError extends Data.TaggedError(
  * @category services
  * @since 4.0.0
  */
-export class IndexedDbDatabase extends Context.Service<
-  IndexedDbDatabase,
-  {
-    readonly database: MutableRef.MutableRef<globalThis.IDBDatabase>
-    readonly IDBKeyRange: typeof globalThis.IDBKeyRange
-    readonly reactivity: Reactivity.Reactivity["Service"]
-    readonly rebuild: Effect.Effect<void, IndexedDbDatabaseError>
-  }
->()(TypeId) {}
+export interface IndexedDbDatabase {
+  readonly [IndexedDbDatabaseTypeId]: typeof IndexedDbDatabaseTypeId
+
+  readonly database: MutableRef.MutableRef<globalThis.IDBDatabase>
+  readonly IDBKeyRange: typeof globalThis.IDBKeyRange
+  readonly reactivity: Reactivity.Reactivity
+  readonly rebuild: Effect.Effect<void, IndexedDbDatabaseError>
+}
+
+/**
+ * Service key for `IndexedDbDatabase` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const IndexedDbDatabase = Context.Service<IndexedDbDatabase>(TypeId)
 
 /**
  * Describes an IndexedDB schema version and its migrations, and acts as an effect that yields a query builder for the target version.
@@ -528,7 +537,13 @@ const layer = <DatabaseName extends string>(
         rebuildLock
       )
 
-      return IndexedDbDatabase.of({ database, IDBKeyRange, rebuild, reactivity })
+      return IndexedDbDatabase.of({
+        [IndexedDbDatabaseTypeId]: IndexedDbDatabaseTypeId as typeof IndexedDbDatabaseTypeId,
+        database,
+        IDBKeyRange,
+        rebuild,
+        reactivity
+      })
     })
   ).pipe(
     Layer.provide(Reactivity.layer)
@@ -553,7 +568,7 @@ const makeTransactionProto = <Source extends IndexedDbVersion.AnyWithProps>({
   readonly IDBKeyRange: typeof globalThis.IDBKeyRange
   readonly tables: ReadonlyMap<string, IndexedDbVersion.Tables<Source>>
   readonly transaction: globalThis.IDBTransaction
-  readonly reactivity: Reactivity.Reactivity["Service"]
+  readonly reactivity: Reactivity.Reactivity
 }): Transaction<Source> => {
   const migration = IndexedDbQueryBuilder.make({
     database,

--- a/packages/platform/browser/src/IndexedDbQueryBuilder.ts
+++ b/packages/platform/browser/src/IndexedDbQueryBuilder.ts
@@ -106,7 +106,7 @@ export interface IndexedDbQueryBuilder<
 > extends Pipeable.Pipeable, Inspectable {
   readonly tables: ReadonlyMap<string, IndexedDbVersion.Tables<Source>>
   readonly database: MutableRef.MutableRef<globalThis.IDBDatabase>
-  readonly reactivity: Reactivity.Reactivity["Service"]
+  readonly reactivity: Reactivity.Reactivity
   readonly IDBKeyRange: typeof globalThis.IDBKeyRange
   readonly IDBTransaction: globalThis.IDBTransaction | undefined
 
@@ -268,7 +268,7 @@ export declare namespace IndexedDbQuery {
     readonly table: Table
     readonly database: MutableRef.MutableRef<globalThis.IDBDatabase>
     readonly IDBKeyRange: typeof globalThis.IDBKeyRange
-    readonly reactivity: Reactivity.Reactivity["Service"]
+    readonly reactivity: Reactivity.Reactivity
 
     readonly clear: Effect.Effect<void, IndexedDbQueryError>
 
@@ -1413,7 +1413,7 @@ const makeFrom = <
   readonly table: Table
   readonly database: MutableRef.MutableRef<globalThis.IDBDatabase>
   readonly IDBKeyRange: typeof globalThis.IDBKeyRange
-  readonly reactivity: Reactivity.Reactivity["Service"]
+  readonly reactivity: Reactivity.Reactivity
 }): IndexedDbQuery.From<Table> => {
   const self = Object.create(FromProto)
   self.table = options.table
@@ -2055,7 +2055,7 @@ export const make = <Source extends IndexedDbVersion.AnyWithProps>({
   readonly database: MutableRef.MutableRef<globalThis.IDBDatabase>
   readonly IDBKeyRange: typeof globalThis.IDBKeyRange
   readonly tables: ReadonlyMap<string, IndexedDbVersion.Tables<Source>>
-  readonly reactivity: Reactivity.Reactivity["Service"]
+  readonly reactivity: Reactivity.Reactivity
 }): IndexedDbQueryBuilder<Source> => {
   const self = Object.create(QueryBuilderProto)
   self.tables = tables

--- a/packages/platform/bun/src/BunClusterHttp.ts
+++ b/packages/platform/bun/src/BunClusterHttp.ts
@@ -111,7 +111,7 @@ export const layer = <
     readonly namespace?: string | undefined
     readonly labelSelector?: string | undefined
   } | undefined
-  readonly shardingConfig?: Partial<ShardingConfig.ShardingConfig["Service"]> | undefined
+  readonly shardingConfig?: Partial<ShardingConfig.ShardingConfig> | undefined
 }): ClientOnly extends true ? Layer.Layer<
     Sharding | Runners.Runners | ("byo" extends Storage ? never : MessageStorage.MessageStorage),
     Config.ConfigError,

--- a/packages/platform/bun/src/BunClusterSocket.ts
+++ b/packages/platform/bun/src/BunClusterSocket.ts
@@ -70,7 +70,7 @@ export const layer = <
       readonly namespace?: string | undefined
       readonly labelSelector?: string | undefined
     } | undefined
-    readonly shardingConfig?: Partial<ShardingConfig.ShardingConfig["Service"]> | undefined
+    readonly shardingConfig?: Partial<ShardingConfig.ShardingConfig> | undefined
   }
 ): ClientOnly extends true ? Layer.Layer<
     Sharding | Runners.Runners | ("byo" extends Storage ? never : MessageStorage.MessageStorage),

--- a/packages/platform/bun/src/BunHttpPlatform.ts
+++ b/packages/platform/bun/src/BunHttpPlatform.ts
@@ -30,7 +30,7 @@ const compression = NodeHttpCompression.make(Platform.makeCompressionWeb({
  * @since 4.0.0
  */
 const make: Effect.Effect<
-  Platform.HttpPlatform["Service"],
+  Platform.HttpPlatform,
   never,
   FileSystem | Etag.Generator
 > = Platform.make({

--- a/packages/platform/bun/src/BunRedis.ts
+++ b/packages/platform/bun/src/BunRedis.ts
@@ -19,16 +19,28 @@ import * as Layer from "effect/Layer"
 import * as Scope from "effect/Scope"
 import * as Redis from "effect/unstable/persistence/Redis"
 
+const BunRedisTypeId = "~@effect/platform-bun/BunRedis"
+
 /**
  * Service tag for Bun Redis integration, exposing the raw `RedisClient` and a `use` helper that maps client promise failures to `RedisError`.
  *
  * @category services
  * @since 4.0.0
  */
-export class BunRedis extends Context.Service<BunRedis, {
+export interface BunRedis {
+  readonly [BunRedisTypeId]: typeof BunRedisTypeId
+
   readonly client: RedisClient
   readonly use: <A>(f: (client: RedisClient) => Promise<A>) => Effect.Effect<A, Redis.RedisError>
-}>()("@effect/platform-bun/BunRedis") {}
+}
+
+/**
+ * Service key for `BunRedis` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const BunRedis = Context.Service<BunRedis>("@effect/platform-bun/BunRedis")
 
 const make = Effect.fnUntraced(function*(
   options?: {
@@ -88,7 +100,8 @@ const make = Effect.fnUntraced(function*(
       })
   })
 
-  const bunRedis = Fn.identity<BunRedis["Service"]>({
+  const bunRedis = Fn.identity<BunRedis>({
+    [BunRedisTypeId]: BunRedisTypeId as typeof BunRedisTypeId,
     client,
     use
   })

--- a/packages/platform/bun/src/BunWorkerRunner.ts
+++ b/packages/platform/bun/src/BunWorkerRunner.ts
@@ -31,6 +31,7 @@ declare const self: MessagePort
  * @since 4.0.0
  */
 export const layer: Layer.Layer<WorkerRunner.WorkerRunnerPlatform> = Layer.succeed(WorkerRunner.WorkerRunnerPlatform)({
+  ["~effect/workers/WorkerRunner/WorkerRunnerPlatform"]: "~effect/workers/WorkerRunner/WorkerRunnerPlatform" as const,
   start: Effect.fnUntraced(function*<O = unknown, I = unknown>() {
     if (!("postMessage" in self)) {
       return yield* new WorkerError({

--- a/packages/platform/deno/src/DenoClusterHttp.ts
+++ b/packages/platform/deno/src/DenoClusterHttp.ts
@@ -91,7 +91,7 @@ export const layer = <
     readonly namespace?: string | undefined
     readonly labelSelector?: string | undefined
   } | undefined
-  readonly shardingConfig?: Partial<ShardingConfig.ShardingConfig["Service"]> | undefined
+  readonly shardingConfig?: Partial<ShardingConfig.ShardingConfig> | undefined
 }): ClientOnly extends true ? Layer.Layer<
     Sharding | Runners.Runners | ("byo" extends Storage ? never : MessageStorage.MessageStorage),
     Config.ConfigError,

--- a/packages/platform/deno/src/DenoClusterSocket.ts
+++ b/packages/platform/deno/src/DenoClusterSocket.ts
@@ -49,6 +49,7 @@ export const layerClientProtocol: Layer.Layer<
   Effect.gen(function*() {
     const serialization = yield* RpcSerialization.RpcSerialization
     return {
+      ["~effect/cluster/Runners/RpcClientProtocol"]: "~effect/cluster/Runners/RpcClientProtocol" as const,
       codecFor: serialization.codecFor,
       make: Effect.fnUntraced(function*(address) {
         const socket = yield* DenoSocket.makeTcp({
@@ -109,7 +110,7 @@ export const layer = <
       readonly namespace?: string | undefined
       readonly labelSelector?: string | undefined
     } | undefined
-    readonly shardingConfig?: Partial<ShardingConfig.ShardingConfig["Service"]> | undefined
+    readonly shardingConfig?: Partial<ShardingConfig.ShardingConfig> | undefined
   }
 ): ClientOnly extends true ? Layer.Layer<
     Sharding | Runners.Runners | ("byo" extends Storage ? never : MessageStorage.MessageStorage),

--- a/packages/platform/deno/src/DenoFileSystem.ts
+++ b/packages/platform/deno/src/DenoFileSystem.ts
@@ -438,7 +438,7 @@ const watchNative = (
   )
 
 const watch = (
-  backend: Option.Option<FileSystem.WatchBackend["Service"]>,
+  backend: Option.Option<FileSystem.WatchBackend>,
   path: string,
   options?: FileSystem.WatchOptions
 ) =>

--- a/packages/platform/deno/src/DenoRedis.ts
+++ b/packages/platform/deno/src/DenoRedis.ts
@@ -31,6 +31,8 @@ export type RedisOptions = Omit<RedisConnectOptions, "hostname"> & {
   readonly url?: string
 }
 
+const DenoRedisTypeId = "~@effect/platform-deno/DenoRedis"
+
 /**
  * Service tag for Deno Redis integration, exposing the raw `@db/redis` client
  * and a `use` helper that maps client promise failures to `RedisError`.
@@ -38,10 +40,20 @@ export type RedisOptions = Omit<RedisConnectOptions, "hostname"> & {
  * @category services
  * @since 4.0.0
  */
-export class DenoRedis extends Context.Service<DenoRedis, {
+export interface DenoRedis {
+  readonly [DenoRedisTypeId]: typeof DenoRedisTypeId
+
   readonly client: RedisClient
   readonly use: <A>(f: (client: RedisClient) => Promise<A>) => Effect.Effect<A, Redis.RedisError>
-}>()("@effect/platform-deno/DenoRedis") {}
+}
+
+/**
+ * Service key for `DenoRedis` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const DenoRedis = Context.Service<DenoRedis>("@effect/platform-deno/DenoRedis")
 
 const make = Effect.fnUntraced(function*(options: RedisOptions = {}) {
   const connectClient = () => {
@@ -111,7 +123,8 @@ const make = Effect.fnUntraced(function*(options: RedisOptions = {}) {
       )
   })
 
-  const denoRedis = Fn.identity<DenoRedis["Service"]>({
+  const denoRedis = Fn.identity<DenoRedis>({
+    [DenoRedisTypeId]: DenoRedisTypeId as typeof DenoRedisTypeId,
     client,
     use
   })

--- a/packages/platform/deno/src/DenoWorkerRunner.ts
+++ b/packages/platform/deno/src/DenoWorkerRunner.ts
@@ -29,7 +29,8 @@ if (typeof self !== "undefined" && "onconnect" in self) {
  * @category constructors
  * @since 4.0.0
  */
-export const make = (self: MessagePort): WorkerRunner.WorkerRunnerPlatform["Service"] => ({
+export const make = (self: MessagePort): WorkerRunner.WorkerRunnerPlatform => ({
+  ["~effect/workers/WorkerRunner/WorkerRunnerPlatform"]: "~effect/workers/WorkerRunner/WorkerRunnerPlatform" as const,
   start: Effect.fnUntraced(function*<O = unknown, I = unknown>() {
     const disconnects = yield* Queue.make<number>()
     let currentPortId = 0

--- a/packages/platform/node-shared/src/NodeClusterSocket.ts
+++ b/packages/platform/node-shared/src/NodeClusterSocket.ts
@@ -35,6 +35,7 @@ export const layerClientProtocol: Layer.Layer<
   Effect.gen(function*() {
     const serialization = yield* RpcSerialization.RpcSerialization
     return {
+      ["~effect/cluster/Runners/RpcClientProtocol"]: "~effect/cluster/Runners/RpcClientProtocol" as const,
       codecFor: serialization.codecFor,
       make: Effect.fnUntraced(function*(address) {
         const socket = yield* NodeSocket.makeNet({

--- a/packages/platform/node-shared/src/NodeFileSystem.ts
+++ b/packages/platform/node-shared/src/NodeFileSystem.ts
@@ -633,7 +633,7 @@ const watchNode = (path: string, info: FileSystem.File.Info, options?: FileSyste
   )
 
 const watch = (
-  backend: Option.Option<FileSystem.WatchBackend["Service"]>,
+  backend: Option.Option<FileSystem.WatchBackend>,
   path: string,
   options?: FileSystem.WatchOptions
 ) =>

--- a/packages/platform/node-shared/src/NodeSocketServer.ts
+++ b/packages/platform/node-shared/src/NodeSocketServer.ts
@@ -69,7 +69,7 @@ export class IncomingMessage extends Context.Service<
 export const make = (
   options: Net.ServerOpts & Net.ListenOptions
 ): Effect.Effect<
-  SocketServer.SocketServer["Service"],
+  SocketServer.SocketServer,
   SocketServer.SocketServerError,
   Scope.Scope
 > =>
@@ -111,7 +111,7 @@ export const layer: (
 export const makeTls = (
   options: Tls.TlsOptions & Net.ListenOptions
 ): Effect.Effect<
-  SocketServer.SocketServer["Service"],
+  SocketServer.SocketServer,
   SocketServer.SocketServerError,
   Scope.Scope
 > =>
@@ -152,7 +152,7 @@ export const layerTls: (
 export const makeWebSocket: (
   options: NodeWS.ServerOptions<typeof NodeWS.WebSocket, typeof Http.IncomingMessage>
 ) => Effect.Effect<
-  SocketServer.SocketServer["Service"],
+  SocketServer.SocketServer,
   SocketServer.SocketServerError,
   Scope.Scope
 > = Effect.fnUntraced(function*(
@@ -244,6 +244,7 @@ export const makeWebSocket: (
 
   const boundAddress = yield* socketAddressFromNode(server.address()!)
   return SocketServer.SocketServer.of({
+    ["~@effect/platform/SocketServer"]: "~@effect/platform/SocketServer" as const,
     address: boundAddress,
     run
   })
@@ -383,6 +384,7 @@ const makeNetServer = Effect.fnUntraced(function*(options: {
 
   const boundAddress = yield* socketAddressFromNode(server.address()!)
   return SocketServer.SocketServer.of({
+    ["~@effect/platform/SocketServer"]: "~@effect/platform/SocketServer" as const,
     address: boundAddress,
     run
   })

--- a/packages/platform/node/src/NodeClusterHttp.ts
+++ b/packages/platform/node/src/NodeClusterHttp.ts
@@ -69,7 +69,7 @@ export const layer = <
     readonly namespace?: string | undefined
     readonly labelSelector?: string | undefined
   } | undefined
-  readonly shardingConfig?: Partial<ShardingConfig.ShardingConfig["Service"]> | undefined
+  readonly shardingConfig?: Partial<ShardingConfig.ShardingConfig> | undefined
 }): ClientOnly extends true ? Layer.Layer<
     Sharding | Runners.Runners | ("byo" extends Storage ? never : MessageStorage.MessageStorage),
     Config.ConfigError,

--- a/packages/platform/node/src/NodeClusterSocket.ts
+++ b/packages/platform/node/src/NodeClusterSocket.ts
@@ -73,7 +73,7 @@ export const layer = <
       readonly namespace?: string | undefined
       readonly labelSelector?: string | undefined
     } | undefined
-    readonly shardingConfig?: Partial<ShardingConfig.ShardingConfig["Service"]> | undefined
+    readonly shardingConfig?: Partial<ShardingConfig.ShardingConfig> | undefined
   }
 ): ClientOnly extends true ? Layer.Layer<
     Sharding | Runners.Runners | ("byo" extends Storage ? never : MessageStorage.MessageStorage),

--- a/packages/platform/node/src/NodeHttpClient.ts
+++ b/packages/platform/node/src/NodeHttpClient.ts
@@ -372,6 +372,8 @@ export const layerUndici: Layer.Layer<Client.HttpClient> = Layer.provide(layerUn
 // node:http
 // -----------------------------------------------------------------------------
 
+const HttpAgentTypeId = "~@effect/platform-node/NodeHttpClient/HttpAgent"
+
 /**
  * Service tag for the paired Node `http` and `https` agents used by the
  * node:http-backed HTTP client.
@@ -379,10 +381,20 @@ export const layerUndici: Layer.Layer<Client.HttpClient> = Layer.provide(layerUn
  * @category services
  * @since 4.0.0
  */
-export class HttpAgent extends Context.Service<HttpAgent, {
+export interface HttpAgent {
+  readonly [HttpAgentTypeId]: typeof HttpAgentTypeId
+
   readonly http: Http.Agent
   readonly https: Https.Agent
-}>()("@effect/platform-node/NodeHttpClient/HttpAgent") {}
+}
+
+/**
+ * Service key for `HttpAgent` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const HttpAgent = Context.Service<HttpAgent>("@effect/platform-node/NodeHttpClient/HttpAgent")
 
 /**
  * Acquires Node `http` and `https` agents with the supplied options and
@@ -391,7 +403,7 @@ export class HttpAgent extends Context.Service<HttpAgent, {
  * @category resource management
  * @since 4.0.0
  */
-export const makeAgent = (options?: Https.AgentOptions): Effect.Effect<HttpAgent["Service"], never, Scope.Scope> =>
+export const makeAgent = (options?: Https.AgentOptions): Effect.Effect<HttpAgent, never, Scope.Scope> =>
   Effect.zipWith(
     Effect.acquireRelease(
       Effect.sync(() => new Http.Agent(options)),
@@ -401,7 +413,11 @@ export const makeAgent = (options?: Https.AgentOptions): Effect.Effect<HttpAgent
       Effect.sync(() => new Https.Agent(options)),
       (agent) => Effect.sync(() => agent.destroy())
     ),
-    (http, https) => ({ http, https })
+    (http, https) => ({
+      [HttpAgentTypeId]: HttpAgentTypeId as typeof HttpAgentTypeId,
+      http,
+      https
+    })
   )
 
 /**

--- a/packages/platform/node/src/NodeRedis.ts
+++ b/packages/platform/node/src/NodeRedis.ts
@@ -22,6 +22,8 @@ import { createClient, SocketTimeoutError } from "redis"
 type NodeRedisClient = ReturnType<typeof createClient>
 type NodeRedisClientOptions = NonNullable<Parameters<typeof createClient>[0]>
 
+const NodeRedisTypeId = "~@effect/platform-node/NodeRedis"
+
 /**
  * Service tag for the Node Redis integration, exposing the underlying
  * `node-redis` client and a `use` helper that maps client failures to
@@ -30,10 +32,20 @@ type NodeRedisClientOptions = NonNullable<Parameters<typeof createClient>[0]>
  * @category services
  * @since 4.0.0
  */
-export class NodeRedis extends Context.Service<NodeRedis, {
+export interface NodeRedis {
+  readonly [NodeRedisTypeId]: typeof NodeRedisTypeId
+
   readonly client: NodeRedisClient
   readonly use: <A>(f: (client: NodeRedisClient) => Promise<A>) => Effect.Effect<A, Redis.RedisError>
-}>()("@effect/platform-node/NodeRedis") {}
+}
+
+/**
+ * Service key for `NodeRedis` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const NodeRedis = Context.Service<NodeRedis>("@effect/platform-node/NodeRedis")
 
 const make = Effect.fnUntraced(function*(
   options?: NodeRedisClientOptions
@@ -143,7 +155,8 @@ const make = Effect.fnUntraced(function*(
       })
   })
 
-  const nodeRedis = Fn.identity<NodeRedis["Service"]>({
+  const nodeRedis = Fn.identity<NodeRedis>({
+    [NodeRedisTypeId]: NodeRedisTypeId as typeof NodeRedisTypeId,
     client,
     use
   })

--- a/packages/platform/node/src/NodeWorkerRunner.ts
+++ b/packages/platform/node/src/NodeWorkerRunner.ts
@@ -30,6 +30,7 @@ import * as WorkerThreads from "node:worker_threads"
  * @since 4.0.0
  */
 export const layer: Layer.Layer<WorkerRunner.WorkerRunnerPlatform> = Layer.succeed(WorkerRunner.WorkerRunnerPlatform)({
+  ["~effect/workers/WorkerRunner/WorkerRunnerPlatform"]: "~effect/workers/WorkerRunner/WorkerRunnerPlatform" as const,
   start<O = unknown, I = unknown>() {
     return Effect.gen(function*() {
       if (!WorkerThreads.parentPort && !process.send) {

--- a/packages/platform/node/test/HttpStaticServerConditional.test.ts
+++ b/packages/platform/node/test/HttpStaticServerConditional.test.ts
@@ -67,6 +67,7 @@ const makeHandler = async () => {
   })
 
   const httpPlatform = HttpPlatform.HttpPlatform.of({
+    ["~effect/http/HttpPlatform"]: "~effect/http/HttpPlatform" as const,
     platform: "node",
     compression: stubCompression,
     fileResponse: (_path, options) =>
@@ -108,6 +109,7 @@ const makeFailingApp = async (options: {
   })
 
   const httpPlatform = HttpPlatform.HttpPlatform.of({
+    ["~effect/http/HttpPlatform"]: "~effect/http/HttpPlatform" as const,
     platform: "node",
     compression: stubCompression,
     fileResponse: (_path, fileOptions) => {
@@ -147,6 +149,7 @@ const makeLayerHandler = (options: {
     }
   })
   const httpPlatform = HttpPlatform.HttpPlatform.of({
+    ["~effect/http/HttpPlatform"]: "~effect/http/HttpPlatform" as const,
     platform: "node",
     compression: stubCompression,
     fileResponse: () =>

--- a/packages/platform/node/test/RpcServer.test.ts
+++ b/packages/platform/node/test/RpcServer.test.ts
@@ -193,7 +193,7 @@ describe("RpcServer", () => {
             })
         })
         const sharding = Sharding.Sharding.of({
-          ...({} as Sharding.Sharding["Service"]),
+          ...({} as Sharding.Sharding),
           isShutdown: Effect.succeed(false),
           makeClient: () => Effect.succeed(testClient) as never,
           pollStorage: Effect.void

--- a/packages/platform/node/test/cluster-integration/harness.ts
+++ b/packages/platform/node/test/cluster-integration/harness.ts
@@ -37,7 +37,7 @@ export interface ClusterRunner {
   readonly address: RunnerAddress.RunnerAddress
   readonly index: number
   readonly shardGroups: ReadonlyArray<string>
-  readonly sharding: Sharding.Sharding["Service"]
+  readonly sharding: Sharding.Sharding
   readonly state: () => "frozen" | "killed" | "running" | "stopped"
 }
 
@@ -49,7 +49,7 @@ export interface MessageCounts {
 
 export interface MakeOptions {
   readonly backend: Backend
-  readonly config?: Partial<ShardingConfig.ShardingConfig["Service"]> | undefined
+  readonly config?: Partial<ShardingConfig.ShardingConfig> | undefined
   readonly entities:
     | RunnerEntities
     | ((options: { readonly prefix: string }) => RunnerEntities)
@@ -86,7 +86,7 @@ export interface InsertMessageRow {
   readonly trace_id: string | null
 }
 
-type HarnessConfig = Partial<ShardingConfig.ShardingConfig["Service"]> & {
+type HarnessConfig = Partial<ShardingConfig.ShardingConfig> & {
   readonly shardLockDisableAdvisory: boolean
 }
 
@@ -214,7 +214,7 @@ const makeLockFaultController = (sql: SqlClient.SqlClient) => {
   return { client, set }
 }
 
-const makeRunnerStorageController = (storage: RunnerStorage.RunnerStorage["Service"]) => {
+const makeRunnerStorageController = (storage: RunnerStorage.RunnerStorage) => {
   const gate = Latch.makeUnsafe(true)
   const refreshPaused = Latch.makeUnsafe()
   const syncPaused = Latch.makeUnsafe()
@@ -317,6 +317,7 @@ const trackedClientProtocolLayer = (
     Effect.gen(function*() {
       const serialization = yield* RpcSerialization.RpcSerialization
       return {
+        "~effect/cluster/Runners/RpcClientProtocol": "~effect/cluster/Runners/RpcClientProtocol" as const,
         codecFor: serialization.codecFor,
         make: Effect.fnUntraced(function*(address) {
           const socket = yield* NodeSocket.fromDuplex(
@@ -367,7 +368,7 @@ const runnerHealthLayer = (
 export const socketRunnerLayer = (
   address: RunnerAddress.RunnerAddress,
   entities: RunnerEntities,
-  socketServer: SocketServer.SocketServer["Service"],
+  socketServer: SocketServer.SocketServer,
   config: HarnessConfig,
   clientProtocol = NodeClusterSocket.layerClientProtocol
 ) =>

--- a/packages/sql/clickhouse/src/ClickhouseClient.ts
+++ b/packages/sql/clickhouse/src/ClickhouseClient.ts
@@ -201,6 +201,7 @@ export const make = (
     )
 
     class ConnectionImpl implements Connection {
+      readonly ["~effect/sql/SqlConnection"] = "~effect/sql/SqlConnection" as const
       private conn: Clickhouse.ClickHouseClient
       constructor(conn: Clickhouse.ClickHouseClient) {
         this.conn = conn

--- a/packages/sql/d1/src/D1Client.ts
+++ b/packages/sql/d1/src/D1Client.ts
@@ -292,6 +292,7 @@ export const make = (
         })
 
       const connection = identity<Connection>({
+        ["~effect/sql/SqlConnection"]: "~effect/sql/SqlConnection" as const,
         execute(sql, params, transformRows) {
           return transformRows
             ? Effect.map(runCached(sql, params), transformRows)

--- a/packages/sql/libsql/src/LibsqlClient.ts
+++ b/packages/sql/libsql/src/LibsqlClient.ts
@@ -199,6 +199,7 @@ export const make = (
     ]
 
     class LibsqlConnectionImpl implements LibsqlConnection {
+      readonly ["~effect/sql/SqlConnection"] = "~effect/sql/SqlConnection" as const
       readonly sdk: Libsql.Client | Libsql.Transaction
       constructor(sdk: Libsql.Client | Libsql.Transaction) {
         this.sdk = sdk

--- a/packages/sql/mssql/src/MssqlClient.ts
+++ b/packages/sql/mssql/src/MssqlClient.ts
@@ -428,6 +428,7 @@ export const make = (
         })
 
       const connection = identity<MssqlConnection>({
+        ["~effect/sql/SqlConnection"]: "~effect/sql/SqlConnection" as const,
         execute(sql, params, transformRows) {
           return transformRows
             ? Effect.map(run(sql, params), transformRows)

--- a/packages/sql/mysql2/src/MysqlClient.ts
+++ b/packages/sql/mysql2/src/MysqlClient.ts
@@ -227,6 +227,7 @@ export const make = (
     const defaultMethod: "execute" | "query" = options.disablePreparedStatements === true ? "query" : "execute"
 
     class ConnectionImpl implements Connection {
+      readonly ["~effect/sql/SqlConnection"] = "~effect/sql/SqlConnection" as const
       readonly conn: Mysql.PoolConnection | Mysql.Pool
       constructor(conn: Mysql.PoolConnection | Mysql.Pool) {
         this.conn = conn

--- a/packages/sql/pg/src/PgClient.ts
+++ b/packages/sql/pg/src/PgClient.ts
@@ -243,6 +243,7 @@ const makeImpl = Effect.fnUntraced(function*(
 })
 
 class ConnectionImpl implements Connection {
+  readonly ["~effect/sql/SqlConnection"] = "~effect/sql/SqlConnection" as const
   readonly connection: PgConnection.PgConnection
   readonly streamAcquirer: Effect.Effect<PgConnection.PgConnection, SqlError, Scope.Scope> | undefined
 

--- a/packages/sql/pg/test/Persistence.integration.test.ts
+++ b/packages/sql/pg/test/Persistence.integration.test.ts
@@ -116,7 +116,7 @@ it.layer(PgContainer.layerClient, { timeout: "30 seconds" })("PersistedQueue SQL
         tableName: "effect_queue_two_workers",
         pollInterval: "10 millis"
       } as const
-      const makeQueue = Effect.fnUntraced(function*(store: PersistedQueue.PersistedQueueStore["Service"]) {
+      const makeQueue = Effect.fnUntraced(function*(store: PersistedQueue.PersistedQueueStore) {
         const factory = yield* PersistedQueue.makeFactory.pipe(
           Effect.provideService(PersistedQueue.PersistedQueueStore, store)
         )

--- a/packages/sql/pglite/src/PgliteClient.ts
+++ b/packages/sql/pglite/src/PgliteClient.ts
@@ -283,6 +283,7 @@ export const fromClient = (
   })
 
 class PgliteConnection implements Connection {
+  readonly ["~effect/sql/SqlConnection"] = "~effect/sql/SqlConnection" as const
   readonly pglite: PGliteInterface
   constructor(pglite: PGliteInterface) {
     this.pglite = pglite

--- a/packages/sql/sqlite-bun/src/SqliteClient.ts
+++ b/packages/sql/sqlite-bun/src/SqliteClient.ts
@@ -181,6 +181,7 @@ export const make = (
         })
 
       return identity<SqliteConnection>({
+        ["~effect/sql/SqlConnection"]: "~effect/sql/SqlConnection" as const,
         execute(sql, params, transformRows) {
           return transformRows
             ? Effect.map(run(sql, params), transformRows)

--- a/packages/sql/sqlite-do/src/SqliteClient.ts
+++ b/packages/sql/sqlite-do/src/SqliteClient.ts
@@ -235,6 +235,7 @@ export const make = (
         })
 
       return identity<Connection>({
+        ["~effect/sql/SqlConnection"]: "~effect/sql/SqlConnection" as const,
         execute(sql, params, transformRows) {
           return transformRows
             ? Effect.map(runStatement(sql, params), transformRows)

--- a/packages/sql/sqlite-node/src/SqliteClient.ts
+++ b/packages/sql/sqlite-node/src/SqliteClient.ts
@@ -251,6 +251,7 @@ export const make = (
       ) => Effect.flatMap(prepare(sql), (statement) => runStatementValuesUnprepared(statement, params))
 
       return identity<SqliteConnection>({
+        ["~effect/sql/SqlConnection"]: "~effect/sql/SqlConnection" as const,
         execute(sql, params, transformRows) {
           return transformRows
             ? Effect.map(run(sql, params), transformRows)

--- a/packages/sql/sqlite-node/test/SqlEventLogServerEncrypted.test.ts
+++ b/packages/sql/sqlite-node/test/SqlEventLogServerEncrypted.test.ts
@@ -26,8 +26,8 @@ const makeEntry = (value: number) =>
   }, { disableChecks: true })
 
 const persistEntries = (
-  encryption: EventLogEncryption.EventLogEncryption["Service"],
-  identity: EventLog.Identity["Service"],
+  encryption: EventLogEncryption.EventLogEncryption,
+  identity: EventLog.Identity,
   entries: ReadonlyArray<EventJournal.Entry>
 ) =>
   Effect.gen(function*() {
@@ -42,8 +42,8 @@ const persistEntries = (
   })
 
 const encodeWrite = Effect.fnUntraced(function*(
-  encryption: EventLogEncryption.EventLogEncryption["Service"],
-  identity: EventLog.Identity["Service"],
+  encryption: EventLogEncryption.EventLogEncryption,
+  identity: EventLog.Identity,
   entry: EventJournal.Entry
 ) {
   const encrypted = yield* encryption.encrypt(identity, [entry])
@@ -68,7 +68,7 @@ const makePersistedEntry = (index: number, entryId = EventJournal.makeEntryIdUns
 const getIdentityRootSecretMaterial = makeGetIdentityRootSecretMaterial(globalThis.crypto)
 
 const makeAuthenticateRequest = Effect.fnUntraced(function*(options: {
-  readonly identity: EventLog.Identity["Service"]
+  readonly identity: EventLog.Identity
   readonly challenge: Uint8Array
   readonly remoteId: EventJournal.RemoteId
 }) {
@@ -89,8 +89,8 @@ const makeAuthenticateRequest = Effect.fnUntraced(function*(options: {
 })
 
 const makeAuthenticatedRpcClient = Effect.fnUntraced(function*(
-  storage: EventLogServer.Storage["Service"],
-  identities: ReadonlyArray<EventLog.Identity["Service"]>
+  storage: EventLogServer.Storage,
+  identities: ReadonlyArray<EventLog.Identity>
 ) {
   const rpcClient = yield* RpcTest.makeClient(EventLogMessage.EventLogRemoteRpcs).pipe(
     Effect.provide(
@@ -313,7 +313,8 @@ describe("SqlEventLogServer", () => {
 
       const firstIdentity = yield* EventLog.makeIdentity
       const secondIdentitySeed = yield* EventLog.makeIdentity
-      const secondIdentity: EventLog.Identity["Service"] = {
+      const secondIdentity: EventLog.Identity = {
+        ["~effect/eventlog/EventLog/Identity"]: "~effect/eventlog/EventLog/Identity" as const,
         publicKey: firstIdentity.publicKey,
         privateKey: secondIdentitySeed.privateKey
       }

--- a/packages/sql/sqlite-node/test/SqlEventLogServerUnencrypted.test.ts
+++ b/packages/sql/sqlite-node/test/SqlEventLogServerUnencrypted.test.ts
@@ -33,7 +33,7 @@ const makeEntry = (value: number) =>
   }, { disableChecks: true })
 
 const makeAuthenticateRequest = Effect.fnUntraced(function*(options: {
-  readonly identity: EventLog.Identity["Service"]
+  readonly identity: EventLog.Identity
   readonly challenge: Uint8Array
   readonly remoteId: EventJournal.RemoteId
 }) {
@@ -67,10 +67,14 @@ describe("SqlEventLogServerUnencrypted (sql-sqlite-node)", () => {
             Layer.provideMerge(EventLog.layerRegistry),
             Layer.provide(Layer.succeed(EventLogServerUnencrypted.Storage, storage)),
             Layer.provide(Layer.succeed(EventLogServerUnencrypted.StoreMapping, {
+              ["~effect/eventlog/EventLogServerUnencrypted/StoreMapping"]:
+                "~effect/eventlog/EventLogServerUnencrypted/StoreMapping" as const,
               resolve: ({ storeId }) => Effect.succeed(storeId),
               hasStore: () => Effect.succeed(true)
             })),
             Layer.provide(Layer.succeed(EventLogServerUnencrypted.EventLogServerAuthorization, {
+              ["~effect/eventlog/EventLogServerUnencrypted/EventLogServerAuthorization"]:
+                "~effect/eventlog/EventLogServerUnencrypted/EventLogServerAuthorization" as const,
               authorizeWrite: () => Effect.void,
               authorizeRead: () => Effect.void,
               authorizeIdentity: () => Effect.void
@@ -116,10 +120,14 @@ describe("SqlEventLogServerUnencrypted (sql-sqlite-node)", () => {
             Layer.provideMerge(EventLog.layerRegistry),
             Layer.provide(Layer.succeed(EventLogServerUnencrypted.Storage, storage)),
             Layer.provide(Layer.succeed(EventLogServerUnencrypted.StoreMapping, {
+              ["~effect/eventlog/EventLogServerUnencrypted/StoreMapping"]:
+                "~effect/eventlog/EventLogServerUnencrypted/StoreMapping" as const,
               resolve: ({ storeId }) => Effect.succeed(storeId),
               hasStore: () => Effect.succeed(true)
             })),
             Layer.provide(Layer.succeed(EventLogServerUnencrypted.EventLogServerAuthorization, {
+              ["~effect/eventlog/EventLogServerUnencrypted/EventLogServerAuthorization"]:
+                "~effect/eventlog/EventLogServerUnencrypted/EventLogServerAuthorization" as const,
               authorizeWrite: () => Effect.void,
               authorizeRead: () => Effect.void,
               authorizeIdentity: () => Effect.void
@@ -130,7 +138,8 @@ describe("SqlEventLogServerUnencrypted (sql-sqlite-node)", () => {
 
       const firstIdentity = yield* EventLog.makeIdentity
       const secondIdentitySeed = yield* EventLog.makeIdentity
-      const secondIdentity: EventLog.Identity["Service"] = {
+      const secondIdentity: EventLog.Identity = {
+        ["~effect/eventlog/EventLog/Identity"]: "~effect/eventlog/EventLog/Identity" as const,
         publicKey: firstIdentity.publicKey,
         privateKey: secondIdentitySeed.privateKey
       }

--- a/packages/sql/sqlite-react-native/src/SqliteClient.ts
+++ b/packages/sql/sqlite-react-native/src/SqliteClient.ts
@@ -196,6 +196,7 @@ export const make = (
         })
 
       return identity<SqliteConnection>({
+        ["~effect/sql/SqlConnection"]: "~effect/sql/SqlConnection" as const,
         execute(sql, params, transformRows) {
           return transformRows
             ? Effect.map(run(sql, params), transformRows)
@@ -302,6 +303,8 @@ interface DB {
    * Sync version of the execute function
    * It will block the JS thread and therefore your UI and should be used with caution
    *
+   * **Details**
+   *
    * When writing your queries, you can use the ? character as a placeholder for parameters
    * The parameters will be automatically escaped and sanitized
    *
@@ -316,6 +319,8 @@ interface DB {
   executeSync: (query: string, params?: Array<any>) => QueryResult
   /**
    * Basic query execution function, it is async don't forget to await it
+   *
+   * **Details**
    *
    * When writing your queries, you can use the ? character as a placeholder for parameters
    * The parameters will be automatically escaped and sanitized
@@ -365,6 +370,8 @@ interface DB {
    * Allows to trigger a sync the database with it's remote replica
    * In order for this function to work you need to use openSync or openRemote functions
    * with libsql: true in the package.json
+   *
+   * **Details**
    *
    * The database is hosted in turso
    */

--- a/packages/sql/sqlite-wasm/src/SqliteClient.ts
+++ b/packages/sql/sqlite-wasm/src/SqliteClient.ts
@@ -198,6 +198,7 @@ export const makeMemory = (
         })
 
       return identity<SqliteConnection>({
+        ["~effect/sql/SqlConnection"]: "~effect/sql/SqlConnection" as const,
         execute(sql, params, transformRows) {
           return transformRows
             ? Effect.map(run(sql, params), transformRows)
@@ -397,6 +398,7 @@ export const make = (
       }
 
       return identity<SqliteConnection>({
+        ["~effect/sql/SqlConnection"]: "~effect/sql/SqlConnection" as const,
         execute(sql, params, transformRows) {
           return transformRows
             ? Effect.map(run(sql, params), transformRows)

--- a/packages/tools/ai-codegen/src/Discovery.ts
+++ b/packages/tools/ai-codegen/src/Discovery.ts
@@ -48,6 +48,7 @@ export interface DiscoveredProvider {
   readonly specSource: SpecSource
   readonly outputPath: string
 }
+const ProviderDiscoveryTypeId = "~@effect/ai-codegen/ProviderDiscovery"
 
 /**
  * Service for discovering AI provider configurations.
@@ -56,6 +57,8 @@ export interface DiscoveredProvider {
  * @since 4.0.0
  */
 export interface ProviderDiscovery {
+  readonly [ProviderDiscoveryTypeId]: typeof ProviderDiscoveryTypeId
+
   readonly discover: () => Effect.Effect<
     Array<DiscoveredProvider>,
     DiscoveryError | Glob.GlobError
@@ -209,5 +212,9 @@ export const layer: Layer.Layer<
     return found
   })
 
-  return { discover, discoverOne }
+  return {
+    [ProviderDiscoveryTypeId]: ProviderDiscoveryTypeId as typeof ProviderDiscoveryTypeId,
+    discover,
+    discoverOne
+  }
 }).pipe(Layer.effect(ProviderDiscovery))

--- a/packages/tools/ai-codegen/src/Generator.ts
+++ b/packages/tools/ai-codegen/src/Generator.ts
@@ -65,6 +65,7 @@ export class PatchError extends Data.TaggedError("PatchError")<{
   readonly provider: string
   readonly cause: unknown
 }> {}
+const CodeGeneratorTypeId = "~@effect/ai-codegen/CodeGenerator"
 
 /**
  * Service for generating Effect code from OpenAPI specs.
@@ -73,6 +74,8 @@ export class PatchError extends Data.TaggedError("PatchError")<{
  * @since 4.0.0
  */
 export interface CodeGenerator {
+  readonly [CodeGeneratorTypeId]: typeof CodeGeneratorTypeId
+
   readonly generate: (
     provider: DiscoveredProvider,
     spec: unknown
@@ -205,7 +208,10 @@ export const layer: Layer.Layer<
       )
   })
 
-  return { generate }
+  return {
+    [CodeGeneratorTypeId]: CodeGeneratorTypeId as typeof CodeGeneratorTypeId,
+    generate
+  }
 }).pipe(Layer.effect(CodeGenerator))
 
 /**

--- a/packages/tools/ai-codegen/src/Glob.ts
+++ b/packages/tools/ai-codegen/src/Glob.ts
@@ -19,6 +19,7 @@ export class GlobError extends Data.TaggedError("GlobError")<{
   readonly pattern: string | ReadonlyArray<string>
   readonly cause: unknown
 }> {}
+const GlobTypeId = "~@effect/ai-codegen/Glob"
 
 /**
  * Service for glob pattern matching.
@@ -27,6 +28,8 @@ export class GlobError extends Data.TaggedError("GlobError")<{
  * @since 4.0.0
  */
 export interface Glob {
+  readonly [GlobTypeId]: typeof GlobTypeId
+
   readonly glob: (
     pattern: string | ReadonlyArray<string>,
     options?: GlobLib.GlobOptions
@@ -48,6 +51,7 @@ export const Glob: Context.Service<Glob, Glob> = Context.Service("@effect/ai-cod
  * @since 4.0.0
  */
 export const layer: Layer.Layer<Glob> = Layer.succeed(Glob, {
+  [GlobTypeId]: GlobTypeId as typeof GlobTypeId,
   glob: (pattern, options) =>
     Effect.tryPromise({
       try: () => GlobLib.glob(pattern as string | Array<string>, options ?? {}) as Promise<Array<string>>,

--- a/packages/tools/ai-codegen/src/PostProcess.ts
+++ b/packages/tools/ai-codegen/src/PostProcess.ts
@@ -62,6 +62,7 @@ export class PostProcessError extends Data.TaggedError("PostProcessError")<{
     return lines.join("\n")
   }
 }
+const PostProcessorTypeId = "~@effect/ai-codegen/PostProcessor"
 
 /**
  * Service for post-processing generated code.
@@ -70,6 +71,8 @@ export class PostProcessError extends Data.TaggedError("PostProcessError")<{
  * @since 4.0.0
  */
 export interface PostProcessor {
+  readonly [PostProcessorTypeId]: typeof PostProcessorTypeId
+
   readonly lint: (filePath: string) => Effect.Effect<void, PostProcessError>
   readonly format: (filePath: string) => Effect.Effect<void, PostProcessError>
 }
@@ -156,5 +159,9 @@ export const layer: Layer.Layer<
     yield* runCommand("pnpm", ["exec", "dprint", "--log-level", "silent", "fmt", filePath], "format", filePath)
   })
 
-  return { lint, format }
+  return {
+    [PostProcessorTypeId]: PostProcessorTypeId as typeof PostProcessorTypeId,
+    lint,
+    format
+  }
 }).pipe(Layer.effect(PostProcessor))

--- a/packages/tools/ai-codegen/src/SpecFetcher.ts
+++ b/packages/tools/ai-codegen/src/SpecFetcher.ts
@@ -39,6 +39,7 @@ export class SpecFetchError extends Data.TaggedError("SpecFetchError")<{
   readonly source: string
   readonly cause: unknown
 }> {}
+const SpecFetcherTypeId = "~@effect/ai-codegen/SpecFetcher"
 
 /**
  * Service for fetching OpenAPI specifications.
@@ -47,6 +48,8 @@ export class SpecFetchError extends Data.TaggedError("SpecFetchError")<{
  * @since 4.0.0
  */
 export interface SpecFetcher {
+  readonly [SpecFetcherTypeId]: typeof SpecFetcherTypeId
+
   readonly fetch: (
     source: SpecSource,
     provider: string
@@ -153,5 +156,8 @@ export const layer: Layer.Layer<
     return yield* parseSpec(content, sourceString, provider)
   })
 
-  return { fetch }
+  return {
+    [SpecFetcherTypeId]: SpecFetcherTypeId as typeof SpecFetcherTypeId,
+    fetch
+  }
 }).pipe(Layer.effect(SpecFetcher))

--- a/packages/tools/ai-codegen/test/Generator.test.ts
+++ b/packages/tools/ai-codegen/test/Generator.test.ts
@@ -10,6 +10,7 @@ import * as Path from "effect/Path"
 
 const TestLayer = Generator.layer.pipe(
   Layer.provide(Layer.succeed(OpenApiGenerator.OpenApiGenerator, {
+    ["~@effect/openapi-generator/OpenApiGenerator"]: "~@effect/openapi-generator/OpenApiGenerator" as const,
     generate: (spec) => Effect.succeed(JSON.stringify(spec))
   })),
   Layer.provideMerge(NodeServices.layer)

--- a/packages/tools/ai-docgen/src/Glob.ts
+++ b/packages/tools/ai-docgen/src/Glob.ts
@@ -20,18 +20,30 @@ export class GlobError extends Data.TaggedError("GlobError")<{
   readonly cause: unknown
 }> {}
 
+const GlobTypeId = "~@effect/ai-docgen/Glob"
+
 /**
  * Context service for glob pattern matching used by AI docgen tooling.
  *
  * @category services
  * @since 4.0.0
  */
-export class Glob extends Context.Service<Glob, {
+export interface Glob {
+  readonly [GlobTypeId]: typeof GlobTypeId
+
   readonly glob: (
     pattern: string | ReadonlyArray<string>,
     options?: GlobLib.GlobOptions
   ) => Effect.Effect<Array<string>, GlobError>
-}>()("@effect/ai-codegen/Glob") {}
+}
+
+/**
+ * Service key for `Glob` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Glob = Context.Service<Glob>("@effect/ai-codegen/Glob")
 
 /**
  * Layer providing the Glob service.
@@ -40,6 +52,7 @@ export class Glob extends Context.Service<Glob, {
  * @since 4.0.0
  */
 export const layer: Layer.Layer<Glob> = Layer.succeed(Glob, {
+  [GlobTypeId]: GlobTypeId as typeof GlobTypeId,
   glob: (pattern, options) =>
     Effect.tryPromise({
       try: () => GlobLib.glob(pattern as string | Array<string>, options ?? {}) as Promise<Array<string>>,

--- a/packages/tools/api-diff/src/ApiDiff.ts
+++ b/packages/tools/api-diff/src/ApiDiff.ts
@@ -27,144 +27,164 @@ export interface ApiDiffOptions {
   readonly check: boolean
 }
 
-export class ApiDiff extends Context.Service<ApiDiff, {
+const ApiDiffTypeId = "~@effect/api-diff/ApiDiff"
+
+export interface ApiDiff {
+  readonly [ApiDiffTypeId]: typeof ApiDiffTypeId
+
   readonly run: (options: ApiDiffOptions) => Effect.Effect<void, ApiDiffError>
-}>()("@effect/api-diff/ApiDiff") {
-  static readonly layerNoDependencies = Layer.effect(
-    ApiDiff,
-    Effect.gen(function*() {
-      const fs = yield* FileSystem.FileSystem
-      const path = yield* Path.Path
-      const worktrees = yield* Worktrees
-
-      const absolute = (repoRoot: string, location: string): string =>
-        path.isAbsolute(location) ? location : path.resolve(repoRoot, location)
-
-      const findRepoRoot = Effect.fnUntraced(function*() {
-        let current = path.resolve()
-        while (true) {
-          if (
-            (yield* fs.exists(path.join(current, ".git"))) ||
-            (yield* fs.exists(path.join(current, "pnpm-workspace.yaml")))
-          ) {
-            return current
-          }
-          const parent = path.dirname(current)
-          if (parent === current) {
-            return yield* new ApiDiffError({
-              message: `Could not locate repository root from ${path.resolve()}`
-            })
-          }
-          current = parent
-        }
-      })
-
-      const runInternal = Effect.fnUntraced(function*(options: ApiDiffOptions) {
-        const repoRoot = yield* findRepoRoot()
-        if (options.output === undefined && options.writeDoc === undefined && !options.check) {
-          return yield* new ApiDiffError({ message: "Specify --output, --write-doc, or --check" })
-        }
-
-        const baseSha = yield* worktrees.resolveRef(repoRoot, options.baseRef)
-        const headSha = yield* (options.headRef === "main"
-          ? worktrees.resolveRef(repoRoot, "origin/main").pipe(
-            Effect.catch(() => worktrees.resolveRef(repoRoot, options.headRef))
-          )
-          : worktrees.resolveRef(repoRoot, options.headRef))
-        const toolRoot = path.join(repoRoot, "tmp", "api-diff")
-        const cacheRoot = path.join(toolRoot, "cache")
-        const worktreesRoot = path.join(toolRoot, "worktrees")
-        yield* Console.log(
-          `Base ${options.baseRef}: ${baseSha}\nHead ${options.headRef}: ${headSha}`
-        )
-        const base = yield* worktrees.prepareSnapshot({
-          repoRoot,
-          cacheRoot,
-          worktreesRoot,
-          name: "base",
-          ref: options.baseRef,
-          sha: baseSha
-        })
-        const head = yield* worktrees.prepareSnapshot({
-          repoRoot,
-          cacheRoot,
-          worktreesRoot,
-          name: "head",
-          ref: options.headRef,
-          sha: headSha
-        })
-        const diff = diffSnapshots(base, head)
-
-        if (options.output !== undefined) {
-          const output = absolute(repoRoot, options.output)
-          yield* fs.makeDirectory(output, { recursive: true })
-          yield* fs.writeFileString(path.join(output, "base.snapshot.json"), prettyJson(base))
-          yield* fs.writeFileString(path.join(output, "head.snapshot.json"), prettyJson(head))
-          yield* fs.writeFileString(path.join(output, "diff.json"), prettyJson(diff))
-          yield* fs.writeFileString(path.join(output, "report.md"), renderMarkdownReport(diff))
-          yield* Console.log(`Wrote ${path.relative(repoRoot, output)} (${diff.changes.length} changes)`)
-        }
-
-        if (options.writeDoc !== undefined || options.check) {
-          const annotations = yield* loadAnnotations(path.join(repoRoot, "migration", "annotations")).pipe(
-            Effect.provideService(FileSystem.FileSystem, fs),
-            Effect.provideService(Path.Path, path)
-          )
-          const documentPath = options.writeDoc === undefined
-            ? path.join(repoRoot, "migration", "v3-to-v4.md")
-            : absolute(repoRoot, options.writeDoc)
-          const existing = (yield* fs.exists(documentPath)) ? yield* fs.readFileString(documentPath) : ""
-          const importMapSections = extractImportMapSections(existing)
-          let documentForCheck = existing
-          if (options.writeDoc !== undefined) {
-            const document = renderMigrationDocument(diff, annotations, importMapSections)
-            const unsafeMarkdown = markdownSafetyIssues(document)
-            if (unsafeMarkdown.length > 0) {
-              return yield* new ApiDiffError({
-                message: `Generated migration document has unsafe Markdown:\n${unsafeMarkdown.join("\n")}`
-              })
-            }
-            documentForCheck = document
-            yield* fs.makeDirectory(path.dirname(documentPath), { recursive: true })
-            yield* fs.writeFileString(documentPath, document)
-            yield* Console.log(`Wrote ${path.relative(repoRoot, documentPath)} (${diff.changes.length} changes)`)
-          }
-          if (options.check) {
-            const unsafeMarkdown = markdownSafetyIssues(documentForCheck)
-            if (unsafeMarkdown.length > 0) {
-              return yield* new ApiDiffError({
-                message: `Migration document has unsafe Markdown:\n${unsafeMarkdown.join("\n")}`
-              })
-            }
-            const missingApis = unannotatedApiIds(diff, annotations, importMapSections)
-            const missingModules = unannotatedModuleIds(diff, annotations, importMapSections)
-            yield* Console.log(renderMissingAnnotations(diff, annotations, importMapSections).trimEnd())
-            if (missingApis.size > 0 || missingModules.length > 0) {
-              return yield* new ApiDiffError({
-                message: `${missingApis.size} API groups and ${missingModules.length} modules need migration guidance`
-              })
-            }
-          }
-        }
-      })
-
-      const run = (options: ApiDiffOptions): Effect.Effect<void, ApiDiffError> =>
-        runInternal(options).pipe(
-          Effect.mapError((cause) =>
-            isApiDiffError(cause)
-              ? cause
-              : new ApiDiffError({
-                message: "API diff failed",
-                cause
-              })
-          )
-        )
-
-      return ApiDiff.of({ run })
-    })
-  )
-
-  static readonly layer = this.layerNoDependencies.pipe(
-    Layer.provide(Worktrees.layer)
-  )
 }
+
+/**
+ * Service key for `ApiDiff` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const ApiDiff = (() => {
+  const service = Context.Service<ApiDiff>("@effect/api-diff/ApiDiff")
+  const service1 = Object.assign(service, {
+    layerNoDependencies: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        const fs = yield* FileSystem.FileSystem
+        const path = yield* Path.Path
+        const worktrees = yield* Worktrees
+
+        const absolute = (repoRoot: string, location: string): string =>
+          path.isAbsolute(location) ? location : path.resolve(repoRoot, location)
+
+        const findRepoRoot = Effect.fnUntraced(function*() {
+          let current = path.resolve()
+          while (true) {
+            if (
+              (yield* fs.exists(path.join(current, ".git"))) ||
+              (yield* fs.exists(path.join(current, "pnpm-workspace.yaml")))
+            ) {
+              return current
+            }
+            const parent = path.dirname(current)
+            if (parent === current) {
+              return yield* new ApiDiffError({
+                message: `Could not locate repository root from ${path.resolve()}`
+              })
+            }
+            current = parent
+          }
+        })
+
+        const runInternal = Effect.fnUntraced(function*(options: ApiDiffOptions) {
+          const repoRoot = yield* findRepoRoot()
+          if (options.output === undefined && options.writeDoc === undefined && !options.check) {
+            return yield* new ApiDiffError({ message: "Specify --output, --write-doc, or --check" })
+          }
+
+          const baseSha = yield* worktrees.resolveRef(repoRoot, options.baseRef)
+          const headSha = yield* (options.headRef === "main"
+            ? worktrees.resolveRef(repoRoot, "origin/main").pipe(
+              Effect.catch(() => worktrees.resolveRef(repoRoot, options.headRef))
+            )
+            : worktrees.resolveRef(repoRoot, options.headRef))
+          const toolRoot = path.join(repoRoot, "tmp", "api-diff")
+          const cacheRoot = path.join(toolRoot, "cache")
+          const worktreesRoot = path.join(toolRoot, "worktrees")
+          yield* Console.log(
+            `Base ${options.baseRef}: ${baseSha}\nHead ${options.headRef}: ${headSha}`
+          )
+          const base = yield* worktrees.prepareSnapshot({
+            repoRoot,
+            cacheRoot,
+            worktreesRoot,
+            name: "base",
+            ref: options.baseRef,
+            sha: baseSha
+          })
+          const head = yield* worktrees.prepareSnapshot({
+            repoRoot,
+            cacheRoot,
+            worktreesRoot,
+            name: "head",
+            ref: options.headRef,
+            sha: headSha
+          })
+          const diff = diffSnapshots(base, head)
+
+          if (options.output !== undefined) {
+            const output = absolute(repoRoot, options.output)
+            yield* fs.makeDirectory(output, { recursive: true })
+            yield* fs.writeFileString(path.join(output, "base.snapshot.json"), prettyJson(base))
+            yield* fs.writeFileString(path.join(output, "head.snapshot.json"), prettyJson(head))
+            yield* fs.writeFileString(path.join(output, "diff.json"), prettyJson(diff))
+            yield* fs.writeFileString(path.join(output, "report.md"), renderMarkdownReport(diff))
+            yield* Console.log(`Wrote ${path.relative(repoRoot, output)} (${diff.changes.length} changes)`)
+          }
+
+          if (options.writeDoc !== undefined || options.check) {
+            const annotations = yield* loadAnnotations(path.join(repoRoot, "migration", "annotations")).pipe(
+              Effect.provideService(FileSystem.FileSystem, fs),
+              Effect.provideService(Path.Path, path)
+            )
+            const documentPath = options.writeDoc === undefined
+              ? path.join(repoRoot, "migration", "v3-to-v4.md")
+              : absolute(repoRoot, options.writeDoc)
+            const existing = (yield* fs.exists(documentPath)) ? yield* fs.readFileString(documentPath) : ""
+            const importMapSections = extractImportMapSections(existing)
+            let documentForCheck = existing
+            if (options.writeDoc !== undefined) {
+              const document = renderMigrationDocument(diff, annotations, importMapSections)
+              const unsafeMarkdown = markdownSafetyIssues(document)
+              if (unsafeMarkdown.length > 0) {
+                return yield* new ApiDiffError({
+                  message: `Generated migration document has unsafe Markdown:\n${unsafeMarkdown.join("\n")}`
+                })
+              }
+              documentForCheck = document
+              yield* fs.makeDirectory(path.dirname(documentPath), { recursive: true })
+              yield* fs.writeFileString(documentPath, document)
+              yield* Console.log(`Wrote ${path.relative(repoRoot, documentPath)} (${diff.changes.length} changes)`)
+            }
+            if (options.check) {
+              const unsafeMarkdown = markdownSafetyIssues(documentForCheck)
+              if (unsafeMarkdown.length > 0) {
+                return yield* new ApiDiffError({
+                  message: `Migration document has unsafe Markdown:\n${unsafeMarkdown.join("\n")}`
+                })
+              }
+              const missingApis = unannotatedApiIds(diff, annotations, importMapSections)
+              const missingModules = unannotatedModuleIds(diff, annotations, importMapSections)
+              yield* Console.log(renderMissingAnnotations(diff, annotations, importMapSections).trimEnd())
+              if (missingApis.size > 0 || missingModules.length > 0) {
+                return yield* new ApiDiffError({
+                  message: `${missingApis.size} API groups and ${missingModules.length} modules need migration guidance`
+                })
+              }
+            }
+          }
+        })
+
+        const run = (options: ApiDiffOptions): Effect.Effect<void, ApiDiffError> =>
+          runInternal(options).pipe(
+            Effect.mapError((cause) =>
+              isApiDiffError(cause)
+                ? cause
+                : new ApiDiffError({
+                  message: "API diff failed",
+                  cause
+                })
+            )
+          )
+
+        return service.of({
+          [ApiDiffTypeId]: ApiDiffTypeId as typeof ApiDiffTypeId,
+          run
+        })
+      })
+    )
+  })
+  const service2 = Object.assign(service1, {
+    layer: service1.layerNoDependencies.pipe(
+      Layer.provide(Worktrees.layer)
+    )
+  })
+  return service2
+})()

--- a/packages/tools/api-diff/src/Discovery.ts
+++ b/packages/tools/api-diff/src/Discovery.ts
@@ -61,182 +61,200 @@ const matchPattern = (pattern: string, value: string): string | undefined => {
     : undefined
 }
 
-export class Discovery extends Context.Service<Discovery, {
+const DiscoveryTypeId = "~@effect/api-diff/Discovery"
+
+export interface Discovery {
+  readonly [DiscoveryTypeId]: typeof DiscoveryTypeId
+
   readonly discoverEntrypoints: (
     repoRoot: string,
     requestedModules?: ReadonlyArray<string>
   ) => Effect.Effect<DiscoveryResult, ApiDiffError>
-}>()("@effect/api-diff/Discovery") {
-  static readonly layer = Layer.effect(
-    Discovery,
-    Effect.gen(function*() {
-      const fs = yield* FileSystem.FileSystem
-      const path = yield* Path.Path
+}
 
-      const readManifest = Effect.fnUntraced(function*(location: string) {
-        const source = yield* fs.readFileString(location)
-        return yield* decodePackageManifest(source)
-      })
+/**
+ * Service key for `Discovery` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Discovery = (() => {
+  const service = Context.Service<Discovery>("@effect/api-diff/Discovery")
+  return Object.assign(service, {
+    layer: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        const fs = yield* FileSystem.FileSystem
+        const path = yield* Path.Path
 
-      const walk = Effect.fnUntraced(function*(
-        root: string,
-        predicate: (location: string) => boolean
-      ) {
-        const output: Array<string> = []
-        const visit: (directory: string) => Effect.Effect<void, PlatformError.PlatformError> = Effect.fnUntraced(
-          function*(directory: string) {
-            const entries = yield* fs.readDirectory(directory)
-            for (const entry of entries) {
-              if (entry === "node_modules" || entry === ".git") {
-                continue
-              }
-              const location = path.join(directory, entry)
-              const info = yield* fs.stat(location)
-              if (info.type === "Directory") {
-                yield* visit(location)
-              } else if (predicate(location)) {
-                output.push(location)
+        const readManifest = Effect.fnUntraced(function*(location: string) {
+          const source = yield* fs.readFileString(location)
+          return yield* decodePackageManifest(source)
+        })
+
+        const walk = Effect.fnUntraced(function*(
+          root: string,
+          predicate: (location: string) => boolean
+        ) {
+          const output: Array<string> = []
+          const visit: (directory: string) => Effect.Effect<void, PlatformError.PlatformError> = Effect.fnUntraced(
+            function*(directory: string) {
+              const entries = yield* fs.readDirectory(directory)
+              for (const entry of entries) {
+                if (entry === "node_modules" || entry === ".git") {
+                  continue
+                }
+                const location = path.join(directory, entry)
+                const info = yield* fs.stat(location)
+                if (info.type === "Directory") {
+                  yield* visit(location)
+                } else if (predicate(location)) {
+                  output.push(location)
+                }
               }
             }
-          }
-        )
-        if (yield* fs.exists(root)) {
-          yield* visit(root)
-        }
-        return output.sort()
-      })
-
-      const packagesIn = Effect.fnUntraced(function*(repoRoot: string) {
-        const manifestPaths = yield* walk(
-          path.join(repoRoot, "packages"),
-          (location) => location.endsWith(`${path.sep}package.json`)
-        )
-        const packages: Array<PackageInfo> = []
-        for (const manifestPath of manifestPaths) {
-          const sourceRoot = path.dirname(manifestPath)
-          if (
-            path.basename(sourceRoot) === "dist" &&
-            (yield* fs.exists(path.join(path.dirname(sourceRoot), "package.json")))
-          ) {
-            continue
-          }
-          const packedPath = path.join(sourceRoot, "dist", "package.json")
-          const packed = yield* fs.exists(packedPath)
-          const manifest = yield* readManifest(packed ? packedPath : manifestPath)
-          if (manifest.name === undefined || manifest.private === true) {
-            continue
-          }
-          packages.push({
-            name: manifest.name,
-            root: packed ? path.join(sourceRoot, "dist") : sourceRoot,
-            exports: packed ? manifest.exports : (manifest.publishConfig?.exports ?? manifest.exports),
-            manifest
-          })
-        }
-        return packages.sort((left, right) => right.name.length - left.name.length)
-      })
-
-      const targetToDeclaration = (packageInfo: PackageInfo, target: string): string | undefined => {
-        const relativeTarget = target.replace(/^\.\//, "")
-        const declaration = relativeTarget.endsWith(".d.ts")
-          ? relativeTarget
-          : relativeTarget.replace(/\.(?:mjs|cjs|js|mts|cts|ts)$/, ".d.ts")
-        return declaration.endsWith(".d.ts") ? path.resolve(packageInfo.root, declaration) : undefined
-      }
-
-      const expandPattern = Effect.fnUntraced(function*(
-        packageInfo: PackageInfo,
-        keyPattern: string,
-        targetPattern: string,
-        requested: ReadonlySet<string> | undefined,
-        exportsMap: Readonly<Record<string, unknown>>
-      ) {
-        const candidates = yield* walk(packageInfo.root, (location) => location.endsWith(".d.ts"))
-        const targetNormalized = targetPattern.endsWith(".d.ts")
-          ? targetPattern
-          : targetPattern.replace(/\.(?:mjs|cjs|js|mts|cts|ts)$/, ".d.ts")
-        const entries: Array<Entrypoint> = []
-        for (const declarationFile of candidates) {
-          const relativeFile = `./${path.relative(packageInfo.root, declarationFile).split(path.sep).join("/")}`
-          const capture = matchPattern(targetNormalized, relativeFile)
-          if (capture === undefined) {
-            continue
-          }
-          const key = keyPattern.replace("*", capture)
-          const module = key === "." ? packageInfo.name : `${packageInfo.name}${key.slice(1)}`
-          const excluded = Object.entries(exportsMap).some(([excludedKey, excludedTarget]) =>
-            excludedTarget === null && matchPattern(excludedKey, key) !== undefined
           )
-          if (!excluded && (requested === undefined || requested.has(module))) {
-            entries.push({ packageName: packageInfo.name, module, declarationFile })
+          if (yield* fs.exists(root)) {
+            yield* visit(root)
           }
-        }
-        return entries
-      })
+          return output.sort()
+        })
 
-      const discoverEntrypointsInternal = Effect.fnUntraced(function*(
-        repoRoot: string,
-        requestedModules?: ReadonlyArray<string>
-      ) {
-        const packages = yield* packagesIn(repoRoot)
-        const requested = requestedModules === undefined ? undefined : new Set(requestedModules)
-        const output = new Map<string, Entrypoint>()
-
-        for (const packageInfo of packages) {
-          if (typeof packageInfo.exports !== "object" || packageInfo.exports === null) {
-            continue
-          }
-          const exportsMap = packageInfo.exports as Record<string, unknown>
-          for (const [keyPattern, rawTarget] of Object.entries(exportsMap)) {
-            const target = exportedTarget(rawTarget)
+        const packagesIn = Effect.fnUntraced(function*(repoRoot: string) {
+          const manifestPaths = yield* walk(
+            path.join(repoRoot, "packages"),
+            (location) => location.endsWith(`${path.sep}package.json`)
+          )
+          const packages: Array<PackageInfo> = []
+          for (const manifestPath of manifestPaths) {
+            const sourceRoot = path.dirname(manifestPath)
             if (
-              !keyPattern.includes("*") &&
-              typeof target === "string" &&
-              (requested === undefined || requested.has(
-                keyPattern === "." ? packageInfo.name : `${packageInfo.name}${keyPattern.slice(1)}`
-              ))
+              path.basename(sourceRoot) === "dist" &&
+              (yield* fs.exists(path.join(path.dirname(sourceRoot), "package.json")))
             ) {
-              const module = keyPattern === "." ? packageInfo.name : `${packageInfo.name}${keyPattern.slice(1)}`
-              const declarationFile = targetToDeclaration(packageInfo, target)
-              if (
-                declarationFile !== undefined &&
-                !output.has(module) &&
-                (yield* fs.exists(declarationFile)) &&
-                (yield* fs.stat(declarationFile)).type === "File"
-              ) {
-                output.set(module, { packageName: packageInfo.name, module, declarationFile })
-              }
+              continue
             }
-            if (keyPattern.includes("*") && typeof target === "string" && target.includes("*")) {
-              for (const entry of yield* expandPattern(packageInfo, keyPattern, target, requested, exportsMap)) {
-                if (!output.has(entry.module)) {
-                  output.set(entry.module, entry)
+            const packedPath = path.join(sourceRoot, "dist", "package.json")
+            const packed = yield* fs.exists(packedPath)
+            const manifest = yield* readManifest(packed ? packedPath : manifestPath)
+            if (manifest.name === undefined || manifest.private === true) {
+              continue
+            }
+            packages.push({
+              name: manifest.name,
+              root: packed ? path.join(sourceRoot, "dist") : sourceRoot,
+              exports: packed ? manifest.exports : (manifest.publishConfig?.exports ?? manifest.exports),
+              manifest
+            })
+          }
+          return packages.sort((left, right) => right.name.length - left.name.length)
+        })
+
+        const targetToDeclaration = (packageInfo: PackageInfo, target: string): string | undefined => {
+          const relativeTarget = target.replace(/^\.\//, "")
+          const declaration = relativeTarget.endsWith(".d.ts")
+            ? relativeTarget
+            : relativeTarget.replace(/\.(?:mjs|cjs|js|mts|cts|ts)$/, ".d.ts")
+          return declaration.endsWith(".d.ts") ? path.resolve(packageInfo.root, declaration) : undefined
+        }
+
+        const expandPattern = Effect.fnUntraced(function*(
+          packageInfo: PackageInfo,
+          keyPattern: string,
+          targetPattern: string,
+          requested: ReadonlySet<string> | undefined,
+          exportsMap: Readonly<Record<string, unknown>>
+        ) {
+          const candidates = yield* walk(packageInfo.root, (location) => location.endsWith(".d.ts"))
+          const targetNormalized = targetPattern.endsWith(".d.ts")
+            ? targetPattern
+            : targetPattern.replace(/\.(?:mjs|cjs|js|mts|cts|ts)$/, ".d.ts")
+          const entries: Array<Entrypoint> = []
+          for (const declarationFile of candidates) {
+            const relativeFile = `./${path.relative(packageInfo.root, declarationFile).split(path.sep).join("/")}`
+            const capture = matchPattern(targetNormalized, relativeFile)
+            if (capture === undefined) {
+              continue
+            }
+            const key = keyPattern.replace("*", capture)
+            const module = key === "." ? packageInfo.name : `${packageInfo.name}${key.slice(1)}`
+            const excluded = Object.entries(exportsMap).some(([excludedKey, excludedTarget]) =>
+              excludedTarget === null && matchPattern(excludedKey, key) !== undefined
+            )
+            if (!excluded && (requested === undefined || requested.has(module))) {
+              entries.push({ packageName: packageInfo.name, module, declarationFile })
+            }
+          }
+          return entries
+        })
+
+        const discoverEntrypointsInternal = Effect.fnUntraced(function*(
+          repoRoot: string,
+          requestedModules?: ReadonlyArray<string>
+        ) {
+          const packages = yield* packagesIn(repoRoot)
+          const requested = requestedModules === undefined ? undefined : new Set(requestedModules)
+          const output = new Map<string, Entrypoint>()
+
+          for (const packageInfo of packages) {
+            if (typeof packageInfo.exports !== "object" || packageInfo.exports === null) {
+              continue
+            }
+            const exportsMap = packageInfo.exports as Record<string, unknown>
+            for (const [keyPattern, rawTarget] of Object.entries(exportsMap)) {
+              const target = exportedTarget(rawTarget)
+              if (
+                !keyPattern.includes("*") &&
+                typeof target === "string" &&
+                (requested === undefined || requested.has(
+                  keyPattern === "." ? packageInfo.name : `${packageInfo.name}${keyPattern.slice(1)}`
+                ))
+              ) {
+                const module = keyPattern === "." ? packageInfo.name : `${packageInfo.name}${keyPattern.slice(1)}`
+                const declarationFile = targetToDeclaration(packageInfo, target)
+                if (
+                  declarationFile !== undefined &&
+                  !output.has(module) &&
+                  (yield* fs.exists(declarationFile)) &&
+                  (yield* fs.stat(declarationFile)).type === "File"
+                ) {
+                  output.set(module, { packageName: packageInfo.name, module, declarationFile })
+                }
+              }
+              if (keyPattern.includes("*") && typeof target === "string" && target.includes("*")) {
+                for (const entry of yield* expandPattern(packageInfo, keyPattern, target, requested, exportsMap)) {
+                  if (!output.has(entry.module)) {
+                    output.set(entry.module, entry)
+                  }
                 }
               }
             }
           }
-        }
 
-        return {
-          entrypoints: [...output.values()].sort((left, right) => left.module.localeCompare(right.module)),
-          missing: requestedModules?.filter((module) => !output.has(module)).sort() ?? []
-        }
-      })
+          return {
+            entrypoints: [...output.values()].sort((left, right) => left.module.localeCompare(right.module)),
+            missing: requestedModules?.filter((module) => !output.has(module)).sort() ?? []
+          }
+        })
 
-      const discoverEntrypoints = (
-        repoRoot: string,
-        requestedModules?: ReadonlyArray<string>
-      ): Effect.Effect<DiscoveryResult, ApiDiffError> =>
-        discoverEntrypointsInternal(repoRoot, requestedModules).pipe(
-          Effect.mapError((cause) =>
-            new ApiDiffError({
-              message: `Could not discover API entrypoints in ${repoRoot}`,
-              cause
-            })
+        const discoverEntrypoints = (
+          repoRoot: string,
+          requestedModules?: ReadonlyArray<string>
+        ): Effect.Effect<DiscoveryResult, ApiDiffError> =>
+          discoverEntrypointsInternal(repoRoot, requestedModules).pipe(
+            Effect.mapError((cause) =>
+              new ApiDiffError({
+                message: `Could not discover API entrypoints in ${repoRoot}`,
+                cause
+              })
+            )
           )
-        )
 
-      return Discovery.of({ discoverEntrypoints })
-    })
-  )
-}
+        return service.of({
+          [DiscoveryTypeId]: DiscoveryTypeId as typeof DiscoveryTypeId,
+          discoverEntrypoints
+        })
+      })
+    )
+  })
+})()

--- a/packages/tools/api-diff/src/Snapshot.ts
+++ b/packages/tools/api-diff/src/Snapshot.ts
@@ -869,37 +869,57 @@ export const snapshotCacheKey = (
     modules === undefined ? "all" : [...modules].sort()
   ])
 
-export class Snapshotter extends Context.Service<Snapshotter, {
+const SnapshotterTypeId = "~@effect/api-diff/Snapshotter"
+
+export interface Snapshotter {
+  readonly [SnapshotterTypeId]: typeof SnapshotterTypeId
+
   readonly extract: (options: ExtractSnapshotOptions) => Effect.Effect<
     ApiSnapshot,
     ApiDiffError | SnapshotExtractionError
   >
-}>()("@effect/api-diff/Snapshotter") {
-  static readonly layerNoDependencies = Layer.effect(
-    Snapshotter,
-    Effect.gen(function*() {
-      const discovery = yield* Discovery
-      const path = yield* Path.Path
+}
 
-      const extract = Effect.fnUntraced(function*(options: ExtractSnapshotOptions) {
-        const discovered = yield* discovery.discoverEntrypoints(options.repoRoot, options.modules)
-        return yield* Effect.try({
-          try: () => extractSnapshot(options, discovered, path),
-          catch: (cause) =>
-            isSnapshotExtractionError(cause)
-              ? cause
-              : new ApiDiffError({
-                message: `Could not extract the API snapshot for ${options.ref}`,
-                cause
-              })
+/**
+ * Service key for `Snapshotter` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Snapshotter = (() => {
+  const service = Context.Service<Snapshotter>("@effect/api-diff/Snapshotter")
+  const service1 = Object.assign(service, {
+    layerNoDependencies: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        const discovery = yield* Discovery
+        const path = yield* Path.Path
+
+        const extract = Effect.fnUntraced(function*(options: ExtractSnapshotOptions) {
+          const discovered = yield* discovery.discoverEntrypoints(options.repoRoot, options.modules)
+          return yield* Effect.try({
+            try: () => extractSnapshot(options, discovered, path),
+            catch: (cause) =>
+              isSnapshotExtractionError(cause)
+                ? cause
+                : new ApiDiffError({
+                  message: `Could not extract the API snapshot for ${options.ref}`,
+                  cause
+                })
+          })
+        })
+
+        return service.of({
+          [SnapshotterTypeId]: SnapshotterTypeId as typeof SnapshotterTypeId,
+          extract
         })
       })
-
-      return Snapshotter.of({ extract })
-    })
-  )
-
-  static readonly layer = this.layerNoDependencies.pipe(
-    Layer.provide(Discovery.layer)
-  )
-}
+    )
+  })
+  const service2 = Object.assign(service1, {
+    layer: service1.layerNoDependencies.pipe(
+      Layer.provide(Discovery.layer)
+    )
+  })
+  return service2
+})()

--- a/packages/tools/api-diff/src/Worktrees.ts
+++ b/packages/tools/api-diff/src/Worktrees.ts
@@ -22,222 +22,242 @@ export interface PrepareSnapshotOptions {
   readonly modules?: ReadonlyArray<string>
 }
 
-export class Worktrees extends Context.Service<Worktrees, {
+const WorktreesTypeId = "~@effect/api-diff/Worktrees"
+
+export interface Worktrees {
+  readonly [WorktreesTypeId]: typeof WorktreesTypeId
+
   readonly resolveRef: (repoRoot: string, ref: string) => Effect.Effect<string, ApiDiffError>
   readonly prepareSnapshot: (options: PrepareSnapshotOptions) => Effect.Effect<ApiSnapshot, ApiDiffError>
-}>()("@effect/api-diff/Worktrees") {
-  static readonly layerNoDependencies = Layer.effect(
-    Worktrees,
-    Effect.gen(function*() {
-      const fs = yield* FileSystem.FileSystem
-      const path = yield* Path.Path
-      const snapshotter = yield* Snapshotter
-      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+}
 
-      const runCommandScoped = Effect.fnUntraced(function*(
-        command: string,
-        args: ReadonlyArray<string>,
-        cwd: string
-      ) {
-        const display = `${command} ${args.join(" ")}`
-        const handle = yield* spawner.spawn(
-          ChildProcess.make(command, args, { cwd })
-        ).pipe(
-          Effect.mapError((cause) =>
-            new ApiDiffError({
-              message: `Could not start command (${display})`,
-              cause
-            })
+/**
+ * Service key for `Worktrees` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Worktrees = (() => {
+  const service = Context.Service<Worktrees>("@effect/api-diff/Worktrees")
+  const service1 = Object.assign(service, {
+    layerNoDependencies: Layer.effect(
+      service,
+      Effect.gen(function*() {
+        const fs = yield* FileSystem.FileSystem
+        const path = yield* Path.Path
+        const snapshotter = yield* Snapshotter
+        const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+
+        const runCommandScoped = Effect.fnUntraced(function*(
+          command: string,
+          args: ReadonlyArray<string>,
+          cwd: string
+        ) {
+          const display = `${command} ${args.join(" ")}`
+          const handle = yield* spawner.spawn(
+            ChildProcess.make(command, args, { cwd })
+          ).pipe(
+            Effect.mapError((cause) =>
+              new ApiDiffError({
+                message: `Could not start command (${display})`,
+                cause
+              })
+            )
           )
-        )
-        const [output, exitCode] = yield* Effect.all([
-          Stream.mkString(Stream.decodeText(handle.all)),
-          handle.exitCode
-        ], { concurrency: "unbounded" }).pipe(
-          Effect.mapError((cause) =>
-            new ApiDiffError({
-              message: `Could not run command (${display})`,
-              cause
-            })
+          const [output, exitCode] = yield* Effect.all([
+            Stream.mkString(Stream.decodeText(handle.all)),
+            handle.exitCode
+          ], { concurrency: "unbounded" }).pipe(
+            Effect.mapError((cause) =>
+              new ApiDiffError({
+                message: `Could not run command (${display})`,
+                cause
+              })
+            )
           )
-        )
-        return { display, exitCode, output }
-      })
+          return { display, exitCode, output }
+        })
 
-      const runCommand = (
-        command: string,
-        args: ReadonlyArray<string>,
-        cwd: string
-      ): Effect.Effect<{
-        readonly display: string
-        readonly exitCode: ChildProcessSpawner.ExitCode
-        readonly output: string
-      }, ApiDiffError> => Effect.scoped(runCommandScoped(command, args, cwd))
+        const runCommand = (
+          command: string,
+          args: ReadonlyArray<string>,
+          cwd: string
+        ): Effect.Effect<{
+          readonly display: string
+          readonly exitCode: ChildProcessSpawner.ExitCode
+          readonly output: string
+        }, ApiDiffError> => Effect.scoped(runCommandScoped(command, args, cwd))
 
-      const runChecked = Effect.fnUntraced(function*(
-        command: string,
-        args: ReadonlyArray<string>,
-        cwd: string
-      ) {
-        const result = yield* runCommand(command, args, cwd)
-        if (result.exitCode !== ChildProcessSpawner.ExitCode(0)) {
-          return yield* new ApiDiffError({
-            message: `Command failed (${result.display}):\n${result.output}`.trim()
-          })
-        }
-        return result.output.trim()
-      })
-
-      const enableStripInternal = Effect.fnUntraced(function*(worktree: string) {
-        const baseConfig = path.join(worktree, "tsconfig.base.json")
-        if (!(yield* fs.exists(baseConfig))) {
-          return
-        }
-        const source = yield* fs.readFileString(baseConfig)
-        if (/"stripInternal"\s*:\s*true/.test(source)) {
-          return
-        }
-        const updated = source.replace(/("stripInternal"\s*:\s*)false/, "$1true")
-        if (updated !== source) {
-          yield* fs.writeFileString(baseConfig, updated)
-        }
-      })
-
-      const hasProductionStripInternal = Effect.fnUntraced(function*(worktree: string) {
-        const candidates = [
-          path.join(worktree, "tsconfig.base.json"),
-          path.join(worktree, "tsconfig.build.json"),
-          path.join(worktree, "packages", "effect", "tsconfig.build.json")
-        ]
-        for (const candidate of candidates) {
-          if ((yield* fs.exists(candidate)) && /"stripInternal"\s*:\s*true/.test(yield* fs.readFileString(candidate))) {
-            return true
+        const runChecked = Effect.fnUntraced(function*(
+          command: string,
+          args: ReadonlyArray<string>,
+          cwd: string
+        ) {
+          const result = yield* runCommand(command, args, cwd)
+          if (result.exitCode !== ChildProcessSpawner.ExitCode(0)) {
+            return yield* new ApiDiffError({
+              message: `Command failed (${result.display}):\n${result.output}`.trim()
+            })
           }
-        }
-        return false
-      })
+          return result.output.trim()
+        })
 
-      const buildWorktree = Effect.fnUntraced(function*(worktree: string) {
-        yield* enableStripInternal(worktree)
-        if (!(yield* hasProductionStripInternal(worktree))) {
-          return yield* new ApiDiffError({
-            message: `No production TypeScript configuration enables stripInternal in ${worktree}`
-          })
-        }
-        // Native test-only dependencies in old branches may not build on the
-        // current Node runtime. Declaration emission does not require dependency lifecycle scripts.
-        yield* runChecked("pnpm", ["install", "--frozen-lockfile", "--ignore-scripts"], worktree)
-        yield* runChecked("pnpm", ["build"], worktree)
-      })
+        const enableStripInternal = Effect.fnUntraced(function*(worktree: string) {
+          const baseConfig = path.join(worktree, "tsconfig.base.json")
+          if (!(yield* fs.exists(baseConfig))) {
+            return
+          }
+          const source = yield* fs.readFileString(baseConfig)
+          if (/"stripInternal"\s*:\s*true/.test(source)) {
+            return
+          }
+          const updated = source.replace(/("stripInternal"\s*:\s*)false/, "$1true")
+          if (updated !== source) {
+            yield* fs.writeFileString(baseConfig, updated)
+          }
+        })
 
-      const removeWorktree = (repoRoot: string, worktree: string): Effect.Effect<void> =>
-        runCommand("git", ["worktree", "remove", "--force", worktree], repoRoot).pipe(
-          Effect.flatMap((result) =>
-            result.exitCode === ChildProcessSpawner.ExitCode(0)
-              ? Effect.void
-              : Console.error(result.output)
-          ),
-          Effect.catch((error) => Console.error(error.message))
-        )
+        const hasProductionStripInternal = Effect.fnUntraced(function*(worktree: string) {
+          const candidates = [
+            path.join(worktree, "tsconfig.base.json"),
+            path.join(worktree, "tsconfig.build.json"),
+            path.join(worktree, "packages", "effect", "tsconfig.build.json")
+          ]
+          for (const candidate of candidates) {
+            if (
+              (yield* fs.exists(candidate)) && /"stripInternal"\s*:\s*true/.test(yield* fs.readFileString(candidate))
+            ) {
+              return true
+            }
+          }
+          return false
+        })
 
-      const resolveRef = Effect.fnUntraced(function*(repoRoot: string, ref: string) {
-        return yield* runChecked("git", ["rev-parse", "--verify", `${ref}^{commit}`], repoRoot)
-      })
+        const buildWorktree = Effect.fnUntraced(function*(worktree: string) {
+          yield* enableStripInternal(worktree)
+          if (!(yield* hasProductionStripInternal(worktree))) {
+            return yield* new ApiDiffError({
+              message: `No production TypeScript configuration enables stripInternal in ${worktree}`
+            })
+          }
+          // Native test-only dependencies in old branches may not build on the
+          // current Node runtime. Declaration emission does not require dependency lifecycle scripts.
+          yield* runChecked("pnpm", ["install", "--frozen-lockfile", "--ignore-scripts"], worktree)
+          yield* runChecked("pnpm", ["build"], worktree)
+        })
 
-      const prepareSnapshotInternal = Effect.fnUntraced(function*(options: PrepareSnapshotOptions) {
-        const key = snapshotCacheKey(options.sha, options.modules)
-        const cacheLocation = path.join(options.cacheRoot, key, "snapshot.json")
-        if (yield* fs.exists(cacheLocation)) {
-          const source = yield* fs.readFileString(cacheLocation).pipe(
-            Effect.mapError((cause) =>
-              new ApiDiffError({
-                message: `Could not read cached snapshot ${cacheLocation}`,
-                cause
-              })
-            )
+        const removeWorktree = (repoRoot: string, worktree: string): Effect.Effect<void> =>
+          runCommand("git", ["worktree", "remove", "--force", worktree], repoRoot).pipe(
+            Effect.flatMap((result) =>
+              result.exitCode === ChildProcessSpawner.ExitCode(0)
+                ? Effect.void
+                : Console.error(result.output)
+            ),
+            Effect.catch((error) => Console.error(error.message))
           )
-          const cached = (yield* decodeJson(source).pipe(
-            Effect.mapError((cause) =>
-              new ApiDiffError({
-                message: `Could not parse cached snapshot ${cacheLocation}`,
-                cause
-              })
-            )
-          )) as ApiSnapshot
-          return { ...cached, ref: options.ref, sha: options.sha }
-        }
 
-        yield* fs.makeDirectory(options.worktreesRoot, { recursive: true })
-        return yield* Effect.scoped(Effect.gen(function*() {
-          const runRoot = yield* fs.makeTempDirectoryScoped({
-            directory: options.worktreesRoot,
-            prefix: `${options.name}-`
-          })
-          const worktree = path.join(runRoot, "repo")
-          return yield* Effect.acquireUseRelease(
-            runChecked("git", ["worktree", "add", "--detach", worktree, options.sha], options.repoRoot),
-            () =>
-              Effect.gen(function*() {
-                yield* buildWorktree(worktree)
-                const snapshot = yield* snapshotter.extract({
-                  repoRoot: worktree,
-                  ref: options.ref,
-                  sha: options.sha,
-                  ...(options.modules === undefined ? {} : { modules: options.modules })
-                }).pipe(
-                  Effect.mapError((cause) =>
-                    isApiDiffError(cause)
-                      ? cause
-                      : new ApiDiffError({
-                        message: `Could not extract the ${options.name} API snapshot`,
-                        cause
-                      })
-                  )
-                )
-                let encoded: string | undefined
-                try {
-                  encoded = JSON.stringify(snapshot)
-                } catch {
-                  encoded = undefined
-                }
-                if (encoded !== undefined) {
-                  yield* fs.makeDirectory(path.dirname(cacheLocation), { recursive: true })
-                  yield* fs.writeFileString(cacheLocation, encoded).pipe(
+        const resolveRef = Effect.fnUntraced(function*(repoRoot: string, ref: string) {
+          return yield* runChecked("git", ["rev-parse", "--verify", `${ref}^{commit}`], repoRoot)
+        })
+
+        const prepareSnapshotInternal = Effect.fnUntraced(function*(options: PrepareSnapshotOptions) {
+          const key = snapshotCacheKey(options.sha, options.modules)
+          const cacheLocation = path.join(options.cacheRoot, key, "snapshot.json")
+          if (yield* fs.exists(cacheLocation)) {
+            const source = yield* fs.readFileString(cacheLocation).pipe(
+              Effect.mapError((cause) =>
+                new ApiDiffError({
+                  message: `Could not read cached snapshot ${cacheLocation}`,
+                  cause
+                })
+              )
+            )
+            const cached = (yield* decodeJson(source).pipe(
+              Effect.mapError((cause) =>
+                new ApiDiffError({
+                  message: `Could not parse cached snapshot ${cacheLocation}`,
+                  cause
+                })
+              )
+            )) as ApiSnapshot
+            return { ...cached, ref: options.ref, sha: options.sha }
+          }
+
+          yield* fs.makeDirectory(options.worktreesRoot, { recursive: true })
+          return yield* Effect.scoped(Effect.gen(function*() {
+            const runRoot = yield* fs.makeTempDirectoryScoped({
+              directory: options.worktreesRoot,
+              prefix: `${options.name}-`
+            })
+            const worktree = path.join(runRoot, "repo")
+            return yield* Effect.acquireUseRelease(
+              runChecked("git", ["worktree", "add", "--detach", worktree, options.sha], options.repoRoot),
+              () =>
+                Effect.gen(function*() {
+                  yield* buildWorktree(worktree)
+                  const snapshot = yield* snapshotter.extract({
+                    repoRoot: worktree,
+                    ref: options.ref,
+                    sha: options.sha,
+                    ...(options.modules === undefined ? {} : { modules: options.modules })
+                  }).pipe(
                     Effect.mapError((cause) =>
-                      new ApiDiffError({
-                        message: `Could not cache the ${options.name} API snapshot`,
-                        cause
-                      })
+                      isApiDiffError(cause)
+                        ? cause
+                        : new ApiDiffError({
+                          message: `Could not extract the ${options.name} API snapshot`,
+                          cause
+                        })
                     )
                   )
-                }
-                return snapshot
-              }),
-            () => removeWorktree(options.repoRoot, worktree)
+                  let encoded: string | undefined
+                  try {
+                    encoded = JSON.stringify(snapshot)
+                  } catch {
+                    encoded = undefined
+                  }
+                  if (encoded !== undefined) {
+                    yield* fs.makeDirectory(path.dirname(cacheLocation), { recursive: true })
+                    yield* fs.writeFileString(cacheLocation, encoded).pipe(
+                      Effect.mapError((cause) =>
+                        new ApiDiffError({
+                          message: `Could not cache the ${options.name} API snapshot`,
+                          cause
+                        })
+                      )
+                    )
+                  }
+                  return snapshot
+                }),
+              () => removeWorktree(options.repoRoot, worktree)
+            )
+          }))
+        })
+
+        const prepareSnapshot = (options: PrepareSnapshotOptions): Effect.Effect<ApiSnapshot, ApiDiffError> =>
+          prepareSnapshotInternal(options).pipe(
+            Effect.mapError((cause) =>
+              isApiDiffError(cause)
+                ? cause
+                : new ApiDiffError({
+                  message: `Could not prepare the ${options.name} API snapshot`,
+                  cause
+                })
+            )
           )
-        }))
+
+        return service.of({
+          [WorktreesTypeId]: WorktreesTypeId as typeof WorktreesTypeId,
+          prepareSnapshot,
+          resolveRef
+        })
       })
-
-      const prepareSnapshot = (options: PrepareSnapshotOptions): Effect.Effect<ApiSnapshot, ApiDiffError> =>
-        prepareSnapshotInternal(options).pipe(
-          Effect.mapError((cause) =>
-            isApiDiffError(cause)
-              ? cause
-              : new ApiDiffError({
-                message: `Could not prepare the ${options.name} API snapshot`,
-                cause
-              })
-          )
-        )
-
-      return Worktrees.of({
-        prepareSnapshot,
-        resolveRef
-      })
-    })
-  )
-
-  static readonly layer = this.layerNoDependencies.pipe(
-    Layer.provide(Snapshotter.layer)
-  )
-}
+    )
+  })
+  const service2 = Object.assign(service1, {
+    layer: service1.layerNoDependencies.pipe(
+      Layer.provide(Snapshotter.layer)
+    )
+  })
+  return service2
+})()

--- a/packages/tools/api-diff/test/Cli.test.ts
+++ b/packages/tools/api-diff/test/Cli.test.ts
@@ -25,6 +25,7 @@ const snapshot = (ref: string, sha: string, entities: ReadonlyArray<ApiEntity> =
 const WorktreesTest = Layer.succeed(
   Worktrees,
   Worktrees.of({
+    ["~@effect/api-diff/Worktrees"]: "~@effect/api-diff/Worktrees" as const,
     resolveRef: (_repoRoot, ref) => Effect.succeed(ref.repeat(40).slice(0, 40)),
     prepareSnapshot: (options) => Effect.succeed(snapshot(options.ref, options.sha))
   })
@@ -54,6 +55,7 @@ const CheckLayer = ApiDiff.layerNoDependencies.pipe(
   Layer.provide(Layer.succeed(
     Worktrees,
     Worktrees.of({
+      ["~@effect/api-diff/Worktrees"]: "~@effect/api-diff/Worktrees" as const,
       resolveRef: (_repoRoot, ref) => Effect.succeed(ref.repeat(40).slice(0, 40)),
       prepareSnapshot: (options) =>
         Effect.succeed(snapshot(options.ref, options.sha, options.name === "base" ? [removed] : []))

--- a/packages/tools/api-diff/test/Worktrees.test.ts
+++ b/packages/tools/api-diff/test/Worktrees.test.ts
@@ -26,7 +26,10 @@ const snapshot = {
 
 const SnapshotterTest = Layer.succeed(
   Snapshotter,
-  Snapshotter.of({ extract: () => Effect.succeed(snapshot) })
+  Snapshotter.of({
+    ["~@effect/api-diff/Snapshotter"]: "~@effect/api-diff/Snapshotter" as const,
+    extract: () => Effect.succeed(snapshot)
+  })
 )
 
 const ChildProcessSpawnerTest = Layer.succeed(

--- a/packages/tools/bundle/src/Fixtures.ts
+++ b/packages/tools/bundle/src/Fixtures.ts
@@ -24,29 +24,40 @@ import * as Order from "effect/Order"
 import * as Glob from "glob"
 import { fileURLToPath } from "node:url"
 
+const FixturesTypeId = "~@effect/bundle/Fixtures"
+const FixturesMake = Effect.gen(function*() {
+  const fixturesDir = fileURLToPath(new URL("../fixtures/", import.meta.url))
+
+  const fixtures = yield* Effect.promise(() => Glob.glob("*.ts", { cwd: fixturesDir })).pipe(
+    Effect.map(Array.sort(Order.String)),
+    Effect.orDie
+  )
+
+  return {
+    [FixturesTypeId]: FixturesTypeId as typeof FixturesTypeId,
+    fixtures,
+    fixturesDir
+  } as const
+})
+type FixturesShape = Effect.Success<typeof FixturesMake>
+
 /**
  * Context service that discovers and sorts TypeScript fixture files used by the bundle size tooling.
  *
  * @category services
  * @since 4.0.0
  */
-export class Fixtures extends Context.Service<Fixtures>()(
-  "@effect/bundle/Fixtures",
-  {
-    make: Effect.gen(function*() {
-      const fixturesDir = fileURLToPath(new URL("../fixtures/", import.meta.url))
-
-      const fixtures = yield* Effect.promise(() => Glob.glob("*.ts", { cwd: fixturesDir })).pipe(
-        Effect.map(Array.sort(Order.String)),
-        Effect.orDie
-      )
-
-      return {
-        fixtures,
-        fixturesDir
-      } as const
-    })
-  }
-) {
-  static readonly layer = Layer.effect(this, this.make)
+export interface Fixtures extends FixturesShape {
+  readonly [FixturesTypeId]: typeof FixturesTypeId
 }
+
+/**
+ * Service key for `Fixtures` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Fixtures = (() => {
+  const service = Object.assign(Context.Service<Fixtures>("@effect/bundle/Fixtures"), { make: FixturesMake })
+  return Object.assign(service, { layer: Layer.effect(service, service.make) })
+})()

--- a/packages/tools/bundle/src/Reporter.ts
+++ b/packages/tools/bundle/src/Reporter.ts
@@ -80,212 +80,225 @@ export interface ReportSelectedComparisonOptions {
   readonly paths: ReadonlyArray<string>
 }
 
+const ReporterTypeId = "~@effect/bundle/Reporter"
+const ReporterMake = Effect.gen(function*() {
+  const fs = yield* FileSystem.FileSystem
+  const path = yield* Path.Path
+  const { fixtures, fixturesDir } = yield* Fixtures
+  const rollup = yield* Rollup
+  const currentDirectory = path.resolve(fileURLToPath(new URL("../../../../", import.meta.url)))
+
+  const calculateDifference = (current: BundleStats, previous: BundleStats) => {
+    const currSize = current.sizeInBytes
+    const prevSize = previous.sizeInBytes
+    const diff = currSize - prevSize
+    const diffPct = prevSize === 0 ? 0 : (Math.abs(diff) / prevSize) * 100
+    const currKb = (currSize / 1000).toFixed(2)
+    const prevKb = (prevSize / 1000).toFixed(2)
+    const diffKb = (Math.abs(diff) / 1000).toFixed(2)
+    const filename = path.basename(current.path)
+    return {
+      diff,
+      diffPct,
+      currKb,
+      prevKb,
+      diffKb,
+      filename
+    }
+  }
+
+  const createComparisonReport = (
+    entries: ReadonlyArray<{
+      readonly current: BundleStats
+      readonly previous: BundleStats
+      readonly filename: string
+    }>
+  ): string => {
+    const lines: Array<string> = [
+      "| File Name | Current Size | Previous Size | Difference |",
+      "|:----------|:------------:|:-------------:|:----------:|"
+    ]
+    for (const { current, previous, filename } of entries) {
+      const comparison = calculateDifference(current, previous)
+      const currKb = `${comparison.currKb} KB`
+      const prevKb = `${comparison.prevKb} KB`
+      const diffKb = `${comparison.diffKb} KB`
+      const diffPct = `${comparison.diffPct.toFixed(2)}%`
+      const sign = comparison.diff === 0 ? "" : comparison.diff > 0 ? "+" : "-"
+      const line = `| \`${filename}\` | ${currKb} | ${prevKb} | ${sign}${diffKb} (${sign}${diffPct}) |`
+      lines.push(line)
+    }
+    return lines.join("\n") + "\n"
+  }
+
+  const createReport = (curr: ReadonlyArray<BundleStats>, prev: ReadonlyArray<BundleStats>): string => {
+    const entries: Array<{
+      readonly current: BundleStats
+      readonly previous: BundleStats
+      readonly filename: string
+    }> = []
+    for (const current of curr) {
+      const previous = prev.find((previous) => {
+        return path.basename(previous.path) === path.basename(current.path)
+      }) ?? current
+      entries.push({
+        current,
+        previous,
+        filename: path.basename(current.path)
+      })
+    }
+    return createComparisonReport(entries)
+  }
+
+  const createSelectedReport = (stats: ReadonlyArray<BundleStats>): string => {
+    const lines: Array<string> = [
+      "| File Name | Current Size |",
+      "|:----------|:------------:|"
+    ]
+
+    for (const current of stats) {
+      const filename = `\`${path.basename(current.path)}\``
+      const currKb = `${(current.sizeInBytes / 1000).toFixed(2)} KB`
+      const line = `| ${filename} | ${currKb} |`
+      lines.push(line)
+    }
+
+    return lines.join("\n") + "\n"
+  }
+
+  const createVisualizationReport = (paths: ReadonlyArray<string>, outputDirectory: string): string => {
+    const lines: Array<string> = [
+      "| File Name | Generated Bundle | Treemap | Raw Data |",
+      "|:----------|:----------------|:--------|:---------|"
+    ]
+    for (const entryPath of paths) {
+      const name = path.parse(entryPath).name
+      const filename = path.relative(currentDirectory, path.resolve(entryPath))
+      const minified = path.join(outputDirectory, `${name}.min.js`)
+      const treemap = path.join(outputDirectory, `${name}.treemap.html`)
+      const rawData = path.join(outputDirectory, `${name}.raw-data.json`)
+      lines.push(`| \`${filename}\` | \`${minified}\` | \`${treemap}\` | \`${rawData}\` |`)
+    }
+    return lines.join("\n") + "\n"
+  }
+
+  const report = Effect.fn("Reporter.report")(
+    function*(options: ReportOptions) {
+      yield* Effect.logInfo(`Found ${fixtures.length} files to bundle`)
+
+      const currentPaths = fixtures.map((fixture) => path.join(fixturesDir, fixture))
+      const previousPaths = yield* Effect.filter(
+        fixtures.map((fixture) => path.join(options.baseDirectory, fixture)),
+        (previousPath) => fs.exists(previousPath).pipe(Effect.orElseSucceed(constFalse)),
+        { concurrency: fixtures.length }
+      )
+
+      const currentStats = yield* rollup.bundleAll({ paths: currentPaths })
+      const previousStats = yield* rollup.bundleAll({ paths: previousPaths })
+
+      yield* Effect.logInfo("Bundling complete! Generating bundle size report...")
+
+      return createReport(currentStats, previousStats)
+    }
+  )
+
+  const visualize = Effect.fn("Reporter.visualize")(
+    function*(options: VisualizeOptions) {
+      yield* fs.makeDirectory(options.outputDirectory, { recursive: true })
+      yield* rollup.bundleAll({
+        paths: options.paths,
+        outputDirectory: options.outputDirectory,
+        visualize: true
+      })
+      return createVisualizationReport(options.paths, options.outputDirectory)
+    }
+  )
+
+  const reportSelected = Effect.fn("Reporter.reportSelected")(
+    function*(options: ReportSelectedOptions) {
+      yield* Effect.logInfo(`Found ${options.paths.length} files to bundle`)
+      const stats = yield* rollup.bundleAll({ paths: options.paths })
+      yield* Effect.logInfo("Bundling complete! Generating bundle size report...")
+      return createSelectedReport(stats)
+    }
+  )
+
+  const reportSelectedComparison = Effect.fn("Reporter.reportSelectedComparison")(
+    function*(options: ReportSelectedComparisonOptions) {
+      yield* Effect.logInfo(`Found ${options.paths.length} files to compare`)
+      const baseDirectory = path.resolve(options.baseDirectory)
+      const currentPaths = options.paths.map((currentPath) => path.resolve(currentPath))
+      const previousPaths = yield* Effect.forEach(
+        currentPaths,
+        Effect.fnUntraced(function*(currentPath) {
+          const relativePath = path.relative(currentDirectory, currentPath)
+          if (relativePath === "" || relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+            return yield* Effect.fail(
+              new ReporterError({
+                cause: `Selected bundle entry must be inside ${currentDirectory}: ${currentPath}`
+              })
+            )
+          }
+          const previousPath = path.join(baseDirectory, relativePath)
+          yield* fs.makeDirectory(path.dirname(previousPath), { recursive: true })
+          yield* fs.copy(currentPath, previousPath, { overwrite: true })
+          return previousPath
+        }),
+        { concurrency: currentPaths.length }
+      )
+
+      const currentStats = yield* rollup.bundleAll({ paths: currentPaths })
+      const previousStats = yield* rollup.bundleAll({ paths: previousPaths })
+
+      const entries: Array<{
+        readonly current: BundleStats
+        readonly previous: BundleStats
+        readonly filename: string
+      }> = []
+      for (let i = 0; i < currentStats.length; i++) {
+        entries.push({
+          current: currentStats[i]!,
+          previous: previousStats[i]!,
+          filename: path.relative(currentDirectory, currentStats[i]!.path)
+        })
+      }
+      yield* Effect.logInfo("Bundling complete! Generating bundle size report...")
+      return createComparisonReport(entries)
+    }
+  )
+
+  return {
+    [ReporterTypeId]: ReporterTypeId as typeof ReporterTypeId,
+    report,
+    reportSelectedComparison,
+    reportSelected,
+    visualize
+  } as const
+})
+type ReporterShape = Effect.Success<typeof ReporterMake>
+
 /**
  * Context service for producing bundle size reports and visualizations from Rollup-generated fixture stats.
  *
  * @category services
  * @since 4.0.0
  */
-export class Reporter extends Context.Service<Reporter>()(
-  "@effect/bundle/Reporter",
-  {
-    make: Effect.gen(function*() {
-      const fs = yield* FileSystem.FileSystem
-      const path = yield* Path.Path
-      const { fixtures, fixturesDir } = yield* Fixtures
-      const rollup = yield* Rollup
-      const currentDirectory = path.resolve(fileURLToPath(new URL("../../../../", import.meta.url)))
-
-      const calculateDifference = (current: BundleStats, previous: BundleStats) => {
-        const currSize = current.sizeInBytes
-        const prevSize = previous.sizeInBytes
-        const diff = currSize - prevSize
-        const diffPct = prevSize === 0 ? 0 : (Math.abs(diff) / prevSize) * 100
-        const currKb = (currSize / 1000).toFixed(2)
-        const prevKb = (prevSize / 1000).toFixed(2)
-        const diffKb = (Math.abs(diff) / 1000).toFixed(2)
-        const filename = path.basename(current.path)
-        return {
-          diff,
-          diffPct,
-          currKb,
-          prevKb,
-          diffKb,
-          filename
-        }
-      }
-
-      const createComparisonReport = (
-        entries: ReadonlyArray<{
-          readonly current: BundleStats
-          readonly previous: BundleStats
-          readonly filename: string
-        }>
-      ): string => {
-        const lines: Array<string> = [
-          "| File Name | Current Size | Previous Size | Difference |",
-          "|:----------|:------------:|:-------------:|:----------:|"
-        ]
-        for (const { current, previous, filename } of entries) {
-          const comparison = calculateDifference(current, previous)
-          const currKb = `${comparison.currKb} KB`
-          const prevKb = `${comparison.prevKb} KB`
-          const diffKb = `${comparison.diffKb} KB`
-          const diffPct = `${comparison.diffPct.toFixed(2)}%`
-          const sign = comparison.diff === 0 ? "" : comparison.diff > 0 ? "+" : "-"
-          const line = `| \`${filename}\` | ${currKb} | ${prevKb} | ${sign}${diffKb} (${sign}${diffPct}) |`
-          lines.push(line)
-        }
-        return lines.join("\n") + "\n"
-      }
-
-      const createReport = (curr: ReadonlyArray<BundleStats>, prev: ReadonlyArray<BundleStats>): string => {
-        const entries: Array<{
-          readonly current: BundleStats
-          readonly previous: BundleStats
-          readonly filename: string
-        }> = []
-        for (const current of curr) {
-          const previous = prev.find((previous) => {
-            return path.basename(previous.path) === path.basename(current.path)
-          }) ?? current
-          entries.push({
-            current,
-            previous,
-            filename: path.basename(current.path)
-          })
-        }
-        return createComparisonReport(entries)
-      }
-
-      const createSelectedReport = (stats: ReadonlyArray<BundleStats>): string => {
-        const lines: Array<string> = [
-          "| File Name | Current Size |",
-          "|:----------|:------------:|"
-        ]
-
-        for (const current of stats) {
-          const filename = `\`${path.basename(current.path)}\``
-          const currKb = `${(current.sizeInBytes / 1000).toFixed(2)} KB`
-          const line = `| ${filename} | ${currKb} |`
-          lines.push(line)
-        }
-
-        return lines.join("\n") + "\n"
-      }
-
-      const createVisualizationReport = (paths: ReadonlyArray<string>, outputDirectory: string): string => {
-        const lines: Array<string> = [
-          "| File Name | Generated Bundle | Treemap | Raw Data |",
-          "|:----------|:----------------|:--------|:---------|"
-        ]
-        for (const entryPath of paths) {
-          const name = path.parse(entryPath).name
-          const filename = path.relative(currentDirectory, path.resolve(entryPath))
-          const minified = path.join(outputDirectory, `${name}.min.js`)
-          const treemap = path.join(outputDirectory, `${name}.treemap.html`)
-          const rawData = path.join(outputDirectory, `${name}.raw-data.json`)
-          lines.push(`| \`${filename}\` | \`${minified}\` | \`${treemap}\` | \`${rawData}\` |`)
-        }
-        return lines.join("\n") + "\n"
-      }
-
-      const report = Effect.fn("Reporter.report")(
-        function*(options: ReportOptions) {
-          yield* Effect.logInfo(`Found ${fixtures.length} files to bundle`)
-
-          const currentPaths = fixtures.map((fixture) => path.join(fixturesDir, fixture))
-          const previousPaths = yield* Effect.filter(
-            fixtures.map((fixture) => path.join(options.baseDirectory, fixture)),
-            (previousPath) => fs.exists(previousPath).pipe(Effect.orElseSucceed(constFalse)),
-            { concurrency: fixtures.length }
-          )
-
-          const currentStats = yield* rollup.bundleAll({ paths: currentPaths })
-          const previousStats = yield* rollup.bundleAll({ paths: previousPaths })
-
-          yield* Effect.logInfo("Bundling complete! Generating bundle size report...")
-
-          return createReport(currentStats, previousStats)
-        }
-      )
-
-      const visualize = Effect.fn("Reporter.visualize")(
-        function*(options: VisualizeOptions) {
-          yield* fs.makeDirectory(options.outputDirectory, { recursive: true })
-          yield* rollup.bundleAll({
-            paths: options.paths,
-            outputDirectory: options.outputDirectory,
-            visualize: true
-          })
-          return createVisualizationReport(options.paths, options.outputDirectory)
-        }
-      )
-
-      const reportSelected = Effect.fn("Reporter.reportSelected")(
-        function*(options: ReportSelectedOptions) {
-          yield* Effect.logInfo(`Found ${options.paths.length} files to bundle`)
-          const stats = yield* rollup.bundleAll({ paths: options.paths })
-          yield* Effect.logInfo("Bundling complete! Generating bundle size report...")
-          return createSelectedReport(stats)
-        }
-      )
-
-      const reportSelectedComparison = Effect.fn("Reporter.reportSelectedComparison")(
-        function*(options: ReportSelectedComparisonOptions) {
-          yield* Effect.logInfo(`Found ${options.paths.length} files to compare`)
-          const baseDirectory = path.resolve(options.baseDirectory)
-          const currentPaths = options.paths.map((currentPath) => path.resolve(currentPath))
-          const previousPaths = yield* Effect.forEach(
-            currentPaths,
-            Effect.fnUntraced(function*(currentPath) {
-              const relativePath = path.relative(currentDirectory, currentPath)
-              if (relativePath === "" || relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
-                return yield* Effect.fail(
-                  new ReporterError({
-                    cause: `Selected bundle entry must be inside ${currentDirectory}: ${currentPath}`
-                  })
-                )
-              }
-              const previousPath = path.join(baseDirectory, relativePath)
-              yield* fs.makeDirectory(path.dirname(previousPath), { recursive: true })
-              yield* fs.copy(currentPath, previousPath, { overwrite: true })
-              return previousPath
-            }),
-            { concurrency: currentPaths.length }
-          )
-
-          const currentStats = yield* rollup.bundleAll({ paths: currentPaths })
-          const previousStats = yield* rollup.bundleAll({ paths: previousPaths })
-
-          const entries: Array<{
-            readonly current: BundleStats
-            readonly previous: BundleStats
-            readonly filename: string
-          }> = []
-          for (let i = 0; i < currentStats.length; i++) {
-            entries.push({
-              current: currentStats[i]!,
-              previous: previousStats[i]!,
-              filename: path.relative(currentDirectory, currentStats[i]!.path)
-            })
-          }
-          yield* Effect.logInfo("Bundling complete! Generating bundle size report...")
-          return createComparisonReport(entries)
-        }
-      )
-
-      return {
-        report,
-        reportSelectedComparison,
-        reportSelected,
-        visualize
-      } as const
-    })
-  }
-) {
-  static readonly layer = Layer.effect(this, this.make).pipe(
-    Layer.provide(Fixtures.layer),
-    Layer.provide(Rollup.layer)
-  )
+export interface Reporter extends ReporterShape {
+  readonly [ReporterTypeId]: typeof ReporterTypeId
 }
+
+/**
+ * Service key for `Reporter` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Reporter = (() => {
+  const service = Object.assign(Context.Service<Reporter>("@effect/bundle/Reporter"), { make: ReporterMake })
+  return Object.assign(service, {
+    layer: Layer.effect(service, service.make).pipe(
+      Layer.provide(Fixtures.layer),
+      Layer.provide(Rollup.layer)
+    )
+  })
+})()

--- a/packages/tools/bundle/src/Rollup.ts
+++ b/packages/tools/bundle/src/Rollup.ts
@@ -74,125 +74,136 @@ export interface BundleAllOptions {
   readonly outputDirectory?: string | undefined
 }
 
+const RollupTypeId = "~@effect/bundle/Rollup"
+const RollupMake = Effect.gen(function*() {
+  const pathService = yield* Path.Path
+  const fs = yield* FileSystem.FileSystem
+
+  const createVisualizationOutputs = (options: BundleOptions): ReadonlyArray<VisualizationOutput> => {
+    if (!options.visualize || !options.outputDirectory) {
+      return []
+    }
+    const name = pathService.parse(options.path).name
+    return [
+      {
+        filename: pathService.join(options.outputDirectory, `${name}.treemap.html`),
+        template: "treemap",
+        title: `${name} bundle treemap`
+      },
+      {
+        filename: pathService.join(options.outputDirectory, `${name}.raw-data.json`),
+        template: "raw-data",
+        title: `${name} bundle raw data`
+      }
+    ]
+  }
+
+  const getRollupOptions = (options: BundleOptions): RollupOptions => ({
+    input: options.path,
+    output: {
+      format: "esm"
+    },
+    plugins: createPlugins(pathService, {
+      visualize: options.visualize,
+      visualizations: createVisualizationOutputs(options)
+    }),
+    onwarn: (warning, next) => {
+      if (warning.code === "THIS_IS_UNDEFINED") return
+      next(warning)
+    }
+  })
+
+  const bundle = Effect.fn("Rollup.bundle")(
+    function*(options: BundleOptions) {
+      const bundle = yield* Effect.acquireRelease(
+        Effect.tryPromise({
+          try: () => rollup(getRollupOptions(options)),
+          catch: (cause) => new RollupError({ cause })
+        }),
+        (bundle) => Effect.promise(() => bundle.close())
+      )
+      const { output } = yield* Effect.tryPromise({
+        try: () => bundle.generate({ format: "esm" }),
+        catch: (cause) => new RollupError({ cause })
+      })
+
+      const stream = yield* Stream.fromIterable(output).pipe(
+        Stream.filter((output) => output.type === "chunk"),
+        Stream.map((chunk) => chunk.code),
+        Stream.encodeText,
+        Stream.broadcast({ capacity: 8, replay: 8 })
+      )
+
+      const writeOutput = options.outputDirectory
+        ? stream.pipe(
+          Stream.run(fs.sink(pathService.join(
+            options.outputDirectory,
+            `${pathService.parse(options.path).name}.min.js`
+          ))),
+          Effect.mapError((cause) => new RollupError({ cause }))
+        )
+        : Effect.void
+
+      const [, sizeInBytes] = yield* Effect.all([
+        writeOutput,
+        stream.pipe(
+          NodeStream.pipeThroughDuplex({
+            evaluate: () => createGzip({ level: 9 }),
+            onError: (cause) => new RollupError({ cause })
+          }),
+          Stream.runFold(
+            () => 0,
+            (totalBytes, chunkBytes) => chunkBytes.length + totalBytes
+          )
+        )
+      ], { concurrency: 2 })
+
+      yield* Effect.log(`Bundled ${options.path}`).pipe(
+        Effect.annotateLogs({ size: `${(sizeInBytes / 1000).toFixed(2)} kB` })
+      )
+
+      return new BundleStats({ path: options.path, sizeInBytes })
+    },
+    Effect.scoped
+  )
+
+  const bundleAll = Effect.fn("Rollup.bundleAll")(
+    function*(options: BundleAllOptions) {
+      return yield* Effect.forEach(
+        options.paths,
+        (path) => bundle({ path, visualize: options.visualize, outputDirectory: options.outputDirectory }),
+        // Rollup retains a module graph for each active bundle, so unbounded
+        // concurrency can exhaust the Node.js heap on CI runners.
+        { concurrency: 4 }
+      )
+    }
+  )
+
+  return {
+    [RollupTypeId]: RollupTypeId as typeof RollupTypeId,
+    bundle,
+    bundleAll
+  } as const
+})
+type RollupShape = Effect.Success<typeof RollupMake>
+
 /**
  * Context service for bundling entry files with Rollup and measuring their gzipped output size.
  *
  * @category services
  * @since 4.0.0
  */
-export class Rollup extends Context.Service<Rollup>()(
-  "@effect/bundle/Rollup",
-  {
-    make: Effect.gen(function*() {
-      const pathService = yield* Path.Path
-      const fs = yield* FileSystem.FileSystem
-
-      const createVisualizationOutputs = (options: BundleOptions): ReadonlyArray<VisualizationOutput> => {
-        if (!options.visualize || !options.outputDirectory) {
-          return []
-        }
-        const name = pathService.parse(options.path).name
-        return [
-          {
-            filename: pathService.join(options.outputDirectory, `${name}.treemap.html`),
-            template: "treemap",
-            title: `${name} bundle treemap`
-          },
-          {
-            filename: pathService.join(options.outputDirectory, `${name}.raw-data.json`),
-            template: "raw-data",
-            title: `${name} bundle raw data`
-          }
-        ]
-      }
-
-      const getRollupOptions = (options: BundleOptions): RollupOptions => ({
-        input: options.path,
-        output: {
-          format: "esm"
-        },
-        plugins: createPlugins(pathService, {
-          visualize: options.visualize,
-          visualizations: createVisualizationOutputs(options)
-        }),
-        onwarn: (warning, next) => {
-          if (warning.code === "THIS_IS_UNDEFINED") return
-          next(warning)
-        }
-      })
-
-      const bundle = Effect.fn("Rollup.bundle")(
-        function*(options: BundleOptions) {
-          const bundle = yield* Effect.acquireRelease(
-            Effect.tryPromise({
-              try: () => rollup(getRollupOptions(options)),
-              catch: (cause) => new RollupError({ cause })
-            }),
-            (bundle) => Effect.promise(() => bundle.close())
-          )
-          const { output } = yield* Effect.tryPromise({
-            try: () => bundle.generate({ format: "esm" }),
-            catch: (cause) => new RollupError({ cause })
-          })
-
-          const stream = yield* Stream.fromIterable(output).pipe(
-            Stream.filter((output) => output.type === "chunk"),
-            Stream.map((chunk) => chunk.code),
-            Stream.encodeText,
-            Stream.broadcast({ capacity: 8, replay: 8 })
-          )
-
-          const writeOutput = options.outputDirectory
-            ? stream.pipe(
-              Stream.run(fs.sink(pathService.join(
-                options.outputDirectory,
-                `${pathService.parse(options.path).name}.min.js`
-              ))),
-              Effect.mapError((cause) => new RollupError({ cause }))
-            )
-            : Effect.void
-
-          const [, sizeInBytes] = yield* Effect.all([
-            writeOutput,
-            stream.pipe(
-              NodeStream.pipeThroughDuplex({
-                evaluate: () => createGzip({ level: 9 }),
-                onError: (cause) => new RollupError({ cause })
-              }),
-              Stream.runFold(
-                () => 0,
-                (totalBytes, chunkBytes) => chunkBytes.length + totalBytes
-              )
-            )
-          ], { concurrency: 2 })
-
-          yield* Effect.log(`Bundled ${options.path}`).pipe(
-            Effect.annotateLogs({ size: `${(sizeInBytes / 1000).toFixed(2)} kB` })
-          )
-
-          return new BundleStats({ path: options.path, sizeInBytes })
-        },
-        Effect.scoped
-      )
-
-      const bundleAll = Effect.fn("Rollup.bundleAll")(
-        function*(options: BundleAllOptions) {
-          return yield* Effect.forEach(
-            options.paths,
-            (path) => bundle({ path, visualize: options.visualize, outputDirectory: options.outputDirectory }),
-            // Rollup retains a module graph for each active bundle, so unbounded
-            // concurrency can exhaust the Node.js heap on CI runners.
-            { concurrency: 4 }
-          )
-        }
-      )
-
-      return {
-        bundle,
-        bundleAll
-      } as const
-    })
-  }
-) {
-  static readonly layer = Layer.effect(this, this.make)
+export interface Rollup extends RollupShape {
+  readonly [RollupTypeId]: typeof RollupTypeId
 }
+
+/**
+ * Service key for `Rollup` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Rollup = (() => {
+  const service = Object.assign(Context.Service<Rollup>("@effect/bundle/Rollup"), { make: RollupMake })
+  return Object.assign(service, { layer: Layer.effect(service, service.make) })
+})()

--- a/packages/tools/bundle/test/Plugins.test.ts
+++ b/packages/tools/bundle/test/Plugins.test.ts
@@ -91,6 +91,7 @@ describe("Fixtures", () => {
       const { Fixtures } = await import(pathToFileURL(modulePath).href)
 
       assert.deepStrictEqual(await Effect.runPromise(Fixtures.make), {
+        "~@effect/bundle/Fixtures": "~@effect/bundle/Fixtures",
         fixtures: ["example.ts"],
         fixturesDir: fixturesDir + path.sep
       })

--- a/packages/tools/docgen/src/Configuration.ts
+++ b/packages/tools/docgen/src/Configuration.ts
@@ -112,6 +112,7 @@ export const ConfigurationSchema = Schema.Struct({
  * @since 0.6.0
  */
 export interface ConfigurationShape {
+  readonly [ConfigurationTypeId]: typeof ConfigurationTypeId
   readonly projectName: string
   readonly projectHomepage: string
   readonly srcLink: string
@@ -129,15 +130,25 @@ export interface ConfigurationShape {
   readonly examplesCompilerOptions: Record<string, unknown>
 }
 
+const ConfigurationTypeId = "~@effect/docgen/Configuration"
+
 /**
  * Service that provides resolved docgen configuration.
  *
  * @category services
  * @since 0.6.0
  */
-export class Configuration
-  extends Context.Service<Configuration, ConfigurationShape>()("@effect/docgen/Configuration")
-{}
+export interface Configuration extends ConfigurationShape {
+  readonly [ConfigurationTypeId]: typeof ConfigurationTypeId
+}
+
+/**
+ * Service key for `Configuration` implementations.
+ *
+ * @category services
+ * @since 0.6.0
+ */
+export const Configuration = Context.Service<Configuration>("@effect/docgen/Configuration")
 
 /** @internal */
 export const defaultCompilerOptions = {
@@ -343,6 +354,7 @@ export const load = (args: {
     )
 
     return Configuration.of({
+      [ConfigurationTypeId]: ConfigurationTypeId,
       ...args,
       srcDir,
       outDir,

--- a/packages/tools/docgen/src/Domain.ts
+++ b/packages/tools/docgen/src/Domain.ts
@@ -321,28 +321,44 @@ export class DocgenError extends Data.TaggedError("DocgenError")<{
   readonly message: string
 }> {}
 
+const ProcessTypeId = "~@effect/docgen/Process"
+
 /**
  * Represents a handle to the currently executing process.
  *
  * @category services
  * @since 0.6.0
  */
-export class Process extends Context.Service<Process, {
+export interface Process {
+  readonly [ProcessTypeId]: typeof ProcessTypeId
+
   readonly cwd: Effect.Effect<string>
   readonly platform: Effect.Effect<NodeJS.Platform>
   readonly argv: Effect.Effect<Array<string>>
   readonly env: Effect.Effect<Record<string, string>>
-}>()("@effect/docgen/Process") {
-  static readonly layer = Layer.succeed(Process, {
-    cwd: Effect.sync(() => process.cwd()),
-    platform: Effect.sync(() => process.platform),
-    argv: Effect.sync(() => process.argv),
-    env: Effect.sync(() => {
-      const env: Record<string, string> = {}
-      for (const [key, value] of Object.entries(process.env)) {
-        if (value !== undefined) Rec.assignProperty(env, key, value)
-      }
-      return env
+}
+
+/**
+ * Service key for `Process` implementations.
+ *
+ * @category services
+ * @since 0.6.0
+ */
+export const Process = (() => {
+  const service = Context.Service<Process>("@effect/docgen/Process")
+  return Object.assign(service, {
+    layer: Layer.succeed(service, {
+      [ProcessTypeId]: ProcessTypeId as typeof ProcessTypeId,
+      cwd: Effect.sync(() => process.cwd()),
+      platform: Effect.sync(() => process.platform),
+      argv: Effect.sync(() => process.argv),
+      env: Effect.sync(() => {
+        const env: Record<string, string> = {}
+        for (const [key, value] of Object.entries(process.env)) {
+          if (value !== undefined) Rec.assignProperty(env, key, value)
+        }
+        return env
+      })
     })
   })
-}
+})()

--- a/packages/tools/docgen/src/Parser.ts
+++ b/packages/tools/docgen/src/Parser.ts
@@ -23,12 +23,23 @@ import * as Domain from "./Domain.ts"
  * @since 0.6.0
  */
 export interface SourceShape {
+  readonly ["~@effect/docgen/Source"]: "~@effect/docgen/Source"
   readonly path: Array.NonEmptyReadonlyArray<string>
   readonly sourceFile: ast.SourceFile
 }
 
 /** @internal */
-export class Source extends Context.Service<Source, SourceShape>()("@effect/docgen/Source") {}
+export interface Source extends SourceShape {
+  readonly ["~@effect/docgen/Source"]: "~@effect/docgen/Source"
+}
+
+/**
+ * Service key for `Source` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Source = Context.Service<Source>("@effect/docgen/Source")
 
 const sortModulesByPath: <A extends Domain.Module>(self: Iterable<A>) => Array<A> = Array
   .sort(Domain.ByPath)
@@ -693,7 +704,11 @@ export const parseFile =
       const sourceFile = project.getSourceFile(file.path)
       const filePath = file.path.split(path.sep)
       if (sourceFile !== undefined && Array.isArrayNonEmpty(filePath)) {
-        return yield* Effect.provideService(parseModule, Source, { sourceFile, path: filePath })
+        return yield* Effect.provideService(parseModule, Source, {
+          ["~@effect/docgen/Source"]: "~@effect/docgen/Source",
+          sourceFile,
+          path: filePath
+        })
       }
       return yield* Effect.fail([`Unable to locate file: ${file.path}`])
     })

--- a/packages/tools/docgen/test/Checker.test.ts
+++ b/packages/tools/docgen/test/Checker.test.ts
@@ -12,6 +12,7 @@ const project = new ast.Project({
 })
 
 const defaultConfig: Configuration.ConfigurationShape = {
+  ["~@effect/docgen/Configuration"]: "~@effect/docgen/Configuration" as const,
   projectName: "docgen",
   projectHomepage: "https://github.com/effect-ts/docgen",
   srcLink: "https://github.com/effect-ts/docgen/blob/main/src/",
@@ -45,6 +46,7 @@ const makeSource = (source: string | ast.SourceFile) => {
   const sourceFile = makeSourcefile(source)
   const filename = sourceFile.getBaseName()
   return Parser.Source.of({
+    ["~@effect/docgen/Source"]: "~@effect/docgen/Source" as const,
     path: [filename],
     sourceFile
   })

--- a/packages/tools/docgen/test/Configuration.test.ts
+++ b/packages/tools/docgen/test/Configuration.test.ts
@@ -74,6 +74,7 @@ const TestFileSystem = Layer.effect(
 
 const makeProcess = (env: Record<string, string> = {}) =>
   Layer.succeed(Domain.Process, {
+    ["~@effect/docgen/Process"]: "~@effect/docgen/Process" as const,
     cwd: Effect.sync(() => process.cwd()),
     platform: Effect.sync(() => process.platform),
     argv: Effect.sync(() => process.argv),
@@ -108,6 +109,7 @@ describe("Configuration", () => {
     const program = Effect.gen(function*() {
       const config = yield* Configuration.Configuration
       assert.deepStrictEqual(config, {
+        ["~@effect/docgen/Configuration"]: "~@effect/docgen/Configuration" as const,
         projectName: "name",
         projectHomepage: "homepage",
         srcLink: "homepage/blob/main/src/",
@@ -141,6 +143,7 @@ describe("Configuration", () => {
     const program = Effect.gen(function*() {
       const config = yield* Configuration.Configuration
       assert.deepStrictEqual(config, {
+        ["~@effect/docgen/Configuration"]: "~@effect/docgen/Configuration" as const,
         projectName: "name",
         projectHomepage: "myproject",
         srcLink: "mygithub",

--- a/packages/tools/docgen/test/Core.test.ts
+++ b/packages/tools/docgen/test/Core.test.ts
@@ -27,6 +27,7 @@ const assertExampleFiles = (source: string, expected: ReadonlyArray<string>, run
     const path = yield* Path.Path
     const cwd = yield* fs.makeTempDirectoryScoped()
     const config: Configuration.ConfigurationShape = {
+      ["~@effect/docgen/Configuration"]: "~@effect/docgen/Configuration" as const,
       projectName: "docgen",
       projectHomepage: "https://example.test",
       srcLink: "https://example.test",
@@ -77,6 +78,7 @@ const assertExampleFiles = (source: string, expected: ReadonlyArray<string>, run
     yield* Core.program.pipe(
       Effect.provideService(Configuration.Configuration, config),
       Effect.provideService(Domain.Process, {
+        ["~@effect/docgen/Process"]: "~@effect/docgen/Process" as const,
         cwd: Effect.succeed(process.cwd()),
         platform: Effect.succeed(process.platform),
         argv: Effect.succeed([]),
@@ -186,6 +188,7 @@ describe("Core", () => {
           }
         }).pipe(
           Effect.provideService(Configuration.Configuration, {
+            ["~@effect/docgen/Configuration"]: "~@effect/docgen/Configuration" as const,
             projectName: "docgen",
             projectHomepage: "https://example.com",
             srcLink: "https://example.com/src",
@@ -219,7 +222,11 @@ describe("Core", () => {
     )
 
     return Parser.parseTypeAliases.pipe(
-      Effect.provideService(Parser.Source, { path: ["Identity.ts"], sourceFile }),
+      Effect.provideService(Parser.Source, {
+        ["~@effect/docgen/Source"]: "~@effect/docgen/Source" as const,
+        path: ["Identity.ts"],
+        sourceFile
+      }),
       Effect.map(([alias]) => assert.strictEqual(alias?.signature, "type Identity<A extends string = string> = A"))
     )
   })

--- a/packages/tools/docgen/test/Parser.test.ts
+++ b/packages/tools/docgen/test/Parser.test.ts
@@ -15,6 +15,7 @@ const project = new ast.Project({
 })
 
 const defaultConfig: Configuration.ConfigurationShape = {
+  ["~@effect/docgen/Configuration"]: "~@effect/docgen/Configuration" as const,
   projectName: "docgen",
   projectHomepage: "https://github.com/effect-ts/docgen",
   srcLink: "https://github.com/effect-ts/docgen/blob/main/src/",
@@ -48,6 +49,7 @@ const makeSource = (source: string | ast.SourceFile) => {
   const sourceFile = makeSourcefile(source)
   const filename = sourceFile.getBaseName()
   return Parser.Source.of({
+    ["~@effect/docgen/Source"]: "~@effect/docgen/Source" as const,
     path: [filename],
     sourceFile
   })

--- a/packages/tools/openapi-generator/src/OpenApiGenerator.ts
+++ b/packages/tools/openapi-generator/src/OpenApiGenerator.ts
@@ -26,6 +26,8 @@ import * as OpenApiTransformer from "./OpenApiTransformer.ts"
 import * as ParsedOperation from "./ParsedOperation.ts"
 import * as Utils from "./Utils.ts"
 
+const OpenApiGeneratorTypeId = "~@effect/openapi-generator/OpenApiGenerator"
+
 /**
  * Service for turning OpenAPI or Swagger specifications into generated Effect
  * HTTP client or HttpApi source code.
@@ -33,10 +35,18 @@ import * as Utils from "./Utils.ts"
  * @category services
  * @since 4.0.0
  */
-export class OpenApiGenerator extends Context.Service<
-  OpenApiGenerator,
-  { readonly generate: (spec: OpenAPISpec, options: OpenApiGenerateOptions) => Effect.Effect<string> }
->()("OpenApiGenerator") {}
+export interface OpenApiGenerator {
+  readonly [OpenApiGeneratorTypeId]: typeof OpenApiGeneratorTypeId
+  readonly generate: (spec: OpenAPISpec, options: OpenApiGenerateOptions) => Effect.Effect<string>
+}
+
+/**
+ * Service key for `OpenApiGenerator` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const OpenApiGenerator = Context.Service<OpenApiGenerator>("OpenApiGenerator")
 
 /**
  * Output targets supported by the OpenAPI generator.
@@ -200,7 +210,10 @@ export const make = Effect.gen(function*() {
       )
   )
 
-  return { generate } as const
+  return {
+    [OpenApiGeneratorTypeId]: OpenApiGeneratorTypeId as typeof OpenApiGeneratorTypeId,
+    generate
+  } as const
 })
 
 type WarningEmitter = (warning: OpenApiGeneratorWarning) => void

--- a/packages/tools/openapi-generator/src/OpenApiTransformer.ts
+++ b/packages/tools/openapi-generator/src/OpenApiTransformer.ts
@@ -16,6 +16,8 @@ import * as Predicate from "effect/Predicate"
 import type { ParsedOpenApi, ParsedOperation, ParsedOperationHttpClientResponses } from "./ParsedOperation.ts"
 import * as Utils from "./Utils.ts"
 
+const OpenApiTransformerTypeId = "~@effect/openapi-generator/OpenApiTransformer"
+
 /**
  * Service used by the OpenAPI generator to render parsed operations as an
  * Effect HttpClient module.
@@ -29,14 +31,21 @@ import * as Utils from "./Utils.ts"
  * @category services
  * @since 4.0.0
  */
-export class OpenApiTransformer extends Context.Service<
-  OpenApiTransformer,
-  {
-    readonly imports: (importName: string, parsed: ParsedOpenApi) => string
-    readonly toTypes: (importName: string, name: string, parsed: ParsedOpenApi) => string
-    readonly toImplementation: (importName: string, name: string, parsed: ParsedOpenApi) => string
-  }
->()("OpenApiTransformer") {}
+export interface OpenApiTransformer {
+  readonly [OpenApiTransformerTypeId]: typeof OpenApiTransformerTypeId
+
+  readonly imports: (importName: string, parsed: ParsedOpenApi) => string
+  readonly toTypes: (importName: string, name: string, parsed: ParsedOpenApi) => string
+  readonly toImplementation: (importName: string, name: string, parsed: ParsedOpenApi) => string
+}
+
+/**
+ * Service key for `OpenApiTransformer` implementations.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const OpenApiTransformer = Context.Service<OpenApiTransformer>("OpenApiTransformer")
 
 interface ImportRequirements {
   readonly eventStream: boolean
@@ -475,6 +484,7 @@ export const make = (
   }
 
   return OpenApiTransformer.of({
+    [OpenApiTransformerTypeId]: OpenApiTransformerTypeId as typeof OpenApiTransformerTypeId,
     imports: (importName, parsed) => {
       const operations = parsed.operations
       const requirements = computeImportRequirements(operations)
@@ -911,6 +921,7 @@ export const make = (
   }
 
   return OpenApiTransformer.of({
+    [OpenApiTransformerTypeId]: OpenApiTransformerTypeId as typeof OpenApiTransformerTypeId,
     imports: (_importName, parsed) => {
       const operations = parsed.operations
       const requirements = computeImportRequirements(operations)

--- a/packages/tools/utils/src/Codegen.ts
+++ b/packages/tools/utils/src/Codegen.ts
@@ -114,6 +114,7 @@ export interface BarrelFile {
   readonly pattern: string
   readonly offset: number
 }
+const BarrelGeneratorTypeId = "~@effect/utils/BarrelGenerator"
 
 /**
  * Service interface for discovering annotated barrel files and regenerating their export contents.
@@ -122,6 +123,8 @@ export interface BarrelFile {
  * @since 4.0.0
  */
 export interface BarrelGenerator {
+  readonly [BarrelGeneratorTypeId]: typeof BarrelGeneratorTypeId
+
   readonly discoverFiles: (
     pattern: string,
     cwd: string
@@ -212,6 +215,10 @@ export const layer: Layer.Layer<BarrelGenerator, never, FileSystem.FileSystem | 
       yield* fs.writeFileString(file.path, `${header}\n\n${generated}\n`)
     })
 
-    return { discoverFiles, processFile }
+    return {
+      [BarrelGeneratorTypeId]: BarrelGeneratorTypeId as typeof BarrelGeneratorTypeId,
+      discoverFiles,
+      processFile
+    }
   }
 ).pipe(Layer.effect(BarrelGenerator), Layer.provide(Glob.layer))

--- a/packages/tools/utils/src/Glob.ts
+++ b/packages/tools/utils/src/Glob.ts
@@ -24,6 +24,7 @@ export class GlobError extends Data.TaggedError("GlobError")<{
   readonly pattern: string | ReadonlyArray<string>
   readonly cause: unknown
 }> {}
+const GlobTypeId = "~@effect/utils/Glob"
 
 /**
  * Service interface for matching filesystem paths with glob patterns.
@@ -32,6 +33,8 @@ export class GlobError extends Data.TaggedError("GlobError")<{
  * @since 4.0.0
  */
 export interface Glob {
+  readonly [GlobTypeId]: typeof GlobTypeId
+
   readonly glob: (
     pattern: string | ReadonlyArray<string>,
     options?: GlobLib.GlobOptions
@@ -53,6 +56,7 @@ export const Glob: Context.Service<Glob, Glob> = Context.Service("@effect/utils/
  * @since 4.0.0
  */
 export const layer: Layer.Layer<Glob> = Layer.succeed(Glob, {
+  [GlobTypeId]: GlobTypeId as typeof GlobTypeId,
   glob: (pattern, options) =>
     Effect.tryPromise({
       try: () => GlobLib.glob(pattern as string | Array<string>, options ?? {}) as Promise<Array<string>>,


### PR DESCRIPTION
Migrates 124 owned service declarations to same-name interfaces and `Context.Service` values with TypeIds, making the implementation type directly nameable. For migrated exports, use `Foo` instead of `Foo["Service"]` or `typeof Foo.Service`; module constructors supply the marker, and manual implementations must include it.

Preserves runtime service-key strings, static helpers, and both class and const forms of the `Context.Service` API. Updates constructors, implementation annotations, usage examples, migration guidance, and a changeset. AI config markers are stripped before provider request serialization.

Test follow-up is complete: mocks carry the required markers, implementation type projections use the service interfaces, and the Fixtures and Configuration assertions expect the markers. The follow-up commit changes only 40 test/helper files. Existing class services and dedicated const-support cases are preserved.

The 53 retained declarations below still need acceptance or resolution before merge.

Validation

- Full `pnpm check` and `pnpm lint-fix` passed.
- Affected runtime tests, including Context/Layer and MCP helper consumers: 1,329 passed, 44 skipped across 43 files.
- Context type tests passed under TypeScript 5.9.3 and 6.0.3 (4 tests, 6 assertions).
- PostgreSQL persistence and cluster integration tests were attempted with their enable flags, but global setup could not find a working container runtime. These require a container-enabled runner.
- Prior implementation validation: production/example project type-check, public JSDoc checks, and all 637 executable snippets passed.
- Migration reference regenerated against committed implementation 64d1ca59563e1524f6dc8f33b8286f8ab2ce4030. Its check still fails on 14 API groups with TODOs already present in the base document; no new TODOs remain from this migration.

<details>
<summary>53 retained declarations requiring review</summary>

Retained declarations requiring scope/design review

These declarations still use class syntax. Primitive and union values cannot be directly represented by branded interfaces without changing their shape. Adding markers to borrowed native objects, callbacks, schemas, and metadata requires a policy for identity, frozen values, and serialization. The generic HttpApiMiddleware.Service implementation is constructor API machinery and remains unchanged. Do not merge this as a claim that the full repository-wide scope is complete until these exceptions are accepted or resolved.

- `ai-docs/src/51_http-server/fixtures/api/Authorization.ts:5`: `CurrentUser` stores `User`.
- `packages/opentelemetry/src/OtelTracer.ts:46`: `OtelTracer` stores `Otel.Tracer`.
- `packages/opentelemetry/src/OtelTracer.ts:57`: `OtelTracerProvider` stores `Otel.TracerProvider`.
- `packages/opentelemetry/src/OtelTracer.ts:68`: `OtelTraceFlags` stores `Otel.TraceFlags`.
- `packages/opentelemetry/src/OtelTracer.ts:79`: `OtelTraceState` stores `Otel.TraceState`.
- `packages/opentelemetry/src/OtelTracer.ts:517`: `OtelParentSpanContext` stores `Otel.SpanContext`.
- `packages/opentelemetry/src/OtelLogger.ts:36`: `OtelLoggerProvider` stores `Otel.LoggerProvider`.
- `packages/opentelemetry/src/Resource.ts:34`: `Resource` stores `Resources.Resource`.
- `packages/platform/browser/src/IndexedDbQueryBuilder.ts:730`: `IndexedDbTransaction` stores `globalThis.IDBTransaction`.
- `packages/platform/browser/src/BrowserHttpClient.ts:119`: `XMLHttpRequest` stores `LazyArg<globalThis.XMLHttpRequest>`.
- `packages/platform/node-shared/src/NodeSocketServer.ts:56`: `IncomingMessage` stores `Http.IncomingMessage`.
- `packages/platform/node-shared/src/NodeSocket.ts:43`: `NetSocket` stores `Net.Socket`.
- `packages/platform/deno/src/DenoSocket.ts:51`: `Conn` stores `Deno.Conn`.
- `packages/platform/node/src/NodeHttpClient.ts:89`: `Dispatcher` stores `Undici.Dispatcher`.
- `packages/effect/src/unstable/httpapi/HttpApiMiddleware.ts:363`: `Service` stores `any`.
- `packages/effect/src/unstable/httpapi/HttpApi.ts:335`: `AdditionalSchemas` stores `ReadonlyArray<Schema.Constraint>`.
- `packages/effect/src/unstable/httpapi/OpenApi.ts:41`: `Identifier` stores `string`.
- `packages/effect/src/unstable/httpapi/OpenApi.ts:49`: `Title` stores `string`.
- `packages/effect/src/unstable/httpapi/OpenApi.ts:57`: `Version` stores `string`.
- `packages/effect/src/unstable/httpapi/OpenApi.ts:65`: `Description` stores `string`.
- `packages/effect/src/unstable/httpapi/OpenApi.ts:73`: `License` stores `OpenAPISpecLicense`.
- `packages/effect/src/unstable/httpapi/OpenApi.ts:81`: `ExternalDocs` stores `OpenAPISpecExternalDocs`.
- `packages/effect/src/unstable/httpapi/OpenApi.ts:91`: `Servers` stores `ReadonlyArray<OpenAPISpecServer>`.
- `packages/effect/src/unstable/httpapi/OpenApi.ts:101`: `Format` stores `string`.
- `packages/effect/src/unstable/httpapi/OpenApi.ts:109`: `Summary` stores `string`.
- `packages/effect/src/unstable/httpapi/OpenApi.ts:117`: `Deprecated` stores `boolean`.
- `packages/effect/src/unstable/httpapi/OpenApi.ts:125`: `Override` stores `Record<string, unknown>`.
- `packages/effect/src/unstable/httpapi/OpenApi.ts:154`: `Transform` stores `(openApiSpec: Record<string, any>) => Record<string, any>`.
- `packages/effect/src/unstable/ai/McpSchema.ts:3036`: `EnabledWhen` stores `Predicate.Predicate<typeof Initialize.payloadSchema.Type>`.
- `packages/effect/src/unstable/ai/Telemetry.ts:540`: `CurrentSpanTransformer` stores `SpanTransformer`.
- `packages/effect/src/unstable/cluster/EntityResource.ts:72`: `CloseScope` stores `Scope.Scope`.
- `packages/effect/src/unstable/cluster/K8sHttpClient.ts:30`: `K8sHttpClient` stores `HttpClient.HttpClient`.
- `packages/effect/src/unstable/cluster/Entity.ts:475`: `CurrentAddress` stores `EntityAddress`.
- `packages/effect/src/unstable/cluster/Entity.ts:491`: `CurrentRunnerAddress` stores `RunnerAddress`.
- `packages/effect/src/unstable/cluster/Entity.ts:783`: `KeepAliveLatch` stores `Latch.Latch`.
- `packages/effect/src/unstable/cluster/ClusterSchema.ts:23`: `Abandon` stores `true`.
- `packages/effect/src/Cause.ts:1815`: `StackTrace` stores `StackFrame`.
- `packages/effect/src/Cause.ts:1837`: `InterruptorStackTrace` stores `StackFrame`.
- `packages/effect/src/Tracer.ts:171`: `ParentSpan` stores `AnySpan`.
- `packages/effect/src/DateTime.ts:1857`: `CurrentTimeZone` stores `TimeZone`.
- `packages/effect/src/unstable/socket/Socket.ts:770`: `WebSocket` stores `WebSocketLike`.
- `packages/effect/src/unstable/socket/Socket.ts:781`: `WebSocketConstructor` stores `(url: string, options?: WebSocketConstructorOptions | undefined) => WebSocketLike`.
- `packages/effect/src/unstable/ai/EmbeddingModel.ts:63`: `Dimensions` stores `number`.
- `packages/effect/src/unstable/ai/Tool.ts:1714`: `Title` stores `string`.
- `packages/effect/src/unstable/ai/Tool.ts:1733`: `Meta` stores `Record<string, unknown>`.
- `packages/effect/src/unstable/ai/Model.ts:66`: `ProviderName` stores `string`.
- `packages/effect/src/unstable/ai/Model.ts:82`: `ModelName` stores `string`.
- `packages/effect/src/Layer.ts:608`: `CurrentMemoMap` stores `MemoMap`.
- `packages/effect/src/unstable/rpc/RpcSchema.ts:92`: `ClientAbort` stores `true`.
- `packages/effect/src/unstable/rpc/RpcWorker.ts:27`: `InitialMessage` stores `Effect.Effect< readonly [ data: unknown, transfers: ReadonlyArray<Transferable> ] >`.
- `packages/effect/src/unstable/http/FetchHttpClient.ts:49`: `RequestInit` stores `globalThis.RequestInit`.
- `packages/effect/src/unstable/http/HttpServerError.ts:255`: `ClientAbort` stores `true`.
- `packages/effect/src/unstable/http/HttpServerRequest.ts:132`: `ParsedSearchParams` stores `ReadonlyRecord<string, string | Array<string>>`.


</details>

Closes EFF-1329

