### PR TITLE
fix(http): omit body in toWeb for 204, 205, and 304

### DIFF
--- a/.changeset/fix-http-toweb-null-body-status.md
+++ b/.changeset/fix-http-toweb-null-body-status.md
@@ -4,4 +4,4 @@
 "@effect/platform-deno": patch
 ---
 
-Stop `HttpServerResponse.toWeb` from passing a body into the Web `Response` constructor for status 204, 205, and 304. Node/undici rejects those statuses when a body is present; empty and `{ withoutBody: true }` already worked.
+Omit response bodies for statuses 204, 205, and 304 in `HttpServerResponse.toWeb` and the Bun/Deno HTTP adapters, preventing invalid Web responses and hung requests. Cancel omitted raw `ReadableStream` bodies, and finalize request resources without starting omitted Effect streams.

--- a/.changeset/fix-http-toweb-null-body-status.md
+++ b/.changeset/fix-http-toweb-null-body-status.md
@@ -1,5 +1,7 @@
 ---
 "effect": patch
+"@effect/platform-bun": patch
+"@effect/platform-deno": patch
 ---
 
 Stop `HttpServerResponse.toWeb` from passing a body into the Web `Response` constructor for status 204, 205, and 304. Node/undici rejects those statuses when a body is present; empty and `{ withoutBody: true }` already worked.

--- a/.changeset/fix-http-toweb-null-body-status.md
+++ b/.changeset/fix-http-toweb-null-body-status.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Stop `HttpServerResponse.toWeb` from passing a body into the Web `Response` constructor for status 204, 205, and 304. Node/undici rejects those statuses when a body is present; empty and `{ withoutBody: true }` already worked.

