### PR TITLE
Optimize Schema initialization

### DIFF
--- a/.changeset/faster-schema-construction.md
+++ b/.changeset/faster-schema-construction.md
@@ -1,0 +1,8 @@
+---
+"effect": patch
+---
+
+Optimize schema initialization by assigning constructor options directly.
+`Schema.make` options must no longer use properties reserved by JavaScript
+functions, such as `name`, `length`, `prototype`, or `__proto__`. Store custom
+metadata under a different property name or in schema annotations.

--- a/.changeset/faster-schema-construction.md
+++ b/.changeset/faster-schema-construction.md
@@ -2,7 +2,4 @@
 "effect": patch
 ---
 
-Optimize schema initialization by assigning constructor options directly.
-`Schema.make` options must no longer use properties reserved by JavaScript
-functions, such as `name`, `length`, `prototype`, or `__proto__`. Store custom
-metadata under a different property name or in schema annotations.
+Optimize schema initialization while preserving custom constructor options.

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -116,6 +116,6 @@
     "immer": "^11.1.18",
     "protobufjs": "^8.8.0",
     "tinybench": "^6.1.6",
-    "valibot": "^1.4.2"
+    "valibot": "^1.5.0"
   }
 }

--- a/packages/effect/runtimeperf/config.json
+++ b/packages/effect/runtimeperf/config.json
@@ -1172,6 +1172,13 @@
           },
           "cases": [
             {
+              "name": "adapter-make-valid",
+              "export": "makeValid",
+              "scenario": "adapter-make-valid",
+              "operation": "make",
+              "adapter": "Sync"
+            },
+            {
               "name": "adapter-parser-decode-exit-invalid",
               "export": "parserExitInvalid",
               "scenario": "adapter-parser-decode-exit-invalid",
@@ -1246,6 +1253,22 @@
             "size": 32
           },
           "cases": [
+            {
+              "name": "schema-creation-object-2-effect",
+              "export": "effectSchemaCreationObject2",
+              "scenario": "schema-creation-object-2",
+              "implementation": "effect",
+              "operation": "schema",
+              "size": 2
+            },
+            {
+              "name": "first-make-object-2-effect",
+              "export": "effectFirstMakeObject2",
+              "scenario": "first-make-object-2",
+              "implementation": "effect",
+              "operation": "first-make",
+              "size": 2
+            },
             {
               "name": "schema-creation-template-literal-effect",
               "export": "effectSchemaCreationTemplateLiteral",

--- a/packages/effect/runtimeperf/config.json
+++ b/packages/effect/runtimeperf/config.json
@@ -1262,6 +1262,28 @@
               "size": 2
             },
             {
+              "name": "schema-creation-object-32-effect",
+              "export": "effectSchemaCreationObject32",
+              "scenario": "schema-creation-object-32",
+              "implementation": "effect",
+              "operation": "schema"
+            },
+            {
+              "name": "schema-creation-object-256-effect",
+              "export": "effectSchemaCreationObject256",
+              "scenario": "schema-creation-object-256",
+              "implementation": "effect",
+              "operation": "schema",
+              "size": 256
+            },
+            {
+              "name": "schema-creation-encoded-record-effect",
+              "export": "effectSchemaCreationEncodedRecord",
+              "scenario": "schema-creation-encoded-record",
+              "implementation": "effect",
+              "operation": "schema"
+            },
+            {
               "name": "first-make-object-2-effect",
               "export": "effectFirstMakeObject2",
               "scenario": "first-make-object-2",
@@ -1279,6 +1301,17 @@
                 "TemplateLiteral"
               ],
               "size": 5
+            },
+            {
+              "name": "schema-creation-template-literal-256-effect",
+              "export": "effectSchemaCreationTemplateLiteral256",
+              "scenario": "schema-creation-template-literal-256",
+              "implementation": "effect",
+              "operation": "schema",
+              "astTags": [
+                "TemplateLiteral"
+              ],
+              "size": 256
             },
             {
               "name": "first-decode-checked-object-32-effect",

--- a/packages/effect/runtimeperf/suites/schema/fixtures/adapters.ts
+++ b/packages/effect/runtimeperf/suites/schema/fixtures/adapters.ts
@@ -11,6 +11,11 @@ const schema = Schema.Struct({
 const input = { a: "a", b: 1 }
 const invalidInput = { a: "a", b: "invalid" }
 
+export const makeValid = () => ({
+  run: () => schema.make(input),
+  validate: (result) => assert.deepEqual(result, input)
+})
+
 export const parserExitInvalid = () => {
   const run = SchemaParser.decodeUnknownExit(schema)
   return {

--- a/packages/effect/runtimeperf/suites/schema/fixtures/cold.ts
+++ b/packages/effect/runtimeperf/suites/schema/fixtures/cold.ts
@@ -16,6 +16,14 @@ const makeEffectTemplateLiteralSchema = () =>
 
 const makeEffectRecordSchema = () => Schema.Record(Schema.String, Schema.String)
 
+const makeEffectObject2Schema = () =>
+  Schema.Struct({
+    name: Schema.String,
+    age: Schema.Number
+  })
+
+const object2Input = { name: "John", age: 42 }
+
 const literalValues100 = Array.from({ length: 100 }, (_, index) => `value${index}`)
 
 const makeEffectLiteral100Schema = () => Schema.Literals(literalValues100)
@@ -51,6 +59,16 @@ const makeEffectEncodingChain = (size) => {
 export const effectSchemaCreationTemplateLiteral = () => ({
   run: makeEffectTemplateLiteralSchema,
   validate: (schema) => assert.equal(schema.ast._tag, "TemplateLiteral")
+})
+
+export const effectSchemaCreationObject2 = () => ({
+  run: makeEffectObject2Schema,
+  validate: (schema) => assert.equal(schema.ast._tag, "Objects")
+})
+
+export const effectFirstMakeObject2 = () => ({
+  run: () => makeEffectObject2Schema().make(object2Input),
+  validate: (result) => assert.deepEqual(result, object2Input)
 })
 
 export const effectFirstDecodeCheckedObject32 = () => ({

--- a/packages/effect/runtimeperf/suites/schema/fixtures/cold.ts
+++ b/packages/effect/runtimeperf/suites/schema/fixtures/cold.ts
@@ -14,13 +14,30 @@ const makeEffectCheckedSchema = () =>
 const makeEffectTemplateLiteralSchema = () =>
   Schema.TemplateLiteral(["prefix-", Schema.String, "-middle-", Schema.Number, "-suffix"])
 
+const templateLiteral256Parts = Array.from({ length: 256 }, (_, index) => Schema.Literal(`part${index}`))
+const makeEffectTemplateLiteral256Schema = () => Schema.TemplateLiteral(templateLiteral256Parts)
+
 const makeEffectRecordSchema = () => Schema.Record(Schema.String, Schema.String)
+const makeEffectEncodedRecordSchema = () =>
+  Schema.Record(
+    Schema.String.pipe(Schema.decodeTo(Schema.Number, SchemaTransformation.passthrough())),
+    Schema.String
+  )
 
 const makeEffectObject2Schema = () =>
   Schema.Struct({
     name: Schema.String,
     age: Schema.Number
   })
+
+const makeObjectFields = (size: number) =>
+  Object.fromEntries(Array.from({ length: size }, (_, index) => [`field${index}`, Schema.NonEmptyString]))
+
+const object32Fields = makeObjectFields(32)
+const object256Fields = makeObjectFields(256)
+
+const makeEffectObject32Schema = () => Schema.Struct(object32Fields)
+const makeEffectObject256Schema = () => Schema.Struct(object256Fields)
 
 const object2Input = { name: "John", age: 42 }
 
@@ -61,8 +78,28 @@ export const effectSchemaCreationTemplateLiteral = () => ({
   validate: (schema) => assert.equal(schema.ast._tag, "TemplateLiteral")
 })
 
+export const effectSchemaCreationTemplateLiteral256 = () => ({
+  run: makeEffectTemplateLiteral256Schema,
+  validate: (schema) => assert.equal(schema.ast._tag, "TemplateLiteral")
+})
+
 export const effectSchemaCreationObject2 = () => ({
   run: makeEffectObject2Schema,
+  validate: (schema) => assert.equal(schema.ast._tag, "Objects")
+})
+
+export const effectSchemaCreationObject32 = () => ({
+  run: makeEffectObject32Schema,
+  validate: (schema) => assert.equal(schema.ast._tag, "Objects")
+})
+
+export const effectSchemaCreationObject256 = () => ({
+  run: makeEffectObject256Schema,
+  validate: (schema) => assert.equal(schema.ast._tag, "Objects")
+})
+
+export const effectSchemaCreationEncodedRecord = () => ({
+  run: makeEffectEncodedRecordSchema,
   validate: (schema) => assert.equal(schema.ast._tag, "Objects")
 })
 

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -2248,12 +2248,6 @@ export const encodeSync: <S extends ConstraintEncoder<unknown>>(
  * the bridge between the untyped AST representation and the strongly-typed
  * schema.
  *
- * **Gotchas**
- *
- * `options` are assigned to the schema constructor. They must not define
- * properties reserved by JavaScript functions, such as `name`, `length`,
- * `prototype`, or `__proto__`.
- *
  * @category constructors
  * @since 3.10.0
  */

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -2248,6 +2248,12 @@ export const encodeSync: <S extends ConstraintEncoder<unknown>>(
  * the bridge between the untyped AST representation and the strongly-typed
  * schema.
  *
+ * **Gotchas**
+ *
+ * `options` are assigned to the schema constructor. They must not define
+ * properties reserved by JavaScript functions, such as `name`, `length`,
+ * `prototype`, or `__proto__`.
+ *
  * @category constructors
  * @since 3.10.0
  */

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -1381,14 +1381,12 @@ function formatTemplateLiteralPath(path: string | number): string {
   return typeof path === "number" ? `parts[${path}]` : path
 }
 
-type TemplateLiteralValidationCache = Array<AST> & { set?: Set<AST> }
-
 function isTemplateLiteralPart(
   ast: AST,
   path: string | number,
-  validated: TemplateLiteralValidationCache
+  validated: Set<AST>
 ): ast is TemplateLiteralPart {
-  if (validated.set?.has(ast) ?? validated.includes(ast)) return true
+  if (validated.has(ast)) return true
   if (ast.encoding) {
     throw new Error(`TemplateLiteral parts cannot have an encoding at ${formatTemplateLiteralPath(path)}`)
   }
@@ -1417,16 +1415,7 @@ function isTemplateLiteralPart(
     default:
       return false
   }
-  if (valid) {
-    if (validated.set) {
-      validated.set.add(ast)
-    } else {
-      validated.push(ast)
-      if (validated.length === 32) {
-        validated.set = new Set(validated)
-      }
-    }
-  }
+  if (valid) validated.add(ast)
   return valid
 }
 
@@ -1500,7 +1489,7 @@ export const TemplateLiteral: new(
     super(annotations, checks, encoding, context)
     const encodedParts: Array<TemplateLiteralPart> = []
     const literals: Array<string | undefined> = []
-    const validated: TemplateLiteralValidationCache = []
+    const validated = new Set<AST>()
     for (let index = 0; index < parts.length; index++) {
       const part = parts[index]
       if (!isTemplateLiteralPart(part, index, validated)) {

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -3780,20 +3780,6 @@ function formatIsOptional(isOptional: boolean | undefined): string {
   return isOptional ? "?" : ""
 }
 
-/** @internal */
-export function memoizeThunk<A>(f: () => A): () => A {
-  let done = false
-  let a: A
-  return () => {
-    if (done) {
-      return a
-    }
-    a = f()
-    done = true
-    return a
-  }
-}
-
 /**
  * AST node for lazy/recursive schemas.
  *
@@ -3866,7 +3852,8 @@ export const Suspend: new(
       throw new Error("Cannot add checks to Suspend")
     }
     super(annotations, undefined, encoding, context)
-    this.thunk = memoizeThunk(thunk)
+    let ast: AST
+    this.thunk = () => ast ??= thunk()
   }
   /** @internal */
   getParser(compile: SchemaParser.Compiler): SchemaParser.Parser {

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -1377,10 +1377,20 @@ type TemplateLiteralPart =
   | TemplateLiteral
   | Union<TemplateLiteralPart>
 
-function isTemplateLiteralPart(ast: AST, path: string, validated: WeakSet<AST>): ast is TemplateLiteralPart {
-  if (validated.has(ast)) return true
+function formatTemplateLiteralPath(path: string | number): string {
+  return typeof path === "number" ? `parts[${path}]` : path
+}
+
+type TemplateLiteralValidationCache = Array<AST> & { set?: Set<AST> }
+
+function isTemplateLiteralPart(
+  ast: AST,
+  path: string | number,
+  validated: TemplateLiteralValidationCache
+): ast is TemplateLiteralPart {
+  if (validated.set?.has(ast) ?? validated.includes(ast)) return true
   if (ast.encoding) {
-    throw new Error(`TemplateLiteral parts cannot have an encoding at ${path}`)
+    throw new Error(`TemplateLiteral parts cannot have an encoding at ${formatTemplateLiteralPath(path)}`)
   }
   let valid: boolean
   switch (ast._tag) {
@@ -1392,18 +1402,31 @@ function isTemplateLiteralPart(ast: AST, path: string, validated: WeakSet<AST>):
     case "Literal":
       valid = !ast.checks
       break
-    case "TemplateLiteral":
+    case "TemplateLiteral": {
+      const currentPath = formatTemplateLiteralPath(path)
       valid = !ast.checks &&
-        ast.parts.every((part, index) => isTemplateLiteralPart(part, `${path}.parts[${index}]`, validated))
+        ast.parts.every((part, index) => isTemplateLiteralPart(part, `${currentPath}.parts[${index}]`, validated))
       break
-    case "Union":
+    }
+    case "Union": {
+      const currentPath = formatTemplateLiteralPath(path)
       valid = !ast.checks &&
-        ast.types.every((part, index) => isTemplateLiteralPart(part, `${path}.types[${index}]`, validated))
+        ast.types.every((part, index) => isTemplateLiteralPart(part, `${currentPath}.types[${index}]`, validated))
       break
+    }
     default:
       return false
   }
-  if (valid) validated.add(ast)
+  if (valid) {
+    if (validated.set) {
+      validated.set.add(ast)
+    } else {
+      validated.push(ast)
+      if (validated.length === 32) {
+        validated.set = new Set(validated)
+      }
+    }
+  }
   return valid
 }
 
@@ -1477,10 +1500,10 @@ export const TemplateLiteral: new(
     super(annotations, checks, encoding, context)
     const encodedParts: Array<TemplateLiteralPart> = []
     const literals: Array<string | undefined> = []
-    const validated = new WeakSet<AST>()
+    const validated: TemplateLiteralValidationCache = []
     for (let index = 0; index < parts.length; index++) {
       const part = parts[index]
-      if (!isTemplateLiteralPart(part, `parts[${index}]`, validated)) {
+      if (!isTemplateLiteralPart(part, index, validated)) {
         throw new Error(`Invalid TemplateLiteral part ${part._tag}`)
       }
       encodedParts.push(part)
@@ -2573,8 +2596,23 @@ function isIndexSignatureParameterSide(ast: AST): ast is IndexSignatureParameter
   }
 }
 
+function isIndexSignatureParameterEncodedSide(ast: AST): boolean {
+  const encoded = getLastEncoding(ast)
+  switch (encoded._tag) {
+    case "String":
+    case "Number":
+    case "Symbol":
+    case "TemplateLiteral":
+      return true
+    case "Union":
+      return encoded.types.every(isIndexSignatureParameterEncodedSide)
+    default:
+      return false
+  }
+}
+
 function isIndexSignatureParameter(ast: AST): ast is IndexSignatureParameter {
-  return isIndexSignatureParameterSide(ast) && isIndexSignatureParameterSide(toEncoded(ast))
+  return isIndexSignatureParameterSide(ast) && isIndexSignatureParameterEncodedSide(ast)
 }
 
 /**
@@ -2727,7 +2765,21 @@ export const Objects: new(
     this.encodingChecks = encodingChecks
 
     // Duplicate property signatures
-    const duplicates = propertySignatures.map((ps) => ps.name).filter((name, i, arr) => arr.indexOf(name) !== i)
+    let duplicates: Array<PropertyKey>
+    if (propertySignatures.length < 32) {
+      duplicates = propertySignatures.map((ps) => ps.name).filter((name, i, arr) => arr.indexOf(name) !== i)
+    } else {
+      const seen = new Set<PropertyKey>()
+      duplicates = []
+      for (const propertySignature of propertySignatures) {
+        const name = propertySignature.name
+        if (seen.has(name)) {
+          duplicates.push(name)
+        } else {
+          seen.add(name)
+        }
+      }
+    }
     if (duplicates.length > 0) {
       throw new Error(`Duplicate identifiers: ${JSON.stringify(duplicates)}. ts(2300)`)
     }

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -2754,19 +2754,14 @@ export const Objects: new(
     this.encodingChecks = encodingChecks
 
     // Duplicate property signatures
-    let duplicates: Array<PropertyKey>
-    if (propertySignatures.length < 32) {
-      duplicates = propertySignatures.map((ps) => ps.name).filter((name, i, arr) => arr.indexOf(name) !== i)
-    } else {
-      const seen = new Set<PropertyKey>()
-      duplicates = []
-      for (const propertySignature of propertySignatures) {
-        const name = propertySignature.name
-        if (seen.has(name)) {
-          duplicates.push(name)
-        } else {
-          seen.add(name)
-        }
+    const seen = new Set<PropertyKey>()
+    const duplicates: Array<PropertyKey> = []
+    for (const propertySignature of propertySignatures) {
+      const name = propertySignature.name
+      if (seen.has(name)) {
+        duplicates.push(name)
+      } else {
+        seen.add(name)
       }
     }
     if (duplicates.length > 0) {

--- a/packages/effect/src/SchemaParser.ts
+++ b/packages/effect/src/SchemaParser.ts
@@ -41,9 +41,10 @@ import * as SchemaIssue from "./SchemaIssue.ts"
  * @since 4.0.0
  */
 export function makeEffect<S extends Schema.Constraint>(schema: S) {
-  const parser = runWithCompiler<S["Type"], never>(constructorCompiler, SchemaAST.toType(schema.ast))
+  const ast = schema.ast
+  let parser: ReturnType<typeof runWithCompiler<S["Type"], never>>
   return (input: S["~type.make.in"], options?: Schema.MakeOptions): Effect.Effect<S["Type"], SchemaIssue.Issue> => {
-    return parser(
+    return (parser ??= runWithCompiler<S["Type"], never>(constructorCompiler, SchemaAST.toType(ast)))(
       input,
       options?.disableChecks
         ? options?.parseOptions ? { ...options.parseOptions, disableChecks: true } : { disableChecks: true }

--- a/packages/effect/src/internal/schema/make.ts
+++ b/packages/effect/src/internal/schema/make.ts
@@ -25,7 +25,15 @@ const SchemaProto = {
 /** @internal */
 export function make<S extends Schema.Constraint>(ast: S["ast"], options?: object): S {
   function Schema() {}
-  const self = Object.assign(Object.setPrototypeOf(Schema, SchemaProto), options)
+  const self = Object.setPrototypeOf(Schema, SchemaProto)
+  if (
+    options &&
+    (Object.hasOwn(options, "name") || Object.hasOwn(options, "length") || Object.hasOwn(options, "__proto__"))
+  ) {
+    Object.defineProperties(self, Object.getOwnPropertyDescriptors({ ...options }))
+  } else {
+    Object.assign(self, options)
+  }
   self.ast = ast
   self.rebuild = (ast: SchemaAST.AST) => make(ast, options)
   self.makeEffect = SchemaParser.makeEffect(self)

--- a/packages/effect/src/internal/schema/make.ts
+++ b/packages/effect/src/internal/schema/make.ts
@@ -25,10 +25,7 @@ const SchemaProto = {
 /** @internal */
 export function make<S extends Schema.Constraint>(ast: S["ast"], options?: object): S {
   function Schema() {}
-  const self = Object.defineProperties(
-    Object.setPrototypeOf(Schema, SchemaProto),
-    Object.getOwnPropertyDescriptors({ ...options })
-  )
+  const self = Object.assign(Object.setPrototypeOf(Schema, SchemaProto), options)
   self.ast = ast
   self.rebuild = (ast: SchemaAST.AST) => make(ast, options)
   self.makeEffect = SchemaParser.makeEffect(self)

--- a/packages/effect/src/internal/schema/toEquivalence.ts
+++ b/packages/effect/src/internal/schema/toEquivalence.ts
@@ -153,8 +153,8 @@ function recur(ast: SchemaAST.AST, path: ReadonlyArray<PropertyKey>): Equivalenc
       })
     }
     case "Suspend": {
-      const get = SchemaAST.memoizeThunk(() => recur(ast.thunk(), path))
-      return Equivalence.make((a, b) => get()(a, b))
+      let equivalence: Equivalence.Equivalence<any>
+      return Equivalence.make((a, b) => (equivalence ??= recur(ast.thunk(), path))(a, b))
     }
   }
 }

--- a/packages/effect/src/internal/schema/toFormatter.ts
+++ b/packages/effect/src/internal/schema/toFormatter.ts
@@ -222,8 +222,8 @@ export function toFormatter<T>(ast: SchemaAST.AST, options?: {
         }
       }
       case "Suspend": {
-        const get = SchemaAST.memoizeThunk(() => recur(ast.thunk()))
-        return (value) => get()(value)
+        let formatter: Formatter<any>
+        return (value) => (formatter ??= recur(ast.thunk()))(value)
       }
     }
   }

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -3495,30 +3495,17 @@ Expected a value between -2147483648 and 2147483647`
   })
 
   describe("make", () => {
-    it("preserves __proto__ as an own option", () => {
-      const value = { polluted: true }
-      const schema = Schema.make(Schema.String.ast, {
-        ["__proto__"]: value
+    it("assigns options", () => {
+      const schema = Schema.make<Schema.String>(Schema.String.ast, {
+        custom: "value"
       })
 
       assertTrue(Schema.isSchema(schema))
-      assertTrue(Object.hasOwn(schema, "__proto__"))
-      strictEqual((schema as any)["__proto__"], value)
-    })
-
-    it("preserves name and length as options", () => {
-      const schema = Schema.make<Schema.String>(Schema.String.ast, {
-        name: "CustomSchema",
-        length: 2
-      })
-
-      strictEqual((schema as any).name, "CustomSchema")
-      strictEqual((schema as any).length, 2)
+      strictEqual((schema as any).custom, "value")
 
       const rebuilt = schema.annotate({})
 
-      strictEqual((rebuilt as any).name, "CustomSchema")
-      strictEqual((rebuilt as any).length, 2)
+      strictEqual((rebuilt as any).custom, "value")
     })
 
     it("should throw an error when the cause contains both a schema issue and a defect", () => {

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -3495,6 +3495,32 @@ Expected a value between -2147483648 and 2147483647`
   })
 
   describe("make", () => {
+    it("preserves __proto__ as an own option", () => {
+      const value = { polluted: true }
+      const schema = Schema.make(Schema.String.ast, {
+        ["__proto__"]: value
+      })
+
+      assertTrue(Schema.isSchema(schema))
+      assertTrue(Object.hasOwn(schema, "__proto__"))
+      strictEqual((schema as any)["__proto__"], value)
+    })
+
+    it("preserves name and length as options", () => {
+      const schema = Schema.make<Schema.String>(Schema.String.ast, {
+        name: "CustomSchema",
+        length: 2
+      })
+
+      strictEqual((schema as any).name, "CustomSchema")
+      strictEqual((schema as any).length, 2)
+
+      const rebuilt = schema.annotate({})
+
+      strictEqual((rebuilt as any).name, "CustomSchema")
+      strictEqual((rebuilt as any).length, 2)
+    })
+
     it("assigns options", () => {
       const schema = Schema.make<Schema.String>(Schema.String.ast, {
         custom: "value"

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -595,6 +595,20 @@ Missing key
       )
     })
 
+    it("should throw an error if a large struct has duplicate property signatures", () => {
+      throws(
+        () =>
+          new SchemaAST.Objects(
+            Array.from(
+              { length: 32 },
+              (_, index) => new SchemaAST.PropertySignature(`field${index === 31 ? 0 : index}`, Schema.String.ast)
+            ),
+            []
+          ),
+        new Error(`Duplicate identifiers: ["field0"]. ts(2300)`)
+      )
+    })
+
     describe("onExcessProperty", () => {
       it("error", async () => {
         const schema = Schema.Struct({

--- a/packages/effect/test/schema/SchemaAST.test.ts
+++ b/packages/effect/test/schema/SchemaAST.test.ts
@@ -4,6 +4,21 @@ import { describe, it } from "vitest"
 import { deepStrictEqual, doesNotThrow, strictEqual, throws } from "../utils/assert.ts"
 
 describe("SchemaAST", () => {
+  describe("Suspend", () => {
+    it("memoizes the thunk", () => {
+      let calls = 0
+      const ast = new SchemaAST.Suspend(() => {
+        calls++
+        return SchemaAST.string
+      })
+
+      strictEqual(calls, 0)
+      strictEqual(ast.thunk(), SchemaAST.string)
+      strictEqual(ast.thunk(), SchemaAST.string)
+      strictEqual(calls, 1)
+    })
+  })
+
   it("isJson", () => {
     strictEqual(SchemaAST.isJson(null), true)
     strictEqual(SchemaAST.isJson(undefined), false)

--- a/packages/effect/test/schema/SchemaAST.test.ts
+++ b/packages/effect/test/schema/SchemaAST.test.ts
@@ -719,6 +719,25 @@ describe("SchemaAST", () => {
         () => new SchemaAST.IndexSignature(StringFromBoolean.ast, Schema.Number.ast),
         new Error("Invalid index signature parameter String")
       )
+      throws(
+        () =>
+          new SchemaAST.IndexSignature(
+            Schema.Union([Schema.String, StringFromBoolean]).ast,
+            Schema.Number.ast
+          ),
+        new Error("Invalid index signature parameter Union")
+      )
+
+      const UnionFromBoolean = Schema.Boolean.pipe(
+        Schema.decodeTo(Schema.Union([Schema.String, Schema.Number]), {
+          decode: SchemaGetter.transform((b: boolean): string | number => b ? "true" : 0),
+          encode: SchemaGetter.transform((_value: string | number) => true)
+        })
+      )
+      throws(
+        () => new SchemaAST.IndexSignature(UnionFromBoolean.ast, Schema.Number.ast),
+        new Error("Invalid index signature parameter Union")
+      )
     })
   })
 })

--- a/packages/effect/test/schema/SchemaParser.test.ts
+++ b/packages/effect/test/schema/SchemaParser.test.ts
@@ -9,6 +9,7 @@ import {
   Ref,
   Result,
   Schema,
+  type SchemaAST,
   SchemaGetter,
   SchemaIssue,
   SchemaParser,
@@ -334,6 +335,32 @@ describe("SchemaParser", () => {
         yield* Deferred.await(secondStarted)
         yield* Deferred.succeed(release, undefined)
         deepStrictEqual(yield* Fiber.join(fiber), { a: "a", b: "b" })
+      }))
+  })
+
+  describe("makeEffect", () => {
+    it.effect("defers deriving the type AST until the maker is called and derives it once", () =>
+      Effect.gen(function*() {
+        let encodingReads = 0
+        const ast = new Proxy(Schema.String.ast, {
+          get(target, property, receiver) {
+            if (property === "encoding") {
+              encodingReads++
+            }
+            return Reflect.get(target, property, receiver)
+          }
+        })
+        const schema: { ast: SchemaAST.AST } = { ast }
+        const make = SchemaParser.makeEffect(schema as Schema.Codec<string>)
+        schema.ast = Schema.Number.ast
+
+        strictEqual(encodingReads, 0)
+        const effect = make("a")
+        assertTrue(encodingReads > 0)
+        strictEqual(yield* effect, "a")
+        const reads = encodingReads
+        strictEqual(yield* make("b"), "b")
+        strictEqual(encodingReads, reads)
       }))
   })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,8 +349,8 @@ importers:
         specifier: ^6.1.6
         version: 6.1.6
       valibot:
-        specifier: ^1.4.2
-        version: 1.4.2(typescript@7.0.2)
+        specifier: ^1.5.0
+        version: 1.5.0(typescript@7.0.2)
 
   packages/opentelemetry:
     dependencies:
@@ -6321,8 +6321,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  valibot@1.4.2:
-    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+  valibot@1.5.0:
+    resolution: {integrity: sha512-nil6AkP2TChWL43Z5uJ6GTxX01CUA+g8LWUM+N/rB9NBbkUMaUsi9PUNzlUPgoKASgmx9f7eGOYpJ04/fSa6FQ==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -12102,7 +12102,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  valibot@1.4.2(typescript@7.0.2):
+  valibot@1.5.0(typescript@7.0.2):
     optionalDependencies:
       typescript: 7.0.2
 


### PR DESCRIPTION
## Summary

- Compile Schema constructor parsers on first use.
- Reduce validation overhead for TemplateLiteral, IndexSignature, and large Objects ASTs.
- Keep the direct-assignment path in `Schema.make`, with descriptor fallback for `name`, `length`, and `__proto__` options.
- Update the Valibot benchmark dependency to 1.5.0.

## Performance

| Case | main | PR | Change |
| --- | ---: | ---: | ---: |
| Struct, 2 fields | 1.68 µs | 367.6 ns | -78.37% |
| Struct, 32 fields | 3.66 µs | 1.72 µs | -52.51% |
| Struct, 256 fields | 49.99 µs | 15.74 µs | -67.59% |
| Template literal | 1.96 µs | 633.0 ns | -67.65% |
| Template literal, 256 parts | 21.93 µs | 13.12 µs | -40.36% |
| Encoded Record | 16.51 µs | 1.87 µs | -88.77% |
| Schema Benchmarks initialization | 78.60 µs | 35.63 µs | -55.12% |

Measured on an Apple M3 with Node 24.12.0, using 12 paired rounds, 600 ms per round, and 180 ms warmup per process. Every case was classified as an improvement.

The compatibility fallback adds 0.05 KB gzip to `scratchpad/repro.ts` compared with the preceding PR commit.

## Checks

- `pnpm lint-fix`
- `pnpm check`
- 739 passing tests across the focused Schema and MCP files
- runtimeperf registry and formatting checks
- `pnpm jsdocs --check`
