### PR TITLE
fix: remove dangling @internal references from published declarations

### DIFF
--- a/.changeset/fix-dangling-internal-declarations.md
+++ b/.changeset/fix-dangling-internal-declarations.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix published declarations referencing symbols stripped as `@internal`, which broke consumers compiling with `skipLibCheck: false`. `Effectable.d.ts` now uses the public `Effect.TypeId`, `Match.d.ts` no longer aliases an internal `Contextual` type, `Schema.d.ts` ships the `AnnotationSchemaConstraint` alias it references, and the CLI's `toFlagDoc` helper is marked internal so it no longer leaks `Param.getParamMetadata`.

--- a/.changeset/rename-schema-arbitrary-filter-constraint.md
+++ b/.changeset/rename-schema-arbitrary-filter-constraint.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Rename `Schema.Annotations.ToArbitrary.Constraint` to `Schema.Annotations.ToArbitrary.FilterConstraint`.
+
+Code that refers to the previous type name should update its type annotations to use `FilterConstraint`.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -68,6 +68,7 @@ jobs:
         run: |
           sed -i 's/"stripInternal": false/"stripInternal": true/' tsconfig.base.json
       - run: pnpm build
+      - run: pnpm check-dist-types
 
   bundle:
     name: Bundle

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "runtimeperf": "pnpm --dir packages/effect exec node runtimeperf/run.mts",
     "runtimeperf-compare": "pnpm --dir packages/effect exec node runtimeperf/compare.mts",
     "check-recursive": "pnpm --recursive --filter \"./packages/**/*\" exec tsc -b tsconfig.json",
+    "check-dist-types": "node scripts/check-dist-types.mjs",
     "jsdocs": "effect-jsdocs",
     "lint": "oxlint -f unix && dprint check",
     "lint-fix": "oxlint --fix && dprint fmt",

--- a/packages/effect/src/Effectable.ts
+++ b/packages/effect/src/Effectable.ts
@@ -8,7 +8,7 @@
  */
 import type * as Effect from "./Effect.ts"
 import type * as Fiber from "./Fiber.ts"
-import { type EffectTypeId, evaluate, makePrimitiveProto } from "./internal/core.ts"
+import { evaluate, makePrimitiveProto } from "./internal/core.ts"
 
 /**
  * Create a low-level `Effect` prototype.
@@ -78,7 +78,7 @@ type AsEffectReturn<Self> = Self extends {
 
 declare abstract class MixinBase extends Class<any, any, any> {
   constructor(...args: ReadonlyArray<any>)
-  override readonly [EffectTypeId]: AsEffectReturn<this>[typeof EffectTypeId]
+  override readonly [Effect.TypeId]: AsEffectReturn<this>[Effect.TypeId]
   override [Symbol.iterator](): Effect.EffectIterator<AsEffectReturn<this>>
 }
 

--- a/packages/effect/src/Match.ts
+++ b/packages/effect/src/Match.ts
@@ -22,7 +22,7 @@ const TypeId = internal.TypeId
 
 // The conditional must stay deferred until P is inferred. Replacing it with an
 // intersection loses contextual typing for nested generic calls (microsoft/TypeScript#52864).
-type Contextual<P, Fallback> = internal.Contextual<P, Fallback>
+type Contextual<P, Fallback> = [P] extends [never] ? Fallback : P
 
 type TagHandlers<D extends string, R, Ret> = {
   readonly [Tag in Types.Tags<D, R> & string]: (_: Extract<R, Record<D, Tag>>) => Ret

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -14980,7 +14980,7 @@ export function resolveAnnotations<S extends Constraint>(
 export function resolveAnnotationsKey<S extends Constraint>(schema: S): Annotations.Key<S["Type"]> | undefined {
   return schema.ast.context?.annotations
 }
-/** @internal */
+// Alias for the top-level `Constraint`, which `Annotations.ToArbitrary.Constraint` shadows below.
 type AnnotationSchemaConstraint = Constraint
 
 /**

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -62,8 +62,6 @@ import * as Record_ from "./Record.ts"
 import * as Redacted_ from "./Redacted.ts"
 import * as RegExp_ from "./RegExp.ts"
 import * as Result_ from "./Result.ts"
-// oxlint-disable-next-line import/no-self-import -- Qualifies Constraint where Annotations.ToArbitrary.Constraint shadows it.
-import type * as Schema_ from "./Schema.ts"
 import * as SchemaAST from "./SchemaAST.ts"
 import * as SchemaGetter from "./SchemaGetter.ts"
 import * as SchemaIssue from "./SchemaIssue.ts"
@@ -15300,7 +15298,7 @@ export declare namespace Annotations {
      *
      * @since 4.0.0
      */
