### PR TITLE
Update migration guidance for branded services and Schema changes

### DIFF
--- a/migration/annotations/effect__JSONSchema.yaml
+++ b/migration/annotations/effect__JSONSchema.yaml
@@ -1,6 +1,6 @@
 "effect/JSONSchema#fromAST":
   replacement: "Schema.toJsonSchemaDocument"
-  note: "Wrap a low-level AST with Schema.make, then generate a document; v4 generation targets draft 2020-12."
+  note: "Wrap a low-level AST with Schema.make, then generate a draft 2020-12 document. Generation defaults to onExcessProperty: 'ignore'; use 'error' for closed objects. JSON Schema validation is approximate and does not replace Effect decoding."
   example: "Schema.toJsonSchemaDocument(Schema.make(ast))"
 "effect/JSONSchema#JsonSchema7":
   replacement: "JsonSchema.JsonSchema"
@@ -67,5 +67,5 @@
   note: "Schema metadata now uses string-keyed Schema annotations; JSON Schema-specific checks use toJsonSchema annotations."
 "effect/JSONSchema#make":
   replacement: "Schema.toJsonSchemaDocument"
-  note: "Generate draft 2020-12, then call JsonSchema.toDocumentDraft07 when draft-07 output is required."
+  note: "Generate draft 2020-12, then call JsonSchema.toDocumentDraft07 when draft-07 output is required. Generation now defaults to onExcessProperty: 'ignore'; pass 'error' to retain closed-object output, and use the same option when decoding to reject excess properties. The earlier v4 additionalProperties generation option was removed. JSON Schema validation is approximate and does not replace Effect decoding."
   example: "JsonSchema.toDocumentDraft07(Schema.toJsonSchemaDocument(schema))"

--- a/migration/annotations/effect__Schema.yaml
+++ b/migration/annotations/effect__Schema.yaml
@@ -27,7 +27,7 @@ effect/Schema#Annotations.Doc:
   note: The v3 helper/protocol type was removed by the v4 Schema model rewrite. Use the public v4 constructor and infer its result types instead.
 effect/Schema#Annotations.Filter:
   replacement: Schema.Annotations.Filter
-  note: The API remains public in v4, but its type/value declaration was consolidated; use the v4 declaration and update inferred types/signature as needed.
+  note: "Use the v4 filter annotation shape. arbitraryConstraint uses Schema.Annotations.ToArbitrary.FilterConstraint; the earlier v4 ToArbitrary.Constraint name was removed."
 effect/Schema#Annotations.GenericSchema:
   replacement: none
   note: The v3 helper/protocol type was removed by the v4 Schema model rewrite. Use the public v4 constructor and infer its result types instead.
@@ -312,7 +312,7 @@ effect/Schema#EndsWithSchemaId:
   note: The v3 schema-id symbol was removed. Use the corresponding public v4 constructor/check instead of inspecting schema ids.
 effect/Schema#Enums:
   replacement: Schema.Enum
-  note: Rename the enum constructor and pass the enum object.
+  note: "Rename the enum constructor and pass the enum object. Numeric members must be finite; NaN and positive or negative Infinity throw at construction."
 effect/Schema#EnumsDefinition:
   replacement: none
   note: Compared the v3 declaration with v4 Schema and the schema migration guide; no direct public replacement remains. Rebuild the behavior from public v4 codecs/getters where still required.
@@ -660,7 +660,7 @@ effect/Schema#MinLengthSchemaId:
   note: The v3 schema-id symbol was removed. Use the corresponding public v4 constructor/check instead of inspecting schema ids.
 effect/Schema#multipleOf:
   replacement: Schema.isMultipleOf
-  note: Rename the predicate to `isMultipleOf` and apply it with `Schema.check` or a schema's `check` method.
+  note: "Rename the predicate to `isMultipleOf` and apply it with `Schema.check` or a schema's `check` method. The divisor must be finite and nonzero or construction throws RangeError; negative divisors are normalized to their absolute value."
 effect/Schema#MultipleOfSchemaId:
   replacement: none
   note: The v3 schema-id symbol was removed. Use the corresponding public v4 constructor/check instead of inspecting schema ids.
@@ -1278,7 +1278,7 @@ effect/Schema#Union:
   note: Pass union members as one array.
 effect/Schema#UniqueSymbolFromSelf:
   replacement: Schema.UniqueSymbol
-  note: Use the v4 unique-symbol schema constructor.
+  note: "Use the v4 unique-symbol schema constructor. JSON encoding is available only for globally registered symbols and uses the exact String(symbol) value; local symbols cannot be encoded as JSON."
 effect/Schema#Unknown:
   replacement: Schema.Unknown
   note: The API remains public in v4, but its type/value declaration was consolidated; use the v4 declaration and update inferred types/signature as needed.

