### PR TITLE
feat(Schema): add UndefinedOrFromNullOr

### DIFF
--- a/.changeset/schema-undefined-or-from-null-or.md
+++ b/.changeset/schema-undefined-or-from-null-or.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Schema.UndefinedOrFromNullOr` and `SchemaTransformation.undefinedOrFromNullOr`, the `T | undefined` counterpart of `Schema.OptionFromNullOr`: decoding maps `null` to `undefined`, encoding maps `undefined` back to `null`. Use it when a program models absence as `undefined` but the wire (JSON) must carry `null`, so the codec lives in the payload schema rather than at every call site.

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -12963,6 +12963,55 @@ export function OptionFromNullishOr<S extends Constraint>(
 }
 
 /**
+ * Type-level representation returned by {@link UndefinedOrFromNullOr}.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface UndefinedOrFromNullOr<S extends Constraint> extends decodeTo<UndefinedOr<toType<S>>, NullOr<S>> {
+  readonly "Rebuild": UndefinedOrFromNullOr<S>
+}
+/**
+ * Decodes a nullable, required value `T` to a required `T | undefined` value.
+ *
+ * **When to use**
+ *
+ * Use when the program models absence as `undefined` but the wire can only
+ * carry `null` (JSON has no `undefined`; `JSON.stringify` drops a key whose
+ * value is `undefined`). The codec then lives in the payload schema instead
+ * of at every call site.
+ *
+ * **Details**
+ *
+ * Decoding maps `null` to `undefined` and all other values to themselves.
+ * Encoding maps `undefined` to `null` and all other values to themselves.
+ *
+ * **Example** (A probe payload that always carries the key)
+ *
+ * ```ts import.meta.vitest
+ * import { Schema } from "effect"
+ *
+ * const Payload = Schema.Struct({
+ *   lastError: Schema.UndefinedOrFromNullOr(Schema.String)
+ * })
+ *
+ * Schema.encodeSync(Payload)({ lastError: undefined }) // => { lastError: null }
+ * Schema.decodeSync(Payload)({ lastError: null }) // => { lastError: undefined }
+ * ```
+ *
+ * @see {@link OptionFromNullOr} when absence is modelled as `Option`.
+ *
+ * @category schemas
+ * @since 4.0.0
+ */
+export function UndefinedOrFromNullOr<S extends Constraint>(schema: S): UndefinedOrFromNullOr<S> {
+  return NullOr(schema).pipe(decodeTo(
+    UndefinedOr(toType(schema)),
+    SchemaTransformation.undefinedOrFromNullOr()
+  ))
+}
+
+/**
  * Type-level representation of {@link Cookie}.
  *
  * @unstable

--- a/packages/effect/src/SchemaTransformation.ts
+++ b/packages/effect/src/SchemaTransformation.ts
@@ -1316,6 +1316,50 @@ export function optionFromNullOr<T>(): Transformation<Option.Option<T>, T | null
 }
 
 /**
+ * Decodes `T | null` into `T | undefined` and encodes `undefined` back to
+ * `null`.
+ *
+ * **When to use**
+ *
+ * Use when your program models absence as `undefined` (the `Array.find` /
+ * `Map.get` idiom) but the wire can only carry `null` — JSON has no
+ * `undefined`, and `JSON.stringify` drops a key whose value is `undefined`,
+ * so a stable payload shape needs `null` on the encoded side.
+ *
+ * **Details**
+ *
+ * Decoding maps `null` to `undefined` and passes every other value through.
+ * Encoding maps `undefined` to `null` and passes every other value through.
+ * The transformation is pure and synchronous.
+ *
+ * **Example** (Emitting `null` for an absent value)
+ *
+ * ```ts import.meta.vitest
+ * import { Schema, SchemaTransformation } from "effect"
+ *
+ * const schema = Schema.NullOr(Schema.String).pipe(
+ *   Schema.decodeTo(
+ *     Schema.UndefinedOr(Schema.String),
+ *     SchemaTransformation.undefinedOrFromNullOr()
+ *   )
+ * )
+ * Schema.decodeSync(schema)(null) // => undefined
+ * Schema.encodeSync(schema)(undefined) // => null
+ * ```
+ *
+ * @see {@link optionFromNullOr}
+ *
+ * @category transforming
+ * @since 4.0.0
+ */
+export function undefinedOrFromNullOr<T>(): Transformation<T | undefined, T | null> {
+  return transform({
+    decode: (e: T | null): T | undefined => (e === null ? undefined : e),
+    encode: (t: T | undefined): T | null => (t === undefined ? null : t)
+  })
+}
+
+/**
  * Decodes `T | undefined` into `Option<T>` and encodes `Option.none()` back to
  * `undefined`.
  *

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -2984,6 +2984,24 @@ Expected a value between -2147483648 and 2147483647`
     await encoding.succeed(Option.some(1), "1")
   })
 
