### PR TITLE
fix(schema): resolve $ref pointers below a top-level definition in fromJsonSchemaDocument

### DIFF
--- a/.changeset/json-pointer-refs-below-definitions.md
+++ b/.changeset/json-pointer-refs-below-definitions.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+`SchemaRepresentation.fromJsonSchemaDocument` now resolves `$ref` pointers that descend below a top-level definition, such as `#/definitions/update/properties/schedule`, by translating the referenced subschema in place instead of rejecting the whole document as an unsupported reference.

--- a/packages/effect/src/JsonSchema.ts
+++ b/packages/effect/src/JsonSchema.ts
@@ -688,6 +688,20 @@ export function getReferenceKey($ref: string): string | undefined {
     : undefined
 }
 
+/**
+ * The unescaped tokens of a local reference that points below a top-level
+ * definition, e.g. `#/$defs/update/properties/schedule`, or `undefined` for any
+ * other reference.
+ *
+ * @internal
+ */
+export function getReferencePath($ref: string): ReadonlyArray<string> | undefined {
+  const path = $ref.startsWith("#") ? parseUriFragment($ref) : undefined
+  return path !== undefined && path.length > 2 && path[0] === "$defs"
+    ? path
+    : undefined
+}
+
 function transformSchema(
   node: unknown,
   transform: (schema: Record<string, unknown>, inEmbeddedResource: boolean) => void

--- a/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts
+++ b/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts
@@ -307,6 +307,55 @@ function translateJsonSchemaMultiDocument(
     return representation
   }
 
+  // Pointers below a definition are translated in place at each use site. The
+  // set guards against a pointer that leads back to itself.
+  const pointersInProgress = new Set<string>()
+
+  function translatePointerReference($ref: string, path: Path): ImportedJsonSchemaRepresentation {
+    const pointer = JsonSchema.getReferencePath($ref)
+    if (pointer === undefined) {
+      throw errorWithPath(
+        `Unsupported $ref ${JSON.stringify($ref)}. Use "#/$defs/Name".`,
+        [...path, "$ref"]
+      )
+    }
+    const [, key, ...tokens] = pointer
+    if (!Object.hasOwn(document.definitions, key)) {
+      throw errorWithPath(
+        `Missing definition ${JSON.stringify(key)} for $ref ${JSON.stringify($ref)}.`,
+        [...path, "$ref"]
+      )
+    }
+    let node: unknown = document.definitions[key]
+    for (const token of tokens) {
+      if (Array.isArray(node)) {
+        node = /^(0|[1-9][0-9]*)$/.test(token) ? node[Number(token)] : undefined
+      } else if (isObject(node) && Object.hasOwn(node, token)) {
+        node = node[token]
+      } else {
+        node = undefined
+      }
+      if (node === undefined) {
+        throw errorWithPath(
+          `Unresolvable $ref ${JSON.stringify($ref)}. Nothing exists at that location.`,
+          [...path, "$ref"]
+        )
+      }
+    }
+    if (pointersInProgress.has($ref)) {
+      throw errorWithPath(
+        `Recursive $ref ${JSON.stringify($ref)} cannot be inlined. Use "#/$defs/Name".`,
+        [...path, "$ref"]
+      )
+    }
+    pointersInProgress.add($ref)
+    try {
+      return translateSchema(node, ["definitions", key, ...tokens])
+    } finally {
+      pointersInProgress.delete($ref)
+    }
+  }
+
   function mergeAnnotations(
     left: Schema.Annotations.Annotations | undefined,
     right: Schema.Annotations.Annotations | undefined
@@ -924,32 +973,35 @@ function translateJsonSchemaMultiDocument(
       }
       const $ref = JsonSchema.getReferenceKey(schema.$ref)
       if ($ref === undefined) {
-        throw errorWithPath(
-          `Unsupported $ref ${JSON.stringify(schema.$ref)}. Use "#/$defs/Name".`,
-          [...path, "$ref"]
-        )
+        const pointed = translatePointerReference(schema.$ref, path)
+        representation = representation._tag === "Unknown"
+          ? pointed
+          : representation._tag === "Never"
+          ? never
+          : intersect(pointed, representation, path)
+      } else {
+        if (!Object.hasOwn(document.definitions, $ref)) {
+          throw errorWithPath(
+            `Missing definition ${JSON.stringify($ref)} for $ref ${JSON.stringify(schema.$ref)}.`,
+            [...path, "$ref"]
+          )
+        }
+        if (!reachableDefinitions.has($ref)) reachableDefinitions.set($ref, path)
+        const reference: SchemaRepresentation.Reference = { _tag: "Reference", $ref }
+        representation = representation._tag === "Unknown"
+          ? reference
+          : representation._tag === "Never"
+          ? never
+          : intersect(
+            resolveReference(
+              reference,
+              path,
+              `Recursive $ref ${JSON.stringify(reference.$ref)} cannot have sibling constraints.`
+            ),
+            representation,
+            path
+          )
       }
-      if (!Object.hasOwn(document.definitions, $ref)) {
-        throw errorWithPath(
-          `Missing definition ${JSON.stringify($ref)} for $ref ${JSON.stringify(schema.$ref)}.`,
-          [...path, "$ref"]
-        )
-      }
-      if (!reachableDefinitions.has($ref)) reachableDefinitions.set($ref, path)
-      const reference: SchemaRepresentation.Reference = { _tag: "Reference", $ref }
-      representation = representation._tag === "Unknown"
-        ? reference
-        : representation._tag === "Never"
-        ? never
-        : intersect(
-          resolveReference(
-            reference,
-            path,
-            `Recursive $ref ${JSON.stringify(reference.$ref)} cannot have sibling constraints.`
-          ),
-          representation,
-          path
-        )
     }
     const annotations = jsonSchemaAnnotations(schema)
     if (annotations !== undefined && representation._tag === "Reference") {

--- a/packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts
+++ b/packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts
@@ -1216,27 +1216,78 @@ describe("fromJsonSchemaDocument", () => {
       )
     })
 
-    it("rejects a reference below a definition instead of resolving its final token", () => {
-      throws(
-        () =>
-          toSchemaFromJsonSchemaDocument(
-            JsonSchema.fromSchemaDraft07({
-              definitions: {
-                inner: { type: "number" },
-                outer: {
-                  type: "object",
-                  properties: {
-                    inner: { type: "string" }
-                  }
-                }
-              },
+    it("resolves a reference below a definition to the pointed subschema", () => {
+      const schema = toSchemaFromJsonSchemaDocument(
+        JsonSchema.fromSchemaDraft07({
+          definitions: {
+            inner: { type: "number" },
+            outer: {
               type: "object",
               properties: {
-                copy: { $ref: "#/definitions/outer/properties/inner" }
+                inner: { type: "string" }
               }
-            })
-          ),
-        `Unsupported $ref "#/$defs/outer/properties/inner". Use "#/$defs/Name".\n  at ["schema"]["properties"]["copy"]["$ref"]`
+            }
+          },
+          type: "object",
+          properties: {
+            copy: { $ref: "#/definitions/outer/properties/inner" }
+          }
+        })
+      )
+      const is = Schema.is(schema)
+      assert.isTrue(is({ copy: "a" }))
+      assert.isFalse(is({ copy: 1 }))
+    })
+
+    it("resolves a reference through an array index below a definition", () => {
+      const schema = toSchemaFromJsonSchemaDocument(JsonSchema.fromSchemaDraft2020_12({
+        $ref: "#/$defs/either/anyOf/1",
+        $defs: {
+          either: { anyOf: [{ type: "string" }, { type: "number" }] }
+        }
+      }))
+      const is = Schema.is(schema)
+      assert.isTrue(is(1))
+      assert.isFalse(is("a"))
+    })
+
+    it("resolves a reference below a definition next to other keywords", () => {
+      const schema = toSchemaFromJsonSchemaDocument(JsonSchema.fromSchemaDraft2020_12({
+        $ref: "#/$defs/outer/properties/name",
+        minLength: 2,
+        $defs: {
+          outer: { type: "object", properties: { name: { type: "string" } } }
+        }
+      }))
+      const is = Schema.is(schema)
+      assert.isTrue(is("ab"))
+      assert.isFalse(is("a"))
+      assert.isFalse(is(1))
+    })
+
+    it("reports a reference below a definition that leads nowhere", () => {
+      throws(
+        () =>
+          toSchemaFromJsonSchemaDocument(JsonSchema.fromSchemaDraft2020_12({
+            $ref: "#/$defs/outer/properties/missing",
+            $defs: {
+              outer: { type: "object", properties: { name: { type: "string" } } }
+            }
+          })),
+        `Unresolvable $ref "#/$defs/outer/properties/missing". Nothing exists at that location.\n  at ["schema"]["$ref"]`
+      )
+    })
+
+    it("rejects a reference below a definition that leads back to itself", () => {
+      throws(
+        () =>
+          toSchemaFromJsonSchemaDocument(JsonSchema.fromSchemaDraft2020_12({
+            $ref: "#/$defs/A/properties/self",
+            $defs: {
+              A: { type: "object", properties: { self: { $ref: "#/$defs/A/properties/self" } } }
+            }
+          })),
+        `Recursive $ref "#/$defs/A/properties/self" cannot be inlined. Use "#/$defs/Name".\n  at ["definitions"]["A"]["properties"]["self"]["$ref"]`
       )
     })
 


### PR DESCRIPTION
Closes #7418.

## Problem

`SchemaRepresentation.fromJsonSchemaDocument` only accepts `$ref`s of the form `#/$defs/<name>` (or `#/definitions/<name>` after normalisation). A pointer that descends below a definition, such as `#/definitions/update/properties/schedule`, throws `Unsupported reference` since #7415, so a document that uses that form anywhere cannot be imported at all. Hand-written schemas use it routinely; SchemaStore's `dependabot-2.0.json` has 14 of them.

## Change

- `JsonSchema.getReferencePath` (internal): returns the unescaped tokens of a local reference that points below a top-level definition, `undefined` otherwise. `getReferenceKey` is unchanged, so plain definition references keep going through the existing `Reference` path.
- `fromJsonSchemaDocument`: when `getReferenceKey` rejects a `$ref`, the new `translatePointerReference` walks the tokens from the named definition (object keys and array indices, for example `anyOf/1`) and translates the pointed subschema in place at the use site. Sibling keywords on the referencing schema intersect with it as before. A pointer that leads nowhere reports `Unresolvable $ref` with the full pointer; a pointer that leads back to itself reports `Recursive $ref ... cannot be inlined` instead of recursing forever. Messages follow the style introduced in #8169.
- Definitions reached only through such a pointer are inlined rather than hoisted, which keeps the change local and leaves the output unchanged for every document that already imported.

## Tests

`packages/effect/test/schema/representation/fromJsonSchemaDocument.test.ts`: the test that asserted rejection is replaced by five cases: a pointer below a definition, a pointer through an array index, a pointer next to other keywords, a dangling pointer, and a self-referencing pointer. Ran the file locally together with `tsc -b`, `dprint check` and `oxlint`.

Changeset included (`effect`, patch).
