### PR TITLE
Fix Vitest timeout finalizer ordering

### DIFF
--- a/.changeset/vitest-await-timeout-finalizers.md
+++ b/.changeset/vitest-await-timeout-finalizers.md
@@ -2,4 +2,4 @@
 "@effect/vitest": patch
 ---
 
-Await asynchronous Effect finalizers after a test times out before starting the next test.
+Await asynchronous test and layer finalizers after an Effect test times out before starting the next test.

--- a/.changeset/vitest-await-timeout-finalizers.md
+++ b/.changeset/vitest-await-timeout-finalizers.md
@@ -1,0 +1,5 @@
+---
+"@effect/vitest": patch
+---
+
+Await asynchronous Effect finalizers after a test times out before starting the next test.

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -37,16 +37,13 @@ const runPromise: <E, A>(
 const runTest = (ctx?: Vitest.TestContext) => <E, A>(effect: Effect.Effect<A, E>) => {
   const promise = runPromise(effect, ctx)
   if (ctx) {
-    // Register only on abort so normally completing concurrent tests keep their
-    // usual teardown order. Keep failures on the original test promise.
+    // Vitest stops awaiting the test promise once the signal aborts (timeout or
+    // cancellation), so only then add a hook that waits for the finalizers.
+    // Registering it unconditionally would change the teardown of every test.
     const onAbort = () => ctx.onTestFinished(() => promise.then(constVoid, constVoid))
-    if (ctx.signal.aborted) {
-      onAbort()
-    } else {
-      ctx.signal.addEventListener("abort", onAbort, { once: true })
-      const cleanup = () => ctx.signal.removeEventListener("abort", onAbort)
-      promise.then(cleanup, cleanup)
-    }
+    ctx.signal.addEventListener("abort", onAbort, { once: true })
+    const cleanup = () => ctx.signal.removeEventListener("abort", onAbort)
+    promise.then(cleanup, cleanup)
   }
   return promise
 }

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -6,7 +6,7 @@ import * as Cause from "effect/Cause"
 import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
-import { flow, pipe } from "effect/Function"
+import { constVoid, flow, pipe } from "effect/Function"
 import * as Layer from "effect/Layer"
 import * as Schedule from "effect/Schedule"
 import type * as Schema from "effect/Schema"
@@ -34,7 +34,13 @@ const runPromise: <E, A>(
 }, (effect, _, ctx) => Effect.runPromise(effect, { signal: ctx?.signal }))
 
 /** @internal */
