### PR TITLE
add `Context.Mixin`

### DIFF
--- a/.changeset/context-mixin.md
+++ b/.changeset/context-mixin.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Context.Mixin` to wrap an existing class constructor as a `Context.Service` key, preserving the original constructor and instance members.

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -115,6 +115,7 @@ export interface Service<in out Identifier, in out Shape> extends Key<Identifier
  * The class itself is the `Context` key, and its string `key` identifies the
  * service at runtime.
  *
+ * @see {@link Mixin} for wrapping an existing class constructor
  * @see {@link Service} for creating function-style keys or class-style service keys
  *
  * @category services
@@ -193,6 +194,7 @@ export declare namespace ServiceClass {
  * Context.get(config, Config).port // => 8080
  * ```
  *
+ * @see {@link Mixin} for wrapping an existing class constructor
  * @see {@link Reference} for service keys with default values
  *
  * @category services
@@ -433,6 +435,118 @@ export declare namespace Service {
    */
   export type Identifier<T> = T extends Key<infer I, infer _S> ? I : never
 }
+
+declare class MixinBase<out Identifier extends string = string, out Shape = any> {
+  constructor(...args: ReadonlyArray<any>)
+  readonly [ServiceTypeId]: typeof ServiceTypeId
+  readonly key: Identifier
+  readonly Service: Shape
+}
+
+type MixinService<
+  TBase extends abstract new(...args: ReadonlyArray<any>) => object,
+  Identifier extends string,
+  Shape,
+  Self
+> =
+  & TBase
+  & (abstract new(...args: ReadonlyArray<any>) => MixinBase<Identifier, Shape>)
+  & Service<Self, Shape>
+  & { readonly key: Identifier }
+
+type MixinMakeShape<Make> = Make extends
+  Effect<infer _A, infer _E, infer _R> | ((...args: infer _Args) => Effect<infer _A, infer _E, infer _R>) ? _A
+  : never
+
+/**
+ * Returns a subclass of the provided class that is a `Context` service key.
+ *
+ * **When to use**
+ *
+ * Use to turn an existing class into a `Context.Service` key without moving its
+ * constructor onto a `Context.Service` subclass.
+ *
+ * **Details**
+ *
+ * Call `Context.Mixin("Key")(Base)` with the same optional `make` and
+ * `fiberCached` options used by {@link Service}. The returned class is the
+ * `Context` key, and instances of the wrapped class are the service
+ * implementation. Constructor parameters and instance members are preserved.
+ *
+ * **Gotchas**
+ *
+ * The string key is the runtime identity of the service. Reusing the same key
+ * string for unrelated services makes them occupy the same slot in a
+ * `Context`. Service methods such as `pipe` and `toJSON` are installed on the
+ * constructor and shadow static members of the same name on the wrapped class.
+ *
+ * **Example** (Wrapping an existing class constructor)
+ *
+ * ```ts import.meta.vitest
+ * import { Context } from "effect"
+ *
+ * class Box {
+ *   constructor(readonly value: number) {}
+ * }
+ *
+ * class MyText extends Context.Mixin("MyText")(Box) {}
+ *
+ * const context = Context.make(MyText, new MyText(1))
+ * Context.get(context, MyText).value // => 1
+ * ```
+ *
+ * @see {@link Service} for creating service keys without wrapping a class
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const Mixin: {
+  <const Identifier extends string>(
+    id: Identifier,
+    options?: {
+      /** @internal */
+      readonly fiberCached?: boolean | undefined
+    } | undefined
+  ): <TBase extends abstract new(...args: ReadonlyArray<any>) => object>(
+    klass: TBase
+  ) => MixinService<
+    TBase,
+    Identifier,
+    InstanceType<TBase>,
+    InstanceType<TBase> & MixinBase<Identifier, InstanceType<TBase>>
+  >
+  <
+    const Identifier extends string,
+    Make extends Effect<any, any, any> | ((...args: any) => Effect<any, any, any>)
+  >(
+    id: Identifier,
+    options: {
+      readonly make: Make
+      /** @internal */
+      readonly fiberCached?: boolean | undefined
+    }
+  ): <TBase extends abstract new(...args: ReadonlyArray<any>) => object>(
+    klass: TBase
+  ) => MixinService<TBase, Identifier, MixinMakeShape<Make>, MixinBase<Identifier, MixinMakeShape<Make>>> & {
+    readonly make: Make
+  }
+} =
+  ((id: string, options?: { readonly make?: any; readonly fiberCached?: boolean }) =>
+  (klass: abstract new(...args: ReadonlyArray<any>) => object) => {
+    const Key = Service(id, options)
+    class Mixed extends klass {}
+    const descriptors = Object.getOwnPropertyDescriptors(Object.getPrototypeOf(Key))
+    delete descriptors.prototype
+    delete descriptors.length
+    delete descriptors.name
+    Object.defineProperties(Mixed, descriptors)
+    const mixed = Mixed as any
+    mixed.key = (Key as any).key
+    if ((Key as any).make !== undefined) {
+      mixed.make = (Key as any).make
+    }
+    return Mixed
+  }) as any
 
 const TypeId = "~effect/Context" as const
 

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -436,33 +436,30 @@ export declare namespace Service {
   export type Identifier<T> = T extends Key<infer I, infer _S> ? I : never
 }
 
