### PR TITLE
fix(FileSystem): keep stat when optional inode exceeds MAX_SAFE_INTEGER

### DIFF
--- a/.changeset/filesystem-stat-optional-inode.md
+++ b/.changeset/filesystem-stat-optional-inode.md
@@ -1,5 +1,6 @@
 ---
 "effect": patch
+"@effect/platform-node-shared": patch
 ---
 
 Keep `FileSystem.stat` working when optional identity metadata such as NTFS inodes exceeds `Number.MAX_SAFE_INTEGER`. Overflowed optional fields (`ino`, `nlink`, `uid`, `gid`, `rdev`, `blocks`) are now `Option.none()` instead of failing the whole `stat` with `BadArgument`.

--- a/.changeset/filesystem-stat-optional-inode.md
+++ b/.changeset/filesystem-stat-optional-inode.md
@@ -3,4 +3,4 @@
 "@effect/platform-node-shared": patch
 ---
 
-Keep `FileSystem.stat` working when optional identity metadata such as NTFS inodes exceeds `Number.MAX_SAFE_INTEGER`. Overflowed optional fields (`ino`, `nlink`, `uid`, `gid`, `rdev`, `blocks`) are now `Option.none()` instead of failing the whole `stat` with `BadArgument`.
+Keep Node and Bun file stats usable when optional numeric metadata exceeds the safe integer range by returning `Option.none()` for those fields.

--- a/.changeset/filesystem-stat-optional-inode.md
+++ b/.changeset/filesystem-stat-optional-inode.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Keep `FileSystem.stat` working when optional identity metadata such as NTFS inodes exceeds `Number.MAX_SAFE_INTEGER`. Overflowed optional fields (`ino`, `nlink`, `uid`, `gid`, `rdev`, `blocks`) are now `Option.none()` instead of failing the whole `stat` with `BadArgument`.

