### PR TITLE
fix(Match): infer valueTags input only from the value (#8167)

### DIFF
--- a/.changeset/fix-match-value-tags-inference.md
+++ b/.changeset/fix-match-value-tags-inference.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Lock `Match.valueTags` input inference so unknown tags and missing handlers are rejected.

--- a/packages/effect/src/Match.ts
+++ b/packages/effect/src/Match.ts
@@ -446,11 +446,11 @@ export const valueTags: {
   <
     const I,
     P extends
-      & ValueTagHandlers<I>
-      & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", I>>]: never }
+      & ValueTagHandlers<T.NoInfer<I>>
+      & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", T.NoInfer<I>>>]: never }
   >(
     input: I,
-    fields: Contextual<P, ValueTagHandlers<I>>
+    fields: Contextual<P, ValueTagHandlers<T.NoInfer<I>>>
   ): Unify<ReturnType<P[keyof P]>>
 } = internal.valueTags
 

--- a/packages/effect/src/internal/matcher.ts
+++ b/packages/effect/src/internal/matcher.ts
@@ -1,4 +1,5 @@
 import { dual, identity } from "../Function.ts"
+import type { NoInfer } from "../Types.ts"
 import type {
   Case,
   Matcher,
@@ -243,22 +244,22 @@ export const valueTags: {
   <
     const I,
     P extends
-      & ValueTagHandlers<I>
-      & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", I>>]: never }
+      & ValueTagHandlers<NoInfer<I>>
+      & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", NoInfer<I>>>]: never }
   >(
     input: I,
-    fields: Contextual<P, ValueTagHandlers<I>>
+    fields: Contextual<P, ValueTagHandlers<NoInfer<I>>>
   ): Unify<ReturnType<P[keyof P]>>
 } = dual(
   2,
   <
     const I,
     P extends
-      & ValueTagHandlers<I>
-      & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", I>>]: never }
+      & ValueTagHandlers<NoInfer<I>>
+      & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", NoInfer<I>>>]: never }
   >(
     input: I,
-    fields: Contextual<P, ValueTagHandlers<I>>
+    fields: Contextual<P, ValueTagHandlers<NoInfer<I>>>
   ): Unify<ReturnType<P[keyof P]>> => {
     const match: any = tagsExhaustive(fields as any)(makeTypeMatcher(identity, []))
     return match(input)

--- a/packages/effect/typetest/Match.tst.ts
+++ b/packages/effect/typetest/Match.tst.ts
@@ -286,4 +286,36 @@ describe("Match", () => {
       })
     )
   })
+
+  it("valueTags rejects unknown tags and requires exhaustiveness from the input", () => {
+    Match.valueTags(taggedInput, {
+      A: () => "a",
+      B: () => "b",
+      // @ts-expect-error Type '() => string' is not assignable to type 'never'
+      C: () => "c"
+    })
+
+    // @ts-expect-error Property 'B' is missing
+    Match.valueTags(taggedInput, {
+      A: () => "a"
+    })
+
+    expect(
+      Match.valueTags(taggedInput, {
+        A: (value) => value.a,
+        B: (value) => value.b
+      })
+    ).type.toBe<string | number>()
+
+    Match.valueTags(taggedInput, {
+      A: Effect.fn(function*(value) {
+        expect(value).type.toBe<{ readonly _tag: "A"; readonly a: string }>()
+        return value.a
+      }),
+      B: Effect.fnUntraced(function*(value) {
+        expect(value).type.toBe<{ readonly _tag: "B"; readonly b: number }>()
+        return value.b
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`Match.valueTags(value, handlers)` was not type-checking the handler object.

If you passed a `Car | Bike` value and wrote `{ Plane: () => "plane" }`, TypeScript said nothing. At runtime it still blew up with `effect/match/Match/exhaustive: absurd`, because there is no `Plane` handler and the `Bike` case is missing.

The type parameter for the value was being inferred from both arguments. The handlers could drag that type around, so the exhaustiveness check never ran against the real input type.

This change only affects the two-argument form. The input type is now taken from the value (`Types.NoInfer`), then the handlers are checked against that. Unknown tags and missing tags should both error. Runtime behavior is unchanged.

## Verification

- `tstyche packages/effect/typetest/Match.tst.ts --target '>=5.9'` — 22 passed on TypeScript 5.9 and 6.0
- `vitest run packages/effect/test/Match.test.ts` — 5 passed

Changeset included for `effect` (patch).

## Related

- Fixes #8167