### PR TITLE
fix(platform-bun): forward default hostname to Bun.serve

### DIFF
--- a/.changeset/fix-bun-http-server-default-hostname.md
+++ b/.changeset/fix-bun-http-server-default-hostname.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-bun": patch
+---
+
+Fix `BunHttpServer` startup when `hostname` is omitted or `undefined` by explicitly passing the default `0.0.0.0` listen address to Bun.

--- a/packages/platform/bun/src/BunHttpServer.ts
+++ b/packages/platform/bun/src/BunHttpServer.ts
@@ -131,6 +131,8 @@ export const make = Effect.fnUntraced(
           catch: (cause) => new Error.ServeError({ cause })
         })
         listenOptions = { ...options, hostname: resolved }
+      } else {
+        listenOptions = { ...options, hostname }
       }
     }
     const { compressionThreshold = MIN_COMPRESSIBLE_SIZE, ...websocket } = options.websocket ?? {}

--- a/packages/platform/bun/test/BunHttpServer.test.ts
+++ b/packages/platform/bun/test/BunHttpServer.test.ts
@@ -113,6 +113,21 @@ const makeWebSocketServer = Effect.fnUntraced(function*(payload: string, compres
 })
 
 describe("BunHttpServer", () => {
+  for (const options of [{ port: 0 }, { hostname: undefined, port: 0 }, { unix: undefined, port: 0 }]) {
+    it.effect(`defaults to a numeric wildcard address with ${Object.keys(options).join(", ")}`, () =>
+      Effect.gen(function*() {
+        const server = yield* HttpServer.HttpServer
+        if (!NetAddress.isInetAddressV4(server.address)) {
+          assert.fail("Expected an IPv4 listen address")
+        }
+        assert.strictEqual(NetAddress.formatIp(server.address.address), "0.0.0.0")
+        yield* server.serve(Effect.succeed(HttpServerResponse.text("tcp")))
+        const client = yield* HttpServer.makeTestClient.pipe(Effect.provide(FetchHttpClient.layer))
+        const response = yield* client.get("/")
+        assert.strictEqual(yield* response.text, "tcp")
+      }).pipe(Effect.provide(BunHttpServer.layer(options))))
+  }
+
   it.effect("treats an undefined Unix path as a TCP listener", () =>
     Effect.gen(function*() {
       for (const hostname of ["localhost", "127.0.0.1"]) {


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes `BunHttpServer.layer({ port: 3001 })` failing with `ServeError` when `hostname` is omitted. The default `0.0.0.0` hostname was computed but never forwarded to `Bun.serve`, allowing Bun to return `localhost`, which fails numeric IP parsing.

Explicitly forwards the default hostname. Adds regression coverage for omitted hostname, `hostname: undefined`, and `unix: undefined`, plus a patch changeset.

Validation: all 13 Bun HTTP server tests pass. Lint and type checking pass with pnpm’s dependency metadata guard disabled due to an existing mismatch.

## Related

- Related to #7524 