-const runTest = (ctx?: Vitest.TestContext) => <E, A>(effect: Effect.Effect<A, E>) => runPromise(effect, ctx)
+const runTest = (ctx?: Vitest.TestContext) => <E, A>(effect: Effect.Effect<A, E>) => {
+  const promise = runPromise(effect, ctx)
+  // Vitest stops awaiting the test promise on timeout, but the interrupted fiber
+  // still needs to finish its finalizers. Keep failures on the original promise.
+  ctx?.onTestFinished(() => promise.then(constVoid, constVoid))
+  return promise
+}
 
 /** @internal */
 export type TestContext = TestConsole.TestConsole | TestClock.TestClock

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -36,9 +36,18 @@ const runPromise: <E, A>(
 /** @internal */
 const runTest = (ctx?: Vitest.TestContext) => <E, A>(effect: Effect.Effect<A, E>) => {
   const promise = runPromise(effect, ctx)
-  // Vitest stops awaiting the test promise on timeout, but the interrupted fiber
-  // still needs to finish its finalizers. Keep failures on the original promise.
-  ctx?.onTestFinished(() => promise.then(constVoid, constVoid))
+  if (ctx) {
+    // Register only on abort so normally completing concurrent tests keep their
+    // usual teardown order. Keep failures on the original test promise.
+    const onAbort = () => ctx.onTestFinished(() => promise.then(constVoid, constVoid))
+    if (ctx.signal.aborted) {
+      onAbort()
+    } else {
+      ctx.signal.addEventListener("abort", onAbort, { once: true })
+      const cleanup = () => ctx.signal.removeEventListener("abort", onAbort)
+      promise.then(cleanup, cleanup)
+    }
+  }
   return promise
 }
 
@@ -261,12 +270,13 @@ export const layer = <R, E>(
     Effect.runSync
   )
   let closed = false
-  const closeScope = (ctx?: Vitest.TestContext) => {
+  const closeScope = () => {
     if (closed) {
       return Promise.resolve()
     }
     closed = true
-    return runPromise(Scope.close(scope, Exit.void), ctx)
+    // Layer cleanup must outlive the last test's already-aborted signal.
+    return runPromise(Scope.close(scope, Exit.void))
   }
 
   const makeIt = (it: V.TestAPI): Vitest.Vitest.MethodsNonLive<R> =>
@@ -319,7 +329,7 @@ export const layer = <R, E>(
         ctx.onTestFinished(() => {
           remaining--
           if (remaining === 0) {
-            return closeScope(ctx)
+            return closeScope()
           }
         })
         return runPromise(Effect.asVoid(contextEffect), ctx)

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -44,6 +44,8 @@ const runTest = (ctx?: Vitest.TestContext) => <E, A>(effect: Effect.Effect<A, E>
     ctx.signal.addEventListener("abort", onAbort, { once: true })
     const cleanup = () => ctx.signal.removeEventListener("abort", onAbort)
     promise.then(cleanup, cleanup)
+    // A retry after a timed-out attempt reuses the aborted signal, so no event fires.
+    if (ctx.signal.aborted) onAbort()
   }
   return promise
 }

--- a/packages/vitest/test/timeout.test.ts
+++ b/packages/vitest/test/timeout.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, assert, describe, it } from "@effect/vitest"
-import { Effect } from "effect"
+import { Effect, Layer } from "effect"
 
 for (const mode of ["effect", "live"] as const) {
   describe(`it.${mode} timeout finalizers`, { concurrent: false }, () => {
@@ -40,3 +40,53 @@ for (const mode of ["effect", "live"] as const) {
     })
   })
 }
+
+describe("anonymous it.layer timeout finalizers", { concurrent: false }, () => {
+  const events: Array<string> = []
+  const pendingReleases: Array<Promise<void>> = []
+  let signal: AbortSignal | undefined
+
+  // Drain real timers even if an interrupted layer close abandons its finalizer.
+  afterAll(() => Promise.all(pendingReleases))
+
+  const resource = (name: string) =>
+    Effect.acquireRelease(
+      Effect.sync(() => {
+        events.push(`${name}:acquired`)
+      }),
+      () =>
+        Effect.gen(function*() {
+          events.push(`${name}:release:start`)
+          // TestClock cannot drive a finalizer after the test has timed out.
+          yield* Effect.promise(() => {
+            const pending = new Promise<void>((resolve) => setTimeout(resolve, 250))
+            pendingReleases.push(pending)
+            return pending
+          })
+          events.push(`${name}:release:end`)
+        })
+    )
+
+  it.layer(Layer.effectDiscard(resource("layer")))((it) => {
+    it.effect.fails("times out in the last test using the layer", (ctx) =>
+      Effect.gen(function*() {
+        signal = ctx.signal
+        yield* resource("test")
+        return yield* Effect.never
+      }), { timeout: 75 })
+  })
+
+  it("awaits both test and layer finalizers before starting the next test", () => {
+    events.push("next:start")
+    assert.isTrue(signal?.aborted)
+    assert.deepStrictEqual(events, [
+      "layer:acquired",
+      "test:acquired",
+      "test:release:start",
+      "test:release:end",
+      "layer:release:start",
+      "layer:release:end",
+      "next:start"
+    ])
+  })
+})

