### PR TITLE
fix(ai-openai): preserve failed search outcomes

### DIFF
--- a/.changeset/openai-web-search-outcomes.md
+++ b/.changeset/openai-web-search-outcomes.md
@@ -3,12 +3,3 @@
 ---
 
 Report failed OpenAI provider-executed tool calls as failure tool results in both `generateText` and `streamText`, preserving the call details.
-
-- Web and file searches with a non-`completed` status are failures. Failure payloads preserve the status, action or queries, and partial file results.
-- Code interpreter calls with a non-`completed` status are failures. Results include `status` and normalize omitted `outputs` to `null`. Decoding accepts the `interpreting` and `failed` statuses and null outputs.
-- Image generation calls with a non-`completed` status are failures carrying `status` and `result`. Partial images remain preliminary successful results.
-- MCP calls that report an `error` are failures carrying the error message; successful MCP results no longer include `error`.
-
-Omitted code-interpreter and image-generation statuses default to `completed`. Code-interpreter calls accept null or omitted code. Streams complete parameter JSON and emit one matching call before its result even without `code.done`, preserving any streamed code. Parameter JSON now uses `container_id` instead of `containerId` and correctly escapes its value.
-
-Search and code-interpreter success types restrict `status` to `"completed"`; handle other statuses when `isFailure` is `true`. File-search success and failure results require `results`, an array or `null`. Streaming normalizes omitted file-search results to `null`, matching `generateText`.

--- a/.changeset/openai-web-search-outcomes.md
+++ b/.changeset/openai-web-search-outcomes.md
@@ -2,6 +2,11 @@
 "@effect/ai-openai": patch
 ---
 
-Report non-completed OpenAI web and file searches as failure tool results, preserving search details and partial file results in both `generateText` and `streamText`.
+Report failed OpenAI provider-executed tool calls as failure tool results in both `generateText` and `streamText`, preserving the call details.
 
-Search success types now restrict `status` to `"completed"`; handle other statuses when `isFailure` is `true`. File-search success and failure results now require `results`, an array or `null`. Streaming normalizes omitted results to `null`, matching `generateText`. When constructing result payloads, include `results: null` when results are unavailable.
+- Web and file searches with a non-`completed` status are failures. Failure payloads preserve the status, action or queries, and partial file results.
+- Code interpreter calls with a non-`completed` status are failures. Results now include `status` alongside `outputs`, and omitted outputs are normalized to `null`. Response decoding now accepts the `interpreting` and `failed` statuses and `null` outputs that OpenAI documents for these calls.
+- Image generation calls with a non-`completed` status are failures carrying `status` and `result`. Partial images remain preliminary successful results.
+- MCP calls that report an `error` are failures carrying the error message; successful MCP results no longer include `error`.
+
+Success types now restrict `status` to `"completed"`; handle other statuses when `isFailure` is `true`. File-search success and failure results require `results`, an array or `null`. Streaming normalizes omitted file-search results to `null`, matching `generateText`.

--- a/.changeset/openai-web-search-outcomes.md
+++ b/.changeset/openai-web-search-outcomes.md
@@ -2,4 +2,4 @@
 "@effect/ai-openai": patch
 ---
 
-Mark failed and unfinished OpenAI web searches as failure tool results.
+Mark failed and unfinished OpenAI web and file searches as failure tool results.

--- a/.changeset/openai-web-search-outcomes.md
+++ b/.changeset/openai-web-search-outcomes.md
@@ -2,4 +2,4 @@
 "@effect/ai-openai": patch
 ---
 
-Report failed and unfinished web searches as failure tool results in generated and streamed responses. Preserve their original action and status through typed failure schemas for both web search tools.
+Mark failed and unfinished OpenAI web searches as failure tool results.

--- a/.changeset/openai-web-search-outcomes.md
+++ b/.changeset/openai-web-search-outcomes.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai": patch
+---
+
+Report failed and unfinished web searches as failure tool results in generated and streamed responses. Preserve their original action and status through typed failure schemas for both web search tools.

--- a/.changeset/openai-web-search-outcomes.md
+++ b/.changeset/openai-web-search-outcomes.md
@@ -5,8 +5,10 @@
 Report failed OpenAI provider-executed tool calls as failure tool results in both `generateText` and `streamText`, preserving the call details.
 
 - Web and file searches with a non-`completed` status are failures. Failure payloads preserve the status, action or queries, and partial file results.
-- Code interpreter calls with a non-`completed` status are failures. Results now include `status` alongside `outputs`, and omitted outputs are normalized to `null`. Response decoding now accepts the `interpreting` and `failed` statuses and `null` outputs that OpenAI documents for these calls.
+- Code interpreter calls with a non-`completed` status are failures. Results include `status` and normalize omitted `outputs` to `null`. Decoding accepts the `interpreting` and `failed` statuses and null outputs.
 - Image generation calls with a non-`completed` status are failures carrying `status` and `result`. Partial images remain preliminary successful results.
 - MCP calls that report an `error` are failures carrying the error message; successful MCP results no longer include `error`.
 
-Success types now restrict `status` to `"completed"`; handle other statuses when `isFailure` is `true`. File-search success and failure results require `results`, an array or `null`. Streaming normalizes omitted file-search results to `null`, matching `generateText`.
+Omitted code-interpreter and image-generation statuses default to `completed`. Code-interpreter calls accept null or omitted code. Streams complete parameter JSON and emit one matching call before its result even without `code.done`, preserving any streamed code. Parameter JSON now uses `container_id` instead of `containerId` and correctly escapes its value.
+
+Search and code-interpreter success types restrict `status` to `"completed"`; handle other statuses when `isFailure` is `true`. File-search success and failure results require `results`, an array or `null`. Streaming normalizes omitted file-search results to `null`, matching `generateText`.

--- a/.changeset/openai-web-search-outcomes.md
+++ b/.changeset/openai-web-search-outcomes.md
@@ -2,4 +2,6 @@
 "@effect/ai-openai": patch
 ---
 
-Mark failed and unfinished OpenAI web and file searches as failure tool results.
+Report non-completed OpenAI web and file searches as failure tool results, preserving search details and partial file results in both `generateText` and `streamText`.
+
+Search success types now restrict `status` to `"completed"`; handle other statuses when `isFailure` is `true`. File-search success and failure results now require `results`, an array or `null`. Streaming normalizes omitted results to `null`, matching `generateText`. When constructing result payloads, include `results: null` when results are unavailable.

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -1348,8 +1348,8 @@ const makeResponse = Effect.fnUntraced(
             type: "tool-result",
             id: part.id,
             name: toolName,
-            isFailure: false,
-            result: { outputs: part.outputs },
+            isFailure: part.status !== "completed",
+            result: { status: part.status, outputs: part.outputs ?? null },
             providerExecuted: true
           })
           break
@@ -1422,8 +1422,10 @@ const makeResponse = Effect.fnUntraced(
             type: "tool-result",
             id: part.id,
             name: toolName,
-            isFailure: false,
-            result: { result: part.result }
+            isFailure: part.status !== "completed",
+            result: part.status === "completed"
+              ? { result: part.result }
+              : { status: part.status, result: part.result }
           })
           break
         }
@@ -1463,7 +1465,7 @@ const makeResponse = Effect.fnUntraced(
             type: "tool-result",
             id: toolId,
             name: toolName,
-            isFailure: false,
+            isFailure: Predicate.isNotNullish(part.error),
             providerExecuted: true,
             result: {
               type: "mcp_call",
@@ -2071,8 +2073,8 @@ const makeStreamResponse = Effect.fnUntraced(
                   type: "tool-result",
                   id: event.item.id,
                   name: toolName,
-                  isFailure: false,
-                  result: { outputs: event.item.outputs },
+                  isFailure: event.item.status !== "completed",
+                  result: { status: event.item.status, outputs: event.item.outputs ?? null },
                   providerExecuted: true
                 })
                 break
@@ -2170,8 +2172,10 @@ const makeStreamResponse = Effect.fnUntraced(
                   type: "tool-result",
                   id: event.item.id,
                   name: toolName,
-                  isFailure: false,
-                  result: { result: event.item.result },
+                  isFailure: event.item.status !== "completed",
+                  result: event.item.status === "completed"
+                    ? { result: event.item.result }
+                    : { status: event.item.status, result: event.item.result },
                   providerExecuted: true
                 })
                 break
