### PR TITLE
fix(SchemaRepresentation): group optional tuple element types

### DIFF
--- a/.changeset/fix-schema-codegen-optional-tuples.md
+++ b/.changeset/fix-schema-codegen-optional-tuples.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `SchemaRepresentation.toCodeDocument` generating invalid TypeScript for optional tuple elements containing unions or nested readonly tuples. Optional element types are now parenthesized, for example `readonly [(string | number)?]` instead of `readonly [string | number?]`. Generated runtime schemas are unchanged.

--- a/packages/effect/src/internal/schema/toCodeDocument.ts
+++ b/packages/effect/src/internal/schema/toCodeDocument.ts
@@ -484,7 +484,7 @@ export function toCodeDocument(
             `${element.isOptional ? "Schema.optionalKey(" : ""}${type.runtime}${element.isOptional ? ")" : ""}${
               runtimeAnnotate(element.annotations, "annotateKey")
             }`,
-            `${type.Type}${element.isOptional ? "?" : ""}`
+            element.isOptional ? `(${type.Type})?` : type.Type
           )
         })
         const rest = representation.rest.map((item, index) => recur(item, [...path, "rest", index]))

--- a/packages/effect/test/schema/representation/toCodeDocument.annotations.test.ts
+++ b/packages/effect/test/schema/representation/toCodeDocument.annotations.test.ts
@@ -319,7 +319,7 @@ describe("SchemaRepresentation.toCodeDocument annotations", () => {
       },
       {
         runtime: `Schema.TupleWithRest(Schema.Tuple([Schema.optionalKey(Schema.String)]), [Schema.Number])`,
-        Type: `readonly [string?, ...Array<number>]`
+        Type: `readonly [(string)?, ...Array<number>]`
       },
       {
         runtime: `Schema.Struct({ 1: Schema.Boolean })`,

--- a/packages/effect/test/schema/representation/toCodeDocument.test.ts
+++ b/packages/effect/test/schema/representation/toCodeDocument.test.ts
@@ -1069,7 +1069,7 @@ describe("toCodeDocument", () => {
       assertSchema(
         { schema: Schema.Tuple([Schema.optionalKey(Schema.String)]) },
         {
-          codes: makeCode(`Schema.Tuple([Schema.optionalKey(Schema.String)])`, "readonly [string?]")
+          codes: makeCode(`Schema.Tuple([Schema.optionalKey(Schema.String)])`, `readonly [(string)?]`)
         }
       )
       assertSchema(
@@ -1077,10 +1077,58 @@ describe("toCodeDocument", () => {
         {
           codes: makeCode(
             `Schema.Tuple([Schema.optionalKey(Schema.String)]).annotate({ "description": "a" })`,
-            "readonly [string?]"
+            `readonly [(string)?]`
           )
         }
       )
+    })
+
+    it("optional union elements", () => {
+      assertSchema(
+        { schema: Schema.Tuple([Schema.optionalKey(Schema.Union([Schema.String, Schema.Number]))]) },
+        {
+          codes: makeCode(
+            `Schema.Tuple([Schema.optionalKey(Schema.Union([Schema.String, Schema.Number]))])`,
+            `readonly [(string | number)?]`
+          )
+        }
+      )
+      assertSchema(
+        { schema: Schema.Tuple([Schema.optionalKey(Schema.Literals(["a", "b"]))]) },
+        {
+          codes: makeCode(
+            `Schema.Tuple([Schema.optionalKey(Schema.Literals(["a", "b"]))])`,
+            `readonly [("a" | "b")?]`
+          )
+        }
+      )
+    })
+
+    it("optional readonly tuple element", () => {
+      assertSchema(
+        { schema: Schema.Tuple([Schema.optionalKey(Schema.Tuple([Schema.String]))]) },
+        {
+          codes: makeCode(
+            `Schema.Tuple([Schema.optionalKey(Schema.Tuple([Schema.String]))])`,
+            `readonly [(readonly [string])?]`
+          )
+        }
+      )
+    })
+
+    it("optional union element imported from JSON Schema", () => {
+      assertJsonSchema({
+        schema: {
+          type: "array",
+          prefixItems: [{ anyOf: [{ type: "string" }, { type: "number" }] }],
+          items: false
+        }
+      }, {
+        codes: makeCode(
+          `Schema.Tuple([Schema.optionalKey(Schema.Union([Schema.String, Schema.Number.check(Schema.isFinite())]))])`,
+          `readonly [(string | number)?]`
+        )
+      })
     })
 
     it("annotateKey", () => {
@@ -1115,6 +1163,20 @@ describe("toCodeDocument", () => {
   })
 
   it("TupleWithRest", () => {
+    assertSchema(
+      {
+        schema: Schema.TupleWithRest(
+          Schema.Tuple([Schema.optionalKey(Schema.Union([Schema.String, Schema.Number]))]),
+          [Schema.Boolean]
+        )
+      },
+      {
+        codes: makeCode(
+          `Schema.TupleWithRest(Schema.Tuple([Schema.optionalKey(Schema.Union([Schema.String, Schema.Number]))]), [Schema.Boolean])`,
+          `readonly [(string | number)?, ...Array<boolean>]`
+        )
+      }
+    )
     assertSchema(
       { schema: Schema.TupleWithRest(Schema.Tuple([Schema.String]), [Schema.Number]) },
       {


### PR DESCRIPTION
## Summary

`SchemaRepresentation.toCodeDocument` appends `?` directly to optional tuple element types, producing invalid TypeScript for unions and nested readonly tuples.

Parenthesize optional element types before appending `?`. For example:

```ts
// Before
readonly [string | number?]

// After
readonly [(string | number)?]
```

Generated runtime schemas are unchanged. Includes regression coverage for unions, literal unions, nested readonly tuples, tuples with rest elements, and the JSON Schema import path, plus a changeset.

## Validation

- 353 targeted tests passed across code generation, annotations, JSON Schema import, and the OpenAPI generator.
- Seven generated-code cases compiled under strict TypeScript settings, including intersections.
- `pnpm lint-fix` and `pnpm check` passed.
- The new regression cases failed before the fix.

Local commands used `--config.verify-deps-before-run=false` for the previously identified workspace install-state mismatch after switching branches. No dependencies or lockfile changes.