--- a/migration/annotations/effect__SchemaAST.yaml
+++ b/migration/annotations/effect__SchemaAST.yaml
@@ -96,7 +96,7 @@
   note: "The separate encoded-bound projection was removed; use the encoded projection and v4 encoding links."
 "effect/SchemaAST#Enums":
   replacement: "SchemaAST.Enum"
-  note: "The v4 SchemaAST redesign renamed this primitive, collection, or guard while preserving its role."
+  note: "Renamed to Enum in the v4 AST model. Numeric enum members must be finite; NaN and positive or negative Infinity throw at construction."
 "effect/SchemaAST#EquivalenceAnnotation":
   replacement: "Schema.Annotations.ToEquivalence.Declaration"
   note: "Equivalence derivation annotations now use the toEquivalence key in Schema.Annotations."

--- a/migration/annotations/effect__ai__Chat.yaml
+++ b/migration/annotations/effect__ai__Chat.yaml
@@ -1,0 +1,6 @@
+"@effect/ai/Chat#Chat":
+  replacement: "Chat.Chat"
+  note: "Use the Chat interface for implementations and the Context.Service value as the service key; it is no longer a class. Chat.empty and Chat.fromPrompt construct branded chat sessions."
+"@effect/ai/Chat#Service":
+  replacement: "Chat.Chat"
+  note: "Service was renamed to Chat. Implementations require [Chat.TypeId]: Chat.TypeId; use Chat.empty or Chat.fromPrompt to create a session."

--- a/migration/annotations/effect__ai__EmbeddingModel.yaml
+++ b/migration/annotations/effect__ai__EmbeddingModel.yaml
@@ -1,3 +1,9 @@
 "@effect/ai/EmbeddingModel#makeDataLoader":
   replacement: "EmbeddingModel.make + RequestResolver.setDelay + RequestResolver.batchN"
   note: "The dedicated data-loader constructor was removed. EmbeddingModel.make batches concurrent embed requests through its resolver; compose the exposed resolver with setDelay and optional batchN for the old window and maximum-batch behavior."
+"@effect/ai/EmbeddingModel#EmbeddingModel":
+  replacement: "EmbeddingModel.EmbeddingModel"
+  note: "Use the EmbeddingModel interface for implementations and the Context.Service value as the service key; it is no longer a class. Prefer EmbeddingModel.make to construct the branded implementation."
+"@effect/ai/EmbeddingModel#Service":
+  replacement: "EmbeddingModel.EmbeddingModel"
+  note: "Service was renamed to EmbeddingModel. Implementations require [EmbeddingModel.TypeId]: EmbeddingModel.TypeId; EmbeddingModel.make supplies the brand."

--- a/migration/annotations/effect__ai__LanguageModel.yaml
+++ b/migration/annotations/effect__ai__LanguageModel.yaml
@@ -4,3 +4,9 @@
 "@effect/ai/LanguageModel#ExtractContext":
   replacement: "LanguageModel.ExtractServices"
   note: "Renamed in effect/unstable/ai/LanguageModel. ExtractServices infers toolkit handler, result-decoding, and effectful-toolkit service requirements."
+"@effect/ai/LanguageModel#LanguageModel":
+  replacement: "LanguageModel.LanguageModel"
+  note: "Use the LanguageModel interface for implementations and the Context.Service value as the service key; it is no longer a class. Prefer LanguageModel.make to construct the branded implementation."
+"@effect/ai/LanguageModel#Service":
+  replacement: "LanguageModel.LanguageModel"
+  note: "Service was renamed to LanguageModel. Implementations require [LanguageModel.TypeId]: LanguageModel.TypeId; LanguageModel.make supplies the brand."

--- a/migration/annotations/effect__experimental__Reactivity.yaml
+++ b/migration/annotations/effect__experimental__Reactivity.yaml
@@ -6,10 +6,10 @@
   note: Import make from the v4 unstable Reactivity module.
 "@effect/experimental/Reactivity#Reactivity":
   replacement: effect/unstable/reactivity/Reactivity#Reactivity
-  note: Use the v4 Reactivity Context.Service; unsafe methods were renamed with an Unsafe suffix.
+  note: Use the Reactivity interface for implementations and the Reactivity Context.Service value as the service key. Implementations require the TypeId brand; prefer Reactivity.make. Unsafe methods were renamed with an Unsafe suffix.
 "@effect/experimental/Reactivity#Reactivity.Service":
