### PR TITLE
fix(platform-bun): restore startup when hostname is omitted

### DIFF
--- a/.changeset/fix-bun-http-default-hostname.md
+++ b/.changeset/fix-bun-http-default-hostname.md
@@ -3,3 +3,5 @@
 ---
 
 Fix `BunHttpServer` startup when `hostname` is omitted by explicitly listening on `::`, preserving IPv4 and IPv6 connectivity and avoiding a `ServeError` when parsing Bun's default hostname.
+
+Preserve the configured listen address in `BunClusterHttp`, including loopback addresses, when applying the HTTP server hostname default.

--- a/.changeset/fix-bun-http-default-hostname.md
+++ b/.changeset/fix-bun-http-default-hostname.md
@@ -2,4 +2,4 @@
 "@effect/platform-bun": patch
 ---
 
-Fix `BunHttpServer` startup when `hostname` is omitted by explicitly listening on `0.0.0.0`, avoiding a `ServeError` when parsing Bun's default hostname.
+Fix `BunHttpServer` startup when `hostname` is omitted by explicitly listening on `::`, preserving IPv4 and IPv6 connectivity and avoiding a `ServeError` when parsing Bun's default hostname.

--- a/.changeset/fix-bun-http-default-hostname.md
+++ b/.changeset/fix-bun-http-default-hostname.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-bun": patch
+---
+
+Fix `BunHttpServer` startup when `hostname` is omitted by explicitly listening on `0.0.0.0`, avoiding a `ServeError` when parsing Bun's default hostname.

--- a/packages/platform/bun/src/BunClusterHttp.ts
+++ b/packages/platform/bun/src/BunClusterHttp.ts
@@ -64,7 +64,7 @@ export const layerHttpServer: Layer.Layer<
   if (Option.isNone(listenAddress)) {
     return yield* Effect.die("BunClusterHttp.layerHttpServer: ShardingConfig.runnerAddress is None")
   }
