### PR TITLE
fix(persistence): parameterize persistence lookup keys

### DIFF
--- a/.changeset/fix-persistence-get-many-sql-injection.md
+++ b/.changeset/fix-persistence-get-many-sql-injection.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Parameterize request keys in both Persistence SQL backing stores' `getMany` queries to prevent SQL injection.

--- a/.changeset/fix-persistence-get-many-sql-injection.md
+++ b/.changeset/fix-persistence-get-many-sql-injection.md
@@ -1,5 +1,0 @@
----
-"effect": patch
----
-
-Parameterize request keys in both Persistence SQL backing stores' `getMany` queries to prevent SQL injection.

--- a/.changeset/parameterize-persistence-lookup-keys.md
+++ b/.changeset/parameterize-persistence-lookup-keys.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Parameterize persistence lookup keys in both SQL backing stores' `getMany` queries.

--- a/packages/effect/src/unstable/persistence/Persistence.ts
+++ b/packages/effect/src/unstable/persistence/Persistence.ts
@@ -385,11 +385,6 @@ export const layerBackingSqlMultiTable: Layer.Layer<
           `.unprepared
       })
 
-      const wrapString = sql.onDialectOrElse({
-        mssql: () => (s: string) => `N'${s}'`,
-        orElse: () => (s: string) => `'${s}'`
-      })
-
       return identity<BackingPersistenceStore>({
         get: (key) =>
           sql<
@@ -419,9 +414,9 @@ export const layerBackingSqlMultiTable: Layer.Layer<
               })
             ),
         getMany: (keys) =>
-          sql<{ id: string; value: string }>`SELECT id, value FROM ${table} WHERE id IN (${
-            sql.literal(keys.map(wrapString).join(", "))
-          }) AND (expires IS NULL OR expires > ${clock.currentTimeMillisUnsafe()})`.unprepared.pipe(
+          sql<{ id: string; value: string }>`SELECT id, value FROM ${table} WHERE ${
+            sql.in("id", keys)
+          } AND (expires IS NULL OR expires > ${clock.currentTimeMillisUnsafe()})`.pipe(
             Effect.mapError((cause) =>
               new PersistenceError({
                 message: `Failed to getMany from backing store`,
@@ -726,11 +721,6 @@ export const layerBackingSql: Layer.Layer<
       `.unprepared
   })
 