+  it("UndefinedOrFromNullOr", async () => {
+    const schema = Schema.UndefinedOrFromNullOr(Schema.FiniteFromString)
+    const asserts = new TestSchema.Asserts(schema)
+
+    if (verifyGeneration) {
+      asserts.arbitrary().verifyGeneration()
+    }
+
+    const decoding = asserts.decoding()
+    await decoding.succeed(null, undefined)
+    await decoding.succeed("1", 1)
+    await decoding.fail("a", `Expected a finite number`)
+
+    const encoding = asserts.encoding()
+    await encoding.succeed(undefined, null)
+    await encoding.succeed(1, "1")
+  })
+
   it("OptionFromUndefinedOr", async () => {
     const schema = Schema.OptionFromUndefinedOr(Schema.FiniteFromString)
     const asserts = new TestSchema.Asserts(schema)

--- a/packages/effect/typetest/schema/Schema.tst.ts
+++ b/packages/effect/typetest/schema/Schema.tst.ts
@@ -2028,6 +2028,14 @@ describe("Schema", () => {
       const optionalNullOr = Schema.OptionFromOptionalNullOr(Schema.FiniteFromString)
       expect(optionalNullOr).type.toBe<Schema.OptionFromOptionalNullOr<typeof Schema.FiniteFromString>>()
       expect(optionalNullOr.annotate({})).type.toBe<Schema.OptionFromOptionalNullOr<typeof Schema.FiniteFromString>>()
+
+      const undefinedOrFromNullOr = Schema.UndefinedOrFromNullOr(Schema.FiniteFromString)
+      expect(undefinedOrFromNullOr).type.toBe<Schema.UndefinedOrFromNullOr<typeof Schema.FiniteFromString>>()
+      expect(undefinedOrFromNullOr.annotate({})).type.toBe<
+        Schema.UndefinedOrFromNullOr<typeof Schema.FiniteFromString>
+      >()
+      expect(undefinedOrFromNullOr["Type"]).type.toBe<number | undefined>()
+      expect(undefinedOrFromNullOr["Encoded"]).type.toBe<string | null>()
     })
   })
 


### PR DESCRIPTION
## What

Adds `Schema.UndefinedOrFromNullOr(schema)` and `SchemaTransformation.undefinedOrFromNullOr()`.

The schema is `NullOr(schema)` decoded to `UndefinedOr(toType(schema))`. Decoding maps `null` to `undefined`. Encoding maps `undefined` to `null`. Other values pass through in both directions. It follows the `OptionFromNullOr` / `OptionFromUndefinedOr` / `OptionFromNullishOr` family in shape, naming, JSDoc and placement.

Includes a unit test with `TestSchema.Asserts` (decoding, encoding, arbitrary generation), a `tstyche` type test for the wrapper type and its `Type` / `Encoded` sides, doc examples that run under `pnpm doctest`, and a `patch` changeset for `effect`.

`pnpm check` for `packages/effect`, the Schema unit test file, `pnpm test-types` for the Schema type tests, `pnpm doctest` for both modules, `oxlint` and `dprint check` all pass.

## Why

JSON has no `undefined`. `JSON.stringify` drops a key whose value is `undefined`, so a payload with a stable shape (a health probe, a status response) must carry `null` for absence on the wire. Many programs model absence as `T | undefined` rather than `Option<T>`, following the `Array.find` / `Map.get` idiom. Today that combination has no first-class codec: `NullOr` is `null` on both sides, `UndefinedOr` is `undefined` on both sides, `optional` / `optionalKey` drop the key, and `OptionFromNullOr` requires `Option` in the domain. The user-land answer is a per-field helper such as `jsonNull(value)` at every call site, which is exactly the kind of manual boundary code Schema exists to replace, or a hand-written `encodeTo` with two getters in every codebase. This PR provides the codec once, in the library, with the same name pattern as the `Option` variants so it is discoverable next to them.

https://claude.ai/code/session_01XpmvW3MzCahnWN6PD1UCsc