--- a/packages/effect/src/FileSystem.ts
+++ b/packages/effect/src/FileSystem.ts
@@ -906,11 +906,9 @@ export declare namespace File {
    * permissions, and size information. This structure is returned by file
    * stat operations.
    *
-   * Node and Bun preserve `size` and `blksize` exactly. Optional numeric
-   * metadata that does not fit in a safe integer (`ino`, `nlink`, `uid`,
-   * `gid`, `rdev`, `blocks`) is returned as `Option.none()` rather than
-   * failing the whole `stat`. Required numeric fields (`dev`, `mode`) that
-   * overflow still fail with `BadArgument`.
+   * Node and Bun preserve `size` and `blksize` exactly. Optional `number`
+   * metadata is `Option.none()` when absent or outside the safe integer range.
+   * Unsafe `dev` or `mode` values fail the stat operation with `BadArgument`.
    *
    * **Example** (Inspecting file information)
    *

--- a/packages/effect/src/FileSystem.ts
+++ b/packages/effect/src/FileSystem.ts
@@ -906,10 +906,11 @@ export declare namespace File {
    * permissions, and size information. This structure is returned by file
    * stat operations.
    *
-   * Node and Bun preserve `size` and `blksize` exactly. Unsafe numeric metadata
-   * (such as `ino` or `dev`) fails the entire stat operation with `BadArgument`,
-   * including optional fields. Inode values above `Number.MAX_SAFE_INTEGER`
-   * can therefore prevent stat and HTTP file serving even for small files.
+   * Node and Bun preserve `size` and `blksize` exactly. Optional numeric
+   * metadata that does not fit in a safe integer (`ino`, `nlink`, `uid`,
+   * `gid`, `rdev`, `blocks`) is returned as `Option.none()` rather than
+   * failing the whole `stat`. Required numeric fields (`dev`, `mode`) that
+   * overflow still fail with `BadArgument`.
    *
    * **Example** (Inspecting file information)
    *

--- a/packages/platform/node-shared/src/NodeFileSystem.ts
+++ b/packages/platform/node-shared/src/NodeFileSystem.ts
@@ -41,8 +41,13 @@ const bigintToNumber = (value: bigint, field: string): number => {
   return number
 }
 
-const bigintToNumberOption = (value: bigint | undefined, field: string): Option.Option<number> =>
-  Option.map(Option.fromNullishOr(value), (value) => bigintToNumber(value, field))
+const bigintToNumberOption = (value: bigint | undefined): Option.Option<number> => {
+  if (value === undefined) {
+    return Option.none()
+  }
+  const number = Number(value)
+  return Number.isSafeInteger(number) ? Option.some(number) : Option.none()
+}
 
 // fs.write ignores bigint positions.
 const positionToNumber = (position: bigint, method: string) =>
@@ -530,15 +535,15 @@ const makeFileInfo = (stat: NFS.BigIntStats): Effect.Effect<FileSystem.File.Info
       atime: Option.fromNullishOr(stat.atime),
       birthtime: Option.fromNullishOr(stat.birthtime),
       dev: bigintToNumber(stat.dev, "dev"),
-      rdev: bigintToNumberOption(stat.rdev, "rdev"),
-      ino: bigintToNumberOption(stat.ino, "ino"),
+      rdev: bigintToNumberOption(stat.rdev),
+      ino: bigintToNumberOption(stat.ino),
       mode: bigintToNumber(stat.mode, "mode"),
-      nlink: bigintToNumberOption(stat.nlink, "nlink"),
-      uid: bigintToNumberOption(stat.uid, "uid"),
-      gid: bigintToNumberOption(stat.gid, "gid"),
+      nlink: bigintToNumberOption(stat.nlink),
+      uid: bigintToNumberOption(stat.uid),
+      gid: bigintToNumberOption(stat.gid),
       size: ByteSize.bytes(stat.size),
       blksize: stat.blksize !== undefined ? Option.some(ByteSize.bytes(stat.blksize)) : Option.none(),
-      blocks: bigintToNumberOption(stat.blocks, "blocks")
+      blocks: bigintToNumberOption(stat.blocks)
     }),
     catch: handleBadArgument("stat")
   })

--- a/packages/platform/node-shared/src/NodeFileSystem.ts
+++ b/packages/platform/node-shared/src/NodeFileSystem.ts
@@ -9,6 +9,7 @@
  *
  * @since 4.0.0
  */
+import * as BI from "effect/BigInt"
 import * as ByteSize from "effect/ByteSize"
 import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
@@ -41,13 +42,8 @@ const bigintToNumber = (value: bigint, field: string): number => {
   return number
 }
 
-const bigintToNumberOption = (value: bigint | undefined): Option.Option<number> => {
-  if (value === undefined) {
-    return Option.none()
-  }
-  const number = Number(value)
-  return Number.isSafeInteger(number) ? Option.some(number) : Option.none()
-}
+const bigintToNumberOption = (value: bigint | undefined): Option.Option<number> =>
+  Option.flatMap(Option.fromNullishOr(value), BI.toNumber)
 
 // fs.write ignores bigint positions.
 const positionToNumber = (position: bigint, method: string) =>