-  replacement: effect/unstable/reactivity/Reactivity#Reactivity["Service"]
-  note: The named namespace member was removed; derive the service shape from the Context.Service class.
+  replacement: effect/unstable/reactivity/Reactivity#Reactivity
+  note: "The named namespace member was removed; use the branded Reactivity interface directly. Prefer Reactivity.make, or include [Reactivity.TypeId]: Reactivity.TypeId in a custom implementation."
 "@effect/experimental/Reactivity#stream":
   replacement: effect/unstable/reactivity/Reactivity#stream
   note: Import stream from the v4 unstable Reactivity module.

--- a/migration/annotations/effect__platform__HttpServer.yaml
+++ b/migration/annotations/effect__platform__HttpServer.yaml
@@ -12,7 +12,10 @@
   note: "Renamed; it provides the standard HTTP platform services."
 "@effect/platform/HttpServer#make":
   replacement: "HttpServer.make"
-  note: "Retained; it returns the Context.Service implementation."
+  note: "Retained; it returns the Context.Service implementation. Supply a NetAddress.SocketAddress for address, using NetAddress.inetAddressUnsafe for a parsed IP and port or NetAddress.unixPathAddress for a Unix path. Use NetAddress.inetAddress to validate the port through Result instead."
+"@effect/platform/HttpServer#formatAddress":
+  replacement: "HttpServer.formatAddress"
+  note: "Accepts NetAddress.SocketAddress and delegates to NetAddress.formatUrlUnsafe. Scoped IPv6 addresses throw NetAddressError; Unix paths use the unix:// prefix."
 "@effect/platform/HttpServer#ServeOptions":
   replacement: "none"
   note: "The unused respond option model was removed with no shared v4 counterpart."

--- a/migration/v3-to-v4.md
+++ b/migration/v3-to-v4.md
@@ -2,9 +2,9 @@
 
 # v3 to v4 Migration Reference
 
-Base: `origin/v3` (`6985be0cf461f0997f28f6798f469d01a2b46ca3`)
+Base: `origin/v3` (`1af4232fea7bc613e1dc68db9bec7b1f596d9e68`)
 
-Head: `HEAD` (`f57836b4418ea7c7d399f51bc1adad3fc0c08e98`)
+Head: `origin/main` (`91abe38c3797b1c290aedef3b01e8c96dd4fee79`)
 
 This file is generated from the API diff and `migration/annotations/*.yaml`.
 
@@ -4912,9 +4912,19 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `AiError.UnknownError` -> `AiError.make + AiError.UnknownError`: UnknownError is now a semantic reason rather than a top-level error. Put module and method on AiError.make and inspect reason.\_tag when handling the outer AiError.
 
+### `@effect/ai/Chat`
+
+- `Chat.Chat` -> `Chat.Chat`: Use the Chat interface for implementations and the Context.Service value as the service key; it is no longer a class. Chat.empty and Chat.fromPrompt construct branded chat sessions.
+
+- `Chat.Service` -> `Chat.Chat`: Service was renamed to Chat. Implementations require [Chat.TypeId]: Chat.TypeId; use Chat.empty or Chat.fromPrompt to create a session.
+
 ### `@effect/ai/EmbeddingModel`
 
+- `EmbeddingModel.EmbeddingModel` -> `EmbeddingModel.EmbeddingModel`: Use the EmbeddingModel interface for implementations and the Context.Service value as the service key; it is no longer a class. Prefer EmbeddingModel.make to construct the branded implementation.
+
 - `EmbeddingModel.Result`: TODO: needs guidance
+
+- `EmbeddingModel.Service` -> `EmbeddingModel.EmbeddingModel`: Service was renamed to EmbeddingModel. Implementations require [EmbeddingModel.TypeId]: EmbeddingModel.TypeId; EmbeddingModel.make supplies the brand.
 
 - `EmbeddingModel.makeDataLoader` -> `EmbeddingModel.make + RequestResolver.setDelay + RequestResolver.batchN`: The dedicated data-loader constructor was removed. EmbeddingModel.make batches concurrent embed requests through its resolver; compose the exposed resolver with setDelay and optional batchN for the old window and maximum-batch behavior.
 
@@ -4927,6 +4937,10 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 - `LanguageModel.ConstructorParams` -> `none`: V4 inlines this provider-adapter shape in LanguageModel.make. Pass generateText and streamText directly to make, with optional codecTransformer, instead of naming a constructor-parameter type.
 
 - `LanguageModel.ExtractContext` -> `LanguageModel.ExtractServices`: Renamed in effect/unstable/ai/LanguageModel. ExtractServices infers toolkit handler, result-decoding, and effectful-toolkit service requirements.