-  return BunHttpServer.layer(listenAddress.value)
+  return BunHttpServer.layer({ hostname: listenAddress.value.host, port: listenAddress.value.port })
 }).pipe(Layer.unwrap)
 
 /**

--- a/packages/platform/bun/src/BunHttpServer.ts
+++ b/packages/platform/bun/src/BunHttpServer.ts
@@ -120,10 +120,9 @@ export const make = Effect.fnUntraced(
     let listenOptions = options
     if (!("unix" in options) || options.unix === undefined) {
       const internetOptions = options as Bun.Serve.HostnamePortServeOptions<WebSocketContext>
-      const hostname = internetOptions.hostname ?? "0.0.0.0"
-      listenOptions = { ...options, hostname }
+      let hostname = internetOptions.hostname ?? "::"
       if (Result.isFailure(NetAddress.ipFromString(hostname))) {
-        const resolved = yield* Effect.tryPromise({
+        hostname = yield* Effect.tryPromise({
           try: async () => {
             const result = await Bun.dns.lookup(hostname, { socketType: "tcp" })
             if (result.length === 0) throw new globalThis.Error(`Could not resolve hostname: ${hostname}`)
@@ -131,8 +130,8 @@ export const make = Effect.fnUntraced(
           },
           catch: (cause) => new Error.ServeError({ cause })
         })
-        listenOptions = { ...options, hostname: resolved }
       }
+      listenOptions = { ...options, hostname }
     }
     const { compressionThreshold = MIN_COMPRESSIBLE_SIZE, ...websocket } = options.websocket ?? {}
     const handlerStack: Array<(request: Request, server: BunServer<WebSocketContext>) => Response | Promise<Response>> =

--- a/packages/platform/bun/src/BunHttpServer.ts
+++ b/packages/platform/bun/src/BunHttpServer.ts
@@ -121,6 +121,7 @@ export const make = Effect.fnUntraced(
     if (!("unix" in options) || options.unix === undefined) {
       const internetOptions = options as Bun.Serve.HostnamePortServeOptions<WebSocketContext>
       const hostname = internetOptions.hostname ?? "0.0.0.0"
+      listenOptions = { ...options, hostname }
       if (Result.isFailure(NetAddress.ipFromString(hostname))) {
         const resolved = yield* Effect.tryPromise({
           try: async () => {

--- a/packages/platform/bun/test/BunClusterHttp.test.ts
+++ b/packages/platform/bun/test/BunClusterHttp.test.ts
@@ -1,0 +1,45 @@
+import * as BunClusterHttp from "@effect/platform-bun/BunClusterHttp"
+import { assert, describe, it } from "@effect/vitest"
+import * as ConfigProvider from "effect/ConfigProvider"
+import * as Effect from "effect/Effect"
+import * as ShardingConfig from "effect/unstable/cluster/ShardingConfig"
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient"
+import * as HttpServer from "effect/unstable/http/HttpServer"
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse"
+import * as NetAddress from "effect/unstable/net/NetAddress"
+
+describe("BunClusterHttp", () => {
+  for (
+    const [name, values] of [
+      ["listen address overrides the runner address", {
+        host: "::1",
+        port: "0",
+        listenHost: "127.0.0.1",
+        listenPort: "0"
+      }],
+      ["runner address is used when the listen address is omitted", { host: "127.0.0.1", port: "0" }]
+    ] as const
+  ) {
+    it.effect(name, () =>
+      Effect.gen(function*() {
+        const config = yield* ShardingConfig.config.parse(ConfigProvider.fromUnknown(values))
+        yield* Effect.gen(function*() {
+          const server = yield* HttpServer.HttpServer
+          if (server.address._tag !== "InetAddressV4") {
+            return assert.fail(`expected InetAddressV4 at 127.0.0.1, got ${server.address}`)
+          }
+          assert.strictEqual(NetAddress.formatIp(server.address.address), "127.0.0.1")
+          assert.isAbove(server.address.port, 0)
+
+          yield* server.serve(Effect.succeed(HttpServerResponse.text("cluster loopback")))
+          const client = yield* HttpServer.makeTestClient.pipe(Effect.provide(FetchHttpClient.layer))
+          const response = yield* client.get("/")
+          assert.strictEqual(response.status, 200)
+          assert.strictEqual(yield* response.text, "cluster loopback")
+        }).pipe(
+          Effect.provide(BunClusterHttp.layerHttpServer),
+          Effect.provide(ShardingConfig.layer(config))
+        )
+      }))
+  }
+})

--- a/packages/platform/bun/test/BunHttpServer.test.ts
+++ b/packages/platform/bun/test/BunHttpServer.test.ts
@@ -114,18 +114,19 @@ const makeWebSocketServer = Effect.fnUntraced(function*(payload: string, compres
 
 describe("BunHttpServer", () => {
   for (
-    const [name, options] of [
-      ["omitted hostname", { port: 0 }],
-      ["undefined Unix path and omitted hostname", { port: 0, unix: undefined }],
-      ["explicit wildcard hostname", { port: 0, hostname: "0.0.0.0" }]
+    const [name, options, expectedTag, expectedIp] of [
+      ["omitted hostname", { port: 0 }, "InetAddressV6", "::"],
+      ["undefined Unix path and omitted hostname", { port: 0, unix: undefined }, "InetAddressV6", "::"],
+      ["explicit wildcard hostname", { port: 0, hostname: "0.0.0.0" }, "InetAddressV4", "0.0.0.0"]
     ] as const
   ) {
     it.effect(`starts a layer with ${name}`, () =>
       Effect.gen(function*() {
         const server = yield* HttpServer.HttpServer
-        assert.strictEqual(server.address._tag, "InetAddressV4")
-        if (server.address._tag !== "InetAddressV4") return
-        assert.strictEqual(NetAddress.formatIp(server.address.address), "0.0.0.0")
+        if (server.address._tag !== expectedTag) {
+          return assert.fail(`expected ${expectedTag}, got ${server.address._tag}`)
+        }
+        assert.strictEqual(NetAddress.formatIp(server.address.address), expectedIp)
         assert.isAbove(server.address.port, 0)
 
         yield* server.serve(Effect.succeed(HttpServerResponse.text("default hostname")))

--- a/packages/platform/bun/test/BunHttpServer.test.ts
+++ b/packages/platform/bun/test/BunHttpServer.test.ts
@@ -113,6 +113,29 @@ const makeWebSocketServer = Effect.fnUntraced(function*(payload: string, compres
 })
 
 describe("BunHttpServer", () => {
+  for (
+    const [name, options] of [
+      ["omitted hostname", { port: 0 }],
+      ["undefined Unix path and omitted hostname", { port: 0, unix: undefined }],
+      ["explicit wildcard hostname", { port: 0, hostname: "0.0.0.0" }]
+    ] as const
+  ) {
+    it.effect(`starts a layer with ${name}`, () =>
+      Effect.gen(function*() {
+        const server = yield* HttpServer.HttpServer
+        assert.strictEqual(server.address._tag, "InetAddressV4")
+        if (server.address._tag !== "InetAddressV4") return
+        assert.strictEqual(NetAddress.formatIp(server.address.address), "0.0.0.0")
+        assert.isAbove(server.address.port, 0)
+
+        yield* server.serve(Effect.succeed(HttpServerResponse.text("default hostname")))
+        const client = yield* HttpServer.makeTestClient.pipe(Effect.provide(FetchHttpClient.layer))
+        const response = yield* client.get("/")
+        assert.strictEqual(response.status, 200)
+        assert.strictEqual(yield* response.text, "default hostname")
+      }).pipe(Effect.provide(BunHttpServer.layer(options))))
+  }
+
   it.effect("treats an undefined Unix path as a TCP listener", () =>
     Effect.gen(function*() {
       for (const hostname of ["localhost", "127.0.0.1"]) {


### PR DESCRIPTION
`BunHttpServer.layer({ port: 3001 })` fails with `ServeError` because Bun reports `localhost` when the hostname is omitted, and the server address parser expects an IP. Default TCP listeners to `::` to restore startup and preserve IPv4 and IPv6 connectivity. Resolve explicit hostnames when necessary, then assign the listen options once. Includes a patch changeset for `@effect/platform-bun`.

Map the selected `BunClusterHttp` listen address from `host` to `hostname` explicitly so the HTTP default preserves configured cluster bindings, including loopback addresses. This covers both the listen-address override and the runner-address fallback.

Regression tests exercise the public HTTP server layer and the cluster layer with parsed sharding configuration, checking bound addresses, allocated ports, and HTTP responses. Test and implementation changes are in separate commits.

Validation:

- `nix develop -c bun run --bun vitest run packages/platform/bun/test/BunClusterHttp.test.ts packages/platform/bun/test/BunHttpServer.test.ts`: all 15 tests pass on Bun 1.3.13. The two cluster tests were verified to fail before the caller fix, reporting `::` instead of `127.0.0.1`.
- A temporary public-layer probe verified HTTP 200 and the expected response body through both `127.0.0.1` and `[::1]` for `{ port: 0 }` and `{ port: 0, unix: undefined }`.
- `nix develop -c pnpm lint-fix` and `nix develop -c pnpm check` pass.

Closes EFF-1343
