### PR TITLE
feat(cli): make message optional for Prompt.Select and Prompt.MultiSelect

### DIFF
--- a/.changeset/select-prompt-optional-message.md
+++ b/.changeset/select-prompt-optional-message.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-`Prompt.Select` and `Prompt.MultiSelect` no longer require a `message`. When it is omitted the header line is skipped and only the choice list is rendered; submission, clearing and quitting behave as before. `Prompt.AutoComplete` still requires a message.
+Make `message` optional for `Prompt.Select` and `Prompt.MultiSelect`. When omitted, prompts display only the choices and submission shows a tick followed by the selected titles. `Prompt.AutoComplete` still requires a message.

--- a/.changeset/select-prompt-optional-message.md
+++ b/.changeset/select-prompt-optional-message.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+`Prompt.Select` and `Prompt.MultiSelect` no longer require a `message`. When it is omitted the header line is skipped and only the choice list is rendered; submission, clearing and quitting behave as before. `Prompt.AutoComplete` still requires a message.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -447,9 +447,10 @@ export interface FileOptions extends ThemeOptions {
  */
 export interface SelectOptions<A> extends ThemeOptions {
   /**
-   * The message to display in the prompt.
+   * The message to display in the prompt. When omitted, the prompt renders
+   * only the choice list, without a header line.
    */
-  readonly message: string
+  readonly message?: string | undefined
   /**
    * The choices to display to the user.
    */
@@ -468,6 +469,10 @@ export interface SelectOptions<A> extends ThemeOptions {
  * @since 4.0.0
  */
 export interface AutoCompleteOptions<A> extends SelectOptions<A> {
+  /**
+   * The message to display in the prompt.
+   */
+  readonly message: string
   /**
    * The label used for the filter display (defaults to "filter").
    */
@@ -2641,7 +2646,9 @@ const handleFileProcess = (options: FileOptionsReq) => {
   })
 }
 
-interface SelectOptionsReq<A> extends OptionsReq<SelectOptions<A>> {}
+interface SelectOptionsReq<A> extends Omit<OptionsReq<SelectOptions<A>>, "message"> {
+  readonly message?: string | undefined
+}
 interface MultiSelectOptionsReq extends MultiSelectOptions {}
 
 type MultiSelectState = {
@@ -2768,7 +2775,7 @@ const renderMultiSelectNextFrame = Effect.fnUntraced(
     const trailingSymbol = annotateSymbol(figures.pointerSmall, figures.mutedColor)
     const promptMsg = renderSelectOutput(leadingSymbol, trailingSymbol, options)
     const error = renderMultiSelectError(state, figures.pointer, figures)
-    return Ansi.cursorHide + promptMsg + "\n" + choices + error
+    return Ansi.cursorHide + withSelectHeader(promptMsg, choices) + error
   }
 )
 
@@ -2781,7 +2788,7 @@ const renderMultiSelectSubmission = Effect.fnUntraced(
     const selectedText = selectedChoices.join(", ")
     const leadingSymbol = annotateSymbol(figures.tick, figures.successColor)
     const trailingSymbol = annotateSymbol(figures.ellipsis, figures.mutedColor)
-    const promptMsg = renderSelectOutput(leadingSymbol, trailingSymbol, options)
+    const promptMsg = renderSelectOutput(leadingSymbol, trailingSymbol, options) ?? leadingSymbol
     return promptMsg + " " + Ansi.annotate(selectedText, figures.submittedColor) + "\n"
   }
 )
@@ -2843,7 +2850,7 @@ const handleMultiSelectClear = <A>(options: SelectOptionsReq<A>) =>
     const promptText = renderSelectOutput(figures.prefix, figures.pointerSmall, options, { plain: true })
     const choicesText = renderMultiSelectChoices(state, options, figures, { plain: true })
     const errorText = renderMultiSelectError(state, figures.pointer, figures, { plain: true })
-    const clearOutput = clearOutputWithError(`${promptText}\n${choicesText}`, columns, errorText)
+    const clearOutput = clearOutputWithError(withSelectHeader(promptText, choicesText), columns, errorText)
     return clearOutput + clearPrompt
   })
 
@@ -3207,7 +3214,9 @@ type AutoCompleteState = {
   readonly filtered: ReadonlyArray<number>
 }
 
