### PR TITLE
Add Match.valueTags API contract type tests

### DIFF
--- a/packages/effect/typetest/Match.tst.ts
+++ b/packages/effect/typetest/Match.tst.ts
@@ -1,4 +1,4 @@
-import { Effect, Match, Option, pipe, type Result } from "effect"
+import { Effect, Match, Option, pipe, type Result, Schema } from "effect"
 import { describe, expect, it } from "tstyche"
 
 type Closed = { readonly _tag: "Closed" }
@@ -245,6 +245,79 @@ describe("Match", () => {
         C: () => 1
       })
     )
+  })
+
+  it("valueTags rejects the unknown tag in the Schema union reproduction", () => {
+    // https://github.com/Effect-TS/effect/issues/8167
+    const Vehicles = Schema.Union([
+      Schema.TaggedStruct("Car", {}),
+      Schema.TaggedStruct("Bike", {})
+    ])
+    const myVehicle: typeof Vehicles.Type = { _tag: "Bike" }
+
+    // @ts-expect-error Type '() => string' is not assignable to type 'never'
+    Match.valueTags(myVehicle, { Plane: () => "plane" })
+  })
+
+  it("valueTags rejects unknown tags with a complete handler map", () => {
+    // @ts-expect-error Type '() => boolean' is not assignable to type 'never'
+    Match.valueTags(taggedInput, { A: () => "a", B: () => 1, C: () => true })
+  })
+
+  it("valueTags requires every tag of a union", () => {
+    // @ts-expect-error Property 'B' is missing
+    Match.valueTags(taggedInput, { A: () => "a" })
+  })
+
+  it("valueTags rejects an empty handler map", () => {
+    // @ts-expect-error Type '{}' is missing the following properties
+    Match.valueTags(taggedInput, {})
+  })
+
+  it("valueTags rejects unknown tags in a pipeline", () => {
+    pipe(
+      taggedInput,
+      // @ts-expect-error Type '() => boolean' is not assignable to type 'never'
+      Match.valueTags({ A: () => "a", B: () => 1, C: () => true })
+    )
+  })
+
+  it("valueTags requires every tag of a union in a pipeline", () => {
+    pipe(
+      taggedInput,
+      // @ts-expect-error Property 'B' is missing
+      Match.valueTags({ A: () => "a" })
+    )
+  })
+
+  it("valueTags infers handler inputs and the union of return types", () => {
+    const result = Match.valueTags(taggedInput, {
+      A: (value) => {
+        expect(value).type.toBe<{ readonly _tag: "A"; readonly a: string }>()
+        return value.a
+      },
+      B: (value) => {
+        expect(value).type.toBe<{ readonly _tag: "B"; readonly b: number }>()
+        return value.b
+      }
+    })
+    expect(result).type.toBe<string | number>()
+
+    expect(
+      pipe(
+        taggedInput,
+        Match.valueTags({
+          A: (value) => {
+            expect(value).type.toBe<{ readonly _tag: "A"; readonly a: string }>()
+            return value.a
+          },
+          B: (value) => {
+            expect(value).type.toBe<{ readonly _tag: "B"; readonly b: number }>()
+            return value.b
+          }
+        })
+      )
+    ).type.toBe<string | number>()
   })
 
   it("related handler maps contextually type nested Effect.fn calls", () => {

--- a/packages/effect/typetest/Match.tst.ts
+++ b/packages/effect/typetest/Match.tst.ts
@@ -259,30 +259,22 @@ describe("Match", () => {
     Match.valueTags(myVehicle, { Plane: () => "plane" })
   })
 
-  it("valueTags rejects unknown tags with a complete handler map", () => {
+  it("valueTags rejects missing and unknown tags", () => {
     // @ts-expect-error Type '() => boolean' is not assignable to type 'never'
     Match.valueTags(taggedInput, { A: () => "a", B: () => 1, C: () => true })
-  })
 
-  it("valueTags requires every tag of a union", () => {
     // @ts-expect-error Property 'B' is missing
     Match.valueTags(taggedInput, { A: () => "a" })
-  })
 
-  it("valueTags rejects an empty handler map", () => {
     // @ts-expect-error Type '{}' is missing the following properties
     Match.valueTags(taggedInput, {})
-  })
 
-  it("valueTags rejects unknown tags in a pipeline", () => {
     pipe(
       taggedInput,
       // @ts-expect-error Type '() => boolean' is not assignable to type 'never'
       Match.valueTags({ A: () => "a", B: () => 1, C: () => true })
     )
-  })
 
-  it("valueTags requires every tag of a union in a pipeline", () => {
     pipe(
       taggedInput,
       // @ts-expect-error Property 'B' is missing


### PR DESCRIPTION
`Match.valueTags` lacked negative type coverage for unknown tags and incomplete handler maps. These tests pin its public API contract: unknown-tag rejection, required and empty handler maps, and handler/return inference in direct and piped calls. The Schema example from #8167 stays separate; the other negative cases are grouped together.

The rc.113 failure occurred during declaration emit: published declarations referenced the stripped `internal.Contextual` helper. #8162 fixes that reference. These source-level tests pass with or without that fix; the existing `check-dist-types` check in the PR build job guards declaration emit. Consumers on rc.113 need a release containing #8162 and its `.changeset/fix-dangling-internal-declarations.md` to receive the fix.

Validation:

- After regrouping, `nix develop -c pnpm test-types Match` passes on TypeScript 5.9.3 and 6.0.3: 26 tests, 68 assertions, and all 20 expected diagnostics matched. The targeted formatter check also passes.
- At `aafd689a9f`, enabling `stripInternal` with `nix develop -c node scripts/set-strip-internal.mjs`, then running `nix develop -c pnpm build` and `nix develop -c pnpm check-dist-types`, passed. The temporary setting was restored afterward.
- At that same revision, the reproduction probe passed against fresh `packages/effect/dist` declarations on both TypeScript versions: 14 tests, 12 assertions, and 12 expected diagnostics matched. The same probe failed against published rc.113. The subsequent edit only groups existing test cases.
- The existing Match runtime tests, lint, and repository typecheck passed when the initial test commit was prepared, using the Nix shell.

Closes EFF-1338
Closes #8167
