### PR TITLE
docs(ai): clarify tool failure modes and recovery limits

### DIFF
--- a/ai-docs/src/71_ai/20_tools.ts
+++ b/ai-docs/src/71_ai/20_tools.ts
@@ -39,14 +39,13 @@ const SearchProducts = Tool.make("SearchProducts", {
     })
   }),
   success: Schema.Array(Product),
-  // The strategy used for handling errors returned from tool call handler
-  // execution.
-  //
-  // If set to `"error"` (the default), errors that occur during tool call handler
-  // execution will be returned in the error channel of the calling effect.
-  //
-  // If set to `"return"`, errors that occur during tool call handler execution
-  // will be captured and returned as part of the tool call result.
+  // "error" is the default: typed handler failures fail the calling model
+  // operation. Declaring a failure schema alone does not enable recovery.
+  // Choose "return" to encode typed failures as results with isFailure: true,
+  // which an agent loop can include in its next prompt for the model to handle.
+  // Toolkit parameter-validation failures follow the same mode without running
+  // the handler. Defects, interruption and result encoding failures still escape.
+  // This setting does not retry the tool or undo its side effects.
   failureMode: "error"
 })
 

--- a/packages/effect/src/unstable/ai/Tool.ts
+++ b/packages/effect/src/unstable/ai/Tool.ts
@@ -111,8 +111,9 @@ export type DynamicTypeId = "~effect/ai/Tool/Dynamic"
  * An agent loop can include these results in its next prompt so the model can
  * respond to the failure. This does not retry the tool or roll back side effects.
  *
- * Parameter validation in `Toolkit.handle` follows the same mode; an invalid call
- * never starts its handler. Unknown tool names cannot use a per-tool failure mode.
+ * Parameter validation in a resolved toolkit's `handle` method follows the same
+ * mode; an invalid call never starts its handler. Unknown tool names cannot use
+ * a per-tool failure mode.
  * Validation outside `Toolkit`, including model response validation when
  * `disableToolCallResolution` is `true`, is not controlled by this setting.
  *

--- a/packages/effect/src/unstable/ai/Tool.ts
+++ b/packages/effect/src/unstable/ai/Tool.ts
@@ -99,16 +99,59 @@ export type DynamicTypeId = "~effect/ai/Tool/Dynamic"
 // =============================================================================
 
 /**
- * The strategy used for handling errors returned from tool call handler
- * execution.
+ * Controls whether typed tool failures propagate or become failed tool results.
  *
  * **Details**
  *
- * If set to `"error"` (the default), errors that occur during tool call handler
- * execution will be returned in the error channel of the calling effect.
+ * `"error"` (the default) propagates handler failures through the Effect error
+ * channel. With automatic tool resolution, such a failure also fails the calling
+ * `LanguageModel` operation. Declaring a `failure` schema does not enable recovery.
  *
- * If set to `"return"`, errors that occur during tool call handler execution
- * will be captured and returned as part of the tool call result.
+ * `"return"` encodes typed handler failures as results with `isFailure: true`.
+ * An agent loop can include these results in its next prompt so the model can
+ * respond to the failure. This does not retry the tool or roll back side effects.
+ *
+ * Parameter validation in `Toolkit.handle` follows the same mode; an invalid call
+ * never starts its handler. Unknown tool names cannot use a per-tool failure mode.
+ * Validation outside `Toolkit`, including model response validation when
+ * `disableToolCallResolution` is `true`, is not controlled by this setting.
+ *
+ * **Gotchas**
+ *
+ * `"return"` does not recover defects, interruption, or tool result encoding
+ * failures. A failed result must still be encodable by its failure result schema.
+ * Only include information intended for the model in returned failures.
+ *
+ * **Example** (Returning a declared failure)
+ *
+ * ```ts import.meta.vitest
+ * import { Effect, Schema, Stream } from "effect"
+ * import { Tool, Toolkit } from "effect/unstable/ai"
+ *
+ * class LookupUnavailable extends Schema.TaggedError<LookupUnavailable>()(
+ *   "LookupUnavailable",
+ *   { message: Schema.String }
+ * ) {}
+ *
+ * const Lookup = Tool.make("Lookup", {
+ *   parameters: Schema.Struct({ id: Schema.String }),
+ *   success: Schema.String,
+ *   failure: LookupUnavailable,
+ *   failureMode: "return"
+ * })
+ * const tools = Toolkit.make(Lookup)
+ * const program = Effect.gen(function*() {
+ *   const handlers = yield* tools
+ *   const results = yield* handlers.handle("Lookup", { id: "item-1" }).pipe(
+ *     Effect.flatMap(Stream.runCollect)
+ *   )
+ *   return results[0]?.isFailure
+ * }).pipe(Effect.provide(tools.toLayer({
+ *   Lookup: () => Effect.fail(new LookupUnavailable({ message: "Try another source" }))
+ * })))
+ *
+ * await Effect.runPromise(program) // => true
+ * ```
  *
  * @category models
  * @since 4.0.0
@@ -224,17 +267,11 @@ export interface Tool<
   readonly description?: string | undefined
 
   /**
-   * The strategy used for handling errors returned from tool call handler
-   * execution.
+   * The configured strategy for typed handler and Toolkit parameter-validation
+   * failures. `"error"` propagates them; `"return"` emits failed tool results.
+   * Defects, interruption and result encoding failures are not recovered.
    *
-   * **Details**
-   *
-   * If set to `"error"` (the default), errors that occur during tool call
-   * handler execution will be returned in the error channel of the calling
-   * effect.
-   *
-   * If set to `"return"`, errors that occur during tool call handler execution
-   * will be captured and returned as part of the tool call result.
+   * @see {@link FailureMode}
    */
   readonly failureMode: FailureMode
 
@@ -1222,16 +1259,11 @@ export const make = <
    */
   readonly failure?: Failure | undefined
   /**
-   * The strategy used for handling errors returned from tool call handler
-   * execution.
+   * Defaults to `"error"`, which propagates typed failures and can fail the
+   * calling model operation. Choose `"return"` to encode them as failed tool
+   * results. Declaring a `failure` schema alone does not change the default.
    *
-   * **Details**
-   *
-   * If set to `"error"` (the default), errors that occur during tool call handler
-   * execution will be returned in the error channel of the calling effect.
-   *
-   * If set to `"return"`, errors that occur during tool call handler execution
-   * will be captured and returned as part of the tool call result.
+   * @see {@link FailureMode} for parameter validation and unrecovered failures.
    */
   readonly failureMode?: Mode
   /**


### PR DESCRIPTION
Declaring a tool's `failure` schema can look like enough to let an agent recover, but the default `failureMode: "error"` propagates typed failures and can end the calling model operation. Document that distinction at `FailureMode`, `Tool.failureMode`, and `Tool.make`, with an executable `"return"` example.

Clarify that Toolkit parameter validation follows the mode (as implemented in #7588), while defects, interruption, result encoding, unknown tool names, and validation outside Toolkit have different boundaries. Update the AI tools guide to match. This changes documentation only; it preserves the default and runtime behavior.

Validated with `pnpm ai-docgen` (no generated diff), `pnpm lint-fix`, `pnpm jsdocs --check`, `pnpm lint`, and `pnpm doctest --run packages/effect/src/unstable/ai/Tool.ts` (19 tests passed). Documentation-only changes do not require a changeset under the repository's contribution policy.