+
+- `LanguageModel.LanguageModel` -> `LanguageModel.LanguageModel`: Use the LanguageModel interface for implementations and the Context.Service value as the service key; it is no longer a class. Prefer LanguageModel.make to construct the branded implementation.
+
+- `LanguageModel.Service` -> `LanguageModel.LanguageModel`: Service was renamed to LanguageModel. Implementations require [LanguageModel.TypeId]: LanguageModel.TypeId; LanguageModel.make supplies the brand.
 
 ### `@effect/ai/McpSchema`
 
@@ -6052,9 +6066,9 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 ### `@effect/experimental/Reactivity`
 
-- `Reactivity.Reactivity` -> `effect/unstable/reactivity/Reactivity#Reactivity`: Use the v4 Reactivity Context.Service; unsafe methods were renamed with an Unsafe suffix.
+- `Reactivity.Reactivity` -> `effect/unstable/reactivity/Reactivity#Reactivity`: Use the Reactivity interface for implementations and the Reactivity Context.Service value as the service key. Implementations require the TypeId brand; prefer Reactivity.make. Unsafe methods were renamed with an Unsafe suffix.
 
-- `Reactivity.Reactivity.Service` -> `effect/unstable/reactivity/Reactivity#Reactivity["Service"]`: The named namespace member was removed; derive the service shape from the Context.Service class.
+- `Reactivity.Reactivity.Service` -> `effect/unstable/reactivity/Reactivity#Reactivity`: The named namespace member was removed; use the branded Reactivity interface directly. Prefer Reactivity.make, or include [Reactivity.TypeId]: Reactivity.TypeId in a custom implementation.
 
 - `Reactivity.make` -> `effect/unstable/reactivity/Reactivity#make`: Import make from the v4 unstable Reactivity module.
 
@@ -7218,9 +7232,11 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `HttpServer.addressWith` -> `HttpServer.HttpServer.use(({ address }) => effect(address))`: The accessor was removed; read the service and pass its Address to the callback.
 
+- `HttpServer.formatAddress` -> `HttpServer.formatAddress`: Accepts NetAddress.SocketAddress and delegates to NetAddress.formatUrlUnsafe. Scoped IPv6 addresses throw NetAddressError; Unix paths use the unix:// prefix.
+
 - `HttpServer.layerContext` -> `HttpServer.layerServices`: Renamed; it provides the standard HTTP platform services.
 
-- `HttpServer.make` -> `HttpServer.make`: Retained; it returns the Context.Service implementation.
+- `HttpServer.make` -> `HttpServer.make`: Retained; it returns the Context.Service implementation. Supply a NetAddress.SocketAddress for address, using NetAddress.inetAddressUnsafe for a parsed IP and port or NetAddress.unixPathAddress for a Unix path. Use NetAddress.inetAddress to validate the port through Result instead.
 
 - `HttpServer.serve` -> `effect/unstable/http/HttpServer#serve`: Moved to the v4 HTTP module; the application is now an Effect producing HttpServerResponse rather than the separate HttpApp model.
 