-    readonly arbitraryConstraint?: ToArbitrary.Constraint<any> | undefined
+    readonly arbitraryConstraint?: ToArbitrary.FilterConstraint<any> | undefined
     /**
      * Marks the filter as *structural*, meaning it applies to the shape or
      * structure of the container (e.g., array length, object keys) rather than
@@ -15366,7 +15364,7 @@ export declare namespace Annotations {
      * @category models
      * @since 4.0.0
      */
-    interface Constraint<T = unknown> extends GenerationConstraint<T> {
+    interface FilterConstraint<T = unknown> extends GenerationConstraint<T> {
       readonly order?: Order.Order<T> | undefined
     }
     /**
@@ -15375,7 +15373,7 @@ export declare namespace Annotations {
      * @category models
      * @since 4.0.0
      */
-    interface DeclarationInput<T, Parameters extends ReadonlyArray<Schema_.Constraint>> {
+    interface DeclarationInput<T, Parameters extends ReadonlyArray<Constraint>> {
       readonly typeParameters: TypeParameters.Type<Parameters>
       readonly constraint: GenerationConstraint<T> | undefined
     }
@@ -15385,7 +15383,7 @@ export declare namespace Annotations {
      * @category models
      * @since 4.0.0
      */
-    interface Declaration<T, Parameters extends ReadonlyArray<Schema_.Constraint>> {
+    interface Declaration<T, Parameters extends ReadonlyArray<Constraint>> {
       (input: DeclarationInput<T, Parameters>): SchemaAST.Link
     }
   }

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -62,6 +62,8 @@ import * as Record_ from "./Record.ts"
 import * as Redacted_ from "./Redacted.ts"
 import * as RegExp_ from "./RegExp.ts"
 import * as Result_ from "./Result.ts"
+// oxlint-disable-next-line import/no-self-import -- Qualifies Constraint where Annotations.ToArbitrary.Constraint shadows it.
+import type * as Schema_ from "./Schema.ts"
 import * as SchemaAST from "./SchemaAST.ts"
 import * as SchemaGetter from "./SchemaGetter.ts"
 import * as SchemaIssue from "./SchemaIssue.ts"
@@ -14980,9 +14982,6 @@ export function resolveAnnotations<S extends Constraint>(
 export function resolveAnnotationsKey<S extends Constraint>(schema: S): Annotations.Key<S["Type"]> | undefined {
   return schema.ast.context?.annotations
 }
-// Alias for the top-level `Constraint`, which `Annotations.ToArbitrary.Constraint` shadows below.
-type AnnotationSchemaConstraint = Constraint
-
 /**
  * The `Annotations` namespace groups all annotation interfaces used to attach
  * metadata to schemas. Annotations control documentation, validation messages,
@@ -15376,7 +15375,7 @@ export declare namespace Annotations {
      * @category models
      * @since 4.0.0
      */
-    interface DeclarationInput<T, Parameters extends ReadonlyArray<AnnotationSchemaConstraint>> {
+    interface DeclarationInput<T, Parameters extends ReadonlyArray<Schema_.Constraint>> {
       readonly typeParameters: TypeParameters.Type<Parameters>
       readonly constraint: GenerationConstraint<T> | undefined
     }
@@ -15386,7 +15385,7 @@ export declare namespace Annotations {
      * @category models
      * @since 4.0.0
      */
-    interface Declaration<T, Parameters extends ReadonlyArray<AnnotationSchemaConstraint>> {
+    interface Declaration<T, Parameters extends ReadonlyArray<Schema_.Constraint>> {
       (input: DeclarationInput<T, Parameters>): SchemaAST.Link
     }
   }

--- a/packages/effect/src/internal/arbitrary/schema.ts
+++ b/packages/effect/src/internal/arbitrary/schema.ts
@@ -14,16 +14,16 @@ import * as InternalRecord from "../record.ts"
 import * as Model from "./model.ts"
 import * as Regexp from "./regexp.ts"
 
-type Constraint = Schema.Annotations.ToArbitrary.Constraint<any>
+type FilterConstraint = Schema.Annotations.ToArbitrary.FilterConstraint<any>
 type GenerationConstraint = Schema.Annotations.ToArbitrary.GenerationConstraint<any>
 
 interface Checks {
-  readonly constraint: Constraint | undefined
+  readonly constraint: FilterConstraint | undefined
   readonly filters: ReadonlyArray<SchemaAST.Filter<any>>
 }
 
 const infinity = Number.POSITIVE_INFINITY
-const finiteNumberConstraint: Constraint = { number: "finite" }
+const finiteNumberConstraint: FilterConstraint = { number: "finite" }
 const optionMatch = { onFailure: Option.none, onSuccess: Option.some }
 
 const optionComputation = <A, E, R>(self: Effect.Effect<A, E, R>): Model.Computation<Option.Option<A>> => {
@@ -79,7 +79,7 @@ function mergeMaximum(self: number | undefined, that: number | undefined): numbe
   return self === undefined ? that : that === undefined ? self : Math.min(self, that)
 }
 
-function mergeConstraint(self: Constraint | undefined, that: Constraint): Constraint {
+function mergeConstraint(self: FilterConstraint | undefined, that: FilterConstraint): FilterConstraint {
   const order = that.order ?? self?.order
   if (self?.order !== undefined && that.order !== undefined && self.order !== that.order) {
     throw new Error("Cannot merge ordered arbitrary constraints with different Order instances")
@@ -142,7 +142,7 @@ function mergeConstraint(self: Constraint | undefined, that: Constraint): Constr
   }
 }
 
-function collectChecks(checks: SchemaAST.Checks | undefined, inherited: Constraint | undefined): Checks {
+function collectChecks(checks: SchemaAST.Checks | undefined, inherited: FilterConstraint | undefined): Checks {
   let constraint = inherited
   const filters: Array<SchemaAST.Filter<any>> = []
   const visit = (check: SchemaAST.Check<any>): void => {
@@ -180,7 +180,7 @@ function applyFilters(
     })
 }
 
-function validateConstraint(constraint: Constraint | undefined, path: ReadonlyArray<PropertyKey>): void {
+function validateConstraint(constraint: FilterConstraint | undefined, path: ReadonlyArray<PropertyKey>): void {
   if (constraint === undefined) return
   const cardinalities = [
     [constraint.minLength, constraint.maxLength],
@@ -207,7 +207,7 @@ function validateConstraint(constraint: Constraint | undefined, path: ReadonlyAr
   }
 }
 
-function withoutOrder(constraint: Constraint | undefined): GenerationConstraint | undefined {
+function withoutOrder(constraint: FilterConstraint | undefined): GenerationConstraint | undefined {
   if (constraint === undefined) return undefined
   const { order: _, ...out } = constraint
   return Object.keys(out).length === 0 ? undefined : out
@@ -352,7 +352,7 @@ function builtInDeclarationLink(
 }
 
 function lengthBounds(
-  constraint: Constraint | undefined,
+  constraint: FilterConstraint | undefined,
   keys: readonly [
     minimum: "minLength" | "minSize" | "minProperties",
     maximum: "maxLength" | "maxSize" | "maxProperties"
@@ -801,7 +801,7 @@ function randomString(state: Model.GenerationState, minimum: number, maximum: nu
   return value
 }
 
-function numberBounds(constraint: Constraint | undefined, integer: boolean, path: ReadonlyArray<PropertyKey>) {
+function numberBounds(constraint: FilterConstraint | undefined, integer: boolean, path: ReadonlyArray<PropertyKey>) {
   const ordered = constraint?.order === Order.Number ? constraint : undefined
   let minimum = ordered?.minimum as number | undefined
   let maximum = ordered?.maximum as number | undefined
@@ -1027,14 +1027,14 @@ function bigIntSample(
 /** @internal */
 export function compile<S extends Schema.Constraint>(schema: S): Model.Compiled<S["Type"]> {
   const rootAst = SchemaAST.toType(schema.ast)
-  const cache = new WeakMap<SchemaAST.AST, Map<Constraint | undefined, Model.Compiled<any>>>()
+  const cache = new WeakMap<SchemaAST.AST, Map<FilterConstraint | undefined, Model.Compiled<any>>>()
   const nodes: Array<Model.Compiled<any>> = []
   const suspendBodies = new Map<Model.Compiled<any>, Model.Compiled<any>>()
   const pending: Array<() => void> = []
   const recur = (
     ast: SchemaAST.AST,
     path: ReadonlyArray<PropertyKey>,
-    inherited?: Constraint
+    inherited?: FilterConstraint
   ): Model.Compiled<any> => {
     let entries = cache.get(ast)
     const cached = entries?.get(inherited)
@@ -1079,7 +1079,7 @@ export function compile<S extends Schema.Constraint>(schema: S): Model.Compiled<
   const compileBase = (
     ast: SchemaAST.AST,
     path: ReadonlyArray<PropertyKey>,
-    constraint: Constraint | undefined
+    constraint: FilterConstraint | undefined
   ): Model.Compiled<any> => {
     switch (ast._tag) {
       case "Never":
@@ -1336,7 +1336,7 @@ export function compile<S extends Schema.Constraint>(schema: S): Model.Compiled<
   const compileArrays = (
     ast: SchemaAST.Arrays,
     path: ReadonlyArray<PropertyKey>,
-    constraint: Constraint | undefined
+    constraint: FilterConstraint | undefined
   ): Model.Compiled<ReadonlyArray<any>> => {
     const uniqueBy = constraint?.uniqueBy
     const elements = ast.elements.map((element, index) => ({
@@ -1492,7 +1492,7 @@ export function compile<S extends Schema.Constraint>(schema: S): Model.Compiled<
   const compileObjects = (
     ast: SchemaAST.Objects,
     path: ReadonlyArray<PropertyKey>,
-    constraint: Constraint | undefined
+    constraint: FilterConstraint | undefined
   ): Model.Compiled<Record<PropertyKey, any>> => {
     const constrainedIndexes = ast.indexSignatures.flatMap((index, position) => {
       const constraint = collectChecks(index.type.checks, undefined).constraint
@@ -1517,7 +1517,7 @@ export function compile<S extends Schema.Constraint>(schema: S): Model.Compiled<
         if (cached !== undefined) return cached
         let specialized = compiled
         try {
-          let inherited: Constraint | undefined
+          let inherited: FilterConstraint | undefined
           for (const match of matching) inherited = mergeConstraint(inherited, match.constraint)
           const checks = collectChecks(type.checks, inherited)
           specialized = compileBase(type, path, checks.constraint)
@@ -1668,7 +1668,7 @@ export function compile<S extends Schema.Constraint>(schema: S): Model.Compiled<
   const compileDeclaration = (
     ast: SchemaAST.Declaration,
     path: ReadonlyArray<PropertyKey>,
-    constraint: Constraint | undefined
+    constraint: FilterConstraint | undefined
   ): Model.Compiled<any> => {
     validateConstraint(constraint, path)
     const typeParameters = ast.typeParameters.map((parameter, index) => recur(parameter, [...path, index]))

--- a/packages/effect/src/unstable/cli/internal/command.ts
+++ b/packages/effect/src/unstable/cli/internal/command.ts
@@ -234,6 +234,8 @@ export const makeCommand = <const Name extends string, Input, E, R, ContextInput
 
 /**
  * Converts a single flag param into a FlagDoc for help display.
+ *
+ * @internal
  */
 export const toFlagDoc = (
   single: Param.Single<typeof Param.flagKind, unknown>,

--- a/scripts/check-dist-types.mjs
+++ b/scripts/check-dist-types.mjs
@@ -1,0 +1,56 @@
+// Type-checks the built `effect` declarations the way a consumer with
+// `skipLibCheck: false` does. Run after `pnpm build` with `stripInternal`
+// enabled to catch public declarations that reference `@internal` symbols
+// (see Effect-TS/effect#6431, #7187, #8161).
+import { execFileSync } from "node:child_process"
+import * as Fs from "node:fs"
+import * as Os from "node:os"
+import * as Path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = Path.resolve(Path.dirname(fileURLToPath(import.meta.url)), "..")
+const pkgDir = Path.join(root, "packages", "effect")
+const dist = Path.join(pkgDir, "dist")
+
+if (!Fs.existsSync(Path.join(dist, "index.d.ts"))) {
+  console.error("packages/effect/dist is missing; run `pnpm build` first")
+  process.exit(1)
+}
+
+const pkg = JSON.parse(Fs.readFileSync(Path.join(pkgDir, "package.json"), "utf8"))
+const entrypoints = Object.entries(pkg.publishConfig.exports)
+  .filter(([key, target]) => target !== null && key !== "./package.json" && !key.includes("*"))
+  .map(([key]) => Path.posix.join(pkg.name, key))
+
+const dir = Fs.mkdtempSync(Path.join(Os.tmpdir(), "effect-dist-types-"))
+try {
+  Fs.writeFileSync(
+    Path.join(dir, "index.ts"),
+    entrypoints.map((entry, i) => `import * as _${i} from "${entry}"\nexport { _${i} }\n`).join("")
+  )
+  Fs.writeFileSync(
+    Path.join(dir, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        strict: true,
+        noEmit: true,
+        target: "ES2022",
+        module: "ESNext",
+        moduleResolution: "bundler",
+        skipLibCheck: false,
+        types: ["node"],
+        typeRoots: [Path.join(root, "node_modules", "@types")],
+        paths: {
+          [pkg.name]: [Path.join(dist, "index.d.ts")],
+          [`${pkg.name}/*`]: [Path.join(dist, "*")]
+        }
+      },
+      files: ["index.ts"]
+    })
+  )
+  execFileSync("pnpm", ["exec", "tsc", "-p", Path.join(dir, "tsconfig.json")], { cwd: root, stdio: "inherit" })
+} catch (error) {
+  process.exitCode = typeof error.status === "number" ? error.status : 1
+} finally {
+  Fs.rmSync(dir, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Problem

`effect@4.0.0-rc.113` publishes declaration files that reference names removed by `stripInternal`, so any consumer compiling with `skipLibCheck: false` fails on a bare `import { Effect } from "effect"`. Building `packages/effect` with `stripInternal: true` and type-checking a trivial consumer reproduces the five reported errors plus one more in the CLI:

```text
dist/Effectable.d.ts(11,15): error TS2305: Module '"./internal/core.ts"' has no exported member 'EffectTypeId'.
dist/Effectable.d.ts(55,24): error TS2589: Type instantiation is excessively deep and possibly infinite.
dist/Match.d.ts(21,41): error TS2694: Namespace '".../dist/internal/matcher"' has no exported member 'Contextual'.
dist/Schema.d.ts(10470,72): error TS2304: Cannot find name 'AnnotationSchemaConstraint'.
dist/Schema.d.ts(10480,67): error TS2304: Cannot find name 'AnnotationSchemaConstraint'.
dist/unstable/cli/internal/command.d.ts(66,122): error TS2339: Property 'getParamMetadata' does not exist on type 'typeof import(".../dist/unstable/cli/Param")'.
```

## Fix

- `Effectable.ts`: use the public `Effect.TypeId` instead of the internal `EffectTypeId` in the `MixinBase` declaration.
- `Match.ts`: define the `Contextual` conditional locally instead of aliasing the `@internal` type from `internal/matcher.ts`.
- `Schema.ts`: remove `AnnotationSchemaConstraint` and reference the public `Schema.Constraint` through a type-only namespace import in `Annotations.ToArbitrary.DeclarationInput` and `Declaration`. This preserves their generic bounds despite the nested `ToArbitrary.Constraint` name collision.
- `unstable/cli/internal/command.ts`: mark `toFlagDoc` as `@internal`. It is only used by the internal help and command modules, and its signature leaked `Param.getParamMetadata`.

## Guard

This is the third occurrence of this class of bug (#6431, #7187). `scripts/check-dist-types.mjs` type-checks the built `effect` declarations from a generated consumer that imports every published entrypoint with `skipLibCheck: false`. The CI `build` job now runs it via `pnpm check-dist-types` right after the `stripInternal` build. On the original source it fails with the six errors above; after this fix it passes.

## Validation

- `pnpm check`, `pnpm lint`, `pnpm jsdocs --check`
- `pnpm test --run` for `Match`, `Effectable`, `cli/Help`, `cli/Command`
- `pnpm test-types Match Effectable`

Closes EFF-1336
Closes #8161

