### PR TITLE
improve tx value comparison

### DIFF
--- a/.changeset/txref-nan-commit.md
+++ b/.changeset/txref-nan-commit.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Compare committed `TxRef` values with `Object.is`. Setting `NaN` over `NaN` no longer increments the reference version, while `0` and `-0` are treated as distinct and do bump it.

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -14635,7 +14635,7 @@ const awaitPendingTransaction = (state: Transaction["Service"]) =>
 
 function commitTransaction(fiber: Fiber<unknown, unknown>, state: Transaction["Service"]) {
   for (const [ref, { value }] of state.journal) {
-    if (value !== ref.value) {
+    if (!Object.is(value, ref.value)) {
       ref.version = ref.version + 1
       ref.value = value
     }

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -3301,6 +3301,21 @@ describe("Effect", () => {
           assert.strictEqual(value, 10)
         }))
 
+      it.effect("should use Object.is when deciding whether to bump TxRef version on commit", () =>
+        Effect.gen(function*() {
+          const nanRef = yield* TxRef.make(NaN)
+          const nanVersion = nanRef.version
+          yield* TxRef.set(nanRef, NaN)
+          assert.strictEqual(nanRef.version, nanVersion)
+          assert.isTrue(Object.is(yield* TxRef.get(nanRef), NaN))
+
+          const zeroRef = yield* TxRef.make(0)
+          const zeroVersion = zeroRef.version
+          yield* TxRef.set(zeroRef, -0)
+          assert.strictEqual(zeroRef.version, zeroVersion + 1)
+          assert.isTrue(Object.is(yield* TxRef.get(zeroRef), -0))
+        }))
+
       it.effect("should roll back nested changes when the outer transaction fails", () =>
         Effect.gen(function*() {
           const ref1 = TxRef.makeUnsafe(0)


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->
Compare committed `TxRef` values with `Object.is`. 
Setting `NaN` over `NaN` no longer increments the reference version, while `0` and `-0` are treated as distinct and do bump it.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
