### PR TITLE
Declare Reactivity, LanguageModel, EmbeddingModel, and Chat as interface + Context.Service

### DIFF
--- a/.changeset/service-interface-const.md
+++ b/.changeset/service-interface-const.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Declare `Reactivity`, `LanguageModel`, `EmbeddingModel`, and `Chat` as a same-name interface plus `Context.Service` key with a `TypeId` brand instead of a class. The service shape is now the exported interface itself (`LanguageModel.LanguageModel` instead of `LanguageModel.Service`, `Reactivity.Reactivity` instead of `Reactivity.Reactivity["Service"]`), and implementations must carry the module `TypeId`.
+Use branded interfaces for `Reactivity`, `LanguageModel`, `EmbeddingModel`, and `Chat`. Refer to each service's same-name type instead of `.Service` or `["Service"]`; custom implementations must include `[TypeId]: TypeId`.

--- a/.changeset/service-interface-const.md
+++ b/.changeset/service-interface-const.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Declare `Reactivity`, `LanguageModel`, `EmbeddingModel`, and `Chat` as a same-name interface plus `Context.Service` key with a `TypeId` brand instead of a class. The service shape is now the exported interface itself (`LanguageModel.LanguageModel` instead of `LanguageModel.Service`, `Reactivity.Reactivity` instead of `Reactivity.Reactivity["Service"]`), and implementations must carry the module `TypeId`.

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -660,7 +660,7 @@ export const model = (
  *
  * **When to use**
  *
- * Use when you need to construct a `LanguageModel.Service` value backed by
+ * Use when you need to construct a `LanguageModel` value backed by
  * `AnthropicClient` inside an Effect.
  *
  * **Details**
@@ -678,7 +678,7 @@ export const model = (
 export const make = Effect.fnUntraced(function*({ model, config: providerConfig }: {
   readonly model: (string & {}) | Model
   readonly config?: Omit<typeof Config.Service, "model"> | undefined
-}): Effect.fn.Return<LanguageModel.Service, never, AnthropicClient> {
+}): Effect.fn.Return<LanguageModel.LanguageModel, never, AnthropicClient> {
   const client = yield* AnthropicClient
 
   const makeConfig: Effect.Effect<typeof Config.Service & { readonly model: string }> = Effect.contextWith((services) =>

--- a/packages/ai/openai-compat/src/OpenAiEmbeddingModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiEmbeddingModel.ts
@@ -118,7 +118,7 @@ export const model = (
 export const make = Effect.fnUntraced(function*({ model, config: providerConfig }: {
   readonly model: string
   readonly config?: ModelConfig | undefined
-}): Effect.fn.Return<EmbeddingModel.Service, never, OpenAiClient> {
+}): Effect.fn.Return<EmbeddingModel.EmbeddingModel, never, OpenAiClient> {
   const client = yield* OpenAiClient
 
   const makeConfig = Effect.contextWith((services: Context.Context<never>) =>

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -572,7 +572,7 @@ export const model = (
 export const make = Effect.fnUntraced(function*({ model, config: providerConfig }: {
   readonly model: string
   readonly config?: ModelConfig | undefined
-}): Effect.fn.Return<LanguageModel.Service, never, OpenAiClient> {
+}): Effect.fn.Return<LanguageModel.LanguageModel, never, OpenAiClient> {
   const client = yield* OpenAiClient
 
   const makeConfig = Effect.contextWith((services: Context.Context<never>) =>

--- a/packages/ai/openai/src/OpenAiEmbeddingModel.ts
+++ b/packages/ai/openai/src/OpenAiEmbeddingModel.ts
@@ -101,7 +101,7 @@ export const model = (
  *
  * **When to use**
  *
- * Use to construct the `EmbeddingModel.Service` effectfully when
+ * Use to construct the `EmbeddingModel` effectfully when
  * `OpenAiClient` is already available in the environment.
  *
  * **Details**
@@ -127,7 +127,7 @@ export const model = (
 export const make = Effect.fnUntraced(function*({ model, config: providerConfig }: {
   readonly model: (string & {}) | Model
   readonly config?: Omit<typeof Config.Service, "model"> | undefined
-}): Effect.fn.Return<EmbeddingModel.Service, never, OpenAiClient> {
+}): Effect.fn.Return<EmbeddingModel.EmbeddingModel, never, OpenAiClient> {
   const client = yield* OpenAiClient
 
   const makeConfig = Effect.contextWith((services: Context.Context<never>) =>

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -612,7 +612,7 @@ export const model = (
 export const make = Effect.fnUntraced(function*({ model, config: providerConfig }: {
   readonly model: (string & {}) | Model
   readonly config?: Omit<typeof Config.Service, "model"> | undefined
-}): Effect.fn.Return<LanguageModel.Service, never, OpenAiClient> {
+}): Effect.fn.Return<LanguageModel.LanguageModel, never, OpenAiClient> {
   const client = yield* OpenAiClient
 
   const makeConfig = Effect.gen(function*() {

--- a/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
+++ b/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
@@ -516,7 +516,7 @@ export const model = (
  *
  * **When to use**
  *
- * Use when you need to construct a `LanguageModel.Service` value backed by
+ * Use when you need to construct a `LanguageModel` value backed by
  * `OpenRouterClient` inside an Effect.
  *
  * **Details**
@@ -541,7 +541,7 @@ export const model = (
 export const make = Effect.fnUntraced(function*({ model, config: providerConfig }: {
   readonly model: string
   readonly config?: Omit<typeof Config.Service, "model"> | undefined
-}): Effect.fn.Return<LanguageModel.Service, never, OpenRouterClient> {
+}): Effect.fn.Return<LanguageModel.LanguageModel, never, OpenRouterClient> {
   const client = yield* OpenRouterClient
   const codecTransformer = getCodecTransformer(model)
 

--- a/packages/effect/src/unstable/ai/Chat.ts
+++ b/packages/effect/src/unstable/ai/Chat.ts
@@ -33,18 +33,7 @@ import type * as Response from "./Response.ts"
 import type * as Tool from "./Tool.ts"
 
 /**
- * Service tag for stateful AI conversation sessions.
- *
- * **When to use**
- *
- * Use to access or provide conversational AI sessions through the Effect
- * context.
- *
- * **Details**
- *
- * This tag provides access to chat functionality throughout your application,
- * enabling persistent conversational AI interactions with full context
- * management.
+ * Service key for stateful AI conversations.
  *
  * **Example** (Accessing the Chat service)
  *
@@ -85,7 +74,7 @@ import type * as Tool from "./Tool.ts"
 export const Chat: Context.Service<Chat, Chat> = Context.Service("effect/ai/Chat")
 
 /**
- * Type-level identifier for `Chat` service implementations.
+ * Brand type for `Chat`.
  *
  * @category type IDs
  * @since 4.0.0
@@ -93,7 +82,7 @@ export const Chat: Context.Service<Chat, Chat> = Context.Service("effect/ai/Chat
 export type TypeId = "~effect/ai/Chat"
 
 /**
- * Runtime identifier stored on `Chat` service implementations.
+ * Brand for `Chat` implementations.
  *
  * @category type IDs
  * @since 4.0.0
@@ -101,13 +90,7 @@ export type TypeId = "~effect/ai/Chat"
 export const TypeId: TypeId = "~effect/ai/Chat"
 
 /**
- * Represents the interface that the `Chat` service provides.
- *
- * **When to use**
- *
- * Use as the service contract for code that receives or constructs a stateful
- * chat session and needs history, export, text generation, streaming, and
- * structured-output operations.
+ * Chat session with history, export, and generation operations.
  *
  * @see {@link Persisted} for the persistence-backed extension
  *

--- a/packages/effect/src/unstable/ai/Chat.ts
+++ b/packages/effect/src/unstable/ai/Chat.ts
@@ -82,9 +82,23 @@ import type * as Tool from "./Tool.ts"
  * @category services
  * @since 4.0.0
  */
-export class Chat extends Context.Service<Chat, Service>()(
-  "effect/ai/Chat"
-) {}
+export const Chat: Context.Service<Chat, Chat> = Context.Service("effect/ai/Chat")
+
+/**
+ * Type-level identifier for `Chat` service implementations.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export type TypeId = "~effect/ai/Chat"
+
+/**
+ * Runtime identifier stored on `Chat` service implementations.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export const TypeId: TypeId = "~effect/ai/Chat"
 
 /**
  * Represents the interface that the `Chat` service provides.
@@ -95,13 +109,14 @@ export class Chat extends Context.Service<Chat, Service>()(
  * chat session and needs history, export, text generation, streaming, and
  * structured-output operations.
  *
- * @see {@link Chat} for the context tag that provides this service
  * @see {@link Persisted} for the persistence-backed extension
  *
  * @category models
  * @since 4.0.0
  */
-export interface Service {
+export interface Chat {
+  readonly [TypeId]: TypeId
+
   /**
    * Reference to the chat history.
    *
@@ -419,6 +434,7 @@ const makeUnsafe = (history: Ref.Ref<Prompt.Prompt>) => {
   const semaphore = Semaphore.makeUnsafe(1)
 
   return Chat.of({
+    [TypeId]: TypeId,
     history,
     export: Ref.get(history).pipe(
       Effect.flatMap(encodeHistory),
@@ -455,7 +471,7 @@ const makeUnsafe = (history: Ref.Ref<Prompt.Prompt>) => {
       },
       semaphore.withPermits(1),
       (effect) => Effect.withSpan(effect, "Chat.generateText", { captureStackTrace: false })
-    ) as Service["generateText"],
+    ) as Chat["generateText"],
     streamText: Effect.fnUntraced(
       function*(options) {
         let parts = Chunk.empty<Response.AnyPart>()
@@ -487,7 +503,7 @@ const makeUnsafe = (history: Ref.Ref<Prompt.Prompt>) => {
         )
       },
       Stream.unwrap
-    ) as Service["streamText"],
+    ) as Chat["streamText"],
     generateObject: Effect.fnUntraced(
       function*(options) {
         const newPrompt = Prompt.make(options.prompt)
@@ -539,7 +555,7 @@ const makeUnsafe = (history: Ref.Ref<Prompt.Prompt>) => {
  * @category constructors
  * @since 4.0.0
  */
-export const empty: Effect.Effect<Service> = Effect.sync(() => makeUnsafe(Ref.makeUnsafe(Prompt.empty)))
+export const empty: Effect.Effect<Chat> = Effect.sync(() => makeUnsafe(Ref.makeUnsafe(Prompt.empty)))
 
 /**
  * Creates a new Chat service from an initial prompt.
@@ -655,7 +671,7 @@ export const fromPrompt = (prompt: Prompt.RawInput) =>
  * @since 4.0.0
  */
 export const fromExport = (data: unknown): Effect.Effect<
-  Service,
+  Chat,
   Schema.SchemaError
 > => Effect.flatMap(decodeHistory(data), fromPrompt)
 
@@ -689,7 +705,7 @@ export const fromExport = (data: unknown): Effect.Effect<
  * @since 4.0.0
  */
 export const fromJson = (data: string): Effect.Effect<
-  Service,
+  Chat,
   Schema.SchemaError
 > => Effect.flatMap(decodeHistoryJson(data), fromPrompt)
 
@@ -779,7 +795,7 @@ export declare namespace Persistence {
  * @category models
  * @since 4.0.0
  */
-export interface Persisted extends Service {
+export interface Persisted extends Chat {
   /**
    * The identifier for the chat in the backing persistence store.
    */
@@ -816,7 +832,7 @@ export const makePersisted = Effect.fnUntraced(function*(options: {
   const store = yield* persistence.make(options.storeId)
 
   const toPersisted = Effect.fnUntraced(
-    function*(chatId: string, chat: Service, ttl: Duration.Input | undefined) {
+    function*(chatId: string, chat: Chat, ttl: Duration.Input | undefined) {
       const idGenerator = yield* Effect.serviceOption(IdGenerator.IdGenerator).pipe(
         Effect.map(Option.getOrElse(() => IdGenerator.defaultIdGenerator))
       )
@@ -865,7 +881,7 @@ export const makePersisted = Effect.fnUntraced(function*(options: {
           return yield* chat.generateText(options).pipe(
             Effect.ensuring(Effect.orDie(saveChat(history)))
           )
-        }) as Service["generateText"],
+        }) as Chat["generateText"],
         generateObject: Effect.fnUntraced(function*(options) {
           const history = yield* Ref.get(chat.history)
           return yield* chat.generateObject(options).pipe(
@@ -878,7 +894,7 @@ export const makePersisted = Effect.fnUntraced(function*(options: {
             Stream.ensuring(Effect.orDie(saveChat(history)))
           )
           return stream
-        }, Stream.unwrap) as Service["streamText"]
+        }, Stream.unwrap) as Chat["streamText"]
       }
 
       return persisted

--- a/packages/effect/src/unstable/ai/EmbeddingModel.ts
+++ b/packages/effect/src/unstable/ai/EmbeddingModel.ts
@@ -26,16 +26,31 @@ import * as AiError from "./AiError.ts"
  * Use to retrieve or provide the embedding model service for an `Effect`
  * program that embeds text into vectors.
  *
- * @see {@link Service} for the service contract provided by this tag
  * @see {@link make} for constructing an embedding model service from a provider
  * @see {@link Dimensions} for the current embedding vector size service
  *
  * @category services
  * @since 4.0.0
  */
-export class EmbeddingModel extends Context.Service<EmbeddingModel, Service>()(
+export const EmbeddingModel: Context.Service<EmbeddingModel, EmbeddingModel> = Context.Service(
   "effect/unstable/ai/EmbeddingModel"
-) {}
+)
+
+/**
+ * Type-level identifier for `EmbeddingModel` service implementations.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export type TypeId = "~effect/ai/EmbeddingModel"
+
+/**
+ * Runtime identifier stored on `EmbeddingModel` service implementations.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export const TypeId: TypeId = "~effect/ai/EmbeddingModel"
 
 /**
  * Service tag that provides the current embedding dimensions.
@@ -137,7 +152,7 @@ export interface ProviderResponse {
  * Use when you need a typed request for one embedding input while building or
  * calling a low-level embedding request resolver.
  *
- * @see {@link Service} for the resolver-bearing service contract
+ * @see {@link EmbeddingModel} for the resolver-bearing service contract
  * @see {@link make} for constructing the request resolver from a provider implementation
  * @see {@link EmbedResponse} for the response produced by this request
  *
@@ -156,7 +171,8 @@ export class EmbeddingRequest extends Request.TaggedClass("EmbeddingRequest")<
  * @category models
  * @since 4.0.0
  */
-export interface Service {
+export interface EmbeddingModel {
+  readonly [TypeId]: TypeId
   readonly resolver: RequestResolver.RequestResolver<EmbeddingRequest>
   readonly embed: (input: string) => Effect.Effect<EmbedResponse, AiError.AiError>
   readonly embedMany: (input: ReadonlyArray<string>) => Effect.Effect<EmbedManyResponse, AiError.AiError>
@@ -175,7 +191,7 @@ const invalidProviderResponse = (description: string): AiError.AiError =>
  * **When to use**
  *
  * Use to adapt a provider's batch embedding implementation into an
- * `EmbeddingModel.Service` that offers single-input and batch embedding
+ * `EmbeddingModel` that offers single-input and batch embedding
  * operations.
  *
  * **Details**
@@ -192,7 +208,7 @@ const invalidProviderResponse = (description: string): AiError.AiError =>
  * result for each requested input. If the provider returns a different number
  * of results, `embed` and `embedMany` fail with `AiError.InvalidOutputError`.
  *
- * @see {@link Service} for the service shape returned by this constructor
+ * @see {@link EmbeddingModel} for the service shape returned by this constructor
  * @see {@link ProviderOptions} for the input passed to the provider implementation
  * @see {@link ProviderResponse} for the provider response contract consumed by this constructor
  *
@@ -201,7 +217,7 @@ const invalidProviderResponse = (description: string): AiError.AiError =>
  */
 export const make: (params: {
   readonly embedMany: (options: ProviderOptions) => Effect.Effect<ProviderResponse, AiError.AiError>
-}) => Effect.Effect<Service> = Effect.fnUntraced(function*(params) {
+}) => Effect.Effect<EmbeddingModel> = Effect.fnUntraced(function*(params) {
   const resolver = RequestResolver.make<EmbeddingRequest>((entries) =>
     Effect.flatMap(
       params.embedMany({
@@ -219,6 +235,7 @@ export const make: (params: {
   )
 
   return EmbeddingModel.of({
+    [TypeId]: TypeId,
     resolver,
     embed: (input) =>
       Effect.request(new EmbeddingRequest({ input }), resolver).pipe(

--- a/packages/effect/src/unstable/ai/EmbeddingModel.ts
+++ b/packages/effect/src/unstable/ai/EmbeddingModel.ts
@@ -19,12 +19,7 @@ import * as Schema from "../../Schema.ts"
 import * as AiError from "./AiError.ts"
 
 /**
- * Service tag for embedding model operations.
- *
- * **When to use**
- *
- * Use to retrieve or provide the embedding model service for an `Effect`
- * program that embeds text into vectors.
+ * Service key for embedding text into vectors.
  *
  * @see {@link make} for constructing an embedding model service from a provider
  * @see {@link Dimensions} for the current embedding vector size service
@@ -37,7 +32,7 @@ export const EmbeddingModel: Context.Service<EmbeddingModel, EmbeddingModel> = C
 )
 
 /**
- * Type-level identifier for `EmbeddingModel` service implementations.
+ * Brand type for `EmbeddingModel`.
  *
  * @category type IDs
  * @since 4.0.0
@@ -45,7 +40,7 @@ export const EmbeddingModel: Context.Service<EmbeddingModel, EmbeddingModel> = C
 export type TypeId = "~effect/ai/EmbeddingModel"
 
 /**
- * Runtime identifier stored on `EmbeddingModel` service implementations.
+ * Brand for `EmbeddingModel` implementations.
  *
  * @category type IDs
  * @since 4.0.0
@@ -166,7 +161,7 @@ export class EmbeddingRequest extends Request.TaggedClass("EmbeddingRequest")<
 > {}
 
 /**
- * Defines the service interface for embedding operations.
+ * Single-input and batch embedding operations.
  *
  * @category models
  * @since 4.0.0

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -38,17 +38,8 @@ import { CurrentSpanTransformer } from "./Telemetry.ts"
 import type * as Tool from "./Tool.ts"
 import * as Toolkit from "./Toolkit.ts"
 
-// =============================================================================
-// Service Definition
-// =============================================================================
-
 /**
- * Service tag for AI model services.
- *
- * **When to use**
- *
- * Use to access or provide text generation, streaming generation, structured
- * output, and tool-calling capabilities through the Effect context.
+ * Service key for text generation, structured output, and tool calls.
  *
  * **Example** (Accessing the language model service)
  *
@@ -87,7 +78,7 @@ export const LanguageModel: Context.Service<LanguageModel, LanguageModel> = Cont
 )
 
 /**
- * Type-level identifier for `LanguageModel` service implementations.
+ * Brand type for `LanguageModel`.
  *
  * @category type IDs
  * @since 4.0.0
@@ -95,7 +86,7 @@ export const LanguageModel: Context.Service<LanguageModel, LanguageModel> = Cont
 export type TypeId = "~effect/ai/LanguageModel"
 
 /**
- * Runtime identifier stored on `LanguageModel` service implementations.
+ * Brand for `LanguageModel` implementations.
  *
  * @category type IDs
  * @since 4.0.0
@@ -103,7 +94,7 @@ export type TypeId = "~effect/ai/LanguageModel"
 export const TypeId: TypeId = "~effect/ai/LanguageModel"
 
 /**
- * The service interface for language model operations, defining the contract that all language model implementations must fulfill.
+ * Text generation, streaming, and structured output operations.
  *
  * @category models
  * @since 4.0.0

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -82,9 +82,25 @@ import * as Toolkit from "./Toolkit.ts"
  * @category services
  * @since 4.0.0
  */
-export class LanguageModel extends Context.Service<LanguageModel, Service>()(
+export const LanguageModel: Context.Service<LanguageModel, LanguageModel> = Context.Service(
   "effect/unstable/ai/LanguageModel"
-) {}
+)
+
+/**
+ * Type-level identifier for `LanguageModel` service implementations.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export type TypeId = "~effect/ai/LanguageModel"
+
+/**
+ * Runtime identifier stored on `LanguageModel` service implementations.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export const TypeId: TypeId = "~effect/ai/LanguageModel"
 
 /**
  * The service interface for language model operations, defining the contract that all language model implementations must fulfill.
@@ -92,7 +108,9 @@ export class LanguageModel extends Context.Service<LanguageModel, Service>()(
  * @category models
  * @since 4.0.0
  */
-export interface Service {
+export interface LanguageModel {
+  readonly [TypeId]: TypeId
+
   /**
    * Generate text using the language model.
    */
@@ -771,7 +789,7 @@ export interface ProviderOptions {
  * response format prepared in `ProviderOptions`; invalid parts fail decoding as
  * `AiError.InvalidOutputError`.
  *
- * @see {@link Service} for the returned service contract
+ * @see {@link LanguageModel} for the returned service contract
  * @see {@link ProviderOptions} for the normalized options passed to provider hooks
  * @see {@link defaultCodecTransformer} for the default structured-output schema transformer
  *
@@ -798,7 +816,7 @@ export const make: (params: {
    * for structured output generation.
    */
   readonly codecTransformer?: CodecTransformer | undefined
-}) => Effect.Effect<Service> = Effect.fnUntraced(function*(params) {
+}) => Effect.Effect<LanguageModel> = Effect.fnUntraced(function*(params) {
   const codecTransformer = params.codecTransformer ?? defaultCodecTransformer
 
   const parentSpanTransformer = yield* Effect.serviceOption(
@@ -1707,11 +1725,12 @@ export const make: (params: {
     return Stream.fromQueue(queue)
   }) as any
 
-  return {
-    generateText: generateText as Service["generateText"],
-    generateObject: generateObject as Service["generateObject"],
-    streamText: streamText as Service["streamText"]
-  } as const
+  return LanguageModel.of({
+    [TypeId]: TypeId,
+    generateText: generateText as LanguageModel["generateText"],
+    generateObject: generateObject as LanguageModel["generateObject"],
+    streamText: streamText as LanguageModel["streamText"]
+  })
 })
 
 // =============================================================================

--- a/packages/effect/src/unstable/eventlog/EventLog.ts
+++ b/packages/effect/src/unstable/eventlog/EventLog.ts
@@ -702,7 +702,7 @@ export const makeReplayFromRemote = (options: {
   readonly handlers: ReadonlyMap<string, Handlers.Item<any>>
   readonly storeId: StoreId
   readonly identity: Identity["Service"]
-  readonly reactivity: Reactivity["Service"]
+  readonly reactivity: Reactivity
   readonly reactivityKeys: Record<string, ReadonlyArray<string>>
   readonly logAnnotations: {
     readonly service: string

--- a/packages/effect/src/unstable/reactivity/Reactivity.ts
+++ b/packages/effect/src/unstable/reactivity/Reactivity.ts
@@ -22,7 +22,7 @@ import * as Scope from "../../Scope.ts"
 import * as Stream from "../../Stream.ts"
 
 /**
- * Type-level identifier for `Reactivity` service implementations.
+ * Brand type for `Reactivity`.
  *
  * @category type IDs
  * @since 4.0.0
@@ -30,7 +30,7 @@ import * as Stream from "../../Stream.ts"
 export type TypeId = "~effect/reactivity/Reactivity"
 
 /**
- * Runtime identifier stored on `Reactivity` service implementations.
+ * Brand for `Reactivity` implementations.
  *
  * @category type IDs
  * @since 4.0.0
@@ -38,13 +38,7 @@ export type TypeId = "~effect/reactivity/Reactivity"
 export const TypeId: TypeId = "~effect/reactivity/Reactivity"
 
 /**
- * Service for key-based reactive invalidation.
- *
- * **Details**
- *
- * The service can register handlers for keys, invalidate those keys, wrap
- * mutations so successful effects invalidate keys, and turn query effects into
- * queues or streams that rerun when keys are invalidated.
+ * Registers handlers and reruns queries when their keys are invalidated.
  *
  * @category models
  * @since 4.0.0
@@ -75,12 +69,7 @@ export interface Reactivity {
 }
 
 /**
- * Service key for key-based reactive invalidation.
- *
- * **When to use**
- *
- * Use to provide or access the invalidation service that refreshes queries,
- * streams, and atoms when application keys change.
+ * Service key for reactive invalidation.
  *
  * @category services
  * @since 4.0.0

--- a/packages/effect/src/unstable/reactivity/Reactivity.ts
+++ b/packages/effect/src/unstable/reactivity/Reactivity.ts
@@ -22,12 +22,23 @@ import * as Scope from "../../Scope.ts"
 import * as Stream from "../../Stream.ts"
 
 /**
+ * Type-level identifier for `Reactivity` service implementations.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export type TypeId = "~effect/reactivity/Reactivity"
+
+/**
+ * Runtime identifier stored on `Reactivity` service implementations.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export const TypeId: TypeId = "~effect/reactivity/Reactivity"
+
+/**
  * Service for key-based reactive invalidation.
- *
- * **When to use**
- *
- * Use to provide the invalidation service that refreshes queries, streams, and
- * atoms when application keys change.
  *
  * **Details**
  *
@@ -35,35 +46,46 @@ import * as Stream from "../../Stream.ts"
  * mutations so successful effects invalidate keys, and turn query effects into
  * queues or streams that rerun when keys are invalidated.
  *
+ * @category models
+ * @since 4.0.0
+ */
+export interface Reactivity {
+  readonly [TypeId]: TypeId
+  readonly invalidateUnsafe: (keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>) => void
+  readonly registerUnsafe: (
+    keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,
+    handler: () => void
+  ) => () => void
+  readonly invalidate: (
+    keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>
+  ) => Effect.Effect<void>
+  readonly mutation: <A, E, R>(
+    keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,
+    effect: Effect.Effect<A, E, R>
+  ) => Effect.Effect<A, E, R>
+  readonly query: <A, E, R>(
+    keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,
+    effect: Effect.Effect<A, E, R>
+  ) => Effect.Effect<Queue.Dequeue<A, E>, never, R | Scope.Scope>
+  readonly stream: <A, E, R>(
+    keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,
+    effect: Effect.Effect<A, E, R>
+  ) => Stream.Stream<A, E, Exclude<R, Scope.Scope>>
+  readonly withBatch: <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
+}
+
+/**
+ * Service key for key-based reactive invalidation.
+ *
+ * **When to use**
+ *
+ * Use to provide or access the invalidation service that refreshes queries,
+ * streams, and atoms when application keys change.
+ *
  * @category services
  * @since 4.0.0
  */
-export class Reactivity extends Context.Service<
-  Reactivity,
-  {
-    readonly invalidateUnsafe: (keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>) => void
-    readonly registerUnsafe: (
-      keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,
-      handler: () => void
-    ) => () => void
-    readonly invalidate: (
-      keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>
-    ) => Effect.Effect<void>
-    readonly mutation: <A, E, R>(
-      keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,
-      effect: Effect.Effect<A, E, R>
-    ) => Effect.Effect<A, E, R>
-    readonly query: <A, E, R>(
-      keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,
-      effect: Effect.Effect<A, E, R>
-    ) => Effect.Effect<Queue.Dequeue<A, E>, never, R | Scope.Scope>
-    readonly stream: <A, E, R>(
-      keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,
-      effect: Effect.Effect<A, E, R>
-    ) => Stream.Stream<A, E, Exclude<R, Scope.Scope>>
-    readonly withBatch: <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
-  }
->()("effect/reactivity/Reactivity") {}
+export const Reactivity: Context.Service<Reactivity, Reactivity> = Context.Service("effect/reactivity/Reactivity")
 
 /**
  * Creates an in-memory `Reactivity` service.
@@ -202,6 +224,7 @@ export const make = Effect.sync(() => {
     })
 
   return Reactivity.of({
+    [TypeId]: TypeId,
     mutation,
     query,
     stream,

--- a/packages/effect/typetest/unstable/ai/LanguageModel.tst.ts
+++ b/packages/effect/typetest/unstable/ai/LanguageModel.tst.ts
@@ -340,7 +340,7 @@ describe("LanguageModel", () => {
 
   describe("Chat", () => {
     it("uses encoded tool parameters when tool call resolution is disabled", () => {
-      const chat = null as unknown as Chat.Service
+      const chat = null as unknown as Chat.Chat
       const toolkit = Toolkit.make(TransformTool)
       const program = chat.generateText({
         prompt: "hello",

--- a/packages/platform/browser/src/IndexedDbDatabase.ts
+++ b/packages/platform/browser/src/IndexedDbDatabase.ts
@@ -134,7 +134,7 @@ export class IndexedDbDatabase extends Context.Service<
   {
     readonly database: MutableRef.MutableRef<globalThis.IDBDatabase>
     readonly IDBKeyRange: typeof globalThis.IDBKeyRange
-    readonly reactivity: Reactivity.Reactivity["Service"]
+    readonly reactivity: Reactivity.Reactivity
     readonly rebuild: Effect.Effect<void, IndexedDbDatabaseError>
   }
 >()(TypeId) {}
@@ -553,7 +553,7 @@ const makeTransactionProto = <Source extends IndexedDbVersion.AnyWithProps>({
   readonly IDBKeyRange: typeof globalThis.IDBKeyRange
   readonly tables: ReadonlyMap<string, IndexedDbVersion.Tables<Source>>
   readonly transaction: globalThis.IDBTransaction
-  readonly reactivity: Reactivity.Reactivity["Service"]
+  readonly reactivity: Reactivity.Reactivity
 }): Transaction<Source> => {
   const migration = IndexedDbQueryBuilder.make({
     database,

--- a/packages/platform/browser/src/IndexedDbQueryBuilder.ts
+++ b/packages/platform/browser/src/IndexedDbQueryBuilder.ts
@@ -106,7 +106,7 @@ export interface IndexedDbQueryBuilder<
 > extends Pipeable.Pipeable, Inspectable {
   readonly tables: ReadonlyMap<string, IndexedDbVersion.Tables<Source>>
   readonly database: MutableRef.MutableRef<globalThis.IDBDatabase>
-  readonly reactivity: Reactivity.Reactivity["Service"]
+  readonly reactivity: Reactivity.Reactivity
   readonly IDBKeyRange: typeof globalThis.IDBKeyRange
   readonly IDBTransaction: globalThis.IDBTransaction | undefined
 
@@ -268,7 +268,7 @@ export declare namespace IndexedDbQuery {
     readonly table: Table
     readonly database: MutableRef.MutableRef<globalThis.IDBDatabase>
     readonly IDBKeyRange: typeof globalThis.IDBKeyRange
-    readonly reactivity: Reactivity.Reactivity["Service"]
+    readonly reactivity: Reactivity.Reactivity
 
     readonly clear: Effect.Effect<void, IndexedDbQueryError>
 
@@ -1413,7 +1413,7 @@ const makeFrom = <
   readonly table: Table
   readonly database: MutableRef.MutableRef<globalThis.IDBDatabase>
   readonly IDBKeyRange: typeof globalThis.IDBKeyRange
-  readonly reactivity: Reactivity.Reactivity["Service"]
+  readonly reactivity: Reactivity.Reactivity
 }): IndexedDbQuery.From<Table> => {
   const self = Object.create(FromProto)
   self.table = options.table
@@ -2055,7 +2055,7 @@ export const make = <Source extends IndexedDbVersion.AnyWithProps>({
   readonly database: MutableRef.MutableRef<globalThis.IDBDatabase>
   readonly IDBKeyRange: typeof globalThis.IDBKeyRange
   readonly tables: ReadonlyMap<string, IndexedDbVersion.Tables<Source>>
-  readonly reactivity: Reactivity.Reactivity["Service"]
+  readonly reactivity: Reactivity.Reactivity
 }): IndexedDbQueryBuilder<Source> => {
   const self = Object.create(QueryBuilderProto)
   self.tables = tables


### PR DESCRIPTION
Converts four class-style services to the same-name interface + `Context.Service` key form with a `TypeId` brand, so consumers can name the service shape directly instead of indexing `["Service"]`.

- `Reactivity`: `Reactivity.Reactivity` is now the shape type; `IndexedDbDatabase`, `IndexedDbQueryBuilder`, and `EventLog` drop `["Service"]`.
- `LanguageModel`, `EmbeddingModel`, `Chat`: the former `Service` interface is now the module's same-name interface. Provider packages (`@effect/ai-anthropic`, `@effect/ai-openai`, `@effect/ai-openai-compat`, `@effect/ai-openrouter`) reference `LanguageModel.LanguageModel` / `EmbeddingModel.EmbeddingModel` in their `make` return types.
- Each shape carries `readonly [TypeId]: TypeId` (`~effect/reactivity/Reactivity`, `~effect/ai/LanguageModel`, `~effect/ai/EmbeddingModel`, `~effect/ai/Chat`), set by the module's `make` / `makeUnsafe` constructors. Service key strings are unchanged.

Background: this follows the inventory and discussion in EFF-1331, where these four were picked for conversion.

Validation: `pnpm lint`, `pnpm check`, `pnpm jsdocs --check`, targeted `pnpm test --run` on the ai, reactivity, and provider test files (341 tests), `pnpm test-types` on the LanguageModel typetest, and `pnpm doctest --run` on the four modules all pass.

Closes EFF-1331