--- a/packages/effect/src/unstable/http/HttpEffect.ts
+++ b/packages/effect/src/unstable/http/HttpEffect.ts
@@ -295,7 +295,14 @@ export const toWebHandlerWith = <Provided, R = never, ReqR = Exclude<R, Provided
 {
   const resolveSymbol = Symbol.for("@effect/platform/HttpApp/resolve")
   const httpApp = toHandled(self, (request, response) => {
-    if (request.method !== "HEAD") response = scopeTransferToStream(response)
+    if (
+      request.method !== "HEAD" &&
+      response.status !== 204 &&
+      response.status !== 205 &&
+      response.status !== 304
+    ) {
+      response = scopeTransferToStream(response)
+    }
     ;(request as any)[resolveSymbol](
       Response.toWeb(response, { withoutBody: request.method === "HEAD", context })
     )

--- a/packages/effect/src/unstable/http/HttpEffect.ts
+++ b/packages/effect/src/unstable/http/HttpEffect.ts
@@ -295,16 +295,12 @@ export const toWebHandlerWith = <Provided, R = never, ReqR = Exclude<R, Provided
 {
   const resolveSymbol = Symbol.for("@effect/platform/HttpApp/resolve")
   const httpApp = toHandled(self, (request, response) => {
-    if (
-      request.method !== "HEAD" &&
-      response.status !== 204 &&
-      response.status !== 205 &&
-      response.status !== 304
-    ) {
+    const withoutBody = request.method === "HEAD"
+    if (!Response.omitsBody(response, withoutBody)) {
       response = scopeTransferToStream(response)
     }
     ;(request as any)[resolveSymbol](
-      Response.toWeb(response, { withoutBody: request.method === "HEAD", context })
+      Response.toWeb(response, { withoutBody, context })
     )
     return Effect.void
   }, middleware)

--- a/packages/effect/src/unstable/http/HttpServerResponse.ts
+++ b/packages/effect/src/unstable/http/HttpServerResponse.ts
@@ -991,7 +991,11 @@ export const toWeb = (
       headers.append("set-cookie", header)
     }
   }
-  if (options?.withoutBody) {
+  const omitBody = options?.withoutBody === true ||
+    response.status === 204 ||
+    response.status === 205 ||
+    response.status === 304
+  if (omitBody) {
     return new Response(undefined, {
       status: response.status,
       statusText: response.statusText as string,

--- a/packages/effect/src/unstable/http/HttpServerResponse.ts
+++ b/packages/effect/src/unstable/http/HttpServerResponse.ts
@@ -967,7 +967,7 @@ export const setStatus: {
 
 /**
  * Returns whether a response must omit its body because its status is 204, 205,
- * or 304, or `withoutBody` is enabled for a request such as HEAD.
+ * or 304, or `withoutBody` is true.
  *
  * @category predicates
  * @since 4.0.0
@@ -981,8 +981,11 @@ export const omitsBody = (response: HttpServerResponse, withoutBody = false): bo
  * **Details**
  *
  * Cookies are appended as `Set-Cookie` headers. Stream bodies are converted using
- * the supplied context, and `withoutBody` can be used for responses such as HEAD
- * responses.
+ * the supplied context.
+ *
+ * Bodies are omitted for statuses 204, 205, and 304, or when `withoutBody` is true
+ * (for example, for HEAD responses). Omitted raw `ReadableStream` bodies are
+ * cancelled without awaiting completion, and cancellation errors are ignored.
  *
  * @category converting
  * @since 4.0.0

--- a/packages/effect/src/unstable/http/HttpServerResponse.ts
+++ b/packages/effect/src/unstable/http/HttpServerResponse.ts
@@ -14,7 +14,7 @@ import type * as ByteSize from "../../ByteSize.ts"
 import * as Context from "../../Context.ts"
 import * as Effect from "../../Effect.ts"
 import * as ErrorReporter from "../../ErrorReporter.ts"
-import { dual } from "../../Function.ts"
+import { constVoid, dual } from "../../Function.ts"
 import * as Inspectable from "../../Inspectable.ts"
 import { PipeInspectableProto } from "../../internal/core.ts"
 import * as Option from "../../Option.ts"
@@ -966,6 +966,16 @@ export const setStatus: {
 )
 
 /**
+ * Returns whether a response must omit its body because its status is 204, 205,
+ * or 304, or `withoutBody` is enabled for a request such as HEAD.
+ *
+ * @category predicates
+ * @since 4.0.0
+ */
+export const omitsBody = (response: HttpServerResponse, withoutBody = false): boolean =>
+  withoutBody || response.status === 204 || response.status === 205 || response.status === 304
+
+/**
  * Converts an `HttpServerResponse` to a Web `Response`.
  *
  * **Details**
@@ -991,11 +1001,11 @@ export const toWeb = (
       headers.append("set-cookie", header)
     }
   }
-  const omitBody = options?.withoutBody === true ||
-    response.status === 204 ||
-    response.status === 205 ||
-    response.status === 304
-  if (omitBody) {
+  if (omitsBody(response, options?.withoutBody)) {
+    const body = response.body
+    if ((body._tag === "Raw" || body._tag === "Uint8Array") && body.body instanceof ReadableStream) {
+      body.body.cancel().catch(constVoid)
+    }
     return new Response(undefined, {
       status: response.status,
       statusText: response.statusText as string,

--- a/packages/effect/src/unstable/http/HttpServerResponse.ts
+++ b/packages/effect/src/unstable/http/HttpServerResponse.ts
@@ -1001,9 +1001,9 @@ export const toWeb = (
       headers.append("set-cookie", header)
     }
   }
+  const body = response.body
   if (omitsBody(response, options?.withoutBody)) {
-    const body = response.body
-    if ((body._tag === "Raw" || body._tag === "Uint8Array") && body.body instanceof ReadableStream) {
+    if (body._tag === "Raw" && isReadableStream(body.body)) {
       body.body.cancel().catch(constVoid)
     }
     return new Response(undefined, {
@@ -1012,7 +1012,6 @@ export const toWeb = (
       headers
     })
   }
-  const body = response.body
   switch (body._tag) {
     case "Empty": {
       return new Response(undefined, {

--- a/packages/effect/test/unstable/http/HttpEffect.test.ts
+++ b/packages/effect/test/unstable/http/HttpEffect.test.ts
@@ -151,6 +151,32 @@ describe("HttpEffect", () => {
       strictEqual(finalized, true)
     })
 
+    test.each([204, 205, 304])("status %i closes the request scope without starting the stream", async (status) => {
+      let finalized = false
+      let streamStarted = false
+      const handler = HttpEffect.toWebHandler(Effect.gen(function*() {
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            finalized = true
+          })
+        )
+        return HttpServerResponse.stream(
+          Stream.fromEffect(Effect.sync(() => {
+            streamStarted = true
+            return new Uint8Array([1])
+          })),
+          { status }
+        )
+      }))
+
+      const response = await handler(new Request("http://localhost:3000/"))
+
+      strictEqual(response.status, status)
+      strictEqual(response.body, null)
+      strictEqual(streamStarted, false)
+      strictEqual(finalized, true)
+    })
+
     test("stream runtime", async () => {
       const handler = Effect.succeed(HttpServerResponse.stream(
         Stream.fromEffect(TestValue).pipe(Stream.map(String), Stream.encodeText)

--- a/packages/effect/test/unstable/http/HttpServerResponse.test.ts
+++ b/packages/effect/test/unstable/http/HttpServerResponse.test.ts
@@ -6,6 +6,44 @@ const TestValue = Context.Reference<number>("test/TestValue", { defaultValue: ()
 
 describe("HttpServerResponse", () => {
   describe("toWeb", () => {
+    it.each([
+      { status: 200, withoutBody: true },
+      { status: 304, withoutBody: false }
+    ])(
+      "preserves representation headers for status $status with withoutBody=$withoutBody",
+      ({ status, withoutBody }) => {
+        const web = HttpServerResponse.toWeb(HttpServerResponse.text("body", { status }), { withoutBody })
+
+        assert.strictEqual(web.body, null)
+        assert.strictEqual(web.headers.get("content-length"), "4")
+        assert.strictEqual(web.headers.get("content-type"), "text/plain")
+      }
+    )
+
+    it.each([
+      { status: 200, withoutBody: true },
+      { status: 204, withoutBody: false },
+      { status: 205, withoutBody: false },
+      { status: 304, withoutBody: false }
+    ])("cancels raw streams for status $status with withoutBody=$withoutBody", async ({ status, withoutBody }) => {
+      let cancelled = false
+      const body = new ReadableStream({
+        cancel() {
+          cancelled = true
+        }
+      })
+      try {
+        const web = HttpServerResponse.toWeb(HttpServerResponse.raw(body, { status }), { withoutBody })
+
+        assert.strictEqual(web.status, status)
+        assert.strictEqual(web.body, null)
+        assert.strictEqual(await web.text(), "")
+        assert.strictEqual(cancelled, true)
+      } finally {
+        await body.cancel()
+      }
+    })
+
     for (const status of [204, 205, 304]) {
       it.each([
         { name: "text", response: HttpServerResponse.text("body", { status }) },

--- a/packages/effect/test/unstable/http/HttpServerResponse.test.ts
+++ b/packages/effect/test/unstable/http/HttpServerResponse.test.ts
@@ -5,13 +5,20 @@ import { HttpBody, HttpClientRequest, HttpClientResponse, HttpServerResponse } f
 const TestValue = Context.Reference<number>("test/TestValue", { defaultValue: () => 0 })
 
 describe("HttpServerResponse", () => {
-  it("toWeb drops the body for 204, 205, and 304 so Node can construct the Response", () => {
-    for (const status of [204, 205, 304] as const) {
-      const web = HttpServerResponse.toWeb(
-        HttpServerResponse.text("still a body", { status })
-      )
-      assert.strictEqual(web.status, status)
-      assert.strictEqual(web.body, null)
+  describe("toWeb", () => {
+    for (const status of [204, 205, 304]) {
+      it.each([
+        { name: "text", response: HttpServerResponse.text("body", { status }) },
+        { name: "uint8Array", response: HttpServerResponse.uint8Array(new Uint8Array([1]), { status }) },
+        { name: "raw", response: HttpServerResponse.raw("body", { status }) },
+        { name: "formData", response: HttpServerResponse.formData(new FormData(), { status }) },
+        { name: "stream", response: HttpServerResponse.stream(Stream.succeed(new Uint8Array([1])), { status }) }
+      ])(`omits $name bodies for status ${status}`, ({ response }) => {
+        const web = HttpServerResponse.toWeb(response)
+
+        assert.strictEqual(web.status, status)
+        assert.strictEqual(web.body, null)
+      })
     }
   })
 

--- a/packages/effect/test/unstable/http/HttpServerResponse.test.ts
+++ b/packages/effect/test/unstable/http/HttpServerResponse.test.ts
@@ -5,6 +5,16 @@ import { HttpBody, HttpClientRequest, HttpClientResponse, HttpServerResponse } f
 const TestValue = Context.Reference<number>("test/TestValue", { defaultValue: () => 0 })
 
 describe("HttpServerResponse", () => {
+  it("toWeb drops the body for 204, 205, and 304 so Node can construct the Response", () => {
+    for (const status of [204, 205, 304] as const) {
+      const web = HttpServerResponse.toWeb(
+        HttpServerResponse.text("still a body", { status })
+      )
+      assert.strictEqual(web.status, status)
+      assert.strictEqual(web.body, null)
+    }
+  })
+
   it("setHeader overrides body-derived content headers", () => {
     const response = HttpServerResponse.text("body").pipe(
       HttpServerResponse.setHeader("content-type", "text/custom"),

--- a/packages/platform/bun/src/BunHttpServer.ts
+++ b/packages/platform/bun/src/BunHttpServer.ts
@@ -46,7 +46,7 @@ import type { HttpPlatform } from "effect/unstable/http/HttpPlatform"
 import * as Server from "effect/unstable/http/HttpServer"
 import * as Error from "effect/unstable/http/HttpServerError"
 import * as ServerRequest from "effect/unstable/http/HttpServerRequest"
-import type * as ServerResponse from "effect/unstable/http/HttpServerResponse"
+import * as ServerResponse from "effect/unstable/http/HttpServerResponse"
 import type * as Multipart from "effect/unstable/http/Multipart"
 import * as UrlParams from "effect/unstable/http/UrlParams"
 import * as NetAddress from "effect/unstable/net/NetAddress"
@@ -232,6 +232,9 @@ const makeResponse = (
   context: Context.Context<never>,
   scope: Scope.Scope
 ): Response => {
+  if (ServerResponse.omitsBody(response, request.method === "HEAD")) {
+    return ServerResponse.toWeb(response, { withoutBody: true })
+  }
   const fields: {
     headers: globalThis.Headers
     status?: number
@@ -251,9 +254,6 @@ const makeResponse = (
     fields.statusText = response.statusText
   }
 
-  if (request.method === "HEAD") {
-    return new Response(undefined, fields)
-  }
   response = HttpEffect.scopeTransferToStream(response)
   const body = response.body
   switch (body._tag) {

--- a/packages/platform/bun/test/BunHttpServer.test.ts
+++ b/packages/platform/bun/test/BunHttpServer.test.ts
@@ -145,7 +145,6 @@ describe("BunHttpServer", () => {
             assert.strictEqual(streamStarted, false)
             assert.strictEqual(finalized, true)
             if (status === 304) {
-              assert.strictEqual(response.headers["content-length"], "4")
               assert.strictEqual(response.headers["content-type"], "text/plain")
             }
           }).pipe(
@@ -177,11 +176,13 @@ describe("BunHttpServer", () => {
           const response = yield* (method === "HEAD" ? HttpClient.head("/") : HttpClient.get("/"))
           assert.strictEqual(response.status, status)
           assert.strictEqual(yield* response.text, "")
-          if (method === "HEAD" || status === 304) {
+          assert.strictEqual(cancelled, true)
+          if (method === "HEAD") {
             assert.strictEqual(response.headers["content-length"], "4")
+          }
+          if (method === "HEAD" || status === 304) {
             assert.strictEqual(response.headers["content-type"], "text/plain")
           }
-          assert.strictEqual(cancelled, true)
         }).pipe(
           Effect.timeout("2 seconds"),
           Effect.provide(BunHttpServer.layerTest)

--- a/packages/platform/bun/test/BunHttpServer.test.ts
+++ b/packages/platform/bun/test/BunHttpServer.test.ts
@@ -5,7 +5,9 @@ import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
 import * as Scope from "effect/Scope"
+import * as Stream from "effect/Stream"
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient"
+import * as HttpClient from "effect/unstable/http/HttpClient"
 import * as HttpServer from "effect/unstable/http/HttpServer"
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest"
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse"
@@ -113,6 +115,80 @@ const makeWebSocketServer = Effect.fnUntraced(function*(payload: string, compres
 })
 
 describe("BunHttpServer", () => {
+  describe("body omission", () => {
+    for (const status of [204, 205, 304]) {
+      for (const bodyKind of ["text", "stream"]) {
+        it.live(`omits ${bodyKind} bodies for status ${status}`, () =>
+          Effect.gen(function*() {
+            let finalized = false
+            let streamStarted = false
+            yield* HttpServer.serveEffect(Effect.gen(function*() {
+              yield* Effect.addFinalizer(() =>
+                Effect.sync(() => {
+                  finalized = true
+                })
+              )
+              const options = { status, contentType: "text/plain", contentLength: 4 }
+              return bodyKind === "text"
+                ? HttpServerResponse.text("body", options)
+                : HttpServerResponse.stream(
+                  Stream.fromEffect(Effect.sync(() => {
+                    streamStarted = true
+                    return new TextEncoder().encode("body")
+                  })),
+                  options
+                )
+            }))
+            const response = yield* HttpClient.get("/")
+            assert.strictEqual(response.status, status)
+            assert.strictEqual(yield* response.text, "")
+            assert.strictEqual(streamStarted, false)
+            assert.strictEqual(finalized, true)
+            if (status === 304) {
+              assert.strictEqual(response.headers["content-length"], "4")
+              assert.strictEqual(response.headers["content-type"], "text/plain")
+            }
+          }).pipe(
+            Effect.timeout("2 seconds"),
+            Effect.provide(BunHttpServer.layerTest)
+          ), 5000)
+      }
+    }
+
+    for (const [method, status] of [["HEAD", 200], ["GET", 204], ["GET", 205], ["GET", 304]] as const) {
+      it.live(`cancels raw streams for ${method} status ${status}`, () =>
+        Effect.gen(function*() {
+          let cancelled = false
+          const body = new ReadableStream<Uint8Array>({
+            pull(controller) {
+              controller.enqueue(new TextEncoder().encode("body"))
+              controller.close()
+            },
+            cancel() {
+              cancelled = true
+            }
+          }, { highWaterMark: 0 })
+          yield* Effect.addFinalizer(() => Effect.ignoreCause(Effect.promise(() => body.cancel())))
+          yield* HttpServer.serveEffect(Effect.succeed(HttpServerResponse.raw(body, {
+            status,
+            contentType: "text/plain",
+            contentLength: 4
+          })))
+          const response = yield* (method === "HEAD" ? HttpClient.head("/") : HttpClient.get("/"))
+          assert.strictEqual(response.status, status)
+          assert.strictEqual(yield* response.text, "")
+          if (method === "HEAD" || status === 304) {
+            assert.strictEqual(response.headers["content-length"], "4")
+            assert.strictEqual(response.headers["content-type"], "text/plain")
+          }
+          assert.strictEqual(cancelled, true)
+        }).pipe(
+          Effect.timeout("2 seconds"),
+          Effect.provide(BunHttpServer.layerTest)
+        ), 5000)
+    }
+  })
+
   for (
     const [name, options, expectedTag, expectedIp] of [
       ["omitted hostname", { port: 0 }, "InetAddressV6", "::"],

--- a/packages/platform/deno/src/DenoHttpServer.ts
+++ b/packages/platform/deno/src/DenoHttpServer.ts
@@ -32,7 +32,7 @@ import type { HttpPlatform } from "effect/unstable/http/HttpPlatform"
 import * as Server from "effect/unstable/http/HttpServer"
 import * as Error from "effect/unstable/http/HttpServerError"
 import * as ServerRequest from "effect/unstable/http/HttpServerRequest"
-import type * as ServerResponse from "effect/unstable/http/HttpServerResponse"
+import * as ServerResponse from "effect/unstable/http/HttpServerResponse"
 import type * as Multipart from "effect/unstable/http/Multipart"
 import * as UrlParams from "effect/unstable/http/UrlParams"
 import * as NetAddress from "effect/unstable/net/NetAddress"
@@ -171,7 +171,7 @@ const makeResponse = Effect.fnUntraced(function*(
   }
   if (response.statusText !== undefined) fields.statusText = response.statusText
 
-  if (request.method === "HEAD") {
+  if (ServerResponse.omitsBody(response, request.method === "HEAD")) {
     yield* cancelResponseBody(response.body)
     return new Response(undefined, fields)
   }

--- a/packages/platform/deno/src/DenoHttpServer.ts
+++ b/packages/platform/deno/src/DenoHttpServer.ts
@@ -552,8 +552,8 @@ const bufferedWebSocket = (ws: WebSocket): Socket.WebSocketLike => {
 }
 
 const cancelResponseBody = (body: HttpBody.HttpBody): Effect.Effect<void> => {
-  const stream = (body as any).body
-  if ((body._tag === "Raw" || body._tag === "Uint8Array") && stream instanceof ReadableStream) {
+  if (body._tag === "Raw" && typeof ReadableStream !== "undefined" && body.body instanceof ReadableStream) {
+    const stream = body.body
     return Effect.ignoreCause(Effect.promise(() => stream.cancel()))
   }
   return Effect.void

--- a/packages/platform/deno/test/DenoHttpServer.test.ts
+++ b/packages/platform/deno/test/DenoHttpServer.test.ts
@@ -72,7 +72,6 @@ describe("DenoHttpServer", () => {
             assert.strictEqual(streamStarted, false)
             assert.strictEqual(finalized, true)
             if (status === 304) {
-              assert.strictEqual(response.headers["content-length"], "4")
               assert.strictEqual(response.headers["content-type"], "text/plain")
             }
           }).pipe(
@@ -104,11 +103,13 @@ describe("DenoHttpServer", () => {
           const response = yield* (method === "HEAD" ? HttpClient.head("/") : HttpClient.get("/"))
           assert.strictEqual(response.status, status)
           assert.strictEqual(yield* response.text, "")
-          if (method === "HEAD" || status === 304) {
+          assert.strictEqual(cancelled, true)
+          if (method === "HEAD") {
             assert.strictEqual(response.headers["content-length"], "4")
+          }
+          if (method === "HEAD" || status === 304) {
             assert.strictEqual(response.headers["content-type"], "text/plain")
           }
-          assert.strictEqual(cancelled, true)
         }).pipe(
           Effect.timeout("2 seconds"),
           Effect.provide(DenoHttpServer.layerTest)

--- a/packages/platform/deno/test/DenoHttpServer.test.ts
+++ b/packages/platform/deno/test/DenoHttpServer.test.ts
@@ -42,6 +42,80 @@ const todoResponse = HttpServerResponse.schemaJson(Todo)
 const fixture = `${import.meta.dirname}/fixtures/text.txt`
 
 describe("DenoHttpServer", () => {
+  describe("body omission", () => {
+    for (const status of [204, 205, 304]) {
+      for (const bodyKind of ["text", "stream"]) {
+        it.live(`omits ${bodyKind} bodies for status ${status}`, () =>
+          Effect.gen(function*() {
+            let finalized = false
+            let streamStarted = false
+            yield* HttpServer.serveEffect(Effect.gen(function*() {
+              yield* Effect.addFinalizer(() =>
+                Effect.sync(() => {
+                  finalized = true
+                })
+              )
+              const options = { status, contentType: "text/plain", contentLength: 4 }
+              return bodyKind === "text"
+                ? HttpServerResponse.text("body", options)
+                : HttpServerResponse.stream(
+                  Stream.fromEffect(Effect.sync(() => {
+                    streamStarted = true
+                    return new TextEncoder().encode("body")
+                  })),
+                  options
+                )
+            }))
+            const response = yield* HttpClient.get("/")
+            assert.strictEqual(response.status, status)
+            assert.strictEqual(yield* response.text, "")
+            assert.strictEqual(streamStarted, false)
+            assert.strictEqual(finalized, true)
+            if (status === 304) {
+              assert.strictEqual(response.headers["content-length"], "4")
+              assert.strictEqual(response.headers["content-type"], "text/plain")
+            }
+          }).pipe(
+            Effect.timeout("2 seconds"),
+            Effect.provide(DenoHttpServer.layerTest)
+          ), 5000)
+      }
+    }
+
+    for (const [method, status] of [["HEAD", 200], ["GET", 204], ["GET", 205], ["GET", 304]] as const) {
+      it.live(`cancels raw streams for ${method} status ${status}`, () =>
+        Effect.gen(function*() {
+          let cancelled = false
+          const body = new ReadableStream<Uint8Array>({
+            pull(controller) {
+              controller.enqueue(new TextEncoder().encode("body"))
+              controller.close()
+            },
+            cancel() {
+              cancelled = true
+            }
+          }, { highWaterMark: 0 })
+          yield* Effect.addFinalizer(() => Effect.ignoreCause(Effect.promise(() => body.cancel())))
+          yield* HttpServer.serveEffect(Effect.succeed(HttpServerResponse.raw(body, {
+            status,
+            contentType: "text/plain",
+            contentLength: 4
+          })))
+          const response = yield* (method === "HEAD" ? HttpClient.head("/") : HttpClient.get("/"))
+          assert.strictEqual(response.status, status)
+          assert.strictEqual(yield* response.text, "")
+          if (method === "HEAD" || status === 304) {
+            assert.strictEqual(response.headers["content-length"], "4")
+            assert.strictEqual(response.headers["content-type"], "text/plain")
+          }
+          assert.strictEqual(cancelled, true)
+        }).pipe(
+          Effect.timeout("2 seconds"),
+          Effect.provide(DenoHttpServer.layerTest)
+        ), 5000)
+    }
+  })
+
   it.effect("schema", () =>
     Effect.gen(function*() {
       yield* HttpRouter.add(


### PR DESCRIPTION
Closes #8189
Closes EFF-1356

HTTP responses with status 204, 205, or 304 now omit their bodies in `HttpServerResponse.toWeb` and the native Bun/Deno adapters. This prevents rejected Web Response construction and hung Deno requests.

The shared `HttpServerResponse.omitsBody` predicate also governs request-scope ownership in `HttpEffect`. Omitted Effect streams never start, request finalizers run, and omitted raw `ReadableStream` bodies are cancelled. The adapters preserve response headers when constructing the Web response, including HEAD and 304 representation metadata.

Includes patch changeset entries for `effect`, `@effect/platform-bun`, and `@effect/platform-deno`.

Validation, all through `nix develop -c`:

- `pnpm test --run packages/effect/test/unstable/http/HttpServerResponse.test.ts packages/effect/test/unstable/http/HttpEffect.test.ts`: 55 passed.
- `bun run --bun vitest run packages/platform/bun/test/BunHttpServer.test.ts`: 23 passed.
- `deno task test --run packages/platform/deno/test/DenoHttpServer.test.ts`: 39 passed.
- `pnpm lint-fix`, `pnpm check`, and `deno check packages/platform/deno/src/DenoHttpServer.ts packages/platform/deno/test/DenoHttpServer.test.ts`: passed.
- Temporary probes confirmed that omitted text/JSON bodies retain lazy encoding in `toWeb` and the Deno adapter for HEAD/204/205/304, and that `toWeb` succeeds when the `ReadableStream` global is absent. Both issues were reproduced before the guard fix.

Coverage verifies body omission, request finalization, raw-stream cancellation, HEAD headers, and direct-conversion 304 headers. Native-adapter tests avoid asserting a 304 Content-Length value because Bun and Deno rewrite it during HTTP serialization.
