### PR TITLE
fix(ai-openrouter): handle disjoint reasoning and cached token usage details

### DIFF
--- a/.changeset/openrouter-disjoint-usage-details.md
+++ b/.changeset/openrouter-disjoint-usage-details.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openrouter": patch
+---
+
+Fix `OpenRouterLanguageModel` reporting negative usage components when an upstream provider counts `reasoning_tokens` separately from `completion_tokens` (or `cached_tokens` separately from `prompt_tokens`). When a detail count exceeds its parent total the two are now treated as disjoint, so `outputTokens.total` is `completion_tokens + reasoning_tokens` and `outputTokens.text` is `completion_tokens` (likewise `inputTokens.total` and `inputTokens.uncached`), instead of a negative `text` or `uncached` value.

--- a/.changeset/openrouter-disjoint-usage-details.md
+++ b/.changeset/openrouter-disjoint-usage-details.md
@@ -2,4 +2,6 @@
 "@effect/ai-openrouter": patch
 ---
 
-Fix `OpenRouterLanguageModel` reporting negative usage components when an upstream provider counts `reasoning_tokens` separately from `completion_tokens` (or `cached_tokens` separately from `prompt_tokens`). When a detail count exceeds its parent total the two are now treated as disjoint, so `outputTokens.total` is `completion_tokens + reasoning_tokens` and `outputTokens.text` is `completion_tokens` (likewise `inputTokens.total` and `inputTokens.uncached`), instead of a negative `text` or `uncached` value.
+Fix negative text and uncached token usage when reasoning or cached counts exceed their parent totals. Treat these counts as disjoint, adding them to the total and retaining the parent count as text or uncached usage.
+
+Disjoint counts at or below their parent totals remain indistinguishable from subsets, so their totals are still undercounted.

