### PR TITLE
fix(SchemaRepresentation): preserve __proto__ fields in generated code

### DIFF
--- a/.changeset/fix-schema-codegen-proto.md
+++ b/.changeset/fix-schema-codegen-proto.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `SchemaRepresentation.toCodeDocument` dropping Struct fields named `__proto__` from generated schemas. These fields now use computed keys, such as `Schema.Struct({ ["__proto__"]: Schema.String })`, so the generated schema validates them correctly.

--- a/packages/effect/src/internal/schema/toCodeDocument.ts
+++ b/packages/effect/src/internal/schema/toCodeDocument.ts
@@ -516,15 +516,15 @@ export function toCodeDocument(
         const properties = representation.propertySignatures.map((property, index) => {
           const isSymbol = typeof property.name === "symbol"
           const name = isSymbol
-            ? addSymbol(property.name)
+            ? `[${addSymbol(property.name)}]`
             : formatPropertyKey(property.name)
           const type = recur(property.type, [...path, "propertySignatures", index, "type"])
           let runtime = type.runtime
           if (property.isMutable) runtime = `Schema.mutableKey(${runtime})`
           if (property.isOptional) runtime = `Schema.optionalKey(${runtime})`
           runtime += runtimeAnnotate(property.annotations, "annotateKey")
-          const runtimeName = isSymbol ? `[${name}]` : name
-          const typeName = `${property.isMutable ? "" : "readonly "}${runtimeName}${property.isOptional ? "?" : ""}`
+          const runtimeName = property.name === "__proto__" ? `[${name}]` : name
+          const typeName = `${property.isMutable ? "" : "readonly "}${name}${property.isOptional ? "?" : ""}`
           return {
             code: makeCode(`${runtimeName}: ${runtime}`, `${typeName}: ${type.Type}`)
           }

--- a/packages/effect/test/schema/representation/toCodeDocument.test.ts
+++ b/packages/effect/test/schema/representation/toCodeDocument.test.ts
@@ -1,4 +1,6 @@
+import { assert } from "@effect/vitest"
 import { JsonSchema, Schema, SchemaRepresentation } from "effect"
+import { TestSchema } from "effect/testing"
 import { describe, it } from "vitest"
 import { assertTrue, deepStrictEqual, strictEqual, throws } from "../../utils/assert.ts"
 
@@ -1147,6 +1149,42 @@ describe("toCodeDocument", () => {
   })
 
   describe("Struct", () => {
+    it("preserves a required __proto__ property in generated code", async () => {
+      const schema = Schema.Struct({ ["__proto__"]: Schema.String })
+      assertSchema({ schema }, {
+        codes: makeCode(
+          `Schema.Struct({ ["__proto__"]: Schema.String })`,
+          `{ readonly "__proto__": string }`
+        )
+      })
+
+      const document = SchemaRepresentation.toCodeDocument(SchemaRepresentation.toRepresentations([schema.ast]))
+      const generated: typeof schema = new Function("Schema", `return ${document.codes[0].runtime}`)(Schema)
+      assert.deepStrictEqual(Object.keys(generated.fields), ["__proto__"])
+      const decoding = new TestSchema.Asserts(generated).decoding()
+      await decoding.succeed({ ["__proto__"]: "value" })
+      await decoding.fail({}, `Missing key\n  at ["__proto__"]`)
+      await decoding.fail({ ["__proto__"]: 123 }, `Expected string\n  at ["__proto__"]`)
+    })
+
+    it("preserves an optional __proto__ property in generated code", async () => {
+      const schema = Schema.Struct({ ["__proto__"]: Schema.optionalKey(Schema.String) })
+      assertSchema({ schema }, {
+        codes: makeCode(
+          `Schema.Struct({ ["__proto__"]: Schema.optionalKey(Schema.String) })`,
+          `{ readonly "__proto__"?: string }`
+        )
+      })
+
+      const document = SchemaRepresentation.toCodeDocument(SchemaRepresentation.toRepresentations([schema.ast]))
+      const generated: typeof schema = new Function("Schema", `return ${document.codes[0].runtime}`)(Schema)
+      assert.deepStrictEqual(Object.keys(generated.fields), ["__proto__"])
+      const decoding = new TestSchema.Asserts(generated).decoding()
+      await decoding.succeed({})
+      await decoding.succeed({ ["__proto__"]: "value" })
+      await decoding.fail({ ["__proto__"]: 123 }, `Expected string\n  at ["__proto__"]`)
+    })
+
     it("empty struct", () => {
       assertSchema({ schema: Schema.Struct({}) }, {
         codes: makeCode("Schema.Struct({  })", "{  }")


### PR DESCRIPTION
## Summary

`SchemaRepresentation.toCodeDocument` emits `"__proto__": Schema.String` as an object-literal property. JavaScript treats this as a prototype setter, so the generated Struct loses the field and accepts values that the original schema rejects.

Emit `["__proto__"]: Schema.String` instead. Keep the generated TypeScript type unchanged.

Includes regression tests for required and optional fields that check the emitted code, execute it, and verify decoding with `TestSchema`.

## Validation

- Code-generation and OpenAPI generator suites: 126 tests passed.
- `pnpm lint-fix` and `pnpm check` passed.
- Both new tests failed before the fix.

Local commands used `--config.verify-deps-before-run=false` because switching branches changed workspace package versions. The lockfile and dependency specifications are unchanged.

This PR is separate from the JSON Schema importer work.