@@ -11439,7 +11455,7 @@ stream.pipe(
 
 **Replacement:** `Schema.toJsonSchemaDocument`
 
-Wrap a low-level AST with Schema.make, then generate a document; v4 generation targets draft 2020-12.
+Wrap a low-level AST with Schema.make, then generate a draft 2020-12 document. Generation defaults to onExcessProperty: 'ignore'; use 'error' for closed objects. JSON Schema validation is approximate and does not replace Effect decoding.
 
 **Example**
 
@@ -11451,7 +11467,7 @@ Schema.toJsonSchemaDocument(Schema.make(ast))
 
 **Replacement:** `Schema.toJsonSchemaDocument`
 
-Generate draft 2020-12, then call JsonSchema.toDocumentDraft07 when draft-07 output is required.
+Generate draft 2020-12, then call JsonSchema.toDocumentDraft07 when draft-07 output is required. Generation now defaults to onExcessProperty: 'ignore'; pass 'error' to retain closed-object output, and use the same option when decoding to reject excess properties. The earlier v4 additionalProperties generation option was removed. JSON Schema validation is approximate and does not replace Effect decoding.
 
 **Example**
 
@@ -14039,7 +14055,7 @@ Schema.toFormatter(schema)
 
 - `Schema.Annotations.Doc` -> `none`: The v3 helper/protocol type was removed by the v4 Schema model rewrite. Use the public v4 constructor and infer its result types instead.
 
-- `Schema.Annotations.Filter` -> `Schema.Annotations.Filter`: The API remains public in v4, but its type/value declaration was consolidated; use the v4 declaration and update inferred types/signature as needed.
+- `Schema.Annotations.Filter` -> `Schema.Annotations.Filter`: Use the v4 filter annotation shape. arbitraryConstraint uses Schema.Annotations.ToArbitrary.FilterConstraint; the earlier v4 ToArbitrary.Constraint name was removed.
 
 - `Schema.Annotations.GenericSchema` -> `none`: The v3 helper/protocol type was removed by the v4 Schema model rewrite. Use the public v4 constructor and infer its result types instead.
 
@@ -14159,7 +14175,7 @@ Schema.toFormatter(schema)
 
 - `Schema.EndsWithSchemaId` -> `none`: The v3 schema-id symbol was removed. Use the corresponding public v4 constructor/check instead of inspecting schema ids.
 
-- `Schema.Enums` -> `Schema.Enum`: Rename the enum constructor and pass the enum object.
+- `Schema.Enums` -> `Schema.Enum`: Rename the enum constructor and pass the enum object. Numeric members must be finite; NaN and positive or negative Infinity throw at construction.
 
 - `Schema.EnumsDefinition` -> `none`: Compared the v3 declaration with v4 Schema and the schema migration guide; no direct public replacement remains. Rebuild the behavior from public v4 codecs/getters where still required.
 
@@ -14603,7 +14619,7 @@ Schema.toFormatter(schema)
 
 - `Schema.Union` -> `Schema.Union(members)`: Pass union members as one array.
 
-- `Schema.UniqueSymbolFromSelf` -> `Schema.UniqueSymbol`: Use the v4 unique-symbol schema constructor.
+- `Schema.UniqueSymbolFromSelf` -> `Schema.UniqueSymbol`: Use the v4 unique-symbol schema constructor. JSON encoding is available only for globally registered symbols and uses the exact String(symbol) value; local symbols cannot be encoded as JSON.
 
 - `Schema.Unknown` -> `Schema.Unknown`: The API remains public in v4, but its type/value declaration was consolidated; use the v4 declaration and update inferred types/signature as needed.
 
@@ -14805,7 +14821,7 @@ Schema.toFormatter(schema)
 
 - `Schema.minLength` -> `Schema.isMinLength`: Rename the string predicate to `isMinLength` and apply it with `Schema.check` or a schema's `check` method.
 
-- `Schema.multipleOf` -> `Schema.isMultipleOf`: Rename the predicate to `isMultipleOf` and apply it with `Schema.check` or a schema's `check` method.
+- `Schema.multipleOf` -> `Schema.isMultipleOf`: Rename the predicate to `isMultipleOf` and apply it with `Schema.check` or a schema's `check` method. The divisor must be finite and nonzero or construction throws RangeError; negative divisors are normalized to their absolute value.
 
 - `Schema.mutable` -> `Schema.mutable`: The API remains public in v4, but its type/value declaration was consolidated; use the v4 declaration and update inferred types/signature as needed.
 
@@ -14977,7 +14993,7 @@ Schema.toFormatter(schema)
 
 - `SchemaAST.DocumentationAnnotationId` -> `Schema.Annotations.Augment["documentation"]`: Symbol annotation IDs were removed; use the documentation key.
 
-- `SchemaAST.Enums` -> `SchemaAST.Enum`: The v4 SchemaAST redesign renamed this primitive, collection, or guard while preserving its role.
+- `SchemaAST.Enums` -> `SchemaAST.Enum`: Renamed to Enum in the v4 AST model. Numeric enum members must be finite; NaN and positive or negative Infinity throw at construction.
 
 - `SchemaAST.EquivalenceAnnotation` -> `Schema.Annotations.ToEquivalence.Declaration`: Equivalence derivation annotations now use the toEquivalence key in Schema.Annotations.
 


### PR DESCRIPTION
Recent main changes removed the AI Service interfaces, changed Reactivity's implementation type, and altered Schema and HTTP address behavior. Update 17 migration annotations to explain branded service implementations, JSON Schema excess-property options, stricter Schema constructors, and NetAddress-based HTTP helpers; regenerate the reference.

Audited 25 commits from `5a802043984727b0c5a291af39d1b9bbfa8d7b8b` through `91abe38c3797b1c290aedef3b01e8c96dd4fee79`. CLI renames and Schema parser changes already have current guidance.

Validation: all 17 ids exist in v3; annotation parsing, Markdown safety, deterministic regeneration, lint, and whitespace checks pass. The full migration check still reports 14 unresolved API groups, matching the previous maintenance run, and this diff adds no TODO entries. The optional JSON report export hits a string-size limit; generation from the cached snapshots succeeds without it. No tests were added.

Closes EFF-1339