--- a/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
+++ b/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
@@ -1844,18 +1844,9 @@ const getUsage = (usage: Generated.ChatUsage | undefined): Response.Usage => {
   const cacheReadTokens = usage.prompt_tokens_details?.cached_tokens ?? 0
   const cacheWriteTokens = usage.prompt_tokens_details?.cache_write_tokens ?? 0
   const reasoningTokens = usage.completion_tokens_details?.reasoning_tokens ?? 0
-  // OpenRouter documents `cached_tokens` and `reasoning_tokens` as subsets of
-  // `prompt_tokens` and `completion_tokens` respectively, but some upstream
-  // providers report them as disjoint counts (i.e. `reasoning_tokens` exceeds
-  // `completion_tokens`). When a detail exceeds its parent count, treat the
-  // two as disjoint so the derived components never go negative.
-  //
-  // This only catches the provable case. A provider that reports disjoint
-  // counts where the detail is less than or equal to its parent is
-  // indistinguishable from the documented subset accounting: nothing on the
-  // usage block indicates which convention applies (`total_tokens` is just
-  // `prompt_tokens + completion_tokens`), so those responses still use the
-  // subset derivation and will under-report `total` by the detail count.
+  // Some providers report cached or reasoning tokens separately from their parent counts.
+  // Treat details exceeding the parent as disjoint to avoid negative remainders.
+  // Otherwise, retain subset accounting.
   const inputTotal = cacheReadTokens > promptTokens ? promptTokens + cacheReadTokens : promptTokens
   const outputTotal = reasoningTokens > completionTokens ? completionTokens + reasoningTokens : completionTokens
   return {

--- a/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
+++ b/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
@@ -1844,16 +1844,30 @@ const getUsage = (usage: Generated.ChatUsage | undefined): Response.Usage => {
   const cacheReadTokens = usage.prompt_tokens_details?.cached_tokens ?? 0
   const cacheWriteTokens = usage.prompt_tokens_details?.cache_write_tokens ?? 0
   const reasoningTokens = usage.completion_tokens_details?.reasoning_tokens ?? 0
+  // OpenRouter documents `cached_tokens` and `reasoning_tokens` as subsets of
+  // `prompt_tokens` and `completion_tokens` respectively, but some upstream
+  // providers report them as disjoint counts (i.e. `reasoning_tokens` exceeds
+  // `completion_tokens`). When a detail exceeds its parent count, treat the
+  // two as disjoint so the derived components never go negative.
+  //
+  // This only catches the provable case. A provider that reports disjoint
+  // counts where the detail is less than or equal to its parent is
+  // indistinguishable from the documented subset accounting: nothing on the
+  // usage block indicates which convention applies (`total_tokens` is just
+  // `prompt_tokens + completion_tokens`), so those responses still use the
+  // subset derivation and will under-report `total` by the detail count.
+  const inputTotal = cacheReadTokens > promptTokens ? promptTokens + cacheReadTokens : promptTokens
+  const outputTotal = reasoningTokens > completionTokens ? completionTokens + reasoningTokens : completionTokens
   return {
     inputTokens: {
-      uncached: promptTokens - cacheReadTokens,
-      total: promptTokens,
+      uncached: inputTotal - cacheReadTokens,
+      total: inputTotal,
       cacheRead: cacheReadTokens,
       cacheWrite: cacheWriteTokens
     },
     outputTokens: {
-      total: completionTokens,
-      text: completionTokens - reasoningTokens,
+      total: outputTotal,
+      text: outputTotal - reasoningTokens,
       reasoning: reasoningTokens
     }
   }

--- a/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
+++ b/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
@@ -315,8 +315,12 @@ describe("OpenRouterLanguageModel", () => {
             Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini"))
           )
 
-          assert.deepStrictEqual(result.usage.inputTokens, { uncached: 0, total: 100, cacheRead: 100, cacheWrite: 0 })
-          assert.deepStrictEqual(result.usage.outputTokens, { total: 20, text: 0, reasoning: 20 })
+          deepStrictEqual(
+            result.usage.inputTokens,
+            { uncached: 0, total: 100, cacheRead: 100, cacheWrite: 0 },
+            "input usage at equality"
+          )
+          deepStrictEqual(result.usage.outputTokens, { total: 20, text: 0, reasoning: 20 }, "output usage at equality")
         }).pipe(Effect.provide(makeTestLayer({
           body: {
             usage: {
@@ -368,29 +372,31 @@ describe("OpenRouterLanguageModel", () => {
   })
 
   describe("streamText", () => {
-    it.effect("treats streamed reasoning tokens as disjoint when they exceed completion tokens", () =>
-      Effect.gen(function*() {
-        const parts = yield* LanguageModel.streamText({ prompt: "Hello" }).pipe(
-          Stream.runCollect,
-          Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini")),
-          Effect.provide(makeStreamTestLayer([{
-            id: "response-1",
-            object: "chat.completion.chunk",
-            model: "openai/gpt-4o-mini",
-            created: 1,
-            choices: [],
-            usage: {
-              prompt_tokens: 100,
-              completion_tokens: 10,
-              completion_tokens_details: { reasoning_tokens: 20 },
-              total_tokens: 110
-            }
-          }]))
-        )
+    describe("usage", () => {
+      it.effect("treats streamed reasoning tokens as disjoint when they exceed completion tokens", () =>
+        Effect.gen(function*() {
+          const parts = yield* LanguageModel.streamText({ prompt: "Hello" }).pipe(
+            Stream.runCollect,
+            Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini")),
+            Effect.provide(makeStreamTestLayer([{
+              id: "response-1",
+              object: "chat.completion.chunk",
+              model: "openai/gpt-4o-mini",
+              created: 1,
+              choices: [],
+              usage: {
+                prompt_tokens: 100,
+                completion_tokens: 10,
+                completion_tokens_details: { reasoning_tokens: 20 },
+                total_tokens: 110
+              }
+            }]))
+          )
 
-        const finishPart = parts.find((part) => part.type === "finish")
-        deepStrictEqual(finishPart?.usage.outputTokens, { total: 30, text: 10, reasoning: 20 })
-      }))
+          const finishPart = parts.find((part) => part.type === "finish")
+          deepStrictEqual(finishPart?.usage.outputTokens, { total: 30, text: 10, reasoning: 20 })
+        }))
+    })
 
     it.effect("preserves streamed citation start and end indexes", () =>
       Effect.gen(function*() {

--- a/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
+++ b/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
@@ -295,8 +295,12 @@ describe("OpenRouterLanguageModel", () => {
             Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini"))
           )
 
-          deepStrictEqual(result.usage.inputTokens, { uncached: 70, total: 100, cacheRead: 30, cacheWrite: 0 })
-          deepStrictEqual(result.usage.outputTokens, { total: 50, text: 30, reasoning: 20 })
+          deepStrictEqual(
+            result.usage.inputTokens,
+            { uncached: 70, total: 100, cacheRead: 30, cacheWrite: 0 },
+            "subset input usage"
+          )
+          deepStrictEqual(result.usage.outputTokens, { total: 50, text: 30, reasoning: 20 }, "subset output usage")
         }).pipe(Effect.provide(makeTestLayer({
           body: {
             usage: {

--- a/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
+++ b/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
@@ -295,22 +295,13 @@ describe("OpenRouterLanguageModel", () => {
             Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini"))
           )
 
-          const finishPart = result.content.find((part) => part.type === "finish")
-          assert.isDefined(finishPart)
-          if (finishPart?.type === "finish") {
-            deepStrictEqual(finishPart.usage.inputTokens, {
-              uncached: 70,
-              total: 100,
-              cacheRead: 30,
-              cacheWrite: 5
-            })
-            deepStrictEqual(finishPart.usage.outputTokens, { total: 50, text: 30, reasoning: 20 })
-          }
+          deepStrictEqual(result.usage.inputTokens, { uncached: 70, total: 100, cacheRead: 30, cacheWrite: 0 })
+          deepStrictEqual(result.usage.outputTokens, { total: 50, text: 30, reasoning: 20 })
         }).pipe(Effect.provide(makeTestLayer({
           body: {
             usage: {
               prompt_tokens: 100,
-              prompt_tokens_details: { cached_tokens: 30, cache_write_tokens: 5 },
+              prompt_tokens_details: { cached_tokens: 30 },
               completion_tokens: 50,
               completion_tokens_details: { reasoning_tokens: 20 },
               total_tokens: 150
@@ -320,24 +311,18 @@ describe("OpenRouterLanguageModel", () => {
 
       it.effect("treats reasoning tokens as disjoint when they exceed completion tokens", () =>
         Effect.gen(function*() {
-          // Observed from `z-ai/glm-5.3-flash` via OpenRouter, where the upstream
-          // provider reports reasoning tokens separately from completion tokens
           const result = yield* LanguageModel.generateText({ prompt: "Hello" }).pipe(
-            Effect.provide(OpenRouterLanguageModel.model("z-ai/glm-5.3-flash"))
+            Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini"))
           )
 
-          const finishPart = result.content.find((part) => part.type === "finish")
-          assert.isDefined(finishPart)
-          if (finishPart?.type === "finish") {
-            deepStrictEqual(finishPart.usage.outputTokens, { total: 614, text: 293, reasoning: 321 })
-          }
+          deepStrictEqual(result.usage.outputTokens, { total: 30, text: 10, reasoning: 20 })
         }).pipe(Effect.provide(makeTestLayer({
           body: {
             usage: {
-              prompt_tokens: 1200,
-              completion_tokens: 293,
-              completion_tokens_details: { reasoning_tokens: 321 },
-              total_tokens: 1493
+              prompt_tokens: 100,
+              completion_tokens: 10,
+              completion_tokens_details: { reasoning_tokens: 20 },
+              total_tokens: 110
             }
           }
         }))))
@@ -348,16 +333,7 @@ describe("OpenRouterLanguageModel", () => {
             Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini"))
           )
 
-          const finishPart = result.content.find((part) => part.type === "finish")
-          assert.isDefined(finishPart)
-          if (finishPart?.type === "finish") {
-            deepStrictEqual(finishPart.usage.inputTokens, {
-              uncached: 100,
-              total: 400,
-              cacheRead: 300,
-              cacheWrite: 0
-            })
-          }
+          deepStrictEqual(result.usage.inputTokens, { uncached: 100, total: 400, cacheRead: 300, cacheWrite: 0 })
         }).pipe(Effect.provide(makeTestLayer({
           body: {
             usage: {
@@ -376,36 +352,24 @@ describe("OpenRouterLanguageModel", () => {
       Effect.gen(function*() {
         const parts = yield* LanguageModel.streamText({ prompt: "Hello" }).pipe(
           Stream.runCollect,
-          Effect.provide(OpenRouterLanguageModel.model("z-ai/glm-5.3-flash")),
-          Effect.provide(makeStreamTestLayer([
-            {
-              id: "response-1",
-              object: "chat.completion.chunk",
-              model: "z-ai/glm-5.3-flash",
-              created: 1,
-              choices: [{ index: 0, finish_reason: "stop", delta: { content: "answer" } }]
-            },
-            {
-              id: "response-1",
-              object: "chat.completion.chunk",
-              model: "z-ai/glm-5.3-flash",
-              created: 1,
-              choices: [],
-              usage: {
-                prompt_tokens: 1200,
-                completion_tokens: 445,
-                completion_tokens_details: { reasoning_tokens: 518 },
-                total_tokens: 1645
-              }
+          Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini")),
+          Effect.provide(makeStreamTestLayer([{
+            id: "response-1",
+            object: "chat.completion.chunk",
+            model: "openai/gpt-4o-mini",
+            created: 1,
+            choices: [],
+            usage: {
+              prompt_tokens: 100,
+              completion_tokens: 10,
+              completion_tokens_details: { reasoning_tokens: 20 },
+              total_tokens: 110
             }
-          ]))
+          }]))
         )
 
-        const finishPart = globalThis.Array.from(parts).find((part) => part.type === "finish")
-        assert.isDefined(finishPart)
-        if (finishPart?.type === "finish") {
-          deepStrictEqual(finishPart.usage.outputTokens, { total: 963, text: 445, reasoning: 518 })
-        }
+        const finishPart = parts.find((part) => part.type === "finish")
+        deepStrictEqual(finishPart?.usage.outputTokens, { total: 30, text: 10, reasoning: 20 })
       }))
 
     it.effect("preserves streamed citation start and end indexes", () =>

--- a/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
+++ b/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
@@ -309,6 +309,26 @@ describe("OpenRouterLanguageModel", () => {
           }
         }))))
 
+      it.effect("preserves totals when detail counts equal their parent counts", () =>
+        Effect.gen(function*() {
+          const result = yield* LanguageModel.generateText({ prompt: "Hello" }).pipe(
+            Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini"))
+          )
+
+          assert.deepStrictEqual(result.usage.inputTokens, { uncached: 0, total: 100, cacheRead: 100, cacheWrite: 0 })
+          assert.deepStrictEqual(result.usage.outputTokens, { total: 20, text: 0, reasoning: 20 })
+        }).pipe(Effect.provide(makeTestLayer({
+          body: {
+            usage: {
+              prompt_tokens: 100,
+              prompt_tokens_details: { cached_tokens: 100 },
+              completion_tokens: 20,
+              completion_tokens_details: { reasoning_tokens: 20 },
+              total_tokens: 120
+            }
+          }
+        }))))
+
       it.effect("treats reasoning tokens as disjoint when they exceed completion tokens", () =>
         Effect.gen(function*() {
           const result = yield* LanguageModel.generateText({ prompt: "Hello" }).pipe(

--- a/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
+++ b/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
@@ -339,7 +339,7 @@ describe("OpenRouterLanguageModel", () => {
             Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini"))
           )
 
-          deepStrictEqual(result.usage.outputTokens, { total: 30, text: 10, reasoning: 20 })
+          deepStrictEqual(result.usage.outputTokens, { total: 30, text: 10, reasoning: 20 }, "disjoint reasoning usage")
         }).pipe(Effect.provide(makeTestLayer({
           body: {
             usage: {
@@ -357,7 +357,11 @@ describe("OpenRouterLanguageModel", () => {
             Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini"))
           )
 
-          deepStrictEqual(result.usage.inputTokens, { uncached: 100, total: 400, cacheRead: 300, cacheWrite: 0 })
+          deepStrictEqual(
+            result.usage.inputTokens,
+            { uncached: 100, total: 400, cacheRead: 300, cacheWrite: 0 },
+            "disjoint cached usage"
+          )
         }).pipe(Effect.provide(makeTestLayer({
           body: {
             usage: {
@@ -394,7 +398,11 @@ describe("OpenRouterLanguageModel", () => {
           )
 
           const finishPart = parts.find((part) => part.type === "finish")
-          deepStrictEqual(finishPart?.usage.outputTokens, { total: 30, text: 10, reasoning: 20 })
+          deepStrictEqual(
+            finishPart?.usage.outputTokens,
+            { total: 30, text: 10, reasoning: 20 },
+            "streamed disjoint reasoning usage"
+          )
         }))
     })
 

--- a/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
+++ b/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
@@ -287,9 +287,127 @@ describe("OpenRouterLanguageModel", () => {
           deepStrictEqual(tool.function.parameters, inputSchema)
         }).pipe(Effect.provide(makeTestLayer())))
     })
+
+    describe("usage", () => {
+      it.effect("derives text and uncached tokens when details are subsets of their totals", () =>
+        Effect.gen(function*() {
+          const result = yield* LanguageModel.generateText({ prompt: "Hello" }).pipe(
+            Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini"))
+          )
+
+          const finishPart = result.content.find((part) => part.type === "finish")
+          assert.isDefined(finishPart)
+          if (finishPart?.type === "finish") {
+            deepStrictEqual(finishPart.usage.inputTokens, {
+              uncached: 70,
+              total: 100,
+              cacheRead: 30,
+              cacheWrite: 5
+            })
+            deepStrictEqual(finishPart.usage.outputTokens, { total: 50, text: 30, reasoning: 20 })
+          }
+        }).pipe(Effect.provide(makeTestLayer({
+          body: {
+            usage: {
+              prompt_tokens: 100,
+              prompt_tokens_details: { cached_tokens: 30, cache_write_tokens: 5 },
+              completion_tokens: 50,
+              completion_tokens_details: { reasoning_tokens: 20 },
+              total_tokens: 150
+            }
+          }
+        }))))
+
+      it.effect("treats reasoning tokens as disjoint when they exceed completion tokens", () =>
+        Effect.gen(function*() {
+          // Observed from `z-ai/glm-5.3-flash` via OpenRouter, where the upstream
+          // provider reports reasoning tokens separately from completion tokens
+          const result = yield* LanguageModel.generateText({ prompt: "Hello" }).pipe(
+            Effect.provide(OpenRouterLanguageModel.model("z-ai/glm-5.3-flash"))
+          )
+
+          const finishPart = result.content.find((part) => part.type === "finish")
+          assert.isDefined(finishPart)
+          if (finishPart?.type === "finish") {
+            deepStrictEqual(finishPart.usage.outputTokens, { total: 614, text: 293, reasoning: 321 })
+          }
+        }).pipe(Effect.provide(makeTestLayer({
+          body: {
+            usage: {
+              prompt_tokens: 1200,
+              completion_tokens: 293,
+              completion_tokens_details: { reasoning_tokens: 321 },
+              total_tokens: 1493
+            }
+          }
+        }))))
+
+      it.effect("treats cached tokens as disjoint when they exceed prompt tokens", () =>
+        Effect.gen(function*() {
+          const result = yield* LanguageModel.generateText({ prompt: "Hello" }).pipe(
+            Effect.provide(OpenRouterLanguageModel.model("openai/gpt-4o-mini"))
+          )
+
+          const finishPart = result.content.find((part) => part.type === "finish")
+          assert.isDefined(finishPart)
+          if (finishPart?.type === "finish") {
+            deepStrictEqual(finishPart.usage.inputTokens, {
+              uncached: 100,
+              total: 400,
+              cacheRead: 300,
+              cacheWrite: 0
+            })
+          }
+        }).pipe(Effect.provide(makeTestLayer({
+          body: {
+            usage: {
+              prompt_tokens: 100,
+              prompt_tokens_details: { cached_tokens: 300 },
+              completion_tokens: 10,
+              total_tokens: 110
+            }
+          }
+        }))))
+    })
   })
 
   describe("streamText", () => {
+    it.effect("treats streamed reasoning tokens as disjoint when they exceed completion tokens", () =>
+      Effect.gen(function*() {
+        const parts = yield* LanguageModel.streamText({ prompt: "Hello" }).pipe(
+          Stream.runCollect,
+          Effect.provide(OpenRouterLanguageModel.model("z-ai/glm-5.3-flash")),
+          Effect.provide(makeStreamTestLayer([
+            {
+              id: "response-1",
+              object: "chat.completion.chunk",
+              model: "z-ai/glm-5.3-flash",
+              created: 1,
+              choices: [{ index: 0, finish_reason: "stop", delta: { content: "answer" } }]
+            },
+            {
+              id: "response-1",
+              object: "chat.completion.chunk",
+              model: "z-ai/glm-5.3-flash",
+              created: 1,
+              choices: [],
+              usage: {
+                prompt_tokens: 1200,
+                completion_tokens: 445,
+                completion_tokens_details: { reasoning_tokens: 518 },
+                total_tokens: 1645
+              }
+            }
+          ]))
+        )
+
+        const finishPart = globalThis.Array.from(parts).find((part) => part.type === "finish")
+        assert.isDefined(finishPart)
+        if (finishPart?.type === "finish") {
+          deepStrictEqual(finishPart.usage.outputTokens, { total: 963, text: 445, reasoning: 518 })
+        }
+      }))
+
     it.effect("preserves streamed citation start and end indexes", () =>
       Effect.gen(function*() {
         const parts = yield* LanguageModel.streamText({ prompt: "cite a source" }).pipe(


### PR DESCRIPTION
## Summary

`getUsage` in `OpenRouterLanguageModel` derives `outputTokens.text = completion_tokens - reasoning_tokens` and `inputTokens.uncached = prompt_tokens - cached_tokens`, assuming each detail is a subset of its parent total (which is how OpenRouter documents them).

Some upstream providers behind OpenRouter report `reasoning_tokens` **separately** from `completion_tokens`. Three real generations on `z-ai/glm-5.3-flash` (provider Friendli, numbers from `GET /api/v1/generation?id=…`):

| completion_tokens | reasoning_tokens | old `outputTokens.text` |
| ----------------- | ---------------- | ----------------------- |
| 293               | 321              | -28                     |
| 445               | 518              | -73                     |
| 277               | 323              | -46                     |

A negative `text` breaks any consumer that validates usage as non-negative integers, failing the call after the model has already answered.

## Change

When a detail count exceeds its parent total, treat the two as disjoint:

- `outputTokens.total = completion_tokens + reasoning_tokens`, `outputTokens.text = completion_tokens`
- same guard on the input side: `inputTokens.total = prompt_tokens + cached_tokens`, `inputTokens.uncached = prompt_tokens`

The documented (subset) case is unchanged. No derived usage component can go negative anymore.

## Limitation

This only handles the provable case. A provider that reports disjoint counts where `reasoning_tokens <= completion_tokens` (or `cached_tokens <= prompt_tokens`) is indistinguishable from the documented subset accounting: nothing on the usage block indicates which convention applies (`total_tokens` is `prompt_tokens + completion_tokens` and so inherits the same ambiguity; `cost_details` would need per-model pricing to interpret). Those responses keep the subset derivation and under-report `total` by the detail count. Resolving that requires OpenRouter to normalize the upstream counts, or to expose native counts alongside the normalized ones.

## Tests

- `generateText`: subset accounting (including details equal to their parent counts), disjoint reasoning counts, and disjoint cached counts
- `streamText`: disjoint reasoning counts via a usage-only chunk

The three disjoint tests fail on `main` and pass with this change.

## Verification

```sh
pnpm lint-fix
pnpm test --run packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
pnpm check
git diff --check
```

All pass: 18 tests in `OpenRouterLanguageModel.test.ts`, root lint and formatting, root `pnpm check`, and `git diff --check`. The equality test also fails when either disjoint-count guard is independently changed from `>` to `>=`. Includes an `@effect/ai-openrouter` patch changeset.

## Notes

`@effect/ai-openai-compat` has the same `outputTokens - reasoningTokens` derivation; left untouched here to keep the change scoped to the provider where this was observed. Happy to apply the same guard there if wanted.

I also reached out to OpenRouter via Mail, I'll add a comment to this PR if anything comes of it.

Closes EFF-1342