-  const wrapString = sql.onDialectOrElse({
-    mssql: () => (s: string) => `N'${s}'`,
-    orElse: () => (s: string) => `'${s}'`
-  })
-
   return BackingPersistence.of({
     make: Effect.fnUntraced(function*(storeId) {
       const clock = yield* Clock.Clock
@@ -764,9 +754,9 @@ export const layerBackingSql: Layer.Layer<
               })
             ),
         getMany: (keys) =>
-          sql<{ id: string; value: string }>`SELECT id, value FROM ${table} WHERE store_id = ${storeId} AND id IN (${
-            sql.literal(keys.map(wrapString).join(", "))
-          }) AND (expires IS NULL OR expires > ${clock.currentTimeMillisUnsafe()})`.unprepared.pipe(
+          sql<{ id: string; value: string }>`SELECT id, value FROM ${table} WHERE store_id = ${storeId} AND ${
+            sql.in("id", keys)
+          } AND (expires IS NULL OR expires > ${clock.currentTimeMillisUnsafe()})`.pipe(
             Effect.mapError((cause) =>
               new PersistenceError({
                 message: `Failed to getMany from backing store`,

--- a/packages/effect/src/unstable/persistence/Persistence.ts
+++ b/packages/effect/src/unstable/persistence/Persistence.ts
@@ -416,7 +416,7 @@ export const layerBackingSqlMultiTable: Layer.Layer<
         getMany: (keys) =>
           sql<{ id: string; value: string }>`SELECT id, value FROM ${table} WHERE ${
             sql.in("id", keys)
-          } AND (expires IS NULL OR expires > ${clock.currentTimeMillisUnsafe()})`.pipe(
+          } AND (expires IS NULL OR expires > ${clock.currentTimeMillisUnsafe()})`.unprepared.pipe(
             Effect.mapError((cause) =>
               new PersistenceError({
                 message: `Failed to getMany from backing store`,
@@ -756,7 +756,7 @@ export const layerBackingSql: Layer.Layer<
         getMany: (keys) =>
           sql<{ id: string; value: string }>`SELECT id, value FROM ${table} WHERE store_id = ${storeId} AND ${
             sql.in("id", keys)
-          } AND (expires IS NULL OR expires > ${clock.currentTimeMillisUnsafe()})`.pipe(
+          } AND (expires IS NULL OR expires > ${clock.currentTimeMillisUnsafe()})`.unprepared.pipe(
             Effect.mapError((cause) =>
               new PersistenceError({
                 message: `Failed to getMany from backing store`,

--- a/packages/sql/sqlite-node/test/Persistence.test.ts
+++ b/packages/sql/sqlite-node/test/Persistence.test.ts
@@ -23,7 +23,18 @@ const ClientLayer = Effect.gen(function*() {
 const testLayer = (layer: Layer.Layer<Persistence.BackingPersistence, never, SqlClient.SqlClient>) =>
   layer.pipe(Layer.provideMerge(ClientLayer))
 
-const suite = (name: string, layer: Layer.Layer<Persistence.BackingPersistence, never, SqlClient.SqlClient>) =>
+const suite = (
+  name: string,
+  layer: Layer.Layer<Persistence.BackingPersistence, never, SqlClient.SqlClient>,
+  options: {
+    /**
+     * A crafted `getMany` key which, if request keys are interpolated into SQL
+     * without parameterization (GHSA-jcj9-qx5g-vgh6), escapes the `IN` list and
+     * reads the `sqli_victim` store's entries from the `sqli_attacker` store.
+     */
+    readonly injectionProbe: string
+  }
+) =>
   it.layer(testLayer(layer))(`Persistence (${name})`, (it) => {
     it.effect("set + get", () =>
       Effect.gen(function*() {
@@ -114,10 +125,49 @@ const suite = (name: string, layer: Layer.Layer<Persistence.BackingPersistence, 
         expect(yield* storeA.get("shared-key")).toEqual(undefined)
         expect(yield* storeB.get("shared-key")).toEqual({ name: "Bob" })
       }))
+
+    it.effect("getMany treats keys containing single quotes as data", () =>
+      Effect.gen(function*() {
+        const persistence = yield* Persistence.BackingPersistence
+        const store = yield* persistence.make("test_store_quotes")
+        yield* store.set("it's-a-key", { name: "Alice" }, undefined)
+
+        // GHSA-jcj9-qx5g-vgh6: keys must be bound as parameters, not
+        // interpolated into the `IN` list as raw string literals.
+        const values = yield* store.getMany(["it's-a-key", "missing'key"])
+        expect(values).toEqual([{ name: "Alice" }, undefined])
+      }))
+
+    it.effect("getMany does not leak entries across stores (GHSA-jcj9-qx5g-vgh6)", () =>
+      Effect.gen(function*() {
+        const persistence = yield* Persistence.BackingPersistence
+        const victim = yield* persistence.make("sqli_victim")
+        yield* victim.set("secret", { secret: "victim-data" }, undefined)
+
+        const attacker = yield* persistence.make("sqli_attacker")
+        yield* attacker.set("innocent", { name: "Mallory" }, undefined)
+
+        // The probe is a no-op key when keys are parameterized. If keys are
+        // interpolated into raw SQL it escapes the `IN` list and exfiltrates
+        // the victim store's `secret` entry into the attacker's results.
+        const values = yield* attacker.getMany(["secret", options.injectionProbe])
+        expect(values).toEqual([undefined, undefined])
+        expect(yield* attacker.get("secret")).toEqual(undefined)
+      }))
   })
 
-suite("table-per-store", Persistence.layerBackingSqlMultiTable)
-suite("single-table", Persistence.layerBackingSql)
+suite("table-per-store", Persistence.layerBackingSqlMultiTable, {
+  // Expands to `... WHERE id IN ('secret', '') UNION SELECT id, value FROM
+  // effect_persistence_sqli_victim WHERE ('1'='1') AND (expires IS NULL OR
+  // expires > ?)`, appending every victim row to the attacker's result set.
+  injectionProbe: `') UNION SELECT id, value FROM effect_persistence_sqli_victim WHERE ('1'='1`
+})
+suite("single-table", Persistence.layerBackingSql, {
+  // Expands to `... WHERE store_id = 'sqli_attacker' AND id IN ('secret', '')
+  // OR store_id='sqli_victim' AND ('1'='1') AND (expires IS NULL OR expires >
+  // ?)`, bypassing the store isolation filter.
+  injectionProbe: `') OR store_id='sqli_victim' AND ('1'='1`
+})
 
 PersistedQueueTest.suite(
   "sql-sqlite-node",

--- a/packages/sql/sqlite-node/test/Persistence.test.ts
+++ b/packages/sql/sqlite-node/test/Persistence.test.ts
@@ -29,7 +29,7 @@ const suite = (
   options: {
     /**
      * A crafted `getMany` key which, if request keys are interpolated into SQL
-     * without parameterization (GHSA-jcj9-qx5g-vgh6), escapes the `IN` list and
+     * without parameterization, escapes the `IN` list and
      * reads the `sqli_victim` store's entries from the `sqli_attacker` store.
      */
     readonly injectionProbe: string
@@ -132,13 +132,13 @@ const suite = (
         const store = yield* persistence.make("test_store_quotes")
         yield* store.set("it's-a-key", { name: "Alice" }, undefined)
 
-        // GHSA-jcj9-qx5g-vgh6: keys must be bound as parameters, not
+        // Keys must be bound as parameters, not
         // interpolated into the `IN` list as raw string literals.
         const values = yield* store.getMany(["it's-a-key", "missing'key"])
         expect(values).toEqual([{ name: "Alice" }, undefined])
       }))
 
-    it.effect("getMany does not leak entries across stores (GHSA-jcj9-qx5g-vgh6)", () =>
+    it.effect("getMany preserves store isolation for crafted keys", () =>
       Effect.gen(function*() {
         const persistence = yield* Persistence.BackingPersistence
         const victim = yield* persistence.make("sqli_victim")


### PR DESCRIPTION
Parameterize persistence lookup keys in both SQL backing stores with `sql.in("id", keys)`. Quoted keys now work as data, and crafted keys preserve store isolation. Remove the unused quote wrappers and retain `.unprepared` so varying batch sizes do not populate prepared statement caches with a query for each size.

Includes regression coverage for quoted keys and store isolation, preserves existing assertions, and adds a patch changeset for `effect`.

Validation (`pnpm` commands run through `nix develop -c`):

- `pnpm test --run packages/sql/sqlite-node/test/Persistence.test.ts`: before the fix, 4 regression failures and 26 passes; after the fix, 30/30 pass.
- `pnpm lint-fix`: passed.
- `pnpm check`: passed.
- `git diff --check`: passed.

PostgreSQL, MySQL, and MSSQL integration suites were not run; runtime regression coverage is SQLite.

Parameter-limit handling for large batches is tracked separately in EFF-1354, with boundary tests and implementation planned as separate runs.

Closes EFF-1350