-interface SelectOptionsReq<A> extends OptionsReq<SelectOptions<A>> {}
+interface SelectOptionsReq<A> extends Omit<OptionsReq<SelectOptions<A>>, "message"> {
+  readonly message?: string | undefined
+}
 interface AutoCompleteOptionsReq<A> extends OptionsReq<AutoCompleteOptions<A>> {}
 
 const filterAutoCompleteChoices = <A>(choices: ReadonlyArray<SelectChoice<A>>, query: string) => {
@@ -3244,7 +3253,13 @@ const renderSelectOutput = <A>(
   trailingSymbol: string,
   options: SelectOptionsReq<A>,
   renderOptions?: RenderOptions | undefined
-) => renderPrompt("", options.message, leadingSymbol, trailingSymbol, renderOptions)
+): string | undefined =>
+  options.message === undefined
+    ? undefined
+    : renderPrompt("", options.message, leadingSymbol, trailingSymbol, renderOptions)
+
+const withSelectHeader = (header: string | undefined, body: string): string =>
+  header === undefined ? body : header + "\n" + body
 
 const renderAutoCompleteFilter = <A>(
   state: AutoCompleteState,
@@ -3406,7 +3421,7 @@ const renderSelectNextFrame = Effect.fnUntraced(function*<A>(state: SelectState,
   const leadingSymbol = annotateSymbol(figures.prefix, figures.primaryColor)
   const trailingSymbol = annotateSymbol(figures.pointerSmall, figures.mutedColor)
   const promptMsg = renderSelectOutput(leadingSymbol, trailingSymbol, options)
-  return Ansi.cursorHide + promptMsg + "\n" + choices
+  return Ansi.cursorHide + withSelectHeader(promptMsg, choices)
 })
 
 const renderAutoCompleteNextFrame = Effect.fnUntraced(function*<A>(
@@ -3426,7 +3441,7 @@ const renderSelectSubmission = Effect.fnUntraced(function*<A>(state: SelectState
   const selected = options.choices[state].title
   const leadingSymbol = annotateSymbol(figures.tick, figures.successColor)
   const trailingSymbol = annotateSymbol(figures.ellipsis, figures.mutedColor)
-  const promptMsg = renderSelectOutput(leadingSymbol, trailingSymbol, options)
+  const promptMsg = renderSelectOutput(leadingSymbol, trailingSymbol, options) ?? leadingSymbol
   return promptMsg + " " + Ansi.annotate(selected, figures.submittedColor) + "\n"
 })
 
@@ -3527,7 +3542,7 @@ const handleSelectClear = <A>(options: SelectOptionsReq<A>) =>
     const clearPrompt = Ansi.eraseLine + Ansi.cursorLeft
     const promptText = renderSelectOutput(figures.prefix, figures.pointerSmall, options, { plain: true })
     const choicesText = renderSelectChoices(state, options, figures, { plain: true })
-    const clearOutput = eraseText(`${promptText}\n${choicesText}`, columns)
+    const clearOutput = eraseText(withSelectHeader(promptText, choicesText), columns)
     return clearOutput + clearPrompt
   })
 

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -447,8 +447,7 @@ export interface FileOptions extends ThemeOptions {
  */
 export interface SelectOptions<A> extends ThemeOptions {
   /**
-   * The message to display in the prompt. When omitted, the prompt renders
-   * only the choice list, without a header line.
+   * The prompt message. Omit to display only the choices.
    */
   readonly message?: string | undefined
   /**
@@ -470,7 +469,7 @@ export interface SelectOptions<A> extends ThemeOptions {
  */
 export interface AutoCompleteOptions<A> extends SelectOptions<A> {
   /**
-   * The message to display in the prompt.
+   * The required prompt message.
    */
   readonly message: string
   /**

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -2646,8 +2646,8 @@ const handleFileProcess = (options: FileOptionsReq) => {
   })
 }
 
-interface SelectOptionsReq<A> extends Omit<OptionsReq<SelectOptions<A>>, "message"> {
-  readonly message?: string | undefined
+interface SelectOptionsReq<A> extends SelectOptions<A> {
+  readonly maxPerPage: number
 }
 interface MultiSelectOptionsReq extends MultiSelectOptions {}
 
@@ -3214,9 +3214,6 @@ type AutoCompleteState = {
   readonly filtered: ReadonlyArray<number>
 }
 
-interface SelectOptionsReq<A> extends Omit<OptionsReq<SelectOptions<A>>, "message"> {
-  readonly message?: string | undefined
-}
 interface AutoCompleteOptionsReq<A> extends OptionsReq<AutoCompleteOptions<A>> {}
 
 const filterAutoCompleteChoices = <A>(choices: ReadonlyArray<SelectChoice<A>>, query: string) => {

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -416,32 +416,11 @@ describe("Prompt.Select", () => {
 
       assert.strictEqual(result, "second")
       const frames = toFrames(yield* MockTerminal.displayLines)
-      const firstLine = frames[0]?.split("\n")[0] ?? ""
-      assert.include(firstLine, "First")
-      assert.include(frames.at(-1) ?? "", "Second")
-      assert.notInclude(frames.at(-1) ?? "", "First")
-    }).pipe(Effect.provide(TestLayer)))
-
-  it.effect("renders only the choice list for a multi-select without a message", () =>
-    Effect.gen(function*() {
-      yield* MockTerminal.inputKey("down")
-      yield* MockTerminal.inputKey("down")
-      yield* MockTerminal.inputKey("space")
-      yield* MockTerminal.inputKey("enter")
-
-      const result = yield* Prompt.run(Prompt.MultiSelect({
-        choices: [
-          { title: "First", value: "first" },
-          { title: "Second", value: "second" }
-        ]
-      }))
-
-      assert.deepStrictEqual(result, ["first"])
-      const frames = toFrames(yield* MockTerminal.displayLines)
-      const firstLine = frames[0]?.split("\n")[0] ?? ""
-      assert.include(firstLine, "Select All")
-      assert.include(frames.at(-1) ?? "", "First")
-      assert.notInclude(frames.at(-1) ?? "", "Select All")
+      assert.deepStrictEqual(frames, [
+        "❯ First \n  Second ",
+        "  First \n❯ Second ",
+        "✔ Second\n"
+      ])
     }).pipe(Effect.provide(TestLayer)))
 
   it.effect("renders a per-prompt theme across redraws", () =>
@@ -1041,6 +1020,27 @@ describe("Prompt.File", () => {
 })
 
 describe("Prompt.MultiSelect", () => {
+  it.effect("renders only the choice list when message is omitted", () =>
+    Effect.gen(function*() {
+      yield* MockTerminal.inputKey("space")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(Prompt.MultiSelect({
+        choices: [
+          { title: "First", value: "first" },
+          { title: "Second", value: "second" }
+        ]
+      }))
+
+      assert.deepStrictEqual(result, ["first", "second"])
+      const frames = toFrames(yield* MockTerminal.displayLines)
+      assert.deepStrictEqual(frames, [
+        "  Select All\n  Inverse Selection\n  ☐ First \n  ☐ Second ",
+        "  Select None\n  Inverse Selection\n  ☒ First \n  ☒ Second ",
+        "✔ First, Second\n"
+      ])
+    }).pipe(Effect.provide(TestLayer)))
+
   it.effect("renders paging and checkbox symbols from the prompt theme", () =>
     Effect.gen(function*() {
       const prompt = Prompt.MultiSelect({

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -402,6 +402,48 @@ describe("Prompt.String", () => {
 })
 
 describe("Prompt.Select", () => {
+  it.effect("renders only the choice list when message is omitted", () =>
+    Effect.gen(function*() {
+      yield* MockTerminal.inputKey("down")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(Prompt.Select({
+        choices: [
+          { title: "First", value: "first" },
+          { title: "Second", value: "second" }
+        ]
+      }))
+
+      assert.strictEqual(result, "second")
+      const frames = toFrames(yield* MockTerminal.displayLines)
+      const firstLine = frames[0]?.split("\n")[0] ?? ""
+      assert.include(firstLine, "First")
+      assert.include(frames.at(-1) ?? "", "Second")
+      assert.notInclude(frames.at(-1) ?? "", "First")
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("renders only the choice list for a multi-select without a message", () =>
+    Effect.gen(function*() {
+      yield* MockTerminal.inputKey("down")
+      yield* MockTerminal.inputKey("down")
+      yield* MockTerminal.inputKey("space")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(Prompt.MultiSelect({
+        choices: [
+          { title: "First", value: "first" },
+          { title: "Second", value: "second" }
+        ]
+      }))
+
+      assert.deepStrictEqual(result, ["first"])
+      const frames = toFrames(yield* MockTerminal.displayLines)
+      const firstLine = frames[0]?.split("\n")[0] ?? ""
+      assert.include(firstLine, "Select All")
+      assert.include(frames.at(-1) ?? "", "First")
+      assert.notInclude(frames.at(-1) ?? "", "Select All")
+    }).pipe(Effect.provide(TestLayer)))
+
   it.effect("renders a per-prompt theme across redraws", () =>
     Effect.gen(function*() {
       yield* MockTerminal.inputKey("down")

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -415,12 +415,24 @@ describe("Prompt.Select", () => {
       }))
 
       assert.strictEqual(result, "second")
-      const frames = toFrames(yield* MockTerminal.displayLines)
+      const output = yield* MockTerminal.displayLines
+      const frames = toFrames(output)
       assert.deepStrictEqual(frames, [
         "❯ First \n  Second ",
         "  First \n❯ Second ",
         "✔ Second\n"
       ])
+      assert.isTrue(toRawFrames(output)[1]?.startsWith(`${escape}[2K${escape}[1A${escape}[2K${escape}[G`))
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("keeps the header when message is empty", () =>
+    Effect.gen(function*() {
+      yield* MockTerminal.inputKey("enter")
+
+      yield* Prompt.run(Prompt.Select({ message: "", choices: [{ title: "First", value: "first" }] }))
+
+      const frames = toFrames(yield* MockTerminal.displayLines)
+      assert.strictEqual(frames[0]?.split("\n")[0], "?  › ")
     }).pipe(Effect.provide(TestLayer)))
 
   it.effect("renders a per-prompt theme across redraws", () =>
@@ -1033,12 +1045,42 @@ describe("Prompt.MultiSelect", () => {
       }))
 
       assert.deepStrictEqual(result, ["first", "second"])
-      const frames = toFrames(yield* MockTerminal.displayLines)
+      const output = yield* MockTerminal.displayLines
+      const frames = toFrames(output)
       assert.deepStrictEqual(frames, [
         "  Select All\n  Inverse Selection\n  ☐ First \n  ☐ Second ",
         "  Select None\n  Inverse Selection\n  ☒ First \n  ☒ Second ",
         "✔ First, Second\n"
       ])
+      const clearChoices = `${escape}[2K${escape}[1A`.repeat(3) + `${escape}[2K${escape}[G`
+      assert.isTrue(toRawFrames(output)[1]?.startsWith(clearChoices))
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("clears validation errors without a message", () =>
+    Effect.gen(function*() {
+      yield* MockTerminal.inputKey("enter")
+      yield* MockTerminal.inputKey("space")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(Prompt.MultiSelect({
+        min: 1,
+        choices: [
+          { title: "First", value: "first" },
+          { title: "Second", value: "second" }
+        ]
+      }))
+
+      assert.deepStrictEqual(result, ["first", "second"])
+      const output = yield* MockTerminal.displayLines
+      const frames = toFrames(output)
+      assert.isTrue(frames[1]?.endsWith("\n❯ At least 1 are required"))
+      assert.strictEqual(frames.at(-1), "✔ First, Second\n")
+
+      const clearError = `${escape}[1B${escape}[2K${escape}[1A${escape}[2K${escape}[G`
+      const clearChoices = `${escape}[2K${escape}[1A`.repeat(3) + `${escape}[2K${escape}[G`
+      const rawFrames = toRawFrames(output)
+      assert.isTrue(rawFrames[2]?.startsWith(clearError + clearChoices))
+      assert.isTrue(rawFrames[3]?.startsWith(clearError + clearChoices))
     }).pipe(Effect.provide(TestLayer)))
 
   it.effect("renders paging and checkbox symbols from the prompt theme", () =>

--- a/packages/effect/typetest/unstable/cli/Prompt.tst.ts
+++ b/packages/effect/typetest/unstable/cli/Prompt.tst.ts
@@ -6,6 +6,13 @@ declare const stringEvents: Queue.Dequeue<string, never>
 declare const objectEvents: Queue.Dequeue<{ readonly tick: number }, never>
 
 describe("Prompt", () => {
+  it("allows select messages to be omitted but requires an autocomplete message", () => {
+    const options = { choices: [{ title: "First", value: "first" }] }
+    expect(Prompt.Select).type.toBeCallableWith(options)
+    expect(Prompt.MultiSelect).type.toBeCallableWith(options)
+    expect(Prompt.AutoComplete).type.not.toBeCallableWith(options)
+  })
+
   it("numeric option types match their constructors", () => {
     const intOptions: Prompt.IntOptions = { message: "Count", min: 0, incrementBy: 2 }
     const numberOptions: Prompt.NumberOptions = { ...intOptions, precision: 3 }


### PR DESCRIPTION
Closes #7255
Closes EFF-1344

`Prompt.Select` and `Prompt.MultiSelect` require a message and always render a header, even for an empty string. Make `SelectOptions.message` optional so callers can omit it to display only the choices. Submission displays the tick symbol and selected titles. Autocomplete continues to require a message.

Exporting the choice-list renderer for `Prompt.custom` remains outside this PR's scope. Includes an `effect` patch changeset.

The two regression tests in `packages/effect/test/unstable/cli/Prompt.test.ts` live in their respective Select and MultiSelect groups. They assert complete initial, redraw, and submission frames without a message, along with the selected values.

Validation passed with `nix develop -c` for each command:

- `pnpm test --run packages/effect/test/unstable/cli/Prompt.test.ts` (65 tests)
- `pnpm lint-fix`
- `pnpm check`