-
-interface MixinBase<Self> extends Service<Self, Self>
-{
+interface MixinBase<Self> extends Service<Self, Self> {
   readonly key: string
 }
-
 /**
  * Returns a subclass of the provided class that is a `Context` service key.
  *
  * **When to use**
  *
- * Use to turn an existing class into a `Context.Service` key without moving its
- * constructor onto a `Context.Service` subclass.
+ * Use to turn an existing class into a `Context.Service` key while preserving
+ * the original class constructor and instance members.
  *
  * **Details**
  *
- * Call `Context.Mixin<Self>("Key")(Base)` with the same optional `make` and
- * `fiberCached` options used by {@link Service}. The returned class is the
- * `Context` key, and instances of the wrapped class are the service
- * implementation. Constructor parameters and instance members are preserved.
+ * Call `Context.Mixin<Self>("Key")(Base)` to create a service key from an
+ * existing class. The returned class can be used with `Context.make`,
+ * `Context.add`, and the Context getter functions. Constructor parameters and
+ * instance members from the base class are preserved.
  *
  * **Gotchas**
  *
  * The string key is the runtime identity of the service. Reusing the same key
- * string for unrelated services makes them occupy the same slot in a
- * `Context`. Service methods such as `pipe` and `toJSON` are installed on the
- * constructor and shadow static members of the same name on the wrapped class.
+ * string for unrelated services makes them occupy the same slot in a `Context`.
+ * Service methods such as `pipe` and `toJSON` are installed on the constructor
+ * and shadow static members of the same name on the wrapped class.
  *
  * **Example** (Wrapping an existing class constructor)
  *
@@ -495,16 +492,13 @@ export const Mixin: {
     klass: TBase
   ) => TBase & MixinBase<Self>
 } =
-  ((id: string, options?: { readonly make?: any; readonly fiberCached?: boolean }) =>
+  ((id: string, options?: { readonly fiberCached?: boolean }) =>
   (klass: abstract new(...args: ReadonlyArray<any>) => object) => {
     const Key = Service(id, options)
     class Mixed extends klass {}
     Object.defineProperties(Mixed, Object.getOwnPropertyDescriptors(ServiceProto))
     const mixed = Mixed as any
     mixed.key = (Key as any).key
-    if ((Key as any).make !== undefined) {
-      mixed.make = (Key as any).make
-    }
     return Mixed
   }) as any
 

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -436,27 +436,11 @@ export declare namespace Service {
   export type Identifier<T> = T extends Key<infer I, infer _S> ? I : never
 }
 
-declare class MixinBase<out Identifier extends string = string, out Shape = any> {
-  constructor(...args: ReadonlyArray<any>)
-  readonly [ServiceTypeId]: typeof ServiceTypeId
-  readonly key: Identifier
-  readonly Service: Shape
+
+interface MixinBase<Self> extends Service<Self, Self>
+{
+  readonly key: string
 }
-
-type MixinService<
-  TBase extends abstract new(...args: ReadonlyArray<any>) => object,
-  Identifier extends string,
-  Shape,
-  Self
-> =
-  & TBase
-  & (abstract new(...args: ReadonlyArray<any>) => MixinBase<Identifier, Shape>)
-  & Service<Self, Shape>
-  & { readonly key: Identifier }
-
-type MixinMakeShape<Make> = Make extends
-  Effect<infer _A, infer _E, infer _R> | ((...args: infer _Args) => Effect<infer _A, infer _E, infer _R>) ? _A
-  : never
 
 /**
  * Returns a subclass of the provided class that is a `Context` service key.
@@ -468,7 +452,7 @@ type MixinMakeShape<Make> = Make extends
  *
  * **Details**
  *
- * Call `Context.Mixin("Key")(Base)` with the same optional `make` and
+ * Call `Context.Mixin<Self>("Key")(Base)` with the same optional `make` and
  * `fiberCached` options used by {@link Service}. The returned class is the
  * `Context` key, and instances of the wrapped class are the service
  * implementation. Constructor parameters and instance members are preserved.
@@ -489,10 +473,10 @@ type MixinMakeShape<Make> = Make extends
  *   constructor(readonly value: number) {}
  * }
  *
- * class MyText extends Context.Mixin("MyText")(Box) {}
+ * class MyClass extends Context.Mixin<MyClass>("MyClass")(Box) {}
  *
- * const context = Context.make(MyText, new MyText(1))
- * Context.get(context, MyText).value // => 1
+ * const context = Context.make(MyClass, new MyClass(1))
+ * Context.get(context, MyClass).value // => 1
  * ```
  *
  * @see {@link Service} for creating service keys without wrapping a class
@@ -501,45 +485,21 @@ type MixinMakeShape<Make> = Make extends
  * @since 4.0.0
  */
 export const Mixin: {
-  <const Identifier extends string>(
-    id: Identifier,
+  <Self>(
+    id: string,
     options?: {
       /** @internal */
       readonly fiberCached?: boolean | undefined
     } | undefined
   ): <TBase extends abstract new(...args: ReadonlyArray<any>) => object>(
     klass: TBase
-  ) => MixinService<
-    TBase,
-    Identifier,
-    InstanceType<TBase>,
-    InstanceType<TBase> & MixinBase<Identifier, InstanceType<TBase>>
-  >
-  <
-    const Identifier extends string,
-    Make extends Effect<any, any, any> | ((...args: any) => Effect<any, any, any>)
-  >(
-    id: Identifier,
-    options: {
-      readonly make: Make
-      /** @internal */
-      readonly fiberCached?: boolean | undefined
-    }
-  ): <TBase extends abstract new(...args: ReadonlyArray<any>) => object>(
-    klass: TBase
-  ) => MixinService<TBase, Identifier, MixinMakeShape<Make>, MixinBase<Identifier, MixinMakeShape<Make>>> & {
-    readonly make: Make
-  }
+  ) => TBase & MixinBase<Self>
 } =
   ((id: string, options?: { readonly make?: any; readonly fiberCached?: boolean }) =>
   (klass: abstract new(...args: ReadonlyArray<any>) => object) => {
     const Key = Service(id, options)
     class Mixed extends klass {}
-    const descriptors = Object.getOwnPropertyDescriptors(Object.getPrototypeOf(Key))
-    delete descriptors.prototype
-    delete descriptors.length
-    delete descriptors.name
-    Object.defineProperties(Mixed, descriptors)
+    Object.defineProperties(Mixed, Object.getOwnPropertyDescriptors(ServiceProto))
     const mixed = Mixed as any
     mixed.key = (Key as any).key
     if ((Key as any).make !== undefined) {

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -228,7 +228,7 @@ describe("Context", () => {
       }
     }
 
-    class MyText extends Context.Mixin("ContextTest/MyText")(Box) {}
+    class MyText extends Context.Mixin<MyText>("ContextTest/MyText")(Box) {}
 
     it("stores and retrieves instances as the service", () => {
       const context = Context.make(MyText, new MyText(1))
@@ -278,21 +278,11 @@ describe("Context", () => {
     })
 
     it("invalidates the fiber cache when fiberCached is set", () => {
-      class CachedText extends Context.Mixin("ContextTest/CachedText", { fiberCached: true })(Box) {}
+      class CachedText extends Context.Mixin<CachedText>("ContextTest/CachedText", { fiberCached: true })(Box) {}
       const source = Context.make(A, 1)
 
       assertFalse(Context.hasSameCache(source, Context.add(source, CachedText, new CachedText(1))))
       assertTrue(Context.hasSameCache(source, Context.add(source, MyText, new MyText(1))))
     })
-
-    it.effect("exposes make when it is provided", () =>
-      Effect.gen(function*() {
-        class Logger extends Context.Mixin("ContextTest/MixinMake", {
-          make: Effect.succeed({ log: (message: string) => message })
-        })(Box) {}
-
-        const logger = yield* Logger.make
-        strictEqual(logger.log("hello"), "hello")
-      }))
   })
 })

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -1,9 +1,10 @@
+import { describe, it } from "@effect/vitest"
 import { assertFalse, assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
 import * as Equal from "effect/Equal"
 import * as Option from "effect/Option"
 import * as Redactable from "effect/Redactable"
-import { describe, it } from "vitest"
 
 describe("Context", () => {
   const A = Context.Service<number>("ContextTest/A")
@@ -214,5 +215,84 @@ describe("Context", () => {
     const context = Context.makeUnsafe(map)
 
     strictEqual(context.mapUnsafe, map)
+  })
+
+  describe("Mixin", () => {
+    class Box {
+      constructor(readonly value: number) {}
+      double() {
+        return this.value * 2
+      }
+      static origin() {
+        return 0
+      }
+    }
+
+    class MyText extends Context.Mixin("ContextTest/MyText")(Box) {}
+
+    it("stores and retrieves instances as the service", () => {
+      const context = Context.make(MyText, new MyText(1))
+
+      strictEqual(Context.get(context, MyText).value, 1)
+      strictEqual(Context.get(context, MyText).double(), 2)
+    })
+
+    it.effect("yields the wrapped instance from the current context", () =>
+      Effect.gen(function*() {
+        const text = yield* MyText
+        strictEqual(text.value, 2)
+        strictEqual(text.double(), 4)
+      }).pipe(Effect.provideService(MyText, new MyText(2))))
+
+    it.effect("use and useSync read the wrapped instance", () =>
+      Effect.gen(function*() {
+        strictEqual(yield* MyText.use((text) => Effect.succeed(text.value)), 3)
+        strictEqual(yield* MyText.useSync((text) => text.double()), 6)
+      }).pipe(Effect.provideService(MyText, new MyText(3))))
+
+    it("preserves the original constructor and instance members", () => {
+      const text = new MyText(2)
+
+      assertTrue(text instanceof MyText)
+      assertTrue(text instanceof Box)
+      strictEqual(text.constructor, MyText)
+      strictEqual(text.value, 2)
+      strictEqual(text.double(), 4)
+      strictEqual(MyText.origin(), 0)
+    })
+
+    it("makes the class a service key without turning instances into Effects", () => {
+      assertTrue(Context.isKey(MyText))
+      assertTrue(Effect.isEffect(MyText))
+      assertFalse(Effect.isEffect(new MyText(1)))
+      strictEqual(MyText.key, "ContextTest/MyText")
+      strictEqual(MyText.of(new MyText(4)).value, 4)
+      strictEqual(Context.get(MyText.context(new MyText(5)), MyText).value, 5)
+      strictEqual(MyText.pipe((service) => service.key), "ContextTest/MyText")
+    })
+
+    it("does not modify the original class prototype", () => {
+      assertFalse(Context.isKey(Box))
+      assertFalse(Effect.isEffect(Box))
+      assertFalse(Effect.isEffect(new Box(1)))
+    })
+
+    it("invalidates the fiber cache when fiberCached is set", () => {
+      class CachedText extends Context.Mixin("ContextTest/CachedText", { fiberCached: true })(Box) {}
+      const source = Context.make(A, 1)
+
+      assertFalse(Context.hasSameCache(source, Context.add(source, CachedText, new CachedText(1))))
+      assertTrue(Context.hasSameCache(source, Context.add(source, MyText, new MyText(1))))
+    })
+
+    it.effect("exposes make when it is provided", () =>
+      Effect.gen(function*() {
+        class Logger extends Context.Mixin("ContextTest/MixinMake", {
+          make: Effect.succeed({ log: (message: string) => message })
+        })(Box) {}
+
+        const logger = yield* Logger.make
+        strictEqual(logger.log("hello"), "hello")
+      }))
   })
 })

--- a/packages/effect/typetest/Context.tst.ts
+++ b/packages/effect/typetest/Context.tst.ts
@@ -31,10 +31,6 @@ describe("Context.Mixin", () => {
     expect<ConstructorParameters<typeof MyText>>().type.toBe<[value: number]>()
   })
 
-  it("rejects unknown properties", () => {
-    expect(new MyText(1)).type.not.toHaveProperty("typo")
-  })
-
   it("instances are the wrapped class and the service shape", () => {
     expect(new MyText(1)).type.toBeAssignableTo<Box>()
     expect(Context.get(Context.make(MyText, new MyText(1)), MyText)).type.toBeAssignableTo<Box>()
@@ -44,7 +40,7 @@ describe("Context.Mixin", () => {
     const effect = Effect.gen(function*() {
       return yield* MyText
     })
-    expect(effect).type.toBeAssignableTo<Effect.Effect<Box, never, unknown>>()
+    expect(effect).type.toBeAssignableTo<Effect.Effect<MyText, never, MyText>>()
   })
 
   it("does not add a make constructor", () => {

--- a/packages/effect/typetest/Context.tst.ts
+++ b/packages/effect/typetest/Context.tst.ts
@@ -25,7 +25,7 @@ describe("Context.Mixin", () => {
     }
   }
 
-  class MyText extends Context.Mixin("MyText")(Box) {}
+  class MyText extends Context.Mixin<MyText>("MyText")(Box) {}
 
   it("preserves constructor parameters", () => {
     expect<ConstructorParameters<typeof MyText>>().type.toBe<[value: number]>()
@@ -42,20 +42,16 @@ describe("Context.Mixin", () => {
 
   it("propagates the wrapped instance through yield*", () => {
     const effect = Effect.gen(function*() {
-      const qwe =  yield* MyText
+      return yield* MyText
     })
     expect(effect).type.toBeAssignableTo<Effect.Effect<Box, never, unknown>>()
   })
 
-  it("infers the make success type as the service shape", () => {
-    class Logger extends Context.Mixin("Logger", {
-      make: Effect.succeed({ log: (message: string) => message })
-    })(Box) {}
-
-    expect(Logger.make).type.toBe<Effect.Effect<{ log: (message: string) => string }>>()
-    expect(Context.get(Context.make(Logger, { log: (message) => message }), Logger).log).type.toBe<
-      (message: string) => string
-    >()
+  it("does not add a make constructor", () => {
+    expect(MyText).type.not.toHaveProperty("make")
+    expect(Context.Mixin<MyText>).type.not.toBeCallableWith("MyText", {
+      make: Effect.succeed(new MyText(1))
+    })
   })
 
   it("supports abstract base classes", () => {

--- a/packages/effect/typetest/Context.tst.ts
+++ b/packages/effect/typetest/Context.tst.ts
@@ -1,5 +1,5 @@
-import { Context, Option } from "effect"
-import { expect, it } from "tstyche"
+import { Context, Effect, Option } from "effect"
+import { describe, expect, it } from "tstyche"
 
 it("does not type a service removed with addOrOmit as present", () => {
   const Service = Context.Service<{ readonly value: number }>("TestService")
@@ -15,4 +15,64 @@ it("infers services for a saved curried getter", () => {
   const getService = Context.get(Service)
 
   expect(getService(Context.make(Service, { value: 1 }))).type.toBe<{ readonly value: number }>()
+})
+
+describe("Context.Mixin", () => {
+  class Box {
+    constructor(readonly value: number) {}
+    double() {
+      return this.value * 2
+    }
+  }
+
+  class MyText extends Context.Mixin("MyText")(Box) {}
+
+  it("preserves constructor parameters", () => {
+    expect<ConstructorParameters<typeof MyText>>().type.toBe<[value: number]>()
+  })
+
+  it("rejects unknown properties", () => {
+    expect(new MyText(1)).type.not.toHaveProperty("typo")
+  })
+
+  it("instances are the wrapped class and the service shape", () => {
+    expect(new MyText(1)).type.toBeAssignableTo<Box>()
+    expect(Context.get(Context.make(MyText, new MyText(1)), MyText)).type.toBeAssignableTo<Box>()
+  })
+
+  it("propagates the wrapped instance through yield*", () => {
+    const effect = Effect.gen(function*() {
+      const qwe =  yield* MyText
+    })
+    expect(effect).type.toBeAssignableTo<Effect.Effect<Box, never, unknown>>()
+  })
+
+  it("infers the make success type as the service shape", () => {
+    class Logger extends Context.Mixin("Logger", {
+      make: Effect.succeed({ log: (message: string) => message })
+    })(Box) {}
+
+    expect(Logger.make).type.toBe<Effect.Effect<{ log: (message: string) => string }>>()
+    expect(Context.get(Context.make(Logger, { log: (message) => message }), Logger).log).type.toBe<
+      (message: string) => string
+    >()
+  })
+
+  it("supports abstract base classes", () => {
+    abstract class AbstractBox {
+      constructor(readonly value: number) {}
+      abstract double(): number
+    }
+
+    class ConcreteText extends Context.Mixin("ConcreteText")(AbstractBox) {
+      double() {
+        return this.value * 2
+      }
+    }
+
+    expect<ConstructorParameters<typeof ConcreteText>>().type.toBe<[value: number]>()
+    expect(new ConcreteText(1)).type.toBeAssignableTo<AbstractBox>()
+    // @ts-expect-error does not implement inherited abstract member double
+    class MissingDouble extends Context.Mixin("MissingDouble")(AbstractBox) {}
+  })
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

https://discord.com/channels/795981131316985866/847382157861060618/1546595868386402394

`Context.Mixin` wraps an existing class constructor as a `Context.Service` key without moving that constructor onto a `Context.Service` subclass. Constructor parameters, instance methods, and instanceof checks against the base class are preserved. The mixed class is the service key (`yield*`, `Context.get`, `use / useSync`); instances are not `Effects`.

The only option is `{ fiberCached }`, matching `Service`. `Mixin` does not take `make`; construct instances with new or a static helper on the class.

```ts
import { Context, Effect } from "effect"
class Box {
  constructor(readonly value: number) {}
  double() { return this.value * 2 }
}

class MyText extends Context.Mixin<MyText>("MyText")(Box) {}

const context = Context.make(MyText, new MyText(1))

Context.get(context, MyText).double() // => 2

const program = Effect.gen(function*() {
  const text = yield* MyText
  return text.value
}).pipe(Effect.provideService(MyText, new MyText(2)))
```
## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