--- a/packages/platform/node-shared/test/NodeFileSystem.test.ts
+++ b/packages/platform/node-shared/test/NodeFileSystem.test.ts
@@ -139,8 +139,7 @@ const state = vi.hoisted(() => ({
 
 vi.mock("node:fs", async (importOriginal) => {
   const original = await importOriginal<typeof NFS>()
-  // Model Node's default numeric Stats as well as its opt-in BigIntStats.
-  // No real file descriptor or oversized sparse file is involved.
+  // Match Node's number and bigint stat modes.
   const stat = (
     _pathOrFd: string | number,
     optionsOrCallback: { bigint?: boolean } | ((error: null, stats: object) => void),
@@ -259,12 +258,12 @@ describe("NodeFileSystem precision", { concurrent: false }, () => {
 
     it.effect(`${method} omits only the overflowing optional field`, () =>
       Effect.gen(function*() {
-        Object.assign(state.values, { ino: maxSafe + 1n, nlink: 3n, uid: 0n, gid: 1000n, rdev: 0n, blocks: 8n })
+        Object.assign(state.values, { ino: maxSafe + 1n, nlink: 3n, uid: 1000n, gid: 1001n, rdev: 0n, blocks: 8n })
         const info = yield* getInfo
         assert.deepStrictEqual(info.ino, Option.none())
         assert.deepStrictEqual(info.nlink, Option.some(3))
-        assert.deepStrictEqual(info.uid, Option.some(0))
-        assert.deepStrictEqual(info.gid, Option.some(1000))
+        assert.deepStrictEqual(info.uid, Option.some(1000))
+        assert.deepStrictEqual(info.gid, Option.some(1001))
         assert.deepStrictEqual(info.rdev, Option.some(0))
         assert.deepStrictEqual(info.blocks, Option.some(8))
         assert.strictEqual(info.type, "File")

--- a/packages/platform/node-shared/test/NodeFileSystem.test.ts
+++ b/packages/platform/node-shared/test/NodeFileSystem.test.ts
@@ -257,6 +257,21 @@ describe("NodeFileSystem precision", { concurrent: false }, () => {
         }).pipe(Effect.provide(NodeFileSystem.layer)))
     }
 
+    it.effect(`${method} omits only the overflowing optional field`, () =>
+      Effect.gen(function*() {
+        Object.assign(state.values, { ino: maxSafe + 1n, nlink: 3n, uid: 0n, gid: 1000n, rdev: 0n, blocks: 8n })
+        const info = yield* getInfo
+        assert.deepStrictEqual(info.ino, Option.none())
+        assert.deepStrictEqual(info.nlink, Option.some(3))
+        assert.deepStrictEqual(info.uid, Option.some(0))
+        assert.deepStrictEqual(info.gid, Option.some(1000))
+        assert.deepStrictEqual(info.rdev, Option.some(0))
+        assert.deepStrictEqual(info.blocks, Option.some(8))
+        assert.strictEqual(info.type, "File")
+        assert.strictEqual(info.size, ByteSize.bytes(4n))
+        assert.deepStrictEqual(info.mtime, Option.some(new Date(0)))
+      }).pipe(Effect.provide(NodeFileSystem.layer)))
+
     for (
       const { expected, name, value } of [
         {

--- a/packages/platform/node-shared/test/NodeFileSystem.test.ts
+++ b/packages/platform/node-shared/test/NodeFileSystem.test.ts
@@ -248,20 +248,41 @@ describe("NodeFileSystem precision", { concurrent: false }, () => {
         assert.strictEqual(Option.getOrThrow(info.blksize), ByteSize.bytes(oversized))
       }).pipe(Effect.provide(NodeFileSystem.layer)))
 
-    it.effect(`${method} rejects unsafe required dev metadata`, () =>
-      Effect.gen(function*() {
-        state.values.dev = oversized
-        const error = yield* Effect.flip(getInfo)
-        assert.strictEqual(error.reason._tag, "BadArgument")
-      }).pipe(Effect.provide(NodeFileSystem.layer)))
-
-    for (const field of ["ino", "nlink", "uid", "gid", "rdev", "blocks"] as const) {
-      it.effect(`${method} omits unsafe ${field} metadata`, () =>
+    for (const field of ["dev", "mode"] as const) {
+      it.effect(`${method} rejects unsafe ${field} metadata`, () =>
         Effect.gen(function*() {
-          state.values[field] = oversized
+          state.values[field] = maxSafe + 1n
+          const error = yield* Effect.flip(getInfo)
+          assert.strictEqual(error.reason._tag, "BadArgument")
+        }).pipe(Effect.provide(NodeFileSystem.layer)))
+    }
+
+    for (
+      const { expected, name, value } of [
+        {
+          name: "preserves optional metadata at MAX_SAFE_INTEGER",
+          value: maxSafe,
+          expected: Option.some(Number.MAX_SAFE_INTEGER)
+        },
+        { name: "omits optional metadata above MAX_SAFE_INTEGER", value: maxSafe + 1n, expected: Option.none() },
+        { name: "omits missing optional metadata", value: undefined, expected: Option.none() }
+      ]
+    ) {
+      it.effect(`${method} ${name}`, () =>
+        Effect.gen(function*() {
+          const fields = ["ino", "nlink", "uid", "gid", "rdev", "blocks"] as const
+          for (const field of fields) {
+            if (value === undefined) {
+              delete state.values[field]
+            } else {
+              state.values[field] = value
+            }
+          }
           const info = yield* getInfo
-          assert.deepStrictEqual(info[field], Option.none())
-          assert.strictEqual(info.dev, 1)
+          for (const field of fields) {
+            assert.deepStrictEqual(info[field], expected, field)
+          }
+          assert.strictEqual(info.type, "File")
           assert.strictEqual(info.size, ByteSize.bytes(4n))
           assert.deepStrictEqual(info.mtime, Option.some(new Date(0)))
         }).pipe(Effect.provide(NodeFileSystem.layer)))

--- a/packages/platform/node-shared/test/NodeFileSystem.test.ts
+++ b/packages/platform/node-shared/test/NodeFileSystem.test.ts
@@ -248,12 +248,23 @@ describe("NodeFileSystem precision", { concurrent: false }, () => {
         assert.strictEqual(Option.getOrThrow(info.blksize), ByteSize.bytes(oversized))
       }).pipe(Effect.provide(NodeFileSystem.layer)))
 
-    const field = method === "stat" ? "dev" : "ino"
-    it.effect(`${method} rejects unsafe ${field} metadata`, () =>
+    it.effect(`${method} rejects unsafe required dev metadata`, () =>
       Effect.gen(function*() {
-        state.values[field] = oversized
+        state.values.dev = oversized
         const error = yield* Effect.flip(getInfo)
         assert.strictEqual(error.reason._tag, "BadArgument")
       }).pipe(Effect.provide(NodeFileSystem.layer)))
+
+    for (const field of ["ino", "nlink", "uid", "gid", "rdev", "blocks"] as const) {
+      it.effect(`${method} omits unsafe ${field} metadata`, () =>
+        Effect.gen(function*() {
+          state.values[field] = oversized
+          const info = yield* getInfo
+          assert.deepStrictEqual(info[field], Option.none())
+          assert.strictEqual(info.dev, 1)
+          assert.strictEqual(info.size, ByteSize.bytes(4n))
+          assert.deepStrictEqual(info.mtime, Option.some(new Date(0)))
+        }).pipe(Effect.provide(NodeFileSystem.layer)))
+    }
   }
 })


### PR DESCRIPTION
Keep Node and Bun file stats working when optional numeric metadata exceeds `Number.MAX_SAFE_INTEGER`, including Windows NTFS inode values.

Oversized `ino`, `nlink`, `uid`, `gid`, `rdev`, and `blocks` become `Option.none()`, preserving the remaining file information. Required `dev` and `mode` still fail with `BadArgument`; byte counts remain exact.

The `stat` and `fstat` tests cover safe integer boundaries, missing fields, mixed safe and overflowing metadata, zero values, and required-field overflow. All five reviewed mutations are caught.

Closes #8163
Closes EFF-1341

Validation (run with `nix develop -c`):

- `pnpm test --run packages/platform/node-shared/test/NodeFileSystem.test.ts`: 58 passed
- `pnpm lint-fix` and `pnpm lint`
- `pnpm check`
- `pnpm jsdocs --check`

Overflow cases use mocked Node stats on Linux. Native Windows NTFS and Bun execution remain unverified.