@@ -2216,7 +2220,7 @@ const makeStreamResponse = Effect.fnUntraced(
                   type: "tool-result",
                   id: toolId,
                   name: toolName,
-                  isFailure: false,
+                  isFailure: Predicate.isNotNullish(event.item.error),
                   providerExecuted: true,
                   result: {
                     type: "mcp_call",

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -2105,15 +2105,16 @@ const makeStreamResponse = Effect.fnUntraced(
               case "file_search_call": {
                 delete activeToolCalls[event.output_index]
                 const toolName = toolNameMapper.getCustomName("file_search")
-                const results = Predicate.isNotNullish(event.item.results)
-                  ? { results: event.item.results }
-                  : undefined
                 parts.push({
                   type: "tool-result",
                   id: event.item.id,
                   name: toolName,
                   isFailure: event.item.status !== "completed",
-                  result: { ...results, status: event.item.status, queries: event.item.queries },
+                  result: {
+                    status: event.item.status,
+                    queries: event.item.queries,
+                    results: event.item.results ?? null
+                  },
                   providerExecuted: true
                 })
                 break

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -1337,6 +1337,7 @@ const makeResponse = Effect.fnUntraced(
 
         case "code_interpreter_call": {
           const toolName = toolNameMapper.getCustomName("code_interpreter")
+          const status = part.status ?? "completed"
           parts.push({
             type: "tool-call",
             id: part.id,
@@ -1348,8 +1349,8 @@ const makeResponse = Effect.fnUntraced(
             type: "tool-result",
             id: part.id,
             name: toolName,
-            isFailure: part.status !== "completed",
-            result: { status: part.status, outputs: part.outputs ?? null },
+            isFailure: status !== "completed",
+            result: { status, outputs: part.outputs ?? null },
             providerExecuted: true
           })
           break
@@ -1411,6 +1412,7 @@ const makeResponse = Effect.fnUntraced(
 
         case "image_generation_call": {
           const toolName = toolNameMapper.getCustomName("image_generation")
+          const status = part.status ?? "completed"
           parts.push({
             type: "tool-call",
             id: part.id,
@@ -1422,10 +1424,10 @@ const makeResponse = Effect.fnUntraced(
             type: "tool-result",
             id: part.id,
             name: toolName,
-            isFailure: part.status !== "completed",
-            result: part.status === "completed"
+            isFailure: status !== "completed",
+            result: status === "completed"
               ? { result: part.result }
-              : { status: part.status, result: part.result }
+              : { status, result: part.result }
           })
           break
         }
@@ -2069,12 +2071,13 @@ const makeStreamResponse = Effect.fnUntraced(
               case "code_interpreter_call": {
                 delete activeToolCalls[event.output_index]
                 const toolName = toolNameMapper.getCustomName("code_interpreter")
+                const status = event.item.status ?? "completed"
                 parts.push({
                   type: "tool-result",
                   id: event.item.id,
                   name: toolName,
-                  isFailure: event.item.status !== "completed",
-                  result: { status: event.item.status, outputs: event.item.outputs ?? null },
+                  isFailure: status !== "completed",
+                  result: { status, outputs: event.item.outputs ?? null },
                   providerExecuted: true
                 })
                 break
@@ -2168,14 +2171,15 @@ const makeStreamResponse = Effect.fnUntraced(
 
               case "image_generation_call": {
                 const toolName = toolNameMapper.getCustomName("image_generation")
+                const status = event.item.status ?? "completed"
                 parts.push({
                   type: "tool-result",
                   id: event.item.id,
                   name: toolName,
-                  isFailure: event.item.status !== "completed",
-                  result: event.item.status === "completed"
+                  isFailure: status !== "completed",
+                  result: status === "completed"
                     ? { result: event.item.result }
-                    : { status: event.item.status, result: event.item.result },
+                    : { status, result: event.item.result },
                   providerExecuted: true
                 })
                 break

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -1661,7 +1661,7 @@ const makeResponse = Effect.fnUntraced(
             type: "tool-result",
             id: part.id,
             name: toolName,
-            isFailure: false,
+            isFailure: part.status !== "completed",
             result: { action: part.action, status: part.status },
             providerExecuted: true
           })
@@ -2323,7 +2323,7 @@ const makeStreamResponse = Effect.fnUntraced(
                   type: "tool-result",
                   id: event.item.id,
                   name: toolName,
-                  isFailure: false,
+                  isFailure: event.item.status !== "completed",
                   result: { action: event.item.action, status: event.item.status },
                   providerExecuted: true
                 })

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -1368,7 +1368,7 @@ const makeResponse = Effect.fnUntraced(
             type: "tool-result",
             id: part.id,
             name: toolName,
-            isFailure: false,
+            isFailure: part.status !== "completed",
             result: {
               status: part.status,
               queries: part.queries,
@@ -2112,7 +2112,7 @@ const makeStreamResponse = Effect.fnUntraced(
                   type: "tool-result",
                   id: event.item.id,
                   name: toolName,
-                  isFailure: false,
+                  isFailure: event.item.status !== "completed",
                   result: { ...results, status: event.item.status, queries: event.item.queries },
                   providerExecuted: true
                 })

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -1762,6 +1762,7 @@ const makeStreamResponse = Effect.fnUntraced(
       readonly codeInterpreter?: {
         readonly containerId: string
         hasCode: boolean
+        streamedCode: string
       }
     }> = {}
 
@@ -1784,7 +1785,10 @@ const makeStreamResponse = Effect.fnUntraced(
         type: "tool-call",
         id: toolCall.id,
         name: toolCall.name,
-        params: { code, container_id: toolCall.codeInterpreter.containerId },
+        params: {
+          code: toolCall.codeInterpreter.hasCode ? toolCall.codeInterpreter.streamedCode : code,
+          container_id: toolCall.codeInterpreter.containerId
+        },
         providerExecuted: true
       })
       delete activeToolCalls[outputIndex]
@@ -1901,7 +1905,7 @@ const makeStreamResponse = Effect.fnUntraced(
                 activeToolCalls[event.output_index] = {
                   id: event.item.id,
                   name: toolName,
-                  codeInterpreter: { containerId: event.item.container_id, hasCode: false }
+                  codeInterpreter: { containerId: event.item.container_id, hasCode: false, streamedCode: "" }
                 }
                 parts.push({
                   type: "tool-params-start",
@@ -2550,6 +2554,7 @@ const makeStreamResponse = Effect.fnUntraced(
                   InternalUtilities.escapeJSONDelta(event.delta)
               })
               toolCall.codeInterpreter.hasCode = true
+              toolCall.codeInterpreter.streamedCode += event.delta
             }
             break
           }

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -1342,7 +1342,7 @@ const makeResponse = Effect.fnUntraced(
             type: "tool-call",
             id: part.id,
             name: toolName,
-            params: { code: part.code, container_id: part.container_id },
+            params: { code: part.code ?? null, container_id: part.container_id },
             providerExecuted: true
           })
           parts.push({
@@ -1761,8 +1761,34 @@ const makeStreamResponse = Effect.fnUntraced(
       }
       readonly codeInterpreter?: {
         readonly containerId: string
+        hasCode: boolean
       }
     }> = {}
+
+    const finishCodeInterpreterCall = (
+      outputIndex: number,
+      code: string | null,
+      parts: Array<Response.StreamPartEncoded>
+    ) => {
+      const toolCall = activeToolCalls[outputIndex]
+      if (Predicate.isUndefined(toolCall?.codeInterpreter)) {
+        return
+      }
+      parts.push({
+        type: "tool-params-delta",
+        id: toolCall.id,
+        delta: toolCall.codeInterpreter.hasCode ? "\"}" : `${JSON.stringify(code)}}`
+      })
+      parts.push({ type: "tool-params-end", id: toolCall.id })
+      parts.push({
+        type: "tool-call",
+        id: toolCall.id,
+        name: toolCall.name,
+        params: { code, container_id: toolCall.codeInterpreter.containerId },
+        providerExecuted: true
+      })
+      delete activeToolCalls[outputIndex]
+    }
 
     const webSearchTool = options.tools.find((tool) =>
       Tool.isProviderDefined(tool) &&
@@ -1875,7 +1901,7 @@ const makeStreamResponse = Effect.fnUntraced(
                 activeToolCalls[event.output_index] = {
                   id: event.item.id,
                   name: toolName,
-                  codeInterpreter: { containerId: event.item.container_id }
+                  codeInterpreter: { containerId: event.item.container_id, hasCode: false }
                 }
                 parts.push({
                   type: "tool-params-start",
@@ -1886,7 +1912,7 @@ const makeStreamResponse = Effect.fnUntraced(
                 parts.push({
                   type: "tool-params-delta",
                   id: event.item.id,
-                  delta: `{"containerId":"${event.item.container_id}","code":"`
+                  delta: `{"container_id":${JSON.stringify(event.item.container_id)},"code":`
                 })
                 break
               }
@@ -2069,7 +2095,7 @@ const makeStreamResponse = Effect.fnUntraced(
               }
 
               case "code_interpreter_call": {
-                delete activeToolCalls[event.output_index]
+                finishCodeInterpreterCall(event.output_index, event.item.code ?? null, parts)
                 const toolName = toolNameMapper.getCustomName("code_interpreter")
                 const status = event.item.status ?? "completed"
                 parts.push({
@@ -2516,37 +2542,20 @@ const makeStreamResponse = Effect.fnUntraced(
 
           case "response.code_interpreter_call_code.delta": {
             const toolCall = activeToolCalls[event.output_index]
-            if (Predicate.isNotUndefined(toolCall)) {
+            if (Predicate.isNotUndefined(toolCall?.codeInterpreter)) {
               parts.push({
                 type: "tool-params-delta",
                 id: toolCall.id,
-                delta: InternalUtilities.escapeJSONDelta(event.delta)
+                delta: (toolCall.codeInterpreter.hasCode ? "" : "\"") +
+                  InternalUtilities.escapeJSONDelta(event.delta)
               })
+              toolCall.codeInterpreter.hasCode = true
             }
             break
           }
 
           case "response.code_interpreter_call_code.done": {
-            const toolCall = activeToolCalls[event.output_index]
-            if (Predicate.isNotUndefined(toolCall) && Predicate.isNotUndefined(toolCall.codeInterpreter)) {
-              const toolName = toolNameMapper.getCustomName("code_interpreter")
-              parts.push({
-                type: "tool-params-delta",
-                id: toolCall.id,
-                delta: "\"}"
-              })
-              parts.push({ type: "tool-params-end", id: toolCall.id })
-              parts.push({
-                type: "tool-call",
-                id: toolCall.id,
-                name: toolName,
-                params: {
-                  code: event.code,
-                  container_id: toolCall.codeInterpreter.containerId
-                },
-                providerExecuted: true
-              })
-            }
+            finishCodeInterpreterCall(event.output_index, event.code, parts)
             break
           }
 

--- a/packages/ai/openai/src/OpenAiSchema.ts
+++ b/packages/ai/openai/src/OpenAiSchema.ts
@@ -766,7 +766,7 @@ const ApplyPatchCall = Schema.Struct({
 const CodeInterpreterCall = Schema.Struct({
   id: Schema.String,
   type: Schema.Literal("code_interpreter_call"),
-  code: Schema.optionalKey(Schema.String),
+  code: Schema.optionalKey(Schema.NullOr(Schema.String)),
   container_id: Schema.String,
   outputs: Schema.optionalKey(Schema.NullOr(Schema.Array(Schema.Unknown))),
   status: Schema.optionalKey(

--- a/packages/ai/openai/src/OpenAiSchema.ts
+++ b/packages/ai/openai/src/OpenAiSchema.ts
@@ -768,8 +768,10 @@ const CodeInterpreterCall = Schema.Struct({
   type: Schema.Literal("code_interpreter_call"),
   code: Schema.optionalKey(Schema.String),
   container_id: Schema.String,
-  outputs: Schema.optionalKey(Schema.Array(Schema.Unknown)),
-  status: Schema.optionalKey(MessageStatus)
+  outputs: Schema.optionalKey(Schema.NullOr(Schema.Array(Schema.Unknown))),
+  status: Schema.optionalKey(
+    Schema.Literals(["in_progress", "completed", "incomplete", "interpreting", "failed"])
+  )
 })
 
 const ComputerCall = Schema.Struct({

--- a/packages/ai/openai/src/OpenAiTool.ts
+++ b/packages/ai/openai/src/OpenAiTool.ts
@@ -104,6 +104,8 @@ export const CodeInterpreter = Tool.providerDefined({
  * The tool requires `vector_store_ids` and accepts optional `filters`,
  * `max_num_results`, and `ranking_options`. Successful tool calls expose the
  * search `status`, generated `queries`, and optional `results`.
+ * Calls that finish without a `completed` status return failure tool results,
+ * preserving the original status, queries, and any partial results.
  *
  * @category tools
  * @since 4.0.0
@@ -120,6 +122,11 @@ export const FileSearch = Tool.providerDefined({
   }),
   success: Schema.Struct({
     status: Generated.FileSearchToolCall.fields.status,
+    queries: Generated.FileSearchToolCall.fields.queries,
+    results: Generated.FileSearchToolCall.fields.results
+  }),
+  failure: Schema.Struct({
+    status: Schema.Literals(["in_progress", "searching", "incomplete", "failed"]),
     queries: Generated.FileSearchToolCall.fields.queries,
     results: Generated.FileSearchToolCall.fields.results
   })

--- a/packages/ai/openai/src/OpenAiTool.ts
+++ b/packages/ai/openai/src/OpenAiTool.ts
@@ -102,10 +102,10 @@ export const CodeInterpreter = Tool.providerDefined({
  * **Details**
  *
  * The tool requires `vector_store_ids` and accepts optional `filters`,
- * `max_num_results`, and `ranking_options`. Successful tool calls expose the
- * search `status`, generated `queries`, and optional `results`.
- * Calls that finish without a `completed` status return failure tool results,
- * preserving the original status, queries, and any partial results.
+ * `max_num_results`, and `ranking_options`. Results include `queries` and a
+ * required `results` field containing matches or `null`. Only `completed` is
+ * successful; all other statuses produce failure results, preserving partial
+ * matches.
  *
  * @category tools
  * @since 4.0.0
@@ -304,9 +304,8 @@ const WebSearchFailure = Schema.Struct({
  * **Details**
  *
  * The tool accepts optional filters, user location, and search context size.
- * Successful calls expose the performed search action and status.
- * Calls that finish without a `completed` status return a failure result with
- * the original action and status, including unfinished searches.
+ * Results preserve the action and status. Only `completed` is successful;
+ * all other statuses produce failure results.
  *
  * @see {@link WebSearchPreview} for the preview web search provider tool
  *
@@ -338,10 +337,9 @@ export const WebSearch = Tool.providerDefined({
  *
  * **Details**
  *
- * The preview tool accepts optional user location and search context size, then
- * exposes the performed search action and status in successful calls.
- * Calls that finish without a `completed` status return a failure result with
- * the original action and status, including unfinished searches.
+ * The preview tool accepts optional user location and search context size.
+ * Results preserve the action and status. Only `completed` is successful;
+ * all other statuses produce failure results.
  *
  * @see {@link WebSearch} for the stable web search provider tool
  *

--- a/packages/ai/openai/src/OpenAiTool.ts
+++ b/packages/ai/openai/src/OpenAiTool.ts
@@ -67,10 +67,10 @@ export const ApplyPatch = Tool.providerDefined({
  *
  * **Details**
  *
- * The tool is configured with a `container` argument. Results include the
- * call `status` and `outputs`, which may contain logs or generated images, or
- * `null` when no outputs are available. Only `completed` is successful; all
- * other statuses produce failure results, preserving any outputs.
+ * The tool is configured with a `container` argument. Results include `status`
+ * and `outputs`: logs, generated images, or `null` when unavailable. A `completed`
+ * status indicates success; omitted statuses default to it. Other statuses
+ * produce failure results that preserve any outputs.
  *
  * @category tools
  * @since 4.0.0
@@ -155,10 +155,10 @@ export const FileSearch = Tool.providerDefined({
  *
  * The tool configures the `image_generation` provider tool, including model,
  * size, quality, output format, moderation, background, input-image options,
- * and partial image settings. Successful tool calls expose `result` as base64
- * image data or `null`; partial images arrive as preliminary successful
- * results. Only `completed` is successful; all other statuses produce failure
- * results that also include the call `status`.
+ * and partial image settings. Successful calls expose `result` as base64 image
+ * data or `null`. Partial images are preliminary success results. Final results
+ * with a status other than `completed` are failures that include `status`.
+ * Omitted statuses default to `completed`.
  *
  * @category tools
  * @since 4.0.0
@@ -243,8 +243,8 @@ const McpResultFields = {
  * The tool accepts MCP server configuration such as allowed tools,
  * authorization, connector id, approval requirements, server metadata, and
  * server URL. Tool call results include the called tool name, arguments, output,
- * and server label. A call that reports an `error` is a failure result carrying
- * the error message; successful results have no error.
+ * and server label. Calls that report an `error` produce failure results that
+ * include it; successful results omit `error`.
  *
  * **Gotchas**
  *

--- a/packages/ai/openai/src/OpenAiTool.ts
+++ b/packages/ai/openai/src/OpenAiTool.ts
@@ -123,14 +123,14 @@ export const FileSearch = Tool.providerDefined({
   success: Schema.Struct({
     status: Schema.Literal("completed"),
     queries: Generated.FileSearchToolCall.fields.queries,
-    results: Generated.FileSearchToolCall.fields.results
+    results: Generated.FileSearchToolCall.fields.results.schema
   }),
   failure: Schema.Struct({
     status: Schema.Literals(
       Generated.FileSearchToolCall.fields.status.literals.filter((status) => status !== "completed")
     ),
     queries: Generated.FileSearchToolCall.fields.queries,
-    results: Generated.FileSearchToolCall.fields.results
+    results: Generated.FileSearchToolCall.fields.results.schema
   })
 })
 

--- a/packages/ai/openai/src/OpenAiTool.ts
+++ b/packages/ai/openai/src/OpenAiTool.ts
@@ -126,7 +126,9 @@ export const FileSearch = Tool.providerDefined({
     results: Generated.FileSearchToolCall.fields.results
   }),
   failure: Schema.Struct({
-    status: Schema.Literals(["in_progress", "searching", "incomplete", "failed"]),
+    status: Schema.Literals(
+      Generated.FileSearchToolCall.fields.status.literals.filter((status) => status !== "completed")
+    ),
     queries: Generated.FileSearchToolCall.fields.queries,
     results: Generated.FileSearchToolCall.fields.results
   })
@@ -283,7 +285,7 @@ export const Shell = Tool.providerDefined({
 
 const WebSearchFailure = Schema.Struct({
   action: Generated.WebSearchToolCall.fields.action,
-  status: Schema.Literals(["in_progress", "searching", "failed"])
+  status: Schema.Literals(Generated.WebSearchToolCall.fields.status.literals.filter((status) => status !== "completed"))
 })
 
 /**

--- a/packages/ai/openai/src/OpenAiTool.ts
+++ b/packages/ai/openai/src/OpenAiTool.ts
@@ -67,9 +67,10 @@ export const ApplyPatch = Tool.providerDefined({
  *
  * **Details**
  *
- * The tool is configured with a `container` argument. Successful tool calls
- * expose `outputs`, which may contain logs or generated images, or `null` when
- * no outputs are available.
+ * The tool is configured with a `container` argument. Results include the
+ * call `status` and `outputs`, which may contain logs or generated images, or
+ * `null` when no outputs are available. Only `completed` is successful; all
+ * other statuses produce failure results, preserving any outputs.
  *
  * @category tools
  * @since 4.0.0
@@ -86,6 +87,13 @@ export const CodeInterpreter = Tool.providerDefined({
     container_id: Generated.CodeInterpreterToolCall.fields.container_id
   }),
   success: Schema.Struct({
+    status: Schema.Literal("completed"),
+    outputs: Generated.CodeInterpreterToolCall.fields.outputs
+  }),
+  failure: Schema.Struct({
+    status: Schema.Literals(
+      Generated.CodeInterpreterToolCall.fields.status.literals.filter((status) => status !== "completed")
+    ),
     outputs: Generated.CodeInterpreterToolCall.fields.outputs
   })
 })
@@ -148,7 +156,9 @@ export const FileSearch = Tool.providerDefined({
  * The tool configures the `image_generation` provider tool, including model,
  * size, quality, output format, moderation, background, input-image options,
  * and partial image settings. Successful tool calls expose `result` as base64
- * image data or `null`.
+ * image data or `null`; partial images arrive as preliminary successful
+ * results. Only `completed` is successful; all other statuses produce failure
+ * results that also include the call `status`.
  *
  * @category tools
  * @since 4.0.0
@@ -170,6 +180,12 @@ export const ImageGeneration = Tool.providerDefined({
     size: Generated.ImageGenTool.fields.size
   }),
   success: Schema.Struct({
+    result: Generated.ImageGenToolCall.fields.result
+  }),
+  failure: Schema.Struct({
+    status: Schema.Literals(
+      Generated.ImageGenToolCall.fields.status.literals.filter((status) => status !== "completed")
+    ),
     result: Generated.ImageGenToolCall.fields.result
   })
 })
@@ -206,6 +222,14 @@ export const LocalShell = Tool.providerDefined({
   })
 })
 
+const McpResultFields = {
+  type: Generated.MCPToolCall.fields.type,
+  name: Generated.MCPToolCall.fields.name,
+  arguments: Generated.MCPToolCall.fields.arguments,
+  output: Generated.MCPToolCall.fields.output,
+  server_label: Generated.MCPToolCall.fields.server_label
+}
+
 /**
  * Defines the OpenAI MCP tool that gives the model access to additional tools via remote
  * Model Context Protocol (MCP) servers.
@@ -219,7 +243,8 @@ export const LocalShell = Tool.providerDefined({
  * The tool accepts MCP server configuration such as allowed tools,
  * authorization, connector id, approval requirements, server metadata, and
  * server URL. Tool call results include the called tool name, arguments, output,
- * error, and server label.
+ * and server label. A call that reports an `error` is a failure result carrying
+ * the error message; successful results have no error.
  *
  * **Gotchas**
  *
@@ -243,13 +268,10 @@ export const Mcp = Tool.providerDefined({
     server_url: Generated.MCPTool.fields.server_url
   }),
   parameters: Schema.Unknown,
-  success: Schema.Struct({
-    type: Generated.MCPToolCall.fields.type,
-    name: Generated.MCPToolCall.fields.name,
-    arguments: Generated.MCPToolCall.fields.arguments,
-    output: Generated.MCPToolCall.fields.output,
-    error: Generated.MCPToolCall.fields.error,
-    server_label: Generated.MCPToolCall.fields.server_label
+  success: Schema.Struct(McpResultFields),
+  failure: Schema.Struct({
+    ...McpResultFields,
+    error: Schema.String
   })
 })
 

--- a/packages/ai/openai/src/OpenAiTool.ts
+++ b/packages/ai/openai/src/OpenAiTool.ts
@@ -121,7 +121,7 @@ export const FileSearch = Tool.providerDefined({
     vector_store_ids: Generated.FileSearchTool.fields.vector_store_ids
   }),
   success: Schema.Struct({
-    status: Generated.FileSearchToolCall.fields.status,
+    status: Schema.Literal("completed"),
     queries: Generated.FileSearchToolCall.fields.queries,
     results: Generated.FileSearchToolCall.fields.results
   }),
@@ -283,6 +283,11 @@ export const Shell = Tool.providerDefined({
   })
 })
 
+const WebSearchSuccess = Schema.Struct({
+  action: Generated.WebSearchToolCall.fields.action,
+  status: Schema.Literal("completed")
+})
+
 const WebSearchFailure = Schema.Struct({
   action: Generated.WebSearchToolCall.fields.action,
   status: Schema.Literals(Generated.WebSearchToolCall.fields.status.literals.filter((status) => status !== "completed"))
@@ -320,10 +325,7 @@ export const WebSearch = Tool.providerDefined({
   parameters: Schema.Struct({
     action: Generated.WebSearchToolCall.fields.action
   }),
-  success: Schema.Struct({
-    action: Generated.WebSearchToolCall.fields.action,
-    status: Generated.WebSearchToolCall.fields.status
-  }),
+  success: WebSearchSuccess,
   failure: WebSearchFailure
 })
 
@@ -354,9 +356,6 @@ export const WebSearchPreview = Tool.providerDefined({
     user_location: Generated.WebSearchPreviewTool.fields.user_location,
     search_context_size: Generated.WebSearchPreviewTool.fields.search_context_size
   }),
-  success: Schema.Struct({
-    action: Generated.WebSearchToolCall.fields.action,
-    status: Generated.WebSearchToolCall.fields.status
-  }),
+  success: WebSearchSuccess,
   failure: WebSearchFailure
 })

--- a/packages/ai/openai/src/OpenAiTool.ts
+++ b/packages/ai/openai/src/OpenAiTool.ts
@@ -274,6 +274,11 @@ export const Shell = Tool.providerDefined({
   })
 })
 
+const WebSearchFailure = Schema.Struct({
+  action: Generated.WebSearchToolCall.fields.action,
+  status: Schema.Literals(["in_progress", "searching", "failed"])
+})
+
 /**
  * Defines the OpenAI Web Search tool that enables the model to search the web for
  * information.
@@ -286,6 +291,8 @@ export const Shell = Tool.providerDefined({
  *
  * The tool accepts optional filters, user location, and search context size.
  * Successful calls expose the performed search action and status.
+ * Calls that finish without a `completed` status return a failure result with
+ * the original action and status, including unfinished searches.
  *
  * @see {@link WebSearchPreview} for the preview web search provider tool
  *
@@ -307,7 +314,8 @@ export const WebSearch = Tool.providerDefined({
   success: Schema.Struct({
     action: Generated.WebSearchToolCall.fields.action,
     status: Generated.WebSearchToolCall.fields.status
-  })
+  }),
+  failure: WebSearchFailure
 })
 
 /**
@@ -321,6 +329,8 @@ export const WebSearch = Tool.providerDefined({
  *
  * The preview tool accepts optional user location and search context size, then
  * exposes the performed search action and status in successful calls.
+ * Calls that finish without a `completed` status return a failure result with
+ * the original action and status, including unfinished searches.
  *
  * @see {@link WebSearch} for the stable web search provider tool
  *
@@ -338,5 +348,6 @@ export const WebSearchPreview = Tool.providerDefined({
   success: Schema.Struct({
     action: Generated.WebSearchToolCall.fields.action,
     status: Generated.WebSearchToolCall.fields.status
-  })
+  }),
+  failure: WebSearchFailure
 })

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -12,6 +12,20 @@ const webSearchOutcomes = [
   { status: "searching", isFailure: true }
 ] as const
 
+const fileSearchOutcomes = [
+  { status: "completed", isFailure: false },
+  { status: "failed", isFailure: true },
+  { status: "incomplete", isFailure: true },
+  { status: "in_progress", isFailure: true },
+  { status: "searching", isFailure: true }
+] as const
+
+const fileSearchResults = [
+  { label: "partial results", results: [{ file_id: "file_123", text: "Matching text", score: 0.8 }] },
+  { label: "null results", results: null },
+  { label: "omitted results", results: undefined }
+] as const
+
 describe("OpenAiLanguageModel", () => {
   describe("make", () => {
     it.effect("sends correct model in request", () =>
@@ -1235,6 +1249,33 @@ describe("OpenAiLanguageModel", () => {
         )
       }
 
+      for (const { label, results } of fileSearchResults) {
+        it.effect.each(fileSearchOutcomes)(
+          `OpenAiFileSearch reports $status with ${label}`,
+          ({ status, isFailure }) =>
+            Effect.gen(function*() {
+              const result = yield* LanguageModel.generateText({
+                prompt: "Search the files",
+                toolkit: Toolkit.make(OpenAiTool.FileSearch({ vector_store_ids: ["vs_123"] }))
+              }).pipe(Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")))
+
+              strictEqual(result.toolResults.length, 1)
+              const toolResult = result.toolResults[0]!
+              strictEqual(toolResult.name, "OpenAiFileSearch")
+              strictEqual(toolResult.id, "fs_123")
+              strictEqual(toolResult.providerExecuted, true)
+              strictEqual(toolResult.isFailure, isFailure)
+              deepStrictEqual(toolResult.result, {
+                status,
+                queries: ["Effect TypeScript"],
+                results: results ?? null
+              })
+            }).pipe(Effect.provide(makeTestLayer({
+              body: { output: [makeFileSearchCall({ status, ...(results === undefined ? {} : { results }) })] }
+            })))
+        )
+      }
+
       it.effect("uses canonical OpenAiMcp name for mcp_approval_request", () =>
         Effect.gen(function*() {
           const result = yield* LanguageModel.generateText({
@@ -1762,6 +1803,63 @@ describe("OpenAiLanguageModel", () => {
       )
     }
 
+    for (const { label, results } of fileSearchResults) {
+      it.effect.each(fileSearchOutcomes)(
+        `OpenAiFileSearch reports $status with ${label} from output_item.done`,
+        ({ status, isFailure }) =>
+          Effect.gen(function*() {
+            const call = makeFileSearchCall({ status, ...(results === undefined ? {} : { results }) })
+            const streamEvents: ReadonlyArray<typeof Generated.ResponseStreamEvent.Type> = [
+              {
+                type: "response.created",
+                sequence_number: 1,
+                response: makeDefaultResponse({ status: "in_progress" })
+              },
+              {
+                type: "response.output_item.added",
+                sequence_number: 2,
+                output_index: 0,
+                item: makeFileSearchCall({ status: "in_progress" })
+              },
+              {
+                type: "response.output_item.done",
+                sequence_number: 3,
+                output_index: 0,
+                item: call
+              },
+              {
+                type: "response.completed",
+                sequence_number: 4,
+                response: makeDefaultResponse({ output: [call] })
+              }
+            ]
+
+            const parts = yield* LanguageModel.streamText({
+              prompt: "Search the files",
+              toolkit: Toolkit.make(OpenAiTool.FileSearch({ vector_store_ids: ["vs_123"] }))
+            }).pipe(
+              Stream.runCollect,
+              Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+              Effect.provide(makeStreamTestLayer(streamEvents))
+            )
+
+            const toolResults = parts.filter((part) => part.type === "tool-result")
+            strictEqual(toolResults.length, 1)
+            const toolResult = toolResults[0]!
+            strictEqual(toolResult.name, "OpenAiFileSearch")
+            strictEqual(toolResult.id, "fs_123")
+            strictEqual(toolResult.providerExecuted, true)
+            strictEqual(toolResult.isFailure, isFailure)
+            deepStrictEqual(toolResult.result, {
+              status,
+              queries: ["Effect TypeScript"],
+              ...(results == null ? {} : { results })
+            })
+            assert.isDefined(parts.find((part) => part.type === "finish"))
+          })
+      )
+    }
+
     it.effect("handles reasoning summary events when reasoning state is missing", () =>
       Effect.gen(function*() {
         const streamEvents = [
@@ -2183,6 +2281,16 @@ const makeWebSearchCall = (
   id: "ws_123",
   status: "completed",
   action: { type: "search", query: "Effect TypeScript" },
+  ...overrides
+})
+
+const makeFileSearchCall = (
+  overrides: Partial<Generated.FileSearchToolCall> = {}
+): Generated.FileSearchToolCall => ({
+  type: "file_search_call",
+  id: "fs_123",
+  status: "completed",
+  queries: ["Effect TypeScript"],
   ...overrides
 })
 

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -5,6 +5,13 @@ import { Array, Context, Effect, Layer, Redacted, Ref, Schema, SchemaGetter, Str
 import { type AiError, LanguageModel, Prompt, Response as AiResponse, Tool, Toolkit } from "effect/unstable/ai"
 import { HttpClient, type HttpClientError, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
+const webSearchOutcomes = [
+  { status: "completed", isFailure: false },
+  { status: "failed", isFailure: true },
+  { status: "in_progress", isFailure: true },
+  { status: "searching", isFailure: true }
+] as const
+
 describe("OpenAiLanguageModel", () => {
   describe("make", () => {
     it.effect("sends correct model in request", () =>
@@ -1202,6 +1209,32 @@ describe("OpenAiLanguageModel", () => {
           )
       )
 
+      for (const tool of [OpenAiTool.WebSearch({}), OpenAiTool.WebSearchPreview({})]) {
+        it.effect.each(webSearchOutcomes)(
+          `${tool.name} reports $status results`,
+          ({ status, isFailure }) =>
+            Effect.gen(function*() {
+              const result = yield* LanguageModel.generateText({
+                prompt: "Search the web",
+                toolkit: Toolkit.make(tool)
+              }).pipe(Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")))
+
+              strictEqual(result.toolResults.length, 1)
+              const toolResult = result.toolResults[0]!
+              strictEqual(toolResult.name, tool.name)
+              strictEqual(toolResult.id, "ws_123")
+              strictEqual(toolResult.providerExecuted, true)
+              strictEqual(toolResult.isFailure, isFailure)
+              deepStrictEqual(toolResult.result, {
+                action: { type: "search", query: "Effect TypeScript" },
+                status
+              })
+            }).pipe(Effect.provide(makeTestLayer({
+              body: { output: [makeWebSearchCall({ status })] }
+            })))
+        )
+      }
+
       it.effect("uses canonical OpenAiMcp name for mcp_approval_request", () =>
         Effect.gen(function*() {
           const result = yield* LanguageModel.generateText({
@@ -1673,6 +1706,61 @@ describe("OpenAiLanguageModel", () => {
           status: "completed"
         })
       }))
+
+    for (const tool of [OpenAiTool.WebSearch({}), OpenAiTool.WebSearchPreview({})]) {
+      it.effect.each(webSearchOutcomes)(
+        `${tool.name} reports $status results from output_item.done`,
+        ({ status, isFailure }) =>
+          Effect.gen(function*() {
+            const streamEvents: ReadonlyArray<typeof Generated.ResponseStreamEvent.Type> = [
+              {
+                type: "response.created",
+                sequence_number: 1,
+                response: makeDefaultResponse({ status: "in_progress" })
+              },
+              {
+                type: "response.output_item.added",
+                sequence_number: 2,
+                output_index: 0,
+                item: makeWebSearchCall({ status: "in_progress" })
+              },
+              {
+                type: "response.output_item.done",
+                sequence_number: 3,
+                output_index: 0,
+                item: makeWebSearchCall({ status })
+              },
+              {
+                type: "response.completed",
+                sequence_number: 4,
+                response: makeDefaultResponse({ output: [makeWebSearchCall({ status })] })
+              }
+            ]
+
+            const parts = yield* LanguageModel.streamText({
+              prompt: "Search the web",
+              toolkit: Toolkit.make(tool)
+            }).pipe(
+              Stream.runCollect,
+              Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+              Effect.provide(makeStreamTestLayer(streamEvents))
+            )
+
+            const results = parts.filter((part) => part.type === "tool-result")
+            strictEqual(results.length, 1)
+            const toolResult = results[0]!
+            strictEqual(toolResult.name, tool.name)
+            strictEqual(toolResult.id, "ws_123")
+            strictEqual(toolResult.providerExecuted, true)
+            strictEqual(toolResult.isFailure, isFailure)
+            deepStrictEqual(toolResult.result, {
+              action: { type: "search", query: "Effect TypeScript" },
+              status
+            })
+            assert.isDefined(parts.find((part) => part.type === "finish"))
+          })
+      )
+    }
 
     it.effect("handles reasoning summary events when reasoning state is missing", () =>
       Effect.gen(function*() {

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -12,16 +12,16 @@ const webSearchOutcomes = [
   { status: "searching", isFailure: true }
 ] as const
 
-const partialFileSearchResults = [{ file_id: "file_123", text: "Matching text", score: 0.8 }] as const
+const fileSearchResults = [{ file_id: "file_123", text: "Matching text", score: 0.8 }] as const
 
 const fileSearchOutcomes = [
-  { status: "completed", isFailure: false, label: "results", results: partialFileSearchResults },
+  { status: "completed", isFailure: false, label: "results", results: fileSearchResults },
   { status: "completed", isFailure: false, label: "null results", results: null },
   { status: "completed", isFailure: false, label: "omitted results", results: undefined },
-  { status: "failed", isFailure: true, label: "partial results", results: partialFileSearchResults },
-  { status: "incomplete", isFailure: true, label: "partial results", results: partialFileSearchResults },
-  { status: "in_progress", isFailure: true, label: "partial results", results: partialFileSearchResults },
-  { status: "searching", isFailure: true, label: "partial results", results: partialFileSearchResults },
+  { status: "failed", isFailure: true, label: "results", results: fileSearchResults },
+  { status: "incomplete", isFailure: true, label: "results", results: fileSearchResults },
+  { status: "in_progress", isFailure: true, label: "results", results: fileSearchResults },
+  { status: "searching", isFailure: true, label: "results", results: fileSearchResults },
   { status: "failed", isFailure: true, label: "null results", results: null },
   { status: "failed", isFailure: true, label: "omitted results", results: undefined }
 ] as const
@@ -1822,7 +1822,7 @@ describe("OpenAiLanguageModel", () => {
             status,
             queries: ["Effect TypeScript"],
             results: results ?? null
-          }, "File search results should normalize null or omitted results to null")
+          })
         })
     )
 

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -16,6 +16,8 @@ const partialFileSearchResults = [{ file_id: "file_123", text: "Matching text", 
 
 const fileSearchOutcomes = [
   { status: "completed", isFailure: false, label: "results", results: partialFileSearchResults },
+  { status: "completed", isFailure: false, label: "null results", results: null },
+  { status: "completed", isFailure: false, label: "omitted results", results: undefined },
   { status: "failed", isFailure: true, label: "partial results", results: partialFileSearchResults },
   { status: "incomplete", isFailure: true, label: "partial results", results: partialFileSearchResults },
   { status: "in_progress", isFailure: true, label: "partial results", results: partialFileSearchResults },
@@ -1819,8 +1821,8 @@ describe("OpenAiLanguageModel", () => {
           deepStrictEqual(toolResult.result, {
             status,
             queries: ["Effect TypeScript"],
-            ...(results == null ? {} : { results })
-          })
+            results: results ?? null
+          }, "File search results should normalize null or omitted results to null")
         })
     )
 

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -12,18 +12,16 @@ const webSearchOutcomes = [
   { status: "searching", isFailure: true }
 ] as const
 
-const fileSearchOutcomes = [
-  { status: "completed", isFailure: false },
-  { status: "failed", isFailure: true },
-  { status: "incomplete", isFailure: true },
-  { status: "in_progress", isFailure: true },
-  { status: "searching", isFailure: true }
-] as const
+const partialFileSearchResults = [{ file_id: "file_123", text: "Matching text", score: 0.8 }] as const
 
-const fileSearchResults = [
-  { label: "partial results", results: [{ file_id: "file_123", text: "Matching text", score: 0.8 }] },
-  { label: "null results", results: null },
-  { label: "omitted results", results: undefined }
+const fileSearchOutcomes = [
+  { status: "completed", isFailure: false, label: "results", results: partialFileSearchResults },
+  { status: "failed", isFailure: true, label: "partial results", results: partialFileSearchResults },
+  { status: "incomplete", isFailure: true, label: "partial results", results: partialFileSearchResults },
+  { status: "in_progress", isFailure: true, label: "partial results", results: partialFileSearchResults },
+  { status: "searching", isFailure: true, label: "partial results", results: partialFileSearchResults },
+  { status: "failed", isFailure: true, label: "null results", results: null },
+  { status: "failed", isFailure: true, label: "omitted results", results: undefined }
 ] as const
 
 describe("OpenAiLanguageModel", () => {
@@ -1236,8 +1234,6 @@ describe("OpenAiLanguageModel", () => {
               strictEqual(result.toolResults.length, 1)
               const toolResult = result.toolResults[0]!
               strictEqual(toolResult.name, tool.name)
-              strictEqual(toolResult.id, "ws_123")
-              strictEqual(toolResult.providerExecuted, true)
               strictEqual(toolResult.isFailure, isFailure)
               deepStrictEqual(toolResult.result, {
                 action: { type: "search", query: "Effect TypeScript" },
@@ -1249,32 +1245,28 @@ describe("OpenAiLanguageModel", () => {
         )
       }
 
-      for (const { label, results } of fileSearchResults) {
-        it.effect.each(fileSearchOutcomes)(
-          `OpenAiFileSearch reports $status with ${label}`,
-          ({ status, isFailure }) =>
-            Effect.gen(function*() {
-              const result = yield* LanguageModel.generateText({
-                prompt: "Search the files",
-                toolkit: Toolkit.make(OpenAiTool.FileSearch({ vector_store_ids: ["vs_123"] }))
-              }).pipe(Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")))
+      it.effect.each(fileSearchOutcomes)(
+        "OpenAiFileSearch reports $status with $label",
+        ({ status, isFailure, results }) =>
+          Effect.gen(function*() {
+            const result = yield* LanguageModel.generateText({
+              prompt: "Search the files",
+              toolkit: Toolkit.make(OpenAiTool.FileSearch({ vector_store_ids: ["vs_123"] }))
+            }).pipe(Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")))
 
-              strictEqual(result.toolResults.length, 1)
-              const toolResult = result.toolResults[0]!
-              strictEqual(toolResult.name, "OpenAiFileSearch")
-              strictEqual(toolResult.id, "fs_123")
-              strictEqual(toolResult.providerExecuted, true)
-              strictEqual(toolResult.isFailure, isFailure)
-              deepStrictEqual(toolResult.result, {
-                status,
-                queries: ["Effect TypeScript"],
-                results: results ?? null
-              })
-            }).pipe(Effect.provide(makeTestLayer({
-              body: { output: [makeFileSearchCall({ status, ...(results === undefined ? {} : { results }) })] }
-            })))
-        )
-      }
+            strictEqual(result.toolResults.length, 1)
+            const toolResult = result.toolResults[0]!
+            strictEqual(toolResult.name, "OpenAiFileSearch")
+            strictEqual(toolResult.isFailure, isFailure)
+            deepStrictEqual(toolResult.result, {
+              status,
+              queries: ["Effect TypeScript"],
+              results: results ?? null
+            })
+          }).pipe(Effect.provide(makeTestLayer({
+            body: { output: [makeFileSearchCall({ status, ...(results === undefined ? {} : { results }) })] }
+          })))
+      )
 
       it.effect("uses canonical OpenAiMcp name for mcp_approval_request", () =>
         Effect.gen(function*() {
@@ -1755,26 +1747,16 @@ describe("OpenAiLanguageModel", () => {
           Effect.gen(function*() {
             const streamEvents: ReadonlyArray<typeof Generated.ResponseStreamEvent.Type> = [
               {
-                type: "response.created",
-                sequence_number: 1,
-                response: makeDefaultResponse({ status: "in_progress" })
-              },
-              {
                 type: "response.output_item.added",
-                sequence_number: 2,
+                sequence_number: 1,
                 output_index: 0,
                 item: makeWebSearchCall({ status: "in_progress" })
               },
               {
                 type: "response.output_item.done",
-                sequence_number: 3,
+                sequence_number: 2,
                 output_index: 0,
                 item: makeWebSearchCall({ status })
-              },
-              {
-                type: "response.completed",
-                sequence_number: 4,
-                response: makeDefaultResponse({ output: [makeWebSearchCall({ status })] })
               }
             ]
 
@@ -1791,74 +1773,56 @@ describe("OpenAiLanguageModel", () => {
             strictEqual(results.length, 1)
             const toolResult = results[0]!
             strictEqual(toolResult.name, tool.name)
-            strictEqual(toolResult.id, "ws_123")
-            strictEqual(toolResult.providerExecuted, true)
             strictEqual(toolResult.isFailure, isFailure)
             deepStrictEqual(toolResult.result, {
               action: { type: "search", query: "Effect TypeScript" },
               status
             })
-            assert.isDefined(parts.find((part) => part.type === "finish"))
           })
       )
     }
 
-    for (const { label, results } of fileSearchResults) {
-      it.effect.each(fileSearchOutcomes)(
-        `OpenAiFileSearch reports $status with ${label} from output_item.done`,
-        ({ status, isFailure }) =>
-          Effect.gen(function*() {
-            const call = makeFileSearchCall({ status, ...(results === undefined ? {} : { results }) })
-            const streamEvents: ReadonlyArray<typeof Generated.ResponseStreamEvent.Type> = [
-              {
-                type: "response.created",
-                sequence_number: 1,
-                response: makeDefaultResponse({ status: "in_progress" })
-              },
-              {
-                type: "response.output_item.added",
-                sequence_number: 2,
-                output_index: 0,
-                item: makeFileSearchCall({ status: "in_progress" })
-              },
-              {
-                type: "response.output_item.done",
-                sequence_number: 3,
-                output_index: 0,
-                item: call
-              },
-              {
-                type: "response.completed",
-                sequence_number: 4,
-                response: makeDefaultResponse({ output: [call] })
-              }
-            ]
+    it.effect.each(fileSearchOutcomes)(
+      "OpenAiFileSearch reports $status with $label from output_item.done",
+      ({ status, isFailure, results }) =>
+        Effect.gen(function*() {
+          const call = makeFileSearchCall({ status, ...(results === undefined ? {} : { results }) })
+          const streamEvents: ReadonlyArray<typeof Generated.ResponseStreamEvent.Type> = [
+            {
+              type: "response.output_item.added",
+              sequence_number: 1,
+              output_index: 0,
+              item: makeFileSearchCall({ status: "in_progress" })
+            },
+            {
+              type: "response.output_item.done",
+              sequence_number: 2,
+              output_index: 0,
+              item: call
+            }
+          ]
 
-            const parts = yield* LanguageModel.streamText({
-              prompt: "Search the files",
-              toolkit: Toolkit.make(OpenAiTool.FileSearch({ vector_store_ids: ["vs_123"] }))
-            }).pipe(
-              Stream.runCollect,
-              Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
-              Effect.provide(makeStreamTestLayer(streamEvents))
-            )
+          const parts = yield* LanguageModel.streamText({
+            prompt: "Search the files",
+            toolkit: Toolkit.make(OpenAiTool.FileSearch({ vector_store_ids: ["vs_123"] }))
+          }).pipe(
+            Stream.runCollect,
+            Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+            Effect.provide(makeStreamTestLayer(streamEvents))
+          )
 
-            const toolResults = parts.filter((part) => part.type === "tool-result")
-            strictEqual(toolResults.length, 1)
-            const toolResult = toolResults[0]!
-            strictEqual(toolResult.name, "OpenAiFileSearch")
-            strictEqual(toolResult.id, "fs_123")
-            strictEqual(toolResult.providerExecuted, true)
-            strictEqual(toolResult.isFailure, isFailure)
-            deepStrictEqual(toolResult.result, {
-              status,
-              queries: ["Effect TypeScript"],
-              ...(results == null ? {} : { results })
-            })
-            assert.isDefined(parts.find((part) => part.type === "finish"))
+          const toolResults = parts.filter((part) => part.type === "tool-result")
+          strictEqual(toolResults.length, 1)
+          const toolResult = toolResults[0]!
+          strictEqual(toolResult.name, "OpenAiFileSearch")
+          strictEqual(toolResult.isFailure, isFailure)
+          deepStrictEqual(toolResult.result, {
+            status,
+            queries: ["Effect TypeScript"],
+            ...(results == null ? {} : { results })
           })
-      )
-    }
+        })
+    )
 
     it.effect("handles reasoning summary events when reasoning state is missing", () =>
       Effect.gen(function*() {

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -5,25 +5,15 @@ import { Array, Context, Effect, Layer, Redacted, Ref, Schema, SchemaGetter, Str
 import { type AiError, LanguageModel, Prompt, Response as AiResponse, Tool, Toolkit } from "effect/unstable/ai"
 import { HttpClient, type HttpClientError, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
-const webSearchOutcomes = [
-  { status: "completed", isFailure: false },
-  { status: "failed", isFailure: true },
-  { status: "in_progress", isFailure: true },
-  { status: "searching", isFailure: true }
+const webSearchFailures = [
+  { tool: OpenAiTool.WebSearch({}), status: "failed" },
+  { tool: OpenAiTool.WebSearchPreview({}), status: "searching" }
 ] as const
 
-const fileSearchResults = [{ file_id: "file_123", text: "Matching text", score: 0.8 }] as const
-
 const fileSearchOutcomes = [
-  { status: "completed", isFailure: false, label: "results", results: fileSearchResults },
-  { status: "completed", isFailure: false, label: "null results", results: null },
-  { status: "completed", isFailure: false, label: "omitted results", results: undefined },
-  { status: "failed", isFailure: true, label: "results", results: fileSearchResults },
-  { status: "incomplete", isFailure: true, label: "results", results: fileSearchResults },
-  { status: "in_progress", isFailure: true, label: "results", results: fileSearchResults },
-  { status: "searching", isFailure: true, label: "results", results: fileSearchResults },
-  { status: "failed", isFailure: true, label: "null results", results: null },
-  { status: "failed", isFailure: true, label: "omitted results", results: undefined }
+  { status: "completed", isFailure: false, results: undefined },
+  { status: "failed", isFailure: true, results: null },
+  { status: "incomplete", isFailure: true, results: [{ file_id: "file_123", text: "Matching text" }] }
 ] as const
 
 describe("OpenAiLanguageModel", () => {
@@ -1223,20 +1213,17 @@ describe("OpenAiLanguageModel", () => {
           )
       )
 
-      for (const tool of [OpenAiTool.WebSearch({}), OpenAiTool.WebSearchPreview({})]) {
-        it.effect.each(webSearchOutcomes)(
-          `${tool.name} reports $status results`,
-          ({ status, isFailure }) =>
+      for (const { tool, status } of webSearchFailures) {
+        it.effect(
+          `${tool.name} preserves ${status} results`,
+          () =>
             Effect.gen(function*() {
               const result = yield* LanguageModel.generateText({
                 prompt: "Search the web",
                 toolkit: Toolkit.make(tool)
               }).pipe(Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")))
-
-              strictEqual(result.toolResults.length, 1)
               const toolResult = result.toolResults[0]!
-              strictEqual(toolResult.name, tool.name)
-              strictEqual(toolResult.isFailure, isFailure)
+              strictEqual(toolResult.isFailure, true)
               deepStrictEqual(toolResult.result, {
                 action: { type: "search", query: "Effect TypeScript" },
                 status
@@ -1248,17 +1235,14 @@ describe("OpenAiLanguageModel", () => {
       }
 
       it.effect.each(fileSearchOutcomes)(
-        "OpenAiFileSearch reports $status with $label",
+        "OpenAiFileSearch reports $status results",
         ({ status, isFailure, results }) =>
           Effect.gen(function*() {
             const result = yield* LanguageModel.generateText({
               prompt: "Search the files",
               toolkit: Toolkit.make(OpenAiTool.FileSearch({ vector_store_ids: ["vs_123"] }))
             }).pipe(Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")))
-
-            strictEqual(result.toolResults.length, 1)
             const toolResult = result.toolResults[0]!
-            strictEqual(toolResult.name, "OpenAiFileSearch")
             strictEqual(toolResult.isFailure, isFailure)
             deepStrictEqual(toolResult.result, {
               status,
@@ -1742,40 +1726,27 @@ describe("OpenAiLanguageModel", () => {
         })
       }))
 
-    for (const tool of [OpenAiTool.WebSearch({}), OpenAiTool.WebSearchPreview({})]) {
-      it.effect.each(webSearchOutcomes)(
-        `${tool.name} reports $status results from output_item.done`,
-        ({ status, isFailure }) =>
+    for (const { tool, status } of webSearchFailures) {
+      it.effect(
+        `${tool.name} preserves ${status} results from output_item.done`,
+        () =>
           Effect.gen(function*() {
-            const streamEvents: ReadonlyArray<typeof Generated.ResponseStreamEvent.Type> = [
-              {
-                type: "response.output_item.added",
-                sequence_number: 1,
-                output_index: 0,
-                item: makeWebSearchCall({ status: "in_progress" })
-              },
-              {
-                type: "response.output_item.done",
-                sequence_number: 2,
-                output_index: 0,
-                item: makeWebSearchCall({ status })
-              }
-            ]
-
             const parts = yield* LanguageModel.streamText({
               prompt: "Search the web",
               toolkit: Toolkit.make(tool)
             }).pipe(
               Stream.runCollect,
               Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
-              Effect.provide(makeStreamTestLayer(streamEvents))
+              Effect.provide(makeStreamTestLayer([{
+                type: "response.output_item.done",
+                sequence_number: 1,
+                output_index: 0,
+                item: makeWebSearchCall({ status })
+              }]))
             )
 
-            const results = parts.filter((part) => part.type === "tool-result")
-            strictEqual(results.length, 1)
-            const toolResult = results[0]!
-            strictEqual(toolResult.name, tool.name)
-            strictEqual(toolResult.isFailure, isFailure)
+            const toolResult = parts.find((part) => part.type === "tool-result")!
+            strictEqual(toolResult.isFailure, true)
             deepStrictEqual(toolResult.result, {
               action: { type: "search", query: "Effect TypeScript" },
               status
@@ -1785,38 +1756,24 @@ describe("OpenAiLanguageModel", () => {
     }
 
     it.effect.each(fileSearchOutcomes)(
-      "OpenAiFileSearch reports $status with $label from output_item.done",
+      "OpenAiFileSearch reports $status results from output_item.done",
       ({ status, isFailure, results }) =>
         Effect.gen(function*() {
-          const call = makeFileSearchCall({ status, ...(results === undefined ? {} : { results }) })
-          const streamEvents: ReadonlyArray<typeof Generated.ResponseStreamEvent.Type> = [
-            {
-              type: "response.output_item.added",
-              sequence_number: 1,
-              output_index: 0,
-              item: makeFileSearchCall({ status: "in_progress" })
-            },
-            {
-              type: "response.output_item.done",
-              sequence_number: 2,
-              output_index: 0,
-              item: call
-            }
-          ]
-
           const parts = yield* LanguageModel.streamText({
             prompt: "Search the files",
             toolkit: Toolkit.make(OpenAiTool.FileSearch({ vector_store_ids: ["vs_123"] }))
           }).pipe(
             Stream.runCollect,
             Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
-            Effect.provide(makeStreamTestLayer(streamEvents))
+            Effect.provide(makeStreamTestLayer([{
+              type: "response.output_item.done",
+              sequence_number: 1,
+              output_index: 0,
+              item: makeFileSearchCall({ status, ...(results === undefined ? {} : { results }) })
+            }]))
           )
 
-          const toolResults = parts.filter((part) => part.type === "tool-result")
-          strictEqual(toolResults.length, 1)
-          const toolResult = toolResults[0]!
-          strictEqual(toolResult.name, "OpenAiFileSearch")
+          const toolResult = parts.find((part) => part.type === "tool-result")!
           strictEqual(toolResult.isFailure, isFailure)
           deepStrictEqual(toolResult.result, {
             status,

--- a/packages/ai/openai/typetest/OpenAiTool.tst.ts
+++ b/packages/ai/openai/typetest/OpenAiTool.tst.ts
@@ -6,7 +6,7 @@ describe("OpenAiTool", () => {
   it("distinguishes completed file searches from failed and unfinished searches", () => {
     const fileSearch = OpenAiTool.FileSearch({ vector_store_ids: ["vs_123"] })
 
-    type Results = typeof Generated.FileSearchToolCall.fields.results.schema.Type
+    type Results = Exclude<Generated.FileSearchToolCall["results"], undefined>
 
     type Failure = {
       readonly status: "in_progress" | "searching" | "incomplete" | "failed"

--- a/packages/ai/openai/typetest/OpenAiTool.tst.ts
+++ b/packages/ai/openai/typetest/OpenAiTool.tst.ts
@@ -3,6 +3,18 @@ import type { Tool } from "effect/unstable/ai"
 import { describe, expect, it } from "tstyche"
 
 describe("OpenAiTool", () => {
+  it("preserves failed and unfinished file search details in its failure type", () => {
+    const fileSearch = OpenAiTool.FileSearch({ vector_store_ids: ["vs_123"] })
+
+    type Failure = {
+      readonly status: "in_progress" | "searching" | "incomplete" | "failed"
+      readonly queries: Generated.FileSearchToolCall["queries"]
+      readonly results?: Exclude<Generated.FileSearchToolCall["results"], undefined>
+    }
+
+    expect<Tool.Failure<typeof fileSearch>>().type.toBe<Failure>()
+  })
+
   it("preserves failed and unfinished web search details in both tools' failure types", () => {
     const webSearch = OpenAiTool.WebSearch({})
     const preview = OpenAiTool.WebSearchPreview({})

--- a/packages/ai/openai/typetest/OpenAiTool.tst.ts
+++ b/packages/ai/openai/typetest/OpenAiTool.tst.ts
@@ -1,0 +1,18 @@
+import { type Generated, OpenAiTool } from "@effect/ai-openai"
+import type { Tool } from "effect/unstable/ai"
+import { describe, expect, it } from "tstyche"
+
+describe("OpenAiTool", () => {
+  it("preserves failed and unfinished web search details in both tools' failure types", () => {
+    const webSearch = OpenAiTool.WebSearch({})
+    const preview = OpenAiTool.WebSearchPreview({})
+
+    type Failure = {
+      readonly action: Generated.WebSearchToolCall["action"]
+      readonly status: "in_progress" | "searching" | "failed"
+    }
+
+    expect<Tool.Failure<typeof webSearch>>().type.toBe<Failure>()
+    expect<Tool.Failure<typeof preview>>().type.toBe<Failure>()
+  })
+})

--- a/packages/ai/openai/typetest/OpenAiTool.tst.ts
+++ b/packages/ai/openai/typetest/OpenAiTool.tst.ts
@@ -6,22 +6,18 @@ describe("OpenAiTool", () => {
   it("distinguishes completed file searches from failed and unfinished searches", () => {
     const fileSearch = OpenAiTool.FileSearch({ vector_store_ids: ["vs_123"] })
 
-    type Results = Exclude<Generated.FileSearchToolCall["results"], undefined>
-
     type Failure = {
       readonly status: "in_progress" | "searching" | "incomplete" | "failed"
       readonly queries: Generated.FileSearchToolCall["queries"]
-      readonly results: Results
+      readonly results: Exclude<Generated.FileSearchToolCall["results"], undefined>
     }
 
     expect<Tool.Failure<typeof fileSearch>>().type.toBe<Failure>()
-    expect<Tool.Success<typeof fileSearch>["status"]>().type.toBe<"completed">()
-    expect<Pick<Tool.Success<typeof fileSearch>, "results">>().type.toBe<{ readonly results: Results }>()
+    expect<Tool.Success<typeof fileSearch>>().type.toBe<Omit<Failure, "status"> & { readonly status: "completed" }>()
   })
 
-  it("distinguishes completed web searches from failed and unfinished searches for both tools", () => {
+  it("distinguishes completed web searches from failed and unfinished searches", () => {
     const webSearch = OpenAiTool.WebSearch({})
-    const preview = OpenAiTool.WebSearchPreview({})
 
     type Failure = {
       readonly action: Generated.WebSearchToolCall["action"]
@@ -29,8 +25,6 @@ describe("OpenAiTool", () => {
     }
 
     expect<Tool.Failure<typeof webSearch>>().type.toBe<Failure>()
-    expect<Tool.Failure<typeof preview>>().type.toBe<Failure>()
     expect<Tool.Success<typeof webSearch>["status"]>().type.toBe<"completed">()
-    expect<Tool.Success<typeof preview>["status"]>().type.toBe<"completed">()
   })
 })

--- a/packages/ai/openai/typetest/OpenAiTool.tst.ts
+++ b/packages/ai/openai/typetest/OpenAiTool.tst.ts
@@ -3,7 +3,7 @@ import type { Tool } from "effect/unstable/ai"
 import { describe, expect, it } from "tstyche"
 
 describe("OpenAiTool", () => {
-  it("preserves failed and unfinished file search details in its failure type", () => {
+  it("distinguishes completed file searches from failed and unfinished searches", () => {
     const fileSearch = OpenAiTool.FileSearch({ vector_store_ids: ["vs_123"] })
 
     type Failure = {
@@ -13,9 +13,10 @@ describe("OpenAiTool", () => {
     }
 
     expect<Tool.Failure<typeof fileSearch>>().type.toBe<Failure>()
+    expect<Tool.Success<typeof fileSearch>["status"]>().type.toBe<"completed">()
   })
 
-  it("preserves failed and unfinished web search details in both tools' failure types", () => {
+  it("distinguishes completed web searches from failed and unfinished searches for both tools", () => {
     const webSearch = OpenAiTool.WebSearch({})
     const preview = OpenAiTool.WebSearchPreview({})
 
@@ -26,5 +27,7 @@ describe("OpenAiTool", () => {
 
     expect<Tool.Failure<typeof webSearch>>().type.toBe<Failure>()
     expect<Tool.Failure<typeof preview>>().type.toBe<Failure>()
+    expect<Tool.Success<typeof webSearch>["status"]>().type.toBe<"completed">()
+    expect<Tool.Success<typeof preview>["status"]>().type.toBe<"completed">()
   })
 })

--- a/packages/ai/openai/typetest/OpenAiTool.tst.ts
+++ b/packages/ai/openai/typetest/OpenAiTool.tst.ts
@@ -6,14 +6,17 @@ describe("OpenAiTool", () => {
   it("distinguishes completed file searches from failed and unfinished searches", () => {
     const fileSearch = OpenAiTool.FileSearch({ vector_store_ids: ["vs_123"] })
 
+    type Results = typeof Generated.FileSearchToolCall.fields.results.schema.Type
+
     type Failure = {
       readonly status: "in_progress" | "searching" | "incomplete" | "failed"
       readonly queries: Generated.FileSearchToolCall["queries"]
-      readonly results?: Exclude<Generated.FileSearchToolCall["results"], undefined>
+      readonly results: Results
     }
 
     expect<Tool.Failure<typeof fileSearch>>().type.toBe<Failure>()
     expect<Tool.Success<typeof fileSearch>["status"]>().type.toBe<"completed">()
+    expect<Pick<Tool.Success<typeof fileSearch>, "results">>().type.toBe<{ readonly results: Results }>()
   })
 
   it("distinguishes completed web searches from failed and unfinished searches for both tools", () => {


### PR DESCRIPTION
OpenAI provider-executed tool calls were reported as successful tool results even when they failed. Both `generateText` and `streamText` now classify failures while preserving the call details.

- Web and file searches with a non-`completed` status are failures. Failure payloads preserve the status, action or queries, and partial file results. File-search `incomplete` outcomes remain failures with their partial results preserved.
- Code interpreter calls with a non-`completed` status are failures. Results include `status` alongside `outputs`, and omitted outputs become `null`. The response decoder accepts `interpreting` and `failed` statuses, nullable code, and nullable outputs. Omitted code becomes `null`. Streaming closes parameter JSON and emits a matching call before the result when no `code.done` event arrives, without duplicating calls completed by `code.done`.
- Image generation calls with a non-`completed` status are failures carrying `status` and `result`. Partial images remain preliminary successful results with the existing `{ result }` shape.
- Omitted code-interpreter and image-generation statuses default to `completed` consistently for classification and result payloads in both response paths.
- MCP calls that report an `error` are failures carrying the error message. Successful MCP results no longer include `error`.

Success schemas accept only `completed`; failure schemas derive the remaining statuses from the generated definitions. `WebSearch` and `WebSearchPreview` share their success and failure schemas. Both response paths normalize null or omitted file-search results to `results: null`, and both file-search schemas require this nullable field.

Validation passed through `nix develop -c`:

- `pnpm test --run packages/ai/openai/test/OpenAiLanguageModel.test.ts`: 78 tests. Ten focused search cases cover failed/unfinished web searches, completed file searches with omitted results, failed file searches with null results, and incomplete searches with partial results across both response paths. Existing tests cover completed web searches and successful MCP calls.
- `pnpm test-types packages/ai/openai/typetest/OpenAiTool.tst.ts`: eight assertions across TypeScript 5.9.3 and 6.0.3.
- `pnpm check`
- `pnpm lint-fix`
- A temporary JSON/SSE probe passed 16 code-interpreter scenarios through parameter and result validation: null/omitted code on completed and failed calls, normal escaped code deltas, empty code, `code.done` without deltas, and completion from `output_item.done`. It checked complete parameter JSON and exactly one matching call before each result. Ten scenarios failed on the preceding commit. The probe was removed; committed tests are unchanged.


Closes EFF-1335