--- a/packages/vitest/test/timeout.test.ts
+++ b/packages/vitest/test/timeout.test.ts
@@ -1,0 +1,42 @@
+import { afterAll, assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+
+for (const mode of ["effect", "live"] as const) {
+  describe(`it.${mode} timeout finalizers`, { concurrent: false }, () => {
+    const events: Array<string> = []
+    let signal: AbortSignal | undefined
+    let releaseFinished: Promise<void> | undefined
+
+    // Drain cleanup even when the ordering assertion fails on a broken adapter.
+    afterAll(() => releaseFinished)
+
+    it[mode].fails("times out while holding a resource", (ctx) =>
+      Effect.gen(function*() {
+        signal = ctx.signal
+        yield* Effect.acquireRelease(
+          Effect.sync(() => {
+            events.push("acquired")
+          }),
+          () =>
+            Effect.promise(() => {
+              events.push("release:start")
+              // A real timer is needed: it.effect's TestClock is not advanced during cleanup.
+              releaseFinished = new Promise<void>((resolve) => {
+                setTimeout(() => {
+                  events.push("release:end")
+                  resolve()
+                }, 250)
+              })
+              return releaseFinished
+            })
+        )
+        return yield* Effect.never
+      }), { timeout: 75 })
+
+    it("awaits the finalizer before starting the next test", () => {
+      events.push("next:start")
+      assert.isTrue(signal?.aborted)
+      assert.deepStrictEqual(events, ["acquired", "release:start", "release:end", "next:start"])
+    })
+  })
+}

--- a/packages/vitest/test/timeout.test.ts
+++ b/packages/vitest/test/timeout.test.ts
@@ -1,77 +1,60 @@
 import { afterAll, assert, describe, it } from "@effect/vitest"
 import { Effect, Layer } from "effect"
 
+const pendingReleases: Array<Promise<void>> = []
+
+// Drain the real timers even when a broken adapter abandons a finalizer.
+afterAll(() => Promise.all(pendingReleases))
+
+// The release takes real time: the TestClock is not advanced once a test has timed out.
+const resource = (events: Array<string>, name: string) =>
+  Effect.acquireRelease(
+    Effect.sync(() => {
+      events.push(`${name}:acquired`)
+    }),
+    () =>
+      Effect.promise(() => {
+        events.push(`${name}:release:start`)
+        const pending = new Promise<void>((resolve) =>
+          setTimeout(() => {
+            events.push(`${name}:release:end`)
+            resolve()
+          }, 250)
+        )
+        pendingReleases.push(pending)
+        return pending
+      })
+  )
+
 for (const mode of ["effect", "live"] as const) {
   describe(`it.${mode} timeout finalizers`, { concurrent: false }, () => {
     const events: Array<string> = []
     let signal: AbortSignal | undefined
-    let releaseFinished: Promise<void> | undefined
-
-    // Drain cleanup even when the ordering assertion fails on a broken adapter.
-    afterAll(() => releaseFinished)
 
     it[mode].fails("times out while holding a resource", (ctx) =>
       Effect.gen(function*() {
         signal = ctx.signal
-        yield* Effect.acquireRelease(
-          Effect.sync(() => {
-            events.push("acquired")
-          }),
-          () =>
-            Effect.promise(() => {
-              events.push("release:start")
-              // A real timer is needed: it.effect's TestClock is not advanced during cleanup.
-              releaseFinished = new Promise<void>((resolve) => {
-                setTimeout(() => {
-                  events.push("release:end")
-                  resolve()
-                }, 250)
-              })
-              return releaseFinished
-            })
-        )
+        yield* resource(events, "test")
         return yield* Effect.never
       }), { timeout: 75 })
 
     it("awaits the finalizer before starting the next test", () => {
       events.push("next:start")
       assert.isTrue(signal?.aborted)
-      assert.deepStrictEqual(events, ["acquired", "release:start", "release:end", "next:start"])
+      assert.deepStrictEqual(events, ["test:acquired", "test:release:start", "test:release:end", "next:start"])
     })
   })
 }
 
-describe("anonymous it.layer timeout finalizers", { concurrent: false }, () => {
+describe("it.layer timeout finalizers", { concurrent: false }, () => {
   const events: Array<string> = []
-  const pendingReleases: Array<Promise<void>> = []
   let signal: AbortSignal | undefined
 
-  // Drain real timers even if an interrupted layer close abandons its finalizer.
-  afterAll(() => Promise.all(pendingReleases))
-
-  const resource = (name: string) =>
-    Effect.acquireRelease(
-      Effect.sync(() => {
-        events.push(`${name}:acquired`)
-      }),
-      () =>
-        Effect.gen(function*() {
-          events.push(`${name}:release:start`)
-          // TestClock cannot drive a finalizer after the test has timed out.
-          yield* Effect.promise(() => {
-            const pending = new Promise<void>((resolve) => setTimeout(resolve, 250))
-            pendingReleases.push(pending)
-            return pending
-          })
-          events.push(`${name}:release:end`)
-        })
-    )
-
-  it.layer(Layer.effectDiscard(resource("layer")))((it) => {
+  it.layer(Layer.effectDiscard(resource(events, "layer")))((it) => {
     it.effect.fails("times out in the last test using the layer", (ctx) =>
       Effect.gen(function*() {
         signal = ctx.signal
-        yield* resource("test")
+        yield* resource(events, "test")
         return yield* Effect.never
       }), { timeout: 75 })
   })

--- a/packages/vitest/test/timeout.test.ts
+++ b/packages/vitest/test/timeout.test.ts
@@ -46,6 +46,36 @@ for (const mode of ["effect", "live"] as const) {
   })
 }
 
+describe("it.effect timeout retry finalizers", { concurrent: false }, () => {
+  const events: Array<string> = []
+  const abortedAtStart: Array<boolean> = []
+  let attempts = 0
+
+  it.effect.fails("retries after timing out while holding a resource", (ctx) =>
+    Effect.gen(function*() {
+      const attempt = ++attempts
+      abortedAtStart.push(ctx.signal.aborted)
+      yield* resource(events, `attempt${attempt}`)
+      return yield* Effect.never
+    }), { timeout: 75, retry: 1 })
+
+  it("awaits the retry's finalizer before starting the next test", () => {
+    events.push("next:start")
+    assert.strictEqual(attempts, 2)
+    // Vitest reuses the signal aborted by the first attempt's timeout.
+    assert.deepStrictEqual(abortedAtStart, [false, true])
+    assert.deepStrictEqual(events, [
+      "attempt1:acquired",
+      "attempt1:release:start",
+      "attempt1:release:end",
+      "attempt2:acquired",
+      "attempt2:release:start",
+      "attempt2:release:end",
+      "next:start"
+    ])
+  })
+})
+
 describe("it.layer timeout finalizers", { concurrent: false }, () => {
   const events: Array<string> = []
   let signal: AbortSignal | undefined


### PR DESCRIPTION
When an Effect test timed out, Vitest interrupted its fiber but started the next test before asynchronous finalizers completed. Register an `onTestFinished` hook when the test aborts and await the original Effect run promise so finalizers finish before Vitest advances. Registering only on abort preserves normal concurrent test teardown; the abort listener is removed when the Effect settles. Test failures still propagate through the original promise.

Handle an already-aborted signal too: Vitest reuses that signal when retrying a timed-out test, so the retry needs the completion hook without waiting for another abort event. Close anonymous layer scopes independently of the last test's signal so an already-aborted signal cannot interrupt layer cleanup.

Includes timeout-ordering regression coverage for `it.effect`, `it.live`, anonymous `it.layer`, and a timeout retry, plus a patch changeset for `@effect/vitest`. Cleanup remains subject to Vitest's hook timeout.

This fix targets the package's existing Vitest requirement, `>=5.0.0 <6.0.0`. The reporter's Vitest 4.1.11 configuration must upgrade to Vitest 5 to use this version of `@effect/vitest`.

Validation:

- All five adapter test files and `packages/effect/test/unstable/cli/Help.test.ts` pass on Node 26.7.0 and Bun 1.3.13 with Vitest 5.0.0: 130 passed, 9 expected failures, 5 skipped across six files.
- All four timeout-ordering assertions pass. The retry case proves both attempts execute and the second release finishes before the next test starts; it failed before restoring the aborted-signal guard.
- `nix develop -c pnpm lint-fix` and `nix develop -c pnpm check` pass.

Closes EFF-1330
Closes #8151
